### PR TITLE
Gate outbound queue android test

### DIFF
--- a/scripts/check-ci-journey-harness-selftest.sh
+++ b/scripts/check-ci-journey-harness-selftest.sh
@@ -12,7 +12,11 @@ cleanup() {
 }
 trap cleanup EXIT
 
-mkdir -p "$SANDBOX/scripts" "$SANDBOX/app/src/androidTest/java/com/pocketshell/app/proof"
+mkdir -p \
+  "$SANDBOX/scripts" \
+  "$SANDBOX/app/src/androidTest/java/com/pocketshell/app/composer" \
+  "$SANDBOX/app/src/androidTest/java/com/pocketshell/app/costs" \
+  "$SANDBOX/app/src/androidTest/java/com/pocketshell/app/proof"
 
 cat > "$SANDBOX/scripts/ci-journey-suite.sh" <<'SH'
 #!/usr/bin/env bash
@@ -24,9 +28,20 @@ JOURNEY_CLASSES=(
   "$FQCN_PREFIX.GoodLaunchOwnedE2eTest"
   "$FQCN_PREFIX.ExemptManualHarnessE2eTest"
   "com.pocketshell.app.proof.DirectProofEntryE2eTest#singleMethod"
+  "com.pocketshell.app.composer.PromptComposerOutboundQueueTest"
   "com.pocketshell.app.tmux.NotAProofEntryE2eTest"
 )
 SH
+
+cat > "$SANDBOX/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerOutboundQueueTest.kt" <<'KT'
+package com.pocketshell.app.composer
+class PromptComposerOutboundQueueTest
+KT
+
+cat > "$SANDBOX/app/src/androidTest/java/com/pocketshell/app/costs/CostsScreenE2eTest.kt" <<'KT'
+package com.pocketshell.app.costs
+class CostsScreenE2eTest
+KT
 
 cat > "$SANDBOX/app/src/androidTest/java/com/pocketshell/app/proof/BadManualHarnessE2eTest.kt" <<'KT'
 package com.pocketshell.app.proof
@@ -154,16 +169,23 @@ else
   note_fail "inline manual exemption was incorrectly reported as a new failure"
 fi
 
-if ! printf '%s' "$out" | grep -q 'NotListedBadManualE2eTest'; then
-  note_pass "unlisted proof fixture is ignored"
+if printf '%s' "$out" | awk '/NEW FAIL - androidTest E2e\/Docker class not wired/{capture=1; next} /^$/{if (capture) exit} capture {print}' | grep -q 'NotListedBadManualE2eTest'; then
+  note_pass "unlisted E2e/Docker fixture is reported by the per-push wiring guard"
 else
-  note_fail "unlisted proof fixture should not be scanned"
+  note_fail "unlisted E2e/Docker fixture should be reported as unwired"
+fi
+
+if printf '%s' "$out" | awk '/KNOWN - unwired androidTest E2e\/Docker baseline/{capture=1; next} /^$/{if (capture) exit} capture {print}' | grep -q 'CostsScreenE2eTest'; then
+  note_pass "known current unwired E2e/Docker baseline is spared"
+else
+  note_fail "known current unwired E2e/Docker baseline should be spared"
 fi
 
 rm -f \
   "$SANDBOX/app/src/androidTest/java/com/pocketshell/app/proof/BadManualHarnessE2eTest.kt" \
   "$SANDBOX/app/src/androidTest/java/com/pocketshell/app/proof/BadMissingSeedE2eTest.kt" \
-  "$SANDBOX/app/src/androidTest/java/com/pocketshell/app/proof/BadCommentOnlySeedE2eTest.kt"
+  "$SANDBOX/app/src/androidTest/java/com/pocketshell/app/proof/BadCommentOnlySeedE2eTest.kt" \
+  "$SANDBOX/app/src/androidTest/java/com/pocketshell/app/proof/NotListedBadManualE2eTest.kt"
 cat > "$SANDBOX/scripts/ci-journey-suite.sh" <<'SH'
 #!/usr/bin/env bash
 FQCN_PREFIX="com.pocketshell.app.proof"
@@ -171,6 +193,7 @@ JOURNEY_CLASSES=(
   "$FQCN_PREFIX.GoodLaunchOwnedE2eTest"
   "$FQCN_PREFIX.ExemptManualHarnessE2eTest"
   "com.pocketshell.app.proof.DirectProofEntryE2eTest#singleMethod"
+  "com.pocketshell.app.composer.PromptComposerOutboundQueueTest"
 )
 SH
 
