### PR TITLE
connection: preserve suppressed drop cause for foreground heal

### DIFF
--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -64,6 +64,7 @@ import com.pocketshell.app.tmux.connection.CurrentClientTmuxPort
 import com.pocketshell.app.tmux.connection.debounceReconnectUi
 import com.pocketshell.app.tmux.connection.GraceEffects
 import com.pocketshell.app.tmux.connection.SshLeaseTransportPort
+import com.pocketshell.app.tmux.connection.SuppressedDropDiagnostic
 import com.pocketshell.app.tmux.connection.TmuxAttachEffects
 import com.pocketshell.app.tmux.connection.TransportEffects
 import com.pocketshell.app.tmux.connection.hostKeyFor
@@ -930,6 +931,9 @@ public class TmuxSessionViewModel @Inject constructor(
             // band (the #635 regression). Recovery is deferred to the within-grace
             // foreground heal ([launchForegroundHealWithinGrace]) — the single owner.
             suppressTransportDrops = { shouldSuppressTransportDropsForSingleGraceOwner() },
+            onDropSuppressed = { diagnostic ->
+                recordSuppressedDropDiagnostic(diagnostic)
+            },
             // EPIC #766 Slice 2b: the driver now owns the passive transport-drop edge.
             // The typed client stream lets the VM reject a late old-client close BEFORE
             // the driver submits TransportDropped to the controller (#630), while still
@@ -1301,6 +1305,36 @@ public class TmuxSessionViewModel @Inject constructor(
         // deferred to the single grace owner.
         return isProcessBackgroundedForGraceOwner()
     }
+
+    private fun recordSuppressedDropDiagnostic(diagnostic: SuppressedDropDiagnostic) {
+        lastSuppressedDropDiagnostic = diagnostic
+    }
+
+    private fun suppressedDropDiagnosticFor(
+        disconnectEvent: TmuxDisconnectEvent,
+        source: String,
+    ): SuppressedDropDiagnostic =
+        SuppressedDropDiagnostic(
+            cause = disconnectEvent.reason.logValue,
+            fields = mapOf(
+                "transportDropSource" to source,
+                "disconnectReason" to disconnectEvent.reason.logValue,
+                "disconnectSource" to disconnectEvent.source,
+                "disconnectIntent" to disconnectEvent.intent,
+                "commandKind" to disconnectEvent.commandKind,
+                "timeoutMode" to disconnectEvent.timeoutMode,
+                "exceptionClass" to disconnectEvent.exceptionClass,
+                "message" to disconnectEvent.message,
+            ),
+        )
+
+    private fun suppressedDropDiagnosticFields(
+        diagnostic: SuppressedDropDiagnostic?,
+    ): Array<Pair<String, Any?>> =
+        diagnostic?.fields
+            ?.map { (key, value) -> key to value }
+            ?.toTypedArray()
+            ?: emptyArray()
 
     /**
      * EPIC #687 P2 (J1/#635): true when the app is backgrounded at the PROCESS level
@@ -3026,6 +3060,7 @@ public class TmuxSessionViewModel @Inject constructor(
     private var pendingReattach: PendingReattach? = null
     private var pausedAutoReconnect: PausedAutoReconnect? = null
     private var backgroundDetachJob: Job? = null
+    private var lastSuppressedDropDiagnostic: SuppressedDropDiagnostic? = null
 
     // EPIC #687 slice 1c-iv-b-B1 (#738): the `preserveConnectingTarget` computed
     // SYNCHRONOUSLY by [detachForBackground] at background time, stashed for the
@@ -3700,6 +3735,11 @@ public class TmuxSessionViewModel @Inject constructor(
         passiveDisconnectGraceJob = null
         activeTarget = target
         connectingTarget = null
+        val suppressedDropDiagnostic = lastSuppressedDropDiagnostic
+        val originationCause =
+            suppressedDropDiagnostic?.cause ?: "within_grace_foreground_socket_drop"
+        val originationDiagnosticFields = suppressedDropDiagnosticFields(suppressedDropDiagnostic)
+        lastSuppressedDropDiagnostic = null
         Log.i(
             ISSUE_235_LIFECYCLE_TAG,
             "tmux-foreground-heal-within-grace generation=$connectGeneration " +
@@ -3708,16 +3748,18 @@ public class TmuxSessionViewModel @Inject constructor(
         ReconnectCauseTrail.record(
             stage = "foreground_reattach",
             outcome = "silent_heal_within_grace",
-            cause = "within_grace_foreground_socket_drop",
+            cause = originationCause,
             trigger = TmuxConnectTrigger.LifecycleReattach.logValue,
             "hostId" to target.hostId,
             "generation" to connectGeneration,
+            *originationDiagnosticFields,
         )
         DiagnosticEvents.record(
             "connection",
             "foreground_reattach",
             "source" to "app_lifecycle",
             "outcome" to "silent_heal_within_grace",
+            "cause" to originationCause,
             "trigger" to TmuxConnectTrigger.LifecycleReattach.logValue,
             "generation" to connectGeneration,
             "hostId" to target.hostId,
@@ -3725,6 +3767,7 @@ public class TmuxSessionViewModel @Inject constructor(
             "port" to target.port,
             "user" to target.user,
             "session" to target.sessionName,
+            *originationDiagnosticFields,
         )
         // Keep the displayed status CALM while we heal: the within-grace foreground is a
         // ride-through, not a reconnect. Promote the controller back toward Live so the
@@ -3756,6 +3799,10 @@ public class TmuxSessionViewModel @Inject constructor(
                     target = target,
                     reason = "Reattaching to ${target.user}@${target.host}:${target.port}.",
                     trigger = TmuxConnectTrigger.AutoReconnect,
+                    diagnosticFields = arrayOf(
+                        "originationCause" to originationCause,
+                        *originationDiagnosticFields,
+                    ),
                 )
             }
         }
@@ -5349,6 +5396,7 @@ public class TmuxSessionViewModel @Inject constructor(
         // stale cause from a previous attempt never influences the retry
         // decision. [failConnectAttempt] re-populates it if this one fails.
         lastConnectFailureCause = null
+        lastSuppressedDropDiagnostic = null
         try {
             val lease = acquireLeaseForTmux(target, attempt, trigger, startedAtMs)
                 ?: return
@@ -7121,6 +7169,12 @@ public class TmuxSessionViewModel @Inject constructor(
         // within-grace background. [isProcessBackgroundedForGraceOwner] flips at `ON_STOP`
         // regardless of grace, correctly identifying the within-grace background.
         if (isProcessBackgroundedForGraceOwner()) {
+            recordSuppressedDropDiagnostic(
+                suppressedDropDiagnosticFor(
+                    disconnectEvent = disconnectEvent,
+                    source = "passive_disconnect_deferred_to_grace_owner",
+                ),
+            )
             DiagnosticEvents.record(
                 "connection",
                 "passive_disconnect_deferred_to_grace_owner",

--- a/app/src/main/java/com/pocketshell/app/tmux/connection/ConnectionEffectDriver.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/connection/ConnectionEffectDriver.kt
@@ -153,6 +153,9 @@ import kotlinx.coroutines.launch
  * @param controlChannelDroppedEffect fired AFTER an accepted, unsuppressed current-control-channel
  *   drop has moved the controller. This is the typed effect edge for the VM's passive recovery IO;
  *   suppressed drops, rejected stale drops, and controller no-ops do not fire it.
+ * @param onDropSuppressed records the originating cause for a drop suppressed by
+ *   the single-grace-owner gate, so the later within-grace foreground heal can
+ *   export the real cause instead of a generic foreground placeholder.
  * @param sink where every observed transition is recorded. Defaults to logcat.
  */
 class ConnectionEffectDriver(
@@ -192,6 +195,7 @@ class ConnectionEffectDriver(
     // current host (the reconnect edge); the VM's effect is fail-soft + cheap, and
     // a blank trail is a no-op, so an extra fire never perturbs the connection.
     private val onTransportReconnected: () -> Unit = {},
+    private val onDropSuppressed: (SuppressedDropDiagnostic) -> Unit = {},
     private val sink: (String) -> Unit = { line -> Log.i(TAG, line) },
 ) {
     private val jobs = mutableListOf<Job>()
@@ -292,6 +296,7 @@ class ConnectionEffectDriver(
         drops.collect { client ->
             record(Observation.Disconnected(true))
             if (suppressTransportDrops()) {
+                onDropSuppressed(suppressedControlChannelDiagnostic(client))
                 record(Observation.DropSuppressed)
             } else if (shouldSubmitControlChannelDrop(client)) {
                 val wasTargetless = isTargetless()
@@ -322,6 +327,9 @@ class ConnectionEffectDriver(
                 // returns to a (controller-projected) disconnect band. Deferring leaves
                 // the channel-heal to the within-grace foreground (the single owner).
                 if (suppressTransportDrops()) {
+                    onDropSuppressed(
+                        SuppressedDropDiagnostic(cause = "control_channel_disconnected"),
+                    )
                     record(Observation.DropSuppressed)
                 } else {
                     submitTransport(
@@ -389,6 +397,15 @@ class ConnectionEffectDriver(
                             cause = edge.reason,
                         )
                         if (suppressTransportDrops()) {
+                            onDropSuppressed(
+                                SuppressedDropDiagnostic(
+                                    cause = edge.reason,
+                                    fields = mapOf(
+                                        "transportDropReason" to edge.reason,
+                                        "transportDropSource" to "lease_transport",
+                                    ),
+                                ),
+                            )
                             record(Observation.DropSuppressed)
                         } else {
                             submitTransport(
@@ -417,6 +434,25 @@ class ConnectionEffectDriver(
 
     private fun isTargetless(): Boolean =
         controller.state.value is ConnectionState.Idle
+
+    private fun suppressedControlChannelDiagnostic(client: TmuxClient): SuppressedDropDiagnostic {
+        val disconnectEvent = client.disconnectEvent.value
+        return SuppressedDropDiagnostic(
+            cause = disconnectEvent?.reason?.logValue ?: "control_channel_disconnected",
+            fields = buildMap {
+                put("transportDropSource", "control_channel")
+                if (disconnectEvent != null) {
+                    put("disconnectReason", disconnectEvent.reason.logValue)
+                    put("disconnectSource", disconnectEvent.source)
+                    put("disconnectIntent", disconnectEvent.intent)
+                    put("commandKind", disconnectEvent.commandKind)
+                    put("timeoutMode", disconnectEvent.timeoutMode)
+                    put("exceptionClass", disconnectEvent.exceptionClass)
+                    put("message", disconnectEvent.message)
+                }
+            },
+        )
+    }
 
     private fun record(observation: Observation) {
         _observations.value = _observations.value + observation
@@ -483,3 +519,8 @@ class ConnectionEffectDriver(
         const val TAG: String = "PsConnEffectDriver"
     }
 }
+
+data class SuppressedDropDiagnostic(
+    val cause: String,
+    val fields: Map<String, Any?> = emptyMap(),
+)

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
@@ -6,6 +6,7 @@ import com.pocketshell.app.cards.SessionCardsRemoteSource
 import com.pocketshell.app.connectivity.TerminalNetworkChange
 import com.pocketshell.app.connectivity.TerminalNetworkChangeKind
 import com.pocketshell.app.connectivity.TerminalNetworkSnapshot
+import com.pocketshell.app.diagnostics.ReconnectCauseTrail
 import com.pocketshell.app.diagnostics.installRecordingDiagnosticSink
 import com.pocketshell.app.hosts.MainDispatcherRule
 import com.pocketshell.app.projects.FolderListGateway
@@ -2322,6 +2323,79 @@ class TmuxSessionViewModelTest {
             diagnostics.close()
         }
     }
+
+    @Test
+    fun withinGraceForegroundHealExportsSuppressedDisconnectCauseToTrailAndFallback() =
+        runTest(scheduler) {
+            val diagnostics = installRecordingDiagnosticSink()
+            val registry = ActiveTmuxClients()
+            val vm = newVm(
+                registry = registry,
+                sshLeaseManager = testLeaseManager(
+                    connector = FailingLeaseConnector(SshException("synthetic heal failure")),
+                    scope = this,
+                    idleTtlMillis = 0L,
+                ),
+            )
+            vm.setPassiveDisconnectRecoveryForTest(graceMs = 1L, silentReattachTimeoutMs = 1L)
+            vm.setAutoReconnectDelaysForTest(listOf(60_000L))
+            try {
+                val backgroundDeadClient = FakeTmuxClient()
+                vm.replaceClientForTest(
+                    hostId = 7L,
+                    hostName = "alpha",
+                    host = "alpha.example",
+                    port = 22,
+                    user = "alex",
+                    keyPath = "/keys/a",
+                    sessionName = "work",
+                    client = backgroundDeadClient,
+                )
+                runCurrent()
+
+                vm.setProcessForegroundForClearedForTest(false)
+                backgroundDeadClient.markDisconnectedForTest(
+                    TmuxDisconnectEvent(
+                        reason = TmuxDisconnectReason.ReaderEof,
+                        source = "reader_loop",
+                        intent = "unexpected_eof",
+                    ),
+                )
+                runCurrent()
+
+                vm.setProcessForegroundForClearedForTest(true)
+                vm.onAppForegrounded(resumedWithinGrace = true)
+                runCurrent()
+                advanceTimeBy(1L)
+                runCurrent()
+
+                val healTrail = diagnostics.eventsNamed(ReconnectCauseTrail.NAME).single {
+                    it.fields["stage"] == "foreground_reattach" &&
+                        it.fields["outcome"] == "silent_heal_within_grace"
+                }
+                assertEquals("reader_eof", healTrail.fields["cause"])
+                assertEquals("reader_eof", healTrail.fields["disconnectReason"])
+                assertEquals("reader_loop", healTrail.fields["disconnectSource"])
+                assertEquals("unexpected_eof", healTrail.fields["disconnectIntent"])
+
+                val foregroundHeal = diagnostics.eventsNamed("foreground_reattach").single {
+                    it.fields["outcome"] == "silent_heal_within_grace"
+                }
+                assertEquals("reader_eof", foregroundHeal.fields["cause"])
+                assertEquals("reader_eof", foregroundHeal.fields["disconnectReason"])
+
+                val scheduledFallback = diagnostics.eventsNamed("auto_reconnect_decision").single {
+                    it.fields["decision"] == "scheduled" &&
+                        it.fields["cause"] == "retryable"
+                }
+                assertEquals("reader_eof", scheduledFallback.fields["originationCause"])
+                assertEquals("reader_eof", scheduledFallback.fields["disconnectReason"])
+                assertEquals("reader_loop", scheduledFallback.fields["disconnectSource"])
+            } finally {
+                vm.setProcessForegroundForClearedForTest(null)
+                diagnostics.close()
+            }
+        }
 
     @Test
     fun livenessProbeDeclaredDropClosesTheClientAndDrivesTheSingleReconnectEntrypoint() =

--- a/app/src/test/java/com/pocketshell/app/tmux/connection/ConnectionEffectDriverTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/connection/ConnectionEffectDriverTest.kt
@@ -21,6 +21,8 @@ import com.pocketshell.core.ssh.SshLeaseTarget
 import com.pocketshell.core.ssh.SshPortForward
 import com.pocketshell.core.ssh.SshSession
 import com.pocketshell.core.ssh.SshShell
+import com.pocketshell.core.tmux.TmuxDisconnectEvent
+import com.pocketshell.core.tmux.TmuxDisconnectReason
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
@@ -522,12 +524,14 @@ class ConnectionEffectDriverTest {
         val tmuxPort = InertTmuxPort()
         val transportPort = InertTransportPort(warm = true)
         val controller = ConnectionController(clock = TestClock(), transport = transportPort)
+        val suppressedDrops = mutableListOf<SuppressedDropDiagnostic>()
         val driver = ConnectionEffectDriver(
             controller = controller,
             tmuxPort = tmuxPort,
             transportPort = transportPort,
             scope = scope,
             suppressTransportDrops = { true }, // backgrounded under the NEW path
+            onDropSuppressed = { suppressedDrops += it },
         ).also { it.start() }
 
         // Drive to Live (warm enter: Attaching -> Live).
@@ -557,6 +561,53 @@ class ConnectionEffectDriverTest {
         assertTrue(
             "controller must remain Live (the single grace owner handles recovery)",
             controller.state.value is ConnectionState.Live,
+        )
+        assertEquals(
+            "untyped control-channel suppression must preserve its originating cause token",
+            listOf("control_channel_disconnected"),
+            suppressedDrops.map { it.cause },
+        )
+        scope.cancel()
+    }
+
+    @Test
+    fun suppressedTypedControlChannelDropPreservesDisconnectEventCause() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val tmuxPort = InertTmuxPort()
+        val transportPort = InertTransportPort(warm = true)
+        val controller = ConnectionController(clock = TestClock(), transport = transportPort)
+        val typedDrops = MutableSharedFlow<FakeTmuxClient>(extraBufferCapacity = 16)
+        val suppressedDrops = mutableListOf<SuppressedDropDiagnostic>()
+        val driver = ConnectionEffectDriver(
+            controller = controller,
+            tmuxPort = tmuxPort,
+            transportPort = transportPort,
+            scope = scope,
+            controlChannelDrops = typedDrops,
+            suppressTransportDrops = { true },
+            onDropSuppressed = { suppressedDrops += it },
+        ).also { it.start() }
+
+        controller.submit(ConnectionEvent.Enter(host, sessionA))
+        controller.submit(ConnectionEvent.SeedLanded(sessionA, paneId = "%0"))
+
+        val client = FakeTmuxClient()
+        client.disconnectEventSignal.value = TmuxDisconnectEvent(
+            reason = TmuxDisconnectReason.ReaderEof,
+            source = "reader_loop",
+            intent = "unexpected_eof",
+        )
+        typedDrops.emit(client)
+
+        val suppressed = suppressedDrops.single()
+        assertEquals("reader_eof", suppressed.cause)
+        assertEquals("reader_eof", suppressed.fields["disconnectReason"])
+        assertEquals("reader_loop", suppressed.fields["disconnectSource"])
+        assertEquals("unexpected_eof", suppressed.fields["disconnectIntent"])
+        assertEquals(
+            "a suppressed typed drop must NOT walk the controller off Live",
+            listOf("Idle", "Attaching", "Live"),
+            stateNamesOf(driver),
         )
         scope.cancel()
     }
@@ -731,12 +782,14 @@ class ConnectionEffectDriverTest {
         val tmuxPort = InertTmuxPort()
         val transportPort = InertTransportPort(warm = true)
         val controller = ConnectionController(clock = TestClock(), transport = transportPort)
+        val suppressedDrops = mutableListOf<SuppressedDropDiagnostic>()
         val driver = ConnectionEffectDriver(
             controller = controller,
             tmuxPort = tmuxPort,
             transportPort = transportPort,
             scope = scope,
             suppressTransportDrops = { true }, // backgrounded: single grace owner governs
+            onDropSuppressed = { suppressedDrops += it },
         ).also { it.start() }
 
         controller.submit(ConnectionEvent.Enter(host, sessionA))
@@ -746,7 +799,7 @@ class ConnectionEffectDriverTest {
         // A lease Down while backgrounded must be recorded as DropSuppressed and NOT
         // submitted — submitting it would collapse the controller toward Unreachable
         // while backgrounded (the #635 band on the next within-grace foreground).
-        transportPort.transportEventsFlow.emit(TransportUpDown.Down(host, reason = "closed"))
+        transportPort.transportEventsFlow.emit(TransportUpDown.Down(host, reason = "keepalive_dead"))
         assertTrue(
             "a suppressed lease Down must be recorded as DropSuppressed",
             driver.observations.value.any {
@@ -761,6 +814,11 @@ class ConnectionEffectDriverTest {
         assertTrue(
             "controller stays Live (single grace owner handles recovery)",
             controller.state.value is ConnectionState.Live,
+        )
+        assertEquals(
+            "suppressed lease Down must preserve the lease-originating cause token",
+            listOf("keepalive_dead"),
+            suppressedDrops.map { it.cause },
         )
         scope.cancel()
     }


### PR DESCRIPTION
Closes #978.\n\nWhat changed:\n- Captures suppressed single-grace-owner drop diagnostics for lease down and control-channel drops.\n- Carries the originating cause/fields into within-grace foreground heal records and fallback reconnect diagnostics.\n- Adds class coverage for lease keepalive, typed control-channel EOF, and VM foreground heal/fallback export.\n\nReviewed/approved on #978: https://github.com/alexeygrigorev/pocketshell/issues/978#issuecomment-4815626560\n\nLocal verification in a clean worktree:\n- ./gradlew :app:testDebugUnitTest --tests 'com.pocketshell.app.tmux.connection.ConnectionEffectDriverTest' --tests 'com.pocketshell.app.tmux.TmuxSessionViewModelTest'\n- git diff --check