### PR TITLE
Isolate share uploads and show progress

### DIFF
--- a/app/src/main/java/com/pocketshell/app/share/HostPickerScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/share/HostPickerScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -170,7 +171,7 @@ internal fun HostPickerScreen(
                         )
                 }
             }
-            is UploadState.Running -> UploadingSurface(hostName = state.hostName)
+            is UploadState.Running -> UploadingSurface(state = state)
             is UploadState.NeedsPassphrase ->
                 PassphraseDialog(
                     hostName = state.hostName,
@@ -468,7 +469,13 @@ private fun ShareEmptyState(message: String) {
 }
 
 @Composable
-private fun UploadingSurface(hostName: String) {
+private fun UploadingSurface(state: UploadState.Running) {
+    val totalBytes = state.totalBytes?.takeIf { it > 0L }
+    val progress = if (totalBytes != null) {
+        (state.bytesTransferred.toFloat() / totalBytes.toFloat()).coerceIn(0f, 1f)
+    } else {
+        null
+    }
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -479,9 +486,54 @@ private fun UploadingSurface(hostName: String) {
         LoadingIndicator.Spinner(size = SpinnerSize.Medium)
         Spacer(Modifier.height(24.dp))
         Text(
-            text = "Uploading to $hostName...",
+            text = "Uploading to ${state.hostName}...",
             style = MaterialTheme.typography.titleMedium,
         )
+        state.currentItemName?.let { name ->
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = name,
+                style = PocketShellType.bodyDense,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        if (state.totalCount > 1 && state.currentItemIndex > 0) {
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = "File ${state.currentItemIndex} of ${state.totalCount}",
+                style = PocketShellType.labelMono,
+                color = PocketShellColors.TextMuted,
+            )
+        }
+        if (progress != null && totalBytes != null) {
+            Spacer(Modifier.height(16.dp))
+            LinearProgressIndicator(
+                progress = { progress },
+                modifier = Modifier.fillMaxWidth(),
+            )
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = "${formatUploadBytes(state.bytesTransferred)} / ${formatUploadBytes(totalBytes)}",
+                style = PocketShellType.labelMono,
+                color = PocketShellColors.TextMuted,
+            )
+        }
+    }
+}
+
+private fun formatUploadBytes(bytes: Long): String {
+    val units = listOf("B", "KB", "MB", "GB")
+    var value = bytes.toDouble()
+    var unit = 0
+    while (value >= 1024.0 && unit < units.lastIndex) {
+        value /= 1024.0
+        unit += 1
+    }
+    return if (unit == 0) {
+        "${bytes.coerceAtLeast(0L)} ${units[unit]}"
+    } else {
+        String.format(java.util.Locale.US, "%.1f %s", value, units[unit])
     }
 }
 

--- a/app/src/main/java/com/pocketshell/app/share/ShareUploader.kt
+++ b/app/src/main/java/com/pocketshell/app/share/ShareUploader.kt
@@ -10,6 +10,7 @@ import com.pocketshell.core.ssh.SshConnection
 import com.pocketshell.core.ssh.SshException
 import com.pocketshell.core.ssh.SshKey
 import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshUploadProgress
 import com.pocketshell.core.storage.entity.HostEntity
 import com.pocketshell.core.storage.entity.SshKeyEntity
 import kotlinx.coroutines.Dispatchers
@@ -53,6 +54,7 @@ internal interface ShareItemUploader {
         keyEntity: SshKeyEntity,
         item: ShareableItem,
         target: ShareTarget = ShareTarget.HostInbox,
+        onProgress: ((SshUploadProgress) -> Unit)? = null,
     ): Result<String>
 }
 
