### PR TITLE
Right-size journey-suite budget + stop masking STEP_TIMEOUT

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -121,9 +121,11 @@ jobs:
       # so the #470-stall hardening cannot silently regress. This is a fast
       # JVM-free shell test (stubbed gradle/adb, tiny budget) proving the suite
       # bails CLEANLY at its deadline, ALWAYS writes summary.md, marks it with
-      # the distinct JOURNEY_STEP_TIMEOUT label, exits red, and that the workflow
-      # classifier grep ladder routes that summary to the timeout branch (NOT the
-      # #771 EMULATOR INFRA UNAVAILABLE branch). Cheap (< 15 s), no emulator.
+      # the distinct JOURNEY_STEP_TIMEOUT label, exits red, and (issue #835
+      # REOPENED, the DURABLE GUARD) that the workflow classifier now routes that
+      # summary to a HARD-RED timeout verdict — NOT advisory-green and NOT the
+      # #771 EMULATOR INFRA UNAVAILABLE branch — so a cut-short load-bearing class
+      # can never again be masked. Cheap (< 15 s), no emulator.
       - name: CI journey-suite budget guard (issue #835)
         run: |
           chmod +x scripts/test-ci-journey-budget.sh
@@ -317,11 +319,23 @@ jobs:
     if: github.event_name != 'pull_request'
     needs: [unit, python, integration]
     runs-on: ubuntu-latest
-    # Issue #691 (STABILIZE): lowered 75 -> 45 as a backstop. A wedging test
-    # should now fail fast via the per-test `timeout_msec` in
-    # scripts/ci-journey-suite.sh; this job cap only bounds the worst case so a
-    # hang can never again burn ~75 min + a failure email on every push.
-    timeout-minutes: 45
+    # Issue #835 (REOPENED, RIGHT-SIZE): raised 45 -> 95 so the suite can run the
+    # FULL load-bearing selection (~83 journey classes + 6 core-terminal proofs ≈
+    # 89 connected-test invocations) to a verdict in one serial pass instead of
+    # being SIGKILLed mid-loop. The dominant cost — a fresh `--no-daemon` Gradle
+    # JVM per class — is removed by reusing the Gradle daemon in
+    # scripts/ci-journey-suite.sh (per-class isolation preserved; see that note),
+    # which is what makes the serial wall-clock fit this cap at all.
+    # `timeout-minutes` is a CAP, not a fixed duration: the job ENDS when the
+    # suite ends (early on a healthy run), so this only lets the worst case
+    # finish. The suite owns its OWN 4200s budget and bails cleanly before this
+    # cap; the arithmetic is 95-min cap (5700s) - 900s worst-case boot - 4200s
+    # suite budget = 600s for the classifier + Docker log collection + artifact
+    # upload (the same 600s slack the #908 invariant kept). A wedging test still
+    # fails fast via the per-test `timeout_msec` in the suite; this cap only
+    # bounds the absolute worst case so a hang can never burn the runner
+    # indefinitely.
+    timeout-minutes: 95
 
     steps:
       - name: Checkout
@@ -700,10 +714,11 @@ jobs:
 
       # Issue #835/#470: inspect the first attempt's suite-owned summary before
       # spending the second cold boot. If the first attempt already reached the
-      # 20-min suite budget and wrote a pure JOURNEY_STEP_TIMEOUT summary (no
+      # suite budget and wrote a pure JOURNEY_STEP_TIMEOUT summary (no
       # JOURNEY_FAILED / Failed BOTH attempts section), retrying inside this
-      # same 45-min job cannot recover it; it only gets cancelled by the job cap
-      # and creates another red email. Genuine journey failures and no-summary
+      # same job cannot recover it (a budget timeout is deterministic given the
+      # class set vs the budget); it only gets cancelled by the job cap and
+      # creates another red email. Genuine journey failures and no-summary
       # boot/adb aborts still retry and classify below.
       - name: Inspect first journey summary
         id: journey_summary
@@ -792,14 +807,18 @@ jobs:
           emulator-boot-timeout: 900
           script: scripts/ci-journey-suite.sh
 
-      # Classify the final verdict. The job is red for genuine journey failures
-      # and for no-summary emulator infra aborts. A first-attempt failure that
-      # the retry recovered is surfaced as an explicit "infra flake recovered"
-      # note in the log so a degrading-flake trend stays visible (parity with
-      # the suite script's JOURNEY_FLAKE_RECOVERED marker), not silently hidden.
-      # A pure suite-budget timeout is advisory-green: it means the emulator
-      # booted and many classes ran, but the known #470 capacity/stall class
-      # prevented a full verdict before the suite budget.
+      # Classify the final verdict. The job is red for genuine journey failures,
+      # for no-summary emulator infra aborts, AND (issue #835 REOPENED) for a
+      # suite-budget timeout. A first-attempt failure that the retry recovered is
+      # surfaced as an explicit "infra flake recovered" note in the log so a
+      # degrading-flake trend stays visible (parity with the suite script's
+      # JOURNEY_FLAKE_RECOVERED marker), not silently hidden.
+      # A suite-budget timeout is now a HARD RED, not advisory-green (#835
+      # REOPENED, D31): the old advisory-green MASKED the fact that a load-bearing
+      # class was cut short before reaching a verdict. With the right-sized 4200s
+      # budget the full selection should always finish, so a timeout now means the
+      # enumeration stall returned or the selection outgrew the budget — both of
+      # which leave a load-bearing class unverified and must fail the gate.
       #
       # Issue #771: when BOTH attempts fail, AUTO-CLASSIFY infra-abort vs genuine
       # test-failure from the suite's own artifact instead of telling the human to
@@ -847,9 +866,9 @@ jobs:
           fi
           if [[ "${first_timeout:-false}" == "true" ]]; then
             timed_out_classes="$(awk '/JOURNEY_STEP_TIMEOUT|Suite step time budget exhausted/{f=1} f && /^- /{gsub(/`/,""); sub(/^- /,"    "); print}' "$summary" || true)"
-            echo "::warning title=Emulator journey TIMEOUT — #470 enumeration stall::The journey suite booted and ran, but the in-emulator tmux list-sessions enumeration stall exhausted the suite time budget before all load-bearing classes finished (issue #835 / #470). This is advisory and does not fail the per-push gate because no journey class failed both attempts. Class(es) cut short / not run:"
+            echo "::error title=Emulator journey TIMEOUT — load-bearing classes cut short (#835/#470)::The journey suite booted and ran, but exhausted its own 4200s time budget before every load-bearing class reached a verdict (issue #835 / #470). This is now a HARD RED durable guard (#835 REOPENED, D31): a budget timeout means a load-bearing class was silently cut short, which used to be masked as advisory-green. The retry is skipped because a budget timeout is deterministic. Either the enumeration stall has returned or the selection no longer fits the budget — investigate; do NOT treat as a flake. Class(es) cut short / not run:"
             [[ -n "$timed_out_classes" ]] && printf '%s\n' "$timed_out_classes"
-            exit 0
+            exit 1
           fi
           # If a cold-boot attempt was cancelled, do not trust summary.md for a
           # "failed BOTH" verdict: the retry shares the same workspace path, so
@@ -869,19 +888,23 @@ jobs:
             [[ -n "$failed_classes" ]] && printf '%s\n' "$failed_classes"
             exit 1
           fi
-          # Issue #835: the suite ran (the emulator booted, classes ran to
-          # verdicts) but the suite-level time budget was exhausted — typically
-          # by the recurring #470 in-emulator tmux `list-sessions` enumeration
-          # stall consuming the session/reconnect journeys' retry windows. The
-          # suite now bails CLEANLY at its own deadline (below the 45-min job
-          # cap) and writes summary.md with the `JOURNEY_STEP_TIMEOUT` marker, so
-          # this is a distinct, correctly-attributed advisory — NOT a never-booted
-          # emulator (#771) and NOT a genuine test regression.
+          # Issue #835 (REOPENED, DURABLE GUARD): the suite ran (the emulator
+          # booted, classes ran to verdicts) but the suite-level time budget was
+          # exhausted before every load-bearing class reached a verdict. This
+          # used to be downgraded to advisory-green, which MASKED the fact that a
+          # load-bearing class (BackgroundGrace / LiveHold / the share/composer/
+          # folder tail) was silently cut short — the exact reopen complaint. It
+          # is now a HARD RED: a budget timeout means the enumeration stall has
+          # returned OR the selection no longer fits the (now right-sized 4200s)
+          # budget. Either way a class did not run to a verdict, so the gate must
+          # fail. The summary still carries the `JOURNEY_STEP_TIMEOUT` marker so
+          # this is attributed distinctly from a genuine `JOURNEY_FAILED`
+          # regression and from a never-booted (#771) emulator.
           if [[ -f "$summary" ]] && grep -qE 'JOURNEY_STEP_TIMEOUT|Suite step time budget exhausted' "$summary"; then
             timed_out_classes="$(awk '/JOURNEY_STEP_TIMEOUT|Suite step time budget exhausted/{f=1} f && /^- /{gsub(/`/,""); sub(/^- /,"    "); print}' "$summary" || true)"
-            echo "::warning title=Emulator journey TIMEOUT — #470 enumeration stall::The journey suite booted and ran, but the in-emulator tmux list-sessions enumeration stalled and exhausted the suite time budget before all load-bearing classes finished (issue #835 / #470). This is the recurring CI enumeration-stall infra class, NOT a never-booted emulator (#771) and NOT a genuine test regression. Class(es) cut short / not run:"
+            echo "::error title=Emulator journey TIMEOUT — load-bearing classes cut short (#835/#470)::The journey suite booted and ran, but exhausted its 4200s time budget before every load-bearing class reached a verdict (issue #835 / #470). This is now a HARD RED durable guard (#835 REOPENED, D31), NOT an advisory-green: a budget timeout means a load-bearing class was silently cut short. Either the in-emulator enumeration stall has returned or the selection no longer fits the budget — investigate. This is distinct from a never-booted emulator (#771) and from a genuine test regression. Class(es) cut short / not run:"
             [[ -n "$timed_out_classes" ]] && printf '%s\n' "$timed_out_classes"
-            exit 0
+            exit 1
           fi
           # No suite summary at all: the script aborted before any class reached
           # a verdict. The emulator never reached `device` / adb never came up,

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -1251,7 +1251,7 @@ echo "=========================================================="
 #
 # ---------------------------------------------------------------------------
 # Issue #835: SUITE-LEVEL time budget so the recurring #470 enumeration stall
-# can never burn the whole 45-min job to a `cancelled` (which writes NO
+# can never burn the whole job to a `cancelled` (which writes NO
 # summary.md and mis-routes the workflow classifier to the #771
 # "EMULATOR INFRA UNAVAILABLE" branch).
 #
@@ -1262,19 +1262,61 @@ echo "=========================================================="
 # `summary.md` was ever written. Without an artifact the classifier cannot tell a
 # #470 time-budget stall from a never-booted emulator.
 #
-# Fix (#908): the suite owns its OWN deadline (JOURNEY_STEP_BUDGET_SECS,
-# default 20 min). Arithmetic against the workflow cap is explicit:
-# 45-min job cap (2700s) - worst-case emulator boot (900s) - default suite
-# budget (1200s) = 600s for setup, classifier, Docker log collection, and
-# artifact upload.
+# Fix (#908): the suite owns its OWN deadline (JOURNEY_STEP_BUDGET_SECS).
 # When the remaining budget is exhausted the suite STOPS launching new classes,
 # records the not-run classes as a distinct BUDGET-timeout bucket, ALWAYS writes
 # summary.md (with the greppable `JOURNEY_STEP_TIMEOUT` marker), and exits
-# non-zero. So a #470 stall now surfaces as a legible, correctly-labelled red
-# verdict WITH an artifact instead of a `cancelled` step with none. Each
-# individual class attempt is ALSO hard-capped (via `timeout`) at the smaller of
-# its own ceiling and the budget remaining, so one wedged class can never run
-# past the suite deadline.
+# non-zero. Each individual class attempt is ALSO hard-capped (via `timeout`) at
+# the smaller of its own ceiling and the budget remaining, so one wedged class
+# can never run past the suite deadline.
+#
+# Right-sizing (#835 REOPENED): the 1200s (20-min) budget could not run the full
+# load-bearing selection (~83 journey classes + 6 core-terminal proofs ≈ 89
+# connected-test invocations) to a verdict SERIALLY, so the slow heavy
+# reconnect/switch journeys at the front always ate the 1200s before
+# BackgroundGrace / LiveHold / the share/composer/folder tail could run. The root
+# cause is harness arithmetic, NOT an unbounded tmux hang (every enumeration
+# round-trip is hard-bounded post #687/#702/#1041). Two changes make the WHOLE
+# selection reach a verdict in one pass:
+#
+#   1. Kill the per-class cold-Gradle tax. Each journey class used to run as its
+#      OWN cold `--no-daemon` Gradle invocation (~30-60s of fresh-JVM config +
+#      APK install + runner spin-up BEFORE a single assertion) — ~89 of those is
+#      ~40-80 min of pure overhead, which no sane job cap can fit. `run_class`
+#      now reuses the Gradle DAEMON across invocations (the `--no-daemon` flag is
+#      dropped), so config/JVM-start is paid ~once instead of ~89×. This PRESERVES
+#      per-class isolation: every class is STILL its own `:app:
+#      connectedDebugAndroidTest` task targeting one `class=` FQCN, run in its own
+#      on-device `am instrument` process, so the #1042 grace-state-leak-across-
+#      test-methods-in-one-process hazard does NOT apply (we never batch multiple
+#      classes into one instrumentation process). It also matches how the six
+#      core-terminal proofs below ALREADY invoke Gradle (daemon, no `--no-daemon`).
+#      The #918 file-hash-lock poisoning a KILLED invocation could leave is still
+#      cleared by `cleanup_gradle_after_timeout` (`gradlew --stop` after a class
+#      is killed by `timeout`), so a wedged class cannot poison its retry.
+#
+#   2. Right-size the budget + job cap to the daemon-warm serial wall-clock.
+#      `timeout-minutes` is a CAP, not a fixed duration: the job ENDS when the
+#      suite ends (early on a healthy run), so a generous budget is pure
+#      correctness upside — it only lets the worst case finish instead of being
+#      SIGKILLed mid-loop.
+#
+# Arithmetic against the workflow cap is explicit (the same 600s post-boot slack
+# the #908 invariant preserved, scaled up):
+#   95-min job cap (5700s) - worst-case emulator boot (900s) - default suite
+#   budget (4200s) = 600s for setup, classifier, Docker log collection, and
+#   artifact upload.
+# A suite-budget timeout SKIPS the workflow retry: a budget timeout is
+# deterministic given the class set vs the budget (boot happens BEFORE
+# SUITE_START, so a slow boot never eats the suite budget), so a retry would only
+# burn the cap again. The job therefore never runs two full-budget attempts.
+#
+# Durable guard (#835 REOPENED, D31): a budget timeout is now a HARD RED, not an
+# advisory-green. The suite already exits non-zero on STEP_TIMEOUT; the workflow
+# classifier no longer downgrades a `JOURNEY_STEP_TIMEOUT` summary to green. So
+# if the stall ever returns — or a future class addition pushes the tail back
+# over the budget edge — the job goes RED with the cut-short classes named,
+# instead of silently masking a missing verdict (the exact reopen complaint).
 #
 # Override knobs (used by the suite's own unit test; CI uses the defaults):
 #   JOURNEY_STEP_BUDGET_SECS   — total wall-clock budget for the class loop.
@@ -1288,7 +1330,7 @@ echo "=========================================================="
 #   JOURNEY_CLASS_KILL_AFTER_SECS
 #                              — SIGKILL backstop after the per-class timeout
 #                                sends TERM (default 30s).
-JOURNEY_STEP_BUDGET_SECS="${JOURNEY_STEP_BUDGET_SECS:-1200}"
+JOURNEY_STEP_BUDGET_SECS="${JOURNEY_STEP_BUDGET_SECS:-4200}"
 JOURNEY_CLASS_TIMEOUT_SECS="${JOURNEY_CLASS_TIMEOUT_SECS:-420}"
 JOURNEY_GRADLE_STOP_TIMEOUT_SECS="${JOURNEY_GRADLE_STOP_TIMEOUT_SECS:-60}"
 JOURNEY_CLASS_KILL_AFTER_SECS="${JOURNEY_CLASS_KILL_AFTER_SECS:-30}"
@@ -1344,7 +1386,18 @@ needs_gradle_cleanup_after_class_abort() {
 # one class per invocation (rather than all classes comma-joined into a single
 # invocation) is what makes the per-class retry below clean: the gradle exit
 # code IS the per-class verdict, with no XML parsing or fragile result-file
-# scraping required.
+# scraping required. It ALSO preserves per-class isolation — each class runs in
+# its own on-device `am instrument` process, so the #1042 grace-state leak across
+# test methods in one instrumentation process cannot occur.
+#
+# Issue #835 (REOPENED): the Gradle DAEMON is reused across invocations (no
+# `--no-daemon` flag — matching the core-terminal proofs below) so the ~30-60s
+# fresh-JVM config + spin-up cost is paid ~once instead of ~89×; that cold-Gradle
+# tax was the dominant reason the full selection could not finish in budget.
+# Per-class isolation is unchanged (still one `class=` FQCN per task). A KILLED
+# invocation's lingering daemon/file-hash lock (#918) is still cleared by
+# `cleanup_gradle_after_timeout` (`gradlew --stop`) before the retry, so a wedged
+# class cannot poison its retry even with the daemon reused.
 #
 # Issue #835: wrap the gradle invocation in `timeout` capped at the SMALLER of
 # the per-class ceiling and the budget remaining, so a single #470-stalled class
@@ -1368,7 +1421,7 @@ run_class() {
   fi
   attempt_start=$SECONDS
   timeout --signal=TERM --kill-after="$JOURNEY_CLASS_KILL_AFTER_SECS" "${cap}s" \
-    "$GRADLEW" --no-daemon :app:connectedDebugAndroidTest \
+    "$GRADLEW" :app:connectedDebugAndroidTest \
     -Pandroid.testInstrumentationRunnerArguments.pocketshellCi=true \
     -Pandroid.testInstrumentationRunnerArguments.timeout_msec=300000 \
     -Pandroid.testInstrumentationRunnerArguments.class="$fqcn" \
@@ -1520,7 +1573,7 @@ STEP_TIMEOUT_HIT=0    # issue #835: set to 1 once the suite-level budget is spen
 SUITE_START=$SECONDS
 
 echo ">>> Suite-level time budget (issue #835): ${JOURNEY_STEP_BUDGET_SECS}s"
-echo "    (per-class attempt cap: ${JOURNEY_CLASS_TIMEOUT_SECS}s; workflow job cap: 45 min)"
+echo "    (per-class attempt cap: ${JOURNEY_CLASS_TIMEOUT_SECS}s; workflow job cap: 95 min)"
 
 for fqcn in "${JOURNEY_CLASSES[@]}"; do
   # Issue #835: stop launching new classes once the suite-level budget is spent.
@@ -1958,7 +2011,7 @@ echo "=========================================================="
   # marker to label the red as a journey timeout / #470 stall — DISTINCT from a
   # genuine `JOURNEY_FAILED` regression and from a "no summary at all" #771
   # EMULATOR INFRA UNAVAILABLE abort. Writing this summary at all (instead of
-  # being SIGKILLed mid-loop by the 45-min job cap) is the whole point: an
+  # being SIGKILLed mid-loop by the workflow job cap) is the whole point: an
   # artifact exists, so the classifier can attribute the red correctly.
   if [[ "$STEP_TIMEOUT_HIT" -eq 1 ]]; then
     echo

--- a/scripts/test-ci-journey-budget.sh
+++ b/scripts/test-ci-journey-budget.sh
@@ -4,7 +4,7 @@
 #
 # The recurring failure: the in-emulator #470 tmux `list-sessions` enumeration
 # stall makes session/reconnect journeys burn their retry windows; with no
-# suite-level deadline the 45-min workflow job cap SIGKILLs the suite mid-loop
+# suite-level deadline the workflow job cap SIGKILLs the suite mid-loop
 # before summary.md is written, so the workflow classifier mis-routes the red to
 # "EMULATOR INFRA UNAVAILABLE (#771)".
 #
@@ -17,8 +17,11 @@
 #       (NOT `JOURNEY_FAILED` and NOT a missing file),
 #   (d) the suite still exits NON-ZERO so the first attempt outcome records the
 #       timeout and the classifier can inspect the summary,
-#   (e) the workflow classifier grep that distinguishes a #470 timeout from a
-#       genuine failure / infra abort routes this summary to advisory-green.
+#   (e) the DURABLE GUARD (issue #835 REOPENED, D31): the workflow classifier
+#       routes a budget-timeout summary to a HARD-RED timeout verdict — NOT
+#       advisory-green (which used to MASK a cut-short load-bearing class) and
+#       NOT the #771 infra branch. A budget timeout = a load-bearing class did
+#       not reach a verdict = the gate FAILS.
 #   (f) a cancelled retry is classified before any `Failed BOTH attempts`
 #       summary, because summary.md can be stale from the first cold boot.
 #   (g) first-attempt diagnostics are snapshotted before the workflow retry can
@@ -40,8 +43,9 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 WORKFLOW="$REPO_ROOT/.github/workflows/tests.yml"
 THIS_TEST="$SCRIPT_DIR/test-ci-journey-budget.sh"
 
-# (pre) #908 budget/default/comment guard: prove the suite budget leaves
-# explicit slack under the workflow cap after a worst-case emulator boot.
+# (pre) #835 right-sized budget/default/comment guard: prove the suite budget is
+# large enough to run the full load-bearing selection to a verdict AND still
+# leaves explicit slack under the workflow cap after a worst-case emulator boot.
 job_cap_min="$(awk '
   /^  emulator-journey:/ { in_job=1; next }
   in_job && /^  [A-Za-z0-9_-]+:/ { in_job=0 }
@@ -50,8 +54,8 @@ job_cap_min="$(awk '
 [[ "$job_cap_min" =~ ^[0-9]+$ ]] \
   || fail "(pre) could not parse emulator-journey timeout-minutes from tests.yml"
 job_cap_secs=$((job_cap_min * 60))
-[[ "$job_cap_secs" -eq 2700 ]] \
-  || fail "(pre) emulator-journey job cap must stay 45 min / 2700s (got ${job_cap_secs}s)"
+[[ "$job_cap_secs" -eq 5700 ]] \
+  || fail "(pre) emulator-journey job cap must be 95 min / 5700s after the #835 right-size (got ${job_cap_secs}s)"
 
 mapfile -t emulator_boot_timeout_values < <(awk '/emulator-boot-timeout:/ { print $2 }' "$WORKFLOW")
 [[ "${#emulator_boot_timeout_values[@]}" -gt 0 ]] \
@@ -69,25 +73,65 @@ emulator_boot_timeout_secs="${emulator_boot_timeout_values[0]}"
 default_suite_budget_secs="$(sed -n 's/^JOURNEY_STEP_BUDGET_SECS="${JOURNEY_STEP_BUDGET_SECS:-\([0-9][0-9]*\)}"$/\1/p' "$REAL_SUITE")"
 [[ "$default_suite_budget_secs" =~ ^[0-9]+$ ]] \
   || fail "(pre) could not parse default JOURNEY_STEP_BUDGET_SECS from ci-journey-suite.sh"
-[[ "$default_suite_budget_secs" -eq 1200 ]] \
-  || fail "(pre) default JOURNEY_STEP_BUDGET_SECS must stay 1200s / 20 min (got ${default_suite_budget_secs}s)"
+[[ "$default_suite_budget_secs" -eq 4200 ]] \
+  || fail "(pre) default JOURNEY_STEP_BUDGET_SECS must be 4200s / 70 min after the #835 right-size (got ${default_suite_budget_secs}s)"
 
 remaining_slack_secs=$((job_cap_secs - emulator_boot_timeout_secs - default_suite_budget_secs))
 [[ "$remaining_slack_secs" -ge 600 ]] \
   || fail "(pre) insufficient post-boot slack: ${job_cap_secs}s job cap - ${emulator_boot_timeout_secs}s boot - ${default_suite_budget_secs}s suite = ${remaining_slack_secs}s (< 600s)"
 
-grep -q 'default 20 min' "$REAL_SUITE" \
-  || fail "(pre) ci-journey-suite.sh budget comment must document the 20-min default"
-grep -q '45-min job cap (2700s) - worst-case emulator boot (900s) - default suite' "$REAL_SUITE" \
-  || fail "(pre) ci-journey-suite.sh budget comment must show the safe arithmetic"
-grep -q 'workflow job cap: 45 min' "$REAL_SUITE" \
-  || fail "(pre) ci-journey-suite.sh log line must refer to the 45-min job cap"
-grep -q '20-min suite budget' "$WORKFLOW" \
-  || fail "(pre) tests.yml first-summary comment must match the 20-min suite budget"
+grep -q '95-min job cap (5700s) - worst-case emulator boot (900s) - default suite' "$REAL_SUITE" \
+  || fail "(pre) ci-journey-suite.sh budget comment must show the right-sized arithmetic"
+grep -q 'budget (4200s) = 600s' "$REAL_SUITE" \
+  || fail "(pre) ci-journey-suite.sh budget comment must document the 4200s/600s arithmetic"
+grep -q 'workflow job cap: 95 min' "$REAL_SUITE" \
+  || fail "(pre) ci-journey-suite.sh log line must refer to the 95-min job cap"
+grep -q '95-min cap (5700s) - 900s worst-case boot - 4200s' "$WORKFLOW" \
+  || fail "(pre) tests.yml timeout-minutes comment must show the 5700s/900s/4200s arithmetic"
+# The masking the #835 reopen is about: a budget timeout must NOT be downgraded
+# to advisory-green. Pin DIRECTLY on the real workflow classifier text: the
+# timeout verdict must be reported as a `::error` (red), and the old advisory
+# `::warning title=Emulator journey TIMEOUT` (which paired with `exit 0`) must be
+# GONE. A regression that re-downgrades it to a warning/green trips this.
+grep -q 'HARD RED' "$WORKFLOW" \
+  || fail "(pre) tests.yml classifier must document the budget timeout is now a HARD RED (#835 durable guard)"
+grep -q '::error title=Emulator journey TIMEOUT' "$WORKFLOW" \
+  || fail "(pre) tests.yml classifier must report the journey TIMEOUT as a ::error (red), not advisory"
+if grep -q '::warning title=Emulator journey TIMEOUT' "$WORKFLOW"; then
+  fail "(pre) tests.yml still has an advisory ::warning journey-TIMEOUT branch — the #835 masking regressed"
+fi
+# Each TIMEOUT ::error must be immediately followed by `exit 1` (red), never
+# `exit 0`. Walk the file: after a line containing the timeout error title, the
+# next `exit N` we see must be `exit 1` (set a `bad` flag otherwise; print the
+# verdict ONCE at END so awk's `exit`-runs-END quirk can't mask it).
+timeout_exit_verdict="$(awk '
+  /::error title=Emulator journey TIMEOUT/ { armed=1; next }
+  armed && /[[:space:]]exit 0([[:space:]]|$)/ { bad=1; armed=0 }
+  armed && /[[:space:]]exit 1([[:space:]]|$)/ { armed=0 }
+  END { print (bad ? "ADVISORY" : "OK") }
+' "$WORKFLOW")"
+[[ "$timeout_exit_verdict" == "OK" ]] \
+  || fail "(pre) a journey-TIMEOUT ::error is followed by exit 0 (advisory-green) — the #835 masking regressed"
+# Stale pre-#835 budget/cap wording must not survive in the suite or workflow.
+# Scan ONLY $REAL_SUITE + $WORKFLOW (not $THIS_TEST) so the regex literal below
+# can't match its own definition line. Tokens use a split ("12""00") so even
+# this assertion's source text never contains the contiguous stale string.
+stale_budget_re="JOURNEY_STEP_BUDGET_SECS:-12""00|default 2""0 min|45-min job cap \(27""00s\)|workflow job cap: 4""5 min"
+if grep -qE "$stale_budget_re" "$REAL_SUITE" "$WORKFLOW"; then
+  fail "(pre) stale pre-#835 budget/cap wording found; use the right-sized 4200s budget / 95-min cap"
+fi
+# #835 REOPENED tax-cut pin: the journey class invocation must REUSE the Gradle
+# daemon (no `--no-daemon` on :app:connectedDebugAndroidTest). Scan $REAL_SUITE
+# only so this regex literal can't match its own definition. The daemon reuse is
+# what makes ~89 serial invocations fit the right-sized budget; a regression back
+# to `--no-daemon` would blow the budget and re-introduce the STEP_TIMEOUT.
+if grep -qE -- '--no-daemon[[:space:]]+:app:connectedDebugAndroidTest' "$REAL_SUITE"; then
+  fail "(pre) journey :app:connectedDebugAndroidTest still passes --no-daemon; the #835 daemon-reuse tax cut regressed"
+fi
 stale_step_cap_re="workflow ste""p|ste""p cap|45-min ste""p|45 min ste""p"
 if grep -qE "$stale_step_cap_re" \
   "$REAL_SUITE" "$WORKFLOW" "$THIS_TEST"; then
-  fail "(pre) stale workflow-timeout wording found; use 45-min job cap"
+  fail "(pre) stale workflow-timeout wording found; refer to the job cap, not a workflow ste""p timeout"
 fi
 
 preserve_line="$(grep -n 'name: Preserve first journey attempt diagnostics' "$WORKFLOW" | cut -d: -f1)"
@@ -105,7 +149,7 @@ grep -q 'cp -a artifacts/ci-journey/.' "$WORKFLOW" \
   || fail "(pre) preservation step must snapshot artifacts/ci-journey before retry overwrites summary.md"
 grep -q 'summary-missing.txt' "$WORKFLOW" \
   || fail "(pre) preservation step must record first-attempt missing-summary infra aborts"
-pass "(pre) #908 budget arithmetic pinned (${job_cap_secs}s job - ${emulator_boot_timeout_secs}s boot - ${default_suite_budget_secs}s suite = ${remaining_slack_secs}s slack)"
+pass "(pre) #835 right-sized budget arithmetic pinned (${job_cap_secs}s job - ${emulator_boot_timeout_secs}s boot - ${default_suite_budget_secs}s suite = ${remaining_slack_secs}s slack)"
 pass "(pre) first-attempt diagnostics are preserved before emulator retry"
 
 # ---------------------------------------------------------------------------
@@ -185,13 +229,19 @@ pass "(c) summary has the timeout marker and NOT a genuine-failure marker"
 
 # (d) the suite exited NON-ZERO so the workflow sees a failed first attempt and
 #     then lets the classifier decide whether the summary is genuine-failure red
-#     or timeout-only advisory-green.
+#     or timeout red.
 [[ "$rc" -ne 0 ]] || fail "(d) suite exited 0 on a budget timeout — classifier would never inspect the timeout summary"
 pass "(d) suite exited non-zero (rc=$rc) on a budget timeout"
 
-# (e) classifier routing: replicate the workflow's grep ladder against this
-#     summary and assert it lands on the TIMEOUT branch, not genuine-failure,
-#     not infra-abort.
+# (e) DURABLE GUARD (issue #835 REOPENED, D31): replicate the workflow's
+#     classifier ladder against this summary and assert a budget timeout is now a
+#     HARD-RED timeout verdict — NOT advisory-green (which used to mask a
+#     cut-short load-bearing class), NOT genuine-failure, NOT infra-abort.
+#
+# classify() mirrors .github/workflows/tests.yml "Classify emulator-journey
+# result"; verdict_is_red() mirrors its exit code (exit 0 = green, exit 1 = red).
+# A regression that re-downgrades the timeout to green would flip
+# verdict_is_red() and fail this test.
 classify() {
   local s="$1"
   local first_outcome="${2:-failure}"
@@ -218,7 +268,8 @@ classify() {
     echo "FIRST_GENUINE_FAILURE"; return
   fi
   if [[ "$first_timeout" == "true" ]]; then
-    echo "JOURNEY_TIMEOUT_ADVISORY"; return
+    # #835 REOPENED: the first-attempt budget timeout is now a HARD RED.
+    echo "FIRST_TIMEOUT_RED"; return
   fi
   if [[ "$first_outcome" == "cancelled" || "$retry_outcome" == "cancelled" || "$first_concl" == "cancelled" || "$retry_concl" == "cancelled" ]]; then
     echo "STEP_CANCELLED"; return
@@ -227,14 +278,27 @@ classify() {
     echo "GENUINE_FAILURE"; return
   fi
   if [[ -f "$s" ]] && grep -qE 'JOURNEY_STEP_TIMEOUT|Suite step time budget exhausted' "$s"; then
-    echo "JOURNEY_TIMEOUT"; return
+    # #835 REOPENED: the both-failed budget timeout is now a HARD RED.
+    echo "JOURNEY_TIMEOUT_RED"; return
   fi
   echo "INFRA_UNAVAILABLE"
 }
+
+# verdict_is_red — exit 0 (true) iff this verdict turns the job RED, mirroring
+# the workflow classifier's exit code. ONLY a clean first/retry pass is green.
+verdict_is_red() {
+  case "$1" in
+    PASS_FIRST|PASS_RETRY) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
 verdict="$(classify "$summary")"
-[[ "$verdict" == "JOURNEY_TIMEOUT_ADVISORY" ]] \
-  || fail "(e) classifier routed to '$verdict', expected JOURNEY_TIMEOUT_ADVISORY"
-pass "(e) workflow classifier grep ladder routes this summary to advisory timeout"
+[[ "$verdict" == "FIRST_TIMEOUT_RED" ]] \
+  || fail "(e) classifier routed to '$verdict', expected FIRST_TIMEOUT_RED (a budget timeout must NOT be advisory-green — #835 durable guard)"
+verdict_is_red "$verdict" \
+  || fail "(e) budget-timeout verdict '$verdict' was classified GREEN — the #835 masking regressed"
+pass "(e) workflow classifier routes a budget timeout to a HARD-RED verdict (#835 durable guard)"
 
 # (f) stale-summary guard: the two cold-boot attempts share the same summary.md
 #     path. If the retry is cancelled, an old `Failed BOTH attempts` summary
@@ -343,13 +407,22 @@ grep -q 'GRADLE_TIMEOUT_CLEANUP:' "$out_lock" \
   || fail "(i) cleanup marker was not logged after timeout"
 grep -q 'JOURNEY_FLAKE_RECOVERED:' "$out_lock" \
   || fail "(i) timed-out class did not recover on retry"
-grep -q -- '--no-daemon :app:connectedDebugAndroidTest' "$lock_stub_dir/args.log" \
-  || fail "(i) per-class journey invocation did not use --no-daemon"
+# #835 REOPENED: the per-class journey invocation now REUSES the Gradle daemon
+# (no `--no-daemon` flag) to cut the cold-Gradle tax, but it is STILL one targeted
+# `class=` invocation (per-class isolation preserved). Assert both: the journey
+# task ran AND it did NOT carry the old `--no-daemon` flag.
+grep -q -- ':app:connectedDebugAndroidTest' "$lock_stub_dir/args.log" \
+  || fail "(i) per-class journey task did not run"
+grep -q -- 'class=' "$lock_stub_dir/args.log" \
+  || fail "(i) per-class journey invocation lost its single-class targeting"
+if grep -q -- '--no-daemon' "$lock_stub_dir/args.log"; then
+  fail "(i) journey invocation still passes --no-daemon; the #835 daemon-reuse tax cut regressed"
+fi
 if grep -q 'Cannot lock file hash cache' "$out_lock"; then
   sed -n '1,160p' "$out_lock"
   fail "(i) retry still saw the simulated Gradle file-hash lock"
 fi
-pass "(i) per-class timeout stops Gradle and retry avoids the poisoned file-hash lock"
+pass "(i) daemon-reused per-class timeout stops Gradle and retry avoids the poisoned file-hash lock"
 
 # The hard timeout path matters too: GNU `timeout --kill-after` returns 137 when
 # the child ignores TERM and is killed by the SIGKILL backstop. That path must
@@ -571,11 +644,41 @@ fi
 # "first attempt outcome == success -> exit 0" short-circuit; in the real
 # workflow a clean PASS never reaches the grep ladder at all. We only assert
 # the summary itself does NOT carry the timeout marker (so it could not be
-# mis-routed to JOURNEY_TIMEOUT if the ladder were reached).
+# mis-routed to JOURNEY_TIMEOUT_RED if the ladder were reached).
 neg_verdict="$(classify "$summary2")"
-[[ "$neg_verdict" != "JOURNEY_TIMEOUT" ]] \
-  || fail "(neg) clean run mis-classified as JOURNEY_TIMEOUT"
+[[ "$neg_verdict" != "JOURNEY_TIMEOUT_RED" && "$neg_verdict" != "FIRST_TIMEOUT_RED" ]] \
+  || fail "(neg) clean run mis-classified as a timeout"
+[[ "$rc2" -eq 0 ]] \
+  || { cat "$out2"; fail "(neg) clean run (generous budget, every class verdicts) exited non-zero (rc=$rc2)"; }
 pass "(neg) clean run: no false timeout (summary has no timeout marker; rc=$rc2)"
+
+# (neg-2) ACCEPTANCE CRITERION 2 (#835 REOPENED): with a budget that fits, EVERY
+# selected load-bearing class reaches a verdict — none is silently cut short.
+# Assert the historically cut-short classes (BackgroundGrace, LiveHold) and a
+# share/composer/folder tail representative are present in the run AND that NO
+# class is bucketed as a budget timeout (no "cut short / not run" section).
+for cut_short_class in \
+  com.pocketshell.app.proof.BackgroundGraceReconnectE2eTest \
+  com.pocketshell.app.proof.SessionForegroundServiceLiveHoldJourneyE2eTest; do
+  grep -q "$cut_short_class" "$summary2" \
+    || { cat "$summary2"; fail "(neg-2) $cut_short_class missing from a healthy full run — selection drifted"; }
+done
+# The "cut short / not run" budget bucket must be ABSENT on a healthy run.
+if grep -q 'cut short / not run' "$summary2"; then
+  cat "$summary2"
+  fail "(neg-2) a healthy full run wrongly bucketed a class as cut-short / not-run"
+fi
+# Every selected class launched gradle (one daemon-reused invocation each) —
+# count the per-class launches in the run log and assert it matches the FULL
+# class count (all quoted JOURNEY_CLASSES entries, not just the $FQCN_PREFIX
+# ones), so a healthy run is proven to reach a verdict for EVERY class.
+class_count="$(awk '/^JOURNEY_CLASSES=\(/{f=1;next} /^\)/{f=0} f && /^[[:space:]]*"/{c++} END{print c+0}' "$SANDBOX/scripts/ci-journey-suite.sh")"
+[[ "$class_count" -ge 80 ]] \
+  || fail "(neg-2) parsed only $class_count journey classes — enumeration changed unexpectedly (expected the full ~83-class load-bearing set)"
+launched="$(grep -c '>>> JOURNEY CLASS:.*(attempt 1)' "$out2" || true)"
+[[ "$launched" -eq "$class_count" ]] \
+  || { sed -n '1,40p' "$out2"; fail "(neg-2) launched $launched/$class_count journey classes on a healthy run — some class never reached a verdict"; }
+pass "(neg-2) healthy run reaches a verdict for all $class_count load-bearing classes (none cut short)"
 
 echo
 echo "ALL TESTS PASSED"


### PR DESCRIPTION
Closes #835. The journey STEP_TIMEOUT was harness arithmetic, not a tmux hang: ~89 classes run serially each as its own cold `--no-daemon` Gradle invocation. Reuse the Gradle daemon (per-class `am instrument` isolation preserved); budget 1200→4200s, job timeout 45→95min (600s slack). **Durable guard: STEP_TIMEOUT flips from advisory-green to HARD ::error+exit 1 — ends the masking that hid the MultiSessionSwitch regression.** Budget self-test 16/16 (asserts all classes reach a verdict). **Reviewer APPROVED** (isolation holds; budget tight-but-fail-loud). Merge LAST (tests.yml journey-timeout vs guards' Unit-step — different sections, auto-merge).