### PR TITLE
Bound usage scheduler host fetches

### DIFF
--- a/app/src/main/java/com/pocketshell/app/usage/UsageScheduler.kt
+++ b/app/src/main/java/com/pocketshell/app/usage/UsageScheduler.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import java.io.File
 import java.time.Instant
 import java.util.concurrent.atomic.AtomicLong
@@ -318,6 +319,13 @@ public class UsageScheduler @Inject constructor(
      */
     internal var loopIntervalOverrideMs: Long? = null
 
+    /**
+     * Per-host upper bound for one usage fetch. A single host can be slow,
+     * wedged in SSH/exec, or stuck behind a transport lease; keep that failure
+     * local so the scheduler-wide cadence/manual-refresh mutex is released.
+     */
+    internal var hostFetchTimeoutMs: Long = HOST_FETCH_TIMEOUT_MS
+
     private suspend fun runLoop() {
         try {
             while (true) {
@@ -357,13 +365,30 @@ public class UsageScheduler @Inject constructor(
         // Drop snapshots for hosts that have been removed or lost pocketshell.
         next.keys.retainAll(pocketshellHosts.map { it.id }.toSet())
         pocketshellHosts.forEach { host ->
-            val snapshot = fetchHost(host)
+            val snapshot = fetchHostWithTimeout(host)
             if (snapshot != null) {
                 next[host.id] = snapshot
             }
         }
         publishSnapshots(next.toMap())
     }
+
+    private suspend fun fetchHostWithTimeout(host: HostEntity): UsageSnapshot? {
+        val completed = withTimeoutOrNull(hostFetchTimeoutMs) {
+            HostFetchResult(fetchHost(host))
+        }
+        if (completed != null) return completed.snapshot
+        return UsageSnapshot.Failed(
+            hostId = host.id,
+            hostName = host.name,
+            reason = "Usage fetch timed out after ${hostFetchTimeoutMs} ms",
+            fetchedAt = Instant.now(),
+        )
+    }
+
+    private data class HostFetchResult(
+        val snapshot: UsageSnapshot?,
+    )
 
     private fun publishSnapshots(next: Map<Long, UsageSnapshot>) {
         _snapshots.value = next
@@ -441,6 +466,9 @@ public class UsageScheduler @Inject constructor(
          * a "background while backgrounded" cadence (D21).
          */
         public const val BACKGROUND_INTERVAL_MS: Long = 5L * 60L * 1000L
+
+        /** Bound each host fetch so one hung host cannot wedge the cadence. */
+        public const val HOST_FETCH_TIMEOUT_MS: Long = 30_000L
     }
 }
 

--- a/app/src/test/java/com/pocketshell/app/usage/UsageSchedulerTest.kt
+++ b/app/src/test/java/com/pocketshell/app/usage/UsageSchedulerTest.kt
@@ -8,7 +8,10 @@ import com.pocketshell.core.storage.entity.SshKeyEntity
 import com.pocketshell.core.usage.UsageProviderRecord
 import com.pocketshell.core.usage.UsageStatus
 import com.pocketshell.core.usage.UsageWindow
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeoutOrNull
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -198,6 +201,71 @@ class UsageSchedulerTest {
 
         scheduler.refreshNow()
         assertTrue("stale snapshot must be dropped when pocketshell is gone", scheduler.snapshots.value.isEmpty())
+    }
+
+    @Test
+    fun refreshNow_boundsHungHostFetch_andDoesNotWedgeLaterManualRefresh() = runTest {
+        val keyId = db.sshKeyDao().insert(SshKeyEntity(name = "k", privateKeyPath = "/tmp/k"))
+        val hungHostId = db.hostDao().insert(
+            HostEntity(name = "a-hung", hostname = "hung", username = "u", keyId = keyId, pocketshellInstalled = true),
+        )
+        val healthyHostId = db.hostDao().insert(
+            HostEntity(
+                name = "b-healthy",
+                hostname = "healthy",
+                username = "u",
+                keyId = keyId,
+                pocketshellInstalled = true,
+            ),
+        )
+        val scheduler = UsageScheduler(db.hostDao(), db.sshKeyDao(), UsageRemoteSource())
+        scheduler.hostFetchTimeoutMs = 50L
+
+        val hungStarted = CompletableDeferred<Unit>()
+        val releaseHungFetch = CompletableDeferred<Unit>()
+        var hungFetches = 0
+        scheduler.fetchHost = { host ->
+            when (host.id) {
+                hungHostId -> {
+                    hungFetches += 1
+                    if (hungFetches == 1) {
+                        hungStarted.complete(Unit)
+                        releaseHungFetch.await()
+                    }
+                    UsageSnapshot.Failed(
+                        hostId = host.id,
+                        hostName = host.name,
+                        reason = "later manual refresh recovered",
+                        fetchedAt = Instant.now(),
+                    )
+                }
+
+                healthyHostId -> UsageSnapshot.Records(
+                    hostId = host.id,
+                    hostName = host.name,
+                    records = emptyList(),
+                    fetchedAt = Instant.now(),
+                    command = UsageRemoteSource.defaultUsageCommand,
+                )
+
+                else -> null
+            }
+        }
+
+        val firstRefresh = async { scheduler.refreshNow() }
+        hungStarted.await()
+
+        val secondRefresh = async { scheduler.refreshNow() }
+        val secondCompleted = withTimeoutOrNull(500L) {
+            secondRefresh.await()
+            true
+        }
+
+        releaseHungFetch.complete(Unit)
+        firstRefresh.await()
+
+        assertEquals("later manual refresh must not stay parked behind a hung host", true, secondCompleted)
+        assertTrue(scheduler.snapshots.value[healthyHostId] is UsageSnapshot.Records)
     }
 
     /**


### PR DESCRIPTION
## Summary
- Bound each UsageScheduler per-host fetch so one hung host cannot hold the cadence/manual-refresh mutex indefinitely
- Preserve the existing null-fetch behavior while publishing a Failed usage snapshot only on actual timeout
- Add a regression test for a hung host followed by a later manual refresh

References #935

## Tests
- ./gradlew :app:testDebugUnitTest --tests com.pocketshell.app.usage.UsageSchedulerTest.refreshNow_boundsHungHostFetch_andDoesNotWedgeLaterManualRefresh
- ./gradlew :app:testDebugUnitTest --tests com.pocketshell.app.usage.UsageSchedulerTest
- git diff --check