@@ -187,6 +210,7 @@ cat > "$SANDBOX/scripts/ci-journey-suite.sh" <<'SH'
 FQCN_PREFIX="com.pocketshell.app.proof"
 JOURNEY_CLASSES=(
   "$FQCN_PREFIX.DeepLinkSessionSwitchE2eTest"
+  "com.pocketshell.app.composer.PromptComposerOutboundQueueTest"
 )
 SH
 cat > "$SANDBOX/app/src/androidTest/java/com/pocketshell/app/proof/DeepLinkSessionSwitchE2eTest.kt" <<'KT'
@@ -212,6 +236,7 @@ cat > "$SANDBOX/scripts/ci-journey-suite.sh" <<'SH'
 FQCN_PREFIX="com.pocketshell.app.proof"
 JOURNEY_CLASSES=(
   "com.pocketshell.app.tmux.NotAProofEntryE2eTest"
+  "com.pocketshell.app.composer.PromptComposerOutboundQueueTest"
 )
 SH
 

--- a/scripts/check-ci-journey-harness.sh
+++ b/scripts/check-ci-journey-harness.sh
@@ -65,6 +65,101 @@ KNOWN_LAUNCH_OWNED_WITHOUT_SHARED_SEED=(
   "ReconnectKebabInPlaceJourneyE2eTest"
 )
 
