### PR TITLE
Fix port-forward received byte counting race

### DIFF
--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshPortForward.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshPortForward.kt
@@ -190,9 +190,9 @@ internal class RealSshPortForward(
             while (running.get()) {
                 val n = src.read(buf)
                 if (n < 0) break
+                counter.addAndGet(n.toLong())
                 dst.write(buf, 0, n)
                 dst.flush()
-                counter.addAndGet(n.toLong())
             }
         } catch (_: IOException) {
             // Either side closed; normal termination of the copy loop.

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshPortForwardCountersTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshPortForwardCountersTest.kt
@@ -1,0 +1,78 @@
+package com.pocketshell.core.ssh
+
+import net.schmizz.sshj.connection.channel.direct.DirectConnection
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.InputStream
+import java.io.OutputStream
+import java.net.InetAddress
+import java.net.ServerSocket
+import java.util.concurrent.atomic.AtomicLong
+
+class RealSshPortForwardCountersTest {
+
+    @Test
+    fun `copy counts bytes as soon as they are read before local write can observe them`() {
+        val localPort = ServerSocket(0, 1, InetAddress.getByName("127.0.0.1"))
+            .use { it.localPort }
+        val forward = RealSshPortForward(
+            channels = object : PortForwardChannelTransport {
+                override fun openChannel(remoteHost: String, remotePort: Int): DirectConnection =
+                    error("test does not accept local connections")
+
+                override fun closeChannel(channel: DirectConnection) = Unit
+            },
+            remoteHost = "remote.example",
+            remotePort = 5432,
+            localPort = localPort,
+        )
+        try {
+            val counter = AtomicLong(0)
+            val input = SingleReadInputStream(byteArrayOf(1, 2, 3, 4))
+            var counterObservedInWrite = -1L
+            val output = object : OutputStream() {
+                override fun write(b: Int) = Unit
+
+                override fun write(b: ByteArray, off: Int, len: Int) {
+                    counterObservedInWrite = counter.get()
+                }
+            }
+
+            val copy = RealSshPortForward::class.java.getDeclaredMethod(
+                "copy",
+                InputStream::class.java,
+                OutputStream::class.java,
+                AtomicLong::class.java,
+            )
+            copy.isAccessible = true
+            copy.invoke(forward, input, output, counter)
+
+            assertEquals(4, counter.get())
+            assertEquals(4, counterObservedInWrite)
+            assertTrue(input.exhausted)
+        } finally {
+            forward.close()
+        }
+    }
+
+    private class SingleReadInputStream(
+        private val bytes: ByteArray,
+    ) : InputStream() {
+        var exhausted = false
+            private set
+        private var read = false
+
+        override fun read(): Int = error("bulk read expected")
+
+        override fun read(b: ByteArray, off: Int, len: Int): Int {
+            if (read) {
+                exhausted = true
+                return -1
+            }
+            read = true
+            bytes.copyInto(b, off, 0, bytes.size)
+            return bytes.size
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- increment the port-forward received/forwarded byte counter immediately after a successful read
- add a focused RealSshPortForward copy-loop regression test that observes the counter before write/flush

## Verification
- ./gradlew :shared:core-ssh:testReleaseUnitTest --tests com.pocketshell.core.ssh.RealSshPortForwardCountersTest --tests com.pocketshell.core.ssh.PortForwardSingleWriterTest