### PR TITLE
Mobile: ride through brief cellular network blips instead of redialing

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/BareNetworkLossRestoreReconnectE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/BareNetworkLossRestoreReconnectE2eTest.kt
@@ -87,6 +87,18 @@ import java.io.File
  * no `network_restore_reconnect_start` → the load-bearing assertions FAIL (RED).
  * With the fix the loss surfaces, the lease is held, and the restore drives a fast
  * reconnect (GREEN).
+ *
+ * ISSUE #1042 (cause #1) — the GENUINELY-DEAD-SOCKET preservation guard. #1042 makes
+ * the restore arm LIVENESS-FIRST: it rides through with NO redial when the existing
+ * transport survived the dip. That MUST NOT regress the #997 contract — a genuinely
+ * dead post-outage socket still has to reconnect. So this journey now SYNTHETICALLY
+ * injects a dead transport across the restore (the #780 model — hard inject, no
+ * self-skip): it pins the transport keepalive NOT-proven-alive AND the bounded
+ * restore probe DEAD, so the liveness-first gate fails and the #997 fresh-lease
+ * redial fires — `network_restore_reconnect_start` is still recorded. This is the
+ * guard the brief names ("Do not weaken BareNetworkLossRestoreReconnectE2eTest:
+ * socket-IS-dead ⇒ reconnects"). The companion ride-through (socket SURVIVED ⇒ NO
+ * redial) journey is [MobileSpuriousReconnectE2eTest].
  */
 @RunWith(AndroidJUnit4::class)
 class BareNetworkLossRestoreReconnectE2eTest {
@@ -194,10 +206,23 @@ class BareNetworkLossRestoreReconnectE2eTest {
 
         diagnostics!!.clear()
 
+        // ISSUE #1042: synthetically inject a GENUINELY-DEAD transport across the
+        // restore (the #780 hard-inject model, no self-skip) so the #1042
+        // liveness-first gate must FALL THROUGH to the #997 fresh-lease redial:
+        //   - keepalive NOT proven alive (the link did not survive the dip), and
+        //   - the bounded restore probe reports DEAD.
+        // Without this the live agents:2222 socket would (correctly, per #1042) ride
+        // through with no redial — which is the OTHER journey. Here we are proving the
+        // dead-socket case still reconnects (the #997 contract).
+        val vm = currentViewModel()
+        vm.forceTransportProvenAliveForTest = false
+        vm.forceLivenessProbeDeadForTest = true
+
         // THE RESTORE: validation returns to the SAME pure-WIFI identity — the
         // airplane-mode round-trip the pre-#997 detector swallowed at `:333`. On
-        // BASE this emits NOTHING. With #997 it emits a NetworkRestored and drives a
-        // FAST reconnect even though the session is in the loss-suspended state.
+        // BASE this emits NOTHING. With #997 it emits a NetworkRestored and (with the
+        // dead transport injected above) drives a FAST fresh-lease reconnect even
+        // though the session is in the loss-suspended state.
         val restoreStart = SystemClock.elapsedRealtime()
         val restored = observer.emitSyntheticSnapshotForTest(
             TerminalNetworkSnapshot.Validated(networkHandle = "wifi-A", transports = setOf("WIFI")),
@@ -232,6 +257,11 @@ class BareNetworkLossRestoreReconnectE2eTest {
                 "events=${diagnostics!!.events.map { it.name }}",
             diagnostics!!.eventsNamed("network_restore_reconnect_start").isNotEmpty(),
         )
+
+        // ISSUE #1042: the redial decision has fired; release the synthetic dead-probe
+        // seam so the freshly-redialled (real, healthy) transport is not immediately
+        // re-declared dead by the periodic liveness probe loop.
+        vm.forceLivenessProbeDeadForTest = false
 
         // LOAD-BEARING #5: the session settles back to a steady Connected state with
         // a painted viewport — the user is recovered, not left in a dead session.

--- a/app/src/androidTest/java/com/pocketshell/app/proof/MobileSpuriousReconnectE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/MobileSpuriousReconnectE2eTest.kt
@@ -43,9 +43,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.rules.RuleChain
-import org.junit.rules.TestRule
 import org.junit.runner.RunWith
-import org.junit.runners.model.Statement
 import java.io.File
 
 /**
@@ -85,13 +83,17 @@ import java.io.File
 @RunWith(AndroidJUnit4::class)
 class MobileSpuriousReconnectE2eTest {
 
+    // Issue #788/#848: createAndroidComposeRule<MainActivity>() + the shared
+    // SeedBeforeLaunchRule own the harness — the durable launch-owned shape the
+    // CI journey-harness guard pins. The compose rule launches MainActivity in its
+    // `before()`, so the remote tmux session + DB host row are seeded BEFORE launch
+    // by the chain (outer `before()` first): grant perms -> seed -> launch.
     val compose = createAndroidComposeRule<MainActivity>()
-    private val grantPermissions = PreGrantPermissionsRule()
 
     @get:org.junit.Rule
     val ruleChain: RuleChain = RuleChain
-        .outerRule(grantPermissions)
-        .around(seedFixtureRule())
+        .outerRule(PreGrantPermissionsRule())
+        .around(SeedBeforeLaunchRule { seedBeforeLaunch() })
         .around(compose)
 
     private var diagnostics: RecordingDiagnosticSink? = null
@@ -99,24 +101,29 @@ class MobileSpuriousReconnectE2eTest {
     private var seededHostRowTag: String? = null
     private val timings = mutableListOf<String>()
 
-    private fun seedFixtureRule(): TestRule = TestRule { base, _ ->
-        object : Statement() {
-            override fun evaluate() {
-                runBlocking {
-                    val key = readFixtureKey()
-                    seededKey = key
-                    waitForSshFixtureReady(SshKey.Pem(key))
-                    seedTmuxSession(key)
-                    seededHostRowTag = seedDockerHost(key)
-                }
-                base.evaluate()
-            }
-        }
+    /**
+     * Issue #788: all LAUNCH-time state established BEFORE MainActivity launches
+     * (run by [SeedBeforeLaunchRule], which evaluates before the compose rule's
+     * `before()`): clear the last-session pref so the app reads a clean baseline on
+     * its first composition (read at launch — clearing it in @Before, post-launch,
+     * would be too late), then seed the remote tmux session + DB host row.
+     */
+    private suspend fun seedBeforeLaunch() {
+        clearLastSessionPrefs()
+        val key = readFixtureKey()
+        seededKey = key
+        waitForSshFixtureReady(SshKey.Pem(key))
+        seedTmuxSession(key)
+        seededHostRowTag = seedDockerHost(key)
     }
 
     @Before
     fun setUp() {
-        clearLastSessionPrefs()
+        // The diagnostics sink is installed in @Before (which runs AFTER MainActivity
+        // launches under createAndroidComposeRule). Fine — the events the assertions
+        // read are emitted during the network drive the body runs later, and each
+        // method clears the sink before its load-bearing drive. The launch-time pref
+        // clear moved into [seedBeforeLaunch] so it precedes the rule's launch.
         diagnostics = RecordingDiagnosticSink().also { DiagnosticEvents.install(it) }
     }
 

--- a/app/src/androidTest/java/com/pocketshell/app/proof/MobileSpuriousReconnectE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/MobileSpuriousReconnectE2eTest.kt
@@ -1,0 +1,687 @@
+package com.pocketshell.app.proof
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.os.SystemClock
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.ViewModelProvider
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.connectivity.TerminalNetworkChange
+import com.pocketshell.app.connectivity.TerminalNetworkChangeKind
+import com.pocketshell.app.connectivity.TerminalNetworkObserver
+import com.pocketshell.app.connectivity.TerminalNetworkSnapshot
+import com.pocketshell.app.diagnostics.DiagnosticEvents
+import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
+import com.pocketshell.app.hosts.SshKeyStorage
+import com.pocketshell.app.MainActivity
+import com.pocketshell.app.testaccess.TestAccessEntryPoint
+import com.pocketshell.app.tmux.TMUX_SESSION_SCREEN_TAG
+import com.pocketshell.app.tmux.TMUX_SWITCHING_LOADING_TAG
+import com.pocketshell.app.tmux.TmuxSessionViewModel
+import com.pocketshell.core.ssh.KnownHostsPolicy
+import com.pocketshell.core.ssh.SshConnection
+import com.pocketshell.core.ssh.SshKey
+import com.pocketshell.core.storage.AppDatabase
+import com.pocketshell.core.storage.entity.HostEntity
+import com.termux.view.TerminalView
+import dagger.hilt.android.EntryPointAccessors
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.rules.TestRule
+import org.junit.runner.RunWith
+import org.junit.runners.model.Statement
+import java.io.File
+
+/**
+ * ISSUE #1042 — stop SPURIOUS reconnects on mobile/cellular when the link/socket
+ * ACTUALLY SURVIVED the dip. This is the companion to
+ * [BareNetworkLossRestoreReconnectE2eTest] (which guards the GENUINELY-DEAD case —
+ * the socket really died ⇒ still reconnects, preserving #997). Here every case
+ * proves that a survivable network event does NOT churn the connection.
+ *
+ * All three journeys drive the real `MainActivity` → attach → `-CC` path against the
+ * deterministic `agents:2222` fixture (no toxiproxy, no workflow change), inject the
+ * device network event SYNTHETICALLY through the PRODUCTION [TerminalNetworkObserver]
+ * detector + emit pipeline (the AVD can't mint a new `networkHandle` / enter airplane
+ * mode on demand without killing the test ADB link — the #780 hard-inject model, NO
+ * self-skip), and assert from the connection diagnostics (the `ReconnectCauseTrail`
+ * siblings recorded by the VM), not a passing assertion alone:
+ *
+ *  (a) [briefLossRestoreWithSurvivingSocketRidesThroughWithNoRedial] — cause #1.
+ *      A brief `NetworkLost`→`NetworkRestored` where the existing transport SURVIVED
+ *      (proven alive). The pre-#1042 restore arm redialled UNCONDITIONALLY, so on
+ *      BASE `network_restore_reconnect_start` fires (RED). With #1042 the restore is
+ *      liveness-first → it rides through with NO redial → ZERO
+ *      reconnect_start/network_reconnect_start/network_restore_reconnect_start, and a
+ *      `network_restore_ride_through` is recorded (GREEN).
+ *
+ *  (c) [cellularSameIdentityReassocDoesNotRedial] — cause #2. A `{CELLULAR}`→
+ *      `{CELLULAR}` re-association that mints a NEW `networkHandle` on the same single
+ *      cellular transport (a RAT/band re-validation, or a v4↔v6 dual-stack flip). On
+ *      BASE the same-identity relaxation was pure-`{WIFI}`-only, so this was treated
+ *      as a real handoff → `network_reconnect_start` (RED). With #1042 the detector
+ *      suppresses it (the emit returns null) → no event → no redial (GREEN).
+ *
+ *  (d) [crossTransportHandoffStillRedials] — the scope guard for cause #2. A REAL
+ *      cross-transport WIFI↔CELLULAR handoff still flips identity and redials
+ *      (`network_reconnect_start`), so the #548 proactive-handoff feature is preserved.
+ */
+@RunWith(AndroidJUnit4::class)
+class MobileSpuriousReconnectE2eTest {
+
+    val compose = createAndroidComposeRule<MainActivity>()
+    private val grantPermissions = PreGrantPermissionsRule()
+
+    @get:org.junit.Rule
+    val ruleChain: RuleChain = RuleChain
+        .outerRule(grantPermissions)
+        .around(seedFixtureRule())
+        .around(compose)
+
+    private var diagnostics: RecordingDiagnosticSink? = null
+    private var seededKey: String? = null
+    private var seededHostRowTag: String? = null
+    private val timings = mutableListOf<String>()
+
+    private fun seedFixtureRule(): TestRule = TestRule { base, _ ->
+        object : Statement() {
+            override fun evaluate() {
+                runBlocking {
+                    val key = readFixtureKey()
+                    seededKey = key
+                    waitForSshFixtureReady(SshKey.Pem(key))
+                    seedTmuxSession(key)
+                    seededHostRowTag = seedDockerHost(key)
+                }
+                base.evaluate()
+            }
+        }
+    }
+
+    @Before
+    fun setUp() {
+        clearLastSessionPrefs()
+        diagnostics = RecordingDiagnosticSink().also { DiagnosticEvents.install(it) }
+    }
+
+    @After
+    fun tearDown() {
+        runCatching {
+            compose.activityRule.scenario.onActivity { activity ->
+                val vm = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+                vm.forceTransportProvenAliveForTest = null
+                vm.forceLivenessProbeDeadForTest = false
+            }
+        }
+        runCatching {
+            compose.activityRule.scenario.moveToState(Lifecycle.State.RESUMED)
+        }
+        diagnostics?.close()
+        diagnostics = null
+        clearLastSessionPrefs()
+        seededKey?.let { key ->
+            runCatching { runBlocking { cleanupRemoteTmuxSession(key) } }
+        }
+    }
+
+    // (a) cause #1 — the link SURVIVED the brief dip: ride through, NO redial.
+    @Test
+    fun briefLossRestoreWithSurvivingSocketRidesThroughWithNoRedial() = runBlocking<Unit> {
+        val hostRowTag = requireNotNull(seededHostRowTag)
+        attachSeededTmuxSession(hostRowTag)
+        waitForVisibleTerminal("initial attach") { it.contains(READY_MARKER) }
+        waitForConnected("initial attach")
+        waitForNoSwitchingOverlay("pre-loss attach settle")
+        captureViewport("issue1042a-01-attached")
+
+        val vm = currentViewModel()
+        // The existing transport SURVIVED the dip — pin the keepalive proven-alive so
+        // the #1042 liveness-first restore rides through deterministically (the AVD
+        // cannot reproduce the 90s real ride-through window in-test).
+        vm.forceTransportProvenAliveForTest = true
+        diagnostics!!.clear()
+
+        // THE BRIEF DIP: drive the REAL VM network hook directly with a bare loss then
+        // a same-identity restore. We bypass the App-level background/post-resume
+        // suppression gate ON PURPOSE — it is orthogonal to #1042 (its background
+        // suppression is exercised by the full-pipeline cellular/handoff cases below),
+        // and driving the production [TmuxSessionViewModel.onNetworkChanged] entry
+        // (exactly what the App gate calls) deterministically exercises the real
+        // reducer → ride-through → controller → setConnectionState path that #1042
+        // changes, against the LIVE connected `-CC` Docker session.
+        val baseline = TerminalNetworkSnapshot.Validated(networkHandle = "wifi-A", transports = setOf("WIFI"))
+        val loss = TerminalNetworkChange(
+            previous = baseline,
+            current = TerminalNetworkSnapshot.NoValidatedNetwork,
+            previousValidated = baseline,
+            reason = "issue1042a-brief-loss",
+            sequence = 1L,
+            kind = TerminalNetworkChangeKind.NetworkLost,
+        )
+        val restore = TerminalNetworkChange(
+            previous = TerminalNetworkSnapshot.NoValidatedNetwork,
+            current = baseline,
+            previousValidated = baseline,
+            reason = "issue1042a-restore",
+            sequence = 2L,
+            kind = TerminalNetworkChangeKind.NetworkRestored,
+        )
+        compose.activityRule.scenario.onActivity {
+            vm.onNetworkChanged(loss)
+            vm.onNetworkChanged(restore)
+        }
+
+        // LOAD-BEARING (RED on base, GREEN with #1042): the surviving transport rides
+        // through — ZERO redial diagnostics across the WHOLE brief-dip window (loss +
+        // restore; diagnostics were NOT cleared between them, so this also proves the
+        // loss held with no churn). On BASE the restore arm redials unconditionally →
+        // network_restore_reconnect_start fires → this watch FAILS.
+        watchNoRedialDiagnostics("across the survivable brief dip", WATCH_NO_REDIAL_AFTER_RESTORE_MS)
+        assertTrue(
+            "expected a network_loss_hold (proves the loss arm fired, not a vacuous pass); " +
+                "events=${diagnostics!!.events.map { it.name }}",
+            diagnostics!!.eventsNamed("network_loss_hold").isNotEmpty(),
+        )
+        val rideThrough = diagnostics!!.eventsNamed("network_restore_ride_through")
+        assertTrue(
+            "expected a network_restore_ride_through (proves the ride-through arm fired, " +
+                "not a vacuous pass); events=${diagnostics!!.events.map { it.name }}",
+            rideThrough.isNotEmpty(),
+        )
+        assertEquals(
+            "arm 1: the ride-through is attributed to the proven-alive keepalive",
+            "transport_proven_alive",
+            rideThrough.first().fields["cause"],
+        )
+
+        // The session never left Connected — no Attaching overlay, viewport still painted.
+        waitForConnected("after ride-through")
+        waitForNoSwitchingOverlay("after ride-through settle")
+        waitForVisibleTerminal("after ride-through terminal") { it.contains(READY_MARKER) }
+        captureViewport("issue1042a-02-rode-through")
+        writeTimings("issue1042a")
+    }
+
+    // (b2) cause #1 ARM 2 — keepalive aged out but the bounded probe ANSWERS over the
+    // live socket: must RIDE THROUGH with no redial (cause="probe_answered").
+    @Test
+    fun briefLossRestoreWhereBoundedProbeAnswersRidesThrough() = runBlocking<Unit> {
+        val hostRowTag = requireNotNull(seededHostRowTag)
+        attachSeededTmuxSession(hostRowTag)
+        waitForVisibleTerminal("initial attach") { it.contains(READY_MARKER) }
+        waitForConnected("initial attach")
+        waitForNoSwitchingOverlay("pre-loss attach settle")
+        captureViewport("issue1042b2-01-attached")
+
+        val vm = currentViewModel()
+        // Keepalive NOT proven alive (force the fast gate to MISS) but the bounded probe
+        // is LIVE (probe-dead seam off) — the quiet/idle-cellular socket-survived case.
+        // runLivenessProbePing() answers over the REAL connected `-CC` Docker session.
+        vm.forceTransportProvenAliveForTest = false
+        vm.forceLivenessProbeDeadForTest = false
+        diagnostics!!.clear()
+
+        val baseline = TerminalNetworkSnapshot.Validated(networkHandle = "wifi-A", transports = setOf("WIFI"))
+        val loss = TerminalNetworkChange(
+            previous = baseline,
+            current = TerminalNetworkSnapshot.NoValidatedNetwork,
+            previousValidated = baseline,
+            reason = "issue1042b2-brief-loss",
+            sequence = 1L,
+            kind = TerminalNetworkChangeKind.NetworkLost,
+        )
+        val restore = TerminalNetworkChange(
+            previous = TerminalNetworkSnapshot.NoValidatedNetwork,
+            current = baseline,
+            previousValidated = baseline,
+            reason = "issue1042b2-restore",
+            sequence = 2L,
+            kind = TerminalNetworkChangeKind.NetworkRestored,
+        )
+        compose.activityRule.scenario.onActivity {
+            vm.onNetworkChanged(loss)
+            vm.onNetworkChanged(restore)
+        }
+
+        // The bounded probe runs async over the live channel — wait for the ride-through
+        // attribution, then assert ZERO redials across the window.
+        compose.waitUntil(timeoutMillis = RESTORE_RECONNECT_TIMEOUT_MS) {
+            diagnostics!!.eventsNamed("network_restore_ride_through").isNotEmpty()
+        }
+        watchNoRedialDiagnostics("across the probe-answered survivable dip", WATCH_NO_REDIAL_AFTER_RESTORE_MS)
+        val rideThrough = diagnostics!!.eventsNamed("network_restore_ride_through")
+        assertTrue(
+            "expected a network_restore_ride_through (proves arm 2 fired, not a vacuous " +
+                "pass); events=${diagnostics!!.events.map { it.name }}",
+            rideThrough.isNotEmpty(),
+        )
+        assertEquals(
+            "arm 2: the ride-through must be attributed to the bounded probe answering",
+            "probe_answered",
+            rideThrough.last().fields["cause"],
+        )
+
+        waitForConnected("after probe-answered ride-through")
+        waitForNoSwitchingOverlay("after probe-answered ride-through settle")
+        waitForVisibleTerminal("after probe-answered terminal") { it.contains(READY_MARKER) }
+        captureViewport("issue1042b2-02-rode-through")
+        writeTimings("issue1042b2")
+    }
+
+    // (c) cause #2 — a same-identity {CELLULAR} reassoc must NOT redial.
+    @Test
+    fun cellularSameIdentityReassocDoesNotRedial() = runBlocking<Unit> {
+        val hostRowTag = requireNotNull(seededHostRowTag)
+        attachSeededTmuxSession(hostRowTag)
+        waitForVisibleTerminal("initial attach") { it.contains(READY_MARKER) }
+        waitForConnected("initial attach")
+        waitForNoSwitchingOverlay("pre-reassoc attach settle")
+        captureViewport("issue1042c-01-attached")
+
+        val observer = terminalNetworkObserver()
+        val vm = currentViewModel()
+
+        // Seed the baseline cellular identity with the keepalive pinned proven-alive so
+        // the baseline transition (real-network → synthetic cellular) is suppressed and
+        // never tears the session before the load-bearing reassoc.
+        vm.forceTransportProvenAliveForTest = true
+        observer.emitSyntheticSnapshotForTest(
+            TerminalNetworkSnapshot.Validated(networkHandle = "cell-A", transports = setOf("CELLULAR")),
+            reason = "issue1042c-baseline-cell",
+        )
+        waitForConnected("post-baseline cell")
+        waitForNoSwitchingOverlay("post-baseline cell settle")
+
+        // Pin NOT-proven-alive: this isolates the DETECTOR-level suppression (cause #2),
+        // so on BASE the reassoc cannot be saved by the #981 proven-alive gate — it
+        // reaches the redial. With #1042 the detector suppresses it (no event at all).
+        vm.forceTransportProvenAliveForTest = false
+        diagnostics!!.clear()
+
+        // THE REASSOC: a NEW handle on the SAME single CELLULAR transport (RAT/band /
+        // v4↔v6 dual-stack re-validation). On BASE this emits a ValidatedIdentityChange
+        // → network_reconnect_start (RED). With #1042 the emit returns null (GREEN).
+        val reassoc = observer.emitSyntheticSnapshotForTest(
+            TerminalNetworkSnapshot.Validated(networkHandle = "cell-B", transports = setOf("CELLULAR")),
+            reason = "issue1042c-cellular-reassoc",
+        )
+        assertNull(
+            "a same-transport {CELLULAR} reassoc to a new handle must be SUPPRESSED by the " +
+                "detector (no event) — issue 1042 cause #2; emitted=$reassoc",
+            reassoc,
+        )
+
+        // LOAD-BEARING: ZERO redial diagnostics across the window after the reassoc.
+        watchNoRedialDiagnostics("after the cellular same-IP reassoc", WATCH_NO_REDIAL_AFTER_RESTORE_MS)
+        waitForConnected("after cellular reassoc")
+        waitForNoSwitchingOverlay("after cellular reassoc settle")
+        waitForVisibleTerminal("after cellular reassoc terminal") { it.contains(READY_MARKER) }
+        captureViewport("issue1042c-02-no-redial")
+        writeTimings("issue1042c")
+    }
+
+    // (d) cause #2 scope guard — a REAL cross-transport handoff must STILL redial.
+    @Test
+    fun crossTransportHandoffStillRedials() = runBlocking<Unit> {
+        val hostRowTag = requireNotNull(seededHostRowTag)
+        attachSeededTmuxSession(hostRowTag)
+        waitForVisibleTerminal("initial attach") { it.contains(READY_MARKER) }
+        waitForConnected("initial attach")
+        waitForNoSwitchingOverlay("pre-handoff attach settle")
+        captureViewport("issue1042d-01-attached")
+
+        val vm = currentViewModel()
+
+        // Pin NOT-proven-alive so the #981 ride-through cannot suppress the REAL handoff
+        // (we WANT it to redial — that is the contract being guarded).
+        vm.forceTransportProvenAliveForTest = false
+        diagnostics!!.clear()
+
+        // THE HANDOFF: WIFI→CELLULAR crosses transport sets — a real handoff (the #1042
+        // scope guard: the same-identity relaxation must NOT swallow it). Drive the real
+        // VM hook directly (the App-gate background suppression is orthogonal to #1042
+        // and exercised by the cellular case above) so the redial decision is
+        // deterministic against the LIVE connected `-CC` Docker session.
+        val wifi = TerminalNetworkSnapshot.Validated(networkHandle = "wifi-A", transports = setOf("WIFI"))
+        val cellular = TerminalNetworkSnapshot.Validated(networkHandle = "cell-A", transports = setOf("CELLULAR"))
+        val handoff = TerminalNetworkChange(
+            previous = wifi,
+            current = cellular,
+            previousValidated = wifi,
+            reason = "issue1042d-cross-transport-handoff",
+            sequence = 1L,
+            kind = TerminalNetworkChangeKind.ValidatedIdentityChange,
+        )
+        compose.activityRule.scenario.onActivity { vm.onNetworkChanged(handoff) }
+
+        // LOAD-BEARING: the real handoff DOES redial (#548 preserved).
+        compose.waitUntil(timeoutMillis = RESTORE_RECONNECT_TIMEOUT_MS) {
+            diagnostics!!.eventsNamed("network_reconnect_start").isNotEmpty()
+        }
+        assertTrue(
+            "expected a network_reconnect_start for the real cross-transport handoff " +
+                "(proves the #548 redial fired, not a vacuous pass); " +
+                "events=${diagnostics!!.events.map { it.name }}",
+            diagnostics!!.eventsNamed("network_reconnect_start").isNotEmpty(),
+        )
+
+        // The redial reconnects over the (real, healthy) fixture and settles.
+        waitForConnected("after cross-transport handoff reconnect")
+        waitForNoSwitchingOverlay("after cross-transport handoff settle")
+        waitForVisibleTerminal("after cross-transport terminal") { it.contains(READY_MARKER) }
+        captureViewport("issue1042d-02-redialled")
+        writeTimings("issue1042d")
+    }
+
+    private fun currentViewModel(): TmuxSessionViewModel {
+        lateinit var vm: TmuxSessionViewModel
+        compose.activityRule.scenario.onActivity { activity ->
+            vm = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+        }
+        return vm
+    }
+
+    private fun waitForNoSwitchingOverlay(label: String) {
+        compose.waitUntil(timeoutMillis = CONNECTED_TIMEOUT_MS) {
+            runCatching {
+                compose.onAllNodesWithTag(TMUX_SWITCHING_LOADING_TAG, useUnmergedTree = true)
+                    .fetchSemanticsNodes()
+                    .isEmpty()
+            }.getOrDefault(false)
+        }
+        assertEquals(
+            "expected no 'Attaching…' overlay before/after $label",
+            0,
+            compose.onAllNodesWithTag(TMUX_SWITCHING_LOADING_TAG, useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .size,
+        )
+    }
+
+    private fun terminalNetworkObserver(): TerminalNetworkObserver {
+        val ctx = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
+        return EntryPointAccessors
+            .fromApplication(ctx, TestAccessEntryPoint::class.java)
+            .terminalNetworkObserver()
+    }
+
+    private fun attachSeededTmuxSession(hostRowTag: String) {
+        compose.waitUntil(timeoutMillis = HOST_ROW_TIMEOUT_MS) {
+            runCatching {
+                compose.onAllNodesWithTag(hostRowTag, useUnmergedTree = true)
+                    .fetchSemanticsNodes()
+                    .isNotEmpty()
+            }.getOrDefault(false)
+        }
+        compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick()
+        compose.waitUntil(timeoutMillis = TerminalTestTimeouts.terminalVisibilityTimeoutMs()) {
+            runCatching {
+                compose.onAllNodesWithText(SESSION_NAME, useUnmergedTree = true)
+                    .fetchSemanticsNodes()
+                    .isNotEmpty()
+            }.getOrDefault(false)
+        }
+        compose.onNodeWithText(SESSION_NAME, useUnmergedTree = true).performClick()
+        compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertExists()
+        waitForTerminalViewAttached()
+    }
+
+    private fun waitForTerminalViewAttached() {
+        compose.waitUntil(timeoutMillis = 30_000) {
+            var attached = false
+            compose.activityRule.scenario.onActivity { activity ->
+                val view = activity.window.decorView.findTerminalView()
+                attached = view?.currentSession != null && view.mEmulator != null
+            }
+            attached
+        }
+    }
+
+    private fun waitForConnected(label: String) {
+        compose.waitUntil(timeoutMillis = CONNECTED_TIMEOUT_MS) {
+            currentConnectionStatus() is TmuxSessionViewModel.ConnectionStatus.Connected
+        }
+        assertTrue(
+            "expected Connected after $label, observed=${currentConnectionStatus()}",
+            currentConnectionStatus() is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+    }
+
+    private fun currentConnectionStatus(): TmuxSessionViewModel.ConnectionStatus {
+        var status: TmuxSessionViewModel.ConnectionStatus =
+            TmuxSessionViewModel.ConnectionStatus.Idle
+        compose.activityRule.scenario.onActivity { activity ->
+            status = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+                .connectionStatus
+                .value
+        }
+        return status
+    }
+
+    private fun waitForVisibleTerminal(
+        label: String,
+        timeoutMillis: Long = TerminalTestTimeouts.terminalVisibilityTimeoutMs(),
+        predicate: (String) -> Boolean,
+    ): String {
+        var last = ""
+        compose.waitUntil(timeoutMillis = timeoutMillis) {
+            last = visibleTerminalText()
+            last.isNotBlank() && predicate(last)
+        }
+        assertTrue("expected visible terminal for $label; got:\n$last", predicate(last))
+        return last
+    }
+
+    private fun visibleTerminalText(): String {
+        var text = ""
+        compose.activityRule.scenario.onActivity { activity ->
+            text = activity.window.decorView
+                .findTerminalView()
+                ?.currentSession
+                ?.emulator
+                ?.screen
+                ?.transcriptText
+                .orEmpty()
+        }
+        return text
+    }
+
+    /**
+     * Forbid the loud redial signals across a window — proves the lease is held / the
+     * link rode through with NO churn (the whole point of #1042).
+     */
+    private fun watchNoRedialDiagnostics(label: String, durationMs: Long) {
+        val deadline = SystemClock.elapsedRealtime() + durationMs
+        while (SystemClock.elapsedRealtime() < deadline) {
+            assertNoRedialDiagnostics(label)
+            SystemClock.sleep(100)
+        }
+    }
+
+    private fun assertNoRedialDiagnostics(label: String) {
+        val events = diagnostics!!.events
+        val forbidden = events.filter { event ->
+            event.name in setOf(
+                "reconnect_start",
+                "network_reconnect_start",
+                "network_restore_reconnect_start",
+            )
+        }
+        assertTrue(
+            "expected NO redial diagnostics for $label (the link survived; no churn); " +
+                "forbidden=${forbidden.map { it.name }} all=${events.map { it.name }}",
+            forbidden.isEmpty(),
+        )
+    }
+
+    private fun readFixtureKey(): String =
+        InstrumentationRegistry.getInstrumentation()
+            .context
+            .assets
+            .open("test_key")
+            .bufferedReader()
+            .use { it.readText() }
+
+    private suspend fun seedDockerHost(key: String): String {
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
+        val db = Room.databaseBuilder(appContext, AppDatabase::class.java, DATABASE_NAME)
+            .fallbackToDestructiveMigration(dropAllTables = true)
+            .build()
+        return try {
+            db.clearAllTables()
+            val storedKey = SshKeyStorage.persistKey(
+                context = appContext,
+                sshKeyDao = db.sshKeyDao(),
+                name = "issue1042-key-${System.currentTimeMillis()}",
+                content = key,
+            )
+            val hostId = db.hostDao().insert(
+                HostEntity(
+                    name = "Issue1042 Mobile SpuriousReconnect",
+                    hostname = DEFAULT_HOST,
+                    port = DEFAULT_PORT,
+                    username = DEFAULT_USER,
+                    keyId = storedKey.id,
+                    tmuxInstalled = true,
+                    lastBootstrapAt = System.currentTimeMillis(),
+                ),
+            )
+            HOST_ROW_TAG_PREFIX + hostId
+        } finally {
+            db.close()
+        }
+    }
+
+    private suspend fun seedTmuxSession(key: String) {
+        val script = buildString {
+            appendLine("set -eu")
+            appendLine("tmux kill-session -t ${shellQuote(SESSION_NAME)} 2>/dev/null || true")
+            appendLine(
+                "tmux new-session -d -s ${shellQuote(SESSION_NAME)} " +
+                    shellQuote("printf '$READY_MARKER\\n'; exec sleep 600"),
+            )
+            appendLine("sleep 1")
+            appendLine("tmux list-sessions")
+        }
+        val result = execRemoteSetupUntilReady(
+            key = SshKey.Pem(key),
+            command = script,
+            description = "issue1042 tmux seed session",
+        )
+        assertTrue(
+            "expected tmux seeding to succeed; exit=${result.exitCode} stderr='${result.stderr}'",
+            result.exitCode == 0,
+        )
+    }
+
+    private suspend fun cleanupRemoteTmuxSession(key: String) {
+        runCatching {
+            SshConnection.connect(
+                host = DEFAULT_HOST,
+                port = DEFAULT_PORT,
+                user = DEFAULT_USER,
+                key = SshKey.Pem(key),
+                knownHosts = KnownHostsPolicy.AcceptAll,
+                timeoutMs = 15_000,
+            ).mapCatching { session ->
+                session.use {
+                    it.exec("tmux kill-session -t ${shellQuote(SESSION_NAME)} 2>/dev/null || true")
+                }
+            }
+        }
+    }
+
+    private fun captureViewport(name: String) {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.waitForIdleSync()
+        SystemClock.sleep(150)
+
+        var bitmap: Bitmap? = null
+        compose.activityRule.scenario.onActivity { activity ->
+            val view = activity.window.decorView.findTerminalView() ?: return@onActivity
+            if (view.width <= 0 || view.height <= 0) return@onActivity
+            val b = Bitmap.createBitmap(view.width, view.height, Bitmap.Config.ARGB_8888)
+            view.draw(Canvas(b))
+            bitmap = b
+        }
+        bitmap?.let { writeBitmap("$name-viewport", it) }
+        writeText("$name-visible-terminal.txt", visibleTerminalText())
+        bitmap?.recycle()
+    }
+
+    private fun writeBitmap(name: String, bitmap: Bitmap): File {
+        val file = artifactFile("$name.png")
+        java.io.FileOutputStream(file).use { out ->
+            check(bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)) {
+                "failed to write bitmap to ${file.absolutePath}"
+            }
+        }
+        println("ISSUE1042_VIEWPORT ${file.absolutePath}")
+        return file
+    }
+
+    private fun writeText(name: String, text: String): File {
+        val file = artifactFile(name)
+        file.writeText(text)
+        println("ISSUE1042_TEXT ${file.absolutePath}")
+        return file
+    }
+
+    private fun writeTimings(prefix: String): File =
+        writeText("$prefix-timings.txt", timings.joinToString(separator = "\n", postfix = "\n"))
+
+    private fun artifactFile(name: String): File {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val mediaRoot = com.pocketshell.app.test.testArtifactsRoot(instrumentation.targetContext)
+        val dir = File(mediaRoot, "additional_test_output/$DEVICE_DIR_NAME")
+        check(dir.exists() || dir.mkdirs()) {
+            "could not create artifact directory ${dir.absolutePath}"
+        }
+        return File(dir, name)
+    }
+
+    private fun View.findTerminalView(): TerminalView? {
+        if (this is TerminalView) return this
+        if (this !is ViewGroup) return null
+        for (index in 0 until childCount) {
+            val match = getChildAt(index).findTerminalView()
+            if (match != null) return match
+        }
+        return null
+    }
+
+    private fun shellQuote(value: String): String =
+        "'" + value.replace("'", "'\"'\"'") + "'"
+
+    private companion object {
+        const val DATABASE_NAME: String = "pocketshell.db"
+        const val DEVICE_DIR_NAME: String = "issue1042-mobile-spurious-reconnect"
+        const val SESSION_NAME: String = "issue1042-spurious-proof"
+        const val READY_MARKER: String = "ISSUE1042-SPURIOUS-READY"
+
+        const val WATCH_NO_REDIAL_AFTER_RESTORE_MS: Long = 3_000L
+
+        val HOST_ROW_TIMEOUT_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 60_000L else 20_000L
+        val CONNECTED_TIMEOUT_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 30_000L else 15_000L
+        val RESTORE_RECONNECT_TIMEOUT_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 30_000L else 15_000L
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/connectivity/TerminalNetworkObserver.kt
+++ b/app/src/main/java/com/pocketshell/app/connectivity/TerminalNetworkObserver.kt
@@ -217,11 +217,16 @@ data class TerminalNetworkChange(
      *   swallowed this entirely (`return null` on any non-validated snapshot), so a
      *   clean drop was only noticed reactively ~90s later by the keepalive.
      * - [TerminalNetworkChangeKind.NetworkRestored] — validation returned after a
-     *   loss. Drives a FAST reconnect even from a non-Connected (loss-suspended)
-     *   state, even when the restored identity equals the pre-loss one (the
-     *   airplane-mode round-trip the pre-#997 detector also swallowed at `:333`).
-     *   A real loss means the old socket is dead, so this BYPASSES the
-     *   proven-alive gate.
+     *   loss. Recovers even from a non-Connected (loss-suspended) state, even when
+     *   the restored identity equals the pre-loss one (the airplane-mode round-trip
+     *   the pre-#997 detector also swallowed at `:333`). Issue #1042 (cause #1)
+     *   makes the recovery LIVENESS-FIRST: a brief no-validated-network window
+     *   (tunnel, elevator, RAT handover, congestion re-validation) does NOT mean
+     *   the TCP socket died — cellular hits those windows constantly — so the VM
+     *   rides through with NO redial when the existing transport is proven alive
+     *   (keepalive within its window, or a single bounded probe answers), and only
+     *   forces the #997 fresh-lease redial when the transport does NOT answer (a
+     *   genuinely dead post-outage socket still reconnects).
      */
     val kind: TerminalNetworkChangeKind = TerminalNetworkChangeKind.ValidatedIdentityChange,
 )
@@ -292,23 +297,44 @@ internal fun TerminalNetworkChange.networkDiagnosticFields(): Array<Pair<String,
  * A genuine handoff that #548 must still catch crosses transports (WIFI→CELLULAR,
  * a VPN coming up/down, ETHERNET↔WIFI). So we now treat two validated snapshots
  * as the SAME network identity when EITHER the handle matches OR the transport
- * sets are identical AND that set is a *pure single-WIFI* network (no cellular /
- * VPN / ethernet on either side). That suppresses the band-steer/mesh reassoc
- * (the spurious case) while a real transport change still flips identity and
- * reconnects. We deliberately scope the relaxation to pure `{WIFI}`: a VPN or a
- * tethered/multi-transport network re-establishing can legitimately need the
- * fresh lease, so those keep the strict handle check.
+ * sets are identical AND that set is a *single benign-reassoc* transport (no VPN /
+ * ethernet / tethering / multi-transport on either side). That suppresses the
+ * band-steer/mesh reassoc (the spurious case) while a real transport change still
+ * flips identity and reconnects.
+ *
+ * Issue #1042 (cause #2 — cellular churn): the relaxation used to be scoped to
+ * pure `{WIFI}` ONLY, so a `{CELLULAR}` RAT/band re-association (or a v4↔v6
+ * dual-stack re-validation) that mints a NEW `networkHandle` while staying on the
+ * SAME single cellular transport was treated as a real handoff → a self-inflicted
+ * fresh-lease redial on a quiet/idle cellular session (the maintainer's "constant
+ * reconnects on mobile internet"). Cellular hits these handle-churning
+ * re-validations FAR more often than Wi-Fi. So we now treat a same-transport-set
+ * reassoc as the same identity for `{WIFI}` *or* `{CELLULAR}` (a dual-stack v4↔v6
+ * flip keeps the same single transport set, so it is covered too). We deliberately
+ * keep the strict handle check for any set carrying VPN / ethernet / multiple
+ * transports: a VPN coming up or a real cross-transport WIFI↔CELLULAR handoff
+ * still flips identity and redials.
  */
 internal fun TerminalNetworkSnapshot.Validated.hasSameNetworkIdentityAs(
     other: TerminalNetworkSnapshot.Validated,
 ): Boolean =
     networkHandle == other.networkHandle ||
-        (isPureWifi() && other.isPureWifi() && transports == other.transports)
+        (transports == other.transports && isBenignReassocTransportSet())
 
-private val PURE_WIFI_TRANSPORTS: Set<String> = setOf("WIFI")
+/**
+ * Issue #1042: the single-transport networks whose supplicant/RAT re-association
+ * mints a new `networkHandle` on a PHYSICALLY STABLE link that SSH almost always
+ * survives — a Wi-Fi band-steer / mesh roam, or a cellular RAT/band/dual-stack
+ * re-validation. A new handle on one of these, with an unchanged transport set, is
+ * a benign reassoc (suppress the redial), NOT a real handoff.
+ */
+private val BENIGN_REASSOC_TRANSPORT_SETS: Set<Set<String>> = setOf(
+    setOf("WIFI"),
+    setOf("CELLULAR"),
+)
 
-private fun TerminalNetworkSnapshot.Validated.isPureWifi(): Boolean =
-    transports == PURE_WIFI_TRANSPORTS
+private fun TerminalNetworkSnapshot.Validated.isBenignReassocTransportSet(): Boolean =
+    transports in BENIGN_REASSOC_TRANSPORT_SETS
 
 internal fun TerminalNetworkSnapshot.hasSameNetworkIdentityAs(
     other: TerminalNetworkSnapshot,

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -4862,15 +4862,125 @@ public class TmuxSessionViewModel @Inject constructor(
     }
 
     /**
-     * Issue #997: the [ConnectionDecision.ScheduleNetworkReconnectOnRestore] body.
-     * Validation RETURNED after a loss — drive a FAST reconnect via the existing
-     * `scheduleAutoReconnect` ladder (D28: NO new reconnect path). Unlike
-     * [scheduleNetworkReconnect] this does NOT require a `Connected` status (it
-     * recovers a loss-suspended / `Reconnecting` session — the whole point) and it
-     * BYPASSES the proven-alive ride-through (a real loss means the old socket is
-     * already dead). `target` is the held [activeTarget]/[connectingTarget].
+     * Issue #997 / #1042: the [ConnectionDecision.ScheduleNetworkReconnectOnRestore]
+     * body. Validation RETURNED after a loss. Unlike [scheduleNetworkReconnect] this
+     * does NOT require a `Connected` status (it recovers a loss-suspended /
+     * `Reconnecting` session — the whole point). `target` is the held
+     * [activeTarget]/[connectingTarget].
+     *
+     * Issue #1042 (cause #1) makes this LIVENESS-FIRST. The pre-#1042 body redialled
+     * UNCONDITIONALLY (a fresh lease, bypassing the proven-alive gate) on every
+     * restore. On cellular the device dips into no-validated-network constantly
+     * (tunnel, elevator, RAT handover, congestion re-validation) WITHOUT the TCP
+     * socket dying, so that unconditional redial was the maintainer's "constant
+     * reconnects on mobile internet". We now check whether the EXISTING transport
+     * survived the dip before tearing it down:
+     *   1. if the always-on transport keepalive proves the link alive within its
+     *      ride-through window (a sub-budget loss never ages it out), RIDE THROUGH
+     *      synchronously with no redial; otherwise
+     *   2. issue ONE bounded control-channel probe — if it answers, ride through.
+     * Only when the transport does NOT answer (or the bounded probe times out) do we
+     * fall back to the #997 fresh-lease redial. A genuinely dead post-outage socket
+     * therefore STILL reconnects (BareNetworkLossRestoreReconnectE2eTest guards it).
      */
     private fun scheduleNetworkReconnectOnRestore(
+        change: TerminalNetworkChange,
+        target: ConnectionTarget,
+    ) {
+        // (1) Fast synchronous ride-through: the keepalive already proves the link
+        // alive within its window, so the brief loss did not kill the socket.
+        if (isTransportKeepAliveProvenAliveRecently()) {
+            rideThroughNetworkRestore(change, target, cause = "transport_proven_alive")
+            return
+        }
+        // (2) The keepalive aged out (a quiet/idle link). Do not blindly redial —
+        // issue ONE bounded probe over the warm control channel; ride through if it
+        // answers, redial only if it does not.
+        viewModelScope.launch {
+            val alive = withTimeoutOrNull(RESTORE_LIVENESS_PROBE_BUDGET_MS) {
+                runLivenessProbePing()
+            } ?: false
+            if (alive) {
+                rideThroughNetworkRestore(change, target, cause = "probe_answered")
+            } else {
+                forceFreshLeaseRestoreReconnect(change, target)
+            }
+        }
+    }
+
+    /**
+     * Issue #1042 (cause #1): the restore RIDE-THROUGH arm. The existing transport
+     * survived the brief loss (proven alive, or the bounded probe answered), so the
+     * `-CC` client was never torn down. We do NOT redial — we just clear the calm
+     * loss-hold band by flipping back to [ConnectionState.Live] (which re-promotes
+     * the controller via `revealLive` and reopens the liveness-probe gate). No fresh
+     * lease, no visible Reconnecting churn — exactly the spurious-reconnect this
+     * issue kills. Records a `network_restore_ride_through` device trail so the
+     * decision is visible in field logs (not mislabelled as a redial).
+     */
+    private fun rideThroughNetworkRestore(
+        change: TerminalNetworkChange,
+        target: ConnectionTarget,
+        cause: String,
+    ) {
+        val reason = change.reason
+        lifecycleReattachNetworkCoalesce = null
+        Log.i(
+            ISSUE_548_NETWORK_TAG,
+            "tmux-network-restore-ride-through reason=$reason cause=$cause " +
+                targetLogFields(target),
+        )
+        DiagnosticEvents.record(
+            "connection",
+            "network_restore_ride_through",
+            "source" to "network_observer",
+            "trigger" to TmuxConnectTrigger.NetworkReconnect.logValue,
+            "reason" to reason,
+            "cause" to cause,
+            "classification" to "network_restored_transport_alive",
+            "reconnect" to false,
+            "sequence" to change.sequence,
+            "hostId" to target.hostId,
+            "host" to target.host,
+            "port" to target.port,
+            "user" to target.user,
+            "session" to target.sessionName,
+            "generation" to connectGeneration,
+            "clientHash" to clientRef?.let { System.identityHashCode(it) },
+            "deferredFromBackground" to change.deferredFromBackground,
+            *change.networkDiagnosticFields(),
+        )
+        ReconnectCauseTrail.record(
+            stage = "network_reconnect_decision",
+            outcome = "ride_through",
+            cause = cause,
+            trigger = TmuxConnectTrigger.NetworkReconnect.logValue,
+            "sequence" to change.sequence,
+            "hostId" to target.hostId,
+            "generation" to connectGeneration,
+            "classification" to "network_restored_transport_alive",
+            "deferredFromBackground" to change.deferredFromBackground,
+        )
+        // Clear the loss-hold "reconnecting" band: the surviving transport is alive,
+        // so flip back to Live (the -CC client was never torn down).
+        setConnectionState(
+            ConnectionState.Live(
+                target.host,
+                target.port,
+                target.user,
+            ),
+        )
+    }
+
+    /**
+     * Issue #997 / #1042: the restore FRESH-LEASE REDIAL arm — the #997 fallback for
+     * a genuinely dead post-outage socket (the transport did not survive the loss,
+     * so neither the keepalive nor the bounded probe answered). Drives a FAST
+     * reconnect via the existing `scheduleAutoReconnect` ladder (D28: NO new reconnect
+     * path). This is the unchanged pre-#1042 restore body — it now runs ONLY past the
+     * liveness gate in [scheduleNetworkReconnectOnRestore].
+     */
+    private fun forceFreshLeaseRestoreReconnect(
         change: TerminalNetworkChange,
         target: ConnectionTarget,
     ) {
@@ -4891,7 +5001,9 @@ public class TmuxSessionViewModel @Inject constructor(
             "reason" to reason,
             "classification" to "network_restored_fast_reconnect",
             "reconnect" to true,
-            "bypassedProvenAlive" to true,
+            // Issue #1042: the redial now runs only PAST the liveness gate — the
+            // transport did NOT answer (keepalive aged out + bounded probe failed).
+            "transportAnswered" to false,
             "sequence" to change.sequence,
             "hostId" to target.hostId,
             "host" to target.host,
@@ -16063,12 +16175,20 @@ public class TmuxSessionViewModel @Inject constructor(
         data object HoldNetworkLost : ConnectionDecision
 
         /**
-         * Issue #997: validation RETURNED after a loss. Drive a FAST reconnect
-         * via the existing `scheduleAutoReconnect` ladder — even from a
-         * non-Connected (loss-suspended / Reconnecting) state, which the
-         * [ScheduleNetworkReconnect] `Connected`-only gate would have ignored —
-         * and BYPASS the proven-alive ride-through (a real loss means the old
-         * socket is already dead, so there is nothing alive to ride through).
+         * Issue #997 / #1042: validation RETURNED after a loss. Recovers even from
+         * a non-Connected (loss-suspended / Reconnecting) state, which the
+         * [ScheduleNetworkReconnect] `Connected`-only gate would have ignored.
+         *
+         * Issue #1042 (cause #1) makes the recovery LIVENESS-FIRST. The pre-#1042
+         * body redialled UNCONDITIONALLY (bypassing the proven-alive gate on the
+         * assumption "a loss means the socket is dead"). On cellular that fires
+         * constantly even when the TCP socket survived a brief no-validated window
+         * (tunnel, elevator, RAT handover, congestion re-validation). The body now:
+         *   1. rides through with NO redial when the existing transport is proven
+         *      alive (transport keepalive within its window, or a single bounded
+         *      control-channel probe answers), and
+         *   2. forces the #997 fresh-lease redial ONLY when the transport does not
+         *      answer — a genuinely dead post-outage socket still reconnects.
          */
         data object ScheduleNetworkReconnectOnRestore : ConnectionDecision
 
@@ -16150,8 +16270,10 @@ public class TmuxSessionViewModel @Inject constructor(
                 if (clientRef == null && sessionRef == null) return ConnectionDecision.Ignore
                 // A reconnect ladder is already driving recovery — let it run.
                 if (autoReconnectJob?.isActive == true) return ConnectionDecision.Ignore
-                // Bypass the proven-alive gate: a real loss means the old socket
-                // is dead, so there is nothing alive to ride through.
+                // Issue #1042 (cause #1): the body is LIVENESS-FIRST — it rides
+                // through with no redial when the existing transport is proven
+                // alive (the common brief-cellular-dip case) and only forces the
+                // #997 fresh-lease redial when the transport does not answer.
                 return ConnectionDecision.ScheduleNetworkReconnectOnRestore
             }
             TerminalNetworkChangeKind.ValidatedIdentityChange -> Unit
@@ -17145,6 +17267,15 @@ internal const val SEND_SESSION_WAIT_POLL_MS: Long = 100L
 internal const val RUNTIME_HEALTH_PROBE_TIMEOUT_MS: Long = 750L
 
 internal const val CACHED_RUNTIME_HEALTH_PROBE_TIMEOUT_MS: Long = RUNTIME_HEALTH_PROBE_TIMEOUT_MS
+
+/**
+ * Issue #1042 (cause #1): the small bound on the single control-channel probe the
+ * liveness-first network-restore arm issues when the transport keepalive has aged
+ * out. A surviving link answers well within this; a genuinely dead socket times out
+ * and falls through to the #997 fresh-lease redial. Kept short so a dead socket's
+ * recovery is not noticeably delayed past the old unconditional redial.
+ */
+internal const val RESTORE_LIVENESS_PROBE_BUDGET_MS: Long = 2_000L
 
 /**
  * Classification of a foreground tmux control-channel health probe.

--- a/app/src/test/java/com/pocketshell/app/connectivity/TerminalNetworkChangeDetectorConcurrencyTest.kt
+++ b/app/src/test/java/com/pocketshell/app/connectivity/TerminalNetworkChangeDetectorConcurrencyTest.kt
@@ -49,8 +49,15 @@ class TerminalNetworkChangeDetectorConcurrencyTest {
             // Each iteration starts from a fresh, known identity. Threads race
             // to flip the validated network to many DISTINCT new identities so
             // most updates are real handoffs that bump `sequence`.
+            //
+            // Issue #1042: a same-transport-set {WIFI}/{CELLULAR} reassoc to a new
+            // handle is now SUPPRESSED (not a handoff), so the targets carry a
+            // VPN-bearing transport set — a distinct handle on a non-benign set is
+            // still a genuine identity handoff, keeping this race test exercising the
+            // emission path it is about (the #995 sequence-tearing race), not the
+            // identity policy (covered by TerminalNetworkChangeDetectorTest).
             val detector = TerminalNetworkChangeDetector(
-                initial = TerminalNetworkSnapshot.Validated("net-0", setOf("CELLULAR")),
+                initial = TerminalNetworkSnapshot.Validated("net-0", setOf("CELLULAR", "VPN")),
             )
             val emitted = ConcurrentLinkedQueue<TerminalNetworkChange>()
             val startLatch = CountDownLatch(1)
@@ -64,7 +71,7 @@ class TerminalNetworkChangeDetectorConcurrencyTest {
                     // wins is a genuine transport/identity handoff.
                     val target = TerminalNetworkSnapshot.Validated(
                         networkHandle = "net-$iteration-$t",
-                        transports = setOf("CELLULAR"),
+                        transports = setOf("CELLULAR", "VPN"),
                     )
                     val change = detector.update(target, "race-$t")
                     if (change != null) emitted.add(change)
@@ -110,9 +117,10 @@ class TerminalNetworkChangeDetectorConcurrencyTest {
      * max-sequence that does not equal the emission count). A lost slot is the
      * "suppress a real handoff → no reconnect → dead socket" symptom.
      *
-     * Class-cover: this is the WIFI→CELLULAR-style real-handoff case (every
-     * target is a distinct CELLULAR identity off a CELLULAR start, all genuine
-     * transitions), driven under contention.
+     * Class-cover: this is the real-handoff case (every target is a distinct
+     * VPN-bearing identity off a VPN-bearing start, all genuine transitions —
+     * #1042: a VPN-bearing set keeps the strict handle check, so distinct handles
+     * stay distinct identities), driven under contention.
      */
     @Test
     fun `no concurrent real handoff is lost or torn`() {
@@ -120,8 +128,12 @@ class TerminalNetworkChangeDetectorConcurrencyTest {
         val iterations = 400
 
         repeat(iterations) { iteration ->
+            // Issue #1042: VPN-bearing identities so a distinct handle is still a
+            // genuine handoff (a bare same-transport {CELLULAR} reassoc is now
+            // suppressed — that is the identity policy, covered elsewhere; this test
+            // is about the #995 sequence-tearing race on the emission path).
             val detector = TerminalNetworkChangeDetector(
-                initial = TerminalNetworkSnapshot.Validated("net-init", setOf("CELLULAR")),
+                initial = TerminalNetworkSnapshot.Validated("net-init", setOf("CELLULAR", "VPN")),
             )
             val emitted = ConcurrentLinkedQueue<TerminalNetworkChange>()
             val startLatch = CountDownLatch(1)
@@ -135,7 +147,7 @@ class TerminalNetworkChangeDetectorConcurrencyTest {
                     // handoff that MUST surface exactly once.
                     val target = TerminalNetworkSnapshot.Validated(
                         networkHandle = "net-$iteration-$t",
-                        transports = setOf("CELLULAR"),
+                        transports = setOf("CELLULAR", "VPN"),
                     )
                     val change = detector.update(target, "handoff-$t")
                     if (change != null) emitted.add(change)

--- a/app/src/test/java/com/pocketshell/app/connectivity/TerminalNetworkChangeDetectorTest.kt
+++ b/app/src/test/java/com/pocketshell/app/connectivity/TerminalNetworkChangeDetectorTest.kt
@@ -338,6 +338,80 @@ class TerminalNetworkChangeDetectorTest {
         assertEquals("cell-handle", handoff.current.networkHandle)
     }
 
+    // --- Issue #1042 (cause #2) — a `{CELLULAR}` RAT/band/dual-stack re-association
+    // mints a NEW networkHandle while staying on the SAME single cellular transport.
+    // Pre-#1042 the same-identity relaxation was scoped to pure `{WIFI}` ONLY, so a
+    // cellular reassoc on a quiet/idle session was treated as a real handoff → a
+    // self-inflicted fresh-lease redial (the maintainer's "constant reconnects on
+    // mobile internet"). The relaxation now also covers a same-transport `{CELLULAR}`
+    // reassoc; a real cross-transport WIFI↔CELLULAR handoff still redials.
+
+    @Test
+    fun `same-transport cellular reassociation to a new handle does not emit a reconnect (issue 1042)`() {
+        val detector = TerminalNetworkChangeDetector(
+            initial = TerminalNetworkSnapshot.Validated("cell-handle-A", setOf("CELLULAR")),
+        )
+
+        // RAT/band re-association (or a v4↔v6 dual-stack re-validation): SAME single
+        // CELLULAR transport, NEW handle. RED on base (handle inequality + the pure-WIFI
+        // -only relaxation → emits a handoff → redial); GREEN with the #1042
+        // generalisation (a same-transport cellular reassoc = same network identity).
+        assertNull(
+            "a same-transport {CELLULAR} reassoc to a new handle must NOT emit (issue 1042)",
+            detector.update(
+                snapshot = TerminalNetworkSnapshot.Validated("cell-handle-B", setOf("CELLULAR")),
+                reason = "default-network-capabilities",
+            ),
+        )
+
+        // The new handle is still LEARNED, so a subsequent REAL transport change
+        // (CELLULAR→WIFI) is still caught as a handoff against the latest cell handle.
+        val realHandoff = detector.update(
+            snapshot = TerminalNetworkSnapshot.Validated("wifi-handle", setOf("WIFI")),
+            reason = "real-handoff",
+        )
+        assertTrue("a real CELLULAR→WIFI handoff must still emit", realHandoff != null)
+        assertEquals("cell-handle-B", realHandoff!!.previousValidated!!.networkHandle)
+        assertEquals("wifi-handle", realHandoff.current.networkHandle)
+    }
+
+    @Test
+    fun `cellular to wifi cross-transport handoff still emits (issue 1042 scope guard)`() {
+        // The #1042 relaxation is per-transport-set: a real cross-transport handoff
+        // (CELLULAR→WIFI here, the inverse of the #875 WIFI→CELLULAR guard) crosses
+        // transport sets, so it is NOT a benign reassoc and must still redial.
+        val detector = TerminalNetworkChangeDetector(
+            initial = TerminalNetworkSnapshot.Validated("cell-handle", setOf("CELLULAR")),
+        )
+
+        val handoff = detector.update(
+            snapshot = TerminalNetworkSnapshot.Validated("wifi-handle", setOf("WIFI")),
+            reason = "real-handoff",
+        )
+
+        assertTrue("CELLULAR→WIFI must still be a handoff", handoff != null)
+        assertEquals("cell-handle", handoff!!.previousValidated!!.networkHandle)
+        assertEquals("wifi-handle", handoff.current.networkHandle)
+    }
+
+    @Test
+    fun `cellular reassoc that adds a VPN transport still emits a reconnect (issue 1042 scope guard)`() {
+        // The relaxation is scoped to a SINGLE benign transport ({WIFI} or {CELLULAR})
+        // on both sides. A VPN coming up over cellular is NOT a benign reassoc — it can
+        // legitimately need the fresh lease, so it keeps the strict handle check.
+        val detector = TerminalNetworkChangeDetector(
+            initial = TerminalNetworkSnapshot.Validated("cell-handle-A", setOf("CELLULAR")),
+        )
+
+        val handoff = detector.update(
+            snapshot = TerminalNetworkSnapshot.Validated("cell-vpn-handle", setOf("CELLULAR", "VPN")),
+            reason = "vpn-up",
+        )
+
+        assertTrue("a CELLULAR→CELLULAR+VPN change must still emit (not a benign reassoc)", handoff != null)
+        assertEquals("cell-vpn-handle", handoff!!.current.networkHandle)
+    }
+
     @Test
     fun `wifi reassoc that adds a VPN transport still emits a reconnect (issue 875 scope guard)`() {
         // The relaxation is scoped to PURE {WIFI} on both sides. A VPN coming up

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
@@ -4004,6 +4004,13 @@ class TmuxSessionViewModelTest {
         )
         runCurrent()
 
+        // Issue #1042: this case proves a restore CAN redial FROM the loss-suspended
+        // (non-Connected) state — the #997 gap. Under #1042 the restore is now
+        // liveness-first, so inject a GENUINELY-DEAD transport (keepalive not proven
+        // alive by default + the bounded restore probe DEAD) so the liveness gate
+        // falls through to the fresh-lease redial being asserted here.
+        vm.forceLivenessProbeDeadForTest = true
+
         // Loss: hold + flip to Reconnecting (the loss-suspended state).
         registry.lifecycleHooksSnapshot().single().onNetworkChanged(networkLoss())
         runCurrent()
@@ -4029,11 +4036,15 @@ class TmuxSessionViewModelTest {
     }
 
     @Test
-    fun issue997NetworkRestoreReconnectsEvenWhenTransportWasProvenAlive() = runTest(scheduler) {
-        // A real loss means the old socket is DEAD, so the proven-alive
-        // ride-through (#981) must NOT suppress a restore-driven reconnect. Pin
-        // proven-alive=true and confirm the restore still redials (unlike a bare
-        // validated handoff, which #981 rides through when proven alive).
+    fun issue1042NetworkRestoreRidesThroughWhenTransportProvenAlive() = runTest(scheduler) {
+        // Issue #1042 (cause #1) REFINES the pre-#1042 #997 restore behaviour. The old
+        // assumption — "a loss means the socket is DEAD, so always redial" — fired a
+        // spurious fresh-lease reconnect on every brief cellular dip even when the TCP
+        // socket survived. The restore is now LIVENESS-FIRST: when the existing
+        // transport is proven alive it RIDES THROUGH with NO redial. Pin
+        // proven-alive=true and confirm the restore does NOT redial and the session
+        // returns to Connected. (The genuinely-dead case still redials —
+        // issue997NetworkRestoreDrivesFastReconnectFromLossSuspendedState guards it.)
         TMUX_CONNECT_ATTEMPTS.set(0)
         val registry = ActiveTmuxClients()
         val connector = QueueLeaseConnector(FakeSshSession())
@@ -4063,13 +4074,102 @@ class TmuxSessionViewModelTest {
         advanceUntilIdle()
 
         assertEquals(
-            "a restore after a real loss bypasses the proven-alive gate and reconnects",
-            TmuxConnectTrigger.NetworkReconnect,
-            vm.latestRestoreIntentSnapshot()?.trigger,
+            "a restore over a PROVEN-ALIVE transport must NOT redial (rides through) — #1042",
+            0,
+            connector.connectCount,
         )
-        assertEquals(1, connector.connectCount)
+        assertNull(
+            "a ride-through restore must not schedule a network-reconnect redial",
+            vm.latestRestoreIntentSnapshot(),
+        )
+        assertTrue(
+            "the ride-through clears the loss-hold band back to Connected",
+            vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
 
         vm.forceTransportProvenAliveForTest = null
+    }
+
+    @Test
+    fun issue1042NetworkRestoreRidesThroughWhenBoundedProbeAnswers() = runTest(scheduler) {
+        // Issue #1042 (cause #1) ARM 2 — the headline symptom path: a quiet/idle
+        // cellular session whose transport keepalive has AGED OUT of its ride-through
+        // window (so the proven-alive fast gate does NOT fire) but whose TCP socket is
+        // still alive. The restore must then issue ONE bounded control-channel probe
+        // and, when it ANSWERS, RIDE THROUGH with no redial — NOT redial. This arm is
+        // distinct from arm 1 (keepalive proven alive) and arm 3 (neither answers ->
+        // fresh-lease redial). Asserted via the `cause="probe_answered"` device trail
+        // so it cannot be confused with the proven-alive arm.
+        TMUX_CONNECT_ATTEMPTS.set(0)
+        val registry = ActiveTmuxClients()
+        val connector = QueueLeaseConnector(FakeSshSession())
+        val reconnectClient = FakeTmuxClient().withSinglePane("work", "%1")
+        val vm = newVm(
+            registry = registry,
+            sshLeaseManager = testLeaseManager(connector = connector, scope = this, idleTtlMillis = 0L),
+        )
+        vm.setTmuxClientFactoryForTest { _, _, _ -> reconnectClient }
+        vm.setAutoReconnectDelaysForTest(listOf(0L))
+        vm.replaceClientForTest(
+            hostId = 7L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            sessionName = "work",
+            client = FakeTmuxClient(),
+        )
+        runCurrent()
+
+        // Keepalive NOT proven alive (the fast gate must MISS so the bounded-probe arm
+        // runs) but the bounded probe ANSWERS (healthy attached client, probe-dead seam
+        // off) — the surviving-but-quiet-link case.
+        vm.forceTransportProvenAliveForTest = false
+        vm.forceLivenessProbeDeadForTest = false
+
+        val diagnostics = installRecordingDiagnosticSink()
+        try {
+            registry.lifecycleHooksSnapshot().single().onNetworkChanged(networkLoss())
+            runCurrent()
+            registry.lifecycleHooksSnapshot().single().onNetworkChanged(networkRestore())
+            advanceUntilIdle()
+
+            assertEquals(
+                "a restore whose bounded probe ANSWERS must NOT redial (rides through) — #1042 arm 2",
+                0,
+                connector.connectCount,
+            )
+            assertNull(
+                "a probe-answered ride-through must not schedule a network-reconnect redial",
+                vm.latestRestoreIntentSnapshot(),
+            )
+            assertTrue(
+                "the probe-answered ride-through clears the loss-hold band back to Connected",
+                vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected,
+            )
+            assertTrue(
+                "no redial diagnostic may fire on the probe-answered arm; events=" +
+                    diagnostics.events.map { it.name },
+                diagnostics.eventsNamed("network_restore_reconnect_start").isEmpty() &&
+                    diagnostics.eventsNamed("reconnect_start").isEmpty(),
+            )
+            val rideThrough = diagnostics.eventsNamed("network_restore_ride_through")
+            assertTrue(
+                "expected a network_restore_ride_through (proves arm 2 fired, not a vacuous " +
+                    "pass); events=${diagnostics.events.map { it.name }}",
+                rideThrough.isNotEmpty(),
+            )
+            assertEquals(
+                "the ride-through must be attributed to the bounded probe answering " +
+                    "(distinguishes arm 2 from the proven-alive arm 1)",
+                "probe_answered",
+                rideThrough.single().fields["cause"],
+            )
+        } finally {
+            diagnostics.close()
+            vm.forceTransportProvenAliveForTest = null
+        }
     }
 
     @Test

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
@@ -5602,22 +5602,48 @@ class TmuxSessionViewModelTest {
                 }
             }
 
-            val completed = withTimeoutOrNull(SLOW_FEED_DRAIN_TIMEOUT_MS) {
-                while (sender.isActive) {
-                    shadowOf(Looper.getMainLooper()).idle()
-                    runCurrent()
-                    delay(10)
+            // Issue #1042 follow-up (CI-only flake, PR #1045): the live `%output`
+            // drain feeds the REAL SshTerminalBridge, whose tail render runs on a
+            // wall-clock background thread and whose budgeted main-thread drain
+            // reposts a `postDelayed` continuation that a bare `idle()` never fires.
+            // The old pump here was bounded ONLY by the virtual `runTest` clock
+            // (`delay(10)` + a virtual `withTimeoutOrNull`), so the entire loop
+            // elapsed in ~0 wall-clock time and gave the background feed no real
+            // time to drain — under a contended JVM (CI) the sender stayed suspended
+            // behind the full SharedFlow buffer and `completed` flaked false (the
+            // pre-existing real-dispatcher-vs-virtual-clock race the sibling
+            // `codexLike...` test documents; #1042's network-change-only diff cannot
+            // reach this path). Pump on the WALL clock instead: advance the looper a
+            // frame (`idleFor(16ms)`) so the budgeted continuations fire, drive the
+            // virtual scheduler (`runCurrent()`) so the sender coroutine progresses,
+            // and give the background thread real time (`Thread.sleep`). This
+            // STRENGTHENS the assertion — a genuine stall still exhausts the deadline
+            // and `completed` stays false.
+            var completed = false
+            val drainDeadline = System.currentTimeMillis() + SLOW_FEED_DRAIN_TIMEOUT_MS
+            do {
+                shadowOf(Looper.getMainLooper())
+                    .idleFor(16L, java.util.concurrent.TimeUnit.MILLISECONDS)
+                runCurrent()
+                if (!sender.isActive) {
+                    completed = true
+                    break
                 }
+                Thread.sleep(20)
+            } while (System.currentTimeMillis() < drainDeadline)
+            if (completed) {
                 sender.await()
-                true
-            } ?: false
+            } else {
+                sender.cancel()
+            }
 
             assertTrue(
                 "tmux %output flood must not stall terminal pane output",
                 completed,
             )
             advanceUntilIdle()
-            shadowOf(Looper.getMainLooper()).idle()
+            shadowOf(Looper.getMainLooper())
+                .idleFor(16L, java.util.concurrent.TimeUnit.MILLISECONDS)
 
             assertTrue(
                 "tmux %output flood should still publish best-effort side-channel chunks",
@@ -5699,30 +5725,39 @@ class TmuxSessionViewModelTest {
                     }
                 }
 
-                val completed = withTimeoutOrNull(SLOW_FEED_DRAIN_TIMEOUT_MS) {
-                    while (sender.isActive) {
-                        // Issue #803/#804: the off-main live `%output` drain is now
-                        // frame-paced — the MainThreadDrainScheduler `postDelayed`s its
-                        // continuation one frame (16ms) out between bounded parse turns
-                        // so the looper is guaranteed a servicing gap (the ANR fix).
-                        // Under the Robolectric PAUSED looper a plain `idle()` only runs
-                        // tasks already DUE, so it never fires those delayed
-                        // continuations and the 64KB process queue stays full, blocking
-                        // the real off-main producer forever. Advance the virtual main
-                        // looper one frame per pump (as SshTerminalBridgeTest.
-                        // drainMainLooperUntil does) so the budgeted continuations fire
-                        // and the burst drains. This models a real device looper that
-                        // advances time; it does NOT weaken the assertion — if the burst
-                        // genuinely stalled behind the slow side-channel the loop still
-                        // times out and `completed` stays false.
-                        shadowOf(Looper.getMainLooper())
-                            .idleFor(16L, java.util.concurrent.TimeUnit.MILLISECONDS)
-                        runCurrent()
-                        delay(10)
+                // Issue #1042 follow-up (CI-only flake, PR #1045): the off-main live
+                // `%output` drain is frame-paced — the MainThreadDrainScheduler
+                // `postDelayed`s its continuation one frame (16ms) out between bounded
+                // parse turns so the looper is guaranteed a servicing gap (the #803/#804
+                // ANR fix). Under the Robolectric PAUSED looper a plain `idle()` only
+                // runs tasks already DUE, so the looper MUST be advanced a frame
+                // (`idleFor(16ms)`) for those delayed continuations to fire and the
+                // burst to drain. The pump ALSO drives the real off-main SshTerminalBridge
+                // feed (a wall-clock background thread). The old budget here was the
+                // virtual `runTest` clock (`delay(10)` + a virtual `withTimeoutOrNull`),
+                // which elapsed in ~0 wall-clock time and starved that background thread
+                // under a contended JVM (CI) — the sender stayed suspended behind the
+                // full SharedFlow buffer and `completed` flaked false. Pump on the WALL
+                // clock instead so the background feed gets real time (`Thread.sleep`),
+                // mirroring the marker loop below. This does NOT weaken the assertion: a
+                // genuine stall still exhausts the deadline and `completed` stays false.
+                var completed = false
+                val drainDeadline = System.currentTimeMillis() + SLOW_FEED_DRAIN_TIMEOUT_MS
+                do {
+                    shadowOf(Looper.getMainLooper())
+                        .idleFor(16L, java.util.concurrent.TimeUnit.MILLISECONDS)
+                    runCurrent()
+                    if (!sender.isActive) {
+                        completed = true
+                        break
                     }
+                    Thread.sleep(20)
+                } while (System.currentTimeMillis() < drainDeadline)
+                if (completed) {
                     sender.await()
-                    true
-                } ?: false
+                } else {
+                    sender.cancel()
+                }
 
                 assertTrue(
                     "Codex-like tmux %output burst must not stall behind a slow terminal side-channel",

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -594,7 +594,28 @@ JOURNEY_CLASSES=(
   # back to Connected with a painted viewport. RED on base (loss + same-identity
   # restore both swallowed → no NetworkLost, no fast reconnect); GREEN after #997.
   # Same deterministic agents:2222 fixture; runs on CI.
+  #
+  # ISSUE #1042: this class is now the GENUINELY-DEAD-SOCKET preservation guard —
+  # it synthetically injects a dead transport across the restore (keepalive
+  # NOT-proven-alive + the bounded restore probe DEAD) so the #1042 liveness-first
+  # gate must fall through to the #997 fresh-lease redial. The companion
+  # ride-through (socket SURVIVED ⇒ NO redial) journey is below.
   "$FQCN_PREFIX.BareNetworkLossRestoreReconnectE2eTest"
+  # ADDED (#1042): stop SPURIOUS reconnects on mobile/cellular when the link/socket
+  # ACTUALLY SURVIVED the dip. Three deterministic agents:2222 journeys (no toxiproxy,
+  # synthetic snapshot injection through the production TerminalNetworkObserver — the
+  # #780 hard-inject model, no self-skip):
+  #   (a) a brief NetworkLost→NetworkRestored where the transport SURVIVED (keepalive
+  #       pinned proven-alive) → the #1042 liveness-first restore RIDES THROUGH with NO
+  #       redial. RED on base (the restore arm redialled unconditionally →
+  #       network_restore_reconnect_start); GREEN with #1042 (network_restore_ride_through,
+  #       ZERO redial diagnostics).
+  #   (c) a {CELLULAR}→{CELLULAR} same-transport reassoc (new handle) is SUPPRESSED by
+  #       the detector → no event → no redial. RED on base (the same-identity relaxation
+  #       was pure-{WIFI}-only → network_reconnect_start); GREEN with #1042.
+  #   (d) the scope guard: a REAL cross-transport WIFI↔CELLULAR handoff STILL redials
+  #       (network_reconnect_start) — the #548 proactive-handoff feature is preserved.
+  "$FQCN_PREFIX.MobileSpuriousReconnectE2eTest"
   # ADDED (#970): the realistic-wifi STABILITY regression gate — the durable proof
   # for #964 (D31/D32/D33). Only the DETERMINISTIC method is run by FQCN here; it
   # reproduces the #964 budget mismatch on the plain deterministic agents:2222


### PR DESCRIPTION
Closes #1042. Directly serves the goal: no constant reconnects on mobile internet.

## Problem
On cellular the device dips into no-validated-network constantly (tunnels, elevators, RAT handovers, congestion re-validation) WITHOUT the TCP socket dying. The pre-#1042 `NetworkRestored` path redialed **unconditionally** (fresh lease, bypassing the proven-alive gate) on every such blip, and a `{CELLULAR}` reassoc that minted a new network handle on a stable link was treated as a real handoff — both = "constant reconnects on mobile internet".

## Fix
- **Liveness-first restore** (`scheduleNetworkReconnectOnRestore`): ride through with NO redial when the keepalive is proven alive, or after a single bounded (2s) probe answers; only force the #997 fresh-lease redial when the transport does not answer. A genuinely dead post-outage socket still reconnects.
- **Same-identity suppression** extended from pure `{WIFI}` to `{WIFI}` or `{CELLULAR}` (and dual-stack v4↔v6); cross-transport WIFI↔CELLULAR + VPN/multi-transport keep the strict handle check.

## Tests (reviewer-validated, all 3 restore arms covered)
- `MobileSpuriousReconnectE2eTest`: proven-alive ride-through, probe-answered ride-through (headline quiet-cellular arm), cellular reassoc, cross-transport handoff redials — reproduce-first red→green on emulator+Docker.
- Reworked `BareNetworkLossRestoreReconnectE2eTest` dies-case green (#997 preserved).
- VM unit tests for both ride-through arms + detector scope guards.
- Full JVM: app 3110 / core-ssh / core-tmux, 0 failed. Rebased on `main` post-#1043 (clean).

Reviewer (D28 rigor) independently confirmed red→green, #997 + cross-transport preserved, and the 2s probe cannot wedge.