### PR TITLE
portfwd: ride port forwards through cellular network changes (#1058)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/portfwd/ForwardingNetworkRideThroughE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/portfwd/ForwardingNetworkRideThroughE2eTest.kt
@@ -1,0 +1,279 @@
+package com.pocketshell.app.portfwd
+
+import android.content.Context
+import android.os.SystemClock
+import android.util.Log
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.MainActivity
+import com.pocketshell.app.connectivity.TerminalNetworkObserver
+import com.pocketshell.app.connectivity.TerminalNetworkSnapshot
+import com.pocketshell.app.diagnostics.DiagnosticEvents
+import com.pocketshell.app.hosts.FORWARDING_INDICATOR_TAG
+import com.pocketshell.app.hosts.SshKeyStorage
+import com.pocketshell.app.proof.DEFAULT_HOST
+import com.pocketshell.app.proof.DEFAULT_PORT
+import com.pocketshell.app.proof.DEFAULT_USER
+import com.pocketshell.app.proof.PreGrantPermissionsRule
+import com.pocketshell.app.proof.RecordingDiagnosticSink
+import com.pocketshell.app.proof.waitForSshFixtureReady
+import com.pocketshell.app.testaccess.TestAccessEntryPoint
+import com.pocketshell.core.ssh.SshKey
+import com.pocketshell.core.storage.entity.HostEntity
+import dagger.hilt.android.EntryPointAccessors
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * ISSUE #1058 (#843 audit R1, trigger T11 / coverage gap C1) — the port-forward
+ * tunnel must ride through a cellular network handoff / bare loss / restore the
+ * SAME liveness-first way the terminal transport already does
+ * (#981/#997/#1042/#1045), instead of calling `forceReconnectNow()` on EVERY
+ * emitted network change. On cellular the device dips into no-validated-network
+ * constantly (tunnel, elevator, RAT handover, congestion re-validation) WITHOUT
+ * the socket dying, so the old unconditional redial churned the user's forwards
+ * "restoring…" on every blip while the terminal stayed Live.
+ *
+ * This is the D33/G10 reproduce-first END-TO-END proof: it stands up a REAL
+ * forward against the deterministic `agents:2222` fixture (real [SshSession]
+ * with the always-on #945 transport keepalive running), then injects the device
+ * network event SYNTHETICALLY through the PRODUCTION [TerminalNetworkObserver]
+ * detector + emit pipeline — the SAME `changes` stream the controller subscribes
+ * to (the AVD can't mint a new `networkHandle` / enter airplane mode on demand;
+ * the #780 hard-inject model, NO self-skip). It asserts from the controller's
+ * `portforward` diagnostics (recorded on the same run), covering all three arms
+ * the audit names (D32 G2 class coverage):
+ *
+ *   (a) NetworkLost  → HOLD: the tunnels are held, ZERO redial.
+ *   (b) handoff/restore on a PROVEN-ALIVE tunnel → RIDE THROUGH: ZERO redial,
+ *       no "restoring…" churn.
+ *   (c) handoff/restore on a GENUINELY-DEAD tunnel → REDIAL (preserves the
+ *       #329/#439 re-establish contract).
+ *
+ * RED on base: the old controller recorded NO `network_loss_hold` /
+ * `network_ride_through` and force-redialled on the loss + the proven-alive
+ * restore → arms (a) and (b) FAIL. GREEN with #1058.
+ *
+ * No Docker fixture beyond the default `agents:2222` is used, so no
+ * `.github/workflows/tests.yml` change is needed.
+ */
+@RunWith(AndroidJUnit4::class)
+class ForwardingNetworkRideThroughE2eTest {
+
+    @get:Rule
+    val compose = createEmptyComposeRule()
+
+    @get:Rule
+    val grantPermissions = PreGrantPermissionsRule()
+
+    private var launchedActivity: ActivityScenario<MainActivity>? = null
+    private var seededHostId: Long? = null
+    private var diagnostics: RecordingDiagnosticSink? = null
+
+    private fun appContext(): Context =
+        InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
+
+    private fun entryPoint(): TestAccessEntryPoint =
+        EntryPointAccessors.fromApplication(appContext(), TestAccessEntryPoint::class.java)
+
+    private fun controller(): ForwardingController = entryPoint().forwardingController()
+
+    private fun observer(): TerminalNetworkObserver = entryPoint().terminalNetworkObserver()
+
+    @After
+    fun teardown() {
+        runCatching { controller().forceTransportProvenAliveForTest = null }
+        runCatching { controller().stopAllForwarding() }
+        diagnostics?.close()
+        diagnostics = null
+        seededHostId = null
+        launchedActivity?.close()
+        launchedActivity = null
+    }
+
+    @Test
+    fun cellularHandoffLossRestoreRidesThroughWhenTunnelSurvived_redialsWhenDead() {
+        val key = readFixtureKey()
+        runBlocking { waitForSshFixtureReady(SshKey.Pem(key)) }
+
+        // 1. Seed an ENABLED host pointing at the agents fixture into the real
+        //    singleton DB (the same instance the running app flows observe),
+        //    BEFORE launching MainActivity — the persisted "auto-forward on"
+        //    state, so the production resume hook stands up a REAL forward.
+        val db = entryPoint().appDatabase()
+        runBlocking {
+            db.clearAllTables()
+            controller().activeHostIdsSnapshot().forEach { controller().stopForwarding(it) }
+            val storedKey = SshKeyStorage.persistKey(
+                context = appContext(),
+                sshKeyDao = db.sshKeyDao(),
+                name = "issue1058-key-${System.currentTimeMillis()}",
+                content = key,
+            )
+            seededHostId = db.hostDao().insert(
+                HostEntity(
+                    name = "Issue1058 Ride-Through Host",
+                    hostname = DEFAULT_HOST,
+                    port = DEFAULT_PORT,
+                    username = DEFAULT_USER,
+                    keyId = storedKey.id,
+                    enabled = true,
+                ),
+            )
+        }
+        val hostId = requireNotNull(seededHostId)
+
+        // 2. Launch + force a real STOP→START so the production resume connects to
+        //    the fixture and adopts the host — a live tunnel transport (real
+        //    SshSession + always-on keepalive).
+        launchedActivity = ActivityScenario.launch(MainActivity::class.java)
+        compose.waitUntil(timeoutMillis = LAUNCH_TIMEOUT_MS) {
+            compose.onAllNodesWithText("Hosts").fetchSemanticsNodes().isNotEmpty()
+        }
+        launchedActivity!!.moveToState(Lifecycle.State.CREATED)
+        SystemClock.sleep(300)
+        launchedActivity!!.moveToState(Lifecycle.State.RESUMED)
+        compose.waitUntil(timeoutMillis = FORWARD_TIMEOUT_MS) {
+            controller().isHostActive(hostId)
+        }
+        compose.waitUntil(timeoutMillis = FORWARD_TIMEOUT_MS) {
+            compose.onAllNodesWithTag(FORWARDING_INDICATOR_TAG).fetchSemanticsNodes().isNotEmpty()
+        }
+        assertTrue(
+            "ForwardingController must report the host active before the network drive",
+            controller().isHostActive(hostId),
+        )
+
+        // 3. Record the controller's portforward diagnostics on this run.
+        val sink = RecordingDiagnosticSink().also { DiagnosticEvents.install(it) }
+        diagnostics = sink
+
+        val observer = observer()
+        // Seed a known validated baseline so the subsequent loss reliably emits a
+        // NetworkLost (the detector's loss arm is idempotent if already lost).
+        observer.emitSyntheticSnapshotForTest(
+            TerminalNetworkSnapshot.Validated(networkHandle = "net-A", transports = setOf("WIFI")),
+            reason = "issue1058-baseline",
+        )
+        SystemClock.sleep(200)
+        sink.clear()
+
+        // ---- ARM (a): a bare NetworkLost is HELD — ZERO redial. ----
+        controller().forceTransportProvenAliveForTest = false // redial-eligible if it were a handoff
+        observer.emitSyntheticSnapshotForTest(
+            TerminalNetworkSnapshot.NoValidatedNetwork,
+            reason = "issue1058-bare-loss",
+        )
+        waitForDiagnostic("network_loss_hold")
+        watchNoRedial("across the bare network loss")
+        assertEquals(
+            "the host must stay active (held, not removed) across a bare loss",
+            true,
+            controller().isHostActive(hostId),
+        )
+        Log.i(LOG_TAG, "arm (a) loss-hold verified: ${sink.events.map { it.name }}")
+
+        // ---- ARM (b): the tunnel SURVIVED the dip → restore RIDES THROUGH. ----
+        sink.clear()
+        controller().forceTransportProvenAliveForTest = true
+        observer.emitSyntheticSnapshotForTest(
+            TerminalNetworkSnapshot.Validated(networkHandle = "net-A", transports = setOf("WIFI")),
+            reason = "issue1058-restore-survived",
+        )
+        waitForDiagnostic("network_ride_through")
+        watchNoRedial("across the survivable restore (proven alive)")
+        val rideThrough = sink.eventsNamed("network_ride_through")
+        assertTrue(
+            "expected a network_ride_through (proves the ride-through arm fired, not a " +
+                "vacuous pass); events=${sink.events.map { it.name }}",
+            rideThrough.isNotEmpty(),
+        )
+        assertEquals(
+            "ride-through must be attributed to the proven-alive keepalive",
+            "transport_proven_alive",
+            rideThrough.first().fields["cause"],
+        )
+        assertEquals(
+            "the surviving tunnel must NOT enter 'restoring…' churn on ride-through",
+            0,
+            controller().flowOfRestoringHostCount().value,
+        )
+        Log.i(LOG_TAG, "arm (b) ride-through verified: ${sink.events.map { it.name }}")
+
+        // ---- ARM (c): a GENUINELY-DEAD tunnel on a handoff → REDIAL. ----
+        sink.clear()
+        controller().forceTransportProvenAliveForTest = false
+        // A cross-transport handoff (WIFI→CELLULAR) on a not-proven-alive tunnel —
+        // a real handoff the dead socket cannot survive — must redial.
+        observer.emitSyntheticSnapshotForTest(
+            TerminalNetworkSnapshot.Validated(networkHandle = "net-B", transports = setOf("CELLULAR")),
+            reason = "issue1058-handoff-dead",
+        )
+        waitForDiagnostic("network_redial")
+        val redial = sink.eventsNamed("network_redial")
+        assertTrue(
+            "expected a network_redial for the genuinely-dead handoff (preserves the " +
+                "#329/#439 re-establish contract); events=${sink.events.map { it.name }}",
+            redial.isNotEmpty(),
+        )
+        Log.i(LOG_TAG, "arm (c) dead-redial verified: ${sink.events.map { it.name }}")
+    }
+
+    private fun waitForDiagnostic(name: String) {
+        val sink = requireNotNull(diagnostics)
+        compose.waitUntil(timeoutMillis = DIAGNOSTIC_TIMEOUT_MS) {
+            sink.eventsNamed(name).isNotEmpty()
+        }
+        assertTrue(
+            "expected a $name diagnostic; events=${sink.events.map { it.name }}",
+            sink.eventsNamed(name).isNotEmpty(),
+        )
+    }
+
+    /**
+     * Forbid the redial signal across a window — proves the tunnel was held / rode
+     * through with NO churn (the whole point of #1058).
+     */
+    private fun watchNoRedial(label: String) {
+        val sink = requireNotNull(diagnostics)
+        val deadline = SystemClock.elapsedRealtime() + WATCH_NO_REDIAL_MS
+        while (SystemClock.elapsedRealtime() < deadline) {
+            val redials = sink.eventsNamed("network_redial")
+            assertTrue(
+                "expected NO network_redial for $label (the tunnel survived; no churn); " +
+                    "events=${sink.events.map { it.name }}",
+                redials.isEmpty(),
+            )
+            SystemClock.sleep(100)
+        }
+    }
+
+    private fun readFixtureKey(): String =
+        InstrumentationRegistry.getInstrumentation()
+            .context
+            .assets
+            .open("test_key")
+            .bufferedReader()
+            .use { it.readText() }
+
+    private companion object {
+        const val LOG_TAG = "Issue1058RideThrough"
+        const val WATCH_NO_REDIAL_MS = 2_000L
+        val LAUNCH_TIMEOUT_MS: Long =
+            if (com.pocketshell.app.proof.TerminalTestTimeouts.isRunningOnCi()) 40_000L else 20_000L
+        val FORWARD_TIMEOUT_MS: Long =
+            if (com.pocketshell.app.proof.TerminalTestTimeouts.isRunningOnCi()) 45_000L else 30_000L
+        val DIAGNOSTIC_TIMEOUT_MS: Long =
+            if (com.pocketshell.app.proof.TerminalTestTimeouts.isRunningOnCi()) 30_000L else 15_000L
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/portfwd/ForwardingController.kt
+++ b/app/src/main/java/com/pocketshell/app/portfwd/ForwardingController.kt
@@ -3,7 +3,10 @@ package com.pocketshell.app.portfwd
 import android.content.Context
 import android.util.Log
 import androidx.annotation.VisibleForTesting
+import com.pocketshell.app.connectivity.TerminalNetworkChange
+import com.pocketshell.app.connectivity.TerminalNetworkChangeKind
 import com.pocketshell.app.connectivity.TerminalNetworkObserver
+import com.pocketshell.app.diagnostics.DiagnosticEvents
 import com.pocketshell.app.portfwd.service.ForwardingService
 import com.pocketshell.core.portfwd.AutoForwardConfig
 import com.pocketshell.core.portfwd.AutoForwarderSupervisor
@@ -28,6 +31,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.SupervisorJob
 import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * App-singleton owner for active port-forwarding sessions and the
@@ -66,18 +70,17 @@ class ForwardingController(
     private val portRemappingDao: PortRemappingDao,
     private val scope: CoroutineScope,
     /**
-     * Validated-default-network change signal (issue #329 / #439). Each
-     * emission is a real handoff of the validated default network (e.g.
-     * wifi ↔ cellular), which is exactly the case sshj can leave a
-     * port-forward session reporting "connected" while the phone-side
-     * forwards are already dead. The controller subscribes from the
-     * port-forward side and forces a transport rebuild so the user's
-     * forwards re-establish without toggling auto-forward off/on.
+     * Validated-default-network change signal (issue #329 / #439 / #1058).
+     * The SAME [com.pocketshell.app.connectivity.TerminalNetworkObserver.changes]
+     * stream the terminal transport consumes — a kind-aware
+     * [TerminalNetworkChange] (handoff / bare loss / restore), NOT a bare
+     * marker. The controller applies the SAME liveness-first ride-through the
+     * terminal does (see [onValidatedNetworkChange]).
      *
      * Defaults to [emptyFlow] for the test constructor so unit tests that
      * don't exercise the network path stay light.
      */
-    validatedNetworkChanges: Flow<*> = emptyFlow<Any?>(),
+    validatedNetworkChanges: Flow<TerminalNetworkChange> = emptyFlow(),
 ) {
     @Inject
     constructor(
@@ -99,7 +102,7 @@ class ForwardingController(
         connector = UnavailablePortForwardConnector,
         portRemappingDao = EmptyPortRemappingDao,
         scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate),
-        validatedNetworkChanges = emptyFlow<Any?>(),
+        validatedNetworkChanges = emptyFlow(),
     )
 
     @VisibleForTesting
@@ -107,7 +110,7 @@ class ForwardingController(
         appContext: Context,
         connector: PortForwardConnector,
         portRemappingDao: PortRemappingDao,
-        validatedNetworkChanges: Flow<*>,
+        validatedNetworkChanges: Flow<TerminalNetworkChange>,
     ) : this(
         appContext = appContext,
         connector = connector,
@@ -134,20 +137,143 @@ class ForwardingController(
         MutableStateFlow<Map<Long, AutoForwarderSupervisor.ConnectionState>>(emptyMap())
     private val hostErrors = MutableStateFlow<Map<Long, String?>>(emptyMap())
 
+    /**
+     * Issue #1058 test seam (the #780/#964 hard-inject model): pin the
+     * keepalive-proven liveness verdict the network-change policy reads, so a
+     * connected journey can drive the ride-through (`true`) and genuinely-dead
+     * (`false`) arms deterministically WITHOUT reproducing the real ~90s
+     * keepalive ride-through window on the AVD. `null` (production default)
+     * reads the real per-host live [SshSession] keepalive oracle. `@Volatile`
+     * so the collector coroutine sees a flip from the test thread.
+     */
+    @Volatile
+    @VisibleForTesting
+    var forceTransportProvenAliveForTest: Boolean? = null
+
     init {
         // Subscribe to the validated-default-network change signal from the
-        // port-forward side (issue #329). A real handoff forces a transport
-        // rebuild on every active host's supervisor, mirroring what the
-        // terminal/tmux flow already does for its own sessions — but the
-        // port-forward sessions are independent transports and were missing
-        // this hook, so a clean wifi↔cellular handoff (onAvailable without a
-        // preceding onLost) left them stale-connected with dead forwards.
+        // port-forward side (issue #329 / #1058). Mirrors the terminal
+        // transport's kind-aware, liveness-first policy — see
+        // [onValidatedNetworkChange].
         scope.launch {
-            validatedNetworkChanges.collect {
-                Log.i(TAG, "validated-network-change → forceReconnectNow active=${activeHosts.size}")
-                forceReconnectNow()
+            validatedNetworkChanges.collect { change ->
+                onValidatedNetworkChange(change)
             }
         }
+    }
+
+    /**
+     * Issue #1058 (#843 R1, trigger T11 / coverage gap C1): liveness-first
+     * network-change policy for the port-forward tunnels, identical in shape to
+     * the terminal transport's (#981/#997/#1042/#1045).
+     *
+     * Before this, the controller called [forceReconnectNow] on EVERY emitted
+     * change — so on cellular, where the device dips into no-validated-network
+     * constantly (tunnel, elevator, RAT handover, congestion re-validation),
+     * the user's forwards churned "restoring…" on every blip even though the
+     * tunnel transport never died, while the terminal stayed Live.
+     *
+     * The policy now mirrors the terminal, reusing the SAME keepalive-proven
+     * liveness oracle ([SshSession.isTransportProvenAliveWithinKeepAliveWindow],
+     * #964 — the exact oracle the terminal's
+     * `isTransportKeepAliveProvenAliveRecently` also reads), with NO second
+     * liveness notion:
+     *
+     *  - [TerminalNetworkChangeKind.NetworkLost] → HOLD. A bare loss is
+     *    frequently transient; do NOT redial. Mirrors the terminal's
+     *    `holdNetworkLost` — the tunnels are held, not torn down.
+     *  - [TerminalNetworkChangeKind.NetworkRestored] /
+     *    [TerminalNetworkChangeKind.ValidatedIdentityChange] → liveness-first:
+     *    a host whose tunnel transport is keepalive-PROVEN alive RIDES THROUGH
+     *    with no redial and no "restoring…" churn; a host whose transport is
+     *    genuinely dead (or has no live session) is REDIALLED via the existing
+     *    force hook. A real cross-transport handoff on a dead/quiet tunnel
+     *    therefore still re-establishes (the #329/#439/#980 contract).
+     */
+    @VisibleForTesting
+    fun onValidatedNetworkChange(change: TerminalNetworkChange) {
+        when (change.kind) {
+            TerminalNetworkChangeKind.NetworkLost -> holdNetworkLoss(change)
+            TerminalNetworkChangeKind.NetworkRestored,
+            TerminalNetworkChangeKind.ValidatedIdentityChange,
+            -> rideThroughOrRedial(change)
+        }
+    }
+
+    /**
+     * Issue #1058: a bare network LOSS is HELD — the tunnels are NOT torn down
+     * (a loss is frequently transient: pocket, elevator, RAT handover).
+     * Recovery is driven by the matching [TerminalNetworkChangeKind.NetworkRestored].
+     */
+    private fun holdNetworkLoss(change: TerminalNetworkChange) {
+        Log.i(
+            TAG,
+            "network-loss-hold reason=${change.reason} active=${activeHosts.size} " +
+                "(bare loss — tunnels held, no redial)",
+        )
+        DiagnosticEvents.record(
+            "portforward",
+            "network_loss_hold",
+            "reason" to change.reason,
+            "kind" to change.kind.name,
+            "activeHosts" to activeHosts.size,
+        )
+    }
+
+    /**
+     * Issue #1058: a handoff / restore — ride through the hosts whose tunnel
+     * transport is keepalive-proven alive (no redial, no churn), redial the
+     * hosts whose transport is genuinely dead.
+     */
+    private fun rideThroughOrRedial(change: TerminalNetworkChange) {
+        activeHosts.forEach { host ->
+            if (isTunnelTransportProvenAlive(host)) {
+                Log.i(
+                    TAG,
+                    "network-change ride-through host=${host.hostId} reason=${change.reason} " +
+                        "kind=${change.kind} (transport proven alive)",
+                )
+                DiagnosticEvents.record(
+                    "portforward",
+                    "network_ride_through",
+                    "reason" to change.reason,
+                    "kind" to change.kind.name,
+                    "hostId" to host.hostId,
+                    "cause" to "transport_proven_alive",
+                )
+            } else {
+                Log.i(
+                    TAG,
+                    "network-change redial host=${host.hostId} reason=${change.reason} " +
+                        "kind=${change.kind} (transport not proven alive)",
+                )
+                DiagnosticEvents.record(
+                    "portforward",
+                    "network_redial",
+                    "reason" to change.reason,
+                    "kind" to change.kind.name,
+                    "hostId" to host.hostId,
+                    "cause" to "transport_dead",
+                )
+                runCatching { (host.forceReconnectHook ?: host.reconnectHook)?.invoke() }
+            }
+        }
+    }
+
+    /**
+     * Issue #1058: reuse the terminal's keepalive-proven liveness oracle
+     * ([SshSession.isTransportProvenAliveWithinKeepAliveWindow], #964) on this
+     * host's CURRENT live tunnel session. No second liveness notion — the
+     * always-on transport keepalive (#945) runs on every [SshSession]
+     * (including the port-forward sessions), so a brief sub-window dip keeps
+     * the oracle TRUE (ride through) while a genuinely dead post-outage socket
+     * ages out to FALSE (redial). A host with no live session reads FALSE.
+     */
+    private fun isTunnelTransportProvenAlive(host: ActiveHost): Boolean {
+        forceTransportProvenAliveForTest?.let { return it }
+        val session = host.liveSession?.get() ?: return false
+        return runCatching { session.isTransportProvenAliveWithinKeepAliveWindow() }
+            .getOrDefault(false)
     }
 
     fun flowOfActiveHostCount(): StateFlow<Int> = activeHostCount.asStateFlow()
@@ -250,6 +376,7 @@ class ForwardingController(
                 activeRemotePorts = existing.activeRemotePorts,
                 forwardedPortMap = existing.forwardedPortMap,
                 restoring = existing.restoring,
+                liveSession = existing.liveSession,
             )
         } else {
             activeHosts += ActiveHost(
@@ -355,10 +482,16 @@ class ForwardingController(
     }
 
     /**
-     * Stronger network-recovery hint used after the foreground service
-     * has observed an actual default-network loss. This may rebuild a
-     * session that still reports "connected" but whose forwards died
-     * under the old network.
+     * Stronger explicit redial-all hint: force-rebuilds every active host's
+     * transport even if it still reports "connected". Used for an explicit
+     * user/manual recovery action.
+     *
+     * Issue #1058: this is NOT the network-change path any more. A
+     * validated-network change goes through [onValidatedNetworkChange], which
+     * is liveness-first (it holds on a bare loss and rides a handoff/restore
+     * through when the tunnel transport is keepalive-proven alive) — it does
+     * NOT redial unconditionally, which was the cellular-churn defect (#843
+     * trigger T11).
      */
     fun forceReconnectNow() {
         activeHosts.forEach {
@@ -377,11 +510,20 @@ class ForwardingController(
     ) {
         val reconnectPassphrase = passphrase?.copyOf()
         var first: SshSession? = firstSession
+        // Issue #1058: track the CURRENT live tunnel session so the
+        // network-change policy can read its keepalive-proven liveness oracle.
+        // The supervisor owns the session lifecycle (it swaps/closes on every
+        // drop+reconnect), so we capture the freshest session at its single
+        // creation point — the factory. A stale (closed) reference reads
+        // not-proven-alive, which is the correct "redial" direction.
+        val liveSession = AtomicReference<SshSession?>(firstSession)
         val supervisor = AutoForwarderSupervisor(
             sessionFactory = {
-                first?.also { first = null }
+                val session = first?.also { first = null }
                     ?: connector.connect(host, keyPath, reconnectPassphrase?.copyOf())
                         .getOrElse { throw it }
+                liveSession.set(session)
+                session
             },
             config = host.toAutoForwardConfig(),
             initialRemappings = initialRemappings,
@@ -440,6 +582,7 @@ class ForwardingController(
                 activeRemotePorts = existing?.activeRemotePorts.orEmpty(),
                 forwardedPortMap = existing?.forwardedPortMap.orEmpty(),
                 restoring = existing?.restoring ?: false,
+                liveSession = liveSession,
             )
             recomputeSnapshot()
             if (wasEmpty) ForwardingService.start(appContext)
@@ -489,6 +632,12 @@ class ForwardingController(
         // but its transport is currently down and reconnecting, so its
         // forwards are being restored rather than removed.
         val restoring: Boolean = false,
+        // Issue #1058: the CURRENT live tunnel session (swapped by the
+        // supervisor on every reconnect), read by the network-change policy
+        // for the keepalive-proven liveness oracle. Null for a panel-only
+        // registration with no live supervisor yet (reads not-proven-alive →
+        // redial on handoff, the safe direction).
+        val liveSession: AtomicReference<SshSession?>? = null,
     ) {
         fun stopOwnedSupervisor() {
             supervisorJob?.cancel()

--- a/app/src/test/java/com/pocketshell/app/portfwd/ForwardingControllerTest.kt
+++ b/app/src/test/java/com/pocketshell/app/portfwd/ForwardingControllerTest.kt
@@ -8,6 +8,9 @@ import android.content.Intent
 import androidx.core.app.NotificationCompat
 import android.os.Looper
 import androidx.test.core.app.ApplicationProvider
+import com.pocketshell.app.connectivity.TerminalNetworkChange
+import com.pocketshell.app.connectivity.TerminalNetworkChangeKind
+import com.pocketshell.app.connectivity.TerminalNetworkSnapshot
 import com.pocketshell.app.portfwd.service.ForwardingService
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -261,14 +264,14 @@ class ForwardingControllerTest {
     }
 
     @Test
-    fun `validated network change forces a reconnect on every active host`() {
-        // Issue #329 / #439: the port-forward sessions are independent
-        // transports from the terminal/tmux flow, so a wifi↔cellular
-        // handoff (which can leave sshj reporting "connected" while the
-        // forwards are dead) must reach the supervisor force-reconnect
-        // hook. The controller subscribes to the validated-default-network
-        // change signal and forces a rebuild on each emission.
-        val networkChanges = MutableSharedFlow<Any?>(extraBufferCapacity = 16)
+    fun `validated handoff on a not-proven-alive tunnel forces a reconnect`() {
+        // Issue #329 / #439 / #1058: a real validated handoff on a tunnel whose
+        // transport is NOT keepalive-proven alive (a panel-only registration with
+        // no live session, or a genuinely dead socket) must reach the supervisor
+        // force-reconnect hook so the forwards re-establish. The liveness-first
+        // policy (#1058) only suppresses the redial when the transport is proven
+        // alive — the genuinely-dead/handoff case still redials.
+        val networkChanges = MutableSharedFlow<TerminalNetworkChange>(extraBufferCapacity = 16)
         val controller = ForwardingController(
             appContext = context,
             connector = TestUnavailableConnector,
@@ -285,24 +288,101 @@ class ForwardingControllerTest {
             forceReconnectHook = { forceCalls.incrementAndGet() },
         )
 
-        // A validated-network change forces a reconnect, not a no-churn one.
-        assertTrue(networkChanges.tryEmit(NetworkChangeMarker))
+        // A validated handoff on a not-proven-alive tunnel forces a reconnect.
+        assertTrue(networkChanges.tryEmit(handoffChange(seq = 1L)))
         idleMainLooper()
-        assertEquals("validated-network change must force a reconnect", 1, forceCalls.get())
-        assertEquals("validated-network change must not use the no-churn hook", 0, normalCalls.get())
+        assertEquals("validated handoff must force a reconnect", 1, forceCalls.get())
+        assertEquals("validated handoff must not use the no-churn hook", 0, normalCalls.get())
 
         // A second handoff forces again — the subscription is durable.
-        assertTrue(networkChanges.tryEmit(NetworkChangeMarker))
+        assertTrue(networkChanges.tryEmit(handoffChange(seq = 2L)))
         idleMainLooper()
         assertEquals(2, forceCalls.get())
         assertEquals(0, normalCalls.get())
     }
 
     @Test
+    fun `bare network loss holds the tunnels and never redials`() {
+        // Issue #1058 (#843 R1, trigger T11) — load-bearing arm (a): a bare
+        // network LOSS is HELD; the tunnels are NOT torn down (a loss is
+        // frequently transient). On BASE the controller called forceReconnectNow
+        // on EVERY change → a loss redialled (RED). With #1058 a NetworkLost is
+        // a no-redial hold (GREEN).
+        val networkChanges = MutableSharedFlow<TerminalNetworkChange>(extraBufferCapacity = 16)
+        val controller = ForwardingController(
+            appContext = context,
+            connector = TestUnavailableConnector,
+            portRemappingDao = TestEmptyRemappingDao,
+            validatedNetworkChanges = networkChanges,
+        )
+        idleMainLooper()
+        val normalCalls = java.util.concurrent.atomic.AtomicInteger(0)
+        val forceCalls = java.util.concurrent.atomic.AtomicInteger(0)
+        controller.registerActiveHost(
+            hostId = 1,
+            hostName = "alpha",
+            reconnectHook = { normalCalls.incrementAndGet() },
+            forceReconnectHook = { forceCalls.incrementAndGet() },
+        )
+        // Even pinning the transport NOT-proven-alive (the redial-eligible state
+        // for a handoff/restore), a bare LOSS must still hold — the loss is its
+        // own arm, independent of liveness.
+        controller.forceTransportProvenAliveForTest = false
+
+        assertTrue(networkChanges.tryEmit(lossChange(seq = 1L)))
+        idleMainLooper()
+        assertEquals("a bare network loss must NOT redial (held)", 0, forceCalls.get())
+        assertEquals("a bare network loss must NOT use the no-churn hook either", 0, normalCalls.get())
+    }
+
+    @Test
+    fun `restore rides through a proven-alive tunnel with zero redial, redials a dead one`() {
+        // Issue #1058 (#843 R1) — load-bearing arms (b) ride-through + (c)
+        // genuinely-dead redial. This is the JVM analogue of the connected
+        // ForwardingNetworkRideThroughE2eTest, using the keepalive-proven
+        // liveness seam to pin survived/dead deterministically.
+        val networkChanges = MutableSharedFlow<TerminalNetworkChange>(extraBufferCapacity = 16)
+        val controller = ForwardingController(
+            appContext = context,
+            connector = TestUnavailableConnector,
+            portRemappingDao = TestEmptyRemappingDao,
+            validatedNetworkChanges = networkChanges,
+        )
+        idleMainLooper()
+        val forceCalls = java.util.concurrent.atomic.AtomicInteger(0)
+        controller.registerActiveHost(
+            hostId = 1,
+            hostName = "alpha",
+            forceReconnectHook = { forceCalls.incrementAndGet() },
+        )
+
+        // (b) The tunnel SURVIVED the dip (keepalive proven alive) → RIDE THROUGH:
+        // a restore must NOT redial. On BASE every change redialled → RED.
+        controller.forceTransportProvenAliveForTest = true
+        assertTrue(networkChanges.tryEmit(restoreChange(seq = 1L)))
+        idleMainLooper()
+        assertEquals(
+            "a restore on a proven-alive tunnel must RIDE THROUGH with zero redial",
+            0,
+            forceCalls.get(),
+        )
+
+        // (c) The tunnel is genuinely DEAD (keepalive aged out) → REDIAL.
+        controller.forceTransportProvenAliveForTest = false
+        assertTrue(networkChanges.tryEmit(restoreChange(seq = 2L)))
+        idleMainLooper()
+        assertEquals(
+            "a restore on a genuinely-dead tunnel must redial (preserves #997 recovery)",
+            1,
+            forceCalls.get(),
+        )
+    }
+
+    @Test
     fun `validated network change with no active hosts is a no-op`() {
         // Before any host is auto-forwarding, a network change must not
         // crash or start the service — the fan-out is over an empty set.
-        val networkChanges = MutableSharedFlow<Any?>(extraBufferCapacity = 16)
+        val networkChanges = MutableSharedFlow<TerminalNetworkChange>(extraBufferCapacity = 16)
         val controller = ForwardingController(
             appContext = context,
             connector = TestUnavailableConnector,
@@ -312,7 +392,7 @@ class ForwardingControllerTest {
         idleMainLooper()
         drainStartedServices()
 
-        assertTrue(networkChanges.tryEmit(NetworkChangeMarker))
+        assertTrue(networkChanges.tryEmit(handoffChange(seq = 1L)))
         idleMainLooper()
 
         assertEquals(0, controller.flowOfActiveHostCount().value)
@@ -793,8 +873,44 @@ class ForwardingControllerTest {
         Shadows.shadowOf(Looper.getMainLooper()).idle()
     }
 
-    /** Marker payload for the validated-network-change signal in tests. */
-    private object NetworkChangeMarker
+    // --- Issue #1058: real TerminalNetworkChange builders for the policy tests.
+
+    private fun handoffChange(seq: Long): TerminalNetworkChange {
+        val wifi = TerminalNetworkSnapshot.Validated(networkHandle = "wifi-$seq", transports = setOf("WIFI"))
+        val cell = TerminalNetworkSnapshot.Validated(networkHandle = "cell-$seq", transports = setOf("CELLULAR"))
+        return TerminalNetworkChange(
+            previous = wifi,
+            current = cell,
+            previousValidated = wifi,
+            reason = "test-handoff-$seq",
+            sequence = seq,
+            kind = TerminalNetworkChangeKind.ValidatedIdentityChange,
+        )
+    }
+
+    private fun lossChange(seq: Long): TerminalNetworkChange {
+        val wifi = TerminalNetworkSnapshot.Validated(networkHandle = "wifi-$seq", transports = setOf("WIFI"))
+        return TerminalNetworkChange(
+            previous = wifi,
+            current = TerminalNetworkSnapshot.NoValidatedNetwork,
+            previousValidated = wifi,
+            reason = "test-loss-$seq",
+            sequence = seq,
+            kind = TerminalNetworkChangeKind.NetworkLost,
+        )
+    }
+
+    private fun restoreChange(seq: Long): TerminalNetworkChange {
+        val wifi = TerminalNetworkSnapshot.Validated(networkHandle = "wifi-$seq", transports = setOf("WIFI"))
+        return TerminalNetworkChange(
+            previous = TerminalNetworkSnapshot.NoValidatedNetwork,
+            current = wifi,
+            previousValidated = wifi,
+            reason = "test-restore-$seq",
+            sequence = seq,
+            kind = TerminalNetworkChangeKind.NetworkRestored,
+        )
+    }
 
     private object TestUnavailableConnector : PortForwardConnector {
         override suspend fun connect(

--- a/app/src/test/java/com/pocketshell/app/portfwd/PortForwardPanelViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/portfwd/PortForwardPanelViewModelTest.kt
@@ -896,7 +896,9 @@ class PortForwardPanelViewModelTest {
         // (the service's raw force-tear callback was deleted). Emit a real
         // validated-handoff change through that flow to trigger the rebuild.
         val networkChanges =
-            kotlinx.coroutines.flow.MutableSharedFlow<Any?>(extraBufferCapacity = 16)
+            kotlinx.coroutines.flow.MutableSharedFlow<com.pocketshell.app.connectivity.TerminalNetworkChange>(
+                extraBufferCapacity = 16,
+            )
         val forwardingController = newForwardingController(
             connector = connector,
             validatedNetworkChanges = networkChanges,
@@ -921,9 +923,31 @@ class PortForwardPanelViewModelTest {
 
             firstSession.simulateDeadForwardButStillConnected()
             // A real validated default-network handoff reaches the controller's
-            // hardened subscription, which forces a rebuild on every active host
-            // even after the panel is gone.
-            assertTrue(networkChanges.tryEmit(Any()))
+            // hardened subscription. The stale session is NOT keepalive-proven
+            // alive (FakeSshSession returns the interface default `false`), so the
+            // #1058 liveness-first policy classifies it genuinely dead and forces a
+            // rebuild on every active host even after the panel is gone.
+            assertTrue(
+                networkChanges.tryEmit(
+                    com.pocketshell.app.connectivity.TerminalNetworkChange(
+                        previous = com.pocketshell.app.connectivity.TerminalNetworkSnapshot.Validated(
+                            networkHandle = "wifi-1",
+                            transports = setOf("WIFI"),
+                        ),
+                        current = com.pocketshell.app.connectivity.TerminalNetworkSnapshot.Validated(
+                            networkHandle = "cell-1",
+                            transports = setOf("CELLULAR"),
+                        ),
+                        previousValidated = com.pocketshell.app.connectivity.TerminalNetworkSnapshot.Validated(
+                            networkHandle = "wifi-1",
+                            transports = setOf("WIFI"),
+                        ),
+                        reason = "issue980-handoff",
+                        sequence = 1L,
+                        kind = com.pocketshell.app.connectivity.TerminalNetworkChangeKind.ValidatedIdentityChange,
+                    ),
+                ),
+            )
             advanceTimeBy(1_100L)
             runCurrent()
 
@@ -1594,8 +1618,8 @@ class PortForwardPanelViewModelTest {
     private fun newForwardingController(
         connector: PortForwardConnector,
         portRemappingDao: com.pocketshell.core.storage.dao.PortRemappingDao = db.portRemappingDao(),
-        validatedNetworkChanges: kotlinx.coroutines.flow.Flow<*> =
-            kotlinx.coroutines.flow.emptyFlow<Any?>(),
+        validatedNetworkChanges: kotlinx.coroutines.flow.Flow<com.pocketshell.app.connectivity.TerminalNetworkChange> =
+            kotlinx.coroutines.flow.emptyFlow(),
     ): ForwardingController =
         ForwardingController(
             appContext = context,

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -847,6 +847,21 @@ JOURNEY_CLASSES=(
   # split so the intentional crash cannot poison the GREEN tests' compose rule.
   "com.pocketshell.app.portfwd.PortForwardDuplicateKeyCrashTest"
   "com.pocketshell.app.portfwd.PortForwardDuplicateKeyRenderTest"
+  # ADDED (#1058 — #843 audit R1, trigger T11 / coverage gap C1, D33/G10): the
+  # port-forward tunnel must ride through a cellular handoff / bare loss / restore
+  # the SAME liveness-first way the terminal transport does (#981/#997/#1042/#1045)
+  # instead of force-redialling on EVERY network change (the cellular-churn defect).
+  # Stands up a REAL forward against the deterministic agents:2222 fixture (real
+  # SshSession + always-on keepalive), injects the network event SYNTHETICALLY
+  # through the production TerminalNetworkObserver detector + emit pipeline (the
+  # SAME `changes` stream the controller subscribes to — the #780 hard-inject
+  # model, no self-skip), and asserts from the controller's `portforward`
+  # diagnostics across all three arms: (a) NetworkLost → HOLD (zero redial),
+  # (b) proven-alive handoff/restore → RIDE THROUGH (zero redial, no restoring
+  # churn), (c) genuinely-dead handoff → REDIAL. RED on base (the old controller
+  # recorded no loss_hold/ride_through and force-redialled the loss + proven-alive
+  # restore); GREEN with #1058. Same agents:2222 fixture; runs on CI.
+  "com.pocketshell.app.portfwd.ForwardingNetworkRideThroughE2eTest"
   # ADDED (epic #792 Slice D, #822/V7a + #823 — D31 durable-fix gate): the
   # PROACTIVE silent mid-session drop detection + auto-recovery journey. The
   # maintainer's headline #822 bug: SSH silently drops on stable Wi-Fi while the


### PR DESCRIPTION
## R1 — port-forward cellular ride-through (from #843 audit)

The tunnel called `forceReconnectNow()` on every network change, so forwards churned 'restoring…' on cellular while the terminal stayed Live (audit T11/C1). Now uses the terminal's kind-aware, liveness-first policy: `NetworkLost`→hold; restore/identity-change→ride through when the tunnel transport is keepalive-proven alive (reusing `SshSession.isTransportProvenAliveWithinKeepAliveWindow()`, the **same** oracle the terminal uses — no forked liveness); redial only when genuinely dead.

### Verification
- Reviewer **APPROVED**: drove the 3-arm red→green (loss-hold, restore ride-through zero-churn, dead-redial), confirmed oracle reuse + CI-compat.
- New connected E2E `ForwardingNetworkRideThroughE2eTest` wired into the sharded journey suite; full `:app` 447/0.
- Rebased onto the #835 reshard; journey-budget test passes at 85 classes.

Closes #1058.