### PR TITLE
Gate emulator journey after cheap CI jobs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -272,6 +272,7 @@ jobs:
   # connect-break class was structurally invisible to CI — the exact #848 gate gap.
   emulator-journey:
     name: Emulator journey subset (load-bearing, Docker agents)
+    needs: [unit, python, integration]
     runs-on: ubuntu-latest
     # Issue #691 (STABILIZE): lowered 75 -> 45 as a backstop. A wedging test
     # should now fail fast via the per-test `timeout_msec` in


### PR DESCRIPTION
## Summary
- Add `needs: [unit, python, integration]` to the `emulator-journey` job.
- Reduces CI notification noise by avoiding expensive emulator starts when cheaper Unit/Python/Integration gates already failed.

## Validation
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/tests.yml"); puts "YAML OK"'`\n- `bash scripts/test-ci-journey-budget.sh`\n- Dry merge check with PR #917 using `git merge-tree --write-tree HEAD origin/pr-917`