### PR TITLE
Offer to create missing folder when starting a session

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/projects/RootProjectAddSheetTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/RootProjectAddSheetTest.kt
@@ -132,4 +132,41 @@ class RootProjectAddSheetTest {
                 .fetchSemanticsNodes().isEmpty(),
         )
     }
+
+    @Test
+    fun unmatchedSafeSearchOffersCreateAndStartThere() {
+        val root = FolderTreeRoot(
+            path = "/home/alexey/git",
+            label = "git",
+            folders = emptyList(),
+            isWatched = true,
+        )
+        val events = mutableListOf<String>()
+
+        compose.setContent {
+            PocketShellTheme {
+                RootProjectAddSheetContent(
+                    root = root,
+                    candidates = listOf(
+                        RootProjectCandidate(
+                            path = "/home/alexey/git/pocketshell",
+                            label = "pocketshell",
+                            source = RootProjectSource.Scanned,
+                        ),
+                    ),
+                    onStartSession = { events += "start:${it.path}" },
+                    onCreateEmptyProject = { events += "empty" },
+                    onCreateNamedProject = { events += "create:$it" },
+                    onCloneGitProject = { events += "clone" },
+                )
+            }
+        }
+
+        compose.onNodeWithTag(ROOT_PROJECT_ADD_SEARCH_TAG).performTextInput("new.project")
+        compose.onNodeWithTag(ROOT_PROJECT_ADD_CREATE_MATCH_TAG)
+            .assertIsDisplayed()
+            .performClick()
+
+        assertEquals(listOf("create:new.project"), events)
+    }
 }

--- a/app/src/main/java/com/pocketshell/app/projects/FolderListScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListScreen.kt
@@ -487,32 +487,53 @@ fun FolderListScreen(
             claudeProfiles = claudeProfiles,
             codexProfiles = codexProfiles,
             creating = (state as? FolderListUiState.Ready)?.isCreatingSession == true,
+            allowMissingStartDirectoryCreation = true,
             // Issue #1184: prefill the editable "Session name" field with the
             // directory-derived default for the chosen start folder.
             deriveDefaultName = { dir ->
                 defaultSessionBaseName(dir, conventionalRemoteHome(username))
             },
             onCreate = { choice ->
-                val newName = derivedSessionName(
-                    choice = choice,
-                    homeDirectory = conventionalRemoteHome(username),
-                    existingNames = knownSessionNames(state),
-                )
-                viewModel.createSession(
-                    sessionName = newName,
-                    cwd = choice.startDirectory,
-                    startCommand = choice.startCommand(claudeProfiles, codexProfiles),
-                    // Epic #821 Workstream A: record the picked kind onto the
-                    // new tree node immediately (no detection round-trip).
-                    chosenKind = choice.sessionAgentKind,
-                    onResolved = { resolved ->
-                        pickerFolder = null
-                        onSessionCreated(resolved, choice.startDirectory)
-                    },
-                    onFinished = {
-                        pickerFolder = null
-                    },
-                )
+                fun createPickedSession(cwd: String) {
+                    val resolvedChoice = choice.copy(
+                        startDirectory = cwd,
+                        createStartDirectory = null,
+                    )
+                    val newName = derivedSessionName(
+                        choice = resolvedChoice,
+                        homeDirectory = conventionalRemoteHome(username),
+                        existingNames = knownSessionNames(state),
+                    )
+                    viewModel.createSession(
+                        sessionName = newName,
+                        cwd = cwd,
+                        startCommand = resolvedChoice.startCommand(claudeProfiles, codexProfiles),
+                        // Epic #821 Workstream A: record the picked kind onto the
+                        // new tree node immediately (no detection round-trip).
+                        chosenKind = resolvedChoice.sessionAgentKind,
+                        onResolved = { resolved ->
+                            pickerFolder = null
+                            onSessionCreated(resolved, cwd)
+                        },
+                        onFinished = {
+                            pickerFolder = null
+                        },
+                    )
+                }
+
+                val missingFolder = choice.createStartDirectory
+                if (missingFolder != null) {
+                    pickerFolder = null
+                    viewModel.createEmptyProject(
+                        parentPath = missingFolder.parentPath,
+                        folderName = missingFolder.folderName,
+                        onCreated = { createdPath ->
+                            createPickedSession(createdPath)
+                        },
+                    )
+                } else {
+                    createPickedSession(choice.startDirectory)
+                }
             },
         )
     }
