### PR TITLE
Avoid blocking share UI on URI metadata

### DIFF
--- a/app/src/main/java/com/pocketshell/app/share/ShareActivity.kt
+++ b/app/src/main/java/com/pocketshell/app/share/ShareActivity.kt
@@ -19,7 +19,10 @@ import com.pocketshell.app.share.ShareUploader.Companion.extensionForMimeType
 import com.pocketshell.app.share.ShareUploader.Companion.queryUriDisplayName
 import com.pocketshell.uikit.theme.PocketShellTheme
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 
 /**
  * System share-target entry point (issue #138). Receives an
@@ -63,12 +66,29 @@ class ShareActivity : FragmentActivity() {
             }
         }
 
+        resolveSharedUriMetadata(staged)
+
         // Issue #560: when the user picked an active SESSION as the
         // destination, the ViewModel stages the file into that session's
         // attachment scope and emits a one-shot launch event. Hand off to
         // MainActivity into that tmux session with the staged path
         // pre-loaded as a composer chip, then finish this one-shot surface.
         watchSessionLaunch()
+    }
+
+    private fun resolveSharedUriMetadata(staged: List<ShareableItem>) {
+        if (staged.none { it is ShareableItem.UriItem }) return
+        lifecycleScope.launch {
+            val resolved = resolveShareUriDisplayNames(
+                items = staged,
+                queryDisplayName = { uri ->
+                    withContext(Dispatchers.IO) {
+                        queryUriDisplayName(contentResolver, uri)
+                    }
+                },
+            )
+            viewModel.replaceItemsIfCurrent(staged, resolved)
+        }
     }
 
     override fun onStart() {
@@ -109,25 +129,27 @@ class ShareActivity : FragmentActivity() {
         }
 
     /**
-     * Convert the inbound share `Intent` into the staged item list,
-     * resolving display names against this activity's
-     * [ContentResolver]. Thin wrapper over the pure
-     * [decodeShareIntent] free function so the parsing logic is unit
-     * testable without instantiating a Hilt activity.
+     * Convert the inbound share `Intent` into the staged item list.
+     * This deliberately performs only cheap, local parsing so `onCreate`
+     * can render the host picker before any shared URI provider metadata
+     * query runs.
      */
     internal fun decodeShareIntent(intent: Intent?): List<ShareableItem> =
-        decodeShareIntent(intent, contentResolver)
+        com.pocketshell.app.share.decodeShareIntent(intent)
 }
+
+private const val SHARE_URI_METADATA_PER_URI_TIMEOUT_MS = 500L
+private const val SHARE_URI_METADATA_TOTAL_TIMEOUT_MS = 2_000L
 
 /**
  * Convert an inbound Android share `Intent` into a list of internal
  * [ShareableItem]s. Returns an empty list when the intent doesn't carry
  * anything we can route.
  *
- * Pure function (no `Activity` state) — display names are resolved via
- * the supplied [resolver] so this can be exercised in a Robolectric
- * unit test without a live activity. The [ShareActivity] member of the
- * same name simply forwards its `contentResolver`.
+ * Pure function (no `Activity` state) — URI display names are resolved
+ * only from intent extras or URI path fallbacks. ContentResolver metadata
+ * lookup happens later via [resolveShareUriDisplayNames] so a slow
+ * provider cannot block initial UI creation.
  *
  * Supported shapes:
  *
@@ -141,17 +163,14 @@ class ShareActivity : FragmentActivity() {
  *   selecting N screenshots uploaded just one. Now every selected file
  *   is staged and uploaded.
  */
