### PR TITLE
composer: lock mic recording from swipe-up gesture

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerMicSwipeLockJourneyTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerMicSwipeLockJourneyTest.kt
@@ -1,0 +1,185 @@
+package com.pocketshell.app.composer
+
+import androidx.activity.ComponentActivity
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import androidx.lifecycle.SavedStateHandle
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.composer.PromptComposerViewModel.ApiKeyVault
+import com.pocketshell.app.composer.PromptComposerViewModel.MicCapture
+import com.pocketshell.app.composer.PromptComposerViewModel.RecordingState
+import com.pocketshell.app.composer.PromptComposerViewModel.VoiceSettingsSnapshot
+import com.pocketshell.app.di.WhisperClientFactory
+import com.pocketshell.app.proof.WalkthroughScreenshotArtifacts
+import com.pocketshell.core.voice.SpeechAudioGuard
+import com.pocketshell.core.voice.WhisperClient
+import com.pocketshell.uikit.theme.PocketShellTheme
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Issue #585: a Telegram-style hold-and-pull-up on the Prompt Composer mic
+ * must start recording and lock it hands-free in one gesture. This drives the
+ * real [PromptComposerSheet] inside its [androidx.compose.material3.ModalBottomSheet]
+ * with a real [PromptComposerViewModel] so the mic gesture competes with the
+ * same sheet drag detector that regressed on device.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@RunWith(AndroidJUnit4::class)
+class PromptComposerMicSwipeLockJourneyTest {
+
+    @get:Rule
+    val compose = createAndroidComposeRule<ComponentActivity>()
+
+    @Before
+    fun grantRecordAudio() {
+        val targetPackage = InstrumentationRegistry.getInstrumentation()
+            .targetContext.packageName
+        InstrumentationRegistry.getInstrumentation().uiAutomation.executeShellCommand(
+            "pm grant $targetPackage android.permission.RECORD_AUDIO",
+        ).close()
+    }
+
+    private class FakeMicCapture : MicCapture {
+        var startCount = 0
+        var stopCount = 0
+        private var running = false
+
+        override fun start() {
+            startCount++
+            running = true
+        }
+
+        override fun stop(): ByteArray {
+            stopCount++
+            running = false
+            return SpeechAudioGuard.speechWavForTesting()
+        }
+
+        override fun currentAmplitude(): Float = if (running) 0.65f else 0f
+    }
+
+    private class FakeVault : ApiKeyVault {
+        private var key: CharArray? = "sk-test".toCharArray()
+        override fun save(key: CharArray) { this.key = key.copyOf() }
+        override fun load(): CharArray? = key?.copyOf()
+        override fun clear() { key = null }
+    }
+
+    private class FakeVoiceSettings : VoiceSettingsSnapshot {
+        override fun silenceWindowMs(): Long = 600_000L
+        override fun whisperLanguageHint(): String? = null
+    }
+
+    private fun newViewModel(mic: MicCapture): PromptComposerViewModel {
+        val whisper = object : WhisperClient {
+            override suspend fun transcribe(audio: ByteArray, language: String?): Result<String> =
+                Result.success("locked dictation")
+        }
+        return PromptComposerViewModel(
+            audioRecorder = mic,
+            whisperClientFactory = WhisperClientFactory { whisper },
+            apiKeyStorage = FakeVault(),
+            voiceSettings = FakeVoiceSettings(),
+            savedStateHandle = SavedStateHandle(),
+        )
+    }
+
+    private fun renderComposer(viewModel: PromptComposerViewModel) {
+        var sheetVisible by mutableStateOf(true)
+        compose.setContent {
+            PocketShellTheme {
+                if (sheetVisible) {
+                    PromptComposerSheet(
+                        onDismiss = { sheetVisible = false },
+                        onSend = { _ -> true },
+                        viewModel = viewModel,
+                    )
+                }
+            }
+        }
+        compose.waitUntil(timeoutMillis = 10_000) {
+            compose.onAllNodesWithTag(COMPOSER_MIC_TAG).fetchSemanticsNodes().isNotEmpty()
+        }
+        compose.waitForIdle()
+    }
+
+    @Test
+    fun holdMicThenSwipeUpStartsAndLocksHandsFreeRecording() {
+        val mic = FakeMicCapture()
+        val viewModel = newViewModel(mic)
+        renderComposer(viewModel)
+
+        compose.onNodeWithTag(COMPOSER_MIC_TAG, useUnmergedTree = true)
+            .performTouchInput {
+                down(center)
+                advanceEventTime(80L)
+                repeat(8) {
+                    moveBy(Offset(0f, -28f))
+                    advanceEventTime(16L)
+                }
+                up()
+            }
+
+        compose.waitUntil(timeoutMillis = 5_000) {
+            viewModel.uiState.value.recording == RecordingState.Recording &&
+                viewModel.uiState.value.recordingLocked
+        }
+        compose.waitForIdle()
+
+        assertEquals("Swipe-up lock should start exactly one capture", 1, mic.startCount)
+        assertEquals("Finger-up after locking must not stop capture", 0, mic.stopCount)
+        assertEquals(RecordingState.Recording, viewModel.uiState.value.recording)
+        assertTrue(viewModel.uiState.value.recordingLocked)
+        compose.onNodeWithTag(COMPOSER_RECORDING_LOCKED_TAG).assertIsDisplayed()
+        compose.onNodeWithTag(COMPOSER_CANCEL_RECORDING_TAG).assertIsDisplayed()
+        compose.onNodeWithTag(COMPOSER_TO_FIELD_TAG).assertIsDisplayed()
+        compose.onNodeWithTag(COMPOSER_STOP_SEND_TAG).assertIsDisplayed()
+        WalkthroughScreenshotArtifacts.capture("issue-585-mic-swipe-locked")
+
+        compose.onNodeWithTag(COMPOSER_CANCEL_RECORDING_TAG).performClick()
+        compose.waitUntil(timeoutMillis = 5_000) {
+            viewModel.uiState.value.recording == RecordingState.Idle &&
+                !viewModel.uiState.value.recordingLocked
+        }
+        assertEquals("Discard should stop the locked capture once", 1, mic.stopCount)
+        compose.onNodeWithTag(COMPOSER_MIC_TAG).assertIsDisplayed()
+    }
+
+    @Test
+    fun plainTapStartsRecordingWithoutLocking() {
+        val mic = FakeMicCapture()
+        val viewModel = newViewModel(mic)
+        renderComposer(viewModel)
+
+        compose.onNodeWithTag(COMPOSER_MIC_TAG).performClick()
+        compose.waitUntil(timeoutMillis = 5_000) {
+            viewModel.uiState.value.recording == RecordingState.Recording
+        }
+        compose.waitForIdle()
+
+        assertEquals(1, mic.startCount)
+        assertEquals(0, mic.stopCount)
+        assertEquals(RecordingState.Recording, viewModel.uiState.value.recording)
+        assertFalse(viewModel.uiState.value.recordingLocked)
+        compose.onNodeWithTag(COMPOSER_RECORDING_LOCKED_TAG).assertDoesNotExist()
+
+        viewModel.cancelRecording()
+        compose.waitForIdle()
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerSheet.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerSheet.kt
@@ -84,6 +84,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.changedToUpIgnoreConsumed
 import androidx.compose.ui.input.pointer.positionChanged
 import androidx.compose.ui.input.pointer.pointerInput
@@ -1943,7 +1944,7 @@ private fun MicTriggerButton(
     }
 }
 
-private fun Modifier.micSwipeUpLockGesture(
+internal fun Modifier.micSwipeUpLockGesture(
     lockThresholdPx: Float,
     startSlopPx: Float,
     enabled: () -> Boolean,
@@ -1953,12 +1954,14 @@ private fun Modifier.micSwipeUpLockGesture(
 ): Modifier {
     return pointerInput(lockThresholdPx, startSlopPx) {
         awaitEachGesture {
-            // requireUnconsumed = false so we still see the down even when a
-            // parent (the ModalBottomSheet drag-to-dismiss nested scroll) has
-            // a claim on vertical motion; we then aggressively own the pointer
-            // so a fast hold-and-pull-up cannot be reinterpreted as a sheet
-            // drag before recording starts (#585).
-            val down = awaitFirstDown(requireUnconsumed = false)
+            // Issue #585: listen in the Initial pass so this nested mic gesture
+            // beats the ModalBottomSheet's Main-pass drag-to-dismiss detector.
+            // The real-device failure was a fast upward pull being won by the
+            // sheet before the mic lock detector saw enough movement.
+            val down = awaitFirstDown(
+                requireUnconsumed = false,
+                pass = PointerEventPass.Initial,
+            )
             val bounds = startBounds()
             // Issue #585: the mic disc is a small 44dp target at the far
             // bottom-right; a real hold-and-pull-up frequently lands the
@@ -1979,7 +1982,7 @@ private fun Modifier.micSwipeUpLockGesture(
             // drag-to-dismiss.
             down.consume()
             while (true) {
-                val event = awaitPointerEvent()
+                val event = awaitPointerEvent(PointerEventPass.Initial)
                 val change = event.changes.firstOrNull { it.id == down.id } ?: break
                 val drag = change.position - down.position
                 // Consume every move belonging to our pointer so the upward

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -291,6 +291,12 @@ JOURNEY_CLASSES=(
   # regression cannot silently return. It lives under com.pocketshell.app.composer,
   # not the proof prefix, so it carries its fully-qualified name directly.
   "com.pocketshell.app.composer.PromptComposerDiscardE2eTest"
+  # ADDED (#585): Telegram-style hold-and-pull-up on the composer mic must start
+  # recording and lock it hands-free in one gesture, with the real
+  # ModalBottomSheet still mounted so the mic detector competes with the sheet
+  # drag detector. This was repeatedly emulator-green but device-broken, so the
+  # focused journey is gate-wired per D31/G9; it uses no Docker fixture.
+  "com.pocketshell.app.composer.PromptComposerMicSwipeLockJourneyTest"
   # ADDED (#832 — durable per-session composer draft store): a draft authored in
   # session A and lost on a FAILED attachment-send (despite the "Your draft was
   # kept" banner) must survive. The ComposerDraftStore persists the per-session


### PR DESCRIPTION
Refs #585.

## Summary
- Move the prompt composer mic swipe-lock detector to PointerEventPass.Initial so it consumes down/move events before ModalBottomSheet drag handling can steal the upward pull.
- Add a real-sheet connected journey test for hold mic -> swipe up -> release staying Recording + locked, with Discard/Insert/Send visible, plus plain tap-to-record regression coverage.
- Gate-wire the new journey class in scripts/ci-journey-suite.sh next to the composer journeys.

## Validation
- ./gradlew --no-daemon :app:testDebugUnitTest --tests com.pocketshell.app.composer.PromptComposerMicGestureTest --tests com.pocketshell.app.composer.PromptComposerViewModelTest
- ./gradlew --no-daemon :app:compileDebugAndroidTestKotlin
- scripts/test-ci-journey-budget.sh
- scripts/check-test-validity.sh
- git diff --check
- scripts/connected-test.sh --suffix i585 :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.pocketshell.app.composer.PromptComposerMicSwipeLockJourneyTest
  - XML: tests=2, failures=0, errors=0, skipped=0
  - Passed: holdMicThenSwipeUpStartsAndLocksHandsFreeRecording, plainTapStartsRecordingWithoutLocking
- ./gradlew --no-daemon :app:assembleDebug

## Notes
- This intentionally does not touch PromptComposerViewModel.kt, avoiding PR #914.
- The emulator proves the mechanics and regression coverage. Physical-device feel and real microphone capture/transcription still need maintainer dogfood confirmation before closing #585.
