### PR TITLE
Bulletproof batch B: composer queue+clear (#971) + lease-pool cap (#996) + network-detector race (#995)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerDegradedSendE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerDegradedSendE2eTest.kt
@@ -39,6 +39,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -106,7 +107,9 @@ class PromptComposerDegradedSendE2eTest {
         override fun whisperLanguageHint(): String? = null
     }
 
-    private fun newViewModel(): PromptComposerViewModel = PromptComposerViewModel(
+    private fun newViewModel(
+        outboundQueueStore: OutboundQueueStore = DisabledOutboundQueueStore,
+    ): PromptComposerViewModel = PromptComposerViewModel(
         audioRecorder = TestMicCapture(),
         whisperClientFactory = WhisperClientFactory {
             object : WhisperClient {
@@ -116,6 +119,7 @@ class PromptComposerDegradedSendE2eTest {
         },
         apiKeyStorage = TestVault(),
         voiceSettings = TestVoiceSettings(),
+        outboundQueueStore = outboundQueueStore,
     )
 
     /**
@@ -128,6 +132,8 @@ class PromptComposerDegradedSendE2eTest {
         visibleState: androidx.compose.runtime.MutableState<Boolean>,
         connectionLost: Boolean,
         onAttachFiles: (() -> Unit)? = null,
+        sendTarget: PromptComposerViewModel.SendTargetSnapshot =
+            PromptComposerViewModel.SendTargetSnapshot(),
     ) {
         compose.activityRule.scenario.onActivity { activity ->
             val dark = PocketShellColors.Background.toArgb()
@@ -152,6 +158,7 @@ class PromptComposerDegradedSendE2eTest {
                 val visible by remember { visibleState }
                 if (visible) {
                     val state by vm.uiState.collectAsState()
+                    val queue by vm.outboundQueueItems.collectAsState()
                     Box(
                         modifier = Modifier
                             .fillMaxSize()
@@ -164,8 +171,11 @@ class PromptComposerDegradedSendE2eTest {
                             onClose = {},
                             onDraftChange = vm::onDraftChange,
                             onMicTap = {},
-                            onSend = { withEnter -> vm.requestSend(withEnter) },
+                            onSend = { withEnter -> vm.requestSend(withEnter, sendTarget) },
                             onAttachFiles = onAttachFiles,
+                            outboundQueueItems = queue,
+                            onDeleteOutboundItem = vm::discardOutboundItem,
+                            onRetryOutboundItem = vm::retryOutboundItem,
                         )
                     }
                 }
@@ -233,8 +243,9 @@ class PromptComposerDegradedSendE2eTest {
         }
         compose.onNodeWithTag(COMPOSER_SEND_IN_FLIGHT_TAG).assertIsDisplayed()
         compose.onNodeWithTag(COMPOSER_SEND_ENTER_TAG).assertIsNotEnabled()
-        // The draft is STILL on screen mid-flight — no optimistic empty/flicker.
-        assertEquals("restart the worker pool", vm.uiState.value.draft)
+        // Issue #971: the prompt is HANDED OFF mid-flight — the editor is cleared
+        // (single representation), so the same prompt is never shown twice.
+        assertEquals("", vm.uiState.value.draft)
         WalkthroughScreenshotArtifacts.capture("issue-745-02-sending-in-flight")
 
         // (c) the failure resolves within a BOUNDED time. We release the hung
@@ -305,9 +316,10 @@ class PromptComposerDegradedSendE2eTest {
                 .fetchSemanticsNodes().isNotEmpty()
         }
         compose.onNodeWithTag(COMPOSER_SEND_IN_FLIGHT_TAG).assertIsDisplayed()
-        assertEquals("deploy the staging branch", vm.uiState.value.draft)
+        // Issue #971: the prompt is handed off mid-flight — the editor is cleared.
+        assertEquals("", vm.uiState.value.draft)
 
-        // Host confirms delivery → draft clears AND the composer dismisses.
+        // Host confirms delivery → draft stays cleared AND the composer dismisses.
         releaseSend.complete(true)
         compose.waitUntil(timeoutMillis = 5_000) { !visible.value }
         compose.onNodeWithTag(COMPOSER_DRAFT_TAG).assertDoesNotExist()
@@ -420,5 +432,123 @@ class PromptComposerDegradedSendE2eTest {
         assertTrue(second.text.contains(attachPath))
 
         compose.runOnUiThread { vm.discardDraft() }
+    }
+
+    @Test
+    fun issue971_inFlightShowsPromptOnceThenDropStaysQueuedAutoSendsOnReconnect() {
+        // Issue #971/#987 (G10 end-to-end reproduce-first, maintainer Option A):
+        // the maintainer's v0.4.18 + v0.4.18-drop dogfood — while a send is in
+        // flight the SAME prompt (`/clear`) showed up TWICE (editor + "1 unsent
+        // prompt — Sending" row) and on a DROP the composer stacked contradictory
+        // status (the prompt back in the editor + "Not sent… send again or
+        // discard" AND "Send will retry once reconnected"). The CANONICAL design
+        // drives the PRODUCTION [PromptComposerViewModel] + [SheetContent] +
+        // [PromptComposerSendDispatcher] with a real outbound queue store and
+        // asserts the new contract:
+        //  (a) in flight the editor is EMPTY (single representation) with Send
+        //      disabled,
+        //  (b) on a drop the prompt STAYS as ONE queued "Will send when
+        //      reconnected." row (NOT returned to the composer), with NO "Not
+        //      sent / send again or discard" error and NO duplicate
+        //      "Connection lost" banner,
+        //  (c) on reconnect the queued row AUTO-SENDS (the #900 flush) and is
+        //      pruned on delivery.
+        val queue = InMemoryOutboundQueueStore()
+        val vm = newViewModel(outboundQueueStore = queue)
+        val target = PromptComposerViewModel.SendTargetSnapshot(sessionKey = "1/session-a")
+        vm.onComposerTargetChanged("1/session-a")
+        val visible = mutableStateOf(true)
+        // The host's send behaviour is test-controlled: the FIRST dispatch fails
+        // (the drop), and after "reconnect" the SECOND dispatch (the auto-flush)
+        // delivers. This mirrors the production
+        // sendRequests → markSendDelivered | markOutboundSendDeferred wiring.
+        val sendCount = java.util.concurrent.atomic.AtomicInteger(0)
+        val firstSendEntered = CompletableDeferred<Unit>()
+        val releaseFirst = CompletableDeferred<Boolean>()
+        val secondSendEntered = CompletableDeferred<Unit>()
+        collectorScope.launch {
+            vm.sendRequests.collect { request ->
+                val attempt = sendCount.incrementAndGet()
+                if (attempt == 1) {
+                    firstSendEntered.complete(Unit)
+                    val delivered = withTimeoutOrNull(8_000L) { releaseFirst.await() } == true
+                    if (delivered) vm.markSendDelivered(request) else vm.markOutboundSendDeferred(request)
+                } else {
+                    secondSendEntered.complete(Unit)
+                    // The reconnect auto-flush delivers.
+                    vm.markSendDelivered(request)
+                    visible.value = false
+                }
+            }
+        }
+        // Connection is down at first (the drop scenario).
+        renderComposer(vm, visible, connectionLost = true, sendTarget = target)
+
+        // Type the prompt the maintainer reported being duplicated.
+        compose.onNodeWithTag(COMPOSER_DRAFT_TAG).performTextInput("/clear")
+        compose.waitForIdle()
+        compose.onNodeWithTag(COMPOSER_DRAFT_TAG).assertTextContains("/clear", substring = true)
+
+        // Tap Send.
+        compose.onNodeWithTag(COMPOSER_SEND_ENTER_TAG).performClick()
+        compose.waitUntil(timeoutMillis = 5_000) { firstSendEntered.isCompleted }
+        compose.waitUntil(timeoutMillis = 5_000) { vm.uiState.value.sendInFlight }
+        compose.waitUntil(timeoutMillis = 5_000) {
+            compose.onAllNodesWithTag(COMPOSER_SEND_IN_FLIGHT_TAG)
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+
+        // (a) SINGLE REPRESENTATION in flight: editor EMPTY, ONE queue banner,
+        // Send disabled.
+        assertEquals("", vm.uiState.value.draft)
+        compose.onNodeWithTag(COMPOSER_OUTBOUND_QUEUE_BANNER_TAG).assertIsDisplayed()
+        compose.onNodeWithText("1 unsent prompt", substring = true).assertIsDisplayed()
+        assertEquals(listOf("/clear"), vm.outboundQueueItems.value.map { it.cleanText })
+        assertEquals(1, vm.outboundQueueItems.value.size)
+        compose.onNodeWithTag(COMPOSER_SEND_ENTER_TAG).assertIsNotEnabled()
+        WalkthroughScreenshotArtifacts.capture("issue-971-01-in-flight-single-representation")
+
+        // The send fails because the connection dropped.
+        releaseFirst.complete(false)
+        compose.waitUntil(timeoutMillis = 5_000) { !vm.uiState.value.sendInFlight }
+        compose.waitUntil(timeoutMillis = 5_000) {
+            compose.onAllNodesWithTag(COMPOSER_SEND_IN_FLIGHT_TAG)
+                .fetchSemanticsNodes().isEmpty()
+        }
+
+        // (b) DROP → the prompt STAYS QUEUED, NOT returned to the composer:
+        //  - the editor is still EMPTY (no manual-resend draft),
+        //  - exactly ONE queued row remains, reading "Will send when reconnected.",
+        //  - NO "Not sent / send again or discard" error banner,
+        //  - the standalone "Connection lost" banner is SUPPRESSED (the queue
+        //    banner is the single status — no contradictory stack).
+        assertEquals("", vm.uiState.value.draft)
+        assertEquals(1, vm.outboundQueueItems.value.size)
+        assertEquals(OutboundState.Queued, vm.outboundQueueItems.value.single().state)
+        assertNull(
+            "a drop must not stamp a 'Not sent / send again or discard' error",
+            vm.uiState.value.error,
+        )
+        compose.onNodeWithTag(COMPOSER_OUTBOUND_QUEUE_BANNER_TAG).assertIsDisplayed()
+        compose.onNodeWithText(
+            PromptComposerViewModel.WILL_SEND_WHEN_RECONNECTED_MESSAGE,
+            substring = true,
+        ).assertIsDisplayed()
+        compose.onNodeWithText("send again or discard").assertDoesNotExist()
+        compose.onNodeWithTag(COMPOSER_CONNECTION_LOST_TAG).assertDoesNotExist()
+        WalkthroughScreenshotArtifacts.capture("issue-971-02-drop-single-status-stays-queued")
+
+        // (c) RECONNECT → the queued row auto-sends via the #900 flush and is
+        // pruned on delivery. (The production TmuxSessionScreen calls
+        // requeueStaleOutboundInFlight + retryNextOutboundItem on each refresh;
+        // we drive the flush directly here.)
+        compose.runOnUiThread { vm.setConnectionDegraded(false) }
+        compose.runOnUiThread { vm.retryNextOutboundItem() }
+        compose.waitUntil(timeoutMillis = 5_000) { secondSendEntered.isCompleted }
+        compose.waitUntil(timeoutMillis = 5_000) { !visible.value }
+        assertEquals(2, sendCount.get())
+        assertTrue(vm.outboundQueueItems.value.isEmpty())
+        assertEquals("", vm.uiState.value.draft)
+        WalkthroughScreenshotArtifacts.capture("issue-971-03-reconnect-auto-sent-queue-cleared")
     }
 }

--- a/app/src/main/java/com/pocketshell/app/composer/OutboundQueueStore.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/OutboundQueueStore.kt
@@ -238,6 +238,24 @@ public interface OutboundQueueStore {
     ): OutboundItem?
 
     /**
+     * Issue #971/#987: re-arm exactly the row with [id] back to
+     * [OutboundState.Queued] and CLEAR its [OutboundItem.lastError] so the
+     * foreground/reconnect auto-flush can re-claim it. This is the canonical
+     * drop-failure path (maintainer decision on #987 — Option A): a send that
+     * failed because the connection dropped STAYS QUEUED and auto-retries on
+     * reconnect, instead of returning to the composer for a manual resend. It is
+     * distinct from [markFailed] (which leaves a terminal-looking `Failed —
+     * <error>` row): a deferred row reads as the single coherent "Will send when
+     * reconnected." status with no contradictory manual-resend messaging.
+     *
+     * Only an un-delivered row (`Queued`/`Uploading`/`InFlight`/`Failed`) is
+     * re-armed; an unknown/`Delivered` id returns `null` (a late ack cannot
+     * resurrect a pruned/delivered row). Attempt counts are not bumped here; the
+     * next [claimNext] / [claim] records the next attempt.
+     */
+    public fun requeueForRetry(id: String): OutboundItem?
+
+    /**
      * Requeue stale [OutboundState.InFlight] rows for [sessionKey] so a
      * foreground/reconnect flush can pick them up again after a prior delivery
      * attempt was abandoned by process death or a lost callback.
@@ -518,6 +536,14 @@ public open class InMemoryOutboundQueueStore : OutboundQueueStore {
             updated
         }
 
+    override fun requeueForRetry(id: String): OutboundItem? = synchronized(lock) {
+        val existing = items[id] ?: return null
+        if (existing.state == OutboundState.Delivered) return null
+        val updated = existing.copy(state = OutboundState.Queued, lastError = null)
+        items[updated.id] = updated
+        updated
+    }
+
     override fun requeueStaleInFlight(sessionKey: String, cutoffMs: Long): List<OutboundItem> =
         synchronized(lock) {
             val updated = items.values
@@ -573,6 +599,7 @@ public object DisabledOutboundQueueStore : OutboundQueueStore {
     override fun markAttachmentsUploaded(id: String, attachments: List<DurableAttachmentRef>): OutboundItem? = null
     override fun markDelivered(id: String): Boolean = false
     override fun markFailed(id: String, lastError: String?, lastAttemptAtMs: Long): OutboundItem? = null
+    override fun requeueForRetry(id: String): OutboundItem? = null
     override fun requeueStaleInFlight(sessionKey: String, cutoffMs: Long): List<OutboundItem> = emptyList()
     override fun remove(id: String): Boolean = false
     override fun clearSession(sessionKey: String) = Unit
@@ -799,6 +826,16 @@ public class SharedPrefsOutboundQueueStore @Inject constructor(
             replaceAndStore(sessionKey, list, updated)
             updated
         }
+
+    override fun requeueForRetry(id: String): OutboundItem? = synchronized(lock) {
+        val sessionKey = sessionOf(id) ?: return null
+        val list = loadSession(sessionKey)
+        val existing = list.firstOrNull { it.id == id } ?: return null
+        if (existing.state == OutboundState.Delivered) return null
+        val updated = existing.copy(state = OutboundState.Queued, lastError = null)
+        replaceAndStore(sessionKey, list, updated)
+        updated
+    }
 
     override fun requeueStaleInFlight(sessionKey: String, cutoffMs: Long): List<OutboundItem> =
         synchronized(lock) {

--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerSheet.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerSheet.kt
@@ -1138,7 +1138,15 @@ internal fun SheetContent(
         // up. Surfaced the moment the host reports the SSH/tmux link is
         // degraded/lost, BEFORE the user taps Send, so a send into a dead link
         // is never a silent blind wait.
-        if (state.connectionDegraded) {
+        //
+        // Issue #971/#987 (Option A): once there is a queued outbound prompt
+        // waiting, the OutboundQueueBanner already carries the SINGLE coherent
+        // "Will send when reconnected." status. Showing this standalone
+        // "Connection lost — Send will retry once reconnected." banner on top of
+        // it is the exact duplicated/contradictory stack the maintainer reported
+        // on #987 — so suppress it whenever the queue banner is present. With no
+        // queued prompt the standalone indicator still warns BEFORE the first Send.
+        if (state.connectionDegraded && outboundQueueItems.isEmpty()) {
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -1389,7 +1397,18 @@ public fun PromptComposerSendDispatcher(
                 viewModel.markSendDelivered(request)
                 currentOnDelivered()
             } else {
-                viewModel.restoreFailedSend(request)
+                // Issue #971/#987 (maintainer decision — Option A): a failed /
+                // timed-out send on a degraded link is a connection drop, not a
+                // permanent rejection. The host `onSend` cannot distinguish the
+                // two (it returns only false/timeout), so treat it as the common
+                // drop case: keep the prompt QUEUED and auto-send it on reconnect
+                // (the #900 flush wired in TmuxSessionScreen) instead of returning
+                // it to the composer for a manual resend. This removes the
+                // contradictory "send again or discard" vs "will retry" stacking
+                // the maintainer reported on #987. markOutboundSendDeferred falls
+                // back to a composer-restore only when there is no durable queue
+                // row, so the prompt is never silently lost.
+                viewModel.markOutboundSendDeferred(request)
             }
         }
     }
@@ -3057,7 +3076,10 @@ internal fun outboundQueueSubline(items: List<OutboundItem>): String {
 }
 
 internal fun outboundQueueStateLabel(item: OutboundItem): String = when (item.state) {
-    OutboundState.Queued -> "Queued"
+    // Issue #971/#987 (Option A): a queued row is waiting to auto-send on
+    // reconnect — show the SINGLE coherent status, not a bare "Queued" that
+    // reads as a mysterious stuck item next to the connection chrome.
+    OutboundState.Queued -> PromptComposerViewModel.WILL_SEND_WHEN_RECONNECTED_MESSAGE
     OutboundState.Uploading -> "Uploading attachments"
     OutboundState.InFlight -> "Sending"
     OutboundState.Delivered -> "Delivered"

--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerViewModel.kt
@@ -276,6 +276,20 @@ public class PromptComposerViewModel @Inject constructor(
     private var outboundSidecarDispatchInFlight: Boolean = false
 
     /**
+     * Issue #971: the [SendRequest] for the prompt currently in flight, captured
+     * at handoff. Because the editable composer is now CLEARED on enqueue (the
+     * queue row is the single representation), the live `_uiState.draft` is no
+     * longer the source for restoring a wedged send. The non-delivering recovery
+     * paths — the #891 overall-send watchdog ([onSendWatchdogExpired]), the #929
+     * stranded-dispatch clears, and a structured-concurrency cancellation —
+     * therefore reconstruct the prompt from THIS captured request so the exact
+     * draft + attachment tiles still return to the (now-single) composer instead
+     * of an empty one. Set the instant a send goes in-flight; cleared the instant
+     * it resolves (delivered / failed / strand-cleared / discarded).
+     */
+    private var inFlightSendRequest: SendRequest? = null
+
+    /**
      * Issue #891: the overall send-operation watchdog. The maintainer's
      * on-device symptom — a prompt with a PNG attachment stuck on "Sending…"
      * FOREVER, only recoverable by restarting the app — happens when the
@@ -918,12 +932,17 @@ public class PromptComposerViewModel @Inject constructor(
             "attachmentCount" to attachments.size,
             "withEnter" to withEnter,
         )
-        // Issue #745: flip the composer into the IN-FLIGHT state and clear
-        // any stale "Not sent" banner BEFORE emitting the request. The draft
-        // and staged attachment TILES stay on screen (cleared only on
-        // confirmed delivery). The send button reads `sendInFlight` to disable
-        // itself + show the "Sending…" spinner for immediate feedback the moment
-        // Send is tapped.
+        // Issue #971: HAND THE PROMPT OFF to the outbound queue — clear the
+        // editable draft + staged tiles the instant we go in-flight so the
+        // prompt is represented EXACTLY ONCE (the "Sending…" queue row), never
+        // as BOTH the editor text AND a duplicate "1 unsent prompt" row. This
+        // reverses the #745 keep-the-draft-visible behaviour (hard-cut per D22):
+        // the queue row is now the single in-flight source of truth, and the
+        // Send button reads `sendInFlight` to disable itself + show "Sending…".
+        // The clean draft + tiles still travel in the [SendRequest] / queue row,
+        // so a failed send ([restoreFailedSend]) puts the EXACT prompt back into
+        // the (now-single) composer, and a delivered send leaves it empty.
+        clearComposerForHandoff()
         _uiState.update { it.copy(sendInFlight = true, error = null) }
         // Issue #891: arm the overall-send watchdog the instant we go in-flight
         // so a host `onSend` that never resolves (wedged channel / dropped
@@ -977,8 +996,47 @@ public class PromptComposerViewModel @Inject constructor(
             sendTarget = sendTarget,
             outboundQueueItemId = outboundItem?.id,
         )
+        // Issue #971: remember the in-flight prompt so a wedged/cancelled send
+        // (watchdog / strand-clear / cancellation) restores the EXACT draft +
+        // tiles to the now-cleared composer, not an empty one.
+        inFlightSendRequest = request
         if (_sendRequests.trySend(request).isFailure) {
-            restoreFailedSend(request)
+            // Issue #971/#987: a buffer-full enqueue is a transient dispatch
+            // failure, not a permanent rejection — defer to the queue so the row
+            // stays queued and auto-retries on the next flush (Option A). Falls
+            // back to a composer-restore only when there is no durable row.
+            markOutboundSendDeferred(request)
+        }
+    }
+
+    /**
+     * Issue #971: hand the prompt off to the outbound queue — empty the editable
+     * composer (draft text + staged attachment tiles + the persisted draft slots)
+     * so an in-flight send is represented EXACTLY ONCE by its "Sending…" queue
+     * row, never as BOTH the editor AND a duplicate "1 unsent prompt" row.
+     *
+     * This clears the in-memory draft/tiles, the [SavedStateHandle] draft slots
+     * (so a process-death recreate mid-send does not resurrect the handed-off
+     * text into the editor alongside the queue row), and the durable per-session
+     * draft store (so a session switch away-and-back mid-send does not reload the
+     * handed-off draft into the editor next to its queue row). The prompt is NOT
+     * lost: it travels in the [SendRequest] + the durable queue row, so a failed
+     * send ([restoreFailedSend]) restores the exact draft + tiles back into the
+     * (now-single) composer, and a delivered send leaves the composer empty.
+     */
+    private fun clearComposerForHandoff() {
+        savedStateHandle[KEY_DRAFT] = ""
+        savedStateHandle[KEY_DRAFT_OWNER] = null
+        composerTarget?.let { target ->
+            composerDraftStore.clear(target)
+            composerDraftStore.clearAttachments(target)
+        }
+        _uiState.update { current ->
+            current.copy(
+                draft = "",
+                attachments = emptyList(),
+                attachmentUpload = AttachmentUploadState.Idle,
+            )
         }
     }
 
@@ -1087,6 +1145,9 @@ public class PromptComposerViewModel @Inject constructor(
         // Issue #891: the send resolved successfully — disarm the overall-send
         // watchdog so it cannot fire a spurious "Send failed" afterwards.
         disarmSendWatchdog()
+        // Issue #971: the in-flight send resolved — drop the captured request so a
+        // later watchdog/strand cannot restore a stale prompt.
+        inFlightSendRequest = null
         markOutboundSendDelivered(request)
         val deliveryTarget = request?.sendTarget?.sessionKey?.takeIf { it.isNotBlank() } ?: composerTarget
         if (deliveryTarget != null && deliveryTarget != composerTarget) {
@@ -1141,6 +1202,9 @@ public class PromptComposerViewModel @Inject constructor(
         // watchdog so the retryable failed state we are about to set is not
         // immediately re-stamped by a late watchdog firing.
         disarmSendWatchdog()
+        // Issue #971: the in-flight send resolved — drop the captured request so a
+        // later watchdog/strand cannot restore it a second time.
+        inFlightSendRequest = null
         markOutboundSendFailed(request, message)
         // Issue #872: restore the CLEAN draft (no appended "Attached files:"
         // block) so the editable text is not polluted with raw remote paths and
@@ -1190,6 +1254,72 @@ public class PromptComposerViewModel @Inject constructor(
                 // Issue #872: re-show the actual attachment tiles so Retry
                 // re-sends the original attachment, not just the text.
                 attachments = restoredAttachments,
+                attachmentUpload = AttachmentUploadState.Idle,
+            )
+        }
+    }
+
+    /**
+     * Issue #971/#987 (maintainer decision — Option A): the canonical
+     * drop/wedge-failure path for a send that owns a durable outbound queue row.
+     * A send that fails because the connection dropped (or wedged past the
+     * watchdog) must NOT return to the composer for a manual resend — it STAYS
+     * QUEUED and auto-sends on reconnect (the #900 flush). This:
+     *
+     *  - re-arms the durable row to [OutboundState.Queued] and clears its error
+     *    (so it reads as the single "Will send when reconnected." status, never a
+     *    terminal-looking "Failed — …" row),
+     *  - clears the in-flight gates + watchdog so the next foreground/reconnect
+     *    flush ([retryNextOutboundItem]) can re-claim it,
+     *  - leaves the composer EMPTY (the prompt lives in the queue row — the
+     *    single representation; #971) and sets NO "Not sent / send again or
+     *    discard" error banner.
+     *
+     * Falls back to [restoreFailedSend] only when the request has no durable
+     * queue row ([SendRequest.outboundQueueItemId] is null — e.g. the composer
+     * is wired to [DisabledOutboundQueueStore], or an upload-await wedge that
+     * failed before the row was enqueued): there is then nothing to keep queued,
+     * so the prompt must come back to the composer rather than be silently lost.
+     * The user can still cancel/discard a queued item from the queue surface.
+     */
+    public fun markOutboundSendDeferred(
+        request: SendRequest,
+        // The message used ONLY when there is no durable queue row and we fall
+        // back to [restoreFailedSend] (the prompt comes back to the composer
+        // instead of being lost). The deferred (row-kept) path never sets an
+        // error — its single status is the queue row's "Will send when
+        // reconnected." Defaults to the calm reconnect copy.
+        noRowFallbackMessage: String = "Not sent. Reconnect, then send again or discard the draft.",
+    ) {
+        // Issue #891: the send resolved (deferred to the queue) — disarm the
+        // overall-send watchdog so it cannot re-stamp a stale "Send failed".
+        disarmSendWatchdog()
+        // Issue #971: the in-flight send resolved — drop the captured request so a
+        // later watchdog/strand cannot act on it again.
+        inFlightSendRequest = null
+        val id = request.outboundQueueItemId
+        val requeued = id?.let { outboundQueueStore.requeueForRetry(it) }
+        if (requeued == null) {
+            // No durable row to keep queued — fall back to the composer-restore
+            // path so the typed prompt is not silently lost.
+            restoreFailedSend(request, message = noRowFallbackMessage)
+            return
+        }
+        DiagnosticEvents.record(
+            "action",
+            "composer_send_deferred_to_queue",
+            "attachmentCount" to request.attachments.size,
+        )
+        request.sendTarget.sessionKey
+            .takeIf { it.isNotBlank() }
+            ?.let { refreshOutboundQueueItemsFor(it) }
+        // Clear the in-flight gates so the reconnect flush can re-claim the row.
+        // The composer stays EMPTY (the row is the single representation) and NO
+        // "Not sent" error is set — the queue row's "Will send when reconnected."
+        // is the single coherent status.
+        _uiState.update { current ->
+            current.copy(
+                sendInFlight = false,
                 attachmentUpload = AttachmentUploadState.Idle,
             )
         }
@@ -1305,6 +1435,31 @@ public class PromptComposerViewModel @Inject constructor(
     private fun clearStrandedSendInFlight(error: String? = null) {
         disarmSendWatchdog()
         outboundSidecarDispatchInFlight = false
+        // Issue #971/#987: the composer was cleared at handoff, so a non-delivering
+        // strand must not silently lose the prompt. Per the maintainer's #987
+        // decision (Option A) a drop/wedge keeps the prompt QUEUED and auto-retries
+        // on reconnect rather than returning to the composer for manual resend.
+        // When we hold the captured in-flight request, route through the deferred
+        // path: a request with a durable queue row stays queued (single
+        // representation, single "Will send when reconnected." status); a request
+        // with no row (Disabled store / pre-enqueue wedge) falls back to the
+        // composer-restore inside markOutboundSendDeferred so the prompt is not
+        // lost. A passed-in [error] (a genuine non-retryable failure, e.g.
+        // "could not preserve attachment bytes") still surfaces via the
+        // composer-restore fallback so the user sees the reason.
+        val pending = inFlightSendRequest
+        if (pending != null && pending.text.isNotEmpty()) {
+            if (error != null) {
+                // A genuine non-retryable reason was given — surface it on the
+                // composer (the bytes/attachment could not be preserved, not a
+                // recoverable connection drop). This is the distinct
+                // permanent-failure path from #987.
+                restoreFailedSend(pending, message = error)
+            } else {
+                markOutboundSendDeferred(pending)
+            }
+            return
+        }
         _uiState.update { current ->
             if (error != null) {
                 current.copy(sendInFlight = false, error = error)
@@ -1325,25 +1480,35 @@ public class PromptComposerViewModel @Inject constructor(
      */
     private fun onSendWatchdogExpired() {
         sendWatchdogJob = null
-        val state = _uiState.value
-        if (!state.sendInFlight) return
-        DiagnosticEvents.record(
-            "action",
-            "composer_send_watchdog_timeout",
-            "attachmentCount" to state.attachments.size,
-        )
-        // Reconstruct a SendRequest from the live composer state so the existing
-        // #872 durable failed-send path restores the exact draft + attachments.
-        val composed = appendAttachmentPaths(state.draft, state.attachments.map { it.remotePath })
-        restoreFailedSend(
+        if (!_uiState.value.sendInFlight) return
+        // Issue #971: the editable composer is cleared on handoff, so prefer the
+        // captured in-flight request to restore the EXACT prompt + tiles. Fall
+        // back to the live state only for the upload-await wedge, where the send
+        // went in-flight before the request was built and the draft is still on
+        // screen.
+        val request = inFlightSendRequest ?: run {
+            val state = _uiState.value
+            val composed = appendAttachmentPaths(state.draft, state.attachments.map { it.remotePath })
             SendRequest(
                 text = composed,
                 withEnter = false,
                 cleanDraft = state.draft,
                 attachments = state.attachments,
-            ),
-            message = SEND_TIMEOUT_MESSAGE,
+            )
+        }
+        DiagnosticEvents.record(
+            "action",
+            "composer_send_watchdog_timeout",
+            "attachmentCount" to request.attachments.size,
         )
+        // Issue #971/#987: a wedged send is a connection problem, not a permanent
+        // rejection — defer it to the queue so it auto-retries on reconnect
+        // (Option A). When the request owns a durable queue row this keeps it
+        // queued + clears the composer; the upload-await wedge (no row) falls
+        // back to the composer-restore path inside markOutboundSendDeferred with
+        // the watchdog-specific copy so the typed prompt is not lost and the user
+        // sees that the send timed out.
+        markOutboundSendDeferred(request, noRowFallbackMessage = SEND_TIMEOUT_MESSAGE)
     }
 
     /**
@@ -1365,6 +1530,9 @@ public class PromptComposerViewModel @Inject constructor(
         // the watchdog so it cannot resurrect a "Send failed" banner over the
         // now-empty composer.
         disarmSendWatchdog()
+        // Issue #971: drop the captured in-flight request so a late
+        // watchdog/strand cannot restore a prompt the user just discarded.
+        inFlightSendRequest = null
         savedStateHandle[KEY_DRAFT] = ""
         savedStateHandle[KEY_DRAFT_OWNER] = null
         // Issue #832 / #872: discard is the explicit "throw it away" control, so
@@ -1493,9 +1661,7 @@ public class PromptComposerViewModel @Inject constructor(
         val item = outboundQueueStore.item(id) ?: return
         if (item.state != OutboundState.Queued && item.state != OutboundState.Failed) return
         outboundQueueStore.remove(id)
-        outboundAttachmentSidecarStore?.let { store ->
-            viewModelScope.launch { store.removeOutboundItem(id) }
-        }
+        launchSidecarRemoval(id)
         refreshOutboundQueueItems()
     }
 
@@ -1685,8 +1851,15 @@ public class PromptComposerViewModel @Inject constructor(
         )
         _uiState.update { it.copy(sendInFlight = true, error = null) }
         armSendWatchdog()
+        // Issue #971: remember the in-flight prompt for the wedged/cancelled
+        // recovery paths (watchdog / strand-clear) so they restore the exact
+        // payload rather than the cleared composer.
+        inFlightSendRequest = request
         if (_sendRequests.trySend(request).isFailure) {
-            restoreFailedSend(request)
+            // Issue #971/#987: transient dispatch failure on a queue-flush — keep
+            // the row queued for the next auto-retry (Option A), don't return it
+            // to the composer.
+            markOutboundSendDeferred(request)
             return false
         }
         return true
@@ -1695,9 +1868,7 @@ public class PromptComposerViewModel @Inject constructor(
     private fun markOutboundSendDelivered(request: SendRequest?) {
         val id = request?.outboundQueueItemId ?: return
         outboundQueueStore.markDelivered(id)
-        outboundAttachmentSidecarStore?.let { store ->
-            viewModelScope.launch { store.removeOutboundItem(id) }
-        }
+        launchSidecarRemoval(id)
         request.sendTarget.sessionKey
             .takeIf { it.isNotBlank() }
             ?.let { refreshOutboundQueueItemsFor(it) }
@@ -1705,11 +1876,62 @@ public class PromptComposerViewModel @Inject constructor(
 
     private fun markOutboundSendFailed(request: SendRequest, message: String) {
         val id = request.outboundQueueItemId ?: return
-        outboundQueueStore.markFailed(id, lastError = message)
+        // Issue #971/#987: this is the GENUINE-permanent-failure path
+        // ([restoreFailedSend]) — the prompt is returned to the composer as the
+        // SINGLE representation, so REMOVE the queue row instead of leaving a
+        // "Failed" duplicate next to the restored editor text (the maintainer's
+        // exact complaint, and the leftover row would let the reconnect auto-flush
+        // double-send what the user can now re-Send by hand). NOTE: the COMMON
+        // drop/wedge case no longer reaches here — it routes through
+        // [markOutboundSendDeferred], which KEEPS the row queued for auto-retry
+        // (Option A). Drop any sidecar bytes the row owned so nothing is orphaned.
+        outboundQueueStore.remove(id)
+        launchSidecarRemoval(id)
         request.sendTarget.sessionKey
             .takeIf { it.isNotBlank() }
             ?.let { refreshOutboundQueueItemsFor(it) }
     }
+
+    /**
+     * Issue #971 leak fix: the single, GUARDED fire-and-forget for dropping the
+     * durable sidecar bytes a resolved (delivered / failed / discarded) outbound
+     * row owned. Cleanup is best-effort — a failed delete must NEVER surface as
+     * an UNCAUGHT exception that escapes [viewModelScope].
+     *
+     * The bare `viewModelScope.launch { store.removeOutboundItem(id) }` callers
+     * this replaces hopped to real `Dispatchers.IO` (inside
+     * [OutboundAttachmentSidecarStore.removeOutboundItem]) with NO try/catch. A
+     * `persistAll` write failure there threw on a real background thread, after
+     * the test body returned, and kotlinx-coroutines-test re-surfaced it as
+     * `UncaughtExceptionsBeforeTest` on the NEXT coroutine-using unit test — the
+     * cross-test leak that reddened CI's full `:app:testDebugUnitTest`. Wrapping
+     * in [runCatching] (mirroring the #180 reconcile sweep at construction) makes
+     * the cleanup swallow its own failure, so it can never poison another test or
+     * the on-device pipeline. Idempotent and a no-op when no sidecar store is
+     * wired.
+     */
+    private fun launchSidecarRemoval(outboundItemId: String) {
+        val store = outboundAttachmentSidecarStore
+        val seam = sidecarRemovalForTest
+        if (store == null && seam == null) return
+        viewModelScope.launch {
+            runCatching {
+                if (seam != null) seam(outboundItemId) else store?.removeOutboundItem(outboundItemId)
+            }
+        }
+    }
+
+    /**
+     * Issue #971 leak-fix test seam. When non-null, [launchSidecarRemoval] routes
+     * the cleanup through this instead of the real store, so a unit test can
+     * synthetically inject a THROW on the fire-and-forget cleanup path (the #780
+     * synthetic-state model — the real `Dispatchers.IO` `persistAll` failure is
+     * not deterministically reproducible under `runTest`) and prove the
+     * [runCatching] guard contains it: `runTest` must finish with NO uncaught
+     * exception, which is the exact cross-test leak being closed.
+     */
+    @androidx.annotation.VisibleForTesting
+    internal var sidecarRemovalForTest: (suspend (String) -> Unit)? = null
 
     private fun refreshOutboundQueueItems() {
         _outboundQueueItems.value = composerTarget
@@ -3758,6 +3980,20 @@ public class PromptComposerViewModel @Inject constructor(
          */
         internal const val SEND_TIMEOUT_MESSAGE: String =
             "Send failed — it took too long. Tap Send to retry, or discard the draft."
+
+        /**
+         * Issue #971/#987 (maintainer decision — Option A): the SINGLE coherent
+         * status shown for a queued send that is waiting to auto-send on
+         * reconnect. Replaces the contradictory stack the maintainer hit during a
+         * drop ("Not sent. Reconnect, then send again or discard the draft." +
+         * "1 unsent prompt — Failed — Not sent…" + "Connection lost — Send will
+         * retry once reconnected."). On Send the message is queued, the composer
+         * clears, and the row auto-sends on reconnect (#900 flush) — there is no
+         * manual-resend affordance to contradict the auto-retry, just this one
+         * status.
+         */
+        internal const val WILL_SEND_WHEN_RECONNECTED_MESSAGE: String =
+            "Will send when reconnected."
 
         /**
          * Issue #939 (audit #935 S5-2): the end-to-end ceiling on the voice

--- a/app/src/main/java/com/pocketshell/app/connectivity/TerminalNetworkObserver.kt
+++ b/app/src/main/java/com/pocketshell/app/connectivity/TerminalNetworkObserver.kt
@@ -305,9 +305,29 @@ private val TRANSPORT_PROBES = listOf(
     TransportProbe(NetworkCapabilities.TRANSPORT_SATELLITE, "SATELLITE", Build.VERSION_CODES.VANILLA_ICE_CREAM),
 )
 
+/**
+ * Issue #995 (#935 H2): `update` is driven directly from concurrent
+ * `ConnectivityManager` binder callbacks (`onAvailable` / `onLost` /
+ * `onCapabilitiesChanged` / `onUnavailable` all dispatch on the framework's
+ * own threads), so two callbacks can enter `update` at once. The detector's
+ * identity state (`current` / `lastValidated` / `sequence`) was mutated with
+ * NO synchronization — a cross-thread race that can either (a) suppress a real
+ * handoff (both threads read the same stale `current`, one wins the write, the
+ * transport-changing snapshot's emission is lost → no reconnect → dead socket)
+ * or (b) tear/duplicate the change (two threads both increment `sequence` off a
+ * stale read → a duplicate/torn emission → spurious reconnect).
+ *
+ * The whole compare-and-mutate (read `current`/`lastValidated`, decide, write
+ * back, bump `sequence`) must be ONE atomic critical section. We guard the
+ * entire body with a single lock so concurrent callbacks serialize: each
+ * `update` sees the result of the previous one, so no handoff is dropped and no
+ * duplicate sequence is emitted. This only makes the state mutation thread-safe
+ * — the handoff POLICY (what counts as a handoff) is unchanged (that is #981).
+ */
 internal class TerminalNetworkChangeDetector(
     initial: TerminalNetworkSnapshot,
 ) {
+    private val lock = Any()
     private var current: TerminalNetworkSnapshot = initial
     private var lastValidated: TerminalNetworkSnapshot.Validated? =
         initial as? TerminalNetworkSnapshot.Validated
@@ -316,27 +336,27 @@ internal class TerminalNetworkChangeDetector(
     fun update(
         snapshot: TerminalNetworkSnapshot,
         reason: String,
-    ): TerminalNetworkChange? {
+    ): TerminalNetworkChange? = synchronized(lock) {
         val previous = current
         val previousValidated = lastValidated
         if (previous.hasSameNetworkIdentityAs(snapshot)) {
             current = snapshot
             if (snapshot is TerminalNetworkSnapshot.Validated) lastValidated = snapshot
-            return null
+            return@synchronized null
         }
         current = snapshot
-        if (snapshot !is TerminalNetworkSnapshot.Validated) return null
+        if (snapshot !is TerminalNetworkSnapshot.Validated) return@synchronized null
         if (previousValidated == null) {
             lastValidated = snapshot
-            return null
+            return@synchronized null
         }
         if (snapshot.hasSameNetworkIdentityAs(previousValidated)) {
             lastValidated = snapshot
-            return null
+            return@synchronized null
         }
         lastValidated = snapshot
         sequence += 1L
-        return TerminalNetworkChange(
+        TerminalNetworkChange(
             previous = previous,
             current = snapshot,
             previousValidated = previousValidated,

--- a/app/src/test/java/com/pocketshell/app/composer/PromptComposerViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/PromptComposerViewModelTest.kt
@@ -1415,9 +1415,10 @@ class PromptComposerViewModelTest {
         advanceUntilIdle()
 
         assertEquals(listOf(PromptComposerViewModel.SendRequest("Please summarize this", true)), sends)
-        // Issue #745: the queued voice send dispatches with the draft RETAINED
-        // and in-flight; it clears only when the host confirms delivery.
-        assertEquals("Please summarize this", vm.uiState.value.draft)
+        // Issue #971: the queued voice send hands the prompt off to the queue
+        // row, so the editor is CLEARED in flight (single representation);
+        // `sendInFlight` clears when the host confirms delivery.
+        assertEquals("", vm.uiState.value.draft)
         assertTrue(vm.uiState.value.sendInFlight)
         vm.markSendDelivered()
         assertEquals("", vm.uiState.value.draft)
@@ -1530,8 +1531,8 @@ class PromptComposerViewModelTest {
         advanceUntilIdle()
 
         assertEquals(listOf(PromptComposerViewModel.SendRequest("Please summarize this", true)), sends)
-        // Issue #745: draft retained in-flight until delivery is confirmed.
-        assertEquals("Please summarize this", vm.uiState.value.draft)
+        // Issue #971: handed off to the queue row — editor cleared in flight.
+        assertEquals("", vm.uiState.value.draft)
         assertTrue(vm.uiState.value.sendInFlight)
         vm.markSendDelivered()
         assertEquals("", vm.uiState.value.draft)
@@ -3125,11 +3126,12 @@ class PromptComposerViewModelTest {
 
     @Test
     fun requestSendInIdleDispatchesDraftAndKeepsItInFlightUntilDelivered() = runTest {
-        // Issue #745: tapping Send dispatches the draft AND flips the composer
-        // into the in-flight state — the typed text is NOT cleared
-        // optimistically. The draft only clears once the host confirms
-        // delivery via [markSendDelivered]. This is the no-flicker contract:
-        // the field never empties before the bytes are actually sent.
+        // Issue #971 (reverses #745): tapping Send dispatches the draft AND hands
+        // it off to the outbound queue — the editor is CLEARED on enqueue so the
+        // prompt is represented EXACTLY ONCE (the "Sending…" row, when a queue
+        // store is wired), never as BOTH editor text AND a queued row.
+        // `sendInFlight` stays true (Send disabled / "Sending…") until the host
+        // confirms delivery via [markSendDelivered].
         val vm = newVm(samplerDispatcher = StandardTestDispatcher(testScheduler))
         val sent = collectSendRequests(vm)
         vm.onDraftChange("hello shell")
@@ -3140,12 +3142,12 @@ class PromptComposerViewModelTest {
         assertEquals(1, sent.size)
         assertEquals("hello shell", sent[0].text)
         assertEquals(false, sent[0].withEnter)
-        // In-flight: the draft is RETAINED and `sendInFlight` is true so the
-        // Send button shows "Sending…".
-        assertEquals("hello shell", vm.uiState.value.draft)
+        // In-flight: the editor is CLEARED (the prompt was handed off) and
+        // `sendInFlight` is true so the Send button shows "Sending…" + is disabled.
+        assertEquals("", vm.uiState.value.draft)
         assertTrue(vm.uiState.value.sendInFlight)
 
-        // Host confirms delivery: now the draft clears and in-flight ends.
+        // Host confirms delivery: in-flight ends, editor still empty.
         vm.markSendDelivered()
         assertEquals("", vm.uiState.value.draft)
         assertFalse(vm.uiState.value.sendInFlight)
@@ -3210,6 +3212,230 @@ class PromptComposerViewModelTest {
         vm.discardOutboundItem(queueId)
         assertNotNull(queue.item(queueId))
         assertEquals(listOf(queueId), vm.outboundQueueItems.value.map { it.id })
+    }
+
+    // -- Issue #971/#987: single-representation + auto-retry on drop -------
+    //
+    // The maintainer's v0.4.18 dogfood + the #987 refinement: while a send is in
+    // flight the same prompt was shown TWICE — still in the editable composer
+    // field AND as a "1 unsent prompt — Sending — <text>" queue row — and on a
+    // DROP the composer stacked contradictory status ("Not sent… send again or
+    // discard" vs "Send will retry once reconnected"). The CANONICAL design
+    // (#987 Option A): on enqueue the editor CLEARS (the queue row is the ONE
+    // representation in flight), Send is disabled in flight; on a drop the prompt
+    // STAYS QUEUED and auto-sends on reconnect (NOT returned to the composer for
+    // manual resend), shown as the SINGLE "Will send when reconnected." status.
+
+    @Test
+    fun issue971_sendInFlightClearsComposerSoPromptShowsExactlyOnce() = runTest {
+        // RED on base: emitSendRequest kept the draft visible (#745) AND
+        // enqueued a "Sending…" row, so the prompt appeared in BOTH the editor
+        // and the queue row at once. GREEN after #971: the editor is cleared on
+        // enqueue, leaving the single queue row as the in-flight representation,
+        // and Send is disabled while in flight.
+        val queue = InMemoryOutboundQueueStore()
+        val vm = newVm(
+            samplerDispatcher = StandardTestDispatcher(testScheduler),
+            outboundQueueStore = queue,
+        )
+        val sent = collectSendRequests(vm)
+        val target = PromptComposerViewModel.SendTargetSnapshot(sessionKey = "1/session-a")
+
+        vm.onComposerTargetChanged("1/session-a")
+        vm.onDraftChange("/clear")
+        vm.requestSend(withEnter = true, sendTarget = target)
+        advanceUntilIdle()
+
+        // The send is in flight…
+        assertTrue("send should be in flight after Send tap", vm.uiState.value.sendInFlight)
+        // …and exactly ONE representation of the prompt exists: the queue row.
+        // The composer editor is empty (handed off), NOT still holding "/clear".
+        assertEquals(
+            "composer editor must be cleared on enqueue — the queue row is the single representation",
+            "",
+            vm.uiState.value.draft,
+        )
+        // The single queue row carries the prompt.
+        assertEquals(listOf("/clear"), vm.outboundQueueItems.value.map { it.cleanText })
+        assertEquals(1, vm.outboundQueueItems.value.size)
+
+        // Delivery clears the in-flight gate and prunes the row — still empty.
+        vm.markSendDelivered(sent.single())
+        assertFalse(vm.uiState.value.sendInFlight)
+        assertEquals("", vm.uiState.value.draft)
+        assertTrue(vm.outboundQueueItems.value.isEmpty())
+    }
+
+    @Test
+    fun issue971_droppedSendStaysQueuedForAutoRetryNotReturnedToComposer() = runTest {
+        // RED on base (this worktree's prior #971 fix): markOutboundSendDeferred
+        // did not exist and the drop path called restoreFailedSend, which restored
+        // the draft to the composer AND removed the queue row + stamped a "Not
+        // sent. …send again or discard" error — exactly the #987 contradiction.
+        // GREEN after #987 Option A: a dropped send STAYS QUEUED (single "Will
+        // send when reconnected." row), the composer stays EMPTY (single
+        // representation), and NO "Not sent / send again or discard" error is set.
+        val queue = InMemoryOutboundQueueStore()
+        val vm = newVm(
+            samplerDispatcher = StandardTestDispatcher(testScheduler),
+            outboundQueueStore = queue,
+        )
+        val sent = collectSendRequests(vm)
+        val target = PromptComposerViewModel.SendTargetSnapshot(sessionKey = "1/session-a")
+
+        vm.onComposerTargetChanged("1/session-a")
+        vm.onDraftChange("/clear")
+        vm.requestSend(withEnter = true, sendTarget = target)
+        advanceUntilIdle()
+        val request = sent.single()
+        val queueId = requireNotNull(request.outboundQueueItemId)
+
+        // In flight: editor cleared, single row.
+        assertEquals("", vm.uiState.value.draft)
+        assertEquals(1, vm.outboundQueueItems.value.size)
+
+        // The send fails because the connection dropped (the dispatcher's
+        // false/timeout branch routes here).
+        vm.markOutboundSendDeferred(request)
+
+        // (a) The composer stays CLEARED — the prompt is NOT returned to the
+        // editor for a manual resend.
+        assertEquals("", vm.uiState.value.draft)
+        // (b) The prompt is ONE queued "will retry" row, NOT a removed/failed row.
+        val row = requireNotNull(queue.item(queueId))
+        assertEquals(OutboundState.Queued, row.state)
+        assertNull("a deferred (will-retry) row carries no error label", row.lastError)
+        assertEquals(listOf("/clear"), vm.outboundQueueItems.value.map { it.cleanText })
+        assertEquals(1, vm.outboundQueueItems.value.size)
+        // (c) NO contradictory "Not sent / send again or discard" error banner.
+        assertNull(
+            "a drop must show the single 'will retry' status, not a 'Not sent' error",
+            vm.uiState.value.error,
+        )
+        // The consolidated status copy reads "Will send when reconnected."
+        assertEquals(
+            PromptComposerViewModel.WILL_SEND_WHEN_RECONNECTED_MESSAGE,
+            outboundQueueStateLabel(row),
+        )
+        // In-flight gate cleared so the reconnect flush can re-claim the row.
+        assertFalse(vm.uiState.value.sendInFlight)
+    }
+
+    @Test
+    fun issue971_queuedDropAutoSendsOnReconnectFlushExactlyOnce() = runTest {
+        // (d) On reconnect the queued message auto-sends (the #900 flush wired in
+        // TmuxSessionScreen via retryNextOutboundItem). After a drop the row stays
+        // Queued; the flush claims it exactly once and delivery prunes it — no
+        // duplicate, no manual resend needed.
+        val queue = InMemoryOutboundQueueStore()
+        val vm = newVm(
+            samplerDispatcher = StandardTestDispatcher(testScheduler),
+            outboundQueueStore = queue,
+        )
+        val sent = collectSendRequests(vm)
+        val target = PromptComposerViewModel.SendTargetSnapshot(sessionKey = "1/session-a")
+
+        vm.onComposerTargetChanged("1/session-a")
+        vm.onDraftChange("/clear")
+        vm.requestSend(withEnter = true, sendTarget = target)
+        advanceUntilIdle()
+        val first = sent.single()
+
+        // Connection drops → the send is deferred (stays queued, composer empty).
+        vm.markOutboundSendDeferred(first)
+        assertEquals("", vm.uiState.value.draft)
+        assertEquals(1, queue.itemsFor("1/session-a").size)
+        assertEquals(OutboundState.Queued, queue.itemsFor("1/session-a").single().state)
+        assertFalse(vm.uiState.value.sendInFlight)
+        assertEquals(1, sent.size)
+
+        // Reconnect: the screen's flush claims the next queued row and re-dispatches.
+        val flushedId = vm.retryNextOutboundItem()
+        advanceUntilIdle()
+        waitForSendCount(sent, 2)
+        assertEquals(
+            "the flush must re-claim the SAME queued row, not mint a new one",
+            first.outboundQueueItemId,
+            flushedId,
+        )
+        // Exactly ONE deliverable row for the one logical prompt; the auto-send
+        // delivers it and the row is pruned — no duplicate.
+        assertEquals(1, queue.itemsFor("1/session-a").size)
+        assertEquals(2, sent.size)
+        vm.markSendDelivered(sent.last())
+        assertTrue(vm.outboundQueueItems.value.isEmpty())
+        assertEquals("", vm.uiState.value.draft)
+    }
+
+    @Test
+    fun issue971_sidecarRemovalFailureNeverLeaksUncaughtCoroutineAcrossTests() = runTest {
+        // Issue #971 cross-test leak regression. The #971 fix added fire-and-forget
+        // `viewModelScope.launch { store.removeOutboundItem(id) }` cleanups on the
+        // delivered / failed / discarded outbound paths. Those hopped to real
+        // `Dispatchers.IO` (inside removeOutboundItem) with NO try/catch, so a
+        // `persistAll` write failure threw an UNCAUGHT exception that escaped
+        // viewModelScope. Under `runTest` that exception is captured and
+        // re-surfaced as `kotlinx.coroutines.test.UncaughtExceptionsBeforeTest`
+        // on the NEXT coroutine-using unit test — exactly the leak that reddened
+        // CI's full `:app:testDebugUnitTest` (green alone, red in the suite).
+        //
+        // The real IO `persistAll` failure is not deterministically reproducible
+        // under `runTest`, so we inject the THROW synthetically on the cleanup
+        // seam (the #780 synthetic-state model). The cleanup runs on the test
+        // scheduler here, so without the [runCatching] guard the throw escapes
+        // viewModelScope and FAILS this very `runTest` at body-end (RED). With the
+        // guard it is swallowed and `runTest` completes cleanly (GREEN) — proving
+        // a cleanup failure can never poison a sibling test or the on-device
+        // pipeline.
+        val queue = InMemoryOutboundQueueStore()
+        val vm = newVm(
+            samplerDispatcher = StandardTestDispatcher(testScheduler),
+            outboundQueueStore = queue,
+            outboundAttachmentSidecarStore = newSidecarStore(),
+        )
+        var removalAttempts = 0
+        vm.sidecarRemovalForTest = { _ ->
+            removalAttempts++
+            throw IllegalStateException("synthetic persistAll failure on sidecar cleanup")
+        }
+        val sent = collectSendRequests(vm)
+        val target = PromptComposerViewModel.SendTargetSnapshot(sessionKey = "1/session-a")
+
+        // Drive ALL THREE cleanup callers so the whole class is covered:
+        //  1) delivered (markOutboundSendDelivered)
+        vm.onComposerTargetChanged("1/session-a")
+        vm.onDraftChange("delivered prompt")
+        vm.requestSend(withEnter = true, sendTarget = target)
+        advanceUntilIdle()
+        vm.markSendDelivered(sent.single())
+        advanceUntilIdle()
+
+        //  2) failed (markOutboundSendFailed via restoreFailedSend)
+        vm.onDraftChange("failing prompt")
+        vm.requestSend(withEnter = true, sendTarget = target)
+        advanceUntilIdle()
+        vm.restoreFailedSend(sent.last())
+        advanceUntilIdle()
+
+        //  3) discarded (discardOutboundItem)
+        vm.onDraftChange("discard prompt")
+        vm.requestSend(withEnter = true, sendTarget = target)
+        advanceUntilIdle()
+        val toDiscard = vm.outboundQueueItems.value.firstOrNull()
+            ?: queue.itemsFor("1/session-a").first()
+        vm.markOutboundSendDeferred(sent.last())
+        advanceUntilIdle()
+        vm.discardOutboundItem(toDiscard.id)
+        advanceUntilIdle()
+
+        // The cleanup seam was actually exercised (G3: not a vacuous pass) and the
+        // injected throws were contained — `runTest` reaching this assertion at all
+        // means NO uncaught coroutine escaped (the leak is gone). If the guard were
+        // missing, this body would never complete cleanly.
+        assertTrue(
+            "the sidecar cleanup seam must have been driven so the throw path is real",
+            removalAttempts >= 1,
+        )
     }
 
     @Test
@@ -3565,7 +3791,11 @@ class PromptComposerViewModelTest {
     }
 
     @Test
-    fun failedSendMarksOutboundItemFailedAndKeepsItVisible() = runTest {
+    fun failedSendRemovesOutboundRowAndReturnsPromptToComposer() = runTest {
+        // Issue #971: a failed delivery restores the prompt to the composer as
+        // the SINGLE representation, so the queue row is REMOVED (not left as a
+        // "Failed" row). Keeping both was the maintainer's reported duplicate —
+        // the prompt back in the editor PLUS a "1 unsent prompt — Failed" row.
         val queue = InMemoryOutboundQueueStore()
         val vm = newVm(
             samplerDispatcher = StandardTestDispatcher(testScheduler),
@@ -3578,19 +3808,19 @@ class PromptComposerViewModelTest {
         vm.onDraftChange("retry me")
         vm.requestSend(withEnter = false, sendTarget = target)
         advanceUntilIdle()
+        // Handed off: editor cleared, single in-flight row.
+        assertEquals("", vm.uiState.value.draft)
+        assertEquals(1, vm.outboundQueueItems.value.size)
 
         val request = sent.single()
         vm.restoreFailedSend(request, message = "host send failed")
 
-        val failed = requireNotNull(queue.item(request.outboundQueueItemId!!))
-        assertEquals(OutboundState.Failed, failed.state)
-        assertEquals("host send failed", failed.lastError)
-        assertEquals(1, failed.attemptCount)
-        assertEquals(listOf(failed.id), vm.outboundQueueItems.value.map { it.id })
-
-        vm.discardOutboundItem(failed.id)
-        assertNull(queue.item(failed.id))
+        // The row is GONE — the prompt is the single representation in the editor.
+        assertNull(queue.item(request.outboundQueueItemId!!))
         assertTrue(vm.outboundQueueItems.value.isEmpty())
+        assertEquals("retry me", vm.uiState.value.draft)
+        assertEquals("host send failed", vm.uiState.value.error)
+        assertFalse(vm.uiState.value.sendInFlight)
     }
 
     @Test
@@ -3645,18 +3875,30 @@ class PromptComposerViewModelTest {
         assertEquals(2, inFlight.attemptCount)
         assertEquals(listOf(item.id), vm.outboundQueueItems.value.map { it.id })
 
+        // Issue #971: a failed retry restores the prompt to the composer as the
+        // SINGLE representation, so the queue row is REMOVED (not left "Failed").
         vm.restoreFailedSend(request, message = "still down")
-        val failedAgain = requireNotNull(queue.item(item.id))
-        assertEquals(OutboundState.Failed, failedAgain.state)
-        assertEquals("still down", failedAgain.lastError)
-        assertEquals(2, failedAgain.attemptCount)
+        assertNull(queue.item(item.id))
+        assertTrue(vm.outboundQueueItems.value.isEmpty())
+        assertEquals("ship with context", vm.uiState.value.draft)
 
-        vm.retryOutboundItem(item.id)
+        // Re-Send from the restored composer mints exactly one fresh deliverable
+        // row, and delivery prunes it.
+        vm.requestSend(
+            withEnter = true,
+            sendTarget = PromptComposerViewModel.SendTargetSnapshot(
+                sessionKey = "1/session-a",
+                paneId = "%7",
+                route = OutboundRoute.AgentPayload,
+                agentKind = "codex",
+            ),
+        )
         advanceUntilIdle()
+        waitForSendCount(sent, 2)
+        assertEquals(1, queue.itemsFor("1/session-a").size)
         val secondRequest = sent.last()
         vm.markSendDelivered(secondRequest)
 
-        assertNull(queue.item(item.id))
         assertTrue(vm.outboundQueueItems.value.isEmpty())
     }
 
@@ -3909,16 +4151,17 @@ class PromptComposerViewModelTest {
 
     @Test
     fun reSendAfterFailedSendCoalescesToOneRowAndDeliversExactlyOnce() = runTest {
-        // Issue #961 — THE REPORTED CASE (drop+reconnect double-send).
+        // Issue #961 + #971 — THE REPORTED CASE (drop+reconnect double-send).
         // Connected → Send (row A, InFlight) → drop fails the send
-        // (restoreFailedSend: row A Failed, sendInFlight reset, draft restored)
-        // → user re-Sends the restored draft → deliver → reconnect auto-flush.
+        // (restoreFailedSend) → user re-Sends the restored draft → deliver →
+        // reconnect auto-flush.
         //
-        // RED on base: the re-Send minted row B (new UUID, same text), so the
-        // queue held TWO rows (A Failed + B). Delivering B pruned it, then the
-        // reconnect auto-flush claimed the leftover A and delivered the prompt a
-        // SECOND time → TWO distinct delivered ids.
-        // GREEN: the re-Send coalesces onto A → ONE row ever, ONE delivery.
+        // Under #971 the failed send REMOVES row A and restores the prompt to the
+        // composer as the single representation. The re-Send mints exactly ONE
+        // fresh row; delivering it prunes it and the reconnect auto-flush finds
+        // nothing left — so the prompt is delivered EXACTLY ONCE (no leftover
+        // Failed row for the storm to re-deliver), the same end guarantee #961
+        // gave via coalesce.
         val queue = InMemoryOutboundQueueStore()
         val vm = newVm(
             samplerDispatcher = StandardTestDispatcher(testScheduler),
@@ -3929,27 +4172,29 @@ class PromptComposerViewModelTest {
         vm.onComposerTargetChanged("1/session-a")
         vm.onDraftChange("deploy now")
 
-        // 1) First Send → row A goes in-flight.
+        // 1) First Send → row A goes in-flight, editor cleared (handoff).
         vm.requestSend(withEnter = true, sendTarget = target)
         advanceUntilIdle()
         val firstRequest = sent.single()
         assertEquals(1, vm.outboundQueueItems.value.size)
+        assertEquals("", vm.uiState.value.draft)
 
         // 2) The link drops mid-send → the dispatcher restores the failed send.
-        //    Row A is left Failed (still queued/retryable), sendInFlight reset,
-        //    and the draft is restored to "deploy now".
+        //    Row A is REMOVED (#971) and the draft is restored to "deploy now".
         vm.restoreFailedSend(firstRequest, message = "Not sent. Reconnect, then send again or discard.")
         assertEquals("deploy now", vm.uiState.value.draft)
-        assertEquals(OutboundState.Failed, queue.item(firstRequest.outboundQueueItemId!!)!!.state)
+        assertNull(queue.item(firstRequest.outboundQueueItemId!!))
+        assertTrue(vm.outboundQueueItems.value.isEmpty())
 
         // 3) The user re-Sends the restored draft (the banner says "send again").
-        //    The re-Send itself emits a SendRequest for the (coalesced) row.
+        //    The re-Send emits a SendRequest for the (single fresh) row.
         vm.requestSend(withEnter = true, sendTarget = target)
         advanceUntilIdle()
+        waitForSendCount(sent, 2)
 
-        // The coalesce: STILL exactly ONE row — no duplicate deliverable row.
+        // STILL exactly ONE row — no duplicate deliverable row.
         assertEquals(
-            "re-Send of the restored draft must coalesce — exactly ONE queued row",
+            "re-Send of the restored draft must leave exactly ONE queued row",
             1,
             queue.itemsFor("1/session-a").size,
         )
@@ -3980,10 +4225,12 @@ class PromptComposerViewModelTest {
     }
 
     @Test
-    fun reSendOfADifferentPromptStillMintsASecondRow() = runTest {
-        // Issue #961 — class coverage: a genuinely different prompt must NOT be
-        // swallowed by the coalesce. After a failed send, typing + sending a
-        // DIFFERENT prompt makes a second row (two distinct logical sends).
+    fun reSendOfADifferentPromptAfterFailureMakesOneFreshRow() = runTest {
+        // Issue #961 + #971 — class coverage. Under #971 a failed send REMOVES
+        // its row and restores the prompt to the composer, so there is no
+        // leftover row to coalesce against. The user clears it and types a
+        // DIFFERENT prompt; sending it must mint exactly ONE fresh deliverable
+        // row carrying the new prompt (the old one is gone, not duplicated).
         val queue = InMemoryOutboundQueueStore()
         val vm = newVm(
             samplerDispatcher = StandardTestDispatcher(testScheduler),
@@ -3997,17 +4244,19 @@ class PromptComposerViewModelTest {
         vm.requestSend(withEnter = true, sendTarget = target)
         advanceUntilIdle()
         vm.restoreFailedSend(sent.single(), message = "down")
+        // The failed row is removed; the prompt is back in the composer.
+        assertTrue(queue.itemsFor("1/session-a").isEmpty())
+        assertEquals("deploy now", vm.uiState.value.draft)
 
         // A different prompt this time.
         vm.onDraftChange("rollback")
         vm.requestSend(withEnter = true, sendTarget = target)
         advanceUntilIdle()
+        waitForSendCount(sent, 2)
 
-        assertEquals(
-            "a different prompt must still make a second row",
-            2,
-            queue.itemsFor("1/session-a").size,
-        )
+        val rows = queue.itemsFor("1/session-a")
+        assertEquals("a fresh send makes exactly one row", 1, rows.size)
+        assertEquals("rollback", rows.single().cleanText)
     }
 
     @Test
@@ -4030,8 +4279,10 @@ class PromptComposerViewModelTest {
         vm.requestSend(withEnter = true, sendTarget = target)
         advanceUntilIdle()
         vm.restoreFailedSend(sent.single(), message = "down")
+        // #971: the failed row is removed; the re-Send mints a single fresh row.
         vm.requestSend(withEnter = true, sendTarget = target)
         advanceUntilIdle()
+        waitForSendCount(sent, 2)
         assertEquals(1, queue.itemsFor("1/session-a").size)
 
         // The re-Send emitted its own request — deliver it.
@@ -4096,10 +4347,10 @@ class PromptComposerViewModelTest {
             sent[0].text,
         )
         assertEquals(true, sent[0].withEnter)
-        // Issue #745: in-flight — draft + chips are RETAINED until the host
-        // confirms delivery, then cleared by [markSendDelivered].
-        assertEquals("Review these", vm.uiState.value.draft)
-        assertEquals(2, vm.uiState.value.attachments.size)
+        // Issue #971: in-flight — the prompt + chips were HANDED OFF to the queue
+        // row, so the editor is cleared (the row is the single representation).
+        assertEquals("", vm.uiState.value.draft)
+        assertTrue(vm.uiState.value.attachments.isEmpty())
         assertTrue(vm.uiState.value.sendInFlight)
         vm.markSendDelivered()
         assertEquals("", vm.uiState.value.draft)
@@ -4133,9 +4384,10 @@ class PromptComposerViewModelTest {
             """.trimIndent(),
             sent[0].text,
         )
-        // Issue #745: in-flight — the chip is retained until delivery is
-        // confirmed, then cleared.
-        assertEquals(1, vm.uiState.value.attachments.size)
+        // Issue #971: in-flight — the chip was handed off to the queue row, so
+        // the editor's tiles are cleared (the row is the single representation).
+        assertTrue(vm.uiState.value.attachments.isEmpty())
+        assertTrue(vm.uiState.value.sendInFlight)
         vm.markSendDelivered()
         assertTrue(vm.uiState.value.attachments.isEmpty())
     }
@@ -4195,7 +4447,9 @@ class PromptComposerViewModelTest {
         assertEquals(1, sent[0].attachments.size)
         assertTrue(sent[0].text.startsWith("send this now"))
         assertTrue(sent[0].text.contains("late.png"))
-        assertEquals("send this now", vm.uiState.value.draft)
+        // Issue #971: once the real dispatch fires (after the upload), the prompt
+        // is handed off to the queue row — the editor is cleared.
+        assertEquals("", vm.uiState.value.draft)
         assertTrue(vm.uiState.value.sendInFlight)
     }
 
@@ -4860,10 +5114,11 @@ class PromptComposerViewModelTest {
         // The composed prompt carries both files.
         assertTrue(composed.text.contains("20260611-120000-01-report.txt"))
         assertTrue(composed.text.contains("20260611-120000-02-data.csv"))
-        // Issue #745: in-flight — the clean draft + chips are RETAINED (no
-        // optimistic empty); `sendInFlight` is true while awaiting the host.
-        assertEquals("Review these", vm.uiState.value.draft)
-        assertEquals(2, vm.uiState.value.attachments.size)
+        // Issue #971: in-flight — the prompt + chips were HANDED OFF, so the
+        // editor is cleared (single representation); `sendInFlight` is true while
+        // awaiting the host. The clean draft + tiles still travel in the request.
+        assertEquals("", vm.uiState.value.draft)
+        assertTrue(vm.uiState.value.attachments.isEmpty())
         assertTrue(vm.uiState.value.sendInFlight)
 
         // The host reports the write failed (degraded connection). The sheet
@@ -5129,8 +5384,11 @@ class PromptComposerViewModelTest {
             sent[0].text.contains("shot.png"),
         )
         assertTrue(sent[0].text.startsWith("look at this screenshot"))
-        // And the live tile is on screen while in flight (so Retry has it).
-        assertEquals(1, vm.uiState.value.attachments.size)
+        // Issue #971: once the real dispatch fires (after the upload), the prompt
+        // + tile are handed off to the queue row — the editor is cleared (single
+        // representation). The attachment still travels in the request, and a
+        // failed send restores the tile via [restoreFailedSend].
+        assertTrue(vm.uiState.value.attachments.isEmpty())
         assertTrue(vm.uiState.value.sendInFlight)
     }
 
@@ -5285,14 +5543,15 @@ class PromptComposerViewModelTest {
             advanceUntilIdle()
             job.cancelAndJoin()
 
-            // Issue #745: each send dispatches exactly one request and parks
-            // the composer in-flight with the draft retained. The success path
-            // (host confirmed) then clears it via [markSendDelivered], leaving
-            // a clean slate so the NEXT iteration's send is allowed (the
-            // in-flight guard would otherwise drop a back-to-back send).
+            // Issue #971: each send dispatches exactly one request and HANDS the
+            // prompt off to the queue row, so the editor is cleared in flight (the
+            // message never appears twice). The success path (host confirmed) then
+            // ends the in-flight state via [markSendDelivered], leaving a clean
+            // slate so the NEXT iteration's send is allowed (the in-flight guard
+            // would otherwise drop a back-to-back send).
             assertEquals(1, sent.size)
             assertEquals("message $i", sent[0].text)
-            assertEquals("message $i", vm.uiState.value.draft)
+            assertEquals("", vm.uiState.value.draft)
             assertTrue(vm.uiState.value.sendInFlight)
             vm.markSendDelivered()
             assertEquals("", vm.uiState.value.draft)
@@ -5320,13 +5579,14 @@ class PromptComposerViewModelTest {
         job.cancelAndJoin()
 
         assertEquals(1, sent.size)
-        // Issue #745: no optimistic clear — the draft stays visible while the
-        // send is in flight (no flicker), so the user keeps seeing their text.
-        assertEquals("ship it", vm.uiState.value.draft)
+        // Issue #971: the prompt is handed off to the queue row in flight, so the
+        // editor is cleared (single representation) while `sendInFlight` is true.
+        assertEquals("", vm.uiState.value.draft)
         assertTrue(vm.uiState.value.sendInFlight)
 
-        // Host reports failure → restore. The draft stays, in-flight ends, and
-        // an actionable banner appears; the sheet stays open on this state.
+        // Host reports failure → restore. The prompt returns to the (now-single)
+        // composer, in-flight ends, and an actionable banner appears; the sheet
+        // stays open on this state.
         vm.restoreFailedSend(sent[0])
         assertFalse(vm.uiState.value.sendInFlight)
         assertEquals("ship it", vm.uiState.value.draft)
@@ -5408,11 +5668,12 @@ class PromptComposerViewModelTest {
         // Mic was stopped by the queued-send path, not by a separate
         // mic-tap.
         assertEquals(1, mic.stopCount)
-        // FSM lands back at Idle. Issue #745: the dispatched send parks the
-        // composer in-flight with the combined draft retained until delivery
-        // is confirmed; it clears only via [markSendDelivered].
+        // FSM lands back at Idle. Issue #971: the dispatched send hands the
+        // combined prompt off to the queue row, so the editor is CLEARED in
+        // flight (single representation); `sendInFlight` stays true until
+        // delivery is confirmed via [markSendDelivered].
         assertEquals(RecordingState.Idle, vm.uiState.value.recording)
-        assertEquals("Tell me from dictation", vm.uiState.value.draft)
+        assertEquals("", vm.uiState.value.draft)
         assertTrue(vm.uiState.value.sendInFlight)
         vm.markSendDelivered()
         assertEquals("", vm.uiState.value.draft)
@@ -5461,8 +5722,8 @@ class PromptComposerViewModelTest {
         assertEquals("queued result", sent[0].text)
         assertEquals(false, sent[0].withEnter)
         assertEquals(RecordingState.Idle, vm.uiState.value.recording)
-        // Issue #745: in-flight until delivery confirmed.
-        assertEquals("queued result", vm.uiState.value.draft)
+        // Issue #971: handed off to the queue row — editor cleared in flight.
+        assertEquals("", vm.uiState.value.draft)
         assertTrue(vm.uiState.value.sendInFlight)
         vm.markSendDelivered()
         assertEquals("", vm.uiState.value.draft)
@@ -5767,8 +6028,8 @@ class PromptComposerViewModelTest {
         assertEquals(1, sent.size)
         assertEquals("deploy the app", sent[0].text)
         assertEquals(true, sent[0].withEnter)
-        // Issue #745: in-flight until delivery confirmed.
-        assertEquals("deploy the app", vm.uiState.value.draft)
+        // Issue #971: handed off to the queue row — editor cleared in flight.
+        assertEquals("", vm.uiState.value.draft)
         vm.markSendDelivered()
         assertEquals("", vm.uiState.value.draft)
     }
@@ -5792,8 +6053,8 @@ class PromptComposerViewModelTest {
 
         assertEquals(1, sent.size)
         assertEquals("deploy the app", sent[0].text)
-        // Issue #745: in-flight until delivery confirmed.
-        assertEquals("deploy the app", vm.uiState.value.draft)
+        // Issue #971: handed off to the queue row — editor cleared in flight.
+        assertEquals("", vm.uiState.value.draft)
         vm.markSendDelivered()
         assertEquals("", vm.uiState.value.draft)
     }
@@ -5838,8 +6099,8 @@ class PromptComposerViewModelTest {
         advanceUntilIdle()
         assertEquals(1, sent.size)
         assertEquals("send from transcribing", sent[0].text)
-        // Issue #745: in-flight until delivery confirmed.
-        assertEquals("send from transcribing", vm.uiState.value.draft)
+        // Issue #971: handed off to the queue row — editor cleared in flight.
+        assertEquals("", vm.uiState.value.draft)
         vm.markSendDelivered()
         assertEquals("", vm.uiState.value.draft)
     }

--- a/app/src/test/java/com/pocketshell/app/connectivity/TerminalNetworkChangeDetectorConcurrencyTest.kt
+++ b/app/src/test/java/com/pocketshell/app/connectivity/TerminalNetworkChangeDetectorConcurrencyTest.kt
@@ -1,0 +1,243 @@
+package com.pocketshell.app.connectivity
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import org.junit.Test
+
+/**
+ * Issue #995 (#935 H2) — `TerminalNetworkChangeDetector.update` is driven from
+ * concurrent `ConnectivityManager` binder callbacks, so two callbacks can be in
+ * `update` at once. Before the fix the identity state (`current` /
+ * `lastValidated` / `sequence`) was mutated with NO synchronization — a true
+ * cross-thread race that can (a) suppress a real handoff (no reconnect → dead
+ * socket) or (b) tear/duplicate the change (a torn `sequence += 1` → a
+ * duplicate/torn emission → spurious reconnect).
+ *
+ * These tests drive `update(...)` from many threads with barrier-synchronized
+ * bursts and assert invariants of the EMITTED stream that the unsynchronized
+ * code violates. They are RED on the racy base and GREEN once the whole
+ * compare-and-mutate is one critical section.
+ *
+ * Determinism note: a concurrency race is inherently probabilistic, so each
+ * test runs MANY iterations with `CountDownLatch` barriers that release all
+ * worker threads at the same instant (maximising the contention window). The
+ * asserted property is an INVARIANT of a correct serialization, not a fixed
+ * count — so a correct implementation passes every iteration deterministically,
+ * while the racy one reliably trips at least one iteration across the burst.
+ */
+class TerminalNetworkChangeDetectorConcurrencyTest {
+
+    /**
+     * Core race: concurrent callbacks must NEVER tear or duplicate the change
+     * identity. Every emitted change must carry a UNIQUE, contiguous sequence
+     * (1..count, no duplicates, no gaps). A torn `sequence += 1L` (two threads
+     * read the same value and both write N+1) produces duplicate sequence
+     * numbers and/or lost increments — exactly the "torn/duplicate change →
+     * spurious reconnect" symptom in the issue.
+     */
+    @Test
+    fun `concurrent updates never tear or duplicate the change sequence`() {
+        val threads = 8
+        val iterations = 400
+
+        repeat(iterations) { iteration ->
+            // Each iteration starts from a fresh, known identity. Threads race
+            // to flip the validated network to many DISTINCT new identities so
+            // most updates are real handoffs that bump `sequence`.
+            val detector = TerminalNetworkChangeDetector(
+                initial = TerminalNetworkSnapshot.Validated("net-0", setOf("CELLULAR")),
+            )
+            val emitted = ConcurrentLinkedQueue<TerminalNetworkChange>()
+            val startLatch = CountDownLatch(1)
+            val doneLatch = CountDownLatch(threads)
+            val pool = Executors.newFixedThreadPool(threads)
+
+            for (t in 0 until threads) {
+                pool.execute {
+                    startLatch.await()
+                    // Each thread targets a DISTINCT handle so every update it
+                    // wins is a genuine transport/identity handoff.
+                    val target = TerminalNetworkSnapshot.Validated(
+                        networkHandle = "net-$iteration-$t",
+                        transports = setOf("CELLULAR"),
+                    )
+                    val change = detector.update(target, "race-$t")
+                    if (change != null) emitted.add(change)
+                    doneLatch.countDown()
+                }
+            }
+
+            startLatch.countDown()
+            assertTrue(
+                "workers did not finish in time (iteration=$iteration)",
+                doneLatch.await(10, TimeUnit.SECONDS),
+            )
+            pool.shutdownNow()
+
+            val sequences = emitted.map { it.sequence }
+            val distinct = sequences.toSet()
+            assertEquals(
+                "duplicate/torn sequence numbers across concurrent updates " +
+                    "(iteration=$iteration, sequences=${sequences.sorted()})",
+                sequences.size,
+                distinct.size,
+            )
+            // The emitted sequences must be exactly 1..count with no gaps — a
+            // dropped increment leaves a hole, a torn increment leaves a dupe.
+            assertEquals(
+                "emitted sequences are not the contiguous 1..count range " +
+                    "(iteration=$iteration, sequences=${sequences.sorted()})",
+                (1L..sequences.size.toLong()).toList(),
+                sequences.sorted(),
+            )
+        }
+    }
+
+    /**
+     * No REAL handoff may be LOST under concurrency. Many threads each apply a
+     * DISTINCT new validated identity. Every one is a genuine transport/identity
+     * transition, so a correct serialization emits EXACTLY one change per thread
+     * AND the emitted `sequence` values are the contiguous range 1..threads (one
+     * monotonic bump per surviving handoff). The racy code drops/torns those:
+     * two threads read the same stale `sequence` and both write the same N+1, so
+     * a real handoff's slot is overwritten — the emitted sequences contain
+     * duplicates and/or holes (fewer distinct sequences than emissions, or a
+     * max-sequence that does not equal the emission count). A lost slot is the
+     * "suppress a real handoff → no reconnect → dead socket" symptom.
+     *
+     * Class-cover: this is the WIFI→CELLULAR-style real-handoff case (every
+     * target is a distinct CELLULAR identity off a CELLULAR start, all genuine
+     * transitions), driven under contention.
+     */
+    @Test
+    fun `no concurrent real handoff is lost or torn`() {
+        val threads = 8
+        val iterations = 400
+
+        repeat(iterations) { iteration ->
+            val detector = TerminalNetworkChangeDetector(
+                initial = TerminalNetworkSnapshot.Validated("net-init", setOf("CELLULAR")),
+            )
+            val emitted = ConcurrentLinkedQueue<TerminalNetworkChange>()
+            val startLatch = CountDownLatch(1)
+            val doneLatch = CountDownLatch(threads)
+            val pool = Executors.newFixedThreadPool(threads)
+
+            for (t in 0 until threads) {
+                pool.execute {
+                    startLatch.await()
+                    // A DISTINCT identity per thread — every update is a real
+                    // handoff that MUST surface exactly once.
+                    val target = TerminalNetworkSnapshot.Validated(
+                        networkHandle = "net-$iteration-$t",
+                        transports = setOf("CELLULAR"),
+                    )
+                    val change = detector.update(target, "handoff-$t")
+                    if (change != null) emitted.add(change)
+                    doneLatch.countDown()
+                }
+            }
+
+            startLatch.countDown()
+            assertTrue(
+                "workers did not finish in time (iteration=$iteration)",
+                doneLatch.await(10, TimeUnit.SECONDS),
+            )
+            pool.shutdownNow()
+
+            // Every distinct handoff surfaces exactly once: count == threads, and
+            // the emitted targets are exactly the distinct per-thread identities.
+            val emittedTargets = emitted.mapNotNull { it.current.networkHandle }.toSet()
+            val expectedTargets = (0 until threads).map { "net-$iteration-$it" }.toSet()
+            assertEquals(
+                "emitted handoffs do not cover every distinct target identity " +
+                    "(iteration=$iteration, emitted=${emitted.size})",
+                expectedTargets,
+                emittedTargets,
+            )
+            // The sequence stream of the SURVIVING handoffs must be a unique,
+            // contiguous 1..count range — a torn `sequence += 1` leaves dupes /
+            // holes even when every distinct identity happens to surface once.
+            val sequences = emitted.map { it.sequence }
+            assertEquals(
+                "a real handoff's sequence slot was torn/lost under concurrency " +
+                    "(iteration=$iteration, sequences=${sequences.sorted()})",
+                (1L..emitted.size.toLong()).toList(),
+                sequences.sorted(),
+            )
+        }
+    }
+
+    /**
+     * A transient duplicate callback (the SAME validated network reported twice
+     * concurrently) must NOT be emitted as a spurious reconnect. Two threads
+     * push the SAME new network identity at once; at most ONE emission may
+     * result, and only because the identity genuinely changed from the initial
+     * — never two emissions for the one transition.
+     */
+    @Test
+    fun `concurrent duplicate of the same new network is not emitted as a spurious second reconnect`() {
+        val iterations = 600
+
+        repeat(iterations) { iteration ->
+            val detector = TerminalNetworkChangeDetector(
+                initial = TerminalNetworkSnapshot.Validated("wifi-$iteration", setOf("WIFI")),
+            )
+            val newNet = TerminalNetworkSnapshot.Validated("cell-$iteration", setOf("CELLULAR"))
+
+            val emitted = ConcurrentLinkedQueue<TerminalNetworkChange>()
+            val startLatch = CountDownLatch(1)
+            val doneLatch = CountDownLatch(2)
+            val pool = Executors.newFixedThreadPool(2)
+
+            // Both threads report the IDENTICAL new validated network — a
+            // duplicate callback delivery. The transition (wifi→cell) happens
+            // once, so the stream must contain at most ONE change for it.
+            repeat(2) {
+                pool.execute {
+                    startLatch.await()
+                    val change = detector.update(newNet, "duplicate")
+                    if (change != null) emitted.add(change)
+                    doneLatch.countDown()
+                }
+            }
+
+            startLatch.countDown()
+            assertTrue(
+                "workers did not finish in time (iteration=$iteration)",
+                doneLatch.await(10, TimeUnit.SECONDS),
+            )
+            pool.shutdownNow()
+
+            assertTrue(
+                "a duplicate same-network callback was emitted as a second " +
+                    "spurious reconnect (iteration=$iteration, count=${emitted.size})",
+                emitted.size <= 1,
+            )
+            // When the single emission happens it must be the real transition,
+            // with sequence 1 — never a torn/duplicate sequence.
+            emitted.firstOrNull()?.let { change ->
+                assertEquals(
+                    "the single emission must be the real wifi→cell transition " +
+                        "(iteration=$iteration)",
+                    newNet,
+                    change.current,
+                )
+                assertEquals(
+                    "the single emission must carry sequence 1 (iteration=$iteration)",
+                    1L,
+                    change.sequence,
+                )
+            }
+            assertFalse(
+                "no emission for a genuine identity change (iteration=$iteration)",
+                emitted.isEmpty(),
+            )
+        }
+    }
+}

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshLeaseManager.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshLeaseManager.kt
@@ -645,7 +645,24 @@ public class SshLeaseManager(
 
     public companion object {
         public const val DEFAULT_IDLE_TTL_MILLIS: Long = 60_000L
-        public const val DEFAULT_MAX_IDLE_LEASES: Int = 2
+
+        /**
+         * Issue #996: maximum number of zero-ref (warm/idle) transports the pool
+         * keeps open at once before [trimIdleLocked] evicts the LRU.
+         *
+         * Raised from 2 to 4. At 2, a 3-host round-trip (A->B->C->A) trimmed
+         * host A's still-warm transport in the very gesture the user switched
+         * BACK to it — a self-inflicted COLD redial (fresh handshake +
+         * `Connecting` overlay) on a stable network. 4 covers a comfortable
+         * 3-host active working set plus one in-flight, so a switch-back reuses
+         * the warm lease instead of cold-redialing. The existing LRU + 60s-TTL
+         * trim ([trimIdleLocked] / [DEFAULT_IDLE_TTL_MILLIS]) is RETAINED as the
+         * ceiling: a burst beyond the cap still evicts the LRU, and a truly
+         * abandoned host still closes after the TTL — the pool can never grow
+         * unbounded. The maintainer may tune this number later for a larger
+         * working set (cap = working-set + 1).
+         */
+        public const val DEFAULT_MAX_IDLE_LEASES: Int = 4
 
         /**
          * Issue #687: default hard cap on a single owned cold connect/handshake.

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/SshLeaseLifetimeCharacterizationTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/SshLeaseLifetimeCharacterizationTest.kt
@@ -2,6 +2,7 @@ package com.pocketshell.core.ssh
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceTimeBy
@@ -111,6 +112,101 @@ class SshLeaseLifetimeCharacterizationTest {
     }
 
     @Test
+    fun `switching across three hosts does not cold-redial a still-warm host`() = runTest {
+        // Issue #996 (reproduce-first, D33/G10): the lease pool's idle cap must
+        // cover a realistic multi-host working set. The maintainer's reported
+        // journey is a 3-host round-trip A->B->C->A: at the moment the user
+        // switches BACK to A, A's still-warm idle transport must NOT be trimmed
+        // out from under them and cold-redialed.
+        //
+        // RED on the PRE-FIX cap of 2: after C goes idle the pool holds three
+        // idle entries {A,B,C}; trimIdleLocked evicts the LRU (A) the instant it
+        // exceeds the cap, so switching back to A is a fresh handshake
+        // (isNewConnection == true, connectCount for A bumps).
+        //
+        // GREEN on the SHIPPED default cap (4): {A,B,C} (3) <= 4, no trim, A is
+        // reused warm (isNewConnection == false, no extra handshake for A).
+        //
+        // The load-bearing, behavior-true assertions (G6) are BOTH the
+        // per-host counting-connector handshake count AND isNewConnection ==
+        // false — isNewConnection alone could be satisfied by a proxy.
+        val connector = MultiHostCountingConnector()
+        val manager = leaseManager(
+            connector,
+            idleTtlMillis = 60_000,
+            maxIdleLeases = SshLeaseManager.DEFAULT_MAX_IDLE_LEASES,
+        )
+
+        // Open + immediately release each host (each goes idle, warm, TTL armed).
+        manager.acquire(TARGET_A).getOrThrow().release() // A idle
+        manager.acquire(TARGET_B).getOrThrow().release() // B idle
+        manager.acquire(TARGET_C).getOrThrow().release() // C idle -> trims A pre-fix
+        runCurrent()
+
+        assertEquals("three distinct hosts -> three cold dials so far", 3, connector.totalConnects)
+        val aConnectsBefore = connector.connectsFor(TARGET_A.leaseKey)
+        assertEquals("host A dialed exactly once on its first open", 1, aConnectsBefore)
+
+        // Switch back to A. A was warm three steps ago and the network never
+        // dropped: this must be a warm reuse, not a self-inflicted cold redial.
+        val a2 = manager.acquire(TARGET_A).getOrThrow()
+        assertFalse(
+            "host A must reuse its still-warm lease on switch-back, not cold-redial",
+            a2.isNewConnection,
+        )
+        assertEquals(
+            "no extra handshake for a still-warm host on switch-back",
+            aConnectsBefore,
+            connector.connectsFor(TARGET_A.leaseKey),
+        )
+        a2.release()
+    }
+
+    @Test
+    fun `the idle cap still trims the lru once the working set exceeds it`() = runTest {
+        // Issue #996: raising the cap must NOT make the pool unbounded — the
+        // existing LRU + TTL trim must still be the ceiling. With the shipped
+        // default cap of 4, opening a FIFTH idle host pushes the idle set to 5,
+        // exceeding the cap, so the LRU (the first-idled host) is IdleTrimmed and
+        // a switch-back to it IS a genuine cold redial. Proves the bound holds.
+        val connector = MultiHostCountingConnector()
+        val manager = leaseManager(
+            connector,
+            idleTtlMillis = 60_000,
+            maxIdleLeases = SshLeaseManager.DEFAULT_MAX_IDLE_LEASES,
+        )
+
+        val trimmedKeys = mutableListOf<SshLeaseKey>()
+        val collector = launch {
+            manager.stateEvents.collect { event ->
+                if (event.closeReason == SshLeaseCloseReason.IdleTrimmed) {
+                    trimmedKeys += event.key
+                }
+            }
+        }
+        runCurrent()
+
+        // Five distinct hosts, each opened then released (idled), in order.
+        val hosts = listOf(TARGET_A, TARGET_B, TARGET_C, TARGET_D, TARGET_E)
+        hosts.forEach { manager.acquire(it).getOrThrow().release() }
+        runCurrent()
+
+        // The cap is 4; the 5th idle host trips the trim, evicting the LRU (A,
+        // the first-idled). Exactly one host is trimmed and it is the oldest.
+        assertEquals("exactly one host is trimmed once the cap is exceeded", 1, trimmedKeys.size)
+        assertEquals("the LRU (first-idled) host is the one trimmed", TARGET_A.leaseKey, trimmedKeys.single())
+
+        // Switching back to the trimmed LRU host IS a genuine cold redial: the
+        // cap correctly bounds the pool.
+        val a2 = manager.acquire(TARGET_A).getOrThrow()
+        assertTrue("the trimmed LRU host cold-redials on switch-back", a2.isNewConnection)
+        assertEquals("the trimmed host dials a second time", 2, connector.connectsFor(TARGET_A.leaseKey))
+        a2.release()
+
+        collector.cancel()
+    }
+
+    @Test
     fun `the default idle ttl keeps a released lease warm for sixty seconds`() = runTest {
         // The warm window is exactly DEFAULT_IDLE_TTL_MILLIS = 60s (the value the
         // target architecture wants to make THE single grace clock — collapsing
@@ -168,6 +264,27 @@ class SshLeaseLifetimeCharacterizationTest {
         }
     }
 
+    /**
+     * Issue #996: a connector that mints a fresh [FakeSshSession] per dial and
+     * counts dials PER lease key, so a multi-host journey can assert exactly
+     * which host got cold-redialed (vs reused warm). Distinct from
+     * [QueueLeaseConnector] (single-host, global queue) — here every host has an
+     * independent transport and an independent connect counter.
+     */
+    private class MultiHostCountingConnector : SshLeaseConnector {
+        private val countsByKey: MutableMap<SshLeaseKey, Int> = mutableMapOf()
+        var totalConnects: Int = 0
+            private set
+
+        fun connectsFor(key: SshLeaseKey): Int = countsByKey[key] ?: 0
+
+        override suspend fun connect(target: SshLeaseTarget): Result<SshSession> {
+            countsByKey[target.leaseKey] = (countsByKey[target.leaseKey] ?: 0) + 1
+            totalConnects += 1
+            return Result.success(FakeSshSession())
+        }
+    }
+
     private class FakeSshSession : SshSession {
         var closed: Boolean = false
         var connected: Boolean = true
@@ -219,5 +336,22 @@ class SshLeaseLifetimeCharacterizationTest {
             ),
             key = SshKey.Path(File("/tmp/key-a")),
         )
+
+        // Issue #996: distinct per-host targets for the multi-host journey.
+        private fun targetForHost(host: String): SshLeaseTarget = SshLeaseTarget(
+            leaseKey = SshLeaseKey(
+                host = host,
+                port = 2222,
+                user = "testuser",
+                credentialId = "/tmp/key-$host",
+            ),
+            key = SshKey.Path(File("/tmp/key-$host")),
+        )
+
+        val TARGET_A: SshLeaseTarget = targetForHost("hostA")
+        val TARGET_B: SshLeaseTarget = targetForHost("hostB")
+        val TARGET_C: SshLeaseTarget = targetForHost("hostC")
+        val TARGET_D: SshLeaseTarget = targetForHost("hostD")
+        val TARGET_E: SshLeaseTarget = targetForHost("hostE")
     }
 }


### PR DESCRIPTION
Three independently-APPROVED, fully-disjoint fixes (composer / core-ssh lease / connectivity) batched to share one CI cycle. Full local `:app:testDebugUnitTest` + `:shared:core-ssh:test` + assembleDebug green on flake-free main.

- **#971** — composer: on a dropped send, QUEUE the message + CLEAR the composer + auto-retry on reconnect (single 'Will send when reconnected.' status), and a guarded sidecar-cleanup so the best-effort removal can't leak an uncaught coroutine. The maintainer's #987 design. Closes #971.
- **#996** — core-ssh: raise the idle-lease cap 2→4 (pool already LRU+TTL) so a 3-host working set stays warm instead of a self-inflicted cold redial on switch-back. Closes #996.
- **#995** — connectivity: synchronize `TerminalNetworkChangeDetector`'s compare-and-mutate so concurrent ConnectivityManager callbacks can't tear/drop a handoff (#935 H2). Closes #995.

Each reviewer-driven red→green. Part of #928 bulletproof. Reviewer approvals on the issue threads.