### PR TITLE
ci: shard journey suite 3-way + bound core-terminal proofs (#835)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -319,22 +319,42 @@ jobs:
     if: github.event_name != 'pull_request'
     needs: [unit, python, integration]
     runs-on: ubuntu-latest
-    # Issue #835 (REOPENED, RIGHT-SIZE): raised 45 -> 95 so the suite can run the
-    # FULL load-bearing selection (~83 journey classes + 6 core-terminal proofs ≈
-    # 89 connected-test invocations) to a verdict in one serial pass instead of
-    # being SIGKILLed mid-loop. The dominant cost — a fresh `--no-daemon` Gradle
-    # JVM per class — is removed by reusing the Gradle daemon in
-    # scripts/ci-journey-suite.sh (per-class isolation preserved; see that note),
-    # which is what makes the serial wall-clock fit this cap at all.
-    # `timeout-minutes` is a CAP, not a fixed duration: the job ENDS when the
-    # suite ends (early on a healthy run), so this only lets the worst case
-    # finish. The suite owns its OWN 4200s budget and bails cleanly before this
-    # cap; the arithmetic is 95-min cap (5700s) - 900s worst-case boot - 4200s
-    # suite budget = 600s for the classifier + Docker log collection + artifact
-    # upload (the same 600s slack the #908 invariant kept). A wedging test still
-    # fails fast via the per-test `timeout_msec` in the suite; this cap only
-    # bounds the absolute worst case so a hang can never burn the runner
-    # indefinitely.
+    # Issue #835 (REOPENED, SHARD): the right-size-only fix (#1055, 45->95 cap +
+    # 4200s budget + Gradle daemon reuse) STILL could not finish the full
+    # selection serially on ONE swiftshader AVD — its own validation run
+    # (98384e91, run 28307686762) ran the full 95 min and was CANCELLED. ~83
+    # journey classes + 6 proofs run serially is ~69+ min of wall-clock AND
+    # degrades the single emulator (the #470 enumeration stall worsens the more
+    # the one AVD is churned). Fix: SHARD the journey class list across a matrix
+    # of runners — each leg is its OWN runner + cold-booted emulator + Docker
+    # `agents` fixtures and runs only its 1/N round-robin slice (the suite reads
+    # POCKETSHELL_JOURNEY_CI_SHARD_INDEX/_TOTAL; see scripts/ci-journey-suite.sh).
+    # That cuts each leg's wall-clock to ~1/N (comfortably inside the budget) and
+    # keeps each emulator far healthier (~1/N install/teardown cycles), attacking
+    # the #470 root. `fail-fast: false` so one shard's failure does not cancel the
+    # others (we want every shard's verdict). The 6 core-terminal proofs are NOT
+    # sharded — they run on every leg (cheap in-process Compose UI tests).
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2]
+    env:
+      # Set by the matrix; the suite partitions JOURNEY_CLASSES round-robin by
+      # (index % total). Keep _TOTAL in sync with the length of matrix.shard.
+      POCKETSHELL_JOURNEY_CI_SHARD_INDEX: ${{ matrix.shard }}
+      POCKETSHELL_JOURNEY_CI_SHARD_TOTAL: 3
+    # Issue #835 (REOPENED, RIGHT-SIZE): raised 45 -> 95 originally so the FULL
+    # serial selection could finish; with sharding each leg runs ~1/3 the classes
+    # and finishes well under this cap. `timeout-minutes` is a CAP, not a fixed
+    # duration: the job ENDS when the suite ends (early on a healthy run), so this
+    # only bounds the absolute worst case. The suite owns its OWN 4200s budget and
+    # bails cleanly before this cap; the arithmetic is
+    # 95-min cap (5700s) - 900s worst-case boot - 4200s suite budget = 600s for
+    # the classifier + Docker log collection + artifact upload (the same 600s
+    # slack the #908 invariant kept).
+    # A wedging test still fails fast via the per-test `timeout_msec` in the
+    # suite; this cap only bounds the absolute worst case so a hang can never burn
+    # the runner indefinitely.
     timeout-minutes: 95
 
     steps:
@@ -944,7 +964,8 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: emulator-journey-android-test-reports
+          # Issue #835: per-shard name so matrix legs don't collide on upload.
+          name: emulator-journey-android-test-reports-shard-${{ matrix.shard }}
           path: |
             **/build/reports/androidTests/
             **/build/outputs/androidTest-results/
@@ -957,7 +978,8 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: emulator-journey-docker-logs
+          # Issue #835: per-shard name so matrix legs don't collide on upload.
+          name: emulator-journey-docker-logs-shard-${{ matrix.shard }}
           path: artifacts/docker/
           if-no-files-found: ignore
 

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -1231,10 +1231,60 @@ JOURNEY_CLASSES=(
   "com.pocketshell.app.diagnostics.ConnectionLogHostMirrorReconnectDockerTest"
 )
 
+# ---------------------------------------------------------------------------
+# Issue #835 (REOPENED): CI-matrix sharding of the journey class list.
+#
+# Root cause of the persistent emulator-journey RED/cancel: ~83 journey classes
+# + 6 core-terminal proofs run STRICTLY SERIALLY on ONE swiftshader AVD take
+# ~69+ min of wall-clock AND degrade the single emulator (the #470 enumeration
+# stall worsens as the one AVD is churned by ~89 install/run/teardown cycles).
+# Even the right-sized 4200s budget / 95-min cap (#1055) could not finish: its
+# own validation run (commit 98384e91, GH Actions run 28307686762) ran the full
+# ~95 min and was CANCELLED — no green verdict. Daemon-reuse + a bigger budget cut
+# per-class overhead but the SERIAL wall-clock and single-emulator fragility
+# remained the structural blocker.
+#
+# Fix: shard the class list across a CI MATRIX of runners (.github/workflows/
+# tests.yml `strategy.matrix.shard`). Each matrix leg is its OWN runner with its
+# OWN cold-booted emulator + its OWN Docker `agents` fixtures, and runs only its
+# 1/N slice of the journey classes (round-robin by index so the heavy
+# reconnect/switch journeys at the FRONT of the list distribute evenly across
+# shards rather than all landing on one). This (a) cuts each leg's wall-clock to
+# ~1/N so it finishes comfortably inside the budget, and (b) keeps each emulator
+# far healthier (~1/N install/teardown cycles), which directly attacks the #470
+# enumeration-stall root (a churned, degraded AVD).
+#
+# POCKETSHELL_JOURNEY_CI_SHARD_TOTAL / _INDEX are set by the workflow matrix.
+# Default (unset / TOTAL<=1) = the unsharded serial path, UNCHANGED — so local
+# runs and the budget self-test still run the FULL set. This is ORTHOGONAL to the
+# #724 POCKETSHELL_JOURNEY_SHARD dev-box pool sharding (multiple emulators on ONE
+# host); the two never combine on CI (one AVD per matrix leg). The six
+# core-terminal proofs are NOT sharded — they are cheap in-process Compose UI
+# tests (no Docker churn) and run on EVERY shard so a regression in any of them is
+# caught on every leg.
+JOURNEY_CI_SHARD_TOTAL="${POCKETSHELL_JOURNEY_CI_SHARD_TOTAL:-1}"
+JOURNEY_CI_SHARD_INDEX="${POCKETSHELL_JOURNEY_CI_SHARD_INDEX:-0}"
+[[ "$JOURNEY_CI_SHARD_TOTAL" =~ ^[0-9]+$ ]] || JOURNEY_CI_SHARD_TOTAL=1
+[[ "$JOURNEY_CI_SHARD_INDEX" =~ ^[0-9]+$ ]] || JOURNEY_CI_SHARD_INDEX=0
+(( JOURNEY_CI_SHARD_TOTAL < 1 )) && JOURNEY_CI_SHARD_TOTAL=1
+(( JOURNEY_CI_SHARD_INDEX < 0 || JOURNEY_CI_SHARD_INDEX >= JOURNEY_CI_SHARD_TOTAL )) && JOURNEY_CI_SHARD_INDEX=0
+
+EFFECTIVE_JOURNEY_CLASSES=()
+if (( JOURNEY_CI_SHARD_TOTAL <= 1 )); then
+  EFFECTIVE_JOURNEY_CLASSES=("${JOURNEY_CLASSES[@]}")
+else
+  for _shard_i in "${!JOURNEY_CLASSES[@]}"; do
+    if (( _shard_i % JOURNEY_CI_SHARD_TOTAL == JOURNEY_CI_SHARD_INDEX )); then
+      EFFECTIVE_JOURNEY_CLASSES+=("${JOURNEY_CLASSES[$_shard_i]}")
+    fi
+  done
+  echo ">>> CI journey shard ${JOURNEY_CI_SHARD_INDEX}/${JOURNEY_CI_SHARD_TOTAL} (issue #835): running ${#EFFECTIVE_JOURNEY_CLASSES[@]} of ${#JOURNEY_CLASSES[@]} journey classes (round-robin), plus all 6 core-terminal proofs"
+fi
+
 echo "=========================================================="
 echo "Per-push CI journey suite (issue #691) — load-bearing subset"
 echo "Included classes:"
