### PR TITLE
docs: keep CI release validation tied to main

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -54,7 +54,9 @@ core, black screen, terminal/ANR, composer, tree, process learnings) →
   after each approved task.
 - Release tags come only after the version bump is committed to `main`, pushed,
   and confirmed with `HEAD == origin/main`; tags label stable reviewed `main`
-  commits.
+  commits. GitHub Actions validation summaries are acceptable release evidence
+  only when their `Commit SHA` equals the reviewed `origin/main` commit being
+  tagged.
 
 ## "Hetzner" — the maintainer's dev box
 

--- a/docs/docker-emulator-runbook.md
+++ b/docs/docker-emulator-runbook.md
@@ -407,7 +407,8 @@ release summary. The tested debug APK is included inside that artifact at
 written under `build/release-emulator-validation/<run-id>/app-debug.apk`.
 Inspect the visual-audit screenshots before using the artifact as release
 evidence. The manual workflow does not push the tag and does not relax the
-stable-main tag rule.
+stable-main tag rule. A GitHub Actions summary is taggable only when its
+`Commit SHA` equals the reviewed `origin/main` commit being tagged.
 
 ## APK Pre-Release Gate
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -566,7 +566,14 @@ That wrapper requires `HEAD == origin/main`, then runs the confidence gate,
 `scripts/phone-walkthrough.sh setup-detection`, and visual-audit screenshot
 capture. It writes `build/release-emulator-validation/<run-id>/summary.md`
 with the artifact directories that must be attached or linked in the issue and
-tag notes. Push the tag only through:
+tag notes.
+
+A GitHub Actions Release Emulator Validation summary is acceptable release
+evidence only when its `Commit SHA` is the commit being tagged. If the run was
+on a release branch and the merge to `main` changes the SHA, rerun validation
+on `main`.
+
+Push the tag only through:
 
 ```bash
 scripts/push-release-tag.sh --visual-audit-inspected <tag> build/release-emulator-validation/<run-id>/summary.md

--- a/process.md
+++ b/process.md
@@ -1176,7 +1176,9 @@ Release build steps:
    local `main` and confirm the checkout is clean and `HEAD` equals
    `origin/main` before creating or pushing any tag. A direct `main` push here
    is only allowed through the documented admin/emergency bypass.
-6. From that stable pushed `main`, run the emulator-only release validation:
+6. From that stable pushed `main`, run the emulator-only release validation.
+   Run it locally or through GitHub Actions, but the release summary must name
+   the exact commit that will be tagged:
    - `scripts/pre-release-confidence-gate.sh`
    - `scripts/phone-walkthrough.sh terminal-lab`
    - `scripts/phone-walkthrough.sh tmux-existing-session`
@@ -1201,7 +1203,10 @@ Manual Release Emulator Validation can also be run from GitHub Actions when a
 local emulator is unavailable:
 
 1. Open Actions -> Release Emulator Validation -> Run workflow.
-2. Choose the release branch or `main`; optionally provide a `run_id`.
+2. Choose `main` for taggable release evidence after the version bump PR has
+   merged. A release-branch run is pre-merge evidence unless that exact commit
+   becomes `origin/main`; if the merge changes the SHA, rerun validation on
+   `main`. Optionally provide a `run_id`.
 3. Wait for the workflow to finish, then read the job summary.
 4. Download the `release-emulator-validation-<run-id>` artifact for logs,
    screenshots, and the release summary.
@@ -1217,7 +1222,8 @@ local emulator is unavailable:
 The manual workflow is validation evidence only. It does not create or push the
 release tag, does not replace the guarded tag helper, and does not weaken the
 stable-main rule: the tag still must point at a reviewed commit already pushed
-to `main`.
+to `main`. Before tagging, confirm the downloaded summary's `Commit SHA` equals
+the reviewed `origin/main` commit.
 
 The release issue and tag notes must attach or link all emulator-only evidence
 directories:


### PR DESCRIPTION
## Summary
- Clarify that GitHub Actions Release Emulator Validation can be release evidence only when its summary commit is the commit being tagged.
- Keep release tags anchored to reviewed `origin/main` instead of RC-only commits.
- Mirror the stable-main rule across process, testing, Docker runbook, and agent quick rules.

## Verification
- git diff --check
- stylint process.md docs/testing.md docs/docker-emulator-runbook.md agents.md (reports pre-existing findings across these docs; no broad cleanup included)

Replaces #934