### PR TITLE
core-connection: migrate classifyPassiveTransportDrop to the driver (#1047 Slice 2)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -67,6 +67,8 @@ import com.pocketshell.app.tmux.connection.CurrentClientTmuxPort
 import com.pocketshell.app.tmux.connection.ForegroundReturnEffects
 import com.pocketshell.app.tmux.connection.debounceReconnectUi
 import com.pocketshell.app.tmux.connection.GraceEffects
+import com.pocketshell.app.tmux.connection.PassiveDropArm
+import com.pocketshell.app.tmux.connection.PassiveTransportDropEffects
 import com.pocketshell.app.tmux.connection.SshLeaseTransportPort
 import com.pocketshell.app.tmux.connection.SuppressedDropDiagnostic
 import com.pocketshell.app.tmux.connection.TmuxAttachEffects
@@ -937,7 +939,7 @@ public class TmuxSessionViewModel @Inject constructor(
             // keeping the submit itself inside the driver-owned path.
             controlChannelDrops = connectionTmuxPort.disconnectedClients,
             shouldSubmitControlChannelDrop = { client ->
-                classifyPassiveTransportDrop(client) != ConnectionDecision.Ignore
+                passiveTransportDropEffects.classify(client) != PassiveDropArm.Ignore
             },
             controlChannelDroppedEffect = { client -> onControllerTransportDropped(client) },
             // Issue #972: on the current host's lease coming back `Up` after a
@@ -1171,7 +1173,7 @@ public class TmuxSessionViewModel @Inject constructor(
      */
     internal fun triggerCleanPassiveDropForTest(): Boolean {
         val client = clientRef ?: return false
-        if (classifyPassiveTransportDrop(client) == ConnectionDecision.Ignore) return false
+        if (passiveTransportDropEffects.classify(client) == PassiveDropArm.Ignore) return false
         connectionManager.submit(
             CoreConnectionEvent.TransportDropped(reason = "test_clean_outage_seam"),
         )
@@ -3195,6 +3197,40 @@ public class TmuxSessionViewModel @Inject constructor(
                 // The clean-detach teardown reads the bookkeeping just set above; run it
                 // AFTER, through the single [GraceEffects] owner.
                 graceEffects.onBackgrounded()
+            },
+        )
+
+    /**
+     * EPIC #687 Slice 2 (#1047): the connection-core PASSIVE-TRANSPORT-DROP authority — the
+     * hard-cut replacement for the deleted inline `classifyPassiveTransportDrop()` selector
+     * (D28 single active path; D22 hard-cut). All four passive-drop call sites (the driver's
+     * [ConnectionEffectDriver] `shouldSubmitControlChannelDrop` stale-client gate, the
+     * [triggerCleanPassiveDropForTest] seam, the stale-client breadcrumb observer, and the
+     * real [handlePassiveClientDisconnect] dispatch) route their decision through
+     * [PassiveTransportDropEffects.classify]. The predicates re-read the VM's live state at
+     * call time (the #685 re-read trap: the live `clientRef` identity, the
+     * `activeTarget`/`connectingTarget`, the in-app-navigation intent). The per-arm recovery
+     * IO stays in [handlePassiveClientDisconnect] (it threads handler-local
+     * `target`/`reason`/`disconnectEvent`, including the [triggerCleanPassiveDropForTest]
+     * synthetic event); only the DECISION moved to the connection core.
+     */
+    private val passiveTransportDropEffects: PassiveTransportDropEffects =
+        PassiveTransportDropEffects(
+            isExplicitDetach = { client ->
+                val disconnectEvent = client.disconnectEvent.value
+                disconnectEvent?.reason == TmuxDisconnectReason.ExplicitDetach ||
+                    disconnectEvent?.intent == "detach_or_replace"
+            },
+            isCurrentClient = { client -> clientRef === client },
+            hasTarget = { (activeTarget ?: connectingTarget) != null },
+            screenStartedForCleared = { screenStartedForCleared },
+            navigatingToDifferentSession = {
+                val target = activeTarget ?: connectingTarget
+                connectJob?.isActive == true ||
+                    (
+                        target != null &&
+                            latestConnectIntent?.let { it.target.sessionName != target.sessionName } == true
+                    )
             },
         )
 
@@ -7333,8 +7369,8 @@ public class TmuxSessionViewModel @Inject constructor(
                 // driver-owned handler records the canonical `passive_disconnect`
                 // diagnostic so silent reattach cannot cancel this collector before
                 // observability lands.
-                val decision = classifyPassiveTransportDrop(client)
-                if (decision == ConnectionDecision.Ignore) {
+                val decision = passiveTransportDropEffects.classify(client)
+                if (decision == PassiveDropArm.Ignore) {
                     DiagnosticEvents.record(
                         "connection",
                         "passive_disconnect_ignored",
@@ -7422,9 +7458,9 @@ public class TmuxSessionViewModel @Inject constructor(
         // nothing tappable. A transport drop is real regardless of the display
         // status; the controller's `onTransportDropped` already walks `Attaching`/
         // `Live`/`Reattaching`/`Reconnecting` into the silent-heal ladder, and the
-        // [classifyPassiveTransportDrop] self-gates the IO arm by client identity
-        // (a stale-client drop is ignored there). The display status no longer
-        // gates recovery — only the client-identity guard in [classifyPassiveTransportDrop]
+        // connection-core [PassiveTransportDropEffects] self-gates the IO arm by client
+        // identity (a stale-client drop is ignored there). The display status no longer
+        // gates recovery — only the client-identity guard in [PassiveTransportDropEffects]
         // does.
         val target = activeTarget ?: connectingTarget
         val reason = passiveDisconnectMessage(target, disconnectEvent)
@@ -7483,8 +7519,8 @@ public class TmuxSessionViewModel @Inject constructor(
         // Classify the drop FIRST (status-agnostic — #895/#766). `Ignore` means the
         // dropped client is not the current one (a stale `-CC` close on a healthy
         // fast switch, the #635 spurious-band case) — for that we surface NOTHING.
-        val decision = classifyPassiveTransportDrop(client)
-        if (decision == ConnectionDecision.Ignore) {
+        val decision = passiveTransportDropEffects.classify(client)
+        if (decision == PassiveDropArm.Ignore) {
             projectStatusFromController()
             return
         }
@@ -7498,13 +7534,13 @@ public class TmuxSessionViewModel @Inject constructor(
         // checkpoint); the controller-fed band above is the escapable state, this
         // drives the recovery underneath it.
         when (decision) {
-            ConnectionDecision.SkipPassiveInAppNavigation ->
+            PassiveDropArm.SkipInAppNavigation ->
                 if (target != null) skipPassiveInAppNavigation(target)
-            ConnectionDecision.PausePassiveUntilForeground ->
+            PassiveDropArm.PauseUntilForeground ->
                 if (target != null) pausePassiveUntilForeground(target, reason, disconnectEvent)
-            ConnectionDecision.SilentReattachWithinGrace ->
+            PassiveDropArm.SilentReattachWithinGrace ->
                 silentReattachWithinPassiveGrace(client, target, reason, disconnectEvent)
-            else -> Unit
+            PassiveDropArm.Ignore -> Unit
         }
         // APPROVED #685 divergence #1 (silent recovery): a recoverable live-channel
         // drop moves the controller Live → Reattaching, so the displayed status is a
@@ -7516,7 +7552,7 @@ public class TmuxSessionViewModel @Inject constructor(
     }
 
     /**
-     * EPIC #687 slice 1a: the [ConnectionDecision.SkipPassiveInAppNavigation]
+     * EPIC #687 slice 1a: the [PassiveDropArm.SkipInAppNavigation]
      * body (#630) — formerly inline in [handlePassiveClientDisconnect].
      * Unchanged behavior.
      */
@@ -7533,7 +7569,7 @@ public class TmuxSessionViewModel @Inject constructor(
     }
 
     /**
-     * EPIC #687 slice 1a: the [ConnectionDecision.PausePassiveUntilForeground]
+     * EPIC #687 slice 1a: the [PassiveDropArm.PauseUntilForeground]
      * body — formerly inline in [handlePassiveClientDisconnect]. Unchanged
      * behavior.
      */
@@ -7558,7 +7594,7 @@ public class TmuxSessionViewModel @Inject constructor(
     }
 
     /**
-     * EPIC #687 slice 1a: the [ConnectionDecision.SilentReattachWithinGrace]
+     * EPIC #687 slice 1a: the [PassiveDropArm.SilentReattachWithinGrace]
      * body — formerly the grace-job tail of [handlePassiveClientDisconnect].
      * Unchanged behavior.
      */
@@ -16264,21 +16300,12 @@ public class TmuxSessionViewModel @Inject constructor(
          */
         data object SuppressNetworkTransportProvenAlive : ConnectionDecision
 
-        // --- TransportDropped (passive disconnect) ---
-        /**
-         * The screen stopped for an in-app navigation to a DIFFERENT session
-         * (#630) — skip the pause entirely so it cannot race the new connect.
-         */
-        data object SkipPassiveInAppNavigation : ConnectionDecision
-
-        /**
-         * The screen stopped (app background / explicit leave) — pause the
-         * auto-reconnect until foreground rather than racing a grace reattach.
-         */
-        data object PausePassiveUntilForeground : ConnectionDecision
-
-        /** Foreground passive disconnect — race the within-grace silent reattach. */
-        data object SilentReattachWithinGrace : ConnectionDecision
+        // --- TransportDropped (passive disconnect) --- EPIC #687 Slice 2 (#1047): the
+        // passive-drop classification moved into the connection core
+        // ([PassiveTransportDropEffects], the SINGLE passive-drop authority); the inline
+        // `classifyPassiveTransportDrop()` + its three variants (`SkipPassiveInAppNavigation`
+        // / `PausePassiveUntilForeground` / `SilentReattachWithinGrace`) are DELETED (D22
+        // hard-cut). The arms are now [com.pocketshell.app.tmux.connection.PassiveDropArm].
     }
 
     // EPIC #687 Slice 1 (#1047): `reduceBackground()` is DELETED. The background
@@ -16354,43 +16381,13 @@ public class TmuxSessionViewModel @Inject constructor(
         return ConnectionDecision.ScheduleNetworkReconnect
     }
 
-    private fun classifyPassiveTransportDrop(client: TmuxClient): ConnectionDecision {
-        val disconnectEvent = client.disconnectEvent.value
-        if (
-            disconnectEvent?.reason == TmuxDisconnectReason.ExplicitDetach ||
-            disconnectEvent?.intent == "detach_or_replace"
-        ) {
-            return ConnectionDecision.Ignore
-        }
-        // Issue #895 (#766 down-payment): STATUS-AGNOSTIC. The old
-        // `inlineConnectionStatus !is Connected -> Ignore` gate swallowed a drop
-        // that landed during the `Switching` (Attaching) window — the R1
-        // switch-while-black freeze. The real protection against acting on the
-        // brief tmux `-CC` close of a NORMAL fast switch (the #635 spurious-band
-        // risk) is the client-identity guard below: during a healthy switch the
-        // old client's `disconnected` edge fires AFTER `clientRef` already points
-        // at the new client, so it is correctly ignored. A drop on the CURRENT
-        // client — whatever the display status — is a real transport loss and
-        // must drive recovery, so it is no longer gated by the status. An
-        // Idle/Gone session has no current client, so the identity guard below
-        // returns Ignore for it; the controller also self-gates a drop from a
-        // non-live-ish state, so no spurious band can surface there.
-        //
-        // Only react if this is still THE active client (a fresh connect may have
-        // swapped in a new client whose state this drop must not stomp).
-        if (clientRef !== client) return ConnectionDecision.Ignore
-        val target = activeTarget ?: connectingTarget
-        if (target != null && !screenStartedForCleared) {
-            val navigatingToDifferentSession = connectJob?.isActive == true ||
-                latestConnectIntent?.let { it.target.sessionName != target.sessionName } == true
-            return if (navigatingToDifferentSession) {
-                ConnectionDecision.SkipPassiveInAppNavigation
-            } else {
-                ConnectionDecision.PausePassiveUntilForeground
-            }
-        }
-        return ConnectionDecision.SilentReattachWithinGrace
-    }
+    // EPIC #687 Slice 2 (#1047): `classifyPassiveTransportDrop()` is DELETED. The passive
+    // `-CC` drop classification now lives in the connection core
+    // ([PassiveTransportDropEffects], the SINGLE passive-drop authority), fed the live
+    // `clientRef` identity / `activeTarget`/`connectingTarget` / in-app-navigation context
+    // the controller's display state lacks; the inline selector was the second decision
+    // authority D28 exists to end (D22 hard-cut — no shadow). The status-agnostic #895/#766
+    // contract + the #635 client-identity guard now live in [selectPassiveDropArm].
 
     /** Coarse-grained connection state. Mirrors `SessionViewModel.ConnectionStatus`. */
     public sealed interface ConnectionStatus {

--- a/app/src/main/java/com/pocketshell/app/tmux/connection/PassiveTransportDropEffects.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/connection/PassiveTransportDropEffects.kt
@@ -1,0 +1,123 @@
+package com.pocketshell.app.tmux.connection
+
+import com.pocketshell.core.tmux.TmuxClient
+
+/**
+ * EPIC #687 Slice 2 (#1047) — the PASSIVE-TRANSPORT-DROP classification, the THIRD of the
+ * four inline `TmuxSessionViewModel` `reduce*` selectors retired into the connection core
+ * under the maintainer's Path-A D28 consolidation (Slice 0 retired `reduceForeground`,
+ * Slice 1 retired `reduceBackground`; this slice follows the SAME proven pattern).
+ *
+ * Before this slice the passive `-CC` control-channel drop was classified by the inline
+ * `TmuxSessionViewModel.classifyPassiveTransportDrop()` selector — a SECOND decision
+ * authority alongside the [com.pocketshell.core.connection.ConnectionController], the exact
+ * dual-authority condition D28 exists to end. The classification decides whether a passive
+ * disconnect is acted on at all (the driver's `shouldSubmitControlChannelDrop` stale-client
+ * gate) and, when it is, WHICH passive-recovery arm runs. It re-reads context the controller
+ * does not have (the live `clientRef` identity, the `activeTarget`/`connectingTarget`, the
+ * in-app-navigation intent) — the #685 re-read trap.
+ *
+ * The inline `classifyPassiveTransportDrop()` and its three passive `ConnectionDecision`
+ * variants (`SkipPassiveInAppNavigation` / `PausePassiveUntilForeground` /
+ * `SilentReattachWithinGrace`) are DELETED in the same change (D22 hard-cut — no shadow
+ * selector, no coexistence). The shared `ConnectionDecision.Ignore` stays because the
+ * network reducer (Slice 3) still uses it; the passive-drop Ignore is now
+ * [PassiveDropArm.Ignore].
+ */
+enum class PassiveDropArm {
+    /**
+     * Not actionable: an explicit detach / `detach_or_replace`, OR the drop is on a STALE
+     * (non-current) client — the #635 spurious-band protection. The old inline `Ignore`.
+     */
+    Ignore,
+
+    /**
+     * The screen stopped for an in-app navigation to a DIFFERENT session (#630) — skip the
+     * pause entirely so it cannot race the new connect. The old `SkipPassiveInAppNavigation`.
+     */
+    SkipInAppNavigation,
+
+    /**
+     * The screen stopped (app background / explicit leave) — pause the auto-reconnect until
+     * foreground rather than racing a grace reattach. The old `PausePassiveUntilForeground`.
+     */
+    PauseUntilForeground,
+
+    /** Foreground passive disconnect — race the within-grace silent reattach. The old `SilentReattachWithinGrace`. */
+    SilentReattachWithinGrace,
+}
+
+/**
+ * The PURE passive-drop selector — the connection-core replacement for the deleted inline
+ * `classifyPassiveTransportDrop()` predicate. The arm ORDER is byte-identical to the inline
+ * selector (the #685 predicate-order trap — keep the EXACT inline precedence so behavior is
+ * unchanged):
+ *
+ *   1. [isExplicitDetach] (ExplicitDetach reason OR `detach_or_replace` intent) -> [PassiveDropArm.Ignore]
+ *   2. NOT [isCurrentClient] (the #635 client-identity guard — a stale old-client close)   -> [PassiveDropArm.Ignore]
+ *   3. [hasTarget] AND NOT [screenStartedForCleared]:
+ *        - [navigatingToDifferentSession] -> [PassiveDropArm.SkipInAppNavigation]
+ *        - else                           -> [PassiveDropArm.PauseUntilForeground]
+ *   4. else                                                                                  -> [PassiveDropArm.SilentReattachWithinGrace]
+ *
+ * Issue #895 (#766 down-payment): STATUS-AGNOSTIC. There is intentionally NO
+ * `inlineConnectionStatus !is Connected -> Ignore` gate — the old status gate swallowed a
+ * drop that landed during the `Switching` (Attaching) window (the R1 switch-while-black
+ * freeze). The real protection against acting on the brief `-CC` close of a NORMAL fast
+ * switch is the client-identity guard ([isCurrentClient]): during a healthy switch the old
+ * client's `disconnected` edge fires AFTER `clientRef` already points at the new client, so
+ * it is correctly ignored. A drop on the CURRENT client — whatever the display status — is a
+ * real transport loss and must drive recovery.
+ */
+fun selectPassiveDropArm(
+    isExplicitDetach: Boolean,
+    isCurrentClient: Boolean,
+    hasTarget: Boolean,
+    screenStartedForCleared: Boolean,
+    navigatingToDifferentSession: Boolean,
+): PassiveDropArm = when {
+    isExplicitDetach -> PassiveDropArm.Ignore
+    !isCurrentClient -> PassiveDropArm.Ignore
+    hasTarget && !screenStartedForCleared ->
+        if (navigatingToDifferentSession) {
+            PassiveDropArm.SkipInAppNavigation
+        } else {
+            PassiveDropArm.PauseUntilForeground
+        }
+
+    else -> PassiveDropArm.SilentReattachWithinGrace
+}
+
+/**
+ * The connection-core passive-transport-drop authority: the SINGLE owner of the passive
+ * `-CC` drop classification. Every passive-drop call site (the driver's
+ * `shouldSubmitControlChannelDrop` stale-client gate, the clean-drop test seam, the
+ * stale-client breadcrumb observer, and the real `handlePassiveClientDisconnect` dispatch)
+ * routes its decision through [classify].
+ *
+ * The predicates re-read the VM's live state at classification time (the #685 trap: the
+ * decision must read CURRENT state — the live `clientRef`, `activeTarget`/`connectingTarget`,
+ * the in-app-navigation intent — not a snapshot captured at construction). This type holds
+ * the DECISION; the VM holds the state + the per-arm recovery IO.
+ */
+class PassiveTransportDropEffects(
+    private val isExplicitDetach: (TmuxClient) -> Boolean,
+    private val isCurrentClient: (TmuxClient) -> Boolean,
+    private val hasTarget: () -> Boolean,
+    private val screenStartedForCleared: () -> Boolean,
+    private val navigatingToDifferentSession: () -> Boolean,
+) {
+    /**
+     * Classify the passive drop of [client] from the live predicates. Pure read; fires no IO
+     * (the caller — `handlePassiveClientDisconnect` — owns the per-arm recovery IO with its
+     * handler-local `target`/`reason`/`disconnectEvent`).
+     */
+    fun classify(client: TmuxClient): PassiveDropArm =
+        selectPassiveDropArm(
+            isExplicitDetach = isExplicitDetach(client),
+            isCurrentClient = isCurrentClient(client),
+            hasTarget = hasTarget(),
+            screenStartedForCleared = screenStartedForCleared(),
+            navigatingToDifferentSession = navigatingToDifferentSession(),
+        )
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/connection/PassiveTransportDropEffectsTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/connection/PassiveTransportDropEffectsTest.kt
@@ -1,0 +1,237 @@
+package com.pocketshell.app.tmux.connection
+
+import com.pocketshell.app.tmux.FakeTmuxClient
+import com.pocketshell.core.tmux.TmuxClient
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * EPIC #687 Slice 2 (#1047) — the connection-core CHARACTERIZATION proof for the
+ * passive-transport-drop classification, the hard-cut replacement for the deleted inline
+ * `TmuxSessionViewModel.classifyPassiveTransportDrop()` selector (D28 single active path;
+ * D22 hard-cut).
+ *
+ * RED→GREEN (the load-bearing proof — the #635 client-identity guard + the #895 status-agnostic
+ * contract):
+ *  - RED: drop the `!isCurrentClient -> Ignore` guard from [selectPassiveDropArm] (i.e. the
+ *    controller/driver acting on EVERY `-CC` close without re-reading the live `clientRef`
+ *    identity). Then a STALE old-client close on a healthy fast switch (the #635 spurious-band
+ *    case) is WRONGLY treated as actionable, and the per-call re-read fixture
+ *    ([classify_reReadsCurrentClientEachCall]) fails. (Demonstrated by stubbing the selector.)
+ *  - GREEN: with the client-identity guard, the connection-core [PassiveTransportDropEffects]
+ *    reproduces the EXACT inline arm for every fixture, including the NON-happy ones (explicit
+ *    detach, stale client, in-app navigation, screen-stopped pause, foreground silent reattach).
+ *
+ * The inline `classifyPassiveTransportDrop()` mapping this pins (now deleted from the VM):
+ *   ExplicitDetach reason / `detach_or_replace` intent          -> Ignore
+ *   clientRef !== client (stale old-client close, #635)         -> Ignore
+ *   target present && !screenStartedForCleared && navigating    -> SkipInAppNavigation (#630)
+ *   target present && !screenStartedForCleared && !navigating   -> PauseUntilForeground
+ *   else                                                        -> SilentReattachWithinGrace
+ *
+ * Issue #895 (#766 down-payment): the selector is STATUS-AGNOSTIC — there is NO connection-status
+ * input, so a drop on the CURRENT client during the `Switching`/Attaching window is NOT swallowed
+ * (it classifies to a recovery arm), exactly the switch-while-black-band freeze fix. The only gate
+ * against acting on a NORMAL fast switch is the client-identity guard, not the status.
+ */
+class PassiveTransportDropEffectsTest {
+
+    // ---- the PURE selector: class-coverage over the input combinations ----------------
+
+    @Test
+    fun selector_explicitDetach_ignored() {
+        // Explicit detach / `detach_or_replace` wins FIRST, regardless of the rest (#685 ORDER).
+        assertEquals(
+            PassiveDropArm.Ignore,
+            selectPassiveDropArm(
+                isExplicitDetach = true,
+                isCurrentClient = true,
+                hasTarget = true,
+                screenStartedForCleared = false,
+                navigatingToDifferentSession = true,
+            ),
+        )
+    }
+
+    @Test
+    fun selector_staleClient_ignored() {
+        // THE #635 load-bearing fixture: a stale old-client `-CC` close on a healthy fast switch
+        // (clientRef already points at the NEW client) — must stay Ignore so no spurious band.
+        assertEquals(
+            PassiveDropArm.Ignore,
+            selectPassiveDropArm(
+                isExplicitDetach = false,
+                isCurrentClient = false,
+                hasTarget = true,
+                screenStartedForCleared = false,
+                navigatingToDifferentSession = false,
+            ),
+        )
+    }
+
+    @Test
+    fun selector_currentClient_navigatingToDifferentSession_skips() {
+        // #630: the screen stopped for an in-app navigation to a DIFFERENT session — skip the
+        // pause so it cannot race the new connect.
+        assertEquals(
+            PassiveDropArm.SkipInAppNavigation,
+            selectPassiveDropArm(
+                isExplicitDetach = false,
+                isCurrentClient = true,
+                hasTarget = true,
+                screenStartedForCleared = false,
+                navigatingToDifferentSession = true,
+            ),
+        )
+    }
+
+    @Test
+    fun selector_currentClient_screenStopped_notNavigating_pauses() {
+        assertEquals(
+            PassiveDropArm.PauseUntilForeground,
+            selectPassiveDropArm(
+                isExplicitDetach = false,
+                isCurrentClient = true,
+                hasTarget = true,
+                screenStartedForCleared = false,
+                navigatingToDifferentSession = false,
+            ),
+        )
+    }
+
+    @Test
+    fun selector_currentClient_noTarget_silentReattach() {
+        assertEquals(
+            PassiveDropArm.SilentReattachWithinGrace,
+            selectPassiveDropArm(
+                isExplicitDetach = false,
+                isCurrentClient = true,
+                hasTarget = false,
+                screenStartedForCleared = false,
+                navigatingToDifferentSession = false,
+            ),
+        )
+    }
+
+    @Test
+    fun selector_currentClient_screenStartedForCleared_silentReattach() {
+        // screenStartedForCleared = true (a foreground drop) -> the within-grace silent reattach,
+        // NOT the pause/skip arm (the pause/skip branch is gated on `!screenStartedForCleared`).
+        assertEquals(
+            PassiveDropArm.SilentReattachWithinGrace,
+            selectPassiveDropArm(
+                isExplicitDetach = false,
+                isCurrentClient = true,
+                hasTarget = true,
+                screenStartedForCleared = true,
+                navigatingToDifferentSession = true,
+            ),
+        )
+    }
+
+    @Test
+    fun selector_staleClient_winsOverNavigationArm() {
+        // The #685 predicate-ORDER trap: the client-identity guard is checked BEFORE the
+        // target/navigation branch, so a stale client is Ignore even when it would otherwise
+        // look like an in-app navigation.
+        assertEquals(
+            PassiveDropArm.Ignore,
+            selectPassiveDropArm(
+                isExplicitDetach = false,
+                isCurrentClient = false,
+                hasTarget = true,
+                screenStartedForCleared = false,
+                navigatingToDifferentSession = true,
+            ),
+        )
+    }
+
+    @Test
+    fun selector_statusAgnostic_currentClientDropAlwaysRecovers() {
+        // Issue #895: there is NO status input — a drop on the CURRENT client (whatever the
+        // display status, including the Switching/Attaching window) is NEVER swallowed; it
+        // classifies to a recovery arm. Here: current client, no in-app nav -> silent reattach.
+        assertEquals(
+            PassiveDropArm.SilentReattachWithinGrace,
+            selectPassiveDropArm(
+                isExplicitDetach = false,
+                isCurrentClient = true,
+                hasTarget = false,
+                screenStartedForCleared = true,
+                navigatingToDifferentSession = false,
+            ),
+        )
+    }
+
+    // ---- the CLASSIFIER: re-reads live state per call (#685 re-read trap) --------------
+
+    private val client: TmuxClient = FakeTmuxClient()
+
+    private fun effects(
+        isExplicitDetach: (TmuxClient) -> Boolean = { false },
+        isCurrentClient: (TmuxClient) -> Boolean = { true },
+        hasTarget: () -> Boolean = { true },
+        screenStartedForCleared: () -> Boolean = { false },
+        navigatingToDifferentSession: () -> Boolean = { false },
+    ) = PassiveTransportDropEffects(
+        isExplicitDetach = isExplicitDetach,
+        isCurrentClient = isCurrentClient,
+        hasTarget = hasTarget,
+        screenStartedForCleared = screenStartedForCleared,
+        navigatingToDifferentSession = navigatingToDifferentSession,
+    )
+
+    @Test
+    fun classify_explicitDetach_ignored() {
+        assertEquals(
+            PassiveDropArm.Ignore,
+            effects(isExplicitDetach = { true }).classify(client),
+        )
+    }
+
+    @Test
+    fun classify_currentClient_navigating_skips() {
+        assertEquals(
+            PassiveDropArm.SkipInAppNavigation,
+            effects(navigatingToDifferentSession = { true }).classify(client),
+        )
+    }
+
+    @Test
+    fun classify_currentClient_screenStopped_pauses() {
+        assertEquals(
+            PassiveDropArm.PauseUntilForeground,
+            effects().classify(client),
+        )
+    }
+
+    @Test
+    fun classify_currentClient_foreground_silentReattach() {
+        assertEquals(
+            PassiveDropArm.SilentReattachWithinGrace,
+            effects(screenStartedForCleared = { true }).classify(client),
+        )
+    }
+
+    /**
+     * The #685 RE-READ trap + the #635 client-identity guard: the classifier must consult the
+     * live `clientRef` identity at CALL time, NOT a value snapshotted at construction. A fast
+     * switch swaps in a new current client; the OLD client's late `-CC` close must then classify
+     * to Ignore (no spurious band), while a drop on the new current client still recovers.
+     */
+    @Test
+    fun classify_reReadsCurrentClientEachCall() {
+        val oldClient: TmuxClient = FakeTmuxClient()
+        val newClient: TmuxClient = FakeTmuxClient()
+        var currentClient: TmuxClient = oldClient
+        val fx = effects(isCurrentClient = { it === currentClient })
+
+        // While oldClient is current, its drop recovers (no target/screenStopped -> here pause).
+        assertEquals(PassiveDropArm.PauseUntilForeground, fx.classify(oldClient))
+        // A fast switch swaps in newClient: the OLD client's late close is now a stale drop.
+        currentClient = newClient
+        assertEquals(PassiveDropArm.Ignore, fx.classify(oldClient))
+        // The new current client's drop still recovers.
+        assertEquals(PassiveDropArm.PauseUntilForeground, fx.classify(newClient))
+    }
+}


### PR DESCRIPTION
## D28 Path A — Slice 2 of 0–5

Migrates the inline `classifyPassiveTransportDrop` classifier into the connection core (new `PassiveTransportDropEffects`).

### Change
- New `PassiveTransportDropEffects` (`selectPassiveDropArm` + `classify(client)`) owns the passive-drop classification.
- Deleted inline `classifyPassiveTransportDrop` + 3 passive `ConnectionDecision` variants; **10 → 7**.
- All **four** call sites route through the new authority (driver predicate, ForTest seam, stale-client observer, real dispatch); the ForTest seam kept working, full retirement deferred to Slice 5.

### Verification
- Reviewer **APPROVED**: drove the #635-guard red→green (3 stale-client cases), confirmed **#685 equivalence** (arm order line-for-line), the **#635 client-identity guard** + **#895 status-agnostic contract** preserved, predicates re-read live state per call.
- `PassiveTransportDropEffectsTest` 13, full `:app` **3145/0**. Post-rebase onto #1057: compile + test green.
- Journeys Issue895SwitchWhileBlackBand / MultiSessionSwitch / SilentDropSyntheticSeam gate-wired.

Part of #1047 — does NOT close it (Slices 3–5 follow).