### PR TITLE
core-ssh: keepalive rides through starved replies while live data flows (#974 slice 1)

### DIFF
--- a/shared/core-ssh/src/integrationTest/java/com/pocketshell/core/ssh/KeepAliveIntegrationTest.kt
+++ b/shared/core-ssh/src/integrationTest/java/com/pocketshell/core/ssh/KeepAliveIntegrationTest.kt
@@ -213,6 +213,240 @@ class KeepAliveIntegrationTest {
     }
 
     @Test
+    fun liveShellDataProvesTheTransportAliveWithoutAKeepAliveReply() = runTest {
+        // Issue #974 (reproduce-first, the bug the maintainer hit on stable Wi-Fi):
+        // live `-CC`/shell data flowing over the transport MUST count as proof of
+        // life — exactly what the keepalive contract docstring promises ("any bytes
+        // from the server"). Before #974, lastInboundActivityNanos was bumped ONLY
+        // on a keepalive REPLY, so streaming shell output did NOT reset the keepalive
+        // miss counter: a few delayed/missed 30s replies on an otherwise-live link
+        // tore it down while data was still flowing.
+        //
+        // This drives the REAL RealSshSession against a real OpenSSH server: open a
+        // shell, push commands so the server streams decoded bytes back, drain them,
+        // and assert the session's raw inbound-activity timestamp ADVANCED across the
+        // read — WITHOUT ever sending a keepalive. RED on base (data never bumps the
+        // field); GREEN with the fix.
+        connectDirect().use { session ->
+            val real = session as RealSshSession
+            assertTrue("session should be connected", session.isConnected)
+
+            session.startShell().use { shell ->
+                // Capture the activity timestamp BEFORE any data and let it age a
+                // little so an advance is unambiguous (not the same nanosecond).
+                Thread.sleep(50)
+                val beforeNanos = real.lastInboundActivityNanosForTest()
+
+                // Push a command and DRAIN the server's streamed reply (the decoded
+                // `-CC`/shell bytes). No keepalive is sent anywhere in this block.
+                shell.stdin.write("echo ps974-live-data\n".toByteArray(Charsets.UTF_8))
+                shell.stdin.flush()
+
+                val sawData = AtomicBoolean(false)
+                val reader = thread(isDaemon = true) {
+                    val buf = ByteArray(4096)
+                    val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(8)
+                    while (System.nanoTime() < deadline) {
+                        if (shell.stdout.available() > 0) {
+                            val n = runCatching { shell.stdout.read(buf) }.getOrDefault(-1)
+                            if (n < 0) break
+                            if (n > 0) sawData.set(true)
+                        } else {
+                            Thread.sleep(20)
+                        }
+                    }
+                }
+                runBlocking { waitUntil(8_000) { sawData.get() } }
+                reader.join(2_000)
+
+                assertTrue(
+                    "the server must have streamed shell bytes back (test precondition)",
+                    sawData.get(),
+                )
+                val afterNanos = real.lastInboundActivityNanosForTest()
+                assertTrue(
+                    "live shell/`-CC` data must bump the inbound-activity timestamp " +
+                        "(honour the keepalive contract — 'any bytes from the server'). " +
+                        "before=$beforeNanos after=$afterNanos. RED on base: only a " +
+                        "keepalive REPLY bumped it, so streaming data did not prove the " +
+                        "transport alive (#974).",
+                    afterNanos > beforeNanos,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun keepAliveRidesThroughStarvedRepliesWhileShellDataFlows() {
+        // Issue #974 (the durable teardown-prevention gate — the exact stable-Wi-Fi
+        // signature #964/#970 missed): a link where the keepalive REPLY is starved
+        // (delayed/dropped past the ride-through window) but the `-CC` reader is
+        // STILL delivering bytes must NOT be declared dead. The #970 gate only
+        // injected sub-budget stalls and never this "replies starved WHILE data
+        // flows" case.
+        //
+        // We drive a synthetic TransportKeepAlive whose sendKeepAlive() ALWAYS
+        // misses (replies starved), isAlive() reads the real session, and
+        // lastInboundActivityNanos() reads the REAL session's inbound-activity
+        // timestamp (bumped by the live shell reader, the #974 fix). A background
+        // writer keeps pushing shell commands so the server keeps streaming bytes.
+        // GREEN with the fix: the loop's reset-on-inbound shortcut sees fresh data
+        // every interval, so despite EVERY ping missing, the peer is NEVER declared
+        // dead. RED on base: data never bumps the timestamp, so the loop pings,
+        // every ping misses, and it declares dead within countMax x interval.
+        val session = connectDirect()
+        val real = session as RealSshSession
+        val ioScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        val deadDeclared = AtomicBoolean(false)
+        val pingsMissed = AtomicInteger(0)
+        try {
+            session.startShell().use { shell ->
+                val holdMs = 12_000L
+                val deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(holdMs)
+
+                // Background: keep the server streaming bytes back, and DRAIN them
+                // (the read is what bumps the real inbound-activity timestamp).
+                val writer = ioScope.launch {
+                    while (isActive && System.nanoTime() < deadline) {
+                        runCatching {
+                            shell.stdin.write("echo ps974-tick\n".toByteArray(Charsets.UTF_8))
+                            shell.stdin.flush()
+                        }
+                        delay(300)
+                    }
+                }
+                val reader = ioScope.launch {
+                    val buf = ByteArray(4096)
+                    while (isActive && System.nanoTime() < deadline) {
+                        if (shell.stdout.available() > 0) {
+                            if (runCatching { shell.stdout.read(buf) }.getOrDefault(-1) < 0) break
+                        } else {
+                            delay(20)
+                        }
+                    }
+                }
+
+                // The synthetic keepalive: interval 1s, countMax 3 -> ~3s budget, so
+                // 12s of held link is 4x the budget. Replies are ALWAYS starved.
+                val keepAlive = TransportKeepAlive(
+                    io = object : TransportKeepAlive.KeepAliveIo {
+                        override fun isAlive(): Boolean = session.isConnected
+                        // The load-bearing wire: read the REAL session's
+                        // inbound-activity timestamp. With the #974 fix the live
+                        // shell reader bumps it; on base it stays stuck at construction.
+                        override fun lastInboundActivityNanos(): Long =
+                            real.lastInboundActivityNanosForTest()
+                        override suspend fun sendKeepAlive(): Boolean {
+                            // Replies are STARVED on this otherwise-live link.
+                            pingsMissed.incrementAndGet()
+                            return false
+                        }
+                        override fun onKeepAliveDead(consecutiveMisses: Int) {
+                            deadDeclared.set(true)
+                        }
+                    },
+                    intervalMs = 1_000L,
+                    countMax = 3,
+                )
+                keepAlive.start(ioScope)
+
+                // Hold the link with data flowing + replies starved for > 4x budget.
+                Thread.sleep(holdMs)
+
+                writer.cancel()
+                reader.cancel()
+                keepAlive.stop()
+
+                assertTrue(
+                    "the session must still be connected after riding through starved " +
+                        "keepalive replies WHILE shell data flowed",
+                    session.isConnected,
+                )
+                assertFalse(
+                    "a link with live `-CC`/shell data flowing must NOT be declared dead " +
+                        "just because the keepalive REPLY is starved — the streaming data " +
+                        "proves the transport alive (the keepalive's reset-on-inbound " +
+                        "shortcut). RED on base: data never bumped the timestamp so the " +
+                        "loop pinged, every ping missed, and it declared dead. (#974)",
+                    deadDeclared.get(),
+                )
+            }
+        } finally {
+            ioScope.cancel()
+            runCatching { session.close() }
+        }
+    }
+
+    @Test
+    fun genuinelyDeadHalfOpenPeerWithNoDataIsStillDeclaredDeadWithDataBumpHonoured() {
+        // Issue #974 class-coverage (the dual of the ride-through case — the fix must
+        // NOT make a truly-dead link look alive forever). A HALF-OPEN dead peer: no
+        // FIN, no inbound bytes, no keepalive reply. With the #974 inbound-activity
+        // bump in place, the synthetic loop's lastInboundActivityNanos() reads the
+        // REAL session's timestamp — which STAYS STALE because no server bytes arrive
+        // once the link is starved — so the reset-on-inbound shortcut does NOT fire,
+        // the loop pings, every ping misses, and the peer IS declared dead within
+        // countMax x interval. Proves the data-bump did not mask a genuine death.
+        val relay = PausableTcpRelay(sshHost, sshPort).also { it.start() }
+        try {
+            val session = connectThroughRelay(relay)
+            val real = session as RealSshSession
+            val ioScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+            val deadDeclaredAtNanos = AtomicLong(0L)
+            try {
+                val keepAlive = TransportKeepAlive(
+                    io = object : TransportKeepAlive.KeepAliveIo {
+                        override fun isAlive(): Boolean = session.isConnected
+                        // Read the REAL session timestamp (the #974 fix wiring). With
+                        // the link starved, NO inbound bytes arrive, so this stays
+                        // stale — the loop must still reach the dead-peer reaction.
+                        override fun lastInboundActivityNanos(): Long =
+                            real.lastInboundActivityNanosForTest()
+                        override suspend fun sendKeepAlive(): Boolean = session.sendKeepAlive()
+                        override fun onKeepAliveDead(consecutiveMisses: Int) {
+                            deadDeclaredAtNanos.compareAndSet(0L, System.nanoTime())
+                        }
+                    },
+                    intervalMs = 2_000L,
+                    countMax = 3,
+                )
+                keepAlive.start(ioScope)
+
+                runBlocking {
+                    assertTrue(
+                        "session healthy before the cut",
+                        waitUntil(8_000) { session.sendKeepAlive() },
+                    )
+                }
+
+                // Permanent HALF-OPEN starve: NO data, NO reply, NO FIN.
+                val cutAtNanos = System.nanoTime()
+                relay.pause()
+
+                runBlocking { waitUntil(40_000) { deadDeclaredAtNanos.get() != 0L } }
+                assertTrue(
+                    "a genuinely dead half-open peer (no data, no reply) must STILL be " +
+                        "declared dead even with the #974 inbound-activity bump in place — " +
+                        "the fix must not make a truly-dead link look alive forever",
+                    deadDeclaredAtNanos.get() != 0L,
+                )
+                val detectMs = TimeUnit.NANOSECONDS.toMillis(deadDeclaredAtNanos.get() - cutAtNanos)
+                assertTrue(
+                    "dead-peer detection ($detectMs ms) must land within a generous budget " +
+                        "ceiling (3 misses x (interval 2s + reply timeout 5s) ~21s worst case).",
+                    detectMs in 0..35_000,
+                )
+                keepAlive.stop()
+            } finally {
+                ioScope.cancel()
+                runCatching { session.close() }
+            }
+        } finally {
+            relay.close()
+        }
+    }
+
+    @Test
     fun transientGapShorterThanBudgetIsRiddenThrough() {
         // RIDE-THROUGH (the Terminus behaviour, the red->green core): pause the
         // link for a window SHORTER than the keepalive budget, then resume. The

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshSession.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshSession.kt
@@ -74,14 +74,63 @@ internal class RealSshSession(
 
     /**
      * Monotonic ([System.nanoTime]) timestamp of the most recent inbound
-     * transport activity — bumped on every successful keepalive reply (issue
-     * #945). The keepalive loop reads this to SKIP a ping when the link answered
-     * within the last interval (OpenSSH reset-on-server-traffic semantics), so a
-     * busy link is self-evidently alive and we never ping a channel that just
-     * round-tripped.
+     * transport activity — bumped on a successful keepalive reply (issue #945)
+     * AND on ANY decoded application bytes the server sends back over the
+     * transport: the live `-CC` control-mode reader's output, an exec/list/cat
+     * round-trip's stdout/stderr, and each `tail -F` line (issue #974). The
+     * keepalive loop reads this to SKIP a ping when the link produced server
+     * bytes within the last interval (OpenSSH reset-on-server-traffic
+     * semantics), so a busy link is self-evidently alive and we never ping —
+     * nor tear down — a channel that is actively streaming.
+     *
+     * ## Issue #974 — honour the contract: live data proves the transport alive
+     *
+     * Before #974 this was bumped at EXACTLY ONE site — only on a keepalive
+     * global-request reply ([sendKeepAlive]) — even though the contract docstring
+     * ([TransportKeepAlive.KeepAliveIo.lastInboundActivityNanos]) promised it
+     * tracks "any bytes from the server." That gap meant live `-CC` data did NOT
+     * count as proof of life: on a stable-but-jittery Wi-Fi link, a few
+     * delayed/missed 30s keepalive replies (power-save / bufferbloat straddling
+     * three ping windows) could trip the keepalive's `countMax` death budget and
+     * tear a link the user saw as perfectly stable — WHILE the `-CC` reader was
+     * still delivering bytes. And because #964's
+     * [isTransportProvenAliveWithinKeepAliveWindow] reads the SAME field, the
+     * `LivenessProbe` deferral collapsed at the same instant. Recording inbound
+     * data here closes both: real server bytes legitimately reset the miss
+     * counter and keep [isTransportProvenAliveWithinKeepAliveWindow] true, so a
+     * link with live data is never spuriously declared dead.
+     *
+     * Bound to DECODED application bytes from the server (the channel streams
+     * sshj already decrypted/decoded), NOT raw socket reads — a genuinely
+     * half-open peer that sends no bytes still produces no activity here, so the
+     * keepalive's own ride-through budget still catches a truly-dead link
+     * promptly (the fix must not make a dead link look alive forever).
      */
     @Volatile
     private var lastInboundActivityNanos: Long = System.nanoTime()
+
+    /**
+     * Record inbound transport activity (issue #974). Called from EVERY path
+     * that reads decoded application bytes the server sent back — the `-CC`
+     * shell reader, exec/list/cat round-trips, and `tail -F` lines — so live
+     * data proves the transport alive to the keepalive loop's reset-on-inbound
+     * shortcut and to #964's [isTransportProvenAliveWithinKeepAliveWindow]
+     * deferral oracle, exactly as the [TransportKeepAlive.KeepAliveIo] contract
+     * promises. Cheap volatile store, safe to call from any reader thread.
+     */
+    private fun recordInboundActivity() {
+        lastInboundActivityNanos = System.nanoTime()
+    }
+
+    /**
+     * Issue #974 — `core-ssh`-internal accessor on the raw inbound-activity
+     * timestamp so [KeepAliveIntegrationTest] can drive a synthetic
+     * [TransportKeepAlive] off the SAME field the production keepalive reads,
+     * proving that live `-CC`/exec data bumps it (the reproduce-first gate). Not
+     * part of the public [SshSession] surface — production code uses the
+     * keepalive loop + [isTransportProvenAliveWithinKeepAliveWindow] instead.
+     */
+    internal fun lastInboundActivityNanosForTest(): Long = lastInboundActivityNanos
 
     /**
      * Why this session's transport went down (issue #969 — reconnect
@@ -306,6 +355,11 @@ internal class RealSshSession(
                         val stdout = liveCommand.inputStream.readBytes().toString(Charsets.UTF_8)
                         val stderr = liveCommand.errorStream.readBytes().toString(Charsets.UTF_8)
                         liveCommand.join()
+                        // Issue #974: a completed exec round-trip is decoded server
+                        // bytes — proof the transport is alive. Record it so a busy
+                        // exec workload keeps the keepalive's inbound-activity
+                        // timestamp fresh (honouring the contract).
+                        recordInboundActivity()
                         // sshj returns null exitStatus when the server didn't send
                         // one (e.g. signal-killed). Map to -1 so the caller can
                         // still tell it wasn't a clean 0.
@@ -470,6 +524,11 @@ internal class RealSshSession(
                             logTailRecoverableFailure(path, e)
                             return@launch
                         }
+                        // Issue #974: a tail line is decoded server bytes — proof
+                        // the transport is alive. Record it BEFORE the (possibly
+                        // slow) onLine callback so a steadily-tailing agent log
+                        // keeps the keepalive's inbound-activity timestamp fresh.
+                        recordInboundActivity()
                         onLine(line)
                         // Suspend per-line so a cancelled tail job exits
                         // promptly even when the remote is gushing output.
@@ -573,6 +632,11 @@ internal class RealSshSession(
                     sessionChannel = sessionChannel,
                     shell = shell,
                     dispatcher = dispatcher,
+                    // Issue #974: the `-CC` control-mode reader is the highest-rate
+                    // inbound stream on a foregrounded session — every byte it
+                    // decodes proves the transport alive, so record it as inbound
+                    // activity (honouring the keepalive contract).
+                    onInboundActivity = ::recordInboundActivity,
                 )
             } catch (t: Throwable) {
                 runCatching { sessionChannel.close() }

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshShell.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshShell.kt
@@ -32,6 +32,15 @@ internal class RealSshShell(
     private val sessionChannel: Session,
     private val shell: Session.Shell,
     private val dispatcher: TransportDispatcher,
+    /**
+     * Issue #974 — invoked on EVERY successful (>0 bytes) read from [stdout] /
+     * [stderr] so the live `-CC` control-mode reader's decoded bytes prove the
+     * transport alive. [RealSshSession] passes `::recordInboundActivity`, which
+     * bumps the keepalive's inbound-activity timestamp — the signal the keepalive
+     * loop's reset-on-inbound shortcut and #964's deferral oracle read. Defaults
+     * to a no-op so the unit fakes that construct a shell need not supply it.
+     */
+    private val onInboundActivity: () -> Unit = {},
 ) : SshShell {
 
     /**
@@ -42,14 +51,26 @@ internal class RealSshShell(
      */
     private val serializedStdin: OutputStream = DispatchedOutputStream(shell.outputStream, dispatcher)
 
+    /**
+     * stdout/stderr wrapped so every successful read records inbound transport
+     * activity (issue #974). The READ side is NOT dispatched (it runs on the
+     * `-CC` reader coroutine, mirroring sshj's Reader-thread split) — the wrapper
+     * only OBSERVES the byte count to bump the keepalive's inbound-activity
+     * timestamp, never serialises the read.
+     */
+    private val activityStdout: InputStream =
+        InboundActivityInputStream(shell.inputStream, onInboundActivity)
+    private val activityStderr: InputStream =
+        InboundActivityInputStream(shell.errorStream, onInboundActivity)
+
     override val stdin: OutputStream
         get() = serializedStdin
 
     override val stdout: InputStream
-        get() = shell.inputStream
+        get() = activityStdout
 
     override val stderr: InputStream
-        get() = shell.errorStream
+        get() = activityStderr
 
     override fun close() {
         // Order matters: close the shell-level resource first so any in-flight
@@ -161,5 +182,53 @@ private class DispatchedOutputStream(
         // (RealSshShell.close / RealSshSession.close). Closing the stdin stream
         // directly is not part of the public SshShell contract, so this is a
         // no-op to avoid a teardown ordering race with the dispatcher.
+    }
+}
+
+/**
+ * [InputStream] decorator that fires [onActivity] on every successful read of
+ * one or more decoded bytes from [delegate] (issue #974). The `-CC` reader loop
+ * reads off [RealSshShell.stdout]; each non-empty read is decoded application
+ * data from the server — positive proof the transport is alive — so it bumps the
+ * keepalive's inbound-activity timestamp via this callback. A `-1` (EOF) or a
+ * `0`-length read is NOT activity (no server bytes arrived), so it does not bump.
+ *
+ * Pure observer: it never buffers, transforms, or serialises the read — it only
+ * counts. So it is safe on the un-dispatched read side and adds a single cheap
+ * volatile store per read.
+ */
+private class InboundActivityInputStream(
+    private val delegate: InputStream,
+    private val onActivity: () -> Unit,
+) : InputStream() {
+
+    override fun read(): Int {
+        val b = delegate.read()
+        if (b >= 0) onActivity()
+        return b
+    }
+
+    override fun read(b: ByteArray): Int {
+        val n = delegate.read(b)
+        if (n > 0) onActivity()
+        return n
+    }
+
+    override fun read(b: ByteArray, off: Int, len: Int): Int {
+        val n = delegate.read(b, off, len)
+        if (n > 0) onActivity()
+        return n
+    }
+
+    override fun available(): Int = delegate.available()
+
+    override fun skip(n: Long): Long = delegate.skip(n)
+
+    override fun close() {
+        // Read-side close is owned by RealSshShell.close / RealSshSession.close
+        // (the channel teardown). Delegate the close so a caller that closes the
+        // stream directly still tears the underlying channel stream down, but it
+        // is idempotent at the sshj layer.
+        delegate.close()
     }
 }

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/TransportKeepAliveTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/TransportKeepAliveTest.kt
@@ -128,6 +128,85 @@ class TransportKeepAliveTest {
     }
 
     @Test
+    fun `inbound data flowing while keepalive replies are starved never declares dead`() = runTest {
+        // Issue #974 — the MISSING #970 signature: a stable-but-jittery link where
+        // every keepalive REPLY is starved (delayed/dropped past the ride-through
+        // window) but the `-CC` reader is STILL delivering bytes. The reset-on-inbound
+        // shortcut must keep the link alive off the live data, NOT tear it down on
+        // the missed replies. The #970 gate only injected sub-budget stalls and never
+        // this case.
+        //
+        // RED on base (production): RealSshSession bumped lastInboundActivityNanos
+        // ONLY on a keepalive reply, so streaming `-CC` data never reset the miss
+        // counter — exactly the spurious stable-Wi-Fi teardown. GREEN with the fix:
+        // the live reader bumps the timestamp every interval, so even though every
+        // ping misses, the loop SKIPS the ping (inbound activity) and never declares
+        // dead. Here we model the fix by keeping lastActivity fresh each tick, which
+        // is precisely what the production `-CC` reader now does.
+        val io = FakeIo()
+        val keepAlive = TransportKeepAlive(io = io, intervalMs = 1_000L, countMax = 3)
+        keepAlive.start(this)
+
+        // Replies are ALWAYS starved — if the loop ever pinged it would miss.
+        io.pingResult = false
+        // Hold the link for FOUR budgets (12 ticks, budget = 3) with inbound DATA
+        // arriving fresh every tick (the live `-CC` reader). The loop must ride
+        // through indefinitely on the data alone.
+        repeat(12) {
+            io.lastActivityNanos = System.nanoTime() // live data just arrived
+            advanceTimeBy(1_000L)
+            runCurrent()
+        }
+
+        assertEquals(
+            "a link with live inbound data must never be declared dead even when every " +
+                "keepalive reply is starved — the streaming data proves it alive (#974)",
+            null,
+            io.deadDeclaredWith,
+        )
+        assertEquals(
+            "the loop must SKIP every ping while inbound data is fresh (reset-on-inbound), " +
+                "so a busy link with starved replies sends ZERO pings",
+            0,
+            io.pingsSent,
+        )
+        keepAlive.stop()
+    }
+
+    @Test
+    fun `data stops AND replies starved - a genuinely dead link is still declared dead`() = runTest {
+        // Issue #974 class-coverage (the dual): once the inbound data ALSO stops
+        // (genuine half-open death — no bytes, no reply), the data-bump no longer
+        // fires, the reset-on-inbound shortcut goes silent, and the loop MUST still
+        // declare the peer dead within countMax. The fix must not make a truly-dead
+        // link look alive forever.
+        val io = FakeIo()
+        val keepAlive = TransportKeepAlive(io = io, intervalMs = 1_000L, countMax = 3)
+        keepAlive.start(this)
+
+        // Phase 1: data flowing + replies starved -> ridden through (no death).
+        io.pingResult = false
+        repeat(5) {
+            io.lastActivityNanos = System.nanoTime()
+            advanceTimeBy(1_000L); runCurrent()
+        }
+        assertEquals("ridden through while data flowed", null, io.deadDeclaredWith)
+
+        // Phase 2: data STOPS (no more bumps) and replies stay starved -> dead.
+        io.lastActivityNanos = Long.MIN_VALUE // no inbound activity any more
+        advanceTimeBy(1_000L); runCurrent() // miss 1
+        advanceTimeBy(1_000L); runCurrent() // miss 2
+        advanceTimeBy(1_000L); runCurrent() // miss 3 -> declare dead
+        assertEquals(
+            "once inbound data ALSO stops, a genuinely dead link must still be declared " +
+                "dead within countMax — the #974 data-bump must not mask a real death",
+            3,
+            io.deadDeclaredWith,
+        )
+        keepAlive.stop()
+    }
+
+    @Test
     fun `a single miss between successes never declares dead - counter resets`() = runTest {
         val io = FakeIo()
         val keepAlive = TransportKeepAlive(io = io, intervalMs = 1_000L, countMax = 3)


### PR DESCRIPTION
Fixes the stable-wifi spurious-drop root cause from #974 (Slice 1 of 2).

## Problem
`lastInboundActivityNanos` — driving both the keepalive reset-on-inbound shortcut and #964's `transportProvenAliveRecently()` deferral — was bumped at exactly one site: a successful keepalive global-request reply. Live tmux `-CC` data never proved the transport alive, so a few delayed/missed 30s replies on a stable-but-jittery wifi link tore a link the user saw as stable.

## Fix
Record inbound activity on every decoded server-byte read path (`InboundActivityInputStream` on the `-CC` shell stdout/stderr, exec round-trips, `tail -F` lines), bound to decoded application bytes so a genuinely half-open peer still trips the death budget promptly. Adds the data-flowing-while-replies-starved ride-through signature the #970 gate was missing.

## Verification (reviewer-reproduced red→green this run)
- Reverting the bump to a no-op: `keepAliveRidesThroughStarvedRepliesWhileShellDataFlows` and `liveShellDataProvesTheTransportAliveWithoutAKeepAliveReply` FAIL (link torn while data flowed). Restored: pass.
- Class coverage: data-flowing → zero teardown; genuinely-dead (no bytes, no reply) → still declared dead in budget.
- 8/8 `KeepAliveIntegrationTest` (incl. 100s soak) + 9/9 unit, 0 skipped. CI runs `:shared:core-ssh:integrationTest` (tests.yml).

## Scope
Slice 1 (root drop) only. The attachment-upload queue + auto-flush ACs (the 'No live SSH session' banner) are Slice 2 and remain open — **this PR does not close #974.**

Refs #974, #964, #970. Reviewer APPROVED: https://github.com/alexeygrigorev/pocketshell/issues/974#issuecomment-4806476895