### PR TITLE
Release v0.4.17 — connection stability + black-screen

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -162,6 +162,22 @@ jobs:
         working-directory: tools/pocketshell
         run: uv run pytest -v
 
+      # Issue #948: fail at PR time when the app `versionName`
+      # (app/build.gradle.kts) and the tools/pocketshell package `version`
+      # (pyproject.toml) drift. The app derives the EXPECTED host pocketshell
+      # CLI version from its own versionName, so a drift makes the in-app
+      # host-version banner nag the user (it happened 2026-06-25: app 0.4.16
+      # vs package 0.4.14). The existing check-pypi-version.sh only runs on
+      # tag push; this catches the drift at PR/push time. --self-test first
+      # proves the guard's own red->green logic, then the bare run checks the
+      # real tree. Cheap (~1s); kept in this cheap Python job, not the emulator
+      # job.
+      - name: "Version-coupling guard (issue #948)"
+        run: |
+          chmod +x scripts/check-version-coupling.sh
+          scripts/check-version-coupling.sh --self-test
+          scripts/check-version-coupling.sh
+
       - name: Smoke-test installed CLI
         working-directory: tools/pocketshell
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -579,6 +579,45 @@ jobs:
             testuser@127.0.0.1 \
             'pocketshell tree get </dev/null; rc=$?; if [ "$rc" -eq 0 ]; then echo "old-cli fixture unexpectedly accepted tree get (rc=0)" >&2; exit 1; fi; tmux -V >/dev/null && echo "old-cli mismatch confirmed: tree get rc=$rc, host still live"'
 
+      # Issue #839 (epic #821 workstream C): bring up the DAEMON fixture on host
+      # port 2239 so the durable-tree journey (FolderListDurableTreeDaemonDockerTest)
+      # actually RUNS on CI. Its `pocketshell` is the REAL Python package (genuine
+      # `tree.py` daemon code), so `tree get|upsert|reconcile` PERSIST a host-side
+      # JSON registry that survives an app kill + relaunch — the #837 durable
+      # property. Without this fixture started the journey self-skipped on CI and
+      # the durable-tree assertion had ZERO per-push protection (D32/G4/F3). Mirrors
+      # the agents-old-cli (#849) precedent directly above.
+      - name: Start Docker fixture (agents-daemon, issue #839)
+        run: |
+          docker compose -f tests/docker/docker-compose.yml up -d --build --no-deps agents-daemon
+
+      - name: Wait for the agents-daemon fixture to report healthy
+        run: |
+          source tests/docker/lib/wait-for-healthy.sh
+          wait_for_container_healthy tests/docker/docker-compose.yml agents-daemon /tmp/agents-daemon-health.log 60
+          cat /tmp/agents-daemon-health.log
+
+      # Confirm the 2239 fixture really IS the REAL daemon: `pocketshell tree`
+      # round-trips a persist (upsert then get over a fresh exec returns the
+      # collapsed node) AND reconcile diffs against the LIVE tmux server. A broken
+      # fixture fails the job loudly here instead of letting the journey pass
+      # vacuously / self-skip. Mirrors the agents-old-cli mismatch sanity check.
+      - name: Verify agents-daemon real `pocketshell tree` persists (issue #839)
+        run: |
+          chmod 600 tests/docker/test_key
+          ssh -i tests/docker/test_key -p 2239 \
+            -o BatchMode=yes \
+            -o ConnectTimeout=3 \
+            -o StrictHostKeyChecking=no \
+            -o UserKnownHostsFile=/dev/null \
+            testuser@127.0.0.1 \
+            'set -e;
+             printf "%s" "{\"host\":\"ci\",\"nodes\":[{\"session\":\"s\",\"order\":0,\"folder_path\":\"/p\",\"collapsed\":true}]}" | pocketshell tree upsert >/dev/null;
+             got="$(printf "%s" "{\"host\":\"ci\"}" | pocketshell tree get)";
+             echo "$got" | grep -q "\"session\": \"s\"" || { echo "agents-daemon tree did NOT persist: $got" >&2; exit 1; };
+             echo "$got" | grep -q "\"collapsed\": true" || { echo "agents-daemon tree dropped the collapse: $got" >&2; exit 1; };
+             echo "agents-daemon real-tree persist confirmed: $got"'
+
       # Issue #760: the journey job intermittently failed with
       # "WARNING | Failed to load snapshot 'default_boot'" followed by
       # "adb … exit code 1" — a STALE/CORRUPT quickboot snapshot the runner
@@ -818,6 +857,9 @@ jobs:
           # Issue #849: also capture the old-CLI (2238) fixture diagnostics.
           docker compose -f tests/docker/docker-compose.yml logs --no-color agents-old-cli > artifacts/docker/agents-old-cli.log 2>/dev/null || true
           docker inspect pocketshell-test-agents-old-cli > artifacts/docker/agents-old-cli-inspect.json 2>/dev/null || true
+          # Issue #839: also capture the daemon (2239) fixture diagnostics.
+          docker compose -f tests/docker/docker-compose.yml logs --no-color agents-daemon > artifacts/docker/agents-daemon.log 2>/dev/null || true
+          docker inspect pocketshell-test-agents-daemon > artifacts/docker/agents-daemon-inspect.json 2>/dev/null || true
 
       - name: Publish journey suite summary
         if: always()

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,8 +65,8 @@ android {
         applicationId = "com.pocketshell.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 63
-        versionName = "0.4.16"
+        versionCode = 64
+        versionName = "0.4.17"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/androidTest/java/com/pocketshell/app/cards/SessionCardFeedRegistryTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/cards/SessionCardFeedRegistryTest.kt
@@ -1,0 +1,176 @@
+package com.pocketshell.app.cards
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.pocketshell.uikit.theme.PocketShellTheme
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Issue #859 Slice B: prove the generic feed renders a HETEROGENEOUS card list
+ * through the renderer registry (no `when (type)` in the feed):
+ *
+ * - a checklist card still renders + ticks as before (no regression),
+ * - a `note` card renders + marks-read via the registry (new type, no feed
+ *   code change),
+ * - a genuinely unknown type renders a graceful "unsupported card" row.
+ */
+class SessionCardFeedRegistryTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    private class RecordingInteractions : SessionCardInteractions {
+        val checklistToggles = mutableListOf<Triple<String, String, Boolean>>()
+        val noteReads = mutableListOf<Pair<String, Boolean>>()
+
+        override fun onToggleChecklistItem(cardId: String, itemId: String, checked: Boolean) {
+            checklistToggles += Triple(cardId, itemId, checked)
+        }
+
+        override fun onSetNoteRead(cardId: String, read: Boolean) {
+            noteReads += cardId to read
+        }
+    }
+
+    @Test
+    fun feedRendersChecklistNoteAndUnknownTypesViaRegistry() {
+        val interactions = RecordingInteractions()
+        composeRule.setContent {
+            PocketShellTheme {
+                SessionCardFeedContent(
+                    cards = listOf(
+                        SessionCardsRemoteSource.ChecklistCard(
+                            id = "cl",
+                            title = "Deploy",
+                            createdAt = null,
+                            updatedAt = null,
+                            items = listOf(
+                                SessionCardsRemoteSource.ChecklistItem("build-0", "Build"),
+                            ),
+                            checkedIds = emptySet(),
+                        ),
+                        SessionCardsRemoteSource.NoteCard(
+                            id = "nt",
+                            title = "Heads up",
+                            createdAt = null,
+                            updatedAt = null,
+                            text = "Deploy finished",
+                            read = false,
+                        ),
+                        SessionCardsRemoteSource.UnknownCard(
+                            id = "uk",
+                            type = "approval",
+                            title = "Approve?",
+                            createdAt = null,
+                            updatedAt = null,
+                        ),
+                    ),
+                    interactions = interactions,
+                    onClose = {},
+                )
+            }
+        }
+
+        // Checklist card + item rendered through the registry's checklist renderer.
+        composeRule.onNodeWithTag(SESSION_CHECKLIST_CARD_TAG_PREFIX + "cl").assertIsDisplayed()
+        composeRule.onNodeWithText("Build").assertIsDisplayed()
+        // Note card rendered through the registry's note renderer.
+        composeRule.onNodeWithTag(SESSION_NOTE_CARD_TAG_PREFIX + "nt").assertIsDisplayed()
+        composeRule.onNodeWithText("Deploy finished").assertIsDisplayed()
+        // Unknown type rendered as the graceful fallback row.
+        composeRule.onNodeWithTag(SESSION_UNKNOWN_CARD_TAG_PREFIX + "uk").assertIsDisplayed()
+    }
+
+    @Test
+    fun checklistItemTickRoutesThroughRegistryRenderer() {
+        val interactions = RecordingInteractions()
+        composeRule.setContent {
+            PocketShellTheme {
+                SessionCardFeedContent(
+                    cards = listOf(
+                        SessionCardsRemoteSource.ChecklistCard(
+                            id = "cl",
+                            title = null,
+                            createdAt = null,
+                            updatedAt = null,
+                            items = listOf(
+                                SessionCardsRemoteSource.ChecklistItem("build-0", "Build"),
+                            ),
+                            checkedIds = emptySet(),
+                        ),
+                    ),
+                    interactions = interactions,
+                    onClose = {},
+                )
+            }
+        }
+
+        composeRule
+            .onNodeWithTag(SESSION_CHECKLIST_ITEM_TAG_PREFIX + "cl:build-0")
+            .performClick()
+
+        assertEquals(listOf(Triple("cl", "build-0", true)), interactions.checklistToggles)
+    }
+
+    @Test
+    fun noteMarkReadRoutesThroughRegistryRenderer() {
+        val interactions = RecordingInteractions()
+        composeRule.setContent {
+            PocketShellTheme {
+                SessionCardFeedContent(
+                    cards = listOf(
+                        SessionCardsRemoteSource.NoteCard(
+                            id = "nt",
+                            title = null,
+                            createdAt = null,
+                            updatedAt = null,
+                            text = "Deploy finished",
+                            read = false,
+                        ),
+                    ),
+                    interactions = interactions,
+                    onClose = {},
+                )
+            }
+        }
+
+        composeRule
+            .onNodeWithTag(SESSION_NOTE_READ_TOGGLE_TAG_PREFIX + "nt")
+            .performClick()
+
+        assertEquals(listOf("nt" to true), interactions.noteReads)
+    }
+
+    @Test
+    fun noteRendererRendersStandaloneViaRegistryLookup() {
+        // The registry is the single dispatch site: ask for the `note` renderer
+        // and render it directly — no feed-level `when (type)` needed.
+        val interactions = RecordingInteractions()
+        composeRule.setContent {
+            PocketShellTheme {
+                SessionCardRenderers
+                    .rendererFor(SessionCardsRemoteSource.TYPE_NOTE)
+                    .Render(
+                        card = SessionCardsRemoteSource.NoteCard(
+                            id = "nt",
+                            title = "Heads up",
+                            createdAt = null,
+                            updatedAt = null,
+                            text = "Standalone note",
+                            read = true,
+                        ),
+                        interactions = interactions,
+                        modifier = Modifier,
+                    )
+            }
+        }
+
+        composeRule.onNodeWithText("Standalone note").assertIsDisplayed()
+        composeRule.onNodeWithText("Heads up").assertIsDisplayed()
+    }
+}

--- a/app/src/androidTest/java/com/pocketshell/app/cards/SessionChecklistPushJourneyDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/cards/SessionChecklistPushJourneyDockerTest.kt
@@ -1,0 +1,417 @@
+package com.pocketshell.app.cards
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.proof.DEFAULT_HOST
+import com.pocketshell.app.proof.DEFAULT_PORT
+import com.pocketshell.app.proof.DEFAULT_USER
+import com.pocketshell.app.proof.waitForSshFixtureReady
+import com.pocketshell.core.ssh.KnownHostsPolicy
+import com.pocketshell.core.ssh.SshConnection
+import com.pocketshell.core.ssh.SshKey
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.uikit.theme.PocketShellTheme
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+import java.io.FileOutputStream
+
+/**
+ * Epic #859 Slice A (tracking issue #949) — the end-to-end emulator+Docker
+ * acceptance journey for the host→app typed-card push (Phase-1 "verify-gone",
+ * D33). Phase-1 (the host CLI `pocketshell push checklist|get|check|status` +
+ * the app's [SessionCardsRemoteSource] + the checklist chip / bottom-sheet)
+ * shipped code-complete on `main` but **WITHOUT** an end-to-end journey, so the
+ * real warm-session path was unproven. This class proves it and gate-wires it
+ * (per-push, see `scripts/ci-journey-suite.sh`) so the card-push transport
+ * cannot silently regress.
+ *
+ * It exercises the REAL path, NOT a unit proxy:
+ *
+ *  1. A host (the deterministic Docker `agents` fixture, host port 2222 — or the
+ *     pool-allocated port under `--pool`) runs `pocketshell push checklist
+ *     --session <s> --item …` over a real SSH session to write the per-session
+ *     card store.
+ *  2. The app reads it through the PRODUCTION [SessionCardsRemoteSource.getCards]
+ *     over the SAME warm [SshSession] (D21 — no new connection) and parses it to
+ *     a [SessionCardsRemoteSource.ChecklistCard].
+ *  3. The PRODUCTION checklist chip + bottom-sheet ([ChecklistChip] /
+ *     [ChecklistCardsContent], the same composables the session screen mounts)
+ *     render that real feed; the test asserts the card + its items ACTUALLY
+ *     appear in the rendered feed (not a fabricated in-memory card).
+ *  4. Tapping an item drives the PRODUCTION
+ *     [SessionCardsRemoteSource.setChecklistItemChecked] tick exec over the same
+ *     warm session.
+ *  5. Re-reading the host (`push status` + the production [getCards]) confirms
+ *     the tick ROUND-TRIPPED to the host store, and an untick round-trips too.
+ *
+ * RED→GREEN (D32 G10): [readPathBroken_wrongSessionName_yieldsEmptyFeed_redGuard]
+ * is the inverted guard — reading the card under the WRONG tmux session name
+ * (the read-path-broken signal) yields an empty feed and renders NO chip, so the
+ * "card reaches the feed" assertions above are load-bearing (a broken read path
+ * makes the journey fail, a working one makes it pass).
+ *
+ * Mirrors the structure of [com.pocketshell.app.projects.ManualKindWriterDockerTest]
+ * (same fixture + key bootstrap), but exercises the card-push read/render/tick
+ * round-trip rather than agent-kind classification.
+ */
+@RunWith(AndroidJUnit4::class)
+class SessionChecklistPushJourneyDockerTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    private lateinit var sshKey: SshKey.Pem
+    private lateinit var keyFile: File
+    private val cleanupCommands = mutableListOf<String>()
+
+    @After
+    fun tearDown(): Unit = runBlocking {
+        if (cleanupCommands.isNotEmpty()) {
+            runCatching {
+                withTimeout(15_000) {
+                    withSshSession { session ->
+                        session.exec(cleanupCommands.joinToString("\n"))
+                    }
+                }
+            }
+        }
+        runCatching { keyFile.delete() }
+    }
+
+    @Test
+    fun hostPushChecklistRendersInAppFeedAndTickRoundTripsToHost(): Unit = runBlocking {
+        bootstrapKey()
+        waitForSshFixtureReady(sshKey, port = DEFAULT_PORT)
+
+        val suffix = System.currentTimeMillis().toString().takeLast(8)
+        val sessionName = "issue859-cards-$suffix"
+        // The card store lives under ~/.pocketshell/cards/<session>.json on the
+        // host (the cards.py default), so clean both the session and its store.
+        cleanupCommands += "rm -f \"\$HOME/.pocketshell/cards/$sessionName.json\" 2>/dev/null || true"
+
+        val source = SessionCardsRemoteSource()
+
+        // ---------------------------------------------------------------
+        // (1) AGENT push: the host writes a per-session checklist card via the
+        //     real `pocketshell push checklist` verb over a real SSH session.
+        // ---------------------------------------------------------------
+        val pushCmd = pocketshellExec(
+            "push checklist --session ${shellQuote(sessionName)} " +
+                "--title ${shellQuote("Deploy plan")} " +
+                "--item ${shellQuote("Build the app")} " +
+                "--item ${shellQuote("Run the tests")} " +
+                "--item ${shellQuote("Ship it")}",
+        )
+        withSshSession { s ->
+            val r = withTimeout(20_000) { s.exec(pushCmd) }
+            assertEquals(
+                "host `pocketshell push checklist` must succeed; " +
+                    "stderr='${r.stderr}' stdout='${r.stdout}'",
+                0,
+                r.exitCode,
+            )
+            assertTrue(
+                "push confirmation should name the session; got '${r.stdout}'",
+                r.stdout.contains(sessionName),
+            )
+        }
+
+        // ---------------------------------------------------------------
+        // (2) APP read: the PRODUCTION remote source reads the card back over
+        //     the warm session and parses it to a ChecklistCard with the
+        //     pushed items (item ids are `<slug>-<index>`, faithful to cards.py).
+        // ---------------------------------------------------------------
+        val feed = withSshSession { s ->
+            withTimeout(20_000) { source.getCards(s, sessionName) }
+        }
+        assertEquals("feed session must match the pushed session", sessionName, feed.session)
+        val card = feed.cards.filterIsInstance<SessionCardsRemoteSource.ChecklistCard>()
+            .singleOrNull()
+        assertNotNull("the pushed checklist card must reach the app feed", card)
+        card!!
+        assertEquals("checklist", card.type)
+        assertEquals("Deploy plan", card.title)
+        assertEquals(
+            "the pushed items must round-trip to the app feed in order",
+            listOf("Build the app", "Run the tests", "Ship it"),
+            card.items.map { it.text },
+        )
+        assertEquals(
+            "item ids must be the cards.py <slug>-<index> shape",
+            listOf("build-the-app-0", "run-the-tests-1", "ship-it-2"),
+            card.items.map { it.id },
+        )
+        assertTrue(
+            "no item should be pre-checked on a fresh push",
+            card.checkedIds.isEmpty(),
+        )
+
+        // ---------------------------------------------------------------
+        // (3) APP RENDER: the PRODUCTION chip + bottom-sheet render the REAL
+        //     feed. The toggle path drives the PRODUCTION tick exec over the
+        //     SAME warm session (this is the user's actual tap path). We hold
+        //     the feed in app state and re-read it after each tick so the
+        //     render reflects the host store, exactly like the VM does.
+        // ---------------------------------------------------------------
+        var renderedCards by mutableStateOf(
+            feed.cards.filterIsInstance<SessionCardsRemoteSource.ChecklistCard>(),
+        )
+
+        // The production toggle: tick over the warm session, then re-read the
+        // host store (mirrors TmuxSessionViewModel.toggleChecklistItem).
+        suspend fun toggle(cardId: String, itemId: String, checked: Boolean) {
+            withSshSession { s ->
+                val ok = withTimeout(20_000) {
+                    source.setChecklistItemChecked(
+                        session = s,
+                        tmuxSessionName = sessionName,
+                        cardId = cardId,
+                        itemId = itemId,
+                        checked = checked,
+                    )
+                }
+                assertTrue("the production tick exec must be acknowledged by the host", ok)
+            }
+            val refreshed = withSshSession { s ->
+                withTimeout(20_000) { source.getCards(s, sessionName) }
+            }
+            renderedCards = refreshed.cards
+                .filterIsInstance<SessionCardsRemoteSource.ChecklistCard>()
+        }
+
+        val toggleRequests = mutableListOf<Triple<String, String, Boolean>>()
+        composeRule.setContent {
+            PocketShellTheme {
+                val chip = checklistChipState(renderedCards)
+                if (chip != null) {
+                    ChecklistChip(state = chip, onClick = {})
+                }
+                ChecklistCardsContent(
+                    cards = renderedCards,
+                    onToggle = { cardId, itemId, isChecked ->
+                        toggleRequests += Triple(cardId, itemId, isChecked)
+                    },
+                    onClose = {},
+                )
+            }
+        }
+
+        // The chip is present (count chip over the real feed) and the card +
+        // every pushed item are ACTUALLY rendered in the production sheet.
+        composeRule.onNodeWithTag(SESSION_CHECKLIST_CHIP_TAG).assertIsDisplayed()
+        composeRule.onNodeWithTag(SESSION_CHECKLIST_CARD_TAG_PREFIX + card.id)
+            .assertIsDisplayed()
+        composeRule.onNodeWithText("Build the app").assertIsDisplayed()
+        composeRule.onNodeWithText("Run the tests").assertIsDisplayed()
+        composeRule.onNodeWithText("Ship it").assertIsDisplayed()
+
+        // ---------------------------------------------------------------
+        // (4)+(5) TICK round-trip: tap the second item in the rendered sheet ->
+        //     production tick over the warm session -> host store reflects it.
+        // ---------------------------------------------------------------
+        composeRule.onNodeWithTag(
+            SESSION_CHECKLIST_ITEM_TAG_PREFIX + card.id + ":run-the-tests-1",
+        ).performClick()
+        composeRule.waitForIdle()
+
+        // The rendered tap requested a tick (checked=true) for that item.
+        assertEquals(
+            "the rendered item tap must request a tick of run-the-tests-1",
+            Triple(card.id, "run-the-tests-1", true),
+            toggleRequests.last(),
+        )
+        // Drive the production tick over the warm session for the requested tap.
+        toggleRequests.last().let { (cardId, itemId, checked) ->
+            toggle(cardId, itemId, checked)
+        }
+        composeRule.waitForIdle()
+
+        // The host store now shows the item checked — proven via BOTH the
+        // production read AND the agent's `push status` read-back.
+        val afterTick = withSshSession { s ->
+            withTimeout(20_000) { source.getCards(s, sessionName) }
+        }.cards.filterIsInstance<SessionCardsRemoteSource.ChecklistCard>().single()
+        assertTrue(
+            "after the app tick the host store must mark run-the-tests-1 checked",
+            "run-the-tests-1" in afterTick.checkedIds,
+        )
+        withSshSession { s ->
+            val status = withTimeout(20_000) {
+                s.exec(pocketshellExec("push status --json --session ${shellQuote(sessionName)}"))
+            }
+            assertEquals(0, status.exitCode)
+            assertTrue(
+                "agent `push status` must reflect the human's tick; got '${status.stdout}'",
+                status.stdout.contains("run-the-tests-1"),
+            )
+        }
+
+        // The rendered sheet now shows that item checked (host-backed state).
+        assertTrue(
+            "the rendered card must reflect the checked item",
+            renderedCards.single().checkedIds.contains("run-the-tests-1"),
+        )
+
+        // ---------------------------------------------------------------
+        // UNTICK round-trip — the human can change their mind.
+        // ---------------------------------------------------------------
+        toggle(card.id, "run-the-tests-1", checked = false)
+        composeRule.waitForIdle()
+        val afterUntick = withSshSession { s ->
+            withTimeout(20_000) { source.getCards(s, sessionName) }
+        }.cards.filterIsInstance<SessionCardsRemoteSource.ChecklistCard>().single()
+        assertFalse(
+            "after the app untick the host store must clear run-the-tests-1",
+            "run-the-tests-1" in afterUntick.checkedIds,
+        )
+    }
+
+    @Test
+    fun noChecklistPushedYieldsEmptyFeedAndNoChip(): Unit = runBlocking {
+        bootstrapKey()
+        waitForSshFixtureReady(sshKey, port = DEFAULT_PORT)
+
+        val suffix = System.currentTimeMillis().toString().takeLast(8)
+        // A session that never had a card pushed — the empty/no-card state.
+        val emptySession = "issue859-empty-$suffix"
+
+        val source = SessionCardsRemoteSource()
+        val feed = withSshSession { s ->
+            withTimeout(20_000) { source.getCards(s, emptySession) }
+        }
+        assertTrue(
+            "a session with no pushed card must read back an empty feed",
+            feed.cards.isEmpty(),
+        )
+
+        val cards = feed.cards.filterIsInstance<SessionCardsRemoteSource.ChecklistCard>()
+        assertNull(
+            "checklistChipState must be null for an empty feed (no chip)",
+            checklistChipState(cards),
+        )
+
+        composeRule.setContent {
+            PocketShellTheme {
+                val chip = checklistChipState(cards)
+                if (chip != null) {
+                    ChecklistChip(state = chip, onClick = {})
+                }
+            }
+        }
+        composeRule.onNodeWithTag(SESSION_CHECKLIST_CHIP_TAG).assertDoesNotExist()
+    }
+
+    /**
+     * RED→GREEN guard (D32 G10): the load-bearing "card reaches the feed"
+     * assertions above only mean something if a BROKEN read path produces a
+     * different, empty result. Here the card is pushed under [sessionName] but
+     * the app reads under the WRONG tmux session name — the read-path-broken
+     * signal — and the feed is empty + NO chip renders. So if a regression made
+     * `getCards` ignore the session (or always return empty), the GREEN test
+     * above would fail; if it always returned the card regardless of session,
+     * THIS test would fail. The two together pin the real path.
+     */
+    @Test
+    fun readPathBroken_wrongSessionName_yieldsEmptyFeed_redGuard(): Unit = runBlocking {
+        bootstrapKey()
+        waitForSshFixtureReady(sshKey, port = DEFAULT_PORT)
+
+        val suffix = System.currentTimeMillis().toString().takeLast(8)
+        val sessionName = "issue859-guard-$suffix"
+        cleanupCommands += "rm -f \"\$HOME/.pocketshell/cards/$sessionName.json\" 2>/dev/null || true"
+
+        val source = SessionCardsRemoteSource()
+        withSshSession { s ->
+            val r = withTimeout(20_000) {
+                s.exec(
+                    pocketshellExec(
+                        "push checklist --session ${shellQuote(sessionName)} " +
+                            "--item ${shellQuote("Build the app")}",
+                    ),
+                )
+            }
+            assertEquals("push setup failed: '${r.stderr}'", 0, r.exitCode)
+        }
+
+        // Sanity: the RIGHT session name reads the card (the path works).
+        val correct = withSshSession { s ->
+            withTimeout(20_000) { source.getCards(s, sessionName) }
+        }
+        assertTrue(
+            "control: the correct session name must read the pushed card",
+            correct.cards.any { it is SessionCardsRemoteSource.ChecklistCard },
+        )
+
+        // The WRONG session name (read-path-broken signal) reads an empty feed.
+        val wrong = withSshSession { s ->
+            withTimeout(20_000) { source.getCards(s, sessionName + "-WRONG") }
+        }
+        assertTrue(
+            "a wrong session name must NOT surface another session's card",
+            wrong.cards.isEmpty(),
+        )
+        assertNull(
+            "no chip renders for the broken read path",
+            checklistChipState(
+                wrong.cards.filterIsInstance<SessionCardsRemoteSource.ChecklistCard>(),
+            ),
+        )
+    }
+
+    // ----------------------------------------------------------- Helpers
+
+    /**
+     * Wrap a `pocketshell <args>` invocation the SAME way the app does
+     * ([com.pocketshell.app.pocketshell.PocketshellCommand.wrap]) so the host
+     * CLI is resolved from the non-interactive exec PATH. The fixture installs
+     * `pocketshell` at `/usr/local/bin`, which the wrapper probes.
+     */
+    private fun pocketshellExec(args: String): String =
+        com.pocketshell.app.pocketshell.PocketshellCommand.wrap(args)
+
+    private fun bootstrapKey() {
+        val keyText = InstrumentationRegistry.getInstrumentation()
+            .context.assets.open("test_key").bufferedReader().use { it.readText() }
+        sshKey = SshKey.Pem(keyText)
+        val cacheDir = InstrumentationRegistry.getInstrumentation().targetContext.cacheDir
+        keyFile = File(cacheDir, "issue859-cards-key").apply {
+            parentFile?.mkdirs()
+            if (exists()) delete()
+            FileOutputStream(this).use { it.write(keyText.toByteArray()) }
+            setReadable(true, true)
+        }
+    }
+
+    private suspend fun <T> withSshSession(block: suspend (SshSession) -> T): T {
+        val session = SshConnection.connect(
+            host = DEFAULT_HOST,
+            port = DEFAULT_PORT,
+            user = DEFAULT_USER,
+            key = sshKey,
+            knownHosts = KnownHostsPolicy.AcceptAll,
+            timeoutMs = 15_000,
+        ).getOrThrow()
+        return session.use { block(it) }
+    }
+
+    private fun shellQuote(value: String): String =
+        "'" + value.replace("'", "'\\''") + "'"
+}

--- a/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerMicSwipeLockJourneyTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerMicSwipeLockJourneyTest.kt
@@ -161,6 +161,76 @@ class PromptComposerMicSwipeLockJourneyTest {
         compose.onNodeWithTag(COMPOSER_MIC_TAG).assertIsDisplayed()
     }
 
+    /**
+     * Issue #585 (6th reopen): the deterministic, sheet-drag-PROOF hands-free
+     * lock path. The swipe-up gesture competes with the ModalBottomSheet's
+     * velocity-driven drag-to-dismiss — that arbitration broke on the
+     * maintainer's real device every round while passing the emulator. A single
+     * tap on the explicit Lock control cannot be stolen by the sheet drag, so it
+     * is the durable way to "release the finger and keep recording". This test
+     * is the regression that fails on base (no Lock control exists) and passes
+     * with the fix.
+     *
+     * Reproduction note: the COMPOSER_LOCK_RECORDING_TAG control does not exist
+     * on the unfixed code, so `onNodeWithTag(...).performClick()` below throws
+     * (assert-on-empty-node) → the test is RED on base, GREEN with the fix.
+     */
+    @Test
+    fun tapLockControlLocksRecordingHandsFree() {
+        val mic = FakeMicCapture()
+        val viewModel = newViewModel(mic)
+        renderComposer(viewModel)
+
+        // Start recording with a plain tap (the regular start path).
+        compose.onNodeWithTag(COMPOSER_MIC_TAG).performClick()
+        compose.waitUntil(timeoutMillis = 5_000) {
+            viewModel.uiState.value.recording == RecordingState.Recording
+        }
+        compose.waitForIdle()
+
+        // While recording-but-not-locked: the hands-free hint is shown and the
+        // Lock control is present; the persistent locked indicator is NOT.
+        assertFalse(viewModel.uiState.value.recordingLocked)
+        compose.onNodeWithTag(COMPOSER_LOCK_HINT_TAG).assertIsDisplayed()
+        compose.onNodeWithTag(COMPOSER_RECORDING_LOCKED_TAG).assertDoesNotExist()
+
+        // Tap the deterministic Lock control — a tap, so the finger is already
+        // off the screen. Recording must lock and KEEP capturing.
+        compose.onNodeWithTag(COMPOSER_LOCK_RECORDING_TAG).assertIsDisplayed()
+        compose.onNodeWithTag(COMPOSER_LOCK_RECORDING_TAG).performClick()
+        compose.waitUntil(timeoutMillis = 5_000) {
+            viewModel.uiState.value.recordingLocked
+        }
+        compose.waitForIdle()
+
+        // Hands-free: the capture is still live (never stopped) and locked.
+        assertEquals("Lock must not stop or restart capture", 1, mic.startCount)
+        assertEquals("Lock must not stop capture", 0, mic.stopCount)
+        assertEquals(RecordingState.Recording, viewModel.uiState.value.recording)
+        assertTrue(viewModel.uiState.value.recordingLocked)
+
+        // Locked state reads clean: the persistent lock indicator is shown, and
+        // the pre-lock hint + Lock control are gone (locked is the end state).
+        compose.onNodeWithTag(COMPOSER_RECORDING_LOCKED_TAG).assertIsDisplayed()
+        compose.onNodeWithTag(COMPOSER_LOCK_HINT_TAG).assertDoesNotExist()
+        compose.onNodeWithTag(COMPOSER_LOCK_RECORDING_TAG).assertDoesNotExist()
+        WalkthroughScreenshotArtifacts.capture("issue-585-lock-button-locked")
+
+        // The locked recording can still be stopped/cancelled/sent.
+        compose.onNodeWithTag(COMPOSER_CANCEL_RECORDING_TAG).assertIsDisplayed()
+        compose.onNodeWithTag(COMPOSER_TO_FIELD_TAG).assertIsDisplayed()
+        compose.onNodeWithTag(COMPOSER_STOP_SEND_TAG).assertIsDisplayed()
+
+        // Discard cancels only the recording, without closing the composer.
+        compose.onNodeWithTag(COMPOSER_CANCEL_RECORDING_TAG).performClick()
+        compose.waitUntil(timeoutMillis = 5_000) {
+            viewModel.uiState.value.recording == RecordingState.Idle &&
+                !viewModel.uiState.value.recordingLocked
+        }
+        assertEquals("Discard should stop the locked capture once", 1, mic.stopCount)
+        compose.onNodeWithTag(COMPOSER_MIC_TAG).assertIsDisplayed()
+    }
+
     @Test
     fun plainTapStartsRecordingWithoutLocking() {
         val mic = FakeMicCapture()

--- a/app/src/androidTest/java/com/pocketshell/app/fileviewer/FileViewerScaffoldTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/fileviewer/FileViewerScaffoldTest.kt
@@ -242,6 +242,46 @@ class FileViewerScaffoldTest {
     }
 
     /**
+     * Issue #921: a GitHub-flavored pipe table in rendered Markdown mode shows
+     * laid-out table cells, NOT the raw `|---|---|` delimiter text. Before the
+     * fix the whole table parsed as a raw paragraph, so the literal delimiter
+     * row "|------|-------|" appeared on screen as text.
+     */
+    @Test
+    fun markdownRenderedPipeTableShowsCellsNotRawDelimiter() {
+        compose.setContent {
+            PocketShellTheme {
+                FileViewerScaffold(
+                    hostName = "agents",
+                    state = FileViewerUiState.TextContent(
+                        displayPath = "/tmp/report.md",
+                        content = "# Benchmark\n\n" +
+                            "| Model | Score |\n" +
+                            "|-------|-------|\n" +
+                            "| gpt-4 | 92 |\n" +
+                            "| haiku | 81 |\n",
+                        sizeBytes = 90,
+                    ),
+                    readingPrefs = FileViewerReadingPrefs(wordWrap = false, renderMarkdown = true),
+                    onBack = {},
+                    onRetry = {},
+                )
+            }
+        }
+        // The rendered table surface is present and visible.
+        compose.assertNodeFullyWithinRoot(FILE_VIEWER_MARKDOWN_TABLE_TAG)
+        // The header + body cells render as their own text nodes.
+        compose.onNodeWithText("Model").assertIsDisplayed()
+        compose.onNodeWithText("Score").assertIsDisplayed()
+        compose.onNodeWithText("gpt-4").assertIsDisplayed()
+        compose.onNodeWithText("92").assertIsDisplayed()
+        compose.onNodeWithText("haiku").assertIsDisplayed()
+        // The raw delimiter row must NOT appear as literal text.
+        compose.onNodeWithText("|-------|-------|").assertDoesNotExist()
+        compose.onNodeWithText("| Model | Score |").assertDoesNotExist()
+    }
+
+    /**
      * Build a minimal valid PCM WAV of [millis] of silence (16-bit mono, 8 kHz)
      * so MediaPlayer can prepare it without a codec — enough to exercise the
      * panel's control surface in a unit-scope Compose test.

--- a/app/src/androidTest/java/com/pocketshell/app/projects/CliVersionMismatchBannerUpdateButtonTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/CliVersionMismatchBannerUpdateButtonTest.kt
@@ -1,0 +1,187 @@
+package com.pocketshell.app.projects
+
+import android.graphics.Bitmap
+import android.os.SystemClock
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.proof.signals.assertNodeFullyWithinRoot
+import com.pocketshell.uikit.theme.PocketShellColors
+import com.pocketshell.uikit.theme.PocketShellTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+import java.io.FileOutputStream
+
+/**
+ * Issue #947 — UI gate (#641 / #567 / #657 / G9) for the host-version-mismatch
+ * banner's one-tap **Update** button.
+ *
+ * The maintainer asked for an Update button on the FolderList host-version banner
+ * (the arrow in the issue screenshot). The reviewer's blocker: the JVM render is
+ * only the fast-first check — the acceptance for a maintainer-reported UI control
+ * is a connected androidTest of the REAL production composable with viewport
+ * CONTAINMENT (the #780 real-component model), proving the Update + Dismiss
+ * controls are present, reachable, and NOT clipped in every state.
+ *
+ * This composes the PRODUCTION [CliVersionMismatchBanner] (the exact composable
+ * the FolderList screen renders — `internal` for this test, no proxy/stand-in)
+ * pinned to the bottom edge of a full-screen [Box] (its real placement on the
+ * session-tree screen), in each of its three states:
+ *
+ *  - **Idle** — Update + Dismiss both present, ENABLED, clickable, and FULLY
+ *    within the window root (`assertNodeFullyWithinRoot`, not a bare
+ *    `assertIsDisplayed` — a control pushed off the right edge by the long
+ *    version message still reports "displayed").
+ *  - **Running** — the spinner is shown and contained; Update/Dismiss are
+ *    replaced (no double-run), so the spinner stands in for the in-flight action.
+ *  - **Failure** — the error line + the **Retry** + **Dismiss** controls are
+ *    present and contained; no stuck spinner.
+ *
+ * Each state writes a full-device screenshot for the status comment (the
+ * maintainer's arrow-target acceptance: Update next to Dismiss). NO Docker
+ * fixture, NO SSH/tmux, NO self-skip — a pure Compose UI gate that runs per-push.
+ */
+@RunWith(AndroidJUnit4::class)
+class CliVersionMismatchBannerUpdateButtonTest {
+
+    @get:Rule
+    val compose = createAndroidComposeRule<ComponentActivity>()
+
+    private val message =
+        "This host's pocketshell is 0.4.14; the app expects 0.4.16. " +
+            "Update it on the host:\nuv tool install --upgrade " +
+            "--exclude-newer-package pocketshell=2099-12-31 pocketshell\n" +
+            "(or: pipx upgrade pocketshell / pip install -U pocketshell)"
+
+    @Test
+    fun idleState_updateAndDismissPresentReachableNotClipped() {
+        setBanner(FolderListViewModel.CliVersionUpdateState.Idle)
+
+        // Both controls present + clickable (reachability).
+        compose.onNodeWithTag(FOLDER_LIST_CLI_VERSION_UPDATE_TAG)
+            .assertIsDisplayed().assertIsEnabled().assertHasClickAction()
+        compose.onNodeWithTag(FOLDER_LIST_CLI_VERSION_DISMISS_TAG)
+            .assertIsDisplayed().assertIsEnabled().assertHasClickAction()
+
+        // CONTAINMENT (#657/F1): neither button is pushed off any edge by the
+        // long multi-line version message — the #641-class occlusion check that a
+        // bare assertIsDisplayed would NOT catch.
+        compose.assertNodeFullyWithinRoot(FOLDER_LIST_CLI_VERSION_UPDATE_TAG)
+        compose.assertNodeFullyWithinRoot(FOLDER_LIST_CLI_VERSION_DISMISS_TAG)
+        // The whole banner is on-screen too.
+        compose.assertNodeFullyWithinRoot(FOLDER_LIST_CLI_VERSION_BANNER_TAG)
+
+        capture("issue-947-banner-idle-update-dismiss.png")
+    }
+
+    @Test
+    fun runningState_spinnerShownAndContained_noButtons() {
+        setBanner(FolderListViewModel.CliVersionUpdateState.Running)
+
+        compose.onNodeWithTag(FOLDER_LIST_CLI_VERSION_UPDATE_SPINNER_TAG).assertIsDisplayed()
+        compose.assertNodeFullyWithinRoot(FOLDER_LIST_CLI_VERSION_UPDATE_SPINNER_TAG)
+        compose.assertNodeFullyWithinRoot(FOLDER_LIST_CLI_VERSION_BANNER_TAG)
+        // While running the Update button is replaced by the spinner so a second
+        // tap cannot double-run.
+        compose.onNodeWithTag(FOLDER_LIST_CLI_VERSION_UPDATE_TAG).assertDoesNotExist()
+
+        capture("issue-947-banner-running-spinner.png")
+    }
+
+    @Test
+    fun failureState_errorAndRetryDismissPresentReachableNotClipped() {
+        setBanner(
+            FolderListViewModel.CliVersionUpdateState.Failure(
+                "Update failed (exit 1):\nerror: network unreachable",
+            ),
+        )
+
+        // The error line is shown + contained (no stuck spinner).
+        compose.onNodeWithTag(FOLDER_LIST_CLI_VERSION_UPDATE_ERROR_TAG).assertIsDisplayed()
+        compose.assertNodeFullyWithinRoot(FOLDER_LIST_CLI_VERSION_UPDATE_ERROR_TAG)
+        compose.onNodeWithTag(FOLDER_LIST_CLI_VERSION_UPDATE_SPINNER_TAG).assertDoesNotExist()
+
+        // Retry (re-uses the Update tag) + Dismiss present, reachable, contained.
+        compose.onNodeWithTag(FOLDER_LIST_CLI_VERSION_UPDATE_TAG)
+            .assertIsDisplayed().assertIsEnabled().assertHasClickAction()
+        compose.onNodeWithTag(FOLDER_LIST_CLI_VERSION_DISMISS_TAG)
+            .assertIsDisplayed().assertIsEnabled().assertHasClickAction()
+        compose.assertNodeFullyWithinRoot(FOLDER_LIST_CLI_VERSION_UPDATE_TAG)
+        compose.assertNodeFullyWithinRoot(FOLDER_LIST_CLI_VERSION_DISMISS_TAG)
+
+        capture("issue-947-banner-failure-retry-dismiss.png")
+    }
+
+    // --- helpers ------------------------------------------------------------
+
+    private fun setBanner(state: FolderListViewModel.CliVersionUpdateState) {
+        compose.setContent {
+            PocketShellTheme {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(PocketShellColors.Background),
+                ) {
+                    // The banner's REAL placement on the FolderList screen: a
+                    // non-displacing overlay pinned to the bottom edge with the
+                    // same 12dp padding the production call site uses.
+                    CliVersionMismatchBanner(
+                        message = message,
+                        updateState = state,
+                        onUpdate = {},
+                        onDismiss = {},
+                        // The banner's REAL placement on the FolderList screen: a
+                        // bottom-edge overlay with 12dp padding, ABOVE the system
+                        // nav bar (the production content Box carries the nav
+                        // inset). Adding it here makes the acceptance screenshot
+                        // faithful and keeps the controls off the nav bar.
+                        modifier = Modifier
+                            .align(Alignment.BottomCenter)
+                            .navigationBarsPadding()
+                            .padding(12.dp),
+                    )
+                }
+            }
+        }
+        compose.waitForIdle()
+        SystemClock.sleep(150)
+    }
+
+    private fun capture(name: String) {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.waitForIdleSync()
+        SystemClock.sleep(150)
+        val mediaRoot = com.pocketshell.app.test.testArtifactsRoot(instrumentation.targetContext)
+        val dir = File(mediaRoot, "additional_test_output/cli-version-banner-update")
+        check(dir.exists() || dir.mkdirs()) {
+            "Could not create screenshot directory: ${dir.absolutePath}"
+        }
+        val bitmap = instrumentation.uiAutomation.takeScreenshot() ?: return
+        val file = File(dir, name)
+        try {
+            FileOutputStream(file).use { output ->
+                check(bitmap.compress(Bitmap.CompressFormat.PNG, 100, output)) {
+                    "Could not write screenshot: ${file.absolutePath}"
+                }
+            }
+            println("CLI_VERSION_BANNER_UPDATE_SCREENSHOT ${file.absolutePath}")
+        } finally {
+            bitmap.recycle()
+        }
+    }
+}

--- a/app/src/androidTest/java/com/pocketshell/app/projects/FolderListDurableTreeDaemonDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/FolderListDurableTreeDaemonDockerTest.kt
@@ -1,0 +1,462 @@
+package com.pocketshell.app.projects
+
+import androidx.lifecycle.ViewModelStore
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.portfwd.ForwardingController
+import com.pocketshell.app.proof.DEFAULT_HOST
+import com.pocketshell.app.proof.DEFAULT_USER
+import com.pocketshell.app.proof.waitForSshFixtureReady
+import com.pocketshell.core.ssh.KnownHostsPolicy
+import com.pocketshell.core.ssh.SshConnection
+import com.pocketshell.core.ssh.SshKey
+import com.pocketshell.core.storage.AppDatabase
+import com.pocketshell.core.storage.entity.HostEntity
+import com.pocketshell.core.storage.entity.ProjectRootEntity
+import com.pocketshell.core.storage.entity.SshKeyEntity
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+import java.io.FileOutputStream
+
+/**
+ * Issue #839 (epic #821 workstream C, #837 follow-up) — the END-TO-END
+ * durable-tree journey on a REAL device + REAL daemon. #837 was approved on
+ * JVM-level proofs (an in-memory `FakeTreeDaemon` standing in for the host-side
+ * `pocketshell tree` registry); the reviewer flagged the non-blocking gap that
+ * the daemon was never installed on a Docker fixture, so the `tree.*` RPCs could
+ * not be exercised end-to-end on-device. This is that missing journey.
+ *
+ * ## What it proves on the real path (no proxy)
+ *
+ * The PRODUCTION [FolderListViewModel] + a REAL [TreeRemoteSource] drive
+ * `pocketshell tree get|upsert|reconcile` over a warm SSH session against the
+ * `agents-daemon` Docker fixture (port 2239,
+ * `tests/docker/Dockerfile.agents-daemon`) whose `pocketshell` is the REAL Python
+ * package — the genuine `tree.py` daemon code persisting a host-keyed JSON
+ * registry under `$XDG_STATE_HOME/pocketshell/tree/registry.json`. That registry
+ * is HOST-SIDE state, so it survives an Android app kill + relaunch (the #837
+ * durable property the JVM proof could only model).
+ *
+ * The journey, in the issue's words ("collapse a folder + establish an order,
+ * kill + relaunch the app, assert the tree hydrates with the held order/collapse
+ * INSTANTLY, then a refresh reconciles gone/added as deltas"):
+ *
+ * 1. **First app session** binds the daemon host. Two real tmux sessions seeded
+ *    under a watched root render in the live tree. The user COLLAPSES that
+ *    folder — `persistTree` fire-and-forgets a `tree.upsert` to the daemon.
+ * 2. The collapse + order is confirmed PERSISTED host-side via a direct
+ *    out-of-band `pocketshell tree get` over a fresh SSH session (proving the
+ *    durability lives in the host JSON registry, not any client cache — D22).
+ * 3. **App kill + relaunch**: the first VM's store is cleared and a BRAND-NEW
+ *    [FolderListViewModel] + a NEW [TreeRemoteSource] bind the same host over a
+ *    NEW SSH session. The cold-start hydrate reads the held order/collapse back
+ *    and renders it INSTANTLY — the collapsed folder STAYS collapsed across the
+ *    process death (the load-bearing daemon-hydrate assertion).
+ * 4. **Refresh reconciles deltas**: a session is killed out-of-band on the host,
+ *    then a resume-when-stale fires the daemon `tree.reconcile`, which diffs the
+ *    registry against the LIVE `tmuxctl list` and PRUNES the gone session as a
+ *    DELTA (no full reload). A newly-added session is then picked up too.
+ *
+ * ## RED / GREEN
+ *
+ * RED (if the daemon durability were broken — e.g. `tree.upsert` not persisting,
+ * or the registry NOT surviving the new SSH session): the relaunched VM2 would
+ * NOT see the held collapse — the folder would auto-EXPAND on first ready (its
+ * default), failing the "stays collapsed across relaunch" assertion. GREEN: the
+ * host-side registry hydrates the collapse instantly. The two pre-conditions
+ * (the fixture really persists; the registry shows the collapse over a fresh SSH
+ * session) are asserted explicitly before the VM journey so the proof can never
+ * pass vacuously against a daemon that silently dropped the write.
+ *
+ * ## CI gating (#839 — this test RUNS on per-push CI)
+ *
+ * The `emulator-journey` workflow now brings up the `agents-daemon` fixture on
+ * host port 2239 (and a sanity step verifies its real `pocketshell tree`
+ * persists), AND this class is wired into
+ * `scripts/ci-journey-suite.sh::JOURNEY_CLASSES`, mirroring the `agents-old-cli`
+ * (#849) promotion precedent. So there is NO `assumeFalse(isRunningOnCi())`
+ * self-skip — the load-bearing durable-tree assertion runs at PR time (D32/G4/F3;
+ * a self-skip would leave it with zero protection). `waitForSshFixtureReady`
+ * HARD-fails fast if 2239 is unreachable, so a missing fixture surfaces loudly
+ * rather than skipping. The always-runnable JVM backstop is
+ * `FolderListViewModelTreeDurabilityTest` (per-push Unit job). Locally the fixture
+ * is brought up with
+ * `docker compose -f tests/docker/docker-compose.yml up -d --build agents-daemon`
+ * and the test runs via `scripts/connected-test.sh --suffix i839`.
+ *
+ * Docker service: `agents-daemon` on host port `2239`.
+ */
+@RunWith(AndroidJUnit4::class)
+class FolderListDurableTreeDaemonDockerTest {
+
+    private lateinit var sshKey: SshKey.Pem
+    private lateinit var keyFile: File
+    private lateinit var db: AppDatabase
+    private val viewModelStore = ViewModelStore()
+    private var nextViewModelKey: Int = 0
+    private val createdSessions = mutableListOf<String>()
+    private var hostName: String = "issue839-host"
+
+    @Before
+    fun setUp(): Unit = runBlocking {
+        // Issue #839: NO assumeFalse(isRunningOnCi()) self-skip. The
+        // emulator-journey workflow now brings up the `agents-daemon` fixture on
+        // port 2239 (and verifies its real `pocketshell tree` persists) AND this
+        // class is wired into scripts/ci-journey-suite.sh::JOURNEY_CLASSES, so the
+        // load-bearing durable-tree assertion RUNS on per-push CI (D32/G4/F3 — a
+        // self-skip would leave it with zero protection). waitForSshFixtureReady
+        // below HARD-fails fast if 2239 is unreachable, so a missing fixture
+        // surfaces loudly instead of a vacuous skip (G3/G10). The always-runnable
+        // backstop is the JVM FolderListViewModelTreeDurabilityTest (Unit job).
+        val keyText = InstrumentationRegistry.getInstrumentation()
+            .context
+            .assets
+            .open("test_key")
+            .bufferedReader()
+            .use { it.readText() }
+        sshKey = SshKey.Pem(keyText)
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        keyFile = File(context.cacheDir, "issue839-daemon-key").apply {
+            parentFile?.mkdirs()
+            if (exists()) delete()
+            FileOutputStream(this).use { it.write(keyText.toByteArray()) }
+            setReadable(true, true)
+        }
+        db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        waitForSshFixtureReady(sshKey, port = DAEMON_PORT)
+    }
+
+    @After
+    fun tearDown(): Unit = runBlocking {
+        viewModelStore.clear()
+        runCatching {
+            withTimeout(20_000) {
+                connect().use { session ->
+                    for (name in createdSessions) {
+                        runCatching {
+                            session.exec("tmux kill-session -t $name 2>/dev/null || true")
+                        }
+                    }
+                    // Reset the durable registry for this host so a re-run starts
+                    // clean (the host-side state is, by design, persistent).
+                    runCatching {
+                        session.exec(
+                            "rm -f \"\${XDG_STATE_HOME:-\$HOME/.local/state}\"" +
+                                "/pocketshell/tree/registry.json 2>/dev/null || true",
+                        )
+                    }
+                }
+            }
+        }
+        runCatching { db.close() }
+        runCatching { keyFile.delete() }
+    }
+
+    /**
+     * The load-bearing journey: collapse a folder + hold an order, KILL +
+     * RELAUNCH the app, and assert the daemon-hydrated tree renders the held
+     * order/collapse INSTANTLY, then a resume reconcile prunes a gone session as
+     * a delta and a refresh picks up an added session.
+     */
+    @Test
+    fun durableTreeSurvivesAppKillAndRelaunch_thenReconcilesDeltas(): Unit = runBlocking {
+        val suffix = System.currentTimeMillis().toString().takeLast(6)
+        hostName = "issue839-host-$suffix"
+        val rootDir = "/tmp/issue839-$suffix"
+        val alphaDir = "$rootDir/alpha"
+        val betaDir = "$rootDir/beta"
+        val alphaSession = "issue839-alpha-$suffix"
+        val betaSession = "issue839-beta-$suffix"
+        val alphaFolder = FolderListViewModel.canonicalisePath(alphaDir)
+        val watchRoot = FolderListViewModel.canonicalisePath(rootDir)
+
+        // --- Pre-condition A: a CLEAN registry for this fresh host name, and a
+        // fixture whose `pocketshell tree` REALLY persists (not a no-op). Seed two
+        // real tmux sessions, one per project folder under the watched root, so
+        // the live tree groups them under their folders. ---
+        withTimeout(30_000) {
+            connect().use { session ->
+                session.exec("mkdir -p $alphaDir $betaDir")
+                session.exec("tmux new-session -d -s $alphaSession -c $alphaDir")
+                session.exec("tmux new-session -d -s $betaSession -c $betaDir")
+                createdSessions += alphaSession
+                createdSessions += betaSession
+                // Prove this fixture's `tree` actually persists: upsert a probe,
+                // get it back over the SAME session. If the daemon were a no-op
+                // the get would be empty and the durability journey would be
+                // vacuous, so fail loud here.
+                val probeHost = "issue839-probe-$suffix"
+                session.exec(
+                    "printf '%s' '{\"host\":\"$probeHost\",\"nodes\":" +
+                        "[{\"session\":\"p\",\"order\":0,\"folder_path\":\"/x\",\"collapsed\":true}]}' " +
+                        "| pocketshell tree upsert",
+                )
+                val probeGet = session.exec(
+                    "printf '%s' '{\"host\":\"$probeHost\"}' | pocketshell tree get",
+                )
+                assertTrue(
+                    "the agents-daemon fixture's `pocketshell tree` must REALLY persist " +
+                        "(get returned: ${probeGet.stdout} / exit=${probeGet.exitCode}) — " +
+                        "otherwise the durability journey is vacuous",
+                    probeGet.exitCode == 0 &&
+                        probeGet.stdout.contains("\"session\": \"p\"") &&
+                        probeGet.stdout.contains("\"collapsed\": true"),
+                )
+            }
+        }
+
+        val keyId = db.sshKeyDao().insert(
+            SshKeyEntity(name = "issue839-key", privateKeyPath = keyFile.absolutePath),
+        )
+        val hostId = db.hostDao().insert(
+            HostEntity(
+                name = hostName,
+                hostname = DEFAULT_HOST,
+                port = DAEMON_PORT,
+                username = DEFAULT_USER,
+                keyId = keyId,
+            ),
+        )
+        // Persist the watched root so the live tree buckets the two sessions under
+        // their project folders (the grouping the collapse acts on).
+        db.projectRootDao().insert(
+            ProjectRootEntity(hostId = hostId, label = "issue839", path = watchRoot),
+        )
+        val host = db.hostDao().getById(hostId)!!
+
+        // --- Phase 1: first app session — bind, render the live tree, collapse
+        // the alpha folder (which fire-and-forget upserts to the daemon). ---
+        val vm1 = newViewModel()
+        vm1.setProcessStartedForTest(true)
+        bind(vm1, host)
+
+        val ready1 = awaitReadyWithSessions(vm1, setOf(alphaSession, betaSession))
+        assertTrue(
+            "alpha must auto-expand before the user collapses it — expanded=" +
+                "${ready1.expandedProjectPaths}",
+            alphaFolder in ready1.expandedProjectPaths,
+        )
+
+        // The user collapses the alpha folder.
+        vm1.toggleProjectExpanded(alphaFolder)
+        // The collapse is reflected locally immediately.
+        withTimeout(10_000) {
+            while (alphaFolder in readyExpanded(vm1)) delay(100L)
+        }
+
+        // --- Phase 2: confirm the collapse PERSISTED host-side over a FRESH SSH
+        // session (the app-kill-equivalent: the registry is host state, read with
+        // a brand-new connection). ---
+        withTimeout(20_000) {
+            // The upsert is fire-and-forget; poll the host registry until it
+            // reflects the collapse (or fail loud after the window).
+            var sawCollapse = false
+            val deadline = System.currentTimeMillis() + 15_000
+            while (System.currentTimeMillis() < deadline) {
+                val got = connect().use { session ->
+                    session.exec(
+                        "printf '%s' '{\"host\":\"$hostName\"}' | pocketshell tree get",
+                    )
+                }
+                if (got.exitCode == 0 &&
+                    got.stdout.contains("\"session\": \"$alphaSession\"") &&
+                    registryMarksFolderCollapsed(got.stdout, alphaSession)
+                ) {
+                    sawCollapse = true
+                    break
+                }
+                delay(500L)
+            }
+            assertTrue(
+                "the collapsed alpha folder must be PERSISTED to the host-side " +
+                    "registry (durable across a fresh SSH session)",
+                sawCollapse,
+            )
+        }
+
+        // --- Phase 3: app kill + relaunch — a BRAND-NEW VM + a NEW TreeRemoteSource
+        // bind the same host. The cold-start hydrate reads the held order/collapse
+        // from the daemon and renders it; the collapsed folder STAYS collapsed. ---
+        viewModelStore.clear() // simulate the process death tearing down vm1
+        val vm2 = newViewModel()
+        vm2.setProcessStartedForTest(true)
+        bind(vm2, host)
+
+        val ready2 = awaitReadyWithSessions(vm2, setOf(alphaSession, betaSession))
+        // The LOAD-BEARING daemon-hydrate assertion: a folder collapsed before the
+        // kill must stay collapsed after the relaunch — restored from the durable
+        // host registry, NOT any client cache (this VM has none).
+        assertFalse(
+            "a folder collapsed before the app kill MUST stay collapsed after " +
+                "relaunch (daemon-hydrated) — expanded=${ready2.expandedProjectPaths}",
+            alphaFolder in ready2.expandedProjectPaths,
+        )
+
+        // --- Phase 4: a refresh reconciles gone/added as DELTAS. Kill beta
+        // out-of-band; a resume-when-stale fires the daemon `tree.reconcile`,
+        // which diffs the registry against the LIVE `tmuxctl list` and prunes beta
+        // as a gone DELTA (no full reload). ---
+        withTimeout(20_000) {
+            connect().use { session ->
+                session.exec("tmux kill-session -t $betaSession")
+            }
+        }
+        // Drive a resume-when-stale: background → foreground past the freshen
+        // window so maybeReconcileOnResume takes the daemon delta path.
+        vm2.forceTreeStaleForTest()
+        vm2.setProcessStartedForTest(false)
+        delay(200L)
+        vm2.setProcessStartedForTest(true)
+
+        withTimeout(30_000) {
+            while (true) {
+                val s = vm2.state.value
+                if (s is FolderListUiState.Ready &&
+                    s.flatSessions.none { it.sessionName == betaSession } &&
+                    s.flatSessions.any { it.sessionName == alphaSession }
+                ) {
+                    break
+                }
+                delay(250L)
+            }
+        }
+        val afterPrune = vm2.state.value as FolderListUiState.Ready
+        assertTrue(
+            "the killed beta session must be PRUNED by the daemon reconcile delta — " +
+                "sessions=${afterPrune.flatSessions.map { it.sessionName }}",
+            afterPrune.flatSessions.none { it.sessionName == betaSession } &&
+                afterPrune.flatSessions.any { it.sessionName == alphaSession },
+        )
+        // The collapse survives the reconcile too (still collapsed).
+        assertFalse(
+            "the collapse must survive the reconcile — expanded=" +
+                "${afterPrune.expandedProjectPaths}",
+            alphaFolder in afterPrune.expandedProjectPaths,
+        )
+
+        // --- Phase 5: a newly-ADDED session is picked up on refresh (the added
+        // side of the delta). Create a fresh session, then refresh. ---
+        val gammaDir = "$rootDir/gamma"
+        val gammaSession = "issue839-gamma-$suffix"
+        withTimeout(20_000) {
+            connect().use { session ->
+                session.exec("mkdir -p $gammaDir")
+                session.exec("tmux new-session -d -s $gammaSession -c $gammaDir")
+                createdSessions += gammaSession
+            }
+        }
+        vm2.refreshSessions()
+        withTimeout(30_000) {
+            while (true) {
+                val s = vm2.state.value
+                if (s is FolderListUiState.Ready &&
+                    s.flatSessions.any { it.sessionName == gammaSession } &&
+                    !s.isRefreshing
+                ) {
+                    break
+                }
+                delay(250L)
+            }
+        }
+        val afterAdd = vm2.state.value as FolderListUiState.Ready
+        assertTrue(
+            "a newly-added session must be reconciled in — sessions=" +
+                "${afterAdd.flatSessions.map { it.sessionName }}",
+            afterAdd.flatSessions.any { it.sessionName == gammaSession } &&
+                afterAdd.flatSessions.any { it.sessionName == alphaSession },
+        )
+    }
+
+    private fun bind(vm: FolderListViewModel, host: HostEntity) {
+        vm.bind(
+            hostId = host.id,
+            hostName = host.name,
+            hostname = host.hostname,
+            port = host.port,
+            username = host.username,
+            keyPath = keyFile.absolutePath,
+            passphrase = null,
+        )
+    }
+
+    private fun readyExpanded(vm: FolderListViewModel): Set<String> =
+        (vm.state.value as? FolderListUiState.Ready)?.expandedProjectPaths ?: emptySet()
+
+    private suspend fun awaitReadyWithSessions(
+        vm: FolderListViewModel,
+        expected: Set<String>,
+    ): FolderListUiState.Ready {
+        withTimeout(40_000) {
+            while (true) {
+                val s = vm.state.value
+                if (s is FolderListUiState.Ready &&
+                    expected.all { name -> s.flatSessions.any { it.sessionName == name } }
+                ) {
+                    return@withTimeout
+                }
+                delay(250L)
+            }
+        }
+        return vm.state.value as FolderListUiState.Ready
+    }
+
+    private suspend fun connect() = SshConnection.connect(
+        host = DEFAULT_HOST,
+        port = DAEMON_PORT,
+        user = DEFAULT_USER,
+        key = sshKey,
+        knownHosts = KnownHostsPolicy.AcceptAll,
+        timeoutMs = 10_000,
+    ).getOrThrow()
+
+    /**
+     * Parse the `pocketshell tree get` JSON envelope and report whether [session]'s
+     * node carries `"collapsed": true`. A small string scan (no JSON dep here)
+     * keyed off the session name so it is robust to whitespace / key order.
+     */
+    private fun registryMarksFolderCollapsed(stdout: String, session: String): Boolean {
+        val root = runCatching { org.json.JSONObject(stdout.trim()) }.getOrNull() ?: return false
+        val nodes = root.optJSONArray("nodes") ?: return false
+        for (i in 0 until nodes.length()) {
+            val node = nodes.optJSONObject(i) ?: continue
+            if (node.optString("session") == session) {
+                return node.optBoolean("collapsed", false)
+            }
+        }
+        return false
+    }
+
+    private fun newViewModel(): FolderListViewModel {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        return FolderListViewModel(
+            gateway = SshFolderListGateway(),
+            hostDao = db.hostDao(),
+            projectRootDao = db.projectRootDao(),
+            forwardingController = ForwardingController(context),
+            // A REAL TreeRemoteSource so the cold-start hydrate + persist +
+            // resume-reconcile all exercise the genuine `pocketshell tree` daemon
+            // on the host. NO treeClientCache: this isolates the DAEMON durable
+            // path (#837/#839) from the client-side instant-render cache (#867),
+            // so the relaunch's instant collapse can only come from the host.
+            treeRemoteSource = TreeRemoteSource(),
+            attachLifecycle = false,
+        ).also { vm ->
+            viewModelStore.put("FolderListViewModel-${nextViewModelKey++}", vm)
+        }
+    }
+
+    private companion object {
+        const val DAEMON_PORT: Int = 2239
+    }
+}

--- a/app/src/androidTest/java/com/pocketshell/app/proof/BackgroundGraceReconnectE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/BackgroundGraceReconnectE2eTest.kt
@@ -35,6 +35,7 @@ import com.pocketshell.core.ssh.SshConnection
 import com.pocketshell.core.ssh.SshKey
 import com.pocketshell.core.storage.AppDatabase
 import com.pocketshell.core.storage.entity.HostEntity
+import com.pocketshell.core.tmux.TmuxClientDiagnostics
 import com.termux.view.TerminalView
 import kotlinx.coroutines.runBlocking
 import org.junit.After
@@ -89,6 +90,15 @@ class BackgroundGraceReconnectE2eTest {
     private lateinit var fixtureKey: String
     private lateinit var hostRowTag: String
     private var diagnostics: RecordingDiagnosticSink? = null
+
+    // Issue #743 de-flake: observe the LOCAL `-CC` control-client reader exit so
+    // the post-grace foreground can be gated on the local detach genuinely
+    // completing (see [waitForPostGraceLocalDetachSettled]). `tmux_client_reader_exit`
+    // is emitted by the core TmuxClient when its reader thread exits — a stronger
+    // "local detach settled" signal than the REMOTE client-count poll alone, which
+    // can read 0 before the local VM coroutine + the conflating-StateFlow driver
+    // collector have drained `Backgrounded`.
+    private var tmuxDiagnostics: RecordingTmuxDiagnosticSink? = null
     private val timings = mutableListOf<String>()
 
     @Before
@@ -100,6 +110,7 @@ class BackgroundGraceReconnectE2eTest {
         // measured cycle. The pref/override clears that the app reads AT LAUNCH
         // moved into [seedBeforeLaunch] so they precede the rule's launch.
         diagnostics = RecordingDiagnosticSink().also { DiagnosticEvents.install(it) }
+        tmuxDiagnostics = RecordingTmuxDiagnosticSink().also { TmuxClientDiagnostics.install(it) }
     }
 
     /**
@@ -135,6 +146,8 @@ class BackgroundGraceReconnectE2eTest {
         BackgroundGraceTestOverride.setForTest(null)
         diagnostics?.close()
         diagnostics = null
+        tmuxDiagnostics?.close()
+        tmuxDiagnostics = null
         clearLastSessionPrefs()
         clearBackgroundGraceSetting()
         if (::fixtureKey.isInitialized) {
@@ -185,6 +198,24 @@ class BackgroundGraceReconnectE2eTest {
         }
         waitForDiagnostic("terminal_background_teardown", "post-grace teardown")
         waitForClientCountAtMost(0, "post-grace detached")
+        // Issue #743 de-flake: the headline `quickAppSwitch…` flake on a contended
+        // swiftshader box is a deterministic conflation race, NOT a slow render. The
+        // post-grace foreground reattach (`foreground_reattach`) is fired by the
+        // ConnectionEffectDriver ONLY on the controller edge
+        // `current is Reconnecting && previous is Backgrounded`, and the driver collects
+        // a CONFLATING StateFlow. If the test submits `Foreground` (moveToState RESUMED)
+        // before the driver's collector has resumed past `Backgrounded`, the
+        // `Backgrounded -> Reconnecting` edge is conflated away and `foreground_reattach`
+        // NEVER fires -> the test wedges on `waitForDiagnostic("foreground_reattach")`.
+        //
+        // The REMOTE client-count poll above can read 0 before the LOCAL `-CC` reader
+        // has exited and the driver collector has drained `Backgrounded`, so it is not a
+        // sufficient gate. Wait here for the LOCAL detach to genuinely complete (the
+        // core TmuxClient reader thread exiting) + an idle pump, restoring the
+        // production-faithful ordering (real grace is 30-60s, so the controller/driver
+        // is long-settled into `Backgrounded` before any real foreground). HARD-fails if
+        // the local detach never lands — it does not mask a regression.
+        waitForPostGraceLocalDetachSettled("post-grace detached")
         compose.activityRule.scenario.moveToState(Lifecycle.State.RESUMED)
         waitForDiagnostic("background_grace_foreground", "post-grace foreground") {
             it.fields["withinGrace"] == false
@@ -247,44 +278,141 @@ class BackgroundGraceReconnectE2eTest {
         writeTimings()
     }
 
+    /**
+     * Issue #743 de-flake: a plain WALL-CLOCK poll loop, DECOUPLED from the Compose
+     * idling resource.
+     *
+     * `compose.waitUntil` only evaluates its predicate after Compose reaches idle
+     * (it pumps the looper "until idle" between polls). Under heavy software-GL
+     * contention on a loaded box + a continuously-recomposing app, Compose rarely
+     * idles, so the predicate is checked only sporadically and the wait can burn its
+     * entire budget WITHOUT ever observing a signal that already landed — exactly the
+     * `ComposeTimeoutException after 90000ms` wedge reproduced on base at
+     * `attachSeededTmuxSession` (the #470 family the issue predicted). This loop
+     * evaluates `condition()` directly each 100ms iteration regardless of Compose
+     * idle, so a render/state that DID land is seen the moment it lands.
+     *
+     * Still HARD-fails with the labelled stuck condition if the signal never arrives,
+     * so a real regression surfaces (it does not weaken any assertion).
+     */
+    private fun pollUntil(
+        timeoutMs: Long,
+        label: String,
+        // Issue #743: optionally drain queued main-thread work each iteration via the
+        // BOUNDED `waitForIdleSync` (it returns once the queue drains, so it cannot
+        // hang on a never-idle app the way Compose's unbounded `waitForIdle()` can).
+        // This lets a state read via `onActivity` (VM connection status) observe a
+        // value that landed on the main thread. NOTE: Compose-FRAME-dependent UI
+        // signals — recomposition presence, the Termux `TerminalView` interop child
+        // placement, the emulator transcript — use [waitForRender] instead, which
+        // actually drives frames; this idle-decoupled loop is for the remote/sink/VM
+        // reads that the never-idle-Compose wedge (round 2) would otherwise starve.
+        pumpMainLooper: Boolean = true,
+        condition: () -> Boolean,
+    ) {
+        val deadline = SystemClock.elapsedRealtime() + timeoutMs
+        while (SystemClock.elapsedRealtime() < deadline) {
+            if (runCatching { condition() }.getOrDefault(false)) return
+            if (pumpMainLooper) {
+                runCatching { InstrumentationRegistry.getInstrumentation().waitForIdleSync() }
+            }
+            SystemClock.sleep(100)
+        }
+        // Final post-deadline evaluation so a signal that landed in the last sleep
+        // window is not lost to an off-by-one.
+        check(runCatching { condition() }.getOrDefault(false)) {
+            "timed out after ${timeoutMs}ms waiting for: $label"
+        }
+    }
+
+    /**
+     * Issue #743: read a semantics node count tolerantly — return the TRUE count when
+     * the tree is readable, and treat the transient "No compose hierarchies found" ISE
+     * (thrown while the compose root is momentarily absent under cold compose / a
+     * navigation transition — the #470 family) as 0. Returns the real count whenever a
+     * root exists, so it never masks a genuinely-present node.
+     */
+    private fun tolerantNodeCountWithTag(tag: String): Int =
+        runCatching {
+            compose.onAllNodesWithTag(tag, useUnmergedTree = true).fetchSemanticsNodes().size
+        }.getOrDefault(0)
+
+    private fun tolerantNodeCountWithText(text: String): Int =
+        runCatching {
+            compose.onAllNodesWithText(text, useUnmergedTree = true).fetchSemanticsNodes().size
+        }.getOrDefault(0)
+
+    /**
+     * Issue #743: a UI-render wait that DRIVES Compose frames (via `compose.waitUntil`,
+     * which pumps the looper to idle between polls) so a Compose-frame-dependent
+     * signal — recomposition of a presence node, and crucially the Termux `TerminalView`
+     * AndroidView interop child being PLACED + laid out into the resumed activity — can
+     * actually advance. The reliably-attaching EmulatorDockerSshSmokeTest uses the same
+     * frame-driving wait; a purely idle-DECOUPLED wall-clock poll never advances the
+     * interop placement and wedges at "terminal view attached" even though tmux is ready.
+     *
+     * The `condition` is wrapped in `runCatching` so the transient "No compose
+     * hierarchies found" ISE (the #470 family, thrown while the compose root is
+     * momentarily absent under cold compose / a navigation transition) is treated as
+     * "keep waiting" rather than escaping. On timeout it re-checks once and HARD-fails
+     * with the labelled stuck condition, so a real regression still surfaces.
+     */
+    private fun waitForRender(timeoutMs: Long, label: String, condition: () -> Boolean) {
+        runCatching {
+            compose.waitUntil(timeoutMillis = timeoutMs) {
+                runCatching { condition() }.getOrDefault(false)
+            }
+        }
+        check(runCatching { condition() }.getOrDefault(false)) {
+            "timed out after ${timeoutMs}ms waiting for: $label"
+        }
+    }
+
     private fun attachSeededTmuxSession(hostRowTag: String) {
-        // Issue #788: cold-compose-aware presence budget + tolerate the transient
-        // "No compose hierarchies found" ISE on the first frames under
-        // createAndroidComposeRule (MainActivity cold compose can take ~28s on a
-        // contended swiftshader emulator). Early-exits the instant the row appears.
-        compose.waitUntil(timeoutMillis = TerminalTestTimeouts.screenRenderPresenceTimeoutMs()) {
-            runCatching {
-                compose.onAllNodesWithTag(hostRowTag, useUnmergedTree = true)
-                    .fetchSemanticsNodes()
-                    .isNotEmpty()
-            }.getOrDefault(false)
+        // Issue #788 + #743: cold-compose-aware presence budget on a FRAME-DRIVING wait
+        // ([waitForRender]) so the awaited node's recomposition actually advances. The
+        // wait early-exits the instant the node appears and tolerates the transient
+        // "No compose hierarchies found" ISE under cold compose (the #470 family).
+        waitForRender(TerminalTestTimeouts.screenRenderPresenceTimeoutMs(), "host row '$hostRowTag' present") {
+            tolerantNodeCountWithTag(hostRowTag) > 0
         }
         compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick()
-        compose.waitUntil(timeoutMillis = TerminalTestTimeouts.screenRenderPresenceTimeoutMs()) {
-            runCatching {
-                compose.onAllNodesWithText(SESSION_NAME, useUnmergedTree = true)
-                    .fetchSemanticsNodes()
-                    .isNotEmpty()
-            }.getOrDefault(false)
+        waitForRender(TerminalTestTimeouts.screenRenderPresenceTimeoutMs(), "session row '$SESSION_NAME' present") {
+            tolerantNodeCountWithText(SESSION_NAME) > 0
         }
         compose.onNodeWithText(SESSION_NAME, useUnmergedTree = true).performClick()
-        compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertExists()
+        waitForRender(TerminalTestTimeouts.screenRenderPresenceTimeoutMs(), "session screen present") {
+            tolerantNodeCountWithTag(TMUX_SESSION_SCREEN_TAG) > 0
+        }
         waitForTerminalViewAttached()
     }
 
     private fun waitForTerminalViewAttached() {
-        compose.waitUntil(timeoutMillis = 30_000) {
-            var attached = false
-            compose.activityRule.scenario.onActivity { activity ->
-                val view = activity.window.decorView.findTerminalView()
-                attached = view?.currentSession != null && view.mEmulator != null
-            }
-            attached
+        // Issue #743 de-flake: the Termux TerminalView is an AndroidView interop child
+        // whose PLACEMENT into the resumed activity REQUIRES Compose frames to run — so
+        // this wait MUST drive frames ([waitForRender], not the idle-decoupled
+        // [pollUntil]); an idle-decoupled poll observes tmux "panes ready" yet never
+        // sees the interop child because no frame placed it (the round-4 / #470 stall).
+        // The old hardcoded 30s was NOT CI/contention-aware — reuse the #788 cold-compose
+        // presence budget (90s local / 150s CI), which EARLY-EXITS the instant the view
+        // attaches, so a fast emulator pays nothing. Stays under the 300s
+        // ci-journey-suite.sh watchdog.
+        waitForRender(TerminalTestTimeouts.screenRenderPresenceTimeoutMs(), "terminal view attached") {
+            terminalViewAttached()
         }
     }
 
+    private fun terminalViewAttached(): Boolean {
+        var attached = false
+        compose.activityRule.scenario.onActivity { activity ->
+            val view = activity.window.decorView.findTerminalView()
+            attached = view?.currentSession != null && view.mEmulator != null
+        }
+        return attached
+    }
+
     private fun waitForConnected(label: String) {
-        compose.waitUntil(timeoutMillis = CONNECTED_TIMEOUT_MS) {
+        pollUntil(CONNECTED_TIMEOUT_MS, "Connected after $label") {
             currentConnectionStatus() is TmuxSessionViewModel.ConnectionStatus.Connected
         }
         assertTrue(
@@ -309,8 +437,13 @@ class BackgroundGraceReconnectE2eTest {
         timeoutMillis: Long = TerminalTestTimeouts.terminalVisibilityTimeoutMs(),
         predicate: (String) -> Boolean,
     ): String {
+        // Issue #743 de-flake: the visible transcript comes from the Termux
+        // TerminalView's emulator screen, which only advances as Compose frames drive
+        // the interop child — so this MUST be a frame-driving wait ([waitForRender]),
+        // not the idle-decoupled [pollUntil]. Early-exits the instant the predicate
+        // matches; reads the live transcript via `onActivity` each iteration.
         var last = ""
-        compose.waitUntil(timeoutMillis = timeoutMillis) {
+        waitForRender(timeoutMillis, "visible terminal for $label") {
             last = visibleTerminalText()
             last.isNotBlank() && predicate(last)
         }
@@ -501,6 +634,52 @@ class BackgroundGraceReconnectE2eTest {
             SystemClock.sleep(100)
         }
         error("expected at least $min tmux clients for $label, got $lastCount; raw=`$lastRaw`")
+    }
+
+    /**
+     * Issue #743 de-flake: gate the post-grace foreground on the LOCAL `-CC`
+     * control-client detach genuinely completing, so the conflating-StateFlow
+     * driver collector has drained `Backgrounded` before `Foreground` is
+     * submitted (see the call site for the conflation explanation).
+     *
+     * The clean background teardown ([TmuxSessionViewModel.closeCurrentConnectionAndJoin],
+     * launched by the driver's Backgrounded effect) closes the local `-CC` client,
+     * whose reader thread then exits and emits `tmux_client_reader_exit` via
+     * [TmuxClientDiagnostics]. Waiting for that event proves the LOCAL detach
+     * actually finished — a stronger signal than the REMOTE client-count poll,
+     * which can read 0 while the local coroutine + driver collector are still in
+     * flight.
+     *
+     * After the local detach lands, pump both the instrumentation idle loop and a
+     * short settle so any pending Main-loop turns (the driver collector resuming on
+     * `Backgrounded`, the `previous = Backgrounded` assignment) have drained before
+     * the foreground submit.
+     *
+     * HARD-fails if the local detach never lands — it does NOT mask a regression; a
+     * foreground that genuinely fails to reattach still times out on the downstream
+     * `waitForDiagnostic("foreground_reattach")`.
+     */
+    private fun waitForPostGraceLocalDetachSettled(label: String) {
+        val sink = tmuxDiagnostics
+            ?: error("tmux diagnostics sink not installed for $label")
+        val deadline = SystemClock.elapsedRealtime() + LOCAL_DETACH_SETTLE_TIMEOUT_MS
+        var sawReaderExit = false
+        while (SystemClock.elapsedRealtime() < deadline) {
+            if (sink.eventsNamed("tmux_client_reader_exit").isNotEmpty()) {
+                sawReaderExit = true
+                break
+            }
+            SystemClock.sleep(50)
+        }
+        check(sawReaderExit) {
+            "expected the local -CC reader to exit (tmux_client_reader_exit) during " +
+                "$label before foregrounding; tmux events=${sink.events}"
+        }
+        // Drain pending Main-loop turns so the conflating driver collector has
+        // resumed past `Backgrounded` before the foreground submit.
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        SystemClock.sleep(LOCAL_DETACH_SETTLE_PUMP_MS)
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
     }
 
     private suspend fun waitForClientCountAtMost(max: Int, label: String) {
@@ -696,8 +875,28 @@ class BackgroundGraceReconnectE2eTest {
         const val POST_GRACE_MS: Long = 500L
         const val SIX_SECOND_APP_SWITCH_MS: Long = 6_000L
         const val WATCH_NO_RECONNECT_MS: Long = 1_200L
-        const val DIAGNOSTIC_TIMEOUT_MS: Long = 8_000L
-        const val CLIENT_COUNT_TIMEOUT_MS: Long = 8_000L
+
+        // Issue #743 de-flake: the flat 8s budgets were a secondary contended-box
+        // flake source. Each remote `tmux list-clients` probe opens a FRESH SSH
+        // connection (see [listClientsRaw]); on a contended swiftshader box that
+        // single connect can take several seconds, and the diagnostic round-trips
+        // (e.g. the post-grace teardown chain) are equally slowed. These loops
+        // EARLY-EXIT on the deterministic signal, so a fast box pays nothing — only
+        // a contended/CI box consumes the headroom. They stay well under the 300s
+        // per-test `ci-journey-suite.sh` watchdog and are sequential (the first
+        // wedged step fails immediately, so they cannot stack toward 300s).
+        val DIAGNOSTIC_TIMEOUT_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 30_000L else 12_000L
+        val CLIENT_COUNT_TIMEOUT_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 30_000L else 12_000L
+
+        // Issue #743 de-flake: budget for the local `-CC` reader exit to land after
+        // the driver-owned background teardown is launched (see
+        // [waitForPostGraceLocalDetachSettled]). Early-exits on the
+        // `tmux_client_reader_exit` signal, so a fast box pays nothing.
+        val LOCAL_DETACH_SETTLE_TIMEOUT_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 30_000L else 12_000L
+        const val LOCAL_DETACH_SETTLE_PUMP_MS: Long = 250L
 
         val CONNECTED_TIMEOUT_MS: Long =
             if (TerminalTestTimeouts.isRunningOnCi()) 30_000L else 15_000L

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/AgentConversationReconnectDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/AgentConversationReconnectDockerTest.kt
@@ -3,6 +3,8 @@ package com.pocketshell.app.tmux
 import android.os.SystemClock
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.connectivity.TerminalNetworkChange
+import com.pocketshell.app.connectivity.TerminalNetworkSnapshot
 import com.pocketshell.app.proof.DEFAULT_HOST
 import com.pocketshell.app.proof.DEFAULT_PORT
 import com.pocketshell.app.proof.DEFAULT_USER
@@ -29,6 +31,7 @@ import org.junit.After
 import org.junit.Assume
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -157,6 +160,22 @@ class AgentConversationReconnectDockerTest {
             key,
             buildString {
                 appendLine("set -eu")
+                // Issue #819 (A2): the fixture pre-seeds the JSONL only for the
+                // old `/workspace`-encoded project dir. On the home-dir-rebased
+                // cwd we create the encoded project dir + seed a minimal Claude
+                // transcript ourselves so per-pane detection has a candidate to
+                // bind, then refresh its mtime into the recency window.
+                appendLine("mkdir -p ${shellQuote(claudeProjectDir(CLAUDE_PATH))}")
+                appendLine("if [ ! -s ${shellQuote(CLAUDE_PATH)} ]; then")
+                appendLine(
+                    "  printf '%s\\n' " +
+                        shellQuote(
+                            "{\"uuid\":\"claude-user-1\",\"timestamp\":\"2026-05-22T10:00:00Z\"," +
+                                "\"message\":{\"role\":\"user\",\"content\":\"inspect the failing tests\"}}",
+                        ) +
+                        " > ${shellQuote(CLAUDE_PATH)}",
+                )
+                appendLine("fi")
                 appendLine("touch ${shellQuote(CLAUDE_PATH)}")
                 // The detector derives Claude's encoded project dir from the
                 // pane cwd, so the pane must actually sit in REMOTE_CWD.
@@ -177,6 +196,17 @@ class AgentConversationReconnectDockerTest {
                     "tmux new-session -d -x 80 -y 24 -s ${shellQuote(sessionName)} " +
                         "-c ${shellQuote(REMOTE_CWD)} ${shellQuote(wrapperPath)}",
                 )
+                // Record the agent kind on the session (the #825 launch wrapper
+                // does this for PocketShell-launched sessions), so post-#826
+                // detection resolves via the deterministic RECORDED-identity path
+                // (readRecordedAgentKind → recorded source) rather than the
+                // cgroup/proc daemon kind-guess. Without it this fixture's
+                // claude-named sleep process is NOT in a pocketshell agent cgroup
+                // scope (`/proc/<pid>/cgroup` is `0::/`), so the daemon returns
+                // `unknown` and detection NEVER lands — the test would time out at
+                // the `waitForAgentForWindow` precondition before any A2 assertion
+                // runs. Mirrors the sibling `agentOpensOnDefaultView…` setup.
+                appendLine("tmux set-option -t ${shellQuote(sessionName)} @ps_agent_kind claude")
                 appendLine("sleep 1")
                 appendLine("tmux list-panes -t ${shellQuote(sessionName)} -F '#{pane_id} #{pane_tty} #{pane_current_command}'")
             },
@@ -255,6 +285,29 @@ class AgentConversationReconnectDockerTest {
             stamp("force_reconnect_via_transport_drop_then_auto_reconnect")
             killControlClientSshConnection(key, sessionName)
 
+            // Drive the FOREGROUND proactive reconnect with a real
+            // validated-network handoff (the production path a phone takes on a
+            // wifi→cell switch), mirroring the working `SshReconnectE2eTest`.
+            // Under instrumentation the app's process-foreground signal is
+            // false, so the bare EOF now goes through the post-#926
+            // passive-disconnect GRACE path and is SUPPRESSED (single-grace-
+            // owner) — the auto-reconnect is gated off until a foreground
+            // signal arrives, which is why the kill alone left the VM parked on
+            // `Connected` with `disconnected=true` (observed in logcat:
+            // `PsConnEffectDriver tmux.disconnected=true SUPPRESSED`). The
+            // network handoff is the genuine foreground reconnect trigger and
+            // makes the fresh re-attach (new pane ids, empty conversation map)
+            // fire deterministically.
+            vm.onNetworkChanged(
+                TerminalNetworkChange(
+                    previous = TerminalNetworkSnapshot.Validated("wifi"),
+                    current = TerminalNetworkSnapshot.Validated("cell"),
+                    previousValidated = TerminalNetworkSnapshot.Validated("wifi"),
+                    reason = "validated-default-network-changed",
+                    sequence = 1L,
+                ),
+            )
+
             // The VM observes the dead socket and enters Reconnecting, then a
             // fresh connect attempt fires. Bound it loudly so a drop that is
             // never observed is a clear failure, not a hang.
@@ -297,34 +350,54 @@ class AgentConversationReconnectDockerTest {
 
             // CORE ASSERTION: the moment panes land, the remembered agent
             // status is restored — the Conversation tab is available and the
-            // user is back on Conversation — WITHOUT waiting for live
-            // re-detection. Bound it: the restore is seeded synchronously in
-            // applyParsedPanes, so it must hold within a short grace window.
+            // user is back on Conversation — WITHOUT bouncing to Terminal. The
+            // restore is seeded synchronously in applyParsedPanes.
+            //
+            // Issue #819 (Slice A2): the reattach seed is a detection-LESS
+            // RESOLVING placeholder (rememberedAgentPlaceholder = true,
+            // detection == null), NOT the remembered detection rendered Live —
+            // so it never re-shows a stale/sibling source before live
+            // re-detection re-anchors the route-true one. Because this fixture
+            // records `@ps_agent_kind claude`, live re-detection resolves via the
+            // deterministic single-round-trip recorded-Claude path and can bind
+            // the route-true source FAST — sometimes before the 5s checkpoint —
+            // so the resolving-placeholder phase may be brief. The load-bearing
+            // A2 property is the same either way: the restored Conversation
+            // source is ALWAYS the route-true source, NEVER a stale/sibling one.
+            // So we observe the row right at reattach and accept EITHER (a) the
+            // resolving placeholder (detection-less, route-true source not yet
+            // shown) OR (b) the already-bound route-true Claude source — but
+            // NEVER any OTHER source. Poll fast to catch the transient.
+            var sawResolvingPlaceholder = false
             waitForCondition(
-                "agent status restored immediately on reattach from memory",
+                "agent status restored on Conversation after reattach (A2 re-anchor)",
                 timeoutMs = IMMEDIATE_RESTORE_TIMEOUT_MS,
                 describe = {
                     "agent status NOT restored on reattach (pane=$reattachedPaneId, " +
                         "window=$windowId); conversations=${vm.agentConversations.value.keys}, " +
-                        "agentForWindow=${vm.agentForWindow(windowId)}"
+                        "row=${vm.agentConversations.value[reattachedPaneId]}"
                 },
             ) {
-                val restored = vm.agentConversations.value[reattachedPaneId]
-                restored != null &&
-                    vm.agentForWindow(windowId) == AgentKind.ClaudeCode &&
-                    restored.selectedTab == SessionTab.Conversation
+                val row = vm.agentConversations.value[reattachedPaneId]
+                if (row?.rememberedAgentPlaceholder == true && row.detection == null) {
+                    sawResolvingPlaceholder = true
+                }
+                // The restore landed once the row exists on Conversation and is
+                // EITHER the A2 resolving placeholder OR has bound the route-true
+                // Claude source (the fast recorded path).
+                row != null &&
+                    row.selectedTab == SessionTab.Conversation &&
+                    (
+                        (row.rememberedAgentPlaceholder && row.detection == null) ||
+                            (row.detection?.agent == AgentKind.ClaudeCode && row.detection?.sourcePath == CLAUDE_PATH)
+                    )
             }
             val restored = vm.agentConversations.value[reattachedPaneId]
             assertNotNull(
-                "agent status must be restored immediately on reattach " +
+                "agent status must be restored on reattach " +
                     "(pane=$reattachedPaneId, window=$windowId); " +
                     "conversations=${vm.agentConversations.value.keys}",
                 restored,
-            )
-            assertEquals(
-                "Conversation tab must be available immediately on reattach",
-                AgentKind.ClaudeCode,
-                vm.agentForWindow(windowId),
             )
             assertEquals(
                 "user who was in Conversation must stay on Conversation after reconnect " +
@@ -332,10 +405,42 @@ class AgentConversationReconnectDockerTest {
                 SessionTab.Conversation,
                 restored!!.selectedTab,
             )
-            stamp("immediate_restore_ok selectedTab=${restored.selectedTab}")
+            // The load-bearing A2 assertion: the restored row NEVER shows a
+            // stale/sibling source. Whichever phase we observed:
+            //  - resolving placeholder: detection is null (no source shown yet);
+            //  - bound: the source is the ROUTE-TRUE Claude JSONL, not another.
+            // The OLD blind-restore (the #819 bug) would have carried whatever
+            // `remembered.detection.sourcePath` was, rendered Live immediately.
+            if (restored.detection == null) {
+                assertTrue(
+                    "#819 (A2): a detection-less restored row must be the remembered-agent " +
+                        "resolving placeholder (held until live re-detection re-anchors), " +
+                        "not a torn-down/blank row",
+                    restored.rememberedAgentPlaceholder,
+                )
+            } else {
+                assertEquals(
+                    "#819 (A2): the restored row's bound source must be the ROUTE-TRUE " +
+                        "Claude session, never a stale/sibling rollout",
+                    CLAUDE_PATH,
+                    restored.detection!!.sourcePath,
+                )
+            }
+            stamp(
+                "immediate_restore_ok selectedTab=${restored.selectedTab} " +
+                    "sawResolvingPlaceholder=$sawResolvingPlaceholder " +
+                    "detection=${restored.detection?.sourcePath}",
+            )
 
-            // Live re-detection confirms; assert it does not bounce the user.
+            // Live re-detection confirms; assert it re-anchors the route-true
+            // source (agentForWindow becomes ClaudeCode) and does not bounce the
+            // user off Conversation.
             waitForAgentForWindow(vm, windowId, "post-reattach live re-detection")
+            assertEquals(
+                "#819 (A2): live re-detection binds the route-true Claude source",
+                AgentKind.ClaudeCode,
+                vm.agentForWindow(windowId),
+            )
             assertEquals(
                 "live re-detection must keep the user on Conversation",
                 SessionTab.Conversation,
@@ -1234,10 +1339,23 @@ class AgentConversationReconnectDockerTest {
     private fun shellQuote(value: String): String =
         "'" + value.replace("'", "'\"'\"'") + "'"
 
+    /** Parent directory of a Claude JSONL transcript path. */
+    private fun claudeProjectDir(jsonlPath: String): String =
+        jsonlPath.substringBeforeLast('/')
+
     private companion object {
+        // Issue #819 (A2): rebased off `/workspace/pocketshell` onto the
+        // WRITABLE home dir. The `agents` fixture does NOT provision
+        // `/workspace`, and `testuser` cannot create it, so the old setup
+        // failed at `mkdir -p /workspace/pocketshell` (Permission denied)
+        // BEFORE any A2 assertion ran — a pre-existing fixture gap the sibling
+        // `conversationTapIsHonouredBeforeDetectionLands` test already avoids by
+        // using the home dir. The Claude project-dir encoding follows the cwd
+        // (`encodeClaudeCwd`: `/`→`-`), so `/home/testuser/pocketshell` maps to
+        // `.claude/projects/-home-testuser-pocketshell/`.
+        const val REMOTE_CWD: String = "/home/testuser/pocketshell"
         const val CLAUDE_PATH: String =
-            "/home/testuser/.claude/projects/-workspace-pocketshell/pocketshell-claude.jsonl"
-        const val REMOTE_CWD: String = "/workspace/pocketshell"
+            "/home/testuser/.claude/projects/-home-testuser-pocketshell/pocketshell-claude.jsonl"
 
         /**
          * Ceiling for the VM to observe the server-side transport drop and

--- a/app/src/main/java/com/pocketshell/app/cards/SessionCardRenderers.kt
+++ b/app/src/main/java/com/pocketshell/app/cards/SessionCardRenderers.kt
@@ -1,0 +1,209 @@
+package com.pocketshell.app.cards
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.pocketshell.uikit.theme.PocketShellColors
+import com.pocketshell.uikit.theme.PocketShellShapes
+import com.pocketshell.uikit.theme.PocketShellSpacing
+import com.pocketshell.uikit.theme.PocketShellType
+
+/**
+ * Issue #859 Slice B: the typed-card **renderer registry**.
+ *
+ * The session feed is a heterogeneous list of [SessionCardsRemoteSource.SessionCard]s
+ * of different `type`s. Rather than a `when (card.type)` ladder embedded in the
+ * feed sheet (the half-built checklist-only state before this slice), the feed
+ * dispatches each card to the [SessionCardRenderer] registered for its `type`.
+ *
+ * Adding a new card type (e.g. `note`) is exactly: register one
+ * [SessionCardRenderer] in [SessionCardRenderers]. The feed sheet
+ * ([SessionCardFeedContent]) never changes — it asks the registry for the
+ * renderer and calls [SessionCardRenderer.Render]. This mirrors the host-side
+ * `CardType` registry in `cards.py`, so the host and app stay symmetrically
+ * extensible (hard-cut per D22: there is one dispatch site, the registry).
+ *
+ * A genuinely unknown type falls back to [UnknownCardRenderer], a graceful
+ * "unsupported card" row — forward-compat for a future host type the app build
+ * does not yet know about.
+ */
+
+/** Callbacks a renderer may invoke for the human's interaction with a card. */
+@Stable
+internal interface SessionCardInteractions {
+    /** Tick/untick a checklist item. */
+    fun onToggleChecklistItem(cardId: String, itemId: String, checked: Boolean)
+
+    /** Mark a note read/unread. */
+    fun onSetNoteRead(cardId: String, read: Boolean)
+}
+
+/** Renders one [type] of [SessionCardsRemoteSource.SessionCard]. */
+internal interface SessionCardRenderer {
+    /** The card `type` this renderer handles (the registry key). */
+    val type: String
+
+    @Composable
+    fun Render(
+        card: SessionCardsRemoteSource.SessionCard,
+        interactions: SessionCardInteractions,
+        modifier: Modifier,
+    )
+}
+
+/**
+ * The renderer registry, keyed by card `type`. The single dispatch site for the
+ * feed. New types register here; the feed never special-cases a type.
+ */
+internal object SessionCardRenderers {
+
+    private val byType: Map<String, SessionCardRenderer> = listOf(
+        ChecklistCardRenderer,
+        NoteCardRenderer,
+    ).associateBy { it.type }
+
+    /**
+     * The renderer for [type], or [UnknownCardRenderer] when no registered
+     * renderer claims it (forward-compat: a future host type renders as a
+     * graceful "unsupported" row rather than vanishing).
+     */
+    fun rendererFor(type: String): SessionCardRenderer =
+        byType[type] ?: UnknownCardRenderer
+
+    /** Test/introspection seam: the set of types with a real renderer. */
+    fun registeredTypes(): Set<String> = byType.keys
+}
+
+internal const val SESSION_NOTE_CARD_TAG_PREFIX: String = "session:note:card:"
+internal const val SESSION_NOTE_READ_TOGGLE_TAG_PREFIX: String = "session:note:read:"
+internal const val SESSION_UNKNOWN_CARD_TAG_PREFIX: String = "session:card:unknown:"
+
+// ---------------------------------------------------------------------------
+// checklist renderer — the existing checklist rows, now a registered renderer
+// ---------------------------------------------------------------------------
+
+internal object ChecklistCardRenderer : SessionCardRenderer {
+    override val type: String = SessionCardsRemoteSource.TYPE_CHECKLIST
+
+    @Composable
+    override fun Render(
+        card: SessionCardsRemoteSource.SessionCard,
+        interactions: SessionCardInteractions,
+        modifier: Modifier,
+    ) {
+        val checklist = card as? SessionCardsRemoteSource.ChecklistCard ?: return
+        ChecklistCardRows(
+            card = checklist,
+            onToggle = interactions::onToggleChecklistItem,
+            modifier = modifier,
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// note renderer (#859 Slice B — proves the registry is genuinely generic)
+// ---------------------------------------------------------------------------
+
+internal object NoteCardRenderer : SessionCardRenderer {
+    override val type: String = SessionCardsRemoteSource.TYPE_NOTE
+
+    @Composable
+    override fun Render(
+        card: SessionCardsRemoteSource.SessionCard,
+        interactions: SessionCardInteractions,
+        modifier: Modifier,
+    ) {
+        val note = card as? SessionCardsRemoteSource.NoteCard ?: return
+        Column(
+            modifier = modifier
+                .fillMaxWidth()
+                .background(PocketShellColors.SurfaceElev, PocketShellShapes.small)
+                .padding(PocketShellSpacing.sm)
+                .testTag(SESSION_NOTE_CARD_TAG_PREFIX + note.id),
+        ) {
+            if (!note.title.isNullOrBlank()) {
+                Text(
+                    text = note.title,
+                    color = PocketShellColors.Text,
+                    style = PocketShellType.bodyDense,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.padding(horizontal = PocketShellSpacing.sm),
+                )
+            }
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { interactions.onSetNoteRead(note.id, !note.read) }
+                    .padding(vertical = 2.dp)
+                    .testTag(SESSION_NOTE_READ_TOGGLE_TAG_PREFIX + note.id),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Checkbox(
+                    checked = note.read,
+                    onCheckedChange = { next -> interactions.onSetNoteRead(note.id, next) },
+                )
+                Text(
+                    text = note.text,
+                    color = PocketShellColors.Text,
+                    style = PocketShellType.bodyDense,
+                    modifier = Modifier.weight(1f),
+                )
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// unknown renderer — graceful "unsupported card" row (forward-compat)
+// ---------------------------------------------------------------------------
+
+internal object UnknownCardRenderer : SessionCardRenderer {
+    // Not a real card type; never used as a registry key.
+    override val type: String = "__unknown__"
+
+    @Composable
+    override fun Render(
+        card: SessionCardsRemoteSource.SessionCard,
+        interactions: SessionCardInteractions,
+        modifier: Modifier,
+    ) {
+        Column(
+            modifier = modifier
+                .fillMaxWidth()
+                .background(PocketShellColors.SurfaceElev, PocketShellShapes.small)
+                .padding(PocketShellSpacing.sm)
+                .testTag(SESSION_UNKNOWN_CARD_TAG_PREFIX + card.id),
+            verticalArrangement = Arrangement.spacedBy(2.dp),
+        ) {
+            Text(
+                text = card.title?.takeIf { it.isNotBlank() } ?: card.type,
+                color = PocketShellColors.Text,
+                style = PocketShellType.bodyDense,
+                fontWeight = FontWeight.SemiBold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text(
+                text = "Unsupported card (${card.type}) — update the app to view it.",
+                color = PocketShellColors.TextSecondary,
+                style = PocketShellType.bodyDense,
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/cards/SessionCardsRemoteSource.kt
+++ b/app/src/main/java/com/pocketshell/app/cards/SessionCardsRemoteSource.kt
@@ -49,6 +49,23 @@ public class SessionCardsRemoteSource @Inject constructor() {
         val text: String,
     )
 
+    /**
+     * Issue #859 Slice B: a non-interactive note the agent hands the human.
+     * Its only interaction is mark-as-read; the second registered card type,
+     * proving the renderer registry is genuinely generic (a new type is a
+     * renderer + a parser arm, not a feed rewrite).
+     */
+    public data class NoteCard(
+        override val id: String,
+        override val title: String?,
+        override val createdAt: String?,
+        override val updatedAt: String?,
+        val text: String,
+        val read: Boolean,
+    ) : SessionCard {
+        override val type: String = TYPE_NOTE
+    }
+
     public data class UnknownCard(
         override val id: String,
         override val type: String,
@@ -113,6 +130,35 @@ public class SessionCardsRemoteSource @Inject constructor() {
         }
     }
 
+    /**
+     * Mark a note read/unread over the warm session (D21). Returns `true` only
+     * when the host CLI acknowledges the change. Mirrors
+     * [setChecklistItemChecked]: the registry's second interactive write-back.
+     */
+    public suspend fun setNoteRead(
+        session: SshSession,
+        tmuxSessionName: String,
+        cardId: String,
+        read: Boolean,
+    ): Boolean {
+        val target = tmuxSessionName.trim()
+        if (target.isEmpty() || cardId.isBlank()) return false
+        val readFlag = if (read) "--read" else "--unread"
+        return try {
+            val result = session.exec(
+                PocketshellCommand.wrap(
+                    "push read --id ${shellQuote(cardId)} " +
+                        "$readFlag --session ${shellQuote(target)}",
+                ),
+            )
+            result.exitCode == 0
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Throwable) {
+            false
+        }
+    }
+
     internal fun parseFeed(stdout: String): Feed {
         val trimmed = stdout.trim().ifBlank { return Feed.Empty }
         val root = runCatching { JSONObject(trimmed) }.getOrNull() ?: return Feed.Empty
@@ -133,6 +179,12 @@ public class SessionCardsRemoteSource @Inject constructor() {
             val updatedAt = row.optString("updated_at", "").takeIf { it.isNotBlank() }
             out += when (type) {
                 TYPE_CHECKLIST -> row.toChecklistCard(
+                    id = id,
+                    title = title,
+                    createdAt = createdAt,
+                    updatedAt = updatedAt,
+                )
+                TYPE_NOTE -> row.toNoteCard(
                     id = id,
                     title = title,
                     createdAt = createdAt,
@@ -174,6 +226,26 @@ public class SessionCardsRemoteSource @Inject constructor() {
         )
     }
 
+    private fun JSONObject.toNoteCard(
+        id: String,
+        title: String?,
+        createdAt: String?,
+        updatedAt: String?,
+    ): NoteCard {
+        val body = optJSONObject("body")
+        val state = optJSONObject("state")
+        val text = body?.optString("text", "").orEmpty()
+        val read = state?.optBoolean("read", false) ?: false
+        return NoteCard(
+            id = id,
+            title = title,
+            createdAt = createdAt,
+            updatedAt = updatedAt,
+            text = text,
+            read = read,
+        )
+    }
+
     private fun JSONArray?.toChecklistItems(): List<ChecklistItem> {
         if (this == null) return emptyList()
         val out = ArrayList<ChecklistItem>(length())
@@ -201,5 +273,6 @@ public class SessionCardsRemoteSource @Inject constructor() {
 
     public companion object {
         public const val TYPE_CHECKLIST: String = "checklist"
+        public const val TYPE_NOTE: String = "note"
     }
 }

--- a/app/src/main/java/com/pocketshell/app/cards/SessionChecklistUi.kt
+++ b/app/src/main/java/com/pocketshell/app/cards/SessionChecklistUi.kt
@@ -24,6 +24,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
@@ -42,6 +43,14 @@ internal const val SESSION_CHECKLIST_SHEET_TAG: String = "session:checklist:shee
 internal const val SESSION_CHECKLIST_CARD_TAG_PREFIX: String = "session:checklist:card:"
 internal const val SESSION_CHECKLIST_ITEM_TAG_PREFIX: String = "session:checklist:item:"
 internal const val SESSION_CHECKLIST_CLOSE_TAG: String = "session:checklist:close"
+
+// Issue #859 Slice B: the generic feed chip + sheet (all card types via the
+// renderer registry). The checklist-only chip/sheet below remain for the
+// current single-checklist wiring and are themselves now expressed through the
+// registry's [ChecklistCardRenderer] (no checklist-specific layout duplicated).
+internal const val SESSION_CARD_FEED_CHIP_TAG: String = "session:card-feed-chip"
+internal const val SESSION_CARD_FEED_SHEET_TAG: String = "session:card-feed:sheet"
+internal const val SESSION_CARD_FEED_CLOSE_TAG: String = "session:card-feed:close"
 
 @Immutable
 internal data class ChecklistChipUiState(
@@ -82,6 +91,121 @@ internal fun ChecklistChip(
     )
 }
 
+// ---------------------------------------------------------------------------
+// Generic feed chip (#859 Slice B) — a COUNT chip over ALL card types, not just
+// checklist items. Renders nothing when the feed is empty.
+// ---------------------------------------------------------------------------
+
+@Immutable
+internal data class SessionCardFeedChipUiState(
+    val cardCount: Int,
+) {
+    val hasCards: Boolean
+        get() = cardCount > 0
+}
+
+internal fun cardFeedChipState(
+    cards: List<SessionCardsRemoteSource.SessionCard>,
+): SessionCardFeedChipUiState? {
+    if (cards.isEmpty()) return null
+    return SessionCardFeedChipUiState(cardCount = cards.size)
+}
+
+@Composable
+internal fun SessionCardFeedChip(
+    state: SessionCardFeedChipUiState,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (!state.hasCards) return
+    val label = if (state.cardCount == 1) "1 card" else "${state.cardCount} cards"
+    CommandChip(
+        label = label,
+        onClick = onClick,
+        modifier = modifier.testTag(SESSION_CARD_FEED_CHIP_TAG),
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Generic feed sheet (#859 Slice B) — renders a heterogeneous card list by
+// dispatching each card to its registered renderer. NO `when (type)` here.
+// ---------------------------------------------------------------------------
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun SessionCardFeedSheet(
+    cards: List<SessionCardsRemoteSource.SessionCard>,
+    interactions: SessionCardInteractions,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+    sheetState: SheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+) {
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = PocketShellColors.Surface,
+        contentColor = PocketShellColors.Text,
+        modifier = modifier,
+    ) {
+        SessionCardFeedContent(
+            cards = cards,
+            interactions = interactions,
+            onClose = onDismiss,
+            modifier = Modifier.testTag(SESSION_CARD_FEED_SHEET_TAG),
+        )
+    }
+}
+
+@Composable
+internal fun SessionCardFeedContent(
+    cards: List<SessionCardsRemoteSource.SessionCard>,
+    interactions: SessionCardInteractions,
+    onClose: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .navigationBarsPadding()
+            .imePadding()
+            .padding(horizontal = PocketShellSpacing.lg)
+            .padding(bottom = PocketShellSpacing.lg),
+    ) {
+        SessionCardFeedHeader(
+            title = "Cards",
+            closeTag = SESSION_CARD_FEED_CLOSE_TAG,
+            onClose = onClose,
+        )
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(max = 420.dp),
+            verticalArrangement = Arrangement.spacedBy(PocketShellSpacing.sm),
+        ) {
+            items(cards, key = { it.id }) { card ->
+                // The single dispatch site: ask the registry, render. Adding a
+                // new card type renders here with zero change to this feed.
+                SessionCardRenderers
+                    .rendererFor(card.type)
+                    .Render(
+                        card = card,
+                        interactions = interactions,
+                        modifier = Modifier,
+                    )
+            }
+            item {
+                Spacer(modifier = Modifier.height(PocketShellSpacing.sm))
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Checklist-only sheet — kept for the current single-checklist wiring, but now
+// renders through the registry's [ChecklistCardRenderer] so there is no
+// checklist-specific row layout duplicated outside the renderer (hard-cut D22).
+// ---------------------------------------------------------------------------
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun ChecklistCardsSheet(
@@ -114,6 +238,9 @@ internal fun ChecklistCardsContent(
     onClose: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    // Adapt the checklist-only callback into the generic interactions contract
+    // so the SAME [ChecklistCardRenderer] draws the rows (no duplicated layout).
+    val interactions = remember(onToggle) { checklistOnlyInteractions(onToggle) }
     Column(
         modifier = modifier
             .fillMaxWidth()
@@ -122,35 +249,11 @@ internal fun ChecklistCardsContent(
             .padding(horizontal = PocketShellSpacing.lg)
             .padding(bottom = PocketShellSpacing.lg),
     ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(bottom = 12.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween,
-        ) {
-            Text(
-                text = "Checklist",
-                style = PocketShellType.bodyDense,
-                fontWeight = FontWeight.SemiBold,
-                color = PocketShellColors.Text,
-            )
-            Box(
-                modifier = Modifier
-                    .size(PocketShellDensity.tapTargetMin)
-                    .clickable(onClick = onClose)
-                    .testTag(SESSION_CHECKLIST_CLOSE_TAG),
-                contentAlignment = Alignment.Center,
-            ) {
-                Text(
-                    text = "X",
-                    color = PocketShellColors.TextSecondary,
-                    style = PocketShellType.bodyDense,
-                    fontWeight = FontWeight.SemiBold,
-                )
-            }
-        }
-
+        SessionCardFeedHeader(
+            title = "Checklist",
+            closeTag = SESSION_CHECKLIST_CLOSE_TAG,
+            onClose = onClose,
+        )
         LazyColumn(
             modifier = Modifier
                 .fillMaxWidth()
@@ -158,9 +261,10 @@ internal fun ChecklistCardsContent(
             verticalArrangement = Arrangement.spacedBy(PocketShellSpacing.sm),
         ) {
             items(cards, key = { it.id }) { card ->
-                ChecklistCardRows(
+                ChecklistCardRenderer.Render(
                     card = card,
-                    onToggle = onToggle,
+                    interactions = interactions,
+                    modifier = Modifier,
                 )
             }
             item {
@@ -170,8 +274,59 @@ internal fun ChecklistCardsContent(
     }
 }
 
+private fun checklistOnlyInteractions(
+    onToggle: (cardId: String, itemId: String, checked: Boolean) -> Unit,
+): SessionCardInteractions = object : SessionCardInteractions {
+    override fun onToggleChecklistItem(cardId: String, itemId: String, checked: Boolean) =
+        onToggle(cardId, itemId, checked)
+
+    override fun onSetNoteRead(cardId: String, read: Boolean) = Unit
+}
+
 @Composable
-private fun ChecklistCardRows(
+private fun SessionCardFeedHeader(
+    title: String,
+    closeTag: String,
+    onClose: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(bottom = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(
+            text = title,
+            style = PocketShellType.bodyDense,
+            fontWeight = FontWeight.SemiBold,
+            color = PocketShellColors.Text,
+        )
+        Box(
+            modifier = Modifier
+                .size(PocketShellDensity.tapTargetMin)
+                .clickable(onClick = onClose)
+                .testTag(closeTag),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = "X",
+                color = PocketShellColors.TextSecondary,
+                style = PocketShellType.bodyDense,
+                fontWeight = FontWeight.SemiBold,
+            )
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Checklist card rows — the checklist renderer's layout. `internal` so
+// [ChecklistCardRenderer] in the registry can draw it.
+// ---------------------------------------------------------------------------
+
+@Composable
+internal fun ChecklistCardRows(
     card: SessionCardsRemoteSource.ChecklistCard,
     onToggle: (cardId: String, itemId: String, checked: Boolean) -> Unit,
     modifier: Modifier = Modifier,

--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerSheet.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerSheet.kt
@@ -1299,6 +1299,25 @@ internal fun SheetContent(
                     // The non-transcribing discard action is intentionally in
                     // the recording panel itself, not this row, so it cannot be
                     // confused with either stop+transcribe choice.
+                    //
+                    // Issue #585: a DETERMINISTIC hands-free lock affordance.
+                    // The Telegram-style swipe-up-to-lock gesture (below) is the
+                    // one-gesture path, but it competes with the
+                    // ModalBottomSheet's drag-to-dismiss and that velocity-driven
+                    // arbitration repeatedly failed on the maintainer's real
+                    // device while passing every emulator round (this issue's 5
+                    // reopens). A single-tap Lock button cannot be stolen by the
+                    // sheet drag — it is the device-independent way to "release
+                    // the finger and keep recording". It shows only BEFORE the
+                    // recording is locked (once locked, the recording panel shows
+                    // the persistent lock indicator instead).
+                    if (!state.recordingLocked) {
+                        LockRecordingButton(
+                            onClick = onLockRecording,
+                            modifier = Modifier.testTag(COMPOSER_LOCK_RECORDING_TAG),
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                    }
                     ToFieldButton(
                         onClick = onMicTap,
                         modifier = Modifier.testTag(COMPOSER_TO_FIELD_TAG),
@@ -1558,6 +1577,21 @@ private fun RecordingSurface(
             )
             DiscardRecordingButton(onClick = onCancel)
         }
+        // Issue #585: until the recording is locked, surface a one-line hint so
+        // the user knows the hands-free path exists and how to reach it — "tap
+        // Lock" is the deterministic affordance, "swipe up" the gesture. The
+        // hint disappears the moment the lock indicator appears, so a locked
+        // recording reads clean. The missing feedback was itself a reason the
+        // gesture felt broken ("I don't think it's recording / locking").
+        if (!locked && liveTranscript.isNullOrBlank()) {
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = "Tap Lock or swipe up to keep recording hands-free",
+                color = PocketShellColors.TextMuted,
+                fontSize = 11.sp,
+                modifier = Modifier.testTag(COMPOSER_LOCK_HINT_TAG),
+            )
+        }
         if (!liveTranscript.isNullOrBlank()) {
             Spacer(modifier = Modifier.height(8.dp))
             LiveTranscriptTwoLine(
@@ -1741,6 +1775,56 @@ private fun DiscardRecordingButton(
         Text(
             text = "Discard",
             color = PocketShellColors.TextSecondary,
+            fontSize = 13.sp,
+            fontWeight = FontWeight.SemiBold,
+        )
+    }
+}
+
+/**
+ * Issue #585: the deterministic hands-free LOCK affordance shown while
+ * Recording but not yet locked. A single tap calls [onLockRecording] so the
+ * user can release the finger and keep dictating — exactly the maintainer's
+ * Telegram-style "swipe up to lock" intent, but via a tap that the
+ * ModalBottomSheet drag-to-dismiss can NEVER steal (the velocity-driven
+ * arbitration that broke the swipe gesture on real hardware across this
+ * issue's reopens). Rendered as a compact accent-bordered pill with the lock
+ * glyph so it reads as "lock this recording on". A 48dp min touch target keeps
+ * it comfortably tappable next to the Insert/Send pills.
+ */
+@Composable
+private fun LockRecordingButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .heightIn(min = 48.dp)
+            .clip(RoundedCornerShape(22.dp))
+            .background(
+                color = PocketShellColors.SurfaceElev,
+                shape = RoundedCornerShape(22.dp),
+            )
+            .border(
+                width = 1.dp,
+                color = PocketShellColors.Accent,
+                shape = RoundedCornerShape(22.dp),
+            )
+            .clickable(role = Role.Button, onClick = onClick)
+            .semantics { contentDescription = "Lock recording to continue hands-free" }
+            .padding(horizontal = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        Icon(
+            imageVector = Icons.Outlined.Lock,
+            contentDescription = null,
+            tint = PocketShellColors.Accent,
+            modifier = Modifier.size(16.dp),
+        )
+        Text(
+            text = "Lock",
+            color = PocketShellColors.Accent,
             fontSize = 13.sp,
             fontWeight = FontWeight.SemiBold,
         )
@@ -3309,6 +3393,20 @@ internal fun composerSendTooltipTestTag(label: String): String =
  * `Recording`, where it stops the mic and drops the buffer before Whisper.
  */
 internal const val COMPOSER_CANCEL_RECORDING_TAG = "prompt-composer-cancel-recording"
+
+/**
+ * Issue #585: test tag for the deterministic hands-free Lock control. It only
+ * appears while `Recording` and NOT yet locked; a single tap locks the
+ * recording so the finger can be released without stopping capture (the
+ * sheet-drag-proof alternative to the swipe-up-to-lock gesture).
+ */
+internal const val COMPOSER_LOCK_RECORDING_TAG = "prompt-composer-lock-recording"
+
+/**
+ * Issue #585: test tag for the recording hands-free hint shown while
+ * `Recording` and not yet locked. Disappears once locked.
+ */
+internal const val COMPOSER_LOCK_HINT_TAG = "prompt-composer-lock-hint"
 
 /**
  * Issue #174/#453: test tag for the transcribing cancel control. Kept

--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerSheet.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerSheet.kt
@@ -1781,6 +1781,15 @@ private fun DiscardRecordingButton(
     }
 }
 
+// Genuine sub-ladder component geometry: the composer's 44–48dp action pills
+// (Send / Stop / To-field / Lock) read as fully-rounded "pills", which needs a
+// half-height radius the named ladder rungs (8/14/20/28dp — design-system.md
+// "Radius, Elevation, And Borders") don't provide. 22dp is that pill radius for
+// this control height; named here (vs an inline literal) so it stays a single
+// intentional token rather than off-ladder drift. See docs/design-system.md.
+private val ComposerActionPillRadius = 22.dp
+private val ComposerActionPillShape = RoundedCornerShape(ComposerActionPillRadius)
+
 /**
  * Issue #585: the deterministic hands-free LOCK affordance shown while
  * Recording but not yet locked. A single tap calls [onLockRecording] so the
@@ -1800,15 +1809,15 @@ private fun LockRecordingButton(
     Row(
         modifier = modifier
             .heightIn(min = 48.dp)
-            .clip(RoundedCornerShape(22.dp))
+            .clip(ComposerActionPillShape)
             .background(
                 color = PocketShellColors.SurfaceElev,
-                shape = RoundedCornerShape(22.dp),
+                shape = ComposerActionPillShape,
             )
             .border(
                 width = 1.dp,
                 color = PocketShellColors.Accent,
-                shape = RoundedCornerShape(22.dp),
+                shape = ComposerActionPillShape,
             )
             .clickable(role = Role.Button, onClick = onClick)
             .semantics { contentDescription = "Lock recording to continue hands-free" }

--- a/app/src/main/java/com/pocketshell/app/fileviewer/MarkdownModel.kt
+++ b/app/src/main/java/com/pocketshell/app/fileviewer/MarkdownModel.kt
@@ -53,6 +53,24 @@ internal sealed interface MarkdownBlock {
     /** A `>` block quote; [spans] is the inline content of the quoted text. */
     data class BlockQuote(val spans: List<InlineSpan>) : MarkdownBlock
 
+    /**
+     * A GitHub-flavored pipe table (issue #921).
+     *
+     * [header] is the single header row; [rows] are the body rows. Each cell is
+     * its own list of inline spans (so emphasis/code/links render inside cells).
+     * [alignments] mirrors the delimiter row (one entry per column) so the
+     * renderer can justify cells; columns with no explicit alignment are
+     * [Alignment.NONE].
+     */
+    data class Table(
+        val header: List<List<InlineSpan>>,
+        val alignments: List<Alignment>,
+        val rows: List<List<List<InlineSpan>>>,
+    ) : MarkdownBlock {
+        /** Per-column text justification derived from the `|---|:--:|` delimiter row. */
+        enum class Alignment { NONE, LEFT, CENTER, RIGHT }
+    }
+
     /** A thematic break (`---`, `***`, `___`). */
     data object HorizontalRule : MarkdownBlock
 }

--- a/app/src/main/java/com/pocketshell/app/fileviewer/MarkdownParser.kt
+++ b/app/src/main/java/com/pocketshell/app/fileviewer/MarkdownParser.kt
@@ -27,6 +27,12 @@ internal object MarkdownParser {
     private val BLOCKQUOTE = Regex("^\\s{0,3}>\\s?(.*)$")
 
     /**
+     * A GFM table delimiter cell: dashes with an optional leading/trailing `:`
+     * for alignment (e.g. `:---`, `---:`, `:--:`, `---`). At least one dash.
+     */
+    private val TABLE_DELIMITER_CELL = Regex("^:?-+:?$")
+
+    /**
      * Thematic break (`---`, `***`, `___`) detected with a plain character scan
      * — never a backreference regex. A backref like `([-*_])(?:\s*\1){2,}`
      * makes the JDK engine recurse per repetition and overflows the stack on a
@@ -128,6 +134,35 @@ internal object MarkdownParser {
                 continue
             }
 
+            // GFM pipe table — a header row plus a delimiter row, then body rows
+            // (issue #921). Only a header line immediately followed by a valid
+            // delimiter row whose column count EQUALS the header's begins a
+            // table; otherwise the `|` text is a normal paragraph. The
+            // column-count match is the GFM guard that keeps a prose line with a
+            // pipe above a `---` thematic break (a 1-cell delimiter) from being
+            // swallowed as a table (issue #921 review).
+            if (line.contains('|') && i + 1 < lines.size && isTableDelimiterRow(lines[i + 1]) &&
+                splitTableRow(lines[i + 1]).size == splitTableRow(line).size
+            ) {
+                val alignments = parseDelimiterAlignments(lines[i + 1])
+                val header = splitTableRow(line)
+                i += 2 // past header + delimiter
+                val rows = mutableListOf<List<List<InlineSpan>>>()
+                while (i < lines.size) {
+                    val rowLine = lines[i]
+                    // A table ends at a blank line or any line without a pipe.
+                    if (rowLine.isBlank() || !rowLine.contains('|')) break
+                    rows += splitTableRow(rowLine).map { parseInline(it) }
+                    i++
+                }
+                blocks += MarkdownBlock.Table(
+                    header = header.map { parseInline(it) },
+                    alignments = alignments,
+                    rows = rows,
+                )
+                continue
+            }
+
             // List (ordered or unordered) — consume consecutive item lines.
             if (UL_ITEM.matchEntire(line) != null || OL_ITEM.matchEntire(line) != null) {
                 val items = mutableListOf<MarkdownBlock.ListBlock.Item>()
@@ -171,7 +206,14 @@ internal object MarkdownParser {
                     ATX.matchEntire(next) != null ||
                     BLOCKQUOTE.matchEntire(next) != null ||
                     UL_ITEM.matchEntire(next) != null ||
-                    OL_ITEM.matchEntire(next) != null
+                    OL_ITEM.matchEntire(next) != null ||
+                    // A table header starting here (pipe line followed by a
+                    // matching-width delimiter row) ends the paragraph so the
+                    // table parses. The column-count match mirrors the table
+                    // branch's GFM guard so a `---` rule below a pipe prose line
+                    // does not falsely split the paragraph.
+                    (next.contains('|') && i + 1 < lines.size && isTableDelimiterRow(lines[i + 1]) &&
+                        splitTableRow(lines[i + 1]).size == splitTableRow(next).size)
                 ) {
                     break
                 }
@@ -186,6 +228,65 @@ internal object MarkdownParser {
     private fun indentLevel(leading: String): Int {
         val width = leading.fold(0) { acc, c -> acc + if (c == '\t') 4 else 1 }
         return (width / 2).coerceAtMost(4)
+    }
+
+    /**
+     * Whether [line] is a valid GFM table delimiter row: at least one cell, and
+     * every `|`-separated cell is dashes with optional alignment colons. The
+     * leading/trailing pipes are optional, so we split tolerantly first.
+     */
+    fun isTableDelimiterRow(line: String): Boolean {
+        val cells = splitTableRow(line)
+        if (cells.isEmpty()) return false
+        return cells.all { it.isNotEmpty() && TABLE_DELIMITER_CELL.matches(it) }
+    }
+
+    /** Per-column alignment parsed from the delimiter row's `:` markers. */
+    private fun parseDelimiterAlignments(line: String): List<MarkdownBlock.Table.Alignment> =
+        splitTableRow(line).map { cell ->
+            val left = cell.startsWith(':')
+            val right = cell.endsWith(':')
+            when {
+                left && right -> MarkdownBlock.Table.Alignment.CENTER
+                right -> MarkdownBlock.Table.Alignment.RIGHT
+                left -> MarkdownBlock.Table.Alignment.LEFT
+                else -> MarkdownBlock.Table.Alignment.NONE
+            }
+        }
+
+    /**
+     * Split one table row into trimmed cell strings. Leading/trailing pipes are
+     * stripped, and a backslash-escaped `\|` inside a cell is kept literal (it
+     * is not a column separator). Empty leading/trailing cells from the outer
+     * pipes are dropped; interior empty cells are preserved.
+     */
+    fun splitTableRow(line: String): List<String> {
+        val cells = mutableListOf<String>()
+        val current = StringBuilder()
+        var i = 0
+        while (i < line.length) {
+            val c = line[i]
+            when {
+                c == '\\' && i + 1 < line.length && line[i + 1] == '|' -> {
+                    current.append('|') // escaped pipe — literal
+                    i += 2
+                }
+                c == '|' -> {
+                    cells += current.toString().trim()
+                    current.clear()
+                    i++
+                }
+                else -> {
+                    current.append(c)
+                    i++
+                }
+            }
+        }
+        cells += current.toString().trim()
+        // Drop the empty cells produced by an outer leading/trailing pipe.
+        if (cells.isNotEmpty() && cells.first().isEmpty()) cells.removeAt(0)
+        if (cells.isNotEmpty() && cells.last().isEmpty()) cells.removeAt(cells.size - 1)
+        return cells
     }
 
     /**

--- a/app/src/main/java/com/pocketshell/app/fileviewer/MarkdownView.kt
+++ b/app/src/main/java/com/pocketshell/app/fileviewer/MarkdownView.kt
@@ -4,12 +4,17 @@ import android.content.Intent
 import android.net.Uri
 import android.widget.Toast
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.ClickableText
@@ -26,6 +31,7 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
@@ -33,6 +39,9 @@ import androidx.compose.ui.unit.sp
 import com.pocketshell.uikit.theme.PocketShellColors
 
 const val FILE_VIEWER_MARKDOWN_TAG = "fileViewerMarkdown"
+
+/** Test tag for a rendered Markdown pipe table (issue #921). */
+const val FILE_VIEWER_MARKDOWN_TABLE_TAG = "fileViewerMarkdownTable"
 
 /** The clickable-text URL annotation tag for Markdown links. */
 private const val MD_URL_TAG = "md_url"
@@ -66,6 +75,7 @@ internal fun MarkdownView(
                 is MarkdownBlock.CodeBlock -> CodeBlock(block)
                 is MarkdownBlock.ListBlock -> ListBlock(block)
                 is MarkdownBlock.BlockQuote -> BlockQuoteBlock(block)
+                is MarkdownBlock.Table -> TableBlock(block)
                 MarkdownBlock.HorizontalRule -> HorizontalRuleBlock()
             }
         }
@@ -169,6 +179,95 @@ private fun BlockQuoteBlock(block: MarkdownBlock.BlockQuote) {
                 .fillMaxWidth()
                 .padding(12.dp),
         )
+    }
+}
+
+/**
+ * Renders a GFM pipe table (issue #921) as laid-out cells: a tinted header row
+ * over equal-width body rows, hairline borders between cells, per-column
+ * justification from the delimiter row, and a horizontal scroll so a wide table
+ * stays readable. The header and each body row share the same column count
+ * (padded/truncated to the header width) so cells line up.
+ */
+@Composable
+private fun TableBlock(block: MarkdownBlock.Table) {
+    val columnCount = block.header.size.coerceAtLeast(1)
+    val hScroll = rememberScrollState()
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp)
+            .testTag(FILE_VIEWER_MARKDOWN_TABLE_TAG),
+    ) {
+        Column(
+            modifier = Modifier
+                .horizontalScroll(hScroll)
+                .border(1.dp, PocketShellColors.BorderSoft, RoundedCornerShape(6.dp)),
+        ) {
+            // Header row.
+            TableRow(
+                cells = block.header,
+                columnCount = columnCount,
+                alignments = block.alignments,
+                isHeader = true,
+            )
+            // Body rows.
+            block.rows.forEach { row ->
+                Box(
+                    modifier = Modifier
+                        .height(1.dp)
+                        .fillMaxWidth()
+                        .background(PocketShellColors.BorderSoft),
+                )
+                TableRow(
+                    cells = row,
+                    columnCount = columnCount,
+                    alignments = block.alignments,
+                    isHeader = false,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun TableRow(
+    cells: List<List<InlineSpan>>,
+    columnCount: Int,
+    alignments: List<MarkdownBlock.Table.Alignment>,
+    isHeader: Boolean,
+) {
+    Row(
+        modifier = Modifier
+            .height(IntrinsicSize.Min)
+            .then(if (isHeader) Modifier.background(PocketShellColors.SurfaceElev) else Modifier),
+    ) {
+        for (col in 0 until columnCount) {
+            if (col > 0) {
+                Box(
+                    modifier = Modifier
+                        .width(1.dp)
+                        .fillMaxHeight()
+                        .background(PocketShellColors.BorderSoft),
+                )
+            }
+            val spans = cells.getOrNull(col) ?: listOf(InlineSpan.Text(""))
+            val alignment = alignments.getOrNull(col) ?: MarkdownBlock.Table.Alignment.NONE
+            Text(
+                text = annotated(spans),
+                color = PocketShellColors.Text,
+                fontSize = 13.sp,
+                fontWeight = if (isHeader) FontWeight.SemiBold else FontWeight.Normal,
+                textAlign = when (alignment) {
+                    MarkdownBlock.Table.Alignment.CENTER -> TextAlign.Center
+                    MarkdownBlock.Table.Alignment.RIGHT -> TextAlign.End
+                    else -> TextAlign.Start
+                },
+                modifier = Modifier
+                    .width(140.dp)
+                    .padding(horizontal = 10.dp, vertical = 6.dp),
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/pocketshell/app/fileviewer/MarkdownView.kt
+++ b/app/src/main/java/com/pocketshell/app/fileviewer/MarkdownView.kt
@@ -182,6 +182,14 @@ private fun BlockQuoteBlock(block: MarkdownBlock.BlockQuote) {
     }
 }
 
+// Genuine sub-ladder "micro role" geometry: an inline code/table tint band uses
+// a 3–6dp radius (design-system.md "Radius, Elevation, And Borders" — "Micro
+// role badges | 3-6dp"), smaller than the named ladder rungs (8/14/20/28dp).
+// 6dp matches the sibling CodeBlock tint; named here so it reads as one
+// intentional token rather than off-ladder drift. See docs/design-system.md.
+private val MarkdownTableBorderRadius = 6.dp
+private val MarkdownTableBorderShape = RoundedCornerShape(MarkdownTableBorderRadius)
+
 /**
  * Renders a GFM pipe table (issue #921) as laid-out cells: a tinted header row
  * over equal-width body rows, hairline borders between cells, per-column
@@ -202,7 +210,7 @@ private fun TableBlock(block: MarkdownBlock.Table) {
         Column(
             modifier = Modifier
                 .horizontalScroll(hScroll)
-                .border(1.dp, PocketShellColors.BorderSoft, RoundedCornerShape(6.dp)),
+                .border(1.dp, PocketShellColors.BorderSoft, MarkdownTableBorderShape),
         ) {
             // Header row.
             TableRow(

--- a/app/src/main/java/com/pocketshell/app/projects/FolderListScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListScreen.kt
@@ -34,7 +34,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -1437,12 +1436,9 @@ internal fun CliVersionMismatchBanner(
             if (running) {
                 // Issue #947: running spinner — Update is in flight; the action
                 // buttons are replaced so a second tap can't double-run.
-                CircularProgressIndicator(
-                    color = color,
-                    strokeWidth = 2.dp,
-                    modifier = Modifier
-                        .size(18.dp)
-                        .testTag(FOLDER_LIST_CLI_VERSION_UPDATE_SPINNER_TAG),
+                LoadingIndicator.Spinner(
+                    size = SpinnerSize.Small,
+                    modifier = Modifier.testTag(FOLDER_LIST_CLI_VERSION_UPDATE_SPINNER_TAG),
                 )
                 Spacer(modifier = Modifier.width(10.dp))
                 Text(

--- a/app/src/main/java/com/pocketshell/app/projects/FolderListScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -232,6 +233,9 @@ fun FolderListScreen(
     // `pocketshell tree` payload on every host open — surfaced as a dismissible
     // update prompt (NOT a slow blocking on-open `--version` wait).
     val cliVersionMismatch by viewModel.cliVersionMismatch.collectAsState()
+    // Issue #947: progress of the banner's one-tap Update action (host upgrade
+    // over the warm session). Drives the Update button's spinner + failure line.
+    val cliVersionUpdateState by viewModel.cliVersionUpdateState.collectAsState()
     val assistantState by viewModel.assistantState.collectAsState()
     val claudeProfiles by viewModel.claudeProfiles.collectAsState()
     val codexProfiles by viewModel.codexProfiles.collectAsState()
@@ -441,6 +445,8 @@ fun FolderListScreen(
         cliVersionMismatch?.let { mismatch ->
             CliVersionMismatchBanner(
                 message = PayloadVersionCheck.outdatedHostPrompt(mismatch),
+                updateState = cliVersionUpdateState,
+                onUpdate = viewModel::runHostPocketshellUpgrade,
                 onDismiss = viewModel::dismissCliVersionMismatch,
                 modifier = Modifier
                     .align(Alignment.BottomCenter)
@@ -1378,14 +1384,22 @@ private fun FolderActionFailureBanner(
  * on-open `--version` exec). The [message] carries the version delta + the
  * copy-paste update command.
  */
+// Issue #947: `internal` (not `private`) so the connected UI-gate androidTest
+// (`CliVersionMismatchBannerUpdateButtonTest`) can compose the PRODUCTION banner
+// in its real Idle/Running/Failure states and assert viewport CONTAINMENT of the
+// Update + Dismiss controls (the #641/#657/#780 real-component model).
 @Composable
-private fun CliVersionMismatchBanner(
+internal fun CliVersionMismatchBanner(
     message: String,
+    updateState: FolderListViewModel.CliVersionUpdateState,
+    onUpdate: () -> Unit,
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val color = PocketShellColors.Accent
-    Row(
+    val running = updateState is FolderListViewModel.CliVersionUpdateState.Running
+    val failure = updateState as? FolderListViewModel.CliVersionUpdateState.Failure
+    Column(
         modifier = modifier
             .fillMaxWidth()
             .background(PocketShellColors.Surface, PocketShellShapes.medium)
@@ -1393,21 +1407,69 @@ private fun CliVersionMismatchBanner(
             .border(1.dp, color.copy(alpha = 0.4f), PocketShellShapes.medium)
             .padding(horizontal = 14.dp, vertical = 10.dp)
             .testTag(FOLDER_LIST_CLI_VERSION_BANNER_TAG),
-        verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(
             text = message,
             color = PocketShellColors.Text,
             style = PocketShellType.bodyDense,
-            modifier = Modifier.weight(1f),
+            modifier = Modifier.fillMaxWidth(),
         )
-        PocketShellButton(
-            text = "Dismiss",
-            onClick = onDismiss,
-            modifier = Modifier.testTag(FOLDER_LIST_CLI_VERSION_DISMISS_TAG),
-            variant = ButtonVariant.Text,
-            compact = true,
-        )
+        // Issue #947: the upgrade failure line (installer stderr / timeout /
+        // no-installer), shown above the action row so the user can read it and
+        // then Retry or Dismiss — the spinner never sticks.
+        failure?.let { fail ->
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = fail.message,
+                color = PocketShellColors.Red,
+                style = PocketShellType.bodyDense,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag(FOLDER_LIST_CLI_VERSION_UPDATE_ERROR_TAG),
+            )
+        }
+        Spacer(modifier = Modifier.height(6.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.End,
+        ) {
+            if (running) {
+                // Issue #947: running spinner — Update is in flight; the action
+                // buttons are replaced so a second tap can't double-run.
+                CircularProgressIndicator(
+                    color = color,
+                    strokeWidth = 2.dp,
+                    modifier = Modifier
+                        .size(18.dp)
+                        .testTag(FOLDER_LIST_CLI_VERSION_UPDATE_SPINNER_TAG),
+                )
+                Spacer(modifier = Modifier.width(10.dp))
+                Text(
+                    text = "Updating…",
+                    color = PocketShellColors.TextSecondary,
+                    style = PocketShellType.bodyDense,
+                )
+            } else {
+                PocketShellButton(
+                    // Issue #947: a no-op upgrade re-raises a failure, so offer
+                    // "Retry" once the first attempt failed.
+                    text = if (failure != null) "Retry" else "Update",
+                    onClick = onUpdate,
+                    modifier = Modifier.testTag(FOLDER_LIST_CLI_VERSION_UPDATE_TAG),
+                    variant = ButtonVariant.Primary,
+                    compact = true,
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                PocketShellButton(
+                    text = "Dismiss",
+                    onClick = onDismiss,
+                    modifier = Modifier.testTag(FOLDER_LIST_CLI_VERSION_DISMISS_TAG),
+                    variant = ButtonVariant.Text,
+                    compact = true,
+                )
+            }
+        }
     }
 }
 
@@ -2820,6 +2882,10 @@ const val FOLDER_LIST_FLAT_IDLE_SECTION_TAG: String = "folder-list:flat:section:
 // Issue #885: the passive host-CLI-version update prompt banner + its dismiss.
 const val FOLDER_LIST_CLI_VERSION_BANNER_TAG: String = "folder-list:cli-version-banner"
 const val FOLDER_LIST_CLI_VERSION_DISMISS_TAG: String = "folder-list:cli-version-dismiss"
+// Issue #947: the one-tap Update button on that banner + its running spinner.
+const val FOLDER_LIST_CLI_VERSION_UPDATE_TAG: String = "folder-list:cli-version-update"
+const val FOLDER_LIST_CLI_VERSION_UPDATE_SPINNER_TAG: String = "folder-list:cli-version-update-spinner"
+const val FOLDER_LIST_CLI_VERSION_UPDATE_ERROR_TAG: String = "folder-list:cli-version-update-error"
 
 // Stable LazyColumn item keys for the flat-view section rows (#489). The host
 // header band moved into the app bar (#522 item 1), so there is no in-list

--- a/app/src/main/java/com/pocketshell/app/projects/FolderListViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListViewModel.kt
@@ -527,6 +527,146 @@ class FolderListViewModel internal constructor(
     /** Dismiss the passive CLI-version update prompt (issue #885). */
     fun dismissCliVersionMismatch() {
         _cliVersionMismatch.value = null
+        _cliVersionUpdateState.value = CliVersionUpdateState.Idle
+    }
+
+    /**
+     * Issue #947: the progress state of the banner's one-tap **Update** action,
+     * which runs the host-side `pocketshell` upgrade over the warm SSH session.
+     *
+     * - [Idle] — no update in flight (the banner shows the Update + Dismiss
+     *   buttons).
+     * - [Running] — the upgrade exec is in flight (the banner shows a spinner;
+     *   Update is disabled).
+     * - [Failure] — the upgrade failed; [Failure.message] (installer stderr /
+     *   timeout / no-installer) is shown and the user can Retry or Dismiss. There
+     *   is NO stuck spinner: the state always leaves [Running] (the exec is
+     *   bounded, #944/#939).
+     *
+     * A SUCCESS does not get its own state — the upgrade re-checks the host
+     * version and, when it now matches, clears [cliVersionMismatch] so the whole
+     * banner disappears (the success signal is the banner going away).
+     */
+    public sealed interface CliVersionUpdateState {
+        public data object Idle : CliVersionUpdateState
+        public data object Running : CliVersionUpdateState
+        public data class Failure(val message: String) : CliVersionUpdateState
+    }
+
+    private val _cliVersionUpdateState: MutableStateFlow<CliVersionUpdateState> =
+        MutableStateFlow(CliVersionUpdateState.Idle)
+    val cliVersionUpdateState: StateFlow<CliVersionUpdateState> =
+        _cliVersionUpdateState.asStateFlow()
+
+    /**
+     * Issue #947: the host-upgrade seam. Runs `pocketshell`'s installer upgrade
+     * (uv / pipx / pip, auto-detected) over the warm session, bounded. Injectable
+     * for tests; the production default is a real [HostPocketshellUpgrade].
+     */
+    private var hostPocketshellUpgrade: HostPocketshellUpgrade = HostPocketshellUpgrade()
+
+    @androidx.annotation.VisibleForTesting
+    internal fun setHostPocketshellUpgradeForTest(upgrade: HostPocketshellUpgrade) {
+        hostPocketshellUpgrade = upgrade
+    }
+
+    private var hostUpgradeJob: Job? = null
+
+    /**
+     * Issue #947: run the host-side `pocketshell` upgrade for the
+     * [cliVersionMismatch] banner's one-tap **Update** button.
+     *
+     * Over the EXISTING warm SSH session (D21 — no new connection) it:
+     *  1. flips the banner to [CliVersionUpdateState.Running] (spinner);
+     *  2. execs the auto-detected installer upgrade (bounded — #944/#939);
+     *  3. on success RE-CHECKS the host version via a fresh `tree get` and feeds
+     *     it through [observePayloadCliVersion] — when it now matches, the
+     *     mismatch clears and the whole banner disappears;
+     *  4. on failure (or a re-check that still reports outdated) surfaces a
+     *     [CliVersionUpdateState.Failure] with the installer error so the user can
+     *     Retry or Dismiss — never a stuck spinner.
+     *
+     * Idempotent against a double tap: a second call while one is in flight is
+     * ignored.
+     */
+    fun runHostPocketshellUpgrade() {
+        if (_cliVersionUpdateState.value is CliVersionUpdateState.Running) return
+        val params = bound
+        if (params == null) {
+            _cliVersionUpdateState.value =
+                CliVersionUpdateState.Failure("Not connected to the host — reconnect and try again.")
+            return
+        }
+        hostUpgradeJob?.cancel()
+        _cliVersionUpdateState.value = CliVersionUpdateState.Running
+        hostUpgradeJob = viewModelScope.launch {
+            val session = awaitWarmSession()
+            if (session == null || bound != params) {
+                _cliVersionUpdateState.value =
+                    CliVersionUpdateState.Failure("Not connected to the host — reconnect and try again.")
+                return@launch
+            }
+            when (val result = hostPocketshellUpgrade.run(session)) {
+                is HostPocketshellUpgrade.Result.Success -> {
+                    // Re-check the host version from a fresh payload. A SUCCESSFUL
+                    // upgrade should now report the matching version, clearing the
+                    // banner; a no-op upgrade (already-newest / capped) re-raises
+                    // a failure so the user isn't left thinking it worked.
+                    recheckHostVersionAfterUpgrade(params, session)
+                }
+                is HostPocketshellUpgrade.Result.Failure -> {
+                    _cliVersionUpdateState.value = CliVersionUpdateState.Failure(result.message)
+                }
+            }
+        }
+    }
+
+    /**
+     * Issue #947: after a successful upgrade exec, re-read the host CLI version
+     * from a fresh `tree get` and re-evaluate the mismatch. When it now matches
+     * (or the host is newer), [observePayloadCliVersion] clears
+     * [cliVersionMismatch] and we drop back to [CliVersionUpdateState.Idle] (the
+     * banner disappears). When it STILL reports outdated — e.g. the upgrade was a
+     * silent no-op — we surface a failure so the spinner never sticks and the
+     * user can retry/dismiss.
+     */
+    private suspend fun recheckHostVersionAfterUpgrade(params: BoundParams, session: SshSession) {
+        val source = treeRemoteSource
+        if (source == null) {
+            // No durable source (some unit paths): trust the exit-0 success and
+            // clear the banner so the spinner doesn't stick.
+            _cliVersionMismatch.value = null
+            _cliVersionUpdateState.value = CliVersionUpdateState.Idle
+            return
+        }
+        // `getTree` is itself bounded (TreeRemoteSource.execTreeRpcBounded), but
+        // wrap the re-check in an OUTER bound too so a future unbounded `getTree`
+        // can never leave the banner's spinner stuck (#947 / #944 / #939).
+        val treeResult = withTimeoutOrNull(HYDRATE_TIMEOUT_MS) {
+            runCatching { source.getTree(session, params.hostName) }
+                .getOrDefault(TreeRemoteSource.TreeResult.Empty)
+        } ?: TreeRemoteSource.TreeResult.Empty
+        if (treeResult.cliVersion.isNullOrBlank()) {
+            // The re-read carried NO version (timed out / old-CLI omits it /
+            // empty payload). The upgrade exec itself exited 0, so trust that
+            // success and clear the banner rather than raising a false
+            // "still outdated" — and never leave the spinner stuck.
+            _cliVersionMismatch.value = null
+            _cliVersionUpdateState.value = CliVersionUpdateState.Idle
+            return
+        }
+        observePayloadCliVersion(treeResult.cliVersion)
+        if (_cliVersionMismatch.value == null) {
+            _cliVersionUpdateState.value = CliVersionUpdateState.Idle
+        } else {
+            // The re-read reported a CONCRETE version that is STILL older — the
+            // upgrade was a silent no-op (e.g. capped). Don't pretend it worked.
+            _cliVersionUpdateState.value = CliVersionUpdateState.Failure(
+                "Update ran but the host still reports " +
+                    "${_cliVersionMismatch.value?.hostVersion ?: "an older version"}. " +
+                    "It may be capped — try the command on the host.",
+            )
+        }
     }
 
     /**

--- a/app/src/main/java/com/pocketshell/app/projects/HostPocketshellUpgrade.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/HostPocketshellUpgrade.kt
@@ -1,0 +1,168 @@
+package com.pocketshell.app.projects
+
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.SshSession
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.async
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+
+/**
+ * Issue #947: run the host-side `pocketshell` upgrade over the EXISTING warm SSH
+ * session (D21 — no new connection), so the host-version-mismatch banner can
+ * offer a one-tap **Update** button instead of only printing the manual command.
+ *
+ * ## What it does
+ *
+ * In a SINGLE non-interactive `/bin/sh` exec it:
+ *
+ * 1. Augments `PATH` with the common per-user bin dirs (the
+ *    [com.pocketshell.app.pocketshell.PocketshellCommand] problem: a
+ *    non-interactive SSH exec misses `~/.local/bin`, where uv/pipx/pip drop
+ *    their shims).
+ * 2. PROBES which installer owns `pocketshell` and runs the matching upgrade:
+ *    - `uv tool list` mentions `pocketshell` → `uv tool install --upgrade
+ *      --exclude-newer-package pocketshell=2099-12-31 pocketshell` (the #779
+ *      override that lifts uv's global `exclude-newer` cap so the upgrade is
+ *      never a silent no-op — mirrors [PayloadVersionCheck.UPDATE_COMMAND]).
+ *    - else `pipx` present → `pipx upgrade pocketshell`.
+ *    - else `pip`/`pip3` present → `pip install -U pocketshell`.
+ *    - else exit `127` so the caller surfaces "no installer found".
+ *
+ * The probe-then-run lives entirely server-side in the one command so there is
+ * exactly ONE exec round-trip (no extra latency, no second blocking read).
+ *
+ * ## Bounding (issues #944 / #939)
+ *
+ * The exec is bounded with [execBounded] (mirrors
+ * [TreeRemoteSource.execTreeRpcBounded]): the upgrade runs in a child coroutine
+ * and is awaited with [upgradeTimeoutMs]; on timeout the child is cancelled and
+ * the session closed so a wedged installer can never pin the warm path forever
+ * and the banner's spinner can never stick. An upgrade is heavier than a
+ * `tree get`, so the default timeout is generous (a real `uv tool install`
+ * downloads + builds).
+ */
+public class HostPocketshellUpgrade {
+
+    /**
+     * Bound on a single upgrade exec. An installer upgrade (uv resolve +
+     * download + build) is much heavier than a `tree get`, so this is generous —
+     * it is the last-line defence against a TRULY wedged installer, not a normal
+     * completion deadline. Test-overridable.
+     */
+    internal var upgradeTimeoutMs: Long = UPGRADE_TIMEOUT_MS
+    internal var execDispatcher: CoroutineDispatcher = Dispatchers.IO
+
+    /** The outcome of a [run] call. */
+    public sealed interface Result {
+        /** The upgrade command exited 0. */
+        public data object Success : Result
+
+        /**
+         * The upgrade did not succeed. [message] is a short, user-facing reason
+         * built from the installer stderr/stdout (or a timeout / no-installer
+         * note), suitable for the banner's failure line.
+         */
+        public data class Failure(val message: String) : Result
+    }
+
+    /**
+     * Run the host upgrade over [session] (the warm lease's session). Never
+     * throws except [CancellationException]; any transport/parse failure
+     * degrades to a [Result.Failure] so the banner always leaves the running
+     * state (no stuck spinner — #939).
+     */
+    public suspend fun run(session: SshSession): Result {
+        val result = try {
+            session.execBounded(UPGRADE_COMMAND)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (t: Throwable) {
+            return Result.Failure(t.message?.takeIf { it.isNotBlank() } ?: "Update failed.")
+        }
+            ?: return Result.Failure(
+                "Update timed out after ${upgradeTimeoutMs / 1000}s. Try again, or run the command on the host.",
+            )
+        if (result.exitCode == 0) return Result.Success
+        if (result.exitCode == NO_INSTALLER_EXIT) {
+            return Result.Failure(
+                "No uv / pipx / pip found on the host to upgrade pocketshell. " +
+                    "Install one, or run the command on the host.",
+            )
+        }
+        return Result.Failure(formatFailure(result))
+    }
+
+    private fun formatFailure(result: ExecResult): String {
+        val detail = result.stderr.trim().ifBlank { result.stdout.trim() }
+        val tail = detail.lines().filter { it.isNotBlank() }.takeLast(MAX_ERROR_LINES)
+            .joinToString("\n")
+            .take(MAX_ERROR_CHARS)
+        return if (tail.isBlank()) {
+            "Update failed (exit ${result.exitCode})."
+        } else {
+            "Update failed (exit ${result.exitCode}):\n$tail"
+        }
+    }
+
+    private suspend fun SshSession.execBounded(command: String): ExecResult? =
+        withContext(execDispatcher) {
+            val deferred = async { exec(command) }
+            withTimeoutOrNull(upgradeTimeoutMs) { deferred.await() }
+                ?: run {
+                    deferred.cancel()
+                    withContext(NonCancellable) {
+                        runCatching { close() }
+                    }
+                    null
+                }
+        }
+
+    public companion object {
+        /** 4 minutes: an installer download + build is slow; this only guards a true wedge. */
+        internal const val UPGRADE_TIMEOUT_MS: Long = 240_000L
+
+        /** Exit code the [UPGRADE_COMMAND] uses when no installer owns pocketshell. */
+        internal const val NO_INSTALLER_EXIT: Int = 127
+
+        private const val MAX_ERROR_LINES: Int = 6
+        private const val MAX_ERROR_CHARS: Int = 600
+
+        /**
+         * The single `/bin/sh` command: augment PATH, probe the owning installer
+         * (uv → pipx → pip), and run the matching upgrade. Exits 127 when none is
+         * found. The uv arm mirrors [PayloadVersionCheck.UPDATE_COMMAND]
+         * (`--exclude-newer-package pocketshell=2099-12-31`, issue #779) so the
+         * upgrade is never silently capped by the host's global uv cutoff.
+         */
+        internal val UPGRADE_COMMAND: String = buildString {
+            // PATH augmentation: same per-user bin dirs PocketshellCommand prepends
+            // so uv/pipx/pip shims under ~/.local/bin etc. are discoverable on a
+            // non-interactive exec.
+            append("export PATH=\"\$HOME/.local/bin:\$HOME/.cargo/bin:\$HOME/.pixi/bin:")
+            append("\$HOME/bin:/usr/local/bin:\$PATH\"; ")
+            // uv: only if uv exists AND its tool list actually owns pocketshell —
+            // otherwise a host with uv-for-something-else but pipx-owned
+            // pocketshell would wrongly try uv.
+            append("if command -v uv >/dev/null 2>&1 && ")
+            append("uv tool list 2>/dev/null | grep -qi '^pocketshell\\b'; then ")
+            append("exec uv tool install --upgrade ")
+            append("--exclude-newer-package $UV_EXCLUDE_NEWER pocketshell; ")
+            // pipx next.
+            append("elif command -v pipx >/dev/null 2>&1; then ")
+            append("exec pipx upgrade pocketshell; ")
+            // pip / pip3 last.
+            append("elif command -v pip >/dev/null 2>&1; then ")
+            append("exec pip install -U pocketshell; ")
+            append("elif command -v pip3 >/dev/null 2>&1; then ")
+            append("exec pip3 install -U pocketshell; ")
+            // No installer at all.
+            append("else exit 127; fi")
+        }
+
+        private const val UV_EXCLUDE_NEWER: String = "pocketshell=2099-12-31"
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/session/AgentConversationUiState.kt
+++ b/app/src/main/java/com/pocketshell/app/session/AgentConversationUiState.kt
@@ -113,6 +113,33 @@ public data class AgentConversationUiState(
      * detection lands, since the row is then a genuine agent row.
      */
     val autoSeededPlaceholder: Boolean = false,
+    /**
+     * Issue #819 (Slice A2): true when this detection-less placeholder row was
+     * seeded from [com.pocketshell.app.tmux.AgentSessionMemory] for a window
+     * that was KNOWN to host an agent before a reconnect (the #495 reattach
+     * seed), and is holding "resolving" while live re-detection re-anchors the
+     * route-true transcript source.
+     *
+     * The #495 seed used to restore the remembered [AgentDetection] BLIND —
+     * carrying its `sourcePath` — and render it `Live` immediately, before live
+     * re-detection confirmed the source was still the route's own session. When
+     * that remembered source had been captured during a prior same-cwd same-kind
+     * mis-pick (a sibling / sub-agent / second window/worktree Codex rollout),
+     * the Conversation tab rendered the WRONG transcript under a route-true
+     * Terminal until the live `/proc/<pid>/fd` round-trip landed (#819). So the
+     * seed now restores only the remembered KIND + the user's tab choice as a
+     * resolving placeholder, never the stale source, and live
+     * `detectRecordedSessionForPane` binds the real source.
+     *
+     * Like [autoSeededPlaceholder] this is the auto-seed's own teardown marker
+     * for [com.pocketshell.app.tmux.TmuxSessionViewModel] `clearAgentDetectionForPane`
+     * (drop on a confirmed exit, do not strand on "Loading…"), but unlike it the
+     * window is a CONFIRMED-prior agent, so a transient null after reattach is
+     * held and re-confirmed for `AGENT_EXIT_CONFIRMATIONS` (the #554 no-flap
+     * guarantee) before teardown. Cleared (to false) the moment a real detection
+     * lands, since the row is then a genuine agent row.
+     */
+    val rememberedAgentPlaceholder: Boolean = false,
 )
 
 /**

--- a/app/src/main/java/com/pocketshell/app/sessions/LeaseSessionExec.kt
+++ b/app/src/main/java/com/pocketshell/app/sessions/LeaseSessionExec.kt
@@ -1,6 +1,7 @@
 package com.pocketshell.app.sessions
 
 import com.pocketshell.core.ssh.KnownHostsPolicy
+import com.pocketshell.core.ssh.SshExecTimeoutException
 import com.pocketshell.core.ssh.SshKey
 import com.pocketshell.core.ssh.SshLeaseKey
 import com.pocketshell.core.ssh.SshLeaseManager
@@ -9,6 +10,7 @@ import com.pocketshell.core.ssh.SshSession
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import java.io.File
 
 /**
@@ -109,21 +111,35 @@ object LeaseSessionExec {
         leaseManager: SshLeaseManager,
         target: LeaseSessionTarget,
         block: suspend (SshSession) -> T,
+    ): Result<T> = withSession(leaseManager, target, BLOCK_TIMEOUT_MS, block)
+
+    /**
+     * Overload that lets the caller (and tests) override the wall-clock ceiling
+     * on [block] (#935 S4-2). Production callers use the default
+     * [BLOCK_TIMEOUT_MS]; tests inject a short value so the wedged-block bound
+     * can be exercised without a real multi-second wait.
+     */
+    suspend fun <T> withSession(
+        leaseManager: SshLeaseManager,
+        target: LeaseSessionTarget,
+        blockTimeoutMs: Long,
+        block: suspend (SshSession) -> T,
     ): Result<T> {
         val leaseTarget = target.toSshLeaseTarget()
-        val firstAttempt = runAttempt(leaseManager, leaseTarget, block)
+        val firstAttempt = runAttempt(leaseManager, leaseTarget, blockTimeoutMs, block)
         val firstError = firstAttempt.exceptionOrNull()
         if (firstError == null || !isStaleChannelSymptom(firstError)) {
             return firstAttempt
         }
         // The eviction inside runAttempt already discarded the poisoned
         // transport, so this second acquire dials a FRESH connection.
-        return runAttempt(leaseManager, leaseTarget, block)
+        return runAttempt(leaseManager, leaseTarget, blockTimeoutMs, block)
     }
 
     private suspend fun <T> runAttempt(
         leaseManager: SshLeaseManager,
         leaseTarget: SshLeaseTarget,
+        blockTimeoutMs: Long,
         block: suspend (SshSession) -> T,
     ): Result<T> {
         val lease = try {
@@ -135,13 +151,39 @@ object LeaseSessionExec {
         }
         var poisonedTransport = false
         return try {
-            Result.success(block(lease.session))
+            // #935 S4-2: the lease bounded only the ACQUIRE — `block` (the exec /
+            // upload / download work on the warm transport) ran with NO ceiling.
+            // A half-open / wedged transport hung the borrow indefinitely while a
+            // ref kept the lease warm (the 60s idle-TTL could never close a
+            // still-referenced corpse). Bound the block itself: on expiry the
+            // wedged transport is a corpse, so treat it as a stale-channel symptom
+            // — evict it (below) + surface a clear, retryable error — exactly like
+            // a dead-channel exception. `withTimeoutOrNull` cancels the block; the
+            // session-level read bound (`RealSshSession.exec` #935 S4-2) is what
+            // actually unparks the in-flight blocking JDK read, but this outer
+            // bound also covers a block that does several ops or a non-exec
+            // (upload/download) hang and keeps the lease from being pinned open.
+            //
+            // `block` itself may legitimately return `null`, so we wrap its
+            // result in a one-element holder: a `null` from `withTimeoutOrNull`
+            // means the TIMEOUT fired, never a null block result. The block's own
+            // exceptions propagate OUT of `withTimeoutOrNull` to the `catch`
+            // below (we do NOT `runCatching` inside, which would swallow the
+            // timeout's own CancellationException and defeat the bound).
+            val holder = withTimeoutOrNull(blockTimeoutMs) { Holder(block(lease.session)) }
+            if (holder == null) {
+                poisonedTransport = true
+                Result.failure(LeaseSessionBlockTimeoutException(blockTimeoutMs))
+            } else {
+                Result.success(holder.value)
+            }
         } catch (e: CancellationException) {
             throw e
         } catch (t: Throwable) {
-            // A dead-transport / channel-open / "not connected" failure must
-            // EVICT the pooled lease, not just release it, so the retry / next
-            // action opens a fresh transport instead of re-grabbing the corpse.
+            // A dead-transport / channel-open / "not connected" /
+            // wedged-read-timeout failure must EVICT the pooled lease, not just
+            // release it, so the retry / next action opens a fresh transport
+            // instead of re-grabbing the corpse.
             poisonedTransport = isStaleChannelSymptom(t)
             Result.failure(t)
         } finally {
@@ -161,9 +203,30 @@ object LeaseSessionExec {
      * [com.pocketshell.app.tmux.TmuxSessionViewModel] stale-channel detection.
      */
     internal fun isStaleChannelSymptom(cause: Throwable?): Boolean =
-        isChannelOpenFailure(cause) ||
+        isWedgedReadTimeout(cause) ||
+            isChannelOpenFailure(cause) ||
             isTransportDisconnected(cause) ||
             isSessionNotConnected(cause)
+
+    /**
+     * A wedged-read / wedged-block timeout (#935 S4-2) is a stale-channel
+     * symptom: the transport stopped making progress, so the borrow must heal +
+     * retry on a FRESH lease rather than re-grab the corpse. Covers both the
+     * session-level [SshExecTimeoutException] (the `exec` read blew its ceiling)
+     * and the lease-level [LeaseSessionBlockTimeoutException] (the whole block
+     * blew its ceiling).
+     */
+    private fun isWedgedReadTimeout(cause: Throwable?): Boolean {
+        var current: Throwable? = cause
+        val seen = HashSet<Throwable>()
+        while (current != null && seen.add(current)) {
+            if (current is SshExecTimeoutException || current is LeaseSessionBlockTimeoutException) {
+                return true
+            }
+            current = current.cause
+        }
+        return false
+    }
 
     private fun isSessionNotConnected(cause: Throwable?): Boolean =
         anyInChain(cause) { message ->
@@ -213,4 +276,34 @@ object LeaseSessionExec {
         }
         return false
     }
+
+    /**
+     * Wall-clock ceiling for the borrowed-session [block] (#935 S4-2). The lease
+     * previously bounded only the acquire; a wedged transport could hang the
+     * borrow indefinitely while a ref kept the lease warm. 45s is generous for
+     * the heaviest in-scope block (a file-viewer save = `mkdir` + a multi-MB
+     * `uploadStream`) yet bounds an indefinite hang. It sits ABOVE the
+     * session-level [com.pocketshell.core.ssh.RealSshSession] exec read bound
+     * (30s) so a single wedged exec surfaces its own clear
+     * [SshExecTimeoutException] FIRST; this outer bound is the net for a block
+     * that strings several ops or wedges on a non-exec (upload/download) hang.
+     */
+    internal const val BLOCK_TIMEOUT_MS: Long = 45_000L
+
+    /**
+     * One-element holder so a `null` from `withTimeoutOrNull` unambiguously means
+     * the timeout fired (vs a [block] that legitimately returned `null`).
+     */
+    private class Holder<T>(val value: T)
 }
+
+/**
+ * Thrown (wrapped in `Result.failure`) by [LeaseSessionExec.withSession] when
+ * the borrowed-session block does not complete within
+ * [LeaseSessionExec.BLOCK_TIMEOUT_MS] (#935 S4-2). The wedged transport is
+ * evicted so the next borrow re-dials a fresh connection; the action surfaces a
+ * clear, retryable error instead of hanging forever.
+ */
+class LeaseSessionBlockTimeoutException(
+    val timeoutMs: Long,
+) : Exception("SSH lease-session block wedged >${timeoutMs}ms (no progress)")

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -1895,6 +1895,17 @@ public class TmuxSessionViewModel @Inject constructor(
     // [AGENT_EXIT_CONFIRMATIONS] consecutive nulls do we treat the agent as
     // genuinely exited and reconcile it away.
     private val paneAgentNullDetections: MutableMap<String, Int> = ConcurrentHashMap()
+    // Issue #942 (black-screen B2): the wall-clock (elapsedRealtime) of the last
+    // `%output` chunk observed for a pane. A remembered/seeded agent whose grep
+    // detection comes back EMPTY but whose `-CC` channel is still actively
+    // streaming output is WEDGED-but-alive (the #470/#835 capture-behind-a-busy-
+    // agent symptom), not exited — the empty grep raced the busy channel. Such a
+    // `Resolved(null)` must NOT be counted toward [AGENT_EXIT_CONFIRMATIONS] (which
+    // tears the Conversation row down to the raw black Terminal). #897 protected
+    // the `Unavailable` (probe-threw) branch; this protects the still-streaming
+    // `Resolved(null)` branch. A genuinely-exited agent stops emitting output, so
+    // its empty grep arrives with NO recent activity and tears down correctly.
+    private val paneLastOutputAtMs: MutableMap<String, Long> = ConcurrentHashMap()
     // Issue #793: per-pane conversation-load watchdog. Flips a never-completing
     // "Loading conversation…" state to Failed so the tab can't spin forever.
     private val conversationLoadWatchdogJobs: MutableMap<String, Job> = ConcurrentHashMap()
@@ -4497,6 +4508,7 @@ public class TmuxSessionViewModel @Inject constructor(
         paneAgentTailGenerations.clear()
         paneAgentInputs.clear()
         paneAgentNullDetections.clear()
+        paneLastOutputAtMs.clear()
         paneConversationOpenStartedAtMs.clear()
         sessionRecordedKindCache.clear()
         sessionForeignKindGuessCache.clear()
@@ -4604,6 +4616,7 @@ public class TmuxSessionViewModel @Inject constructor(
         paneAgentTailGenerations.clear()
         paneAgentInputs.clear()
         paneAgentNullDetections.clear()
+        paneLastOutputAtMs.clear()
         paneConversationOpenStartedAtMs.clear()
         sessionRecordedKindCache.clear()
         sessionForeignKindGuessCache.clear()
@@ -8333,6 +8346,7 @@ public class TmuxSessionViewModel @Inject constructor(
             paneAgentTailGenerations.remove(paneId)
             paneAgentInputs.remove(paneId)
             paneAgentNullDetections.remove(paneId)
+            paneLastOutputAtMs.remove(paneId)
             paneInputJobs.remove(paneId)?.cancel()
             paneInputQueues.remove(paneId)?.close()
             paneSurfaceRecoveryTimestamps.remove(paneId)
@@ -8420,6 +8434,11 @@ public class TmuxSessionViewModel @Inject constructor(
     }
 
     private fun recordVisiblePaneOutput(event: ControlEvent.Output) {
+        // Issue #942: stamp the pane's last live-output wall-clock so an empty
+        // grep detection can tell a still-streaming (wedged-but-alive) channel
+        // apart from a genuinely-exited agent (no output) before it counts the
+        // empty detection toward agent-exit confirmation.
+        paneLastOutputAtMs[event.paneId] = SystemClock.elapsedRealtime()
         logFirstPaneOutput(event)
     }
 
@@ -10080,6 +10099,22 @@ public class TmuxSessionViewModel @Inject constructor(
      */
     private fun handleNullAgentDetection(pane: TmuxPaneState, guard: RuntimeRefreshGuard): Boolean {
         val paneId = pane.paneId
+        // Issue #942 (black-screen B2, reopen-class): an empty grep
+        // (`Resolved(null)`) on a channel that is STILL actively streaming
+        // output is a WEDGED-but-alive channel (the capture/grep raced behind a
+        // busy agent — the #470/#835 symptom), not an agent that exited. Counting
+        // it toward [AGENT_EXIT_CONFIRMATIONS] is how a remembered Conversation
+        // collapsed to the raw black Terminal after 2× empty detections (#874 D4,
+        // verified live on v0.4.16). #897 protected the `Unavailable` branch; this
+        // guards the still-streaming `Resolved(null)` branch. We only protect a
+        // pane that actually has agent UI to lose — a genuine shell pane (no
+        // remembered/seeded agent, no live detection) is unaffected — and a
+        // genuinely-exited agent stops emitting output, so its empty grep arrives
+        // with NO recent activity and tears down correctly (no over-protection).
+        if (isChannelWedgedButAlive(paneId) && hasProtectableAgentUi(paneId)) {
+            scheduleAgentDetectionRecheck(pane, guard)
+            return false
+        }
         if (shouldDeferAgentDowngrade(paneId)) {
             val nulls = (paneAgentNullDetections[paneId] ?: 0) + 1
             paneAgentNullDetections[paneId] = nulls
@@ -10196,6 +10231,40 @@ public class TmuxSessionViewModel @Inject constructor(
     private fun isAutoSeededPlaceholderUp(paneId: String): Boolean {
         val row = _agentConversations.value[paneId] ?: return false
         return row.autoSeededPlaceholder && row.detection == null
+    }
+
+    /**
+     * Issue #942 (black-screen B2): true when [paneId]'s `-CC` channel produced
+     * a `%output` chunk within the last [CHANNEL_WEDGED_RECENT_OUTPUT_MS] — i.e.
+     * the channel is still actively STREAMING. An empty grep detection
+     * (`Resolved(null)`) on such a channel is the wedged-but-alive
+     * capture-behind-a-busy-agent race (#470/#835), NOT an agent exit, so it must
+     * not be counted toward [AGENT_EXIT_CONFIRMATIONS]. A genuinely-exited agent
+     * stops emitting output, so its empty grep lands with no recent activity and
+     * this returns false (the row tears down correctly — no over-protection).
+     * False when the pane has never emitted output (no entry) or its last output
+     * is older than the window.
+     */
+    private fun isChannelWedgedButAlive(paneId: String): Boolean {
+        val lastOutputAtMs = paneLastOutputAtMs[paneId] ?: return false
+        return SystemClock.elapsedRealtime() - lastOutputAtMs < CHANNEL_WEDGED_RECENT_OUTPUT_MS
+    }
+
+    /**
+     * Issue #942: true when [paneId] currently has agent Conversation UI that an
+     * empty/transient detection could TEAR DOWN to the raw black Terminal — a
+     * live detection, a remembered-agent resolving placeholder (#819 A2), an
+     * auto-seeded detecting placeholder (#878), or a remembered window status the
+     * #495 reattach seed protects (#554). The wedged-channel guard only fires for
+     * such panes; a genuine shell pane (none of these) has nothing to protect, so
+     * its null detection proceeds through the normal path unchanged.
+     */
+    private fun hasProtectableAgentUi(paneId: String): Boolean {
+        val row = _agentConversations.value[paneId]
+        if (row != null && (row.detection != null || row.rememberedAgentPlaceholder || row.autoSeededPlaceholder)) {
+            return true
+        }
+        return shouldDeferAgentDowngrade(paneId)
     }
 
     /**
@@ -11916,6 +11985,40 @@ public class TmuxSessionViewModel @Inject constructor(
     }
 
     /**
+     * Issue #942 test seam: drive the production `%output` activity recorder for
+     * [paneId] (the path the per-pane output collector calls on every live
+     * `%output` chunk), stamping the pane as a STILL-STREAMING (wedged-but-alive)
+     * channel. Lets a JVM test put a remembered/seeded agent's channel into the
+     * wedged-but-alive state synthetically — without standing up a real `-CC`
+     * stream — before injecting the empty `Resolved(null)` detection that #942
+     * must not count toward agent-exit confirmation.
+     */
+    @androidx.annotation.VisibleForTesting
+    internal fun recordPaneOutputActivityForTest(paneId: String) {
+        recordVisiblePaneOutput(ControlEvent.Output(paneId, ByteArray(1)))
+    }
+
+    /**
+     * Issue #942 test seam: clear [paneId]'s recorded `%output` activity so the
+     * channel reads as IDLE (a genuinely-exited agent stops emitting output).
+     * Lets a JVM test prove the genuine-exit case still tears the row down — the
+     * wedged-channel guard must NOT over-protect a channel that went quiet.
+     */
+    @androidx.annotation.VisibleForTesting
+    internal fun clearPaneOutputActivityForTest(paneId: String) {
+        paneLastOutputAtMs.remove(paneId)
+    }
+
+    /**
+     * Issue #942 test seam: true when [paneId]'s channel currently reads as
+     * wedged-but-alive (recent `%output`). Lets a JVM test assert the signal
+     * itself flips with activity vs idleness, independent of the routing.
+     */
+    @androidx.annotation.VisibleForTesting
+    internal fun isChannelWedgedButAliveForTest(paneId: String): Boolean =
+        isChannelWedgedButAlive(paneId)
+
+    /**
      * Issue #897 test seam: drive the degraded/unavailable detection branch
      * directly. Unlike [handleNullAgentDetectionForTest], this path represents
      * an untrustworthy probe and must never confirm agent exit.
@@ -13516,6 +13619,7 @@ public class TmuxSessionViewModel @Inject constructor(
         paneAgentTailGenerations.clear()
         paneAgentInputs.clear()
         paneAgentNullDetections.clear()
+        paneLastOutputAtMs.clear()
         paneConversationOpenStartedAtMs.clear()
         sessionRecordedKindCache.clear()
         sessionForeignKindGuessCache.clear()
@@ -13632,6 +13736,7 @@ public class TmuxSessionViewModel @Inject constructor(
         paneAgentTailGenerations.clear()
         paneAgentInputs.clear()
         paneAgentNullDetections.clear()
+        paneLastOutputAtMs.clear()
         paneConversationOpenStartedAtMs.clear()
         sessionRecordedKindCache.clear()
         sessionForeignKindGuessCache.clear()
@@ -13776,6 +13881,7 @@ public class TmuxSessionViewModel @Inject constructor(
         paneAgentTailGenerations.clear()
         paneAgentInputs.clear()
         paneAgentNullDetections.clear()
+        paneLastOutputAtMs.clear()
         paneConversationOpenStartedAtMs.clear()
         sessionRecordedKindCache.clear()
         sessionForeignKindGuessCache.clear()
@@ -15338,6 +15444,20 @@ internal const val AGENT_EXIT_CONFIRMATIONS: Int = 2
 
 /** Delay before the issue #554 agent-exit confirmation re-detection. */
 internal const val AGENT_EXIT_RECHECK_DELAY_MS: Long = 1_200L
+
+/**
+ * Issue #942 (black-screen B2): how recently a pane must have produced `%output`
+ * for its channel to be treated as WEDGED-but-alive (still streaming) when an
+ * empty grep detection (`Resolved(null)`) lands. Within this window an empty
+ * detection is the capture-behind-a-busy-agent race (#470/#835), not an agent
+ * exit, so it is NOT counted toward [AGENT_EXIT_CONFIRMATIONS]. Sized to comfortably
+ * span a busy agent's brief inter-chunk gaps plus the detection round-trip, while
+ * staying short enough that a genuinely-exited agent (which stops emitting output)
+ * clears the window before its empty grep arrives, so a real exit still tears the
+ * Conversation row down. Two consecutive recheck cycles
+ * ([AGENT_EXIT_RECHECK_DELAY_MS]) fit inside it.
+ */
+internal const val CHANNEL_WEDGED_RECENT_OUTPUT_MS: Long = 3_000L
 
 /**
  * Issue #793: how long the Conversation tab spins on "Loading conversation…"

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -8892,6 +8892,29 @@ public class TmuxSessionViewModel @Inject constructor(
     }
 
     /**
+     * Issue #941 (black-screen B1) test seam: invoke the production switch-reveal
+     * gate [awaitActivePaneSeededOrLoading] directly against the supplied client,
+     * building a runtime guard for the current generation/target. A passthrough —
+     * no test-only behavior. Lets a JVM regression test prove the gate heals a
+     * PARTIAL-black active pane (the switch-to-black symptom) without driving the
+     * full connect coroutine state machine. Returns the gate's reveal decision.
+     */
+    @androidx.annotation.VisibleForTesting
+    internal suspend fun awaitActivePaneSeededOrLoadingForTest(client: TmuxClient): Boolean {
+        val target = activeTarget
+        val guard = if (target != null) {
+            RuntimeRefreshGuard(
+                generation = connectGeneration,
+                target = target,
+                client = client,
+            )
+        } else {
+            null
+        }
+        return awaitActivePaneSeededOrLoading(guard)
+    }
+
+    /**
      * Issue #722 (characterization test seam): arm [armConnectedBlankWatchdog]
      * directly against the supplied guard. A passthrough — no production logic.
      */
@@ -9115,12 +9138,51 @@ public class TmuxSessionViewModel @Inject constructor(
     ): Boolean {
         val client = clientRef ?: return true
         var attempt = 0
+        var partialBlankHealed = false
         while (true) {
             if (refreshGuard != null && !isCurrentRuntime(refreshGuard)) return true
             if (client.disconnected.value) return true
             val activePane = activeVisiblePane() ?: return true
-            if (!activePane.terminalState.visibleScreenIsBlank()) return true
-            // Active pane is blank: try to (re-)seed it before revealing.
+            val blank = activePane.terminalState.visibleScreenIsBlank()
+            val partialBlank = activePane.terminalState.visibleScreenIsPartiallyBlank()
+            if (!blank && !partialBlank) return true
+            // Issue #941 (black-screen B1): a plain session switch can reveal a
+            // PARTIAL-black pane (one live line, the rest of the prior viewport
+            // gone). That reads "not blank", so the pre-#941 gate passed it and the
+            // partial-black pane was revealed as Connected and never reseeded (the
+            // maintainer's "switched and it was black" symptom). Heal it here too —
+            // `seedPaneFromCapture` does a full clear+repaint, so it restores the
+            // FULL viewport from tmux's authoritative grid.
+            //
+            // Over-heal guard: a partial-black read is a HEURISTIC and a real
+            // one-line prompt looks identical to "one live line, rest black". So
+            // for partial-black we do EXACTLY ONE heal capture, then REVEAL — never
+            // loop while it persists (a real prompt legitimately stays "partial",
+            // and re-capturing it just re-paints the same content). Only a FULLY
+            // blank pane keeps the bounded retry loop (a degraded link's empty
+            // capture genuinely needs another attempt). This prevents reseed-thrash
+            // and a spurious "Attaching…" overlay on a real blank prompt.
+            if (!blank && partialBlank) {
+                if (partialBlankHealed) return true
+                Log.i(
+                    ISSUE_145_RECONNECT_TAG,
+                    "tmux-reveal-gate-active-pane-partial-blank pane=${activePane.paneId} " +
+                        "session=${activeTarget?.sessionName} -> one heal capture then reveal",
+                )
+                seedPaneFromCapture(
+                    client = client,
+                    pane = activePane,
+                    refreshGuard = refreshGuard,
+                    recordMilestone = false,
+                    maxAttempts = 1,
+                )
+                partialBlankHealed = true
+                // Reveal regardless of the post-heal partial-black read (a real
+                // small prompt is legitimately partial); the capture restored
+                // whatever tmux's grid holds.
+                return true
+            }
+            // Active pane is FULLY blank: try to (re-)seed it before revealing.
             Log.i(
                 ISSUE_145_RECONNECT_TAG,
                 "tmux-reveal-gate-active-pane-blank pane=${activePane.paneId} " +
@@ -9191,6 +9253,17 @@ public class TmuxSessionViewModel @Inject constructor(
                 if (activePane == null || !activePane.terminalState.visibleScreenIsBlank()) {
                     // A frame landed (seed or live %output) — drop the loading
                     // overlay and let the Connected surface show the content.
+                    //
+                    // Issue #941 (black-screen B1): the watchdog INTENTIONALLY stays
+                    // FULLY-blank-only here. A partial-black active pane (one live
+                    // line) is healed by the switch-reveal gate BEFORE this watchdog
+                    // is even armed ([awaitActivePaneSeededOrLoading]), and a
+                    // send-overpaint partial-black is healed by the post-send heal
+                    // ([scheduleSendOverpaintHeal]). Extending this post-reveal net to
+                    // partial-black would over-heal a legitimately small single-line
+                    // pane (a real one-line prompt that landed after reveal reads
+                    // partial-black), reseed-thrashing it on every arming — so the
+                    // watchdog keeps its narrow fully-blank contract.
                     if (_switchHidesTerminal.value) _switchHidesTerminal.value = false
                     return@launch
                 }
@@ -11067,6 +11140,64 @@ public class TmuxSessionViewModel @Inject constructor(
             awaitAgentPasteIngestedBeforeSubmit(client, paneId, payload, agent)
             client.sendCommand("send-keys -t $paneId Enter")
                 .throwIfTmuxError("submit pasted agent input")
+            // Issue #941 (black-screen B1): the maintainer's "I sent a message and
+            // everything became black" symptom. After the submit Enter, a full-screen
+            // agent TUI repaints — it can `clear`+redraw and emit a `%output` overpaint
+            // that leaves the active pane PARTIAL-black (a single live status/spinner
+            // line, the rest of the prior viewport gone). The reattach/manual-Redraw
+            // heals already restore a partial-black pane; a SEND-triggered overpaint had
+            // NO heal, so the pane stayed black until the user manually redrew. Schedule
+            // a one-shot, guarded active-pane heal that fires ONLY if the pane settles
+            // partial-black/blank after the overpaint.
+            scheduleSendOverpaintHeal(client, paneId)
+        }
+    }
+
+    /**
+     * Issue #941 (black-screen B1): after a send's submit Enter, the agent's
+     * `%output` overpaint can leave the active pane partial-black. Wait one settle
+     * tick for the overpaint to land, then — ONLY if the active pane is blank /
+     * partial-black — do the UNCONDITIONAL active-pane full-viewport restore
+     * ([reseedActivePaneForReattach], a `capture-pane` clear+repaint). Guarded by a
+     * [RuntimeRefreshGuard] keyed to the current generation + target + client so a
+     * late heal can never paint a switched-away session, and scoped to the pane the
+     * user is actually looking at (the active visible pane), since only that pane's
+     * overpaint is the reported "everything went black".
+     *
+     * One-shot, no loop: a real one-line agent prompt looks partial-black too, and
+     * re-capturing it just re-paints the same authoritative content, so there is no
+     * reseed-thrash. The heal is a no-op when the overpaint left a normally-painted
+     * pane (the common case — a multi-line agent response), so a healthy send costs
+     * nothing beyond the cheap blank/partial-blank pre-check.
+     */
+    private fun scheduleSendOverpaintHeal(client: TmuxClient, paneId: String) {
+        val target = activeTarget ?: return
+        val healGeneration = connectGeneration
+        bridgeScope.launch {
+            // Let the post-submit agent overpaint land before judging the pane.
+            delay(SEND_OVERPAINT_HEAL_SETTLE_MS)
+            if (clientRef !== client) return@launch
+            if (client.disconnected.value) return@launch
+            val activePane = activeVisiblePane() ?: return@launch
+            // Heal only the pane the send targeted while it is still the active pane
+            // (the reported "sent a message → everything black" is the focused pane).
+            if (activePane.paneId != paneId) return@launch
+            val blank = activePane.terminalState.visibleScreenIsBlank()
+            val partialBlank = activePane.terminalState.visibleScreenIsPartiallyBlank()
+            if (!blank && !partialBlank) return@launch
+            Log.i(
+                ISSUE_145_RECONNECT_TAG,
+                "tmux-send-overpaint-active-pane-heal pane=${activePane.paneId} " +
+                    "window=${activePane.windowId} session=${target.sessionName} " +
+                    "blank=$blank partialBlank=$partialBlank",
+            )
+            reseedActivePaneForReattach(
+                RuntimeRefreshGuard(
+                    generation = healGeneration,
+                    target = target,
+                    client = client,
+                ),
+            )
         }
     }
 
@@ -15053,6 +15184,15 @@ internal const val CONNECTED_BLANK_WATCHDOG_TICK_MS: Long = 500L
  * over once the channel actually drops.
  */
 internal const val CONNECTED_BLANK_WATCHDOG_MAX_TICKS: Int = 20
+
+/**
+ * Issue #941 (black-screen B1): after a send's submit Enter, wait this long for
+ * the agent's `%output` overpaint to land before judging whether the active pane
+ * settled partial-black/blank and needs the one-shot send-overpaint heal. Short
+ * enough that the heal restores a black pane promptly, long enough that a normal
+ * multi-line agent response has painted (so the heal correctly no-ops).
+ */
+internal const val SEND_OVERPAINT_HEAL_SETTLE_MS: Long = 350L
 
 /**
  * Parse a tmux `display-message -p '#{cursor_x},#{cursor_y}'` reply line

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -9558,6 +9558,33 @@ public class TmuxSessionViewModel @Inject constructor(
      *
      * Only seeds when there is no existing conversation row for the pane
      * (a fresh attach), so it never clobbers live state mid-session.
+     *
+     * Issue #819 (Slice A2 — re-anchor, don't trust the remembered source):
+     * the seed used to restore `remembered.detection` BLIND and render it
+     * `Live` immediately. That `detection` carries a `sourcePath`, and the
+     * conversation source is selected by mtime among same-cwd same-kind
+     * candidates — so when a sibling / sub-agent / second window/worktree
+     * Codex rollout shared the cwd, the remembered `sourcePath` could be the
+     * WRONG session's rollout, captured during a prior mis-pick. Rendering it
+     * `Live` before live re-detection re-bound the route-true source showed the
+     * Conversation tab a DIFFERENT transcript than the route-named Terminal —
+     * the reported `ai-shipping-labs` header vs `git-pocketshell-desktop-codex`
+     * divergence. The route-true source can only be re-confirmed by the live
+     * `detectRecordedSessionForPane` `/proc/<pid>/fd` round-trip
+     * ([AgentDetector.detect]'s owned-then-refuse-to-guess pin, #819 Slice A1).
+     *
+     * So the seed now restores ONLY the remembered KIND + the user's tab choice
+     * as a RESOLVING placeholder ([rememberedAgentPlaceholder] = true,
+     * `detection = null`, [ConversationLoadState.Loading]) — never the stale
+     * `sourcePath`. The Conversation tab still appears instantly on reattach
+     * (no black-Terminal flash, the #495 benefit preserved), but it shows
+     * "Loading conversation…" until live detection binds the route's OWN source,
+     * instead of flashing a sibling's transcript. The placeholder is held and
+     * re-confirmed across a transient post-reattach null (a CONFIRMED-prior agent
+     * window — the #554 no-flap guarantee, via [shouldDeferAgentDowngrade]); only
+     * after [AGENT_EXIT_CONFIRMATIONS] consecutive nulls is it torn down by
+     * [clearAgentDetectionForPane] (the agent genuinely exited). This NEVER tears
+     * the pane down to a raw shell on the first null (no #554 flap regression).
      */
     private fun seedAgentConversationFromMemory(pane: TmuxPaneState) {
         val target = activeTarget ?: return
@@ -9572,7 +9599,11 @@ public class TmuxSessionViewModel @Inject constructor(
         setAgentConversation(
             pane.paneId,
             AgentConversationUiState(
-                detection = remembered.detection,
+                // Issue #819 (A2): do NOT carry remembered.detection.sourcePath
+                // — it may be a stale/sibling source from a prior mis-pick. Seed
+                // detection-less; live detectRecordedSessionForPane re-anchors
+                // the route-true source via the /proc/<pid>/fd pin (A1).
+                detection = null,
                 events = emptyList(),
                 selectedTab = if (remembered.wasOnConversation) {
                     SessionTab.Conversation
@@ -9580,8 +9611,21 @@ public class TmuxSessionViewModel @Inject constructor(
                     SessionTab.Terminal
                 },
                 syncStatus = AgentConversationSyncStatus.Live,
+                // Issue #819 (A2): hold "Loading conversation…" — a resolving
+                // placeholder, not the stale transcript — until live detection
+                // binds the real source.
+                loadState = ConversationLoadState.Loading,
+                // Issue #819 (A2): mark this as the remembered-agent placeholder
+                // so a transient post-reattach null is held + re-confirmed (a
+                // KNOWN agent, the #554 no-flap guarantee) and a confirmed exit
+                // tears it down instead of stranding it on "Loading…".
+                rememberedAgentPlaceholder = true,
             ),
         )
+        // Issue #819 (A2): arm the load watchdog so a never-arriving live
+        // re-detection resolves the placeholder to a clear terminal state
+        // instead of spinning forever (mirrors seedPresumedAgentPlaceholder).
+        armConversationLoadWatchdog(pane.paneId)
     }
 
     /**
@@ -9616,11 +9660,17 @@ public class TmuxSessionViewModel @Inject constructor(
         }
         if (isShell) {
             // Drop any auto-seeded placeholder that raced ahead of this verdict.
+            // Issue #819 (A2): a remembered-agent resolving placeholder for a
+            // session the durable tree now confirms is a SHELL is a STALE
+            // reattach seed (the window's agent exited and was replaced by a
+            // shell since memory was recorded) — drop it too, so a confirmed
+            // shell never lingers on the #819 "Loading conversation…" resolving
+            // placeholder.
             val shellPaneIds = paneRows.values
                 .filter { it.sessionId.trim() == key }
                 .map { it.paneId }
             for (paneId in shellPaneIds) {
-                if (isAutoSeededPlaceholderUp(paneId)) {
+                if (isAutoSeededPlaceholderUp(paneId) || isRememberedAgentPlaceholderUp(paneId)) {
                     conversationLoadWatchdogJobs.remove(paneId)?.cancel()
                     paneAgentNullDetections.remove(paneId)
                     clearAgentDetectionForPane(paneId)
@@ -10085,7 +10135,11 @@ public class TmuxSessionViewModel @Inject constructor(
             scheduleAgentDetectionRecheck(pane, guard)
             return false
         }
-        if (row?.autoSeededPlaceholder == true) {
+        // Issue #819 (A2): a remembered-agent resolving placeholder (detection
+        // still null while the route-true source is being re-bound) is a
+        // KNOWN-prior agent — a degraded probe must keep retrying it, not strand
+        // it on "Loading…", exactly as for the #878 auto-seed below.
+        if (row?.autoSeededPlaceholder == true || row?.rememberedAgentPlaceholder == true) {
             scheduleAgentDetectionRecheck(pane, guard)
             return false
         }
@@ -10100,6 +10154,17 @@ public class TmuxSessionViewModel @Inject constructor(
      * detection. In that state a transient null after a reconnect is almost
      * always a detection-not-yet-warm race, not a genuine agent exit, so we
      * hold the agent UI and re-confirm before tearing it down.
+     *
+     * Issue #819 (Slice A2): the #495 reattach seed now restores the remembered
+     * window as a detection-LESS resolving placeholder
+     * ([AgentConversationUiState.rememberedAgentPlaceholder] = true) instead of
+     * carrying the (possibly stale) remembered source. That placeholder is just
+     * as much a confirmed-prior agent that a transient post-reattach null must
+     * NOT tear down, so the "still showing the seeded agent UI" condition below
+     * holds for BOTH a real detection AND a remembered resolving placeholder.
+     * Without this the A2 seed would re-introduce the #554 flap (a remembered
+     * agent dropped to a raw shell on the first null because its `detection` is
+     * now null until the live re-bind lands).
      */
     private fun shouldDeferAgentDowngrade(paneId: String): Boolean {
         val target = activeTarget ?: return false
@@ -10113,8 +10178,10 @@ public class TmuxSessionViewModel @Inject constructor(
         ) ?: return false
         // Only defer while the seeded agent UI is actually still showing; once
         // detection has confirmed an exit and the row is gone, there is
-        // nothing to protect.
-        return _agentConversations.value[paneId]?.detection != null
+        // nothing to protect. A remembered resolving placeholder (#819 A2)
+        // counts as "still showing" even though its detection is null.
+        val row = _agentConversations.value[paneId] ?: return false
+        return row.detection != null || row.rememberedAgentPlaceholder
     }
 
     /**
@@ -10129,6 +10196,18 @@ public class TmuxSessionViewModel @Inject constructor(
     private fun isAutoSeededPlaceholderUp(paneId: String): Boolean {
         val row = _agentConversations.value[paneId] ?: return false
         return row.autoSeededPlaceholder && row.detection == null
+    }
+
+    /**
+     * Issue #819 (A2): true when a REMEMBERED-agent resolving placeholder is
+     * currently up for [paneId] — the #495 reattach seed, now detection-less,
+     * holding "Loading conversation…" while live `detectRecordedSessionForPane`
+     * re-anchors the route-true source. False once a real detection lands (the
+     * flag is cleared) or the row is gone.
+     */
+    private fun isRememberedAgentPlaceholderUp(paneId: String): Boolean {
+        val row = _agentConversations.value[paneId] ?: return false
+        return row.rememberedAgentPlaceholder && row.detection == null
     }
 
     /**
@@ -10184,6 +10263,19 @@ public class TmuxSessionViewModel @Inject constructor(
                 // own teardown; it is NOT a #815 yank (no user-chosen tab is
                 // being changed — the user never picked this view).
                 current.autoSeededPlaceholder -> {
+                    rowDropped = true
+                    null
+                }
+                // Issue #819 (A2): a REMEMBERED-agent resolving placeholder (the
+                // #495 reattach seed, now detection-less) whose live re-detection
+                // came back null AFTER the #554 hold/re-confirm window means the
+                // agent genuinely exited — drop it so it does not strand on
+                // "Loading conversation…". Like the auto-seed teardown above, this
+                // is NOT a #815 yank (no user-chosen tab is being changed). The
+                // transient post-reattach null was already absorbed by
+                // shouldDeferAgentDowngrade's AGENT_EXIT_CONFIRMATIONS hold, so by
+                // the time we reach here the exit is confirmed.
+                current.rememberedAgentPlaceholder -> {
                     rowDropped = true
                     null
                 }
@@ -11861,6 +11953,21 @@ public class TmuxSessionViewModel @Inject constructor(
     internal fun seedPresumedAgentPlaceholderForTest(paneId: String) {
         val pane = paneRows[paneId] ?: return
         seedPresumedAgentPlaceholder(pane)
+    }
+
+    /**
+     * Issue #819 (A2) test seam: drive [seedAgentConversationFromMemory]
+     * directly for the row registered under [paneId]. Mirrors the pane-add
+     * call in [applyParsedPanes] so a test can assert the reattach seed restores
+     * the remembered window as a RESOLVING placeholder (detection-less,
+     * [AgentConversationUiState.rememberedAgentPlaceholder] = true) — NOT the
+     * remembered (possibly stale/sibling) `detection.sourcePath` rendered Live —
+     * without standing up the SSH/JSONL detection round-trip.
+     */
+    @androidx.annotation.VisibleForTesting
+    internal fun seedAgentConversationFromMemoryForTest(paneId: String) {
+        val pane = paneRows[paneId] ?: return
+        seedAgentConversationFromMemory(pane)
     }
 
     /**

--- a/app/src/test/java/com/pocketshell/app/cards/SessionCardRenderersTest.kt
+++ b/app/src/test/java/com/pocketshell/app/cards/SessionCardRenderersTest.kt
@@ -1,0 +1,71 @@
+package com.pocketshell.app.cards
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #859 Slice B: prove the renderer registry is genuinely generic — the
+ * feed dispatches by `type` through the registry, not a `when (type)` ladder.
+ */
+class SessionCardRenderersTest {
+
+    @Test
+    fun checklistTypeResolvesToChecklistRenderer() {
+        assertSame(
+            ChecklistCardRenderer,
+            SessionCardRenderers.rendererFor(SessionCardsRemoteSource.TYPE_CHECKLIST),
+        )
+    }
+
+    @Test
+    fun noteTypeResolvesToNoteRenderer() {
+        // The whole point of Slice B: `note` is a registered renderer, so it
+        // dispatches without a feed code change.
+        assertSame(
+            NoteCardRenderer,
+            SessionCardRenderers.rendererFor(SessionCardsRemoteSource.TYPE_NOTE),
+        )
+    }
+
+    @Test
+    fun unknownTypeFallsBackToUnknownRenderer() {
+        assertSame(
+            UnknownCardRenderer,
+            SessionCardRenderers.rendererFor("approval"),
+        )
+        assertSame(
+            UnknownCardRenderer,
+            SessionCardRenderers.rendererFor(""),
+        )
+    }
+
+    @Test
+    fun registeredTypesAreChecklistAndNote() {
+        assertEquals(setOf("checklist", "note"), SessionCardRenderers.registeredTypes())
+    }
+
+    @Test
+    fun cardFeedChipCountsAllCardTypes() {
+        val state = cardFeedChipState(
+            listOf(
+                SessionCardsRemoteSource.ChecklistCard(
+                    id = "c", title = null, createdAt = null, updatedAt = null,
+                    items = listOf(SessionCardsRemoteSource.ChecklistItem("i", "Build")),
+                    checkedIds = emptySet(),
+                ),
+                SessionCardsRemoteSource.NoteCard(
+                    id = "n", title = null, createdAt = null, updatedAt = null,
+                    text = "fyi", read = false,
+                ),
+            ),
+        )
+        assertEquals(SessionCardFeedChipUiState(cardCount = 2), state)
+    }
+
+    @Test
+    fun cardFeedChipNullForEmptyFeed() {
+        assertTrue(cardFeedChipState(emptyList()) == null)
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/cards/SessionCardsRemoteSourceTest.kt
+++ b/app/src/test/java/com/pocketshell/app/cards/SessionCardsRemoteSourceTest.kt
@@ -41,13 +41,13 @@ class SessionCardsRemoteSourceTest {
                       "state": {"checked": ["build-0"]}
                     },
                     {
-                      "id": "note-1",
-                      "type": "note",
+                      "id": "future-1",
+                      "type": "approval",
                       "title": "Heads up",
                       "created_at": "2026-06-20T21:00:00+00:00",
                       "updated_at": "2026-06-20T21:00:00+00:00",
-                      "body": {"text": "later type"},
-                      "state": {"read": false}
+                      "body": {"choices": ["yes", "no"]},
+                      "state": {"chosen": null}
                     }
                   ]
                 }
@@ -64,13 +64,143 @@ class SessionCardsRemoteSourceTest {
         assertEquals("2026-06-20T20:00:00+00:00", checklist.createdAt)
         assertEquals(listOf("build", "ship"), checklist.items.map { it.text })
         assertEquals(setOf("build-0"), checklist.checkedIds)
+        // A type with no registered renderer still degrades to UnknownCard.
         val unknown = feed.cards[1] as SessionCardsRemoteSource.UnknownCard
-        assertEquals("note", unknown.type)
+        assertEquals("approval", unknown.type)
         assertEquals("Heads up", unknown.title)
 
         val command = session.recorded.single()
         assertTrue(command, command.contains("push get --json"))
         assertTrue(command, command.contains("--session 'demo'"))
+    }
+
+    @Test
+    fun getCardsParsesNoteCardViaRegistry() = runTest {
+        // #859 Slice B: a `note` card now parses into a typed NoteCard (no code
+        // change to the feed dispatch — it is a registered type), where before
+        // Slice B it degraded to an UnknownCard tombstone.
+        val session = cardsSession(
+            getStdout = """
+                {
+                  "session": "demo",
+                  "cards": [
+                    {
+                      "id": "note",
+                      "type": "note",
+                      "title": "Heads up",
+                      "created_at": "2026-06-25T10:00:00+00:00",
+                      "updated_at": "2026-06-25T10:01:00+00:00",
+                      "body": {"text": "deploy finished"},
+                      "state": {"read": true, "read_at": "2026-06-25T10:01:00+00:00"}
+                    }
+                  ]
+                }
+            """.trimIndent(),
+        )
+
+        val feed = source.getCards(session, tmuxSessionName = "demo")
+
+        val note = feed.cards.single() as SessionCardsRemoteSource.NoteCard
+        assertEquals("note", note.id)
+        assertEquals("Heads up", note.title)
+        assertEquals("deploy finished", note.text)
+        assertTrue(note.read)
+    }
+
+    @Test
+    fun getCardsParsesMixedChecklistAndNoteFeed() = runTest {
+        val session = cardsSession(
+            getStdout = """
+                {
+                  "session": "demo",
+                  "cards": [
+                    {
+                      "id": "checklist", "type": "checklist", "title": "Deploy",
+                      "body": {"items": [{"id": "build-0", "text": "build"}]},
+                      "state": {"checked": []}
+                    },
+                    {
+                      "id": "note", "type": "note", "title": null,
+                      "body": {"text": "fyi"}, "state": {"read": false}
+                    },
+                    {
+                      "id": "future", "type": "approval", "title": "Approve?",
+                      "body": {}, "state": {}
+                    }
+                  ]
+                }
+            """.trimIndent(),
+        )
+
+        val feed = source.getCards(session, tmuxSessionName = "demo")
+
+        assertEquals(3, feed.cards.size)
+        assertTrue(feed.cards[0] is SessionCardsRemoteSource.ChecklistCard)
+        val note = feed.cards[1] as SessionCardsRemoteSource.NoteCard
+        assertEquals("fyi", note.text)
+        assertFalse(note.read)
+        // A genuinely unknown future type still degrades to UnknownCard.
+        val unknown = feed.cards[2] as SessionCardsRemoteSource.UnknownCard
+        assertEquals("approval", unknown.type)
+    }
+
+    @Test
+    fun setNoteReadBuildsReadCommandAndReturnsAck() = runTest {
+        val session = cardsSession(readResult = ExecResult("note: read", "", 0))
+
+        val ok = source.setNoteRead(
+            session = session,
+            tmuxSessionName = "demo ' prod",
+            cardId = "no'te",
+            read = true,
+        )
+
+        assertTrue(ok)
+        val command = session.recorded.single()
+        assertTrue(command, command.contains("push read"))
+        assertTrue(command, command.contains("--id ${shellQuote("no'te")}"))
+        assertTrue(command, command.contains("--read"))
+        assertTrue(command, command.contains("--session ${shellQuote("demo ' prod")}"))
+    }
+
+    @Test
+    fun setNoteUnreadUsesUnreadFlagAndFalseOnFailure() = runTest {
+        val session = cardsSession(readResult = ExecResult("", "no card", 2))
+
+        val ok = source.setNoteRead(
+            session = session,
+            tmuxSessionName = "demo",
+            cardId = "note",
+            read = false,
+        )
+
+        assertFalse(ok)
+        val command = session.recorded.single()
+        assertTrue(command, command.contains("--unread"))
+        assertFalse(command.contains("--read "))
+    }
+
+    @Test
+    fun blankNoteInputsDoNotRunReadCommand() = runTest {
+        val session = cardsSession()
+
+        assertFalse(
+            source.setNoteRead(
+                session = session,
+                tmuxSessionName = " ",
+                cardId = "note",
+                read = true,
+            ),
+        )
+        assertFalse(
+            source.setNoteRead(
+                session = session,
+                tmuxSessionName = "demo",
+                cardId = " ",
+                read = true,
+            ),
+        )
+        assertTrue(session.recorded.isEmpty())
     }
 
     @Test
@@ -179,14 +309,17 @@ class SessionCardsRemoteSourceTest {
         getStdout: String = "",
         getResult: ExecResult? = null,
         checkResult: ExecResult = ExecResult("", "", 0),
+        readResult: ExecResult = ExecResult("", "", 0),
     ): RoutingSshSession = RoutingSshSession(
         getResult = getResult ?: ExecResult(getStdout, "", 0),
         checkResult = checkResult,
+        readResult = readResult,
     )
 
     private class RoutingSshSession(
         private val getResult: ExecResult,
         private val checkResult: ExecResult,
+        private val readResult: ExecResult,
     ) : SshSession {
         val recorded = mutableListOf<String>()
         override val isConnected: Boolean = true
@@ -196,6 +329,7 @@ class SessionCardsRemoteSourceTest {
             return when {
                 command.contains("push get") -> getResult
                 command.contains("push check") -> checkResult
+                command.contains("push read") -> readResult
                 else -> ExecResult("", "no route for $command", 127)
             }
         }

--- a/app/src/test/java/com/pocketshell/app/fileviewer/MarkdownParserOldBehaviorProofTest.kt
+++ b/app/src/test/java/com/pocketshell/app/fileviewer/MarkdownParserOldBehaviorProofTest.kt
@@ -55,4 +55,42 @@ class MarkdownParserOldBehaviorProofTest {
         val link = MarkdownParser.parseInline(md).filterIsInstance<InlineSpan.Link>().single()
         assertEquals("https://en.wikipedia.org/wiki/Foo_(bar)", link.url)
     }
+
+    /**
+     * Failing-on-old PROOF for issue #921. The pre-fix parser had no table
+     * branch, so a GFM pipe table fell through to the paragraph collector and
+     * the raw `|---|---|` delimiter row was joined into the visible paragraph
+     * text (`oldParagraphJoin` reconstructs that). The shipped parser instead
+     * emits a [MarkdownBlock.Table] and never leaks the delimiter as text.
+     */
+    private val tableSource =
+        "| Name | Score |\n|------|-------|\n| foo | 12 |\n| bar | 34 |"
+
+    /** Replicates the pre-fix paragraph join: soft-wrap lines joined by spaces. */
+    private fun oldParagraphJoin(src: String): String =
+        src.split("\n").joinToString(" ") { it.trim() }
+
+    @Test
+    fun `old parser leaked the raw pipe-table delimiter as paragraph text, new parser renders a table`() {
+        // Old: the whole table — including the `|------|-------|` delimiter row —
+        // would render as one raw paragraph string.
+        val oldText = oldParagraphJoin(tableSource)
+        assertTrue(
+            "the pre-fix paragraph join must contain the raw `|---|` delimiter",
+            oldText.contains("|------|-------|"),
+        )
+
+        // New: a real Table block, and NO paragraph carries the raw delimiter.
+        val blocks = MarkdownParser.parse(tableSource)
+        val table = blocks.filterIsInstance<MarkdownBlock.Table>().single()
+        assertEquals(2, table.header.size)
+        assertEquals(2, table.rows.size)
+        assertTrue(
+            "no paragraph may carry the raw `|---|` delimiter text after the fix",
+            blocks.none {
+                it is MarkdownBlock.Paragraph &&
+                    it.spans.filterIsInstance<InlineSpan.Text>().any { s -> s.text.contains("---") }
+            },
+        )
+    }
 }

--- a/app/src/test/java/com/pocketshell/app/fileviewer/MarkdownParserTest.kt
+++ b/app/src/test/java/com/pocketshell/app/fileviewer/MarkdownParserTest.kt
@@ -160,4 +160,172 @@ class MarkdownParserTest {
         assertFalse("URL tail must not leak as text", plain.trim().startsWith(")"))
         assertTrue(plain.contains("here"))
     }
+
+    // ---- Issue #921: GFM pipe tables ----
+
+    /**
+     * Reproduce-first (D33/G10): a GitHub-flavored pipe table — header row +
+     * `|---|---|` delimiter + body rows — must parse to a [MarkdownBlock.Table],
+     * NOT a [MarkdownBlock.Paragraph] of raw pipe text. Before the fix the
+     * parser had no table branch, so this same source parsed as a single
+     * paragraph whose text still contained the literal `|` and `---` delimiter —
+     * this assertion was red on base.
+     */
+    @Test
+    fun `gfm pipe table parses as a table block, not a raw paragraph`() {
+        val src = """
+            | Name | Score |
+            |------|-------|
+            | foo  | 12    |
+            | bar  | 34    |
+        """.trimIndent()
+        val blocks = MarkdownParser.parse(src)
+        // The bug: parsed as a paragraph carrying the raw `|---|` delimiter text.
+        assertFalse(
+            "table source must NOT parse as a raw paragraph",
+            blocks.any {
+                it is MarkdownBlock.Paragraph &&
+                    (it.spans.filterIsInstance<InlineSpan.Text>().any { s -> s.text.contains("---") } ||
+                        it.spans.filterIsInstance<InlineSpan.Text>().any { s -> s.text.contains("|") })
+            },
+        )
+        val table = blocks.filterIsInstance<MarkdownBlock.Table>().single()
+        // Header has two columns.
+        assertEquals(2, table.header.size)
+        assertEquals("Name", (table.header[0].single() as InlineSpan.Text).text)
+        assertEquals("Score", (table.header[1].single() as InlineSpan.Text).text)
+        // Two body rows, each with two cells.
+        assertEquals(2, table.rows.size)
+        assertEquals("foo", (table.rows[0][0].single() as InlineSpan.Text).text)
+        assertEquals("12", (table.rows[0][1].single() as InlineSpan.Text).text)
+        assertEquals("bar", (table.rows[1][0].single() as InlineSpan.Text).text)
+        assertEquals("34", (table.rows[1][1].single() as InlineSpan.Text).text)
+    }
+
+    @Test
+    fun `table delimiter row is detected with and without outer pipes`() {
+        assertTrue(MarkdownParser.isTableDelimiterRow("|---|---|"))
+        assertTrue(MarkdownParser.isTableDelimiterRow("---|---"))
+        assertTrue(MarkdownParser.isTableDelimiterRow("| :--- | ---: | :--: |"))
+        assertTrue(MarkdownParser.isTableDelimiterRow("|-|"))
+        // Not a delimiter row: a header / data row of words.
+        assertFalse(MarkdownParser.isTableDelimiterRow("| Name | Score |"))
+        // Not a delimiter row: no dashes at all.
+        assertFalse(MarkdownParser.isTableDelimiterRow("| : | : |"))
+        // Plain text with no pipe is not a delimiter row.
+        assertFalse(MarkdownParser.isTableDelimiterRow("just text"))
+    }
+
+    @Test
+    fun `delimiter colons set per-column alignment`() {
+        val src = """
+            | L | C | R | N |
+            | :--- | :--: | ---: | --- |
+            | a | b | c | d |
+        """.trimIndent()
+        val table = MarkdownParser.parse(src).filterIsInstance<MarkdownBlock.Table>().single()
+        assertEquals(
+            listOf(
+                MarkdownBlock.Table.Alignment.LEFT,
+                MarkdownBlock.Table.Alignment.CENTER,
+                MarkdownBlock.Table.Alignment.RIGHT,
+                MarkdownBlock.Table.Alignment.NONE,
+            ),
+            table.alignments,
+        )
+    }
+
+    @Test
+    fun `inline markup inside table cells is parsed`() {
+        val src = """
+            | Field | Value |
+            |-------|-------|
+            | **bold** | `code` |
+        """.trimIndent()
+        val table = MarkdownParser.parse(src).filterIsInstance<MarkdownBlock.Table>().single()
+        val boldCell = table.rows[0][0]
+        assertTrue(boldCell.filterIsInstance<InlineSpan.Text>().any { it.bold && it.text == "bold" })
+        val codeCell = table.rows[0][1]
+        assertEquals("code", codeCell.filterIsInstance<InlineSpan.Code>().single().text)
+    }
+
+    @Test
+    fun `a pipe line without a delimiter row stays a paragraph`() {
+        // A lone "| a | b |" with no `|---|` row underneath is NOT a table.
+        val blocks = MarkdownParser.parse("| a | b |\nnext line")
+        assertTrue(blocks.all { it !is MarkdownBlock.Table })
+        assertTrue(blocks.any { it is MarkdownBlock.Paragraph })
+    }
+
+    @Test
+    fun `table ends at a blank line and following content parses separately`() {
+        val src = """
+            | A | B |
+            |---|---|
+            | 1 | 2 |
+
+            After the table.
+        """.trimIndent()
+        val blocks = MarkdownParser.parse(src)
+        val table = blocks.filterIsInstance<MarkdownBlock.Table>().single()
+        assertEquals(1, table.rows.size)
+        val para = blocks.filterIsInstance<MarkdownBlock.Paragraph>().single()
+        assertEquals("After the table.", (para.spans.single() as InlineSpan.Text).text)
+    }
+
+    @Test
+    fun `escaped pipe inside a cell is literal, not a column separator`() {
+        val src = """
+            | Expr | Note |
+            |------|------|
+            | a \| b | or |
+        """.trimIndent()
+        val table = MarkdownParser.parse(src).filterIsInstance<MarkdownBlock.Table>().single()
+        assertEquals(2, table.rows[0].size)
+        assertEquals("a | b", (table.rows[0][0].single() as InlineSpan.Text).text)
+    }
+
+    /**
+     * Regression (issue #921 review): a `|`-containing PROSE line immediately
+     * followed by a `---` thematic break must NOT be misparsed as a table. A
+     * single `---` is a valid 1-cell delimiter row, so the bare delimiter check
+     * swallowed the horizontal rule. The GFM guard is that the delimiter row's
+     * cell count must EQUAL the header row's cell count — `"foo | bar"` has 2
+     * columns, `"---"` has 1, so it is not a table.
+     */
+    @Test
+    fun `pipe prose line above a thematic break is a paragraph plus rule, not a table`() {
+        val blocks = MarkdownParser.parse("foo | bar\n---\nnext para")
+        assertTrue("must not be a table", blocks.none { it is MarkdownBlock.Table })
+        assertEquals(
+            listOf("Paragraph", "HorizontalRule", "Paragraph"),
+            blocks.map { it::class.simpleName },
+        )
+        assertEquals(
+            "foo | bar",
+            ((blocks[0] as MarkdownBlock.Paragraph).spans.single() as InlineSpan.Text).text,
+        )
+    }
+
+    @Test
+    fun `pipe heading line above a closing thematic break is not a table`() {
+        val blocks = MarkdownParser.parse("Heading text | more\n---")
+        assertTrue("must not be a table", blocks.none { it is MarkdownBlock.Table })
+        assertEquals(
+            listOf("Paragraph", "HorizontalRule"),
+            blocks.map { it::class.simpleName },
+        )
+    }
+
+    /**
+     * The column-count guard must also reject a delimiter row whose cell count
+     * differs from the header for any other reason (a genuinely malformed table
+     * stays prose rather than rendering a lopsided grid).
+     */
+    @Test
+    fun `delimiter row with a different column count than the header is not a table`() {
+        // Header has 2 columns, delimiter has 3 — not a table.
+        val blocks = MarkdownParser.parse("| a | b |\n|---|---|---|\n| 1 | 2 |")
+        assertTrue("mismatched column count must not parse as a table", blocks.none { it is MarkdownBlock.Table })
+    }
 }

--- a/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelHostUpgradeTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelHostUpgradeTest.kt
@@ -1,0 +1,386 @@
+package com.pocketshell.app.projects
+
+import androidx.lifecycle.ViewModelStore
+import androidx.test.core.app.ApplicationProvider
+import com.pocketshell.app.hosts.MainDispatcherRule
+import com.pocketshell.app.portfwd.ForwardingController
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.SshLeaseConnector
+import com.pocketshell.core.ssh.SshLeaseManager
+import com.pocketshell.core.ssh.SshPortForward
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshShell
+import com.pocketshell.core.storage.dao.HostDao
+import com.pocketshell.core.storage.dao.ProjectRootDao
+import com.pocketshell.core.storage.entity.HostEntity
+import com.pocketshell.core.storage.entity.ProjectRootEntity
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Issue #947 — RED→GREEN for the host-version-mismatch banner's one-tap
+ * **Update** action, which runs the host `pocketshell` upgrade over the EXISTING
+ * warm SSH session (D21) and clears the banner on success / surfaces the error on
+ * failure (no stuck spinner — #939/#944).
+ *
+ * The maintainer asked for a button that replaces the copy-paste upgrade command
+ * on the banner with a one-tap upgrade. These tests drive [runHostPocketshellUpgrade]
+ * directly against a fake warm session whose `tree get` reports an OLD CLI first
+ * (so the banner is raised), then a fresh version after the upgrade.
+ *
+ * Coverage:
+ *  - SUCCESS: tapping Update execs the upgrade, the host re-reports the matching
+ *    version, and the banner clears (state back to Idle).
+ *  - FAILURE: a failing upgrade exec leaves the banner with a Failure state (the
+ *    stderr surfaced) and NEVER a stuck Running spinner.
+ *  - NO-OP SUCCESS: an exit-0 upgrade whose re-check STILL reports outdated
+ *    raises a Failure (so the user isn't told it worked when it didn't).
+ *  - Running is entered then left (no stuck spinner) for both paths.
+ *  - The exact upgrade command probes uv → pipx → pip with the #779 uv cap
+ *    override (installer detection criterion).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class FolderListViewModelHostUpgradeTest {
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val viewModelStore = ViewModelStore()
+    private var nextViewModelKey: Int = 0
+
+    @After
+    fun tearDown() {
+        viewModelStore.clear()
+    }
+
+    @Test
+    fun update_success_clearsBanner_andEntersThenLeavesRunning() = runTest {
+        // Host starts at 0.4.9, app expects 0.4.16 → banner raised. After the
+        // upgrade exec succeeds, the host re-reports 0.4.16 → banner clears.
+        val session = UpgradableSession(
+            initialVersion = "0.4.9",
+            upgradedVersion = "0.4.16",
+            upgradeResult = ExecResult("upgraded pocketshell 0.4.9 -> 0.4.16", "", 0),
+        )
+        val vm = newViewModel(session, expectedVersion = "0.4.16")
+        bind(vm)
+        advanceUntilIdle()
+        assertTrue("banner must be raised before update", vm.cliVersionMismatch.value != null)
+
+        vm.runHostPocketshellUpgrade()
+        advanceUntilIdle()
+
+        assertNull("the banner must clear after a successful upgrade", vm.cliVersionMismatch.value)
+        assertEquals(
+            FolderListViewModel.CliVersionUpdateState.Idle,
+            vm.cliVersionUpdateState.value,
+        )
+        assertTrue("the upgrade exec must have run over the warm session", session.upgradeRan)
+    }
+
+    @Test
+    fun update_failure_showsError_andNoStuckSpinner() = runTest {
+        // The upgrade exec fails (non-zero exit + stderr). The banner must end in
+        // Failure with the stderr surfaced, NOT a stuck Running spinner, and the
+        // mismatch banner stays up so the user can Retry/Dismiss.
+        val session = UpgradableSession(
+            initialVersion = "0.4.9",
+            upgradedVersion = "0.4.9", // still old (upgrade didn't take)
+            upgradeResult = ExecResult("", "error: network unreachable", 1),
+        )
+        val vm = newViewModel(session, expectedVersion = "0.4.16")
+        bind(vm)
+        advanceUntilIdle()
+        assertTrue(vm.cliVersionMismatch.value != null)
+
+        vm.runHostPocketshellUpgrade()
+        advanceUntilIdle()
+
+        val state = vm.cliVersionUpdateState.value
+        assertTrue(
+            "a failing upgrade must end in Failure, not a stuck spinner — was $state",
+            state is FolderListViewModel.CliVersionUpdateState.Failure,
+        )
+        assertTrue(
+            "the failure message must surface the installer stderr — was $state",
+            (state as FolderListViewModel.CliVersionUpdateState.Failure).message.contains("network unreachable"),
+        )
+        assertTrue(
+            "the mismatch banner must stay up so the user can retry/dismiss",
+            vm.cliVersionMismatch.value != null,
+        )
+    }
+
+    @Test
+    fun update_noOpSuccess_stillOutdated_raisesFailure() = runTest {
+        // Exit-0 upgrade but the host STILL reports the old version (a silent
+        // no-op / capped upgrade). The banner must NOT pretend success — it
+        // surfaces a Failure so the user knows it didn't take.
+        val session = UpgradableSession(
+            initialVersion = "0.4.9",
+            upgradedVersion = "0.4.9", // unchanged despite exit-0
+            upgradeResult = ExecResult("nothing to upgrade", "", 0),
+        )
+        val vm = newViewModel(session, expectedVersion = "0.4.16")
+        bind(vm)
+        advanceUntilIdle()
+
+        vm.runHostPocketshellUpgrade()
+        advanceUntilIdle()
+
+        val state = vm.cliVersionUpdateState.value
+        assertTrue(
+            "an exit-0 upgrade that did not bump the version must raise a Failure — was $state",
+            state is FolderListViewModel.CliVersionUpdateState.Failure,
+        )
+        assertTrue("the banner stays up", vm.cliVersionMismatch.value != null)
+    }
+
+    @Test
+    fun update_timeout_raisesFailure_noStuckSpinner() = runTest {
+        // A wedged installer (never returns) must be bounded — the state leaves
+        // Running and ends in Failure (timeout), never a stuck spinner.
+        val session = UpgradableSession(
+            initialVersion = "0.4.9",
+            upgradedVersion = "0.4.9",
+            upgradeResult = ExecResult("", "", 0),
+            wedgeUpgrade = true,
+        )
+        val vm = newViewModel(session, expectedVersion = "0.4.16")
+        // Tiny upgrade timeout so the wedge is bounded within the test.
+        vm.setHostPocketshellUpgradeForTest(
+            HostPocketshellUpgrade().apply {
+                upgradeTimeoutMs = 50L
+                execDispatcher = UnconfinedTestDispatcher(testScheduler)
+            },
+        )
+        bind(vm)
+        advanceUntilIdle()
+
+        vm.runHostPocketshellUpgrade()
+        advanceUntilIdle()
+
+        val state = vm.cliVersionUpdateState.value
+        assertTrue(
+            "a wedged upgrade must be bounded to a Failure (no stuck spinner) — was $state",
+            state is FolderListViewModel.CliVersionUpdateState.Failure,
+        )
+    }
+
+    @Test
+    fun upgradeCommand_probesUvPipxPip_withUvCapOverride() {
+        // Installer-detection criterion: the single command probes uv → pipx →
+        // pip and uses the #779 uv exclude-newer override so the upgrade is not a
+        // silent no-op.
+        val cmd = HostPocketshellUpgrade.UPGRADE_COMMAND
+        assertTrue("must probe uv tool ownership", cmd.contains("uv tool list"))
+        assertTrue(
+            "uv arm must use the #779 exclude-newer cap override",
+            cmd.contains("--exclude-newer-package pocketshell=2099-12-31"),
+        )
+        assertTrue("must fall back to pipx", cmd.contains("pipx upgrade pocketshell"))
+        assertTrue("must fall back to pip", cmd.contains("pip install -U pocketshell"))
+        assertTrue("must exit 127 when no installer is found", cmd.contains("exit 127"))
+    }
+
+    // --- helpers ------------------------------------------------------------
+
+    private fun bind(vm: FolderListViewModel) {
+        vm.bind(
+            hostId = HOST.id,
+            hostName = HOST.name,
+            hostname = HOST.hostname,
+            port = HOST.port,
+            username = HOST.username,
+            keyPath = KEY_PATH,
+            passphrase = null,
+        )
+    }
+
+    private fun TestScope.newViewModel(
+        session: SshSession,
+        expectedVersion: String,
+    ): FolderListViewModel {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        Dispatchers.setMain(dispatcher)
+        val manager = SshLeaseManager(
+            connector = SshLeaseConnector { Result.success(session) },
+            scope = this,
+            idleTtlMillis = 0L,
+            connectTimeoutContext = dispatcher,
+            nowMillis = { testScheduler.currentTime },
+        )
+        return FolderListViewModel(
+            gateway = StubGateway(listOf(sessionRow("alpha"))),
+            hostDao = FakeHostDao(HOST),
+            projectRootDao = FakeProjectRootDao(),
+            sshLeaseManager = manager,
+            forwardingController = ForwardingController(ApplicationProvider.getApplicationContext()),
+            treeRemoteSource = TreeRemoteSource().apply {
+                remoteExecDispatcher = dispatcher
+            },
+            expectedPocketshellVersionProvider = { expectedVersion },
+            attachLifecycle = false,
+        ).also {
+            it.ioDispatcher = dispatcher
+            it.setHostPocketshellUpgradeForTest(
+                HostPocketshellUpgrade().apply { execDispatcher = dispatcher },
+            )
+            it.setProcessStartedForTest(true)
+            viewModelStore.put("FolderListViewModel-${nextViewModelKey++}", it)
+        }
+    }
+
+    private fun sessionRow(name: String): FolderSessionRow =
+        FolderSessionRow(
+            sessionName = name,
+            lastActivity = 1_000L,
+            attached = true,
+            cwd = "/home/alexey/git/$name",
+        )
+
+    /**
+     * A warm session whose `tree get` reports [initialVersion] until the upgrade
+     * exec runs, then [upgradedVersion]. The upgrade exec returns [upgradeResult]
+     * (or, with [wedgeUpgrade], blocks until cancelled so the bound can be
+     * exercised).
+     */
+    private class UpgradableSession(
+        private val initialVersion: String?,
+        private val upgradedVersion: String?,
+        private val upgradeResult: ExecResult,
+        private val wedgeUpgrade: Boolean = false,
+    ) : SshSession {
+        @Volatile var upgradeRan: Boolean = false
+        override val isConnected: Boolean = true
+
+        override suspend fun exec(command: String): ExecResult {
+            return when {
+                // The upgrade probe-and-run command (issue #947).
+                command.contains("pipx upgrade pocketshell") -> {
+                    upgradeRan = true
+                    if (wedgeUpgrade) {
+                        kotlinx.coroutines.awaitCancellation()
+                    }
+                    upgradeResult
+                }
+                command.contains("tree get") -> {
+                    val v = if (upgradeRan) upgradedVersion else initialVersion
+                    val versionField = v?.let { ",\"cli_version\":\"$it\"" } ?: ""
+                    ExecResult("{\"nodes\":[],\"version\":0$versionField}", "", 0)
+                }
+                command.contains("tree reconcile") -> {
+                    val v = if (upgradeRan) upgradedVersion else initialVersion
+                    val versionField = v?.let { ",\"cli_version\":\"$it\"" } ?: ""
+                    ExecResult("{\"alive\":[],\"gone\":[],\"added\":[]$versionField}", "", 0)
+                }
+                else -> ExecResult("", "", 0)
+            }
+        }
+
+        override fun tail(path: String, onLine: (String) -> Unit): Job = error("unused")
+        override fun openLocalPortForward(remoteHost: String, remotePort: Int, localPort: Int): SshPortForward =
+            error("unused")
+        override fun startShell(): SshShell = error("unused")
+        override suspend fun uploadFile(file: java.io.File, remotePath: String): String = error("unused")
+        override suspend fun uploadStream(
+            input: java.io.InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String = error("unused")
+        override fun close() = Unit
+    }
+
+    private class StubGateway(
+        @Volatile var rows: List<FolderSessionRow>?,
+    ) : FolderListGateway {
+        override suspend fun listSessionsWithFolder(
+            host: HostEntity,
+            keyPath: String,
+            passphrase: CharArray?,
+            watchedRoots: List<ProjectRootEntity>,
+        ): FolderListResult = FolderListResult.Sessions(rows = rows ?: error("gateway probe must not be called"))
+
+        override suspend fun createSession(
+            host: HostEntity,
+            keyPath: String,
+            passphrase: CharArray?,
+            sessionName: String,
+            cwd: String,
+            startCommand: String?,
+        ): Result<String> = error("not used")
+
+        override suspend fun createEmptyProject(
+            host: HostEntity,
+            keyPath: String,
+            passphrase: CharArray?,
+            parentPath: String,
+            folderName: String,
+        ): Result<String> = error("not used")
+
+        override suspend fun importFile(
+            host: HostEntity,
+            keyPath: String,
+            passphrase: CharArray?,
+            folderPath: String,
+            payload: FolderImportPayload,
+        ): Result<String> = error("not used")
+
+        override suspend fun killSession(
+            host: HostEntity,
+            keyPath: String,
+            passphrase: CharArray?,
+            sessionName: String,
+        ): Result<Unit> = error("not used")
+    }
+
+    private class FakeHostDao(private val host: HostEntity) : HostDao {
+        override fun getAll(): Flow<List<HostEntity>> = flowOf(listOf(host))
+        override suspend fun getById(id: Long): HostEntity? = host.takeIf { it.id == id }
+        override fun getEnabled(): Flow<List<HostEntity>> = flowOf(listOf(host))
+        override suspend fun insert(host: HostEntity): Long = error("not used")
+        override suspend fun update(host: HostEntity) = error("not used")
+        override suspend fun delete(host: HostEntity) = error("not used")
+        override suspend fun deleteById(id: Long) = error("not used")
+    }
+
+    private class FakeProjectRootDao : ProjectRootDao {
+        private val roots = MutableStateFlow<List<ProjectRootEntity>>(emptyList())
+        override fun getByHostId(hostId: Long): Flow<List<ProjectRootEntity>> = roots
+        override suspend fun insert(root: ProjectRootEntity): Long = error("not used")
+        override suspend fun update(root: ProjectRootEntity) = error("not used")
+        override suspend fun delete(root: ProjectRootEntity) = error("not used")
+    }
+
+    private companion object {
+        const val KEY_PATH: String = "/tmp/pocketshell-test-key"
+        val HOST: HostEntity = HostEntity(
+            id = 42L,
+            name = "hetzner",
+            hostname = "10.0.2.2",
+            port = 2222,
+            username = "testuser",
+            keyId = 7L,
+        )
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/projects/HostPocketshellUpgradeTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/HostPocketshellUpgradeTest.kt
@@ -1,0 +1,110 @@
+package com.pocketshell.app.projects
+
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.SshPortForward
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshShell
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #947 — unit-level RED→GREEN for the host upgrade seam that the banner's
+ * one-tap **Update** button drives over the warm SSH session.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class HostPocketshellUpgradeTest {
+
+    @Test
+    fun success_onExitZero() = runTest {
+        val session = FakeSession { ExecResult("upgraded", "", 0) }
+        val upgrade = HostPocketshellUpgrade().apply {
+            execDispatcher = UnconfinedTestDispatcher(testScheduler)
+        }
+        val result = upgrade.run(session)
+        assertEquals(HostPocketshellUpgrade.Result.Success, result)
+        assertTrue("the bounded upgrade command must have run", session.ran)
+    }
+
+    @Test
+    fun failure_surfacesStderr_onNonZeroExit() = runTest {
+        val session = FakeSession { ExecResult("", "uv: resolution failed\nE: cap hit", 1) }
+        val upgrade = HostPocketshellUpgrade().apply {
+            execDispatcher = UnconfinedTestDispatcher(testScheduler)
+        }
+        val result = upgrade.run(session)
+        assertTrue(result is HostPocketshellUpgrade.Result.Failure)
+        val message = (result as HostPocketshellUpgrade.Result.Failure).message
+        assertTrue("surfaces stderr — was $message", message.contains("resolution failed"))
+        assertTrue("includes exit code — was $message", message.contains("exit 1"))
+    }
+
+    @Test
+    fun failure_noInstaller_onExit127() = runTest {
+        val session = FakeSession { ExecResult("", "", 127) }
+        val upgrade = HostPocketshellUpgrade().apply {
+            execDispatcher = UnconfinedTestDispatcher(testScheduler)
+        }
+        val result = upgrade.run(session)
+        assertTrue(result is HostPocketshellUpgrade.Result.Failure)
+        assertTrue(
+            (result as HostPocketshellUpgrade.Result.Failure).message.contains("No uv / pipx / pip"),
+        )
+    }
+
+    @Test
+    fun failure_onThrow_doesNotEscape() = runTest {
+        val session = FakeSession { throw RuntimeException("channel closed") }
+        val upgrade = HostPocketshellUpgrade().apply {
+            execDispatcher = UnconfinedTestDispatcher(testScheduler)
+        }
+        val result = upgrade.run(session)
+        assertTrue(result is HostPocketshellUpgrade.Result.Failure)
+        assertTrue(
+            (result as HostPocketshellUpgrade.Result.Failure).message.contains("channel closed"),
+        )
+    }
+
+    @Test
+    fun failure_onTimeout_closesSession() = runTest {
+        val session = FakeSession { awaitCancellation() }
+        val upgrade = HostPocketshellUpgrade().apply {
+            execDispatcher = UnconfinedTestDispatcher(testScheduler)
+            upgradeTimeoutMs = 25L
+        }
+        val result = upgrade.run(session)
+        assertTrue("a wedged installer must time out to a Failure", result is HostPocketshellUpgrade.Result.Failure)
+        assertTrue("timed-out exec closes the session for reconnect", session.closed)
+    }
+
+    private class FakeSession(
+        private val onExec: suspend () -> ExecResult,
+    ) : SshSession {
+        @Volatile var ran: Boolean = false
+        @Volatile var closed: Boolean = false
+        override val isConnected: Boolean = true
+
+        override suspend fun exec(command: String): ExecResult {
+            ran = true
+            return onExec()
+        }
+
+        override fun tail(path: String, onLine: (String) -> Unit): Job = error("unused")
+        override fun openLocalPortForward(remoteHost: String, remotePort: Int, localPort: Int): SshPortForward =
+            error("unused")
+        override fun startShell(): SshShell = error("unused")
+        override suspend fun uploadFile(file: java.io.File, remotePath: String): String = error("unused")
+        override suspend fun uploadStream(
+            input: java.io.InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String = error("unused")
+        override fun close() { closed = true }
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/sessions/LeaseSessionExecTest.kt
+++ b/app/src/test/java/com/pocketshell/app/sessions/LeaseSessionExecTest.kt
@@ -1,6 +1,7 @@
 package com.pocketshell.app.sessions
 
 import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.SshExecTimeoutException
 import com.pocketshell.core.ssh.SshLeaseConnector
 import com.pocketshell.core.ssh.SshLeaseManager
 import com.pocketshell.core.ssh.SshLeaseTarget
@@ -9,6 +10,7 @@ import com.pocketshell.core.ssh.SshSession
 import com.pocketshell.core.ssh.SshShell
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
@@ -106,6 +108,86 @@ class LeaseSessionExecTest {
     }
 
     @Test
+    fun wedgedBlockFastFailsWithBlockTimeoutInsteadOfHanging() = runTest {
+        // #935 S4-2 reproduce-first: the lease previously bounded only the
+        // ACQUIRE, never the borrowed-session `block`. A block that never returns
+        // (wedged transport) hung the borrow indefinitely. On BASE (no block
+        // bound) the `withSession` below never returns and `runTest`'s own
+        // timeout trips (red). With the bound it fast-fails with a clear,
+        // retryable LeaseSessionBlockTimeoutException and evicts the corpse so a
+        // ref can no longer pin it warm forever (green).
+        val wedgedSession = FakeSshSession(blockForever = true)
+        // A fresh healthy session is dialed on the retry after eviction.
+        val healthySession = FakeSshSession()
+        val connector = SequenceConnector(listOf(wedgedSession, healthySession))
+        val manager = SshLeaseManager(connector = connector, scope = this, idleTtlMillis = 30_000L)
+
+        val result = LeaseSessionExec.withSession(
+            manager,
+            TARGET,
+            blockTimeoutMs = 5_000L,
+        ) { it.exec("wedged") }
+
+        // The wedged block is a stale-channel symptom: evicted + retried ONCE on
+        // a fresh transport, where the second (healthy) block also wedges? No —
+        // the second session is healthy, so the retry succeeds and returns.
+        assertTrue("retry on a fresh transport should succeed", result.isSuccess)
+        assertEquals(2, connector.connectCount)
+        assertTrue("wedged transport must be evicted (closed)", wedgedSession.closed)
+        assertFalse("healed transport must stay warm", healthySession.closed)
+    }
+
+    @Test
+    fun wedgedBlockOnBothTransportsSurfacesRetryableTimeout() = runTest {
+        // When BOTH the first borrow and the retry wedge, the helper must surface
+        // a clear, retryable LeaseSessionBlockTimeoutException (not hang, not a
+        // success). Proves the failure is the bounded timeout type, not a silent
+        // never-return.
+        val wedgedA = FakeSshSession(blockForever = true)
+        val wedgedB = FakeSshSession(blockForever = true)
+        val connector = SequenceConnector(listOf(wedgedA, wedgedB))
+        val manager = SshLeaseManager(connector = connector, scope = this, idleTtlMillis = 30_000L)
+
+        val result = LeaseSessionExec.withSession(
+            manager,
+            TARGET,
+            blockTimeoutMs = 5_000L,
+        ) { it.exec("wedged") }
+
+        assertTrue(result.isFailure)
+        assertTrue(
+            "wedged block must surface LeaseSessionBlockTimeoutException",
+            result.exceptionOrNull() is LeaseSessionBlockTimeoutException,
+        )
+        // Evicted + retried once → two dials, both corpses closed.
+        assertEquals(2, connector.connectCount)
+        assertTrue(wedgedA.closed)
+        assertTrue(wedgedB.closed)
+    }
+
+    @Test
+    fun sessionExecTimeoutIsTreatedAsStaleChannelAndRetried() = runTest {
+        // The session-level exec read bound (#935 S4-2 in RealSshSession) surfaces
+        // a SshExecTimeoutException. The lease helper must classify that as a
+        // stale-channel symptom: evict the wedged transport + retry ONCE on a
+        // fresh one (a wedged read means the link is a corpse worth healing).
+        val wedgedReadSession = FakeSshSession(
+            resultForCommand = { throw SshExecTimeoutException("probe", 30_000L) },
+        )
+        val healthySession = FakeSshSession()
+        val connector = SequenceConnector(listOf(wedgedReadSession, healthySession))
+        val manager = SshLeaseManager(connector = connector, scope = this, idleTtlMillis = 30_000L)
+
+        val result = LeaseSessionExec.withSession(manager, TARGET) { it.exec("probe") }
+
+        assertTrue("a wedged-read timeout must heal + retry", result.isSuccess)
+        assertEquals(2, connector.connectCount)
+        assertTrue("wedged-read transport must be evicted (closed)", wedgedReadSession.closed)
+        assertFalse("healed transport must stay warm", healthySession.closed)
+        assertEquals(listOf("probe"), healthySession.execCommands)
+    }
+
+    @Test
     fun nonStaleFailureDoesNotRetry() = runTest {
         val session = FakeSshSession(
             resultForCommand = { throw IllegalStateException("boom") },
@@ -140,6 +222,7 @@ class LeaseSessionExecTest {
 
     private class FakeSshSession(
         private val cancelOnExec: Boolean = false,
+        private val blockForever: Boolean = false,
         private val resultForCommand: (String) -> ExecResult = { ExecResult("", "", 0) },
     ) : SshSession {
         val execCommands: MutableList<String> = mutableListOf()
@@ -149,6 +232,14 @@ class LeaseSessionExecTest {
             if (cancelOnExec) {
                 currentCoroutineContext()[Job]?.cancel()
                 throw CancellationException("cancelled during borrow")
+            }
+            if (blockForever) {
+                // Suspend forever until the block-timeout cancels us — emulates a
+                // wedged transport that never returns. `awaitCancellation()` is
+                // the idiomatic "suspend until cancelled" (vs `delay(MAX_VALUE)`,
+                // which under `runTest`'s auto-advancing virtual clock can stall
+                // the scheduler rather than let `withTimeoutOrNull` fire).
+                awaitCancellation()
             }
             execCommands += command
             return resultForCommand(command)

--- a/app/src/test/java/com/pocketshell/app/tmux/PartialBlackPaneHealTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/PartialBlackPaneHealTest.kt
@@ -1,0 +1,513 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.app.sessions.ActiveTmuxClients
+import com.pocketshell.core.agents.AgentKind
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.SshLeaseConnector
+import com.pocketshell.core.ssh.SshLeaseManager
+import com.pocketshell.core.ssh.SshLeaseTarget
+import com.pocketshell.core.ssh.SshPortForward
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshShell
+import com.pocketshell.core.tmux.CommandResponse
+import com.pocketshell.core.tmux.TmuxClientFactory
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+import java.io.InputStream
+
+/**
+ * Issue #941 (black-screen residual B1) — DURABLE REGRESSION GUARD for the
+ * maintainer's "I sent a message and everything became black" symptom, driving the
+ * REAL production [TmuxSessionViewModel] paths (the switch-reveal gate and the
+ * agent send path), NOT a heal seam.
+ *
+ * ## The bug (root cause)
+ *
+ * A PARTIALLY-black active pane (one live line, the rest of the prior viewport
+ * gone) was auto-healed ONLY on a within-grace reattach, a beyond-grace
+ * `LifecycleReattach`, and a manual Redraw — NEVER on a plain session switch or a
+ * send-triggered `%output` overpaint. The root cause: the switch-reveal gate
+ * ([TmuxSessionViewModel.awaitActivePaneSeededOrLoading]) and the connected blank
+ * watchdog ([TmuxSessionViewModel.armConnectedBlankWatchdog]) gated purely on
+ * `TerminalSurfaceState.visibleScreenIsBlank()` — pure `transcriptText.isBlank()`.
+ * A partial-black pane has ONE live line, so `isBlank()` is false; both gates
+ * treated it as "painted", passed it through, and it stayed black with a green dot
+ * until a manual redraw. The send path had NO heal at all.
+ *
+ * ## The fix
+ *
+ *  - The switch-reveal gate heals on `blank || partialBlank` (a full clear+repaint
+ *    `capture-pane`), so a switch to a partial-black pane is restored before reveal.
+ *  - The send path schedules a one-shot guarded active-pane heal after the submit
+ *    Enter that fires ONLY if the pane settled partial-black/blank.
+ *  - Over-heal guard: partial-black is a heuristic (a real one-line prompt looks
+ *    identical), so each path heals AT MOST ONCE — never loops while it persists —
+ *    and a normally-painted pane is a no-op (the heal pre-checks blank/partial).
+ *
+ * ## Red -> green
+ *
+ * Each test drives a pane into the partial-black state (a `%output`/seed overpaint:
+ * `ESC[2J ESC[H` + ONE live line, the EXACT "one live line, rest black" symptom),
+ * then exercises the REAL switch / send entry point. The discriminator is a
+ * `capture-pane` heal AFTER the entry point and the restored content:
+ *  - On base (pure-`isBlank()` gates): partial-black reads "not blank" -> NO heal
+ *    capture -> the pane stays partial-black -> RED.
+ *  - With the fix: exactly one heal `capture-pane` -> the queued recovery frame
+ *    restores the FULL viewport -> GREEN.
+ *
+ * Class coverage (D31/D32-G2): switch-to-partial-black AND send-overpaint-to-black,
+ * each on a shell pane AND an agent pane.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class PartialBlackPaneHealTest {
+
+    private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val createdVms = mutableListOf<TmuxSessionViewModel>()
+
+    @After
+    fun tearDown() {
+        factoryScope.cancel()
+    }
+
+    // -------------------------------------------------------------------------
+    // (1) SWITCH to a partial-black pane: the switch-reveal gate must heal it.
+    //     SHELL pane. RED on base (gate passes a non-blank partial-black pane),
+    //     GREEN with the fix (gate detects partial-black -> one heal capture).
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun switchRevealHealsPartialBlackShellPane() = runVmTest {
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%1")
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == "%1" }
+
+        // Apply a phone grid so the emulator has real row geometry (the
+        // partial-blank fraction is measured against the emulator's mRows).
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+
+        // Drive the pane into the PARTIAL-black state: a clear+one-live-line
+        // overpaint (the maintainer's "one live line, rest black" symptom).
+        overpaintPartialBlack(pane)
+        assertFalse(
+            "precondition: a partial-black pane is NOT fully blank (so the pre-#941 " +
+                "switch-reveal gate would pass it through unhealed)",
+            pane.terminalState.visibleScreenIsBlank(),
+        )
+        assertTrue(
+            "precondition: the pane IS partial-black (the #941 symptom)",
+            pane.terminalState.visibleScreenIsPartiallyBlank(),
+        )
+
+        // Queue the ONE recovery frame tmux's grid returns on the heal capture.
+        client.capturePaneResponses.addLast(
+            CommandResponse(number = 99L, output = recoveredFrameLines(), isError = false),
+        )
+        val capturesBefore = client.captureCount()
+
+        // THE REAL ENTRY POINT: the switch-reveal gate runs on the active pane.
+        val revealed = vm.awaitActivePaneSeededOrLoadingForTest(client)
+        advanceUntilIdle()
+
+        assertTrue(
+            "REGRESSION (#941): the switch-reveal gate must heal a partial-black active " +
+                "pane (issue exactly one capture-pane). On base the pure-isBlank() gate " +
+                "saw a non-blank pane and skipped the heal -> the pane stayed black.",
+            client.captureCount() > capturesBefore,
+        )
+        assertTrue("the gate still reveals (does not spin)", revealed)
+        assertTrue(
+            "the heal restored the full viewport from tmux's authoritative grid",
+            renderedTranscriptFor(pane).contains(RECOVERED_FRAME),
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // (2) SWITCH to a partial-black AGENT pane: same gate, agent framing
+    //     (class coverage — shell + agent).
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun switchRevealHealsPartialBlackAgentPane() = runVmTest {
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%2", title = "codex")
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == "%2" }
+
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+
+        overpaintPartialBlack(pane)
+        assertTrue(
+            "precondition: the agent pane is partial-black",
+            pane.terminalState.visibleScreenIsPartiallyBlank(),
+        )
+
+        client.capturePaneResponses.addLast(
+            CommandResponse(number = 99L, output = recoveredFrameLines(), isError = false),
+        )
+        val capturesBefore = client.captureCount()
+
+        val revealed = vm.awaitActivePaneSeededOrLoadingForTest(client)
+        advanceUntilIdle()
+
+        assertTrue(
+            "REGRESSION (#941, agent pane): the switch-reveal gate must heal a " +
+                "partial-black agent pane too (not just shell)",
+            client.captureCount() > capturesBefore,
+        )
+        assertTrue(revealed)
+        assertTrue(renderedTranscriptFor(pane).contains(RECOVERED_FRAME))
+    }
+
+    // -------------------------------------------------------------------------
+    // (3) SEND-overpaint to partial-black on an AGENT pane: the post-send heal
+    //     must restore it. RED on base (no post-send heal at all), GREEN with fix.
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun sendOverpaintHealsPartialBlackAgentPane() = runVmTest {
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%3", title = "codex")
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == "%3" }
+
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+        neutralizeSubmitAckGate(vm, client)
+
+        // The send succeeds; the agent then overpaints the pane to partial-black
+        // (a `clear`+one-line redraw) — the maintainer's "sent a message -> black".
+        overpaintPartialBlack(pane)
+        assertTrue(
+            "precondition: after the send overpaint the pane is partial-black",
+            pane.terminalState.visibleScreenIsPartiallyBlank(),
+        )
+
+        // Queue the ONE recovery frame tmux's grid returns on the post-send HEAL
+        // capture (`capture-pane -p -e ...`), distinct from the submit-ack poll's
+        // `capture-pane -p -t` (neutralized above).
+        client.capturePaneResponses.addLast(
+            CommandResponse(number = 99L, output = recoveredFrameLines(), isError = false),
+        )
+        val healCapturesBefore = client.healCaptureCount()
+
+        // THE REAL SEND PATH (production): drives the submit + the post-send heal.
+        val result = vm.sendAgentPayloadToPaneResult("%3", "hello agent", AgentKind.Codex)
+        advanceUntilIdle()
+
+        assertTrue("the send itself must succeed", result.isSuccess)
+        assertTrue(
+            "REGRESSION (#941): a send whose %output overpaint left the active pane " +
+                "partial-black must trigger the post-send HEAL (a `capture-pane -p -e`). " +
+                "On base there was NO post-send heal and the pane stayed black until a " +
+                "manual redraw.",
+            client.healCaptureCount() > healCapturesBefore,
+        )
+        assertFalse(
+            "the post-send heal restored the pane (no longer partial-black)",
+            pane.terminalState.visibleScreenIsPartiallyBlank(),
+        )
+        assertTrue(
+            "the restored pane shows tmux's authoritative content",
+            renderedTranscriptFor(pane).contains(RECOVERED_FRAME),
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // (4) SEND-overpaint to FULLY-black on a SHELL-style pane: same post-send heal
+    //     covers the fully-blank end of the class too (shell + fully-black).
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun sendOverpaintHealsFullyBlankPane() = runVmTest {
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%4")
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == "%4" }
+
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+        neutralizeSubmitAckGate(vm, client)
+
+        // A clear-only overpaint wipes the pane FULLY black.
+        pane.terminalState.appendRemoteOutput(CLEAR_ONLY.toByteArray(Charsets.US_ASCII))
+        advanceUntilIdle()
+        assertTrue(
+            "precondition: the send overpaint wiped the pane fully black",
+            pane.terminalState.visibleScreenIsBlank(),
+        )
+
+        client.capturePaneResponses.addLast(
+            CommandResponse(number = 99L, output = recoveredFrameLines(), isError = false),
+        )
+        val healCapturesBefore = client.healCaptureCount()
+
+        val result = vm.sendAgentPayloadToPaneResult("%4", "ls -la", AgentKind.Codex)
+        advanceUntilIdle()
+
+        assertTrue(result.isSuccess)
+        assertTrue(
+            "REGRESSION (#941, fully-black): a send that left the pane fully black must " +
+                "also trigger the post-send heal",
+            client.healCaptureCount() > healCapturesBefore,
+        )
+        assertFalse(
+            "the post-send heal restored the fully-black pane",
+            pane.terminalState.visibleScreenIsBlank(),
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // (5) OVER-HEAL GUARD: a send whose overpaint left the pane NORMALLY painted
+    //     must NOT issue a heal capture (no reseed-thrash on a healthy pane).
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun sendDoesNotHealANormallyPaintedPane() = runVmTest {
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%5")
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == "%5" }
+
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+        neutralizeSubmitAckGate(vm, client)
+
+        // A normal multi-line agent response: many live rows -> neither blank nor
+        // partial-black -> the post-send heal must correctly no-op.
+        val fullFrame = buildString {
+            append(CLEAR_ONLY)
+            repeat(20) { append("agent response line $it with real content\r\n") }
+        }
+        pane.terminalState.appendRemoteOutput(fullFrame.toByteArray(Charsets.US_ASCII))
+        advanceUntilIdle()
+        assertFalse(pane.terminalState.visibleScreenIsBlank())
+        assertFalse(pane.terminalState.visibleScreenIsPartiallyBlank())
+
+        // If the heal wrongly fired it would re-capture and overpaint the pane with
+        // this banner; queue it so a spurious heal is detectable.
+        client.capturePaneResponses.addLast(
+            CommandResponse(number = 99L, output = recoveredFrameLines(), isError = false),
+        )
+        val healCapturesBefore = client.healCaptureCount()
+        val result = vm.sendAgentPayloadToPaneResult("%5", "another prompt", AgentKind.Codex)
+        advanceUntilIdle()
+
+        assertTrue(result.isSuccess)
+        org.junit.Assert.assertEquals(
+            "OVER-HEAL GUARD: a send onto an already-painted pane must NOT issue any " +
+                "post-send HEAL capture-pane (no reseed-thrash on a healthy pane)",
+            healCapturesBefore,
+            client.healCaptureCount(),
+        )
+        assertFalse(
+            "the already-painted pane must NOT have been overpainted by a spurious heal",
+            renderedTranscriptFor(pane).contains(RECOVERED_FRAME),
+        )
+    }
+
+    // ------------------------------------------------------------------ Harness
+
+    private fun runVmTest(body: suspend TestScope.() -> Unit) = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        LivenessProbeTestOverride.setAutoStartEnabledForTest(false)
+        try {
+            body()
+        } finally {
+            for (vm in createdVms) {
+                runCatching { vm.setProcessForegroundForClearedForTest(false) }
+                runCatching { vm.clearForTest() }
+            }
+            advanceUntilIdle()
+            createdVms.clear()
+            LivenessProbeTestOverride.clear()
+            Dispatchers.resetMain()
+        }
+    }
+
+    private fun TestScope.newVm(
+        registry: ActiveTmuxClients,
+        sshLeaseManager: SshLeaseManager,
+    ): TmuxSessionViewModel = TmuxSessionViewModel(
+        tmuxClientFactory = TmuxClientFactory(factoryScope),
+        activeTmuxClients = registry,
+        runtimeCache = TmuxSessionRuntimeCache(),
+        sshLeaseManager = sshLeaseManager,
+        sessionLifecycleSignals = null,
+    ).also {
+        it.setSeedIoDispatcherForTest(StandardTestDispatcher(testScheduler))
+        createdVms.add(it)
+    }
+
+    private fun TestScope.connectVm(client: FakeTmuxClient): TmuxSessionViewModel {
+        val live = AlwaysConnectedSession(id = "live")
+        val connector = SingleSessionConnector(live)
+        val leaseManager =
+            testLeaseManager(connector = connector, scope = this, idleTtlMillis = 60_000L)
+        val registry = ActiveTmuxClients()
+        val vm = newVm(registry = registry, sshLeaseManager = leaseManager)
+        runCurrent()
+        vm.setTmuxClientFactoryForTest { _, _, _ -> client }
+        vm.connect(
+            hostId = 1L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            passphrase = null,
+            sessionName = "work",
+        )
+        advanceUntilIdle()
+        return vm
+    }
+
+    /**
+     * Drive a pane into the PARTIAL-black state: a clear + ONE live line, the
+     * "one live line, rest black" symptom (#941). NOT fully blank (the line is
+     * present) but the vast majority of the grid is empty.
+     */
+    private fun overpaintPartialBlack(pane: TmuxPaneState) {
+        pane.terminalState.appendRemoteOutput(
+            (CLEAR_ONLY + "ISSUE941-LIVE-LINE 7\r\n").toByteArray(Charsets.US_ASCII),
+        )
+    }
+
+    private fun FakeTmuxClient.captureCount(): Int =
+        sentCommands.count { it.startsWith("capture-pane") }
+
+    /**
+     * Count ONLY the post-send HEAL captures (`capture-pane -p -e ...`, issued by
+     * the seed [TmuxClient.captureWithCursor]), distinct from the submit-ack poll's
+     * `capture-pane -p -t` (no `-e`). This isolates the #941 heal from the unrelated
+     * #869 ack-gate captures that also fire on the send path.
+     */
+    private fun FakeTmuxClient.healCaptureCount(): Int =
+        sentCommands.count { it.startsWith("capture-pane") && it.contains(" -e") }
+
+    /**
+     * Neutralize the #869 submit-ack gate so its `capture-pane -p -t` poll does not
+     * consume the heal's queued recovery frame or skew the heal-capture count: set a
+     * zero floor + a single-poll timeout, and queue ONE dummy ack frame (no needle
+     * match -> the poll misses and falls through immediately). The heal's
+     * `capture-pane -p -e` frame stays separately queued for the heal to consume.
+     */
+    private fun neutralizeSubmitAckGate(vm: TmuxSessionViewModel, client: FakeTmuxClient) {
+        vm.setAgentSubmitEnterDelayForTest(0)
+        vm.setAgentSubmitAckTimeoutForTest(AGENT_SUBMIT_ACK_POLL_INTERVAL_MS)
+        client.capturePaneResponses.addLast(
+            CommandResponse(number = 50L, output = listOf("ack-poll-no-match"), isError = false),
+        )
+    }
+
+    private fun FakeTmuxClient.withSinglePaneRow(
+        sessionName: String,
+        paneId: String,
+        title: String = sessionName,
+    ): FakeTmuxClient = apply {
+        responses.addLast(
+            CommandResponse(
+                number = 1L,
+                output = listOf("$paneId\t@0\t\$0\t$sessionName\t$title\t0"),
+                isError = false,
+            ),
+        )
+        capturePaneResponses.addLast(
+            CommandResponse(number = 2L, output = listOf("$sessionName ready"), isError = false),
+        )
+        cursorQueryResponses.addLast(
+            CommandResponse(number = 3L, output = listOf("0,0"), isError = false),
+        )
+    }
+
+    private fun renderedTranscriptFor(pane: TmuxPaneState): String {
+        val state = pane.terminalState
+        val bridgeField = com.pocketshell.core.terminal.ui.TerminalSurfaceState::class.java
+            .getDeclaredField("bridge").apply { isAccessible = true }
+        val bridge = bridgeField.get(state)
+            as? com.pocketshell.core.terminal.bridge.SshTerminalBridge ?: return ""
+        return bridge.emulator.screen.transcriptText
+    }
+
+    private class SingleSessionConnector(
+        private val session: SshSession,
+    ) : SshLeaseConnector {
+        override suspend fun connect(target: SshLeaseTarget): Result<SshSession> =
+            Result.success(session)
+    }
+
+    private class AlwaysConnectedSession(
+        val id: String,
+    ) : SshSession {
+        @Volatile
+        var closed: Boolean = false
+
+        override val isConnected: Boolean get() = !closed
+
+        override suspend fun exec(command: String): ExecResult =
+            ExecResult(stdout = "", stderr = "", exitCode = 0)
+
+        override fun tail(path: String, onLine: (String) -> Unit): Job =
+            Job().apply { complete() }
+
+        override fun tail(path: String, fromLineExclusive: Long, onLine: (String) -> Unit): Job =
+            Job().apply { complete() }
+
+        override fun openLocalPortForward(
+            remoteHost: String,
+            remotePort: Int,
+            localPort: Int,
+        ): SshPortForward = error("not used")
+
+        override fun startShell(): SshShell = error("not used")
+
+        override suspend fun uploadFile(file: File, remotePath: String): String = error("not used")
+
+        override suspend fun uploadStream(
+            input: InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String = error("not used")
+
+        override fun close() {
+            closed = true
+        }
+    }
+
+    /**
+     * The full viewport tmux's grid returns on a heal `capture-pane`: a MULTI-line
+     * frame (the recovered banner + many context rows) so that after the heal the
+     * pane is neither blank nor partial-black — i.e. the restore actually un-blacks
+     * the pane (not a one-line frame that would itself read partial-black).
+     */
+    private fun recoveredFrameLines(): List<String> = buildList {
+        add(RECOVERED_FRAME)
+        repeat(12) { add("recovered context row $it") }
+    }
+
+    private companion object {
+        const val RECOVERED_FRAME: String = "ISSUE941-RECOVERED-VIEWPORT"
+
+        // ESC[2J ESC[H — clear screen + cursor home (the overpaint preamble).
+        val CLEAR_ONLY: String = "[2J[H"
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
@@ -8384,6 +8384,154 @@ class TmuxSessionViewModelTest {
     }
 
     /**
+     * Issue #942 (black-screen B2, reopen-class D31): a remembered Conversation
+     * row collapsed to the raw black Terminal after 2× consecutive
+     * successful-but-EMPTY (`Resolved(null)`) detections on a wedged-but-alive
+     * channel — the capture/grep raced behind a busy agent (#470/#835) and read
+     * "no agent" while the agent was very much alive and still streaming output.
+     * #897 protected only the `Unavailable` (probe-threw) branch; the empty-grep
+     * `Resolved(null)` branch still counted toward [AGENT_EXIT_CONFIRMATIONS] and
+     * tore the row down. The maintainer's 2026-06-24 Claude `faq-assistant` black
+     * capture.
+     *
+     * RED (no fix): each empty null on the streaming channel counts toward exit;
+     * the second confirms and the remembered Conversation row is cleared.
+     * GREEN (fix): the still-streaming channel (recent `%output`) marks the empty
+     * detection as wedged-but-alive, it does NOT count toward exit confirmation,
+     * and the remembered Conversation row is preserved across both nulls.
+     *
+     * Class-cover: Claude, Codex AND OpenCode kinds.
+     */
+    @Test
+    fun emptyDetectionOnWedgedButAliveChannelDoesNotCollapseRememberedConversation() = runTest(scheduler) {
+        val detections = listOf(
+            newClaudeDetection(),
+            newCodexDetection(),
+            newOpenCodeDetection(),
+        )
+
+        detections.forEachIndexed { index, detection ->
+            val windowId = "@$index"
+            val vm = newVm()
+            vm.connectWithPaneForTest(paneId = "%0", windowId = windowId, sessionName = "wedged-$index")
+            vm.startAgentConversationForTest("%0", detection)
+            vm.selectSessionTab("%0", SessionTab.Conversation)
+            runCurrent()
+
+            // Reattach: the pane comes back as a remembered-agent resolving
+            // placeholder (the #495/#819 A2 seed) — the exact remembered
+            // Conversation state the maintainer had open when it went black.
+            vm.applyParsedPanesForTest(
+                listOf(
+                    TmuxSessionViewModel.ParsedPane(
+                        "%7",
+                        windowId,
+                        "$0",
+                        "shell",
+                        paneIndex = 0,
+                        sessionName = "wedged-$index",
+                    ),
+                ),
+            )
+            runCurrent()
+            assertTrue(
+                "#819 (A2): the remembered ${detection.agent} placeholder is up before the empty detections",
+                vm.agentConversations.value["%7"]?.rememberedAgentPlaceholder == true,
+            )
+
+            // The `-CC` channel is WEDGED-but-ALIVE: it is still streaming
+            // `%output` for this pane (a busy agent), so the grep raced an empty
+            // read. Inject 2× empty `Resolved(null)` while output keeps arriving.
+            repeat(AGENT_EXIT_CONFIRMATIONS) {
+                vm.recordPaneOutputActivityForTest("%7")
+                assertTrue(
+                    "#942: a freshly-streaming channel reads wedged-but-alive",
+                    vm.isChannelWedgedButAliveForTest("%7"),
+                )
+                val downgraded = vm.handleNullAgentDetectionForTest("%7")
+                runCurrent()
+                assertFalse(
+                    "#942: an empty grep on a streaming (wedged-but-alive) ${detection.agent} channel must NOT confirm agent exit",
+                    downgraded,
+                )
+                assertTrue(
+                    "#942: the remembered ${detection.agent} Conversation row survives the empty detection (no black Terminal)",
+                    vm.agentConversations.value["%7"]?.rememberedAgentPlaceholder == true,
+                )
+            }
+
+            vm.clearForTest()
+        }
+    }
+
+    /**
+     * Issue #942: the wedged-channel guard must NOT over-protect — a GENUINE
+     * agent exit stops emitting output, so its empty `Resolved(null)` arrives on
+     * a now-IDLE channel and must still tear the Conversation row down after
+     * [AGENT_EXIT_CONFIRMATIONS] consecutive nulls. Class-cover Claude/Codex/
+     * OpenCode so a kind-specific over-protection regression is caught.
+     */
+    @Test
+    fun emptyDetectionOnIdleChannelStillTearsDownAGenuinelyExitedAgent() = runTest(scheduler) {
+        val detections = listOf(
+            newClaudeDetection(),
+            newCodexDetection(),
+            newOpenCodeDetection(),
+        )
+
+        detections.forEachIndexed { index, detection ->
+            val windowId = "@$index"
+            val vm = newVm()
+            vm.connectWithPaneForTest(paneId = "%0", windowId = windowId, sessionName = "exited-$index")
+            vm.startAgentConversationForTest("%0", detection)
+            vm.selectSessionTab("%0", SessionTab.Conversation)
+            runCurrent()
+
+            vm.applyParsedPanesForTest(
+                listOf(
+                    TmuxSessionViewModel.ParsedPane(
+                        "%7",
+                        windowId,
+                        "$0",
+                        "shell",
+                        paneIndex = 0,
+                        sessionName = "exited-$index",
+                    ),
+                ),
+            )
+            runCurrent()
+
+            // The agent exited: the channel went IDLE (no `%output`). The empty
+            // grep is now a TRUE "no agent" verdict, not a wedged race.
+            vm.clearPaneOutputActivityForTest("%7")
+            assertFalse(
+                "#942: an idle channel must not read wedged-but-alive",
+                vm.isChannelWedgedButAliveForTest("%7"),
+            )
+
+            val firstNull = vm.handleNullAgentDetectionForTest("%7")
+            runCurrent()
+            assertFalse(
+                "#554: the first clean null defers (confirmation window) for ${detection.agent}",
+                firstNull,
+            )
+
+            val secondNull = vm.handleNullAgentDetectionForTest("%7")
+            runCurrent()
+            assertTrue(
+                "#942: a real ${detection.agent} exit on an idle channel still tears the row down (no over-protection)",
+                secondNull,
+            )
+            assertNull(
+                "#942: the genuinely-exited ${detection.agent} Conversation row is gone",
+                vm.agentConversations.value["%7"],
+            )
+            assertNull(vm.agentForWindow(windowId))
+            vm.clearForTest()
+        }
+    }
+
+    /**
      * Issue #554: the deferral is a confirmation window, not a permanent
      * pin. A genuinely-exited agent (null detection persisting past
      * [AGENT_EXIT_CONFIRMATIONS]) still reconciles away so a stale

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
@@ -74,6 +74,7 @@ import net.schmizz.sshj.transport.TransportException
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNotSame
 import org.junit.Assert.assertNull
@@ -7103,16 +7104,34 @@ class TmuxSessionViewModelTest {
         )
         runCurrent()
 
-        // Conversation tab is available immediately on the new pane id,
-        // without waiting for live re-detection.
+        // Issue #819 (A2): the Conversation tab is available immediately on the
+        // new pane id (a row exists on the remembered tab), but the seed now
+        // restores a RESOLVING placeholder — NOT the remembered (possibly
+        // stale/sibling) detection rendered Live. The screen surfaces this via
+        // the `presumedAgent` "Loading conversation…" placeholder path (a
+        // detection-less row whose pane is not a confirmed shell), so the #495
+        // tab-availability benefit is preserved without flashing a stale source.
         assertNull("old pane id is gone after reattach", vm.agentConversations.value["%0"])
         val restored = vm.agentConversations.value["%7"]
         assertNotNull("agent status restored immediately on the new pane", restored)
-        assertEquals(AgentKind.ClaudeCode, restored!!.detection?.agent)
         assertEquals(
-            "the Conversation tab is gated on agentForWindow being non-null",
-            AgentKind.ClaudeCode,
-            vm.agentForWindow("@0"),
+            "the remembered window is restored on the Conversation tab the user was on",
+            SessionTab.Conversation,
+            restored!!.selectedTab,
+        )
+        assertNull(
+            "#819 (A2): the seed must NOT carry the remembered (possibly stale) " +
+                "source — live detection re-anchors the route-true source",
+            restored.detection,
+        )
+        assertTrue(
+            "#819 (A2): the reattach seed is a remembered-agent resolving placeholder",
+            restored.rememberedAgentPlaceholder,
+        )
+        assertEquals(
+            "#819 (A2): the resolving placeholder holds Loading until live detection binds",
+            ConversationLoadState.Loading,
+            restored.loadState,
         )
     }
 
@@ -7134,13 +7153,22 @@ class TmuxSessionViewModelTest {
             "process-scoped memory must restore agent status for a fresh VM before detection",
             restored,
         )
-        assertEquals(AgentKind.ClaudeCode, restored!!.detection?.agent)
         assertEquals(
             "the user's Conversation tab choice survives VM recreation",
             SessionTab.Conversation,
-            restored.selectedTab,
+            restored!!.selectedTab,
         )
-        assertEquals(AgentKind.ClaudeCode, recreatedVm.agentForWindow("@0"))
+        // Issue #819 (A2): a cross-VM restore must also NOT trust the remembered
+        // source blind — it seeds the resolving placeholder and re-anchors the
+        // route-true source on live re-detection in the fresh VM.
+        assertNull(
+            "#819 (A2): the cross-VM seed must not carry the remembered source",
+            restored.detection,
+        )
+        assertTrue(
+            "#819 (A2): the cross-VM reattach seed is a remembered-agent resolving placeholder",
+            restored.rememberedAgentPlaceholder,
+        )
     }
 
     @Test
@@ -7178,13 +7206,336 @@ class TmuxSessionViewModelTest {
         runCurrent()
 
         val restored = vm.agentConversations.value["%7"]!!
-        assertEquals(AgentKind.ClaudeCode, restored.detection?.agent)
+        // Issue #819 (A2): the seed restores the remembered TAB (Terminal here)
+        // as a resolving placeholder — not the remembered (possibly stale)
+        // source — and live detection re-anchors the route-true source.
+        assertNull(
+            "#819 (A2): the seed must not carry the remembered source",
+            restored.detection,
+        )
+        assertTrue(
+            "#819 (A2): the reattach seed is a remembered-agent resolving placeholder",
+            restored.rememberedAgentPlaceholder,
+        )
         assertEquals(
             "Conversation tab available but Terminal stays selected",
             SessionTab.Terminal,
             restored.selectedTab,
         )
     }
+
+    // ════════════════════════════════════════════════════════════════════
+    // Issue #819 (Slice A2): the #495 reattach memory-seed must RE-ANCHOR the
+    // remembered conversation source against live re-detection — it must NOT
+    // render the remembered `detection.sourcePath` BLIND as Live.
+    //
+    // The bug (maintainer dogfood): the Conversation tab showed a DIFFERENT
+    // Codex transcript than the route-true Terminal — the `ai-shipping-labs`
+    // header over a `git-pocketshell-desktop-codex` transcript — because two
+    // same-cwd same-kind (Codex) sessions (a sub-agent / second window / second
+    // worktree) share a cwd and the source is picked by mtime, so a remembered
+    // detection captured during a prior mis-pick carried the SIBLING's rollout.
+    // The seed restored that stale source and rendered it Live before the live
+    // `/proc/<pid>/fd` round-trip (Slice A1) re-bound the route-true source.
+    //
+    // RED on base: the seed carries `remembered.detection.sourcePath` (the stale
+    // sibling source) as a Live row — so `restored.detection!!.sourcePath`
+    // equals the sibling source the Terminal is NOT attached to.
+    // GREEN with A2: the seed restores a detection-LESS resolving placeholder;
+    // live re-detection (the route's OWN fd-pinned source) binds the route-true
+    // source, so Conversation == Terminal route.
+    //
+    // G2 class coverage: sub-agent/nested, two-windows, two-worktrees all reduce
+    // to "remembered source != route-true source"; plus the missing-data
+    // (remembered window whose agent has since EXITED) case, and the #554 no-flap
+    // hold (a transient post-reattach null must NOT tear the pane to a raw shell).
+    // ════════════════════════════════════════════════════════════════════
+
+    private fun codexDetection(sourcePath: String, sessionId: String): AgentDetection =
+        AgentDetection(
+            agent = AgentKind.Codex,
+            sourcePath = sourcePath,
+            sessionId = sessionId,
+            confidence = AgentDetection.Confidence.ProcessConfirmed,
+        )
+
+    @Test
+    fun codexReattachSeedDoesNotRenderRememberedSiblingSourceAsLive() = runTest(scheduler) {
+        // The reported scenario: a Codex window the user was reading in
+        // Conversation. The remembered detection was captured during a prior
+        // same-cwd mis-pick, so it carries the SIBLING/orchestrator rollout
+        // (`git-pocketshell-desktop-codex`), NOT the route's own session
+        // (`ai-shipping-labs`).
+        val siblingRollout = "/home/u/.codex/sessions/git-pocketshell-desktop-codex.jsonl"
+        val routeTrueRollout = "/home/u/.codex/sessions/ai-shipping-labs.jsonl"
+
+        val vm = newVm()
+        vm.connectWithPaneForTest(paneId = "%0", windowId = "@0")
+        // The remembered detection points at the SIBLING rollout (the stale
+        // mis-pick). Recording it + opening Conversation arms agentSessionMemory.
+        vm.startAgentConversationForTest(
+            "%0",
+            codexDetection(siblingRollout, "git-pocketshell-desktop-codex"),
+        )
+        vm.selectSessionTab("%0", SessionTab.Conversation)
+        runCurrent()
+
+        // Reconnect: a NEW pane id under the SAME window @0; the seed fires.
+        vm.applyParsedPanesForTest(
+            listOf(
+                TmuxSessionViewModel.ParsedPane(
+                    "%7", "@0", "$0", "shell", paneIndex = 0,
+                    cwd = "/home/u/git/pocketshell", paneTty = "/dev/pts/9",
+                    sessionName = "work",
+                ),
+            ),
+        )
+        runCurrent()
+
+        val seeded = vm.agentConversations.value["%7"]!!
+        // The LOAD-BEARING assertion (G6): the seed must NOT render the stale
+        // sibling source. On base the seed carries remembered.detection, so
+        // `seeded.detection!!.sourcePath == siblingRollout` (RED).
+        assertNull(
+            "#819 (A2): the reattach seed must NOT render the remembered " +
+                "(stale sibling) Codex source — it holds resolving until live " +
+                "re-detection binds the route-true source",
+            seeded.detection,
+        )
+        assertNotEquals(
+            "#819 (A2): the stale sibling rollout must NOT be the active source",
+            siblingRollout,
+            seeded.detection?.sourcePath,
+        )
+        assertTrue(seeded.rememberedAgentPlaceholder)
+        assertEquals(SessionTab.Conversation, seeded.selectedTab)
+
+        // Live re-detection (the route's OWN fd-pinned source via Slice A1) lands
+        // and binds the route-true rollout. The Conversation now matches the
+        // route-named Terminal.
+        vm.markAgentTailLiveForTest("%7", codexDetection(routeTrueRollout, "ai-shipping-labs"))
+        runCurrent()
+
+        val bound = vm.agentConversations.value["%7"]!!
+        assertEquals(
+            "#819 (A2): after live re-detection the Conversation is bound to the " +
+                "ROUTE-TRUE source the Terminal is attached to",
+            routeTrueRollout,
+            bound.detection!!.sourcePath,
+        )
+        assertEquals("ai-shipping-labs", bound.detection!!.sessionId)
+        assertEquals(
+            "the remembered Conversation tab is preserved across the re-anchor",
+            SessionTab.Conversation,
+            bound.selectedTab,
+        )
+        assertFalse(
+            "the resolving-placeholder flag clears once the route-true source binds",
+            bound.rememberedAgentPlaceholder,
+        )
+    }
+
+    @Test
+    fun codexReattachSeedReanchorsAcrossSubAgentTwoWindowAndTwoWorktreeSiblings() =
+        runTest(scheduler) {
+            // G2 class coverage: the three same-cwd same-kind collision shapes the
+            // maintainer can hit (a sub-agent/orchestrator, a second tmux window,
+            // a second git worktree) all reduce to "the remembered source is a
+            // sibling rollout, the route-true source is the pane's own". For each,
+            // the seed must refuse the remembered source and the live re-bind must
+            // restore the route-true one.
+            data class Case(
+                val name: String,
+                val siblingSource: String,
+                val routeTrueSource: String,
+            )
+            val cases = listOf(
+                Case(
+                    "sub-agent/orchestrator out-flushing the pane's own rollout",
+                    "/home/u/.codex/sessions/orchestrator-subagent.jsonl",
+                    "/home/u/.codex/sessions/pane-own-session.jsonl",
+                ),
+                Case(
+                    "two tmux windows in one project dir",
+                    "/home/u/.codex/sessions/window-b.jsonl",
+                    "/home/u/.codex/sessions/window-a.jsonl",
+                ),
+                Case(
+                    "two git worktrees of one repo sharing the codex sessions dir",
+                    "/home/u/.codex/sessions/worktree-feature.jsonl",
+                    "/home/u/.codex/sessions/worktree-main.jsonl",
+                ),
+            )
+
+            for ((index, case) in cases.withIndex()) {
+                val windowId = "@$index"
+                val oldPane = "%${index * 2}"
+                val newPane = "%${index * 2 + 1}"
+                val vm = newVm()
+                vm.connectWithPaneForTest(paneId = oldPane, windowId = windowId)
+                vm.startAgentConversationForTest(
+                    oldPane,
+                    codexDetection(case.siblingSource, "sibling-$index"),
+                )
+                vm.selectSessionTab(oldPane, SessionTab.Conversation)
+                runCurrent()
+
+                vm.applyParsedPanesForTest(
+                    listOf(
+                        TmuxSessionViewModel.ParsedPane(
+                            newPane, windowId, "$0", "shell", paneIndex = 0,
+                            cwd = "/home/u/git/pocketshell", paneTty = "/dev/pts/$index",
+                            sessionName = "work",
+                        ),
+                    ),
+                )
+                runCurrent()
+
+                val seeded = vm.agentConversations.value[newPane]!!
+                assertNull(
+                    "#819 (A2) [${case.name}]: seed must not carry the sibling source",
+                    seeded.detection,
+                )
+                assertNotEquals(
+                    "#819 (A2) [${case.name}]: sibling source must not be active",
+                    case.siblingSource,
+                    seeded.detection?.sourcePath,
+                )
+
+                vm.markAgentTailLiveForTest(
+                    newPane,
+                    codexDetection(case.routeTrueSource, "route-true-$index"),
+                )
+                runCurrent()
+
+                val bound = vm.agentConversations.value[newPane]!!
+                assertEquals(
+                    "#819 (A2) [${case.name}]: live re-bind anchors the route-true source",
+                    case.routeTrueSource,
+                    bound.detection!!.sourcePath,
+                )
+            }
+        }
+
+    @Test
+    fun codexReattachSeedHoldsResolvingPlaceholderThroughTransientNullThenTearsDownOnConfirmedExit() =
+        runTest(scheduler) {
+            // #554 no-flap guarantee AND the missing-data (agent-exited) case.
+            // The A2 seed is detection-less, so the #554 hold can no longer key
+            // off `detection != null`. A transient post-reattach null must be
+            // HELD + re-confirmed (the window was a KNOWN agent), and only a
+            // CONFIRMED exit (AGENT_EXIT_CONFIRMATIONS consecutive nulls) tears
+            // the placeholder down — never a flap to a raw shell on the first null.
+            val vm = newVm()
+            vm.connectWithPaneForTest(paneId = "%0", windowId = "@0")
+            vm.startAgentConversationForTest(
+                "%0",
+                codexDetection("/home/u/.codex/sessions/remembered.jsonl", "remembered"),
+            )
+            vm.selectSessionTab("%0", SessionTab.Conversation)
+            runCurrent()
+
+            vm.applyParsedPanesForTest(
+                listOf(
+                    TmuxSessionViewModel.ParsedPane(
+                        "%7", "@0", "$0", "shell", paneIndex = 0,
+                        cwd = "/home/u/git/pocketshell", paneTty = "/dev/pts/9",
+                        sessionName = "work",
+                    ),
+                ),
+            )
+            runCurrent()
+
+            assertTrue(
+                "precondition: the reattach seed is a remembered-agent resolving placeholder",
+                vm.agentConversations.value["%7"]!!.rememberedAgentPlaceholder,
+            )
+
+            // First live re-detection comes back NULL (the agent's log/process is
+            // not yet observable on the fresh attach). The #554 hold must keep the
+            // placeholder — NOT drop the pane to a raw shell.
+            val droppedOnFirstNull = vm.handleNullAgentDetectionForTest("%7")
+            runCurrent()
+            assertFalse(
+                "#554/#819 (A2): a transient first null must NOT tear down the " +
+                    "remembered resolving placeholder",
+                droppedOnFirstNull,
+            )
+            assertNotNull(
+                "#819 (A2): the resolving placeholder is retained across the first null",
+                vm.agentConversations.value["%7"],
+            )
+
+            // After AGENT_EXIT_CONFIRMATIONS consecutive nulls the exit is
+            // confirmed; the placeholder is torn down (the agent genuinely exited
+            // — the missing-data case), never left stranded on "Loading…".
+            var dropped = false
+            repeat(8) {
+                if (!dropped) {
+                    dropped = vm.handleNullAgentDetectionForTest("%7")
+                    runCurrent()
+                }
+            }
+            assertTrue(
+                "#819 (A2): a CONFIRMED exit tears down the remembered placeholder",
+                dropped,
+            )
+            assertNull(
+                "#819 (A2): the placeholder is dropped on confirmed exit — never " +
+                    "stranded on 'Loading…'",
+                vm.agentConversations.value["%7"],
+            )
+        }
+
+    @Test
+    fun codexReattachSeedSeam_seedsResolvingPlaceholderNotRememberedSource() =
+        runTest(scheduler) {
+            // Direct seam coverage of seedAgentConversationFromMemory itself (no
+            // live-detection round-trip in the way), proving the seed in isolation
+            // restores a resolving placeholder rather than the remembered source.
+            val memory = AgentSessionMemory()
+            val vm = newVm(agentSessionMemory = memory)
+            vm.connectWithPaneForTest(paneId = "%0", windowId = "@0")
+            runCurrent()
+            // Arm memory for window @0 with a Codex sibling source.
+            memory.remember(
+                hostId = 42L,
+                sessionName = "work",
+                windowId = "@0",
+                detection = codexDetection(
+                    "/home/u/.codex/sessions/sibling.jsonl",
+                    "sibling",
+                ),
+                wasOnConversation = true,
+            )
+            // Drop the existing row so the seed's "no existing row" gate passes,
+            // then drive the seed seam directly.
+            vm.clearAgentDetectionForPaneForTest("%0")
+            // clearAgentDetectionForPane forgets memory; re-arm it after the clear.
+            memory.remember(
+                hostId = 42L,
+                sessionName = "work",
+                windowId = "@0",
+                detection = codexDetection(
+                    "/home/u/.codex/sessions/sibling.jsonl",
+                    "sibling",
+                ),
+                wasOnConversation = true,
+            )
+            runCurrent()
+            vm.seedAgentConversationFromMemoryForTest("%0")
+            runCurrent()
+
+            val seeded = vm.agentConversations.value["%0"]!!
+            assertNull(
+                "#819 (A2): the seed seam restores a resolving placeholder, not " +
+                    "the remembered source",
+                seeded.detection,
+            )
+            assertTrue(seeded.rememberedAgentPlaceholder)
+            assertEquals(ConversationLoadState.Loading, seeded.loadState)
+            assertEquals(SessionTab.Conversation, seeded.selectedTab)
+        }
 
     // ─── Issue #818: configurable open-time default tab + the #815 line ───
     //
@@ -7636,8 +7987,16 @@ class TmuxSessionViewModelTest {
     @Test
     fun autoSeedDoesNotOverwriteRememberedConversationRowNoYank() = runTest(scheduler) {
         // AC2 (#815 no-yank): a window whose user previously had a Conversation
-        // row must reattach with the live agent detection restored, NOT replaced
-        // by a fresh detection-less auto-seed placeholder. seed-from-memory wins.
+        // row must reattach on the REMEMBERED Conversation tab — NOT replaced by
+        // a fresh #878 auto-seed placeholder. seed-from-memory wins (it runs
+        // first and creates the row, so seedPresumedAgentPlaceholder no-ops).
+        //
+        // Issue #819 (A2): the remembered row is now restored as a REMEMBERED-
+        // agent resolving placeholder (rememberedAgentPlaceholder = true,
+        // detection-less) — NOT the remembered detection rendered Live (which
+        // could re-show a stale/sibling source). It is still distinct from the
+        // #878 AUTO-seed (autoSeededPlaceholder = false), so the no-yank line
+        // holds: the remembered Conversation choice survives.
         val vm = newVm()
         vm.connectWithPaneForTest(paneId = "%0", windowId = "@0")
         vm.startAgentConversationForTest("%0", newClaudeDetection())
@@ -7655,13 +8014,18 @@ class TmuxSessionViewModelTest {
             SessionTab.Conversation,
             restored.selectedTab,
         )
-        assertEquals(
-            "#878: seed-from-memory restored the live detection, not a detection-less placeholder",
-            AgentKind.ClaudeCode,
-            restored.detection?.agent,
+        assertNull(
+            "#819 (A2): the reattach seed restores a resolving placeholder, not " +
+                "the remembered (possibly stale) source rendered Live",
+            restored.detection,
+        )
+        assertTrue(
+            "#819 (A2): the remembered row is a remembered-agent resolving placeholder",
+            restored.rememberedAgentPlaceholder,
         )
         assertFalse(
-            "#878: a restored remembered row is never an auto-seeded placeholder",
+            "#878: a restored remembered row is the remembered-agent placeholder, " +
+                "NOT the #878 auto-seed placeholder",
             restored.autoSeededPlaceholder,
         )
     }
@@ -7919,26 +8283,33 @@ class TmuxSessionViewModelTest {
             listOf(TmuxSessionViewModel.ParsedPane("%7", "@0", "$0", "shell", paneIndex = 0, sessionName = "work")),
         )
         runCurrent()
-        assertEquals(
-            "precondition: agent UI restored immediately on reattach",
-            AgentKind.ClaudeCode,
-            vm.agentConversations.value["%7"]?.detection?.agent,
+        // Issue #819 (A2): the reattach seed is a detection-less remembered-agent
+        // resolving placeholder (the agent UI is available, but the route-true
+        // source is bound by live re-detection, not the remembered one).
+        assertTrue(
+            "precondition: remembered-agent resolving placeholder restored on reattach",
+            vm.agentConversations.value["%7"]?.rememberedAgentPlaceholder == true,
         )
 
         // First live-detection null right after the reattach: DEFER, do not
-        // forget. The seeded agent UI must survive.
+        // forget. The seeded agent UI must survive. This is the #554 no-flap
+        // guarantee — A2 preserves it for the detection-less placeholder via
+        // shouldDeferAgentDowngrade keying off rememberedAgentPlaceholder.
         val downgraded = vm.handleNullAgentDetectionForTest("%7")
         runCurrent()
         assertFalse("first transient null must be deferred, not a downgrade", downgraded)
-        assertEquals(
+        assertNotNull(
             "the seeded agent UI must survive a single transient null",
-            AgentKind.ClaudeCode,
-            vm.agentConversations.value["%7"]?.detection?.agent,
+            vm.agentConversations.value["%7"],
+        )
+        assertTrue(
+            "the remembered-agent resolving placeholder survives the transient null",
+            vm.agentConversations.value["%7"]?.rememberedAgentPlaceholder == true,
         )
         assertEquals(
-            "the Conversation tab stays available for the window",
-            AgentKind.ClaudeCode,
-            vm.agentForWindow("@0"),
+            "the Conversation tab stays selected for the window",
+            SessionTab.Conversation,
+            vm.agentConversations.value["%7"]?.selectedTab,
         )
     }
 
@@ -7972,6 +8343,10 @@ class TmuxSessionViewModelTest {
             )
             runCurrent()
 
+            // Issue #819 (A2): the reattach seed is a detection-less remembered-
+            // agent resolving placeholder. A degraded probe must keep retrying
+            // it (#897) — it must NOT be treated as an agent exit, and the
+            // remembered placeholder stays visible on the Conversation tab.
             repeat(AGENT_EXIT_CONFIRMATIONS) {
                 val downgraded = vm.handleUnavailableAgentDetectionForTest("%7")
                 runCurrent()
@@ -7982,11 +8357,9 @@ class TmuxSessionViewModelTest {
                 val row = vm.agentConversations.value["%7"]
                 assertNotNull("#897: remembered ${detection.agent} row stays visible", row)
                 assertEquals(SessionTab.Conversation, row!!.selectedTab)
-                assertEquals(detection.agent, row.detection?.agent)
-                assertEquals(
-                    "#897: the Conversation tab remains available for the window",
-                    detection.agent,
-                    vm.agentForWindow(windowId),
+                assertTrue(
+                    "#897/#819 (A2): the remembered-agent resolving placeholder survives the degraded probe",
+                    row.rememberedAgentPlaceholder,
                 )
             }
 
@@ -7996,7 +8369,10 @@ class TmuxSessionViewModelTest {
                 "#897: degraded probes must not consume the clean-null exit confirmation budget",
                 firstCleanNull,
             )
-            assertEquals(detection.agent, vm.agentConversations.value["%7"]?.detection?.agent)
+            assertTrue(
+                "#819 (A2): the remembered placeholder survives the first clean null",
+                vm.agentConversations.value["%7"]?.rememberedAgentPlaceholder == true,
+            )
 
             val secondCleanNull = vm.handleNullAgentDetectionForTest("%7")
             runCurrent()

--- a/app/src/test/java/com/pocketshell/app/tmux/connection/ConnectionEffectDriverForegroundConflationProofTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/connection/ConnectionEffectDriverForegroundConflationProofTest.kt
@@ -1,0 +1,214 @@
+package com.pocketshell.app.tmux.connection
+
+import com.pocketshell.core.connection.Clock
+import com.pocketshell.core.connection.ConnectionController
+import com.pocketshell.core.connection.ConnectionEvent
+import com.pocketshell.core.connection.HostKey
+import com.pocketshell.core.connection.LeaseHandle
+import com.pocketshell.core.connection.Seed
+import com.pocketshell.core.connection.SessionId
+import com.pocketshell.core.connection.TmuxPort
+import com.pocketshell.core.connection.TransportPort
+import com.pocketshell.core.connection.TransportUpDown
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #743 — DETERMINISTIC, environment-INDEPENDENT proof of the conflation race
+ * the journey de-flake in [com.pocketshell.app.proof.BackgroundGraceReconnectE2eTest]
+ * targets, and of why the de-flake's foreground-ordering gate is the fix.
+ *
+ * ## Why this JVM proof exists (the #780 model: inject the failure deterministically)
+ *
+ * `quickAppSwitch…` flaked on a CONTENDED swiftshader box: the post-grace branch
+ * foregrounds the instant the remote tmux client count hits 0, while the local
+ * detach + the [ConnectionEffectDriver]'s collector resuming on `Backgrounded` are
+ * still in flight. On an IDLE box the collector resumes between the two submits, so
+ * the flake cannot be reproduced on demand there; on the contended box the only
+ * trigger is real CPU contention from sibling agents that crashes base AND fix
+ * indiscriminately — so a clean on-device base-RED is not obtainable.
+ *
+ * This test reproduces the EXACT mechanism deterministically with a controllable
+ * coroutine dispatcher (no emulator, no contention), and is gated for free in the
+ * Unit job (G9).
+ *
+ * ## The mechanism (verified in [ConnectionEffectDriver.collectStateTransitions])
+ *
+ * The driver fires `foregroundReconnectEffect` (→ the VM's `foreground_reattach`)
+ * ONLY on the controller edge `current is Reconnecting && previous is Backgrounded`,
+ * by collecting `controller.state` — a CONFLATING `StateFlow`. So the edge survives
+ * only if the driver's collector resumes on `Backgrounded` BEFORE `Foreground` is
+ * submitted. With a [StandardTestDispatcher] the collector does NOT run between two
+ * synchronous submits, exactly modelling the contended box where the collector
+ * hasn't resumed yet:
+ *
+ *  - [conflatedBackgroundForeground_dropsForegroundReconnectEffect] (BASE-RED):
+ *    submit `Background` then `Foreground` back-to-back with NO scheduler turn
+ *    between them → the conflating StateFlow only ever surfaces `Reconnecting` to
+ *    the collector → `previous` was never `Backgrounded` → `foregroundReconnectEffect`
+ *    fires ZERO times. This is the journey's headline failure
+ *    (`timed out waiting for diagnostic 'foreground_reattach'`).
+ *  - [drainingBackgroundedBeforeForeground_firesForegroundReconnectEffect] (FIX-GREEN):
+ *    let the scheduler drain so the collector OBSERVES `Backgrounded` before
+ *    `Foreground` is submitted (the production-faithful ordering the de-flake's
+ *    `waitForPostGraceLocalDetachSettled` restores by gating the foreground on the
+ *    local `-CC` detach actually completing + an idle pump) → the
+ *    `Backgrounded -> Reconnecting` edge IS observed → `foregroundReconnectEffect`
+ *    fires exactly ONCE.
+ *
+ * Same controller, same submits, same effect wiring — only the ordering between the
+ * two submits differs. That is the base-RED → fix-GREEN the de-flake rests on,
+ * captured deterministically.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ConnectionEffectDriverForegroundConflationProofTest {
+
+    private class TestClock(var now: Long = 0L) : Clock {
+        override fun nowMs(): Long = now
+    }
+
+    private val host = HostKey("alice@example.com:22/7")
+    private val sessionA = SessionId("7/main")
+
+    private class InertTmuxPort : TmuxPort {
+        val disconnectedFlow = MutableSharedFlow<Boolean>(extraBufferCapacity = 16)
+        override val disconnected: Flow<Boolean> = disconnectedFlow
+        override suspend fun attach(targetId: SessionId) = fail("attach")
+        override suspend fun selectWindow(targetId: SessionId) = fail("selectWindow")
+        override suspend fun seedActivePane(targetId: SessionId): Seed = fail("seedActivePane")
+        override suspend fun detachCleanly() = fail("detachCleanly")
+        private fun fail(method: String): Nothing =
+            throw AssertionError("inert driver must NOT call TmuxPort.$method")
+    }
+
+    private class InertTransportPort(private val warm: Boolean) : TransportPort {
+        val transportEventsFlow = MutableSharedFlow<TransportUpDown>(extraBufferCapacity = 16)
+        override val transportEvents: Flow<TransportUpDown> = transportEventsFlow
+        override fun isWarm(host: HostKey): Boolean = warm
+        override suspend fun ensureLease(host: HostKey): LeaseHandle = fail("ensureLease")
+        override suspend fun evictStale(host: HostKey) = fail("evictStale")
+        private fun fail(method: String): Nothing =
+            throw AssertionError("inert driver must NOT call TransportPort.$method")
+    }
+
+    /**
+     * A harness whose driver collector runs on a [StandardTestDispatcher] — it
+     * resumes ONLY when the scheduler is advanced, so we control exactly whether the
+     * collector observes `Backgrounded` before `Foreground` is submitted.
+     *
+     * `warm = false` so the beyond-grace foreground resolves to `Reconnecting` (the
+     * edge under test), matching the journey's post-grace branch (App-grace teardown
+     * evicted the warm lease).
+     */
+    private class Harness(
+        scope: CoroutineScope,
+        val clock: TestClock,
+        private val host: HostKey,
+        private val sessionA: SessionId,
+    ) {
+        val tmuxPort = InertTmuxPort()
+        val transportPort = InertTransportPort(warm = false)
+        val controller = ConnectionController(clock = clock, transport = transportPort)
+        var foregroundReconnectEffectCount = 0
+        val driver = ConnectionEffectDriver(
+            controller = controller,
+            tmuxPort = tmuxPort,
+            transportPort = transportPort,
+            scope = scope,
+            foregroundReconnectEffect = { foregroundReconnectEffectCount += 1 },
+        ).also { it.start() }
+
+        /** Drive the controller to Live (cold path) so Background has a live source. */
+        fun driveToLive() {
+            controller.submit(ConnectionEvent.Enter(host, sessionA))
+            controller.submit(ConnectionEvent.TransportLive)
+            controller.submit(ConnectionEvent.SeedLanded(sessionA, paneId = "%0"))
+        }
+    }
+
+    /**
+     * BASE-RED: `Background` then `Foreground` submitted back-to-back with NO
+     * scheduler turn between them. The collector (StandardTestDispatcher) has not
+     * resumed, so the conflating `controller.state` collapses `Backgrounded` —
+     * the collector only ever sees `Reconnecting`, never the `Backgrounded ->
+     * Reconnecting` edge, and `foregroundReconnectEffect` fires ZERO times. This is
+     * the deterministic synthetic of the journey's
+     * `timed out waiting for diagnostic 'foreground_reattach'`.
+     */
+    @Test
+    fun conflatedBackgroundForeground_dropsForegroundReconnectEffect() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val scope = CoroutineScope(dispatcher)
+        val h = Harness(scope, TestClock(), host, sessionA)
+
+        h.driveToLive()
+        h.controller.submit(ConnectionEvent.Background)
+        // No advanceUntilIdle() here: the driver's collector has NOT resumed, so it
+        // has not observed Backgrounded yet — exactly the contended-box race.
+        h.clock.now = ConnectionController.DEFAULT_GRACE_MS + 1L
+        h.controller.submit(ConnectionEvent.Foreground) // Backgrounded -> Reconnecting (conflated)
+
+        // Now let the collector drain. Because the StateFlow conflated, it never
+        // observed `Backgrounded`, so the edge effect never fired.
+        advanceUntilIdle()
+
+        assertEquals(
+            "BASE-RED expected: when Foreground is submitted before the driver's " +
+                "collector resumes on Backgrounded, the conflating StateFlow drops the " +
+                "Backgrounded -> Reconnecting edge and foregroundReconnectEffect must NOT " +
+                "fire (this is the journey's missing 'foreground_reattach')",
+            0,
+            h.foregroundReconnectEffectCount,
+        )
+        // Sanity: the controller's terminal state IS Reconnecting — the controller
+        // reduced correctly; only the DRIVER's edge observation was lost.
+        assertTrue(
+            "controller must still have reduced to Reconnecting — the conflation is in " +
+                "the driver's edge OBSERVATION, not the controller reducer",
+            h.controller.state.value is com.pocketshell.core.connection.ConnectionState.Reconnecting,
+        )
+        scope.cancel()
+    }
+
+    /**
+     * FIX-GREEN: let the collector OBSERVE `Backgrounded` before `Foreground` is
+     * submitted (the production-faithful ordering the de-flake's
+     * `waitForPostGraceLocalDetachSettled` restores by gating the foreground on the
+     * real local-detach signal). The `Backgrounded -> Reconnecting` edge is then
+     * observed and `foregroundReconnectEffect` fires exactly once.
+     */
+    @Test
+    fun drainingBackgroundedBeforeForeground_firesForegroundReconnectEffect() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val scope = CoroutineScope(dispatcher)
+        val h = Harness(scope, TestClock(), host, sessionA)
+
+        h.driveToLive()
+        h.controller.submit(ConnectionEvent.Background)
+        // The fix's ordering: drain so the driver's collector OBSERVES Backgrounded
+        // (sets previous = Backgrounded) BEFORE the foreground is submitted.
+        advanceUntilIdle()
+
+        h.clock.now = ConnectionController.DEFAULT_GRACE_MS + 1L
+        h.controller.submit(ConnectionEvent.Foreground) // Backgrounded -> Reconnecting (observed)
+        advanceUntilIdle()
+
+        assertEquals(
+            "FIX-GREEN expected: with the collector having observed Backgrounded first, " +
+                "the Backgrounded -> Reconnecting edge fires foregroundReconnectEffect once " +
+                "(the journey's post-grace 'foreground_reattach')",
+            1,
+            h.foregroundReconnectEffectCount,
+        )
+        scope.cancel()
+    }
+}

--- a/scripts/check-version-coupling.sh
+++ b/scripts/check-version-coupling.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# PR-time version-coupling guard for issue #948.
+#
+# The Android app derives the EXPECTED host `pocketshell` CLI version from its
+# own `versionName` (app/build.gradle.kts). `FolderListViewModel`'s
+# `expectedPocketshellVersionProvider` reads
+# `packageManager.getPackageInfo(...).versionName`, and
+# `PayloadVersionCheck.evaluate` compares the host CLI version against it to
+# drive the in-app host-version-mismatch banner. So the app `versionName` and
+# the `tools/pocketshell` Python package `version` MUST be the same string.
+#
+# They drifted on 2026-06-25 (app 0.4.16 vs package 0.4.14); the in-app banner
+# nagged the maintainer and PR #946 bumped the package manually. The existing
+# `scripts/check-pypi-version.sh` only runs on TAG push in build.yml, so the
+# drift was never caught at PR time. This guard closes that gap: it runs in the
+# cheap Python job of .github/workflows/tests.yml so a `versionName` bump
+# without a matching `pyproject.toml` bump goes RED at PR time.
+#
+# Usage:
+#   scripts/check-version-coupling.sh        # check the real tree
+#   scripts/check-version-coupling.sh --self-test
+#                                            # run an in-process red->green
+#                                            # proof on synthetic fixtures and
+#                                            # exit 0 only if both pass
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+GRADLE_REL="app/build.gradle.kts"
+PYPROJECT_REL="tools/pocketshell/pyproject.toml"
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/check-version-coupling.sh [--self-test]
+
+Verifies that the app's expected host `pocketshell` version (the Android
+`versionName` in app/build.gradle.kts) equals the `pocketshell` Python package
+`version` in tools/pocketshell/pyproject.toml. Exits 0 on match, non-zero (1) on
+mismatch with a clear message.
+
+--self-test runs a synthetic red->green proof: it builds a matched fixture pair
+(expects PASS) and a skewed fixture pair (expects FAIL), and exits 0 only if the
+guard behaves correctly on both. Use it to prove the guard works without
+touching the real version files.
+USAGE
+}
+
+# Extract the app `versionName` from an app/build.gradle.kts file.
+parse_version_name() {
+  local file="$1"
+  sed -n 's/^[[:space:]]*versionName[[:space:]]*=[[:space:]]*"\([^"]*\)".*$/\1/p' "$file" |
+    head -n 1
+}
+
+# Extract the `pocketshell` package `version` from a pyproject.toml file.
+# Hatchling pyproject.toml has both [build-system] (no `version`) and [project]
+# (the one we want); grabbing the first `version = "..."` is reliable for the
+# single-package layout.
+parse_pyproject_version() {
+  local file="$1"
+  sed -n 's/^[[:space:]]*version[[:space:]]*=[[:space:]]*"\([^"]*\)".*$/\1/p' "$file" |
+    head -n 1
+}
+
+# Core comparison. Args: <gradle-file> <pyproject-file>.
+# Exits 0 on match, 1 on mismatch. Prints both versions and the verdict.
+check_pair() {
+  local gradle_file="$1"
+  local pyproject_file="$2"
+
+  if [[ ! -f "$gradle_file" ]]; then
+    printf 'FAIL: missing %s\n' "$gradle_file" >&2
+    return 1
+  fi
+  if [[ ! -f "$pyproject_file" ]]; then
+    printf 'FAIL: missing %s\n' "$pyproject_file" >&2
+    return 1
+  fi
+
+  local version_name pkg_version
+  version_name="$(parse_version_name "$gradle_file")"
+  pkg_version="$(parse_pyproject_version "$pyproject_file")"
+
+  if [[ -z "$version_name" ]]; then
+    printf 'FAIL: could not parse versionName from %s\n' "$gradle_file" >&2
+    return 1
+  fi
+  if [[ -z "$pkg_version" ]]; then
+    printf 'FAIL: could not parse version from %s\n' "$pyproject_file" >&2
+    return 1
+  fi
+
+  printf 'app versionName (expected host version): %s\n' "$version_name"
+  printf 'tools/pocketshell package version:       %s\n' "$pkg_version"
+
+  if [[ "$version_name" != "$pkg_version" ]]; then
+    printf 'FAIL: tools/pocketshell version (%s) != app versionName (%s).\n' \
+      "$pkg_version" "$version_name" >&2
+    printf '      The app expects the host `pocketshell` CLI to report %s ' \
+      "$version_name" >&2
+    printf '(it reads its own versionName);\n' >&2
+    printf '      a mismatch makes the in-app host-version banner nag the user.\n' >&2
+    printf '      Bump %s `version` to %s (or fix the versionName) and commit both in lockstep.\n' \
+      "$pyproject_file" "$version_name" >&2
+    return 1
+  fi
+
+  printf 'OK: app versionName and tools/pocketshell version are aligned (%s).\n' \
+    "$version_name"
+  return 0
+}
+
+run_self_test() {
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  # Matched fixtures -> expect PASS (exit 0).
+  mkdir -p "$tmp/match/app" "$tmp/match/tools/pocketshell"
+  printf '    versionName = "9.9.9"\n' > "$tmp/match/app/build.gradle.kts"
+  printf '[project]\nversion = "9.9.9"\n' > "$tmp/match/tools/pocketshell/pyproject.toml"
+
+  # Skewed fixtures -> expect FAIL (exit 1).
+  mkdir -p "$tmp/skew/app" "$tmp/skew/tools/pocketshell"
+  printf '    versionName = "9.9.9"\n' > "$tmp/skew/app/build.gradle.kts"
+  printf '[project]\nversion = "9.9.8"\n' > "$tmp/skew/tools/pocketshell/pyproject.toml"
+
+  local failures=0
+
+  printf '== self-test: matched pair (expect PASS) ==\n'
+  if check_pair "$tmp/match/app/build.gradle.kts" "$tmp/match/tools/pocketshell/pyproject.toml"; then
+    printf '   -> PASS as expected\n\n'
+  else
+    printf '   -> UNEXPECTED FAIL on matched pair\n\n' >&2
+    failures=$((failures + 1))
+  fi
+
+  printf '== self-test: skewed pair (expect FAIL) ==\n'
+  if check_pair "$tmp/skew/app/build.gradle.kts" "$tmp/skew/tools/pocketshell/pyproject.toml"; then
+    printf '   -> UNEXPECTED PASS on skewed pair\n\n' >&2
+    failures=$((failures + 1))
+  else
+    printf '   -> FAIL as expected\n\n'
+  fi
+
+  if [[ "$failures" -ne 0 ]]; then
+    printf 'SELF-TEST FAILED: %d case(s) behaved incorrectly.\n' "$failures" >&2
+    return 1
+  fi
+  printf 'SELF-TEST OK: matched pair passes, skewed pair fails.\n'
+  return 0
+}
+
+main() {
+  case "${1:-}" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --self-test)
+      run_self_test
+      exit $?
+      ;;
+    "")
+      check_pair "$ROOT_DIR/$GRADLE_REL" "$ROOT_DIR/$PYPROJECT_REL"
+      exit $?
+      ;;
+    *)
+      printf 'FAIL: unknown arg: %s\n' "$1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+}
+
+main "$@"

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -920,6 +920,39 @@ JOURNEY_CLASSES=(
   # assumeTrue / assumeFalse(isRunningOnCi()) on the load-bearing assertions —
   # process.md F3 / D33). It lives under the com.pocketshell.app.proof prefix.
   "$FQCN_PREFIX.StrictModeMainThreadIoDetectorE2eTest"
+
+  # ===========================================================================
+  # Issue #949 (epic #859 Slice A — host→app card push, Phase-1 verify-gone,
+  # D33). Kept in its OWN block to minimize merge friction with the sibling
+  # blocks above.
+  #
+  # Phase-1 (the host CLI `pocketshell push checklist|get|check|status` + the
+  # app's SessionCardsRemoteSource + the checklist chip / bottom-sheet) shipped
+  # code-complete on `main` but WITHOUT an end-to-end emulator+Docker acceptance
+  # journey, so the real warm-session card-push path was UNPROVEN (D33). This
+  # journey closes that gap and gate-wires it per-push so the transport cannot
+  # silently regress.
+  #
+  # It exercises the REAL path, not a unit proxy: a host (the deterministic
+  # agents fixture) runs `pocketshell push checklist --session <s> --item …`
+  # over a real SSH session to write the per-session card store; the PRODUCTION
+  # SessionCardsRemoteSource.getCards reads it back over the SAME warm session
+  # (D21) and parses a ChecklistCard; the PRODUCTION checklist chip +
+  # ChecklistCardsContent render the real feed and the test asserts the card +
+  # its items ACTUALLY appear; tapping an item drives the PRODUCTION
+  # setChecklistItemChecked tick exec, and re-reading the host (`push status` +
+  # getCards) confirms the tick ROUND-TRIPPED (untick too). The
+  # readPathBroken_wrongSessionName_yieldsEmptyFeed_redGuard case is the
+  # inverted RED→GREEN guard (D32 G10) that pins the load-bearing
+  # "card-reaches-the-feed" assertions. The fixture `pocketshell push` verb is
+  # now faithful to cards.py (item ids <slug>-<index>, full-replace on re-push,
+  # the JSON `get` contract the app reads, unknown-id error). It uses ONLY the
+  # deterministic agents:2222 fixture (DEFAULT_HOST/PORT/USER -> 10.0.2.2:2222,
+  # or the pool-allocated port under `--pool`) that tests.yml already brings up
+  # with `up -d --build` (so CI gets the new `push` verb, not a stale image) —
+  # no new Docker service/port, no toxiproxy — and does NOT self-skip on CI. It
+  # lives under com.pocketshell.app.cards, so it carries its FQCN directly.
+  "com.pocketshell.app.cards.SessionChecklistPushJourneyDockerTest"
 )
 
 echo "=========================================================="

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -881,6 +881,12 @@ JOURNEY_CLASSES=(
   "com.pocketshell.app.fileexplorer.FileExplorerScaffoldTest#successTransferShowsDismissibleBanner"
   "com.pocketshell.app.fileviewer.FileViewerScaffoldTest#cannotPreviewStateShowsMessageAndRetry"
   "com.pocketshell.app.fileviewer.FileViewerScaffoldTest#cannotPreviewWithLocateCandidatesOffersOpenRows"
+  # ADDED (#921, D32 G9): rendered Markdown shows GFM pipe tables as laid-out
+  # cells, not raw `|---|---|` delimiter text. Drives the REAL FileViewerScaffold
+  # with a benchmark/report `.md` and HARD-asserts the table surface is present
+  # and the delimiter row is NOT shown as literal text. PURE Compose (no Docker /
+  # SSH / tmux / port — runs on the already-booted AVD), no self-skip.
+  "com.pocketshell.app.fileviewer.FileViewerScaffoldTest#markdownRenderedPipeTableShowsCellsNotRawDelimiter"
   # ADDED (#885, D32 G9): the post-update "Host ready" success sheet must show
   # ONLY Continue — the "Open Usage" CTA (#117) was removed (hard cut, D22).
   # This connected test drives the REAL HostBootstrapSheet in its Success state

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -1575,6 +1575,53 @@ else
   fi
 fi
 
+# ---------------------------------------------------------------------------
+# v0.4.17 RELEASE-BLOCKER: the terminal affordance-overlay UNBOUNDED-height
+# measure crash (CI run 28184338389, reproduced 4/4). The draw-only overlays
+# (SmartSelectionAffordanceOverlay / FilePathOverlay / AgentPaneAffordanceOverlay
+# / EngineCommandOverlay) laid out at the raw `constraints.maxHeight` — fine
+# under a normal bounded measure, but the overlay sits inside the terminal pane,
+# itself inside the `TmuxTerminalPager` (Pager), whose lookahead/measure pass
+# runs with an UNBOUNDED (`Int.MAX_VALUE`) max height. That overflowed `layout()`
+# → `IllegalStateException: Size(1070 x 2147483647) is out of range`, which tore
+# down the whole back-to-picker / multi-session-switch journey. This proof
+# composes EACH of the four PRODUCTION overlays under EXACTLY that crash
+# constraint (`Constraints(maxWidth=1070, maxHeight=Infinity)`) and HARD-asserts
+# every one lays out at a FINITE height (class coverage, no self-skip). RED on
+# the un-fixed overlays (the activity dies with the out-of-range crash); GREEN
+# after the `layoutOverlayBounded` clamp. Uses NO Docker fixture (in-process
+# Compose UI test). It lives under com.pocketshell.core.terminal.selection.
+CORE_TERMINAL_OVERLAY_UNBOUNDED_CLASS="com.pocketshell.core.terminal.selection.TerminalOverlayUnboundedMeasureCrashTest"
+OVERLAY_UNBOUNDED_STATUS="PASS"
+
+run_core_terminal_overlay_unbounded() {
+  "$GRADLEW" :shared:core-terminal:connectedDebugAndroidTest \
+    -Pandroid.testInstrumentationRunnerArguments.class="$CORE_TERMINAL_OVERLAY_UNBOUNDED_CLASS" \
+    --stacktrace
+}
+
+if budget_exhausted; then
+  STEP_TIMEOUT_HIT=1
+  OVERLAY_UNBOUNDED_STATUS="SKIPPED"
+  echo "JOURNEY_STEP_TIMEOUT: skipping overlay-unbounded-measure proof — suite budget exhausted (issue #835 / #470 stall)"
+else
+  echo "=========================================================="
+  echo ">>> CORE-TERMINAL OVERLAY-UNBOUNDED-MEASURE PROOF: $CORE_TERMINAL_OVERLAY_UNBOUNDED_CLASS (attempt 1)"
+  echo "=========================================================="
+  overlay_unbounded_start=$SECONDS
+  if run_core_terminal_overlay_unbounded; then
+    echo "OVERLAY_UNBOUNDED_PASS: passed on attempt 1 (elapsed $((SECONDS - overlay_unbounded_start))s)"
+  else
+    echo ">>> OVERLAY-UNBOUNDED-MEASURE PROOF FAILED attempt 1 — retrying once (CI-AVD infra flake / sibling-install)"
+    if run_core_terminal_overlay_unbounded; then
+      echo "OVERLAY_UNBOUNDED_FLAKE_RECOVERED: passed on retry (attempt 2)"
+    else
+      echo "OVERLAY_UNBOUNDED_FAILED: overlay-unbounded-measure proof failed twice"
+      OVERLAY_UNBOUNDED_STATUS="FAIL"
+    fi
+  fi
+fi
+
 SUITE_ELAPSED=$((SECONDS - SUITE_START))
 
 # The job is red iff at least one class failed BOTH attempts, OR the #803
@@ -1587,13 +1634,13 @@ SUITE_ELAPSED=$((SECONDS - SUITE_START))
 if [[ "${#FAILED_CLASSES[@]}" -eq 0 && "$STEP_TIMEOUT_HIT" -eq 0 \
       && "$APPEND_BURST_STATUS" == "PASS" && "$OUTPUT_BURST_IME_STATUS" == "PASS" \
       && "$MULTICHUNK_SEED_STATUS" == "PASS" && "$AGENT_LINK_AFFORDANCE_STATUS" == "PASS" \
-      && "$REATTACH_REPAINT_STATUS" == "PASS" ]]; then
+      && "$REATTACH_REPAINT_STATUS" == "PASS" && "$OVERLAY_UNBOUNDED_STATUS" == "PASS" ]]; then
   JOURNEY_EXIT=0
   journey_status="PASS"
 elif [[ "$STEP_TIMEOUT_HIT" -eq 1 && "${#FAILED_CLASSES[@]}" -eq 0 \
         && "$APPEND_BURST_STATUS" != "FAIL" && "$OUTPUT_BURST_IME_STATUS" != "FAIL" \
         && "$MULTICHUNK_SEED_STATUS" != "FAIL" && "$AGENT_LINK_AFFORDANCE_STATUS" != "FAIL" \
-        && "$REATTACH_REPAINT_STATUS" != "FAIL" ]]; then
+        && "$REATTACH_REPAINT_STATUS" != "FAIL" && "$OVERLAY_UNBOUNDED_STATUS" != "FAIL" ]]; then
   # Only the budget timeout fired (no class failed BOTH attempts on its own
   # merits): a pure #470-stall time-budget casualty.
   JOURNEY_EXIT=1
@@ -1639,6 +1686,9 @@ echo "=========================================================="
   echo
   echo "Core-terminal #879 beyond-grace reattach-repaint proof (\`shared:core-terminal\`): **$REATTACH_REPAINT_STATUS**"
   echo "- \`$CORE_TERMINAL_REATTACH_REPAINT_CLASS\`"
+  echo
+  echo "Core-terminal v0.4.17 overlay-unbounded-measure crash proof (\`shared:core-terminal\`): **$OVERLAY_UNBOUNDED_STATUS**"
+  echo "- \`$CORE_TERMINAL_OVERLAY_UNBOUNDED_CLASS\`"
   if [[ "${#RECOVERED_CLASSES[@]}" -gt 0 ]]; then
     echo
     echo "Recovered on retry (CI-AVD flake — \`JOURNEY_FLAKE_RECOVERED\`):"
@@ -1681,7 +1731,8 @@ echo "=========================================================="
   # here, otherwise an append-burst-only regression falls through to the grep's
   # else-branch and is mislabeled as an infra abort, burying the real cause.
   if [[ "${#FAILED_CLASSES[@]}" -gt 0 || "$APPEND_BURST_STATUS" == "FAIL" || "$OUTPUT_BURST_IME_STATUS" == "FAIL" \
-        || "$MULTICHUNK_SEED_STATUS" == "FAIL" || "$AGENT_LINK_AFFORDANCE_STATUS" == "FAIL" ]]; then
+        || "$MULTICHUNK_SEED_STATUS" == "FAIL" || "$AGENT_LINK_AFFORDANCE_STATUS" == "FAIL" \
+        || "$REATTACH_REPAINT_STATUS" == "FAIL" || "$OVERLAY_UNBOUNDED_STATUS" == "FAIL" ]]; then
     echo
     echo "Failed BOTH attempts (\`JOURNEY_FAILED\` — job red):"
     for c in "${FAILED_CLASSES[@]}"; do
@@ -1698,6 +1749,12 @@ echo "=========================================================="
     fi
     if [[ "$AGENT_LINK_AFFORDANCE_STATUS" == "FAIL" ]]; then
       echo "- \`$CORE_TERMINAL_AGENT_LINK_AFFORDANCE_CLASS\` (#871 agent-pane link-affordance off-main proof)"
+    fi
+    if [[ "$REATTACH_REPAINT_STATUS" == "FAIL" ]]; then
+      echo "- \`$CORE_TERMINAL_REATTACH_REPAINT_CLASS\` (#879 reattach-repaint proof)"
+    fi
+    if [[ "$OVERLAY_UNBOUNDED_STATUS" == "FAIL" ]]; then
+      echo "- \`$CORE_TERMINAL_OVERLAY_UNBOUNDED_CLASS\` (v0.4.17 overlay-unbounded-measure crash proof)"
     fi
   fi
 } > "$SUMMARY"

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -570,6 +570,19 @@ JOURNEY_CLASSES=(
   # self-skip on CI (no assumeTrue / assumeFalse(isRunningOnCi()) on the
   # load-bearing assertion). It lives under com.pocketshell.app.tmux.
   "com.pocketshell.app.tmux.TmuxComposerLauncherNarrowFontClipProofTest"
+  # ADDED (#859 Slice B): the typed-card RENDERER REGISTRY proof. The session
+  # feed is now a generic typed-card list dispatched through
+  # SessionCardRenderers (no `when (type)` in the feed). This connected Compose
+  # test renders a HETEROGENEOUS feed (checklist + the new `note` type + a
+  # genuinely unknown type) through the registry and asserts: the checklist
+  # still renders + ticks (no regression), the `note` card renders + marks-read
+  # via the registry (new type, zero feed code change), and an unknown type
+  # degrades to the graceful "unsupported card" row. It is a PURE Compose test —
+  # NO Docker fixture, NO SSH/tmux, NO toxiproxy, NO 2222/2226 port — so it
+  # needs no tests.yml service change, and it does NOT self-skip on CI (no
+  # assumeTrue / assumeFalse(isRunningOnCi())). Lives under
+  # com.pocketshell.app.cards.
+  "com.pocketshell.app.cards.SessionCardFeedRegistryTest"
   # ADDED (#750, 3rd occurrence — D31 durable-fix gate): the tmux non-Connected
   # SINGLE-INDICATOR regression guard. The maintainer's "two loading indicators
   # on the reconnect/reattach screen" symptom has now shipped THREE times because

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -792,6 +792,24 @@ JOURNEY_CLASSES=(
   # cache seed (first state is Loading); GREEN after. Lives under
   # com.pocketshell.app.projects, so it carries its FQCN directly.
   "com.pocketshell.app.projects.FolderListClientCacheInstantRenderDockerTest"
+  # ADDED (#839, epic #821 workstream C — the #837 durable-tree daemon journey):
+  # the END-TO-END durable-tree proof on a REAL device + REAL daemon. #837 was
+  # approved on a JVM FakeTreeDaemon proxy; this drives the PRODUCTION
+  # FolderListViewModel + a REAL TreeRemoteSource against the `agents-daemon`
+  # fixture (port 2239) whose `pocketshell` is the genuine Python package, so
+  # `tree get|upsert|reconcile` PERSIST a host-side JSON registry that survives an
+  # app kill + relaunch. The journey collapses a folder + holds an order, KILLS +
+  # RELAUNCHES the app (a fresh VM + a NEW TreeRemoteSource), asserts the
+  # cold-start hydrate renders the held order/collapse INSTANTLY (folder stays
+  # collapsed), then a resume reconcile prunes a gone session as a DELTA against
+  # the LIVE `tmuxctl list` and a refresh picks up an added one. RED on a broken
+  # durable path (the test's pre-condition guard fails if the daemon doesn't
+  # persist); GREEN with the real daemon. The emulator-journey workflow now brings
+  # up the 2239 fixture (+ a real-tree persist sanity check), so this does NOT
+  # self-skip on CI. The always-runnable JVM backstop is
+  # FolderListViewModelTreeDurabilityTest (per-push Unit job). It lives under
+  # com.pocketshell.app.projects, so it carries its FQCN directly.
+  "com.pocketshell.app.projects.FolderListDurableTreeDaemonDockerTest"
   # ADDED (#869): the composer-Send ACK-GATE on-device submit JOURNEY — the
   # load-bearing real-agent proof the #869 reviewer required (BLOCKED-G4). The
   # maintainer's symptom: "most of the time when I click Send it's not really

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -921,6 +921,7 @@ JOURNEY_CLASSES=(
   # process.md F3 / D33). It lives under the com.pocketshell.app.proof prefix.
   "$FQCN_PREFIX.StrictModeMainThreadIoDetectorE2eTest"
 
+<<<<<<< ours
   # ===========================================================================
   # Issue #949 (epic #859 Slice A — host→app card push, Phase-1 verify-gone,
   # D33). Kept in its OWN block to minimize merge friction with the sibling
@@ -953,6 +954,28 @@ JOURNEY_CLASSES=(
   # no new Docker service/port, no toxiproxy — and does NOT self-skip on CI. It
   # lives under com.pocketshell.app.cards, so it carries its FQCN directly.
   "com.pocketshell.app.cards.SessionChecklistPushJourneyDockerTest"
+=======
+  # ADDED (#947): the host-version-mismatch banner's one-tap Update button — the
+  # UI gate (#641/#567/#657/G9) for a maintainer-reported UI control. The
+  # maintainer asked for an Update button on the FolderList host-version banner
+  # (the arrow in the issue screenshot) so the host `pocketshell` upgrade runs
+  # over the warm session instead of copy-paste. This connected proof composes the
+  # PRODUCTION CliVersionMismatchBanner (internal, no proxy/stand-in) in all THREE
+  # states — Idle (Update + Dismiss), Running (spinner replaces the buttons, no
+  # double-run), Failure (error line + Retry + Dismiss, no stuck spinner) — pinned
+  # to the bottom edge like its real placement, and HARD-asserts viewport
+  # CONTAINMENT (assertNodeFullyWithinRoot, the #657/F1 helper — NOT a bare
+  # assertIsDisplayed, which a control pushed off the right edge by the long
+  # version message would still satisfy) plus reachability (enabled + clickable)
+  # of the Update + Dismiss controls. Each state writes a full-device screenshot
+  # (the maintainer's arrow-target acceptance: Update next to Dismiss). It uses NO
+  # Docker fixture, NO SSH/tmux/port (pure Compose UI test on the booted AVD) and
+  # does NOT self-skip on CI (no assumeTrue / assumeFalse(isRunningOnCi()) on the
+  # load-bearing assertions — process.md F3 / D33). It lives under
+  # com.pocketshell.app.projects, not the proof prefix, so it carries its
+  # fully-qualified name directly.
+  "com.pocketshell.app.projects.CliVersionMismatchBannerUpdateButtonTest"
+>>>>>>> theirs
 )
 
 echo "=========================================================="

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -921,7 +921,6 @@ JOURNEY_CLASSES=(
   # process.md F3 / D33). It lives under the com.pocketshell.app.proof prefix.
   "$FQCN_PREFIX.StrictModeMainThreadIoDetectorE2eTest"
 
-<<<<<<< ours
   # ===========================================================================
   # Issue #949 (epic #859 Slice A — host→app card push, Phase-1 verify-gone,
   # D33). Kept in its OWN block to minimize merge friction with the sibling
@@ -954,7 +953,6 @@ JOURNEY_CLASSES=(
   # no new Docker service/port, no toxiproxy — and does NOT self-skip on CI. It
   # lives under com.pocketshell.app.cards, so it carries its FQCN directly.
   "com.pocketshell.app.cards.SessionChecklistPushJourneyDockerTest"
-=======
   # ADDED (#947): the host-version-mismatch banner's one-tap Update button — the
   # UI gate (#641/#567/#657/G9) for a maintainer-reported UI control. The
   # maintainer asked for an Update button on the FolderList host-version banner
@@ -975,7 +973,6 @@ JOURNEY_CLASSES=(
   # com.pocketshell.app.projects, not the proof prefix, so it carries its
   # fully-qualified name directly.
   "com.pocketshell.app.projects.CliVersionMismatchBannerUpdateButtonTest"
->>>>>>> theirs
 )
 
 echo "=========================================================="

--- a/shared/core-ssh/src/integrationTest/java/com/pocketshell/core/ssh/KeepAliveIntegrationTest.kt
+++ b/shared/core-ssh/src/integrationTest/java/com/pocketshell/core/ssh/KeepAliveIntegrationTest.kt
@@ -1,0 +1,579 @@
+package com.pocketshell.core.ssh
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import org.junit.AfterClass
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
+import org.junit.BeforeClass
+import org.junit.Test
+import org.testcontainers.DockerClientFactory
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.images.builder.ImageFromDockerfile
+import java.io.File
+import java.net.InetSocketAddress
+import java.net.ServerSocket
+import java.net.Socket
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
+import kotlin.concurrent.thread
+
+/**
+ * Issue #945 — the SAFE dispatcher-serialized SSH transport keepalive (the real
+ * "stays up like Terminus" fix) END-TO-END against a real Docker OpenSSH server.
+ *
+ * The maintainer's #1 dogfood pain: "I'm tired of reconnects and glitches and I
+ * have to use Terminus." Terminus survives flaky Wi-Fi because it runs an
+ * always-on, transport-level `ServerAliveInterval` keepalive. PocketShell had
+ * NONE (removed in #847 because sshj's `KeepAliveRunner` was an un-ownable second
+ * writer that corrupted KEX). [TransportDispatcher] is now the sole FIFO writer,
+ * so a keepalive sent THROUGH it ([SshSession.sendKeepAlive]) is safe.
+ *
+ * Reproduce-first (D33/G10) — these run on the REAL [RealSshSession] /
+ * [TransportKeepAlive] path against a real sshd, with a controllable in-JVM TCP
+ * relay ([PausableTcpRelay]) in front of it so we can inject a REAL link gap on
+ * the REAL encrypted transport:
+ *
+ *  - **Ride-through:** pause the relay for a window SHORTER than the keepalive
+ *    budget (no FIN — a half-open starve), then resume. The transport keepalive
+ *    rides through it: the session stays connected and a keepalive answers again
+ *    after recovery. RED without a keepalive (nothing keeps the link warm / the
+ *    detector has nothing to reset); GREEN with it.
+ *  - **Dead-peer detection:** CUT the relay permanently. The keepalive misses
+ *    answer, the loop declares dead within `countMax × interval`, and the dead
+ *    transport is closed (the existing reconnect entrypoint) — no #822 regression.
+ *  - **No KEX corruption (the #847 guard):** hold a real session > 100s with the
+ *    keepalive cadence ON under concurrent traffic + rekey and assert the sshd
+ *    log NEVER shows `Connection corrupted` / `Bad packet length` /
+ *    `ssh_dispatch_run_fatal` — proving the keepalive-through-the-dispatcher does
+ *    NOT reintroduce the #847 corruption.
+ *
+ * Wired into the per-push required check `Integration tests (Docker)` via the
+ * `:shared:core-ssh:integrationTest` task (it includes all `*IntegrationTest`).
+ */
+class KeepAliveIntegrationTest {
+
+    companion object {
+        private const val CONTAINER_SSH_PORT = 22
+
+        private val projectRoot: Path by lazy { findProjectRoot() }
+
+        @Volatile
+        private var container: GenericContainer<*>? = null
+
+        /** Same #847 server-side desync signatures as [SshIntegrationTest]. */
+        private val CORRUPTION_SIGNATURES = listOf(
+            "Connection corrupted",
+            "Bad packet length",
+            "ssh_dispatch_run_fatal",
+            "message authentication code incorrect",
+            "padding error",
+        )
+
+        @BeforeClass
+        @JvmStatic
+        fun setUp() {
+            val dockerAvailable = runCatching {
+                DockerClientFactory.instance().isDockerAvailable
+            }.getOrDefault(false)
+            assumeTrue("Docker not available; skipping keepalive integration tests", dockerAvailable)
+
+            val dockerDir = projectRoot.resolve("tests/docker")
+            val image = ImageFromDockerfile("pocketshell-test-ssh", false)
+                .withDockerfile(dockerDir.resolve("Dockerfile.ssh"))
+            container = GenericContainer(image)
+                .withExposedPorts(CONTAINER_SSH_PORT)
+                .also { it.start() }
+        }
+
+        @AfterClass
+        @JvmStatic
+        fun tearDown() {
+            container?.stop()
+            container = null
+        }
+
+        private fun findProjectRoot(): Path {
+            var dir: Path? = Paths.get(System.getProperty("user.dir")).toAbsolutePath()
+            while (dir != null) {
+                if (dir.resolve("tests/docker/Dockerfile.ssh").toFile().exists()) {
+                    return dir
+                }
+                dir = dir.parent
+            }
+            error(
+                "Could not locate tests/docker/Dockerfile.ssh from user.dir=" +
+                    System.getProperty("user.dir"),
+            )
+        }
+    }
+
+    private val sshHost: String get() = container!!.host
+    private val sshPort: Int get() = container!!.getMappedPort(CONTAINER_SSH_PORT)
+    private val privateKeyFile: File
+        get() = projectRoot.resolve("tests/docker/test_key").toFile()
+
+    private fun connectDirect(): SshSession = runBlocking {
+        SshConnection.connect(
+            host = sshHost,
+            port = sshPort,
+            user = "testuser",
+            key = SshKey.Path(privateKeyFile),
+            passphrase = null,
+            knownHosts = KnownHostsPolicy.AcceptAll,
+            timeoutMs = 15_000,
+        ).getOrThrow()
+    }
+
+    private fun connectThroughRelay(relay: PausableTcpRelay): SshSession = runBlocking {
+        SshConnection.connect(
+            host = "127.0.0.1",
+            port = relay.localPort,
+            user = "testuser",
+            key = SshKey.Path(privateKeyFile),
+            passphrase = null,
+            knownHosts = KnownHostsPolicy.AcceptAll,
+            timeoutMs = 15_000,
+        ).getOrThrow()
+    }
+
+    @Test
+    fun sendKeepAliveRoundTripsAgainstRealOpenSsh() = runTest {
+        // The base mechanism proof: the `keepalive@openssh.com` global request,
+        // sent through the dispatcher, gets a reply from a real OpenSSH server
+        // (a REQUEST_FAILURE, since the server doesn't implement the request type)
+        // — and that reply STILL counts as proof of life. RED without the fix:
+        // `sendKeepAlive` doesn't exist / throws NotImplementedError.
+        connectDirect().use { session ->
+            assertTrue("session should be connected", session.isConnected)
+            assertTrue(
+                "sendKeepAlive() must return true (peer is alive) against a real " +
+                    "OpenSSH server — the REQUEST_FAILURE reply for keepalive@openssh.com " +
+                    "proves liveness exactly as OpenSSH's own ServerAlive does",
+                session.sendKeepAlive(),
+            )
+            // After close, a keepalive must be a miss, not a crash.
+            session.close()
+            assertFalse(
+                "sendKeepAlive() on a closed transport must return false (miss), not throw",
+                session.sendKeepAlive(),
+            )
+        }
+    }
+
+    @Test
+    fun transientGapShorterThanBudgetIsRiddenThrough() {
+        // RIDE-THROUGH (the Terminus behaviour, the red->green core): pause the
+        // link for a window SHORTER than the keepalive budget, then resume. The
+        // transport keepalive absorbs the blip — the session stays connected and
+        // answers a keepalive again after recovery — where PocketShell used to
+        // drop. The keepalive loop runs at a SHORTENED cadence so the gap is
+        // meaningful relative to its budget without a multi-minute test.
+        val relay = PausableTcpRelay(sshHost, sshPort).also { it.start() }
+        try {
+            val session = connectThroughRelay(relay)
+            val ioScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+            val deadDeclared = AtomicBoolean(false)
+            val keepAliveSends = AtomicInteger(0)
+            val keepAliveOks = AtomicInteger(0)
+            try {
+                // A short-cadence keepalive: interval 2s, countMax 3 -> ~6s budget.
+                val keepAlive = TransportKeepAlive(
+                    io = object : TransportKeepAlive.KeepAliveIo {
+                        override fun isAlive(): Boolean = session.isConnected
+                        override fun lastInboundActivityNanos(): Long = Long.MIN_VALUE
+                        override suspend fun sendKeepAlive(): Boolean {
+                            keepAliveSends.incrementAndGet()
+                            val ok = session.sendKeepAlive()
+                            if (ok) keepAliveOks.incrementAndGet()
+                            return ok
+                        }
+                        override fun onKeepAliveDead(consecutiveMisses: Int) {
+                            deadDeclared.set(true)
+                        }
+                    },
+                    intervalMs = 2_000L,
+                    countMax = 3,
+                )
+                keepAlive.start(ioScope)
+
+                // Let a couple of healthy keepalives land first.
+                runBlocking { waitUntil(8_000) { keepAliveOks.get() >= 1 } }
+                val oksBeforeGap = keepAliveOks.get()
+
+                // Inject a TRANSIENT gap of ~4s — under the ~6s budget (3x2s).
+                relay.pause()
+                Thread.sleep(4_000)
+                relay.resume()
+
+                // The session must NOT have been declared dead (rode through), and
+                // a keepalive must answer again after recovery.
+                runBlocking { waitUntil(10_000) { keepAliveOks.get() > oksBeforeGap } }
+                assertFalse(
+                    "a transient gap shorter than the keepalive budget must be ridden " +
+                        "through — the peer was NOT declared dead (sends=${keepAliveSends.get()} " +
+                        "oks=${keepAliveOks.get()})",
+                    deadDeclared.get(),
+                )
+                assertTrue(
+                    "the session must still be connected after riding through the gap",
+                    session.isConnected,
+                )
+                assertTrue(
+                    "a keepalive must answer again after the link recovers " +
+                        "(oksBeforeGap=$oksBeforeGap oksNow=${keepAliveOks.get()})",
+                    keepAliveOks.get() > oksBeforeGap,
+                )
+
+                keepAlive.stop()
+            } finally {
+                ioScope.cancel()
+                runCatching { session.close() }
+            }
+        } finally {
+            relay.close()
+        }
+    }
+
+    @Test
+    fun genuinelyDeadPeerIsDetectedWithinTheKeepAliveBudget() {
+        // DEAD-PEER detection (no #822 regression): a HALF-OPEN dead peer — the
+        // link goes permanently silent with NO FIN (the exact #822 silent-Wi-Fi
+        // drop), so `sshj.isConnected` LIES indefinitely and the reader never
+        // sees EOF. The transport keepalive is the SOLE detector here: every ping
+        // misses (no reply), and the loop declares dead within
+        // countMax x interval. (A clean FIN-close is detected faster by the reader
+        // EOF; the keepalive's reason to exist is THIS half-open case.) The budget
+        // is 3 x 2s = 6s; assert detection within a generous ceiling.
+        val relay = PausableTcpRelay(sshHost, sshPort).also { it.start() }
+        try {
+            val session = connectThroughRelay(relay)
+            val ioScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+            val deadDeclaredAtNanos = AtomicLong(0L)
+            try {
+                val keepAlive = TransportKeepAlive(
+                    io = object : TransportKeepAlive.KeepAliveIo {
+                        override fun isAlive(): Boolean = session.isConnected
+                        override fun lastInboundActivityNanos(): Long = Long.MIN_VALUE
+                        override suspend fun sendKeepAlive(): Boolean = session.sendKeepAlive()
+                        override fun onKeepAliveDead(consecutiveMisses: Int) {
+                            deadDeclaredAtNanos.compareAndSet(0L, System.nanoTime())
+                        }
+                    },
+                    intervalMs = 2_000L,
+                    countMax = 3,
+                )
+                keepAlive.start(ioScope)
+
+                // Prove it's healthy first.
+                runBlocking {
+                    assertTrue(
+                        "session healthy before the cut",
+                        waitUntil(8_000) { session.sendKeepAlive() },
+                    )
+                }
+
+                // Permanent HALF-OPEN starve: drop bytes both ways, NO FIN, so
+                // the socket stays "established" and isConnected lies — only the
+                // keepalive can catch it.
+                val cutAtNanos = System.nanoTime()
+                relay.pause()
+
+                // The keepalive loop must declare dead within a generous ceiling
+                // (budget 6s; allow margin for the in-flight reply timeout). The
+                // session is STILL nominally connected (half-open) — isAlive()
+                // stays true — so the loop reaches the dead-peer reaction rather
+                // than ending on a closed transport.
+                runBlocking { waitUntil(40_000) { deadDeclaredAtNanos.get() != 0L } }
+                assertTrue(
+                    "a genuinely dead peer must be detected by the keepalive loop",
+                    deadDeclaredAtNanos.get() != 0L,
+                )
+                val detectMs = TimeUnit.NANOSECONDS.toMillis(deadDeclaredAtNanos.get() - cutAtNanos)
+                assertTrue(
+                    "dead-peer detection ($detectMs ms) must land within a generous " +
+                        "budget ceiling. Each missed tick is interval (2s) + the reply " +
+                        "timeout (5s), so 3 misses ~21s worst case; allow margin.",
+                    detectMs in 0..35_000,
+                )
+
+                keepAlive.stop()
+            } finally {
+                ioScope.cancel()
+                runCatching { session.close() }
+            }
+        } finally {
+            relay.close()
+        }
+    }
+
+    @Test
+    fun keepAliveCadenceDoesNotCorruptTheTransportOver100s() {
+        // The #847 GUARD (acceptance #3): a real session held > 100s with the
+        // transport keepalive cadence ON, under concurrent exec churn + shell
+        // writes + PTY resize (the corruption amplifier) near rekey boundaries.
+        // The keepalive goes through the dispatcher, so it must NOT reintroduce
+        // the `Connection corrupted` desync the un-ownable sshj writer caused.
+        runBlocking {
+            val session = connectDirect()
+            val logMarkStartLen = container!!.logs.length
+            val execCount = AtomicInteger(0)
+            val keepAliveOks = AtomicInteger(0)
+            val ioScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+            try {
+                session.use { s ->
+                    // An aggressive keepalive cadence (interval 1s) MAXIMISES the
+                    // number of keepalive global requests interleaved with the
+                    // exec/resize churn and rekey windows over the hold — the
+                    // worst case for the #847 race, now serialized through the
+                    // dispatcher.
+                    val keepAlive = TransportKeepAlive(
+                        io = object : TransportKeepAlive.KeepAliveIo {
+                            override fun isAlive(): Boolean = s.isConnected
+                            override fun lastInboundActivityNanos(): Long = Long.MIN_VALUE
+                            override suspend fun sendKeepAlive(): Boolean {
+                                val ok = s.sendKeepAlive()
+                                if (ok) keepAliveOks.incrementAndGet()
+                                return ok
+                            }
+                            override fun onKeepAliveDead(consecutiveMisses: Int) { /* no-op for the soak */ }
+                        },
+                        intervalMs = 1_000L,
+                        countMax = 3,
+                    )
+                    keepAlive.start(ioScope)
+
+                    s.startShell().use { shell ->
+                        val holdMs = 105_000L
+                        val deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(holdMs)
+
+                        val shellWriter = ioScope.launch {
+                            while (isActive && System.nanoTime() < deadline) {
+                                runCatching {
+                                    shell.stdin.write("echo tick\n".toByteArray(Charsets.UTF_8))
+                                    shell.stdin.flush()
+                                }
+                                delay(250)
+                            }
+                        }
+                        val shellReader = ioScope.launch {
+                            val buf = ByteArray(4096)
+                            while (isActive && System.nanoTime() < deadline) {
+                                if (shell.stdout.available() > 0) {
+                                    if (shell.stdout.read(buf) < 0) break
+                                } else {
+                                    delay(50)
+                                }
+                            }
+                        }
+                        val execChurn = (0 until 4).map {
+                            ioScope.async {
+                                while (isActive && System.nanoTime() < deadline) {
+                                    runCatching {
+                                        s.exec("true")
+                                        execCount.incrementAndGet()
+                                    }
+                                    delay(20)
+                                }
+                            }
+                        }
+                        val resizer = ioScope.launch {
+                            var cols = 80
+                            while (isActive && System.nanoTime() < deadline) {
+                                runCatching { shell.resizePty(cols, 24) }
+                                cols = if (cols == 80) 120 else 80
+                                delay(2_000)
+                            }
+                        }
+
+                        while (System.nanoTime() < deadline) {
+                            assertTrue(
+                                "session must stay connected across the >100s keepalive hold (#945/#847)",
+                                s.isConnected,
+                            )
+                            delay(2_000)
+                        }
+                        shellWriter.cancel()
+                        shellReader.cancel()
+                        execChurn.forEach { it.cancel() }
+                        resizer.cancel()
+                    }
+
+                    assertEquals(
+                        "a final exec must round-trip after the >100s keepalive hold",
+                        0,
+                        s.exec("true").exitCode,
+                    )
+                    assertTrue(
+                        "the keepalive must have answered repeatedly during the hold " +
+                            "(it was actually running): oks=${keepAliveOks.get()}",
+                        keepAliveOks.get() >= 10,
+                    )
+                }
+            } finally {
+                ioScope.cancel()
+            }
+
+            // Authoritative server-side assertion: no corruption signature in the
+            // sshd log produced during the hold.
+            val newLogs = container!!.logs.substring(
+                minOf(logMarkStartLen, container!!.logs.length),
+            )
+            for (signature in CORRUPTION_SIGNATURES) {
+                assertFalse(
+                    "sshd log must NOT contain `$signature` after a >100s keepalive-cadence " +
+                        "hold (#945: the dispatcher-serialized keepalive must NOT reintroduce the " +
+                        "#847 corruption); execs=${execCount.get()} keepalive_oks=${keepAliveOks.get()}; " +
+                        "offending sshd log:\n$newLogs",
+                    newLogs.contains(signature, ignoreCase = true),
+                )
+            }
+        }
+    }
+
+    private suspend fun waitUntil(timeoutMs: Long, predicate: suspend () -> Boolean): Boolean {
+        val deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMs)
+        while (System.nanoTime() < deadline) {
+            if (runCatching { predicate() }.getOrDefault(false)) return true
+            delay(100)
+        }
+        return runCatching { predicate() }.getOrDefault(false)
+    }
+}
+
+/**
+ * A minimal in-JVM TCP relay (issue #945 test seam): forwards a local port to
+ * [targetHost]:[targetPort] and lets the test inject a REAL link fault on the
+ * REAL encrypted SSH transport without pulling in a Toxiproxy container.
+ *
+ *  - [pause]: stop forwarding bytes in BOTH directions (a half-open starve —
+ *    the sockets stay established, no FIN) — the transient-gap case.
+ *  - [resume]: forward bytes again.
+ *  - [cut]: close all live tunnels and refuse new accepts (a hard dead peer) —
+ *    the genuinely-dead-peer case.
+ */
+private class PausableTcpRelay(
+    private val targetHost: String,
+    private val targetPort: Int,
+) : AutoCloseable {
+    private val serverSocket = ServerSocket().apply {
+        reuseAddress = true
+        bind(InetSocketAddress("127.0.0.1", 0))
+    }
+    val localPort: Int get() = serverSocket.localPort
+
+    private val paused = AtomicBoolean(false)
+    private val cut = AtomicBoolean(false)
+    private val closed = AtomicBoolean(false)
+    private val tunnels = java.util.concurrent.ConcurrentHashMap.newKeySet<Socket>()
+    private var acceptThread: Thread? = null
+
+    fun start() {
+        acceptThread = thread(name = "ps945-relay-accept", isDaemon = true) {
+            while (!closed.get()) {
+                val client = try {
+                    serverSocket.accept()
+                } catch (t: Throwable) {
+                    if (closed.get()) break else continue
+                }
+                if (cut.get()) {
+                    runCatching { client.close() }
+                    continue
+                }
+                handleTunnel(client)
+            }
+        }
+    }
+
+    private fun handleTunnel(client: Socket) {
+        thread(name = "ps945-relay-tunnel", isDaemon = true) {
+            val upstream = try {
+                Socket(targetHost, targetPort)
+            } catch (t: Throwable) {
+                runCatching { client.close() }
+                return@thread
+            }
+            tunnels.add(client)
+            tunnels.add(upstream)
+            val a = pump(client, upstream)
+            val b = pump(upstream, client)
+            runCatching { a.join() }
+            runCatching { b.join() }
+            tunnels.remove(client)
+            tunnels.remove(upstream)
+            runCatching { client.close() }
+            runCatching { upstream.close() }
+        }
+    }
+
+    private fun pump(from: Socket, to: Socket): Thread =
+        thread(isDaemon = true) {
+            val buf = ByteArray(16 * 1024)
+            try {
+                val input = from.getInputStream()
+                val output = to.getOutputStream()
+                while (!closed.get() && !cut.get()) {
+                    // While paused, hold the bytes (do NOT read) — a half-open
+                    // starve: the socket stays established, the peer just goes
+                    // quiet, exactly the flaky-Wi-Fi gap.
+                    if (paused.get()) {
+                        Thread.sleep(50)
+                        continue
+                    }
+                    if (input.available() <= 0) {
+                        // Avoid a busy spin while still being responsive to a
+                        // pause/cut transition; a short blocking read with a
+                        // timeout keeps latency low without burning CPU.
+                        from.soTimeout = 100
+                        val n = try {
+                            input.read(buf)
+                        } catch (e: java.net.SocketTimeoutException) {
+                            continue
+                        }
+                        if (n < 0) break
+                        output.write(buf, 0, n)
+                        output.flush()
+                    } else {
+                        val n = input.read(buf)
+                        if (n < 0) break
+                        output.write(buf, 0, n)
+                        output.flush()
+                    }
+                }
+            } catch (t: Throwable) {
+                // tunnel broken — let the join() finish and clean up.
+            }
+        }
+
+    fun pause() { paused.set(true) }
+    fun resume() { paused.set(false) }
+
+    fun cut() {
+        cut.set(true)
+        tunnels.forEach { runCatching { it.close() } }
+        tunnels.clear()
+    }
+
+    override fun close() {
+        closed.set(true)
+        cut.set(true)
+        tunnels.forEach { runCatching { it.close() } }
+        tunnels.clear()
+        runCatching { serverSocket.close() }
+        runCatching { acceptThread?.join(1_000) }
+    }
+}

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshSession.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshSession.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.currentCoroutineContext
@@ -38,6 +39,12 @@ import java.util.logging.Logger
  */
 internal class RealSshSession(
     private val client: SSHClient,
+    /**
+     * Wall-clock ceiling for the Phase-2 exec read (#935 S4-2). Defaults to the
+     * production [EXEC_READ_TIMEOUT_MS]; tests inject a short value so the
+     * wedged-read bound can be exercised without a real 30s wait.
+     */
+    private val execReadTimeoutMs: Long = EXEC_READ_TIMEOUT_MS,
 ) : SshSession {
 
     /**
@@ -107,22 +114,85 @@ internal class RealSshSession(
             }
             // Phase 2 — read stdout/stderr to EOF OUTSIDE the dispatcher so a
             // slow command never wedges the `-CC` write or other execs.
-            withContext(Dispatchers.IO) {
-                val stdout = liveCommand.inputStream.readBytes().toString(Charsets.UTF_8)
-                val stderr = liveCommand.errorStream.readBytes().toString(Charsets.UTF_8)
-                liveCommand.join()
-                // sshj returns null exitStatus when the server didn't send one
-                // (e.g. signal-killed). Map to -1 so the caller can still tell
-                // it wasn't a clean 0.
-                val exitCode = liveCommand.exitStatus ?: -1
-                ExecResult(stdout = stdout, stderr = stderr, exitCode = exitCode)
+            //
+            // #935 S4-2: the blocking `readBytes()`/`join()` were UNBOUNDED — on
+            // a half-open / wedged transport (no FIN/RST) the JDK read parks
+            // forever, hanging the calling coroutine (and any caller that didn't
+            // wrap us in its own timeout — six gateways did not).
+            //
+            // The bound is a REAL wall-clock watchdog ([WallClockCeiling]), NOT a
+            // coroutine `withTimeout`/`withTimeoutOrNull` (issue #940 / the #937
+            // regression). `withTimeout` reads the delay source from the CALLER's
+            // coroutine context — under `runTest`'s virtual, auto-advancing clock
+            // (every `:shared:core-ssh:integrationTest`) the ceiling fires
+            // INSTANTLY in virtual time and interrupts a HEALTHY live sshj read,
+            // aborting it as `InterruptedException` (the 13/21 integration-suite
+            // break). The wall-clock watchdog interrupts the worker thread only
+            // after [execReadTimeoutMs] of REAL elapsed time, identically in
+            // production and under any test scheduler, so a healthy read is never
+            // cut short while a genuinely-wedged read is still reclaimed. The body
+            // runs inside `runInterruptible(Dispatchers.IO)` so the watchdog's
+            // `Thread.interrupt()` actually unparks the blocking JDK read.
+            //
+            // On a real timeout the watchdog interrupt makes the read throw; that
+            // is mapped to a clear, RETRYABLE [SshExecTimeoutException], and we
+            // then CLOSE the session (lease pool self-heals — a now-disconnected
+            // session is discarded + re-dialed on next acquire). This is the SAME
+            // close-on-timeout intent the three bespoke gateway wraps
+            // (`FolderListGateway.execBounded`, `TreeRemoteSource`,
+            // `AgentKindRemoteSource`) implement per-caller — pulled down to the
+            // `exec` boundary so EVERY caller inherits it (D22 hard-cut), now with
+            // the wall-clock mechanism #940 established for the dispatcher.
+            try {
+                runInterruptible(Dispatchers.IO) {
+                    WallClockCeiling.runUnderWallClockCeiling(
+                        timeoutMs = execReadTimeoutMs,
+                        onTimeout = { cause -> SshExecTimeoutException(command, execReadTimeoutMs, cause) },
+                    ) {
+                        val stdout = liveCommand.inputStream.readBytes().toString(Charsets.UTF_8)
+                        val stderr = liveCommand.errorStream.readBytes().toString(Charsets.UTF_8)
+                        liveCommand.join()
+                        // sshj returns null exitStatus when the server didn't send
+                        // one (e.g. signal-killed). Map to -1 so the caller can
+                        // still tell it wasn't a clean 0.
+                        val exitCode = liveCommand.exitStatus ?: -1
+                        ExecResult(stdout = stdout, stderr = stderr, exitCode = exitCode)
+                    }
+                }
+            } catch (timeout: SshExecTimeoutException) {
+                EXEC_LOGGER.warning(
+                    "exec read wedged >${execReadTimeoutMs}ms (real wall-clock); closing wedged " +
+                        "session + surfacing retryable SshExecTimeoutException. cmd=${command.takeLast(48)}",
+                )
+                // CLOSE the session to tear down the transport so the lease pool
+                // discards the corpse (the watchdog already interrupted+unparked
+                // the read; this also frees the channel deterministically).
+                // NonCancellable so a cancelled/timed-out coroutine still closes.
+                withContext(NonCancellable) {
+                    runCatching { close() }
+                }
+                throw timeout
             }
         } finally {
             cancelHandle?.dispose()
             // Phase 3 — close the channel, serialised through the dispatcher
             // (channel close writes SSH_MSG_CHANNEL_CLOSE on the transport).
-            runCatching { dispatcher.run { runCatching { cmdRef.get()?.close() } } }
-            runCatching { dispatcher.run { runCatching { sessionChannelRef.get()?.close() } } }
+            //
+            // Run under `NonCancellable`: when the caller cancels the exec (or
+            // our own read-timeout bound unwinds), the coroutine is in the
+            // cancelled state, so a plain `dispatcher.run` here would hit
+            // `mutex.withLock`/`withContext` (cancellation points) and throw
+            // `CancellationException` BEFORE running the close block — leaving the
+            // channel teardown to race the async `scope.launch` cancel handler.
+            // Wrapping in `NonCancellable` makes the channel close run
+            // deterministically inside `exec` before it returns/throws, so the
+            // SSH_MSG_CHANNEL_CLOSE is flushed and no orphaned channel leaks (the
+            // `scope.launch` handler stays as belt-and-braces for the
+            // can't-suspend-at-all path).
+            withContext(NonCancellable) {
+                runCatching { dispatcher.run { runCatching { cmdRef.get()?.close() } } }
+                runCatching { dispatcher.run { runCatching { sessionChannelRef.get()?.close() } } }
+            }
         }
     }
 
@@ -1106,6 +1176,28 @@ internal const val INTERACTIVE_PTY_INITIAL_ROWS: Int = 24
  * Android-only dependency from this shared module.
  */
 internal const val CLOSE_LOG_TAG: String = "issue239-close-teardown"
+
+/**
+ * Wall-clock ceiling for the Phase-2 stdout/stderr read (`readBytes()` +
+ * `join()`) of a single [RealSshSession.exec] (#935 S4-2). A half-open / wedged
+ * transport leaves the blocking JDK read parked forever; this is the boundary
+ * bound that turns "the action silently never returns" into a fast, clear,
+ * RETRYABLE [SshExecTimeoutException]. On expiry the session is closed so the
+ * lease pool discards the corpse and re-dials on the next acquire.
+ *
+ * 30s is generous relative to a normal control exec (tens of ms — env edit,
+ * profile list, start-dir autocomplete, manual-kind write, watched-folder
+ * discovery, the file-viewer `mkdir`/`pwd`/`cat`) yet bounds an indefinite
+ * hang. It sits ABOVE the three bespoke per-caller wraps
+ * ([com.pocketshell.app.projects.SshFolderListGateway]'s `EXEC_READ_TIMEOUT_MS`
+ * = 3.5s, `TreeRemoteSource`, `AgentKindRemoteSource`) so those tighter,
+ * latency-sensitive enumeration bounds still fire FIRST on their hot paths and
+ * this boundary bound is the safety net for every other caller that has no wrap
+ * of its own.
+ */
+internal const val EXEC_READ_TIMEOUT_MS: Long = 30_000L
+
+private val EXEC_LOGGER: Logger = Logger.getLogger(RealSshSession::class.java.name + ".exec")
 
 /**
  * Wall-clock ceiling for the blocking byte-copy + `join()` of a single

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshSession.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshSession.kt
@@ -72,8 +72,117 @@ internal class RealSshSession(
      */
     private val dispatcher = TransportDispatcher()
 
+    /**
+     * Monotonic ([System.nanoTime]) timestamp of the most recent inbound
+     * transport activity — bumped on every successful keepalive reply (issue
+     * #945). The keepalive loop reads this to SKIP a ping when the link answered
+     * within the last interval (OpenSSH reset-on-server-traffic semantics), so a
+     * busy link is self-evidently alive and we never ping a channel that just
+     * round-tripped.
+     */
+    @Volatile
+    private var lastInboundActivityNanos: Long = System.nanoTime()
+
+    /**
+     * Issue #945 — the always-on, dispatcher-serialized SSH transport keepalive
+     * (the real "stays up like Terminus" fix). It is the SAFE successor to sshj's
+     * removed `KeepAliveRunner` background writer (#847): every keepalive packet
+     * is sent through [dispatcher] (`dispatcher.run`), so it is FIFO-serialized
+     * against every channel open / `-CC` write / exec and can never race a
+     * KEX/rekey boundary the way the un-ownable background thread did. On
+     * [TransportKeepAlive.DEFAULT_COUNT_MAX] consecutive misses it closes the dead
+     * transport so the existing reader-EOF / reconnect machinery surfaces the
+     * drop and recovers (the SAME single recovery entrypoint the app-level
+     * `LivenessProbe` uses — never a second reconnect writer).
+     */
+    private val keepAlive = TransportKeepAlive(
+        io = object : TransportKeepAlive.KeepAliveIo {
+            override fun isAlive(): Boolean = isConnected
+            override fun lastInboundActivityNanos(): Long = lastInboundActivityNanos
+            override suspend fun sendKeepAlive(): Boolean = this@RealSshSession.sendKeepAlive()
+            override fun onKeepAliveDead(consecutiveMisses: Int) {
+                KEEPALIVE_LOGGER.log(
+                    Level.INFO,
+                    "[$KEEPALIVE_LOG_TAG] transport keepalive declared the peer dead after " +
+                        "$consecutiveMisses consecutive misses; closing the dead transport so the " +
+                        "reconnect machinery recovers",
+                )
+                // Close the dead transport on the session scope. This drives the
+                // reader to EOF, which the tmux/reconnect layer already handles as
+                // a recoverable drop through its single reconnect entrypoint — no
+                // second reconnect writer (D28).
+                scope.launch { runCatching { close() } }
+            }
+        },
+        log = { msg -> KEEPALIVE_LOGGER.log(Level.FINE, "[$KEEPALIVE_LOG_TAG] $msg") },
+    )
+
+    init {
+        // Start the always-on transport keepalive immediately. Under D21 the app
+        // backgrounds and tmux holds state remotely, so a backgrounded transport
+        // is intentionally torn down and the keepalive loop ends with it (its IO
+        // `isAlive()` reads the live transport); the loop's value is the
+        // FOREGROUNDED-but-flaky window — congested/bufferbloat/train-Wi-Fi links
+        // and the transition windows — where it absorbs a transient gap the way
+        // Terminus does, without the `-CC` `refresh-client` contention.
+        keepAlive.start(scope)
+    }
+
     override val isConnected: Boolean
         get() = !dispatcher.isClosed && client.isConnected && client.isAuthenticated
+
+    override suspend fun sendKeepAlive(): Boolean {
+        // Route the global request through the single-writer dispatcher so it is
+        // FIFO-serialized against every other transport op (the #847-safe path).
+        //
+        // OpenSSH does NOT implement the `keepalive@openssh.com` request type, so
+        // it answers with `SSH_MSG_REQUEST_FAILURE` — which sshj surfaces as a
+        // thrown `ConnectionException("Global request [...] failed")` rather than
+        // a returned packet (see ConnectionImpl.gotGlobalReqResponse). That
+        // FAILURE reply STILL proves the peer is alive — it is exactly how
+        // OpenSSH's own client treats its `ServerAliveInterval` ping. So BOTH a
+        // returned packet (REQUEST_SUCCESS) AND the "request failed" exception
+        // (REQUEST_FAILURE) count as proof of life; only a timeout (no reply) or a
+        // genuine transport-death error is a miss.
+        return runCatching {
+            dispatcher.run {
+                if (!isConnected) return@run false
+                val promise = client.connection.sendGlobalRequest(
+                    KEEPALIVE_REQUEST_NAME,
+                    /* wantReply = */ true,
+                    EMPTY_PAYLOAD,
+                )
+                val answered = try {
+                    // A returned packet (REQUEST_SUCCESS) is proof of life; a null
+                    // (timeout — no reply at all) is a miss.
+                    promise.tryRetrieve(
+                        KEEPALIVE_REPLY_TIMEOUT_MS,
+                        java.util.concurrent.TimeUnit.MILLISECONDS,
+                    ) != null
+                } catch (ce: CancellationException) {
+                    throw ce
+                } catch (t: Throwable) {
+                    // The reader thread delivered an error to this promise. A
+                    // REQUEST_FAILURE response is delivered as the specific
+                    // "Global request [...] failed" ConnectionException — the
+                    // server DID answer, so the peer is ALIVE. Any OTHER error
+                    // (connection lost, MAC failure, transport torn down) is a
+                    // genuine miss.
+                    isKeepAliveServerAnswered(t)
+                }
+                if (answered) {
+                    lastInboundActivityNanos = System.nanoTime()
+                }
+                answered
+            }
+        }.getOrElse { t ->
+            if (t is CancellationException) throw t
+            // The send itself (write / dispatcher) failed, or a non-promise
+            // exception escaped — but a REQUEST_FAILURE that escaped the inner
+            // catch still proves the peer answered. Otherwise it is a miss.
+            isKeepAliveServerAnswered(t)
+        }
+    }
 
     @OptIn(InternalCoroutinesApi::class)
     override suspend fun exec(command: String): ExecResult {
@@ -837,6 +946,9 @@ internal class RealSshSession(
     }
 
     override fun close() {
+        // Issue #945: stop the transport keepalive before tearing the scope down
+        // so no keepalive op is submitted to a dispatcher that is about to close.
+        keepAlive.stop()
         scope.cancel()
         // Issue #151 + #239: `close()` is idempotent and silent by
         // contract. The v0.2.7 crash report showed the original
@@ -966,6 +1078,35 @@ internal class RealSshSession(
 
     private fun ensureConnected() {
         if (!isConnected) throw SshException("SSH session is not connected")
+    }
+
+    /**
+     * True iff [t] is the sshj-delivered response to our `keepalive@openssh.com`
+     * global request that PROVES the peer answered (issue #945).
+     *
+     * OpenSSH does not implement the request type, so it replies
+     * `SSH_MSG_REQUEST_FAILURE`, which sshj's `ConnectionImpl.gotGlobalReqResponse`
+     * delivers to the promise as `deliverError(ConnectionException("Global request
+     * [...] failed"))`. That exception means the SERVER ANSWERED — proof of life,
+     * exactly as OpenSSH's own `ServerAliveInterval` treats it. We match the
+     * stable sshj message text on the cause chain. A genuine transport death
+     * (connection lost, MAC failure, reader EOF) carries a DIFFERENT message and
+     * is therefore correctly a miss.
+     */
+    private fun isKeepAliveServerAnswered(t: Throwable): Boolean {
+        var cause: Throwable? = t
+        var depth = 0
+        while (cause != null && depth < 8) {
+            val msg = cause.message
+            if (msg != null && msg.contains("Global request", ignoreCase = true) &&
+                msg.contains("failed", ignoreCase = true)
+            ) {
+                return true
+            }
+            cause = cause.cause
+            depth += 1
+        }
+        return false
     }
 }
 
@@ -1215,6 +1356,38 @@ internal const val UPLOAD_TRANSFER_TIMEOUT_MS: Long = 60_000L
 internal const val UPLOAD_CLEANUP_TIMEOUT_MS: Long = 10_000L
 
 private val CLOSE_LOGGER: Logger = Logger.getLogger(RealSshSession::class.java.name + ".close")
+
+/**
+ * The SSH global-request name OpenSSH uses for its `ServerAliveInterval` keepalive
+ * (issue #945). The server replies with `SSH_MSG_REQUEST_FAILURE` because it does
+ * not implement this request type — and that FAILURE reply still proves the peer
+ * is alive, exactly as OpenSSH's own client treats it.
+ */
+internal const val KEEPALIVE_REQUEST_NAME: String = "keepalive@openssh.com"
+
+/**
+ * Per-keepalive reply budget (issue #945). A healthy global-request round-trip is
+ * sub-second even on a congested link; this generous ceiling means a single
+ * momentarily-slow reply is a soft miss the loop absorbs (it takes
+ * [TransportKeepAlive.DEFAULT_COUNT_MAX] consecutive misses to declare dead), not
+ * a false positive. The send itself is also bounded by the dispatcher's per-op
+ * wall-clock ceiling, so a wedged write can never park the keepalive forever.
+ */
+internal const val KEEPALIVE_REPLY_TIMEOUT_MS: Long = 5_000L
+
+/** Empty payload for the [KEEPALIVE_REQUEST_NAME] global request (issue #945). */
+private val EMPTY_PAYLOAD: ByteArray = ByteArray(0)
+
+/**
+ * Logcat-grep tag for the transport keepalive (issue #945) — declaring a dead
+ * peer and the per-tick diagnostics. Routed through `java.util.logging` for the
+ * same reason the other [RealSshSession] tags are: no Android-only dependency
+ * from this shared module.
+ */
+internal const val KEEPALIVE_LOG_TAG: String = "issue945-keepalive"
+
+private val KEEPALIVE_LOGGER: Logger =
+    Logger.getLogger(RealSshSession::class.java.name + ".keepalive")
 
 /**
  * Logcat-grep tag for `RealSshSession.tail()` swallowing a recoverable

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshException.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshException.kt
@@ -42,3 +42,24 @@ public class SshFileTooLargeException(
         "(${if (sizeBytes >= 0) "$sizeBytes bytes" else "size unknown"}, limit $maxBytes bytes)",
     cause,
 )
+
+/**
+ * Thrown by [SshSession.exec] when the command's stdout/stderr read does not
+ * reach EOF within the per-exec wall-clock ceiling (#935 S4-2). A half-open /
+ * wedged transport leaves the blocking `readBytes()` parked forever; this
+ * timeout is the boundary bound that turns "the action silently never returns"
+ * into a fast, clear, RETRYABLE failure. The session is closed on the way out
+ * so the lease pool discards the corpse and re-dials on the next acquire.
+ *
+ * A subclass of [SshException] so existing catch-all `catch (e: SshException)`
+ * sites keep working; lease-exec retry logic catches it specifically to treat a
+ * wedged read as a stale-channel symptom worth healing on a fresh transport.
+ */
+public class SshExecTimeoutException(
+    public val command: String,
+    public val timeoutMs: Long,
+    cause: Throwable? = null,
+) : SshException(
+    "exec read wedged >${timeoutMs}ms (no EOF): ${command.takeLast(64)}",
+    cause,
+)

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshSession.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshSession.kt
@@ -199,6 +199,32 @@ public interface SshSession : AutoCloseable {
     ): RemoteListing =
         throw NotImplementedError("listDirectory is only implemented by RealSshSession")
 
+    /**
+     * Send ONE `keepalive@openssh.com` SSH transport keepalive global request
+     * and await its reply (issue #945 — the Terminus-parity transport keepalive).
+     *
+     * Returns `true` on ANY reply — including the mandatory
+     * `SSH_MSG_REQUEST_FAILURE` an OpenSSH server sends for the (intentionally
+     * unimplemented) `keepalive@openssh.com` request type, which STILL proves the
+     * peer is alive, exactly as OpenSSH's own `ServerAliveInterval` treats it.
+     * Returns `false` on a transport error / timeout / no reply (the peer is
+     * dead or the link is down).
+     *
+     * The production [RealSshSession] routes this through the single-writer
+     * [TransportDispatcher] (`dispatcher.run { ... }`), so the keepalive is just
+     * another FIFO-serialized op — it CANNOT race a KEX/rekey boundary or a
+     * channel open the way sshj's removed background `KeepAliveRunner` did (the
+     * #847 corruption). This is the safe successor to that removed writer.
+     *
+     * Has a default body that throws [NotImplementedError] so the many bespoke
+     * per-test [SshSession] fakes don't all have to override it; only
+     * [RealSshSession] and the keepalive loop drive it.
+     *
+     * This is a blocking call wrapped to play well with coroutines.
+     */
+    public suspend fun sendKeepAlive(): Boolean =
+        throw NotImplementedError("sendKeepAlive is only implemented by RealSshSession")
+
     /** Disconnect and free all resources. Idempotent. */
     override fun close()
 

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/TransportDispatcher.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/TransportDispatcher.kt
@@ -7,9 +7,7 @@ import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import java.util.concurrent.Executors
-import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.ThreadFactory
-import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
 
@@ -74,8 +72,8 @@ import java.util.concurrent.atomic.AtomicLong
  *    surfaces a [TransportClosedException] once teardown has run) WITHOUT
  *    freezing the connection or leaking the thread.
  *
- *    The ceiling is driven by a REAL wall-clock watchdog ([WATCHDOG]), NOT by
- *    coroutine `withTimeout` (issue #940). `withTimeout` reads the delay source
+ *    The ceiling is driven by a REAL wall-clock watchdog ([WallClockCeiling]),
+ *    NOT by coroutine `withTimeout` (issue #940). `withTimeout` reads the delay source
  *    from the CALLER's coroutine context — under `runTest`'s virtual,
  *    auto-advancing test clock that fires the ceiling INSTANTLY in virtual time
  *    while the real sshj op is still legitimately in progress on the executor
@@ -164,49 +162,27 @@ internal class TransportDispatcher(
 
     /**
      * Run [block] on the CURRENT (dispatch) thread under a real wall-clock
-     * ceiling (issue #940). A [WATCHDOG] task is scheduled to interrupt THIS
-     * thread after [perOpTimeoutMs] of real elapsed time; it is cancelled the
-     * instant [block] returns. If the watchdog fired (the op wedged past the
-     * ceiling), the interrupt is converted into a [TransportOpTimeoutException]
-     * and the thread's interrupt status is CLEARED so it can never leak onto the
-     * next op reusing this single dispatch thread (the #937 interrupt-leak
-     * invariant, now driven by the wall clock instead of the caller's coroutine
-     * clock).
+     * ceiling (issue #940). Delegates to the shared
+     * `WallClockCeiling.runUnderWallClockCeiling`, which schedules an interrupt
+     * on THIS thread after [perOpTimeoutMs] of real elapsed time, cancels it the
+     * instant [block] returns, converts a watchdog-fired interrupt into a
+     * [TransportOpTimeoutException] (regardless of which blocking call the
+     * interrupt landed in — sshj wraps it as a `ConnectionException`, a raw JDK
+     * read/write throws `InterruptedException`), and CLEARS the thread's
+     * interrupt status so it can never leak onto the next op reusing this single
+     * dispatch thread (the #937 interrupt-leak invariant, driven by the wall
+     * clock not the caller's coroutine clock).
      *
      * MUST be called from inside [runInterruptible] so the surrounding coroutine
      * machinery does not also try to interrupt the thread; the watchdog is the
      * sole source of interruption here.
      */
-    private fun <T> runUnderWallClockCeiling(block: () -> T): T {
-        val target = Thread.currentThread()
-        val firedByWatchdog = AtomicBoolean(false)
-        val watchdog = WATCHDOG.schedule(
-            {
-                firedByWatchdog.set(true)
-                target.interrupt()
-            },
-            perOpTimeoutMs,
-            TimeUnit.MILLISECONDS,
+    private fun <T> runUnderWallClockCeiling(block: () -> T): T =
+        WallClockCeiling.runUnderWallClockCeiling(
+            timeoutMs = perOpTimeoutMs,
+            onTimeout = { cause -> TransportOpTimeoutException(perOpTimeoutMs, cause) },
+            block = block,
         )
-        try {
-            return block()
-        } catch (t: Throwable) {
-            // If the watchdog interrupted a wedged op, surface the bounded
-            // timeout regardless of which blocking call the interrupt landed in
-            // (sshj wraps an InterruptedException as a ConnectionException, a
-            // raw JDK blocking read/write throws InterruptedException directly).
-            if (firedByWatchdog.get()) {
-                throw TransportOpTimeoutException(perOpTimeoutMs, t)
-            }
-            throw t
-        } finally {
-            watchdog.cancel(false)
-            // Clear any interrupt status the watchdog set so it can never leak
-            // onto the next op reusing this dispatch thread. Safe even when the
-            // watchdog never fired (no-op then).
-            Thread.interrupted()
-        }
-    }
 
     /**
      * Blocking variant of [run] for the non-suspending `AutoCloseable` /
@@ -257,21 +233,6 @@ internal class TransportDispatcher(
     private companion object {
         /** Per-process dispatcher id, for thread-name uniqueness in logs. */
         private val SEQ = AtomicLong(0)
-
-        /**
-         * Shared real wall-clock watchdog (issue #940). A single daemon
-         * scheduler across all dispatchers schedules a per-op interrupt that
-         * fires after [perOpTimeoutMs] of REAL elapsed time — decoupled from the
-         * caller's coroutine delay source so the ceiling behaves identically in
-         * production and under `runTest`'s virtual clock. Each scheduled task is
-         * cancelled the instant its op returns, so a healthy fast op leaves no
-         * pending timer; the scheduler is therefore effectively idle between
-         * wedges. Daemon so it never holds the JVM open.
-         */
-        private val WATCHDOG: ScheduledExecutorService =
-            Executors.newSingleThreadScheduledExecutor { r ->
-                Thread(r, "ps-ssh-dispatch-watchdog").apply { isDaemon = true }
-            }
 
         /**
          * Default per-op ceiling (issue #937 / S4-1). 8s comfortably exceeds

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/TransportKeepAlive.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/TransportKeepAlive.kt
@@ -1,0 +1,240 @@
+package com.pocketshell.core.ssh
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+
+/**
+ * Issue #945 — the SAFE, dispatcher-serialized SSH transport keepalive (the
+ * real "stays up like Terminus" fix).
+ *
+ * ## Why this exists (and why it is NOT sshj's keepalive)
+ *
+ * Terminus / OpenSSH survive a flaky Wi-Fi link because they run an always-on,
+ * transport-level `ServerAliveInterval` ping over the encrypted channel: idle
+ * gaps are absorbed, a real dead peer is detected on a conservative budget, and
+ * — crucially — it is a SINGLE packet writer with no app contention. PocketShell
+ * had NO such signal: #847 removed sshj's `KeepAliveProvider` because that
+ * provider runs an **un-ownable `sshj-KeepAliveRunner` background thread** — a
+ * SECOND writer on the live transport that could write `keepalive@openssh.com`
+ * straight into a KEX/rekey window and desync the encoder sequence counter, so
+ * the server logged `ssh_dispatch_run_fatal: ... Connection corrupted` ~one
+ * keepalive interval after the handshake. The single-transport-writer rule
+ * ([TransportDispatcher]) cannot tolerate an un-ownable background writer.
+ *
+ * The structural cause of #847 is exactly what [TransportDispatcher] eliminates:
+ * every transport-touching op funnels through it and runs strictly one-at-a-time
+ * in submission order, and no op is dispatched once teardown is enqueued. A
+ * keepalive sent THROUGH the dispatcher ([SshSession.sendKeepAlive]) is just
+ * another FIFO-serialized op — it cannot overlap a channel open, cannot
+ * interleave a `-CC` write, cannot race a rekey/`die()`. So we own the keepalive
+ * ourselves, serialized through the dispatcher; we do **NOT** re-enable sshj's
+ * `KeepAliveRunner` (that would reopen #847 — [KeepAliveConfigTest] keeps that
+ * door shut).
+ *
+ * ## Belt-and-suspenders with the #927 LivenessProbe
+ *
+ * This keepalive is the cheap, always-running, uncontended transport signal: it
+ * keeps the encrypted channel warm and detects a transport-dead peer on a
+ * ~90s budget (interval × countMax). The app-level
+ * `com.pocketshell.core.connection.LivenessProbe` stays as the half-open
+ * detector for the specific tmux-control-channel-wedged case the transport
+ * keepalive cannot see. Together they close the Terminus gap; neither alone does.
+ *
+ * ## Determinism (the test seam)
+ *
+ * The loop's cadence is driven entirely by [delay] on the [CoroutineScope]'s
+ * dispatcher, so a `TestScope` virtual clock advances the keepalive window with
+ * zero wall-clock waiting (the same shape as [com.pocketshell.core.connection.LivenessProbe]).
+ * The [intervalMs], [countMax], and the [KeepAliveIo] adapter are all injected so a
+ * connected/Docker proof can shorten the window and flip a synthetic
+ * dead/transient-gap state WITHOUT weakening any assertion or self-skipping.
+ *
+ * No `android.*`, no real IO inside this class: the actual ping + the dead-peer
+ * reaction are the [KeepAliveIo] adapter. This stays a pure, deterministically
+ * testable loop.
+ */
+internal class TransportKeepAlive(
+    private val io: KeepAliveIo,
+    private val intervalMs: Long = DEFAULT_INTERVAL_MS,
+    private val countMax: Int = DEFAULT_COUNT_MAX,
+    private val log: (String) -> Unit = {},
+) {
+    init {
+        require(intervalMs > 0) { "intervalMs must be > 0" }
+        require(countMax >= 1) { "countMax must be >= 1" }
+    }
+
+    /**
+     * The narrow capability the session supplies. None of these performs
+     * connection-lifecycle decisions beyond the final dead-peer reaction — they
+     * only gate, observe inbound activity, send the ping, and react to a
+     * confirmed sustained miss.
+     */
+    interface KeepAliveIo {
+        /**
+         * True iff the transport is alive and the keepalive loop should keep
+         * running. Re-evaluated before every tick so a closed/disconnected
+         * session immediately stops the loop (the loop ends itself, no ping).
+         */
+        fun isAlive(): Boolean
+
+        /**
+         * Nanos (monotonic, [System.nanoTime] domain) of the most recent inbound
+         * transport activity the session has observed — a keepalive reply, an
+         * exec/tail round-trip, any bytes from the server. The loop SKIPS the
+         * explicit ping when this is within [intervalMs] of now, so a busy link
+         * is self-evidently alive and we never ping a channel that just answered
+         * (OpenSSH's reset-on-server-traffic behaviour).
+         */
+        fun lastInboundActivityNanos(): Long
+
+        /**
+         * Send ONE `keepalive@openssh.com` global request through the transport
+         * dispatcher and await the reply. Returns `true` on ANY reply (including
+         * the mandatory `SSH_MSG_REQUEST_FAILURE` for an unknown request type,
+         * which still proves the peer is alive), `false` on a transport
+         * error / timeout / no reply. MUST route through `dispatcher.run` so it
+         * is FIFO-serialized — never a raw background write.
+         */
+        suspend fun sendKeepAlive(): Boolean
+
+        /**
+         * [countMax] consecutive keepalive misses confirmed — the transport is
+         * dead. The production body closes the dead client so the EXISTING
+         * recovery machinery (reader EOF -> the single reconnect entrypoint)
+         * surfaces the indicator and recovers. NEVER a second reconnect writer.
+         */
+        fun onKeepAliveDead(consecutiveMisses: Int)
+    }
+
+    private var job: Job? = null
+    private var consecutiveMisses: Int = 0
+
+    /**
+     * Start the keepalive loop in [scope]. Idempotent: a second [start] while a
+     * loop is active is a no-op. Each tick sleeps [intervalMs], then — only if
+     * [KeepAliveIo.isAlive] and there was no recent inbound activity — sends one
+     * keepalive through the dispatcher, counting consecutive misses; on
+     * [countMax] it fires [KeepAliveIo.onKeepAliveDead] ONCE and stops counting
+     * (the recovery path now owns the transport).
+     */
+    fun start(scope: CoroutineScope) {
+        if (job?.isActive == true) return
+        consecutiveMisses = 0
+        job = scope.launch {
+            while (isActive) {
+                delay(intervalMs)
+                if (!io.isAlive()) {
+                    // Transport gone (closed/disconnected): end the loop. The
+                    // recovery machinery owns it now.
+                    consecutiveMisses = 0
+                    break
+                }
+                // Reset-on-inbound (OpenSSH semantics): a link that produced
+                // server bytes within the last interval is self-evidently alive,
+                // so skip the explicit ping and reset the miss counter. This is
+                // why a heavy `%output` burst is POSITIVE proof of life, not a
+                // missed probe.
+                val sinceActivityNanos = System.nanoTime() - io.lastInboundActivityNanos()
+                if (sinceActivityNanos in 0 until intervalNanos()) {
+                    if (consecutiveMisses != 0) {
+                        log("keepalive: inbound activity, reset after $consecutiveMisses miss(es)")
+                    }
+                    consecutiveMisses = 0
+                    continue
+                }
+                val alive = sendOne()
+                if (alive) {
+                    if (consecutiveMisses != 0) {
+                        log("keepalive: recovered after $consecutiveMisses miss(es)")
+                    }
+                    consecutiveMisses = 0
+                } else {
+                    consecutiveMisses += 1
+                    log("keepalive: miss consecutive=$consecutiveMisses countMax=$countMax")
+                    if (consecutiveMisses >= countMax) {
+                        // Re-check liveness before acting: a teardown could have
+                        // raced in during the send, in which case the existing
+                        // close path already owns recovery and an extra reaction
+                        // would be a spurious teardown.
+                        if (io.isAlive()) {
+                            log("keepalive: DECLARED DEAD consecutive=$consecutiveMisses")
+                            io.onKeepAliveDead(consecutiveMisses)
+                        }
+                        // The recovery path now owns the transport; reset so we do
+                        // not re-fire every interval against the dead/reconnecting
+                        // session.
+                        consecutiveMisses = 0
+                    }
+                }
+            }
+        }
+    }
+
+    /** Stop the keepalive loop. Idempotent. */
+    fun stop() {
+        job?.cancel()
+        job = null
+        consecutiveMisses = 0
+    }
+
+    private fun intervalNanos(): Long = intervalMs * 1_000_000L
+
+    private suspend fun sendOne(): Boolean =
+        try {
+            io.sendKeepAlive()
+        } catch (ce: CancellationException) {
+            throw ce
+        } catch (t: Throwable) {
+            // A keepalive that throws (transport gone, dispatcher closed) is a
+            // miss, not a crash — count it like a no-reply.
+            log("keepalive: send threw ${t.javaClass.simpleName}: ${t.message}")
+            false
+        }
+
+    companion object {
+        /**
+         * ### #945 detection budget — the load-bearing arithmetic
+         *
+         * Each tick is `delay(intervalMs)` then, when idle, ONE keepalive bounded
+         * by the dispatcher's own per-op ceiling (the send returns `false` rather
+         * than hanging). So the WORST-CASE time to declare a genuinely dead
+         * transport is:
+         *
+         *     worstCase ≈ countMax × intervalMs = 3 × 30s = 90s
+         *
+         * 90s matches a conservative OpenSSH/Terminus client
+         * (`ServerAliveInterval 30 ServerAliveCountMax 3`). This is the always-on
+         * transport backstop; the foreground app-level
+         * [com.pocketshell.core.connection.LivenessProbe] (48s budget) detects the
+         * narrower tmux-control-channel-wedged case faster. The two are
+         * complementary (belt-and-suspenders, #927 + #945).
+         *
+         * A transient gap SHORTER than this budget is RIDDEN THROUGH — the miss
+         * counter has not yet reached [countMax] when the link recovers and the
+         * next keepalive (or any inbound byte) resets it — exactly the Terminus
+         * "absorb the blip" behaviour PocketShell lacked.
+         */
+
+        /**
+         * Keepalive interval. 30s matches OpenSSH `ServerAliveInterval 30`: a
+         * single tiny global request per 30s of IDLE link is negligible traffic,
+         * and reset-on-inbound means a busy link sends none at all.
+         */
+        const val DEFAULT_INTERVAL_MS: Long = 30_000L
+
+        /**
+         * Consecutive keepalive misses before the transport is declared dead.
+         * 3 matches OpenSSH `ServerAliveCountMax 3`: up to TWO consecutive missed
+         * pings on a flaky-but-alive link are absorbed (the counter resets the
+         * moment one answers or any inbound byte arrives), so only a sustained
+         * ~90s silence trips a drop. This is the tolerance that lets a transient
+         * Wi-Fi gap ride through where PocketShell used to redial.
+         */
+        const val DEFAULT_COUNT_MAX: Int = 3
+    }
+}

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/WallClockCeiling.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/WallClockCeiling.kt
@@ -1,0 +1,95 @@
+package com.pocketshell.core.ssh
+
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Shared REAL wall-clock watchdog for bounding blocking sshj operations
+ * (issues #937 / #940 / #935 S4).
+ *
+ * ## Why a wall clock and not `withTimeout`
+ *
+ * `kotlinx.coroutines.withTimeout` / `withTimeoutOrNull` read the delay source
+ * from the CALLER's coroutine context. Under `runTest`'s virtual, auto-advancing
+ * test clock that fires the ceiling INSTANTLY in virtual time while the real
+ * sshj op is still legitimately in progress on a worker thread — interrupting
+ * every healthy connect/exec/open/read and aborting it as an
+ * `InterruptedException` / `ConnectionException`. That is exactly the #937/#940
+ * regression (the `13/21` integration-suite signature) and it is the trap #935
+ * S4-2's first attempt fell into.
+ *
+ * [runUnderWallClockCeiling] interrupts the worker thread only after
+ * [timeoutMs] of REAL elapsed time, identically in production and under any test
+ * scheduler — so a healthy op is never aborted while a genuinely-wedged op is
+ * still reclaimed. This is the SAME mechanism [TransportDispatcher] uses for its
+ * per-op ceiling; factored out here so the exec-read bound (which runs OUTSIDE
+ * the dispatcher by design — #935 S4-2) reuses one watchdog instead of a
+ * caller-clock `withTimeout`.
+ */
+internal object WallClockCeiling {
+
+    /**
+     * Shared real wall-clock watchdog. A single daemon scheduler across the
+     * whole module schedules a per-op interrupt that fires after the requested
+     * real elapsed time — decoupled from the caller's coroutine delay source.
+     * Each scheduled task is cancelled the instant its op returns, so a healthy
+     * fast op leaves no pending timer; the scheduler is effectively idle between
+     * wedges. Daemon so it never holds the JVM open.
+     */
+    private val WATCHDOG: ScheduledExecutorService =
+        Executors.newSingleThreadScheduledExecutor { r ->
+            Thread(r, "ps-ssh-wall-clock-ceiling").apply { isDaemon = true }
+        }
+
+    /**
+     * Run [block] on the CURRENT thread under a real wall-clock ceiling. A
+     * watchdog task is scheduled to interrupt THIS thread after [timeoutMs] of
+     * real elapsed time; it is cancelled the instant [block] returns.
+     *
+     * On expiry the thread's interrupt unblocks a parked blocking JDK
+     * `read()`/`write()`/`join()`; [onTimeout] is then invoked to map the
+     * resulting failure into the caller's chosen exception (the interrupt may
+     * surface as `InterruptedException`, `InterruptedIOException`, or an sshj
+     * wrapper). The thread's interrupt status is CLEARED in `finally` so it can
+     * never leak onto a later op reusing the thread.
+     *
+     * MUST be called from inside `runInterruptible` (so the surrounding
+     * coroutine machinery does not also try to interrupt the thread — the
+     * watchdog is the sole source of interruption here), on a thread the caller
+     * owns for the duration of [block].
+     *
+     * @param onTimeout maps the wedged-op failure into the exception to throw;
+     *   receives the underlying cause (the interrupt-derived throwable, if any).
+     */
+    fun <T> runUnderWallClockCeiling(
+        timeoutMs: Long,
+        onTimeout: (cause: Throwable?) -> Throwable,
+        block: () -> T,
+    ): T {
+        val target = Thread.currentThread()
+        val firedByWatchdog = AtomicBoolean(false)
+        val watchdog = WATCHDOG.schedule(
+            {
+                firedByWatchdog.set(true)
+                target.interrupt()
+            },
+            timeoutMs,
+            TimeUnit.MILLISECONDS,
+        )
+        try {
+            return block()
+        } catch (t: Throwable) {
+            if (firedByWatchdog.get()) {
+                throw onTimeout(t)
+            }
+            throw t
+        } finally {
+            watchdog.cancel(false)
+            // Clear any interrupt status the watchdog set so it can never leak
+            // onto the next op reusing this thread. No-op when it never fired.
+            Thread.interrupted()
+        }
+    }
+}

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshSessionExecReadTimeoutTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshSessionExecReadTimeoutTest.kt
@@ -1,0 +1,199 @@
+package com.pocketshell.core.ssh
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import net.schmizz.sshj.SSHClient
+import net.schmizz.sshj.common.LoggerFactory
+import net.schmizz.sshj.common.Message
+import net.schmizz.sshj.common.SSHException
+import net.schmizz.sshj.common.SSHPacket
+import net.schmizz.sshj.connection.channel.Channel
+import net.schmizz.sshj.connection.channel.direct.PTYMode
+import net.schmizz.sshj.connection.channel.direct.Session
+import net.schmizz.sshj.connection.channel.direct.Signal
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.io.OutputStream
+import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.TimeUnit
+
+/**
+ * Reproduce-first regression for #935 S4-2: [RealSshSession.exec]'s Phase-2
+ * stdout/stderr read was UNBOUNDED. A half-open / wedged transport leaves the
+ * blocking JDK `readBytes()` parked forever, hanging the calling coroutine (and
+ * every caller — six gateways — that did not wrap `exec` in its own timeout).
+ *
+ * On BASE (no fix) `exec` against a wedged read NEVER returns, so the
+ * `withTimeout(...)` wrapping the call below trips and the test fails (red). With
+ * the boundary read-timeout bound the exec fast-fails with a clear, retryable
+ * [SshExecTimeoutException] and closes the wedged session so the lease pool
+ * self-heals (green).
+ */
+class RealSshSessionExecReadTimeoutTest {
+
+    @Test
+    fun `wedged exec read fast-fails with SshExecTimeoutException instead of hanging`() =
+        runBlocking {
+            val command = WedgedReadCommand()
+            val sessionChannel = RecordingSessionChannel(command)
+            val client = ConnectedClient(sessionChannel)
+            // Short bound so the test exercises the wedged-read ceiling without a
+            // real 30s wait. On base (no bound) this constructor param doesn't
+            // exist / is ignored and the read hangs forever.
+            val session = RealSshSession(client, execReadTimeoutMs = 300L)
+
+            try {
+                // On BASE (no bound) `exec` never returns and the surrounding
+                // `withTimeout(10s)` trips → test fails (red). With the boundary
+                // read-timeout bound `exec` throws fast (green).
+                val thrown: SshExecTimeoutException = withTimeout(10_000L) {
+                    try {
+                        session.exec("cat /tmp/wedged")
+                        throw AssertionError("exec must not return on a wedged read")
+                    } catch (e: SshExecTimeoutException) {
+                        e
+                    }
+                }
+
+                assertTrue(
+                    "the wedged read must actually have started (not failed on open)",
+                    command.readStarted.isCompleted,
+                )
+                assertTrue(
+                    "timeout exception must carry the wedged command",
+                    thrown.command.contains("cat /tmp/wedged"),
+                )
+
+                // The bound CLOSED the wedged session so the lease pool self-heals:
+                // a disconnected session is discarded + re-dialed on next acquire.
+                assertFalse(
+                    "wedged exec timeout must close the session (lease self-heal)",
+                    session.isConnected,
+                )
+            } finally {
+                session.close()
+            }
+        }
+
+    private class ConnectedClient(
+        private val sessionChannel: Session,
+    ) : SSHClient() {
+        @Volatile
+        var disconnected: Boolean = false
+            private set
+
+        override fun isConnected(): Boolean = !disconnected
+        override fun isAuthenticated(): Boolean = !disconnected
+        override fun startSession(): Session = sessionChannel
+        override fun disconnect() {
+            // No socket is opened by this test client; flip the flag so
+            // `session.isConnected` reports the post-close state.
+            disconnected = true
+        }
+    }
+
+    private class RecordingSessionChannel(
+        private val command: Session.Command,
+    ) : FakeChannel(), Session {
+        override fun exec(command: String): Session.Command = this.command
+        override fun allocateDefaultPTY() = Unit
+        override fun allocatePTY(
+            term: String,
+            cols: Int,
+            rows: Int,
+            width: Int,
+            height: Int,
+            modes: MutableMap<PTYMode, Int>,
+        ) = Unit
+
+        override fun reqX11Forwarding(host: String, proto: String, cookie: Int) = Unit
+        override fun setEnvVar(name: String, value: String) = Unit
+        override fun startShell(): Session.Shell = throw UnsupportedOperationException("not used")
+        override fun startSubsystem(name: String): Session.Subsystem =
+            throw UnsupportedOperationException("not used")
+    }
+
+    private class WedgedReadCommand : FakeChannel(), Session.Command {
+        val readStarted = CompletableDeferred<Unit>()
+        private val stdout = WedgedInputStream(readStarted)
+
+        override fun getInputStream(): InputStream = stdout
+        override fun getErrorStream(): InputStream = ByteArrayInputStream(ByteArray(0))
+        override fun getExitErrorMessage(): String? = null
+        override fun getExitSignal(): Signal? = null
+        override fun getExitStatus(): Int = 0
+        override fun getExitWasCoreDumped(): Boolean = false
+        override fun signal(signal: Signal) = Unit
+
+        override fun close() {
+            super.close()
+            stdout.close()
+        }
+    }
+
+    /**
+     * Models the half-open transport: `read()` parks indefinitely (never reaches
+     * EOF) until the channel is closed by the timeout's session teardown, OR the
+     * thread is interrupted by the `runInterruptible` cancellation the bound
+     * raises. Either way the read unparks only because the BOUND acted — never on
+     * its own.
+     */
+    private class WedgedInputStream(
+        private val readStarted: CompletableDeferred<Unit>,
+    ) : InputStream() {
+        @Volatile
+        private var closed = false
+
+        override fun read(): Int {
+            readStarted.complete(Unit)
+            while (!closed) {
+                // Honour interrupt so the bound's runInterruptible teardown can
+                // unpark this thread (the real JDK socket read throws on
+                // close/interrupt; we emulate that here).
+                if (Thread.interrupted()) throw java.io.InterruptedIOException("wedged read interrupted")
+                Thread.sleep(10L)
+            }
+            return -1
+        }
+
+        override fun close() {
+            closed = true
+        }
+    }
+
+    private abstract class FakeChannel : Channel {
+        @Volatile
+        var closed: Boolean = false
+            private set
+
+        override fun close() {
+            closed = true
+        }
+
+        override fun getAutoExpand(): Boolean = false
+        override fun getID(): Int = 1
+        override fun getInputStream(): InputStream = ByteArrayInputStream(ByteArray(0))
+        override fun getLocalMaxPacketSize(): Int = 32 * 1024
+        override fun getLocalWinSize(): Long = 0L
+        override fun getOutputStream(): OutputStream = ByteArrayOutputStream()
+        override fun getRecipient(): Int = 1
+        override fun getRemoteCharset(): Charset = StandardCharsets.UTF_8
+        override fun getRemoteMaxPacketSize(): Int = 32 * 1024
+        override fun getRemoteWinSize(): Long = 0L
+        override fun getType(): String = "session"
+        override fun isOpen(): Boolean = !closed
+        override fun setAutoExpand(autoExpand: Boolean) = Unit
+        override fun join() = Unit
+        override fun join(timeout: Long, unit: TimeUnit) = Unit
+        override fun isEOF(): Boolean = false
+        override fun getLoggerFactory(): LoggerFactory = LoggerFactory.DEFAULT
+        override fun handle(message: Message, packet: SSHPacket) = Unit
+        override fun notifyError(error: SSHException) = Unit
+    }
+}

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/TransportKeepAliveTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/TransportKeepAliveTest.kt
@@ -1,0 +1,183 @@
+package com.pocketshell.core.ssh
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Deterministic (Docker-free) JVM contract for [TransportKeepAlive] — the
+ * Terminus-parity transport keepalive loop (issue #945).
+ *
+ * These pin the load-bearing behaviour as a pure virtual-clock loop, the same
+ * shape as `LivenessProbeTest`: a transient gap shorter than the budget is
+ * RIDDEN THROUGH (no dead-peer reaction); a sustained dead peer IS declared
+ * within `countMax × interval`; reset-on-inbound suppresses the ping on a busy
+ * link. The connected/real-sshd round-trip + the >100s no-KEX-corruption soak
+ * live in the integration test; these are the always-runnable per-push gate that
+ * keeps the loop's contract from silently regressing.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class TransportKeepAliveTest {
+
+    private class FakeIo(
+        var alive: Boolean = true,
+    ) : TransportKeepAlive.KeepAliveIo {
+        var pingResult: Boolean = true
+        var pingsSent: Int = 0
+        var deadDeclaredWith: Int? = null
+        var lastActivityNanos: Long = Long.MIN_VALUE // "no recent activity"
+
+        override fun isAlive(): Boolean = alive
+        override fun lastInboundActivityNanos(): Long = lastActivityNanos
+        override suspend fun sendKeepAlive(): Boolean {
+            pingsSent += 1
+            return pingResult
+        }
+        override fun onKeepAliveDead(consecutiveMisses: Int) {
+            deadDeclaredWith = consecutiveMisses
+        }
+    }
+
+    @Test
+    fun `transient gap shorter than the budget is ridden through - no dead-peer reaction`() = runTest {
+        // The Terminus behaviour: a brief gap (here TWO consecutive missed pings,
+        // budget is 3) recovers before countMax, so the peer is NEVER declared
+        // dead — exactly where PocketShell used to redial.
+        val io = FakeIo()
+        val keepAlive = TransportKeepAlive(
+            io = io,
+            intervalMs = 1_000L,
+            countMax = 3,
+        )
+        keepAlive.start(this)
+
+        // Two ticks miss (link starved)...
+        io.pingResult = false
+        advanceTimeBy(1_000L); runCurrent() // miss 1
+        advanceTimeBy(1_000L); runCurrent() // miss 2
+        assertEquals("no dead-peer reaction yet (under countMax)", null, io.deadDeclaredWith)
+
+        // ...then the link recovers BEFORE the 3rd consecutive miss.
+        io.pingResult = true
+        advanceTimeBy(1_000L); runCurrent() // recover
+
+        // A long quiet healthy run after recovery: still no dead-peer reaction.
+        repeat(10) { advanceTimeBy(1_000L); runCurrent() }
+        assertEquals(
+            "a transient gap shorter than the keepalive budget must be ridden through " +
+                "(no dead-peer declaration)",
+            null,
+            io.deadDeclaredWith,
+        )
+
+        keepAlive.stop()
+    }
+
+    @Test
+    fun `a genuinely dead peer is declared within countMax consecutive misses`() = runTest {
+        val io = FakeIo()
+        val keepAlive = TransportKeepAlive(
+            io = io,
+            intervalMs = 1_000L,
+            countMax = 3,
+        )
+        keepAlive.start(this)
+
+        io.pingResult = false // dead peer: every ping misses
+        advanceTimeBy(1_000L); runCurrent() // miss 1
+        assertEquals(null, io.deadDeclaredWith)
+        advanceTimeBy(1_000L); runCurrent() // miss 2
+        assertEquals(null, io.deadDeclaredWith)
+        advanceTimeBy(1_000L); runCurrent() // miss 3 -> declare dead
+
+        assertEquals(
+            "a dead peer must be declared at exactly countMax consecutive misses",
+            3,
+            io.deadDeclaredWith,
+        )
+        keepAlive.stop()
+    }
+
+    @Test
+    fun `recent inbound activity skips the ping - a busy link is self-evidently alive`() = runTest {
+        // OpenSSH reset-on-server-traffic: a link that produced bytes within the
+        // last interval is NOT pinged, and a prior miss streak is reset.
+        val io = FakeIo()
+        val keepAlive = TransportKeepAlive(
+            io = io,
+            intervalMs = 1_000L,
+            countMax = 3,
+        )
+        keepAlive.start(this)
+
+        // Mark inbound activity "just now" for every tick: the loop must skip the
+        // ping entirely across a long run, so a busy link sends ZERO keepalives.
+        io.pingResult = false // would miss IF it pinged
+        repeat(10) {
+            io.lastActivityNanos = System.nanoTime()
+            advanceTimeBy(1_000L)
+            runCurrent()
+        }
+        assertEquals("a busy link must never be pinged", 0, io.pingsSent)
+        assertEquals("a busy link must never be declared dead", null, io.deadDeclaredWith)
+        keepAlive.stop()
+    }
+
+    @Test
+    fun `a single miss between successes never declares dead - counter resets`() = runTest {
+        val io = FakeIo()
+        val keepAlive = TransportKeepAlive(io = io, intervalMs = 1_000L, countMax = 3)
+        keepAlive.start(this)
+
+        // miss, success, miss, success, ... never reaches 3 in a row.
+        repeat(20) { i ->
+            io.pingResult = (i % 2 == 1)
+            advanceTimeBy(1_000L)
+            runCurrent()
+        }
+        assertEquals(
+            "an isolated miss between successes must never declare dead (counter resets)",
+            null,
+            io.deadDeclaredWith,
+        )
+        keepAlive.stop()
+    }
+
+    @Test
+    fun `the loop ends when the transport is no longer alive - no ping after`() = runTest {
+        val io = FakeIo(alive = true)
+        val keepAlive = TransportKeepAlive(io = io, intervalMs = 1_000L, countMax = 3)
+        keepAlive.start(this)
+
+        advanceTimeBy(1_000L); runCurrent()
+        val pingsWhileAlive = io.pingsSent
+        assertTrue("should have pinged while alive", pingsWhileAlive >= 1)
+
+        io.alive = false // transport closed
+        repeat(5) { advanceTimeBy(1_000L); runCurrent() }
+        assertEquals(
+            "no keepalive should be sent once the transport is no longer alive",
+            pingsWhileAlive,
+            io.pingsSent,
+        )
+        keepAlive.stop()
+    }
+
+    @Test
+    fun `default budget matches a conservative OpenSSH client - 30s x 3 = 90s`() {
+        // Pin the documented budget so a future retune that brushes the floor is
+        // a visible diff (mirrors LivenessProbeBudgetUnder55sTest's intent).
+        assertEquals(30_000L, TransportKeepAlive.DEFAULT_INTERVAL_MS)
+        assertEquals(3, TransportKeepAlive.DEFAULT_COUNT_MAX)
+        val worstCaseMs = TransportKeepAlive.DEFAULT_INTERVAL_MS * TransportKeepAlive.DEFAULT_COUNT_MAX
+        assertEquals(
+            "worst-case dead-peer detection must be ~90s (Terminus-parity ServerAlive 30x3)",
+            90_000L,
+            worstCaseMs,
+        )
+    }
+}

--- a/shared/core-terminal/src/androidTest/java/com/pocketshell/core/terminal/selection/TerminalOverlayUnboundedMeasureCrashTest.kt
+++ b/shared/core-terminal/src/androidTest/java/com/pocketshell/core/terminal/selection/TerminalOverlayUnboundedMeasureCrashTest.kt
@@ -1,0 +1,167 @@
+package com.pocketshell.core.terminal.selection
+
+import android.os.SystemClock
+import androidx.activity.ComponentActivity
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.unit.Constraints
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.flow.MutableSharedFlow
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * REGRESSION PROOF for the v0.4.17 RELEASE-BLOCKING Compose **measure** crash on
+ * the terminal / session-picker journey (issue #958, CI run 28184338389,
+ * reproduced 4/4 — NOT a flake).
+ *
+ * ## The reported defect
+ *
+ * The `MultiSessionSwitchJourneyE2eTest#backToPicker…` /
+ * `#rapidMultiSessionSwitch…` / `BackThenOpenSecondSessionReusesWarmLease…`
+ * journeys tore down with:
+ *
+ * ```
+ * java.lang.IllegalStateException: Size(1070 x 2147483647) is out of range.
+ *   Each dimension must be between 0 and 16777215.
+ *   at androidx.compose.ui.node.LookaheadCapablePlaceable.layout(…)
+ *   at …selection.SmartSelectionAffordanceOverlayKt
+ *       $AgentPaneAffordanceOverlay$4$1.measure(SmartSelectionAffordanceOverlay.kt:350)
+ *   at …ui.TerminalSurfaceKt$TerminalSurface$9$1.measure(TerminalSurface.kt:688)
+ *   at …pager.PagerMeasureKt.measurePager(…)
+ * ```
+ *
+ * i.e. the draw-only terminal affordance overlays
+ * ([SmartSelectionAffordanceOverlay], [FilePathOverlay],
+ * [AgentPaneAffordanceOverlay], [EngineCommandOverlay]) each laid out at the raw
+ * `constraints.maxHeight.coerceAtLeast(0)` — fine under a normal bounded measure,
+ * but the overlay sits inside the terminal pane, which sits inside the
+ * `TmuxTerminalPager` ([androidx.compose.foundation.pager.Pager]). The pager /
+ * lookahead runs intermittent measure passes with an **unbounded**
+ * (`Constraints.Infinity` = `Int.MAX_VALUE`) maximum height. `coerceAtLeast(0)`
+ * left `Int.MAX_VALUE` intact, so `layout(width, Int.MAX_VALUE)` threw the
+ * out-of-range crash that brought the whole journey down. (The on-call's
+ * banner-correlation was the trigger that produced the unbounded remeasure on
+ * the back-to-picker path, not the crash site — the crash is in the terminal
+ * overlay.)
+ *
+ * ## Why this is the load-bearing assertion (F2 / G6 / G10)
+ *
+ * This composes EACH of the four PRODUCTION overlays (no proxy/stand-in) inside a
+ * [measureUnbounded] harness that hands it EXACTLY the crash constraint —
+ * `Constraints(maxWidth = 1070, maxHeight = Infinity)`. On the unfixed overlay
+ * this throws the exact `Size(1070 x Int.MAX_VALUE)` crash (the test fails / the
+ * activity dies); with the fix every overlay lays out at a FINITE, bounded size.
+ * Class coverage (G2): all four overlays, not only the one in the captured trace.
+ */
+@RunWith(AndroidJUnit4::class)
+class TerminalOverlayUnboundedMeasureCrashTest {
+
+    @get:Rule
+    val compose = createAndroidComposeRule<ComponentActivity>()
+
+    /** The full device width the CI crash reported (`Size(1070 x …)`). */
+    private val widthPx = 1070
+
+    private val renders = MutableSharedFlow<Unit>()
+
+    /**
+     * Measures [content] at a fixed full width (1070px) with an **unbounded**
+     * maximum height — the precise `Constraints(maxWidth = 1070, maxHeight =
+     * Infinity)` the `TmuxTerminalPager`'s lookahead/measure pass hands the
+     * terminal-overlay subtree on-device. Records the measured height of the
+     * overlay so the test can hard-assert it came back FINITE (never the
+     * `Int.MAX_VALUE` that overflowed `layout()` on the unfixed code).
+     */
+    @Composable
+    private fun measureUnbounded(onMeasuredHeight: (Int) -> Unit, content: @Composable () -> Unit) {
+        Layout(content = content) { measurables, _ ->
+            val unbounded = Constraints(
+                minWidth = widthPx,
+                maxWidth = widthPx,
+                minHeight = 0,
+                maxHeight = Constraints.Infinity,
+            )
+            val placeables = measurables.map { it.measure(unbounded) }
+            val height = placeables.maxOfOrNull { it.height } ?: 0
+            onMeasuredHeight(height)
+            layout(widthPx, height.coerceIn(0, 1_000)) {
+                placeables.forEach { it.place(0, 0) }
+            }
+        }
+    }
+
+    private fun assertOverlayMeasuresFinite(name: String, overlay: @Composable () -> Unit) {
+        var measuredHeight = -1
+        compose.setContent {
+            measureUnbounded(onMeasuredHeight = { measuredHeight = it }) {
+                overlay()
+            }
+        }
+        compose.waitForIdle()
+        SystemClock.sleep(100)
+        // The overlay laid out (no `Size(1070 x Int.MAX_VALUE)` crash tore down
+        // the activity) AND it came back at a FINITE height — never the
+        // unbounded `Int.MAX_VALUE` that overflowed `layout()` before the fix.
+        assertTrue(
+            "$name overlay measured height should be set (>=0), was $measuredHeight",
+            measuredHeight in 0..16_777_215,
+        )
+    }
+
+    @Test
+    fun smartSelectionAffordanceOverlay_measuresFiniteUnderUnboundedHeight() {
+        assertOverlayMeasuresFinite("SmartSelectionAffordance") {
+            SmartSelectionAffordanceOverlay(
+                view = null,
+                renderRequests = renders,
+                onMatchesChanged = {},
+                modifier = Modifier,
+            )
+        }
+    }
+
+    @Test
+    fun filePathOverlay_measuresFiniteUnderUnboundedHeight() {
+        assertOverlayMeasuresFinite("FilePath") {
+            FilePathOverlay(
+                view = null,
+                renderRequests = renders,
+                onFilePathsChanged = {},
+                modifier = Modifier,
+            )
+        }
+    }
+
+    @Test
+    fun agentPaneAffordanceOverlay_measuresFiniteUnderUnboundedHeight() {
+        // This is the exact overlay in the captured crash trace
+        // (SmartSelectionAffordanceOverlay.kt:350, AgentPaneAffordanceOverlay$4$1).
+        assertOverlayMeasuresFinite("AgentPaneAffordance") {
+            AgentPaneAffordanceOverlay(
+                view = null,
+                renderRequests = renders,
+                onFilePathsChanged = {},
+                onUrlsChanged = {},
+                modifier = Modifier,
+            )
+        }
+    }
+
+    @Test
+    fun engineCommandOverlay_measuresFiniteUnderUnboundedHeight() {
+        assertOverlayMeasuresFinite("EngineCommand") {
+            EngineCommandOverlay(
+                view = null,
+                renderRequests = renders,
+                knownCommands = setOf("git", "ls"),
+                onEngineCommandsChanged = {},
+                modifier = Modifier,
+            )
+        }
+    }
+}

--- a/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/selection/SmartSelectionAffordanceOverlay.kt
+++ b/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/selection/SmartSelectionAffordanceOverlay.kt
@@ -13,6 +13,9 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.MeasureResult
+import androidx.compose.ui.layout.MeasureScope
+import androidx.compose.ui.unit.Constraints
 import com.termux.view.TerminalView
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -130,12 +133,11 @@ fun SmartSelectionAffordanceOverlay(
             }
         },
     ) { _, constraints ->
-        // Inert sized box matching the available space. drawBehind requires
-        // non-zero bounds to actually paint.
-        layout(
-            constraints.maxWidth.coerceAtLeast(0),
-            constraints.maxHeight.coerceAtLeast(0),
-        ) {}
+        // Inert draw-only box sized to the terminal pane (drawBehind needs
+        // non-zero bounds to paint) — but robust to the pager/lookahead's
+        // intermittent UNBOUNDED-height measure pass (the v0.4.17
+        // `Size(W x Int.MAX_VALUE)` crash). See [layoutOverlayBounded].
+        layoutOverlayBounded(constraints)
     }
 }
 
@@ -200,10 +202,10 @@ public fun FilePathOverlay(
             }
         },
     ) { _, constraints ->
-        layout(
-            constraints.maxWidth.coerceAtLeast(0),
-            constraints.maxHeight.coerceAtLeast(0),
-        ) {}
+        // Issue: a draw-only overlay sized to the pane — but robust to the
+        // pager/lookahead's intermittent UNBOUNDED-height measure pass (the
+        // v0.4.17 `Size(W x Int.MAX_VALUE)` crash). See [layoutOverlayBounded].
+        layoutOverlayBounded(constraints)
     }
 }
 
@@ -347,10 +349,10 @@ public fun AgentPaneAffordanceOverlay(
             }
         },
     ) { _, constraints ->
-        layout(
-            constraints.maxWidth.coerceAtLeast(0),
-            constraints.maxHeight.coerceAtLeast(0),
-        ) {}
+        // Issue: a draw-only overlay sized to the pane — but robust to the
+        // pager/lookahead's intermittent UNBOUNDED-height measure pass (the
+        // v0.4.17 `Size(W x Int.MAX_VALUE)` crash). See [layoutOverlayBounded].
+        layoutOverlayBounded(constraints)
     }
 }
 
@@ -421,11 +423,49 @@ public fun EngineCommandOverlay(
             }
         },
     ) { _, constraints ->
-        layout(
-            constraints.maxWidth.coerceAtLeast(0),
-            constraints.maxHeight.coerceAtLeast(0),
-        ) {}
+        // Issue: a draw-only overlay sized to the pane — but robust to the
+        // pager/lookahead's intermittent UNBOUNDED-height measure pass (the
+        // v0.4.17 `Size(W x Int.MAX_VALUE)` crash). See [layoutOverlayBounded].
+        layoutOverlayBounded(constraints)
     }
+}
+
+/**
+ * Lay out a draw-only terminal affordance overlay at the available size — but
+ * NEVER at an unbounded dimension.
+ *
+ * These overlays ([SmartSelectionAffordanceOverlay], [FilePathOverlay],
+ * [AgentPaneAffordanceOverlay], [EngineCommandOverlay]) are inert `drawBehind`
+ * boxes that just need to fill the terminal pane so their hairlines paint. Each
+ * previously called `layout(maxWidth.coerceAtLeast(0), maxHeight.coerceAtLeast(0))`,
+ * which is fine under a normal bounded measure — but the overlay sits inside the
+ * terminal pane, which is itself inside a [androidx.compose.foundation.pager.Pager]
+ * (`TmuxTerminalPager`). The pager / lookahead runs intermittent measure passes
+ * with an **unbounded** (`Constraints.Infinity`, i.e. `Int.MAX_VALUE`) maximum
+ * dimension. `coerceAtLeast(0)` leaves that `Int.MAX_VALUE` intact, so
+ * `layout(width, Int.MAX_VALUE)` threw
+ * `IllegalStateException: Size(<w> x 2147483647) is out of range. Each dimension
+ * must be between 0 and 16777215.` — the v0.4.17 RELEASE-BLOCKING crash that
+ * tore down the whole terminal/picker journey (issue #958, CI run 28184338389).
+ *
+ * When a dimension is unbounded there is no real space to fill, so we fall back
+ * to the constraint's minimum (0 for a fully-loose overlay measure). A draw-only
+ * overlay contributing a 0 dimension on a transient unbounded pass is correct —
+ * it has nothing to paint there — and on the real bounded pass it still fills the
+ * pane exactly as before.
+ */
+private fun MeasureScope.layoutOverlayBounded(constraints: Constraints): MeasureResult {
+    val width = if (constraints.hasBoundedWidth) {
+        constraints.maxWidth
+    } else {
+        constraints.minWidth
+    }.coerceAtLeast(0)
+    val height = if (constraints.hasBoundedHeight) {
+        constraints.maxHeight
+    } else {
+        constraints.minHeight
+    }.coerceAtLeast(0)
+    return layout(width, height) {}
 }
 
 internal data class SmartSelectionAffordanceSegment(

--- a/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurfaceState.kt
+++ b/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurfaceState.kt
@@ -531,6 +531,34 @@ class TerminalSurfaceState(
     }
 
     /**
+     * Issue #941 (black-screen residual B1) — true when the visible screen is FULLY
+     * blank ([visibleScreenIsBlank]) OR partially blank ([visibleScreenIsPartiallyBlank]):
+     * the union "the active pane looks lost (black, or one-live-line-rest-black)".
+     *
+     * The maintainer's "I sent a message and everything became black" symptom is a
+     * PARTIAL black — a `%output` overpaint (or a plain session switch reveal) wiped the
+     * static viewport and left one live line. The reattach/manual-Redraw heals already
+     * branch on `blank || partialBlank` inline (see
+     * [com.pocketshell.app.tmux.TmuxSessionViewModel.reseedActivePaneForReattach] and
+     * `maybeHealActivePaneOnNoOpResize`), but the SWITCH-reveal gate and the connected
+     * blank watchdog used pure `visibleScreenIsBlank()` — so a partial-black pane reached
+     * via a switch or a send-overpaint reads "not blank", passes the gate, and is never
+     * reseeded. This combined oracle is the single "needs heal" predicate those gates now
+     * share, so the partial-black case is healed on EVERY reveal/watchdog path, not only
+     * on reattach.
+     *
+     * Inherits [visibleScreenIsPartiallyBlank]'s best-effort-heuristic caveat: a lone
+     * fresh-prompt line is indistinguishable from a lone timer line, so this can be true
+     * for a legitimately-mostly-empty pane. That is acceptable because the heal it gates
+     * is a `capture-pane` full-viewport restore — re-seeding a real prompt re-paints the
+     * SAME authoritative content (idempotent, no visible change), and the callers guard
+     * against reseed-thrash by only healing once per reveal / per send-quiescence, not on
+     * a tight loop.
+     */
+    fun visibleScreenIsBlankOrPartiallyBlank(): Boolean =
+        visibleScreenIsBlank() || visibleScreenIsPartiallyBlank()
+
+    /**
      * Pull the current visible-transcript text from the attached session and
      * run the matcher across it. Returns an empty list when no session is
      * attached or the session has no emulator yet (the View has not yet laid

--- a/shared/core-terminal/src/test/java/com/pocketshell/core/terminal/ui/TerminalSurfaceStatePartialBlankTest.kt
+++ b/shared/core-terminal/src/test/java/com/pocketshell/core/terminal/ui/TerminalSurfaceStatePartialBlankTest.kt
@@ -115,4 +115,62 @@ class TerminalSurfaceStatePartialBlankTest {
             state.visibleScreenIsPartiallyBlank(),
         )
     }
+
+    // ----------------------------------------------------------------- Issue #941
+    // The combined oracle [visibleScreenIsBlankOrPartiallyBlank] is the single
+    // "needs heal" predicate the switch-reveal gate, the connected blank watchdog,
+    // and the send-overpaint heal now share, so a PARTIAL-black pane (the "sent a
+    // message -> black" symptom) is healed on every reveal/watchdog path, not only
+    // on reattach. These pin its union semantics.
+
+    @Test
+    fun blankOrPartiallyBlankIsTrueForAFullyBlankPane() = withAttachedSurface { state ->
+        state.appendRemoteOutput("[2J[H".toByteArray(Charsets.US_ASCII))
+        shadowOf(Looper.getMainLooper()).idle()
+        assertTrue(
+            "precondition: a clear-only frame is fully blank",
+            state.visibleScreenIsBlank(),
+        )
+        assertTrue(
+            "the combined oracle must be true for a fully-blank pane",
+            state.visibleScreenIsBlankOrPartiallyBlank(),
+        )
+    }
+
+    @Test
+    fun blankOrPartiallyBlankIsTrueForAPartialBlackPane() = withAttachedSurface { state ->
+        // The #941 symptom: a send/switch overpaint wiped the static viewport and
+        // left ONE live line. Fully-blank is false (the line is present), but the
+        // combined oracle must catch it so the heal fires.
+        state.appendRemoteOutput("[2J[HISSUE941-OVERPAINT 7\r\n".toByteArray(Charsets.US_ASCII))
+        shadowOf(Looper.getMainLooper()).idle()
+        assertFalse(
+            "precondition: a partial-black pane is NOT fully blank",
+            state.visibleScreenIsBlank(),
+        )
+        assertTrue(
+            "precondition: a partial-black pane IS partially blank",
+            state.visibleScreenIsPartiallyBlank(),
+        )
+        assertTrue(
+            "the combined oracle must be true for a partial-black pane (the heal " +
+                "gates the switch-reveal / watchdog / send-overpaint paths read on it)",
+            state.visibleScreenIsBlankOrPartiallyBlank(),
+        )
+    }
+
+    @Test
+    fun blankOrPartiallyBlankIsFalseForANormallyPaintedPane() = withAttachedSurface { state ->
+        val frame = buildString {
+            append("[2J[H")
+            repeat(20) { append("line $it has real content here\r\n") }
+        }
+        state.appendRemoteOutput(frame.toByteArray(Charsets.US_ASCII))
+        shadowOf(Looper.getMainLooper()).idle()
+        assertFalse(
+            "the combined oracle must be FALSE for a normally-painted pane so the " +
+                "heal correctly no-ops (no reseed-thrash on a healthy pane)",
+            state.visibleScreenIsBlankOrPartiallyBlank(),
+        )
+    }
 }

--- a/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenders.kt
+++ b/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenders.kt
@@ -3769,6 +3769,7 @@ class DesignRenders {
     }
 
     /**
+<<<<<<< ours
      * Issue #859 Slice B: the typed-card session feed sheet — a heterogeneous
      * card list rendered through the renderer registry (checklist + the new
      * `note` type + a graceful "unsupported card" fallback for an unknown type).
@@ -3849,12 +3850,110 @@ class DesignRenders {
                         text = "Unsupported card (approval) — update the app to view it.",
                         color = PocketShellColors.TextSecondary,
                         style = PocketShellType.bodyDense,
+=======
+     * Issue #947: the host-pocketshell-version-mismatch banner with the one-tap
+     * **Update** button next to **Dismiss**, plus its running-spinner and
+     * failure states. The production composable
+     * (`app/.../projects/FolderListScreen.kt#CliVersionMismatchBanner`) is
+     * app-private, so this render faithfully re-creates the same layout with the
+     * same ui-kit primitives (Update = Primary, Dismiss = Text, the running
+     * spinner, the red failure line) — the fast first visual check that the
+     * Update button fits the banner cleanly. The emulator screenshot of the real
+     * FolderList banner is the acceptance.
+     */
+    @Test
+    fun cliVersionMismatchBannerUpdateButton() = render("cli-version-mismatch-update-button") {
+        val message = "This host's pocketshell is 0.4.14; the app expects 0.4.16. " +
+            "Update it on the host:\nuv tool install --upgrade " +
+            "--exclude-newer-package pocketshell=2099-12-31 pocketshell\n" +
+            "(or: pipx upgrade pocketshell / pip install -U pocketshell)"
+        SectionHeader(label = "DEFAULT — Update + Dismiss")
+        CliVersionBannerRender(message = message, state = BannerRenderState.Idle)
+        SectionHeader(label = "RUNNING — host upgrade in flight")
+        CliVersionBannerRender(message = message, state = BannerRenderState.Running)
+        SectionHeader(label = "FAILURE — error shown, Retry + Dismiss")
+        CliVersionBannerRender(
+            message = message,
+            state = BannerRenderState.Failure(
+                "Update failed (exit 1):\nerror: network unreachable",
+            ),
+        )
+    }
+
+    private sealed interface BannerRenderState {
+        data object Idle : BannerRenderState
+        data object Running : BannerRenderState
+        data class Failure(val message: String) : BannerRenderState
+    }
+
+    @Composable
+    private fun CliVersionBannerRender(message: String, state: BannerRenderState) {
+        val color = PocketShellColors.Accent
+        val running = state is BannerRenderState.Running
+        val failure = state as? BannerRenderState.Failure
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 12.dp)
+                .background(PocketShellColors.Surface, PocketShellShapes.medium)
+                .background(color.copy(alpha = 0.12f), PocketShellShapes.medium)
+                .border(1.dp, color.copy(alpha = 0.4f), PocketShellShapes.medium)
+                .padding(horizontal = 14.dp, vertical = 10.dp),
+        ) {
+            Text(
+                text = message,
+                color = PocketShellColors.Text,
+                style = PocketShellType.bodyDense,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            failure?.let { fail ->
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = fail.message,
+                    color = PocketShellColors.Red,
+                    style = PocketShellType.bodyDense,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+            Spacer(modifier = Modifier.height(6.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.End,
+            ) {
+                if (running) {
+                    androidx.compose.material3.CircularProgressIndicator(
+                        color = color,
+                        strokeWidth = 2.dp,
+                        modifier = Modifier.size(18.dp),
+                    )
+                    Spacer(modifier = Modifier.width(10.dp))
+                    Text(
+                        text = "Updating…",
+                        color = PocketShellColors.TextSecondary,
+                        style = PocketShellType.bodyDense,
+                    )
+                } else {
+                    PocketShellButton(
+                        text = if (failure != null) "Retry" else "Update",
+                        onClick = {},
+                        variant = ButtonVariant.Primary,
+                        compact = true,
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    PocketShellButton(
+                        text = "Dismiss",
+                        onClick = {},
+                        variant = ButtonVariant.Text,
+                        compact = true,
+>>>>>>> theirs
                     )
                 }
             }
         }
     }
 
+<<<<<<< ours
     @Composable
     private fun sessionCardCheckRow(text: String, checked: Boolean) {
         Row(
@@ -3872,6 +3971,8 @@ class DesignRenders {
         }
     }
 
+=======
+>>>>>>> theirs
     private fun render(name: String, content: @Composable () -> Unit) {
         captureRoboImage("build/renders/$name.png") {
             PocketShellTheme {

--- a/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenders.kt
+++ b/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenders.kt
@@ -3768,6 +3768,110 @@ class DesignRenders {
         }
     }
 
+    /**
+     * Issue #859 Slice B: the typed-card session feed sheet — a heterogeneous
+     * card list rendered through the renderer registry (checklist + the new
+     * `note` type + a graceful "unsupported card" fallback for an unknown type).
+     *
+     * NOTE: the production composables live app-side
+     * (`app/.../cards/SessionCardRenderers.kt` + `SessionChecklistUi.kt`), which
+     * the ui-kit render harness cannot see (no app→ui-kit reverse dependency).
+     * This case faithfully reproduces those rows with ui-kit primitives as the
+     * fast first DESIGN check; the REAL composables are exercised by the
+     * connected Compose test `SessionCardFeedRegistryTest` (gated in
+     * `scripts/ci-journey-suite.sh`). Use the emulator run for acceptance.
+     */
+    @Test
+    fun sessionCardFeed() = render("session-card-feed") {
+        Surface(color = PocketShellColors.Surface) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp, vertical = 12.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                Text(
+                    text = "Cards",
+                    color = PocketShellColors.Text,
+                    fontWeight = FontWeight.SemiBold,
+                    style = PocketShellType.bodyDense,
+                )
+                // Checklist card row (ChecklistCardRenderer).
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(PocketShellColors.SurfaceElev)
+                        .padding(8.dp),
+                ) {
+                    Text(
+                        text = "Deploy",
+                        color = PocketShellColors.Text,
+                        fontWeight = FontWeight.SemiBold,
+                        style = PocketShellType.bodyDense,
+                        modifier = Modifier.padding(horizontal = 8.dp),
+                    )
+                    sessionCardCheckRow("Build", checked = true)
+                    sessionCardCheckRow("Ship", checked = false)
+                }
+                // Note card row (NoteCardRenderer) — mark-as-read affordance.
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(PocketShellColors.SurfaceElev)
+                        .padding(8.dp),
+                ) {
+                    Text(
+                        text = "Heads up",
+                        color = PocketShellColors.Text,
+                        fontWeight = FontWeight.SemiBold,
+                        style = PocketShellType.bodyDense,
+                        modifier = Modifier.padding(horizontal = 8.dp),
+                    )
+                    sessionCardCheckRow("Deploy finished — review the logs", checked = false)
+                }
+                // Unknown type fallback (UnknownCardRenderer).
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(PocketShellColors.SurfaceElev)
+                        .padding(8.dp),
+                ) {
+                    Text(
+                        text = "Approve?",
+                        color = PocketShellColors.Text,
+                        fontWeight = FontWeight.SemiBold,
+                        style = PocketShellType.bodyDense,
+                    )
+                    Text(
+                        text = "Unsupported card (approval) — update the app to view it.",
+                        color = PocketShellColors.TextSecondary,
+                        style = PocketShellType.bodyDense,
+                    )
+                }
+            }
+        }
+    }
+
+    @Composable
+    private fun sessionCardCheckRow(text: String, checked: Boolean) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 2.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Checkbox(checked = checked, onCheckedChange = {})
+            Text(
+                text = text,
+                color = PocketShellColors.Text,
+                style = PocketShellType.bodyDense,
+            )
+        }
+    }
+
     private fun render(name: String, content: @Composable () -> Unit) {
         captureRoboImage("build/renders/$name.png") {
             PocketShellTheme {

--- a/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenders.kt
+++ b/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenders.kt
@@ -3769,7 +3769,6 @@ class DesignRenders {
     }
 
     /**
-<<<<<<< ours
      * Issue #859 Slice B: the typed-card session feed sheet — a heterogeneous
      * card list rendered through the renderer registry (checklist + the new
      * `note` type + a graceful "unsupported card" fallback for an unknown type).
@@ -3850,110 +3849,12 @@ class DesignRenders {
                         text = "Unsupported card (approval) — update the app to view it.",
                         color = PocketShellColors.TextSecondary,
                         style = PocketShellType.bodyDense,
-=======
-     * Issue #947: the host-pocketshell-version-mismatch banner with the one-tap
-     * **Update** button next to **Dismiss**, plus its running-spinner and
-     * failure states. The production composable
-     * (`app/.../projects/FolderListScreen.kt#CliVersionMismatchBanner`) is
-     * app-private, so this render faithfully re-creates the same layout with the
-     * same ui-kit primitives (Update = Primary, Dismiss = Text, the running
-     * spinner, the red failure line) — the fast first visual check that the
-     * Update button fits the banner cleanly. The emulator screenshot of the real
-     * FolderList banner is the acceptance.
-     */
-    @Test
-    fun cliVersionMismatchBannerUpdateButton() = render("cli-version-mismatch-update-button") {
-        val message = "This host's pocketshell is 0.4.14; the app expects 0.4.16. " +
-            "Update it on the host:\nuv tool install --upgrade " +
-            "--exclude-newer-package pocketshell=2099-12-31 pocketshell\n" +
-            "(or: pipx upgrade pocketshell / pip install -U pocketshell)"
-        SectionHeader(label = "DEFAULT — Update + Dismiss")
-        CliVersionBannerRender(message = message, state = BannerRenderState.Idle)
-        SectionHeader(label = "RUNNING — host upgrade in flight")
-        CliVersionBannerRender(message = message, state = BannerRenderState.Running)
-        SectionHeader(label = "FAILURE — error shown, Retry + Dismiss")
-        CliVersionBannerRender(
-            message = message,
-            state = BannerRenderState.Failure(
-                "Update failed (exit 1):\nerror: network unreachable",
-            ),
-        )
-    }
-
-    private sealed interface BannerRenderState {
-        data object Idle : BannerRenderState
-        data object Running : BannerRenderState
-        data class Failure(val message: String) : BannerRenderState
-    }
-
-    @Composable
-    private fun CliVersionBannerRender(message: String, state: BannerRenderState) {
-        val color = PocketShellColors.Accent
-        val running = state is BannerRenderState.Running
-        val failure = state as? BannerRenderState.Failure
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 12.dp)
-                .background(PocketShellColors.Surface, PocketShellShapes.medium)
-                .background(color.copy(alpha = 0.12f), PocketShellShapes.medium)
-                .border(1.dp, color.copy(alpha = 0.4f), PocketShellShapes.medium)
-                .padding(horizontal = 14.dp, vertical = 10.dp),
-        ) {
-            Text(
-                text = message,
-                color = PocketShellColors.Text,
-                style = PocketShellType.bodyDense,
-                modifier = Modifier.fillMaxWidth(),
-            )
-            failure?.let { fail ->
-                Spacer(modifier = Modifier.height(8.dp))
-                Text(
-                    text = fail.message,
-                    color = PocketShellColors.Red,
-                    style = PocketShellType.bodyDense,
-                    modifier = Modifier.fillMaxWidth(),
-                )
-            }
-            Spacer(modifier = Modifier.height(6.dp))
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.End,
-            ) {
-                if (running) {
-                    androidx.compose.material3.CircularProgressIndicator(
-                        color = color,
-                        strokeWidth = 2.dp,
-                        modifier = Modifier.size(18.dp),
-                    )
-                    Spacer(modifier = Modifier.width(10.dp))
-                    Text(
-                        text = "Updating…",
-                        color = PocketShellColors.TextSecondary,
-                        style = PocketShellType.bodyDense,
-                    )
-                } else {
-                    PocketShellButton(
-                        text = if (failure != null) "Retry" else "Update",
-                        onClick = {},
-                        variant = ButtonVariant.Primary,
-                        compact = true,
-                    )
-                    Spacer(modifier = Modifier.width(8.dp))
-                    PocketShellButton(
-                        text = "Dismiss",
-                        onClick = {},
-                        variant = ButtonVariant.Text,
-                        compact = true,
->>>>>>> theirs
                     )
                 }
             }
         }
     }
 
-<<<<<<< ours
     @Composable
     private fun sessionCardCheckRow(text: String, checked: Boolean) {
         Row(
@@ -3971,8 +3872,6 @@ class DesignRenders {
         }
     }
 
-=======
->>>>>>> theirs
     private fun render(name: String, content: @Composable () -> Unit) {
         captureRoboImage("build/renders/$name.png") {
             PocketShellTheme {

--- a/tests/docker/Dockerfile.agents-daemon
+++ b/tests/docker/Dockerfile.agents-daemon
@@ -1,0 +1,84 @@
+# Daemon-backed agents fixture for the durable-tree journey (issue #839).
+#
+# The standard `agents` fixture (Dockerfile.agents) ships a FAKE shell-script
+# `pocketshell` that has no `tree` subcommand — so the durable per-host project
+# tree (#837, epic #821 workstream C) could never be exercised end-to-end on a
+# real device + real daemon. This fixture installs the REAL Python `pocketshell`
+# package from the in-repo source so `pocketshell tree get|upsert|reconcile`
+# runs the GENUINE daemon code (tools/pocketshell/src/pocketshell/tree.py): a
+# host-keyed JSON registry under `$XDG_STATE_HOME/pocketshell/tree/registry.json`
+# (atomic temp-file + os.replace, 0600). That registry is HOST-SIDE state, so it
+# SURVIVES an Android app kill + relaunch — which is exactly the #839 proof: the
+# emulator collapses a folder + holds an order, the app is killed + relaunched,
+# and the cold-start hydrate reads the persisted tree back INSTANTLY.
+#
+# `pocketshell tree reconcile` diffs the registry against `tmuxctl list`, so this
+# image carries a `tmuxctl` (tests/docker/agent-bin-daemon/tmuxctl) whose `list`
+# reflects the LIVE tmux server (not the static canned table the standard fixture
+# uses) — the only way a session the test KILLED shows up as a reconcile `gone`
+# delta and a session it CREATED shows up as `added`.
+#
+# Bound on host port 2239 (distinct from `agents`/2222, `tmux`/2224,
+# `flaky-agent`/2226, bootstrap/2230-2236, `agents-old-cli`/2238,
+# `real-agent`/2240, agents-pool/2243-2245). NOT started by the default workflow;
+# the connected journey that uses it is gated with Assume otherwise.
+#
+# Build context is the REPO ROOT (see docker-compose.yml) so it can COPY both
+# tests/docker/* and tools/pocketshell/*.
+FROM alpine:latest
+
+# python3 + py3-click satisfy the `pocketshell` CLI's only eager dependency
+# (click>=8.2.0; alpine ships 8.3.x). pyyaml / google-auth / tmuxctl are LAZY /
+# subprocess-only (see tools/pocketshell/pyproject.toml comments), so the package
+# installs with --no-deps and the tree CLI path needs none of them. The real
+# `tmuxctl list` is provided by our shell shim below.
+RUN apk add --no-cache \
+        openssh-server openssh-client tmux procps bash sqlite git \
+        python3 py3-click py3-pip \
+    && ssh-keygen -A \
+    && adduser -D -s /bin/sh testuser \
+    && passwd -u testuser \
+    && mkdir -p /home/testuser/.ssh \
+    && chmod 700 /home/testuser/.ssh
+
+COPY tests/docker/sshd_config /etc/ssh/sshd_config
+COPY tests/docker/test_key.pub /home/testuser/.ssh/authorized_keys
+COPY tests/docker/test_key /root/test_key
+# The shared fake agent CLIs (claude/codex/opencode/quse/agent-log-explorer)
+# so a session launch in the journey still resolves a runnable agent. The REAL
+# `pocketshell` (installed below) and the daemon-aware `tmuxctl` (copied after)
+# deliberately OVERRIDE the fakes from this dir.
+COPY tests/docker/agent-bin/ /usr/local/bin/
+COPY tests/docker/agent-fixtures/ /opt/pocketshell-agent-fixtures/
+COPY tests/docker/agent-entrypoint.sh /usr/local/bin/pocketshell-agent-entrypoint
+
+# Install the REAL pocketshell package (genuine tree.py daemon code). --no-deps
+# keeps the build offline (only py3-click, installed via apk above, is needed for
+# the `tree` CLI path). --break-system-packages because alpine marks the system
+# python as externally-managed; this is a throwaway test image.
+COPY tools/pocketshell/ /opt/pocketshell-src/
+RUN pip install --no-deps --break-system-packages /opt/pocketshell-src \
+    && pocketshell --version
+
+# The daemon-aware tmuxctl: a real `list` over the LIVE tmux server (for the
+# reconcile delta) + create-detached. Copied AFTER agent-bin/ so it overrides the
+# static-list fake tmuxctl.
+COPY tests/docker/agent-bin-daemon/tmuxctl /usr/local/bin/tmuxctl
+
+RUN chmod 600 /home/testuser/.ssh/authorized_keys /root/test_key \
+    && chmod +x /usr/local/bin/claude \
+        /usr/local/bin/codex \
+        /usr/local/bin/opencode \
+        /usr/local/bin/quse \
+        /usr/local/bin/agent-log-explorer \
+        /usr/local/bin/tmux \
+        /usr/local/bin/tmuxctl \
+        /usr/local/bin/pocketshell-tui-smoke \
+        /usr/local/bin/pocketshell-fake-agent \
+        /usr/local/bin/pocketshell-agent-entrypoint \
+    && rm -f /usr/local/bin/pocketshell \
+    && chown -R testuser:testuser /home/testuser/.ssh
+
+EXPOSE 22
+
+CMD ["/usr/local/bin/pocketshell-agent-entrypoint"]

--- a/tests/docker/agent-bin-daemon/tmuxctl
+++ b/tests/docker/agent-bin-daemon/tmuxctl
@@ -1,0 +1,87 @@
+#!/bin/sh
+set -eu
+
+# Daemon-fixture `tmuxctl` (issue #839).
+#
+# The standard `agents` fixture's `tmuxctl list` (tests/docker/agent-bin/tmuxctl)
+# prints a STATIC canned table so the deterministic session-list parser tests see
+# a stable shape. That is wrong for THIS fixture: the durable-tree journey
+# (#839) drives the REAL `pocketshell tree reconcile` daemon code, which execs
+# `tmuxctl list` and DIFFS its output against the persisted registry to compute
+# the `{alive, gone, added}` deltas. A static list could never show a session
+# the test just KILLED as `gone`, nor a session it just CREATED as `added`.
+#
+# So this `tmuxctl list` reflects the LIVE tmux server: it renders the same
+# fixed-width `IDX  SESSION  CREATED` table the daemon's `_parse_session_names`
+# parses, one row per live `tmux list-sessions` session. `create-detached`
+# mirrors the standard fixture (a plain detached `tmux new-session -A -d`), and
+# the side-effect-free `create-detached --help` capability probe still exits 0.
+
+if [ "${1:-}" = "list" ] || [ "${1:-}" = "ls" ] || [ "${1:-}" = "l" ]; then
+  printf 'IDX  SESSION               CREATED\n'
+  # Enumerate the LIVE tmux sessions. `#{session_created}` is an epoch second;
+  # format it to the same `YYYY-MM-DD HH:MM:SS` shape the canned table used.
+  # A tmux with no server / no sessions exits non-zero on list-sessions, which we
+  # swallow so an empty live server prints just the header (zero data rows) and
+  # still exits 0 — the daemon then sees "no live sessions" (not an enumeration
+  # FAILURE, which would suppress pruning).
+  idx=0
+  tmux list-sessions -F '#{session_name} #{session_created}' 2>/dev/null \
+    | while IFS=' ' read -r name created; do
+        idx=$((idx + 1))
+        if [ -n "$created" ]; then
+          created_fmt="$(date -u -d "@${created}" '+%Y-%m-%d %H:%M:%S' 2>/dev/null \
+            || date -u -r "${created}" '+%Y-%m-%d %H:%M:%S' 2>/dev/null \
+            || printf '1970-01-01 00:00:00')"
+        else
+          created_fmt='1970-01-01 00:00:00'
+        fi
+        printf '%-4s %-21s %s\n' "$idx" "$name" "$created_fmt"
+      done
+  exit 0
+fi
+
+if [ "${1:-}" = "create-detached" ]; then
+  shift
+  case "${1:-}" in
+    --help | -h)
+      printf 'Usage: tmuxctl create-detached SESSION_NAME [COMMAND]... [--cwd DIR] [--mem CAP]\n'
+      exit 0
+      ;;
+  esac
+  session=""
+  cwd=""
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      -c | --cwd)
+        cwd="${2:-}"
+        shift 2 || shift
+        ;;
+      --mem)
+        shift 2 || shift
+        ;;
+      -*)
+        shift
+        ;;
+      *)
+        if [ -z "${session}" ]; then
+          session="$1"
+        fi
+        shift
+        ;;
+    esac
+  done
+  if [ -z "${session}" ]; then
+    printf 'create-detached: session name required\n' >&2
+    exit 64
+  fi
+  if [ -n "${cwd}" ]; then
+    tmux new-session -A -d -s "${session}" -c "${cwd}"
+  else
+    tmux new-session -A -d -s "${session}"
+  fi
+  exit 0
+fi
+
+printf 'tmuxctl daemon fixture supports: list, create-detached\n' >&2
+exit 64

--- a/tests/docker/agent-bin/pocketshell
+++ b/tests/docker/agent-bin/pocketshell
@@ -451,6 +451,473 @@ case "${1:-}" in
     fi
     exit 0
     ;;
+  push)
+    # Issue #859 Slice A — the agent->app typed-card feed transport, made REAL
+    # in the deterministic fixture so the connected emulator+Docker journey
+    # exercises the SAME warm-session exec path the device hits (D21), not a
+    # happy unit proxy. This mirrors the observable contract of the real Python
+    # CLI (tools/pocketshell/src/pocketshell/cards.py):
+    #
+    #   * `pocketshell push checklist --session S [--title T] [--id ID]
+    #       --item "a" --item "b" ...`  -> writes/replaces the per-session card
+    #     store. Item ids are `<slug>-<index>` (slug = lowercase ascii, `-`-
+    #     joined, <=48 chars; index = the 0-based position in the --item list),
+    #     EXACTLY matching cards.py `_slug` + `parse_checklist_markdown`. A re-
+    #     push of the same `--id` is a FULL replace (hard-cut, like cards.py
+    #     `upsert_card`).
+    #   * `pocketshell push get --json --session S` -> emits the app's contract
+    #     `{"session":S,"cards":[{id,type,title?,created_at,updated_at,
+    #       body:{items:[{id,text}]},state:{checked:[...]}}]}` — the exact JSON
+    #     SessionCardsRemoteSource.parseFeed reads. (No --json => human/YAML-ish.)
+    #   * `pocketshell push check --id ID --item ITEM --done|--undone
+    #       --session S` -> ticks/unticks one item in `state.checked` (the app's
+    #     toggle path), like cards.py `apply_interaction`. Unknown id/item -> 65.
+    #   * `pocketshell push status [--json] --session S` -> the agent's read-back
+    #     of the human's ticks (cards.py `push status`).
+    #
+    # The store is per-session JSON under
+    # `${POCKETSHELL_CARDS_DIR:-$HOME/.pocketshell/cards}/<session>.json`,
+    # mode 0600 / dir 0700 (the cards.py private-write convention). The real CLI
+    # persists YAML and emits JSON for the app; the app ONLY ever reads JSON, so
+    # a JSON-backed fixture store is faithful to the app's exact contract while
+    # staying parseable in POSIX `/bin/sh` (no python/yaml in this Alpine image).
+    shift
+    push_sub="${1:-}"
+    shift 2>/dev/null || true
+
+    push_cards_dir="${POCKETSHELL_CARDS_DIR:-$HOME/.pocketshell/cards}"
+    push_now="$(date -u +%Y-%m-%dT%H:%M:%S+00:00 2>/dev/null || printf '1970-01-01T00:00:00+00:00')"
+
+    # `tmux display-message -p '#S'` auto-detection when --session is omitted and
+    # $TMUX is set, mirroring cards.py detect_session. The journey always passes
+    # --session, but the agent-CLI happy path relies on auto-detect.
+    push_detect_session() {
+      if [ -n "${1:-}" ]; then
+        printf '%s' "$1"
+        return 0
+      fi
+      if [ -n "${TMUX:-}" ]; then
+        tmux display-message -p '#S' 2>/dev/null && return 0
+      fi
+      return 1
+    }
+
+    # JSON-escape a string for embedding in a double-quoted JSON value.
+    push_json_escape() {
+      printf '%s' "$1" | awk '
+        BEGIN { ORS="" }
+        {
+          s=$0
+          gsub(/\\/, "\\\\", s)
+          gsub(/"/, "\\\"", s)
+          gsub(/\t/, "\\t", s)
+          if (NR>1) printf "\\n"
+          printf "%s", s
+        }'
+    }
+
+    # Stable item id = `<slug>-<index>` (cards.py _slug + the parse index).
+    push_slug() {
+      printf '%s' "$1" | awk '
+        {
+          s=tolower($0)
+          gsub(/[^a-z0-9]+/, "-", s)
+          sub(/^-+/, "", s); sub(/-+$/, "", s)
+          if (length(s) > 48) s=substr(s, 1, 48)
+          if (s == "") s="item"
+          printf "%s", s
+        }'
+    }
+
+    push_session_file() {
+      printf '%s/%s.json' "$push_cards_dir" "$1"
+    }
+
+    case "$push_sub" in
+      checklist)
+        push_title=""
+        push_card_id="checklist"
+        push_session_arg=""
+        push_items=""   # newline-separated raw item texts
+        while [ "$#" -gt 0 ]; do
+          case "$1" in
+            --title) push_title="${2:-}"; shift 2 ;;
+            --id) push_card_id="${2:-}"; shift 2 ;;
+            --item) push_items="${push_items}${2:-}
+"; shift 2 ;;
+            --session) push_session_arg="${2:-}"; shift 2 ;;
+            *) shift ;;
+          esac
+        done
+        push_session="$(push_detect_session "$push_session_arg")" || {
+          printf 'could not determine the tmux session: pass --session or run inside tmux.\n' >&2
+          exit 64
+        }
+        # Build the items JSON array. The store JSON IS the app contract object.
+        push_items_json=""
+        push_count=0
+        push_index=0
+        # NOTE: iterate preserving order; a trailing empty line from the
+        # accumulation is skipped.
+        OLDIFS="$IFS"
+        IFS='
+'
+        for push_raw in $push_items; do
+          [ -n "$push_raw" ] || { push_index=$((push_index + 1)); continue; }
+          push_text="$(printf '%s' "$push_raw" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+          [ -n "$push_text" ] || { push_index=$((push_index + 1)); continue; }
+          push_slug_val="$(push_slug "$push_text")"
+          push_item_id="${push_slug_val}-${push_index}"
+          push_text_esc="$(push_json_escape "$push_text")"
+          [ "$push_count" -gt 0 ] && push_items_json="${push_items_json},"
+          push_items_json="${push_items_json}{\"id\":\"${push_item_id}\",\"text\":\"${push_text_esc}\"}"
+          push_count=$((push_count + 1))
+          push_index=$((push_index + 1))
+        done
+        IFS="$OLDIFS"
+        if [ "$push_count" -eq 0 ]; then
+          printf 'no checklist items: pass --item (or pipe markdown on stdin).\n' >&2
+          exit 64
+        fi
+
+        # Read any existing cards for this session and drop the one we replace,
+        # preserving the others (hard-cut replace of THIS card id only).
+        push_file="$(push_session_file "$push_session")"
+        # Compose the title key if provided.
+        push_title_json=""
+        if [ -n "$push_title" ]; then
+          push_title_json="\"title\":\"$(push_json_escape "$push_title")\","
+        fi
+        push_card="{\"id\":\"$(push_json_escape "$push_card_id")\",\"type\":\"checklist\",\"created_at\":\"${push_now}\",\"updated_at\":\"${push_now}\",${push_title_json}\"body\":{\"items\":[${push_items_json}]},\"state\":{\"checked\":[]}}"
+
+        # Preserve any OTHER existing cards (different id) verbatim. Extract them
+        # from the existing store with a small python-free splitter.
+        push_other_cards="$(
+          if [ -f "$push_file" ]; then
+            awk -v want="$push_card_id" '
+              BEGIN { depth=0; incards=0; buf=""; first=1; out="" }
+              {
+                line=line $0 "\n"
+              }
+              END {
+                # Parse the cards array char-by-char, emitting top-level card
+                # objects whose `"id":"..."` != want.
+                s=line
+                n=length(s)
+                # locate `"cards":[`
+                idx=index(s, "\"cards\":[")
+                if (idx == 0) { printf ""; exit }
+                i=idx + length("\"cards\":[")
+                arrdepth=1
+                obj=""; objdepth=0; collecting=0
+                res=""
+                while (i <= n) {
+                  c=substr(s, i, 1)
+                  if (collecting == 0) {
+                    if (c == "{") { collecting=1; objdepth=1; obj="{" }
+                    else if (c == "]") { break }
+                  } else {
+                    obj=obj c
+                    if (c == "{") objdepth++
+                    else if (c == "}") {
+                      objdepth--
+                      if (objdepth == 0) {
+                        # got one card object in obj
+                        idpos=match(obj, /"id"[ ]*:[ ]*"[^"]*"/)
+                        cid=""
+                        if (idpos > 0) {
+                          frag=substr(obj, idpos, RLENGTH)
+                          sub(/"id"[ ]*:[ ]*"/, "", frag)
+                          sub(/".*/, "", frag)
+                          cid=frag
+                        }
+                        if (cid != want) {
+                          if (res != "") res=res ","
+                          res=res obj
+                        }
+                        collecting=0; obj=""
+                      }
+                    }
+                  }
+                  i++
+                }
+                printf "%s", res
+              }
+            ' "$push_file"
+          fi
+        )"
+
+        push_all_cards="$push_card"
+        if [ -n "$push_other_cards" ]; then
+          push_all_cards="${push_other_cards},${push_card}"
+        fi
+
+        mkdir -p "$push_cards_dir" 2>/dev/null || true
+        chmod 700 "$push_cards_dir" 2>/dev/null || true
+        push_tmp="${push_file}.tmp.$$"
+        printf '{"session":"%s","cards":[%s]}\n' "$(push_json_escape "$push_session")" "$push_all_cards" > "$push_tmp"
+        chmod 600 "$push_tmp" 2>/dev/null || true
+        mv -f "$push_tmp" "$push_file"
+        printf "checklist '%s' (%d items) -> session '%s' (%s)\n" "$push_card_id" "$push_count" "$push_session" "$push_file"
+        exit 0
+        ;;
+      get)
+        push_as_json=0
+        push_session_arg=""
+        while [ "$#" -gt 0 ]; do
+          case "$1" in
+            --json) push_as_json=1; shift ;;
+            --session) push_session_arg="${2:-}"; shift 2 ;;
+            *) shift ;;
+          esac
+        done
+        push_session="$(push_detect_session "$push_session_arg")" || {
+          printf 'could not determine the tmux session: pass --session or run inside tmux.\n' >&2
+          exit 64
+        }
+        push_file="$(push_session_file "$push_session")"
+        if [ "$push_as_json" -eq 1 ]; then
+          if [ -f "$push_file" ]; then
+            cat "$push_file"
+          else
+            printf '{"session":"%s","cards":[]}\n' "$(push_json_escape "$push_session")"
+          fi
+          exit 0
+        fi
+        if [ -f "$push_file" ]; then
+          cat "$push_file"
+        else
+          printf '(no cards for session %s)\n' "$push_session"
+        fi
+        exit 0
+        ;;
+      status)
+        push_as_json=0
+        push_session_arg=""
+        push_only_id=""
+        while [ "$#" -gt 0 ]; do
+          case "$1" in
+            --json) push_as_json=1; shift ;;
+            --id) push_only_id="${2:-}"; shift 2 ;;
+            --session) push_session_arg="${2:-}"; shift 2 ;;
+            *) shift ;;
+          esac
+        done
+        push_session="$(push_detect_session "$push_session_arg")" || {
+          printf 'could not determine the tmux session: pass --session or run inside tmux.\n' >&2
+          exit 64
+        }
+        push_file="$(push_session_file "$push_session")"
+        if [ ! -f "$push_file" ]; then
+          if [ "$push_as_json" -eq 1 ]; then
+            printf '{"session":"%s","status":[]}\n' "$(push_json_escape "$push_session")"
+          else
+            printf '(no cards for session %s)\n' "$push_session"
+          fi
+          exit 0
+        fi
+        # Re-emit each card's {id,type,state} from the store JSON. Use the same
+        # awk card-splitter and pull the id/type/state fragments.
+        push_status_body="$(
+          awk -v want="$push_only_id" -v session="$push_session" '
+            BEGIN { res="" }
+            { line=line $0 "\n" }
+            END {
+              s=line; n=length(s)
+              idx=index(s, "\"cards\":[")
+              if (idx == 0) { printf ""; exit }
+              i=idx + length("\"cards\":["); collecting=0; obj=""; objdepth=0
+              while (i <= n) {
+                c=substr(s, i, 1)
+                if (collecting == 0) {
+                  if (c == "{") { collecting=1; objdepth=1; obj="{" }
+                  else if (c == "]") break
+                } else {
+                  obj=obj c
+                  if (c == "{") objdepth++
+                  else if (c == "}") {
+                    objdepth--
+                    if (objdepth == 0) {
+                      cid=""; ctype=""; cstate="{}"
+                      if (match(obj, /"id"[ ]*:[ ]*"[^"]*"/)) {
+                        f=substr(obj, RSTART, RLENGTH); sub(/"id"[ ]*:[ ]*"/, "", f); sub(/".*/, "", f); cid=f
+                      }
+                      if (match(obj, /"type"[ ]*:[ ]*"[^"]*"/)) {
+                        f=substr(obj, RSTART, RLENGTH); sub(/"type"[ ]*:[ ]*"/, "", f); sub(/".*/, "", f); ctype=f
+                      }
+                      sp=index(obj, "\"state\":")
+                      if (sp > 0) {
+                        rest=substr(obj, sp + length("\"state\":"))
+                        # capture the balanced {...} of state
+                        d=0; st=""; started=0
+                        for (k=1; k<=length(rest); k++) {
+                          ch=substr(rest, k, 1)
+                          if (ch == "{") { d++; started=1 }
+                          st=st ch
+                          if (ch == "}") { d--; if (started && d==0) break }
+                        }
+                        cstate=st
+                      }
+                      if (want == "" || cid == want) {
+                        if (res != "") res=res ","
+                        res=res "{\"id\":\"" cid "\",\"type\":\"" ctype "\",\"state\":" cstate "}"
+                      }
+                      collecting=0; obj=""
+                    }
+                  }
+                }
+                i++
+              }
+              printf "%s", res
+            }
+          ' "$push_file"
+        )"
+        if [ "$push_as_json" -eq 1 ]; then
+          printf '{"session":"%s","status":[%s]}\n' "$(push_json_escape "$push_session")" "$push_status_body"
+        else
+          printf 'session %s:\n%s\n' "$push_session" "$push_status_body"
+        fi
+        exit 0
+        ;;
+      check)
+        push_card_id=""
+        push_item_id=""
+        push_done=1
+        push_session_arg=""
+        while [ "$#" -gt 0 ]; do
+          case "$1" in
+            --id) push_card_id="${2:-}"; shift 2 ;;
+            --item) push_item_id="${2:-}"; shift 2 ;;
+            --done) push_done=1; shift ;;
+            --undone) push_done=0; shift ;;
+            --session) push_session_arg="${2:-}"; shift 2 ;;
+            *) shift ;;
+          esac
+        done
+        push_session="$(push_detect_session "$push_session_arg")" || {
+          printf 'could not determine the tmux session: pass --session or run inside tmux.\n' >&2
+          exit 64
+        }
+        if [ -z "$push_card_id" ] || [ -z "$push_item_id" ]; then
+          printf 'push check requires --id and --item.\n' >&2
+          exit 64
+        fi
+        push_file="$(push_session_file "$push_session")"
+        if [ ! -f "$push_file" ]; then
+          printf "no card with id '%s' in session '%s'\n" "$push_card_id" "$push_session" >&2
+          exit 65
+        fi
+        # Mutate state.checked for the named card+item. Faithful to cards.py
+        # apply_interaction: unknown card id or unknown item id -> error (65).
+        push_new="$(
+          awk -v want="$push_card_id" -v item="$push_item_id" -v done="$push_done" '
+            BEGIN { found_card=0; found_item=0 }
+            { line=line $0 "\n" }
+            END {
+              s=line; n=length(s)
+              # Split the whole document into a prefix `{"session":...,"cards":[`,
+              # the card objects, and the suffix `]}`.
+              idx=index(s, "\"cards\":[")
+              if (idx == 0) { printf "%s", s; exit }
+              prefix=substr(s, 1, idx + length("\"cards\":[") - 1)
+              i=idx + length("\"cards\":[")
+              collecting=0; obj=""; objdepth=0; cards=""; suffix=""
+              while (i <= n) {
+                c=substr(s, i, 1)
+                if (collecting == 0) {
+                  if (c == "{") { collecting=1; objdepth=1; obj="{" }
+                  else if (c == "]") { suffix=substr(s, i); break }
+                } else {
+                  obj=obj c
+                  if (c == "{") objdepth++
+                  else if (c == "}") {
+                    objdepth--
+                    if (objdepth == 0) {
+                      cid=""
+                      if (match(obj, /"id"[ ]*:[ ]*"[^"]*"/)) {
+                        f=substr(obj, RSTART, RLENGTH); sub(/"id"[ ]*:[ ]*"/, "", f); sub(/".*/, "", f); cid=f
+                      }
+                      if (cid == want) {
+                        found_card=1
+                        # confirm the item id exists in body.items
+                        if (obj ~ ("\"id\":\"" item "\"")) {
+                          # locate item by checking body items only is overkill;
+                          # the items + checked both use "id":"..." — but the
+                          # checked entries are bare strings. A body item match
+                          # is enough to confirm existence.
+                          found_item=1
+                        }
+                        # rebuild state.checked
+                        sp=index(obj, "\"state\":")
+                        head=substr(obj, 1, sp - 1)
+                        rest=substr(obj, sp)
+                        # extract existing checked list contents
+                        cp=index(rest, "\"checked\":[")
+                        chk=""
+                        if (cp > 0) {
+                          after=substr(rest, cp + length("\"checked\":["))
+                          # read up to the closing ]
+                          end=index(after, "]")
+                          chk=substr(after, 1, end - 1)
+                        }
+                        # split chk into existing ids (quoted, comma-sep)
+                        nids=0; split("", ids)
+                        tmp=chk
+                        while (match(tmp, /"[^"]*"/)) {
+                          v=substr(tmp, RSTART + 1, RLENGTH - 2)
+                          ids[++nids]=v
+                          tmp=substr(tmp, RSTART + RLENGTH)
+                        }
+                        present=0
+                        for (j=1;j<=nids;j++) if (ids[j]==item) present=1
+                        newchk=""
+                        if (done == "1") {
+                          for (j=1;j<=nids;j++) { if (newchk!="") newchk=newchk ","; newchk=newchk "\"" ids[j] "\"" }
+                          if (!present) { if (newchk!="") newchk=newchk ","; newchk=newchk "\"" item "\"" }
+                        } else {
+                          for (j=1;j<=nids;j++) if (ids[j]!=item) { if (newchk!="") newchk=newchk ","; newchk=newchk "\"" ids[j] "\"" }
+                        }
+                        obj=head "\"state\":{\"checked\":[" newchk "]}}"
+                      }
+                      if (cards != "") cards=cards ","
+                      cards=cards obj
+                      collecting=0; obj=""
+                    }
+                  }
+                }
+                i++
+              }
+              if (found_card == 0) { printf "__NO_CARD__"; exit }
+              if (found_item == 0) { printf "__NO_ITEM__"; exit }
+              printf "%s%s%s", prefix, cards, suffix
+            }
+          ' "$push_file"
+        )"
+        case "$push_new" in
+          __NO_CARD__)
+            printf "no card with id '%s' in session '%s'\n" "$push_card_id" "$push_session" >&2
+            exit 65 ;;
+          __NO_ITEM__)
+            printf "checklist: unknown item id '%s'\n" "$push_item_id" >&2
+            exit 65 ;;
+        esac
+        push_tmp="${push_file}.tmp.$$"
+        printf '%s' "$push_new" > "$push_tmp"
+        chmod 600 "$push_tmp" 2>/dev/null || true
+        mv -f "$push_tmp" "$push_file"
+        if [ "$push_done" -eq 1 ]; then
+          printf "%s: item '%s' checked\n" "$push_card_id" "$push_item_id"
+        else
+          printf "%s: item '%s' unchecked\n" "$push_card_id" "$push_item_id"
+        fi
+        exit 0
+        ;;
+      *)
+        printf 'pocketshell push fixture supports: checklist|get|status|check\n' >&2
+        exit 64
+        ;;
+    esac
+    ;;
 esac
 
 printf 'pocketshell fixture supports: usage --json, sessions list, jobs list/add/edit/remove, agent-log, profiles list, agents kind\n' >&2

--- a/tests/docker/docker-compose.yml
+++ b/tests/docker/docker-compose.yml
@@ -126,6 +126,31 @@ services:
       - "2238:22"
     healthcheck: *ssh-healthcheck
 
+  # Issue #839: agents fixture whose host `pocketshell` is the REAL Python
+  # package (genuine `tree.py` daemon code), so `tree get|upsert|reconcile`
+  # actually PERSIST to a host-side JSON registry under
+  # `$XDG_STATE_HOME/pocketshell/tree/registry.json` (atomic temp-file +
+  # os.replace, 0600). That host-side state SURVIVES an Android app kill +
+  # relaunch — the #837 durable-tree property. The connected journey
+  # (FolderListDurableTreeDaemonDockerTest) collapses a folder + holds an order,
+  # KILLS + RELAUNCHES the app (a fresh FolderListViewModel + a NEW
+  # TreeRemoteSource binding the same host over a NEW SSH session), and asserts
+  # the cold-start hydrate reads the held order/collapse back INSTANTLY, then a
+  # reconcile diffs the registry against the LIVE `tmuxctl list` and returns
+  # gone/added deltas. Bound on host port 2239 (distinct from `agents`/2222,
+  # `tmux`/2224, `flaky-agent`/2226, bootstrap/2230-2236, `agents-old-cli`/2238,
+  # `real-agent`/2240, agents-pool/2243-2245). NOT started by the default
+  # workflow; the connected test that uses it is gated accordingly (Assume).
+  agents-daemon:
+    build:
+      context: ../..
+      dockerfile: tests/docker/Dockerfile.agents-daemon
+    image: pocketshell-test:agents-daemon
+    container_name: pocketshell-test-agents-daemon
+    ports:
+      - "2239:22"
+    healthcheck: *ssh-healthcheck
+
   # Issue #632 (slice 2): the 7 bootstrap setup-detection fixtures bind disjoint
   # host ports 2230-2236, so they can be sharded across multiple emulators and
   # brought up concurrently under DISTINCT compose projects

--- a/tools/pocketshell/pyproject.toml
+++ b/tools/pocketshell/pyproject.toml
@@ -8,7 +8,7 @@ name = "pocketshell"
 # scripts/check-pypi-version.sh enforces this; .github/workflows/build.yml
 # runs that check before publishing to PyPI. See
 # tools/pocketshell/README.md ("Release flow") for the bump procedure.
-version = "0.4.14"
+version = "0.4.16"
 description = "Unified server-side Python utility for the PocketShell Android client."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tools/pocketshell/pyproject.toml
+++ b/tools/pocketshell/pyproject.toml
@@ -8,7 +8,7 @@ name = "pocketshell"
 # scripts/check-pypi-version.sh enforces this; .github/workflows/build.yml
 # runs that check before publishing to PyPI. See
 # tools/pocketshell/README.md ("Release flow") for the bump procedure.
-version = "0.4.16"
+version = "0.4.17"
 description = "Unified server-side Python utility for the PocketShell Android client."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tools/pocketshell/src/pocketshell/cards.py
+++ b/tools/pocketshell/src/pocketshell/cards.py
@@ -361,6 +361,62 @@ register_card_type(
 
 
 # ---------------------------------------------------------------------------
+# note card type (#859 Slice B — proves the registry is genuinely generic)
+# ---------------------------------------------------------------------------
+#
+# A ``note`` is a non-interactive message the agent hands the human ("deploy
+# finished", "found a flaky test"). Its only interaction is mark-as-read, so the
+# agent can tell from ``push status`` whether the human has seen it. Registering
+# it is exactly one ``register_card_type`` call + a ``push note`` verb — no new
+# transport, no change to the store/read/write/upsert path. That is the whole
+# point of the registry: a second real type is additive.
+
+# Default note card id used when ``--id`` is omitted (one default note per
+# session unless the agent names them — mirrors DEFAULT_CHECKLIST_ID).
+DEFAULT_NOTE_ID = "note"
+
+
+def _note_build_body(*, text: str, **_: Any) -> dict[str, Any]:
+    """Build the note ``body`` — ``{"text": <message>}``."""
+    return {"text": text}
+
+
+def _note_initial_state(_body: dict[str, Any]) -> dict[str, Any]:
+    """A fresh note is unread."""
+    return {"read": False, "read_at": None}
+
+
+def _note_apply_interaction(
+    body: dict[str, Any],
+    state: dict[str, Any],
+    interaction: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Mark a note read/unread.
+
+    ``interaction = {"read": bool}``. ``read`` defaults to True (mark read).
+    ``read_at`` records when it was first read (cleared on unread) so the agent
+    can see acknowledgement timing via ``push status``.
+    """
+    read = bool(interaction.get("read", True))
+    return {"read": read, "read_at": _now_iso() if read else None}
+
+
+def _note_summarise(body: dict[str, Any], state: dict[str, Any]) -> str:
+    return "note: read" if state.get("read") else "note: unread"
+
+
+register_card_type(
+    CardType(
+        name="note",
+        build_body=_note_build_body,
+        initial_state=_note_initial_state,
+        apply_interaction=_note_apply_interaction,
+        summarise=_note_summarise,
+    )
+)
+
+
+# ---------------------------------------------------------------------------
 # Store read/write
 # ---------------------------------------------------------------------------
 
@@ -652,6 +708,74 @@ def register_push_card_commands(push_group: click.Group) -> None:
                 target,
                 card_id,
                 {"item": item_id, "done": done},
+                paths=resolve_paths(),
+            )
+        except ValueError as exc:
+            raise click.ClickException(str(exc))
+        handler = get_card_type(card.get("type", ""))
+        body = card.get("body", {}) if isinstance(card.get("body"), Mapping) else {}
+        state = card.get("state", {}) if isinstance(card.get("state"), Mapping) else {}
+        summary = handler.summarise(dict(body), dict(state)) if handler else ""
+        click.echo(f"{card_id}: {summary}")
+
+    @push_group.command("note")
+    @click.option("--title", "title", default=None, help="Human title for the note card.")
+    @click.option(
+        "--id",
+        "card_id",
+        default=DEFAULT_NOTE_ID,
+        help=f"Card id (default {DEFAULT_NOTE_ID!r}; one default note per session).",
+    )
+    @click.option(
+        "--text",
+        "text",
+        default=None,
+        help="The note body. Alternative to piping the message on stdin.",
+    )
+    @click.option("--session", "session", default=None, help="Override the auto-detected tmux session.")
+    def push_note(
+        title: Optional[str],
+        card_id: str,
+        text: Optional[str],
+        session: Optional[str],
+    ) -> None:
+        """Create/replace the session's note card from --text or piped stdin.
+
+        A note is a non-interactive message the human marks read (``push read``).
+        The session is auto-detected from ``$TMUX`` (override with ``--session``).
+        A re-push fully replaces the card of that id (hard-cut, D22).
+        """
+        target = _require_session(session)
+        if text is not None and text.strip():
+            body_text = text.strip()
+        else:
+            stdin_text = "" if sys.stdin is None or sys.stdin.isatty() else sys.stdin.read()
+            body_text = stdin_text.strip()
+        if not body_text:
+            raise click.ClickException(
+                "empty note: pass --text or pipe the message on stdin."
+            )
+        card = build_card(
+            card_type="note",
+            card_id=card_id,
+            title=title,
+            build_kwargs={"text": body_text},
+        )
+        path = upsert_card(target, card, paths=resolve_paths())
+        click.echo(f"note {card_id!r} -> session {target!r} ({path})")
+
+    @push_group.command("read")
+    @click.option("--id", "card_id", required=True, help="The note card id.")
+    @click.option("--read/--unread", "read", default=True, help="Mark read (default) or unread.")
+    @click.option("--session", "session", default=None, help="Override the auto-detected tmux session.")
+    def push_read(card_id: str, read: bool, session: Optional[str]) -> None:
+        """Set a note's read state (this is what the app's "mark read" calls)."""
+        target = _require_session(session)
+        try:
+            card = apply_interaction(
+                target,
+                card_id,
+                {"read": read},
                 paths=resolve_paths(),
             )
         except ValueError as exc:

--- a/tools/pocketshell/tests/test_cards.py
+++ b/tools/pocketshell/tests/test_cards.py
@@ -389,3 +389,139 @@ def test_cli_check_unknown_item_errors(tmp_path: Path) -> None:
     )
     assert res.exit_code != 0
     assert "unknown item" in res.output
+
+
+# ----- note card type (#859 Slice B — registry is genuinely generic) ----
+
+
+def test_note_card_type_is_registered() -> None:
+    """AC: the host registers a REAL `note` CardType (not just the stub test)."""
+    handler = cards_mod.get_card_type("note")
+    assert handler is not None
+    assert handler.name == "note"
+
+
+def test_build_upsert_read_note(tmp_path: Path) -> None:
+    """AC: note `body={text}`, `state={read:false, read_at:None}` round-trips."""
+    paths = _paths(tmp_path)
+    card = cards_mod.build_card(
+        card_type="note",
+        card_id="note",
+        title="Heads up",
+        build_kwargs={"text": "deploy finished"},
+    )
+    cards_mod.upsert_card("demo", card, paths=paths)
+    got = cards_mod.read_cards("demo", paths=paths)
+    assert len(got) == 1
+    assert got[0]["type"] == "note"
+    assert got[0]["title"] == "Heads up"
+    assert got[0]["body"] == {"text": "deploy finished"}
+    assert got[0]["state"] == {"read": False, "read_at": None}
+
+
+def test_note_apply_interaction_marks_read_and_unread(tmp_path: Path) -> None:
+    """AC: mark-as-read interaction sets read + read_at; unread clears read_at."""
+    paths = _paths(tmp_path)
+    card = cards_mod.build_card(
+        card_type="note", card_id="note", title=None,
+        build_kwargs={"text": "hi"},
+    )
+    cards_mod.upsert_card("demo", card, paths=paths)
+
+    read = cards_mod.apply_interaction("demo", "note", {"read": True}, paths=paths)
+    assert read["state"]["read"] is True
+    assert read["state"]["read_at"]  # a timestamp, not None
+
+    unread = cards_mod.apply_interaction("demo", "note", {"read": False}, paths=paths)
+    assert unread["state"]["read"] is False
+    assert unread["state"]["read_at"] is None
+
+
+def test_note_and_checklist_coexist_in_one_session(tmp_path: Path) -> None:
+    """The store is type-agnostic: a note + a checklist live side by side."""
+    paths = _paths(tmp_path)
+    checklist = cards_mod.build_card(
+        card_type="checklist", card_id="checklist", title="Deploy",
+        build_kwargs={"items": [{"id": "build-0", "text": "build"}]},
+    )
+    note = cards_mod.build_card(
+        card_type="note", card_id="note", title=None,
+        build_kwargs={"text": "fyi"},
+    )
+    cards_mod.upsert_card("demo", checklist, paths=paths)
+    cards_mod.upsert_card("demo", note, paths=paths)
+    got = cards_mod.read_cards("demo", paths=paths)
+    assert {c["type"] for c in got} == {"checklist", "note"}
+
+
+def test_cli_note_set_get_read_status_flow(tmp_path: Path) -> None:
+    """AC: push note (stdin) → get --json → read → status reflects read."""
+    runner = CliRunner()
+    env = _env(tmp_path)
+
+    res = runner.invoke(
+        cli,
+        ["push", "note", "--title", "Heads up", "--session", "demo"],
+        input="deploy finished\n",
+        env=env,
+    )
+    assert res.exit_code == 0, res.output
+    assert "note 'note'" in res.output
+
+    res = runner.invoke(cli, ["push", "get", "--json", "--session", "demo"], env=env)
+    assert res.exit_code == 0, res.output
+    payload = json.loads(res.output)
+    card = payload["cards"][0]
+    assert card["type"] == "note"
+    assert card["title"] == "Heads up"
+    assert card["body"]["text"] == "deploy finished"
+    assert card["state"]["read"] is False
+
+    # Human marks it read (this is what the app's "mark read" calls).
+    res = runner.invoke(
+        cli, ["push", "read", "--id", "note", "--session", "demo"], env=env
+    )
+    assert res.exit_code == 0, res.output
+    assert "note: read" in res.output
+
+    # Agent reads the acknowledgement via status.
+    res = runner.invoke(cli, ["push", "status", "--json", "--session", "demo"], env=env)
+    assert res.exit_code == 0, res.output
+    status = json.loads(res.output)
+    assert status["status"][0]["state"]["read"] is True
+
+    res = runner.invoke(cli, ["push", "status", "--session", "demo"], env=env)
+    assert res.exit_code == 0, res.output
+    assert "note: read" in res.output
+
+
+def test_cli_note_text_via_flag(tmp_path: Path) -> None:
+    runner = CliRunner()
+    env = _env(tmp_path)
+    res = runner.invoke(
+        cli, ["push", "note", "--text", "found a flaky test", "--session", "demo"],
+        env=env,
+    )
+    assert res.exit_code == 0, res.output
+    got = cards_mod.read_cards("demo", paths=_paths(tmp_path))
+    assert got[0]["body"]["text"] == "found a flaky test"
+
+
+def test_cli_note_empty_errors(tmp_path: Path) -> None:
+    runner = CliRunner()
+    env = _env(tmp_path)
+    res = runner.invoke(
+        cli, ["push", "note", "--session", "demo"], input="", env=env
+    )
+    assert res.exit_code != 0
+    assert "empty note" in res.output
+
+
+def test_cli_read_unknown_card_errors(tmp_path: Path) -> None:
+    runner = CliRunner()
+    env = _env(tmp_path)
+    res = runner.invoke(
+        cli, ["push", "read", "--id", "ghost", "--session", "demo"], env=env
+    )
+    assert res.exit_code != 0
+    assert "no card" in res.output

--- a/tools/pocketshell/uv.lock
+++ b/tools/pocketshell/uv.lock
@@ -3,7 +3,8 @@ revision = 3
 requires-python = ">=3.11"
 
 [options]
-exclude-newer = "2026-12-31T23:00:00Z"
+exclude-newer = "2026-06-18T14:08:51.166593044Z"
+exclude-newer-span = "P7D"
 
 [[package]]
 name = "annotated-doc"

--- a/tools/pocketshell/uv.lock
+++ b/tools/pocketshell/uv.lock
@@ -315,7 +315,7 @@ wheels = [
 
 [[package]]
 name = "pocketshell"
-version = "0.4.14"
+version = "0.4.16"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
**v0.4.17** — the connection-stability + black-screen release.

## Headliners (the maintainer's pain list)
- **#945** — SSH keepalive (Terminus parity): rides through link blips instead of reconnecting. Verified red→green on the real transport, no #847 corruption.
- **#941 (B1)** — heal partial-black pane on switch/send ('sent a message → black').
- **#942 (B2)** — don't tear Conversation to black on a wedged-but-alive channel's empty detection.
- **#944** — bound the 6 unbounded exec reads (wall-clock watchdog) — no host wedge hangs.
- **#819** — conversation source re-anchored to route-true (no stale/sibling transcript).

## Also
#585 mic tap-lock · #921 Markdown tables · #943/#949 typed cards + verify journey · #839 durable-tree journey · #948 version-coupling CI guard · #743 background-grace de-flake + synthetic proof.

12 reviewed fixes, each red→green. Cut from the green RC tip after CI + release validation, then merged back. `pocketshell` package bumped to 0.4.17 to match (the #948 guard enforces this).