### PR TITLE
connection: rework keepalive+probe to stop stable-wifi drops (#1006)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/RealisticWifiStabilityNoSpuriousReconnectE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/RealisticWifiStabilityNoSpuriousReconnectE2eTest.kt
@@ -193,15 +193,18 @@ class RealisticWifiStabilityNoSpuriousReconnectE2eTest : NetworkFaultProofBase()
         diagnostics!!.clear()
         val attemptsAfterAttach = TMUX_CONNECT_ATTEMPTS.get()
 
-        // ---- THE #964 SLOW-BUT-LIVE WINDOW ----
+        // ---- THE #982/#984 SLOW-BUT-LIVE WINDOW (spans >2 probe budgets) ----
         // Arm the slow `-CC` channel: the probe's refresh-client ping reports DEAD
         // (a momentarily congested control channel), while the agents:2222 SSH
         // TRANSPORT stays genuinely live, so the always-on keepalive keeps proving
-        // the link alive. Hold it just PAST one shortened probe budget so the probe
-        // REACHES its failure threshold (base redials here), then CLEAR it so the
-        // next probe answers — modelling a slow link that un-congests (the #964
-        // case), NOT a permanently wedged channel (#822, which the #964 fix
-        // correctly still escalates after its bounded deferral).
+        // the link alive the WHOLE time (ride-through window 60s ≫ the 12s hold).
+        // Hold it across MORE THAN TWO shortened probe budgets — the gap the deleted
+        // maxKeepAliveDeferrals=1 time ceiling could not cross without escalating
+        // (#982/#984). The new contract DEFERS UNCONDITIONALLY while the keepalive
+        // proves alive → ZERO reconnect. Then CLEAR it so the next probe answers —
+        // a slow link that un-congests, NOT a permanently wedged channel (#822,
+        // which the new contract still escalates via the keepalive death signal or
+        // the 180s absolute backstop).
         val stallStart = SystemClock.elapsedRealtime()
         currentViewModel().forceLivenessProbeDeadForTest = true
         recordTiming("stable_slow_cc_armed_at_ms", stallStart - attachStart)
@@ -571,29 +574,28 @@ class RealisticWifiStabilityNoSpuriousReconnectE2eTest : NetworkFaultProofBase()
         // Shorten the keepalive INTERVAL so a real keepalive reply lands every
         // couple of seconds (keeping the transport's inbound-activity timestamp
         // fresh), but keep countMax HIGH so the derived ride-through WINDOW
-        // (intervalMs × countMax = 2s × 15 = 30s, the window the #964 deferral
+        // (intervalMs × countMax = 2s × 30 = 60s, the window the #982/#984 deferral
         // guard `isTransportProvenAliveWithinKeepAliveWindow` checks) stays
-        // COMFORTABLY LONGER than the slow-CC hold (10s). This guarantees the
+        // COMFORTABLY LONGER than the slow-CC hold (12s). This guarantees the
         // keepalive is continuously "proving the transport alive" for the whole
         // slow window even if a couple of replies are momentarily delayed — so the
-        // #964 deferral guard always has a fresh live signal to defer to. (A short
-        // 6s window would expire mid-hold and the probe would stop deferring — a
-        // false RED.)
+        // #982/#984 deferral guard always has a fresh live signal to defer to. The
+        // window MUST exceed SLOW_CC_HOLD_MS or it would expire mid-hold and the
+        // probe would stop deferring — a false RED.
         const val KEEPALIVE_INTERVAL_MS: Long = 2_000L
-        const val KEEPALIVE_COUNT_MAX: Int = 15
+        const val KEEPALIVE_COUNT_MAX: Int = 30
 
-        // Hold the slow `-CC` window so it brackets EXACTLY ONE shortened probe
-        // threshold hit:
-        //   - PAST one budget (~4.5s) so the threshold is reached — BASE redials
-        //     here (RED), and the #964 fix takes its single bounded DEFERRAL; but
-        //   - UNDER two budgets (~9s) so a SECOND threshold hit never lands inside
-        //     the dead window — which would make the #964 fix correctly ESCALATE
-        //     the #822 wedge path (a genuinely-stuck `-CC` channel), a FALSE red for
-        //     THIS slow-but-live scenario.
-        // 6.5s sits squarely in the (4.5s, 9s) window with ~2s margin on each side,
-        // robust against AVD scheduling jitter. After clearing, the next real probe
-        // answers (the channel was never down) and the deferral run resets.
-        const val SLOW_CC_HOLD_MS: Long = 6_500L
+        // #982/#984: hold the slow `-CC` window so it spans MORE THAN TWO shortened
+        // probe budgets — the structural gap the deleted maxKeepAliveDeferrals=1
+        // time ceiling could not cross without escalating at ~96s (audit #984 §5,
+        // the #970 gate's old SLOW_CC_HOLD_MS=6.5s sat inside ONE budget and so
+        // never reached the escalation branch). With the keepalive PROVEN ALIVE the
+        // whole time (ride-through window 60s ≫ 12s), the new contract DEFERS
+        // UNCONDITIONALLY across every budget — ZERO reconnect.
+        //   - PROBE_RAW_BUDGET_MS = 3 × 1.5s = 4.5s, so 12s spans ~2.7 budgets.
+        // RED at the old time-ceiling (it escalates after ~2 budgets ≈ 9s, inside
+        // the 12s hold → a reconnect fires); GREEN with the time-ceiling removed.
+        const val SLOW_CC_HOLD_MS: Long = 12_000L
         const val POST_RECOVER_WATCH_MS: Long = 4_000L
 
         // Realistic-link (toxiproxy) variant knobs.

--- a/app/src/androidTest/java/com/pocketshell/app/proof/SilentDropSyntheticSeamJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/SilentDropSyntheticSeamJourneyE2eTest.kt
@@ -115,10 +115,6 @@ class SilentDropSyntheticSeamJourneyE2eTest {
             intervalMs = PROBE_INTERVAL_MS,
             perProbeTimeoutMs = PROBE_TIMEOUT_MS,
             failureThreshold = PROBE_FAILURE_THRESHOLD,
-            // #964: keep the keepalive-deferral bound generous on the shortened
-            // window so the slow-but-live ride-through is observable AND the wedge
-            // escalation is reachable within the test windows below.
-            maxKeepAliveDeferrals = KEEPALIVE_MAX_DEFERRALS,
         )
     }
 
@@ -275,22 +271,28 @@ class SilentDropSyntheticSeamJourneyE2eTest {
                 !indicatorDuringSlowLive,
             )
 
-            // ---- 2) WEDGED `-CC` + healthy keepalive SUSTAINED (#822) → recover ----
-            // Now the `-CC` channel stays WEDGED (dead) with the keepalive STILL
-            // proving the transport alive the whole time. A blanket keepalive veto
-            // would leave this wedged forever; the bounded deferral must escalate.
+            // ---- 2) WEDGED `-CC` + keepalive FLIPS DEAD (#822/#982/#984) → recover --
+            // The dominant real #822: a half-open wifi drop wedges the `-CC` channel
+            // AND kills the transport keepalive together. Under the #982/#984 contract
+            // the probe defers to the keepalive's OWN death signal — so the indicator
+            // surfaces the instant the keepalive flips FALSE (no fixed time ceiling).
+            // (The rare "transport-keepalive-healthy-FOREVER but `-CC`-wedged" sub-case
+            // is bounded separately by the 180s absoluteWedgeBudgetMs backstop, proven
+            // deterministically in the pure virtual-clock LivenessProbeTest — a 180s
+            // emulator hold would be wasteful and flaky here.)
             val wedgeStart = SystemClock.elapsedRealtime()
-            vm.forceTransportProvenAliveForTest = true
             vm.forceLivenessProbeDeadForTest = true
+            vm.forceTransportProvenAliveForTest = false
             val detectedWedge = waitForConnectionLostIndicator(DROP_DETECT_WINDOW_MS)
             recordTiming(
-                "wedged_cc_healthy_keepalive_detected_ms",
+                "wedged_cc_keepalive_dead_detected_ms",
                 if (detectedWedge) SystemClock.elapsedRealtime() - wedgeStart else -1L,
             )
             assertTrue(
-                "Expected the indicator to surface for a SUSTAINED wedged `-CC` channel " +
-                    "even though the keepalive keeps proving the transport alive (#822 " +
-                    "must NOT be suppressed by the #964 deferral). " +
+                "Expected the indicator to surface for a wedged `-CC` channel once the " +
+                    "keepalive ALSO gives up (transportProvenAliveRecently=false — the " +
+                    "dominant real #822). The probe defers to the keepalive death " +
+                    "authority and escalates immediately when it flips false. " +
                     "status=${currentConnectionStatus()}",
                 detectedWedge,
             )