@@ -599,6 +620,19 @@ fun FolderListScreen(
             onCreateEmptyProject = {
                 rootAddSheet = null
                 emptyProjectFolder = PickerTarget(path = root.path, label = root.label)
+            },
+            onCreateNamedProject = { folderName ->
+                rootAddSheet = null
+                viewModel.createEmptyProject(
+                    parentPath = root.path,
+                    folderName = folderName,
+                    onCreated = { path ->
+                        pickerFolder = PickerTarget(
+                            path = path,
+                            label = FolderListViewModel.defaultLabelForPath(path),
+                        )
+                    },
+                )
             },
             onCloneGitProject = {
                 rootAddSheet = null

--- a/app/src/main/java/com/pocketshell/app/projects/RootProjectAddSheet.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/RootProjectAddSheet.kt
@@ -51,6 +51,7 @@ fun RootProjectAddSheet(
     onStartSession: (RootProjectCandidate) -> Unit,
     onCreateEmptyProject: () -> Unit,
     onCloneGitProject: () -> Unit,
+    onCreateNamedProject: (String) -> Unit = {},
 ) {
     // Issue #613: the search field auto-focuses, so the soft keyboard opens
     // immediately. Use a fully-expanded sheet (not a partial one) so the
@@ -70,6 +71,7 @@ fun RootProjectAddSheet(
             onStartSession = onStartSession,
             onCreateEmptyProject = onCreateEmptyProject,
             onCloneGitProject = onCloneGitProject,
+            onCreateNamedProject = onCreateNamedProject,
         )
     }
 }
@@ -81,10 +83,14 @@ internal fun RootProjectAddSheetContent(
     onStartSession: (RootProjectCandidate) -> Unit,
     onCreateEmptyProject: () -> Unit,
     onCloneGitProject: () -> Unit,
+    onCreateNamedProject: (String) -> Unit = {},
 ) {
     var query by remember { mutableStateOf("") }
     val filtered = remember(candidates, query) {
         RootProjectFilter.filter(candidates, query)
+    }
+    val createOffer = remember(root.path, candidates, query) {
+        rootProjectCreateOffer(root = root, candidates = candidates, query = query)
     }
     val rootSessionTarget = remember(root.path, root.label) {
         RootProjectCandidate(
@@ -167,7 +173,15 @@ internal fun RootProjectAddSheetContent(
             contentPadding = PaddingValues(bottom = PocketShellSpacing.md),
             verticalArrangement = Arrangement.spacedBy(PocketShellSpacing.xs),
         ) {
-            if (filtered.isEmpty()) {
+            if (createOffer != null) {
+                item {
+                    RootProjectCreateRow(
+                        offer = createOffer,
+                        onClick = { onCreateNamedProject(createOffer.folderName) },
+                    )
+                }
+            }
+            if (filtered.isEmpty() && createOffer == null) {
                 item { RootProjectAddEmptyState(query = query) }
             } else {
                 items(filtered, key = { it.path }) { candidate ->
@@ -179,6 +193,30 @@ internal fun RootProjectAddSheetContent(
             }
         }
     }
+}
+
+internal data class RootProjectCreateOffer(
+    val folderName: String,
+    val path: String,
+)
+
+internal fun rootProjectCreateOffer(
+    root: FolderTreeRoot,
+    candidates: List<RootProjectCandidate>,
+    query: String,
+): RootProjectCreateOffer? {
+    val raw = query.trim()
+    if (raw.isBlank()) return null
+    if (RootProjectFilter.filter(candidates, raw).isNotEmpty()) return null
+    val safeName = SshFolderListGateway.normaliseProjectFolderName(raw) ?: return null
+    if (safeName != raw.trim('/')) return null
+    val childPath = SshFolderListGateway.childPath(root.path, safeName)
+    val exists = candidates.any { candidate ->
+        candidate.label == safeName ||
+            candidate.path.trimEnd('/') == childPath.trimEnd('/')
+    }
+    if (exists) return null
+    return RootProjectCreateOffer(folderName = safeName, path = childPath)
 }
 
 @Composable
@@ -258,6 +296,34 @@ private fun RootProjectCandidateRow(
     }
 }
 
+@Composable
+private fun RootProjectCreateRow(
+    offer: RootProjectCreateOffer,
+    onClick: () -> Unit,
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(PocketShellColors.SurfaceElev, PocketShellShapes.small)
+            .border(1.dp, PocketShellColors.BorderSoft, PocketShellShapes.small)
+            .testTag(ROOT_PROJECT_ADD_CREATE_MATCH_TAG),
+    ) {
+        ListRow(
+            title = "Create folder ${offer.folderName}",
+            subtitle = "Start a new session there.",
+            onClick = onClick,
+            trailing = {
+                Text(
+                    text = "+",
+                    color = PocketShellColors.Accent,
+                    style = PocketShellType.bodyDense,
+                    fontWeight = FontWeight.Bold,
+                )
+            },
+        )
+    }
+}
+
 /**
  * The path segment leading up to (but excluding) the project [label], shown
  * dimmed so the user keeps just enough context to disambiguate same-named
@@ -333,6 +399,7 @@ const val ROOT_PROJECT_ADD_ROOT_SESSION_TAG: String = "root-project-add:root-ses
 const val ROOT_PROJECT_ADD_SEARCH_TAG: String = "root-project-add:search"
 const val ROOT_PROJECT_ADD_LIST_TAG: String = "root-project-add:list"
 const val ROOT_PROJECT_ADD_EMPTY_TAG: String = "root-project-add:empty"
+const val ROOT_PROJECT_ADD_CREATE_MATCH_TAG: String = "root-project-add:create-match"
 
 fun rootProjectCandidateTestTag(path: String): String = "root-project-add:project:$path"
 fun rootProjectCandidateSourceTestTag(path: String): String = "root-project-add:project:$path:source"

--- a/app/src/main/java/com/pocketshell/app/projects/SessionTypePickerSheet.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/SessionTypePickerSheet.kt
@@ -23,6 +23,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -35,6 +36,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.pocketshell.app.sessions.StartDirectoryAutocompleteController
 import com.pocketshell.app.sessions.StartDirectoryAutocompleteField
+import com.pocketshell.app.sessions.StartDirectoryAutocompleteUiState
 import com.pocketshell.app.sessions.rememberStartDirectoryAutocompleteController
 import com.pocketshell.core.ssh.shellSingleQuote
 import com.pocketshell.uikit.components.ButtonVariant
@@ -49,6 +51,7 @@ import com.pocketshell.uikit.model.SessionAgentKind
 import com.pocketshell.uikit.theme.PocketShellColors
 import com.pocketshell.uikit.theme.PocketShellSpacing
 import com.pocketshell.uikit.theme.PocketShellType
+import kotlinx.coroutines.flow.MutableStateFlow
 
 /**
  * Picker for "new session" type — issue #171 round 2.
@@ -78,6 +81,7 @@ fun SessionTypePickerSheet(
     claudeProfiles: List<ClaudeProfile> = emptyList(),
     codexProfiles: List<CodexProfile> = emptyList(),
     creating: Boolean = false,
+    allowMissingStartDirectoryCreation: Boolean = false,
     // Issue #678: the same picker also drives the in-session `+ window` flow,
     // which creates a new WINDOW rather than a new session. The only visible
     // difference is the heading, so the title is parameterised; everything else
@@ -108,6 +112,7 @@ fun SessionTypePickerSheet(
             claudeProfiles = claudeProfiles,
             codexProfiles = codexProfiles,
             creating = creating,
+            allowMissingStartDirectoryCreation = allowMissingStartDirectoryCreation,
             title = title,
             deriveDefaultName = deriveDefaultName,
         )
@@ -129,6 +134,7 @@ internal fun SessionTypePickerContent(
     claudeProfiles: List<ClaudeProfile> = emptyList(),
     codexProfiles: List<CodexProfile> = emptyList(),
     creating: Boolean = false,
+    allowMissingStartDirectoryCreation: Boolean = false,
     title: String = "New session",
     deriveDefaultName: (startDirectory: String) -> String = { it.trimEnd('/').substringAfterLast('/') },
 ) {
@@ -154,6 +160,45 @@ internal fun SessionTypePickerContent(
     // Issue #631: selected Codex profile. null = default (no config dir override).
     var codexProfile by remember { mutableStateOf<String?>(null) }
     val scrollState = rememberScrollState()
+    val fallbackAutocompleteState = remember { MutableStateFlow(StartDirectoryAutocompleteUiState()) }
+    val autocompleteState by (autocompleteController?.state ?: fallbackAutocompleteState).collectAsState()
+    val missingFolderOffer = if (allowMissingStartDirectoryCreation) {
+        missingStartDirectoryCreation(
+            baseFolderPath = folderPath,
+            typedStartDirectory = startDirectory,
+            suggestions = autocompleteState.suggestions,
+            loading = autocompleteState.loading,
+        )
+    } else {
+        null
+    }
+
+    fun emitCreateChoice(createStartDirectory: MissingStartDirectoryCreation?) {
+        val resolvedStartDirectory = createStartDirectory?.path
+            ?: startDirectory.trim().ifBlank { folderPath }
+        onCreate(
+            SessionTypeChoice(
+                type = sessionType,
+                agent = if (sessionType == SessionType.Agent) agentKind else null,
+                startDirectory = resolvedStartDirectory,
+                skipPermissions = skipPermissions,
+                claudeProfileName = if (sessionType == SessionType.Agent && agentKind == AgentCli.Claude) {
+                    claudeProfile
+                } else {
+                    null
+                },
+                codexProfileName = if (sessionType == SessionType.Agent && agentKind == AgentCli.Codex) {
+                    codexProfile
+                } else {
+                    null
+                },
+                // Issue #1184: carry the user's custom label. Blank falls
+                // back to the derived default at create time.
+                customName = sessionName.trim().ifBlank { null },
+                createStartDirectory = createStartDirectory,
+            ),
+        )
+    }
 
     Column(
         modifier = Modifier
@@ -212,6 +257,16 @@ internal fun SessionTypePickerContent(
                     autocompleteController = autocompleteController,
                     suggestionsMaxHeight = SESSION_TYPE_PICKER_SUGGESTIONS_MAX_HEIGHT,
                 )
+                missingFolderOffer?.let { offer ->
+                    ListRow(
+                        title = "Create folder",
+                        subtitle = "${offer.path} - start the new session there.",
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .testTag(SESSION_TYPE_PICKER_CREATE_MISSING_FOLDER_TAG),
+                        onClick = { emitCreateChoice(offer) },
+                    )
+                }
             }
 
             // Segmented control: Shell vs Agent. Uses the shared ui-kit
@@ -338,36 +393,7 @@ internal fun SessionTypePickerContent(
             Spacer(modifier = Modifier.padding(end = 8.dp))
             PocketShellButton(
                 onClick = {
-                    if (!creating) {
-                        onCreate(
-                            SessionTypeChoice(
-                                type = sessionType,
-                                agent = if (sessionType == SessionType.Agent) agentKind else null,
-                                startDirectory = startDirectory.trim().ifBlank { folderPath },
-                                skipPermissions = skipPermissions,
-                                claudeProfileName = if (
-                                    sessionType == SessionType.Agent &&
-                                    agentKind == AgentCli.Claude
-                                ) {
-                                    claudeProfile
-                                } else {
-                                    null
-                                },
-                                codexProfileName = if (
-                                    sessionType == SessionType.Agent &&
-                                    agentKind == AgentCli.Codex
-                                ) {
-                                    codexProfile
-                                } else {
-                                    null
-                                },
-                                // Issue #1184: carry the user's custom label.
-                                // Blank falls back to the derived default at
-                                // create time (SessionNameDerivation).
-                                customName = sessionName.trim().ifBlank { null },
-                            ),
-                        )
-                    }
+                    if (!creating) emitCreateChoice(missingFolderOffer)
                 },
                 variant = ButtonVariant.Primary,
                 enabled = startDirectory.isNotBlank() && !creating,
@@ -446,6 +472,12 @@ data class SessionTypeChoice(
      * time — it never bypasses collision handling.
      */
     val customName: String? = null,
+    /**
+     * Missing start folder the picker should create before creating the
+     * session. `null` means the typed [startDirectory] already exists or
+     * should be used as-is.
+     */
+    val createStartDirectory: MissingStartDirectoryCreation? = null,
 ) {
     /**
      * The start command to invoke inside the new tmux pane after
@@ -506,6 +538,59 @@ data class SessionTypeChoice(
             SessionType.Agent -> agent?.toSessionAgentKind()
         }
 }
+
+data class MissingStartDirectoryCreation(
+    val parentPath: String,
+    val folderName: String,
+    val path: String,
+)
+
+internal fun missingStartDirectoryCreation(
+    baseFolderPath: String,
+    typedStartDirectory: String,
+    suggestions: List<String>,
+    loading: Boolean,
+): MissingStartDirectoryCreation? {
+    if (loading) return null
+    val typed = typedStartDirectory.trim().trimEnd('/')
+    if (typed.isBlank()) return null
+    if (typed == "~" || typed == "\$HOME") return null
+    if (typed == baseFolderPath.trim().trimEnd('/')) return null
+    val exactMatch = suggestions.any { suggestion ->
+        suggestion.trim().trimEnd('/') == typed
+    }
+    if (exactMatch) return null
+
+    val normalised = typed.replace('\\', '/')
+    val slashIndex = normalised.lastIndexOf('/')
+    val rawParent = when {
+        slashIndex < 0 -> baseFolderPath
+        slashIndex == 0 -> "/"
+        else -> normalised.substring(0, slashIndex)
+    }.ifBlank { baseFolderPath }
+    if (slashIndex >= 0 && !isRootedRemoteParent(rawParent)) return null
+    if (rawParent.split('/').any { it == ".." }) return null
+    val rawName = when {
+        slashIndex < 0 -> normalised
+        else -> normalised.substring(slashIndex + 1)
+    }
+    val safeName = SshFolderListGateway.normaliseProjectFolderName(rawName) ?: return null
+    if (safeName != rawName.trim().trim('/')) return null
+    val parent = rawParent.trim().trimEnd('/').ifBlank { "~" }
+    return MissingStartDirectoryCreation(
+        parentPath = parent,
+        folderName = safeName,
+        path = SshFolderListGateway.childPath(parent, safeName),
+    )
+}
+
+private fun isRootedRemoteParent(parent: String): Boolean =
+    parent == "/" ||
+        parent == "~" ||
+        parent == "\$HOME" ||
+        parent.startsWith("/") ||
+        parent.startsWith("~/") ||
+        parent.startsWith("\$HOME/")
 
 enum class SessionType { Shell, Agent }
 
@@ -621,6 +706,8 @@ const val SESSION_TYPE_PICKER_AGENT_OPENCODE_TAG: String = "session-type-picker:
 const val SESSION_TYPE_PICKER_SKIP_PERMISSIONS_TAG: String = "session-type-picker:skip-permissions"
 const val SESSION_TYPE_PICKER_CWD_TAG: String = "session-type-picker:cwd"
 const val SESSION_TYPE_PICKER_NAME_TAG: String = "session-type-picker:name"
+const val SESSION_TYPE_PICKER_CREATE_MISSING_FOLDER_TAG: String =
+    "session-type-picker:create-missing-folder"
 const val SESSION_TYPE_PICKER_CANCEL_TAG: String = "session-type-picker:cancel"
 const val SESSION_TYPE_PICKER_CREATE_TAG: String = "session-type-picker:create"
 const val SESSION_TYPE_PICKER_CLAUDE_PROFILE_TAG: String = "session-type-picker:claude-profile"

--- a/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelCreateSessionTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelCreateSessionTest.kt
@@ -223,6 +223,45 @@ class FolderListViewModelCreateSessionTest {
     }
 
     @Test
+    fun createMissingFolderThenStartsSessionInResolvedPath() = runTest {
+        val gateway = StubGateway(
+            rows = listOf(sessionRow("alpha")),
+            createdProjectPath = "/home/alexey/git/new.project",
+        )
+        val vm = newViewModel(gateway)
+        try {
+            bind(vm)
+            runCurrent()
+
+            var createdPath: String? = null
+            var resolvedSession: String? = null
+            vm.createEmptyProject(
+                parentPath = "/home/alexey/git",
+                folderName = "new.project",
+                onCreated = { path ->
+                    createdPath = path
+                    vm.createSession(
+                        sessionName = "git-new.project",
+                        cwd = path,
+                        startCommand = null,
+                        onResolved = { resolvedSession = it },
+                    )
+                },
+            )
+            runCurrent()
+
+            assertEquals("/home/alexey/git", gateway.createdProjectParentPath)
+            assertEquals("new.project", gateway.createdProjectFolderName)
+            assertEquals("/home/alexey/git/new.project", createdPath)
+            assertEquals("git-new.project", resolvedSession)
+            assertEquals("/home/alexey/git/new.project", gateway.lastCreateCwd)
+            assertEquals(setOf("alpha", "git-new.project"), readySessionNames(vm))
+        } finally {
+            vm.stopPolling()
+        }
+    }
+
+    @Test
     fun createSessionShowsRunningStatusUntilGatewayReturns() = runTest {
         val pendingCreate = CompletableDeferred<Result<String>>()
         val gateway = StubGateway(
@@ -434,8 +473,12 @@ class FolderListViewModelCreateSessionTest {
         // reporting the created session (i.e. the probe observed it).
         @Volatile var reportCreatedSession: Boolean = false,
         @Volatile var createDelayMs: Long = 0L,
+        @Volatile var createdProjectPath: String = "/home/alexey/git/new-project",
     ) : FolderListGateway {
         @Volatile var createCalls: Int = 0
+        var createdProjectParentPath: String? = null
+        var createdProjectFolderName: String? = null
+        var lastCreateCwd: String? = null
 
         override suspend fun listSessionsWithFolder(
             host: HostEntity,
@@ -463,6 +506,7 @@ class FolderListViewModelCreateSessionTest {
             if (!createSucceeds) {
                 return Result.failure(RuntimeException("tmux refused to create '$sessionName'"))
             }
+            lastCreateCwd = cwd
             if (reportCreatedSession) {
                 rows = rows + FolderSessionRow(
                     sessionName = sessionName,
@@ -481,7 +525,11 @@ class FolderListViewModelCreateSessionTest {
             passphrase: CharArray?,
             parentPath: String,
             folderName: String,
-        ): Result<String> = error("not used")
+        ): Result<String> {
+            createdProjectParentPath = parentPath
+            createdProjectFolderName = folderName
+            return Result.success(createdProjectPath)
+        }
 
         override suspend fun importFile(
             host: HostEntity,

--- a/app/src/test/java/com/pocketshell/app/projects/RootProjectFilterTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/RootProjectFilterTest.kt
@@ -119,4 +119,37 @@ class RootProjectFilterTest {
         assertTrue(RootProjectFilter.filter(candidates, "xyzq").isEmpty())
         assertFalse(RootProjectFilter.filter(candidates, "pocket").isEmpty())
     }
+
+    @Test
+    fun createOfferBuildsMissingChildUnderRoot() {
+        val root = FolderTreeRoot(
+            path = "/home/alexey/git",
+            label = "git",
+            folders = emptyList(),
+            isWatched = true,
+        )
+        val offer = rootProjectCreateOffer(
+            root = root,
+            candidates = listOf(candidate("/home/alexey/git/pocketshell", "pocketshell")),
+            query = "new.project",
+        )
+
+        assertEquals("new.project", offer?.folderName)
+        assertEquals("/home/alexey/git/new.project", offer?.path)
+    }
+
+    @Test
+    fun createOfferRejectsKnownOrUnsafeFolderNames() {
+        val root = FolderTreeRoot(
+            path = "/home/alexey/git",
+            label = "git",
+            folders = emptyList(),
+            isWatched = true,
+        )
+        val candidates = listOf(candidate("/home/alexey/git/pocketshell", "pocketshell"))
+
+        assertEquals(null, rootProjectCreateOffer(root, candidates, "pocketshell"))
+        assertEquals(null, rootProjectCreateOffer(root, candidates, "../bad"))
+        assertEquals(null, rootProjectCreateOffer(root, candidates, "nested/bad"))
+    }
 }

--- a/app/src/test/java/com/pocketshell/app/projects/SessionTypeChoiceCommandTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/SessionTypeChoiceCommandTest.kt
@@ -30,6 +30,78 @@ class SessionTypeChoiceCommandTest {
             skipPermissions = skip,
         )
 
+    @Test
+    fun missingStartDirectoryCreationBuildsChildUnderCurrentFolder() {
+        val offer = missingStartDirectoryCreation(
+            baseFolderPath = "~/git",
+            typedStartDirectory = "new.project",
+            suggestions = emptyList(),
+            loading = false,
+        )
+
+        assertEquals("~/git", offer?.parentPath)
+        assertEquals("new.project", offer?.folderName)
+        assertEquals("~/git/new.project", offer?.path)
+    }
+
+    @Test
+    fun missingStartDirectoryCreationUsesTypedParentForExplicitPath() {
+        val offer = missingStartDirectoryCreation(
+            baseFolderPath = "~",
+            typedStartDirectory = "~/git/new.project",
+            suggestions = emptyList(),
+            loading = false,
+        )
+
+        assertEquals("~/git", offer?.parentPath)
+        assertEquals("new.project", offer?.folderName)
+        assertEquals("~/git/new.project", offer?.path)
+    }
+
+    @Test
+    fun missingStartDirectoryCreationSuppressesExistingAndUnsafeNames() {
+        assertNull(
+            missingStartDirectoryCreation(
+                baseFolderPath = "~/git",
+                typedStartDirectory = "~/git/pocketshell",
+                suggestions = listOf("~/git/pocketshell/"),
+                loading = false,
+            ),
+        )
+        assertNull(
+            missingStartDirectoryCreation(
+                baseFolderPath = "~/git",
+                typedStartDirectory = "../bad",
+                suggestions = emptyList(),
+                loading = false,
+            ),
+        )
+        assertNull(
+            missingStartDirectoryCreation(
+                baseFolderPath = "~/git",
+                typedStartDirectory = "new.project",
+                suggestions = emptyList(),
+                loading = true,
+            ),
+        )
+        assertNull(
+            missingStartDirectoryCreation(
+                baseFolderPath = "~/git",
+                typedStartDirectory = "~",
+                suggestions = emptyList(),
+                loading = false,
+            ),
+        )
+        assertNull(
+            missingStartDirectoryCreation(
+                baseFolderPath = "~/git/pocketshell",
+                typedStartDirectory = "~/git/pocketshell",
+                suggestions = emptyList(),
+                loading = false,
+            ),
+        )
+    }
+
     // --- The short wrapper form, per agent ---
 
     @Test


### PR DESCRIPTION
## Summary
- add a create-folder row when root project search has no matching folder
- let the start-folder picker create a missing safe folder before creating the session
- reuse the existing createEmptyProject -> createSession flow so remote mkdir validation and optimistic tree/session updates stay centralized

## Verification
- git diff --check
- not run locally: Gradle/unit/emulator tests; CI should run them
- no local emulator started