-for c in "${JOURNEY_CLASSES[@]}"; do
+for c in "${EFFECTIVE_JOURNEY_CLASSES[@]}"; do
   echo "  - $c"
 done
 echo "  (pocketshellCi=true; deterministic agents:2222 only, no toxiproxy)"
@@ -1440,6 +1490,54 @@ run_class() {
   return "$rc"
 }
 
+# run_ct_class <FQCN> — runs ONE core-terminal proof class as its own
+# :shared:core-terminal:connectedDebugAndroidTest invocation, wrapped in the
+# SAME budget-capped `timeout` discipline as run_class (issue #835 REOPENED).
+#
+# Before this, the six core-terminal proofs below invoked Gradle with NO
+# `timeout` wrapper and NO budget cap. That is the PROXIMATE cause of the
+# 95-min CANCEL in run 28307686762: the #796 output-burst-IME proof
+# (CodexOutputBurstImeMainThreadProofTest) HUNG on the degraded swiftshader AVD
+# at minute ~69 and, being unbounded, ran until the workflow JOB cap SIGKILLed
+# the whole step — producing a "cancelled" with NO trustworthy summary.md (the
+# exact reopen symptom, mis-routed to the #470/#771 branches). Bounding every
+# proof at min(per-class cap, budget remaining) — identical to run_class —
+# guarantees a hung proof is a CLEAN classifiable cap-hit (rc 124/137) that
+# writes a summary, NEVER a job-cap cancel. A killed invocation's Gradle
+# daemon/file-hash lock (#918) is cleared by cleanup_gradle_after_timeout, same
+# as the journey path.
+run_ct_class() {
+  local fqcn="$1"
+  local remaining cap rc attempt_start attempt_elapsed
+  LAST_RUN_CLASS_TIMEOUT_HIT=0
+  LAST_RUN_CLASS_BUDGET_EXHAUSTED_AFTER_ATTEMPT=0
+  remaining="$(budget_remaining)"
+  cap="$JOURNEY_CLASS_TIMEOUT_SECS"
+  (( remaining < cap )) && cap="$remaining"
+  if (( cap <= 0 )); then
+    LAST_RUN_CLASS_TIMEOUT_HIT=1
+    LAST_RUN_CLASS_BUDGET_EXHAUSTED_AFTER_ATTEMPT=1
+    return 124
+  fi
+  attempt_start=$SECONDS
+  timeout --signal=TERM --kill-after="$JOURNEY_CLASS_KILL_AFTER_SECS" "${cap}s" \
+    "$GRADLEW" :shared:core-terminal:connectedDebugAndroidTest \
+    -Pandroid.testInstrumentationRunnerArguments.class="$fqcn" \
+    --stacktrace
+  rc=$?
+  attempt_elapsed=$((SECONDS - attempt_start))
+  if [[ $rc -eq 124 || ( $rc -eq 137 && $attempt_elapsed -ge $cap ) ]]; then
+    LAST_RUN_CLASS_TIMEOUT_HIT=1
+  fi
+  if budget_exhausted; then
+    LAST_RUN_CLASS_BUDGET_EXHAUSTED_AFTER_ATTEMPT=1
+  fi
+  if needs_gradle_cleanup_after_class_abort "$rc"; then
+    cleanup_gradle_after_timeout "$fqcn"
+  fi
+  return "$rc"
+}
+
 # ---------------------------------------------------------------------------
 # Issue #724: optional cross-lane sharding.
 #