@@ -123,6 +125,7 @@ internal class ShareUploader(
         keyEntity: SshKeyEntity,
         item: ShareableItem,
         target: ShareTarget,
+        onProgress: ((SshUploadProgress) -> Unit)?,
     ): Result<String> = withContext(Dispatchers.IO) {
         val keyFile = File(keyEntity.privateKeyPath)
         val key: SshKey = SshKey.Path(keyFile)
@@ -151,9 +154,9 @@ internal class ShareUploader(
                 val remotePath = "${destination.uploadDirectory}/$remoteName"
 
                 when (item) {
-                    is ShareableItem.UriItem -> uploadUri(live, item, remotePath)
-                    is ShareableItem.TextItem -> uploadText(live, item, remotePath, remoteName)
-                    is ShareableItem.FileItem -> live.uploadFile(item.file, remotePath)
+                    is ShareableItem.UriItem -> uploadUri(live, item, remotePath, onProgress)
+                    is ShareableItem.TextItem -> uploadText(live, item, remotePath, remoteName, onProgress)
+                    is ShareableItem.FileItem -> live.uploadFile(item.file, remotePath, onProgress)
                 }
                 Result.success("${destination.displayDirectory}/$remoteName")
             }
@@ -257,6 +260,7 @@ internal class ShareUploader(
         session: SshSession,
         item: ShareableItem.UriItem,
         remotePath: String,
+        onProgress: ((SshUploadProgress) -> Unit)?,
     ) {
         val resolver = context.contentResolver
         val length = item.size ?: resolveSize(resolver, item.uri)
@@ -266,7 +270,7 @@ internal class ShareUploader(
             // file under the cache directory so we can use uploadFile.
             val temp = drainToTempFile(resolver, item.uri)
             try {
-                session.uploadFile(temp, remotePath)
+                session.uploadFile(temp, remotePath, onProgress)
             } finally {
                 temp.delete()
             }
@@ -279,6 +283,7 @@ internal class ShareUploader(
                 length = length,
                 name = remotePath.substringAfterLast('/'),
                 remotePath = remotePath,
+                onProgress = onProgress,
             )
         } ?: throw SshException("Could not read shared file (content provider returned null)")
     }
@@ -288,6 +293,7 @@ internal class ShareUploader(
         item: ShareableItem.TextItem,
         remotePath: String,
         remoteName: String,
+        onProgress: ((SshUploadProgress) -> Unit)?,
     ) {
         val bytes = item.text.toByteArray(Charsets.UTF_8)
         bytes.inputStream().use { input ->
@@ -296,6 +302,7 @@ internal class ShareUploader(
                 length = bytes.size.toLong(),
                 name = remoteName,
                 remotePath = remotePath,
+                onProgress = onProgress,
             )
         }
     }

--- a/app/src/main/java/com/pocketshell/app/share/ShareViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/share/ShareViewModel.kt
@@ -16,6 +16,7 @@ import com.pocketshell.core.ssh.SshLeaseManager
 import com.pocketshell.core.ssh.SshLeaseTarget
 import com.pocketshell.core.ssh.SshKey
 import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshUploadProgress
 import com.pocketshell.core.storage.dao.HostDao
 import com.pocketshell.core.storage.dao.ProjectRootDao
 import com.pocketshell.core.storage.dao.SshKeyDao
@@ -222,7 +223,11 @@ internal class ShareViewModel internal constructor(
     @androidx.annotation.VisibleForTesting
     internal var connectForStaging: suspend (HostEntity, SshKeyEntity) -> Result<SshSession> =
         { host, keyEntity ->
-            acquireLeaseBackedSession(host = host, keyPath = keyEntity.privateKeyPath)
+            acquireLeaseBackedSession(
+                host = host,
+                keyPath = keyEntity.privateKeyPath,
+                purpose = "staging",
+            )
         }
 
     private suspend fun connectForUpload(
@@ -235,14 +240,19 @@ internal class ShareViewModel internal constructor(
                 com.pocketshell.core.ssh.SshException("Share upload requires a persisted SSH key"),
             )
         }
-        return acquireLeaseBackedSession(host = host, keyPath = keyPath)
+        return acquireLeaseBackedSession(host = host, keyPath = keyPath, purpose = "upload")
     }
 
     private suspend fun acquireLeaseBackedSession(
         host: HostEntity,
         keyPath: String,
+        purpose: String,
     ): Result<SshSession> {
-        val target = host.toShareLeaseTarget(keyPath, pendingPassphrase.get())
+        val target = host.toShareLeaseTarget(
+            keyPath = keyPath,
+            passphrase = pendingPassphrase.get(),
+            purpose = purpose,
+        )
         return sshLeaseManager.acquire(target).map { lease ->
             LeaseBackedShareSession(lease)
         }
@@ -251,26 +261,21 @@ internal class ShareViewModel internal constructor(
     /**
      * Build the lease target for the share connect.
      *
-     * The [SshLeaseKey] is byte-for-byte identical to the one the live
-     * tmux session uses (`TmuxSessionViewModel.toSshLeaseTarget`) — same
-     * `credentialId` (`"$id:$keyPath"`) and `knownHostsId` — so when the
-     * app already holds a warm lease for this host/key the share REUSES it
-     * (the passphrase is intentionally NOT part of the lease key, so a
-     * warm, already-unlocked lease is shared regardless of whether we have
-     * a passphrase here). The [passphrase] only matters on the
-     * fresh-connect fallback, when no reusable lease exists and the key is
-     * passphrase-protected (issue #654).
+     * File-transfer work gets its own lease-key purpose suffix instead of
+     * borrowing the live tmux terminal transport. A multi-megabyte upload can
+     * otherwise disturb the active control session on the same SSH connection.
      */
     private fun HostEntity.toShareLeaseTarget(
         keyPath: String,
         passphrase: CharArray?,
+        purpose: String,
     ): SshLeaseTarget =
         SshLeaseTarget(
             leaseKey = SshLeaseKey(
                 host = hostname,
                 port = port,
                 user = username,
-                credentialId = "$id:$keyPath",
+                credentialId = "$id:$keyPath:$purpose",
                 knownHostsId = "accept-all",
             ),
             key = SshKey.Path(File(keyPath)),
@@ -686,7 +691,7 @@ internal class ShareViewModel internal constructor(
             "target" to targetName,
         )
         _targetSelection.value = null
-        _uploadState.value = UploadState.Running(host.name)
+        _uploadState.value = UploadState.Running(hostName = host.name, totalCount = payload.size)
         viewModelScope.launch {
             val keyEntity = sshKeyDao.getById(host.keyId)
             if (keyEntity == null) {
@@ -714,7 +719,32 @@ internal class ShareViewModel internal constructor(
 
             for ((index, item) in payload.withIndex()) {
                 val itemLabel = item.displayName?.takeIf { it.isNotBlank() } ?: "file"
-                val result = uploader.upload(host, keyEntity, item, target)
+                val itemNumber = index + 1
+                val estimatedBytes = estimatedUploadBytes(item)
+                _uploadState.value = UploadState.Running(
+                    hostName = host.name,
+                    currentItemIndex = itemNumber,
+                    totalCount = payload.size,
+                    currentItemName = itemLabel,
+                    bytesTransferred = 0L,
+                    totalBytes = estimatedBytes,
+                )
+                val result = uploader.upload(
+                    host = host,
+                    keyEntity = keyEntity,
+                    item = item,
+                    target = target,
+                    onProgress = { progress ->
+                        _uploadState.value = UploadState.Running(
+                            hostName = host.name,
+                            currentItemIndex = itemNumber,
+                            totalCount = payload.size,
+                            currentItemName = itemLabel,
+                            bytesTransferred = progress.bytesTransferred,
+                            totalBytes = progress.totalBytes.takeIf { it > 0L } ?: estimatedBytes,
+                        )
+                    },
+                )
                 val failure = result.exceptionOrNull()
                 // Issue #654: a fresh share connect (when no warm app lease
                 // is reusable — e.g. the live session's lease expired while
@@ -1012,6 +1042,12 @@ internal class ShareViewModel internal constructor(
         ShareUploadNotifications.showFailure(applicationContext, hostName, message)
     }
 
+    private fun estimatedUploadBytes(item: ShareableItem): Long? = when (item) {
+        is ShareableItem.FileItem -> item.file.length().takeIf { it > 0L }
+        is ShareableItem.TextItem -> item.text.toByteArray(Charsets.UTF_8).size.toLong()
+        is ShareableItem.UriItem -> item.size?.takeIf { it > 0L }
+    }
+
     private data class SessionStagingInput(
         val uris: List<Uri>,
         val tempFiles: List<File>,
@@ -1164,7 +1200,7 @@ internal class ShareViewModel internal constructor(
      */
     fun submitPassphrase(passphrase: CharArray) {
         if (passphrase.isEmpty()) return
-        pendingPassphrase.getAndSet(passphrase.copyOf())?.fill(' ')
+        pendingPassphrase.getAndSet(passphrase.copyOf())?.fill('\u0000')
         retryLastShareAction()
     }
 
@@ -1174,7 +1210,7 @@ internal class ShareViewModel internal constructor(
     }
 
     private fun clearPendingPassphrase() {
-        pendingPassphrase.getAndSet(null)?.fill(' ')
+        pendingPassphrase.getAndSet(null)?.fill('\u0000')
     }
 
     /**
@@ -1257,7 +1293,14 @@ internal sealed interface UploadState {
     data object Idle : UploadState
 
     /** SCP upload (or send-keys paste) is running. Surface a spinner + the host name. */
-    data class Running(val hostName: String) : UploadState
+    data class Running(
+        val hostName: String,
+        val currentItemIndex: Int = 0,
+        val totalCount: Int = 1,
+        val currentItemName: String? = null,
+        val bytesTransferred: Long = 0L,
+        val totalBytes: Long? = null,
+    ) : UploadState
 
     /**
      * Issue #654: the fresh share connect could not authenticate because
@@ -1357,6 +1400,13 @@ private class LeaseBackedShareSession(
     override suspend fun uploadFile(file: File, remotePath: String): String =
         session.uploadFile(file, remotePath)
 
+    override suspend fun uploadFile(
+        file: File,
+        remotePath: String,
+        onProgress: ((SshUploadProgress) -> Unit)?,
+    ): String =
+        session.uploadFile(file, remotePath, onProgress)
+
     override suspend fun downloadFile(remotePath: String, maxBytes: Long): ByteArray =
         session.downloadFile(remotePath, maxBytes)
 
@@ -1367,6 +1417,15 @@ private class LeaseBackedShareSession(
         remotePath: String,
     ): String =
         session.uploadStream(input, length, name, remotePath)
+
+    override suspend fun uploadStream(
+        input: java.io.InputStream,
+        length: Long,
+        name: String,
+        remotePath: String,
+        onProgress: ((SshUploadProgress) -> Unit)?,
+    ): String =
+        session.uploadStream(input, length, name, remotePath, onProgress)
 
     override suspend fun listDirectory(
         remotePath: String,

--- a/app/src/test/java/com/pocketshell/app/share/ShareViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/share/ShareViewModelTest.kt
@@ -657,18 +657,19 @@ class ShareViewModelTest {
     }
 
     @Test
-    fun startUploadReusesActiveSshLeaseInsteadOfStartingFreshAuth() = runTest {
+    fun startUploadUsesTransferLeaseWithoutClosingActiveSshLease() = runTest {
         val host = seededHost(id = 138L, name = "hetzner")
         val keyPath = "/tmp/key-138"
-        val fakeSession = FakeStagingSshSession()
+        val terminalSession = FakeStagingSshSession()
+        val uploadSession = FakeStagingSshSession()
         var connectCalls = 0
         val leaseManager = SshLeaseManager(
             connector = { _: SshLeaseTarget ->
                 connectCalls += 1
-                if (connectCalls == 1) {
-                    Result.success(fakeSession)
-                } else {
-                    Result.failure(SshException("Authentication failed"))
+                when (connectCalls) {
+                    1 -> Result.success(terminalSession)
+                    2 -> Result.success(uploadSession)
+                    else -> Result.failure(SshException("unexpected extra connect"))
                 }
             },
         )
@@ -687,17 +688,21 @@ class ShareViewModelTest {
                     success.copyText.endsWith("report.txt"),
             )
             assertEquals(
-                "a live lease for the same host/key should be reused",
-                1,
+                "share upload should use a separate transfer lease",
+                2,
                 connectCalls,
             )
             assertTrue(
-                "the upload should have used the already-live session",
-                fakeSession.uploadedRemotePaths.isNotEmpty(),
+                "the upload should use the transfer session",
+                uploadSession.uploadedRemotePaths.isNotEmpty(),
+            )
+            assertTrue(
+                "the active app session should not receive upload bytes",
+                terminalSession.uploadedRemotePaths.isEmpty(),
             )
             assertFalse(
                 "releasing the share lease must not close the active app session",
-                fakeSession.closed,
+                terminalSession.closed,
             )
         } finally {
             activeLease.release()
@@ -706,24 +711,22 @@ class ShareViewModelTest {
     }
 
     @Test
-    fun startUploadDoesNotReAuthWhenWarmLeaseExistsForPassphraseKey() = runTest {
-        // Issue #654: a passphrase-protected key must STILL reuse the warm
-        // app lease without any passphrase prompt — the passphrase is not
-        // part of the lease key, so an already-unlocked lease is shared.
+    fun startUploadUsesIsolatedTransferLeaseEvenWhenWarmTerminalLeaseExists() = runTest {
+        // Issue #1037: a multi-megabyte share upload must not ride the same
+        // warm transport as the active terminal session. It dials a transfer
+        // lease with a purpose-suffixed key instead.
         val host = seededHost(id = 654L, name = "hetzner", hasPassphrase = true)
         val keyPath = "/tmp/key-654"
-        val fakeSession = FakeStagingSshSession()
+        val terminalSession = FakeStagingSshSession()
+        val uploadSession = FakeStagingSshSession()
         var connectCalls = 0
-        // The first connect (the live app session's) succeeds; any SECOND
-        // connect would mean the share re-authenticated instead of reusing
-        // the warm lease, which the assertion below forbids.
         val leaseManager = SshLeaseManager(
             connector = { _: SshLeaseTarget ->
                 connectCalls += 1
-                if (connectCalls == 1) {
-                    Result.success(fakeSession)
-                } else {
-                    Result.failure(SshException("Authentication failed"))
+                when (connectCalls) {
+                    1 -> Result.success(terminalSession)
+                    2 -> Result.success(uploadSession)
+                    else -> Result.failure(SshException("unexpected extra connect"))
                 }
             },
         )
@@ -736,11 +739,19 @@ class ShareViewModelTest {
             advanceUntilIdle()
 
             val success = vm.uploadState.first { it is UploadState.Success }
-            assertTrue("warm lease reuse must succeed", success is UploadState.Success)
+            assertTrue("isolated upload lease must succeed", success is UploadState.Success)
             assertEquals(
-                "the passphrase-protected key's warm lease was reused; no fresh auth",
-                1,
+                "the upload should dial a separate transfer lease instead of reusing the terminal lease",
+                2,
                 connectCalls,
+            )
+            assertTrue(
+                "the upload session should receive the file",
+                uploadSession.uploadedRemotePaths.isNotEmpty(),
+            )
+            assertTrue(
+                "the active terminal session should not receive upload bytes",
+                terminalSession.uploadedRemotePaths.isEmpty(),
             )
         } finally {
             activeLease.release()
@@ -1498,10 +1509,17 @@ class ShareViewModelTest {
             keyEntity: SshKeyEntity,
             item: ShareableItem,
             target: ShareTarget,
+            onProgress: ((com.pocketshell.core.ssh.SshUploadProgress) -> Unit)?,
         ): Result<String> {
             val name = item.displayName.orEmpty()
             uploadedNames += name
             uploadedTargets += target
+            onProgress?.invoke(
+                com.pocketshell.core.ssh.SshUploadProgress(
+                    bytesTransferred = 1L,
+                    totalBytes = 1L,
+                ),
+            )
             return if (name in failNames) {
                 Result.failure(IllegalStateException("Permission denied"))
             } else if (name in blankNames) {

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshSession.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshSession.kt
@@ -88,15 +88,16 @@ internal class RealSshSession(
     private val dispatcher = TransportDispatcher()
 
     /**
-     * Monotonic ([System.nanoTime]) timestamp of the most recent inbound
-     * transport activity — bumped on a successful keepalive reply (issue #945)
-     * AND on ANY decoded application bytes the server sends back over the
-     * transport: the live `-CC` control-mode reader's output, an exec/list/cat
-     * round-trip's stdout/stderr, and each `tail -F` line (issue #974). The
-     * keepalive loop reads this to SKIP a ping when the link produced server
-     * bytes within the last interval (OpenSSH reset-on-server-traffic
-     * semantics), so a busy link is self-evidently alive and we never ping —
-     * nor tear down — a channel that is actively streaming.
+     * Monotonic ([System.nanoTime]) timestamp of the most recent transport
+     * activity that should reset idle liveness accounting — bumped on a
+     * successful keepalive reply (issue #945), on ANY decoded application bytes
+     * the server sends back over the transport, and on active outbound upload
+     * byte progress. Inbound examples are the live `-CC` control-mode reader's
+     * output, an exec/list/cat round-trip's stdout/stderr, and each `tail -F`
+     * line (issue #974). The keepalive loop reads this to SKIP a ping when
+     * the link produced server bytes or foreground upload progress within the
+     * last interval, so a busy link is self-evidently alive and we never ping
+     * — nor tear down — a channel that is actively streaming.
      *
      * ## Issue #974 — honour the contract: live data proves the transport alive
      *
@@ -115,11 +116,12 @@ internal class RealSshSession(
      * counter and keep [isTransportProvenAliveWithinKeepAliveWindow] true, so a
      * link with live data is never spuriously declared dead.
      *
-     * Bound to DECODED application bytes from the server (the channel streams
-     * sshj already decrypted/decoded), NOT raw socket reads — a genuinely
-     * half-open peer that sends no bytes still produces no activity here, so the
-     * keepalive's own ride-through budget still catches a truly-dead link
-     * promptly (the fix must not make a dead link look alive forever).
+     * Normally bound to DECODED application bytes from the server (the channel
+     * streams sshj already decrypted/decoded), NOT raw socket reads. Uploads are
+     * the deliberate exception: a large foreground upload can be outbound-only
+     * until EOF/exit-status, so successful chunk writes count as active transport
+     * progress while the upload's own 60s transfer timeout still bounds a
+     * genuinely wedged/dead link.
      */
     @Volatile
     private var lastInboundActivityNanos: Long = System.nanoTime()
@@ -134,6 +136,10 @@ internal class RealSshSession(
      * promises. Cheap volatile store, safe to call from any reader thread.
      */
     private fun recordInboundActivity() {
+        lastInboundActivityNanos = System.nanoTime()
+    }
+
+    private fun recordUploadProgressActivity() {
         lastInboundActivityNanos = System.nanoTime()
     }
 
@@ -775,6 +781,13 @@ internal class RealSshSession(
     }
 
     override suspend fun uploadFile(file: File, remotePath: String): String =
+        uploadFile(file, remotePath, onProgress = null)
+
+    override suspend fun uploadFile(
+        file: File,
+        remotePath: String,
+        onProgress: ((SshUploadProgress) -> Unit)?,
+    ): String =
         withContext(Dispatchers.IO) {
             ensureConnected()
             if (!file.exists()) {
@@ -786,6 +799,7 @@ internal class RealSshSession(
                     length = file.length(),
                     name = file.name,
                     remotePath = remotePath,
+                    onProgress = onProgress,
                 )
             }
             remotePath
@@ -796,9 +810,18 @@ internal class RealSshSession(
         length: Long,
         name: String,
         remotePath: String,
+    ): String =
+        uploadStream(input, length, name, remotePath, onProgress = null)
+
+    override suspend fun uploadStream(
+        input: InputStream,
+        length: Long,
+        name: String,
+        remotePath: String,
+        onProgress: ((SshUploadProgress) -> Unit)?,
     ): String = withContext(Dispatchers.IO) {
         ensureConnected()
-        uploadStreamInternal(input, length, name, remotePath)
+        uploadStreamInternal(input, length, name, remotePath, onProgress)
         remotePath
     }
 
@@ -952,6 +975,7 @@ internal class RealSshSession(
         length: Long,
         name: String,
         remotePath: String,
+        onProgress: ((SshUploadProgress) -> Unit)?,
     ) {
         // Atomic temp sibling of the final path: `<final>.part-<rand>`. A
         // dropped/timed-out transfer corrupts only THIS temp name, never the
@@ -959,7 +983,14 @@ internal class RealSshSession(
         // concurrent retries of the same attachment.
         val tempRemotePath = remotePath + ".part-" + java.util.UUID.randomUUID().toString().take(8)
         try {
-            val copied = streamToRemoteTemp(input, name, remotePath, tempRemotePath)
+            val copied = streamToRemoteTemp(
+                input = input,
+                name = name,
+                remotePath = remotePath,
+                tempRemotePath = tempRemotePath,
+                totalBytes = length,
+                onProgress = onProgress,
+            )
 
             // Integrity check BEFORE the rename: the bytes that actually landed
             // in the temp file must match what we copied, and — when the caller
@@ -1013,6 +1044,8 @@ internal class RealSshSession(
         name: String,
         remotePath: String,
         tempRemotePath: String,
+        totalBytes: Long,
+        onProgress: ((SshUploadProgress) -> Unit)?,
     ): Long {
         val coroutineJob = currentCoroutineContext()[Job]
         // Channel open + `cat >` exec are transport-mutating packets — serialise
@@ -1063,7 +1096,7 @@ internal class RealSshSession(
             val copied = withTimeoutOrNull(UPLOAD_TRANSFER_TIMEOUT_MS) {
                 runInterruptible(Dispatchers.IO) {
                     val n = command!!.outputStream.use { output ->
-                        copyToRemoteBlocking(input, output)
+                        copyToRemoteBlocking(input, output, totalBytes, onProgress)
                     }
                     // `outputStream.close()` sends EOF on the channel. The remote
                     // `cat` exits on EOF; `join()` waits for it so we can read
@@ -1195,9 +1228,15 @@ internal class RealSshSession(
      * wedged transfer unblocks promptly instead of hanging. Returns the number
      * of bytes copied.
      */
-    private fun copyToRemoteBlocking(input: InputStream, output: OutputStream): Long {
+    private fun copyToRemoteBlocking(
+        input: InputStream,
+        output: OutputStream,
+        totalBytes: Long,
+        onProgress: ((SshUploadProgress) -> Unit)?,
+    ): Long {
         val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
         var total = 0L
+        onProgress?.invoke(SshUploadProgress(bytesTransferred = 0L, totalBytes = totalBytes))
         while (true) {
             if (Thread.interrupted()) throw InterruptedException("SSH upload interrupted")
             val read = input.read(buffer)
@@ -1205,6 +1244,8 @@ internal class RealSshSession(
             if (Thread.interrupted()) throw InterruptedException("SSH upload interrupted")
             output.write(buffer, 0, read)
             total += read
+            recordUploadProgressActivity()
+            onProgress?.invoke(SshUploadProgress(bytesTransferred = total, totalBytes = totalBytes))
         }
         output.flush()
         return total

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshSession.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshSession.kt
@@ -4,6 +4,11 @@ import kotlinx.coroutines.Job
 import java.io.File
 import java.io.InputStream
 
+public data class SshUploadProgress(
+    val bytesTransferred: Long,
+    val totalBytes: Long,
+)
+
 /**
  * Live SSH connection to a single host. Obtain instances via
  * [SshConnection.connect].
@@ -121,6 +126,12 @@ public interface SshSession : AutoCloseable {
      */
     public suspend fun uploadFile(file: File, remotePath: String): String
 
+    public suspend fun uploadFile(
+        file: File,
+        remotePath: String,
+        onProgress: ((SshUploadProgress) -> Unit)?,
+    ): String = uploadFile(file, remotePath)
+
     /**
      * Read the contents of a remote file at [remotePath] into memory.
      *
@@ -178,6 +189,14 @@ public interface SshSession : AutoCloseable {
         name: String,
         remotePath: String,
     ): String
+
+    public suspend fun uploadStream(
+        input: InputStream,
+        length: Long,
+        name: String,
+        remotePath: String,
+        onProgress: ((SshUploadProgress) -> Unit)?,
+    ): String = uploadStream(input, length, name, remotePath)
 
     /**
      * List the entries of remote directory [remotePath] (issue #528 — file


### PR DESCRIPTION
## Summary
- isolate share upload/staging SSH leases from active terminal transports so multi-megabyte uploads do not ride the live tmux connection
- report byte progress through the share upload UI
- count outbound upload chunk progress as SSH transport activity while the upload timeout still bounds wedged transfers

## Notes
- This fixes the Android share-target upload path reported in #1037.
- Composer attachment upload progress is not wired in this PR; it can be handled as a follow-up if the same UX gap applies there.
- Passphrase-protected transfer leases may need their own auth path instead of silently borrowing an already-unlocked terminal lease.

## Verification
- git diff --check
- focused JVM tests passed locally before daemon cleanup:
  ./gradlew :app:testDebugUnitTest --tests 'com.pocketshell.app.share.ShareViewModelTest.startUploadUsesTransferLeaseWithoutClosingActiveSshLease' --tests 'com.pocketshell.app.share.ShareViewModelTest.startUploadUsesIsolatedTransferLeaseEvenWhenWarmTerminalLeaseExists'
- no emulator or connected Android tests run locally

Refs #1037