### PR TITLE
projects: guard new-session launch against name collision (#976)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/projects/FolderListGateway.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListGateway.kt
@@ -6,6 +6,7 @@ import com.pocketshell.app.repos.ReposListResult
 import com.pocketshell.app.repos.ReposJsonParser
 import com.pocketshell.app.sessions.ActiveTmuxClients
 import com.pocketshell.app.sessions.HostTmuxSessionListParser
+import com.pocketshell.app.sessions.launchTargetCollisionMessage
 import com.pocketshell.app.sessions.remoteStartDirectoryExists
 import com.pocketshell.app.sessions.startDirectoryMissingMessage
 import com.pocketshell.core.agents.AgentKind
@@ -1206,6 +1207,34 @@ class SshFolderListGateway internal constructor(
         }
         val quotedName = shellQuote(sessionName)
         val quotedCwd = shellQuote(cwd)
+        // Issue #976: routing-safety guard for a LAUNCH create (startCommand
+        // set). The create commands (`create-detached` / `new-session -A`) are
+        // intentionally idempotent — re-picking the same folder ATTACHES to the
+        // already-open same-named session rather than erroring (#642/#429). That
+        // idempotency is correct for a plain re-pick, but it is the misroute trap
+        // for an agent/shell LAUNCH: session names are a pure path-prefix shared
+        // by agent AND shell (#642), so a new Codex launch in a dir that already
+        // has an open Claude session derives the SAME name. When the picker's
+        // de-dupe list is empty (a #974 connection drop / still-loading list
+        // collapses `existingNames` to ∅, so the `-2`/`-3` suffix is skipped),
+        // the name collides, the idempotent create is a no-op REUSE of the live
+        // session, and `send-keys -t '<name>'` types the launch line straight
+        // into the currently-attached pane (the maintainer's #976 report).
+        //
+        // So before creating for a launch, probe whether the target name already
+        // exists. If it does, the launch must NOT proceed — typing into a
+        // pre-existing (possibly current) pane is exactly the #968-class misroute
+        // we refuse. Surface a clear error so the caller can re-derive against a
+        // fresh list / suffix instead of silently leaking keystrokes. A plain
+        // shell/no-launch create keeps its idempotent attach-or-create semantics.
+        if (startCommand != null) {
+            val hasSession = session.exec(
+                pathAware("tmux has-session -t $quotedName"),
+            )
+            if (hasSession.exitCode == 0) {
+                throw RuntimeException(launchTargetCollisionMessage(sessionName))
+            }
+        }
         val createResult = session.exec(
             pathAware(cappedCreateSessionCommand(quotedName, quotedCwd)),
         )

--- a/app/src/main/java/com/pocketshell/app/sessions/TmuxSessionCreation.kt
+++ b/app/src/main/java/com/pocketshell/app/sessions/TmuxSessionCreation.kt
@@ -42,6 +42,23 @@ internal fun startDirectoryMissingMessage(
     "Couldn't create $sessionName: start folder does not exist: " +
         startDirectory.trim().ifBlank { DEFAULT_TMUX_START_DIRECTORY }
 
+/**
+ * Issue #976: a LAUNCH (agent/shell start command) tried to create a session
+ * whose derived name already belongs to a live session on the host. The
+ * idempotent create would REUSE that session, and `send-keys -t '<name>'` would
+ * then type the launch command into the existing (possibly currently-attached)
+ * pane — the misroute the maintainer reported. We refuse rather than leak the
+ * keystrokes into the wrong pane (the #968-class "never act against the current
+ * target" invariant). The de-dupe list was empty (e.g. a #974 connection drop /
+ * still-loading session list), so the `-2`/`-3` suffix that would have produced
+ * a fresh name was skipped; surfacing this prompts a retry once the list is
+ * known.
+ */
+internal fun launchTargetCollisionMessage(sessionName: String): String =
+    "Couldn't launch a new session: '$sessionName' is already open, so the " +
+        "launch would have been typed into the existing session. Reconnect / " +
+        "let the session list finish loading, then try again."
+
 internal fun remoteStartDirectoryExistsCommand(startDirectory: String): String {
     val resolved = startDirectory.trim().ifBlank { DEFAULT_TMUX_START_DIRECTORY }
     return """

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
@@ -1,5 +1,6 @@
 package com.pocketshell.app.tmux
 
+import android.widget.Toast
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.CubicBezierEasing
@@ -1142,6 +1143,16 @@ public fun TmuxSessionScreen(
     LaunchedEffect(Unit) {
         viewModel.sessionEnded.collect { endedSessionName ->
             onSessionEnded(endedSessionName)
+        }
+    }
+
+    // Issue #976: surface a refused new-session LAUNCH (e.g. the gateway's
+    // name-collision guard) so it fails VISIBLY. The launch line was NOT typed
+    // into the current pane and no navigation happened; a toast tells the user
+    // why nothing opened so they can retry once the session list is known.
+    LaunchedEffect(Unit) {
+        viewModel.sessionCreateError.collect { message ->
+            Toast.makeText(context, message, Toast.LENGTH_LONG).show()
         }
     }
 
@@ -2298,29 +2309,47 @@ public fun TmuxSessionScreen(
                     // (the gateway/tmux has no server-side de-dupe, so a
                     // duplicate name fails the create). This mirrors the host
                     // screen, which passes `knownSessionNames(state)`.
-                    val knownNames =
-                        (sessionPickerState as? HostTmuxSessionPickerState.Ready)
-                            ?.rows
-                            ?.map { it.name }
-                            ?.toSet()
-                            .orEmpty()
-                    val newName = derivedSessionName(
-                        choice = choice,
-                        homeDirectory = conventionalRemoteHome(user),
-                        existingNames = knownNames,
-                    )
-                    viewModel.createSession(
-                        name = newName,
-                        cwd = choice.startDirectory,
-                        startCommand = choice.startCommand(
-                            newSessionClaudeProfiles,
-                            newSessionCodexProfiles,
-                        ),
-                        chosenKind = choice.sessionAgentKind,
-                        onResolved = { resolved ->
-                            onOpenTmuxSession(resolved, choice.startDirectory)
-                        },
-                    )
+                    //
+                    // Issue #976: the de-dupe ONLY works when this list is
+                    // populated. If the picker is NOT `Ready` (a #974 connection
+                    // drop / still-loading list flips it to Loading/ConnectError),
+                    // the list collapses to ∅, the `-2`/`-3` suffix is skipped,
+                    // the derived name COLLIDES with the live same-folder session,
+                    // and the launch send-keys would type into that existing pane.
+                    // So do NOT proceed with a possibly-colliding name when the
+                    // list is unknown — block with a clear message and let the
+                    // user retry once the list is `Ready`. (The gateway's
+                    // has-session guard is the server-side safety net; this avoids
+                    // even attempting the collision-prone create.)
+                    val readyPicker =
+                        sessionPickerState as? HostTmuxSessionPickerState.Ready
+                    if (readyPicker == null) {
+                        Toast.makeText(
+                            context,
+                            "Session list isn't loaded yet — reconnect or wait " +
+                                "for it to finish, then start the new session again.",
+                            Toast.LENGTH_LONG,
+                        ).show()
+                    } else {
+                        val knownNames = readyPicker.rows.map { it.name }.toSet()
+                        val newName = derivedSessionName(
+                            choice = choice,
+                            homeDirectory = conventionalRemoteHome(user),
+                            existingNames = knownNames,
+                        )
+                        viewModel.createSession(
+                            name = newName,
+                            cwd = choice.startDirectory,
+                            startCommand = choice.startCommand(
+                                newSessionClaudeProfiles,
+                                newSessionCodexProfiles,
+                            ),
+                            chosenKind = choice.sessionAgentKind,
+                            onResolved = { resolved ->
+                                onOpenTmuxSession(resolved, choice.startDirectory)
+                            },
+                        )
+                    }
                 },
             )
         }

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -596,6 +596,20 @@ public class TmuxSessionViewModel @Inject constructor(
         _sessionEnded.asSharedFlow()
 
     /**
+     * Issue #976: a new-session LAUNCH that the gateway refused (e.g. the
+     * derived name collides with an already-open session, so sending the launch
+     * line would type it into the existing/current pane). The Screen collects
+     * this to surface the failure to the user instead of letting the launch
+     * silently no-op — the launch command is NEVER leaked into the current pane,
+     * and the user is told why (mirrors #968's "fail visibly, never act against
+     * the current target").
+     */
+    private val _sessionCreateError: MutableSharedFlow<String> =
+        MutableSharedFlow(extraBufferCapacity = 1)
+    public val sessionCreateError: SharedFlow<String> =
+        _sessionCreateError.asSharedFlow()
+
+    /**
      * Issue #626: called by the Screen when the unified pager settles on a
      * page. If the pane belongs to a different session, emit a
      * [sessionSwitchRequest] so the Screen triggers a warm switch.
@@ -13581,6 +13595,17 @@ public class TmuxSessionViewModel @Inject constructor(
                         ISSUE_464_KILL_TAG,
                         "create-session-failed host=${current.hostId} name=${creation.sessionName} " +
                             "err=${error.javaClass.simpleName}: ${error.message}",
+                    )
+                    // Issue #976: a refused launch (e.g. name-collision guard in
+                    // the gateway) must FAIL VISIBLY — never silently swallow it,
+                    // or the user is left wondering why nothing happened. The
+                    // launch line was NOT sent into the current pane; tell them
+                    // why so they can retry once the session list is known. We do
+                    // NOT call onResolved here, so no navigation/attach to a wrong
+                    // session occurs.
+                    _sessionCreateError.tryEmit(
+                        error.message?.takeIf { it.isNotBlank() }
+                            ?: "Couldn't create the session.",
                     )
                 },
             )

--- a/app/src/test/java/com/pocketshell/app/projects/FolderListGatewayFallbackTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/FolderListGatewayFallbackTest.kt
@@ -419,6 +419,188 @@ class FolderListGatewayFallbackTest {
         assertTrue(session.execCommands.any { it.contains("send-keys") })
     }
 
+    // --- Issue #976: a LAUNCH must never type into an already-open session ---
+
+    @Test
+    fun agentLaunchIntoAnAlreadyOpenSameNameSessionRefusesAndDoesNotSendKeys() = runTest {
+        // The #976 misroute: a new Codex launch in a directory that ALREADY has
+        // an open session derives the SAME path-prefix name. With an empty
+        // de-dupe list (a #974 drop / still-loading picker collapsed
+        // `existingNames` to ∅), the suffix is skipped and the idempotent create
+        // would REUSE the live session — `send-keys -t '<name>'` then types the
+        // launch line into the currently-attached pane. The gateway must probe
+        // `tmux has-session` first, see the name is taken, and REFUSE: no create,
+        // no send-keys, a surfaced error. (Red on base: base has no has-session
+        // guard, so the create no-ops and send-keys fires into the existing pane.)
+        val session = CreateSessionFake(
+            results = listOf(
+                // The session already exists on the host → has-session exits 0.
+                CreateSessionFake.Rule(match = "has-session", result = ok()),
+                CreateSessionFake.Rule(match = "create-detached", result = ok()),
+                CreateSessionFake.Rule(match = "pocketshell agent --help", result = ok()),
+                CreateSessionFake.Rule(match = "send-keys", result = ok()),
+            ),
+        )
+        val gateway = SshFolderListGateway()
+
+        val ex = runCatching {
+            gateway.createSessionOnSession(
+                session = session,
+                sessionName = SESSION_NAME,
+                cwd = CWD,
+                startCommand = "pocketshell agent codex --dir '/home/me/proj dir'",
+            )
+        }.exceptionOrNull()
+
+        assertTrue("a colliding launch must surface an error, got $ex", ex is RuntimeException)
+        // The load-bearing assertion: the launch line was NEVER typed into the
+        // existing (current) pane.
+        assertFalse(
+            "must NOT send-keys the launch into an already-open session",
+            session.execCommands.any { it.contains("send-keys") },
+        )
+        // It must not have created/attached either — the create is skipped once
+        // the collision is detected.
+        assertFalse(
+            "must NOT run the idempotent create once a collision is detected",
+            session.execCommands.any { it.contains("create-detached") },
+        )
+        // It DID probe for the collision.
+        assertTrue(
+            "must probe has-session before launching",
+            session.execCommands.any { it.contains("has-session") },
+        )
+    }
+
+    @Test
+    fun agentLaunchWithSuffixedFreshNameCreatesAndSendsKeys() = runTest {
+        // Class-cover (b): a legitimate same-dir second session has already been
+        // given a `-2` suffix by the deriver (picker was Ready), so the name is
+        // genuinely FREE on the host. has-session exits non-zero, the create runs,
+        // and send-keys fires into the NEW session — the happy path still works.
+        val freshName = "$SESSION_NAME-2"
+        val session = CreateSessionFake(
+            results = listOf(
+                // -2 name is free → has-session exits non-zero.
+                CreateSessionFake.Rule(
+                    match = "has-session",
+                    result = ExecResult(stdout = "", stderr = "can't find session", exitCode = 1),
+                ),
+                CreateSessionFake.Rule(match = "create-detached", result = ok()),
+                CreateSessionFake.Rule(match = "pocketshell agent --help", result = ok()),
+                CreateSessionFake.Rule(match = "send-keys", result = ok()),
+            ),
+        )
+        val gateway = SshFolderListGateway()
+
+        gateway.createSessionOnSession(
+            session = session,
+            sessionName = freshName,
+            cwd = CWD,
+            startCommand = "pocketshell agent codex --dir '/home/me/proj dir'",
+        )
+
+        assertTrue(
+            "a fresh suffixed name must create the session",
+            session.execCommands.any { it.contains("create-detached") },
+        )
+        val sendKeys = session.execCommands.single { it.contains("send-keys") }
+        assertTrue(
+            "send-keys must target the fresh suffixed name: $sendKeys",
+            sendKeys.contains("tmux send-keys -t ${escapedInWrapper(freshName)}"),
+        )
+    }
+
+    @Test
+    fun agentLaunchIntoAFreshDistinctDirNameCreatesAndSendsKeys() = runTest {
+        // Class-cover (c): a distinct directory derives a distinct name that does
+        // not collide with any open session — has-session exits non-zero, create
+        // runs, send-keys fires. No regression for the no-collision common case.
+        val session = CreateSessionFake(
+            results = listOf(
+                CreateSessionFake.Rule(
+                    match = "has-session",
+                    result = ExecResult(stdout = "", stderr = "no session", exitCode = 1),
+                ),
+                CreateSessionFake.Rule(match = "create-detached", result = ok()),
+                CreateSessionFake.Rule(match = "pocketshell agent --help", result = ok()),
+                CreateSessionFake.Rule(match = "send-keys", result = ok()),
+            ),
+        )
+        val gateway = SshFolderListGateway()
+
+        gateway.createSessionOnSession(
+            session = session,
+            sessionName = "var-log",
+            cwd = "/var/log",
+            startCommand = "pocketshell agent claude --dir '/var/log'",
+        )
+
+        assertTrue(session.execCommands.any { it.contains("create-detached") })
+        assertTrue(session.execCommands.any { it.contains("send-keys") })
+    }
+
+    @Test
+    fun shellLaunchIntoAnAlreadyOpenSameNameSessionRefusesAndDoesNotSendKeys() = runTest {
+        // Class-cover: the same collision guard applies to a SHELL launch (the
+        // path-prefix name is shared by agent AND shell — #642). A shell start
+        // command into an already-open same-name session must also refuse rather
+        // than type into the existing pane.
+        val session = CreateSessionFake(
+            results = listOf(
+                CreateSessionFake.Rule(match = "has-session", result = ok()),
+                CreateSessionFake.Rule(match = "create-detached", result = ok()),
+                CreateSessionFake.Rule(match = "send-keys", result = ok()),
+            ),
+        )
+        val gateway = SshFolderListGateway()
+
+        val ex = runCatching {
+            gateway.createSessionOnSession(
+                session = session,
+                sessionName = SESSION_NAME,
+                cwd = CWD,
+                startCommand = "htop",
+            )
+        }.exceptionOrNull()
+
+        assertTrue("a colliding shell launch must surface an error, got $ex", ex is RuntimeException)
+        assertFalse(
+            "must NOT send-keys a shell launch into an already-open session",
+            session.execCommands.any { it.contains("send-keys") },
+        )
+    }
+
+    @Test
+    fun plainRepickWithNoLaunchKeepsIdempotentAttachOrCreate() = runTest {
+        // A plain re-pick (no startCommand) must KEEP the idempotent
+        // attach-or-create semantics (#642/#429) — it does NOT probe has-session
+        // and does NOT refuse on an existing name (the collision guard is scoped
+        // to the LAUNCH case only, so the re-pick UX is unchanged).
+        val session = CreateSessionFake(
+            results = listOf(
+                CreateSessionFake.Rule(match = "create-detached", result = ok()),
+            ),
+        )
+        val gateway = SshFolderListGateway()
+
+        gateway.createSessionOnSession(
+            session = session,
+            sessionName = SESSION_NAME,
+            cwd = CWD,
+            startCommand = null,
+        )
+
+        assertFalse(
+            "a no-launch re-pick must not probe has-session",
+            session.execCommands.any { it.contains("has-session") },
+        )
+        assertTrue(
+            "a no-launch re-pick must still run the idempotent create",
+            session.execCommands.any { it.contains("create-detached") },
+        )
+    }
+
     /**
      * A configurable fake [SshSession] for the create-session path: it records
      * every command, returns the start-directory-exists probe as success, and

--- a/app/src/test/java/com/pocketshell/app/projects/SessionNameDerivationTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/SessionNameDerivationTest.kt
@@ -219,6 +219,23 @@ class SessionNameDerivationTest {
     }
 
     @Test
+    fun emptyExistingNamesDerivesTheBareCollidingBase() {
+        // Issue #976: when the picker isn't `Ready` (a #974 drop / still-loading
+        // list) the de-dupe input collapses to ∅, so the deriver CANNOT add a
+        // `-2` suffix — it returns the bare base, which COLLIDES with the live
+        // same-folder session. This is the input that triggers the misroute; the
+        // server-side has-session guard in the gateway is what then refuses the
+        // launch instead of typing it into the existing pane.
+        val name = SessionNameDerivation.derive(
+            startDirectory = "~/git/pocketshell",
+            homeDirectory = home,
+            agentCommand = "codex",
+            existingNames = emptySet(),
+        )
+        assertEquals("git-pocketshell", name)
+    }
+
+    @Test
     fun collisionWalksUpUntilFreeSlot() {
         val name = SessionNameDerivation.derive(
             startDirectory = "/var/log",


### PR DESCRIPTION
Fixes #976 — a new-session launch command typed into the CURRENT pane instead of opening a new window.

## Root cause
Session names are path-derived and shared by agent+shell, so a new Codex session in a dir with an already-open Claude session derived the SAME name. The de-dupe that suffixes (`-2`) collapsed to empty when the picker wasn't `Ready` (a #974 drop / still-loading list). The idempotent create (`new-session -A`) then REUSED the existing session and `send-keys` fired with no 'did I create a NEW session?' guard → the launch line landed in the current pane.

## Fix
- `has-session` guard before the idempotent create when a launch is requested → REFUSE on collision (no create, no send-keys); surface a visible `sessionCreateError` instead of silently leaking into the current pane.
- Block the launch when the picker isn't `Ready` rather than creating with an unknown existing-name set.
- Legitimate same-dir second sessions still get a `-2` suffix and create a genuinely new session (reviewer-verified non-regression, JVM + on-device).

## Verification (reviewer reproduced red→green this run)
- Reverting the gateway guard → only the two collision tests fail (the misroute); restored → 42/42 pass, 0 skipped.
- Critical non-regression: legit same-dir `-2` sessions NOT spuriously refused — proven JVM + #898 in-session collision Docker journey (4 viewport screenshots).
- Visible failure: `onResolved` only fires on success; failure → toast, no navigation.

Sibling of #968 (attachment misroute class). Reviewer APPROVED: https://github.com/alexeygrigorev/pocketshell/issues/976#issuecomment-4806542838