### PR TITLE
composer: keep dropped attachment sends queued

### DIFF
--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerViewModel.kt
@@ -1762,11 +1762,9 @@ public class PromptComposerViewModel @Inject constructor(
         }
         val uploader = outboundAttachmentUploader
         if (uploader == null) {
-            outboundQueueStore.markFailed(id, lastError = "Attachment upload unavailable")
+            outboundQueueStore.requeueForRetry(id)
             refreshOutboundQueueItemsFor(item.sessionKey)
-            clearStrandedSendInFlight(
-                error = "Attachment upload failed: reconnect, then send again or discard the draft.",
-            )
+            clearStrandedSendInFlight()
             return false
         }
         // Issue #929: `markUploading` lost the claim race (row no longer exactly
@@ -1787,16 +1785,15 @@ public class PromptComposerViewModel @Inject constructor(
             Result.failure(t)
         }
         val uploadedPaths = result.getOrElse { error ->
-            outboundQueueStore.markFailed(id, lastError = attachmentErrorMessage(error))
+            outboundQueueStore.requeueForRetry(id)
             refreshOutboundQueueItemsFor(uploading.sessionKey)
-            clearStrandedSendInFlight(error = attachmentErrorMessage(error))
+            clearStrandedSendInFlight()
             return false
         }.filter { it.isNotBlank() }
         if (uploadedPaths.size != sidecars.size) {
-            val message = "Attachment upload failed: uploaded ${uploadedPaths.size} of ${sidecars.size} files."
-            outboundQueueStore.markFailed(id, lastError = message)
+            outboundQueueStore.requeueForRetry(id)
             refreshOutboundQueueItemsFor(uploading.sessionKey)
-            clearStrandedSendInFlight(error = message)
+            clearStrandedSendInFlight()
             return false
         }
         val uploadedSidecarRefs = sidecars.mapIndexed { index, ref ->

--- a/app/src/test/java/com/pocketshell/app/composer/PromptComposerViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/PromptComposerViewModelTest.kt
@@ -3499,6 +3499,103 @@ class PromptComposerViewModelTest {
     }
 
     @Test
+    fun issue987_attachmentUploadDropKeepsQueuedRowAndComposerClear() = runTest {
+        // Reproduces the #987 attachment gap: after Send, a normal dropped SSH
+        // connection during sidecar upload used to stamp an upload error and
+        // leave a Failed row. Canonical behaviour is the same as text: the row
+        // stays queued, the composer stays clear, and reconnect flush retries it.
+        val queue = InMemoryOutboundQueueStore()
+        val sidecars = newSidecarStore()
+        val vm = newVm(
+            samplerDispatcher = StandardTestDispatcher(testScheduler),
+            outboundQueueStore = queue,
+            outboundAttachmentSidecarStore = sidecars,
+        )
+        var uploadAttempts = 0
+        vm.setOutboundAttachmentSidecarUploader {
+            uploadAttempts++
+            Result.failure(IllegalStateException("No live SSH session"))
+        }
+        val sent = collectSendRequests(vm)
+        val target = PromptComposerViewModel.SendTargetSnapshot(sessionKey = "1/session-a")
+        val local = localAttachmentFile("drop-upload.txt", "queued bytes")
+
+        vm.onComposerTargetChanged("1/session-a")
+        vm.onDraftChange("send with attachment")
+        vm.attachFiles(
+            count = 1,
+            previews = listOf(PromptComposerViewModel.AttachmentPreview(Uri.fromFile(local), "text/plain")),
+        ) {
+            Result.success(listOf("~/.pocketshell/attachments/old/drop-upload.txt"))
+        }
+        settleUntil { vm.uiState.value.attachments.isNotEmpty() }
+
+        vm.requestSend(withEnter = true, sendTarget = target)
+        settleUntil { uploadAttempts == 1 && !vm.uiState.value.sendInFlight }
+
+        assertTrue("upload drop must not emit a text-only send", sent.isEmpty())
+        assertEquals("", vm.uiState.value.draft)
+        assertTrue(vm.uiState.value.attachments.isEmpty())
+        assertNull("drop status is represented by the queued row only", vm.uiState.value.error)
+        val row = queue.itemsFor("1/session-a").single()
+        assertEquals(OutboundState.Queued, row.state)
+        assertNull(row.lastError)
+        assertEquals(
+            PromptComposerViewModel.WILL_SEND_WHEN_RECONNECTED_MESSAGE,
+            outboundQueueStateLabel(row),
+        )
+        assertEquals(listOf(row.id), vm.outboundQueueItems.value.map { it.id })
+    }
+
+    @Test
+    fun issue987_sidecarFlushWithoutLiveUploaderStaysQueuedForReconnect() = runTest {
+        // Reproduces the no-live-session reconnect path for an already queued
+        // attachment row. The flush must not hard-fail the row or surface a
+        // separate composer banner; it waits in the queue for the next reconnect.
+        var uploadClaims = 0
+        val queue = object : InMemoryOutboundQueueStore() {
+            override fun markUploading(id: String, lastAttemptAtMs: Long): OutboundItem? {
+                uploadClaims++
+                return super.markUploading(id, lastAttemptAtMs)
+            }
+        }
+        val sidecars = newSidecarStore()
+        val item = OutboundItem(
+            id = "queued-no-live-uploader",
+            sessionKey = "1/session-a",
+            cleanText = "send queued attachment",
+            attachments = listOf(DurableAttachmentRef("stale-local", "drop-upload.txt", "text/plain")),
+            createdAtMs = 1L,
+        )
+        queue.enqueueExisting(item)
+        sidecars.stage(
+            outboundItemId = item.id,
+            uris = listOf(Uri.fromFile(localAttachmentFile("drop-upload.txt", "queued bytes"))),
+        )
+        val vm = newVm(
+            samplerDispatcher = StandardTestDispatcher(testScheduler),
+            outboundQueueStore = queue,
+            outboundAttachmentSidecarStore = sidecars,
+        )
+        val sent = collectSendRequests(vm)
+        vm.onComposerTargetChanged("1/session-a")
+
+        assertEquals(item.id, vm.retryNextOutboundItem())
+        settleUntil { uploadClaims == 1 && !vm.uiState.value.sendInFlight }
+
+        assertTrue(sent.isEmpty())
+        assertNull(vm.uiState.value.error)
+        val row = queue.item(item.id)!!
+        assertEquals(OutboundState.Queued, row.state)
+        assertNull(row.lastError)
+        assertEquals(
+            PromptComposerViewModel.WILL_SEND_WHEN_RECONNECTED_MESSAGE,
+            outboundQueueStateLabel(row),
+        )
+        assertEquals(listOf(item.id), vm.outboundQueueItems.value.map { it.id })
+    }
+
+    @Test
     fun retryNextOutboundItemUploadsPersistedSidecarsBeforeClaimingQueuedRow() = runTest {
         val queue = InMemoryOutboundQueueStore()
         val sidecars = newSidecarStore()


### PR DESCRIPTION
Closes #987.\n\nWhat changed:\n- Attachment sidecar upload unavailable/failure/partial upload now requeues the outbound row for reconnect instead of marking it failed and surfacing a separate composer error.\n- Composer remains cleared after Send; queued row stays the single representation with the existing reconnect status.\n- Adds regression coverage for local attachment Send with no live SSH session and queued sidecar flush with no uploader.\n\nReviewed/approved on #987: https://github.com/alexeygrigorev/pocketshell/issues/987#issuecomment-4815618373\n\nLocal verification in a clean worktree:\n- ./gradlew :app:testDebugUnitTest --tests 'com.pocketshell.app.composer.PromptComposerViewModelTest'\n- git diff --check