### PR TITLE
ssh: make tmux control writes cancellable

### DIFF
--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshShell.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshShell.kt
@@ -72,6 +72,17 @@ internal class RealSshShell(
     override val stderr: InputStream
         get() = activityStderr
 
+    override suspend fun writeStdin(bytes: ByteArray) {
+        // The tmux control client is coroutine/cancellation driven. Use the
+        // suspending dispatcher path so cancellation while queued behind another
+        // transport op removes the waiter instead of parking a Dispatchers.IO
+        // thread inside runBlockingDispatch.
+        dispatcher.run {
+            shell.outputStream.write(bytes)
+            shell.outputStream.flush()
+        }
+    }
+
     override fun close() {
         // Order matters: close the shell-level resource first so any in-flight
         // `read` returns -1 promptly, then drop the parent session channel.

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshShell.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshShell.kt
@@ -1,5 +1,7 @@
 package com.pocketshell.core.ssh
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runInterruptible
 import java.io.InputStream
 import java.io.OutputStream
 
@@ -44,6 +46,21 @@ public interface SshShell : AutoCloseable {
      * non-PTY callers can read it independently.
      */
     public val stderr: InputStream
+
+    /**
+     * Coroutine-friendly stdin write for control-channel callers that need
+     * cancellation to unpark a queued/blocking write. The default preserves the
+     * blocking-stream contract for test doubles and simple implementations; the
+     * sshj-backed shell overrides this to route through its suspending
+     * transport dispatcher without parking a caller IO thread behind the
+     * dispatcher's mutex.
+     */
+    public suspend fun writeStdin(bytes: ByteArray) {
+        runInterruptible(Dispatchers.IO) {
+            stdin.write(bytes)
+            stdin.flush()
+        }
+    }
 
     /**
      * Tear down the shell channel. Idempotent. Subsequent reads on the

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshShellWriteCancellationTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshShellWriteCancellationTest.kt
@@ -1,0 +1,114 @@
+package com.pocketshell.core.ssh
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import net.schmizz.sshj.connection.channel.direct.Session
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.ByteArrayInputStream
+import java.io.InputStream
+import java.io.OutputStream
+import java.lang.reflect.InvocationHandler
+import java.lang.reflect.Method
+import java.lang.reflect.Proxy
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Issue #935 H1: tmux command writes must be cancellable while queued behind
+ * another transport operation. The old tmux path called [SshShell.stdin] from
+ * `Dispatchers.IO`; for [RealSshShell] that entered `runBlockingDispatch`, so a
+ * cancelled command could leave an IO worker parked behind the dispatch mutex
+ * until the current transport op finished.
+ */
+class RealSshShellWriteCancellationTest {
+
+    @Test
+    fun `writeStdin cancellation while queued behind dispatcher mutex does not write later`() =
+        runBlocking {
+            val dispatcher = TransportDispatcher(perOpTimeoutMs = 5_000L)
+            val holderEntered = CountDownLatch(1)
+            val releaseHolder = CountDownLatch(1)
+            val writtenBytes = AtomicInteger(0)
+            val output = object : OutputStream() {
+                override fun write(b: Int) {
+                    writtenBytes.incrementAndGet()
+                }
+
+                override fun write(b: ByteArray, off: Int, len: Int) {
+                    writtenBytes.addAndGet(len)
+                }
+            }
+            val shell = RealSshShell(
+                sessionChannel = noopSession(),
+                shell = shellWithOutput(output),
+                dispatcher = dispatcher,
+            )
+
+            val holder = async(Dispatchers.IO) {
+                dispatcher.run {
+                    holderEntered.countDown()
+                    releaseHolder.await()
+                }
+            }
+            assertTrue("holder must acquire the dispatcher mutex", holderEntered.await(5, TimeUnit.SECONDS))
+
+            val writer = async(Dispatchers.IO) {
+                shell.writeStdin("queued-write\n".toByteArray(Charsets.UTF_8))
+            }
+            delay(100)
+
+            writer.cancelAndJoin()
+            releaseHolder.countDown()
+            holder.await()
+            delay(100)
+
+            assertEquals(
+                "a cancelled queued write must be removed from the dispatcher wait queue",
+                0,
+                writtenBytes.get(),
+            )
+            dispatcher.closeAndAwaitDrain { }
+        }
+
+    private fun shellWithOutput(output: OutputStream): Session.Shell =
+        proxy(Session.Shell::class.java) { _, method, _ ->
+            when (method.name) {
+                "getOutputStream" -> output
+                "getInputStream", "getErrorStream" -> ByteArrayInputStream(ByteArray(0))
+                else -> defaultReturn(method)
+            }
+        }
+
+    private fun noopSession(): Session =
+        proxy(Session::class.java) { _, method, _ -> defaultReturn(method) }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T> proxy(type: Class<T>, handler: InvocationHandler): T =
+        Proxy.newProxyInstance(
+            type.classLoader,
+            arrayOf(type),
+            handler,
+        ) as T
+
+    private fun defaultReturn(method: Method): Any? =
+        when (method.returnType) {
+            java.lang.Boolean.TYPE -> false
+            java.lang.Byte.TYPE -> 0.toByte()
+            java.lang.Short.TYPE -> 0.toShort()
+            java.lang.Integer.TYPE -> 0
+            java.lang.Long.TYPE -> 0L
+            java.lang.Float.TYPE -> 0f
+            java.lang.Double.TYPE -> 0.0
+            java.lang.Character.TYPE -> 0.toChar()
+            java.lang.Void.TYPE -> null
+            InputStream::class.java -> ByteArrayInputStream(ByteArray(0))
+            OutputStream::class.java -> OutputStream.nullOutputStream()
+            else -> null
+        }
+}

--- a/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxClient.kt
+++ b/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxClient.kt
@@ -33,7 +33,6 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
-import java.io.OutputStream
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedDeque
 import java.util.concurrent.atomic.AtomicBoolean
@@ -981,8 +980,7 @@ internal class RealTmuxClient(
                 append('\n')
             }
             withContext(Dispatchers.IO) {
-                sh.stdin.write(command.toByteArray(Charsets.UTF_8))
-                sh.stdin.flush()
+                sh.writeStdin(command.toByteArray(Charsets.UTF_8))
             }
         } catch (t: Throwable) {
             readerJob?.cancel()
@@ -1087,7 +1085,7 @@ internal class RealTmuxClient(
             val writeResult = CompletableDeferred<Unit>()
             val writeJob = clientScope.launch {
                 try {
-                    writeLine(sh.stdin, chained)
+                    writeLine(sh, chained)
                     writeResult.complete(Unit)
                 } catch (t: Throwable) {
                     writeResult.completeExceptionally(t)
@@ -1259,7 +1257,7 @@ internal class RealTmuxClient(
             val writeResult = CompletableDeferred<Unit>()
             val writeJob = clientScope.launch {
                 try {
-                    writeLine(sh.stdin, chained)
+                    writeLine(sh, chained)
                     writeResult.complete(Unit)
                 } catch (t: Throwable) {
                     writeResult.completeExceptionally(t)
@@ -1364,7 +1362,7 @@ internal class RealTmuxClient(
             val writeResult = CompletableDeferred<Unit>()
             val writeJob = clientScope.launch {
                 try {
-                    writeLine(sh.stdin, cmd)
+                    writeLine(sh, cmd)
                     writeResult.complete(Unit)
                 } catch (t: Throwable) {
                     writeResult.completeExceptionally(t)
@@ -2083,12 +2081,9 @@ internal class RealTmuxClient(
      * needs. Flushes so the bytes hit the wire immediately (sshj uses a
      * buffered output stream under the hood).
      */
-    private suspend fun writeLine(stdin: OutputStream, line: String) =
-        withContext(Dispatchers.IO) {
-            stdin.write(line.toByteArray(Charsets.UTF_8))
-            stdin.write('\n'.code)
-            stdin.flush()
-        }
+    private suspend fun writeLine(shell: SshShell, line: String) {
+        shell.writeStdin("$line\n".toByteArray(Charsets.UTF_8))
+    }
 
     private companion object {
         private const val DEFAULT_SESSION_NAME = "pocketshell"


### PR DESCRIPTION
## Summary
- Add a cancellable `SshShell.writeStdin` path for coroutine control-channel writers.
- Route tmux control writes through the suspending ssh transport dispatcher instead of parking IO threads behind `runBlockingDispatch`.
- Add a regression test for cancelling a queued write before the dispatcher mutex opens.

## Verification
- ./gradlew :shared:core-ssh:testDebugUnitTest --tests 'com.pocketshell.core.ssh.TransportDispatcherTest' --tests 'com.pocketshell.core.ssh.TransportDispatcherWedgeBoundTest' --tests 'com.pocketshell.core.ssh.RealSshShellWriteCancellationTest' --tests 'com.pocketshell.core.ssh.RealSshShellCloseOffMainTest'\n- ./gradlew :shared:core-tmux:testDebugUnitTest --tests 'com.pocketshell.core.tmux.TmuxClientTest'\n- ./gradlew :shared:core-ssh:testReleaseUnitTest --tests 'com.pocketshell.core.ssh.RealSshShellWriteCancellationTest'\n- ./gradlew :shared:core-tmux:testReleaseUnitTest --tests 'com.pocketshell.core.tmux.TmuxClientTest'\n- git diff --check\n\nRefs #935