### PR TITLE
Harden connection lifecycle (SSH/tmux/lease) + fix red main journeys

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,14 @@ on:
     tags: ["v*"]
   workflow_dispatch:
 
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     permissions:
       contents: write
 
@@ -78,6 +83,7 @@ jobs:
     needs: build
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     environment:
       name: pypi

--- a/.github/workflows/release-emulator-validation.yml
+++ b/.github/workflows/release-emulator-validation.yml
@@ -13,6 +13,12 @@ on:
         default: false
         type: boolean
 
+# Manual release validation owns a long emulator runner; queue one per ref
+# instead of letting duplicate dispatches pile up.
+concurrency:
+  group: release-emulator-validation-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   emulator-release-validation:
     name: Emulator-only release validation

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Common commands:
 
 ```bash
 scripts/cgroup-run.sh -- ./gradlew assembleDebug
-./gradlew test --stacktrace
+scripts/cgroup-run.sh -- ./gradlew test --stacktrace
 scripts/cgroup-run.sh -- ./gradlew check --stacktrace
 scripts/connected-test.sh
 ```

--- a/README.md
+++ b/README.md
@@ -202,10 +202,10 @@ sdk.dir=/home/alexey/Android/Sdk
 Common commands:
 
 ```bash
-./gradlew assembleDebug
+scripts/cgroup-run.sh -- ./gradlew assembleDebug
 ./gradlew test --stacktrace
-./gradlew check --stacktrace
-./gradlew connectedDebugAndroidTest
+scripts/cgroup-run.sh -- ./gradlew check --stacktrace
+scripts/connected-test.sh
 ```
 
 The test matrix and Docker/emulator setup are in

--- a/agents.md
+++ b/agents.md
@@ -359,7 +359,8 @@ are looking at before proposing a fix:
   filtered subset.** A filter passes while the full suite fails or HANGS. The
   **#882 miss (2026-06-21):** a recording-timer `while(recording){delay(50)}`
   coroutine left active spun `advanceUntilIdle` forever under `runTest` virtual
-  time → the CI Unit job (`./gradlew test --no-daemon`, whole suite, 35-min cap)
+  time → the CI Unit job (`./gradlew test --no-daemon`, whole suite, 35-min cap;
+  local repros use `scripts/cgroup-run.sh -- ./gradlew test --no-daemon`)
   hit its timeout and `main` went red, but every gate ran the filtered subset and
   never saw it. Mandatory especially when a change adds a coroutine loop / ticker /
   new `runTest` test. A CI job that ends with "timed out after N minutes" + all
@@ -443,11 +444,12 @@ those sections, not repeated here.)
   even though `alexey` is in `/etc/group` (the login predates the group add), so
   any emulator the orchestrator boots directly fails with "user doesn't have
   permissions to use /dev/kvm" and release/emulator gates die at
-  emulator-readiness. Start ONE emulator under `sg kvm -c "... emulator -avd test
-  ..."`, let it boot, then run the gate (adb/gradle don't need kvm, only the
-  emulator process does). **Do NOT kill pre-existing running emulators** to "clean
-  up" — they were booted by a kvm-capable context and work; the orchestrator can't
-  re-boot them. Leave exactly ONE (or export `ANDROID_SERIAL`).
+  emulator-readiness. Start ONE emulator with `AVD_HOLD=1
+  scripts/start-local-avd.sh`, which uses the shared AVD lock, cgroup scoping,
+  and KVM wrapper, then run the gate. **Do NOT kill pre-existing running
+  emulators** to "clean up" — they were booted by a kvm-capable context and
+  work; the orchestrator may not be able to re-boot them. Leave exactly ONE (or
+  export `ANDROID_SERIAL`).
 - **Port 2222 squatter:** the #638 journey gate / terminal-workbench need the
   Docker `agents` fixture on host port **2222** specifically (the emulator's
   `10.0.2.2:2222` alias is fixed). The sibling project pocketshell-desktop's

--- a/app/src/androidTest/java/com/pocketshell/app/proof/BackgroundGraceReconnectE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/BackgroundGraceReconnectE2eTest.kt
@@ -23,6 +23,7 @@ import com.pocketshell.app.MainActivity
 import com.pocketshell.app.diagnostics.DiagnosticEvents
 import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
 import com.pocketshell.app.hosts.SshKeyStorage
+import com.pocketshell.app.sessions.service.SessionConnectionService
 import com.pocketshell.app.tmux.TMUX_CONNECTING_PROGRESS_TAG
 import com.pocketshell.app.tmux.TMUX_CONNECTION_STATUS_PILL_TAG
 import com.pocketshell.app.tmux.TMUX_SESSION_ERROR_TAG
@@ -189,6 +190,7 @@ class BackgroundGraceReconnectE2eTest {
         // Post-grace branch: with the same real UI path still open, use a
         // shorter override so the teardown branch is covered without waiting
         // for the user-facing 30s minimum.
+        stopSessionHoldBeforeExpectedTeardown()
         diagnostics!!.clear()
         BackgroundGraceTestOverride.setForTest(POST_GRACE_MS)
         val postStart = SystemClock.elapsedRealtime()
@@ -282,6 +284,7 @@ class BackgroundGraceReconnectE2eTest {
         // the post-grace branch of the within-grace test (same proven sequencing),
         // using the short override so the teardown actually fires without a 30s+
         // real-grace wait.
+        stopSessionHoldBeforeExpectedTeardown()
         BackgroundGraceTestOverride.setForTest(POST_GRACE_MS)
         val postStart = SystemClock.elapsedRealtime()
         compose.activityRule.scenario.moveToState(Lifecycle.State.CREATED)
@@ -862,6 +865,13 @@ class BackgroundGraceReconnectE2eTest {
             .edit()
             .remove("background_grace_millis")
             .commit()
+    }
+
+    private fun stopSessionHoldBeforeExpectedTeardown() {
+        val ctx = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
+        SessionConnectionService.stop(ctx)
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        SystemClock.sleep(250L)
     }
 
     private suspend fun seedDockerHost(key: String): String {

--- a/app/src/androidTest/java/com/pocketshell/app/proof/BackgroundGraceReconnectE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/BackgroundGraceReconnectE2eTest.kt
@@ -195,8 +195,14 @@ class BackgroundGraceReconnectE2eTest {
         BackgroundGraceTestOverride.setForTest(POST_GRACE_MS)
         val postStart = SystemClock.elapsedRealtime()
         compose.activityRule.scenario.moveToState(Lifecycle.State.CREATED)
+        // The grace deadline elapsing is recorded by `background_grace_elapsed`
+        // carrying `deadlineElapsed=true` (the connection-stability hardening
+        // renamed the old `teardown` field to `deadlineElapsed`; the matching JVM
+        // contract lives in BackgroundGraceControllerTest). The GENUINE teardown is
+        // proven independently on the next line by `terminal_background_teardown`,
+        // so this wait only confirms the deadline fired.
         waitForDiagnostic("background_grace_elapsed", "post-grace elapsed") {
-            it.fields["teardown"] == true
+            it.fields["deadlineElapsed"] == true
         }
         waitForDiagnostic("terminal_background_teardown", "post-grace teardown")
         waitForClientCountAtMost(0, "post-grace detached")
@@ -288,8 +294,12 @@ class BackgroundGraceReconnectE2eTest {
         BackgroundGraceTestOverride.setForTest(POST_GRACE_MS)
         val postStart = SystemClock.elapsedRealtime()
         compose.activityRule.scenario.moveToState(Lifecycle.State.CREATED)
+        // See the matching wait in
+        // quickAppSwitchWithinBackgroundGraceDoesNotShowOrRecordReconnect: the
+        // grace deadline is recorded with `deadlineElapsed=true`, and the genuine
+        // teardown is proven by the `terminal_background_teardown` wait below.
         waitForDiagnostic("background_grace_elapsed", "post-grace elapsed") {
-            it.fields["teardown"] == true
+            it.fields["deadlineElapsed"] == true
         }
         waitForDiagnostic("terminal_background_teardown", "post-grace teardown")
         waitForClientCountAtMost(0, "post-grace detached")

--- a/app/src/main/java/com/pocketshell/app/App.kt
+++ b/app/src/main/java/com/pocketshell/app/App.kt
@@ -996,14 +996,17 @@ internal class BackgroundGraceController(
     private var graceJob: Job? = null
     private var backgroundCycleId: Long = 0L
     private var backgroundStartedAtMs: Long = 0L
+    private var backgroundDeadlineAtMs: Long = 0L
+    private var backgroundGraceMillisForCycle: Long = graceMillis.coerceAtLeast(0L)
     private var backgrounded: Boolean = false
     private var holdStopTeardownDispatched: Boolean = false
 
     /**
-     * True once [onGraceElapsed] has actually run for the current
-     * background cycle. Distinguishes a within-grace resume (connection
-     * intact) from a post-grace resume (connection torn down, reattach
-     * needed). Reset on the next [onBackground].
+     * True once the grace-elapsed action has been dispatched for the current
+     * background cycle. The action may preserve the connection (for example,
+     * while a session foreground-service hold is active), so this tracks
+     * elapsed/deadline handling rather than a guaranteed destructive teardown.
+     * Reset on the next [onBackground].
      */
     private var teardownFired: Boolean = false
 
@@ -1013,8 +1016,9 @@ internal class BackgroundGraceController(
      * cannot unexpectedly prolong a backgrounded connection.
      */
     fun setGraceMillis(millis: Long) {
-        if (graceJob?.isActive == true || graceMillis == millis) return
-        graceMillis = millis
+        val normalizedMillis = millis.coerceAtLeast(0L)
+        if (backgrounded || graceMillis == normalizedMillis) return
+        graceMillis = normalizedMillis
     }
 
     fun onBackground() {
@@ -1024,14 +1028,17 @@ internal class BackgroundGraceController(
         if (backgrounded && teardownFired) return
         backgroundCycleId += 1L
         backgroundStartedAtMs = nowMillis()
+        backgroundGraceMillisForCycle = graceMillis.coerceAtLeast(0L)
+        backgroundDeadlineAtMs = backgroundStartedAtMs + backgroundGraceMillisForCycle
         backgrounded = true
         teardownFired = false
         holdStopTeardownDispatched = false
-        Log.i(GRACE_LIFECYCLE_TAG, "grace-window-start millis=$graceMillis")
+        Log.i(GRACE_LIFECYCLE_TAG, "grace-window-start millis=$backgroundGraceMillisForCycle")
         DiagnosticEvents.record(
             "app",
             "background_grace_start",
-            "millis" to graceMillis,
+            "millis" to backgroundGraceMillisForCycle,
+            "deadlineMs" to backgroundDeadlineAtMs,
             "backgroundCycleId" to backgroundCycleId,
             "source" to "process_lifecycle",
             "trigger" to "on_stop",
@@ -1041,78 +1048,41 @@ internal class BackgroundGraceController(
             outcome = "start",
             cause = "process_background",
             trigger = "on_stop",
-            "graceMs" to graceMillis,
+            "graceMs" to backgroundGraceMillisForCycle,
+            "deadlineMs" to backgroundDeadlineAtMs,
             "backgroundCycleId" to backgroundCycleId,
         )
         graceJob = scope.launch {
-            delay(graceMillis)
-            teardownFired = true
-            val elapsedMs = (nowMillis() - backgroundStartedAtMs).coerceAtLeast(0L)
-            Log.i(GRACE_LIFECYCLE_TAG, "grace-window-elapsed teardown")
-            DiagnosticEvents.record(
-                "app",
-                "background_grace_elapsed",
-                "teardown" to true,
-                "elapsedMs" to elapsedMs,
-                "millis" to graceMillis,
-                "backgroundCycleId" to backgroundCycleId,
-                "source" to "timer",
-                "trigger" to "grace_timeout",
-            )
-            ReconnectCauseTrail.record(
-                stage = "background_grace",
-                outcome = "elapsed_teardown",
-                cause = "grace_timeout",
-                trigger = "timer",
-                "elapsedMs" to elapsedMs,
-                "graceMs" to graceMillis,
-                "backgroundCycleId" to backgroundCycleId,
-            )
-            onGraceElapsed()
+            delay(backgroundGraceMillisForCycle)
+            dispatchGraceElapsedIfNeeded(source = "timer", trigger = "grace_timeout")
         }
     }
 
     fun onForeground() {
         val pending = graceJob
         graceJob = null
-        val resumedWithinGrace = pending?.isActive == true && !teardownFired
-        val elapsedMs = (nowMillis() - backgroundStartedAtMs).coerceAtLeast(0L)
+        val foregroundAtMs = nowMillis()
+        val hadBackgroundCycle = backgroundCycleId > 0L
+        val resumedWithinGrace = backgrounded && !teardownFired && foregroundAtMs < backgroundDeadlineAtMs
+        val elapsedMs = elapsedMs(foregroundAtMs)
         backgrounded = false
         if (resumedWithinGrace) {
             pending?.cancel()
+        } else if (!teardownFired && pending?.isActive == true) {
+            pending.cancel()
         }
-        Log.i(
-            GRACE_LIFECYCLE_TAG,
-            "grace-window-foreground resumedWithinGrace=$resumedWithinGrace elapsedMs=$elapsedMs",
-        )
-        val diagnosticFields = foregroundDiagnosticFields(resumedWithinGrace)
-        DiagnosticEvents.record(
-            "app",
-            "background_grace_foreground",
-            "resumedWithinGrace" to resumedWithinGrace,
-            "withinGrace" to resumedWithinGrace,
-            "elapsedMs" to elapsedMs,
-            "millis" to graceMillis,
-            "backgroundCycleId" to backgroundCycleId,
-            "source" to "process_lifecycle",
-            "trigger" to "on_start",
-            *diagnosticFields.toTypedArray(),
-        )
-        ReconnectCauseTrail.record(
-            stage = "background_grace",
-            outcome = if (resumedWithinGrace) "foreground_preserved" else "foreground_reattach_needed",
-            cause = if (resumedWithinGrace) "within_grace" else "post_grace",
-            trigger = "on_start",
-            "withinGrace" to resumedWithinGrace,
-            "elapsedMs" to elapsedMs,
-            "graceMs" to graceMillis,
-            "backgroundCycleId" to backgroundCycleId,
-            *diagnosticFields.toTypedArray(),
-        )
         scope.launch {
             if (!resumedWithinGrace) {
-                pending?.join()
+                if (!teardownFired && hadBackgroundCycle && foregroundAtMs >= backgroundDeadlineAtMs) {
+                    dispatchGraceElapsedIfNeeded(
+                        source = "process_lifecycle",
+                        trigger = "deadline_before_on_start",
+                    )
+                } else {
+                    pending?.join()
+                }
             }
+            recordForeground(resumedWithinGrace = resumedWithinGrace, elapsedMs = elapsedMs)
             onForeground(resumedWithinGrace)
         }
     }
@@ -1129,9 +1099,10 @@ internal class BackgroundGraceController(
         DiagnosticEvents.record(
             "app",
             "background_grace_session_hold_stop",
-            "teardown" to true,
+            "teardownRequested" to true,
             "elapsedMs" to elapsedMs,
-            "millis" to graceMillis,
+            "millis" to backgroundGraceMillisForCycle,
+            "deadlineMs" to backgroundDeadlineAtMs,
             "backgroundCycleId" to backgroundCycleId,
             "source" to "session_notification",
             "trigger" to "stop_action",
@@ -1142,7 +1113,8 @@ internal class BackgroundGraceController(
             cause = "session_notification_stop",
             trigger = "stop_action",
             "elapsedMs" to elapsedMs,
-            "graceMs" to graceMillis,
+            "graceMs" to backgroundGraceMillisForCycle,
+            "deadlineMs" to backgroundDeadlineAtMs,
             "backgroundCycleId" to backgroundCycleId,
         )
         scope.launch {
@@ -1150,8 +1122,76 @@ internal class BackgroundGraceController(
         }
     }
 
-    /** Test seam: true while the grace timer is counting down. */
-    internal fun isGracePendingForTest(): Boolean = graceJob?.isActive == true
+    private suspend fun dispatchGraceElapsedIfNeeded(source: String, trigger: String): Boolean {
+        if (teardownFired) return false
+        teardownFired = true
+        val now = nowMillis()
+        val elapsedMs = elapsedMs(now)
+        Log.i(GRACE_LIFECYCLE_TAG, "grace-window-deadline-elapsed")
+        DiagnosticEvents.record(
+            "app",
+            "background_grace_elapsed",
+            "deadlineElapsed" to true,
+            "elapsedMs" to elapsedMs,
+            "millis" to backgroundGraceMillisForCycle,
+            "deadlineMs" to backgroundDeadlineAtMs,
+            "backgroundCycleId" to backgroundCycleId,
+            "source" to source,
+            "trigger" to trigger,
+        )
+        ReconnectCauseTrail.record(
+            stage = "background_grace",
+            outcome = "elapsed",
+            cause = "grace_deadline",
+            trigger = trigger,
+            "elapsedMs" to elapsedMs,
+            "graceMs" to backgroundGraceMillisForCycle,
+            "deadlineMs" to backgroundDeadlineAtMs,
+            "backgroundCycleId" to backgroundCycleId,
+        )
+        onGraceElapsed()
+        return true
+    }
+
+    private fun recordForeground(resumedWithinGrace: Boolean, elapsedMs: Long) {
+        Log.i(
+            GRACE_LIFECYCLE_TAG,
+            "grace-window-foreground resumedWithinGrace=$resumedWithinGrace elapsedMs=$elapsedMs",
+        )
+        val diagnosticFields = foregroundDiagnosticFields(resumedWithinGrace)
+        DiagnosticEvents.record(
+            "app",
+            "background_grace_foreground",
+            "resumedWithinGrace" to resumedWithinGrace,
+            "withinGrace" to resumedWithinGrace,
+            "elapsedMs" to elapsedMs,
+            "millis" to backgroundGraceMillisForCycle,
+            "deadlineMs" to backgroundDeadlineAtMs,
+            "backgroundCycleId" to backgroundCycleId,
+            "source" to "process_lifecycle",
+            "trigger" to "on_start",
+            *diagnosticFields.toTypedArray(),
+        )
+        ReconnectCauseTrail.record(
+            stage = "background_grace",
+            outcome = if (resumedWithinGrace) "foreground_preserved" else "foreground_reattach_needed",
+            cause = if (resumedWithinGrace) "within_grace" else "post_grace",
+            trigger = "on_start",
+            "withinGrace" to resumedWithinGrace,
+            "elapsedMs" to elapsedMs,
+            "graceMs" to backgroundGraceMillisForCycle,
+            "deadlineMs" to backgroundDeadlineAtMs,
+            "backgroundCycleId" to backgroundCycleId,
+            *diagnosticFields.toTypedArray(),
+        )
+    }
+
+    private fun elapsedMs(now: Long = nowMillis()): Long =
+        (now - backgroundStartedAtMs).coerceAtLeast(0L)
+
+    /** Test seam: true while the current background cycle is still inside its deadline. */
+    internal fun isGracePendingForTest(): Boolean =
+        backgrounded && !teardownFired && nowMillis() < backgroundDeadlineAtMs
 }
 
 internal class SshLeaseLifecycleDispatcher(

--- a/app/src/main/java/com/pocketshell/app/App.kt
+++ b/app/src/main/java/com/pocketshell/app/App.kt
@@ -345,7 +345,18 @@ class App : Application() {
         sessionServiceController.observeActiveSessions()
         graceLifecycleScope.launch {
             sessionServiceController.notificationStopRequests().collect {
-                backgroundGraceController.onSessionHoldStoppedByNotification()
+                backgroundGraceController.onSessionHoldStopped(
+                    source = "session_notification",
+                    trigger = "stop_action",
+                )
+            }
+        }
+        graceLifecycleScope.launch {
+            sessionServiceController.sessionHoldEndedRequests().collect {
+                backgroundGraceController.onSessionHoldStopped(
+                    source = "session_service",
+                    trigger = "hold_ended",
+                )
             }
         }
         StartupTiming.mark("session-service-lifecycle-observed")
@@ -1088,6 +1099,10 @@ internal class BackgroundGraceController(
     }
 
     fun onSessionHoldStoppedByNotification() {
+        onSessionHoldStopped(source = "session_notification", trigger = "stop_action")
+    }
+
+    fun onSessionHoldStopped(source: String, trigger: String) {
         if (!backgrounded || !teardownFired || graceJob?.isActive == true) return
         if (holdStopTeardownDispatched) return
         holdStopTeardownDispatched = true
@@ -1104,14 +1119,14 @@ internal class BackgroundGraceController(
             "millis" to backgroundGraceMillisForCycle,
             "deadlineMs" to backgroundDeadlineAtMs,
             "backgroundCycleId" to backgroundCycleId,
-            "source" to "session_notification",
-            "trigger" to "stop_action",
+            "source" to source,
+            "trigger" to trigger,
         )
         ReconnectCauseTrail.record(
             stage = "background_grace",
             outcome = "session_hold_stop_teardown",
-            cause = "session_notification_stop",
-            trigger = "stop_action",
+            cause = source,
+            trigger = trigger,
             "elapsedMs" to elapsedMs,
             "graceMs" to backgroundGraceMillisForCycle,
             "deadlineMs" to backgroundDeadlineAtMs,

--- a/app/src/main/java/com/pocketshell/app/composer/PromptAttachmentStager.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptAttachmentStager.kt
@@ -10,6 +10,7 @@ import com.pocketshell.core.ssh.SshSession
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import java.io.File
 
 /**
@@ -48,11 +49,54 @@ internal class PromptAttachmentStager(
         val safeScope = safeScopeSegment(scopeKey)
         val remoteDir = "$REMOTE_DIRECTORY/$safeScope"
         val displayDir = "~/$remoteDir"
+        val timestamp = ShareUploader.formatTimestamp(now())
+
+        val preparedAttachments = mutableListOf<PreparedAttachment>()
+        var firstFailure: Throwable? = null
+        var failedCount = 0
+        uris.forEachIndexed { index, uri ->
+            try {
+                val prepared = withTimeoutOrNull(ATTACHMENT_SAF_TIMEOUT_MS) {
+                    val item = describe(uri)
+                    val sanitised = FilenameSanitiser.sanitise(
+                        item.displayName ?: uri.lastPathSegment,
+                        defaultExtension = ShareUploader.extensionForMimeType(item.mimeType),
+                    )
+                    val remoteName = composeAttachmentName(timestamp, index, sanitised)
+                    PreparedAttachment(
+                        remotePath = "$remoteDir/$remoteName",
+                        displayPath = "$displayDir/$remoteName",
+                        tempFile = drainToTempFile(uri),
+                    )
+                } ?: throw SshException("Timed out reading selected file")
+                preparedAttachments += prepared
+            } catch (cancelled: CancellationException) {
+                preparedAttachments.forEach { it.tempFile.delete() }
+                throw cancelled
+            } catch (t: Throwable) {
+                failedCount++
+                if (firstFailure == null) firstFailure = t
+            }
+        }
+
+        if (preparedAttachments.isEmpty()) {
+            val cause = firstFailure
+            return@withContext Result.failure(
+                if (cause is SshException) {
+                    cause
+                } else {
+                    SshException("Attachment upload failed: ${cause?.message}", cause)
+                },
+            )
+        }
+
         try {
             ensureRemoteDirectory(session, remoteDir)
         } catch (cancelled: CancellationException) {
+            preparedAttachments.forEach { it.tempFile.delete() }
             throw cancelled
         } catch (t: Throwable) {
+            preparedAttachments.forEach { it.tempFile.delete() }
             // The remote directory could not be created — nothing can be
             // uploaded, so this is a clean total failure.
             return@withContext Result.failure(
@@ -60,35 +104,32 @@ internal class PromptAttachmentStager(
             )
         }
 
-        val timestamp = ShareUploader.formatTimestamp(now())
         // Issue #570: upload each file independently so a single stalling /
         // failing image among N never discards the ones that DID upload (the
         // multi-image wedge/discard the maintainer hit). Successful display
         // paths are collected as they land; per-file failures are recorded
         // and aggregated after the loop.
         val uploadedPaths = mutableListOf<String>()
-        var firstFailure: Throwable? = null
-        var failedCount = 0
-        uris.forEachIndexed { index, uri ->
-            try {
-                val item = describe(uri)
-                val sanitised = FilenameSanitiser.sanitise(
-                    item.displayName ?: uri.lastPathSegment,
-                    defaultExtension = ShareUploader.extensionForMimeType(item.mimeType),
-                )
-                val remoteName = composeAttachmentName(timestamp, index, sanitised)
-                val remotePath = "$remoteDir/$remoteName"
-                uploadUri(session, uri, item.size, remotePath, remoteName)
-                uploadedPaths += "$displayDir/$remoteName"
-            } catch (cancelled: CancellationException) {
-                // A cancellation (sheet dismissed, send-while-uploading
-                // override, or the [withTimeout] in the ViewModel) must
-                // unwind the whole stage — never swallow it into a partial.
-                throw cancelled
-            } catch (t: Throwable) {
-                failedCount++
-                if (firstFailure == null) firstFailure = t
+        try {
+            preparedAttachments.forEach { prepared ->
+                try {
+                    session.uploadFile(prepared.tempFile, prepared.remotePath)
+                    uploadedPaths += prepared.displayPath
+                } catch (cancelled: CancellationException) {
+                    // A cancellation (sheet dismissed, send-while-uploading
+                    // override, or the [withTimeout] in the ViewModel) must
+                    // unwind the whole stage — never swallow it into a partial.
+                    throw cancelled
+                } catch (t: Throwable) {
+                    failedCount++
+                    if (firstFailure == null) firstFailure = t
+                } finally {
+                    prepared.tempFile.delete()
+                }
             }
+        } catch (cancelled: CancellationException) {
+            preparedAttachments.forEach { it.tempFile.delete() }
+            throw cancelled
         }
 
         // Best-effort prune runs whenever at least one upload landed — the
@@ -138,53 +179,18 @@ internal class PromptAttachmentStager(
 
     private fun describe(uri: Uri): AttachmentDescription {
         var displayName: String? = null
-        var size: Long? = null
         runCatching {
             resolver.query(uri, arrayOf(OpenableColumns.DISPLAY_NAME, OpenableColumns.SIZE), null, null, null)
                 ?.use { cursor ->
                     if (!cursor.moveToFirst()) return@use
                     val nameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
                     if (nameIndex >= 0) displayName = cursor.getString(nameIndex)
-                    val sizeIndex = cursor.getColumnIndex(OpenableColumns.SIZE)
-                    if (sizeIndex >= 0) {
-                        val queriedSize = cursor.getLong(sizeIndex)
-                        if (queriedSize > 0L) size = queriedSize
-                    }
                 }
         }
         return AttachmentDescription(
             displayName = displayName,
-            size = size,
             mimeType = resolver.getType(uri),
         )
-    }
-
-    private suspend fun uploadUri(
-        session: SshSession,
-        uri: Uri,
-        size: Long?,
-        remotePath: String,
-        remoteName: String,
-    ) {
-        val knownSize = size
-        if (knownSize != null) {
-            resolver.openInputStream(uri)?.use { input ->
-                session.uploadStream(
-                    input = input,
-                    length = knownSize,
-                    name = remoteName,
-                    remotePath = remotePath,
-                )
-            } ?: throw SshException("Could not read selected file")
-            return
-        }
-
-        val temp = drainToTempFile(uri)
-        try {
-            session.uploadFile(temp, remotePath)
-        } finally {
-            temp.delete()
-        }
     }
 
     private fun drainToTempFile(uri: Uri): File {
@@ -204,12 +210,18 @@ internal class PromptAttachmentStager(
 
     private data class AttachmentDescription(
         val displayName: String?,
-        val size: Long?,
         val mimeType: String?,
+    )
+
+    private data class PreparedAttachment(
+        val remotePath: String,
+        val displayPath: String,
+        val tempFile: File,
     )
 
     companion object {
         const val REMOTE_DIRECTORY: String = ".pocketshell/attachments"
+        const val ATTACHMENT_SAF_TIMEOUT_MS: Long = 10_000L
 
         fun safeScopeSegment(scopeKey: String): String {
             val cleaned = scopeKey.map { ch ->

--- a/app/src/main/java/com/pocketshell/app/fileexplorer/FileExplorerScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/fileexplorer/FileExplorerScreen.kt
@@ -511,7 +511,9 @@ private fun TransferBanner(
     val dismissible: Boolean
     when (transfer) {
         is FileTransferState.InProgress -> {
-            text = (if (transfer.isUpload) "Uploading " else "Downloading ") + transfer.name + "…"
+            val size = transfer.bytesTotal?.let { " (${formatSize(it)})" } ?: " (size unknown)"
+            text = (if (transfer.isUpload) "Uploading " else "Downloading ") +
+                transfer.name + size + "…"
             role = BannerRole.Info
             showSpinner = true
             dismissible = false

--- a/app/src/main/java/com/pocketshell/app/fileexplorer/FileExplorerViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/fileexplorer/FileExplorerViewModel.kt
@@ -77,7 +77,11 @@ sealed interface FileTransferState {
      * [isUpload] picks the verb shown in the banner ("Uploading…" vs
      * "Downloading…").
      */
-    data class InProgress(val name: String, val isUpload: Boolean) : FileTransferState
+    data class InProgress(
+        val name: String,
+        val isUpload: Boolean,
+        val bytesTotal: Long? = null,
+    ) : FileTransferState
 
     /** A transfer finished successfully. [message] is the user-facing summary. */
     data class Success(val message: String) : FileTransferState
@@ -257,11 +261,15 @@ class FileExplorerViewModel @Inject constructor(
         if (dir.isBlank()) return
         if (_transfer.value is FileTransferState.InProgress) return
         val safeName = sanitizeUploadName(displayName)
-        _transfer.value = FileTransferState.InProgress(name = safeName, isUpload = true)
+        _transfer.value = FileTransferState.InProgress(
+            name = safeName,
+            isUpload = true,
+            bytesTotal = length.takeIf { it > 0L },
+        )
         transferJob?.cancel()
         transferJob = viewModelScope.launch {
             val result = withContext(Dispatchers.IO) {
-                withLeaseSession(req) { live ->
+                withLeaseSession(req, leasePurpose = LEASE_PURPOSE_TRANSFER, blockTimeoutMs = null) { live ->
                     val remotePath = joinPath(dir, safeName)
                     val input = openStream()
                         ?: throw IllegalStateException("Couldn't read the selected file.")
@@ -311,11 +319,15 @@ class FileExplorerViewModel @Inject constructor(
         val dir = currentDir
         if (dir.isBlank()) return
         if (_transfer.value is FileTransferState.InProgress) return
-        _transfer.value = FileTransferState.InProgress(name = entry.name, isUpload = false)
+        _transfer.value = FileTransferState.InProgress(
+            name = entry.name,
+            isUpload = false,
+            bytesTotal = entry.sizeBytes.takeIf { it > 0L },
+        )
         transferJob?.cancel()
         transferJob = viewModelScope.launch {
             val result = withContext(Dispatchers.IO) {
-                withLeaseSession(req) { live ->
+                withLeaseSession(req, leasePurpose = LEASE_PURPOSE_TRANSFER, blockTimeoutMs = null) { live ->
                     val remotePath = joinPath(dir, entry.name)
                     val bytes = live.downloadFile(remotePath, MAX_DOWNLOAD_BYTES)
                     writeBytes(bytes)
@@ -444,11 +456,14 @@ class FileExplorerViewModel @Inject constructor(
      */
     private suspend fun <T> withLeaseSession(
         req: Request,
+        leasePurpose: String? = null,
+        blockTimeoutMs: Long? = LeaseSessionExec.BLOCK_TIMEOUT_MS,
         block: suspend (SshSession) -> T,
     ): Result<T> =
         LeaseSessionExec.withSession(
             leaseManager = sshLeaseManager,
-            target = req.toLeaseSessionTarget(),
+            target = req.toLeaseSessionTarget(leasePurpose),
+            blockTimeoutMs = blockTimeoutMs,
             block = block,
         )
 
@@ -459,7 +474,7 @@ class FileExplorerViewModel @Inject constructor(
      * warm transport those screens already opened, so the explorer's SFTP/exec
      * channel rides the existing connection instead of dialing its own.
      */
-    private fun Request.toLeaseSessionTarget(): LeaseSessionTarget =
+    private fun Request.toLeaseSessionTarget(leasePurpose: String? = null): LeaseSessionTarget =
         LeaseSessionTarget(
             hostId = hostId,
             hostname = hostname,
@@ -467,6 +482,7 @@ class FileExplorerViewModel @Inject constructor(
             username = username,
             keyPath = keyPath,
             passphrase = passphrase?.copyOf(),
+            leasePurpose = leasePurpose,
         )
 
     /**
@@ -594,6 +610,8 @@ class FileExplorerViewModel @Inject constructor(
          */
         internal fun sanitizeUploadName(displayName: String): String =
             FilenameSanitiser.sanitise(displayName).render()
+
+        internal const val LEASE_PURPOSE_TRANSFER: String = "file-transfer"
 
         /**
          * Join [name] onto a directory [base], collapsing the trailing slash.

--- a/app/src/main/java/com/pocketshell/app/fileexplorer/FileExplorerViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/fileexplorer/FileExplorerViewModel.kt
@@ -2,14 +2,12 @@ package com.pocketshell.app.fileexplorer
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.pocketshell.core.ssh.KnownHostsPolicy
+import com.pocketshell.app.sessions.LeaseSessionExec
+import com.pocketshell.app.sessions.LeaseSessionTarget
 import com.pocketshell.core.ssh.RemoteEntry
 import com.pocketshell.core.ssh.SshFileNotFoundException
 import com.pocketshell.core.ssh.SshFileTooLargeException
-import com.pocketshell.core.ssh.SshKey
-import com.pocketshell.core.ssh.SshLeaseKey
 import com.pocketshell.core.ssh.SshLeaseManager
-import com.pocketshell.core.ssh.SshLeaseTarget
 import com.pocketshell.core.ssh.SshNotADirectoryException
 import com.pocketshell.core.ssh.SshPermissionDeniedException
 import com.pocketshell.core.ssh.SshSession
@@ -20,13 +18,11 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import java.io.File
 import java.io.InputStream
 import javax.inject.Inject
 
@@ -449,47 +445,12 @@ class FileExplorerViewModel @Inject constructor(
     private suspend fun <T> withLeaseSession(
         req: Request,
         block: suspend (SshSession) -> T,
-    ): Result<T> {
-        val target = req.toSshLeaseTarget()
-        val first = runLeaseAttempt(target, block)
-        val error = first.exceptionOrNull()
-        if (error == null || !isStaleChannelSymptom(error)) {
-            return first
-        }
-        // The eviction inside runLeaseAttempt already discarded the poisoned
-        // transport, so this second acquire dials a fresh connection.
-        return runLeaseAttempt(target, block)
-    }
-
-    private suspend fun <T> runLeaseAttempt(
-        target: SshLeaseTarget,
-        block: suspend (SshSession) -> T,
-    ): Result<T> {
-        val lease = try {
-            sshLeaseManager.acquire(target)
-                .getOrElse { return Result.failure(it) }
-        } catch (e: CancellationException) {
-            throw e
-        } catch (t: Throwable) {
-            return Result.failure(t)
-        }
-        var poisonedTransport = false
-        return try {
-            Result.success(block(lease.session))
-        } catch (e: CancellationException) {
-            throw e
-        } catch (t: Throwable) {
-            poisonedTransport = isStaleChannelSymptom(t)
-            Result.failure(t)
-        } finally {
-            withContext(NonCancellable) {
-                lease.release()
-                if (poisonedTransport) {
-                    runCatching { sshLeaseManager.disconnect(target.leaseKey) }
-                }
-            }
-        }
-    }
+    ): Result<T> =
+        LeaseSessionExec.withSession(
+            leaseManager = sshLeaseManager,
+            target = req.toLeaseSessionTarget(),
+            block = block,
+        )
 
     /**
      * Build the lease target keyed IDENTICALLY to the session / folder / tmux
@@ -498,83 +459,15 @@ class FileExplorerViewModel @Inject constructor(
      * warm transport those screens already opened, so the explorer's SFTP/exec
      * channel rides the existing connection instead of dialing its own.
      */
-    private fun Request.toSshLeaseTarget(): SshLeaseTarget =
-        SshLeaseTarget(
-            leaseKey = SshLeaseKey(
-                host = hostname,
-                port = port,
-                user = username,
-                credentialId = "$hostId:$keyPath",
-                knownHostsId = "accept-all",
-            ),
-            key = SshKey.Path(File(keyPath)),
+    private fun Request.toLeaseSessionTarget(): LeaseSessionTarget =
+        LeaseSessionTarget(
+            hostId = hostId,
+            hostname = hostname,
+            port = port,
+            username = username,
+            keyPath = keyPath,
             passphrase = passphrase?.copyOf(),
-            knownHosts = KnownHostsPolicy.AcceptAll,
         )
-
-    /**
-     * Issue #697 / #680: the family of transient probe failures that must HEAL +
-     * RETRY on a fresh lease rather than surface a persistent error. Mirrors
-     * [com.pocketshell.app.projects.FolderListGateway.isStaleChannelSymptom]:
-     * a channel "open failed" against a live transport, a sshj
-     * `TransportException` / `BY_APPLICATION` teardown of a silently-dead pooled
-     * transport, or an `ensureConnected()` "SSH session is not connected" probe
-     * failure when the pooled lease's `isConnected` flipped false between acquire
-     * and the exec.
-     */
-    private fun isStaleChannelSymptom(cause: Throwable?): Boolean =
-        matchesCauseMessage(cause) { message ->
-            message.contains("open failed", ignoreCase = true) ||
-                message.contains("failed to open SSH shell", ignoreCase = true) ||
-                message.contains("SSH session is not connected", ignoreCase = true) ||
-                message.contains("transport endpoint is not connected", ignoreCase = true)
-        } || isTransportDisconnected(cause)
-
-    /**
-     * The transport-DEAD variant: the pooled SSH transport silently died, so the
-     * probe fails with a sshj `TransportException` carrying disconnect reason
-     * `BY_APPLICATION` ("Disconnected"). Matched on class simple name + reason /
-     * message text (no sshj compile-time dep), walking the cause chain.
-     */
-    private fun isTransportDisconnected(cause: Throwable?): Boolean {
-        var current: Throwable? = cause
-        val seen = HashSet<Throwable>()
-        while (current != null && seen.add(current)) {
-            if (current.javaClass.simpleName == "TransportException") {
-                val reasonName = runCatching {
-                    current!!.javaClass.getMethod("getDisconnectReason").invoke(current)?.toString()
-                }.getOrNull()
-                if (reasonName != null && reasonName.contains("BY_APPLICATION", ignoreCase = true)) {
-                    return true
-                }
-                val message = current.message
-                if (message != null &&
-                    (
-                        message.contains("BY_APPLICATION", ignoreCase = true) ||
-                            message.contains("Disconnected", ignoreCase = true)
-                        )
-                ) {
-                    return true
-                }
-            }
-            current = current.cause
-        }
-        return false
-    }
-
-    private inline fun matchesCauseMessage(
-        cause: Throwable?,
-        predicate: (String) -> Boolean,
-    ): Boolean {
-        var current: Throwable? = cause
-        val seen = HashSet<Throwable>()
-        while (current != null && seen.add(current)) {
-            val message = current.message
-            if (message != null && predicate(message)) return true
-            current = current.cause
-        }
-        return false
-    }
 
     /**
      * Shorten an absolute remote path for the success banner: collapse the

--- a/app/src/main/java/com/pocketshell/app/fileexplorer/FileExplorerViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/fileexplorer/FileExplorerViewModel.kt
@@ -327,9 +327,15 @@ class FileExplorerViewModel @Inject constructor(
         transferJob?.cancel()
         transferJob = viewModelScope.launch {
             val result = withContext(Dispatchers.IO) {
-                withLeaseSession(req, leasePurpose = LEASE_PURPOSE_TRANSFER, blockTimeoutMs = null) { live ->
+                val downloaded = withLeaseSession(
+                    req,
+                    leasePurpose = LEASE_PURPOSE_TRANSFER,
+                    blockTimeoutMs = null,
+                ) { live ->
                     val remotePath = joinPath(dir, entry.name)
-                    val bytes = live.downloadFile(remotePath, MAX_DOWNLOAD_BYTES)
+                    live.downloadFile(remotePath, MAX_DOWNLOAD_BYTES)
+                }
+                downloaded.mapCatching { bytes ->
                     writeBytes(bytes)
                     bytes.size
                 }

--- a/app/src/main/java/com/pocketshell/app/fileviewer/FileViewerScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/fileviewer/FileViewerScreen.kt
@@ -917,29 +917,34 @@ private fun HeaderAction(
  * type/extension so the receiving app accepts it.
  */
 private fun shareFile(context: Context, shareable: Shareable) {
-    val file = shareable.resolveFile(context)
-    if (file == null) {
-        Toast.makeText(context, "Nothing to share", Toast.LENGTH_SHORT).show()
-        return
+    val appContext = context.applicationContext
+    saveScope.launch {
+        val file = shareable.resolveFile(appContext)
+        withContext(Dispatchers.Main) {
+            if (file == null) {
+                Toast.makeText(appContext, "Nothing to share", Toast.LENGTH_SHORT).show()
+                return@withContext
+            }
+            val uri = runCatching {
+                FileProvider.getUriForFile(appContext, appContext.packageName + ".fileprovider", file)
+            }.getOrNull()
+            if (uri == null) {
+                Toast.makeText(appContext, "Couldn't prepare the file to share", Toast.LENGTH_SHORT).show()
+                return@withContext
+            }
+            val intent = Intent(Intent.ACTION_SEND).apply {
+                type = shareable.mimeType
+                putExtra(Intent.EXTRA_STREAM, uri)
+                putExtra(Intent.EXTRA_SUBJECT, file.name)
+                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            }
+            appContext.startActivity(
+                Intent.createChooser(intent, "Share ${file.name}").apply {
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                },
+            )
+        }
     }
-    val uri = runCatching {
-        FileProvider.getUriForFile(context, context.packageName + ".fileprovider", file)
-    }.getOrNull()
-    if (uri == null) {
-        Toast.makeText(context, "Couldn't prepare the file to share", Toast.LENGTH_SHORT).show()
-        return
-    }
-    val intent = Intent(Intent.ACTION_SEND).apply {
-        type = shareable.mimeType
-        putExtra(Intent.EXTRA_STREAM, uri)
-        putExtra(Intent.EXTRA_SUBJECT, file.name)
-        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-    }
-    context.startActivity(
-        Intent.createChooser(intent, "Share ${file.name}").apply {
-            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        },
-    )
 }
 
 /**
@@ -949,26 +954,31 @@ private fun shareFile(context: Context, shareable: Shareable) {
  * the `.fileprovider` URI.
  */
 private fun copyFileToClipboard(context: Context, shareable: Shareable) {
-    val file = shareable.resolveFile(context)
-    if (file == null) {
-        Toast.makeText(context, "Nothing to copy", Toast.LENGTH_SHORT).show()
-        return
+    val appContext = context.applicationContext
+    saveScope.launch {
+        val file = shareable.resolveFile(appContext)
+        withContext(Dispatchers.Main) {
+            if (file == null) {
+                Toast.makeText(appContext, "Nothing to copy", Toast.LENGTH_SHORT).show()
+                return@withContext
+            }
+            val uri = runCatching {
+                FileProvider.getUriForFile(appContext, appContext.packageName + ".fileprovider", file)
+            }.getOrNull()
+            if (uri == null) {
+                Toast.makeText(appContext, "Couldn't prepare the file to copy", Toast.LENGTH_SHORT).show()
+                return@withContext
+            }
+            val clipboard = appContext.getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager
+            if (clipboard == null) {
+                Toast.makeText(appContext, "Clipboard unavailable", Toast.LENGTH_SHORT).show()
+                return@withContext
+            }
+            val clip = ClipData.newUri(appContext.contentResolver, file.name, uri)
+            clipboard.setPrimaryClip(clip)
+            Toast.makeText(appContext, "Copied ${file.name} to clipboard", Toast.LENGTH_SHORT).show()
+        }
     }
-    val uri = runCatching {
-        FileProvider.getUriForFile(context, context.packageName + ".fileprovider", file)
-    }.getOrNull()
-    if (uri == null) {
-        Toast.makeText(context, "Couldn't prepare the file to copy", Toast.LENGTH_SHORT).show()
-        return
-    }
-    val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager
-    if (clipboard == null) {
-        Toast.makeText(context, "Clipboard unavailable", Toast.LENGTH_SHORT).show()
-        return
-    }
-    val clip = ClipData.newUri(context.contentResolver, file.name, uri)
-    clipboard.setPrimaryClip(clip)
-    Toast.makeText(context, "Copied ${file.name} to clipboard", Toast.LENGTH_SHORT).show()
 }
 
 /**

--- a/app/src/main/java/com/pocketshell/app/hosts/HostListViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/hosts/HostListViewModel.kt
@@ -47,6 +47,8 @@ import com.pocketshell.uikit.model.HostSetupState
 import com.pocketshell.uikit.model.HostStatus
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -59,10 +61,10 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import java.io.File
 import java.util.IdentityHashMap
 import javax.inject.Inject
@@ -1592,13 +1594,16 @@ class HostListViewModel internal constructor(
     private fun expectedPocketshellVersion(): String = currentVersionName().orEmpty()
 
     private fun closeBootstrapSession() {
-        bootstrapSession?.let { closeSession(it) }
+        val session = bootstrapSession ?: return
         bootstrapSession = null
+        closeSession(session)
     }
 
     private fun closeSession(session: SshSession) {
-        runCatching {
-            runBlocking { sessionOpener.close(session) }
+        CoroutineScope(Dispatchers.IO).launch {
+            withTimeoutOrNull(BOOTSTRAP_SESSION_CLOSE_TIMEOUT_MS) {
+                runCatching { sessionOpener.close(session) }
+            }
         }
     }
 
@@ -1723,6 +1728,7 @@ class HostListViewModel internal constructor(
     private companion object {
         /** 24-hour cache window — re-probe after this. */
         const val BOOTSTRAP_CACHE_MS: Long = 24L * 60L * 60L * 1000L
+        const val BOOTSTRAP_SESSION_CLOSE_TIMEOUT_MS: Long = 3_000L
     }
 
     private fun probeLockFor(hostId: Long): Mutex =
@@ -1824,10 +1830,12 @@ internal class LeaseBackedHostSessionOpener(
             }
             lease
         }
-        if (lease != null) {
-            lease.release()
-        } else {
-            session.close()
+        withContext(Dispatchers.IO) {
+            if (lease != null) {
+                lease.release()
+            } else {
+                session.close()
+            }
         }
     }
 }

--- a/app/src/main/java/com/pocketshell/app/projects/FolderListGateway.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListGateway.kt
@@ -381,6 +381,7 @@ data class FolderImportPayload(
     val remoteName: String,
     val length: Long?,
     val openStream: () -> InputStream?,
+    val cleanup: () -> Unit = {},
 )
 
 /**
@@ -665,9 +666,10 @@ class SshFolderListGateway internal constructor(
         host: HostEntity,
         keyPath: String,
         passphrase: CharArray?,
+        leasePurpose: String? = null,
         block: suspend (SshSession) -> T,
     ): Result<T> {
-        val leaseTarget = host.toSshLeaseTarget(keyPath, passphrase)
+        val leaseTarget = host.toSshLeaseTarget(keyPath, passphrase, leasePurpose)
         // Issue #680: a refresh probe over a pooled lease whose transport went
         // STALE between acquire and the exec (sshj's `isConnected` lies until
         // its keepalive trips, so `ensureConnected()` can throw "SSH session is
@@ -912,13 +914,14 @@ class SshFolderListGateway internal constructor(
     private fun HostEntity.toSshLeaseTarget(
         keyPath: String,
         passphrase: CharArray?,
+        leasePurpose: String? = null,
     ): SshLeaseTarget =
         SshLeaseTarget(
             leaseKey = SshLeaseKey(
                 host = hostname,
                 port = port,
                 user = username,
-                credentialId = "$id:$keyPath",
+                credentialId = buildCredentialId(id, keyPath, leasePurpose),
                 knownHostsId = "accept-all",
             ),
             key = SshKey.Path(File(keyPath)),
@@ -1492,25 +1495,34 @@ class SshFolderListGateway internal constructor(
         folderPath: String,
         payload: FolderImportPayload,
     ): Result<String> {
-        return withLeaseSession(host, keyPath, passphrase) { session ->
-            val mkdir = session.exec(pathAware("mkdir -p -- ${shellQuoteRemotePath(folderPath)}"))
-            if (mkdir.exitCode != 0) {
-                throw RuntimeException(mkdir.stderr.ifBlank { mkdir.stdout }.trim())
+        return try {
+            withLeaseSession(
+                host = host,
+                keyPath = keyPath,
+                passphrase = passphrase,
+                leasePurpose = LEASE_PURPOSE_IMPORT,
+            ) { session ->
+                val mkdir = session.exec(pathAware("mkdir -p -- ${shellQuoteRemotePath(folderPath)}"))
+                if (mkdir.exitCode != 0) {
+                    throw RuntimeException(mkdir.stderr.ifBlank { mkdir.stdout }.trim())
+                }
+                val resolvedFolderPath = resolveRemoteDirectory(session, folderPath)
+                    .getOrThrow()
+                val remotePath = childPath(resolvedFolderPath, payload.remoteName)
+                val input = payload.openStream()
+                    ?: throw RuntimeException("Couldn't read selected file.")
+                input.use { stream ->
+                    session.uploadStream(
+                        input = stream,
+                        length = payload.length ?: -1L,
+                        name = payload.remoteName,
+                        remotePath = remotePath,
+                    )
+                }
+                remotePath
             }
-            val resolvedFolderPath = resolveRemoteDirectory(session, folderPath)
-                .getOrThrow()
-            val remotePath = childPath(resolvedFolderPath, payload.remoteName)
-            val input = payload.openStream()
-                ?: throw RuntimeException("Couldn't read selected file.")
-            input.use { stream ->
-                session.uploadStream(
-                    input = stream,
-                    length = payload.length ?: -1L,
-                    name = payload.remoteName,
-                    remotePath = remotePath,
-                )
-            }
-            remotePath
+        } finally {
+            payload.cleanup()
         }
     }
 
@@ -1777,6 +1789,18 @@ class SshFolderListGateway internal constructor(
          * `ConnectError` instead of hanging.
          */
         const val PROBE_LOG_TAG: String = "PsFolderProbe"
+
+        internal const val LEASE_PURPOSE_IMPORT: String = "folder-import"
+
+        internal fun buildCredentialId(
+            hostId: Long,
+            keyPath: String,
+            leasePurpose: String?,
+        ): String {
+            val base = "$hostId:$keyPath"
+            val purpose = leasePurpose?.trim()?.takeIf { it.isNotEmpty() } ?: return base
+            return "$base|purpose=$purpose"
+        }
 
         /**
          * Issue #758 — DETERMINISTIC test injection of a poll-time stale-channel

--- a/app/src/main/java/com/pocketshell/app/projects/FolderListGateway.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListGateway.kt
@@ -7,7 +7,7 @@ import com.pocketshell.app.repos.ReposJsonParser
 import com.pocketshell.app.sessions.ActiveTmuxClients
 import com.pocketshell.app.sessions.HostTmuxSessionListParser
 import com.pocketshell.app.sessions.launchTargetCollisionMessage
-import com.pocketshell.app.sessions.remoteStartDirectoryExists
+import com.pocketshell.app.sessions.remoteStartDirectoryExistsCommand
 import com.pocketshell.app.sessions.startDirectoryMissingMessage
 import com.pocketshell.core.agents.AgentKind
 import com.pocketshell.core.portfwd.PortScanner
@@ -1197,7 +1197,7 @@ class SshFolderListGateway internal constructor(
         cwd: String,
         startCommand: String?,
     ): String {
-        if (!remoteStartDirectoryExists(session, cwd)) {
+        if (session.execBounded(remoteStartDirectoryExistsCommand(cwd)).exitCode != 0) {
             throw RuntimeException(
                 startDirectoryMissingMessage(
                     sessionName = sessionName,
@@ -1228,21 +1228,21 @@ class SshFolderListGateway internal constructor(
         // fresh list / suffix instead of silently leaking keystrokes. A plain
         // shell/no-launch create keeps its idempotent attach-or-create semantics.
         if (startCommand != null) {
-            val hasSession = session.exec(
+            val hasSession = session.execBounded(
                 pathAware("tmux has-session -t $quotedName"),
             )
             if (hasSession.exitCode == 0) {
                 throw RuntimeException(launchTargetCollisionMessage(sessionName))
             }
         }
-        val createResult = session.exec(
+        val createResult = session.execBounded(
             pathAware(cappedCreateSessionCommand(quotedName, quotedCwd)),
         )
         if (createResult.exitCode == TMUXCTL_UNSUPPORTED_EXIT_CODE) {
             // Layer 1: tmuxctl is absent OR too old to know `create-detached`.
             // Fall back to the pre-#726 raw capped-less create so the user still
             // gets a session (just without the memory cap).
-            val fallback = session.exec(
+            val fallback = session.execBounded(
                 pathAware(fallbackCreateSessionCommand(quotedName, quotedCwd)),
             )
             if (fallback.exitCode != 0 && fallback.stderr.isNotBlank()) {
@@ -1284,7 +1284,7 @@ class SshFolderListGateway internal constructor(
                 ensureAgentSubcommandAvailable(session)
             }
             val quotedCommand = shellQuote(startCommand)
-            session.exec(
+            session.execBounded(
                 pathAware("tmux send-keys -t $quotedName $quotedCommand Enter"),
             )
         }
@@ -1305,7 +1305,7 @@ class SshFolderListGateway internal constructor(
      * never blocks a healthy launch.
      */
     private suspend fun ensureAgentSubcommandAvailable(session: SshSession) {
-        val probe = session.exec(pathAware(AgentLaunchVersionCheck.AGENT_PROBE_COMMAND))
+        val probe = session.execBounded(pathAware(AgentLaunchVersionCheck.AGENT_PROBE_COMMAND))
         if (!AgentLaunchVersionCheck.isAgentSubcommandMissing(
                 stdout = probe.stdout,
                 stderr = probe.stderr,
@@ -1317,7 +1317,7 @@ class SshFolderListGateway internal constructor(
         // Outdated host: best-effort fetch of the installed version so the hint
         // can be concrete ("this host's pocketshell is 0.3.33").
         val installedVersion = runCatching {
-            val version = session.exec(pathAware(AgentLaunchVersionCheck.VERSION_PROBE_COMMAND))
+            val version = session.execBounded(pathAware(AgentLaunchVersionCheck.VERSION_PROBE_COMMAND))
             AgentLaunchVersionCheck.parseReportedVersion(
                 version.stdout.ifBlank { version.stderr },
             )

--- a/app/src/main/java/com/pocketshell/app/projects/FolderListScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListScreen.kt
@@ -463,8 +463,8 @@ fun FolderListScreen(
             suggestStartDirectories = suggestStartDirectories,
             claudeProfiles = claudeProfiles,
             codexProfiles = codexProfiles,
+            creating = (state as? FolderListUiState.Ready)?.isCreatingSession == true,
             onCreate = { choice ->
-                pickerFolder = null
                 val newName = derivedSessionName(
                     choice = choice,
                     homeDirectory = conventionalRemoteHome(username),
@@ -478,7 +478,11 @@ fun FolderListScreen(
                     // new tree node immediately (no detection round-trip).
                     chosenKind = choice.sessionAgentKind,
                     onResolved = { resolved ->
+                        pickerFolder = null
                         onSessionCreated(resolved, choice.startDirectory)
+                    },
+                    onFinished = {
+                        pickerFolder = null
                     },
                 )
             },

--- a/app/src/main/java/com/pocketshell/app/projects/FolderListScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListScreen.kt
@@ -5,6 +5,7 @@ import android.content.ContentResolver
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.provider.OpenableColumns
+import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Canvas
@@ -50,6 +51,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -100,7 +102,12 @@ import com.pocketshell.uikit.theme.PocketShellDensity
 import com.pocketshell.uikit.theme.PocketShellShapes
 import com.pocketshell.uikit.theme.PocketShellSpacing
 import com.pocketshell.uikit.theme.PocketShellType
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import java.io.File
 
 /**
  * Per-host folder list — issue #171.
@@ -245,6 +252,7 @@ fun FolderListScreen(
     }
     val assistantDictationState by assistantDictationUiState.collectAsState()
     val context = LocalContext.current
+    val importScope = rememberCoroutineScope()
     val showFlatFolderList = hostDetailViewMode == HostDetailViewMode.Flat
     var pickerFolder by remember { mutableStateOf<PickerTarget?>(null) }
     var actionFolder by remember { mutableStateOf<PickerTarget?>(null) }
@@ -307,13 +315,23 @@ fun FolderListScreen(
         val target = importFolder
         importFolder = null
         if (uri != null && target != null) {
-            viewModel.importFileIntoFolder(
-                folderPath = target.path,
-                payload = folderImportPayload(
-                    resolver = context.contentResolver,
-                    uri = uri,
-                ),
-            )
+            val appContext = context.applicationContext
+            importScope.launch {
+                val payload = runCatching {
+                    folderImportPayload(
+                        resolver = appContext.contentResolver,
+                        uri = uri,
+                        cacheDir = appContext.cacheDir,
+                    )
+                }.getOrElse {
+                    Toast.makeText(appContext, "Couldn't read selected file", Toast.LENGTH_SHORT).show()
+                    return@launch
+                }
+                viewModel.importFileIntoFolder(
+                    folderPath = target.path,
+                    payload = payload,
+                )
+            }
         }
     }
 
@@ -614,20 +632,28 @@ private data class PickerTarget(
 
 private enum class AssistantDictationTarget { Prompt, Correction }
 
-private fun folderImportPayload(resolver: ContentResolver, uri: Uri): FolderImportPayload {
-    val displayName = ShareUploader.queryUriDisplayName(resolver, uri)
-        ?: uri.lastPathSegment
-        ?: "imported"
-    val mime = resolver.getType(uri)
-    val sanitised = FilenameSanitiser.sanitise(
-        input = displayName,
-        defaultExtension = ShareUploader.extensionForMimeType(mime),
-    )
-    return FolderImportPayload(
-        remoteName = sanitised.render(),
-        length = queryUriSize(resolver, uri),
-        openStream = { resolver.openInputStream(uri) },
-    )
+private suspend fun folderImportPayload(
+    resolver: ContentResolver,
+    uri: Uri,
+    cacheDir: File,
+): FolderImportPayload = withContext(Dispatchers.IO) {
+    withTimeoutOrNull(FOLDER_IMPORT_SAF_TIMEOUT_MS) {
+        val displayName = ShareUploader.queryUriDisplayName(resolver, uri)
+            ?: uri.lastPathSegment
+            ?: "imported"
+        val mime = resolver.getType(uri)
+        val sanitised = FilenameSanitiser.sanitise(
+            input = displayName,
+            defaultExtension = ShareUploader.extensionForMimeType(mime),
+        )
+        val temp = copyImportUriToTempFile(resolver, uri, cacheDir)
+        FolderImportPayload(
+            remoteName = sanitised.render(),
+            length = temp.length().takeIf { it > 0L } ?: queryUriSize(resolver, uri),
+            openStream = { temp.inputStream() },
+            cleanup = { temp.delete() },
+        )
+    } ?: throw IllegalStateException("Timed out reading selected file.")
 }
 
 private fun queryUriSize(resolver: ContentResolver, uri: Uri): Long? = try {
@@ -640,6 +666,27 @@ private fun queryUriSize(resolver: ContentResolver, uri: Uri): Long? = try {
 } catch (_: Throwable) {
     null
 }
+
+private fun copyImportUriToTempFile(
+    resolver: ContentResolver,
+    uri: Uri,
+    cacheDir: File,
+): File {
+    val dir = File(cacheDir, "folder-imports").also { it.mkdirs() }
+    val temp = File.createTempFile("folder-import-", ".bin", dir)
+    try {
+        resolver.openInputStream(uri).use { input ->
+            if (input == null) throw IllegalStateException("Couldn't read selected file.")
+            temp.outputStream().use { output -> input.copyTo(output) }
+        }
+        return temp
+    } catch (t: Throwable) {
+        temp.delete()
+        throw t
+    }
+}
+
+private const val FOLDER_IMPORT_SAF_TIMEOUT_MS: Long = 10_000L
 
 /**
  * Derive a tmux session name from the user's picker choice — issue #429.

--- a/app/src/main/java/com/pocketshell/app/projects/FolderListViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListViewModel.kt
@@ -2819,7 +2819,7 @@ class FolderListViewModel internal constructor(
 
     private fun releaseWarmLeaseAsync() {
         val lease = takeWarmLeaseForRelease() ?: return
-        CoroutineScope(Dispatchers.IO).launch {
+        CoroutineScope(ioDispatcher).launch {
             releaseWarmLeaseBounded(lease)
         }
     }
@@ -2832,7 +2832,15 @@ class FolderListViewModel internal constructor(
     }
 
     private suspend fun releaseWarmLeaseBounded(lease: SshLease) {
-        withContext(NonCancellable + Dispatchers.IO) {
+        // Run the bounded release off the Main thread (in production [ioDispatcher]
+        // is `Dispatchers.IO`) so a wedged half-open transport `close()` socket
+        // write can never block the caller; the lease manager's own release does
+        // the wedge-free refcount bookkeeping NonCancellably and only the bounded
+        // transport close runs here. Use the injectable [ioDispatcher] — NOT a
+        // hardcoded `Dispatchers.IO` — so a `runTest` virtual clock drives the
+        // release-into-idle-TTL deterministically, matching every other IO hop in
+        // this view model.
+        withContext(NonCancellable + ioDispatcher) {
             withTimeoutOrNull(WARM_LEASE_RELEASE_TIMEOUT_MS) {
                 lease.release()
             }

--- a/app/src/main/java/com/pocketshell/app/projects/FolderListViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListViewModel.kt
@@ -41,6 +41,7 @@ import com.pocketshell.uikit.model.SessionAgentKind
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -61,7 +62,6 @@ import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import java.io.File
@@ -2757,9 +2757,7 @@ class FolderListViewModel internal constructor(
         emitJob = null
         warmJob?.cancel()
         warmReleaseJob?.cancel()
-        runBlocking {
-            releaseWarmLease()
-        }
+        releaseWarmLeaseAsync()
         watchedFoldersJob?.cancel()
         lifecycleObserver?.let { observer ->
             // `removeObserver` is main-thread-affine; `onCleared` runs on
@@ -2823,11 +2821,29 @@ class FolderListViewModel internal constructor(
     }
 
     private suspend fun releaseWarmLease() {
-        withContext(NonCancellable) {
-            val lease = warmLease ?: return@withContext
-            warmLease = null
-            warmSessionReady.value = false
-            lease.release()
+        val lease = takeWarmLeaseForRelease() ?: return
+        releaseWarmLeaseBounded(lease)
+    }
+
+    private fun releaseWarmLeaseAsync() {
+        val lease = takeWarmLeaseForRelease() ?: return
+        CoroutineScope(Dispatchers.IO).launch {
+            releaseWarmLeaseBounded(lease)
+        }
+    }
+
+    private fun takeWarmLeaseForRelease(): SshLease? {
+        val lease = warmLease ?: return null
+        warmLease = null
+        warmSessionReady.value = false
+        return lease
+    }
+
+    private suspend fun releaseWarmLeaseBounded(lease: SshLease) {
+        withContext(NonCancellable + Dispatchers.IO) {
+            withTimeoutOrNull(WARM_LEASE_RELEASE_TIMEOUT_MS) {
+                lease.release()
+            }
         }
     }
 
@@ -2885,6 +2901,7 @@ class FolderListViewModel internal constructor(
         // on a stale foreground/resume ([HostTreeModel.RECONCILE_STALENESS_MS])
         // and on the explicit pull-to-refresh swipe — never on a tight loop.
         const val WARM_RELEASE_DELAY_MS: Long = 10_000L
+        const val WARM_LEASE_RELEASE_TIMEOUT_MS: Long = 3_000L
 
         /**
          * Epic #821 slice C (issue #837): bound on how long the cold-start

--- a/app/src/main/java/com/pocketshell/app/projects/FolderListViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListViewModel.kt
@@ -269,13 +269,6 @@ class FolderReconcileTimeoutException(
     "Session list didn't load within ${timeoutMs}ms. Tap to retry.",
 )
 
-private class CreateSessionActionTimeoutException(
-    timeoutMs: Long,
-) : RuntimeException(
-    "creating the session took longer than ${timeoutMs / 1_000}s. " +
-        "Check whether it appeared on the host, then try again.",
-)
-
 /**
  * Active/idle split of the flat host-detail session list (#489).
  *
@@ -1319,11 +1312,10 @@ class FolderListViewModel internal constructor(
         setCreateSessionInFlight(true)
         viewModelScope.launch {
             try {
-                val result = withTimeoutOrNull(CREATE_SESSION_ACTION_TIMEOUT_MS) {
-                    val host = withContext(ioDispatcher) { hostDao.getById(params.hostId) }
-                        ?: return@withTimeoutOrNull Result.failure<String>(
-                            IllegalStateException("Host not found."),
-                        )
+                val host = withContext(ioDispatcher) { hostDao.getById(params.hostId) }
+                val result = if (host == null) {
+                    Result.failure<String>(IllegalStateException("Host not found."))
+                } else {
                     gateway.createSession(
                         host = host,
                         keyPath = params.keyPath,
@@ -1332,7 +1324,7 @@ class FolderListViewModel internal constructor(
                         cwd = cwd,
                         startCommand = startCommand,
                     )
-                } ?: Result.failure(CreateSessionActionTimeoutException(CREATE_SESSION_ACTION_TIMEOUT_MS))
+                }
                 result.fold(
                     onSuccess = { resolvedName ->
                         // EPIC #679 (#678 create side): the app KNOWS it just created
@@ -2941,14 +2933,6 @@ class FolderListViewModel internal constructor(
          * an indefinite `Loading`.
          */
         const val RECONCILE_TIMEOUT_MS: Long = 12_000L
-
-        /**
-         * User-facing ceiling for the complete create-session action. The
-         * gateway also bounds individual exec reads, but create can perform
-         * several sequential probes/commands; this keeps the sheet in an
-         * explicit busy state for a finite window instead of feeling frozen.
-         */
-        const val CREATE_SESSION_ACTION_TIMEOUT_MS: Long = 12_000L
 
         /**
          * Issue #711: the COMPACT, calm, human one-liner shown when the folder

--- a/app/src/main/java/com/pocketshell/app/projects/FolderListViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListViewModel.kt
@@ -215,6 +215,7 @@ sealed interface FolderListUiState {
         val flatSessions: List<FolderSessionEntry>,
         val expandedProjectPaths: Set<String>,
         val isRefreshing: Boolean = false,
+        val isCreatingSession: Boolean = false,
         val portForwarding: HostPortForwardingSummary = HostPortForwardingSummary(),
     ) : FolderListUiState
 
@@ -266,6 +267,13 @@ class FolderReconcileTimeoutException(
     timeoutMs: Long,
 ) : RuntimeException(
     "Session list didn't load within ${timeoutMs}ms. Tap to retry.",
+)
+
+private class CreateSessionActionTimeoutException(
+    timeoutMs: Long,
+) : RuntimeException(
+    "creating the session took longer than ${timeoutMs / 1_000}s. " +
+        "Check whether it appeared on the host, then try again.",
 )
 
 /**
@@ -880,6 +888,7 @@ class FolderListViewModel internal constructor(
     private var lastDiscoveredPorts: List<HostDiscoveredPort> = emptyList()
     private var forwardingSnapshots: Map<Long, ForwardingHostSnapshot> = emptyMap()
     private var sessionRefreshInFlight: Boolean = false
+    private var createSessionInFlight: Boolean = false
     private var refreshSessionsRequested: Boolean = false
 
     /**
@@ -1303,62 +1312,72 @@ class FolderListViewModel internal constructor(
         startCommand: String?,
         chosenKind: SessionAgentKind? = null,
         onResolved: (sessionName: String) -> Unit,
+        onFinished: () -> Unit = {},
     ) {
         val params = bound ?: return
+        if (createSessionInFlight) return
+        setCreateSessionInFlight(true)
         viewModelScope.launch {
-            val host = withContext(ioDispatcher) { hostDao.getById(params.hostId) } ?: run {
-                _state.value = FolderListUiState.Failed("Host not found.")
-                return@launch
+            try {
+                val result = withTimeoutOrNull(CREATE_SESSION_ACTION_TIMEOUT_MS) {
+                    val host = withContext(ioDispatcher) { hostDao.getById(params.hostId) }
+                        ?: return@withTimeoutOrNull Result.failure<String>(
+                            IllegalStateException("Host not found."),
+                        )
+                    gateway.createSession(
+                        host = host,
+                        keyPath = params.keyPath,
+                        passphrase = params.passphrase,
+                        sessionName = sessionName,
+                        cwd = cwd,
+                        startCommand = startCommand,
+                    )
+                } ?: Result.failure(CreateSessionActionTimeoutException(CREATE_SESSION_ACTION_TIMEOUT_MS))
+                result.fold(
+                    onSuccess = { resolvedName ->
+                        // EPIC #679 (#678 create side): the app KNOWS it just created
+                        // this session, so insert it into the maintained tree by id
+                        // immediately — optimistically — instead of waiting for the
+                        // next reconcile to discover it ("created session/window
+                        // slow-to-appear"). The node carries an optimistic grace so
+                        // the reconcile that follows does not prune it before the
+                        // probe has observed it; that same reconcile then confirms it
+                        // and clears the grace.
+                        //
+                        // EPIC #821 Workstream A: the app already KNOWS the kind it
+                        // just launched (the picker chose it, and the wrapper has
+                        // recorded it host-side as `@ps_agent_kind`). Stamp that
+                        // chosen kind onto the optimistic node instead of `Probing`
+                        // so the tree shows the real kind from the moment of
+                        // creation — no detection round-trip, no flicker through
+                        // Probing. The sticky `mergeAgentKind` guard keeps this
+                        // recorded kind across the reconcile that follows (which
+                        // also re-reads it from the host option). A shell session
+                        // (`chosenKind == null`) keeps the optimistic `Probing`
+                        // placeholder until the reconcile confirms it as `Shell`.
+                        tree.insertSession(
+                            entry = FolderSessionEntry(
+                                sessionName = resolvedName,
+                                lastActivity = System.currentTimeMillis(),
+                                attached = false,
+                                agentKind = chosenKind ?: SessionAgentKind.Probing,
+                            ),
+                            folderPath = cwd,
+                        )
+                        emitReady()
+                        onResolved(resolvedName)
+                        refresh()
+                    },
+                    onFailure = { error ->
+                        _state.value = FolderListUiState.Failed(
+                            "Couldn't create session: ${error.message ?: error.javaClass.simpleName}",
+                        )
+                    },
+                )
+            } finally {
+                setCreateSessionInFlight(false)
+                onFinished()
             }
-            val result = gateway.createSession(
-                host = host,
-                keyPath = params.keyPath,
-                passphrase = params.passphrase,
-                sessionName = sessionName,
-                cwd = cwd,
-                startCommand = startCommand,
-            )
-            result.fold(
-                onSuccess = { resolvedName ->
-                    // EPIC #679 (#678 create side): the app KNOWS it just created
-                    // this session, so insert it into the maintained tree by id
-                    // immediately — optimistically — instead of waiting for the
-                    // next reconcile to discover it ("created session/window
-                    // slow-to-appear"). The node carries an optimistic grace so
-                    // the reconcile that follows does not prune it before the
-                    // probe has observed it; that same reconcile then confirms it
-                    // and clears the grace.
-                    //
-                    // EPIC #821 Workstream A: the app already KNOWS the kind it
-                    // just launched (the picker chose it, and the wrapper has
-                    // recorded it host-side as `@ps_agent_kind`). Stamp that
-                    // chosen kind onto the optimistic node instead of `Probing`
-                    // so the tree shows the real kind from the moment of
-                    // creation — no detection round-trip, no flicker through
-                    // Probing. The sticky `mergeAgentKind` guard keeps this
-                    // recorded kind across the reconcile that follows (which
-                    // also re-reads it from the host option). A shell session
-                    // (`chosenKind == null`) keeps the optimistic `Probing`
-                    // placeholder until the reconcile confirms it as `Shell`.
-                    tree.insertSession(
-                        entry = FolderSessionEntry(
-                            sessionName = resolvedName,
-                            lastActivity = System.currentTimeMillis(),
-                            attached = false,
-                            agentKind = chosenKind ?: SessionAgentKind.Probing,
-                        ),
-                        folderPath = cwd,
-                    )
-                    emitReady()
-                    onResolved(resolvedName)
-                    refresh()
-                },
-                onFailure = { error ->
-                    _state.value = FolderListUiState.Failed(
-                        "Couldn't create session: ${error.message ?: error.javaClass.simpleName}",
-                    )
-                },
-            )
         }
     }
 
@@ -2681,9 +2700,16 @@ class FolderListViewModel internal constructor(
                 flatSessions = projection.flatSessions,
                 expandedProjectPaths = projection.expandedProjectPaths,
                 isRefreshing = refreshing,
+                isCreatingSession = createSessionInFlight,
                 portForwarding = forwardingSummary(),
             )
         }
+    }
+
+    private fun setCreateSessionInFlight(inFlight: Boolean) {
+        createSessionInFlight = inFlight
+        val ready = _state.value as? FolderListUiState.Ready ?: return
+        _state.value = ready.copy(isCreatingSession = inFlight)
     }
 
     private fun loadingState(): FolderListUiState.Loading {
@@ -2898,6 +2924,14 @@ class FolderListViewModel internal constructor(
          * an indefinite `Loading`.
          */
         const val RECONCILE_TIMEOUT_MS: Long = 12_000L
+
+        /**
+         * User-facing ceiling for the complete create-session action. The
+         * gateway also bounds individual exec reads, but create can perform
+         * several sequential probes/commands; this keeps the sheet in an
+         * explicit busy state for a finite window instead of feeling frozen.
+         */
+        const val CREATE_SESSION_ACTION_TIMEOUT_MS: Long = 12_000L
 
         /**
          * Issue #711: the COMPACT, calm, human one-liner shown when the folder

--- a/app/src/main/java/com/pocketshell/app/projects/SessionTypePickerSheet.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/SessionTypePickerSheet.kt
@@ -86,9 +86,7 @@ fun SessionTypePickerSheet(
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val autocompleteController = rememberStartDirectoryAutocompleteController(suggestStartDirectories)
     ModalBottomSheet(
-        onDismissRequest = {
-            if (!creating) onDismiss()
-        },
+        onDismissRequest = onDismiss,
         sheetState = sheetState,
         containerColor = PocketShellColors.Surface,
         modifier = Modifier.testTag(SESSION_TYPE_PICKER_SHEET_TAG),
@@ -294,7 +292,6 @@ internal fun SessionTypePickerContent(
                 text = "Cancel",
                 onClick = onCancel,
                 variant = ButtonVariant.Text,
-                enabled = !creating,
                 modifier = Modifier.testTag(SESSION_TYPE_PICKER_CANCEL_TAG),
             )
             Spacer(modifier = Modifier.padding(end = 8.dp))

--- a/app/src/main/java/com/pocketshell/app/projects/SessionTypePickerSheet.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/SessionTypePickerSheet.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Checkbox
@@ -36,10 +37,12 @@ import com.pocketshell.app.sessions.rememberStartDirectoryAutocompleteController
 import com.pocketshell.core.ssh.shellSingleQuote
 import com.pocketshell.uikit.components.ButtonVariant
 import com.pocketshell.uikit.components.ListRow
+import com.pocketshell.uikit.components.LoadingIndicator
 import com.pocketshell.uikit.components.PocketShellButton
 import com.pocketshell.uikit.components.SectionHeader
 import com.pocketshell.uikit.components.SegmentedToggle
 import com.pocketshell.uikit.components.SheetHeader
+import com.pocketshell.uikit.components.SpinnerSize
 import com.pocketshell.uikit.model.SessionAgentKind
 import com.pocketshell.uikit.theme.PocketShellColors
 import com.pocketshell.uikit.theme.PocketShellSpacing
@@ -72,6 +75,7 @@ fun SessionTypePickerSheet(
     suggestStartDirectories: (suspend (String) -> List<String>)? = null,
     claudeProfiles: List<ClaudeProfile> = emptyList(),
     codexProfiles: List<CodexProfile> = emptyList(),
+    creating: Boolean = false,
     // Issue #678: the same picker also drives the in-session `+ window` flow,
     // which creates a new WINDOW rather than a new session. The only visible
     // difference is the heading, so the title is parameterised; everything else
@@ -82,7 +86,9 @@ fun SessionTypePickerSheet(
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val autocompleteController = rememberStartDirectoryAutocompleteController(suggestStartDirectories)
     ModalBottomSheet(
-        onDismissRequest = onDismiss,
+        onDismissRequest = {
+            if (!creating) onDismiss()
+        },
         sheetState = sheetState,
         containerColor = PocketShellColors.Surface,
         modifier = Modifier.testTag(SESSION_TYPE_PICKER_SHEET_TAG),
@@ -95,6 +101,7 @@ fun SessionTypePickerSheet(
             autocompleteController = autocompleteController,
             claudeProfiles = claudeProfiles,
             codexProfiles = codexProfiles,
+            creating = creating,
             title = title,
         )
     }
@@ -114,6 +121,7 @@ internal fun SessionTypePickerContent(
     autocompleteController: StartDirectoryAutocompleteController? = null,
     claudeProfiles: List<ClaudeProfile> = emptyList(),
     codexProfiles: List<CodexProfile> = emptyList(),
+    creating: Boolean = false,
     title: String = "New session",
 ) {
     var sessionType by remember { mutableStateOf(SessionType.Agent) }
@@ -286,35 +294,51 @@ internal fun SessionTypePickerContent(
                 text = "Cancel",
                 onClick = onCancel,
                 variant = ButtonVariant.Text,
+                enabled = !creating,
                 modifier = Modifier.testTag(SESSION_TYPE_PICKER_CANCEL_TAG),
             )
             Spacer(modifier = Modifier.padding(end = 8.dp))
             PocketShellButton(
-                text = "Create",
                 onClick = {
-                    onCreate(
-                        SessionTypeChoice(
-                            type = sessionType,
-                            agent = if (sessionType == SessionType.Agent) agentKind else null,
-                            startDirectory = startDirectory.trim().ifBlank { folderPath },
-                            skipPermissions = skipPermissions,
-                            claudeProfileName = if (sessionType == SessionType.Agent && agentKind == AgentCli.Claude) {
-                                claudeProfile
-                            } else {
-                                null
-                            },
-                            codexProfileName = if (sessionType == SessionType.Agent && agentKind == AgentCli.Codex) {
-                                codexProfile
-                            } else {
-                                null
-                            },
-                        ),
-                    )
+                    if (!creating) {
+                        onCreate(
+                            SessionTypeChoice(
+                                type = sessionType,
+                                agent = if (sessionType == SessionType.Agent) agentKind else null,
+                                startDirectory = startDirectory.trim().ifBlank { folderPath },
+                                skipPermissions = skipPermissions,
+                                claudeProfileName = if (
+                                    sessionType == SessionType.Agent &&
+                                    agentKind == AgentCli.Claude
+                                ) {
+                                    claudeProfile
+                                } else {
+                                    null
+                                },
+                                codexProfileName = if (
+                                    sessionType == SessionType.Agent &&
+                                    agentKind == AgentCli.Codex
+                                ) {
+                                    codexProfile
+                                } else {
+                                    null
+                                },
+                            ),
+                        )
+                    }
                 },
                 variant = ButtonVariant.Primary,
-                enabled = startDirectory.isNotBlank(),
+                enabled = startDirectory.isNotBlank() && !creating,
                 modifier = Modifier.testTag(SESSION_TYPE_PICKER_CREATE_TAG),
-            )
+            ) {
+                if (creating) {
+                    LoadingIndicator.Spinner(size = SpinnerSize.Small, onAccent = true)
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text("Creating", fontWeight = FontWeight.SemiBold)
+                } else {
+                    Text("Create", fontWeight = FontWeight.SemiBold)
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/pocketshell/app/session/AgentConversationRepository.kt
+++ b/app/src/main/java/com/pocketshell/app/session/AgentConversationRepository.kt
@@ -866,6 +866,7 @@ public class AgentConversationRepository internal constructor(
         val kindSentinel = "@@PS_RECORDED_KIND@@"
         val sourceGenerationSentinel = "@@PS_RECORDED_SOURCE_GENERATION@@"
         val sourceSentinel = "@@PS_RECORDED_SOURCE@@"
+        val sourceGenerationSeparator = "\t"
         // The Claude window-fold tail budget mirrors [readEventsWindow]: raw
         // lines = messages * JSONL_RAW_LINES_PER_EVENT, floored at the message
         // count and at 1.
@@ -903,6 +904,29 @@ public class AgentConversationRepository internal constructor(
             append("\n")
             append("printf '%s\\n' $sourceSentinel")
             append("\n")
+            // Parse the raw tmux option into the exact path the host watcher
+            // recorded. New host CLIs write "<generation><tab><path>"; older
+            // hosts wrote just "<path>". Keep this shell-side parse in lockstep
+            // with [recordedAgentSourceOptionFromRaw] so the folded Claude
+            // window reads the exact recorded file instead of falling back to
+            // the newest same-cwd sibling.
+            append(
+                "ps_recorded_source_path=; " +
+                    "if [ -n \"\$ps_recorded_source_generation\" ]; then " +
+                    "ps_recorded_source_prefix=\"\$ps_recorded_source_generation$sourceGenerationSeparator\"; " +
+                    "case \"\$ps_recorded_source\" in " +
+                    "\"\$ps_recorded_source_prefix\"*) " +
+                    "ps_recorded_source_path=\${ps_recorded_source#\"\$ps_recorded_source_prefix\"};; " +
+                    "esac; " +
+                    "else " +
+                    "case \"\$ps_recorded_source\" in " +
+                    "*\"$sourceGenerationSeparator\"*) " +
+                    "ps_recorded_source_path=\${ps_recorded_source#*$sourceGenerationSeparator};; " +
+                    "*) ps_recorded_source_path=\$ps_recorded_source;; " +
+                    "esac; " +
+                    "fi",
+            )
+            append("\n")
             // 2. The SAME candidate enumeration the split path runs.
             append(detectionCommand(normalizedCwd))
             append("\n")
@@ -920,8 +944,8 @@ public class AgentConversationRepository internal constructor(
             append("\n")
             append(
                     "claude_proj=\"\$HOME/.claude/projects/$encodedClaudeCwd\"; " +
-                    "if [ -n \"\$ps_recorded_source\" ] && [ -f \"\$ps_recorded_source\" ]; then " +
-                    "newest=\"\$ps_recorded_source\"; " +
+                    "if [ -n \"\$ps_recorded_source_path\" ] && [ -f \"\$ps_recorded_source_path\" ]; then " +
+                    "newest=\"\$ps_recorded_source_path\"; " +
                     "else " +
                     "newest=\$(" +
                     "find \"\$claude_proj\" -maxdepth 1 -type f -name '*.jsonl' -mmin -120 -print 2>/dev/null | " +

--- a/app/src/main/java/com/pocketshell/app/sessions/HostTmuxSessionPickerViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/sessions/HostTmuxSessionPickerViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
 
 @HiltViewModel
@@ -36,7 +37,15 @@ class HostTmuxSessionPickerViewModel @Inject constructor(
         loadJob?.cancel()
         _state.value = HostTmuxSessionPickerState.Loading(request)
         loadJob = viewModelScope.launch {
-            _state.value = when (val result = gateway.listSessions(request.host, request.keyPath, request.passphrase)) {
+            val result = withTimeoutOrNull(LOAD_TIMEOUT_MS) {
+                gateway.listSessions(request.host, request.keyPath, request.passphrase)
+            }
+            _state.value = if (result == null) {
+                HostTmuxSessionPickerState.Fallback(
+                    request = request,
+                    message = "Timed out while loading tmux sessions. Please retry.",
+                )
+            } else when (result) {
                 is HostTmuxSessionListResult.Sessions -> HostTmuxSessionPickerState.Ready(
                     request = request,
                     rows = result.rows.sortedWith(
@@ -184,5 +193,14 @@ class HostTmuxSessionPickerViewModel @Inject constructor(
     ) {
         val hasSiblingsToSwitch: Boolean
             get() = siblings.any { it.name != currentSessionName }
+    }
+
+    internal companion object {
+        /**
+         * Last-resort UI ceiling: gateway paths have their own tighter bounds,
+         * but the picker must still leave Loading if a future implementation
+         * accidentally parks forever.
+         */
+        const val LOAD_TIMEOUT_MS: Long = 12_000L
     }
 }

--- a/app/src/main/java/com/pocketshell/app/sessions/HostTmuxSessionsGateway.kt
+++ b/app/src/main/java/com/pocketshell/app/sessions/HostTmuxSessionsGateway.kt
@@ -1,18 +1,13 @@
 package com.pocketshell.app.sessions
 
+import android.util.Log
 import com.pocketshell.app.repos.ReposRemoteSource
-import com.pocketshell.core.ssh.KnownHostsPolicy
 import com.pocketshell.core.ssh.DefaultSshLeaseConnector
-import com.pocketshell.core.ssh.SshKey
 import com.pocketshell.core.ssh.SshLeaseConnector
-import com.pocketshell.core.ssh.SshLeaseKey
 import com.pocketshell.core.ssh.SshLeaseManager
-import com.pocketshell.core.ssh.SshLeaseTarget
 import com.pocketshell.core.storage.entity.HostEntity
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.NonCancellable
-import kotlinx.coroutines.withContext
-import java.io.File
+import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
 
 interface HostTmuxSessionsGateway {
@@ -36,15 +31,37 @@ interface HostTmuxSessionsGateway {
     ): HostTmuxSessionListResult?
 }
 
-class SshHostTmuxSessionsGateway @Inject constructor(
+class SshHostTmuxSessionsGateway internal constructor(
     private val parser: HostTmuxSessionListParser,
     private val activeTmuxClients: ActiveTmuxClients,
-    private val sshLeaseManager: SshLeaseManager = SshLeaseManager(
-        connector = SshLeaseConnector { target ->
-            DefaultSshLeaseConnector().connect(target)
-        },
-    ),
+    private val sshLeaseManager: SshLeaseManager,
+    private val leaseBlockTimeoutMs: Long,
+    private val liveEnumTimeoutMs: Long,
 ) : HostTmuxSessionsGateway {
+    constructor(
+        parser: HostTmuxSessionListParser,
+        activeTmuxClients: ActiveTmuxClients,
+    ) : this(
+        parser = parser,
+        activeTmuxClients = activeTmuxClients,
+        sshLeaseManager = defaultLeaseManager(),
+        leaseBlockTimeoutMs = LEASE_BLOCK_TIMEOUT_MS,
+        liveEnumTimeoutMs = LIVE_ENUM_TIMEOUT_MS,
+    )
+
+    @Inject
+    constructor(
+        parser: HostTmuxSessionListParser,
+        activeTmuxClients: ActiveTmuxClients,
+        sshLeaseManager: SshLeaseManager,
+    ) : this(
+        parser = parser,
+        activeTmuxClients = activeTmuxClients,
+        sshLeaseManager = sshLeaseManager,
+        leaseBlockTimeoutMs = LEASE_BLOCK_TIMEOUT_MS,
+        liveEnumTimeoutMs = LIVE_ENUM_TIMEOUT_MS,
+    )
+
     override suspend fun listSessions(
         host: HostEntity,
         keyPath: String,
@@ -58,29 +75,16 @@ class SshHostTmuxSessionsGateway @Inject constructor(
             port = host.port,
             user = host.username,
         )
-        val lease = try {
-            sshLeaseManager.acquire(host.toSshLeaseTarget(keyPath, passphrase)).getOrElse { error ->
-                // Issue #109: surface the throwable up to the view-model so
-                // the user-facing summary path (HostConnectError) can run.
-                // Concatenating `error.message` into the sheet body was what
-                // produced the raw "ECONNREFUSED" stack trace.
-                return HostTmuxSessionListResult.ConnectFailed(error)
-            }
-        } catch (e: CancellationException) {
-            throw e
-        } catch (t: Throwable) {
-            // Issue #109: surface the throwable up to the view-model so
-            // the user-facing summary path (HostConnectError) can run.
-            // Concatenating `error.message` into the sheet body was what
-            // produced the raw "ECONNREFUSED" stack trace.
-            return HostTmuxSessionListResult.ConnectFailed(t)
-        }
-
-        return try {
-            val session = lease.session
+        return LeaseSessionExec.withSession(
+            leaseManager = sshLeaseManager,
+            target = host.toLeaseSessionTarget(keyPath, passphrase),
+            blockTimeoutMs = leaseBlockTimeoutMs,
+        ) { session ->
             val pocketshell = session.exec(pathAware("pocketshell sessions list --by activity"))
             if (pocketshell.exitCode == 0) {
-                return HostTmuxSessionListResult.Sessions(parser.parsePocketshellSessionsList(pocketshell.stdout))
+                return@withSession HostTmuxSessionListResult.Sessions(
+                    parser.parsePocketshellSessionsList(pocketshell.stdout),
+                )
             }
 
             val tmux = session.exec(
@@ -103,32 +107,23 @@ class SshHostTmuxSessionsGateway @Inject constructor(
                     tmux.stderr.ifBlank { tmux.stdout }.ifBlank { "tmux exited ${tmux.exitCode}" },
                 )
             }
-        } catch (e: CancellationException) {
-            throw e
-        } catch (t: Throwable) {
-            HostTmuxSessionListResult.Failed("${t.javaClass.simpleName}: ${t.message ?: "unknown error"}")
-        } finally {
-            withContext(NonCancellable) {
-                lease.release()
-            }
-        }
+        }.fold(
+            onSuccess = { it },
+            onFailure = { error -> HostTmuxSessionListResult.ConnectFailed(error) },
+        )
     }
 
-    private fun HostEntity.toSshLeaseTarget(
+    private fun HostEntity.toLeaseSessionTarget(
         keyPath: String,
         passphrase: CharArray?,
-    ): SshLeaseTarget =
-        SshLeaseTarget(
-            leaseKey = SshLeaseKey(
-                host = hostname,
-                port = port,
-                user = username,
-                credentialId = "$id:$keyPath",
-                knownHostsId = "accept-all",
-            ),
-            key = SshKey.Path(File(keyPath)),
-            passphrase = passphrase?.copyOf(),
-            knownHosts = KnownHostsPolicy.AcceptAll,
+    ): LeaseSessionTarget =
+        LeaseSessionTarget(
+            hostId = id,
+            hostname = hostname,
+            port = port,
+            username = username,
+            keyPath = keyPath,
+            passphrase = passphrase,
         )
 
     private fun pathAware(command: String): String =
@@ -143,7 +138,16 @@ class SshHostTmuxSessionsGateway @Inject constructor(
             ?.takeUnless { it.client.disconnected.value }
             ?: return null
         return try {
-            val response = entry.client.sendCommand(LIVE_LIST_SESSIONS_COMMAND)
+            val response = withTimeoutOrNull(liveEnumTimeoutMs) {
+                entry.client.sendCommand(LIVE_LIST_SESSIONS_COMMAND)
+            } ?: run {
+                Log.w(
+                    LOG_TAG,
+                    "live -CC session picker enumeration wedged >${liveEnumTimeoutMs}ms; " +
+                        "falling through to bounded SSH-lease enumeration.",
+                )
+                return null
+            }
             if (response.isError) {
                 val message = response.output.joinToString("\n")
                 if (message.contains("no server running", ignoreCase = true)) {
@@ -170,6 +174,19 @@ class SshHostTmuxSessionsGateway @Inject constructor(
             this.keyPath == keyPath
 
     private companion object {
+        const val LOG_TAG: String = "HostTmuxSessions"
+
+        const val LEASE_BLOCK_TIMEOUT_MS: Long = 3_500L
+
+        const val LIVE_ENUM_TIMEOUT_MS: Long = 3_500L
+
+        fun defaultLeaseManager(): SshLeaseManager =
+            SshLeaseManager(
+                connector = SshLeaseConnector { target ->
+                    DefaultSshLeaseConnector().connect(target)
+                },
+            )
+
         // Issue #463: append `#{session_path}` so the warm live-client list
         // carries each session's working directory and the in-session
         // project switcher can group sessions by project/folder without a

--- a/app/src/main/java/com/pocketshell/app/sessions/LeaseSessionExec.kt
+++ b/app/src/main/java/com/pocketshell/app/sessions/LeaseSessionExec.kt
@@ -34,6 +34,7 @@ data class LeaseSessionTarget(
     val username: String,
     val keyPath: String,
     val passphrase: CharArray?,
+    val leasePurpose: String? = null,
 ) {
     internal fun toSshLeaseTarget(): SshLeaseTarget =
         SshLeaseTarget(
@@ -41,7 +42,7 @@ data class LeaseSessionTarget(
                 host = hostname,
                 port = port,
                 user = username,
-                credentialId = "$hostId:$keyPath",
+                credentialId = credentialId(),
                 knownHostsId = "accept-all",
             ),
             key = SshKey.Path(File(keyPath)),
@@ -58,7 +59,8 @@ data class LeaseSessionTarget(
             hostname == other.hostname &&
             port == other.port &&
             username == other.username &&
-            keyPath == other.keyPath
+            keyPath == other.keyPath &&
+            leasePurpose == other.leasePurpose
     }
 
     override fun hashCode(): Int {
@@ -67,7 +69,14 @@ data class LeaseSessionTarget(
         result = 31 * result + port
         result = 31 * result + username.hashCode()
         result = 31 * result + keyPath.hashCode()
+        result = 31 * result + (leasePurpose?.hashCode() ?: 0)
         return result
+    }
+
+    private fun credentialId(): String {
+        val base = "$hostId:$keyPath"
+        val purpose = leasePurpose?.trim()?.takeIf { it.isNotEmpty() } ?: return base
+        return "$base|purpose=$purpose"
     }
 }
 
@@ -122,7 +131,7 @@ object LeaseSessionExec {
     suspend fun <T> withSession(
         leaseManager: SshLeaseManager,
         target: LeaseSessionTarget,
-        blockTimeoutMs: Long,
+        blockTimeoutMs: Long?,
         block: suspend (SshSession) -> T,
     ): Result<T> {
         val leaseTarget = target.toSshLeaseTarget()
@@ -139,7 +148,7 @@ object LeaseSessionExec {
     private suspend fun <T> runAttempt(
         leaseManager: SshLeaseManager,
         leaseTarget: SshLeaseTarget,
-        blockTimeoutMs: Long,
+        blockTimeoutMs: Long?,
         block: suspend (SshSession) -> T,
     ): Result<T> {
         val lease = try {
@@ -170,10 +179,14 @@ object LeaseSessionExec {
             // exceptions propagate OUT of `withTimeoutOrNull` to the `catch`
             // below (we do NOT `runCatching` inside, which would swallow the
             // timeout's own CancellationException and defeat the bound).
-            val holder = withTimeoutOrNull(blockTimeoutMs) { Holder(block(lease.session)) }
+            val holder = if (blockTimeoutMs == null) {
+                Holder(block(lease.session))
+            } else {
+                withTimeoutOrNull(blockTimeoutMs) { Holder(block(lease.session)) }
+            }
             if (holder == null) {
                 poisonedTransport = true
-                Result.failure(LeaseSessionBlockTimeoutException(blockTimeoutMs))
+                Result.failure(LeaseSessionBlockTimeoutException(blockTimeoutMs ?: BLOCK_TIMEOUT_MS))
             } else {
                 Result.success(holder.value)
             }

--- a/app/src/main/java/com/pocketshell/app/sessions/LeaseSessionExec.kt
+++ b/app/src/main/java/com/pocketshell/app/sessions/LeaseSessionExec.kt
@@ -203,7 +203,7 @@ object LeaseSessionExec {
             withContext(NonCancellable) {
                 lease.release()
                 if (poisonedTransport) {
-                    runCatching { leaseManager.disconnect(leaseTarget.leaseKey) }
+                    runCatching { leaseManager.evictIdle(leaseTarget.leaseKey) }
                 }
             }
         }

--- a/app/src/main/java/com/pocketshell/app/sessions/StartDirectoryAutocomplete.kt
+++ b/app/src/main/java/com/pocketshell/app/sessions/StartDirectoryAutocomplete.kt
@@ -47,6 +47,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
 
 data class StartDirectoryAutocompleteTarget(
@@ -139,21 +140,26 @@ class StartDirectoryAutocompleteController(
         job = scope.launch {
             delay(debounceMs)
             val query = value
-            var suggestions: List<String> = emptyList()
-            try {
-                suggestions = suggest(query)
+            val suggestions: List<String> = try {
+                val requested = if (requestTimeoutMs == null) {
+                    suggest(query)
+                } else {
+                    withTimeoutOrNull(requestTimeoutMs) {
+                        suggest(query)
+                    }.orEmpty()
+                }
+                requested
             } catch (e: CancellationException) {
                 throw e
             } catch (_: Throwable) {
-                suggestions = emptyList()
-            } finally {
-                if (latestInput == query) {
-                    _state.value = StartDirectoryAutocompleteUiState(
-                        suggestions = suggestions.distinct(),
-                        loading = false,
-                        highlightedIndex = 0,
-                    )
-                }
+                emptyList()
+            }
+            if (latestInput == query) {
+                _state.value = StartDirectoryAutocompleteUiState(
+                    suggestions = suggestions.distinct(),
+                    loading = false,
+                    highlightedIndex = 0,
+                )
             }
         }
     }

--- a/app/src/main/java/com/pocketshell/app/sessions/StartDirectoryAutocomplete.kt
+++ b/app/src/main/java/com/pocketshell/app/sessions/StartDirectoryAutocomplete.kt
@@ -40,12 +40,14 @@ import com.pocketshell.core.ssh.SshLeaseManager
 import com.pocketshell.core.ssh.shellSingleQuote
 import com.pocketshell.uikit.theme.PocketShellColors
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
 
 data class StartDirectoryAutocompleteTarget(
@@ -119,6 +121,7 @@ class StartDirectoryAutocompleteController(
     private val scope: CoroutineScope,
     private val suggest: suspend (String) -> List<String>,
     private val debounceMs: Long = START_DIRECTORY_AUTOCOMPLETE_DEBOUNCE_MS,
+    private val requestTimeoutMs: Long = START_DIRECTORY_AUTOCOMPLETE_TIMEOUT_MS,
 ) {
     private val _state = MutableStateFlow(StartDirectoryAutocompleteUiState())
     val state: StateFlow<StartDirectoryAutocompleteUiState> = _state.asStateFlow()
@@ -137,13 +140,21 @@ class StartDirectoryAutocompleteController(
         job = scope.launch {
             delay(debounceMs)
             val query = value
-            val suggestions = runCatching { suggest(query) }.getOrDefault(emptyList())
-            if (latestInput == query) {
-                _state.value = StartDirectoryAutocompleteUiState(
-                    suggestions = suggestions.distinct(),
-                    loading = false,
-                    highlightedIndex = 0,
-                )
+            var suggestions: List<String> = emptyList()
+            try {
+                suggestions = withTimeoutOrNull(requestTimeoutMs) { suggest(query) }.orEmpty()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Throwable) {
+                suggestions = emptyList()
+            } finally {
+                if (latestInput == query) {
+                    _state.value = StartDirectoryAutocompleteUiState(
+                        suggestions = suggestions.distinct(),
+                        loading = false,
+                        highlightedIndex = 0,
+                    )
+                }
             }
         }
     }
@@ -171,6 +182,7 @@ class StartDirectoryAutocompleteController(
 
     fun dispose() {
         job?.cancel()
+        _state.value = StartDirectoryAutocompleteUiState()
     }
 }
 
@@ -178,16 +190,18 @@ class StartDirectoryAutocompleteController(
 fun rememberStartDirectoryAutocompleteController(
     suggestStartDirectories: (suspend (String) -> List<String>)?,
     debounceMs: Long = START_DIRECTORY_AUTOCOMPLETE_DEBOUNCE_MS,
+    requestTimeoutMs: Long = START_DIRECTORY_AUTOCOMPLETE_TIMEOUT_MS,
 ): StartDirectoryAutocompleteController? {
     val currentSuggest by rememberUpdatedState(suggestStartDirectories)
     val scope = rememberCoroutineScope()
     val enabled = suggestStartDirectories != null
-    val controller = remember(enabled, debounceMs) {
+    val controller = remember(enabled, debounceMs, requestTimeoutMs) {
         if (enabled) {
             StartDirectoryAutocompleteController(
                 scope = scope,
                 suggest = { query -> currentSuggest?.invoke(query).orEmpty() },
                 debounceMs = debounceMs,
+                requestTimeoutMs = requestTimeoutMs,
             )
         } else {
             null
@@ -372,4 +386,5 @@ fun startDirectoryAutocompleteSuggestionTag(path: String): String =
     "start-directory-autocomplete:suggestion:${path.hashCode()}"
 
 private const val START_DIRECTORY_AUTOCOMPLETE_DEBOUNCE_MS: Long = 250L
+private const val START_DIRECTORY_AUTOCOMPLETE_TIMEOUT_MS: Long = 1_500L
 private const val DEFAULT_START_DIRECTORY_AUTOCOMPLETE_LIMIT: Int = 30

--- a/app/src/main/java/com/pocketshell/app/sessions/StartDirectoryAutocomplete.kt
+++ b/app/src/main/java/com/pocketshell/app/sessions/StartDirectoryAutocomplete.kt
@@ -374,6 +374,7 @@ internal fun startDirectoryAutocompleteCommand(request: StartDirectoryAutocomple
           pocketshell_ac_count=${'$'}((pocketshell_ac_count + 1))
           [ "${'$'}pocketshell_ac_count" -ge ${request.limit} ] && break
         done
+        exit 0
     """.trimIndent()
 
 internal fun parseStartDirectoryAutocompleteOutput(

--- a/app/src/main/java/com/pocketshell/app/sessions/StartDirectoryAutocomplete.kt
+++ b/app/src/main/java/com/pocketshell/app/sessions/StartDirectoryAutocomplete.kt
@@ -47,7 +47,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
 
 data class StartDirectoryAutocompleteTarget(
@@ -121,7 +120,7 @@ class StartDirectoryAutocompleteController(
     private val scope: CoroutineScope,
     private val suggest: suspend (String) -> List<String>,
     private val debounceMs: Long = START_DIRECTORY_AUTOCOMPLETE_DEBOUNCE_MS,
-    private val requestTimeoutMs: Long = START_DIRECTORY_AUTOCOMPLETE_TIMEOUT_MS,
+    private val requestTimeoutMs: Long? = START_DIRECTORY_AUTOCOMPLETE_TIMEOUT_MS,
 ) {
     private val _state = MutableStateFlow(StartDirectoryAutocompleteUiState())
     val state: StateFlow<StartDirectoryAutocompleteUiState> = _state.asStateFlow()
@@ -142,7 +141,7 @@ class StartDirectoryAutocompleteController(
             val query = value
             var suggestions: List<String> = emptyList()
             try {
-                suggestions = withTimeoutOrNull(requestTimeoutMs) { suggest(query) }.orEmpty()
+                suggestions = suggest(query)
             } catch (e: CancellationException) {
                 throw e
             } catch (_: Throwable) {
@@ -190,7 +189,7 @@ class StartDirectoryAutocompleteController(
 fun rememberStartDirectoryAutocompleteController(
     suggestStartDirectories: (suspend (String) -> List<String>)?,
     debounceMs: Long = START_DIRECTORY_AUTOCOMPLETE_DEBOUNCE_MS,
-    requestTimeoutMs: Long = START_DIRECTORY_AUTOCOMPLETE_TIMEOUT_MS,
+    requestTimeoutMs: Long? = START_DIRECTORY_AUTOCOMPLETE_TIMEOUT_MS,
 ): StartDirectoryAutocompleteController? {
     val currentSuggest by rememberUpdatedState(suggestStartDirectories)
     val scope = rememberCoroutineScope()
@@ -386,5 +385,5 @@ fun startDirectoryAutocompleteSuggestionTag(path: String): String =
     "start-directory-autocomplete:suggestion:${path.hashCode()}"
 
 private const val START_DIRECTORY_AUTOCOMPLETE_DEBOUNCE_MS: Long = 250L
-private const val START_DIRECTORY_AUTOCOMPLETE_TIMEOUT_MS: Long = 1_500L
+private val START_DIRECTORY_AUTOCOMPLETE_TIMEOUT_MS: Long? = null
 private const val DEFAULT_START_DIRECTORY_AUTOCOMPLETE_LIMIT: Int = 30

--- a/app/src/main/java/com/pocketshell/app/sessions/StartDirectoryAutocomplete.kt
+++ b/app/src/main/java/com/pocketshell/app/sessions/StartDirectoryAutocomplete.kt
@@ -364,9 +364,12 @@ internal fun startDirectoryAutocompleteCommand(request: StartDirectoryAutocomple
         LC_ALL=C
         export LC_ALL
         pocketshell_ac_count=0
-        for pocketshell_ac_path in "${'$'}pocketshell_ac_parent"/"${'$'}pocketshell_ac_prefix"*; do
-          [ -d "${'$'}pocketshell_ac_path" ] || continue
+        find -L "${'$'}pocketshell_ac_parent" -mindepth 1 -maxdepth 1 -type d -print 2>/dev/null | while IFS= read -r pocketshell_ac_path; do
           pocketshell_ac_name=${'$'}{pocketshell_ac_path##*/}
+          case "${'$'}pocketshell_ac_name" in
+            "${'$'}pocketshell_ac_prefix"*) ;;
+            *) continue ;;
+          esac
           printf '%s/\n' "${'$'}pocketshell_ac_name"
           pocketshell_ac_count=${'$'}((pocketshell_ac_count + 1))
           [ "${'$'}pocketshell_ac_count" -ge ${request.limit} ] && break
@@ -391,5 +394,5 @@ fun startDirectoryAutocompleteSuggestionTag(path: String): String =
     "start-directory-autocomplete:suggestion:${path.hashCode()}"
 
 private const val START_DIRECTORY_AUTOCOMPLETE_DEBOUNCE_MS: Long = 250L
-private val START_DIRECTORY_AUTOCOMPLETE_TIMEOUT_MS: Long? = null
+private const val START_DIRECTORY_AUTOCOMPLETE_TIMEOUT_MS: Long = 2_000L
 private const val DEFAULT_START_DIRECTORY_AUTOCOMPLETE_LIMIT: Int = 30

--- a/app/src/main/java/com/pocketshell/app/sessions/service/SessionConnectionService.kt
+++ b/app/src/main/java/com/pocketshell/app/sessions/service/SessionConnectionService.kt
@@ -64,14 +64,16 @@ class SessionConnectionService : Service() {
         const val ACTION_START = "com.pocketshell.app.sessions.action.START_SESSION_HOLD"
         const val ACTION_STOP = "com.pocketshell.app.sessions.action.STOP_SESSION_HOLD"
 
-        fun start(context: Context) {
+        fun start(context: Context): Boolean {
             val intent = Intent(context, SessionConnectionService::class.java).apply {
                 action = ACTION_START
             }
-            runCatching {
+            return runCatching {
                 ContextCompat.startForegroundService(context, intent)
-            }.onFailure {
+                true
+            }.getOrElse {
                 Log.w(TAG, "session foreground service start was rejected", it)
+                false
             }
         }
 
@@ -100,7 +102,10 @@ class SessionConnectionService : Service() {
                 return START_NOT_STICKY
             }
             else -> {
-                promoteToForegroundIfNeeded(initialNotification())
+                if (!promoteToForegroundIfNeeded(initialNotification())) {
+                    stopSessionHold()
+                    return START_NOT_STICKY
+                }
                 acquireWakeLockIfNeeded()
                 if (observeJob?.isActive != true) {
                     startObserving()
@@ -144,22 +149,31 @@ class SessionConnectionService : Service() {
         observeJob = null
         stopForeground(STOP_FOREGROUND_REMOVE)
         hasStartedForeground = false
+        controller.onForegroundServiceStopped()
         releaseWakeLock()
         stopSelf()
     }
 
-    private fun promoteToForegroundIfNeeded(notification: Notification) {
-        if (hasStartedForeground) return
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-            startForeground(
-                NOTIFICATION_ID,
-                notification,
-                ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE,
-            )
-        } else {
-            startForeground(NOTIFICATION_ID, notification)
+    private fun promoteToForegroundIfNeeded(notification: Notification): Boolean {
+        if (hasStartedForeground) return true
+        return runCatching {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                startForeground(
+                    NOTIFICATION_ID,
+                    notification,
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE,
+                )
+            } else {
+                startForeground(NOTIFICATION_ID, notification)
+            }
+            hasStartedForeground = true
+            controller.onForegroundServicePromoted()
+            true
+        }.getOrElse {
+            Log.w(TAG, "session foreground service promotion failed", it)
+            controller.onForegroundServiceStartFailed()
+            false
         }
-        hasStartedForeground = true
     }
 
     private fun updateNotification(snapshot: SessionConnectionSnapshot) {

--- a/app/src/main/java/com/pocketshell/app/sessions/service/SessionServiceController.kt
+++ b/app/src/main/java/com/pocketshell/app/sessions/service/SessionServiceController.kt
@@ -43,12 +43,15 @@ class SessionServiceController @Inject constructor(
 
     private val _snapshot = MutableStateFlow(SessionConnectionSnapshot.Empty)
     private val _notificationStopRequests = MutableSharedFlow<Unit>(extraBufferCapacity = 16)
+    private val _sessionHoldEndedRequests = MutableSharedFlow<Unit>(extraBufferCapacity = 16)
     private var observeJob: Job? = null
     private var holdStoppedByUser: Boolean = false
 
     fun flowOfSnapshot(): StateFlow<SessionConnectionSnapshot> = _snapshot.asStateFlow()
 
     fun notificationStopRequests(): SharedFlow<Unit> = _notificationStopRequests.asSharedFlow()
+
+    fun sessionHoldEndedRequests(): SharedFlow<Unit> = _sessionHoldEndedRequests.asSharedFlow()
 
     fun observeActiveSessions() {
         if (observeJob?.isActive == true) return
@@ -85,7 +88,10 @@ class SessionServiceController @Inject constructor(
                     _snapshot.value = snapshot
                     when {
                         !wasHolding && snapshot.isHoldingConnection -> SessionConnectionService.start(appContext)
-                        wasHolding && !snapshot.isHoldingConnection -> SessionConnectionService.stop(appContext)
+                        wasHolding && !snapshot.isHoldingConnection -> {
+                            _sessionHoldEndedRequests.tryEmit(Unit)
+                            SessionConnectionService.stop(appContext)
+                        }
                     }
                 }
         }

--- a/app/src/main/java/com/pocketshell/app/sessions/service/SessionServiceController.kt
+++ b/app/src/main/java/com/pocketshell/app/sessions/service/SessionServiceController.kt
@@ -46,6 +46,8 @@ class SessionServiceController @Inject constructor(
     private val _sessionHoldEndedRequests = MutableSharedFlow<Unit>(extraBufferCapacity = 16)
     private var observeJob: Job? = null
     private var holdStoppedByUser: Boolean = false
+    private var foregroundServicePromoted: Boolean = false
+    private var foregroundServiceStartRejected: Boolean = false
 
     fun flowOfSnapshot(): StateFlow<SessionConnectionSnapshot> = _snapshot.asStateFlow()
 
@@ -87,9 +89,16 @@ class SessionServiceController @Inject constructor(
                     val wasHolding = _snapshot.value.isHoldingConnection
                     _snapshot.value = snapshot
                     when {
-                        !wasHolding && snapshot.isHoldingConnection -> SessionConnectionService.start(appContext)
+                        !wasHolding && snapshot.isHoldingConnection -> {
+                            foregroundServiceStartRejected = !SessionConnectionService.start(appContext)
+                            if (foregroundServiceStartRejected) {
+                                foregroundServicePromoted = false
+                            }
+                        }
                         wasHolding && !snapshot.isHoldingConnection -> {
                             _sessionHoldEndedRequests.tryEmit(Unit)
+                            foregroundServicePromoted = false
+                            foregroundServiceStartRejected = false
                             SessionConnectionService.stop(appContext)
                         }
                     }
@@ -101,12 +110,17 @@ class SessionServiceController @Inject constructor(
         SessionConnectionSnapshot.fromEntries(activeTmuxClients.clients.value.values)
 
     fun isHoldingSessionConnection(): Boolean =
-        !holdStoppedByUser && currentSnapshot().isHoldingConnection
+        !holdStoppedByUser &&
+            !foregroundServiceStartRejected &&
+            foregroundServicePromoted &&
+            currentSnapshot().isHoldingConnection
 
     fun stopHoldingFromNotification(requestServiceStop: Boolean = true) {
         if (holdStoppedByUser) return
         if (!currentSnapshot().isHoldingConnection) return
         holdStoppedByUser = true
+        foregroundServicePromoted = false
+        foregroundServiceStartRejected = false
         _snapshot.value = SessionConnectionSnapshot.Empty
         _notificationStopRequests.tryEmit(Unit)
         if (requestServiceStop) {
@@ -114,11 +128,27 @@ class SessionServiceController @Inject constructor(
         }
     }
 
+    fun onForegroundServicePromoted() {
+        foregroundServiceStartRejected = false
+        foregroundServicePromoted = true
+    }
+
+    fun onForegroundServiceStartFailed() {
+        foregroundServiceStartRejected = true
+        foregroundServicePromoted = false
+    }
+
+    fun onForegroundServiceStopped() {
+        foregroundServicePromoted = false
+    }
+
     @VisibleForTesting
     internal fun stopObservingForTest() {
         observeJob?.cancel()
         observeJob = null
         holdStoppedByUser = false
+        foregroundServicePromoted = false
+        foregroundServiceStartRejected = false
         _snapshot.value = SessionConnectionSnapshot.Empty
     }
 }

--- a/app/src/main/java/com/pocketshell/app/share/HostPickerScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/share/HostPickerScreen.kt
@@ -170,7 +170,7 @@ internal fun HostPickerScreen(
                         )
                 }
             }
-            is UploadState.Running -> UploadingSurface(hostName = state.hostName)
+            is UploadState.Running -> UploadingSurface(hostName = state.hostName, detail = state.detail)
             is UploadState.NeedsPassphrase ->
                 PassphraseDialog(
                     hostName = state.hostName,
@@ -468,7 +468,7 @@ private fun ShareEmptyState(message: String) {
 }
 
 @Composable
-private fun UploadingSurface(hostName: String) {
+private fun UploadingSurface(hostName: String, detail: String?) {
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -482,6 +482,14 @@ private fun UploadingSurface(hostName: String) {
             text = "Uploading to $hostName...",
             style = MaterialTheme.typography.titleMedium,
         )
+        if (!detail.isNullOrBlank()) {
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = detail,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/pocketshell/app/share/ShareUploader.kt
+++ b/app/src/main/java/com/pocketshell/app/share/ShareUploader.kt
@@ -96,7 +96,7 @@ internal class ShareUploader(
      * default points at the same [SshConnection.connect] the rest of
      * the app uses.
      */
-    private val connect: suspend (HostEntity, SshKey, String) -> Result<SshSession> = { host, key, _ ->
+    private val connect: suspend (HostEntity, SshKey, String, String?) -> Result<SshSession> = { host, key, _, _ ->
         SshConnection.connect(
             host = host.hostname,
             port = host.port,
@@ -126,7 +126,7 @@ internal class ShareUploader(
     ): Result<String> = withContext(Dispatchers.IO) {
         val keyFile = File(keyEntity.privateKeyPath)
         val key: SshKey = SshKey.Path(keyFile)
-        val sessionResult = connect(host, key, keyEntity.privateKeyPath)
+        val sessionResult = connect(host, key, keyEntity.privateKeyPath, SHARE_LEASE_PURPOSE_UPLOAD)
         val session = sessionResult.getOrElse { e ->
             return@withContext Result.failure(
                 SshException(errorMessage("connect", e), e),
@@ -442,6 +442,8 @@ internal class ShareUploader(
             if (mime.isNullOrBlank()) return null
             return MimeTypeMap.getSingleton().getExtensionFromMimeType(mime)
         }
+
+        const val SHARE_LEASE_PURPOSE_UPLOAD = "share-upload"
     }
 }
 

--- a/app/src/main/java/com/pocketshell/app/share/ShareUploader.kt
+++ b/app/src/main/java/com/pocketshell/app/share/ShareUploader.kt
@@ -14,6 +14,7 @@ import com.pocketshell.core.storage.entity.HostEntity
 import com.pocketshell.core.storage.entity.SshKeyEntity
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -124,10 +125,21 @@ internal class ShareUploader(
         item: ShareableItem,
         target: ShareTarget,
     ): Result<String> = withContext(Dispatchers.IO) {
+        val preparedUriFile = if (item is ShareableItem.UriItem) {
+            val resolver = context.contentResolver
+            withTimeoutOrNull(SHARE_SAF_TIMEOUT_MS) {
+                drainToTempFile(resolver, item.uri)
+            } ?: return@withContext Result.failure(
+                SshException("Could not read shared file before upload"),
+            )
+        } else {
+            null
+        }
         val keyFile = File(keyEntity.privateKeyPath)
         val key: SshKey = SshKey.Path(keyFile)
         val sessionResult = connect(host, key, keyEntity.privateKeyPath, SHARE_LEASE_PURPOSE_UPLOAD)
         val session = sessionResult.getOrElse { e ->
+            preparedUriFile?.delete()
             return@withContext Result.failure(
                 SshException(errorMessage("connect", e), e),
             )
@@ -151,7 +163,11 @@ internal class ShareUploader(
                 val remotePath = "${destination.uploadDirectory}/$remoteName"
 
                 when (item) {
-                    is ShareableItem.UriItem -> uploadUri(live, item, remotePath)
+                    is ShareableItem.UriItem -> live.uploadFile(
+                        preparedUriFile
+                            ?: throw SshException("Could not read shared file before upload"),
+                        remotePath,
+                    )
                     is ShareableItem.TextItem -> uploadText(live, item, remotePath, remoteName)
                     is ShareableItem.FileItem -> live.uploadFile(item.file, remotePath)
                 }
@@ -161,6 +177,8 @@ internal class ShareUploader(
             Result.failure(e)
         } catch (e: Throwable) {
             Result.failure(SshException(errorMessage("upload", e), e))
+        } finally {
+            preparedUriFile?.delete()
         }
     }
 
@@ -253,36 +271,6 @@ internal class ShareUploader(
         )
     }
 
-    private suspend fun uploadUri(
-        session: SshSession,
-        item: ShareableItem.UriItem,
-        remotePath: String,
-    ) {
-        val resolver = context.contentResolver
-        val length = item.size ?: resolveSize(resolver, item.uri)
-        if (length == null) {
-            // SCP needs a content length up-front. When the content
-            // provider doesn't tell us, drain the stream into a temp
-            // file under the cache directory so we can use uploadFile.
-            val temp = drainToTempFile(resolver, item.uri)
-            try {
-                session.uploadFile(temp, remotePath)
-            } finally {
-                temp.delete()
-            }
-            return
-        }
-
-        resolver.openInputStream(item.uri)?.use { input ->
-            session.uploadStream(
-                input = input,
-                length = length,
-                name = remotePath.substringAfterLast('/'),
-                remotePath = remotePath,
-            )
-        } ?: throw SshException("Could not read shared file (content provider returned null)")
-    }
-
     private suspend fun uploadText(
         session: SshSession,
         item: ShareableItem.TextItem,
@@ -297,20 +285,6 @@ internal class ShareUploader(
                 name = remoteName,
                 remotePath = remotePath,
             )
-        }
-    }
-
-    private fun resolveSize(resolver: ContentResolver, uri: Uri): Long? {
-        return try {
-            resolver.query(uri, arrayOf(OpenableColumns.SIZE), null, null, null)?.use { cursor ->
-                if (!cursor.moveToFirst()) return@use null
-                val index = cursor.getColumnIndex(OpenableColumns.SIZE)
-                if (index < 0) return@use null
-                val size = cursor.getLong(index)
-                if (size <= 0) null else size
-            }
-        } catch (_: Throwable) {
-            null
         }
     }
 
@@ -444,6 +418,7 @@ internal class ShareUploader(
         }
 
         const val SHARE_LEASE_PURPOSE_UPLOAD = "share-upload"
+        const val SHARE_SAF_TIMEOUT_MS: Long = 10_000L
     }
 }
 

--- a/app/src/main/java/com/pocketshell/app/share/ShareViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/share/ShareViewModel.kt
@@ -177,7 +177,7 @@ internal class ShareViewModel internal constructor(
     @androidx.annotation.VisibleForTesting
     internal var uploader: ShareItemUploader = ShareUploader(
         context = applicationContext,
-        connect = { host, key, keyPath -> connectForUpload(host, key, keyPath) },
+        connect = { host, key, keyPath, purpose -> connectForUpload(host, key, keyPath, purpose) },
     )
 
     private var lastShareAction: ShareRetryAction? = null
@@ -222,27 +222,33 @@ internal class ShareViewModel internal constructor(
     @androidx.annotation.VisibleForTesting
     internal var connectForStaging: suspend (HostEntity, SshKeyEntity) -> Result<SshSession> =
         { host, keyEntity ->
-            acquireLeaseBackedSession(host = host, keyPath = keyEntity.privateKeyPath)
+            acquireLeaseBackedSession(
+                host = host,
+                keyPath = keyEntity.privateKeyPath,
+                leasePurpose = SHARE_LEASE_PURPOSE_STAGING,
+            )
         }
 
     private suspend fun connectForUpload(
         host: HostEntity,
         key: SshKey,
         keyPath: String,
+        leasePurpose: String?,
     ): Result<SshSession> {
         if (key !is SshKey.Path) {
             return Result.failure(
                 com.pocketshell.core.ssh.SshException("Share upload requires a persisted SSH key"),
             )
         }
-        return acquireLeaseBackedSession(host = host, keyPath = keyPath)
+        return acquireLeaseBackedSession(host = host, keyPath = keyPath, leasePurpose = leasePurpose)
     }
 
     private suspend fun acquireLeaseBackedSession(
         host: HostEntity,
         keyPath: String,
+        leasePurpose: String?,
     ): Result<SshSession> {
-        val target = host.toShareLeaseTarget(keyPath, pendingPassphrase.get())
+        val target = host.toShareLeaseTarget(keyPath, pendingPassphrase.get(), leasePurpose)
         return sshLeaseManager.acquire(target).map { lease ->
             LeaseBackedShareSession(lease)
         }
@@ -264,19 +270,26 @@ internal class ShareViewModel internal constructor(
     private fun HostEntity.toShareLeaseTarget(
         keyPath: String,
         passphrase: CharArray?,
+        leasePurpose: String?,
     ): SshLeaseTarget =
         SshLeaseTarget(
             leaseKey = SshLeaseKey(
                 host = hostname,
                 port = port,
                 user = username,
-                credentialId = "$id:$keyPath",
+                credentialId = shareCredentialId(keyPath, leasePurpose),
                 knownHostsId = "accept-all",
             ),
             key = SshKey.Path(File(keyPath)),
             passphrase = passphrase?.copyOf(),
             knownHosts = KnownHostsPolicy.AcceptAll,
         )
+
+    private fun HostEntity.shareCredentialId(keyPath: String, leasePurpose: String?): String {
+        val base = "$id:$keyPath"
+        val purpose = leasePurpose?.trim()?.takeIf { it.isNotEmpty() } ?: return base
+        return "$base|purpose=$purpose"
+    }
 
     /**
      * Stage the [items] the activity extracted from the share intent.
@@ -459,7 +472,7 @@ internal class ShareViewModel internal constructor(
             return
         }
         _targetSelection.value = null
-        _uploadState.value = UploadState.Running(host.name)
+        _uploadState.value = UploadState.Running(host.name, runningDetail(payload, "Staging"))
         viewModelScope.launch {
             val liveEntry = activeTmuxClients.clients.value[host.id]
             if (liveEntry == null || !isSessionTargetCurrent(liveEntry.client, session)) {
@@ -756,7 +769,7 @@ internal class ShareViewModel internal constructor(
             "target" to targetName,
         )
         _targetSelection.value = null
-        _uploadState.value = UploadState.Running(host.name)
+        _uploadState.value = UploadState.Running(host.name, runningDetail(payload, "Uploading"))
         viewModelScope.launch {
             val keyEntity = sshKeyDao.getById(host.keyId)
             if (keyEntity == null) {
@@ -1039,7 +1052,7 @@ internal class ShareViewModel internal constructor(
             notifyShareFailure(host.name, message)
             return
         }
-        _uploadState.value = UploadState.Running(host.name)
+        _uploadState.value = UploadState.Running(host.name, "Pasting text into active session")
         viewModelScope.launch {
             val sendResult = runCatching {
                 sendTextToAttachedPane(entry.client, staged.text)
@@ -1276,6 +1289,8 @@ internal class ShareViewModel internal constructor(
         const val TEXT_PASTE_BUDGET_BYTES: Int = 8 * 1024
         const val LOG_TAG: String = "PocketShellShare"
         const val STAGE_INTO_SESSION_TIMEOUT_MS: Long = 90_000L
+        const val SHARE_LEASE_PURPOSE_UPLOAD: String = "share-upload"
+        const val SHARE_LEASE_PURPOSE_STAGING: String = "share-staging"
 
         /** Truncation cap for the paste preview surfaced in UploadState.Success. */
         const val PASTE_PREVIEW_LENGTH: Int = 80
@@ -1299,6 +1314,33 @@ internal class ShareViewModel internal constructor(
             } else {
                 firstLine
             }
+        }
+
+        fun runningDetail(items: List<ShareableItem>, verb: String): String {
+            val totalBytes = items.mapNotNull { item ->
+                when (item) {
+                    is ShareableItem.FileItem -> item.file.length().takeIf { it > 0L }
+                    is ShareableItem.TextItem -> item.text.toByteArray(Charsets.UTF_8).size.toLong()
+                    is ShareableItem.UriItem -> item.size?.takeIf { it > 0L }
+                }
+            }.takeIf { it.size == items.size }?.sum()
+            val count = when (items.size) {
+                1 -> "1 item"
+                else -> "${items.size} items"
+            }
+            return if (totalBytes != null) {
+                "$verb $count (${formatRunningBytes(totalBytes)})"
+            } else {
+                "$verb $count (size unknown)"
+            }
+        }
+
+        private fun formatRunningBytes(bytes: Long): String = when {
+            bytes < 1024L -> "$bytes B"
+            bytes < 1024L * 1024L -> String.format(java.util.Locale.US, "%.1f KB", bytes / 1024.0)
+            bytes < 1024L * 1024L * 1024L ->
+                String.format(java.util.Locale.US, "%.1f MB", bytes / (1024.0 * 1024.0))
+            else -> String.format(java.util.Locale.US, "%.1f GB", bytes / (1024.0 * 1024.0 * 1024.0))
         }
 
         /**
@@ -1327,7 +1369,7 @@ internal sealed interface UploadState {
     data object Idle : UploadState
 
     /** SCP upload (or send-keys paste) is running. Surface a spinner + the host name. */
-    data class Running(val hostName: String) : UploadState
+    data class Running(val hostName: String, val detail: String? = null) : UploadState
 
     /**
      * Issue #654: the fresh share connect could not authenticate because

--- a/app/src/main/java/com/pocketshell/app/share/ShareViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/share/ShareViewModel.kt
@@ -461,6 +461,21 @@ internal class ShareViewModel internal constructor(
         _targetSelection.value = null
         _uploadState.value = UploadState.Running(host.name)
         viewModelScope.launch {
+            val liveEntry = activeTmuxClients.clients.value[host.id]
+            if (liveEntry == null || !isSessionTargetCurrent(liveEntry.client, session)) {
+                DiagnosticEvents.record(
+                    "action",
+                    "share_stage_into_session_result",
+                    "status" to "failure",
+                    "hostId" to host.id,
+                    "cause" to "StaleSessionTarget",
+                )
+                val message = staleSessionTargetMessage(host, session)
+                android.util.Log.w(LOG_TAG, "share into session aborted: $message")
+                _uploadState.value = UploadState.Failed(host.name, message)
+                notifyShareFailure(host.name, message)
+                return@launch
+            }
             val keyEntity = sshKeyDao.getById(host.keyId)
             if (keyEntity == null) {
                 DiagnosticEvents.record(
@@ -646,21 +661,76 @@ internal class ShareViewModel internal constructor(
                 if (name != focusedSession) add(name)
             }
         }
+        val identitiesBySession = resolveSessionIdentities(host, ordered)
 
         val sessions = mutableListOf<ActiveSessionTarget>()
         for (sessionName in ordered) {
             if (sessionName.isBlank()) continue
             val cwd = activePanes[sessionName]?.cwd?.trim().orEmpty()
             val normalised = cwd.takeIf { it.startsWith("/") }?.trimEnd('/')?.ifBlank { "/" }.orEmpty()
+            val identity = identitiesBySession[sessionName]
             sessions += ActiveSessionTarget(
                 sessionName = sessionName,
                 cwd = normalised,
                 label = sessionName,
                 focused = sessionName == focusedSession,
+                tmuxSessionId = identity?.tmuxSessionId,
+                sessionCreated = identity?.sessionCreated,
             )
         }
         return sessions
     }
+
+    private suspend fun resolveSessionIdentities(
+        host: HostEntity,
+        sessionNames: List<String>,
+    ): Map<String, ActiveSessionIdentity> {
+        if (sessionNames.isEmpty()) return emptyMap()
+        val entry = activeTmuxClients.clients.value[host.id] ?: return emptyMap()
+        val wanted = sessionNames.toSet()
+        return runCatching {
+            val response = entry.client.sendCommand(SshFolderListGateway.CONTROL_LIST_SESSIONS_COMMAND)
+            if (response.isError) return@runCatching emptyMap()
+            SshFolderListGateway.parseListSessionsRows(response.output.joinToString("\n"))
+                .asSequence()
+                .filter { it.sessionName in wanted }
+                .mapNotNull { row ->
+                    val id = row.tmuxSessionId ?: return@mapNotNull null
+                    val created = row.sessionCreated ?: return@mapNotNull null
+                    row.sessionName to ActiveSessionIdentity(id, created)
+                }
+                .toMap()
+        }.getOrDefault(emptyMap())
+    }
+
+    private suspend fun isSessionTargetCurrent(
+        client: TmuxClient,
+        session: ActiveSessionTarget,
+    ): Boolean {
+        val escaped = escapeSingleQuoted(session.sessionName)
+        val expectedId = session.tmuxSessionId
+        val expectedCreated = session.sessionCreated
+        if (expectedId != null && expectedCreated != null) {
+            val response = runCatching {
+                client.sendCommand(
+                    "display-message -p -t '$escaped' '#{session_id}::#{session_created}'",
+                )
+            }.getOrNull() ?: return false
+            if (response.isError) return false
+            val actual = response.output.firstOrNull()?.trim().orEmpty()
+            return actual == "$expectedId::$expectedCreated"
+        }
+        val response = runCatching {
+            client.sendCommand("has-session -t '$escaped'")
+        }.getOrNull() ?: return false
+        return !response.isError
+    }
+
+    private fun staleSessionTargetMessage(
+        host: HostEntity,
+        session: ActiveSessionTarget,
+    ): String =
+        "Session ${session.sessionName} is no longer active on ${host.name} — save to inbox instead"
 
     /**
      * Issue #473: upload every staged item to [host], routing to either
@@ -1164,7 +1234,7 @@ internal class ShareViewModel internal constructor(
      */
     fun submitPassphrase(passphrase: CharArray) {
         if (passphrase.isEmpty()) return
-        pendingPassphrase.getAndSet(passphrase.copyOf())?.fill(' ')
+        pendingPassphrase.getAndSet(passphrase.copyOf())?.fill('\u0000')
         retryLastShareAction()
     }
 
@@ -1174,7 +1244,7 @@ internal class ShareViewModel internal constructor(
     }
 
     private fun clearPendingPassphrase() {
-        pendingPassphrase.getAndSet(null)?.fill(' ')
+        pendingPassphrase.getAndSet(null)?.fill('\u0000')
     }
 
     /**
@@ -1469,12 +1539,24 @@ internal data class TargetSelection(
  * @property label the user-visible session label (the session name).
  * @property focused true for the host's currently-focused session, which
  *   the picker lists first.
+ * @property tmuxSessionId stable tmux `#{session_id}` captured when the picker
+ *   was rendered. Rechecked before staging so a stale same-name target is not
+ *   treated as the original session.
+ * @property sessionCreated tmux `#{session_created}` paired with
+ *   [tmuxSessionId] to distinguish recreated same-name sessions.
  */
 internal data class ActiveSessionTarget(
     val sessionName: String,
     val cwd: String,
     val label: String,
     val focused: Boolean = false,
+    val tmuxSessionId: String? = null,
+    val sessionCreated: Long? = null,
+)
+
+private data class ActiveSessionIdentity(
+    val tmuxSessionId: String,
+    val sessionCreated: Long,
 )
 
 private class ShareStageIntoSessionTimeoutException(

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
@@ -400,11 +400,11 @@ public fun TmuxSessionScreen(
     // Issue #626: unified pane list for the cross-session pager.
     val unifiedPanes by viewModel.unifiedPanes.collectAsState()
     // Issue #876: collect the DEBOUNCED display status so a sub-1s reconnect blip
-    // never flashes the "Reconnecting" band/spinner. Steady states
-    // (Connected/Connecting/Switching/Failed/Idle) still surface immediately, so
-    // input-gating (`sessionLive`) and the connecting overlay are unaffected — only
-    // the transient Reconnecting surfacing is held back ~1s.
+    // never flashes the "Reconnecting" band/spinner. Input gating reads the raw
+    // status below so a held display state cannot leave controls live during a
+    // real transport drop.
     val status by viewModel.displayConnectionStatus.collectAsState()
+    val rawStatus by viewModel.connectionStatus.collectAsState()
     // EPIC #687 P1 (#686/#658): the screen is keyed to the TARGET session id —
     // the rendered screen state is a pure function of that id (`RevealStateMachine`),
     // so a late/stale frame from the previous session can NEVER paint.
@@ -449,7 +449,7 @@ public fun TmuxSessionScreen(
     // dead bridge and silently lost — exactly the data-loss the user
     // reported. We disable those affordances and surface a visible
     // "Reconnecting" / "Disconnected" pill instead.
-    val sessionLive = status is ConnectionStatus.Connected
+    val sessionLive = rawStatus is ConnectionStatus.Connected
     val outboundQueueItems by promptComposerViewModel.outboundQueueItems.collectAsState()
     val outboundQueueAutoFlushController = remember(targetSessionId.value) {
         OutboundQueueAutoFlushController()

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
@@ -149,10 +149,10 @@ import com.pocketshell.app.sessions.HostTmuxSessionPickerState
 import com.pocketshell.app.sessions.HostTmuxSessionPickerViewModel
 import com.pocketshell.app.sessions.HostTmuxSessionRow
 import com.pocketshell.app.agentcommands.AgentCommandCatalog
-import com.pocketshell.app.cards.ChecklistCardsSheet
-import com.pocketshell.app.cards.ChecklistChip
-import com.pocketshell.app.cards.SessionCardsRemoteSource
-import com.pocketshell.app.cards.checklistChipState
+import com.pocketshell.app.cards.SessionCardFeedChip
+import com.pocketshell.app.cards.SessionCardFeedSheet
+import com.pocketshell.app.cards.SessionCardInteractions
+import com.pocketshell.app.cards.cardFeedChipState
 import com.pocketshell.app.snippets.SnippetKind
 import com.pocketshell.app.snippets.SnippetPickerSheet
 import com.pocketshell.app.snippets.snippetDispatchText
@@ -480,15 +480,15 @@ public fun TmuxSessionScreen(
         }
     }
     val sessionCardsState by viewModel.sessionCards.collectAsState()
-    val checklistCards = remember(sessionCardsState, activeSessionCardsTargetKey) {
+    val sessionCards = remember(sessionCardsState, activeSessionCardsTargetKey) {
         if (sessionCardsState.targetKey == activeSessionCardsTargetKey) {
-            sessionCardsState.feed.cards.filterIsInstance<SessionCardsRemoteSource.ChecklistCard>()
+            sessionCardsState.feed.cards
         } else {
             emptyList()
         }
     }
-    val sessionChecklistChipState = remember(checklistCards) {
-        checklistChipState(checklistCards)
+    val sessionCardFeedChipState = remember(sessionCards) {
+        cardFeedChipState(sessionCards)
     }
     LaunchedEffect(sessionLive, activeSessionCardsTargetKey) {
         if (sessionLive) viewModel.refreshActiveSessionCards()
@@ -727,7 +727,20 @@ public fun TmuxSessionScreen(
     // dark for voice input).
     var showMicSheet by remember { mutableStateOf(false) }
     var showSnippetPicker by remember { mutableStateOf(false) }
-    var showChecklistSheet by remember(activeSessionCardsTargetKey) { mutableStateOf(false) }
+    var showCardFeedSheet by remember(activeSessionCardsTargetKey) { mutableStateOf(false) }
+    val sessionCardInteractions = remember(viewModel) {
+        object : SessionCardInteractions {
+            override fun onToggleChecklistItem(cardId: String, itemId: String, checked: Boolean) {
+                viewModel.toggleChecklistItem(
+                    cardId = cardId,
+                    itemId = itemId,
+                    checked = checked,
+                )
+            }
+
+            override fun onSetNoteRead(cardId: String, read: Boolean) = Unit
+        }
+    }
 
     // Issue #560: a share-into-session launch carries staged remote
     // attachment path(s). Seed them into the shared composer VM as #544
@@ -959,7 +972,7 @@ public fun TmuxSessionScreen(
         sessionDrawerOpen = showSessionSwitcher || showSessionDrawer,
         micSheetOpen = showMicSheet,
         snippetPickerOpen = showSnippetPicker,
-        checklistSheetOpen = showChecklistSheet,
+        cardFeedSheetOpen = showCardFeedSheet,
         onDismissDialog = { dialogMode = null },
         onDismissSessionDrawer = {
             showSessionSwitcher = false
@@ -968,7 +981,7 @@ public fun TmuxSessionScreen(
         },
         onDismissMicSheet = { showMicSheet = false },
         onDismissSnippetPicker = { showSnippetPicker = false },
-        onDismissChecklistSheet = { showChecklistSheet = false },
+        onDismissCardFeedSheet = { showCardFeedSheet = false },
         onBack = onBack,
     )
 
@@ -2246,13 +2259,13 @@ public fun TmuxSessionScreen(
                             showHotkeysPanel = true
                         }
                     },
-                    leadingChipContent = if (controlsInputEnabled) sessionChecklistChipState?.let { state ->
+                    leadingChipContent = if (controlsInputEnabled) sessionCardFeedChipState?.let { state ->
                         {
-                            ChecklistChip(
+                            SessionCardFeedChip(
                                 state = state,
                                 onClick = {
                                     viewModel.refreshActiveSessionCards()
-                                    showChecklistSheet = true
+                                    showCardFeedSheet = true
                                 },
                             )
                         }
@@ -2706,17 +2719,11 @@ public fun TmuxSessionScreen(
         )
     }
 
-    if (showChecklistSheet) {
-        ChecklistCardsSheet(
-            cards = checklistCards,
-            onToggle = { cardId, itemId, checked ->
-                viewModel.toggleChecklistItem(
-                    cardId = cardId,
-                    itemId = itemId,
-                    checked = checked,
-                )
-            },
-            onDismiss = { showChecklistSheet = false },
+    if (showCardFeedSheet) {
+        SessionCardFeedSheet(
+            cards = sessionCards,
+            interactions = sessionCardInteractions,
+            onDismiss = { showCardFeedSheet = false },
         )
     }
 
@@ -6337,12 +6344,12 @@ internal fun TmuxSessionBackHandler(
     sessionDrawerOpen: Boolean,
     micSheetOpen: Boolean,
     snippetPickerOpen: Boolean,
-    checklistSheetOpen: Boolean = false,
+    cardFeedSheetOpen: Boolean = false,
     onDismissDialog: () -> Unit,
     onDismissSessionDrawer: () -> Unit,
     onDismissMicSheet: () -> Unit,
     onDismissSnippetPicker: () -> Unit,
-    onDismissChecklistSheet: () -> Unit = {},
+    onDismissCardFeedSheet: () -> Unit = {},
     onBack: () -> Unit,
 ) {
     BackHandler {
@@ -6351,7 +6358,7 @@ internal fun TmuxSessionBackHandler(
             sessionDrawerOpen -> onDismissSessionDrawer()
             micSheetOpen -> onDismissMicSheet()
             snippetPickerOpen -> onDismissSnippetPicker()
-            checklistSheetOpen -> onDismissChecklistSheet()
+            cardFeedSheetOpen -> onDismissCardFeedSheet()
             else -> onBack()
         }
     }

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -1192,6 +1192,10 @@ public class TmuxSessionViewModel @Inject constructor(
     internal fun currentClientIdentityForTest(): Int? =
         clientRef?.let { System.identityHashCode(it) }
 
+    @androidx.annotation.VisibleForTesting
+    internal fun paneProducerClientIdentityForTest(paneId: String): Int? =
+        paneProducerClients[paneId]?.let { System.identityHashCode(it) }
+
     /**
      * Issue #895 (switch-while-black) test seam: force the inline connection
      * state to [ConnectionState.Attaching] so a regression test can drive a
@@ -9024,6 +9028,7 @@ public class TmuxSessionViewModel @Inject constructor(
                 // closed client must be replaced.
                 if (client != null && paneProducerClients[p.paneId] !== client) {
                     paneProducerJobs.remove(p.paneId)?.cancel()
+                    paneProducerClients.remove(p.paneId)
                     paneOutputActivityJobs.remove(p.paneId)?.cancel()
                     panePortDetectorJobs.remove(p.paneId)?.cancel()
                     paneInputJobs.remove(p.paneId)?.cancel()
@@ -9182,6 +9187,7 @@ public class TmuxSessionViewModel @Inject constructor(
             // (re)attached — cold attach, warm switch, surface recreate.
             startPortDetectionForPane(paneId = paneId, client = client)
         }.onFailure { cause ->
+            paneProducerClients.remove(paneId)
             Log.w(
                 ISSUE_145_RECONNECT_TAG,
                 "tmux-terminal-producer-attach-failed pane=$paneId",
@@ -9194,6 +9200,7 @@ public class TmuxSessionViewModel @Inject constructor(
         for (pane in paneRows.values) {
             val paneId = pane.paneId
             paneProducerJobs.remove(paneId)?.cancel()
+            paneProducerClients.remove(paneId)
             paneOutputActivityJobs.remove(paneId)?.cancel()
             panePortDetectorJobs.remove(paneId)?.cancel()
             paneInputJobs.remove(paneId)?.cancel()
@@ -9493,6 +9500,7 @@ public class TmuxSessionViewModel @Inject constructor(
         )
 
         paneProducerJobs.remove(paneId)?.cancel()
+        paneProducerClients.remove(paneId)
         paneOutputActivityJobs.remove(paneId)?.cancel()
         paneInputJobs.remove(paneId)?.cancel()
         paneInputQueues.remove(paneId)?.close()
@@ -9562,6 +9570,7 @@ public class TmuxSessionViewModel @Inject constructor(
         val existing = paneRows[paneId] ?: return
         paneSurfaceRecoveryTimestamps.remove(paneId)
         paneProducerJobs.remove(paneId)?.cancel()
+        paneProducerClients.remove(paneId)
         paneOutputActivityJobs.remove(paneId)?.cancel()
         paneInputJobs.remove(paneId)?.cancel()
         paneInputQueues.remove(paneId)?.close()

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -2070,6 +2070,7 @@ public class TmuxSessionViewModel @Inject constructor(
     // restored runtime never re-prompts a port already handled.
     private val portDetector: PortDetector = PortDetector()
     private val panePortDetectorJobs: MutableMap<String, Job> = ConcurrentHashMap()
+    private val panePortDetectorClients: MutableMap<String, TmuxClient> = ConcurrentHashMap()
     private val scannedConversationPortEventKeys: MutableSet<String> =
         ConcurrentHashMap.newKeySet()
 
@@ -2887,6 +2888,15 @@ public class TmuxSessionViewModel @Inject constructor(
             sameSessionIdentity(currentTarget, guard.target)
     }
 
+    private fun currentRuntimeGuardForClient(client: TmuxClient): RuntimeRefreshGuard? {
+        val target = activeTarget ?: return null
+        return RuntimeRefreshGuard(
+            generation = connectGeneration,
+            target = target,
+            client = client,
+        )
+    }
+
     private fun ConnectionTarget.toRuntimeKey(): TmuxRuntimeKey =
         TmuxRuntimeKey(
             hostId = hostId,
@@ -3562,8 +3572,10 @@ public class TmuxSessionViewModel @Inject constructor(
      */
     private fun canReseedWithinGraceForeground(): Boolean {
         if (inlineConnectionStatus !is ConnectionStatus.Connected) return false
-        if (clientRef == null) return false
-        if (sessionRef == null) return false
+        val client = clientRef ?: return false
+        val session = sessionRef ?: return false
+        if (client.disconnected.value) return false
+        if (!session.isConnected) return false
         val target = activeTarget ?: return false
         if (pendingReattach != null) return false
         if (pausedAutoReconnect != null) return false
@@ -5118,6 +5130,9 @@ public class TmuxSessionViewModel @Inject constructor(
         paneOutputActivityJobs.clear()
         paneInputQueues.clear()
         paneInputJobs.clear()
+        panePortDetectorJobs.values.forEach { it.cancel() }
+        panePortDetectorJobs.clear()
+        panePortDetectorClients.clear()
         paneSurfaceRecoveryTimestamps.clear()
         paneAgentJobs.values.forEach { it.cancel() }
         paneAgentJobs.clear()
@@ -9031,6 +9046,7 @@ public class TmuxSessionViewModel @Inject constructor(
                     paneProducerClients.remove(p.paneId)
                     paneOutputActivityJobs.remove(p.paneId)?.cancel()
                     panePortDetectorJobs.remove(p.paneId)?.cancel()
+                    panePortDetectorClients.remove(p.paneId)
                     paneInputJobs.remove(p.paneId)?.cancel()
                     paneInputQueues.remove(p.paneId)?.close()
                     existing.terminalState.detachExternalProducer()
@@ -9125,6 +9141,7 @@ public class TmuxSessionViewModel @Inject constructor(
             paneOutputActivityJobs.remove(paneId)?.cancel()
             // Issue #448: stop the new-port detector for a removed pane.
             panePortDetectorJobs.remove(paneId)?.cancel()
+            panePortDetectorClients.remove(paneId)
             paneAgentJobs.remove(paneId)?.cancel()
             conversationLoadWatchdogJobs.remove(paneId)?.cancel()
             paneAgentTailGenerations.remove(paneId)
@@ -9203,6 +9220,7 @@ public class TmuxSessionViewModel @Inject constructor(
             paneProducerClients.remove(paneId)
             paneOutputActivityJobs.remove(paneId)?.cancel()
             panePortDetectorJobs.remove(paneId)?.cancel()
+            panePortDetectorClients.remove(paneId)
             paneInputJobs.remove(paneId)?.cancel()
             paneInputQueues.remove(paneId)?.close()
             attachTerminalProducerForPane(
@@ -9243,10 +9261,18 @@ public class TmuxSessionViewModel @Inject constructor(
      * and foreground-gated (the flow is only collected while attached).
      */
     private fun startPortDetectionForPane(paneId: String, client: TmuxClient) {
-        if (panePortDetectorJobs[paneId]?.isActive == true) return
-        panePortDetectorJobs[paneId]?.cancel()
-        panePortDetectorJobs[paneId] = bridgeScope.launch {
+        val existingJob = panePortDetectorJobs[paneId]
+        if (existingJob?.isActive == true && panePortDetectorClients[paneId] === client) return
+        if (existingJob != null) {
+            panePortDetectorJobs.remove(paneId)
+            existingJob.cancel()
+        }
+        panePortDetectorClients[paneId] = client
+        val guard = currentRuntimeGuardForClient(client)
+        val job = bridgeScope.launch {
             client.outputFor(paneId).collect { event ->
+                if (panePortDetectorClients[paneId] !== client) return@collect
+                if (guard == null || !isCurrentRuntime(guard)) return@collect
                 if (!appActive) return@collect
                 // Issue #877: the UTF-8 decode + 7-regex PortDetector.scan over
                 // the 4 KB tail is the per-`%output` main-thread work that froze
@@ -9257,6 +9283,13 @@ public class TmuxSessionViewModel @Inject constructor(
                 for (candidate in candidates) {
                     confirmAndSurfaceDetectedPort(candidate.port)
                 }
+            }
+        }
+        panePortDetectorJobs[paneId] = job
+        job.invokeOnCompletion {
+            if (panePortDetectorJobs[paneId] === job) {
+                panePortDetectorJobs.remove(paneId)
+                panePortDetectorClients.remove(paneId)
             }
         }
     }
@@ -9370,6 +9403,7 @@ public class TmuxSessionViewModel @Inject constructor(
         paneProducerClients.remove(overflow.paneId) // Issue #959
         paneOutputActivityJobs.remove(overflow.paneId)?.cancel()
         panePortDetectorJobs.remove(overflow.paneId)?.cancel()
+        panePortDetectorClients.remove(overflow.paneId)
         runCatching { existing.terminalState.detachExternalProducer() }
 
         val errored = existing.copy(surfaceError = true)
@@ -9419,6 +9453,7 @@ public class TmuxSessionViewModel @Inject constructor(
         paneProducerClients.remove(paneId) // Issue #959
         paneOutputActivityJobs.remove(paneId)?.cancel()
         panePortDetectorJobs.remove(paneId)?.cancel()
+        panePortDetectorClients.remove(paneId)
         paneInputJobs.remove(paneId)?.cancel()
         paneInputQueues.remove(paneId)?.close()
         runCatching { existing.terminalState.detachExternalProducer() }
@@ -12208,6 +12243,12 @@ public class TmuxSessionViewModel @Inject constructor(
     @androidx.annotation.VisibleForTesting
     internal fun attachmentWaitWouldRedialForTest(): Boolean = !isAttachmentLeaseWarm()
 
+    @androidx.annotation.VisibleForTesting
+    internal fun markActiveLeaseWarmForTest() {
+        val target = activeTarget ?: connectingTarget ?: return
+        liveLeaseKeys.add(target.toSshLeaseTarget().leaseKey)
+    }
+
     /**
      * EPIC #687 slice 3 / #785: true when a connect/reconnect attempt is already in
      * flight, so the attach wait must not kick another [reconnect] on top of it.
@@ -13866,15 +13907,88 @@ public class TmuxSessionViewModel @Inject constructor(
                             "pane" to paneId,
                             "bytes" to batch.bytes.size,
                         )
-                        runCatching { sendInputBytesToPane(targetClient, paneId, batch.bytes) }
-                            .onSuccess {
-                                newQueue.recordSent(batch)
-                            }
+                        sendDequeuedInputBatch(
+                            client = targetClient,
+                            paneId = paneId,
+                            batch = batch,
+                            queue = newQueue,
+                        )
                     }
                 }
             }
         }
         return TmuxPaneInputStream(queue)
+    }
+
+    private suspend fun sendDequeuedInputBatch(
+        client: TmuxClient,
+        paneId: String,
+        batch: TmuxPaneInputBatch,
+        queue: TmuxPaneInputQueue,
+    ) {
+        var lastFailure: Throwable? = null
+        repeat(TMUX_INPUT_SEND_MAX_ATTEMPTS) { attempt ->
+            if (attempt > 0) delay(TMUX_INPUT_SEND_RETRY_DELAY_MS)
+            val currentClient = clientRef
+            if (client !== currentClient && !client.disconnected.value) {
+                DiagnosticEvents.record(
+                    "connection",
+                    "pane_input_send_abandoned",
+                    "pane" to paneId,
+                    "bytes" to batch.bytes.size,
+                    "attempt" to (attempt + 1),
+                    "reason" to "client_superseded",
+                    "clientHash" to System.identityHashCode(client),
+                    "currentClientHash" to currentClient?.let { System.identityHashCode(it) },
+                )
+                return
+            }
+            val outcome = runCatching { sendInputBytesToPane(client, paneId, batch.bytes) }
+            if (outcome.isSuccess) {
+                queue.recordSent(batch)
+                return
+            }
+            lastFailure = outcome.exceptionOrNull()
+            if (lastFailure is CancellationException) throw lastFailure
+            DiagnosticEvents.record(
+                "connection",
+                "pane_input_send_failed",
+                "pane" to paneId,
+                "bytes" to batch.bytes.size,
+                "attempt" to (attempt + 1),
+                "maxAttempts" to TMUX_INPUT_SEND_MAX_ATTEMPTS,
+                "willRetry" to (attempt + 1 < TMUX_INPUT_SEND_MAX_ATTEMPTS),
+                "clientHash" to System.identityHashCode(client),
+                "currentClient" to (client === clientRef),
+                "clientDisconnected" to client.disconnected.value,
+                "exceptionClass" to lastFailure?.javaClass?.simpleName,
+                "message" to lastFailure?.message,
+            )
+        }
+        val failure = lastFailure
+        Log.w(
+            ISSUE_145_RECONNECT_TAG,
+            "tmux-pane-input-send-failed pane=$paneId bytes=${batch.bytes.size} " +
+                "clientCurrent=${client === clientRef} clientDisconnected=${client.disconnected.value}",
+            failure,
+        )
+        if (client === clientRef) {
+            handlePassiveClientDisconnect(
+                client = client,
+                disconnectEvent = TmuxDisconnectEvent(
+                    reason = if (client.disconnected.value) {
+                        TmuxDisconnectReason.ReaderEof
+                    } else {
+                        TmuxDisconnectReason.ReaderException
+                    },
+                    source = "pane_input_send",
+                    intent = "input_send_failure",
+                    commandKind = "send-keys",
+                    exceptionClass = failure?.javaClass?.simpleName,
+                    message = failure?.message,
+                ),
+            )
+        }
     }
 
     private suspend fun sendInputBytesToPane(
@@ -16915,6 +17029,8 @@ internal const val LIST_PANES_FIELD_SEPARATOR: String = "|PS|"
 internal const val TMUX_INPUT_MAX_PENDING_BYTES: Int = 64 * 1024
 internal const val TMUX_INPUT_MAX_BATCH_BYTES: Int = 4 * 1024
 internal const val TMUX_INPUT_CHUNK_BYTES: Int = 512
+internal const val TMUX_INPUT_SEND_MAX_ATTEMPTS: Int = 2
+internal const val TMUX_INPUT_SEND_RETRY_DELAY_MS: Long = 150L
 internal const val TMUX_PASTE_BODY_CHUNK_BYTES: Int = BracketedPaste.BODY_CHUNK_BYTES
 internal const val TMUX_INPUT_MAX_PENDING_CHUNKS: Int =
     TMUX_INPUT_MAX_PENDING_BYTES / TMUX_INPUT_CHUNK_BYTES - 1

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -128,7 +128,6 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.channels.trySendBlocking
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -2071,6 +2070,7 @@ public class TmuxSessionViewModel @Inject constructor(
     private val portDetector: PortDetector = PortDetector()
     private val panePortDetectorJobs: MutableMap<String, Job> = ConcurrentHashMap()
     private val panePortDetectorClients: MutableMap<String, TmuxClient> = ConcurrentHashMap()
+    private val panePortDetectorGenerations: MutableMap<String, Long> = ConcurrentHashMap()
     private val scannedConversationPortEventKeys: MutableSet<String> =
         ConcurrentHashMap.newKeySet()
 
@@ -3450,7 +3450,39 @@ public class TmuxSessionViewModel @Inject constructor(
         val target = activeTarget ?: return false
         val client = clientRef ?: return false
         val session = sessionRef ?: return false
-        if (client.disconnected.value) return false
+        if (client.disconnected.value) {
+            Log.w(
+                ISSUE_235_LIFECYCLE_TAG,
+                "tmux-post-grace-held-foreground-disconnected-schedule-reconnect " +
+                    "generation=$connectGeneration " + targetLogFields(target),
+            )
+            DiagnosticEvents.record(
+                "connection",
+                "foreground_reattach",
+                "source" to "app_lifecycle",
+                "outcome" to "post_grace_hold_disconnected_reconnect",
+                "cause" to "session_foreground_service",
+                "trigger" to TmuxConnectTrigger.LifecycleReattach.logValue,
+                "generation" to connectGeneration,
+                "hostId" to target.hostId,
+                "host" to target.host,
+                "port" to target.port,
+                "user" to target.user,
+                "session" to target.sessionName,
+                "clientHash" to System.identityHashCode(client),
+            )
+            unregisterCurrentClient()
+            scheduleAutoReconnect(
+                target = target,
+                reason = "Session connection was lost while PocketShell was backgrounded.",
+                trigger = TmuxConnectTrigger.LifecycleReattach,
+                diagnosticFields = arrayOf(
+                    "source" to "post_grace_session_hold",
+                    "clientDisconnected" to true,
+                ),
+            )
+            return true
+        }
 
         Log.i(
             ISSUE_235_LIFECYCLE_TAG,
@@ -5133,6 +5165,7 @@ public class TmuxSessionViewModel @Inject constructor(
         panePortDetectorJobs.values.forEach { it.cancel() }
         panePortDetectorJobs.clear()
         panePortDetectorClients.clear()
+        panePortDetectorGenerations.clear()
         paneSurfaceRecoveryTimestamps.clear()
         paneAgentJobs.values.forEach { it.cancel() }
         paneAgentJobs.clear()
@@ -5247,6 +5280,10 @@ public class TmuxSessionViewModel @Inject constructor(
         // never trusts a stale binding.
         paneProducerClients.clear()
         paneOutputActivityJobs.clear()
+        panePortDetectorJobs.values.forEach { it.cancel() }
+        panePortDetectorJobs.clear()
+        panePortDetectorClients.clear()
+        panePortDetectorGenerations.clear()
         paneInputQueues.clear()
         paneInputQueues.putAll(runtime.paneInputQueues)
         paneInputJobs.clear()
@@ -9047,6 +9084,7 @@ public class TmuxSessionViewModel @Inject constructor(
                     paneOutputActivityJobs.remove(p.paneId)?.cancel()
                     panePortDetectorJobs.remove(p.paneId)?.cancel()
                     panePortDetectorClients.remove(p.paneId)
+                    panePortDetectorGenerations.remove(p.paneId)
                     paneInputJobs.remove(p.paneId)?.cancel()
                     paneInputQueues.remove(p.paneId)?.close()
                     existing.terminalState.detachExternalProducer()
@@ -9142,6 +9180,7 @@ public class TmuxSessionViewModel @Inject constructor(
             // Issue #448: stop the new-port detector for a removed pane.
             panePortDetectorJobs.remove(paneId)?.cancel()
             panePortDetectorClients.remove(paneId)
+            panePortDetectorGenerations.remove(paneId)
             paneAgentJobs.remove(paneId)?.cancel()
             conversationLoadWatchdogJobs.remove(paneId)?.cancel()
             paneAgentTailGenerations.remove(paneId)
@@ -9221,6 +9260,7 @@ public class TmuxSessionViewModel @Inject constructor(
             paneOutputActivityJobs.remove(paneId)?.cancel()
             panePortDetectorJobs.remove(paneId)?.cancel()
             panePortDetectorClients.remove(paneId)
+            panePortDetectorGenerations.remove(paneId)
             paneInputJobs.remove(paneId)?.cancel()
             paneInputQueues.remove(paneId)?.close()
             attachTerminalProducerForPane(
@@ -9261,18 +9301,26 @@ public class TmuxSessionViewModel @Inject constructor(
      * and foreground-gated (the flow is only collected while attached).
      */
     private fun startPortDetectionForPane(paneId: String, client: TmuxClient) {
+        val guard = currentRuntimeGuardForClient(client) ?: return
         val existingJob = panePortDetectorJobs[paneId]
-        if (existingJob?.isActive == true && panePortDetectorClients[paneId] === client) return
+        if (
+            existingJob?.isActive == true &&
+            panePortDetectorClients[paneId] === client &&
+            panePortDetectorGenerations[paneId] == guard.generation
+        ) {
+            return
+        }
         if (existingJob != null) {
             panePortDetectorJobs.remove(paneId)
             existingJob.cancel()
         }
         panePortDetectorClients[paneId] = client
-        val guard = currentRuntimeGuardForClient(client)
+        panePortDetectorGenerations[paneId] = guard.generation
         val job = bridgeScope.launch {
             client.outputFor(paneId).collect { event ->
                 if (panePortDetectorClients[paneId] !== client) return@collect
-                if (guard == null || !isCurrentRuntime(guard)) return@collect
+                if (panePortDetectorGenerations[paneId] != guard.generation) return@collect
+                if (!isCurrentRuntime(guard)) return@collect
                 if (!appActive) return@collect
                 // Issue #877: the UTF-8 decode + 7-regex PortDetector.scan over
                 // the 4 KB tail is the per-`%output` main-thread work that froze
@@ -9290,6 +9338,7 @@ public class TmuxSessionViewModel @Inject constructor(
             if (panePortDetectorJobs[paneId] === job) {
                 panePortDetectorJobs.remove(paneId)
                 panePortDetectorClients.remove(paneId)
+                panePortDetectorGenerations.remove(paneId)
             }
         }
     }
@@ -9404,6 +9453,7 @@ public class TmuxSessionViewModel @Inject constructor(
         paneOutputActivityJobs.remove(overflow.paneId)?.cancel()
         panePortDetectorJobs.remove(overflow.paneId)?.cancel()
         panePortDetectorClients.remove(overflow.paneId)
+        panePortDetectorGenerations.remove(overflow.paneId)
         runCatching { existing.terminalState.detachExternalProducer() }
 
         val errored = existing.copy(surfaceError = true)
@@ -9454,6 +9504,7 @@ public class TmuxSessionViewModel @Inject constructor(
         paneOutputActivityJobs.remove(paneId)?.cancel()
         panePortDetectorJobs.remove(paneId)?.cancel()
         panePortDetectorClients.remove(paneId)
+        panePortDetectorGenerations.remove(paneId)
         paneInputJobs.remove(paneId)?.cancel()
         paneInputQueues.remove(paneId)?.close()
         runCatching { existing.terminalState.detachExternalProducer() }
@@ -13907,12 +13958,15 @@ public class TmuxSessionViewModel @Inject constructor(
                             "pane" to paneId,
                             "bytes" to batch.bytes.size,
                         )
-                        sendDequeuedInputBatch(
+                        val sent = sendDequeuedInputBatch(
                             client = targetClient,
                             paneId = paneId,
                             batch = batch,
                             queue = newQueue,
                         )
+                        if (!sent) {
+                            delay(TMUX_INPUT_SEND_RETRY_DELAY_MS)
+                        }
                     }
                 }
             }
@@ -13925,7 +13979,7 @@ public class TmuxSessionViewModel @Inject constructor(
         paneId: String,
         batch: TmuxPaneInputBatch,
         queue: TmuxPaneInputQueue,
-    ) {
+    ): Boolean {
         var lastFailure: Throwable? = null
         repeat(TMUX_INPUT_SEND_MAX_ATTEMPTS) { attempt ->
             if (attempt > 0) delay(TMUX_INPUT_SEND_RETRY_DELAY_MS)
@@ -13941,12 +13995,13 @@ public class TmuxSessionViewModel @Inject constructor(
                     "clientHash" to System.identityHashCode(client),
                     "currentClientHash" to currentClient?.let { System.identityHashCode(it) },
                 )
-                return
+                queue.requeueFront(batch)
+                return false
             }
             val outcome = runCatching { sendInputBytesToPane(client, paneId, batch.bytes) }
             if (outcome.isSuccess) {
                 queue.recordSent(batch)
-                return
+                return true
             }
             lastFailure = outcome.exceptionOrNull()
             if (lastFailure is CancellationException) throw lastFailure
@@ -13989,6 +14044,8 @@ public class TmuxSessionViewModel @Inject constructor(
                 ),
             )
         }
+        queue.recordDropped(batch)
+        return true
     }
 
     private suspend fun sendInputBytesToPane(
@@ -15311,10 +15368,12 @@ public class TmuxSessionViewModel @Inject constructor(
         _projectRoots.value = emptyList()
         val producerJobsToJoin = paneProducerJobs.values.toList()
         val outputActivityJobsToJoin = paneOutputActivityJobs.values.toList()
+        val portDetectorJobsToJoin = panePortDetectorJobs.values.toList()
         val agentJobsToJoin = paneAgentJobs.values.toList()
         val inputJobsToJoin = paneInputJobs.values.toList()
         for (job in producerJobsToJoin) job.cancelAndJoin()
         for (job in outputActivityJobsToJoin) job.cancelAndJoin()
+        for (job in portDetectorJobsToJoin) job.cancelAndJoin()
         for (job in agentJobsToJoin) job.cancelAndJoin()
         for (job in inputJobsToJoin) job.cancelAndJoin()
         for ((_, queue) in paneInputQueues) {
@@ -15328,6 +15387,9 @@ public class TmuxSessionViewModel @Inject constructor(
         paneConversationOpenStartedAtMs.clear()
         sessionRecordedKindCache.clear()
         sessionForeignKindGuessCache.clear()
+        panePortDetectorJobs.clear()
+        panePortDetectorClients.clear()
+        panePortDetectorGenerations.clear()
         // Issue #894 (Slice C): drop the durable confirmed-shell verdicts so a
         // different session never inherits a stale shell verdict.
         confirmedShellSessionIds.clear()
@@ -15459,6 +15521,9 @@ public class TmuxSessionViewModel @Inject constructor(
             job.cancel()
         }
         for ((_, job) in paneOutputActivityJobs) {
+            job.cancel()
+        }
+        for ((_, job) in panePortDetectorJobs) {
             job.cancel()
         }
         for ((_, job) in paneAgentJobs) {
@@ -16417,8 +16482,9 @@ internal class TmuxPaneInputQueue(
     private val maxPendingBytes: Int,
     private val maxBatchBytes: Int,
 ) {
-    private val channel = Channel<TmuxPaneInputSegment>(TMUX_INPUT_MAX_PENDING_CHUNKS)
+    private val signal = Channel<Unit>(capacity = 1)
     private val lock = Any()
+    private val pending = ArrayDeque<TmuxPaneInputSegment>()
     private var pendingBytes: Int = 0
     private var totalEnqueuedBytes: Long = 0L
     private var totalSentBytes: Long = 0L
@@ -16430,6 +16496,9 @@ internal class TmuxPaneInputQueue(
     private var maxObservedSendLatencyNs: Long = 0L
 
     fun write(buffer: ByteArray, offset: Int, length: Int) {
+        if (length > maxPendingBytes) {
+            throw IOException("tmux pane input queue write exceeds pending byte budget")
+        }
         var written = 0
         while (written < length) {
             val chunkLength = minOf(maxPendingBytes, TMUX_INPUT_CHUNK_BYTES, length - written)
@@ -16440,19 +16509,25 @@ internal class TmuxPaneInputQueue(
     }
 
     suspend fun takeBatch(): TmuxPaneInputBatch? {
-        val first = channel.receiveCatching().getOrNull() ?: return null
-        onDequeued(first.bytes.size)
+        signal.receiveCatching().getOrNull() ?: return null
+        val first = synchronized(lock) {
+            pending.removeFirstOrNull()
+        } ?: return null
         val out = java.io.ByteArrayOutputStream(maxBatchBytes)
         out.write(first.bytes)
         var chunks = 1
         val firstEnqueuedAtNs = first.enqueuedAtNs
 
         while (out.size() + TMUX_INPUT_CHUNK_BYTES <= maxBatchBytes) {
-            val next = channel.tryReceive().getOrNull() ?: break
-            onDequeued(next.bytes.size)
+            val next = synchronized(lock) {
+                pending.firstOrNull()?.takeIf { out.size() + it.bytes.size <= maxBatchBytes }?.also {
+                    pending.removeFirst()
+                }
+            } ?: break
             out.write(next.bytes)
             chunks += 1
         }
+        signalIfPending()
         return TmuxPaneInputBatch(
             bytes = out.toByteArray(),
             chunks = chunks,
@@ -16461,12 +16536,24 @@ internal class TmuxPaneInputQueue(
     }
 
     fun recordSent(batch: TmuxPaneInputBatch) = synchronized(lock) {
+        pendingBytes -= batch.bytes.size
         totalSentBytes += batch.bytes.size.toLong()
         sentBatchCount += 1
         maxObservedBatchBytes = maxOf(maxObservedBatchBytes, batch.bytes.size)
         maxObservedBatchChunks = maxOf(maxObservedBatchChunks, batch.chunks)
         val latencyNs = System.nanoTime() - batch.firstEnqueuedAtNs
         maxObservedSendLatencyNs = maxOf(maxObservedSendLatencyNs, latencyNs)
+    }
+
+    fun recordDropped(batch: TmuxPaneInputBatch) = synchronized(lock) {
+        pendingBytes -= batch.bytes.size
+    }
+
+    fun requeueFront(batch: TmuxPaneInputBatch) {
+        synchronized(lock) {
+            pending.addFirst(TmuxPaneInputSegment(batch.bytes, batch.firstEnqueuedAtNs))
+        }
+        signal.trySend(Unit)
     }
 
     fun snapshot(): TmuxInputStressMetrics = synchronized(lock) {
@@ -16483,31 +16570,43 @@ internal class TmuxPaneInputQueue(
     }
 
     fun close() {
-        channel.close()
+        signal.close()
     }
 
     private fun enqueue(bytes: ByteArray) {
         val segment = TmuxPaneInputSegment(bytes, System.nanoTime())
         synchronized(lock) {
+            if (pendingBytes + bytes.size > maxPendingBytes) {
+                throw IOException("tmux pane input queue pending byte budget exceeded")
+            }
             pendingBytes += bytes.size
             totalEnqueuedBytes += bytes.size.toLong()
+            pending.addLast(segment)
             maxObservedPendingBytes = maxOf(maxObservedPendingBytes, pendingBytes)
             maxObservedPendingChunks = maxOf(
                 maxObservedPendingChunks,
                 (pendingBytes + maxBatchBytes - 1) / maxBatchBytes,
             )
         }
-        val result = channel.trySendBlocking(segment)
+        val result = signal.trySend(Unit)
+        if (result.isFailure && result.exceptionOrNull() == null) {
+            return
+        }
         if (result.isFailure) {
-            onDequeued(bytes.size)
+            synchronized(lock) {
+                if (pending.remove(segment)) {
+                    pendingBytes -= bytes.size
+                    totalEnqueuedBytes -= bytes.size.toLong()
+                }
+            }
             throw IOException("tmux pane input queue is closed")
         }
     }
 
-    private fun onDequeued(bytes: Int) = synchronized(lock) {
-        pendingBytes -= bytes
+    private fun signalIfPending() {
+        val hasPending = synchronized(lock) { pending.isNotEmpty() }
+        if (hasPending) signal.trySend(Unit)
     }
-
 }
 
 /**

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -392,17 +392,9 @@ public class TmuxSessionViewModel @Inject constructor(
      * `commandTimeoutMs` (10 s) so a wedged-but-alive control channel makes the
      * seed surface a best-effort failure FAST and fall through to the blank
      * watchdog on the still-live transport, instead of the (now off-Main, but
-     * still bounded) seed parking for the full 10 s. NOT a constructor parameter,
-     * for the same Hilt-graph reason as the other timeout seams; a unit test
-     * shrinks it via [setSeedCaptureTimeoutForTest] to assert the fall-through
-     * deterministically.
+     * still bounded) seed parking for the full 10 s.
      */
-    private var seedCaptureTimeoutMs: Long = SEED_CAPTURE_TIMEOUT_MS
-
-    @androidx.annotation.VisibleForTesting
-    internal fun setSeedCaptureTimeoutForTest(timeoutMs: Long) {
-        seedCaptureTimeoutMs = timeoutMs
-    }
+    private val seedCaptureTimeoutMs: Long = SEED_CAPTURE_TIMEOUT_MS
 
     /**
      * Issue #576 (Slice A of #792): the dispatcher the structural reconcile's
@@ -1667,14 +1659,9 @@ public class TmuxSessionViewModel @Inject constructor(
     private var attachPanesReadyTimeoutMs: Long = ATTACH_PANES_READY_TIMEOUT_MS
     private var activeAttachMilestone: AttachMilestone? = null
 
-    // Issue #886: the blank-watchdog tick bound, injectable so a unit test can
-    // exhaust it quickly (the stuck-attach-reveal safety net). Defaults to the
-    // production constant — production behavior is unchanged.
-    private var connectedBlankWatchdogMaxTicks: Int = CONNECTED_BLANK_WATCHDOG_MAX_TICKS
-
-    internal fun setConnectedBlankWatchdogMaxTicksForTest(maxTicks: Int) {
-        connectedBlankWatchdogMaxTicks = maxTicks
-    }
+    // Issue #886: the blank-watchdog tick bound for the stuck-attach-reveal
+    // safety net.
+    private val connectedBlankWatchdogMaxTicks: Int = CONNECTED_BLANK_WATCHDOG_MAX_TICKS
 
     // Issue #886: when false, [armConnectedBlankWatchdog] is suppressed entirely.
     // Used ONLY by the watchdog-in-isolation characterization tests that manually
@@ -3063,6 +3050,7 @@ public class TmuxSessionViewModel @Inject constructor(
     private var pendingReattach: PendingReattach? = null
     private var pausedAutoReconnect: PausedAutoReconnect? = null
     private var backgroundDetachJob: Job? = null
+    private var postGraceHeldForegroundProbeJob: Job? = null
     private var lastSuppressedDropDiagnostic: SuppressedDropDiagnostic? = null
 
     // EPIC #687 slice 1c-iv-b-B1 (#738): the `preserveConnectingTarget` computed
@@ -3408,6 +3396,7 @@ public class TmuxSessionViewModel @Inject constructor(
         // predicate — the #685 trap: the controller edge is the trigger, the inline
         // predicate the gate). The inline foreground event arm is no longer
         // consulted (Slice 2a).
+        if (launchPostGraceHeldForegroundProbeIfNeeded()) return
         connectionManager.observeForeground()
         dispatchPostGraceForegroundArmIfPending()
         // The controller's single grace predicate decided reattach-vs-reconnect:
@@ -3431,6 +3420,100 @@ public class TmuxSessionViewModel @Inject constructor(
     private fun dispatchPostGraceForegroundArmIfPending() {
         if (pendingReattach == null && pausedAutoReconnect == null) return
         onControllerForegrounded()
+    }
+
+    /**
+     * Issue #1021 follow-up: when the foreground service preserved a live terminal past
+     * the App grace deadline, foreground arrives as "post-grace" but there is no
+     * [pendingReattach] to replay because no teardown ran. That must not no-op: probe the
+     * held control channel, reseed if it is alive, or silently re-open the same session if
+     * the held channel went stale while backgrounded.
+     */
+    private fun launchPostGraceHeldForegroundProbeIfNeeded(): Boolean {
+        if (pendingReattach != null || pausedAutoReconnect != null) return false
+        if (postGraceHeldForegroundProbeJob?.isActive == true) return true
+        if (inlineConnectionStatus !is ConnectionStatus.Connected) return false
+        val target = activeTarget ?: return false
+        val client = clientRef ?: return false
+        val session = sessionRef ?: return false
+        if (client.disconnected.value) return false
+
+        Log.i(
+            ISSUE_235_LIFECYCLE_TAG,
+            "tmux-post-grace-held-foreground-probe generation=$connectGeneration " +
+                targetLogFields(target),
+        )
+        val job = launchContainedTeardown {
+            val verdict = probeRuntimeControlChannel(client, session)
+            val currentTarget = activeTarget
+            if (
+                clientRef !== client ||
+                currentTarget == null ||
+                !sameSessionIdentity(currentTarget, target)
+            ) {
+                return@launchContainedTeardown
+            }
+            ReconnectCauseTrail.record(
+                stage = "foreground_reattach",
+                outcome = "post_grace_hold_probe",
+                cause = "session_foreground_service",
+                trigger = TmuxConnectTrigger.LifecycleReattach.logValue,
+                "hostId" to target.hostId,
+                "generation" to connectGeneration,
+                "probeVerdict" to verdict.name,
+                "clientHash" to System.identityHashCode(client),
+            )
+            DiagnosticEvents.record(
+                "connection",
+                "foreground_reattach",
+                "source" to "app_lifecycle",
+                "outcome" to "post_grace_hold_probe",
+                "cause" to "session_foreground_service",
+                "trigger" to TmuxConnectTrigger.LifecycleReattach.logValue,
+                "generation" to connectGeneration,
+                "hostId" to target.hostId,
+                "host" to target.host,
+                "port" to target.port,
+                "user" to target.user,
+                "session" to target.sessionName,
+                "probeVerdict" to verdict.name,
+            )
+            if (verdict == RuntimeHealthVerdict.HEALTHY) {
+                connectionManager.observeForegroundReattachLive()
+                projectStatusFromController()
+                reseedActivePaneForReattach(
+                    RuntimeRefreshGuard(
+                        generation = connectGeneration,
+                        target = target,
+                        client = client,
+                    ),
+                )
+                return@launchContainedTeardown
+            }
+
+            val recovered = silentlyReconnectTransportAfterPassiveDisconnect(
+                staleClient = client,
+                target = target,
+                timeoutMs = passiveDisconnectGraceMs.coerceAtLeast(1L),
+            )
+            if (!recovered) {
+                scheduleAutoReconnect(
+                    target = target,
+                    reason = "Reattaching to ${target.user}@${target.host}:${target.port}.",
+                    trigger = TmuxConnectTrigger.AutoReconnect,
+                    diagnosticFields = arrayOf(
+                        "originationCause" to "post_grace_session_hold_probe_${verdict.name.lowercase()}",
+                    ),
+                )
+            }
+        }
+        postGraceHeldForegroundProbeJob = job
+        job.invokeOnCompletion {
+            if (postGraceHeldForegroundProbeJob == job) {
+                postGraceHeldForegroundProbeJob = null
+            }
+        }
+        return true
     }
 
     /**
@@ -7452,7 +7535,12 @@ public class TmuxSessionViewModel @Inject constructor(
         if (forceCleanOutageForTest) return false
         val session = sessionRef?.takeIf { it.isConnected } ?: return false
         val startedAtMs = SystemClock.elapsedRealtime()
-        val replacement = createTmuxClient(session, target.sessionName, target.startDirectory)
+        val replacement = createTmuxClient(
+            session,
+            target.sessionName,
+            target.startDirectory,
+            probeServerLiveness = true,
+        )
         return try {
             val ready = withTimeoutOrNull(timeoutMs) {
                 eventsJob?.cancelAndJoin()
@@ -7650,7 +7738,12 @@ public class TmuxSessionViewModel @Inject constructor(
                 val lease = sshLeaseManager.acquire(leaseTarget).getOrThrow()
                 acquiredLease = lease
                 val session = lease.session
-                val newClient = createTmuxClient(session, target.sessionName, target.startDirectory)
+                val newClient = createTmuxClient(
+                    session,
+                    target.sessionName,
+                    target.startDirectory,
+                    probeServerLiveness = true,
+                )
                 replacement = newClient
                 eventsJob?.cancelAndJoin()
                 eventsJob = null
@@ -15185,133 +15278,6 @@ public class TmuxSessionViewModel @Inject constructor(
     private sealed interface RuntimeCacheEviction {
         data object HostWide : RuntimeCacheEviction
         data class TargetRuntime(val key: TmuxRuntimeKey) : RuntimeCacheEviction
-    }
-
-    /**
-     * Issue #178: tear down everything tied to the **tmux client** but
-     * keep the underlying [SshSession] alive so the fast-switch path can
-     * reuse it for a new [TmuxClient].
-     *
-     * Mirrors [closeCurrentConnectionAndJoin] structurally — same
-     * cancel-and-join ordering for the event loop and per-pane jobs to
-     * preserve the issue #151 race-fix — but stops short of
-     * `sessionRef.close()`. We deliberately ALSO leave [sessionRef]
-     * populated; the caller ([runFastSessionSwitch]) consumes it
-     * directly. We DO clear [activeTarget] / [registeredHostId] /
-     * `remoteColumns`/`remoteRows` because the new tmux client will
-     * register a fresh entry, take ownership of the next resize, and
-     * needs a clean slate — same lifecycle reset the slow path uses.
-     *
-     * Bridge / pane / agent / input scratch state is cleared identically
-     * to the slow path: the new tmux session will report its own panes
-     * via `%window-add` and the bootstrap `list-panes`, so retaining
-     * stale per-pane jobs from the previous session would only leak
-     * coroutines onto the now-dead pane IDs.
-     */
-    private suspend fun closeCurrentClientKeepSession() {
-        eventsJob?.cancelAndJoin()
-        eventsJob = null
-        outputOverflowJob?.cancelAndJoin()
-        outputOverflowJob = null
-        passiveDisconnectGraceJob?.cancelAndJoin()
-        passiveDisconnectGraceJob = null
-        disconnectedJob?.cancelAndJoin()
-        disconnectedJob = null
-        projectRootsJob?.cancelAndJoin()
-        projectRootsJob = null
-        _projectRoots.value = emptyList()
-        val producerJobsToJoin = paneProducerJobs.values.toList()
-        val outputActivityJobsToJoin = paneOutputActivityJobs.values.toList()
-        val agentJobsToJoin = paneAgentJobs.values.toList()
-        val inputJobsToJoin = paneInputJobs.values.toList()
-        for (job in producerJobsToJoin) job.cancelAndJoin()
-        for (job in outputActivityJobsToJoin) job.cancelAndJoin()
-        for (job in agentJobsToJoin) job.cancelAndJoin()
-        for (job in inputJobsToJoin) job.cancelAndJoin()
-        for ((_, queue) in paneInputQueues) {
-            queue.close()
-        }
-        paneAgentJobs.clear()
-        paneAgentTailGenerations.clear()
-        paneAgentInputs.clear()
-        paneAgentNullDetections.clear()
-        paneLastOutputAtMs.clear()
-        paneConversationOpenStartedAtMs.clear()
-        sessionRecordedKindCache.clear()
-        sessionForeignKindGuessCache.clear()
-        // Issue #894 (Slice C): drop the durable confirmed-shell verdicts so a
-        // different session never inherits a stale shell verdict.
-        confirmedShellSessionIds.clear()
-        _confirmedShellPaneIds.value = emptySet()
-        paneInputJobs.clear()
-        paneInputQueues.clear()
-        _agentConversations.value = emptyMap()
-        paneProducerJobs.clear()
-        // Issue #959: drop stale per-pane client bindings so a fresh reconnect
-        // re-binds every reused pane's producer/input to the new client.
-        paneProducerClients.clear()
-        paneOutputActivityJobs.clear()
-        for ((_, row) in paneRows) {
-            runCatching { row.terminalState.detachExternalProducer() }
-        }
-        paneRows.clear()
-        _panes.value = emptyList()
-        rebuildUnifiedPanes()
-        // Close the tmux -CC channel. This tears down only the SSH
-        // shell channel inside the live [SshSession] — the session
-        // itself stays open for the next [TmuxClient].
-        //
-        // Issue #215: the same orphan-control-client problem the slow
-        // teardown path fixes applies here too — when a same-host
-        // session switch tears down the previous tmux `-CC` channel
-        // without notifying tmux, the previous client lingers in
-        // `tmux list-clients` for the previous session until tmux
-        // notices the SSH shell channel close on its own. Sending
-        // `detach-client` first removes that delay window and matches
-        // the slow path's contract for "PocketShell promises to leave
-        // a clean server when it tears a tmux client down".
-        //
-        // Issue #257 (perf): the previous version `await`ed
-        // [TmuxClient.detachCleanly] here, putting up to a 1s
-        // `detach-client` + reader-EOF round-trip directly on the
-        // session-switch critical path — the new session could not
-        // start attaching until the OLD client had finished detaching.
-        // Each tmux `-CC` client owns its own SSH shell channel
-        // ([SshSession.startShell] opens a fresh channel and closing one
-        // leaves the parent session + sibling channels alive), so the
-        // new client's [TmuxClient.connect] can open its channel
-        // immediately while the old client's clean detach drains in the
-        // background. We launch the detach fire-and-forget on
-        // [viewModelScope] (cancelled with the VM in [onCleared]) and
-        // null [clientRef] right away so [runFastSessionSwitch] proceeds
-        // without waiting. The #215 clean-server contract is preserved —
-        // the detach still runs, just not blocking the user's switch.
-        val previousClient = clientRef
-        clientRef = null
-        orphanDetachJob?.cancel()
-        // Issue #935 R1: contained — the orphan detach runs `detachCleanly()` IO
-        // against the LEAVING client (a transport mid-teardown during the switch).
-        orphanDetachJob = previousClient?.let { client ->
-            launchContainedTeardown {
-                withContext(NonCancellable) {
-                    runCatching { client.detachCleanly() }
-                }
-            }
-        }
-        unregisterCurrentClient()
-        // Intentionally NOT touching [sessionRef] — that is the
-        // contract of this method. The caller will pass the same
-        // session to the next tmux client.
-        activeTarget = null
-        activeAttachMilestone = null
-        // Keep [connectingTarget] — connect() set it to the new
-        // target before invoking us; clearing it here would lose the
-        // intent.
-        // A fresh attach must capture a fresh phone grid and re-run the
-        // size-mismatch check.
-        remoteColumns = 0
-        remoteRows = 0
-        resetControlClientSizeForAttach()
     }
 
     /**

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -13951,7 +13951,19 @@ public class TmuxSessionViewModel @Inject constructor(
                 jobs[paneId] = bridgeScope.launch {
                     while (true) {
                         val batch = newQueue.takeBatch() ?: break
-                        val targetClient = client ?: clientRef ?: continue
+                        val targetClient = client ?: clientRef
+                        if (targetClient == null) {
+                            DiagnosticEvents.record(
+                                "connection",
+                                "pane_input_send_deferred",
+                                "pane" to paneId,
+                                "bytes" to batch.bytes.size,
+                                "reason" to "no_current_client",
+                            )
+                            newQueue.requeueFront(batch)
+                            delay(TMUX_INPUT_SEND_RETRY_DELAY_MS)
+                            continue
+                        }
                         DiagnosticEvents.record(
                             "action",
                             "pane_input_batch",
@@ -15359,6 +15371,10 @@ public class TmuxSessionViewModel @Inject constructor(
         passiveDisconnectGraceJob = null
         eventsJob?.cancelAndJoin()
         eventsJob = null
+        layoutChangeCoalescer?.stop()
+        layoutChangeCoalescer = null
+        layoutCoalescerScope?.cancel()
+        layoutCoalescerScope = null
         outputOverflowJob?.cancelAndJoin()
         outputOverflowJob = null
         disconnectedJob?.cancelAndJoin()
@@ -15429,7 +15445,9 @@ public class TmuxSessionViewModel @Inject constructor(
         // block the teardown. The `runCatching` is belt-and-suspenders
         // — the implementation already swallows transport drops mid-
         // detach.
-        runCatching { clientRef?.detachCleanly() }
+        val toDetach = clientRef
+        connectionTmuxPort.setClient(null)
+        runCatching { toDetach?.detachCleanly() }
         clientRef = null
         unregisterCurrentClient()
         when (cacheEviction) {
@@ -15570,6 +15588,7 @@ public class TmuxSessionViewModel @Inject constructor(
         // [TmuxClient.close] below.
         val toDetach = clientRef
         if (toDetach != null) {
+            connectionTmuxPort.setClient(null)
             runCatching {
                 runBlocking(Dispatchers.IO) {
                     withTimeoutOrNull(SYNC_DETACH_TIMEOUT_MS) {
@@ -16171,6 +16190,13 @@ public class TmuxSessionViewModel @Inject constructor(
     }
 
     private fun classifyPassiveTransportDrop(client: TmuxClient): ConnectionDecision {
+        val disconnectEvent = client.disconnectEvent.value
+        if (
+            disconnectEvent?.reason == TmuxDisconnectReason.ExplicitDetach ||
+            disconnectEvent?.intent == "detach_or_replace"
+        ) {
+            return ConnectionDecision.Ignore
+        }
         // Issue #895 (#766 down-payment): STATUS-AGNOSTIC. The old
         // `inlineConnectionStatus !is Connected -> Ignore` gate swallowed a drop
         // that landed during the `Switching` (Attaching) window — the R1

--- a/app/src/test/java/com/pocketshell/app/BackgroundGraceControllerTest.kt
+++ b/app/src/test/java/com/pocketshell/app/BackgroundGraceControllerTest.kt
@@ -292,6 +292,44 @@ class BackgroundGraceControllerTest {
     }
 
     @Test
+    fun `natural session hold end after held grace elapsed runs the destructive teardown path`() = runTest {
+        val events = mutableListOf<String>()
+        var sessionHoldActive = true
+        val controller = BackgroundGraceController(
+            scope = backgroundScope,
+            graceMillis = graceMillis,
+            onGraceElapsed = {
+                if (sessionHoldActive) {
+                    events += "session:preserve"
+                } else {
+                    events += "tmux:background"
+                    events += "runtime-cache:clear"
+                    events += "ssh:stop"
+                }
+            },
+            onForeground = { resumedWithinGrace ->
+                events += "foreground:$resumedWithinGrace"
+            },
+        )
+
+        controller.onBackground()
+        runCurrent()
+        advanceTimeBy(graceMillis + 1)
+        runCurrent()
+
+        assertEquals(listOf("session:preserve"), events)
+
+        sessionHoldActive = false
+        controller.onSessionHoldStopped(source = "session_service", trigger = "hold_ended")
+        runCurrent()
+
+        assertEquals(
+            listOf("session:preserve", "tmux:background", "runtime-cache:clear", "ssh:stop"),
+            events,
+        )
+    }
+
+    @Test
     fun `a second background during the window does not restart the deadline`() = runTest {
         val events = mutableListOf<String>()
         val controller = controller(events)

--- a/app/src/test/java/com/pocketshell/app/BackgroundGraceControllerTest.kt
+++ b/app/src/test/java/com/pocketshell/app/BackgroundGraceControllerTest.kt
@@ -72,7 +72,37 @@ class BackgroundGraceControllerTest {
     }
 
     @Test
-    fun `diagnostics distinguish within-grace foreground from elapsed teardown`() = runTest {
+    fun `foreground after deadline runs elapsed action before foreground when timer has not resumed`() = runTest {
+        val events = mutableListOf<String>()
+        val controller = controller(events)
+
+        controller.onBackground()
+        runCurrent()
+        advanceTimeBy(graceMillis)
+
+        assertFalse(
+            "deadline has passed even though the timer continuation has not resumed",
+            controller.isGracePendingForTest(),
+        )
+
+        controller.onForeground()
+        runCurrent()
+
+        assertEquals(
+            listOf("teardown", "foreground:resumedWithinGrace=false"),
+            events,
+        )
+
+        runCurrent()
+        assertEquals(
+            "the cancelled timer must not run the elapsed action a second time",
+            listOf("teardown", "foreground:resumedWithinGrace=false"),
+            events,
+        )
+    }
+
+    @Test
+    fun `diagnostics distinguish within-grace foreground from elapsed deadline`() = runTest {
         val diagnostics = installRecordingDiagnosticSink()
         try {
             val controller = BackgroundGraceController(
@@ -113,7 +143,8 @@ class BackgroundGraceControllerTest {
             runCurrent()
 
             val elapsed = diagnostics.eventsNamed("background_grace_elapsed").single()
-            assertEquals(true, elapsed.fields["teardown"])
+            assertEquals(true, elapsed.fields["deadlineElapsed"])
+            assertEquals(null, elapsed.fields["teardown"])
             assertEquals("grace_timeout", elapsed.fields["trigger"])
             val postGraceForeground = diagnostics.eventsNamed("background_grace_foreground").last()
             assertEquals(false, postGraceForeground.fields["resumedWithinGrace"])
@@ -121,7 +152,7 @@ class BackgroundGraceControllerTest {
             val allGraceTrail = diagnostics.eventsNamed("cause_trail")
                 .filter { it.fields["stage"] == "background_grace" }
             assertEquals(
-                listOf("start", "foreground_preserved", "start", "elapsed_teardown", "foreground_reattach_needed"),
+                listOf("start", "foreground_preserved", "start", "elapsed", "foreground_reattach_needed"),
                 allGraceTrail.map { it.fields["outcome"] },
             )
             assertEquals("post_grace", allGraceTrail.last().fields["cause"])
@@ -1338,6 +1369,7 @@ class BackgroundGraceControllerTest {
             onForeground = { resumedWithinGrace ->
                 events += "foreground:resumedWithinGrace=$resumedWithinGrace"
             },
+            nowMillis = { currentTime },
         )
 
     private fun terminalNetworkChange(

--- a/app/src/test/java/com/pocketshell/app/cards/SessionCardRenderersTest.kt
+++ b/app/src/test/java/com/pocketshell/app/cards/SessionCardRenderersTest.kt
@@ -65,6 +65,28 @@ class SessionCardRenderersTest {
     }
 
     @Test
+    fun cardFeedChipCountsChecklistAndUnknownCards() {
+        val state = cardFeedChipState(
+            listOf(
+                SessionCardsRemoteSource.ChecklistCard(
+                    id = "c", title = null, createdAt = null, updatedAt = null,
+                    items = listOf(SessionCardsRemoteSource.ChecklistItem("i", "Build")),
+                    checkedIds = emptySet(),
+                ),
+                SessionCardsRemoteSource.UnknownCard(
+                    id = "future",
+                    type = "approval",
+                    title = "Approve?",
+                    createdAt = null,
+                    updatedAt = null,
+                ),
+            ),
+        )
+
+        assertEquals(SessionCardFeedChipUiState(cardCount = 2), state)
+    }
+
+    @Test
     fun cardFeedChipNullForEmptyFeed() {
         assertTrue(cardFeedChipState(emptyList()) == null)
     }

--- a/app/src/test/java/com/pocketshell/app/composer/PromptAttachmentStagerTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/PromptAttachmentStagerTest.kt
@@ -151,6 +151,25 @@ class PromptAttachmentStagerTest {
         assertTrue(result.exceptionOrNull() is SshException)
     }
 
+    @Test
+    fun uriBytesAreMaterializedBeforeRemoteDirectoryCommand() = runTest {
+        val source = File(cacheDir, "before-ssh.png").apply {
+            writeBytes(ByteArray(64) { it.toByte() })
+        }
+        val session = FakeStagingSshSession(
+            onExec = { source.delete() },
+        )
+
+        val result = newStager().stage(session, "host-7", listOf(Uri.fromFile(source)))
+
+        assertTrue(result.isSuccess)
+        assertEquals(1, session.uploadedRemotePaths.size)
+        assertTrue(
+            "source URI file is gone before upload; success proves the temp copy was made first",
+            !source.exists(),
+        )
+    }
+
     /**
      * Minimal [SshSession] fake: records uploads, fails the upload at a
      * configured index (or all when negative), and reports the attachment
@@ -158,6 +177,7 @@ class PromptAttachmentStagerTest {
      */
     private class FakeStagingSshSession(
         private val failOnUploadIndex: Int = Int.MIN_VALUE,
+        private val onExec: () -> Unit = {},
     ) : SshSession {
         val uploadedRemotePaths = mutableListOf<String>()
         private var uploadCalls = 0
@@ -165,8 +185,10 @@ class PromptAttachmentStagerTest {
 
         override val isConnected: Boolean get() = !closed
 
-        override suspend fun exec(command: String): ExecResult =
-            ExecResult(stdout = "", stderr = "", exitCode = 0)
+        override suspend fun exec(command: String): ExecResult {
+            onExec()
+            return ExecResult(stdout = "", stderr = "", exitCode = 0)
+        }
 
         override fun tail(path: String, onLine: (String) -> Unit): Job =
             Job().apply { complete() }

--- a/app/src/test/java/com/pocketshell/app/composer/PromptComposerViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/PromptComposerViewModelTest.kt
@@ -16,12 +16,10 @@ import com.pocketshell.core.voice.WhisperClient
 import com.pocketshell.core.voice.WhisperException
 import java.util.concurrent.atomic.AtomicReference
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancelAndJoin
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
@@ -29,8 +27,6 @@ import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.withContext
-import kotlinx.coroutines.yield
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -3103,40 +3099,39 @@ class PromptComposerViewModelTest {
         }
     }
 
-    private suspend fun yieldToRealDispatchers() {
-        withContext(Dispatchers.IO) {
-            yield()
+    private suspend fun kotlinx.coroutines.test.TestScope.advanceSchedulerUntil(
+        predicate: suspend () -> Boolean,
+        maxTicks: Int = 1_000,
+    ): Boolean {
+        repeat(maxTicks) {
+            advanceUntilIdle()
+            if (predicate()) return true
+            runCurrent()
+            if (predicate()) return true
+            advanceTimeBy(1L)
+            runCurrent()
+            if (predicate()) return true
         }
+        advanceUntilIdle()
+        return predicate()
     }
 
     private suspend fun kotlinx.coroutines.test.TestScope.waitForSidecarsCleared(
         store: OutboundAttachmentSidecarStore,
         outboundItemId: String,
     ) {
-        repeat(100) {
-            advanceUntilIdle()
-            if (store.refsFor(outboundItemId).isEmpty()) return
-            runCurrent()
-            if (store.refsFor(outboundItemId).isEmpty()) return
-            yieldToRealDispatchers()
-        }
-        advanceUntilIdle()
-        assertTrue(store.refsFor(outboundItemId).isEmpty())
+        assertTrue(
+            advanceSchedulerUntil(predicate = { store.refsFor(outboundItemId).isEmpty() }),
+        )
     }
 
     private suspend fun kotlinx.coroutines.test.TestScope.waitForSendCount(
         sent: List<PromptComposerViewModel.SendRequest>,
         count: Int,
     ) {
-        repeat(100) {
-            advanceUntilIdle()
-            if (sent.size >= count) return
-            runCurrent()
-            if (sent.size >= count) return
-            yieldToRealDispatchers()
-        }
-        advanceUntilIdle()
-        assertEquals(count, sent.size)
+        assertTrue(
+            advanceSchedulerUntil(predicate = { sent.size >= count }),
+        )
     }
 
     @Test
@@ -6286,22 +6281,14 @@ class PromptComposerViewModelTest {
     // the safety net.
 
     /**
-     * The sidecar store does real `Dispatchers.IO` file work + the dispatch is
-     * launched on viewModelScope, so `advanceUntilIdle` alone cannot observe the
-     * settled outcome. Drive the virtual clock AND yield to the real IO threads
-     * until [predicate] holds (or the bound elapses).
+     * The sidecar dispatch resumes on the test Main dispatcher after any store
+     * work completes. Drive the `runTest` scheduler in bounded virtual-time ticks
+     * until [predicate] holds.
      */
     private suspend fun kotlinx.coroutines.test.TestScope.settleUntil(
         predicate: () -> Boolean,
     ) {
-        repeat(1_000) {
-            advanceUntilIdle()
-            if (predicate()) return
-            runCurrent()
-            if (predicate()) return
-            yieldToRealDispatchers()
-        }
-        advanceUntilIdle()
+        advanceSchedulerUntil(predicate = { predicate() })
     }
 
     /**

--- a/app/src/test/java/com/pocketshell/app/composer/PromptComposerViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/PromptComposerViewModelTest.kt
@@ -16,6 +16,7 @@ import com.pocketshell.core.voice.WhisperClient
 import com.pocketshell.core.voice.WhisperException
 import java.util.concurrent.atomic.AtomicReference
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.awaitCancellation
@@ -27,6 +28,8 @@ import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.yield
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -3099,6 +3102,14 @@ class PromptComposerViewModelTest {
         }
     }
 
+    /**
+     * The sidecar store does real `Dispatchers.IO` file work (see
+     * [OutboundAttachmentSidecarStore]) and the dispatch resumes back on the
+     * test Main dispatcher only AFTER that IO completes — so driving the virtual
+     * clock alone never observes the settled outcome. Each tick must also yield
+     * to the real IO threads so the store work can make progress before the next
+     * scheduler advance.
+     */
     private suspend fun kotlinx.coroutines.test.TestScope.advanceSchedulerUntil(
         predicate: suspend () -> Boolean,
         maxTicks: Int = 1_000,
@@ -3111,9 +3122,16 @@ class PromptComposerViewModelTest {
             advanceTimeBy(1L)
             runCurrent()
             if (predicate()) return true
+            yieldToRealDispatchers()
         }
         advanceUntilIdle()
         return predicate()
+    }
+
+    private suspend fun yieldToRealDispatchers() {
+        withContext(Dispatchers.IO) {
+            yield()
+        }
     }
 
     private suspend fun kotlinx.coroutines.test.TestScope.waitForSidecarsCleared(

--- a/app/src/test/java/com/pocketshell/app/fileexplorer/FileExplorerLeaseTest.kt
+++ b/app/src/test/java/com/pocketshell/app/fileexplorer/FileExplorerLeaseTest.kt
@@ -23,6 +23,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import java.io.File
+import java.io.ByteArrayInputStream
 import java.io.InputStream
 
 /**
@@ -121,6 +122,34 @@ class FileExplorerLeaseTest {
         leaseManager.close()
     }
 
+    @Test
+    fun transfersUsePurposeLeaseSeparateFromBrowseLease() = runBlocking {
+        val session = FakeSshSession()
+        val connector = RecordingConnector(session)
+        val leaseManager = SshLeaseManager(
+            connector = connector,
+            idleTtlMillis = 30_000L,
+        )
+        val vm = FileExplorerViewModel(leaseManager)
+
+        vm.start(request("/srv"))
+        val ready = vm.state.awaitReady()
+
+        vm.uploadFile("note.txt", 4L) { ByteArrayInputStream(byteArrayOf(1, 2, 3, 4)) }
+        vm.transfer.awaitSuccess()
+        vm.downloadFile(ready.entries.first { it.type == RemoteEntry.Type.FILE }) { }
+        vm.transfer.awaitSuccess()
+
+        assertEquals(
+            listOf(
+                "1:/tmp/key",
+                "1:/tmp/key|purpose=${FileExplorerViewModel.LEASE_PURPOSE_TRANSFER}",
+            ),
+            connector.credentialIds,
+        )
+        leaseManager.close()
+    }
+
     private suspend fun StateFlow<FileExplorerUiState>.awaitReady(
         predicate: (FileExplorerUiState.Ready) -> Boolean = { true },
     ): FileExplorerUiState.Ready {
@@ -131,6 +160,16 @@ class FileExplorerLeaseTest {
             kotlinx.coroutines.delay(20)
         }
         error("explorer never reached the expected Ready state; was ${value}")
+    }
+
+    private suspend fun StateFlow<FileTransferState>.awaitSuccess(): FileTransferState.Success {
+        val deadline = System.currentTimeMillis() + 10_000
+        while (System.currentTimeMillis() < deadline) {
+            val s = value
+            if (s is FileTransferState.Success) return s
+            kotlinx.coroutines.delay(20)
+        }
+        error("transfer never reached Success; was ${value}")
     }
 
     private fun request(startDir: String) = FileExplorerViewModel.Request(
@@ -168,6 +207,17 @@ class FileExplorerLeaseTest {
         override suspend fun connect(target: SshLeaseTarget): Result<SshSession> {
             val session = sessions.getOrNull(connectCount) ?: sessions.last()
             connectCount += 1
+            return Result.success(session)
+        }
+    }
+
+    private class RecordingConnector(
+        private val session: FakeSshSession,
+    ) : SshLeaseConnector {
+        val credentialIds: MutableList<String> = mutableListOf()
+
+        override suspend fun connect(target: SshLeaseTarget): Result<SshSession> {
+            credentialIds += target.leaseKey.credentialId
             return Result.success(session)
         }
     }
@@ -226,14 +276,17 @@ class FileExplorerLeaseTest {
 
         override fun startShell(): SshShell = error("not used")
 
-        override suspend fun uploadFile(file: File, remotePath: String): String = error("not used")
+        override suspend fun uploadFile(file: File, remotePath: String): String = remotePath
 
         override suspend fun uploadStream(
             input: InputStream,
             length: Long,
             name: String,
             remotePath: String,
-        ): String = error("not used")
+        ): String = remotePath
+
+        override suspend fun downloadFile(remotePath: String, maxBytes: Long): ByteArray =
+            byteArrayOf(1, 2, 3)
 
         override fun close() {
             closed = true

--- a/app/src/test/java/com/pocketshell/app/fileexplorer/FileExplorerLeaseTest.kt
+++ b/app/src/test/java/com/pocketshell/app/fileexplorer/FileExplorerLeaseTest.kt
@@ -150,6 +150,32 @@ class FileExplorerLeaseTest {
         leaseManager.close()
     }
 
+    @Test
+    fun downloadWritesDestinationAfterTransferLeaseIsReleased() = runBlocking {
+        val browseSession = FakeSshSession()
+        val transferSession = FakeSshSession()
+        val leaseManager = SshLeaseManager(
+            connector = SequenceConnector(listOf(browseSession, transferSession)),
+            idleTtlMillis = 0L,
+        )
+        val vm = FileExplorerViewModel(leaseManager)
+
+        vm.start(request("/srv"))
+        val ready = vm.state.awaitReady()
+        var writeSawReleasedTransfer = false
+
+        vm.downloadFile(ready.entries.first { it.type == RemoteEntry.Type.FILE }) {
+            writeSawReleasedTransfer = transferSession.closed
+        }
+        vm.transfer.awaitSuccess()
+
+        assertTrue(
+            "SAF destination write must run after the transfer lease is released",
+            writeSawReleasedTransfer,
+        )
+        leaseManager.close()
+    }
+
     private suspend fun StateFlow<FileExplorerUiState>.awaitReady(
         predicate: (FileExplorerUiState.Ready) -> Boolean = { true },
     ): FileExplorerUiState.Ready {

--- a/app/src/test/java/com/pocketshell/app/fileexplorer/FileExplorerLeaseTest.kt
+++ b/app/src/test/java/com/pocketshell/app/fileexplorer/FileExplorerLeaseTest.kt
@@ -4,6 +4,7 @@ import com.pocketshell.app.hosts.MainDispatcherRule
 import com.pocketshell.core.ssh.ExecResult
 import com.pocketshell.core.ssh.RemoteEntry
 import com.pocketshell.core.ssh.RemoteListing
+import com.pocketshell.core.ssh.SshExecTimeoutException
 import com.pocketshell.core.ssh.SshLeaseConnector
 import com.pocketshell.core.ssh.SshLeaseManager
 import com.pocketshell.core.ssh.SshLeaseTarget
@@ -97,6 +98,29 @@ class FileExplorerLeaseTest {
         leaseManager.close()
     }
 
+    @Test
+    fun browseRetriesOnceWhenLeaseExecTimesOutAsStale() = runBlocking {
+        val wedged = FakeSshSession(
+            listDirectoryFailure = SshExecTimeoutException("ls", 30_000L),
+        )
+        val healthy = FakeSshSession()
+        val connector = SequenceConnector(listOf(wedged, healthy))
+        val leaseManager = SshLeaseManager(
+            connector = connector,
+            idleTtlMillis = 30_000L,
+        )
+        val vm = FileExplorerViewModel(leaseManager)
+
+        vm.start(request("/srv"))
+        val ready = vm.state.awaitReady()
+
+        assertEquals("/srv", ready.currentPath)
+        assertEquals("stale timeout must evict and retry on a fresh lease", 2, connector.connectCount)
+        assertTrue("timed-out transport must be evicted", wedged.closed)
+        assertFalse("healthy retry transport must remain warm", healthy.closed)
+        leaseManager.close()
+    }
+
     private suspend fun StateFlow<FileExplorerUiState>.awaitReady(
         predicate: (FileExplorerUiState.Ready) -> Boolean = { true },
     ): FileExplorerUiState.Ready {
@@ -136,12 +160,26 @@ class FileExplorerLeaseTest {
         }
     }
 
+    private class SequenceConnector(
+        private val sessions: List<FakeSshSession>,
+    ) : SshLeaseConnector {
+        var connectCount: Int = 0
+
+        override suspend fun connect(target: SshLeaseTarget): Result<SshSession> {
+            val session = sessions.getOrNull(connectCount) ?: sessions.last()
+            connectCount += 1
+            return Result.success(session)
+        }
+    }
+
     /**
      * Minimal in-memory remote filesystem: any directory lists one subfolder +
      * one file; `cd … && pwd -P` echoes the requested absolute path so
      * canonicalize succeeds.
      */
-    private class FakeSshSession : SshSession {
+    private class FakeSshSession(
+        private val listDirectoryFailure: Throwable? = null,
+    ) : SshSession {
         var closed: Boolean = false
 
         override val isConnected: Boolean
@@ -157,8 +195,9 @@ class FileExplorerLeaseTest {
             }
         }
 
-        override suspend fun listDirectory(remotePath: String, maxEntries: Int): RemoteListing =
-            RemoteListing(
+        override suspend fun listDirectory(remotePath: String, maxEntries: Int): RemoteListing {
+            listDirectoryFailure?.let { throw it }
+            return RemoteListing(
                 entries = listOf(
                     RemoteEntry(
                         name = "sub",
@@ -175,6 +214,7 @@ class FileExplorerLeaseTest {
                 ),
                 truncated = false,
             )
+        }
 
         override fun tail(path: String, onLine: (String) -> Unit): Job = error("not used")
 

--- a/app/src/test/java/com/pocketshell/app/hosts/HostListViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/hosts/HostListViewModelTest.kt
@@ -532,6 +532,41 @@ class HostListViewModelTest {
         assertEquals(info, warning.releaseInfo)
     }
 
+    @Test
+    fun bootstrapReadyClosesProbeSessionAsynchronouslyOffMain() = runTest {
+        val keyId = db.sshKeyDao().insert(SshKeyEntity(name = "k", privateKeyPath = "/tmp/k"))
+        val hostId = db.hostDao().insert(
+            HostEntity(name = "ready", hostname = "h.example", username = "u", keyId = keyId),
+        )
+        val host = db.hostDao().getById(hostId)!!
+        val session = FakeBootstrapSession()
+        val closeThread = CompletableDeferred<String>()
+        val viewModel = newViewModel(
+            sessionOpener = object : HostSessionOpener {
+                override suspend fun open(
+                    host: HostEntity,
+                    keyPath: String,
+                    passphrase: CharArray?,
+                ): SshSession = session
+
+                override suspend fun close(session: SshSession) {
+                    closeThread.complete(Thread.currentThread().name)
+                    session.close()
+                }
+            },
+        )
+
+        viewModel.bootstrapHost(host, keyPath = "/tmp/k").join()
+        val threadName = kotlinx.coroutines.withTimeout(5_000L) { closeThread.await() }
+
+        assertEquals(true, viewModel.pendingNavigation.value!!.ready)
+        assertEquals(1, session.closeCount)
+        assertFalse(
+            "bootstrap probe close must not run on the test main thread, ran on $threadName",
+            threadName.contains("main", ignoreCase = true),
+        )
+    }
+
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun appUpdateWarning_offersResolvedRelease_whenCachedHostProbeSaysRemoteCliNewerThanApp() = runTest {
@@ -1206,10 +1241,13 @@ class HostListViewModelTest {
                 connectCount += 1
                 Result.success(session)
             },
-            scope = this,
+            scope = kotlinx.coroutines.CoroutineScope(
+                kotlinx.coroutines.SupervisorJob() + kotlinx.coroutines.Dispatchers.IO,
+            ),
             idleTtlMillis = 60_000L,
         )
         val opener = LeaseBackedHostSessionOpener(manager)
+        manager.onProcessStarted()
 
         val opened = opener.open(host, keyFile.absolutePath, passphrase = null)
         assertSame(session, opened)
@@ -1229,6 +1267,7 @@ class HostListViewModelTest {
         )
         assertEquals("reacquire should not perform a second SSH connect", 1, connectCount)
         reacquired.release()
+        manager.close()
     }
 
     /**

--- a/app/src/test/java/com/pocketshell/app/projects/FolderListGatewaySshLeaseTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/FolderListGatewaySshLeaseTest.kt
@@ -144,13 +144,60 @@ class FolderListGatewaySshLeaseTest {
         )
     }
 
+    @Test
+    fun importFileUsesPurposeLeaseAndCleansPreparedPayload() = runTest {
+        var cleaned = false
+        val session = FakeSshSession { command ->
+            when {
+                command.contains("pwd -P") ->
+                    ExecResult(stdout = "/srv/app\n", stderr = "", exitCode = 0)
+                else ->
+                    ExecResult(stdout = "", stderr = "", exitCode = 0)
+            }
+        }
+        val connector = CountingConnector(session)
+        val gateway = SshFolderListGateway(
+            reposRemoteSource = ReposRemoteSource(ReposJsonParser()),
+            activeTmuxClients = ActiveTmuxClients(),
+            sshLeaseManager = SshLeaseManager(
+                connector = connector,
+                scope = this,
+                idleTtlMillis = 30_000L,
+            ),
+        )
+
+        val result = gateway.importFile(
+            host = HOST,
+            keyPath = KEY_PATH,
+            passphrase = null,
+            folderPath = "/srv/app",
+            payload = FolderImportPayload(
+                remoteName = "note.txt",
+                length = 4L,
+                openStream = { "note".byteInputStream() },
+                cleanup = { cleaned = true },
+            ),
+        )
+
+        assertTrue(result.isSuccess)
+        assertEquals("/srv/app/note.txt", result.getOrThrow())
+        assertEquals(
+            listOf("42:/tmp/pocketshell-test-key|purpose=${SshFolderListGateway.LEASE_PURPOSE_IMPORT}"),
+            connector.credentialIds,
+        )
+        assertEquals("/srv/app/note.txt", session.uploadedRemotePath)
+        assertTrue("prepared import payload must be cleaned after gateway returns", cleaned)
+    }
+
     private class CountingConnector(
         private val session: FakeSshSession,
     ) : SshLeaseConnector {
         var connectCount: Int = 0
+        val credentialIds: MutableList<String> = mutableListOf()
 
         override suspend fun connect(target: SshLeaseTarget): Result<SshSession> {
             connectCount += 1
+            credentialIds += target.leaseKey.credentialId
             return Result.success(session)
         }
     }
@@ -161,6 +208,7 @@ class FolderListGatewaySshLeaseTest {
     ) : SshSession {
         val execCommands: MutableList<String> = mutableListOf()
         var closed: Boolean = false
+        var uploadedRemotePath: String? = null
 
         override val isConnected: Boolean
             get() = !closed
@@ -193,7 +241,11 @@ class FolderListGatewaySshLeaseTest {
             length: Long,
             name: String,
             remotePath: String,
-        ): String = error("not used")
+        ): String {
+            input.readBytes()
+            uploadedRemotePath = remotePath
+            return remotePath
+        }
 
         override fun close() {
             closed = true

--- a/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelCreateSessionTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelCreateSessionTest.kt
@@ -289,32 +289,37 @@ class FolderListViewModelCreateSessionTest {
     }
 
     @Test
-    fun createSessionTimesOutAndClearsBusyState() = runTest {
+    fun createSessionDoesNotFalseTimeoutHealthySlowCreate() = runTest {
         val gateway = StubGateway(
             rows = listOf(sessionRow("alpha")),
-            createDelayMs = FolderListViewModel.CREATE_SESSION_ACTION_TIMEOUT_MS + 1L,
+            createDelayMs = 13_000L,
         )
         val vm = newViewModel(gateway)
         try {
             bind(vm)
             runCurrent()
 
+            var resolved: String? = null
             vm.createSession(
                 sessionName = "beta",
                 cwd = "/home/alexey/git/beta",
                 startCommand = null,
-                onResolved = {},
+                onResolved = { resolved = it },
             )
             runCurrent()
             assertTrue((vm.state.value as FolderListUiState.Ready).isCreatingSession)
 
-            advanceTimeBy(FolderListViewModel.CREATE_SESSION_ACTION_TIMEOUT_MS)
+            advanceTimeBy(12_000L)
             runCurrent()
 
-            val failed = vm.state.value as FolderListUiState.Failed
-            assertTrue(failed.message.contains("creating the session took longer"))
+            assertTrue((vm.state.value as FolderListUiState.Ready).isCreatingSession)
             assertEquals(1, gateway.createCalls)
-            assertEquals(false, vm.state.value is FolderListUiState.Ready)
+
+            advanceTimeBy(1_000L)
+            runCurrent()
+
+            assertEquals("beta", resolved)
+            assertEquals(false, (vm.state.value as FolderListUiState.Ready).isCreatingSession)
         } finally {
             vm.stopPolling()
         }

--- a/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelCreateSessionTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelCreateSessionTest.kt
@@ -21,7 +21,9 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runCurrent
@@ -247,6 +249,77 @@ class FolderListViewModelCreateSessionTest {
         }
     }
 
+    @Test
+    fun duplicateCreateClickWhileInFlightIsIgnoredAndExposesBusyState() = runTest {
+        val gateway = StubGateway(
+            rows = listOf(sessionRow("alpha")),
+            createDelayMs = 500L,
+        )
+        val vm = newViewModel(gateway)
+        try {
+            bind(vm)
+            runCurrent()
+
+            vm.createSession(
+                sessionName = "beta",
+                cwd = "/home/alexey/git/beta",
+                startCommand = null,
+                onResolved = {},
+            )
+            vm.createSession(
+                sessionName = "beta",
+                cwd = "/home/alexey/git/beta",
+                startCommand = null,
+                onResolved = {},
+            )
+            runCurrent()
+
+            assertEquals("duplicate create taps must not enqueue another remote create", 1, gateway.createCalls)
+            assertTrue((vm.state.value as FolderListUiState.Ready).isCreatingSession)
+
+            advanceTimeBy(500L)
+            runCurrent()
+
+            assertEquals(setOf("alpha", "beta"), readySessionNames(vm))
+            assertEquals(1, gateway.createCalls)
+            assertEquals(false, (vm.state.value as FolderListUiState.Ready).isCreatingSession)
+        } finally {
+            vm.stopPolling()
+        }
+    }
+
+    @Test
+    fun createSessionTimesOutAndClearsBusyState() = runTest {
+        val gateway = StubGateway(
+            rows = listOf(sessionRow("alpha")),
+            createDelayMs = FolderListViewModel.CREATE_SESSION_ACTION_TIMEOUT_MS + 1L,
+        )
+        val vm = newViewModel(gateway)
+        try {
+            bind(vm)
+            runCurrent()
+
+            vm.createSession(
+                sessionName = "beta",
+                cwd = "/home/alexey/git/beta",
+                startCommand = null,
+                onResolved = {},
+            )
+            runCurrent()
+            assertTrue((vm.state.value as FolderListUiState.Ready).isCreatingSession)
+
+            advanceTimeBy(FolderListViewModel.CREATE_SESSION_ACTION_TIMEOUT_MS)
+            runCurrent()
+
+            val failed = vm.state.value as FolderListUiState.Failed
+            assertTrue(failed.message.contains("creating the session took longer"))
+            assertEquals(1, gateway.createCalls)
+            assertEquals(false, vm.state.value is FolderListUiState.Ready)
+        } finally {
+            vm.stopPolling()
+        }
+    }
+
     private fun bind(vm: FolderListViewModel) {
         vm.bind(
             hostId = HOST.id,
@@ -308,7 +381,10 @@ class FolderListViewModelCreateSessionTest {
         // When true, a successful create makes the gateway's probe start
         // reporting the created session (i.e. the probe observed it).
         @Volatile var reportCreatedSession: Boolean = false,
+        @Volatile var createDelayMs: Long = 0L,
     ) : FolderListGateway {
+        @Volatile var createCalls: Int = 0
+
         override suspend fun listSessionsWithFolder(
             host: HostEntity,
             keyPath: String,
@@ -324,6 +400,10 @@ class FolderListViewModelCreateSessionTest {
             cwd: String,
             startCommand: String?,
         ): Result<String> {
+            createCalls += 1
+            if (createDelayMs > 0L) {
+                delay(createDelayMs)
+            }
             if (!createSucceeds) {
                 return Result.failure(RuntimeException("tmux refused to create '$sessionName'"))
             }

--- a/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelPrewarmLeaseTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelPrewarmLeaseTest.kt
@@ -70,6 +70,10 @@ class FolderListViewModelPrewarmLeaseTest {
             projectRootDao = FakeProjectRootDao(),
             sshLeaseManager = manager,
         )
+        // Drive the bounded warm-lease release on the same virtual clock as the
+        // lease manager so the release-into-idle-TTL is observable deterministically
+        // (the release runs on [ioDispatcher]; production wires `Dispatchers.IO`).
+        vm.ioDispatcher = StandardTestDispatcher(testScheduler)
 
         vm.bind(
             hostId = HOST.id,

--- a/app/src/test/java/com/pocketshell/app/session/AgentConversationRepositoryTest.kt
+++ b/app/src/test/java/com/pocketshell/app/session/AgentConversationRepositoryTest.kt
@@ -860,6 +860,36 @@ class AgentConversationRepositoryTest {
     }
 
     @Test
+    fun recordedClaudeSessionFallsBackToNewestSameKindSiblingWhenRecordedSourceIsAbsent() = runTest {
+        val now = System.currentTimeMillis() / 1000
+        val ownPath = "/home/testuser/.claude/projects/-workspace-proj/older.jsonl"
+        val siblingPath = "/home/testuser/.claude/projects/-workspace-proj/newer.jsonl"
+        val session = FakeSshSession(
+            detectionOutput = """
+                claude|${now - 120}|/workspace/proj|$ownPath
+                claude|$now|/workspace/proj|$siblingPath
+            """.trimIndent(),
+        )
+
+        val detection = AgentConversationRepository().detectRecordedSessionForPane(
+            session = session,
+            cwd = "/workspace/proj",
+            paneTty = "/dev/pts/7",
+            paneCommand = "node",
+            recordedKind = AgentKind.ClaudeCode,
+            recordedSource = null,
+        )
+
+        assertEquals(
+            "legacy/foreign sessions with no @ps_agent_source must keep the " +
+                "existing same-kind mtime selector",
+            siblingPath,
+            detection?.sourcePath,
+        )
+        assertEquals("newer", detection?.sessionId)
+    }
+
+    @Test
     fun recordedClaudeSessionResolvesEvenWhenNoAgentProcessIsObservable() = runTest {
         // The recorded kind is authoritative: an idle recorded Claude session
         // (no live `claude` process visible on the TTY right now) must STILL
@@ -1297,6 +1327,61 @@ class AgentConversationRepositoryTest {
         assertEquals(
             listOf("hello agent", "hi back"),
             window.events.filterIsInstance<ConversationEvent.Message>().map { it.text },
+        )
+    }
+
+    @Test
+    fun resolveRecordedSessionOpenPrefetchesGenerationScopedRecordedClaudeSourceOverNewerSibling() = runTest {
+        val now = System.currentTimeMillis() / 1000
+        val ownPath = "/home/testuser/.claude/projects/-workspace-proj/own.jsonl"
+        val siblingPath = "/home/testuser/.claude/projects/-workspace-proj/busier.jsonl"
+        val session = FakeSshSession(
+            recordedKindOutput = "claude\n",
+            recordedSourceGenerationOutput = "launch-2\n",
+            recordedSourceOutput = "launch-2\t$ownPath\n",
+            detectionOutput = """
+                claude|${now - 120}|/workspace/proj|$ownPath
+                claude|$now|/workspace/proj|$siblingPath
+            """.trimIndent(),
+            foldedClaudeWcOutput = "2",
+            foldedClaudeTail = listOf(
+                """{"type":"user","uuid":"u1","message":{"role":"user","content":"older own"}}""",
+                """{"type":"assistant","uuid":"a1","message":{"role":"assistant","content":"selected"}}""",
+            ).joinToString("\n"),
+            emulateFoldedClaudePathFromShell = true,
+        )
+
+        val open = AgentConversationRepository().resolveRecordedSessionOpen(
+            session = session,
+            sessionTarget = "\$3",
+            cwd = "/workspace/proj",
+            paneTty = "/dev/pts/7",
+            paneCommand = "node",
+        )
+
+        assertEquals(AgentKind.ClaudeCode, open.recordedKind)
+        assertEquals(ownPath, open.recordedSource)
+        assertEquals(
+            "the generation-scoped exact @ps_agent_source must beat newer " +
+                "same-kind mtime during source selection",
+            ownPath,
+            open.detection?.sourcePath,
+        )
+        val window = open.prefetchedWindow
+        assertNotNull(
+            "the folded Claude window must be read from the parsed recorded " +
+                "source path, not the newer same-kind sibling",
+            window,
+        )
+        assertEquals(
+            listOf("older own", "selected"),
+            window!!.events.filterIsInstance<ConversationEvent.Message>().map { it.text },
+        )
+        val command = session.execCommands.single()
+        assertTrue(
+            "the combined open command must parse @ps_agent_source into a clean " +
+                "path before folding the Claude window; got $command",
+            command.contains("ps_recorded_source_path"),
         )
     }
 
@@ -2207,6 +2292,7 @@ class AgentConversationRepositoryTest {
         private val foldedClaudePath: String = "",
         private val foldedClaudeWcOutput: String = "0",
         private val foldedClaudeTail: String = "",
+        private val emulateFoldedClaudePathFromShell: Boolean = false,
     ) : SshSession {
         val execCommands = mutableListOf<String>()
         val tailFromLineCalls = mutableListOf<Pair<String, Long>>()
@@ -2231,8 +2317,13 @@ class AgentConversationRepositoryTest {
                     append("\n@@PS_RECORDED_SOURCE@@\n")
                     append(detectionOutput)
                     append("\n@@PS_CLAUDE_WINDOW@@\n")
-                    if (foldedClaudePath.isNotBlank()) {
-                        append("PATH=").append(foldedClaudePath).append("\n")
+                    val emulatedFoldedPath = if (emulateFoldedClaudePathFromShell) {
+                        emulatedFoldedClaudePath(command)
+                    } else {
+                        foldedClaudePath
+                    }
+                    if (emulatedFoldedPath.isNotBlank()) {
+                        append("PATH=").append(emulatedFoldedPath).append("\n")
                         append(foldedClaudeWcOutput.trim()).append("\n")
                         append("@@PS_CLAUDE_WINDOW@@\n")
                         append(foldedClaudeTail)
@@ -2273,6 +2364,48 @@ class AgentConversationRepositoryTest {
             }
             return ExecResult(stdout = stdout, stderr = "", exitCode = 0)
         }
+
+        private fun emulatedFoldedClaudePath(command: String): String {
+            val recordedSource = parsedRecordedSource()
+            if (recordedSource.isNotBlank() && command.contains("ps_recorded_source_path")) {
+                return recordedSource
+            }
+            return newestClaudeCandidatePath()
+        }
+
+        private fun parsedRecordedSource(): String {
+            val raw = recordedSourceOutput.trim()
+            if (raw.isBlank()) return ""
+            val generation = recordedSourceGenerationOutput.trim()
+            if (generation.isNotBlank()) {
+                val prefix = "$generation\t"
+                return raw.removePrefix(prefix)
+                    .takeIf { it != raw }
+                    ?.trim()
+                    .orEmpty()
+            }
+            val tabIndex = raw.indexOf('\t')
+            return if (tabIndex >= 0) {
+                raw.substring(tabIndex + 1).trim()
+            } else {
+                raw
+            }
+        }
+
+        private fun newestClaudeCandidatePath(): String =
+            detectionOutput
+                .lineSequence()
+                .mapNotNull { line ->
+                    val parts = line.trim().split("|", limit = 4)
+                    if (parts.size == 4 && parts[0] == "claude") {
+                        parts[1].toLongOrNull()?.let { modifiedAt -> modifiedAt to parts[3] }
+                    } else {
+                        null
+                    }
+                }
+                .maxByOrNull { it.first }
+                ?.second
+                .orEmpty()
 
         override fun tail(path: String, onLine: (String) -> Unit): Job {
             tailCalls += 1

--- a/app/src/test/java/com/pocketshell/app/sessions/HostTmuxSessionPickerViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/sessions/HostTmuxSessionPickerViewModelTest.kt
@@ -5,6 +5,7 @@ import com.pocketshell.core.ssh.SshException
 import com.pocketshell.core.storage.entity.HostEntity
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -152,6 +153,22 @@ class HostTmuxSessionPickerViewModelTest {
         vm.cancelLoading()
         runCurrent()
         assertEquals(HostTmuxSessionPickerState.Idle, vm.state.value)
+    }
+
+    @Test
+    fun loadTimeoutProducesRetryableFallbackInsteadOfStayingLoading() = runTest {
+        val gate = CompletableDeferred<HostTmuxSessionListResult>()
+        val vm = HostTmuxSessionPickerViewModel(SuspendingGateway(gate))
+
+        vm.load(request())
+        runCurrent()
+        assertTrue(vm.state.value is HostTmuxSessionPickerState.Loading)
+
+        advanceTimeBy(HostTmuxSessionPickerViewModel.LOAD_TIMEOUT_MS)
+        runCurrent()
+
+        val state = vm.state.value as HostTmuxSessionPickerState.Fallback
+        assertEquals("Timed out while loading tmux sessions. Please retry.", state.message)
     }
 
     @Test

--- a/app/src/test/java/com/pocketshell/app/sessions/HostTmuxSessionsGatewayTest.kt
+++ b/app/src/test/java/com/pocketshell/app/sessions/HostTmuxSessionsGatewayTest.kt
@@ -14,6 +14,7 @@ import com.pocketshell.core.storage.entity.HostEntity
 import com.pocketshell.core.tmux.CommandResponse
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -124,6 +125,96 @@ class HostTmuxSessionsGatewayTest {
     }
 
     @Test
+    fun liveClientTimeoutFallsBackToLeaseEnumeration() = runTest {
+        val client = FakeTmuxClient().apply {
+            suspendForeverOnCommandPrefix = "list-sessions"
+        }
+        activeTmuxClients.register(
+            hostId = HOST.id,
+            hostName = HOST.name,
+            hostname = HOST.hostname,
+            port = HOST.port,
+            username = HOST.username,
+            keyPath = KEY_PATH,
+            client = client,
+        )
+        val session = FakeSshSession(
+            responses = ArrayDeque(
+                listOf(
+                    ExecResult(stdout = "", stderr = "not found", exitCode = 127),
+                    ExecResult(stdout = "lease::100::300::0\n", stderr = "", exitCode = 0),
+                ),
+            ),
+        )
+        val connector = CountingConnector(Result.success(session))
+        val manager = SshLeaseManager(
+            connector = connector,
+            scope = this,
+            idleTtlMillis = 30_000L,
+        )
+        val gateway = SshHostTmuxSessionsGateway(
+            parser = parser,
+            activeTmuxClients = activeTmuxClients,
+            sshLeaseManager = manager,
+            leaseBlockTimeoutMs = 250L,
+            liveEnumTimeoutMs = 250L,
+        )
+
+        try {
+            val result = gateway.listSessions(HOST, KEY_PATH, passphrase = null)
+
+            assertTrue(result is HostTmuxSessionListResult.Sessions)
+            assertEquals(
+                listOf("lease"),
+                (result as HostTmuxSessionListResult.Sessions).rows.map { it.name },
+            )
+            assertEquals(1, connector.connectCount)
+            assertEquals(1, SshOpenTelemetry.count(SSH_SOURCE_SESSION_PICKER_LIST))
+            assertEquals(
+                listOf(
+                    "list-sessions -F " +
+                        "'#{session_name}::#{session_created}::#{session_activity}::" +
+                        "#{session_attached}::#{session_path}'",
+                ),
+                client.sentCommands,
+            )
+        } finally {
+            manager.close()
+        }
+    }
+
+    @Test
+    fun wedgedLeaseEnumerationSurfacesConnectFailedInsteadOfHanging() = runTest {
+        val first = FakeSshSession(blockForever = true)
+        val second = FakeSshSession(blockForever = true)
+        val connector = SequenceConnector(listOf(first, second))
+        val manager = SshLeaseManager(
+            connector = connector,
+            scope = this,
+            idleTtlMillis = 30_000L,
+        )
+        val gateway = SshHostTmuxSessionsGateway(
+            parser = parser,
+            activeTmuxClients = activeTmuxClients,
+            sshLeaseManager = manager,
+            leaseBlockTimeoutMs = 250L,
+            liveEnumTimeoutMs = 250L,
+        )
+
+        val result = gateway.listSessions(HOST, KEY_PATH, passphrase = null)
+
+        assertTrue(result is HostTmuxSessionListResult.ConnectFailed)
+        val cause = (result as HostTmuxSessionListResult.ConnectFailed).cause
+        assertTrue(
+            "wedged lease enumeration should surface the bounded timeout, got ${cause::class.java.name}",
+            cause is LeaseSessionBlockTimeoutException,
+        )
+        assertEquals(2, connector.connectCount)
+        assertTrue(first.closed)
+        assertTrue(second.closed)
+    }
+
+    @Test
     fun connectFailureMapsToConnectFailed() = runTest {
         val cause = SshException("connection refused")
         val gateway = SshHostTmuxSessionsGateway(
@@ -180,9 +271,22 @@ class HostTmuxSessionsGatewayTest {
         }
     }
 
+    private class SequenceConnector(
+        private val sessions: List<SshSession>,
+    ) : SshLeaseConnector {
+        var connectCount: Int = 0
+
+        override suspend fun connect(target: SshLeaseTarget): Result<SshSession> {
+            val session = sessions[connectCount.coerceAtMost(sessions.lastIndex)]
+            connectCount += 1
+            return Result.success(session)
+        }
+    }
+
     private class FakeSshSession(
         private val responses: ArrayDeque<ExecResult> = ArrayDeque(),
         private val cancelOnExec: Boolean = false,
+        private val blockForever: Boolean = false,
     ) : SshSession {
         val execCommands: MutableList<String> = mutableListOf()
         var closed: Boolean = false
@@ -193,6 +297,9 @@ class HostTmuxSessionsGatewayTest {
         override suspend fun exec(command: String): ExecResult {
             if (cancelOnExec) {
                 throw CancellationException("cancelled during picker list")
+            }
+            if (blockForever) {
+                awaitCancellation()
             }
             execCommands += command
             return responses.removeFirstOrNull()

--- a/app/src/test/java/com/pocketshell/app/sessions/LeaseSessionExecTest.kt
+++ b/app/src/test/java/com/pocketshell/app/sessions/LeaseSessionExecTest.kt
@@ -188,6 +188,47 @@ class LeaseSessionExecTest {
     }
 
     @Test
+    fun staleSideBorrowDoesNotDisconnectActiveSharedHolder() = runTest {
+        val sharedSession = FakeSshSession(
+            resultForCommand = { throw IOException("channel open failed") },
+        )
+        val connector = CountingConnector(sharedSession)
+        val manager = SshLeaseManager(connector = connector, scope = this, idleTtlMillis = 30_000L)
+        val active = manager.acquire(TARGET.toSshLeaseTarget()).getOrThrow()
+
+        val result = LeaseSessionExec.withSession(manager, TARGET) { it.exec("probe") }
+
+        assertTrue("stale side borrow should fail after one retry on the still-active lease", result.isFailure)
+        assertEquals("active holder should keep the lease from being re-dialed", 1, connector.connectCount)
+        assertFalse("stale side borrow must not close the active holder's transport", sharedSession.closed)
+        assertTrue("active holder should still be usable", active.session.isConnected)
+
+        active.release()
+    }
+
+    @Test
+    fun timeoutSideBorrowDoesNotDisconnectActiveSharedHolder() = runTest {
+        val sharedSession = FakeSshSession(blockForever = true)
+        val connector = CountingConnector(sharedSession)
+        val manager = SshLeaseManager(connector = connector, scope = this, idleTtlMillis = 30_000L)
+        val active = manager.acquire(TARGET.toSshLeaseTarget()).getOrThrow()
+
+        val result = LeaseSessionExec.withSession(
+            manager,
+            TARGET,
+            blockTimeoutMs = 5_000L,
+        ) { it.exec("wedged") }
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is LeaseSessionBlockTimeoutException)
+        assertEquals("active holder should keep the lease from being re-dialed", 1, connector.connectCount)
+        assertFalse("timed-out side borrow must not close the active holder's transport", sharedSession.closed)
+        assertTrue("active holder should still be usable", active.session.isConnected)
+
+        active.release()
+    }
+
+    @Test
     fun nonStaleFailureDoesNotRetry() = runTest {
         val session = FakeSshSession(
             resultForCommand = { throw IllegalStateException("boom") },

--- a/app/src/test/java/com/pocketshell/app/sessions/StartDirectoryAutocompleteTest.kt
+++ b/app/src/test/java/com/pocketshell/app/sessions/StartDirectoryAutocompleteTest.kt
@@ -152,4 +152,49 @@ class StartDirectoryAutocompleteTest {
         assertTrue(controller.state.value.suggestions.isEmpty())
         assertFalse(controller.state.value.loading)
     }
+
+    @Test
+    fun controllerTimesOutSlowSuggestionAndClearsLoading() = runTest {
+        val controller = StartDirectoryAutocompleteController(
+            scope = this,
+            debounceMs = 0L,
+            requestTimeoutMs = 100L,
+            suggest = {
+                delay(1_000L)
+                listOf("/srv/app/")
+            },
+        )
+
+        controller.onInputChanged("/srv/a")
+        runCurrent()
+        assertTrue(controller.state.value.loading)
+
+        advanceTimeBy(100L)
+        runCurrent()
+
+        assertEquals(emptyList<String>(), controller.state.value.suggestions)
+        assertFalse(controller.state.value.loading)
+    }
+
+    @Test
+    fun controllerDisposeClearsLoading() = runTest {
+        val controller = StartDirectoryAutocompleteController(
+            scope = this,
+            debounceMs = 0L,
+            suggest = {
+                delay(1_000L)
+                listOf("/srv/app/")
+            },
+        )
+
+        controller.onInputChanged("/srv/a")
+        runCurrent()
+        assertTrue(controller.state.value.loading)
+
+        controller.dispose()
+        runCurrent()
+
+        assertEquals(emptyList<String>(), controller.state.value.suggestions)
+        assertFalse(controller.state.value.loading)
+    }
 }

--- a/app/src/test/java/com/pocketshell/app/sessions/StartDirectoryAutocompleteTest.kt
+++ b/app/src/test/java/com/pocketshell/app/sessions/StartDirectoryAutocompleteTest.kt
@@ -154,7 +154,7 @@ class StartDirectoryAutocompleteTest {
     }
 
     @Test
-    fun controllerTimesOutSlowSuggestionAndClearsLoading() = runTest {
+    fun controllerKeepsWaitingForSlowSuggestionInsteadOfBlankingResults() = runTest {
         val controller = StartDirectoryAutocompleteController(
             scope = this,
             debounceMs = 0L,
@@ -173,6 +173,12 @@ class StartDirectoryAutocompleteTest {
         runCurrent()
 
         assertEquals(emptyList<String>(), controller.state.value.suggestions)
+        assertTrue(controller.state.value.loading)
+
+        advanceTimeBy(900L)
+        runCurrent()
+
+        assertEquals(listOf("/srv/app/"), controller.state.value.suggestions)
         assertFalse(controller.state.value.loading)
     }
 

--- a/app/src/test/java/com/pocketshell/app/sessions/StartDirectoryAutocompleteTest.kt
+++ b/app/src/test/java/com/pocketshell/app/sessions/StartDirectoryAutocompleteTest.kt
@@ -154,7 +154,7 @@ class StartDirectoryAutocompleteTest {
     }
 
     @Test
-    fun controllerKeepsWaitingForSlowSuggestionInsteadOfBlankingResults() = runTest {
+    fun controllerTimesOutSlowSuggestionAndIgnoresItsResult() = runTest {
         val controller = StartDirectoryAutocompleteController(
             scope = this,
             debounceMs = 0L,
@@ -173,12 +173,12 @@ class StartDirectoryAutocompleteTest {
         runCurrent()
 
         assertEquals(emptyList<String>(), controller.state.value.suggestions)
-        assertTrue(controller.state.value.loading)
+        assertFalse(controller.state.value.loading)
 
         advanceTimeBy(900L)
         runCurrent()
 
-        assertEquals(listOf("/srv/app/"), controller.state.value.suggestions)
+        assertEquals(emptyList<String>(), controller.state.value.suggestions)
         assertFalse(controller.state.value.loading)
     }
 

--- a/app/src/test/java/com/pocketshell/app/sessions/StartDirectoryAutocompleteTest.kt
+++ b/app/src/test/java/com/pocketshell/app/sessions/StartDirectoryAutocompleteTest.kt
@@ -13,6 +13,7 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
+import java.nio.file.Files
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class StartDirectoryAutocompleteTest {
@@ -69,7 +70,36 @@ class StartDirectoryAutocompleteTest {
         assertTrue(command.contains("pocketshell_ac_parent='~/it isn'\\''t'"))
         assertTrue(command.contains("pocketshell_ac_prefix='prefix; rm -rf \$HOME'"))
         assertTrue(command.contains("'~/'*) pocketshell_ac_parent=\$HOME/\${pocketshell_ac_parent#~/} ;;"))
+        assertTrue(command.contains("find -L \"\$pocketshell_ac_parent\" -mindepth 1 -maxdepth 1 -type d -print"))
+        assertTrue(command.contains("\"\$pocketshell_ac_prefix\"*) ;;"))
         assertTrue(command.contains("[ \"\$pocketshell_ac_count\" -ge 7 ] && break"))
+        assertFalse(command.contains("/\"\$pocketshell_ac_prefix\"*"))
+    }
+
+    @Test
+    fun commandTreatsPrefixAsLiteralWhenFilteringFindOutput() {
+        val temp = Files.createTempDirectory("pocketshell-ac").toFile()
+        try {
+            java.io.File(temp, "lit[abc-one").mkdir()
+            java.io.File(temp, "lita-one").mkdir()
+            java.io.File(temp, "lit[abc-file").writeText("not a directory")
+
+            val request = StartDirectoryAutocompleteRequest.from("lit[abc", limit = 5)!!
+            val process = ProcessBuilder("/bin/sh", "-c", startDirectoryAutocompleteCommand(request))
+                .directory(temp)
+                .redirectErrorStream(true)
+                .start()
+            val output = process
+                .inputStream
+                .bufferedReader()
+                .readText()
+            val exitCode = process.waitFor()
+
+            assertEquals(0, exitCode)
+            assertEquals("lit[abc-one/\n", output)
+        } finally {
+            temp.deleteRecursively()
+        }
     }
 
     @Test

--- a/app/src/test/java/com/pocketshell/app/sessions/service/SessionServiceControllerTest.kt
+++ b/app/src/test/java/com/pocketshell/app/sessions/service/SessionServiceControllerTest.kt
@@ -64,6 +64,12 @@ class SessionServiceControllerTest {
         assertEquals(SessionConnectionService.ACTION_START, started?.action)
         assertTrue(controller.flowOfSnapshot().value.isHoldingConnection)
         assertEquals("alpha", controller.flowOfSnapshot().value.primaryHostName)
+        assertFalse(
+            "the App grace gate must wait for actual foreground promotion, not just start intent",
+            controller.isHoldingSessionConnection(),
+        )
+        controller.onForegroundServicePromoted()
+        assertTrue(controller.isHoldingSessionConnection())
     }
 
     @Test
@@ -137,9 +143,41 @@ class SessionServiceControllerTest {
 
         val snapshot = controller.currentSnapshot()
 
+        assertFalse(
+            "without actual foreground-service promotion, the App grace gate must not preserve",
+            controller.isHoldingSessionConnection(),
+        )
+        controller.onForegroundServicePromoted()
         assertTrue(controller.isHoldingSessionConnection())
         assertEquals(1, snapshot.liveSessionCount)
         assertEquals("alpha", snapshot.primaryHostName)
+    }
+
+    @Test
+    fun `foreground service start failure disables App grace preservation`() = runTest {
+        val activeClients = ActiveTmuxClients()
+        val controller = controller(activeClients, testScheduler)
+
+        controller.observeActiveSessions()
+        runCurrent()
+        activeClients.register(
+            hostId = 1L,
+            hostName = "alpha",
+            hostname = "alpha.example",
+            port = 22,
+            username = "alexey",
+            keyPath = "/tmp/key",
+            client = FakeTmuxClient(),
+        )
+        runCurrent()
+
+        controller.onForegroundServiceStartFailed()
+
+        assertTrue(controller.flowOfSnapshot().value.isHoldingConnection)
+        assertFalse(
+            "a rejected or failed foreground promotion must not preserve the terminal at grace expiry",
+            controller.isHoldingSessionConnection(),
+        )
     }
 
     @Test
@@ -167,6 +205,7 @@ class SessionServiceControllerTest {
         )
         runCurrent()
         drainStartedServices()
+        controller.onForegroundServicePromoted()
 
         controller.stopHoldingFromNotification()
         runCurrent()
@@ -200,6 +239,7 @@ class SessionServiceControllerTest {
         val restarted = shadow.nextStartedService
         assertNotNull("a fresh live-client transition after all-clear may start the hold again", restarted)
         assertEquals(SessionConnectionService.ACTION_START, restarted?.action)
+        controller.onForegroundServicePromoted()
         assertTrue(controller.isHoldingSessionConnection())
         stopCollector.cancel()
     }

--- a/app/src/test/java/com/pocketshell/app/sessions/service/SessionServiceControllerTest.kt
+++ b/app/src/test/java/com/pocketshell/app/sessions/service/SessionServiceControllerTest.kt
@@ -71,6 +71,12 @@ class SessionServiceControllerTest {
         val activeClients = ActiveTmuxClients()
         val client = FakeTmuxClient()
         val controller = controller(activeClients, testScheduler)
+        val holdEnded = mutableListOf<Unit>()
+        val holdEndedCollector = launch {
+            controller.sessionHoldEndedRequests().collect {
+                holdEnded += Unit
+            }
+        }
 
         controller.observeActiveSessions()
         runCurrent()
@@ -94,6 +100,12 @@ class SessionServiceControllerTest {
         assertEquals(SessionConnectionService::class.java.name, stopped?.component?.className)
         assertEquals(SessionConnectionService.ACTION_STOP, stopped?.action)
         assertFalse(controller.flowOfSnapshot().value.isHoldingConnection)
+        assertEquals(
+            "natural hold end must notify App so a post-grace preserved hold can tear down",
+            1,
+            holdEnded.size,
+        )
+        holdEndedCollector.cancel()
     }
 
     @Test

--- a/app/src/test/java/com/pocketshell/app/share/ShareUploaderTargetTest.kt
+++ b/app/src/test/java/com/pocketshell/app/share/ShareUploaderTargetTest.kt
@@ -1,6 +1,7 @@
 package com.pocketshell.app.share
 
 import android.content.Context
+import android.net.Uri
 import androidx.test.core.app.ApplicationProvider
 import com.pocketshell.core.ssh.ExecResult
 import com.pocketshell.core.ssh.SshPortForward
@@ -155,6 +156,42 @@ class ShareUploaderTargetTest {
     }
 
     @Test
+    fun uriItemIsMaterializedBeforeSshConnect() = runTest {
+        val source = File(context.cacheDir, "picked-note.txt").apply {
+            writeText("provider bytes")
+        }
+        val session = RecordingSession(execStdout = "")
+        val uploader = ShareUploader(
+            context = context,
+            connect = { _, _, _, purpose ->
+                seenLeasePurposes += purpose
+                source.delete()
+                Result.success(session)
+            },
+            now = { 0L },
+        )
+
+        val result = uploader.upload(
+            host(),
+            keyEntity(),
+            ShareableItem.UriItem(
+                uri = Uri.fromFile(source),
+                displayName = "picked-note.txt",
+                size = source.length(),
+                mimeType = "text/plain",
+                fallbackExtension = "txt",
+            ),
+            ShareTarget.HostInbox,
+        )
+
+        assertTrue(result.isSuccess)
+        assertTrue(
+            "upload must still succeed after the original URI source disappears at connect time",
+            session.lastRemotePath!!.endsWith("picked-note.txt"),
+        )
+    }
+
+    @Test
     fun toShellExpandablePathRewritesTildeAndTrimsTrailingSlash() {
         assertEquals("\$HOME", ShareUploader.toShellExpandablePath("~"))
         assertEquals("\$HOME/git/foo", ShareUploader.toShellExpandablePath("~/git/foo"))
@@ -225,6 +262,7 @@ class ShareUploaderTargetTest {
         override fun startShell(): SshShell = error("not used")
 
         override suspend fun uploadFile(file: File, remotePath: String): String {
+            file.readBytes()
             lastRemotePath = remotePath
             return remotePath
         }

--- a/app/src/test/java/com/pocketshell/app/share/ShareUploaderTargetTest.kt
+++ b/app/src/test/java/com/pocketshell/app/share/ShareUploaderTargetTest.kt
@@ -35,10 +35,12 @@ import java.io.InputStream
 class ShareUploaderTargetTest {
 
     private lateinit var context: Context
+    private val seenLeasePurposes: MutableList<String?> = mutableListOf()
 
     @Before
     fun setUp() {
         context = ApplicationProvider.getApplicationContext()
+        seenLeasePurposes.clear()
     }
 
     @Test
@@ -64,6 +66,7 @@ class ShareUploaderTargetTest {
             "success path must show ~/inbox/pocketshell, got '${result.getOrNull()}'",
             result.getOrNull()!!.startsWith("~/inbox/pocketshell/"),
         )
+        assertEquals(listOf("share-upload"), seenLeasePurposes)
     }
 
     @Test
@@ -163,7 +166,10 @@ class ShareUploaderTargetTest {
     private fun newUploader(session: SshSession): ShareUploader =
         ShareUploader(
             context = context,
-            connect = { _, _, _ -> Result.success(session) },
+            connect = { _, _, _, purpose ->
+                seenLeasePurposes += purpose
+                Result.success(session)
+            },
             now = { 0L },
         )
 

--- a/app/src/test/java/com/pocketshell/app/share/ShareViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/share/ShareViewModelTest.kt
@@ -657,7 +657,7 @@ class ShareViewModelTest {
     }
 
     @Test
-    fun startUploadReusesActiveSshLeaseInsteadOfStartingFreshAuth() = runTest {
+    fun startUploadReusesShareUploadPurposeLeaseInsteadOfStartingFreshAuth() = runTest {
         val host = seededHost(id = 138L, name = "hetzner")
         val keyPath = "/tmp/key-138"
         val fakeSession = FakeStagingSshSession()
@@ -672,7 +672,9 @@ class ShareViewModelTest {
                 }
             },
         )
-        val activeLease = leaseManager.acquire(host.shareTestLeaseTarget(keyPath)).getOrThrow()
+        val activeLease = leaseManager.acquire(
+            host.shareTestLeaseTarget(keyPath, purpose = "share-upload"),
+        ).getOrThrow()
         try {
             val vm = newVm(ActiveTmuxClients(), sshLeaseManager = leaseManager)
             vm.setItem(ShareableItem.TextItem(text = "crash report body", displayName = "report"))
@@ -687,7 +689,7 @@ class ShareViewModelTest {
                     success.copyText.endsWith("report.txt"),
             )
             assertEquals(
-                "a live lease for the same host/key should be reused",
+                "a live share-upload lease for the same host/key should be reused",
                 1,
                 connectCalls,
             )
@@ -702,6 +704,96 @@ class ShareViewModelTest {
         } finally {
             activeLease.release()
             leaseManager.close()
+        }
+    }
+
+    @Test
+    fun startUploadDoesNotReuseGenericInteractiveLease() = runTest {
+        val host = seededHost(id = 139L, name = "hetzner")
+        val keyPath = "/tmp/key-139"
+        val genericSession = FakeStagingSshSession()
+        val uploadSession = FakeStagingSshSession()
+        val seenCredentialIds = mutableListOf<String>()
+        var connectCalls = 0
+        val leaseManager = SshLeaseManager(
+            connector = { target: SshLeaseTarget ->
+                seenCredentialIds += target.leaseKey.credentialId
+                connectCalls += 1
+                if (connectCalls == 1) {
+                    Result.success(genericSession)
+                } else {
+                    Result.success(uploadSession)
+                }
+            },
+        )
+        val activeLease = leaseManager.acquire(host.shareTestLeaseTarget(keyPath)).getOrThrow()
+        try {
+            val vm = newVm(ActiveTmuxClients(), sshLeaseManager = leaseManager)
+            vm.setItem(ShareableItem.TextItem(text = "body", displayName = "report"))
+
+            vm.startUpload(host)
+            advanceUntilIdle()
+
+            val success = vm.uploadState.first { it is UploadState.Success }
+            assertTrue(success is UploadState.Success)
+            assertEquals(
+                listOf("${host.id}:$keyPath", "${host.id}:$keyPath|purpose=share-upload"),
+                seenCredentialIds,
+            )
+            assertTrue(uploadSession.uploadedRemotePaths.isNotEmpty())
+            assertTrue(genericSession.uploadedRemotePaths.isEmpty())
+        } finally {
+            activeLease.release()
+            leaseManager.close()
+        }
+    }
+
+    @Test
+    @Config(sdk = [28])
+    fun stageIntoSessionUsesShareStagingPurposeLease() {
+        kotlinx.coroutines.runBlocking {
+            kotlinx.coroutines.Dispatchers.setMain(kotlinx.coroutines.Dispatchers.Default)
+            try {
+                val registry = ActiveTmuxClients()
+                val host = seededHost(id = 140L, name = "hetzner")
+                val fakeSession = FakeStagingSshSession()
+                val seenCredentialIds = mutableListOf<String>()
+                val leaseManager = SshLeaseManager(
+                    connector = { target: SshLeaseTarget ->
+                        seenCredentialIds += target.leaseKey.credentialId
+                        Result.success(fakeSession)
+                    },
+                )
+                val vm = newVm(registry, sshLeaseManager = leaseManager)
+                registry.register(
+                    hostId = host.id,
+                    hostName = host.name,
+                    hostname = host.hostname,
+                    port = host.port,
+                    username = host.username,
+                    keyPath = "/tmp/key-140",
+                    client = FakeTmuxClient(),
+                )
+                vm.setItem(ShareableItem.TextItem(text = "attach me", displayName = "note"))
+
+                vm.stageIntoSession(
+                    host,
+                    ActiveSessionTarget(sessionName = "scratch", cwd = "/x", label = "scratch"),
+                )
+                kotlinx.coroutines.withTimeout(5_000L) {
+                    fakeSession.uploadStarted.await()
+                }
+
+                assertEquals(
+                    listOf("${host.id}:/tmp/key-140|purpose=share-staging"),
+                    seenCredentialIds,
+                )
+                leaseManager.close()
+            } finally {
+                kotlinx.coroutines.Dispatchers.setMain(
+                    kotlinx.coroutines.test.UnconfinedTestDispatcher(),
+                )
+            }
         }
     }
 
@@ -727,7 +819,9 @@ class ShareViewModelTest {
                 }
             },
         )
-        val activeLease = leaseManager.acquire(host.shareTestLeaseTarget(keyPath)).getOrThrow()
+        val activeLease = leaseManager.acquire(
+            host.shareTestLeaseTarget(keyPath, purpose = "share-upload"),
+        ).getOrThrow()
         try {
             val vm = newVm(ActiveTmuxClients(), sshLeaseManager = leaseManager)
             vm.setItem(ShareableItem.TextItem(text = "report body", displayName = "report"))
@@ -1708,13 +1802,13 @@ class ShareViewModelTest {
             keyId = 99L,
         )
 
-    private fun HostEntity.shareTestLeaseTarget(keyPath: String): SshLeaseTarget =
+    private fun HostEntity.shareTestLeaseTarget(keyPath: String, purpose: String? = null): SshLeaseTarget =
         SshLeaseTarget(
             leaseKey = SshLeaseKey(
                 host = hostname,
                 port = port,
                 user = username,
-                credentialId = "$id:$keyPath",
+                credentialId = if (purpose == null) "$id:$keyPath" else "$id:$keyPath|purpose=$purpose",
                 knownHostsId = "accept-all",
             ),
             key = SshKey.Path(java.io.File(keyPath)),

--- a/app/src/test/java/com/pocketshell/app/share/ShareViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/share/ShareViewModelTest.kt
@@ -967,7 +967,7 @@ class ShareViewModelTest {
         assertEquals("live-project", selection.sessionProjects.first().label)
         assertTrue(
             "the command must enumerate all sessions' panes, got ${client.sentCommands}",
-            client.sentCommands.single().startsWith("list-panes -a"),
+            client.sentCommands.first().startsWith("list-panes -a"),
         )
     }
 
@@ -1125,6 +1125,16 @@ class ShareViewModelTest {
                     isError = false,
                 ),
             )
+            responses.addLast(
+                CommandResponse(
+                    number = 0L,
+                    output = listOf(
+                        "work::\$1::101::101::0::::::/home/alexey/git/pocketshell",
+                        "scratch::\$2::202::202::1::::::/home/alexey/git/live",
+                    ),
+                    isError = false,
+                ),
+            )
         }
         registry.register(
             hostId = host.id,
@@ -1146,6 +1156,8 @@ class ShareViewModelTest {
             listOf("scratch", "work"),
             selection.activeSessions.map { it.sessionName },
         )
+        assertEquals("\$2", selection.activeSessions.first().tmuxSessionId)
+        assertEquals(202L, selection.activeSessions.first().sessionCreated)
         assertTrue(
             "the focused session must lead and be flagged focused",
             selection.activeSessions.first().sessionName == "scratch" &&
@@ -1326,6 +1338,100 @@ class ShareViewModelTest {
         val failed = vm.uploadState.first { it is UploadState.Failed } as UploadState.Failed
         assertEquals("gpu-box", failed.hostName)
         assertTrue(failed.message.contains("save to inbox", ignoreCase = true))
+    }
+
+    @Test
+    fun stageIntoSessionRefusesSameNameSessionWhoseTmuxIdentityChanged() = runTest {
+        val registry = ActiveTmuxClients()
+        val vm = newVm(registry)
+        val host = seededHost(id = 56L, name = "gpu-box")
+        val client = FakeTmuxClient().apply {
+            responses.addLast(
+                CommandResponse(
+                    number = 0L,
+                    output = listOf("\$99::999"),
+                    isError = false,
+                ),
+            )
+        }
+        registry.register(
+            hostId = host.id,
+            hostName = host.name,
+            hostname = host.hostname,
+            port = host.port,
+            username = host.username,
+            keyPath = "/tmp/key",
+            client = client,
+        )
+        var openedStagingSession = false
+        vm.connectForStaging = { _, _ ->
+            openedStagingSession = true
+            Result.success(FakeStagingSshSession())
+        }
+        vm.setItem(uriItem("shot.png"))
+
+        vm.stageIntoSession(
+            host,
+            ActiveSessionTarget(
+                sessionName = "scratch",
+                cwd = "/x",
+                label = "scratch",
+                tmuxSessionId = "\$7",
+                sessionCreated = 777L,
+            ),
+        )
+        advanceUntilIdle()
+
+        val failed = vm.uploadState.first { it is UploadState.Failed } as UploadState.Failed
+        assertEquals("gpu-box", failed.hostName)
+        assertTrue(failed.message.contains("no longer active", ignoreCase = true))
+        assertFalse("stale target must fail before opening staging SSH", openedStagingSession)
+        assertTrue(
+            "identity revalidation must target the selected session, got ${client.sentCommands}",
+            client.sentCommands.single().contains("display-message -p -t 'scratch'"),
+        )
+    }
+
+    @Test
+    fun stageIntoSessionRefusesVanishedNameOnlySessionBeforeStaging() = runTest {
+        val registry = ActiveTmuxClients()
+        val vm = newVm(registry)
+        val host = seededHost(id = 57L, name = "gpu-box")
+        val client = FakeTmuxClient().apply {
+            responses.addLast(
+                CommandResponse(
+                    number = 0L,
+                    output = listOf("can't find session"),
+                    isError = true,
+                ),
+            )
+        }
+        registry.register(
+            hostId = host.id,
+            hostName = host.name,
+            hostname = host.hostname,
+            port = host.port,
+            username = host.username,
+            keyPath = "/tmp/key",
+            client = client,
+        )
+        var openedStagingSession = false
+        vm.connectForStaging = { _, _ ->
+            openedStagingSession = true
+            Result.success(FakeStagingSshSession())
+        }
+        vm.setItem(uriItem("shot.png"))
+
+        vm.stageIntoSession(
+            host,
+            ActiveSessionTarget(sessionName = "scratch", cwd = "/x", label = "scratch"),
+        )
+        advanceUntilIdle()
+
+        val failed = vm.uploadState.first { it is UploadState.Failed } as UploadState.Failed
+        assertTrue(failed.message.contains("save to inbox", ignoreCase = true))
+        assertFalse("vanished target must fail before opening staging SSH", openedStagingSession)
+        assertEquals("has-session -t 'scratch'", client.sentCommands.single())
     }
 
     @Test

--- a/app/src/test/java/com/pocketshell/app/tmux/FakeTmuxClient.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/FakeTmuxClient.kt
@@ -161,6 +161,12 @@ internal class FakeTmuxClient(
 
     var closeAndThrowDisconnectEvent: TmuxDisconnectEvent? = null
 
+    var throwOnCommandPrefix: String? = null
+
+    var throwOnCommandRemaining: Int = 0
+
+    var throwOnCommandException: Throwable = TmuxClientException("tmux command timed out")
+
     var failBestEffortOnCommandPrefix: String? = null
 
     var bestEffortException: Throwable = TmuxClientException("tmux best-effort command timed out")
@@ -328,6 +334,12 @@ internal class FakeTmuxClient(
                     ),
                 )
                 throw closeAndThrowException
+            }
+        }
+        throwOnCommandPrefix?.let { prefix ->
+            if (cmd.startsWith(prefix) && throwOnCommandRemaining > 0) {
+                throwOnCommandRemaining -= 1
+                throw throwOnCommandException
             }
         }
         if (bestEffort) {

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
@@ -2858,6 +2858,10 @@ class TmuxSessionViewModelTest {
         )
         assertTrue("stale client should be closed after silent reattach", deadClient.closed)
         assertTrue("replacement control client should be opened", replacementClient.connectCalled)
+        assertTrue(
+            "silent same-SSH reattach expects the session to exist, so it must probe server liveness",
+            vm.lastProbeServerLivenessForTest(),
+        )
     }
 
     @Test
@@ -5052,6 +5056,68 @@ class TmuxSessionViewModelTest {
                 "VM-level foreground diagnostic must be emitted for the Android wait",
                 1,
                 diagnostics.eventsNamed("foreground_reattach").size,
+            )
+        } finally {
+            diagnostics.close()
+        }
+    }
+
+    @Test
+    fun postGraceForegroundWithoutPendingReattachProbesAndReseedsHeldRuntime() = runTest(scheduler) {
+        val diagnostics = installRecordingDiagnosticSink()
+        try {
+            val vm = newVm()
+            val client = FakeTmuxClient().withSinglePane("work", "%1")
+            val session = FakeSshSession()
+            vm.replaceClientForTest(
+                hostId = 1L,
+                hostName = "alpha",
+                host = "alpha.example",
+                port = 22,
+                user = "alex",
+                keyPath = "/keys/a",
+                sessionName = "work",
+                client = client,
+                session = session,
+            )
+            client.emittedEvents.emit(
+                ControlEvent.WindowAdd(sessionId = "work", windowId = "@0", name = "work"),
+            )
+            advanceUntilIdle()
+
+            client.capturePaneResponses.addLast(
+                CommandResponse(number = 4L, output = listOf("post-grace held reseed"), isError = false),
+            )
+            val probeCountBefore =
+                client.sentCommands.count { it == "display-message -p '#{session_name}'" }
+            val captureCountBefore =
+                client.sentCommands.count { it == seedCaptureCommand("%1") }
+
+            vm.onAppForegrounded(resumedWithinGrace = false)
+            assertTrue(
+                "service-held post-grace foreground must not flash a reconnect state while probing",
+                vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected,
+            )
+            advanceUntilIdle()
+
+            assertFalse(
+                "service-held post-grace foreground has no detached runtime to replay",
+                vm.hasPendingReattachForTest(),
+            )
+            assertTrue(
+                "post-grace foreground with a held runtime must probe the control channel",
+                client.sentCommands.count { it == "display-message -p '#{session_name}'" } > probeCountBefore,
+            )
+            assertTrue(
+                "a healthy held runtime must be reseeded instead of no-oping",
+                client.sentCommands.count { it == seedCaptureCommand("%1") } > captureCountBefore,
+            )
+            assertTrue(
+                "the post-grace hold probe must emit a foreground diagnostic",
+                diagnostics.eventsNamed("foreground_reattach").any {
+                    it.fields["outcome"] == "post_grace_hold_probe" &&
+                        it.fields["probeVerdict"] == RuntimeHealthVerdict.HEALTHY.name
+                },
             )
         } finally {
             diagnostics.close()
@@ -11915,13 +11981,12 @@ class TmuxSessionViewModelTest {
     // ─── Issue #178: same-host fast-switch reuses the SSH transport ───
     //
     // The connect() path detects "same host, different tmux session"
-    // and routes through [closeCurrentClientKeepSession] +
-    // [runFastSessionSwitch] instead of the full SSH-handshake teardown
-    // + reconnect. Production exercise lives in the connected
-    // TmuxSessionSwitchSameHostReusesSshE2eTest because a unit test
-    // cannot reach into [SshConnection.connect] without a real
-    // network. The unit tests below pin the predicate behaviour, the
-    // teardown-keep-session invariant, and the registry side-effects
+    // and routes through the fast-switch path instead of the full
+    // SSH-handshake teardown + reconnect. Production exercise lives in
+    // the connected TmuxSessionSwitchSameHostReusesSshE2eTest because a
+    // unit test cannot reach into [SshConnection.connect] without a
+    // real network. The unit tests below pin the predicate behaviour,
+    // the teardown-keep-session invariant, and the registry side-effects
     // through the dedicated test seams the VM exposes.
 
     @Test

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
@@ -1114,12 +1114,14 @@ class TmuxSessionViewModelTest {
             listOf(TmuxSessionViewModel.ParsedPane("%0", "@0", "\$0", "shell", paneIndex = 0)),
         )
         runCurrent()
-        // Wait until client A's pane-output collectors (producer + activity +
-        // port detector) are all subscribed before emitting.
+        // Wait until client A's pane-output collectors (producer + activity)
+        // are subscribed before emitting. The port detector is now
+        // target/generation-owned and intentionally does not start from this
+        // attachClientForTest-only harness because it has no active target.
         assertTrue(
             "client A pane-output collectors must subscribe",
             withTimeoutOrNull(SLOW_FEED_DRAIN_TIMEOUT_MS) {
-                clientA.emittedPaneOutputs.subscriptionCount.first { it >= 3 }
+                clientA.emittedPaneOutputs.subscriptionCount.first { it >= 2 }
                 true
             } ?: false,
         )
@@ -5163,6 +5165,46 @@ class TmuxSessionViewModelTest {
     }
 
     @Test
+    fun postGraceForegroundWithoutPendingReattachReconnectsDisconnectedHeldRuntime() = runTest(scheduler) {
+        val diagnostics = installRecordingDiagnosticSink()
+        try {
+            val vm = newVm()
+            vm.setAutoReconnectDelaysForTest(listOf(60_000L))
+            val client = FakeTmuxClient().withSinglePane("work", "%1")
+            val session = FakeSshSession()
+            vm.replaceClientForTest(
+                hostId = 1L,
+                hostName = "alpha",
+                host = "alpha.example",
+                port = 22,
+                user = "alex",
+                keyPath = "/keys/a",
+                sessionName = "work",
+                client = client,
+                session = session,
+            )
+            client.markDisconnectedForTest(
+                TmuxDisconnectEvent(
+                    reason = TmuxDisconnectReason.ReaderEof,
+                    source = "test",
+                    intent = "held_post_grace",
+                ),
+            )
+
+            vm.onAppForegrounded(resumedWithinGrace = false)
+            runCurrent()
+
+            assertTrue(
+                "post-grace foreground with a disconnected held client must schedule reconnect, got " +
+                    "${vm.connectionStatus.value}",
+                vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Reconnecting,
+            )
+        } finally {
+            diagnostics.close()
+        }
+    }
+
+    @Test
     fun shortAppSwitchPassiveDisconnectResumesAutoReconnectOnScreenStart() = runTest(scheduler) {
         val registry = ActiveTmuxClients()
         val connector = QueueLeaseConnector(FakeSshSession())
@@ -6206,7 +6248,7 @@ class TmuxSessionViewModelTest {
         }
         vm.attachClientForTest(client)
         val sink = vm.tmuxInputSinkForTest("%0")
-        val chunks = List(2_000) { index ->
+        val chunks = List(800) { index ->
             ("stress-${index.toString().padStart(4, '0')}-" + "x".repeat(51))
                 .toByteArray(Charsets.US_ASCII)
         }
@@ -6250,6 +6292,32 @@ class TmuxSessionViewModelTest {
             expected.toList(),
             reconstructed.toList(),
         )
+    }
+
+    @Test
+    fun tmuxInputEnqueueRejectsWhenPendingByteBudgetIsFull() = runTest(scheduler) {
+        val vm = newVm()
+        val client = FakeTmuxClient().apply {
+            sendCommandGatePrefix = "send-keys -l -t %0"
+            sendCommandGate = CompletableDeferred()
+        }
+        vm.attachClientForTest(client)
+        val sink = vm.tmuxInputSinkForTest("%0")
+        val chunk = ByteArray(TMUX_INPUT_CHUNK_BYTES) { 'x'.code.toByte() }
+
+        repeat(vm.tmuxInputCapacityBytesForTest() / TMUX_INPUT_CHUNK_BYTES) {
+            sink.write(chunk)
+        }
+        runCurrent()
+
+        val thrown = runCatching { sink.write("overflow".toByteArray(Charsets.US_ASCII)) }
+            .exceptionOrNull()
+        assertTrue(
+            "enqueue must fail fast instead of blocking when the pending-byte budget is full",
+            thrown is IOException,
+        )
+        client.sendCommandGate?.complete(Unit)
+        advanceUntilIdle()
     }
 
     @Test

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
@@ -2400,6 +2400,42 @@ class TmuxSessionViewModelTest {
         }
 
     @Test
+    fun withinGraceForegroundDoesNotReseedDisconnectedHeldClient() = runTest(scheduler) {
+        val registry = ActiveTmuxClients()
+        val connector = QueueLeaseConnector(FakeSshSession())
+        val replacementClient = FakeTmuxClient().withSinglePane("work", "%1")
+        val vm = newVm(
+            registry = registry,
+            sshLeaseManager = testLeaseManager(connector = connector, scope = this, idleTtlMillis = 0L),
+        )
+        vm.setTmuxClientFactoryForTest { _, _, _ -> replacementClient }
+        vm.setPassiveDisconnectRecoveryForTest(graceMs = 1_000L, silentReattachTimeoutMs = 1_000L)
+        val staleClient = FakeTmuxClient().withSinglePane("work", "%0")
+        vm.replaceClientForTest(
+            hostId = 7L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            sessionName = "work",
+            client = staleClient,
+            session = FakeSshSession(),
+        )
+        vm.markActiveLeaseWarmForTest()
+        runCurrent()
+
+        staleClient.disconnectedSignal.value = true
+        vm.onAppForegrounded(resumedWithinGrace = true)
+        advanceUntilIdle()
+
+        assertTrue(
+            "within-grace foreground must not run capture/reseed over a disconnected held client",
+            staleClient.sentCommands.none { it.startsWith("capture-pane") },
+        )
+    }
+
+    @Test
     fun livenessProbeDeclaredDropClosesTheClientAndDrivesTheSingleReconnectEntrypoint() =
         runTest(scheduler) {
             // EPIC #792 Slice D (#822/V7a): the LivenessProbe's confirmed-drop body
@@ -6131,6 +6167,35 @@ class TmuxSessionViewModelTest {
             "recreate must not flip tmux disconnected",
             client.disconnectedSignal.value,
         )
+    }
+
+    @Test
+    fun dequeuedTmuxInputSendFailureRetriesOnceBeforeRecordingSent() = runTest(scheduler) {
+        val vm = newVm()
+        val client = FakeTmuxClient().apply {
+            throwOnCommandPrefix = "send-keys -l -t %0"
+            throwOnCommandRemaining = 1
+        }
+        vm.attachClientForTest(client)
+        val sink = vm.tmuxInputSinkForTest("%0")
+
+        sink.write("retry".toByteArray(Charsets.US_ASCII))
+        advanceUntilIdle()
+
+        val literalSends = client.sentCommands.filter { it.startsWith("send-keys -l -t %0") }
+        assertEquals(
+            "the dequeued batch must be retried once after a post-dequeue send failure",
+            2,
+            literalSends.size,
+        )
+        val metrics = vm.tmuxInputMetricsForTest("%0") ?: error("input metrics should be recorded")
+        assertEquals(5L, metrics.totalEnqueuedBytes)
+        assertEquals(
+            "bytes should only be counted sent after the retry succeeds",
+            5L,
+            metrics.totalSentBytes,
+        )
+        assertFalse("one recovered send failure must not disconnect the client", client.disconnected.value)
     }
 
     @Test
@@ -15196,6 +15261,40 @@ class TmuxSessionViewModelTest {
         advanceUntilIdle()
 
         assertEquals(5173, vm.detectedPort.value)
+    }
+
+    @Test
+    fun stalePortDetectorFromParkedRuntimeDoesNotSurfaceOnNewRuntime() = runTest(scheduler) {
+        val vm = newVm()
+        val oldClient = FakeTmuxClient()
+        val oldSession = FakeSshSession(ssListeningPorts = emptySet())
+        vm.attachForPortDetection(oldClient, oldSession)
+        advanceUntilIdle()
+
+        val newClient = FakeTmuxClient()
+        val newSession = FakeSshSession(ssListeningPorts = setOf(5173))
+        vm.fastSwitchSessionForTest(
+            hostId = 1L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            sessionName = "other",
+            client = newClient,
+            session = newSession,
+        )
+        advanceUntilIdle()
+
+        oldClient.emittedEvents.emit(
+            ControlEvent.Output("%0", "Local:   http://localhost:5173/\n".toByteArray()),
+        )
+        advanceUntilIdle()
+
+        assertNull(
+            "a detector bound to the parked old runtime must not confirm against the new runtime",
+            vm.detectedPort.value,
+        )
     }
 
     @Test

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
@@ -38,6 +38,7 @@ import com.pocketshell.core.ssh.SshLeaseTarget
 import com.pocketshell.core.terminal.bridge.SshTerminalBridge
 import com.pocketshell.core.terminal.ui.TerminalSurfaceState
 import com.pocketshell.core.tmux.CommandResponse
+import com.pocketshell.core.tmux.TmuxClient
 import com.pocketshell.uikit.model.KeyKind
 import com.pocketshell.uikit.model.SessionAgentKind
 import com.pocketshell.core.tmux.TmuxClientException
@@ -63,6 +64,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceTimeBy
@@ -5999,6 +6001,59 @@ class TmuxSessionViewModelTest {
             vm.panes.value.single().terminalState,
         )
     }
+
+    @Test
+    fun terminalSurfaceFailureClearsProducerClientWhenAttachProducerFailsSoReconcileRetries() =
+        runTest(scheduler) {
+            val vm = newVm()
+            val backingClient = FakeTmuxClient()
+            val client = OutputFailingTmuxClient(backingClient)
+            vm.attachClientForTest(client)
+            vm.applyParsedPanesForTest(
+                listOf(TmuxSessionViewModel.ParsedPane("%0", "@0", "\$0", "shell", paneIndex = 0)),
+            )
+            advanceUntilIdle()
+
+            val clientIdentity = System.identityHashCode(client)
+            assertEquals(
+                "precondition: pane producer starts bound to the live client",
+                clientIdentity,
+                vm.paneProducerClientIdentityForTest("%0"),
+            )
+            val originalState = vm.panes.value.single().terminalState
+
+            client.failOutputFor = true
+            vm.reportTerminalSurfaceFailureForTest(
+                paneId = "%0",
+                cause = RuntimeException("surface reset"),
+            )
+            advanceUntilIdle()
+
+            assertNull(
+                "failed terminal producer reattach must clear the client binding so " +
+                    "the next reconcile retries instead of assuming the producer is live",
+                vm.paneProducerClientIdentityForTest("%0"),
+            )
+            assertNotSame(
+                "surface failure still replaces the local TerminalSurfaceState",
+                originalState,
+                vm.panes.value.single().terminalState,
+            )
+
+            client.failOutputFor = false
+            vm.applyParsedPanesForTest(
+                listOf(TmuxSessionViewModel.ParsedPane("%0", "@0", "\$0", "shell", paneIndex = 0)),
+            )
+            advanceUntilIdle()
+
+            assertEquals(
+                "a later reconcile must retry and restore the producer-client binding",
+                clientIdentity,
+                vm.paneProducerClientIdentityForTest("%0"),
+            )
+            assertTrue(vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected)
+            assertFalse(backingClient.disconnectedSignal.value)
+        }
 
     @Test
     fun repeatedTerminalSurfaceFailuresStopAtErrorStateInsteadOfReconnectStorm() = runTest(scheduler) {
@@ -16731,6 +16786,17 @@ class TmuxSessionViewModelTest {
         override suspend fun delete(host: com.pocketshell.core.storage.entity.HostEntity) =
             error("not used")
         override suspend fun deleteById(id: Long) = error("not used")
+    }
+
+    private class OutputFailingTmuxClient(
+        private val delegate: FakeTmuxClient,
+    ) : TmuxClient by delegate {
+        var failOutputFor: Boolean = false
+
+        override fun outputFor(paneId: String): Flow<ControlEvent.Output> {
+            if (failOutputFor) throw RuntimeException("outputFor failed")
+            return delegate.outputFor(paneId)
+        }
     }
 
     /**

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -619,16 +619,16 @@ cheap inner loop. Run it for migration PRs that affect app screens or sheets.
 Run targeted connected tests when a slice touches a covered surface:
 
 ```bash
-./gradlew :app:connectedDebugAndroidTest \
+scripts/connected-test.sh --suffix design-tmux \
   -Pandroid.testInstrumentationRunnerArguments.class=com.pocketshell.app.tmux.TmuxConsolidatedChromeScreenshotTest
 
-./gradlew :app:connectedDebugAndroidTest \
+scripts/connected-test.sh --suffix design-composer \
   -Pandroid.testInstrumentationRunnerArguments.class=com.pocketshell.app.composer.PromptComposerVisualScreenshotTest
 
-./gradlew :app:connectedDebugAndroidTest \
+scripts/connected-test.sh --suffix design-folder \
   -Pandroid.testInstrumentationRunnerArguments.class=com.pocketshell.app.projects.FolderContextActionSheetScreenshotTest
 
-./gradlew :app:connectedDebugAndroidTest \
+scripts/connected-test.sh --suffix design-costs \
   -Pandroid.testInstrumentationRunnerArguments.class=com.pocketshell.app.costs.CostsScreenScreenshotTest
 ```
 

--- a/docs/docker-emulator-runbook.md
+++ b/docs/docker-emulator-runbook.md
@@ -35,7 +35,8 @@ diagnostics under `build/local-avd-start/<run-id>/` if the emulator exits before
 adb device discovery. A newly started emulator runs in a memory-capped cgroup by
 default via `scripts/lib/scope-run.sh`, so an emulator OOM stops that scope
 instead of the interactive session. The default cap is `POCKETSHELL_TEST_MEM=8G`;
-override it only for a specific reproduction:
+if local user systemd is unavailable, the helper fails closed instead of
+starting the emulator raw. Override memory only for a specific reproduction:
 
 ```bash
 POCKETSHELL_TEST_MEM=6G scripts/start-local-avd.sh
@@ -66,8 +67,8 @@ scripts/cgroup-run.sh -- ./gradlew --no-daemon :app:compileDebugKotlin
 POCKETSHELL_TEST_MEM=6G scripts/cgroup-run.sh --unit local-repro -- bash -lc '...'
 ```
 
-Only set `AVD_SCOPE=0` or bypass `scripts/cgroup-run.sh` when debugging cgroup
-setup itself.
+Only set `AVD_SCOPE=0` or bypass `scripts/cgroup-run.sh` together with
+`POCKETSHELL_SCOPE_ALLOW_BARE=1` when debugging cgroup setup itself.
 
 To run the same command manually:
 
@@ -293,15 +294,15 @@ ssh -i tests/docker/test_key -p 2222 \
 Run the full connected Android suite:
 
 ```bash
-./gradlew --no-daemon connectedDebugAndroidTest --stacktrace
+scripts/connected-test.sh
 ```
 
 Run focused connected checks:
 
 ```bash
-./gradlew --no-daemon :shared:core-terminal:connectedDebugAndroidTest --stacktrace
+scripts/connected-test.sh --module shared:core-terminal --suffix terminal
 CLASS_ARG="-Pandroid.testInstrumentationRunnerArguments.class=com.pocketshell.app.proof.EmulatorDockerSshSmokeTest"
-./gradlew --no-daemon :app:connectedDebugAndroidTest \
+scripts/connected-test.sh --suffix smoke \
   "$CLASS_ARG"
 ```
 
@@ -483,7 +484,7 @@ The fast pre-release gate does all of the following:
    first runs focused app KSP/Hilt generated-source tasks for debug, release,
    androidTest, and unit-test variants so lint has deterministic generated
    source inputs, then runs
-   `./gradlew --no-daemon --no-build-cache --no-parallel --max-workers=2 assembleDebug check -x lint -x lintDebug --stacktrace`.
+   `scripts/cgroup-run.sh -- ./gradlew --no-daemon --no-build-cache --no-parallel --max-workers=2 assembleDebug check -x lint -x lintDebug --stacktrace`.
    Lint is intentionally excluded from this local pre-release gate so unrelated
    dirty-worktree lint findings do not block the install and focused
    instrumentation checks; run lint separately from a clean checkout before
@@ -554,16 +555,16 @@ AVD_HOLD=1 RUN_ID=pre-release-hold scripts/start-local-avd.sh
 ```
 
 Leave that terminal open while `scripts/pre-release-confidence-gate.sh` or any
-focused `connectedDebugAndroidTest` command runs in another terminal. Hold mode
+focused `scripts/connected-test.sh` command runs in another terminal. Hold mode
 keeps the startup helper attached to the emulator and records diagnostics under
 `build/local-avd-start/pre-release-hold/` if the AVD exits while Gradle is still
 collecting connected-test evidence.
 
-If you need to start the AVD manually instead of using the helper, use the same
-flag set:
+If you need to start the AVD manually instead of using the helper, still use the
+cgroup wrapper with the same flag set:
 
 ```bash
-"$EMULATOR" -avd test \
+scripts/cgroup-run.sh -- "$EMULATOR" -avd test \
   -no-window \
   -no-audio \
   -no-boot-anim \
@@ -592,7 +593,7 @@ scripts/pre-release-confidence-gate.sh
 Slower opt-in suites are not part of the fast APK pre-release gate:
 
 - Full connected Android sweep:
-  `./gradlew --no-daemon connectedDebugAndroidTest --stacktrace`. Run this
+  `scripts/connected-test.sh`. Run this
   before a public release candidate or when shared instrumentation fixtures
   change.
 - Bootstrap/setup scenarios:
@@ -621,7 +622,7 @@ Run the opt-in bootstrap suite:
 ```bash
 BOOTSTRAP_ARG="-Pandroid.testInstrumentationRunnerArguments.pocketshellBootstrapScenarios=true"
 CLASS_ARG="-Pandroid.testInstrumentationRunnerArguments.class=com.pocketshell.app.bootstrap.HostBootstrapScenarioSuiteTest"
-./gradlew --no-daemon :app:connectedDebugAndroidTest \
+scripts/connected-test.sh --suffix bootstrap \
   "$BOOTSTRAP_ARG" \
   "$CLASS_ARG"
 ```

--- a/docs/docker-emulator-runbook.md
+++ b/docs/docker-emulator-runbook.md
@@ -32,20 +32,47 @@ scripts/start-local-avd.sh
 The helper uses the shared AVD lock, starts the local `test` AVD with the
 review-safe headless flags, waits for `sys.boot_completed=1`, and writes
 diagnostics under `build/local-avd-start/<run-id>/` if the emulator exits before
-adb device discovery. For connected-test review evidence, keep it open in a
-dedicated terminal:
+adb device discovery. A newly started emulator runs in a memory-capped cgroup by
+default via `scripts/lib/scope-run.sh`, so an emulator OOM stops that scope
+instead of the interactive session. The default cap is `POCKETSHELL_TEST_MEM=8G`;
+override it only for a specific reproduction:
+
+```bash
+POCKETSHELL_TEST_MEM=6G scripts/start-local-avd.sh
+```
+
+For connected-test review evidence, keep it open in a dedicated terminal:
 
 ```bash
 AVD_HOLD=1 scripts/start-local-avd.sh
 ```
 
-Then run `:app:connectedDebugAndroidTest` from another terminal. If the emulator
-exits after boot, the held helper records the failure in the same run directory.
+Then run `:app:connectedDebugAndroidTest` from another terminal through the
+scoped connected-test wrapper. It already runs Gradle in a sibling cgroup and
+serializes AVD access:
+
+```bash
+scripts/connected-test.sh --suffix i123 \
+  -Pandroid.testInstrumentationRunnerArguments.class=com.pocketshell.app.proof.SomeTest
+```
+
+If the emulator exits after boot, the held helper records the failure in the
+same run directory.
+
+For other heavy local reproduction commands, use the explicit cgroup wrapper:
+
+```bash
+scripts/cgroup-run.sh -- ./gradlew --no-daemon :app:compileDebugKotlin
+POCKETSHELL_TEST_MEM=6G scripts/cgroup-run.sh --unit local-repro -- bash -lc '...'
+```
+
+Only set `AVD_SCOPE=0` or bypass `scripts/cgroup-run.sh` when debugging cgroup
+setup itself.
 
 To run the same command manually:
 
 ```bash
-"$EMULATOR" -avd test \
+scripts/cgroup-run.sh -- "$EMULATOR" -avd test \
   -no-window \
   -no-audio \
   -no-boot-anim \

--- a/docs/docker-emulator-runbook.md
+++ b/docs/docker-emulator-runbook.md
@@ -466,9 +466,10 @@ Unless `GRADLE_USER_HOME` is already set, the gate uses
 `build/pre-release-confidence-gate/gradle-home` for its Gradle cache and daemon
 registry. This isolates the release gate from unrelated local Gradle daemon
 stops and generated-output churn in other worktrees. Gate Gradle invocations
-also pass `--no-build-cache`, `--no-parallel`, and `--max-workers=2` to avoid
-cache-packing races, generated-source ordering races, and resource
-oversubscription when other local Gradle jobs are active.
+also run through `scripts/cgroup-run.sh` and pass `--no-build-cache`,
+`--no-parallel`, and `--max-workers=2` to avoid cache-packing races,
+generated-source ordering races, and resource oversubscription when other local
+Gradle jobs are active.
 
 By default, the script copies the current working tree to
 `build/pre-release-confidence-gate/<run-id>/worktree` and re-execs from that

--- a/docs/release-terminal-gate.md
+++ b/docs/release-terminal-gate.md
@@ -60,7 +60,7 @@ terminal release evidence. Run this connected benchmark when release risk
 includes tmux session switching, SSH reuse, or terminal first-frame latency:
 
 ```bash
-./gradlew :app:connectedDebugAndroidTest \
+scripts/connected-test.sh --suffix warm-switch \
   -Pandroid.testInstrumentationRunnerArguments.class=com.pocketshell.app.proof.TmuxSessionSwitchSameHostReusesSshE2eTest#sameHostWarmSwitchBenchmarkReportsRepeatedStats
 ```
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -24,7 +24,7 @@ Command-line launch (no Android Studio):
 
 ```bash
 scripts/start-local-avd.sh
-./gradlew installDebug
+scripts/cgroup-run.sh -- ./gradlew installDebug
 adb shell am start -n com.pocketshell.app/.MainActivity
 ```
 
@@ -43,7 +43,7 @@ failure if the emulator exits after initially reporting boot complete.
 
 ### Automated UI tests
 
-Compose UI tests on the emulator via `./gradlew connectedDebugAndroidTest`. Use:
+Compose UI tests on the emulator via `scripts/connected-test.sh`. Use:
 
 - `createComposeRule()` for component-level tests
 - `createAndroidComposeRule<MainActivity>()` for screen-level tests
@@ -55,7 +55,7 @@ debug tests on an already-running emulator:
 
 ```bash
 docker compose -f tests/docker/docker-compose.yml up -d --build agents
-./gradlew connectedDebugAndroidTest
+scripts/connected-test.sh
 docker compose -f tests/docker/docker-compose.yml down --volumes --remove-orphans
 ```
 
@@ -68,7 +68,7 @@ flow, inspects the visible result, and records the command, artifact path, Docke
 involvement when relevant, and observed result in the issue.
 
 1. Start from the latest implementer status for the scoped issue
-2. `./gradlew installDebug`, or use the issue's documented walkthrough command
+2. `scripts/cgroup-run.sh -- ./gradlew installDebug`, or use the issue's documented walkthrough command
 3. Compare side-by-side with `docs/mockups/<screen>.html` open in Chrome at
    412 × 915
 4. Capture reviewer evidence:
@@ -226,10 +226,15 @@ scheme `5554 + 2K` -> `emulator-5556 / 5558 / 5560`), leaving the maintainer's
 manual `emulator-5554` untouched:
 
 ```bash
-scripts/avd-pool.sh start     # POOL_SIZE=3: boot test-1/2/3 (emulator-5556/5558/5560)
+scripts/avd-pool.sh start     # scoped: boot test-1/2/3 (emulator-5556/5558/5560)
 scripts/avd-pool.sh status    # CLONE / SERIAL / PORT / STATE + host load/RAM
 scripts/avd-pool.sh stop      # tear down the pool (leaves emulator-5554 alone)
 ```
+
+`avd-pool.sh` starts each pool emulator through `scripts/lib/scope-run.sh`, so
+the emulator process tree is memory-capped in its own sibling cgroup. If local
+user systemd is unavailable, pool startup fails closed instead of launching raw;
+set `POCKETSHELL_SCOPE_ALLOW_BARE=1` only when debugging cgroup setup.
 
 **KVM gotcha (this is the whole point of #776):** x86_64 emulation requires
 `/dev/kvm`, and on the Hetzner dev box a plain shell often lacks an *active*
@@ -243,10 +248,11 @@ foreground-steal + sibling-SIGKILL contention this issue set out to kill (a
 sibling lane launches its own `MainActivity` on the shared device, clearing
 another lane's activity -> `processForeground=false` -> null node lookups).
 
-So `avd-pool.sh` launches each pool emulator via `sg kvm -c "emulator -avd …"`
-to gain active `/dev/kvm` access. It auto-detects this: when the current shell
-can already read+write `/dev/kvm` (a CI runner with active membership) OR there
-is no `/dev/kvm` at all, it launches directly — byte-for-byte the legacy path.
+So `avd-pool.sh` launches each scoped pool emulator via
+`sg kvm -c "emulator -avd ..."` when that wrapper is needed to gain active
+`/dev/kvm` access. It auto-detects this: when the current shell can already
+read+write `/dev/kvm` (a CI runner with active membership) OR there is no
+`/dev/kvm` at all, it launches the emulator directly inside the cgroup scope.
 Override with `POOL_KVM_WRAP=sg` (always wrap) / `none` (never wrap) / `auto`
 (default).
 
@@ -276,7 +282,7 @@ single-lock, no-pin, no-pool behaviour unchanged.
 Two concurrent lanes, end to end:
 
 ```bash
-scripts/avd-pool.sh start                       # boot the pool via sg kvm
+scripts/avd-pool.sh start                       # boot the pool in cgroup scopes
 scripts/agents-pool.sh up 2222 2243             # warm two isolated agents fixtures
 CLASS=-Pandroid.testInstrumentationRunnerArguments.class=com.example.SomeE2eTest
 scripts/connected-test.sh --pool --suffix iA $CLASS &   # -> emulator-5556
@@ -375,7 +381,7 @@ ssh -i tests/docker/test_key -p 2222 -o StrictHostKeyChecking=no testuser@127.0.
 4. Run the connected Android smoke:
 
 ```bash
-./gradlew connectedDebugAndroidTest
+scripts/connected-test.sh
 ```
 
 The smoke test authenticates with `tests/docker/test_key`, connects to
@@ -413,10 +419,10 @@ visible-terminal sidecars, timings, Docker logs, instrumentation output, and
 logcat.
 
 If an emulator and the Docker `agents` service are already running, the focused
-Gradle equivalent is:
+wrapper equivalent is:
 
 ```bash
-./gradlew :app:connectedDebugAndroidTest \
+scripts/connected-test.sh --suffix i548 \
   -Pandroid.testInstrumentationRunnerArguments.class=com.pocketshell.app.proof.BackgroundGraceReconnectE2eTest#sixSecondAppSwitchWithProductionGraceDoesNotShowOrRecordReconnect
 ```
 
@@ -632,12 +638,13 @@ emulator-touching gate, the second invocation prints
 blocks until the first one exits. The lock is released automatically when
 the holding script exits (the open file descriptor closes).
 
-Individual `./gradlew :app:connectedDebugAndroidTest` invocations from
-implementer or reviewer worktrees do NOT take this lock: they are cheap
-to retry on collision and locking them would serialise all parallel
-worktree work. The lock is scoped to the release-gate scripts because
-their long sequential workflows cannot tolerate a sibling `adb install`
-mid-test (see issue #182).
+Direct `./gradlew :app:connectedDebugAndroidTest` invocations from implementer
+or reviewer worktrees do not take the AVD lock or cgroup scope and should not be
+used for local evidence. Use `scripts/connected-test.sh` for ad-hoc connected
+tests; it owns the lock/suffix/serial-pin/cgroup path. Some legacy broad
+harnesses still invoke Gradle internally, but new reusable local paths should
+call the wrapper or `scripts/cgroup-run.sh` rather than teaching raw connected
+Gradle.
 
 To override the lock-file path (rare; only useful when chaining gates by
 hand under a custom build directory):
@@ -739,7 +746,7 @@ running emulator + real-agent fixture without the rest of the release gate:
 
 ```bash
 docker compose -f tests/docker/real-agent/compose.yml up -d --build real-agents
-./gradlew :app:connectedDebugAndroidTest \
+scripts/connected-test.sh --suffix realagent \
   -Pandroid.testInstrumentationRunnerArguments.class=com.pocketshell.app.proof.RealAgentReleaseGateTest \
   -Pandroid.testInstrumentationRunnerArguments.pocketshellRealAgentReleaseGate=1
 ```
@@ -893,7 +900,7 @@ docker compose -f tests/docker/docker-compose.yml up -d --build \
 Run the issue #552 ride-through proof:
 
 ```bash
-./gradlew :app:connectedDebugAndroidTest \
+scripts/connected-test.sh --suffix netfault \
   -Pandroid.testInstrumentationRunnerArguments.pocketshellNetworkFaultProofs=true \
   -Pandroid.testInstrumentationRunnerArguments.class=com.pocketshell.app.proof.RideThroughInterruptionE2eTest
 ```
@@ -938,7 +945,7 @@ docker compose -f tests/docker/docker-compose.yml up -d --build \
 Run the whole opt-in suite on an already-running emulator:
 
 ```bash
-./gradlew :app:connectedDebugAndroidTest \
+scripts/connected-test.sh --suffix bootstrap \
   -Pandroid.testInstrumentationRunnerArguments.pocketshellBootstrapScenarios=true \
   -Pandroid.testInstrumentationRunnerArguments.class=com.pocketshell.app.bootstrap.HostBootstrapScenarioSuiteTest
 ```
@@ -946,7 +953,7 @@ Run the whole opt-in suite on an already-running emulator:
 Run one scenario by name:
 
 ```bash
-./gradlew :app:connectedDebugAndroidTest \
+scripts/connected-test.sh --suffix bootstrap \
   -Pandroid.testInstrumentationRunnerArguments.pocketshellBootstrapScenarios=true \
   -Pandroid.testInstrumentationRunnerArguments.class=com.pocketshell.app.bootstrap.HostBootstrapScenarioSuiteTest#uvInstall
 ```
@@ -1056,7 +1063,7 @@ GitHub Actions runs:
 2. `./gradlew :shared:core-ssh:integrationTest :shared:core-portfwd:integrationTest` — Docker-backed JVM integration tests via Testcontainers
 3. Local emulator + Docker agent smoke after the fast gates pass:
    - starts `tests/docker`'s `agents` target on host port 2222
-   - runs `./gradlew connectedDebugAndroidTest` on an Android emulator
+   - runs the connected Android suite on an emulator
    - uploads Android test reports and Docker logs as workflow artifacts
 
 ---
@@ -1069,8 +1076,8 @@ pushing an approved issue, the orchestrator follows the
 [process verification checklist](../process.md#verification-checklist).
 For testing-specific work, the minimum local checks are:
 
-1. `./gradlew assembleDebug` — does it build?
-2. `./gradlew check` — do unit tests pass?
+1. `scripts/cgroup-run.sh -- ./gradlew assembleDebug` — does it build?
+2. `scripts/cgroup-run.sh -- ./gradlew check` — do unit tests pass?
 3. For UI changes: install on emulator, eyeball against the matching mockup
 4. For SSH / tmux / agent / usage changes: run the relevant Testcontainers
    integration test

--- a/docs/walkthrough-visual-pass.md
+++ b/docs/walkthrough-visual-pass.md
@@ -148,7 +148,7 @@ Compose semantics nodes, not a full pixel-level proof for every painted element.
 Fresh compile validation after the assertion changes:
 
 ```text
-./gradlew --no-daemon --no-build-cache :app:compileDebugAndroidTestKotlin
+scripts/cgroup-run.sh -- ./gradlew --no-daemon --no-build-cache :app:compileDebugAndroidTestKotlin
 ```
 
 Result: `BUILD SUCCESSFUL in 21s`. This specifically verifies the screenshot

--- a/process.md
+++ b/process.md
@@ -974,7 +974,7 @@ After reviewer approval, the orchestrator runs:
 
 - [ ] `git status` shows only expected files
 - [ ] `git diff` reads sensibly
-- [ ] Build succeeds, usually `./gradlew assembleDebug`
+- [ ] Build succeeds, usually `scripts/cgroup-run.sh -- ./gradlew assembleDebug`
 - [ ] Tests pass for touched code
 - [ ] No secrets or generated build outputs are staged
 - [ ] Acceptance criteria are demonstrably met

--- a/scripts/android-upgrade-preservation-gate.sh
+++ b/scripts/android-upgrade-preservation-gate.sh
@@ -5,6 +5,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
 source "$ROOT_DIR/scripts/lib/avd-lock.sh"
+source "$ROOT_DIR/scripts/lib/scope-run.sh"
 pocketshell_acquire_avd_lock "$ROOT_DIR" "${1:-}"
 
 ANDROID_SDK="${ANDROID_SDK:-/home/alexey/Android/Sdk}"
@@ -64,7 +65,8 @@ install_apk() {
 }
 
 if [[ "$BUILD_NEW_APK" == "1" ]]; then
-  ./gradlew $GRADLE_FLAGS :app:assembleDebug
+  "$ROOT_DIR/scripts/cgroup-run.sh" --unit "pocketshell-upgrade-preservation-$(pocketshell_unit_token "$RUN_ID")-new-apk" -- \
+    ./gradlew $GRADLE_FLAGS :app:assembleDebug
 fi
 
 if [[ -z "$OLD_APK_PATH" ]]; then
@@ -74,10 +76,8 @@ if [[ -z "$OLD_APK_PATH" ]]; then
   fi
   old_worktree="$RUN_DIR/old-$OLD_REF"
   git worktree add --detach "$old_worktree" "$OLD_REF"
-  (
-    cd "$old_worktree"
-    ./gradlew $GRADLE_FLAGS :app:assembleDebug
-  )
+  "$ROOT_DIR/scripts/cgroup-run.sh" --unit "pocketshell-upgrade-preservation-$(pocketshell_unit_token "$RUN_ID")-old-apk" -- \
+    "$old_worktree/gradlew" $GRADLE_FLAGS -p "$old_worktree" :app:assembleDebug
   built_old_apk="$RUN_DIR/old-app-debug-$OLD_REF.apk"
   cp "$old_worktree/app/build/outputs/apk/debug/app-debug.apk" "$built_old_apk"
   git worktree remove --force "$old_worktree"

--- a/scripts/avd-pool.sh
+++ b/scripts/avd-pool.sh
@@ -21,7 +21,13 @@ set -euo pipefail
 # The base `test` AVD (emulator-5554) is deliberately NEVER in the pool, so a
 # sibling agent already using emulator-5554 is never disturbed.
 #
-# KVM / hardware acceleration (issue #776):
+# Cgroup scope + KVM / hardware acceleration (issues #730/#776):
+#   Pool emulator launches are heavy local processes. They run through
+#   scripts/lib/scope-run.sh by default, so emulator OOMs stop their own
+#   transient cgroup scope instead of the caller's tmux/session cgroup. If user
+#   systemd is unavailable locally, startup fails closed; set
+#   POCKETSHELL_SCOPE_ALLOW_BARE=1 only when debugging cgroup setup.
+#
 #   x86_64 emulation REQUIRES /dev/kvm. On the Hetzner dev box a plain shell
 #   often lacks ACTIVE kvm-group membership (the login session predates the
 #   group add), so a bare `emulator -avd ...` dies with "x86_64 emulation
@@ -46,11 +52,13 @@ set -euo pipefail
 #                            can reach it)
 #   ANDROID_SDK / ADB / EMULATOR   tool paths
 #   AVD_START_FLAGS          emulator launch flags
+#   POCKETSHELL_TEST_MEM=8G  MemoryMax for each emulator scope
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
 source "$ROOT_DIR/scripts/lib/avd-clone.sh"
+source "$ROOT_DIR/scripts/lib/scope-run.sh"
 
 ANDROID_SDK="${ANDROID_SDK:-/home/alexey/Android/Sdk}"
 ADB="${ADB:-$ANDROID_SDK/platform-tools/adb}"
@@ -91,28 +99,34 @@ pool_needs_kvm_wrap() {
   return 1
 }
 
-# Launch the emulator, wrapping in `sg kvm -c` when pool_needs_kvm_wrap says so.
-# The launched process is detached (nohup ... &) and its PID written by the
-# caller. When wrapping, the `sg` process is the parent of the emulator; killing
-# the process bound to the console port (emulator_pid_for_port) still tears the
-# emulator down regardless, so teardown is unaffected.
+# Launch the emulator in its own memory-capped sibling scope, wrapping in
+# `sg kvm -c` when pool_needs_kvm_wrap says so. When wrapping, the `sg` process
+# is the parent of the emulator; killing the process bound to the console port
+# (emulator_pid_for_port) still tears the emulator down, so teardown is
+# unaffected.
 pool_launch_emulator() {
-  local clone_name="$1" port="$2" logf="$3"
+  local clone_name="$1" port="$2" logf="$3" pidf="$4"
+  local scope_unit="pocketshell-avd-pool-${clone_name//[^A-Za-z0-9._-]/_}-${port}"
+  local -a avd_start_args
+  read -r -a avd_start_args <<< "$AVD_START_FLAGS"
+
+  {
+    printf '[%s] scope=%s.scope command:' "$(date -Is)" "$scope_unit"
+    printf ' %q' "$EMULATOR" -avd "$clone_name" -port "$port" "${avd_start_args[@]}"
+    printf '\n'
+  } > "$logf"
+
   if pool_needs_kvm_wrap; then
     # shellcheck disable=SC2016  # backticks here are literal log text, not a subshell
     printf '  (launching via `sg kvm -c` for /dev/kvm access)\n' >&2
-    # Build a single shell command string for sg -c. AVD_START_FLAGS is a
-    # space-separated flag list (word-splitting is intentional, as in the
-    # direct-launch path below).
-    # shellcheck disable=SC2086
-    nohup sg kvm -c "exec '$EMULATOR' -avd '$clone_name' -port '$port' $AVD_START_FLAGS" \
-      > "$logf" 2>&1 &
+    local sg_command
+    printf -v sg_command '%q ' "$EMULATOR" -avd "$clone_name" -port "$port" "${avd_start_args[@]}"
+    pocketshell_scope_start_background "$scope_unit" "$logf" "$pidf" \
+      sg kvm -c "exec $sg_command"
   else
-    # shellcheck disable=SC2086
-    nohup "$EMULATOR" -avd "$clone_name" -port "$port" $AVD_START_FLAGS \
-      > "$logf" 2>&1 &
+    pocketshell_scope_start_background "$scope_unit" "$logf" "$pidf" \
+      "$EMULATOR" -avd "$clone_name" -port "$port" "${avd_start_args[@]}"
   fi
-  printf '%s\n' "$!"
 }
 
 usage() {
@@ -129,6 +143,7 @@ parallel agents run connected tests without queueing on one AVD.
   purge    stop + delete the clone AVDs from disk
 
 Env: POOL_SIZE=3 BASE_AVD=test POOL_PORT_BASE=5554 BOOT_TIMEOUT_SECONDS=300
+     POCKETSHELL_TEST_MEM=8G POCKETSHELL_SCOPE_ALLOW_BARE=1
 USAGE
 }
 
@@ -178,7 +193,11 @@ boot_one() {
     printf 'Pool emulator on port %s already starting; waiting for boot.\n' "$port" >&2
   else
     printf 'Booting %s on port %s (%s)...\n' "$clone_name" "$port" "$serial" >&2
-    pool_launch_emulator "$clone_name" "$port" "$logf" > "$LOG_ROOT/$clone_name.pid"
+    if ! pool_launch_emulator "$clone_name" "$port" "$logf" "$LOG_ROOT/$clone_name.pid"; then
+      printf 'FAIL: could not start scoped emulator launch for %s. Log tail:\n' "$clone_name" >&2
+      tail -n 25 "$logf" >&2 || true
+      return 1
+    fi
   fi
 
   local deadline=$((SECONDS + BOOT_TIMEOUT_SECONDS))

--- a/scripts/capture-terminal-lab.sh
+++ b/scripts/capture-terminal-lab.sh
@@ -4,6 +4,10 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
+source "$ROOT_DIR/scripts/lib/avd-lock.sh"
+source "$ROOT_DIR/scripts/lib/scope-run.sh"
+pocketshell_acquire_avd_lock "$ROOT_DIR" "${1:-}"
+
 ANDROID_SDK="${ANDROID_SDK:-/home/alexey/Android/Sdk}"
 ADB="${ADB:-$ANDROID_SDK/platform-tools/adb}"
 EMULATOR="${EMULATOR:-$ANDROID_SDK/emulator/emulator}"
@@ -76,7 +80,7 @@ collect_diagnostics() {
     printf '\nDiagnostics collected in %s\n' "$RUN_DIR" >&2
   fi
 }
-trap collect_diagnostics EXIT
+trap 'collect_diagnostics; pocketshell_release_all' EXIT
 
 # Issue #150: wait on the compose `healthcheck:` block via
 # `docker inspect`, not a host-side SSH retry loop. Keep one follow-up
@@ -152,7 +156,9 @@ run_logged "06-cold-reset-emulator-app-state" bash -lc \
 run_logged "07-clear-logcat" "$ADB" logcat -c
 run_logged "08-clear-device-artifacts" "$ADB" shell rm -rf "$DEVICE_ARTIFACT_DIR"
 if [[ "$BUILD_APKS" = "1" ]]; then
-  run_logged "09-build-terminal-lab-apks" ./gradlew --no-daemon :app:assembleDebug :app:assembleDebugAndroidTest --stacktrace
+  run_logged "09-build-terminal-lab-apks" \
+    "$ROOT_DIR/scripts/cgroup-run.sh" --unit "pocketshell-terminal-lab-$(pocketshell_unit_token "$RUN_ID")-build-apks" -- \
+    ./gradlew --no-daemon :app:assembleDebug :app:assembleDebugAndroidTest --stacktrace
 else
   [[ -f "$APP_APK" ]] || fail "BUILD_APKS=0 but app APK is missing at $APP_APK"
   [[ -f "$TEST_APK" ]] || fail "BUILD_APKS=0 but androidTest APK is missing at $TEST_APK"

--- a/scripts/capture-walkthrough-screenshots.sh
+++ b/scripts/capture-walkthrough-screenshots.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
+source "$ROOT_DIR/scripts/lib/scope-run.sh"
+
 ANDROID_SDK="${ANDROID_SDK:-/home/alexey/Android/Sdk}"
 ADB="${ADB:-$ANDROID_SDK/platform-tools/adb}"
 EMULATOR="${EMULATOR:-$ANDROID_SDK/emulator/emulator}"
@@ -336,6 +338,7 @@ run_logged "07-clear-logcat" "$ADB" logcat -c
 run_logged "08-clear-device-screenshots" "$ADB" shell rm -rf "$DEVICE_OUTPUT_DIR"
 run_logged "09-stop-gradle-daemons" ./gradlew --stop
 run_logged "10-build-walkthrough-visual-apks" \
+  "$ROOT_DIR/scripts/cgroup-run.sh" --unit "pocketshell-visual-audit-$(pocketshell_unit_token "$RUN_ID")-build-apks" -- \
   ./gradlew --no-daemon --no-build-cache :app:assembleDebug :app:assembleDebugAndroidTest --stacktrace
 install_apks "11-install-walkthrough-visual-apks"
 run_instrumentation_class "12-run-main-walkthrough-visual-instrumentation" "$MAIN_TEST_CLASS"

--- a/scripts/capture-walkthrough-screenshots.sh
+++ b/scripts/capture-walkthrough-screenshots.sh
@@ -4,7 +4,9 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
+source "$ROOT_DIR/scripts/lib/avd-lock.sh"
 source "$ROOT_DIR/scripts/lib/scope-run.sh"
+pocketshell_acquire_avd_lock "$ROOT_DIR" "${1:-}"
 
 ANDROID_SDK="${ANDROID_SDK:-/home/alexey/Android/Sdk}"
 ADB="${ADB:-$ANDROID_SDK/platform-tools/adb}"
@@ -140,7 +142,7 @@ collect_diagnostics() {
     printf '\nDiagnostics collected in %s\n' "$RUN_DIR" >&2
   fi
 }
-trap collect_diagnostics EXIT
+trap 'collect_diagnostics; pocketshell_release_all' EXIT
 
 # Issue #150: wait on the compose `healthcheck:` block via
 # `docker inspect`, not a host-side SSH retry loop. Keep one follow-up
@@ -336,7 +338,9 @@ run_logged "06-cold-reset-emulator-app-state" bash -lc \
   _ "$ADB"
 run_logged "07-clear-logcat" "$ADB" logcat -c
 run_logged "08-clear-device-screenshots" "$ADB" shell rm -rf "$DEVICE_OUTPUT_DIR"
-run_logged "09-stop-gradle-daemons" ./gradlew --stop
+run_logged "09-stop-gradle-daemons" \
+  "$ROOT_DIR/scripts/cgroup-run.sh" --unit "pocketshell-visual-audit-$(pocketshell_unit_token "$RUN_ID")-stop-gradle" -- \
+  ./gradlew --stop
 run_logged "10-build-walkthrough-visual-apks" \
   "$ROOT_DIR/scripts/cgroup-run.sh" --unit "pocketshell-visual-audit-$(pocketshell_unit_token "$RUN_ID")-build-apks" -- \
   ./gradlew --no-daemon --no-build-cache :app:assembleDebug :app:assembleDebugAndroidTest --stacktrace

--- a/scripts/cgroup-run.sh
+++ b/scripts/cgroup-run.sh
@@ -15,11 +15,18 @@ Runs a heavy local reproduction command in a transient systemd --user scope
 with memory caps. Use this wrapper for local emulator/connected-test debugging
 when a purpose-built script does not already scope the command.
 
+Fail-closed rule:
+  If user systemd is unavailable, this wrapper refuses to run locally instead
+  of running the command uncapped in the caller's cgroup. Set
+  POCKETSHELL_SCOPE_ALLOW_BARE=1 only when debugging cgroup setup. CI may fall
+  back automatically.
+
 Defaults:
   POCKETSHELL_TEST_MEM=8G
   POCKETSHELL_TEST_HIGH=<85% of MemoryMax>
   POCKETSHELL_TEST_SWAP=8G
   POCKETSHELL_SCOPE_SLICE=robust.slice
+  POCKETSHELL_SCOPE_ALLOW_BARE=<unset>
 
 Examples:
   scripts/cgroup-run.sh -- ./gradlew --no-daemon :app:compileDebugKotlin

--- a/scripts/cgroup-run.sh
+++ b/scripts/cgroup-run.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+source "$ROOT_DIR/scripts/lib/scope-run.sh"
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/cgroup-run.sh [--unit <name>] -- <command> [args...]
+
+Runs a heavy local reproduction command in a transient systemd --user scope
+with memory caps. Use this wrapper for local emulator/connected-test debugging
+when a purpose-built script does not already scope the command.
+
+Defaults:
+  POCKETSHELL_TEST_MEM=8G
+  POCKETSHELL_TEST_HIGH=<85% of MemoryMax>
+  POCKETSHELL_TEST_SWAP=8G
+  POCKETSHELL_SCOPE_SLICE=robust.slice
+
+Examples:
+  scripts/cgroup-run.sh -- ./gradlew --no-daemon :app:compileDebugKotlin
+  POCKETSHELL_TEST_MEM=6G scripts/cgroup-run.sh --unit local-repro -- bash -lc '...'
+
+Prefer purpose-built wrappers when available:
+  AVD_HOLD=1 scripts/start-local-avd.sh
+  scripts/connected-test.sh --suffix i123 -Pandroid.testInstrumentationRunnerArguments.class=...
+USAGE
+}
+
+unit=""
+args=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    --unit)
+      [[ $# -ge 2 ]] || { printf 'FAIL: --unit needs a value\n' >&2; exit 2; }
+      unit="$2"
+      shift 2
+      ;;
+    --unit=*)
+      unit="${1#--unit=}"
+      shift
+      ;;
+    --)
+      shift
+      args+=("$@")
+      break
+      ;;
+    *)
+      args+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [[ "${#args[@]}" -eq 0 ]]; then
+  usage >&2
+  exit 2
+fi
+
+if [[ -z "$unit" ]]; then
+  base="$(basename "${args[0]}")"
+  unit="pocketshell-local-${base//[^A-Za-z0-9._-]/_}-$$"
+fi
+
+pocketshell_scope_run "$unit" "${args[@]}"

--- a/scripts/check-ci-journey-harness.sh
+++ b/scripts/check-ci-journey-harness.sh
@@ -141,6 +141,7 @@ KNOWN_UNWIRED_ANDROID_E2E_DOCKER_CLASSES=(
   "com.pocketshell.app.sessions.service.SessionConnectionServiceE2eTest"
   "com.pocketshell.app.session.ConversationToolResultPairingE2eTest"
   "com.pocketshell.app.session.ShowKeyboardChipE2eTest"
+  "com.pocketshell.app.sessions.service.SessionConnectionServiceE2eTest"
   "com.pocketshell.app.settings.ConversationFontSizeSettingE2eTest"
   "com.pocketshell.app.settings.DiagnosticsRecordingIndicatorE2eTest"
   "com.pocketshell.app.settings.SettingsAboutFooterE2eTest"

--- a/scripts/check-ci-journey-harness.sh
+++ b/scripts/check-ci-journey-harness.sh
@@ -141,7 +141,6 @@ KNOWN_UNWIRED_ANDROID_E2E_DOCKER_CLASSES=(
   "com.pocketshell.app.sessions.service.SessionConnectionServiceE2eTest"
   "com.pocketshell.app.session.ConversationToolResultPairingE2eTest"
   "com.pocketshell.app.session.ShowKeyboardChipE2eTest"
-  "com.pocketshell.app.sessions.service.SessionConnectionServiceE2eTest"
   "com.pocketshell.app.settings.ConversationFontSizeSettingE2eTest"
   "com.pocketshell.app.settings.DiagnosticsRecordingIndicatorE2eTest"
   "com.pocketshell.app.settings.SettingsAboutFooterE2eTest"

--- a/scripts/check-test-validity-selftest.sh
+++ b/scripts/check-test-validity-selftest.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 # Self-test for scripts/check-test-validity.sh (issue #850).
 #
-# For each NEW detector added in #850 (C1, FAKE1, AWAIT1) and the pre-existing
-# A5, this driver plants a BAD fixture (the smell) and a GOOD fixture (the
+# For each detector added for #848/#850 (C1, FAKE1, AWAIT1, J1) and the
+# pre-existing A5, this driver plants a BAD fixture (the smell) and a GOOD fixture (the
 # corrective shape), runs the guard, and asserts the bad fixture is reported as
 # a finding while the good fixture is NOT — the red->green proof for the
 # detector itself. It also asserts the guard HARD-FAILS (exit 1) when an
-# unjustified hard-fail smell (A5 / C1) is planted, and PASSES (exit 0) when
+# unjustified hard-fail smell (A5 / C1 / J1) is planted, and PASSES (exit 0) when
 # only the corrective shapes are present.
 #
 # Fixtures are planted under throwaway subdirectories of the REAL scanned test
@@ -48,7 +48,7 @@ note_fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
 
 # Assert a path appears (mode=present) or does not appear (mode=absent) as a
 # FINDING in the named report section. `section` is a substring of the section
-# header line (e.g. "C1 — NEW", "FAKE1 — NEW", "AWAIT1 — NEW"). A GOOD fixture
+# header line (e.g. "C1 — NEW", "FAKE1 — NEW", "AWAIT1 — NEW", "J1 — NEW"). A GOOD fixture
 # may legitimately appear in an advisory JUSTIFIED/KNOWN list — "absent" here
 # means "not listed as a finding in THIS section", not "absent from the whole
 # report".
@@ -138,6 +138,42 @@ assert_exit 1 "C1 unjustified skip hard-fails the guard"
 # Remove the BAD C1 so subsequent FAKE1/AWAIT1 (advisory) checks can confirm a
 # clean exit-0 with only advisory findings present.
 rm -f "$ANDROID_FIX_DIR/C1BadJourneyTest.kt"
+
+# --------------------------------------------------------------------------
+# J1 — androidTest E2e/Docker class missing ci-journey-suite coverage.
+# --------------------------------------------------------------------------
+echo
+echo "[J1] unwired androidTest journey class"
+
+# BAD: a new journey-shaped androidTest class that is not wired into
+# scripts/ci-journey-suite.sh and has no local reason for staying out.
+cat > "$ANDROID_FIX_DIR/J1BadUnwiredE2eTest.kt" <<'KT'
+package com.pocketshell.app.validityselftest
+class J1BadUnwiredE2eTest {
+    fun journey() {
+        // Load-bearing connected journey proof, but not in ci-journey-suite.
+    }
+}
+KT
+
+# GOOD: the same unwired shape with a local source-level justification.
+cat > "$ANDROID_FIX_DIR/J1GoodJustifiedDockerTest.kt" <<'KT'
+package com.pocketshell.app.validityselftest
+// CI_JOURNEY_SUITE_JUSTIFIED: opt-in Docker fixture runs only in nightly.
+class J1GoodJustifiedDockerTest {
+    fun journey() {
+        // Local/nightly-only fixture; the comment above is the required reason.
+    }
+}
+KT
+
+assert_report present "J1BadUnwiredE2eTest" "J1 — NEW" "J1 fires on an unwired androidTest journey"
+assert_report absent  "J1GoodJustifiedDockerTest" "J1 — NEW" "J1 spares a local ci-journey-suite justification"
+assert_exit 1 "J1 unwired androidTest journey hard-fails the guard"
+
+# Remove the BAD J1 so advisory checks can still prove guard-mode exit 0 when
+# no hard-fail smells remain.
+rm -f "$ANDROID_FIX_DIR/J1BadUnwiredE2eTest.kt"
 
 # --------------------------------------------------------------------------
 # FAKE1 — connect-path RPC test with an always-answering fake (no fault case).

--- a/scripts/check-test-validity.sh
+++ b/scripts/check-test-validity.sh
@@ -65,16 +65,25 @@
 #       but never returns pinned the coroutine and `Loading` never resolved.
 #       Advisory + baselined; the bound + regression test is the #847 hotfix.
 #
+#   J1 (HARD-FAIL on a NEW occurrence) — an androidTest `*E2eTest` /
+#       `*DockerTest` class that is not wired into `scripts/ci-journey-suite.sh`
+#       and has no local `// CI_JOURNEY_SUITE_JUSTIFIED:` reason. The per-push
+#       journey suite is the load-bearing connected-test net; new journey-shaped
+#       classes must either join it or say, next to the class, why they are
+#       intentionally local/nightly/backlog-only. Current known unwired classes
+#       are baselined, and stale J1 baseline entries hard-fail so the baseline
+#       only shrinks as classes are promoted or removed.
+#
 # A BASELINE allowlist records the offenders the audits catalogued but that are
 # intentionally NOT rewritten here (the rewrites are per-issue follow-up work).
 # Those are reported as KNOWN-baseline (advisory) so this guard does not redden
 # CI for tests it is not this PR's job to fix, while any NEW unjustified
-# occurrence (A5, C1) hard-fails. Removing a file from a baseline (because its
+# occurrence (A5, C1, J1) hard-fails. Removing a file from a baseline (because its
 # test was converted to the deterministic / fault-covering model) is the
 # intended direction of travel; a stale baseline entry is pruned + noted.
 #
 # Usage:
-#   scripts/check-test-validity.sh            # guard mode (CI): exit 1 on a NEW A5/C1 smell
+#   scripts/check-test-validity.sh            # guard mode (CI): exit 1 on a NEW A5/C1/J1 smell
 #   scripts/check-test-validity.sh --report   # report ALL findings incl. baseline; never fails
 #
 # This is intentionally a grep-guard, not a custom lint rule, for affordability
@@ -100,6 +109,8 @@ done < <(find shared -maxdepth 3 -type d -path 'shared/*/src/test' 2>/dev/null |
 # Connect-path production RPC sources (#850 AWAIT1). These are the warm-session
 # RPC seams consumed on the connect / cold-start path.
 RPC_SOURCE_ROOT="app/src/main/java/com/pocketshell/app"
+ANDROID_TEST_ROOT="app/src/androidTest/java"
+CI_JOURNEY_SUITE="scripts/ci-journey-suite.sh"
 
 # Collect all test .kt files once.
 collect_test_files() {
@@ -154,6 +165,99 @@ FAKE1_BASELINE=(
 AWAIT1_BASELINE=(
 )
 
+# --------------------------------------------------------------------------
+# BASELINE — J1 (#848 follow-up): current androidTest `*E2eTest` /
+# `*DockerTest` classes that are intentionally not in the per-push
+# ci-journey-suite yet. New journey-shaped classes must be wired into
+# scripts/ci-journey-suite.sh or carry a local
+# `// CI_JOURNEY_SUITE_JUSTIFIED:` reason in their source. Stale entries are a
+# hard failure so this list is removed when a class is promoted or deleted.
+# --------------------------------------------------------------------------
+J1_UNWIRED_ANDROID_E2E_DOCKER_BASELINE=(
+  "com.pocketshell.app.composer.AttachmentStagerRealUploadDockerTest"
+  "com.pocketshell.app.composer.ComposerPartialExpandE2eTest"
+  "com.pocketshell.app.composer.PromptComposerSendDismissE2eTest"
+  "com.pocketshell.app.costs.CostsScreenE2eTest"
+  "com.pocketshell.app.crash.ShareAllReportsDockerTest"
+  "com.pocketshell.app.env.EnvScreenE2eTest"
+  "com.pocketshell.app.fileexplorer.FileExplorerDockerTest"
+  "com.pocketshell.app.fileviewer.FileViewerDockerTest"
+  "com.pocketshell.app.fileviewer.LinkTapParsingDockerTest"
+  "com.pocketshell.app.fileviewer.TerminalFilePathTapToViewerDockerTest"
+  "com.pocketshell.app.git.GitHistoryDockerTest"
+  "com.pocketshell.app.hosts.DefaultHostLaunchE2eTest"
+  "com.pocketshell.app.hosts.HostAndFolderListScrollE2eTest"
+  "com.pocketshell.app.hosts.HostEditFromKebabE2eTest"
+  "com.pocketshell.app.notifications.UpdateAvailableNotificationE2eTest"
+  "com.pocketshell.app.portfwd.ForwardingIndicatorE2eTest"
+  "com.pocketshell.app.portfwd.ForwardingNotificationE2eTest"
+  "com.pocketshell.app.portfwd.ForwardingResumeOnLaunchE2eTest"
+  "com.pocketshell.app.portfwd.PortForwardPanelLifecycleE2eTest"
+  "com.pocketshell.app.projects.AgentLaunchCommandDockerTest"
+  "com.pocketshell.app.projects.FolderListGatewayDockerTest"
+  "com.pocketshell.app.projects.FolderListGatewayStaleChannelHealDockerTest"
+  "com.pocketshell.app.projects.FolderListKillSessionDockerTest"
+  "com.pocketshell.app.projects.FolderListOutOfBandSessionDockerTest"
+  "com.pocketshell.app.projects.FolderListSessionResumeDockerTest"
+  "com.pocketshell.app.projects.FolderListTreeStopSessionDockerTest"
+  "com.pocketshell.app.projects.WatchedFoldersE2eTest"
+  "com.pocketshell.app.proof.BackgroundResumeSocketDeathE2eTest"
+  "com.pocketshell.app.proof.CodexOverflowNoReconnectE2eTest"
+  "com.pocketshell.app.proof.CodexRedrawOverflowReconnectE2eTest"
+  "com.pocketshell.app.proof.CodexWindowStartupControlSequenceE2eTest"
+  "com.pocketshell.app.proof.ColdInstallE2eTest"
+  "com.pocketshell.app.proof.DisconnectBlackholeE2eTest"
+  "com.pocketshell.app.proof.DisconnectFlapSoakE2eTest"
+  "com.pocketshell.app.proof.EmulatorWorkflowE2eTest"
+  "com.pocketshell.app.proof.FastResumeReconnectE2eTest"
+  "com.pocketshell.app.proof.MultiHostSessionE2eTest"
+  "com.pocketshell.app.proof.NavigatorBackForegroundNoSshE2eTest"
+  "com.pocketshell.app.proof.NetworkLatencyModelE2eTest"
+  "com.pocketshell.app.proof.NoBackgroundWorkE2eTest"
+  "com.pocketshell.app.proof.PacketLossNetworkFaultE2eTest"
+  "com.pocketshell.app.proof.ProjectSwitcherDropdownE2eTest"
+  "com.pocketshell.app.proof.RideThroughInterruptionE2eTest"
+  "com.pocketshell.app.proof.SessionSwipeSwitchE2eTest"
+  "com.pocketshell.app.proof.SilentMidSessionDropDetectionE2eTest"
+  "com.pocketshell.app.proof.SshReconnectE2eTest"
+  "com.pocketshell.app.proof.StaleLeaseSwitchRecoveryE2eTest"
+  "com.pocketshell.app.proof.StrictModeNoNetworkOnMainE2eTest"
+  "com.pocketshell.app.proof.SystemBackForegroundE2eTest"
+  "com.pocketshell.app.proof.TmuxBracketedPasteDictationE2eTest"
+  "com.pocketshell.app.proof.TmuxDetachOnBackgroundE2eTest"
+  "com.pocketshell.app.proof.TmuxExternalUpdateDockerTest"
+  "com.pocketshell.app.proof.TmuxKeyBarCtrlComboE2eTest"
+  "com.pocketshell.app.proof.TmuxOrphanClientCleanupE2eTest"
+  "com.pocketshell.app.proof.TmuxSessionSwitchE2eTest"
+  "com.pocketshell.app.proof.TmuxSessionSwitchSameHostReusesSshE2eTest"
+  "com.pocketshell.app.proof.TmuxTerminalSurfaceFailureE2eTest"
+  "com.pocketshell.app.proof.WarmLeaseReuseBatchCDockerTest"
+  "com.pocketshell.app.proof.WarmLeaseReuseDockerTest"
+  "com.pocketshell.app.proof.WithinGraceResumeRideThroughE2eTest"
+  "com.pocketshell.app.release.UpdateCheckSchedulerE2eTest"
+  "com.pocketshell.app.session.ConversationToolResultPairingE2eTest"
+  "com.pocketshell.app.session.ShowKeyboardChipE2eTest"
+  "com.pocketshell.app.sessions.service.SessionConnectionServiceE2eTest"
+  "com.pocketshell.app.settings.ConversationFontSizeSettingE2eTest"
+  "com.pocketshell.app.settings.DiagnosticsRecordingIndicatorE2eTest"
+  "com.pocketshell.app.settings.SettingsAboutFooterE2eTest"
+  "com.pocketshell.app.settings.SettingsPersistenceE2eTest"
+  "com.pocketshell.app.settings.SettingsSectionOrderE2eTest"
+  "com.pocketshell.app.share.SharePasteIntoSessionE2eTest"
+  "com.pocketshell.app.snippets.SnippetPickerTmuxZOrderDockerTest"
+  "com.pocketshell.app.terminal.TerminalLabDockerTest"
+  "com.pocketshell.app.tmux.ConversationOpenLatencyRttDockerTest"
+  "com.pocketshell.app.tmux.Issue887TerminalFixedUnderImeE2eTest"
+  "com.pocketshell.app.tmux.TmuxAttachPrefillDockerTest"
+  "com.pocketshell.app.tmux.TmuxAttachTimeoutDockerTest"
+  "com.pocketshell.app.tmux.TmuxDetectedPortForwardDockerTest"
+  "com.pocketshell.app.tmux.TmuxResizeSessionE2eTest"
+  "com.pocketshell.app.tmux.TmuxSessionOpencodeInputDockerTest"
+  "com.pocketshell.app.tmux.TmuxShellComposerOcclusionE2eTest"
+  "com.pocketshell.app.usage.UsageScreenE2eTest"
+  "com.pocketshell.app.usage.UsageThresholdNotificationE2eTest"
+)
+
 in_list() {
   local file="$1"; shift
   local b
@@ -168,6 +272,24 @@ in_list() {
 # --------------------------------------------------------------------------
 is_code_line() {
   ! printf '%s' "$1" | grep -Eq '^[[:space:]]*(\*|//|import |/\*)'
+}
+
+android_class_file_for() {
+  local fqcn="$1"
+  local rel="${fqcn//.//}"
+  printf '%s/%s.kt\n' "$ANDROID_TEST_ROOT" "$rel"
+}
+
+android_test_fqcn_for_file() {
+  local file="$1"
+  local rel="${file#"$ANDROID_TEST_ROOT"/}"
+  rel="${rel%.kt}"
+  printf '%s\n' "${rel//\//.}"
+}
+
+has_ci_journey_suite_justification() {
+  local file="$1"
+  grep -Eq 'CI_JOURNEY_SUITE_JUSTIFIED:[[:space:]]*[^[:space:]]' "$file"
 }
 
 # --------------------------------------------------------------------------
@@ -467,6 +589,79 @@ scan_await1() {
 }
 
 # --------------------------------------------------------------------------
+# J1 scan (#848 follow-up) — androidTest `*E2eTest` / `*DockerTest` classes
+# must be in the per-push ci-journey-suite, locally justified, or part of the
+# current unwired baseline.
+# --------------------------------------------------------------------------
+declare -a J1_WIRED=()
+declare -a J1_NEW=()
+declare -a J1_KNOWN=()
+declare -a J1_JUSTIFIED=()
+declare -a J1_STALE_BASELINE=()
+declare -a J1_PARSER_FAILURE=()
+declare -a J1_WIRED_ANDROID_TEST_CLASSES=()
+declare -A J1_WIRED_ANDROID_TEST_SEEN=()
+
+parse_ci_journey_suite_classes() {
+  if [[ ! -f "$CI_JOURNEY_SUITE" ]]; then
+    J1_PARSER_FAILURE+=("missing $CI_JOURNEY_SUITE")
+    return
+  fi
+
+  local fqcn
+  while IFS= read -r fqcn; do
+    [[ -z "${fqcn:-}" ]] && continue
+    if [[ -z "${J1_WIRED_ANDROID_TEST_SEEN[$fqcn]:-}" ]]; then
+      J1_WIRED_ANDROID_TEST_CLASSES+=("$fqcn")
+      J1_WIRED_ANDROID_TEST_SEEN[$fqcn]=1
+    fi
+  done < <(
+    sed -nE \
+      -e 's/.*"\$FQCN_PREFIX\.([A-Za-z0-9_]+)(#[^"]*)?".*/com.pocketshell.app.proof.\1/p' \
+      -e 's/.*"(com\.pocketshell\.app\.[A-Za-z0-9_.]+)(#[^"]*)?".*/\1/p' \
+      "$CI_JOURNEY_SUITE"
+  )
+
+  if [[ "${#J1_WIRED_ANDROID_TEST_CLASSES[@]}" -eq 0 ]]; then
+    J1_PARSER_FAILURE+=("no androidTest classes parsed from $CI_JOURNEY_SUITE")
+  fi
+}
+
+scan_j1() {
+  parse_ci_journey_suite_classes
+
+  local file fqcn
+  while IFS= read -r file; do
+    [[ -z "${file:-}" ]] && continue
+    fqcn="$(android_test_fqcn_for_file "$file")"
+    if in_list "$fqcn" "${J1_WIRED_ANDROID_TEST_CLASSES[@]}"; then
+      J1_WIRED+=("$fqcn")
+    elif has_ci_journey_suite_justification "$file"; then
+      J1_JUSTIFIED+=("$fqcn")
+    elif in_list "$fqcn" "${J1_UNWIRED_ANDROID_E2E_DOCKER_BASELINE[@]}"; then
+      J1_KNOWN+=("$fqcn")
+    else
+      J1_NEW+=("$fqcn")
+    fi
+  done < <(
+    find "$ANDROID_TEST_ROOT" -type f \
+      \( -name '*E2eTest.kt' -o -name '*DockerTest.kt' \) \
+      2>/dev/null | sort
+  )
+
+  for fqcn in "${J1_UNWIRED_ANDROID_E2E_DOCKER_BASELINE[@]}"; do
+    file="$(android_class_file_for "$fqcn")"
+    if [[ ! -f "$file" ]]; then
+      J1_STALE_BASELINE+=("$fqcn -> missing source file")
+    elif in_list "$fqcn" "${J1_WIRED_ANDROID_TEST_CLASSES[@]}"; then
+      J1_STALE_BASELINE+=("$fqcn -> now wired into $CI_JOURNEY_SUITE")
+    elif has_ci_journey_suite_justification "$file"; then
+      J1_STALE_BASELINE+=("$fqcn -> now has local CI_JOURNEY_SUITE_JUSTIFIED")
+    fi
+  done
+}
+
+# --------------------------------------------------------------------------
 # Validate baselines: prune entries whose file no longer exists.
 # --------------------------------------------------------------------------
 declare -a STALE_BASELINE=()
@@ -479,12 +674,14 @@ scan_a4
 scan_c1
 scan_fake1
 scan_await1
+scan_j1
 
 echo "=============================================================="
 echo " Test-validity guard (issue #657 / F4; extended #848 / #850)"
 echo " Scanned test roots:"
 for r in "${TEST_ROOTS[@]}"; do echo "   - $r/**/*.kt"; done
 echo " Connect-path RPC sources: $RPC_SOURCE_ROOT/**/*RemoteSource.kt (+ FolderListViewModel.kt)"
+echo " CI journey suite: $CI_JOURNEY_SUITE (${#J1_WIRED_ANDROID_TEST_CLASSES[@]} androidTest class entr(y/ies) parsed)"
 echo "=============================================================="
 
 print_list() {
@@ -517,6 +714,12 @@ print_list "FAKE1 — NEW connect-path test with an always-answering fake (no fa
 print_list "FAKE1 — KNOWN baseline (always-answering connect fake; #847/#849) [advisory]" "${FAKE1_KNOWN[@]:-}"
 print_list "AWAIT1 — NEW unbounded connect-path RPC await (no withTimeout) [advisory]" "${AWAIT1_FINDINGS[@]:-}"
 print_list "AWAIT1 — KNOWN baseline (unbounded connect RPC; #847) [advisory]" "${AWAIT1_KNOWN[@]:-}"
+print_list "J1 — WIRED androidTest E2e/Docker classes in ci-journey-suite.sh [advisory]" "${J1_WIRED[@]:-}"
+print_list "J1 — NEW androidTest E2e/Docker class missing ci-journey-suite coverage or local justification [HARD FAIL]" "${J1_NEW[@]:-}"
+print_list "J1 — KNOWN unwired androidTest E2e/Docker baseline (#848 follow-up) [advisory]" "${J1_KNOWN[@]:-}"
+print_list "J1 — JUSTIFIED local CI_JOURNEY_SUITE_JUSTIFIED exemption [advisory]" "${J1_JUSTIFIED[@]:-}"
+print_list "J1 — STALE unwired baseline entry [HARD FAIL]" "${J1_STALE_BASELINE[@]:-}"
+print_list "J1 — PARSER failure reading ci-journey-suite.sh [HARD FAIL]" "${J1_PARSER_FAILURE[@]:-}"
 
 if [[ "${#STALE_BASELINE[@]}" -gt 0 ]]; then
   echo
@@ -537,11 +740,18 @@ echo "        never-returns/hang, timeout) so Loading must still resolve"
 echo "        (the v0.4.10 #847 gap; fixture work tracked in #849)."
 echo " AWAIT1 bound the warm-session RPC with withTimeout so a"
 echo "        non-returning exec cannot pin the cold-start coroutine (#847)."
+echo " J1     wire the androidTest journey into scripts/ci-journey-suite.sh"
+echo "        or add a local // CI_JOURNEY_SUITE_JUSTIFIED: reason."
 echo "--------------------------------------------------------------"
 
-# Collect the HARD-FAIL categories (A5 + C1).
+# Collect the HARD-FAIL categories (A5 + C1 + J1).
 real_hard_fail=()
-for x in "${A5_NEW[@]:-}" "${C1_NEW[@]:-}"; do
+for x in \
+  "${A5_NEW[@]:-}" \
+  "${C1_NEW[@]:-}" \
+  "${J1_NEW[@]:-}" \
+  "${J1_STALE_BASELINE[@]:-}" \
+  "${J1_PARSER_FAILURE[@]:-}"; do
   [[ -n "$x" ]] && real_hard_fail+=("$x")
 done
 
@@ -553,12 +763,12 @@ fi
 
 if [[ "${#real_hard_fail[@]}" -gt 0 ]]; then
   echo
-  echo "::error title=Test-validity guard (issue #657/#848)::A NEW load-bearing self-skip was found. An IME/keyboard/geometry test must not gate its assertion behind assumeTrue(...) (convert to the synthetic-inset model, #780), and a connect/journey test must not gate behind assumeFalse(isRunningOnCi()) outside a genuine opt-in fault/Docker fixture (inject the state and HARD-assert, or add an inline // JUSTIFIED: comment naming the opt-in fixture)."
+  echo "::error title=Test-validity guard (issue #657/#848)::A NEW load-bearing self-skip or ungated androidTest journey was found. An IME/keyboard/geometry test must not gate its assertion behind assumeTrue(...) (convert to the synthetic-inset model, #780), a connect/journey test must not gate behind assumeFalse(isRunningOnCi()) outside a genuine opt-in fault/Docker fixture (inject the state and HARD-assert, or add an inline // JUSTIFIED: comment naming the opt-in fixture), and a new androidTest *E2eTest/*DockerTest class must be wired into scripts/ci-journey-suite.sh or carry a local // CI_JOURNEY_SUITE_JUSTIFIED: reason. Remove stale J1 baselines when a class is promoted or deleted."
   echo
-  echo "FAIL: ${#real_hard_fail[@]} new unjustified hard-fail occurrence(s) (A5 + C1)."
+  echo "FAIL: ${#real_hard_fail[@]} unjustified hard-fail occurrence(s) (A5 + C1 + J1)."
   exit 1
 fi
 
 echo
-echo "PASS: no new unjustified load-bearing self-skips (A5 + C1)."
+echo "PASS: no new unjustified load-bearing self-skips or ungated androidTest journeys (A5 + C1 + J1)."
 exit 0

--- a/scripts/issue271-startup-connect-timing.sh
+++ b/scripts/issue271-startup-connect-timing.sh
@@ -4,6 +4,10 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
+source "$ROOT_DIR/scripts/lib/avd-lock.sh"
+source "$ROOT_DIR/scripts/lib/scope-run.sh"
+pocketshell_acquire_avd_lock "$ROOT_DIR" "${1:-}"
+
 ANDROID_SDK="${ANDROID_SDK:-/home/alexey/Android/Sdk}"
 ADB="${ADB:-$ANDROID_SDK/platform-tools/adb}"
 PACKAGE="${PACKAGE:-com.pocketshell.app}"
@@ -72,7 +76,7 @@ Environment:
   LOG_ROOT=<dir>            default build/issue271-startup-connect
   LAUNCHES=3                number of measured launches
   WAIT_AFTER_START_SEC=35   logcat capture window after each launch
-  BUILD_APK=1               run ./gradlew :app:assembleDebug first
+  BUILD_APK=1               build :app:assembleDebug first via scripts/cgroup-run.sh
   INSTALL_APK=1             adb install -r the debug APK before launch 1
   APP_APK=<path>            APK path when BUILD_APK=0 or custom install
   SCENARIO=...              tmux-process-death-resume or hostlist-force-stop
@@ -333,7 +337,9 @@ run_logged "01-adb-devices" "$ADB" devices -l
 "$ADB" shell getprop >"$RUN_DIR/getprop.txt" 2>&1 || true
 
 if [[ "$BUILD_APK" == "1" ]]; then
-  run_logged "02-assemble-debug" ./gradlew :app:assembleDebug
+  run_logged "02-assemble-debug" \
+    "$ROOT_DIR/scripts/cgroup-run.sh" --unit "pocketshell-issue271-$(pocketshell_unit_token "$RUN_ID")-assemble-debug" -- \
+    ./gradlew :app:assembleDebug
 fi
 
 if command -v unzip >/dev/null 2>&1 && [[ -f "$APP_APK" ]]; then

--- a/scripts/issue78-phone-walkthrough.sh
+++ b/scripts/issue78-phone-walkthrough.sh
@@ -4,7 +4,9 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
+source "$ROOT_DIR/scripts/lib/avd-lock.sh"
 source "$ROOT_DIR/scripts/lib/scope-run.sh"
+pocketshell_acquire_avd_lock "$ROOT_DIR" "${1:-}"
 
 ANDROID_SDK="${ANDROID_SDK:-/home/alexey/Android/Sdk}"
 ADB="${ADB:-$ANDROID_SDK/platform-tools/adb}"
@@ -92,7 +94,7 @@ collect_diagnostics() {
   "$ADB" devices -l > "$RUN_DIR/adb-devices-final.txt" 2>&1 || true
   "$ADB" logcat -d -v threadtime > "$RUN_DIR/adb-logcat-final.txt" 2>&1 || true
 }
-trap collect_diagnostics EXIT
+trap 'collect_diagnostics; pocketshell_release_all' EXIT
 
 prepare_verify_root() {
   if [[ -e "$ROOT_DIR/app/src/main/java/com/pocketshell/app/terminal/TerminalLabActivity.kt" ]] &&

--- a/scripts/issue78-phone-walkthrough.sh
+++ b/scripts/issue78-phone-walkthrough.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
+source "$ROOT_DIR/scripts/lib/scope-run.sh"
+
 ANDROID_SDK="${ANDROID_SDK:-/home/alexey/Android/Sdk}"
 ADB="${ADB:-$ANDROID_SDK/platform-tools/adb}"
 COMPOSE_FILE="${COMPOSE_FILE:-tests/docker/docker-compose.yml}"
@@ -232,7 +234,9 @@ run_logged "01-docker-agents-up" docker compose -f "$ROOT_DIR/$COMPOSE_FILE" up 
 wait_for_docker_ssh
 wait_for_emulator
 wait_for_pocketshell_idle "03b-wait-for-shared-emulator-idle"
-run_logged "04-build-apks" "$VERIFY_ROOT/gradlew" --no-daemon --no-build-cache -p "$VERIFY_ROOT" :app:assembleDebug :app:assembleDebugAndroidTest --stacktrace
+run_logged "04-build-apks" \
+  "$ROOT_DIR/scripts/cgroup-run.sh" --unit "pocketshell-issue78-$(pocketshell_unit_token "$RUN_ID")-build-apks" -- \
+  "$VERIFY_ROOT/gradlew" --no-daemon --no-build-cache -p "$VERIFY_ROOT" :app:assembleDebug :app:assembleDebugAndroidTest --stacktrace
 wait_for_pocketshell_idle "05-wait-before-install"
 install_apks
 wait_for_pocketshell_idle "06c-wait-before-issue78-instrumentation"

--- a/scripts/keyboard-stress.sh
+++ b/scripts/keyboard-stress.sh
@@ -24,6 +24,10 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
+source "$ROOT_DIR/scripts/lib/avd-lock.sh"
+source "$ROOT_DIR/scripts/lib/scope-run.sh"
+pocketshell_acquire_avd_lock "$ROOT_DIR" "${1:-}"
+
 ANDROID_SDK="${ANDROID_SDK:-/home/alexey/Android/Sdk}"
 ADB="${ADB:-$ANDROID_SDK/platform-tools/adb}"
 EMULATOR="${EMULATOR:-$ANDROID_SDK/emulator/emulator}"
@@ -125,7 +129,7 @@ collect_diagnostics() {
 }
 
 mkdir -p "$RUN_DIR"
-trap collect_diagnostics EXIT
+trap 'collect_diagnostics; pocketshell_release_all' EXIT
 
 printf 'PocketShell keyboard stress harness (issue #104)\n'
 printf 'Artifacts: %s\n' "$RUN_DIR"
@@ -137,14 +141,23 @@ printf 'Test selector: %s\n' "$TEST_SELECTOR"
 command -v ssh >/dev/null 2>&1 || fail "ssh client is missing"
 
 if ! "$ADB" get-state >/dev/null 2>&1; then
-  run_logged "00-start-emulator" "$EMULATOR" -avd "$AVD_NAME" -no-snapshot -no-window -gpu swiftshader_indirect -no-audio -no-boot-anim &
+  declare -a emulator_cmd=()
+  pocketshell_build_sg_kvm_command emulator_cmd \
+    "$EMULATOR" -avd "$AVD_NAME" -no-snapshot -no-window -gpu swiftshader_indirect -no-audio -no-boot-anim
+  pocketshell_scope_start_background \
+    "pocketshell-keyboard-stress-avd-$(pocketshell_unit_token "$RUN_ID")" \
+    "$RUN_DIR/00-start-emulator.log" \
+    "$RUN_DIR/00-start-emulator.pid" \
+    "${emulator_cmd[@]}"
 fi
 run_logged "01-wait-emulator" wait_for_emulator
 run_logged "02-docker-agents-up" docker compose -f "$COMPOSE_FILE" up -d --build agents
 run_logged "03-docker-ssh-readiness" wait_for_ssh_fixture
 
 if [[ "$BUILD_APKS" == "1" ]]; then
-  run_logged "04-build-apks" ./gradlew --no-daemon :app:assembleDebug :app:assembleDebugAndroidTest --stacktrace
+  run_logged "04-build-apks" \
+    "$ROOT_DIR/scripts/cgroup-run.sh" --unit "pocketshell-keyboard-stress-$(pocketshell_unit_token "$RUN_ID")-build-apks" -- \
+    ./gradlew --no-daemon :app:assembleDebug :app:assembleDebugAndroidTest --stacktrace
 else
   [[ -f "$APP_APK" ]] || fail "app APK missing at $APP_APK"
   [[ -f "$TEST_APK" ]] || fail "test APK missing at $TEST_APK"

--- a/scripts/lib/scope-run.sh
+++ b/scripts/lib/scope-run.sh
@@ -45,6 +45,7 @@
 # -----
 #   source scripts/lib/scope-run.sh
 #   pocketshell_scope_run <unit> <cmd...>
+#   pocketshell_scope_start_background <unit> <log-file> <pid-file> <cmd...>
 #
 # The memory caps are env-tunable (so CI/dev can size them):
 #   POCKETSHELL_TEST_MEM   hard MemoryMax for the scope         (default 8G)
@@ -173,4 +174,40 @@ pocketshell_scope_run() {
     systemctl --user reset-failed "$unit.scope" >/dev/null 2>&1 || true
   fi
   return "$rc"
+}
+
+# pocketshell_scope_start_background <unit> <log-file> <pid-file> <cmd...>
+#
+# Starts <cmd...> under the same memory-capped transient scope as
+# pocketshell_scope_run, but returns immediately after writing the launcher PID
+# to <pid-file>. This is for long-lived local reproduction processes such as
+# the Android emulator. The scoped process tree still has its own sibling
+# cgroup, so an OOM stops that scope rather than the interactive session.
+pocketshell_scope_start_background() {
+  local unit="$1"
+  local log_file="$2"
+  local pid_file="$3"
+  shift 3
+  if [[ -z "$unit" || -z "$log_file" || -z "$pid_file" || $# -eq 0 ]]; then
+    printf 'pocketshell_scope_start_background: need <unit> <log-file> <pid-file> and a command\n' >&2
+    return 2
+  fi
+
+  mkdir -p "$(dirname "$log_file")" "$(dirname "$pid_file")"
+
+  if ! pocketshell_scope_available; then
+    printf 'scope-run: user systemd unavailable; starting %s BARE (uncapped fallback)\n' \
+      "$unit" >&2
+    nohup "$@" >> "$log_file" 2>&1 &
+    printf '%s\n' "$!" > "$pid_file"
+    return 0
+  fi
+
+  (
+    exec >> "$log_file" 2>&1
+    pocketshell_scope_run "$unit" "$@"
+  ) &
+  printf '%s\n' "$!" > "$pid_file"
+  printf 'scope-run: background launcher for %s.scope pid=%s log=%s\n' \
+    "$unit" "$!" "$log_file" >&2
 }

--- a/scripts/lib/scope-run.sh
+++ b/scripts/lib/scope-run.sh
@@ -59,6 +59,57 @@
 # The <unit> should be UNIQUE per invocation (include suffix/serial/pid) so
 # parallel lanes get distinct sibling scopes that never collide.
 
+pocketshell_unit_token() {
+  local token="${1//[^A-Za-z0-9._-]/_}"
+  [[ -n "$token" ]] || token="default"
+  printf '%s' "$token"
+}
+
+pocketshell_shell_join() {
+  local arg quoted joined=""
+  for arg in "$@"; do
+    printf -v quoted '%q' "$arg"
+    joined+=" $quoted"
+  done
+  printf '%s' "${joined# }"
+}
+
+pocketshell_should_wrap_sg_kvm() {
+  case "${POCKETSHELL_EMULATOR_SG_KVM:-auto}" in
+    0 | false | FALSE | no | NO)
+      return 1
+      ;;
+    1 | true | TRUE | yes | YES)
+      command -v sg >/dev/null 2>&1 || return 1
+      getent group kvm >/dev/null 2>&1 || return 1
+      return 0
+      ;;
+  esac
+
+  [[ -e /dev/kvm ]] || return 1
+  [[ -r /dev/kvm && -w /dev/kvm ]] && return 1
+  command -v sg >/dev/null 2>&1 || return 1
+  local group_entry user
+  group_entry="$(getent group kvm 2>/dev/null || true)"
+  [[ -n "$group_entry" ]] || return 1
+  user="$(id -un 2>/dev/null || true)"
+  [[ -n "$user" ]] || return 1
+  if id -nG 2>/dev/null | tr ' ' '\n' | grep -Fxq kvm; then
+    return 0
+  fi
+  [[ ",${group_entry##*:}," == *",$user,"* ]] || return 1
+  return 0
+}
+
+pocketshell_build_sg_kvm_command() {
+  local -n _pocketshell_out="$1"
+  shift
+  _pocketshell_out=("$@")
+  if pocketshell_should_wrap_sg_kvm; then
+    _pocketshell_out=(sg kvm -c "$(pocketshell_shell_join "$@")")
+  fi
+}
+
 # robust.systemd_available() equivalent: systemd-run on PATH AND a reachable
 # user systemd manager. `systemctl --user is-system-running` returns one of
 # running/degraded/starting/... with exit 0/1 when the bus is reachable, and

--- a/scripts/lib/scope-run.sh
+++ b/scripts/lib/scope-run.sh
@@ -35,11 +35,13 @@
 # of dying outright; we additionally pin `OOMPolicy=stop` so that when the hard
 # wall IS hit, only this scope's process tree is stopped.
 #
-# GRACEFUL DEGRADE
-# ----------------
-# When `systemd-run` / a working user systemd is unavailable (e.g. CI), the
-# command is run BARE — byte-for-byte the legacy behaviour — and a one-line
-# warning is emitted. Mirrors robust.systemd_available().
+# FAIL-CLOSED LOCAL DEFAULT
+# -------------------------
+# When `systemd-run` / a working user systemd is unavailable, local runs fail
+# instead of silently running heavy work in the caller's cgroup. CI still falls
+# back to bare execution because many hosted runners do not expose user systemd.
+# A local caller may opt into the old uncapped fallback for cgroup debugging with
+# POCKETSHELL_SCOPE_ALLOW_BARE=1.
 #
 # USAGE
 # -----
@@ -52,6 +54,7 @@
 #   POCKETSHELL_TEST_HIGH  soft MemoryHigh throttle threshold   (default ~85% of MEM)
 #   POCKETSHELL_TEST_SWAP  MemorySwapMax cushion                (default 8G)
 #   POCKETSHELL_SCOPE_SLICE parent slice                        (default robust.slice)
+#   POCKETSHELL_SCOPE_ALLOW_BARE=1 allow uncapped fallback outside CI
 #
 # The <unit> should be UNIQUE per invocation (include suffix/serial/pid) so
 # parallel lanes get distinct sibling scopes that never collide.
@@ -77,6 +80,28 @@ pocketshell_scope_available() {
       return 1
       ;;
   esac
+}
+
+pocketshell_scope_allow_bare() {
+  case "${POCKETSHELL_SCOPE_ALLOW_BARE:-}" in
+    1 | true | TRUE | yes | YES)
+      return 0
+      ;;
+  esac
+  case "${CI:-}" in
+    "" | 0 | false | FALSE | no | NO)
+      return 1
+      ;;
+    *)
+      return 0
+      ;;
+  esac
+}
+
+_pocketshell_scope_unavailable_message() {
+  local unit="$1"
+  printf 'scope-run: user systemd unavailable; refusing to run %s uncapped.\n' "$unit" >&2
+  printf 'scope-run: rerun inside a working systemd --user session, or set POCKETSHELL_SCOPE_ALLOW_BARE=1 only when debugging cgroup setup. CI may fall back automatically.\n' >&2
 }
 
 # Compute ~85% of a systemd size string (e.g. 8G -> 6963543080 bytes) for the
@@ -111,7 +136,7 @@ _pocketshell_scope_high_default() {
 # pocketshell_scope_run <unit> <cmd...>
 #
 # Runs <cmd...> inside a transient memory-capped `systemd-run --user --scope`
-# sibling scope when user systemd is available; otherwise runs <cmd...> bare.
+# sibling scope when user systemd is available; otherwise fails closed locally.
 # Returns the command's own exit code. On an OOM-kill of the scope, systemd-run
 # surfaces a non-zero exit and this function returns it with a clear message.
 pocketshell_scope_run() {
@@ -131,7 +156,11 @@ pocketshell_scope_run() {
   fi
 
   if ! pocketshell_scope_available; then
-    printf 'scope-run: user systemd unavailable; running %s BARE (uncapped fallback)\n' \
+    if ! pocketshell_scope_allow_bare; then
+      _pocketshell_scope_unavailable_message "$unit"
+      return 125
+    fi
+    printf 'scope-run: user systemd unavailable; running %s BARE (explicit uncapped fallback)\n' \
       "$unit" >&2
     "$@"
     return $?
@@ -196,7 +225,11 @@ pocketshell_scope_start_background() {
   mkdir -p "$(dirname "$log_file")" "$(dirname "$pid_file")"
 
   if ! pocketshell_scope_available; then
-    printf 'scope-run: user systemd unavailable; starting %s BARE (uncapped fallback)\n' \
+    if ! pocketshell_scope_allow_bare; then
+      _pocketshell_scope_unavailable_message "$unit"
+      return 125
+    fi
+    printf 'scope-run: user systemd unavailable; starting %s BARE (explicit uncapped fallback)\n' \
       "$unit" >&2
     nohup "$@" >> "$log_file" 2>&1 &
     printf '%s\n' "$!" > "$pid_file"

--- a/scripts/parallel-setup-detection.sh
+++ b/scripts/parallel-setup-detection.sh
@@ -32,6 +32,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
 source "$ROOT_DIR/scripts/lib/avd-lock.sh"
+source "$ROOT_DIR/scripts/lib/scope-run.sh"
 
 ANDROID_SDK="${ANDROID_SDK:-/home/alexey/Android/Sdk}"
 ADB="${ADB:-$ANDROID_SDK/platform-tools/adb}"
@@ -283,7 +284,8 @@ export GRADLE_USER_HOME="${GRADLE_USER_HOME:-$LOG_ROOT/gradle-home}"
 if [[ "$PARALLEL_BUILD_APKS" = "1" ]]; then
   build_log="$RUN_DIR/00-build-apks.log"
   printf 'building app + androidTest APKs once (shared by all shards) -> %s\n' "$build_log"
-  if ! ./gradlew --no-daemon --no-build-cache --no-parallel \
+  if ! "$ROOT_DIR/scripts/cgroup-run.sh" --unit "pocketshell-parallel-setup-$(pocketshell_unit_token "$RUN_ID")-build-apks" -- \
+      ./gradlew --no-daemon --no-build-cache --no-parallel \
       :app:assembleDebug :app:assembleDebugAndroidTest --stacktrace \
       >"$build_log" 2>&1; then
     tail -n 40 "$build_log" >&2 || true

--- a/scripts/phone-walkthrough.sh
+++ b/scripts/phone-walkthrough.sh
@@ -5,6 +5,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
 source "$ROOT_DIR/scripts/lib/avd-lock.sh"
+source "$ROOT_DIR/scripts/lib/scope-run.sh"
 pocketshell_acquire_avd_lock "$ROOT_DIR" "${1:-}"
 
 ANDROID_SDK="${ANDROID_SDK:-/home/alexey/Android/Sdk}"
@@ -676,7 +677,9 @@ build_and_install_apks() {
     if [[ -n "$POCKETSHELL_APP_ID_SUFFIX" ]]; then
       GRADLE_SUFFIX_ARGS+=("-PpocketshellAppIdSuffix=$POCKETSHELL_APP_ID_SUFFIX")
     fi
-    run_logged "08-build-apks" ./gradlew --no-daemon --no-build-cache --no-parallel :app:assembleDebug :app:assembleDebugAndroidTest "${GRADLE_SUFFIX_ARGS[@]}" --stacktrace
+    run_logged "08-build-apks" \
+      "$ROOT_DIR/scripts/cgroup-run.sh" --unit "pocketshell-phone-walkthrough-$(pocketshell_unit_token "$RUN_ID")-build-apks" -- \
+      ./gradlew --no-daemon --no-build-cache --no-parallel :app:assembleDebug :app:assembleDebugAndroidTest "${GRADLE_SUFFIX_ARGS[@]}" --stacktrace
   else
     [[ -f "$APP_APK" ]] || fail "BUILD_APKS=0 but app APK is missing at $APP_APK"
     [[ -f "$TEST_APK" ]] || fail "BUILD_APKS=0 but androidTest APK is missing at $TEST_APK"

--- a/scripts/pre-release-confidence-gate.sh
+++ b/scripts/pre-release-confidence-gate.sh
@@ -5,6 +5,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
 source "$ROOT_DIR/scripts/lib/avd-lock.sh"
+source "$ROOT_DIR/scripts/lib/scope-run.sh"
 pocketshell_acquire_avd_lock "$ROOT_DIR" "${1:-}"
 
 ANDROID_SDK="${ANDROID_SDK:-/home/alexey/Android/Sdk}"
@@ -120,6 +121,7 @@ Environment overrides:
   CORE_TERMINAL_CONNECTED_ATTEMPTS=2
   PRE_RELEASE_MANAGE_EMULATOR=0
   PRE_RELEASE_EMULATOR_START_ARGS="-no-window -no-audio -no-boot-anim -gpu swiftshader_indirect -no-snapshot-load -no-snapshot-save"
+  POCKETSHELL_EMULATOR_SG_KVM=auto
 USAGE
 }
 
@@ -428,7 +430,8 @@ for attempt in \$(seq 1 '$CORE_TERMINAL_CONNECTED_ATTEMPTS'); do
   '$ADB' logcat -c >/dev/null 2>&1 || true
 
   set +e
-  ./gradlew $GRADLE_FLAGS :shared:core-terminal:connectedDebugAndroidTest --stacktrace 2>&1 | tee "\$attempt_log"
+  '$ROOT_DIR/scripts/cgroup-run.sh' --unit "pocketshell-pre-release-core-terminal-\$attempt-$$" -- \
+    ./gradlew $GRADLE_FLAGS :shared:core-terminal:connectedDebugAndroidTest --stacktrace 2>&1 | tee "\$attempt_log"
   status=\${PIPESTATUS[0]}
   set -e
 
@@ -464,8 +467,11 @@ set -euo pipefail
 
 diagnostics='$RUN_DIR/emulator-readiness-diagnostics.log'
 managed_emulator_log='$RUN_DIR/emulator-readiness-managed-emulator.log'
+managed_emulator_pid='$RUN_DIR/emulator-readiness-managed-emulator.pid'
+managed_emulator_scope='$RUN_DIR/emulator-readiness-managed-emulator.scope'
 manage_emulator='$PRE_RELEASE_MANAGE_EMULATOR'
 avd_name='$AVD_NAME'
+source '$ROOT_DIR/scripts/lib/scope-run.sh'
 
 list_emulator_processes() {
   ps -eo pid=,comm=,args= |
@@ -504,6 +510,8 @@ record_diagnostics() {
     printf 'avd=%s\n' "\$avd_name"
     printf 'manage_emulator=%s\n' "\$manage_emulator"
     printf 'managed_start_args=%s\n' '$PRE_RELEASE_EMULATOR_START_ARGS'
+    printf 'managed_emulator_pid=%s\n' "\$managed_emulator_pid"
+    printf 'managed_emulator_scope=%s\n' "\$managed_emulator_scope"
     printf '\n== adb devices ==\n'
     '$ADB' devices -l || true
     printf '\n== adb get-state ==\n'
@@ -544,7 +552,13 @@ start_managed_emulator() {
 
   printf 'No ADB devices and no emulator process for AVD %s; starting managed emulator.\n' "\$avd_name" >&2
   printf '[%s] starting managed emulator for AVD %s\n' "\$(date -Is)" "\$avd_name" >> "\$managed_emulator_log"
-  nohup '$EMULATOR' -avd "\$avd_name" $PRE_RELEASE_EMULATOR_START_ARGS >> "\$managed_emulator_log" 2>&1 &
+  read -r -a start_args <<< '$PRE_RELEASE_EMULATOR_START_ARGS'
+  declare -a emulator_cmd=()
+  pocketshell_build_sg_kvm_command emulator_cmd '$EMULATOR' -avd "\$avd_name" "\${start_args[@]}"
+  local scope_unit
+  scope_unit="pocketshell-pre-release-avd-\$(pocketshell_unit_token "\$avd_name")-\$(pocketshell_unit_token '$RUN_ID')-$$"
+  pocketshell_scope_start_background "\$scope_unit" "\$managed_emulator_log" "\$managed_emulator_pid" "\${emulator_cmd[@]}"
+  printf '%s.scope\n' "\$scope_unit" > "\$managed_emulator_scope"
 }
 
 '$ADB' devices -l || true
@@ -1309,7 +1323,7 @@ if ! "$EMULATOR" -list-avds | grep -Fxq "$AVD_NAME"; then
 fi
 
 run_bash_step "gradle-compile-unit" \
-  "./gradlew $GRADLE_FLAGS :app:kspDebugKotlin :app:kspReleaseKotlin :app:kspDebugAndroidTestKotlin :app:kspDebugUnitTestKotlin :app:kspReleaseUnitTestKotlin :app:hiltJavaCompileDebug :app:hiltJavaCompileRelease :app:hiltJavaCompileDebugAndroidTest --stacktrace && ./gradlew $GRADLE_FLAGS assembleDebug check -x lint -x lintDebug --stacktrace"
+  "'$ROOT_DIR/scripts/cgroup-run.sh' --unit 'pocketshell-pre-release-$(pocketshell_unit_token "$RUN_ID")-ksp-hilt' -- ./gradlew $GRADLE_FLAGS :app:kspDebugKotlin :app:kspReleaseKotlin :app:kspDebugAndroidTestKotlin :app:kspDebugUnitTestKotlin :app:kspReleaseUnitTestKotlin :app:hiltJavaCompileDebug :app:hiltJavaCompileRelease :app:hiltJavaCompileDebugAndroidTest --stacktrace && '$ROOT_DIR/scripts/cgroup-run.sh' --unit 'pocketshell-pre-release-$(pocketshell_unit_token "$RUN_ID")-assemble-check' -- ./gradlew $GRADLE_FLAGS assembleDebug check -x lint -x lintDebug --stacktrace"
 
 run_step "docker-agents-up" docker compose -f "$COMPOSE_FILE" up -d --build agents
 # Issue #150: wait on the compose `healthcheck:` block via
@@ -1355,6 +1369,7 @@ update_emulator_serial
 run_bash_step "connected-terminal-input" "$(core_terminal_connected_input_script)"
 
 run_step "build-app-test-apks" \
+  "$ROOT_DIR/scripts/cgroup-run.sh" --unit "pocketshell-pre-release-$(pocketshell_unit_token "$RUN_ID")-build-app-test-apks" -- \
   ./gradlew $GRADLE_FLAGS :app:assembleDebug :app:assembleDebugAndroidTest --stacktrace
 [[ -f "$APK_PATH" ]] || fail "APK artifact was not created at $APK_PATH"
 [[ -f "$TEST_APK_PATH" ]] || fail "Android test APK artifact was not created at $TEST_APK_PATH"
@@ -1388,7 +1403,9 @@ for app_walkthrough_index in "${!APP_WALKTHROUGH_TESTS[@]}"; do
   fi
 done
 
-run_step "build-debug-apk" ./gradlew $GRADLE_FLAGS :app:assembleDebug --stacktrace
+run_step "build-debug-apk" \
+  "$ROOT_DIR/scripts/cgroup-run.sh" --unit "pocketshell-pre-release-$(pocketshell_unit_token "$RUN_ID")-build-debug-apk" -- \
+  ./gradlew $GRADLE_FLAGS :app:assembleDebug --stacktrace
 [[ -f "$APK_PATH" ]] || fail "APK artifact was not created at $APK_PATH"
 
 run_step "update-install-debug-apk" "$ROOT_DIR/scripts/install-update-apk.sh" "$APK_PATH"

--- a/scripts/reconnect-app-switch.sh
+++ b/scripts/reconnect-app-switch.sh
@@ -12,6 +12,10 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
+source "$ROOT_DIR/scripts/lib/avd-lock.sh"
+source "$ROOT_DIR/scripts/lib/scope-run.sh"
+pocketshell_acquire_avd_lock "$ROOT_DIR" "${1:-}"
+
 ANDROID_SDK="${ANDROID_SDK:-/home/alexey/Android/Sdk}"
 ADB="${ADB:-$ANDROID_SDK/platform-tools/adb}"
 EMULATOR="${EMULATOR:-$ANDROID_SDK/emulator/emulator}"
@@ -153,7 +157,7 @@ validate_artifacts() {
 }
 
 mkdir -p "$RUN_DIR"
-trap collect_diagnostics EXIT
+trap 'collect_diagnostics; pocketshell_release_all' EXIT
 
 printf 'PocketShell short app-switch reconnect harness\n'
 printf 'Artifacts: %s\n' "$RUN_DIR"
@@ -168,14 +172,23 @@ cp "$SSH_KEY" "$RUN_SSH_KEY"
 chmod 600 "$RUN_SSH_KEY"
 
 if ! "$ADB" get-state >/dev/null 2>&1; then
-  run_logged "00-start-emulator" "$EMULATOR" -avd "$AVD_NAME" -no-snapshot -no-window -gpu swiftshader_indirect -no-audio -no-boot-anim &
+  declare -a emulator_cmd=()
+  pocketshell_build_sg_kvm_command emulator_cmd \
+    "$EMULATOR" -avd "$AVD_NAME" -no-snapshot -no-window -gpu swiftshader_indirect -no-audio -no-boot-anim
+  pocketshell_scope_start_background \
+    "pocketshell-reconnect-app-switch-avd-$(pocketshell_unit_token "$RUN_ID")" \
+    "$RUN_DIR/00-start-emulator.log" \
+    "$RUN_DIR/00-start-emulator.pid" \
+    "${emulator_cmd[@]}"
 fi
 run_logged "01-wait-emulator" wait_for_emulator
 run_logged "02-docker-agents-up" docker compose -f "$COMPOSE_FILE" up -d --build "$AGENT_SERVICE"
 run_logged "03-docker-ssh-readiness" wait_for_ssh_fixture
 
 if [[ "$BUILD_APKS" == "1" ]]; then
-  run_logged "04-build-apks" ./gradlew --no-daemon :app:assembleDebug :app:assembleDebugAndroidTest --stacktrace
+  run_logged "04-build-apks" \
+    "$ROOT_DIR/scripts/cgroup-run.sh" --unit "pocketshell-reconnect-app-switch-$(pocketshell_unit_token "$RUN_ID")-build-apks" -- \
+    ./gradlew --no-daemon :app:assembleDebug :app:assembleDebugAndroidTest --stacktrace
 else
   [[ -f "$APP_APK" ]] || fail "app APK missing at $APP_APK"
   [[ -f "$TEST_APK" ]] || fail "test APK missing at $TEST_APK"

--- a/scripts/release-terminal-gate.sh
+++ b/scripts/release-terminal-gate.sh
@@ -43,6 +43,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
 source "$ROOT_DIR/scripts/lib/avd-lock.sh"
+source "$ROOT_DIR/scripts/lib/scope-run.sh"
 pocketshell_acquire_avd_lock "$ROOT_DIR" "${1:-}"
 
 ANDROID_SDK="${ANDROID_SDK:-/home/alexey/Android/Sdk}"
@@ -545,6 +546,7 @@ fi
 # normal build/unit checks first unless explicitly skipped.
 if [[ "$SKIP_GRADLE_CHECKS" != "1" ]]; then
   run_logged "00-gradle-build-and-unit-checks" \
+    "$ROOT_DIR/scripts/cgroup-run.sh" --unit "pocketshell-release-terminal-$(pocketshell_unit_token "$RUN_ID")-build-unit" -- \
     ./gradlew --no-daemon \
     :app:assembleDebug \
     :app:test \

--- a/scripts/render.sh
+++ b/scripts/render.sh
@@ -44,7 +44,8 @@ START="$(date +%s)"
 
 # recordRoborazziDebug (re)writes the golden PNGs. --rerun-tasks isn't needed:
 # editing a composable invalidates the test task, so a normal record re-renders.
-./gradlew :shared:ui-kit:recordRoborazziDebug --tests "$TESTS_ARG"
+scripts/cgroup-run.sh --unit "pocketshell-render-$(date +%Y%m%d-%H%M%S)-$$" -- \
+  ./gradlew :shared:ui-kit:recordRoborazziDebug --tests "$TESTS_ARG"
 
 END="$(date +%s)"
 echo

--- a/scripts/start-local-avd.sh
+++ b/scripts/start-local-avd.sh
@@ -52,6 +52,7 @@ Environment overrides:
   AVD_SCOPE=0 POCKETSHELL_SCOPE_ALLOW_BARE=1
   POCKETSHELL_TEST_MEM=8G
   POCKETSHELL_SCOPE_ALLOW_BARE=1
+  POCKETSHELL_EMULATOR_SG_KVM=auto
 
 Set AVD_HOLD=1 in one terminal when collecting connectedDebugAndroidTest
 evidence. The helper keeps monitoring adb/process state until interrupted, so
@@ -236,24 +237,26 @@ fi
 
 if ! has_adb_device && [[ -z "$(list_emulator_processes)" ]]; then
   printf 'Starting AVD %s with flags:%s\n' "$AVD_NAME" " $AVD_START_FLAGS"
+  declare -a emulator_cmd=()
+  pocketshell_build_sg_kvm_command emulator_cmd "$EMULATOR" -avd "$AVD_NAME" "${start_args[@]}"
   {
     printf '[%s] command:' "$(date -Is)"
-    printf ' %q' "$EMULATOR" -avd "$AVD_NAME" "${start_args[@]}"
+    printf ' %q' "${emulator_cmd[@]}"
     printf '\n\n'
   } > "$RUN_DIR/emulator.log"
   if [[ "$AVD_SCOPE" == "1" ]]; then
-    scope_unit="pocketshell-avd-${AVD_NAME//[^A-Za-z0-9._-]/_}-${RUN_ID//[^A-Za-z0-9._-]/_}"
+    scope_unit="pocketshell-avd-$(pocketshell_unit_token "$AVD_NAME")-$(pocketshell_unit_token "$RUN_ID")"
     pocketshell_scope_start_background \
       "$scope_unit" \
       "$RUN_DIR/emulator.log" \
       "$RUN_DIR/emulator.pid" \
-      "$EMULATOR" -avd "$AVD_NAME" "${start_args[@]}"
+      "${emulator_cmd[@]}"
     printf '%s\n' "$scope_unit.scope" > "$RUN_DIR/emulator.scope"
   else
     if ! pocketshell_scope_allow_bare; then
       fail "AVD_SCOPE=0 would start AVD '$AVD_NAME' uncapped; set POCKETSHELL_SCOPE_ALLOW_BARE=1 only when debugging cgroup setup"
     fi
-    nohup "$EMULATOR" -avd "$AVD_NAME" "${start_args[@]}" >> "$RUN_DIR/emulator.log" 2>&1 &
+    nohup "${emulator_cmd[@]}" >> "$RUN_DIR/emulator.log" 2>&1 &
     emulator_pid="$!"
     printf '%s\n' "$emulator_pid" > "$RUN_DIR/emulator.pid"
   fi

--- a/scripts/start-local-avd.sh
+++ b/scripts/start-local-avd.sh
@@ -35,7 +35,8 @@ build/local-avd-start/<run-id>/ so an emulator that exits before adb discovery
 leaves actionable logs instead of only a missing device.
 
 New emulator processes are cgroup-scoped by default through
-scripts/lib/scope-run.sh. Set AVD_SCOPE=0 only when debugging cgroup setup.
+scripts/lib/scope-run.sh. Set AVD_SCOPE=0 together with
+POCKETSHELL_SCOPE_ALLOW_BARE=1 only when debugging cgroup setup.
 
 Environment overrides:
   ANDROID_SDK=/home/alexey/Android/Sdk
@@ -48,15 +49,16 @@ Environment overrides:
   AVD_START_FLAGS="-no-window -no-audio -no-boot-anim -gpu swiftshader_indirect -no-snapshot-load -no-snapshot-save"
   AVD_WIPE_DATA=1
   AVD_HOLD=1
-  AVD_SCOPE=0
+  AVD_SCOPE=0 POCKETSHELL_SCOPE_ALLOW_BARE=1
   POCKETSHELL_TEST_MEM=8G
+  POCKETSHELL_SCOPE_ALLOW_BARE=1
 
 Set AVD_HOLD=1 in one terminal when collecting connectedDebugAndroidTest
 evidence. The helper keeps monitoring adb/process state until interrupted, so
 an emulator that exits after boot is reported in the same run directory.
 
 On success, run focused evidence commands such as:
-  ./gradlew --no-daemon :app:connectedDebugAndroidTest \
+  scripts/connected-test.sh --suffix i123 \
     -Pandroid.testInstrumentationRunnerArguments.class=com.pocketshell.app.proof.EmulatorDockerSshSmokeTest
 USAGE
 }
@@ -248,6 +250,9 @@ if ! has_adb_device && [[ -z "$(list_emulator_processes)" ]]; then
       "$EMULATOR" -avd "$AVD_NAME" "${start_args[@]}"
     printf '%s\n' "$scope_unit.scope" > "$RUN_DIR/emulator.scope"
   else
+    if ! pocketshell_scope_allow_bare; then
+      fail "AVD_SCOPE=0 would start AVD '$AVD_NAME' uncapped; set POCKETSHELL_SCOPE_ALLOW_BARE=1 only when debugging cgroup setup"
+    fi
     nohup "$EMULATOR" -avd "$AVD_NAME" "${start_args[@]}" >> "$RUN_DIR/emulator.log" 2>&1 &
     emulator_pid="$!"
     printf '%s\n' "$emulator_pid" > "$RUN_DIR/emulator.pid"

--- a/scripts/start-local-avd.sh
+++ b/scripts/start-local-avd.sh
@@ -5,6 +5,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
 source "$ROOT_DIR/scripts/lib/avd-lock.sh"
+source "$ROOT_DIR/scripts/lib/scope-run.sh"
 pocketshell_acquire_avd_lock "$ROOT_DIR" "${1:-}"
 
 ANDROID_SDK="${ANDROID_SDK:-/home/alexey/Android/Sdk}"
@@ -22,6 +23,7 @@ BOOT_TIMEOUT_SECONDS="${BOOT_TIMEOUT_SECONDS:-240}"
 AVD_START_FLAGS="${AVD_START_FLAGS:--no-window -no-audio -no-boot-anim -gpu swiftshader_indirect -no-snapshot-load -no-snapshot-save}"
 AVD_WIPE_DATA="${AVD_WIPE_DATA:-0}"
 AVD_HOLD="${AVD_HOLD:-0}"
+AVD_SCOPE="${AVD_SCOPE:-1}"
 
 usage() {
   cat <<'USAGE'
@@ -31,6 +33,9 @@ Starts the local AVD used for PocketShell connected Android review evidence and
 waits until adb reports sys.boot_completed=1. It writes diagnostics under
 build/local-avd-start/<run-id>/ so an emulator that exits before adb discovery
 leaves actionable logs instead of only a missing device.
+
+New emulator processes are cgroup-scoped by default through
+scripts/lib/scope-run.sh. Set AVD_SCOPE=0 only when debugging cgroup setup.
 
 Environment overrides:
   ANDROID_SDK=/home/alexey/Android/Sdk
@@ -43,6 +48,8 @@ Environment overrides:
   AVD_START_FLAGS="-no-window -no-audio -no-boot-anim -gpu swiftshader_indirect -no-snapshot-load -no-snapshot-save"
   AVD_WIPE_DATA=1
   AVD_HOLD=1
+  AVD_SCOPE=0
+  POCKETSHELL_TEST_MEM=8G
 
 Set AVD_HOLD=1 in one terminal when collecting connectedDebugAndroidTest
 evidence. The helper keeps monitoring adb/process state until interrupted, so
@@ -128,6 +135,8 @@ record_diagnostics() {
     printf 'avd_start_flags=%s\n' "$AVD_START_FLAGS"
     printf 'avd_wipe_data=%s\n' "$AVD_WIPE_DATA"
     printf 'avd_hold=%s\n' "$AVD_HOLD"
+    printf 'avd_scope=%s\n' "$AVD_SCOPE"
+    printf 'pocketshell_test_mem=%s\n' "${POCKETSHELL_TEST_MEM:-8G}"
     printf 'boot_timeout_seconds=%s\n' "$BOOT_TIMEOUT_SECONDS"
     printf '\n== adb devices ==\n'
     "$ADB" devices -l || true
@@ -176,6 +185,7 @@ write_summary() {
     printf 'ADB serial: %s\n' "$serial"
     printf 'Start flags: %s\n' "$AVD_START_FLAGS"
     printf 'Hold mode: %s\n' "$AVD_HOLD"
+    printf 'Cgroup scope: %s\n' "$AVD_SCOPE"
     printf 'Diagnostics: %s\n' "$RUN_DIR/diagnostics.txt"
     printf 'Emulator log: %s\n' "$RUN_DIR/emulator.log"
     printf 'ADB devices: %s\n' "$RUN_DIR/adb-devices.txt"
@@ -229,9 +239,19 @@ if ! has_adb_device && [[ -z "$(list_emulator_processes)" ]]; then
     printf ' %q' "$EMULATOR" -avd "$AVD_NAME" "${start_args[@]}"
     printf '\n\n'
   } > "$RUN_DIR/emulator.log"
-  nohup "$EMULATOR" -avd "$AVD_NAME" "${start_args[@]}" >> "$RUN_DIR/emulator.log" 2>&1 &
-  emulator_pid="$!"
-  printf '%s\n' "$emulator_pid" > "$RUN_DIR/emulator.pid"
+  if [[ "$AVD_SCOPE" == "1" ]]; then
+    scope_unit="pocketshell-avd-${AVD_NAME//[^A-Za-z0-9._-]/_}-${RUN_ID//[^A-Za-z0-9._-]/_}"
+    pocketshell_scope_start_background \
+      "$scope_unit" \
+      "$RUN_DIR/emulator.log" \
+      "$RUN_DIR/emulator.pid" \
+      "$EMULATOR" -avd "$AVD_NAME" "${start_args[@]}"
+    printf '%s\n' "$scope_unit.scope" > "$RUN_DIR/emulator.scope"
+  else
+    nohup "$EMULATOR" -avd "$AVD_NAME" "${start_args[@]}" >> "$RUN_DIR/emulator.log" 2>&1 &
+    emulator_pid="$!"
+    printf '%s\n' "$emulator_pid" > "$RUN_DIR/emulator.pid"
+  fi
 fi
 
 deadline=$((SECONDS + BOOT_TIMEOUT_SECONDS))

--- a/scripts/terminal-workbench.sh
+++ b/scripts/terminal-workbench.sh
@@ -18,6 +18,7 @@ if [[ -n "${RUN_ID:-}" ]]; then
 fi
 
 source "$ROOT_DIR/scripts/lib/avd-lock.sh"
+source "$ROOT_DIR/scripts/lib/scope-run.sh"
 pocketshell_acquire_avd_lock "$ROOT_DIR"
 
 ANDROID_SDK="${ANDROID_SDK:-/home/alexey/Android/Sdk}"
@@ -360,7 +361,14 @@ require_positive_integer "$WORKBENCH_INSTRUMENTATION_ATTEMPTS" "WORKBENCH_INSTRU
 chmod 600 "$SSH_KEY" || fail "could not restrict SSH key permissions at $SSH_KEY"
 
 if ! "$ADB" get-state >/dev/null 2>&1; then
-  run_logged "00-start-emulator" "$EMULATOR" -avd "$AVD_NAME" -no-snapshot -no-window -gpu swiftshader_indirect -no-audio -no-boot-anim &
+  declare -a emulator_cmd=()
+  pocketshell_build_sg_kvm_command emulator_cmd \
+    "$EMULATOR" -avd "$AVD_NAME" -no-snapshot -no-window -gpu swiftshader_indirect -no-audio -no-boot-anim
+  pocketshell_scope_start_background \
+    "pocketshell-terminal-workbench-avd-$(pocketshell_unit_token "$RUN_ID")" \
+    "$RUN_DIR/00-start-emulator.log" \
+    "$RUN_DIR/00-start-emulator.pid" \
+    "${emulator_cmd[@]}"
 fi
 run_logged "01-wait-emulator" wait_for_emulator
 run_logged "02-docker-agents-up" docker compose -f "$COMPOSE_FILE" up -d --build "$AGENT_SERVICE"
@@ -371,7 +379,9 @@ if [[ "$BUILD_APKS" == "1" ]]; then
   if [[ -n "$POCKETSHELL_APP_ID_SUFFIX" ]]; then
     GRADLE_SUFFIX_ARGS+=("-PpocketshellAppIdSuffix=$POCKETSHELL_APP_ID_SUFFIX")
   fi
-  run_logged "04-build-apks" ./gradlew --no-daemon :app:assembleDebug :app:assembleDebugAndroidTest "${GRADLE_SUFFIX_ARGS[@]}" --stacktrace
+  run_logged "04-build-apks" \
+    "$ROOT_DIR/scripts/cgroup-run.sh" --unit "pocketshell-terminal-workbench-$(pocketshell_unit_token "$RUN_ID")-build-apks" -- \
+    ./gradlew --no-daemon :app:assembleDebug :app:assembleDebugAndroidTest "${GRADLE_SUFFIX_ARGS[@]}" --stacktrace
 else
   [[ -f "$APP_APK" ]] || fail "app APK missing at $APP_APK"
   [[ -f "$TEST_APK" ]] || fail "test APK missing at $TEST_APK"

--- a/scripts/tmux-attach-prefill.sh
+++ b/scripts/tmux-attach-prefill.sh
@@ -26,6 +26,8 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
+source "$ROOT_DIR/scripts/lib/scope-run.sh"
+
 ANDROID_SDK="${ANDROID_SDK:-/home/alexey/Android/Sdk}"
 ADB="${ADB:-$ANDROID_SDK/platform-tools/adb}"
 EMULATOR="${EMULATOR:-$ANDROID_SDK/emulator/emulator}"
@@ -226,7 +228,9 @@ run_logged "02-docker-agents-up" docker compose -f "$COMPOSE_FILE" up -d --build
 run_logged "03-docker-ssh-readiness" wait_for_ssh_fixture
 
 if [[ "$BUILD_APKS" == "1" ]]; then
-  run_logged "04-build-apks" ./gradlew --no-daemon :app:assembleDebug :app:assembleDebugAndroidTest --stacktrace
+  run_logged "04-build-apks" \
+    "$ROOT_DIR/scripts/cgroup-run.sh" --unit "pocketshell-tmux-attach-$(pocketshell_unit_token "$RUN_ID")-build-apks" -- \
+    ./gradlew --no-daemon :app:assembleDebug :app:assembleDebugAndroidTest --stacktrace
 else
   [[ -f "$APP_APK" ]] || fail "app APK missing at $APP_APK"
   [[ -f "$TEST_APK" ]] || fail "test APK missing at $TEST_APK"

--- a/scripts/tmux-attach-prefill.sh
+++ b/scripts/tmux-attach-prefill.sh
@@ -26,7 +26,9 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
+source "$ROOT_DIR/scripts/lib/avd-lock.sh"
 source "$ROOT_DIR/scripts/lib/scope-run.sh"
+pocketshell_acquire_avd_lock "$ROOT_DIR" "${1:-}"
 
 ANDROID_SDK="${ANDROID_SDK:-/home/alexey/Android/Sdk}"
 ADB="${ADB:-$ANDROID_SDK/platform-tools/adb}"
@@ -208,7 +210,7 @@ validate_artifacts() {
 }
 
 mkdir -p "$RUN_DIR"
-trap collect_diagnostics EXIT
+trap 'collect_diagnostics; pocketshell_release_all' EXIT
 
 printf 'PocketShell issue #103 tmux attach prefill workbench\n'
 printf 'Artifacts: %s\n' "$RUN_DIR"
@@ -221,7 +223,14 @@ printf 'Test selector: %s\n' "$TEST_SELECTOR"
 command -v ssh >/dev/null 2>&1 || fail "ssh client is missing"
 
 if ! "$ADB" get-state >/dev/null 2>&1; then
-  run_logged "00-start-emulator" "$EMULATOR" -avd "$AVD_NAME" -no-snapshot -no-window -gpu swiftshader_indirect -no-audio -no-boot-anim &
+  declare -a emulator_cmd=()
+  pocketshell_build_sg_kvm_command emulator_cmd \
+    "$EMULATOR" -avd "$AVD_NAME" -no-snapshot -no-window -gpu swiftshader_indirect -no-audio -no-boot-anim
+  pocketshell_scope_start_background \
+    "pocketshell-tmux-attach-avd-$(pocketshell_unit_token "$RUN_ID")" \
+    "$RUN_DIR/00-start-emulator.log" \
+    "$RUN_DIR/00-start-emulator.pid" \
+    "${emulator_cmd[@]}"
 fi
 run_logged "01-wait-emulator" wait_for_emulator
 run_logged "02-docker-agents-up" docker compose -f "$COMPOSE_FILE" up -d --build "$AGENT_SERVICE"

--- a/scripts/tmux-issue303-toolbar-proof.sh
+++ b/scripts/tmux-issue303-toolbar-proof.sh
@@ -13,6 +13,10 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
+source "$ROOT_DIR/scripts/lib/avd-lock.sh"
+source "$ROOT_DIR/scripts/lib/scope-run.sh"
+pocketshell_acquire_avd_lock "$ROOT_DIR" "${1:-}"
+
 ANDROID_SDK="${ANDROID_SDK:-/home/alexey/Android/Sdk}"
 ADB="${ADB:-$ANDROID_SDK/platform-tools/adb}"
 EMULATOR="${EMULATOR:-$ANDROID_SDK/emulator/emulator}"
@@ -200,7 +204,7 @@ validate_artifacts() {
 mkdir -p "$RUN_DIR"
 cp "$SSH_KEY" "$HOST_SSH_KEY"
 chmod 600 "$HOST_SSH_KEY"
-trap collect_diagnostics EXIT
+trap 'collect_diagnostics; pocketshell_release_all' EXIT
 
 printf 'PocketShell issue #303 live tmux toolbar proof workbench\n'
 printf 'Artifacts: %s\n' "$RUN_DIR"
@@ -213,14 +217,23 @@ printf 'Test selector: %s\n' "$TEST_SELECTOR"
 command -v ssh >/dev/null 2>&1 || fail "ssh client is missing"
 
 if ! "$ADB" get-state >/dev/null 2>&1; then
-  run_logged "00-start-emulator" "$EMULATOR" -avd "$AVD_NAME" -no-snapshot -no-window -gpu swiftshader_indirect -no-audio -no-boot-anim &
+  declare -a emulator_cmd=()
+  pocketshell_build_sg_kvm_command emulator_cmd \
+    "$EMULATOR" -avd "$AVD_NAME" -no-snapshot -no-window -gpu swiftshader_indirect -no-audio -no-boot-anim
+  pocketshell_scope_start_background \
+    "pocketshell-issue303-avd-$(pocketshell_unit_token "$RUN_ID")" \
+    "$RUN_DIR/00-start-emulator.log" \
+    "$RUN_DIR/00-start-emulator.pid" \
+    "${emulator_cmd[@]}"
 fi
 run_logged "01-wait-emulator" wait_for_emulator
 run_logged "02-docker-agents-up" docker compose -f "$COMPOSE_FILE" up -d --build "$AGENT_SERVICE"
 run_logged "03-docker-ssh-readiness" wait_for_ssh_fixture
 
 if [[ "$BUILD_APKS" == "1" ]]; then
-  run_logged "04-build-apks" ./gradlew --no-daemon :app:assembleDebug :app:assembleDebugAndroidTest --stacktrace
+  run_logged "04-build-apks" \
+    "$ROOT_DIR/scripts/cgroup-run.sh" --unit "pocketshell-issue303-$(pocketshell_unit_token "$RUN_ID")-build-apks" -- \
+    ./gradlew --no-daemon :app:assembleDebug :app:assembleDebugAndroidTest --stacktrace
 else
   [[ -f "$APP_APK" ]] || fail "app APK missing at $APP_APK"
   [[ -f "$TEST_APK" ]] || fail "test APK missing at $TEST_APK"

--- a/shared/core-portfwd/src/main/java/com/pocketshell/core/portfwd/AutoForwarder.kt
+++ b/shared/core-portfwd/src/main/java/com/pocketshell/core/portfwd/AutoForwarder.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import java.net.InetAddress
@@ -170,18 +171,21 @@ public class AutoForwarder(
         stopped = true
         loopJob?.cancel()
         loopJob = null
-        // Close tunnels synchronously — these don't suspend, so there's no
-        // need to launch into a scope that may have just been cancelled.
-        synchronized(this) {
-            tunnels.values.forEach { runCatching { it.close() } }
-            tunnels.clear()
-            manualPorts.clear()
-            processNames.clear()
-            localPortMap.clear()
-            failedPorts.clear()
-            priorTotalBytes.clear()
+
+        val tunnelsToClose = runBlocking {
+            mutex.withLock {
+                val captured = tunnels.values.toList()
+                tunnels.clear()
+                manualPorts.clear()
+                processNames.clear()
+                localPortMap.clear()
+                failedPorts.clear()
+                priorTotalBytes.clear()
+                tunnelsState.value = emptyList()
+                captured
+            }
         }
-        tunnelsState.value = emptyList()
+        tunnelsToClose.forEach { runCatching { it.close() } }
     }
 
     /**
@@ -193,17 +197,23 @@ public class AutoForwarder(
      * block on I/O.
      */
     public suspend fun togglePort(remotePort: Int) {
-        mutex.withLock {
+        val tunnelToClose = mutex.withLock {
             if (stopped) return
             if (remotePort in tunnels) {
-                stopTunnelLocked(remotePort)
                 manualPorts.remove(remotePort)
+                val tunnel = detachTunnelLocked(remotePort)
+                updateStateLocked()
+                tunnel
             } else {
                 manualPorts.add(remotePort)
-                forwardPortLocked(remotePort)
+                null
             }
-            updateStateLocked()
         }
+        tunnelToClose?.let {
+            runCatching { it.close() }
+            return
+        }
+        forwardPort(remotePort)
     }
 
     /**
@@ -215,17 +225,22 @@ public class AutoForwarder(
      * forwarder stay consistent across reconnects.
      */
     public suspend fun ensurePort(remotePort: Int, enabled: Boolean) {
-        mutex.withLock {
+        val tunnelToClose = mutex.withLock {
             if (stopped) return
             if (enabled) {
-                if (manualPorts.add(remotePort) || remotePort !in tunnels) {
-                    forwardPortLocked(remotePort)
-                }
+                manualPorts.add(remotePort)
+                null
             } else {
                 manualPorts.remove(remotePort)
-                stopTunnelLocked(remotePort)
+                val tunnel = detachTunnelLocked(remotePort)
+                localPortMap.remove(remotePort)
+                updateStateLocked()
+                tunnel
             }
-            updateStateLocked()
+        }
+        tunnelToClose?.let { runCatching { it.close() } }
+        if (enabled) {
+            forwardPort(remotePort)
         }
     }
 
@@ -250,7 +265,8 @@ public class AutoForwarder(
         val remotePorts = PortScanner.scan(session)
         val remotePortSet = remotePorts.map { it.port }.toSet()
 
-        mutex.withLock {
+        val tunnelsToClose = mutableListOf<SshPortForward>()
+        val portsToOpen = mutex.withLock {
             if (stopped) return
             // Evict TTL'd deny-list entries up front so the rest of the
             // scan sees an accurate "is this port denied?" view.
@@ -261,12 +277,17 @@ public class AutoForwarder(
                 processNames[rp.port] = rp.processName
             }
 
-            // Open new forwards for newly-discovered ports.
-            remotePorts.forEach { rp ->
-                if (rp.port !in tunnels && rp.port !in failedPorts) {
-                    if (shouldForwardPort(rp.port)) {
-                        forwardPortLocked(rp.port)
-                    }
+            val discoveredPortsToOpen = remotePorts.mapNotNull { rp ->
+                val remotePort = rp.port
+                if (
+                    remotePort !in tunnels &&
+                    remotePort !in localPortMap &&
+                    remotePort !in failedPorts &&
+                    shouldForwardPort(remotePort)
+                ) {
+                    remotePort
+                } else {
+                    null
                 }
             }
 
@@ -277,9 +298,15 @@ public class AutoForwarder(
             // `maxAutoPort`, or briefly not listening). Without this the
             // forward would only come back if the port happened to fall in
             // the auto window AND was listening — i.e. the reconnect bug.
-            manualPorts.forEach { remotePort ->
-                if (remotePort !in tunnels && remotePort !in failedPorts) {
-                    forwardPortLocked(remotePort)
+            val manualPortsToOpen = manualPorts.mapNotNull { remotePort ->
+                if (
+                    remotePort !in tunnels &&
+                    remotePort !in localPortMap &&
+                    remotePort !in failedPorts
+                ) {
+                    remotePort
+                } else {
+                    null
                 }
             }
 
@@ -288,7 +315,16 @@ public class AutoForwarder(
             // disappearances (the user may have just restarted the service).
             tunnels.keys.toList().forEach { remotePort ->
                 if (remotePort !in remotePortSet && remotePort !in manualPorts) {
-                    stopTunnelLocked(remotePort)
+                    detachTunnelLocked(remotePort)?.let(tunnelsToClose::add)
+                }
+            }
+            localPortMap.keys.toList().forEach { remotePort ->
+                if (
+                    remotePort !in tunnels &&
+                    remotePort !in remotePortSet &&
+                    remotePort !in manualPorts
+                ) {
+                    localPortMap.remove(remotePort)
                 }
             }
 
@@ -298,7 +334,72 @@ public class AutoForwarder(
             failedPorts.keys.removeAll { it !in remotePortSet }
 
             updateStateLocked()
+            (discoveredPortsToOpen + manualPortsToOpen).distinct()
         }
+
+        tunnelsToClose.forEach { runCatching { it.close() } }
+        portsToOpen.forEach { forwardPort(it) }
+    }
+
+    private suspend fun forwardPort(remotePort: Int) {
+        val localPort = mutex.withLock {
+            if (stopped || remotePort in tunnels || remotePort in localPortMap) return
+            try {
+                // resolveLocalPortLocked() throws when localPortRange is
+                // exhausted — that's a forward-creation failure too.
+                resolveLocalPortLocked(remotePort).also { resolvedPort ->
+                    // Reserve the local port while the SSH open happens
+                    // outside the mutex. This prevents a concurrent scan or
+                    // manual toggle from allocating the same local port.
+                    localPortMap[remotePort] = resolvedPort
+                }
+            } catch (_: Throwable) {
+                failedPorts[remotePort] = clock()
+                updateStateLocked()
+                return
+            }
+        }
+
+        val forward = try {
+            // Forward 127.0.0.1:<remotePort> on the remote's side — the
+            // standard "service bound to localhost on the dev box" case.
+            // Matches the legacy ssh-auto-forward-android behaviour.
+            session.openLocalPortForward(
+                remoteHost = "127.0.0.1",
+                remotePort = remotePort,
+                localPort = localPort,
+            )
+        } catch (_: Throwable) {
+            mutex.withLock {
+                if (localPortMap[remotePort] == localPort) {
+                    localPortMap.remove(remotePort)
+                    failedPorts[remotePort] = clock()
+                    updateStateLocked()
+                }
+            }
+            return
+        }
+
+        var closeForward = false
+        mutex.withLock {
+            if (stopped || localPortMap[remotePort] != localPort || remotePort in tunnels) {
+                localPortMap.remove(remotePort)
+                closeForward = true
+            } else {
+                tunnels[remotePort] = forward
+            }
+            updateStateLocked()
+        }
+        if (closeForward) {
+            runCatching { forward.close() }
+        }
+    }
+
+    private fun detachTunnelLocked(remotePort: Int): SshPortForward? {
+        val tunnel = tunnels.remove(remotePort) ?: return null
+        localPortMap.remove(remotePort)
+        priorTotalBytes.remove(remotePort)
+        return tunnel
     }
 
     /**
@@ -316,51 +417,6 @@ public class AutoForwarder(
     private fun shouldForwardPort(remotePort: Int): Boolean {
         if (remotePort in manualPorts) return true
         return remotePort in config.skipPortsBelow..config.maxAutoPort
-    }
-
-    private fun forwardPortLocked(remotePort: Int) {
-        if (stopped) return
-        if (remotePort in tunnels) return
-        try {
-            // resolveLocalPortLocked() throws when localPortRange is
-            // exhausted — that's a forward-creation failure too, so it
-            // belongs inside the same catch as the openLocalPortForward
-            // call. Without this widening, an exhausted range would
-            // crash the scan loop instead of being memoed in failedPorts.
-            val localPort = resolveLocalPortLocked(remotePort)
-            if (stopped) return
-            // Forward 127.0.0.1:<remotePort> on the remote's side — the
-            // standard "service bound to localhost on the dev box" case.
-            // Matches the legacy ssh-auto-forward-android behaviour.
-            val forward = session.openLocalPortForward(
-                remoteHost = "127.0.0.1",
-                remotePort = remotePort,
-                localPort = localPort,
-            )
-            if (stopped) {
-                runCatching { forward.close() }
-                return
-            }
-            tunnels[remotePort] = forward
-            localPortMap[remotePort] = localPort
-        } catch (_: Throwable) {
-            // Forward couldn't be created (local port already in use,
-            // remote refused the channel, allocator exhausted, ...).
-            // Remember so we don't pummel the remote on every scan; the
-            // next disappearance of this remote port will clear the
-            // memo. We also TTL the entry
-            // ([AutoForwardConfig.failedPortTtlMs]) so a transient
-            // failure isn't sticky across re-scans on a still-listening
-            // remote port.
-            failedPorts[remotePort] = clock()
-        }
-    }
-
-    private fun stopTunnelLocked(remotePort: Int) {
-        val tunnel = tunnels.remove(remotePort) ?: return
-        runCatching { tunnel.close() }
-        localPortMap.remove(remotePort)
-        priorTotalBytes.remove(remotePort)
     }
 
     private fun resolveLocalPortLocked(remotePort: Int): Int {
@@ -412,8 +468,8 @@ public class AutoForwarder(
                 // Range fully exhausted — every slot is allocated. Fail
                 // fast with a clear message rather than silently handing
                 // out an already-used port (or, worse, looping forever).
-                // The caller (forwardPortLocked) catches Throwable and
-                // memos the remote port; this is the right shape.
+                // The caller (forwardPort) catches Throwable and memos
+                // the remote port; this is the right shape.
                 val low = config.localPortRange.first
                 val high = config.localPortRange.last
                 throw RuntimeException("no free local ports in range $low..$high")

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshPortForward.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshPortForward.kt
@@ -10,6 +10,7 @@ import java.net.Socket
 import java.net.SocketException
 import java.util.concurrent.CopyOnWriteArraySet
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
 
 /**
@@ -53,6 +54,7 @@ internal class RealSshPortForward(
     private val running = AtomicBoolean(true)
     private val forwardedBytes = AtomicLong(0)
     private val receivedBytes = AtomicLong(0)
+    private val activeConnectionSlots = AtomicInteger(0)
 
     /**
      * Live copy threads (one per direction, per accepted connection). We
@@ -106,6 +108,11 @@ internal class RealSshPortForward(
     }
 
     private fun startChannel(local: Socket) {
+        if (!tryAcquireConnectionSlot()) {
+            runCatching { local.close() }
+            return
+        }
+
         // Open the direct-tcpip channel synchronously so an open failure is
         // visible *here* (we can log + close the local socket). Once open, we
         // hand off to two daemon copy threads — one per direction.
@@ -117,6 +124,7 @@ internal class RealSshPortForward(
         } catch (t: Throwable) {
             // Couldn't open the channel — drop the local connection. Don't
             // crash the accept loop; another connection might succeed.
+            releaseConnectionSlot()
             runCatching { local.close() }
             return
         }
@@ -125,7 +133,11 @@ internal class RealSshPortForward(
         // accept() returning and us getting here, don't bother spinning
         // up the copy threads — tear the pair down and bail.
         if (!running.get()) {
-            closePair(local, channel)
+            try {
+                closePair(local, channel)
+            } finally {
+                releaseConnectionSlot()
+            }
             return
         }
 
@@ -136,7 +148,11 @@ internal class RealSshPortForward(
         // ours). In that case we close eagerly and skip the copy threads.
         if (!running.get()) {
             activePairs.remove(pair)
-            closePair(local, channel)
+            try {
+                closePair(local, channel)
+            } finally {
+                releaseConnectionSlot()
+            }
             return
         }
 
@@ -162,8 +178,24 @@ internal class RealSshPortForward(
 
     private fun closePairAndUntrack(pair: Pair<Socket, DirectConnection>) {
         if (activePairs.remove(pair)) {
-            closePair(pair.first, pair.second)
+            try {
+                closePair(pair.first, pair.second)
+            } finally {
+                releaseConnectionSlot()
+            }
         }
+    }
+
+    private fun tryAcquireConnectionSlot(): Boolean {
+        while (true) {
+            val current = activeConnectionSlots.get()
+            if (current >= MAX_ACTIVE_CONNECTIONS) return false
+            if (activeConnectionSlots.compareAndSet(current, current + 1)) return true
+        }
+    }
+
+    private fun releaseConnectionSlot() {
+        activeConnectionSlots.updateAndGet { current -> (current - 1).coerceAtLeast(0) }
     }
 
     /**
@@ -225,17 +257,24 @@ internal class RealSshPortForward(
         val pairs = activePairs.toList()
         activePairs.clear()
         for ((local, channel) in pairs) {
-            closePair(local, channel)
+            try {
+                closePair(local, channel)
+            } finally {
+                releaseConnectionSlot()
+            }
         }
         // Join the in-flight copy threads so callers see deterministic
         // teardown (no file descriptors leak past close() returning). We
         // skip joining if we'd be deadlocking on ourselves (a copy thread
         // calling close() — unusual but cheap to guard).
         val self = Thread.currentThread()
+        val deadlineNanos = System.nanoTime() + CLOSE_JOIN_TIMEOUT_MS * NANOS_PER_MILLI
         for (t in copyThreads) {
             if (t === self) continue
+            val remainingMillis = (deadlineNanos - System.nanoTime()) / NANOS_PER_MILLI
+            if (remainingMillis <= 0L) break
             try {
-                t.join(JOIN_TIMEOUT_MS)
+                t.join(remainingMillis)
             } catch (_: InterruptedException) {
                 // Preserve interrupt status; stop joining the rest — they
                 // are daemon threads and will eventually exit on their
@@ -255,9 +294,16 @@ internal class RealSshPortForward(
         // the copy loop tight without over-allocating.
         const val BUFFER_SIZE = 32 * 1024
 
-        // Per-thread join budget in close(). Two copy threads * 500 ms ==
-        // 1 s worst-case stall, which is generous given the underlying
-        // sockets are already closed by the time we get here.
-        const val JOIN_TIMEOUT_MS = 500L
+        // Each accepted connection creates two copy threads. Keep a runaway
+        // local client burst from creating unbounded daemon threads and SSH
+        // direct-tcpip channels while still allowing normal browser/dev-tool
+        // concurrency.
+        const val MAX_ACTIVE_CONNECTIONS = 32
+
+        // Aggregate join budget in close(). The underlying sockets/channels
+        // have already been closed, so this is only a deterministic cleanup
+        // window, not a per-thread multiplier.
+        const val CLOSE_JOIN_TIMEOUT_MS = 1_000L
+        const val NANOS_PER_MILLI = 1_000_000L
     }
 }

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshSession.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshSession.kt
@@ -2,6 +2,7 @@ package com.pocketshell.core.ssh
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableJob
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.InternalCoroutinesApi
@@ -15,6 +16,8 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.runInterruptible
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.coroutines.yield
@@ -28,11 +31,15 @@ import net.schmizz.sshj.connection.channel.direct.Session
 import net.schmizz.sshj.connection.channel.direct.Session.Command
 import net.schmizz.sshj.transport.TransportException
 import java.io.BufferedReader
+import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.IOException
 import java.io.InputStream
 import java.io.InputStreamReader
 import java.io.OutputStream
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.Executors
+import java.util.concurrent.Future
 import java.util.concurrent.atomic.AtomicReference
 import java.util.logging.Level
 import java.util.logging.Logger
@@ -196,7 +203,7 @@ internal class RealSshSession(
      * the local no-activity budget elapses — otherwise the 90s `onKeepAliveDead`
      * teardown would never fire (see [awaitKeepAliveReply]).
      */
-    @Volatile
+    private val keepAliveSingleFlightMutex = Mutex()
     private var pendingKeepAliveReply: Job? = null
 
     /**
@@ -301,9 +308,20 @@ internal class RealSshSession(
         // request would enqueue a second sshj promise behind the unresolved one.
         // Count this tick against the same bounded no-activity budget, but do
         // not put a new packet on the transport.
-        if (pendingKeepAliveReply?.isCompleted == false) {
-            return awaitKeepAliveActivity(lastInboundActivityNanos)
+        val marker = Job()
+        val decision = keepAliveSingleFlightMutex.withLock {
+            val pending = pendingKeepAliveReply
+            if (pending != null && !pending.isCompleted) {
+                KeepAliveSendDecision.AwaitExisting(lastInboundActivityNanos)
+            } else {
+                pendingKeepAliveReply = marker
+                KeepAliveSendDecision.Send(marker, lastInboundActivityNanos)
+            }
         }
+        if (decision is KeepAliveSendDecision.AwaitExisting) {
+            return awaitKeepAliveActivity(decision.before)
+        }
+        decision as KeepAliveSendDecision.Send
 
         // Issue #983 — split the op so the single-writer mutex is held ONLY for the
         // wire write, never for the multi-second reply wait. The
@@ -329,11 +347,15 @@ internal class RealSshSession(
                 if (t is CancellationException) throw t
                 // The send itself (write / dispatcher) failed. A REQUEST_FAILURE that
                 // escaped here still proves the peer answered; otherwise it is a miss.
+                clearKeepAliveMarker(decision.marker)
                 return isKeepAliveServerAnswered(t)
-            } ?: return false
+            } ?: run {
+                clearKeepAliveMarker(decision.marker)
+                return false
+            }
 
         // Issue #985 — confirm the reply OUTSIDE the mutex with a NON-ORPHANING wait.
-        return awaitKeepAliveReply(promise)
+        return awaitKeepAliveReply(promise, decision.marker, decision.before)
     }
 
     /**
@@ -371,34 +393,47 @@ internal class RealSshSession(
      */
     private suspend fun awaitKeepAliveReply(
         promise: Promise<SSHPacket, ConnectionException>,
+        marker: CompletableJob,
+        before: Long,
     ): Boolean {
-        val before = lastInboundActivityNanos
-
-        // Only launch a NEW unbounded retrieve when the prior one has completed.
-        // A still-pending reply job means the previous promise's consumer is still
-        // alive (so its queue slot is not abandoned); callers with a pending job
-        // are gated before the wire send and run only the local no-activity budget.
-        val existing = pendingKeepAliveReply
-        if (existing == null || existing.isCompleted) {
-            pendingKeepAliveReply = scope.launch {
-                runCatching {
-                    runInterruptible(Dispatchers.IO) {
-                        // UNBOUNDED — never abandons the queue slot. Returns the
-                        // REQUEST_SUCCESS packet, or throws the REQUEST_FAILURE
-                        // ConnectionException (both prove the peer answered), or
-                        // throws a transport-death error / is interrupted on
-                        // scope-cancel (close()/notifyError).
-                        promise.retrieve()
-                    }
-                }.onSuccess {
-                    recordInboundActivity()
-                }.onFailure { t ->
-                    if (isKeepAliveServerAnswered(t)) recordInboundActivity()
+        val observer = scope.launch {
+            runCatching {
+                runInterruptible(Dispatchers.IO) {
+                    // UNBOUNDED — never abandons the queue slot. Returns the
+                    // REQUEST_SUCCESS packet, or throws the REQUEST_FAILURE
+                    // ConnectionException (both prove the peer answered), or
+                    // throws a transport-death error / is interrupted on
+                    // scope-cancel (close()/notifyError).
+                    promise.retrieve()
                 }
+            }.onSuccess {
+                recordInboundActivity()
+            }.onFailure { t ->
+                if (isKeepAliveServerAnswered(t)) recordInboundActivity()
             }
         }
+        keepAliveSingleFlightMutex.withLock {
+            if (pendingKeepAliveReply === marker) {
+                pendingKeepAliveReply = observer
+            }
+        }
+        marker.complete()
 
         return awaitKeepAliveActivity(before)
+    }
+
+    private suspend fun clearKeepAliveMarker(marker: CompletableJob) {
+        keepAliveSingleFlightMutex.withLock {
+            if (pendingKeepAliveReply === marker) {
+                pendingKeepAliveReply = null
+            }
+        }
+        marker.complete()
+    }
+
+    private sealed interface KeepAliveSendDecision {
+        data class Send(val marker: CompletableJob, val before: Long) : KeepAliveSendDecision
+        data class AwaitExisting(val before: Long) : KeepAliveSendDecision
     }
 
     private suspend fun awaitKeepAliveActivity(before: Long): Boolean {
@@ -495,8 +530,7 @@ internal class RealSshSession(
                         timeoutMs = execReadTimeoutMs,
                         onTimeout = { cause -> SshExecTimeoutException(command, execReadTimeoutMs, cause) },
                     ) {
-                        val stdout = liveCommand.inputStream.readBytes().toString(Charsets.UTF_8)
-                        val stderr = liveCommand.errorStream.readBytes().toString(Charsets.UTF_8)
+                        val output = readExecOutputConcurrently(liveCommand)
                         liveCommand.join()
                         // Issue #974: a completed exec round-trip is decoded server
                         // bytes — proof the transport is alive. Record it so a busy
@@ -507,7 +541,7 @@ internal class RealSshSession(
                         // one (e.g. signal-killed). Map to -1 so the caller can
                         // still tell it wasn't a clean 0.
                         val exitCode = liveCommand.exitStatus ?: -1
-                        ExecResult(stdout = stdout, stderr = stderr, exitCode = exitCode)
+                        ExecResult(stdout = output.stdout, stderr = output.stderr, exitCode = exitCode)
                     }
                 }
             } catch (timeout: SshExecTimeoutException) {
@@ -548,6 +582,65 @@ internal class RealSshSession(
             }
         }
     }
+
+    private fun readExecOutputConcurrently(command: Command): ExecOutput {
+        val executor = Executors.newFixedThreadPool(2) { runnable ->
+            Thread(runnable, "pocketshell-exec-drain").apply { isDaemon = true }
+        }
+        val stdout = executor.submit<String> {
+            command.inputStream.readBytesCapped(EXEC_STREAM_MAX_BYTES, "stdout")
+                .toString(Charsets.UTF_8)
+        }
+        val stderr = executor.submit<String> {
+            command.errorStream.readBytesCapped(EXEC_STREAM_MAX_BYTES, "stderr")
+                .toString(Charsets.UTF_8)
+        }
+        return try {
+            ExecOutput(
+                stdout = awaitExecDrain(stdout),
+                stderr = awaitExecDrain(stderr),
+            )
+        } finally {
+            executor.shutdownNow()
+        }
+    }
+
+    private fun awaitExecDrain(future: Future<String>): String =
+        try {
+            future.get()
+        } catch (e: ExecutionException) {
+            val cause = e.cause
+            when (cause) {
+                is SshException -> throw cause
+                is RuntimeException -> throw cause
+                is Error -> throw cause
+                null -> throw e
+                else -> throw IOException("exec stream drain failed: ${cause.message}", cause)
+            }
+        }
+
+    private fun InputStream.readBytesCapped(maxBytes: Int, streamName: String): ByteArray {
+        val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+        val output = ByteArrayOutputStream()
+        var total = 0
+        while (true) {
+            val read = read(buffer)
+            if (read < 0) break
+            if (total + read > maxBytes) {
+                throw SshException(
+                    "SSH exec $streamName exceeded ${maxBytes} bytes; refusing to buffer unbounded output",
+                )
+            }
+            output.write(buffer, 0, read)
+            total += read
+        }
+        return output.toByteArray()
+    }
+
+    private data class ExecOutput(
+        val stdout: String,
+        val stderr: String,
+    )
 
     override fun tail(path: String, onLine: (String) -> Unit): Job =
         tail(path, fromLineExclusive = -1, onLine = onLine)
@@ -860,7 +953,7 @@ internal class RealSshSession(
         // The same reasoning is why `downloadFile`/`uploadStream` use a `cat`
         // exec channel rather than SCP/SFTP — we only require a POSIX shell plus
         // `find`/`stat`, which are present on busybox and coreutils alike.
-        val probe = exec(buildListDirCommand(remotePath))
+        val probe = exec(buildListDirCommand(remotePath, maxEntries))
         if (probe.exitCode != PROBE_EXIT_OK) {
             throw classifyListFailure(remotePath, probe)
         }
@@ -1062,7 +1155,7 @@ internal class RealSshSession(
         // concurrent retries of the same attachment.
         val tempRemotePath = remotePath + ".part-" + java.util.UUID.randomUUID().toString().take(8)
         try {
-            val copied = streamToRemoteTemp(input, name, remotePath, tempRemotePath)
+            val copied = streamToRemoteTemp(input, name, remotePath, tempRemotePath, length)
 
             // Integrity check BEFORE the rename: the bytes that actually landed
             // in the temp file must match what we copied, and — when the caller
@@ -1116,6 +1209,7 @@ internal class RealSshSession(
         name: String,
         remotePath: String,
         tempRemotePath: String,
+        declaredLength: Long,
     ): Long {
         val coroutineJob = currentCoroutineContext()[Job]
         // Channel open + `cat >` exec are transport-mutating packets — serialise
@@ -1164,7 +1258,7 @@ internal class RealSshSession(
             val copied = try {
                 runInterruptible(Dispatchers.IO) {
                     val output = command!!.outputStream
-                    val n = copyToRemoteBlocking(input, output)
+                    val n = copyToRemoteBlocking(input, output, declaredLength)
                     runTransferStepWithStallTimeout(
                         operation = "closing upload output",
                         timeoutMs = uploadStallTimeoutMs,
@@ -1313,7 +1407,11 @@ internal class RealSshSession(
      * a per-step real wall-clock stall budget; total upload duration is
      * intentionally unbounded while bytes continue moving.
      */
-    private fun copyToRemoteBlocking(input: InputStream, output: OutputStream): Long {
+    private fun copyToRemoteBlocking(
+        input: InputStream,
+        output: OutputStream,
+        declaredLength: Long,
+    ): Long {
         val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
         var total = 0L
         while (true) {
@@ -1325,6 +1423,12 @@ internal class RealSshSession(
                 input.read(buffer)
             }
             if (read < 0) break
+            if (declaredLength >= 0 && total + read > declaredLength) {
+                throw SshException(
+                    "Upload stream exceeded declared length: declared $declaredLength bytes " +
+                        "but source produced more",
+                )
+            }
             if (Thread.interrupted()) throw InterruptedException("SSH upload interrupted")
             runTransferStepWithStallTimeout(
                 operation = "writing upload bytes",
@@ -1617,6 +1721,9 @@ internal const val PROBE_EXIT_DENIED: Int = 22
  */
 internal const val LIST_FIELD_SEP: Char = '|'
 
+private const val LIST_REMOTE_EXTRA_ROWS: Int = 2
+private const val LIST_REMOTE_MAX_LINES: Int = 100_000
+
 /**
  * Build the remote directory-listing command for [remotePath] (issue #528).
  *
@@ -1639,8 +1746,9 @@ internal const val LIST_FIELD_SEP: Char = '|'
  * NUL-terminate); such names are extremely rare and degrade to a skipped/garbled
  * row rather than a crash.
  */
-internal fun buildListDirCommand(remotePath: String): String {
+internal fun buildListDirCommand(remotePath: String, maxEntries: Int? = null): String {
     val quoted = quoteRemotePathForShell(remotePath)
+    val remoteLineLimit = maxEntries?.let { listDirectoryRemoteLineLimit(it) }
     return buildString {
         append("d=").append(quoted).append("; ")
         append("if [ ! -e \"\$d\" ]; then exit ").append(PROBE_EXIT_NO_SUCH).append("; fi; ")
@@ -1651,10 +1759,17 @@ internal fun buildListDirCommand(remotePath: String): String {
         append("find \"\$d\" -maxdepth 1 -exec stat -c '%F")
             .append(LIST_FIELD_SEP).append("%s")
             .append(LIST_FIELD_SEP).append("%Y")
-            .append(LIST_FIELD_SEP).append("%n' {} ").append("\\;").append(" 2>/dev/null; ")
+            .append(LIST_FIELD_SEP).append("%n' {} ").append("\\;").append(" 2>/dev/null")
+        if (remoteLineLimit != null) {
+            append(" | sed -n '1,").append(remoteLineLimit).append("p'")
+        }
+        append("; ")
         append("exit ").append(PROBE_EXIT_OK)
     }
 }
+
+internal fun listDirectoryRemoteLineLimit(maxEntries: Int): Int =
+    (maxEntries.coerceAtLeast(0) + LIST_REMOTE_EXTRA_ROWS).coerceAtMost(LIST_REMOTE_MAX_LINES)
 
 /**
  * Map a non-zero [buildListDirCommand] exit onto a typed [SshException].
@@ -1789,6 +1904,8 @@ internal const val CLOSE_LOG_TAG: String = "issue239-close-teardown"
  * of its own.
  */
 internal const val EXEC_READ_TIMEOUT_MS: Long = 30_000L
+
+internal const val EXEC_STREAM_MAX_BYTES: Int = 8 * 1024 * 1024
 
 private val EXEC_LOGGER: Logger = Logger.getLogger(RealSshSession::class.java.name + ".exec")
 

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshSession.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshSession.kt
@@ -296,6 +296,15 @@ internal class RealSshSession(
     override suspend fun sendKeepAlive(): Boolean {
         if (!isConnected) return false
 
+        // Single-flight must gate the WIRE SEND, not just the reply observer.
+        // If a prior keepalive promise is still pending, sending another global
+        // request would enqueue a second sshj promise behind the unresolved one.
+        // Count this tick against the same bounded no-activity budget, but do
+        // not put a new packet on the transport.
+        if (pendingKeepAliveReply?.isCompleted == false) {
+            return awaitKeepAliveActivity(lastInboundActivityNanos)
+        }
+
         // Issue #983 — split the op so the single-writer mutex is held ONLY for the
         // wire write, never for the multi-second reply wait. The
         // `keepalive@openssh.com` global request (wantReply=true) is the only
@@ -357,7 +366,7 @@ internal class RealSshSession(
      * `retrieve()` job is still pending. On a genuinely dead peer the job blocks
      * forever, so treating "pending" as "not a miss" would silently break dead-peer
      * detection and the 90s teardown would never fire. The single-flight guard
-     * ([pendingKeepAliveReply]) only suppresses launching a DUPLICATE `retrieve()`,
+     * ([pendingKeepAliveReply]) suppresses duplicate wire requests/retrieves,
      * never the miss.
      */
     private suspend fun awaitKeepAliveReply(
@@ -365,11 +374,10 @@ internal class RealSshSession(
     ): Boolean {
         val before = lastInboundActivityNanos
 
-        // Single-flight: only launch a NEW unbounded retrieve when the prior one has
-        // completed. A still-pending reply job means the previous promise's consumer
-        // is still alive (so its queue slot is not abandoned); we do not need — and
-        // must not — stack a second retrieve. We DO still run the local no-activity
-        // budget below, so a dead peer with a perpetually-pending job is still a miss.
+        // Only launch a NEW unbounded retrieve when the prior one has completed.
+        // A still-pending reply job means the previous promise's consumer is still
+        // alive (so its queue slot is not abandoned); callers with a pending job
+        // are gated before the wire send and run only the local no-activity budget.
         val existing = pendingKeepAliveReply
         if (existing == null || existing.isCompleted) {
             pendingKeepAliveReply = scope.launch {
@@ -390,6 +398,10 @@ internal class RealSshSession(
             }
         }
 
+        return awaitKeepAliveActivity(before)
+    }
+
+    private suspend fun awaitKeepAliveActivity(before: Long): Boolean {
         // Locally wait up to KEEPALIVE_REPLY_TIMEOUT_MS for the inbound-activity
         // timestamp to advance (a reply OR any reader byte). "No inbound activity
         // within the budget" IS the liveness question, and it leaves the promise
@@ -946,12 +958,11 @@ internal class RealSshSession(
                 if (exit != 0) {
                     val stderr = runCatching {
                         runInterruptible(Dispatchers.IO) {
-                            runTransferStepWithStallTimeout(
+                            readTransferStderrCappedBlocking(
+                                input = command.errorStream,
                                 operation = "reading remote `cat` stderr",
                                 timeoutMs = downloadStallTimeoutMs,
-                            ) {
-                                command.errorStream.readBytes().toString(Charsets.UTF_8)
-                            }
+                            )
                         }
                     }.getOrDefault("").trim()
                     // `cat` on a missing/unreadable file exits non-zero; map a
@@ -1184,7 +1195,13 @@ internal class RealSshSession(
             val exit = command!!.exitStatus ?: -1
             if (exit != 0) {
                 val stderr = runCatching {
-                    command!!.errorStream.readBytes().toString(Charsets.UTF_8)
+                    runInterruptible(Dispatchers.IO) {
+                        readTransferStderrCappedBlocking(
+                            input = command!!.errorStream,
+                            operation = "reading remote upload `cat` stderr",
+                            timeoutMs = uploadStallTimeoutMs,
+                        )
+                    }
                 }.getOrDefault("")
                 throw SshException(
                     "Remote `cat` exited with status $exit while writing $tempRemotePath: ${stderr.trim()}",
@@ -1325,6 +1342,32 @@ internal class RealSshSession(
             output.flush()
         }
         return total
+    }
+
+    private fun readTransferStderrCappedBlocking(
+        input: InputStream,
+        operation: String,
+        timeoutMs: Long,
+    ): String {
+        val buffer = ByteArray(4 * 1024)
+        val out = java.io.ByteArrayOutputStream()
+        var total = 0
+        input.use {
+            while (total < TRANSFER_STDERR_MAX_BYTES) {
+                if (Thread.interrupted()) throw InterruptedException("SSH transfer stderr read interrupted")
+                val limit = minOf(buffer.size, TRANSFER_STDERR_MAX_BYTES - total)
+                val read = runTransferStepWithStallTimeout(operation, timeoutMs) {
+                    it.read(buffer, 0, limit)
+                }
+                if (read < 0) {
+                    return out.toString(Charsets.UTF_8.name())
+                }
+                out.write(buffer, 0, read)
+                total += read
+            }
+        }
+        return out.toString(Charsets.UTF_8.name()) +
+            "\n[stderr truncated after $TRANSFER_STDERR_MAX_BYTES bytes]"
     }
 
     private fun <T> runTransferStepWithStallTimeout(
@@ -1778,6 +1821,13 @@ internal const val UPLOAD_STALL_TIMEOUT_MS: Long = 60_000L
  * wait that makes no progress for this long is treated as a wedged transfer.
  */
 internal const val DOWNLOAD_STALL_TIMEOUT_MS: Long = 60_000L
+
+/**
+ * Maximum stderr bytes captured from transfer helper commands (`cat` upload /
+ * download). Diagnostics stay useful while a noisy or malicious remote cannot
+ * grow memory unbounded when reporting a non-zero transfer exit.
+ */
+private const val TRANSFER_STDERR_MAX_BYTES: Int = 64 * 1024
 
 /**
  * Wall-clock ceiling for removing a partial upload's temp file after a failed

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshSession.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshSession.kt
@@ -341,32 +341,43 @@ internal class RealSshSession(
         // its FIFO `globalReqPromises` ATOMICALLY with the write, under sshj's own
         // lock. OpenSSH does not implement the request type, so it answers
         // `SSH_MSG_REQUEST_FAILURE` — which still proves the peer alive (#945).
-        val promise: Promise<SSHPacket, ConnectionException> =
-            runCatching {
-                dispatcher.run {
-                    if (!isConnected) {
-                        null
-                    } else {
-                        client.connection.sendGlobalRequest(
-                            KEEPALIVE_REQUEST_NAME,
-                            /* wantReply = */ true,
-                            EMPTY_PAYLOAD,
-                        )
+        try {
+            val promise: Promise<SSHPacket, ConnectionException> =
+                runCatching {
+                    dispatcher.run {
+                        if (!isConnected) {
+                            null
+                        } else {
+                            client.connection.sendGlobalRequest(
+                                KEEPALIVE_REQUEST_NAME,
+                                /* wantReply = */ true,
+                                EMPTY_PAYLOAD,
+                            )
+                        }
                     }
+                }.getOrElse { t ->
+                    if (t is CancellationException) throw t
+                    // The send itself (write / dispatcher) failed. A REQUEST_FAILURE that
+                    // escaped here still proves the peer answered; otherwise it is a miss.
+                    clearKeepAliveMarker(decision.marker)
+                    return isKeepAliveServerAnswered(t)
+                } ?: run {
+                    clearKeepAliveMarker(decision.marker)
+                    return false
                 }
-            }.getOrElse { t ->
-                if (t is CancellationException) throw t
-                // The send itself (write / dispatcher) failed. A REQUEST_FAILURE that
-                // escaped here still proves the peer answered; otherwise it is a miss.
-                clearKeepAliveMarker(decision.marker)
-                return isKeepAliveServerAnswered(t)
-            } ?: run {
-                clearKeepAliveMarker(decision.marker)
-                return false
-            }
 
-        // Issue #985 — confirm the reply OUTSIDE the mutex with a NON-ORPHANING wait.
-        return awaitKeepAliveReply(promise, decision.marker, decision.before)
+            // Issue #985 — confirm the reply OUTSIDE the mutex with a NON-ORPHANING wait.
+            return awaitKeepAliveReply(promise, decision.marker, decision.before)
+        } finally {
+            // If the caller is cancelled while waiting to enter/run the dispatcher
+            // send, or while handing the sent promise to the observer, the
+            // provisional single-flight marker would otherwise remain pending
+            // forever and suppress all later pings. Once awaitKeepAliveReply
+            // replaces it with the observer job this is a no-op.
+            withContext(NonCancellable) {
+                clearKeepAliveMarker(decision.marker)
+            }
+        }
     }
 
     /**
@@ -423,12 +434,14 @@ internal class RealSshSession(
                 if (isKeepAliveServerAnswered(t)) recordInboundActivity()
             }
         }
-        keepAliveSingleFlightMutex.withLock {
-            if (pendingKeepAliveReply === marker) {
-                pendingKeepAliveReply = observer
+        withContext(NonCancellable) {
+            keepAliveSingleFlightMutex.withLock {
+                if (pendingKeepAliveReply === marker) {
+                    pendingKeepAliveReply = observer
+                }
             }
+            marker.complete()
         }
-        marker.complete()
 
         return awaitKeepAliveActivity(before)
     }
@@ -470,6 +483,7 @@ internal class RealSshSession(
         val callerJob = currentCoroutineContext()[Job]
         val sessionChannelRef = AtomicReference<Session?>()
         val cmdRef = AtomicReference<Command?>()
+        var drainPermitAcquired = false
         val cancelHandle = callerJob?.invokeOnCompletion(onCancelling = true) { cause ->
             if (cause != null) {
                 // Channel close is itself a transport write — serialise it
@@ -484,6 +498,8 @@ internal class RealSshSession(
             }
         }
         return try {
+            acquireExecDrainPermit()
+            drainPermitAcquired = true
             // Phase 1 — open the channel + send the command, serialised against
             // every other transport op (the corruption-prone packets).
             val liveCommand = dispatcher.run {
@@ -541,7 +557,12 @@ internal class RealSshSession(
                         timeoutMs = execReadTimeoutMs,
                         onTimeout = { cause -> SshExecTimeoutException(command, execReadTimeoutMs, cause) },
                     ) {
-                        val output = readExecOutputConcurrently(liveCommand)
+                        val output = try {
+                            readExecOutputConcurrently(liveCommand)
+                        } finally {
+                            execDrainPermits.release()
+                            drainPermitAcquired = false
+                        }
                         liveCommand.join()
                         // Issue #974: a completed exec round-trip is decoded server
                         // bytes — proof the transport is alive. Record it so a busy
@@ -571,6 +592,10 @@ internal class RealSshSession(
             }
         } finally {
             cancelHandle?.dispose()
+            if (drainPermitAcquired) {
+                execDrainPermits.release()
+                drainPermitAcquired = false
+            }
             // Phase 3 — close the channel, serialised through the dispatcher
             // (channel close writes SSH_MSG_CHANNEL_CLOSE on the transport).
             //
@@ -594,8 +619,13 @@ internal class RealSshSession(
         }
     }
 
+    private suspend fun acquireExecDrainPermit() {
+        runInterruptible(Dispatchers.IO) {
+            execDrainPermits.acquire()
+        }
+    }
+
     private fun readExecOutputConcurrently(command: Command): ExecOutput {
-        execDrainPermits.acquire()
         val stdout = execDrainExecutor.submit<String> {
             command.inputStream.readBytesCapped(EXEC_STREAM_MAX_BYTES, "stdout").toString(Charsets.UTF_8)
         }
@@ -610,7 +640,6 @@ internal class RealSshSession(
         } finally {
             stdout.cancel(true)
             stderr.cancel(true)
-            execDrainPermits.release()
         }
     }
 
@@ -1643,8 +1672,17 @@ internal class RealSshSession(
         }
     }
 
-    private fun forceDisconnectRawClient() {
-        runCatching { client.disconnect() }
+    private suspend fun forceDisconnectRawClient() {
+        runCatching {
+            runInterruptible(Dispatchers.IO) {
+                WallClockCeiling.runUnderWallClockCeiling(
+                    timeoutMs = SESSION_CLOSE_TIMEOUT_MS,
+                    onTimeout = { cause -> TransportOpTimeoutException(SESSION_CLOSE_TIMEOUT_MS, cause) },
+                ) {
+                    client.disconnect()
+                }
+            }
+        }
             .onFailure { e ->
                 CLOSE_LOGGER.log(
                     Level.INFO,

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshSession.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshSession.kt
@@ -40,6 +40,7 @@ import java.io.OutputStream
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.Executors
 import java.util.concurrent.Future
+import java.util.concurrent.Semaphore
 import java.util.concurrent.atomic.AtomicReference
 import java.util.logging.Level
 import java.util.logging.Logger
@@ -105,6 +106,16 @@ internal class RealSshSession(
      * connect/enumeration latency.
      */
     private val dispatcher = TransportDispatcher()
+
+    /**
+     * Exec stdout/stderr drains must run concurrently per command, but the pool
+     * cannot grow with every exec call. Each permit represents one exec whose two
+     * stream readers may occupy the bounded per-session pool.
+     */
+    private val execDrainPermits = Semaphore(EXEC_DRAIN_MAX_CONCURRENT_EXECS)
+    private val execDrainExecutor = Executors.newFixedThreadPool(EXEC_DRAIN_MAX_CONCURRENT_EXECS * 2) { runnable ->
+        Thread(runnable, "pocketshell-exec-drain").apply { isDaemon = true }
+    }
 
     /**
      * Monotonic ([System.nanoTime]) timestamp of the most recent inbound
@@ -584,16 +595,12 @@ internal class RealSshSession(
     }
 
     private fun readExecOutputConcurrently(command: Command): ExecOutput {
-        val executor = Executors.newFixedThreadPool(2) { runnable ->
-            Thread(runnable, "pocketshell-exec-drain").apply { isDaemon = true }
+        execDrainPermits.acquire()
+        val stdout = execDrainExecutor.submit<String> {
+            command.inputStream.readBytesCapped(EXEC_STREAM_MAX_BYTES, "stdout").toString(Charsets.UTF_8)
         }
-        val stdout = executor.submit<String> {
-            command.inputStream.readBytesCapped(EXEC_STREAM_MAX_BYTES, "stdout")
-                .toString(Charsets.UTF_8)
-        }
-        val stderr = executor.submit<String> {
-            command.errorStream.readBytesCapped(EXEC_STREAM_MAX_BYTES, "stderr")
-                .toString(Charsets.UTF_8)
+        val stderr = execDrainExecutor.submit<String> {
+            command.errorStream.readBytesCapped(EXEC_STREAM_MAX_BYTES, "stderr").toString(Charsets.UTF_8)
         }
         return try {
             ExecOutput(
@@ -601,7 +608,9 @@ internal class RealSshSession(
                 stderr = awaitExecDrain(stderr),
             )
         } finally {
-            executor.shutdownNow()
+            stdout.cancel(true)
+            stderr.cancel(true)
+            execDrainPermits.release()
         }
     }
 
@@ -1580,9 +1589,10 @@ internal class RealSshSession(
                     CLOSE_LOGGER.log(
                         Level.INFO,
                         "[$CLOSE_LOG_TAG] close() timed out after ${SESSION_CLOSE_TIMEOUT_MS}ms; " +
-                            "forcing dispatcher shutdown",
+                            "forcing dispatcher shutdown and raw SSH disconnect",
                     )
                     dispatcher.closeNow()
+                    forceDisconnectRawClient()
                 }
             }
         } catch (e: TransportException) {
@@ -1628,8 +1638,19 @@ internal class RealSshSession(
                 "[$CLOSE_LOG_TAG] swallowed RuntimeException during close(): ${e.message}",
             )
         } finally {
+            execDrainExecutor.shutdownNow()
             teardownScope.cancel()
         }
+    }
+
+    private fun forceDisconnectRawClient() {
+        runCatching { client.disconnect() }
+            .onFailure { e ->
+                CLOSE_LOGGER.log(
+                    Level.INFO,
+                    "[$CLOSE_LOG_TAG] swallowed raw SSH disconnect failure after dispatcher timeout: ${e.message}",
+                )
+            }
     }
 
     private fun ensureConnected() {
@@ -1906,6 +1927,8 @@ internal const val CLOSE_LOG_TAG: String = "issue239-close-teardown"
 internal const val EXEC_READ_TIMEOUT_MS: Long = 30_000L
 
 internal const val EXEC_STREAM_MAX_BYTES: Int = 8 * 1024 * 1024
+
+internal const val EXEC_DRAIN_MAX_CONCURRENT_EXECS: Int = 4
 
 private val EXEC_LOGGER: Logger = Logger.getLogger(RealSshSession::class.java.name + ".exec")
 

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshSession.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshSession.kt
@@ -51,6 +51,18 @@ internal class RealSshSession(
      * wedged-read bound can be exercised without a real 30s wait.
      */
     private val execReadTimeoutMs: Long = EXEC_READ_TIMEOUT_MS,
+    /**
+     * Per-block no-progress ceiling for upload copies. This is deliberately a
+     * stall budget, not a whole-transfer budget, so large uploads over slow links
+     * may run for longer than one window as long as bytes continue moving.
+     */
+    private val uploadStallTimeoutMs: Long = UPLOAD_STALL_TIMEOUT_MS,
+    /**
+     * Per-block no-progress ceiling for raw `cat` downloads. Tests inject a
+     * short value to prove a wedged read is bounded without waiting a production
+     * interval.
+     */
+    private val downloadStallTimeoutMs: Long = DOWNLOAD_STALL_TIMEOUT_MS,
 ) : SshSession {
 
     /**
@@ -125,6 +137,15 @@ internal class RealSshSession(
     private var lastInboundActivityNanos: Long = System.nanoTime()
 
     /**
+     * Monotonic timestamp of the most recent outbound upload payload bytes. This
+     * mirrors [lastInboundActivityNanos] for the high-volume client-to-server
+     * path: an upload that is steadily writing payload is active even when the
+     * server is quiet until EOF.
+     */
+    @Volatile
+    private var lastOutboundActivityNanos: Long = System.nanoTime()
+
+    /**
      * Record inbound transport activity (issue #974). Called from EVERY path
      * that reads decoded application bytes the server sent back — the `-CC`
      * shell reader, exec/list/cat round-trips, and `tail -F` lines — so live
@@ -138,6 +159,16 @@ internal class RealSshSession(
     }
 
     /**
+     * Record client-to-server payload activity for upload streaming. Kept
+     * separate from inbound keepalive proof because outbound bytes alone do not
+     * prove the server can still reply, but they do prove the upload copy loop is
+     * not stalled.
+     */
+    private fun recordOutboundActivity() {
+        lastOutboundActivityNanos = System.nanoTime()
+    }
+
+    /**
      * Issue #974 — `core-ssh`-internal accessor on the raw inbound-activity
      * timestamp so [KeepAliveIntegrationTest] can drive a synthetic
      * [TransportKeepAlive] off the SAME field the production keepalive reads,
@@ -146,6 +177,8 @@ internal class RealSshSession(
      * keepalive loop + [isTransportProvenAliveWithinKeepAliveWindow] instead.
      */
     internal fun lastInboundActivityNanosForTest(): Long = lastInboundActivityNanos
+
+    internal fun lastOutboundActivityNanosForTest(): Long = lastOutboundActivityNanos
 
     /**
      * Issue #985/#983 — single-flight guard for the keepalive reply wait. Holds
@@ -854,13 +887,13 @@ internal class RealSshSession(
      * arrive. Binary-safe — reads from sshj's raw channel stream with no
      * charset round-trip.
      */
-    private fun readRemoteBytesCapped(remotePath: String, maxBytes: Long): ByteArray {
+    private suspend fun readRemoteBytesCapped(remotePath: String, maxBytes: Long): ByteArray {
         // Channel open + `cat` exec are transport-mutating packets — serialise
         // through the dispatcher (issue #847). The capped streaming read below
         // runs OUTSIDE the dispatcher so a large file never wedges the `-CC`
         // write or other ops.
         val quoted = quoteRemotePathForShell(remotePath)
-        val (sessionChannel, command) = dispatcher.runBlockingDispatch {
+        val (sessionChannel, command) = dispatcher.run {
             val channel = try {
                 client.startSession()
             } catch (t: Throwable) {
@@ -876,25 +909,50 @@ internal class RealSshSession(
         }
         try {
             try {
-                val buffer = java.io.ByteArrayOutputStream()
-                val chunk = ByteArray(64 * 1024)
-                var total = 0L
-                command.inputStream.use { input ->
-                    while (true) {
-                        val read = input.read(chunk)
-                        if (read < 0) break
-                        total += read
-                        if (total > maxBytes) {
-                            throw SshFileTooLargeException(remotePath, -1, maxBytes)
-                        }
-                        buffer.write(chunk, 0, read)
+                val bytes = try {
+                    runInterruptible(Dispatchers.IO) {
+                        readRemoteBytesCappedBlocking(
+                            input = command.inputStream,
+                            remotePath = remotePath,
+                            maxBytes = maxBytes,
+                        )
                     }
+                } catch (stall: TransferStallTimeoutException) {
+                    runCatching { dispatcher.run { runCatching { command.close() } } }
+                    runCatching { dispatcher.run { runCatching { sessionChannel.close() } } }
+                    throw SshException(
+                        "Download of $remotePath stalled for ${stall.timeoutMs}ms during ${stall.operation}",
+                        stall,
+                    )
                 }
-                command.join()
+                try {
+                    runInterruptible(Dispatchers.IO) {
+                        runTransferStepWithStallTimeout(
+                            operation = "waiting for remote `cat` to exit",
+                            timeoutMs = downloadStallTimeoutMs,
+                        ) {
+                            command.join()
+                        }
+                    }
+                } catch (stall: TransferStallTimeoutException) {
+                    runCatching { dispatcher.run { runCatching { command.close() } } }
+                    runCatching { dispatcher.run { runCatching { sessionChannel.close() } } }
+                    throw SshException(
+                        "Download of $remotePath stalled for ${stall.timeoutMs}ms during ${stall.operation}",
+                        stall,
+                    )
+                }
                 val exit = command.exitStatus ?: -1
                 if (exit != 0) {
                     val stderr = runCatching {
-                        command.errorStream.readBytes().toString(Charsets.UTF_8)
+                        runInterruptible(Dispatchers.IO) {
+                            runTransferStepWithStallTimeout(
+                                operation = "reading remote `cat` stderr",
+                                timeoutMs = downloadStallTimeoutMs,
+                            ) {
+                                command.errorStream.readBytes().toString(Charsets.UTF_8)
+                            }
+                        }
                     }.getOrDefault("").trim()
                     // `cat` on a missing/unreadable file exits non-zero; map a
                     // "No such file" stderr to the friendly not-found type.
@@ -903,17 +961,50 @@ internal class RealSshSession(
                     }
                     throw SshException("Remote `cat` exited with status $exit reading $remotePath: $stderr")
                 }
-                return buffer.toByteArray()
+                return bytes
             } finally {
-                runCatching { dispatcher.runBlockingDispatch { runCatching { command.close() } } }
+                withContext(NonCancellable) {
+                    runCatching { dispatcher.run { runCatching { command.close() } } }
+                }
             }
         } catch (e: SshException) {
             throw e
         } catch (t: Throwable) {
             throw SshException("Reading $remotePath failed: ${t.message}", t)
         } finally {
-            runCatching { dispatcher.runBlockingDispatch { runCatching { sessionChannel.close() } } }
+            withContext(NonCancellable) {
+                runCatching { dispatcher.run { runCatching { sessionChannel.close() } } }
+            }
         }
+    }
+
+    private fun readRemoteBytesCappedBlocking(
+        input: InputStream,
+        remotePath: String,
+        maxBytes: Long,
+    ): ByteArray {
+        val buffer = java.io.ByteArrayOutputStream()
+        val chunk = ByteArray(64 * 1024)
+        var total = 0L
+        input.use {
+            while (true) {
+                if (Thread.interrupted()) throw InterruptedException("SSH download interrupted")
+                val read = runTransferStepWithStallTimeout(
+                    operation = "reading remote file bytes",
+                    timeoutMs = downloadStallTimeoutMs,
+                ) {
+                    it.read(chunk)
+                }
+                if (read < 0) break
+                total += read
+                if (total > maxBytes) {
+                    throw SshFileTooLargeException(remotePath, -1, maxBytes)
+                }
+                buffer.write(chunk, 0, read)
+                recordInboundActivity()
+            }
+        }
+        return buffer.toByteArray()
     }
 
     /**
@@ -938,9 +1029,10 @@ internal class RealSshSession(
      * `cat` approach only needs a POSIX shell, `cat`, `wc`, `mv` and `rm`,
      * which are universally present.
      *
-     * Bounding (issue #930, folds in #928 D5 W-4): the blocking byte-copy +
-     * `join()` is wrapped in a [withTimeoutOrNull] ceiling so a wedged channel
-     * fails fast with a clear error instead of hanging indefinitely.
+     * Bounding (issue #930, folds in #928 D5 W-4): each blocking byte-copy step
+     * and the final `join()` run under a real wall-clock no-progress ceiling, so
+     * a wedged channel fails fast without imposing a whole-upload duration cap on
+     * slow but progressing transfers.
      *
      * [length] is the declared content length. When known (>= 0) it is also
      * verified against the bytes the remote actually received before the rename,
@@ -1002,10 +1094,10 @@ internal class RealSshSession(
     }
 
     /**
-     * Stream [input] into the remote [tempRemotePath] via `cat > <temp>`,
-     * bounded by [UPLOAD_TRANSFER_TIMEOUT_MS]. Returns the number of bytes
-     * copied. Throws [SshException] on a transport failure, a non-zero remote
-     * exit, or a timeout — the caller cleans up the temp file.
+     * Stream [input] into the remote [tempRemotePath] via `cat > <temp>`.
+     * Returns the number of bytes copied. Throws [SshException] on a transport
+     * failure, a non-zero remote exit, or a no-progress stall — the caller
+     * cleans up the temp file.
      */
     @OptIn(InternalCoroutinesApi::class)
     private suspend fun streamToRemoteTemp(
@@ -1052,32 +1144,41 @@ internal class RealSshSession(
             }
         }
         try {
-            // Issue #930 (folds in #928 D5 W-4): bound the blocking transfer so a
-            // wedged channel fails fast instead of hanging. `withTimeoutOrNull`
-            // returning null == we blew the ceiling. The byte-copy + `join()` run
-            // inside `runInterruptible` so the timeout's cancellation becomes a
-            // real `Thread.interrupt()` — that unblocks a stuck blocking
-            // `read()`/`write()` on the wedged channel (a plain `withTimeout`
-            // alone can't preempt a thread parked in a JDK blocking call). We
-            // also force-close the channel so the remote `cat` tears down.
-            val copied = withTimeoutOrNull(UPLOAD_TRANSFER_TIMEOUT_MS) {
+            // Issue #930 follow-up: bound upload by no-progress windows, not by a
+            // whole-transfer wall clock. A large upload over a slow but moving
+            // link may legitimately exceed 60s; only a blocking read/write/flush
+            // or remote EOF wait that makes no progress for the stall budget is
+            // failed. The watchdog is a real wall-clock interrupt, independent of
+            // caller coroutine clocks.
+            val copied = try {
                 runInterruptible(Dispatchers.IO) {
-                    val n = command!!.outputStream.use { output ->
-                        copyToRemoteBlocking(input, output)
+                    val output = command!!.outputStream
+                    val n = copyToRemoteBlocking(input, output)
+                    runTransferStepWithStallTimeout(
+                        operation = "closing upload output",
+                        timeoutMs = uploadStallTimeoutMs,
+                    ) {
+                        output.close()
                     }
                     // `outputStream.close()` sends EOF on the channel. The remote
                     // `cat` exits on EOF; `join()` waits for it so we can read
                     // the exit code.
-                    command!!.join()
+                    runTransferStepWithStallTimeout(
+                        operation = "waiting for remote upload `cat` to exit",
+                        timeoutMs = uploadStallTimeoutMs,
+                    ) {
+                        command!!.join()
+                    }
                     n
                 }
-            } ?: run {
+            } catch (stall: TransferStallTimeoutException) {
                 runCatching { input.close() }
                 runCatching { dispatcher.run { runCatching { command?.close() } } }
                 runCatching { dispatcher.run { runCatching { sessionChannel.close() } } }
                 throw SshException(
-                    "Upload of $name to $remotePath timed out after " +
-                        "${UPLOAD_TRANSFER_TIMEOUT_MS}ms (stalled transfer)",
+                    "Upload of $name to $remotePath stalled for " +
+                        "${stall.timeoutMs}ms during ${stall.operation}",
+                    stall,
                 )
             }
             val exit = command!!.exitStatus ?: -1
@@ -1189,26 +1290,52 @@ internal class RealSshSession(
 
     /**
      * Blocking byte-copy from [input] to [output]. Runs inside
-     * [runInterruptible] (issue #930), so the upload timeout cancels by
-     * interrupting this thread: each loop checks [Thread.interrupted] and the
-     * blocking `read`/`write` JDK calls themselves throw on interrupt, so a
-     * wedged transfer unblocks promptly instead of hanging. Returns the number
-     * of bytes copied.
+     * [runInterruptible] (issue #930), so cancellation interrupts this thread:
+     * each loop checks [Thread.interrupted] and the blocking `read`/`write` JDK
+     * calls themselves throw on interrupt. Each blocking step is also guarded by
+     * a per-step real wall-clock stall budget; total upload duration is
+     * intentionally unbounded while bytes continue moving.
      */
     private fun copyToRemoteBlocking(input: InputStream, output: OutputStream): Long {
         val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
         var total = 0L
         while (true) {
             if (Thread.interrupted()) throw InterruptedException("SSH upload interrupted")
-            val read = input.read(buffer)
+            val read = runTransferStepWithStallTimeout(
+                operation = "reading upload input",
+                timeoutMs = uploadStallTimeoutMs,
+            ) {
+                input.read(buffer)
+            }
             if (read < 0) break
             if (Thread.interrupted()) throw InterruptedException("SSH upload interrupted")
-            output.write(buffer, 0, read)
+            runTransferStepWithStallTimeout(
+                operation = "writing upload bytes",
+                timeoutMs = uploadStallTimeoutMs,
+            ) {
+                output.write(buffer, 0, read)
+            }
             total += read
+            recordOutboundActivity()
         }
-        output.flush()
+        runTransferStepWithStallTimeout(
+            operation = "flushing upload bytes",
+            timeoutMs = uploadStallTimeoutMs,
+        ) {
+            output.flush()
+        }
         return total
     }
+
+    private fun <T> runTransferStepWithStallTimeout(
+        operation: String,
+        timeoutMs: Long,
+        block: () -> T,
+    ): T = WallClockCeiling.runUnderWallClockCeiling(
+        timeoutMs = timeoutMs,
+        onTimeout = { cause -> TransferStallTimeoutException(operation, timeoutMs, cause) },
+        block = block,
+    )
 
     override fun close() {
         // Issue #945: stop the transport keepalive before tearing the scope down
@@ -1622,6 +1749,12 @@ internal const val EXEC_READ_TIMEOUT_MS: Long = 30_000L
 
 private val EXEC_LOGGER: Logger = Logger.getLogger(RealSshSession::class.java.name + ".exec")
 
+private class TransferStallTimeoutException(
+    val operation: String,
+    val timeoutMs: Long,
+    cause: Throwable?,
+) : IOException("$operation made no progress for ${timeoutMs}ms", cause)
+
 /**
  * Hard ceiling on the caller-visible wait inside [RealSshSession.close] for the
  * dispatcher drain + final disconnect. The dispatcher's per-op watchdog still
@@ -1631,12 +1764,20 @@ private val EXEC_LOGGER: Logger = Logger.getLogger(RealSshSession::class.java.na
 private const val SESSION_CLOSE_TIMEOUT_MS: Long = 2_000L
 
 /**
- * Wall-clock ceiling for the blocking byte-copy + `join()` of a single
- * attachment upload (issue #930, folds in #928 D5 W-4). A wedged channel must
- * fail fast with a clear error rather than hang forever. 60s comfortably covers
- * a multi-MB attachment over a slow mobile link while still bounding a stall.
+ * No-progress ceiling for a single blocking upload step: source read, remote
+ * channel write, final flush, or remote `cat` exit wait. This replaces the old
+ * absolute whole-upload 60s cap. A large upload may run for much longer than
+ * one window as long as each step keeps completing; a wedged channel still
+ * fails fast with a clear error.
  */
-internal const val UPLOAD_TRANSFER_TIMEOUT_MS: Long = 60_000L
+internal const val UPLOAD_STALL_TIMEOUT_MS: Long = 60_000L
+
+/**
+ * No-progress ceiling for raw file downloads over `cat`. Each successful chunk
+ * records inbound activity and resets the effective budget; a read/join/stderr
+ * wait that makes no progress for this long is treated as a wedged transfer.
+ */
+internal const val DOWNLOAD_STALL_TIMEOUT_MS: Long = 60_000L
 
 /**
  * Wall-clock ceiling for removing a partial upload's temp file after a failed

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshConnection.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshConnection.kt
@@ -1,12 +1,18 @@
 package com.pocketshell.core.ssh
 
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import net.schmizz.sshj.DefaultConfig
 import net.schmizz.sshj.SSHClient
 import net.schmizz.sshj.transport.verification.PromiscuousVerifier
@@ -32,6 +38,10 @@ public object SshConnection {
 
     /** Default TCP + auth timeouts, in milliseconds. */
     internal const val DEFAULT_TIMEOUT_MS: Int = 30_000
+
+    private const val CANCEL_DISCONNECT_TIMEOUT_MS: Long = 2_000L
+
+    private val cancellationCleanupScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     /**
      * Connect to `[host]:[port]` as [user] and authenticate with [key]
@@ -97,14 +107,31 @@ public object SshConnection {
             val liveClient = AtomicReference<C?>(null)
             var worker: Job? = null
 
-            fun disconnectClient() {
-                liveClient.getAndSet(null)?.let { client ->
-                    runCatching { connector.disconnect(client) }
+            fun takeLiveClient(): C? = liveClient.getAndSet(null)
+
+            fun disconnectClientBlocking(client: C) {
+                runCatching { connector.disconnect(client) }
+            }
+
+            fun disconnectClientAsync() {
+                val client = takeLiveClient() ?: return
+                cancellationCleanupScope.launch {
+                    withContext(NonCancellable) {
+                        withTimeoutOrNull(CANCEL_DISCONNECT_TIMEOUT_MS) {
+                            runInterruptible(Dispatchers.IO) {
+                                disconnectClientBlocking(client)
+                            }
+                        }
+                    }
                 }
             }
 
+            fun disconnectClientBestEffort() {
+                takeLiveClient()?.let { disconnectClientBlocking(it) }
+            }
+
             continuation.invokeOnCancellation {
-                disconnectClient()
+                disconnectClientAsync()
                 worker?.cancel()
             }
 
@@ -132,10 +159,10 @@ public object SshConnection {
                         session.close()
                     }
                 } catch (e: CancellationException) {
-                    disconnectClient()
+                    disconnectClientAsync()
                     continuation.cancel(e)
                 } catch (e: Throwable) {
-                    disconnectClient()
+                    disconnectClientBestEffort()
                     if (continuation.isActive) {
                         continuation.resume(Result.failure(wrap(e, host, port, user)))
                     }

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshLeaseManager.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshLeaseManager.kt
@@ -220,51 +220,56 @@ public class SshLeaseManager(
                 deferred.complete(Result.failure(error))
                 return Result.failure(error)
             }
-            return mutex.withLock {
-                if (inFlightConnects[key] === deferred) inFlightConnects.remove(key)
-                if (closed) {
-                    runCatching { session.close() }
-                    retractConnectingHintLocked(key)
-                    deferred.complete(Result.failure(SshLeaseManagerClosedException()))
-                    return@withLock Result.failure(SshLeaseManagerClosedException())
-                }
-                val raced = entries[key]
-                if (raced != null && raced.session.isConnected) {
-                    // A live entry appeared for this key while we were dialing
-                    // (e.g. a different code path acquired directly). Drop our
-                    // redundant transport and reuse the live one; awaiters reuse
-                    // it too via the deferred.
-                    runCatching { session.close() }
-                    raced.closeJob?.cancel()
-                    raced.closeJob = null
-                    raced.idleSinceMillis = null
-                    raced.refCount += 1
-                    emitStateLocked(key, SshLeaseConnectionState.Connected)
-                    deferred.complete(Result.success(raced))
-                    Result.success(
-                        SshLease(
-                            key = key,
-                            session = raced.session,
-                            isNewConnection = false,
-                            entryId = raced.id,
-                            releaseAction = ::release,
-                        ),
-                    )
-                } else {
-                    raced?.close()
-                    val entry = Entry(id = nextEntryId++, key = key, session = session, refCount = 1)
-                    entries[key] = entry
-                    emitStateLocked(key, SshLeaseConnectionState.Connected)
-                    deferred.complete(Result.success(entry))
-                    Result.success(
-                        SshLease(
-                            key = key,
-                            session = session,
-                            isNewConnection = true,
-                            entryId = entry.id,
-                            releaseAction = ::release,
-                        ),
-                    )
+            return withContext(NonCancellable) {
+                mutex.withLock {
+                    if (inFlightConnects[key] === deferred) inFlightConnects.remove(key)
+                    if (closed) {
+                        runCatching { session.close() }
+                        retractConnectingHintLocked(key)
+                        deferred.complete(Result.failure(SshLeaseManagerClosedException()))
+                        return@withLock Result.failure(SshLeaseManagerClosedException())
+                    }
+                    val raced = entries[key]
+                    if (raced != null && raced.session.isConnected) {
+                        // A live entry appeared for this key while we were dialing
+                        // (e.g. a different code path acquired directly). Drop our
+                        // redundant transport and reuse the live one; awaiters reuse
+                        // it too via the deferred. Run this registration/close block
+                        // noncancellably so a successful-but-not-yet-registered
+                        // transport cannot leak if the acquiring coroutine is
+                        // cancelled just after boundedConnect returns.
+                        runCatching { session.close() }
+                        raced.closeJob?.cancel()
+                        raced.closeJob = null
+                        raced.idleSinceMillis = null
+                        raced.refCount += 1
+                        emitStateLocked(key, SshLeaseConnectionState.Connected)
+                        deferred.complete(Result.success(raced))
+                        Result.success(
+                            SshLease(
+                                key = key,
+                                session = raced.session,
+                                isNewConnection = false,
+                                entryId = raced.id,
+                                releaseAction = ::release,
+                            ),
+                        )
+                    } else {
+                        raced?.close()
+                        val entry = Entry(id = nextEntryId++, key = key, session = session, refCount = 1)
+                        entries[key] = entry
+                        emitStateLocked(key, SshLeaseConnectionState.Connected)
+                        deferred.complete(Result.success(entry))
+                        Result.success(
+                            SshLease(
+                                key = key,
+                                session = session,
+                                isNewConnection = true,
+                                entryId = entry.id,
+                                releaseAction = ::release,
+                            ),
+                        )
+                    }
                 }
             }
         } finally {

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshLeaseManager.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshLeaseManager.kt
@@ -2,6 +2,7 @@ package com.pocketshell.core.ssh
 
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
@@ -71,7 +72,7 @@ public class SshLeaseManager(
     // from host detail instant: host detail's warm-lease acquire and the
     // user's session-open tap share ONE handshake, so the tap reuses the warm
     // transport the moment it is up rather than racing a second 3-4s connect.
-    private val inFlightConnects: MutableMap<SshLeaseKey, CompletableDeferred<Entry?>> =
+    private val inFlightConnects: MutableMap<SshLeaseKey, CompletableDeferred<Result<Entry>>> =
         linkedMapOf()
     private var closed: Boolean = false
     private var nextEntryId: Long = 1L
@@ -125,7 +126,7 @@ public class SshLeaseManager(
                     // it instead of opening a second redundant handshake.
                     AcquireDecision.Await(pending)
                 } else {
-                    val deferred = CompletableDeferred<Entry?>()
+                    val deferred = CompletableDeferred<Result<Entry>>()
                     inFlightConnects[key] = deferred
                     // Announce the in-flight handshake so a synchronous consumer
                     // (the tmux warm-open hint) can treat a session open landing
@@ -155,21 +156,22 @@ public class SshLeaseManager(
 
     /**
      * Issue #620: take a ref on the entry produced by another acquire's
-     * in-flight connect for this key. If that connect failed, or the shared
-     * entry was closed/disconnected by the time we awoke, fall back to a fresh
-     * owned connect so the caller still gets a lease (never silently fails just
-     * because the connect it joined lost its transport).
+     * in-flight connect for this key. If that connect failed, propagate the
+     * owner failure to every waiter instead of letting waiters serially retry
+     * one-by-one after a shared outage.
      */
     private suspend fun awaitSharedConnect(
         target: SshLeaseTarget,
-        deferred: CompletableDeferred<Entry?>,
+        deferred: CompletableDeferred<Result<Entry>>,
     ): Result<SshLease> {
         val key = target.leaseKey
-        val shared = deferred.await()
+        val shared = deferred.await().getOrElse { error ->
+            return Result.failure(error)
+        }
         val reused = mutex.withLock {
             if (closed) return Result.failure(SshLeaseManagerClosedException())
             val entry = shared
-                ?.takeIf { entries[key] === it && it.session.isConnected }
+                .takeIf { entries[key] === it && it.session.isConnected }
                 ?: return@withLock null
             entry.closeJob?.cancel()
             entry.closeJob = null
@@ -189,8 +191,9 @@ public class SshLeaseManager(
                 ),
             )
         }
-        // The shared connect did not yield a usable entry for us; dial our own.
-        return acquire(target)
+        return Result.failure(
+            SshException("Coalesced SSH connect for $key did not produce a live session"),
+        )
     }
 
     /**
@@ -201,20 +204,20 @@ public class SshLeaseManager(
      */
     private suspend fun runOwnedConnect(
         target: SshLeaseTarget,
-        deferred: CompletableDeferred<Entry?>,
+        deferred: CompletableDeferred<Result<Entry>>,
     ): Result<SshLease> {
         val key = target.leaseKey
         try {
             val session = boundedConnect(target).getOrElse { error ->
                 // Connect failed (including a bounded handshake timeout): clear
                 // the in-flight slot, retract the optimistic Connecting hint, and
-                // wake any awaiters so they fall back to their own dial rather
-                // than blocking forever.
+                // wake any awaiters with the same failure rather than letting
+                // them serially retry the same outage one-by-one.
                 mutex.withLock {
                     if (inFlightConnects[key] === deferred) inFlightConnects.remove(key)
                     retractConnectingHintLocked(key)
                 }
-                deferred.complete(null)
+                deferred.complete(Result.failure(error))
                 return Result.failure(error)
             }
             return mutex.withLock {
@@ -222,7 +225,7 @@ public class SshLeaseManager(
                 if (closed) {
                     runCatching { session.close() }
                     retractConnectingHintLocked(key)
-                    deferred.complete(null)
+                    deferred.complete(Result.failure(SshLeaseManagerClosedException()))
                     return@withLock Result.failure(SshLeaseManagerClosedException())
                 }
                 val raced = entries[key]
@@ -237,7 +240,7 @@ public class SshLeaseManager(
                     raced.idleSinceMillis = null
                     raced.refCount += 1
                     emitStateLocked(key, SshLeaseConnectionState.Connected)
-                    deferred.complete(raced)
+                    deferred.complete(Result.success(raced))
                     Result.success(
                         SshLease(
                             key = key,
@@ -252,7 +255,7 @@ public class SshLeaseManager(
                     val entry = Entry(id = nextEntryId++, key = key, session = session, refCount = 1)
                     entries[key] = entry
                     emitStateLocked(key, SshLeaseConnectionState.Connected)
-                    deferred.complete(entry)
+                    deferred.complete(Result.success(entry))
                     Result.success(
                         SshLease(
                             key = key,
@@ -267,9 +270,10 @@ public class SshLeaseManager(
         } finally {
             // Cancellation (or any non-local exit) must never strand the
             // in-flight slot or leave awaiters blocked on a deferred that
-            // would never complete. Clear our slot and wake awaiters; they
-            // fall back to their own dial. No-op when the success/failure
-            // paths above already completed the deferred.
+            // would never complete. Clear our slot and wake awaiters with the
+            // cancellation rather than making them start serial fallback dials.
+            // No-op when the success/failure paths above already completed the
+            // deferred.
             if (!deferred.isCompleted) {
                 withContext(NonCancellable) {
                     mutex.withLock {
@@ -277,7 +281,9 @@ public class SshLeaseManager(
                         retractConnectingHintLocked(key)
                     }
                 }
-                deferred.complete(null)
+                deferred.complete(
+                    Result.failure(CancellationException("SSH connect cancelled for $key")),
+                )
             }
         }
     }
@@ -371,8 +377,8 @@ public class SshLeaseManager(
 
     private sealed interface AcquireDecision {
         data class Reuse(val entry: Entry) : AcquireDecision
-        data class Await(val deferred: CompletableDeferred<Entry?>) : AcquireDecision
-        data class Own(val deferred: CompletableDeferred<Entry?>) : AcquireDecision
+        data class Await(val deferred: CompletableDeferred<Result<Entry>>) : AcquireDecision
+        data class Own(val deferred: CompletableDeferred<Result<Entry>>) : AcquireDecision
     }
 
     /**
@@ -488,7 +494,7 @@ public class SshLeaseManager(
 
     override fun close() {
         val toClose = mutableListOf<Entry>()
-        val pendingToWake = mutableListOf<CompletableDeferred<Entry?>>()
+        val pendingToWake = mutableListOf<CompletableDeferred<Result<Entry>>>()
         runCatching {
             kotlinx.coroutines.runBlocking {
                 mutex.withLock {
@@ -510,7 +516,7 @@ public class SshLeaseManager(
                 }
             }
         }
-        pendingToWake.forEach { it.complete(null) }
+        pendingToWake.forEach { it.complete(Result.failure(SshLeaseManagerClosedException())) }
         toClose.forEach { it.close() }
         connectScope.cancel()
         connectAbortScope.cancel()

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshLeaseManager.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshLeaseManager.kt
@@ -365,13 +365,17 @@ public class SshLeaseManager(
      * as warm. No-op when a live entry exists for the key (it already announced
      * Connected). Must be called while holding [mutex].
      */
-    private fun retractConnectingHintLocked(key: SshLeaseKey) {
+    private fun retractConnectingHintLocked(
+        key: SshLeaseKey,
+        closeReason: SshLeaseCloseReason = SshLeaseCloseReason.Disconnected,
+    ) {
         if (entries[key]?.session?.isConnected == true) return
         if (inFlightConnects.containsKey(key)) return
+        if (lastPublishedState[key] != SshLeaseConnectionState.Connecting) return
         emitStateLocked(
             key = key,
             state = SshLeaseConnectionState.Closed,
-            closeReason = SshLeaseCloseReason.Disconnected,
+            closeReason = closeReason,
         )
     }
 
@@ -500,12 +504,22 @@ public class SshLeaseManager(
                 mutex.withLock {
                     closed = true
                     toClose += entries.values
+                    val keysWithEntries = entries.keys.toSet()
+                    val pendingKeys = inFlightConnects.keys.toList()
                     entries.clear()
                     // Issue #620: wake any acquires parked on an in-flight
                     // connect so they observe `closed` and fail fast instead of
                     // blocking forever on a deferred that would never complete.
                     pendingToWake += inFlightConnects.values
                     inFlightConnects.clear()
+                    pendingKeys
+                        .filterNot { it in keysWithEntries }
+                        .forEach {
+                            retractConnectingHintLocked(
+                                key = it,
+                                closeReason = SshLeaseCloseReason.ManagerClosed,
+                            )
+                        }
                     toClose.forEach {
                         emitStateLocked(
                             key = it.key,

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshLeaseManager.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshLeaseManager.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
-import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -17,6 +17,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * App-scoped, DI-ready SSH connection lease pool keyed by host and credential
@@ -38,8 +39,8 @@ public class SshLeaseManager(
     // is NOT a kotlinx suspension point, so a wedged/slow peer can pin the
     // acquire even when the caller wraps it in `withTimeout` — `withTimeout`
     // cancels the coroutine but the cancellation cannot interrupt the in-flight
-    // blocking read. This bound runs the connect as a child the lease can
-    // CANCEL on expiry; cancelling that child propagates into
+    // blocking read. This bound runs the connect as a manager-owned dial job the
+    // lease can CANCEL on expiry; cancelling that job propagates into
     // `SshConnection.connect`'s `invokeOnCancellation`, which DISCONNECTS the
     // half-open transport and unparks the blocking read (the same close-to-heal
     // trick `SshFolderListGateway.execBounded` uses for reads). Without this the
@@ -87,6 +88,8 @@ public class SshLeaseManager(
     // edge (transport gone), so a fresh dial after a close re-emits `Connected`.
     private val lastPublishedState: MutableMap<SshLeaseKey, SshLeaseConnectionState> =
         hashMapOf()
+    private val connectScope = CoroutineScope(SupervisorJob() + connectTimeoutContext)
+    private val connectAbortScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     public val stateEvents: SharedFlow<SshLeaseStateEvent> = _stateEvents.asSharedFlow()
 
@@ -288,8 +291,8 @@ public class SshLeaseManager(
      * NOT a kotlinx suspension point. A wedged/slow peer can therefore pin the
      * acquire indefinitely: ordinary coroutine cancellation (what `withTimeout`
      * does) unparks at the next suspension point, but the in-flight blocking
-     * read has none. We run the dial as a CHILD coroutine and, on bound expiry,
-     * CANCEL that child. Cancelling it propagates into
+     * read has none. We run the dial as a manager-owned job and, on bound expiry,
+     * CANCEL that job. Cancelling it propagates into
      * [SshConnection.connect]'s `suspendCancellableCoroutine`, whose
      * `invokeOnCancellation` disconnects the half-open client — closing the
      * socket is what tears down the transport and unparks the blocking read
@@ -300,18 +303,18 @@ public class SshLeaseManager(
      *
      * On the healthy path the child completes well within the bound and the
      * timeout coroutine is cancelled, so this adds no latency. Cancellation of
-     * the acquire itself still flows straight through (the child is cancelled
-     * with the parent), preserving the #620 coalescing cleanup contract.
+     * the acquire itself still schedules cancellation of the owned dial job,
+     * preserving the #620 coalescing cleanup contract.
      */
     private suspend fun boundedConnect(target: SshLeaseTarget): Result<SshSession> =
         withContext(connectTimeoutContext) {
-            // Dial as a child of this withContext scope. The connector already
-            // returns Result, so a normal connect failure is a value, not a
-            // thrown child failure; a defensively caught throw is folded into a
-            // failure Result too so a misbehaving connector can never crash the
-            // lease scope.
-            val dial = async {
-                try {
+            // Dial outside this withContext's structured child tree. Timeout
+            // expiry must be able to return even when the connector's cancellation
+            // cleanup blocks inside disconnect(); a regular child would keep the
+            // parent scope from completing until that cleanup returned.
+            val abandoned = AtomicBoolean(false)
+            val dial = connectScope.async {
+                val result = try {
                     connector.connect(target)
                 } catch (ce: kotlinx.coroutines.CancellationException) {
                     throw ce // never swallow cancellation
@@ -320,20 +323,31 @@ public class SshLeaseManager(
                     // failure Result must not crash the lease scope.
                     Result.failure(t)
                 }
-            }
-            withTimeoutOrNull(connectTimeoutMillis) { dial.await() }
-                ?: run {
-                    // Stop awaiting the wedged handshake so this coroutine can
-                    // resume; cancelling the child fires
-                    // SshConnection.connect's invokeOnCancellation, which
-                    // disconnects the half-open transport and unparks the
-                    // blocking read. NonCancellable + cancelAndJoin guards the
-                    // cleanup so the disconnect actually runs and the child is
-                    // fully settled (never left dangling) before we return,
-                    // even if the acquire itself is racing cancellation.
-                    withContext(NonCancellable) { dial.cancelAndJoin() }
-                    Result.failure(SshLeaseConnectTimeoutException(target.leaseKey, connectTimeoutMillis))
+                if (abandoned.get()) {
+                    result.getOrNull()?.close()
                 }
+                result
+            }
+            try {
+                withTimeoutOrNull(connectTimeoutMillis) { dial.await() }
+                    ?: run {
+                        // Stop awaiting the wedged handshake so this coroutine can
+                        // resume; cancelling the detached dial fires
+                        // SshConnection.connect's invokeOnCancellation, which
+                        // disconnects the half-open transport and unparks the
+                        // blocking read. Do NOT cancel on this coroutine: a
+                        // blocking cancellation handler would make the timeout
+                        // path hang. Fire it from the abort scope and return.
+                        abandoned.set(true)
+                        connectAbortScope.launch { dial.cancel() }
+                        Result.failure(SshLeaseConnectTimeoutException(target.leaseKey, connectTimeoutMillis))
+                    }
+            } finally {
+                if (!dial.isCompleted) {
+                    abandoned.set(true)
+                    connectAbortScope.launch { dial.cancel() }
+                }
+            }
         }
 
     /**
@@ -498,6 +512,8 @@ public class SshLeaseManager(
         }
         pendingToWake.forEach { it.complete(null) }
         toClose.forEach { it.close() }
+        connectScope.cancel()
+        connectAbortScope.cancel()
     }
 
     private suspend fun release(key: SshLeaseKey, entryId: Long) {

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshLeaseManager.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshLeaseManager.kt
@@ -61,6 +61,22 @@ public class SshLeaseManager(
     // Virtual-time unit tests inject a `StandardTestDispatcher(testScheduler)`
     // to step the bound deterministically.
     private val connectTimeoutContext: kotlin.coroutines.CoroutineContext = Dispatchers.IO,
+    // Issue #687: context the bounded connect's ABORT (the off-path
+    // `connectAbortScope.launch { dial.cancel() }` that fires on timeout/expiry)
+    // runs on. Defaults to [Dispatchers.IO] so the abort runs on a REAL
+    // background thread: cancelling a wedged dial can drive a blocking
+    // `invokeOnCancellation` cleanup (disconnecting the half-open transport to
+    // unpark the socket read), and that blocking cleanup MUST NOT run on the
+    // caller's resume thread — firing it off-path on the IO pool is what lets
+    // the acquire return its bounded failure even while cleanup is still
+    // tearing the socket down. Kept SEPARATE from [connectTimeoutContext] only
+    // so virtual-time unit tests can pin the abort to the SAME test scheduler
+    // as the dial: cancelling a coroutine that lives on a `TestCoroutineScheduler`
+    // from a real `Dispatchers.IO` thread is a cross-thread mutation of a
+    // scheduler kotlinx documents as single-thread-only — a heisenbug under CI
+    // load. Production stays on real [Dispatchers.IO]; only the test injects a
+    // `StandardTestDispatcher(testScheduler)`.
+    private val abortTimeoutContext: kotlin.coroutines.CoroutineContext = Dispatchers.IO,
     private val nowMillis: () -> Long = { System.currentTimeMillis() },
 ) : AutoCloseable {
     private val mutex = Mutex()
@@ -90,7 +106,7 @@ public class SshLeaseManager(
     private val lastPublishedState: MutableMap<SshLeaseKey, SshLeaseConnectionState> =
         hashMapOf()
     private val connectScope = CoroutineScope(SupervisorJob() + connectTimeoutContext)
-    private val connectAbortScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val connectAbortScope = CoroutineScope(SupervisorJob() + abortTimeoutContext)
 
     public val stateEvents: SharedFlow<SshLeaseStateEvent> = _stateEvents.asSharedFlow()
 

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/ListDirectoryParseTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/ListDirectoryParseTest.kt
@@ -29,6 +29,12 @@ class ListDirectoryParseTest {
     }
 
     @Test
+    fun `buildListDirCommand caps remote output before parsing when maxEntries is provided`() {
+        val cmd = buildListDirCommand("/var/log", maxEntries = 4)
+        assertTrue("remote output is capped to requested rows plus sentinels", cmd.contains("sed -n '1,6p'"))
+    }
+
+    @Test
     fun `buildListDirCommand expands a leading tilde for HOME-relative dirs`() {
         // Issue #558 bug 3: a `~/...` directory must expand to $HOME.
         val cmd = buildListDirCommand("~/git/pocketshell")

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshPortForwardCountersTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshPortForwardCountersTest.kt
@@ -1,13 +1,22 @@
 package com.pocketshell.core.ssh
 
+import net.schmizz.sshj.DefaultConfig
+import net.schmizz.sshj.connection.Connection
 import net.schmizz.sshj.connection.channel.direct.DirectConnection
+import net.schmizz.sshj.transport.Transport
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.io.IOException
 import java.io.InputStream
 import java.io.OutputStream
 import java.net.InetAddress
 import java.net.ServerSocket
+import java.net.Socket
+import java.lang.reflect.Proxy
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
 
 class RealSshPortForwardCountersTest {
@@ -56,6 +65,97 @@ class RealSshPortForwardCountersTest {
         }
     }
 
+    @Test
+    fun `accepted local connections are capped to bound copy thread pressure`() {
+        val localPort = ServerSocket(0, 1, InetAddress.getByName("127.0.0.1"))
+            .use { it.localPort }
+        val openCalls = AtomicInteger(0)
+        val forward = RealSshPortForward(
+            channels = object : PortForwardChannelTransport {
+                override fun openChannel(remoteHost: String, remotePort: Int): DirectConnection {
+                    openCalls.incrementAndGet()
+                    return TestDirectConnection()
+                }
+
+                override fun closeChannel(channel: DirectConnection) {
+                    channel.close()
+                }
+            },
+            remoteHost = "remote.example",
+            remotePort = 5432,
+            localPort = localPort,
+        )
+        val clients = mutableListOf<Socket>()
+        try {
+            repeat(40) {
+                clients += Socket(InetAddress.getByName("127.0.0.1"), localPort)
+            }
+            assertTrue(
+                "accept loop should fill the active connection budget",
+                waitUntilReal(2_000L) { openCalls.get() >= 32 },
+            )
+            Thread.sleep(150)
+            assertEquals(
+                "connections beyond the active budget must be rejected before opening SSH channels",
+                32,
+                openCalls.get(),
+            )
+        } finally {
+            forward.close()
+            clients.forEach { runCatching { it.close() } }
+        }
+    }
+
+    @Test
+    fun `close uses an aggregate copy thread join budget`() {
+        val localPort = ServerSocket(0, 1, InetAddress.getByName("127.0.0.1"))
+            .use { it.localPort }
+        val forward = RealSshPortForward(
+            channels = object : PortForwardChannelTransport {
+                override fun openChannel(remoteHost: String, remotePort: Int): DirectConnection =
+                    error("test does not accept local connections")
+
+                override fun closeChannel(channel: DirectConnection) = Unit
+            },
+            remoteHost = "remote.example",
+            remotePort = 5432,
+            localPort = localPort,
+        )
+        val started = CountDownLatch(4)
+        val release = CountDownLatch(1)
+        val startCopyThread = RealSshPortForward::class.java.getDeclaredMethod(
+            "startCopyThread",
+            String::class.java,
+            Function0::class.java,
+        )
+        startCopyThread.isAccessible = true
+        repeat(4) { index ->
+            startCopyThread.invoke(
+                forward,
+                "test-copy-$index",
+                {
+                    started.countDown()
+                    release.await(5, TimeUnit.SECONDS)
+                    Unit
+                } as Function0<Unit>,
+            )
+        }
+        assertTrue("test copy threads should be running", started.await(2, TimeUnit.SECONDS))
+
+        val startedAt = System.nanoTime()
+        try {
+            forward.close()
+        } finally {
+            release.countDown()
+        }
+        val elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startedAt)
+
+        assertTrue(
+            "close should spend one aggregate join budget, not one timeout per copy thread; elapsed=$elapsedMs ms",
+            elapsedMs < 1_800L,
+        )
+    }
+
     private class SingleReadInputStream(
         private val bytes: ByteArray,
     ) : InputStream() {
@@ -73,6 +173,106 @@ class RealSshPortForwardCountersTest {
             read = true
             bytes.copyInto(b, off, 0, bytes.size)
             return bytes.size
+        }
+    }
+
+    private class TestDirectConnection : DirectConnection(fakeConnection(), "remote.example", 5432) {
+        private val input = BlockingInputStream()
+        private val output = object : OutputStream() {
+            override fun write(b: Int) = Unit
+            override fun write(b: ByteArray, off: Int, len: Int) = Unit
+        }
+
+        override fun getInputStream(): InputStream = input
+        override fun getOutputStream(): OutputStream = output
+
+        override fun close() {
+            input.close()
+        }
+    }
+
+    private class BlockingInputStream : InputStream() {
+        private val closed = CountDownLatch(1)
+
+        override fun read(): Int {
+            awaitClosed()
+            return -1
+        }
+
+        override fun read(b: ByteArray, off: Int, len: Int): Int {
+            awaitClosed()
+            return -1
+        }
+
+        override fun close() {
+            closed.countDown()
+        }
+
+        private fun awaitClosed() {
+            try {
+                closed.await()
+            } catch (e: InterruptedException) {
+                Thread.currentThread().interrupt()
+                throw IOException(e)
+            }
+        }
+    }
+
+    private companion object {
+        fun fakeConnection(): Connection {
+            val config = DefaultConfig()
+            val transport = proxy<Transport> { methodName, returnType ->
+                when (methodName) {
+                    "getConfig" -> config
+                    "getTimeoutMs" -> 0
+                    "getRemoteHost" -> "remote.example"
+                    "getRemotePort" -> 22
+                    "isRunning" -> true
+                    else -> defaultValue(returnType)
+                }
+            }
+            val nextId = AtomicInteger(0)
+            return proxy { methodName, returnType ->
+                when (methodName) {
+                    "getTransport" -> transport
+                    "nextID" -> nextId.incrementAndGet()
+                    "getWindowSize" -> 1_048_576L
+                    "getMaxPacketSize" -> 32 * 1024
+                    "getTimeoutMs" -> 0
+                    else -> defaultValue(returnType)
+                }
+            }
+        }
+
+        inline fun <reified T> proxy(
+            crossinline handler: (methodName: String, returnType: Class<*>) -> Any?,
+        ): T {
+            return Proxy.newProxyInstance(
+                T::class.java.classLoader,
+                arrayOf(T::class.java),
+            ) { _, method, _ -> handler(method.name, method.returnType) } as T
+        }
+
+        fun defaultValue(returnType: Class<*>): Any? = when (returnType) {
+            java.lang.Boolean.TYPE -> false
+            java.lang.Byte.TYPE -> 0.toByte()
+            java.lang.Short.TYPE -> 0.toShort()
+            java.lang.Integer.TYPE -> 0
+            java.lang.Long.TYPE -> 0L
+            java.lang.Float.TYPE -> 0f
+            java.lang.Double.TYPE -> 0.0
+            java.lang.Character.TYPE -> 0.toChar()
+            java.lang.Void.TYPE -> null
+            else -> null
+        }
+
+        fun waitUntilReal(timeoutMs: Long, predicate: () -> Boolean): Boolean {
+            val deadline = System.currentTimeMillis() + timeoutMs
+            while (System.currentTimeMillis() < deadline) {
+                if (predicate()) return true
+                Thread.sleep(10)
+            }
+            return predicate()
         }
     }
 }

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshSessionExecReadTimeoutTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshSessionExecReadTimeoutTest.kt
@@ -1,6 +1,9 @@
 package com.pocketshell.core.ssh
 
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import net.schmizz.sshj.SSHClient
@@ -24,6 +27,7 @@ import java.nio.charset.Charset
 import java.nio.charset.StandardCharsets
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * Reproduce-first regression for #935 S4-2: [RealSshSession.exec]'s Phase-2
@@ -106,6 +110,39 @@ class RealSshSessionExecReadTimeoutTest {
     }
 
     @Test
+    fun `exec stream drains use a bounded per-session worker pool`() = runBlocking {
+        val baselineDrainThreads = execDrainThreadCount()
+        val streamReadsStarted = CountDownLatch(EXEC_DRAIN_MAX_CONCURRENT_EXECS * 2)
+        val commands = List(EXEC_DRAIN_MAX_CONCURRENT_EXECS + 4) {
+            BlockingDrainsCommand(streamReadsStarted)
+        }
+        val session = RealSshSession(
+            QueueingClient(commands),
+            execReadTimeoutMs = 30_000L,
+        )
+        val execs = commands.mapIndexed { index, _ ->
+            async(Dispatchers.IO) {
+                runCatching { session.exec("blocked-drain-$index") }
+            }
+        }
+
+        try {
+            assertTrue(
+                "the bounded set of drain workers must start both streams",
+                streamReadsStarted.await(5, TimeUnit.SECONDS),
+            )
+            val activeDrainThreads = execDrainThreadCount() - baselineDrainThreads
+            assertTrue(
+                "exec drain workers must be capped per session; active=$activeDrainThreads",
+                activeDrainThreads <= EXEC_DRAIN_MAX_CONCURRENT_EXECS * 2,
+            )
+        } finally {
+            execs.forEach { it.cancelAndJoin() }
+            session.close()
+        }
+    }
+
+    @Test
     fun `exec caps buffered stdout`() = runBlocking {
         val command = LargeStdoutCommand()
         val session = RealSshSession(
@@ -131,6 +168,9 @@ class RealSshSessionExecReadTimeoutTest {
         }
     }
 
+    private fun execDrainThreadCount(): Int =
+        Thread.getAllStackTraces().keys.count { it.name.startsWith("pocketshell-exec-drain") }
+
     private class ConnectedClient(
         private val sessionChannel: Session,
     ) : SSHClient() {
@@ -144,6 +184,25 @@ class RealSshSessionExecReadTimeoutTest {
         override fun disconnect() {
             // No socket is opened by this test client; flip the flag so
             // `session.isConnected` reports the post-close state.
+            disconnected = true
+        }
+    }
+
+    private class QueueingClient(
+        private val commands: List<Session.Command>,
+    ) : SSHClient() {
+        private val nextCommand = AtomicInteger(0)
+
+        @Volatile
+        var disconnected: Boolean = false
+            private set
+
+        override fun isConnected(): Boolean = !disconnected
+        override fun isAuthenticated(): Boolean = !disconnected
+        override fun startSession(): Session =
+            RecordingSessionChannel(commands[nextCommand.getAndIncrement()])
+
+        override fun disconnect() {
             disconnected = true
         }
     }
@@ -235,6 +294,51 @@ class RealSshSessionExecReadTimeoutTest {
         override fun getExitStatus(): Int = 0
         override fun getExitWasCoreDumped(): Boolean = false
         override fun signal(signal: Signal) = Unit
+    }
+
+    private class BlockingDrainsCommand(
+        streamReadsStarted: CountDownLatch,
+    ) : FakeChannel(), Session.Command {
+        private val stdout = BlockingDrainInputStream(streamReadsStarted)
+        private val stderr = BlockingDrainInputStream(streamReadsStarted)
+
+        override fun getInputStream(): InputStream = stdout
+        override fun getErrorStream(): InputStream = stderr
+        override fun getExitErrorMessage(): String? = null
+        override fun getExitSignal(): Signal? = null
+        override fun getExitStatus(): Int = 0
+        override fun getExitWasCoreDumped(): Boolean = false
+        override fun signal(signal: Signal) = Unit
+
+        override fun close() {
+            super.close()
+            stdout.close()
+            stderr.close()
+        }
+    }
+
+    private class BlockingDrainInputStream(
+        private val readStarted: CountDownLatch,
+    ) : InputStream() {
+        @Volatile
+        private var closed = false
+
+        override fun read(): Int = blockUntilClosed()
+
+        override fun read(b: ByteArray, off: Int, len: Int): Int = blockUntilClosed()
+
+        private fun blockUntilClosed(): Int {
+            readStarted.countDown()
+            while (!closed) {
+                if (Thread.interrupted()) throw java.io.InterruptedIOException("drain interrupted")
+                Thread.sleep(10L)
+            }
+            return -1
+        }
+
+        override fun close() {
+            closed = true
+        }
     }
 
     /**

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshSessionExecReadTimeoutTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshSessionExecReadTimeoutTest.kt
@@ -143,6 +143,55 @@ class RealSshSessionExecReadTimeoutTest {
     }
 
     @Test
+    fun `queued exec waits for a drain permit before opening an exec channel`() = runBlocking {
+        val streamReadsStarted = CountDownLatch(EXEC_DRAIN_MAX_CONCURRENT_EXECS * 2)
+        val commands = List(EXEC_DRAIN_MAX_CONCURRENT_EXECS + 1) {
+            BlockingDrainsCommand(streamReadsStarted)
+        }
+        val client = QueueingClient(commands)
+        val session = RealSshSession(
+            client,
+            execReadTimeoutMs = 30_000L,
+        )
+        val blockers = (0 until EXEC_DRAIN_MAX_CONCURRENT_EXECS).map { index ->
+            async(Dispatchers.IO) {
+                runCatching { session.exec("blocked-drain-$index") }
+            }
+        }
+
+        try {
+            assertTrue(
+                "all drain permits must be occupied before starting the queued exec",
+                streamReadsStarted.await(5, TimeUnit.SECONDS),
+            )
+
+            val queued = async(Dispatchers.IO) {
+                runCatching { session.exec("queued-behind-drain-pool") }
+            }
+            Thread.sleep(250L)
+
+            assertEquals(
+                "local drain-pool saturation must not open another remote exec channel",
+                EXEC_DRAIN_MAX_CONCURRENT_EXECS,
+                client.startSessionCount.get(),
+            )
+            assertFalse(
+                "the queued exec should still be waiting locally for a drain permit",
+                queued.isCompleted,
+            )
+            assertTrue(
+                "local drain-pool saturation must not be treated as a transport failure",
+                session.isConnected,
+            )
+
+            queued.cancelAndJoin()
+        } finally {
+            blockers.forEach { it.cancelAndJoin() }
+            session.close()
+        }
+    }
+
+    @Test
     fun `exec caps buffered stdout`() = runBlocking {
         val command = LargeStdoutCommand()
         val session = RealSshSession(
@@ -192,6 +241,7 @@ class RealSshSessionExecReadTimeoutTest {
         private val commands: List<Session.Command>,
     ) : SSHClient() {
         private val nextCommand = AtomicInteger(0)
+        val startSessionCount = AtomicInteger(0)
 
         @Volatile
         var disconnected: Boolean = false
@@ -199,8 +249,10 @@ class RealSshSessionExecReadTimeoutTest {
 
         override fun isConnected(): Boolean = !disconnected
         override fun isAuthenticated(): Boolean = !disconnected
-        override fun startSession(): Session =
-            RecordingSessionChannel(commands[nextCommand.getAndIncrement()])
+        override fun startSession(): Session {
+            startSessionCount.incrementAndGet()
+            return RecordingSessionChannel(commands[nextCommand.getAndIncrement()])
+        }
 
         override fun disconnect() {
             disconnected = true

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshSessionExecReadTimeoutTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshSessionExecReadTimeoutTest.kt
@@ -12,6 +12,7 @@ import net.schmizz.sshj.connection.channel.Channel
 import net.schmizz.sshj.connection.channel.direct.PTYMode
 import net.schmizz.sshj.connection.channel.direct.Session
 import net.schmizz.sshj.connection.channel.direct.Signal
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -21,6 +22,7 @@ import java.io.InputStream
 import java.io.OutputStream
 import java.nio.charset.Charset
 import java.nio.charset.StandardCharsets
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
 /**
@@ -81,6 +83,54 @@ class RealSshSessionExecReadTimeoutTest {
             }
         }
 
+    @Test
+    fun `exec drains stdout and stderr concurrently`() = runBlocking {
+        val command = CoordinatedStdoutStderrCommand()
+        val session = RealSshSession(
+            ConnectedClient(RecordingSessionChannel(command)),
+            execReadTimeoutMs = 2_000L,
+        )
+
+        try {
+            val result = withTimeout(5_000L) {
+                session.exec("writes-both-streams")
+            }
+
+            assertEquals("stdout\n", result.stdout)
+            assertEquals("stderr\n", result.stderr)
+            assertEquals(0, result.exitCode)
+            assertTrue("stderr reader must have started", command.stderrReadStarted.await(1, TimeUnit.SECONDS))
+        } finally {
+            session.close()
+        }
+    }
+
+    @Test
+    fun `exec caps buffered stdout`() = runBlocking {
+        val command = LargeStdoutCommand()
+        val session = RealSshSession(
+            ConnectedClient(RecordingSessionChannel(command)),
+            execReadTimeoutMs = 2_000L,
+        )
+
+        try {
+            val thrown = try {
+                session.exec("too-much-output")
+                throw AssertionError("exec must reject unbounded stdout")
+            } catch (e: com.pocketshell.core.ssh.SshException) {
+                e
+            }
+
+            assertTrue(
+                "error should mention capped stdout",
+                thrown.message.orEmpty().contains("stdout exceeded"),
+            )
+            assertTrue("command channel should be closed", command.closed)
+        } finally {
+            session.close()
+        }
+    }
+
     private class ConnectedClient(
         private val sessionChannel: Session,
     ) : SSHClient() {
@@ -135,6 +185,56 @@ class RealSshSessionExecReadTimeoutTest {
             super.close()
             stdout.close()
         }
+    }
+
+    private class CoordinatedStdoutStderrCommand : FakeChannel(), Session.Command {
+        val stderrReadStarted = CountDownLatch(1)
+        private val stdout = object : InputStream() {
+            private val delegate = ByteArrayInputStream("stdout\n".toByteArray(StandardCharsets.UTF_8))
+
+            override fun read(): Int {
+                stderrReadStarted.await(5, TimeUnit.SECONDS)
+                return delegate.read()
+            }
+
+            override fun read(b: ByteArray, off: Int, len: Int): Int {
+                stderrReadStarted.await(5, TimeUnit.SECONDS)
+                return delegate.read(b, off, len)
+            }
+        }
+        private val stderr = object : InputStream() {
+            private val delegate = ByteArrayInputStream("stderr\n".toByteArray(StandardCharsets.UTF_8))
+
+            override fun read(): Int {
+                stderrReadStarted.countDown()
+                return delegate.read()
+            }
+
+            override fun read(b: ByteArray, off: Int, len: Int): Int {
+                stderrReadStarted.countDown()
+                return delegate.read(b, off, len)
+            }
+        }
+
+        override fun getInputStream(): InputStream = stdout
+        override fun getErrorStream(): InputStream = stderr
+        override fun getExitErrorMessage(): String? = null
+        override fun getExitSignal(): Signal? = null
+        override fun getExitStatus(): Int = 0
+        override fun getExitWasCoreDumped(): Boolean = false
+        override fun signal(signal: Signal) = Unit
+    }
+
+    private class LargeStdoutCommand : FakeChannel(), Session.Command {
+        private val stdout = ByteArrayInputStream(ByteArray(EXEC_STREAM_MAX_BYTES + 1) { 'x'.code.toByte() })
+
+        override fun getInputStream(): InputStream = stdout
+        override fun getErrorStream(): InputStream = ByteArrayInputStream(ByteArray(0))
+        override fun getExitErrorMessage(): String? = null
+        override fun getExitSignal(): Signal? = null
+        override fun getExitStatus(): Int = 0
+        override fun getExitWasCoreDumped(): Boolean = false
+        override fun signal(signal: Signal) = Unit
     }
 
     /**

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshSessionKeepAliveSingleFlightTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshSessionKeepAliveSingleFlightTest.kt
@@ -2,6 +2,7 @@ package com.pocketshell.core.ssh
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import net.schmizz.concurrent.Promise
@@ -90,6 +91,33 @@ class RealSshSessionKeepAliveSingleFlightTest {
         }
     }
 
+    @Test
+    fun `cancelled keepalive send clears provisional single-flight marker`() = runBlocking {
+        val connection = CancelFirstSendConnection()
+        val client = KeepAliveClient(connection)
+        val session = RealSshSession(client)
+
+        try {
+            val first = async(Dispatchers.IO) { session.sendKeepAlive() }
+            assertTrue(connection.firstSendEntered.await(5, TimeUnit.SECONDS))
+
+            first.cancelAndJoin()
+            assertTrue(connection.firstSendInterrupted.await(5, TimeUnit.SECONDS))
+
+            val second = async(Dispatchers.IO) { session.sendKeepAlive() }
+            withTimeout(5_000L) {
+                assertTrue(second.await())
+            }
+            assertEquals(
+                "cancelling a send while it is in dispatcher.run must not strand the marker",
+                2,
+                connection.sendCount.get(),
+            )
+        } finally {
+            session.close()
+        }
+    }
+
     private class KeepAliveClient(
         private val connection: Connection,
     ) : SSHClient() {
@@ -145,6 +173,57 @@ class RealSshSessionKeepAliveSingleFlightTest {
         override fun getKeepAlive(): KeepAlive = throw UnsupportedOperationException("not used")
     }
 
+    private class CancelFirstSendConnection : Connection {
+        val firstSendEntered = CountDownLatch(1)
+        val firstSendInterrupted = CountDownLatch(1)
+        val sendCount = AtomicInteger(0)
+
+        override fun sendGlobalRequest(
+            name: String,
+            wantReply: Boolean,
+            data: ByteArray,
+        ): Promise<SSHPacket, ConnectionException> {
+            assertEquals(KEEPALIVE_REQUEST_NAME, name)
+            assertTrue(wantReply)
+            val count = sendCount.incrementAndGet()
+            if (count == 1) {
+                firstSendEntered.countDown()
+                try {
+                    while (true) {
+                        Thread.sleep(10L)
+                    }
+                } catch (e: InterruptedException) {
+                    firstSendInterrupted.countDown()
+                    throw e
+                }
+            }
+            return ImmediateAnsweredKeepAlivePromise()
+        }
+
+        override fun attach(chan: Channel) = Unit
+        override fun attach(opener: ForwardedChannelOpener) = Unit
+        override fun forget(chan: Channel) = Unit
+        override fun forget(opener: ForwardedChannelOpener) = Unit
+        override fun get(id: Int): Channel = throw UnsupportedOperationException("not used")
+        override fun get(chanType: String): ForwardedChannelOpener =
+            throw UnsupportedOperationException("not used")
+        override fun join() = Unit
+        override fun nextID(): Int = 1
+        override fun sendOpenFailure(
+            recipient: Int,
+            reason: OpenFailException.Reason,
+            message: String,
+        ) = Unit
+        override fun getMaxPacketSize(): Int = 32 * 1024
+        override fun setMaxPacketSize(maxPacketSize: Int) = Unit
+        override fun getWindowSize(): Long = 0L
+        override fun setWindowSize(windowSize: Long) = Unit
+        override fun getTransport(): Transport = throw UnsupportedOperationException("not used")
+        override fun getTimeoutMs(): Int = 0
+        override fun setTimeoutMs(timeout: Int) = Unit
+        override fun getKeepAlive(): KeepAlive = throw UnsupportedOperationException("not used")
+    }
+
     private class BlockingKeepAlivePromise : Promise<SSHPacket, ConnectionException>(
         "keepalive",
         ConnectionException.chainer,
@@ -156,6 +235,16 @@ class RealSshSessionKeepAliveSingleFlightTest {
         override fun retrieve(): SSHPacket {
             retrieveStarted.countDown()
             allowRetrieveToFinish.await(30, TimeUnit.SECONDS)
+            throw ConnectionException("Global request keepalive failed")
+        }
+    }
+
+    private class ImmediateAnsweredKeepAlivePromise : Promise<SSHPacket, ConnectionException>(
+        "keepalive",
+        ConnectionException.chainer,
+        LoggerFactory.DEFAULT,
+    ) {
+        override fun retrieve(): SSHPacket {
             throw ConnectionException("Global request keepalive failed")
         }
     }

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshSessionKeepAliveSingleFlightTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshSessionKeepAliveSingleFlightTest.kt
@@ -55,6 +55,41 @@ class RealSshSessionKeepAliveSingleFlightTest {
         }
     }
 
+    @Test
+    fun `concurrent sendKeepAlive callers share one wire request`() = runBlocking {
+        val connection = PendingKeepAliveConnection()
+        val client = KeepAliveClient(connection)
+        val session = RealSshSession(client)
+        val callers = 12
+        val start = CountDownLatch(callers)
+
+        try {
+            val jobs = (1..callers).map {
+                async(Dispatchers.IO) {
+                    start.countDown()
+                    start.await(5, TimeUnit.SECONDS)
+                    session.sendKeepAlive()
+                }
+            }
+            assertTrue(connection.requestSent.await(5, TimeUnit.SECONDS))
+            assertTrue(connection.promise.retrieveStarted.await(5, TimeUnit.SECONDS))
+            Thread.sleep(150L)
+            assertEquals(
+                "single-flight must cover the check-to-send race, not only the reply wait",
+                1,
+                connection.sendCount.get(),
+            )
+
+            connection.promise.allowRetrieveToFinish.countDown()
+            withTimeout(5_000L) {
+                jobs.forEach { assertTrue(it.await()) }
+            }
+            assertEquals(1, connection.sendCount.get())
+        } finally {
+            session.close()
+        }
+    }
+
     private class KeepAliveClient(
         private val connection: Connection,
     ) : SSHClient() {

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshSessionKeepAliveSingleFlightTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshSessionKeepAliveSingleFlightTest.kt
@@ -1,0 +1,127 @@
+package com.pocketshell.core.ssh
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import net.schmizz.concurrent.Promise
+import net.schmizz.keepalive.KeepAlive
+import net.schmizz.sshj.SSHClient
+import net.schmizz.sshj.common.LoggerFactory
+import net.schmizz.sshj.common.SSHPacket
+import net.schmizz.sshj.connection.Connection
+import net.schmizz.sshj.connection.ConnectionException
+import net.schmizz.sshj.connection.channel.Channel
+import net.schmizz.sshj.connection.channel.OpenFailException
+import net.schmizz.sshj.connection.channel.forwarded.ForwardedChannelOpener
+import net.schmizz.sshj.transport.Transport
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+class RealSshSessionKeepAliveSingleFlightTest {
+
+    @Test
+    fun `sendKeepAlive does not send a second global request while the prior reply is pending`() = runBlocking {
+        val connection = PendingKeepAliveConnection()
+        val client = KeepAliveClient(connection)
+        val session = RealSshSession(client)
+
+        try {
+            val first = async(Dispatchers.IO) { session.sendKeepAlive() }
+            assertTrue(connection.requestSent.await(5, TimeUnit.SECONDS))
+            assertTrue(connection.promise.retrieveStarted.await(5, TimeUnit.SECONDS))
+
+            val second = async(Dispatchers.IO) { session.sendKeepAlive() }
+            Thread.sleep(100L)
+            assertEquals(
+                "a pending keepalive reply observer must suppress the next wire request",
+                1,
+                connection.sendCount.get(),
+            )
+
+            connection.promise.allowRetrieveToFinish.countDown()
+
+            withTimeout(5_000L) {
+                assertTrue(first.await())
+                assertTrue(second.await())
+            }
+            assertEquals(1, connection.sendCount.get())
+        } finally {
+            session.close()
+        }
+    }
+
+    private class KeepAliveClient(
+        private val connection: Connection,
+    ) : SSHClient() {
+        @Volatile
+        private var disconnected = false
+
+        override fun isConnected(): Boolean = !disconnected
+        override fun isAuthenticated(): Boolean = !disconnected
+        override fun getConnection(): Connection = connection
+        override fun disconnect() {
+            disconnected = true
+        }
+    }
+
+    private class PendingKeepAliveConnection : Connection {
+        val promise = BlockingKeepAlivePromise()
+        val requestSent = CountDownLatch(1)
+        val sendCount = AtomicInteger(0)
+
+        override fun sendGlobalRequest(
+            name: String,
+            wantReply: Boolean,
+            data: ByteArray,
+        ): Promise<SSHPacket, ConnectionException> {
+            assertEquals(KEEPALIVE_REQUEST_NAME, name)
+            assertTrue(wantReply)
+            sendCount.incrementAndGet()
+            requestSent.countDown()
+            return promise
+        }
+
+        override fun attach(chan: Channel) = Unit
+        override fun attach(opener: ForwardedChannelOpener) = Unit
+        override fun forget(chan: Channel) = Unit
+        override fun forget(opener: ForwardedChannelOpener) = Unit
+        override fun get(id: Int): Channel = throw UnsupportedOperationException("not used")
+        override fun get(chanType: String): ForwardedChannelOpener =
+            throw UnsupportedOperationException("not used")
+        override fun join() = Unit
+        override fun nextID(): Int = 1
+        override fun sendOpenFailure(
+            recipient: Int,
+            reason: OpenFailException.Reason,
+            message: String,
+        ) = Unit
+        override fun getMaxPacketSize(): Int = 32 * 1024
+        override fun setMaxPacketSize(maxPacketSize: Int) = Unit
+        override fun getWindowSize(): Long = 0L
+        override fun setWindowSize(windowSize: Long) = Unit
+        override fun getTransport(): Transport = throw UnsupportedOperationException("not used")
+        override fun getTimeoutMs(): Int = 0
+        override fun setTimeoutMs(timeout: Int) = Unit
+        override fun getKeepAlive(): KeepAlive = throw UnsupportedOperationException("not used")
+    }
+
+    private class BlockingKeepAlivePromise : Promise<SSHPacket, ConnectionException>(
+        "keepalive",
+        ConnectionException.chainer,
+        LoggerFactory.DEFAULT,
+    ) {
+        val retrieveStarted = CountDownLatch(1)
+        val allowRetrieveToFinish = CountDownLatch(1)
+
+        override fun retrieve(): SSHPacket {
+            retrieveStarted.countDown()
+            allowRetrieveToFinish.await(30, TimeUnit.SECONDS)
+            throw ConnectionException("Global request keepalive failed")
+        }
+    }
+}

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshSessionTeardownOrderingTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshSessionTeardownOrderingTest.kt
@@ -69,6 +69,44 @@ class RealSshSessionTeardownOrderingTest {
     }
 
     @Test
+    fun `raw disconnect fallback is bounded after dispatcher close timeout`() = runBlocking {
+        val client = WedgedStartSessionAndRawDisconnectClient()
+        val session = RealSshSession(client)
+        val exec = async(Dispatchers.IO) {
+            runCatching { session.exec("true") }
+        }
+
+        assertTrue(
+            "the synthetic startSession must enter before close queues behind it",
+            client.startSessionEntered.await(5, TimeUnit.SECONDS),
+        )
+
+        val closeThread = Thread({ session.close() }, "ps-test-session-close").apply {
+            isDaemon = true
+            start()
+        }
+        closeThread.join(5_500L)
+
+        assertFalse(
+            "close() must return even when the raw disconnect fallback wedges",
+            closeThread.isAlive,
+        )
+        assertTrue(
+            "the raw fallback disconnect must have been attempted",
+            client.rawDisconnectEntered.await(1, TimeUnit.SECONDS),
+        )
+        assertTrue(
+            "the raw fallback disconnect must be interrupted by a wall-clock ceiling",
+            client.rawDisconnectInterrupted.get(),
+        )
+
+        withTimeout(5_000L) {
+            exec.await()
+        }
+        Unit
+    }
+
+    @Test
     fun `close with active tail queues channel closes before session disconnect`() = runBlocking {
         val events = RecordingEvents()
         val command = BlockingTailCommand(events)
@@ -146,6 +184,52 @@ class RealSshSessionTeardownOrderingTest {
 
         override fun disconnect() {
             rawDisconnected.countDown()
+        }
+    }
+
+    private class WedgedStartSessionAndRawDisconnectClient : SSHClient() {
+        val startSessionEntered = CountDownLatch(1)
+        val startSessionInterrupted = AtomicBoolean(false)
+        val rawDisconnectEntered = CountDownLatch(1)
+        val rawDisconnectInterrupted = AtomicBoolean(false)
+
+        @Volatile
+        private var disconnected = false
+
+        override fun isConnected(): Boolean = !disconnected
+        override fun isAuthenticated(): Boolean = !disconnected
+
+        override fun startSession(): Session {
+            startSessionEntered.countDown()
+            try {
+                while (true) {
+                    if (Thread.interrupted()) {
+                        startSessionInterrupted.set(true)
+                        throw InterruptedException("wedged startSession interrupted")
+                    }
+                    Thread.sleep(10L)
+                }
+            } catch (e: InterruptedException) {
+                startSessionInterrupted.set(true)
+                throw e
+            }
+        }
+
+        override fun disconnect() {
+            disconnected = true
+            rawDisconnectEntered.countDown()
+            try {
+                while (true) {
+                    if (Thread.interrupted()) {
+                        rawDisconnectInterrupted.set(true)
+                        throw InterruptedException("wedged raw disconnect interrupted")
+                    }
+                    Thread.sleep(10L)
+                }
+            } catch (e: InterruptedException) {
+                rawDisconnectInterrupted.set(true)
+                throw e
+            }
         }
     }
 

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshSessionTeardownOrderingTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshSessionTeardownOrderingTest.kt
@@ -54,6 +54,10 @@ class RealSshSessionTeardownOrderingTest {
             elapsedMs < 3_500L,
         )
         assertFalse("close must mark the session disconnected", session.isConnected)
+        assertTrue(
+            "forced close must hard-disconnect the raw SSH client",
+            client.rawDisconnected.await(1, TimeUnit.SECONDS),
+        )
 
         withTimeout(5_000L) {
             exec.await()
@@ -119,12 +123,10 @@ class RealSshSessionTeardownOrderingTest {
     private class WedgedStartSessionClient : SSHClient() {
         val startSessionEntered = CountDownLatch(1)
         val startSessionInterrupted = AtomicBoolean(false)
+        val rawDisconnected = CountDownLatch(1)
 
-        @Volatile
-        private var disconnected = false
-
-        override fun isConnected(): Boolean = !disconnected
-        override fun isAuthenticated(): Boolean = !disconnected
+        override fun isConnected(): Boolean = rawDisconnected.count != 0L
+        override fun isAuthenticated(): Boolean = rawDisconnected.count != 0L
 
         override fun startSession(): Session {
             startSessionEntered.countDown()
@@ -143,7 +145,7 @@ class RealSshSessionTeardownOrderingTest {
         }
 
         override fun disconnect() {
-            disconnected = true
+            rawDisconnected.countDown()
         }
     }
 

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshSessionTransferStallTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshSessionTransferStallTest.kt
@@ -96,6 +96,43 @@ class RealSshSessionTransferStallTest {
     }
 
     @Test
+    fun `upload aborts before writing bytes past the declared length`() = runBlocking {
+        val upload = RecordingUploadCommand()
+        val client = ScriptedClient { command ->
+            when {
+                command.startsWith("cat > ") -> upload
+                command.startsWith("rm -f ") -> CompletedCommand(stdout = { "" })
+                else -> error("unexpected command: $command")
+            }
+        }
+        val session = RealSshSession(client, uploadStallTimeoutMs = 120L)
+
+        try {
+            val thrown = withTimeout(5_000L) {
+                try {
+                    session.uploadStream(
+                        input = ByteArrayInputStream(byteArrayOf(1, 2, 3, 4)),
+                        length = 3L,
+                        name = "too-long.bin",
+                        remotePath = "/tmp/too-long.bin",
+                    )
+                    throw AssertionError("upload must fail when the source exceeds declared length")
+                } catch (e: SshException) {
+                    e
+                }
+            }
+
+            assertTrue(
+                "upload failure should identify the declared length violation: ${thrown.message}",
+                thrown.message?.contains("exceeded declared length") == true,
+            )
+            assertEquals("bytes past the declared length must not be written", 0, upload.size)
+        } finally {
+            session.close()
+        }
+    }
+
+    @Test
     fun `upload non-zero stderr is byte capped instead of reading forever`() = runBlocking {
         val upload = NonZeroUploadCommand(InfiniteStderrInputStream())
         val client = ScriptedClient { command ->

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshSessionTransferStallTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshSessionTransferStallTest.kt
@@ -1,0 +1,259 @@
+package com.pocketshell.core.ssh
+
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import net.schmizz.sshj.SSHClient
+import net.schmizz.sshj.common.LoggerFactory
+import net.schmizz.sshj.common.Message
+import net.schmizz.sshj.common.SSHException
+import net.schmizz.sshj.common.SSHPacket
+import net.schmizz.sshj.connection.channel.Channel
+import net.schmizz.sshj.connection.channel.direct.PTYMode
+import net.schmizz.sshj.connection.channel.direct.Session
+import net.schmizz.sshj.connection.channel.direct.Signal
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.io.InterruptedIOException
+import java.io.OutputStream
+import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.TimeUnit
+
+class RealSshSessionTransferStallTest {
+
+    @Test
+    fun `slow but progressing upload is not capped by total duration`() = runBlocking {
+        val upload = RecordingUploadCommand()
+        val client = ScriptedClient { command ->
+            when {
+                command.startsWith("cat > ") -> upload
+                command.startsWith("wc -c < ") -> CompletedCommand(stdout = { "${upload.size}\n" })
+                command.startsWith("mv -f ") -> CompletedCommand(stdout = { "" })
+                else -> error("unexpected command: $command")
+            }
+        }
+        val session = RealSshSession(client, uploadStallTimeoutMs = 120L)
+        val before = session.lastOutboundActivityNanosForTest()
+
+        try {
+            val path = withTimeout(5_000L) {
+                session.uploadStream(
+                    input = SlowChunkInputStream(chunks = 8, bytesPerChunk = 32, delayMs = 45L),
+                    length = 8L * 32L,
+                    name = "slow.bin",
+                    remotePath = "/tmp/slow.bin",
+                )
+            }
+
+            assertEquals("/tmp/slow.bin", path)
+            assertEquals(8 * 32, upload.size)
+            assertTrue(
+                "upload payload writes must record outbound activity",
+                session.lastOutboundActivityNanosForTest() > before,
+            )
+        } finally {
+            session.close()
+        }
+    }
+
+    @Test
+    fun `wedged download read is bounded by stall timeout`() = runBlocking {
+        val wedgedCat = WedgedReadCommand()
+        val client = ScriptedClient { command ->
+            when {
+                command.contains(SIZE_PROBE_NO_FILE_SENTINEL) -> CompletedCommand(stdout = { "10\n" })
+                command.startsWith("cat ") -> wedgedCat
+                else -> error("unexpected command: $command")
+            }
+        }
+        val session = RealSshSession(client, downloadStallTimeoutMs = 120L)
+
+        try {
+            val thrown = withTimeout(5_000L) {
+                try {
+                    session.downloadFile("/tmp/wedged.bin", maxBytes = 1_024L)
+                    throw AssertionError("download must not return from a wedged read")
+                } catch (e: SshException) {
+                    e
+                }
+            }
+
+            assertTrue(
+                "download failure should identify the stall: ${thrown.message}",
+                thrown.message?.contains("stalled for 120ms") == true,
+            )
+            assertTrue(
+                "the wedged read must actually have started",
+                wedgedCat.readStarted,
+            )
+        } finally {
+            session.close()
+        }
+    }
+
+    private class ScriptedClient(
+        private val commandFactory: (String) -> Session.Command,
+    ) : SSHClient() {
+        @Volatile
+        private var disconnected = false
+
+        override fun isConnected(): Boolean = !disconnected
+        override fun isAuthenticated(): Boolean = !disconnected
+        override fun startSession(): Session = ScriptedSessionChannel(commandFactory)
+        override fun disconnect() {
+            disconnected = true
+        }
+    }
+
+    private class ScriptedSessionChannel(
+        private val commandFactory: (String) -> Session.Command,
+    ) : FakeChannel(), Session {
+        override fun exec(command: String): Session.Command = commandFactory(command)
+        override fun allocateDefaultPTY() = Unit
+        override fun allocatePTY(
+            term: String,
+            cols: Int,
+            rows: Int,
+            width: Int,
+            height: Int,
+            modes: MutableMap<PTYMode, Int>,
+        ) = Unit
+
+        override fun reqX11Forwarding(host: String, proto: String, cookie: Int) = Unit
+        override fun setEnvVar(name: String, value: String) = Unit
+        override fun startShell(): Session.Shell = throw UnsupportedOperationException("not used")
+        override fun startSubsystem(name: String): Session.Subsystem =
+            throw UnsupportedOperationException("not used")
+    }
+
+    private class RecordingUploadCommand : FakeChannel(), Session.Command {
+        private val bytes = ByteArrayOutputStream()
+
+        val size: Int
+            get() = bytes.size()
+
+        override fun getOutputStream(): OutputStream = bytes
+        override fun getInputStream(): InputStream = ByteArrayInputStream(ByteArray(0))
+        override fun getErrorStream(): InputStream = ByteArrayInputStream(ByteArray(0))
+        override fun getExitErrorMessage(): String? = null
+        override fun getExitSignal(): Signal? = null
+        override fun getExitStatus(): Int = 0
+        override fun getExitWasCoreDumped(): Boolean = false
+        override fun signal(signal: Signal) = Unit
+    }
+
+    private class CompletedCommand(
+        private val stdout: () -> String,
+        private val exit: Int = 0,
+    ) : FakeChannel(), Session.Command {
+        override fun getInputStream(): InputStream =
+            ByteArrayInputStream(stdout().toByteArray(Charsets.UTF_8))
+
+        override fun getErrorStream(): InputStream = ByteArrayInputStream(ByteArray(0))
+        override fun getExitErrorMessage(): String? = null
+        override fun getExitSignal(): Signal? = null
+        override fun getExitStatus(): Int = exit
+        override fun getExitWasCoreDumped(): Boolean = false
+        override fun signal(signal: Signal) = Unit
+    }
+
+    private class WedgedReadCommand : FakeChannel(), Session.Command {
+        @Volatile
+        var readStarted: Boolean = false
+            private set
+
+        private val stdout = object : InputStream() {
+            @Volatile
+            private var closed = false
+
+            override fun read(): Int {
+                readStarted = true
+                while (!closed) {
+                    if (Thread.interrupted()) throw InterruptedIOException("wedged download interrupted")
+                    Thread.sleep(10L)
+                }
+                return -1
+            }
+
+            override fun read(b: ByteArray, off: Int, len: Int): Int = read()
+
+            override fun close() {
+                closed = true
+            }
+        }
+
+        override fun getInputStream(): InputStream = stdout
+        override fun getErrorStream(): InputStream = ByteArrayInputStream(ByteArray(0))
+        override fun getExitErrorMessage(): String? = null
+        override fun getExitSignal(): Signal? = null
+        override fun getExitStatus(): Int = 0
+        override fun getExitWasCoreDumped(): Boolean = false
+        override fun signal(signal: Signal) = Unit
+
+        override fun close() {
+            super.close()
+            stdout.close()
+        }
+    }
+
+    private class SlowChunkInputStream(
+        private val chunks: Int,
+        private val bytesPerChunk: Int,
+        private val delayMs: Long,
+    ) : InputStream() {
+        private var emitted = 0
+
+        override fun read(): Int {
+            val one = ByteArray(1)
+            val read = read(one, 0, 1)
+            return if (read < 0) -1 else one[0].toInt() and 0xff
+        }
+
+        override fun read(b: ByteArray, off: Int, len: Int): Int {
+            if (emitted >= chunks) return -1
+            try {
+                Thread.sleep(delayMs)
+            } catch (e: InterruptedException) {
+                Thread.currentThread().interrupt()
+                throw InterruptedIOException("slow input interrupted")
+            }
+            val count = minOf(bytesPerChunk, len)
+            b.fill(0x5a, off, off + count)
+            emitted += 1
+            return count
+        }
+    }
+
+    private abstract class FakeChannel : Channel {
+        @Volatile
+        private var closed = false
+
+        override fun close() {
+            closed = true
+        }
+
+        override fun getAutoExpand(): Boolean = false
+        override fun getID(): Int = 1
+        override fun getInputStream(): InputStream = ByteArrayInputStream(ByteArray(0))
+        override fun getLocalMaxPacketSize(): Int = 32 * 1024
+        override fun getLocalWinSize(): Long = 0L
+        override fun getOutputStream(): OutputStream = ByteArrayOutputStream()
+        override fun getRecipient(): Int = 1
+        override fun getRemoteCharset(): Charset = StandardCharsets.UTF_8
+        override fun getRemoteMaxPacketSize(): Int = 32 * 1024
+        override fun getRemoteWinSize(): Long = 0L
+        override fun getType(): String = "session"
+        override fun isOpen(): Boolean = !closed
+        override fun setAutoExpand(autoExpand: Boolean) = Unit
+        override fun join() = Unit
+        override fun join(timeout: Long, unit: TimeUnit) = Unit
+        override fun isEOF(): Boolean = false
+        override fun getLoggerFactory(): LoggerFactory = LoggerFactory.DEFAULT
+        override fun handle(message: Message, packet: SSHPacket) = Unit
+        override fun notifyError(error: SSHException) = Unit
+    }
+}

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshSessionTransferStallTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshSessionTransferStallTest.kt
@@ -95,6 +95,42 @@ class RealSshSessionTransferStallTest {
         }
     }
 
+    @Test
+    fun `upload non-zero stderr is byte capped instead of reading forever`() = runBlocking {
+        val upload = NonZeroUploadCommand(InfiniteStderrInputStream())
+        val client = ScriptedClient { command ->
+            when {
+                command.startsWith("cat > ") -> upload
+                command.startsWith("rm -f ") -> CompletedCommand(stdout = { "" })
+                else -> error("unexpected command: $command")
+            }
+        }
+        val session = RealSshSession(client, uploadStallTimeoutMs = 120L)
+
+        try {
+            val thrown = withTimeout(5_000L) {
+                try {
+                    session.uploadStream(
+                        input = ByteArrayInputStream(byteArrayOf(1, 2, 3)),
+                        length = 3L,
+                        name = "bad.bin",
+                        remotePath = "/tmp/bad.bin",
+                    )
+                    throw AssertionError("non-zero upload cat must fail")
+                } catch (e: SshException) {
+                    e
+                }
+            }
+
+            assertTrue(
+                "upload stderr should be capped and visibly truncated: ${thrown.message}",
+                thrown.message?.contains("stderr truncated after") == true,
+            )
+        } finally {
+            session.close()
+        }
+    }
+
     private class ScriptedClient(
         private val commandFactory: (String) -> Session.Command,
     ) : SSHClient() {
@@ -142,6 +178,21 @@ class RealSshSessionTransferStallTest {
         override fun getExitErrorMessage(): String? = null
         override fun getExitSignal(): Signal? = null
         override fun getExitStatus(): Int = 0
+        override fun getExitWasCoreDumped(): Boolean = false
+        override fun signal(signal: Signal) = Unit
+    }
+
+    private class NonZeroUploadCommand(
+        private val stderr: InputStream,
+    ) : FakeChannel(), Session.Command {
+        private val bytes = ByteArrayOutputStream()
+
+        override fun getOutputStream(): OutputStream = bytes
+        override fun getInputStream(): InputStream = ByteArrayInputStream(ByteArray(0))
+        override fun getErrorStream(): InputStream = stderr
+        override fun getExitErrorMessage(): String? = null
+        override fun getExitSignal(): Signal? = null
+        override fun getExitStatus(): Int = 1
         override fun getExitWasCoreDumped(): Boolean = false
         override fun signal(signal: Signal) = Unit
     }
@@ -224,6 +275,17 @@ class RealSshSessionTransferStallTest {
             val count = minOf(bytesPerChunk, len)
             b.fill(0x5a, off, off + count)
             emitted += 1
+            return count
+        }
+    }
+
+    private class InfiniteStderrInputStream : InputStream() {
+        override fun read(): Int = 'x'.code
+
+        override fun read(b: ByteArray, off: Int, len: Int): Int {
+            if (len == 0) return 0
+            val count = len
+            b.fill('x'.code.toByte(), off, off + count)
             return count
         }
     }

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/SshConnectionCancellationTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/SshConnectionCancellationTest.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
@@ -14,6 +15,8 @@ import org.junit.Test
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.IOException
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 class SshConnectionCancellationTest {
 
@@ -33,8 +36,40 @@ class SshConnectionCancellationTest {
         connector.connectEntered.await()
         job.cancelAndJoin()
 
+        assertTrue(connector.client.disconnectEntered.await(5, TimeUnit.SECONDS))
         assertEquals(1, connector.client.disconnectCount)
         assertTrue(connector.client.closed)
+    }
+
+    @Test
+    fun `cancel during handshake does not wait for a blocking disconnect cleanup`() = runTest {
+        val connector = FakeConnector(
+            connectMode = ConnectMode.HangUntilCancelled,
+            blockDisconnect = true,
+        )
+        val job = launch {
+            SshConnection.connect(
+                host = "example.test",
+                port = 22,
+                user = "me",
+                key = SshKey.Pem("key"),
+                connector = connector,
+            )
+        }
+
+        connector.connectEntered.await()
+        job.cancel()
+
+        withTimeout(1_000L) {
+            job.join()
+        }
+        assertTrue(
+            "disconnect cleanup should be running off the cancellation path",
+            connector.client.disconnectEntered.await(5, TimeUnit.SECONDS),
+        )
+
+        connector.client.allowDisconnectToFinish.countDown()
+        assertTrue(connector.client.disconnectFinished.await(5, TimeUnit.SECONDS))
     }
 
     @Test
@@ -55,6 +90,7 @@ class SshConnectionCancellationTest {
         connector.releaseConnect.complete(Unit)
         job.join()
 
+        assertTrue(connector.client.disconnectEntered.await(5, TimeUnit.SECONDS))
         assertTrue("expected cancellation cleanup to disconnect the client", connector.client.disconnectCount >= 1)
         assertTrue("expected late success session to be closed", connector.client.sessionClosed)
     }
@@ -85,8 +121,9 @@ class SshConnectionCancellationTest {
 
     private class FakeConnector(
         private val connectMode: ConnectMode,
+        private val blockDisconnect: Boolean = false,
     ) : SshConnection.SshConnector<FakeClient> {
-        val client = FakeClient()
+        val client = FakeClient(blockDisconnect)
         val connectEntered = CompletableDeferred<Unit>()
         val releaseConnect = CompletableDeferred<Unit>()
 
@@ -131,16 +168,26 @@ class SshConnectionCancellationTest {
         }
     }
 
-    private class FakeClient {
-        var knownHostsApplied: Boolean = false
-        var authenticated: Boolean = false
-        var closed: Boolean = false
-        var sessionClosed: Boolean = false
-        var disconnectCount: Int = 0
+    private class FakeClient(
+        private val blockDisconnect: Boolean = false,
+    ) {
+        @Volatile var knownHostsApplied: Boolean = false
+        @Volatile var authenticated: Boolean = false
+        @Volatile var closed: Boolean = false
+        @Volatile var sessionClosed: Boolean = false
+        @Volatile var disconnectCount: Int = 0
+        val disconnectEntered = CountDownLatch(1)
+        val allowDisconnectToFinish = CountDownLatch(1)
+        val disconnectFinished = CountDownLatch(1)
 
         fun disconnect() {
+            disconnectEntered.countDown()
+            if (blockDisconnect) {
+                allowDisconnectToFinish.await(30, TimeUnit.SECONDS)
+            }
             disconnectCount += 1
             closed = true
+            disconnectFinished.countDown()
         }
     }
 

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/SshLeaseAcquireBoundCharacterizationTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/SshLeaseAcquireBoundCharacterizationTest.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceTimeBy
@@ -20,6 +21,8 @@ import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.InputStream
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 /**
  * EPIC #687 (lease-acquire bounding slice) — pins the bound that stops a
@@ -33,7 +36,7 @@ import java.io.InputStream
  * `PsFolderProbe` and even the downstream reconcile timeout never fires.
  *
  * The fix: the lease bounds the OWNED connect itself (`connectTimeoutMillis`),
- * running it as a child it can cancel; cancelling that child propagates into
+ * running it as a manager-owned job it can cancel; cancelling that job propagates into
  * `SshConnection.connect`'s `invokeOnCancellation`, which disconnects the
  * half-open transport and unparks the blocking read. On expiry the acquire
  * surfaces a bounded [SshLeaseConnectTimeoutException] instead of hanging.
@@ -71,10 +74,39 @@ class SshLeaseAcquireBoundCharacterizationTest {
             "the failure is the bounded timeout type, got ${error?.javaClass?.name}",
             error is SshLeaseConnectTimeoutException,
         )
-        // The bound CANCELS the child connect, which is the signal that
+        // The bound CANCELS the owned connect job, which is the signal that
         // propagates into SshConnection.connect's invokeOnCancellation to
         // disconnect the half-open transport and unpark the blocking read.
-        assertTrue("the wedged connect child was cancelled to unpark the read", connector.connectCancelled)
+        assertTrue("the wedged connect job was cancelled to unpark the read", connector.connectCancelled)
+    }
+
+    @Test
+    fun `a wedged handshake whose cancellation cleanup blocks still returns the bounded failure`() = runTest {
+        val connector = BlockingCancelCleanupConnector()
+        val manager = leaseManager(connector, connectTimeoutMillis = 2_000)
+
+        try {
+            val acquire = async { manager.acquire(TARGET) }
+            runCurrent()
+            assertTrue("the lease entered its owned connect", connector.connectEntered)
+
+            advanceTimeBy(2_001)
+            runCurrent()
+
+            assertTrue(
+                "acquire must return on the lease timeout even while cancellation cleanup is blocked",
+                acquire.isCompleted,
+            )
+            val result = acquire.await()
+            assertTrue(result.isFailure)
+            assertTrue(result.exceptionOrNull() is SshLeaseConnectTimeoutException)
+            assertTrue(
+                "the cancellation cleanup should have been started off the acquire path",
+                connector.cleanupEntered.await(5, TimeUnit.SECONDS),
+            )
+        } finally {
+            connector.allowCleanupToFinish.countDown()
+        }
     }
 
     @Test
@@ -174,6 +206,21 @@ class SshLeaseAcquireBoundCharacterizationTest {
                 throw e
             }
         }
+    }
+
+    private class BlockingCancelCleanupConnector : SshLeaseConnector {
+        @Volatile var connectEntered: Boolean = false
+        val cleanupEntered = CountDownLatch(1)
+        val allowCleanupToFinish = CountDownLatch(1)
+
+        override suspend fun connect(target: SshLeaseTarget): Result<SshSession> =
+            suspendCancellableCoroutine { continuation ->
+                connectEntered = true
+                continuation.invokeOnCancellation {
+                    cleanupEntered.countDown()
+                    allowCleanupToFinish.await(30, TimeUnit.SECONDS)
+                }
+            }
     }
 
     private class ImmediateLeaseConnector(private val session: FakeSshSession) : SshLeaseConnector {

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/SshLeaseAcquireBoundCharacterizationTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/SshLeaseAcquireBoundCharacterizationTest.kt
@@ -77,7 +77,10 @@ class SshLeaseAcquireBoundCharacterizationTest {
         // The bound CANCELS the owned connect job, which is the signal that
         // propagates into SshConnection.connect's invokeOnCancellation to
         // disconnect the half-open transport and unpark the blocking read.
-        assertTrue("the wedged connect job was cancelled to unpark the read", connector.connectCancelled)
+        assertTrue(
+            "the wedged connect job was cancelled to unpark the read",
+            connector.cancellationObserved.await(5, TimeUnit.SECONDS),
+        )
     }
 
     @Test
@@ -195,6 +198,7 @@ class SshLeaseAcquireBoundCharacterizationTest {
     private class WedgedLeaseConnector : SshLeaseConnector {
         @Volatile var connectEntered: Boolean = false
         @Volatile var connectCancelled: Boolean = false
+        val cancellationObserved = CountDownLatch(1)
 
         override suspend fun connect(target: SshLeaseTarget): Result<SshSession> {
             connectEntered = true
@@ -203,6 +207,7 @@ class SshLeaseAcquireBoundCharacterizationTest {
                 error("unreachable")
             } catch (e: kotlinx.coroutines.CancellationException) {
                 connectCancelled = true
+                cancellationObserved.countDown()
                 throw e
             }
         }

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/SshLeaseAcquireBoundCharacterizationTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/SshLeaseAcquireBoundCharacterizationTest.kt
@@ -1,6 +1,7 @@
 package com.pocketshell.core.ssh
 
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
@@ -86,7 +87,18 @@ class SshLeaseAcquireBoundCharacterizationTest {
     @Test
     fun `a wedged handshake whose cancellation cleanup blocks still returns the bounded failure`() = runTest {
         val connector = BlockingCancelCleanupConnector()
-        val manager = leaseManager(connector, connectTimeoutMillis = 2_000)
+        // This connector's `invokeOnCancellation` BLOCKS (it parks on a real
+        // CountDownLatch to model a cancellation cleanup that disconnects a
+        // wedged transport). The abort therefore MUST run on a real background
+        // thread — running it on the test scheduler would block the test
+        // thread inside the very `runCurrent()` that must still resolve the
+        // acquire. This is exactly the off-the-acquire-path behaviour the test
+        // pins down, so it deliberately keeps the production real-IO abort.
+        val manager = leaseManager(
+            connector,
+            connectTimeoutMillis = 2_000,
+            abortTimeoutContext = Dispatchers.IO,
+        )
 
         try {
             val acquire = async { manager.acquire(TARGET) }
@@ -181,6 +193,17 @@ class SshLeaseAcquireBoundCharacterizationTest {
         connectTimeoutMillis: Long,
         idleTtlMillis: Long = 60_000,
         maxIdleLeases: Int = 2,
+        // The owned-dial ABORT (`connectAbortScope.launch { dial.cancel() }`)
+        // defaults to the SAME virtual scheduler as the dial. Cancelling a
+        // coroutine that lives on a `TestCoroutineScheduler` from a real
+        // `Dispatchers.IO` thread is a cross-thread mutation of a
+        // single-thread-only scheduler — the heisenbug that flaked this class
+        // under CI load. Pinning the abort to the test scheduler makes the
+        // cancellation + its `cancellationObserved` countdown happen
+        // deterministically inside `runCurrent()`. A test whose cancellation
+        // cleanup BLOCKS (it must run off the test thread) overrides this with
+        // real `Dispatchers.IO`.
+        abortTimeoutContext: kotlin.coroutines.CoroutineContext = StandardTestDispatcher(testScheduler),
     ): SshLeaseManager =
         SshLeaseManager(
             connector = connector,
@@ -191,6 +214,7 @@ class SshLeaseAcquireBoundCharacterizationTest {
             // Drive the bound on the SAME virtual scheduler so advanceTimeBy
             // deterministically trips it (production uses real-time Dispatchers.IO).
             connectTimeoutContext = StandardTestDispatcher(testScheduler),
+            abortTimeoutContext = abortTimeoutContext,
             nowMillis = { testScheduler.currentTime },
         )
 

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/SshLeaseCoalescingCharacterizationTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/SshLeaseCoalescingCharacterizationTest.kt
@@ -185,6 +185,13 @@ class SshLeaseCoalescingCharacterizationTest {
             idleTtlMillis = idleTtlMillis,
             maxIdleLeases = maxIdleLeases,
             connectTimeoutContext = StandardTestDispatcher(testScheduler),
+            // Pin the owned-dial ABORT to the same virtual scheduler as the
+            // dial: cancelling a test-scheduler coroutine from a real
+            // Dispatchers.IO thread is a cross-thread mutation of a
+            // single-thread-only scheduler (the CI-load heisenbug). No
+            // connector here blocks in cancellation, so the test scheduler is
+            // safe and deterministic.
+            abortTimeoutContext = StandardTestDispatcher(testScheduler),
             nowMillis = { testScheduler.currentTime },
         )
 

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/SshLeaseCoalescingCharacterizationTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/SshLeaseCoalescingCharacterizationTest.kt
@@ -86,12 +86,11 @@ class SshLeaseCoalescingCharacterizationTest {
     }
 
     @Test
-    fun `owner connect failure completes the slot and wakes the joined awaiter to dial its own`() = runTest {
-        // #620: when the OWNING connect fails, the awaiter that joined it must
-        // NOT silently fail — the failed slot is completed (cleared) and the
-        // awaiter falls back to its own dial so the caller still gets a lease.
-        val good = FakeSshSession()
-        val connector = GatedLeaseConnector(null, good) // owner fails, fallback succeeds
+    fun `owner connect failure completes the slot and wakes the joined awaiter with the same failure`() = runTest {
+        // When the OWNING connect fails, waiters that joined it must not serially
+        // retry. They receive the same failure, and a future fresh acquire can
+        // decide when to dial again.
+        val connector = GatedLeaseConnector(null, FakeSshSession())
         val manager = leaseManager(connector)
 
         val owner = async { manager.acquire(TARGET) }
@@ -105,14 +104,10 @@ class SshLeaseCoalescingCharacterizationTest {
         val ownerResult = owner.await()
         assertTrue("the owning acquire surfaces the connect failure", ownerResult.isFailure)
 
-        connector.releaseConnect() // resolve the awaiter's own fallback dial
         runCurrent()
         val joinerResult = joiner.await()
-        assertTrue("the woken awaiter recovers via its own connect", joinerResult.isSuccess)
-        assertSame(good, joinerResult.getOrThrow().session)
-        assertEquals("exactly two connects: failed owner + awaiter fallback", 2, connector.startedConnects)
-
-        joinerResult.getOrThrow().release()
+        assertTrue("the woken awaiter receives the shared failure", joinerResult.isFailure)
+        assertEquals("the awaiter must not serially retry after shared failure", 1, connector.startedConnects)
     }
 
     @Test
@@ -120,12 +115,9 @@ class SshLeaseCoalescingCharacterizationTest {
         // #620: the owner's connect is CANCELLED mid-flight (its acquire scope
         // dies). The NonCancellable finally in runOwnedConnect must clear the
         // in-flight slot and complete the Deferred so the awaiter that parked on
-        // it is woken and falls back to its own dial — never blocked forever on a
-        // Deferred that would otherwise never complete.
-        val fallback = FakeSshSession()
-        // Slot 0 = owner (will be cancelled, never released). Slot 1 = awaiter's
-        // own fallback dial.
-        val connector = GatedLeaseConnector(FakeSshSession(), fallback)
+        // it is woken with cancellation — never blocked forever on a Deferred
+        // that would otherwise never complete, and never serially retrying.
+        val connector = GatedLeaseConnector(FakeSshSession(), FakeSshSession())
         val manager = leaseManager(connector)
 
         val owner = async { manager.acquire(TARGET) }
@@ -143,21 +135,17 @@ class SshLeaseCoalescingCharacterizationTest {
         owner.join()
         runCurrent()
 
-        // The awaiter must now be unblocked and dialing its OWN connect — proof
+        // The awaiter must now be unblocked with the same cancellation — proof
         // the slot was completed rather than stranded.
         assertEquals(
-            "owner cancellation wakes the awaiter, which dials its own connect",
-            2,
+            "owner cancellation wakes the awaiter without a serial retry",
+            1,
             connector.startedConnects,
         )
 
-        connector.releaseConnect() // release the awaiter's own dial (slot 1)
         runCurrent()
         val awaiterResult = awaiter.await()
-        assertTrue("the woken awaiter completes successfully on its own transport", awaiterResult.isSuccess)
-        assertSame(fallback, awaiterResult.getOrThrow().session)
-
-        awaiterResult.getOrThrow().release()
+        assertTrue("the woken awaiter completes with cancellation", awaiterResult.isFailure)
     }
 
     @Test

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/SshLeaseLifetimeCharacterizationTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/SshLeaseLifetimeCharacterizationTest.kt
@@ -220,6 +220,11 @@ class SshLeaseLifetimeCharacterizationTest {
             connector = QueueLeaseConnector(session),
             scope = this,
             connectTimeoutContext = StandardTestDispatcher(testScheduler),
+            // Pin the owned-dial ABORT to the same virtual scheduler as the
+            // dial: cancelling a test-scheduler coroutine from a real
+            // Dispatchers.IO thread is a cross-thread mutation of a
+            // single-thread-only scheduler (the CI-load heisenbug).
+            abortTimeoutContext = StandardTestDispatcher(testScheduler),
             nowMillis = { testScheduler.currentTime },
         )
 
@@ -248,6 +253,11 @@ class SshLeaseLifetimeCharacterizationTest {
             idleTtlMillis = idleTtlMillis,
             maxIdleLeases = maxIdleLeases,
             connectTimeoutContext = StandardTestDispatcher(testScheduler),
+            // Pin the owned-dial ABORT to the same virtual scheduler as the
+            // dial: cancelling a test-scheduler coroutine from a real
+            // Dispatchers.IO thread is a cross-thread mutation of a
+            // single-thread-only scheduler (the CI-load heisenbug).
+            abortTimeoutContext = StandardTestDispatcher(testScheduler),
             nowMillis = { testScheduler.currentTime },
         )
 

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/SshLeaseManagerTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/SshLeaseManagerTest.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
@@ -360,6 +361,38 @@ class SshLeaseManagerTest {
             "a failed in-flight connect emits Closed to retract the hint",
             events.contains(SshLeaseConnectionState.Closed),
         )
+        eventsCollector.cancel()
+    }
+
+    @Test
+    fun `closing manager emits Closed for optimistic Connecting key`() = runTest {
+        val connector = GatedLeaseConnector(FakeSshSession())
+        val manager = leaseManager(connector, idleTtlMillis = 60_000)
+
+        val events = mutableListOf<SshLeaseStateEvent>()
+        val eventsCollector = launch { manager.stateEvents.collect { events.add(it) } }
+        runCurrent()
+
+        val acquireJob = async { manager.acquire(TARGET) }
+        runCurrent()
+
+        assertTrue(manager.hasLiveOrConnectingLease(TARGET.leaseKey))
+        assertTrue(events.any { it.state == SshLeaseConnectionState.Connecting })
+
+        manager.close()
+        runCurrent()
+
+        assertFalse(manager.hasLiveOrConnectingLease(TARGET.leaseKey))
+        assertTrue(
+            "manager close must publish a terminal Closed edge for an optimistic Connecting key",
+            events.any {
+                it.key == TARGET.leaseKey &&
+                    it.state == SshLeaseConnectionState.Closed &&
+                    it.closeReason == SshLeaseCloseReason.ManagerClosed
+            },
+        )
+
+        acquireJob.cancelAndJoin()
         eventsCollector.cancel()
     }
 

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/SshLeaseManagerTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/SshLeaseManagerTest.kt
@@ -154,6 +154,11 @@ class SshLeaseManagerTest {
             connector = QueueLeaseConnector(session),
             scope = this,
             connectTimeoutContext = StandardTestDispatcher(testScheduler),
+            // Pin the owned-dial ABORT to the same virtual scheduler as the
+            // dial: cancelling a test-scheduler coroutine from a real
+            // Dispatchers.IO thread is a cross-thread mutation of a
+            // single-thread-only scheduler (the CI-load heisenbug).
+            abortTimeoutContext = StandardTestDispatcher(testScheduler),
             nowMillis = { testScheduler.currentTime },
         )
 
@@ -1075,6 +1080,11 @@ class SshLeaseManagerTest {
             idleTtlMillis = idleTtlMillis,
             maxIdleLeases = maxIdleLeases,
             connectTimeoutContext = StandardTestDispatcher(testScheduler),
+            // Pin the owned-dial ABORT to the same virtual scheduler as the
+            // dial: cancelling a test-scheduler coroutine from a real
+            // Dispatchers.IO thread is a cross-thread mutation of a
+            // single-thread-only scheduler (the CI-load heisenbug).
+            abortTimeoutContext = StandardTestDispatcher(testScheduler),
             nowMillis = { testScheduler.currentTime },
         )
 

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/SshLeaseManagerTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/SshLeaseManagerTest.kt
@@ -364,12 +364,11 @@ class SshLeaseManagerTest {
     }
 
     @Test
-    fun `awaiter falls back to its own connect when the shared connect fails`() = runTest {
-        // Issue #620: if the coalesced (owning) connect fails, the acquire that
-        // joined it must NOT silently fail — it dials its own transport so the
-        // caller still gets a usable lease.
-        val good = FakeSshSession()
-        val connector = GatedLeaseConnector(null, good)
+    fun `awaiter receives the shared connect failure instead of serially retrying`() = runTest {
+        // If the coalesced owner fails, every waiter must see that same failure.
+        // Otherwise a burst of waiters retries one-by-one and turns one outage
+        // into serialized SSH handshakes.
+        val connector = GatedLeaseConnector(null, FakeSshSession())
         val manager = leaseManager(connector, idleTtlMillis = 60_000)
 
         val firstDeferred = async { manager.acquire(TARGET) }
@@ -385,13 +384,10 @@ class SshLeaseManagerTest {
         val first = firstDeferred.await()
         assertTrue("the owning acquire surfaces the connect failure", first.isFailure)
 
-        // The awaiter falls back to its own dial and succeeds.
-        connector.releaseConnect()
         runCurrent()
         val second = secondDeferred.await()
-        assertTrue("the awaiter recovers with its own connect", second.isSuccess)
-        assertSame(good, second.getOrThrow().session)
-        assertEquals("exactly two connects: failed shared + awaiter fallback", 2, connector.startedConnects)
+        assertTrue("the waiter receives the shared connect failure", second.isFailure)
+        assertEquals("the waiter must not serially retry after the shared failure", 1, connector.startedConnects)
     }
 
     @Test

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/SshLeaseStaleHealCharacterizationTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/SshLeaseStaleHealCharacterizationTest.kt
@@ -196,6 +196,11 @@ class SshLeaseStaleHealCharacterizationTest {
             idleTtlMillis = idleTtlMillis,
             maxIdleLeases = maxIdleLeases,
             connectTimeoutContext = StandardTestDispatcher(testScheduler),
+            // Pin the owned-dial ABORT to the same virtual scheduler as the
+            // dial: cancelling a test-scheduler coroutine from a real
+            // Dispatchers.IO thread is a cross-thread mutation of a
+            // single-thread-only scheduler (the CI-load heisenbug).
+            abortTimeoutContext = StandardTestDispatcher(testScheduler),
             nowMillis = { testScheduler.currentTime },
         )
 

--- a/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxClient.kt
+++ b/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxClient.kt
@@ -1492,7 +1492,7 @@ internal class RealTmuxClient(
                 )
                 val waitingForBegin = synchronized(responseCorrelationLock) {
                     val waiting = pendingCmd.commandNumber < 0L
-                    if (effectiveTimeoutMode == CommandTimeoutMode.FailOpenDrain) {
+                    if (!waiting || effectiveTimeoutMode == CommandTimeoutMode.FailOpenDrain) {
                         abandonPendingResponse(pendingCmd, commandWasWritten = writeCompleted)
                     } else {
                         pendingQueue.remove(pendingCmd)

--- a/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxClient.kt
+++ b/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxClient.kt
@@ -30,7 +30,6 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.selects.select
 import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import java.util.concurrent.ConcurrentHashMap
@@ -1345,11 +1344,31 @@ internal class RealTmuxClient(
     ): CommandResponse {
         if (closed) throw TmuxClientException("client is closed")
         if (!connected) throw TmuxClientException("client is not connected")
+        // Issue #470: bound the single-flight ACQUIRE itself, matching
+        // sendChainedCommands/captureWithCursor. A wedged current holder used to
+        // leave bare sendCommand callers parked forever before any bytes were
+        // written, outside the command timeout gate. On acquire timeout we have
+        // not touched the wire, so surface a recoverable command failure without
+        // closing an otherwise healthy shell.
+        val acquired = withTimeoutOrNull(commandTimeoutMs) {
+            sendMutex.lock()
+            true
+        }
+        if (acquired != true) {
+            val kind = commandKind(cmd)
+            Log.w(
+                ISSUE_244_DIAG_TAG,
+                "tmux-command-acquire-wedged kind=$kind timeoutMs=$commandTimeoutMs",
+            )
+            throw TmuxClientException(
+                "tmux command `$kind` acquire wedged after ${commandTimeoutMs}ms",
+            )
+        }
         // Single-flight: tmux only honours one outstanding command at a
         // time. The deferred is registered (queued) BEFORE we write the
         // bytes so we can't lose a response that arrives before we've
         // returned from the write.
-        return sendMutex.withLock {
+        return try {
             if (closed) throw TmuxClientException("client is closed")
             if (!connected) throw TmuxClientException("client is not connected")
             val sh = shell ?: throw TmuxClientException("client has no active shell")
@@ -1411,7 +1430,7 @@ internal class RealTmuxClient(
                 }
                 throw t
             }
-            if (response != null) return@withLock response
+            if (response != null) return response
 
             val kind = commandKind(cmd)
             val exception = TmuxClientException(
@@ -1530,6 +1549,8 @@ internal class RealTmuxClient(
                 timeoutMode = effectiveTimeoutMode,
             )
             throw exception
+        } finally {
+            sendMutex.unlock()
         }
     }
 

--- a/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxClient.kt
+++ b/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxClient.kt
@@ -1102,7 +1102,11 @@ internal class RealTmuxClient(
                     // Capture itself timed out: tear down both pending entries
                     // and surface a best-effort failure (the caller falls back
                     // to opening the seed gate without a snapshot).
-                    cleanupCaptureWithCursorPending(capturePending, cursorPending)
+                    cleanupCaptureWithCursorPending(
+                        capturePending = capturePending,
+                        cursorPending = cursorPending,
+                        commandWasWritten = writeCompleted,
+                    )
                     writeJob.cancel()
                     throw TmuxClientException(
                         "tmux capture-pane (combined) timed out after ${effectiveTimeoutMs}ms",
@@ -1130,7 +1134,11 @@ internal class RealTmuxClient(
                 }
                 CaptureWithCursor(capture = capture, cursorReply = cursorReply)
             } catch (t: Throwable) {
-                cleanupCaptureWithCursorPending(capturePending, cursorPending)
+                cleanupCaptureWithCursorPending(
+                    capturePending = capturePending,
+                    cursorPending = cursorPending,
+                    commandWasWritten = writeCompleted,
+                )
                 writeJob.cancel()
                 if (!writeCompleted) {
                     close()
@@ -1148,17 +1156,19 @@ internal class RealTmuxClient(
 
     /**
      * Issue #640: remove both pending entries for a combined capture exchange,
-     * accounting for any block tmux has already begun (so its late `%end`
-     * drains as a stale block rather than mis-correlating with a later command).
+     * accounting for blocks tmux has already begun, plus every not-yet-begun
+     * block still owed by a written chained line, so late replies cannot bind
+     * to a later command.
      */
     private fun cleanupCaptureWithCursorPending(
         capturePending: PendingCommand,
         cursorPending: PendingCommand,
+        commandWasWritten: Boolean,
     ) {
         synchronized(responseCorrelationLock) {
             for (pending in listOf(capturePending, cursorPending)) {
                 val startedBlock = pending.commandNumber >= 0L
-                if (pendingQueue.remove(pending) && startedBlock) {
+                if (pendingQueue.remove(pending) && (startedBlock || commandWasWritten)) {
                     staleResponseBlocksToIgnore += 1
                 }
             }
@@ -1271,7 +1281,10 @@ internal class RealTmuxClient(
                     checkpoint.writeCompleted()
                     pendings.first().deferred.await()
                 } ?: run {
-                    cleanupChainedPending(pendings)
+                    cleanupChainedPending(
+                        pendings = pendings,
+                        commandWasWritten = writeCompleted,
+                    )
                     writeJob.cancel()
                     throw TmuxClientException(
                         "tmux chained command (first block) timed out after ${commandTimeoutMs}ms",
@@ -1307,7 +1320,10 @@ internal class RealTmuxClient(
                 }
                 responses
             } catch (t: Throwable) {
-                cleanupChainedPending(pendings)
+                cleanupChainedPending(
+                    pendings = pendings,
+                    commandWasWritten = writeCompleted,
+                )
                 writeJob.cancel()
                 if (!writeCompleted) {
                     close()
@@ -1323,15 +1339,18 @@ internal class RealTmuxClient(
 
     /**
      * Issue #692: remove every still-pending entry for a chained exchange,
-     * accounting for any block tmux has already begun (so its late `%end`
-     * drains as a stale block rather than mis-correlating with a later
-     * command). Mirrors [cleanupCaptureWithCursorPending] for N blocks.
+     * accounting for blocks tmux has already begun, plus every not-yet-begun
+     * block still owed by a written chained line. Mirrors
+     * [cleanupCaptureWithCursorPending] for N blocks.
      */
-    private fun cleanupChainedPending(pendings: List<PendingCommand>) {
+    private fun cleanupChainedPending(
+        pendings: List<PendingCommand>,
+        commandWasWritten: Boolean,
+    ) {
         synchronized(responseCorrelationLock) {
             for (pending in pendings) {
                 val startedBlock = pending.commandNumber >= 0L
-                if (pendingQueue.remove(pending) && startedBlock) {
+                if (pendingQueue.remove(pending) && (startedBlock || commandWasWritten)) {
                     staleResponseBlocksToIgnore += 1
                 }
             }

--- a/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxClient.kt
+++ b/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxClient.kt
@@ -1082,20 +1082,20 @@ internal class RealTmuxClient(
             }
 
             val writeResult = CompletableDeferred<Unit>()
+            val writeCompleted = AtomicBoolean(false)
             val writeJob = clientScope.launch {
                 try {
                     writeLine(sh, chained)
+                    writeCompleted.set(true)
                     writeResult.complete(Unit)
                 } catch (t: Throwable) {
                     writeResult.completeExceptionally(t)
                 }
             }
-            var writeCompleted = false
 
             try {
                 val capture = commandTimeoutGate.run(effectiveTimeoutMs) { checkpoint ->
                     writeResult.await()
-                    writeCompleted = true
                     checkpoint.writeCompleted()
                     capturePending.deferred.await()
                 } ?: run {
@@ -1105,7 +1105,7 @@ internal class RealTmuxClient(
                     cleanupCaptureWithCursorPending(
                         capturePending = capturePending,
                         cursorPending = cursorPending,
-                        commandWasWritten = writeCompleted,
+                        commandWasWritten = writeCompleted.get(),
                     )
                     writeJob.cancel()
                     throw TmuxClientException(
@@ -1134,10 +1134,10 @@ internal class RealTmuxClient(
                 cleanupCaptureWithCursorPending(
                     capturePending = capturePending,
                     cursorPending = cursorPending,
-                    commandWasWritten = writeCompleted,
+                    commandWasWritten = writeCompleted.get(),
                 )
                 writeJob.cancel()
-                if (!writeCompleted) {
+                if (!writeCompleted.get()) {
                     close()
                     throw TmuxClientException(
                         "failed to write tmux combined capture command: ${t.message}",
@@ -1258,26 +1258,26 @@ internal class RealTmuxClient(
             }
 
             val writeResult = CompletableDeferred<Unit>()
+            val writeCompleted = AtomicBoolean(false)
             val writeJob = clientScope.launch {
                 try {
                     writeLine(sh, chained)
+                    writeCompleted.set(true)
                     writeResult.complete(Unit)
                 } catch (t: Throwable) {
                     writeResult.completeExceptionally(t)
                 }
             }
-            var writeCompleted = false
 
             try {
                 val first = commandTimeoutGate.run(commandTimeoutMs) { checkpoint ->
                     writeResult.await()
-                    writeCompleted = true
                     checkpoint.writeCompleted()
                     pendings.first().deferred.await()
                 } ?: run {
                     cleanupChainedPending(
                         pendings = pendings,
-                        commandWasWritten = writeCompleted,
+                        commandWasWritten = writeCompleted.get(),
                     )
                     writeJob.cancel()
                     throw TmuxClientException(
@@ -1313,10 +1313,10 @@ internal class RealTmuxClient(
             } catch (t: Throwable) {
                 cleanupChainedPending(
                     pendings = pendings,
-                    commandWasWritten = writeCompleted,
+                    commandWasWritten = writeCompleted.get(),
                 )
                 writeJob.cancel()
-                if (!writeCompleted) {
+                if (!writeCompleted.get()) {
                     close()
                     throw TmuxClientException(
                         "failed to write tmux chained command: ${t.message}",
@@ -1405,20 +1405,20 @@ internal class RealTmuxClient(
             }
 
             val writeResult = CompletableDeferred<Unit>()
+            val writeCompleted = AtomicBoolean(false)
             val writeJob = clientScope.launch {
                 try {
                     writeLine(sh, cmd)
+                    writeCompleted.set(true)
                     writeResult.complete(Unit)
                 } catch (t: Throwable) {
                     writeResult.completeExceptionally(t)
                 }
             }
-            var writeCompleted = false
 
             val response = try {
                 commandTimeoutGate.run(commandTimeoutMs) { checkpoint ->
                     writeResult.await()
-                    writeCompleted = true
                     checkpoint.writeCompleted()
                     deferred.await()
                 }
@@ -1438,10 +1438,10 @@ internal class RealTmuxClient(
                 // (`staleResponseBlocksToIgnore += 1`) so a cancelled-after-write
                 // command leaves the FIFO consistent.
                 synchronized(responseCorrelationLock) {
-                    abandonPendingResponse(pendingCmd, commandWasWritten = writeCompleted)
+                    abandonPendingResponse(pendingCmd, commandWasWritten = writeCompleted.get())
                 }
                 writeJob.cancel()
-                if (!writeCompleted) {
+                if (!writeCompleted.get()) {
                     val kind = commandKind(cmd)
                     Log.w(
                         ISSUE_244_DIAG_TAG,
@@ -1458,7 +1458,8 @@ internal class RealTmuxClient(
             val exception = TmuxClientException(
                 "tmux command `$kind` timed out after ${commandTimeoutMs}ms",
             )
-            val effectiveTimeoutMode = if (writeCompleted) {
+            val wasWritten = writeCompleted.get()
+            val effectiveTimeoutMode = if (wasWritten) {
                 timeoutMode
             } else {
                 CommandTimeoutMode.FatalClose
@@ -1466,16 +1467,16 @@ internal class RealTmuxClient(
             recordCommandTimeout(
                 kind = kind,
                 timeoutMode = effectiveTimeoutMode,
-                writeCompleted = writeCompleted,
+                writeCompleted = wasWritten,
             )
             if (effectiveTimeoutMode != CommandTimeoutMode.FatalClose) {
+                val lateDrainMs = bestEffortLateResponseDrainMs()
                 Log.w(
                     ISSUE_244_DIAG_TAG,
                     "tmux-command-${effectiveTimeoutMode.logName}-timeout kind=$kind timeoutMs=$commandTimeoutMs " +
-                        "lateDrainMs=$BEST_EFFORT_LATE_RESPONSE_DRAIN_MS",
+                        "lateDrainMs=$lateDrainMs",
                 )
-                val lateResponse = commandTimeoutGate.run(BEST_EFFORT_LATE_RESPONSE_DRAIN_MS) { checkpoint ->
-                    checkpoint.writeCompleted()
+                val lateResponse = withTimeoutOrNull(lateDrainMs) {
                     deferred.await()
                 }
                 if (lateResponse != null) {
@@ -1492,11 +1493,7 @@ internal class RealTmuxClient(
                 )
                 val waitingForBegin = synchronized(responseCorrelationLock) {
                     val waiting = pendingCmd.commandNumber < 0L
-                    if (!waiting || effectiveTimeoutMode == CommandTimeoutMode.FailOpenDrain) {
-                        abandonPendingResponse(pendingCmd, commandWasWritten = writeCompleted)
-                    } else {
-                        pendingQueue.remove(pendingCmd)
-                    }
+                    abandonPendingResponse(pendingCmd, commandWasWritten = writeCompleted.get())
                     waiting
                 }
                 if (effectiveTimeoutMode == CommandTimeoutMode.FailOpenDrain && waitingForBegin) {
@@ -1552,7 +1549,7 @@ internal class RealTmuxClient(
                     // for it, count that block as stale so the reader discards it
                     // instead of binding it to the next command (FIFO desync).
                     val waitingForBegin = pendingCmd.commandNumber < 0L
-                    abandonPendingResponse(pendingCmd, commandWasWritten = writeCompleted)
+                    abandonPendingResponse(pendingCmd, commandWasWritten = writeCompleted.get())
                 }
                 throw exception
             }
@@ -1562,7 +1559,7 @@ internal class RealTmuxClient(
                 "tmux-command-timeout kind=$kind timeoutMs=$commandTimeoutMs transportProvenAlive=false",
             )
             synchronized(responseCorrelationLock) {
-                abandonPendingResponse(pendingCmd, commandWasWritten = writeCompleted)
+                abandonPendingResponse(pendingCmd, commandWasWritten = writeCompleted.get())
             }
             closeInternal(
                 ReaderExitIntent.CommandTimeout,
@@ -1897,12 +1894,9 @@ internal class RealTmuxClient(
                     }
                     else -> Unit
                 }
-                // Always forward non-output events to the bus so external
-                // observers (UI, session-list updater, etc.) see the same
-                // structural events the response-correlator just consumed.
-                // Pane output fanout is deliberately non-blocking: terminal
-                // rendering and diagnostic collectors must not starve this
-                // reader loop and delay command-response parsing.
+                // Forward public events without ever suspending the reader.
+                // Response framing markers are internal to correlation and are
+                // deliberately not exposed to UI collectors.
                 if (event is ControlEvent.Output) {
                     // Issue #105 diagnostics. We log BEFORE and AFTER the
                     // emit so a reviewer reading logcat can tell apart:
@@ -1926,7 +1920,7 @@ internal class RealTmuxClient(
                         "tmux-output-bus-emit pane=${event.paneId} bytes=${event.data.size}",
                     )
                 } else {
-                    eventBus.emit(event)
+                    emitPublicEvent(event)
                 }
             }
         } finally {
@@ -2018,6 +2012,31 @@ internal class RealTmuxClient(
         }
     }
 
+    private fun emitPublicEvent(event: ControlEvent) {
+        if (event is ControlEvent.Begin || event is ControlEvent.End || event is ControlEvent.Error) {
+            return
+        }
+        if (!eventBus.tryEmit(event)) {
+            val dropped = eventBusDroppedEvents.incrementAndGet()
+            if (eventBusOverflowDiagnosticEmitted.compareAndSet(false, true)) {
+                TmuxClientDiagnostics.record(
+                    "tmux_client_eventbus_overflow",
+                    commonDiagnosticFields() + mapOf(
+                        "session" to sessionName,
+                        "event" to event.javaClass.simpleName,
+                        "droppedEvents" to dropped,
+                        "capacity" to EVENT_BUFFER,
+                    ),
+                )
+            }
+            Log.w(
+                ISSUE_105_DIAG_TAG,
+                "tmux-eventbus-drop event=${event.javaClass.simpleName} " +
+                    "droppedEvents=$dropped capacity=$EVENT_BUFFER",
+            )
+        }
+    }
+
     private fun recordCommandTimeout(
         kind: String,
         timeoutMode: CommandTimeoutMode,
@@ -2034,6 +2053,9 @@ internal class RealTmuxClient(
             ),
         )
     }
+
+    private fun bestEffortLateResponseDrainMs(): Long =
+        BEST_EFFORT_LATE_RESPONSE_DRAIN_MS.coerceAtMost(commandTimeoutMs).coerceAtLeast(1L)
 
     /**
      * Issue #979: a `FatalClose` command timed out, but the transport-liveness

--- a/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxClient.kt
+++ b/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxClient.kt
@@ -1122,14 +1122,11 @@ internal class RealTmuxClient(
                     ?.output
                     ?.firstOrNull()
                 if (cursorReply == null) {
-                    // Stop waiting on the cursor block: drop it from the queue so
-                    // a late reply is treated as a stale block to ignore rather
-                    // than mis-correlating with the NEXT command on the wire.
+                    // Stop waiting on the cursor block: discard a not-yet-begun
+                    // late block or drain an already-open one so it cannot
+                    // mis-correlate with the NEXT command on the wire.
                     synchronized(responseCorrelationLock) {
-                        val stillWaitingForBegin = cursorPending.commandNumber < 0L
-                        if (pendingQueue.remove(cursorPending) && stillWaitingForBegin) {
-                            staleResponseBlocksToIgnore += 1
-                        }
+                        abandonPendingResponse(cursorPending, commandWasWritten = true)
                     }
                 }
                 CaptureWithCursor(capture = capture, cursorReply = cursorReply)
@@ -1167,10 +1164,7 @@ internal class RealTmuxClient(
     ) {
         synchronized(responseCorrelationLock) {
             for (pending in listOf(capturePending, cursorPending)) {
-                val startedBlock = pending.commandNumber >= 0L
-                if (pendingQueue.remove(pending) && (startedBlock || commandWasWritten)) {
-                    staleResponseBlocksToIgnore += 1
-                }
+                abandonPendingResponse(pending, commandWasWritten = commandWasWritten)
             }
         }
     }
@@ -1306,10 +1300,7 @@ internal class RealTmuxClient(
                         responses += response
                     } else {
                         synchronized(responseCorrelationLock) {
-                            val stillWaitingForBegin = pending.commandNumber < 0L
-                            if (pendingQueue.remove(pending) && stillWaitingForBegin) {
-                                staleResponseBlocksToIgnore += 1
-                            }
+                            abandonPendingResponse(pending, commandWasWritten = true)
                         }
                         responses += CommandResponse(
                             number = -1L,
@@ -1349,11 +1340,27 @@ internal class RealTmuxClient(
     ) {
         synchronized(responseCorrelationLock) {
             for (pending in pendings) {
-                val startedBlock = pending.commandNumber >= 0L
-                if (pendingQueue.remove(pending) && (startedBlock || commandWasWritten)) {
-                    staleResponseBlocksToIgnore += 1
-                }
+                abandonPendingResponse(pending, commandWasWritten = commandWasWritten)
             }
+        }
+    }
+
+    private fun abandonPendingResponse(
+        pending: PendingCommand,
+        commandWasWritten: Boolean,
+    ) {
+        if (pending.commandNumber >= 0L) {
+            pending.abandoned = true
+            pending.deferred.completeExceptionally(
+                TmuxClientException("tmux command abandoned while response block was open"),
+            )
+            return
+        }
+        if (pendingQueue.remove(pending) && commandWasWritten) {
+            staleResponseBlocksToIgnore += 1
+            pending.deferred.completeExceptionally(
+                TmuxClientException("tmux command abandoned before response block began"),
+            )
         }
     }
 
@@ -1431,11 +1438,7 @@ internal class RealTmuxClient(
                 // (`staleResponseBlocksToIgnore += 1`) so a cancelled-after-write
                 // command leaves the FIFO consistent.
                 synchronized(responseCorrelationLock) {
-                    val stillWaitingForBegin = pendingCmd.commandNumber < 0L
-                    val removed = pendingQueue.remove(pendingCmd)
-                    if (writeCompleted && removed && stillWaitingForBegin) {
-                        staleResponseBlocksToIgnore += 1
-                    }
+                    abandonPendingResponse(pendingCmd, commandWasWritten = writeCompleted)
                 }
                 writeJob.cancel()
                 if (!writeCompleted) {
@@ -1489,10 +1492,11 @@ internal class RealTmuxClient(
                 )
                 val waitingForBegin = synchronized(responseCorrelationLock) {
                     val waiting = pendingCmd.commandNumber < 0L
-                    if (effectiveTimeoutMode == CommandTimeoutMode.FailOpenDrain && waiting) {
-                        staleResponseBlocksToIgnore += 1
+                    if (effectiveTimeoutMode == CommandTimeoutMode.FailOpenDrain) {
+                        abandonPendingResponse(pendingCmd, commandWasWritten = writeCompleted)
+                    } else {
+                        pendingQueue.remove(pendingCmd)
                     }
-                    pendingQueue.remove(pendingCmd)
                     waiting
                 }
                 if (effectiveTimeoutMode == CommandTimeoutMode.FailOpenDrain && waitingForBegin) {
@@ -1548,9 +1552,7 @@ internal class RealTmuxClient(
                     // for it, count that block as stale so the reader discards it
                     // instead of binding it to the next command (FIFO desync).
                     val waitingForBegin = pendingCmd.commandNumber < 0L
-                    if (pendingQueue.remove(pendingCmd) && waitingForBegin) {
-                        staleResponseBlocksToIgnore += 1
-                    }
+                    abandonPendingResponse(pendingCmd, commandWasWritten = writeCompleted)
                 }
                 throw exception
             }
@@ -1560,7 +1562,7 @@ internal class RealTmuxClient(
                 "tmux-command-timeout kind=$kind timeoutMs=$commandTimeoutMs transportProvenAlive=false",
             )
             synchronized(responseCorrelationLock) {
-                pendingQueue.remove(pendingCmd)
+                abandonPendingResponse(pendingCmd, commandWasWritten = writeCompleted)
             }
             closeInternal(
                 ReaderExitIntent.CommandTimeout,
@@ -1840,6 +1842,10 @@ internal class RealTmuxClient(
                         val match = inflight
                         if (ignoredResponseNumber == event.number) {
                             ignoredResponseNumber = -1L
+                        } else if (match?.abandoned == true && match.commandNumber == event.number) {
+                            // The waiter timed out or was cancelled after `%begin`.
+                            // Drain the open block to its close marker, then let the
+                            // next `%begin` bind to the next queued command.
                         } else if (match != null && match.commandNumber == event.number) {
                             match.deferred.complete(
                                 CommandResponse(
@@ -1857,6 +1863,9 @@ internal class RealTmuxClient(
                         val match = inflight
                         if (ignoredResponseNumber == event.number) {
                             ignoredResponseNumber = -1L
+                        } else if (match?.abandoned == true && match.commandNumber == event.number) {
+                            // See the `%end` branch: this closes an abandoned
+                            // response block without poisoning the FIFO.
                         } else if (match != null && match.commandNumber == event.number) {
                             match.deferred.complete(
                                 CommandResponse(
@@ -2353,6 +2362,8 @@ internal class RealTmuxClient(
     ) {
         @Volatile
         var commandNumber: Long = -1L
+        @Volatile
+        var abandoned: Boolean = false
         val output: MutableList<String> = mutableListOf()
     }
 }

--- a/shared/core-tmux/src/test/java/com/pocketshell/core/tmux/TmuxClientTest.kt
+++ b/shared/core-tmux/src/test/java/com/pocketshell/core/tmux/TmuxClientTest.kt
@@ -2342,6 +2342,63 @@ class TmuxClientTest {
     }
 
     @Test
+    fun `best-effort timeout after begin abandons open response before next command`() = runBlocking {
+        val shell = FakeShell()
+        val session = FakeSession(shell)
+        val timeoutGate = DeterministicCommandTimeoutGate()
+        val client = RealTmuxClient(
+            session,
+            scope,
+            commandTimeoutMs = 100L,
+            commandTimeoutGate = timeoutGate,
+        )
+        val command = "capture-pane -p -e -S -200 -t %0"
+        try {
+            client.connect()
+            withTimeout(2_000) {
+                while (shell.stdinBytes().isEmpty()) { yield(); delay(10) }
+            }
+            shell.resetStdin()
+
+            val sent = scope.async { runCatching { client.sendBestEffortCommand(command) } }
+            withTimeout(2_000) {
+                while (shell.stdinAsString() != "$command\n") { yield(); delay(10) }
+            }
+            shell.feed(
+                "%begin 1 20 0\n" +
+                    "stale-open-response\n",
+            )
+
+            timeoutGate.fireNextTimeout()
+            timeoutGate.fireNextTimeout()
+            val outcome = withTimeout(ASYNC_AWAIT_TIMEOUT_MS) { sent.await() }
+            assertTrue("expected best-effort timeout, got ${outcome.getOrNull()}", outcome.isFailure)
+            assertFalse("open-block best-effort timeout must not close shell", shell.closed)
+            assertFalse("open-block best-effort timeout must not disconnect client", client.disconnected.value)
+
+            shell.resetStdin()
+            val next = scope.async { client.sendCommand("list-panes -F ok") }
+            withTimeout(2_000) {
+                while (shell.stdinAsString() != "list-panes -F ok\n") { yield(); delay(10) }
+            }
+            shell.feed(
+                "%end 1 20 0\n" +
+                    "%begin 1 21 0\n" +
+                    "next-ok\n" +
+                    "%end 1 21 0\n",
+            )
+
+            val nextResponse = withTimeout(ASYNC_AWAIT_TIMEOUT_MS) { next.await() }
+            assertEquals(21L, nextResponse.number)
+            assertEquals(listOf("next-ok"), nextResponse.output)
+            assertFalse("follow-up command must not disconnect client", client.disconnected.value)
+            assertFalse("follow-up command must not close shell", shell.closed)
+        } finally {
+            client.close()
+        }
+    }
+
+    @Test
     fun `sendCommand write failure closes client and fails visibly`() = runBlocking {
         val shell = FakeShell()
         val session = FakeSession(shell)

--- a/shared/core-tmux/src/test/java/com/pocketshell/core/tmux/TmuxClientTest.kt
+++ b/shared/core-tmux/src/test/java/com/pocketshell/core/tmux/TmuxClientTest.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
@@ -1818,6 +1819,105 @@ class TmuxClientTest {
             assertEquals(listOf("next-ok"), nextResponse.output)
             assertFalse("follow-up command must not disconnect client", client.disconnected.value)
             assertFalse("follow-up command must not close shell", shell.closed)
+        } finally {
+            client.close()
+        }
+    }
+
+    @Test
+    fun `send-keys timeout after begin drains open block before next command`() = runBlocking {
+        val shell = FakeShell()
+        val session = FakeSession(shell)
+        val timeoutGate = DeterministicCommandTimeoutGate()
+        val client = RealTmuxClient(
+            session,
+            scope,
+            commandTimeoutMs = 100L,
+            commandTimeoutGate = timeoutGate,
+        )
+        try {
+            client.connect()
+            withTimeout(2_000) {
+                while (shell.stdinBytes().isEmpty()) { yield(); delay(10) }
+            }
+            shell.resetStdin()
+
+            val sent = scope.async { runCatching { client.sendCommand("send-keys -t %0 Enter") } }
+            withTimeout(2_000) {
+                while (shell.stdinAsString() != "send-keys -t %0 Enter\n") { yield(); delay(10) }
+            }
+            shell.feed("%begin 1 10 0\n")
+            repeat(10) { yield(); delay(10) }
+
+            timeoutGate.fireNextTimeout()
+            timeoutGate.fireNextTimeout()
+            val timedOut = withTimeout(ASYNC_AWAIT_TIMEOUT_MS) { sent.await() }
+            assertTrue("open response block should time out", timedOut.isFailure)
+            assertFalse("fail-open timeout must not close the shell", shell.closed)
+            assertFalse("fail-open timeout must not disconnect the client", client.disconnected.value)
+
+            shell.resetStdin()
+            val next = scope.async { client.sendCommand("list-panes -F ok") }
+            withTimeout(2_000) {
+                while (shell.stdinAsString() != "list-panes -F ok\n") { yield(); delay(10) }
+            }
+
+            shell.feed(
+                "late-send-keys-output\n" +
+                    "%end 1 10 0\n" +
+                    "%begin 1 11 0\n" +
+                    "next-ok\n" +
+                    "%end 1 11 0\n",
+            )
+
+            val nextResponse = withTimeout(ASYNC_AWAIT_TIMEOUT_MS) { next.await() }
+            assertEquals(
+                "the late close of the abandoned block must not complete the follow-up command",
+                11L,
+                nextResponse.number,
+            )
+            assertEquals(listOf("next-ok"), nextResponse.output)
+        } finally {
+            client.close()
+        }
+    }
+
+    @Test
+    fun `cancelled command after begin drains open block before next command`() = runBlocking {
+        val shell = FakeShell()
+        val session = FakeSession(shell)
+        val client = RealTmuxClient(session, scope)
+        try {
+            client.connect()
+            withTimeout(2_000) {
+                while (shell.stdinBytes().isEmpty()) { yield(); delay(10) }
+            }
+            shell.resetStdin()
+
+            val cancelled = scope.async { client.sendCommand("send-keys -t %0 Enter") }
+            withTimeout(2_000) {
+                while (shell.stdinAsString() != "send-keys -t %0 Enter\n") { yield(); delay(10) }
+            }
+            shell.feed("%begin 1 20 0\n")
+            repeat(10) { yield(); delay(10) }
+            cancelled.cancelAndJoin()
+
+            shell.resetStdin()
+            val next = scope.async { client.sendCommand("list-panes -F ok") }
+            withTimeout(2_000) {
+                while (shell.stdinAsString() != "list-panes -F ok\n") { yield(); delay(10) }
+            }
+
+            shell.feed(
+                "%end 1 20 0\n" +
+                    "%begin 1 21 0\n" +
+                    "next-ok\n" +
+                    "%end 1 21 0\n",
+            )
+
+            val nextResponse = withTimeout(ASYNC_AWAIT_TIMEOUT_MS) { next.await() }
+            assertEquals(21L, nextResponse.number)
+            assertEquals(listOf("next-ok"), nextResponse.output)
         } finally {
             client.close()
         }

--- a/shared/core-tmux/src/test/java/com/pocketshell/core/tmux/TmuxClientTest.kt
+++ b/shared/core-tmux/src/test/java/com/pocketshell/core/tmux/TmuxClientTest.kt
@@ -988,6 +988,65 @@ class TmuxClientTest {
     }
 
     @Test
+    fun `sendCommand bounds the acquire and does not close when the mutex is wedged`() = runBlocking {
+        // Issue #470: bare sendCommand had an unbounded sendMutex acquire while
+        // sendChainedCommands/captureWithCursor were already bounded. A stuck
+        // owner must not park the caller forever, and because this caller has
+        // not written anything yet, the acquire timeout must not close a healthy
+        // shell.
+        val shell = FakeShell()
+        val session = FakeSession(shell)
+        val timeoutGate = DeterministicCommandTimeoutGate()
+        val client = RealTmuxClient(
+            session,
+            scope,
+            commandTimeoutMs = 200L,
+            commandTimeoutGate = timeoutGate,
+        )
+        try {
+            client.connect()
+            withTimeout(2_000) {
+                while (shell.stdinBytes().isEmpty()) { yield(); delay(10) }
+            }
+            shell.resetStdin()
+
+            val holder = scope.async { runCatching { client.sendCommand("send-keys -t %0 Enter") } }
+            withTimeout(2_000) {
+                while (shell.stdinAsString() != "send-keys -t %0 Enter\n") { yield(); delay(10) }
+            }
+
+            val outcome = withTimeout(ASYNC_AWAIT_TIMEOUT_MS) {
+                runCatching { client.sendCommand("list-sessions") }
+            }
+
+            assertTrue("expected acquire timeout failure, got ${outcome.getOrNull()}", outcome.isFailure)
+            val ex = outcome.exceptionOrNull()!!
+            assertTrue("expected TmuxClientException, got ${ex.javaClass.name}", ex is TmuxClientException)
+            assertTrue(
+                "timeout message must identify the command kind and acquire failure",
+                ex.message?.contains("tmux command `list-sessions` acquire wedged") == true,
+            )
+            assertEquals(
+                "acquire timeout must not write the blocked command",
+                "send-keys -t %0 Enter\n",
+                shell.stdinAsString(),
+            )
+            assertFalse("acquire timeout must not close the shell", shell.closed)
+            assertFalse("acquire timeout must not trip disconnected latch", client.disconnected.value)
+
+            // Release the original holder so the test tears down without a
+            // parked coroutine. send-keys is fail-open, so fire the primary
+            // timeout and the late-drain timeout.
+            timeoutGate.fireNextTimeout()
+            timeoutGate.fireNextTimeout()
+            withTimeout(ASYNC_AWAIT_TIMEOUT_MS) { holder.await() }
+            Unit
+        } finally {
+            client.close()
+        }
+    }
+
+    @Test
     fun `setWindowSizeLatest sends window option command and shell-quotes target`() = runBlocking {
         val shell = FakeShell()
         val session = FakeSession(shell)

--- a/shared/core-tmux/src/test/java/com/pocketshell/core/tmux/TmuxClientTest.kt
+++ b/shared/core-tmux/src/test/java/com/pocketshell/core/tmux/TmuxClientTest.kt
@@ -1174,9 +1174,8 @@ class TmuxClientTest {
             assertFalse("acquire timeout must not trip disconnected latch", client.disconnected.value)
 
             // Release the original holder so the test tears down without a
-            // parked coroutine. send-keys is fail-open, so fire the primary
-            // timeout and the late-drain timeout.
-            timeoutGate.fireNextTimeout()
+            // parked coroutine. send-keys is fail-open; the late drain is now
+            // a strict wall-clock quarantine bounded by commandTimeoutMs here.
             timeoutGate.fireNextTimeout()
             withTimeout(ASYNC_AWAIT_TIMEOUT_MS) { holder.await() }
             Unit
@@ -1243,7 +1242,6 @@ class TmuxClientTest {
                     yield(); delay(10)
                 }
             }
-            timeoutGate.fireNextTimeout()
             timeoutGate.fireNextTimeout()
             val outcome = withTimeout(ASYNC_AWAIT_TIMEOUT_MS) { sent.await() }
 
@@ -1361,7 +1359,6 @@ class TmuxClientTest {
             withTimeout(2_000) {
                 while (shell.stdinAsString() != "refresh-client -C 62x52\n") { yield(); delay(10) }
             }
-            timeoutGate.fireNextTimeout()
             timeoutGate.fireNextTimeout()
             val outcome = withTimeout(ASYNC_AWAIT_TIMEOUT_MS) { sent.await() }
 
@@ -1768,9 +1765,8 @@ class TmuxClientTest {
             withTimeout(2_000) {
                 while (shell.stdinAsString() != "send-keys -t %0 Enter\n") { yield(); delay(10) }
             }
-            // Primary response timeout, then the fail-open late-drain timeout
-            // (no late response is fed, so the quarantine expires).
-            timeoutGate.fireNextTimeout()
+            // Primary response timeout. No late response is fed, so the strict
+            // wall-clock quarantine expires.
             timeoutGate.fireNextTimeout()
             val outcome = withTimeout(ASYNC_AWAIT_TIMEOUT_MS) { sent.await() }
 
@@ -1849,7 +1845,6 @@ class TmuxClientTest {
             shell.feed("%begin 1 10 0\n")
             repeat(10) { yield(); delay(10) }
 
-            timeoutGate.fireNextTimeout()
             timeoutGate.fireNextTimeout()
             val timedOut = withTimeout(ASYNC_AWAIT_TIMEOUT_MS) { sent.await() }
             assertTrue("open response block should time out", timedOut.isFailure)
@@ -1957,8 +1952,8 @@ class TmuxClientTest {
             withTimeout(2_000) {
                 while (shell.stdinAsString() != "capture-pane -p\n") { yield(); delay(10) }
             }
-            // Primary response timeout, then the fail-open late-drain timeout.
-            timeoutGate.fireNextTimeout()
+            // Primary response timeout; the late drain is a strict wall-clock
+            // quarantine now.
             timeoutGate.fireNextTimeout()
             val outcome = withTimeout(ASYNC_AWAIT_TIMEOUT_MS) { sent.await() }
 
@@ -2276,7 +2271,7 @@ class TmuxClientTest {
     }
 
     @Test
-    fun `best-effort command timeout without late response does not disconnect or mis-correlate next command`() = runBlocking {
+    fun `best-effort command timeout quarantines late stale response before next command`() = runBlocking {
         val shell = FakeShell()
         val session = FakeSession(shell)
         // Issue #676: deterministic timeout gate (best-effort: primary + late-drain).
@@ -2299,9 +2294,9 @@ class TmuxClientTest {
             withTimeout(2_000) {
                 while (shell.stdinAsString() != "$command\n") { yield(); delay(10) }
             }
-            // No late response is fed, so both the primary timeout and the
-            // best-effort late-drain quarantine expire deterministically.
-            timeoutGate.fireNextTimeout()
+            // No response lands inside the strict late-drain window, so the
+            // command times out and reserves the still-owed response block as
+            // stale before the next command can use the FIFO.
             timeoutGate.fireNextTimeout()
             val outcome = withTimeout(ASYNC_AWAIT_TIMEOUT_MS) { sent.await() }
 
@@ -2327,6 +2322,9 @@ class TmuxClientTest {
                 while (shell.stdinAsString() != "list-panes -F ok\n") { yield(); delay(10) }
             }
             shell.feed(
+                "%begin 1 9 0\n" +
+                    "late-capture\n" +
+                    "%end 1 9 0\n" +
                 "%begin 1 10 0\n" +
                     "next-ok\n" +
                     "%end 1 10 0\n",
@@ -2369,7 +2367,6 @@ class TmuxClientTest {
                     "stale-open-response\n",
             )
 
-            timeoutGate.fireNextTimeout()
             timeoutGate.fireNextTimeout()
             val outcome = withTimeout(ASYNC_AWAIT_TIMEOUT_MS) { sent.await() }
             assertTrue("expected best-effort timeout, got ${outcome.getOrNull()}", outcome.isFailure)
@@ -2801,8 +2798,9 @@ class TmuxClientTest {
             }
 
             val collected = scope.async {
-                // 2 outputs + Begin + End
-                client.events.take(4).toList()
+                // Response framing markers stay internal; output notifications
+                // still flow around the response block.
+                client.events.take(2).toList()
             }
             delay(100)
 
@@ -2822,11 +2820,9 @@ class TmuxClientTest {
             val r = withTimeout(ASYNC_AWAIT_TIMEOUT_MS) { response.await() }
             assertEquals(listOf("row"), r.output)
             val events = withTimeout(ASYNC_AWAIT_TIMEOUT_MS) { collected.await() }
-            assertEquals(4, events.size)
+            assertEquals(2, events.size)
             assertTrue(events[0] is ControlEvent.Output)
-            assertTrue(events[1] is ControlEvent.Begin)
-            assertTrue(events[2] is ControlEvent.End)
-            assertTrue(events[3] is ControlEvent.Output)
+            assertTrue(events[1] is ControlEvent.Output)
         } finally {
             client.close()
         }

--- a/shared/core-tmux/src/test/java/com/pocketshell/core/tmux/TmuxClientTest.kt
+++ b/shared/core-tmux/src/test/java/com/pocketshell/core/tmux/TmuxClientTest.kt
@@ -840,6 +840,73 @@ class TmuxClientTest {
         }
 
     @Test
+    fun `captureWithCursor timeout before begin quarantines all late batch blocks`() = runBlocking {
+        // A combined capture writes TWO tmux commands in one line. If the line
+        // has reached tmux but neither reply block has begun before the timeout,
+        // both late blocks must be reserved as stale; otherwise the first late
+        // capture block can bind to the next unrelated command.
+        val shell = FakeShell()
+        val session = FakeSession(shell)
+        val timeoutGate = DeterministicCommandTimeoutGate()
+        val client = RealTmuxClient(
+            session,
+            scope,
+            commandTimeoutMs = 100L,
+            commandTimeoutGate = timeoutGate,
+        )
+        try {
+            client.connect()
+            withTimeout(2_000) {
+                while (shell.stdinBytes().isEmpty()) { yield(); delay(10) }
+            }
+            shell.resetStdin()
+
+            val timedOut = scope.async {
+                runCatching { client.captureWithCursor("%3", scrollbackLines = 200) }
+            }
+            withTimeout(2_000) {
+                while (!shell.stdinAsString().contains("capture-pane")) { yield(); delay(10) }
+            }
+            timeoutGate.fireNextTimeout()
+            assertTrue(
+                "combined capture must time out before any reply block begins",
+                withTimeout(ASYNC_AWAIT_TIMEOUT_MS) { timedOut.await() }.isFailure,
+            )
+            shell.resetStdin()
+
+            val next = scope.async { client.sendCommand("list-sessions") }
+            withTimeout(2_000) {
+                while (shell.stdinAsString() != "list-sessions\n") { yield(); delay(10) }
+            }
+
+            shell.feed(
+                "%begin 1700000000 10 0\n" +
+                    "late-capture\n" +
+                    "%end 1700000000 10 0\n" +
+                    "%begin 1700000000 11 0\n" +
+                    "9,4\n" +
+                    "%end 1700000000 11 0\n",
+            )
+            repeat(10) { yield(); delay(10) }
+            shell.feed(
+                "%begin 1700000000 12 0\n" +
+                    "next-session\n" +
+                    "%end 1700000000 12 0\n",
+            )
+
+            val response = withTimeout(ASYNC_AWAIT_TIMEOUT_MS) { next.await() }
+            assertEquals(
+                "late combined-capture blocks must not bind to the next command",
+                12L,
+                response.number,
+            )
+            assertEquals(listOf("next-session"), response.output)
+        } finally {
+            client.close()
+        }
+    }
+
+    @Test
     fun `sendChainedCommands writes one chained line and drains both blocks in order`() = runBlocking {
         // Issue #692: the folder-list discovery probe fetches list-sessions +
         // list-panes in ONE control-mode round-trip. tmux -CC answers a
@@ -923,6 +990,77 @@ class TmuxClientTest {
             assertFalse(responses[0].isError)
             assertEquals(listOf("sess-a"), responses[0].output)
             assertTrue("trailing block must degrade to an error response", responses[1].isError)
+        } finally {
+            client.close()
+        }
+    }
+
+    @Test
+    fun `sendChainedCommands timeout before begin quarantines all late batch blocks`() = runBlocking {
+        // The first-block timeout fires after the chained line is written but
+        // before tmux emits any %begin. Every command in that written batch is
+        // still owed a response block, so every pending entry must reserve a
+        // stale block before the next command is allowed onto the FIFO.
+        val shell = FakeShell()
+        val session = FakeSession(shell)
+        val timeoutGate = DeterministicCommandTimeoutGate()
+        val client = RealTmuxClient(
+            session,
+            scope,
+            commandTimeoutMs = 100L,
+            commandTimeoutGate = timeoutGate,
+        )
+        try {
+            client.connect()
+            withTimeout(2_000) {
+                while (shell.stdinBytes().isEmpty()) { yield(); delay(10) }
+            }
+            shell.resetStdin()
+
+            val timedOut = scope.async {
+                runCatching { client.sendChainedCommands(listOf("list-sessions", "list-panes -a")) }
+            }
+            withTimeout(2_000) {
+                while (shell.stdinAsString() != "list-sessions ; list-panes -a\n") {
+                    yield(); delay(10)
+                }
+            }
+            timeoutGate.fireNextTimeout()
+            assertTrue(
+                "chained command must time out before any reply block begins",
+                withTimeout(ASYNC_AWAIT_TIMEOUT_MS) { timedOut.await() }.isFailure,
+            )
+            shell.resetStdin()
+
+            val next = scope.async { client.sendCommand("display-message -p ok") }
+            withTimeout(2_000) {
+                while (shell.stdinAsString() != "display-message -p ok\n") {
+                    yield(); delay(10)
+                }
+            }
+
+            shell.feed(
+                "%begin 1700000000 20 0\n" +
+                    "late-sessions\n" +
+                    "%end 1700000000 20 0\n" +
+                    "%begin 1700000000 21 0\n" +
+                    "late-panes\n" +
+                    "%end 1700000000 21 0\n",
+            )
+            repeat(10) { yield(); delay(10) }
+            shell.feed(
+                "%begin 1700000000 22 0\n" +
+                    "ok\n" +
+                    "%end 1700000000 22 0\n",
+            )
+
+            val response = withTimeout(ASYNC_AWAIT_TIMEOUT_MS) { next.await() }
+            assertEquals(
+                "late chained-command blocks must not bind to the next command",
+                22L,
+                response.number,
+            )
+            assertEquals(listOf("ok"), response.output)
         } finally {
             client.close()
         }


### PR DESCRIPTION
## What

Connection-manager stability hardening across the SSH transport, tmux control
client, lease manager, and app-side session/upload paths — the D28 critical
subsystem. Rebased onto current `main`.

### SSH lifecycle (`core-ssh`)
- `SshLeaseManager` closes successful-but-unregistered sessions on late
  cancellation/failure after `boundedConnect`.
- `RealSshSession.close()` raw-disconnect fallback is wall-clock bounded.
- Keepalive single-flight marker cleanup survives cancellation.
- Exec drain permits acquired before opening the remote exec channel (local
  drain saturation no longer misclassified as a transport read timeout).

### tmux lifecycle (`core-tmux` + app)
- Writer-owned write-completion tracking; wall-clock-bounded late-response drain;
  timeout cleanup via stale-response accounting; nonblocking public event fanout.
- `TmuxSessionViewModel` requeues pane input on client swap/teardown; suspended
  teardown stops the layout coalescer; planned-detach unpoints before detach.
- Input gating uses raw `connectionStatus` (debounced status is display-only).

### App helpers
- `LeaseSessionExec` stale/timeout side-borrow evicts idle instead of
  disconnecting a shared active lease.
- `StartDirectoryAutocomplete` finite request timeout + bounded listing
  (and `exit 0` so a sub-limit match count never drops all suggestions).
- `FolderListViewModel` warm-lease release routes through the injectable
  `ioDispatcher` (production still wires `Dispatchers.IO`).

### Process/scripts
- AVD locks on legacy emulator harnesses; `cgroup-run` for raw local Gradle;
  scoped emulator background starts; `build.yml` concurrency + job timeout.

## Validation

- **Unit:** full `:app:testDebugUnitTest` 3104, `:shared:core-ssh` 199,
  `:shared:core-tmux` 158 — 0 failures / 0 skipped.
- **Real-path journeys** (the three that are RED on `main` right now —
  failing both cold-boot attempts): all proven GREEN on the branch —
  `ServerDeathReconnectNoResurrect` (full CI journey run 28295160655),
  `SessionForegroundServiceLiveHold` and `BackgroundGraceReconnect` (targeted
  cgroup'd emulator runs, 3/3 methods green).

## Known limitations (pre-existing, NOT introduced here)

- The **#470/#835 tmux `list-sessions` enumeration stall** still exhausts the
  journey suite's 1200s budget (it does on `main` too; classified advisory).
  Tracked as a separate follow-up.
- A transient combined-run flake observed in the `#959` post-grace reattach
  journey (re-ran isolated + full suite, all green — not a regression).
  Candidate de-flake follow-up.

The emulator journey job is skipped on PRs (`if: != pull_request`); it ran via
manual dispatch on the branch and is batched on `main` after merge.