### PR TITLE
Consolidate start directory autocomplete shell quoting

### DIFF
--- a/app/src/main/java/com/pocketshell/app/sessions/StartDirectoryAutocomplete.kt
+++ b/app/src/main/java/com/pocketshell/app/sessions/StartDirectoryAutocomplete.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.pocketshell.core.ssh.SshLeaseManager
+import com.pocketshell.core.ssh.shellSingleQuote
 import com.pocketshell.uikit.theme.PocketShellColors
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -332,8 +333,8 @@ internal data class StartDirectoryAutocompleteRequest(
 
 internal fun startDirectoryAutocompleteCommand(request: StartDirectoryAutocompleteRequest): String =
     """
-        pocketshell_ac_parent=${shellQuote(request.parentDirectory)}
-        pocketshell_ac_prefix=${shellQuote(request.childPrefix)}
+        pocketshell_ac_parent=${shellSingleQuote(request.parentDirectory)}
+        pocketshell_ac_prefix=${shellSingleQuote(request.childPrefix)}
         case "${'$'}pocketshell_ac_parent" in
           '~') pocketshell_ac_parent=${'$'}HOME ;;
           '~/'*) pocketshell_ac_parent=${'$'}HOME/${'$'}{pocketshell_ac_parent#~/} ;;
@@ -363,9 +364,6 @@ internal fun parseStartDirectoryAutocompleteOutput(
         .map { request.suggestionPrefix + it }
         .take(request.limit)
         .toList()
-
-private fun shellQuote(value: String): String =
-    "'" + value.replace("'", "'\\''") + "'"
 
 const val START_DIRECTORY_AUTOCOMPLETE_SUGGESTIONS_TAG: String =
     "start-directory-autocomplete:suggestions"


### PR DESCRIPTION
## Summary

References #684.

- Replace `StartDirectoryAutocomplete`'s private POSIX single-quote helper with the shared `shellSingleQuote` helper.
- Preserve the generated command bytes covered by the existing hostile-path command-string test.
- Keep the slice scoped to the app start-directory autocomplete source; no foreground-service, connection/tmux core, PromptComposerViewModelTest, share, usage scheduler, jobs, or attachment cleanup files touched.

## Verification

```text
GRADLE_USER_HOME=/tmp/pocketshell-gradle-684-startdir ./gradlew --no-daemon --no-build-cache --max-workers=1 :app:testDebugUnitTest --tests 'com.pocketshell.app.sessions.StartDirectoryAutocompleteTest'
BUILD SUCCESSFUL
```

```text
GRADLE_USER_HOME=/tmp/pocketshell-gradle-684-startdir ./gradlew --no-daemon --no-build-cache --max-workers=1 :shared:core-ssh:testDebugUnitTest --tests 'com.pocketshell.core.ssh.ShellQuotingTest'
BUILD SUCCESSFUL
```

```text
git diff --check
# passed
```
