### PR TITLE
Remove SSH key passphrase ViewModel test seam

### DIFF
--- a/app/src/main/java/com/pocketshell/app/hosts/SshKeysViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/hosts/SshKeysViewModel.kt
@@ -201,6 +201,4 @@ class SshKeysViewModel @Inject constructor(
         }
     }
 
-    internal fun hasPrivateKeyPassphrase(content: String): Boolean =
-        SshKeyStorage.hasPrivateKeyPassphrase(content)
 }

--- a/app/src/test/java/com/pocketshell/app/hosts/SshKeyStorageTest.kt
+++ b/app/src/test/java/com/pocketshell/app/hosts/SshKeyStorageTest.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -87,6 +88,62 @@ class SshKeyStorageTest {
         assertTrue(first.id != second.id)
         assertTrue(first.privateKeyPath != second.privateKeyPath)
         assertEquals(2, files.size)
+    }
+
+    @Test
+    fun hasPrivateKeyPassphrase_detectsEncryptedPemHeaders() {
+        val encrypted = """
+            -----BEGIN RSA PRIVATE KEY-----
+            Proc-Type: 4,ENCRYPTED
+            DEK-Info: AES-128-CBC,00112233445566778899AABBCCDDEEFF
+            abc
+            -----END RSA PRIVATE KEY-----
+        """.trimIndent()
+
+        assertTrue(SshKeyStorage.hasPrivateKeyPassphrase(encrypted))
+    }
+
+    @Test
+    fun hasPrivateKeyPassphrase_detectsPkcs8EncryptedPrivateKeyHeader() {
+        val encrypted = """
+            -----BEGIN ENCRYPTED PRIVATE KEY-----
+            abc
+            -----END ENCRYPTED PRIVATE KEY-----
+        """.trimIndent()
+
+        assertTrue(SshKeyStorage.hasPrivateKeyPassphrase(encrypted))
+    }
+
+    @Test
+    fun hasPrivateKeyPassphrase_detectsOpenSshEncryptionFromDecodedHeader() {
+        val encrypted = openSshPrivateKey(cipherName = "aes256-ctr", kdfName = "bcrypt")
+        val unencrypted = openSshPrivateKey(cipherName = "none", kdfName = "none")
+
+        assertTrue(SshKeyStorage.hasPrivateKeyPassphrase(encrypted))
+        assertFalse(SshKeyStorage.hasPrivateKeyPassphrase(unencrypted))
+    }
+
+    private fun openSshPrivateKey(cipherName: String, kdfName: String): String {
+        val bytes = java.io.ByteArrayOutputStream().apply {
+            write("openssh-key-v1\u0000".toByteArray(Charsets.US_ASCII))
+            writeOpenSshString(cipherName)
+            writeOpenSshString(kdfName)
+        }.toByteArray()
+        val body = java.util.Base64.getEncoder()
+            .encodeToString(bytes)
+            .chunked(64)
+            .joinToString("\n")
+        return """
+            -----BEGIN OPENSSH PRIVATE KEY-----
+            $body
+            -----END OPENSSH PRIVATE KEY-----
+        """.trimIndent()
+    }
+
+    private fun java.io.ByteArrayOutputStream.writeOpenSshString(value: String) {
+        val bytes = value.toByteArray(Charsets.US_ASCII)
+        write(java.nio.ByteBuffer.allocate(4).putInt(bytes.size).array())
+        write(bytes)
     }
 
     private companion object {

--- a/app/src/test/java/com/pocketshell/app/hosts/SshKeysViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/hosts/SshKeysViewModelTest.kt
@@ -10,7 +10,6 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import org.junit.After
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -183,59 +182,4 @@ class SshKeysViewModelTest {
         }
     }
 
-    @Test
-    fun hasPrivateKeyPassphrase_detectsEncryptedPemHeaders() = runBlocking {
-        val vm = SshKeysViewModel(db.sshKeyDao())
-        val encrypted = """
-            -----BEGIN RSA PRIVATE KEY-----
-            Proc-Type: 4,ENCRYPTED
-            DEK-Info: AES-128-CBC,00112233445566778899AABBCCDDEEFF
-            abc
-            -----END RSA PRIVATE KEY-----
-        """.trimIndent()
-
-        assertTrue(vm.hasPrivateKeyPassphrase(encrypted))
-    }
-
-    @Test
-    fun hasPrivateKeyPassphrase_detectsPkcs8EncryptedPrivateKeyHeader() = runBlocking {
-        val vm = SshKeysViewModel(db.sshKeyDao())
-        val encrypted = """
-            -----BEGIN ENCRYPTED PRIVATE KEY-----
-            abc
-            -----END ENCRYPTED PRIVATE KEY-----
-        """.trimIndent()
-
-        assertTrue(vm.hasPrivateKeyPassphrase(encrypted))
-    }
-
-    @Test
-    fun hasPrivateKeyPassphrase_detectsOpenSshEncryptionFromDecodedHeader() = runBlocking {
-        val vm = SshKeysViewModel(db.sshKeyDao())
-        val encrypted = openSshPrivateKey(cipherName = "aes256-ctr", kdfName = "bcrypt")
-        val unencrypted = openSshPrivateKey(cipherName = "none", kdfName = "none")
-
-        assertTrue(vm.hasPrivateKeyPassphrase(encrypted))
-        assertFalse(vm.hasPrivateKeyPassphrase(unencrypted))
-    }
-
-    private fun openSshPrivateKey(cipherName: String, kdfName: String): String {
-        val bytes = java.io.ByteArrayOutputStream().apply {
-            write("openssh-key-v1\u0000".toByteArray(Charsets.US_ASCII))
-            writeOpenSshString(cipherName)
-            writeOpenSshString(kdfName)
-        }.toByteArray()
-        val body = java.util.Base64.getEncoder().encodeToString(bytes).chunked(64).joinToString("\n")
-        return """
-            -----BEGIN OPENSSH PRIVATE KEY-----
-            $body
-            -----END OPENSSH PRIVATE KEY-----
-        """.trimIndent()
-    }
-
-    private fun java.io.ByteArrayOutputStream.writeOpenSshString(value: String) {
-        val bytes = value.toByteArray(Charsets.US_ASCII)
-        write(java.nio.ByteBuffer.allocate(4).putInt(bytes.size).array())
-        write(bytes)
-    }
 }


### PR DESCRIPTION
## Summary
- move SSH private-key passphrase characterization coverage from `SshKeysViewModelTest` to `SshKeyStorageTest`
- remove the redundant `SshKeysViewModel.hasPrivateKeyPassphrase` delegate, leaving production callers on `SshKeyStorage` directly
- keep this cleanup separate from #1028 and avoid StartDirectoryAutocomplete / shell quoting areas

## Verification
- `./gradlew :app:testDebugUnitTest --tests 'com.pocketshell.app.hosts.SshKeyStorageTest' --tests 'com.pocketshell.app.hosts.SshKeysViewModelTest'`\n- `git diff --check`\n\nRefs #684