### PR TITLE
core-ssh: exec read no-progress budget (mobile cause #3 — stop slow execs cascade-dropping the lease)

### DIFF
--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshSession.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshSession.kt
@@ -528,76 +528,58 @@ internal class RealSshSession(
             // forever, hanging the calling coroutine (and any caller that didn't
             // wrap us in its own timeout — six gateways did not).
             //
-            // Issue #1046: the bound is now a per-read NO-PROGRESS budget, NOT a
-            // whole-call wall-clock ceiling. The old design wrapped the ENTIRE
-            // read+join in one [WallClockCeiling] of [execReadTimeoutMs] and
-            // CLOSED the shared lease transport the instant the call exceeded that
-            // budget in TOTAL — so a slow-but-*progressing* control exec (large
-            // directory listing, `cat`, git probe) on a high-RTT cellular link
-            // could trip the ceiling, tear the shared `-CC` session, and trigger a
-            // spurious reconnect even though bytes were still arriving. That is a
-            // mobile spurious-reconnect cause. Upload/download already bound by
-            // no-progress windows (UPLOAD_/DOWNLOAD_STALL_TIMEOUT_MS); exec now
-            // mirrors that shape: the budget RESETS on every byte that arrives on
-            // EITHER stream, so a progressing exec keeps the transport alive for
-            // as long as it keeps making progress, and only a genuinely wedged
-            // read (no bytes on any stream for the whole window) is bounded. See
-            // [InputStream.readStepUnderStallBudget] / [ExecReadStallBudget].
+            // The bound is a REAL wall-clock watchdog ([WallClockCeiling]), NOT a
+            // coroutine `withTimeout`/`withTimeoutOrNull` (issue #940 / the #937
+            // regression). `withTimeout` reads the delay source from the CALLER's
+            // coroutine context — under `runTest`'s virtual, auto-advancing clock
+            // (every `:shared:core-ssh:integrationTest`) the ceiling fires
+            // INSTANTLY in virtual time and interrupts a HEALTHY live sshj read,
+            // aborting it as `InterruptedException` (the 13/21 integration-suite
+            // break). The wall-clock watchdog interrupts the worker thread only
+            // after [execReadTimeoutMs] of REAL elapsed time, identically in
+            // production and under any test scheduler, so a healthy read is never
+            // cut short while a genuinely-wedged read is still reclaimed. The body
+            // runs inside `runInterruptible(Dispatchers.IO)` so the watchdog's
+            // `Thread.interrupt()` actually unparks the blocking JDK read.
             //
-            // The mechanism is still the REAL wall-clock watchdog
-            // ([WallClockCeiling]), NOT a coroutine `withTimeout`/`withTimeoutOrNull`
-            // (issue #940 / the #937 regression): `withTimeout` reads the delay
-            // source from the CALLER's coroutine context, so under `runTest`'s
-            // virtual auto-advancing clock it fires INSTANTLY and aborts a HEALTHY
-            // live read. The watchdog interrupts the blocking worker only after
-            // REAL elapsed time, identically in production and under any test
-            // scheduler. The reads run on [execDrainExecutor] worker threads and
-            // the post-EOF join runs inside `runInterruptible(Dispatchers.IO)` so
-            // the watchdog's `Thread.interrupt()` actually unparks the blocking
-            // JDK read/join.
-            //
-            // On a genuine no-progress stall the read is mapped to a clear,
-            // RETRYABLE [SshExecTimeoutException], and we then CLOSE the session
-            // (lease pool self-heals — a now-disconnected session is discarded +
-            // re-dialed on next acquire). This is the SAME close-on-timeout intent
-            // the three bespoke gateway wraps (`FolderListGateway.execBounded`,
-            // `TreeRemoteSource`, `AgentKindRemoteSource`) implement per-caller —
-            // pulled down to the `exec` boundary so EVERY caller inherits it (D22
-            // hard-cut).
+            // On a real timeout the watchdog interrupt makes the read throw; that
+            // is mapped to a clear, RETRYABLE [SshExecTimeoutException], and we
+            // then CLOSE the session (lease pool self-heals — a now-disconnected
+            // session is discarded + re-dialed on next acquire). This is the SAME
+            // close-on-timeout intent the three bespoke gateway wraps
+            // (`FolderListGateway.execBounded`, `TreeRemoteSource`,
+            // `AgentKindRemoteSource`) implement per-caller — pulled down to the
+            // `exec` boundary so EVERY caller inherits it (D22 hard-cut), now with
+            // the wall-clock mechanism #940 established for the dispatcher.
             try {
                 runInterruptible(Dispatchers.IO) {
-                    val output = try {
-                        readExecOutputConcurrently(liveCommand, command)
-                    } finally {
-                        execDrainPermits.release()
-                        drainPermitAcquired = false
-                    }
-                    // Both streams have reached EOF, so the command has exited and
-                    // `join()` returns immediately; bound it with a fresh
-                    // no-progress window as belt-and-braces against a wedged join.
                     WallClockCeiling.runUnderWallClockCeiling(
                         timeoutMs = execReadTimeoutMs,
                         onTimeout = { cause -> SshExecTimeoutException(command, execReadTimeoutMs, cause) },
                     ) {
+                        val output = try {
+                            readExecOutputConcurrently(liveCommand)
+                        } finally {
+                            execDrainPermits.release()
+                            drainPermitAcquired = false
+                        }
                         liveCommand.join()
+                        // Issue #974: a completed exec round-trip is decoded server
+                        // bytes — proof the transport is alive. Record it so a busy
+                        // exec workload keeps the keepalive's inbound-activity
+                        // timestamp fresh (honouring the contract).
+                        recordInboundActivity()
+                        // sshj returns null exitStatus when the server didn't send
+                        // one (e.g. signal-killed). Map to -1 so the caller can
+                        // still tell it wasn't a clean 0.
+                        val exitCode = liveCommand.exitStatus ?: -1
+                        ExecResult(stdout = output.stdout, stderr = output.stderr, exitCode = exitCode)
                     }
-                    // Issue #974: a completed exec round-trip is decoded server
-                    // bytes — proof the transport is alive. Record it so a busy
-                    // exec workload keeps the keepalive's inbound-activity
-                    // timestamp fresh (honouring the contract). The per-chunk
-                    // drain also bumps this (issue #1046) so a long progressing
-                    // exec keeps the keepalive fresh throughout, not only at the end.
-                    recordInboundActivity()
-                    // sshj returns null exitStatus when the server didn't send
-                    // one (e.g. signal-killed). Map to -1 so the caller can
-                    // still tell it wasn't a clean 0.
-                    val exitCode = liveCommand.exitStatus ?: -1
-                    ExecResult(stdout = output.stdout, stderr = output.stderr, exitCode = exitCode)
                 }
             } catch (timeout: SshExecTimeoutException) {
                 EXEC_LOGGER.warning(
-                    "exec read made no progress for ${execReadTimeoutMs}ms (real wall-clock); closing " +
-                        "wedged session + surfacing retryable SshExecTimeoutException. cmd=${command.takeLast(48)}",
+                    "exec read wedged >${execReadTimeoutMs}ms (real wall-clock); closing wedged " +
+                        "session + surfacing retryable SshExecTimeoutException. cmd=${command.takeLast(48)}",
                 )
                 // CLOSE the session to tear down the transport so the lease pool
                 // discards the corpse (the watchdog already interrupted+unparked
@@ -643,21 +625,12 @@ internal class RealSshSession(
         }
     }
 
-    private fun readExecOutputConcurrently(command: Command, commandText: String): ExecOutput {
-        // Issue #1046: one no-progress budget SHARED across both concurrent
-        // drains. A byte on either stream resets it, so a long progressing exec
-        // (bytes trickling on stdout while stderr stays silent until exit) is
-        // never bounded by the slowest stream — only a genuine all-stream stall
-        // is. The budget bumps the keepalive's inbound-activity timestamp on each
-        // chunk so a busy exec keeps the transport's liveness fresh.
-        val stallBudget = ExecReadStallBudget(execReadTimeoutMs, onProgress = ::recordInboundActivity)
+    private fun readExecOutputConcurrently(command: Command): ExecOutput {
         val stdout = execDrainExecutor.submit<String> {
-            command.inputStream.readBytesCapped(EXEC_STREAM_MAX_BYTES, "stdout", commandText, stallBudget)
-                .toString(Charsets.UTF_8)
+            command.inputStream.readBytesCapped(EXEC_STREAM_MAX_BYTES, "stdout").toString(Charsets.UTF_8)
         }
         val stderr = execDrainExecutor.submit<String> {
-            command.errorStream.readBytesCapped(EXEC_STREAM_MAX_BYTES, "stderr", commandText, stallBudget)
-                .toString(Charsets.UTF_8)
+            command.errorStream.readBytesCapped(EXEC_STREAM_MAX_BYTES, "stderr").toString(Charsets.UTF_8)
         }
         return try {
             ExecOutput(
@@ -684,17 +657,12 @@ internal class RealSshSession(
             }
         }
 
-    private fun InputStream.readBytesCapped(
-        maxBytes: Int,
-        streamName: String,
-        commandText: String,
-        stallBudget: ExecReadStallBudget,
-    ): ByteArray {
+    private fun InputStream.readBytesCapped(maxBytes: Int, streamName: String): ByteArray {
         val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
         val output = ByteArrayOutputStream()
         var total = 0
         while (true) {
-            val read = readStepUnderStallBudget(buffer, commandText, stallBudget)
+            val read = read(buffer)
             if (read < 0) break
             if (total + read > maxBytes) {
                 throw SshException(
@@ -703,55 +671,8 @@ internal class RealSshSession(
             }
             output.write(buffer, 0, read)
             total += read
-            // A byte arrived — reset the SHARED no-progress budget (issue #1046)
-            // and bump the keepalive inbound-activity timestamp.
-            stallBudget.recordProgress()
         }
         return output.toByteArray()
-    }
-
-    /**
-     * Read one block under the per-read NO-PROGRESS budget (issue #1046).
-     *
-     * Each blocking `read` is bounded by a fresh [WallClockCeiling] of the budget
-     * window (interrupting only THIS worker thread, never another exec's reused
-     * pool thread). When a single read produces no byte for the window it is only
-     * treated as a wedged exec when NEITHER stream made progress within that
-     * window: stderr is typically silent until the command exits, so its single
-     * blocking read parks for the whole command duration while stdout keeps
-     * flowing — re-arming on the other stream's progress keeps a slow-but-
-     * progressing exec alive indefinitely, exactly like the upload/download
-     * per-step stall budgets. This REPLACES the old whole-call wall-clock ceiling
-     * that closed the shared lease transport whenever a progressing exec exceeded
-     * the budget in TOTAL.
-     *
-     * A genuinely silent-and-slow command (no output for the whole window) is
-     * still bounded — that was already true under the old whole-call ceiling, so
-     * this is no regression for the no-progress case while it fixes the
-     * progressing case.
-     */
-    private fun InputStream.readStepUnderStallBudget(
-        buffer: ByteArray,
-        commandText: String,
-        stallBudget: ExecReadStallBudget,
-    ): Int {
-        while (true) {
-            try {
-                return WallClockCeiling.runUnderWallClockCeiling(
-                    timeoutMs = stallBudget.windowMs,
-                    onTimeout = { cause -> ExecReadStallSignal(cause) },
-                ) {
-                    read(buffer)
-                }
-            } catch (stall: ExecReadStallSignal) {
-                // No byte on THIS stream for the window. As long as SOME stream
-                // made progress within the window the exec is still alive — re-arm
-                // and keep waiting. Only when NEITHER stream progressed for the
-                // whole window is the read genuinely wedged.
-                if (stallBudget.progressedWithinWindow()) continue
-                throw SshExecTimeoutException(commandText, stallBudget.windowMs, stall.cause)
-            }
-        }
     }
 
     private data class ExecOutput(
@@ -2031,21 +1952,10 @@ internal const val CLOSE_LOG_TAG: String = "issue239-close-teardown"
  * RETRYABLE [SshExecTimeoutException]. On expiry the session is closed so the
  * lease pool discards the corpse and re-dials on the next acquire.
  *
- * Issue #1046: this is now a per-read NO-PROGRESS window, NOT a whole-call
- * wall-clock ceiling. The budget RESETS on every byte that arrives on either
- * stream, so a slow-but-progressing exec on a high-RTT cellular link keeps the
- * shared lease transport alive for as long as it keeps making progress; only a
- * genuinely wedged read (no bytes on any stream for the whole window) is
- * bounded. The old whole-call ceiling closed the shared `-CC` session whenever a
- * progressing control exec exceeded 30s in TOTAL — a mobile spurious-reconnect
- * cause. This mirrors the per-step no-progress shape the transfer path already
- * uses ([UPLOAD_STALL_TIMEOUT_MS] / [DOWNLOAD_STALL_TIMEOUT_MS]).
- *
- * 30s is a generous no-progress window relative to a normal control exec (tens
- * of ms between bytes — env edit, profile list, start-dir autocomplete,
- * manual-kind write, watched-folder discovery, the file-viewer
- * `mkdir`/`pwd`/`cat`) yet bounds a truly wedged transport. It sits ABOVE the
- * three bespoke per-caller wraps
+ * 30s is generous relative to a normal control exec (tens of ms — env edit,
+ * profile list, start-dir autocomplete, manual-kind write, watched-folder
+ * discovery, the file-viewer `mkdir`/`pwd`/`cat`) yet bounds an indefinite
+ * hang. It sits ABOVE the three bespoke per-caller wraps
  * ([com.pocketshell.app.projects.SshFolderListGateway]'s `EXEC_READ_TIMEOUT_MS`
  * = 3.5s, `TreeRemoteSource`, `AgentKindRemoteSource`) so those tighter,
  * latency-sensitive enumeration bounds still fire FIRST on their hot paths and
@@ -2065,50 +1975,6 @@ private class TransferStallTimeoutException(
     val timeoutMs: Long,
     cause: Throwable?,
 ) : IOException("$operation made no progress for ${timeoutMs}ms", cause)
-
-/**
- * Internal signal raised when a single exec read step (one blocking `read`)
- * produces no byte for the no-progress window (issue #1046). Caught locally in
- * [RealSshSession.readStepUnderStallBudget]; it never escapes a reader thread —
- * it is either re-armed (some stream still progressing) or converted into a
- * [SshExecTimeoutException] (the whole exec is wedged).
- */
-private class ExecReadStallSignal(cause: Throwable?) : RuntimeException(cause)
-
-/**
- * Shared NO-PROGRESS budget across an exec's concurrent stdout + stderr drain
- * (issue #1046).
- *
- * The exec read drains two streams concurrently. stderr is typically silent
- * until the command exits — its single blocking `read` parks for the whole
- * command duration — so the budget must reset on progress from EITHER stream
- * rather than per individual read; a per-stream per-read budget would false-trip
- * a long-but-progressing stdout while stderr waits for EOF. A byte on either
- * stream pushes [lastProgressNanos] forward, so a progressing exec is never
- * bounded by the slowest stream; only an all-stream stall for the whole
- * [windowMs] is treated as a wedged transport. This mirrors the per-step
- * no-progress shape the transfer path uses
- * ([UPLOAD_STALL_TIMEOUT_MS] / [DOWNLOAD_STALL_TIMEOUT_MS]).
- */
-private class ExecReadStallBudget(
-    val windowMs: Long,
-    private val onProgress: () -> Unit,
-) {
-    private val windowNanos = windowMs * 1_000_000L
-
-    @Volatile
-    private var lastProgressNanos = System.nanoTime()
-
-    /** A byte arrived on some stream — reset the shared window. */
-    fun recordProgress() {
-        lastProgressNanos = System.nanoTime()
-        onProgress()
-    }
-
-    /** True iff SOME stream made progress within the last [windowMs]. */
-    fun progressedWithinWindow(): Boolean =
-        System.nanoTime() - lastProgressNanos < windowNanos
-}
 
 /**
  * Hard ceiling on the caller-visible wait inside [RealSshSession.close] for the

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshSession.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshSession.kt
@@ -528,58 +528,76 @@ internal class RealSshSession(
             // forever, hanging the calling coroutine (and any caller that didn't
             // wrap us in its own timeout — six gateways did not).
             //
-            // The bound is a REAL wall-clock watchdog ([WallClockCeiling]), NOT a
-            // coroutine `withTimeout`/`withTimeoutOrNull` (issue #940 / the #937
-            // regression). `withTimeout` reads the delay source from the CALLER's
-            // coroutine context — under `runTest`'s virtual, auto-advancing clock
-            // (every `:shared:core-ssh:integrationTest`) the ceiling fires
-            // INSTANTLY in virtual time and interrupts a HEALTHY live sshj read,
-            // aborting it as `InterruptedException` (the 13/21 integration-suite
-            // break). The wall-clock watchdog interrupts the worker thread only
-            // after [execReadTimeoutMs] of REAL elapsed time, identically in
-            // production and under any test scheduler, so a healthy read is never
-            // cut short while a genuinely-wedged read is still reclaimed. The body
-            // runs inside `runInterruptible(Dispatchers.IO)` so the watchdog's
-            // `Thread.interrupt()` actually unparks the blocking JDK read.
+            // Issue #1046: the bound is now a per-read NO-PROGRESS budget, NOT a
+            // whole-call wall-clock ceiling. The old design wrapped the ENTIRE
+            // read+join in one [WallClockCeiling] of [execReadTimeoutMs] and
+            // CLOSED the shared lease transport the instant the call exceeded that
+            // budget in TOTAL — so a slow-but-*progressing* control exec (large
+            // directory listing, `cat`, git probe) on a high-RTT cellular link
+            // could trip the ceiling, tear the shared `-CC` session, and trigger a
+            // spurious reconnect even though bytes were still arriving. That is a
+            // mobile spurious-reconnect cause. Upload/download already bound by
+            // no-progress windows (UPLOAD_/DOWNLOAD_STALL_TIMEOUT_MS); exec now
+            // mirrors that shape: the budget RESETS on every byte that arrives on
+            // EITHER stream, so a progressing exec keeps the transport alive for
+            // as long as it keeps making progress, and only a genuinely wedged
+            // read (no bytes on any stream for the whole window) is bounded. See
+            // [InputStream.readStepUnderStallBudget] / [ExecReadStallBudget].
             //
-            // On a real timeout the watchdog interrupt makes the read throw; that
-            // is mapped to a clear, RETRYABLE [SshExecTimeoutException], and we
-            // then CLOSE the session (lease pool self-heals — a now-disconnected
-            // session is discarded + re-dialed on next acquire). This is the SAME
-            // close-on-timeout intent the three bespoke gateway wraps
-            // (`FolderListGateway.execBounded`, `TreeRemoteSource`,
-            // `AgentKindRemoteSource`) implement per-caller — pulled down to the
-            // `exec` boundary so EVERY caller inherits it (D22 hard-cut), now with
-            // the wall-clock mechanism #940 established for the dispatcher.
+            // The mechanism is still the REAL wall-clock watchdog
+            // ([WallClockCeiling]), NOT a coroutine `withTimeout`/`withTimeoutOrNull`
+            // (issue #940 / the #937 regression): `withTimeout` reads the delay
+            // source from the CALLER's coroutine context, so under `runTest`'s
+            // virtual auto-advancing clock it fires INSTANTLY and aborts a HEALTHY
+            // live read. The watchdog interrupts the blocking worker only after
+            // REAL elapsed time, identically in production and under any test
+            // scheduler. The reads run on [execDrainExecutor] worker threads and
+            // the post-EOF join runs inside `runInterruptible(Dispatchers.IO)` so
+            // the watchdog's `Thread.interrupt()` actually unparks the blocking
+            // JDK read/join.
+            //
+            // On a genuine no-progress stall the read is mapped to a clear,
+            // RETRYABLE [SshExecTimeoutException], and we then CLOSE the session
+            // (lease pool self-heals — a now-disconnected session is discarded +
+            // re-dialed on next acquire). This is the SAME close-on-timeout intent
+            // the three bespoke gateway wraps (`FolderListGateway.execBounded`,
+            // `TreeRemoteSource`, `AgentKindRemoteSource`) implement per-caller —
+            // pulled down to the `exec` boundary so EVERY caller inherits it (D22
+            // hard-cut).
             try {
                 runInterruptible(Dispatchers.IO) {
+                    val output = try {
+                        readExecOutputConcurrently(liveCommand, command)
+                    } finally {
+                        execDrainPermits.release()
+                        drainPermitAcquired = false
+                    }
+                    // Both streams have reached EOF, so the command has exited and
+                    // `join()` returns immediately; bound it with a fresh
+                    // no-progress window as belt-and-braces against a wedged join.
                     WallClockCeiling.runUnderWallClockCeiling(
                         timeoutMs = execReadTimeoutMs,
                         onTimeout = { cause -> SshExecTimeoutException(command, execReadTimeoutMs, cause) },
                     ) {
-                        val output = try {
-                            readExecOutputConcurrently(liveCommand)
-                        } finally {
-                            execDrainPermits.release()
-                            drainPermitAcquired = false
-                        }
                         liveCommand.join()
-                        // Issue #974: a completed exec round-trip is decoded server
-                        // bytes — proof the transport is alive. Record it so a busy
-                        // exec workload keeps the keepalive's inbound-activity
-                        // timestamp fresh (honouring the contract).
-                        recordInboundActivity()
-                        // sshj returns null exitStatus when the server didn't send
-                        // one (e.g. signal-killed). Map to -1 so the caller can
-                        // still tell it wasn't a clean 0.
-                        val exitCode = liveCommand.exitStatus ?: -1
-                        ExecResult(stdout = output.stdout, stderr = output.stderr, exitCode = exitCode)
                     }
+                    // Issue #974: a completed exec round-trip is decoded server
+                    // bytes — proof the transport is alive. Record it so a busy
+                    // exec workload keeps the keepalive's inbound-activity
+                    // timestamp fresh (honouring the contract). The per-chunk
+                    // drain also bumps this (issue #1046) so a long progressing
+                    // exec keeps the keepalive fresh throughout, not only at the end.
+                    recordInboundActivity()
+                    // sshj returns null exitStatus when the server didn't send
+                    // one (e.g. signal-killed). Map to -1 so the caller can
+                    // still tell it wasn't a clean 0.
+                    val exitCode = liveCommand.exitStatus ?: -1
+                    ExecResult(stdout = output.stdout, stderr = output.stderr, exitCode = exitCode)
                 }
             } catch (timeout: SshExecTimeoutException) {
                 EXEC_LOGGER.warning(
-                    "exec read wedged >${execReadTimeoutMs}ms (real wall-clock); closing wedged " +
-                        "session + surfacing retryable SshExecTimeoutException. cmd=${command.takeLast(48)}",
+                    "exec read made no progress for ${execReadTimeoutMs}ms (real wall-clock); closing " +
+                        "wedged session + surfacing retryable SshExecTimeoutException. cmd=${command.takeLast(48)}",
                 )
                 // CLOSE the session to tear down the transport so the lease pool
                 // discards the corpse (the watchdog already interrupted+unparked
@@ -625,12 +643,21 @@ internal class RealSshSession(
         }
     }
 
-    private fun readExecOutputConcurrently(command: Command): ExecOutput {
+    private fun readExecOutputConcurrently(command: Command, commandText: String): ExecOutput {
+        // Issue #1046: one no-progress budget SHARED across both concurrent
+        // drains. A byte on either stream resets it, so a long progressing exec
+        // (bytes trickling on stdout while stderr stays silent until exit) is
+        // never bounded by the slowest stream — only a genuine all-stream stall
+        // is. The budget bumps the keepalive's inbound-activity timestamp on each
+        // chunk so a busy exec keeps the transport's liveness fresh.
+        val stallBudget = ExecReadStallBudget(execReadTimeoutMs, onProgress = ::recordInboundActivity)
         val stdout = execDrainExecutor.submit<String> {
-            command.inputStream.readBytesCapped(EXEC_STREAM_MAX_BYTES, "stdout").toString(Charsets.UTF_8)
+            command.inputStream.readBytesCapped(EXEC_STREAM_MAX_BYTES, "stdout", commandText, stallBudget)
+                .toString(Charsets.UTF_8)
         }
         val stderr = execDrainExecutor.submit<String> {
-            command.errorStream.readBytesCapped(EXEC_STREAM_MAX_BYTES, "stderr").toString(Charsets.UTF_8)
+            command.errorStream.readBytesCapped(EXEC_STREAM_MAX_BYTES, "stderr", commandText, stallBudget)
+                .toString(Charsets.UTF_8)
         }
         return try {
             ExecOutput(
@@ -657,12 +684,17 @@ internal class RealSshSession(
             }
         }
 
-    private fun InputStream.readBytesCapped(maxBytes: Int, streamName: String): ByteArray {
+    private fun InputStream.readBytesCapped(
+        maxBytes: Int,
+        streamName: String,
+        commandText: String,
+        stallBudget: ExecReadStallBudget,
+    ): ByteArray {
         val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
         val output = ByteArrayOutputStream()
         var total = 0
         while (true) {
-            val read = read(buffer)
+            val read = readStepUnderStallBudget(buffer, commandText, stallBudget)
             if (read < 0) break
             if (total + read > maxBytes) {
                 throw SshException(
@@ -671,8 +703,55 @@ internal class RealSshSession(
             }
             output.write(buffer, 0, read)
             total += read
+            // A byte arrived — reset the SHARED no-progress budget (issue #1046)
+            // and bump the keepalive inbound-activity timestamp.
+            stallBudget.recordProgress()
         }
         return output.toByteArray()
+    }
+
+    /**
+     * Read one block under the per-read NO-PROGRESS budget (issue #1046).
+     *
+     * Each blocking `read` is bounded by a fresh [WallClockCeiling] of the budget
+     * window (interrupting only THIS worker thread, never another exec's reused
+     * pool thread). When a single read produces no byte for the window it is only
+     * treated as a wedged exec when NEITHER stream made progress within that
+     * window: stderr is typically silent until the command exits, so its single
+     * blocking read parks for the whole command duration while stdout keeps
+     * flowing — re-arming on the other stream's progress keeps a slow-but-
+     * progressing exec alive indefinitely, exactly like the upload/download
+     * per-step stall budgets. This REPLACES the old whole-call wall-clock ceiling
+     * that closed the shared lease transport whenever a progressing exec exceeded
+     * the budget in TOTAL.
+     *
+     * A genuinely silent-and-slow command (no output for the whole window) is
+     * still bounded — that was already true under the old whole-call ceiling, so
+     * this is no regression for the no-progress case while it fixes the
+     * progressing case.
+     */
+    private fun InputStream.readStepUnderStallBudget(
+        buffer: ByteArray,
+        commandText: String,
+        stallBudget: ExecReadStallBudget,
+    ): Int {
+        while (true) {
+            try {
+                return WallClockCeiling.runUnderWallClockCeiling(
+                    timeoutMs = stallBudget.windowMs,
+                    onTimeout = { cause -> ExecReadStallSignal(cause) },
+                ) {
+                    read(buffer)
+                }
+            } catch (stall: ExecReadStallSignal) {
+                // No byte on THIS stream for the window. As long as SOME stream
+                // made progress within the window the exec is still alive — re-arm
+                // and keep waiting. Only when NEITHER stream progressed for the
+                // whole window is the read genuinely wedged.
+                if (stallBudget.progressedWithinWindow()) continue
+                throw SshExecTimeoutException(commandText, stallBudget.windowMs, stall.cause)
+            }
+        }
     }
 
     private data class ExecOutput(
@@ -1952,10 +2031,21 @@ internal const val CLOSE_LOG_TAG: String = "issue239-close-teardown"
  * RETRYABLE [SshExecTimeoutException]. On expiry the session is closed so the
  * lease pool discards the corpse and re-dials on the next acquire.
  *
- * 30s is generous relative to a normal control exec (tens of ms — env edit,
- * profile list, start-dir autocomplete, manual-kind write, watched-folder
- * discovery, the file-viewer `mkdir`/`pwd`/`cat`) yet bounds an indefinite
- * hang. It sits ABOVE the three bespoke per-caller wraps
+ * Issue #1046: this is now a per-read NO-PROGRESS window, NOT a whole-call
+ * wall-clock ceiling. The budget RESETS on every byte that arrives on either
+ * stream, so a slow-but-progressing exec on a high-RTT cellular link keeps the
+ * shared lease transport alive for as long as it keeps making progress; only a
+ * genuinely wedged read (no bytes on any stream for the whole window) is
+ * bounded. The old whole-call ceiling closed the shared `-CC` session whenever a
+ * progressing control exec exceeded 30s in TOTAL — a mobile spurious-reconnect
+ * cause. This mirrors the per-step no-progress shape the transfer path already
+ * uses ([UPLOAD_STALL_TIMEOUT_MS] / [DOWNLOAD_STALL_TIMEOUT_MS]).
+ *
+ * 30s is a generous no-progress window relative to a normal control exec (tens
+ * of ms between bytes — env edit, profile list, start-dir autocomplete,
+ * manual-kind write, watched-folder discovery, the file-viewer
+ * `mkdir`/`pwd`/`cat`) yet bounds a truly wedged transport. It sits ABOVE the
+ * three bespoke per-caller wraps
  * ([com.pocketshell.app.projects.SshFolderListGateway]'s `EXEC_READ_TIMEOUT_MS`
  * = 3.5s, `TreeRemoteSource`, `AgentKindRemoteSource`) so those tighter,
  * latency-sensitive enumeration bounds still fire FIRST on their hot paths and
@@ -1975,6 +2065,50 @@ private class TransferStallTimeoutException(
     val timeoutMs: Long,
     cause: Throwable?,
 ) : IOException("$operation made no progress for ${timeoutMs}ms", cause)
+
+/**
+ * Internal signal raised when a single exec read step (one blocking `read`)
+ * produces no byte for the no-progress window (issue #1046). Caught locally in
+ * [RealSshSession.readStepUnderStallBudget]; it never escapes a reader thread —
+ * it is either re-armed (some stream still progressing) or converted into a
+ * [SshExecTimeoutException] (the whole exec is wedged).
+ */
+private class ExecReadStallSignal(cause: Throwable?) : RuntimeException(cause)
+
+/**
+ * Shared NO-PROGRESS budget across an exec's concurrent stdout + stderr drain
+ * (issue #1046).
+ *
+ * The exec read drains two streams concurrently. stderr is typically silent
+ * until the command exits — its single blocking `read` parks for the whole
+ * command duration — so the budget must reset on progress from EITHER stream
+ * rather than per individual read; a per-stream per-read budget would false-trip
+ * a long-but-progressing stdout while stderr waits for EOF. A byte on either
+ * stream pushes [lastProgressNanos] forward, so a progressing exec is never
+ * bounded by the slowest stream; only an all-stream stall for the whole
+ * [windowMs] is treated as a wedged transport. This mirrors the per-step
+ * no-progress shape the transfer path uses
+ * ([UPLOAD_STALL_TIMEOUT_MS] / [DOWNLOAD_STALL_TIMEOUT_MS]).
+ */
+private class ExecReadStallBudget(
+    val windowMs: Long,
+    private val onProgress: () -> Unit,
+) {
+    private val windowNanos = windowMs * 1_000_000L
+
+    @Volatile
+    private var lastProgressNanos = System.nanoTime()
+
+    /** A byte arrived on some stream — reset the shared window. */
+    fun recordProgress() {
+        lastProgressNanos = System.nanoTime()
+        onProgress()
+    }
+
+    /** True iff SOME stream made progress within the last [windowMs]. */
+    fun progressedWithinWindow(): Boolean =
+        System.nanoTime() - lastProgressNanos < windowNanos
+}
 
 /**
  * Hard ceiling on the caller-visible wait inside [RealSshSession.close] for the

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshException.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshException.kt
@@ -44,12 +44,16 @@ public class SshFileTooLargeException(
 )
 
 /**
- * Thrown by [SshSession.exec] when the command's stdout/stderr read does not
- * reach EOF within the per-exec wall-clock ceiling (#935 S4-2). A half-open /
+ * Thrown by [SshSession.exec] when the command's stdout/stderr read makes NO
+ * PROGRESS for the per-read no-progress budget (#935 S4-2; #1046). A half-open /
  * wedged transport leaves the blocking `readBytes()` parked forever; this
  * timeout is the boundary bound that turns "the action silently never returns"
  * into a fast, clear, RETRYABLE failure. The session is closed on the way out
  * so the lease pool discards the corpse and re-dials on the next acquire.
+ *
+ * Issue #1046: [timeoutMs] is now the per-read NO-PROGRESS window, not a
+ * whole-call ceiling — a slow-but-progressing exec (bytes still arriving) is
+ * NOT bounded, so this is raised only for a genuinely stalled read.
  *
  * A subclass of [SshException] so existing catch-all `catch (e: SshException)`
  * sites keep working; lease-exec retry logic catches it specifically to treat a
@@ -60,6 +64,6 @@ public class SshExecTimeoutException(
     public val timeoutMs: Long,
     cause: Throwable? = null,
 ) : SshException(
-    "exec read wedged >${timeoutMs}ms (no EOF): ${command.takeLast(64)}",
+    "exec read made no progress for ${timeoutMs}ms: ${command.takeLast(64)}",
     cause,
 )

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshException.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshException.kt
@@ -44,16 +44,12 @@ public class SshFileTooLargeException(
 )
 
 /**
- * Thrown by [SshSession.exec] when the command's stdout/stderr read makes NO
- * PROGRESS for the per-read no-progress budget (#935 S4-2; #1046). A half-open /
+ * Thrown by [SshSession.exec] when the command's stdout/stderr read does not
+ * reach EOF within the per-exec wall-clock ceiling (#935 S4-2). A half-open /
  * wedged transport leaves the blocking `readBytes()` parked forever; this
  * timeout is the boundary bound that turns "the action silently never returns"
  * into a fast, clear, RETRYABLE failure. The session is closed on the way out
  * so the lease pool discards the corpse and re-dials on the next acquire.
- *
- * Issue #1046: [timeoutMs] is now the per-read NO-PROGRESS window, not a
- * whole-call ceiling — a slow-but-progressing exec (bytes still arriving) is
- * NOT bounded, so this is raised only for a genuinely stalled read.
  *
  * A subclass of [SshException] so existing catch-all `catch (e: SshException)`
  * sites keep working; lease-exec retry logic catches it specifically to treat a
@@ -64,6 +60,6 @@ public class SshExecTimeoutException(
     public val timeoutMs: Long,
     cause: Throwable? = null,
 ) : SshException(
-    "exec read made no progress for ${timeoutMs}ms: ${command.takeLast(64)}",
+    "exec read wedged >${timeoutMs}ms (no EOF): ${command.takeLast(64)}",
     cause,
 )

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshSessionExecReadTimeoutTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshSessionExecReadTimeoutTest.kt
@@ -136,6 +136,59 @@ class RealSshSessionExecReadTimeoutTest {
     }
 
     /**
+     * Keystone for #1046's shared-budget re-arm (AC3 — the real mobile scenario).
+     *
+     * stderr is PARKED silent (no data, no EOF) across the WHOLE no-progress
+     * window while stdout keeps trickling bytes at sub-window gaps for a total
+     * duration exceeding the window — i.e. a long stdout-heavy `cat`/listing/git
+     * probe with silent stderr on a slow link. The shared no-progress budget
+     * resets off stdout's progress, so stderr's parked read is re-armed
+     * (`if (stallBudget.progressedWithinWindow()) continue` in
+     * `readStepUnderStallBudget`) rather than tripping the budget; both streams
+     * EOF when the command completes and the exec succeeds WITHOUT tearing the
+     * transport.
+     *
+     * This PINS the shared-budget design: under a naive per-stream budget (each
+     * stream bounded by its OWN window, no cross-stream re-arm) the parked stderr
+     * read would trip at the window and throw [SshExecTimeoutException] + close
+     * the session even though stdout is progressing — the exact false
+     * spurious-reconnect this issue fixes. Removing the re-arm `continue` turns
+     * this test RED; the shipped shared budget keeps it GREEN.
+     */
+    @Test
+    fun `progressing stdout re-arms the shared budget while stderr is parked silent`() = runBlocking {
+        val command = SilentParkingStderrSlowStdoutCommand(chunkCount = 8, gapMillis = 100L)
+        val client = ConnectedClient(RecordingSessionChannel(command))
+        // window 500ms < total stdout duration (~800ms); stderr stays parked the
+        // whole time (longer than one window) yet must not bound the exec.
+        val session = RealSshSession(client, execReadTimeoutMs = 500L)
+
+        try {
+            val result = withTimeout(10_000L) {
+                session.exec("stdout-heavy-listing-silent-stderr")
+            }
+
+            assertEquals(
+                "every trickled stdout byte must be drained",
+                "x".repeat(8),
+                result.stdout,
+            )
+            assertEquals("silent stderr must drain to empty", "", result.stderr)
+            assertEquals(0, result.exitCode)
+            assertTrue(
+                "stderr must actually have parked silently (not instant EOF)",
+                command.stderrParked.isCompleted,
+            )
+            assertTrue(
+                "a parked-silent stderr must NOT trip the shared budget while stdout progresses",
+                session.isConnected,
+            )
+        } finally {
+            session.close()
+        }
+    }
+
+    /**
      * Class coverage for #1046: an exec that PROGRESSES for a while and THEN
      * wedges (no further bytes on either stream) must still be bounded and still
      * close the session — the no-progress budget must not be defeated by earlier
@@ -499,6 +552,104 @@ class RealSshSessionExecReadTimeoutTest {
 
         override fun close() {
             closed = true
+        }
+    }
+
+    /**
+     * Models the real #1046 mobile scenario (AC3): stdout trickles [chunkCount]
+     * single bytes (each after a sub-window [gapMillis] gap), while stderr is
+     * PARKED silent — it returns no bytes and does NOT EOF until the command
+     * completes (stdout reaches EOF). stderr therefore stays blocked across the
+     * whole no-progress window, and only the SHARED budget re-armed off stdout's
+     * progress keeps the exec alive. Both streams EOF when stdout finishes.
+     */
+    private class SilentParkingStderrSlowStdoutCommand(
+        chunkCount: Int,
+        gapMillis: Long,
+    ) : FakeChannel(), Session.Command {
+        val firstStdoutReadStarted = CompletableDeferred<Unit>()
+        val stderrParked = CompletableDeferred<Unit>()
+
+        @Volatile
+        private var closedFlag = false
+        private val stdoutComplete = java.util.concurrent.atomic.AtomicBoolean(false)
+        private val delivered = AtomicInteger(0)
+
+        private val stdout = object : InputStream() {
+            override fun read(): Int {
+                val one = ByteArray(1)
+                val n = read(one, 0, 1)
+                return if (n < 0) -1 else one[0].toInt() and 0xff
+            }
+
+            override fun read(b: ByteArray, off: Int, len: Int): Int {
+                firstStdoutReadStarted.complete(Unit)
+                if (delivered.get() >= chunkCount) {
+                    // All bytes delivered: the command has finished — signal EOF
+                    // and release the parked stderr.
+                    stdoutComplete.set(true)
+                    return -1
+                }
+                val deadlineNanos = System.nanoTime() + gapMillis * 1_000_000L
+                while (System.nanoTime() < deadlineNanos) {
+                    if (closedFlag) return -1
+                    try {
+                        Thread.sleep(5L)
+                    } catch (e: InterruptedException) {
+                        throw java.io.InterruptedIOException("stdout trickle interrupted")
+                    }
+                }
+                delivered.incrementAndGet()
+                b[off] = 'x'.code.toByte()
+                return 1
+            }
+
+            override fun close() {
+                closedFlag = true
+            }
+        }
+
+        private val stderr = object : InputStream() {
+            override fun read(): Int {
+                val one = ByteArray(1)
+                val n = read(one, 0, 1)
+                return if (n < 0) -1 else one[0].toInt() and 0xff
+            }
+
+            override fun read(b: ByteArray, off: Int, len: Int): Int {
+                stderrParked.complete(Unit)
+                // Park silently — no data, no EOF — until the command completes
+                // (stdout reached EOF). Honour interrupt so the per-read
+                // wall-clock watchdog can unpark us: under the SHARED budget the
+                // watchdog interrupts this parked read every window, the budget
+                // re-arms off stdout's progress, and we re-park here.
+                while (!stdoutComplete.get()) {
+                    if (closedFlag) return -1
+                    try {
+                        Thread.sleep(5L)
+                    } catch (e: InterruptedException) {
+                        throw java.io.InterruptedIOException("stderr parked read interrupted")
+                    }
+                }
+                return -1
+            }
+
+            override fun close() {
+                closedFlag = true
+            }
+        }
+
+        override fun getInputStream(): InputStream = stdout
+        override fun getErrorStream(): InputStream = stderr
+        override fun getExitErrorMessage(): String? = null
+        override fun getExitSignal(): Signal? = null
+        override fun getExitStatus(): Int = 0
+        override fun getExitWasCoreDumped(): Boolean = false
+        override fun signal(signal: Signal) = Unit
+
+        override fun close() {
+            super.close()
+            closedFlag = true
         }
     }
 

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshSessionExecReadTimeoutTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshSessionExecReadTimeoutTest.kt
@@ -87,6 +87,95 @@ class RealSshSessionExecReadTimeoutTest {
             }
         }
 
+    /**
+     * Reproduce-first regression for #1046: a slow-but-PROGRESSING exec (bytes
+     * trickle in, each gap below the no-progress budget, total far above the
+     * budget) must NOT trip the bound and must NOT cascade-close the shared lease
+     * transport.
+     *
+     * On BASE (old whole-call wall-clock ceiling) the entire read+join was wrapped
+     * in ONE [WallClockCeiling] of `execReadTimeoutMs`, so this exec — whose total
+     * duration (~800ms) exceeds the 500ms budget — trips the ceiling at 500ms,
+     * throws [SshExecTimeoutException], and CLOSES the session (red: the exec
+     * fails / the transport is torn). With the per-read no-progress budget each
+     * 100ms gap is well under the 500ms window, the budget resets on every byte,
+     * the exec completes, and the transport stays connected (green).
+     */
+    @Test
+    fun `slow but progressing exec keeps the transport alive past the budget`() = runBlocking {
+        val command = SlowProgressingCommand(chunkCount = 8, gapMillis = 100L)
+        val client = ConnectedClient(RecordingSessionChannel(command))
+        // Budget (500ms) is far below the exec's total duration (~800ms) but well
+        // above each inter-byte gap (100ms) — the regression's whole-call ceiling
+        // closes on total time; the no-progress budget survives because each step
+        // makes progress.
+        val session = RealSshSession(client, execReadTimeoutMs = 500L)
+
+        try {
+            val result = withTimeout(10_000L) {
+                session.exec("slow-but-progressing-listing")
+            }
+
+            assertEquals(
+                "every trickled byte must be drained (no whole-call ceiling cut)",
+                "x".repeat(8),
+                result.stdout,
+            )
+            assertEquals(0, result.exitCode)
+            assertTrue(
+                "the first read must actually have started (not failed on open)",
+                command.firstReadStarted.isCompleted,
+            )
+            assertTrue(
+                "a slow-but-progressing exec must NOT cascade-close the shared lease transport",
+                session.isConnected,
+            )
+        } finally {
+            session.close()
+        }
+    }
+
+    /**
+     * Class coverage for #1046: an exec that PROGRESSES for a while and THEN
+     * wedges (no further bytes on either stream) must still be bounded and still
+     * close the session — the no-progress budget must not be defeated by earlier
+     * progress. The budget resets while bytes flow, then bounds the final stall.
+     */
+    @Test
+    fun `exec that progresses then wedges is still bounded and closes the session`() = runBlocking {
+        val command = ProgressesThenWedgesCommand(chunkCount = 3, gapMillis = 100L)
+        val session = RealSshSession(
+            ConnectedClient(RecordingSessionChannel(command)),
+            execReadTimeoutMs = 400L,
+        )
+
+        try {
+            val thrown: SshExecTimeoutException = withTimeout(10_000L) {
+                try {
+                    session.exec("progress-then-wedge")
+                    throw AssertionError("a wedged-after-progress exec must not return")
+                } catch (e: SshExecTimeoutException) {
+                    e
+                }
+            }
+
+            assertTrue(
+                "the wedge must have followed real progress",
+                command.deliveredCount() >= 1,
+            )
+            assertTrue(
+                "timeout exception must carry the wedged command",
+                thrown.command.contains("progress-then-wedge"),
+            )
+            assertFalse(
+                "a mid-stream wedge must still close the session (lease self-heal)",
+                session.isConnected,
+            )
+        } finally {
+            session.close()
+        }
+    }
+
     @Test
     fun `exec drains stdout and stderr concurrently`() = runBlocking {
         val command = CoordinatedStdoutStderrCommand()
@@ -295,6 +384,121 @@ class RealSshSessionExecReadTimeoutTest {
         override fun close() {
             super.close()
             stdout.close()
+        }
+    }
+
+    /**
+     * Models a slow-but-PROGRESSING command (#1046): stdout yields [chunkCount]
+     * single bytes, each after a [gapMillis] gap (below the no-progress budget),
+     * then EOF. stderr is silent (empty). The total duration is `chunkCount *
+     * gapMillis`, deliberately set ABOVE the per-exec budget so a whole-call
+     * ceiling would close it while a per-read no-progress budget survives.
+     */
+    private class SlowProgressingCommand(
+        chunkCount: Int,
+        gapMillis: Long,
+    ) : FakeChannel(), Session.Command {
+        val firstReadStarted = CompletableDeferred<Unit>()
+        private val stdout = TricklingInputStream(firstReadStarted, chunkCount, gapMillis, wedgeAfter = false)
+
+        override fun getInputStream(): InputStream = stdout
+        override fun getErrorStream(): InputStream = ByteArrayInputStream(ByteArray(0))
+        override fun getExitErrorMessage(): String? = null
+        override fun getExitSignal(): Signal? = null
+        override fun getExitStatus(): Int = 0
+        override fun getExitWasCoreDumped(): Boolean = false
+        override fun signal(signal: Signal) = Unit
+
+        override fun close() {
+            super.close()
+            stdout.close()
+        }
+    }
+
+    /**
+     * Models a command that progresses then wedges (#1046): stdout yields
+     * [chunkCount] single bytes (each after [gapMillis]) and then parks forever
+     * (until interrupt/close). The no-progress budget must reset while bytes flow
+     * and then bound the final stall.
+     */
+    private class ProgressesThenWedgesCommand(
+        chunkCount: Int,
+        gapMillis: Long,
+    ) : FakeChannel(), Session.Command {
+        val firstReadStarted = CompletableDeferred<Unit>()
+        private val stdout = TricklingInputStream(firstReadStarted, chunkCount, gapMillis, wedgeAfter = true)
+
+        fun deliveredCount(): Int = stdout.deliveredCount()
+
+        override fun getInputStream(): InputStream = stdout
+        override fun getErrorStream(): InputStream = ByteArrayInputStream(ByteArray(0))
+        override fun getExitErrorMessage(): String? = null
+        override fun getExitSignal(): Signal? = null
+        override fun getExitStatus(): Int = 0
+        override fun getExitWasCoreDumped(): Boolean = false
+        override fun signal(signal: Signal) = Unit
+
+        override fun close() {
+            super.close()
+            stdout.close()
+        }
+    }
+
+    /**
+     * Trickles [chunkCount] single `x` bytes, one per blocking `read`, each after
+     * a [gapMillis] real-time gap. When [wedgeAfter] is true, after the last byte
+     * the stream parks indefinitely (no EOF) until closed/interrupted — modelling
+     * a command that progresses and then wedges. Otherwise it returns EOF after
+     * the last byte. The gap honours interruption so the per-read wall-clock
+     * watchdog (and the test's future cancel) can unpark a parked read.
+     */
+    private class TricklingInputStream(
+        private val firstReadStarted: CompletableDeferred<Unit>,
+        private val chunkCount: Int,
+        private val gapMillis: Long,
+        private val wedgeAfter: Boolean,
+    ) : InputStream() {
+        @Volatile
+        private var closed = false
+        private val delivered = AtomicInteger(0)
+
+        fun deliveredCount(): Int = delivered.get()
+
+        override fun read(): Int {
+            val one = ByteArray(1)
+            val n = read(one, 0, 1)
+            return if (n < 0) -1 else one[0].toInt() and 0xff
+        }
+
+        override fun read(b: ByteArray, off: Int, len: Int): Int {
+            firstReadStarted.complete(Unit)
+            if (delivered.get() >= chunkCount) {
+                // All bytes delivered: either wedge forever or signal EOF.
+                if (!wedgeAfter) return -1
+                while (!closed) {
+                    if (Thread.interrupted()) throw java.io.InterruptedIOException("wedged read interrupted")
+                    Thread.sleep(10L)
+                }
+                return -1
+            }
+            // Real-time inter-byte gap (below the no-progress budget). Honour
+            // interrupt so the wall-clock watchdog / future-cancel can unpark us.
+            val deadlineNanos = System.nanoTime() + gapMillis * 1_000_000L
+            while (System.nanoTime() < deadlineNanos) {
+                if (closed) return -1
+                try {
+                    Thread.sleep(5L)
+                } catch (e: InterruptedException) {
+                    throw java.io.InterruptedIOException("trickle read interrupted")
+                }
+            }
+            delivered.incrementAndGet()
+            b[off] = 'x'.code.toByte()
+            return 1
+        }
+
+        override fun close() {
+            closed = true
         }
     }
 


### PR DESCRIPTION
Closes #1046. Audit cause #3 toward the no-constant-reconnects-on-mobile goal.

A slow-but-progressing control exec on a high-RTT cellular link exceeded the 30s **whole-call** exec read ceiling and closed the **shared lease transport**, cascade-dropping the live `-CC` session. Now a **per-read no-progress budget** (`ExecReadStallBudget`): wedged only when neither stdout nor stderr progresses within the window (handles stderr-silent-until-exit). A genuinely wedged read is still bounded and closes the session for lease self-heal.

`SshExecTimeoutException` type/ctor unchanged (LeaseSessionExec classification unaffected). Reproduce-first red→green; wedged + progresses-then-wedges class coverage. **core-ssh unit 201/0; real Docker integrationTest 33/0.**