@@ -1575,7 +1673,7 @@ SUITE_START=$SECONDS
 echo ">>> Suite-level time budget (issue #835): ${JOURNEY_STEP_BUDGET_SECS}s"
 echo "    (per-class attempt cap: ${JOURNEY_CLASS_TIMEOUT_SECS}s; workflow job cap: 95 min)"
 
-for fqcn in "${JOURNEY_CLASSES[@]}"; do
+for fqcn in "${EFFECTIVE_JOURNEY_CLASSES[@]}"; do
   # Issue #835: stop launching new classes once the suite-level budget is spent.
   # A #470 enumeration stall earlier in the run can eat the budget; rather than
   # let the workflow job SIGKILL us mid-class (which writes NO summary and
@@ -1670,9 +1768,7 @@ CORE_TERMINAL_APPEND_BURST_CLASS="com.pocketshell.core.terminal.ui.CodexAppendBu
 APPEND_BURST_STATUS="PASS"
 
 run_core_terminal_append_burst() {
-  "$GRADLEW" :shared:core-terminal:connectedDebugAndroidTest \
-    -Pandroid.testInstrumentationRunnerArguments.class="$CORE_TERMINAL_APPEND_BURST_CLASS" \
-    --stacktrace
+  run_ct_class "$CORE_TERMINAL_APPEND_BURST_CLASS"
 }
 
 # Issue #835: if the suite budget was already spent by a #470 stall in the
@@ -1719,9 +1815,7 @@ CORE_TERMINAL_OUTPUT_BURST_IME_CLASS="com.pocketshell.core.terminal.ui.CodexOutp
 OUTPUT_BURST_IME_STATUS="PASS"
 
 run_core_terminal_output_burst_ime() {
-  "$GRADLEW" :shared:core-terminal:connectedDebugAndroidTest \
-    -Pandroid.testInstrumentationRunnerArguments.class="$CORE_TERMINAL_OUTPUT_BURST_IME_CLASS" \
-    --stacktrace
+  run_ct_class "$CORE_TERMINAL_OUTPUT_BURST_IME_CLASS"
 }
 
 # Issue #835: same budget guard as the #803 proof above.
@@ -1763,9 +1857,7 @@ CORE_TERMINAL_MULTICHUNK_SEED_CLASS="com.pocketshell.core.terminal.ui.CodexMulti
 MULTICHUNK_SEED_STATUS="PASS"
 
 run_core_terminal_multichunk_seed() {
-  "$GRADLEW" :shared:core-terminal:connectedDebugAndroidTest \
-    -Pandroid.testInstrumentationRunnerArguments.class="$CORE_TERMINAL_MULTICHUNK_SEED_CLASS" \
-    --stacktrace
+  run_ct_class "$CORE_TERMINAL_MULTICHUNK_SEED_CLASS"
 }
 
 if budget_exhausted; then
