### PR TITLE
refactor: reuse shared shell quoting helpers

### DIFF
--- a/app/src/main/java/com/pocketshell/app/fileexplorer/FileExplorerViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/fileexplorer/FileExplorerViewModel.kt
@@ -14,6 +14,7 @@ import com.pocketshell.core.ssh.SshNotADirectoryException
 import com.pocketshell.core.ssh.SshPermissionDeniedException
 import com.pocketshell.core.ssh.SshSession
 import com.pocketshell.core.ssh.SortField
+import com.pocketshell.core.ssh.shellSingleQuote
 import com.pocketshell.app.share.FilenameSanitiser
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CancellationException
@@ -430,8 +431,8 @@ class FileExplorerViewModel @Inject constructor(
      * then surfaces the listing error, which has the precise reason).
      */
     private suspend fun canonicalize(live: SshSession, path: String): String? {
-        val quoted = path.replace("'", "'\\''")
-        val result = runCatching { live.exec("cd '$quoted' 2>/dev/null && pwd -P") }.getOrNull()
+        val quoted = shellSingleQuote(path)
+        val result = runCatching { live.exec("cd $quoted 2>/dev/null && pwd -P") }.getOrNull()
         val out = result?.stdout?.trim()
         return out?.takeIf { result.exitCode == 0 && it.startsWith("/") }
     }

--- a/app/src/main/java/com/pocketshell/app/git/GitHistoryGateway.kt
+++ b/app/src/main/java/com/pocketshell/app/git/GitHistoryGateway.kt
@@ -2,6 +2,7 @@ package com.pocketshell.app.git
 
 import com.pocketshell.app.pocketshell.PocketshellCommand
 import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.shellSingleQuote
 import org.json.JSONException
 import org.json.JSONObject
 
@@ -427,7 +428,7 @@ class GitHistoryGateway(private val session: SshSession) {
 
         /** Single-quote a path for safe interpolation into a remote shell command. */
         internal fun quoteSingle(value: String): String =
-            "'" + value.replace("'", "'\\''") + "'"
+            shellSingleQuote(value)
 
         /**
          * Build the `gh issue create` command line for [dir] — issue #650. Pure

--- a/app/src/main/java/com/pocketshell/app/projects/ManualKindWriter.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/ManualKindWriter.kt
@@ -1,6 +1,7 @@
 package com.pocketshell.app.projects
 
 import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.shellSingleQuote
 import com.pocketshell.uikit.model.SessionAgentKind
 import com.pocketshell.uikit.model.tmuxOptionValue
 
@@ -50,7 +51,7 @@ internal object ManualKindWriter {
      */
     fun buildSetOptionCommand(sessionName: String, kind: SessionAgentKind): String? {
         val value = kind.tmuxOptionValue() ?: return null
-        return "tmux set-option -t ${shellQuote(sessionName)} @ps_agent_kind $value"
+        return "tmux set-option -t ${shellSingleQuote(sessionName)} @ps_agent_kind $value"
     }
 
     /**
@@ -79,7 +80,4 @@ internal object ManualKindWriter {
         }
     }
 
-    /** Single-quote a value for safe inclusion in a shell command. */
-    private fun shellQuote(value: String): String =
-        "'" + value.replace("'", "'\\''") + "'"
 }

--- a/app/src/main/java/com/pocketshell/app/projects/SessionTypePickerSheet.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/SessionTypePickerSheet.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.unit.dp
 import com.pocketshell.app.sessions.StartDirectoryAutocompleteController
 import com.pocketshell.app.sessions.StartDirectoryAutocompleteField
 import com.pocketshell.app.sessions.rememberStartDirectoryAutocompleteController
+import com.pocketshell.core.ssh.shellSingleQuote
 import com.pocketshell.uikit.components.ButtonVariant
 import com.pocketshell.uikit.components.ListRow
 import com.pocketshell.uikit.components.PocketShellButton
@@ -518,19 +519,15 @@ enum class AgentCli(val command: String) {
         ): String {
             val parts = StringBuilder("pocketshell agent ")
             parts.append(kind)
-            parts.append(" --dir ").append(shellQuote(directory))
+            parts.append(" --dir ").append(shellSingleQuote(directory))
             if (noSkipPermissions) {
                 parts.append(" --no-skip-permissions")
             }
             if (profileName != null) {
-                parts.append(" --profile ").append(shellQuote(profileName))
+                parts.append(" --profile ").append(shellSingleQuote(profileName))
             }
             return parts.toString()
         }
-
-        /** Single-quote a value for safe inclusion in a shell command. */
-        private fun shellQuote(value: String): String =
-            "'" + value.replace("'", "'\\''") + "'"
     }
 }
 


### PR DESCRIPTION
## Summary
- Reuse the shared shell quoting helpers across file explorer, git history, manual kind writing, and session type command construction.
- Keep existing behavior covered by focused unit tests.

## Verification
- ./gradlew :app:testDebugUnitTest --tests 'com.pocketshell.app.projects.ManualKindWriterTest' --tests 'com.pocketshell.app.projects.SessionTypeChoiceCommandTest' --tests 'com.pocketshell.app.git.*' --tests 'com.pocketshell.app.fileexplorer.*'\n- git diff --check\n\nCloses #684