### PR TITLE
ui: add shared navigation chevron

### DIFF
--- a/app/src/main/java/com/pocketshell/app/costs/CostsScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/costs/CostsScreen.kt
@@ -39,6 +39,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.pocketshell.uikit.components.ButtonVariant
 import com.pocketshell.uikit.components.ConfirmDialog
 import com.pocketshell.uikit.components.ListRow
+import com.pocketshell.uikit.components.NavigationChevron
 import com.pocketshell.uikit.components.PocketShellButton
 import com.pocketshell.uikit.components.ScreenHeader
 import com.pocketshell.uikit.components.SectionHeader
@@ -404,8 +405,8 @@ private fun ActionsSection(onExportCsv: () -> Unit, onClearLog: () -> Unit) {
 
 /**
  * An "Export CSV" / "Clear log" action row. Mirrors the Settings nav-row pattern
- * (#479 Slice C1/D): the actionable line is the shared [ListRow] with a `›`
- * disclosure chevron in the [trailing] slot, and the prose description renders
+ * (#479 Slice C1/D): the actionable line is the shared [ListRow] with a
+ * navigation chevron in the [trailing] slot, and the prose description renders
  * below it on the `labelSmall`(11) caption rung (mono [ListRow] subtitles are
  * reserved for paths/IDs, so a prose description does not belong in that slot).
  */
@@ -414,12 +415,7 @@ private fun ActionRow(label: String, description: String, testTag: String, onCli
     ListRow(
         title = label,
         trailing = {
-            Text(
-                text = "›",
-                color = PocketShellColors.TextSecondary,
-                style = PocketShellType.bodyDense,
-                fontWeight = FontWeight.Bold,
-            )
+            NavigationChevron()
         },
         onClick = onClick,
         modifier = Modifier.testTag(testTag),

--- a/app/src/main/java/com/pocketshell/app/fileexplorer/FileExplorerScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/fileexplorer/FileExplorerScreen.kt
@@ -51,6 +51,7 @@ import com.pocketshell.uikit.components.FileIconClass
 import com.pocketshell.uikit.components.FileTypeIcon
 import com.pocketshell.uikit.components.ListRow
 import com.pocketshell.uikit.components.LoadingIndicator
+import com.pocketshell.uikit.components.NavigationChevron
 import com.pocketshell.uikit.components.PocketShellButton
 import com.pocketshell.uikit.components.ScreenHeader
 import com.pocketshell.uikit.components.SectionHeader
@@ -573,7 +574,7 @@ private fun ReadyPanel(
                     title = "..",
                     subtitle = "Parent folder",
                     leading = { FileTypeIcon(iconClass = FileIconClass.FOLDER) },
-                    trailing = { Chevron() },
+                    trailing = { RowNavigationChevron() },
                     onClick = onUp,
                     modifier = Modifier.testTag(FILE_EXPLORER_UP_TAG),
                 )
@@ -620,7 +621,7 @@ private fun ReadyPanel(
                     }
                 }
             } else {
-                { Chevron() }
+                { RowNavigationChevron() }
             }
             ListRow(
                 title = entry.name,
@@ -671,16 +672,12 @@ private fun StatusGlyphCell(glyph: String) {
 
 /** The navigational chevron in the trailing slot for a folder / symlink row. */
 @Composable
-private fun Chevron() {
+private fun RowNavigationChevron() {
     Box(
         modifier = Modifier.size(PocketShellDensity.tapTargetMin),
         contentAlignment = Alignment.Center,
     ) {
-        Text(
-            text = "›",
-            color = PocketShellColors.TextMuted,
-            style = MaterialTheme.typography.titleMedium,
-        )
+        NavigationChevron(tint = PocketShellColors.TextMuted)
     }
 }
 

--- a/app/src/main/java/com/pocketshell/app/projects/FolderContextActionSheet.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderContextActionSheet.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.pocketshell.uikit.components.ButtonVariant
 import com.pocketshell.uikit.components.ListRow
+import com.pocketshell.uikit.components.NavigationChevron
 import com.pocketshell.uikit.components.PocketShellButton
 import com.pocketshell.uikit.components.SectionHeader
 import com.pocketshell.uikit.components.SheetHeader
@@ -169,12 +170,7 @@ private fun FolderContextRow(
             subtitle = description,
             onClick = onClick,
             trailing = {
-                Text(
-                    text = "›",
-                    color = PocketShellColors.TextSecondary,
-                    style = PocketShellType.bodyDense,
-                    fontWeight = FontWeight.SemiBold,
-                )
+                NavigationChevron()
             },
         )
     }

--- a/app/src/main/java/com/pocketshell/app/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/settings/SettingsScreen.kt
@@ -59,6 +59,7 @@ import com.pocketshell.core.assistant.AssistantProvider
 import com.pocketshell.core.terminal.ui.TerminalKeyboardMode
 import com.pocketshell.uikit.components.ButtonVariant
 import com.pocketshell.uikit.components.ListRow
+import com.pocketshell.uikit.components.NavigationChevron
 import com.pocketshell.uikit.components.PocketShellButton
 import com.pocketshell.uikit.components.ScreenHeader
 import com.pocketshell.uikit.components.SectionHeader
@@ -454,25 +455,8 @@ private fun SectionCard(content: @Composable ColumnScope.() -> Unit) {
 }
 
 /**
- * The right-aligned `›` disclosure chevron carried by every navigation row
- * (Import host, Usage, Crash reports, …). Tokenised onto
- * [PocketShellType.bodyDense] so the glyph rides the dense-row type rung
- * instead of a raw `22.sp` literal (#479 Slice D); the muted secondary
- * colour keeps it quiet next to the row title.
- */
-@Composable
-private fun NavChevron() {
-    Text(
-        text = "›",
-        color = PocketShellColors.TextSecondary,
-        style = PocketShellType.bodyDense,
-        fontWeight = FontWeight.Bold,
-    )
-}
-
-/**
  * A disclosure navigation row inside a [SectionCard] — title + optional
- * prose description + a right-aligned `›` chevron that routes deeper
+ * prose description + a right-aligned navigation chevron that routes deeper
  * (Import host, Usage & quota, Crash reports). The actionable line is the
  * shared [ListRow] so the row inherits the design language's dense
  * 44/8/12 density and the 48dp touch floor (#479 Slice D); the prose
@@ -489,7 +473,7 @@ private fun SettingsNavRow(
 ) {
     ListRow(
         title = title,
-        trailing = { NavChevron() },
+        trailing = { NavigationChevron() },
         onClick = onClick,
         modifier = Modifier.testTag(testTag),
     )
@@ -1771,7 +1755,7 @@ private fun DiagnosticsSection(
                 } else {
                     "Share diagnostics JSONL"
                 },
-                trailing = { NavChevron() },
+                trailing = { NavigationChevron() },
                 onClick = {
                     if (shareState !is DiagnosticsShareState.Preparing) {
                         onShareLog()
@@ -1888,7 +1872,7 @@ private fun WorkspaceRootsSection(
                     ListRow(
                         title = host.name,
                         subtitle = "${host.username}@${host.hostname}:${host.port}",
-                        trailing = { NavChevron() },
+                        trailing = { NavigationChevron() },
                         onClick = { onPickHost(host.id, host.name) },
                         modifier = Modifier.testTag(watchedFoldersSettingsHostRowTag(host.id)),
                     )

--- a/app/src/test/java/com/pocketshell/app/ui/NavigationChevronAdoptionTest.kt
+++ b/app/src/test/java/com/pocketshell/app/ui/NavigationChevronAdoptionTest.kt
@@ -1,0 +1,72 @@
+package com.pocketshell.app.ui
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * Issue #756 follow-up: drill-in/navigation rows use the shared
+ * NavigationChevron, while DisclosureIcon remains expand/collapse-only.
+ */
+class NavigationChevronAdoptionTest {
+
+    @Test
+    fun fileExplorerUsesSharedNavigationChevronForEntryRows() {
+        val src = locate("fileexplorer/FileExplorerScreen.kt")
+        val rowChevron = src.substringFrom("private fun RowNavigationChevron()")
+
+        assertTrue(src.contains("import com.pocketshell.uikit.components.NavigationChevron"))
+        assertTrue(rowChevron.contains("NavigationChevron("))
+        assertFalse("FileExplorer must not keep the old private Chevron helper", src.contains("private fun Chevron()"))
+    }
+
+    @Test
+    fun settingsUsesSharedNavigationChevronForNavigationRows() {
+        val src = locate("settings/SettingsScreen.kt")
+
+        assertTrue(src.contains("import com.pocketshell.uikit.components.NavigationChevron"))
+        assertTrue(
+            "Settings navigation rows should use the shared chevron in trailing content",
+            src.countNavigationChevronTrailing() >= 2,
+        )
+        assertFalse("Settings must not keep the old raw-glyph NavChevron helper", src.contains("fun NavChevron()"))
+        assertFalse("Settings navigation rows must not use raw guillemet Text", src.hasRawRightGuillemetText())
+    }
+
+    @Test
+    fun folderContextAndCostsRowsDoNotUseRawRightGuillemet() {
+        val folderContext = locate("projects/FolderContextActionSheet.kt")
+        val costs = locate("costs/CostsScreen.kt")
+
+        assertTrue(folderContext.contains("import com.pocketshell.uikit.components.NavigationChevron"))
+        assertTrue(folderContext.contains("NavigationChevron()"))
+        assertFalse(folderContext.hasRawRightGuillemetText())
+
+        assertTrue(costs.contains("import com.pocketshell.uikit.components.NavigationChevron"))
+        assertTrue(costs.contains("NavigationChevron()"))
+        assertFalse(costs.hasRawRightGuillemetText())
+    }
+
+    private fun String.countNavigationChevronTrailing(): Int =
+        Regex("""trailing\s*=\s*\{\s*NavigationChevron\s*\(""").findAll(this).count()
+
+    private fun String.hasRawRightGuillemetText(): Boolean =
+        Regex("""Text\s*\(\s*(?:text\s*=\s*)?"›"""").containsMatchIn(this)
+
+    private fun String.substringFrom(marker: String): String {
+        val start = indexOf(marker)
+        assertTrue("$marker not found", start >= 0)
+        return substring(start, minOf(start + 800, length))
+    }
+
+    private fun locate(relative: String): String {
+        val candidates = listOf(
+            File("app/src/main/java/com/pocketshell/app/$relative"),
+            File("src/main/java/com/pocketshell/app/$relative"),
+        )
+        val file = candidates.firstOrNull { it.isFile }
+            ?: error("Could not locate $relative from ${File(".").absolutePath}")
+        return file.readText()
+    }
+}

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -417,8 +417,9 @@ Don't:
 - Hand-roll a `Text("›")` / `Text("v")` glyph pair, or draw two separate
   triangle `Path`s for the two states — that is the #840 "two different icons"
   bug. Hard-cut (D22): there is no second disclosure affordance.
-- Confuse it with the navigation drill-in chevron (`›` on nav `ListRow`s) or the
-  dropdown trigger (`▾`) — those are different, deliberate affordances.
+- Confuse it with the navigation drill-in chevron (`NavigationChevron` on nav
+  `ListRow`s) or the dropdown trigger (`▾`) — those are different, deliberate
+  affordances.
 
 ### Empty, Loading, And Error States
 

--- a/shared/ui-kit/src/main/java/com/pocketshell/uikit/components/NavigationChevron.kt
+++ b/shared/ui-kit/src/main/java/com/pocketshell/uikit/components/NavigationChevron.kt
@@ -1,0 +1,54 @@
+package com.pocketshell.uikit.components
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.pocketshell.uikit.theme.PocketShellColors
+
+/**
+ * Shared drill-in/navigation affordance for rows that route to another screen,
+ * sheet, or folder. This is deliberately separate from [DisclosureIcon], whose
+ * contract is expand/collapse only.
+ */
+@Composable
+fun NavigationChevron(
+    modifier: Modifier = Modifier,
+    tint: Color = PocketShellColors.TextSecondary,
+    size: Dp = NavigationChevronDefaultSize,
+    strokeWidth: Dp = NavigationChevronStrokeWidth,
+) {
+    Canvas(modifier = modifier.size(size)) {
+        val strokePx = strokeWidth.toPx()
+        val lineStyle = Stroke(width = strokePx, cap = StrokeCap.Round)
+        val startX = this.size.width * 0.38f
+        val endX = this.size.width * 0.62f
+        val topY = this.size.height * 0.26f
+        val midY = this.size.height * 0.50f
+        val bottomY = this.size.height * 0.74f
+
+        drawLine(
+            color = tint,
+            start = Offset(startX, topY),
+            end = Offset(endX, midY),
+            strokeWidth = lineStyle.width,
+            cap = lineStyle.cap,
+        )
+        drawLine(
+            color = tint,
+            start = Offset(endX, midY),
+            end = Offset(startX, bottomY),
+            strokeWidth = lineStyle.width,
+            cap = lineStyle.cap,
+        )
+    }
+}
+
+val NavigationChevronDefaultSize: Dp = 18.dp
+val NavigationChevronStrokeWidth: Dp = 2.dp

--- a/shared/ui-kit/src/test/java/com/pocketshell/uikit/components/NavigationChevronTest.kt
+++ b/shared/ui-kit/src/test/java/com/pocketshell/uikit/components/NavigationChevronTest.kt
@@ -1,0 +1,60 @@
+package com.pocketshell.uikit.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertHeightIsEqualTo
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertWidthIsEqualTo
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.dp
+import com.pocketshell.uikit.theme.PocketShellTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(qualifiers = "w412dp-h915dp-night-xxhdpi")
+class NavigationChevronTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun rendersWithDefaultFootprint() {
+        composeRule.setContent {
+            PocketShellTheme {
+                NavigationChevron(modifier = Modifier.testTag("nav-chevron"))
+            }
+        }
+
+        composeRule.onNodeWithTag("nav-chevron")
+            .assertIsDisplayed()
+            .assertWidthIsEqualTo(NavigationChevronDefaultSize)
+            .assertHeightIsEqualTo(NavigationChevronDefaultSize)
+    }
+
+    @Test
+    fun callerCanWrapInRowTouchTargetWithoutChangingIconSize() {
+        composeRule.setContent {
+            PocketShellTheme {
+                Box(modifier = Modifier.size(48.dp).testTag("touch-target")) {
+                    NavigationChevron(modifier = Modifier.testTag("nav-chevron"))
+                }
+            }
+        }
+
+        composeRule.onNodeWithTag("touch-target")
+            .assertWidthIsEqualTo(48.dp)
+            .assertHeightIsEqualTo(48.dp)
+        composeRule.onNodeWithTag("nav-chevron")
+            .assertWidthIsEqualTo(NavigationChevronDefaultSize)
+            .assertHeightIsEqualTo(NavigationChevronDefaultSize)
+    }
+}

--- a/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenders.kt
+++ b/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenders.kt
@@ -61,6 +61,7 @@ import com.pocketshell.uikit.components.FileTypeIcon
 import com.pocketshell.uikit.components.HostCard
 import com.pocketshell.uikit.components.ListRow
 import com.pocketshell.uikit.components.LoadingIndicator
+import com.pocketshell.uikit.components.NavigationChevron
 import com.pocketshell.uikit.components.SpinnerSize
 import com.pocketshell.uikit.components.ButtonVariant
 import com.pocketshell.uikit.components.Pill
@@ -3654,11 +3655,7 @@ class DesignRenders {
     @Composable
     private fun FileExplorerChevron() {
         Box(modifier = Modifier.size(48.dp), contentAlignment = Alignment.Center) {
-            Text(
-                text = "›",
-                color = PocketShellColors.TextMuted,
-                fontSize = 18.sp,
-            )
+            NavigationChevron(tint = PocketShellColors.TextMuted)
         }
     }
 


### PR DESCRIPTION
## Summary
- Add a shared `NavigationChevron` for drill-in/navigation rows, separate from expand/collapse-only `DisclosureIcon`.
- Replace migrated raw navigation `›` glyphs in costs, file explorer rows, folder context actions, and settings.
- Add component/adoption tests and update the design-system guidance.

## Verification
- ./gradlew :shared:ui-kit:testDebugUnitTest --tests com.pocketshell.uikit.components.NavigationChevronTest
- ./gradlew :app:testDebugUnitTest --tests com.pocketshell.app.ui.NavigationChevronAdoptionTest
- ./gradlew :app:compileDebugKotlin :shared:ui-kit:compileDebugKotlin
- git diff --check

Refs #756