### PR TITLE
Bulletproof wave 3: network-flip ride-through (#981) + last black-screen residual (#874) + integration-test flake (#1003)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/StableWifiNoSpuriousReconnectE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/StableWifiNoSpuriousReconnectE2eTest.kt
@@ -216,6 +216,144 @@ class StableWifiNoSpuriousReconnectE2eTest {
         writeTimings()
     }
 
+    /**
+     * ISSUE #981 — a REAL validated WIFI→CELLULAR identity flip (which DOES emit,
+     * past the #875 identity suppression) on a STABLE wifi while the live SSH
+     * transport is provably alive must NOT tear down + redial the healthy socket
+     * (the #974 stable-wifi drop). This is the gap the #875 proof above leaves:
+     * it deliberately does NOT drive the emitted WIFI→CELLULAR handoff to
+     * completion against a live transport. Here we DO — a transient default-network
+     * validation flip while the keepalive is still proving the link alive — and
+     * assert ZERO reconnect on the FULL on-device path (observer detector → App
+     * `changes` collector → VM network hook → `reduceNetworkChanged`).
+     *
+     * The transport-proven-alive state is pinned SYNTHETICALLY via
+     * [TmuxSessionViewModel.forceTransportProvenAliveForTest] (the #780 model — a
+     * HARD inject, no `assumeTrue` skip) so the load-bearing assertion runs on the
+     * CI swiftshader AVD too, modelling a live `-CC` link whose keepalive saw
+     * inbound bytes within the ride-through window.
+     *
+     * On BASE (no #981 liveness gate) the emitted WIFI→CELLULAR change →
+     * `scheduleNetworkReconnect` records `network_reconnect_start` + raises the
+     * Reconnecting band → the ZERO-reconnect assertions FAIL (RED). With the gate
+     * the proven-alive transport is ridden through → no diagnostics, no band,
+     * viewport painted, session stays Connected (GREEN).
+     */
+    @Test
+    fun realValidatedHandoffWhileTransportProvenAliveDoesNotReconnect() = runBlocking<Unit> {
+        val hostRowTag = requireNotNull(seededHostRowTag)
+        attachSeededTmuxSession(hostRowTag)
+        waitForVisibleTerminal("initial attach") { it.contains(READY_MARKER) }
+        waitForConnected("initial attach")
+        // Let the attach FULLY settle (the transient "Attaching…" switching overlay
+        // is part of the initial attach, not a reconnect) so the "stable wifi"
+        // precondition genuinely holds before we drive the flip.
+        waitForNoSwitchingOverlay("pre-flip attach settle")
+        captureViewport("issue981-01-attached")
+        diagnostics!!.clear()
+
+        // Pin the live transport as PROVEN ALIVE (the #974 case: a real -CC link
+        // whose keepalive saw inbound bytes within the ride-through window). HARD
+        // synthetic inject (#780) — no skip — so the gate is exercised on CI too.
+        currentViewModel().forceTransportProvenAliveForTest = true
+        try {
+            val observer = terminalNetworkObserver()
+            // Seed a baseline pure-WIFI identity so the next snapshot is a genuine
+            // transport-CHANGING flip (different identity → emits past #875).
+            observer.emitSyntheticSnapshotForTest(
+                TerminalNetworkSnapshot.Validated(networkHandle = "wifi-A", transports = setOf("WIFI")),
+                reason = "issue981-baseline-wifi",
+            )
+
+            // THE FLIP: a real WIFI→CELLULAR validated identity change. This DOES
+            // emit (different transports → not identity-identical) and reaches the VM
+            // network hook — exactly the transient stable-wifi validation flip from
+            // #974. The #981 liveness gate must ride it through.
+            val flipStart = SystemClock.elapsedRealtime()
+            val emitted = observer.emitSyntheticSnapshotForTest(
+                TerminalNetworkSnapshot.Validated(networkHandle = "cell-X", transports = setOf("CELLULAR")),
+                reason = "issue981-transient-wifi-cellular-flip",
+            )
+            recordTiming("issue981_flip_emit_ms", SystemClock.elapsedRealtime() - flipStart)
+
+            // Sanity: the flip genuinely EMITTED (past #875). If it were suppressed
+            // upstream this proof would be vacuous (G6) — assert it actually reached
+            // the VM hook so the gate, not the detector, is what rides it through.
+            assertNotNull(
+                "the WIFI→CELLULAR flip must EMIT (different identity, past #875) so the " +
+                    "#981 liveness gate — not the detector — is what suppresses the redial",
+                emitted,
+            )
+
+            // Watch the AUTHORITATIVE redial signal across the whole window: the redial
+            // path records `network_reconnect_start` the instant it tears down + redials
+            // (it fires on BASE the moment the emitted flip reaches the VM hook). The
+            // teardown also bumps the connect-attempt counter. A transient "Attaching…"
+            // recomposition is NOT the symptom (no socket was torn down) — the redial
+            // diagnostic + connect attempt are, so those are the load-bearing watch.
+            watchNoReconnectDiagnostics("during proven-alive handoff", WATCH_NO_RECONNECT_MS)
+
+            // LOAD-BEARING #1 (the always-available authoritative proof): ZERO redial
+            // diagnostics. `network_reconnect_start` is the loud signal the redial path
+            // records — it fires on BASE and is absent with the gate.
+            assertNoReconnectDiagnostics("after proven-alive handoff")
+            // LOAD-BEARING #2 (positive control, G6 — the gate actually FIRED, not a
+            // vacuous pass): the suppress decision was recorded with the proven-alive
+            // cause. This proves the #981 gate — not the detector — rode it through.
+            val suppressedAlive = diagnostics!!.eventsNamed("network_reconnect_skip")
+                .filter { it.fields["cause"] == "transport_proven_alive" }
+            assertTrue(
+                "expected the #981 liveness gate to record a transport_proven_alive " +
+                    "suppress for the emitted WIFI→CELLULAR flip (proves the gate fired, " +
+                    "not a vacuous pass); skips=${diagnostics!!.eventsNamed("network_reconnect_skip")}",
+                suppressedAlive.isNotEmpty(),
+            )
+            // LOAD-BEARING #3: the session settles back to a steady Connected state with
+            // the viewport painted and NO lingering reconnect band — the user is never
+            // left in a Reconnecting/Disconnected state by the flip.
+            waitForConnected("after proven-alive handoff")
+            waitForVisibleTerminal("after handoff terminal") { it.contains(READY_MARKER) }
+            waitForNoSwitchingOverlay("after proven-alive handoff settle")
+            assertNoVisibleReconnect("after proven-alive handoff")
+            captureViewport("issue981-02-after-proven-alive-handoff")
+        } finally {
+            currentViewModel().forceTransportProvenAliveForTest = null
+        }
+
+        writeTimings()
+    }
+
+    private fun currentViewModel(): TmuxSessionViewModel {
+        lateinit var vm: TmuxSessionViewModel
+        compose.activityRule.scenario.onActivity { activity ->
+            vm = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+        }
+        return vm
+    }
+
+    /**
+     * Wait until the transient "Attaching…" switching-loading overlay is gone — it
+     * appears as part of the initial attach settle and is NOT a reconnect. Gating on
+     * its absence establishes the genuine "stable wifi" precondition before driving
+     * the #981 flip.
+     */
+    private fun waitForNoSwitchingOverlay(label: String) {
+        compose.waitUntil(timeoutMillis = CONNECTED_TIMEOUT_MS) {
+            runCatching {
+                compose.onAllNodesWithTag(TMUX_SWITCHING_LOADING_TAG, useUnmergedTree = true)
+                    .fetchSemanticsNodes()
+                    .isEmpty()
+            }.getOrDefault(false)
+        }
+        assertEquals(
+            "expected the attach to fully settle (no 'Attaching…' overlay) before $label",
+            0,
+            compose.onAllNodesWithTag(TMUX_SWITCHING_LOADING_TAG, useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .size,
+        )
+    }
+
     private fun terminalNetworkObserver(): TerminalNetworkObserver {
         val ctx = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
         return EntryPointAccessors
@@ -355,6 +493,22 @@ class StableWifiNoSpuriousReconnectE2eTest {
         val deadline = SystemClock.elapsedRealtime() + durationMs
         while (SystemClock.elapsedRealtime() < deadline) {
             assertNoVisibleReconnect(label)
+            SystemClock.sleep(100)
+        }
+    }
+
+    /**
+     * Issue #981: watch the AUTHORITATIVE redial diagnostics across the window. The
+     * teardown+redial path records `network_reconnect_start` the instant it fires
+     * (on BASE, the moment the emitted flip reaches the VM hook). A stable session
+     * riding the flip through records NONE — this is the load-bearing no-reconnect
+     * watch (a transient "Attaching…" recomposition with no socket teardown is not
+     * the #974 symptom; the redial diagnostic is).
+     */
+    private fun watchNoReconnectDiagnostics(label: String, durationMs: Long) {
+        val deadline = SystemClock.elapsedRealtime() + durationMs
+        while (SystemClock.elapsedRealtime() < deadline) {
+            assertNoReconnectDiagnostics(label)
             SystemClock.sleep(100)
         }
     }

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/AgentConversationReconnectDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/AgentConversationReconnectDockerTest.kt
@@ -1033,6 +1033,182 @@ class AgentConversationReconnectDockerTest {
         }
     }
 
+    /**
+     * Issue #874 (residual black-screen): a presumed-agent pane that is
+     * RECONCILED rather than freshly added — a beyond-grace reattach (#959) or a
+     * switch-back to a REBUILT cached runtime — whose Conversation row was DROPPED
+     * (the R3-B 2-null collapse on a wedged channel) has NO row on restore.
+     * `restoreCachedRuntime` only restarts rows that had a live `detection`
+     * (`restartAgentConversationsForRestoredRuntime`), and the cache-restore path
+     * never reconciles — so a presumed-agent pane with a dropped row falls through
+     * to the always-mounted raw `TmuxTerminalPager` → the #807 black void.
+     *
+     * #975 fixed the verdict-clearing and #989 fixed the terminal-buffer reseed;
+     * this closes the remaining void by re-seeding the #878 Conversation
+     * placeholder when the recorded-kind verdict resolves the session as NOT a
+     * confirmed shell (`applyRecordedShellVerdict(isShell = false)`, the single
+     * verdict-application point reached after a restore via
+     * `refreshCurrentSessionRecordedKind`), AFTER the verdict so #894's
+     * no-flash-on-shell invariant holds.
+     *
+     * This drives the production [TmuxSessionViewModel] against the deterministic
+     * Docker `agents` fixture (host port 2222) through the FRESH-attach path, then
+     * injects the residual-void state synthetically (the #780/D33 model — the
+     * wedged-channel row-drop-then-restore cannot be driven deterministically on
+     * the shared AVD): drop the pane's conversation row, then drive the not-shell
+     * verdict, and assert the user-visible Conversation placeholder is re-seeded —
+     * never the raw black Terminal. The verdict seam ([applyRecordedShellVerdictForTest])
+     * is the EXACT production code path `refreshCurrentSessionRecordedKind`
+     * invokes; no synthetic stand-in for the surface logic itself.
+     */
+    @Test
+    fun reconciledPresumedAgentWithDroppedRowReseedsConversationPlaceholderOnDevice(): Unit = runBlocking {
+        val key = readFixtureKey()
+        waitForSshFixtureReady(SshKey.Pem(key))
+
+        val keyPath = writeKeyFile(key)
+        val sessionName = "issue874-void-${System.currentTimeMillis().toString().takeLast(8)}"
+        val cwd = "/home/$DEFAULT_USER"
+        cleanupCommands += "tmux kill-session -t ${shellQuote(sessionName)} 2>/dev/null || true"
+
+        // A presumed-agent pane: a plain shell pane attached over the real
+        // fixture (presumed-agent at the screen layer; no confirmed-shell verdict
+        // recorded). The residual-void state is then injected synthetically.
+        execRemote(
+            key,
+            buildString {
+                appendLine("set -eu")
+                appendLine("tmux kill-session -t ${shellQuote(sessionName)} 2>/dev/null || true")
+                appendLine(
+                    "tmux new-session -d -x 80 -y 24 -s ${shellQuote(sessionName)} " +
+                        "-c ${shellQuote(cwd)}",
+                )
+                appendLine("sleep 1")
+            },
+        )
+
+        val vm = TmuxSessionViewModel(
+            tmuxClientFactory = TmuxClientFactory(factoryScope),
+            activeTmuxClients = ActiveTmuxClients(),
+            runtimeCache = TmuxSessionRuntimeCache(maxEntries = 0),
+        )
+        // The open-time default is Conversation (the black-screen cure) — the
+        // exact state where the residual void appears.
+        vm.setDefaultAgentSessionViewForTest(
+            com.pocketshell.app.settings.DefaultAgentSessionView.Conversation,
+        )
+        try {
+            vm.connect(
+                hostId = 874L,
+                hostName = "Issue874 Void Docker",
+                host = DEFAULT_HOST,
+                port = DEFAULT_PORT,
+                user = DEFAULT_USER,
+                keyPath = keyPath,
+                passphrase = null,
+                sessionName = sessionName,
+            )
+            waitForStatus<TmuxSessionViewModel.ConnectionStatus.Connected>(vm, "issue874 connect")
+            val panes = waitForPanes(vm, "issue874 attach panes")
+            val windowId = panes.first().windowId
+            val paneId = panes.first { it.windowId == windowId }.paneId
+            val sessionId = panes.first { it.paneId == paneId }.sessionId
+            stamp("issue874_attached window=$windowId pane=$paneId sessionId=$sessionId")
+
+            // On open the pane got the #878 Conversation placeholder.
+            waitForCondition(
+                label = "issue874 open-time Conversation placeholder",
+                timeoutMs = 10_000,
+                describe = { "row=${vm.agentConversations.value[paneId]}" },
+                predicate = { vm.agentConversations.value[paneId]?.selectedTab == SessionTab.Conversation },
+            )
+
+            // SYNTHETIC residual-void injection (#780/D33): the R3-B 2-null
+            // collapse on a wedged channel dropped the conversation row, and the
+            // runtime was parked WITHOUT it — so on a switch-back/restore the pane
+            // has NO row and falls to the raw black Terminal.
+            vm.clearAgentDetectionForPaneForTest(paneId)
+            waitForCondition(
+                label = "issue874 row dropped (the void precondition)",
+                timeoutMs = 5_000,
+                describe = { "row=${vm.agentConversations.value[paneId]}" },
+                predicate = { vm.agentConversations.value[paneId] == null },
+            )
+            assertNull(
+                "#874 precondition: the presumed-agent pane has NO conversation row " +
+                    "(the raw-Terminal void state); pane=$paneId",
+                vm.agentConversations.value[paneId],
+            )
+
+            // The recorded-kind verdict resolves the session as NOT a confirmed
+            // shell — the EXACT production verdict-application call
+            // refreshCurrentSessionRecordedKind makes after a restore. On base no
+            // re-seed runs → the pane stays rowless → the raw black Terminal void.
+            vm.applyRecordedShellVerdictForTest(sessionId = sessionId, isShell = false)
+            waitForCondition(
+                label = "issue874 Conversation placeholder re-seeded",
+                timeoutMs = 10_000,
+                describe = { "row=${vm.agentConversations.value[paneId]} confirmedShell=${vm.confirmedShellPaneIds.value}" },
+                predicate = { vm.agentConversations.value[paneId] != null },
+            )
+
+            // CORE ASSERTION (#874): the dropped presumed-agent pane re-seeds the
+            // Conversation placeholder — the user-visible surface is the readable
+            // detecting placeholder, NEVER the residual black Terminal void.
+            val row = vm.agentConversations.value[paneId]
+            assertNotNull(
+                "#874: a not-shell verdict re-seeds the dropped presumed-agent pane's " +
+                    "Conversation placeholder (no residual black Terminal void); pane=$paneId; " +
+                    "conversations=${vm.agentConversations.value.keys}",
+                row,
+            )
+            assertEquals(
+                "#874: the re-seed lands on the Conversation surface (not the raw Terminal void)",
+                SessionTab.Conversation,
+                row!!.selectedTab,
+            )
+            assertNull(
+                "#874: the re-seed is the detection-less detecting placeholder",
+                row.detection,
+            )
+            assertEquals(
+                "#874: the re-seed is in the Loading (detecting) state",
+                ConversationLoadState.Loading,
+                row.loadState,
+            )
+            assertTrue(
+                "#874: the re-seed is flagged as an auto-seed",
+                row.autoSeededPlaceholder,
+            )
+            stamp(
+                "issue874_void_healed pane=$paneId tab=${row.selectedTab} " +
+                    "detection=${row.detection} loadState=${row.loadState}",
+            )
+
+            writeText(
+                "issue874-residual-void-summary.txt",
+                buildString {
+                    appendLine("scenario=reconciled-presumed-agent-dropped-row-reseeds-conversation-placeholder (#874)")
+                    appendLine("session_name=$sessionName")
+                    appendLine("window_id=$windowId")
+                    appendLine("pane_id=$paneId")
+                    appendLine("session_id=$sessionId")
+                    appendLine("void_precondition_row_dropped=true")
+                    appendLine("verdict_applied=not-shell (refreshCurrentSessionRecordedKind path)")
+                    appendLine("reseeded_tab=${row.selectedTab}")
+                    appendLine("reseeded_detection=${row.detection}")
+                    appendLine("reseeded_load_state=${row.loadState}")
+                    appendLine("reseeded_auto_seed=${row.autoSeededPlaceholder}")
+                    appendLine("confirmed_shell=${vm.confirmedShellPaneIds.value}")
+                    appendLine("stamps:")
+                    stamps.forEach { appendLine("  $it") }
+                },
+            )
+        } finally {
+            vm.clearForTest()
+        }
+    }
+
     private suspend inline fun <reified T : TmuxSessionViewModel.ConnectionStatus> waitForStatus(
         vm: TmuxSessionViewModel,
         label: String,

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -4276,16 +4276,26 @@ public class TmuxSessionViewModel @Inject constructor(
         val target = activeTarget ?: connectingTarget
         // EPIC #792 Slice E: feed the AUTHORITATIVE controller the #548 validated-handoff
         // signal it suppresses on (computed identically to the inline reducer).
+        //
+        // Issue #981: the controller flips Live → Reconnecting on a validated handoff,
+        // which drives the RevealStateMachine → the "Attaching…" overlay. That is a
+        // USER-VISIBLE disconnect glitch even when the inline reducer rides the flip
+        // through. So the controller signal MUST honor the SAME liveness gate: when the
+        // old transport is proven alive we report NO handoff to the controller, keeping
+        // it Live (no overlay), in lockstep with [reduceNetworkChanged].
+        val realValidatedHandoff = change.previousValidated?.let { previous ->
+            !previous.hasSameNetworkIdentityAs(change.current)
+        } ?: false
         connectionManager.observeNetworkChanged(
-            validatedHandoff = change.previousValidated?.let { previous ->
-                !previous.hasSameNetworkIdentityAs(change.current)
-            } ?: false,
+            validatedHandoff = realValidatedHandoff && !isTransportKeepAliveProvenAliveRecently(),
         )
         when (reduceConnection(ConnectionEvent.NetworkChanged(change))) {
             ConnectionDecision.SuppressNetworkNotValidated ->
                 if (target != null) suppressNetworkNotValidated(change, target)
             ConnectionDecision.SuppressNetworkCoalesced ->
                 if (target != null) suppressNetworkCoalesced(change, target)
+            ConnectionDecision.SuppressNetworkTransportProvenAlive ->
+                if (target != null) suppressNetworkTransportProvenAlive(change, target)
             ConnectionDecision.ScheduleNetworkReconnect ->
                 if (target != null) scheduleNetworkReconnect(change, target)
             else -> Unit
@@ -4421,6 +4431,73 @@ public class TmuxSessionViewModel @Inject constructor(
                 "hostId" to target.hostId,
                 "generation" to lifecycleCoalesce.generation,
                 "classification" to "lifecycle_network_replay",
+                "deferredFromBackground" to change.deferredFromBackground,
+            )
+        }
+    }
+
+    /**
+     * Issue #981: the [ConnectionDecision.SuppressNetworkTransportProvenAlive]
+     * body. A real validated identity change WAS observed (we are past the
+     * `realValidatedIdentityChange` gate), but the live transport's keepalive
+     * has seen inbound bytes within its ride-through window, so the old socket
+     * is provably alive and a teardown+redial here would be the #974 spurious
+     * stable-wifi drop. We ride it through (no `unregisterCurrentClient` / no
+     * `scheduleAutoReconnect`) and emit the device trail showing WHY, mirroring
+     * [suppressNetworkNotValidated]. `realValidatedIdentityChange` is always
+     * `true` here (only a real handoff reaches this gate).
+     */
+    private fun suppressNetworkTransportProvenAlive(
+        change: TerminalNetworkChange,
+        target: ConnectionTarget,
+    ) {
+        val reason = change.reason
+        val previousValidated = change.previousValidated
+        run {
+            Log.i(
+                ISSUE_548_NETWORK_TAG,
+                "tmux-network-proactive-reconnect-skip reason=$reason " +
+                    "cause=transport-proven-alive " +
+                    "previousValidated=${previousValidated?.logValue ?: "none"} " +
+                    "current=${change.current.logValue} " +
+                    targetLogFields(target),
+            )
+            DiagnosticEvents.record(
+                "connection",
+                "network_reconnect_skip",
+                "source" to "network_observer",
+                "trigger" to TmuxConnectTrigger.NetworkReconnect.logValue,
+                "reason" to reason,
+                "cause" to "transport_proven_alive",
+                "classification" to "network_handoff_transport_alive",
+                "reconnect" to false,
+                "realValidatedIdentityChange" to true,
+                "sequence" to change.sequence,
+                "hostId" to target.hostId,
+                "host" to target.host,
+                "port" to target.port,
+                "user" to target.user,
+                "session" to target.sessionName,
+                "generation" to connectGeneration,
+                "attempt" to activeAttachMilestone?.attempt,
+                "activeTrigger" to activeAttachMilestone?.trigger?.logValue,
+                "deferredFromBackground" to change.deferredFromBackground,
+                *change.networkDiagnosticFields(),
+                *shortAppSwitchReconnectFields(
+                    trigger = TmuxConnectTrigger.NetworkReconnect,
+                    target = target,
+                    sourceCandidate = "network_observer",
+                ),
+            )
+            ReconnectCauseTrail.record(
+                stage = "network_reconnect_decision",
+                outcome = "suppress",
+                cause = "transport_proven_alive",
+                trigger = TmuxConnectTrigger.NetworkReconnect.logValue,
+                "sequence" to change.sequence,
+                "hostId" to target.hostId,
+                "generation" to connectGeneration,
+                "classification" to "network_handoff_transport_alive",
                 "deferredFromBackground" to change.deferredFromBackground,
             )
         }
@@ -15443,6 +15520,19 @@ public class TmuxSessionViewModel @Inject constructor(
         /** Suppress: coalesced with an in-flight lifecycle reattach (#548). */
         data object SuppressNetworkCoalesced : ConnectionDecision
 
+        /**
+         * Suppress: a real validated identity change WAS observed, but the live
+         * transport is provably alive within the keepalive ride-through window
+         * (#981). A new default-network identity does NOT mean the old socket
+         * died — if the keepalive has seen inbound bytes recently the link is
+         * healthy, so tearing it down + redialing is a spurious disconnect (the
+         * #974 stable-wifi drop). Mirrors the #964 probe deferral so both redial
+         * triggers honor ONE coherent liveness budget. A genuinely dead link
+         * ages out of the keepalive window, this gate stops suppressing, and
+         * recovery proceeds via the next change or the keepalive's own close.
+         */
+        data object SuppressNetworkTransportProvenAlive : ConnectionDecision
+
         // --- TransportDropped (passive disconnect) ---
         /**
          * The screen stopped for an in-app navigation to a DIFFERENT session
@@ -15510,6 +15600,19 @@ public class TmuxSessionViewModel @Inject constructor(
             sameSessionIdentity(lifecycleCoalesce.target, target)
         ) {
             return ConnectionDecision.SuppressNetworkCoalesced
+        }
+        // Issue #981: a real validated default-network identity change does NOT
+        // prove the old SSH socket died. If the transport keepalive has seen
+        // inbound bytes within its ride-through window the link is provably
+        // alive, so a teardown+redial here is a SPURIOUS disconnect — the #974
+        // stable-wifi drop, where a transient WIFI↔CELLULAR validation flip on
+        // an otherwise-healthy link tore down a live socket. Mirror the #964
+        // probe deferral and ride it through. A genuinely dead link stops
+        // bumping inbound activity, ages out of the window, this gate stops
+        // suppressing, and the next change (or the keepalive's own dead-close)
+        // recovers it.
+        if (isTransportKeepAliveProvenAliveRecently()) {
+            return ConnectionDecision.SuppressNetworkTransportProvenAlive
         }
         return ConnectionDecision.ScheduleNetworkReconnect
     }

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -10415,6 +10415,32 @@ public class TmuxSessionViewModel @Inject constructor(
                     clearAgentDetectionForPane(paneId)
                 }
             }
+        } else {
+            // Issue #874 (residual black-screen): a presumed-agent pane that is
+            // RECONCILED rather than freshly added — a beyond-grace reattach
+            // (#959) or a switch-back to a REBUILT cached runtime
+            // ([restoreCachedRuntime] restores `runtime.agentConversations`, which
+            // only carries rows that had a live `detection`; a row dropped by the
+            // R3-B 2-null collapse on a wedged channel is gone) — has NO
+            // conversation row. `seedPresumedAgentPlaceholder` fires per-pane in
+            // [applyParsedPanes], but the cache-restore path never reconciles, so
+            // its presumed-agent panes fall through to the always-mounted raw
+            // `TmuxTerminalPager` — the #807 black void.
+            //
+            // The verdict has now resolved this session as NOT a confirmed shell
+            // (foreign / agent / re-classified). Running the re-seed pass HERE —
+            // AFTER the recorded-kind verdict applies — re-establishes the
+            // Conversation "Loading…" placeholder for any presumed-agent pane that
+            // lost its row, closing the void. It is idempotent: a pane that still
+            // has a row (`containsKey`), a confirmed shell
+            // (`isConfirmedShellSession`, false here by construction), or the
+            // Terminal open-time default are all skipped inside
+            // [seedPresumedAgentPlaceholder] — so #894's no-flash-on-shell
+            // invariant holds (a confirmed shell is never re-seeded) and a live
+            // row is never clobbered (no #815 yank).
+            paneRows.values
+                .filter { it.sessionId.trim() == key }
+                .forEach { seedPresumedAgentPlaceholder(it) }
         }
         if (changed || isShell) refreshConfirmedShellPaneIds()
     }

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
@@ -8184,6 +8184,134 @@ class TmuxSessionViewModelTest {
     //
     // G2 class coverage: shell-vs-agent × default=Conversation-vs-Terminal.
 
+    // ─── Issue #874 (residual black-screen): the reconcile/cache-restore void ──
+    //
+    // #975 fixed the verdict-clearing and #989 fixed the terminal-buffer reseed,
+    // leaving one residual void: a presumed-agent pane that is RECONCILED rather
+    // than freshly added — a beyond-grace reattach (#959) or a switch-back to a
+    // REBUILT cached runtime — whose conversation row was DROPPED (the R3-B
+    // 2-null collapse on a wedged channel) has NO row on restore.
+    // `restoreCachedRuntime` only restarts rows that carried a live `detection`
+    // (`restartAgentConversationsForRestoredRuntime`'s `state.detection ?: return`),
+    // and that path never reconciles — so a presumed-agent pane with a dropped
+    // row falls through to the always-mounted raw `TmuxTerminalPager` → the #807
+    // black void.
+    //
+    // The fix re-seeds the #878 Conversation placeholder for the session's
+    // presumed-agent panes when the recorded-kind verdict resolves the session as
+    // NOT a confirmed shell (`applyRecordedShellVerdict(isShell = false)`, the
+    // single verdict-application point reached after a restore via
+    // `refreshCurrentSessionRecordedKind`). It runs AFTER the verdict so #894's
+    // no-flash-on-shell invariant holds.
+    //
+    // G10 reproduce-first: on base the verdict-application re-seed does not exist,
+    // so a dropped-row presumed-agent pane stays rowless → raw Terminal void. RED
+    // on base (row null after the verdict), GREEN with the fix (Conversation
+    // placeholder re-seeded). G2 class coverage: reconciled-presumed-agent
+    // (re-seeds), reconciled-confirmed-shell (NO placeholder, #894 no-flash),
+    // freshly-added (unchanged).
+
+    @Test
+    fun reconciledPresumedAgentWithDroppedRowReseedsConversationPlaceholder() = runTest(scheduler) {
+        // The residual #874 void: a presumed-agent pane whose row was dropped and
+        // is then restored/reconciled (no live detection to restart) gets its
+        // Conversation placeholder re-seeded when the verdict resolves NOT-shell.
+        val vm = newVm()
+        vm.setDefaultAgentSessionViewForTest(
+            com.pocketshell.app.settings.DefaultAgentSessionView.Conversation,
+        )
+        vm.connectWithPaneForTest(paneId = "%0", windowId = "@0")
+        runCurrent()
+        // Drop the auto-seeded row to null — model the R3-B 2-null collapse on a
+        // wedged channel that wiped the conversation row before the runtime was
+        // parked (so the restored runtime carries NO row for this pane).
+        vm.clearAgentDetectionForPaneForTest("%0")
+        runCurrent()
+        assertNull("precondition: the presumed-agent pane has no conversation row", vm.agentConversations.value["%0"])
+
+        // The recorded-kind verdict resolves the session as NOT a confirmed shell
+        // (foreign / agent / re-classified) — the single verdict-application point
+        // reached on a restore via refreshCurrentSessionRecordedKind. On base no
+        // re-seed runs → the pane stays rowless → the raw Terminal void (#807).
+        vm.applyRecordedShellVerdictForTest(sessionId = "$0", isShell = false)
+        runCurrent()
+
+        val row = vm.agentConversations.value["%0"]
+        assertNotNull(
+            "#874: a not-shell verdict re-seeds the dropped presumed-agent pane's" +
+                " Conversation placeholder (no residual black Terminal void)",
+            row,
+        )
+        assertEquals("#874: the re-seed lands on the Conversation surface", SessionTab.Conversation, row!!.selectedTab)
+        assertNull("#874: the re-seed is detection-less (the detecting placeholder)", row.detection)
+        assertEquals("#874: the re-seed is in the Loading state", ConversationLoadState.Loading, row.loadState)
+        assertTrue("#874: the re-seed is flagged as an auto-seed", row.autoSeededPlaceholder)
+    }
+
+    @Test
+    fun confirmedShellVerdictNeverReseedsPlaceholderNoFlash() = runTest(scheduler) {
+        // #894 no-flash invariant (class coverage): a CONFIRMED-shell verdict must
+        // NOT re-seed the Conversation placeholder for a rowless pane. The #874
+        // re-seed pass runs ONLY on the not-shell branch; the shell branch still
+        // drops/keeps placeholders exactly as before (no wrong-surface flash on a
+        // genuine shell).
+        val vm = newVm()
+        vm.setDefaultAgentSessionViewForTest(
+            com.pocketshell.app.settings.DefaultAgentSessionView.Conversation,
+        )
+        vm.connectWithPaneForTest(paneId = "%0", windowId = "@0")
+        runCurrent()
+        vm.clearAgentDetectionForPaneForTest("%0")
+        runCurrent()
+        assertNull("precondition: rowless pane", vm.agentConversations.value["%0"])
+
+        // A recorded SHELL verdict must NOT re-seed — a confirmed shell stays on
+        // the raw Terminal (correct), never flashing the Conversation placeholder.
+        vm.applyRecordedShellVerdictForTest(sessionId = "$0", isShell = true)
+        runCurrent()
+        assertNull(
+            "#894: a confirmed-shell verdict never re-seeds the Conversation placeholder",
+            vm.agentConversations.value["%0"],
+        )
+        assertTrue(
+            "#894: the confirmed-shell verdict is published per-pane",
+            "%0" in vm.confirmedShellPaneIds.value,
+        )
+    }
+
+    @Test
+    fun notShellVerdictDoesNotClobberLiveRowNoYank() = runTest(scheduler) {
+        // #815 no-yank invariant (class coverage): the #874 re-seed must NOT
+        // clobber a pane that ALREADY has a row (a live agent or a user-tapped
+        // choice). seedPresumedAgentPlaceholder self-gates on `containsKey`, so a
+        // not-shell verdict over a live row is a no-op.
+        val vm = newVm()
+        vm.setDefaultAgentSessionViewForTest(
+            com.pocketshell.app.settings.DefaultAgentSessionView.Conversation,
+        )
+        vm.connectWithPaneForTest(paneId = "%0", windowId = "@0")
+        runCurrent()
+        // A live Codex binds; user is on the Terminal tab (an explicit choice the
+        // re-seed must not yank back to Conversation).
+        vm.markAgentTailLiveForTest("%0", newCodexDetection())
+        vm.selectSessionTab("%0", SessionTab.Terminal)
+        runCurrent()
+        val before = vm.agentConversations.value["%0"]!!
+        assertEquals("precondition: live Codex row on Terminal", SessionTab.Terminal, before.selectedTab)
+        assertEquals(AgentKind.Codex, before.detection?.agent)
+
+        vm.applyRecordedShellVerdictForTest(sessionId = "$0", isShell = false)
+        runCurrent()
+        val after = vm.agentConversations.value["%0"]!!
+        assertEquals(
+            "#815: the not-shell verdict re-seed does NOT yank a live row's tab",
+            SessionTab.Terminal,
+            after.selectedTab,
+        )
+        assertEquals("#815: the live detection is preserved", AgentKind.Codex, after.detection?.agent)
+    }
+
+
     @Test
     fun confirmedShellPaneSeedGateSuppressesConversationPlaceholder() = runTest(scheduler) {
         // AC1 + AC4 (shell branch, default = Conversation). A pane whose session

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
@@ -3599,6 +3599,218 @@ class TmuxSessionViewModelTest {
         assertEquals(0, connector.connectCount)
     }
 
+    // ---- Issue #981: network handoff rides through while the transport is proven alive ----
+
+    @Test
+    fun issue981ValidatedNetworkFlipDoesNotTearDownTransportProvenAliveLink() = runTest(scheduler) {
+        // Issue #981 reproduce-first (red on base): a REAL validated default-network
+        // identity flip (WIFI→CELLULAR) arrives while the live SSH transport is
+        // provably alive (its keepalive saw inbound bytes within the ride-through
+        // window — the #974 stable-wifi case where -CC traffic keeps the link warm).
+        // The reactive handoff path must NOT tear down + redial the healthy socket.
+        // On base (no liveness gate) this asserts Reconnecting + 1 connect and FAILS;
+        // with the fix it rides through (Connected, zero connects).
+        TMUX_CONNECT_ATTEMPTS.set(0)
+        val registry = ActiveTmuxClients()
+        val connector = QueueLeaseConnector(FakeSshSession())
+        val vm = newVm(
+            registry = registry,
+            sshLeaseManager = testLeaseManager(connector = connector, scope = this, idleTtlMillis = 0L),
+        )
+        vm.setAutoReconnectDelaysForTest(listOf(0L))
+        // A live session whose transport keepalive proves the link is alive.
+        val session = FakeSshSession().apply { transportProvenAlive = true }
+        vm.replaceClientForTest(
+            hostId = 7L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            sessionName = "work",
+            client = FakeTmuxClient(),
+            session = session,
+        )
+        advanceUntilIdle()
+        assertTrue(
+            "precondition: the link is the proven-alive transport the gate must ride through",
+            vm.isTransportKeepAliveProvenAliveRecentlyForTest(),
+        )
+
+        registry.lifecycleHooksSnapshot().single().onNetworkChanged(
+            networkChange(
+                previous = TerminalNetworkSnapshot.Validated("wifi"),
+                current = TerminalNetworkSnapshot.Validated("cell"),
+                previousValidated = TerminalNetworkSnapshot.Validated("wifi"),
+                reason = "transient-wifi-cellular-flip-on-stable-wifi",
+            ),
+        )
+        advanceUntilIdle()
+
+        assertTrue(
+            "a validated network flip while the transport is PROVEN ALIVE must ride through, " +
+                "not tear down the healthy socket (#981 / #974 stable-wifi drop)",
+            vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+        assertEquals(
+            "no redial may be scheduled while the old transport is provably alive",
+            0,
+            connector.connectCount,
+        )
+        assertEquals(0, TMUX_CONNECT_ATTEMPTS.get())
+        assertNotEquals(
+            "the proactive-handoff redial intent must NOT fire on a proven-alive link",
+            TmuxConnectTrigger.NetworkReconnect,
+            vm.latestRestoreIntentSnapshot()?.trigger,
+        )
+    }
+
+    @Test
+    fun issue981ValidatedNetworkFlipStillReconnectsWhenTransportIsDead() = runTest(scheduler) {
+        // Issue #981 class-coverage (G2): the gate must NOT mask a GENUINE handoff.
+        // Same WIFI→CELLULAR flip, but the transport keepalive has aged out (the old
+        // socket is really dead) → the path must STILL reconnect, exactly as before.
+        val registry = ActiveTmuxClients()
+        val connector = QueueLeaseConnector(FakeSshSession())
+        val vm = newVm(
+            registry = registry,
+            sshLeaseManager = testLeaseManager(connector = connector, scope = this, idleTtlMillis = 0L),
+        )
+        vm.setAutoReconnectDelaysForTest(listOf(60_000L))
+        // A live session whose transport keepalive has stopped proving liveness.
+        val session = FakeSshSession().apply { transportProvenAlive = false }
+        vm.replaceClientForTest(
+            hostId = 7L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            sessionName = "work",
+            client = FakeTmuxClient(),
+            session = session,
+        )
+        runCurrent()
+        assertFalse(
+            "precondition: the dead transport must NOT report proven-alive",
+            vm.isTransportKeepAliveProvenAliveRecentlyForTest(),
+        )
+
+        registry.lifecycleHooksSnapshot().single().onNetworkChanged(
+            networkChange(
+                previous = TerminalNetworkSnapshot.Validated("wifi"),
+                current = TerminalNetworkSnapshot.Validated("cell"),
+                previousValidated = TerminalNetworkSnapshot.Validated("wifi"),
+                reason = "genuine-wifi-cellular-handoff-dead-link",
+            ),
+        )
+        runCurrent()
+
+        assertEquals(
+            "a genuine handoff on a DEAD link must still proactively reconnect (gate must not mask recovery)",
+            TmuxConnectTrigger.NetworkReconnect,
+            vm.latestRestoreIntentSnapshot()?.trigger,
+        )
+        assertTrue(vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Reconnecting)
+    }
+
+    @Test
+    fun issue981SameIdentityReassocStillSuppressedRegardlessOfTransportLiveness() = runTest(scheduler) {
+        // Issue #981 class-coverage: a same-identity reassoc (#875 pure-{WIFI} roam)
+        // is still suppressed by hasSameNetworkIdentityAs BEFORE the liveness gate,
+        // so the new gate does not change that path — proven-alive or not.
+        TMUX_CONNECT_ATTEMPTS.set(0)
+        val registry = ActiveTmuxClients()
+        val connector = QueueLeaseConnector(FakeSshSession())
+        val vm = newVm(
+            registry = registry,
+            sshLeaseManager = testLeaseManager(connector = connector, scope = this, idleTtlMillis = 0L),
+        )
+        vm.setAutoReconnectDelaysForTest(listOf(0L))
+        val session = FakeSshSession().apply { transportProvenAlive = false }
+        vm.replaceClientForTest(
+            hostId = 7L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            sessionName = "work",
+            client = FakeTmuxClient(),
+            session = session,
+        )
+        advanceUntilIdle()
+
+        registry.lifecycleHooksSnapshot().single().onNetworkChanged(
+            networkChange(
+                previous = TerminalNetworkSnapshot.Validated("wifi"),
+                current = TerminalNetworkSnapshot.Validated("wifi"),
+                previousValidated = TerminalNetworkSnapshot.Validated("wifi"),
+                reason = "same-identity-reassoc",
+            ),
+        )
+        advanceUntilIdle()
+
+        assertTrue(
+            "a same-identity reassoc is suppressed upstream (#875) and never reaches the redial",
+            vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+        assertEquals(0, connector.connectCount)
+        assertEquals(0, TMUX_CONNECT_ATTEMPTS.get())
+    }
+
+    @Test
+    fun issue981ReducerSuppressesProvenAliveButSchedulesDeadLinkFlip() = runTest(scheduler) {
+        // Issue #981 reducer-level proof: the decision classifier itself returns
+        // SuppressNetworkTransportProvenAlive when proven alive and
+        // ScheduleNetworkReconnect when the link is dead, using the explicit seam.
+        val registry = ActiveTmuxClients()
+        val connector = QueueLeaseConnector(FakeSshSession())
+        val vm = newVm(
+            registry = registry,
+            sshLeaseManager = testLeaseManager(connector = connector, scope = this, idleTtlMillis = 0L),
+        )
+        vm.setAutoReconnectDelaysForTest(listOf(60_000L))
+        vm.replaceClientForTest(
+            hostId = 7L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            sessionName = "work",
+            client = FakeTmuxClient(),
+        )
+        runCurrent()
+
+        // Proven alive → ride through.
+        vm.forceTransportProvenAliveForTest = true
+        registry.lifecycleHooksSnapshot().single().onNetworkChanged(
+            networkChange(reason = "flip-while-proven-alive"),
+        )
+        runCurrent()
+        assertTrue(
+            "proven-alive flip rides through (no Reconnecting band)",
+            vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+        assertEquals(0, connector.connectCount)
+
+        // Aged out (dead) → reconnect.
+        vm.forceTransportProvenAliveForTest = false
+        registry.lifecycleHooksSnapshot().single().onNetworkChanged(
+            networkChange(reason = "flip-while-dead", sequence = 2L),
+        )
+        runCurrent()
+        assertEquals(
+            "once the keepalive is dead the same flip must schedule the proactive reconnect",
+            TmuxConnectTrigger.NetworkReconnect,
+            vm.latestRestoreIntentSnapshot()?.trigger,
+        )
+        assertTrue(vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Reconnecting)
+
+        vm.forceTransportProvenAliveForTest = null
+    }
+
     @Test
     fun networkReconnectAndPassiveDisconnectAreCoalescedIntoOneAttempt() = runTest(scheduler) {
         TMUX_CONNECT_ATTEMPTS.set(0)

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -638,6 +638,26 @@ JOURNEY_CLASSES=(
   # local-only flaky-reconnect evidence). Target the single @Test method by
   # FQCN#method so the CI-gated reconnect cases are NOT selected here.
   "com.pocketshell.app.tmux.AgentConversationReconnectDockerTest#agentOpensOnDefaultViewAndIsNotYankedMidSessionShellGetsNoConversationRow"
+  # ADDED (#874 residual black-screen, conversation-source area — sibling of
+  # #878/#894/#975, D31/D32): a presumed-agent pane RECONCILED rather than freshly
+  # added — a beyond-grace reattach (#959) or a switch-back to a REBUILT cached
+  # runtime — whose Conversation row was DROPPED (the R3-B 2-null collapse) has NO
+  # row on restore (restoreCachedRuntime only restarts rows that had a live
+  # detection, and never reconciles), so it falls to the always-mounted raw
+  # TmuxTerminalPager → the #807 black void. The fix re-seeds the #878 Conversation
+  # placeholder when the recorded-kind verdict resolves the session NOT-shell
+  # (applyRecordedShellVerdict(isShell=false), AFTER the verdict so #894's
+  # no-flash-on-shell invariant holds). This connected proof drives the production
+  # TmuxSessionViewModel against the deterministic agents:2222 fixture through the
+  # FRESH-attach path, then injects the residual-void state synthetically (#780/D33
+  # — the wedged-channel row-drop-then-restore cannot be driven deterministically
+  # on the shared AVD): drop the row, drive the not-shell verdict (the EXACT
+  # refreshCurrentSessionRecordedKind production path), and assert the Conversation
+  # placeholder is re-seeded — never the raw black Terminal void. It uses ONLY
+  # agents:2222 (DEFAULT_HOST/DEFAULT_PORT -> 10.0.2.2:2222) that tests.yml already
+  # brings up, and does NOT self-skip on CI (no assumeTrue / assumeFalse). The fast
+  # JVM sibling is TmuxSessionViewModelTest.reconciledPresumedAgentWithDroppedRow*.
+  "com.pocketshell.app.tmux.AgentConversationReconnectDockerTest#reconciledPresumedAgentWithDroppedRowReseedsConversationPlaceholderOnDevice"
   # ADDED (#962/#975, conversation-source area — sibling of #819/#821/#894,
   # D31/D32): a live agent (claude) started INSIDE a session recorded
   # `@ps_agent_kind=shell` must regain its Terminal <-> Conversation TOGGLE, EVEN

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -542,6 +542,15 @@ JOURNEY_CLASSES=(
   # on base (the reassoc emits a handoff → the live session reconnects); GREEN after the
   # Angle-C fix. Uses ONLY the deterministic agents:2222 fixture tests.yml already brings
   # up (no toxiproxy, no workflow change) and does NOT self-skip on CI.
+  #
+  # ALSO COVERS (#981): the class now carries
+  # realValidatedHandoffWhileTransportProvenAliveDoesNotReconnect — a REAL validated
+  # WIFI→CELLULAR identity flip (which DOES emit past #875) on a STABLE wifi while the
+  # live SSH transport is provably alive (forceTransportProvenAliveForTest pinned, the
+  # #780 synthetic-inject model — no self-skip) must NOT tear down + redial the healthy
+  # socket (the #974 stable-wifi drop). RED on base (the emitted flip → scheduleNetwork-
+  # Reconnect raises the Reconnecting band); GREEN once the #981 liveness gate rides the
+  # proven-alive transport through. Same deterministic agents:2222 fixture; runs on CI.
   "$FQCN_PREFIX.StableWifiNoSpuriousReconnectE2eTest"
   # ADDED (#970): the realistic-wifi STABILITY regression gate — the durable proof
   # for #964 (D31/D32/D33). Only the DETERMINISTIC method is run by FQCN here; it

--- a/shared/core-tmux/src/integrationTest/java/com/pocketshell/core/tmux/TmuxClientIntegrationTest.kt
+++ b/shared/core-tmux/src/integrationTest/java/com/pocketshell/core/tmux/TmuxClientIntegrationTest.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -173,6 +174,23 @@ class TmuxClientIntegrationTest {
                     // (or a generous timeout elapses), then assert on the
                     // buffer — independent of order. (#691: wired into per-push
                     // CI, so it must pin the contract, not the ordering.)
+                    // `opening` is shared between this coroutine and the
+                    // `collector` coroutine, which appends on the `-CC` reader
+                    // dispatcher. `Collections.synchronizedList` only locks
+                    // individual mutator/accessor calls — it does NOT make an
+                    // *iteration* (Kotlin's `toList()`, or `none { }`/`any { }`
+                    // which walk the backing iterator) atomic against a
+                    // concurrent `add`. Without a guard, the poll-loop predicate
+                    // below and the final snapshot can iterate the backing
+                    // ArrayList while the collector is mid-`add`, which throws
+                    // `ConcurrentModificationException` (issue #1003). Every read
+                    // here therefore takes the list's own monitor via
+                    // `synchronized(opening) { ... }`, the same monitor the
+                    // synchronized wrapper uses for `add`, so reads and writes
+                    // never interleave. We also `join()` the collector after
+                    // cancelling so no append can race the final snapshot
+                    // (`cancel()` only *requests* cancellation; the coroutine may
+                    // still be inside `opening.add` when it returns).
                     val opening = java.util.Collections.synchronizedList(
                         mutableListOf<ControlEvent>(),
                     )
@@ -184,14 +202,16 @@ class TmuxClientIntegrationTest {
                     it.connect()
                     withTimeout(10_000) {
                         while (
-                            opening.none { e -> e is ControlEvent.WindowAdd } ||
-                            opening.none { e -> e is ControlEvent.SessionsChanged }
+                            synchronized(opening) {
+                                opening.none { e -> e is ControlEvent.WindowAdd } ||
+                                    opening.none { e -> e is ControlEvent.SessionsChanged }
+                            }
                         ) {
                             delay(50)
                         }
                     }
-                    collector.cancel()
-                    val events = opening.toList()
+                    collector.cancelAndJoin()
+                    val events = synchronized(opening) { opening.toList() }
                     assertTrue(
                         "expected a WindowAdd in tmux's opening events: $events",
                         events.any { e -> e is ControlEvent.WindowAdd },


### PR DESCRIPTION
Three APPROVED, disjoint-region fixes batched (network reducer / verdict-seed / core-tmux integration test). Full local `:app:testDebugUnitTest` + `:shared:core-tmux:test` + assembleDebug green on flake-free main.

- **#981** — ride through a transient validated WIFI↔CELLULAR identity flip when the transport is proven-alive (reuse the #964/#986 keepalive oracle) instead of tearing down a healthy SSH link; a genuinely dead link still reconnects. On-device proof: real flip → zero reconnect, `cause=transport-proven-alive`. Closes #981.
- **#874 (residual)** — re-seed the #878 Conversation placeholder for a RECONCILED cached presumed-agent pane (beyond-grace reattach / switch-back) so it never falls through to the raw black Terminal void; #894 no-flash-on-shell preserved. Real-path proof: dropped-row pane → Conversation surface, not void. Addresses the last code-level gap of the #874 black-screen umbrella.
- **#1003** — lock the structural-events read in `TmuxClientIntegrationTest` (it raced the `-CC` collector → ConcurrentModificationException) — a pre-existing CI flake. Test-only. Closes #1003.

Each reviewer-driven red→green (incl. on-device for #981/#874). Part of #928 bulletproof. (#998 server-death lands next, separately.)