### PR TITLE
composer: upload queued sidecar attachments on flush (#900)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/composer/OutboundAttachmentSidecarStore.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/OutboundAttachmentSidecarStore.kt
@@ -34,9 +34,12 @@ class OutboundAttachmentSidecarStore @Inject constructor(
     suspend fun stage(
         outboundItemId: String,
         uris: List<Uri>,
+        attachmentIndices: List<Int> = emptyList(),
     ): List<LocalAttachmentSidecarRef> = withContext(Dispatchers.IO) {
         if (outboundItemId.isBlank() || uris.isEmpty()) return@withContext emptyList()
-        uris.mapNotNull { uri -> stageOne(outboundItemId, uri) }
+        uris.mapIndexedNotNull { index, uri ->
+            stageOne(outboundItemId, uri, attachmentIndices.getOrNull(index))
+        }
     }
 
     suspend fun refsFor(outboundItemId: String): List<LocalAttachmentSidecarRef> = withContext(Dispatchers.IO) {
@@ -70,7 +73,11 @@ class OutboundAttachmentSidecarStore @Inject constructor(
             .forEach { dir -> runCatching { dir.delete() } }
     }
 
-    private fun stageOne(outboundItemId: String, uri: Uri): LocalAttachmentSidecarRef? {
+    private fun stageOne(
+        outboundItemId: String,
+        uri: Uri,
+        attachmentIndex: Int?,
+    ): LocalAttachmentSidecarRef? {
         val description = describe(uri)
         val sanitised = FilenameSanitiser.sanitise(
             description.displayName ?: uri.lastPathSegment,
@@ -102,6 +109,7 @@ class OutboundAttachmentSidecarStore @Inject constructor(
             mimeType = description.mimeType,
             byteSize = byteSize,
             createdAtMs = clock(),
+            attachmentIndex = attachmentIndex,
         )
         persistAll(allRefsBlocking() + ref)
         return ref
@@ -134,7 +142,9 @@ class OutboundAttachmentSidecarStore @Inject constructor(
     private fun refsForBlocking(outboundItemId: String): List<LocalAttachmentSidecarRef> =
         allRefsBlocking()
             .filter { it.outboundItemId == outboundItemId && File(it.localPath).exists() }
-            .sortedBy { it.createdAtMs }
+            .sortedWith(compareBy<LocalAttachmentSidecarRef> { it.attachmentIndex ?: Int.MAX_VALUE }
+                .thenBy { it.createdAtMs }
+                .thenBy { it.id })
 
     private fun allRefsBlocking(): List<LocalAttachmentSidecarRef> =
         decodeRefs(prefs.getString(KEY_REFS, "").orEmpty())
@@ -170,6 +180,7 @@ data class LocalAttachmentSidecarRef(
     val mimeType: String?,
     val byteSize: Long,
     val createdAtMs: Long,
+    val attachmentIndex: Int? = null,
 )
 
 private fun encodeRefs(refs: List<LocalAttachmentSidecarRef>): String =
@@ -182,6 +193,7 @@ private fun encodeRefs(refs: List<LocalAttachmentSidecarRef>): String =
             ref.mimeType.orEmpty(),
             ref.byteSize.toString(),
             ref.createdAtMs.toString(),
+            ref.attachmentIndex?.toString().orEmpty(),
         ).joinToString("\t") { field -> escapeSidecarField(field) }
     }
 
@@ -196,6 +208,7 @@ private fun decodeRefs(raw: String): List<LocalAttachmentSidecarRef> {
         val displayName = fields.getOrNull(3).orEmpty()
         val byteSize = fields.getOrNull(5)?.toLongOrNull() ?: return@mapNotNull null
         val createdAtMs = fields.getOrNull(6)?.toLongOrNull() ?: return@mapNotNull null
+        val attachmentIndex = fields.getOrNull(7)?.toIntOrNull()
         if (id.isBlank() || outboundItemId.isBlank() || localPath.isBlank()) return@mapNotNull null
         LocalAttachmentSidecarRef(
             id = id,
@@ -205,6 +218,7 @@ private fun decodeRefs(raw: String): List<LocalAttachmentSidecarRef> {
             mimeType = fields.getOrNull(4).orEmpty().ifBlank { null },
             byteSize = byteSize,
             createdAtMs = createdAtMs,
+            attachmentIndex = attachmentIndex,
         )
     }
 }

--- a/app/src/main/java/com/pocketshell/app/composer/OutboundQueueStore.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/OutboundQueueStore.kt
@@ -160,12 +160,16 @@ public interface OutboundQueueStore {
     public fun markInFlight(id: String): OutboundItem?
 
     /**
-     * Mark the item with [id] [OutboundState.Uploading] (attachment upload in
-     * progress). No-op if the id is unknown. Returns the updated item or
-     * `null`. Only an item currently `Queued` or `InFlight` is moved; a
-     * `Delivered`/`Failed` id is left as-is so a late ack cannot resurrect it.
+     * Atomically claim [id] for attachment upload by moving a `Queued`/`Failed`
+     * row to [OutboundState.Uploading]. Returns `null` if the id is unknown or
+     * already owned by another upload/send attempt. [lastAttemptAtMs] stamps
+     * upload ownership so stale recovery does not requeue a fresh upload whose
+     * row carries an older delivery failure timestamp.
      */
-    public fun markUploading(id: String): OutboundItem?
+    public fun markUploading(
+        id: String,
+        lastAttemptAtMs: Long = System.currentTimeMillis(),
+    ): OutboundItem?
 
     /**
      * Replace [id]'s attachment refs after a queued attachment upload has
@@ -407,12 +411,13 @@ public class InMemoryOutboundQueueStore : OutboundQueueStore {
         updated
     }
 
-    override fun markUploading(id: String): OutboundItem? = synchronized(lock) {
+    override fun markUploading(id: String, lastAttemptAtMs: Long): OutboundItem? = synchronized(lock) {
         val existing = items[id] ?: return null
-        if (existing.state == OutboundState.Delivered || existing.state == OutboundState.Failed) {
-            return existing
-        }
-        val updated = existing.copy(state = OutboundState.Uploading)
+        if (!existing.state.isExactClaimable) return null
+        val updated = existing.copy(
+            state = OutboundState.Uploading,
+            lastAttemptAtMs = lastAttemptAtMs,
+        )
         items[updated.id] = updated
         updated
     }
@@ -458,7 +463,7 @@ public class InMemoryOutboundQueueStore : OutboundQueueStore {
     override fun requeueStaleInFlight(sessionKey: String, cutoffMs: Long): List<OutboundItem> =
         synchronized(lock) {
             val updated = items.values
-                .filter { it.sessionKey == sessionKey && it.isStaleInFlight(cutoffMs) }
+                .filter { it.sessionKey == sessionKey && it.isStaleRecoverableAttempt(cutoffMs) }
                 .sortedBy { it.createdAtMs }
                 .map { it.copy(state = OutboundState.Queued) }
             updated.forEach { items[it.id] = it }
@@ -504,7 +509,7 @@ public object DisabledOutboundQueueStore : OutboundQueueStore {
     override fun claimNext(sessionKey: String): OutboundItem? = null
     override fun claim(id: String): OutboundItem? = null
     override fun markInFlight(id: String): OutboundItem? = null
-    override fun markUploading(id: String): OutboundItem? = null
+    override fun markUploading(id: String, lastAttemptAtMs: Long): OutboundItem? = null
     override fun markAttachmentsUploaded(id: String, attachments: List<DurableAttachmentRef>): OutboundItem? = null
     override fun markDelivered(id: String): Boolean = false
     override fun markFailed(id: String, lastError: String?, lastAttemptAtMs: Long): OutboundItem? = null
@@ -656,14 +661,15 @@ public class SharedPrefsOutboundQueueStore @Inject constructor(
         updated
     }
 
-    override fun markUploading(id: String): OutboundItem? = synchronized(lock) {
+    override fun markUploading(id: String, lastAttemptAtMs: Long): OutboundItem? = synchronized(lock) {
         val sessionKey = sessionOf(id) ?: return null
         val list = loadSession(sessionKey)
         val existing = list.firstOrNull { it.id == id } ?: return null
-        if (existing.state == OutboundState.Delivered || existing.state == OutboundState.Failed) {
-            return existing
-        }
-        val updated = existing.copy(state = OutboundState.Uploading)
+        if (!existing.state.isExactClaimable) return null
+        val updated = existing.copy(
+            state = OutboundState.Uploading,
+            lastAttemptAtMs = lastAttemptAtMs,
+        )
         replaceAndStore(sessionKey, list, updated)
         updated
     }
@@ -717,7 +723,7 @@ public class SharedPrefsOutboundQueueStore @Inject constructor(
         synchronized(lock) {
             val list = loadSession(sessionKey)
             val updatedById = list
-                .filter { it.isStaleInFlight(cutoffMs) }
+                .filter { it.isStaleRecoverableAttempt(cutoffMs) }
                 .associate { it.id to it.copy(state = OutboundState.Queued) }
             if (updatedById.isEmpty()) return emptyList()
             val updatedList = list.map { updatedById[it.id] ?: it }
@@ -762,8 +768,9 @@ private fun OutboundItem.claimedForAttempt(): OutboundItem =
         )
     }
 
-private fun OutboundItem.isStaleInFlight(cutoffMs: Long): Boolean =
-    state == OutboundState.InFlight && (lastAttemptAtMs ?: createdAtMs) <= cutoffMs
+private fun OutboundItem.isStaleRecoverableAttempt(cutoffMs: Long): Boolean =
+    (state == OutboundState.InFlight || state == OutboundState.Uploading) &&
+        (lastAttemptAtMs ?: createdAtMs) <= cutoffMs
 
 /** Issue #900: prefs key for the item-blob slot of [sessionKey]. */
 internal fun blobKey(sessionKey: String): String = "@q/$sessionKey"

--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerViewModel.kt
@@ -40,6 +40,7 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 import javax.inject.Inject
+import java.util.UUID
 
 /**
  * Backs [PromptComposerSheet]: the voice + text composer for agent
@@ -113,6 +114,7 @@ public class PromptComposerViewModel @Inject constructor(
     // direct unit/connected constructors stay source-compatible; production
     // Hilt wiring provides the SharedPreferences-backed store.
     private val outboundQueueStore: OutboundQueueStore = DisabledOutboundQueueStore,
+    private val outboundAttachmentSidecarStore: OutboundAttachmentSidecarStore? = null,
     private val savedStateHandle: SavedStateHandle = SavedStateHandle(),
 ) : ViewModel() {
 
@@ -268,6 +270,9 @@ public class PromptComposerViewModel @Inject constructor(
     private var pendingSendWithEnter: Boolean = false
     private var pendingSendTarget: SendTargetSnapshot = SendTargetSnapshot()
     private var attachmentJob: Job? = null
+    private var outboundAttachmentUploader: (suspend (List<LocalAttachmentSidecarRef>) -> Result<List<String>>)? =
+        null
+    private var outboundSidecarDispatchInFlight: Boolean = false
 
     /**
      * Issue #891: the overall send-operation watchdog. The maintainer's
@@ -318,6 +323,17 @@ public class PromptComposerViewModel @Inject constructor(
     @androidx.annotation.VisibleForTesting
     internal fun setSendWatchdogTimeoutForTest(timeoutMs: Long?) {
         sendWatchdogTimeoutMs = timeoutMs
+    }
+
+    /**
+     * Issue #900: upload hook for durable outbound attachment sidecars. The host
+     * owns the live SSH/session upload primitive; the ViewModel owns when queued
+     * local bytes must be uploaded before a row is claimed for delivery.
+     */
+    public fun setOutboundAttachmentSidecarUploader(
+        uploader: (suspend (List<LocalAttachmentSidecarRef>) -> Result<List<String>>)?,
+    ) {
+        outboundAttachmentUploader = uploader
     }
 
     /**
@@ -850,6 +866,7 @@ public class PromptComposerViewModel @Inject constructor(
         sendTarget: SendTargetSnapshot = SendTargetSnapshot(),
     ) {
         if (_uiState.value.sendInFlight) return
+        if (outboundSidecarDispatchInFlight) return
         val draft = _uiState.value.draft
         val attachments = _uiState.value.attachments
         // Issue #544: compose the outgoing prompt = the user's clean draft
@@ -860,12 +877,6 @@ public class PromptComposerViewModel @Inject constructor(
         // Send when there is either typed text or at least one attachment.
         // (A pure-attachment send still has a non-empty composed `text`.)
         if (text.isEmpty()) return
-        val outboundItem = enqueueOutboundSend(
-            cleanDraft = draft,
-            attachments = attachments,
-            withEnter = withEnter,
-            sendTarget = sendTarget,
-        )
         DiagnosticEvents.record(
             "action",
             "composer_send",
@@ -885,6 +896,23 @@ public class PromptComposerViewModel @Inject constructor(
         // emission with no live collector) can never leave the composer stuck on
         // "Sending…" forever.
         armSendWatchdog()
+        if (sendTarget.sessionKey.isNotBlank() && hasLocalAttachmentsForSidecars(attachments)) {
+            viewModelScope.launch {
+                enqueueAndDispatchSidecarBackedSend(
+                    cleanDraft = draft,
+                    attachments = attachments,
+                    withEnter = withEnter,
+                    sendTarget = sendTarget,
+                )
+            }
+            return
+        }
+        val outboundItem = enqueueOutboundSend(
+            cleanDraft = draft,
+            attachments = attachments,
+            withEnter = withEnter,
+            sendTarget = sendTarget,
+        )
         // Issue #254: a `Channel.trySend` buffers the item until a
         // collector consumes it, so a send dispatched while the sheet's
         // collector is mid-recreate (dismiss → re-open) is delivered to
@@ -903,6 +931,57 @@ public class PromptComposerViewModel @Inject constructor(
         if (_sendRequests.trySend(request).isFailure) {
             restoreFailedSend(request)
         }
+    }
+
+    private fun hasLocalAttachmentsForSidecars(attachments: List<StagedAttachment>): Boolean =
+        outboundQueueStore !== DisabledOutboundQueueStore &&
+            outboundAttachmentSidecarStore != null &&
+            outboundAttachmentUploader != null &&
+            attachments.any { it.previewUri != null }
+
+    private suspend fun enqueueAndDispatchSidecarBackedSend(
+        cleanDraft: String,
+        attachments: List<StagedAttachment>,
+        withEnter: Boolean,
+        sendTarget: SendTargetSnapshot,
+    ) {
+        val sessionKey = sendTarget.sessionKey.takeIf { it.isNotBlank() }
+        val sidecarStore = outboundAttachmentSidecarStore ?: return
+        if (sessionKey == null) return
+        val localAttachments = attachments.mapIndexedNotNull { index, attachment ->
+            attachment.previewUri?.let { index to it }
+        }
+        val itemId = UUID.randomUUID().toString()
+        val sidecars = sidecarStore.stage(
+            outboundItemId = itemId,
+            uris = localAttachments.map { it.second },
+            attachmentIndices = localAttachments.map { it.first },
+        )
+        if (sidecars.size != localAttachments.size) {
+            disarmSendWatchdog()
+            _uiState.update {
+                it.copy(
+                    sendInFlight = false,
+                    error = "Attachment upload failed: could not preserve selected file bytes. Your draft was kept.",
+                )
+            }
+            return
+        }
+        val item = OutboundItem(
+            id = itemId,
+            sessionKey = sessionKey,
+            cleanText = cleanDraft,
+            attachments = attachments.toSidecarAwareDurableRefs(sidecars),
+            withEnter = withEnter,
+            state = OutboundState.Queued,
+            createdAtMs = clock(),
+            paneId = sendTarget.paneId,
+            route = sendTarget.route,
+            agentKind = sendTarget.agentKind,
+        )
+        outboundQueueStore.enqueueExisting(item)
+        refreshOutboundQueueItemsFor(sessionKey)
+        dispatchPreparedOutboundItem(itemId)
     }
 
     private fun enqueueOutboundSend(
@@ -1253,6 +1332,9 @@ public class PromptComposerViewModel @Inject constructor(
         val item = outboundQueueStore.item(id) ?: return
         if (item.state != OutboundState.Queued && item.state != OutboundState.Failed) return
         outboundQueueStore.remove(id)
+        outboundAttachmentSidecarStore?.let { store ->
+            viewModelScope.launch { store.removeOutboundItem(id) }
+        }
         refreshOutboundQueueItems()
     }
 
@@ -1303,6 +1385,100 @@ public class PromptComposerViewModel @Inject constructor(
 
     private fun dispatchOutboundItem(id: String): Boolean {
         if (_uiState.value.sendInFlight) return false
+        val sidecarStore = outboundAttachmentSidecarStore
+        if (sidecarStore != null) {
+            if (outboundSidecarDispatchInFlight) return false
+            outboundSidecarDispatchInFlight = true
+            viewModelScope.launch {
+                try {
+                    val sidecars = sidecarStore.refsFor(id)
+                    if (sidecars.isNotEmpty()) {
+                        dispatchPreparedOutboundItem(id)
+                    } else {
+                        claimAndEmitOutboundItem(id)
+                    }
+                } finally {
+                    outboundSidecarDispatchInFlight = false
+                }
+            }
+            return true
+        }
+        return claimAndEmitOutboundItem(id)
+    }
+
+    private suspend fun dispatchPreparedOutboundItem(id: String): Boolean {
+        if (!uploadSidecarsForOutboundItem(id)) return false
+        return claimAndEmitOutboundItem(id)
+    }
+
+    private suspend fun uploadSidecarsForOutboundItem(id: String): Boolean {
+        val sidecarStore = outboundAttachmentSidecarStore ?: return true
+        val sidecars = sidecarStore.refsFor(id)
+        if (sidecars.isEmpty()) return true
+        val item = outboundQueueStore.item(id) ?: return false
+        val uploader = outboundAttachmentUploader
+        if (uploader == null) {
+            outboundQueueStore.markFailed(id, lastError = "Attachment upload unavailable")
+            refreshOutboundQueueItemsFor(item.sessionKey)
+            disarmSendWatchdog()
+            _uiState.update {
+                it.copy(
+                    sendInFlight = false,
+                    error = "Attachment upload failed: reconnect, then send again or discard the draft.",
+                )
+            }
+            return false
+        }
+        val uploading = outboundQueueStore.markUploading(id, lastAttemptAtMs = clock())
+            ?: return false
+        refreshOutboundQueueItemsFor(uploading.sessionKey)
+        val result = try {
+            withTimeout(ATTACHMENT_UPLOAD_TIMEOUT_MS) { uploader(sidecars) }
+        } catch (timeout: TimeoutCancellationException) {
+            Result.failure(timeout)
+        } catch (cancelled: CancellationException) {
+            throw cancelled
+        } catch (t: Throwable) {
+            Result.failure(t)
+        }
+        val uploadedPaths = result.getOrElse { error ->
+            outboundQueueStore.markFailed(id, lastError = attachmentErrorMessage(error))
+            refreshOutboundQueueItemsFor(uploading.sessionKey)
+            disarmSendWatchdog()
+            _uiState.update {
+                it.copy(
+                    sendInFlight = false,
+                    error = attachmentErrorMessage(error),
+                )
+            }
+            return false
+        }.filter { it.isNotBlank() }
+        if (uploadedPaths.size != sidecars.size) {
+            val message = "Attachment upload failed: uploaded ${uploadedPaths.size} of ${sidecars.size} files."
+            outboundQueueStore.markFailed(id, lastError = message)
+            refreshOutboundQueueItemsFor(uploading.sessionKey)
+            disarmSendWatchdog()
+            _uiState.update { it.copy(sendInFlight = false, error = message) }
+            return false
+        }
+        val uploadedSidecarRefs = sidecars.mapIndexed { index, ref ->
+            DurableAttachmentRef(
+                remotePath = uploadedPaths[index],
+                displayName = ref.displayName,
+                mimeType = ref.mimeType,
+            )
+        }
+        val updatedRefs = item.attachments.withUploadedSidecars(sidecars, uploadedSidecarRefs)
+        val uploaded = outboundQueueStore.markAttachmentsUploaded(id, updatedRefs)
+        if (uploaded?.state != OutboundState.Queued) {
+            refreshOutboundQueueItemsFor(item.sessionKey)
+            return false
+        }
+        refreshOutboundQueueItemsFor(item.sessionKey)
+        return true
+    }
+
+    private fun claimAndEmitOutboundItem(id: String): Boolean {
         val active = outboundQueueStore.claim(id) ?: return false
         val attachments = active.attachments.toStagedAttachments()
         val text = appendAttachmentPaths(active.cleanText, attachments.map { it.remotePath })
@@ -1337,6 +1513,9 @@ public class PromptComposerViewModel @Inject constructor(
     private fun markOutboundSendDelivered(request: SendRequest?) {
         val id = request?.outboundQueueItemId ?: return
         outboundQueueStore.markDelivered(id)
+        outboundAttachmentSidecarStore?.let { store ->
+            viewModelScope.launch { store.removeOutboundItem(id) }
+        }
         request.sendTarget.sessionKey
             .takeIf { it.isNotBlank() }
             ?.let { refreshOutboundQueueItemsFor(it) }
@@ -2789,6 +2968,73 @@ public class PromptComposerViewModel @Inject constructor(
      */
     private fun List<StagedAttachment>.toDurableRefs(): List<DurableAttachmentRef> =
         map { DurableAttachmentRef(it.remotePath, it.displayName, it.mimeType) }
+
+    /**
+     * Issue #900: sidecar-backed sends must be able to replace the provisional
+     * remote upload refs after process death. Persist the sidecar/original file
+     * label for local-preview attachments so retry can match the durable row
+     * back to its staged bytes even when the provisional remote path carried a
+     * timestamped upload filename.
+     */
+    private fun List<StagedAttachment>.toSidecarAwareDurableRefs(
+        sidecars: List<LocalAttachmentSidecarRef>,
+    ): List<DurableAttachmentRef> {
+        val sidecarsByAttachmentIndex = sidecars
+            .mapNotNull { ref -> ref.attachmentIndex?.let { index -> index to ref } }
+            .toMap()
+        val unindexedSidecars = ArrayDeque(sidecars.filter { it.attachmentIndex == null })
+        return mapIndexed { index, attachment ->
+            val sidecar = sidecarsByAttachmentIndex[index]
+                ?: if (attachment.previewUri != null) unindexedSidecars.removeFirstOrNull() else null
+            DurableAttachmentRef(
+                remotePath = attachment.remotePath,
+                displayName = sidecar?.displayName ?: attachment.displayName,
+                mimeType = sidecar?.mimeType ?: attachment.mimeType,
+            )
+        }
+    }
+
+    private fun List<DurableAttachmentRef>.withUploadedSidecars(
+        sidecars: List<LocalAttachmentSidecarRef>,
+        uploadedRefs: List<DurableAttachmentRef>,
+    ): List<DurableAttachmentRef> {
+        if (isEmpty()) return uploadedRefs
+        if (sidecars.all { it.attachmentIndex != null }) {
+            val replacements = sidecars.zip(uploadedRefs)
+                .mapNotNull { (sidecar, uploaded) -> sidecar.attachmentIndex?.let { index -> index to uploaded } }
+                .toMap()
+            if (replacements.size == sidecars.size) {
+                return mapIndexed { index, existing ->
+                    replacements[index]?.copy(mimeType = replacements[index]?.mimeType ?: existing.mimeType) ?: existing
+                }
+            }
+        }
+        val remaining = ArrayDeque(sidecars.zip(uploadedRefs))
+        val updated = map { existing ->
+            val next = remaining.firstOrNull()
+            if (next != null && existing.matchesSidecar(next.first)) {
+                remaining.removeFirst()
+                next.second.copy(mimeType = next.second.mimeType ?: existing.mimeType)
+            } else {
+                existing
+            }
+        }
+        return if (remaining.isEmpty()) updated else uploadedRefs
+    }
+
+    private fun DurableAttachmentRef.matchesSidecar(sidecar: LocalAttachmentSidecarRef): Boolean {
+        if (displayName == sidecar.displayName) return true
+        val remoteName = attachmentDisplayName(remotePath)
+        return remoteName == sidecar.displayName ||
+            displayName.isTimestampedAttachmentNameFor(sidecar.displayName) ||
+            remoteName.isTimestampedAttachmentNameFor(sidecar.displayName)
+    }
+
+    private fun String.isTimestampedAttachmentNameFor(sidecarDisplayName: String): Boolean {
+        if (sidecarDisplayName.isBlank()) return false
+        val pattern = Regex("""\d{8}-\d{6}-\d{2}-${Regex.escape(sidecarDisplayName)}""")
+        return pattern.matches(this)
+    }
 
     /**
      * Issue #872: rehydrate durable refs into live tiles. The local preview Uri

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
@@ -456,6 +456,14 @@ public fun TmuxSessionScreen(
     LaunchedEffect(targetSessionId.value) {
         promptComposerViewModel.onComposerTargetChanged(targetSessionId.value)
     }
+    DisposableEffect(promptComposerViewModel, viewModel) {
+        promptComposerViewModel.setOutboundAttachmentSidecarUploader { refs ->
+            viewModel.uploadQueuedAttachmentSidecars(refs)
+        }
+        onDispose {
+            promptComposerViewModel.setOutboundAttachmentSidecarUploader(null)
+        }
+    }
     LaunchedEffect(sessionLive, targetSessionId.value) {
         promptComposerViewModel.setConnectionDegraded(!sessionLive)
         outboundQueueAutoFlushController.onConnectionWindowChanged(

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -23,6 +23,7 @@ import com.pocketshell.app.assistant.SessionAssistantController
 import com.pocketshell.app.cards.SessionCardsRemoteSource
 import com.pocketshell.app.conversation.ConversationDiagnostics
 import com.pocketshell.app.crash.CrashReporter
+import com.pocketshell.app.composer.LocalAttachmentSidecarRef
 import com.pocketshell.app.composer.PromptAttachmentStager
 import com.pocketshell.app.connectivity.TerminalNetworkChange
 import com.pocketshell.app.connectivity.hasSameNetworkIdentityAs
@@ -38,6 +39,8 @@ import com.pocketshell.app.projects.ProfilesResult
 import com.pocketshell.app.projects.RemoteProfile
 import com.pocketshell.uikit.model.SessionAgentKind
 import com.pocketshell.uikit.model.sessionAgentKindFromOption
+import com.pocketshell.app.share.FilenameSanitiser
+import com.pocketshell.app.share.ShareUploader
 import com.pocketshell.app.repos.ReposRemoteSource
 import com.pocketshell.app.session.AgentConversationRepository
 import com.pocketshell.app.session.AgentConversationSyncStatus
@@ -92,6 +95,7 @@ import com.pocketshell.core.ssh.SshLeaseConnector
 import com.pocketshell.core.ssh.SshLeaseKey
 import com.pocketshell.core.ssh.SshLeaseManager
 import com.pocketshell.core.ssh.SshLeaseTarget
+import com.pocketshell.core.ssh.SshException
 import com.pocketshell.core.ssh.SshSession
 import com.pocketshell.core.terminal.bridge.TerminalSeedGateOverflowException
 import com.pocketshell.core.storage.dao.ProjectRootDao
@@ -10412,6 +10416,69 @@ public class TmuxSessionViewModel @Inject constructor(
             },
         )
         return result
+    }
+
+    public suspend fun uploadQueuedAttachmentSidecars(
+        sidecars: List<LocalAttachmentSidecarRef>,
+    ): Result<List<String>> {
+        DiagnosticEvents.record("action", "tmux_outbound_sidecar_upload_start", "count" to sidecars.size)
+        if (sidecars.isEmpty()) return Result.success(emptyList())
+        val session = awaitLiveSessionForAttachment()
+            ?: return Result.failure(IllegalStateException("No live SSH session for attachment upload."))
+        if (!session.isConnected) {
+            return Result.failure(SshException("SSH session is not connected"))
+        }
+        val target = activeTarget
+        val scopeKey = when (target) {
+            null -> "tmux-session"
+            else -> "host-${target.hostId}-${target.sessionName}"
+        }
+        val safeScope = PromptAttachmentStager.safeScopeSegment(scopeKey)
+        val remoteDir = "${PromptAttachmentStager.REMOTE_DIRECTORY}/$safeScope"
+        val displayDir = "~/$remoteDir"
+        val timestamp = ShareUploader.formatTimestamp(sidecars.minOf { it.createdAtMs })
+        return try {
+            val mkdir = session.exec("mkdir -p \"\$HOME/$remoteDir\"")
+            if (mkdir.exitCode != 0) {
+                val detail = mkdir.stderr.ifBlank { mkdir.stdout }.trim()
+                return Result.failure(
+                    SshException("Could not create attachment directory: ${detail.ifBlank { "mkdir failed" }}"),
+                )
+            }
+            val uploadedPaths = sidecars.mapIndexed { index, ref ->
+                val local = File(ref.localPath)
+                if (!local.exists()) {
+                    throw SshException("Queued attachment no longer exists: ${ref.displayName}")
+                }
+                val sanitised = FilenameSanitiser.sanitise(
+                    ref.displayName,
+                    defaultExtension = ShareUploader.extensionForMimeType(ref.mimeType),
+                )
+                val remoteName = PromptAttachmentStager.composeAttachmentName(timestamp, index, sanitised)
+                val remotePath = "$remoteDir/$remoteName"
+                session.uploadFile(local, remotePath)
+                "$displayDir/$remoteName"
+            }
+            DiagnosticEvents.record(
+                "action",
+                "tmux_outbound_sidecar_upload_success",
+                "count" to uploadedPaths.size,
+                "scope" to scopeKey,
+            )
+            Result.success(uploadedPaths)
+        } catch (cancelled: CancellationException) {
+            throw cancelled
+        } catch (t: Throwable) {
+            DiagnosticEvents.record(
+                "action",
+                "tmux_outbound_sidecar_upload_fail",
+                "count" to sidecars.size,
+                "scope" to scopeKey,
+                "cause" to t.javaClass.simpleName,
+                "message" to t.message,
+            )
+            Result.failure(if (t is SshException) t else SshException("Attachment upload failed: ${t.message}", t))
+        }
     }
 
     /**

--- a/app/src/test/java/com/pocketshell/app/composer/OutboundAttachmentSidecarStoreTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/OutboundAttachmentSidecarStoreTest.kt
@@ -52,6 +52,23 @@ class OutboundAttachmentSidecarStoreTest {
     }
 
     @Test
+    fun stagePersistsAttachmentIndicesAndRefsSortByAttachmentOrder() = runTest {
+        newStore().stage(
+            outboundItemId = "queue-1",
+            uris = listOf(
+                Uri.fromFile(sourceFile("third.txt", "third")),
+                Uri.fromFile(sourceFile("first.txt", "first")),
+            ),
+            attachmentIndices = listOf(2, 0),
+        )
+
+        val reloaded = newStore().refsFor("queue-1")
+
+        assertEquals(listOf("first.txt", "third.txt"), reloaded.map { it.displayName })
+        assertEquals(listOf(0, 2), reloaded.map { it.attachmentIndex })
+    }
+
+    @Test
     fun multipleOutboundItemsDoNotBleedIntoEachOther() = runTest {
         val store = newStore()
         val first = store.stage("queue-a", listOf(Uri.fromFile(sourceFile("a.txt", "a")))).single()

--- a/app/src/test/java/com/pocketshell/app/composer/OutboundQueueStoreTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/OutboundQueueStoreTest.kt
@@ -307,6 +307,41 @@ class OutboundQueueStoreTest {
     }
 
     @Test
+    fun requeueStaleInFlightAlsoRequeuesAbandonedUploadingRows() {
+        val store = store()
+        val staleUpload = OutboundItem(
+            id = "stale-upload",
+            sessionKey = "sessA",
+            cleanText = "upload died",
+            state = OutboundState.Uploading,
+            createdAtMs = 10L,
+            lastAttemptAtMs = null,
+            attemptCount = 0,
+        )
+        val freshUpload = OutboundItem(
+            id = "fresh-upload",
+            sessionKey = "sessA",
+            cleanText = "upload still active",
+            state = OutboundState.Uploading,
+            createdAtMs = 200L,
+            lastAttemptAtMs = null,
+            attemptCount = 0,
+        )
+        store.enqueueExisting(staleUpload)
+        store.enqueueExisting(freshUpload)
+
+        val requeued = store.requeueStaleInFlight("sessA", cutoffMs = 100L)
+
+        assertEquals(listOf(staleUpload.id), requeued.map { it.id })
+        assertEquals(OutboundState.Queued, store.item(staleUpload.id)!!.state)
+        assertEquals(0, store.item(staleUpload.id)!!.attemptCount)
+        assertEquals(OutboundState.Uploading, store.item(freshUpload.id)!!.state)
+        val claimed = store.claimNext("sessA")!!
+        assertEquals(staleUpload.id, claimed.id)
+        assertEquals(1, claimed.attemptCount)
+    }
+
+    @Test
     fun markDeliveredIsExactlyOnce_lateDuplicateAckIsNoOp() {
         val store = store()
         val item = store.enqueue("sessA", "deliver once")
@@ -491,12 +526,15 @@ class OutboundQueueStoreTest {
         val item = store.enqueue("sessA", "uploading first")
 
         // Upload-in-progress is a real persisted state transition.
-        assertEquals(OutboundState.Uploading, store.markUploading(item.id)!!.state)
+        val uploading = store.markUploading(item.id, lastAttemptAtMs = 42L)!!
+        assertEquals(OutboundState.Uploading, uploading.state)
+        assertEquals(42L, uploading.lastAttemptAtMs)
         assertEquals(OutboundState.Uploading, store.item(item.id)!!.state)
 
         // An Uploading item is NOT claimable (claimNext only claims Queued), so a
         // racing flush cannot grab an item whose attachment upload is mid-flight.
         assertNull(store.claimNext("sessA"))
+        assertNull(store.markUploading(item.id, lastAttemptAtMs = 43L))
     }
 
     @Test
@@ -581,16 +619,36 @@ class OutboundQueueStoreTest {
     }
 
     @Test
-    fun lateAckAfterFailureCannotResurrectAlreadyFailedItem() {
-        // markUploading/markDelivered must not undo a terminal Failed except via
-        // an explicit re-arm. markUploading on a Failed item is a no-op.
+    fun markUploadingCanOwnFailedRetryButNotActiveRows() {
         val store = store()
         val item = store.enqueue("sessA", "x")
         store.claimNext("sessA")
         store.markFailed(item.id, "boom")
-        val afterUpload = store.markUploading(item.id)
-        assertEquals("markUploading must not move a Failed item",
-            OutboundState.Failed, afterUpload!!.state)
+
+        val afterUpload = store.markUploading(item.id, lastAttemptAtMs = 100L)!!
+        assertEquals(OutboundState.Uploading, afterUpload.state)
+        assertEquals(100L, afterUpload.lastAttemptAtMs)
+        assertNull(store.markUploading(item.id, lastAttemptAtMs = 101L))
+        assertNull(store.claim(item.id))
+    }
+
+    @Test
+    fun requeueStaleInFlightDoesNotRequeueFreshUploadingRowWithOldFailureTimestamp() {
+        val store = store()
+        val item = store.enqueue("sessA", "retry upload", createdAtMs = 1L)
+        store.claimNext("sessA")
+        store.markFailed(item.id, "old failure", lastAttemptAtMs = 10L)
+
+        val uploading = store.markUploading(item.id, lastAttemptAtMs = 200L)!!
+        assertEquals(OutboundState.Uploading, uploading.state)
+        assertEquals(200L, uploading.lastAttemptAtMs)
+
+        assertTrue(store.requeueStaleInFlight("sessA", cutoffMs = 100L).isEmpty())
+        assertEquals(OutboundState.Uploading, store.item(item.id)!!.state)
+
+        val requeued = store.requeueStaleInFlight("sessA", cutoffMs = 200L)
+        assertEquals(listOf(item.id), requeued.map { it.id })
+        assertEquals(OutboundState.Queued, store.item(item.id)!!.state)
     }
 
     // --- Durability across a simulated restart (in-memory analogue) --------

--- a/app/src/test/java/com/pocketshell/app/composer/PromptComposerViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/PromptComposerViewModelTest.kt
@@ -1,6 +1,9 @@
 package com.pocketshell.app.composer
 
+import android.content.Context
+import android.net.Uri
 import androidx.lifecycle.SavedStateHandle
+import androidx.test.core.app.ApplicationProvider
 import com.pocketshell.app.composer.PromptComposerViewModel.ApiKeyVault
 import com.pocketshell.app.composer.PromptComposerViewModel.RecordingState
 import com.pocketshell.app.diagnostics.installRecordingDiagnosticSink
@@ -17,6 +20,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
@@ -35,6 +39,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
+import java.io.File
 
 /**
  * Unit tests for [PromptComposerViewModel]'s recording FSM. Hits all
@@ -208,6 +213,7 @@ class PromptComposerViewModelTest {
             UnavailableSpeechRecognitionProvider,
         composerDraftStore: ComposerDraftStore = DisabledComposerDraftStore,
         outboundQueueStore: OutboundQueueStore = DisabledOutboundQueueStore,
+        outboundAttachmentSidecarStore: OutboundAttachmentSidecarStore? = null,
         savedStateHandle: SavedStateHandle = SavedStateHandle(),
     ): PromptComposerViewModel {
         val factory = WhisperClientFactory { whisper }
@@ -219,6 +225,7 @@ class PromptComposerViewModelTest {
             speechRecognitionProvider = speechRecognitionProvider,
             composerDraftStore = composerDraftStore,
             outboundQueueStore = outboundQueueStore,
+            outboundAttachmentSidecarStore = outboundAttachmentSidecarStore,
             savedStateHandle = savedStateHandle,
         )
         if (samplerDispatcher != null) vm.samplerDispatcher = samplerDispatcher
@@ -3071,6 +3078,51 @@ class PromptComposerViewModelTest {
         return collected
     }
 
+    private fun newSidecarStore(context: Context = ApplicationProvider.getApplicationContext()): OutboundAttachmentSidecarStore {
+        context.getSharedPreferences(OutboundAttachmentSidecarStore.PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .clear()
+            .commit()
+        File(context.filesDir, OutboundAttachmentSidecarStore.DIRECTORY_NAME).deleteRecursively()
+        var nextId = 0
+        return OutboundAttachmentSidecarStore(context).also { store ->
+            store.idGenerator = { "sidecar-${++nextId}" }
+            store.clock = { nextId.toLong() }
+        }
+    }
+
+    private fun localAttachmentFile(name: String, content: String): File {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        return File(context.cacheDir, name).apply {
+            parentFile?.mkdirs()
+            writeText(content)
+        }
+    }
+
+    private suspend fun waitForSidecarsCleared(
+        store: OutboundAttachmentSidecarStore,
+        outboundItemId: String,
+    ) {
+        repeat(100) {
+            if (store.refsFor(outboundItemId).isEmpty()) return
+            Thread.sleep(10)
+        }
+        assertTrue(store.refsFor(outboundItemId).isEmpty())
+    }
+
+    private fun kotlinx.coroutines.test.TestScope.waitForSendCount(
+        sent: List<PromptComposerViewModel.SendRequest>,
+        count: Int,
+    ) {
+        repeat(100) {
+            runCurrent()
+            if (sent.size >= count) return
+            Thread.sleep(10)
+        }
+        runCurrent()
+        assertEquals(count, sent.size)
+    }
+
     @Test
     fun requestSendInIdleDispatchesDraftAndKeepsItInFlightUntilDelivered() = runTest {
         // Issue #745: tapping Send dispatches the draft AND flips the composer
@@ -3158,6 +3210,334 @@ class PromptComposerViewModelTest {
         vm.discardOutboundItem(queueId)
         assertNotNull(queue.item(queueId))
         assertEquals(listOf(queueId), vm.outboundQueueItems.value.map { it.id })
+    }
+
+    @Test
+    fun requestSendWithLocalAttachmentStagesSidecarUploadsBeforeClaimAndDispatchesUploadedRefs() = runTest {
+        val queue = InMemoryOutboundQueueStore()
+        val sidecars = newSidecarStore()
+        val uploadedSidecarBytes = mutableListOf<String>()
+        val uploadFinished = CompletableDeferred<Unit>()
+        val vm = newVm(
+            samplerDispatcher = StandardTestDispatcher(testScheduler),
+            outboundQueueStore = queue,
+            outboundAttachmentSidecarStore = sidecars,
+        )
+        vm.setOutboundAttachmentSidecarUploader { refs ->
+            uploadedSidecarBytes += refs.map { File(it.localPath).readText() }
+            uploadFinished.complete(Unit)
+            Result.success(refs.map { "~/.pocketshell/attachments/reuploaded/${it.displayName}" })
+        }
+        val sent = collectSendRequests(vm)
+        val target = PromptComposerViewModel.SendTargetSnapshot(sessionKey = "1/session-a")
+        val local = localAttachmentFile("sidecar-report.txt", "local bytes")
+
+        vm.onComposerTargetChanged("1/session-a")
+        vm.onDraftChange("review")
+        vm.attachFiles(
+            count = 1,
+            previews = listOf(PromptComposerViewModel.AttachmentPreview(Uri.fromFile(local), "text/plain")),
+        ) {
+            Result.success(listOf("~/.pocketshell/attachments/old/20260601-120000-01-sidecar-report.txt"))
+        }
+        advanceUntilIdle()
+
+        vm.requestSend(withEnter = true, sendTarget = target)
+        uploadFinished.await()
+        waitForSendCount(sent, 1)
+
+        val request = sent.single()
+        val queueId = requireNotNull(request.outboundQueueItemId)
+        assertEquals(listOf("local bytes"), uploadedSidecarBytes)
+        assertEquals(
+            appendAttachmentPaths("review", listOf("~/.pocketshell/attachments/reuploaded/sidecar-report.txt")),
+            request.text,
+        )
+        assertEquals(
+            listOf(
+                PromptComposerViewModel.StagedAttachment(
+                    remotePath = "~/.pocketshell/attachments/reuploaded/sidecar-report.txt",
+                    displayName = "sidecar-report.txt",
+                    mimeType = "text/plain",
+                ),
+            ),
+            request.attachments,
+        )
+        val inFlight = requireNotNull(queue.item(queueId))
+        assertEquals(OutboundState.InFlight, inFlight.state)
+        assertEquals(
+            listOf(DurableAttachmentRef("~/.pocketshell/attachments/reuploaded/sidecar-report.txt", "sidecar-report.txt", "text/plain")),
+            inFlight.attachments,
+        )
+        assertEquals(listOf(queueId), sidecars.refsFor(queueId).map { it.outboundItemId })
+    }
+
+    @Test
+    fun retryNextOutboundItemUploadsPersistedSidecarsBeforeClaimingQueuedRow() = runTest {
+        val queue = InMemoryOutboundQueueStore()
+        val sidecars = newSidecarStore()
+        val item = OutboundItem(
+            id = "queued-local",
+            sessionKey = "1/session-a",
+            cleanText = "send queued",
+            attachments = listOf(
+                DurableAttachmentRef(
+                    "~/.pocketshell/attachments/old/20260601-120000-01-queued.txt",
+                    "20260601-120000-01-queued.txt",
+                    "text/plain",
+                ),
+            ),
+            createdAtMs = 1L,
+        )
+        queue.enqueueExisting(item)
+        sidecars.stage(
+            outboundItemId = item.id,
+            uris = listOf(Uri.fromFile(localAttachmentFile("queued.txt", "queued bytes"))),
+        )
+        val statesAtUpload = mutableListOf<OutboundState>()
+        val uploadFinished = CompletableDeferred<Unit>()
+        val vm = newVm(
+            samplerDispatcher = StandardTestDispatcher(testScheduler),
+            outboundQueueStore = queue,
+            outboundAttachmentSidecarStore = sidecars,
+        )
+        vm.setOutboundAttachmentSidecarUploader { refs ->
+            statesAtUpload += requireNotNull(queue.item(item.id)).state
+            uploadFinished.complete(Unit)
+            Result.success(refs.map { "~/.pocketshell/attachments/flushed/${it.displayName}" })
+        }
+        val sent = collectSendRequests(vm)
+        vm.onComposerTargetChanged("1/session-a")
+
+        val retried = vm.retryNextOutboundItem()
+        uploadFinished.await()
+        waitForSendCount(sent, 1)
+
+        assertEquals(item.id, retried)
+        assertEquals(listOf(OutboundState.Uploading), statesAtUpload)
+        val request = sent.single()
+        assertEquals(item.id, request.outboundQueueItemId)
+        assertEquals(
+            appendAttachmentPaths("send queued", listOf("~/.pocketshell/attachments/flushed/queued.txt")),
+            request.text,
+        )
+        val active = requireNotNull(queue.item(item.id))
+        assertEquals(OutboundState.InFlight, active.state)
+        assertEquals(1, active.attemptCount)
+        assertEquals(
+            listOf(DurableAttachmentRef("~/.pocketshell/attachments/flushed/queued.txt", "queued.txt", "text/plain")),
+            active.attachments,
+        )
+    }
+
+    @Test
+    fun retryNextOutboundItemReplacesOnlyIndexedSidecarAttachmentWhenRemoteNameCollides() = runTest {
+        val queue = InMemoryOutboundQueueStore()
+        val sidecars = newSidecarStore()
+        val remoteRef = DurableAttachmentRef(
+            remotePath = "~/.pocketshell/attachments/current/conflict.txt",
+            displayName = "conflict.txt",
+            mimeType = "text/plain",
+        )
+        val item = OutboundItem(
+            id = "queued-mixed-local",
+            sessionKey = "1/session-a",
+            cleanText = "send mixed",
+            attachments = listOf(
+                remoteRef,
+                DurableAttachmentRef(
+                    "~/.pocketshell/attachments/old/20260601-120000-02-conflict.txt",
+                    "20260601-120000-02-conflict.txt",
+                    "text/plain",
+                ),
+            ),
+            createdAtMs = 1L,
+        )
+        queue.enqueueExisting(item)
+        sidecars.stage(
+            outboundItemId = item.id,
+            uris = listOf(Uri.fromFile(localAttachmentFile("conflict.txt", "queued bytes"))),
+            attachmentIndices = listOf(1),
+        )
+        val vm = newVm(
+            samplerDispatcher = StandardTestDispatcher(testScheduler),
+            outboundQueueStore = queue,
+            outboundAttachmentSidecarStore = sidecars,
+        )
+        vm.setOutboundAttachmentSidecarUploader { refs ->
+            assertEquals(listOf(1), refs.map { it.attachmentIndex })
+            Result.success(listOf("~/.pocketshell/attachments/flushed/conflict.txt"))
+        }
+        val sent = collectSendRequests(vm)
+        vm.onComposerTargetChanged("1/session-a")
+
+        assertEquals(item.id, vm.retryNextOutboundItem())
+        waitForSendCount(sent, 1)
+
+        assertEquals(
+            appendAttachmentPaths(
+                "send mixed",
+                listOf(
+                    "~/.pocketshell/attachments/current/conflict.txt",
+                    "~/.pocketshell/attachments/flushed/conflict.txt",
+                ),
+            ),
+            sent.single().text,
+        )
+        assertEquals(
+            listOf(
+                remoteRef,
+                DurableAttachmentRef("~/.pocketshell/attachments/flushed/conflict.txt", "conflict.txt", "text/plain"),
+            ),
+            queue.item(item.id)!!.attachments,
+        )
+    }
+
+    @Test
+    fun concurrentSidecarRetriesOnlyOneUploadAndSendOwnsTheQueuedRow() = runTest {
+        val queue = InMemoryOutboundQueueStore()
+        val sidecars = newSidecarStore()
+        val item = OutboundItem(
+            id = "race-local",
+            sessionKey = "1/session-a",
+            cleanText = "send once",
+            attachments = listOf(DurableAttachmentRef("stale-local", "race.txt", "text/plain")),
+            createdAtMs = 1L,
+        )
+        queue.enqueueExisting(item)
+        sidecars.stage(
+            outboundItemId = item.id,
+            uris = listOf(Uri.fromFile(localAttachmentFile("race.txt", "race bytes"))),
+        )
+        var uploadCount = 0
+        val vm = newVm(
+            samplerDispatcher = StandardTestDispatcher(testScheduler),
+            outboundQueueStore = queue,
+            outboundAttachmentSidecarStore = sidecars,
+        )
+        vm.setOutboundAttachmentSidecarUploader { refs ->
+            uploadCount++
+            assertEquals(OutboundState.Uploading, queue.item(item.id)!!.state)
+            vm.retryOutboundItem(item.id)
+            Result.success(refs.map { "~/.pocketshell/attachments/race/${it.displayName}" })
+        }
+        val sent = collectSendRequests(vm)
+        vm.onComposerTargetChanged("1/session-a")
+
+        assertEquals(item.id, vm.retryNextOutboundItem())
+        waitForSendCount(sent, 1)
+        assertEquals(1, uploadCount)
+
+        val request = sent.single()
+        assertEquals(item.id, request.outboundQueueItemId)
+        assertEquals(1, queue.item(item.id)!!.attemptCount)
+        assertEquals(OutboundState.InFlight, queue.item(item.id)!!.state)
+    }
+
+    @Test
+    fun sidecarUploadBlocksSecondQueuedSidecarRowUntilFirstSendResolves() = runTest {
+        val queue = InMemoryOutboundQueueStore()
+        val sidecars = newSidecarStore()
+        val first = OutboundItem(
+            id = "sidecar-first",
+            sessionKey = "1/session-a",
+            cleanText = "first",
+            attachments = listOf(DurableAttachmentRef("stale-first", "first.txt", "text/plain")),
+            createdAtMs = 1L,
+        )
+        val second = OutboundItem(
+            id = "sidecar-second",
+            sessionKey = "1/session-a",
+            cleanText = "second",
+            attachments = listOf(DurableAttachmentRef("stale-second", "second.txt", "text/plain")),
+            createdAtMs = 2L,
+        )
+        queue.enqueueExisting(first)
+        queue.enqueueExisting(second)
+        sidecars.stage(first.id, listOf(Uri.fromFile(localAttachmentFile("first.txt", "first bytes"))))
+        sidecars.stage(second.id, listOf(Uri.fromFile(localAttachmentFile("second.txt", "second bytes"))))
+        val uploadIds = mutableListOf<String>()
+        var reentrantRetry: String? = "not-called"
+        val vm = newVm(
+            samplerDispatcher = StandardTestDispatcher(testScheduler),
+            outboundQueueStore = queue,
+            outboundAttachmentSidecarStore = sidecars,
+        )
+        vm.setOutboundAttachmentSidecarUploader { refs ->
+            uploadIds += refs.single().outboundItemId
+            if (refs.single().outboundItemId == first.id) {
+                reentrantRetry = vm.retryNextOutboundItem()
+            }
+            Result.success(refs.map { "~/.pocketshell/attachments/serial/${it.displayName}" })
+        }
+        val sent = collectSendRequests(vm)
+        vm.onComposerTargetChanged("1/session-a")
+
+        assertEquals(first.id, vm.retryNextOutboundItem())
+        waitForSendCount(sent, 1)
+
+        assertNull(reentrantRetry)
+        assertEquals(listOf(first.id), uploadIds)
+        assertEquals(first.id, sent.single().outboundQueueItemId)
+        assertEquals(OutboundState.InFlight, queue.item(first.id)!!.state)
+        assertEquals(OutboundState.Queued, queue.item(second.id)!!.state)
+
+        vm.markSendDelivered(sent.single())
+        advanceUntilIdle()
+        waitForSidecarsCleared(sidecars, first.id)
+        assertEquals(second.id, vm.retryNextOutboundItem())
+        waitForSendCount(sent, 2)
+
+        assertEquals(listOf(first.id, second.id), uploadIds)
+        assertEquals(second.id, sent.last().outboundQueueItemId)
+        assertEquals(OutboundState.InFlight, queue.item(second.id)!!.state)
+    }
+
+    @Test
+    fun deliveredAndDeletedOutboundItemsCleanUpSidecars() = runTest {
+        val queue = InMemoryOutboundQueueStore()
+        val sidecars = newSidecarStore()
+        val delivered = OutboundItem(
+            id = "delivered-local",
+            sessionKey = "1/session-a",
+            cleanText = "done",
+            state = OutboundState.InFlight,
+            createdAtMs = 1L,
+        )
+        val deleted = OutboundItem(
+            id = "deleted-local",
+            sessionKey = "1/session-a",
+            cleanText = "delete",
+            state = OutboundState.Queued,
+            createdAtMs = 2L,
+        )
+        queue.enqueueExisting(delivered)
+        queue.enqueueExisting(deleted)
+        sidecars.stage(delivered.id, listOf(Uri.fromFile(localAttachmentFile("delivered.txt", "done"))))
+        sidecars.stage(deleted.id, listOf(Uri.fromFile(localAttachmentFile("deleted.txt", "delete"))))
+        val vm = newVm(
+            samplerDispatcher = StandardTestDispatcher(testScheduler),
+            outboundQueueStore = queue,
+            outboundAttachmentSidecarStore = sidecars,
+        )
+        vm.onComposerTargetChanged("1/session-a")
+
+        vm.markSendDelivered(
+            PromptComposerViewModel.SendRequest(
+                text = "done",
+                withEnter = true,
+                sendTarget = PromptComposerViewModel.SendTargetSnapshot(sessionKey = "1/session-a"),
+                outboundQueueItemId = delivered.id,
+            ),
+        )
+        advanceUntilIdle()
+
+        waitForSidecarsCleared(sidecars, delivered.id)
+
+        vm.discardOutboundItem(deleted.id)
+        advanceUntilIdle()
+
+        waitForSidecarsCleared(sidecars, deleted.id)
     }
 
     @Test

--- a/app/src/test/java/com/pocketshell/app/composer/SharedPrefsOutboundQueueStoreDurabilityTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/SharedPrefsOutboundQueueStoreDurabilityTest.kt
@@ -105,13 +105,33 @@ class SharedPrefsOutboundQueueStoreDurabilityTest {
             lastAttemptAtMs = 10L,
             attemptCount = 1,
         )
+        val staleUpload = OutboundItem(
+            id = "durable-stale-upload",
+            sessionKey = "sessA-requeue",
+            cleanText = "upload was interrupted",
+            state = OutboundState.Uploading,
+            createdAtMs = 3L,
+            lastAttemptAtMs = null,
+            attemptCount = 0,
+        )
+        val freshUpload = OutboundItem(
+            id = "durable-fresh-upload",
+            sessionKey = "sessA-requeue",
+            cleanText = "upload still active",
+            state = OutboundState.Uploading,
+            createdAtMs = 50L,
+            lastAttemptAtMs = null,
+            attemptCount = 0,
+        )
         first.enqueueExisting(stale)
         first.enqueueExisting(fresh)
         first.enqueueExisting(otherSession)
+        first.enqueueExisting(staleUpload)
+        first.enqueueExisting(freshUpload)
 
         val afterRestart = newStore()
         val requeued = afterRestart.requeueStaleInFlight("sessA-requeue", cutoffMs = 10L)
-        assertEquals(listOf(stale.id), requeued.map { it.id })
+        assertEquals(listOf(stale.id, staleUpload.id), requeued.map { it.id })
 
         val afterRecoveryRestart = newStore()
         val recovered = afterRecoveryRestart.item(stale.id)!!
@@ -119,6 +139,9 @@ class SharedPrefsOutboundQueueStoreDurabilityTest {
         assertEquals(1, recovered.attemptCount)
         assertEquals(10L, recovered.lastAttemptAtMs)
         assertEquals("previous timeout", recovered.lastError)
+        assertEquals(OutboundState.Queued, afterRecoveryRestart.item(staleUpload.id)!!.state)
+        assertEquals(0, afterRecoveryRestart.item(staleUpload.id)!!.attemptCount)
+        assertEquals(OutboundState.Uploading, afterRecoveryRestart.item(freshUpload.id)!!.state)
         assertEquals(OutboundState.InFlight, afterRecoveryRestart.item(fresh.id)!!.state)
         assertEquals(OutboundState.InFlight, afterRecoveryRestart.item(otherSession.id)!!.state)
 
@@ -126,7 +149,35 @@ class SharedPrefsOutboundQueueStoreDurabilityTest {
         assertEquals(stale.id, claimed.id)
         assertEquals(OutboundState.InFlight, claimed.state)
         assertEquals(2, claimed.attemptCount)
+        val claimedUpload = afterRecoveryRestart.claimNext("sessA-requeue")!!
+        assertEquals(staleUpload.id, claimedUpload.id)
+        assertEquals(OutboundState.InFlight, claimedUpload.state)
+        assertEquals(1, claimedUpload.attemptCount)
         assertNull(afterRecoveryRestart.claimNext("sessA-requeue"))
+    }
+
+    @Test
+    fun freshUploadingRetryUsesUploadTimestampForStaleRecoveryAfterRestart() {
+        val first = newStore()
+        val item = first.enqueue(
+            sessionKey = "sess-upload-retry",
+            cleanText = "retry upload",
+            createdAtMs = 1L,
+        )
+        first.claimNext("sess-upload-retry")
+        first.markFailed(item.id, "old failure", lastAttemptAtMs = 10L)
+        first.markUploading(item.id, lastAttemptAtMs = 200L)
+
+        val afterRestart = newStore()
+        assertEquals(OutboundState.Uploading, afterRestart.item(item.id)!!.state)
+        assertEquals(200L, afterRestart.item(item.id)!!.lastAttemptAtMs)
+
+        assertTrue(afterRestart.requeueStaleInFlight("sess-upload-retry", cutoffMs = 100L).isEmpty())
+        assertEquals(OutboundState.Uploading, afterRestart.item(item.id)!!.state)
+
+        val requeued = afterRestart.requeueStaleInFlight("sess-upload-retry", cutoffMs = 200L)
+        assertEquals(listOf(item.id), requeued.map { it.id })
+        assertEquals(OutboundState.Queued, afterRestart.item(item.id)!!.state)
     }
 
     @Test


### PR DESCRIPTION
Closes #900

## Summary
- Persist local outbound attachment bytes as sidecars and upload them before queued sends are claimed
- Wire tmux-session upload support for queued sidecars, preserving route/session metadata
- Add single-owner upload/dispatch gating plus stale Uploading recovery so reconnect flushes stay send-once
- Replace queued attachment refs by indexed sidecar mapping, including mixed remote/local filename collisions

## Verification
- git diff --check
- ./gradlew :app:testDebugUnitTest --tests com.pocketshell.app.composer.PromptComposerViewModelTest --tests com.pocketshell.app.composer.OutboundQueueStoreTest --tests com.pocketshell.app.composer.SharedPrefsOutboundQueueStoreDurabilityTest --tests com.pocketshell.app.composer.OutboundAttachmentSidecarStoreTest
- ./gradlew :app:testDebugUnitTest --rerun-tasks --tests com.pocketshell.app.composer.PromptComposerViewModelTest.sidecarUploadBlocksSecondQueuedSidecarRowUntilFirstSendResolves

## Review
- Final reviewer approved after indexed sidecar mapping and race-test stabilization.