### PR TITLE
ci: guard per-push journey harness validity

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,6 +62,20 @@ jobs:
           chmod +x scripts/check-test-validity.sh
           scripts/check-test-validity.sh
 
+      # Issue #848: old journey harness regression guard. Per-push proof
+      # journeys listed by scripts/ci-journey-suite.sh that launch MainActivity
+      # should use the launch-owned harness
+      # createAndroidComposeRule<MainActivity>() + SeedBeforeLaunchRule, not the
+      # #743/#788 createEmptyComposeRule() + manual ActivityScenario.launch
+      # shape, unless the file carries a local JOURNEY_HARNESS_JUSTIFIED reason.
+      # Cheap static shell guard; current main's known legacy classes are
+      # baselined so this does not duplicate the open #911 migration.
+      - name: CI journey harness guard (issue #848)
+        run: |
+          chmod +x scripts/check-ci-journey-harness.sh scripts/check-ci-journey-harness-selftest.sh
+          scripts/check-ci-journey-harness.sh
+          scripts/check-ci-journey-harness-selftest.sh
+
       # Issue #865: raw-component drift guardrail. After the #756 design-
       # consistency migrations landed (#860/#861/#862/#863 — shared ConfirmDialog
       # / FormDialog / LoadingIndicator.Spinner / PocketShellButton own the
@@ -628,18 +642,40 @@ jobs:
         if: always()
         run: |
           summary="artifacts/ci-journey/summary.md"
+          first_failed_classes_file="artifacts/ci-journey/first-failed-classes.txt"
           first_timeout="false"
           first_failure="false"
+          first_failed_classes=""
           if [[ -f "$summary" ]] && grep -qE 'JOURNEY_FAILED|Failed BOTH attempts' "$summary"; then
             first_failure="true"
+            first_failed_classes="$(awk '
+              /^Failed BOTH attempts/ { capture=1; next }
+              capture && /^- / {
+                gsub(/`/, "")
+                sub(/^- /, "")
+                sub(/[[:space:]]+\(.*/, "")
+                print
+                next
+              }
+              capture && /^$/ { capture=0 }
+            ' "$summary" || true)"
           fi
           if [[ "$first_failure" != "true" && -f "$summary" ]] && grep -qE 'JOURNEY_STEP_TIMEOUT|Suite step time budget exhausted' "$summary"; then
             first_timeout="true"
+          fi
+          if [[ -n "$first_failed_classes" ]]; then
+            printf '%s\n' "$first_failed_classes" > "$first_failed_classes_file"
+          else
+            rm -f "$first_failed_classes_file"
           fi
           echo "first_timeout=$first_timeout" >> "$GITHUB_OUTPUT"
           echo "first_failure=$first_failure" >> "$GITHUB_OUTPUT"
           echo "first summary timeout-only: $first_timeout"
           echo "first summary genuine failure: $first_failure"
+          if [[ -n "$first_failed_classes" ]]; then
+            echo "first summary failed class(es):"
+            printf '%s\n' "$first_failed_classes" | sed 's/^/  /'
+          fi
 
       # Preserve the first cold-boot attempt before a retry can overwrite the
       # shared artifacts/ci-journey summary or Gradle connected-test outputs.
@@ -745,18 +781,55 @@ jobs:
           first_timeout="${{ steps.journey_summary.outputs.first_timeout }}"
           first_failure="${{ steps.journey_summary.outputs.first_failure }}"
           summary="artifacts/ci-journey/summary.md"
+          first_failed_classes_file="artifacts/ci-journey/first-failed-classes.txt"
           echo "first attempt outcome:  $first"
           echo "retry attempt outcome:  ${retry:-<skipped>}"
           echo "first attempt conclusion:  $first_concl"
           echo "retry attempt conclusion:  ${retry_concl:-<skipped>}"
           echo "first summary timeout-only: ${first_timeout:-false}"
           echo "first summary genuine failure: ${first_failure:-false}"
+
+          retry_summary_is_timeout_only() {
+            [[ -f "$summary" ]] \
+              && ! grep -qE 'JOURNEY_FAILED|Failed BOTH attempts' "$summary" \
+              && grep -qE 'JOURNEY_STEP_TIMEOUT|Suite step time budget exhausted' "$summary"
+          }
+
+          retry_resolved_first_failures() {
+            [[ -s "$first_failed_classes_file" && -f "$summary" ]] || return 1
+            local resolved
+            resolved="$(awk '
+              /^Passed first try:/ || /^Recovered on retry/ { capture=1; next }
+              capture && /^- / {
+                gsub(/`/, "")
+                sub(/^- /, "")
+                sub(/[[:space:]]+\(.*/, "")
+                print
+                next
+              }
+              capture && /^$/ { capture=0 }
+            ' "$summary" || true)"
+            [[ -n "$resolved" ]] || return 1
+            local class_name
+            while IFS= read -r class_name; do
+              [[ -z "$class_name" ]] && continue
+              grep -Fxq "$class_name" <<< "$resolved" || return 1
+            done < "$first_failed_classes_file"
+            return 0
+          }
+
           if [[ "$first" == "success" ]]; then
             echo "Emulator journey passed on the first cold boot."
             exit 0
           fi
           if [[ "$retry" == "success" ]]; then
             echo "::warning title=Emulator infra flake recovered::The first emulator bringup failed but a second cold boot passed (issue #760). Treating as a recovered infra flake, NOT a test failure. Watch for a degrading trend."
+            exit 0
+          fi
+          if [[ "${first_failure:-false}" == "true" ]] && retry_summary_is_timeout_only && retry_resolved_first_failures; then
+            timed_out_classes="$(awk '/JOURNEY_STEP_TIMEOUT|Suite step time budget exhausted/{f=1} f && /^- /{gsub(/`/,""); sub(/^- /,"    "); print}' "$summary" || true)"
+            echo "::warning title=Emulator journey TIMEOUT after cleared first-attempt flake::The first cold boot wrote a JOURNEY_FAILED summary, but the retry cold boot passed the first-failed class(es) before later exhausting the suite budget (issue #835 / #470). Treating this as the timeout class, not a persistent journey regression. Class(es) cut short / not run:"
+            [[ -n "$timed_out_classes" ]] && printf '%s\n' "$timed_out_classes"
             exit 0
           fi
           if [[ "${first_failure:-false}" == "true" ]]; then

--- a/scripts/check-ci-journey-harness-selftest.sh
+++ b/scripts/check-ci-journey-harness-selftest.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+# Self-test for scripts/check-ci-journey-harness.sh.
+#
+# Plants synthetic journey classes in a temporary repo-shaped fixture and proves
+# the guard fails on the old #743/#788 harness, fails on a launch-owned class
+# missing SeedBeforeLaunchRule, passes the launch-owned + shared-seed shape, and
+# honors a local inline exemption. It also proves that comment-only seed mentions,
+# stale baseline entries, and an empty parsed proof allowlist are hard failures.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GUARD="$SCRIPT_DIR/check-ci-journey-harness.sh"
+
+SANDBOX="$(mktemp -d)"
+cleanup() {
+  rm -rf "$SANDBOX"
+}
+trap cleanup EXIT
+
+mkdir -p "$SANDBOX/scripts" "$SANDBOX/app/src/androidTest/java/com/pocketshell/app/proof"
+
+cat > "$SANDBOX/scripts/ci-journey-suite.sh" <<'SH'
+#!/usr/bin/env bash
+FQCN_PREFIX="com.pocketshell.app.proof"
+JOURNEY_CLASSES=(
+  "$FQCN_PREFIX.BadManualHarnessE2eTest"
+  "$FQCN_PREFIX.BadMissingSeedE2eTest"
+  "$FQCN_PREFIX.BadCommentOnlySeedE2eTest"
+  "$FQCN_PREFIX.GoodLaunchOwnedE2eTest"
+  "$FQCN_PREFIX.ExemptManualHarnessE2eTest"
+  "com.pocketshell.app.proof.DirectProofEntryE2eTest#singleMethod"
+  "com.pocketshell.app.tmux.NotAProofEntryE2eTest"
+)
+SH
+
+cat > "$SANDBOX/app/src/androidTest/java/com/pocketshell/app/proof/BadManualHarnessE2eTest.kt" <<'KT'
+package com.pocketshell.app.proof
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.test.core.app.ActivityScenario
+import com.pocketshell.app.MainActivity
+class BadManualHarnessE2eTest {
+    val compose = createEmptyComposeRule()
+    fun test() {
+        ActivityScenario.launch(MainActivity::class.java)
+    }
+}
+KT
+
+cat > "$SANDBOX/app/src/androidTest/java/com/pocketshell/app/proof/BadMissingSeedE2eTest.kt" <<'KT'
+package com.pocketshell.app.proof
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import com.pocketshell.app.MainActivity
+class BadMissingSeedE2eTest {
+    val compose = createAndroidComposeRule<MainActivity>()
+}
+KT
+
+cat > "$SANDBOX/app/src/androidTest/java/com/pocketshell/app/proof/BadCommentOnlySeedE2eTest.kt" <<'KT'
+package com.pocketshell.app.proof
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import com.pocketshell.app.MainActivity
+class BadCommentOnlySeedE2eTest {
+    val compose = createAndroidComposeRule<MainActivity>()
+    val marker = "not a rule" // TODO migrate to SeedBeforeLaunchRule { seed() }
+    // TODO migrate to SeedBeforeLaunchRule { seed() }
+}
+KT
+
+cat > "$SANDBOX/app/src/androidTest/java/com/pocketshell/app/proof/GoodLaunchOwnedE2eTest.kt" <<'KT'
+package com.pocketshell.app.proof
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import com.pocketshell.app.MainActivity
+class GoodLaunchOwnedE2eTest {
+    val compose = createAndroidComposeRule<MainActivity>()
+    val seed = SeedBeforeLaunchRule { }
+}
+KT
+
+cat > "$SANDBOX/app/src/androidTest/java/com/pocketshell/app/proof/ExemptManualHarnessE2eTest.kt" <<'KT'
+package com.pocketshell.app.proof
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.test.core.app.ActivityScenario
+import com.pocketshell.app.MainActivity
+class ExemptManualHarnessE2eTest {
+    // JOURNEY_HARNESS_JUSTIFIED: this fixture verifies two explicit manual relaunches.
+    val compose = createEmptyComposeRule()
+    fun test() {
+        // JOURNEY_HARNESS_JUSTIFIED: this fixture verifies two explicit manual relaunches.
+        ActivityScenario.launch(MainActivity::class.java)
+    }
+}
+KT
+
+cat > "$SANDBOX/app/src/androidTest/java/com/pocketshell/app/proof/DirectProofEntryE2eTest.kt" <<'KT'
+package com.pocketshell.app.proof
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import com.pocketshell.app.MainActivity
+class DirectProofEntryE2eTest {
+    val compose = createAndroidComposeRule<MainActivity>()
+    val seed = SeedBeforeLaunchRule { }
+}
+KT
+
+cat > "$SANDBOX/app/src/androidTest/java/com/pocketshell/app/proof/NotListedBadManualE2eTest.kt" <<'KT'
+package com.pocketshell.app.proof
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.test.core.app.ActivityScenario
+import com.pocketshell.app.MainActivity
+class NotListedBadManualE2eTest {
+    val compose = createEmptyComposeRule()
+    fun test() {
+        ActivityScenario.launch(MainActivity::class.java)
+    }
+}
+KT
+
+PASS=0
+FAIL=0
+note_pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+note_fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+run_guard() {
+  POCKETSHELL_JOURNEY_HARNESS_REPO_ROOT="$SANDBOX" "$GUARD" "$@" 2>&1
+}
+
+echo "=============================================================="
+echo " Self-test: scripts/check-ci-journey-harness.sh"
+echo "=============================================================="
+
+out="$(run_guard)"
+rc=$?
+if [[ "$rc" -eq 1 ]]; then
+  note_pass "guard fails when bad listed proof fixtures are present"
+else
+  note_fail "guard should fail with bad listed proof fixtures (got exit $rc)"
+fi
+
+if printf '%s' "$out" | grep -q 'BadManualHarnessE2eTest'; then
+  note_pass "manual ActivityScenario/createEmptyComposeRule fixture is reported"
+else
+  note_fail "manual old-harness fixture was not reported"
+fi
+
+if printf '%s' "$out" | grep -q 'BadMissingSeedE2eTest'; then
+  note_pass "launch-owned fixture missing SeedBeforeLaunchRule is reported"
+else
+  note_fail "missing SeedBeforeLaunchRule fixture was not reported"
+fi
+
+if printf '%s' "$out" | awk '/NEW FAIL - createAndroidComposeRule without SeedBeforeLaunchRule/{capture=1; next} /^$/{if (capture) exit} capture {print}' | grep -q 'BadCommentOnlySeedE2eTest'; then
+  note_pass "comment-only SeedBeforeLaunchRule mention is not accepted"
+else
+  note_fail "comment-only SeedBeforeLaunchRule mention should be reported as missing shared seed"
+fi
+
+if ! printf '%s' "$out" | awk '/NEW FAIL - manual/{capture=1; next} /^NEW FAIL - createAndroid/{capture=0} capture {print}' | grep -q 'ExemptManualHarnessE2eTest'; then
+  note_pass "inline JOURNEY_HARNESS_JUSTIFIED manual exemption is spared"
+else
+  note_fail "inline manual exemption was incorrectly reported as a new failure"
+fi
+
+if ! printf '%s' "$out" | grep -q 'NotListedBadManualE2eTest'; then
+  note_pass "unlisted proof fixture is ignored"
+else
+  note_fail "unlisted proof fixture should not be scanned"
+fi
+
+rm -f \
+  "$SANDBOX/app/src/androidTest/java/com/pocketshell/app/proof/BadManualHarnessE2eTest.kt" \
+  "$SANDBOX/app/src/androidTest/java/com/pocketshell/app/proof/BadMissingSeedE2eTest.kt" \
+  "$SANDBOX/app/src/androidTest/java/com/pocketshell/app/proof/BadCommentOnlySeedE2eTest.kt"
+cat > "$SANDBOX/scripts/ci-journey-suite.sh" <<'SH'
+#!/usr/bin/env bash
+FQCN_PREFIX="com.pocketshell.app.proof"
+JOURNEY_CLASSES=(
+  "$FQCN_PREFIX.GoodLaunchOwnedE2eTest"
+  "$FQCN_PREFIX.ExemptManualHarnessE2eTest"
+  "com.pocketshell.app.proof.DirectProofEntryE2eTest#singleMethod"
+)
+SH
+
+out="$(run_guard)"
+rc=$?
+if [[ "$rc" -eq 0 ]]; then
+  note_pass "guard passes with only compliant or justified listed fixtures"
+else
+  note_fail "guard should pass after removing bad fixtures (got exit $rc)"
+fi
+
+cat > "$SANDBOX/scripts/ci-journey-suite.sh" <<'SH'
+#!/usr/bin/env bash
+FQCN_PREFIX="com.pocketshell.app.proof"
+JOURNEY_CLASSES=(
+  "$FQCN_PREFIX.DeepLinkSessionSwitchE2eTest"
+)
+SH
+cat > "$SANDBOX/app/src/androidTest/java/com/pocketshell/app/proof/DeepLinkSessionSwitchE2eTest.kt" <<'KT'
+package com.pocketshell.app.proof
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import com.pocketshell.app.MainActivity
+class DeepLinkSessionSwitchE2eTest {
+    val compose = createAndroidComposeRule<MainActivity>()
+    val seed = SeedBeforeLaunchRule { }
+}
+KT
+
+out="$(run_guard)"
+rc=$?
+if [[ "$rc" -eq 1 ]] && printf '%s' "$out" | grep -q 'KNOWN_MANUAL_HARNESS:DeepLinkSessionSwitchE2eTest'; then
+  note_pass "stale known manual-harness baseline is a hard failure"
+else
+  note_fail "stale known manual-harness baseline should fail (got exit $rc)"
+fi
+
+cat > "$SANDBOX/scripts/ci-journey-suite.sh" <<'SH'
+#!/usr/bin/env bash
+FQCN_PREFIX="com.pocketshell.app.proof"
+JOURNEY_CLASSES=(
+  "com.pocketshell.app.tmux.NotAProofEntryE2eTest"
+)
+SH
+
+out="$(run_guard)"
+rc=$?
+if [[ "$rc" -eq 1 ]] && printf '%s' "$out" | grep -q 'NO_PROOF_CLASSES_PARSED'; then
+  note_pass "empty parsed proof class allowlist is a hard failure"
+else
+  note_fail "empty parsed proof class allowlist should fail (got exit $rc)"
+fi
+
+echo
+echo "=============================================================="
+echo " Self-test result: $PASS passed, $FAIL failed"
+echo "=============================================================="
+
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/scripts/check-ci-journey-harness.sh
+++ b/scripts/check-ci-journey-harness.sh
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+# CI journey harness guard (issues #848 / #788 / #743).
+#
+# The per-push journey allowlist in scripts/ci-journey-suite.sh is the set that
+# can block a PR before a broken on-device journey reaches main. For listed
+# com.pocketshell.app.proof.* journeys that launch MainActivity, the durable
+# harness shape is:
+#
+#   createAndroidComposeRule<MainActivity>() + SeedBeforeLaunchRule
+#
+# The old shape, createEmptyComposeRule() plus manual ActivityScenario.launch,
+# was the #743/#788 interop-placement stall. A test may keep a manual launch
+# only with a local inline exemption comment:
+#
+#   // JOURNEY_HARNESS_JUSTIFIED: <why manual ActivityScenario is required>
+#
+# The current main branch still has known old-harness classes and some
+# launch-owned classes with hand-rolled pre-launch seed rules. Those are kept in
+# explicit baselines so this small guard does not rewrite or conflict with the
+# open #911 migration PR. New listed proof journeys must use the durable shape
+# or carry a local justification.
+
+set -uo pipefail
+
+REPO_ROOT="${POCKETSHELL_JOURNEY_HARNESS_REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+cd "$REPO_ROOT" || exit 1
+
+SUITE="${POCKETSHELL_JOURNEY_HARNESS_SUITE:-scripts/ci-journey-suite.sh}"
+ANDROID_TEST_ROOT="${POCKETSHELL_JOURNEY_HARNESS_ANDROID_TEST_ROOT:-app/src/androidTest/java}"
+REPORT_MODE=0
+if [[ "${1:-}" == "--report" ]]; then
+  REPORT_MODE=1
+fi
+
+if [[ ! -f "$SUITE" ]]; then
+  echo "::error title=CI journey harness guard::cannot find $SUITE"
+  exit 1
+fi
+
+# Known current-main manual harnesses. Remove entries as the corresponding
+# journey migrates to createAndroidComposeRule<MainActivity>() +
+# SeedBeforeLaunchRule.
+KNOWN_MANUAL_HARNESS=(
+  "DeepLinkSessionSwitchE2eTest"
+  "WithinGraceSocketDropForegroundJourneyE2eTest"
+  "ReconnectPartialBlankReseedJourneyE2eTest"
+  "RedrawFullViewportReseedJourneyE2eTest"
+  "LongRunningSessionStabilityTest"
+  "ComposerAlwaysPresentSwitchJourneyE2eTest"
+)
+
+# Known current-main launch-owned classes that pre-seed via a local hand-rolled
+# TestRule instead of the shared SeedBeforeLaunchRule. Remove entries when those
+# classes adopt SeedBeforeLaunchRule.
+KNOWN_LAUNCH_OWNED_WITHOUT_SHARED_SEED=(
+  "AttachmentNoReconnectE2eTest"
+  "SendNoReconnectE2eTest"
+  "StableWifiNoSpuriousReconnectE2eTest"
+  "SilentDropSyntheticSeamJourneyE2eTest"
+  "CleanOutageReattachResilienceE2eTest"
+  "Issue895SwitchWhileBlackBandJourneyE2eTest"
+  "AgentSubmitAckJourneyE2eTest"
+)
+
+in_list() {
+  local item="$1"; shift
+  local candidate
+  for candidate in "$@"; do
+    [[ "$item" == "$candidate" ]] && return 0
+  done
+  return 1
+}
+
+is_code_line() {
+  ! printf '%s' "$1" | grep -Eq '^[[:space:]]*(\*|//|import |/\*)'
+}
+
+line_has_exemption() {
+  local file="$1" lineno="$2"
+  local start=$((lineno - 2))
+  [[ "$start" -lt 1 ]] && start=1
+  sed -n "${start},${lineno}p" "$file" |
+    grep -Eq 'JOURNEY_HARNESS_JUSTIFIED:[[:space:]]*[^[:space:]]'
+}
+
+manual_harness_hits() {
+  local file="$1"
+  grep -nE '(^|[[:space:]])(val[[:space:]]+compose[[:space:]]*=[[:space:]]*)?createEmptyComposeRule[[:space:]]*\(|ActivityScenario\.launch[[:space:]]*\(' "$file" 2>/dev/null || true
+}
+
+has_shared_seed_rule_call() {
+  local file="$1"
+  local hit text
+  while IFS= read -r hit; do
+    [[ -z "$hit" ]] && continue
+    text="${hit#*:}"
+    is_code_line "$text" || continue
+    text="${text%%//*}"
+    printf '%s\n' "$text" | grep -Eq 'SeedBeforeLaunchRule[[:space:]]*(\(|\{)' && return 0
+  done < <(grep -n 'SeedBeforeLaunchRule' "$file" 2>/dev/null || true)
+  return 1
+}
+
+class_file_for() {
+  local class_name="$1"
+  printf '%s/com/pocketshell/app/proof/%s.kt\n' "$ANDROID_TEST_ROOT" "$class_name"
+}
+
+declare -a JOURNEY_CLASSES=()
+declare -A SEEN=()
+while IFS= read -r line; do
+  class_name="$(printf '%s\n' "$line" | sed -nE 's/.*"\$FQCN_PREFIX\.([A-Za-z0-9_]+)(#[^"]*)?".*/\1/p')"
+  if [[ -z "${class_name:-}" ]]; then
+    class_name="$(printf '%s\n' "$line" | sed -nE 's/.*"com\.pocketshell\.app\.proof\.([A-Za-z0-9_]+)(#[^"]*)?".*/\1/p')"
+  fi
+  [[ -z "${class_name:-}" ]] && continue
+  if [[ -z "${SEEN[$class_name]:-}" ]]; then
+    JOURNEY_CLASSES+=("$class_name")
+    SEEN[$class_name]=1
+  fi
+done < "$SUITE"
+
+declare -a MISSING_FILES=()
+declare -a MANUAL_NEW=()
+declare -a MANUAL_KNOWN=()
+declare -a MANUAL_JUSTIFIED=()
+declare -a MISSING_SHARED_SEED_NEW=()
+declare -a MISSING_SHARED_SEED_KNOWN=()
+declare -a MISSING_SHARED_SEED_JUSTIFIED=()
+declare -a COMPLIANT=()
+declare -a NOT_MAINACTIVITY_LAUNCHERS=()
+declare -a STALE_BASELINE=()
+declare -a PARSER_FAILURE=()
+
+if [[ "${#JOURNEY_CLASSES[@]}" -eq 0 ]]; then
+  PARSER_FAILURE+=("NO_PROOF_CLASSES_PARSED")
+fi
+
+for class_name in "${JOURNEY_CLASSES[@]}"; do
+  file="$(class_file_for "$class_name")"
+  if [[ ! -f "$file" ]]; then
+    MISSING_FILES+=("$class_name -> $file")
+    continue
+  fi
+
+  has_android_rule=0
+  has_shared_seed=0
+  launches_main=0
+  grep -Eq 'createAndroidComposeRule[[:space:]]*<[[:space:]]*MainActivity[[:space:]]*>[[:space:]]*\(' "$file" && has_android_rule=1
+  has_shared_seed_rule_call "$file" && has_shared_seed=1
+  if [[ "$has_android_rule" -eq 1 ]] ||
+     grep -Eq 'ActivityScenario[[:space:]]*<[[:space:]]*MainActivity[[:space:]]*>|ActivityScenario\.launch[[:space:]]*\([[:space:]]*MainActivity::class\.java[[:space:]]*\)|Intent[[:space:]]*\([^)]*MainActivity::class\.java' "$file"; then
+    launches_main=1
+  fi
+
+  if [[ "$launches_main" -eq 0 ]]; then
+    NOT_MAINACTIVITY_LAUNCHERS+=("$class_name")
+    continue
+  fi
+
+  manual_unjustified=0
+  manual_justified=0
+  while IFS= read -r hit; do
+    [[ -z "$hit" ]] && continue
+    lineno="${hit%%:*}"
+    text="${hit#*:}"
+    is_code_line "$text" || continue
+    if line_has_exemption "$file" "$lineno"; then
+      manual_justified=1
+    else
+      manual_unjustified=1
+    fi
+  done < <(manual_harness_hits "$file")
+
+  if [[ "$manual_unjustified" -eq 1 ]]; then
+    if in_list "$class_name" "${KNOWN_MANUAL_HARNESS[@]}"; then
+      MANUAL_KNOWN+=("$class_name")
+    else
+      MANUAL_NEW+=("$class_name")
+    fi
+    continue
+  fi
+  if [[ "$manual_justified" -eq 1 ]]; then
+    MANUAL_JUSTIFIED+=("$class_name")
+    continue
+  fi
+
+  if [[ "$has_android_rule" -eq 1 && "$has_shared_seed" -eq 1 ]]; then
+    COMPLIANT+=("$class_name")
+    continue
+  fi
+
+  if [[ "$has_android_rule" -eq 1 && "$has_shared_seed" -eq 0 ]]; then
+    create_line="$(grep -nE 'createAndroidComposeRule[[:space:]]*<[[:space:]]*MainActivity[[:space:]]*>[[:space:]]*\(' "$file" | head -n 1 | cut -d: -f1)"
+    if [[ -n "$create_line" ]] && line_has_exemption "$file" "$create_line"; then
+      MISSING_SHARED_SEED_JUSTIFIED+=("$class_name")
+    elif in_list "$class_name" "${KNOWN_LAUNCH_OWNED_WITHOUT_SHARED_SEED[@]}"; then
+      MISSING_SHARED_SEED_KNOWN+=("$class_name")
+    else
+      MISSING_SHARED_SEED_NEW+=("$class_name")
+    fi
+  fi
+done
+
+for class_name in "${KNOWN_MANUAL_HARNESS[@]}"; do
+  if in_list "$class_name" "${JOURNEY_CLASSES[@]}" && ! in_list "$class_name" "${MANUAL_KNOWN[@]}"; then
+    STALE_BASELINE+=("KNOWN_MANUAL_HARNESS:$class_name")
+  fi
+done
+for class_name in "${KNOWN_LAUNCH_OWNED_WITHOUT_SHARED_SEED[@]}"; do
+  if in_list "$class_name" "${JOURNEY_CLASSES[@]}" && ! in_list "$class_name" "${MISSING_SHARED_SEED_KNOWN[@]}"; then
+    STALE_BASELINE+=("KNOWN_LAUNCH_OWNED_WITHOUT_SHARED_SEED:$class_name")
+  fi
+done
+
+print_list() {
+  local label="$1"; shift
+  local -a items=()
+  local item
+  for item in "$@"; do
+    [[ -n "$item" ]] && items+=("$item")
+  done
+  echo
+  echo "$label (${#items[@]}):"
+  if [[ "${#items[@]}" -eq 0 ]]; then
+    echo "  (none)"
+  else
+    for item in "${items[@]}"; do
+      echo "  - $item"
+    done
+  fi
+}
+
+echo "=============================================================="
+echo " CI journey harness guard (#848 / #788 / #743)"
+echo " Suite: $SUITE"
+echo " Proof journey classes listed: ${#JOURNEY_CLASSES[@]}"
+echo "=============================================================="
+
+print_list "PASS - launch-owned MainActivity harness with SeedBeforeLaunchRule" "${COMPLIANT[@]:-}"
+print_list "KNOWN - manual old harness baseline" "${MANUAL_KNOWN[@]:-}"
+print_list "KNOWN - launch-owned but missing shared SeedBeforeLaunchRule baseline" "${MISSING_SHARED_SEED_KNOWN[@]:-}"
+print_list "JUSTIFIED - local JOURNEY_HARNESS_JUSTIFIED exemption" "${MANUAL_JUSTIFIED[@]:-}" "${MISSING_SHARED_SEED_JUSTIFIED[@]:-}"
+print_list "IGNORED - listed proof class does not launch MainActivity" "${NOT_MAINACTIVITY_LAUNCHERS[@]:-}"
+print_list "STALE BASELINE - class no longer matches its baseline entry" "${STALE_BASELINE[@]:-}"
+print_list "PARSER FAIL - proof allowlist parser" "${PARSER_FAILURE[@]:-}"
+print_list "MISSING FILE - listed proof class has no source file" "${MISSING_FILES[@]:-}"
+print_list "NEW FAIL - manual ActivityScenario/createEmptyComposeRule harness" "${MANUAL_NEW[@]:-}"
+print_list "NEW FAIL - createAndroidComposeRule without SeedBeforeLaunchRule" "${MISSING_SHARED_SEED_NEW[@]:-}"
+
+hard_fail=()
+for item in "${PARSER_FAILURE[@]:-}" "${MISSING_FILES[@]:-}" "${MANUAL_NEW[@]:-}" "${MISSING_SHARED_SEED_NEW[@]:-}" "${STALE_BASELINE[@]:-}"; do
+  [[ -n "$item" ]] && hard_fail+=("$item")
+done
+
+if [[ "$REPORT_MODE" -eq 1 ]]; then
+  echo
+  echo "Report mode (--report): findings printed; guard does not fail."
+  exit 0
+fi
+
+if [[ "${#hard_fail[@]}" -gt 0 ]]; then
+  echo
+  echo "::error title=CI journey harness guard (#848/#788/#743)::A listed com.pocketshell.app.proof journey that launches MainActivity is not using createAndroidComposeRule<MainActivity>() plus SeedBeforeLaunchRule, the allowlist parser found no proof classes, or a known-baseline entry is stale. Migrate to the launch-owned harness, remove stale baselines, or add a local // JOURNEY_HARNESS_JUSTIFIED: comment naming why the manual/old pattern is required."
+  echo
+  echo "FAIL: ${#hard_fail[@]} CI journey harness issue(s)."
+  exit 1
+fi
+
+echo
+echo "PASS: no new unbaselined CI journey harness issues."
+exit 0

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -1505,6 +1505,13 @@ echo "=========================================================="
   echo
   echo "Core-terminal #879 beyond-grace reattach-repaint proof (\`shared:core-terminal\`): **$REATTACH_REPAINT_STATUS**"
   echo "- \`$CORE_TERMINAL_REATTACH_REPAINT_CLASS\`"
+  if [[ "${#PASSED_FIRST_TRY[@]}" -gt 0 ]]; then
+    echo
+    echo "Passed first try:"
+    for c in "${PASSED_FIRST_TRY[@]}"; do
+      echo "- \`$c\`"
+    done
+  fi
   if [[ "${#RECOVERED_CLASSES[@]}" -gt 0 ]]; then
     echo
     echo "Recovered on retry (CI-AVD flake — \`JOURNEY_FLAKE_RECOVERED\`):"
@@ -1547,7 +1554,8 @@ echo "=========================================================="
   # here, otherwise an append-burst-only regression falls through to the grep's
   # else-branch and is mislabeled as an infra abort, burying the real cause.
   if [[ "${#FAILED_CLASSES[@]}" -gt 0 || "$APPEND_BURST_STATUS" == "FAIL" || "$OUTPUT_BURST_IME_STATUS" == "FAIL" \
-        || "$MULTICHUNK_SEED_STATUS" == "FAIL" || "$AGENT_LINK_AFFORDANCE_STATUS" == "FAIL" ]]; then
+        || "$MULTICHUNK_SEED_STATUS" == "FAIL" || "$AGENT_LINK_AFFORDANCE_STATUS" == "FAIL" \
+        || "$REATTACH_REPAINT_STATUS" == "FAIL" ]]; then
     echo
     echo "Failed BOTH attempts (\`JOURNEY_FAILED\` — job red):"
     for c in "${FAILED_CLASSES[@]}"; do
@@ -1564,6 +1572,9 @@ echo "=========================================================="
     fi
     if [[ "$AGENT_LINK_AFFORDANCE_STATUS" == "FAIL" ]]; then
       echo "- \`$CORE_TERMINAL_AGENT_LINK_AFFORDANCE_CLASS\` (#871 agent-pane link-affordance off-main proof)"
+    fi
+    if [[ "$REATTACH_REPAINT_STATUS" == "FAIL" ]]; then
+      echo "- \`$CORE_TERMINAL_REATTACH_REPAINT_CLASS\` (#879 beyond-grace reattach-repaint proof)"
     fi
   fi
 } > "$SUMMARY"

