### PR TITLE
Bound create-session SSH execs

### DIFF
--- a/app/src/main/java/com/pocketshell/app/projects/FolderListGateway.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListGateway.kt
@@ -7,7 +7,7 @@ import com.pocketshell.app.repos.ReposJsonParser
 import com.pocketshell.app.sessions.ActiveTmuxClients
 import com.pocketshell.app.sessions.HostTmuxSessionListParser
 import com.pocketshell.app.sessions.launchTargetCollisionMessage
-import com.pocketshell.app.sessions.remoteStartDirectoryExists
+import com.pocketshell.app.sessions.remoteStartDirectoryExistsCommand
 import com.pocketshell.app.sessions.startDirectoryMissingMessage
 import com.pocketshell.core.agents.AgentKind
 import com.pocketshell.core.portfwd.PortScanner
@@ -165,9 +165,9 @@ sealed interface FolderListResult {
 }
 
 /**
- * Raised when a session-enumeration SSH-exec probe (e.g. `tmux
- * list-sessions`) connects and authenticates fine but its output read
- * never reaches EOF within [SshFolderListGateway.EXEC_READ_TIMEOUT_MS].
+ * Raised when a folder-list SSH-exec command (for example `tmux
+ * list-sessions` or `tmux new-session`) connects and authenticates fine but its
+ * output read never reaches EOF within [SshFolderListGateway.EXEC_READ_TIMEOUT_MS].
  *
  * Issue #470: this is the robustness contract for the enumeration probe.
  * A connect can succeed (`destination=FolderList`) and then the post-
@@ -193,7 +193,7 @@ class FolderListExecTimeoutException(
     command: String,
     timeoutMs: Long,
 ) : RuntimeException(
-    "tmux/session-enumeration probe read did not complete within " +
+    "Remote tmux command read did not complete within " +
         "${timeoutMs}ms (connect+auth succeeded; the exec output never " +
         "reached EOF). Command: $command",
 )
@@ -400,11 +400,11 @@ class SshFolderListGateway internal constructor(
     private val activeTmuxClients: ActiveTmuxClients,
     private val sshLeaseManager: SshLeaseManager,
     private val sessionListParser: HostTmuxSessionListParser,
-    // Issue #470: bound on a single session-enumeration exec read. Defaults
-    // to [EXEC_READ_TIMEOUT_MS] in production; the unit test overrides it to
-    // a small deterministic value so the wedge/healthy split can be asserted
-    // on a real dispatcher without virtual-vs-real time racing. Kept off the
-    // @Inject constructor below so Hilt never has to provide a raw Long.
+    // Issue #470/#1036: bound on a single folder-list SSH exec read. Defaults
+    // to [EXEC_READ_TIMEOUT_MS] in production; the unit test overrides it to a
+    // small deterministic value so the wedge/healthy split can be asserted on a
+    // real dispatcher without virtual-vs-real time racing. Kept off the @Inject
+    // constructor below so Hilt never has to provide a raw Long.
     private val execReadTimeoutMs: Long,
     // Issue #702: bound on the LIVE `-CC` client enumeration round-trip. The
     // live path (listSessionRowsFromLiveClient) serves the picker enumeration
@@ -641,8 +641,8 @@ class SshFolderListGateway internal constructor(
                 ?: run {
                     Log.w(
                         PROBE_LOG_TAG,
-                        "session-enumeration exec read wedged >${execReadTimeoutMs}ms; " +
-                            "closing wedged session + surfacing retryable ConnectError. " +
+                        "folder-list SSH exec read wedged >${execReadTimeoutMs}ms; " +
+                            "closing wedged session + surfacing bounded failure. " +
                             "cmd=${command.takeLast(48)}",
                     )
                     // Stop awaiting the wedged read so this coroutine can
@@ -1197,7 +1197,7 @@ class SshFolderListGateway internal constructor(
         cwd: String,
         startCommand: String?,
     ): String {
-        if (!remoteStartDirectoryExists(session, cwd)) {
+        if (session.execBounded(remoteStartDirectoryExistsCommand(cwd)).exitCode != 0) {
             throw RuntimeException(
                 startDirectoryMissingMessage(
                     sessionName = sessionName,
@@ -1228,21 +1228,21 @@ class SshFolderListGateway internal constructor(
         // fresh list / suffix instead of silently leaking keystrokes. A plain
         // shell/no-launch create keeps its idempotent attach-or-create semantics.
         if (startCommand != null) {
-            val hasSession = session.exec(
+            val hasSession = session.execBounded(
                 pathAware("tmux has-session -t $quotedName"),
             )
             if (hasSession.exitCode == 0) {
                 throw RuntimeException(launchTargetCollisionMessage(sessionName))
             }
         }
-        val createResult = session.exec(
+        val createResult = session.execBounded(
             pathAware(cappedCreateSessionCommand(quotedName, quotedCwd)),
         )
         if (createResult.exitCode == TMUXCTL_UNSUPPORTED_EXIT_CODE) {
             // Layer 1: tmuxctl is absent OR too old to know `create-detached`.
             // Fall back to the pre-#726 raw capped-less create so the user still
             // gets a session (just without the memory cap).
-            val fallback = session.exec(
+            val fallback = session.execBounded(
                 pathAware(fallbackCreateSessionCommand(quotedName, quotedCwd)),
             )
             if (fallback.exitCode != 0 && fallback.stderr.isNotBlank()) {
@@ -1284,7 +1284,7 @@ class SshFolderListGateway internal constructor(
                 ensureAgentSubcommandAvailable(session)
             }
             val quotedCommand = shellQuote(startCommand)
-            session.exec(
+            session.execBounded(
                 pathAware("tmux send-keys -t $quotedName $quotedCommand Enter"),
             )
         }
@@ -1305,7 +1305,7 @@ class SshFolderListGateway internal constructor(
      * never blocks a healthy launch.
      */
     private suspend fun ensureAgentSubcommandAvailable(session: SshSession) {
-        val probe = session.exec(pathAware(AgentLaunchVersionCheck.AGENT_PROBE_COMMAND))
+        val probe = session.execBounded(pathAware(AgentLaunchVersionCheck.AGENT_PROBE_COMMAND))
         if (!AgentLaunchVersionCheck.isAgentSubcommandMissing(
                 stdout = probe.stdout,
                 stderr = probe.stderr,
@@ -1317,7 +1317,7 @@ class SshFolderListGateway internal constructor(
         // Outdated host: best-effort fetch of the installed version so the hint
         // can be concrete ("this host's pocketshell is 0.3.33").
         val installedVersion = runCatching {
-            val version = session.exec(pathAware(AgentLaunchVersionCheck.VERSION_PROBE_COMMAND))
+            val version = session.execBounded(pathAware(AgentLaunchVersionCheck.VERSION_PROBE_COMMAND))
             AgentLaunchVersionCheck.parseReportedVersion(
                 version.stdout.ifBlank { version.stderr },
             )
@@ -1771,10 +1771,9 @@ class SshFolderListGateway internal constructor(
 
     internal companion object {
         /**
-         * Logcat-grep tag for issue #470: emitted only when a
-         * session-enumeration exec read trips its bounded timeout
-         * ([execBounded]) and the gateway surfaces a retryable
-         * `ConnectError` instead of hanging.
+         * Logcat-grep tag for bounded folder-list SSH exec reads. Emitted only
+         * when an exec trips [execBounded] and the gateway surfaces a bounded
+         * failure instead of hanging.
          */
         const val PROBE_LOG_TAG: String = "PsFolderProbe"
 

--- a/app/src/main/java/com/pocketshell/app/projects/FolderListScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListScreen.kt
@@ -1093,9 +1093,9 @@ internal fun FolderListContent(
     ) {
         // Issue #656: the action status no longer renders as a top-of-list row.
         // A routine success emits no status at all (the list change is the
-        // feedback) and a failure surfaces as a non-displacing overlay pinned to
-        // the bottom of this Box (see [FolderActionFailureBanner] below), so no
-        // action ever pushes the list down.
+        // feedback), while in-flight/failed work surfaces as a non-displacing
+        // overlay pinned to the bottom of this Box, so no action ever pushes the
+        // list down.
         if (showFlatFolderList) {
             // Flat view (#485 render fix, #489 visual polish): EVERY session on the
             // host, grouped by status into ACTIVE and IDLE sections instead of by
@@ -1246,14 +1246,23 @@ internal fun FolderListContent(
         // pull-to-refresh indicator is itself non-displacing (it overlays the
         // content and reflows no rows), so the #639 "don't push rows down on every
         // session switch" requirement still holds with the single indicator.
-        // Issue #656: failures surface as a non-displacing snackbar-style
-        // overlay pinned to the bottom edge of the content. Like the #639
-        // refresh bar it occupies zero layout slot in the list, so a failed
-        // action never pushes a row down. Successes emit no status at all, so
-        // this overlay only ever appears for [FolderActionStatus.Failed].
-        (actionStatus as? FolderActionStatus.Failed)?.let { failure ->
-            FolderActionFailureBanner(
-                message = failure.message,
+        // Issue #656: action feedback surfaces as a non-displacing snackbar-style
+        // overlay pinned to the bottom edge of the content. Like the #639 refresh
+        // bar it occupies zero layout slot in the list, so create/failure feedback
+        // never pushes a row down.
+        when (val status = actionStatus) {
+            FolderActionStatus.Idle -> Unit
+            is FolderActionStatus.Running -> FolderActionProgressBanner(
+                message = status.message,
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(
+                        horizontal = FolderListBottomContentPadding,
+                        vertical = FolderListBottomContentPadding,
+                    ),
+            )
+            is FolderActionStatus.Failed -> FolderActionFailureBanner(
+                message = status.message,
                 onDismiss = onDismissActionStatus,
                 modifier = Modifier
                     .align(Alignment.BottomCenter)
@@ -1345,12 +1354,45 @@ private fun PortForwardingSummaryRow(
 }
 
 /**
+ * Issue #656: non-displacing in-progress affordance for host-detail actions.
+ * Pinned as an overlay to the bottom edge of the content [Box], it occupies zero
+ * layout slot in the list (mirroring the #639 refresh progress bar), so a
+ * pending create is visible without pushing any list row down.
+ */
+@Composable
+private fun FolderActionProgressBanner(
+    message: String,
+    modifier: Modifier = Modifier,
+) {
+    val color = PocketShellColors.Accent
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(PocketShellColors.Surface, PocketShellShapes.medium)
+            .background(color.copy(alpha = 0.12f), PocketShellShapes.medium)
+            .border(1.dp, color.copy(alpha = 0.4f), PocketShellShapes.medium)
+            .padding(horizontal = PocketShellSpacing.md, vertical = PocketShellSpacing.sm)
+            .testTag(FOLDER_LIST_ACTION_STATUS_TAG),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(PocketShellSpacing.sm),
+    ) {
+        LoadingIndicator.Spinner(size = SpinnerSize.Small)
+        Text(
+            text = message,
+            color = PocketShellColors.Text,
+            style = PocketShellType.bodyDense,
+            modifier = Modifier.weight(1f),
+        )
+    }
+}
+
+/**
  * Issue #656: non-displacing failure affordance for host-detail actions. Pinned
  * as an overlay to the bottom edge of the content [Box], it occupies zero layout
  * slot in the list (mirroring the #639 refresh progress bar), so a failed action
- * is visible without pushing any list row down. Only failures render — a routine
- * success emits no [FolderActionStatus] at all, so the list change alone is the
- * feedback and nothing displaces the list.
+ * is visible without pushing any list row down. Routine success emits no
+ * [FolderActionStatus] at all, so the list change alone is the feedback and
+ * nothing displaces the list.
  */
 @Composable
 private fun FolderActionFailureBanner(

--- a/app/src/main/java/com/pocketshell/app/projects/FolderListViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListViewModel.kt
@@ -228,17 +228,22 @@ sealed interface FolderListUiState {
 /**
  * Host-detail action feedback surface (#656).
  *
- * For a routine **success** there is deliberately no status state at all — the
- * list updating (a session disappearing on Stop, appearing on Create) IS the
- * feedback, so a success never produces a banner that would push the list down.
- * Only a [Failed] action carries a message (the user must know it did not
- * work), and the screen surfaces that as a NON-displacing overlay rather than a
- * top-of-list row. In-progress feedback for the manual refresh rides the
- * non-displacing refresh progress bar ([FolderListUiState.Ready.isRefreshing],
- * #639), not a status banner.
+ * For a routine **success** there is deliberately no final status state at all
+ * — the list updating (a session disappearing on Stop, appearing on Create) IS
+ * the feedback, so a success never produces a banner that would push the list
+ * down. Failures carry a message (the user must know it did not work), and the
+ * screen surfaces them as NON-displacing overlays rather than top-of-list rows.
  */
 sealed interface FolderActionStatus {
     data object Idle : FolderActionStatus
+
+    /**
+     * Non-displacing in-progress feedback for actions whose result is not
+     * otherwise visible until a remote call returns. Create-session uses this so
+     * closing the picker is followed by an explicit "still working" signal rather
+     * than an apparently frozen/no-op host screen.
+     */
+    data class Running(val message: String) : FolderActionStatus
 
     /**
      * A failure banner. [isRefreshFailure] marks the calm "couldn't refresh the
@@ -1293,9 +1298,9 @@ class FolderListViewModel internal constructor(
      *
      * On success [onResolved] fires with the resolved tmux session name
      * so the caller can route to `AppDestination.TmuxSession`. On
-     * failure the screen falls back to the Failed state with the error
-     * message (so the user sees what went wrong instead of a silent
-     * "nothing happened").
+     * failure the screen keeps the current list visible and shows the error
+     * through [actionStatus] (so the user sees what went wrong instead of a
+     * silent "nothing happened").
      */
     fun createSession(
         sessionName: String,
@@ -1306,7 +1311,9 @@ class FolderListViewModel internal constructor(
     ) {
         val params = bound ?: return
         viewModelScope.launch {
+            _actionStatus.value = FolderActionStatus.Running("Creating session…")
             val host = withContext(ioDispatcher) { hostDao.getById(params.hostId) } ?: run {
+                _actionStatus.value = FolderActionStatus.Failed("Host not found.")
                 _state.value = FolderListUiState.Failed("Host not found.")
                 return@launch
             }
@@ -1350,11 +1357,12 @@ class FolderListViewModel internal constructor(
                         folderPath = cwd,
                     )
                     emitReady()
+                    _actionStatus.value = FolderActionStatus.Idle
                     onResolved(resolvedName)
                     refresh()
                 },
                 onFailure = { error ->
-                    _state.value = FolderListUiState.Failed(
+                    _actionStatus.value = FolderActionStatus.Failed(
                         "Couldn't create session: ${error.message ?: error.javaClass.simpleName}",
                     )
                 },

--- a/app/src/test/java/com/pocketshell/app/projects/FolderListGatewayExecTimeoutTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/FolderListGatewayExecTimeoutTest.kt
@@ -101,7 +101,36 @@ class FolderListGatewayExecTimeoutTest {
         )
     }
 
-    private fun newGateway(session: WedgingSshSession): SshFolderListGateway =
+    @Test
+    fun wedgedCreateSessionReadSurfacesBoundedFailureAndClosesSession() = runBlocking {
+        val session = CreateSessionWedgingSshSession()
+        val gateway = newGateway(session)
+
+        val failure = runCatching {
+            gateway.createSessionOnSession(
+                session = session,
+                sessionName = "telegram-writing-assistant",
+                cwd = "/home/me/telegram-writing-assistant",
+                startCommand = "pocketshell agent codex --dir '/home/me/telegram-writing-assistant'",
+            )
+        }.exceptionOrNull()
+
+        assertTrue(
+            "wedged create must fail with the bounded exec timeout, got $failure",
+            failure is FolderListExecTimeoutException,
+        )
+        assertTrue(
+            "directory probe ran before the create wedge",
+            session.execCommands.any { it.contains("test -d") },
+        )
+        assertTrue("capped create command was attempted", session.execCommands.any { it.contains("create-detached") })
+        assertTrue(
+            "wedged session must be closed on create timeout (no orphaned exec channel/thread)",
+            session.closed,
+        )
+    }
+
+    private fun newGateway(session: SshSession): SshFolderListGateway =
         SshFolderListGateway(
             reposRemoteSource = ReposRemoteSource(ReposJsonParser()),
             activeTmuxClients = ActiveTmuxClients(),
@@ -154,6 +183,52 @@ class FolderListGatewayExecTimeoutTest {
                 }
             }
             return ExecResult(stdout = "", stderr = "", exitCode = 0)
+        }
+
+        override fun tail(path: String, onLine: (String) -> Unit): Job = error("not used")
+
+        override fun openLocalPortForward(
+            remoteHost: String,
+            remotePort: Int,
+            localPort: Int,
+        ): SshPortForward = error("not used")
+
+        override fun startShell(): SshShell = error("not used")
+
+        override suspend fun uploadFile(file: File, remotePath: String): String = error("not used")
+
+        override suspend fun uploadStream(
+            input: InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String = error("not used")
+
+        override fun close() {
+            closed = true
+        }
+    }
+
+    /**
+     * Create-session fake: directory exists, launch-target collision probe says
+     * "absent", then the capped create read never reaches EOF.
+     */
+    private class CreateSessionWedgingSshSession : SshSession {
+        val execCommands: MutableList<String> = java.util.Collections.synchronizedList(mutableListOf<String>())
+        @Volatile
+        var closed: Boolean = false
+
+        override val isConnected: Boolean
+            get() = !closed
+
+        override suspend fun exec(command: String): ExecResult {
+            execCommands += command
+            return when {
+                command.contains("test -d") -> ExecResult(stdout = "", stderr = "", exitCode = 0)
+                command.contains("has-session") -> ExecResult(stdout = "", stderr = "", exitCode = 1)
+                command.contains("create-detached") -> awaitCancellation()
+                else -> ExecResult(stdout = "", stderr = "", exitCode = 0)
+            }
         }
 
         override fun tail(path: String, onLine: (String) -> Unit): Job = error("not used")

--- a/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelCreateSessionTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelCreateSessionTest.kt
@@ -16,6 +16,7 @@ import com.pocketshell.core.storage.dao.ProjectRootDao
 import com.pocketshell.core.storage.entity.HostEntity
 import com.pocketshell.core.storage.entity.ProjectRootEntity
 import com.pocketshell.uikit.model.SessionAgentKind
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -220,6 +221,46 @@ class FolderListViewModelCreateSessionTest {
     }
 
     @Test
+    fun createSessionShowsRunningStatusUntilGatewayReturns() = runTest {
+        val pendingCreate = CompletableDeferred<Result<String>>()
+        val gateway = StubGateway(
+            rows = listOf(sessionRow("alpha")),
+            createResult = pendingCreate,
+        )
+        val vm = newViewModel(gateway)
+        try {
+            bind(vm)
+            runCurrent()
+
+            vm.createSession(
+                sessionName = "beta",
+                cwd = "/home/alexey/git/beta",
+                startCommand = null,
+                onResolved = {},
+            )
+            runCurrent()
+
+            val running = vm.actionStatus.value
+            assertTrue(
+                "create must show non-displacing in-progress feedback while the remote call is pending",
+                running is FolderActionStatus.Running,
+            )
+            assertEquals(
+                "Creating session…",
+                (running as FolderActionStatus.Running).message,
+            )
+
+            pendingCreate.complete(Result.success("beta"))
+            runCurrent()
+
+            assertEquals(FolderActionStatus.Idle, vm.actionStatus.value)
+            assertEquals(setOf("alpha", "beta"), readySessionNames(vm))
+        } finally {
+            vm.stopPolling()
+        }
+    }
+
+    @Test
     fun failedCreateDoesNotInsertARow() = runTest {
         val gateway = StubGateway(rows = listOf(sessionRow("alpha")), createSucceeds = false)
         val vm = newViewModel(gateway)
@@ -239,8 +280,13 @@ class FolderListViewModelCreateSessionTest {
 
             assertEquals("a failed create must not fire onResolved", null, resolved)
             assertTrue(
-                "a failed create surfaces the Failed state",
-                vm.state.value is FolderListUiState.Failed,
+                "a failed create keeps the current session list visible",
+                vm.state.value is FolderListUiState.Ready,
+            )
+            assertEquals(setOf("alpha"), readySessionNames(vm))
+            assertTrue(
+                "a failed create surfaces the non-displacing action failure",
+                vm.actionStatus.value is FolderActionStatus.Failed,
             )
         } finally {
             vm.stopPolling()
@@ -305,6 +351,7 @@ class FolderListViewModelCreateSessionTest {
     private class StubGateway(
         @Volatile var rows: List<FolderSessionRow>,
         @Volatile var createSucceeds: Boolean = true,
+        private val createResult: CompletableDeferred<Result<String>>? = null,
         // When true, a successful create makes the gateway's probe start
         // reporting the created session (i.e. the probe observed it).
         @Volatile var reportCreatedSession: Boolean = false,
@@ -324,6 +371,7 @@ class FolderListViewModelCreateSessionTest {
             cwd: String,
             startCommand: String?,
         ): Result<String> {
+            createResult?.let { return it.await() }
             if (!createSucceeds) {
                 return Result.failure(RuntimeException("tmux refused to create '$sessionName'"))
             }


### PR DESCRIPTION
## Summary
- bound SSH exec calls in the create-session path so a wedged remote read cannot freeze the new-session flow before the session is recorded
- surface create-session progress/failure through the folder list UI instead of appearing to hang
- add regression coverage for a wedged create-session read

## Verification
- git diff --check origin/main..HEAD
- no local emulator or connected Android tests
- no local Gradle run for this slice

Fixes #1036