+# Narrow #848 audit pins: connected androidTests that must stay in the per-push
+# journey allowlist even though they do not necessarily use the proof package or
+# E2e/Docker suffix convention.
+REQUIRED_PER_PUSH_ANDROID_TEST_CLASSES=(
+  "com.pocketshell.app.composer.PromptComposerOutboundQueueTest"
+)
+
+# Current-main androidTest E2e/Docker backlog that is intentionally not in the
+# per-push journey allowlist. New *E2eTest/*DockerTest classes must either be
+# wired into scripts/ci-journey-suite.sh or added here with an intentional
+# follow-up. Keep full FQCNs so moves are visible.
+KNOWN_UNWIRED_ANDROID_E2E_DOCKER_CLASSES=(
+  "com.pocketshell.app.composer.AttachmentStagerRealUploadDockerTest"
+  "com.pocketshell.app.composer.ComposerPartialExpandE2eTest"
+  "com.pocketshell.app.composer.PromptComposerSendDismissE2eTest"
+  "com.pocketshell.app.costs.CostsScreenE2eTest"
+  "com.pocketshell.app.crash.ShareAllReportsDockerTest"
+  "com.pocketshell.app.env.EnvScreenE2eTest"
+  "com.pocketshell.app.fileexplorer.FileExplorerDockerTest"
+  "com.pocketshell.app.fileviewer.FileViewerDockerTest"
+  "com.pocketshell.app.fileviewer.LinkTapParsingDockerTest"
+  "com.pocketshell.app.fileviewer.TerminalFilePathTapToViewerDockerTest"
+  "com.pocketshell.app.git.GitHistoryDockerTest"
+  "com.pocketshell.app.hosts.DefaultHostLaunchE2eTest"
+  "com.pocketshell.app.hosts.HostAndFolderListScrollE2eTest"
+  "com.pocketshell.app.hosts.HostEditFromKebabE2eTest"
+  "com.pocketshell.app.notifications.UpdateAvailableNotificationE2eTest"
+  "com.pocketshell.app.portfwd.ForwardingIndicatorE2eTest"
+  "com.pocketshell.app.portfwd.ForwardingNotificationE2eTest"
+  "com.pocketshell.app.portfwd.ForwardingResumeOnLaunchE2eTest"
+  "com.pocketshell.app.portfwd.PortForwardPanelLifecycleE2eTest"
+  "com.pocketshell.app.projects.AgentLaunchCommandDockerTest"
+  "com.pocketshell.app.projects.FolderListGatewayDockerTest"
+  "com.pocketshell.app.projects.FolderListGatewayStaleChannelHealDockerTest"
+  "com.pocketshell.app.projects.FolderListKillSessionDockerTest"
+  "com.pocketshell.app.projects.FolderListOutOfBandSessionDockerTest"
+  "com.pocketshell.app.projects.FolderListSessionResumeDockerTest"
+  "com.pocketshell.app.projects.FolderListTreeStopSessionDockerTest"
+  "com.pocketshell.app.projects.WatchedFoldersE2eTest"
+  "com.pocketshell.app.proof.BackgroundResumeSocketDeathE2eTest"
+  "com.pocketshell.app.proof.CodexOverflowNoReconnectE2eTest"
+  "com.pocketshell.app.proof.CodexRedrawOverflowReconnectE2eTest"
+  "com.pocketshell.app.proof.CodexWindowStartupControlSequenceE2eTest"
+  "com.pocketshell.app.proof.ColdInstallE2eTest"
+  "com.pocketshell.app.proof.DisconnectBlackholeE2eTest"
+  "com.pocketshell.app.proof.DisconnectFlapSoakE2eTest"
+  "com.pocketshell.app.proof.EmulatorWorkflowE2eTest"
+  "com.pocketshell.app.proof.FastResumeReconnectE2eTest"
+  "com.pocketshell.app.proof.MultiHostSessionE2eTest"
+  "com.pocketshell.app.proof.NavigatorBackForegroundNoSshE2eTest"
+  "com.pocketshell.app.proof.NetworkLatencyModelE2eTest"
+  "com.pocketshell.app.proof.NoBackgroundWorkE2eTest"
+  "com.pocketshell.app.proof.PacketLossNetworkFaultE2eTest"
+  "com.pocketshell.app.proof.ProjectSwitcherDropdownE2eTest"
+  "com.pocketshell.app.proof.RideThroughInterruptionE2eTest"
+  "com.pocketshell.app.proof.SessionSwipeSwitchE2eTest"
+  "com.pocketshell.app.proof.SilentMidSessionDropDetectionE2eTest"
+  "com.pocketshell.app.proof.SshReconnectE2eTest"
+  "com.pocketshell.app.proof.StaleLeaseSwitchRecoveryE2eTest"
+  "com.pocketshell.app.proof.StrictModeNoNetworkOnMainE2eTest"
+  "com.pocketshell.app.proof.SystemBackForegroundE2eTest"
+  "com.pocketshell.app.proof.TmuxBracketedPasteDictationE2eTest"
+  "com.pocketshell.app.proof.TmuxDetachOnBackgroundE2eTest"
+  "com.pocketshell.app.proof.TmuxExternalUpdateDockerTest"
+  "com.pocketshell.app.proof.TmuxKeyBarCtrlComboE2eTest"
+  "com.pocketshell.app.proof.TmuxOrphanClientCleanupE2eTest"
+  "com.pocketshell.app.proof.TmuxSessionSwitchE2eTest"
+  "com.pocketshell.app.proof.TmuxSessionSwitchSameHostReusesSshE2eTest"
+  "com.pocketshell.app.proof.TmuxTerminalSurfaceFailureE2eTest"
+  "com.pocketshell.app.proof.WarmLeaseReuseBatchCDockerTest"
+  "com.pocketshell.app.proof.WarmLeaseReuseDockerTest"
+  "com.pocketshell.app.proof.WithinGraceResumeRideThroughE2eTest"
+  "com.pocketshell.app.release.UpdateCheckSchedulerE2eTest"
+  "com.pocketshell.app.session.ConversationToolResultPairingE2eTest"
+  "com.pocketshell.app.session.ShowKeyboardChipE2eTest"
+  "com.pocketshell.app.settings.ConversationFontSizeSettingE2eTest"
+  "com.pocketshell.app.settings.DiagnosticsRecordingIndicatorE2eTest"
+  "com.pocketshell.app.settings.SettingsAboutFooterE2eTest"
+  "com.pocketshell.app.settings.SettingsPersistenceE2eTest"
+  "com.pocketshell.app.settings.SettingsSectionOrderE2eTest"
+  "com.pocketshell.app.share.SharePasteIntoSessionE2eTest"
+  "com.pocketshell.app.snippets.SnippetPickerTmuxZOrderDockerTest"
+  "com.pocketshell.app.terminal.TerminalLabDockerTest"
+  "com.pocketshell.app.tmux.ConversationOpenLatencyRttDockerTest"
+  "com.pocketshell.app.tmux.Issue887TerminalFixedUnderImeE2eTest"
+  "com.pocketshell.app.tmux.TmuxAttachPrefillDockerTest"
+  "com.pocketshell.app.tmux.TmuxAttachTimeoutDockerTest"
+  "com.pocketshell.app.tmux.TmuxDetectedPortForwardDockerTest"
+  "com.pocketshell.app.tmux.TmuxResizeSessionE2eTest"
+  "com.pocketshell.app.tmux.TmuxSessionOpencodeInputDockerTest"
+  "com.pocketshell.app.tmux.TmuxShellComposerOcclusionE2eTest"
+  "com.pocketshell.app.usage.UsageScreenE2eTest"
+  "com.pocketshell.app.usage.UsageThresholdNotificationE2eTest"
+)
+
 in_list() {
   local item="$1"; shift
   local candidate
@@ -109,6 +204,19 @@ class_file_for() {
   printf '%s/com/pocketshell/app/proof/%s.kt\n' "$ANDROID_TEST_ROOT" "$class_name"
 }
 
+android_class_file_for() {
+  local fqcn="$1"
+  local rel="${fqcn//.//}"
+  printf '%s/%s.kt\n' "$ANDROID_TEST_ROOT" "$rel"
+}
+
+android_test_fqcn_for_file() {
+  local file="$1"
+  local rel="${file#"$ANDROID_TEST_ROOT"/}"
+  rel="${rel%.kt}"
+  printf '%s\n' "${rel//\//.}"
+}
+
 declare -a JOURNEY_CLASSES=()
 declare -A SEEN=()
 while IFS= read -r class_name; do
@@ -124,6 +232,21 @@ done < <(
     "$SUITE"
 )
 
+declare -a WIRED_ANDROID_TEST_CLASSES=()
+declare -A WIRED_ANDROID_TEST_SEEN=()
+while IFS= read -r fqcn; do
+  [[ -z "${fqcn:-}" ]] && continue
+  if [[ -z "${WIRED_ANDROID_TEST_SEEN[$fqcn]:-}" ]]; then
+    WIRED_ANDROID_TEST_CLASSES+=("$fqcn")
+    WIRED_ANDROID_TEST_SEEN[$fqcn]=1
+  fi
+done < <(
+  sed -nE \
+    -e 's/.*"\$FQCN_PREFIX\.([A-Za-z0-9_]+)(#[^"]*)?".*/com.pocketshell.app.proof.\1/p' \
+    -e 's/.*"(com\.pocketshell\.app\.[A-Za-z0-9_.]+)(#[^"]*)?".*/\1/p' \
+    "$SUITE"
+)
+
 declare -a MISSING_FILES=()
 declare -a MANUAL_NEW=()
 declare -a MANUAL_KNOWN=()
@@ -135,10 +258,45 @@ declare -a COMPLIANT=()
 declare -a NOT_MAINACTIVITY_LAUNCHERS=()
 declare -a STALE_BASELINE=()
 declare -a PARSER_FAILURE=()
+declare -a REQUIRED_PER_PUSH_WIRED=()
+declare -a MISSING_REQUIRED_PER_PUSH=()
+declare -a UNWIRED_ANDROID_E2E_DOCKER_NEW=()
+declare -a UNWIRED_ANDROID_E2E_DOCKER_KNOWN=()
+declare -a STALE_UNWIRED_ANDROID_E2E_DOCKER_BASELINE=()
 
 if [[ "${#JOURNEY_CLASSES[@]}" -eq 0 ]]; then
   PARSER_FAILURE+=("NO_PROOF_CLASSES_PARSED")
 fi
+if [[ "${#WIRED_ANDROID_TEST_CLASSES[@]}" -eq 0 ]]; then
+  PARSER_FAILURE+=("NO_ANDROID_TEST_CLASSES_PARSED")
+fi
+
+for fqcn in "${REQUIRED_PER_PUSH_ANDROID_TEST_CLASSES[@]}"; do
+  if ! in_list "$fqcn" "${WIRED_ANDROID_TEST_CLASSES[@]}"; then
+    MISSING_REQUIRED_PER_PUSH+=("$fqcn")
+  elif [[ ! -f "$(android_class_file_for "$fqcn")" ]]; then
+    MISSING_REQUIRED_PER_PUSH+=("$fqcn -> $(android_class_file_for "$fqcn")")
+  else
+    REQUIRED_PER_PUSH_WIRED+=("$fqcn")
+  fi
+done
+
+while IFS= read -r file; do
+  [[ -z "${file:-}" ]] && continue
+  fqcn="$(android_test_fqcn_for_file "$file")"
+  if in_list "$fqcn" "${WIRED_ANDROID_TEST_CLASSES[@]}"; then
+    continue
+  fi
+  if in_list "$fqcn" "${KNOWN_UNWIRED_ANDROID_E2E_DOCKER_CLASSES[@]}"; then
+    UNWIRED_ANDROID_E2E_DOCKER_KNOWN+=("$fqcn")
+  else
+    UNWIRED_ANDROID_E2E_DOCKER_NEW+=("$fqcn")
+  fi
+done < <(
+  find "$ANDROID_TEST_ROOT" -type f \
+    \( -name '*E2eTest.kt' -o -name '*DockerTest.kt' \) \
+    | sort
+)
 
 for class_name in "${JOURNEY_CLASSES[@]}"; do
   file="$(class_file_for "$class_name")"
@@ -216,6 +374,11 @@ for class_name in "${KNOWN_LAUNCH_OWNED_WITHOUT_SHARED_SEED[@]}"; do
     STALE_BASELINE+=("KNOWN_LAUNCH_OWNED_WITHOUT_SHARED_SEED:$class_name")
   fi
 done
+for fqcn in "${KNOWN_UNWIRED_ANDROID_E2E_DOCKER_CLASSES[@]}"; do
+  if [[ -f "$(android_class_file_for "$fqcn")" ]] && in_list "$fqcn" "${WIRED_ANDROID_TEST_CLASSES[@]}"; then
+    STALE_UNWIRED_ANDROID_E2E_DOCKER_BASELINE+=("$fqcn")
+  fi
+done
 
 print_list() {
   local label="$1"; shift
@@ -239,21 +402,35 @@ echo "=============================================================="
 echo " CI journey harness guard (#848 / #788 / #743)"
 echo " Suite: $SUITE"
 echo " Proof journey classes listed: ${#JOURNEY_CLASSES[@]}"
+echo " Android test classes wired: ${#WIRED_ANDROID_TEST_CLASSES[@]}"
 echo "=============================================================="
 
+print_list "PASS - required #848 per-push androidTest classes wired" "${REQUIRED_PER_PUSH_WIRED[@]:-}"
 print_list "PASS - launch-owned MainActivity harness with SeedBeforeLaunchRule" "${COMPLIANT[@]:-}"
 print_list "KNOWN - manual old harness baseline" "${MANUAL_KNOWN[@]:-}"
 print_list "KNOWN - launch-owned but missing shared SeedBeforeLaunchRule baseline" "${MISSING_SHARED_SEED_KNOWN[@]:-}"
+print_list "KNOWN - unwired androidTest E2e/Docker baseline" "${UNWIRED_ANDROID_E2E_DOCKER_KNOWN[@]:-}"
 print_list "JUSTIFIED - local JOURNEY_HARNESS_JUSTIFIED exemption" "${MANUAL_JUSTIFIED[@]:-}" "${MISSING_SHARED_SEED_JUSTIFIED[@]:-}"
 print_list "IGNORED - listed proof class does not launch MainActivity" "${NOT_MAINACTIVITY_LAUNCHERS[@]:-}"
 print_list "STALE BASELINE - class no longer matches its baseline entry" "${STALE_BASELINE[@]:-}"
+print_list "STALE BASELINE - unwired androidTest E2e/Docker class is now wired" "${STALE_UNWIRED_ANDROID_E2E_DOCKER_BASELINE[@]:-}"
 print_list "PARSER FAIL - proof allowlist parser" "${PARSER_FAILURE[@]:-}"
 print_list "MISSING FILE - listed proof class has no source file" "${MISSING_FILES[@]:-}"
+print_list "MISSING REQUIRED - #848 per-push androidTest class not wired" "${MISSING_REQUIRED_PER_PUSH[@]:-}"
 print_list "NEW FAIL - manual ActivityScenario/createEmptyComposeRule harness" "${MANUAL_NEW[@]:-}"
 print_list "NEW FAIL - createAndroidComposeRule without SeedBeforeLaunchRule" "${MISSING_SHARED_SEED_NEW[@]:-}"
+print_list "NEW FAIL - androidTest E2e/Docker class not wired into ci-journey-suite.sh" "${UNWIRED_ANDROID_E2E_DOCKER_NEW[@]:-}"
 
 hard_fail=()
-for item in "${PARSER_FAILURE[@]:-}" "${MISSING_FILES[@]:-}" "${MANUAL_NEW[@]:-}" "${MISSING_SHARED_SEED_NEW[@]:-}" "${STALE_BASELINE[@]:-}"; do
+for item in \
+  "${PARSER_FAILURE[@]:-}" \
+  "${MISSING_FILES[@]:-}" \
+  "${MISSING_REQUIRED_PER_PUSH[@]:-}" \
+  "${MANUAL_NEW[@]:-}" \
+  "${MISSING_SHARED_SEED_NEW[@]:-}" \
+  "${UNWIRED_ANDROID_E2E_DOCKER_NEW[@]:-}" \
+  "${STALE_BASELINE[@]:-}" \
+  "${STALE_UNWIRED_ANDROID_E2E_DOCKER_BASELINE[@]:-}"; do
   [[ -n "$item" ]] && hard_fail+=("$item")
 done
 
@@ -265,7 +442,7 @@ fi
 
 if [[ "${#hard_fail[@]}" -gt 0 ]]; then
   echo
-  echo "::error title=CI journey harness guard (#848/#788/#743)::A listed com.pocketshell.app.proof journey that launches MainActivity is not using createAndroidComposeRule<MainActivity>() plus SeedBeforeLaunchRule, the allowlist parser found no proof classes, or a known-baseline entry is stale. Migrate to the launch-owned harness, remove stale baselines, or add a local // JOURNEY_HARNESS_JUSTIFIED: comment naming why the manual/old pattern is required."
+  echo "::error title=CI journey harness guard (#848/#788/#743)::A required #848 androidTest is missing from the per-push journey allowlist, a new androidTest E2e/Docker class is unwired, a listed com.pocketshell.app.proof journey that launches MainActivity is not using createAndroidComposeRule<MainActivity>() plus SeedBeforeLaunchRule, the allowlist parser failed, or a known-baseline entry is stale. Wire the test into scripts/ci-journey-suite.sh, add an intentional unwired baseline for backlog-only E2e/Docker classes, migrate to the launch-owned harness, remove stale baselines, or add a local // JOURNEY_HARNESS_JUSTIFIED: comment naming why the manual/old pattern is required."
   echo
   echo "FAIL: ${#hard_fail[@]} CI journey harness issue(s)."
   exit 1

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -292,6 +292,12 @@ JOURNEY_CLASSES=(
   # collector parks on a test-controlled CompletableDeferred), so it does not
   # race a wall-clock timeout. It carries its fully-qualified name directly.
   "com.pocketshell.app.composer.PromptComposerDegradedSendE2eTest"
+  # ADDED (#848 audit / #900): the foreground outbound queue surface was covered
+  # by a connected androidTest but was not in any per-push gate. This pins the
+  # visible queued/failed/in-flight composer rows, collapsed count, delete, and
+  # retry callbacks in the same per-push androidTest lane as the send-feedback
+  # composer proofs. Pure Compose, no Docker fixture.
+  "com.pocketshell.app.composer.PromptComposerOutboundQueueTest"
   # PROMOTED (#746): the composer "Not sent" DISCARD + draft session-scoping
   # journey. The maintainer's dogfood report: a "Not sent" draft authored in one
   # session had no Discard control (only Send + the close ×, which PRESERVES the


### PR DESCRIPTION
## Summary
- wire com.pocketshell.app.composer.PromptComposerOutboundQueueTest into scripts/ci-journey-suite.sh for the per-push androidTest gate
- extend scripts/check-ci-journey-harness.sh to require the #848 pinned androidTest and detect new androidTest *E2eTest/*DockerTest classes that are neither wired nor intentionally baselined
- update the harness self-test for the required-class and unwired-class checks

References #848.

## Verification
- bash -n scripts/check-ci-journey-harness.sh && bash -n scripts/check-ci-journey-harness-selftest.sh && bash -n scripts/ci-journey-suite.sh
- scripts/check-ci-journey-harness.sh
- scripts/check-ci-journey-harness-selftest.sh
- git diff --check