-internal fun decodeShareIntent(
-    intent: Intent?,
-    resolver: android.content.ContentResolver,
-): List<ShareableItem> {
+internal fun decodeShareIntent(intent: Intent?): List<ShareableItem> {
     if (intent == null) return emptyList()
     val mime = intent.type
     return when (intent.action) {
         Intent.ACTION_SEND -> {
             val stream = extractStream(intent)
             if (stream != null) {
-                listOf(buildUriItem(stream, intent, mime, resolver))
+                listOf(buildUriItem(stream, intent, mime))
             } else {
                 val text = intent.getStringExtra(Intent.EXTRA_TEXT)
                 val subject = intent.getStringExtra(Intent.EXTRA_SUBJECT)
@@ -178,10 +197,32 @@ internal fun decodeShareIntent(
                 } else {
                     intent.getParcelableArrayListExtra(Intent.EXTRA_STREAM)
                 }
-            list.orEmpty().map { buildUriItem(it, intent, mime, resolver) }
+            list.orEmpty().map { buildUriItem(it, intent, mime) }
         }
         else -> emptyList()
     }
+}
+
+internal suspend fun resolveShareUriDisplayNames(
+    items: List<ShareableItem>,
+    queryDisplayName: suspend (Uri) -> String?,
+    perUriTimeoutMs: Long = SHARE_URI_METADATA_PER_URI_TIMEOUT_MS,
+    totalTimeoutMs: Long = SHARE_URI_METADATA_TOTAL_TIMEOUT_MS,
+): List<ShareableItem> {
+    if (items.none { it is ShareableItem.UriItem }) return items
+    return withTimeoutOrNull(totalTimeoutMs) {
+        items.map { item ->
+            if (item !is ShareableItem.UriItem) return@map item
+            val resolved = withTimeoutOrNull(perUriTimeoutMs) {
+                queryDisplayName(item.uri)?.takeIf { it.isNotBlank() }
+            }
+            if (resolved == null || resolved == item.displayName) {
+                item
+            } else {
+                item.copy(displayName = resolved)
+            }
+        }
+    } ?: items
 }
 
 private fun extractStream(intent: Intent): Uri? {
@@ -197,11 +238,9 @@ private fun buildUriItem(
     uri: Uri,
     intent: Intent,
     mime: String?,
-    resolver: android.content.ContentResolver,
 ): ShareableItem.UriItem {
-    val resolverName = queryUriDisplayName(resolver, uri)
     val intentName = intent.getStringExtra(Intent.EXTRA_TITLE)
-    val displayName = resolverName ?: intentName ?: uri.lastPathSegment
+    val displayName = intentName ?: uri.lastPathSegment
     val fallback = extensionForMimeType(mime)
     return ShareableItem.UriItem(
         uri = uri,

--- a/app/src/main/java/com/pocketshell/app/share/ShareViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/share/ShareViewModel.kt
@@ -304,6 +304,17 @@ internal class ShareViewModel internal constructor(
         }
     }
 
+    /**
+     * Apply asynchronous URI metadata refinement without re-running the
+     * text/file dispatch decision. The compare-and-set style guard keeps
+     * late metadata from replacing a newer staged payload.
+     */
+    fun replaceItemsIfCurrent(expected: List<ShareableItem>, updated: List<ShareableItem>) {
+        if (_items.value == expected) {
+            _items.value = updated
+        }
+    }
+
     /** Single-item staging convenience used by tests and callers. */
     fun setItem(item: ShareableItem) = setItems(listOf(item))
 

--- a/app/src/test/java/com/pocketshell/app/share/ShareIntentDecodeTest.kt
+++ b/app/src/test/java/com/pocketshell/app/share/ShareIntentDecodeTest.kt
@@ -1,12 +1,11 @@
 package com.pocketshell.app.share
 
-import android.content.Context
 import android.content.Intent
 import android.net.Uri
-import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
-import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -14,28 +13,20 @@ import org.robolectric.annotation.Config
 
 /**
  * Unit tests for [decodeShareIntent] — the pure share-intent parser that
- * [ShareActivity] forwards its `contentResolver` to.
+ * [ShareActivity] uses before it renders the host picker.
  *
  * Issue #258: the bug was that an `ACTION_SEND_MULTIPLE` intent dropped
  * every URI past the first. These tests pin the fix (extract ALL URIs)
  * while proving the single-file `ACTION_SEND` paths (URI + text) still
  * decode to exactly one item.
  *
- * Robolectric supplies a real `ContentResolver`; the bare `content://`
- * URIs used here aren't backed by a provider, so `queryUriDisplayName`
- * returns null and the decoder falls back to `EXTRA_TITLE` / the URI's
- * last path segment — which is exactly what we assert on.
+ * The bare `content://` URIs used here aren't backed by a provider.
+ * Decode must still return immediately with `EXTRA_TITLE` / URI path
+ * fallbacks; slow provider metadata is resolved later on an async path.
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(manifest = Config.NONE, sdk = [33])
 class ShareIntentDecodeTest {
-
-    private lateinit var context: Context
-
-    @Before
-    fun setUp() {
-        context = ApplicationProvider.getApplicationContext()
-    }
 
     @Test
     fun sendMultipleExtractsEveryUri() {
@@ -49,7 +40,7 @@ class ShareIntentDecodeTest {
             putParcelableArrayListExtra(Intent.EXTRA_STREAM, uris)
         }
 
-        val items = decodeShareIntent(intent, context.contentResolver)
+        val items = decodeShareIntent(intent)
 
         assertEquals("expected one staged item per shared URI", 3, items.size)
         val stagedUris = items.map { (it as ShareableItem.UriItem).uri }
@@ -64,7 +55,7 @@ class ShareIntentDecodeTest {
             putParcelableArrayListExtra(Intent.EXTRA_STREAM, uris)
         }
 
-        val items = decodeShareIntent(intent, context.contentResolver)
+        val items = decodeShareIntent(intent)
 
         assertEquals(1, items.size)
         assertTrue(items.single() is ShareableItem.UriItem)
@@ -74,7 +65,7 @@ class ShareIntentDecodeTest {
     fun sendMultipleWithNoStreamReturnsEmpty() {
         val intent = Intent(Intent.ACTION_SEND_MULTIPLE).apply { type = "image/*" }
 
-        val items = decodeShareIntent(intent, context.contentResolver)
+        val items = decodeShareIntent(intent)
 
         assertTrue("a SEND_MULTIPLE with no EXTRA_STREAM yields nothing", items.isEmpty())
     }
@@ -87,7 +78,7 @@ class ShareIntentDecodeTest {
             putExtra(Intent.EXTRA_STREAM, uri)
         }
 
-        val items = decodeShareIntent(intent, context.contentResolver)
+        val items = decodeShareIntent(intent)
 
         assertEquals(1, items.size)
         val item = items.single() as ShareableItem.UriItem
@@ -103,12 +94,73 @@ class ShareIntentDecodeTest {
             putExtra(Intent.EXTRA_TITLE, "crash-report.txt")
         }
 
-        val items = decodeShareIntent(intent, context.contentResolver)
+        val items = decodeShareIntent(intent)
 
         assertEquals(1, items.size)
         val item = items.single() as ShareableItem.UriItem
         assertEquals(uri, item.uri)
         assertEquals("crash-report.txt", item.displayName)
+    }
+
+    @Test
+    fun uriDecodeUsesCheapFallbackNameWithoutResolverMetadata() {
+        val uri = Uri.parse("content://slow-provider/exports/report.bin")
+        val intent = Intent(Intent.ACTION_SEND).apply {
+            type = "application/octet-stream"
+            putExtra(Intent.EXTRA_STREAM, uri)
+        }
+
+        val items = decodeShareIntent(intent)
+
+        val item = items.single() as ShareableItem.UriItem
+        assertEquals("report.bin", item.displayName)
+    }
+
+    @Test
+    fun metadataResolutionRefinesUriDisplayNameWhenProviderResponds() = runTest {
+        val uri = Uri.parse("content://media/external/images/media/42")
+        val fallback = ShareableItem.UriItem(
+            uri = uri,
+            displayName = "42",
+            size = null,
+            mimeType = "image/png",
+            fallbackExtension = "png",
+        )
+
+        val items = resolveShareUriDisplayNames(
+            items = listOf(fallback),
+            queryDisplayName = { "vacation.png" },
+            perUriTimeoutMs = 100,
+            totalTimeoutMs = 100,
+        )
+
+        val item = items.single() as ShareableItem.UriItem
+        assertEquals("vacation.png", item.displayName)
+    }
+
+    @Test
+    fun metadataResolutionTimeoutKeepsFallbackName() = runTest {
+        val uri = Uri.parse("content://slow-provider/exports/report.bin")
+        val fallback = ShareableItem.UriItem(
+            uri = uri,
+            displayName = "report.bin",
+            size = null,
+            mimeType = "application/octet-stream",
+            fallbackExtension = "bin",
+        )
+
+        val items = resolveShareUriDisplayNames(
+            items = listOf(fallback),
+            queryDisplayName = {
+                delay(1_000)
+                "provider-name.bin"
+            },
+            perUriTimeoutMs = 100,
+            totalTimeoutMs = 100,
+        )
+
+        val item = items.single() as ShareableItem.UriItem
+        assertEquals("report.bin", item.displayName)
     }
 
     @Test
@@ -119,7 +171,7 @@ class ShareIntentDecodeTest {
             putExtra(Intent.EXTRA_SUBJECT, "note title")
         }
 
-        val items = decodeShareIntent(intent, context.contentResolver)
+        val items = decodeShareIntent(intent)
 
         assertEquals(1, items.size)
         val item = items.single() as ShareableItem.TextItem
@@ -129,12 +181,12 @@ class ShareIntentDecodeTest {
 
     @Test
     fun nullIntentReturnsEmpty() {
-        assertTrue(decodeShareIntent(null, context.contentResolver).isEmpty())
+        assertTrue(decodeShareIntent(null).isEmpty())
     }
 
     @Test
     fun unsupportedActionReturnsEmpty() {
         val intent = Intent(Intent.ACTION_VIEW).apply { type = "image/*" }
-        assertTrue(decodeShareIntent(intent, context.contentResolver).isEmpty())
+        assertTrue(decodeShareIntent(intent).isEmpty())
     }
 }


### PR DESCRIPTION
## Summary
- Decode share intents synchronously using only cheap intent/URI fallback names.
- Resolve URI display names after the host picker is rendered, with per-URI and total metadata timeouts.
- Add focused tests for resolver-free decode and bounded metadata refinement.

Fixes part of #935.

## Tests
- ./gradlew :app:testDebugUnitTest --tests com.pocketshell.app.share.ShareIntentDecodeTest
- ./gradlew :app:testDebugUnitTest --tests com.pocketshell.app.share.ShareViewModelTest
- git diff --check