@@ -1807,9 +1899,7 @@ CORE_TERMINAL_AGENT_LINK_AFFORDANCE_CLASS="com.pocketshell.core.terminal.ui.Agen
 AGENT_LINK_AFFORDANCE_STATUS="PASS"
 
 run_core_terminal_agent_link_affordance() {
-  "$GRADLEW" :shared:core-terminal:connectedDebugAndroidTest \
-    -Pandroid.testInstrumentationRunnerArguments.class="$CORE_TERMINAL_AGENT_LINK_AFFORDANCE_CLASS" \
-    --stacktrace
+  run_ct_class "$CORE_TERMINAL_AGENT_LINK_AFFORDANCE_CLASS"
 }
 
 if budget_exhausted; then
@@ -1857,9 +1947,7 @@ CORE_TERMINAL_REATTACH_REPAINT_CLASS="com.termux.view.TerminalViewReattachLateSu
 REATTACH_REPAINT_STATUS="PASS"
 
 run_core_terminal_reattach_repaint() {
-  "$GRADLEW" :shared:core-terminal:connectedDebugAndroidTest \
-    -Pandroid.testInstrumentationRunnerArguments.class="$CORE_TERMINAL_REATTACH_REPAINT_CLASS" \
-    --stacktrace
+  run_ct_class "$CORE_TERMINAL_REATTACH_REPAINT_CLASS"
 }
 
 if budget_exhausted; then
@@ -1904,9 +1992,7 @@ CORE_TERMINAL_OVERLAY_UNBOUNDED_CLASS="com.pocketshell.core.terminal.selection.T
 OVERLAY_UNBOUNDED_STATUS="PASS"
 
 run_core_terminal_overlay_unbounded() {
-  "$GRADLEW" :shared:core-terminal:connectedDebugAndroidTest \
-    -Pandroid.testInstrumentationRunnerArguments.class="$CORE_TERMINAL_OVERLAY_UNBOUNDED_CLASS" \
-    --stacktrace
+  run_ct_class "$CORE_TERMINAL_OVERLAY_UNBOUNDED_CLASS"
 }
 
 if budget_exhausted; then
@@ -1974,10 +2060,10 @@ echo "=========================================================="
   echo
   echo "| Selection | Args | Exit | Elapsed | Result |"
   echo "| --- | --- | --- | --- | --- |"
-  echo "| ${#JOURNEY_CLASSES[@]} load-bearing journey classes (per-class retry-once) | \`pocketshellCi=true\` | $JOURNEY_EXIT | ${SUITE_ELAPSED}s | **$journey_status** |"
+  echo "| ${#EFFECTIVE_JOURNEY_CLASSES[@]} load-bearing journey classes (shard ${JOURNEY_CI_SHARD_INDEX}/${JOURNEY_CI_SHARD_TOTAL}; per-class retry-once) | \`pocketshellCi=true\` | $JOURNEY_EXIT | ${SUITE_ELAPSED}s | **$journey_status** |"
   echo
   echo "Classes exercised:"
-  for c in "${JOURNEY_CLASSES[@]}"; do
+  for c in "${EFFECTIVE_JOURNEY_CLASSES[@]}"; do
     echo "- \`$c\`"
   done
   echo

--- a/scripts/test-ci-journey-budget.sh
+++ b/scripts/test-ci-journey-budget.sh
@@ -680,5 +680,100 @@ launched="$(grep -c '>>> JOURNEY CLASS:.*(attempt 1)' "$out2" || true)"
   || { sed -n '1,40p' "$out2"; fail "(neg-2) launched $launched/$class_count journey classes on a healthy run — some class never reached a verdict"; }
 pass "(neg-2) healthy run reaches a verdict for all $class_count load-bearing classes (none cut short)"
 
