### PR TITLE
ui: add shared sheet header (#756)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/bootstrap/HostBootstrapSheet.kt
+++ b/app/src/main/java/com/pocketshell/app/bootstrap/HostBootstrapSheet.kt
@@ -32,6 +32,7 @@ import com.pocketshell.uikit.components.ListRow
 import com.pocketshell.uikit.components.LoadingIndicator
 import com.pocketshell.uikit.components.PocketShellButton
 import com.pocketshell.uikit.components.SectionHeader
+import com.pocketshell.uikit.components.SheetHeader
 import com.pocketshell.uikit.components.SpinnerSize
 import com.pocketshell.uikit.components.StatusDot
 import com.pocketshell.uikit.model.ConnectionStatus
@@ -152,8 +153,10 @@ private fun PromptContent(
     onSkip: () -> Unit,
 ) {
     SheetColumn {
-        SheetTitle(text = "Host setup needed")
-        SheetSubtitle(text = "$hostName · ${bootstrapPromptText(state)}")
+        SheetHeader(
+            title = "Host setup needed",
+            subtitle = "$hostName · ${bootstrapPromptText(state)}",
+        )
         SetupActions(
             state = state,
             onInstallTool = onInstallTool,
@@ -322,8 +325,10 @@ private fun SetupInfoRow(title: String, detail: String) {
 @Composable
 private fun InstallingContent(hostName: String) {
     SheetColumn {
-        SheetTitle(text = "Setting up host…")
-        SheetSubtitle(text = "$hostName · running installer and systemd commands. This can take a few seconds on a fresh host.")
+        SheetHeader(
+            title = "Setting up host…",
+            subtitle = "$hostName · running installer and systemd commands. This can take a few seconds on a fresh host.",
+        )
         Spacer(modifier = Modifier.height(PocketShellSpacing.lg + PocketShellSpacing.xs))
         ListRow(
             title = "working…",
@@ -349,8 +354,10 @@ private fun SuccessContent(
     onContinue: () -> Unit,
 ) {
     SheetColumn {
-        SheetTitle(text = "Host ready")
-        SheetSubtitle(text = hostBootstrapSuccessSubtitle(hostName))
+        SheetHeader(
+            title = "Host ready",
+            subtitle = hostBootstrapSuccessSubtitle(hostName),
+        )
         Spacer(modifier = Modifier.height(PocketShellSpacing.lg + PocketShellSpacing.xs))
         // Issue #885 (hard cut, D22): after a successful install/update the
         // sheet just acknowledges "Host ready" and offers a single Continue —
@@ -376,8 +383,10 @@ internal fun hostBootstrapSuccessSubtitle(hostName: String): String =
 @Composable
 private fun FailedContent(hostName: String, message: String, onClose: () -> Unit) {
     SheetColumn {
-        SheetTitle(text = "Install failed")
-        SheetSubtitle(text = "$hostName · the package manager reported an error.")
+        SheetHeader(
+            title = "Install failed",
+            subtitle = "$hostName · the package manager reported an error.",
+        )
         Spacer(modifier = Modifier.height(PocketShellSpacing.md))
         Box(
             modifier = Modifier
@@ -538,24 +547,4 @@ private fun SheetColumn(content: @Composable () -> Unit) {
     ) {
         content()
     }
-}
-
-@Composable
-private fun SheetTitle(text: String) {
-    Text(
-        text = text,
-        color = PocketShellColors.Text,
-        style = MaterialTheme.typography.titleMedium,
-        fontWeight = FontWeight.SemiBold,
-    )
-}
-
-@Composable
-private fun SheetSubtitle(text: String) {
-    Spacer(modifier = Modifier.height(PocketShellSpacing.sm))
-    Text(
-        text = text,
-        color = PocketShellColors.TextSecondary,
-        style = PocketShellType.bodyDense,
-    )
 }

--- a/app/src/main/java/com/pocketshell/app/env/EnvScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/env/EnvScreen.kt
@@ -56,6 +56,7 @@ import com.pocketshell.uikit.components.LoadingIndicator
 import com.pocketshell.uikit.components.PocketShellButton
 import com.pocketshell.uikit.components.ScreenHeader
 import com.pocketshell.uikit.components.SegmentedToggle
+import com.pocketshell.uikit.components.SheetHeader
 import com.pocketshell.uikit.components.SpinnerSize
 import com.pocketshell.uikit.theme.PocketShellColors
 import com.pocketshell.uikit.theme.PocketShellShapes
@@ -467,11 +468,7 @@ private fun CopyFromFolderSheet(
                 .padding(bottom = 24.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
-            Text(
-                text = "Copy keys from another folder",
-                color = PocketShellColors.Text,
-                style = MaterialTheme.typography.titleMedium,
-            )
+            SheetHeader(title = "Copy keys from another folder")
 
             val source = selectedSource
             if (source == null) {

--- a/app/src/main/java/com/pocketshell/app/fileviewer/FileViewerReviewUi.kt
+++ b/app/src/main/java/com/pocketshell/app/fileviewer/FileViewerReviewUi.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.pocketshell.uikit.components.ButtonVariant
 import com.pocketshell.uikit.components.PocketShellButton
+import com.pocketshell.uikit.components.SheetHeader
 import com.pocketshell.uikit.theme.PocketShellColors
 import com.pocketshell.uikit.theme.PocketShellDensity
 import com.pocketshell.uikit.theme.PocketShellShapes
@@ -268,22 +269,12 @@ private fun CommentSheet(
                 .padding(bottom = PocketShellSpacing.lg)
                 .testTag(testTag),
         ) {
-            Text(
-                text = title,
-                style = PocketShellType.bodyDense,
-                fontWeight = FontWeight.SemiBold,
-                color = PocketShellColors.Text,
+            SheetHeader(
+                title = title,
+                subtitle = subtitle.takeIf { it.isNotEmpty() },
+                subtitleMaxLines = 2,
+                subtitleStyle = PocketShellType.bodyMono,
             )
-            if (subtitle.isNotEmpty()) {
-                Spacer(modifier = Modifier.height(2.dp))
-                Text(
-                    text = subtitle,
-                    color = PocketShellColors.TextMuted,
-                    style = PocketShellType.bodyMono,
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis,
-                )
-            }
             Spacer(modifier = Modifier.height(PocketShellSpacing.md))
             Box(
                 modifier = Modifier
@@ -382,12 +373,7 @@ private fun PendingTraySheet(
                 .padding(bottom = PocketShellSpacing.lg)
                 .testTag(FILE_VIEWER_REVIEW_TRAY_SHEET_TAG),
         ) {
-            Text(
-                text = "Review (${reviewState.pendingCount})",
-                style = PocketShellType.bodyDense,
-                fontWeight = FontWeight.SemiBold,
-                color = PocketShellColors.Text,
-            )
+            SheetHeader(title = "Review (${reviewState.pendingCount})")
             Spacer(modifier = Modifier.height(PocketShellSpacing.md))
 
             if (!reviewState.hasPending) {
@@ -487,18 +473,10 @@ internal fun ReviewSubmittedSheet(
                 .padding(bottom = PocketShellSpacing.lg)
                 .testTag(FILE_VIEWER_REVIEW_SAVED_SHEET_TAG),
         ) {
-            Text(
-                text = "Review saved",
-                style = PocketShellType.bodyDense,
-                fontWeight = FontWeight.SemiBold,
-                color = PocketShellColors.Text,
-            )
-            Spacer(modifier = Modifier.height(2.dp))
-            Text(
-                text = "Sent $count ${if (count == 1) "comment" else "comments"} to $host. " +
+            SheetHeader(
+                title = "Review saved",
+                subtitle = "Sent $count ${if (count == 1) "comment" else "comments"} to $host. " +
                     "It's in the reviews inbox and you can route it into this session.",
-                style = PocketShellType.bodyDense,
-                color = PocketShellColors.TextSecondary,
             )
             Spacer(modifier = Modifier.height(PocketShellSpacing.md))
 
@@ -598,18 +576,10 @@ internal fun AnnotationSavedSheet(
                 .padding(bottom = PocketShellSpacing.lg)
                 .testTag(FILE_VIEWER_ANNOTATE_SAVED_SHEET_TAG),
         ) {
-            Text(
-                text = "Annotated image saved",
-                style = PocketShellType.bodyDense,
-                fontWeight = FontWeight.SemiBold,
-                color = PocketShellColors.Text,
-            )
-            Spacer(modifier = Modifier.height(2.dp))
-            Text(
-                text = "Sent the marked-up image to $host. " +
+            SheetHeader(
+                title = "Annotated image saved",
+                subtitle = "Sent the marked-up image to $host. " +
                     "It's in the annotations inbox (with a YAML sidecar).",
-                style = PocketShellType.bodyDense,
-                color = PocketShellColors.TextSecondary,
             )
             Spacer(modifier = Modifier.height(PocketShellSpacing.md))
 

--- a/app/src/main/java/com/pocketshell/app/git/GitHistoryScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/git/GitHistoryScreen.kt
@@ -57,6 +57,7 @@ import com.pocketshell.uikit.components.PocketShellButton
 import com.pocketshell.uikit.components.ScreenHeader
 import com.pocketshell.uikit.components.SectionHeader
 import com.pocketshell.uikit.components.SegmentedToggle
+import com.pocketshell.uikit.components.SheetHeader
 import com.pocketshell.uikit.components.SpinnerSize
 import com.pocketshell.uikit.components.StatusDot
 import com.pocketshell.uikit.model.ConnectionStatus
@@ -744,12 +745,7 @@ private fun CreateIssueSheet(
                 .padding(horizontal = PocketShellSpacing.lg, vertical = PocketShellSpacing.lg),
             verticalArrangement = Arrangement.spacedBy(PocketShellSpacing.md),
         ) {
-            Text(
-                text = "New GitHub issue",
-                color = PocketShellColors.Text,
-                style = PocketShellType.bodyDense,
-                fontWeight = FontWeight.SemiBold,
-            )
+            SheetHeader(title = "New GitHub issue")
 
             if (success != null) {
                 CreateIssueSuccess(url = success.url, onOpenUrl = onOpenUrl, onClose = onDismiss)

--- a/app/src/main/java/com/pocketshell/app/projects/FolderContextActionSheet.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderContextActionSheet.kt
@@ -30,6 +30,7 @@ import com.pocketshell.uikit.components.ButtonVariant
 import com.pocketshell.uikit.components.ListRow
 import com.pocketshell.uikit.components.PocketShellButton
 import com.pocketshell.uikit.components.SectionHeader
+import com.pocketshell.uikit.components.SheetHeader
 import com.pocketshell.uikit.theme.PocketShellColors
 import com.pocketshell.uikit.theme.PocketShellShapes
 import com.pocketshell.uikit.theme.PocketShellSpacing
@@ -90,16 +91,10 @@ internal fun FolderContextActionContent(
             .padding(horizontal = PocketShellSpacing.lg, vertical = PocketShellSpacing.lg),
         verticalArrangement = Arrangement.spacedBy(PocketShellSpacing.md),
     ) {
-        Text(
-            text = folderLabel,
-            color = PocketShellColors.Text,
-            style = PocketShellType.bodyDense,
-            fontWeight = FontWeight.SemiBold,
-        )
-        Text(
-            text = folderPath,
-            color = PocketShellColors.TextSecondary,
-            style = PocketShellType.bodyMono,
+        SheetHeader(
+            title = folderLabel,
+            subtitle = folderPath,
+            subtitleStyle = PocketShellType.bodyMono,
         )
         Spacer(modifier = Modifier.height(PocketShellSpacing.xs))
         FolderContextRow("+ New session here", FOLDER_CONTEXT_NEW_SESSION_TAG, onNewSession)

--- a/app/src/main/java/com/pocketshell/app/projects/RootProjectAddSheet.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/RootProjectAddSheet.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.unit.dp
 import com.pocketshell.uikit.components.Badge
 import com.pocketshell.uikit.components.BadgeRole
 import com.pocketshell.uikit.components.ListRow
+import com.pocketshell.uikit.components.SheetHeader
 import com.pocketshell.uikit.theme.PocketShellColors
 import com.pocketshell.uikit.theme.PocketShellShapes
 import com.pocketshell.uikit.theme.PocketShellSpacing
@@ -125,19 +126,11 @@ internal fun RootProjectAddSheetContent(
             .testTag(ROOT_PROJECT_ADD_CONTENT_TAG),
         verticalArrangement = Arrangement.spacedBy(PocketShellSpacing.md),
     ) {
-        Text(
-            text = root.label,
-            color = PocketShellColors.Text,
-            style = PocketShellType.bodyDense,
-            fontWeight = FontWeight.SemiBold,
+        SheetHeader(
+            title = root.label,
+            subtitle = root.displayPath,
+            subtitleStyle = PocketShellType.bodyMono,
         )
-        root.displayPath?.let { path ->
-            Text(
-                text = path,
-                color = PocketShellColors.TextSecondary,
-                style = PocketShellType.bodyMono,
-            )
-        }
         OutlinedTextField(
             value = query,
             onValueChange = { query = it },

--- a/app/src/main/java/com/pocketshell/app/projects/SessionKindPickerSheet.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/SessionKindPickerSheet.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.unit.dp
 import com.pocketshell.uikit.components.ButtonVariant
 import com.pocketshell.uikit.components.ListRow
 import com.pocketshell.uikit.components.PocketShellButton
+import com.pocketshell.uikit.components.SheetHeader
 import com.pocketshell.uikit.model.SessionAgentKind
 import com.pocketshell.uikit.theme.PocketShellColors
 import com.pocketshell.uikit.theme.PocketShellSpacing
@@ -138,25 +139,19 @@ internal fun SessionKindPickerContent(
                 .padding(top = PocketShellSpacing.lg, bottom = PocketShellSpacing.md),
             verticalArrangement = Arrangement.spacedBy(PocketShellSpacing.sm),
         ) {
-            Text(
-                text = if (isUnknown) {
+            SheetHeader(
+                title = if (isUnknown) {
                     "We don't know what this session is"
                 } else {
                     "Change session kind"
                 },
-                color = PocketShellColors.Text,
-                style = PocketShellType.bodyDense,
-                fontWeight = FontWeight.SemiBold,
-                modifier = Modifier.testTag(SESSION_KIND_PICKER_TITLE_TAG),
-            )
-            Text(
-                text = if (isUnknown) {
+                subtitle = if (isUnknown) {
                     "Choose what \"$sessionName\" is running. We'll remember it."
                 } else {
                     "Set what \"$sessionName\" is running."
                 },
-                color = PocketShellColors.TextSecondary,
-                style = PocketShellType.bodyMono,
+                subtitleStyle = PocketShellType.bodyMono,
+                titleTestTag = SESSION_KIND_PICKER_TITLE_TAG,
             )
 
             // Issue #858: surface the recorded NON-default profile/provider so

--- a/app/src/main/java/com/pocketshell/app/projects/SessionTypePickerSheet.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/SessionTypePickerSheet.kt
@@ -38,6 +38,7 @@ import com.pocketshell.uikit.components.ListRow
 import com.pocketshell.uikit.components.PocketShellButton
 import com.pocketshell.uikit.components.SectionHeader
 import com.pocketshell.uikit.components.SegmentedToggle
+import com.pocketshell.uikit.components.SheetHeader
 import com.pocketshell.uikit.model.SessionAgentKind
 import com.pocketshell.uikit.theme.PocketShellColors
 import com.pocketshell.uikit.theme.PocketShellSpacing
@@ -143,16 +144,10 @@ internal fun SessionTypePickerContent(
                 .padding(top = PocketShellSpacing.lg, bottom = PocketShellSpacing.md),
             verticalArrangement = Arrangement.spacedBy(PocketShellSpacing.md),
         ) {
-            Text(
-                text = title,
-                color = PocketShellColors.Text,
-                style = PocketShellType.bodyDense,
-                fontWeight = FontWeight.SemiBold,
-            )
-            Text(
-                text = "in $folderLabel",
-                color = PocketShellColors.TextSecondary,
-                style = PocketShellType.bodyMono,
+            SheetHeader(
+                title = title,
+                subtitle = "in $folderLabel",
+                subtitleStyle = PocketShellType.bodyMono,
             )
 
             // Start folder — pre-filled, editable. Keep this inside the

--- a/app/src/main/java/com/pocketshell/app/snippets/SnippetPickerSheet.kt
+++ b/app/src/main/java/com/pocketshell/app/snippets/SnippetPickerSheet.kt
@@ -56,6 +56,7 @@ import com.pocketshell.uikit.components.BadgeRole
 import com.pocketshell.uikit.components.ButtonVariant
 import com.pocketshell.uikit.components.ListRow
 import com.pocketshell.uikit.components.PocketShellButton
+import com.pocketshell.uikit.components.SheetHeader
 import com.pocketshell.uikit.theme.PocketShellColors
 import com.pocketshell.uikit.theme.PocketShellDensity
 import com.pocketshell.uikit.theme.PocketShellShapes
@@ -230,21 +231,12 @@ internal fun SnippetPickerContent(
             .padding(horizontal = PocketShellSpacing.lg)
             .padding(bottom = PocketShellSpacing.lg),
     ) {
-        // Header: title + close X.
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(bottom = 12.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween,
-        ) {
-            Text(
-                text = "Snippets",
-                style = PocketShellType.bodyDense,
-                fontWeight = FontWeight.SemiBold,
-                color = PocketShellColors.Text,
-            )
-            Row(verticalAlignment = Alignment.CenterVertically) {
+        SheetHeader(
+            title = "Snippets",
+            onClose = onClose,
+            closeContentDescription = "Close snippets",
+            modifier = Modifier.padding(bottom = 12.dp),
+            trailing = {
                 Text(
                     text = "Manage",
                     color = PocketShellColors.Accent,
@@ -254,21 +246,8 @@ internal fun SnippetPickerContent(
                         .clickable(onClick = onManageTap)
                         .padding(horizontal = PocketShellSpacing.sm, vertical = PocketShellSpacing.xs),
                 )
-                Box(
-                    modifier = Modifier
-                        .size(PocketShellDensity.tapTargetMin)
-                        .clickable(onClick = onClose),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    Text(
-                        text = "×",
-                        color = PocketShellColors.TextSecondary,
-                        style = PocketShellType.bodyDense,
-                        fontWeight = FontWeight.SemiBold,
-                    )
-                }
-            }
-        }
+            },
+        )
 
         // Search field. Mirrors the composer text area's surface-elev fill
         // for visual consistency.

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -307,9 +307,15 @@ text entry, passphrase/API-key entry, and blocking errors.
 Standard sheet pattern:
 
 - `ModalBottomSheet`, `Surface` container, 20dp top corners.
-- Title row, optional search/filter, dense `LazyColumn`, fixed action row only
+- [`SheetHeader`](../shared/ui-kit/src/main/java/com/pocketshell/uikit/components/SheetHeader.kt)
+  title row, optional search/filter, dense `LazyColumn`, fixed action row only
   when needed.
 - Rows use `ListRow`, `Badge`, `StatusDot`, and `Kebab` where possible.
+
+`SheetHeader` is the canonical bottom-sheet title surface: `titleMedium`
+SemiBold title, optional muted dense subtitle, optional trailing slot, and an
+optional close affordance. The sheet body keeps owning its height, scrolling,
+and horizontal padding; the header owns only the title/subtitle/action grammar.
 
 Standard dialog pattern:
 

--- a/shared/ui-kit/src/main/java/com/pocketshell/uikit/components/SheetHeader.kt
+++ b/shared/ui-kit/src/main/java/com/pocketshell/uikit/components/SheetHeader.kt
@@ -1,0 +1,122 @@
+package com.pocketshell.uikit.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextOverflow
+import com.pocketshell.uikit.theme.PocketShellColors
+import com.pocketshell.uikit.theme.PocketShellDensity
+import com.pocketshell.uikit.theme.PocketShellSpacing
+import com.pocketshell.uikit.theme.PocketShellType
+
+/**
+ * Shared bottom-sheet header (#756).
+ *
+ * A bottom sheet's top row should read the same whether the sheet is a picker,
+ * an action tray, or a short success surface: title on the title rung, optional
+ * muted subtitle, optional trailing action(s), and an optional close affordance.
+ * Callers keep owning sheet-specific content padding and height constraints; this
+ * component owns the title/subtitle/action grammar only.
+ */
+@Composable
+fun SheetHeader(
+    title: String,
+    modifier: Modifier = Modifier,
+    subtitle: String? = null,
+    titleMaxLines: Int = Int.MAX_VALUE,
+    subtitleMaxLines: Int = Int.MAX_VALUE,
+    subtitleStyle: TextStyle = PocketShellType.bodyDense,
+    titleTestTag: String? = null,
+    subtitleTestTag: String? = null,
+    onClose: (() -> Unit)? = null,
+    closeContentDescription: String = "Close",
+    closeTestTag: String? = null,
+    trailing: (@Composable RowScope.() -> Unit)? = null,
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = title,
+                color = PocketShellColors.Text,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                maxLines = titleMaxLines,
+                overflow = TextOverflow.Ellipsis,
+                modifier = titleTestTag?.let { Modifier.testTag(it) } ?: Modifier,
+            )
+            if (subtitle != null) {
+                Spacer(modifier = Modifier.size(PocketShellSpacing.xs))
+                Text(
+                    text = subtitle,
+                    color = PocketShellColors.TextSecondary,
+                    style = subtitleStyle,
+                    maxLines = subtitleMaxLines,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = subtitleTestTag?.let { Modifier.testTag(it) } ?: Modifier,
+                )
+            }
+        }
+
+        if (trailing != null || onClose != null) {
+            Spacer(modifier = Modifier.width(PocketShellSpacing.sm))
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(PocketShellSpacing.xs),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                trailing?.invoke(this)
+                if (onClose != null) {
+                    SheetCloseButton(
+                        onClick = onClose,
+                        contentDescription = closeContentDescription,
+                        testTag = closeTestTag,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SheetCloseButton(
+    onClick: () -> Unit,
+    contentDescription: String,
+    testTag: String?,
+) {
+    Box(
+        modifier = (testTag?.let { Modifier.testTag(it) } ?: Modifier)
+            .size(PocketShellDensity.tapTargetMin)
+            .semantics { this.contentDescription = contentDescription }
+            .clickable(role = Role.Button, onClick = onClick),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = "×",
+            color = PocketShellColors.TextSecondary,
+            style = PocketShellType.bodyDense,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.padding(bottom = PocketShellSpacing.xs),
+        )
+    }
+}

--- a/shared/ui-kit/src/main/java/com/pocketshell/uikit/components/TerminalHotkeysPanel.kt
+++ b/shared/ui-kit/src/main/java/com/pocketshell/uikit/components/TerminalHotkeysPanel.kt
@@ -104,40 +104,13 @@ fun TerminalHotkeysPanel(
             .semantics { contentDescription = "Terminal hotkeys" },
         verticalArrangement = Arrangement.spacedBy(14.dp),
     ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 6.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween,
-        ) {
-            Text(
-                text = "Terminal hotkeys",
-                fontSize = 16.sp,
-                fontWeight = FontWeight.SemiBold,
-                letterSpacing = (-0.2).sp,
-                color = PocketShellColors.Text,
-            )
-            Box(
-                modifier = Modifier
-                    .height(32.dp)
-                    .background(
-                        PocketShellColors.SurfaceElev,
-                        androidx.compose.foundation.shape.CircleShape,
-                    )
-                    .padding(horizontal = 9.dp)
-                    .clickable(role = Role.Button, onClick = onClose)
-                    .testTag(TERMINAL_HOTKEYS_PANEL_CLOSE_TAG)
-                    .semantics { contentDescription = "Close terminal hotkeys" },
-                contentAlignment = Alignment.Center,
-            ) {
-                Text(
-                    text = "×",
-                    color = PocketShellColors.TextSecondary,
-                    fontSize = 20.sp,
-                )
-            }
-        }
+        SheetHeader(
+            title = "Terminal hotkeys",
+            onClose = onClose,
+            closeContentDescription = "Close terminal hotkeys",
+            closeTestTag = TERMINAL_HOTKEYS_PANEL_CLOSE_TAG,
+            modifier = Modifier.padding(top = 6.dp),
+        )
 
         sections.forEach { section ->
             HotkeySectionGrid(

--- a/shared/ui-kit/src/test/java/com/pocketshell/uikit/components/SheetHeaderTest.kt
+++ b/shared/ui-kit/src/test/java/com/pocketshell/uikit/components/SheetHeaderTest.kt
@@ -1,0 +1,84 @@
+package com.pocketshell.uikit.components
+
+import androidx.compose.material3.Text
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.pocketshell.uikit.theme.PocketShellTheme
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * JVM behaviour tests for the shared bottom-sheet header (#756). The key
+ * contract is presentational consistency plus routing the optional close action;
+ * sheet animation itself stays in the app-level `ModalBottomSheet` wrappers.
+ */
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(qualifiers = "w412dp-h915dp-night-xxhdpi")
+class SheetHeaderTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun rendersTitleSubtitleAndTrailingSlot() {
+        composeRule.setContent {
+            PocketShellTheme {
+                SheetHeader(
+                    title = "New session",
+                    subtitle = "in ~/src/pocketshell",
+                    trailing = { Text("Manage") },
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("New session").assertIsDisplayed()
+        composeRule.onNodeWithText("in ~/src/pocketshell").assertIsDisplayed()
+        composeRule.onNodeWithText("Manage").assertIsDisplayed()
+    }
+
+    @Test
+    fun closeAffordanceRoutesOnClose() {
+        var closes = 0
+        composeRule.setContent {
+            PocketShellTheme {
+                SheetHeader(
+                    title = "Snippets",
+                    onClose = { closes++ },
+                    closeContentDescription = "Close snippets",
+                    closeTestTag = "sheet-close",
+                )
+            }
+        }
+
+        composeRule.onNodeWithContentDescription("Close snippets").assertIsDisplayed()
+        composeRule.onNodeWithTag("sheet-close").performClick()
+        composeRule.runOnIdle { assertEquals(1, closes) }
+    }
+
+    @Test
+    fun exposesTitleAndSubtitleTags() {
+        composeRule.setContent {
+            PocketShellTheme {
+                SheetHeader(
+                    title = "Review saved",
+                    subtitle = "Sent 2 comments to hetzner.",
+                    titleTestTag = "sheet-title",
+                    subtitleTestTag = "sheet-subtitle",
+                )
+            }
+        }
+
+        composeRule.onNodeWithTag("sheet-title").assertIsDisplayed()
+        composeRule.onNodeWithTag("sheet-subtitle").assertIsDisplayed()
+    }
+}

--- a/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenders.kt
+++ b/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenders.kt
@@ -69,6 +69,7 @@ import com.pocketshell.uikit.components.ProgressBar
 import com.pocketshell.uikit.components.ScreenHeader
 import com.pocketshell.uikit.components.SectionHeader
 import com.pocketshell.uikit.components.SegmentedToggle
+import com.pocketshell.uikit.components.SheetHeader
 import com.pocketshell.uikit.components.StatusDot
 import com.pocketshell.uikit.model.ConnectionStatus
 import com.pocketshell.uikit.model.Crumb
@@ -200,6 +201,27 @@ class DesignRenders {
                 Badge(label = "7 active", role = BadgeRole.Active, mono = false)
             },
         )
+    }
+
+    /** Bottom-sheet title row with subtitle, trailing action, and close affordance. */
+    @Test
+    fun sheetHeader() = render("sheet-header") {
+        Surface(color = PocketShellColors.Surface) {
+            SheetHeader(
+                title = "Snippets",
+                subtitle = "12 saved commands",
+                onClose = {},
+                trailing = {
+                    Text(
+                        text = "Manage",
+                        color = PocketShellColors.Accent,
+                        style = PocketShellType.bodyDense,
+                        fontWeight = FontWeight.Medium,
+                    )
+                },
+                modifier = Modifier.padding(20.dp),
+            )
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- Add shared SheetHeader component and tests for issue #756
- Migrate existing sheet headers to the shared UI-kit component
- Document the design-system usage and add the sheetHeader render target

## Validation
- git diff --check
- ./gradlew :shared:ui-kit:testDebugUnitTest :app:compileDebugKotlin
- scripts/render.sh sheetHeader

Render: shared/ui-kit/build/renders/sheet-header.png

Closes #756