### PR TITLE
agents: clear recorded source on manual kind write

### DIFF
--- a/app/src/main/java/com/pocketshell/app/projects/ManualKindWriter.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/ManualKindWriter.kt
@@ -21,7 +21,10 @@ import com.pocketshell.uikit.model.tmuxOptionValue
  * — choose") and, on pick, writes the same `@ps_agent_kind` option HERE, over
  * the warm SSH/tmux session, so the chosen kind becomes the durable recorded
  * kind. The SAME write also drives the "change kind" affordance for an
- * already-classified session — rewriting the option flips the recorded kind.
+ * already-classified session — rewriting the option flips the recorded kind
+ * and clears any launch-recorded transcript source so a stale
+ * `@ps_agent_source` cannot keep the Conversation bound to the previous
+ * identity.
  *
  * Writing the SAME tmux user option that `record_agent_kind` writes means the
  * value round-trips through the unchanged read-back path
@@ -33,7 +36,9 @@ import com.pocketshell.uikit.model.tmuxOptionValue
  *
  * Mirror of the server-side argv (`agents.py`):
  * ```
- * tmux set-option -t <session> @ps_agent_kind <value>
+ * tmux set-option -t <session> @ps_agent_kind <value> \; \
+ *   set-option -u -q -t <session> @ps_agent_source_generation \; \
+ *   set-option -u -q -t <session> @ps_agent_source
  * ```
  * The wrapper omits `-t` (it runs inside the target session); the client is
  * NOT inside the session, so it must target it explicitly with `-t`. The
@@ -42,16 +47,18 @@ import com.pocketshell.uikit.model.tmuxOptionValue
 internal object ManualKindWriter {
 
     /**
-     * Build the `tmux set-option -t <session> @ps_agent_kind <value>` command
-     * for [sessionName] and [kind]. Returns `null` when [kind] has no durable
-     * recorded value (Probing / Exited / Unknown — see
-     * [SessionAgentKind.tmuxOptionValue]); the caller must not write a
-     * non-classification kind. [sessionName] is single-quoted so a name with
-     * shell metacharacters cannot break out of the argument.
+     * Build the manual recorded-kind command for [sessionName] and [kind].
+     * Returns `null` when [kind] has no durable recorded value (Probing /
+     * Exited / Unknown — see [SessionAgentKind.tmuxOptionValue]); the caller
+     * must not write a non-classification kind. [sessionName] is single-quoted
+     * so a name with shell metacharacters cannot break out of the argument.
      */
     fun buildSetOptionCommand(sessionName: String, kind: SessionAgentKind): String? {
         val value = kind.tmuxOptionValue() ?: return null
-        return "tmux set-option -t ${shellSingleQuote(sessionName)} @ps_agent_kind $value"
+        val target = shellSingleQuote(sessionName)
+        return "tmux set-option -t $target @ps_agent_kind $value" +
+            " \\; set-option -u -q -t $target @ps_agent_source_generation" +
+            " \\; set-option -u -q -t $target @ps_agent_source"
     }
 
     /**

--- a/app/src/test/java/com/pocketshell/app/projects/ManualKindWriterTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/ManualKindWriterTest.kt
@@ -26,21 +26,21 @@ class ManualKindWriterTest {
     @Test
     fun `builds session-scoped set-option command for each pickable kind`() {
         assertEquals(
-            "tmux set-option -t 'work' @ps_agent_kind claude",
+            manualKindCommand("work", "claude"),
             ManualKindWriter.buildSetOptionCommand("work", SessionAgentKind.Claude),
         )
         assertEquals(
-            "tmux set-option -t 'work' @ps_agent_kind codex",
+            manualKindCommand("work", "codex"),
             ManualKindWriter.buildSetOptionCommand("work", SessionAgentKind.Codex),
         )
         assertEquals(
-            "tmux set-option -t 'work' @ps_agent_kind opencode",
+            manualKindCommand("work", "opencode"),
             ManualKindWriter.buildSetOptionCommand("work", SessionAgentKind.OpenCode),
         )
         // A manually-classified plain shell IS recordable (so it never
         // re-prompts as Unknown) — the one extra value over the wrapper.
         assertEquals(
-            "tmux set-option -t 'work' @ps_agent_kind shell",
+            manualKindCommand("work", "shell"),
             ManualKindWriter.buildSetOptionCommand("work", SessionAgentKind.Shell),
         )
     }
@@ -48,9 +48,18 @@ class ManualKindWriterTest {
     @Test
     fun `single-quotes a session name with shell metacharacters`() {
         assertEquals(
-            "tmux set-option -t 'a'\\''b c' @ps_agent_kind claude",
+            manualKindCommand("a'\\''b c", "claude"),
             ManualKindWriter.buildSetOptionCommand("a'b c", SessionAgentKind.Claude),
         )
+    }
+
+    @Test
+    fun `manual kind write clears stale recorded transcript source`() {
+        val command = ManualKindWriter.buildSetOptionCommand("work", SessionAgentKind.Codex)!!
+
+        assertTrue(command.contains("@ps_agent_kind codex"))
+        assertTrue(command.contains("set-option -u -q -t 'work' @ps_agent_source_generation"))
+        assertTrue(command.contains("set-option -u -q -t 'work' @ps_agent_source"))
     }
 
     @Test
@@ -65,7 +74,7 @@ class ManualKindWriterTest {
         val session = RecordingSshSession()
         ManualKindWriter.write(session, "work", SessionAgentKind.Codex)
         assertEquals(
-            listOf("tmux set-option -t 'work' @ps_agent_kind codex"),
+            listOf(manualKindCommand("work", "codex")),
             session.commands,
         )
     }
@@ -125,5 +134,12 @@ class ManualKindWriterTest {
             remotePath: String,
         ): String = error("not used")
         override fun close() = Unit
+    }
+
+    private companion object {
+        fun manualKindCommand(target: String, kind: String): String =
+            "tmux set-option -t '$target' @ps_agent_kind $kind" +
+                " \\; set-option -u -q -t '$target' @ps_agent_source_generation" +
+                " \\; set-option -u -q -t '$target' @ps_agent_source"
     }
 }


### PR DESCRIPTION
## Summary
- Clear `@ps_agent_source_generation` and `@ps_agent_source` whenever `ManualKindWriter` records a user-chosen kind.
- Keep manual/foreign reclassification from reusing a launch-recorded transcript source left behind by a previous identity.
- Extend `ManualKindWriterTest` to cover the new command shape and stale-source clearing.

## Verification
- `./gradlew :app:testDebugUnitTest --tests com.pocketshell.app.projects.ManualKindWriterTest`
- `git diff --check`
- Throwaway tmux syntax check for the chained `set-option` command

Refs #821
Follow-up to #1016