@@ -609,16 +611,11 @@ class SilentDropSyntheticSeamJourneyE2eTest {
         const val PROBE_TIMEOUT_MS: Long = 2_000L
         const val PROBE_FAILURE_THRESHOLD: Int = 1
 
-        // #964: keepalive-deferral bound on the shortened window. With threshold=1
-        // each "failure run" is one probe (~1s), so 2 deferrals ≈ 2 failed probes
-        // ridden through before the wedge escalates on the 3rd — comfortably within
-        // SLOW_LIVE_BRIEF_WINDOW_MS for the ride-through and DROP_DETECT_WINDOW_MS
-        // for the wedge escalation.
-        const val KEEPALIVE_MAX_DEFERRALS: Int = 2
-
-        // #964 phase-1: how long the `-CC` stays dead during the slow-but-live blip
-        // before it recovers. ~one probe interval — under the deferral bound — so
-        // the probe rides it through without escalating.
+        // #982/#984 phase-1: how long the `-CC` stays dead during the slow-but-live
+        // blip before it recovers. Under the new contract the probe DEFERS to the
+        // keepalive UNCONDITIONALLY while it proves the transport alive (no deferral
+        // count), so the only requirement is the `-CC` recovers before the 180s
+        // absolute-wedge backstop — trivially satisfied by this brief window.
         const val SLOW_LIVE_BRIEF_WINDOW_MS: Long = 1_500L
 
         // Detection budget on the shortened window (interval + threshold*timeout =

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -1018,7 +1018,6 @@ public class TmuxSessionViewModel @Inject constructor(
             intervalMs = LivenessProbeTestOverride.intervalMs(),
             perProbeTimeoutMs = LivenessProbeTestOverride.perProbeTimeoutMs(),
             failureThreshold = LivenessProbeTestOverride.failureThreshold(),
-            maxKeepAliveDeferrals = LivenessProbeTestOverride.maxKeepAliveDeferrals(),
             log = { line -> Log.i(LIVENESS_PROBE_TAG, line) },
         )
         livenessProbe = probe
@@ -16923,9 +16922,6 @@ internal object LivenessProbeTestOverride {
     @Volatile
     private var failureThresholdOverride: Int? = null
 
-    @Volatile
-    private var maxKeepAliveDeferralsOverride: Int? = null
-
     /**
      * Whether a freshly-constructed VM auto-starts its probe loop. Production +
      * the connected emulator proof keep this TRUE (the loop runs on the real Main
@@ -16945,7 +16941,6 @@ internal object LivenessProbeTestOverride {
         intervalMs: Long?,
         perProbeTimeoutMs: Long?,
         failureThreshold: Int?,
-        maxKeepAliveDeferrals: Int? = null,
     ) {
         require(intervalMs == null || intervalMs > 0) { "intervalMs must be > 0" }
         require(perProbeTimeoutMs == null || perProbeTimeoutMs > 0) {
@@ -16954,17 +16949,13 @@ internal object LivenessProbeTestOverride {
         require(failureThreshold == null || failureThreshold >= 1) {
             "failureThreshold must be >= 1"
         }
-        require(maxKeepAliveDeferrals == null || maxKeepAliveDeferrals >= 1) {
-            "maxKeepAliveDeferrals must be >= 1"
-        }
         intervalMsOverride = intervalMs
         perProbeTimeoutMsOverride = perProbeTimeoutMs
         failureThresholdOverride = failureThreshold
-        maxKeepAliveDeferralsOverride = maxKeepAliveDeferrals
     }
 
     fun clear() {
-        setForTest(null, null, null, null)
+        setForTest(null, null, null)
         autoStartEnabled = true
     }
 
@@ -16975,9 +16966,6 @@ internal object LivenessProbeTestOverride {
 
     fun failureThreshold(): Int =
         failureThresholdOverride ?: LivenessProbe.DEFAULT_FAILURE_THRESHOLD
-
-    fun maxKeepAliveDeferrals(): Int =
-        maxKeepAliveDeferralsOverride ?: LivenessProbe.DEFAULT_MAX_KEEPALIVE_DEFERRALS
 }
 
 /**

--- a/shared/core-connection/src/main/java/com/pocketshell/core/connection/LivenessProbe.kt
+++ b/shared/core-connection/src/main/java/com/pocketshell/core/connection/LivenessProbe.kt
@@ -22,7 +22,7 @@ import kotlinx.coroutines.withTimeoutOrNull
  * note (the exact #822 scenario), no command is in flight, so a wedged channel is
  * invisible — the "detection void". This probe closes that void.
  *
- * **Coordinated with the transport keepalive (#964), WITHOUT regressing #822.**
+ * **Coordinated with the transport keepalive (#982/#984), WITHOUT regressing #822.**
  * There IS now an always-on SSH transport keepalive
  * ([com.pocketshell.core.ssh.TransportKeepAlive], #945 — the safe successor to the
  * #847-removed sshj `KeepAliveRunner`). It pings the SSH TRANSPORT (a
@@ -32,19 +32,32 @@ import kotlinx.coroutines.withTimeoutOrNull
  * force-redialed a FINE link before the keepalive's ~90s could prove the transport
  * alive.
  *
- * The fix THREADS THE NEEDLE rather than a blanket keepalive veto. A successful
- * keepalive ([ProbeIo.transportProvenAliveRecently]) lets the probe DEFER its
- * redial for up to [maxKeepAliveDeferrals] back-to-back failure runs — absorbing
- * the slow-but-live `-CC` blip (#964) — BUT if the `-CC` channel keeps not
- * answering across that bound WHILE the keepalive stays healthy, that is no longer
- * transport jitter: it is a genuinely WEDGED `-CC` channel on a live transport
- * (the #822 failure mode the keepalive CANNOT see — transport fine, control
- * channel stuck). The probe then ESCALATES the drop anyway, so the wedged session
- * still recovers within a sane bound (≈ `(maxKeepAliveDeferrals + 1) × rawBudget`).
- * A blanket "keepalive alive ⇒ never redial" would re-open #822. A single
- * successful `-CC` probe resets the deferral run, so a link that un-congests never
- * escalates. The probe's raw budget still bounds detection of a `-CC` wedge
- * whenever no keepalive signal is available to defer to.
+ * The #982/#984 fix DEFERS TO THE KEEPALIVE'S OWN DEATH SIGNAL, with NO time
+ * ceiling while the keepalive proves the transport alive. On [failureThreshold]
+ * consecutive `-CC` misses the probe asks the single transport-death authority,
+ * [ProbeIo.transportProvenAliveRecently]:
+ *  - if it returns TRUE the probe DEFERS UNCONDITIONALLY — no deferral COUNT, no
+ *    time ceiling — and keeps probing. The keepalive's own ~90s ride-through
+ *    ([com.pocketshell.core.ssh.TransportKeepAlive.RIDE_THROUGH_BUDGET_MS]) is the
+ *    single coherent transport-death budget; while it says "alive" the link is
+ *    reachable and the `-CC` reply is just parked behind a slow/congested channel.
+ *    The fixed `maxKeepAliveDeferrals` time ceiling that escalated at ~96s WAS the
+ *    #982/#984 false positive on stable-but-jittery wifi (#974), and is deleted.
+ *  - if it returns FALSE the probe escalates [onProbeFailed] immediately — either a
+ *    genuine transport death (the keepalive ALSO stopped proving liveness — the
+ *    dominant real #822, where a half-open wifi drop kills both channels) OR no
+ *    keepalive signal exists (test fake / pre-attach), where the raw budget is the
+ *    bound exactly as before.
+ *
+ * A single high ABSOLUTE wedge backstop ([absoluteWedgeBudgetMs], default 180s)
+ * remains as the ONLY time ceiling — independent of the keepalive — for the rare
+ * #822 sub-case where the `-CC` channel is genuinely WEDGED but the transport
+ * keepalive stays HEALTHY FOREVER (transport fine, only the control channel stuck).
+ * If `-CC` has failed continuously for [absoluteWedgeBudgetMs] the probe escalates
+ * even though the keepalive still claims alive, so a truly-stuck control channel
+ * still recovers — just on a sane 180s bound that cannot fire on realistic wifi
+ * jitter. A blanket "keepalive alive ⇒ never redial" would re-open #822; this
+ * backstop closes that hole without the #974-causing 96s false positive.
  *
  * [LivenessProbe] closes that void. While the session is FOREGROUNDED + `Live`
  * (and only then — D21: no background work, no probe inside grace, no probe
@@ -101,14 +114,24 @@ class LivenessProbe(
     private val intervalMs: Long = DEFAULT_INTERVAL_MS,
     private val perProbeTimeoutMs: Long = DEFAULT_PER_PROBE_TIMEOUT_MS,
     private val failureThreshold: Int = DEFAULT_FAILURE_THRESHOLD,
-    private val maxKeepAliveDeferrals: Int = DEFAULT_MAX_KEEPALIVE_DEFERRALS,
+    /**
+     * Issue #982/#984 — the single high ABSOLUTE wedge backstop. The ONLY time
+     * ceiling that remains: if the `-CC` channel has failed continuously for this
+     * long the probe escalates even while [ProbeIo.transportProvenAliveRecently]
+     * still claims the transport alive (the rare "transport-keepalive-healthy-forever
+     * but `-CC`-wedged" #822 sub-case). Defaults to [DEFAULT_ABSOLUTE_WEDGE_BUDGET_MS]
+     * (180s) — comfortably past any realistic wifi jitter and ~2× the keepalive's
+     * ~90s ride-through — so it cannot reproduce the #974/#982 96s false positive but
+     * still recovers a truly-stuck control channel. A virtual-clock test shortens it.
+     */
+    private val absoluteWedgeBudgetMs: Long = DEFAULT_ABSOLUTE_WEDGE_BUDGET_MS,
     private val log: (String) -> Unit = {},
 ) {
     init {
         require(intervalMs > 0) { "intervalMs must be > 0" }
         require(perProbeTimeoutMs > 0) { "perProbeTimeoutMs must be > 0" }
         require(failureThreshold >= 1) { "failureThreshold must be >= 1" }
-        require(maxKeepAliveDeferrals >= 1) { "maxKeepAliveDeferrals must be >= 1" }
+        require(absoluteWedgeBudgetMs > 0) { "absoluteWedgeBudgetMs must be > 0" }
     }
 
     /**
@@ -152,17 +175,19 @@ class LivenessProbe(
          * ~90s) — i.e. the transport is PROVABLY still alive.
          *
          * Consulted immediately before [onProbeFailed] would fire. When it returns
-         * `true` the probe DEFERS: it does NOT declare a drop, because the
-         * keepalive is still successfully riding through and the link is fine — it
-         * is only the tmux control channel that is momentarily slow. This is the
-         * #964 fix: the probe's old ~48s budget used to force a redial BEFORE the
-         * keepalive's ~90s ride-through could prove the link alive, spuriously
-         * reconnecting a slow-but-live link. The probe now defers to the single
-         * transport-liveness authority; only when the keepalive ITSELF stops
-         * seeing activity (a genuinely dead transport, so this returns `false`)
-         * does the probe declare the drop. The keepalive's own ~90s budget detects
-         * a real transport death independently (it closes the dead transport), so
-         * deferring here can never cause an infinite hang.
+         * `true` the probe DEFERS UNCONDITIONALLY (no deferral count, no time
+         * ceiling): it does NOT declare a drop, because the keepalive is still
+         * successfully riding through and the link is fine — it is only the tmux
+         * control channel that is momentarily slow. This is the #982/#984 fix: the
+         * probe's old fixed `maxKeepAliveDeferrals` time ceiling (~96s) force-redialed
+         * a slow-but-live link on stable-but-jittery wifi (#974). The probe now
+         * defers to the single transport-liveness authority for as long as it says
+         * alive; only when the keepalive ITSELF stops seeing activity (a genuinely
+         * dead transport, so this returns `false`) does the probe declare the drop.
+         * The keepalive's own ~90s budget detects a real transport death
+         * independently (it closes the dead transport), so deferring here can never
+         * cause an infinite hang. The rare "keepalive healthy forever but `-CC`
+         * wedged" #822 sub-case is bounded separately by [absoluteWedgeBudgetMs].
          *
          * Default body returns `false` (no keepalive signal available, so the
          * probe keeps its own authority) so the existing probe fakes need not
@@ -176,25 +201,21 @@ class LivenessProbe(
     private var consecutiveFailures: Int = 0
 
     /**
-     * Issue #964 / #822 — how many times in a row the probe has reached its
-     * failure threshold AND deferred to a still-healthy transport keepalive,
-     * WITHOUT any intervening successful `-CC` probe. Reset to 0 on the next
-     * successful `-CC` probe.
+     * Issue #982/#984 — how many probe ticks the `-CC` channel has been failing
+     * CONTINUOUSLY (across deferrals), or 0 when the run is clear (the last probe
+     * answered, or the gate was closed). Tracks how long the `-CC` channel has been
+     * failing so the [absoluteWedgeBudgetMs] backstop can escalate a genuinely-wedged
+     * control channel even while the transport keepalive claims alive forever.
      *
-     * This BOUNDS the deferral so it threads the needle between the two failure
-     * modes the keepalive cannot tell apart from the transport's vantage:
-     *   - a brief `-CC` non-response that coincides with transport jitter (the
-     *     #964 slow-but-live case) clears within one or two deferrals as the link
-     *     un-congests and the `-CC` probe answers again → no redial; and
-     *   - a `-CC` channel that is genuinely WEDGED while the transport stays
-     *     perfectly healthy (the #822 case: keepalive instant, `refresh-client`
-     *     never answers) keeps failing across every deferral → after
-     *     [maxKeepAliveDeferrals] back-to-back deferrals the probe ESCALATES the
-     *     drop EVEN THOUGH the keepalive is alive, because sustained `-CC` silence
-     *     on a provably-live transport IS the wedged-channel signal and must
-     *     recover. A blanket "keepalive alive ⇒ never redial" would re-open #822.
+     * Counted in TICKS (× [intervalMs] = elapsed wedge time) rather than a
+     * [System.nanoTime] wall-clock delta DELIBERATELY: the loop's cadence is pure
+     * [delay], so a `TestScope` virtual clock advances the wedge accounting with zero
+     * wall-clock waiting — the same determinism seam the rest of the probe relies on.
+     * A wall-clock delta would not advance under `advanceTimeBy`, making the backstop
+     * untestable on the virtual clock. Reset to 0 on the next successful `-CC` probe
+     * (or a gate-closed skip), so a link that un-congests never trips it.
      */
-    private var consecutiveDeferrals: Int = 0
+    private var wedgedFailureTicks: Int = 0
 
     /**
      * Start the probe loop in [scope]. Idempotent: a second [start] while a loop
@@ -207,7 +228,7 @@ class LivenessProbe(
     fun start(scope: CoroutineScope) {
         if (job?.isActive == true) return
         consecutiveFailures = 0
-        consecutiveDeferrals = 0
+        wedgedFailureTicks = 0
         job = scope.launch {
             while (isActive) {
                 delay(intervalMs)
@@ -216,25 +237,22 @@ class LivenessProbe(
                     // the counter so a prior partial run never leaks into the
                     // next live window, and skip this tick entirely.
                     consecutiveFailures = 0
-                    consecutiveDeferrals = 0
+                    wedgedFailureTicks = 0
                     continue
                 }
                 val alive = runProbe()
                 if (alive) {
-                    if (consecutiveFailures != 0 || consecutiveDeferrals != 0) {
-                        log(
-                            "liveness-probe recovered after $consecutiveFailures failure(s) / " +
-                                "$consecutiveDeferrals deferral(s)",
-                        )
+                    if (consecutiveFailures != 0) {
+                        log("liveness-probe recovered after $consecutiveFailures failure(s)")
                     }
-                    // A successful `-CC` probe clears BOTH the failure run AND the
-                    // deferral run: the control channel is answering again, so the
-                    // slow-but-live blip is over and we are nowhere near the #822
-                    // wedge.
+                    // A successful `-CC` probe clears the failure run: the control
+                    // channel is answering again, so the slow-but-live blip is over
+                    // and the absolute-wedge clock resets.
                     consecutiveFailures = 0
-                    consecutiveDeferrals = 0
+                    wedgedFailureTicks = 0
                 } else {
                     consecutiveFailures += 1
+                    wedgedFailureTicks += 1
                     log(
                         "liveness-probe failed consecutive=$consecutiveFailures " +
                             "threshold=$failureThreshold",
@@ -249,54 +267,57 @@ class LivenessProbe(
                             // The recovery path / grace owner already governs the
                             // channel; reset and skip.
                             consecutiveFailures = 0
-                            consecutiveDeferrals = 0
-                        } else if (
-                            io.transportProvenAliveRecently() &&
-                            consecutiveDeferrals < maxKeepAliveDeferrals
-                        ) {
-                            // Issue #964 — DEFER to the transport keepalive, but only
-                            // up to [maxKeepAliveDeferrals] back-to-back times. The
-                            // `-CC` probe failed N times, but the always-on keepalive
-                            // has seen inbound TRANSPORT activity within its
-                            // ride-through window, so the LINK is provably reachable —
-                            // the `-CC` reply is just parked behind a momentarily slow
-                            // / congested channel. Forcing a redial here would be the
-                            // exact spurious reconnect on a slow-but-live link the
-                            // keepalive exists to ride through (#964). Reset the
-                            // failure run (so we re-probe next interval) but COUNT the
-                            // deferral: if the `-CC` channel keeps not answering across
-                            // [maxKeepAliveDeferrals] deferrals WHILE the keepalive
-                            // stays healthy, that is no longer transport jitter — it is
-                            // a genuinely WEDGED `-CC` channel on a live transport
-                            // (#822), and the branch below escalates it.
-                            consecutiveDeferrals += 1
-                            log(
-                                "liveness-probe DEFERRED to keepalive (transport proven alive) " +
-                                    "consecutive=$consecutiveFailures deferrals=$consecutiveDeferrals " +
-                                    "max=$maxKeepAliveDeferrals",
-                            )
-                            consecutiveFailures = 0
+                            wedgedFailureTicks = 0
                         } else {
-                            // Declare the drop. Either the keepalive ALSO stopped
-                            // proving the transport alive (a genuine transport death —
-                            // the #964 deferral correctly ends), OR the keepalive is
-                            // still healthy but the `-CC` channel has now failed across
-                            // [maxKeepAliveDeferrals] back-to-back deferrals — the
-                            // #822 wedged-`-CC`-on-a-live-transport case, which MUST
-                            // recover even though the keepalive says the transport is
-                            // fine (a blanket keepalive veto would re-open #822).
-                            val wedgedDespiteKeepAlive = io.transportProvenAliveRecently()
-                            log(
-                                "liveness-probe DECLARED DROP consecutive=$consecutiveFailures " +
-                                    "deferrals=$consecutiveDeferrals " +
-                                    "wedgedDespiteKeepAlive=$wedgedDespiteKeepAlive",
-                            )
-                            io.onProbeFailed(consecutiveFailures)
-                            // The recovery path now owns the channel; reset so the
-                            // probe does not re-fire every interval against the
-                            // already-reconnecting session.
-                            consecutiveFailures = 0
-                            consecutiveDeferrals = 0
+                            val keepAliveProvesAlive = io.transportProvenAliveRecently()
+                            // Elapsed continuous-wedge time, measured in probe ticks ×
+                            // interval (virtual-clock friendly — see wedgedFailureTicks).
+                            val wedgedForMs = wedgedFailureTicks.toLong() * intervalMs
+                            val absoluteWedgeTripped = wedgedForMs >= absoluteWedgeBudgetMs
+                            if (keepAliveProvesAlive && !absoluteWedgeTripped) {
+                                // Issue #982/#984 — DEFER to the transport keepalive
+                                // UNCONDITIONALLY (no deferral count, no time ceiling).
+                                // The `-CC` probe failed N times, but the always-on
+                                // keepalive has seen inbound TRANSPORT activity within
+                                // its ride-through window, so the LINK is provably
+                                // reachable — the `-CC` reply is just parked behind a
+                                // momentarily slow / congested channel. Forcing a redial
+                                // here is the exact stable-wifi spurious reconnect the
+                                // keepalive exists to ride through (#974). Reset the
+                                // failure RUN (re-probe next interval) but KEEP
+                                // wedgedFailureTicks so the absolute-wedge backstop can
+                                // still escalate a genuinely-stuck channel at
+                                // absoluteWedgeBudgetMs.
+                                log(
+                                    "liveness-probe DEFERRED to keepalive (transport proven " +
+                                        "alive) consecutive=$consecutiveFailures " +
+                                        "wedgedForMs=$wedgedForMs " +
+                                        "absoluteWedgeMs=$absoluteWedgeBudgetMs",
+                                )
+                                consecutiveFailures = 0
+                            } else {
+                                // Declare the drop. Either the keepalive stopped proving
+                                // the transport alive (a genuine transport death OR the
+                                // dominant #822 where a half-open drop killed BOTH
+                                // channels — escalate within the keepalive budget), OR
+                                // the keepalive is still healthy but the `-CC` channel
+                                // has been wedged continuously for absoluteWedgeBudgetMs
+                                // — the rare #822 sub-case (transport fine, control
+                                // channel permanently stuck) the absolute backstop
+                                // catches. A blanket keepalive veto would re-open #822.
+                                log(
+                                    "liveness-probe DECLARED DROP consecutive=$consecutiveFailures " +
+                                        "keepAliveProvesAlive=$keepAliveProvesAlive " +
+                                        "wedgedForMs=$wedgedForMs " +
+                                        "absoluteWedgeTripped=$absoluteWedgeTripped",
+                                )
+                                io.onProbeFailed(consecutiveFailures)
+                                // The recovery path now owns the channel; reset so the
+                                // probe does not re-fire every interval against the
+                                // already-reconnecting session.
+                                consecutiveFailures = 0
+                                wedgedFailureTicks = 0
+                            }
                         }
                     }
                 }
@@ -309,7 +330,7 @@ class LivenessProbe(
         job?.cancel()
         job = null
         consecutiveFailures = 0
-        consecutiveDeferrals = 0
+        wedgedFailureTicks = 0
     }
 
     private suspend fun runProbe(): Boolean =
@@ -402,26 +423,28 @@ class LivenessProbe(
         const val DEFAULT_FAILURE_THRESHOLD: Int = 4
 
         /**
-         * Issue #964 / #822 — how many back-to-back failure runs the probe defers
-         * to a still-healthy transport keepalive before it ESCALATES the drop
-         * anyway (the wedged-`-CC`-on-a-live-transport bound).
+         * Issue #982/#984 — the single high ABSOLUTE wedge backstop, the ONLY time
+         * ceiling that remains after the fixed `maxKeepAliveDeferrals` mechanism was
+         * deleted (it was the #974/#982 stable-wifi false-positive source: it
+         * force-redialed a slow-but-live link at ~96s).
          *
-         * Each failure run is [DEFAULT_FAILURE_THRESHOLD] consecutive missed `-CC`
-         * probes ≈ the raw 48s budget. With [DEFAULT_MAX_KEEPALIVE_DEFERRALS] = 1
-         * the probe RIDES THROUGH one full ~48s window of `-CC` silence while the
-         * keepalive proves the transport alive (absorbing the #964 slow-but-live
-         * blip), but if the `-CC` channel is STILL silent through a SECOND ~48s
-         * window with the keepalive still healthy, it declares the drop — so a
-         * genuinely WEDGED `-CC` channel on a live transport (#822) recovers within
-         * ≈ 2 × 48s ≈ 96s, a sane bound, instead of hanging forever behind a
-         * blanket keepalive veto. A single successful `-CC` probe in between resets
-         * the deferral run, so a link that slowly un-congests never escalates.
+         * While [ProbeIo.transportProvenAliveRecently] says the transport is alive
+         * the probe DEFERS UNCONDITIONALLY (the keepalive's own ~90s ride-through is
+         * the death authority). This backstop fires ONLY in the rare #822 sub-case
+         * where the `-CC` channel is genuinely WEDGED but the transport keepalive
+         * stays HEALTHY FOREVER (transport fine, control channel permanently stuck):
+         * if `-CC` has failed continuously for 180s the probe escalates anyway so the
+         * stuck channel still recovers.
          *
-         * 1 is deliberately conservative: the slow-but-live link the maintainer
-         * hits resolves well within one deferral (the `-CC` reply lands once the
-         * bufferbloat clears), while a never-answering `-CC` channel is the wedge
-         * that must recover. [LivenessProbeWedgeEscalationTest] pins both halves.
+         * 180s ≈ 2× the keepalive's ~90s ride-through
+         * ([com.pocketshell.core.ssh.TransportKeepAlive.RIDE_THROUGH_BUDGET_MS]) — far
+         * past any realistic wifi jitter (so it cannot reproduce the #974 false
+         * positive) yet still a bounded, sane recovery for a truly-wedged control
+         * channel. The dominant real #822 (a half-open drop that kills BOTH channels)
+         * is recovered much faster: the keepalive flips false within its ~90s budget,
+         * which escalates immediately via the keepalive-death branch — this backstop
+         * is only for the rarer transport-healthy-forever wedge.
          */
-        const val DEFAULT_MAX_KEEPALIVE_DEFERRALS: Int = 1
+        const val DEFAULT_ABSOLUTE_WEDGE_BUDGET_MS: Long = 180_000L
     }
 }

