### PR TITLE
Add daemon durable tree Docker journey

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/projects/FolderListDaemonTreeDurabilityDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/FolderListDaemonTreeDurabilityDockerTest.kt
@@ -1,0 +1,428 @@
+package com.pocketshell.app.projects
+
+import androidx.lifecycle.ViewModelStore
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.portfwd.ForwardingController
+import com.pocketshell.app.proof.DEFAULT_HOST
+import com.pocketshell.app.proof.DEFAULT_PORT
+import com.pocketshell.app.proof.DEFAULT_USER
+import com.pocketshell.app.proof.waitForSshFixtureReady
+import com.pocketshell.core.ssh.KnownHostsPolicy
+import com.pocketshell.core.ssh.SshConnection
+import com.pocketshell.core.ssh.SshKey
+import com.pocketshell.core.storage.AppDatabase
+import com.pocketshell.core.storage.entity.HostEntity
+import com.pocketshell.core.storage.entity.ProjectRootEntity
+import com.pocketshell.core.storage.entity.SshKeyEntity
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.json.JSONObject
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+import java.io.FileOutputStream
+
+/**
+ * Issue #839: connected emulator + Docker proof for the daemon-backed durable
+ * project tree added in #837.
+ *
+ * The standard `agents` Docker fixture now exposes the `pocketshell tree`
+ * seam with a daemon-ready marker. This journey uses the production
+ * [TreeRemoteSource] and the real [SshFolderListGateway] against that fixture:
+ *
+ * 1. Open a host and let the live tmux probe seed the tree.
+ * 2. Collapse a folder, which persists order/collapse to the host registry.
+ * 3. Simulate app kill + relaunch with a fresh [FolderListViewModel] and no
+ *    client cache; the daemon hydrate must render the held order/collapse before
+ *    the first full gateway probe completes.
+ * 4. Resume when stale: a gone-only delta prunes without a full probe, while an
+ *    added-session delta escalates to the real full probe so the new row appears.
+ */
+@RunWith(AndroidJUnit4::class)
+class FolderListDaemonTreeDurabilityDockerTest {
+
+    private lateinit var sshKey: SshKey.Pem
+    private lateinit var keyFile: File
+    private lateinit var db: AppDatabase
+    private val viewModelStore = ViewModelStore()
+    private var nextViewModelKey: Int = 0
+    private val createdSessions = mutableListOf<String>()
+
+    @Before
+    fun setUp(): Unit = runBlocking {
+        val keyText = InstrumentationRegistry.getInstrumentation()
+            .context
+            .assets
+            .open("test_key")
+            .bufferedReader()
+            .use { it.readText() }
+        sshKey = SshKey.Pem(keyText)
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        keyFile = File(context.cacheDir, "issue839-daemon-tree-key").apply {
+            parentFile?.mkdirs()
+            if (exists()) delete()
+            FileOutputStream(this).use { it.write(keyText.toByteArray()) }
+            setReadable(true, true)
+        }
+        db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        waitForSshFixtureReady(sshKey)
+        assertTreeDaemonReady()
+    }
+
+    @After
+    fun tearDown(): Unit = runBlocking {
+        viewModelStore.clear()
+        if (createdSessions.isNotEmpty()) {
+            runCatching {
+                withSshSession { session ->
+                    createdSessions.forEach { name ->
+                        runCatching { session.exec("tmux kill-session -t ${shellQuote(name)} 2>/dev/null || true") }
+                    }
+                }
+            }
+        }
+        runCatching { db.close() }
+        runCatching { keyFile.delete() }
+    }
+
+    @Test
+    fun daemonTreeSurvivesAppRelaunchAndResumeDeltas(): Unit = runBlocking {
+        val suffix = System.currentTimeMillis().toString().takeLast(6)
+        val hostName = "issue839-host-$suffix"
+        val baseDir = "/tmp/issue839-$suffix"
+        val betaSession = "issue839-beta-$suffix"
+        val alphaSession = "issue839-alpha-$suffix"
+        val addedSession = "issue839-added-$suffix"
+        val betaFolder = FolderListViewModel.canonicalisePath("$baseDir/beta")
+        val alphaFolder = FolderListViewModel.canonicalisePath("$baseDir/alpha")
+
+        seedTmuxSession(betaSession, betaFolder)
+        seedTmuxSession(alphaSession, alphaFolder)
+        upsertEmptyRemoteTree(hostName)
+
+        val host = insertHost(hostName)
+
+        val firstGateway = CountingGateway()
+        val firstVm = newViewModel(firstGateway)
+        firstVm.setProcessStartedForTest(true)
+        bind(firstVm, host)
+
+        val firstReady = awaitReadyContaining(firstVm, setOf(betaSession, alphaSession))
+        val persistedOrder = firstReady.flatSessions.map { it.sessionName }
+            .filter { it == betaSession || it == alphaSession }
+        assertEquals("both seeded sessions must establish the persisted order", 2, persistedOrder.size)
+        assertTrue("alpha starts expanded before the user collapse", alphaFolder in firstReady.expandedProjectPaths)
+
+        firstVm.toggleProjectExpanded(alphaFolder)
+        awaitCollapsed(firstVm, alphaFolder)
+        awaitRemoteTree(hostName) { tree ->
+            val nodes = tree.getJSONArray("nodes")
+            (0 until nodes.length()).any { index ->
+                val node = nodes.getJSONObject(index)
+                node.getString("session") == alphaSession &&
+                    node.getString("folder_path") == alphaFolder &&
+                    node.getBoolean("collapsed")
+            }
+        }
+
+        viewModelStore.clear()
+
+        val relaunchGateway = CountingGateway(delayBeforeFirstListMs = 2_000L)
+        val relaunchVm = newViewModel(relaunchGateway)
+        relaunchVm.setProcessStartedForTest(true)
+        bind(relaunchVm, host)
+
+        val hydrated = awaitReadyOrder(relaunchVm, persistedOrder)
+        assertFalse(
+            "daemon hydrate must preserve the collapsed folder before the full probe completes",
+            alphaFolder in hydrated.expandedProjectPaths,
+        )
+        assertEquals(
+            "the durable daemon hydrate must render before the first full gateway probe completes",
+            0,
+            relaunchGateway.completedListCalls,
+        )
+
+        awaitGatewayCalls(relaunchGateway, completed = 1)
+        awaitReadyOrder(relaunchVm, persistedOrder)
+
+        killTmuxSession(betaSession)
+        val beforeGoneDeltaProbeCount = relaunchGateway.completedListCalls
+        relaunchVm.forceTreeStaleForTest()
+        resumeFromBackground(relaunchVm)
+        awaitSessionsAbsent(relaunchVm, setOf(betaSession))
+        assertEquals(
+            "gone-only daemon delta must prune without a full gateway reload",
+            beforeGoneDeltaProbeCount,
+            relaunchGateway.completedListCalls,
+        )
+
+        seedTmuxSession(addedSession, "$baseDir/added")
+        relaunchVm.forceTreeStaleForTest()
+        resumeFromBackground(relaunchVm)
+        awaitReadyContaining(relaunchVm, setOf(alphaSession, addedSession))
+        assertTrue(
+            "an added-session daemon delta must escalate to the real full probe",
+            relaunchGateway.completedListCalls > beforeGoneDeltaProbeCount,
+        )
+    }
+
+    private suspend fun assertTreeDaemonReady() {
+        val probe = runCatching {
+            withSshSession { session ->
+                val status = session.exec("pocketshell daemon status")
+                val tree = session.exec(
+                    "printf %s ${shellQuote("{\"host\":\"issue839-probe\"}")} | pocketshell tree get",
+                )
+                TreeDaemonProbe(
+                    ready = status.exitCode == 0 && tree.exitCode == 0 && tree.stdout.contains("\"nodes\""),
+                    statusExitCode = status.exitCode,
+                    statusOutput = status.stdout.trim(),
+                    treeExitCode = tree.exitCode,
+                    treeOutput = tree.stdout.trim(),
+                )
+            }
+        }.getOrElse { error ->
+            TreeDaemonProbe(
+                ready = false,
+                failure = error.stackTraceToString(),
+            )
+        }
+        assertTrue(
+            "Docker agents fixture must expose the daemon-backed tree seam; probe=$probe",
+            probe.ready,
+        )
+    }
+
+    private suspend fun seedTmuxSession(sessionName: String, folder: String) {
+        withSshSession { session ->
+            session.exec("mkdir -p ${shellQuote(folder)}")
+            session.exec("tmux kill-session -t ${shellQuote(sessionName)} 2>/dev/null || true")
+            session.exec("tmux new-session -d -s ${shellQuote(sessionName)} -c ${shellQuote(folder)}")
+        }
+        if (sessionName !in createdSessions) createdSessions += sessionName
+    }
+
+    private suspend fun killTmuxSession(sessionName: String) {
+        withSshSession { session ->
+            session.exec("tmux kill-session -t ${shellQuote(sessionName)} 2>/dev/null || true")
+        }
+        createdSessions.remove(sessionName)
+    }
+
+    private suspend fun upsertEmptyRemoteTree(hostName: String) {
+        withSshSession { session ->
+            val json = "{\"host\":\"$hostName\",\"nodes\":[]}"
+            session.exec("printf %s ${shellQuote(json)} | pocketshell tree upsert")
+        }
+    }
+
+    private suspend fun awaitRemoteTree(hostName: String, predicate: (JSONObject) -> Boolean) {
+        withSshSession { session ->
+            withTimeout(20_000L) {
+                while (true) {
+                    val json = "{\"host\":\"$hostName\"}"
+                    val result = session.exec("printf %s ${shellQuote(json)} | pocketshell tree get")
+                    if (result.exitCode == 0) {
+                        val tree = JSONObject(result.stdout.trim())
+                        if (predicate(tree)) return@withTimeout
+                    }
+                    delay(250L)
+                }
+            }
+        }
+    }
+
+    private suspend fun resumeFromBackground(vm: FolderListViewModel) {
+        vm.setProcessStartedForTest(false)
+        delay(250L)
+        vm.setProcessStartedForTest(true)
+    }
+
+    private suspend fun <T> withSshSession(block: suspend (com.pocketshell.core.ssh.SshSession) -> T): T {
+        return SshConnection.connect(
+            host = DEFAULT_HOST,
+            port = DEFAULT_PORT,
+            user = DEFAULT_USER,
+            key = sshKey,
+            knownHosts = KnownHostsPolicy.AcceptAll,
+            timeoutMs = 10_000,
+        ).getOrThrow().use { session -> block(session) }
+    }
+
+    private suspend fun insertHost(hostName: String): HostEntity {
+        val keyId = db.sshKeyDao().insert(
+            SshKeyEntity(name = "issue839-key", privateKeyPath = keyFile.absolutePath),
+        )
+        val hostId = db.hostDao().insert(
+            HostEntity(
+                name = hostName,
+                hostname = DEFAULT_HOST,
+                port = DEFAULT_PORT,
+                username = DEFAULT_USER,
+                keyId = keyId,
+            ),
+        )
+        return db.hostDao().getById(hostId)!!
+    }
+
+    private fun newViewModel(gateway: FolderListGateway): FolderListViewModel {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        return FolderListViewModel(
+            gateway = gateway,
+            hostDao = db.hostDao(),
+            projectRootDao = db.projectRootDao(),
+            forwardingController = ForwardingController(context),
+            treeRemoteSource = TreeRemoteSource(),
+            treeClientCache = null,
+            attachLifecycle = false,
+        ).also { vm ->
+            viewModelStore.put("FolderListViewModel-${nextViewModelKey++}", vm)
+        }
+    }
+
+    private fun bind(vm: FolderListViewModel, host: HostEntity) {
+        vm.bind(
+            hostId = host.id,
+            hostName = host.name,
+            hostname = host.hostname,
+            port = host.port,
+            username = host.username,
+            keyPath = keyFile.absolutePath,
+            passphrase = null,
+        )
+    }
+
+    private suspend fun awaitReadyContaining(
+        vm: FolderListViewModel,
+        expectedSessions: Set<String>,
+    ): FolderListUiState.Ready {
+        return awaitReadyMatching(vm, "expected sessions $expectedSessions") { state ->
+            state.flatSessions.map { it.sessionName }.containsAll(expectedSessions)
+        }
+    }
+
+    private suspend fun awaitReadyOrder(
+        vm: FolderListViewModel,
+        expectedOrder: List<String>,
+    ): FolderListUiState.Ready {
+        return awaitReadyMatching(vm, "expected order $expectedOrder") { state ->
+            state.flatSessions.map { it.sessionName }.filter { it in expectedOrder } == expectedOrder
+        }
+    }
+
+    private suspend fun awaitSessionsAbsent(vm: FolderListViewModel, absentSessions: Set<String>) {
+        awaitReadyMatching(vm, "expected absent sessions $absentSessions") { state ->
+            state.flatSessions.none { it.sessionName in absentSessions }
+        }
+    }
+
+    private suspend fun awaitCollapsed(vm: FolderListViewModel, folder: String) {
+        awaitReadyMatching(vm, "expected collapsed folder $folder") { state -> folder !in state.expandedProjectPaths }
+    }
+
+    private suspend fun awaitReadyMatching(
+        vm: FolderListViewModel,
+        label: String,
+        predicate: (FolderListUiState.Ready) -> Boolean,
+    ): FolderListUiState.Ready {
+        val deadline = android.os.SystemClock.elapsedRealtime() + 30_000L
+        var lastState: FolderListUiState = vm.state.value
+        while (android.os.SystemClock.elapsedRealtime() < deadline) {
+            val state = vm.state.value
+            lastState = state
+            if (state is FolderListUiState.Ready && predicate(state)) {
+                return state
+            }
+            delay(100L)
+        }
+        error("$label timed out; lastState=$lastState")
+    }
+
+    private suspend fun awaitGatewayCalls(gateway: CountingGateway, completed: Int) {
+        withTimeout(30_000L) {
+            while (gateway.completedListCalls < completed) delay(100L)
+        }
+    }
+
+    private fun shellQuote(value: String): String =
+        "'" + value.replace("'", "'\"'\"'") + "'"
+
+    private data class TreeDaemonProbe(
+        val ready: Boolean,
+        val statusExitCode: Int? = null,
+        val statusOutput: String = "",
+        val treeExitCode: Int? = null,
+        val treeOutput: String = "",
+        val failure: String? = null,
+    )
+
+    private class CountingGateway(
+        private val delegate: SshFolderListGateway = SshFolderListGateway(),
+        private val delayBeforeFirstListMs: Long = 0L,
+    ) : FolderListGateway {
+        @Volatile
+        var startedListCalls: Int = 0
+            private set
+
+        @Volatile
+        var completedListCalls: Int = 0
+            private set
+
+        override suspend fun listSessionsWithFolder(
+            host: HostEntity,
+            keyPath: String,
+            passphrase: CharArray?,
+            watchedRoots: List<ProjectRootEntity>,
+        ): FolderListResult {
+            startedListCalls += 1
+            if (startedListCalls == 1 && delayBeforeFirstListMs > 0L) {
+                delay(delayBeforeFirstListMs)
+            }
+            return delegate.listSessionsWithFolder(host, keyPath, passphrase, watchedRoots)
+                .also { completedListCalls += 1 }
+        }
+
+        override suspend fun createSession(
+            host: HostEntity,
+            keyPath: String,
+            passphrase: CharArray?,
+            sessionName: String,
+            cwd: String,
+            startCommand: String?,
+        ): Result<String> = delegate.createSession(host, keyPath, passphrase, sessionName, cwd, startCommand)
+
+        override suspend fun createEmptyProject(
+            host: HostEntity,
+            keyPath: String,
+            passphrase: CharArray?,
+            parentPath: String,
+            folderName: String,
+        ): Result<String> = delegate.createEmptyProject(host, keyPath, passphrase, parentPath, folderName)
+
+        override suspend fun importFile(
+            host: HostEntity,
+            keyPath: String,
+            passphrase: CharArray?,
+            folderPath: String,
+            payload: FolderImportPayload,
+        ): Result<String> = delegate.importFile(host, keyPath, passphrase, folderPath, payload)
+
+        override suspend fun killSession(
+            host: HostEntity,
+            keyPath: String,
+            passphrase: CharArray?,
+            sessionName: String,
+        ): Result<Unit> = delegate.killSession(host, keyPath, passphrase, sessionName)
+    }
+}

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -750,6 +750,15 @@ JOURNEY_CLASSES=(
   # fixture is started by the workflow. It lives under
   # com.pocketshell.app.projects, so it carries its FQCN directly.
   "com.pocketshell.app.projects.FolderListBootstrapSkipTreeLoadsDockerTest"
+  # ADDED (#839): daemon-backed durable tree journey against the standard
+  # agents fixture. It drives the production FolderListViewModel +
+  # TreeRemoteSource + SshFolderListGateway through the fixture's
+  # `pocketshell daemon status` and `pocketshell tree get/upsert/reconcile`
+  # seams, then proves app relaunch hydrates the persisted order/collapse and
+  # stale resume deltas prune/escalate correctly. This is the CI gate for the
+  # #837 daemon-tree acceptance gap, so fixture readiness hard-fails instead of
+  # self-skipping.
+  "com.pocketshell.app.projects.FolderListDaemonTreeDurabilityDockerTest"
   # ADDED (#867): the stale-while-revalidate INSTANT-RENDER journey. A cold
   # connect must paint the LAST-KNOWN tree instantly from the per-host CLIENT
   # cache (Ready, NOT the empty 'No folders yet / 0 projects' rebuild flash the

--- a/tests/docker/Dockerfile.agents
+++ b/tests/docker/Dockerfile.agents
@@ -5,7 +5,7 @@
 # credentials. Use it for local emulator + Docker smoke tests only.
 FROM alpine:latest
 
-RUN apk add --no-cache openssh-server openssh-client tmux procps bash sqlite git \
+RUN apk add --no-cache openssh-server openssh-client tmux procps bash sqlite git jq \
     && ssh-keygen -A \
     && adduser -D -s /bin/sh testuser \
     && passwd -u testuser \

--- a/tests/docker/agent-bin/pocketshell
+++ b/tests/docker/agent-bin/pocketshell
@@ -59,10 +59,169 @@ END {
 }
 '
 
+tree_registry_file() {
+  state_home="${XDG_STATE_HOME:-${HOME:-/home/testuser}/.local/state}"
+  printf '%s\n' "${POCKETSHELL_TREE_REGISTRY:-${state_home}/pocketshell/tree/registry.json}"
+}
+
+tree_registry_init() {
+  registry="$(tree_registry_file)"
+  registry_dir="$(dirname "$registry")"
+  mkdir -p "$registry_dir"
+  chmod 700 "$registry_dir" 2>/dev/null || true
+  if [ ! -s "$registry" ]; then
+    printf '{"hosts":{}}\n' > "$registry"
+    chmod 600 "$registry" 2>/dev/null || true
+  fi
+}
+
+tree_read_stdin_json() {
+  if [ ! -t 0 ]; then
+    cat
+  else
+    printf '{}\n'
+  fi
+}
+
+tree_live_sessions_json() {
+  if tmux list-sessions -F '#{session_name}' >/tmp/pocketshell-tree-live.$$ 2>/dev/null; then
+    jq -Rsc 'split("\n") | map(select(length > 0))' /tmp/pocketshell-tree-live.$$
+    rm -f /tmp/pocketshell-tree-live.$$
+    return 0
+  fi
+  rm -f /tmp/pocketshell-tree-live.$$
+  return 1
+}
+
 case "${1:-}" in
   --version)
     printf 'pocketshell fixture %s\n' "$(fixture_version)"
     exit 0
