### PR TITLE
ci: preserve first emulator journey attempt diagnostics

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -641,6 +641,54 @@ jobs:
           echo "first summary timeout-only: $first_timeout"
           echo "first summary genuine failure: $first_failure"
 
+      # Preserve the first cold-boot attempt before a retry can overwrite the
+      # shared artifacts/ci-journey summary or Gradle connected-test outputs.
+      - name: Preserve first journey attempt diagnostics
+        if: always() && steps.journey.outcome == 'failure'
+        run: |
+          snapshot="artifacts/ci-journey-attempt-1"
+          rm -rf "$snapshot"
+          mkdir -p "$snapshot"
+
+          {
+            echo "# First emulator journey attempt diagnostics"
+            echo
+            echo "- first attempt outcome: \`${{ steps.journey.outcome }}\`"
+            echo "- first attempt conclusion: \`${{ steps.journey.conclusion }}\`"
+            echo "- first summary timeout-only: \`${{ steps.journey_summary.outputs.first_timeout }}\`"
+            echo "- first summary genuine failure: \`${{ steps.journey_summary.outputs.first_failure }}\`"
+            if [[ -f artifacts/ci-journey/summary.md ]]; then
+              echo "- suite summary: \`ci-journey/summary.md\`"
+            else
+              echo "- suite summary: missing after first attempt"
+            fi
+          } > "$snapshot/attempt-metadata.md"
+
+          if [[ -d artifacts/ci-journey ]]; then
+            mkdir -p "$snapshot/ci-journey"
+            cp -a artifacts/ci-journey/. "$snapshot/ci-journey/"
+          else
+            echo "artifacts/ci-journey was missing after the first attempt." > "$snapshot/ci-journey-missing.txt"
+          fi
+          if [[ ! -f "$snapshot/ci-journey/summary.md" ]]; then
+            echo "artifacts/ci-journey/summary.md was missing after the first attempt." > "$snapshot/summary-missing.txt"
+          fi
+
+          shopt -s globstar nullglob
+          copied_android_outputs=0
+          for path in **/build/reports/androidTests \
+                      **/build/outputs/androidTest-results \
+                      **/build/outputs/connected_android_test_additional_output; do
+            [[ -e "$path" ]] || continue
+            dest="$snapshot/android-test-outputs/$path"
+            mkdir -p "$(dirname "$dest")"
+            cp -a "$path" "$dest"
+            copied_android_outputs=1
+          done
+          if [[ "$copied_android_outputs" -eq 0 ]]; then
+            echo "No Android connected-test output directories existed after the first attempt." > "$snapshot/android-test-outputs-missing.txt"
+          fi
+
       # Infra-retry-once: runs if the first bringup failed with a boot/adb abort
       # or a genuine test failure. It is deliberately skipped for a pure
       # suite-budget timeout because the first cold boot already consumed the
@@ -794,6 +842,7 @@ jobs:
             **/build/outputs/androidTest-results/
             **/build/outputs/connected_android_test_additional_output/
             artifacts/ci-journey/
+            artifacts/ci-journey-attempt-1/
           if-no-files-found: ignore
 
       - name: Upload Docker logs

--- a/scripts/test-ci-journey-budget.sh
+++ b/scripts/test-ci-journey-budget.sh
@@ -21,6 +21,8 @@
 #       genuine failure / infra abort routes this summary to advisory-green.
 #   (f) a cancelled retry is classified before any `Failed BOTH attempts`
 #       summary, because summary.md can be stale from the first cold boot.
+#   (g) first-attempt diagnostics are snapshotted before the workflow retry can
+#       overwrite summary.md or connected-test outputs.
 #
 # It runs entirely on the JVM-free shell layer — NO emulator, NO Docker, NO
 # gradle — so it can run as a fast unit check on any box and in the Unit CI job.
@@ -87,7 +89,24 @@ if grep -qE "$stale_step_cap_re" \
   "$REAL_SUITE" "$WORKFLOW" "$THIS_TEST"; then
   fail "(pre) stale workflow-timeout wording found; use 45-min job cap"
 fi
+
+preserve_line="$(grep -n 'name: Preserve first journey attempt diagnostics' "$WORKFLOW" | cut -d: -f1)"
+retry_line="$(grep -n 'name: Retry journey subset on a fresh cold-booted emulator' "$WORKFLOW" | cut -d: -f1)"
+upload_line="$(grep -n 'artifacts/ci-journey-attempt-1/' "$WORKFLOW" | cut -d: -f1 | tail -n 1)"
+[[ "$preserve_line" =~ ^[0-9]+$ ]] \
+  || fail "(pre) workflow must preserve first-attempt diagnostics before retry"
+[[ "$retry_line" =~ ^[0-9]+$ ]] \
+  || fail "(pre) could not find emulator retry step in tests.yml"
+[[ "$upload_line" =~ ^[0-9]+$ ]] \
+  || fail "(pre) first-attempt diagnostics must be uploaded as an artifact"
+[[ "$preserve_line" -lt "$retry_line" ]] \
+  || fail "(pre) first-attempt diagnostics preservation must run before retry"
+grep -q 'cp -a artifacts/ci-journey/.' "$WORKFLOW" \
+  || fail "(pre) preservation step must snapshot artifacts/ci-journey before retry overwrites summary.md"
+grep -q 'summary-missing.txt' "$WORKFLOW" \
+  || fail "(pre) preservation step must record first-attempt missing-summary infra aborts"
 pass "(pre) #908 budget arithmetic pinned (${job_cap_secs}s job - ${emulator_boot_timeout_secs}s boot - ${default_suite_budget_secs}s suite = ${remaining_slack_secs}s slack)"
+pass "(pre) first-attempt diagnostics are preserved before emulator retry"
 
 # ---------------------------------------------------------------------------
 # Build a sandbox "repo root": a copy of the suite script + a stub gradlew that


### PR DESCRIPTION
## Summary
- snapshot first failed cold-boot journey attempt diagnostics before the retry can overwrite shared ci-journey artifacts
- upload the attempt-1 snapshot alongside the final Android test reports
- extend the existing ci-journey budget guard to assert the preservation step stays before retry and remains uploaded

## Conflict check
- inspected #917 (issue-848-journey-harness-guard): adds a Unit-job guard and new scripts; workflow hunk is separate from this retry block
- inspected #919 (ci-emulator-after-cheap-gates): adds only emulator-journey needs; separate from this retry block

## Tests
- scripts/test-ci-journey-budget.sh
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/tests.yml"); puts "yaml ok"'
- git diff --check

Note: actionlint is not installed locally and Go is unavailable, so I could not run actionlint without adding tooling.