### PR TITLE
agents: record launched transcript source

### DIFF
--- a/app/src/main/java/com/pocketshell/app/session/AgentConversationRepository.kt
+++ b/app/src/main/java/com/pocketshell/app/session/AgentConversationRepository.kt
@@ -419,6 +419,81 @@ public class AgentConversationRepository internal constructor(
     }
 
     /**
+     * Issue #821 branch 1: read the exact transcript source PocketShell recorded
+     * for this tmux session (`@ps_agent_source`). It is optional and best-effort:
+     * legacy sessions and old host CLIs simply return `null`, which keeps the
+     * existing source selector unchanged.
+     */
+    suspend fun readRecordedAgentSource(
+        session: SshSession,
+        sessionTarget: String,
+    ): String? = readRecordedAgentSourceOption(session, sessionTarget).source
+
+    data class RecordedAgentSourceOption(
+        val source: String?,
+        val generationScoped: Boolean,
+    )
+
+    suspend fun readRecordedAgentSourceOption(
+        session: SshSession,
+        sessionTarget: String,
+    ): RecordedAgentSourceOption {
+        val target = sessionTarget.trim().ifBlank {
+            return RecordedAgentSourceOption(source = null, generationScoped = false)
+        }
+        val generationSentinel = "@@PS_RECORDED_SOURCE_GENERATION@@"
+        val raw = runCatching {
+            session.exec(
+                "ps_recorded_source_generation=\$(" +
+                    "tmux show-options -v -t ${shellQuote(target)} @ps_agent_source_generation 2>/dev/null || true" +
+                    "); printf '%s\\n' \"\$ps_recorded_source_generation\"; " +
+                    "printf '%s\\n' $generationSentinel; " +
+                    "tmux show-options -v -t ${shellQuote(target)} @ps_agent_source 2>/dev/null || true",
+            ).stdout
+        }.getOrNull() ?: return RecordedAgentSourceOption(source = null, generationScoped = false)
+        val lines = raw.split("\n")
+        val generationIndex = lines.indexOf(generationSentinel)
+        val generation = if (generationIndex >= 0) {
+            lines.take(generationIndex).joinToString("\n").trim().ifBlank { null }
+        } else {
+            null
+        }
+        val sourceRaw = if (generationIndex >= 0) {
+            lines.drop(generationIndex + 1).joinToString("\n")
+        } else {
+            raw
+        }
+        return recordedAgentSourceOptionFromRaw(sourceRaw, generation)
+    }
+
+    internal fun recordedAgentSourceOptionFromRaw(
+        raw: String?,
+        generation: String? = null,
+    ): RecordedAgentSourceOption {
+        val value = raw?.trim()?.takeIf { it.isNotEmpty() }
+            ?: return RecordedAgentSourceOption(source = null, generationScoped = false)
+        val currentGeneration = generation?.trim().orEmpty()
+        val parts = value.split("\t", limit = 2)
+        if (parts.size == 2 && parts[0].isNotBlank()) {
+            if (currentGeneration.isNotEmpty() && parts[0] != currentGeneration) {
+                return RecordedAgentSourceOption(source = null, generationScoped = false)
+            }
+            val source = parts[1].trim().takeIf { it.isNotEmpty() }
+            return RecordedAgentSourceOption(
+                source = source,
+                generationScoped = source != null && currentGeneration.isNotEmpty(),
+            )
+        }
+        if (currentGeneration.isNotEmpty()) {
+            return RecordedAgentSourceOption(source = null, generationScoped = false)
+        }
+        return RecordedAgentSourceOption(source = value, generationScoped = false)
+    }
+
+    internal fun recordedAgentSourceFromOption(raw: String?, generation: String? = null): String? =
+        recordedAgentSourceOptionFromRaw(raw, generation).source
+
+    /**
      * Epic #821 slice #3 (#825): map a raw `@ps_agent_kind` option value to an
      * [AgentKind]. The launch wrapper writes the lowercase engine token
      * (`claude` / `codex` / `opencode`); anything else (blank, a foreign
@@ -473,6 +548,7 @@ public class AgentConversationRepository internal constructor(
         paneTty: String,
         paneCommand: String,
         recordedKind: AgentKind,
+        recordedSource: String? = null,
     ): AgentDetection? {
         val normalizedCwd = cwd.trim().ifBlank { return null }
         val normalizedTty = paneTty.trim().ifBlank { return null }
@@ -491,6 +567,7 @@ public class AgentConversationRepository internal constructor(
             normalizedTty = normalizedTty,
             paneCommand = paneCommand,
             recordedKind = recordedKind,
+            recordedSource = recordedSource,
             candidates = candidates,
         )
     }
@@ -549,6 +626,7 @@ public class AgentConversationRepository internal constructor(
             normalizedTty = normalizedTty,
             paneCommand = paneCommand,
             recordedKind = recordedKind,
+            recordedSource = null,
             candidates = candidates.filter { it.agent == recordedKind },
         )
     }
@@ -570,9 +648,17 @@ public class AgentConversationRepository internal constructor(
         normalizedTty: String,
         paneCommand: String,
         recordedKind: AgentKind,
+        recordedSource: String?,
         candidates: List<AgentLogCandidate>,
     ): AgentDetection? {
         val nowMillis = System.currentTimeMillis()
+        if (recordedKind != AgentKind.Codex) {
+            exactRecordedSourceDetection(
+                recordedKind = recordedKind,
+                recordedSource = recordedSource,
+                candidates = candidates,
+            )?.let { return it }
+        }
         // Issue #828 (perf): the process scan is ONLY load-bearing for the
         // recorded-Codex path — it feeds the `/proc/<pid>/fd` owned-rollout
         // resolution that disambiguates same-cwd Codex siblings (#819) and the
@@ -647,6 +733,22 @@ public class AgentConversationRepository internal constructor(
         )
     }
 
+    private fun exactRecordedSourceDetection(
+        recordedKind: AgentKind,
+        recordedSource: String?,
+        candidates: List<AgentLogCandidate>,
+    ): AgentDetection? {
+        val source = recordedSource?.trim()?.takeIf { it.isNotEmpty() } ?: return null
+        val candidate = candidates.firstOrNull { it.agent == recordedKind && it.path == source }
+            ?: return null
+        return AgentDetection(
+            agent = recordedKind,
+            sourcePath = candidate.path,
+            sessionId = candidate.sessionId ?: candidate.path.substringAfterLast('/').substringBeforeLast('.'),
+            confidence = AgentDetection.Confidence.RecentFile,
+        )
+    }
+
     /**
      * Issue #819: a pane-owned Codex process can hold open a rollout that the
      * normal `find -mmin -120` enumeration skipped because Codex has been idle
@@ -703,6 +805,8 @@ public class AgentConversationRepository internal constructor(
      */
     data class RecordedSessionOpen(
         val recordedKind: AgentKind?,
+        val recordedSource: String?,
+        val recordedSourceGenerationScoped: Boolean,
         val detection: AgentDetection?,
         val needsCodexResolution: Boolean,
         val prefetchedWindow: ConversationEventsWindow? = null,
@@ -751,9 +855,17 @@ public class AgentConversationRepository internal constructor(
         val normalizedCwd = cwd.trim()
         val normalizedTty = paneTty.trim()
         if (normalizedCwd.isBlank() || normalizedTty.isBlank()) {
-            return RecordedSessionOpen(recordedKind = null, detection = null, needsCodexResolution = false)
+            return RecordedSessionOpen(
+                recordedKind = null,
+                recordedSource = null,
+                recordedSourceGenerationScoped = false,
+                detection = null,
+                needsCodexResolution = false,
+            )
         }
         val kindSentinel = "@@PS_RECORDED_KIND@@"
+        val sourceGenerationSentinel = "@@PS_RECORDED_SOURCE_GENERATION@@"
+        val sourceSentinel = "@@PS_RECORDED_SOURCE@@"
         // The Claude window-fold tail budget mirrors [readEventsWindow]: raw
         // lines = messages * JSONL_RAW_LINES_PER_EVENT, floored at the message
         // count and at 1.
@@ -771,6 +883,26 @@ public class AgentConversationRepository internal constructor(
             append("\n")
             append("printf '%s\\n' $kindSentinel")
             append("\n")
+            // 1b. The exact source recorded by the host-side launch watcher.
+            //     Empty on legacy/foreign sessions. Read in the same exec so it
+            //     adds no round-trip to the cold-open path.
+            append(
+                "ps_recorded_source_generation=\$(" +
+                    "tmux show-options -v -t ${shellQuote(sessionTarget.trim())} " +
+                    "@ps_agent_source_generation 2>/dev/null || true" +
+                    "); printf '%s\\n' \"\$ps_recorded_source_generation\"",
+            )
+            append("\n")
+            append("printf '%s\\n' $sourceGenerationSentinel")
+            append("\n")
+            append(
+                "ps_recorded_source=\$(" +
+                    "tmux show-options -v -t ${shellQuote(sessionTarget.trim())} @ps_agent_source 2>/dev/null || true" +
+                    "); printf '%s\\n' \"\$ps_recorded_source\"",
+            )
+            append("\n")
+            append("printf '%s\\n' $sourceSentinel")
+            append("\n")
             // 2. The SAME candidate enumeration the split path runs.
             append(detectionCommand(normalizedCwd))
             append("\n")
@@ -787,14 +919,17 @@ public class AgentConversationRepository internal constructor(
             append("printf '%s\\n' $claudeWindowSentinel")
             append("\n")
             append(
-                "claude_proj=\"\$HOME/.claude/projects/$encodedClaudeCwd\"; " +
+                    "claude_proj=\"\$HOME/.claude/projects/$encodedClaudeCwd\"; " +
+                    "if [ -n \"\$ps_recorded_source\" ] && [ -f \"\$ps_recorded_source\" ]; then " +
+                    "newest=\"\$ps_recorded_source\"; " +
+                    "else " +
                     "newest=\$(" +
                     "find \"\$claude_proj\" -maxdepth 1 -type f -name '*.jsonl' -mmin -120 -print 2>/dev/null | " +
                     "while IFS= read -r f; do " +
                     "m=\$(stat -c '%Y' \"\$f\" 2>/dev/null) || continue; " +
                     "printf '%s %s\\n' \"\$m\" \"\$f\"; " +
                     "done | sort -rn | head -n 1 | cut -d' ' -f2-" +
-                    "); " +
+                    "); fi; " +
                     "if [ -n \"\$newest\" ]; then " +
                     "printf 'PATH=%s\\n' \"\$newest\"; " +
                     "wc -l < \"\$newest\" 2>/dev/null || printf 0; " +
@@ -814,18 +949,45 @@ public class AgentConversationRepository internal constructor(
         val recordedKind = recordedAgentKindFromOption(rawKind)
             ?: return RecordedSessionOpen(
                 recordedKind = null,
+                recordedSource = null,
+                recordedSourceGenerationScoped = false,
                 detection = null,
                 needsCodexResolution = false,
             )
-        // Candidate rows live between the kind sentinel and the FIRST Claude
+        val afterKindRaw = if (kindSentinelIndex >= 0) lines.drop(kindSentinelIndex + 1) else lines
+        val sourceGenerationSentinelIndex = afterKindRaw.indexOf(sourceGenerationSentinel)
+        val rawSourceGeneration = if (sourceGenerationSentinelIndex >= 0) {
+            afterKindRaw.take(sourceGenerationSentinelIndex).joinToString("\n").trim().ifBlank { null }
+        } else {
+            null
+        }
+        val afterSourceGeneration = if (sourceGenerationSentinelIndex >= 0) {
+            afterKindRaw.drop(sourceGenerationSentinelIndex + 1)
+        } else {
+            afterKindRaw
+        }
+        val sourceSentinelIndex = afterSourceGeneration.indexOf(sourceSentinel)
+        val rawSource = if (sourceSentinelIndex >= 0) {
+            afterSourceGeneration.take(sourceSentinelIndex).joinToString("\n").trim().ifBlank { null }
+        } else {
+            null
+        }
+        val recordedSourceOption = recordedAgentSourceOptionFromRaw(rawSource, rawSourceGeneration)
+        val recordedSource = recordedSourceOption.source
+        // Candidate rows live between the source sentinel and the FIRST Claude
         // window sentinel (the section-2 enumeration). Everything from the
         // SECOND Claude window sentinel onward is the prefetched window.
         val afterKind = if (kindSentinelIndex >= 0) lines.drop(kindSentinelIndex + 1) else lines
-        val firstClaudeSentinel = afterKind.indexOf(claudeWindowSentinel)
-        val candidateLines = if (firstClaudeSentinel >= 0) {
-            afterKind.take(firstClaudeSentinel)
+        val afterSource = if (sourceSentinelIndex >= 0) {
+            afterSourceGeneration.drop(sourceSentinelIndex + 1)
         } else {
             afterKind
+        }
+        val firstClaudeSentinel = afterSource.indexOf(claudeWindowSentinel)
+        val candidateLines = if (firstClaudeSentinel >= 0) {
+            afterSource.take(firstClaudeSentinel)
+        } else {
+            afterSource
         }
         val candidates = candidateLines
             .asSequence()
@@ -837,6 +999,8 @@ public class AgentConversationRepository internal constructor(
         if (recordedKind == AgentKind.Codex) {
             return RecordedSessionOpen(
                 recordedKind = recordedKind,
+                recordedSource = recordedSource,
+                recordedSourceGenerationScoped = recordedSourceOption.generationScoped,
                 detection = null,
                 needsCodexResolution = true,
             )
@@ -847,9 +1011,12 @@ public class AgentConversationRepository internal constructor(
             normalizedTty = normalizedTty,
             paneCommand = paneCommand,
             recordedKind = recordedKind,
+            recordedSource = recordedSource,
             candidates = candidates,
         ) ?: return RecordedSessionOpen(
             recordedKind = recordedKind,
+            recordedSource = recordedSource,
+            recordedSourceGenerationScoped = recordedSourceOption.generationScoped,
             detection = null,
             needsCodexResolution = false,
         )
@@ -861,7 +1028,7 @@ public class AgentConversationRepository internal constructor(
         val prefetchedWindow = if (recordedKind == AgentKind.ClaudeCode) {
             parseFoldedClaudeWindow(
                 lines = if (firstClaudeSentinel >= 0) {
-                    afterKind.drop(firstClaudeSentinel + 1)
+                    afterSource.drop(firstClaudeSentinel + 1)
                 } else {
                     emptyList()
                 },
@@ -874,6 +1041,8 @@ public class AgentConversationRepository internal constructor(
         }
         return RecordedSessionOpen(
             recordedKind = recordedKind,
+            recordedSource = recordedSource,
+            recordedSourceGenerationScoped = recordedSourceOption.generationScoped,
             detection = detection,
             needsCodexResolution = false,
             prefetchedWindow = prefetchedWindow,

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -1989,7 +1989,9 @@ public class TmuxSessionViewModel @Inject constructor(
     // from "read = foreign/null" (present-but-null) so a foreign session is not
     // re-probed on every reconcile either. Cleared with the other per-runtime
     // detection maps on park/restore/clear so a different session never inherits
-    // a stale recorded kind.
+    // a stale recorded kind/source. Issue #821 branch 1 carries the sibling
+    // `@ps_agent_source` exact transcript identity through the same cache so
+    // later opens/retries do not fall back to same-kind mtime selection.
     private val sessionRecordedKindCache: MutableMap<String, RecordedKindCacheEntry> =
         ConcurrentHashMap()
     // Epic #821 slice A2: per-tmux-session cache of the ONE-SHOT FOREIGN kind
@@ -10824,9 +10826,36 @@ public class TmuxSessionViewModel @Inject constructor(
      * a `null` map value would be indistinguishable from "no entry", so a
      * foreign session would be re-probed (a wasted `readRecordedAgentKind`
      * round-trip) on every reconcile — defeating the cache for exactly the
-     * sessions that have no recorded kind to find.
+     * sessions that have no recorded kind to find. [source] is the optional
+     * exact `@ps_agent_source` transcript path captured by the host-side launch
+     * watcher for sessions PocketShell started.
      */
-    private class RecordedKindCacheEntry(val kind: AgentKind?)
+    private class RecordedKindCacheEntry(
+        val kind: AgentKind?,
+        val source: String?,
+        val sourceGenerationScoped: Boolean,
+    )
+
+    private suspend fun recordedSourceForCachedKind(
+        session: SshSession,
+        sessionTarget: String,
+        cachedKind: RecordedKindCacheEntry,
+    ): String? {
+        val recordedKind = cachedKind.kind ?: return null
+        cachedKind.source?.takeIf { cachedKind.sourceGenerationScoped }?.let { return it }
+        val key = sessionTarget.trim()
+        if (key.isEmpty()) return null
+        val refreshedSource = agentRepository.readRecordedAgentSourceOption(
+            session = session,
+            sessionTarget = key,
+        )
+        sessionRecordedKindCache[key] = RecordedKindCacheEntry(
+            kind = recordedKind,
+            source = refreshedSource.source,
+            sourceGenerationScoped = refreshedSource.generationScoped,
+        )
+        return refreshedSource.source
+    }
 
     /**
      * Epic #821 slice A2: box for the per-session ONE-SHOT FOREIGN kind guess.
@@ -11070,12 +11099,18 @@ public class TmuxSessionViewModel @Inject constructor(
                     // Cache HIT — kind already known, no `@ps_agent_kind` exec.
                     val recordedKind = cachedKind.kind
                     if (recordedKind != null) {
+                        val recordedSource = recordedSourceForCachedKind(
+                            session = session,
+                            sessionTarget = sessionTarget,
+                            cachedKind = cachedKind,
+                        )
                         agentRepository.detectRecordedSessionForPane(
                             session = session,
                             cwd = cwd,
                             paneTty = tty,
                             paneCommand = command,
                             recordedKind = recordedKind,
+                            recordedSource = recordedSource,
                         )
                     } else {
                         // Epic #821 slice A2: FOREIGN session (no recorded kind).
@@ -11105,7 +11140,11 @@ public class TmuxSessionViewModel @Inject constructor(
                     )
                     sessionRecordedKindCache.putIfAbsent(
                         sessionTarget.trim(),
-                        RecordedKindCacheEntry(open.recordedKind),
+                        RecordedKindCacheEntry(
+                            kind = open.recordedKind,
+                            source = open.recordedSource,
+                            sourceGenerationScoped = open.recordedSourceGenerationScoped,
+                        ),
                     )
                     when {
                         open.recordedKind == null ->
@@ -11128,6 +11167,7 @@ public class TmuxSessionViewModel @Inject constructor(
                                 paneTty = tty,
                                 paneCommand = command,
                                 recordedKind = open.recordedKind,
+                                recordedSource = open.recordedSource,
                             )
                         // Recorded Claude/OpenCode: resolved in the one round-trip.
                         // Claude also carries the prefetched first window.
@@ -12701,12 +12741,21 @@ public class TmuxSessionViewModel @Inject constructor(
         // recorded-source resolution scoped to the known kind so we re-bind the
         // same engine's transcript without re-classifying.
         val detection = runCatching {
+            val cachedEntry = sessionRecordedKindCache[pane.sessionId.trim()]
+            val cachedSource = cachedEntry?.let {
+                recordedSourceForCachedKind(
+                    session = session,
+                    sessionTarget = pane.sessionId,
+                    cachedKind = it,
+                )
+            }
             agentRepository.detectRecordedSessionForPane(
                 session = session,
                 cwd = pane.cwd,
                 paneTty = pane.paneTty,
                 paneCommand = pane.currentCommand,
                 recordedKind = currentDetection.agent,
+                recordedSource = cachedSource ?: currentDetection.sourcePath,
             )
         }.getOrNull()
         if (!isCurrentRuntime(refreshGuard)) return

--- a/app/src/test/java/com/pocketshell/app/session/AgentConversationRepositoryTest.kt
+++ b/app/src/test/java/com/pocketshell/app/session/AgentConversationRepositoryTest.kt
@@ -723,6 +723,62 @@ class AgentConversationRepositoryTest {
     }
 
     @Test
+    fun readRecordedAgentSourceReadsSessionScopedTmuxOption() = runTest {
+        val source = "/home/testuser/.claude/projects/-workspace-proj/own.jsonl"
+        val session = FakeSshSession(recordedSourceOutput = "$source\n")
+
+        val recordedSource = AgentConversationRepository().readRecordedAgentSource(session, "\$3")
+
+        assertEquals(source, recordedSource)
+        val command = session.execCommands.single()
+        assertTrue(command.contains("show-options -v"))
+        assertTrue(command.contains("@ps_agent_source"))
+        assertTrue("must target the pane's session; got $command", command.contains("'\$3'"))
+    }
+
+    @Test
+    fun readRecordedAgentSourceAcceptsSourceFromCurrentGeneration() = runTest {
+        val source = "/home/testuser/.claude/projects/-workspace-proj/current.jsonl"
+        val session = FakeSshSession(
+            recordedSourceGenerationOutput = "launch-2\n",
+            recordedSourceOutput = "launch-2\t$source\n",
+        )
+
+        val recordedSource = AgentConversationRepository().readRecordedAgentSource(session, "\$3")
+
+        assertEquals(source, recordedSource)
+    }
+
+    @Test
+    fun readRecordedAgentSourceIsNullWhenOptionIsBlank() = runTest {
+        val session = FakeSshSession(recordedSourceOutput = "\n")
+
+        assertEquals(null, AgentConversationRepository().readRecordedAgentSource(session, "\$9"))
+    }
+
+    @Test
+    fun readRecordedAgentSourceIgnoresSourceFromStaleGeneration() = runTest {
+        val source = "/home/testuser/.claude/projects/-workspace-proj/stale.jsonl"
+        val session = FakeSshSession(
+            recordedSourceGenerationOutput = "new-launch\n",
+            recordedSourceOutput = "old-launch\t$source\n",
+        )
+
+        assertEquals(null, AgentConversationRepository().readRecordedAgentSource(session, "\$3"))
+    }
+
+    @Test
+    fun readRecordedAgentSourceRejectsRawSourceWhenGenerationIsCurrent() = runTest {
+        val source = "/home/testuser/.claude/projects/-workspace-proj/raw.jsonl"
+        val session = FakeSshSession(
+            recordedSourceGenerationOutput = "current-launch\n",
+            recordedSourceOutput = "$source\n",
+        )
+
+        assertEquals(null, AgentConversationRepository().readRecordedAgentSource(session, "\$3"))
+    }
+
+    @Test
     fun recordedClaudeSessionBindsToRecordedKindEvenWhenABusierCodexSiblingExists() = runTest {
         // The maintainer's #807/#819/#820 cluster: a session PocketShell
         // launched as CLAUDE, but a busier Codex rollout in the SAME cwd flushed
@@ -767,6 +823,39 @@ class AgentConversationRepositoryTest {
         assertEquals(
             "/home/testuser/.claude/projects/-workspace-proj/claude-sess.jsonl",
             detection?.sourcePath,
+        )
+    }
+
+    @Test
+    fun recordedClaudeSessionPrefersRecordedSourceOverNewerSameKindSibling() = runTest {
+        val now = System.currentTimeMillis() / 1000
+        val ownPath = "/home/testuser/.claude/projects/-workspace-proj/own.jsonl"
+        val siblingPath = "/home/testuser/.claude/projects/-workspace-proj/busier.jsonl"
+        val session = FakeSshSession(
+            detectionOutput = """
+                claude|${now - 120}|/workspace/proj|$ownPath
+                claude|$now|/workspace/proj|$siblingPath
+            """.trimIndent(),
+        )
+
+        val detection = AgentConversationRepository().detectRecordedSessionForPane(
+            session = session,
+            cwd = "/workspace/proj",
+            paneTty = "/dev/pts/7",
+            paneCommand = "node",
+            recordedKind = AgentKind.ClaudeCode,
+            recordedSource = ownPath,
+        )
+
+        assertEquals(
+            "an exact @ps_agent_source match must beat same-kind mtime selection",
+            ownPath,
+            detection?.sourcePath,
+        )
+        assertEquals("own", detection?.sessionId)
+        assertFalse(
+            "the exact-source shortcut should not need a process scan",
+            session.execCommands.any { it.contains("ps -eo pid,ppid,tty,comm,args") },
         )
     }
 
@@ -975,6 +1064,32 @@ class AgentConversationRepositoryTest {
     }
 
     @Test
+    fun recordedOpenCodeSessionPrefersRecordedSourceOverNewerSameKindSibling() = runTest {
+        val now = System.currentTimeMillis() / 1000
+        val ownPath = "/home/testuser/.local/share/opencode/opencode.db#own"
+        val siblingPath = "/home/testuser/.local/share/opencode/opencode.db#busier"
+        val session = FakeSshSession(
+            detectionOutput = """
+                opencode|${now - 120}|/workspace/proj|$ownPath
+                opencode|$now|/workspace/proj|$siblingPath
+            """.trimIndent(),
+        )
+
+        val detection = AgentConversationRepository().detectRecordedSessionForPane(
+            session = session,
+            cwd = "/workspace/proj",
+            paneTty = "/dev/pts/3",
+            paneCommand = "node",
+            recordedKind = AgentKind.OpenCode,
+            recordedSource = ownPath,
+        )
+
+        assertEquals(AgentKind.OpenCode, detection?.agent)
+        assertEquals(ownPath, detection?.sourcePath)
+        assertEquals("own", detection?.sessionId)
+    }
+
+    @Test
     fun recordedCodexSessionPicksProcessOwnedRolloutNotTheBusierSibling() = runTest {
         // Codex has no session-id-in-path, so even within the recorded Codex
         // kind a busier same-cwd sibling rollout would win an mtime race. The
@@ -1052,6 +1167,41 @@ class AgentConversationRepositoryTest {
     }
 
     @Test
+    fun recordedCodexSessionDoesNotTrustExactSourceWithoutOwnershipEvidence() = runTest {
+        val now = System.currentTimeMillis() / 1000
+        val recordedButUnowned = "/home/testuser/.codex/sessions/2026/06/18/rollout-sibling.jsonl"
+        val ownCandidate = "/home/testuser/.codex/sessions/2026/06/18/rollout-mine.jsonl"
+        val session = FakeSshSession(
+            detectionOutput = """
+                codex|$now|/workspace/proj|$recordedButUnowned
+                codex|${now - 60}|/workspace/proj|$ownCandidate
+            """.trimIndent(),
+            hostWideProcessOutput = "4242 1 pts/5 codex /usr/local/bin/codex --here",
+            procFdOutput = "",
+        )
+
+        val detection = AgentConversationRepository().detectRecordedSessionForPane(
+            session = session,
+            cwd = "/workspace/proj",
+            paneTty = "/dev/pts/5",
+            paneCommand = "codex",
+            recordedKind = AgentKind.Codex,
+            recordedSource = recordedButUnowned,
+        )
+
+        assertEquals(
+            "an exact @ps_agent_source must not bypass Codex /proc fd ownership; " +
+                "with ambiguous same-cwd rollouts and no owner signal, refuse to bind",
+            null,
+            detection,
+        )
+        assertTrue(
+            "Codex must still run the process-owned rollout check",
+            session.execCommands.any { it.contains("/proc/") && it.contains(".codex/sessions/") },
+        )
+    }
+
+    @Test
     fun recordedCodexSessionConsidersProcessOwnedRolloutOutsideMminEnumeration() = runTest {
         // Issue #819 follow-up: Codex can keep a live rollout fd open after the
         // JSONL mtime has aged beyond the `find -mmin -120` candidate window.
@@ -1097,6 +1247,7 @@ class AgentConversationRepositoryTest {
         val sourcePath = "/home/testuser/.claude/projects/-workspace-proj/sess-abc.jsonl"
         val session = FakeSshSession(
             recordedKindOutput = "claude\n",
+            recordedSourceOutput = "$sourcePath\n",
             detectionOutput = "claude|$now|/workspace/proj|$sourcePath",
             hostWideProcessOutput = "1001 1 pts/7 claude claude",
             // The folded window section: PATH must equal the resolved source so
@@ -1118,6 +1269,7 @@ class AgentConversationRepositoryTest {
         )
 
         assertEquals(AgentKind.ClaudeCode, open.recordedKind)
+        assertEquals(sourcePath, open.recordedSource)
         assertFalse("Claude resolves fully in one round-trip; no Codex pass", open.needsCodexResolution)
         assertEquals(AgentKind.ClaudeCode, open.detection?.agent)
         assertEquals("sess-abc", open.detection?.sessionId)
@@ -1133,6 +1285,7 @@ class AgentConversationRepositoryTest {
             "the one exec must carry the @ps_agent_kind read, the candidate enumeration, " +
                 "and the Claude window fold; got ${session.execCommands}",
             session.execCommands.single().contains("@ps_agent_kind") &&
+                session.execCommands.single().contains("@ps_agent_source") &&
                 session.execCommands.single().contains("claude_dir=") &&
                 session.execCommands.single().contains("@@PS_CLAUDE_WINDOW@@"),
         )
@@ -2043,6 +2196,8 @@ class AgentConversationRepositoryTest {
         private val agentLogOutput: String = "",
         private val jsonlTailOutput: String = "",
         private val recordedKindOutput: String = "",
+        private val recordedSourceGenerationOutput: String = "",
+        private val recordedSourceOutput: String = "",
         private val procFdOutput: String = "",
         // Issue #828: when set, the single-round-trip recorded-open exec emits a
         // folded Claude window section (PATH=<path>, wc -l, sentinel, tail) after
@@ -2070,6 +2225,10 @@ class AgentConversationRepositoryTest {
                 command.contains("@@PS_RECORDED_KIND@@") -> buildString {
                     append(recordedKindOutput.trim())
                     append("\n@@PS_RECORDED_KIND@@\n")
+                    append(recordedSourceGenerationOutput.trim())
+                    append("\n@@PS_RECORDED_SOURCE_GENERATION@@\n")
+                    append(recordedSourceOutput.trim())
+                    append("\n@@PS_RECORDED_SOURCE@@\n")
                     append(detectionOutput)
                     append("\n@@PS_CLAUDE_WINDOW@@\n")
                     if (foldedClaudePath.isNotBlank()) {
@@ -2080,6 +2239,12 @@ class AgentConversationRepositoryTest {
                     }
                 }
                 command.contains("show-options -v") && command.contains("@ps_agent_kind") -> recordedKindOutput
+                command.contains("@@PS_RECORDED_SOURCE_GENERATION@@") -> buildString {
+                    append(recordedSourceGenerationOutput.trim())
+                    append("\n@@PS_RECORDED_SOURCE_GENERATION@@\n")
+                    append(recordedSourceOutput.trim())
+                }
+                command.contains("show-options -v") && command.contains("@ps_agent_source") -> recordedSourceOutput
                 command.contains("/proc/") && command.contains(".codex/sessions/") -> procFdOutput
                 command.contains("claude_dir=") -> detectionOutput
                 command.contains("ps -eo pid,ppid,tty,comm,args") -> hostWideProcessOutput

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
@@ -7916,6 +7916,150 @@ class TmuxSessionViewModelTest {
     }
 
     @Test
+    fun cachedRecordedKindWithNullSourceRereadsSourceOptionAndRebinds() = runTest(scheduler) {
+        val now = System.currentTimeMillis() / 1000
+        val ownSource = "/home/u/.claude/projects/-workspace-proj/own.jsonl"
+        val siblingSource = "/home/u/.claude/projects/-workspace-proj/sibling.jsonl"
+        val session = FakeSshSession(
+            recordedKindOutput = "claude\n",
+            recordedSourceOutput = "",
+            detectionOutput = """
+                claude|${now - 60}|/workspace/proj|$ownSource
+                claude|$now|/workspace/proj|$siblingSource
+            """.trimIndent(),
+        )
+        val vm = newVm()
+        vm.replaceClientForTest(
+            hostId = 1L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            sessionName = "work",
+            client = FakeTmuxClient(),
+            session = session,
+        )
+        vm.applyParsedPanesForTest(
+            listOf(
+                TmuxSessionViewModel.ParsedPane(
+                    paneId = "%0",
+                    windowId = "@0",
+                    sessionId = "$0",
+                    title = "claude",
+                    paneIndex = 0,
+                    cwd = "/workspace/proj",
+                    currentCommand = "claude",
+                    paneTty = "/dev/pts/7",
+                    sessionName = "work",
+                ),
+            ),
+        )
+        advanceUntilIdle()
+
+        assertEquals(
+            "precondition: before the delayed source option exists, the recorded-kind " +
+                "cache has source=null and Claude falls back to newest same-cwd candidate",
+            siblingSource,
+            vm.agentConversations.value["%0"]?.detection?.sourcePath,
+        )
+
+        session.setRecordedSourceOutput("$ownSource\n")
+        vm.startAgentDetectionForPaneForTest("%0")
+        advanceUntilIdle()
+
+        assertEquals(
+            "a cached recorded kind with source=null must re-read @ps_agent_source " +
+                "and rebind to the exact recorded source once the watcher writes it",
+            ownSource,
+            vm.agentConversations.value["%0"]?.detection?.sourcePath,
+        )
+        assertTrue(
+            "the cache-hit path must issue a standalone source option read; commands=${session.execCommands}",
+            session.execCommands.any {
+                it.contains("show-options -v") &&
+                    it.contains("@ps_agent_source") &&
+                    !it.contains("@@PS_RECORDED_KIND@@")
+            },
+        )
+    }
+
+    @Test
+    fun cachedRecordedKindWithRawSourceRereadsAfterGenerationAppearsAndRebinds() =
+        runTest(scheduler) {
+            val now = System.currentTimeMillis() / 1000
+            val rawSource = "/home/u/.claude/projects/-workspace-proj/raw-before-generation.jsonl"
+            val generationSource = "/home/u/.claude/projects/-workspace-proj/generation-current.jsonl"
+            val siblingSource = "/home/u/.claude/projects/-workspace-proj/sibling.jsonl"
+            val session = FakeSshSession(
+                recordedKindOutput = "claude\n",
+                recordedSourceOutput = "$rawSource\n",
+                detectionOutput = """
+                    claude|${now - 120}|/workspace/proj|$rawSource
+                    claude|${now - 60}|/workspace/proj|$generationSource
+                    claude|$now|/workspace/proj|$siblingSource
+                """.trimIndent(),
+            )
+            val vm = newVm()
+            vm.replaceClientForTest(
+                hostId = 1L,
+                hostName = "alpha",
+                host = "alpha.example",
+                port = 22,
+                user = "alex",
+                keyPath = "/keys/a",
+                sessionName = "work",
+                client = FakeTmuxClient(),
+                session = session,
+            )
+            vm.applyParsedPanesForTest(
+                listOf(
+                    TmuxSessionViewModel.ParsedPane(
+                        paneId = "%0",
+                        windowId = "@0",
+                        sessionId = "$0",
+                        title = "claude",
+                        paneIndex = 0,
+                        cwd = "/workspace/proj",
+                        currentCommand = "claude",
+                        paneTty = "/dev/pts/7",
+                        sessionName = "work",
+                    ),
+                ),
+            )
+            advanceUntilIdle()
+
+            assertEquals(
+                "precondition: the first open cached a raw legacy @ps_agent_source",
+                rawSource,
+                vm.agentConversations.value["%0"]?.detection?.sourcePath,
+            )
+
+            session.setRecordedSourceGenerationOutput("launch-2\n")
+            session.setRecordedSourceOutput("launch-2\t$generationSource\n")
+            vm.startAgentDetectionForPaneForTest("%0")
+            advanceUntilIdle()
+
+            assertEquals(
+                "when @ps_agent_source_generation appears, the cache-hit path must " +
+                    "not return the previously cached raw source before validating " +
+                    "the generation-scoped source option",
+                generationSource,
+                vm.agentConversations.value["%0"]?.detection?.sourcePath,
+            )
+            assertTrue(
+                "the raw cached source must be overridden via a standalone " +
+                    "generation-aware source read; commands=${session.execCommands}",
+                session.execCommands.any {
+                    it.contains("@@PS_RECORDED_SOURCE_GENERATION@@") &&
+                        it.contains("@ps_agent_source_generation") &&
+                        it.contains("@ps_agent_source") &&
+                        !it.contains("@@PS_RECORDED_KIND@@")
+                },
+            )
+        }
+
+    @Test
     fun codexReattachSeedReanchorsAcrossSubAgentTwoWindowAndTwoWorktreeSiblings() =
         runTest(scheduler) {
             // G2 class coverage: the three same-cwd same-kind collision shapes the
@@ -16088,6 +16232,9 @@ class TmuxSessionViewModelTest {
         private val tailFailure: Throwable? = null,
         private val detectionOutput: String = "",
         private val processOutput: String = "",
+        private val recordedKindOutput: String = "",
+        private var recordedSourceGenerationOutput: String = "",
+        private var recordedSourceOutput: String = "",
         private val cardGetStdouts: List<String> = emptyList(),
         private val cardCheckExitCode: Int = 0,
         // Issue #448: ports the `ss -tlnp` confirm scan reports as
@@ -16105,6 +16252,8 @@ class TmuxSessionViewModelTest {
         // Issue #793: let a paging test reprogram the window the fake returns.
         fun setWcOutput(value: String) { wcOutput = value }
         fun setInitialEventsOutput(value: String) { initialEventsOutput = value }
+        fun setRecordedSourceGenerationOutput(value: String) { recordedSourceGenerationOutput = value }
+        fun setRecordedSourceOutput(value: String) { recordedSourceOutput = value }
 
         override val isConnected: Boolean
             get() = isConnectedValue && !closed
@@ -16123,6 +16272,25 @@ class TmuxSessionViewModelTest {
             execGate?.await()
             execFailure?.let { throw it }
             val stdout = when {
+                command.contains("@@PS_RECORDED_KIND@@") -> buildString {
+                    append(recordedKindOutput.trim())
+                    append("\n@@PS_RECORDED_KIND@@\n")
+                    append(recordedSourceGenerationOutput.trim())
+                    append("\n@@PS_RECORDED_SOURCE_GENERATION@@\n")
+                    append(recordedSourceOutput.trim())
+                    append("\n@@PS_RECORDED_SOURCE@@\n")
+                    append(detectionOutput)
+                    append("\n@@PS_CLAUDE_WINDOW@@\n")
+                }
+                command.contains("show-options -v") && command.contains("@ps_agent_kind") ->
+                    recordedKindOutput
+                command.contains("@@PS_RECORDED_SOURCE_GENERATION@@") -> buildString {
+                    append(recordedSourceGenerationOutput.trim())
+                    append("\n@@PS_RECORDED_SOURCE_GENERATION@@\n")
+                    append(recordedSourceOutput.trim())
+                }
+                command.contains("show-options -v") && command.contains("@ps_agent_source") ->
+                    recordedSourceOutput
                 command.contains("ss -tlnp") ->
                     ssListeningPorts.joinToString("\n") { "0.0.0.0:$it users:((\"server\",pid=1,fd=3))" }
                 command.contains("netstat -tlnp") || command.contains("ss -tln") -> ""

--- a/tools/pocketshell/src/pocketshell/agents.py
+++ b/tools/pocketshell/src/pocketshell/agents.py
@@ -74,7 +74,11 @@ from __future__ import annotations
 import json
 import os
 import shutil
+import sqlite3
 import subprocess
+import sys
+import time
+import uuid
 from pathlib import Path
 from typing import Optional
 
@@ -442,6 +446,215 @@ def record_agent_kind(
     return True
 
 
+def _encode_agent_cwd(cwd: str) -> str:
+    trimmed = cwd.strip()
+    return trimmed.replace("/", "-").replace(".", "-") if trimmed else "-"
+
+
+def _codex_file_cwd(path: Path) -> Optional[str]:
+    try:
+        with path.open("r", encoding="utf-8", errors="replace") as handle:
+            for line in handle:
+                if '"session_meta"' not in line or '"cwd"' not in line:
+                    continue
+                row = json.loads(line)
+                payload = row.get("payload")
+                if row.get("type") == "session_meta" and isinstance(payload, dict):
+                    cwd = payload.get("cwd")
+                    return cwd if isinstance(cwd, str) else None
+    except Exception:
+        return None
+    return None
+
+
+def _path_mtime(path: Path) -> float:
+    try:
+        return path.stat().st_mtime
+    except OSError:
+        return 0.0
+
+
+def _latest_claude_source(cwd: str, started_at: float) -> Optional[str]:
+    root = Path.home() / ".claude" / "projects" / _encode_agent_cwd(cwd)
+    if not root.is_dir():
+        return None
+    candidates = [
+        path
+        for path in root.glob("*.jsonl")
+        if path.is_file() and _path_mtime(path) >= started_at
+    ]
+    if not candidates:
+        return None
+    return str(max(candidates, key=_path_mtime))
+
+
+def _latest_codex_source(cwd: str, started_at: float) -> Optional[str]:
+    root = Path.home() / ".codex" / "sessions"
+    if not root.is_dir():
+        return None
+    candidates = [
+        path
+        for path in root.rglob("*.jsonl")
+        if path.is_file()
+        and _path_mtime(path) >= started_at
+        and _codex_file_cwd(path) == cwd
+    ]
+    if not candidates:
+        return None
+    return str(max(candidates, key=_path_mtime))
+
+
+def _latest_opencode_source(cwd: str, started_at: float) -> Optional[str]:
+    db = Path.home() / ".local" / "share" / "opencode" / "opencode.db"
+    if not db.is_file():
+        return None
+    normalized_cwd = cwd.rstrip("/") or "/"
+    started_ms = int(started_at * 1000)
+    query = """
+        SELECT s.id, COALESCE(s.time_updated, s.time_created, 0),
+               COALESCE(p.worktree, ''), COALESCE(s.directory, '')
+        FROM session s
+        LEFT JOIN project p ON p.id = s.project_id
+        WHERE COALESCE(s.time_updated, s.time_created, 0) >= ?
+        ORDER BY COALESCE(s.time_updated, s.time_created, 0) DESC
+    """
+    try:
+        with sqlite3.connect(f"file:{db}?mode=ro", uri=True) as conn:
+            rows = conn.execute(query, (started_ms,)).fetchall()
+    except Exception:
+        return None
+    for session_id, _updated, worktree, directory in rows:
+        for candidate_cwd in (worktree, directory):
+            if not candidate_cwd:
+                continue
+            root = str(candidate_cwd).rstrip("/") or "/"
+            if normalized_cwd == root or normalized_cwd.startswith(root + "/"):
+                return f"{db}#{session_id}"
+    return None
+
+
+def _latest_agent_source(
+    kind: str,
+    cwd: str,
+    started_at: float,
+) -> Optional[str]:
+    if kind == "claude":
+        return _latest_claude_source(cwd, started_at)
+    if kind == "codex":
+        return _latest_codex_source(cwd, started_at)
+    if kind == "opencode":
+        return _latest_opencode_source(cwd, started_at)
+    return None
+
+
+def _watch_and_record_agent_source(
+    kind: str,
+    cwd: str,
+    started_at: str,
+    generation: str,
+    timeout_seconds: str = "20",
+) -> int:
+    """Watch for this launch's transcript and record it on the tmux session.
+
+    The wrapper starts this helper immediately before ``execvpe``. The agent
+    process has not minted its transcript id yet, so this runs in a detached
+    host-side child and records ``@ps_agent_source`` once the source appears.
+    """
+    try:
+        started = float(started_at)
+        timeout = float(timeout_seconds)
+    except ValueError:
+        return 2
+    deadline = time.monotonic() + max(timeout, 0.0)
+    while time.monotonic() <= deadline:
+        source = _latest_agent_source(kind, cwd, started)
+        if source:
+            try:
+                current_generation = subprocess.run(
+                    ["tmux", "show-options", "-v", "@ps_agent_source_generation"],
+                    check=False,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.DEVNULL,
+                    text=True,
+                ).stdout.strip()
+                if current_generation != generation:
+                    return 1
+                subprocess.run(
+                    ["tmux", "set-option", "@ps_agent_source", f"{generation}\t{source}"],
+                    check=False,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+                return 0
+            except Exception:
+                return 1
+        time.sleep(0.25)
+    return 1
+
+
+def record_agent_source(
+    kind: str,
+    cwd: str,
+    env: Optional[dict[str, str]] = None,
+    runner=None,
+    popen=None,
+) -> bool:
+    """Start a best-effort recorder for this launch's transcript source.
+
+    ``@ps_agent_kind`` records the engine at launch. This sibling option records
+    the exact transcript identity once the launched CLI has created it, so the
+    Android conversation opener can prefer an exact source over same-kind mtime
+    selection. The old source option is cleared first; if the watcher never
+    finds a transcript, the client falls back to its current selector instead of
+    trusting a stale path from a previous relaunch in the same tmux session.
+    """
+    if not kind or not cwd:
+        return False
+    source_env = os.environ if env is None else env
+    if not source_env.get("TMUX"):
+        return False
+    if runner is None:
+        runner = subprocess.run
+    if popen is None:
+        popen = subprocess.Popen
+    try:
+        generation = uuid.uuid4().hex
+        runner(
+            ["tmux", "set-option", "@ps_agent_source_generation", generation],
+            check=False,
+        )
+        runner(
+            ["tmux", "set-option", "-uq", "@ps_agent_source"],
+            check=False,
+        )
+        started_at = str(time.time() - 1.0)
+        popen(
+            [
+                sys.executable,
+                "-c",
+                (
+                    "from pocketshell.agents import "
+                    "_watch_and_record_agent_source; import sys; "
+                    "raise SystemExit(_watch_and_record_agent_source("
+                    "sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]))"
+                ),
+                kind,
+                cwd,
+                started_at,
+                generation,
+            ],
+            env=dict(source_env),
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            close_fds=True,
+            start_new_session=True,
+        )
+    except Exception:
+        return False
+    return True
+
+
 def launch_agent(
     ctx: click.Context,
     kind: str,
@@ -453,6 +666,7 @@ def launch_agent(
     profile: Optional[str] = None,
     execvpe=None,
     record_kind=None,
+    record_source=None,
 ) -> None:
     """Resolve the dir, build env+argv, suppress prompts, exec the agent.
 
@@ -482,6 +696,8 @@ def launch_agent(
         execvpe = os.execvpe
     if record_kind is None:
         record_kind = record_agent_kind
+    if record_source is None:
+        record_source = record_agent_source
 
     path = _resolve_dir(ctx, directory)
     resolved_dir = str(path)
@@ -517,6 +733,7 @@ def launch_agent(
     # environment (os.environ) for the TMUX detection — `env` is the
     # provider-stripped launch env that does not necessarily carry $TMUX.
     record_kind(kind, dict(os.environ), profile=profile)
+    record_source(kind, resolved_dir, dict(os.environ))
 
     # Replace this process with the agent so it owns the pty cleanly.
     execvpe(argv[0], argv, env)

--- a/tools/pocketshell/tests/test_agents.py
+++ b/tools/pocketshell/tests/test_agents.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 
 import click
 import pytest
@@ -56,6 +57,20 @@ def _restore_cwd():
         yield
     finally:
         os.chdir(original)
+
+
+class _FakePopen:
+    pid = 12345
+
+
+@pytest.fixture(autouse=True)
+def _no_source_recorder_child(monkeypatch):
+    """Keep launch tests from spawning the background source watcher."""
+    monkeypatch.setattr(
+        agents.subprocess,
+        "Popen",
+        lambda *args, **kwargs: _FakePopen(),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -512,6 +527,168 @@ def test_record_agent_kind_swallows_runner_failure():
     assert ok is False
 
 
+def test_record_agent_source_noop_when_not_in_tmux(tmp_path):
+    calls = []
+    ok = agents.record_agent_source(
+        "claude",
+        str(tmp_path),
+        env={},
+        runner=lambda argv, **kw: calls.append(argv),
+        popen=lambda *a, **kw: calls.append(a),
+    )
+    assert ok is False
+    assert calls == []
+
+
+def test_record_agent_source_clears_stale_source_and_starts_watcher(tmp_path):
+    run_calls = []
+    popen_calls = []
+
+    ok = agents.record_agent_source(
+        "codex",
+        str(tmp_path),
+        env={"TMUX": "/tmp/tmux-1000/default,1234,0", "PATH": "/usr/bin"},
+        runner=lambda argv, **kw: run_calls.append((argv, kw)),
+        popen=lambda *args, **kwargs: popen_calls.append((args, kwargs)) or _FakePopen(),
+    )
+
+    assert ok is True
+    generation = run_calls[0][0][-1]
+    assert run_calls[0][0] == ["tmux", "set-option", "@ps_agent_source_generation", generation]
+    assert len(generation) == 32
+    assert run_calls[0][1] == {"check": False}
+    assert run_calls[1] == (
+        ["tmux", "set-option", "-uq", "@ps_agent_source"],
+        {"check": False},
+    )
+    assert len(popen_calls) == 1
+    argv = popen_calls[0][0][0]
+    assert argv[:2] == [sys.executable, "-c"]
+    assert argv[3:5] == ["codex", str(tmp_path)]
+    assert argv[6] == generation
+    assert popen_calls[0][1]["env"]["TMUX"] == "/tmp/tmux-1000/default,1234,0"
+
+
+def test_watch_agent_source_refuses_stale_generation(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        agents,
+        "_latest_agent_source",
+        lambda kind, cwd, started_at: "/tmp/current.jsonl",
+    )
+
+    def fake_run(argv, **kwargs):
+        calls.append((argv, kwargs))
+        if argv[:3] == ["tmux", "show-options", "-v"]:
+            return agents.subprocess.CompletedProcess(argv, 0, stdout="newer-generation\n")
+        return agents.subprocess.CompletedProcess(argv, 0, stdout="")
+
+    monkeypatch.setattr(agents.subprocess, "run", fake_run)
+
+    assert agents._watch_and_record_agent_source(
+        "claude",
+        "/workspace/proj",
+        "100",
+        "older-generation",
+        timeout_seconds="0.01",
+    ) == 1
+    assert calls == [
+        (
+            ["tmux", "show-options", "-v", "@ps_agent_source_generation"],
+            {
+                "check": False,
+                "stdout": agents.subprocess.PIPE,
+                "stderr": agents.subprocess.DEVNULL,
+                "text": True,
+            },
+        )
+    ]
+
+
+def test_watch_agent_source_records_generation_scoped_source(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        agents,
+        "_latest_agent_source",
+        lambda kind, cwd, started_at: "/tmp/current.jsonl",
+    )
+
+    def fake_run(argv, **kwargs):
+        calls.append((argv, kwargs))
+        if argv[:3] == ["tmux", "show-options", "-v"]:
+            return agents.subprocess.CompletedProcess(argv, 0, stdout="same-generation\n")
+        return agents.subprocess.CompletedProcess(argv, 0, stdout="")
+
+    monkeypatch.setattr(agents.subprocess, "run", fake_run)
+
+    assert agents._watch_and_record_agent_source(
+        "claude",
+        "/workspace/proj",
+        "100",
+        "same-generation",
+        timeout_seconds="0.01",
+    ) == 0
+    assert calls[-1][0] == [
+        "tmux",
+        "set-option",
+        "@ps_agent_source",
+        "same-generation\t/tmp/current.jsonl",
+    ]
+
+
+def test_latest_claude_source_encodes_dot_cwd_like_android_detector(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cwd = "/workspace/app.1"
+    log_dir = tmp_path / ".claude" / "projects" / "-workspace-app-1"
+    log_dir.mkdir(parents=True)
+    transcript = log_dir / "session.jsonl"
+    transcript.write_text("new\n", encoding="utf-8")
+    os.utime(transcript, (300, 300))
+
+    assert agents._latest_agent_source("claude", cwd, started_at=200) == str(transcript)
+
+
+def test_latest_claude_source_ignores_prelaunch_sibling(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cwd = "/workspace/proj"
+    log_dir = tmp_path / ".claude" / "projects" / "-workspace-proj"
+    log_dir.mkdir(parents=True)
+    older = log_dir / "older.jsonl"
+    newer = log_dir / "newer.jsonl"
+    older.write_text("old\n", encoding="utf-8")
+    newer.write_text("new\n", encoding="utf-8")
+    os.utime(older, (100, 100))
+    os.utime(newer, (300, 300))
+
+    assert agents._latest_agent_source("claude", cwd, started_at=200) == str(newer)
+
+
+def test_latest_codex_source_matches_cwd_and_launch_time(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    root = tmp_path / ".codex" / "sessions" / "2026" / "06" / "27"
+    root.mkdir(parents=True)
+    mine = root / "rollout-mine.jsonl"
+    sibling = root / "rollout-sibling.jsonl"
+    stale = root / "rollout-stale.jsonl"
+    mine.write_text(
+        """{"type":"session_meta","payload":{"cwd":"/workspace/proj"}}\n""",
+        encoding="utf-8",
+    )
+    sibling.write_text(
+        """{"type":"session_meta","payload":{"cwd":"/workspace/other"}}\n""",
+        encoding="utf-8",
+    )
+    stale.write_text(
+        """{"type":"session_meta","payload":{"cwd":"/workspace/proj"}}\n""",
+        encoding="utf-8",
+    )
+    os.utime(mine, (300, 300))
+    os.utime(sibling, (400, 400))
+    os.utime(stale, (100, 100))
+
+    assert agents._latest_agent_source("codex", "/workspace/proj", started_at=200) == str(mine)
+
+
 @pytest.mark.parametrize("kind", ["claude", "codex", "opencode"])
 def test_launch_agent_records_kind_before_exec(tmp_path, monkeypatch, kind):
     monkeypatch.setenv("HOME", str(tmp_path))
@@ -525,6 +702,10 @@ def test_launch_agent_records_kind_before_exec(tmp_path, monkeypatch, kind):
     def fake_execvpe(file, argv, env):
         order.append(("exec", file))
 
+    def fake_record_source(k, cwd, env=None, runner=None, popen=None):
+        order.append(("source", k, cwd, env.get("TMUX") if env else None))
+        return True
+
     agents.launch_agent(
         _FakeCtx(),
         kind,
@@ -533,11 +714,12 @@ def test_launch_agent_records_kind_before_exec(tmp_path, monkeypatch, kind):
         config_dir=None,
         execvpe=fake_execvpe,
         record_kind=fake_record,
+        record_source=fake_record_source,
     )
-    # The kind is recorded with the wrapper's own $TMUX, and recorded BEFORE
-    # the exec replaces the process.
+    # The kind/source are recorded with the wrapper's own $TMUX before exec.
     assert order == [
         ("record", kind, "/tmp/tmux-1000/default,1234,0"),
+        ("source", kind, str(tmp_path), "/tmp/tmux-1000/default,1234,0"),
         ("exec", kind),
     ]
 
@@ -684,6 +866,7 @@ def test_launch_agent_records_profile_before_exec(tmp_path, monkeypatch):
         profile="Claude (Z.AI)",
         execvpe=lambda f, a, e: None,
         record_kind=fake_record,
+        record_source=lambda *a, **kw: True,
     )
     assert recorded == {"kind": "claude", "profile": "Claude (Z.AI)"}
 
@@ -692,7 +875,7 @@ def test_cli_agent_named_profile_records_profile_option(tmp_path, monkeypatch):
     """End-to-end #858: launching claude via the z.ai profile inside tmux
     writes BOTH @ps_agent_kind=claude AND @ps_agent_profile=<name> before
     exec, via the real --profile resolution path."""
-    home = _seed_zlaude_home(tmp_path, monkeypatch)
+    _seed_zlaude_home(tmp_path, monkeypatch)
     workdir = tmp_path / "work"
     workdir.mkdir()
     monkeypatch.setenv("TMUX", "/tmp/tmux-1000/default,1234,0")
@@ -793,7 +976,8 @@ def test_cli_agent_default_then_zai_relaunch_sets_profile(tmp_path, monkeypatch)
     )
     assert ["tmux", "set-option", "@ps_agent_profile", "Claude (Z.AI)"] in zai_calls
     assert not any(
-        argv[:3] == ["tmux", "set-option", "-uq"] for argv in zai_calls
+        argv[:4] == ["tmux", "set-option", "-uq", "@ps_agent_profile"]
+        for argv in zai_calls
     )
 
 


### PR DESCRIPTION
## Summary
- Record a generation-scoped `@ps_agent_source` for PocketShell-launched agent sessions.
- Prefer validated exact transcript sources before same-kind mtime fallback while preserving Codex owner checks.
- Re-read source options when cached source data is missing or raw, and ignore stale generations.

## Verification
- uv run ruff check src/pocketshell/agents.py tests/test_agents.py
- uv run pytest tests/test_agents.py
- uv run pytest
- ./gradlew :app:testDebugUnitTest --tests 'com.pocketshell.app.session.AgentConversationRepositoryTest' --tests 'com.pocketshell.app.tmux.TmuxSessionViewModelTest'\n- git diff --check\n\nRefs #821