### PR TITLE
core-connection: retire reduceForeground — sole foreground-return authority (#1047 Slice 0)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -61,6 +61,7 @@ import com.pocketshell.app.tmux.connection.ConnectionManager
 import com.pocketshell.app.tmux.connection.ConnectionEffectDriver
 import com.pocketshell.app.tmux.connection.ConnectionStatusProjection
 import com.pocketshell.app.tmux.connection.CurrentClientTmuxPort
+import com.pocketshell.app.tmux.connection.ForegroundReturnEffects
 import com.pocketshell.app.tmux.connection.debounceReconnectUi
 import com.pocketshell.app.tmux.connection.GraceEffects
 import com.pocketshell.app.tmux.connection.SshLeaseTransportPort
@@ -905,10 +906,11 @@ public class TmuxSessionViewModel @Inject constructor(
             foregroundReattachEffect = { graceEffects.onForegroundReattachReseed() },
             // EPIC #766 Slice 2a: the controller's Backgrounded -> Reconnecting edge (the
             // BEYOND-grace foreground) now DRIVES the foreground arm dispatch (the re-home
-            // of the inline foreground dispatch). [onControllerForegrounded]
-            // selects replay-vs-resume via the inline-equivalent [reduceForeground]
-            // predicate (pendingReattach / pausedAutoReconnect) — the controller edge is
-            // only the TRIGGER, not the divergent display-status gate.
+            // of the inline foreground dispatch). [onControllerForegrounded] delegates to
+            // the connection-core [ForegroundReturnEffects] (EPIC #687 Slice 0 / #1047),
+            // which selects replay-vs-resume from the live pendingReattach /
+            // pausedAutoReconnect payloads — the controller edge is only the TRIGGER, not
+            // the divergent display-status gate.
             foregroundReconnectEffect = { onControllerForegrounded() },
             // Slice 1c-iv-b-B2 (#742): after the driver submits a TransportLive /
             // TransportDropped from the real flows, re-project _connectionStatus from
@@ -3406,10 +3408,10 @@ public class TmuxSessionViewModel @Inject constructor(
         // above) the App-grace teardown evicted the warm lease, so the controller's own
         // grace predicate is not-warm and it walks Backgrounded -> Reconnecting, firing
         // [onControllerForegrounded] which replays `pendingReattach` / resumes a
-        // `pausedAutoReconnect` (selected via the inline-equivalent [reduceForeground]
-        // predicate — the #685 trap: the controller edge is the trigger, the inline
-        // predicate the gate). The inline foreground event arm is no longer
-        // consulted (Slice 2a).
+        // `pausedAutoReconnect` (selected by the connection-core [ForegroundReturnEffects]
+        // — EPIC #687 Slice 0 / #1047 — re-reading the live payloads per the #685 trap:
+        // the controller edge is the trigger, the connection-core dispatcher the gate).
+        // The inline foreground event arm is no longer consulted (Slice 2a).
         if (launchPostGraceHeldForegroundProbeIfNeeded()) return
         connectionManager.observeForeground()
         dispatchPostGraceForegroundArmIfPending()
@@ -3563,25 +3565,30 @@ public class TmuxSessionViewModel @Inject constructor(
     }
 
     /**
-     * EPIC #766 Slice 2a — the controller-EDGE-driven beyond-grace FOREGROUND effect.
-     * Fired by the [ConnectionEffectDriver] when the [ConnectionController] transitions
-     * [ConnectionState.Backgrounded] -> [ConnectionState.Reconnecting] (the beyond-grace
-     * foreground return). This is the re-home of the former inline
-     * inline foreground dispatch: the controller edge is the TRIGGER, but
-     * the replay-vs-resume SELECTION still runs through the inline-equivalent
-     * [reduceForeground] predicate (`pendingReattach` / `pausedAutoReconnect`) so behavior
-     * is byte-identical (the #685 non-byte-identical-predicate trap — the arm selection
-     * MUST re-read VM state, not the controller's display state). The no-arm case
-     * ([ConnectionDecision.Ignore]) logs the same "no-pending" skip the inline `else` arm
-     * logged.
+     * EPIC #766 Slice 2a — the controller-EDGE-driven beyond-grace FOREGROUND effect, fired
+     * by the [ConnectionEffectDriver] on the [ConnectionController]'s Backgrounded ->
+     * Reconnecting edge (the controller edge is the TRIGGER). EPIC #687 Slice 0 (#1047): a
+     * thin delegate to the connection-core [foregroundReturnEffects] — the inline
+     * `reduceForeground()` selector (the second decision authority D28 ends) is DELETED.
      */
     private fun onControllerForegrounded() {
-        when (reduceForeground()) {
-            ConnectionDecision.ReplayPendingReattach ->
-                replayPendingReattach()
-            ConnectionDecision.ResumePausedReconnect ->
-                pausedAutoReconnect?.let { resumePausedAutoReconnect(it) }
-            else ->
+        foregroundReturnEffects.dispatch()
+    }
+
+    /**
+     * EPIC #687 Slice 0 (#1047): the connection-core foreground-return decision authority,
+     * the hard-cut replacement for the deleted inline `reduceForeground()`. The payload
+     * predicates re-read the VM's live `pendingReattach` / `pausedAutoReconnect` each
+     * dispatch (the #685 re-read trap); the arm bodies are the VM's existing replay/resume
+     * IO; the no-arm case preserves the prior inline `else` "no-pending" skip log.
+     */
+    private val foregroundReturnEffects: ForegroundReturnEffects =
+        ForegroundReturnEffects(
+            hasPendingReattach = { pendingReattach != null },
+            hasPausedAutoReconnect = { pausedAutoReconnect != null },
+            replayPendingReattach = { replayPendingReattach() },
+            resumePausedAutoReconnect = { pausedAutoReconnect?.let { resumePausedAutoReconnect(it) } },
+            onNoPendingArm = {
                 latestConnectIntent?.let { intent ->
                     Log.i(
                         ISSUE_235_LIFECYCLE_TAG,
@@ -3590,8 +3597,8 @@ public class TmuxSessionViewModel @Inject constructor(
                             targetLogFields(intent.target),
                     )
                 }
-        }
-    }
+            },
+        )
 
     /**
      * EPIC #687 slice 1c-iv-c (#754): the within-grace foreground gate. We can run
@@ -3854,9 +3861,10 @@ public class TmuxSessionViewModel @Inject constructor(
             // edge (the driver fires [onControllerForegrounded]); the inline
             // inline foreground consultation is removed. By construction this
             // branch has NO `pendingReattach`/`pausedAutoReconnect` (the `target`-deriving
-            // expression above already proved both null), so [reduceForeground] is `Ignore`
-            // and the driver-fired effect is a no-op — exactly the prior inline `else`
-            // behavior, just without re-consulting the classifier here.
+            // expression above already proved both null), so the connection-core
+            // [ForegroundReturnEffects] selects the `None` arm and the driver-fired effect
+            // is a no-op — exactly the prior inline `else` behavior, just without
+            // re-consulting the classifier here.
             connectionManager.observeForeground()
             projectStatusFromController()
             return
@@ -3943,9 +3951,10 @@ public class TmuxSessionViewModel @Inject constructor(
     }
 
     /**
-     * EPIC #687 slice 1a: the [ConnectionDecision.ReplayPendingReattach] body —
-     * formerly the second half of [onAppForegrounded]. Unchanged behavior; only
-     * the entry decision moved to [reduceForeground].
+     * EPIC #687 slice 1a: the foreground replay body — formerly the second half of
+     * [onAppForegrounded]. Unchanged behavior; the entry decision now lives in the
+     * connection-core [ForegroundReturnEffects] (EPIC #687 Slice 0 / #1047), which fires
+     * this as its `ReplayPendingReattach` arm.
      */
     private fun replayPendingReattach() {
         val detachJob = backgroundDetachJob
@@ -16150,12 +16159,9 @@ public class TmuxSessionViewModel @Inject constructor(
         /** Detach the live `-CC` control client and stash a pending reattach. */
         data object DetachForBackground : ConnectionDecision
 
-        // --- Foreground ---
-        /** Resume an auto-reconnect that was paused while backgrounded. */
-        data object ResumePausedReconnect : ConnectionDecision
-
-        /** Replay the [pendingReattach] stashed when we backgrounded. */
-        data object ReplayPendingReattach : ConnectionDecision
+        // --- Foreground --- EPIC #687 Slice 0 (#1047): the replay-vs-resume arm decision
+        // moved into the connection core ([ForegroundReturnEffects]); the inline
+        // `reduceForeground()` + its two variants are DELETED (D22 hard-cut).
 
         // --- NetworkChanged ---
         /** Schedule a proactive reconnect for a real validated network handoff. */
@@ -16237,17 +16243,10 @@ public class TmuxSessionViewModel @Inject constructor(
         return ConnectionDecision.DetachForBackground
     }
 
-    private fun reduceForeground(): ConnectionDecision {
-        if (pendingReattach != null) return ConnectionDecision.ReplayPendingReattach
-        if (pausedAutoReconnect != null) return ConnectionDecision.ResumePausedReconnect
-        // EPIC #687 slice 1c-iv-c (#754): the within-grace foreground (no pending
-        // reattach, live session) is now handled BEFORE this reducer in
-        // [onAppForegrounded] via the driver-owned RESEED-ONLY effect — the old
-        // `ProbeForeground → probeCurrentRuntimeOnForegroundIfNeeded → connect(...)`
-        // decision is DELETED (D22 hard-cut). A foreground that is NOT within grace
-        // and has no pending reattach is a no-op here.
-        return ConnectionDecision.Ignore
-    }
+    // EPIC #687 Slice 0 (#1047): `reduceForeground()` is DELETED. The beyond-grace
+    // foreground replay-vs-resume decision now lives in the connection core
+    // ([ForegroundReturnEffects], the SINGLE foreground authority); the inline selector
+    // was the second decision authority D28 exists to end (D22 hard-cut — no shadow).
 
     private fun reduceNetworkChanged(change: TerminalNetworkChange): ConnectionDecision {
         if (!appActive) return ConnectionDecision.Ignore

--- a/app/src/main/java/com/pocketshell/app/tmux/connection/ConnectionEffectDriver.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/connection/ConnectionEffectDriver.kt
@@ -133,7 +133,8 @@ import kotlinx.coroutines.launch
  *   foreground return (#766 slice 2a). The VM supplies the body that re-homes the inline
  *   `reduceConnection(Foreground)` arm dispatch: it replays the stashed `pendingReattach`
  *   (a fresh connect to the detached session) or resumes a `pausedAutoReconnect`, selected
- *   via the inline-equivalent `reduceForeground` predicate. This is the post-grace
+ *   by the connection-core `ForegroundReturnEffects` (EPIC #687 Slice 0 / #1047 — the
+ *   hard-cut replacement for the deleted inline `reduceForeground` selector). This is the post-grace
  *   counterpart of [foregroundReattachEffect]: a within-grace foreground keeps the warm
  *   `-CC` channel and reseeds; a beyond-grace foreground (lease evicted on the App-grace
  *   teardown) re-dials. Defaults to a no-op so the observe-only test harness keeps its
@@ -281,8 +282,9 @@ class ConnectionEffectDriver(
             // edge (the App-grace teardown evicted the warm lease, so the controller's
             // own grace predicate is not-warm -> Reconnecting). On that edge the driver
             // fires the VM-supplied effect that replays `pendingReattach` / resumes a
-            // `pausedAutoReconnect` (selected via the inline-equivalent reduceForeground
-            // predicate). Only the Backgrounded -> Reconnecting edge fires this; a
+            // `pausedAutoReconnect` (selected by the connection-core ForegroundReturnEffects
+            // — EPIC #687 Slice 0 / #1047 — the hard-cut replacement for the deleted inline
+            // reduceForeground selector). Only the Backgrounded -> Reconnecting edge fires this; a
             // Reconnecting reached from the reconnect LADDER (a transport drop, not a
             // foreground return) is NOT a foreground arm.
             if (current is ConnectionState.Reconnecting && previous is ConnectionState.Backgrounded) {

--- a/app/src/main/java/com/pocketshell/app/tmux/connection/ForegroundReturn.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/connection/ForegroundReturn.kt
@@ -1,0 +1,79 @@
+package com.pocketshell.app.tmux.connection
+
+/**
+ * EPIC #687 Slice 0 (#1047) — the FOREGROUND-RETURN decision, the FIRST of the four
+ * inline `TmuxSessionViewModel` `reduce*` selectors retired into the connection core
+ * under the maintainer's Path-A D28 consolidation.
+ *
+ * Before this slice the beyond-grace foreground arm (replay-vs-resume) was decided by the
+ * inline `TmuxSessionViewModel.reduceForeground()` selector — a SECOND decision authority
+ * alongside the [com.pocketshell.core.connection.ConnectionController], the exact
+ * dual-authority condition D28 exists to end. The decision reads ONLY two effect payloads
+ * (`pendingReattach` / `pausedAutoReconnect`), so it needs ZERO new controller context:
+ * the VM passes the two payload predicates + the arm IO bodies and this connection-core
+ * type OWNS the decision. The inline `reduceForeground()` and its two `ConnectionDecision`
+ * variants (`ReplayPendingReattach` / `ResumePausedReconnect`) are DELETED in the same
+ * change (D22 hard-cut — no shadow selector, no coexistence).
+ */
+enum class ForegroundReturnArm {
+    /** Replay the stashed `pendingReattach` (a fresh connect to the detached session). */
+    ReplayPendingReattach,
+
+    /** Resume an auto-reconnect that was paused while backgrounded. */
+    ResumePausedReconnect,
+
+    /** No pending arm — the foreground is a no-op (the old inline `Ignore`). */
+    None,
+}
+
+/**
+ * The PURE foreground-return selector — the connection-core replacement for the deleted
+ * inline `reduceForeground()` predicate. The arm ORDER is byte-identical to the inline
+ * selector: a stashed `pendingReattach` replay takes precedence over a
+ * `pausedAutoReconnect` resume (the #685 predicate-order trap — keep the EXACT inline
+ * precedence so behavior is unchanged).
+ */
+fun selectForegroundReturnArm(
+    hasPendingReattach: Boolean,
+    hasPausedAutoReconnect: Boolean,
+): ForegroundReturnArm = when {
+    hasPendingReattach -> ForegroundReturnArm.ReplayPendingReattach
+    hasPausedAutoReconnect -> ForegroundReturnArm.ResumePausedReconnect
+    else -> ForegroundReturnArm.None
+}
+
+/**
+ * The connection-core foreground-return dispatcher: the SINGLE authority for the
+ * beyond-grace foreground decision. The driver's `Backgrounded -> Reconnecting` edge
+ * (and the App-grace post-grace hook) call [dispatch]; it [selectForegroundReturnArm]s
+ * from the wired payload predicates and fires the matching VM-supplied IO body.
+ *
+ * The payload predicates ([hasPendingReattach] / [hasPausedAutoReconnect]) re-read the
+ * VM's live state at dispatch time (the #685 trap: the decision must read CURRENT state,
+ * not a snapshot captured at construction), and the arm bodies are the VM's existing IO.
+ * This type holds the DECISION; the VM holds the state + the IO.
+ */
+class ForegroundReturnEffects(
+    private val hasPendingReattach: () -> Boolean,
+    private val hasPausedAutoReconnect: () -> Boolean,
+    private val replayPendingReattach: () -> Unit,
+    private val resumePausedAutoReconnect: () -> Unit,
+    private val onNoPendingArm: () -> Unit = {},
+) {
+    /**
+     * Select the foreground-return arm from the live payloads and fire its body. Returns
+     * the selected arm so the characterization test can assert on the decision directly.
+     */
+    fun dispatch(): ForegroundReturnArm {
+        val arm = selectForegroundReturnArm(
+            hasPendingReattach = hasPendingReattach(),
+            hasPausedAutoReconnect = hasPausedAutoReconnect(),
+        )
+        when (arm) {
+            ForegroundReturnArm.ReplayPendingReattach -> replayPendingReattach()
+            ForegroundReturnArm.ResumePausedReconnect -> resumePausedAutoReconnect()
+            ForegroundReturnArm.None -> onNoPendingArm()
+        }
+        return arm
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
@@ -5104,7 +5104,7 @@ class TmuxSessionViewModelTest {
 
             // Beyond grace (the lease was evicted on the detach teardown -> controller's grace
             // predicate is not-warm), the controller walks Backgrounded -> Reconnecting, which
-            // fires the re-homed foreground arm (ConnectionDecision.ReplayPendingReattach).
+            // fires the re-homed foreground arm (ForegroundReturnArm.ReplayPendingReattach).
             vm.onAppForegrounded()
             assertFalse(
                 "app foreground hook must arm post-grace reattach without waiting on a later driver turn",

--- a/app/src/test/java/com/pocketshell/app/tmux/connection/ForegroundReturnEffectsTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/connection/ForegroundReturnEffectsTest.kt
@@ -1,0 +1,151 @@
+package com.pocketshell.app.tmux.connection
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * EPIC #687 Slice 0 (#1047) — the connection-core CHARACTERIZATION proof for the
+ * foreground-return decision, the hard-cut replacement for the deleted inline
+ * `TmuxSessionViewModel.reduceForeground()` selector (D28 single active path; D22 hard-cut).
+ *
+ * RED→GREEN (the retirement pattern this slice proves for the later slices):
+ *  - RED: before the wiring, the [ConnectionController]/driver could NOT reproduce the
+ *    replay-vs-resume arm — it has only DISPLAY state (Reconnecting), not the VM's
+ *    `pendingReattach` / `pausedAutoReconnect` payloads, so a controller-only decision is
+ *    impossible. (Demonstrated by the implementer locally by stubbing
+ *    [selectForegroundReturnArm] to always return `None` — the Replay / Resume / precedence
+ *    cases below FAIL.)
+ *  - GREEN: with the two effect payloads wired in, the connection-core
+ *    [ForegroundReturnEffects] reproduces the EXACT inline `reduceForeground` arm for every
+ *    fixture, including the NON-happy ones (within-grace resume / paused-auto-reconnect)
+ *    and the predicate-order precedence (the #685 trap).
+ *
+ * The inline `reduceForeground()` mapping this pins (now deleted from the VM):
+ *   pendingReattach != null      -> ReplayPendingReattach   (replay wins)
+ *   pausedAutoReconnect != null  -> ResumePausedReconnect
+ *   neither                      -> Ignore / None (no-op)
+ */
+class ForegroundReturnEffectsTest {
+
+    // ---- the PURE selector: class-coverage over all four input combinations ----------
+
+    @Test
+    fun selector_pendingReattachOnly_replays() {
+        assertEquals(
+            ForegroundReturnArm.ReplayPendingReattach,
+            selectForegroundReturnArm(hasPendingReattach = true, hasPausedAutoReconnect = false),
+        )
+    }
+
+    @Test
+    fun selector_pausedAutoReconnectOnly_resumes() {
+        // NON-happy fixture: paused-auto-reconnect (the within-grace-resume class).
+        assertEquals(
+            ForegroundReturnArm.ResumePausedReconnect,
+            selectForegroundReturnArm(hasPendingReattach = false, hasPausedAutoReconnect = true),
+        )
+    }
+
+    @Test
+    fun selector_bothSet_replayWinsPrecedence() {
+        // The #685 predicate-ORDER trap: a stashed replay takes precedence over a resume,
+        // exactly as the inline `reduceForeground` checked pendingReattach FIRST.
+        assertEquals(
+            ForegroundReturnArm.ReplayPendingReattach,
+            selectForegroundReturnArm(hasPendingReattach = true, hasPausedAutoReconnect = true),
+        )
+    }
+
+    @Test
+    fun selector_neitherSet_none() {
+        assertEquals(
+            ForegroundReturnArm.None,
+            selectForegroundReturnArm(hasPendingReattach = false, hasPausedAutoReconnect = false),
+        )
+    }
+
+    // ---- the DISPATCHER: fires exactly the matching arm body, re-reading live state ---
+
+    private class Recorder {
+        var replay = 0
+        var resume = 0
+        var noArm = 0
+    }
+
+    private fun effects(
+        hasPendingReattach: () -> Boolean,
+        hasPausedAutoReconnect: () -> Boolean,
+        rec: Recorder,
+    ) = ForegroundReturnEffects(
+        hasPendingReattach = hasPendingReattach,
+        hasPausedAutoReconnect = hasPausedAutoReconnect,
+        replayPendingReattach = { rec.replay += 1 },
+        resumePausedAutoReconnect = { rec.resume += 1 },
+        onNoPendingArm = { rec.noArm += 1 },
+    )
+
+    @Test
+    fun dispatch_pendingReattach_firesReplayOnly() {
+        val rec = Recorder()
+        val arm = effects({ true }, { false }, rec).dispatch()
+        assertEquals(ForegroundReturnArm.ReplayPendingReattach, arm)
+        assertEquals(1, rec.replay)
+        assertEquals(0, rec.resume)
+        assertEquals(0, rec.noArm)
+    }
+
+    @Test
+    fun dispatch_pausedAutoReconnect_firesResumeOnly() {
+        // NON-happy fixture: within-grace resume / paused-auto-reconnect.
+        val rec = Recorder()
+        val arm = effects({ false }, { true }, rec).dispatch()
+        assertEquals(ForegroundReturnArm.ResumePausedReconnect, arm)
+        assertEquals(0, rec.replay)
+        assertEquals(1, rec.resume)
+        assertEquals(0, rec.noArm)
+    }
+
+    @Test
+    fun dispatch_bothSet_firesReplayOnly_precedence() {
+        val rec = Recorder()
+        val arm = effects({ true }, { true }, rec).dispatch()
+        assertEquals(ForegroundReturnArm.ReplayPendingReattach, arm)
+        assertEquals(1, rec.replay)
+        assertEquals(0, rec.resume)
+    }
+
+    @Test
+    fun dispatch_neitherSet_firesNoArmOnly() {
+        val rec = Recorder()
+        val arm = effects({ false }, { false }, rec).dispatch()
+        assertEquals(ForegroundReturnArm.None, arm)
+        assertEquals(0, rec.replay)
+        assertEquals(0, rec.resume)
+        assertEquals(1, rec.noArm)
+    }
+
+    /**
+     * The #685 RE-READ trap: the dispatcher must consult the payload predicates at
+     * dispatch time, NOT a value snapshotted at construction. A payload that flips from
+     * present to absent between dispatches selects a different arm — proving the live
+     * re-read the inline selector did is preserved.
+     */
+    @Test
+    fun dispatch_reReadsLivePayloadsEachCall() {
+        val rec = Recorder()
+        var hasPending = true
+        val fx = ForegroundReturnEffects(
+            hasPendingReattach = { hasPending },
+            hasPausedAutoReconnect = { false },
+            replayPendingReattach = { rec.replay += 1 },
+            resumePausedAutoReconnect = { rec.resume += 1 },
+            onNoPendingArm = { rec.noArm += 1 },
+        )
+        assertEquals(ForegroundReturnArm.ReplayPendingReattach, fx.dispatch())
+        // The replay consumed the stashed reattach: the live payload is now absent.
+        hasPending = false
+        assertEquals(ForegroundReturnArm.None, fx.dispatch())
+        assertEquals(1, rec.replay)
+        assertEquals(1, rec.noArm)
+    }
+}


### PR DESCRIPTION
## D28 Path A — Slice 0 of 0–5

Retires the inline `reduceForeground` selector into the connection core. Maintainer chose **Path A** (finish the #687 single-path migration via journey-gated slices); this is the first, lowest-risk slice that proves the retirement pattern.

### Change
- Delete inline `reduceForeground()` + its two foreground-only `ConnectionDecision` variants (`ReplayPendingReattach` / `ResumePausedReconnect`).
- New `ForegroundReturnEffects` (`selectForegroundReturnArm`) — the connection core is now the **sole** foreground-return authority (single active path, no shadow).
- `ConnectionDecision` 14 → 12 variants; VM net-negative.

### Verification
- **Red→green** (implementer + reviewer, independently): stub `selectForegroundReturnArm` → 7/9 fail; restore → 9/9 pass.
- **Full `:app:testDebugUnitTest`** = 3119 tests, 0 failures, 0 skipped.
- **#685 predicate-drift**: `when` moved verbatim; characterization covers all 4 arms + within-grace-resume non-happy fixture + the live re-read trap.
- **#638 journey backstop**: `BackgroundGraceReconnectE2eTest` unchanged, gate-wired.
- Reviewer: **APPROVED** (APPROVED-with-CI-journey-gate; verbatim relocation, JVM equivalence proven, on-device journey intact in per-push CI).

Part of #1047 — does NOT close it (Slices 1–5 follow).