--- a/scripts/test-ci-journey-budget.sh
+++ b/scripts/test-ci-journey-budget.sh
@@ -108,6 +108,33 @@ grep -q 'summary-missing.txt' "$WORKFLOW" \
 pass "(pre) #908 budget arithmetic pinned (${job_cap_secs}s job - ${emulator_boot_timeout_secs}s boot - ${default_suite_budget_secs}s suite = ${remaining_slack_secs}s slack)"
 pass "(pre) first-attempt diagnostics are preserved before emulator retry"
 
+# (pre) Every standalone proof that can make the suite red must also appear in
+# the Failed BOTH attempts summary. The workflow classifier only treats a first
+# attempt as a genuine failure when that section is present, so omissions can
+# incorrectly downgrade a proof failure followed by a retry timeout.
+failed_summary_block="$(awk '
+  /Failed BOTH attempts/ { capture=1 }
+  capture { print }
+  capture && /^  fi$/ { exit }
+' "$REAL_SUITE")"
+for proof_pair in \
+  'APPEND_BURST_STATUS:CORE_TERMINAL_APPEND_BURST_CLASS' \
+  'OUTPUT_BURST_IME_STATUS:CORE_TERMINAL_OUTPUT_BURST_IME_CLASS' \
+  'MULTICHUNK_SEED_STATUS:CORE_TERMINAL_MULTICHUNK_SEED_CLASS' \
+  'AGENT_LINK_AFFORDANCE_STATUS:CORE_TERMINAL_AGENT_LINK_AFFORDANCE_CLASS' \
+  'REATTACH_REPAINT_STATUS:CORE_TERMINAL_REATTACH_REPAINT_CLASS'
+do
+  status_var="${proof_pair%%:*}"
+  class_var="${proof_pair#*:}"
+  grep -q "\$$status_var\" == \"FAIL\"" "$REAL_SUITE" \
+    || fail "(pre) $status_var is not represented in the suite failure verdict"
+  grep -q "\$$status_var\" == \"FAIL\"" <<< "$failed_summary_block" \
+    || fail "(pre) $status_var is not represented in the Failed BOTH summary predicate"
+  grep -q "\$$class_var" <<< "$failed_summary_block" \
+    || fail "(pre) $class_var is not emitted in the Failed BOTH summary"
+done
+pass "(pre) every standalone proof failure is emitted under Failed BOTH attempts"
+
 # ---------------------------------------------------------------------------
 # Build a sandbox "repo root": a copy of the suite script + a stub gradlew that
 # SLEEPS (modelling a #470-stalling class) + stub scripts the suite shells out
