### PR TITLE
ssh: bound session teardown drain

### DIFF
--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshSession.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshSession.kt
@@ -2,6 +2,7 @@ package com.pocketshell.core.ssh
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.Job
@@ -57,6 +58,15 @@ internal class RealSshSession(
      * when the session is [close]d so all child jobs cancel deterministically.
      */
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    /**
+     * Independent teardown scope for best-effort channel closes and keepalive-dead
+     * transport teardown. It deliberately outlives [scope] until [close] finishes:
+     * cancellation handlers often run while the session scope is being torn down,
+     * and launching those channel-close writes on the same scope lets
+     * `scope.cancel()` erase the cleanup before it reaches the dispatcher.
+     */
+    private val teardownScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     /**
      * Single-writer dispatch owner for this connection's transport (issue
@@ -200,11 +210,12 @@ internal class RealSshSession(
                         "$consecutiveMisses consecutive misses; closing the dead transport so the " +
                         "reconnect machinery recovers",
                 )
-                // Close the dead transport on the session scope. This drives the
-                // reader to EOF, which the tmux/reconnect layer already handles as
-                // a recoverable drop through its single reconnect entrypoint — no
-                // second reconnect writer (D28).
-                scope.launch { runCatching { close() } }
+                // Close the dead transport outside the session scope: close()
+                // cancels that scope as part of teardown, so re-entering through
+                // it can cancel the child close before the dispatcher drains.
+                launchTeardown {
+                    runCatching { close() }
+                }
             }
         },
         // Issue #970: timing knobs are read from the test-override seam so the
@@ -373,9 +384,11 @@ internal class RealSshSession(
                 // Channel close is itself a transport write — serialise it
                 // through the dispatcher rather than racing the wire from the
                 // cancellation thread.
-                scope.launch {
-                    runCatching { dispatcher.run { runCatching { cmdRef.get()?.close() } } }
-                    runCatching { dispatcher.run { runCatching { sessionChannelRef.get()?.close() } } }
+                launchTeardown {
+                    closeCommandAndSessionChannel(
+                        command = cmdRef.get(),
+                        sessionChannel = sessionChannelRef.get(),
+                    )
                 }
             }
         }
@@ -483,8 +496,10 @@ internal class RealSshSession(
             // `scope.launch` handler stays as belt-and-braces for the
             // can't-suspend-at-all path).
             withContext(NonCancellable) {
-                runCatching { dispatcher.run { runCatching { cmdRef.get()?.close() } } }
-                runCatching { dispatcher.run { runCatching { sessionChannelRef.get()?.close() } } }
+                closeCommandAndSessionChannel(
+                    command = cmdRef.get(),
+                    sessionChannel = sessionChannelRef.get(),
+                )
             }
         }
     }
@@ -492,6 +507,7 @@ internal class RealSshSession(
     override fun tail(path: String, onLine: (String) -> Unit): Job =
         tail(path, fromLineExclusive = -1, onLine = onLine)
 
+    @OptIn(InternalCoroutinesApi::class)
     override fun tail(path: String, fromLineExclusive: Long, onLine: (String) -> Unit): Job {
         // Each tail owns its own exec channel — running `tail -F` keeps the
         // channel open for the lifetime of the job. Cancelling the job
@@ -563,11 +579,13 @@ internal class RealSshSession(
             // follow loop never wedges the `-CC` write or other ops.
             val sessionChannelRef = AtomicReference<Session?>()
             var cmd: Command? = null
-            val cancelHandle = coroutineJob?.invokeOnCompletion {
+            val cancelHandle = coroutineJob?.invokeOnCompletion(onCancelling = true) {
                 // Close is a transport write — funnel through the dispatcher.
-                scope.launch {
-                    runCatching { dispatcher.run { runCatching { cmd?.close() } } }
-                    runCatching { dispatcher.run { runCatching { sessionChannelRef.get()?.close() } } }
+                launchTeardown {
+                    closeCommandAndSessionChannel(
+                        command = cmd,
+                        sessionChannel = sessionChannelRef.get(),
+                    )
                 }
             }
             try {
@@ -624,8 +642,12 @@ internal class RealSshSession(
                 cancelHandle?.dispose()
                 val closeCmd = cmd
                 val closeChannel = sessionChannelRef.get()
-                runCatching { dispatcher.run { runCatching { closeCmd?.close() } } }
-                runCatching { dispatcher.run { runCatching { closeChannel?.close() } } }
+                withContext(NonCancellable) {
+                    closeCommandAndSessionChannel(
+                        command = closeCmd,
+                        sessionChannel = closeChannel,
+                    )
+                }
             }
         }
     }
@@ -985,6 +1007,7 @@ internal class RealSshSession(
      * copied. Throws [SshException] on a transport failure, a non-zero remote
      * exit, or a timeout — the caller cleans up the temp file.
      */
+    @OptIn(InternalCoroutinesApi::class)
     private suspend fun streamToRemoteTemp(
         input: InputStream,
         name: String,
@@ -1017,12 +1040,14 @@ internal class RealSshSession(
             }
             channel
         }
-        val cancelHandle = coroutineJob?.invokeOnCompletion { cause ->
+        val cancelHandle = coroutineJob?.invokeOnCompletion(onCancelling = true) { cause ->
             if (cause != null) {
                 runCatching { input.close() }
-                scope.launch {
-                    runCatching { dispatcher.run { runCatching { command?.close() } } }
-                    runCatching { dispatcher.run { runCatching { sessionChannel.close() } } }
+                launchTeardown {
+                    closeCommandAndSessionChannel(
+                        command = command,
+                        sessionChannel = sessionChannel,
+                    )
                 }
             }
         }
@@ -1067,8 +1092,12 @@ internal class RealSshSession(
             return copied
         } finally {
             cancelHandle?.dispose()
-            runCatching { dispatcher.run { runCatching { command?.close() } } }
-            runCatching { dispatcher.run { runCatching { sessionChannel.close() } } }
+            withContext(NonCancellable) {
+                closeCommandAndSessionChannel(
+                    command = command,
+                    sessionChannel = sessionChannel,
+                )
+            }
         }
     }
 
@@ -1132,8 +1161,28 @@ internal class RealSshSession(
      */
     private fun cleanupTempDetached(tempRemotePath: String) {
         runCatching {
-            scope.launch {
+            launchTeardown {
                 runCatching { exec("rm -f ${shellSingleQuote(tempRemotePath)}") }
+            }
+        }
+    }
+
+    private fun launchTeardown(block: suspend () -> Unit) {
+        teardownScope.launch(start = CoroutineStart.UNDISPATCHED) {
+            withContext(NonCancellable) {
+                block()
+            }
+        }
+    }
+
+    private suspend fun closeCommandAndSessionChannel(
+        command: Command?,
+        sessionChannel: Session?,
+    ) {
+        runCatching {
+            dispatcher.run {
+                runCatching { command?.close() }
+                runCatching { sessionChannel?.close() }
             }
         }
     }
@@ -1165,6 +1214,10 @@ internal class RealSshSession(
         // Issue #945: stop the transport keepalive before tearing the scope down
         // so no keepalive op is submitted to a dispatcher that is about to close.
         keepAlive.stop()
+        // Cancel active exec/tail/upload jobs before the dispatcher drain. Their
+        // cancellation handlers enqueue best-effort channel closes on
+        // teardownScope, which remains alive until close() finishes, so those
+        // closes can run before the final transport disconnect.
         scope.cancel()
         // Issue #151 + #239: `close()` is idempotent and silent by
         // contract. The v0.2.7 crash report showed the original
@@ -1242,9 +1295,20 @@ internal class RealSshSession(
             // rejected before it can touch the dead transport. The disconnect
             // socket write still happens on the dispatch (IO) thread, so the
             // StrictMode `NetworkOnMainThreadException` guard (issue #166) holds.
-            runBlocking {
-                dispatcher.closeAndAwaitDrain {
-                    client.disconnect()
+            runBlocking(Dispatchers.IO) {
+                val drained = withTimeoutOrNull(SESSION_CLOSE_TIMEOUT_MS) {
+                    dispatcher.closeAndAwaitDrain {
+                        client.disconnect()
+                    }
+                    true
+                } ?: false
+                if (!drained) {
+                    CLOSE_LOGGER.log(
+                        Level.INFO,
+                        "[$CLOSE_LOG_TAG] close() timed out after ${SESSION_CLOSE_TIMEOUT_MS}ms; " +
+                            "forcing dispatcher shutdown",
+                    )
+                    dispatcher.closeNow()
                 }
             }
         } catch (e: TransportException) {
@@ -1289,6 +1353,8 @@ internal class RealSshSession(
                 Level.INFO,
                 "[$CLOSE_LOG_TAG] swallowed RuntimeException during close(): ${e.message}",
             )
+        } finally {
+            teardownScope.cancel()
         }
     }
 
@@ -1555,6 +1621,14 @@ internal const val CLOSE_LOG_TAG: String = "issue239-close-teardown"
 internal const val EXEC_READ_TIMEOUT_MS: Long = 30_000L
 
 private val EXEC_LOGGER: Logger = Logger.getLogger(RealSshSession::class.java.name + ".exec")
+
+/**
+ * Hard ceiling on the caller-visible wait inside [RealSshSession.close] for the
+ * dispatcher drain + final disconnect. The dispatcher's per-op watchdog still
+ * owns normal write interruption; this outer bound prevents a synchronous close
+ * caller from parking behind a half-open transport operation indefinitely.
+ */
+private const val SESSION_CLOSE_TIMEOUT_MS: Long = 2_000L
 
 /**
  * Wall-clock ceiling for the blocking byte-copy + `join()` of a single

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/TransportDispatcher.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/TransportDispatcher.kt
@@ -209,24 +209,41 @@ internal class TransportDispatcher(
      */
     suspend fun closeAndAwaitDrain(disconnect: () -> Unit) {
         if (closed.get()) return
-        mutex.withLock {
-            if (closed.getAndSet(true)) return@withLock
-            // Issue #937 / S4-1 (watchdog fix #940): bound + interrupt the final
-            // disconnect too — a `disconnect()` on a half-open link is itself a
-            // blocking socket write that can wedge. Without a ceiling here a
-            // wedged disconnect would hold [mutex] forever and the teardown's own
-            // caller-side timeout (TmuxSessionViewModel / lease release) could
-            // never make progress. The real wall-clock watchdog inside
-            // [runUnderWallClockCeiling] reclaims the dispatch thread when the
-            // ceiling trips (decoupled from the caller's possibly-virtual test
-            // clock); runCatching swallows the resulting timeout so teardown
-            // always completes and the executor is shut down.
-            runCatching {
-                runInterruptible(context) {
-                    runUnderWallClockCeiling { disconnect() }
+        try {
+            mutex.withLock {
+                if (closed.getAndSet(true)) return@withLock
+                // Issue #937 / S4-1 (watchdog fix #940): bound + interrupt the final
+                // disconnect too — a `disconnect()` on a half-open link is itself a
+                // blocking socket write that can wedge. Without a ceiling here a
+                // wedged disconnect would hold [mutex] forever and the teardown's own
+                // caller-side timeout (TmuxSessionViewModel / lease release) could
+                // never make progress. The real wall-clock watchdog inside
+                // [runUnderWallClockCeiling] reclaims the dispatch thread when the
+                // ceiling trips (decoupled from the caller's possibly-virtual test
+                // clock); runCatching swallows the resulting timeout so teardown
+                // always completes and the executor is shut down.
+                runCatching {
+                    runInterruptible(context) {
+                        runUnderWallClockCeiling { disconnect() }
+                    }
                 }
             }
+        } finally {
+            executor.shutdownNow()
         }
+    }
+
+    /**
+     * Mark the dispatcher closed and interrupt its worker immediately.
+     *
+     * Used only by synchronous session teardown after its caller-visible close
+     * budget expires. The normal path remains [closeAndAwaitDrain], which drains
+     * queued channel-close writes before the final disconnect. Once the outer
+     * close budget has elapsed, preserving caller liveness is more important than
+     * waiting for a half-open transport to accept another orderly packet.
+     */
+    fun closeNow() {
+        closed.set(true)
         executor.shutdownNow()
     }
 

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshSessionTeardownOrderingTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshSessionTeardownOrderingTest.kt
@@ -1,0 +1,291 @@
+package com.pocketshell.core.ssh
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import net.schmizz.sshj.SSHClient
+import net.schmizz.sshj.common.LoggerFactory
+import net.schmizz.sshj.common.Message
+import net.schmizz.sshj.common.SSHException
+import net.schmizz.sshj.common.SSHPacket
+import net.schmizz.sshj.connection.channel.Channel
+import net.schmizz.sshj.connection.channel.direct.PTYMode
+import net.schmizz.sshj.connection.channel.direct.Session
+import net.schmizz.sshj.connection.channel.direct.Signal
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.io.OutputStream
+import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
+import java.util.Collections
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.system.measureTimeMillis
+
+class RealSshSessionTeardownOrderingTest {
+
+    @Test
+    fun `close is bounded when dispatcher is occupied by a wedged transport op`() = runBlocking {
+        val client = WedgedStartSessionClient()
+        val session = RealSshSession(client)
+        val exec = async(Dispatchers.IO) {
+            runCatching { session.exec("true") }
+        }
+
+        assertTrue(
+            "the synthetic startSession must enter before close queues behind it",
+            client.startSessionEntered.await(5, TimeUnit.SECONDS),
+        )
+
+        val elapsedMs = measureTimeMillis {
+            session.close()
+        }
+
+        assertTrue(
+            "close() must return within the session close budget instead of waiting " +
+                "for the dispatcher's full per-op ceiling; elapsed=${elapsedMs}ms",
+            elapsedMs < 3_500L,
+        )
+        assertFalse("close must mark the session disconnected", session.isConnected)
+
+        withTimeout(5_000L) {
+            exec.await()
+        }
+        assertTrue(
+            "force-closing the dispatcher must interrupt the wedged startSession",
+            client.startSessionInterrupted.get(),
+        )
+    }
+
+    @Test
+    fun `close with active tail queues channel closes before session disconnect`() = runBlocking {
+        val events = RecordingEvents()
+        val command = BlockingTailCommand(events)
+        val channel = RecordingSessionChannel(command, events)
+        val client = RecordingClient(channel, events)
+        val session = RealSshSession(client)
+
+        val tail = session.tail("/tmp/log") { }
+        assertTrue(
+            "tail read must start before cancellation",
+            command.readStarted.await(5, TimeUnit.SECONDS),
+        )
+
+        session.close()
+        tail.cancelAndJoin()
+
+        val snapshot = events.snapshot()
+        val commandClose = snapshot.indexOf("command.close")
+        val channelClose = snapshot.indexOf("session.close")
+        val disconnect = snapshot.indexOf("disconnect")
+
+        assertTrue("command.close must be recorded: $snapshot", commandClose >= 0)
+        assertTrue("session.close must be recorded: $snapshot", channelClose >= 0)
+        assertTrue("disconnect must be recorded: $snapshot", disconnect >= 0)
+        assertTrue(
+            "tail command close must be queued before transport disconnect: $snapshot",
+            commandClose < disconnect,
+        )
+        assertTrue(
+            "tail session channel close must be queued before transport disconnect: $snapshot",
+            channelClose < disconnect,
+        )
+    }
+
+    @Test
+    fun `keepalive-dead teardown disconnects through independent teardown path`() {
+        KeepAliveTestOverride.setForTest(intervalMs = 10L, countMax = 1)
+        val client = KeepAliveDeadClient()
+        val session = RealSshSession(client)
+        try {
+            assertTrue(
+                "keepalive death must close the transport",
+                client.disconnected.await(5, TimeUnit.SECONDS),
+            )
+            assertFalse("closed keepalive-dead session must report disconnected", session.isConnected)
+        } finally {
+            session.close()
+            KeepAliveTestOverride.clear()
+        }
+    }
+
+    private class WedgedStartSessionClient : SSHClient() {
+        val startSessionEntered = CountDownLatch(1)
+        val startSessionInterrupted = AtomicBoolean(false)
+
+        @Volatile
+        private var disconnected = false
+
+        override fun isConnected(): Boolean = !disconnected
+        override fun isAuthenticated(): Boolean = !disconnected
+
+        override fun startSession(): Session {
+            startSessionEntered.countDown()
+            try {
+                while (true) {
+                    if (Thread.interrupted()) {
+                        startSessionInterrupted.set(true)
+                        throw InterruptedException("wedged startSession interrupted")
+                    }
+                    Thread.sleep(10L)
+                }
+            } catch (e: InterruptedException) {
+                startSessionInterrupted.set(true)
+                throw e
+            }
+        }
+
+        override fun disconnect() {
+            disconnected = true
+        }
+    }
+
+    private class KeepAliveDeadClient : SSHClient() {
+        val disconnected = CountDownLatch(1)
+
+        @Volatile
+        private var closed = false
+
+        override fun isConnected(): Boolean = !closed
+        override fun isAuthenticated(): Boolean = !closed
+
+        override fun disconnect() {
+            closed = true
+            disconnected.countDown()
+        }
+    }
+
+    private class RecordingClient(
+        private val sessionChannel: Session,
+        private val events: RecordingEvents,
+    ) : SSHClient() {
+        @Volatile
+        private var disconnected = false
+
+        override fun isConnected(): Boolean = !disconnected
+        override fun isAuthenticated(): Boolean = !disconnected
+        override fun startSession(): Session = sessionChannel
+
+        override fun disconnect() {
+            events.add("disconnect")
+            disconnected = true
+        }
+    }
+
+    private class RecordingSessionChannel(
+        private val command: Session.Command,
+        private val events: RecordingEvents,
+    ) : FakeChannel(), Session {
+        override fun exec(command: String): Session.Command = this.command
+
+        override fun close() {
+            events.add("session.close")
+            super.close()
+        }
+
+        override fun allocateDefaultPTY() = Unit
+        override fun allocatePTY(
+            term: String,
+            cols: Int,
+            rows: Int,
+            width: Int,
+            height: Int,
+            modes: MutableMap<PTYMode, Int>,
+        ) = Unit
+
+        override fun reqX11Forwarding(host: String, proto: String, cookie: Int) = Unit
+        override fun setEnvVar(name: String, value: String) = Unit
+        override fun startShell(): Session.Shell = throw UnsupportedOperationException("not used")
+        override fun startSubsystem(name: String): Session.Subsystem =
+            throw UnsupportedOperationException("not used")
+    }
+
+    private class BlockingTailCommand(
+        private val events: RecordingEvents,
+    ) : FakeChannel(), Session.Command {
+        val readStarted = CountDownLatch(1)
+        private val stdout = BlockingInputStream(readStarted)
+
+        override fun getInputStream(): InputStream = stdout
+        override fun getErrorStream(): InputStream = ByteArrayInputStream(ByteArray(0))
+        override fun getExitErrorMessage(): String? = null
+        override fun getExitSignal(): Signal? = null
+        override fun getExitStatus(): Int = 0
+        override fun getExitWasCoreDumped(): Boolean = false
+        override fun signal(signal: Signal) = Unit
+
+        override fun close() {
+            events.add("command.close")
+            super.close()
+            stdout.close()
+        }
+    }
+
+    private class BlockingInputStream(
+        private val readStarted: CountDownLatch,
+    ) : InputStream() {
+        @Volatile
+        private var closed = false
+
+        override fun read(): Int {
+            readStarted.countDown()
+            while (!closed) {
+                Thread.sleep(10L)
+            }
+            return -1
+        }
+
+        override fun close() {
+            closed = true
+        }
+    }
+
+    private class RecordingEvents {
+        private val events = Collections.synchronizedList(mutableListOf<String>())
+
+        fun add(event: String) {
+            events += event
+        }
+
+        fun snapshot(): List<String> = synchronized(events) {
+            events.toList()
+        }
+    }
+
+    private abstract class FakeChannel : Channel {
+        @Volatile
+        var closed: Boolean = false
+            private set
+
+        override fun close() {
+            closed = true
+        }
+
+        override fun getAutoExpand(): Boolean = false
+        override fun getID(): Int = 1
+        override fun getInputStream(): InputStream = ByteArrayInputStream(ByteArray(0))
+        override fun getLocalMaxPacketSize(): Int = 32 * 1024
+        override fun getLocalWinSize(): Long = 0L
+        override fun getOutputStream(): OutputStream = ByteArrayOutputStream()
+        override fun getRecipient(): Int = 1
+        override fun getRemoteCharset(): Charset = StandardCharsets.UTF_8
+        override fun getRemoteMaxPacketSize(): Int = 32 * 1024
+        override fun getRemoteWinSize(): Long = 0L
+        override fun getType(): String = "session"
+        override fun isOpen(): Boolean = !closed
+        override fun setAutoExpand(autoExpand: Boolean) = Unit
+        override fun join() = Unit
+        override fun join(timeout: Long, unit: TimeUnit) = Unit
+        override fun isEOF(): Boolean = false
+        override fun getLoggerFactory(): LoggerFactory = LoggerFactory.DEFAULT
+        override fun handle(message: Message, packet: SSHPacket) = Unit
+        override fun notifyError(error: SSHException) = Unit
+    }
+}

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/TransportDispatcherWedgeBoundTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/TransportDispatcherWedgeBoundTest.kt
@@ -1,16 +1,18 @@
 package com.pocketshell.core.ssh
 
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.async
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.withTimeoutOrNull
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 
 /**
@@ -156,6 +158,70 @@ class TransportDispatcherWedgeBoundTest {
 
         latch.countDown()
     }
+
+    /**
+     * Regression for forced close after caller-side timeout: closeAndAwaitDrain
+     * sets `closed=true` before it runs the final disconnect. If the caller's
+     * outer close budget expires while disconnect is still wedged, closeNow()
+     * must still interrupt/shutdown the worker even though the dispatcher is
+     * already marked closed.
+     */
+    @Test
+    fun `closeNow interrupts after closeAndAwaitDrain times out during disconnect`() =
+        runBlocking<Unit> {
+            val dispatcher = TransportDispatcher(perOpTimeoutMs = 30_000L)
+            val disconnectEntered = CountDownLatch(1)
+            val firstInterrupt = CountDownLatch(1)
+            val forcedInterrupt = CountDownLatch(1)
+
+            val closing = async(Dispatchers.IO) {
+                runCatching {
+                    withTimeout(250L) {
+                        dispatcher.closeAndAwaitDrain disconnect@{
+                            disconnectEntered.countDown()
+                            var interrupts = 0
+                            while (true) {
+                                try {
+                                    Thread.sleep(30_000L)
+                                } catch (e: InterruptedException) {
+                                    interrupts += 1
+                                    if (interrupts == 1) {
+                                        firstInterrupt.countDown()
+                                    }
+                                    if (interrupts == 2) {
+                                        forcedInterrupt.countDown()
+                                        return@disconnect
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            assertTrue(
+                "disconnect must enter before the caller-side timeout",
+                disconnectEntered.await(5, TimeUnit.SECONDS),
+            )
+
+            val closeResult = closing.await()
+            assertTrue(
+                "caller-side timeout must cancel closeAndAwaitDrain while disconnect is active",
+                closeResult.exceptionOrNull() is TimeoutCancellationException,
+            )
+            assertTrue(
+                "timeout cancellation should interrupt the disconnect once",
+                firstInterrupt.await(5, TimeUnit.SECONDS),
+            )
+            assertTrue("dispatcher must already be marked closed", dispatcher.isClosed)
+
+            dispatcher.closeNow()
+
+            assertTrue(
+                "forced close must still interrupt/shutdown after closed was already set",
+                forcedInterrupt.await(5, TimeUnit.SECONDS),
+            )
+        }
 
     /**
      * Class coverage: a HEALTHY op well under the ceiling is unaffected — the


### PR DESCRIPTION
## Summary
- keep teardown channel-close writes alive outside the session scope until close() finishes
- bound RealSshSession.close() around dispatcher drain/disconnect and force dispatcher shutdown on timeout
- add regression coverage for active-tail teardown ordering, keepalive-dead close, and closeNow interruption after timed-out disconnect

## Verification
- ./gradlew :shared:core-ssh:testDebugUnitTest --tests 'com.pocketshell.core.ssh.RealSshSessionTeardownOrderingTest' --tests 'com.pocketshell.core.ssh.TransportDispatcherWedgeBoundTest'\n\nRefs #935