### PR TITLE
core-connection: retire reduceBackground — sole background-transition authority (#1047 Slice 1)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -57,6 +57,9 @@ import com.pocketshell.app.session.canRetryAgentStream
 import com.pocketshell.app.session.markOptimisticFailed
 import com.pocketshell.app.session.reconcileAgentEvents
 import com.pocketshell.app.startup.StartupTiming
+import com.pocketshell.app.tmux.connection.BackgroundArm
+import com.pocketshell.app.tmux.connection.BackgroundEffects
+import com.pocketshell.app.tmux.connection.selectBackgroundArm
 import com.pocketshell.app.tmux.connection.ConnectionManager
 import com.pocketshell.app.tmux.connection.ConnectionEffectDriver
 import com.pocketshell.app.tmux.connection.ConnectionStatusProjection
@@ -888,7 +891,7 @@ public class TmuxSessionViewModel @Inject constructor(
             // EPIC #766 Slice 2a: the controller's `-> Backgrounded` edge now DRIVES the
             // full background decision (the re-home of the inline background
             // dispatch). [onControllerBackgrounded] selects pause-vs-detach via the
-            // inline-equivalent [reduceBackground] predicate (the #685 trap) and, on the
+            // connection-core [backgroundEffects] dispatcher (#1047 Slice 1) and, on the
             // detach arm, routes the clean-detach teardown through the single [GraceEffects]
             // owner ([graceEffects.onBackgrounded] -> launchBackgroundDetachTeardown).
             backgroundedEffect = { onControllerBackgrounded() },
@@ -3136,9 +3139,9 @@ public class TmuxSessionViewModel @Inject constructor(
         // teardown which runs AFTER the bookkeeping inside the same effect).
         //
         // The inline background event arm is no longer consulted (Slice
-        // 2a); the #685 trap is avoided because [onControllerBackgrounded] re-applies
-        // the inline-equivalent [reduceBackground] predicate (reading
-        // `clientRef`/`sessionRef`/`inlineConnectionStatus`) to select the arm — the
+        // 2a); the #685 trap is avoided because [onControllerBackgrounded] selects the arm
+        // through the connection-core [backgroundEffects] dispatcher, whose injected
+        // predicates re-read `clientRef`/`sessionRef`/`inlineConnectionStatus` — the
         // controller edge is only the TRIGGER, not the divergent display-status gate.
         connectionManager.observeBackground()
         // The controller moved to Backgrounded (mapped → Connected, the inline
@@ -3151,38 +3154,54 @@ public class TmuxSessionViewModel @Inject constructor(
      * [ConnectionEffectDriver] when the [ConnectionController] transitions INTO
      * [ConnectionState.Backgrounded]. This is the re-home of the former inline
      * inline background dispatch: the controller edge is the TRIGGER, but
-     * the pause-vs-detach SELECTION still runs through the inline-equivalent
-     * [reduceBackground] predicate so behavior is byte-identical (the #685
-     * non-byte-identical-predicate trap — the controller transitions to Backgrounded
-     * whenever it holds a host, e.g. even from `Reconnecting`, but the inline predicate
-     * also gates on `clientRef`/`sessionRef`, so the arm selection MUST re-read VM state
-     * rather than trust the controller's display state).
+     * the pause-vs-detach SELECTION runs through the connection-core [backgroundEffects]
+     * dispatcher so behavior is byte-identical (the #685 non-byte-identical-predicate trap —
+     * the controller transitions to Backgrounded whenever it holds a host, e.g. even from
+     * `Reconnecting`, but the [backgroundEffects] arm also gates on the injected
+     * `hasLiveControlChannel` (`clientRef`/`sessionRef`) liveness, so the arm selection
+     * re-reads VM state rather than trust the controller's display state).
      *
      * Ordering: the SELECTION ([detachForBackground] sets `pendingReattach` /
      * `pendingBackgroundDetachPreserveTarget`) runs FIRST, then the teardown
      * ([graceEffects.onBackgrounded] -> [launchBackgroundDetachTeardown], which reads
-     * those fields). [reduceBackground] returning [ConnectionDecision.Ignore] (no
-     * client/session) is the no-detach case — neither the bookkeeping nor the teardown
-     * runs, matching the inline `else -> Unit` arm.
+     * those fields). The [BackgroundArm.None] arm (no client/session, or no target) is the
+     * no-detach case — neither the bookkeeping nor the teardown runs, matching the inline
+     * `else -> Unit` arm.
      */
     private fun onControllerBackgrounded() {
-        when (reduceBackground()) {
-            ConnectionDecision.PauseReconnectForBackground ->
-                pauseReconnectForBackground()
-            ConnectionDecision.DetachForBackground -> {
+        backgroundEffects.dispatch()
+    }
+
+    /**
+     * EPIC #687 Slice 1 (#1047): the connection-core background-transition decision authority,
+     * the hard-cut replacement for the deleted inline `reduceBackground()`. The predicates
+     * re-read the VM's live state each dispatch (the #685 re-read trap): `isReconnecting`
+     * reads `inlineConnectionStatus`, `hasTarget` reads `activeTarget`/`connectingTarget`, and
+     * the INJECTED [BackgroundEffects.hasLiveControlChannel] port feeds the
+     * `clientRef != null || sessionRef != null` liveness the controller's display state lacks
+     * (a `Backgrounded` transition does not imply a live `-CC` channel). The arm bodies are the
+     * VM's existing IO; the detach arm runs the [detachForBackground] bookkeeping FIRST then the
+     * teardown through the single [GraceEffects] owner (identical order to the deleted inline
+     * `when`); the no-arm case is the inline `else -> Unit` no-op.
+     */
+    private val backgroundEffects: BackgroundEffects =
+        BackgroundEffects(
+            isReconnecting = { inlineConnectionStatus is ConnectionStatus.Reconnecting },
+            hasTarget = { activeTarget != null || connectingTarget != null },
+            hasLiveControlChannel = { clientRef != null || sessionRef != null },
+            pauseReconnectForBackground = { pauseReconnectForBackground() },
+            detachForBackground = {
                 detachForBackground()
                 // The clean-detach teardown reads the bookkeeping just set above; run it
                 // AFTER, through the single [GraceEffects] owner.
                 graceEffects.onBackgrounded()
-            }
-            else -> Unit
-        }
-    }
+            },
+        )
 
     /**
-     * EPIC #687 slice 1a: the [ConnectionDecision.PauseReconnectForBackground]
-     * body — formerly inline at the top of [onAppBackgrounded]. Unchanged
-     * behavior; only the decision moved to [reduceBackground].
+     * EPIC #687 slice 1a: the [BackgroundArm.PauseReconnect] body — formerly inline at the
+     * top of [onAppBackgrounded]. Unchanged behavior; only the decision moved to the
+     * connection-core [backgroundEffects] dispatcher (#1047 Slice 1).
      */
     private fun pauseReconnectForBackground() {
         val reconnecting = inlineConnectionStatus as? ConnectionStatus.Reconnecting ?: return
@@ -3216,11 +3235,11 @@ public class TmuxSessionViewModel @Inject constructor(
     }
 
     /**
-     * EPIC #687 slice 1a: the [ConnectionDecision.DetachForBackground] body —
+     * EPIC #687 slice 1a: the [BackgroundArm.DetachForBackground] body —
      * formerly the lower half of [onAppBackgrounded]. The `target`/`clientRef||
-     * sessionRef` guards already passed in [reduceBackground] but are kept here so
-     * the side-effect body is self-contained and the field reads happen at the same
-     * point in time as before.
+     * sessionRef` guards already passed in the [backgroundEffects] selection
+     * ([selectBackgroundArm]) but are kept here so the side-effect body is self-contained
+     * and the field reads happen at the same point in time as before.
      *
      * EPIC #687 slice 1c-iv-b-B1 (#738): this method keeps ONLY the SYNCHRONOUS
      * bookkeeping — `pendingReattach`, the detach telemetry, and stashing the
@@ -16149,15 +16168,10 @@ public class TmuxSessionViewModel @Inject constructor(
         /** No lifecycle action — the event is a no-op in the current state. */
         data object Ignore : ConnectionDecision
 
-        // --- Background ---
-        /**
-         * A reconnect was in flight; pause it until foreground and surface the
-         * "paused while backgrounded" [ConnectionStatus.Failed] band.
-         */
-        data object PauseReconnectForBackground : ConnectionDecision
-
-        /** Detach the live `-CC` control client and stash a pending reattach. */
-        data object DetachForBackground : ConnectionDecision
+        // --- Background --- EPIC #687 Slice 1 (#1047): the pause-vs-detach arm decision
+        // moved into the connection core ([BackgroundEffects], the SINGLE background
+        // authority); the inline `reduceBackground()` + its two variants
+        // (`PauseReconnectForBackground` / `DetachForBackground`) are DELETED (D22 hard-cut).
 
         // --- Foreground --- EPIC #687 Slice 0 (#1047): the replay-vs-resume arm decision
         // moved into the connection core ([ForegroundReturnEffects]); the inline
@@ -16234,14 +16248,11 @@ public class TmuxSessionViewModel @Inject constructor(
         data object SilentReattachWithinGrace : ConnectionDecision
     }
 
-    private fun reduceBackground(): ConnectionDecision {
-        if (inlineConnectionStatus is ConnectionStatus.Reconnecting) {
-            return ConnectionDecision.PauseReconnectForBackground
-        }
-        if (activeTarget == null && connectingTarget == null) return ConnectionDecision.Ignore
-        if (clientRef == null && sessionRef == null) return ConnectionDecision.Ignore
-        return ConnectionDecision.DetachForBackground
-    }
+    // EPIC #687 Slice 1 (#1047): `reduceBackground()` is DELETED. The background
+    // pause-vs-detach decision now lives in the connection core ([BackgroundEffects], the
+    // SINGLE background authority), fed the injected `hasLiveControlChannel` liveness the
+    // controller's display state lacks; the inline selector was the second decision authority
+    // D28 exists to end (D22 hard-cut — no shadow).
 
     // EPIC #687 Slice 0 (#1047): `reduceForeground()` is DELETED. The beyond-grace
     // foreground replay-vs-resume decision now lives in the connection core

--- a/app/src/main/java/com/pocketshell/app/tmux/connection/BackgroundEffects.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/connection/BackgroundEffects.kt
@@ -1,0 +1,95 @@
+package com.pocketshell.app.tmux.connection
+
+/**
+ * EPIC #687 Slice 1 (#1047) — the BACKGROUND-TRANSITION decision, the SECOND of the four
+ * inline `TmuxSessionViewModel` `reduce*` selectors retired into the connection core under
+ * the maintainer's Path-A D28 consolidation (Slice 0 retired `reduceForeground`; this slice
+ * follows the SAME proven pattern).
+ *
+ * Before this slice the background pause-vs-detach arm was decided by the inline
+ * `TmuxSessionViewModel.reduceBackground()` selector — a SECOND decision authority alongside
+ * the [com.pocketshell.core.connection.ConnectionController], the exact dual-authority
+ * condition D28 exists to end. Unlike the foreground decision (which read only effect
+ * payloads), this decision needs context the controller LACKS: the controller transitions to
+ * `Backgrounded` whenever it holds a host (even from `Reconnecting`), so the arm selection
+ * cannot trust `controller.state` — it needs the missing "is there actually a live client /
+ * session to detach" fact. That fact is injected as the [hasLiveControlChannel] port
+ * (`clientRef != null || sessionRef != null` for the current host — the #685 re-read trap).
+ * The inline `reduceBackground()` and its two `ConnectionDecision` variants
+ * (`PauseReconnectForBackground` / `DetachForBackground`) are DELETED in the same change
+ * (D22 hard-cut — no shadow selector, no coexistence).
+ */
+enum class BackgroundArm {
+    /** A reconnect was in flight; pause it until foreground (the old `PauseReconnectForBackground`). */
+    PauseReconnect,
+
+    /** Detach the live `-CC` control client and stash a pending reattach (the old `DetachForBackground`). */
+    DetachForBackground,
+
+    /** No target, or no live client/session to detach — a no-op (the old inline `Ignore`). */
+    None,
+}
+
+/**
+ * The PURE background selector — the connection-core replacement for the deleted inline
+ * `reduceBackground()` predicate. The arm ORDER is byte-identical to the inline selector
+ * (the #685 predicate-order trap — keep the EXACT inline precedence so behavior is
+ * unchanged):
+ *
+ *   1. [isReconnecting] (an in-flight reconnect ladder)  -> [BackgroundArm.PauseReconnect]
+ *   2. NOT [hasTarget] (no active and no connecting target) -> [BackgroundArm.None]
+ *   3. NOT [hasLiveControlChannel] (no live client and no session) -> [BackgroundArm.None]
+ *   4. else (a live channel exists)                       -> [BackgroundArm.DetachForBackground]
+ *
+ * The third predicate is the INJECTED context the controller lacks: a `Backgrounded`
+ * transition does not imply a live control channel, so the detach arm gates on the VM's
+ * `clientRef`/`sessionRef` liveness fed in as [hasLiveControlChannel].
+ */
+fun selectBackgroundArm(
+    isReconnecting: Boolean,
+    hasTarget: Boolean,
+    hasLiveControlChannel: Boolean,
+): BackgroundArm = when {
+    isReconnecting -> BackgroundArm.PauseReconnect
+    !hasTarget -> BackgroundArm.None
+    !hasLiveControlChannel -> BackgroundArm.None
+    else -> BackgroundArm.DetachForBackground
+}
+
+/**
+ * The connection-core background-transition dispatcher: the SINGLE authority for the
+ * background pause-vs-detach decision. The driver's `-> Backgrounded` edge calls [dispatch];
+ * it [selectBackgroundArm]s from the wired predicates and fires the matching VM-supplied IO
+ * body.
+ *
+ * The predicates ([isReconnecting] / [hasTarget] / [hasLiveControlChannel]) re-read the VM's
+ * live state at dispatch time (the #685 trap: the decision must read CURRENT state, not a
+ * snapshot captured at construction), and the arm bodies are the VM's existing IO. This type
+ * holds the DECISION; the VM holds the state + the IO.
+ */
+class BackgroundEffects(
+    private val isReconnecting: () -> Boolean,
+    private val hasTarget: () -> Boolean,
+    private val hasLiveControlChannel: () -> Boolean,
+    private val pauseReconnectForBackground: () -> Unit,
+    private val detachForBackground: () -> Unit,
+    private val onNoArm: () -> Unit = {},
+) {
+    /**
+     * Select the background arm from the live predicates and fire its body. Returns the
+     * selected arm so the characterization test can assert on the decision directly.
+     */
+    fun dispatch(): BackgroundArm {
+        val arm = selectBackgroundArm(
+            isReconnecting = isReconnecting(),
+            hasTarget = hasTarget(),
+            hasLiveControlChannel = hasLiveControlChannel(),
+        )
+        when (arm) {
+            BackgroundArm.PauseReconnect -> pauseReconnectForBackground()
+            BackgroundArm.DetachForBackground -> detachForBackground()
+            BackgroundArm.None -> onNoArm()
+        }
+        return arm
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/connection/BackgroundEffectsTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/connection/BackgroundEffectsTest.kt
@@ -1,0 +1,183 @@
+package com.pocketshell.app.tmux.connection
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * EPIC #687 Slice 1 (#1047) — the connection-core CHARACTERIZATION proof for the
+ * background-transition decision, the hard-cut replacement for the deleted inline
+ * `TmuxSessionViewModel.reduceBackground()` selector (D28 single active path; D22 hard-cut).
+ *
+ * RED→GREEN (the load-bearing proof — the INJECTED-PORT path):
+ *  - RED: WITHOUT the injected `hasLiveControlChannel` context, the controller/driver could
+ *    NOT reproduce the arm. The controller transitions to `Backgrounded` whenever it holds a
+ *    host (a TARGET is present), even from `Reconnecting`, so a controller-only selection
+ *    that detaches "whenever there is a target" would WRONGLY detach a session that has NO
+ *    live `-CC` client/session — the inline returned `Ignore` there. (Demonstrated by the
+ *    implementer locally by stubbing [selectBackgroundArm] to drop the
+ *    `hasLiveControlChannel` guard — [dispatch_targetButNoLiveControlChannel_firesNoArmOnly]
+ *    and the no-live-channel selector case below FAIL.)
+ *  - GREEN: with `hasLiveControlChannel` injected, the connection-core [BackgroundEffects]
+ *    reproduces the EXACT inline `reduceBackground` arm for every fixture, including the
+ *    NON-happy ones (live-channel-present vs absent, within-grace reconnect-pause, the
+ *    multi-session reconnect-ladder precedence).
+ *
+ * The inline `reduceBackground()` mapping this pins (now deleted from the VM):
+ *   inlineConnectionStatus is Reconnecting              -> PauseReconnectForBackground
+ *   activeTarget == null && connectingTarget == null    -> Ignore (None)
+ *   clientRef == null && sessionRef == null             -> Ignore (None)
+ *   else (a live channel exists)                         -> DetachForBackground
+ */
+class BackgroundEffectsTest {
+
+    // ---- the PURE selector: class-coverage over the input combinations ----------------
+
+    @Test
+    fun selector_reconnecting_pauses() {
+        // Within-grace / in-flight reconnect ladder: pause wins, regardless of the rest.
+        assertEquals(
+            BackgroundArm.PauseReconnect,
+            selectBackgroundArm(isReconnecting = true, hasTarget = true, hasLiveControlChannel = true),
+        )
+    }
+
+    @Test
+    fun selector_reconnecting_winsEvenWithoutLiveChannel() {
+        // The #685 predicate-ORDER trap: the Reconnecting check is FIRST, so it pauses even
+        // when there is no live client/session (exactly as the inline checked it first).
+        assertEquals(
+            BackgroundArm.PauseReconnect,
+            selectBackgroundArm(isReconnecting = true, hasTarget = false, hasLiveControlChannel = false),
+        )
+    }
+
+    @Test
+    fun selector_noTarget_none() {
+        assertEquals(
+            BackgroundArm.None,
+            selectBackgroundArm(isReconnecting = false, hasTarget = false, hasLiveControlChannel = false),
+        )
+    }
+
+    @Test
+    fun selector_targetButNoLiveControlChannel_none() {
+        // THE INJECTED-PORT case (the load-bearing fixture): a target is present (so the
+        // controller is Backgrounded) but there is NO live `-CC` client/session — the inline
+        // returned Ignore. Without the injected `hasLiveControlChannel` this would WRONGLY
+        // detach.
+        assertEquals(
+            BackgroundArm.None,
+            selectBackgroundArm(isReconnecting = false, hasTarget = true, hasLiveControlChannel = false),
+        )
+    }
+
+    @Test
+    fun selector_targetAndLiveControlChannel_detaches() {
+        assertEquals(
+            BackgroundArm.DetachForBackground,
+            selectBackgroundArm(isReconnecting = false, hasTarget = true, hasLiveControlChannel = true),
+        )
+    }
+
+    // ---- the DISPATCHER: fires exactly the matching arm body, re-reading live state ---
+
+    private class Recorder {
+        var pause = 0
+        var detach = 0
+        var noArm = 0
+    }
+
+    private fun effects(
+        isReconnecting: () -> Boolean,
+        hasTarget: () -> Boolean,
+        hasLiveControlChannel: () -> Boolean,
+        rec: Recorder,
+    ) = BackgroundEffects(
+        isReconnecting = isReconnecting,
+        hasTarget = hasTarget,
+        hasLiveControlChannel = hasLiveControlChannel,
+        pauseReconnectForBackground = { rec.pause += 1 },
+        detachForBackground = { rec.detach += 1 },
+        onNoArm = { rec.noArm += 1 },
+    )
+
+    @Test
+    fun dispatch_reconnecting_firesPauseOnly() {
+        val rec = Recorder()
+        val arm = effects({ true }, { true }, { true }, rec).dispatch()
+        assertEquals(BackgroundArm.PauseReconnect, arm)
+        assertEquals(1, rec.pause)
+        assertEquals(0, rec.detach)
+        assertEquals(0, rec.noArm)
+    }
+
+    @Test
+    fun dispatch_liveChannel_firesDetachOnly() {
+        val rec = Recorder()
+        val arm = effects({ false }, { true }, { true }, rec).dispatch()
+        assertEquals(BackgroundArm.DetachForBackground, arm)
+        assertEquals(0, rec.pause)
+        assertEquals(1, rec.detach)
+        assertEquals(0, rec.noArm)
+    }
+
+    @Test
+    fun dispatch_targetButNoLiveControlChannel_firesNoArmOnly() {
+        // The INJECTED-PORT load-bearing case: target present, no live channel -> no-op.
+        val rec = Recorder()
+        val arm = effects({ false }, { true }, { false }, rec).dispatch()
+        assertEquals(BackgroundArm.None, arm)
+        assertEquals(0, rec.pause)
+        assertEquals(0, rec.detach)
+        assertEquals(1, rec.noArm)
+    }
+
+    @Test
+    fun dispatch_noTarget_firesNoArmOnly() {
+        val rec = Recorder()
+        val arm = effects({ false }, { false }, { false }, rec).dispatch()
+        assertEquals(BackgroundArm.None, arm)
+        assertEquals(0, rec.pause)
+        assertEquals(0, rec.detach)
+        assertEquals(1, rec.noArm)
+    }
+
+    /**
+     * Multi-session fixture: a reconnect ladder is in flight (e.g. a fast A→B switch raised
+     * `Reconnecting`) and a live client still exists — the pause arm still wins over detach,
+     * exactly as the inline checked `Reconnecting` before the detach branch.
+     */
+    @Test
+    fun dispatch_reconnectingWithLiveChannel_pausesNotDetaches() {
+        val rec = Recorder()
+        val arm = effects({ true }, { true }, { true }, rec).dispatch()
+        assertEquals(BackgroundArm.PauseReconnect, arm)
+        assertEquals(1, rec.pause)
+        assertEquals(0, rec.detach)
+    }
+
+    /**
+     * The #685 RE-READ trap: the dispatcher must consult the predicates at dispatch time,
+     * NOT a value snapshotted at construction. A live channel that goes away between
+     * dispatches (the detach consumed it) selects a different arm on the next call.
+     */
+    @Test
+    fun dispatch_reReadsLiveStateEachCall() {
+        val rec = Recorder()
+        var hasChannel = true
+        val fx = BackgroundEffects(
+            isReconnecting = { false },
+            hasTarget = { true },
+            hasLiveControlChannel = { hasChannel },
+            pauseReconnectForBackground = { rec.pause += 1 },
+            detachForBackground = { rec.detach += 1 },
+            onNoArm = { rec.noArm += 1 },
+        )
+        assertEquals(BackgroundArm.DetachForBackground, fx.dispatch())
+        // The detach tore down the live `-CC` channel: the live predicate is now false.
+        hasChannel = false
+        assertEquals(BackgroundArm.None, fx.dispatch())
+        assertEquals(1, rec.detach)
+        assertEquals(1, rec.noArm)
+    }
+}


### PR DESCRIPTION
## D28 Path A — Slice 1 of 0–5

Retires the inline `reduceBackground` selector into the connection core (mirrors the merged Slice 0 `ForegroundReturnEffects`).

### Change
- New `BackgroundEffects` (`selectBackgroundArm` + dispatcher) is the sole background-transition authority.
- Deleted inline `reduceBackground` + 2 orphaned variants (`PauseReconnectForBackground` / `DetachForBackground`); `ConnectionDecision` **12 → 10**.
- Injects `hasLiveControlChannel` (= `clientRef != null || sessionRef != null`) — the live-`-CC` fact the controller's display state lacks.

### Verification
- Reviewer **APPROVED**: drove red→green (stubbing the injected guard fails the 3 target-present-but-no-live-channel cases); confirmed #685 equivalence (1:1 De Morgan mapping, port is the *exact* complement — not narrower); single-path (inline + variants deleted).
- `BackgroundEffectsTest` 11, `ConnectionManagerEquivalenceTest` 21 (re-pointed), full `:app` **3130/0**.
- APPROVED-with-CI-journey-gate: MultiSessionSwitch / BackgroundGraceReconnect / LiveHold journeys unchanged + gate-wired.

Part of #1047 — does NOT close it (Slices 2–5 follow).