### PR TITLE
tmux: add a 'Reconnect' kebab action to recover a dropped session in place (#993)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/ReconnectKebabInPlaceJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/ReconnectKebabInPlaceJourneyE2eTest.kt
@@ -1,0 +1,518 @@
+package com.pocketshell.app.proof
+
+import android.os.SystemClock
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.ViewModelProvider
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.MainActivity
+import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
+import com.pocketshell.app.hosts.SshKeyStorage
+import com.pocketshell.app.tmux.TMUX_RECONNECT_BUTTON_TAG
+import com.pocketshell.app.tmux.TMUX_SESSION_ERROR_TAG
+import com.pocketshell.app.tmux.TMUX_SESSION_RECONNECT_TAG
+import com.pocketshell.app.tmux.TMUX_SESSION_SCREEN_TAG
+import com.pocketshell.app.tmux.TmuxSessionViewModel
+import com.pocketshell.core.ssh.KnownHostsPolicy
+import com.pocketshell.core.ssh.SshConnection
+import com.pocketshell.core.ssh.SshKey
+import com.pocketshell.core.storage.AppDatabase
+import com.pocketshell.core.storage.entity.HostEntity
+import com.termux.view.TerminalView
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.rules.TestRule
+import org.junit.runner.RunWith
+import org.junit.runners.model.Statement
+import java.io.File
+
+/**
+ * Issue #993 — DEVICE-TRUTH journey for the new kebab **"Reconnect"** action, on the
+ * deterministic `agents:2222` Docker fixture.
+ *
+ * ## The maintainer's report (2026-06-26)
+ *
+ * "Sometimes I accidentally disconnect — I'm already in a session sending a message, the
+ * disconnect happens, and there's nothing I can do: the session can't reconnect on its own.
+ * So I have to go back, join ANOTHER session (that triggers a reconnect), then come back to
+ * this session, and then the queued message sends. I want a **Reconnect button in the kebab
+ * menu**." A deliberate HALF-MEASURE escape hatch until auto-reconnect is bulletproof (#928).
+ *
+ * ## What this journey proves on the REAL path (the acceptance criteria)
+ *
+ *  - **AC1 — reconnect IN PLACE, no switch dance.** A connected session is dropped (the
+ *    `triggerCleanPassiveDropForTest` clean-passive-disconnect seam — the same EOF body a
+ *    real reader-EOF drives, no toxiproxy), so a USER-VISIBLE connection-lost band surfaces.
+ *    The user opens the kebab and taps the new **Reconnect** item (stable tag
+ *    [TMUX_RECONNECT_BUTTON_TAG]); the SAME session recovers to Connected over a FRESH `-CC`
+ *    client (a different client identity — proving a real re-dial, not a stale hold) WITHOUT
+ *    navigating to another session and back.
+ *  - **AC2/AC4 — a post-reconnect send round-trips.** After the manual reconnect, a fresh
+ *    marker emitted into the pane STREAMS back through the SAME recovered `-CC` channel —
+ *    proving the recovered session is live and input-accepting (the exact precondition the
+ *    #900 outbound-queue auto-flush relies on; the flush-on-`sessionLive` wiring itself is
+ *    pinned by the JVM `TmuxSessionScreenTest` controller tests).
+ *
+ * ## Fail-first (G10/D33)
+ *
+ * WITHOUT the kebab Reconnect item (the `onReconnect` → `viewModel.reconnect()` wiring) there
+ * is NO in-session affordance to recover the dropped session — the [TMUX_RECONNECT_BUTTON_TAG]
+ * node does not exist, so `tapKebabReconnect()` cannot find/click it and the session stays on
+ * the connection-lost band: RED. WITH the fix the tap drives the VM's single
+ * [TmuxSessionViewModel.reconnect] / TransportEffects entrypoint, the same session recovers in
+ * place, and the post-reconnect send round-trips: GREEN.
+ *
+ * Uses ONLY the deterministic `agents` fixture and the synthetic clean-drop seam (no
+ * toxiproxy, no `Assume.assumeFalse(isRunningOnCi())` on any load-bearing assertion), so it
+ * RUNS on the per-PR CI emulator-journey job once wired into `scripts/ci-journey-suite.sh`.
+ */
+@RunWith(AndroidJUnit4::class)
+class ReconnectKebabInPlaceJourneyE2eTest {
+
+    val compose = createAndroidComposeRule<MainActivity>()
+    private val grantPermissions = PreGrantPermissionsRule()
+
+    @get:Rule
+    val ruleChain: RuleChain = RuleChain
+        .outerRule(grantPermissions)
+        .around(seedFixtureRule())
+        .around(compose)
+
+    private var seededKey: String? = null
+    private var seededHostRowTag: String? = null
+
+    private fun seedFixtureRule(): TestRule = TestRule { base, _ ->
+        object : Statement() {
+            override fun evaluate() {
+                runBlocking {
+                    val key = readFixtureKey()
+                    seededKey = key
+                    waitForSshFixtureReady(SshKey.Pem(key))
+                    seedTmuxSession(key)
+                    seededHostRowTag = seedDockerHost(key)
+                }
+                base.evaluate()
+            }
+        }
+    }
+
+    @Before
+    fun setUp() {
+        clearLastSessionPrefs()
+    }
+
+    @After
+    fun tearDown() {
+        runCatching {
+            compose.activityRule.scenario.moveToState(Lifecycle.State.RESUMED)
+        }
+        clearLastSessionPrefs()
+        seededKey?.let { key ->
+            runCatching { runBlocking { cleanupRemoteTmuxSession(key) } }
+        }
+    }
+
+    @Test
+    fun kebabReconnectRecoversDroppedSessionInPlaceThenSendRoundTrips() = runBlocking<Unit> {
+        val hostRowTag = requireNotNull(seededHostRowTag)
+        val key = requireNotNull(seededKey)
+        attachSeededTmuxSession(hostRowTag)
+        waitForVisibleTerminal("initial attach") { it.contains(READY_MARKER) }
+        waitForConnected("initial attach")
+
+        // Live baseline: a fresh marker streams back through the live `-CC` channel.
+        emitMarkerIntoPane(key, "LIVE-$MARKER")
+        waitForVisibleTerminal("pre-drop-live") { it.contains("LIVE-$MARKER") }
+        assertTrue(
+            "expected Connected before the drop, observed=${currentConnectionStatus()}",
+            currentConnectionStatus() is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+        val clientBeforeDrop = currentViewModel().currentClientIdentityForTest()
+
+        // ---- DROP: the maintainer's "I'm in a session and it disconnects" ----
+        // Fire the CLEAN passive-disconnect path directly (the same body a real reader EOF
+        // drives). The session can no longer round-trip and a USER-VISIBLE connection-lost
+        // band surfaces — the stuck state the maintainer has no in-session escape from.
+        val dropped = currentViewModel().triggerCleanPassiveDropForTest()
+        assertTrue("expected the clean-drop seam to fire on a live client", dropped)
+        val bandShown = waitForConnectionLostIndicator(DROP_DETECT_WINDOW_MS)
+        assertTrue(
+            "expected a USER-VISIBLE connection-lost band after the drop " +
+                "(status=${currentConnectionStatus()})",
+            bandShown,
+        )
+
+        // ---- TAP KEBAB → RECONNECT (the new escape hatch) ----
+        // The user opens the kebab and taps the new "Reconnect" item. This drives the VM's
+        // single reconnect entrypoint to re-dial THIS session in place — NO navigation to
+        // another session and back.
+        tapKebabReconnect()
+
+        val recovered = waitForSessionRecovered(RECOVER_WINDOW_MS)
+        assertTrue(
+            "expected the SAME session to recover to Connected IN PLACE after tapping the " +
+                "kebab Reconnect — no switch dance (status=${currentConnectionStatus()}).",
+            recovered,
+        )
+        // The session screen is still up (recovered in place, not torn down / navigated away).
+        assertTrue(
+            "tmux session screen must still be up after the in-place reconnect",
+            compose.onAllNodesWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .isNotEmpty(),
+        )
+        // A FRESH `-CC` client proves a real re-dial happened (not a stale hold of the
+        // dead client).
+        val clientAfter = currentViewModel().currentClientIdentityForTest()
+        assertNotEquals(
+            "the manual reconnect must re-dial a FRESH `-CC` client (different identity)",
+            clientBeforeDrop,
+            clientAfter,
+        )
+
+        // ---- POST-RECONNECT SEND ROUND-TRIP (AC2/AC4) ----
+        // A fresh marker must STREAM back through the SAME recovered channel — the recovered
+        // session is live + input-accepting, the precondition the #900 queue auto-flush needs.
+        emitMarkerIntoPane(key, "AFTER-$MARKER")
+        val roundTripped = runCatching {
+            waitForVisibleTerminal(
+                "post-reconnect",
+                timeoutMillis = ROUND_TRIP_WINDOW_MS,
+            ) { it.contains("AFTER-$MARKER") }
+            true
+        }.getOrDefault(false)
+        assertTrue(
+            "expected a post-reconnect send to round-trip through the SAME session " +
+                "(no switch dance). status=${currentConnectionStatus()}",
+            roundTripped,
+        )
+
+        writeSummary()
+    }
+
+    // -- kebab + indicator helpers -------------------------------------------------
+
+    private fun tapKebabReconnect() {
+        // Open the overflow kebab in the session header.
+        compose.onNodeWithContentDescription("More session actions", useUnmergedTree = true)
+            .performClick()
+        compose.waitUntil(timeoutMillis = 5_000) {
+            compose.onAllNodesWithTag(TMUX_RECONNECT_BUTTON_TAG, useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
+        // AC1: the Reconnect item is present + reachable, then tap it.
+        compose.onNodeWithTag(TMUX_RECONNECT_BUTTON_TAG, useUnmergedTree = true)
+            .assertExists()
+            .performClick()
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+    }
+
+    private fun waitForConnectionLostIndicator(timeoutMillis: Long): Boolean {
+        val deadline = SystemClock.elapsedRealtime() + timeoutMillis
+        while (SystemClock.elapsedRealtime() < deadline) {
+            if (connectionLostIndicatorVisible()) return true
+            SystemClock.sleep(200)
+        }
+        return connectionLostIndicatorVisible()
+    }
+
+    private fun connectionLostIndicatorVisible(): Boolean {
+        if (hasTag(TMUX_SESSION_ERROR_TAG) || hasTag(TMUX_SESSION_RECONNECT_TAG)) return true
+        return when (currentConnectionStatus()) {
+            is TmuxSessionViewModel.ConnectionStatus.Connected -> false
+            is TmuxSessionViewModel.ConnectionStatus.Idle -> false
+            else -> true
+        }
+    }
+
+    private fun waitForSessionRecovered(timeoutMillis: Long): Boolean {
+        val deadline = SystemClock.elapsedRealtime() + timeoutMillis
+        while (SystemClock.elapsedRealtime() < deadline) {
+            if (sessionHealthyConnected()) return true
+            SystemClock.sleep(250)
+        }
+        return sessionHealthyConnected()
+    }
+
+    private fun sessionHealthyConnected(): Boolean {
+        if (hasTag(TMUX_SESSION_ERROR_TAG) || hasTag(TMUX_SESSION_RECONNECT_TAG)) return false
+        return currentConnectionStatus() is TmuxSessionViewModel.ConnectionStatus.Connected
+    }
+
+    private fun hasTag(tag: String): Boolean =
+        compose.onAllNodesWithTag(tag, useUnmergedTree = true)
+            .fetchSemanticsNodes()
+            .isNotEmpty()
+
+    // -- attach + IO helpers -------------------------------------------------------
+
+    private fun attachSeededTmuxSession(hostRowTag: String) {
+        compose.waitUntil(timeoutMillis = HOST_ROW_TIMEOUT_MS) {
+            runCatching {
+                compose.onAllNodesWithTag(hostRowTag, useUnmergedTree = true)
+                    .fetchSemanticsNodes()
+                    .isNotEmpty()
+            }.getOrDefault(false)
+        }
+        compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick()
+        compose.waitUntil(timeoutMillis = TerminalTestTimeouts.terminalVisibilityTimeoutMs()) {
+            runCatching {
+                compose.onAllNodesWithText(SESSION_NAME, useUnmergedTree = true)
+                    .fetchSemanticsNodes()
+                    .isNotEmpty()
+            }.getOrDefault(false)
+        }
+        compose.onNodeWithText(SESSION_NAME, useUnmergedTree = true).performClick()
+        compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertExists()
+        waitForTerminalViewAttached()
+    }
+
+    private fun waitForTerminalViewAttached() {
+        compose.waitUntil(timeoutMillis = 30_000) {
+            var attached = false
+            compose.activityRule.scenario.onActivity { activity ->
+                val view = activity.window.decorView.findTerminalView()
+                attached = view?.currentSession != null && view.mEmulator != null
+            }
+            attached
+        }
+    }
+
+    private suspend fun emitMarkerIntoPane(key: String, marker: String) {
+        SshConnection.connect(
+            host = DEFAULT_HOST,
+            port = DEFAULT_PORT,
+            user = DEFAULT_USER,
+            key = SshKey.Pem(key),
+            knownHosts = KnownHostsPolicy.AcceptAll,
+            timeoutMs = 15_000,
+        ).mapCatching { session ->
+            session.use {
+                it.exec(
+                    "tmux send-keys -t ${shellQuote(SESSION_NAME)} " +
+                        shellQuote("printf '$marker\\n'") + " Enter",
+                )
+            }
+        }.getOrThrow()
+    }
+
+    private fun waitForConnected(label: String) {
+        compose.waitUntil(timeoutMillis = CONNECTED_TIMEOUT_MS) {
+            currentConnectionStatus() is TmuxSessionViewModel.ConnectionStatus.Connected
+        }
+        assertTrue(
+            "expected Connected after $label, observed=${currentConnectionStatus()}",
+            currentConnectionStatus() is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+    }
+
+    private fun currentViewModel(): TmuxSessionViewModel {
+        var vm: TmuxSessionViewModel? = null
+        compose.activityRule.scenario.onActivity { activity ->
+            vm = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+        }
+        return requireNotNull(vm) { "TmuxSessionViewModel not available" }
+    }
+
+    private fun currentConnectionStatus(): TmuxSessionViewModel.ConnectionStatus {
+        var status: TmuxSessionViewModel.ConnectionStatus =
+            TmuxSessionViewModel.ConnectionStatus.Idle
+        compose.activityRule.scenario.onActivity { activity ->
+            status = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+                .connectionStatus
+                .value
+        }
+        return status
+    }
+
+    private fun waitForVisibleTerminal(
+        label: String,
+        timeoutMillis: Long = TerminalTestTimeouts.terminalVisibilityTimeoutMs(),
+        predicate: (String) -> Boolean,
+    ): String {
+        var last = ""
+        compose.waitUntil(timeoutMillis = timeoutMillis) {
+            last = visibleTerminalText()
+            last.isNotBlank() && predicate(last)
+        }
+        assertTrue("expected visible terminal for $label; got:\n$last", predicate(last))
+        return last
+    }
+
+    private fun visibleTerminalText(): String {
+        var text = ""
+        compose.activityRule.scenario.onActivity { activity ->
+            text = activity.window.decorView
+                .findTerminalView()
+                ?.currentSession
+                ?.emulator
+                ?.screen
+                ?.transcriptText
+                .orEmpty()
+        }
+        return text
+    }
+
+    // -- seeding / cleanup ---------------------------------------------------------
+
+    private fun readFixtureKey(): String =
+        InstrumentationRegistry.getInstrumentation()
+            .context
+            .assets
+            .open("test_key")
+            .bufferedReader()
+            .use { it.readText() }
+
+    private suspend fun seedDockerHost(key: String): String {
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
+        val db = Room.databaseBuilder(appContext, AppDatabase::class.java, DATABASE_NAME)
+            .fallbackToDestructiveMigration(dropAllTables = true)
+            .build()
+        return try {
+            db.clearAllTables()
+            val storedKey = SshKeyStorage.persistKey(
+                context = appContext,
+                sshKeyDao = db.sshKeyDao(),
+                name = "issue993-reconnect-key-${System.currentTimeMillis()}",
+                content = key,
+            )
+            val hostId = db.hostDao().insert(
+                HostEntity(
+                    name = "Issue993 Reconnect Kebab",
+                    hostname = DEFAULT_HOST,
+                    port = DEFAULT_PORT,
+                    username = DEFAULT_USER,
+                    keyId = storedKey.id,
+                    tmuxInstalled = true,
+                    lastBootstrapAt = System.currentTimeMillis(),
+                ),
+            )
+            HOST_ROW_TAG_PREFIX + hostId
+        } finally {
+            db.close()
+        }
+    }
+
+    private suspend fun seedTmuxSession(key: String) {
+        val script = buildString {
+            appendLine("set -eu")
+            appendLine("tmux kill-session -t ${shellQuote(SESSION_NAME)} 2>/dev/null || true")
+            // Interactive shell so a `tmux send-keys` printf actually EXECUTES.
+            appendLine(
+                "tmux new-session -d -s ${shellQuote(SESSION_NAME)} " +
+                    shellQuote("printf '$READY_MARKER\\n'; exec sh -i"),
+            )
+            appendLine("sleep 1")
+            appendLine("tmux list-sessions")
+        }
+        val result = execRemoteSetupUntilReady(
+            key = SshKey.Pem(key),
+            command = script,
+            description = "issue993 reconnect-kebab tmux seed session",
+        )
+        assertTrue(
+            "expected tmux seeding to succeed; exit=${result.exitCode} stderr='${result.stderr}'",
+            result.exitCode == 0,
+        )
+    }
+
+    private suspend fun cleanupRemoteTmuxSession(key: String) {
+        runCatching {
+            SshConnection.connect(
+                host = DEFAULT_HOST,
+                port = DEFAULT_PORT,
+                user = DEFAULT_USER,
+                key = SshKey.Pem(key),
+                knownHosts = KnownHostsPolicy.AcceptAll,
+                timeoutMs = 15_000,
+            ).mapCatching { session ->
+                session.use {
+                    it.exec("tmux kill-session -t ${shellQuote(SESSION_NAME)} 2>/dev/null || true")
+                }
+            }
+        }
+    }
+
+    private fun writeSummary(): File {
+        val file = artifactFile("issue993-reconnect-kebab-summary.txt")
+        file.writeText(
+            buildString {
+                appendLine("test=ReconnectKebabInPlaceJourneyE2eTest")
+                appendLine("issue=993")
+                appendLine("fixture=tests/docker agents ($DEFAULT_HOST:$DEFAULT_PORT)")
+                appendLine("running_on_ci=${TerminalTestTimeouts.isRunningOnCi()}")
+                appendLine("session=$SESSION_NAME")
+                appendLine(
+                    "scenario=attach a live session, drop it via the clean-passive seam, then " +
+                        "open the kebab and tap the new Reconnect item",
+                )
+                appendLine(
+                    "expectation=the SAME session recovers to Connected in place (fresh `-CC` " +
+                        "client, no switch dance) and a post-reconnect send round-trips",
+                )
+            },
+        )
+        println("ISSUE993_SUMMARY ${file.absolutePath}")
+        return file
+    }
+
+    private fun artifactFile(name: String): File {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val mediaRoot = com.pocketshell.app.test.testArtifactsRoot(instrumentation.targetContext)
+        val dir = File(mediaRoot, "additional_test_output/$DEVICE_DIR_NAME")
+        check(dir.exists() || dir.mkdirs()) {
+            "could not create artifact directory ${dir.absolutePath}"
+        }
+        return File(dir, name)
+    }
+
+    private fun View.findTerminalView(): TerminalView? {
+        if (this is TerminalView) return this
+        if (this !is ViewGroup) return null
+        for (index in 0 until childCount) {
+            val match = getChildAt(index).findTerminalView()
+            if (match != null) return match
+        }
+        return null
+    }
+
+    private fun shellQuote(value: String): String =
+        "'" + value.replace("'", "'\"'\"'") + "'"
+
+    private companion object {
+        const val DATABASE_NAME: String = "pocketshell.db"
+        const val DEVICE_DIR_NAME: String = "issue993-reconnect-kebab"
+        const val SESSION_NAME: String = "issue993-reconnect-proof"
+        const val READY_MARKER: String = "ISSUE993-READY"
+        const val MARKER: String = "issue993reconnect"
+
+        val DROP_DETECT_WINDOW_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 30_000L else 12_000L
+        val RECOVER_WINDOW_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 60_000L else 45_000L
+        val ROUND_TRIP_WINDOW_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 45_000L else 30_000L
+
+        val HOST_ROW_TIMEOUT_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 60_000L else 20_000L
+        val CONNECTED_TIMEOUT_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 30_000L else 15_000L
+    }
+}

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxMoreMenuReconnectTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxMoreMenuReconnectTest.kt
@@ -1,0 +1,103 @@
+package com.pocketshell.app.tmux
+
+import androidx.activity.ComponentActivity
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.pocketshell.uikit.theme.PocketShellTheme
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Issue #993: the live session kebab must expose a "Reconnect" item (stable test tag)
+ * that, when tapped, invokes the reconnect callback — the manual escape hatch that forces
+ * a reconnect of the CURRENT session in place so the user does not have to switch away and
+ * back. The item is disabled while a connect/reconnect is already in flight (or there is no
+ * target) so a tap is never a silent no-op / redundant re-dial. The full drop → Reconnect →
+ * queued-message-flushes journey is proven end-to-end by the connected reconnect journey;
+ * this focused test covers the kebab AC — the item is present, reachable, enable-gated, and
+ * wired.
+ */
+@RunWith(AndroidJUnit4::class)
+class TmuxMoreMenuReconnectTest {
+
+    @get:Rule
+    val compose = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun reconnectItemIsPresentAndInvokesCallbackWhenEnabled() {
+        var reconnectClicks = 0
+        compose.setContent {
+            PocketShellTheme {
+                val expanded = mutableStateOf(true)
+                TmuxMoreMenu(
+                    expanded = expanded.value,
+                    onDismiss = { expanded.value = false },
+                    onCreateSession = {},
+                    onRenameSession = {},
+                    onKillSession = {},
+                    onSwitchSession = {},
+                    onOpenJobs = {},
+                    onOpenUsage = {},
+                    onOpenSettings = {},
+                    onDetach = {},
+                    onRedraw = {},
+                    onReconnect = { reconnectClicks++ },
+                    reconnectEnabled = true,
+                )
+            }
+        }
+
+        compose
+            .onNodeWithTag(TMUX_RECONNECT_BUTTON_TAG, useUnmergedTree = true)
+            .assertIsDisplayed()
+            .assertIsEnabled()
+            .performClick()
+        compose.waitForIdle()
+
+        assertEquals("Reconnect kebab item should invoke onReconnect", 1, reconnectClicks)
+    }
+
+    @Test
+    fun reconnectItemDisabledDoesNotInvokeCallback() {
+        // AC: sensible disabled state mid-reconnect / no target — a tap on the disabled
+        // item must NOT fire the reconnect (no silent redundant re-dial).
+        var reconnectClicks = 0
+        compose.setContent {
+            PocketShellTheme {
+                val expanded = mutableStateOf(true)
+                TmuxMoreMenu(
+                    expanded = expanded.value,
+                    onDismiss = { expanded.value = false },
+                    onCreateSession = {},
+                    onRenameSession = {},
+                    onKillSession = {},
+                    onSwitchSession = {},
+                    onOpenJobs = {},
+                    onOpenUsage = {},
+                    onOpenSettings = {},
+                    onDetach = {},
+                    onRedraw = {},
+                    onReconnect = { reconnectClicks++ },
+                    reconnectEnabled = false,
+                )
+            }
+        }
+
+        compose
+            .onNodeWithTag(TMUX_RECONNECT_BUTTON_TAG, useUnmergedTree = true)
+            .assertIsDisplayed()
+            .assertIsNotEnabled()
+            .performClick()
+        compose.waitForIdle()
+
+        assertEquals("a disabled Reconnect item must not invoke onReconnect", 0, reconnectClicks)
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
@@ -1395,6 +1395,27 @@ public fun TmuxSessionScreen(
                 moreExpanded = false
                 viewModel.redrawActivePane()
             },
+            onReconnect = {
+                // Issue #993: close the menu, then force an immediate reconnect of THIS
+                // session in place via the VM's single [TmuxSessionViewModel.reconnect]
+                // /TransportEffects entrypoint — the SAME path a session switch uses to
+                // recover a dropped session, so the user no longer has to switch away and
+                // back. `reconnect()` returns false only when there is no target (the
+                // `reconnectEnabled` gate already suppresses that), so the Toast confirms
+                // the reconnect was actually kicked off (visible feedback, no silent
+                // no-op). The terminal then shows the normal "Reconnecting…" band, and on
+                // success the #900 outbound queue auto-flushes the pending message.
+                moreExpanded = false
+                val started = viewModel.reconnect()
+                Toast.makeText(
+                    context,
+                    if (started) "Reconnecting…" else "Nothing to reconnect to",
+                    Toast.LENGTH_SHORT,
+                ).show()
+            },
+            // Issue #993: only actionable when there IS a target to reconnect to AND a
+            // connect/reconnect is not already in flight — see [reconnectKebabEnabled].
+            reconnectEnabled = reconnectKebabEnabled(canReconnect, status),
         )
     }
 
@@ -3652,6 +3673,31 @@ internal class OutboundQueueAutoFlushController {
 }
 
 /**
+ * Issue #993: whether the kebab's "Reconnect" item is actionable right now.
+ *
+ * The manual reconnect escape hatch is the half-measure for a dropped session whose
+ * auto-reconnect didn't fire. It is only meaningful when:
+ *  - there IS a known target to reconnect to ([canReconnect] — the same gate the
+ *    in-session Reconnect band uses, so a tap never silently no-ops), AND
+ *  - a connect/reconnect is NOT already in flight (Connecting/Switching/Reconnecting),
+ *    so the tap is never a redundant re-dial that would yank an already-recovering
+ *    session.
+ *
+ * A `Connected` (possibly stale) or `Failed`/`Idle` session with a target stays
+ * enabled — that is exactly the maintainer's "it dropped but the app still thinks it's
+ * connected / it's sitting on Failed and nothing recovers it" case the button exists for.
+ * Pure so the wiring is a unit-testable predicate rather than an inline boolean (G9).
+ */
+internal fun reconnectKebabEnabled(
+    canReconnect: Boolean,
+    status: ConnectionStatus,
+): Boolean =
+    canReconnect &&
+        status !is ConnectionStatus.Connecting &&
+        status !is ConnectionStatus.Switching &&
+        status !is ConnectionStatus.Reconnecting
+
+/**
  * Issue #750: the single-indicator gate for the top under-header
  * [ReconnectingProgressRow] progress line.
  *
@@ -4179,6 +4225,15 @@ internal const val TMUX_SETTINGS_BUTTON_TAG = "tmux:session:settings-button"
  * detach / new lease) — the manual escape hatch from a black/partial-black terminal.
  */
 internal const val TMUX_REDRAW_BUTTON_TAG = "tmux:session:redraw-button"
+/**
+ * Issue #993: stable test tag for the kebab's "Reconnect" item. Tapping it forces an
+ * immediate reconnect of the CURRENT session in place (reusing the VM's single
+ * [TmuxSessionViewModel.reconnect] / `TransportEffects.onManualReconnect` entrypoint) so
+ * the user does NOT have to switch to another session and back to recover a dropped
+ * session. On reconnect the #900 outbound queue auto-flushes the pending message. A
+ * deliberate HALF-MEASURE escape hatch until auto-reconnect is bulletproof (#928).
+ */
+internal const val TMUX_RECONNECT_BUTTON_TAG = "tmux:session:reconnect-button"
 /**
  * Issue #497: stable test tags for the kebab's "Open file…" item and the
  * path-entry dialog it opens, so instrumentation can drive
@@ -5720,6 +5775,15 @@ internal fun TmuxMoreMenu(
     // terminal. Defaulted so existing direct callers / tests of TmuxMoreMenu stay
     // source-compatible.
     onRedraw: () -> Unit = {},
+    // Issue #993: "Reconnect" — force an immediate reconnect of the CURRENT session in
+    // place (the manual escape hatch when auto-reconnect doesn't fire). Defaulted so
+    // existing direct callers / tests of TmuxMoreMenu stay source-compatible.
+    onReconnect: () -> Unit = {},
+    // Issue #993: gate the "Reconnect" item — disabled while there is no target to
+    // reconnect to OR a connect/reconnect is already in flight, so a tap is never a
+    // silent no-op nor a redundant re-dial. Defaulted true so existing callers/tests
+    // stay source-compatible.
+    reconnectEnabled: Boolean = true,
 ) {
     DropdownMenu(
         expanded = expanded,
@@ -5770,6 +5834,18 @@ internal fun TmuxMoreMenu(
             text = { Text("Redraw") },
             onClick = onRedraw,
             modifier = Modifier.testTag(TMUX_REDRAW_BUTTON_TAG),
+        )
+        // Issue #993: manual escape hatch from a dropped session whose auto-reconnect
+        // didn't fire — force an immediate reconnect of THIS session in place (no
+        // session-switch dance), reusing the VM's single TransportEffects reconnect
+        // entrypoint. On reconnect the #900 outbound queue auto-flushes the pending
+        // message. Disabled (greyed) when there is no target or a reconnect is already
+        // in flight so the tap is never a silent no-op / redundant re-dial.
+        DropdownMenuItem(
+            text = { Text("Reconnect") },
+            onClick = onReconnect,
+            enabled = reconnectEnabled,
+            modifier = Modifier.testTag(TMUX_RECONNECT_BUTTON_TAG),
         )
 
         // --- Sessions: move between / create sessions on this host. ---

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionScreenTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionScreenTest.kt
@@ -1539,4 +1539,111 @@ class TmuxSessionScreenTest {
         assertEquals(listOf("1/session-a", "1/session-a"), requeuedTargets)
         assertEquals(emptySet<String>(), retryExclusions.last())
     }
+
+    // --- Issue #993: kebab "Reconnect" enable gate ---------------------------------
+
+    @Test
+    fun reconnectKebabEnabledForDroppedSessionWithTarget() {
+        // The maintainer's exact case: the session dropped and auto-reconnect did NOT
+        // fire — the app is sitting on Failed (or a stale Connected) WITH a target to
+        // reconnect to. The Reconnect item MUST be enabled so the user can recover in
+        // place without the switch-away-and-back dance.
+        assertTrue(
+            "Failed-with-target must enable Reconnect (the dropped-session escape hatch)",
+            reconnectKebabEnabled(
+                canReconnect = true,
+                status = TmuxSessionViewModel.ConnectionStatus.Failed("Disconnected"),
+            ),
+        )
+        assertTrue(
+            "a (possibly stale) Connected with a target still enables a manual reconnect",
+            reconnectKebabEnabled(
+                canReconnect = true,
+                status = TmuxSessionViewModel.ConnectionStatus.Connected("h", 22, "u"),
+            ),
+        )
+    }
+
+    @Test
+    fun reconnectKebabDisabledWithoutTarget() {
+        // No target to reconnect to (VM never opened / initial-connect race) — the item
+        // must be disabled so a tap is never a silent no-op (AC4).
+        listOf(
+            TmuxSessionViewModel.ConnectionStatus.Idle,
+            TmuxSessionViewModel.ConnectionStatus.Failed("boom"),
+            TmuxSessionViewModel.ConnectionStatus.Connected("h", 22, "u"),
+        ).forEach { status ->
+            assertEquals(
+                "no target → Reconnect disabled for $status",
+                false,
+                reconnectKebabEnabled(canReconnect = false, status = status),
+            )
+        }
+    }
+
+    @Test
+    fun kebabReconnectThenLiveWindowFlushesQueuedOutboundMessage() {
+        // Issue #993 — the maintainer's full journey, end-to-end at the screen-controller
+        // seam: a queued outbound message is pending, the session is DROPPED (not live), the
+        // user taps the kebab Reconnect (which is ENABLED in this dropped-with-target state),
+        // the session recovers (the live window flips), and the #900 outbound queue
+        // auto-flushes the pending message — WITHOUT a session switch.
+        val controller = OutboundQueueAutoFlushController()
+        val flushed = mutableListOf<String>()
+        val sessionId = "1/issue993-proof"
+
+        // 1) DROPPED state: the session is not live, a connection-lost band is up. The kebab
+        //    Reconnect item MUST be actionable so the user has an in-session escape hatch.
+        controller.onConnectionWindowChanged(sessionLive = false, targetSessionId = sessionId) {
+            error("offline must not requeue/flush")
+        }
+        assertTrue(
+            "the kebab Reconnect must be enabled while dropped-with-target (the escape hatch)",
+            reconnectKebabEnabled(
+                canReconnect = true,
+                status = TmuxSessionViewModel.ConnectionStatus.Failed("Disconnected"),
+            ),
+        )
+        // While dropped, the queue does NOT flush (the message stays queued).
+        assertNull(
+            controller.onQueueSnapshotChanged(sessionLive = false) {
+                error("a dropped session must not flush the queue")
+            },
+        )
+        assertTrue("nothing flushed while the session is dropped", flushed.isEmpty())
+
+        // 2) Tapping the kebab Reconnect drives viewModel.reconnect() → the SAME session
+        //    recovers IN PLACE (no switch). At the screen that surfaces as `sessionLive`
+        //    flipping true for the SAME targetSessionId — NOT a different session id (the
+        //    old switch-away-and-back workaround would change the target).
+        controller.onConnectionWindowChanged(sessionLive = true, targetSessionId = sessionId) {
+            // requeue-stale-in-flight on becoming live (no pending in-flight here).
+        }
+        val flushedId = controller.onQueueSnapshotChanged(sessionLive = true) { excludingIds ->
+            assertTrue("first flush after reconnect excludes nothing", excludingIds.isEmpty())
+            flushed += "queued-1"
+            "queued-1"
+        }
+
+        assertEquals("the queued message must auto-flush after the in-place reconnect", "queued-1", flushedId)
+        assertEquals(listOf("queued-1"), flushed)
+    }
+
+    @Test
+    fun reconnectKebabDisabledWhileReconnectAlreadyInFlight() {
+        // A connect/reconnect is already running — a manual reconnect would be a
+        // redundant re-dial that yanks an already-recovering session, so the item is
+        // disabled even with a target present (AC: "sensible state mid-reconnect").
+        listOf(
+            TmuxSessionViewModel.ConnectionStatus.Connecting("h", 22, "u"),
+            TmuxSessionViewModel.ConnectionStatus.Switching("h", 22, "u"),
+            reconnectingStatus,
+        ).forEach { status ->
+            assertEquals(
+                "in-flight → Reconnect disabled for $status",
+                false,
+                reconnectKebabEnabled(canReconnect = true, status = status),
+            )
+        }
+    }
 }

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -387,6 +387,20 @@ JOURNEY_CLASSES=(
   # fixture the happy banner-in-remote fixture masked (G10). Deterministic agents:2222 only
   # (rich frame injected LOCALLY, no toxiproxy), no CI self-skip — belongs in this subset.
   "$FQCN_PREFIX.RedrawNonDestructiveNearBlankCaptureE2eTest"
+  # ADDED (#993 — the manual "Reconnect" kebab escape hatch): the maintainer dogfooded a
+  # session that DROPPED while he was sending a message, with no in-session way to recover
+  # (the connection manager doesn't auto-reconnect a single dropped session reliably yet) —
+  # the old workaround was switch to ANOTHER session and back. This journey attaches a live
+  # session, DROPS it via the clean-passive-disconnect seam (the same EOF body a real reader
+  # EOF drives, no toxiproxy), confirms a USER-VISIBLE connection-lost band, then OPENS the
+  # kebab and TAPS the stable-tagged Reconnect item. RED on base (no kebab Reconnect item →
+  # the [TMUX_RECONNECT_BUTTON_TAG] node doesn't exist → the tap can't recover the session);
+  # GREEN with the fix (the item drives the VM's single reconnect entrypoint → the SAME
+  # session recovers to Connected IN PLACE over a FRESH `-CC` client, no switch dance, and a
+  # post-reconnect send round-trips — the precondition the #900 outbound-queue auto-flush
+  # needs). Uses ONLY the deterministic agents:2222 fixture and does NOT self-skip on CI, so
+  # it belongs in this per-push subset.
+  "$FQCN_PREFIX.ReconnectKebabInPlaceJourneyE2eTest"
   # ADDED (#966/#967 — the DISCRIMINATING render-death-on-a-LIVE-transport journey): the
   # maintainer dogfooded a connected Claude session that went BLACK with only stray
   # FRAGMENTS (a lone cursor, a "3", a scattered status line) while the transport stayed

--- a/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenders.kt
+++ b/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenders.kt
@@ -1711,6 +1711,8 @@ class DesignRenders {
                     "Detach",
                     // Issue #892: manual full-viewport reseed escape hatch.
                     "Redraw",
+                    // Issue #993: manual reconnect-in-place escape hatch.
+                    "Reconnect",
                 ),
                 "Sessions" to listOf(
                     "+ New session",


### PR DESCRIPTION
The maintainer's requested half-measure escape hatch: a **Reconnect** item in the session kebab (sibling of #989's Redraw) that recovers a dropped session IN PLACE — no more switch-to-another-session-and-back. Reuses the existing `viewModel.reconnect()` → `onManualReconnect()` path (no new reconnect path, D28); on recovery the #900 outbound queue auto-flushes the pending message.

Reviewer-APPROVED + rebased to coexist with #989's Redraw item (both in the 'This session' kebab group). On-device journey proven: drop → tap Reconnect → same session reconnects in place → queued send round-trips. Full local `:app:testDebugUnitTest` + assembleDebug green.

Closes #993. Part of #928 bulletproof.