### PR TITLE
pocketshell: bump CLI package to 0.4.16 (match the app)

### DIFF
--- a/tools/pocketshell/pyproject.toml
+++ b/tools/pocketshell/pyproject.toml
@@ -8,7 +8,7 @@ name = "pocketshell"
 # scripts/check-pypi-version.sh enforces this; .github/workflows/build.yml
 # runs that check before publishing to PyPI. See
 # tools/pocketshell/README.md ("Release flow") for the bump procedure.
-version = "0.4.14"
+version = "0.4.16"
 description = "Unified server-side Python utility for the PocketShell Android client."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
The app expects host pocketshell == app version. App shipped 0.4.16; the python package was still 0.4.14, so the in-app host-version banner nagged (maintainer hit this 2026-06-25). Bump to 0.4.16. Host already upgraded via uv tool. Follow-up: couple the pocketshell package bump to the app versionName in the release process.