@@ -200,6 +227,7 @@ classify() {
   local retry_concl="${5:-failure}"
   local first_timeout="${6:-}"
   local first_failure="${7:-false}"
+  local first_failed_classes="${8:-}"
   if [[ -z "$first_timeout" ]]; then
     first_timeout="false"
     if [[ -f "$s" ]] \
@@ -215,6 +243,33 @@ classify() {
     echo "PASS_RETRY"; return
   fi
   if [[ "$first_failure" == "true" ]]; then
+    if [[ -n "$first_failed_classes" ]] \
+      && [[ -f "$s" ]] \
+      && ! grep -qE 'JOURNEY_FAILED|Failed BOTH attempts' "$s" \
+      && grep -qE 'JOURNEY_STEP_TIMEOUT|Suite step time budget exhausted' "$s"; then
+      local resolved all_cleared class_name
+      resolved="$(awk '
+        /^Passed first try:/ || /^Recovered on retry/ { capture=1; next }
+        capture && /^- / {
+          gsub(/`/, "")
+          sub(/^- /, "")
+          sub(/[[:space:]]+\(.*/, "")
+          print
+          next
+        }
+        capture && /^$/ { capture=0 }
+      ' "$s" || true)"
+      all_cleared="true"
+      while IFS= read -r class_name; do
+        [[ -z "$class_name" ]] && continue
+        if ! grep -Fxq "$class_name" <<< "$resolved"; then
+          all_cleared="false"
+        fi
+      done <<< "$first_failed_classes"
+      if [[ "$all_cleared" == "true" ]]; then
+        echo "FIRST_FAILURE_CLEARED_RETRY_TIMEOUT"; return
+      fi
+    fi
     echo "FIRST_GENUINE_FAILURE"; return
   fi
   if [[ "$first_timeout" == "true" ]]; then
@@ -266,18 +321,38 @@ mixed_verdict="$(classify "$mixed_summary" failure failure failure failure false
 pass "(g) genuine Failed BOTH summary remains red even with timeout markers present"
 
 # (h) workflow-real shared-summary overwrite: first attempt wrote a genuine
-#     failure, retry overwrote summary.md with timeout-only content and did not
-#     pass. The captured first_failure output must prevent advisory-green.
+#     failure, retry overwrote summary.md with timeout-only content, and the
+#     retry summary proves the first-failed class passed before the later budget
+#     timeout. This is not a failed-on-both-cold-boots regression.
 retry_timeout_summary="$SANDBOX/retry-timeout-summary.md"
 printf '%s\n' \
   '# Per-push CI journey suite — summary' \
+  'Passed first try:' \
+  '- `com.pocketshell.app.RealRegressionTest`' \
+  '' \
   'Suite step time budget exhausted — JOURNEY_STEP_TIMEOUT (issue #835 / #470 stall — job red):' \
   '- `com.pocketshell.app.RetryTimedOutClass`' \
   > "$retry_timeout_summary"
-overwrite_verdict="$(classify "$retry_timeout_summary" failure failure failure failure false true)"
-[[ "$overwrite_verdict" == "FIRST_GENUINE_FAILURE" ]] \
-  || fail "(h) first genuine failure + retry timeout overwrite routed to '$overwrite_verdict', expected FIRST_GENUINE_FAILURE"
-pass "(h) first genuine failure remains red when retry overwrites summary with timeout-only content"
+overwrite_verdict="$(classify "$retry_timeout_summary" failure failure failure failure false true $'com.pocketshell.app.RealRegressionTest')"
+[[ "$overwrite_verdict" == "FIRST_FAILURE_CLEARED_RETRY_TIMEOUT" ]] \
+  || fail "(h) cleared first failure + retry timeout routed to '$overwrite_verdict', expected FIRST_FAILURE_CLEARED_RETRY_TIMEOUT"
+pass "(h) first-attempt failed class cleared on retry routes to timeout advisory"
+
+# (i) Negative guard for (h): if the retry timeout summary does not prove the
+#     first-failed class passed/recovered, preserve the first genuine-failure red.
+uncleared_retry_timeout_summary="$SANDBOX/uncleared-retry-timeout-summary.md"
+printf '%s\n' \
+  '# Per-push CI journey suite — summary' \
+  'Passed first try:' \
+  '- `com.pocketshell.app.SomeOtherClass`' \
+  '' \
+  'Suite step time budget exhausted — JOURNEY_STEP_TIMEOUT (issue #835 / #470 stall — job red):' \
+  '- `com.pocketshell.app.RetryTimedOutClass`' \
+  > "$uncleared_retry_timeout_summary"
+uncleared_verdict="$(classify "$uncleared_retry_timeout_summary" failure failure failure failure false true $'com.pocketshell.app.RealRegressionTest')"
+[[ "$uncleared_verdict" == "FIRST_GENUINE_FAILURE" ]] \
+  || fail "(i) uncleared first failure + retry timeout routed to '$uncleared_verdict', expected FIRST_GENUINE_FAILURE"
+pass "(i) first-attempt failure remains red when retry summary does not prove it cleared"
 
 # ---------------------------------------------------------------------------
 # Issue #918: if the per-class `timeout` kills a Gradle invocation, the next


### PR DESCRIPTION
## Summary

Refs #848, #788, #743.

Adds a small static CI guard for the per-push journey allowlist in `scripts/ci-journey-suite.sh`:

- parses listed `com.pocketshell.app.proof.*` journey classes, including `$FQCN_PREFIX.*` and `#method` entries
- flags unbaselined MainActivity journeys that use the old `createEmptyComposeRule()` / manual `ActivityScenario.launch(...)` harness
- flags unbaselined launch-owned journeys that use `createAndroidComposeRule<MainActivity>()` without `SeedBeforeLaunchRule`
- allows a local inline `JOURNEY_HARNESS_JUSTIFIED:` exemption comment when a manual harness is genuinely required
- includes a synthetic shell self-test that proves red on bad fixtures and green on compliant/justified fixtures

I did not edit journey test classes, including the three files already covered by open PR #911 (`PreExistingMultiWindowSeedE2eTest`, `SwitchStaleCaptureSessionBodyJourneyE2eTest`, `VoiceSendActivePaneStaysVisibleE2eTest`). Current-main legacy classes are explicit baselines so this guard can merge independently without duplicating that migration.

## Validation

- `bash -n scripts/check-ci-journey-harness.sh scripts/check-ci-journey-harness-selftest.sh scripts/check-test-validity.sh scripts/test-ci-journey-budget.sh` - pass
- `scripts/check-ci-journey-harness.sh && scripts/check-ci-journey-harness-selftest.sh` - pass; self-test shows bad manual/missing-seed fixtures fail and compliant/justified fixtures pass
- `scripts/check-test-validity.sh` - pass
- `scripts/check-component-drift.sh` - pass
- `scripts/check-design-tokens.sh` - pass; reports two existing improved counts, no new drift
- `scripts/test-ci-journey-budget.sh` - pass
- `git diff --check` - pass

## Caveat

This is a guardrail PR, not the migration PR. The baseline should shrink as #911 and later harness migrations land; stale baseline entries are reported by the guard so they can be pruned.
