### PR TITLE
ci: cancel composer scope during test teardown (#913)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerViewModel.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -2887,6 +2888,7 @@ public class PromptComposerViewModel @Inject constructor(
             }
         }
         runCatching { speechRecognitionSession?.cancel() }
+        viewModelScope.cancel()
         super.onCleared()
     }
 


### PR DESCRIPTION
## Summary
- cancel PromptComposerViewModel viewModelScope during onCleared so direct test teardown mirrors AndroidX scope cleanup
- prevents sidecar cleanup coroutines from leaking across PromptComposerViewModelTest cases and tripping the Unconfined test dispatcher

Fixes #913.

## Validation
- ./gradlew :app:testReleaseUnitTest --tests 'com.pocketshell.app.composer.PromptComposerViewModelTest' --stacktrace --max-workers=2
- ./gradlew :app:testDebugUnitTest --tests 'com.pocketshell.app.composer.PromptComposerViewModelTest' --stacktrace --max-workers=2