--- a/shared/core-connection/src/test/java/com/pocketshell/core/connection/LivenessProbeTest.kt
+++ b/shared/core-connection/src/test/java/com/pocketshell/core/connection/LivenessProbeTest.kt
@@ -422,8 +422,8 @@ class LivenessProbeTest {
         }
 
     // ---------------------------------------------------------------------
-    // Issue #964 / #822 — spurious reconnect on slow-but-live wifi, WITHOUT
-    // regressing the wedged-`-CC` recovery (reproduce-first, D33/G10).
+    // Issue #964 / #982 / #984 / #822 — spurious reconnect on slow-but-live wifi,
+    // WITHOUT regressing the wedged-`-CC` recovery (reproduce-first, D33/G10).
     //
     // Two foreground liveness mechanisms run together on DIFFERENT channels: the
     // transport keepalive (#945, TransportKeepAlive) pings the SSH TRANSPORT
@@ -432,17 +432,19 @@ class LivenessProbeTest {
     // live-but-slow link the `-CC` probe declared dead at ~48s and force-redialed
     // a FINE link BEFORE the keepalive's ~90s could prove the transport alive.
     //
-    // The fix THREADS THE NEEDLE rather than a blanket keepalive veto (which would
-    // re-open #822): a healthy keepalive lets the probe DEFER a redial for up to
-    // [maxKeepAliveDeferrals] failure runs — absorbing the slow-but-live blip —
-    // BUT if the `-CC` channel keeps not answering across that bound while the
-    // keepalive stays healthy, that is a genuinely WEDGED `-CC` on a live transport
-    // (#822) and the probe ESCALATES anyway. These pin the whole class:
+    // The #982/#984 fix DEFERS TO THE KEEPALIVE'S OWN DEATH SIGNAL with NO time
+    // ceiling while it proves the transport alive (the deleted maxKeepAliveDeferrals
+    // ~96s ceiling WAS the #974 stable-wifi false positive). Escalation is the
+    // keepalive flipping false, OR a single high absolute wedge backstop (180s) for
+    // the rare keepalive-healthy-forever wedge. These pin the whole class:
     //   (1) live-slow: `-CC` fails one run then RECOVERS while keepalive alive →
     //       NO redial (the #964 fix). RED on base, GREEN after.
-    //   (2) wedged-`-CC` + healthy keepalive (#822): `-CC` NEVER answers, keepalive
-    //       always alive → recovery STILL fires (after the deferral bound). #822
-    //       NOT regressed by the #964 deferral.
+    //   (2a) wedged-`-CC` + keepalive DEAD (#822 dominant): escalate within budget.
+    //   (2b) wedged-`-CC` + keepalive HEALTHY FOREVER: defer with NO time ceiling,
+    //        then escalate ONLY at the absolute wedge budget. #822 not suppressed,
+    //        no #974 false positive.
+    //   (2c) defer-forever across MANY budgets while keepalive alive (the #970
+    //        gate's pure mirror — the gap the old ceiling could not span).
     //   (3) genuinely-dead transport: `-CC` fails AND keepalive sees nothing →
     //       redial within the raw budget (no infinite hang).
     //   (4) slow→dead transition: defer while keepalive alive, then redial the
@@ -495,49 +497,146 @@ class LivenessProbeTest {
         }
 
     /**
-     * #964 / #822 — the load-bearing threading proof. A genuinely WEDGED `-CC`
-     * channel (refresh-client NEVER answers) while the transport keepalive stays
-     * HEALTHY the whole time (`transportProvenAliveRecently = true` forever). This
-     * is the #822 failure mode: the SSH transport is fine but the tmux control
-     * channel is stuck. A blanket "keepalive alive ⇒ never redial" would leave it
-     * wedged forever; the bounded deferral MUST still escalate recovery here.
-     *
-     * The probe rides through [maxKeepAliveDeferrals] failure runs (the #964
-     * slow-but-live tolerance), then — because the `-CC` is STILL silent with the
-     * keepalive still healthy — declares the drop so the wedged session recovers.
+     * #822 sub-case (a) — the DOMINANT real wedge: a half-open wifi drop wedges the
+     * `-CC` channel AND kills the transport keepalive together. The new #982/#984
+     * contract defers to the keepalive's OWN death signal, so the instant
+     * `transportProvenAliveRecently` flips FALSE the probe escalates within the
+     * keepalive budget. This is the path that recovers the maintainer's real #822.
      */
     @Test
-    fun `issue 822 wedged control channel with healthy keepalive still recovers (not regressed)`() =
+    fun `issue 822 wedged control channel with dead keepalive escalates within the keepalive budget`() =
         runTest(StandardTestDispatcher()) {
-            val io = FakeProbeIo(transportProvenAliveRecently = true)
-            // `-CC` never answers; keepalive proves the transport alive the whole
-            // time. enqueue enough misses to cover (maxDeferrals + 1) failure runs.
-            val runsNeeded = LivenessProbe.DEFAULT_MAX_KEEPALIVE_DEFERRALS + 1
-            repeat(LivenessProbe.DEFAULT_FAILURE_THRESHOLD * runsNeeded + 4) { io.enqueue(false) }
+            // `-CC` never answers AND the keepalive sees nothing either (a half-open
+            // drop killed both channels) — transportProvenAliveRecently = false.
+            val io = FakeProbeIo(transportProvenAliveRecently = false)
+            repeat(LivenessProbe.DEFAULT_FAILURE_THRESHOLD + 4) { io.enqueue(false) }
             val probe =
                 LivenessProbe(
                     io,
                     intervalMs = 100,
                     perProbeTimeoutMs = 1_000,
                     failureThreshold = LivenessProbe.DEFAULT_FAILURE_THRESHOLD,
-                    maxKeepAliveDeferrals = LivenessProbe.DEFAULT_MAX_KEEPALIVE_DEFERRALS,
                 )
             probe.start(this)
 
-            // Advance through all the deferral runs PLUS the escalation run.
-            advanceTimeBy(
-                LivenessProbe.DEFAULT_FAILURE_THRESHOLD.toLong() * runsNeeded * 100 + 500,
-            )
+            // ONE failure run is enough — the keepalive death authority is false, so
+            // escalation fires at the threshold (no time ceiling needed).
+            advanceTimeBy(LivenessProbe.DEFAULT_FAILURE_THRESHOLD.toLong() * 100 + 100)
             runCurrent()
             probe.stop()
             runCurrent()
 
             assertTrue(
-                "a WEDGED `-CC` channel on a still-healthy transport (#822) must STILL " +
-                    "recover after the bounded keepalive deferral — a blanket keepalive " +
-                    "veto would re-open #822 (declared count=${io.onProbeFailedCount})",
+                "a wedged `-CC` channel whose keepalive ALSO died (#822, the dominant " +
+                    "real case) must escalate within the keepalive budget once " +
+                    "transportProvenAliveRecently flips false (count=${io.onProbeFailedCount})",
                 io.onProbeFailedCount >= 1,
             )
+        }
+
+    /**
+     * #822 sub-case (b) — the RARE wedge the absolute backstop exists for: the `-CC`
+     * channel is genuinely WEDGED but the transport keepalive stays HEALTHY FOREVER
+     * (`transportProvenAliveRecently = true` the whole time). Under the new
+     * #982/#984 contract there is NO time ceiling while the keepalive proves the
+     * transport alive — the ONLY escalation is the high [absoluteWedgeBudgetMs]
+     * backstop. The probe must DEFER until that absolute budget, then escalate so the
+     * truly-stuck channel still recovers (a blanket keepalive veto would re-open
+     * #822). This pins BOTH the no-time-ceiling-defer AND the absolute-wedge escalate.
+     */
+    @Test
+    fun `issue 822 wedged control channel with healthy keepalive defers until the absolute wedge budget then escalates`() =
+        runTest(StandardTestDispatcher()) {
+            val io = FakeProbeIo(transportProvenAliveRecently = true)
+            // `-CC` never answers; keepalive proves the transport alive the whole
+            // time. Shorten the absolute wedge budget so the virtual clock can reach
+            // it deterministically (production is 180s; the contract is identical).
+            repeat(200) { io.enqueue(false) }
+            val absoluteWedgeMs = 2_000L
+            val probe =
+                LivenessProbe(
+                    io,
+                    intervalMs = 100,
+                    perProbeTimeoutMs = 1_000,
+                    failureThreshold = LivenessProbe.DEFAULT_FAILURE_THRESHOLD,
+                    absoluteWedgeBudgetMs = absoluteWedgeMs,
+                )
+            probe.start(this)
+
+            // BEFORE the absolute wedge budget elapses: the keepalive proves the link
+            // alive, so the probe must DEFER unconditionally — NO escalation, even
+            // though it has failed many full threshold runs. (The deleted
+            // maxKeepAliveDeferrals would have escalated at ~96s here — the #974 bug.)
+            advanceTimeBy(absoluteWedgeMs - 400)
+            runCurrent()
+            assertEquals(
+                "while the keepalive proves the link alive and BEFORE the absolute wedge " +
+                    "budget, a wedged `-CC` must NOT escalate (no fixed time ceiling — " +
+                    "the deleted #982/#984 false positive)",
+                0,
+                io.onProbeFailedCount,
+            )
+
+            // AFTER the absolute wedge budget: the `-CC` has been failing continuously
+            // past absoluteWedgeBudgetMs, so the backstop escalates even though the
+            // keepalive still claims alive — the rare truly-wedged channel recovers.
+            advanceTimeBy(
+                absoluteWedgeMs + LivenessProbe.DEFAULT_FAILURE_THRESHOLD.toLong() * 100 + 200,
+            )
+            runCurrent()
+            probe.stop()
+            runCurrent()
+            assertTrue(
+                "a `-CC` channel WEDGED continuously past the absolute wedge budget must " +
+                    "STILL escalate even with the keepalive healthy forever (#822 not " +
+                    "suppressed; count=${io.onProbeFailedCount})",
+                io.onProbeFailedCount >= 1,
+            )
+        }
+
+    /**
+     * #982/#984 the headline no-time-ceiling proof (the #970 gate's pure
+     * virtual-clock mirror): the `-CC` channel is wedged for FAR longer than two
+     * production probe budgets (the gap the old `maxKeepAliveDeferrals=1` ceiling
+     * could not span without escalating at ~96s) while the keepalive proves the link
+     * alive throughout and the absolute wedge budget is generous. The probe must
+     * DEFER FOREVER — ZERO escalations. RED with the old time-ceiling, GREEN now.
+     */
+    @Test
+    fun `issue 982 defers forever across many probe budgets while keepalive proves alive (no time ceiling)`() =
+        runTest(StandardTestDispatcher()) {
+            val io = FakeProbeIo(transportProvenAliveRecently = true)
+            repeat(500) { io.enqueue(false) } // `-CC` never answers
+            // Absolute wedge budget WELL beyond the window we advance, so only the
+            // keepalive-alive defer-forever behaviour is under test here.
+            val probe =
+                LivenessProbe(
+                    io,
+                    intervalMs = 100,
+                    perProbeTimeoutMs = 1_000,
+                    failureThreshold = LivenessProbe.DEFAULT_FAILURE_THRESHOLD,
+                    absoluteWedgeBudgetMs = 10_000_000L,
+                )
+            probe.start(this)
+
+            // Span MANY full threshold runs (≫ 2 budgets — the structural gap the
+            // #970 deterministic gate now also covers at production scale).
+            val budgets = 8
+            advanceTimeBy(
+                LivenessProbe.DEFAULT_FAILURE_THRESHOLD.toLong() * budgets * 100 + 500,
+            )
+            runCurrent()
+
+            assertEquals(
+                "while the keepalive proves the link alive, the probe must DEFER " +
+                    "across an UNBOUNDED number of `-CC` failure runs — ZERO escalation, " +
+                    "no fixed time ceiling (#982/#984). The deleted maxKeepAliveDeferrals " +
+                    "would have escalated after the first ~2 runs (count=${io.onProbeFailedCount})",
+                0,
+                io.onProbeFailedCount,
+            )
+            assertTrue("the probe keeps probing while deferring", io.probeCount >= budgets)
+            probe.stop()
         }
 
     /**
@@ -595,10 +694,10 @@ class LivenessProbeTest {
                     intervalMs = 100,
                     perProbeTimeoutMs = 1_000,
                     failureThreshold = LivenessProbe.DEFAULT_FAILURE_THRESHOLD,
-                    // Use a high deferral bound so phase 1 stays in the DEFER state
-                    // (this test isolates the keepalive-gave-up trigger, NOT the
-                    // wedge-escalation bound which the #822 test above pins).
-                    maxKeepAliveDeferrals = 100,
+                    // A high absolute wedge budget keeps phase 1 in the pure DEFER
+                    // state (no time-ceiling escalation while the keepalive is alive),
+                    // so this test isolates the keepalive-gave-up trigger.
+                    absoluteWedgeBudgetMs = 10_000_000L,
                 )
             probe.start(this)
 

--- a/shared/core-ssh/src/integrationTest/java/com/pocketshell/core/ssh/KeepAliveIntegrationTest.kt
+++ b/shared/core-ssh/src/integrationTest/java/com/pocketshell/core/ssh/KeepAliveIntegrationTest.kt
@@ -9,7 +9,9 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeoutOrNull
 import org.junit.AfterClass
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -593,6 +595,249 @@ class KeepAliveIntegrationTest {
     }
 
     @Test
+    fun keepAliveSurvivesAReplySlowerThanTheReplyBudget() {
+        // Issue #985 — the slow-reply ride-through + no-orphan-leak contract.
+        //
+        // IMPORTANT empirical finding (captured in the status comment): against the
+        // REAL OpenSSH testcontainer a SINGLE reply delayed past the 5s budget then
+        // delivered does NOT permanently desync sshj's FIFO `globalReqPromises`. The
+        // wire is strictly ordered, so the late reply R1 is polled by ITS OWN promise
+        // P1 (FIFO head) and R2 by P2, etc. — the queue stays 1:1. A permanent desync
+        // needs a genuinely LOST reply (a request whose reply never arrives so its
+        // promise sits at the head forever), which a clean ordered byte relay cannot
+        // inject without breaking the MAC'd stream (a hard disconnect, not the silent
+        // desync). So this test pins the fix's OBSERVABLE contract on a slow reply:
+        // (a) the session is NOT torn down, (b) the late reply still bumps the
+        // inbound-activity timestamp (the unbounded `retrieve()` drained its OWN
+        // promise — no orphan-pending leak), and (c) subsequent keepalives keep
+        // answering. It is GREEN on base AND fix for the slow-reply case (both ride
+        // it through); the fix-SPECIFIC red→green proofs are the #983 mutex test
+        // (controlWriteProceedsWhileKeepAliveReplyOutstanding, RED on base) and the
+        // no-leak-on-close assertion below.
+        val relay = PausableTcpRelay(sshHost, sshPort).also { it.start() }
+        try {
+            val session = connectThroughRelay(relay)
+            val real = session as RealSshSession
+            val ioScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+            val deadDeclared = AtomicBoolean(false)
+            val keepAliveSends = AtomicInteger(0)
+            val keepAliveOks = AtomicInteger(0)
+            try {
+                val keepAlive = TransportKeepAlive(
+                    io = object : TransportKeepAlive.KeepAliveIo {
+                        override fun isAlive(): Boolean = session.isConnected
+                        // No reset-on-inbound shortcut: force the loop to actually
+                        // PING every interval so the slow-reply path is exercised.
+                        override fun lastInboundActivityNanos(): Long = Long.MIN_VALUE
+                        override suspend fun sendKeepAlive(): Boolean {
+                            keepAliveSends.incrementAndGet()
+                            val ok = session.sendKeepAlive()
+                            if (ok) keepAliveOks.incrementAndGet()
+                            return ok
+                        }
+                        override fun onKeepAliveDead(consecutiveMisses: Int) {
+                            deadDeclared.set(true)
+                        }
+                    },
+                    intervalMs = 3_000L,
+                    countMax = 5,
+                )
+                keepAlive.start(ioScope)
+
+                // Let a couple of healthy keepalives land first.
+                runBlocking { waitUntil(15_000) { keepAliveOks.get() >= 1 } }
+
+                // Inject a SINGLE slow reply: hold the reply direction ~6s (> the 5s
+                // reply budget) while requests keep flowing — the server answers but
+                // the reply lands late, exactly the #985 trigger. Capture the activity
+                // timestamp before, so we can prove the LATE reply still bumped it (the
+                // unbounded retrieve drained its own promise — no orphan leak).
+                val activityBeforeSlow = real.lastInboundActivityNanosForTest()
+                relay.holdReplyDirectionOnce(6_000L)
+                runBlocking { waitUntil(12_000) { relay.replyHoldElapsed() } }
+
+                // After the slow reply, subsequent keepalives must KEEP answering (the
+                // FIFO is still aligned — no desync) and the inbound-activity timestamp
+                // must have ADVANCED (the late reply was consumed by its own promise).
+                val oksAtHoldEnd = keepAliveOks.get()
+                runBlocking { waitUntil(20_000) { keepAliveOks.get() >= oksAtHoldEnd + 2 } }
+
+                keepAlive.stop()
+
+                assertFalse(
+                    "a reply slower than the reply budget on an otherwise-live link must " +
+                        "NOT tear the transport down (#985). sends=${keepAliveSends.get()} " +
+                        "oks=${keepAliveOks.get()}",
+                    deadDeclared.get(),
+                )
+                assertTrue(
+                    "the session must still be connected after the slow reply (#985)",
+                    session.isConnected,
+                )
+                assertTrue(
+                    "subsequent keepalives must KEEP answering after the slow reply — the " +
+                        "FIFO promise queue must NOT have desynced (oksAtHoldEnd=" +
+                        "$oksAtHoldEnd oksNow=${keepAliveOks.get()})",
+                    keepAliveOks.get() >= oksAtHoldEnd + 2,
+                )
+                assertTrue(
+                    "the LATE reply must have bumped the inbound-activity timestamp — the " +
+                        "unbounded retrieve drained its OWN promise (no orphan-pending leak, " +
+                        "#985). before=$activityBeforeSlow after=" +
+                        "${real.lastInboundActivityNanosForTest()}",
+                    real.lastInboundActivityNanosForTest() != activityBeforeSlow,
+                )
+                // Direct proof the transport is fully usable post-recovery.
+                assertTrue(
+                    "a direct keepalive must answer after the slow-reply window (#985)",
+                    runBlocking { session.sendKeepAlive() },
+                )
+            } finally {
+                ioScope.cancel()
+                runCatching { session.close() }
+            }
+        } finally {
+            relay.close()
+        }
+    }
+
+    @Test
+    fun keepAliveReplyWaitDoesNotLeakAJobAcrossClose() {
+        // Issue #985 — the no-orphan-leak invariant the unbounded-retrieve fix MUST
+        // preserve (the reviewer-required "no retrieve() job leaks across teardown"
+        // check). On a genuinely dead/half-open peer the keepalive's unbounded
+        // `retrieve()` job blocks forever waiting for a reply that never comes. The
+        // fix launches it on the session scope, so close() (scope.cancel()) MUST reap
+        // it — the blocking sshj wait runs inside runInterruptible, which a scope
+        // cancel interrupts. We assert close() returns promptly (the pending job does
+        // not wedge teardown) and a subsequent keepalive on the closed session is a
+        // clean miss, not a hang/crash.
+        val relay = PausableTcpRelay(sshHost, sshPort).also { it.start() }
+        try {
+            val session = connectThroughRelay(relay)
+            try {
+                // Fire a keepalive whose reply is held → its unbounded retrieve job is
+                // left pending after the local 5s budget elapses (returns a miss).
+                relay.holdReplyDirectionOnce(30_000L)
+                val miss = runBlocking {
+                    withTimeoutOrNull(8_000) { session.sendKeepAlive() }
+                }
+                assertEquals(
+                    "a keepalive whose reply is held past the budget must return a miss " +
+                        "(false) within the budget, not hang (#985)",
+                    false,
+                    miss,
+                )
+                // Now close while the retrieve job is still pending. close() must NOT
+                // block on the forever-pending retrieve — scope.cancel() interrupts it.
+                val closeStart = System.nanoTime()
+                session.close()
+                val closeMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - closeStart)
+                assertTrue(
+                    "close() must return promptly even with a pending keepalive retrieve " +
+                        "job — the job must be reaped by scope.cancel(), not leaked/wedging " +
+                        "teardown (#985). closeMs=$closeMs",
+                    closeMs < 5_000L,
+                )
+                assertFalse(
+                    "a keepalive on the closed session must be a clean miss, not a hang",
+                    runBlocking { withTimeoutOrNull(3_000) { session.sendKeepAlive() } } ?: false,
+                )
+            } finally {
+                runCatching { session.close() }
+            }
+        } finally {
+            relay.close()
+        }
+    }
+
+    @Test
+    fun controlWriteProceedsWhileKeepAliveReplyOutstanding() {
+        // Issue #983 (reproduce-first, the mutex-hold root cause). The keepalive
+        // send used to hold the single-writer TransportDispatcher mutex across the
+        // blocking reply wait (`tryRetrieve(5s)` INSIDE `dispatcher.run { }`), so a
+        // slow keepalive reply froze EVERY `-CC` control write behind it for up to
+        // 5s. The fix holds the mutex ONLY for the wire write and awaits the reply
+        // OUTSIDE it.
+        //
+        // We hold the reply direction so a keepalive reply is outstanding, fire
+        // sendKeepAlive() on one coroutine, and on another assert a `-CC`-style
+        // CONTROL WRITE (`shell.stdin.write`, a pure dispatcher op that needs NO
+        // reply) completes QUICKLY (< 1.5s) WHILE the keepalive reply is still
+        // parked. The stdin write is the faithful proxy for the symptom: the
+        // keepalive that froze every `-CC` control write was the maintainer's pain.
+        // We deliberately do NOT use exec() here — exec's OWN output also flows in
+        // the held reply direction, so it cannot complete fast regardless of the
+        // mutex. A write-only control op isolates the mutex-contention symptom.
+        // RED on base: the write blocks ~5s behind the held mutex
+        // (`tryRetrieve(5s)` ran INSIDE `dispatcher.run { }`).
+        val relay = PausableTcpRelay(sshHost, sshPort).also { it.start() }
+        try {
+            val session = connectThroughRelay(relay)
+            try {
+                // Warm the connection with a healthy round-trip first.
+                runBlocking {
+                    assertEquals(
+                        "warm exec must round-trip before the test",
+                        0,
+                        session.exec("true").exitCode,
+                    )
+                }
+                session.startShell().use { shell ->
+                    // Park the reply direction for 6s (> the 5s reply budget) so a
+                    // keepalive fired now has an OUTSTANDING reply the whole time.
+                    relay.holdReplyDirectionOnce(6_000L)
+
+                    runBlocking {
+                        // Fire the keepalive on its own coroutine — its reply is now
+                        // parked behind the held reply direction.
+                        val keepAliveJob = async { session.sendKeepAlive() }
+                        // Give the keepalive a beat to issue its global-request write
+                        // and (on base) enter its mutex-held reply wait.
+                        delay(300)
+
+                        // Concurrently issue a `-CC`-style control WRITE (stdin write
+                        // = a pure dispatcher op, no reply needed). With the mutex no
+                        // longer held across the reply wait it acquires the mutex and
+                        // completes fast; on base it blocks ~5s behind the keepalive.
+                        val writeStart = System.nanoTime()
+                        val wrote = withTimeoutOrNull(4_000) {
+                            runInterruptible(Dispatchers.IO) {
+                                shell.stdin.write("echo ps983-x\n".toByteArray(Charsets.UTF_8))
+                                shell.stdin.flush()
+                            }
+                            true
+                        }
+                        val writeMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - writeStart)
+
+                        assertTrue(
+                            "a `-CC` control write (stdin) must complete WHILE a keepalive " +
+                                "reply is outstanding — it must NOT block behind the dispatcher " +
+                                "mutex (#983). It took ${writeMs}ms (null=timed out).",
+                            wrote != null,
+                        )
+                        assertTrue(
+                            "the control write completed in ${writeMs}ms — it must be well " +
+                                "under the 5s reply budget the mutex used to hold (#983). RED on " +
+                                "base: ~5s while the keepalive reply is parked behind the mutex.",
+                            writeMs < 1_500L,
+                        )
+
+                        // The keepalive itself eventually returns (a miss on the local
+                        // no-activity budget, or an answer once the held reply lands) —
+                        // either way it must not crash.
+                        runCatching { withTimeoutOrNull(12_000) { keepAliveJob.await() } }
+                    }
+                }
+            } finally {
+                runCatching { session.close() }
+            }
+        } finally {
+            relay.close()
+        }
+    }
+
+    @Test
     fun keepAliveCadenceDoesNotCorruptTheTransportOver100s() {
         // The #847 GUARD (acceptance #3): a real session held > 100s with the
         // transport keepalive cadence ON, under concurrent exec churn + shell
@@ -736,6 +981,12 @@ class KeepAliveIntegrationTest {
  *  - [resume]: forward bytes again.
  *  - [cut]: close all live tunnels and refuse new accepts (a hard dead peer) —
  *    the genuinely-dead-peer case.
+ *  - [holdReplyDirectionOnce]: hold ONLY the server→client (REPLY) direction for
+ *    a bounded window ONCE, while client→server (REQUESTS) keep flowing normally,
+ *    then resume — the #985 single-slow-reply case. The request still reaches the
+ *    server (so sshj keeps enqueuing reply promises into its FIFO) but the reply
+ *    is delayed past the keepalive's local reply budget, which on base orphans the
+ *    promise and desyncs the FIFO.
  */
 private class PausableTcpRelay(
     private val targetHost: String,
@@ -750,6 +1001,11 @@ private class PausableTcpRelay(
     private val paused = AtomicBoolean(false)
     private val cut = AtomicBoolean(false)
     private val closed = AtomicBoolean(false)
+    // #985 — when > 0, the REPLY direction (server→client) holds bytes until this
+    // monotonic [System.nanoTime] deadline; armed exactly ONCE by
+    // [holdReplyDirectionOnce] and cleared the moment it elapses.
+    private val replyHoldUntilNanos = AtomicLong(0L)
+    private val replyHoldArmed = AtomicBoolean(false)
     private val tunnels = java.util.concurrent.ConcurrentHashMap.newKeySet<Socket>()
     private var acceptThread: Thread? = null
 
@@ -780,8 +1036,10 @@ private class PausableTcpRelay(
             }
             tunnels.add(client)
             tunnels.add(upstream)
-            val a = pump(client, upstream)
-            val b = pump(upstream, client)
+            // client→upstream is the REQUEST direction; upstream→client is the
+            // REPLY direction (the only one [holdReplyDirectionOnce] holds).
+            val a = pump(client, upstream, isReplyDirection = false)
+            val b = pump(upstream, client, isReplyDirection = true)
             runCatching { a.join() }
             runCatching { b.join() }
             tunnels.remove(client)
@@ -791,12 +1049,13 @@ private class PausableTcpRelay(
         }
     }
 
-    private fun pump(from: Socket, to: Socket): Thread =
+    private fun pump(from: Socket, to: Socket, isReplyDirection: Boolean): Thread =
         thread(isDaemon = true) {
             val buf = ByteArray(16 * 1024)
             try {
                 val input = from.getInputStream()
                 val output = to.getOutputStream()
+                from.soTimeout = 100
                 while (!closed.get() && !cut.get()) {
                     // While paused, hold the bytes (do NOT read) — a half-open
                     // starve: the socket stays established, the peer just goes
@@ -805,25 +1064,31 @@ private class PausableTcpRelay(
                         Thread.sleep(50)
                         continue
                     }
-                    if (input.available() <= 0) {
-                        // Avoid a busy spin while still being responsive to a
-                        // pause/cut transition; a short blocking read with a
-                        // timeout keeps latency low without burning CPU.
-                        from.soTimeout = 100
-                        val n = try {
-                            input.read(buf)
-                        } catch (e: java.net.SocketTimeoutException) {
-                            continue
-                        }
-                        if (n < 0) break
-                        output.write(buf, 0, n)
-                        output.flush()
-                    } else {
-                        val n = input.read(buf)
-                        if (n < 0) break
-                        output.write(buf, 0, n)
-                        output.flush()
+                    // A short blocking read with a timeout keeps latency low without
+                    // burning CPU and stays responsive to a pause/cut transition.
+                    val n = try {
+                        input.read(buf)
+                    } catch (e: java.net.SocketTimeoutException) {
+                        continue
                     }
+                    if (n < 0) break
+                    // #985 — hold the REPLY direction for the armed window. Critically
+                    // the hold is checked AFTER the read (just before forwarding) and
+                    // BUFFERS the already-read bytes until the window elapses, so a
+                    // reply that lands mid-read is STILL delayed (the earlier
+                    // before-read-only check let a reply in an in-flight read slip
+                    // through, which is why the hold appeared ineffective). Bytes are
+                    // forwarded in order, so the reply lands late but intact.
+                    if (isReplyDirection) {
+                        while (!closed.get() && !cut.get() &&
+                            replyHoldUntilNanos.get() > System.nanoTime()
+                        ) {
+                            Thread.sleep(25)
+                        }
+                    }
+                    if (closed.get() || cut.get()) break
+                    output.write(buf, 0, n)
+                    output.flush()
                 }
             } catch (t: Throwable) {
                 // tunnel broken — let the join() finish and clean up.
@@ -832,6 +1097,23 @@ private class PausableTcpRelay(
 
     fun pause() { paused.set(true) }
     fun resume() { paused.set(false) }
+
+    /**
+     * #985 — hold the REPLY direction (server→client) for [ms] milliseconds ONCE,
+     * starting now. Requests (client→server) keep flowing the whole time, so the
+     * server receives the keepalive global request and answers it — but the answer
+     * is buffered at the relay until the window elapses. Idempotent per arming: a
+     * second call before the first window elapses extends it. Used to inject a
+     * single reply slower than the keepalive's local reply budget.
+     */
+    fun holdReplyDirectionOnce(ms: Long) {
+        replyHoldArmed.set(true)
+        replyHoldUntilNanos.set(System.nanoTime() + ms * 1_000_000L)
+    }
+
+    /** True once the armed reply-hold window has fully elapsed (the reply resumed). */
+    fun replyHoldElapsed(): Boolean =
+        replyHoldArmed.get() && replyHoldUntilNanos.get() <= System.nanoTime()
 
     fun cut() {
         cut.set(true)

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshSession.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshSession.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -16,8 +17,11 @@ import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.coroutines.yield
+import net.schmizz.concurrent.Promise
 import net.schmizz.sshj.SSHClient
 import net.schmizz.sshj.common.SSHException
+import net.schmizz.sshj.common.SSHPacket
+import net.schmizz.sshj.connection.ConnectionException
 import net.schmizz.sshj.connection.channel.direct.DirectConnection
 import net.schmizz.sshj.connection.channel.direct.Session
 import net.schmizz.sshj.connection.channel.direct.Session.Command
@@ -134,6 +138,25 @@ internal class RealSshSession(
     internal fun lastInboundActivityNanosForTest(): Long = lastInboundActivityNanos
 
     /**
+     * Issue #985/#983 — single-flight guard for the keepalive reply wait. Holds
+     * the throwaway [awaitKeepAliveReply] `retrieve()` coroutine launched for the
+     * most recent ping that has NOT yet completed (the reply has not landed and the
+     * transport has not errored it out). [sendKeepAlive] skips launching a SECOND
+     * `retrieve()` while a prior one is still pending — a still-outstanding reply is
+     * "not yet a fresh confirmation," so we wait on the EXISTING job rather than
+     * stacking an unbounded queue of `retrieve()` coroutines on a slow/dead link
+     * (bounded job growth: at most one pending reply job at a time).
+     *
+     * Crucially this guard ONLY suppresses launching a DUPLICATE `retrieve()`; it
+     * does NOT suppress miss accounting. On a genuinely dead peer the pending job
+     * never completes, so [sendKeepAlive] must STILL return `false` (a miss) once
+     * the local no-activity budget elapses — otherwise the 90s `onKeepAliveDead`
+     * teardown would never fire (see [awaitKeepAliveReply]).
+     */
+    @Volatile
+    private var pendingKeepAliveReply: Job? = null
+
+    /**
      * Why this session's transport went down (issue #969 — reconnect
      * observability). Flipped to [SshSessionCloseCause.KeepaliveDead] by the
      * keepalive watchdog ([TransportKeepAlive.KeepAliveIo.onKeepAliveDead]) the
@@ -227,56 +250,117 @@ internal class RealSshSession(
     }
 
     override suspend fun sendKeepAlive(): Boolean {
-        // Route the global request through the single-writer dispatcher so it is
-        // FIFO-serialized against every other transport op (the #847-safe path).
-        //
-        // OpenSSH does NOT implement the `keepalive@openssh.com` request type, so
-        // it answers with `SSH_MSG_REQUEST_FAILURE` — which sshj surfaces as a
-        // thrown `ConnectionException("Global request [...] failed")` rather than
-        // a returned packet (see ConnectionImpl.gotGlobalReqResponse). That
-        // FAILURE reply STILL proves the peer is alive — it is exactly how
-        // OpenSSH's own client treats its `ServerAliveInterval` ping. So BOTH a
-        // returned packet (REQUEST_SUCCESS) AND the "request failed" exception
-        // (REQUEST_FAILURE) count as proof of life; only a timeout (no reply) or a
-        // genuine transport-death error is a miss.
-        return runCatching {
-            dispatcher.run {
-                if (!isConnected) return@run false
-                val promise = client.connection.sendGlobalRequest(
-                    KEEPALIVE_REQUEST_NAME,
-                    /* wantReply = */ true,
-                    EMPTY_PAYLOAD,
-                )
-                val answered = try {
-                    // A returned packet (REQUEST_SUCCESS) is proof of life; a null
-                    // (timeout — no reply at all) is a miss.
-                    promise.tryRetrieve(
-                        KEEPALIVE_REPLY_TIMEOUT_MS,
-                        java.util.concurrent.TimeUnit.MILLISECONDS,
-                    ) != null
-                } catch (ce: CancellationException) {
-                    throw ce
-                } catch (t: Throwable) {
-                    // The reader thread delivered an error to this promise. A
-                    // REQUEST_FAILURE response is delivered as the specific
-                    // "Global request [...] failed" ConnectionException — the
-                    // server DID answer, so the peer is ALIVE. Any OTHER error
-                    // (connection lost, MAC failure, transport torn down) is a
-                    // genuine miss.
-                    isKeepAliveServerAnswered(t)
+        if (!isConnected) return false
+
+        // Issue #983 — split the op so the single-writer mutex is held ONLY for the
+        // wire write, never for the multi-second reply wait. The
+        // `keepalive@openssh.com` global request (wantReply=true) is the only
+        // transport-mutating step here; sshj creates+enqueues the reply Promise into
+        // its FIFO `globalReqPromises` ATOMICALLY with the write, under sshj's own
+        // lock. OpenSSH does not implement the request type, so it answers
+        // `SSH_MSG_REQUEST_FAILURE` — which still proves the peer alive (#945).
+        val promise: Promise<SSHPacket, ConnectionException> =
+            runCatching {
+                dispatcher.run {
+                    if (!isConnected) {
+                        null
+                    } else {
+                        client.connection.sendGlobalRequest(
+                            KEEPALIVE_REQUEST_NAME,
+                            /* wantReply = */ true,
+                            EMPTY_PAYLOAD,
+                        )
+                    }
                 }
-                if (answered) {
-                    lastInboundActivityNanos = System.nanoTime()
+            }.getOrElse { t ->
+                if (t is CancellationException) throw t
+                // The send itself (write / dispatcher) failed. A REQUEST_FAILURE that
+                // escaped here still proves the peer answered; otherwise it is a miss.
+                return isKeepAliveServerAnswered(t)
+            } ?: return false
+
+        // Issue #985 — confirm the reply OUTSIDE the mutex with a NON-ORPHANING wait.
+        return awaitKeepAliveReply(promise)
+    }
+
+    /**
+     * Issue #985 + #983 — await the keepalive reply without ever orphaning the sshj
+     * promise and without holding the transport dispatcher mutex.
+     *
+     * sshj's `Promise.tryRetrieve(timeout)` returns `null` on timeout but does NOT
+     * remove the promise from sshj's FIFO `globalReqPromises` queue (sshj exposes no
+     * per-promise cancel). So a single reply slower than a BOUNDED `tryRetrieve`
+     * budget would abandon a promise at the queue HEAD, every subsequent reply would
+     * be delivered to the wrong (already-abandoned) promise, and every keepalive
+     * thereafter would be a structural miss → `onKeepAliveDead` tears a live
+     * transport. That is the #985 self-corruption that never self-heals.
+     *
+     * The fix: launch an UNBOUNDED `promise.retrieve()` on a throwaway coroutine on
+     * the session [scope]. Because the wait is unbounded, the promise is ALWAYS
+     * eventually polled by sshj's reader thread when its reply lands (even at t+30s)
+     * — or woken with an error on `notifyError` (transport death) / cancelled when
+     * the session [scope] is cancelled in [close]. So the queue slot is never
+     * abandoned and the FIFO can never desync. A late reply always polls its OWN
+     * promise.
+     *
+     * Liveness here is derived from [lastInboundActivityNanos] advancing (the reply,
+     * via [recordInboundActivity] below, OR any reader byte), NOT from the bounded
+     * wait — so the wait can be unbounded while the MISS decision stays bounded.
+     *
+     * Miss accounting (the correctness requirement): if the local
+     * [KEEPALIVE_REPLY_TIMEOUT_MS] no-activity budget elapses with no inbound
+     * activity, this returns `false` (a miss) REGARDLESS of whether the
+     * `retrieve()` job is still pending. On a genuinely dead peer the job blocks
+     * forever, so treating "pending" as "not a miss" would silently break dead-peer
+     * detection and the 90s teardown would never fire. The single-flight guard
+     * ([pendingKeepAliveReply]) only suppresses launching a DUPLICATE `retrieve()`,
+     * never the miss.
+     */
+    private suspend fun awaitKeepAliveReply(
+        promise: Promise<SSHPacket, ConnectionException>,
+    ): Boolean {
+        val before = lastInboundActivityNanos
+
+        // Single-flight: only launch a NEW unbounded retrieve when the prior one has
+        // completed. A still-pending reply job means the previous promise's consumer
+        // is still alive (so its queue slot is not abandoned); we do not need — and
+        // must not — stack a second retrieve. We DO still run the local no-activity
+        // budget below, so a dead peer with a perpetually-pending job is still a miss.
+        val existing = pendingKeepAliveReply
+        if (existing == null || existing.isCompleted) {
+            pendingKeepAliveReply = scope.launch {
+                runCatching {
+                    runInterruptible(Dispatchers.IO) {
+                        // UNBOUNDED — never abandons the queue slot. Returns the
+                        // REQUEST_SUCCESS packet, or throws the REQUEST_FAILURE
+                        // ConnectionException (both prove the peer answered), or
+                        // throws a transport-death error / is interrupted on
+                        // scope-cancel (close()/notifyError).
+                        promise.retrieve()
+                    }
+                }.onSuccess {
+                    recordInboundActivity()
+                }.onFailure { t ->
+                    if (isKeepAliveServerAnswered(t)) recordInboundActivity()
                 }
-                answered
             }
-        }.getOrElse { t ->
-            if (t is CancellationException) throw t
-            // The send itself (write / dispatcher) failed, or a non-promise
-            // exception escaped — but a REQUEST_FAILURE that escaped the inner
-            // catch still proves the peer answered. Otherwise it is a miss.
-            isKeepAliveServerAnswered(t)
         }
+
+        // Locally wait up to KEEPALIVE_REPLY_TIMEOUT_MS for the inbound-activity
+        // timestamp to advance (a reply OR any reader byte). "No inbound activity
+        // within the budget" IS the liveness question, and it leaves the promise
+        // intact — the late reply is delivered to its OWN promise, not the next one.
+        val deadline = System.nanoTime() + KEEPALIVE_REPLY_TIMEOUT_MS * 1_000_000L
+        while (System.nanoTime() < deadline) {
+            if (lastInboundActivityNanos != before) return true
+            if (!isConnected) return false
+            delay(KEEPALIVE_POLL_MS)
+        }
+        // A miss — but the orphan-free retrieve job is STILL pending, so the late
+        // reply (if any) is delivered to its OWN promise. Returning false here even
+        // while the job is pending is REQUIRED so a genuinely dead peer is declared
+        // dead within the keepalive budget (it never bumps the timestamp).
+        return false
     }
 
     @OptIn(InternalCoroutinesApi::class)
@@ -1506,6 +1590,16 @@ internal const val KEEPALIVE_REQUEST_NAME: String = "keepalive@openssh.com"
  * wall-clock ceiling, so a wedged write can never park the keepalive forever.
  */
 internal const val KEEPALIVE_REPLY_TIMEOUT_MS: Long = 5_000L
+
+/**
+ * Poll cadence for the local no-activity budget in
+ * [RealSshSession.awaitKeepAliveReply] (issue #985). The reply confirmation is
+ * derived from [RealSshSession.lastInboundActivityNanos] advancing (a reply OR any
+ * reader byte) rather than a blocking promise wait, so we sample the timestamp at
+ * this cadence while waiting up to [KEEPALIVE_REPLY_TIMEOUT_MS]. 100ms is fine
+ * granularity for a sub-second healthy round-trip without burning CPU.
+ */
+internal const val KEEPALIVE_POLL_MS: Long = 100L
 
 /** Empty payload for the [KEEPALIVE_REQUEST_NAME] global request (issue #945). */
 private val EMPTY_PAYLOAD: ByteArray = ByteArray(0)


### PR DESCRIPTION
Cluster A consolidated rework of the keepalive/probe path — root cause of the recurring **"SSH drops on stable wifi, not a tunnel"** symptom (#974, recurring across #822/#964/#970/#974). One coherent fix, hard-cut (D22), not four stacked shims (D28). Maintainer GO'd the scoped rework (effort M) 2026-06-26.

## The one fault, three layers
- **Transport (#983 + #985):** `sendKeepAlive` now holds the single-writer `TransportDispatcher` mutex only for the global-request WRITE; the reply is awaited OUTSIDE the mutex on an **unbounded, never-orphaning** `promise.retrieve()`, with a single-flight guard that never suppresses miss accounting. A slow keepalive reply no longer freezes the `-CC` control channel and can no longer orphan a promise.
- **Probe (#982 + #984):** the `maxKeepAliveDeferrals` time-ceiling deferral-count mechanism is **deleted wholesale**. The probe defers to the keepalive's own death signal (`transportProvenAliveRecently()` flipping false) as the transport-death authority, with one high **180s** absolute-wedge backstop for the keepalive-unavailable edge. #822 wedge recovery preserved.

## Reproduce-first proof (reviewer-verified red→green this run, D33/G10)
- **#983 mutex** (real OpenSSH testcontainer): a `-CC` control write blocked **4013ms** behind the held mutex on base → **<1.5s** with the split.
- **#982/#984 escalation** (virtual-clock unit): RED on the synthesized old ceiling (`expected:<0> but was:<4>`) → GREEN with the keepalive-death predicate.
- **#974 on the real app path** (emulator + Docker `agents:2222`): extended #970 gate, 12s slow-`-CC` hold spanning ~2.7 probe budgets → `connect_attempt_delta=0 / liveness_probe_silent_drop=0 / reconnect_start=0`, live attached terminal in the after-hold viewport.
- Dead-peer detection, half-open detection, and the reader-activity feed all kept green.

## #985 — honest reframe (reviewer verdict A)
The audited "single *slow* reply → permanent FIFO desync → teardown" was found **non-reproducible on a live ordered SSH link** (confirmed from sshj 0.40 bytecode): an ordered MAC'd stream self-heals a delayed reply and cannot drop one without disconnecting. The orphan path is removed as correct defensive hardening (also required for the #983 fix); the real #974 driver was #983/#982/#984. See the reframe on #985.

## Review
APPROVED by reviewer with the full D31 recurrence gate + G1–G10 applied (default `CHANGES REQUESTED`, every criterion earned from artifacts produced this run): https://github.com/alexeygrigorev/pocketshell/issues/1006#issuecomment-4812289186

Closes #1006
Closes #982
Closes #983
Closes #984
Closes #985