### PR TITLE
Bulletproof batch: ~/git tilde (#990) + tmux FatalClose ride-through (#979) + port-forward single-writer (#980)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/portfwd/PortForwardModule.kt
+++ b/app/src/main/java/com/pocketshell/app/portfwd/PortForwardModule.kt
@@ -2,8 +2,27 @@ package com.pocketshell.app.portfwd
 
 import dagger.Binds
 import dagger.Module
+import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import javax.inject.Qualifier
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+
+/**
+ * Qualifies the `Dispatchers.Default` [CoroutineDispatcher] so port-forward
+ * components (notably
+ * [com.pocketshell.app.portfwd.service.ForwardingService]) can inject — and a
+ * test can override — the dispatcher backing their background coroutines
+ * instead of hard-wiring a bare `Dispatchers.Default` that no test can cancel.
+ *
+ * Issue #994: the un-injectable `Dispatchers.Default` scope let the service's
+ * notification-observe coroutine outlive a Robolectric unit test and crash the
+ * NEXT test with an `UncaughtExceptionsBeforeTest` NPE.
+ */
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class DefaultDispatcher
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -12,4 +31,10 @@ abstract class PortForwardModule {
     abstract fun bindPortForwardConnector(
         connector: DefaultPortForwardConnector,
     ): PortForwardConnector
+
+    companion object {
+        @Provides
+        @DefaultDispatcher
+        fun provideDefaultDispatcher(): CoroutineDispatcher = Dispatchers.Default
+    }
 }

--- a/app/src/main/java/com/pocketshell/app/portfwd/service/ForwardingService.kt
+++ b/app/src/main/java/com/pocketshell/app/portfwd/service/ForwardingService.kt
@@ -15,10 +15,12 @@ import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
 import com.pocketshell.app.MainActivity
 import com.pocketshell.app.R
+import com.pocketshell.app.portfwd.DefaultDispatcher
 import com.pocketshell.app.portfwd.ForwardingController
 import com.pocketshell.app.systemsurfaces.ForwardingTileService
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -79,9 +81,55 @@ class ForwardingService : Service() {
     @Inject
     lateinit var controller: ForwardingController
 
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    /**
+     * Dispatcher backing the notification-observe coroutine ([startObserving]).
+     *
+     * Injected (not a bare `Dispatchers.Default`) so a test can confine the
+     * observe loop to its own [kotlinx.coroutines.test.TestDispatcher] — one it
+     * cancels in `@After` — instead of leaking a real `Dispatchers.Default`
+     * background coroutine that outlives the test and dereferences the
+     * already-torn-down Robolectric Application in [updateNotification] (issue
+     * #994: the intermittent full-suite `UncaughtExceptionsBeforeTest` NPE).
+     *
+     * Hilt field injection runs for this `@AndroidEntryPoint` service before
+     * `onCreate`, so by the time [onStartCommand] builds [scope] the injected
+     * dispatcher is in place. The `Dispatchers.Default` default keeps a
+     * non-Hilt-graph instantiation (a plain `new ForwardingService()` in a unit
+     * test that does not exercise the observe loop) working without a crash.
+     */
+    @Inject
+    @DefaultDispatcher
+    @JvmField
+    @androidx.annotation.VisibleForTesting
+    var observeDispatcher: CoroutineDispatcher = Dispatchers.Default
+
+    // Built lazily off [observeDispatcher] on first use ([startObserving]) so the
+    // injected dispatcher (set by Hilt field injection before onStartCommand, or
+    // by a test before it drives onStartCommand) backs the scope. `lazy` rather
+    // than building it in onCreate because the generated `Hilt_ForwardingService`
+    // onCreate requires a @HiltAndroidApp Application — a plain Robolectric unit
+    // test drives onStartCommand directly without onCreate, so scope creation must
+    // not depend on onCreate having run. Cancelled in [onDestroy].
+    private val scopeDelegate = lazy {
+        // SupervisorJob so a failure in the observe collector does not cascade.
+        CoroutineScope(SupervisorJob() + observeDispatcher)
+    }
+    private val scope: CoroutineScope by scopeDelegate
     private var observeJob: Job? = null
     private var hasStartedForeground = false
+
+    /** Issue #994 test seam: the observe coroutine, so a test can assert it is
+     * active while observing and cancelled by `onDestroy()`. */
+    @get:androidx.annotation.VisibleForTesting
+    internal val observeJobForTest: Job?
+        get() = observeJob
+
+    /** Issue #994 test seam: the dispatcher the observe collector resumed on,
+     * recorded in [startObserving]. Lets a test assert the observe loop is
+     * confined to the injected dispatcher, not a leaked Dispatchers.Default. */
+    @androidx.annotation.VisibleForTesting
+    internal var lastObserveDispatcherForTest: CoroutineDispatcher? = null
+        private set
 
     companion object {
         private const val TAG = "PsForwardingService"
@@ -216,7 +264,10 @@ class ForwardingService : Service() {
     override fun onDestroy() {
         observeJob?.cancel()
         observeJob = null
-        scope.cancel()
+        // Cancel the observe-loop scope so no coroutine outlives the service
+        // (issue #994). Guarded so we don't force-create the lazy scope just to
+        // cancel it on a service that never started observing.
+        if (scopeDelegate.isInitialized()) scope.cancel()
         super.onDestroy()
     }
 
@@ -238,6 +289,12 @@ class ForwardingService : Service() {
 
     private fun startObserving() {
         observeJob = scope.launch {
+            // Issue #994: record the dispatcher the collector actually resumed
+            // on so a JVM test can assert the observe loop is confined to the
+            // INJECTED dispatcher (not a free-running Dispatchers.Default thread
+            // that outlives the test). No production effect — read only by tests.
+            lastObserveDispatcherForTest =
+                coroutineContext[kotlinx.coroutines.CoroutineDispatcher]
             // Combine active-host count + tunnel count so a single
             // collector renders both into the notification. Dropping
             // duplicates means we don't churn the notification on

--- a/app/src/main/java/com/pocketshell/app/portfwd/service/ForwardingService.kt
+++ b/app/src/main/java/com/pocketshell/app/portfwd/service/ForwardingService.kt
@@ -8,8 +8,6 @@ import android.app.Service
 import android.content.Context
 import android.content.Intent
 import android.content.pm.ServiceInfo
-import android.net.ConnectivityManager
-import android.net.Network
 import android.os.Build
 import android.os.IBinder
 import android.util.Log
@@ -52,12 +50,28 @@ import kotlinx.coroutines.launch
  *    user-visible notification (so the OS doesn't kill us)
  *  - Mirror connection / tunnel state from [ForwardingController] into
  *    the notification text so the user sees host name + tunnel count
- *  - Register a network-availability callback and call
- *    [ForwardingController.reconnectNow] on network recovery, so the
- *    controller-owned [com.pocketshell.core.portfwd.AutoForwarderSupervisor]
- *    skips its exponential-backoff sleep
  *  - Stop itself when [ForwardingController.flowOfActiveHostCount]
  *    drops to zero (all hosts disabled their auto-forward toggle)
+ *
+ * ## Network-change handling is NOT the service's job (issue #980)
+ *
+ * The service deliberately does NOT register its own network callback.
+ * Before #980 it registered a raw `ConnectivityManager.registerDefaultNetworkCallback`
+ * that called [ForwardingController.forceReconnectNow] on ANY raw
+ * `onLost`→`onAvailable` pair — including a same-AP band-steer / mesh-node
+ * roam / momentary RF re-association the link actually survives. That
+ * force-closed a transport whose keepalive window said it was still alive,
+ * a self-inflicted drop on stable wifi (the #974 signature) — and it
+ * bypassed the same-SSID-reassoc hardening
+ * ([com.pocketshell.app.connectivity.TerminalNetworkObserver]'s
+ * `hasSameNetworkIdentityAs`, #875) that the rest of the app uses.
+ *
+ * Network-driven reconnect for the forwarding feature is owned SOLELY by
+ * [ForwardingController], which subscribes to the hardened, debounced
+ * `TerminalNetworkObserver.changes` signal and forces a rebuild only on a
+ * REAL validated default-network handoff. Hard-cut (D22): the service's
+ * private raw callback is deleted, not gated behind a flag — there is one
+ * hardened network path, not two competing ones.
  */
 @AndroidEntryPoint
 class ForwardingService : Service() {
@@ -67,9 +81,6 @@ class ForwardingService : Service() {
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     private var observeJob: Job? = null
-    private var networkCallback: ConnectivityManager.NetworkCallback? = null
-    @Volatile
-    private var defaultNetworkWasLost = false
     private var hasStartedForeground = false
 
     companion object {
@@ -189,7 +200,6 @@ class ForwardingService : Service() {
                 promoteToForegroundIfNeeded(initialNotification())
                 if (observeJob == null || observeJob?.isActive != true) {
                     startObserving()
-                    registerNetworkCallback()
                 }
             }
         }
@@ -206,7 +216,6 @@ class ForwardingService : Service() {
     override fun onDestroy() {
         observeJob?.cancel()
         observeJob = null
-        unregisterNetworkCallback()
         scope.cancel()
         super.onDestroy()
     }
@@ -264,69 +273,9 @@ class ForwardingService : Service() {
         }
     }
 
-    private fun registerNetworkCallback() {
-        if (networkCallback != null) return
-        defaultNetworkWasLost = false
-        val cm = getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
-            ?: return
-        val cb = object : ConnectivityManager.NetworkCallback() {
-            override fun onAvailable(network: Network) {
-                handleDefaultNetworkAvailable()
-            }
-
-            override fun onLost(network: Network) {
-                handleDefaultNetworkLost()
-            }
-        }
-        try {
-            cm.registerDefaultNetworkCallback(cb)
-            networkCallback = cb
-        } catch (_: SecurityException) {
-            // Some restricted profiles disallow registering network
-            // callbacks. Reconnect-on-network-recovery becomes a
-            // best-effort feature in that case; the underlying
-            // supervisor still retries on its own backoff schedule.
-        }
-    }
-
-    private fun unregisterNetworkCallback() {
-        val cb = networkCallback ?: return
-        val cm = getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
-        try {
-            cm?.unregisterNetworkCallback(cb)
-        } catch (_: IllegalArgumentException) {
-            // Already unregistered (e.g. service was stop/started
-            // quickly). Safe to ignore.
-        }
-        networkCallback = null
-        defaultNetworkWasLost = false
-    }
-
-    @androidx.annotation.VisibleForTesting
-    internal fun handleDefaultNetworkAvailable() {
-        // Network came back. Nudge the supervisor(s) so any in-flight
-        // backoff sleep cancels and a reconnect attempt happens
-        // immediately. If we observed an actual default-network loss
-        // first, force a transport rebuild: sshj can leave the old
-        // session looking "connected" after Android swaps networks,
-        // while the forwards are already dead.
-        if (defaultNetworkWasLost) {
-            defaultNetworkWasLost = false
-            controller.forceReconnectNow()
-        } else {
-            controller.reconnectNow()
-        }
-    }
-
-    @androidx.annotation.VisibleForTesting
-    internal fun handleDefaultNetworkLost() {
-        defaultNetworkWasLost = true
-    }
-
     private fun stopForwarding() {
         observeJob?.cancel()
         observeJob = null
-        unregisterNetworkCallback()
         // STOP_FOREGROUND_REMOVE makes the notification disappear
         // immediately. The constant has been stable since API 24.
         stopForeground(STOP_FOREGROUND_REMOVE)

--- a/app/src/main/java/com/pocketshell/app/sessions/TmuxSessionCreation.kt
+++ b/app/src/main/java/com/pocketshell/app/sessions/TmuxSessionCreation.kt
@@ -65,7 +65,7 @@ internal fun remoteStartDirectoryExistsCommand(startDirectory: String): String {
         pocketshell_start_dir=${shellQuote(resolved)}
         case "${'$'}pocketshell_start_dir" in
           '~') pocketshell_start_dir=${'$'}HOME ;;
-          '~/'*) pocketshell_start_dir=${'$'}HOME/${'$'}{pocketshell_start_dir#~/} ;;
+          '~/'*) pocketshell_start_dir=${'$'}HOME/${'$'}{pocketshell_start_dir#"~/"} ;;
           '${'$'}HOME') pocketshell_start_dir=${'$'}HOME ;;
           '${'$'}HOME/'*) pocketshell_start_dir=${'$'}HOME/${'$'}{pocketshell_start_dir#${'$'}HOME/} ;;
         esac

--- a/app/src/test/java/com/pocketshell/app/portfwd/ForwardingControllerTest.kt
+++ b/app/src/test/java/com/pocketshell/app/portfwd/ForwardingControllerTest.kt
@@ -11,6 +11,8 @@ import androidx.test.core.app.ApplicationProvider
 import com.pocketshell.app.portfwd.service.ForwardingService
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -543,6 +545,13 @@ class ForwardingControllerTest {
         // the controller manually, exactly like the sibling notification tests.
         val service = Robolectric.buildService(ForwardingService::class.java).get()
         service.controller = ForwardingController(context)
+        // Issue #994: confine the START path's observe coroutine to a test
+        // dispatcher we own, so it CANNOT escape onto a real Dispatchers.Default
+        // background thread and outlive this test (the intermittent full-suite
+        // UncaughtExceptionsBeforeTest NPE — the observe collector dereferencing
+        // the torn-down Application after teardown). onDestroy() below cancels it.
+        val observeScheduler = TestCoroutineScheduler()
+        service.observeDispatcher = StandardTestDispatcher(observeScheduler)
         // Drive the START path that USED to register the raw default-network
         // callback (the deleted `registerNetworkCallback()` call lived here).
         service.onStartCommand(
@@ -560,6 +569,10 @@ class ForwardingControllerTest {
             callbacksBefore,
             callbacksAfter,
         )
+
+        // Issue #994: tear the service down so its observe coroutine is cancelled
+        // and nothing leaks past this test onto a background thread.
+        service.onDestroy()
     }
 
     @Test

--- a/app/src/test/java/com/pocketshell/app/portfwd/ForwardingControllerTest.kt
+++ b/app/src/test/java/com/pocketshell/app/portfwd/ForwardingControllerTest.kt
@@ -516,35 +516,123 @@ class ForwardingControllerTest {
     }
 
     @Test
-    fun `service forces reconnect only after observed default network loss`() {
-        val controller = ForwardingController(context)
-        val normalCalls = java.util.concurrent.atomic.AtomicInteger(0)
+    fun `service registers no raw default-network callback so it cannot force-tear a live transport on stable-wifi jitter`() {
+        // Issue #980 (defect 2) — regression proof.
+        //
+        // The ForwardingService used to register its OWN raw
+        // `registerDefaultNetworkCallback` that called forceReconnectNow() on ANY
+        // raw onLost→onAvailable pair — including a same-AP band-steer / mesh-node
+        // roam / momentary RF re-association the link survives — force-closing a
+        // transport the keepalive window said was still alive (the #974
+        // stable-wifi self-inflicted drop). It bypassed the same-SSID-reassoc
+        // hardening (TerminalNetworkObserver.hasSameNetworkIdentityAs, #875) the
+        // rest of the app uses.
+        //
+        // The fix (hard-cut, D22): the service registers NO network callback at
+        // all — network-driven reconnect is owned SOLELY by ForwardingController's
+        // hardened TerminalNetworkObserver.changes subscription. This asserts the
+        // service holds no raw network path, so a raw stable-wifi blip can never
+        // reach forceReconnectNow through the service.
+        val cm = context.getSystemService(Context.CONNECTIVITY_SERVICE)
+            as android.net.ConnectivityManager
+        val shadowCm = Shadows.shadowOf(cm)
+        val callbacksBefore = shadowCm.networkCallbacks.toSet()
+
+        // buildService(...).get() returns the service WITHOUT running onCreate
+        // (so we don't trigger Hilt injection in this non-Hilt test app); we wire
+        // the controller manually, exactly like the sibling notification tests.
+        val service = Robolectric.buildService(ForwardingService::class.java).get()
+        service.controller = ForwardingController(context)
+        // Drive the START path that USED to register the raw default-network
+        // callback (the deleted `registerNetworkCallback()` call lived here).
+        service.onStartCommand(
+            Intent(context, ForwardingService::class.java).setAction(ForwardingService.ACTION_START),
+            0,
+            0,
+        )
+
+        val callbacksAfter = shadowCm.networkCallbacks.toSet()
+        assertEquals(
+            "ForwardingService must register NO raw default-network callback (#980): " +
+                "network-driven reconnect is owned solely by the controller's hardened " +
+                "TerminalNetworkObserver.changes signal, so a same-AP reassoc cannot " +
+                "force-tear a live transport on stable wifi",
+            callbacksBefore,
+            callbacksAfter,
+        )
+    }
+
+    @Test
+    fun `a raw stable-wifi reassoc routed through the hardened observer does NOT force-reconnect, but a real handoff does`() {
+        // Issue #980 (defect 2) — class coverage: the ONLY network path that can
+        // reach forceReconnectNow is the controller's hardened
+        // TerminalNetworkObserver.changes subscription, which suppresses the
+        // same-SSID/same-handle reassoc (#875) and only emits on a REAL validated
+        // default-network handoff. This drives the REAL TerminalNetworkObserver
+        // detector pipeline (not a marker) so the suppression is exercised end to
+        // end: a same-pure-WIFI-transport reassoc is suppressed (no force), while a
+        // genuine WIFI→CELLULAR handoff forces a rebuild.
+        val observer = com.pocketshell.app.connectivity.TerminalNetworkObserver(context)
+        val controller = ForwardingController(
+            appContext = context,
+            connector = TestUnavailableConnector,
+            portRemappingDao = TestEmptyRemappingDao,
+            validatedNetworkChanges = observer.changes,
+        )
+        idleMainLooper()
         val forceCalls = java.util.concurrent.atomic.AtomicInteger(0)
         controller.registerActiveHost(
             hostId = 1,
             hostName = "alpha",
-            reconnectHook = { normalCalls.incrementAndGet() },
             forceReconnectHook = { forceCalls.incrementAndGet() },
         )
-        val service = Robolectric.buildService(ForwardingService::class.java).get()
-        service.controller = controller
 
-        service.handleDefaultNetworkAvailable()
-        assertEquals(
-            "initial onAvailable during callback registration must not churn a healthy tunnel",
-            1,
-            normalCalls.get(),
+        // Seed a validated pure-WIFI network as the baseline.
+        observer.emitSyntheticSnapshotForTest(
+            com.pocketshell.app.connectivity.TerminalNetworkSnapshot.Validated(
+                networkHandle = "wifi-1",
+                transports = setOf("WIFI"),
+            ),
+            reason = "baseline",
         )
-        assertEquals(0, forceCalls.get())
+        idleMainLooper()
+        forceCalls.set(0)
 
-        service.handleDefaultNetworkLost()
-        service.handleDefaultNetworkAvailable()
-        assertEquals(1, normalCalls.get())
+        // A same-SSID band-steer / mesh reassoc mints a NEW handle but the same
+        // pure-WIFI transport set — the #875 hardening must SUPPRESS it, so no
+        // force-reconnect reaches the supervisor (the stable-wifi false handoff).
+        observer.emitSyntheticSnapshotForTest(
+            com.pocketshell.app.connectivity.TerminalNetworkSnapshot.Validated(
+                networkHandle = "wifi-2-reassoc",
+                transports = setOf("WIFI"),
+            ),
+            reason = "same-ssid-reassoc",
+        )
+        idleMainLooper()
         assertEquals(
-            "onAvailable after an observed loss must force rebuild stale connected transports",
+            "a same-AP pure-WIFI reassociation must NOT force-tear the forward transport " +
+                "(#980/#875 — this is the stable-wifi self-inflicted drop)",
+            0,
+            forceCalls.get(),
+        )
+
+        // A genuine cross-transport handoff (WIFI→CELLULAR) is a real change the
+        // forward transport cannot survive — it MUST force a rebuild.
+        observer.emitSyntheticSnapshotForTest(
+            com.pocketshell.app.connectivity.TerminalNetworkSnapshot.Validated(
+                networkHandle = "cell-1",
+                transports = setOf("CELLULAR"),
+            ),
+            reason = "wifi-to-cellular-handoff",
+        )
+        idleMainLooper()
+        assertEquals(
+            "a genuine WIFI→CELLULAR handoff must force a reconnect on the forward transport",
             1,
             forceCalls.get(),
         )
+
+        observer.close()
     }
 
     @Test

--- a/app/src/test/java/com/pocketshell/app/portfwd/PortForwardPanelViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/portfwd/PortForwardPanelViewModelTest.kt
@@ -891,7 +891,16 @@ class PortForwardPanelViewModelTest {
         val connector = QueueConnector(
             listOf(Result.success(firstSession), Result.success(recoveredSession)),
         )
-        val forwardingController = newForwardingController(connector)
+        // Issue #980: the forced reconnect is now driven SOLELY by the
+        // controller's hardened TerminalNetworkObserver.changes subscription
+        // (the service's raw force-tear callback was deleted). Emit a real
+        // validated-handoff change through that flow to trigger the rebuild.
+        val networkChanges =
+            kotlinx.coroutines.flow.MutableSharedFlow<Any?>(extraBufferCapacity = 16)
+        val forwardingController = newForwardingController(
+            connector = connector,
+            validatedNetworkChanges = networkChanges,
+        )
         val viewModel = newViewModel(
             connector = connector,
             forwardingController = forwardingController,
@@ -911,15 +920,15 @@ class PortForwardPanelViewModelTest {
             assertFalse("panel dismissal must not close the controller-owned SSH session", firstSession.closed)
 
             firstSession.simulateDeadForwardButStillConnected()
-            val service = Robolectric.buildService(ForwardingService::class.java).get()
-            service.controller = forwardingController
-            service.handleDefaultNetworkLost()
-            service.handleDefaultNetworkAvailable()
+            // A real validated default-network handoff reaches the controller's
+            // hardened subscription, which forces a rebuild on every active host
+            // even after the panel is gone.
+            assertTrue(networkChanges.tryEmit(Any()))
             advanceTimeBy(1_100L)
             runCurrent()
 
             assertEquals(
-                "service network recovery must reach the controller-owned supervisor after the panel is gone",
+                "a validated-handoff network change must reach the controller-owned supervisor after the panel is gone",
                 listOf("dev", "dev"),
                 connector.hosts,
             )
@@ -1585,12 +1594,15 @@ class PortForwardPanelViewModelTest {
     private fun newForwardingController(
         connector: PortForwardConnector,
         portRemappingDao: com.pocketshell.core.storage.dao.PortRemappingDao = db.portRemappingDao(),
+        validatedNetworkChanges: kotlinx.coroutines.flow.Flow<*> =
+            kotlinx.coroutines.flow.emptyFlow<Any?>(),
     ): ForwardingController =
         ForwardingController(
             appContext = context,
             connector = connector,
             portRemappingDao = portRemappingDao,
             scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate),
+            validatedNetworkChanges = validatedNetworkChanges,
         )
 
     private class FakeConnector(

--- a/app/src/test/java/com/pocketshell/app/portfwd/service/ForwardingServiceDispatcherLeakTest.kt
+++ b/app/src/test/java/com/pocketshell/app/portfwd/service/ForwardingServiceDispatcherLeakTest.kt
@@ -1,0 +1,152 @@
+package com.pocketshell.app.portfwd.service
+
+import android.content.Context
+import android.content.Intent
+import androidx.test.core.app.ApplicationProvider
+import com.pocketshell.app.portfwd.ForwardingController
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Issue #994 regression — the `ForwardingService` notification-observe
+ * coroutine must NOT escape the test that started it.
+ *
+ * ## The leak class this guards (D31/D32/G2 — the whole class, not one instance)
+ *
+ * Before #994 the service built `scope = CoroutineScope(SupervisorJob() +
+ * Dispatchers.Default)` — a bare, un-injectable dispatcher. When a Robolectric
+ * unit test drove `onStartCommand(ACTION_START)` (directly, or indirectly via
+ * the panel ViewModel toggling auto-forward → `ForwardingService.start()`),
+ * `startObserving()` launched a `Dispatchers.Default` coroutine that
+ * immediately collected the controller's hot `StateFlow`s and called
+ * `updateNotification()` → `getSystemService(NotificationManager)`. The test had
+ * no handle to confine or cancel that real background coroutine, so it outlived
+ * the test; when Robolectric tore the Application down, the still-running
+ * Default-thread coroutine dereferenced the now-null Application in
+ * `getSystemService` → an uncaught NPE surfaced as `UncaughtExceptionsBeforeTest`
+ * on the NEXT test. Intermittent in the full suite because it is a cross-test
+ * race vs teardown.
+ *
+ * ## What this test asserts (deterministic, no flake)
+ *
+ * The fix makes the observe dispatcher INJECTABLE (`observeDispatcher`, the
+ * `@DefaultDispatcher`-qualified Hilt binding). This test injects a
+ * `StandardTestDispatcher` and proves the whole leak class is closed:
+ *
+ *  1. The service scope is built off the INJECTED dispatcher, so the observe
+ *     coroutine is confined to the test scheduler — NOT a free-running
+ *     `Dispatchers.Default` background thread the test cannot reach. We prove
+ *     this by recording, inside the production observe collect, the dispatcher
+ *     the collector actually resumed on and asserting it is the injected one.
+ *  2. The observe coroutine ([ForwardingService.observeJobForTest]) is alive
+ *     while observing and is CANCELLED by `onDestroy()` — no coroutine started
+ *     by the service survives the service lifecycle / the test.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+@OptIn(ExperimentalCoroutinesApi::class)
+class ForwardingServiceDispatcherLeakTest {
+
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+    }
+
+    @Test
+    fun observeCoroutineIsConfinedToInjectedDispatcherAndCancelledOnDestroy() = runTest {
+        // A test dispatcher whose scheduler WE drive — the observe loop must run
+        // on this, not on a real Dispatchers.Default background thread that
+        // outlives the test (the #994 leak).
+        val observeDispatcher = StandardTestDispatcher(testScheduler)
+
+        // A minimal real ForwardingController. Seed an active host directly on the
+        // backing StateFlow via reflection (NOT registerActiveHost, which would
+        // also fire ForwardingService.start() and auto-start a second service)
+        // so the observe collector sees activeHosts > 0 and reaches the
+        // notification-update branch — the leak-prone updateNotification() site.
+        val controller = ForwardingController(context)
+        seedActiveHostCount(controller, 1)
+
+        // Build a real service, inject the test dispatcher + controller, then
+        // drive the production observe path. We call onStartCommand directly (not
+        // serviceController.create()) because the generated
+        // Hilt_ForwardingService.onCreate requires a @HiltAndroidApp Application,
+        // which a plain Robolectric unit test does not have — this mirrors the
+        // existing PortForwardPanelViewModelTest service-stop test. The scope is
+        // built lazily off the injected dispatcher inside startObserving(), so
+        // onCreate is not required.
+        val serviceController = Robolectric.buildService(ForwardingService::class.java)
+        val service = serviceController.get()
+        service.observeDispatcher = observeDispatcher
+        service.controller = controller
+        service.createNotificationChannel()
+        service.onStartCommand(
+            Intent(context, ForwardingService::class.java).apply {
+                action = ForwardingService.ACTION_START
+            },
+            0,
+            1,
+        )
+
+        // The observe coroutine exists and is scheduled — on the INJECTED
+        // dispatcher, so it has run NOTHING until we advance that dispatcher's
+        // scheduler (a free-running Dispatchers.Default coroutine would already
+        // have resumed on its own thread).
+        val observeJob = service.observeJobForTest
+        assertNotNull("startObserving() must have launched the observe coroutine", observeJob)
+        assertTrue("the observe coroutine must be active while observing", observeJob!!.isActive)
+
+        // Drive the injected dispatcher: the production startObserving() collect
+        // resumes — on the injected dispatcher. Recorded by the service for the
+        // test (see ForwardingService.lastObserveDispatcherForTest).
+        advanceUntilIdle()
+        assertSame(
+            "the observe collector must resume on the INJECTED dispatcher, not a " +
+                "free-running Dispatchers.Default (issue #994)",
+            observeDispatcher,
+            service.lastObserveDispatcherForTest,
+        )
+
+        // Tearing the service down cancels the scope → the observe coroutine is
+        // cancelled and leaves nothing behind. With the old bare
+        // Dispatchers.Default scope the coroutine could not be confined to the
+        // test scheduler at all and outlived the test.
+        service.onDestroy()
+        advanceUntilIdle()
+        assertFalse(
+            "onDestroy() must cancel the observe coroutine so none survives the " +
+                "service/test (issue #994: no Dispatchers.Default coroutine may leak)",
+            observeJob.isActive,
+        )
+        assertTrue("the observe coroutine must be fully cancelled after onDestroy()", observeJob.isCancelled)
+    }
+
+    /**
+     * Set the controller's private `activeHostCount` StateFlow to [count] without
+     * triggering the `ForwardingService.start()` side effect that
+     * `registerActiveHost` has. Reflection is acceptable here: the test owns the
+     * controller instance and only needs it to report an active host so the
+     * service's real observe path reaches the notification branch.
+     */
+    @Suppress("UNCHECKED_CAST")
+    private fun seedActiveHostCount(controller: ForwardingController, count: Int) {
+        val field = ForwardingController::class.java.getDeclaredField("activeHostCount")
+        field.isAccessible = true
+        val flow = field.get(controller) as kotlinx.coroutines.flow.MutableStateFlow<Int>
+        flow.value = count
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/sessions/TmuxSessionCreationTest.kt
+++ b/app/src/test/java/com/pocketshell/app/sessions/TmuxSessionCreationTest.kt
@@ -1,7 +1,11 @@
 package com.pocketshell.app.sessions
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.io.File
+import java.nio.file.Files
 
 class TmuxSessionCreationTest {
     @Test
@@ -71,7 +75,7 @@ class TmuxSessionCreationTest {
                 pocketshell_start_dir='/tmp/it'\''s missing; rm -rf ${'$'}HOME'
                 case "${'$'}pocketshell_start_dir" in
                   '~') pocketshell_start_dir=${'$'}HOME ;;
-                  '~/'*) pocketshell_start_dir=${'$'}HOME/${'$'}{pocketshell_start_dir#~/} ;;
+                  '~/'*) pocketshell_start_dir=${'$'}HOME/${'$'}{pocketshell_start_dir#"~/"} ;;
                   '${'$'}HOME') pocketshell_start_dir=${'$'}HOME ;;
                   '${'$'}HOME/'*) pocketshell_start_dir=${'$'}HOME/${'$'}{pocketshell_start_dir#${'$'}HOME/} ;;
                 esac
@@ -79,5 +83,84 @@ class TmuxSessionCreationTest {
             """.trimIndent(),
             command,
         )
+    }
+
+    /**
+     * Issue #990 BEHAVIORAL regression proof. The old test above only asserts the
+     * generated command STRING — it never executes it, which is why the tilde-strip
+     * bug shipped: the `~/` in the `${'$'}{dir#~/}` strip PATTERN underwent tilde
+     * expansion (to `${'$'}HOME/`) BEFORE the strip, so for value `~/git` nothing was
+     * stripped and the result was `${'$'}HOME/~/git` (a path that does not exist) →
+     * `test -d` returned non-zero → a false "start folder does not exist: ~/git".
+     *
+     * This test pipes the *generated* script into a real POSIX `/bin/sh` (the same
+     * way `SshSession.exec` runs it on the remote, with `$HOME` set), against a temp
+     * dir layout, and asserts the exit code matches whether the resolved directory
+     * actually exists. It RED-fails on base (unquoted strip) for the `~/...` cases
+     * and GREEN-passes with the quoted strip pattern. Class coverage: `~`, `~/git`,
+     * `~/a/b`, an absolute path under `$HOME` (the '$HOME/'* arm), an absolute
+     * `/tmp/...`, and the genuinely-missing variants of each (which must still
+     * correctly report missing).
+     */
+    @Test
+    fun remoteStartDirectoryExistsCommandResolvesTildeAndHomeWhenRunInAShell() {
+        val home = Files.createTempDirectory("ps-home").toFile()
+        try {
+            // Build the directory layout the maintainer reported: ~/git exists.
+            File(home, "git").mkdirs()
+            File(home, "a/b").mkdirs()
+            val absoluteExisting = Files.createTempDirectory("ps-abs").toFile()
+            // An absolute path *under* $HOME exercises the '$HOME/'* case arm with the
+            // real on-device value the user would supply (the resolved home prefix),
+            // not a literal "$HOME/..." string a user would never type.
+            val absoluteUnderHome = File(home, "git").absolutePath
+            try {
+                // Existing-directory cases: must report exit 0 (exists).
+                assertTrue("~ (HOME itself) must resolve to an existing dir", existsViaShell(home, "~"))
+                assertTrue("~/git must resolve to \$HOME/git which exists", existsViaShell(home, "~/git"))
+                assertTrue("~/a/b must resolve to \$HOME/a/b which exists", existsViaShell(home, "~/a/b"))
+                assertTrue(
+                    "an absolute path under \$HOME must resolve to an existing dir",
+                    existsViaShell(home, absoluteUnderHome),
+                )
+                assertTrue(
+                    "an absolute path that exists must report present",
+                    existsViaShell(home, absoluteExisting.absolutePath),
+                )
+
+                // Missing-directory cases: must correctly report exit != 0 (missing).
+                assertFalse("~/nope must report missing", existsViaShell(home, "~/nope"))
+                assertFalse(
+                    "an absolute path under \$HOME that does not exist must report missing",
+                    existsViaShell(home, File(home, "nope").absolutePath),
+                )
+                assertFalse(
+                    "an absolute path that does not exist must report missing",
+                    existsViaShell(home, "/tmp/pocketshell-definitely-missing-${System.nanoTime()}"),
+                )
+            } finally {
+                absoluteExisting.deleteRecursively()
+            }
+        } finally {
+            home.deleteRecursively()
+        }
+    }
+
+    /**
+     * Runs the generated existence-check script through a real `/bin/sh` with `HOME`
+     * pointed at [home] (mirrors how `SshSession.exec` runs it remotely). Returns
+     * whether the script reported the directory exists (exit code 0).
+     */
+    private fun existsViaShell(home: File, startDirectory: String): Boolean {
+        val script = remoteStartDirectoryExistsCommand(startDirectory)
+        val process = ProcessBuilder("/bin/sh", "-c", script)
+            .apply {
+                environment()["HOME"] = home.absolutePath
+                redirectErrorStream(true)
+            }
+            .start()
+        process.outputStream.close()
+        process.inputStream.readBytes()
+        return process.waitFor() == 0
     }
 }

--- a/shared/core-ssh/src/integrationTest/java/com/pocketshell/core/ssh/SshIntegrationTest.kt
+++ b/shared/core-ssh/src/integrationTest/java/com/pocketshell/core/ssh/SshIntegrationTest.kt
@@ -613,6 +613,134 @@ class SshIntegrationTest {
     }
 
     @Test
+    fun portForwardChannelChurnConcurrentWithKeepAliveDoesNotCorruptTransport() {
+        // Issue #980 — end-to-end backstop for the port-forward single-writer fix.
+        //
+        // Before #980 `RealSshPortForward` opened one direct-tcpip channel per
+        // accepted local connection by calling `client.newDirectConnection(...)`
+        // STRAIGHT off the accept loop, and closed it off the copy threads —
+        // raw transport-mutating packets racing the dispatcher-serialised
+        // keepalive on the SAME transport. That second un-ownable writer is the
+        // #847 desync the dispatcher rewrite spent a whole epic to remove. A
+        // burst of accepted connections (a fresh-reconnect scan-and-forward
+        // storm) churned these un-serialised opens/closes, so the transport could
+        // desync and the server log `Connection corrupted`.
+        //
+        // This drives exactly that shape against the real sshd: a live forward to
+        // the container's own sshd port, a storm of short local TCP connections
+        // each opening+closing a direct-tcpip channel, concurrently with the
+        // always-on keepalive and exec churn, then asserts the sshd log NEVER
+        // shows a corruption signature and a final round-trip still succeeds. With
+        // the #980 fix the channel open + close funnel through the single-writer
+        // dispatcher, so there is one writer again.
+        runBlocking {
+            val session = SshConnection.connect(
+                host = container!!.host,
+                port = sshPort,
+                user = "testuser",
+                key = SshKey.Path(privateKeyFile),
+                passphrase = null,
+                knownHosts = KnownHostsPolicy.AcceptAll,
+            ).getOrThrow()
+
+            val logMarkStartLen = container!!.logs.length
+            val connectionsDriven = AtomicInteger(0)
+            session.use { s ->
+                // Forward a local loopback port to the container's own sshd port
+                // (22 inside the container) — any TCP service the container speaks
+                // works; we only need a real remote endpoint the direct-tcpip
+                // channel can connect to so the open/close packets hit the wire.
+                val forward = s.openLocalPortForward(
+                    remoteHost = "127.0.0.1",
+                    remotePort = CONTAINER_SSH_PORT,
+                    localPort = 0.let {
+                        // Reserve a free local port, then release it for the forward.
+                        java.net.ServerSocket(0, 1, java.net.InetAddress.getByName("127.0.0.1"))
+                            .use { sock -> sock.localPort }
+                    },
+                )
+                forward.use { fwd ->
+                    coroutineScope {
+                        val holdMs = 30_000L
+                        val deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(holdMs)
+
+                        // (1) The scan-and-forward storm: many short local TCP
+                        // connections, each opening then immediately closing a
+                        // direct-tcpip channel — the un-serialised open/close
+                        // churn that base raced against the keepalive.
+                        val storm = (0 until 6).map {
+                            async(Dispatchers.IO) {
+                                while (isActive && System.nanoTime() < deadline) {
+                                    runCatching {
+                                        java.net.Socket(
+                                            java.net.InetAddress.getByName("127.0.0.1"),
+                                            fwd.localPort,
+                                        ).use { client ->
+                                            // Write a tiny payload + read one byte so
+                                            // the channel actually carries data before
+                                            // we close it (drives open + use + close).
+                                            client.soTimeout = 1_000
+                                            runCatching {
+                                                client.getOutputStream().write("x".toByteArray())
+                                                client.getOutputStream().flush()
+                                                client.getInputStream().read()
+                                            }
+                                        }
+                                        connectionsDriven.incrementAndGet()
+                                    }
+                                    delay(15)
+                                }
+                            }
+                        }
+                        // (2) Concurrent exec churn on the SAME transport — the
+                        // corruption amplifier (the keepalive is already running
+                        // on every RealSshSession by construction).
+                        val execChurn = (0 until 2).map {
+                            async(Dispatchers.IO) {
+                                while (isActive && System.nanoTime() < deadline) {
+                                    runCatching { s.exec("true") }
+                                    delay(40)
+                                }
+                            }
+                        }
+
+                        while (System.nanoTime() < deadline) {
+                            assertTrue(
+                                "session must stay connected across the port-forward " +
+                                    "churn hold (#980)",
+                                s.isConnected,
+                            )
+                            delay(2_000)
+                        }
+                        storm.forEach { it.cancel() }
+                        execChurn.forEach { it.cancel() }
+                    }
+                }
+
+                assertEquals(
+                    "a final exec must round-trip after the port-forward churn hold " +
+                        "(#980 — transport not corrupted)",
+                    0,
+                    s.exec("true").exitCode,
+                )
+            }
+
+            val newLogs = container!!.logs.substring(
+                minOf(logMarkStartLen, container!!.logs.length),
+            )
+            for (signature in CORRUPTION_SIGNATURES) {
+                assertFalse(
+                    "sshd log must NOT contain `$signature` after a port-forward " +
+                        "channel-churn hold (#980 single-writer regression); " +
+                        "connections driven=${connectionsDriven.get()}; " +
+                        "offending sshd log:\n$newLogs",
+                    newLogs.contains(signature, ignoreCase = true),
+                )
+            }
+        }
+    }
+
+    @Test
     fun closeDisconnectsTheSession() = runTest {
         val session = SshConnection.connect(
             host = container!!.host,

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/PortForwardChannelTransport.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/PortForwardChannelTransport.kt
@@ -1,0 +1,88 @@
+package com.pocketshell.core.ssh
+
+import net.schmizz.sshj.connection.channel.direct.DirectConnection
+
+/**
+ * Single-writer-safe channel factory for a port forward (issue #980).
+ *
+ * ## Why this exists
+ *
+ * `RealSshPortForward` opens one `direct-tcpip` channel per accepted local
+ * connection and closes it when either side EOFs. A channel open and a channel
+ * close are BOTH transport-mutating SSH packets that advance the encoder
+ * sequence counter — exactly the kind of write that issue #847 proved must be
+ * serialised against every other writer (the keepalive global request, the
+ * `-CC` stdin write, exec channel opens) or the encoder sequence-number / cipher
+ * desync resurfaces and the server logs `ssh_dispatch_run_fatal: ... Connection
+ * corrupted`.
+ *
+ * Before #980 `RealSshPortForward` held the raw [net.schmizz.sshj.SSHClient] and
+ * called `client.newDirectConnection(...)` / `channel.close()` straight off the
+ * accept loop and the copy threads — a SECOND, un-ownable writer racing the
+ * dispatcher-serialised keepalive on the SAME transport. A burst of accepted
+ * connections (a fresh-reconnect scan-and-forward storm) or a flapping forwarded
+ * service churned un-serialised opens/closes continuously, re-opening the #847
+ * desync on an otherwise-stable link.
+ *
+ * This interface restores the single-writer invariant: the port forward never
+ * touches the raw client. Every channel open and every channel close funnels
+ * through the connection's [TransportDispatcher] (the same FIFO single-thread
+ * path the keepalive / `-CC` / exec writes use), so there is exactly ONE writer
+ * to the transport again. The local-socket `accept()` and the byte copy loops
+ * stay off-dispatcher — only the SSH-side channel-lifecycle packets serialise.
+ */
+internal interface PortForwardChannelTransport {
+
+    /**
+     * Open a `direct-tcpip` channel to `remoteHost:remotePort` from the SSH
+     * server's perspective, serialised through the transport dispatcher so the
+     * channel-open packet can never interleave with the keepalive / another op.
+     * Blocks the calling (accept-loop) thread until the dispatch thread has run
+     * the open. Throws on open failure or once the transport is closed.
+     */
+    fun openChannel(remoteHost: String, remotePort: Int): DirectConnection
+
+    /**
+     * Close [channel], serialised through the transport dispatcher so the
+     * channel-close packet can never interleave with another writer. Best
+     * effort — a failure (transport already gone) is swallowed so teardown of a
+     * forwarded pair never propagates an exception into the copy threads.
+     */
+    fun closeChannel(channel: DirectConnection)
+}
+
+/**
+ * The production [PortForwardChannelTransport] (issue #980): opens and closes
+ * every direct-tcpip channel through the connection's single-writer
+ * [TransportDispatcher].
+ *
+ * `openChannel` runs the [open] body on the dispatch thread, serialised FIFO
+ * against the keepalive global request, the `-CC` stdin write, exec channel
+ * opens, and teardown — restoring the single-writer invariant #847 established.
+ * The blocking [TransportDispatcher.runBlockingDispatch] bridge is correct here
+ * because the only callers are the forward's accept-loop / copy threads (IO
+ * daemon threads), never the dispatch thread itself, so it cannot deadlock on
+ * the dispatcher's mutex.
+ *
+ * `closeChannel` is best-effort: once the transport is torn down the dispatcher
+ * rejects the op with [TransportClosedException] (the channel is already gone
+ * with the transport), so we swallow it — a forwarded pair's EOF teardown must
+ * never propagate an exception into the copy threads.
+ *
+ * Split out from `RealSshSession` so the single-writer property is unit-testable
+ * (`PortForwardSingleWriterTest`) without a live SSH transport: the [open]/[close]
+ * lambdas are injected, while the dispatcher serialisation is the real thing.
+ */
+internal class DispatcherBackedChannelTransport(
+    private val dispatcher: TransportDispatcher,
+    private val open: (remoteHost: String, remotePort: Int) -> DirectConnection,
+    private val close: (DirectConnection) -> Unit,
+) : PortForwardChannelTransport {
+
+    override fun openChannel(remoteHost: String, remotePort: Int): DirectConnection =
+        dispatcher.runBlockingDispatch { open(remoteHost, remotePort) }
+
+    override fun closeChannel(channel: DirectConnection) {
+        runCatching { dispatcher.runBlockingDispatch { close(channel) } }
+    }
+}

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshPortForward.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshPortForward.kt
@@ -1,6 +1,5 @@
 package com.pocketshell.core.ssh
 
-import net.schmizz.sshj.SSHClient
 import net.schmizz.sshj.connection.channel.direct.DirectConnection
 import java.io.IOException
 import java.io.InputStream
@@ -24,11 +23,25 @@ import java.util.concurrent.atomic.AtomicLong
  * [DirectConnection] (direct-tcpip channel) per accepted client, copying bytes
  * in both directions through counting streams.
  *
+ * ## Single-writer transport safety (issue #980)
+ *
+ * Each accepted local connection opens a `direct-tcpip` channel, and each
+ * EOF/teardown closes it. Both are transport-mutating SSH packets that advance
+ * the encoder sequence counter — they MUST NOT race the dispatcher-serialised
+ * keepalive / `-CC` / exec writes on the same transport, or the #847
+ * `Connection corrupted` desync resurfaces. This class therefore never holds the
+ * raw [net.schmizz.sshj.SSHClient]: it opens and closes every channel through a
+ * [PortForwardChannelTransport], which funnels the channel-lifecycle packets
+ * through the connection's single-writer [TransportDispatcher]. The local-socket
+ * `accept()` and the byte copy loops stay off-dispatcher (they touch only the
+ * local socket and the already-decrypted channel streams); only the SSH-side
+ * open/close packets serialise.
+ *
  * Internal to `core-ssh` — callers obtain instances via
  * [SshSession.openLocalPortForward].
  */
 internal class RealSshPortForward(
-    private val client: SSHClient,
+    private val channels: PortForwardChannelTransport,
     override val remoteHost: String,
     override val remotePort: Int,
     override val localPort: Int,
@@ -97,7 +110,10 @@ internal class RealSshPortForward(
         // visible *here* (we can log + close the local socket). Once open, we
         // hand off to two daemon copy threads — one per direction.
         val channel: DirectConnection = try {
-            client.newDirectConnection(remoteHost, remotePort)
+            // Serialised through the single-writer dispatcher (#980): the
+            // channel-open packet can never interleave with the keepalive / a
+            // `-CC` write / another exec open on the same transport.
+            channels.openChannel(remoteHost, remotePort)
         } catch (t: Throwable) {
             // Couldn't open the channel — drop the local connection. Don't
             // crash the accept loop; another connection might succeed.
@@ -185,7 +201,10 @@ internal class RealSshPortForward(
 
     private fun closePair(local: Socket, channel: DirectConnection) {
         runCatching { local.close() }
-        runCatching { channel.close() }
+        // Serialise the channel-close packet through the single-writer
+        // dispatcher (#980) — a raw `channel.close()` here would be a SECOND
+        // un-ownable writer racing the keepalive, exactly the #847 desync.
+        channels.closeChannel(channel)
     }
 
     override fun close() {

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshSession.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshSession.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.coroutines.yield
 import net.schmizz.sshj.SSHClient
 import net.schmizz.sshj.common.SSHException
+import net.schmizz.sshj.connection.channel.direct.DirectConnection
 import net.schmizz.sshj.connection.channel.direct.Session
 import net.schmizz.sshj.connection.channel.direct.Session.Command
 import net.schmizz.sshj.transport.TransportException
@@ -566,8 +567,15 @@ internal class RealSshSession(
     ): SshPortForward {
         ensureConnected()
         return try {
+            // Issue #980: the forward opens/closes one direct-tcpip channel per
+            // accepted local connection — transport-mutating packets that MUST go
+            // through the single-writer dispatcher (the #847-safe path the
+            // keepalive / `-CC` / exec writes use), never straight off the raw
+            // client from the accept loop / copy threads. We hand the forward a
+            // dispatcher-backed channel factory instead of the SSHClient so it
+            // physically cannot become a second un-serialised writer.
             RealSshPortForward(
-                client = client,
+                channels = dispatcherBackedChannelTransport(),
                 remoteHost = remoteHost,
                 remotePort = remotePort,
                 localPort = localPort,
@@ -579,6 +587,21 @@ internal class RealSshSession(
             )
         }
     }
+
+    /**
+     * Build the dispatcher-backed [PortForwardChannelTransport] for a forward
+     * on THIS session's transport (issue #980). The channel open + close run
+     * through [dispatcher], serialised against every other transport writer, so
+     * the forward can never become the #847 second writer. The serialisation
+     * logic lives in [DispatcherBackedChannelTransport] so it is unit-testable
+     * without a live SSH transport; here we only bind the real sshj open/close.
+     */
+    private fun dispatcherBackedChannelTransport(): PortForwardChannelTransport =
+        DispatcherBackedChannelTransport(
+            dispatcher = dispatcher,
+            open = { remoteHost, remotePort -> client.newDirectConnection(remoteHost, remotePort) },
+            close = { channel -> channel.close() },
+        )
 
     override fun startShell(): SshShell {
         ensureConnected()

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/PortForwardSingleWriterTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/PortForwardSingleWriterTest.kt
@@ -1,0 +1,171 @@
+package com.pocketshell.core.ssh
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import net.schmizz.sshj.connection.channel.direct.DirectConnection
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.net.InetAddress
+import java.net.ServerSocket
+import java.net.Socket
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Issue #980 — the port-forward direct-tcpip channel open/close MUST be a
+ * single writer against the transport keepalive, exactly the #847 invariant.
+ *
+ * ## What broke (base, RED)
+ *
+ * `RealSshPortForward` opened one direct-tcpip channel per accepted local
+ * connection by calling `client.newDirectConnection(...)` STRAIGHT off the
+ * accept loop, and closed it straight off the copy threads — both raw
+ * transport-mutating SSH packets racing the dispatcher-serialised keepalive on
+ * the SAME transport. That is a SECOND, un-ownable writer: a channel open/close
+ * landing in a keepalive/rekey window desyncs the encoder sequence counter and
+ * the server logs `Connection corrupted` (the precise #847 fault). A burst of
+ * accepted connections (a fresh-reconnect scan-and-forward storm) or a flapping
+ * forwarded service churns these un-serialised writes continuously.
+ *
+ * ## The fix (GREEN)
+ *
+ * The forward now opens + closes every channel through
+ * [DispatcherBackedChannelTransport], which funnels the channel-lifecycle
+ * packets through the connection's single-writer [TransportDispatcher] — the
+ * same FIFO single-thread path the keepalive uses. So there is exactly ONE
+ * writer again.
+ *
+ * These tests are Docker-free and deterministic (the integration backstop,
+ * `SshIntegrationTest.portForwardChannelChurnConcurrentWithKeepAliveDoesNotCorruptTransport`,
+ * proves no corruption against a real sshd over the wire).
+ */
+class PortForwardSingleWriterTest {
+
+    /**
+     * Concurrency monitor shared between the "channel open/close" ops and the
+     * "keepalive" op. Records the maximum number of ops observed running at the
+     * same time. If the port-forward channel work ran OFF the dispatcher
+     * (the #980/base bug), an open/close would overlap a keepalive write and
+     * this would read > 1.
+     */
+    private class WriterMonitor {
+        private val inFlight = AtomicInteger(0)
+        val maxConcurrent = AtomicInteger(0)
+
+        fun <T> track(block: () -> T): T {
+            val now = inFlight.incrementAndGet()
+            maxConcurrent.updateAndGet { prev -> maxOf(prev, now) }
+            try {
+                // A small busy window so an overlap would actually be observed
+                // by a racing writer rather than slipping through instantly.
+                Thread.sleep(2)
+                return block()
+            } finally {
+                inFlight.decrementAndGet()
+            }
+        }
+    }
+
+    @Test
+    fun `channel open and close serialise against keepalive on the single-writer dispatcher`() =
+        runBlocking {
+            val dispatcher = TransportDispatcher()
+            val monitor = WriterMonitor()
+
+            // The production transport for a forward (issue #980): the channel
+            // open body funnels through the SAME dispatcher the keepalive uses.
+            // We track the open body through the shared monitor so an overlap
+            // with a keepalive write would be observed as maxConcurrent>1. The
+            // body throws AFTER tracking so we never need to fabricate a real
+            // DirectConnection return value — the serialisation (not the channel
+            // object) is what's under test. The close path is identical
+            // (`dispatcher.runBlockingDispatch { close(...) }`) and is covered by
+            // `closeChannel swallows a transport-closed rejection` below.
+            val transport = DispatcherBackedChannelTransport(
+                dispatcher = dispatcher,
+                open = { _, _ -> monitor.track { error("test: no real channel needed") } },
+                close = { monitor.track { } },
+            )
+
+            // (A) Keepalive-style transport writer hammering the dispatcher,
+            // mirroring RealSshSession.sendKeepAlive running through the same
+            // single-writer path every interval.
+            val keepAlive = launch(Dispatchers.IO) {
+                repeat(60) {
+                    dispatcher.run { monitor.track { } }
+                }
+            }
+
+            // (B) A burst of channel opens — the scan-and-forward storm shape:
+            // many accepted local connections each opening a direct-tcpip channel
+            // concurrently with the keepalive. openChannel propagates the body's
+            // throw; we only care that the body never overlapped a keepalive.
+            val churn = (0 until 60).map {
+                launch(Dispatchers.IO) {
+                    runCatching { transport.openChannel("127.0.0.1", 9000) }
+                }
+            }
+
+            keepAlive.join()
+            churn.forEach { it.join() }
+
+            assertEquals(
+                "channel open/close and keepalive are the same transport writer — they " +
+                    "MUST never run concurrently (the #847 single-writer invariant the " +
+                    "#980 fix restores)",
+                1,
+                monitor.maxConcurrent.get(),
+            )
+            dispatcher.closeAndAwaitDrain { }
+        }
+
+    @Test
+    fun `RealSshPortForward opens its direct-tcpip channel through the injected transport, not the raw client`() {
+        // Proves the forward routes its per-connection channel open through the
+        // PortForwardChannelTransport seam (and therefore the dispatcher in
+        // production) rather than touching a raw SSHClient. On the base code the
+        // forward held the SSHClient and called client.newDirectConnection
+        // directly off the accept loop — there was no seam to route through.
+        val openCalls = AtomicInteger(0)
+        val opened = CountDownLatch(1)
+        val transport = object : PortForwardChannelTransport {
+            override fun openChannel(remoteHost: String, remotePort: Int): DirectConnection {
+                openCalls.incrementAndGet()
+                opened.countDown()
+                // Reject the open so the copy threads never spin up — we only
+                // need to prove the accept loop asked the transport (not the raw
+                // client) to open the channel.
+                throw RuntimeException("test: refuse channel open")
+            }
+
+            override fun closeChannel(channel: DirectConnection) = Unit
+        }
+
+        // Pick a free loopback port for the forward to listen on.
+        val localPort = ServerSocket(0, 1, InetAddress.getByName("127.0.0.1"))
+            .use { it.localPort }
+
+        val forward = RealSshPortForward(
+            channels = transport,
+            remoteHost = "remote.example",
+            remotePort = 5432,
+            localPort = localPort,
+        )
+        try {
+            // Drive one local connection — the accept loop should open a channel
+            // through the injected transport.
+            Socket(InetAddress.getByName("127.0.0.1"), localPort).use { /* connect */ }
+            assertTrue(
+                "the forward must open its channel through the injected transport seam",
+                opened.await(5, TimeUnit.SECONDS),
+            )
+            assertTrue("at least one open went through the transport", openCalls.get() >= 1)
+        } finally {
+            forward.close()
+        }
+    }
+}

--- a/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxClient.kt
+++ b/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxClient.kt
@@ -1344,10 +1344,60 @@ internal class RealTmuxClient(
                 throw exception
             }
             writeJob.cancel()
+            // Issue #979: a structural (`FatalClose`) command whose `%begin/%end`
+            // reply is delayed past the budget must NOT, by itself, tear down the
+            // SSH shell channel when the transport is otherwise ALIVE. The 10s
+            // idle / 30s ceiling timeout is NOT proof the transport is dead — on a
+            // stable-but-momentarily-busy wifi link a `select-window`/`kill-window`
+            // reply can park behind a `%output` burst (the #886 streaming class)
+            // while the link is fine. Closing `shell?.close()` here escalates a
+            // slow control-mode reply into a hard SSH transport disconnect — the
+            // self-inflicted "No live SSH session" drop on stable wifi (#974).
+            //
+            // Consult the single transport-liveness oracle (#986/#964):
+            // `isTransportProvenAliveWithinKeepAliveWindow()` is true iff the
+            // always-on keepalive has observed INBOUND server bytes within its
+            // ride-through window — i.e. the transport is PROVABLY alive right now.
+            // The line for THIS command was written (`writeCompleted` is true on
+            // this arm; a never-written command was reclassified to FatalClose
+            // above and closed because the bytes never reached tmux), so an
+            // unanswered structural command on a proven-alive link is "the answer
+            // is slow," not "the transport is dead." Account for the orphaned block
+            // (so a late `%begin/%end` drains as stale rather than mis-correlating
+            // the FIFO by one) and throw a recoverable exception WITHOUT closing the
+            // SSH shell. The transport-death oracle (keepalive / LivenessProbe)
+            // stays the sole authority for closing the SSH session — a control-mode
+            // command timeout never gets to kill a link the keepalive is still
+            // proving alive.
+            //
+            // When the transport is NOT proven alive (no recent inbound activity —
+            // a genuinely dead/half-open link), the timeout IS evidence of death,
+            // so the original FatalClose teardown still runs: the genuine-death
+            // recovery path is preserved.
+            val transportProvenAlive = session.isTransportProvenAliveWithinKeepAliveWindow()
+            if (transportProvenAlive) {
+                Log.w(
+                    ISSUE_244_DIAG_TAG,
+                    "tmux-command-fatal-timeout-rode-through kind=$kind timeoutMs=$commandTimeoutMs " +
+                        "transportProvenAlive=true (not closing SSH shell — #979)",
+                )
+                recordFatalTimeoutRodeThrough(kind = kind)
+                deferred.completeExceptionally(exception)
+                synchronized(responseCorrelationLock) {
+                    // The line was written; if tmux still owes us a `%begin/%end`
+                    // for it, count that block as stale so the reader discards it
+                    // instead of binding it to the next command (FIFO desync).
+                    val waitingForBegin = pendingCmd.commandNumber < 0L
+                    if (pendingQueue.remove(pendingCmd) && waitingForBegin) {
+                        staleResponseBlocksToIgnore += 1
+                    }
+                }
+                throw exception
+            }
             deferred.completeExceptionally(exception)
             Log.w(
                 ISSUE_244_DIAG_TAG,
-                "tmux-command-timeout kind=$kind timeoutMs=$commandTimeoutMs",
+                "tmux-command-timeout kind=$kind timeoutMs=$commandTimeoutMs transportProvenAlive=false",
             )
             synchronized(responseCorrelationLock) {
                 pendingQueue.remove(pendingCmd)
@@ -1783,6 +1833,25 @@ internal class RealTmuxClient(
                 "timeoutMode" to timeoutMode.logName,
                 "timeoutMs" to commandTimeoutMs,
                 "writeCompleted" to writeCompleted,
+            ),
+        )
+    }
+
+    /**
+     * Issue #979: a `FatalClose` command timed out, but the transport-liveness
+     * oracle (#986/#964) proves the SSH link is still alive, so we did NOT close
+     * the SSH shell — the slow reply rode through. Recorded so the reviewer can
+     * tell a self-inflicted-drop-avoided event apart from a genuine command
+     * timeout that DID tear the channel down.
+     */
+    private fun recordFatalTimeoutRodeThrough(kind: String) {
+        TmuxClientDiagnostics.record(
+            "tmux_client_fatal_timeout_rode_through",
+            commonDiagnosticFields() + mapOf(
+                "session" to sessionName,
+                "commandKind" to kind,
+                "timeoutMs" to commandTimeoutMs,
+                "transportProvenAlive" to true,
             ),
         )
     }

--- a/shared/core-tmux/src/test/java/com/pocketshell/core/tmux/TmuxClientTest.kt
+++ b/shared/core-tmux/src/test/java/com/pocketshell/core/tmux/TmuxClientTest.kt
@@ -1521,6 +1521,207 @@ class TmuxClientTest {
     }
 
     @Test
+    fun `FatalClose select-window timeout on a PROVEN-ALIVE transport does NOT close the SSH shell (issue 979)`() =
+        runBlocking {
+            // Issue #979 / #974: a structural (`FatalClose`) control-mode command
+            // — here `select-window`, the exact production command from the
+            // connection/switch path (ConnectionPortAdapters.kt:223) — whose
+            // `%begin/%end` reply is parked behind an output burst times out. On
+            // the BASE code this calls `closeInternal` -> `shell?.close()`, which
+            // tears down the SSH shell channel and surfaces downstream as the
+            // self-inflicted "No live SSH session" drop on stable wifi.
+            //
+            // The fix: when the transport-liveness oracle (#986/#964) proves the
+            // SSH link is still alive (keepalive saw inbound bytes inside its
+            // ride-through window), a stalled structural reply is "the answer is
+            // slow," NOT "the transport is dead" — so the SSH shell must STAY OPEN
+            // and the command fails with a recoverable exception. The transport's
+            // own keepalive/probe remains the sole authority for closing the link.
+            //
+            // RED on base: `shell.closed` is true here (the SSH channel was torn
+            // down by the command timeout). GREEN with the fix: `shell.closed`
+            // stays false and a follow-up command still rides the same channel.
+            val shell = FakeShell()
+            // PROVEN-ALIVE link: the keepalive is still seeing inbound server bytes.
+            val session = FakeSession(shell, transportProvenAlive = true)
+            val timeoutGate = DeterministicCommandTimeoutGate()
+            val client = RealTmuxClient(
+                session,
+                scope,
+                commandTimeoutMs = 100L,
+                commandTimeoutGate = timeoutGate,
+            )
+            val diagnosticEvents = Collections.synchronizedList(
+                mutableListOf<Pair<String, Map<String, Any?>>>(),
+            )
+            installDiagnosticsForClient(
+                client,
+                setOf(
+                    "tmux_client_command_timeout",
+                    "tmux_client_reader_exit",
+                    "tmux_client_fatal_timeout_rode_through",
+                ),
+                diagnosticEvents,
+            )
+            try {
+                client.connect()
+                withTimeout(2_000) {
+                    while (shell.stdinBytes().isEmpty()) { yield(); delay(10) }
+                }
+                shell.resetStdin()
+
+                val sent = scope.async {
+                    runCatching { client.sendCommand("select-window -t @3") }
+                }
+                // Wait for the command bytes to land (write completed) before
+                // firing the deterministic timeout, so the timeout observes
+                // writeCompleted = true (the FatalClose-after-write path).
+                withTimeout(2_000) {
+                    while (shell.stdinAsString() != "select-window -t @3\n") { yield(); delay(10) }
+                }
+                timeoutGate.fireNextTimeout()
+                val outcome = withTimeout(ASYNC_AWAIT_TIMEOUT_MS) { sent.await() }
+
+                // The command itself still fails (the caller is told the reply
+                // never came) — but with a recoverable exception, NOT a teardown.
+                assertTrue("expected the stalled command to fail", outcome.isFailure)
+                val ex = outcome.exceptionOrNull()!!
+                assertTrue("expected TmuxClientException, got ${ex.javaClass.name}", ex is TmuxClientException)
+                assertTrue(
+                    "timeout message must identify the command kind",
+                    ex.message?.contains("tmux command `select-window` timed out") == true,
+                )
+
+                // THE LOAD-BEARING ASSERTION (#979): the SSH shell channel must
+                // survive — a stalled structural reply on a proven-alive link must
+                // NOT self-inflict an SSH transport disconnect.
+                assertFalse(
+                    "FatalClose timeout on a PROVEN-ALIVE transport must NOT close " +
+                        "the SSH shell (issue #979 self-inflicted drop)",
+                    shell.closed,
+                )
+                assertFalse(
+                    "the disconnected latch must NOT trip — the link is still alive",
+                    client.disconnected.value,
+                )
+
+                // The ride-through is recorded (so the avoided-drop is observable),
+                // and NO reader-exit / teardown diagnostic fired.
+                assertTrue(
+                    "expected a fatal-timeout-rode-through diagnostic",
+                    diagnosticEvents.any { it.first == "tmux_client_fatal_timeout_rode_through" },
+                )
+                val rodeThrough = diagnosticEvents.first {
+                    it.first == "tmux_client_fatal_timeout_rode_through"
+                }.second
+                assertEquals("select-window", rodeThrough["commandKind"])
+                assertEquals(true, rodeThrough["transportProvenAlive"])
+                assertTrue(
+                    "a rode-through timeout must NOT emit a reader exit (no teardown)",
+                    diagnosticEvents.none { it.first == "tmux_client_reader_exit" },
+                )
+
+                // The stalled select-window's reply was written, so tmux still
+                // owes us its `%begin/%end` block — it just arrived LATE (after the
+                // timeout fired). The ride-through accounted for it as a stale
+                // block, so the reader must DISCARD this late block instead of
+                // mis-binding it to the next command (FIFO desync). Feed it now.
+                shell.feed(
+                    "%begin 1700000000 50 0\n" +
+                        "%end 1700000000 50 0\n",
+                )
+
+                // The channel is still usable: a follow-up command rides the SAME
+                // shell and completes normally — proof the SSH transport survived
+                // AND the FIFO stayed consistent (the late stale block did not
+                // steal this command's response).
+                shell.resetStdin()
+                val followUp = scope.async { client.sendCommand("list-windows") }
+                withTimeout(2_000) {
+                    while (shell.stdinAsString() != "list-windows\n") { yield(); delay(10) }
+                }
+                shell.feed(
+                    "%begin 1700000000 99 0\n" +
+                        "@3 win-three\n" +
+                        "%end 1700000000 99 0\n",
+                )
+                val followUpResponse = withTimeout(ASYNC_AWAIT_TIMEOUT_MS) { followUp.await() }
+                assertFalse("follow-up command must succeed on the surviving channel", followUpResponse.isError)
+                assertEquals(listOf("@3 win-three"), followUpResponse.output)
+                assertFalse("follow-up must not have closed the shell", shell.closed)
+            } finally {
+                client.close()
+            }
+        }
+
+    @Test
+    fun `FatalClose select-window timeout on a DEAD transport still closes the SSH shell (issue 979 genuine-death preserved)`() =
+        runBlocking {
+            // Issue #979 counterpart: the genuine-death recovery path is preserved.
+            // When the transport-liveness oracle reports the link is NOT proven
+            // alive (no recent inbound activity — a genuinely dead/half-open
+            // link), a structural command timeout IS evidence the transport is
+            // dead, so the original FatalClose teardown still runs and closes the
+            // SSH shell so the reconnect ladder can recover. Same FatalClose
+            // command as the ride-through test, only the liveness signal differs.
+            val shell = FakeShell()
+            // NOT proven alive — the keepalive has seen no inbound bytes.
+            val session = FakeSession(shell, transportProvenAlive = false)
+            val timeoutGate = DeterministicCommandTimeoutGate()
+            val client = RealTmuxClient(
+                session,
+                scope,
+                commandTimeoutMs = 100L,
+                commandTimeoutGate = timeoutGate,
+            )
+            val diagnosticEvents = Collections.synchronizedList(
+                mutableListOf<Pair<String, Map<String, Any?>>>(),
+            )
+            installDiagnosticsForClient(
+                client,
+                setOf("tmux_client_reader_exit", "tmux_client_fatal_timeout_rode_through"),
+                diagnosticEvents,
+            )
+            try {
+                client.connect()
+                withTimeout(2_000) {
+                    while (shell.stdinBytes().isEmpty()) { yield(); delay(10) }
+                }
+                shell.resetStdin()
+
+                val sent = scope.async {
+                    runCatching { client.sendCommand("select-window -t @3") }
+                }
+                withTimeout(2_000) {
+                    while (shell.stdinAsString() != "select-window -t @3\n") { yield(); delay(10) }
+                }
+                timeoutGate.fireNextTimeout()
+                val outcome = withTimeout(ASYNC_AWAIT_TIMEOUT_MS) { sent.await() }
+
+                assertTrue("expected timeout failure", outcome.isFailure)
+                assertTrue(
+                    "a dead-transport FatalClose timeout MUST close the SSH shell " +
+                        "(genuine-death recovery path preserved, issue #979)",
+                    shell.closed,
+                )
+                assertTrue("the disconnected latch must trip on a dead transport", client.disconnected.value)
+                assertEquals(
+                    TmuxDisconnectReason.CommandTimeout,
+                    client.disconnectEvent.value?.reason,
+                )
+                assertTrue(
+                    "a dead-transport timeout must NOT record a ride-through",
+                    diagnosticEvents.none { it.first == "tmux_client_fatal_timeout_rode_through" },
+                )
+                val exit = waitForDiagnosticEvent(diagnosticEvents, "tmux_client_reader_exit")
+                assertEquals("command_timeout", exit["disconnectCause"])
+                assertEquals("select-window", exit["commandKind"])
+            } finally {
+                client.close()
+            }
+        }
+
+    @Test
     fun `best-effort capture timeout drains late response without disconnecting`() = runBlocking {
         assertBestEffortTimeoutDrainsLateResponse(
             command = "capture-pane -p -e -S -200 -t %0",
@@ -2276,6 +2477,14 @@ class TmuxClientTest {
         // attach-only restore path. Tests that exercise it supply a stub; the
         // default keeps every other test (which never preflights) unchanged.
         private val execHandler: (suspend (String) -> ExecResult)? = null,
+        // Issue #979: the transport-liveness oracle (#986/#964). The default
+        // `false` mirrors a link with NO recent inbound activity — so a
+        // FatalClose command timeout STILL closes the SSH shell (the genuine
+        // dead-transport path). Set `true` to simulate a stable wifi link the
+        // keepalive is still proving alive: a stalled structural reply must then
+        // ride through WITHOUT killing the SSH channel.
+        @Volatile
+        var transportProvenAlive: Boolean = false,
     ) : SshSession {
         @Volatile
         private var closed = false
@@ -2284,6 +2493,9 @@ class TmuxClientTest {
             Collections.synchronizedList(mutableListOf())
 
         override val isConnected: Boolean get() = !closed
+
+        override fun isTransportProvenAliveWithinKeepAliveWindow(): Boolean =
+            transportProvenAlive
 
         override suspend fun exec(command: String): ExecResult {
             execCommands.add(command)


### PR DESCRIPTION
Three independently-reviewed, APPROVED connection/session fixes batched into one integration PR (separate commit per issue) to share one emulator/Docker CI cycle. Each was reviewer-driven red→green; the combined local gate (compile + the four touched test classes + both shared-module suites) is green.

- **#990** — `session: quote ~/ strip pattern so start-dir tilde resolves`. A new shell session in `~/git` falsely reported 'does not exist' because `~/` in the `#`-strip pattern was tilde-expanded → `$HOME/~/git`. Behavioral test now runs the script through real `/bin/sh -c`. Closes #990.
- **#979** — `core-tmux: don't self-close the SSH channel on a FatalClose timeout when the transport is proven alive`. A stalled control-mode reply on a live link no longer escalates to an SSH transport disconnect (consults #986's liveness oracle); genuine death still recovers. Closes #979.
- **#980** — `core-ssh: route port-forward channel opens through the single-writer dispatcher + drop the raw network force-tear`. Kills the #847-class two-writer desync (direct-tcpip opens now go through the dispatcher) and hard-cuts the ForwardingService raw network-callback that force-tore live sessions. Closes #980.

Part of the connection-bulletproof release (#928). Reviewer approvals: #990 / #979 / #980 issue threads.

(Note: #971 was assembled into the original batch but pulled back out — it introduced a cross-test uncaught-coroutine leak caught by the combined gate; it's in a fix round. #989 needs a rebase round. Both land separately.)

---
**Update:** folded in **#994** (the pre-existing  Dispatchers.Default flaky-leak fix) so this batch's full-suite CI is reliably green and  becomes flake-free for the rest of the campaign. Closes #994.