### PR TITLE
Guard recurring jobs operations by bound session

### DIFF
--- a/app/src/main/java/com/pocketshell/app/jobs/RecurringJobsViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/jobs/RecurringJobsViewModel.kt
@@ -11,13 +11,18 @@ import com.pocketshell.core.ssh.SshLeaseTarget
 import com.pocketshell.core.ssh.SshSession
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeoutOrNull
 import java.io.File
 import javax.inject.Inject
@@ -47,7 +52,11 @@ public class RecurringJobsViewModel @Inject constructor(
     public val state: StateFlow<RecurringJobsScreenState> = _state.asStateFlow()
 
     private var target: Target? = null
+    private var targetGeneration: Long = 0L
     private var lease: SshLease? = null
+    private var leaseTarget: Target? = null
+    private var commandMutex = Mutex()
+    private val activeOperations = mutableSetOf<Job>()
 
     public fun load(
         hostId: Long,
@@ -61,6 +70,9 @@ public class RecurringJobsViewModel @Inject constructor(
     ) {
         val next = Target(hostId, hostName, hostname, port, username, keyPath, passphrase, sessionName)
         if (next == target) return
+        targetGeneration += 1L
+        cancelActiveOperations()
+        commandMutex = Mutex()
         target = next
         releaseLease()
         _state.value = RecurringJobsScreenState(
@@ -74,25 +86,11 @@ public class RecurringJobsViewModel @Inject constructor(
 
     public fun refresh() {
         val currentTarget = target ?: return
-        viewModelScope.launch {
-            val currentSession = ensureSession(currentTarget) ?: return@launch
-            _state.value = _state.value.copy(loading = true, error = null)
-            when (val result = remoteSource.list(currentSession, currentTarget.sessionName)) {
-                is RecurringJobsCommandResult.Jobs -> {
-                    _state.value = _state.value.copy(jobs = result.jobs, loading = false, error = null)
-                }
-                RecurringJobsCommandResult.Success -> {
-                    _state.value = _state.value.copy(loading = false, error = null)
-                }
-                RecurringJobsCommandResult.ToolMissing -> {
-                    _state.value = _state.value.copy(loading = false, error = "pocketshell is not installed on this host")
-                }
-                is RecurringJobsCommandResult.DaemonUnavailable -> {
-                    _state.value = _state.value.copy(loading = false, error = jobsDaemonUnavailableMessage(result.reason))
-                }
-                is RecurringJobsCommandResult.Failed -> {
-                    _state.value = _state.value.copy(loading = false, error = result.reason)
-                }
+        val generation = targetGeneration
+        val mutex = commandMutex
+        launchOperation {
+            mutex.withLock {
+                refreshLocked(currentTarget, generation)
             }
         }
     }
@@ -120,24 +118,82 @@ public class RecurringJobsViewModel @Inject constructor(
 
     private fun mutate(block: suspend (SshSession) -> RecurringJobsCommandResult) {
         val currentTarget = target ?: return
-        viewModelScope.launch {
-            val currentSession = ensureSession(currentTarget) ?: return@launch
-            _state.value = _state.value.copy(loading = true, error = null)
-            when (val result = block(currentSession)) {
-                RecurringJobsCommandResult.Success -> refresh()
-                is RecurringJobsCommandResult.Jobs -> {
-                    _state.value = _state.value.copy(jobs = result.jobs, loading = false, error = null)
-                }
-                RecurringJobsCommandResult.ToolMissing -> {
-                    _state.value = _state.value.copy(loading = false, error = "pocketshell is not installed on this host")
-                }
-                is RecurringJobsCommandResult.DaemonUnavailable -> {
-                    _state.value = _state.value.copy(loading = false, error = jobsDaemonUnavailableMessage(result.reason))
-                }
-                is RecurringJobsCommandResult.Failed -> {
-                    _state.value = _state.value.copy(loading = false, error = result.reason)
+        val generation = targetGeneration
+        val mutex = commandMutex
+        launchOperation {
+            mutex.withLock {
+                val currentSession = ensureSession(currentTarget, generation) ?: return@withLock
+                if (!isCurrentOperation(currentTarget, generation)) return@withLock
+                _state.value = _state.value.copy(loading = true, error = null)
+                when (val result = block(currentSession)) {
+                    RecurringJobsCommandResult.Success -> refreshLocked(currentTarget, generation, currentSession)
+                    else -> {
+                        if (isCurrentOperation(currentTarget, generation)) {
+                            applyCommandResult(result)
+                        }
+                    }
                 }
             }
+        }
+    }
+
+    private fun launchOperation(block: suspend () -> Unit) {
+        val job = viewModelScope.launch(start = CoroutineStart.LAZY) {
+            try {
+                block()
+            } finally {
+                currentCoroutineContext()[Job]?.let { activeOperations -= it }
+            }
+        }
+        activeOperations += job
+        job.start()
+    }
+
+    private fun cancelActiveOperations() {
+        activeOperations.forEach { it.cancel() }
+        activeOperations.clear()
+    }
+
+    private suspend fun refreshLocked(
+        currentTarget: Target,
+        generation: Long,
+        session: SshSession? = null,
+    ) {
+        val currentSession = session ?: ensureSession(currentTarget, generation) ?: return
+        if (!isCurrentOperation(currentTarget, generation)) return
+        _state.value = _state.value.copy(loading = true, error = null)
+        val result = remoteSource.list(currentSession, currentTarget.sessionName)
+        if (isCurrentOperation(currentTarget, generation)) {
+            applyCommandResult(result)
+        }
+    }
+
+    private fun applyCommandResult(result: RecurringJobsCommandResult) {
+        when (result) {
+            is RecurringJobsCommandResult.Jobs -> {
+                _state.value = _state.value.copy(jobs = result.jobs, loading = false, error = null)
+            }
+            RecurringJobsCommandResult.Success -> {
+                _state.value = _state.value.copy(loading = false, error = null)
+            }
+            RecurringJobsCommandResult.ToolMissing -> {
+                _state.value = _state.value.copy(loading = false, error = "pocketshell is not installed on this host")
+            }
+            is RecurringJobsCommandResult.DaemonUnavailable -> {
+                _state.value = _state.value.copy(loading = false, error = jobsDaemonUnavailableMessage(result.reason))
+            }
+            is RecurringJobsCommandResult.Failed -> {
+                _state.value = _state.value.copy(loading = false, error = result.reason)
+            }
+        }
+    }
+
+    private fun isCurrentOperation(currentTarget: Target, generation: Long): Boolean =
+        target === currentTarget && targetGeneration == generation
+
+    private fun applyConnectError(currentTarget: Target, generation: Long, error: String) {
+        if (isCurrentOperation(currentTarget, generation)) {
+            _state.value = _state.value.copy(loading = false, error = error)
         }
     }
 
@@ -149,26 +205,30 @@ public class RecurringJobsViewModel @Inject constructor(
      * host transport is reused — no extra handshake) and its [SshSession] is
      * reused for every jobs read/write. Released in [onCleared] / [load].
      */
-    private suspend fun ensureSession(target: Target): SshSession? {
-        lease?.let { if (it.session.isConnected) return it.session }
+    private suspend fun ensureSession(target: Target, generation: Long): SshSession? {
+        if (!isCurrentOperation(target, generation)) return null
+        lease?.let {
+            if (leaseTarget === target && it.session.isConnected) return it.session
+            if (leaseTarget === target) releaseLease()
+        }
         // A stale lease (transport dropped) is released before re-acquiring so
         // the next acquire opens or reuses a healthy transport.
-        releaseLease()
         return try {
-            connector.acquire(target).getOrElse { error ->
-                _state.value = _state.value.copy(
-                    loading = false,
-                    error = "connect failed: ${error.message}",
-                )
+            val acquired = connector.acquire(target).getOrElse { error ->
+                applyConnectError(target, generation, "connect failed: ${error.message}")
                 return null
-            }.also { lease = it }.session
+            }
+            if (!isCurrentOperation(target, generation)) {
+                releaseDetachedLease(acquired)
+                return null
+            }
+            lease = acquired
+            leaseTarget = target
+            acquired.session
         } catch (e: CancellationException) {
             throw e
         } catch (t: Throwable) {
-            _state.value = _state.value.copy(
-                loading = false,
-                error = "error: ${t.javaClass.simpleName}: ${t.message ?: "unknown error"}",
-            )
+            applyConnectError(target, generation, "error: ${t.javaClass.simpleName}: ${t.message ?: "unknown error"}")
             null
         }
     }
@@ -181,8 +241,15 @@ public class RecurringJobsViewModel @Inject constructor(
     private fun releaseLease() {
         val toRelease = lease ?: return
         lease = null
+        leaseTarget = null
         viewModelScope.launch(Dispatchers.IO + NonCancellable) {
             runCatching { toRelease.release() }
+        }
+    }
+
+    private fun releaseDetachedLease(lease: SshLease) {
+        viewModelScope.launch(Dispatchers.IO + NonCancellable) {
+            runCatching { lease.release() }
         }
     }
 
@@ -195,6 +262,8 @@ public class RecurringJobsViewModel @Inject constructor(
         // transport itself stays pooled (idle-TTL) for the next surface.
         val toRelease = lease
         lease = null
+        leaseTarget = null
+        cancelActiveOperations()
         if (toRelease != null) {
             runCatching {
                 runBlocking(Dispatchers.IO + NonCancellable) {

--- a/app/src/test/java/com/pocketshell/app/jobs/RecurringJobsViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/jobs/RecurringJobsViewModelTest.kt
@@ -2,22 +2,28 @@ package com.pocketshell.app.jobs
 
 import com.pocketshell.app.hosts.MainDispatcherRule
 import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.SshLease
 import com.pocketshell.core.ssh.SshLeaseConnector
 import com.pocketshell.core.ssh.SshLeaseManager
+import com.pocketshell.core.ssh.SshLeaseKey
 import com.pocketshell.core.ssh.SshLeaseTarget
 import com.pocketshell.core.ssh.SshPortForward
 import com.pocketshell.core.ssh.SshSession
 import com.pocketshell.core.ssh.SshShell
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Rule
 import org.junit.Test
+import kotlin.math.max
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class RecurringJobsViewModelTest {
@@ -191,6 +197,113 @@ class RecurringJobsViewModelTest {
         )
     }
 
+    @Test
+    fun staleRefreshResultCannotOverwriteNewlyBoundSession() = runTest(scheduler) {
+        val oldListStarted = CompletableDeferred<Unit>()
+        val releaseOldList = CompletableDeferred<Unit>()
+        val oldSession = FakeSshSession(
+            pathAware("pocketshell jobs list --session 'alpha'") to ScriptedExec(
+                result = listOutput(id = 1, sessionName = "alpha"),
+                started = oldListStarted,
+                release = releaseOldList,
+                waitNonCancellable = true,
+            ),
+        )
+        val newSession = FakeSshSession(
+            pathAware("pocketshell jobs list --session 'bravo'") to listOutput(id = 2, sessionName = "bravo"),
+        )
+        val connector = DirectLeaseConnector(
+            "old.local" to oldSession,
+            "new.local" to newSession,
+        )
+        val viewModel = RecurringJobsViewModel(
+            remoteSource = remoteSource,
+            connector = connector,
+        )
+
+        viewModel.load(
+            hostId = 1L,
+            hostName = "Old",
+            hostname = "old.local",
+            port = 22,
+            username = "alexey",
+            keyPath = "/tmp/key-old",
+            passphrase = null,
+            sessionName = "alpha",
+        )
+        advanceUntilIdle()
+        oldListStarted.await()
+
+        viewModel.load(
+            hostId = 2L,
+            hostName = "New",
+            hostname = "new.local",
+            port = 22,
+            username = "alexey",
+            keyPath = "/tmp/key-new",
+            passphrase = null,
+            sessionName = "bravo",
+        )
+        advanceUntilIdle()
+
+        assertEquals("New", viewModel.state.value.hostName)
+        assertEquals("bravo", viewModel.state.value.sessionName)
+        assertEquals(listOf(2), viewModel.state.value.jobs.map { it.id })
+
+        releaseOldList.complete(Unit)
+        advanceUntilIdle()
+
+        assertEquals("New", viewModel.state.value.hostName)
+        assertEquals("bravo", viewModel.state.value.sessionName)
+        assertEquals(listOf(2), viewModel.state.value.jobs.map { it.id })
+    }
+
+    @Test
+    fun jobsCommandsAreSerializedAcrossRefreshAndMutation() = runTest(scheduler) {
+        val refreshStarted = CompletableDeferred<Unit>()
+        val releaseRefresh = CompletableDeferred<Unit>()
+        val session = FakeSshSession(
+            pathAware("pocketshell jobs list --session 'codex'") to listOf(
+                listOutput(id = 1, sessionName = "codex"),
+                ScriptedExec(
+                    result = listOutput(id = 1, sessionName = "codex"),
+                    started = refreshStarted,
+                    release = releaseRefresh,
+                    waitNonCancellable = true,
+                ),
+                listOutput(id = 2, sessionName = "codex"),
+            ),
+            pathAware("pocketshell jobs add 'codex' --every '5m' --message 'continue'") to
+                ExecResult("Created job 2\n", "", 0),
+        )
+        val viewModel = newViewModel(session)
+
+        viewModel.load(
+            hostId = 1L,
+            hostName = "Lab",
+            hostname = "lab.local",
+            port = 22,
+            username = "alexey",
+            keyPath = "/tmp/key",
+            passphrase = null,
+            sessionName = "codex",
+        )
+        advanceUntilIdle()
+
+        viewModel.refresh()
+        advanceUntilIdle()
+        refreshStarted.await()
+
+        viewModel.add(RecurringJobDraft(sessionName = "codex", every = "5m", message = "continue"))
+        advanceUntilIdle()
+
+        releaseRefresh.complete(Unit)
+        advanceUntilIdle()
+
+        assertEquals(1, session.maxConcurrentExecs)
+        assertEquals(listOf(2), viewModel.state.value.jobs.map { it.id })
+    }
+
     /**
      * Build a VM whose connector borrows from a REAL [SshLeaseManager] wrapping
      * [connector]. This exercises the actual #699 warm-lease path: acquire →
@@ -199,7 +312,7 @@ class RecurringJobsViewModelTest {
      */
     private fun newViewModel(
         session: SshSession,
-        connector: CountingConnector = CountingConnector(session),
+        connector: SshLeaseConnector = CountingConnector(session),
     ): RecurringJobsViewModel =
         RecurringJobsViewModel(
             remoteSource = remoteSource,
@@ -230,14 +343,46 @@ class RecurringJobsViewModelTest {
         }
     }
 
+    private class DirectLeaseConnector(
+        vararg sessions: Pair<String, SshSession>,
+    ) : RecurringJobsViewModel.RecurringJobsSshConnector {
+        private val sessionsByHost = sessions.toMap()
+
+        override suspend fun acquire(target: RecurringJobsViewModel.Target): Result<SshLease> {
+            val session = sessionsByHost[target.hostname]
+                ?: return Result.failure(IllegalArgumentException("No session for ${target.hostname}"))
+            return Result.success(fakeLease(target.toLeaseTarget().leaseKey, session))
+        }
+
+        private fun fakeLease(key: SshLeaseKey, session: SshSession): SshLease {
+            val releaseAction = { _: SshLeaseKey, _: Long, _: kotlin.coroutines.Continuation<Unit> -> Unit }
+            val constructor = SshLease::class.java.declaredConstructors.single()
+            return constructor.newInstance(key, session, false, 0L, releaseAction) as SshLease
+        }
+    }
+
+    private data class ScriptedExec(
+        val result: ExecResult,
+        val started: CompletableDeferred<Unit>? = null,
+        val release: CompletableDeferred<Unit>? = null,
+        val waitNonCancellable: Boolean = false,
+    )
+
     private class FakeSshSession(
         vararg scripted: Pair<String, Any>,
     ) : SshSession {
-        private val canned: Map<String, ArrayDeque<ExecResult>> =
+        private val canned: Map<String, ArrayDeque<ScriptedExec>> =
             scripted.associate { (command, value) ->
                 val results = when (value) {
-                    is ExecResult -> listOf(value)
-                    is List<*> -> value.filterIsInstance<ExecResult>()
+                    is ExecResult -> listOf(ScriptedExec(value))
+                    is ScriptedExec -> listOf(value)
+                    is List<*> -> value.map {
+                        when (it) {
+                            is ExecResult -> ScriptedExec(it)
+                            is ScriptedExec -> it
+                            else -> error("Unsupported fake result type: ${it?.javaClass?.simpleName}")
+                        }
+                    }
                     else -> error("Unsupported fake result type: ${value::class.java.simpleName}")
                 }
                 command to ArrayDeque(results)
@@ -245,13 +390,32 @@ class RecurringJobsViewModelTest {
 
         val recorded = mutableListOf<String>()
         var closed: Boolean = false
+        var maxConcurrentExecs: Int = 0
+            private set
+        private var activeExecs: Int = 0
 
         override val isConnected: Boolean
             get() = !closed
 
         override suspend fun exec(command: String): ExecResult {
             recorded += command
-            return canned[command]?.removeFirstOrNull() ?: ExecResult("", "missing stub for $command", 127)
+            val next = canned[command]?.removeFirstOrNull() ?: return ExecResult("", "missing stub for $command", 127)
+            activeExecs += 1
+            maxConcurrentExecs = max(maxConcurrentExecs, activeExecs)
+            next.started?.complete(Unit)
+            try {
+                val release = next.release
+                if (release != null) {
+                    if (next.waitNonCancellable) {
+                        withContext(NonCancellable) { release.await() }
+                    } else {
+                        release.await()
+                    }
+                }
+                return next.result
+            } finally {
+                activeExecs -= 1
+            }
         }
 
         override fun tail(path: String, onLine: (String) -> Unit): Job =


### PR DESCRIPTION
## Summary
- Guard recurring jobs refresh/mutate results by target generation so stale work cannot update a newly bound session
- Serialize jobs commands per bound session and keep mutation follow-up refresh inline
- Add regression coverage for stale refresh results and overlapping refresh/mutate execs

Fixes #935.

## Tests
- ./gradlew :app:testDebugUnitTest --tests com.pocketshell.app.jobs.RecurringJobsViewModelTest
- ./gradlew :app:testDebugUnitTest --tests 'com.pocketshell.app.jobs.*'\n- git diff --check origin/main..HEAD