### PR TITLE
release: bump to v0.4.15

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,8 +65,8 @@ android {
         applicationId = "com.pocketshell.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 61
-        versionName = "0.4.14"
+        versionCode = 62
+        versionName = "0.4.15"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 


### PR DESCRIPTION
Cuts **v0.4.15** to ship the attachment-drop fixes that landed on main after the v0.4.14 tag. The maintainer is still seeing attachments dropped on v0.4.14 because the fixes are not yet in a release.

## Included since v0.4.14
- **#872 Part B** — await in-flight attachment upload before Send so it isn't dropped
- **#875** — eliminate the two residual spurious-reconnect triggers on stable wifi (the ~1s reconnect that wiped the staged attachment, #872 root cause)
- **#891** — bound stuck sends with a retryable watchdog (no more 'Sending…' forever)
- **#900** — per-session outbound SEND QUEUE: enqueue on Send, persist attachment sidecar, auto-flush on reconnect, send-once idempotency

## Version
- versionName 0.4.14 → 0.4.15
- versionCode 61 → 62

## Gate
- Required protected-main `Tests` checks must be green before merge.
- After merge + fast-forward, run `scripts/release-emulator-validation.sh` from stable main, then push the `v0.4.15` tag with the guarded helper.

No `Closes` — this is a release bump, not an issue fix.