### PR TITLE
Bulletproof cluster: black-screen recovery (#989) + host connection-log diagnostics (#972)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/diagnostics/ConnectionLogHostMirrorReconnectDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/diagnostics/ConnectionLogHostMirrorReconnectDockerTest.kt
@@ -1,0 +1,455 @@
+package com.pocketshell.app.diagnostics
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.proof.DEFAULT_HOST
+import com.pocketshell.app.proof.DEFAULT_PORT
+import com.pocketshell.app.proof.DEFAULT_USER
+import com.pocketshell.app.proof.waitForSshFixtureReady
+import com.pocketshell.app.sessions.ActiveTmuxClients
+import com.pocketshell.app.settings.SettingsRepository
+import com.pocketshell.app.tmux.TmuxSessionViewModel
+import com.pocketshell.core.ssh.DefaultSshLeaseConnector
+import com.pocketshell.core.ssh.KnownHostsPolicy
+import com.pocketshell.core.ssh.SshConnection
+import com.pocketshell.core.ssh.SshKey
+import com.pocketshell.core.ssh.SshLeaseConnector
+import com.pocketshell.core.ssh.SshLeaseKey
+import com.pocketshell.core.ssh.SshLeaseManager
+import com.pocketshell.core.ssh.SshLeaseTarget
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.tmux.CommandResponse
+import com.pocketshell.core.tmux.TmuxClient
+import com.pocketshell.core.tmux.TmuxClientFactory
+import com.pocketshell.core.tmux.TmuxDisconnectEvent
+import com.pocketshell.core.tmux.TmuxOutputBacklogOverflow
+import com.pocketshell.core.tmux.protocol.ControlEvent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+import java.io.FileOutputStream
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Issue #972 (D33 / G4 / G10): the connected/Docker proof of the host
+ * connection-log mirror's **VM glue on the real path**.
+ *
+ * The #969-part-3 writer ([ConnectionLogHostMirror]) and its driver wiring landed
+ * JVM-tested, but the single highest-risk real-path link — the VM glue
+ * `TmuxSessionViewModel.mirrorConnectionLogToHost()` ->
+ * `ConnectionTarget.toLeaseSessionTarget()` (the BYTE-IDENTICAL lease-key mapping
+ * that makes the warm-lease borrow real) — had **zero** coverage of any kind:
+ *
+ *  - [ConnectionLogHostMirrorTest] writes over a FAKE counting connector /
+ *    [com.pocketshell.app.sessions.LeaseSessionTarget], never the VM's path.
+ *  - [com.pocketshell.app.tmux.connection.ConnectionEffectDriverConnectionLogMirrorTest]
+ *    only counts that the `onTransportReconnected` callback fires; it stubs the
+ *    effect.
+ *
+ * A wrong lease-key field mapping in `toLeaseSessionTarget()` would reproduce the
+ * EXACT "wired but the real host file never lands" failure this issue closes —
+ * and nothing caught it. This matters extra because the bulletproof RC soak will
+ * RELY on this host log to attribute drops.
+ *
+ * This journey drives the **production** [TmuxSessionViewModel] against the
+ * deterministic Docker `agents` fixture (host port 2222 — or the pool-allocated
+ * port under `--pool`):
+ *
+ *  1. Seed a real reconnect-cause trail (incl. the named `keepalive_dead` cause)
+ *     in a real [DiagnosticRecorder] (recording defaults ON, #969).
+ *  2. Set the VM's `activeTarget` to the `agents:2222` host
+ *     ([TmuxSessionViewModel.replaceClientForTest]) — the reconnect-completed
+ *     state from which the production driver fires the mirror.
+ *  3. PRE-WARM the SSH lease for that EXACT key (one cold handshake, counted),
+ *     keeping the ref alive so the transport stays warm.
+ *  4. Fire the EXACT production mirror glue
+ *     ([TmuxSessionViewModel.mirrorConnectionLogToHostForTest], the synchronous
+ *     seam over the same `mirrorConnectionLogToHost()` body the driver's
+ *     `onTransportReconnected` edge fires) and await the result.
+ *
+ * GREEN ([mirrorWritesConnectionLogOverTheWarmLeaseOnReconnect]): the host file
+ * `~/.pocketshell/connection-log.jsonl` ACTUALLY lands — read back over a FRESH
+ * independent SSH exec — carrying the seeded `keepalive_dead` trail, written over
+ * the WARM lease with ZERO extra handshakes (warm reuse), proving
+ * `toLeaseSessionTarget()` produced a byte-identical key.
+ *
+ * RED guard ([wrongLeaseKeyMappingDoesNotLandOverTheWarmLease], G6/G10): the SAME
+ * write driven through a deliberately-MISMATCHED lease key (a wrong port — the
+ * shape a broken field mapping would produce) does NOT reuse the warm transport;
+ * it dials a SECOND cold handshake. That pins the byte-identical-key property as
+ * the LOAD-BEARING assertion: if `toLeaseSessionTarget()` mapped a field wrong,
+ * the GREEN test's warm-reuse assertion (handshakes == 1) would fail exactly like
+ * this guard.
+ *
+ * Uses ONLY the deterministic `agents:2222` fixture; no toxiproxy, no new Docker
+ * service/port; does NOT self-skip on CI.
+ */
+@RunWith(AndroidJUnit4::class)
+class ConnectionLogHostMirrorReconnectDockerTest {
+
+    private lateinit var sshKey: SshKey.Pem
+    private lateinit var keyFile: File
+    private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private var viewModel: TmuxSessionViewModel? = null
+
+    /**
+     * Counts every REAL cold SSH handshake the lease manager dials. A warm lease
+     * already held for the same key means a borrow reuses it and the counter does
+     * NOT advance — the byte-identical-key signal.
+     */
+    private val handshakeCount = AtomicInteger(0)
+
+    @Before
+    fun setUp() {
+        bootstrapKey()
+        // A fresh process-global sink so a sibling test's recorder cannot leak
+        // reconnect-cause events into this run.
+        DiagnosticEvents.install(DiagnosticEventSink.Noop)
+    }
+
+    @After
+    fun tearDown() {
+        viewModel?.clearForTest()
+        viewModel = null
+        factoryScope.cancel()
+        DiagnosticEvents.install(DiagnosticEventSink.Noop)
+    }
+
+    @Test
+    fun mirrorWritesConnectionLogOverTheWarmLeaseOnReconnect() = runBlocking {
+        waitForSshFixtureReady(sshKey, port = DEFAULT_PORT)
+
+        val marker = "k${System.currentTimeMillis().toString(36).takeLast(6)}"
+        val hostId = 972L
+
+        // 1. A real recorder with a seeded reconnect-cause trail (the payload the
+        //    mirror writes), incl. the named keepalive_dead cause + a unique
+        //    marker field so the read-back unambiguously matches THIS run.
+        val recorder = seedRecorderWithTrail(marker)
+        val expectedJsonl = recorder.connectionLogJsonl()
+        assertTrue(
+            "precondition: the seeded trail must be non-blank (the mirror no-ops on blank)",
+            expectedJsonl.isNotBlank() && "keepalive_dead" in expectedJsonl,
+        )
+
+        // 2. The production VM, with a handshake-counting lease manager + the real
+        //    recorder, its activeTarget set to the agents:2222 host.
+        val vm = buildViewModelTargetingFixture(hostId, recorder)
+
+        // Clear any stale host log from a prior run so the assertion is about THIS
+        // write landing, not a leftover file.
+        clearHostConnectionLog()
+
+        // 3. PRE-WARM the lease for the EXACT key the VM's activeTarget maps to.
+        //    One cold handshake; the ref is kept alive so the transport stays warm
+        //    for the mirror's borrow.
+        val warmLease = leaseManager.acquire(fixtureLeaseTarget(hostId)).getOrThrow()
+        assertEquals(
+            "pre-warm must dial exactly one cold handshake",
+            1,
+            handshakeCount.get(),
+        )
+        assertTrue("pre-warm must be a fresh connection", warmLease.isNewConnection)
+
+        try {
+            // 4. Fire the EXACT production mirror glue (activeTarget ->
+            //    toLeaseSessionTarget -> warm-lease write) and await it.
+            val result = withTimeout(MIRROR_TIMEOUT_MS) {
+                vm.mirrorConnectionLogToHostForTest()
+            }
+            assertTrue(
+                "the production mirror glue must succeed over the warm lease; was: $result",
+                result.isSuccess,
+            )
+            assertEquals(
+                "the mirror must write to the well-known host diagnostics path",
+                ConnectionLogHostMirror.REMOTE_PATH,
+                result.getOrNull(),
+            )
+
+            // The byte-identical-key property: the warm-lease borrow reused the
+            // pre-warmed transport, so NO second handshake fired. A wrong field
+            // mapping in toLeaseSessionTarget() would diverge the key -> a fresh
+            // cold dial -> this would be 2 (the RED guard below proves that).
+            assertEquals(
+                "the mirror must reuse the WARM lease (byte-identical key) — no extra handshake",
+                1,
+                handshakeCount.get(),
+            )
+
+            // The authoritative artifact: read the host file back over a FRESH,
+            // independent SSH exec and confirm the seeded trail actually landed.
+            val landed = readHostConnectionLog()
+            assertNotNull("the host connection-log file must exist after the mirror", landed)
+            val contents = landed!!
+            assertTrue(
+                "the host file must carry the seeded keepalive_dead trail; was:\n$contents",
+                "keepalive_dead" in contents,
+            )
+            assertTrue(
+                "the host file must carry THIS run's marker ($marker); was:\n$contents",
+                marker in contents,
+            )
+            assertEquals(
+                "the host file must be byte-identical to the recorder's connection-log payload",
+                expectedJsonl.trim(),
+                contents.trim(),
+            )
+        } finally {
+            warmLease.release()
+        }
+        Unit
+    }
+
+    @Test
+    fun wrongLeaseKeyMappingDoesNotLandOverTheWarmLease() = runBlocking {
+        // G6/G10 RED guard: this pins the byte-identical-key property as the
+        // LOAD-BEARING assertion of the GREEN test. It drives the SAME warm-lease
+        // write helper the mirror uses ([com.pocketshell.app.sessions.LeaseSessionExec]
+        // via [ConnectionLogHostMirror.mirror]) but through a lease target whose key
+        // is WRONG (a mismatched port — the exact shape a broken field mapping in
+        // toLeaseSessionTarget() would produce). Because the key diverges from the
+        // pre-warmed one, the borrow CANNOT reuse the warm transport: it dials a
+        // SECOND cold handshake. So if the production mapping were wrong, the GREEN
+        // test's `handshakes == 1` warm-reuse assertion would fail exactly here.
+        waitForSshFixtureReady(sshKey, port = DEFAULT_PORT)
+        val marker = "w${System.currentTimeMillis().toString(36).takeLast(6)}"
+        val hostId = 9720L
+        val recorder = seedRecorderWithTrail(marker)
+        val jsonl = recorder.connectionLogJsonl()
+        // A fresh counting manager isolated to this test.
+        val counter = AtomicInteger(0)
+        val manager = countingLeaseManager(counter)
+
+        // Pre-warm the CORRECT key.
+        val warmLease = manager.acquire(productionLeaseTarget(hostId, DEFAULT_PORT))
+            .getOrThrow()
+        assertEquals("pre-warm: one handshake", 1, counter.get())
+        try {
+            // Write through a MISMATCHED key (wrong port). The lease manager keys on
+            // (host, port, user, credentialId), so this is a different lease ->
+            // a fresh cold dial, not the warm reuse.
+            val wrongTarget = com.pocketshell.app.sessions.LeaseSessionTarget(
+                hostId = hostId,
+                hostname = DEFAULT_HOST,
+                // A wrong port: the lease key diverges, so the warm transport
+                // CANNOT be reused. (The fixture also listens here in CI? No — the
+                // point is the KEY mismatch, which forces a fresh acquire attempt;
+                // we assert the second handshake was attempted, proving non-reuse.)
+                port = DEFAULT_PORT + 1,
+                username = DEFAULT_USER,
+                keyPath = keyFile.absolutePath,
+                passphrase = null,
+            )
+            // The borrow will TRY to dial the wrong port and fail to connect, but
+            // the attempt itself proves the warm lease was NOT reused. We assert on
+            // the handshake counter, which increments on every acquire attempt.
+            runCatching {
+                withTimeout(MIRROR_TIMEOUT_MS) {
+                    ConnectionLogHostMirror.mirror(
+                        leaseManager = manager,
+                        target = wrongTarget,
+                        jsonl = jsonl,
+                    )
+                }
+            }
+            assertTrue(
+                "a mismatched lease key must NOT reuse the warm transport — it must " +
+                    "dial a fresh handshake (counter was ${counter.get()})",
+                counter.get() >= 2,
+            )
+        } finally {
+            warmLease.release()
+        }
+        Unit
+    }
+
+    // ---- helpers ----
+
+    private lateinit var leaseManager: SshLeaseManager
+
+    private fun countingLeaseManager(counter: AtomicInteger): SshLeaseManager =
+        SshLeaseManager(
+            connector = SshLeaseConnector { target ->
+                counter.incrementAndGet()
+                DefaultSshLeaseConnector().connect(target)
+            },
+        )
+
+    private fun buildViewModelTargetingFixture(
+        hostId: Long,
+        recorder: DiagnosticRecorder,
+    ): TmuxSessionViewModel {
+        leaseManager = countingLeaseManager(handshakeCount)
+        val vm = TmuxSessionViewModel(
+            tmuxClientFactory = TmuxClientFactory(factoryScope),
+            activeTmuxClients = ActiveTmuxClients(),
+            sshLeaseManager = leaseManager,
+            diagnosticRecorder = recorder,
+        )
+        // Set activeTarget to the agents:2222 host (the reconnect-completed state).
+        // An inert client is sufficient — the mirror glue only reads activeTarget
+        // and the lease manager; it issues no tmux commands.
+        vm.replaceClientForTest(
+            hostId = hostId,
+            hostName = "Connection Log Mirror $hostId",
+            host = DEFAULT_HOST,
+            port = DEFAULT_PORT,
+            user = DEFAULT_USER,
+            keyPath = keyFile.absolutePath,
+            sessionName = "mirror-main",
+            client = InertTmuxClient(),
+        )
+        viewModel = vm
+        return vm
+    }
+
+    /**
+     * The [SshLeaseTarget] the VM's `activeTarget.toLeaseSessionTarget()` maps to.
+     * Encoded here the SAME way the production [com.pocketshell.app.sessions.LeaseSessionTarget.toSshLeaseTarget]
+     * does (`credentialId = "$hostId:$keyPath"`, `knownHostsId = "accept-all"`) so
+     * the pre-warm holds the EXACT key the production mapping yields. If the VM's
+     * `toLeaseSessionTarget()` mapped any field wrong, the VM's borrow key would
+     * diverge from THIS pre-warmed key and the warm-reuse assertion would go red.
+     */
+    private fun fixtureLeaseTarget(hostId: Long): SshLeaseTarget =
+        productionLeaseTarget(hostId, DEFAULT_PORT)
+
+    private fun productionLeaseTarget(hostId: Long, port: Int): SshLeaseTarget =
+        SshLeaseTarget(
+            leaseKey = SshLeaseKey(
+                host = DEFAULT_HOST,
+                port = port,
+                user = DEFAULT_USER,
+                credentialId = "$hostId:${keyFile.absolutePath}",
+                knownHostsId = "accept-all",
+            ),
+            key = SshKey.Path(keyFile),
+            passphrase = null,
+            knownHosts = KnownHostsPolicy.AcceptAll,
+        )
+
+    private suspend fun seedRecorderWithTrail(marker: String): DiagnosticRecorder {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val settingsRepository = SettingsRepository(context)
+        val recorder = DiagnosticRecorder(context, settingsRepository)
+        recorder.clear()
+        // The reconnect-cause breadcrumbs route through the globally-installed sink
+        // (ReconnectCauseTrail.record -> DiagnosticEvents -> this recorder), exactly
+        // like production. Seed a keepalive_dead cause so the read-back asserts the
+        // named attribution lands, plus a unique marker field for this run.
+        DiagnosticEvents.install(recorder)
+        ReconnectCauseTrail.record(
+            stage = "lease_transport",
+            outcome = "down",
+            cause = "keepalive_dead",
+            trigger = null,
+            "marker" to marker,
+        )
+        ReconnectCauseTrail.record(
+            stage = "reconnect",
+            outcome = "recovered",
+            cause = null,
+            trigger = "auto",
+            "marker" to marker,
+        )
+        // Flush via the public read path so the JSONL is durable before we mirror.
+        recorder.connectionLogJsonl()
+        return recorder
+    }
+
+    private suspend fun clearHostConnectionLog() {
+        withSshSession { session ->
+            session.exec("rm -f \"\$HOME/${ConnectionLogHostMirror.REMOTE_PATH}\"")
+        }
+    }
+
+    private suspend fun readHostConnectionLog(): String? {
+        val result = withSshSession { session ->
+            session.exec(
+                "if [ -f \"\$HOME/${ConnectionLogHostMirror.REMOTE_PATH}\" ]; then " +
+                    "cat \"\$HOME/${ConnectionLogHostMirror.REMOTE_PATH}\"; else echo __MISSING__; fi",
+            )
+        }
+        if (result.exitCode != 0) return null
+        val out = result.stdout
+        return if (out.trim() == "__MISSING__") null else out
+    }
+
+    private suspend fun <T> withSshSession(block: suspend (SshSession) -> T): T {
+        val session = SshConnection.connect(
+            host = DEFAULT_HOST,
+            port = DEFAULT_PORT,
+            user = DEFAULT_USER,
+            key = sshKey,
+            knownHosts = KnownHostsPolicy.AcceptAll,
+            timeoutMs = 15_000,
+        ).getOrThrow()
+        return session.use { block(it) }
+    }
+
+    private fun bootstrapKey() {
+        val keyText = InstrumentationRegistry.getInstrumentation()
+            .context.assets.open("test_key").bufferedReader().use { it.readText() }
+        sshKey = SshKey.Pem(keyText)
+        val cacheDir = InstrumentationRegistry.getInstrumentation().targetContext.cacheDir
+        keyFile = File(cacheDir, "issue972-connection-log-mirror-key").apply {
+            parentFile?.mkdirs()
+            if (exists()) delete()
+            FileOutputStream(this).use { it.write(keyText.toByteArray()) }
+            setReadable(true, true)
+        }
+    }
+
+    /**
+     * A minimal [TmuxClient] test double for [TmuxSessionViewModel.replaceClientForTest].
+     * The mirror glue reads only `activeTarget` + the lease manager and issues no
+     * tmux commands, so every member is an inert no-op.
+     */
+    private class InertTmuxClient : TmuxClient {
+        private val disconnectedState = MutableStateFlow(false)
+        private val disconnectEventState = MutableStateFlow<TmuxDisconnectEvent?>(null)
+
+        override val events: Flow<ControlEvent> = emptyFlow()
+        override val disconnected: StateFlow<Boolean> = disconnectedState.asStateFlow()
+        override val disconnectEvent: StateFlow<TmuxDisconnectEvent?> = disconnectEventState.asStateFlow()
+        override val outputBacklogOverflows: Flow<TmuxOutputBacklogOverflow> = emptyFlow()
+
+        override suspend fun connect() = Unit
+
+        override suspend fun sendCommand(cmd: String): CommandResponse =
+            CommandResponse(number = 0L, output = emptyList(), isError = false)
+
+        override fun outputFor(paneId: String): Flow<ControlEvent.Output> = emptyFlow()
+
+        override fun close() = Unit
+
+        override suspend fun setWindowSizeLatest(sessionId: String): CommandResponse =
+            CommandResponse(number = 0L, output = emptyList(), isError = false)
+
+        override suspend fun refreshClientSize(cols: Int, rows: Int): CommandResponse =
+            CommandResponse(number = 0L, output = emptyList(), isError = false)
+
+        override suspend fun detachCleanly(timeoutMs: Long) = Unit
+    }
+
+    private companion object {
+        const val MIRROR_TIMEOUT_MS: Long = 30_000L
+    }
+}

--- a/app/src/androidTest/java/com/pocketshell/app/proof/RedrawNonDestructiveNearBlankCaptureE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/RedrawNonDestructiveNearBlankCaptureE2eTest.kt
@@ -1,0 +1,507 @@
+package com.pocketshell.app.proof
+
+import android.os.SystemClock
+import android.util.Log
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.lifecycle.ViewModelProvider
+import androidx.room.Room
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.BackgroundGraceTestOverride
+import com.pocketshell.app.MainActivity
+import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
+import com.pocketshell.app.hosts.SshKeyStorage
+import com.pocketshell.app.tmux.TMUX_REDRAW_BUTTON_TAG
+import com.pocketshell.app.tmux.TMUX_SESSION_SCREEN_TAG
+import com.pocketshell.app.tmux.TmuxSessionViewModel
+import com.pocketshell.core.ssh.KnownHostsPolicy
+import com.pocketshell.core.ssh.SshConnection
+import com.pocketshell.core.ssh.SshKey
+import com.pocketshell.core.storage.AppDatabase
+import com.pocketshell.core.storage.entity.HostEntity
+import com.termux.view.TerminalView
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+
+/**
+ * Issue #989 — DEVICE-TRUTH journey for the maintainer's load-bearing requirement:
+ * a black/empty pane must ALWAYS be recoverable, Redraw must restore content (never
+ * clear-to-black), and a re-attach must not stay black.
+ *
+ * ## The gap this proves (vs the sibling [RedrawFullViewportReseedJourneyE2eTest])
+ *
+ * The #892 sibling wipes the LOCAL emulator (`CSI 2J`) while the REMOTE tmux grid
+ * still holds the full banner — so its `capture-pane` returns a CONTENT-RICH frame
+ * that Redraw paints back. That never exercises the #989 root cause: an IDLE
+ * alternate-screen agent (Claude/Codex) whose REMOTE grid is itself near-blank, so
+ * `capture-pane` returns a near-blank-but-NON-EMPTY frame. Before #989, Redraw /
+ * re-attach painted that near-blank capture after a `CSI 2J` clear and WIPED the
+ * visible content to black-with-a-fragment (the maintainer's screenshot). The
+ * happy (banner-in-remote) fixture masked it — exactly the v0.4.10/#847 lesson, so
+ * this test ADDS the missing near-blank-REMOTE fixture (G10).
+ *
+ * ## Reproduced deterministically (no toxiproxy)
+ *
+ * Seed a tmux pane that is genuinely IDLE and near-blank on the REMOTE side (just a
+ * tiny prompt — nothing for `capture-pane` to return). Attach. Then feed a
+ * CONTENT-RICH banner straight into the SAME local `TerminalView.mEmulator` the app
+ * renders — so LOCAL render = rich, REMOTE grid = near-blank, exactly the idle-agent
+ * mismatch. Tap Redraw: the warm-session `capture-pane` comes back near-blank.
+ *
+ * ## Load-bearing assertion (red→green)
+ *
+ *  - WITH the #989 fix: the non-destructive swap REFUSES the near-blank capture and
+ *    KEEPS the last (rich) frame — the rendered viewport stays painted (NOT black).
+ *  - WITHOUT the fix: the near-blank capture is painted after `CSI 2J` → the viewport
+ *    collapses to (near-)black. So [redrawKeepsRichContentWhenRemoteCaptureIsNearBlank]
+ *    goes RED on base, GREEN with the fix.
+ *
+ * Uses ONLY the deterministic `agents` fixture (host port 2222) and feeds the rich
+ * frame LOCALLY (no toxiproxy, no `Assume.assumeFalse(isRunningOnCi())`), so it RUNS
+ * on the per-PR CI emulator-journey job once wired into `scripts/ci-journey-suite.sh`.
+ */
+@RunWith(AndroidJUnit4::class)
+class RedrawNonDestructiveNearBlankCaptureE2eTest {
+
+    @get:Rule
+    val compose = createEmptyComposeRule()
+
+    @get:Rule
+    val grantPermissions = PreGrantPermissionsRule()
+
+    private var launchedActivity: ActivityScenario<MainActivity>? = null
+    private var seededKey: String? = null
+
+    @Before
+    fun setUp() {
+        BackgroundGraceTestOverride.setForTest(null)
+    }
+
+    @After
+    fun tearDown() {
+        runCatching { launchedActivity?.close() }
+        launchedActivity = null
+        BackgroundGraceTestOverride.setForTest(null)
+        seededKey?.let { key -> runCatching { runBlocking { cleanupRemoteTmuxSession(key) } } }
+    }
+
+    @Test
+    fun redrawKeepsRichContentWhenRemoteCaptureIsNearBlank(): Unit = runBlocking {
+        val key = readFixtureKey()
+        seededKey = key
+        waitForSshFixtureReady(SshKey.Pem(key))
+        seedIdleNearBlankSession(key)
+
+        val hostRowTag = seedDockerHost(key)
+        launchedActivity = ActivityScenario.launch(MainActivity::class.java)
+        attachSeededTmuxSession(hostRowTag)
+        waitForConnected("issue989 initial attach")
+        waitForTerminalViewAttached()
+
+        // LOCAL render = rich: feed a full-viewport banner straight into the emulator the
+        // app renders. The REMOTE tmux grid stays near-blank (the idle prompt) — this is
+        // the idle-agent mismatch the #989 root cause needs.
+        feedRichBannerToEmulator()
+        val richRows = pollPaintedRowsUpToRich("issue989-01-rich-local")
+        assertTrue(
+            "precondition: the LOCAL viewport must be content-rich before Redraw " +
+                "(>= $MIN_RICH_PAINTED_ROWS painted rows); found $richRows",
+            richRows >= MIN_RICH_PAINTED_ROWS,
+        )
+        assertTrue(
+            "precondition: the session must be Connected over the warm lease",
+            currentConnectionStatus() is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+
+        // Tap Redraw. The warm-session `capture-pane` returns the REMOTE near-blank grid.
+        openKebab()
+        tapRedraw()
+
+        // LOAD-BEARING (red→green): the rich viewport must NOT be cleared to black. With the
+        // #989 non-destructive swap the near-blank capture is refused and the last frame is
+        // KEPT; without it the near-blank capture is painted after `CSI 2J` and the viewport
+        // collapses to (near-)black. Poll a settle window so a late clear is caught too.
+        val keptRich = pollViewportStaysRich("issue989-02-after-redraw", POST_REDRAW_SETTLE_MS)
+        assertTrue(
+            "Redraw must NOT clear the content-rich pane to black when the capture is " +
+                "near-blank — the last frame must be kept (>= $MIN_RICH_PAINTED_ROWS painted " +
+                "rows held across the settle window); min observed $keptRich",
+            keptRich >= MIN_RICH_PAINTED_ROWS,
+        )
+
+        // The session screen is still up and Connected (a reseed, not a teardown).
+        assertTrue(
+            "tmux session screen must still be up after Redraw",
+            compose.onAllNodesWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .isNotEmpty(),
+        )
+        assertTrue(
+            "session must stay Connected after Redraw, observed=${currentConnectionStatus()}",
+            currentConnectionStatus() is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+
+        writeSummary()
+    }
+
+    // ---------------------------------------------------------------- Helpers
+
+    private fun openKebab() {
+        compose.onNodeWithContentDescription("More session actions", useUnmergedTree = true)
+            .performClick()
+        compose.waitUntil(timeoutMillis = 5_000) {
+            compose.onAllNodesWithTag(TMUX_REDRAW_BUTTON_TAG, useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
+        compose.onNodeWithTag(TMUX_REDRAW_BUTTON_TAG, useUnmergedTree = true).assertExists()
+    }
+
+    private fun tapRedraw() {
+        compose.onNodeWithTag(TMUX_REDRAW_BUTTON_TAG, useUnmergedTree = true)
+            .assertExists()
+            .performClick()
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        Log.i(LOG_TAG, "tapped Redraw kebab item")
+    }
+
+    /**
+     * Feed a full-viewport content-rich banner into the SAME local emulator the app
+     * renders. Local-only (the remote tmux grid stays near-blank), the #553/#879 model.
+     */
+    private fun feedRichBannerToEmulator() {
+        val esc = "\u001B"
+        val banner = buildString {
+            append("$esc[2J$esc[H")
+            (1..40).forEach { append("$BANNER_MARKER row %02d filler abcdefghijklmnopqrst\r\n".format(it)) }
+        }.toByteArray(Charsets.UTF_8)
+        var fed = false
+        launchedActivity?.onActivity { activity ->
+            val view = activity.window.decorView.findTerminalView() ?: return@onActivity
+            val emulator = view.mEmulator ?: return@onActivity
+            emulator.append(banner, banner.size)
+            view.invalidate()
+            fed = true
+        }
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        assertTrue("expected to feed the rich banner to the live emulator", fed)
+    }
+
+    private fun pollPaintedRowsUpToRich(name: String): Int {
+        val deadline = SystemClock.elapsedRealtime() + RICH_PRECONDITION_TIMEOUT_MS
+        var best = 0
+        while (true) {
+            feedRichBannerToEmulator()
+            val rows = capturePaintedRows(name)
+            if (rows > best) best = rows
+            if (best >= MIN_RICH_PAINTED_ROWS) return best
+            if (SystemClock.elapsedRealtime() >= deadline) break
+            SystemClock.sleep(100)
+        }
+        return best
+    }
+
+    /**
+     * Poll the rendered viewport across a settle window and return the MINIMUM painted-row
+     * count observed — so a late clear-to-black (the #989 symptom landing after a beat) is
+     * caught, not raced past. With the fix the count never drops below the rich floor.
+     */
+    private fun pollViewportStaysRich(name: String, durationMs: Long): Int {
+        val deadline = SystemClock.elapsedRealtime() + durationMs
+        var min = Int.MAX_VALUE
+        var lastBitmapName = name
+        while (SystemClock.elapsedRealtime() < deadline) {
+            val rows = capturePaintedRows(lastBitmapName)
+            if (rows < min) min = rows
+            lastBitmapName = name
+            SystemClock.sleep(150)
+        }
+        return if (min == Int.MAX_VALUE) 0 else min
+    }
+
+    private fun capturePaintedRows(name: String): Int {
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        var rows = 0
+        launchedActivity?.onActivity { activity ->
+            val view = activity.window.decorView.findTerminalView() ?: return@onActivity
+            if (view.width <= 0 || view.height <= 0) return@onActivity
+            val b = android.graphics.Bitmap.createBitmap(
+                view.width, view.height, android.graphics.Bitmap.Config.ARGB_8888,
+            )
+            view.draw(android.graphics.Canvas(b))
+            rows = paintedRowCount(b)
+            writeBitmap("$name-viewport", b)
+            b.recycle()
+        }
+        writeText("$name-visible-terminal.txt", visibleTerminalText())
+        return rows
+    }
+
+    private fun paintedRowCount(bitmap: android.graphics.Bitmap): Int {
+        var painted = 0
+        var y = 0
+        while (y < bitmap.height) {
+            var x = 0
+            var rowPainted = false
+            while (x < bitmap.width) {
+                val p = bitmap.getPixel(x, y)
+                if (android.graphics.Color.red(p) > 40 ||
+                    android.graphics.Color.green(p) > 40 ||
+                    android.graphics.Color.blue(p) > 40
+                ) {
+                    rowPainted = true
+                    break
+                }
+                x += 4
+            }
+            if (rowPainted) painted++
+            y += 4
+        }
+        return painted
+    }
+
+    private fun attachSeededTmuxSession(hostRowTag: String) {
+        compose.waitUntil(timeoutMillis = 15_000) {
+            compose.onAllNodesWithTag(hostRowTag, useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
+        compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick()
+        compose.waitUntil(timeoutMillis = TerminalTestTimeouts.terminalVisibilityTimeoutMs()) {
+            compose.onAllNodesWithText(SESSION_NAME, useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
+        compose.onNodeWithText(SESSION_NAME, useUnmergedTree = true).performClick()
+        compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertExists()
+        waitForTerminalViewAttached()
+    }
+
+    private fun waitForTerminalViewAttached() {
+        compose.waitUntil(timeoutMillis = 30_000) {
+            var attached = false
+            launchedActivity?.onActivity { activity ->
+                val view = activity.window.decorView.findTerminalView()
+                attached = view?.currentSession != null && view.mEmulator != null
+            }
+            attached
+        }
+    }
+
+    private fun waitForConnected(label: String) {
+        compose.waitUntil(timeoutMillis = CONNECTED_TIMEOUT_MS) {
+            currentConnectionStatus() is TmuxSessionViewModel.ConnectionStatus.Connected
+        }
+        assertTrue(
+            "expected Connected after $label, observed=${currentConnectionStatus()}",
+            currentConnectionStatus() is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+    }
+
+    private fun currentConnectionStatus(): TmuxSessionViewModel.ConnectionStatus {
+        var status: TmuxSessionViewModel.ConnectionStatus =
+            TmuxSessionViewModel.ConnectionStatus.Idle
+        launchedActivity?.onActivity { activity ->
+            status = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+                .connectionStatus
+                .value
+        }
+        return status
+    }
+
+    private fun visibleTerminalText(): String {
+        var text = ""
+        launchedActivity?.onActivity { activity ->
+            text = activity.window.decorView
+                .findTerminalView()
+                ?.currentSession
+                ?.emulator
+                ?.screen
+                ?.transcriptText
+                .orEmpty()
+        }
+        return text
+    }
+
+    private fun readFixtureKey(): String =
+        InstrumentationRegistry.getInstrumentation()
+            .context
+            .assets
+            .open("test_key")
+            .bufferedReader()
+            .use { it.readText() }
+
+    /**
+     * Seed a tmux session whose ACTIVE pane is genuinely IDLE and near-blank on the REMOTE
+     * side — just a tiny prompt fragment, nothing for `capture-pane` to return. This is the
+     * idle-alt-screen-agent state whose capture is near-blank (the #989 root cause).
+     */
+    private suspend fun seedIdleNearBlankSession(key: String) {
+        val payload = "printf '\\033[?1049h'; printf '> '; while true; do sleep 3600; done"
+        val script = buildString {
+            appendLine("set -eu")
+            appendLine("tmux kill-session -t ${shellQuote(SESSION_NAME)} 2>/dev/null || true")
+            appendLine("tmux new-session -d -s ${shellQuote(SESSION_NAME)} ${shellQuote(payload)}")
+            appendLine("sleep 2")
+            appendLine("tmux list-sessions")
+        }
+        val result = SshConnection.connect(
+            host = DEFAULT_HOST,
+            port = DEFAULT_PORT,
+            user = DEFAULT_USER,
+            key = SshKey.Pem(key),
+            knownHosts = KnownHostsPolicy.AcceptAll,
+            timeoutMs = 15_000,
+        ).mapCatching { session -> session.use { it.exec(script) } }
+        val exec = result.getOrNull()
+        assertTrue(
+            "expected idle near-blank tmux seeding to succeed; " +
+                "exception=${result.exceptionOrNull()} stderr='${exec?.stderr}'",
+            exec?.exitCode == 0,
+        )
+        Log.i(LOG_TAG, "seeded idle near-blank session: ${exec?.stdout?.trim()}")
+    }
+
+    private suspend fun cleanupRemoteTmuxSession(key: String) {
+        runCatching {
+            SshConnection.connect(
+                host = DEFAULT_HOST,
+                port = DEFAULT_PORT,
+                user = DEFAULT_USER,
+                key = SshKey.Pem(key),
+                knownHosts = KnownHostsPolicy.AcceptAll,
+                timeoutMs = 15_000,
+            ).mapCatching { session ->
+                session.use {
+                    it.exec("tmux kill-session -t ${shellQuote(SESSION_NAME)} 2>/dev/null || true")
+                }
+            }
+        }
+    }
+
+    private suspend fun seedDockerHost(key: String): String {
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
+        val db = Room.databaseBuilder(appContext, AppDatabase::class.java, DATABASE_NAME)
+            .fallbackToDestructiveMigration(dropAllTables = true)
+            .build()
+        return try {
+            db.clearAllTables()
+            val storedKey = SshKeyStorage.persistKey(
+                context = appContext,
+                sshKeyDao = db.sshKeyDao(),
+                name = "issue989-redraw-key-${System.currentTimeMillis()}",
+                content = key,
+            )
+            val hostId = db.hostDao().insert(
+                HostEntity(
+                    name = "Issue989 Non-Destructive Redraw",
+                    hostname = DEFAULT_HOST,
+                    port = DEFAULT_PORT,
+                    username = DEFAULT_USER,
+                    keyId = storedKey.id,
+                    tmuxInstalled = true,
+                    lastBootstrapAt = System.currentTimeMillis(),
+                ),
+            )
+            HOST_ROW_TAG_PREFIX + hostId
+        } finally {
+            db.close()
+        }
+    }
+
+    private fun writeBitmap(name: String, bitmap: android.graphics.Bitmap): File {
+        val file = artifactFile("$name.png")
+        java.io.FileOutputStream(file).use { out ->
+            check(bitmap.compress(android.graphics.Bitmap.CompressFormat.PNG, 100, out)) {
+                "failed to write bitmap to ${file.absolutePath}"
+            }
+        }
+        println("ISSUE989_VIEWPORT ${file.absolutePath}")
+        return file
+    }
+
+    private fun writeText(name: String, text: String): File {
+        val file = artifactFile(name)
+        file.writeText(text)
+        println("ISSUE989_TEXT ${file.absolutePath}")
+        return file
+    }
+
+    private fun writeSummary(): File =
+        writeText(
+            "issue989-summary.txt",
+            buildString {
+                appendLine("test=RedrawNonDestructiveNearBlankCaptureE2eTest")
+                appendLine("issue=989")
+                appendLine("fixture=tests/docker agents ($DEFAULT_HOST:$DEFAULT_PORT)")
+                appendLine("running_on_ci=${TerminalTestTimeouts.isRunningOnCi()}")
+                appendLine("session=$SESSION_NAME")
+                appendLine("banner_marker=$BANNER_MARKER")
+                appendLine(
+                    "scenario=idle near-blank REMOTE alt-screen pane; rich banner fed LOCALLY; " +
+                        "tap Redraw -> warm capture-pane returns near-blank",
+                )
+                appendLine(
+                    "expectation=Redraw KEEPS the rich frame (non-destructive swap), never " +
+                        "clears the visible content to black; still Connected",
+                )
+            },
+        )
+
+    private fun artifactFile(name: String): File {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val mediaRoot = com.pocketshell.app.test.testArtifactsRoot(instrumentation.targetContext)
+        val dir = File(mediaRoot, "additional_test_output/$DEVICE_DIR_NAME")
+        check(dir.exists() || dir.mkdirs()) {
+            "could not create artifact directory ${dir.absolutePath}"
+        }
+        return File(dir, name)
+    }
+
+    private fun View.findTerminalView(): TerminalView? {
+        if (this is TerminalView) return this
+        if (this !is ViewGroup) return null
+        for (index in 0 until childCount) {
+            val match = getChildAt(index).findTerminalView()
+            if (match != null) return match
+        }
+        return null
+    }
+
+    private fun shellQuote(value: String): String =
+        "'" + value.replace("'", "'\"'\"'") + "'"
+
+    private companion object {
+        const val DATABASE_NAME: String = "pocketshell.db"
+        const val LOG_TAG: String = "Issue989Redraw"
+        const val DEVICE_DIR_NAME: String = "issue989-nondestructive-redraw"
+        const val SESSION_NAME: String = "issue989-redraw-proof"
+        const val BANNER_MARKER: String = "ISSUE989-BANNER"
+
+        const val POST_REDRAW_SETTLE_MS: Long = 3_000L
+
+        // The locally-fed banner fills the whole viewport, so a healthy rich render shows
+        // MANY painted rows; a clear-to-black collapses to very few. 30 is a robust floor.
+        const val MIN_RICH_PAINTED_ROWS: Int = 30
+
+        val RICH_PRECONDITION_TIMEOUT_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 15_000L else 10_000L
+        val CONNECTED_TIMEOUT_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 30_000L else 15_000L
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/agents/AgentKindRemoteSource.kt
+++ b/app/src/main/java/com/pocketshell/app/agents/AgentKindRemoteSource.kt
@@ -5,6 +5,7 @@ import com.pocketshell.core.agents.AgentKind
 import com.pocketshell.core.ssh.ExecResult
 import com.pocketshell.core.ssh.SshSession
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.async
@@ -37,8 +38,32 @@ import javax.inject.Inject
 public class AgentKindRemoteSource @Inject constructor() {
     private var execReadTimeoutMs: Long = EXEC_READ_TIMEOUT_MS
 
+    /**
+     * Issue #1001 (CI-flake fix): the dispatcher the bounded daemon RPC exec
+     * runs on. Defaults to [Dispatchers.IO] so the potentially-wedged blocking
+     * SSH read never parks a UI/caller thread in production. A JVM unit test
+     * driving the detection chain under `runTest(scheduler)` pins this to a
+     * `StandardTestDispatcher` on the SHARED virtual-clock scheduler via
+     * [setExecDispatcherForTest], so the exec + its `withTimeoutOrNull` resolve
+     * on the test scheduler — deterministically drained by `runCurrent()` /
+     * `advanceUntilIdle()` instead of racing a real `Dispatchers.IO` background
+     * thread (the b1Masked* detection-bind race, ~1/3 release-variant failures).
+     * Production behaviour is unchanged.
+     */
+    private var execDispatcher: CoroutineDispatcher = Dispatchers.IO
+
     internal constructor(execReadTimeoutMs: Long) : this() {
         this.execReadTimeoutMs = execReadTimeoutMs
+    }
+
+    /**
+     * Issue #1001: confine the bounded-exec dispatcher to a test scheduler so a
+     * `runTest`-driven detection test awaits the daemon RPC deterministically.
+     * Test-only; never called in production.
+     */
+    @androidx.annotation.VisibleForTesting
+    internal fun setExecDispatcherForTest(dispatcher: CoroutineDispatcher) {
+        execDispatcher = dispatcher
     }
 
     /**
@@ -165,7 +190,7 @@ public class AgentKindRemoteSource @Inject constructor() {
      * read.
      */
     private suspend fun SshSession.execBounded(command: String): ExecResult? =
-        withContext(Dispatchers.IO) {
+        withContext(execDispatcher) {
             val deferred = async { exec(command) }
             withTimeoutOrNull(execReadTimeoutMs) { deferred.await() }
                 ?: run {

--- a/app/src/main/java/com/pocketshell/app/diagnostics/ConnectionLogHostMirror.kt
+++ b/app/src/main/java/com/pocketshell/app/diagnostics/ConnectionLogHostMirror.kt
@@ -1,0 +1,100 @@
+package com.pocketshell.app.diagnostics
+
+import com.pocketshell.app.sessions.LeaseSessionExec
+import com.pocketshell.app.sessions.LeaseSessionTarget
+import com.pocketshell.core.ssh.SshLeaseManager
+import com.pocketshell.core.ssh.SshSession
+import kotlinx.coroutines.CancellationException
+import java.io.ByteArrayInputStream
+import java.nio.charset.StandardCharsets
+
+/**
+ * Mirrors the local reconnect-cause trail to a host-side file
+ * `~/.pocketshell/connection-log.jsonl` over the ALREADY-WARM `-CC` lease
+ * (issue #969 part 3, wired by #972).
+ *
+ * Why a host file: the reconnect-cause breadcrumbs ([ReconnectCauseTrail],
+ * recorded by default since #969) already live in the on-device rolling JSONL,
+ * but the maintainer can't read that without adb / the OS share sheet. Writing
+ * the SAME breadcrumbs to a host file lets them open it in PocketShell's own
+ * in-app file viewer (no adb, no share) so a real-world drop can be ATTRIBUTED
+ * (e.g. `keepalive_dead` vs an anonymous `lease_down`) right on the phone.
+ *
+ * Reuses the trusted `~/inbox/pocketshell/` write pattern (D21): the write runs
+ * on the warm lease via [LeaseSessionExec.withSession] — NO fresh SSH handshake
+ * — with a `mkdir -p` exec then an SCP [SshSession.uploadStream]. The destination
+ * is the home-relative `~/.pocketshell/` (the in-app file viewer's well-known
+ * diagnostics directory), not the inbox.
+ *
+ * FAIL-SOFT is a hard contract. A diagnostics mirror must NEVER perturb the live
+ * connection: any failure (lease unavailable, mkdir denied, upload error) returns
+ * [Result.failure] WITHOUT throwing, and the lease helper never closes the warm
+ * transport on the write path. A coroutine cancellation still propagates (so a
+ * torn-down VM scope cancels cleanly) — it is the only throw that escapes.
+ */
+object ConnectionLogHostMirror {
+
+    /** Home-relative directory the in-app file viewer surfaces for diagnostics. */
+    const val REMOTE_DIR: String = ".pocketshell"
+
+    /** The mirrored connection-log filename inside [REMOTE_DIR]. */
+    const val REMOTE_FILENAME: String = "connection-log.jsonl"
+
+    /** Absolute (home-relative) remote path of the mirrored log. */
+    const val REMOTE_PATH: String = "$REMOTE_DIR/$REMOTE_FILENAME"
+
+    /**
+     * Write [jsonl] to `~/.pocketshell/connection-log.jsonl` on the host behind
+     * [target], reusing [leaseManager]'s warm transport. Returns the absolute
+     * remote path on success, or a fail-soft [Result.failure] on any error.
+     *
+     * A blank [jsonl] is a no-op success ([Result.success] with `null`): there
+     * are no breadcrumbs to mirror yet, and writing an empty file would only
+     * confuse the file viewer.
+     */
+    suspend fun mirror(
+        leaseManager: SshLeaseManager,
+        target: LeaseSessionTarget,
+        jsonl: String,
+    ): Result<String?> {
+        if (jsonl.isBlank()) return Result.success(null)
+        return try {
+            LeaseSessionExec.withSession(leaseManager, target) { session ->
+                writeOverSession(session, jsonl)
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (t: Throwable) {
+            // withSession already wraps its own failures in Result.failure; this
+            // catch only covers an unexpected throw from building the borrow so
+            // the contract "never throws (except cancellation)" holds end-to-end.
+            Result.failure(t)
+        }
+    }
+
+    private suspend fun writeOverSession(session: SshSession, jsonl: String): String {
+        // The exec channel drives `mkdir -p $HOME/.pocketshell` (SFTP's per-segment
+        // mkdir is more fragile against minimal OpenSSH images — the ShareUploader
+        // inbox pattern uses the same exec route).
+        val mk = session.exec("mkdir -p \"\$HOME/$REMOTE_DIR\"")
+        if (mk.exitCode != 0) {
+            throw ConnectionLogHostMirrorException(
+                "mkdir ~/$REMOTE_DIR failed: ${mk.stderr.ifBlank { mk.stdout.trim() }}",
+            )
+        }
+        val bytes = jsonl.toByteArray(StandardCharsets.UTF_8)
+        return session.uploadStream(
+            input = ByteArrayInputStream(bytes),
+            length = bytes.size.toLong(),
+            name = REMOTE_FILENAME,
+            remotePath = REMOTE_PATH,
+        )
+    }
+}
+
+/**
+ * Thrown internally by [ConnectionLogHostMirror] when a host write step fails;
+ * always captured into the fail-soft [Result.failure] (never escapes to the
+ * caller as a throw).
+ */
+class ConnectionLogHostMirrorException(message: String) : Exception(message)

--- a/app/src/main/java/com/pocketshell/app/diagnostics/DiagnosticRecorder.kt
+++ b/app/src/main/java/com/pocketshell/app/diagnostics/DiagnosticRecorder.kt
@@ -98,6 +98,28 @@ class DiagnosticRecorder @Inject constructor(
         }
     }
 
+    /**
+     * The reconnect-cause breadcrumbs ([ReconnectCauseTrail]) rendered as JSONL —
+     * one JSON object per line, the same on-disk encoding the rolling diagnostics
+     * file uses. This is the payload
+     * [com.pocketshell.app.diagnostics.ConnectionLogHostMirror] mirrors to the host
+     * so the maintainer can attribute a real-world drop in the in-app file viewer
+     * (#969/#972).
+     *
+     * Blank when nothing has been recorded yet (recording off, or no reconnect):
+     * the mirror treats a blank payload as a no-op so it never writes an empty host
+     * file.
+     */
+    suspend fun connectionLogJsonl(): String {
+        val events = readEvents(
+            DiagnosticEventFilter(
+                category = ReconnectCauseTrail.CATEGORY,
+                name = ReconnectCauseTrail.NAME,
+            ),
+        )
+        return events.joinToString(separator = "\n") { DiagnosticEventJson.encode(it) }
+    }
+
     private suspend fun flush() {
         val done = CompletableDeferred<Unit>()
         commands.send(RecorderCommand.Flush(done))

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
@@ -1017,6 +1017,16 @@ public fun TmuxSessionScreen(
         viewModel.assistantNavRequests.collect { onAssistantNavigate(it) }
     }
 
+    // Issue #989: surface Redraw feedback as a Toast so tapping Redraw with no
+    // live client (dropped / reconnecting) tells the user it can't act right now
+    // instead of silently doing nothing ("I clicked it three times and nothing
+    // happened"). On the happy path Redraw emits NO feedback — it just reseeds.
+    LaunchedEffect(viewModel) {
+        viewModel.redrawFeedback.collect { message ->
+            Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+        }
+    }
+
     // Route inline-dictation transcripts into the currently focused pane.
     // The collector re-binds whenever the focused pane or dictation mode
     // changes so we always write into the pane the user is looking at, not

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -278,6 +278,14 @@ public class TmuxSessionViewModel @Inject constructor(
     private val agentKindRemoteSource: com.pocketshell.app.agents.AgentKindRemoteSource =
         com.pocketshell.app.agents.AgentKindRemoteSource(),
     private val sessionCardsRemoteSource: SessionCardsRemoteSource = SessionCardsRemoteSource(),
+    // Issue #972: the always-on reconnect-cause flight recorder. Its
+    // [DiagnosticRecorder.connectionLogJsonl] payload is mirrored to the host's
+    // `~/.pocketshell/connection-log.jsonl` over the warm lease right after a
+    // reconnect (the driver's `onTransportReconnected` edge), so the maintainer
+    // can attribute a real-world drop in the in-app file viewer (no adb).
+    // Nullable default keeps the existing unit-test constructors working without
+    // the Hilt singleton; when absent the host mirror is simply skipped.
+    private val diagnosticRecorder: com.pocketshell.app.diagnostics.DiagnosticRecorder? = null,
 ) : ViewModel() {
 
     /**
@@ -929,6 +937,13 @@ public class TmuxSessionViewModel @Inject constructor(
                 classifyPassiveTransportDrop(client) != ConnectionDecision.Ignore
             },
             controlChannelDroppedEffect = { client -> onControllerTransportDropped(client) },
+            // Issue #972: on the current host's lease coming back `Up` after a
+            // reconnect, mirror the recorded reconnect-cause trail to the host's
+            // `~/.pocketshell/connection-log.jsonl` over the now-warm lease so the
+            // just-completed drop is attributable in the in-app file viewer (no
+            // adb). Fail-soft + a blank trail no-ops, so it never perturbs the
+            // live connection.
+            onTransportReconnected = { mirrorConnectionLogToHost() },
         ).also { it.start() }
 
     /**
@@ -15185,6 +15200,90 @@ public class TmuxSessionViewModel @Inject constructor(
         val tmuxSessionId: String? = null,
         val sessionCreated: Long? = null,
     )
+
+    /**
+     * The [com.pocketshell.app.sessions.LeaseSessionTarget] for this connection,
+     * byte-identical to the lease key the session screens use (so a borrow reuses
+     * the warm transport, not a fresh handshake). Used by the #972 host
+     * connection-log mirror.
+     */
+    private fun ConnectionTarget.toLeaseSessionTarget(): com.pocketshell.app.sessions.LeaseSessionTarget =
+        com.pocketshell.app.sessions.LeaseSessionTarget(
+            hostId = hostId,
+            hostname = host,
+            port = port,
+            username = user,
+            keyPath = keyPath,
+            passphrase = passphrase,
+        )
+
+    /**
+     * Issue #972 — wire the host connection-log mirror to its trigger. Fired by the
+     * [ConnectionEffectDriver] right after the current host's lease transport comes
+     * back `Up` (a reconnect promoted the controller to Live): mirror the recorded
+     * reconnect-cause trail ([DiagnosticRecorder.connectionLogJsonl]) to the host's
+     * `~/.pocketshell/connection-log.jsonl` over the now-warm lease, so the
+     * maintainer can attribute the just-completed drop in the in-app file viewer
+     * with no adb (#969 part 3 was a tested-but-unwired writer; this is the wiring).
+     *
+     * FAIL-SOFT all the way: a missing recorder, no active target, a blank trail,
+     * or any host-write error is a silent no-op — the mirror NEVER perturbs the
+     * live connection. The write runs on [viewModelScope] off the driver's collect
+     * so the transport-edge collector is never blocked by the host round-trip.
+     */
+    private fun mirrorConnectionLogToHost() {
+        val recorder = diagnosticRecorder ?: return
+        val target = activeTarget ?: return
+        val leaseTarget = target.toLeaseSessionTarget()
+        viewModelScope.launch {
+            // runCatching is belt-and-braces so a surprise never escapes onto
+            // viewModelScope; the shared body is itself fail-soft.
+            runCatching { mirrorConnectionLogToHostBody(recorder, leaseTarget) }
+        }
+    }
+
+    /**
+     * The fail-soft mirror body shared by the production fire-and-forget
+     * [mirrorConnectionLogToHost] and the connected-test seam
+     * [mirrorConnectionLogToHostForTest]. Reads the recorder's reconnect-cause
+     * trail and, when non-blank, writes it to the host over the warm lease via
+     * [com.pocketshell.app.diagnostics.ConnectionLogHostMirror] (itself
+     * `Result.failure` fail-soft, never a throw except cancellation). Returns the
+     * mirror's [Result] (the absolute remote path on success, `null` when the
+     * trail was blank so no write happened).
+     */
+    private suspend fun mirrorConnectionLogToHostBody(
+        recorder: com.pocketshell.app.diagnostics.DiagnosticRecorder,
+        leaseTarget: com.pocketshell.app.sessions.LeaseSessionTarget,
+    ): Result<String?> {
+        val jsonl = runCatching { recorder.connectionLogJsonl() }.getOrNull().orEmpty()
+        if (jsonl.isBlank()) return Result.success(null)
+        return com.pocketshell.app.diagnostics.ConnectionLogHostMirror.mirror(
+            leaseManager = sshLeaseManager,
+            target = leaseTarget,
+            jsonl = jsonl,
+        )
+    }
+
+    /**
+     * Issue #972 connected-test seam. Drives the EXACT production mirror glue —
+     * `activeTarget` → [toLeaseSessionTarget] (the byte-identical lease-key
+     * mapping) → the warm-lease write — synchronously and returns the
+     * [ConnectionLogHostMirror][com.pocketshell.app.diagnostics.ConnectionLogHostMirror]
+     * `Result` so a Docker journey can assert the host file actually lands over
+     * the warm lease (a wrong lease-key field mapping would dial a fresh handshake
+     * or fail outright — the exact "wired but the host file never lands" regression
+     * this issue closes). Returns `Result.failure` when there is no recorder or no
+     * active target, exactly like the fire-and-forget production path returns early.
+     */
+    @androidx.annotation.VisibleForTesting
+    internal suspend fun mirrorConnectionLogToHostForTest(): Result<String?> {
+        val recorder = diagnosticRecorder
+            ?: return Result.failure(IllegalStateException("no diagnosticRecorder"))
+        val target = activeTarget
+            ?: return Result.failure(IllegalStateException("no activeTarget"))
+        return mirrorConnectionLogToHostBody(recorder, target.toLeaseSessionTarget())
+    }
 
     private fun ConnectionTarget.sessionCardsTargetKey(): String =
         sessionCardsTargetKey(

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -610,6 +610,22 @@ public class TmuxSessionViewModel @Inject constructor(
         _sessionCreateError.asSharedFlow()
 
     /**
+     * Issue #989: one-shot user-visible feedback for the manual Redraw kebab item.
+     * Before this, Redraw silently no-op'd (logged + returned) when there was no
+     * live client / the client was disconnected / no active target — so to the
+     * maintainer it read as "Redraw is broken" ("I clicked it three times and
+     * nothing happened"). The Screen collects this and shows a Toast so the user
+     * learns Redraw can't act right now (reconnecting), instead of staring at an
+     * unchanged screen wondering if the feature works. Buffered (replay-less,
+     * extra capacity) so a tap that happens while no collector is bound is not
+     * lost.
+     */
+    private val _redrawFeedback: MutableSharedFlow<String> =
+        MutableSharedFlow(extraBufferCapacity = 4)
+    public val redrawFeedback: SharedFlow<String> =
+        _redrawFeedback.asSharedFlow()
+
+    /**
      * Issue #626: called by the Screen when the unified pager settles on a
      * page. If the pane belongs to a different session, emit a
      * [sessionSwitchRequest] so the Screen triggers a warm switch.
@@ -3484,14 +3500,18 @@ public class TmuxSessionViewModel @Inject constructor(
     public fun redrawActivePane() {
         val client = clientRef ?: run {
             Log.i(ISSUE_145_RECONNECT_TAG, "tmux-redraw-skip no-client")
+            // Issue #989: surface the no-op so Redraw never silently does nothing.
+            _redrawFeedback.tryEmit(REDRAW_UNAVAILABLE_MESSAGE)
             return
         }
         if (client.disconnected.value) {
             Log.i(ISSUE_145_RECONNECT_TAG, "tmux-redraw-skip client-disconnected")
+            _redrawFeedback.tryEmit(REDRAW_UNAVAILABLE_MESSAGE)
             return
         }
         val target = activeTarget ?: run {
             Log.i(ISSUE_145_RECONNECT_TAG, "tmux-redraw-skip no-target")
+            _redrawFeedback.tryEmit(REDRAW_UNAVAILABLE_MESSAGE)
             return
         }
         Log.i(
@@ -3579,7 +3599,19 @@ public class TmuxSessionViewModel @Inject constructor(
         if (!freshlySeededAndPainted) {
             // UNCONDITIONAL full-viewport restore of the active pane (id-tagged via the
             // guard) — NOT gated on `visibleScreenIsBlank()`, so a partial blank is healed.
-            seedPaneFromCapture(client, activePane, refreshGuard, recordMilestone = false)
+            // Issue #989: FORCE the app to repaint first (`send-keys C-l`) so an idle
+            // alt-screen agent re-emits its full frame BEFORE we capture — otherwise the
+            // capture is near-blank and the seed would clear visible content to black.
+            // This single chokepoint feeds manual Redraw, the within-grace reattach, the
+            // no-op-resize heal, and the reflow completion — so all four recover content,
+            // never clear-to-black.
+            seedPaneFromCapture(
+                client,
+                activePane,
+                refreshGuard,
+                recordMilestone = false,
+                forceAgentRepaint = true,
+            )
         }
         // Then run the existing blank-net backstop over any OTHER visible pane that came
         // back fully blank (a no-op for the active pane just restored above).
@@ -9128,6 +9160,21 @@ public class TmuxSessionViewModel @Inject constructor(
     }
 
     /**
+     * Issue #989 (test seam): drive [reseedActivePaneForReattach] directly against
+     * the supplied guard (typically [currentRuntimeGuardForTest]) — the SAME
+     * chokepoint the within-grace foreground reattach, the no-op-resize heal, and
+     * the reflow completion use. Lets a JVM test prove the attach/return reseed
+     * forces a repaint and is non-destructive without driving the whole
+     * background→foreground lifecycle. A no-op when the guard is null. Passthrough,
+     * no production logic.
+     */
+    @androidx.annotation.VisibleForTesting
+    internal suspend fun reseedActivePaneForReattachForTest(guard: RuntimeRefreshGuard?) {
+        val refreshGuard = guard ?: return
+        reseedActivePaneForReattach(refreshGuard, skipWhenFreshlySeeded = false)
+    }
+
+    /**
      * EPIC #687 slice 2 (#717) test seam: deterministically reproduce the
      * SAME-DIMENSION resize short-circuit of [maybeRefreshControlClientSize] —
      * the production branch where a composer/keyboard dismissal after a
@@ -9769,6 +9816,15 @@ public class TmuxSessionViewModel @Inject constructor(
         refreshGuard: RuntimeRefreshGuard?,
         recordMilestone: Boolean,
         maxAttempts: Int = SEED_CAPTURE_EMPTY_RETRY_ATTEMPTS,
+        // Issue #989: when true, FORCE the app in the pane to repaint its full
+        // frame (`send-keys C-l`) BEFORE the first capture, then settle, so an
+        // idle alternate-screen agent (which never re-emits its existing frame on
+        // its own) hands tmux a fresh full grid to capture — instead of a near-
+        // blank one that the seed would clear the visible content to black with.
+        // Only the manual-Redraw / attach-reseed chokepoint
+        // ([reseedActivePaneForReattach]) sets this; the cold-open preload leaves
+        // it false to avoid paying the repaint round-trip on every fresh pane.
+        forceAgentRepaint: Boolean = false,
     ): Boolean {
         // Issue #830: publish "a seed for this pane is in flight" BEFORE the first
         // round-trip so a concurrent reseed net (the pager-settle
@@ -9777,6 +9833,24 @@ public class TmuxSessionViewModel @Inject constructor(
         // so the genuine #662 black-window heal still fires once no seed is pending.
         panesSeedInFlightThisAttach.add(pane.paneId)
         try {
+            // Issue #989: ask the app to repaint BEFORE we capture. `send-keys C-l`
+            // is geometry-stable (no window reflow, so it cannot momentarily strip
+            // the idle frame the way a `refresh-client -C` size-nudge can) and is
+            // honored by every well-behaved TUI. Best-effort: a failure here is
+            // harmless because the non-destructive swap in [seedPaneFromCaptureOnce]
+            // keeps the last frame if the subsequent capture is still near-blank.
+            val runtimeStillCurrent = refreshGuard == null || isCurrentRuntime(refreshGuard)
+            if (forceAgentRepaint && runtimeStillCurrent && !client.disconnected.value) {
+                runCatching {
+                    withContext(seedIoDispatcher) {
+                        client.forceFullRepaint(pane.paneId)
+                    }
+                }
+                // Give the app a beat to emit its fresh redraw before we capture.
+                // The runtime-guard re-check at the top of the loop aborts a
+                // superseded reseed even if this settle is mid-flight.
+                delay(FORCE_REPAINT_SETTLE_MS)
+            }
             var attempt = 0
             while (true) {
                 if (refreshGuard != null && !isCurrentRuntime(refreshGuard)) return false
@@ -9927,6 +10001,29 @@ public class TmuxSessionViewModel @Inject constructor(
         )
         if (refreshGuard != null && !isCurrentRuntime(refreshGuard)) return false
         if (captureResponse == null || captureResponse.isError || captureResponse.output.isEmpty()) {
+            return false
+        }
+        // Issue #989 — NON-DESTRUCTIVE swap. `toTerminalViewportBytes` prepends a
+        // `CSI 2J` clear, so painting an idle alt-screen agent's near-blank-but-
+        // non-empty capture would wipe the visible content to black (the #989
+        // Redraw-to-black / attach-stays-black symptom). The `isEmpty()` guard
+        // above only catches a TRULY empty capture; this catches the near-blank
+        // one. Refuse to paint a capture that would clear an existing content-rich
+        // frame — return false so the seed loop RE-CAPTURES (giving the forced
+        // `C-l` repaint more time to land); if no good frame ever arrives the last
+        // frame is simply KEPT (never cleared to black). A genuinely black pane's
+        // first real seed is unaffected: the guard only fires when the current
+        // render has materially MORE than the capture would restore.
+        val captureText = captureResponse.output.joinToString(separator = "\n")
+        if (pane.terminalState.captureWouldClearVisibleContent(captureText)) {
+            Log.i(
+                ISSUE_145_RECONNECT_TAG,
+                "tmux-seed-skip-near-blank-capture pane=${pane.paneId} " +
+                    "window=${pane.windowId} session=${activeTarget?.sessionName} " +
+                    "rendered=${pane.terminalState.renderedNonBlankCharCount()} " +
+                    "captureChars=${captureText.count { !it.isWhitespace() }} " +
+                    "(kept last frame — not cleared to black)",
+            )
             return false
         }
         // Issue #259/#640: the cursor reply arrived in the SAME single-flight
@@ -15964,6 +16061,25 @@ internal const val SEED_CAPTURE_EMPTY_RETRY_ATTEMPTS: Int = 4
  * without stalling a genuinely-empty pane's reveal.
  */
 internal const val SEED_CAPTURE_EMPTY_RETRY_DELAY_MS: Long = 120L
+
+/**
+ * Issue #989: how long [seedPaneFromCapture] waits after sending `send-keys C-l`
+ * (the forced full repaint) before it captures the pane, so the app has a beat to
+ * emit its fresh redraw and tmux's grid holds the real frame at capture time.
+ * Short — an explicit user Redraw / a within-grace reattach can absorb this — and
+ * the empty-capture retry loop covers a slower app, while the non-destructive
+ * swap keeps the last frame if the repaint never lands.
+ */
+internal const val FORCE_REPAINT_SETTLE_MS: Long = 120L
+
+/**
+ * Issue #989: the user-visible message shown when the manual Redraw kebab item is
+ * tapped but Redraw cannot act — there is no live tmux client (dropped /
+ * reconnecting), the client is disconnected, or there is no active target. Surfaced
+ * as a Toast so Redraw never silently no-ops (the maintainer's "I clicked it three
+ * times and nothing happened" report).
+ */
+internal const val REDRAW_UNAVAILABLE_MESSAGE: String = "Can't redraw — reconnecting…"
 
 /**
  * Issue #693/#661: the never-reveal-black guard polls the active (visible) pane

--- a/app/src/main/java/com/pocketshell/app/tmux/connection/ConnectionEffectDriver.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/connection/ConnectionEffectDriver.kt
@@ -181,6 +181,17 @@ class ConnectionEffectDriver(
     // `Up`/`TransportLive` feed is NEVER suppressed (a healthy re-`Connected` must
     // always promote the controller).
     private val suppressTransportDrops: () -> Boolean = { false },
+    // Issue #972: fired AFTER the current host's lease transport comes back `Up`
+    // (a reconnect promoted the controller to Live). This is the trigger that
+    // mirrors the recorded reconnect-cause trail to `~/.pocketshell/connection-log.jsonl`
+    // on the host over the now-warm lease, so the maintainer can ATTRIBUTE the
+    // just-completed drop in the in-app file viewer (no adb). The driver does the
+    // wiring only — the host write itself (and its fail-soft contract) lives in
+    // the VM-supplied effect ([ConnectionLogHostMirror]); a no-op default keeps the
+    // observe-only test harness unchanged. Fired on EVERY accepted `Up` for the
+    // current host (the reconnect edge); the VM's effect is fail-soft + cheap, and
+    // a blank trail is a no-op, so an extra fire never perturbs the connection.
+    private val onTransportReconnected: () -> Unit = {},
     private val sink: (String) -> Unit = { line -> Log.i(TAG, line) },
 ) {
     private val jobs = mutableListOf<Job>()
@@ -356,6 +367,12 @@ class ConnectionEffectDriver(
                 is TransportUpDown.Up ->
                     if (edge.host == controller.state.value.hostOrNull()) {
                         submitTransport(ConnectionEvent.TransportLive)
+                        // Issue #972: the transport is back warm for the current
+                        // host — mirror the recorded reconnect-cause trail to the
+                        // host log over THIS lease so the just-completed drop is
+                        // attributable in the file viewer. Fail-soft + a blank
+                        // trail no-ops, so this never perturbs the live connection.
+                        onTransportReconnected()
                     }
 
                 is TransportUpDown.Down ->

--- a/app/src/test/java/com/pocketshell/app/diagnostics/ConnectionLogHostMirrorTest.kt
+++ b/app/src/test/java/com/pocketshell/app/diagnostics/ConnectionLogHostMirrorTest.kt
@@ -1,0 +1,161 @@
+package com.pocketshell.app.diagnostics
+
+import com.pocketshell.app.sessions.LeaseSessionTarget
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.SshLeaseConnector
+import com.pocketshell.core.ssh.SshLeaseManager
+import com.pocketshell.core.ssh.SshLeaseTarget
+import com.pocketshell.core.ssh.SshPortForward
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshShell
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+import java.io.IOException
+import java.io.InputStream
+
+/**
+ * Issue #972 (wiring #969 part 3): the host connection-log mirror writer.
+ *
+ * Reproduce-first: these assert the host file `~/.pocketshell/connection-log.jsonl`
+ * is actually WRITTEN — the dead-method gap #972 closes (the writer existed
+ * untested-but-unwired; before this writer landed there was NO host file at all).
+ * They also pin the fail-soft contract (a mirror must never throw or close the
+ * live transport) and the warm-lease reuse (one handshake, not a fresh dial).
+ */
+class ConnectionLogHostMirrorTest {
+
+    private val jsonl =
+        """{"sequence":1,"category":"reconnect","name":"cause_trail","metadata":{"cause":"keepalive_dead"}}""" +
+            "\n" +
+            """{"sequence":2,"category":"reconnect","name":"cause_trail","metadata":{"stage":"lease_transport"}}"""
+
+    @Test
+    fun writesTheTrailToTheHostConnectionLogOverTheWarmLease() = runTest {
+        val session = RecordingSshSession()
+        val connector = CountingConnector(session)
+        val manager = SshLeaseManager(connector = connector, scope = this, idleTtlMillis = 30_000L)
+
+        val result = ConnectionLogHostMirror.mirror(manager, TARGET, jsonl)
+
+        // The host file was produced (the #972 acceptance: the maintainer can open it).
+        assertTrue("mirror must succeed", result.isSuccess)
+        assertEquals(ConnectionLogHostMirror.REMOTE_PATH, result.getOrNull())
+        assertEquals(".pocketshell/connection-log.jsonl", ConnectionLogHostMirror.REMOTE_PATH)
+        // mkdir -p ran for the diagnostics dir.
+        assertTrue(
+            "must mkdir -p ~/.pocketshell",
+            session.execCommands.any { it.contains("mkdir -p") && it.contains(".pocketshell") },
+        )
+        // The uploaded payload is EXACTLY the reconnect trail JSONL (incl. keepalive_dead).
+        assertEquals(jsonl, session.uploadedText())
+        assertEquals(ConnectionLogHostMirror.REMOTE_FILENAME, session.uploadedName)
+        assertEquals(ConnectionLogHostMirror.REMOTE_PATH, session.uploadedRemotePath)
+        // Warm-lease reuse: ONE handshake, and the transport stays open (never closed).
+        assertEquals(1, connector.connectCount)
+        assertFalse("warm transport must stay open after the mirror", session.closed)
+    }
+
+    @Test
+    fun blankTrailIsANoOpAndNeverDialsTheHost() = runTest {
+        val session = RecordingSshSession()
+        val connector = CountingConnector(session)
+        val manager = SshLeaseManager(connector = connector, scope = this, idleTtlMillis = 30_000L)
+
+        val result = ConnectionLogHostMirror.mirror(manager, TARGET, jsonl = "   ")
+
+        assertTrue("blank trail is a no-op success", result.isSuccess)
+        assertNull("no remote path for a no-op", result.getOrNull())
+        assertEquals("a blank trail must not even dial the host", 0, connector.connectCount)
+        assertTrue(session.execCommands.isEmpty())
+    }
+
+    @Test
+    fun mkdirFailureIsFailSoftAndDoesNotThrowOrCloseTheTransport() = runTest {
+        // mkdir denied (e.g. read-only home) — the mirror must FAIL-SOFT.
+        val session = RecordingSshSession(
+            execResult = { cmd ->
+                if (cmd.contains("mkdir")) ExecResult("", "Permission denied", 1) else ExecResult("", "", 0)
+            },
+        )
+        val connector = CountingConnector(session)
+        val manager = SshLeaseManager(connector = connector, scope = this, idleTtlMillis = 30_000L)
+
+        val result = ConnectionLogHostMirror.mirror(manager, TARGET, jsonl)
+
+        assertTrue("a host-write error must be a fail-soft Result.failure", result.isFailure)
+        // The upload must NOT have run after the mkdir failed.
+        assertNull("no upload after mkdir failure", session.uploadedName)
+        // FAIL-SOFT hard contract: the warm transport is NOT closed by a write failure.
+        assertFalse("a mirror failure must never close the live transport", session.closed)
+    }
+
+    @Test
+    fun uploadFailureIsFailSoftAndDoesNotThrowOrCloseTheTransport() = runTest {
+        val session = RecordingSshSession(failUpload = true)
+        val connector = CountingConnector(session)
+        val manager = SshLeaseManager(connector = connector, scope = this, idleTtlMillis = 30_000L)
+
+        val result = ConnectionLogHostMirror.mirror(manager, TARGET, jsonl)
+
+        assertTrue("an upload error must be a fail-soft Result.failure", result.isFailure)
+        assertFalse("a mirror failure must never close the live transport", session.closed)
+    }
+
+    private class CountingConnector(private val session: RecordingSshSession) : SshLeaseConnector {
+        var connectCount: Int = 0
+        override suspend fun connect(target: SshLeaseTarget): Result<SshSession> {
+            connectCount += 1
+            return Result.success(session)
+        }
+    }
+
+    private class RecordingSshSession(
+        private val execResult: (String) -> ExecResult = { ExecResult("", "", 0) },
+        private val failUpload: Boolean = false,
+    ) : SshSession {
+        val execCommands: MutableList<String> = mutableListOf()
+        private var uploadedBytes: ByteArray? = null
+        var uploadedName: String? = null
+        var uploadedRemotePath: String? = null
+        var closed: Boolean = false
+
+        fun uploadedText(): String? = uploadedBytes?.toString(Charsets.UTF_8)
+
+        override val isConnected: Boolean get() = !closed
+        override suspend fun exec(command: String): ExecResult {
+            execCommands += command
+            return execResult(command)
+        }
+        override fun tail(path: String, onLine: (String) -> Unit) = error("not used")
+        override fun openLocalPortForward(remoteHost: String, remotePort: Int, localPort: Int): SshPortForward =
+            error("not used")
+        override fun startShell(): SshShell = error("not used")
+        override suspend fun uploadFile(file: File, remotePath: String): String = error("not used")
+        override suspend fun uploadStream(input: InputStream, length: Long, name: String, remotePath: String): String {
+            if (failUpload) throw IOException("scp upload failed")
+            uploadedBytes = input.readBytes()
+            uploadedName = name
+            uploadedRemotePath = remotePath
+            return remotePath
+        }
+        override fun close() {
+            closed = true
+        }
+    }
+
+    private companion object {
+        val TARGET = LeaseSessionTarget(
+            hostId = 7L,
+            hostname = "10.0.2.2",
+            port = 2222,
+            username = "testuser",
+            keyPath = "/tmp/pocketshell-test-key",
+            passphrase = null,
+        )
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/diagnostics/DiagnosticRecorderTest.kt
+++ b/app/src/test/java/com/pocketshell/app/diagnostics/DiagnosticRecorderTest.kt
@@ -30,6 +30,9 @@ class DiagnosticRecorderTest {
         File(context.filesDir, "diagnostics").deleteRecursively()
         File(context.cacheDir, DIAGNOSTICS_EXPORT_CACHE_DIR).deleteRecursively()
         settingsRepository = SettingsRepository(context)
+        // Reset the process-global diagnostics sink so a prior test's installed
+        // recorder never leaks reconnect-cause events into this one.
+        DiagnosticEvents.install(DiagnosticEventSink.Noop)
     }
 
     @Test
@@ -49,6 +52,47 @@ class DiagnosticRecorderTest {
 
         assertNotNull(recorder.exportSnapshot())
         assertEquals(1, recorder.readEvents().size)
+    }
+
+    @Test
+    fun `connectionLogJsonl renders only the reconnect-cause trail as jsonl`() = runTest {
+        // Issue #972: the payload the host mirror writes to
+        // ~/.pocketshell/connection-log.jsonl. It must carry the reconnect-cause
+        // breadcrumbs (incl. the named keepalive_dead cause) and NOTHING ELSE
+        // (other diagnostics categories are filtered out), one JSON object per line.
+        val recorder = DiagnosticRecorder(context, settingsRepository)
+        // The reconnect-cause breadcrumbs route through the globally-installed
+        // sink (ReconnectCauseTrail.record -> DiagnosticEvents -> this recorder).
+        DiagnosticEvents.install(recorder)
+        // Unrelated diagnostics noise that must NOT leak into the connection log.
+        recorder.record("connection", "connect_start", mapOf("host" to "dev"))
+        // The reconnect-cause breadcrumbs (what ReconnectCauseTrail records).
+        ReconnectCauseTrail.record(stage = "lease_transport", outcome = "down", cause = "keepalive_dead")
+        ReconnectCauseTrail.record(stage = "tmux_probe", outcome = "ok")
+
+        val jsonl = recorder.connectionLogJsonl()
+
+        val lines = jsonl.split("\n").filter { it.isNotBlank() }
+        assertEquals("only the two reconnect-cause events, not the connect_start", 2, lines.size)
+        lines.forEach { line ->
+            val obj = JSONObject(line)
+            assertEquals(ReconnectCauseTrail.CATEGORY, obj.getString("category"))
+            assertEquals(ReconnectCauseTrail.NAME, obj.getString("name"))
+        }
+        assertTrue(
+            "the named keepalive_dead cause must be carried to the host log",
+            jsonl.contains("keepalive_dead"),
+        )
+    }
+
+    @Test
+    fun `connectionLogJsonl is blank when no reconnect cause recorded`() = runTest {
+        // The mirror treats a blank payload as a no-op (never writes an empty host
+        // file), so a fresh session with no reconnect must produce a blank string.
+        val recorder = DiagnosticRecorder(context, settingsRepository)
+        recorder.record("connection", "connect_start", mapOf("host" to "dev"))
+
+        assertEquals("", recorder.connectionLogJsonl())
     }
 
     @Test

--- a/app/src/test/java/com/pocketshell/app/tmux/RedrawNonDestructiveReseedTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/RedrawNonDestructiveReseedTest.kt
@@ -1,0 +1,462 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.app.sessions.ActiveTmuxClients
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.SshLeaseConnector
+import com.pocketshell.core.ssh.SshLeaseManager
+import com.pocketshell.core.ssh.SshLeaseTarget
+import com.pocketshell.core.ssh.SshPortForward
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshShell
+import com.pocketshell.core.terminal.bridge.SshTerminalBridge
+import com.pocketshell.core.terminal.ui.TerminalSurfaceState
+import com.pocketshell.core.tmux.CommandResponse
+import com.pocketshell.core.tmux.TmuxClientFactory
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+import java.io.InputStream
+
+/**
+ * Issue #989 — REPRODUCE-FIRST (D33/G10) JVM proof that the manual Redraw and the
+ * attach/within-grace reseed NEVER clear a content-rich pane to black, and that
+ * Redraw FORCES the app to repaint (`send-keys C-l`) before capturing.
+ *
+ * The bug (confirmed in the spike): both Redraw and re-attach funnel through
+ * `reseedActivePaneForReattach -> seedPaneFromCapture -> seedPaneFromCaptureOnce
+ * -> appendRemoteOutput(toTerminalViewportBytes(...))`. `toTerminalViewportBytes`
+ * unconditionally prepends `CSI 2J` (clear) before painting the captured lines.
+ * For an IDLE alternate-screen agent (Claude/Codex) `capture-pane` returns a
+ * near-blank-but-NON-EMPTY grid (whitespace rows + a stray fragment) — it passes
+ * the `output.isEmpty()` guard and is painted, so the clear wipes the prior full
+ * frame and the near-blank capture replaces it. Net = black-with-a-fragment (the
+ * maintainer's #989 screenshot).
+ *
+ * The fix (all at the shared chokepoint, so Redraw AND attach/return both
+ * benefit):
+ *   1. FORCE the agent to repaint first (`send-keys C-l`) before capture.
+ *   2. NON-DESTRUCTIVE swap: refuse to paint a near-blank capture that would clear
+ *      an existing content-rich frame ([captureWouldClearVisibleContent]); keep
+ *      the last frame until a materially-non-blank capture arrives.
+ *   3. Feedback (Toast) when Redraw can't act (no client / disconnected / no
+ *      target) instead of a silent no-op (the original #989 report).
+ *
+ * RED on base (the assertions that fail without the fix):
+ *   - [redrawDoesNotClearContentRichPaneToBlackForIdleAltScreenAgent]:
+ *     after Redraw the pane keeps its content (rendered chars stay high) — on base
+ *     the near-blank capture clears it to ~0.
+ *   - same test asserts `send-keys C-l` was sent before the final capture — on base
+ *     Redraw never forces a repaint.
+ *   - [reattachDoesNotClearContentRichPaneToBlackForIdleAltScreenAgent]: the
+ *     attach/return reseed shares the chokepoint, so it inherits the same RED→GREEN.
+ *   - [redrawWithNoLiveClientSurfacesFeedbackInsteadOfSilentNoOp]: a no-client
+ *     Redraw emits the feedback message — on base it silently returns.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class RedrawNonDestructiveReseedTest {
+
+    private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val createdVms = mutableListOf<TmuxSessionViewModel>()
+
+    @After
+    fun tearDown() {
+        factoryScope.cancel()
+    }
+
+    private fun runVmTest(body: suspend TestScope.() -> Unit) = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        com.pocketshell.app.tmux.LivenessProbeTestOverride.setAutoStartEnabledForTest(false)
+        try {
+            body()
+        } finally {
+            for (vm in createdVms) {
+                runCatching { vm.setProcessForegroundForClearedForTest(false) }
+                runCatching { vm.clearForTest() }
+            }
+            advanceUntilIdle()
+            createdVms.clear()
+            com.pocketshell.app.tmux.LivenessProbeTestOverride.clear()
+            Dispatchers.resetMain()
+        }
+    }
+
+    private fun TestScope.newVm(
+        registry: ActiveTmuxClients,
+        sshLeaseManager: SshLeaseManager,
+    ): TmuxSessionViewModel = TmuxSessionViewModel(
+        tmuxClientFactory = TmuxClientFactory(factoryScope),
+        activeTmuxClients = registry,
+        runtimeCache = TmuxSessionRuntimeCache(),
+        sshLeaseManager = sshLeaseManager,
+        sessionLifecycleSignals = null,
+    ).also {
+        it.setSeedIoDispatcherForTest(StandardTestDispatcher(testScheduler))
+        createdVms.add(it)
+    }
+
+    /**
+     * Connect a single-pane session whose attach-time capture paints a CONTENT-RICH
+     * frame (a full idle Claude alt-screen), so the pane is genuinely non-blank
+     * (well above the non-destructive-swap render floor) before the Redraw / reseed
+     * under test. Returns the VM with its active pane painted.
+     */
+    private fun TestScope.connectVmWithRichFrame(client: FakeTmuxClient): TmuxSessionViewModel {
+        val live = AlwaysConnectedSession(id = "live")
+        val connector = SingleSessionConnector(live)
+        val leaseManager =
+            testLeaseManager(connector = connector, scope = this, idleTtlMillis = 60_000L)
+        val registry = ActiveTmuxClients()
+        val vm = newVm(registry = registry, sshLeaseManager = leaseManager)
+        runCurrent()
+        // Isolate the Redraw / reseed under test: silence the connect()-auto-armed
+        // blank + stale-render watchdogs so the only capture-pane traffic is the one
+        // the Redraw / reattach issues (they would otherwise add their own captures).
+        vm.setConnectedBlankWatchdogAutoArmEnabledForTest(false)
+        vm.setStaleRenderWatchdogAutoArmEnabledForTest(false)
+        vm.setTmuxClientFactoryForTest { _, _, _ -> client }
+        vm.connect(
+            hostId = 1L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            passphrase = null,
+            sessionName = "work",
+        )
+        advanceUntilIdle()
+        return vm
+    }
+
+    /**
+     * A full idle alt-screen agent frame — many populated rows, hundreds of
+     * non-blank chars, so the pane is content-rich (NOT near-blank) before the
+     * Redraw / reseed under test.
+     */
+    private val contentRichFrame: List<String> = buildList {
+        add("╭──────────────────────────────────────────────╮")
+        add("│  Claude Code  •  idle                          │")
+        add("├──────────────────────────────────────────────┤")
+        repeat(10) { i -> add("│  context line $i — real rendered content here  │") }
+        add("│  > waiting for your next message…              │")
+        add("╰──────────────────────────────────────────────╯")
+    }
+
+    /**
+     * The idle alt-screen capture the maintainer's pane returns: whitespace rows
+     * plus ONE stray status fragment. Non-empty (passes the `isEmpty()` guard) but
+     * materially blank — painting it with the leading `CSI 2J` clears the rich
+     * frame to black-with-a-fragment. This is the #989 capture.
+     */
+    private val nearBlankCapture: List<String> = buildList {
+        repeat(13) { add("") }
+        add("3")
+    }
+
+    private fun FakeTmuxClient.withRichInitialFrame(
+        sessionName: String,
+        paneId: String,
+    ): FakeTmuxClient = apply {
+        responses.addLast(
+            CommandResponse(
+                number = 1L,
+                output = listOf("$paneId\t@0\t\$0\t$sessionName\t$sessionName\t0"),
+                isError = false,
+            ),
+        )
+        // The attach seed paints the content-rich frame.
+        capturePaneResponses.addLast(
+            CommandResponse(number = 2L, output = contentRichFrame, isError = false),
+        )
+        cursorQueryResponses.addLast(
+            CommandResponse(number = 3L, output = listOf("0,0"), isError = false),
+        )
+    }
+
+    // -----------------------------------------------------------------------
+    // (1) Manual Redraw — must NOT clear a content-rich pane to black, and must
+    //     FORCE a repaint (`send-keys C-l`) before capturing.
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun redrawDoesNotClearContentRichPaneToBlackForIdleAltScreenAgent() = runVmTest {
+        val client = FakeTmuxClient().withRichInitialFrame("work", "%1")
+        val vm = connectVmWithRichFrame(client)
+        val pane = vm.panes.value.single { it.paneId == "%1" }
+        val renderedBefore = pane.terminalState.renderedNonBlankCharCount()
+        assertTrue(
+            "precondition: the idle agent pane is content-rich before Redraw " +
+                "(rendered=$renderedBefore)",
+            renderedBefore > 100,
+        )
+        assertFalse(pane.terminalState.visibleScreenIsBlank())
+
+        // The idle agent does NOT re-emit its frame on its own, so the next
+        // `capture-pane` returns the near-blank grid. WITHOUT the fix, Redraw paints
+        // it (after a `CSI 2J` clear) and wipes the pane to black-with-a-fragment.
+        client.capturePaneResponses.addLast(
+            CommandResponse(number = 9L, output = nearBlankCapture, isError = false),
+        )
+        val sentBefore = client.sentCommands.size
+
+        vm.redrawActivePane()
+        advanceUntilIdle()
+
+        // FIX part 1: Redraw FORCED a repaint before it captured.
+        val sentDuringRedraw = client.sentCommands.drop(sentBefore)
+        val forceRepaintIndex = sentDuringRedraw.indexOfFirst {
+            it.startsWith("send-keys C-l -t %1")
+        }
+        assertTrue(
+            "Redraw must send `send-keys C-l -t %1` to FORCE the app to repaint " +
+                "(sent during redraw: $sentDuringRedraw)",
+            forceRepaintIndex >= 0,
+        )
+        val firstCaptureIndex = sentDuringRedraw.indexOfFirst { it.startsWith("capture-pane") }
+        assertTrue(
+            "the forced repaint must be sent BEFORE the capture, not after " +
+                "(C-l@$forceRepaintIndex capture@$firstCaptureIndex)",
+            firstCaptureIndex < 0 || forceRepaintIndex < firstCaptureIndex,
+        )
+
+        // FIX part 2 (the load-bearing assertion): the pane was NOT cleared to black.
+        // The near-blank capture was REFUSED (non-destructive swap kept the last
+        // frame). On base the rich frame collapses to ~1 char (the stray fragment).
+        val renderedAfter = pane.terminalState.renderedNonBlankCharCount()
+        assertTrue(
+            "Redraw must NOT clear the content-rich pane to black — the last frame " +
+                "must be kept when the capture is near-blank " +
+                "(rendered before=$renderedBefore after=$renderedAfter)",
+            renderedAfter > 100,
+        )
+        assertFalse(
+            "the pane must NOT be blank after Redraw",
+            pane.terminalState.visibleScreenIsBlank(),
+        )
+        assertTrue(
+            "the original rendered content must still be on the grid after Redraw",
+            renderedTranscriptFor(pane).contains("context line 5"),
+        )
+    }
+
+    @Test
+    fun redrawRestoresTheRealFrameWhenTheForcedRepaintLands() = runVmTest {
+        // The full recovery path: the forced `C-l` makes the idle agent re-emit its
+        // frame, so the NEXT capture is content-rich and the pane is restored from
+        // (a possibly-degraded) state back to the real content.
+        val client = FakeTmuxClient().withRichInitialFrame("work", "%1")
+        val vm = connectVmWithRichFrame(client)
+        val pane = vm.panes.value.single { it.paneId == "%1" }
+        assertFalse(pane.terminalState.visibleScreenIsBlank())
+
+        // First capture (immediately after C-l, agent slow) is near-blank → REFUSED;
+        // the retry capture (agent has now honored C-l) carries the recovered frame.
+        client.capturePaneResponses.addLast(
+            CommandResponse(number = 9L, output = nearBlankCapture, isError = false),
+        )
+        client.capturePaneResponses.addLast(
+            CommandResponse(
+                number = 10L,
+                output = contentRichFrame.map { it.replace("idle", "REDRAW-RECOVERED") },
+                isError = false,
+            ),
+        )
+
+        vm.redrawActivePane()
+        advanceUntilIdle()
+
+        assertFalse(pane.terminalState.visibleScreenIsBlank())
+        assertTrue(
+            "the recovered real frame must be restored after the forced repaint lands",
+            renderedTranscriptFor(pane).contains("REDRAW-RECOVERED"),
+        )
+    }
+
+    // -----------------------------------------------------------------------
+    // (2) Attach / within-grace return reseed — SAME chokepoint, SAME guarantee.
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun reattachDoesNotClearContentRichPaneToBlackForIdleAltScreenAgent() = runVmTest {
+        val client = FakeTmuxClient().withRichInitialFrame("work", "%1")
+        val vm = connectVmWithRichFrame(client)
+        val pane = vm.panes.value.single { it.paneId == "%1" }
+        val renderedBefore = pane.terminalState.renderedNonBlankCharCount()
+        assertTrue(renderedBefore > 100)
+
+        // The within-grace reattach reseed (the same path Redraw uses) re-captures
+        // the active pane; for an idle agent it comes back near-blank.
+        client.capturePaneResponses.addLast(
+            CommandResponse(number = 9L, output = nearBlankCapture, isError = false),
+        )
+        val sentBefore = client.sentCommands.size
+
+        vm.reseedActivePaneForReattachForTest(vm.currentRuntimeGuardForTest())
+        advanceUntilIdle()
+
+        val sentDuring = client.sentCommands.drop(sentBefore)
+        assertTrue(
+            "the attach/return reseed must FORCE a repaint too (sent: $sentDuring)",
+            sentDuring.any { it.startsWith("send-keys C-l -t %1") },
+        )
+        val renderedAfter = pane.terminalState.renderedNonBlankCharCount()
+        assertTrue(
+            "the attach/return reseed must NOT clear the content-rich pane to black " +
+                "(before=$renderedBefore after=$renderedAfter)",
+            renderedAfter > 100,
+        )
+        assertFalse(pane.terminalState.visibleScreenIsBlank())
+    }
+
+    // -----------------------------------------------------------------------
+    // (3) Redraw feedback — no live client / disconnected / no target must give
+    //     user-visible feedback instead of a silent no-op.
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun redrawWithNoLiveClientSurfacesFeedbackInsteadOfSilentNoOp() = runVmTest {
+        // A VM with NO connection — `clientRef` is null. Before #989 Redraw logged
+        // and returned silently; now it must emit a user-visible feedback message.
+        val live = AlwaysConnectedSession(id = "live")
+        val connector = SingleSessionConnector(live)
+        val leaseManager =
+            testLeaseManager(connector = connector, scope = this, idleTtlMillis = 60_000L)
+        val registry = ActiveTmuxClients()
+        val vm = newVm(registry = registry, sshLeaseManager = leaseManager)
+        runCurrent()
+
+        val feedback = mutableListOf<String>()
+        val collectorJob = launch(StandardTestDispatcher(testScheduler)) {
+            vm.redrawFeedback.collect { feedback.add(it) }
+        }
+        runCurrent()
+
+        vm.redrawActivePane()
+        advanceUntilIdle()
+
+        assertTrue(
+            "Redraw with no live client must surface a user-visible message, not a " +
+                "silent no-op (feedback=$feedback)",
+            feedback.isNotEmpty(),
+        )
+        assertTrue(
+            "the feedback must tell the user Redraw can't act (reconnecting) " +
+                "(feedback=$feedback)",
+            feedback.any { it.contains("redraw", ignoreCase = true) },
+        )
+        collectorJob.cancel()
+    }
+
+    @Test
+    fun redrawWithDisconnectedClientSurfacesFeedback() = runVmTest {
+        // Class coverage: the disconnected-client branch (a dropped link mid-session)
+        // must give feedback too, not just the no-client branch.
+        val client = FakeTmuxClient().withRichInitialFrame("work", "%1")
+        val vm = connectVmWithRichFrame(client)
+
+        val feedback = mutableListOf<String>()
+        val collectorJob = launch(StandardTestDispatcher(testScheduler)) {
+            vm.redrawFeedback.collect { feedback.add(it) }
+        }
+        runCurrent()
+
+        // Drop the link the way a real disconnect does.
+        client.markDisconnectedForTest(
+            com.pocketshell.core.tmux.TmuxDisconnectEvent(
+                reason = com.pocketshell.core.tmux.TmuxDisconnectReason.ExplicitClose,
+                source = "test_redraw_disconnected",
+                intent = "characterization",
+            ),
+        )
+        runCurrent()
+
+        vm.redrawActivePane()
+        advanceUntilIdle()
+
+        assertTrue(
+            "Redraw on a disconnected client must surface feedback (feedback=$feedback)",
+            feedback.any { it.contains("redraw", ignoreCase = true) },
+        )
+        collectorJob.cancel()
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private fun renderedTranscriptFor(pane: TmuxPaneState): String {
+        val state = pane.terminalState
+        val bridgeField = TerminalSurfaceState::class.java.getDeclaredField("bridge").apply {
+            isAccessible = true
+        }
+        val bridge = bridgeField.get(state) as? SshTerminalBridge ?: return ""
+        return bridge.emulator.screen.transcriptText
+    }
+
+    private class SingleSessionConnector(
+        private val session: SshSession,
+    ) : SshLeaseConnector {
+        override suspend fun connect(target: SshLeaseTarget): Result<SshSession> =
+            Result.success(session)
+    }
+
+    private class AlwaysConnectedSession(
+        val id: String,
+    ) : SshSession {
+        @Volatile
+        var closed: Boolean = false
+
+        override val isConnected: Boolean get() = !closed
+
+        override suspend fun exec(command: String): ExecResult =
+            ExecResult(stdout = "", stderr = "", exitCode = 0)
+
+        override fun tail(path: String, onLine: (String) -> Unit): Job =
+            Job().apply { complete() }
+
+        override fun tail(path: String, fromLineExclusive: Long, onLine: (String) -> Unit): Job =
+            Job().apply { complete() }
+
+        override fun openLocalPortForward(
+            remoteHost: String,
+            remotePort: Int,
+            localPort: Int,
+        ): SshPortForward = error("not used")
+
+        override fun startShell(): SshShell = error("not used")
+
+        override suspend fun uploadFile(file: File, remotePath: String): String = error("not used")
+
+        override suspend fun uploadStream(
+            input: InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String = error("not used")
+
+        override fun close() {
+            closed = true
+        }
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
@@ -163,7 +163,19 @@ class TmuxSessionViewModelTest {
         hostDao: HostDao? = null,
         agentRepository: AgentConversationRepository = AgentConversationRepository(),
         agentKindRemoteSource: com.pocketshell.app.agents.AgentKindRemoteSource =
-            com.pocketshell.app.agents.AgentKindRemoteSource(),
+            // Issue #1001 (CI-flake fix): pin the daemon-RPC bounded-exec
+            // dispatcher to the SHARED virtual-clock scheduler. In production it
+            // is `Dispatchers.IO` (a real background thread, so the wedge-prone
+            // SSH read never parks a caller). Under `runTest(scheduler)` that real
+            // thread races the test scheduler: `runCurrent()` returns before the
+            // off-thread `classify` exec completes, so the foreign-detection
+            // chain's `detection != null` assertion sometimes observed a not-yet-
+            // resolved bind (the b1Masked* ~1/3 release-variant flake). Confining
+            // the exec to a `StandardTestDispatcher` on the shared scheduler makes
+            // `runCurrent()` await the bind deterministically.
+            com.pocketshell.app.agents.AgentKindRemoteSource().apply {
+                setExecDispatcherForTest(StandardTestDispatcher(scheduler))
+            },
     ): TmuxSessionViewModel =
         TmuxSessionViewModel(
             tmuxClientFactory = TmuxClientFactory(factoryScope),
@@ -8377,24 +8389,38 @@ class TmuxSessionViewModelTest {
         runCurrent()
 
         // Simulate the one-shot guess having cached "no agent" before the agent
-        // launched (the stale guess the dedup bug never re-evaluated).
+        // launched (the stale guess the dedup bug never re-evaluated). Re-seeding
+        // the cache after the connect-path probe models the stale verdict the
+        // dedup bug never re-evaluated; capture the daemon round-trip count as a
+        // baseline so we can prove the re-probe forces a FRESH query past it.
         vm.seedForeignGuessCacheForTest("$0")
         assertTrue(
             "#975 (B1′): precondition — the stale one-shot guess is cached",
             vm.foreignGuessIsCachedForTest("$0"),
         )
+        val classifyCountBeforeReProbe = session.classifyExecCount
 
         // A re-probe of the confirmed-shell pane (same unchanged input) must BUST
         // the cache BEFORE the dedup early-return, so the daemon re-evaluates.
+        // Issue #1001: with the detection exec now confined to the shared test
+        // scheduler, `runCurrent()` deterministically drains the re-probe job to
+        // completion — including the FRESH daemon classify the bust enabled. The
+        // load-bearing proof of the B1′ fix is therefore that the cache-bust
+        // forced a NEW daemon round-trip (classifyExecCount incremented past the
+        // baseline), not that the cache stays empty (which only ever held because
+        // the race left the re-probe unfinished — exactly the #1001 flake this
+        // change removes).
         vm.startAgentDetectionForPaneForTest("%0")
         runCurrent()
 
-        assertFalse(
+        assertEquals(
             "#975 (B1′): re-probing a confirmed-shell pane busts the stale foreign " +
-                "guess cache (the cache-bust now precedes the dedup early-return) — " +
-                "RED on base where the early-return skipped the bust and the stale " +
-                "guess persisted",
-            vm.foreignGuessIsCachedForTest("$0"),
+                "guess cache BEFORE the dedup early-return, so the daemon is " +
+                "re-queried exactly once more — RED on base where the early-return " +
+                "skipped the bust and the stale seeded guess suppressed any " +
+                "re-evaluation (the daemon round-trip count stayed at the baseline)",
+            classifyCountBeforeReProbe + 1,
+            session.classifyExecCount,
         )
     }
 
@@ -15908,12 +15934,20 @@ class TmuxSessionViewModelTest {
     ) : SshSession {
         override val isConnected: Boolean = true
 
+        // Issue #1001: count `agents kind` daemon classify round-trips so the B1′
+        // dedup-ordering test can assert the cache-bust forced a FRESH daemon
+        // re-evaluation deterministically — instead of relying on the (now-fixed)
+        // race that left the re-probe unfinished when `runCurrent()` returned.
+        var classifyExecCount: Int = 0
+            private set
+
         override suspend fun exec(command: String): ExecResult {
             val stdout = when {
                 // The host-side `pocketshell agents kind` daemon classify. The
                 // request pipes a `{"panes":[{"pane_id":"%N", ...}]}` snapshot; we
                 // echo each requested pane id back with [classifyAgentKind].
                 command.contains("agents kind") -> {
+                    classifyExecCount++
                     val paneIds = PANE_ID_RE.findAll(command).map { it.groupValues[1] }.toList()
                     buildString {
                         append("{\"results\":[")

--- a/app/src/test/java/com/pocketshell/app/tmux/connection/ConnectionEffectDriverConnectionLogMirrorTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/connection/ConnectionEffectDriverConnectionLogMirrorTest.kt
@@ -1,0 +1,107 @@
+package com.pocketshell.app.tmux.connection
+
+import com.pocketshell.core.connection.Clock
+import com.pocketshell.core.connection.ConnectionController
+import com.pocketshell.core.connection.ConnectionEvent
+import com.pocketshell.core.connection.HostKey
+import com.pocketshell.core.connection.LeaseHandle
+import com.pocketshell.core.connection.Seed
+import com.pocketshell.core.connection.SessionId
+import com.pocketshell.core.connection.TmuxPort
+import com.pocketshell.core.connection.TransportPort
+import com.pocketshell.core.connection.TransportUpDown
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Issue #972 — the host connection-log mirror TRIGGER wiring.
+ *
+ * The #969 part-3 writer ([com.pocketshell.app.diagnostics.ConnectionLogHostMirror])
+ * shipped tested-but-UNWIRED (a dead method), so the on-device
+ * `~/.pocketshell/connection-log.jsonl` was never produced. This pins the wiring
+ * that closes that gap: the driver fires `onTransportReconnected` EXACTLY on an
+ * accepted lease `Up` edge for the CURRENT host (the reconnect-completed edge),
+ * and NEVER for a foreign host nor on a `Down`.
+ *
+ * Reproduce-first: on BASE (no `onTransportReconnected` callback wired into the
+ * driver's `Up` branch) the fire count below stays 0 — red. With the wiring it
+ * fires once per accepted current-host `Up` — green.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ConnectionEffectDriverConnectionLogMirrorTest {
+
+    private class TestClock(var now: Long = 0L) : Clock {
+        override fun nowMs(): Long = now
+    }
+
+    private val host = HostKey("alice@example.com:22/7")
+    private val otherHost = HostKey("bob@elsewhere.example:22/9")
+    private val sessionA = SessionId("7/main")
+
+    private class InertTmuxPort : TmuxPort {
+        val disconnectedFlow = MutableSharedFlow<Boolean>(extraBufferCapacity = 16)
+        override val disconnected: Flow<Boolean> = disconnectedFlow
+        override suspend fun attach(targetId: SessionId) = fail("attach")
+        override suspend fun selectWindow(targetId: SessionId) = fail("selectWindow")
+        override suspend fun seedActivePane(targetId: SessionId): Seed = fail("seedActivePane")
+        override suspend fun detachCleanly() = fail("detachCleanly")
+        private fun fail(method: String): Nothing =
+            throw AssertionError("inert driver must NOT call TmuxPort.$method")
+    }
+
+    private class InertTransportPort(private val warm: Boolean) : TransportPort {
+        val transportEventsFlow = MutableSharedFlow<TransportUpDown>(extraBufferCapacity = 16)
+        override val transportEvents: Flow<TransportUpDown> = transportEventsFlow
+        override fun isWarm(host: HostKey): Boolean = warm
+        override suspend fun ensureLease(host: HostKey): LeaseHandle = fail("ensureLease")
+        override suspend fun evictStale(host: HostKey) = fail("evictStale")
+        private fun fail(method: String): Nothing =
+            throw AssertionError("inert driver must NOT call TransportPort.$method")
+    }
+
+    @Test
+    fun firesTheMirrorTriggerOnAReconnectedCurrentHostUpEdge() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val tmuxPort = InertTmuxPort()
+        // Cold so the enter parks at Connecting and a real lease Up (the reconnect
+        // edge) is what promotes it.
+        val transportPort = InertTransportPort(warm = false)
+        val controller = ConnectionController(clock = TestClock(), transport = transportPort)
+        var mirrorFires = 0
+        val driver = ConnectionEffectDriver(
+            controller = controller,
+            tmuxPort = tmuxPort,
+            transportPort = transportPort,
+            scope = scope,
+            onTransportReconnected = { mirrorFires += 1 },
+        ).also { it.start() }
+
+        controller.submit(ConnectionEvent.Enter(host, sessionA))
+
+        // A foreign-host Up must NOT fire the mirror (host filter).
+        transportPort.transportEventsFlow.emit(TransportUpDown.Up(otherHost))
+        assertEquals("a foreign-host Up must not mirror", 0, mirrorFires)
+
+        // A Down for the current host must NOT fire the mirror (only Up does).
+        transportPort.transportEventsFlow.emit(TransportUpDown.Down(host, reason = "closed"))
+        assertEquals("a Down edge must not mirror", 0, mirrorFires)
+
+        // The current-host Up (reconnect completed) fires the mirror exactly once.
+        transportPort.transportEventsFlow.emit(TransportUpDown.Up(host))
+        assertEquals("the current-host reconnect Up must mirror once", 1, mirrorFires)
+
+        // A second reconnect cycle fires it again (it is the per-reconnect trigger).
+        transportPort.transportEventsFlow.emit(TransportUpDown.Down(host, reason = "closed"))
+        transportPort.transportEventsFlow.emit(TransportUpDown.Up(host))
+        assertEquals("each reconnect Up re-mirrors", 2, mirrorFires)
+
+        scope.cancel()
+    }
+}

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -374,6 +374,19 @@ JOURNEY_CLASSES=(
   # Uses ONLY the deterministic agents:2222 fixture (the black state is injected LOCALLY
   # on the emulator, no toxiproxy) and does NOT self-skip on CI, so it belongs here.
   "$FQCN_PREFIX.RedrawFullViewportReseedJourneyE2eTest"
+  # ADDED (#989 — Redraw must NEVER clear-to-black on a NEAR-BLANK remote capture): the
+  # #892 sibling above wipes the LOCAL emulator while the REMOTE tmux grid still holds the
+  # full banner, so its capture-pane returns CONTENT-RICH — it never exercises the #989 root
+  # cause, an IDLE alt-screen agent whose REMOTE grid is itself near-blank. This journey
+  # seeds a genuinely idle near-blank REMOTE pane, feeds a RICH banner LOCALLY (local=rich,
+  # remote=near-blank — the idle-agent mismatch), then TAPS Redraw so the warm capture-pane
+  # comes back near-blank. RED on base (the near-blank capture is painted after a `CSI 2J`
+  # clear → the viewport collapses to black); GREEN with the #989 fix (the non-destructive
+  # swap REFUSES the near-blank capture and KEEPS the last rich frame, and the forced
+  # `send-keys C-l` repaint makes the idle agent re-emit). The missing near-blank-REMOTE
+  # fixture the happy banner-in-remote fixture masked (G10). Deterministic agents:2222 only
+  # (rich frame injected LOCALLY, no toxiproxy), no CI self-skip — belongs in this subset.
+  "$FQCN_PREFIX.RedrawNonDestructiveNearBlankCaptureE2eTest"
   # ADDED (#966/#967 — the DISCRIMINATING render-death-on-a-LIVE-transport journey): the
   # maintainer dogfooded a connected Claude session that went BLACK with only stray
   # FRAGMENTS (a lone cursor, a "3", a scattered status line) while the transport stayed

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -1095,6 +1095,33 @@ JOURNEY_CLASSES=(
   # assumeFalse(isRunningOnCi()) on the load-bearing assertion — process.md
   # F3 / D33). It lives under the com.pocketshell.app.proof prefix.
   "$FQCN_PREFIX.LaunchNoMainThreadRoomReadE2eTest"
+  # ADDED (#972 — D33/G4/G10: prove the host connection-log mirror's VM GLUE on
+  # the real path). The #969-part-3 ConnectionLogHostMirror writer + its driver
+  # wiring landed JVM-tested, but the load-bearing VM glue —
+  # `mirrorConnectionLogToHost()` -> `ConnectionTarget.toLeaseSessionTarget()`,
+  # the BYTE-IDENTICAL lease-key mapping that makes the warm-lease borrow real —
+  # had ZERO coverage of any kind (the writer test used a FAKE lease; the driver
+  # test only counted the callback). A wrong lease-key field mapping would
+  # reproduce the exact "wired but the host file never lands" failure this issue
+  # closes, uncaught. This connected journey drives the REAL production
+  # TmuxSessionViewModel against the deterministic agents:2222 fixture: it seeds a
+  # real reconnect-cause trail in a real DiagnosticRecorder, sets activeTarget to
+  # the agents:2222 host, PRE-WARMS the SSH lease for that exact key (one cold
+  # handshake), then fires the production mirror glue and asserts the host file
+  # `~/.pocketshell/connection-log.jsonl` ACTUALLY LANDS over the WARM lease
+  # (read back over a FRESH independent SSH exec) carrying the seeded keepalive_dead
+  # trail — with ZERO extra handshakes (warm reuse), proving toLeaseSessionTarget()
+  # produced a byte-identical key. The RED guard
+  # (wrongLeaseKeyMappingDoesNotLandOverTheWarmLease) drives the SAME glue through a
+  # deliberately-MISMATCHED key and asserts a SECOND cold handshake fires + the warm
+  # transport is NOT reused — pinning the byte-identical-key property as the
+  # load-bearing assertion (G6/G10). It uses ONLY the deterministic agents:2222
+  # fixture (DEFAULT_HOST/PORT/USER -> 10.0.2.2:2222, or the pool-allocated port
+  # under `--pool`) that tests.yml already brings up — no new Docker service/port,
+  # no toxiproxy — and does NOT self-skip on CI (no assumeTrue /
+  # assumeFalse(isRunningOnCi()) on the load-bearing assertions). It lives under
+  # com.pocketshell.app.diagnostics, so it carries its FQCN directly.
+  "com.pocketshell.app.diagnostics.ConnectionLogHostMirrorReconnectDockerTest"
 )
 
 echo "=========================================================="

--- a/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurfaceState.kt
+++ b/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurfaceState.kt
@@ -647,6 +647,65 @@ class TerminalSurfaceState(
     }
 
     /**
+     * Issue #989 — the NON-DESTRUCTIVE-swap guard for the manual Redraw / attach
+     * reseed. The seed path repaints `capture-pane` into the live buffer with a
+     * leading `CSI 2J` clear (`toTerminalViewportBytes`), so the swap is in-place
+     * and the clear destroys the prior frame BEFORE the new content lands. For an
+     * idle alternate-screen agent (Claude/Codex) a `capture-pane` can come back
+     * near-blank-but-non-empty (whitespace rows + a stray fragment) — it passes
+     * the `output.isEmpty()` guard, so without this gate the clear lands and the
+     * full prior frame is wiped to black-with-fragments (the maintainer's #989
+     * screenshot).
+     *
+     * This returns true — "do NOT paint this capture; keep the last frame" — when
+     * BOTH:
+     *
+     *  1. the fresh capture's visible tail carries near-nothing
+     *     (< [NON_DESTRUCTIVE_SWAP_MIN_CAPTURE_CHARS] non-blank chars), i.e. there
+     *     is no real frame to swap IN; AND
+     *  2. the currently-rendered viewport carries MATERIALLY MORE than the capture
+     *     would restore — so painting it would CLEAR visible content to (near)
+     *     black, a net LOSS.
+     *
+     * It is the inverse discipline of [visibleScreenDivergesFromCapture]: that one
+     * paints only when the capture has substantially MORE than the render (heal a
+     * stale render); this one REFUSES to paint when the capture has substantially
+     * LESS than the render (never clear-to-black). Together the reseed only ever
+     * swaps TOWARD more content.
+     *
+     * Returns false (paint normally) when no emulator is attached, when the
+     * current render is itself (near) blank (a genuinely black pane SHOULD accept
+     * even a sparse capture — there is nothing to lose, and the first real frame
+     * of a freshly-attached black pane must still land), or when the capture
+     * carries a comparable-or-greater amount of content than the render.
+     */
+    fun captureWouldClearVisibleContent(captureText: String): Boolean {
+        val emulator = bridge?.emulator ?: _session?.emulator ?: return false
+        val visibleRows = try {
+            emulator.screen.visibleScreenRows
+        } catch (_: Throwable) {
+            return false
+        }
+        if (visibleRows <= 0) return false
+        val captureVisibleNonBlank = captureText
+            .split('\n')
+            .filter { it.isNotBlank() }
+            .takeLast(visibleRows)
+            .sumOf { line -> line.count { !it.isWhitespace() } }
+        // The incoming capture carries real content → swapping it in is safe
+        // (it is not a near-blank wipe). Defer to the normal paint.
+        if (captureVisibleNonBlank >= NON_DESTRUCTIVE_SWAP_MIN_CAPTURE_CHARS) return false
+        val renderedNonBlank = renderedNonBlankCharCount()
+        // The current render carries little/nothing → there is nothing to lose by
+        // painting the (also near-blank) capture. A freshly-attached black pane's
+        // FIRST seed must still land, so a (near) blank render NEVER blocks here.
+        if (renderedNonBlank < NON_DESTRUCTIVE_SWAP_MIN_RENDER_CHARS) return false
+        // The render has materially MORE than this capture would restore → painting
+        // would clear visible content to (near) black. Keep the last frame.
+        return captureVisibleNonBlank * NON_DESTRUCTIVE_SWAP_CLEAR_RATIO < renderedNonBlank
+    }
+
+    /**
      * Pull the current visible-transcript text from the attached session and
      * run the matcher across it. Returns an empty list when no session is
      * attached or the session has no emulator yet (the View has not yet laid
@@ -901,6 +960,35 @@ class TerminalSurfaceState(
          * and never heals.
          */
         private const val STALE_RENDER_MAX_RENDERED_FRACTION = 0.25
+
+        /**
+         * Issue #989: a fresh `capture-pane` whose visible tail carries FEWER than
+         * this many non-blank chars is treated as "no real frame to swap in" by
+         * [captureWouldClearVisibleContent] — so it cannot clear an existing
+         * content-rich frame to black. An idle alt-screen agent's near-blank
+         * capture (a few stray status fragments) sits well under this floor; a
+         * real frame is hundreds of chars and sails over it.
+         */
+        private const val NON_DESTRUCTIVE_SWAP_MIN_CAPTURE_CHARS = 24
+
+        /**
+         * Issue #989: the current render must carry AT LEAST this many non-blank
+         * chars before [captureWouldClearVisibleContent] will refuse a near-blank
+         * capture. Below this the render is itself (near) black — there is nothing
+         * to lose, and a freshly-attached black pane's first real seed must still
+         * land — so the guard never blocks.
+         */
+        private const val NON_DESTRUCTIVE_SWAP_MIN_RENDER_CHARS = 24
+
+        /**
+         * Issue #989: the render is judged "would be cleared to black" when it
+         * carries MORE than this multiple of the near-blank capture's visible
+         * content. A content-rich frame (hundreds of chars) against a stray-
+         * fragment capture (a handful) is far over this ratio; a render that
+         * already roughly matches the sparse capture sits under it and paints
+         * normally (idempotent re-seed).
+         */
+        private const val NON_DESTRUCTIVE_SWAP_CLEAR_RATIO = 3
     }
 }
 

--- a/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxClient.kt
+++ b/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxClient.kt
@@ -269,6 +269,27 @@ public interface TmuxClient : AutoCloseable {
     public suspend fun refreshClientSize(cols: Int, rows: Int): CommandResponse
 
     /**
+     * Issue #989: ask the application running in [paneId] to REPAINT its full
+     * screen by sending it `C-l` (Ctrl-L) — the universal "clear and redraw" key
+     * that every well-behaved TUI (Claude/Codex, vim, less, htop, a shell) honors.
+     *
+     * This is the missing primitive behind the manual Redraw / attach reseed:
+     * before #989 those paths only ever re-CAPTURED the pane, so an idle
+     * alternate-screen agent (which never re-emits its existing frame on its own)
+     * was captured near-blank and the seed cleared the visible content to black. A
+     * `send-keys C-l` is geometry-stable (no window reflow, unlike a
+     * `refresh-client -C` size-nudge) so it cannot momentarily strip the idle
+     * frame; it simply prompts the app to emit a fresh full redraw, which the
+     * subsequent `capture-pane` then sees.
+     *
+     * Best-effort: a key that the app does not bind to redraw is harmless (the
+     * non-destructive swap keeps the last frame either way). The default
+     * implementation routes through [sendCommand] for [TmuxClient] doubles.
+     */
+    public suspend fun forceFullRepaint(paneId: String): CommandResponse =
+        sendCommand("send-keys C-l -t $paneId")
+
+    /**
      * Issue #927: milliseconds since the control-mode reader last parsed ANY
      * control event (`%begin` / `%end` / `%error` / `%output`) — the
      * "busy ≠ dead" discriminator the [probeLiveness] tolerance leans on.
@@ -1444,6 +1465,17 @@ internal class RealTmuxClient(
             timeoutMode = CommandTimeoutMode.FailOpenDrain,
         )
     }
+
+    override suspend fun forceFullRepaint(paneId: String): CommandResponse =
+        // Issue #989: a rendering-only prompt to the app to redraw. Use the
+        // FailOpenDrain mode (like `refresh-client`/`capture-pane`) so a delayed
+        // reply during an output storm fails open locally instead of being
+        // mistaken for a fatal transport drop — this MUST NOT take the FatalClose
+        // structural-command path (#979 owns that timeout behaviour).
+        sendCommandInternal(
+            "send-keys C-l -t $paneId",
+            timeoutMode = CommandTimeoutMode.FailOpenDrain,
+        )
 
     override suspend fun detachCleanly(timeoutMs: Long) {
         markReaderExitIntent(ReaderExitIntent.DetachOrReplace)


### PR DESCRIPTION
Two APPROVED fixes in the tmux/connection lane, batched (disjoint regions of the shared files). Full local `:app:testDebugUnitTest` + core-terminal + core-tmux + assembleDebug green on flake-free main.

- **#989** — Redraw/re-attach now FORCE a full agent repaint (`send-keys C-l`) before capture and swap NON-destructively, so a black/empty pane is always recoverable and Redraw can never clear content to black (the maintainer's 'never stuck on black' requirement). Closes #989.
- **#972** — mirror the rolling connection-log to `~/.pocketshell/connection-log.jsonl` on the host on reconnect, over the warm lease — with a connected proof of the real lease-key glue. The diagnostics the RC soak relies on to attribute drops. Closes #972.

Part of #928 bulletproof. Reviewer approvals on the issue threads. (#993 reconnect-button rebases on top of this — shares the kebab region with #989.)

---
**Update:** folded in **#1001** (makes the pre-existing flaky agent-detection test `b1Masked...` deterministic via a test-only dispatcher seam) so this cluster's full-suite CI is reliably green. Closes #1001.