### PR TITLE
test: cover attachment dry-run quoting

### DIFF
--- a/app/src/test/java/com/pocketshell/app/composer/AttachmentRetentionPolicyTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/AttachmentRetentionPolicyTest.kt
@@ -124,6 +124,21 @@ class AttachmentRetentionPolicyTest {
         assertFalse(commands.single().contains("rm -f"))
     }
 
+    @Test
+    fun dryRunCommandsShellQuoteFileNames() {
+        val commands = RemoteAttachmentPruner.buildDeleteCommands(
+            remoteDir = ".pocketshell/attachments/host-1",
+            names = listOf("quote's \$file.txt"),
+            dryRun = true,
+            batchSize = 50,
+        )
+
+        assertEquals(
+            listOf("printf 'would-delete\\t%s\\n' '~/.pocketshell/attachments/host-1/quote'\\''s \$file.txt'"),
+            commands,
+        )
+    }
+
     private fun file(name: String, modifiedMillis: Long): RemoteEntry =
         RemoteEntry(
             name = name,


### PR DESCRIPTION
## Summary
- Add focused coverage for attachment prune dry-run command quoting when file names contain single quotes and shell metacharacters.

References #684.

## Verification
- ./gradlew :app:testDebugUnitTest --tests com.pocketshell.app.composer.AttachmentRetentionPolicyTest
- git diff --check