### PR TITLE
Bulletproof wave 4: network-loss detector (#997) + tmux server-death recovery (#998)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/BareNetworkLossRestoreReconnectE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/BareNetworkLossRestoreReconnectE2eTest.kt
@@ -1,0 +1,547 @@
+package com.pocketshell.app.proof
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.os.SystemClock
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.ViewModelProvider
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.connectivity.TerminalNetworkChangeKind
+import com.pocketshell.app.connectivity.TerminalNetworkObserver
+import com.pocketshell.app.connectivity.TerminalNetworkSnapshot
+import com.pocketshell.app.diagnostics.DiagnosticEvents
+import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
+import com.pocketshell.app.hosts.SshKeyStorage
+import com.pocketshell.app.MainActivity
+import com.pocketshell.app.testaccess.TestAccessEntryPoint
+import com.pocketshell.app.tmux.TMUX_SESSION_SCREEN_TAG
+import com.pocketshell.app.tmux.TMUX_SWITCHING_LOADING_TAG
+import com.pocketshell.app.tmux.TmuxSessionViewModel
+import com.pocketshell.core.ssh.KnownHostsPolicy
+import com.pocketshell.core.ssh.SshConnection
+import com.pocketshell.core.ssh.SshKey
+import com.pocketshell.core.storage.AppDatabase
+import com.pocketshell.core.storage.entity.HostEntity
+import com.termux.view.TerminalView
+import dagger.hilt.android.EntryPointAccessors
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.rules.TestRule
+import org.junit.runner.RunWith
+import org.junit.runners.model.Statement
+import java.io.File
+
+/**
+ * ISSUE #997 — a BARE network LOSS (`onLost` / airplane mode) must be detected
+ * PROACTIVELY, hold the lease during the loss window (no churn), and drive a FAST
+ * reconnect the instant validation returns — instead of waiting ~90s for the
+ * keepalive ride-through to age out.
+ *
+ * The pre-#997 detector returned `null` for any non-validated snapshot
+ * (`TerminalNetworkObserver.kt:328`) AND for a same-identity restore (`:333`), so
+ * a clean drop produced NO `TerminalNetworkChange` at all. The only thing that
+ * ever noticed a clean drop was the keepalive ride-through budget aging out (~90s)
+ * or sshj's reader EOF — both reactive and slow, leaving the UI showing a
+ * live-but-dead session for up to ~90s.
+ *
+ * This journey reproduces the maintainer's EXACT scenario on the emulator + Docker
+ * against the deterministic `agents:2222` fixture (no toxiproxy, no workflow
+ * change) and does NOT self-skip on CI:
+ *   1. open a real `tmux -CC` session, capture a painted baseline.
+ *   2. drive a bare network LOSS DETERMINISTICALLY: push a synthetic
+ *      `NoValidatedNetwork` snapshot through the production [TerminalNetworkObserver]
+ *      detector + emit pipeline (the SAME pipeline a real `ConnectivityManager`
+ *      `onLost` callback drives → the App `changes` collector → the VM network hook).
+ *      The AVD can't enter airplane mode on demand without killing the test ADB
+ *      link, so we inject the loss SYNTHETICALLY (the #780 model — a HARD inject, no
+ *      `assumeTrue` skip) so the load-bearing assertion runs on the CI swiftshader
+ *      AVD too.
+ *   3. assert the observer emitted a `NetworkLost` change and that NO redial fired
+ *      during the loss window (the lease is HELD — no churn).
+ *   4. drive a RESTORE: push a synthetic `Validated` snapshot back (SAME identity —
+ *      the airplane-mode round-trip the pre-#997 detector swallowed at `:333`).
+ *   5. assert the observer emitted a `NetworkRestored` change, the FAST
+ *      restore-reconnect diagnostic fired (`network_restore_reconnect_start`), and
+ *      the session settles back to a steady Connected state with a painted viewport.
+ *
+ * On BASE (no fix) step 2 emits NOTHING (the detector swallows the loss) → no
+ * `NetworkLost`, and step 4's same-identity restore also emits nothing (`:333`) →
+ * no `network_restore_reconnect_start` → the load-bearing assertions FAIL (RED).
+ * With the fix the loss surfaces, the lease is held, and the restore drives a fast
+ * reconnect (GREEN).
+ */
+@RunWith(AndroidJUnit4::class)
+class BareNetworkLossRestoreReconnectE2eTest {
+
+    val compose = createAndroidComposeRule<MainActivity>()
+    private val grantPermissions = PreGrantPermissionsRule()
+
+    @get:Rule
+    val ruleChain: RuleChain = RuleChain
+        .outerRule(grantPermissions)
+        .around(seedFixtureRule())
+        .around(compose)
+
+    private var diagnostics: RecordingDiagnosticSink? = null
+    private var seededKey: String? = null
+    private var seededHostRowTag: String? = null
+    private val timings = mutableListOf<String>()
+
+    private fun seedFixtureRule(): TestRule = TestRule { base, _ ->
+        object : Statement() {
+            override fun evaluate() {
+                runBlocking {
+                    val key = readFixtureKey()
+                    seededKey = key
+                    waitForSshFixtureReady(SshKey.Pem(key))
+                    seedTmuxSession(key)
+                    seededHostRowTag = seedDockerHost(key)
+                }
+                base.evaluate()
+            }
+        }
+    }
+
+    @Before
+    fun setUp() {
+        clearLastSessionPrefs()
+        diagnostics = RecordingDiagnosticSink().also { DiagnosticEvents.install(it) }
+    }
+
+    @After
+    fun tearDown() {
+        runCatching {
+            compose.activityRule.scenario.moveToState(Lifecycle.State.RESUMED)
+        }
+        diagnostics?.close()
+        diagnostics = null
+        clearLastSessionPrefs()
+        seededKey?.let { key ->
+            runCatching { runBlocking { cleanupRemoteTmuxSession(key) } }
+        }
+    }
+
+    @Test
+    fun bareLossHoldsTheLeaseThenRestoreDrivesAFastReconnect() = runBlocking<Unit> {
+        val hostRowTag = requireNotNull(seededHostRowTag)
+        attachSeededTmuxSession(hostRowTag)
+        waitForVisibleTerminal("initial attach") { it.contains(READY_MARKER) }
+        waitForConnected("initial attach")
+        waitForNoSwitchingOverlay("pre-loss attach settle")
+        captureViewport("issue997-01-attached")
+        diagnostics!!.clear()
+
+        val observer = terminalNetworkObserver()
+
+        // Seed a baseline validated identity so the detector's `current` is a known
+        // pure-WIFI network before the loss (so the restore below is a same-identity
+        // round-trip — the `:333` swallow case the pre-#997 detector hit).
+        observer.emitSyntheticSnapshotForTest(
+            TerminalNetworkSnapshot.Validated(networkHandle = "wifi-A", transports = setOf("WIFI")),
+            reason = "issue997-baseline-wifi",
+        )
+
+        // THE LOSS: a bare NoValidatedNetwork — an airplane-mode / onLost drop. On
+        // BASE this emits NOTHING (the `:328` swallow). With #997 it surfaces a
+        // NetworkLost and the VM holds the lease + surfaces the calm band.
+        val lossStart = SystemClock.elapsedRealtime()
+        val lost = observer.emitSyntheticSnapshotForTest(
+            TerminalNetworkSnapshot.NoValidatedNetwork,
+            reason = "issue997-bare-network-loss",
+        )
+        recordTiming("loss_emit_ms", SystemClock.elapsedRealtime() - lossStart)
+
+        // LOAD-BEARING #1: the production detector surfaces the bare loss proactively.
+        assertNotNull(
+            "a bare network loss (NoValidatedNetwork) MUST surface a proactive change " +
+                "— issue 997 (pre-fix this returned null at :328)",
+            lost,
+        )
+        assertEquals(
+            "the surfaced change must be a NetworkLost",
+            TerminalNetworkChangeKind.NetworkLost,
+            lost!!.kind,
+        )
+
+        // LOAD-BEARING #2: NO churn during the loss window — the lease is HELD, no
+        // redial ladder starts (`network_reconnect_start` / `network_restore_reconnect_start`
+        // must be absent while we are still in the loss window).
+        watchNoRedialDiagnostics("during the loss window", WATCH_NO_CHURN_MS)
+        assertTrue(
+            "the VM must record a network_loss_hold for the bare loss (proves the hold " +
+                "arm fired, not a vacuous pass); events=${diagnostics!!.events.map { it.name }}",
+            diagnostics!!.eventsNamed("network_loss_hold").isNotEmpty(),
+        )
+        captureViewport("issue997-02-loss-held")
+
+        diagnostics!!.clear()
+
+        // THE RESTORE: validation returns to the SAME pure-WIFI identity — the
+        // airplane-mode round-trip the pre-#997 detector swallowed at `:333`. On
+        // BASE this emits NOTHING. With #997 it emits a NetworkRestored and drives a
+        // FAST reconnect even though the session is in the loss-suspended state.
+        val restoreStart = SystemClock.elapsedRealtime()
+        val restored = observer.emitSyntheticSnapshotForTest(
+            TerminalNetworkSnapshot.Validated(networkHandle = "wifi-A", transports = setOf("WIFI")),
+            reason = "issue997-network-restored",
+        )
+        recordTiming("restore_emit_ms", SystemClock.elapsedRealtime() - restoreStart)
+
+        // LOAD-BEARING #3: the same-identity restore is NOT swallowed.
+        assertNotNull(
+            "a same-identity restore after a loss MUST surface a proactive change " +
+                "— issue 997 (pre-fix this returned null at :333)",
+            restored,
+        )
+        assertEquals(
+            "the surfaced change must be a NetworkRestored",
+            TerminalNetworkChangeKind.NetworkRestored,
+            restored!!.kind,
+        )
+
+        // LOAD-BEARING #4 (the authoritative fast-reconnect signal): the restore
+        // arm fires the FAST redial — `network_restore_reconnect_start` is recorded
+        // well inside the ~90s keepalive ride-through budget. This is what makes the
+        // common clean-drop case fast instead of reactive.
+        val fastReconnectStart = SystemClock.elapsedRealtime()
+        compose.waitUntil(timeoutMillis = RESTORE_RECONNECT_TIMEOUT_MS) {
+            diagnostics!!.eventsNamed("network_restore_reconnect_start").isNotEmpty()
+        }
+        recordTiming("restore_reconnect_signal_ms", SystemClock.elapsedRealtime() - fastReconnectStart)
+        assertTrue(
+            "expected the restore arm to fire a fast network_restore_reconnect_start " +
+                "(proves the restore-driven reconnect fired, not a vacuous pass); " +
+                "events=${diagnostics!!.events.map { it.name }}",
+            diagnostics!!.eventsNamed("network_restore_reconnect_start").isNotEmpty(),
+        )
+
+        // LOAD-BEARING #5: the session settles back to a steady Connected state with
+        // a painted viewport — the user is recovered, not left in a dead session.
+        waitForConnected("after restore reconnect")
+        waitForNoSwitchingOverlay("after restore reconnect settle")
+        waitForVisibleTerminal("after restore terminal") { it.contains(READY_MARKER) }
+        captureViewport("issue997-03-after-restore")
+
+        writeTimings()
+    }
+
+    private fun currentViewModel(): TmuxSessionViewModel {
+        lateinit var vm: TmuxSessionViewModel
+        compose.activityRule.scenario.onActivity { activity ->
+            vm = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+        }
+        return vm
+    }
+
+    private fun waitForNoSwitchingOverlay(label: String) {
+        compose.waitUntil(timeoutMillis = CONNECTED_TIMEOUT_MS) {
+            runCatching {
+                compose.onAllNodesWithTag(TMUX_SWITCHING_LOADING_TAG, useUnmergedTree = true)
+                    .fetchSemanticsNodes()
+                    .isEmpty()
+            }.getOrDefault(false)
+        }
+        assertEquals(
+            "expected no 'Attaching…' overlay before/after $label",
+            0,
+            compose.onAllNodesWithTag(TMUX_SWITCHING_LOADING_TAG, useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .size,
+        )
+    }
+
+    private fun terminalNetworkObserver(): TerminalNetworkObserver {
+        val ctx = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
+        return EntryPointAccessors
+            .fromApplication(ctx, TestAccessEntryPoint::class.java)
+            .terminalNetworkObserver()
+    }
+
+    private fun attachSeededTmuxSession(hostRowTag: String) {
+        compose.waitUntil(timeoutMillis = HOST_ROW_TIMEOUT_MS) {
+            runCatching {
+                compose.onAllNodesWithTag(hostRowTag, useUnmergedTree = true)
+                    .fetchSemanticsNodes()
+                    .isNotEmpty()
+            }.getOrDefault(false)
+        }
+        compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick()
+        compose.waitUntil(timeoutMillis = TerminalTestTimeouts.terminalVisibilityTimeoutMs()) {
+            runCatching {
+                compose.onAllNodesWithText(SESSION_NAME, useUnmergedTree = true)
+                    .fetchSemanticsNodes()
+                    .isNotEmpty()
+            }.getOrDefault(false)
+        }
+        compose.onNodeWithText(SESSION_NAME, useUnmergedTree = true).performClick()
+        compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertExists()
+        waitForTerminalViewAttached()
+    }
+
+    private fun waitForTerminalViewAttached() {
+        compose.waitUntil(timeoutMillis = 30_000) {
+            var attached = false
+            compose.activityRule.scenario.onActivity { activity ->
+                val view = activity.window.decorView.findTerminalView()
+                attached = view?.currentSession != null && view.mEmulator != null
+            }
+            attached
+        }
+    }
+
+    private fun waitForConnected(label: String) {
+        compose.waitUntil(timeoutMillis = CONNECTED_TIMEOUT_MS) {
+            currentConnectionStatus() is TmuxSessionViewModel.ConnectionStatus.Connected
+        }
+        assertTrue(
+            "expected Connected after $label, observed=${currentConnectionStatus()}",
+            currentConnectionStatus() is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+    }
+
+    private fun currentConnectionStatus(): TmuxSessionViewModel.ConnectionStatus {
+        var status: TmuxSessionViewModel.ConnectionStatus =
+            TmuxSessionViewModel.ConnectionStatus.Idle
+        compose.activityRule.scenario.onActivity { activity ->
+            status = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+                .connectionStatus
+                .value
+        }
+        return status
+    }
+
+    private fun waitForVisibleTerminal(
+        label: String,
+        timeoutMillis: Long = TerminalTestTimeouts.terminalVisibilityTimeoutMs(),
+        predicate: (String) -> Boolean,
+    ): String {
+        var last = ""
+        compose.waitUntil(timeoutMillis = timeoutMillis) {
+            last = visibleTerminalText()
+            last.isNotBlank() && predicate(last)
+        }
+        assertTrue("expected visible terminal for $label; got:\n$last", predicate(last))
+        return last
+    }
+
+    private fun visibleTerminalText(): String {
+        var text = ""
+        compose.activityRule.scenario.onActivity { activity ->
+            text = activity.window.decorView
+                .findTerminalView()
+                ?.currentSession
+                ?.emulator
+                ?.screen
+                ?.transcriptText
+                .orEmpty()
+        }
+        return text
+    }
+
+    /**
+     * Issue #997: while we are still in the loss window the lease must be HELD — no
+     * redial ladder may start. Forbid the loud redial signals across the window.
+     */
+    private fun watchNoRedialDiagnostics(label: String, durationMs: Long) {
+        val deadline = SystemClock.elapsedRealtime() + durationMs
+        while (SystemClock.elapsedRealtime() < deadline) {
+            assertNoRedialDiagnostics(label)
+            SystemClock.sleep(100)
+        }
+    }
+
+    private fun assertNoRedialDiagnostics(label: String) {
+        val events = diagnostics!!.events
+        val forbidden = events.filter { event ->
+            event.name in setOf(
+                "reconnect_start",
+                "network_reconnect_start",
+                "network_restore_reconnect_start",
+            )
+        }
+        assertTrue(
+            "expected NO redial diagnostics during the loss window for $label (the lease " +
+                "is held, no churn); forbidden=$forbidden all=${events.map { it.name }}",
+            forbidden.isEmpty(),
+        )
+    }
+
+    private fun readFixtureKey(): String =
+        InstrumentationRegistry.getInstrumentation()
+            .context
+            .assets
+            .open("test_key")
+            .bufferedReader()
+            .use { it.readText() }
+
+    private suspend fun seedDockerHost(key: String): String {
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
+        val db = Room.databaseBuilder(appContext, AppDatabase::class.java, DATABASE_NAME)
+            .fallbackToDestructiveMigration(dropAllTables = true)
+            .build()
+        return try {
+            db.clearAllTables()
+            val storedKey = SshKeyStorage.persistKey(
+                context = appContext,
+                sshKeyDao = db.sshKeyDao(),
+                name = "issue997-key-${System.currentTimeMillis()}",
+                content = key,
+            )
+            val hostId = db.hostDao().insert(
+                HostEntity(
+                    name = "Issue997 BareLoss RestoreReconnect",
+                    hostname = DEFAULT_HOST,
+                    port = DEFAULT_PORT,
+                    username = DEFAULT_USER,
+                    keyId = storedKey.id,
+                    tmuxInstalled = true,
+                    lastBootstrapAt = System.currentTimeMillis(),
+                ),
+            )
+            HOST_ROW_TAG_PREFIX + hostId
+        } finally {
+            db.close()
+        }
+    }
+
+    private suspend fun seedTmuxSession(key: String) {
+        val script = buildString {
+            appendLine("set -eu")
+            appendLine("tmux kill-session -t ${shellQuote(SESSION_NAME)} 2>/dev/null || true")
+            appendLine(
+                "tmux new-session -d -s ${shellQuote(SESSION_NAME)} " +
+                    shellQuote("printf '$READY_MARKER\\n'; exec sleep 600"),
+            )
+            appendLine("sleep 1")
+            appendLine("tmux list-sessions")
+        }
+        val result = execRemoteSetupUntilReady(
+            key = SshKey.Pem(key),
+            command = script,
+            description = "issue997 tmux seed session",
+        )
+        assertTrue(
+            "expected tmux seeding to succeed; exit=${result.exitCode} stderr='${result.stderr}'",
+            result.exitCode == 0,
+        )
+    }
+
+    private suspend fun cleanupRemoteTmuxSession(key: String) {
+        runCatching {
+            SshConnection.connect(
+                host = DEFAULT_HOST,
+                port = DEFAULT_PORT,
+                user = DEFAULT_USER,
+                key = SshKey.Pem(key),
+                knownHosts = KnownHostsPolicy.AcceptAll,
+                timeoutMs = 15_000,
+            ).mapCatching { session ->
+                session.use {
+                    it.exec("tmux kill-session -t ${shellQuote(SESSION_NAME)} 2>/dev/null || true")
+                }
+            }
+        }
+    }
+
+    private fun captureViewport(name: String) {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.waitForIdleSync()
+        SystemClock.sleep(150)
+
+        var bitmap: Bitmap? = null
+        compose.activityRule.scenario.onActivity { activity ->
+            val view = activity.window.decorView.findTerminalView() ?: return@onActivity
+            if (view.width <= 0 || view.height <= 0) return@onActivity
+            val b = Bitmap.createBitmap(view.width, view.height, Bitmap.Config.ARGB_8888)
+            view.draw(Canvas(b))
+            bitmap = b
+        }
+        bitmap?.let { writeBitmap("$name-viewport", it) }
+        writeText("$name-visible-terminal.txt", visibleTerminalText())
+        bitmap?.recycle()
+    }
+
+    private fun writeBitmap(name: String, bitmap: Bitmap): File {
+        val file = artifactFile("$name.png")
+        java.io.FileOutputStream(file).use { out ->
+            check(bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)) {
+                "failed to write bitmap to ${file.absolutePath}"
+            }
+        }
+        println("ISSUE997_VIEWPORT ${file.absolutePath}")
+        return file
+    }
+
+    private fun writeText(name: String, text: String): File {
+        val file = artifactFile(name)
+        file.writeText(text)
+        println("ISSUE997_TEXT ${file.absolutePath}")
+        return file
+    }
+
+    private fun writeTimings(): File =
+        writeText("timings.txt", timings.joinToString(separator = "\n", postfix = "\n"))
+
+    private fun artifactFile(name: String): File {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val mediaRoot = com.pocketshell.app.test.testArtifactsRoot(instrumentation.targetContext)
+        val dir = File(mediaRoot, "additional_test_output/$DEVICE_DIR_NAME")
+        check(dir.exists() || dir.mkdirs()) {
+            "could not create artifact directory ${dir.absolutePath}"
+        }
+        return File(dir, name)
+    }
+
+    private fun recordTiming(name: String, value: Long) {
+        val line = "$name=$value"
+        timings += line
+        println("ISSUE997_TIMING $line")
+    }
+
+    private fun View.findTerminalView(): TerminalView? {
+        if (this is TerminalView) return this
+        if (this !is ViewGroup) return null
+        for (index in 0 until childCount) {
+            val match = getChildAt(index).findTerminalView()
+            if (match != null) return match
+        }
+        return null
+    }
+
+    private fun shellQuote(value: String): String =
+        "'" + value.replace("'", "'\"'\"'") + "'"
+
+    private companion object {
+        const val DATABASE_NAME: String = "pocketshell.db"
+        const val DEVICE_DIR_NAME: String = "issue997-bare-loss-restore-reconnect"
+        const val SESSION_NAME: String = "issue997-loss-proof"
+        const val READY_MARKER: String = "ISSUE997-LOSS-READY"
+
+        const val WATCH_NO_CHURN_MS: Long = 1_500L
+
+        val HOST_ROW_TIMEOUT_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 60_000L else 20_000L
+        val CONNECTED_TIMEOUT_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 30_000L else 15_000L
+        val RESTORE_RECONNECT_TIMEOUT_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 30_000L else 15_000L
+    }
+}

--- a/app/src/androidTest/java/com/pocketshell/app/proof/ServerDeathReconnectNoResurrectE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/ServerDeathReconnectNoResurrectE2eTest.kt
@@ -1,0 +1,413 @@
+package com.pocketshell.app.proof
+
+import android.content.Context
+import android.os.SystemClock
+import android.util.Log
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.lifecycle.Lifecycle
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.BackgroundGraceTestOverride
+import com.pocketshell.app.MainActivity
+import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
+import com.pocketshell.app.hosts.SshKeyStorage
+import com.pocketshell.app.projects.FOLDER_LIST_SCREEN_TAG
+import com.pocketshell.app.tmux.TMUX_SESSION_SCREEN_TAG
+import com.pocketshell.core.ssh.KnownHostsPolicy
+import com.pocketshell.core.ssh.SshConnection
+import com.pocketshell.core.ssh.SshKey
+import com.pocketshell.core.storage.AppDatabase
+import com.pocketshell.core.storage.entity.HostEntity
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+
+/**
+ * Issue #998 — a remote tmux SERVER death (host reboot / OOM / `kill-server`)
+ * must NOT be silently resurrected into a blank "Connected" session.
+ *
+ * The defect: when the tmux *server* dies, a reattach to an expected-existing
+ * session reattaches with `tmux -CC new-session -A`. On a DEAD server that
+ * command boots a brand-NEW empty server and a fresh empty session — so the
+ * reattach "succeeds" into a blank session that reports Connected, the user's
+ * real work is silently gone, and the durable tree still lists vanished
+ * sessions. That looks like data loss with no notice.
+ *
+ * The fix: a reattach to an expected-existing session runs a SERVER-liveness
+ * preflight (`tmux has-session` → `no server running on <socket>`), classifies
+ * the dead server distinctly from an ordinary transport blip, and drops to the
+ * host/session list instead of the silent `new-session -A` resurrection.
+ *
+ * This reproduces the maintainer's exact reported journey on the REAL connected
+ * path (G10/D33) using the deterministic Docker `agents` fixture:
+ *
+ *  1. Attach to a real seeded tmux session through the normal journey
+ *     (host → session picker → Attach).
+ *  2. `tmux kill-server` over a sidecar SSH connection — the whole tmux server
+ *     (every session) is now gone (isolated fixture socket, never the
+ *     maintainer's default socket).
+ *  3. Background past the grace window, then foreground — the maintainer's "I
+ *     left the app and came back" journey. The foreground fires a
+ *     `LifecycleReattach` reconnect, which runs the server-liveness preflight,
+ *     sees `no server running`, and drops to the list (instead of the silent
+ *     `new-session -A` resurrection).
+ *
+ * Class coverage (G2): the dead server means EVERY session vanished, so the
+ * journey seeds TWO sessions, attaches one, kills the server, and asserts
+ * NEITHER session is resurrected — the multi-session class, not the single
+ * reported instance.
+ *
+ * Acceptance:
+ *  - No session is resurrected on the dead server: a `tmux list-sessions`
+ *    probe taken AFTER the reattach still reports the server dead (the bug
+ *    recreated an empty session here, reviving the server).
+ *  - The app drops to the host list (a host row is visible) instead of a
+ *    resurrected, empty session screen.
+ *
+ * Artifacts (process.md "Terminal Artifact Review"): a timings file plus a
+ * server-liveness probe log so a reviewer can confirm from the SAME run that
+ * the server stayed dead and the reattach landed on the list.
+ */
+@RunWith(AndroidJUnit4::class)
+class ServerDeathReconnectNoResurrectE2eTest {
+
+    val compose = createAndroidComposeRule<MainActivity>()
+
+    @get:Rule
+    val ruleChain: org.junit.rules.RuleChain = org.junit.rules.RuleChain
+        .outerRule(PreGrantPermissionsRule())
+        .around(SeedBeforeLaunchRule { seedBeforeLaunch() })
+        .around(compose)
+
+    private lateinit var fixtureKey: String
+    private lateinit var hostRowTag: String
+    private val timings = mutableListOf<String>()
+
+    @After
+    fun tearDown() {
+        runCatching { compose.activityRule.scenario.moveToState(Lifecycle.State.RESUMED) }
+        BackgroundGraceTestOverride.setForTest(null)
+        clearBackgroundGraceSetting()
+        clearLastSessionPrefs()
+        runBlocking {
+            if (::fixtureKey.isInitialized) {
+                // Bring the fixture's tmux server back for the next test.
+                runCatching { runScript(fixtureKey, "tmux kill-server 2>/dev/null || true") }
+            }
+        }
+    }
+
+    private suspend fun seedBeforeLaunch() {
+        clearLastSessionPrefs()
+        clearBackgroundGraceSetting()
+        BackgroundGraceTestOverride.setForTest(null)
+        val key = readFixtureKey()
+        fixtureKey = key
+        waitForSshFixtureReady(SshKey.Pem(key))
+        // Seed TWO sessions so the multi-session class (every session vanishes on
+        // server-death) is exercised, then confirm the server is alive.
+        seedTmuxSessions(key)
+        assertTrue("seeded primary session must be alive", sessionAlive(key, PRIMARY_SESSION))
+        assertTrue("seeded second session must be alive", sessionAlive(key, SECOND_SESSION))
+        hostRowTag = seedDockerHost(key)
+    }
+
+    @Test
+    fun serverDeathOnReconnectDropsToListAndNeverResurrects() = runBlocking {
+        val key = fixtureKey
+
+        // ---- (1) Attach to the primary seeded session via the normal journey.
+        waitForHostRowPresent(hostRowTag)
+        compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick()
+        waitForText(PRIMARY_SESSION, timeoutMs = 20_000)
+        compose.onNodeWithText(PRIMARY_SESSION).performClick()
+        compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertExists()
+        // Let the attach fully settle (panes seeded, Connected revealed).
+        delay(LIFECYCLE_DRAIN_MS)
+
+        // ---- (2) KILL THE SERVER. Every session vanishes; the next reattach via
+        // `new-session -A` would (on base) silently boot a fresh empty server.
+        val killAt = SystemClock.elapsedRealtime()
+        runScript(key, "tmux kill-server 2>/dev/null || true")
+        recordTiming("kill_server_ms", SystemClock.elapsedRealtime() - killAt)
+        assertTrue("the server must be dead after kill-server", serverDead(key))
+        recordTiming("server_dead_after_kill", if (serverDead(key)) 1L else 0L)
+
+        // ---- (3) Background past the grace window, then foreground — the
+        // maintainer's "I left the app and came back" journey. The foreground
+        // fires a LifecycleReattach reconnect, which runs the server-liveness
+        // preflight, sees `no server running`, and routes to failServerDied
+        // (drop to the list) — NOT the silent `new-session -A` resurrection.
+        val reconnectAt = SystemClock.elapsedRealtime()
+        BackgroundGraceTestOverride.setForTest(POST_GRACE_MS)
+        compose.activityRule.scenario.moveToState(Lifecycle.State.CREATED)
+        // Wait out the grace window so the app detaches the live client.
+        delay(POST_GRACE_MS + LIFECYCLE_DRAIN_MS)
+        compose.activityRule.scenario.moveToState(Lifecycle.State.RESUMED)
+
+        // The reattach runs the preflight against the dead server and drops out
+        // of the (now-blank) session into the session list. Give it time.
+        compose.waitUntil(timeoutMillis = RECONNECT_TIMEOUT_MS) {
+            droppedToSessionList()
+        }
+        recordTiming("reconnect_to_list_ms", SystemClock.elapsedRealtime() - reconnectAt)
+
+        // ---- Acceptance A: NO session was resurrected on the dead server. The
+        // bug's symptom is `new-session -A` reviving an empty server+session. A
+        // server-liveness probe taken now must still report the server dead.
+        val stillDead = serverDead(key)
+        val sessionList = listSessions(key)
+        recordTiming("server_resurrected_after_reconnect", if (stillDead) 0L else 1L)
+        writeText(
+            "server-liveness-probe.txt",
+            buildString {
+                appendLine("primary_session=$PRIMARY_SESSION")
+                appendLine("second_session=$SECOND_SESSION")
+                appendLine("server_dead_after_reconnect=$stillDead")
+                appendLine("expected_server_dead_after_reconnect=true")
+                appendLine("list_sessions_after_reconnect=${sessionList?.trim()}")
+            },
+        )
+        assertTrue(
+            "REGRESSION (#998): the tmux server was RESURRECTED on reconnect " +
+                "(`new-session -A` revived an empty server) — server-death must " +
+                "drop to the list, not recreate. list-sessions=${sessionList?.trim()}",
+            stillDead,
+        )
+
+        // ---- Acceptance B: the app dropped OUT of the (would-be-resurrected)
+        // session into the session list, not a resurrected blank session screen.
+        assertTrue(
+            "expected to land on the session list after a server-death reconnect; " +
+                "the FolderList session-list screen should be visible",
+            droppedToSessionList(),
+        )
+        val sessionScreenStillUp = compose
+            .onAllNodesWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true)
+            .fetchSemanticsNodes()
+            .isNotEmpty()
+        assertFalse(
+            "the resurrected (blank) session screen must NOT be showing after a " +
+                "server-death reconnect",
+            sessionScreenStillUp,
+        )
+
+        writeTimings()
+        Unit
+    }
+
+    // ---------------------------------------------------------------- Helpers
+
+    /**
+     * True once the app has dropped OUT of the (would-be-resurrected) session
+     * onto the session list: the FolderList session-list screen is present AND
+     * the tmux session screen is gone. On the base (silent-resurrection) bug the
+     * session screen stays up (a blank "Connected" pane) and this never holds.
+     */
+    private fun droppedToSessionList(): Boolean {
+        val onSessionList = compose
+            .onAllNodesWithTag(FOLDER_LIST_SCREEN_TAG, useUnmergedTree = true)
+            .fetchSemanticsNodes()
+            .isNotEmpty()
+        val sessionScreenGone = compose
+            .onAllNodesWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true)
+            .fetchSemanticsNodes()
+            .isEmpty()
+        return onSessionList && sessionScreenGone
+    }
+
+    private fun readFixtureKey(): String =
+        InstrumentationRegistry.getInstrumentation()
+            .context
+            .assets
+            .open("test_key")
+            .bufferedReader()
+            .use { it.readText() }
+
+    private fun clearBackgroundGraceSetting() {
+        val ctx = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
+        ctx.getSharedPreferences("app_settings", Context.MODE_PRIVATE)
+            .edit()
+            .remove("background_grace_millis")
+            .commit()
+    }
+
+    private suspend fun seedDockerHost(key: String): String {
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
+        val db = Room.databaseBuilder(appContext, AppDatabase::class.java, DATABASE_NAME)
+            .fallbackToDestructiveMigration(dropAllTables = true)
+            .build()
+        return try {
+            db.clearAllTables()
+            val storedKey = SshKeyStorage.persistKey(
+                context = appContext,
+                sshKeyDao = db.sshKeyDao(),
+                name = "issue998-key-${System.currentTimeMillis()}",
+                content = key,
+            )
+            val hostId = db.hostDao().insert(
+                HostEntity(
+                    name = "Issue998 ServerDeath",
+                    hostname = DEFAULT_HOST,
+                    port = DEFAULT_PORT,
+                    username = DEFAULT_USER,
+                    keyId = storedKey.id,
+                    tmuxInstalled = true,
+                    lastBootstrapAt = System.currentTimeMillis(),
+                ),
+            )
+            HOST_ROW_TAG_PREFIX + hostId
+        } finally {
+            db.close()
+        }
+    }
+
+    private suspend fun seedTmuxSessions(key: String) {
+        val script = buildString {
+            appendLine("set -eu")
+            appendLine("tmux kill-server 2>/dev/null || true")
+            appendLine("sleep 1")
+            appendLine(
+                "tmux new-session -d -s ${shellQuote(PRIMARY_SESSION)} " +
+                    "${shellQuote("printf 'ISSUE998-PRIMARY\\n'; exec sleep 600")}",
+            )
+            appendLine(
+                "tmux new-session -d -s ${shellQuote(SECOND_SESSION)} " +
+                    "${shellQuote("printf 'ISSUE998-SECOND\\n'; exec sleep 600")}",
+            )
+            appendLine("sleep 1")
+            appendLine("tmux has-session -t ${shellQuote(PRIMARY_SESSION)}")
+        }
+        val exec = runScript(key, script)
+        assertTrue(
+            "expected tmux seeding to succeed; stderr='${exec?.stderr}'",
+            exec?.exitCode == 0,
+        )
+        Log.i(LOG_TAG, "seeded sessions: ${exec?.stdout?.trim()}")
+    }
+
+    /** True iff the named tmux session currently exists on the server. */
+    private suspend fun sessionAlive(key: String, session: String): Boolean {
+        val exec = runScript(
+            key,
+            "tmux has-session -t ${shellQuote(session)} 2>/dev/null && echo ALIVE || echo GONE",
+        )
+        return exec?.stdout?.contains("ALIVE") == true
+    }
+
+    /**
+     * True iff the tmux SERVER is dead (no server behind the socket). `tmux
+     * list-sessions` exits non-zero with `no server running on <socket>` when
+     * the server is gone — the exact #998 signature.
+     */
+    private suspend fun serverDead(key: String): Boolean {
+        // `tmux list-sessions` exits non-zero with `no server running on
+        // <socket>` when the server is gone; print a sentinel on the success
+        // branch so a revived (empty) server is unambiguously distinguished.
+        val exec = runScript(
+            key,
+            "tmux list-sessions 2>&1 && echo SERVER_ALIVE || echo SERVER_DEAD",
+        )
+        val out = exec?.stdout.orEmpty() + exec?.stderr.orEmpty()
+        return out.contains("no server running", ignoreCase = true) ||
+            (out.contains("SERVER_DEAD") && !out.contains("SERVER_ALIVE"))
+    }
+
+    private suspend fun listSessions(key: String): String? =
+        runScript(key, "tmux list-sessions 2>&1 || true")?.let {
+            (it.stdout + it.stderr)
+        }
+
+    private suspend fun runScript(key: String, script: String) =
+        SshConnection.connect(
+            host = DEFAULT_HOST,
+            port = DEFAULT_PORT,
+            user = DEFAULT_USER,
+            key = SshKey.Pem(key),
+            knownHosts = KnownHostsPolicy.AcceptAll,
+            timeoutMs = 15_000,
+        ).mapCatching { session -> session.use { it.exec(script) } }.getOrNull()
+
+    private fun waitForText(text: String, timeoutMs: Long) {
+        compose.waitUntil(timeoutMillis = timeoutMs) {
+            runCatching {
+                compose.onAllNodesWithText(text, useUnmergedTree = true)
+                    .fetchSemanticsNodes()
+                    .isNotEmpty()
+            }.getOrDefault(false)
+        }
+    }
+
+    private fun waitForHostRowPresent(hostRowTag: String) {
+        compose.waitUntil(timeoutMillis = TerminalTestTimeouts.screenRenderPresenceTimeoutMs()) {
+            runCatching {
+                compose.onAllNodesWithTag(hostRowTag, useUnmergedTree = true)
+                    .fetchSemanticsNodes()
+                    .isNotEmpty()
+            }.getOrDefault(false)
+        }
+    }
+
+    private fun writeText(name: String, text: String): File {
+        val file = artifactFile(name)
+        file.writeText(text)
+        println("ISSUE998_TEXT ${file.absolutePath}")
+        return file
+    }
+
+    private fun writeTimings(): File {
+        val file = artifactFile("timings.txt")
+        file.writeText(timings.joinToString(separator = "\n", postfix = "\n"))
+        println("ISSUE998_TIMINGS ${file.absolutePath}")
+        return file
+    }
+
+    private fun artifactFile(name: String): File {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val mediaRoot = com.pocketshell.app.test.testArtifactsRoot(instrumentation.targetContext)
+        val dir = File(mediaRoot, "additional_test_output/$DEVICE_DIR_NAME")
+        check(dir.exists() || dir.mkdirs()) {
+            "could not create artifact directory ${dir.absolutePath}"
+        }
+        return File(dir, name)
+    }
+
+    private fun recordTiming(name: String, value: Long) {
+        val line = "$name=$value"
+        timings += line
+        println("ISSUE998_TIMING $line")
+    }
+
+    private fun shellQuote(value: String): String =
+        "'" + value.replace("'", "'\"'\"'") + "'"
+
+    private companion object {
+        const val DATABASE_NAME: String = "pocketshell.db"
+        const val LOG_TAG: String = "Issue998ServerDeath"
+        const val DEVICE_DIR_NAME: String = "issue998-server-death-reconnect"
+
+        // Picker entry names shipped by the deterministic `agents` fixture so the
+        // normal attach journey reaches them; `tmux` itself is the real binary,
+        // so has-session / kill-server are authoritative.
+        const val PRIMARY_SESSION: String = "claude-main"
+        const val SECOND_SESSION: String = "shell-2"
+
+        const val LIFECYCLE_DRAIN_MS: Long = 1_500L
+        // Short grace so the post-grace detach + foreground reattach cycle runs
+        // without the user-facing 30s minimum.
+        const val POST_GRACE_MS: Long = 1_200L
+        const val RECONNECT_TIMEOUT_MS: Long = 30_000L
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/App.kt
+++ b/app/src/main/java/com/pocketshell/app/App.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
 import com.pocketshell.app.connectivity.TerminalNetworkChange
+import com.pocketshell.app.connectivity.TerminalNetworkChangeKind
 import com.pocketshell.app.connectivity.TerminalNetworkObserver
 import com.pocketshell.app.connectivity.hasSameNetworkIdentityAs
 import com.pocketshell.app.connectivity.networkDiagnosticFields
@@ -583,6 +584,14 @@ internal fun shouldDispatchPendingTerminalNetworkChange(
 ): Boolean {
     if (pendingChange == null) return false
     if (!resumedWithinGrace) return true
+    // Issue #997: a pending bare-LOSS / RESTORE deferred while backgrounded is a
+    // meaningful drop/recovery, not a same-identity reassoc — replay it on a
+    // within-grace foreground when there is no live runtime, the same as a real
+    // validated handoff. (A NetworkRestored drives the fast reconnect; a
+    // NetworkLost flips the UI to reconnecting/holds.)
+    if (pendingChange.kind != TerminalNetworkChangeKind.ValidatedIdentityChange) {
+        return !hasLiveTerminalRuntime
+    }
     return !hasLiveTerminalRuntime && pendingChange.previousValidated != null &&
         !pendingChange.previousValidated.hasSameNetworkIdentityAs(pendingChange.current)
 }
@@ -818,13 +827,20 @@ private fun TerminalNetworkChange?.pendingNetworkClassification(): String =
     this?.networkClassification() ?: "none"
 
 private fun TerminalNetworkChange.networkClassification(): String =
-    if (
-        previousValidated != null &&
-        !previousValidated.hasSameNetworkIdentityAs(current)
-    ) {
-        "real_validated_identity_change"
-    } else {
-        "non_real_validated_change"
+    when (kind) {
+        // Issue #997: the orthogonal bare-loss / restore signal — classified by
+        // kind, not by validated-identity equality (which would mislabel them).
+        TerminalNetworkChangeKind.NetworkLost -> "network_lost"
+        TerminalNetworkChangeKind.NetworkRestored -> "network_restored"
+        TerminalNetworkChangeKind.ValidatedIdentityChange ->
+            if (
+                previousValidated != null &&
+                !previousValidated.hasSameNetworkIdentityAs(current)
+            ) {
+                "real_validated_identity_change"
+            } else {
+                "non_real_validated_change"
+            }
     }
 
 internal sealed interface TerminalNetworkDecision {

--- a/app/src/main/java/com/pocketshell/app/connectivity/TerminalNetworkObserver.kt
+++ b/app/src/main/java/com/pocketshell/app/connectivity/TerminalNetworkObserver.kt
@@ -133,19 +133,27 @@ class TerminalNetworkObserver @Inject constructor(
         reason: String,
     ): TerminalNetworkChange? {
         val change = detector.update(snapshot = snapshot, reason = reason) ?: return null
+        // Issue #997: the trail outcome is kind-aware so a bare loss / restore is
+        // visible in the device trail (not mislabelled as a validated handoff).
+        val outcome = when (change.kind) {
+            TerminalNetworkChangeKind.NetworkLost -> "network_lost"
+            TerminalNetworkChangeKind.NetworkRestored -> "network_restored"
+            TerminalNetworkChangeKind.ValidatedIdentityChange -> "validated_default_changed"
+        }
         Log.i(
             TAG,
-            "terminal-network-change sequence=${change.sequence} reason=${change.reason} " +
+            "terminal-network-change kind=${change.kind} sequence=${change.sequence} " +
+                "reason=${change.reason} " +
                 "previous=${change.previous.logValue} current=${change.current.logValue}",
         )
         DiagnosticEvents.record(
             "network",
-            "validated_default_changed",
+            outcome,
             *change.networkDiagnosticFields(),
         )
         ReconnectCauseTrail.record(
             stage = "network_callback",
-            outcome = "validated_default_changed",
+            outcome = outcome,
             cause = reason,
             "sequence" to change.sequence,
             "previousNetworkHandle" to change.previous.networkHandle,
@@ -194,7 +202,44 @@ data class TerminalNetworkChange(
     val reason: String,
     val sequence: Long,
     val deferredFromBackground: Boolean = false,
+    /**
+     * Issue #997: the event class. The detector models two ORTHOGONAL signals:
+     *
+     * - [TerminalNetworkChangeKind.ValidatedIdentityChange] — the original #548
+     *   signal: the default network's validated *identity* changed while never
+     *   losing validation (WIFI→CELLULAR handoff, VPN up/down). The proven-alive
+     *   ride-through (#981) and the same-identity suppression (#875) apply here.
+     * - [TerminalNetworkChangeKind.NetworkLost] — a bare availability LOSS
+     *   (`onLost` / airplane mode / `onUnavailable`): the default network dropped
+     *   to no-validated-network. Surfaced IMMEDIATELY so the UI can flip to
+     *   reconnecting and probes can suspend, but it does NOT tear the lease down
+     *   (a loss is frequently transient — pocket, elevator). The pre-#997 detector
+     *   swallowed this entirely (`return null` on any non-validated snapshot), so a
+     *   clean drop was only noticed reactively ~90s later by the keepalive.
+     * - [TerminalNetworkChangeKind.NetworkRestored] — validation returned after a
+     *   loss. Drives a FAST reconnect even from a non-Connected (loss-suspended)
+     *   state, even when the restored identity equals the pre-loss one (the
+     *   airplane-mode round-trip the pre-#997 detector also swallowed at `:333`).
+     *   A real loss means the old socket is dead, so this BYPASSES the
+     *   proven-alive gate.
+     */
+    val kind: TerminalNetworkChangeKind = TerminalNetworkChangeKind.ValidatedIdentityChange,
 )
+
+/**
+ * Issue #997: the orthogonal event classes a [TerminalNetworkChange] can carry.
+ * See [TerminalNetworkChange.kind].
+ */
+enum class TerminalNetworkChangeKind {
+    /** The default network's validated identity changed (the #548 handoff). */
+    ValidatedIdentityChange,
+
+    /** A bare availability loss — surfaced immediately, lease held, no churn. */
+    NetworkLost,
+
+    /** Validation returned after a loss — drives a fast reconnect. */
+    NetworkRestored,
+}
 
 sealed interface TerminalNetworkSnapshot {
     val logValue: String
@@ -220,6 +265,7 @@ sealed interface TerminalNetworkSnapshot {
 internal fun TerminalNetworkChange.networkDiagnosticFields(): Array<Pair<String, Any?>> =
     arrayOf(
         "sequence" to sequence,
+        "kind" to kind.name,
         "reason" to reason,
         "previous" to previous.logValue,
         "current" to current.logValue,
@@ -333,19 +379,72 @@ internal class TerminalNetworkChangeDetector(
         initial as? TerminalNetworkSnapshot.Validated
     private var sequence: Long = 0L
 
+    /**
+     * Issue #997: the second, orthogonal state machine — whether the default
+     * network is currently in a bare-LOSS window (no validated network). Set
+     * when a [TerminalNetworkChangeKind.NetworkLost] is emitted, cleared when a
+     * [TerminalNetworkChangeKind.NetworkRestored] is emitted. Like the identity
+     * state it lives UNDER the same `lock` (#995): concurrent `onLost`/
+     * `onAvailable` binder callbacks must see one another's writes so a loss is
+     * surfaced exactly once and the matching restore reconnects exactly once.
+     */
+    private var lost: Boolean = false
+
     fun update(
         snapshot: TerminalNetworkSnapshot,
         reason: String,
     ): TerminalNetworkChange? = synchronized(lock) {
         val previous = current
         val previousValidated = lastValidated
+
+        // Issue #997: the bare availability-LOSS / RESTORE signal, orthogonal to
+        // the #548 validated-identity-change signal below. Evaluated FIRST so a
+        // loss/restore is surfaced even when the identity-change path would have
+        // swallowed it (a non-validated snapshot, or a same-identity restore).
+        if (snapshot !is TerminalNetworkSnapshot.Validated) {
+            // Transition into the loss window. Idempotent: repeated
+            // NoValidatedNetwork callbacks while already lost emit nothing (no
+            // churn during the loss). `current` is still advanced so the identity
+            // state stays coherent for the eventual restore.
+            current = snapshot
+            if (lost) return@synchronized null
+            lost = true
+            sequence += 1L
+            return@synchronized TerminalNetworkChange(
+                previous = previous,
+                current = snapshot,
+                previousValidated = previousValidated,
+                reason = reason,
+                sequence = sequence,
+                kind = TerminalNetworkChangeKind.NetworkLost,
+            )
+        }
+        if (lost) {
+            // Validation returned after a loss. Emit RESTORED even when the
+            // restored identity equals the pre-loss one — that same-identity
+            // restore is exactly the airplane-mode round-trip the pre-#997
+            // detector swallowed at `:333`, leaving a dead socket un-recovered.
+            current = snapshot
+            lastValidated = snapshot
+            lost = false
+            sequence += 1L
+            return@synchronized TerminalNetworkChange(
+                previous = previous,
+                current = snapshot,
+                previousValidated = previousValidated,
+                reason = reason,
+                sequence = sequence,
+                kind = TerminalNetworkChangeKind.NetworkRestored,
+            )
+        }
+
+        // --- The original #548 validated-identity-change signal (unchanged). ---
         if (previous.hasSameNetworkIdentityAs(snapshot)) {
             current = snapshot
-            if (snapshot is TerminalNetworkSnapshot.Validated) lastValidated = snapshot
+            lastValidated = snapshot
             return@synchronized null
         }
         current = snapshot
-        if (snapshot !is TerminalNetworkSnapshot.Validated) return@synchronized null
         if (previousValidated == null) {
             lastValidated = snapshot
             return@synchronized null

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -111,6 +111,7 @@ import com.pocketshell.core.tmux.TmuxClientFactory
 import com.pocketshell.core.tmux.TmuxDisconnectEvent
 import com.pocketshell.core.tmux.TmuxDisconnectReason
 import com.pocketshell.core.tmux.TmuxOutputBacklogOverflow
+import com.pocketshell.core.tmux.TmuxServerDeadException
 import com.pocketshell.core.tmux.TmuxSessionNotFoundException
 import com.pocketshell.core.tmux.protocol.ControlEvent
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -2801,6 +2802,19 @@ public class TmuxSessionViewModel @Inject constructor(
     @androidx.annotation.VisibleForTesting
     internal fun lastCreateIfMissingForTest(): Boolean = lastCreateIfMissing
 
+    /**
+     * Issue #998: the most recent [probeServerLiveness] flag passed to
+     * [createTmuxClient]. Exposed for tests because the test client-factory
+     * override keeps its 3-arg shape (so it never sees the flag); this
+     * side-channel lets a test assert the reconnect path requested the
+     * server-death probe (`true`) while the explicit-new path did not (`false`).
+     */
+    @Volatile
+    private var lastProbeServerLiveness: Boolean = false
+
+    @androidx.annotation.VisibleForTesting
+    internal fun lastProbeServerLivenessForTest(): Boolean = lastProbeServerLiveness
+
     private fun createTmuxClient(
         session: SshSession,
         sessionName: String,
@@ -2809,14 +2823,23 @@ public class TmuxSessionViewModel @Inject constructor(
         // genuine cold-restore path passes false so a session killed elsewhere
         // is not resurrected; every create/reconnect/switch path keeps true.
         createIfMissing: Boolean = true,
+        // Issue #998: probe whether the tmux SERVER is alive before `new-session
+        // -A`. True only on a reattach to an expected-existing session (a
+        // reconnect / lifecycle / network-reconnect): a dead server then throws
+        // [TmuxServerDeadException] so we drop to the list instead of silently
+        // booting a fresh empty server. The explicit user "new session" intent
+        // passes false — a brand-new session legitimately wants a fresh server.
+        probeServerLiveness: Boolean = false,
     ): TmuxClient {
         lastCreateIfMissing = createIfMissing
+        lastProbeServerLiveness = probeServerLiveness
         return tmuxClientFactoryOverride?.invoke(session, sessionName, startDirectory)
             ?: tmuxClientFactory.create(
                 session,
                 sessionName = sessionName,
                 startDirectory = startDirectory,
                 createIfMissing = createIfMissing,
+                probeServerLiveness = probeServerLiveness,
             )
     }
 
@@ -5358,6 +5381,10 @@ public class TmuxSessionViewModel @Inject constructor(
                 target.sessionName,
                 target.startDirectory,
                 createIfMissing = createIfMissingForTrigger(trigger),
+                // Issue #998: a reconnect/lifecycle/network reattach expects the
+                // server to already be running, so probe for server-death and
+                // refuse the silent `new-session -A` resurrection if it is gone.
+                probeServerLiveness = trigger.isReconnectTrigger,
             )
             activeTarget = target
             refreshReconnectAvailability()
@@ -5585,7 +5612,15 @@ public class TmuxSessionViewModel @Inject constructor(
             // reconnect would just re-run the same gone-session attach. Surface
             // "that session ended" and drop the user to the list instead of
             // resurrecting it.
-            if (t is TmuxSessionNotFoundException) {
+            if (t is TmuxServerDeadException) {
+                // Issue #998: the remote tmux SERVER is gone (host reboot / OOM /
+                // kill-server). Every session vanished. Do NOT route this through
+                // the auto-reconnect ladder — `new-session -A` would boot a fresh
+                // empty server and silently resurrect a blank "Connected" session
+                // (the data-loss-looking bug). Surface "the server restarted —
+                // all sessions ended" and drop to the host/session list.
+                failServerDied(target, attempt, startedAtMs, t)
+            } else if (t is TmuxSessionNotFoundException) {
                 failSessionEnded(target, attempt, startedAtMs, t)
             } else {
                 failConnectAttempt(
@@ -5647,6 +5682,61 @@ public class TmuxSessionViewModel @Inject constructor(
         refreshReconnectAvailability()
         setConnectionState(
             ConnectionState.Unreachable("Session “${target.sessionName}” has ended."),
+        )
+        _sessionEnded.tryEmit(target.sessionName)
+    }
+
+    /**
+     * Issue #998: terminal handling for a reattach that found the remote tmux
+     * SERVER gone (host reboot / OOM / `kill-server`). Sibling of
+     * [failSessionEnded] — the difference is the *scope* of the loss: a dead
+     * server means EVERY session vanished, not one. Like [failSessionEnded] this
+     * does NOT preserve a reconnect target, does NOT auto-reconnect, and does NOT
+     * `new-session -A`-resurrect (which on a dead server boots a brand-new empty
+     * server — exactly the silent-resurrection bug). We tear the half-open
+     * connection down, evict the runtime lease, surface a server-death
+     * [ConnectionState.Unreachable] message, and emit the one-shot [sessionEnded]
+     * event so the Screen drops to the host/session list (which already renders
+     * the empty `no server running` state correctly) and clears the persisted
+     * last-session snapshot.
+     */
+    private suspend fun failServerDied(
+        target: ConnectionTarget,
+        attempt: Int,
+        startedAtMs: Long,
+        cause: TmuxServerDeadException,
+    ) {
+        lastConnectFailureCause = cause
+        Log.i(
+            ISSUE_145_RECONNECT_TAG,
+            "tmux-server-died host=${target.host} session=${target.sessionName} " +
+                "${targetLogFields(target)} attempt=$attempt — server gone, dropping to list, not recreating",
+        )
+        DiagnosticEvents.record(
+            "connection",
+            "reconnect_server_died",
+            "attempt" to attempt,
+            "hostId" to target.hostId,
+            "host" to target.host,
+            "port" to target.port,
+            "user" to target.user,
+            "session" to target.sessionName,
+            "cause" to cause.javaClass.simpleName,
+            "elapsedMs" to (SystemClock.elapsedRealtime() - startedAtMs),
+        )
+        withContext(NonCancellable) {
+            closeCurrentConnectionAndJoin(
+                cacheEviction = RuntimeCacheEviction.TargetRuntime(target.toRuntimeKey()),
+            )
+        }
+        activeAttachMilestone = null
+        activeTarget = null
+        connectingTarget = null
+        refreshReconnectAvailability()
+        setConnectionState(
+            ConnectionState.Unreachable(
+                "The tmux server on ${target.hostName} restarted — all sessions ended.",
+            ),
         )
         _sessionEnded.tryEmit(target.sessionName)
     }
@@ -6584,6 +6674,8 @@ public class TmuxSessionViewModel @Inject constructor(
             when (current.javaClass.simpleName) {
                 "UserAuthException" -> return "authentication failed"
                 "UnknownHostException" -> return "host could not be resolved"
+                // Issue #998: server-death — all sessions ended, recreate one.
+                "TmuxServerDeadException" -> return "the tmux server restarted — all sessions ended"
             }
             if (current.message?.contains(MISSING_KEY_MESSAGE_FRAGMENT, ignoreCase = true) == true) {
                 return "private key file not found"
@@ -7777,6 +7869,12 @@ public class TmuxSessionViewModel @Inject constructor(
             TmuxDisconnectReason.ReaderEof,
             TmuxDisconnectReason.ReaderException,
             TmuxDisconnectReason.CommandTimeout,
+            // Issue #998: a mid-session `%exit server exited` should kick the
+            // reconnect path — NOT to silently resurrect, but because that path
+            // now runs the server-liveness preflight that detects the dead server
+            // and routes to failServerDied (drop to the list). Auto-reconnecting
+            // here is what gives us the chance to classify and recover gracefully.
+            TmuxDisconnectReason.ServerExited,
             -> true
             TmuxDisconnectReason.ExplicitClose,
             TmuxDisconnectReason.ExplicitDetach,
@@ -7794,6 +7892,7 @@ public class TmuxSessionViewModel @Inject constructor(
             TmuxDisconnectReason.CommandTimeout -> "Tmux command timed out"
             TmuxDisconnectReason.ExplicitClose -> "Connection closed locally"
             TmuxDisconnectReason.ExplicitDetach -> "Tmux client detached"
+            TmuxDisconnectReason.ServerExited -> "Tmux server restarted"
             TmuxDisconnectReason.Unknown -> "Disconnected"
         }
         // The user/host/port comes from the target; for the degenerate target-less
@@ -7816,6 +7915,7 @@ public class TmuxSessionViewModel @Inject constructor(
             TmuxDisconnectReason.CommandTimeout -> "Tmux command timed out"
             TmuxDisconnectReason.ExplicitClose -> "Connection closed locally"
             TmuxDisconnectReason.ExplicitDetach -> "Tmux client detached"
+            TmuxDisconnectReason.ServerExited -> "Tmux server restarted"
             TmuxDisconnectReason.Unknown -> "Disconnected"
         }
         return "$prefix from ${target.user}@${target.host}:${target.port}; reconnecting."
@@ -16933,6 +17033,13 @@ private const val STALE_LEASE_AUTO_RECOVER_MAX: Int = 2
 private val NON_RETRYABLE_FAILURE_CLASS_NAMES: Set<String> = setOf(
     "UserAuthException",
     "UnknownHostException",
+    // Issue #998: a dead tmux server will not come back by retrying the same
+    // attach — every retry would re-detect `no server running` (or worse, on a
+    // host whose tmux DID come back up, silently `new-session -A` a fresh empty
+    // server). So the auto-reconnect ladder must STOP on server-death rather
+    // than burn its 4 rungs; the user lands on the list (failServerDied already
+    // emitted `sessionEnded`) and recreates a session explicitly.
+    "TmuxServerDeadException",
 )
 
 /**

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -26,6 +26,7 @@ import com.pocketshell.app.crash.CrashReporter
 import com.pocketshell.app.composer.LocalAttachmentSidecarRef
 import com.pocketshell.app.composer.PromptAttachmentStager
 import com.pocketshell.app.connectivity.TerminalNetworkChange
+import com.pocketshell.app.connectivity.TerminalNetworkChangeKind
 import com.pocketshell.app.connectivity.hasSameNetworkIdentityAs
 import com.pocketshell.app.connectivity.networkDiagnosticFields
 import com.pocketshell.app.diagnostics.DiagnosticEvents
@@ -4283,9 +4284,15 @@ public class TmuxSessionViewModel @Inject constructor(
         // through. So the controller signal MUST honor the SAME liveness gate: when the
         // old transport is proven alive we report NO handoff to the controller, keeping
         // it Live (no overlay), in lockstep with [reduceNetworkChanged].
-        val realValidatedHandoff = change.previousValidated?.let { previous ->
-            !previous.hasSameNetworkIdentityAs(change.current)
-        } ?: false
+        // Issue #997: the bare-loss / restore signal is ORTHOGONAL to the #548
+        // validated-identity handoff — it must NOT be reported to the controller
+        // as a `validatedHandoff` (that flag is the identity-change overlay path).
+        // The loss/restore arms drive the UI via the loss-hold + the restore's
+        // own `scheduleAutoReconnect` → `setConnectionState`.
+        val realValidatedHandoff = change.kind == TerminalNetworkChangeKind.ValidatedIdentityChange &&
+            (change.previousValidated?.let { previous ->
+                !previous.hasSameNetworkIdentityAs(change.current)
+            } ?: false)
         connectionManager.observeNetworkChanged(
             validatedHandoff = realValidatedHandoff && !isTransportKeepAliveProvenAliveRecently(),
         )
@@ -4298,6 +4305,15 @@ public class TmuxSessionViewModel @Inject constructor(
                 if (target != null) suppressNetworkTransportProvenAlive(change, target)
             ConnectionDecision.ScheduleNetworkReconnect ->
                 if (target != null) scheduleNetworkReconnect(change, target)
+            // Issue #997: a bare network LOSS — hold the lease, suspend probes,
+            // surface "reconnecting"; do NOT churn or tear down (frequently
+            // transient). A RESTORE — drive a FAST reconnect even from a
+            // non-Connected (loss-suspended) state, bypassing the proven-alive
+            // gate (a real loss means the old socket is dead).
+            ConnectionDecision.HoldNetworkLost ->
+                if (target != null) holdNetworkLost(change, target)
+            ConnectionDecision.ScheduleNetworkReconnectOnRestore ->
+                if (target != null) scheduleNetworkReconnectOnRestore(change, target)
             else -> Unit
         }
         // NOTE: the network-change reconnect/coalesce decision is INLINE EFFECT
@@ -4562,6 +4578,138 @@ public class TmuxSessionViewModel @Inject constructor(
             "classification" to "proactive_network_handoff",
             "deferredFromBackground" to change.deferredFromBackground,
             "activeAttempt" to activeAttachMilestone?.attempt,
+        )
+        unregisterCurrentClient()
+        scheduleAutoReconnect(
+            target = target,
+            reason = reconnectReason,
+            trigger = TmuxConnectTrigger.NetworkReconnect,
+        )
+    }
+
+    /**
+     * Issue #997: the [ConnectionDecision.HoldNetworkLost] body. A bare network
+     * LOSS (`onLost` / airplane mode) was observed proactively. We do NOT tear the
+     * lease down — a loss is frequently transient (pocket, elevator) — but we DO
+     * surface the calm "reconnecting" band immediately so the user is not staring
+     * at a live-but-dead session, and we suspend the keepalive probe loop for the
+     * loss window. The probe loop self-suspends: [shouldRunLivenessProbe] only
+     * fires when the controller is `Live`, and flipping to `Reconnecting` here
+     * closes that gate — so probes stop churning writes into the dead socket
+     * without a separate suspend flag. Recovery is driven by the matching
+     * [scheduleNetworkReconnectOnRestore] when validation returns.
+     */
+    private fun holdNetworkLost(
+        change: TerminalNetworkChange,
+        target: ConnectionTarget,
+    ) {
+        val reason = change.reason
+        Log.i(
+            ISSUE_548_NETWORK_TAG,
+            "tmux-network-loss-hold reason=$reason " +
+                "cause=bare-network-loss " +
+                "current=${change.current.logValue} " +
+                targetLogFields(target),
+        )
+        DiagnosticEvents.record(
+            "connection",
+            "network_loss_hold",
+            "source" to "network_observer",
+            "trigger" to TmuxConnectTrigger.NetworkReconnect.logValue,
+            "reason" to reason,
+            "classification" to "bare_network_loss",
+            "reconnect" to false,
+            "probesSuspended" to true,
+            "leaseHeld" to true,
+            "sequence" to change.sequence,
+            "hostId" to target.hostId,
+            "host" to target.host,
+            "port" to target.port,
+            "user" to target.user,
+            "session" to target.sessionName,
+            "generation" to connectGeneration,
+            "deferredFromBackground" to change.deferredFromBackground,
+            *change.networkDiagnosticFields(),
+        )
+        ReconnectCauseTrail.record(
+            stage = "network_loss_decision",
+            outcome = "hold",
+            cause = "bare_network_loss",
+            trigger = TmuxConnectTrigger.NetworkReconnect.logValue,
+            "sequence" to change.sequence,
+            "hostId" to target.hostId,
+            "generation" to connectGeneration,
+            "classification" to "bare_network_loss",
+            "deferredFromBackground" to change.deferredFromBackground,
+        )
+        // Surface the calm "reconnecting" band WITHOUT launching a redial loop
+        // (the lease is held; recovery fires on restore). A reconnect already in
+        // flight is filtered out by the reducer, so this never clobbers a ladder.
+        setConnectionState(
+            ConnectionState.Reconnecting(
+                host = target.host,
+                port = target.port,
+                user = target.user,
+                attempt = 0,
+                maxAttempts = 0,
+                retryDelayMs = 0L,
+                reason = "Network lost; waiting for it to come back.",
+            ),
+        )
+    }
+
+    /**
+     * Issue #997: the [ConnectionDecision.ScheduleNetworkReconnectOnRestore] body.
+     * Validation RETURNED after a loss — drive a FAST reconnect via the existing
+     * `scheduleAutoReconnect` ladder (D28: NO new reconnect path). Unlike
+     * [scheduleNetworkReconnect] this does NOT require a `Connected` status (it
+     * recovers a loss-suspended / `Reconnecting` session — the whole point) and it
+     * BYPASSES the proven-alive ride-through (a real loss means the old socket is
+     * already dead). `target` is the held [activeTarget]/[connectingTarget].
+     */
+    private fun scheduleNetworkReconnectOnRestore(
+        change: TerminalNetworkChange,
+        target: ConnectionTarget,
+    ) {
+        val reason = change.reason
+        lifecycleReattachNetworkCoalesce = null
+        val reconnectReason =
+            "Network restored; reconnecting ${target.user}@${target.host}:${target.port}."
+        Log.i(
+            ISSUE_548_NETWORK_TAG,
+            "tmux-network-restore-reconnect reason=$reason " +
+                targetLogFields(target),
+        )
+        DiagnosticEvents.record(
+            "connection",
+            "network_restore_reconnect_start",
+            "source" to "network_observer",
+            "trigger" to TmuxConnectTrigger.NetworkReconnect.logValue,
+            "reason" to reason,
+            "classification" to "network_restored_fast_reconnect",
+            "reconnect" to true,
+            "bypassedProvenAlive" to true,
+            "sequence" to change.sequence,
+            "hostId" to target.hostId,
+            "host" to target.host,
+            "port" to target.port,
+            "user" to target.user,
+            "session" to target.sessionName,
+            "generation" to connectGeneration,
+            "clientHash" to clientRef?.let { System.identityHashCode(it) },
+            "deferredFromBackground" to change.deferredFromBackground,
+            *change.networkDiagnosticFields(),
+        )
+        ReconnectCauseTrail.record(
+            stage = "network_reconnect_decision",
+            outcome = "schedule_reconnect",
+            cause = "network_restored",
+            trigger = TmuxConnectTrigger.NetworkReconnect.logValue,
+            "sequence" to change.sequence,
+            "hostId" to target.hostId,
+            "generation" to connectGeneration,
+            "classification" to "network_restored_fast_reconnect",
+            "deferredFromBackground" to change.deferredFromBackground,
         )
         unregisterCurrentClient()
         scheduleAutoReconnect(
@@ -15540,6 +15688,29 @@ public class TmuxSessionViewModel @Inject constructor(
         /** Schedule a proactive reconnect for a real validated network handoff. */
         data object ScheduleNetworkReconnect : ConnectionDecision
 
+        /**
+         * Issue #997: a bare availability LOSS (`onLost` / airplane mode). Hold
+         * the lease, surface the calm "reconnecting" band, and suspend the
+         * keepalive probe loop so it does not churn writes into a dead socket
+         * during the loss window. Does NOT tear the lease down — a loss is
+         * frequently transient (pocket, elevator); the matching
+         * [ScheduleNetworkReconnectOnRestore] drives recovery when validation
+         * returns. This replaces the pre-#997 behavior where a clean loss was
+         * invisible to the proactive path and only noticed ~90s later by the
+         * keepalive ride-through.
+         */
+        data object HoldNetworkLost : ConnectionDecision
+
+        /**
+         * Issue #997: validation RETURNED after a loss. Drive a FAST reconnect
+         * via the existing `scheduleAutoReconnect` ladder — even from a
+         * non-Connected (loss-suspended / Reconnecting) state, which the
+         * [ScheduleNetworkReconnect] `Connected`-only gate would have ignored —
+         * and BYPASS the proven-alive ride-through (a real loss means the old
+         * socket is already dead, so there is nothing alive to ride through).
+         */
+        data object ScheduleNetworkReconnectOnRestore : ConnectionDecision
+
         /** Suppress: not a real validated handoff (#548). */
         data object SuppressNetworkNotValidated : ConnectionDecision
 
@@ -15611,6 +15782,32 @@ public class TmuxSessionViewModel @Inject constructor(
 
     private fun reduceNetworkChanged(change: TerminalNetworkChange): ConnectionDecision {
         if (!appActive) return ConnectionDecision.Ignore
+
+        // Issue #997: the orthogonal bare-loss / restore signal, classified BEFORE
+        // the #548 validated-identity-change gates (which require a Connected
+        // status and would `Ignore` a loss-suspended session — the whole gap this
+        // closes). A loss/restore is only meaningful when there is a session to
+        // hold or recover.
+        when (change.kind) {
+            TerminalNetworkChangeKind.NetworkLost -> {
+                if (activeTarget == null && connectingTarget == null) return ConnectionDecision.Ignore
+                if (clientRef == null && sessionRef == null) return ConnectionDecision.Ignore
+                // Don't disturb an in-flight reconnect ladder; it already owns the UI.
+                if (autoReconnectJob?.isActive == true) return ConnectionDecision.Ignore
+                return ConnectionDecision.HoldNetworkLost
+            }
+            TerminalNetworkChangeKind.NetworkRestored -> {
+                if (activeTarget == null && connectingTarget == null) return ConnectionDecision.Ignore
+                if (clientRef == null && sessionRef == null) return ConnectionDecision.Ignore
+                // A reconnect ladder is already driving recovery — let it run.
+                if (autoReconnectJob?.isActive == true) return ConnectionDecision.Ignore
+                // Bypass the proven-alive gate: a real loss means the old socket
+                // is dead, so there is nothing alive to ride through.
+                return ConnectionDecision.ScheduleNetworkReconnectOnRestore
+            }
+            TerminalNetworkChangeKind.ValidatedIdentityChange -> Unit
+        }
+
         if (autoReconnectJob?.isActive == true) return ConnectionDecision.Ignore
         if (inlineConnectionStatus !is ConnectionStatus.Connected) return ConnectionDecision.Ignore
         val target = activeTarget ?: connectingTarget ?: return ConnectionDecision.Ignore

--- a/app/src/test/java/com/pocketshell/app/connectivity/TerminalNetworkChangeDetectorTest.kt
+++ b/app/src/test/java/com/pocketshell/app/connectivity/TerminalNetworkChangeDetectorTest.kt
@@ -107,58 +107,183 @@ class TerminalNetworkChangeDetectorTest {
         assertEquals(1L, handoff.sequence)
     }
 
+    // --- Issue #997 — the bare-LOSS / RESTORE signal, orthogonal to the #548
+    // validated-identity-change signal. Pre-#997 the detector returned `null` for
+    // any non-validated snapshot (`:328`) AND for a same-identity restore (`:333`),
+    // so a clean drop (and an airplane-mode round-trip) was invisible to the
+    // proactive path and only noticed ~90s later by the keepalive ride-through.
+    // These cases assert the new NetworkLost / NetworkRestored emissions.
+
     @Test
-    fun `offline transition waits until a validated network returns`() {
+    fun `bare network loss now emits a NetworkLost event (issue 997)`() {
+        // RED on base: a Validated → NoValidatedNetwork transition returned null
+        // (the `:328` swallow). GREEN with #997: a NetworkLost is surfaced.
         val detector = TerminalNetworkChangeDetector(
             initial = TerminalNetworkSnapshot.Validated("wifi"),
         )
 
-        assertNull(
-            detector.update(
-                snapshot = TerminalNetworkSnapshot.NoValidatedNetwork,
-                reason = "lost",
-            ),
+        val lost = detector.update(
+            snapshot = TerminalNetworkSnapshot.NoValidatedNetwork,
+            reason = "default-network-lost",
         )
 
-        val change = detector.update(
-            snapshot = TerminalNetworkSnapshot.Validated("cell"),
-            reason = "available",
-        )
-
-        assertTrue(change != null)
-        assertEquals(TerminalNetworkSnapshot.NoValidatedNetwork, change!!.previous)
-        assertEquals(TerminalNetworkSnapshot.Validated("cell"), change.current)
+        assertTrue("a bare network loss must surface a proactive change", lost != null)
+        assertEquals(TerminalNetworkChangeKind.NetworkLost, lost!!.kind)
+        assertEquals(TerminalNetworkSnapshot.Validated("wifi"), lost.previous)
+        assertEquals(TerminalNetworkSnapshot.NoValidatedNetwork, lost.current)
+        assertEquals(TerminalNetworkSnapshot.Validated("wifi"), lost.previousValidated)
+        assertEquals(1L, lost.sequence)
     }
 
     @Test
-    fun `transient offline bounce back to same validated network does not emit reconnect`() {
+    fun `loss then restore to the SAME identity emits NetworkRestored (issue 997 airplane-mode round-trip)`() {
+        // The airplane-mode round-trip the issue names: wifi → none → SAME wifi.
+        // RED on base: the loss returned null (`:328`) and the same-identity
+        // restore returned null (`:333`) — so the dead socket was never recovered
+        // proactively. GREEN with #997: loss emits NetworkLost, restore emits
+        // NetworkRestored (NOT swallowed despite the identical identity).
         val detector = TerminalNetworkChangeDetector(
             initial = TerminalNetworkSnapshot.Validated("wifi"),
         )
 
-        assertNull(
-            detector.update(
-                snapshot = TerminalNetworkSnapshot.NoValidatedNetwork,
-                reason = "default-network-lost",
-            ),
+        val lost = detector.update(
+            snapshot = TerminalNetworkSnapshot.NoValidatedNetwork,
+            reason = "default-network-lost",
+        )
+        assertEquals(TerminalNetworkChangeKind.NetworkLost, lost!!.kind)
+
+        val restored = detector.update(
+            snapshot = TerminalNetworkSnapshot.Validated("wifi"),
+            reason = "default-network-available",
         )
 
+        assertTrue("a same-identity restore after a loss must NOT be swallowed", restored != null)
+        assertEquals(TerminalNetworkChangeKind.NetworkRestored, restored!!.kind)
+        assertEquals(TerminalNetworkSnapshot.NoValidatedNetwork, restored.previous)
+        assertEquals(TerminalNetworkSnapshot.Validated("wifi"), restored.current)
+        assertEquals(2L, restored.sequence)
+    }
+
+    @Test
+    fun `loss then restore to a DIFFERENT identity emits NetworkRestored (issue 997 handoff)`() {
+        // wifi → none → cell. A cross-transport recovery after a loss. Still a
+        // NetworkRestored (the loss flag is the discriminator vs the #548
+        // validated handoff) and it must drive a reconnect.
+        val detector = TerminalNetworkChangeDetector(
+            initial = TerminalNetworkSnapshot.Validated("wifi"),
+        )
+
+        val lost = detector.update(
+            snapshot = TerminalNetworkSnapshot.NoValidatedNetwork,
+            reason = "default-network-lost",
+        )
+        assertEquals(TerminalNetworkChangeKind.NetworkLost, lost!!.kind)
+
+        val restored = detector.update(
+            snapshot = TerminalNetworkSnapshot.Validated("cell"),
+            reason = "default-network-available",
+        )
+
+        assertTrue(restored != null)
+        assertEquals(TerminalNetworkChangeKind.NetworkRestored, restored!!.kind)
+        assertEquals(TerminalNetworkSnapshot.NoValidatedNetwork, restored.previous)
+        assertEquals(TerminalNetworkSnapshot.Validated("cell"), restored.current)
+        assertEquals(2L, restored.sequence)
+    }
+
+    @Test
+    fun `repeated loss callbacks emit exactly one NetworkLost (no churn during loss, issue 997)`() {
+        // Idempotency: airplane mode can deliver onLost + onUnavailable + repeated
+        // NoValidatedNetwork capability churn. Only the FIRST surfaces — the rest
+        // must NOT re-emit (no churn during the loss window).
+        val detector = TerminalNetworkChangeDetector(
+            initial = TerminalNetworkSnapshot.Validated("wifi"),
+        )
+
+        val first = detector.update(
+            snapshot = TerminalNetworkSnapshot.NoValidatedNetwork,
+            reason = "default-network-lost",
+        )
+        assertEquals(TerminalNetworkChangeKind.NetworkLost, first!!.kind)
+
         assertNull(
+            "a second NoValidatedNetwork while already lost must NOT re-emit",
             detector.update(
-                snapshot = TerminalNetworkSnapshot.Validated("wifi"),
+                snapshot = TerminalNetworkSnapshot.NoValidatedNetwork,
+                reason = "default-network-unavailable",
+            ),
+        )
+        assertNull(
+            "a third NoValidatedNetwork while already lost must NOT re-emit",
+            detector.update(
+                snapshot = TerminalNetworkSnapshot.NoValidatedNetwork,
                 reason = "default-network-capabilities",
             ),
         )
 
+        // ...and the restore still fires exactly once with the next sequence.
+        val restored = detector.update(
+            snapshot = TerminalNetworkSnapshot.Validated("wifi"),
+            reason = "default-network-available",
+        )
+        assertEquals(TerminalNetworkChangeKind.NetworkRestored, restored!!.kind)
+        assertEquals(2L, restored.sequence)
+    }
+
+    @Test
+    fun `a normal validated identity change still emits a ValidatedIdentityChange (issue 997 regression guard)`() {
+        // The #548 handoff signal is orthogonal to the new loss/restore signal and
+        // must be UNCHANGED: a WIFI→CELLULAR flip with no intervening loss is still
+        // a ValidatedIdentityChange, not a restore.
+        val detector = TerminalNetworkChangeDetector(
+            initial = TerminalNetworkSnapshot.Validated("wifi", setOf("WIFI")),
+        )
+
         val handoff = detector.update(
-            snapshot = TerminalNetworkSnapshot.Validated("cell"),
+            snapshot = TerminalNetworkSnapshot.Validated("cell", setOf("CELLULAR")),
             reason = "real-handoff",
         )
 
         assertTrue(handoff != null)
-        assertEquals(TerminalNetworkSnapshot.Validated("wifi"), handoff!!.previous)
-        assertEquals(TerminalNetworkSnapshot.Validated("cell"), handoff.current)
+        assertEquals(TerminalNetworkChangeKind.ValidatedIdentityChange, handoff!!.kind)
+        assertEquals(TerminalNetworkSnapshot.Validated("wifi", setOf("WIFI")), handoff.previous)
+        assertEquals(TerminalNetworkSnapshot.Validated("cell", setOf("CELLULAR")), handoff.current)
         assertEquals(1L, handoff.sequence)
+    }
+
+    @Test
+    fun `restore clears the loss flag so a later same-identity reassoc is still suppressed (issue 997)`() {
+        // After a loss→restore cycle the detector returns to normal identity
+        // tracking: a subsequent same-identity (pure-WIFI) reassoc must still be
+        // suppressed (#875), and a real handoff must still emit ValidatedIdentityChange.
+        val detector = TerminalNetworkChangeDetector(
+            initial = TerminalNetworkSnapshot.Validated("wifi-A", setOf("WIFI")),
+        )
+
+        assertEquals(
+            TerminalNetworkChangeKind.NetworkLost,
+            detector.update(TerminalNetworkSnapshot.NoValidatedNetwork, "lost")!!.kind,
+        )
+        assertEquals(
+            TerminalNetworkChangeKind.NetworkRestored,
+            detector.update(TerminalNetworkSnapshot.Validated("wifi-A", setOf("WIFI")), "available")!!.kind,
+        )
+
+        // A pure-WIFI band-steer reassoc after the restore is still a non-event.
+        assertNull(
+            "a pure-WIFI reassoc after a restore must still be suppressed (#875)",
+            detector.update(
+                TerminalNetworkSnapshot.Validated("wifi-B", setOf("WIFI")),
+                "band-steer",
+            ),
+        )
+
+        // A genuine transport handoff after the restore is still a handoff.
+        val handoff = detector.update(
+            TerminalNetworkSnapshot.Validated("cell", setOf("CELLULAR")),
+            "real-handoff",
+        )
+        assertEquals(TerminalNetworkChangeKind.ValidatedIdentityChange, handoff!!.kind)
     }
 
     // --- Issue #875 (Angle C) — a same-SSID wifi supplicant reassociation mints

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
@@ -4,6 +4,7 @@ import android.os.Looper
 import android.os.SystemClock
 import com.pocketshell.app.cards.SessionCardsRemoteSource
 import com.pocketshell.app.connectivity.TerminalNetworkChange
+import com.pocketshell.app.connectivity.TerminalNetworkChangeKind
 import com.pocketshell.app.connectivity.TerminalNetworkSnapshot
 import com.pocketshell.app.diagnostics.installRecordingDiagnosticSink
 import com.pocketshell.app.hosts.MainDispatcherRule
@@ -3807,6 +3808,148 @@ class TmuxSessionViewModelTest {
             vm.latestRestoreIntentSnapshot()?.trigger,
         )
         assertTrue(vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Reconnecting)
+
+        vm.forceTransportProvenAliveForTest = null
+    }
+
+    // ---- Issue #997: bare network LOSS → hold (no churn) → RESTORE → fast reconnect.
+    // Pre-#997 a clean loss produced NO proactive change at all (the detector
+    // swallowed it), so a loss-suspended session never fast-recovered — it waited
+    // ~90s for the keepalive ride-through. The reducer arms here are the
+    // ViewModel half of the fix: a NetworkLost holds the lease + surfaces the calm
+    // band without churning; a NetworkRestored drives `scheduleAutoReconnect` even
+    // from a non-Connected state and bypasses the proven-alive gate.
+
+    @Test
+    fun issue997BareNetworkLossHoldsTheLeaseWithoutChurningOrTearingDown() = runTest(scheduler) {
+        val registry = ActiveTmuxClients()
+        val connector = QueueLeaseConnector(FakeSshSession())
+        val vm = newVm(
+            registry = registry,
+            sshLeaseManager = testLeaseManager(connector = connector, scope = this, idleTtlMillis = 0L),
+        )
+        vm.setAutoReconnectDelaysForTest(listOf(60_000L))
+        vm.replaceClientForTest(
+            hostId = 7L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            sessionName = "work",
+            client = FakeTmuxClient(),
+        )
+        runCurrent()
+        assertTrue(vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected)
+
+        registry.lifecycleHooksSnapshot().single().onNetworkChanged(networkLoss())
+        runCurrent()
+
+        // The calm "reconnecting" band is surfaced (UI not left on a dead-but-live
+        // session) WITHOUT launching a redial loop and WITHOUT tearing the lease.
+        assertTrue(
+            "a bare loss surfaces the calm Reconnecting band immediately",
+            vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Reconnecting,
+        )
+        assertEquals("no redial during the loss window — lease is held", 0, connector.connectCount)
+
+        // No churn: even after time passes nothing redials (no ladder running).
+        advanceTimeBy(60_000L)
+        advanceUntilIdle()
+        assertEquals(0, connector.connectCount)
+    }
+
+    @Test
+    fun issue997NetworkRestoreDrivesFastReconnectFromLossSuspendedState() = runTest(scheduler) {
+        TMUX_CONNECT_ATTEMPTS.set(0)
+        val registry = ActiveTmuxClients()
+        val connector = QueueLeaseConnector(FakeSshSession())
+        val reconnectClient = FakeTmuxClient().withSinglePane("work", "%1")
+        val vm = newVm(
+            registry = registry,
+            sshLeaseManager = testLeaseManager(connector = connector, scope = this, idleTtlMillis = 0L),
+        )
+        vm.setTmuxClientFactoryForTest { _, sessionName, _ ->
+            assertEquals("work", sessionName)
+            reconnectClient
+        }
+        vm.setAutoReconnectDelaysForTest(listOf(0L))
+        vm.replaceClientForTest(
+            hostId = 7L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            sessionName = "work",
+            client = FakeTmuxClient(),
+        )
+        runCurrent()
+
+        // Loss: hold + flip to Reconnecting (the loss-suspended state).
+        registry.lifecycleHooksSnapshot().single().onNetworkChanged(networkLoss())
+        runCurrent()
+        assertTrue(
+            "loss leaves the session in the loss-suspended Reconnecting state",
+            vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Reconnecting,
+        )
+        assertEquals(0, connector.connectCount)
+
+        // Restore: must drive a FAST reconnect even though status is NOT Connected
+        // (the #997 gap — the Connected-only ScheduleNetworkReconnect path would
+        // have Ignored this).
+        registry.lifecycleHooksSnapshot().single().onNetworkChanged(networkRestore())
+        advanceUntilIdle()
+
+        assertEquals(
+            "restore must redial via the auto-reconnect ladder with the network trigger",
+            TmuxConnectTrigger.NetworkReconnect,
+            vm.latestRestoreIntentSnapshot()?.trigger,
+        )
+        assertEquals("exactly one fresh-lease redial on restore", 1, connector.connectCount)
+        assertSame(reconnectClient, registry.clients.value[7L]?.client)
+    }
+
+    @Test
+    fun issue997NetworkRestoreReconnectsEvenWhenTransportWasProvenAlive() = runTest(scheduler) {
+        // A real loss means the old socket is DEAD, so the proven-alive
+        // ride-through (#981) must NOT suppress a restore-driven reconnect. Pin
+        // proven-alive=true and confirm the restore still redials (unlike a bare
+        // validated handoff, which #981 rides through when proven alive).
+        TMUX_CONNECT_ATTEMPTS.set(0)
+        val registry = ActiveTmuxClients()
+        val connector = QueueLeaseConnector(FakeSshSession())
+        val reconnectClient = FakeTmuxClient().withSinglePane("work", "%1")
+        val vm = newVm(
+            registry = registry,
+            sshLeaseManager = testLeaseManager(connector = connector, scope = this, idleTtlMillis = 0L),
+        )
+        vm.setTmuxClientFactoryForTest { _, _, _ -> reconnectClient }
+        vm.setAutoReconnectDelaysForTest(listOf(0L))
+        vm.replaceClientForTest(
+            hostId = 7L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            sessionName = "work",
+            client = FakeTmuxClient(),
+        )
+        runCurrent()
+
+        vm.forceTransportProvenAliveForTest = true
+        registry.lifecycleHooksSnapshot().single().onNetworkChanged(networkLoss())
+        runCurrent()
+        registry.lifecycleHooksSnapshot().single().onNetworkChanged(networkRestore())
+        advanceUntilIdle()
+
+        assertEquals(
+            "a restore after a real loss bypasses the proven-alive gate and reconnects",
+            TmuxConnectTrigger.NetworkReconnect,
+            vm.latestRestoreIntentSnapshot()?.trigger,
+        )
+        assertEquals(1, connector.connectCount)
 
         vm.forceTransportProvenAliveForTest = null
     }
@@ -15210,6 +15353,37 @@ class TmuxSessionViewModelTest {
             reason = reason,
             sequence = sequence,
             deferredFromBackground = deferredFromBackground,
+        )
+
+    // Issue #997: a bare network LOSS change (Validated → NoValidatedNetwork).
+    private fun networkLoss(
+        previousValidated: TerminalNetworkSnapshot.Validated = TerminalNetworkSnapshot.Validated("wifi"),
+        reason: String = "default-network-lost",
+        sequence: Long = 1L,
+    ): TerminalNetworkChange =
+        TerminalNetworkChange(
+            previous = previousValidated,
+            current = TerminalNetworkSnapshot.NoValidatedNetwork,
+            previousValidated = previousValidated,
+            reason = reason,
+            sequence = sequence,
+            kind = TerminalNetworkChangeKind.NetworkLost,
+        )
+
+    // Issue #997: a network RESTORE change (NoValidatedNetwork → Validated).
+    private fun networkRestore(
+        current: TerminalNetworkSnapshot.Validated = TerminalNetworkSnapshot.Validated("wifi"),
+        previousValidated: TerminalNetworkSnapshot.Validated = TerminalNetworkSnapshot.Validated("wifi"),
+        reason: String = "default-network-available",
+        sequence: Long = 2L,
+    ): TerminalNetworkChange =
+        TerminalNetworkChange(
+            previous = TerminalNetworkSnapshot.NoValidatedNetwork,
+            current = current,
+            previousValidated = previousValidated,
+            reason = reason,
+            sequence = sequence,
+            kind = TerminalNetworkChangeKind.NetworkRestored,
         )
 
     // ---- Issue #626: unified pane list tests ----

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionWarmOpenTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionWarmOpenTest.kt
@@ -14,12 +14,14 @@ import com.pocketshell.core.ssh.SshShell
 import com.pocketshell.core.terminal.bridge.SshTerminalBridge
 import com.pocketshell.core.terminal.ui.TerminalSurfaceState
 import com.pocketshell.core.tmux.TmuxClientFactory
+import com.pocketshell.core.tmux.TmuxServerDeadException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.onSubscription
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
@@ -108,6 +110,43 @@ class TmuxSessionWarmOpenTest {
         // `advanceUntilIdle` drains them. Production defaults to `Dispatchers.IO`
         // (off the UI thread, so the seed never freezes it).
         it.setSeedIoDispatcherForTest(Dispatchers.Main)
+    }
+
+    /**
+     * Issue #998 determinism helper. The server-liveness preflight inside
+     * [com.pocketshell.core.tmux.RealTmuxClient.connect] runs its `tmux
+     * has-session` exec under a hard-coded `withContext(Dispatchers.IO)` — a hop
+     * onto the REAL IO threadpool, off the test virtual clock. `advanceUntilIdle()`
+     * returns as soon as the test scheduler queue is empty, which can happen
+     * while the `connect()` coroutine is still parked on that real IO dispatcher;
+     * the subsequent `failServerDied(...)` `tryEmit` then lands AFTER the test
+     * already cancelled the collector and read `[]` (the flaky
+     * `expected:<[work]> but was:<[]>` in the full suite). This helper bridges the
+     * two clocks deterministically: it pumps the virtual scheduler to idle, and —
+     * if the awaited condition has not yet been satisfied — yields a sliver of
+     * REAL time for the IO continuation to re-enqueue, then pumps again, looping
+     * up to a hard deadline. It HARD-FAILS (never self-skips) if the condition is
+     * not met within the budget, so a genuine routing regression still reds.
+     */
+    private fun TestScope.pumpUntil(
+        timeoutMillis: Long = 5_000L,
+        reason: String,
+        condition: () -> Boolean,
+    ) {
+        val deadlineNanos = System.nanoTime() + timeoutMillis * 1_000_000L
+        while (true) {
+            advanceUntilIdle()
+            if (condition()) return
+            if (System.nanoTime() >= deadlineNanos) {
+                throw AssertionError(
+                    "pumpUntil timed out after ${timeoutMillis}ms waiting for: $reason",
+                )
+            }
+            // Let the real Dispatchers.IO continuation (the preflight exec /
+            // failServerDied tryEmit) make progress and re-enqueue onto the test
+            // scheduler, then loop and drain it.
+            Thread.sleep(2)
+        }
     }
 
     private fun leaseTargetFor(): SshLeaseTarget =
@@ -388,7 +427,21 @@ class TmuxSessionWarmOpenTest {
         }
 
         val sessionEndedEvents = mutableListOf<String>()
-        val endedCollector = launch { vm.sessionEnded.collect { sessionEndedEvents.add(it) } }
+        var endedSubscribed = false
+        val endedCollector = launch {
+            vm.sessionEnded
+                .onSubscription { endedSubscribed = true }
+                .collect { sessionEndedEvents.add(it) }
+        }
+        // DETERMINISM (issue #998 flake): subscribe the no-replay `sessionEnded`
+        // collector BEFORE connect so the drop-to-list `tryEmit` is reliably
+        // observed (no race against the connect coroutine). Same barrier as the
+        // reconnect dead-server / blip tests.
+        testScheduler.runCurrent()
+        assertTrue(
+            "the sessionEnded collector must be subscribed before connect (determinism barrier)",
+            endedSubscribed,
+        )
 
         vm.connect(
             hostId = 1L,
@@ -401,7 +454,11 @@ class TmuxSessionWarmOpenTest {
             sessionName = "work",
             trigger = TmuxConnectTrigger.ColdRestore,
         )
-        advanceUntilIdle()
+        // Wait for the gone-session drop-to-list to settle across the real
+        // Dispatchers.IO preflight hop (see pumpUntil's KDoc).
+        pumpUntil(reason = "gone-session drop-to-list (sessionEnded fired)") {
+            sessionEndedEvents.isNotEmpty()
+        }
         endedCollector.cancel()
 
         // The gone-session preflight ran the has-session probe...
@@ -488,7 +545,21 @@ class TmuxSessionWarmOpenTest {
         }
 
         val sessionEndedEvents = mutableListOf<String>()
-        val endedCollector = launch { vm.sessionEnded.collect { sessionEndedEvents.add(it) } }
+        var endedSubscribed = false
+        val endedCollector = launch {
+            vm.sessionEnded
+                .onSubscription { endedSubscribed = true }
+                .collect { sessionEndedEvents.add(it) }
+        }
+        // DETERMINISM (issue #998 flake): subscribe BEFORE connect so the
+        // negative assert below (`sessionEndedEvents.isEmpty()`) is non-vacuous —
+        // empty because no drop-to-list fired, not because the listener was
+        // absent. Same barrier as the reconnect dead-server / blip tests.
+        testScheduler.runCurrent()
+        assertTrue(
+            "the sessionEnded collector must be subscribed before connect (determinism barrier)",
+            endedSubscribed,
+        )
 
         vm.connect(
             hostId = 1L,
@@ -501,7 +572,13 @@ class TmuxSessionWarmOpenTest {
             sessionName = "work",
             trigger = TmuxConnectTrigger.ColdRestore,
         )
-        advanceUntilIdle()
+        // Wait for the live-restore to settle to Connected across the real
+        // Dispatchers.IO preflight hop (see pumpUntil's KDoc); the negative
+        // sessionEnded assert below is then evaluated against a fully-settled
+        // outcome, not a half-pumped one.
+        pumpUntil(reason = "live cold-restore reaches Connected") {
+            vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected
+        }
         endedCollector.cancel()
 
         assertFalse(
@@ -514,6 +591,229 @@ class TmuxSessionWarmOpenTest {
         )
         assertTrue(
             "a live restore must NOT emit sessionEnded",
+            sessionEndedEvents.isEmpty(),
+        )
+        assertEquals(listOf("%1"), vm.panes.value.map { it.paneId })
+    }
+
+    // ---- Issue #998: a reconnect to a DEAD tmux SERVER must drop to the list,
+    //      never silently resurrect a blank session via `new-session -A` ----
+
+    @Test
+    fun reconnectToDeadServerDropsToListAndNeverResurrects() = runVmTest {
+        // The remote tmux SERVER died (host reboot / OOM / kill-server) while we
+        // were connected. The reconnect attach runs the REAL RealTmuxClient
+        // server-liveness preflight (probeServerLiveness=true for a reconnect
+        // trigger); the `has-session` probe returns `no server running`, so the
+        // attach must surface server-death and drop to the list — NOT silently
+        // boot a fresh empty server with `new-session -A` (the resurrection bug),
+        // NOT auto-reconnect into a blank "Connected" pane.
+        val dead = AlwaysConnectedSession(
+            id = "dead",
+            hasSessionExitCode = 1,
+            hasSessionStderr = "no server running on /tmp/tmux-1000/default",
+        )
+        val connector = SingleSessionConnector(dead)
+        val leaseManager =
+            testLeaseManager(connector = connector, scope = this, idleTtlMillis = 60_000L)
+        val registry = ActiveTmuxClients()
+        val vm = TestNewVm(registry = registry, sshLeaseManager = leaseManager)
+
+        // The real factory is used (no override), so the REAL preflight runs. If
+        // a client were ever spawned past the preflight it would call
+        // startShell() (which this session double errors on) — so reaching
+        // Connected here is impossible without the silent-resurrection path.
+        val sessionEndedEvents = mutableListOf<String>()
+        var endedSubscribed = false
+        val endedCollector = launch {
+            vm.sessionEnded
+                .onSubscription { endedSubscribed = true }
+                .collect { sessionEndedEvents.add(it) }
+        }
+        // DETERMINISM (issue #998 flake): `_sessionEnded` is a no-replay
+        // MutableSharedFlow(extraBufferCapacity=1). On a StandardTestDispatcher a
+        // bare `launch{}` only QUEUES the collector — it does not subscribe until
+        // the scheduler runs it. If `connect()`'s coroutine wins the race and
+        // `failServerDied` calls `tryEmit` before the collector has subscribed,
+        // the drop-to-list event is dropped (no replay) and `sessionEndedEvents`
+        // stays `[]` non-deterministically (flaky `expected:<[work]> but was:<[]>`
+        // in the full suite). `runCurrent()` drains already-queued work WITHOUT
+        // advancing virtual time, running the collector up to (and through) its
+        // `onSubscription` block so the subscription is registered BEFORE we
+        // trigger the server-death path — the emit is then buffered for the live
+        // subscriber and reliably observed. The `endedSubscribed` assert makes
+        // the barrier non-vacuous (it fails loudly if the subscription did not
+        // actually take effect).
+        testScheduler.runCurrent()
+        assertTrue(
+            "the sessionEnded collector must be subscribed before connect (determinism barrier)",
+            endedSubscribed,
+        )
+
+        vm.connect(
+            hostId = 1L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            passphrase = null,
+            sessionName = "work",
+            trigger = TmuxConnectTrigger.Reconnect,
+        )
+        // Wait for the server-death routing to actually settle to a terminal
+        // outcome (drop-to-list emitted OR a Failed surface) across the real
+        // Dispatchers.IO preflight hop — see pumpUntil's KDoc for why a bare
+        // advanceUntilIdle() is insufficient and flaky here.
+        pumpUntil(reason = "server-death drop-to-list (sessionEnded fired)") {
+            sessionEndedEvents.isNotEmpty()
+        }
+        endedCollector.cancel()
+
+        // The reconnect requested the server-liveness probe...
+        assertTrue(
+            "a reconnect must request the server-liveness probe (probeServerLiveness=true)",
+            vm.lastProbeServerLivenessForTest(),
+        )
+        // ...the preflight ran the has-session probe...
+        assertTrue(
+            "reconnect must probe `tmux has-session`; saw: ${dead.execCommands}",
+            dead.execCommands.any { it.startsWith("tmux has-session -t 'work'") },
+        )
+        // ...we dropped to the list (one-shot sessionEnded fired)...
+        assertEquals(
+            "server-death must drop to the list via sessionEnded",
+            listOf("work"),
+            sessionEndedEvents,
+        )
+        // ...the surface is the terminal server-death Failed state, NOT a blank
+        // Connected pane and NOT a Reconnecting band.
+        assertTrue(
+            "server-death must surface Failed (server restarted), got ${vm.connectionStatus.value}",
+            vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Failed,
+        )
+        assertFalse(
+            "server-death must NOT resurrect into Connected",
+            vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+        assertFalse(
+            "server-death must NOT auto-reconnect (the silent-resurrection loop)",
+            vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Reconnecting,
+        )
+        // No pane was ever painted — nothing got resurrected.
+        assertTrue(
+            "no pane must be painted on a dead server, got ${vm.panes.value.map { it.paneId }}",
+            vm.panes.value.isEmpty(),
+        )
+    }
+
+    @Test
+    fun explicitNewSessionNeverRequestsServerLivenessProbe() = runVmTest {
+        // The boundary that keeps the #998 probe off the create path: the
+        // explicit user "new session" intent (UserTap) must NOT request the
+        // server-liveness probe — a brand-new session legitimately wants a fresh
+        // server if none is running.
+        val fresh = AlwaysConnectedSession(id = "fresh")
+        val connector = SingleSessionConnector(fresh)
+        val leaseManager =
+            testLeaseManager(connector = connector, scope = this, idleTtlMillis = 60_000L)
+        val registry = ActiveTmuxClients()
+        val vm = TestNewVm(registry = registry, sshLeaseManager = leaseManager)
+
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%1")
+        vm.setTmuxClientFactoryForTest { _, _, _ -> client }
+
+        vm.connect(
+            hostId = 1L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            passphrase = null,
+            sessionName = "work",
+            trigger = TmuxConnectTrigger.UserTap,
+        )
+        advanceUntilIdle()
+
+        assertFalse(
+            "explicit user tap must NOT request the server-liveness probe",
+            vm.lastProbeServerLivenessForTest(),
+        )
+        assertTrue(
+            "explicit user tap must reach Connected, got ${vm.connectionStatus.value}",
+            vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+    }
+
+    @Test
+    fun reconnectTransportBlipToLiveSessionReattachesConnected() = runVmTest {
+        // The ordinary transport-blip class: the server is ALIVE on reconnect, so
+        // the reattach must succeed (Connected), NOT be misclassified as
+        // server-death. The override returns a live FakeTmuxClient (its connect()
+        // does not throw), proving the blip path is untouched by #998.
+        val live = AlwaysConnectedSession(id = "live") // has-session exit 0 (alive)
+        val connector = SingleSessionConnector(live)
+        val leaseManager =
+            testLeaseManager(connector = connector, scope = this, idleTtlMillis = 60_000L)
+        val registry = ActiveTmuxClients()
+        val vm = TestNewVm(registry = registry, sshLeaseManager = leaseManager)
+
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%1")
+        vm.setTmuxClientFactoryForTest { _, _, _ -> client }
+
+        val sessionEndedEvents = mutableListOf<String>()
+        var endedSubscribed = false
+        val endedCollector = launch {
+            vm.sessionEnded
+                .onSubscription { endedSubscribed = true }
+                .collect { sessionEndedEvents.add(it) }
+        }
+        // DETERMINISM (issue #998 flake): subscribe the no-replay `sessionEnded`
+        // collector BEFORE connect (same reasoning as
+        // reconnectToDeadServerDropsToListAndNeverResurrects). Without the
+        // barrier the negative assertion below (`sessionEndedEvents.isEmpty()`)
+        // would pass VACUOUSLY whenever the collector hadn't subscribed yet — it
+        // must be empty because no drop-to-list fired, not because the listener
+        // was absent. `runCurrent()` registers the subscription before the emit
+        // window opens; the `endedSubscribed` assert pins it non-vacuously.
+        testScheduler.runCurrent()
+        assertTrue(
+            "the sessionEnded collector must be subscribed before connect (determinism barrier)",
+            endedSubscribed,
+        )
+
+        vm.connect(
+            hostId = 1L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            passphrase = null,
+            sessionName = "work",
+            trigger = TmuxConnectTrigger.Reconnect,
+        )
+        // Wait for the transport-blip reattach to settle to Connected across the
+        // real Dispatchers.IO preflight hop (see pumpUntil's KDoc); the negative
+        // sessionEnded assert below is then non-vacuous.
+        pumpUntil(reason = "transport-blip reattach reaches Connected") {
+            vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected
+        }
+        endedCollector.cancel()
+
+        // The reconnect still requested the probe (the flag is trigger-driven)...
+        assertTrue(
+            "a reconnect requests the server-liveness probe",
+            vm.lastProbeServerLivenessForTest(),
+        )
+        // ...but a live server reattaches normally — Connected, no drop-to-list.
+        assertTrue(
+            "a transport-blip reconnect to a live server must reach Connected, got ${vm.connectionStatus.value}",
+            vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+        assertTrue(
+            "a live reconnect must NOT emit sessionEnded",
             sessionEndedEvents.isEmpty(),
         )
         assertEquals(listOf("%1"), vm.panes.value.map { it.paneId })
@@ -886,6 +1186,11 @@ class TmuxSessionWarmOpenTest {
         // Issue #666: exit code the `tmux has-session` cold-restore preflight
         // sees. 0 = alive (default), non-zero = gone (killed elsewhere).
         private val hasSessionExitCode: Int = 0,
+        // Issue #998: stderr the `tmux has-session` preflight sees. The real
+        // server-death signature is `no server running on <socket>`; supply it
+        // (with a non-zero exit) to drive the REAL [RealTmuxClient] reattach
+        // preflight into [TmuxServerDeadException].
+        private val hasSessionStderr: String = "",
     ) : SshSession {
         @Volatile
         var closed: Boolean = false
@@ -898,7 +1203,11 @@ class TmuxSessionWarmOpenTest {
         override suspend fun exec(command: String): ExecResult {
             execCommands.add(command)
             if (command.startsWith("tmux has-session")) {
-                return ExecResult(stdout = "", stderr = "", exitCode = hasSessionExitCode)
+                return ExecResult(
+                    stdout = "",
+                    stderr = hasSessionStderr,
+                    exitCode = hasSessionExitCode,
+                )
             }
             return ExecResult(stdout = "", stderr = "", exitCode = 0)
         }

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -552,6 +552,25 @@ JOURNEY_CLASSES=(
   # Reconnect raises the Reconnecting band); GREEN once the #981 liveness gate rides the
   # proven-alive transport through. Same deterministic agents:2222 fixture; runs on CI.
   "$FQCN_PREFIX.StableWifiNoSpuriousReconnectE2eTest"
+  # ADDED (#997, network sub-cluster after #995/#981): the BARE-NETWORK-LOSS
+  # proactive-detection + fast-reconnect-on-restore journey. The pre-#997 detector
+  # returned null for any non-validated snapshot (TerminalNetworkObserver.kt:328)
+  # AND for a same-identity restore (:333), so a clean drop (onLost / airplane
+  # mode) produced NO TerminalNetworkChange at all — the only thing that noticed
+  # was the ~90s keepalive ride-through or sshj EOF, both reactive and slow,
+  # leaving the UI on a live-but-dead session. This journey opens a real `tmux -CC`
+  # session and drives a bare LOSS then a same-identity RESTORE DETERMINISTICALLY by
+  # pushing synthetic NoValidatedNetwork → Validated snapshots through the PRODUCTION
+  # TerminalNetworkObserver detector + emit pipeline (the AVD can't enter airplane
+  # mode without killing the test ADB link — the #780 synthetic-inject model, no
+  # self-skip). HARD-asserts: the loss surfaces a NetworkLost + the VM HOLDS the
+  # lease with NO redial churn during the loss window (network_loss_hold recorded);
+  # the same-identity restore surfaces a NetworkRestored and fires a FAST
+  # network_restore_reconnect_start well inside the ~90s budget; the session settles
+  # back to Connected with a painted viewport. RED on base (loss + same-identity
+  # restore both swallowed → no NetworkLost, no fast reconnect); GREEN after #997.
+  # Same deterministic agents:2222 fixture; runs on CI.
+  "$FQCN_PREFIX.BareNetworkLossRestoreReconnectE2eTest"
   # ADDED (#970): the realistic-wifi STABILITY regression gate — the durable proof
   # for #964 (D31/D32/D33). Only the DETERMINISTIC method is run by FQCN here; it
   # reproduces the #964 budget mismatch on the plain deterministic agents:2222

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -133,6 +133,15 @@ JOURNEY_CLASSES=(
   # self-skip on CI.
   "$FQCN_PREFIX.BackThenOpenSecondSessionReusesWarmLeaseE2eTest"
   "$FQCN_PREFIX.ColdRestoreGoneSessionNoResurrectE2eTest"
+  # Issue #998: a remote tmux SERVER death (host reboot / OOM / `kill-server`)
+  # must NOT be silently resurrected via `new-session -A` into a blank
+  # "Connected" session. This journey attaches, `tmux kill-server`s the whole
+  # server (every session vanishes), lets the EOF drive the auto-reconnect, and
+  # asserts the reattach drops to the host list — NOT a resurrected empty
+  # session — and the server stays DEAD (no `new-session -A` resurrection). It
+  # runs on the deterministic agents:2222 fixture (no toxiproxy) and does NOT
+  # self-skip on CI, so the server-death class regression cannot silently return.
+  "$FQCN_PREFIX.ServerDeathReconnectNoResurrectE2eTest"
   "$FQCN_PREFIX.ReconnectRepaintE2eTest"
   # Issue #754 (slice 1c-iv-c): this class is the per-PR-CI deterministic regression
   # catcher for the within-grace "Attaching…" reconnect bug. It now (a) forbids the

--- a/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxClient.kt
+++ b/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxClient.kt
@@ -438,6 +438,51 @@ public class TmuxSessionNotFoundException(
     message: String = "tmux session '$sessionName' no longer exists",
 ) : RuntimeException(message)
 
+/**
+ * Issue #998: thrown by [TmuxClient.connect] when a reattach to an
+ * expected-existing session finds that the remote tmux *server* itself is
+ * gone — the host rebooted, OOM-killed tmux, or someone ran `kill-server`.
+ * The `tmux has-session` / `list-sessions` preflight reports
+ * `no server running on <socket>` (exit ≠ 0) in this case.
+ *
+ * This is distinct from [TmuxSessionNotFoundException] (one session ended but
+ * the server is still up): a dead server means EVERY session vanished. It must
+ * NOT be resurrected via `new-session -A`, which on a dead server would boot a
+ * brand-new empty server+session and silently strand the user in a blank
+ * "Connected" shell with their work gone. Callers catch this to surface
+ * "the tmux server restarted — all sessions ended" and drop the user to the
+ * host/session list instead of the silent resurrection.
+ */
+public class TmuxServerDeadException(
+    message: String = "tmux server is no longer running",
+) : RuntimeException(message)
+
+/**
+ * Issue #998: the stderr signature tmux prints to both `has-session` and
+ * `list-sessions` when the control socket has no server behind it (the host
+ * rebooted / OOM / `kill-server`). Matched case-insensitively so a future tmux
+ * wording tweak around the same phrase still classifies as server-death.
+ */
+internal const val TMUX_NO_SERVER_RUNNING_SIGNATURE: String = "no server running"
+
+/**
+ * Issue #998: returns true when [stderr] carries the tmux "server is gone"
+ * signature. Centralised so the reattach preflight, the reader-loop classifier,
+ * and the host session-list gateway all agree on what "server-death" means.
+ */
+internal fun isTmuxServerDeadStderr(stderr: String?): Boolean =
+    stderr?.contains(TMUX_NO_SERVER_RUNNING_SIGNATURE, ignoreCase = true) == true
+
+/**
+ * Issue #998: true when a `%exit` control event's reason announces the SERVER
+ * shutting down (`%exit server exited`), as opposed to a plain client `%exit`.
+ * tmux emits the bare `%exit` for an ordinary client detach and
+ * `%exit server exited` when the server itself is going away. We only treat the
+ * latter as server-death.
+ */
+internal fun isTmuxServerExitReason(reason: String?): Boolean =
+    reason?.contains("server exited", ignoreCase = true) == true
+
 public data class TmuxOutputBacklogOverflow(
     val paneId: String,
     val droppedEvents: Int,
@@ -459,6 +504,11 @@ public enum class TmuxDisconnectReason(public val logValue: String) {
     ReaderEof("reader_eof"),
     ReaderException("reader_exception"),
     CommandTimeout("command_timeout"),
+    // Issue #998: the remote tmux SERVER announced shutdown in-band
+    // (`%exit server exited`) before the channel EOFed — host reboot / OOM /
+    // `kill-server`. The reconnect path treats this as server-death (drop to
+    // the list) rather than a transport blip (silent `new-session -A`).
+    ServerExited("server_exited"),
     Unknown("unknown"),
 }
 
@@ -690,6 +740,16 @@ internal class RealTmuxClient(
     // runs a `tmux has-session` preflight and throws [TmuxSessionNotFoundException]
     // for a session killed elsewhere, so a gone session is never resurrected.
     private val createIfMissing: Boolean = true,
+    // Issue #998: this connect is a *reattach to an expected-existing* session
+    // (a reconnect / lifecycle-reattach / network-reconnect), so before issuing
+    // the `new-session -A` spawn we probe whether the tmux SERVER is still
+    // running. If it is dead (`no server running on <socket>`), `new-session -A`
+    // would boot a brand-new empty server and silently resurrect a blank
+    // session — data-loss-looking. We throw [TmuxServerDeadException] instead so
+    // the caller drops to the host/session list. The default `false` keeps the
+    // explicit user "new session" intent (and every test that never preflights)
+    // unchanged: a brand-new session legitimately wants a fresh server.
+    private val probeServerLiveness: Boolean = false,
     private val commandTimeoutMs: Long = DEFAULT_COMMAND_TIMEOUT_MS,
     // Issue #676 / #576 (P4): seam for the per-command response timeout. When
     // left null, production wires the real idle-deadline gate
@@ -790,6 +850,16 @@ internal class RealTmuxClient(
     @Volatile
     private var readerExitIntent: ReaderExitIntent = ReaderExitIntent.Unknown
 
+    // Issue #998: latched when the reader parses a `%exit server exited` (the
+    // tmux SERVER announcing shutdown) before the channel EOFs. The reader-exit
+    // classifier reads this so a server-death drop is reported as
+    // [ReaderDisconnectCause.ServerExited] — categorically distinct from an
+    // ordinary [ReaderDisconnectCause.ReadEof] transport blip. An ordinary
+    // `%exit` with no "server exited" reason (e.g. a plain client exit) does NOT
+    // set this.
+    @Volatile
+    private var serverExitedInBand: Boolean = false
+
     @Volatile
     private var readerExitCommandKind: String? = null
 
@@ -825,7 +895,14 @@ internal class RealTmuxClient(
         // resurrecting it via the `new-session -A` spawn below. We run this on
         // a separate `exec` channel (not the control shell) so the absence
         // check never touches the control-mode wire and never spawns tmux.
-        if (!createIfMissing) {
+        // Issue #666 (attach-only cold-restore) + Issue #998 (reattach
+        // server-death). Run the `has-session` preflight whenever we are
+        // reattaching to a session we EXPECT to already exist — either an
+        // attach-only cold restore (`!createIfMissing`) or a reconnect/lifecycle
+        // reattach (`probeServerLiveness`). We do NOT run it for the explicit
+        // user "new session" intent (`createIfMissing && !probeServerLiveness`),
+        // which legitimately wants a fresh server if none is running.
+        if (!createIfMissing || probeServerLiveness) {
             val probe = try {
                 withContext(Dispatchers.IO) {
                     session.exec("tmux has-session -t '${escapeSingleQuoted(resolvedSessionName)}'")
@@ -837,11 +914,37 @@ internal class RealTmuxClient(
                 )
             }
             if (probe.exitCode != 0) {
-                Log.i(
-                    ISSUE_105_DIAG_TAG,
-                    "tmux-has-session-gone session=$resolvedSessionName exit=${probe.exitCode}",
-                )
-                throw TmuxSessionNotFoundException(resolvedSessionName)
+                // Issue #998: a dead SERVER (`no server running on <socket>`) is
+                // categorically different from one gone SESSION (`can't find
+                // session`). On a dead server EVERY session vanished, so a
+                // `new-session -A` reattach would silently boot a fresh empty
+                // server — the resurrection bug. Surface it as server-death so
+                // the caller drops to the list and never recreates. We classify
+                // server-death FIRST because it dominates: even on the
+                // attach-only restore path a dead server is server-death, not a
+                // single-session-ended.
+                if (isTmuxServerDeadStderr(probe.stderr)) {
+                    Log.i(
+                        ISSUE_105_DIAG_TAG,
+                        "tmux-server-dead session=$resolvedSessionName exit=${probe.exitCode} " +
+                            "stderr=${probe.stderr.trim()}",
+                    )
+                    throw TmuxServerDeadException()
+                }
+                // Server alive but the target session is gone. On the explicit
+                // reattach path (`createIfMissing && probeServerLiveness`) a
+                // single missing session is the #666 not-the-#998 case: the
+                // server is up, so `new-session -A` recreating that one session
+                // is the correct reconnect behaviour — fall through and attach.
+                // Only the attach-only cold-restore path (`!createIfMissing`)
+                // must refuse to recreate a gone session.
+                if (!createIfMissing) {
+                    Log.i(
+                        ISSUE_105_DIAG_TAG,
+                        "tmux-has-session-gone session=$resolvedSessionName exit=${probe.exitCode}",
+                    )
+                    throw TmuxSessionNotFoundException(resolvedSessionName)
+                }
             }
         }
         // Open the SSH shell and launch the reader. We do not synchronously
@@ -1729,6 +1832,22 @@ internal class RealTmuxClient(
                             inflight = null
                         }
                     }
+                    is ControlEvent.Exit -> {
+                        // Issue #998: the tmux server is shutting down. tmux
+                        // emits `%exit server exited` when the SERVER itself dies
+                        // (host reboot / OOM / `kill-server`) — distinct from a
+                        // plain `%exit` (this client detaching). Latch the
+                        // server-death case so the reader-exit classifier reports
+                        // it as ServerExited and the reconnect path drops to the
+                        // list instead of resurrecting via `new-session -A`.
+                        if (isTmuxServerExitReason(event.reason)) {
+                            serverExitedInBand = true
+                            Log.i(
+                                ISSUE_105_DIAG_TAG,
+                                "tmux-exit-server-died session=$sessionName reason=${event.reason}",
+                            )
+                        }
+                    }
                     else -> Unit
                 }
                 // Always forward non-output events to the bus so external
@@ -1893,6 +2012,12 @@ internal class RealTmuxClient(
             readerExitIntent == ReaderExitIntent.CommandTimeout -> ReaderDisconnectCause.CommandTimeout
             readerExitIntent == ReaderExitIntent.DetachOrReplace -> ReaderDisconnectCause.DetachOrReplace
             closed && readerExitIntent == ReaderExitIntent.LocalClose -> ReaderDisconnectCause.LocalClose
+            // Issue #998: the server announced shutdown in-band before the EOF.
+            // This dominates the generic ReadEof/ReadFailure classification —
+            // it's a confirmed server-death, not an ordinary transport blip —
+            // but stays below our own intentional teardowns (close / detach /
+            // command-timeout) above so a clean local close is never mislabelled.
+            serverExitedInBand -> ReaderDisconnectCause.ServerExited
             source == "read_failure" -> ReaderDisconnectCause.ReadFailure
             source == "eof" -> ReaderDisconnectCause.ReadEof
             closed -> ReaderDisconnectCause.LocalClose
@@ -1920,6 +2045,7 @@ internal class RealTmuxClient(
             ReaderDisconnectCause.LocalClose -> TmuxDisconnectReason.ExplicitClose
             ReaderDisconnectCause.DetachOrReplace -> TmuxDisconnectReason.ExplicitDetach
             ReaderDisconnectCause.CommandTimeout -> TmuxDisconnectReason.CommandTimeout
+            ReaderDisconnectCause.ServerExited -> TmuxDisconnectReason.ServerExited
             ReaderDisconnectCause.ReadEof -> TmuxDisconnectReason.ReaderEof
             ReaderDisconnectCause.ReadFailure -> TmuxDisconnectReason.ReaderException
             ReaderDisconnectCause.Unknown -> TmuxDisconnectReason.Unknown
@@ -1940,6 +2066,10 @@ internal class RealTmuxClient(
             TmuxDisconnectReason.ExplicitClose -> 3
             TmuxDisconnectReason.ExplicitDetach -> 4
             TmuxDisconnectReason.CommandTimeout -> 5
+            // Issue #998: a confirmed in-band server-death is the most
+            // authoritative drop cause — it must not be downgraded to a generic
+            // ReaderEof if the EOF event lands a moment later.
+            TmuxDisconnectReason.ServerExited -> 6
         }
 
     private fun commonDiagnosticFields(): Map<String, Any?> =
@@ -2096,6 +2226,11 @@ internal class RealTmuxClient(
         LocalClose("local_close"),
         DetachOrReplace("detach_or_replace"),
         CommandTimeout("command_timeout"),
+        // Issue #998: the in-band `%exit server exited` arrived before the EOF —
+        // the tmux SERVER announced it is shutting down (host reboot / kill).
+        // This is server-death, NOT an ordinary transport blip, so a reattach
+        // must drop to the list instead of resurrecting via `new-session -A`.
+        ServerExited("server_exited"),
         ReadEof("read_eof"),
         ReadFailure("read_failure"),
         Unknown("unknown"),

--- a/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxClientFactory.kt
+++ b/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxClientFactory.kt
@@ -64,12 +64,20 @@ public class TmuxClientFactory(
         sessionName: String = DEFAULT_SESSION_NAME,
         startDirectory: String? = null,
         createIfMissing: Boolean = true,
+        // Issue #998: when this is a reattach to an expected-existing session (a
+        // reconnect / lifecycle / network-reconnect), pass `true` so
+        // [TmuxClient.connect] probes whether the tmux SERVER is still alive and
+        // throws [TmuxServerDeadException] for `no server running` instead of
+        // silently resurrecting an empty server via `new-session -A`. The
+        // default `false` preserves the explicit user "new session" intent.
+        probeServerLiveness: Boolean = false,
     ): TmuxClient = RealTmuxClient(
         session = session,
         scope = scope,
         sessionName = sessionName,
         startDirectory = startDirectory,
         createIfMissing = createIfMissing,
+        probeServerLiveness = probeServerLiveness,
     )
 
     private companion object {

--- a/shared/core-tmux/src/test/java/com/pocketshell/core/tmux/TmuxClientTest.kt
+++ b/shared/core-tmux/src/test/java/com/pocketshell/core/tmux/TmuxClientTest.kt
@@ -264,6 +264,247 @@ class TmuxClientTest {
         }
     }
 
+    // ---- Issue #998: server-death (vs session-gone vs transport-blip) ----
+
+    @Test
+    fun `reattach preflight to a DEAD SERVER throws TmuxServerDeadException, never recreates`() = runBlocking {
+        // The reconnect/reattach path sets probeServerLiveness=true. tmux
+        // `has-session` against a dead server exits non-zero with
+        // `no server running on <socket>`. That must surface as server-death —
+        // NOT as a generic connect, and NOT via the silent `new-session -A`
+        // resurrection that would boot a brand-new empty server.
+        val shell = FakeShell()
+        val session = FakeSession(
+            shell,
+            execHandler = {
+                ExecResult(
+                    stdout = "",
+                    stderr = "no server running on /tmp/tmux-1000/default",
+                    exitCode = 1,
+                )
+            },
+        )
+        val client = RealTmuxClient(
+            session,
+            scope,
+            sessionName = "work",
+            createIfMissing = true,
+            probeServerLiveness = true,
+        )
+        try {
+            val thrown = runCatching { client.connect() }.exceptionOrNull()
+            assertTrue(
+                "expected TmuxServerDeadException, got $thrown",
+                thrown is TmuxServerDeadException,
+            )
+            // It is NOT misclassified as the single-session-gone case.
+            assertFalse(
+                "server-death must NOT be a TmuxSessionNotFoundException",
+                thrown is TmuxSessionNotFoundException,
+            )
+            // The preflight ran the has-session probe...
+            assertEquals(
+                listOf("tmux has-session -t 'work'"),
+                session.execCommands.toList(),
+            )
+            // ...and NEVER wrote a `new-session` line, so a dead server cannot be
+            // silently resurrected into a blank session.
+            assertTrue(
+                "no creating command should be written, got `${shell.stdinAsString()}`",
+                shell.stdinBytes().isEmpty(),
+            )
+        } finally {
+            client.close()
+        }
+    }
+
+    @Test
+    fun `reattach preflight to an ALIVE server with a gone session still reattaches (recreates that one session)`() = runBlocking {
+        // Server alive (`can't find session: work`, exit 1) on the reattach path
+        // is the #666 case, NOT #998: the server is up, so `new-session -A`
+        // recreating that one session is the correct reconnect behaviour. We must
+        // NOT throw server-death here, and we MUST attach.
+        val shell = FakeShell()
+        val session = FakeSession(
+            shell,
+            execHandler = {
+                ExecResult(stdout = "", stderr = "can't find session: work", exitCode = 1)
+            },
+        )
+        val client = RealTmuxClient(
+            session,
+            scope,
+            sessionName = "work",
+            createIfMissing = true,
+            probeServerLiveness = true,
+        )
+        try {
+            client.connect()
+            withTimeout(2_000) {
+                while (shell.stdinBytes().isEmpty()) { yield(); delay(10) }
+            }
+            assertEquals(
+                listOf("tmux has-session -t 'work'"),
+                session.execCommands.toList(),
+            )
+            // A live server still attaches with the normal control-mode spawn.
+            assertEquals(
+                "tmux -CC new-session -A -s 'work'\n",
+                shell.stdinAsString(),
+            )
+        } finally {
+            client.close()
+        }
+    }
+
+    @Test
+    fun `reattach preflight to a LIVE session reattaches normally (transport blip)`() = runBlocking {
+        // The ordinary transport-blip reconnect: server alive, session alive
+        // (`has-session` exits 0). Must reattach with `new-session -A`, no
+        // server-death.
+        val shell = FakeShell()
+        val session = FakeSession(
+            shell,
+            execHandler = { ExecResult(stdout = "", stderr = "", exitCode = 0) },
+        )
+        val client = RealTmuxClient(
+            session,
+            scope,
+            sessionName = "work",
+            createIfMissing = true,
+            probeServerLiveness = true,
+        )
+        try {
+            client.connect()
+            withTimeout(2_000) {
+                while (shell.stdinBytes().isEmpty()) { yield(); delay(10) }
+            }
+            assertEquals(
+                listOf("tmux has-session -t 'work'"),
+                session.execCommands.toList(),
+            )
+            assertEquals(
+                "tmux -CC new-session -A -s 'work'\n",
+                shell.stdinAsString(),
+            )
+        } finally {
+            client.close()
+        }
+    }
+
+    @Test
+    fun `attach-only cold restore to a DEAD SERVER reports server-death, not session-gone`() = runBlocking {
+        // Even the #666 attach-only cold-restore path must distinguish a dead
+        // SERVER (every session gone) from one gone SESSION: server-death
+        // dominates so the caller can surface the right copy and reconcile the
+        // whole tree, not just the one session.
+        val shell = FakeShell()
+        val session = FakeSession(
+            shell,
+            execHandler = {
+                ExecResult(
+                    stdout = "",
+                    stderr = "no server running on /tmp/tmux-1000/default",
+                    exitCode = 1,
+                )
+            },
+        )
+        val client = RealTmuxClient(session, scope, sessionName = "work", createIfMissing = false)
+        try {
+            val thrown = runCatching { client.connect() }.exceptionOrNull()
+            assertTrue(
+                "expected TmuxServerDeadException on a dead server, got $thrown",
+                thrown is TmuxServerDeadException,
+            )
+            assertTrue(
+                "no creating command on a dead server, got `${shell.stdinAsString()}`",
+                shell.stdinBytes().isEmpty(),
+            )
+        } finally {
+            client.close()
+        }
+    }
+
+    @Test
+    fun `default explicit-new connect never probes server liveness (fresh server allowed)`() = runBlocking {
+        // The explicit user "new session" intent (createIfMissing=true,
+        // probeServerLiveness=false) must NOT preflight at all — a brand-new
+        // session legitimately wants a fresh server if none is running. This is
+        // the boundary that keeps #998's probe off the create path.
+        val shell = FakeShell()
+        val session = FakeSession(shell) // exec not stubbed -> must never be called
+        val client = RealTmuxClient(session, scope, sessionName = "work")
+        try {
+            client.connect()
+            withTimeout(2_000) {
+                while (shell.stdinBytes().isEmpty()) { yield(); delay(10) }
+            }
+            assertTrue("explicit-new must not preflight", session.execCommands.isEmpty())
+            assertEquals(
+                "tmux -CC new-session -A -s 'work'\n",
+                shell.stdinAsString(),
+            )
+        } finally {
+            client.close()
+        }
+    }
+
+    @Test
+    fun `in-band exit server exited classifies the drop as ServerExited, not ReaderEof`() = runBlocking {
+        // A mid-session server death: tmux emits `%exit server exited` before the
+        // control channel EOFs. The reader-exit classifier must report this as
+        // ServerExited (server-death), categorically distinct from the ordinary
+        // ReaderEof a transport blip produces. This is the in-band discriminator
+        // the reconnect path then preflight-confirms.
+        val shell = FakeShell()
+        val session = FakeSession(shell)
+        val client = RealTmuxClient(session, scope)
+        try {
+            client.connect()
+            withTimeout(2_000) {
+                while (shell.stdinBytes().isEmpty()) { yield(); delay(10) }
+            }
+            // The server announces shutdown, then the channel closes.
+            shell.feed("%exit server exited\n")
+            shell.closeStdoutPipe()
+            withTimeout(ASYNC_AWAIT_TIMEOUT_MS) {
+                while (!client.disconnected.value) { yield(); delay(10) }
+            }
+            assertEquals(
+                TmuxDisconnectReason.ServerExited,
+                client.disconnectEvent.value?.reason,
+            )
+        } finally {
+            client.close()
+        }
+    }
+
+    @Test
+    fun `plain client exit without server-exited reason stays an ordinary EOF`() = runBlocking {
+        // A bare `%exit` (this client detaching, server still up) must NOT be
+        // mistaken for server-death — only `%exit server exited` is server-death.
+        val shell = FakeShell()
+        val session = FakeSession(shell)
+        val client = RealTmuxClient(session, scope)
+        try {
+            client.connect()
+            withTimeout(2_000) {
+                while (shell.stdinBytes().isEmpty()) { yield(); delay(10) }
+            }
+            shell.feed("%exit\n")
+            shell.closeStdoutPipe()
+            withTimeout(ASYNC_AWAIT_TIMEOUT_MS) {
+                while (!client.disconnected.value) { yield(); delay(10) }
+            }
+            assertEquals(
+                TmuxDisconnectReason.ReaderEof,
+                client.disconnectEvent.value?.reason,
+            )
+        } finally {
+            client.close()
+        }
+    }
+
     @Test
     fun `events flow surfaces structured notifications from tmux stdout`() = runBlocking {
         val shell = FakeShell()


### PR DESCRIPTION
The final two approved fixes of the connection-stability wave (disjoint regions: connectivity/network-reducer vs core-tmux/reconnect-ladder). Full local `:app:testDebugUnitTest` + `:shared:core-tmux:test` + assembleDebug green.

- **#997** — proactive bare-network-LOSS detector: a bare `onLost`/airplane loss (previously swallowed) now holds the lease + shows the calm Reconnecting band (no churn), and on restore drives a fast reconnect — **~40ms vs the old ~90s keepalive ride-through**. Coexists with #981's proven-alive ride-through (a real loss correctly bypasses it). Closes #997.
- **#998** — detect remote tmux SERVER death distinctly from a transport blip and drop to the session list, instead of silently resurrecting a blank `new-session -A` 'Connected' session with the user's work gone. Closes #998.

Each reviewer-driven red→green incl. on-device journeys; the #998 regression test was hardened against a virtual-clock/real-IO flake (6 full-suite reruns clean). Part of #928 bulletproof — this completes the implementable connection/black-screen work; remaining: Cluster A (#982-985, maintainer rewrite-vs-patch call) + #977.