### PR TITLE
tmux: restore Conversation toggle for a live agent masked by a stale shell verdict (#975)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/tmux/ConversationToggleVisibleForLiveAgentInShellRecordedSessionDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/ConversationToggleVisibleForLiveAgentInShellRecordedSessionDockerTest.kt
@@ -5,14 +5,15 @@ import android.os.SystemClock
 import android.view.View
 import android.view.ViewGroup
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.ViewModelProvider
 import androidx.room.Room
-import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.pocketshell.app.MainActivity
@@ -22,6 +23,8 @@ import com.pocketshell.app.proof.DEFAULT_HOST
 import com.pocketshell.app.proof.DEFAULT_PORT
 import com.pocketshell.app.proof.DEFAULT_USER
 import com.pocketshell.app.proof.PreGrantPermissionsRule
+import com.pocketshell.app.proof.SeedBeforeLaunchRule
+import com.pocketshell.app.proof.clearLastSessionPrefs
 import com.pocketshell.app.proof.waitForSshFixtureReady
 import com.pocketshell.core.ssh.KnownHostsPolicy
 import com.pocketshell.core.ssh.SshConnection
@@ -35,75 +38,98 @@ import org.junit.After
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import java.io.File
 import java.io.FileOutputStream
 
 /**
- * Issue #962 — a recorded `@ps_agent_kind=shell` session with NO agent correctly
- * shows NO Terminal/Conversation toggle (the #894 no-flap adjacency the fix must
- * preserve). The positive direction (a live agent in a recorded-shell session
- * regains its toggle) is owned by the deterministic JVM red→green — see the
- * coverage split below.
+ * Issue #975 (#962 recurrence) — a recorded `@ps_agent_kind=shell` session with a
+ * LIVE agent (a `claude` transcript present in the cwd) MUST regain its
+ * Terminal/Conversation toggle on the REAL path, EVEN when the host agent-kind
+ * daemon's cgroup/`/proc` classify returns `unknown` (the masked node-wrapped /
+ * quiet `claude`). And the no-agent control must STILL show NO toggle (#894
+ * no-flap adjacency).
  *
- * The maintainer's dogfood report: in an active `claude` session the top chrome
- * shows only a single "Terminal" pill — no "Conversation" toggle. Root cause
- * (research, cited): the session was recorded `@ps_agent_kind=shell` (a plain
- * shell the user/kind-picker classified as shell) with `claude` started INSIDE
- * it. The recorded-shell verdict (#894) publishes the pane confirmed-shell,
- * which collapses `presumedAgent` and never binds a live source — so BOTH inputs
- * to `tmuxSessionTabState.showsConversationTab = hasLiveDetection || presumedAgent`
- * stay false and the toggle is gone for the life of the session.
+ * The maintainer's dogfood report (v0.4.18): in an active `claude` session the top
+ * chrome shows only a single "Terminal" pill — no "Conversation" toggle. Root
+ * cause (research, cited): the session was recorded `@ps_agent_kind=shell` (a
+ * plain shell the user/kind-picker classified as shell) with `claude` started
+ * INSIDE it. The recorded-shell verdict (#894) publishes the pane confirmed-shell,
+ * which collapses `presumedAgent`; and because the daemon's classify returns
+ * `unknown` for the masked `claude`, the #962 fix never bound a live source — so
+ * BOTH inputs to
+ * `tmuxSessionTabState.showsConversationTab = hasLiveDetection || presumedAgent`
+ * stayed false and the toggle was gone for the life of the session.
  *
- * ### Coverage split (G4/D33 — the right test on the right surface)
+ * ### Real-path B1 reproduction (G10/D33 — the gap #962 left open)
  *
- * The LOAD-BEARING reproduction of the fix — a live agent detection clears the
- * confirmed-shell verdict so the toggle returns — is the DETERMINISTIC JVM
- * red→green in
- * `TmuxSessionViewModelTest.liveAgentDetectionClearsConfirmedShellSoConversationToggleReturns`
- * (+ codex / opencode + the no-flap control). That synthetic injection is
- * required because the Docker `agents` fixture cannot make the host agent-kind
- * daemon classify a process: the daemon gates on a cgroup-v2 scope that the
- * non-systemd container does not provide (`pocketshell agents kind` returns
- * `unknown`, `scope=null`), so a recorded-shell pane simply cannot bind a live
- * detection in-fixture. Per D33 the unenterable state is injected synthetically
- * and hard-asserted there, never self-skipped.
+ * #962's connected test claimed the Docker `agents` fixture "cannot bind a live
+ * detection in-fixture" because the non-systemd container's daemon returns
+ * `unknown`/`scope=null`. That is EXACTLY the B1 classify-miss the maintainer hit
+ * on-device — and the #975 fix turns it into the load-bearing real-path test: the
+ * fixture's `agents` container DOES ship a live Claude transcript at
+ * `~/.claude/projects/-workspace-pocketshell/pocketshell-claude.jsonl`, and the
+ * daemon DOES return `unknown` for the pane. So a recorded-shell session whose cwd
+ * has a fresh Claude transcript reproduces the masked-live-agent state on the REAL
+ * path: on base (no #975 fix) the foreign resolver returns null on the `unknown`
+ * classify and NO toggle appears (RED); with the fix the transcript-evidence
+ * fallback binds the agent → markAgentTailLive clears the verdict → the toggle
+ * returns (GREEN). [conversationToggleReturnsForMaskedLiveClaudeInRecordedShellSession]
+ * is that real-path proof; the deterministic JVM red→green
+ * (`TmuxSessionViewModelTest.b1MaskedLiveClaudeInRecordedShellBindsDetectionViaTranscriptDespiteUnknownClassify`)
+ * is the fast sibling.
  *
- * This connected journey covers the part the REAL path reliably exercises on the
- * emulator + Docker — the **no-agent control / #894 no-flap invariant**: a session
- * recorded `@ps_agent_kind=shell` with NO agent process must show NO toggle on the
- * production `TmuxSessionScreen`. This is the active-rework adjacency the #962 fix
- * must not resurrect (a recorded shell flashing the Conversation tab), and it runs
- * unchanged in-fixture (the absence assertion needs no daemon classification). The
- * positive recorded-shell-agent-regains-toggle direction is owned by the
- * deterministic JVM red→green above (it cannot bind a live detection in-fixture).
+ * [plainShellRecordedSessionShowsNoConversationToggle] is the **no-agent control /
+ * #894 no-flap invariant**: a session recorded `@ps_agent_kind=shell` with NO
+ * agent transcript must show NO toggle — the active-rework adjacency the fix must
+ * not resurrect.
  *
- * Modeled on the full-Activity Docker harness of
- * `TmuxSessionOpencodeInputDockerTest.issue303TerminalConversationPillStaysInToolbarRow`
- * (persist host → launch MainActivity → attach to a seeded session → assert the
- * tab pill on the real `TmuxSessionScreen`).
+ * ### Harness — #788 interop-placement cure (this round)
+ *
+ * The previous round of this class used `createEmptyComposeRule()` +
+ * `ActivityScenario.launch(MainActivity)` inside the `@Test` body — the exact #788
+ * interop-placement stall: under the swiftshader AVD the Termux `TerminalView`
+ * `AndroidView` interop child is never placed, MainActivity's compose tree never
+ * registers ("No compose hierarchies found in the app"), and the hand-rolled
+ * `ActivityScenario` lands in a bad lifecycle so `tearDown` NPEs — so the test
+ * never reached its toggle assertion. This round migrates to
+ * `createAndroidComposeRule<MainActivity>()` (the rule owns the activity
+ * lifecycle, the test clock drives the SAME foreground activity the interop child
+ * is placed into) wired through a [RuleChain] in the #788 cure order:
+ * grant → seed-remote+DB → launch MainActivity. Each method's per-test remote
+ * tmux session + DB host row is seeded in the rule's `before()` phase (branched on
+ * the JUnit method name), so MainActivity reads a populated DB on cold start.
+ * See `PreExistingMultiWindowSeedE2eTest` / `Issue895SwitchWhileBlackBandJourneyE2eTest`.
  */
 @RunWith(AndroidJUnit4::class)
 class ConversationToggleVisibleForLiveAgentInShellRecordedSessionDockerTest {
 
-    @get:Rule
-    val compose = createEmptyComposeRule()
+    val compose = createAndroidComposeRule<MainActivity>()
+    private val grantPermissions = PreGrantPermissionsRule()
 
     @get:Rule
-    val grantPermissions = PreGrantPermissionsRule()
+    val ruleChain: RuleChain = RuleChain
+        .outerRule(grantPermissions)
+        .around(SeedBeforeLaunchRule { description -> seedForMethod(description.methodName) })
+        .around(compose)
 
-    private var launchedActivity: ActivityScenario<MainActivity>? = null
+    private var seededKey: String? = null
+    private var seededHostRowTag: String? = null
+    private var seededSessionName: String? = null
     private val cleanupCommands = mutableListOf<String>()
     private val stamps = mutableListOf<String>()
 
     @After
     fun tearDown() {
-        launchedActivity?.close()
-        launchedActivity = null
-        if (cleanupCommands.isNotEmpty()) {
-            runBlocking {
-                runCatching {
-                    withTimeout(20_000) { execRemote(readFixtureKey(), cleanupCommands.joinToString("\n")) }
+        runCatching { compose.activityRule.scenario.moveToState(Lifecycle.State.RESUMED) }
+        clearLastSessionPrefs()
+        seededKey?.let { key ->
+            if (cleanupCommands.isNotEmpty()) {
+                runBlocking {
+                    runCatching {
+                        withTimeout(20_000) { execRemote(key, cleanupCommands.joinToString("\n")) }
+                    }
                 }
             }
         }
@@ -120,30 +146,9 @@ class ConversationToggleVisibleForLiveAgentInShellRecordedSessionDockerTest {
      */
     @Test
     fun plainShellRecordedSessionShowsNoConversationToggle() = runBlocking {
-        val key = readFixtureKey()
-        waitForSshFixtureReady(SshKey.Pem(key))
-        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
+        val hostRowTag = requireNotNull(seededHostRowTag) { "seed-before-launch host row missing" }
+        val sessionName = requireNotNull(seededSessionName) { "seed-before-launch session missing" }
 
-        val suffix = unique()
-        val sessionName = "issue962-plain-shell-$suffix"
-        cleanupCommands += "tmux kill-session -t ${shellQuote(sessionName)} 2>/dev/null || true"
-
-        execRemote(
-            key,
-            buildString {
-                appendLine("set -eu")
-                appendLine("tmux kill-session -t ${shellQuote(sessionName)} 2>/dev/null || true")
-                appendLine(
-                    "tmux new-session -d -x 80 -y 24 -s ${shellQuote(sessionName)} -c /tmp " +
-                        "\"printf 'issue962-plain-ready\\r\\n'; exec sh\"",
-                )
-                appendLine("tmux set-option -t ${shellQuote(sessionName)} @ps_agent_kind shell")
-                appendLine("sleep 1")
-            },
-        )
-
-        val hostRowTag = persistHost(appContext, key)
-        launchedActivity = ActivityScenario.launch(MainActivity::class.java)
         attachToSeededSession(hostRowTag, sessionName)
         waitForTerminalSessionAttached()
         waitForVisibleTerminalText("issue962-plain-ready", VISIBLE_TIMEOUT_MS) {
@@ -165,16 +170,186 @@ class ConversationToggleVisibleForLiveAgentInShellRecordedSessionDockerTest {
         Unit
     }
 
+    /**
+     * Issue #975 (B1, classify-miss) — the REAL-PATH reproduction of the
+     * maintainer's bug. A session recorded `@ps_agent_kind=shell` whose cwd holds a
+     * fresh live Claude transcript (copied from the fixture's seed at
+     * `~/.claude/projects/-workspace-pocketshell/pocketshell-claude.jsonl`), while
+     * the host agent-kind daemon's classify returns `unknown` for the pane (the
+     * non-systemd container has no readable cgroup scope — exactly the masked
+     * node-wrapped `claude` on-device). On base (no #975 fix) the foreign resolver
+     * returns null on the `unknown` classify so NO Conversation toggle appears
+     * (the user is stranded on the raw black agent Terminal). With the fix the
+     * transcript-evidence fallback binds the live agent → markAgentTailLive clears
+     * the recorded-shell verdict → the [TMUX_TABS_TAG] toggle returns with a
+     * "Conversation" segment.
+     */
+    @Test
+    fun conversationToggleReturnsForMaskedLiveClaudeInRecordedShellSession() = runBlocking {
+        val hostRowTag = requireNotNull(seededHostRowTag) { "seed-before-launch host row missing" }
+        val sessionName = requireNotNull(seededSessionName) { "seed-before-launch session missing" }
+
+        attachToSeededSession(hostRowTag, sessionName)
+        waitForTerminalSessionAttached()
+        waitForVisibleTerminalText("issue975-masked-ready", VISIBLE_TIMEOUT_MS) {
+            "issue975-masked-ready" in it
+        }
+        stamp("masked_claude_attached session=$sessionName")
+
+        // STEP 1 — observe the recorded-shell verdict APPLYING (the collapse
+        // point), recorded as evidence the optimistic window genuinely ends. The
+        // fresh pane shows the toggle optimistically (#878 black-screen cure)
+        // BEFORE the recorded `@ps_agent_kind=shell` verdict is read+applied; a
+        // test that merely waited for the toggle to appear would catch that
+        // optimistic window and pass even on base. The hard RED/GREEN gate is
+        // STEP 2 (a bound DETECTION, which the optimistic toggle never sets), so
+        // this observation is recorded but not fatal — with the fix B1 clears the
+        // verdict again so quickly that the confirmed-shell set may already be
+        // empty by the time the poll ticks. STEP 2 is the immune signal.
+        val vm = currentViewModel()
+        val verdictObserved = waitForConfirmedShellVerdict(vm)
+        stamp("masked_claude_confirmed_shell_verdict_observed=$verdictObserved")
+
+        // STEP 2 — LOAD-BEARING B1 SIGNAL: a LIVE transcript detection must BIND
+        // for the pane. This is the exact signal the JVM red→green asserts
+        // (`assertNotNull(detection)`): in this fixture the daemon classify returns
+        // `unknown` ({"results":[]}), so the ONLY way `detection != null` can ever
+        // be true is the #975 B1 transcript-evidence fallback. On base (no fix) the
+        // foreign resolver returns null and detection stays null for the life of
+        // the session → RED here, BEFORE the UI assertions. With the fix the
+        // fallback binds the live Claude transcript → detection non-null → GREEN.
+        // Asserting the bound DETECTION (not just the toggle UI) is what makes this
+        // immune to the optimistic-presumedAgent confound: the optimistic toggle
+        // never sets a non-null detection.
+        val detectionBound = waitForLiveDetectionBound(vm)
+        assertTrue(
+            "#975 B1 (real path): a LIVE transcript detection must bind for the " +
+                "masked-claude recorded-shell pane within ${MASKED_TOGGLE_TIMEOUT_MS}ms " +
+                "(the daemon classify is `unknown`, so only the transcript-evidence " +
+                "fallback can bind it). On base (no fix) detection stays null. " +
+                "agentConversations=${vm.agentConversations.value.mapValues { entry -> entry.value.detection?.agent }}",
+            detectionBound,
+        )
+        stamp("masked_claude_live_detection_bound")
+
+        // STEP 3 — DURABLE UI: with the live detection bound, the
+        // Terminal/Conversation toggle must (re)appear and stay. On base the
+        // confirmed-shell verdict permanently suppresses presumedAgent and the
+        // toggle is gone; with the fix markAgentTailLive →
+        // clearConfirmedShellOnLiveAgentDetection clears the verdict → the toggle
+        // returns DURABLY.
+        compose.waitUntil(timeoutMillis = MASKED_TOGGLE_TIMEOUT_MS) {
+            compose.onAllNodesWithTag(TMUX_TABS_TAG, useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
+        compose.onNodeWithTag(TMUX_TABS_TAG, useUnmergedTree = true).assertExists()
+        // The toggle carries a "Conversation" segment (the agent surface the user
+        // was stranded away from), not just a lone "Terminal" pill.
+        compose.waitUntil(timeoutMillis = MASKED_TOGGLE_TIMEOUT_MS) {
+            compose.onAllNodesWithText("Conversation", useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
+        compose.onNodeWithText("Conversation", useUnmergedTree = true).assertExists()
+        captureFullFrame("issue975-masked-claude-toggle-returns")
+        stamp("masked_claude_toggle_returned_ok")
+        Unit
+    }
+
+    // -------------------------------------------------------------- seed-before-launch
+
+    /**
+     * #788 cure: seed the per-test remote tmux session + DB host row in the
+     * RuleChain's `before()` phase (BEFORE `createAndroidComposeRule` launches
+     * MainActivity), branched on the JUnit method name so each test gets its own
+     * fixture. The host row tag + session name are stashed for the `@Test` body.
+     */
+    private suspend fun seedForMethod(methodName: String) {
+        val key = readFixtureKey()
+        seededKey = key
+        clearLastSessionPrefs()
+        waitForSshFixtureReady(SshKey.Pem(key))
+        val sessionName = when (methodName) {
+            "conversationToggleReturnsForMaskedLiveClaudeInRecordedShellSession" ->
+                seedMaskedLiveClaudeSession(key)
+            "plainShellRecordedSessionShowsNoConversationToggle" ->
+                seedPlainShellSession(key)
+            else -> error("unexpected test method $methodName")
+        }
+        seededSessionName = sessionName
+        seededHostRowTag = persistHost(key)
+    }
+
+    private suspend fun seedPlainShellSession(key: String): String {
+        val suffix = unique()
+        val sessionName = "issue962-plain-shell-$suffix"
+        cleanupCommands += "tmux kill-session -t ${shellQuote(sessionName)} 2>/dev/null || true"
+        execRemote(
+            key,
+            buildString {
+                appendLine("set -eu")
+                appendLine("tmux kill-session -t ${shellQuote(sessionName)} 2>/dev/null || true")
+                appendLine(
+                    "tmux new-session -d -x 80 -y 24 -s ${shellQuote(sessionName)} -c /tmp " +
+                        "\"printf 'issue962-plain-ready\\r\\n'; exec sh\"",
+                )
+                appendLine("tmux set-option -t ${shellQuote(sessionName)} @ps_agent_kind shell")
+                appendLine("sleep 1")
+            },
+        )
+        return sessionName
+    }
+
+    private suspend fun seedMaskedLiveClaudeSession(key: String): String {
+        val suffix = unique()
+        val sessionName = "issue975-masked-claude-$suffix"
+        cleanupCommands += "tmux kill-session -t ${shellQuote(sessionName)} 2>/dev/null || true"
+        cleanupCommands +=
+            "rm -f /home/testuser/.claude/projects/-home-testuser/" +
+                "issue975-live-claude.jsonl 2>/dev/null || true"
+        // Seed a FRESH live Claude transcript in the cwd-encoded Claude project
+        // dir for a writable cwd (`/home/testuser` → encoded `-home-testuser`), and
+        // attach the tmux session to that SAME cwd. (`/workspace` is not writable by
+        // testuser in the fixture; the encoded transcript dir is what the detector
+        // enumerates, and the cwd must be a real accessible dir for `pane.cwd` to
+        // match.) Record it `@ps_agent_kind=shell` (the durable verdict that hides
+        // the toggle). The daemon's classify returns `unknown` for this pane (no
+        // cgroup scope in the non-systemd container) — the masked-live-agent state.
+        execRemote(
+            key,
+            buildString {
+                appendLine("set -eu")
+                appendLine("tmux kill-session -t ${shellQuote(sessionName)} 2>/dev/null || true")
+                appendLine("mkdir -p /home/testuser/.claude/projects/-home-testuser")
+                // A fresh Claude transcript (copied from the fixture's seed) inside
+                // the detector's 2h `-mmin -120` freshness window.
+                appendLine(
+                    "cp /home/testuser/.claude/projects/-workspace-pocketshell/" +
+                        "pocketshell-claude.jsonl " +
+                        "/home/testuser/.claude/projects/-home-testuser/" +
+                        "issue975-live-claude.jsonl",
+                )
+                appendLine(
+                    "touch /home/testuser/.claude/projects/-home-testuser/" +
+                        "issue975-live-claude.jsonl",
+                )
+                appendLine(
+                    "tmux new-session -d -x 80 -y 24 -s ${shellQuote(sessionName)} " +
+                        "-c /home/testuser " +
+                        "\"printf 'issue975-masked-ready\\r\\n'; exec sh\"",
+                )
+                appendLine("tmux set-option -t ${shellQuote(sessionName)} @ps_agent_kind shell")
+                appendLine("sleep 1")
+            },
+        )
+        return sessionName
+    }
+
     // ----------------------------------------------------------------- helpers
 
-    private suspend fun persistHost(appContext: android.content.Context, key: String): String {
-        // Clear the persisted last-session so MainActivity starts on the host
-        // list, not auto-restoring a stale (sibling/prior) TmuxSessionScreen — an
-        // auto-restore would bypass the host row and race the attach.
-        appContext.getSharedPreferences("last_session", android.content.Context.MODE_PRIVATE)
-            .edit()
-            .clear()
-            .commit()
+    private suspend fun persistHost(key: String): String {
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
         var hostRowTag = ""
         val db = Room.databaseBuilder(appContext, AppDatabase::class.java, DATABASE_NAME)
             .fallbackToDestructiveMigration(dropAllTables = true)
@@ -206,10 +381,15 @@ class ConversationToggleVisibleForLiveAgentInShellRecordedSessionDockerTest {
     }
 
     private fun attachToSeededSession(hostRowTag: String, sessionName: String) {
-        compose.waitUntil(timeoutMillis = 10_000) {
-            compose.onAllNodesWithTag(hostRowTag, useUnmergedTree = true)
-                .fetchSemanticsNodes()
-                .isNotEmpty()
+        // Under createAndroidComposeRule, MainActivity cold compose can briefly
+        // expose no registered hierarchy, so probe defensively until the
+        // pre-launch seeded host row exists.
+        compose.waitUntil(timeoutMillis = HOST_ROW_TIMEOUT_MS) {
+            runCatching {
+                compose.onAllNodesWithTag(hostRowTag, useUnmergedTree = true)
+                    .fetchSemanticsNodes()
+                    .isNotEmpty()
+            }.getOrDefault(false)
         }
         clickRobustly { compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick() }
         // Tap the session by its NAME text — it matches whether the folder list
@@ -234,13 +414,13 @@ class ConversationToggleVisibleForLiveAgentInShellRecordedSessionDockerTest {
      * and dispatching the gesture. Settle to idle and retry.
      */
     private fun clickRobustly(click: () -> Unit) {
-        runCatching { launchedActivity?.moveToState(androidx.lifecycle.Lifecycle.State.RESUMED) }
+        runCatching { compose.activityRule.scenario.moveToState(Lifecycle.State.RESUMED) }
         compose.waitForIdle()
         try {
             click()
         } catch (e: AssertionError) {
             if (e.message?.contains("Failed to inject touch input") != true) throw e
-            runCatching { launchedActivity?.moveToState(androidx.lifecycle.Lifecycle.State.RESUMED) }
+            runCatching { compose.activityRule.scenario.moveToState(Lifecycle.State.RESUMED) }
             compose.waitForIdle()
             SystemClock.sleep(300)
             click()
@@ -263,7 +443,7 @@ class ConversationToggleVisibleForLiveAgentInShellRecordedSessionDockerTest {
             // (focus moves to the launcher), which makes Compose touch injection
             // fail ("Failed to inject touch input"). Bring the Activity back to
             // RESUMED before each tap so the app window is foreground+touchable.
-            runCatching { launchedActivity?.moveToState(androidx.lifecycle.Lifecycle.State.RESUMED) }
+            runCatching { compose.activityRule.scenario.moveToState(Lifecycle.State.RESUMED) }
             compose.waitForIdle()
             runCatching {
                 compose.onNodeWithText(sessionName, useUnmergedTree = true).performClick()
@@ -281,14 +461,59 @@ class ConversationToggleVisibleForLiveAgentInShellRecordedSessionDockerTest {
     }
 
     private fun waitForTerminalSessionAttached() {
-        compose.waitUntil(timeoutMillis = 20_000) {
-            findTerminalView()?.currentSession?.emulator != null
+        compose.waitUntil(timeoutMillis = 30_000) {
+            var attached = false
+            compose.activityRule.scenario.onActivity { activity ->
+                val view = activity.window.decorView.findTerminalView()
+                attached = view?.currentSession?.emulator != null
+            }
+            attached
         }
+    }
+
+    private fun currentViewModel(): TmuxSessionViewModel {
+        var vm: TmuxSessionViewModel? = null
+        compose.activityRule.scenario.onActivity { activity ->
+            vm = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+        }
+        return requireNotNull(vm) { "TmuxSessionViewModel not available" }
+    }
+
+    /**
+     * Poll until the recorded `@ps_agent_kind=shell` verdict has applied (the
+     * pane's confirmed-shell set became non-empty at least once) — the moment the
+     * optimistic presumed-agent toggle collapses on base. Best-effort: returns
+     * false if never observed within the budget (with the fix, B1 may clear it
+     * before a poll tick lands; STEP 2 is the immune load-bearing signal).
+     */
+    private fun waitForConfirmedShellVerdict(vm: TmuxSessionViewModel): Boolean {
+        val deadline = SystemClock.elapsedRealtime() + VERDICT_TIMEOUT_MS
+        while (SystemClock.elapsedRealtime() < deadline) {
+            if (vm.confirmedShellPaneIds.value.isNotEmpty()) return true
+            SystemClock.sleep(80)
+        }
+        return vm.confirmedShellPaneIds.value.isNotEmpty()
+    }
+
+    /**
+     * Poll until a LIVE transcript detection binds for any pane — the #975 B1
+     * signal. In this fixture the daemon classify is `unknown`, so a non-null
+     * `detection` can ONLY come from the transcript-evidence fallback; on base it
+     * stays null. This is the same property the JVM red→green asserts
+     * (`assertNotNull(detection)`), driven here on the real connected path.
+     */
+    private fun waitForLiveDetectionBound(vm: TmuxSessionViewModel): Boolean {
+        val deadline = SystemClock.elapsedRealtime() + MASKED_TOGGLE_TIMEOUT_MS
+        while (SystemClock.elapsedRealtime() < deadline) {
+            if (vm.agentConversations.value.values.any { it.detection != null }) return true
+            SystemClock.sleep(100)
+        }
+        return vm.agentConversations.value.values.any { it.detection != null }
     }
 
     private fun visibleTerminalText(): String {
         var text = ""
-        launchedActivity?.onActivity { activity ->
+        compose.activityRule.scenario.onActivity { activity ->
             text = activity.window.decorView
                 .findTerminalView()
                 ?.currentSession
@@ -314,14 +539,6 @@ class ConversationToggleVisibleForLiveAgentInShellRecordedSessionDockerTest {
         }
         writeText("issue962-failure-$label-visible-terminal.txt", last)
         assertTrue("predicate $label timed out; visible terminal:\n$last", false)
-    }
-
-    private fun findTerminalView(): TerminalView? {
-        var found: TerminalView? = null
-        launchedActivity?.onActivity { activity ->
-            found = activity.window.decorView.findTerminalView()
-        }
-        return found
     }
 
     private fun View.findTerminalView(): TerminalView? {
@@ -406,7 +623,14 @@ class ConversationToggleVisibleForLiveAgentInShellRecordedSessionDockerTest {
         const val DATABASE_NAME: String = "pocketshell.db"
         const val HOST_NAME: String = "Issue962 Agents"
         const val ATTACH_TIMEOUT_MS: Long = 30_000
+        const val HOST_ROW_TIMEOUT_MS: Long = 60_000
         const val VISIBLE_TIMEOUT_MS: Long = 20_000
         const val SHELL_NO_TOGGLE_SETTLE_MS: Long = 8_000
+        const val VERDICT_TIMEOUT_MS: Long = 20_000
+
+        // Issue #975: the masked-live-agent transcript fallback binds on the first
+        // foreign reconcile + the confirmed-shell cache-bust re-probe; allow a
+        // generous window for the toggle to return on the swiftshader AVD.
+        const val MASKED_TOGGLE_TIMEOUT_MS: Long = 25_000
     }
 }

--- a/app/src/main/java/com/pocketshell/app/session/AgentConversationRepository.kt
+++ b/app/src/main/java/com/pocketshell/app/session/AgentConversationRepository.kt
@@ -496,6 +496,64 @@ public class AgentConversationRepository internal constructor(
     }
 
     /**
+     * Issue #975 (B1, classify-miss): resolve the Conversation source for a pane
+     * WITHOUT a known kind, by trusting a LIVE transcript scoped to the pane's
+     * cwd. This is the trustworthy-live-agent-evidence fallback for a
+     * CONFIRMED-SHELL session whose host agent-kind daemon returned `unknown`
+     * (NOT `none`) — the node-wrapped / quiet `claude` the cgroup-v2/`/proc`
+     * classify cannot see, while its `*.jsonl` transcript is plainly present in
+     * the cwd-encoded log dir. The daemon `unknown` verdict means "we could not
+     * read the scope", which is exactly the masked-agent state; a fresh,
+     * recent transcript in the cwd is then strong enough evidence to bind the
+     * agent and clear the stale recorded-shell verdict (so the Conversation
+     * toggle returns — #962 recurrence).
+     *
+     * It enumerates ALL kinds' candidates for the cwd in ONE exec (the SAME
+     * [detectionCommand] the kind-fixed path uses), picks the MOST-RECENT
+     * candidate's kind, and runs the SAME [selectRecordedCandidate] discipline
+     * for that kind (Codex `/proc/<pid>/fd` owned-rollout binding included). A
+     * genuine shell with no recent agent transcript enumerates NOTHING → returns
+     * null → no flap (the #894 invariant holds: only a real live transcript
+     * binds, so a plain shell never resurrects a Conversation surface). The 2h
+     * `-mmin -120` freshness window in [detectionCommand] is what makes the
+     * transcript "live" rather than a stale leftover.
+     *
+     * This is deliberately a SCOPED fallback — it runs ONLY when the daemon said
+     * `unknown` for a recorded-shell pane (the masked-agent case), never as a
+     * blanket kind guesser (the deleted output-parsing detector stays deleted —
+     * D22). The KIND still comes from the transcript that genuinely exists, not
+     * from output parsing.
+     */
+    suspend fun detectLiveTranscriptForPane(
+        session: SshSession,
+        cwd: String,
+        paneTty: String,
+        paneCommand: String,
+    ): AgentDetection? {
+        val normalizedCwd = cwd.trim().ifBlank { return null }
+        val normalizedTty = paneTty.trim().ifBlank { return null }
+        val candidates = session.exec(detectionCommand(normalizedCwd))
+            .stdout
+            .lineSequence()
+            .mapNotNull(::parseCandidate)
+            .toList()
+        if (candidates.isEmpty()) return null
+        // Pick the kind of the MOST-RECENT candidate scoped to this cwd — the
+        // transcript that is actually live now. Resolve that single kind through
+        // the SAME selection discipline (the kind is taken FROM the present
+        // transcript, never guessed by output parsing).
+        val recordedKind = candidates.maxByOrNull { it.modifiedAtMillis }?.agent ?: return null
+        return selectRecordedCandidate(
+            session = session,
+            normalizedCwd = normalizedCwd,
+            normalizedTty = normalizedTty,
+            paneCommand = paneCommand,
+            recordedKind = recordedKind,
+            candidates = candidates.filter { it.agent == recordedKind },
+        )
+    }
+
+    /**
      * Epic #821 slice #3 (#825) / Issue #828: shared selection step for a
      * recorded session, given the already-enumerated [candidates] of the
      * recorded kind. Split out so BOTH the standalone

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -10181,6 +10181,12 @@ public class TmuxSessionViewModel @Inject constructor(
      * shell-recorded session regains its Conversation toggle. A recorded-shell
      * read that re-marks the session is harmless: if a live agent is present the
      * next detection bind clears it again; a genuine shell stays marked (#894).
+     *
+     * Issue #975 (B2): a REMEMBERED-agent (#819 A2) resolving placeholder is NOT
+     * dropped on `isShell = true` — only the fresh auto-seeded (#878) placeholder
+     * is. A beyond-grace reattach (#959) re-stamps this verdict on every
+     * reconnect; tearing down the restored remembered-agent placeholder would
+     * re-suppress the Conversation toggle for a session that WAS a live agent.
      */
     private fun applyRecordedShellVerdict(sessionId: String, isShell: Boolean) {
         val key = sessionId.trim()
@@ -10191,18 +10197,30 @@ public class TmuxSessionViewModel @Inject constructor(
             confirmedShellSessionIds.remove(key)
         }
         if (isShell) {
-            // Drop any auto-seeded placeholder that raced ahead of this verdict.
-            // Issue #819 (A2): a remembered-agent resolving placeholder for a
-            // session the durable tree now confirms is a SHELL is a STALE
-            // reattach seed (the window's agent exited and was replaced by a
-            // shell since memory was recorded) — drop it too, so a confirmed
-            // shell never lingers on the #819 "Loading conversation…" resolving
-            // placeholder.
+            // Drop any AUTO-seeded (#878) placeholder that raced ahead of this
+            // verdict — that is a fresh first-open optimistic seed, and a
+            // confirmed shell must never linger on the wrong surface (the
+            // first-open flash kill).
+            //
+            // Issue #975 (B2, reattach re-stamp): do NOT drop a REMEMBERED-agent
+            // (#819 A2) resolving placeholder here. A beyond-grace reattach (#959)
+            // re-reads `@ps_agent_kind=shell` and re-applies this verdict on every
+            // reconnect; if it tore down the just-restored remembered-agent
+            // placeholder, it would re-suppress the Conversation toggle for a
+            // session that WAS a live agent before backgrounding — and recovery
+            // would then depend on the same fragile daemon-classify B1 shows is
+            // unproven, stranding the user on the raw black Terminal. A remembered
+            // agent is trustworthy prior live-agent evidence: keep its placeholder
+            // and let detection re-confirm it. A GENUINE shell (the agent really
+            // exited and was replaced) still tears the placeholder down — through
+            // the deferred-downgrade path (handleNullAgentDetection's
+            // AGENT_EXIT_CONFIRMATIONS consecutive nulls), which is the correct,
+            // evidence-driven teardown rather than an unconditional re-stamp.
             val shellPaneIds = paneRows.values
                 .filter { it.sessionId.trim() == key }
                 .map { it.paneId }
             for (paneId in shellPaneIds) {
-                if (isAutoSeededPlaceholderUp(paneId) || isRememberedAgentPlaceholderUp(paneId)) {
+                if (isAutoSeededPlaceholderUp(paneId)) {
                     conversationLoadWatchdogJobs.remove(paneId)?.cancel()
                     paneAgentNullDetections.remove(paneId)
                     clearAgentDetectionForPane(paneId)
@@ -10355,8 +10373,16 @@ public class TmuxSessionViewModel @Inject constructor(
      * shell) or unknown" — either way the guess has already fired and must NOT
      * be re-run on later reconciles (the one-shot discipline). [kind] holds the
      * guessed engine when the daemon classified the pane as an agent.
+     *
+     * Issue #975 (B1, classify-miss): also box the daemon's `none`-vs-`unknown`
+     * distinction ([isShell]). `none` (`isShell = true`) is a READABLE scope with
+     * no agent — a genuine shell. `unknown` (`isShell = false`, kind null) is an
+     * UNREADABLE scope — "we could not tell", which on a CONFIRMED-SHELL session
+     * with a live node-wrapped/quiet `claude` is exactly the masked-agent case.
+     * The caller uses this to gate the transcript-evidence fallback so it fires
+     * ONLY on `unknown` (never collapsing a genuine `none` shell).
      */
-    private class ForeignKindGuessEntry(val kind: AgentKind?)
+    private class ForeignKindGuessEntry(val kind: AgentKind?, val isShell: Boolean)
 
     /**
      * Epic #821 slice A2: resolve a FOREIGN session's agent kind via the
@@ -10364,23 +10390,31 @@ public class TmuxSessionViewModel @Inject constructor(
      * tmux session id so it fires AT MOST ONCE per foreign session. Returns the
      * cached guess immediately on a hit; on a miss it sends the pane's
      * `(pane_id, pane_pid)` to the daemon, caches the verdict, and returns it.
-     * A null result means the daemon did not classify the pane as an agent (a
-     * shell / unknown / no pid / tool missing) — the caller treats that as "no
-     * conversation for this pane" but does NOT re-probe.
+     * A null [ForeignKindGuessEntry.kind] means the daemon did not classify the
+     * pane as an agent (a shell / unknown / no pid / tool missing) — the caller
+     * treats that as "no conversation for this pane" but does NOT re-probe.
+     *
+     * Issue #975: returns the FULL boxed verdict (kind + `none`-vs-`unknown`) so
+     * the caller can distinguish a genuine readable shell (`none`) from an
+     * unreadable scope (`unknown`) for the masked-live-agent transcript fallback.
      */
     private suspend fun resolveForeignKindGuess(
         session: SshSession,
         sessionTarget: String,
         pane: TmuxPaneState,
-    ): AgentKind? {
+    ): ForeignKindGuessEntry {
         val key = sessionTarget.trim()
-        sessionForeignKindGuessCache[key]?.let { return it.kind }
+        sessionForeignKindGuessCache[key]?.let { return it }
         val panePid = pane.panePid.takeIf { it > 0L }
         // No pid → cannot ask the daemon. Cache the (null) verdict so we don't
         // re-probe a pane that never carries a pid, preserving the one-shot rule.
+        // No pid means we could not even ask — `unknown`, not a readable `none`.
         if (panePid == null) {
-            sessionForeignKindGuessCache.putIfAbsent(key, ForeignKindGuessEntry(null))
-            return null
+            sessionForeignKindGuessCache.putIfAbsent(
+                key,
+                ForeignKindGuessEntry(kind = null, isShell = false),
+            )
+            return sessionForeignKindGuessCache.getValue(key)
         }
         val verdict = agentKindRemoteSource.classify(
             session = session,
@@ -10391,9 +10425,18 @@ public class TmuxSessionViewModel @Inject constructor(
                 ),
             ),
         )
-        val guessed = verdict[pane.paneId]?.kind
-        sessionForeignKindGuessCache.putIfAbsent(key, ForeignKindGuessEntry(guessed))
-        return sessionForeignKindGuessCache[key]?.kind
+        val paneVerdict = verdict[pane.paneId]
+        sessionForeignKindGuessCache.putIfAbsent(
+            key,
+            ForeignKindGuessEntry(
+                kind = paneVerdict?.kind,
+                // An ABSENT pane verdict (tool missing / daemon error / parse
+                // failure → empty map) is "we could not tell" = unknown, not a
+                // confirmed shell. Only an explicit `none` row is a readable shell.
+                isShell = paneVerdict?.isShell == true,
+            ),
+        )
+        return sessionForeignKindGuessCache.getValue(key)
     }
 
     /**
@@ -10421,18 +10464,43 @@ public class TmuxSessionViewModel @Inject constructor(
         tty: String,
         command: String,
     ): AgentDetection? {
-        val guessedKind = resolveForeignKindGuess(
+        val guess = resolveForeignKindGuess(
             session = session,
             sessionTarget = sessionTarget,
             pane = pane,
-        ) ?: return null
-        return agentRepository.detectRecordedSessionForPane(
-            session = session,
-            cwd = cwd,
-            paneTty = tty,
-            paneCommand = command,
-            recordedKind = guessedKind,
         )
+        val guessedKind = guess.kind
+        if (guessedKind != null) {
+            return agentRepository.detectRecordedSessionForPane(
+                session = session,
+                cwd = cwd,
+                paneTty = tty,
+                paneCommand = command,
+                recordedKind = guessedKind,
+            )
+        }
+        // Issue #975 (B1, classify-miss): the daemon did not name a kind. If this
+        // is a CONFIRMED-SHELL session AND the daemon's verdict was `unknown`
+        // (an UNREADABLE scope — `isShell == false`), the recorded-shell verdict
+        // is no longer trustworthy: a live node-wrapped/quiet `claude` the
+        // cgroup-v2/`/proc` classify cannot see is exactly the masked-agent case
+        // the maintainer hit (the live Claude session with NO Conversation
+        // toggle, #962 recurrence). Trust a LIVE transcript scoped to the cwd as
+        // the agent evidence: if a fresh `*.jsonl` binds, return that detection
+        // so markAgentTailLive clears the stale shell verdict and the toggle
+        // returns. A daemon `none` (readable scope, no agent — `isShell == true`)
+        // is a GENUINE shell and gets NO fallback (the #894 no-flap invariant). A
+        // foreign (not-confirmed-shell) pane with no kind guess also stays null —
+        // we only second-guess a recorded-shell verdict, never a clean foreign.
+        if (isConfirmedShellSession(sessionTarget) && !guess.isShell) {
+            return agentRepository.detectLiveTranscriptForPane(
+                session = session,
+                cwd = cwd,
+                paneTty = tty,
+                paneCommand = command,
+            )
+        }
+        return null
     }
 
     private fun startAgentDetectionForPane(
@@ -10449,16 +10517,29 @@ public class TmuxSessionViewModel @Inject constructor(
         // moved between ttys would keep its stale "no agent" verdict
         // even after the agent CLI was started on the new tty.
         val input = Triple(cwd, command, tty)
-        if (paneAgentInputs[pane.paneId] == input && paneAgentJobs[pane.paneId]?.isActive == true) return
+        // Issue #975 (B1′, dedup ordering): bust the one-shot foreign kind-guess
+        // cache for a CONFIRMED-SHELL pane BEFORE the dedup early-return, not
+        // after it. A `claude` started inside an already-detected shell pane does
+        // NOT change the `(cwd, command, tty)` triple (no tty change), so the
+        // dedup key matches and — with the bust ordered AFTER the early-return
+        // (the #962 ordering bug) — the cache-bust never ran and the stale "no
+        // agent" guess persisted for the life of the session, suppressing the
+        // Conversation toggle. Busting first means the next re-probe of a
+        // confirmed-shell pane always re-evaluates the daemon (and the #975 B1
+        // transcript fallback), so a live agent started in the shell can bind and
+        // clear the verdict even when the input triple is unchanged. A genuine
+        // shell re-evaluates to "no agent" again (no flap — #894).
+        refreshForeignGuessForConfirmedShellPane(pane)
+        if (paneAgentInputs[pane.paneId] == input && paneAgentJobs[pane.paneId]?.isActive == true) {
+            // The cache-bust above already forced the daemon to re-evaluate on
+            // the NEXT probe. A confirmed-shell pane whose input is unchanged but
+            // whose one-shot guess was just invalidated must not be left deduped
+            // on a stale in-flight job — re-probe it so the bust takes effect.
+            if (!isConfirmedShellSession(pane.sessionId)) return
+        }
         paneAgentJobs.remove(pane.paneId)?.cancel()
         paneAgentTailGenerations.remove(pane.paneId)
         paneAgentInputs[pane.paneId] = input
-        // Issue #962: for a recorded-`shell` session, bust the one-shot foreign
-        // kind-guess cache before probing so the daemon re-evaluates and can bind
-        // an agent started INSIDE the shell (the one-shot guess may have cached
-        // "no agent" before the agent launched). On a positive bind,
-        // markAgentTailLive re-classifies the session out of confirmed-shell.
-        refreshForeignGuessForConfirmedShellPane(pane)
         val paneId = pane.paneId
         val guard = refreshGuard ?: RuntimeRefreshGuard(
             generation = connectGeneration,
@@ -12812,6 +12893,110 @@ public class TmuxSessionViewModel @Inject constructor(
         initialEvents: List<ConversationEvent> = emptyList(),
     ) {
         markAgentTailLive(paneId, detection, initialEvents)
+    }
+
+    /**
+     * Issue #975 (B1, classify-miss) test seam: drive the REAL foreign-session
+     * detection resolver against a supplied [session] for the row registered
+     * under [paneId]. This exercises the actual
+     * `resolveForeignKindGuess` → `AgentKindRemoteSource.classify` →
+     * `AgentConversationRepository.detectLiveTranscriptForPane` chain (not a
+     * synthetic `markAgentTailLive` injection), so a test using a fake SSH
+     * session whose daemon classify returns `unknown` while a live `*.jsonl`
+     * transcript is present can prove the masked-live-agent fallback binds a
+     * detection (B1) and stays null for a genuine `none` shell (the no-flap
+     * control). The pane must already be registered (e.g. via the test
+     * connect/parse helper) and its session marked confirmed-shell.
+     */
+    @androidx.annotation.VisibleForTesting
+    internal suspend fun resolveForeignSessionDetectionForTest(
+        paneId: String,
+        session: SshSession,
+    ): AgentDetection? {
+        val pane = paneRows[paneId] ?: return null
+        return resolveForeignSessionDetection(
+            session = session,
+            sessionTarget = pane.sessionId,
+            pane = pane,
+            cwd = pane.cwd,
+            tty = pane.paneTty,
+            command = pane.currentCommand,
+        )
+    }
+
+    /**
+     * Issue #975 (B1′, dedup ordering) test seam: true when a re-probe of
+     * [paneId] would re-evaluate the daemon — i.e. the one-shot foreign-kind
+     * guess cache for the pane's session is ABSENT (busted). Lets a JVM test
+     * assert that [startAgentDetectionForPane] busts the cache for a
+     * confirmed-shell pane BEFORE the dedup early-return, so a `claude` started
+     * inside an already-detected shell pane (unchanged `(cwd, command, tty)`)
+     * still forces a re-probe instead of keeping the stale "no agent" guess.
+     */
+    @androidx.annotation.VisibleForTesting
+    internal fun foreignGuessIsCachedForTest(sessionId: String): Boolean =
+        sessionForeignKindGuessCache.containsKey(sessionId.trim())
+
+    /**
+     * Issue #975 (B1′) test seam: seed the one-shot foreign-kind guess cache for
+     * [sessionId] with a `unknown`-shaped (kind null) verdict, mirroring a daemon
+     * classify that already cached "no agent" before the agent launched. A
+     * subsequent [startAgentDetectionForPaneForTest] on a confirmed-shell pane of
+     * that session must BUST this entry (the B1′ ordering fix) so the daemon
+     * re-evaluates.
+     */
+    @androidx.annotation.VisibleForTesting
+    internal fun seedForeignGuessCacheForTest(sessionId: String) {
+        sessionForeignKindGuessCache.putIfAbsent(
+            sessionId.trim(),
+            ForeignKindGuessEntry(kind = null, isShell = false),
+        )
+    }
+
+    /**
+     * Issue #975 (B1′) test seam: drive [startAgentDetectionForPane] for the row
+     * registered under [paneId]. With a fake [sessionRef] already set, a JVM test
+     * can assert the cache-bust ordering without a full reconcile.
+     */
+    @androidx.annotation.VisibleForTesting
+    internal fun startAgentDetectionForPaneForTest(paneId: String) {
+        val pane = paneRows[paneId] ?: return
+        startAgentDetectionForPane(pane)
+    }
+
+    /**
+     * Issue #975 test seam: install [session] as the active [sessionRef] so a
+     * JVM test can drive the detection chain ([startAgentDetectionForPane] /
+     * [resolveForeignSessionDetectionForTest]) against a fake SSH session that
+     * models the masked-live-agent host (daemon classify `unknown` + a live
+     * transcript). Mirrors the production assignment in the connect/reconnect
+     * path without standing up a real SSH transport.
+     */
+    @androidx.annotation.VisibleForTesting
+    internal fun setSessionRefForTest(session: SshSession?) {
+        sessionRef = session
+    }
+
+    /**
+     * Issue #975 (B2, reattach re-stamp) test seam: register a REMEMBERED-agent
+     * resolving placeholder (#819 A2: detection-less,
+     * [AgentConversationUiState.rememberedAgentPlaceholder] = true) for [paneId],
+     * mirroring what [seedAgentConversationFromMemory] restores on a beyond-grace
+     * reattach. Lets a JVM test prove [applyRecordedShellVerdict] (`isShell=true`)
+     * does NOT tear it down on the reconnect re-read — the toggle survives.
+     */
+    @androidx.annotation.VisibleForTesting
+    internal fun seedRememberedAgentPlaceholderForTest(paneId: String) {
+        _agentConversations.update { conversations ->
+            conversations + (paneId to AgentConversationUiState(
+                detection = null,
+                events = emptyList(),
+                selectedTab = SessionTab.Conversation,
+                syncStatus = AgentConversationSyncStatus.Live,
+                loadState = ConversationLoadState.Loading,
+                rememberedAgentPlaceholder = true,
+            ))
+        }
     }
 
     /**

--- a/app/src/test/java/com/pocketshell/app/session/AgentConversationRepositoryTest.kt
+++ b/app/src/test/java/com/pocketshell/app/session/AgentConversationRepositoryTest.kt
@@ -798,6 +798,86 @@ class AgentConversationRepositoryTest {
     }
 
     @Test
+    fun detectLiveTranscriptForPaneBindsTheMostRecentKindWithoutAKnownKind() = runTest {
+        // Issue #975 (B1): the kind-agnostic transcript fallback. With NO known
+        // kind (the daemon returned `unknown`), it enumerates ALL kinds for the
+        // cwd, picks the MOST-RECENT candidate's kind, and binds its source. Here
+        // Claude is the most recent, so a Claude detection binds — this is the
+        // masked-live-agent evidence the recorded-shell verdict could not see.
+        val now = System.currentTimeMillis() / 1000
+        val session = FakeSshSession(
+            detectionOutput = """
+                claude|$now|/workspace/proj|/home/testuser/.claude/projects/-workspace-proj/live.jsonl
+                codex|${now - 600}|/workspace/proj|/home/testuser/.codex/sessions/2026/06/18/rollout-older.jsonl
+            """.trimIndent(),
+            hostWideProcessOutput = "1001 1 pts/7 node node",
+        )
+
+        val detection = AgentConversationRepository().detectLiveTranscriptForPane(
+            session = session,
+            cwd = "/workspace/proj",
+            paneTty = "/dev/pts/7",
+            paneCommand = "node",
+        )
+
+        assertEquals(
+            "#975 (B1): the kind-agnostic fallback binds the most-recent live " +
+                "transcript's kind (Claude) without a known/recorded kind",
+            AgentKind.ClaudeCode,
+            detection?.agent,
+        )
+        assertEquals("live", detection?.sessionId)
+    }
+
+    @Test
+    fun detectLiveTranscriptForPaneReturnsNullWhenNoTranscriptExists() = runTest {
+        // Issue #975 (B1 no-flap): a genuine shell with NO recent transcript in
+        // the cwd enumerates nothing → null. The fallback is evidence-driven, so a
+        // plain shell never resurrects a Conversation surface.
+        val session = FakeSshSession(detectionOutput = "")
+
+        val detection = AgentConversationRepository().detectLiveTranscriptForPane(
+            session = session,
+            cwd = "/workspace/proj",
+            paneTty = "/dev/pts/7",
+            paneCommand = "bash",
+        )
+
+        assertEquals(
+            "#975 (B1 no-flap): no live transcript in the cwd binds nothing",
+            null,
+            detection,
+        )
+    }
+
+    @Test
+    fun detectLiveTranscriptForPaneReturnsNullForBlankCwdOrTty() = runTest {
+        // Boundary: blank cwd/tty cannot scope an enumeration → null, never a crash.
+        val session = FakeSshSession(
+            detectionOutput =
+                "claude|1|/workspace/proj|/home/testuser/.claude/projects/-workspace-proj/x.jsonl",
+        )
+        assertEquals(
+            null,
+            AgentConversationRepository().detectLiveTranscriptForPane(
+                session = session,
+                cwd = "   ",
+                paneTty = "/dev/pts/7",
+                paneCommand = "bash",
+            ),
+        )
+        assertEquals(
+            null,
+            AgentConversationRepository().detectLiveTranscriptForPane(
+                session = session,
+                cwd = "/workspace/proj",
+                paneTty = "",
+                paneCommand = "bash",
+            ),
+        )
+    }
+
+    @Test
     fun recordedClaudeSessionResolvesWithoutTheHostWideProcessScan() = runTest {
         // Issue #828 (perf): the recorded-Claude path selects on the cwd-encoded
         // session-id-in-path with requireProcessMatch = false, so the host-wide

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
@@ -22,8 +22,12 @@ import com.pocketshell.core.agents.AgentKind
 import com.pocketshell.core.agents.ConversationEvent
 import com.pocketshell.core.agents.ConversationRole
 import com.pocketshell.core.agents.MessageSendState
+import com.pocketshell.core.ssh.ExecResult
 import com.pocketshell.core.ssh.SshException
 import com.pocketshell.core.ssh.SshKey
+import com.pocketshell.core.ssh.SshPortForward
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshShell
 import com.pocketshell.core.ssh.SshLease
 import com.pocketshell.core.ssh.SshLeaseConnector
 import com.pocketshell.core.ssh.SshLeaseKey
@@ -90,6 +94,7 @@ import org.json.JSONArray
 import org.json.JSONObject
 import java.io.File
 import java.io.IOException
+import java.io.InputStream
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.coroutines.CoroutineContext
@@ -157,6 +162,8 @@ class TmuxSessionViewModelTest {
         folderListGateway: FolderListGateway? = null,
         hostDao: HostDao? = null,
         agentRepository: AgentConversationRepository = AgentConversationRepository(),
+        agentKindRemoteSource: com.pocketshell.app.agents.AgentKindRemoteSource =
+            com.pocketshell.app.agents.AgentKindRemoteSource(),
     ): TmuxSessionViewModel =
         TmuxSessionViewModel(
             tmuxClientFactory = TmuxClientFactory(factoryScope),
@@ -168,6 +175,7 @@ class TmuxSessionViewModelTest {
             sshLeaseManager = sshLeaseManager,
             sessionLifecycleSignals = sessionLifecycleSignals,
             agentRepository = agentRepository,
+            agentKindRemoteSource = agentKindRemoteSource,
         ).also {
             // Issue #576 (Slice A of #792): pin the structural-reconcile
             // dispatcher to Main (the MainDispatcherRule's
@@ -8166,6 +8174,351 @@ class TmuxSessionViewModelTest {
         )
     }
 
+    // ─────────────────────── Issue #975 — REAL-PATH classify-miss ───────────
+    // The maintainer hit a LIVE Claude session showing ONLY "Terminal" — no
+    // Conversation toggle — because the session was recorded `@ps_agent_kind=shell`
+    // with a node-wrapped/quiet `claude` started inside it, and the host
+    // agent-kind daemon's cgroup-v2/`/proc` classify returns `unknown` (it cannot
+    // see the masked process) → no detection binds → the confirmed-shell verdict
+    // never clears → the toggle is gone for the session's life (#962 recurrence).
+    //
+    // These drive the REAL detection chain (resolveForeignKindGuess →
+    // AgentKindRemoteSource.classify → AgentConversationRepository) through a fake
+    // SSH session that models the masked-live-agent host: the `agents kind` daemon
+    // exec returns `unknown` (scope=null) while a fresh `*.jsonl` transcript is
+    // genuinely present in the cwd. This is the #780 synthetic-state-injection at
+    // the host seam — NOT a `markAgentTailLiveForTest` injection (which #962 used
+    // and which CANNOT exercise the failing classify-miss). The end-to-end Docker
+    // proof is `ConversationToggleVisibleForLiveAgentInShellRecordedSessionDockerTest`.
+
+    @Test
+    fun b1MaskedLiveClaudeInRecordedShellBindsDetectionViaTranscriptDespiteUnknownClassify() =
+        runTest(scheduler) {
+            // B1: daemon classify = `unknown` (masked agent) + a live Claude
+            // transcript in the cwd → the foreign resolver binds Claude detection
+            // (the trustworthy-live-agent-evidence fallback). On base (no fix) the
+            // foreign resolver returns null on a null kind guess, so NO detection
+            // binds and the toggle stays gone — RED. With the fix the transcript
+            // fallback binds → GREEN.
+            val now = System.currentTimeMillis() / 1000
+            val session = MaskedAgentSshSession(
+                // The daemon could not read the scope → `unknown`, NOT `none`.
+                classifyAgentKind = "unknown",
+                // …but a live Claude transcript is plainly present in the cwd.
+                detectionOutput =
+                    "claude|$now|/workspace/proj|" +
+                        "/home/testuser/.claude/projects/-workspace-proj/live.jsonl",
+            )
+            val vm = newVm()
+            vm.connectWithRichPaneForTest(
+                paneId = "%0",
+                windowId = "@0",
+                cwd = "/workspace/proj",
+                paneTty = "/dev/pts/7",
+                panePid = 4242L,
+                session = session,
+            )
+            runCurrent()
+            // The durable tree recorded this session `@ps_agent_kind=shell`.
+            vm.applyRecordedShellVerdictForTest(sessionId = "$0", isShell = true)
+            runCurrent()
+            assertTrue(
+                "#975 precondition: the recorded-shell pane is published confirmed-shell",
+                "%0" in vm.confirmedShellPaneIds.value,
+            )
+
+            val detection = vm.resolveForeignSessionDetectionForTest("%0", session)
+            runCurrent()
+
+            assertNotNull(
+                "#975 (B1): a CONFIRMED-SHELL pane whose daemon classify returns " +
+                    "`unknown` while a live Claude transcript is present must bind " +
+                    "the agent via the transcript-evidence fallback (RED on base — " +
+                    "the foreign resolver returned null and no detection bound)",
+                detection,
+            )
+            assertEquals(
+                "#975 (B1): the bound detection is the live Claude transcript",
+                AgentKind.ClaudeCode,
+                detection?.agent,
+            )
+        }
+
+    @Test
+    fun b1GenuineNoneShellGetsNoTranscriptFallbackNoFlap() = runTest(scheduler) {
+        // B1 no-flap control (#894): a daemon `none` verdict (a READABLE scope
+        // with no agent — a genuine shell) must NOT trigger the transcript
+        // fallback even if a STALE transcript lingers in the cwd. `none` is a
+        // confident "no agent", unlike the unreadable `unknown`. Detection stays
+        // null → the confirmed-shell verdict is preserved → the toggle correctly
+        // stays hidden.
+        val now = System.currentTimeMillis() / 1000
+        val session = MaskedAgentSshSession(
+            classifyAgentKind = "none",
+            detectionOutput =
+                "claude|$now|/workspace/proj|" +
+                    "/home/testuser/.claude/projects/-workspace-proj/stale.jsonl",
+        )
+        val vm = newVm()
+        vm.connectWithRichPaneForTest(
+            paneId = "%0",
+            windowId = "@0",
+            cwd = "/workspace/proj",
+            paneTty = "/dev/pts/7",
+            panePid = 4242L,
+            session = session,
+        )
+        runCurrent()
+        vm.applyRecordedShellVerdictForTest(sessionId = "$0", isShell = true)
+        runCurrent()
+
+        val detection = vm.resolveForeignSessionDetectionForTest("%0", session)
+        runCurrent()
+
+        assertNull(
+            "#975 (B1 no-flap): a daemon `none` (genuine readable shell) must NOT " +
+                "bind a transcript fallback — only the unreadable `unknown` does. " +
+                "Detection stays null so the confirmed-shell verdict is preserved.",
+            detection,
+        )
+    }
+
+    @Test
+    fun b1UnknownClassifyButNoTranscriptStaysNull() = runTest(scheduler) {
+        // B1 boundary: `unknown` classify but NO live transcript in the cwd → the
+        // fallback enumerates nothing → null (a genuine shell with an unreadable
+        // scope and no agent). The fallback is evidence-driven: no transcript, no
+        // bind, no flap.
+        val session = MaskedAgentSshSession(
+            classifyAgentKind = "unknown",
+            detectionOutput = "",
+        )
+        val vm = newVm()
+        vm.connectWithRichPaneForTest(
+            paneId = "%0",
+            windowId = "@0",
+            cwd = "/workspace/proj",
+            paneTty = "/dev/pts/7",
+            panePid = 4242L,
+            session = session,
+        )
+        runCurrent()
+        vm.applyRecordedShellVerdictForTest(sessionId = "$0", isShell = true)
+        runCurrent()
+
+        val detection = vm.resolveForeignSessionDetectionForTest("%0", session)
+        runCurrent()
+
+        assertNull(
+            "#975 (B1 boundary): `unknown` classify with NO transcript binds nothing",
+            detection,
+        )
+    }
+
+    @Test
+    fun b1ForeignNotConfirmedShellUnknownClassifyGetsNoTranscriptFallback() = runTest(scheduler) {
+        // B1 scope guard: the transcript fallback is for a CONFIRMED-SHELL session
+        // ONLY — we second-guess a stale recorded-shell verdict, never a clean
+        // foreign session. A foreign (not-confirmed-shell) pane whose daemon
+        // returns `unknown` keeps the existing null behaviour (the user picks the
+        // kind); it does NOT auto-bind a same-cwd transcript.
+        val now = System.currentTimeMillis() / 1000
+        val session = MaskedAgentSshSession(
+            classifyAgentKind = "unknown",
+            detectionOutput =
+                "claude|$now|/workspace/proj|" +
+                    "/home/testuser/.claude/projects/-workspace-proj/live.jsonl",
+        )
+        val vm = newVm()
+        vm.connectWithRichPaneForTest(
+            paneId = "%0",
+            windowId = "@0",
+            cwd = "/workspace/proj",
+            paneTty = "/dev/pts/7",
+            panePid = 4242L,
+            session = session,
+        )
+        runCurrent()
+        // NOTE: no applyRecordedShellVerdict → the session is FOREIGN, not
+        // confirmed-shell.
+
+        val detection = vm.resolveForeignSessionDetectionForTest("%0", session)
+        runCurrent()
+
+        assertNull(
+            "#975 (B1 scope): a FOREIGN (not-confirmed-shell) pane with `unknown` " +
+                "classify gets NO transcript fallback — the fallback only clears a " +
+                "stale recorded-shell verdict",
+            detection,
+        )
+    }
+
+    @Test
+    fun b1PrimeDedupOrderingReProbesConfirmedShellPaneOnUnchangedInput() = runTest(scheduler) {
+        // B1′ (dedup ordering): a `claude` started INSIDE an already-detected
+        // shell pane does NOT change the `(cwd, command, tty)` triple. On base the
+        // dedup early-return PRECEDED the cache-bust, so the stale one-shot "no
+        // agent" guess persisted and the pane never re-probed. The fix busts the
+        // confirmed-shell foreign-guess cache BEFORE the dedup check, so the next
+        // probe re-evaluates. Here: seed a cached `unknown` guess, confirm it is
+        // cached, then a confirmed-shell detection re-run must have BUSTED it.
+        val session = MaskedAgentSshSession(classifyAgentKind = "unknown", detectionOutput = "")
+        val vm = newVm()
+        vm.connectWithRichPaneForTest(
+            paneId = "%0",
+            windowId = "@0",
+            cwd = "/workspace/proj",
+            paneTty = "/dev/pts/7",
+            panePid = 4242L,
+            session = session,
+        )
+        runCurrent()
+        vm.applyRecordedShellVerdictForTest(sessionId = "$0", isShell = true)
+        runCurrent()
+
+        // Simulate the one-shot guess having cached "no agent" before the agent
+        // launched (the stale guess the dedup bug never re-evaluated).
+        vm.seedForeignGuessCacheForTest("$0")
+        assertTrue(
+            "#975 (B1′): precondition — the stale one-shot guess is cached",
+            vm.foreignGuessIsCachedForTest("$0"),
+        )
+
+        // A re-probe of the confirmed-shell pane (same unchanged input) must BUST
+        // the cache BEFORE the dedup early-return, so the daemon re-evaluates.
+        vm.startAgentDetectionForPaneForTest("%0")
+        runCurrent()
+
+        assertFalse(
+            "#975 (B1′): re-probing a confirmed-shell pane busts the stale foreign " +
+                "guess cache (the cache-bust now precedes the dedup early-return) — " +
+                "RED on base where the early-return skipped the bust and the stale " +
+                "guess persisted",
+            vm.foreignGuessIsCachedForTest("$0"),
+        )
+    }
+
+    @Test
+    fun b2ReattachReStampDoesNotDropRememberedAgentPlaceholder() = runTest(scheduler) {
+        // B2 (#959 beyond-grace reattach re-stamp): on reconnect the screen
+        // re-reads `@ps_agent_kind=shell` and re-applies applyRecordedShellVerdict
+        // (isShell=true). On base that UNCONDITIONALLY dropped the just-restored
+        // remembered-agent placeholder (#819 A2), re-suppressing the Conversation
+        // toggle for a session that WAS a live agent before backgrounding — the
+        // raw black Terminal strand. The fix keeps the remembered-agent placeholder
+        // (only the fresh #878 auto-seed is dropped); detection re-confirms it.
+        val vm = newVm()
+        vm.connectWithPaneForTest(paneId = "%0", windowId = "@0")
+        runCurrent()
+
+        // A beyond-grace reattach restored the remembered-agent resolving
+        // placeholder (#819 A2 — detection-less, on Conversation).
+        vm.seedRememberedAgentPlaceholderForTest("%0")
+        runCurrent()
+        assertNotNull(
+            "#975 (B2): precondition — the remembered-agent placeholder is restored",
+            vm.agentConversations.value["%0"],
+        )
+        assertEquals(
+            SessionTab.Conversation,
+            vm.agentConversations.value["%0"]!!.selectedTab,
+        )
+
+        // The reconnect re-read re-applies the recorded-shell verdict.
+        vm.applyRecordedShellVerdictForTest(sessionId = "$0", isShell = true)
+        runCurrent()
+
+        assertNotNull(
+            "#975 (B2): the reattach re-stamp must NOT drop the remembered-agent " +
+                "placeholder (RED on base — applyRecordedShellVerdict tore it down " +
+                "and the Conversation toggle disappeared post-reconnect)",
+            vm.agentConversations.value["%0"],
+        )
+        assertTrue(
+            "#975 (B2): the surviving row is still the remembered-agent placeholder",
+            vm.agentConversations.value["%0"]!!.rememberedAgentPlaceholder,
+        )
+        assertEquals(
+            "#975 (B2): it is still on the Conversation surface (the toggle survives)",
+            SessionTab.Conversation,
+            vm.agentConversations.value["%0"]!!.selectedTab,
+        )
+    }
+
+    @Test
+    fun b2ReattachReStampStillDropsFreshAutoSeededPlaceholder() = runTest(scheduler) {
+        // B2 adjacency (#894): the B2 fix must NOT resurrect the #894 first-open
+        // FLASH — a FRESH #878 auto-seeded placeholder (NOT a remembered agent)
+        // racing ahead of the recorded-shell read must STILL be dropped on the
+        // confirmed-shell verdict. Only the remembered-agent placeholder is spared.
+        val vm = newVm()
+        vm.setDefaultAgentSessionViewForTest(
+            com.pocketshell.app.settings.DefaultAgentSessionView.Conversation,
+        )
+        vm.connectWithPaneForTest(paneId = "%0", windowId = "@0")
+        runCurrent()
+        // The fresh #878 auto-seed is up (autoSeededPlaceholder = true).
+        assertTrue(
+            "#894: precondition — the fresh auto-seed is up",
+            vm.agentConversations.value["%0"]?.autoSeededPlaceholder == true,
+        )
+
+        vm.applyRecordedShellVerdictForTest(sessionId = "$0", isShell = true)
+        runCurrent()
+
+        assertNull(
+            "#975 (B2 adjacency / #894): a FRESH auto-seeded placeholder is STILL " +
+                "dropped on the confirmed-shell verdict (the first-open flash kill " +
+                "is preserved — only the remembered-agent placeholder is spared)",
+            vm.agentConversations.value["%0"],
+        )
+    }
+
+    /**
+     * Issue #975: connect + register a single pane carrying a real [cwd], [paneTty]
+     * and [panePid] (the foreign-detection inputs the one-shot daemon guess + the
+     * transcript fallback need), with [session] installed as the active sessionRef
+     * so the REAL detection chain runs against the fake masked-agent host.
+     */
+    private fun TmuxSessionViewModel.connectWithRichPaneForTest(
+        paneId: String,
+        windowId: String,
+        cwd: String,
+        paneTty: String,
+        panePid: Long,
+        session: SshSession,
+        sessionName: String = "work",
+    ) {
+        replaceClientForTest(
+            hostId = 42L,
+            hostName = "docker",
+            host = "10.0.2.2",
+            port = 2222,
+            user = "alex",
+            keyPath = "/keys/a",
+            sessionName = sessionName,
+            client = FakeTmuxClient(),
+            session = session,
+        )
+        applyParsedPanesForTest(
+            listOf(
+                TmuxSessionViewModel.ParsedPane(
+                    paneId,
+                    windowId,
+                    "$0",
+                    "node",
+                    paneIndex = 0,
+                    cwd = cwd,
+                    currentCommand = "node",
+                    paneTty = paneTty,
+                    panePid = panePid,
+                    sessionName = sessionName,
+                ),
+            ),
+        )
+        setSessionRefForTest(session)
+    }
+
     @Test
     fun terminalDefaultNeverSeedsPlaceholderRegardlessOfShellVerdict() = runTest(scheduler) {
         // G2 class coverage (default = Terminal, both shell and agent): when the
@@ -15531,5 +15884,77 @@ class TmuxSessionViewModelTest {
         override suspend fun delete(host: com.pocketshell.core.storage.entity.HostEntity) =
             error("not used")
         override suspend fun deleteById(id: Long) = error("not used")
+    }
+
+    /**
+     * Issue #975: an [SshSession] double modelling the MASKED-LIVE-AGENT host the
+     * maintainer hit — the agent-kind daemon's cgroup-v2/`/proc` classify returns
+     * `unknown` (or `none`) for a node-wrapped/quiet `claude`, while the agent's
+     * `*.jsonl` transcript is genuinely present in the cwd-encoded log dir. It
+     * answers exactly the two execs the foreign-detection chain issues:
+     *   - the `pocketshell agents kind` daemon classify (JSON envelope, with
+     *     [classifyAgentKind] one of `claude`/`codex`/`opencode`/`none`/`unknown`),
+     *   - the cwd-scoped candidate enumeration ([detectionCommand], `claude_dir=`),
+     *     returning [detectionOutput].
+     * This is the #780 synthetic-state injection at the host seam — it reproduces
+     * the classify-miss the real Docker fixture also produces (scope=null in a
+     * non-systemd container), exercising the REAL resolver, not a markAgentTailLive
+     * injection.
+     */
+    private class MaskedAgentSshSession(
+        private val classifyAgentKind: String,
+        private val detectionOutput: String = "",
+        private val hostWideProcessOutput: String = "",
+    ) : SshSession {
+        override val isConnected: Boolean = true
+
+        override suspend fun exec(command: String): ExecResult {
+            val stdout = when {
+                // The host-side `pocketshell agents kind` daemon classify. The
+                // request pipes a `{"panes":[{"pane_id":"%N", ...}]}` snapshot; we
+                // echo each requested pane id back with [classifyAgentKind].
+                command.contains("agents kind") -> {
+                    val paneIds = PANE_ID_RE.findAll(command).map { it.groupValues[1] }.toList()
+                    buildString {
+                        append("{\"results\":[")
+                        paneIds.forEachIndexed { index, paneId ->
+                            if (index > 0) append(',')
+                            append("{\"pane_id\":\"").append(paneId).append("\",")
+                            append("\"agent_kind\":\"").append(classifyAgentKind).append("\",")
+                            append("\"scope\":null}")
+                        }
+                        append("]}")
+                    }
+                }
+                // The cwd-scoped candidate enumeration ([detectionCommand]).
+                command.contains("claude_dir=") -> detectionOutput
+                command.contains("ps -eo pid,ppid,tty,comm,args") -> hostWideProcessOutput
+                command.contains("ps -eo pid,tty,comm,args") -> hostWideProcessOutput
+                else -> ""
+            }
+            return ExecResult(stdout = stdout, stderr = "", exitCode = 0)
+        }
+
+        override fun tail(path: String, onLine: (String) -> Unit): Job = Job()
+        override fun tail(path: String, fromLineExclusive: Long, onLine: (String) -> Unit): Job = Job()
+        override fun openLocalPortForward(
+            remoteHost: String,
+            remotePort: Int,
+            localPort: Int,
+        ): SshPortForward = throw NotImplementedError()
+        override fun startShell(): SshShell = throw NotImplementedError()
+        override suspend fun uploadFile(file: File, remotePath: String): String =
+            error("uploadFile not used")
+        override suspend fun uploadStream(
+            input: InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String = error("uploadStream not used")
+        override fun close() = Unit
+
+        private companion object {
+            val PANE_ID_RE = Regex("\"pane_id\":\"([^\"]+)\"")
+        }
     }
 }

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -602,25 +602,29 @@ JOURNEY_CLASSES=(
   # local-only flaky-reconnect evidence). Target the single @Test method by
   # FQCN#method so the CI-gated reconnect cases are NOT selected here.
   "com.pocketshell.app.tmux.AgentConversationReconnectDockerTest#agentOpensOnDefaultViewAndIsNotYankedMidSessionShellGetsNoConversationRow"
-  # ADDED (#962, conversation-source area — sibling of #819/#821/#894, D31/D32):
-  # a live agent (claude/codex/opencode) started INSIDE a session recorded
-  # `@ps_agent_kind=shell` must regain its Terminal <-> Conversation TOGGLE. On
-  # base the recorded-shell verdict (#894) collapses presumedAgent for the life of
-  # the session, hiding the toggle (the maintainer's exact dogfood report). The
-  # LOAD-BEARING reproduction (G6/D33 red->green, class-covering claude/codex/
-  # opencode + the no-flap control) is the DETERMINISTIC JVM
-  # TmuxSessionViewModelTest.liveAgentDetectionClearsConfirmedShellSoConversationToggleReturns
-  # (the Docker agents fixture cannot make the host agent-kind daemon classify a
-  # process — it gates on a cgroup-v2 scope the non-systemd container lacks, so a
-  # recorded-shell pane cannot bind a live detection in-fixture; per D33 that
-  # unenterable state is injected synthetically and hard-asserted in JVM, never
-  # self-skipped). THIS connected journey gates the active-rework ADJACENCY the
-  # fix must preserve: a recorded-shell session with NO agent shows NO toggle on
-  # the real TmuxSessionScreen (the #894 no-flap invariant — a recorded shell must
-  # not flash the Conversation tab). It uses ONLY agents:2222
-  # (DEFAULT_HOST/DEFAULT_PORT -> 10.0.2.2:2222) that tests.yml already brings up,
-  # and does NOT self-skip on CI (no assumeTrue / assumeFalse(isRunningOnCi())).
-  # Lives under com.pocketshell.app.tmux.
+  # ADDED (#962/#975, conversation-source area — sibling of #819/#821/#894,
+  # D31/D32): a live agent (claude) started INSIDE a session recorded
+  # `@ps_agent_kind=shell` must regain its Terminal <-> Conversation TOGGLE, EVEN
+  # when the host agent-kind daemon's classify returns `unknown` for the masked
+  # node-wrapped/quiet `claude` (the B1 classify-miss the maintainer hit on
+  # v0.4.18). On base the recorded-shell verdict (#894) collapses presumedAgent and
+  # the `unknown` classify left detection null for the life of the session, hiding
+  # the toggle (the maintainer's exact dogfood report). This class runs BOTH
+  # directions on the REAL path:
+  #   - conversationToggleReturnsForMaskedLiveClaudeInRecordedShellSession (#975 B1):
+  #     the LOAD-BEARING real-path red->green. The agents fixture ships a live Claude
+  #     transcript at ~/.claude/projects/-workspace-pocketshell/pocketshell-claude.jsonl
+  #     AND its daemon returns `unknown`/scope=null (non-systemd container) — exactly
+  #     the masked-live-agent state. On base the foreign resolver returns null and NO
+  #     toggle appears; the #975 transcript-evidence fallback binds the agent so the
+  #     toggle returns. (The fast JVM sibling is TmuxSessionViewModelTest.b1Masked* +
+  #     b1Prime* + b2Reattach*.)
+  #   - plainShellRecordedSessionShowsNoConversationToggle (#894 no-flap ADJACENCY):
+  #     a recorded-shell session with NO agent transcript shows NO toggle (a recorded
+  #     shell must not flash the Conversation tab).
+  # It uses ONLY agents:2222 (DEFAULT_HOST/DEFAULT_PORT -> 10.0.2.2:2222) that
+  # tests.yml already brings up, and does NOT self-skip on CI (no assumeTrue /
+  # assumeFalse(isRunningOnCi())). Lives under com.pocketshell.app.tmux.
   "com.pocketshell.app.tmux.ConversationToggleVisibleForLiveAgentInShellRecordedSessionDockerTest"
   # ADDED (#813): the composer-launcher NARROW / LARGE-FONT clip proof. The
   # maintainer dogfooded (2026-06-18 07:53) the launcher being CLIPPED off the


### PR DESCRIPTION
Fixes #975 — the maintainer's recurring 'half black screen'. A live Claude/Codex agent in a session recorded `@ps_agent_kind=shell` showed only a 'Terminal' toggle (no Conversation) and was stranded on the raw, mostly-black Terminal for the session's whole life when the host daemon classify returned `unknown`. #962 recurrence.

## Fix (whole class)
- **B1** — bind a kind-agnostic live-transcript probe (`AgentConversationRepository.detectLiveTranscriptForPane`) so the recorded-shell verdict clears on trustworthy live-agent evidence even when the daemon classify misses → Conversation toggle returns + agent defaults to Conversation (#818).
- **B1'** — cache-bust before the dedup early-return so a confirmed-shell pane actually re-probes.
- **B2** — a beyond-grace reattach (#959) re-stamp no longer drops a restored remembered-agent placeholder.

## Verification (reviewer-reproduced, round 2)
- Real-path red→green on the connected Docker `agents` fixture (non-systemd → classify `unknown` with a live Claude transcript). GREEN: `tests=2 failures=0`, screenshot shows the Terminal/Conversation toggle + live Conversation surface. RED on base: neutralizing the B1 transcript fallback fails the **bound-detection** assertion (not the optimistic pre-detection toggle — the #962/#635 vacuous-pass trap was found and closed).
- B1/B1'/B2 class coverage; adjacency journeys (#962/#959/#894/#818) green; CI-wired in `ci-journey-suite.sh`.

Part of the #874 black-screen umbrella (residual pre-detection/cached-pane gap tracked separately). Reviewer APPROVED (round 2): https://github.com/alexeygrigorev/pocketshell/issues/975#issuecomment-4806747785