+# ---------------------------------------------------------------------------
+# (shard) ACCEPTANCE — Issue #835 (REOPENED): CI-matrix sharding partitions
+# JOURNEY_CLASSES round-robin so each leg runs a DISJOINT ~1/N slice and the
+# UNION of all legs is the FULL set. This is the structural fix that lets the
+# suite finish within the budget+cap (each leg ~1/N the wall-clock + a far
+# healthier emulator). Drive the REAL suite once per shard (instant gradle stub,
+# generous budget) and assert: (a) each shard launches ~class_count/N classes,
+# (b) the slices are pairwise DISJOINT (no class on two shards), (c) the UNION is
+# every class (none dropped), (d) the core-terminal proofs run on EVERY shard.
+echo "== CI-matrix sharding: round-robin partition is disjoint + complete =="
+cat > "$SANDBOX/gradlew" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+chmod +x "$SANDBOX/gradlew"
+
+shard_total=3
+declare -A seen_class_shard=()
+shard_union_count=0
+for shard_idx in 0 1 2; do
+  shard_log="$SANDBOX/run-shard-$shard_idx.log"
+  set +e
+  PATH="$STUBBIN:$PATH" \
+    JOURNEY_STEP_BUDGET_SECS=3600 \
+    JOURNEY_CLASS_TIMEOUT_SECS=420 \
+    POCKETSHELL_JOURNEY_CI_SHARD_TOTAL="$shard_total" \
+    POCKETSHELL_JOURNEY_CI_SHARD_INDEX="$shard_idx" \
+    bash "$SANDBOX/scripts/ci-journey-suite.sh" > "$shard_log" 2>&1
+  rc_shard=$?
+  set -e
+  [[ "$rc_shard" -eq 0 ]] \
+    || { sed -n '1,40p' "$shard_log"; fail "(shard) shard $shard_idx exited $rc_shard; expected clean pass on the instant stub"; }
+  mapfile -t shard_classes < <(grep -E '>>> JOURNEY CLASS: [^ ]+ \(attempt 1\)' "$shard_log" | awk '{print $4}')
+  shard_n="${#shard_classes[@]}"
+  lo=$(( class_count / shard_total - 2 ))
+  hi=$(( class_count / shard_total + 2 ))
+  [[ "$shard_n" -ge "$lo" && "$shard_n" -le "$hi" ]] \
+    || fail "(shard) shard $shard_idx launched $shard_n classes; expected ~$((class_count / shard_total)) (±2)"
+  for sc in "${shard_classes[@]}"; do
+    [[ -z "${seen_class_shard[$sc]:-}" ]] \
+      || fail "(shard) class $sc ran on BOTH shard ${seen_class_shard[$sc]} and shard $shard_idx — partition not disjoint"
+    seen_class_shard["$sc"]="$shard_idx"
+    shard_union_count=$((shard_union_count + 1))
+  done
+  grep -q 'CORE-TERMINAL #796 OUTPUT-BURST-IME PROOF' "$shard_log" \
+    || fail "(shard) shard $shard_idx did not run the core-terminal proofs (they must run on EVERY leg, not be sharded)"
+done
+[[ "$shard_union_count" -eq "$class_count" ]] \
+  || fail "(shard) union of all shards = $shard_union_count classes, expected the full $class_count (a class ran on no shard or twice)"
+pass "(shard) round-robin partition: 3 shards each ~1/3, disjoint, union = all $class_count classes; proofs on every shard"
+
+# ---------------------------------------------------------------------------
+# (m) ACCEPTANCE — Issue #835 (REOPENED): the six core-terminal proofs are now
+# wrapped in the SAME budget-capped `timeout` as the journey classes
+# (run_ct_class). Before, they ran UNBOUNDED — the #796 proof HUNG in run
+# 28307686762 and ran until the JOB cap SIGKILLed the step, producing a
+# "cancelled" with NO trustworthy summary.md (the exact reopen symptom). Model a
+# proof that HANGS (the core-terminal task sleeps far longer than the per-class
+# cap). With the bound, the suite must SELF-FINISH (write summary, exit red)
+# inside an outer wall-clock guard; WITHOUT the bound the suite would hang and
+# the outer `timeout` would have to KILL it (rc 124) — exactly the cancel we are
+# eliminating.
+echo "== Core-terminal proofs are bounded: a hung proof cannot hang the suite =="
+cat > "$SANDBOX/gradlew" <<'STUB'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--stop" ]]; then exit 0; fi
+if [[ "$*" == *":shared:core-terminal:connectedDebugAndroidTest"* ]]; then
+  sleep 30
+  exit 0
+fi
+exit 0
+STUB
+chmod +x "$SANDBOX/gradlew"
+
+out_ct="$SANDBOX/run-ct-bound.log"
+set +e
+timeout --signal=TERM --kill-after=10 150s \
+  env PATH="$STUBBIN:$PATH" \
+    JOURNEY_STEP_BUDGET_SECS=3600 \
+    JOURNEY_CLASS_TIMEOUT_SECS=2 \
+    JOURNEY_CLASS_KILL_AFTER_SECS=1 \
+    JOURNEY_GRADLE_STOP_TIMEOUT_SECS=5 \
+    bash "$SANDBOX/scripts/ci-journey-suite.sh" > "$out_ct" 2>&1
+rc_ct=$?
+set -e
+
+[[ "$rc_ct" -ne 124 ]] \
+  || { sed -n '1,60p' "$out_ct"; fail "(m) the outer guard had to KILL the suite — a core-terminal proof was NOT bounded (the #835 unbounded-proof regression that caused the 95-min cancel)"; }
+summary_ct="$SANDBOX/artifacts/ci-journey/summary.md"
+[[ -f "$summary_ct" ]] \
+  || fail "(m) a bounded hung proof must still write summary.md (the artifact the classifier needs — no silent cancel)"
+grep -qE 'output-burst-IME ANR proof.*\*\*FAIL\*\*' "$summary_ct" \
+  || { cat "$summary_ct"; fail "(m) the hung #796 proof must surface as FAIL in the summary (classifiable red, not a cancel)"; }
+pass "(m) core-terminal proofs are timeout-bounded — a hung proof yields a classifiable summary, never a job-cap cancel"
+
 echo
 echo "ALL TESTS PASSED"


