### PR TITLE
tmux: keep conversation reachable after agent detection drops (#1057)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/tmux/ConversationStaysReachableAfterDetectionDropsDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/ConversationStaysReachableAfterDetectionDropsDockerTest.kt
@@ -1,0 +1,633 @@
+package com.pocketshell.app.tmux
+
+import android.graphics.Bitmap
+import android.os.SystemClock
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.ViewModelProvider
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.MainActivity
+import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
+import com.pocketshell.app.hosts.SshKeyStorage
+import com.pocketshell.app.proof.DEFAULT_HOST
+import com.pocketshell.app.proof.DEFAULT_PORT
+import com.pocketshell.app.proof.DEFAULT_USER
+import com.pocketshell.app.proof.PreGrantPermissionsRule
+import com.pocketshell.app.proof.SeedBeforeLaunchRule
+import com.pocketshell.app.proof.clearLastSessionPrefs
+import com.pocketshell.app.proof.waitForSshFixtureReady
+import com.pocketshell.core.ssh.KnownHostsPolicy
+import com.pocketshell.core.ssh.SshConnection
+import com.pocketshell.core.ssh.SshKey
+import com.pocketshell.core.storage.AppDatabase
+import com.pocketshell.core.storage.entity.HostEntity
+import com.termux.view.TerminalView
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.After
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.runner.RunWith
+import java.io.File
+import java.io.FileOutputStream
+
+/**
+ * Issue #1057 (maintainer dogfood blocker — "conversation is not visible in this
+ * app") — the REAL-PATH, end-to-end proof that an agent conversation that
+ * genuinely EXISTS stays REACHABLE through the in-session Terminal/Conversation
+ * toggle even after live agent detection drops (the agent exited / re-detection
+ * never rebinds), and that TAPPING the toggle actually switches the in-session
+ * surface to the transcript (the maintainer's "switch between it when I click on
+ * terminal or when I click on conversation" mental model).
+ *
+ * ### Why this exists (the gap round 1 left — G10/F2)
+ *
+ * Round 1 widened [tmuxSessionTabState]'s gate so the Conversation tab is shown
+ * whenever a conversation EXISTS (events present / remembered / user-opened) —
+ * but those were proven only by feeding hand-constructed `AgentConversationUiState`
+ * to the pure gating function. That proves the gate is correct IF the real VM
+ * produces such a row, but NOT that it does in the maintainer's reported
+ * no-rebind scenario. In fact the production VM previously DROPPED the row the
+ * instant live detection settled null ([TmuxSessionViewModel.clearAgentDetectionForPane]),
+ * so a conversation the user was reading became unreachable when the agent exited
+ * — the round-1 gate was a no-op for that real bug. This test drives the REAL VM
+ * into that exact state and is the red→green for the VM fix that keeps an
+ * events-bearing row readable after detection drops.
+ *
+ * ### Real-path red→green (D33/G10)
+ *
+ * [conversationStaysReachableAfterLiveDetectionDropsWithLoadedTranscript]:
+ *  1. Attach to a recorded `@ps_agent_kind=shell` session whose cwd holds a fresh
+ *     Claude transcript (the #975 masked-live-agent fixture shape) — the daemon
+ *     classify is `unknown`, so the ONLY way detection binds is the #975
+ *     transcript-evidence fallback. Detection binds → the transcript tails into
+ *     `events` → the Terminal/Conversation toggle is up. (REAL VM, REAL transcript.)
+ *  2. Tap the Conversation segment → the real [TMUX_CONVERSATION_PANE_TAG]
+ *     transcript pane renders (AC2 — tap-to-switch on the real screen, the gap
+ *     #975's "toggle exists" assertion left open).
+ *  3. Drive the SAME production teardown the null-detection poll calls
+ *     ([TmuxSessionViewModel.clearAgentDetectionForPaneForTest] →
+ *     `clearAgentDetectionForPane`) on the live row — the #780 synthetic-injection
+ *     of the failing transition, because the deduped detector will not naturally
+ *     re-poll to null in-fixture. The row was built by REAL detection + REAL
+ *     transcript events; only the "detection went null" transition is injected.
+ *  4. ASSERT (RED on base / GREEN with the #1057 fix): the conversation row
+ *     PERSISTS with `events` and `detection == null`, the toggle STAYS reachable,
+ *     and tapping Conversation STILL renders the transcript. On base the row is
+ *     dropped → the toggle vanishes → the conversation is unreachable (the
+ *     maintainer's symptom).
+ *
+ * [plainShellShowsNoConversationToggleEvenThroughTeardown] is the #894 no-flap
+ * adjacency control: a genuine no-agent recorded shell (no transcript, no events)
+ * shows NO toggle, and driving the same teardown does not make one appear — the
+ * #1057 keep-events change must not resurrect the toggle for a conversation-less
+ * shell.
+ *
+ * Harness mirrors [ConversationToggleVisibleForLiveAgentInShellRecordedSessionDockerTest]
+ * (the #788 interop-placement cure: RuleChain grant → seed-remote+DB → launch
+ * `createAndroidComposeRule<MainActivity>()`).
+ */
+@RunWith(AndroidJUnit4::class)
+class ConversationStaysReachableAfterDetectionDropsDockerTest {
+
+    val compose = createAndroidComposeRule<MainActivity>()
+    private val grantPermissions = PreGrantPermissionsRule()
+
+    @get:Rule
+    val ruleChain: RuleChain = RuleChain
+        .outerRule(grantPermissions)
+        .around(SeedBeforeLaunchRule { description -> seedForMethod(description.methodName) })
+        .around(compose)
+
+    private var seededKey: String? = null
+    private var seededHostRowTag: String? = null
+    private var seededSessionName: String? = null
+    private val cleanupCommands = mutableListOf<String>()
+    private val stamps = mutableListOf<String>()
+
+    @After
+    fun tearDown() {
+        runCatching { compose.activityRule.scenario.moveToState(Lifecycle.State.RESUMED) }
+        clearLastSessionPrefs()
+        seededKey?.let { key ->
+            if (cleanupCommands.isNotEmpty()) {
+                runBlocking {
+                    runCatching {
+                        withTimeout(20_000) { execRemote(key, cleanupCommands.joinToString("\n")) }
+                    }
+                }
+            }
+        }
+        if (stamps.isNotEmpty()) {
+            writeText("conversation-reachable-1057-stamps.txt", stamps.joinToString("\n", postfix = "\n"))
+        }
+    }
+
+    /**
+     * Issue #1057 LOAD-BEARING real-path red→green: a conversation that genuinely
+     * exists stays reachable + readable after live detection drops.
+     */
+    @Test
+    fun conversationStaysReachableAfterLiveDetectionDropsWithLoadedTranscript() = runBlocking {
+        val hostRowTag = requireNotNull(seededHostRowTag) { "seed-before-launch host row missing" }
+        val sessionName = requireNotNull(seededSessionName) { "seed-before-launch session missing" }
+
+        attachToSeededSession(hostRowTag, sessionName)
+        waitForTerminalSessionAttached()
+        waitForVisibleTerminalText("issue1057-ready", VISIBLE_TIMEOUT_MS) { "issue1057-ready" in it }
+        stamp("attached session=$sessionName")
+
+        val vm = currentViewModel()
+
+        // STEP 1 — REAL detection binds (the #975 transcript-evidence fallback,
+        // the only way to bind for a recorded-shell pane the daemon classifies
+        // `unknown`) AND the transcript tails into `events`. This is the genuine
+        // conversation that EXISTS on the pane — not hand-constructed state.
+        val paneId = waitForLoadedConversationPane(vm)
+        assertNotNull(
+            "#1057 precondition: a live conversation with loaded transcript events " +
+                "must bind on the real path (detection via the #975 transcript " +
+                "fallback, then the transcript tails into events). " +
+                "agentConversations=${describeConversations(vm)}",
+            paneId,
+        )
+        val boundPaneId = requireNotNull(paneId)
+        stamp("conversation_loaded pane=$boundPaneId events=${vm.agentConversations.value[boundPaneId]?.events?.size}")
+
+        // STEP 2 — AC2 tap-to-switch on the REAL screen: tap Conversation → the
+        // real transcript pane renders (not the Terminal). #975 only asserted the
+        // toggle EXISTS; this asserts tapping it actually shows the conversation.
+        tapConversationSegment()
+        compose.waitUntil(timeoutMillis = SURFACE_TIMEOUT_MS) {
+            conversationPaneShown()
+        }
+        compose.onNodeWithTag(TMUX_CONVERSATION_PANE_TAG, useUnmergedTree = true).assertExists()
+        captureFullFrame("issue1057-conversation-live-toggle")
+        stamp("tap_to_switch_shows_transcript_live")
+
+        // STEP 3 — THE #1057 TRANSITION (#780 synthetic injection): live detection
+        // settles null while the loaded transcript is still present. We drive the
+        // SAME production method the null-detection poll calls
+        // (clearAgentDetectionForPane), on the REAL row built by real detection +
+        // real transcript events. The deduped in-fixture detector will not
+        // naturally re-poll to null, so this injects exactly that transition.
+        runOnVm { it.clearAgentDetectionForPaneForTest(boundPaneId) }
+        stamp("detection_dropped_via_production_teardown")
+
+        // STEP 4 — LOAD-BEARING ASSERTION (RED on base / GREEN with the fix): the
+        // conversation row PERSISTS with its transcript and a null detection. On
+        // base clearAgentDetectionForPane drops the row → this waitUntil times out
+        // → RED (the conversation became unreachable, the maintainer's symptom).
+        compose.waitUntil(timeoutMillis = SURFACE_TIMEOUT_MS) {
+            val row = vm.agentConversations.value[boundPaneId]
+            row != null && row.detection == null && row.events.isNotEmpty()
+        }
+        val keptRow = vm.agentConversations.value[boundPaneId]
+        assertNotNull(
+            "#1057: the conversation row must be KEPT (readable) after live " +
+                "detection drops — on base it is dropped and the conversation is " +
+                "unreachable. agentConversations=${describeConversations(vm)}",
+            keptRow,
+        )
+        assertNull(
+            "#1057: the kept row's detection is null (the live agent is gone)",
+            keptRow!!.detection,
+        )
+        assertTrue(
+            "#1057: the kept row preserves the loaded transcript events",
+            keptRow.events.isNotEmpty(),
+        )
+        stamp("conversation_row_kept_after_detection_drop events=${keptRow.events.size}")
+
+        // STEP 5 — the Terminal/Conversation toggle STAYS reachable (the round-1
+        // gate's hasConversationContent term, now load-bearing because the row is
+        // kept). On base the toggle is gone (no row → no conversation content).
+        compose.waitUntil(timeoutMillis = SURFACE_TIMEOUT_MS) {
+            compose.onAllNodesWithTag(TMUX_TABS_TAG, useUnmergedTree = true)
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+        compose.onNodeWithTag(TMUX_TABS_TAG, useUnmergedTree = true).assertExists()
+        compose.onNodeWithTag(CONVERSATION_SEGMENT_TAG, useUnmergedTree = true).assertExists()
+
+        // STEP 6 — tap-to-switch STILL works after the agent exited: switch to
+        // Terminal then back to Conversation and confirm the transcript re-renders
+        // (the durable readable transcript, not the Terminal).
+        tapTerminalSegment()
+        compose.waitUntil(timeoutMillis = SURFACE_TIMEOUT_MS) { !conversationPaneShown() }
+        tapConversationSegment()
+        compose.waitUntil(timeoutMillis = SURFACE_TIMEOUT_MS) { conversationPaneShown() }
+        compose.onNodeWithTag(TMUX_CONVERSATION_PANE_TAG, useUnmergedTree = true).assertExists()
+        captureFullFrame("issue1057-conversation-after-detection-drop")
+        stamp("tap_to_switch_shows_transcript_after_exit_ok")
+        Unit
+    }
+
+    /**
+     * #894 no-flap adjacency control: a genuine no-agent recorded shell shows NO
+     * Conversation toggle, and driving the same production teardown does not make
+     * one appear — the #1057 keep-events change must not resurrect a toggle for a
+     * conversation-less shell.
+     */
+    @Test
+    fun plainShellShowsNoConversationToggleEvenThroughTeardown() = runBlocking {
+        val hostRowTag = requireNotNull(seededHostRowTag) { "seed-before-launch host row missing" }
+        val sessionName = requireNotNull(seededSessionName) { "seed-before-launch session missing" }
+
+        attachToSeededSession(hostRowTag, sessionName)
+        waitForTerminalSessionAttached()
+        waitForVisibleTerminalText("issue1057-plain-ready", VISIBLE_TIMEOUT_MS) {
+            "issue1057-plain-ready" in it
+        }
+        stamp("plain_shell_attached session=$sessionName")
+
+        // Settle: give live detection a generous window to (not) fire.
+        SystemClock.sleep(SHELL_NO_TOGGLE_SETTLE_MS)
+        compose.onNodeWithTag(TMUX_TABS_TAG, useUnmergedTree = true).assertDoesNotExist()
+
+        // Driving the production teardown on the (rowless) shell pane is a no-op
+        // and must NOT synthesize a conversation toggle (a shell has no events).
+        val vm = currentViewModel()
+        val firstPane = vm.panes.value.firstOrNull()?.paneId
+        if (firstPane != null) {
+            runOnVm { it.clearAgentDetectionForPaneForTest(firstPane) }
+        }
+        SystemClock.sleep(2_000)
+        compose.onNodeWithTag(TMUX_TABS_TAG, useUnmergedTree = true).assertDoesNotExist()
+        captureFullFrame("issue1057-plain-shell-no-toggle")
+        stamp("plain_shell_no_toggle_through_teardown_ok")
+        Unit
+    }
+
+    // -------------------------------------------------------------- seed-before-launch
+
+    private suspend fun seedForMethod(methodName: String) {
+        val key = readFixtureKey()
+        seededKey = key
+        clearLastSessionPrefs()
+        waitForSshFixtureReady(SshKey.Pem(key))
+        val sessionName = when (methodName) {
+            "conversationStaysReachableAfterLiveDetectionDropsWithLoadedTranscript" ->
+                seedMaskedLiveClaudeSession(key)
+            "plainShellShowsNoConversationToggleEvenThroughTeardown" ->
+                seedPlainShellSession(key)
+            else -> error("unexpected test method $methodName")
+        }
+        seededSessionName = sessionName
+        seededHostRowTag = persistHost(key)
+    }
+
+    private suspend fun seedPlainShellSession(key: String): String {
+        val suffix = unique()
+        val sessionName = "issue1057-plain-shell-$suffix"
+        cleanupCommands += "tmux kill-session -t ${shellQuote(sessionName)} 2>/dev/null || true"
+        execRemote(
+            key,
+            buildString {
+                appendLine("set -eu")
+                appendLine("tmux kill-session -t ${shellQuote(sessionName)} 2>/dev/null || true")
+                appendLine(
+                    "tmux new-session -d -x 80 -y 24 -s ${shellQuote(sessionName)} -c /tmp " +
+                        "\"printf 'issue1057-plain-ready\\r\\n'; exec sh\"",
+                )
+                appendLine("tmux set-option -t ${shellQuote(sessionName)} @ps_agent_kind shell")
+                appendLine("sleep 1")
+            },
+        )
+        return sessionName
+    }
+
+    /**
+     * The #975 masked-live-claude fixture shape: a session recorded
+     * `@ps_agent_kind=shell` whose cwd holds a FRESH Claude transcript (copied
+     * from the fixture seed), with the daemon classify returning `unknown`. The
+     * #975 transcript-evidence fallback binds detection and the transcript tails
+     * into events — the genuine conversation #1057 needs to keep reachable.
+     */
+    private suspend fun seedMaskedLiveClaudeSession(key: String): String {
+        val suffix = unique()
+        val sessionName = "issue1057-masked-claude-$suffix"
+        cleanupCommands += "tmux kill-session -t ${shellQuote(sessionName)} 2>/dev/null || true"
+        cleanupCommands +=
+            "rm -f /home/testuser/.claude/projects/-home-testuser/" +
+                "issue1057-live-claude.jsonl 2>/dev/null || true"
+        execRemote(
+            key,
+            buildString {
+                appendLine("set -eu")
+                appendLine("tmux kill-session -t ${shellQuote(sessionName)} 2>/dev/null || true")
+                appendLine("mkdir -p /home/testuser/.claude/projects/-home-testuser")
+                appendLine(
+                    "cp /home/testuser/.claude/projects/-workspace-pocketshell/" +
+                        "pocketshell-claude.jsonl " +
+                        "/home/testuser/.claude/projects/-home-testuser/" +
+                        "issue1057-live-claude.jsonl",
+                )
+                appendLine(
+                    "touch /home/testuser/.claude/projects/-home-testuser/" +
+                        "issue1057-live-claude.jsonl",
+                )
+                appendLine(
+                    "tmux new-session -d -x 80 -y 24 -s ${shellQuote(sessionName)} " +
+                        "-c /home/testuser " +
+                        "\"printf 'issue1057-ready\\r\\n'; exec sh\"",
+                )
+                appendLine("tmux set-option -t ${shellQuote(sessionName)} @ps_agent_kind shell")
+                appendLine("sleep 1")
+            },
+        )
+        return sessionName
+    }
+
+    // ----------------------------------------------------------------- helpers
+
+    private suspend fun persistHost(key: String): String {
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
+        var hostRowTag = ""
+        val db = Room.databaseBuilder(appContext, AppDatabase::class.java, DATABASE_NAME)
+            .fallbackToDestructiveMigration(dropAllTables = true)
+            .build()
+        try {
+            db.clearAllTables()
+            val storedKey = SshKeyStorage.persistKey(
+                context = appContext,
+                sshKeyDao = db.sshKeyDao(),
+                name = "issue1057-key-${System.currentTimeMillis()}",
+                content = key,
+            )
+            val hostId = db.hostDao().insert(
+                HostEntity(
+                    name = HOST_NAME,
+                    hostname = DEFAULT_HOST,
+                    port = DEFAULT_PORT,
+                    username = DEFAULT_USER,
+                    keyId = storedKey.id,
+                    tmuxInstalled = true,
+                    lastBootstrapAt = System.currentTimeMillis(),
+                ),
+            )
+            hostRowTag = HOST_ROW_TAG_PREFIX + hostId
+        } finally {
+            db.close()
+        }
+        return hostRowTag
+    }
+
+    private fun attachToSeededSession(hostRowTag: String, sessionName: String) {
+        compose.waitUntil(timeoutMillis = HOST_ROW_TIMEOUT_MS) {
+            runCatching {
+                compose.onAllNodesWithTag(hostRowTag, useUnmergedTree = true)
+                    .fetchSemanticsNodes()
+                    .isNotEmpty()
+            }.getOrDefault(false)
+        }
+        clickRobustly { compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick() }
+        compose.waitUntil(timeoutMillis = ATTACH_TIMEOUT_MS) {
+            compose.onAllNodesWithText(sessionName, useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
+        tapUntilSessionScreenShown(sessionName)
+        compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertIsDisplayed()
+    }
+
+    private fun clickRobustly(click: () -> Unit) {
+        runCatching { compose.activityRule.scenario.moveToState(Lifecycle.State.RESUMED) }
+        compose.waitForIdle()
+        try {
+            click()
+        } catch (e: AssertionError) {
+            if (e.message?.contains("Failed to inject touch input") != true) throw e
+            runCatching { compose.activityRule.scenario.moveToState(Lifecycle.State.RESUMED) }
+            compose.waitForIdle()
+            SystemClock.sleep(300)
+            click()
+        }
+    }
+
+    private fun tapUntilSessionScreenShown(sessionName: String) {
+        val deadline = SystemClock.elapsedRealtime() + ATTACH_TIMEOUT_MS
+        var lastError: Throwable? = null
+        while (SystemClock.elapsedRealtime() < deadline) {
+            runCatching { compose.activityRule.scenario.moveToState(Lifecycle.State.RESUMED) }
+            compose.waitForIdle()
+            runCatching {
+                compose.onNodeWithText(sessionName, useUnmergedTree = true).performClick()
+            }.onFailure { lastError = it }
+            val shown = compose.onAllNodesWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+            if (shown) return
+            SystemClock.sleep(400)
+        }
+        throw AssertionError(
+            "session screen ($TMUX_SESSION_SCREEN_TAG) never mounted after tapping session " +
+                "'$sessionName' within ${ATTACH_TIMEOUT_MS}ms; lastTapError=$lastError",
+        )
+    }
+
+    private fun waitForTerminalSessionAttached() {
+        compose.waitUntil(timeoutMillis = 30_000) {
+            var attached = false
+            compose.activityRule.scenario.onActivity { activity ->
+                val view = activity.window.decorView.findTerminalView()
+                attached = view?.currentSession?.emulator != null
+            }
+            attached
+        }
+    }
+
+    private fun currentViewModel(): TmuxSessionViewModel {
+        var vm: TmuxSessionViewModel? = null
+        compose.activityRule.scenario.onActivity { activity ->
+            vm = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+        }
+        return requireNotNull(vm) { "TmuxSessionViewModel not available" }
+    }
+
+    private fun runOnVm(block: (TmuxSessionViewModel) -> Unit) {
+        compose.activityRule.scenario.onActivity { activity ->
+            block(ViewModelProvider(activity)[TmuxSessionViewModel::class.java])
+        }
+        compose.waitForIdle()
+    }
+
+    /**
+     * Poll until a pane has BOTH a live detection AND a loaded transcript
+     * (`events` non-empty) — the genuine conversation #1057 keeps reachable.
+     * Returns the pane id, or null if it never loaded within the budget.
+     */
+    private fun waitForLoadedConversationPane(vm: TmuxSessionViewModel): String? {
+        val deadline = SystemClock.elapsedRealtime() + CONVERSATION_LOAD_TIMEOUT_MS
+        while (SystemClock.elapsedRealtime() < deadline) {
+            val match = vm.agentConversations.value.entries.firstOrNull {
+                it.value.detection != null && it.value.events.isNotEmpty()
+            }
+            if (match != null) return match.key
+            SystemClock.sleep(150)
+        }
+        return vm.agentConversations.value.entries.firstOrNull {
+            it.value.detection != null && it.value.events.isNotEmpty()
+        }?.key
+    }
+
+    private fun describeConversations(vm: TmuxSessionViewModel): String =
+        vm.agentConversations.value.entries.joinToString(prefix = "{", postfix = "}") { (k, v) ->
+            "$k=(agent=${v.detection?.agent}, events=${v.events.size}, tab=${v.selectedTab})"
+        }
+
+    private fun tapConversationSegment() {
+        clickRobustly {
+            compose.onNodeWithTag(CONVERSATION_SEGMENT_TAG, useUnmergedTree = true).performClick()
+        }
+        compose.waitForIdle()
+    }
+
+    private fun tapTerminalSegment() {
+        clickRobustly {
+            compose.onNodeWithTag(TMUX_TERMINAL_TAB_TAG, useUnmergedTree = true).performClick()
+        }
+        compose.waitForIdle()
+    }
+
+    private fun conversationPaneShown(): Boolean =
+        compose.onAllNodesWithTag(TMUX_CONVERSATION_PANE_TAG, useUnmergedTree = true)
+            .fetchSemanticsNodes()
+            .isNotEmpty()
+
+    private fun visibleTerminalText(): String {
+        var text = ""
+        compose.activityRule.scenario.onActivity { activity ->
+            text = activity.window.decorView
+                .findTerminalView()
+                ?.currentSession
+                ?.emulator
+                ?.screen
+                ?.transcriptText
+                .orEmpty()
+        }
+        return text
+    }
+
+    private fun waitForVisibleTerminalText(
+        label: String,
+        timeoutMs: Long,
+        predicate: (String) -> Boolean,
+    ) {
+        val deadline = SystemClock.elapsedRealtime() + timeoutMs
+        var last = ""
+        while (SystemClock.elapsedRealtime() < deadline) {
+            last = visibleTerminalText()
+            if (predicate(last)) return
+            SystemClock.sleep(50)
+        }
+        writeText("issue1057-failure-$label-visible-terminal.txt", last)
+        assertTrue("predicate $label timed out; visible terminal:\n$last", false)
+    }
+
+    private fun View.findTerminalView(): TerminalView? {
+        if (this is TerminalView) return this
+        if (this !is ViewGroup) return null
+        for (index in 0 until childCount) {
+            val match = getChildAt(index).findTerminalView()
+            if (match != null) return match
+        }
+        return null
+    }
+
+    private fun captureFullFrame(name: String): File {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.waitForIdleSync()
+        SystemClock.sleep(300)
+        val bitmap = instrumentation.uiAutomation.takeScreenshot()
+        val file = artifactFile("$name.png")
+        FileOutputStream(file).use { out ->
+            check(bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)) {
+                "failed to write full-frame screenshot to ${file.absolutePath}"
+            }
+        }
+        bitmap.recycle()
+        println("ISSUE1057_FULLFRAME ${file.absolutePath}")
+        return file
+    }
+
+    private fun writeText(name: String, text: String): File {
+        val file = artifactFile(name)
+        file.writeText(text)
+        println("ISSUE1057_TEXT ${file.absolutePath}")
+        return file
+    }
+
+    private fun artifactFile(name: String): File {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val mediaRoot = com.pocketshell.app.test.testArtifactsRoot(instrumentation.targetContext)
+        val dir = File(mediaRoot, "additional_test_output/conversation-reachable-1057")
+        check(dir.exists() || dir.mkdirs()) { "could not create artifact dir ${dir.absolutePath}" }
+        return File(dir, name)
+    }
+
+    private suspend fun execRemote(key: String, command: String) {
+        val result = withTimeout(30_000) {
+            SshConnection.connect(
+                host = DEFAULT_HOST,
+                port = DEFAULT_PORT,
+                user = DEFAULT_USER,
+                key = SshKey.Pem(key),
+                knownHosts = KnownHostsPolicy.AcceptAll,
+                timeoutMs = 15_000,
+            ).mapCatching { session -> session.use { it.exec(command) } }
+        }
+        val exec = result.getOrNull()
+        assertTrue(
+            "remote command failed: ${result.exceptionOrNull()} exit=${exec?.exitCode} " +
+                "stdout='${exec?.stdout}' stderr='${exec?.stderr}'",
+            exec?.exitCode == 0,
+        )
+    }
+
+    private fun readFixtureKey(): String =
+        InstrumentationRegistry.getInstrumentation()
+            .context
+            .assets
+            .open("test_key")
+            .bufferedReader()
+            .use { it.readText() }
+
+    private fun shellQuote(value: String): String =
+        "'" + value.replace("'", "'\"'\"'") + "'"
+
+    private fun unique(): String =
+        "${System.currentTimeMillis().toString().takeLast(6)}${System.nanoTime().toString().takeLast(4)}"
+
+    private fun stamp(name: String) {
+        stamps += "[issue1057] $name at ${SystemClock.elapsedRealtime()}"
+    }
+
+    private companion object {
+        const val DATABASE_NAME: String = "pocketshell.db"
+        const val HOST_NAME: String = "Issue1057 Agents"
+        const val ATTACH_TIMEOUT_MS: Long = 30_000
+        const val HOST_ROW_TIMEOUT_MS: Long = 60_000
+        const val VISIBLE_TIMEOUT_MS: Long = 20_000
+        const val SHELL_NO_TOGGLE_SETTLE_MS: Long = 8_000
+        const val CONVERSATION_LOAD_TIMEOUT_MS: Long = 30_000
+        const val SURFACE_TIMEOUT_MS: Long = 20_000
+
+        // The Conversation segment is index 1 in the Terminal|Conversation pill
+        // (index 0 is TMUX_TERMINAL_TAB_TAG; see ConsolidatedTabPill.segmentTag).
+        const val CONVERSATION_SEGMENT_TAG: String = TMUX_CONSOLIDATED_TAB_PILL_TAG_PREFIX + "1"
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
@@ -1717,33 +1717,38 @@ public fun TmuxSessionScreen(
             // Whether to render the Conversation *content* (real transcript) in
             // place of the terminal pager. This is the actual content swap,
             // distinct from whether the Conversation *tab* exists (#716
-            // presumed-agent — see [tmuxSessionTabState]). It still requires a
-            // live detection because the heavyweight [TmuxConversationPane] needs
-            // a real transcript — and keeping this detection-gated also preserves
-            // the #605 Conversation→Terminal swap latch, which keys off the real
-            // pane mounting/unmounting (the lightweight placeholder below never
-            // mounts that pane, so it cannot trigger the same-frame teardown
-            // race). Still gated on the ACTIVE `currentPane`: the transcript
-            // mounts only for the promoted active runtime's pane (#797).
-            val showConversation = currentPane != null &&
-                visibleConversation?.detection != null &&
-                visibleConversation.selectedTab == SessionTab.Conversation
-            // Issue #778: when the user has tapped Conversation on a
-            // presumed-agent pane but live detection has NOT landed yet
-            // (`detection == null`), render a lightweight "waiting for agent"
-            // placeholder INSTEAD of swallowing the tap and staying on the
-            // terminal. The tap is now honoured end-to-end (onClick → VM records
-            // `selectedTab = Conversation` on a detection-less row → this branch
-            // paints the placeholder). The real [TmuxConversationPane]
-            // (`showConversation`) takes over the instant detection seeds. Gated
-            // on `presumedAgent` so a confirmed shell can never show this.
-            // Issue #797: the placeholder follows the SURFACE pane so the
-            // "waiting for agent" state is shown on a settled cached presumed-
-            // agent pane too (the Conversation tab is no longer empty there).
-            val showConversationPlaceholder = surfacePane != null &&
-                presumedAgent &&
-                visibleConversation?.detection == null &&
-                visibleConversation?.selectedTab == SessionTab.Conversation
+            // presumed-agent — see [tmuxSessionTabState]). Routing is centralised
+            // in [tmuxSessionConversationSurface] (#1057) so a Conversation tap on
+            // a pane whose agent was mis-classified as a shell still surfaces the
+            // existing transcript (or the loading placeholder) instead of leaving
+            // the user stuck on the Terminal — the maintainer's "can't see
+            // conversation" symptom. Transcript still mounts only for the ACTIVE
+            // `currentPane` (preserves the #797 active-runtime gate and the #605
+            // Conversation→Terminal swap latch); it now also fires for an existing
+            // events transcript whose detection is currently null (an agent that
+            // exited / a recorded-shell pane), not solely live detection.
+            val conversationSurface = tmuxSessionConversationSurface(
+                showsConversationTab = tabState.showsConversationTab,
+                isActivePane = currentPane != null,
+                hasSurfacePane = surfacePane != null,
+                selectedTab = visibleConversation?.selectedTab,
+                hasDetection = visibleConversation?.detection != null,
+                hasEvents = visibleConversation?.events?.isNotEmpty() == true,
+            )
+            // The leading `visibleConversation != null` keeps the K2 smart-cast
+            // for the `showConversation` content branches below (they read
+            // `visibleConversation.events` / `.loadState` non-null); the surface
+            // routing already requires a non-null row to reach Transcript.
+            val showConversation = visibleConversation != null &&
+                conversationSurface == TmuxConversationSurface.Transcript
+            // Issue #778/#1057: a lightweight "Loading conversation…" / Failed
+            // placeholder when the user opened the Conversation tab on a pane with
+            // no transcript yet (detection null AND no events). No longer gated on
+            // `presumedAgent` — a confirmed-shell pane the user deliberately
+            // switched to Conversation must show this placeholder (with a way back
+            // to Terminal), not silently render the Terminal.
+            val showConversationPlaceholder =
+                conversationSurface == TmuxConversationSurface.Placeholder
             // Issue #605: hold the heavyweight terminal AndroidView re-attach
             // for exactly one frame on the Conversation → Terminal edge so the
             // leaving conversation pane's selection-toolbar/focus teardown
@@ -3539,22 +3544,86 @@ internal fun tmuxSessionTabState(
     // the slow-detection window (the tab was drawn but the index could never
     // become 1). Honouring the presumed-agent selection lets the screen render
     // a "waiting for agent" placeholder instead of swallowing the tap; the real
-    // transcript replaces it the instant detection seeds. The selection is still
-    // gated on `showsConversationTab` so a confirmed shell (no tab) can never
-    // land on the Conversation index from a stale row.
+    // transcript replaces it the instant detection seeds.
+    //
+    // Issue #1057 (maintainer dogfood blocker — "conversation is not visible in
+    // this app"): the old gate ALSO hid the Conversation tab entirely whenever a
+    // pane was NOT presumed-agent (a confirmed shell) and had no live detection.
+    // That made an agent conversation that genuinely EXISTS on the pane
+    // permanently unreachable when detection was wrong/pending/dropped — exactly
+    // the maintainer's symptom. The tab is now reachable whenever a conversation
+    // EXISTS or COULD exist for the pane, independent of correct auto-detection:
+    //  - a live-detected agent (`hasLiveDetection`), OR
+    //  - a presumed agent during the slow-detection window (`presumedAgent`), OR
+    //  - a transcript that already exists for the pane (events present, or a
+    //    seeded/remembered placeholder row) even though detection is currently
+    //    null and the pane is recorded as a shell (`hasConversationContent`), OR
+    //  - the user has DELIBERATELY opened the Conversation surface for this pane
+    //    (`userOpenedConversation`) — so the choice is honoured and persists
+    //    (per-pane `selectedTab`) even across a re-classification to shell.
+    // Hard-cut (D22): this replaces the "hide it on a confirmed shell" gate; no
+    // settings flag or legacy fallback is kept.
     val hasLiveDetection = currentAgentConversation?.detection != null
-    val showsConversationTab = hasLiveDetection || presumedAgent
+    val hasConversationContent = currentAgentConversation?.let { conversation ->
+        conversation.events.isNotEmpty() ||
+            conversation.autoSeededPlaceholder ||
+            conversation.rememberedAgentPlaceholder
+    } == true
+    val userOpenedConversation =
+        currentAgentConversation?.selectedTab == SessionTab.Conversation
+    val showsConversationTab =
+        hasLiveDetection || presumedAgent || hasConversationContent || userOpenedConversation
     return TmuxSessionTabState(
         labels = if (showsConversationTab) listOf("Terminal", "Conversation") else listOf("Terminal"),
-        selectedIndex = if (showsConversationTab &&
-            currentAgentConversation?.selectedTab == SessionTab.Conversation
-        ) {
-            1
-        } else {
-            0
-        },
+        selectedIndex = if (showsConversationTab && userOpenedConversation) 1 else 0,
         showsConversationTab = showsConversationTab,
     )
+}
+
+/**
+ * Issue #1057: which surface the in-session content area renders for the visible
+ * pane — the heavyweight Conversation transcript, the lightweight Conversation
+ * placeholder ("Loading conversation…" / Failed), or the Terminal pager.
+ *
+ * Extracted from the inline `showConversation` / `showConversationPlaceholder`
+ * flags in [TmuxSessionScreen] so the tap-to-switch content routing is unit
+ * testable: when the user opens the Conversation tab on a pane whose agent was
+ * mis-classified as a shell (the maintainer's "can't see conversation"
+ * scenario), the existing transcript must render — and when no transcript has
+ * loaded yet, the placeholder must render — instead of silently staying on the
+ * Terminal.
+ *
+ *  - [Transcript]: mount [TmuxConversationPane]. Requires the ACTIVE pane
+ *    (`isActivePane`, the promoted runtime's pane — preserves the #797/#605
+ *    transcript mount/teardown invariants) AND a real transcript to show
+ *    (live detection OR already-loaded events). The #793 loading/failed/empty
+ *    sub-states are handled by the caller's branches on the row's `loadState`.
+ *  - [Placeholder]: a lightweight "Loading conversation…" / Failed placeholder
+ *    for a Conversation tab the user opened that has no transcript yet
+ *    (detection null AND no events). Requires only the surface pane and that the
+ *    Conversation tab is reachable ([showsConversationTab]) — so it shows on a
+ *    confirmed-shell pane the user deliberately switched to Conversation, not
+ *    only on a presumed-agent pane (the old `presumedAgent` gate left such a
+ *    tap rendering the Terminal).
+ *  - [Terminal]: the user is on the Terminal tab, or the pane has nothing to
+ *    show on the Conversation surface.
+ */
+internal enum class TmuxConversationSurface { Transcript, Placeholder, Terminal }
+
+internal fun tmuxSessionConversationSurface(
+    showsConversationTab: Boolean,
+    isActivePane: Boolean,
+    hasSurfacePane: Boolean,
+    selectedTab: SessionTab?,
+    hasDetection: Boolean,
+    hasEvents: Boolean,
+): TmuxConversationSurface {
+    if (selectedTab != SessionTab.Conversation) return TmuxConversationSurface.Terminal
+    if (isActivePane && (hasDetection || hasEvents)) return TmuxConversationSurface.Transcript
+    if (hasSurfacePane && showsConversationTab && !hasDetection && !hasEvents) {
+        return TmuxConversationSurface.Placeholder
+    }
+    return TmuxConversationSurface.Terminal
 }
 
 /**

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -11833,6 +11833,21 @@ public class TmuxSessionViewModel @Inject constructor(
      *
      * Cancels any active tail job and removes the conversation row from
      * [_agentConversations].
+     *
+     * Issue #1057 (maintainer dogfood blocker — "conversation is not visible in
+     * this app"): a row that has LOADED a real transcript ([events] non-empty)
+     * is the DURABLE "events present but detection currently null" state the
+     * Conversation tab must stay reachable for. Dropping such a row the instant
+     * live detection settles null (the agent exited, the live tail dropped, or
+     * re-detection never rebinds) is exactly what makes the conversation
+     * UNREACHABLE — the user can no longer read the transcript that genuinely
+     * exists. So an events-bearing row is now KEPT (detection nulled, transcript
+     * preserved, marked [AgentConversationSyncStatus.Stale]) instead of dropped,
+     * so [tmuxSessionTabState]'s `hasConversationContent` term keeps the toggle
+     * reachable and a Conversation tap still renders the transcript. A row with
+     * NO loaded transcript (a genuine shell / auto-seeded / remembered
+     * placeholder) still drops exactly as before — the #186/#894 "tab disappears
+     * for a window with no conversation" contract is unchanged.
      */
     private fun clearAgentDetectionForPane(paneId: String) {
         // Issue #495: live detection says this window no longer hosts an
@@ -11844,8 +11859,26 @@ public class TmuxSessionViewModel @Inject constructor(
         var rowDropped = false
         updateAgentConversation(paneId) { current ->
             when {
-                // A row that carries a real detection: the agent exited — drop
-                // it so the Conversation tab disappears for this window.
+                // Issue #1057: a row whose transcript has ALREADY loaded (events
+                // present) is a conversation that genuinely EXISTS. Keep it
+                // readable after the agent's live detection drops — null the
+                // detection (no live tail) but preserve the events + the user's
+                // tab choice, marking the frozen transcript Stale — so the
+                // Conversation toggle stays reachable and tapping it still shows
+                // the conversation instead of vanishing the user back to a raw
+                // Terminal. This is the durable real-path state the maintainer's
+                // "can't see the conversation" report needs.
+                current.detection != null && current.events.isNotEmpty() -> {
+                    current.copy(
+                        detection = null,
+                        syncStatus = AgentConversationSyncStatus.Stale,
+                        loadState = ConversationLoadState.Ready,
+                    )
+                }
+                // A row that carries a real detection but NO loaded transcript:
+                // the agent exited before any transcript was read — drop it so
+                // the Conversation tab disappears for this window (nothing to
+                // read; the #186/#894 contract).
                 current.detection != null -> {
                     rowDropped = true
                     null

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionScreenTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionScreenTest.kt
@@ -533,10 +533,15 @@ class TmuxSessionScreenTest {
     }
 
     @Test
-    fun tmuxSessionTabStateStaysTerminalForNonPresumedConversationSelectionWithoutDetection() {
-        // Defensive: a NON-presumed pane (confirmed shell) must never land on the
-        // Conversation index even if a stale row claims `selectedTab =
-        // Conversation` with no detection — there is no Conversation tab to show.
+    fun tmuxSessionTabStateHonoursUserConversationSelectionOnConfirmedShell() {
+        // Issue #1057 (was the OLD "stays Terminal" defensive case — that
+        // behaviour WAS the maintainer's "conversation is not visible" bug): a
+        // NON-presumed pane (confirmed shell / mis-classified agent) whose row
+        // records a DELIBERATE `selectedTab = Conversation` must now keep the
+        // Conversation tab reachable and land on the Conversation index, even
+        // with no live detection. The user explicitly opened the surface; the
+        // per-pane choice is honoured and persists (criterion #3) instead of
+        // being silently swallowed.
         val state = tmuxSessionTabState(
             currentAgentConversation = AgentConversationUiState(
                 detection = null,
@@ -545,9 +550,80 @@ class TmuxSessionScreenTest {
             presumedAgent = false,
         )
 
-        assertEquals(listOf("Terminal"), state.labels)
+        assertEquals(listOf("Terminal", "Conversation"), state.labels)
+        assertEquals(1, state.selectedIndex)
+        assertTrue(state.showsConversationTab)
+    }
+
+    @Test
+    fun tmuxSessionTabStateShowsConversationForConfirmedShellWithExistingTranscript() {
+        // Issue #1057, class case (a): a pane recorded/mis-classified as a
+        // confirmed shell (presumedAgent == false) with NO current live
+        // detection but an existing transcript (events present — e.g. an agent
+        // that has since exited, or a reattach where detection has not re-bound)
+        // must keep the Conversation tab reachable so the user can read it.
+        // On base (the pre-#1057 `hasLiveDetection || presumedAgent` gate) this
+        // FAILS — the tab is hidden and the conversation is unreachable.
+        val state = tmuxSessionTabState(
+            currentAgentConversation = AgentConversationUiState(
+                detection = null,
+                events = listOf(
+                    com.pocketshell.core.agents.ConversationEvent.Message(
+                        id = "m1",
+                        agent = AgentKind.ClaudeCode,
+                        role = com.pocketshell.core.agents.ConversationRole.Assistant,
+                        text = "hello from the agent",
+                    ),
+                ),
+                selectedTab = SessionTab.Terminal,
+            ),
+            presumedAgent = false,
+        )
+
+        assertEquals(listOf("Terminal", "Conversation"), state.labels)
+        // Not opened yet, so the active index stays on Terminal — but the tab
+        // is now reachable (the bug fix).
         assertEquals(0, state.selectedIndex)
-        assertTrue(!state.showsConversationTab)
+        assertTrue(state.showsConversationTab)
+    }
+
+    @Test
+    fun tmuxSessionTabStateShowsConversationForConfirmedShellWithRememberedPlaceholder() {
+        // Issue #1057, class case (a) cont.: a remembered-agent placeholder row
+        // (the #495/#819 reattach seed) on a pane that is momentarily NOT
+        // presumed-agent must still expose the Conversation tab so the remembered
+        // conversation is reachable while live re-detection re-anchors it.
+        val state = tmuxSessionTabState(
+            currentAgentConversation = AgentConversationUiState(
+                detection = null,
+                selectedTab = SessionTab.Terminal,
+                rememberedAgentPlaceholder = true,
+            ),
+            presumedAgent = false,
+        )
+
+        assertEquals(listOf("Terminal", "Conversation"), state.labels)
+        assertEquals(0, state.selectedIndex)
+        assertTrue(state.showsConversationTab)
+    }
+
+    @Test
+    fun tmuxSessionTabStateShowsConversationForDetectionPendingPresumedAgent() {
+        // Issue #1057, class case (b): a detection-pending pane (presumed-agent,
+        // detection == null, no events yet) must keep the Conversation tab
+        // reachable throughout the slow-detection window so the user is never
+        // locked out of the conversation while detection warms.
+        val state = tmuxSessionTabState(
+            currentAgentConversation = AgentConversationUiState(
+                detection = null,
+                selectedTab = SessionTab.Terminal,
+            ),
+            presumedAgent = true,
+        )
+
+        assertEquals(listOf("Terminal", "Conversation"), state.labels)
+        assertEquals(0, state.selectedIndex)
+        assertTrue(state.showsConversationTab)
     }
 
     @Test
@@ -579,6 +655,101 @@ class TmuxSessionScreenTest {
         assertEquals(listOf("Terminal", "Conversation"), state.labels)
         assertEquals(1, state.selectedIndex)
         assertTrue(state.showsConversationTab)
+    }
+
+    // ─── Issue #1057: tap-to-switch content routing. The Conversation tab being
+    // reachable is only half the fix — opening it must actually render the
+    // conversation (transcript or placeholder), not silently stay on Terminal. ─
+
+    @Test
+    fun conversationSurfaceIsTerminalWhenTerminalTabSelected() {
+        // On the Terminal tab the content area is the Terminal, regardless of
+        // detection / events.
+        assertEquals(
+            TmuxConversationSurface.Terminal,
+            tmuxSessionConversationSurface(
+                showsConversationTab = true,
+                isActivePane = true,
+                hasSurfacePane = true,
+                selectedTab = SessionTab.Terminal,
+                hasDetection = true,
+                hasEvents = true,
+            ),
+        )
+    }
+
+    @Test
+    fun conversationSurfaceShowsTranscriptForExistingEventsWithoutDetection() {
+        // Issue #1057 class case (a): the user opens Conversation on an
+        // active pane recorded as a shell whose agent has since dropped its live
+        // detection but whose transcript events are still loaded. The existing
+        // transcript must render (Transcript), NOT the Terminal. On base
+        // (`showConversation` required `detection != null`) this routed to
+        // Terminal — the conversation was unreachable even after tapping.
+        assertEquals(
+            TmuxConversationSurface.Transcript,
+            tmuxSessionConversationSurface(
+                showsConversationTab = true,
+                isActivePane = true,
+                hasSurfacePane = true,
+                selectedTab = SessionTab.Conversation,
+                hasDetection = false,
+                hasEvents = true,
+            ),
+        )
+    }
+
+    @Test
+    fun conversationSurfaceShowsPlaceholderForOpenedConversationWithoutTranscript() {
+        // Issue #1057: the user opened Conversation on a confirmed-shell pane
+        // (no detection, no events yet). The lightweight placeholder must render
+        // (with a way back to Terminal), not the Terminal — the old gate required
+        // `presumedAgent`, so a confirmed-shell tap stayed on the Terminal.
+        assertEquals(
+            TmuxConversationSurface.Placeholder,
+            tmuxSessionConversationSurface(
+                showsConversationTab = true,
+                isActivePane = true,
+                hasSurfacePane = true,
+                selectedTab = SessionTab.Conversation,
+                hasDetection = false,
+                hasEvents = false,
+            ),
+        )
+    }
+
+    @Test
+    fun conversationSurfaceShowsTranscriptForLiveDetectedAgent() {
+        // Unchanged happy path: a live-detected agent on the Conversation tab
+        // mounts the transcript.
+        assertEquals(
+            TmuxConversationSurface.Transcript,
+            tmuxSessionConversationSurface(
+                showsConversationTab = true,
+                isActivePane = true,
+                hasSurfacePane = true,
+                selectedTab = SessionTab.Conversation,
+                hasDetection = true,
+                hasEvents = false,
+            ),
+        )
+    }
+
+    @Test
+    fun conversationSurfaceStaysTerminalWhenTabNotReachableAndNoTranscript() {
+        // A genuine shell the user never opened Conversation on (tab hidden, no
+        // transcript) stays on the Terminal — no empty Conversation surface.
+        assertEquals(
+            TmuxConversationSurface.Terminal,
+            tmuxSessionConversationSurface(
+                showsConversationTab = false,
+                isActivePane = true,
+                hasSurfacePane = true,
+                selectedTab = SessionTab.Terminal,
+                hasDetection = false,
+                hasEvents = false,
+            ),
+        )
     }
 
     @Test

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
@@ -12289,6 +12289,96 @@ class TmuxSessionViewModelTest {
     }
 
     @Test
+    fun conversationWithLoadedTranscriptIsKeptReadableWhenDetectionDrops() = runTest(scheduler) {
+        // Issue #1057 (maintainer dogfood — "conversation is not visible in this
+        // app"): a conversation that genuinely EXISTS (a loaded transcript, events
+        // present) must stay READABLE after live detection drops, so the
+        // Terminal/Conversation toggle stays reachable and the user can still read
+        // it. On base clearAgentDetectionForPane DROPPED the row the instant
+        // detection settled null → the transcript became unreachable (the exact
+        // symptom). This is the fast JVM red→green for the VM fix; the connected
+        // sibling is ConversationStaysReachableAfterDetectionDropsDockerTest.
+        val vm = newVm()
+        vm.attachClientForTest(FakeTmuxClient())
+        vm.applyParsedPanesForTest(
+            listOf(
+                TmuxSessionViewModel.ParsedPane("%0", "@0", "$0", "agent", paneIndex = 0),
+            ),
+        )
+        val event = ConversationEvent.Message(
+            id = "m1",
+            agent = AgentKind.ClaudeCode,
+            role = ConversationRole.Assistant,
+            text = "the transcript the user was reading",
+        )
+        vm.startAgentConversationForTest("%0", newClaudeDetection(), listOf(event))
+        vm.selectSessionTab("%0", SessionTab.Conversation)
+        runCurrent()
+        assertEquals(
+            SessionTab.Conversation,
+            vm.agentConversations.value["%0"]!!.selectedTab,
+        )
+
+        // Live detection settles null (the agent exited / re-detection never
+        // rebinds) — the production teardown the null-detection poll calls.
+        vm.clearAgentDetectionForPaneForTest("%0")
+        runCurrent()
+
+        val row = vm.agentConversations.value["%0"]
+        assertNotNull(
+            "#1057: an events-bearing conversation row is KEPT readable after " +
+                "detection drops (on base it was dropped → conversation unreachable)",
+            row,
+        )
+        assertNull(
+            "#1057: the kept row's detection is null (the live agent is gone)",
+            row!!.detection,
+        )
+        assertTrue(
+            "#1057: the kept row preserves the loaded transcript so it stays readable",
+            row.events.isNotEmpty(),
+        )
+        assertEquals(
+            "#1057: the user's Conversation tab choice persists on the kept row",
+            SessionTab.Conversation,
+            row.selectedTab,
+        )
+        // agentForWindow still reports null (no LIVE agent) — the kept row is a
+        // frozen transcript, not a resurrected live detection.
+        assertNull(
+            "#1057: a kept frozen transcript must not resurrect a live agent",
+            vm.agentForWindow("@0"),
+        )
+    }
+
+    @Test
+    fun conversationWithNoTranscriptStillDropsWhenDetectionDrops() = runTest(scheduler) {
+        // Issue #1057 adjacency (#186/#894 contract unchanged): a row with NO
+        // loaded transcript (the agent exited before any transcript was read, a
+        // genuine shell) still DROPS when detection settles null — the keep-events
+        // change must NOT make a conversation-less window linger on the toggle.
+        val vm = newVm()
+        vm.attachClientForTest(FakeTmuxClient())
+        vm.applyParsedPanesForTest(
+            listOf(
+                TmuxSessionViewModel.ParsedPane("%0", "@0", "$0", "agent", paneIndex = 0),
+            ),
+        )
+        vm.startAgentConversationForTest("%0", newClaudeDetection())
+        runCurrent()
+        assertNotNull(vm.agentConversations.value["%0"])
+
+        vm.clearAgentDetectionForPaneForTest("%0")
+        runCurrent()
+
+        assertNull(
+            "#1057 adjacency: a row with no loaded transcript still drops on exit",
+            vm.agentConversations.value["%0"],
+        )
+        assertNull(vm.agentForWindow("@0"))
+    }
+
+    @Test
     fun parsedPanePaneTtyDefaultsToEmptyWhenOmitted() = runTest(scheduler) {
         // Defensive: an older tmux that doesn't emit the new field, or
         // a unit test passing the legacy shape, must still produce a

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -746,6 +746,28 @@ JOURNEY_CLASSES=(
   # tests.yml already brings up, and does NOT self-skip on CI (no assumeTrue /
   # assumeFalse(isRunningOnCi())). Lives under com.pocketshell.app.tmux.
   "com.pocketshell.app.tmux.ConversationToggleVisibleForLiveAgentInShellRecordedSessionDockerTest"
+  # ADDED (#1057): the conversation stays REACHABLE after live detection drops.
+  # The maintainer dogfood report (2026-06-28): "conversation is not visible in
+  # this app" — they cannot reach the agent conversation view. The #975 sibling
+  # above proves the toggle RETURNS when detection re-binds; this class proves the
+  # OTHER half of the class — a conversation that genuinely EXISTS (a loaded
+  # transcript) must stay reachable + readable when live detection DROPS and never
+  # rebinds (the agent exited / masked no-rebind). It drives the REAL VM:
+  #   - conversationStaysReachableAfterLiveDetectionDropsWithLoadedTranscript: the
+  #     LOAD-BEARING real-path red->green. Detection binds via the #975 transcript
+  #     fallback + the transcript tails into events; tapping Conversation renders
+  #     the transcript (AC2 tap-to-switch); then the production agent-exit teardown
+  #     (clearAgentDetectionForPane, the #780 synthetic-injection of the
+  #     null-detection transition the deduped in-fixture detector won't fire) is
+  #     driven on the live row. On base the row is DROPPED -> the toggle vanishes ->
+  #     the conversation is unreachable (RED); with the #1057 fix the events-bearing
+  #     row is KEPT -> the toggle stays + tapping still shows the transcript (GREEN).
+  #   - plainShellShowsNoConversationToggleEvenThroughTeardown (#894 no-flap
+  #     ADJACENCY): a genuine no-agent recorded shell shows NO toggle and the
+  #     teardown does not synthesize one (the keep-events change must not resurrect
+  #     a toggle for a conversation-less shell).
+  # Uses ONLY agents:2222 that tests.yml already brings up; no self-skip on CI.
+  "com.pocketshell.app.tmux.ConversationStaysReachableAfterDetectionDropsDockerTest"
   # ADDED (#813): the composer-launcher NARROW / LARGE-FONT clip proof. The
   # maintainer dogfooded (2026-06-18 07:53) the launcher being CLIPPED off the
   # right edge of the bottom bar by the 4-chip primary cluster on a narrow /

--- a/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenders.kt
+++ b/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenders.kt
@@ -1085,6 +1085,43 @@ class DesignRenders {
     }
 
     /**
+     * Issue #1057: the in-session header Terminal|Conversation pill — the
+     * tap-to-switch affordance the maintainer asked for. The real pill
+     * (`ConsolidatedTabPill` in the `app` module) wraps exactly this shared
+     * `SegmentedToggle`, so this fixture verifies the affordance under the real
+     * theme in both states. The fix makes the Conversation segment REACHABLE on
+     * panes where agent detection is pending / mis-classified (a conversation
+     * that exists is no longer hidden); the segments below show Terminal-selected
+     * and Conversation-selected. The emulator screenshot of the real session
+     * screen is the acceptance check (#641/#657).
+     */
+    @Test
+    fun sessionTerminalConversationTabPill() = render("session-terminal-conversation-tab-pill") {
+        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            SectionHeader(label = "Terminal selected")
+            SegmentedToggle(
+                labels = listOf("Terminal", "Conversation"),
+                selectedIndex = 0,
+                onSelected = {},
+                fillSegments = true,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+            )
+            SectionHeader(label = "Conversation selected (now reachable)")
+            SegmentedToggle(
+                labels = listOf("Terminal", "Conversation"),
+                selectedIndex = 1,
+                onSelected = {},
+                fillSegments = true,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+            )
+        }
+    }
+
+    /**
      * Issue #781: the conversation Markdown renderer now lays GFM pipe tables
      * out as aligned columns instead of raw `|` text. The real renderer
      * (`com.pocketshell.app.composer.MarkdownText` / its `TableBlock`) lives in


### PR DESCRIPTION
## Dogfood blocker — 'conversation is not visible in this app'

**Root cause:** `clearAgentDetectionForPane` dropped the whole conversation row the instant live detection settled null, so the 'events present, detection null' state the tab gate keys off **never existed on the real path** — once an agent exited / re-detection didn't rebind, the transcript + toggle vanished. (Round-1's pure-function gate was a no-op for the real bug; the reviewer caught it.)

**Fix:** `clearAgentDetectionForPane` KEEPS a row that has loaded transcript `events` (detection nulled, transcript + tab preserved, marked **Stale**); conversation-less rows still drop (#186/#894 contract). `tmuxSessionTabState` shows the tab whenever a conversation exists/was opened; `tmuxSessionConversationSurface` routes content.

## Verification (reviewer-driven, D33 end-to-end)
- **Real-VM red→green:** revert keep-events → row dropped → conversation unreachable (the exact symptom); restore → reachable. Gated on `events` presence (both G2 arms), not a keep-all leak.
- **On-device (G4):** gate-wired connected journey `ConversationStaysReachableAfterDetectionDropsDockerTest` ran **2/2 on emulator + Docker**, with AC5 screenshots: live / after-drop (Stale + toggle + transcript still present) / plain-shell (no toggle, #894).
- Full `:app` **3120/0**; `check-test-validity.sh` PASS.

Closes #1057.