### PR TITLE
ci: leave classifier room in emulator journey job (#908)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('ref-{0}', github.ref) }}
+  cancel-in-progress: true
+
 jobs:
   unit:
     name: Unit tests
@@ -613,7 +617,7 @@ jobs:
 
       # Issue #835/#470: inspect the first attempt's suite-owned summary before
       # spending the second cold boot. If the first attempt already reached the
-      # 38-min suite budget and wrote a pure JOURNEY_STEP_TIMEOUT summary (no
+      # 20-min suite budget and wrote a pure JOURNEY_STEP_TIMEOUT summary (no
       # JOURNEY_FAILED / Failed BOTH attempts section), retrying inside this
       # same 45-min job cannot recover it; it only gets cancelled by the job cap
       # and creates another red email. Genuine journey failures and no-summary
@@ -738,7 +742,7 @@ jobs:
           # verdicts) but the suite-level time budget was exhausted — typically
           # by the recurring #470 in-emulator tmux `list-sessions` enumeration
           # stall consuming the session/reconnect journeys' retry windows. The
-          # suite now bails CLEANLY at its own deadline (below the 45-min step
+          # suite now bails CLEANLY at its own deadline (below the 45-min job
           # cap) and writes summary.md with the `JOURNEY_STEP_TIMEOUT` marker, so
           # this is a distinct, correctly-attributed advisory — NOT a never-booted
           # emulator (#771) and NOT a genuine test regression.

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -855,19 +855,22 @@ echo "=========================================================="
 #
 # ---------------------------------------------------------------------------
 # Issue #835: SUITE-LEVEL time budget so the recurring #470 enumeration stall
-# can never burn the whole 45-min step to a `cancelled` (which writes NO
+# can never burn the whole 45-min job to a `cancelled` (which writes NO
 # summary.md and mis-routes the workflow classifier to the #771
 # "EMULATOR INFRA UNAVAILABLE" branch).
 #
 # The per-test `timeout_msec` above bounds ONE @Test method, but a single
 # stalling CLASS still costs ~2 × 5 min (attempt + retry), and SIX such
 # session/reconnect classes stalling on #470 in one run (run 27845074217) added
-# up past the step cap → the step was SIGKILLed mid-loop before
+# up past the job cap → the step was SIGKILLed mid-loop before
 # `summary.md` was ever written. Without an artifact the classifier cannot tell a
 # #470 time-budget stall from a never-booted emulator.
 #
-# Fix: the suite owns its OWN deadline (JOURNEY_STEP_BUDGET_SECS, default 38 min)
-# which is comfortably BELOW the workflow's 45-min `timeout-minutes` step cap.
+# Fix (#908): the suite owns its OWN deadline (JOURNEY_STEP_BUDGET_SECS,
+# default 20 min). Arithmetic against the workflow cap is explicit:
+# 45-min job cap (2700s) - worst-case emulator boot (900s) - default suite
+# budget (1200s) = 600s for setup, classifier, Docker log collection, and
+# artifact upload.
 # When the remaining budget is exhausted the suite STOPS launching new classes,
 # records the not-run classes as a distinct BUDGET-timeout bucket, ALWAYS writes
 # summary.md (with the greppable `JOURNEY_STEP_TIMEOUT` marker), and exits
@@ -883,7 +886,7 @@ echo "=========================================================="
 #                                420s = 7 min: above the 300s per-test
 #                                timeout_msec so the runner's own interrupt is
 #                                preferred, but a backstop if even that wedges).
-JOURNEY_STEP_BUDGET_SECS="${JOURNEY_STEP_BUDGET_SECS:-2280}"
+JOURNEY_STEP_BUDGET_SECS="${JOURNEY_STEP_BUDGET_SECS:-1200}"
 JOURNEY_CLASS_TIMEOUT_SECS="${JOURNEY_CLASS_TIMEOUT_SECS:-420}"
 
 # budget_remaining — seconds left in the suite-level budget (never negative).
@@ -896,7 +899,7 @@ budget_remaining() {
 
 # budget_exhausted — true (0) once the suite-level budget is spent. Checked
 # before launching each class so the loop stops cleanly instead of being
-# SIGKILLed by the workflow step cap mid-class (which writes no summary).
+# SIGKILLed by the workflow job cap mid-class (which writes no summary).
 budget_exhausted() {
   (( $(budget_remaining) <= 0 ))
 }
@@ -1063,12 +1066,12 @@ STEP_TIMEOUT_HIT=0    # issue #835: set to 1 once the suite-level budget is spen
 SUITE_START=$SECONDS
 
 echo ">>> Suite-level time budget (issue #835): ${JOURNEY_STEP_BUDGET_SECS}s"
-echo "    (per-class attempt cap: ${JOURNEY_CLASS_TIMEOUT_SECS}s; workflow step cap: 45 min)"
+echo "    (per-class attempt cap: ${JOURNEY_CLASS_TIMEOUT_SECS}s; workflow job cap: 45 min)"
 
 for fqcn in "${JOURNEY_CLASSES[@]}"; do
   # Issue #835: stop launching new classes once the suite-level budget is spent.
   # A #470 enumeration stall earlier in the run can eat the budget; rather than
-  # let the workflow step SIGKILL us mid-class (which writes NO summary and
+  # let the workflow job SIGKILL us mid-class (which writes NO summary and
   # mis-routes the classifier to the #771 infra branch), we bail cleanly here,
   # bucket the remaining classes as BUDGET-timeouts, and fall through to ALWAYS
   # write the summary below with the `JOURNEY_STEP_TIMEOUT` marker.
@@ -1095,7 +1098,7 @@ for fqcn in "${JOURNEY_CLASSES[@]}"; do
   # Issue #835: if the budget is now spent (this attempt was cut by `timeout`, or
   # an earlier attempt drained the clock), do NOT burn the remaining-class retry
   # on a stalled AVD — bucket this class as a BUDGET-timeout and move on so the
-  # summary still gets written before the workflow step cap.
+  # summary still gets written before the workflow job cap.
   if budget_exhausted; then
     STEP_TIMEOUT_HIT=1
     echo "JOURNEY_STEP_TIMEOUT: $fqcn attempt 1 exhausted the suite budget (rc=$rc) — not retried (issue #835 / #470 stall)"
@@ -1159,7 +1162,7 @@ run_core_terminal_append_burst() {
 
 # Issue #835: if the suite budget was already spent by a #470 stall in the
 # journey loop above, SKIP the core-terminal proofs and go straight to writing
-# the summary — running another ~2 proofs would push us into the workflow step
+# the summary — running another ~2 proofs would push us into the workflow job
 # cap and lose the artifact. A skipped proof is recorded as SKIPPED (not PASS,
 # not FAIL) so the summary is honest; the budget-timeout label below makes the
 # job red regardless.
@@ -1443,7 +1446,7 @@ echo "=========================================================="
   # marker to label the red as a journey timeout / #470 stall — DISTINCT from a
   # genuine `JOURNEY_FAILED` regression and from a "no summary at all" #771
   # EMULATOR INFRA UNAVAILABLE abort. Writing this summary at all (instead of
-  # being SIGKILLed mid-loop by the 45-min step cap) is the whole point: an
+  # being SIGKILLed mid-loop by the 45-min job cap) is the whole point: an
   # artifact exists, so the classifier can attribute the red correctly.
   if [[ "$STEP_TIMEOUT_HIT" -eq 1 ]]; then
     echo

--- a/scripts/test-ci-journey-budget.sh
+++ b/scripts/test-ci-journey-budget.sh
@@ -4,7 +4,7 @@
 #
 # The recurring failure: the in-emulator #470 tmux `list-sessions` enumeration
 # stall makes session/reconnect journeys burn their retry windows; with no
-# suite-level deadline the 45-min workflow step cap SIGKILLs the suite mid-loop
+# suite-level deadline the 45-min workflow job cap SIGKILLs the suite mid-loop
 # before summary.md is written, so the workflow classifier mis-routes the red to
 # "EMULATOR INFRA UNAVAILABLE (#771)".
 #
@@ -33,6 +33,61 @@ fail() { echo "TEST FAIL: $*" >&2; exit 1; }
 pass() { echo "  ok: $*"; }
 
 [[ -f "$REAL_SUITE" ]] || fail "cannot find ci-journey-suite.sh at $REAL_SUITE"
+
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+WORKFLOW="$REPO_ROOT/.github/workflows/tests.yml"
+THIS_TEST="$SCRIPT_DIR/test-ci-journey-budget.sh"
+
+# (pre) #908 budget/default/comment guard: prove the suite budget leaves
+# explicit slack under the workflow cap after a worst-case emulator boot.
+job_cap_min="$(awk '
+  /^  emulator-journey:/ { in_job=1; next }
+  in_job && /^  [A-Za-z0-9_-]+:/ { in_job=0 }
+  in_job && /timeout-minutes:/ { print $2; exit }
+' "$WORKFLOW")"
+[[ "$job_cap_min" =~ ^[0-9]+$ ]] \
+  || fail "(pre) could not parse emulator-journey timeout-minutes from tests.yml"
+job_cap_secs=$((job_cap_min * 60))
+[[ "$job_cap_secs" -eq 2700 ]] \
+  || fail "(pre) emulator-journey job cap must stay 45 min / 2700s (got ${job_cap_secs}s)"
+
+mapfile -t emulator_boot_timeout_values < <(awk '/emulator-boot-timeout:/ { print $2 }' "$WORKFLOW")
+[[ "${#emulator_boot_timeout_values[@]}" -gt 0 ]] \
+  || fail "(pre) could not parse emulator-boot-timeout from tests.yml"
+for emulator_boot_timeout_secs in "${emulator_boot_timeout_values[@]}"; do
+  [[ "$emulator_boot_timeout_secs" =~ ^[0-9]+$ ]] \
+    || fail "(pre) emulator-boot-timeout must be numeric (got ${emulator_boot_timeout_secs})"
+  [[ "$emulator_boot_timeout_secs" -eq 900 ]] \
+    || fail "(pre) every emulator boot timeout must stay 900s (got ${emulator_boot_timeout_secs}s)"
+done
+emulator_boot_timeout_secs="${emulator_boot_timeout_values[0]}"
+
+# Match the literal shell assignment in ci-journey-suite.sh.
+# shellcheck disable=SC2016
+default_suite_budget_secs="$(sed -n 's/^JOURNEY_STEP_BUDGET_SECS="${JOURNEY_STEP_BUDGET_SECS:-\([0-9][0-9]*\)}"$/\1/p' "$REAL_SUITE")"
+[[ "$default_suite_budget_secs" =~ ^[0-9]+$ ]] \
+  || fail "(pre) could not parse default JOURNEY_STEP_BUDGET_SECS from ci-journey-suite.sh"
+[[ "$default_suite_budget_secs" -eq 1200 ]] \
+  || fail "(pre) default JOURNEY_STEP_BUDGET_SECS must stay 1200s / 20 min (got ${default_suite_budget_secs}s)"
+
+remaining_slack_secs=$((job_cap_secs - emulator_boot_timeout_secs - default_suite_budget_secs))
+[[ "$remaining_slack_secs" -ge 600 ]] \
+  || fail "(pre) insufficient post-boot slack: ${job_cap_secs}s job cap - ${emulator_boot_timeout_secs}s boot - ${default_suite_budget_secs}s suite = ${remaining_slack_secs}s (< 600s)"
+
+grep -q 'default 20 min' "$REAL_SUITE" \
+  || fail "(pre) ci-journey-suite.sh budget comment must document the 20-min default"
+grep -q '45-min job cap (2700s) - worst-case emulator boot (900s) - default suite' "$REAL_SUITE" \
+  || fail "(pre) ci-journey-suite.sh budget comment must show the safe arithmetic"
+grep -q 'workflow job cap: 45 min' "$REAL_SUITE" \
+  || fail "(pre) ci-journey-suite.sh log line must refer to the 45-min job cap"
+grep -q '20-min suite budget' "$WORKFLOW" \
+  || fail "(pre) tests.yml first-summary comment must match the 20-min suite budget"
+stale_step_cap_re="workflow ste""p|ste""p cap|45-min ste""p|45 min ste""p"
+if grep -qE "$stale_step_cap_re" \
+  "$REAL_SUITE" "$WORKFLOW" "$THIS_TEST"; then
+  fail "(pre) stale workflow-timeout wording found; use 45-min job cap"
+fi
+pass "(pre) #908 budget arithmetic pinned (${job_cap_secs}s job - ${emulator_boot_timeout_secs}s boot - ${default_suite_budget_secs}s suite = ${remaining_slack_secs}s slack)"
 
 # ---------------------------------------------------------------------------
 # Build a sandbox "repo root": a copy of the suite script + a stub gradlew that


### PR DESCRIPTION
## Summary
- add `Tests` workflow concurrency so superseded PR/ref runs cancel automatically
- lower the emulator journey suite-owned budget to 20 minutes, leaving 600s slack under the 45-minute job cap after a worst-case 900s emulator boot
- extend the budget guard so it proves the job-cap / boot-timeout / suite-budget arithmetic and catches stale `workflow step` / `step cap` wording

## Evidence
- Current main run 28137263381 and PR #905 run 28137283293 both hit the existing failure mode: non-emulator jobs green, first emulator attempt ran ~39m, retry was cancelled at the 45m job cap, and classifier failed.
- Reviewer approved the corrected diff after verifying concurrency grouping, 2700s - 900s - 1200s = 600s slack, stale wording guard, and focused checks.

## Verification
- `bash -n scripts/ci-journey-suite.sh scripts/test-ci-journey-budget.sh`
- `scripts/test-ci-journey-budget.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/tests.yml"); puts "yaml ok"'`\n- `git diff --check`\n\nCloses #908