### PR TITLE
Bound git history best-effort probes

### DIFF
--- a/app/src/main/java/com/pocketshell/app/git/GitHistoryViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/git/GitHistoryViewModel.kt
@@ -11,6 +11,7 @@ import com.pocketshell.core.ssh.SshLeaseTarget
 import com.pocketshell.core.ssh.SshSession
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
@@ -111,6 +112,17 @@ class GitHistoryViewModel @Inject constructor(
     private val sshLeaseManager: SshLeaseManager,
 ) : ViewModel() {
 
+    internal constructor(
+        sshLeaseManager: SshLeaseManager,
+        ioDispatcher: CoroutineDispatcher,
+        bestEffortProbeTimeoutMs: Long = BEST_EFFORT_PROBE_TIMEOUT_MS,
+        createIssueTimeoutMs: Long = CREATE_ISSUE_TIMEOUT_MS,
+    ) : this(sshLeaseManager) {
+        this.ioDispatcher = ioDispatcher
+        this.bestEffortProbeTimeoutMs = bestEffortProbeTimeoutMs
+        this.createIssueTimeoutMs = createIssueTimeoutMs
+    }
+
     private val _state = MutableStateFlow<GitHistoryUiState>(
         GitHistoryUiState.Loading(dir = ""),
     )
@@ -128,6 +140,9 @@ class GitHistoryViewModel @Inject constructor(
     private var lease: SshLease? = null
     private var loadJob: Job? = null
     private var createJob: Job? = null
+    private var ioDispatcher: CoroutineDispatcher = Dispatchers.IO
+    private var bestEffortProbeTimeoutMs: Long = BEST_EFFORT_PROBE_TIMEOUT_MS
+    private var createIssueTimeoutMs: Long = CREATE_ISSUE_TIMEOUT_MS
 
     /**
      * Bind host credentials + the project directory and load it. Idempotent for
@@ -158,13 +173,19 @@ class GitHistoryViewModel @Inject constructor(
         createJob?.cancel()
         _createState.value = CreateIssueUiState.Submitting
         createJob = viewModelScope.launch {
-            val outcome = withContext(Dispatchers.IO) {
+            val outcome = withContext(ioDispatcher) {
                 val live = ensureSession(req)
                     ?: return@withContext CreateIssueUiState.Failure(
                         "Couldn't reach ${req.username}@${req.hostname}.",
                     )
                 val gateway = GitHistoryGateway(live)
-                gateway.createIssue(req.dir, title, body).fold(
+                val result = boundedGatewayResult(
+                    timeoutMs = createIssueTimeoutMs,
+                    timeoutMessage = "gh issue create timed out",
+                ) {
+                    gateway.createIssue(req.dir, title, body)
+                }
+                result.fold(
                     onSuccess = { url -> CreateIssueUiState.Success(url) },
                     onFailure = { error ->
                         if (error is CancellationException) throw error
@@ -191,7 +212,7 @@ class GitHistoryViewModel @Inject constructor(
         loadJob?.cancel()
         _state.value = GitHistoryUiState.Loading(dir = req.dir)
         loadJob = viewModelScope.launch {
-            _state.value = withContext(Dispatchers.IO) { fetch(req) }
+            _state.value = withContext(ioDispatcher) { fetch(req) }
         }
     }
 
@@ -207,13 +228,16 @@ class GitHistoryViewModel @Inject constructor(
             result.fold(
                 onSuccess = { commits ->
                     // Overview is best-effort: a failure here (e.g. a transient
-                    // git error) must not hide the history that already loaded.
-                    val overview = gateway.repoOverview(req.dir).getOrNull()
+                    // git error or hung status/worktree probe) must not hide the
+                    // history that already loaded.
+                    val overview = bestEffortProbe {
+                        gateway.repoOverview(req.dir).getOrNull()
+                    }
                     // Best-effort GitHub detection (#648): a failure here must
                     // not hide the history/overview that already loaded.
-                    val gitHubUrl = runCatching {
+                    val gitHubUrl = bestEffortProbe {
                         GitHubRemote.webUrl(gateway.originRemoteUrl(req.dir))
-                    }.getOrNull()
+                    }
                     // GitHub issues (#649), gated on gh being configured (#645).
                     // Best-effort: a probe/listing failure must not hide the
                     // history that already loaded — the Issues tab degrades to
@@ -267,19 +291,41 @@ class GitHistoryViewModel @Inject constructor(
         gateway: GitHistoryGateway,
         dir: String,
     ): Pair<List<GitHubIssue>?, String?> {
-        val status = runCatching { gateway.ghStatus() }.getOrElse {
-            return null to GitHistoryGateway.DEFAULT_GH_HINT
-        }
+        val status = bestEffortProbe { gateway.ghStatus() }
+            ?: return null to GitHistoryGateway.DEFAULT_GH_HINT
         return when (status) {
             is GhConfigStatus.NotConfigured -> null to status.hint
             is GhConfigStatus.Configured -> {
-                val issues = runCatching {
+                val issues = bestEffortProbe {
                     gateway.listIssues(dir, limit = ISSUE_LIMIT).getOrNull()
-                }.getOrNull()
+                }
                 issues to null
             }
         }
     }
+
+    private suspend fun <T> bestEffortProbe(block: suspend () -> T?): T? =
+        try {
+            withTimeoutOrNull(bestEffortProbeTimeoutMs) { block() }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Throwable) {
+            null
+        }
+
+    private suspend fun <T> boundedGatewayResult(
+        timeoutMs: Long,
+        timeoutMessage: String,
+        block: suspend () -> Result<T>,
+    ): Result<T> =
+        try {
+            withTimeoutOrNull(timeoutMs) { block() }
+                ?: Result.failure(GitCommandException(timeoutMessage))
+        } catch (e: CancellationException) {
+            throw e
+        } catch (t: Throwable) {
+            Result.failure(t)
+        }
 
     /**
      * Issue #699: borrow the warm transport from the app-wide
@@ -395,6 +441,12 @@ class GitHistoryViewModel @Inject constructor(
     companion object {
         /** Bound the synchronous lease release at teardown (#699). */
         private const val LEASE_RELEASE_TIMEOUT_MS: Long = 2_000L
+
+        /** Bound optional probes so loaded commits are not hidden behind them. */
+        private const val BEST_EFFORT_PROBE_TIMEOUT_MS: Long = 3_500L
+
+        /** Bound the user-triggered gh create call independently of the screen load. */
+        private const val CREATE_ISSUE_TIMEOUT_MS: Long = 15_000L
 
         /** Cap the history so a giant repo doesn't blow up the listing. */
         const val COMMIT_LIMIT: Int = GitHistoryGateway.DEFAULT_LIMIT

--- a/app/src/test/java/com/pocketshell/app/git/GitHistoryBestEffortProbeTest.kt
+++ b/app/src/test/java/com/pocketshell/app/git/GitHistoryBestEffortProbeTest.kt
@@ -1,0 +1,218 @@
+package com.pocketshell.app.git
+
+import com.pocketshell.app.hosts.MainDispatcherRule
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.SshLeaseConnector
+import com.pocketshell.core.ssh.SshLeaseManager
+import com.pocketshell.core.ssh.SshLeaseTarget
+import com.pocketshell.core.ssh.SshPortForward
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshShell
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import java.io.File
+import java.io.InputStream
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class GitHistoryBestEffortProbeTest {
+
+    private val scheduler = TestCoroutineScheduler()
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule(StandardTestDispatcher(scheduler))
+
+    @Test
+    fun hungOverviewProbeDoesNotKeepLoadedCommitsInLoading() = runTest(scheduler) {
+        val session = RoutingSshSession { command ->
+            when {
+                command.contains("rev-parse --is-inside-work-tree") ->
+                    ExecResult(stdout = "true\n", stderr = "", exitCode = 0)
+                command.contains(" log --no-color --max-count=") ->
+                    ExecResult(stdout = commitLog(), stderr = "", exitCode = 0)
+                command.contains("status --porcelain=v2 --branch") ->
+                    awaitCancellation()
+                command.contains("remote get-url origin") ->
+                    ExecResult(stdout = "", stderr = "no origin", exitCode = 2)
+                command.contains("github status --json") ->
+                    ExecResult(
+                        stdout = """{"installed":false,"authenticated":false,"hint":"install gh"}""",
+                        stderr = "",
+                        exitCode = 0,
+                    )
+                else -> ExecResult(stdout = "", stderr = "", exitCode = 0)
+            }
+        }
+        val viewModel = newViewModel(session, probeTimeoutMs = 100L)
+
+        viewModel.start(request())
+        runCurrent()
+        assertTrue(viewModel.state.value is GitHistoryUiState.Loading)
+
+        advanceTimeBy(100L)
+        runCurrent()
+
+        val ready = viewModel.state.value as GitHistoryUiState.Ready
+        assertEquals(listOf("abc1234"), ready.commits.map { it.shortHash })
+        assertNull(ready.overview)
+        assertEquals("install gh", ready.ghHint)
+    }
+
+    @Test
+    fun hungIssueListDoesNotKeepLoadedCommitsInLoading() = runTest(scheduler) {
+        val session = RoutingSshSession { command ->
+            when {
+                command.contains("rev-parse --is-inside-work-tree") ->
+                    ExecResult(stdout = "true\n", stderr = "", exitCode = 0)
+                command.contains(" log --no-color --max-count=") ->
+                    ExecResult(stdout = commitLog(), stderr = "", exitCode = 0)
+                command.contains("status --porcelain=v2 --branch") ->
+                    ExecResult(stdout = "# branch.head main\n", stderr = "", exitCode = 0)
+                command.contains(" log -1 --no-color") ->
+                    ExecResult(stdout = "abc1234 Initial", stderr = "", exitCode = 0)
+                command.contains("branch --no-color --format") ->
+                    ExecResult(stdout = "", stderr = "", exitCode = 0)
+                command.contains("worktree list --porcelain") ->
+                    ExecResult(stdout = "", stderr = "", exitCode = 0)
+                command.contains("remote get-url origin") ->
+                    ExecResult(stdout = "", stderr = "no origin", exitCode = 2)
+                command.contains("github status --json") ->
+                    ExecResult(
+                        stdout = """{"installed":true,"authenticated":true,"account":"alexey"}""",
+                        stderr = "",
+                        exitCode = 0,
+                    )
+                command.contains("gh issue list") ->
+                    awaitCancellation()
+                else -> ExecResult(stdout = "", stderr = "", exitCode = 0)
+            }
+        }
+        val viewModel = newViewModel(session, probeTimeoutMs = 100L)
+
+        viewModel.start(request())
+        runCurrent()
+        assertTrue(viewModel.state.value is GitHistoryUiState.Loading)
+
+        advanceTimeBy(100L)
+        runCurrent()
+
+        val ready = viewModel.state.value as GitHistoryUiState.Ready
+        assertEquals(listOf("abc1234"), ready.commits.map { it.shortHash })
+        assertNull(ready.issues)
+        assertNull(ready.ghHint)
+    }
+
+    @Test
+    fun hungIssueCreateSettlesTheCreateStateAsFailure() = runTest(scheduler) {
+        val session = RoutingSshSession { command ->
+            when {
+                command.contains("rev-parse --is-inside-work-tree") ->
+                    ExecResult(stdout = "true\n", stderr = "", exitCode = 0)
+                command.contains(" log --no-color --max-count=") ->
+                    ExecResult(stdout = commitLog(), stderr = "", exitCode = 0)
+                command.contains("status --porcelain=v2 --branch") ->
+                    ExecResult(stdout = "# branch.head main\n", stderr = "", exitCode = 0)
+                command.contains(" log -1 --no-color") ->
+                    ExecResult(stdout = "abc1234 Initial", stderr = "", exitCode = 0)
+                command.contains("remote get-url origin") ->
+                    ExecResult(stdout = "", stderr = "no origin", exitCode = 2)
+                command.contains("github status --json") ->
+                    ExecResult(
+                        stdout = """{"installed":false,"authenticated":false,"hint":"install gh"}""",
+                        stderr = "",
+                        exitCode = 0,
+                    )
+                command.contains("gh issue create") ->
+                    awaitCancellation()
+                else -> ExecResult(stdout = "", stderr = "", exitCode = 0)
+            }
+        }
+        val viewModel = newViewModel(session, createIssueTimeoutMs = 100L)
+        viewModel.start(request())
+        runCurrent()
+
+        viewModel.createIssue(title = "Bug", body = "Body")
+        runCurrent()
+        assertEquals(CreateIssueUiState.Submitting, viewModel.createState.value)
+
+        advanceTimeBy(100L)
+        runCurrent()
+
+        val failure = viewModel.createState.value as CreateIssueUiState.Failure
+        assertTrue(failure.message.contains("timed out"))
+    }
+
+    private fun newViewModel(
+        session: SshSession,
+        probeTimeoutMs: Long = 1_000L,
+        createIssueTimeoutMs: Long = 1_000L,
+    ): GitHistoryViewModel =
+        GitHistoryViewModel(
+            sshLeaseManager = SshLeaseManager(
+                connector = SshLeaseConnector { _: SshLeaseTarget -> Result.success(session) },
+                idleTtlMillis = 0L,
+                connectTimeoutContext = StandardTestDispatcher(scheduler),
+                nowMillis = { scheduler.currentTime },
+            ),
+            ioDispatcher = StandardTestDispatcher(scheduler),
+            bestEffortProbeTimeoutMs = probeTimeoutMs,
+            createIssueTimeoutMs = createIssueTimeoutMs,
+        )
+
+    private fun request(): GitHistoryViewModel.Request =
+        GitHistoryViewModel.Request(
+            hostId = 1L,
+            hostname = "example.test",
+            port = 22,
+            username = "alexey",
+            keyPath = "/tmp/key",
+            passphrase = null,
+            dir = "/repo",
+        )
+
+    private fun commitLog(): String {
+        val unit = '\u001F'
+        val record = '\u001E'
+        return "abc1234${unit}Alexey${unit}just now${unit}Initial commit$record"
+    }
+
+    private class RoutingSshSession(
+        private val onExec: suspend (String) -> ExecResult,
+    ) : SshSession {
+        override val isConnected: Boolean = true
+
+        override suspend fun exec(command: String): ExecResult =
+            onExec(command)
+
+        override fun tail(path: String, onLine: (String) -> Unit): Job = error("not used")
+
+        override fun openLocalPortForward(
+            remoteHost: String,
+            remotePort: Int,
+            localPort: Int,
+        ): SshPortForward = error("not used")
+
+        override fun startShell(): SshShell = error("not used")
+
+        override suspend fun uploadFile(file: File, remotePath: String): String = error("not used")
+
+        override suspend fun uploadStream(
+            input: InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String = error("not used")
+
+        override fun close() = Unit
+    }
+}


### PR DESCRIPTION
Refs #935.

## Summary
- bound optional git history overview/GitHub probes so commits can render after the probe timeout instead of staying in Loading
- bound `gh issue create` in the create-state path so a hung create settles as a failure
- add focused viewmodel tests for hung overview, hung issue list, and hung issue create

## Tests
- ./gradlew :app:testDebugUnitTest --tests com.pocketshell.app.git.GitHistoryBestEffortProbeTest
- ./gradlew :app:testDebugUnitTest --tests 'com.pocketshell.app.git.*'\n- git diff --check