### PR DESCRIPTION
## Release gate — get a green Emulator-journey run on `main`

There is currently NO green journey run on `main`. #1055 raised the budget but its own run still cancelled at ~95 min. This fixes the two real causes.

### Root cause (run 28307686762)
- **(A)** the 6 core-terminal proofs ran with NO `timeout` wrapper — one hung 21 min until the job cap SIGKILLed the step → `cancelled` with no `summary.md`.
- **(B)** ~89 serial connected tests on one degrading swiftshader AVD ≈ 75–80 min, zero margin.

### Fix (CI/scripts only — no product `.kt`)
- `run_ct_class` bounds all 6 core-terminal proofs in the budget-capped `timeout` → a hung proof is a classifiable cap-hit, never a job-cap cancel.
- **3-way `matrix.shard`** (`fail-fast:false`) round-robins `JOURNEY_CLASSES` → each leg runs ~1/3 (28/28/28) on a fresh emulator (~38 min/leg).
- `test-ci-journey-budget.sh`: +2 gate-wired tests (shard disjoint+complete union = all 84; bounded-proof red→green). **18/18.**

### Verification
- Reviewer **APPROVED**: independently verified shard partition disjoint+complete (84 → 28/28/28), all 6 proofs bounded (own red→green), classifier surfaces the 8-failed-both fork rather than hiding it.
- Local gate: budget 18/18, harness PASS, `bash -n`/`shellcheck` clean, YAML valid, matrix wiring confirmed.

Does NOT `Close` #835 — the durable proof is the green post-merge journey batch (D33); the flake-vs-regression fork on the 8 classes resolves on the first sharded run.