+    ;;
+  daemon)
+    shift
+    case "${1:-}" in
+      status)
+        if [ -f /tmp/pocketshell-fixture-daemon/ready ]; then
+          printf 'running (fixture daemon)\n'
+          exit 0
+        fi
+        printf 'not running\n' >&2
+        exit 3
+        ;;
+      start)
+        install -d -m 0777 /tmp/pocketshell-fixture-daemon
+        : > /tmp/pocketshell-fixture-daemon/ready
+        chmod 0666 /tmp/pocketshell-fixture-daemon/ready
+        printf 'started (fixture daemon)\n'
+        exit 0
+        ;;
+      stop)
+        rm -f /tmp/pocketshell-fixture-daemon/ready
+        printf 'stopped (fixture daemon)\n'
+        exit 0
+        ;;
+    esac
+    printf 'pocketshell daemon fixture supports: start|status|stop\n' >&2
+    exit 64
+    ;;
+  tree)
+    shift
+    tree_registry_init
+    registry="$(tree_registry_file)"
+    request="$(tree_read_stdin_json)"
+    host="$(printf '%s' "$request" | jq -r '.host // empty' 2>/dev/null || true)"
+    if [ -z "$host" ]; then
+      printf 'tree fixture requires stdin JSON with non-empty host\n' >&2
+      exit 64
+    fi
+    case "${1:-}" in
+      get)
+        jq -c --arg h "$host" --arg version "$(fixture_version)" '
+          {
+            nodes: (.hosts[$h].nodes // []),
+            version: (.hosts[$h].version // 0),
+            cli_version: $version
+          }
+        ' "$registry"
+        exit 0
+        ;;
+      upsert)
+        req_file="$(mktemp)"
+        tmp_file="$(mktemp)"
+        printf '%s' "$request" > "$req_file"
+        jq -c --arg h "$host" --slurpfile req "$req_file" '
+          .hosts = (.hosts // {}) |
+          .hosts[$h] = {
+            nodes: (
+              (($req[0].nodes // []) | if type == "array" then . else [] end) |
+              to_entries |
+              map(
+                .key as $idx |
+                .value |
+                select(type == "object") |
+                select((.session // "") | type == "string" and length > 0) |
+                {
+                  session: .session,
+                  order: ((.order // $idx) | tonumber? // $idx),
+                  folder_path: ((.folder_path // "") | tostring),
+                  collapsed: (.collapsed // false)
+                } + (
+                  if ((.foreign_kind // "") | type == "string" and length > 0)
+                  then {foreign_kind: .foreign_kind}
+                  else {}
+                  end
+                )
+              )
+            ),
+            version: ((.hosts[$h].version // 0) + 1)
+          }
+        ' "$registry" > "$tmp_file"
+        mv "$tmp_file" "$registry"
+        chmod 600 "$registry" 2>/dev/null || true
+        rm -f "$req_file"
+        jq -c --arg h "$host" '{status:"ok", version:(.hosts[$h].version // 0)}' "$registry"
+        exit 0
+        ;;
+      reconcile)
+        if live_json="$(tree_live_sessions_json)"; then
+          envelope="$(
+            jq -c --arg h "$host" --arg version "$(fixture_version)" --argjson live "$live_json" '
+              (.hosts[$h].nodes // []) as $nodes |
+              ($nodes | map(.session)) as $registry |
+              {
+                alive: ($registry | map(select(. as $s | $live | index($s)))),
+                gone: ($registry | map(select(. as $s | ($live | index($s) | not)))),
+                added: ($live | map(select(. as $s | ($registry | index($s) | not)))),
+                cli_version: $version
+              }
+            ' "$registry"
+          )"
+          gone_count="$(printf '%s' "$envelope" | jq '.gone | length')"
+          if [ "$gone_count" -gt 0 ]; then
+            tmp_file="$(mktemp)"
+            jq -c --arg h "$host" --argjson live "$live_json" '
+              .hosts = (.hosts // {}) |
+              .hosts[$h] = {
+                nodes: ((.hosts[$h].nodes // []) | map(select(.session as $s | $live | index($s)))),
+                version: ((.hosts[$h].version // 0) + 1)
+              }
+            ' "$registry" > "$tmp_file"
+            mv "$tmp_file" "$registry"
+            chmod 600 "$registry" 2>/dev/null || true
+          fi
+          printf '%s\n' "$envelope"
+        else
+          jq -c --arg h "$host" --arg version "$(fixture_version)" '
+            (.hosts[$h].nodes // [] | map(.session)) as $registry |
+            {alive: $registry, gone: [], added: [], cli_version: $version}
+          ' "$registry"
+        fi
+        exit 0
+        ;;
+    esac
+    printf 'pocketshell tree fixture supports: get|upsert|reconcile\n' >&2
+    exit 64
     ;;
   agent)
     # Issue #703: the app now launches agents via the short server-side
@@ -453,5 +612,5 @@ case "${1:-}" in
     ;;
 esac
 
-printf 'pocketshell fixture supports: usage --json, sessions list, jobs list/add/edit/remove, agent-log, profiles list, agents kind\n' >&2
+printf 'pocketshell fixture supports: usage --json, sessions list, jobs list/add/edit/remove, agent-log, profiles list, agents kind, daemon, tree\n' >&2
 exit 64

--- a/tests/docker/agent-entrypoint.sh
+++ b/tests/docker/agent-entrypoint.sh
@@ -80,4 +80,12 @@ sh -c 'while true; do sleep 3600; done' idle-agent-a &
 sh -c 'while true; do sleep 3600; done' idle-agent-b &
 sh -c 'while true; do sleep 3600; done' idle-agent-c &
 
+install -d -m 0777 /tmp/pocketshell-fixture-daemon
+: > /tmp/pocketshell-fixture-daemon/ready
+chmod 0666 /tmp/pocketshell-fixture-daemon/ready
+(
+  echo "$$" > /tmp/pocketshell-fixture-daemon/pid
+  while true; do sleep 3600; done
+) &
+
 exec /usr/sbin/sshd -D -e


### PR DESCRIPTION
## Summary
- add daemon-ready/tree registry support to the Docker agents fixture
- expose deterministic `pocketshell tree get|upsert|reconcile` envelopes backed by the fixture registry and live tmux sessions
- add connected emulator + Docker journey for daemon hydrate after app relaunch and resume delta reconciliation

## Validation
- `docker compose -f tests/docker/docker-compose.yml build agents`
- `docker compose -f tests/docker/docker-compose.yml up -d --build agents`
- SSH smoke: `pocketshell daemon status` + `pocketshell tree get`
- `./gradlew :app:compileDebugAndroidTestKotlin`
- `./gradlew :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.pocketshell.app.projects.FolderListDaemonTreeDurabilityDockerTest`

Fixes #839