### PR TITLE
core-ssh+tmux: outbound-aware liveness + un-wedge reconnect on attach upload (#1072)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/AttachmentDropReconnectRecoversE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/AttachmentDropReconnectRecoversE2eTest.kt
@@ -43,9 +43,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
-import org.junit.rules.TestRule
 import org.junit.runner.RunWith
-import org.junit.runners.model.Statement
 import java.io.File
 
 /**
@@ -83,13 +81,17 @@ import java.io.File
 @RunWith(AndroidJUnit4::class)
 class AttachmentDropReconnectRecoversE2eTest {
 
+    // Issue #788/#848: createAndroidComposeRule<MainActivity>() + the shared
+    // SeedBeforeLaunchRule own the harness — the durable launch-owned shape the CI
+    // journey-harness guard pins. The compose rule launches MainActivity in its
+    // `before()`, so the remote tmux session + DB host row are seeded BEFORE launch
+    // by the chain (outer `before()` first): grant perms -> seed -> launch.
     val compose = createAndroidComposeRule<MainActivity>()
-    private val grantPermissions = PreGrantPermissionsRule()
 
     @get:Rule
     val ruleChain: RuleChain = RuleChain
-        .outerRule(grantPermissions)
-        .around(seedFixtureRule())
+        .outerRule(PreGrantPermissionsRule())
+        .around(SeedBeforeLaunchRule { seedBeforeLaunch() })
         .around(compose)
 
     private var seededKey: String? = null
@@ -98,24 +100,24 @@ class AttachmentDropReconnectRecoversE2eTest {
     private val uploadScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val timings = mutableListOf<String>()
 
-    private fun seedFixtureRule(): TestRule = TestRule { base, _ ->
-        object : Statement() {
-            override fun evaluate() {
-                runBlocking {
-                    val key = readFixtureKey()
-                    seededKey = key
-                    waitForSshFixtureReady(SshKey.Pem(key))
-                    seedTmuxSession(key)
-                    seededHostRowTag = seedDockerHost(key)
-                }
-                base.evaluate()
-            }
-        }
+    /**
+     * Issue #788: all LAUNCH-time state established BEFORE MainActivity launches
+     * (run by [SeedBeforeLaunchRule], which evaluates before the compose rule's
+     * `before()`): clear the last-session pref so the app reads a clean baseline on
+     * its first composition (read at launch — clearing it in @Before, post-launch,
+     * would be too late), then seed the remote tmux session + DB host row.
+     */
+    private suspend fun seedBeforeLaunch() {
+        clearLastSessionPrefs()
+        val key = readFixtureKey()
+        seededKey = key
+        waitForSshFixtureReady(SshKey.Pem(key))
+        seedTmuxSession(key)
+        seededHostRowTag = seedDockerHost(key)
     }
 
     @Before
     fun setUp() {
-        clearLastSessionPrefs()
         diagnostics = RecordingDiagnosticSink().also { DiagnosticEvents.install(it) }
     }
 

--- a/app/src/androidTest/java/com/pocketshell/app/proof/AttachmentDropReconnectRecoversE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/AttachmentDropReconnectRecoversE2eTest.kt
@@ -1,0 +1,715 @@
+package com.pocketshell.app.proof
+
+import android.net.Uri
+import android.os.SystemClock
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.ViewModelProvider
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.MainActivity
+import com.pocketshell.app.diagnostics.DiagnosticEvents
+import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
+import com.pocketshell.app.hosts.SshKeyStorage
+import com.pocketshell.app.tmux.TMUX_PULL_TO_RECONNECT_TAG
+import com.pocketshell.app.tmux.TMUX_SESSION_ERROR_TAG
+import com.pocketshell.app.tmux.TMUX_SESSION_RECONNECT_TAG
+import com.pocketshell.app.tmux.TMUX_SESSION_SCREEN_TAG
+import com.pocketshell.app.tmux.TmuxSessionViewModel
+import com.pocketshell.core.ssh.KnownHostsPolicy
+import com.pocketshell.core.ssh.SshConnection
+import com.pocketshell.core.ssh.SshKey
+import com.pocketshell.core.storage.AppDatabase
+import com.pocketshell.core.storage.entity.HostEntity
+import com.termux.view.TerminalView
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.rules.TestRule
+import org.junit.runner.RunWith
+import org.junit.runners.model.Statement
+import java.io.File
+
+/**
+ * Issue #1072 (v0.4.19 release blocker, maintainer dogfood): "When I attach
+ * something the connection breaks and then I can't reconnect — I have to restart
+ * the app." Failure 2 — the post-attach drop wedging reconnect — is the
+ * maintainer's "worse half" and a reconnect-core (D28) change.
+ *
+ * This is the missing END-TO-END proof (G10 / D33). The deterministic JVM gate
+ * ([com.pocketshell.app.tmux.AttachmentUploadTeardownReconnectTest]) modeled the
+ * wedge with a `BlockingConnector` + a forever-blocking `CompletableDeferred`, NOT
+ * a real attachment upload being torn down on a real `-CC` transport while the
+ * reconnect ladder redials. The v0.4.19 review BLOCKED on exactly that gap: Failure
+ * 2 had no connected/Docker journey on the real path. Both methods here run on the
+ * REAL path (emulator + Docker `agents:2222`), DETERMINISTICALLY (no toxiproxy — so
+ * they gate per-push), with NO `assumeTrue`/`assumeFalse(isRunningOnCi())` on the
+ * load-bearing assertions (D31/F3):
+ *
+ *  - [attachUploadTornDownOnRealTransportIsOwnedAndCancelled] is the deterministic
+ *    red→green proof of Failure 2's root cause #1: a REAL attachment upload, in
+ *    flight on the REAL warm `-CC` transport, MUST be OWNED by the VM and
+ *    cancel-and-joined by the reconnect ladder's teardown. RED on base (revert the
+ *    `attachmentUploadJob?.cancelAndJoin()` teardown lines): the un-owned upload is
+ *    a free-floating writer that races teardown and wedges reconnect, so the
+ *    `tmux_attachment_stage_cancelled_by_teardown` diagnostic is NEVER recorded.
+ *
+ *  - [genuineDropDuringUploadRecoversToLiveWithoutRestart] is the faithful
+ *    user-visible acceptance: a GENUINE transport death (the app's `-CC` sshd
+ *    worker is killed) mid-upload — the maintainer's real scenario — then a manual
+ *    Reconnect MUST return the SAME session to Live WITHOUT an app restart, with a
+ *    fresh marker round-tripping through the recovered channel. (A genuine death
+ *    leaves the warm transport `isConnected==false`, so the reconnect dials a
+ *    FRESH transport instead of reusing the upload-poisoned one.)
+ */
+@RunWith(AndroidJUnit4::class)
+class AttachmentDropReconnectRecoversE2eTest {
+
+    val compose = createAndroidComposeRule<MainActivity>()
+    private val grantPermissions = PreGrantPermissionsRule()
+
+    @get:Rule
+    val ruleChain: RuleChain = RuleChain
+        .outerRule(grantPermissions)
+        .around(seedFixtureRule())
+        .around(compose)
+
+    private var seededKey: String? = null
+    private var seededHostRowTag: String? = null
+    private var diagnostics: RecordingDiagnosticSink? = null
+    private val uploadScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val timings = mutableListOf<String>()
+
+    private fun seedFixtureRule(): TestRule = TestRule { base, _ ->
+        object : Statement() {
+            override fun evaluate() {
+                runBlocking {
+                    val key = readFixtureKey()
+                    seededKey = key
+                    waitForSshFixtureReady(SshKey.Pem(key))
+                    seedTmuxSession(key)
+                    seededHostRowTag = seedDockerHost(key)
+                }
+                base.evaluate()
+            }
+        }
+    }
+
+    @Before
+    fun setUp() {
+        clearLastSessionPrefs()
+        diagnostics = RecordingDiagnosticSink().also { DiagnosticEvents.install(it) }
+    }
+
+    @After
+    fun tearDown() {
+        runCatching {
+            compose.activityRule.scenario.moveToState(Lifecycle.State.RESUMED)
+        }
+        uploadScope.cancel()
+        diagnostics?.close()
+        diagnostics = null
+        clearLastSessionPrefs()
+        seededKey?.let { key ->
+            runCatching { runBlocking { cleanupRemoteTmuxSession(key) } }
+        }
+    }
+
+    /**
+     * Failure-2 root cause #1 — the deterministic red→green proof, on the REAL
+     * `-CC` transport. A REAL attachment upload streams over the warm lease; we
+     * declare a drop while it is genuinely in flight (the deterministic
+     * liveness-probe seam fires the SAME onLivenessProbeDeclaredDrop ->
+     * scheduleAutoReconnect -> closeCurrentConnectionAndJoin teardown a real silent
+     * drop fires), and assert the teardown OWNS + CANCELS the in-flight upload.
+     */
+    @Test
+    fun attachUploadTornDownOnRealTransportIsOwnedAndCancelled() = runBlocking<Unit> {
+        val key = requireNotNull(seededKey)
+        val hostRowTag = requireNotNull(seededHostRowTag)
+        attachSeededTmuxSession(hostRowTag)
+        waitForVisibleTerminal("initial attach") { it.contains(READY_MARKER) }
+        waitForConnected("initial attach")
+        emitMarkerIntoPane(key, "LIVE-$MARKER")
+        waitForVisibleTerminal("pre-drop-live") { it.contains("LIVE-$MARKER") }
+
+        val vm = currentViewModel()
+        diagnostics!!.clear()
+
+        // Start the REAL, large attachment upload over the warm `-CC` lease and wait
+        // until it is genuinely in flight on the real transport.
+        val uploadResult = startRealUpload(vm)
+        assertTrue(
+            "expected the real attachment upload to be IN FLIGHT on the warm `-CC` " +
+                "transport (attachmentUploadActiveForTest) so the teardown tears it down " +
+                "mid-stream — it never went active within ${UPLOAD_IN_FLIGHT_WINDOW_MS}ms " +
+                "(upload too fast? raise UPLOAD_BYTES).",
+            waitForUploadInFlight(vm, UPLOAD_IN_FLIGHT_WINDOW_MS),
+        )
+
+        // Declare a drop DURING the in-flight upload, on Main — the real
+        // onLivenessProbeDeclaredDrop -> scheduleAutoReconnect ->
+        // closeCurrentConnectionAndJoin teardown chain.
+        val dropStart = SystemClock.elapsedRealtime()
+        compose.activityRule.scenario.onActivity {
+            ViewModelProvider(it)[TmuxSessionViewModel::class.java].triggerLivenessProbeDropForTest(2)
+        }
+
+        // The teardown MUST own + cancel the in-flight upload (Failure-2 root cause).
+        val result = uploadResult.await()
+        val cancelledByTeardown =
+            diagnostics!!.eventsNamed("tmux_attachment_stage_cancelled_by_teardown")
+        recordTiming(
+            "upload_cancelled_by_teardown_ms",
+            if (cancelledByTeardown.isNotEmpty()) SystemClock.elapsedRealtime() - dropStart else -1L,
+        )
+        assertTrue(
+            "#1072 Failure 2: the connection teardown MUST own + cancel the in-flight " +
+                "attachment upload (tmux_attachment_stage_cancelled_by_teardown). On base " +
+                "the un-owned upload races teardown and wedges reconnect — RED: revert the " +
+                "attachmentUploadJob?.cancelAndJoin() teardown lines and this diagnostic is " +
+                "never recorded. Recorded attach diagnostics=" +
+                "${diagnostics!!.events.map { it.name }.filter { it.startsWith("tmux_attachment_stage") }}",
+            cancelledByTeardown.isNotEmpty(),
+        )
+        assertTrue(
+            "the upload must resolve to a draft-preserving failure (not silently apply into " +
+                "a dead session), got=$result",
+            result.isFailure,
+        )
+        assertTrue(
+            "after teardown the owned upload job must no longer be active",
+            !vm.attachmentUploadActiveForTest(),
+        )
+        captureViewport("issue1072-A-upload-torn-down")
+        writeTimings("upload-torn-down")
+    }
+
+    /**
+     * The literal #1072 acceptance criterion, faithful + end-to-end: a GENUINE clean
+     * transport outage (the maintainer's "the connection breaks") DURING an in-flight
+     * attach upload, then a manual Reconnect returns the SAME session to Live WITHOUT
+     * an app restart — rebound onto a FRESH transport (not the upload-poisoned one).
+     *
+     * The outage is injected deterministically with the #833 clean-outage seams
+     * ([TmuxSessionViewModel.forceCleanOutageForTest] +
+     * [TmuxSessionViewModel.triggerCleanPassiveDropForTest], the same seams
+     * [CleanOutageReattachResilienceE2eTest] uses) rather than a real socket kill: a
+     * 48 MB upload to fast localhost finishes before a kill connection's handshake
+     * lands, so a kill cannot deterministically tear it down mid-stream on CI. The
+     * clean-outage seam fires the EOF passive-drop the moment the upload is in flight
+     * and forces the reattach loop to re-dial a FRESH transport every iteration — the
+     * faithful genuine-death recovery (a genuinely dead transport is `isConnected ==
+     * false`, so the lease never reuses the upload-poisoned one).
+     */
+    @Test
+    fun genuineDropDuringUploadRecoversToLiveWithoutRestart() = runBlocking<Unit> {
+        val key = requireNotNull(seededKey)
+        val hostRowTag = requireNotNull(seededHostRowTag)
+        attachSeededTmuxSession(hostRowTag)
+        waitForVisibleTerminal("initial attach") { it.contains(READY_MARKER) }
+        waitForConnected("initial attach")
+
+        val vm = currentViewModel()
+        emitMarkerIntoPane(key, "LIVE-$MARKER")
+        waitForVisibleTerminal("pre-drop-live") { it.contains("LIVE-$MARKER") }
+        diagnostics!!.clear()
+
+        // Pre-open a WARM killer SSH session so the genuine death lands near-instantly
+        // (one exec on an already-open transport) once the upload is in flight — a COLD
+        // kill connection's handshake latency let the 48 MB upload to fast-localhost
+        // finish before the kill landed.
+        val killer = SshConnection.connect(
+            host = DEFAULT_HOST,
+            port = DEFAULT_PORT,
+            user = DEFAULT_USER,
+            key = SshKey.Pem(key),
+            knownHosts = KnownHostsPolicy.AcceptAll,
+            timeoutMs = 15_000,
+        ).getOrThrow()
+        val clientBeforeDrop = vm.currentClientIdentityForTest()
+
+        try {
+            // Start the REAL, large attachment upload over the warm `-CC` lease and wait
+            // until it is genuinely in flight on the real transport.
+            val uploadResult = startRealUpload(vm)
+            assertTrue(
+                "expected the real attachment upload to be IN FLIGHT on the warm `-CC` " +
+                    "transport before the drop (upload too fast? raise UPLOAD_BYTES).",
+                waitForUploadInFlight(vm, UPLOAD_IN_FLIGHT_WINDOW_MS),
+            )
+
+            // GENUINE transport death DURING the in-flight upload: kill EVERY testuser
+            // sshd worker except the killer's own (so the app's `-CC`/upload transport
+            // dies for sure — a PID-diff missed it). The remote tmux server + pane stay
+            // alive; only the app's transport dies — the maintainer's "the connection
+            // breaks" while attaching. A genuinely dead transport is `isConnected==false`,
+            // so the reconnect dials a FRESH transport instead of reusing it.
+            val dropStart = SystemClock.elapsedRealtime()
+            killer.exec(
+                "for p in \$(pgrep -u $DEFAULT_USER sshd); do " +
+                    "[ \"\$p\" != \"\$PPID\" ] && kill -9 \"\$p\" 2>/dev/null || true; done",
+            )
+
+            // The in-flight upload must resolve to a draft-preserving failure (the bytes
+            // are NOT silently applied into the dead session).
+            val result = uploadResult.await()
+            recordTiming("upload_resolved_ms", SystemClock.elapsedRealtime() - dropStart)
+            assertTrue(
+                "the in-flight upload must resolve to a draft-preserving failure when the " +
+                    "transport dies under it, got=$result",
+                result.isFailure,
+            )
+
+            // The drop is USER-VISIBLE.
+            assertTrue(
+                "expected a USER-VISIBLE connection-lost indicator after the mid-upload drop " +
+                    "(status=${currentConnectionStatus()}).",
+                waitForConnectionLostIndicator(DROP_DETECT_WINDOW_MS),
+            )
+            captureViewport("issue1072-B-dropped-mid-upload")
+
+            // The maintainer's "I tap reconnect" — the production handler the Reconnect
+            // button invokes. With the fix an explicit Reconnect PREEMPTS any in-flight
+            // same-target connect so a wedged attempt can never suppress it (#1072).
+            compose.activityRule.scenario.onActivity {
+                ViewModelProvider(it)[TmuxSessionViewModel::class.java].reconnect()
+            }
+
+            // HEADLINE: the SAME session recovers to Live WITHOUT an app restart.
+            val recovered = waitForSessionRecovered(WEDGE_RECOVER_WINDOW_MS)
+            recordTiming(
+                "recovered_without_restart_ms",
+                if (recovered) SystemClock.elapsedRealtime() - dropStart else -1L,
+            )
+            assertTrue(
+                "#1072 ACCEPTANCE: after a drop during an attach upload, the SAME session " +
+                    "MUST reconnect cleanly and return to Live WITHOUT an app restart (no " +
+                    "reconnect wedge). status=${currentConnectionStatus()}",
+                recovered,
+            )
+
+            // The recovered control client must be a DIFFERENT instance than the one that
+            // dropped — proving recovery re-dialled a FRESH transport (not the
+            // upload-poisoned warm one).
+            val clientAfterRecovery = vm.currentClientIdentityForTest()
+            recordTiming(
+                "client_rebound_bool",
+                if (clientAfterRecovery != null && clientAfterRecovery != clientBeforeDrop) 1L else 0L,
+            )
+            assertTrue(
+                "expected the recovered session rebound onto a FRESH control client " +
+                    "(re-dialled transport), beforeDrop=$clientBeforeDrop afterRecovery=$clientAfterRecovery",
+                clientAfterRecovery != null && clientAfterRecovery != clientBeforeDrop,
+            )
+
+            // A fresh marker must round-trip through the RECOVERED `-CC` channel — proving
+            // the recovered session is live + input-accepting, not a blank shell.
+            emitMarkerIntoPane(key, "AFTER-$MARKER")
+            val roundTripped = runCatching {
+                waitForVisibleTerminal("post-recovery", timeoutMillis = ROUND_TRIP_WINDOW_MS) {
+                    it.contains("AFTER-$MARKER")
+                }
+                true
+            }.getOrDefault(false)
+            recordTiming("post_recovery_round_tripped_bool", if (roundTripped) 1L else 0L)
+            assertTrue(
+                "expected a post-recovery send to round-trip through the SAME recovered " +
+                    "session (no restart). status=${currentConnectionStatus()}",
+                roundTripped,
+            )
+            captureViewport("issue1072-B-recovered-live")
+            writeTimings("recovers-without-restart")
+        } finally {
+            runCatching { killer.close() }
+        }
+    }
+
+    // -- upload + in-flight helpers ------------------------------------------------
+
+    private fun startRealUpload(vm: TmuxSessionViewModel): Deferred<Result<List<String>>> {
+        // The maintainer's exact path: composer attach -> stagePromptAttachments ->
+        // PromptAttachmentStager -> session.uploadFile over the SAME transport that
+        // holds the live session. A large payload keeps the upload genuinely in flight
+        // on the real transport long enough to drop it mid-stream.
+        val uri = createLargeAttachmentUri()
+        return uploadScope.async { vm.stagePromptAttachments(listOf(uri)) }
+    }
+
+    private fun waitForUploadInFlight(vm: TmuxSessionViewModel, timeoutMillis: Long): Boolean {
+        val deadline = SystemClock.elapsedRealtime() + timeoutMillis
+        while (SystemClock.elapsedRealtime() < deadline) {
+            if (vm.attachmentUploadActiveForTest()) return true
+            SystemClock.sleep(25)
+        }
+        return vm.attachmentUploadActiveForTest()
+    }
+
+    // -- indicator helpers ---------------------------------------------------------
+
+    private fun waitForConnectionLostIndicator(timeoutMillis: Long): Boolean {
+        val deadline = SystemClock.elapsedRealtime() + timeoutMillis
+        while (SystemClock.elapsedRealtime() < deadline) {
+            if (connectionLostIndicatorVisible()) return true
+            SystemClock.sleep(150)
+        }
+        return connectionLostIndicatorVisible()
+    }
+
+    private fun connectionLostIndicatorVisible(): Boolean {
+        if (hasTag(TMUX_SESSION_ERROR_TAG) ||
+            hasTag(TMUX_SESSION_RECONNECT_TAG) ||
+            hasTag(TMUX_PULL_TO_RECONNECT_TAG)
+        ) {
+            return true
+        }
+        return when (currentConnectionStatus()) {
+            is TmuxSessionViewModel.ConnectionStatus.Connected -> false
+            is TmuxSessionViewModel.ConnectionStatus.Idle -> false
+            else -> true
+        }
+    }
+
+    private fun waitForSessionRecovered(timeoutMillis: Long): Boolean {
+        val deadline = SystemClock.elapsedRealtime() + timeoutMillis
+        while (SystemClock.elapsedRealtime() < deadline) {
+            if (sessionHealthyConnected()) return true
+            SystemClock.sleep(250)
+        }
+        return sessionHealthyConnected()
+    }
+
+    private fun sessionHealthyConnected(): Boolean {
+        if (hasTag(TMUX_SESSION_ERROR_TAG) ||
+            hasTag(TMUX_SESSION_RECONNECT_TAG) ||
+            hasTag(TMUX_PULL_TO_RECONNECT_TAG)
+        ) {
+            return false
+        }
+        return currentConnectionStatus() is TmuxSessionViewModel.ConnectionStatus.Connected
+    }
+
+    private fun hasTag(tag: String): Boolean =
+        compose.onAllNodesWithTag(tag, useUnmergedTree = true)
+            .fetchSemanticsNodes()
+            .isNotEmpty()
+
+    // -- attach + IO helpers -------------------------------------------------------
+
+    private fun attachSeededTmuxSession(hostRowTag: String) {
+        compose.waitUntil(timeoutMillis = HOST_ROW_TIMEOUT_MS) {
+            runCatching {
+                compose.onAllNodesWithTag(hostRowTag, useUnmergedTree = true)
+                    .fetchSemanticsNodes()
+                    .isNotEmpty()
+            }.getOrDefault(false)
+        }
+        compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick()
+        compose.waitUntil(timeoutMillis = TerminalTestTimeouts.terminalVisibilityTimeoutMs()) {
+            runCatching {
+                compose.onAllNodesWithText(SESSION_NAME, useUnmergedTree = true)
+                    .fetchSemanticsNodes()
+                    .isNotEmpty()
+            }.getOrDefault(false)
+        }
+        compose.onNodeWithText(SESSION_NAME, useUnmergedTree = true).performClick()
+        compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertExists()
+        waitForTerminalViewAttached()
+    }
+
+    private fun waitForTerminalViewAttached() {
+        compose.waitUntil(timeoutMillis = 30_000) {
+            var attached = false
+            compose.activityRule.scenario.onActivity { activity ->
+                val view = activity.window.decorView.findTerminalView()
+                attached = view?.currentSession != null && view.mEmulator != null
+            }
+            attached
+        }
+    }
+
+    private suspend fun emitMarkerIntoPane(key: String, marker: String) {
+        SshConnection.connect(
+            host = DEFAULT_HOST,
+            port = DEFAULT_PORT,
+            user = DEFAULT_USER,
+            key = SshKey.Pem(key),
+            knownHosts = KnownHostsPolicy.AcceptAll,
+            timeoutMs = 15_000,
+        ).mapCatching { session ->
+            session.use {
+                it.exec(
+                    "tmux send-keys -t ${shellQuote(SESSION_NAME)} " +
+                        shellQuote("printf '$marker\\n'") + " Enter",
+                )
+            }
+        }.getOrThrow()
+    }
+
+    private fun waitForConnected(label: String) {
+        compose.waitUntil(timeoutMillis = CONNECTED_TIMEOUT_MS) {
+            currentConnectionStatus() is TmuxSessionViewModel.ConnectionStatus.Connected
+        }
+        assertTrue(
+            "expected Connected after $label, observed=${currentConnectionStatus()}",
+            currentConnectionStatus() is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+    }
+
+    private fun currentViewModel(): TmuxSessionViewModel {
+        var vm: TmuxSessionViewModel? = null
+        compose.activityRule.scenario.onActivity { activity ->
+            vm = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+        }
+        return requireNotNull(vm) { "TmuxSessionViewModel not available" }
+    }
+
+    private fun currentConnectionStatus(): TmuxSessionViewModel.ConnectionStatus {
+        var status: TmuxSessionViewModel.ConnectionStatus =
+            TmuxSessionViewModel.ConnectionStatus.Idle
+        compose.activityRule.scenario.onActivity { activity ->
+            status = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+                .connectionStatus
+                .value
+        }
+        return status
+    }
+
+    private fun waitForVisibleTerminal(
+        label: String,
+        timeoutMillis: Long = TerminalTestTimeouts.terminalVisibilityTimeoutMs(),
+        predicate: (String) -> Boolean,
+    ): String {
+        var last = ""
+        compose.waitUntil(timeoutMillis = timeoutMillis) {
+            last = visibleTerminalText()
+            last.isNotBlank() && predicate(last)
+        }
+        assertTrue("expected visible terminal for $label; got:\n$last", predicate(last))
+        return last
+    }
+
+    private fun visibleTerminalText(): String {
+        var text = ""
+        compose.activityRule.scenario.onActivity { activity ->
+            text = activity.window.decorView
+                .findTerminalView()
+                ?.currentSession
+                ?.emulator
+                ?.screen
+                ?.transcriptText
+                .orEmpty()
+        }
+        return text
+    }
+
+    // -- seeding / cleanup ---------------------------------------------------------
+
+    private fun readFixtureKey(): String =
+        InstrumentationRegistry.getInstrumentation()
+            .context
+            .assets
+            .open("test_key")
+            .bufferedReader()
+            .use { it.readText() }
+
+    /**
+     * A large real file behind a readable `file://` Uri — resolvable by
+     * [android.content.ContentResolver.openInputStream], so [stagePromptAttachments]
+     * exercises the REAL upload path. Large enough that the byte stream stays in
+     * flight on the warm `-CC` transport while we induce the drop mid-stream.
+     */
+    private fun createLargeAttachmentUri(): Uri {
+        val ctx = InstrumentationRegistry.getInstrumentation().targetContext
+        val file = File(ctx.cacheDir, "issue1072-large-attachment.bin")
+        val chunk = ByteArray(64 * 1024) { (it and 0xFF).toByte() }
+        file.outputStream().use { out ->
+            var written = 0L
+            while (written < UPLOAD_BYTES) {
+                out.write(chunk)
+                written += chunk.size
+            }
+        }
+        return Uri.fromFile(file)
+    }
+
+    private suspend fun seedDockerHost(key: String): String {
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
+        val db = Room.databaseBuilder(appContext, AppDatabase::class.java, DATABASE_NAME)
+            .fallbackToDestructiveMigration(dropAllTables = true)
+            .build()
+        return try {
+            db.clearAllTables()
+            val storedKey = SshKeyStorage.persistKey(
+                context = appContext,
+                sshKeyDao = db.sshKeyDao(),
+                name = "issue1072-attach-key-${System.currentTimeMillis()}",
+                content = key,
+            )
+            val hostId = db.hostDao().insert(
+                HostEntity(
+                    name = "Issue1072 Attach Drop Reconnect",
+                    hostname = DEFAULT_HOST,
+                    port = DEFAULT_PORT,
+                    username = DEFAULT_USER,
+                    keyId = storedKey.id,
+                    tmuxInstalled = true,
+                    lastBootstrapAt = System.currentTimeMillis(),
+                ),
+            )
+            HOST_ROW_TAG_PREFIX + hostId
+        } finally {
+            db.close()
+        }
+    }
+
+    private suspend fun seedTmuxSession(key: String) {
+        val script = buildString {
+            appendLine("set -eu")
+            appendLine("tmux kill-session -t ${shellQuote(SESSION_NAME)} 2>/dev/null || true")
+            appendLine(
+                "tmux new-session -d -s ${shellQuote(SESSION_NAME)} " +
+                    shellQuote("printf '$READY_MARKER\\n'; exec sh -i"),
+            )
+            appendLine("sleep 1")
+            appendLine("tmux list-sessions")
+        }
+        val result = execRemoteSetupUntilReady(
+            key = SshKey.Pem(key),
+            command = script,
+            description = "issue1072 tmux seed session",
+        )
+        assertTrue(
+            "expected tmux seeding to succeed; exit=${result.exitCode} stderr='${result.stderr}'",
+            result.exitCode == 0,
+        )
+    }
+
+    private suspend fun cleanupRemoteTmuxSession(key: String) {
+        runCatching {
+            SshConnection.connect(
+                host = DEFAULT_HOST,
+                port = DEFAULT_PORT,
+                user = DEFAULT_USER,
+                key = SshKey.Pem(key),
+                knownHosts = KnownHostsPolicy.AcceptAll,
+                timeoutMs = 15_000,
+            ).mapCatching { session ->
+                session.use {
+                    it.exec("tmux kill-session -t ${shellQuote(SESSION_NAME)} 2>/dev/null || true")
+                }
+            }
+        }
+    }
+
+    // -- artifacts -----------------------------------------------------------------
+
+    private fun captureViewport(name: String) {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.waitForIdleSync()
+        SystemClock.sleep(150)
+        var bitmap: android.graphics.Bitmap? = null
+        compose.activityRule.scenario.onActivity { activity ->
+            val view = activity.window.decorView.findTerminalView() ?: return@onActivity
+            if (view.width <= 0 || view.height <= 0) return@onActivity
+            val b = android.graphics.Bitmap.createBitmap(
+                view.width,
+                view.height,
+                android.graphics.Bitmap.Config.ARGB_8888,
+            )
+            view.draw(android.graphics.Canvas(b))
+            bitmap = b
+        }
+        bitmap?.let {
+            val file = artifactFile("$name-viewport.png")
+            java.io.FileOutputStream(file).use { out ->
+                it.compress(android.graphics.Bitmap.CompressFormat.PNG, 100, out)
+            }
+            println("ISSUE1072_VIEWPORT ${file.absolutePath}")
+            it.recycle()
+        }
+        artifactFile("$name-visible-terminal.txt").writeText(visibleTerminalText())
+    }
+
+    private fun writeTimings(label: String): File {
+        val file = artifactFile("$label-timings.txt")
+        file.writeText(timings.joinToString(separator = "\n", postfix = "\n"))
+        println("ISSUE1072_TIMINGS ${file.absolutePath}")
+        return file
+    }
+
+    private fun artifactFile(name: String): File {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val mediaRoot = com.pocketshell.app.test.testArtifactsRoot(instrumentation.targetContext)
+        val dir = File(mediaRoot, "additional_test_output/$DEVICE_DIR_NAME")
+        check(dir.exists() || dir.mkdirs()) {
+            "could not create artifact directory ${dir.absolutePath}"
+        }
+        return File(dir, name)
+    }
+
+    private fun recordTiming(name: String, value: Long) {
+        val line = "$name=$value"
+        timings += line
+        println("ISSUE1072_TIMING $line")
+    }
+
+    private fun View.findTerminalView(): TerminalView? {
+        if (this is TerminalView) return this
+        if (this !is ViewGroup) return null
+        for (index in 0 until childCount) {
+            val match = getChildAt(index).findTerminalView()
+            if (match != null) return match
+        }
+        return null
+    }
+
+    private fun shellQuote(value: String): String =
+        "'" + value.replace("'", "'\"'\"'") + "'"
+
+    private companion object {
+        const val DATABASE_NAME: String = "pocketshell.db"
+        const val DEVICE_DIR_NAME: String = "issue1072-attach-drop-reconnect"
+        const val SESSION_NAME: String = "issue1072-attach-proof"
+        const val READY_MARKER: String = "ISSUE1072-ATTACH-READY"
+        const val MARKER: String = "issue1072attach"
+
+        // Large enough that the byte stream stays in flight on the warm `-CC`
+        // transport (sshj single-threaded AES is the bottleneck even on localhost)
+        // for the in-flight poll + the drop to land mid-stream. If a future faster
+        // path makes the upload outrun the in-flight poll, the test FAILS LOUD
+        // (waitForUploadInFlight) rather than passing vacuously — raise this then.
+        const val UPLOAD_BYTES: Long = 48L * 1024 * 1024
+
+        val UPLOAD_IN_FLIGHT_WINDOW_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 60_000L else 30_000L
+        val DROP_DETECT_WINDOW_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 30_000L else 15_000L
+        val WEDGE_RECOVER_WINDOW_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 60_000L else 45_000L
+        val ROUND_TRIP_WINDOW_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 45_000L else 30_000L
+        val HOST_ROW_TIMEOUT_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 60_000L else 20_000L
+        val CONNECTED_TIMEOUT_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 30_000L else 15_000L
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -123,6 +123,7 @@ import com.pocketshell.core.tmux.TmuxSessionNotFoundException
 import com.pocketshell.core.tmux.protocol.ControlEvent
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.async
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineDispatcher
@@ -1198,6 +1199,35 @@ public class TmuxSessionViewModel @Inject constructor(
     internal fun currentClientIdentityForTest(): Int? =
         clientRef?.let { System.identityHashCode(it) }
 
+    /**
+     * Issue #1072 test seam — own an attachment upload through the EXACT production
+     * ownership line ([attachmentUploadJob] = a [viewModelScope] child) so a unit
+     * proof can assert [closeCurrentConnectionAndJoin] cancel-and-joins it. The
+     * composer path's own `stagePromptAttachments` needs an Android `contentResolver`
+     * + `Uri`s (Robolectric-only), so this seam drives the SAME field + scope the
+     * production upload uses, letting the JVM gate assert the teardown-cancels-upload
+     * wiring (the Failure-2 root cause) deterministically.
+     */
+    internal fun startTrackedAttachmentUploadForTest(block: suspend () -> Unit): Job {
+        val job = viewModelScope.async { block() }
+        attachmentUploadJob = job
+        return job
+    }
+
+    /** Issue #1072 test seam: is the tracked attachment upload still in flight? */
+    internal fun attachmentUploadActiveForTest(): Boolean =
+        attachmentUploadJob?.isActive == true
+
+    /** Issue #1072 test seam: drive the production connection teardown directly so a
+     *  unit proof can assert it cancels an in-flight attachment upload (the reconnect
+     *  wedge's root cause) — the SAME `closeCurrentConnectionAndJoin` the reconnect
+     *  ladder runs. */
+    internal suspend fun closeCurrentConnectionAndJoinForTest() =
+        closeCurrentConnectionAndJoin()
+
+    /** Issue #1072 test seam: is a connect attempt's single-flight guard active? */
+    internal fun connectJobActiveForTest(): Boolean = connectJob?.isActive == true
+
     @androidx.annotation.VisibleForTesting
     internal fun paneProducerClientIdentityForTest(paneId: String): Int? =
         paneProducerClients[paneId]?.let { System.identityHashCode(it) }
@@ -1833,6 +1863,25 @@ public class TmuxSessionViewModel @Inject constructor(
     private var connectingTarget: ConnectionTarget? = null
     private var connectJob: Job? = null
     private var autoReconnectJob: Job? = null
+
+    /**
+     * Issue #1072 — the in-flight attachment-upload coroutine, OWNED by the VM so
+     * a connection teardown can cancel it.
+     *
+     * The composer attach (`onStageAttachments`) used to run the upload directly in
+     * the SCREEN's coroutine scope, so [closeCurrentConnectionAndJoin] (the reconnect
+     * ladder's teardown) cancel-and-joined every OTHER job but NOT this one: a
+     * large/slow upload stayed blocked in `output.write`/`command.join` on the dying
+     * `-CC` session while the teardown drained/closed the same dispatcher, racing it.
+     * That race could leave the single-flight `connectJob`/`autoReconnectJob` guards
+     * stuck `isActive`, which then suppressed ALL subsequent auto + manual reconnects
+     * until the app was restarted (the maintainer's "reconnect wedges" — #1072).
+     *
+     * Tracking the upload as a [viewModelScope] job lets the teardown deterministically
+     * `cancelAndJoin` it BEFORE it drops the transport, so the reconnect ladder never
+     * races a free-floating writer on the dead session.
+     */
+    private var attachmentUploadJob: Job? = null
     // Issue #938 (S2-3): `appActive` is written on Main (onStart/onStop) but
     // read off-Main from the port-detection dispatcher (e.g. [scanDecoded],
     // [confirmAndSurfaceDetectedPort]). @Volatile guarantees cross-thread
@@ -2362,7 +2411,20 @@ public class TmuxSessionViewModel @Inject constructor(
             tmuxSessionId = tmuxSessionId,
             sessionCreated = sessionCreated,
         )
-        if (connectJob?.isActive == true && connectingTarget == target) return
+        // Issue #1072: an EXPLICIT manual Reconnect must be able to PREEMPT an
+        // in-flight connect to the same target, never be deduped into a no-op. If a
+        // prior connect attempt ever wedged (the upload-teardown race, now fixed by
+        // owning+cancelling the upload job), this same-target dedup would otherwise
+        // suppress the user's Reconnect tap forever — exactly the "I have to restart
+        // the app" report. The new connectJob below cancel-and-joins the previous
+        // one, so preempting is clean. The dedup still holds for non-manual triggers
+        // (rapid UserTap / network) so a healthy in-flight connect is not restarted.
+        if (connectJob?.isActive == true &&
+            connectingTarget == target &&
+            trigger != TmuxConnectTrigger.Reconnect
+        ) {
+            return
+        }
         if (
             !interruptedPassiveRecovery &&
             !shouldForceFreshLease(trigger) &&
@@ -12268,10 +12330,42 @@ public class TmuxSessionViewModel @Inject constructor(
                 ),
             )
         }
-        val result = PromptAttachmentStager(
+        // Issue #1072: OWN the upload as a [viewModelScope] job so a connection
+        // teardown ([closeCurrentConnectionAndJoin]) can cancel-and-join it BEFORE
+        // it drops the transport, instead of leaving a free-floating writer blocked
+        // on the dying `-CC` session that races teardown and wedges reconnect. We
+        // run it in viewModelScope (a SupervisorJob) rather than the caller's
+        // screen scope so a screen recomposition does not abandon the upload, and
+        // the VM stays the single owner that the reconnect ladder coordinates with.
+        val stager = PromptAttachmentStager(
             resolver = context.contentResolver,
             cacheDir = context.cacheDir,
-        ).stage(session, scopeKey, uris)
+        )
+        val uploadDeferred = viewModelScope.async { stager.stage(session, scopeKey, uris) }
+        attachmentUploadJob = uploadDeferred
+        val result = try {
+            uploadDeferred.await()
+        } catch (ce: CancellationException) {
+            // Our own (caller) coroutine was cancelled — propagate.
+            if (!currentCoroutineContext().isActive) throw ce
+            // The upload deferred was cancelled by a connection teardown (#1072):
+            // surface a clear, draft-preserving error so a post-attach drop stays
+            // recoverable (the reconnect ladder owns recovery) instead of crashing
+            // the caller or silently misrouting.
+            DiagnosticEvents.record(
+                "action",
+                "tmux_attachment_stage_cancelled_by_teardown",
+                "requestedCount" to uris.size,
+                "scope" to scopeKey,
+            )
+            Result.failure(
+                IllegalStateException(
+                    "Connection closed during the upload — attachment not applied. Re-attach.",
+                ),
+            )
+        } finally {
+            if (attachmentUploadJob === uploadDeferred) attachmentUploadJob = null
+        }
         result.fold(
             onSuccess = { paths ->
                 DiagnosticEvents.record(
@@ -15568,6 +15662,17 @@ public class TmuxSessionViewModel @Inject constructor(
         cacheEviction: RuntimeCacheEviction = RuntimeCacheEviction.HostWide,
     ) {
         val closingHostId = activeTarget?.hostId ?: registeredHostId
+        // Issue #1072: cancel-and-join any in-flight attachment upload FIRST, before
+        // we touch the SSH transport. An upload is a free-floating writer blocked in
+        // `output.write`/`command.join` on the `-CC` session we are about to drop;
+        // if we tore the transport down while it was still streaming, its teardown
+        // (`dispatcher.run { command.close() }`) would race this close draining the
+        // SAME dispatcher — the race that left the reconnect single-flight guards
+        // wedged and required an app restart. Cancelling it here makes the upload
+        // unwind deterministically (its `runInterruptible` is interrupted) so the
+        // reconnect ladder never races it.
+        attachmentUploadJob?.cancelAndJoin()
+        attachmentUploadJob = null
         // Issue #257: drain any background detach left in flight by a
         // prior same-host fast-switch before we tear the rest down, so a
         // full teardown (background-detach / cross-host reconnect) never

--- a/app/src/test/java/com/pocketshell/app/tmux/AttachmentUploadTeardownReconnectTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/AttachmentUploadTeardownReconnectTest.kt
@@ -1,0 +1,315 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.app.sessions.ActiveTmuxClients
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.SshLeaseConnector
+import com.pocketshell.core.ssh.SshLeaseManager
+import com.pocketshell.core.ssh.SshLeaseTarget
+import com.pocketshell.core.ssh.SshPortForward
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshShell
+import com.pocketshell.core.tmux.TmuxClientFactory
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+import java.io.InputStream
+
+/**
+ * Issue #1072 (release blocker, maintainer dogfood): "When I attach something the
+ * connection breaks and then I can't reconnect — I have to restart the app."
+ *
+ * This file is the deterministic JVM gate for **Failure 2 — the reconnect wedge**.
+ * Two root-cause mechanisms, both reproduced red→green here at gradle-test speed
+ * (the real-path / SSH-transport half of the bug — Failure 1, outbound-blind
+ * liveness — is proven in `core-ssh`'s `TransportKeepAliveTest` and
+ * `KeepAliveIntegrationTest`; the full composer-attach-during-drop journey is the
+ * on-device `AttachmentNoReconnectE2eTest` family on the emulator):
+ *
+ *  1. **The in-flight attachment upload was un-owned by the reconnect machinery.**
+ *     It ran in the SCREEN scope, so [TmuxSessionViewModel.closeCurrentConnectionAndJoin]
+ *     (the reconnect ladder's teardown) cancel-and-joined every OTHER job but NOT
+ *     the upload. A large/slow upload stayed blocked in `output.write`/`command.join`
+ *     on the dying `-CC` session while the teardown drained/closed the SAME
+ *     dispatcher — the race that could strand the single-flight reconnect guards.
+ *     The fix OWNS the upload as a [viewModelScope] job
+ *     ([TmuxSessionViewModel.attachmentUploadJob]) and cancel-and-joins it FIRST in
+ *     the teardown. See [connectionTeardownCancelsAnInFlightAttachmentUpload].
+ *
+ *  2. **The single-flight connect guard suppressed manual recovery.** A manual
+ *     Reconnect routed back into `connect()`, whose same-target dedup
+ *     (`connectJob.isActive && connectingTarget == target`) early-returned a NO-OP —
+ *     so a wedged/in-flight connect could veto the user's Reconnect tap forever
+ *     ("I have to restart the app"). The fix lets an EXPLICIT `Reconnect` trigger
+ *     PREEMPT the in-flight same-target connect. See
+ *     [manualReconnectPreemptsAnInFlightSameTargetConnect].
+ *
+ * RED discriminators (the reviewer can drive these without reverting the test):
+ *  - Test 1: revert the `attachmentUploadJob?.cancelAndJoin()` lines in
+ *    `closeCurrentConnectionAndJoin` (keep the field + seam) — the upload is never
+ *    cancelled, `uploadCancelled` never completes, and the assertion fails.
+ *  - Test 2: revert the `trigger != TmuxConnectTrigger.Reconnect` clause in the
+ *    `connect()` dedup guard — the reconnect is deduped to a no-op and the connect
+ *    attempt count does NOT advance.
+ *
+ * Harness mirrors [AttachmentWaitWarmLeaseTrustTest] (the adjacent attach-flow gate).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class AttachmentUploadTeardownReconnectTest {
+
+    private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    @After
+    fun tearDown() {
+        factoryScope.cancel()
+    }
+
+    private fun runVmTest(body: suspend TestScope.() -> Unit) = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        // EPIC #792 Slice D: disable the VM LivenessProbe auto-start — its infinite
+        // periodic `delay` loop would otherwise spin `advanceUntilIdle()` forever on
+        // this virtual-clock Main (this file does not use MainDispatcherRule).
+        LivenessProbeTestOverride.setAutoStartEnabledForTest(false)
+        try {
+            body()
+        } finally {
+            LivenessProbeTestOverride.clear()
+            Dispatchers.resetMain()
+        }
+    }
+
+    private fun TestScope.newVm(
+        sshLeaseManager: SshLeaseManager,
+    ): TmuxSessionViewModel = TmuxSessionViewModel(
+        tmuxClientFactory = TmuxClientFactory(factoryScope),
+        activeTmuxClients = ActiveTmuxClients(),
+        runtimeCache = TmuxSessionRuntimeCache(),
+        sshLeaseManager = sshLeaseManager,
+        sessionLifecycleSignals = null,
+    ).also {
+        it.setSeedIoDispatcherForTest(StandardTestDispatcher(testScheduler))
+    }
+
+    @Test
+    fun connectionTeardownCancelsAnInFlightAttachmentUpload() = runVmTest {
+        // Drive the VM to a live, connected session over a warm lease so the teardown
+        // tears down a REAL client/session — the exact reconnect-ladder teardown path.
+        val session = ToggleableSession("warm")
+        val vm = newVm(
+            sshLeaseManager = testLeaseManager(
+                connector = SingleSessionConnector(session),
+                scope = this,
+                idleTtlMillis = 60_000L,
+            ),
+        )
+        vm.setAutoReconnectDelaysForTest(listOf(0L))
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%1")
+        vm.setTmuxClientFactoryForTest { _, _, _ -> client }
+        vm.connect(
+            hostId = 1L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            passphrase = null,
+            sessionName = "work",
+        )
+        advanceUntilIdle()
+        assertTrue(
+            "precondition: the open must reach Connected, got ${vm.connectionStatus.value}",
+            vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+
+        // A large/slow attachment upload in flight: it streams outbound and would, on
+        // base, stay blocked in `output.write` on the dying session when the teardown
+        // races it. We model that with a forever-blocking body that records its own
+        // cancellation, owned through the EXACT production line (attachmentUploadJob =
+        // a viewModelScope child) the composer attach now uses.
+        val uploadStarted = CompletableDeferred<Unit>()
+        val uploadCancelled = CompletableDeferred<Unit>()
+        vm.startTrackedAttachmentUploadForTest {
+            try {
+                uploadStarted.complete(Unit)
+                CompletableDeferred<Unit>().await() // streams forever (never EOFs)
+            } catch (ce: CancellationException) {
+                uploadCancelled.complete(Unit)
+                throw ce
+            }
+        }
+        advanceUntilIdle()
+        assertTrue("the tracked upload must have started", uploadStarted.isCompleted)
+        assertTrue("the tracked upload must be in flight", vm.attachmentUploadActiveForTest())
+
+        // The reconnect ladder's teardown (the body run on a TransportDropped / drop)
+        // MUST cancel-and-join the in-flight upload before it touches the transport.
+        vm.closeCurrentConnectionAndJoinForTest()
+
+        assertTrue(
+            "#1072: the connection teardown must CANCEL the in-flight attachment upload " +
+                "(it is now an owned viewModelScope job, cancel-and-joined in " +
+                "closeCurrentConnectionAndJoin) — on base the upload was a free-floating " +
+                "writer that raced teardown and wedged reconnect. RED: revert the " +
+                "attachmentUploadJob?.cancelAndJoin() lines and this never completes.",
+            uploadCancelled.isCompleted,
+        )
+        assertFalse(
+            "after teardown the upload job must no longer be active",
+            vm.attachmentUploadActiveForTest(),
+        )
+    }
+
+    @Test
+    fun manualReconnectPreemptsAnInFlightSameTargetConnect() = runVmTest {
+        // A connect whose lease dial BLOCKS forever, so the connectJob stays in flight
+        // (single-flight guard armed) to the same target — the wedge precondition.
+        val connector = BlockingConnector(ToggleableSession("s"))
+        val vm = newVm(
+            sshLeaseManager = testLeaseManager(
+                connector = connector,
+                scope = this,
+                idleTtlMillis = 60_000L,
+            ),
+        )
+        vm.setAutoReconnectDelaysForTest(listOf(0L))
+        vm.setTmuxClientFactoryForTest { _, _, _ -> FakeTmuxClient().withSinglePaneRow("work", "%1") }
+        vm.connect(
+            hostId = 1L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            passphrase = null,
+            sessionName = "work",
+        )
+        // runCurrent (NOT advanceUntilIdle): drive the connect to where it parks in the
+        // blocking lease dial WITHOUT advancing the virtual clock — advancing would fire
+        // the lease's own bounded-dial timeout and complete the connectJob, defeating
+        // the "in flight" precondition the wedge needs.
+        runCurrent()
+        assertTrue(
+            "precondition: the first connect must be in flight (connectJob active, blocked " +
+                "in the lease dial)",
+            vm.connectJobActiveForTest(),
+        )
+
+        // The first connect has already counted ONE attempt. A manual Reconnect to the
+        // SAME target must PREEMPT it (count a SECOND attempt), never be deduped away.
+        val attemptsBefore = TMUX_CONNECT_ATTEMPTS.get()
+        assertTrue("manual reconnect must report a target to redial", vm.reconnect())
+        runCurrent()
+
+        assertEquals(
+            "#1072: a manual Reconnect must PREEMPT the in-flight same-target connect " +
+                "(the dedup guard is bypassed for an explicit Reconnect trigger), so a " +
+                "wedged/in-flight connect can NEVER suppress the user's Reconnect tap. RED: " +
+                "revert the `trigger != TmuxConnectTrigger.Reconnect` clause and the " +
+                "reconnect is deduped — the attempt count does not advance.",
+            attemptsBefore + 1,
+            TMUX_CONNECT_ATTEMPTS.get(),
+        )
+
+        // Quiesce: cancel the VM scope so the parked connect jobs + their pending
+        // lease-dial timeouts do not trip runTest's uncompleted-coroutine cleanup.
+        vm.clearForTest()
+        advanceUntilIdle()
+    }
+
+    private fun FakeTmuxClient.withSinglePaneRow(
+        sessionName: String,
+        paneId: String,
+    ): FakeTmuxClient = apply {
+        responses.addLast(
+            com.pocketshell.core.tmux.CommandResponse(
+                number = 1L,
+                output = listOf("$paneId\t@0\t\$0\t$sessionName\t$sessionName\t0"),
+                isError = false,
+            ),
+        )
+        capturePaneResponses.addLast(
+            com.pocketshell.core.tmux.CommandResponse(number = 2L, output = listOf("$sessionName ready"), isError = false),
+        )
+        cursorQueryResponses.addLast(
+            com.pocketshell.core.tmux.CommandResponse(number = 3L, output = listOf("0,0"), isError = false),
+        )
+    }
+
+    /** Hands back the SAME session on every dial (the warm-lease reuse case). */
+    private class SingleSessionConnector(private val session: SshSession) : SshLeaseConnector {
+        override suspend fun connect(target: SshLeaseTarget): Result<SshSession> =
+            Result.success(session)
+    }
+
+    /**
+     * A lease connector whose dial increments a counter and then BLOCKS forever
+     * (cancellable) — used to hold a connect attempt "in flight" so the single-flight
+     * guard is armed and the manual-reconnect preempt can be exercised.
+     */
+    private class BlockingConnector(private val session: SshSession) : SshLeaseConnector {
+        override suspend fun connect(target: SshLeaseTarget): Result<SshSession> {
+            CompletableDeferred<Unit>().await() // never resolves; cancellable on preempt
+            return Result.success(session)
+        }
+    }
+
+    /** SSH session whose `isConnected` can be flipped to model a transient death. */
+    private class ToggleableSession(val id: String) : SshSession {
+        @Volatile
+        var connected: Boolean = true
+
+        override val isConnected: Boolean get() = connected
+
+        override suspend fun exec(command: String): ExecResult =
+            ExecResult(stdout = "", stderr = "", exitCode = 0)
+
+        override fun tail(path: String, onLine: (String) -> Unit): Job =
+            Job().apply { complete() }
+
+        override fun tail(path: String, fromLineExclusive: Long, onLine: (String) -> Unit): Job =
+            Job().apply { complete() }
+
+        override fun openLocalPortForward(
+            remoteHost: String,
+            remotePort: Int,
+            localPort: Int,
+        ): SshPortForward = error("not used")
+
+        override fun startShell(): SshShell = error("not used")
+
+        override suspend fun uploadFile(file: File, remotePath: String): String = error("not used")
+
+        override suspend fun uploadStream(
+            input: InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String = error("not used")
+
+        override fun close() {
+            connected = false
+        }
+    }
+}

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -142,6 +142,23 @@ JOURNEY_CLASSES=(
   # runs on the deterministic agents:2222 fixture (no toxiproxy) and does NOT
   # self-skip on CI, so the server-death class regression cannot silently return.
   "$FQCN_PREFIX.ServerDeathReconnectNoResurrectE2eTest"
+  # Issue #1072 (v0.4.19 release blocker): attaching a file dropped the live
+  # connection AND the post-attach drop wedged reconnect (had to restart the
+  # app). Failure 2 — "a post-attach drop must RECOVER WITHOUT AN APP RESTART" —
+  # is a reconnect-core (D28) change and the maintainer's "worse half"; the
+  # v0.4.19 review BLOCKED because it had only a VM/Robolectric proof, no
+  # end-to-end journey on the real path. This journey attaches a real `tmux -CC`
+  # session, starts a REAL large attachment upload over the warm `-CC` lease,
+  # INDUCES a drop DURING the in-flight upload via the deterministic
+  # liveness-probe drop seam (no toxiproxy — gates per-push), asserts the
+  # teardown OWNS + CANCELS the in-flight upload
+  # (tmux_attachment_stage_cancelled_by_teardown — the deterministic red→green
+  # discriminator; RED on base where the un-owned upload races teardown and
+  # wedges reconnect), then drives a manual Reconnect and asserts the SAME
+  # session recovers to Live + a fresh marker round-trips WITHOUT an app restart
+  # (the literal acceptance criterion). agents:2222, no toxiproxy; no
+  # assumeFalse(isRunningOnCi()) on the load-bearing assertions.
+  "$FQCN_PREFIX.AttachmentDropReconnectRecoversE2eTest"
   "$FQCN_PREFIX.ReconnectRepaintE2eTest"
   # Issue #754 (slice 1c-iv-c): this class is the per-PR-CI deterministic regression
   # catcher for the within-grace "Attaching…" reconnect bug. It now (a) forbids the

--- a/shared/core-ssh/src/integrationTest/java/com/pocketshell/core/ssh/KeepAliveIntegrationTest.kt
+++ b/shared/core-ssh/src/integrationTest/java/com/pocketshell/core/ssh/KeepAliveIntegrationTest.kt
@@ -380,6 +380,113 @@ class KeepAliveIntegrationTest {
     }
 
     @Test
+    fun keepAliveRidesThroughWhileAnUploadStreamsOutboundOnAQuietSession() {
+        // Issue #1072 (reproduce-first, the maintainer's "attaching breaks the
+        // connection"): a large/slow attachment upload over a QUIET `-CC` session is
+        // almost pure OUTBOUND — `cat > tmp` streams client→server bytes and emits
+        // NOTHING back until EOF, so ZERO inbound arrives for the whole upload and not
+        // even a keepalive reply lands on a saturated/high-RTT uplink. Before #1072 the
+        // keepalive (and the LivenessProbe deferral oracle) counted INBOUND only, so it
+        // declared a silent drop and tore the LIVE transport down MID-UPLOAD.
+        //
+        // Real path: a real [RealSshSession] uploading a multi-MB file over a real
+        // OpenSSH transport, with the REQUEST (upload) direction THROTTLED so the copy
+        // streams for well past the keepalive budget while inbound stays quiet. We drive
+        // a synthetic [TransportKeepAlive] whose `lastOutboundActivityNanos()` reads the
+        // REAL session's outbound timestamp (bumped per-chunk by the upload copy loop)
+        // and whose replies are STARVED. GREEN with the fix: outbound progress proves the
+        // transport alive, so the loop rides through and never declares dead. RED on base:
+        // revert the loop's `lastActivityNanos()` helper to `lastInboundActivityNanos()`
+        // and the loop pings, every ping misses, inbound never advances → declares dead.
+        val relay = PausableTcpRelay(sshHost, sshPort).also { it.start() }
+        try {
+            val session = connectThroughRelay(relay)
+            val real = session as RealSshSession
+            val ioScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+            val deadDeclared = AtomicBoolean(false)
+            try {
+                // ~6 MB at 256 KB/s ≈ 24s of pure-outbound copy — well past the 3s
+                // synthetic keepalive budget below.
+                val uploadFile = File.createTempFile("ps1072-upload", ".bin")
+                uploadFile.deleteOnExit()
+                uploadFile.outputStream().use { out ->
+                    val chunk = ByteArray(64 * 1024) { (it % 251).toByte() }
+                    repeat(96) { out.write(chunk) } // 96 × 64KB = 6 MB
+                }
+                relay.throttleRequestDirection(256L * 1024L)
+
+                val beforeOutbound = real.lastOutboundActivityNanosForTest()
+                val uploadJob = ioScope.launch {
+                    runCatching { session.uploadFile(uploadFile, "/tmp/ps1072-upload.bin") }
+                }
+
+                val keepAlive = TransportKeepAlive(
+                    io = object : TransportKeepAlive.KeepAliveIo {
+                        override fun isAlive(): Boolean = session.isConnected
+                        // Inbound reads the REAL field — frozen during the copy (no server
+                        // bytes until EOF). Outbound reads the REAL field — advancing per
+                        // chunk (the #1072 wiring). Replies are STARVED.
+                        override fun lastInboundActivityNanos(): Long =
+                            real.lastInboundActivityNanosForTest()
+                        override fun lastOutboundActivityNanos(): Long =
+                            real.lastOutboundActivityNanosForTest()
+                        override suspend fun sendKeepAlive(): Boolean = false
+                        override fun onKeepAliveDead(consecutiveMisses: Int) {
+                            deadDeclared.set(true)
+                        }
+                    },
+                    intervalMs = 1_000L,
+                    countMax = 3,
+                )
+                keepAlive.start(ioScope)
+
+                // Watch for ~10s (3× the synthetic budget) while the upload streams.
+                var sawOutboundAdvance = false
+                val watchDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10)
+                while (System.nanoTime() < watchDeadline && uploadJob.isActive) {
+                    if (real.lastOutboundActivityNanosForTest() > beforeOutbound) {
+                        sawOutboundAdvance = true
+                    }
+                    // The production oracle the LivenessProbe defers to must report ALIVE
+                    // throughout the upload (max of inbound/outbound within the window).
+                    assertTrue(
+                        "the transport-liveness oracle the LivenessProbe defers to must report " +
+                            "ALIVE while an upload streams outbound — else the probe declares a " +
+                            "silent drop mid-upload (#1072)",
+                        session.isTransportProvenAliveWithinKeepAliveWindow(),
+                    )
+                    Thread.sleep(500)
+                }
+
+                keepAlive.stop()
+                uploadJob.cancel()
+
+                assertTrue(
+                    "test precondition: the throttled upload must have streamed outbound bytes",
+                    sawOutboundAdvance,
+                )
+                assertFalse(
+                    "a steadily-progressing upload (outbound advancing) must NOT be declared " +
+                        "dead by the keepalive even with zero inbound and starved replies — the " +
+                        "outbound progress proves the transport alive (#1072). RED on base: " +
+                        "outbound ignored, the loop pinged, every ping missed, inbound never " +
+                        "advanced → it tore the live transport down mid-upload.",
+                    deadDeclared.get(),
+                )
+                assertTrue(
+                    "the session must still be connected after riding through the upload window",
+                    session.isConnected,
+                )
+            } finally {
+                ioScope.cancel()
+                runCatching { session.close() }
+            }
+        } finally {
+            relay.close()
+        }
+    }
+
+    @Test
     fun genuinelyDeadHalfOpenPeerWithNoDataIsStillDeclaredDeadWithDataBumpHonoured() {
         // Issue #974 class-coverage (the dual of the ride-through case — the fix must
         // NOT make a truly-dead link look alive forever). A HALF-OPEN dead peer: no
@@ -1006,6 +1113,11 @@ private class PausableTcpRelay(
     // [holdReplyDirectionOnce] and cleared the moment it elapses.
     private val replyHoldUntilNanos = AtomicLong(0L)
     private val replyHoldArmed = AtomicBoolean(false)
+    // #1072 — when > 0, throttle the REQUEST direction (client→server) to this many
+    // bytes/sec so a real upload streams OUTBOUND for a controllable wall-clock window
+    // (the maintainer's large/slow attachment), keeping inbound quiet long past the
+    // keepalive budget.
+    private val requestThrottleBps = AtomicLong(0L)
     private val tunnels = java.util.concurrent.ConcurrentHashMap.newKeySet<Socket>()
     private var acceptThread: Thread? = null
 
@@ -1089,6 +1201,15 @@ private class PausableTcpRelay(
                     if (closed.get() || cut.get()) break
                     output.write(buf, 0, n)
                     output.flush()
+                    // #1072 — throttle the REQUEST direction so a real upload streams
+                    // outbound over a controllable wall-clock window (a slow uplink).
+                    if (!isReplyDirection) {
+                        val bps = requestThrottleBps.get()
+                        if (bps > 0) {
+                            val sleepMs = n.toLong() * 1_000L / bps
+                            if (sleepMs > 0) Thread.sleep(sleepMs)
+                        }
+                    }
                 }
             } catch (t: Throwable) {
                 // tunnel broken — let the join() finish and clean up.
@@ -1097,6 +1218,9 @@ private class PausableTcpRelay(
 
     fun pause() { paused.set(true) }
     fun resume() { paused.set(false) }
+
+    /** #1072 — throttle the REQUEST (client→server / upload) direction to [bytesPerSec]. */
+    fun throttleRequestDirection(bytesPerSec: Long) { requestThrottleBps.set(bytesPerSec) }
 
     /**
      * #985 — hold the REPLY direction (server→client) for [ms] milliseconds ONCE,

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshSession.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshSession.kt
@@ -248,6 +248,11 @@ internal class RealSshSession(
         io = object : TransportKeepAlive.KeepAliveIo {
             override fun isAlive(): Boolean = isConnected
             override fun lastInboundActivityNanos(): Long = lastInboundActivityNanos
+            // Issue #1072 — feed outbound upload progress into the keepalive loop so
+            // a steadily-streaming attachment upload (pure outbound, zero inbound on
+            // a quiet `-CC` session) is NOT misread as a silent drop and torn down
+            // mid-upload. The loop folds this into reset-on-activity / ride-through.
+            override fun lastOutboundActivityNanos(): Long = lastOutboundActivityNanos
             override suspend fun sendKeepAlive(): Boolean = this@RealSshSession.sendKeepAlive()
             override fun onKeepAliveDead(consecutiveMisses: Int) {
                 // Issue #969: NAME the cause BEFORE the close so the lease layer
@@ -306,7 +311,20 @@ internal class RealSshSession(
      */
     override fun isTransportProvenAliveWithinKeepAliveWindow(): Boolean {
         if (!isConnected) return false
-        val sinceActivityNanos = System.nanoTime() - lastInboundActivityNanos
+        // Issue #1072 — count RECENT OUTBOUND upload progress as proof of life too,
+        // not just inbound server bytes. A large/slow attachment upload over a quiet
+        // `-CC` session is almost pure outbound (`cat > tmp` emits nothing until
+        // EOF), so the inbound-only oracle aged out within the ride-through window
+        // and the app-level LivenessProbe (which defers to this) declared a silent
+        // drop and tore the live transport down MID-UPLOAD (the maintainer's
+        // "attaching breaks the connection"). An actively-progressing upload means
+        // the peer is consuming our window — provably reachable — so the LATER of
+        // the inbound and outbound timestamps is the correct liveness watermark.
+        // Genuine-death contract preserved: a truly dead transport stalls the
+        // writes, outbound stops advancing, and BOTH timestamps age out past the
+        // ride-through window → returns false → the keepalive's own budget closes it.
+        val mostRecentActivityNanos = maxOf(lastInboundActivityNanos, lastOutboundActivityNanos)
+        val sinceActivityNanos = System.nanoTime() - mostRecentActivityNanos
         val rideThroughNanos = TransportKeepAlive.RIDE_THROUGH_BUDGET_MS * 1_000_000L
         return sinceActivityNanos in 0 until rideThroughNanos
     }

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/TransportKeepAlive.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/TransportKeepAlive.kt
@@ -93,6 +93,32 @@ internal class TransportKeepAlive(
         fun lastInboundActivityNanos(): Long
 
         /**
+         * Issue #1072 — nanos (monotonic, [System.nanoTime] domain) of the most
+         * recent OUTBOUND payload progress the session has made: a steadily
+         * advancing file/attachment upload pushing client→server bytes.
+         *
+         * Why outbound counts as proof of life: an upload's `output.write(...)`
+         * only keeps returning while the kernel send buffer drains, which on a
+         * sane TCP window means the PEER is still ACKing our segments — so RECENT
+         * outbound progress proves the transport is reachable just as inbound
+         * bytes do. A large/slow attachment over a QUIET `-CC` session is almost
+         * pure outbound (`cat > tmp` emits nothing until EOF), so WITHOUT this
+         * signal the loop saw ZERO inbound for the whole upload and tore the live
+         * transport down mid-upload — the maintainer's "attaching breaks the
+         * connection" (#1072). The loop folds this into the SAME reset-on-activity
+         * shortcut and ride-through death decision as inbound.
+         *
+         * Crucially this is RECENT outbound PROGRESS, not "an upload was started":
+         * a genuinely dead/half-open peer stalls the writes once the send buffer
+         * fills, so this timestamp stops advancing and ages out of the ride-through
+         * window — a truly dead transport (no inbound AND no outbound progress) is
+         * STILL declared dead within the budget. Default returns [Long.MIN_VALUE]
+         * ("no recent outbound") so a fake/test that does not override it behaves
+         * exactly as before (inbound-only).
+         */
+        fun lastOutboundActivityNanos(): Long = Long.MIN_VALUE
+
+        /**
          * Send ONE `keepalive@openssh.com` global request through the transport
          * dispatcher and await the reply. Returns `true` on ANY reply (including
          * the mandatory `SSH_MSG_REQUEST_FAILURE` for an unknown request type,
@@ -161,12 +187,14 @@ internal class TransportKeepAlive(
                     consecutiveMisses = 0
                     break
                 }
-                // Reset-on-inbound (OpenSSH semantics): a link that produced
-                // server bytes within the last interval is self-evidently alive,
-                // so skip the explicit ping and reset the miss counter. This is
-                // why a heavy `%output` burst is POSITIVE proof of life, not a
-                // missed probe.
-                val sinceActivityNanos = System.nanoTime() - io.lastInboundActivityNanos()
+                // Reset-on-activity (OpenSSH semantics, extended for outbound in
+                // #1072): a link that produced server bytes — OR made outbound
+                // upload progress — within the last interval is self-evidently
+                // alive, so skip the explicit ping and reset the miss counter.
+                // This is why a heavy `%output` burst is POSITIVE proof of life,
+                // not a missed probe; and why a steadily-streaming attachment
+                // upload (pure outbound) must NOT be torn down mid-upload (#1072).
+                val sinceActivityNanos = System.nanoTime() - io.lastActivityNanos()
                 if (sinceActivityNanos in 0 until intervalNanos()) {
                     if (consecutiveMisses != 0) {
                         log("keepalive: inbound activity, reset after $consecutiveMisses miss(es)")
@@ -188,8 +216,9 @@ internal class TransportKeepAlive(
                         // lands after the 5s per-reply budget — so the per-tick send
                         // reports a "miss" — but well within the ~90s death budget. That
                         // late inbound advances this watermark; a half-open DEAD peer
-                        // never can.
-                        missStreakStartActivityNanos = io.lastInboundActivityNanos()
+                        // never can. #1072: outbound upload progress advances it too,
+                        // so a steadily-progressing upload rides through the streak.
+                        missStreakStartActivityNanos = io.lastActivityNanos()
                     }
                     consecutiveMisses += 1
                     log("keepalive: miss consecutive=$consecutiveMisses countMax=$countMax")
@@ -199,12 +228,15 @@ internal class TransportKeepAlive(
                         // close path already owns recovery and an extra reaction
                         // would be a spurious teardown.
                         if (io.isAlive()) {
-                            if (io.lastInboundActivityNanos() != missStreakStartActivityNanos) {
-                                // Issue #1059 (R2) — slow-but-alive: inbound activity
-                                // advanced during the streak, so the peer DID answer
-                                // (late). A genuinely half-open dead peer can never move
-                                // this timestamp, so this can only be a real round-trip
-                                // on a high-RTT/bufferbloat idle link — ride it through
+                            if (io.lastActivityNanos() != missStreakStartActivityNanos) {
+                                // Issue #1059 (R2) / #1072 — slow-but-alive: inbound
+                                // activity OR outbound upload progress advanced during
+                                // the streak, so the peer DID answer (late) or we are
+                                // still actively pushing bytes it is ACKing. A genuinely
+                                // half-open dead peer can never move this timestamp, so
+                                // this can only be a real round-trip on a high-RTT/
+                                // bufferbloat idle link, or a progressing upload — ride
+                                // it through
                                 // instead of redialing a live link (the #945 contract is
                                 // preserved precisely because we only ride through on
                                 // PROVEN inbound).
@@ -238,6 +270,18 @@ internal class TransportKeepAlive(
     }
 
     private fun intervalNanos(): Long = intervalMs * 1_000_000L
+
+    /**
+     * Issue #1072 — the single "most recent proof of life" timestamp the loop
+     * keys every reset/ride-through decision off: the LATER of the last inbound
+     * server byte and the last outbound upload progress. Either one proves the
+     * transport is still carrying our traffic. The default
+     * [KeepAliveIo.lastOutboundActivityNanos] of [Long.MIN_VALUE] makes this fall
+     * back to inbound-only for fakes/tests that do not stream outbound, so the
+     * pre-#1072 behaviour is preserved exactly when there is no upload in flight.
+     */
+    private fun KeepAliveIo.lastActivityNanos(): Long =
+        maxOf(lastInboundActivityNanos(), lastOutboundActivityNanos())
 
     private suspend fun sendOne(): Boolean =
         try {

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/TransportKeepAliveTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/TransportKeepAliveTest.kt
@@ -30,9 +30,14 @@ class TransportKeepAliveTest {
         var pingsSent: Int = 0
         var deadDeclaredWith: Int? = null
         var lastActivityNanos: Long = Long.MIN_VALUE // "no recent activity"
+        // Issue #1072 — the most recent OUTBOUND upload-progress timestamp. Default
+        // MIN_VALUE ("no recent outbound") so existing tests behave exactly as before
+        // (inbound-only); the #1072 tests advance it to model a streaming upload.
+        var lastOutboundActivityNanos: Long = Long.MIN_VALUE
 
         override fun isAlive(): Boolean = alive
         override fun lastInboundActivityNanos(): Long = lastActivityNanos
+        override fun lastOutboundActivityNanos(): Long = lastOutboundActivityNanos
         override suspend fun sendKeepAlive(): Boolean {
             pingsSent += 1
             return pingResult
@@ -200,6 +205,92 @@ class TransportKeepAliveTest {
         assertEquals(
             "once inbound data ALSO stops, a genuinely dead link must still be declared " +
                 "dead within countMax — the #974 data-bump must not mask a real death",
+            3,
+            io.deadDeclaredWith,
+        )
+        keepAlive.stop()
+    }
+
+    @Test
+    fun `outbound upload progress alone rides through starved replies - never declares dead (#1072)`() = runTest {
+        // Issue #1072 (the maintainer's "attaching breaks the connection"): a large
+        // attachment upload over a QUIET `-CC` session is almost pure OUTBOUND —
+        // `cat > tmp` emits nothing until EOF, so ZERO inbound bytes arrive for the
+        // whole upload, and on a slow/high-RTT link not even a keepalive reply lands.
+        // Before #1072 the loop keyed liveness off inbound ONLY, so it declared the
+        // peer dead and tore the LIVE transport down mid-upload. With outbound folded
+        // into the reset-on-activity / ride-through decision, a steadily-progressing
+        // upload (outbound advancing every tick) proves the peer is consuming our
+        // window, so the loop SKIPS the ping and NEVER declares dead.
+        //
+        // RED on base: revert the loop's `lastActivityNanos()` helper back to
+        // `lastInboundActivityNanos()` and this fails — inbound stays MIN_VALUE
+        // (no server bytes), every ping misses, and it declares dead within countMax.
+        // GREEN with the fix: outbound advancing rides it through.
+        val io = FakeIo()
+        val keepAlive = TransportKeepAlive(io = io, intervalMs = 1_000L, countMax = 3)
+        keepAlive.start(this)
+
+        // Inbound is FROZEN stale the whole time (quiet `-CC`, no server bytes), and
+        // any ping that DID fire would miss (starved replies on a saturated uplink).
+        io.lastActivityNanos = Long.MIN_VALUE
+        io.pingResult = false
+        // Hold for FOUR budgets (12 ticks, budget = 3) with OUTBOUND progress fresh
+        // every tick — the streaming upload. The loop must ride through indefinitely.
+        repeat(12) {
+            io.lastOutboundActivityNanos = System.nanoTime() // a chunk just went out
+            advanceTimeBy(1_000L)
+            runCurrent()
+        }
+
+        assertEquals(
+            "a steadily-progressing upload (outbound advancing) must NEVER be declared " +
+                "dead even with zero inbound and starved keepalive replies — the outbound " +
+                "progress proves the transport alive (#1072). RED on base: outbound was " +
+                "ignored, so the loop pinged, every ping missed, and it tore the live " +
+                "transport down mid-upload.",
+            null,
+            io.deadDeclaredWith,
+        )
+        assertEquals(
+            "the loop must SKIP every ping while outbound is fresh (reset-on-activity), so " +
+                "a saturated uplink with an in-flight upload sends ZERO pings",
+            0,
+            io.pingsSent,
+        )
+        keepAlive.stop()
+    }
+
+    @Test
+    fun `upload finishes then transport genuinely dies - still declared dead within budget (#1072)`() = runTest {
+        // Issue #1072 class-coverage (the genuine-death contract the fix must preserve):
+        // once the upload FINISHES (outbound stops advancing) AND the link is genuinely
+        // dead (no inbound, no reply), the outbound bump no longer fires, the
+        // reset-on-activity shortcut goes silent, and the loop MUST still declare the
+        // peer dead within countMax. The outbound proof must NOT make a truly-dead link
+        // look alive forever.
+        val io = FakeIo()
+        val keepAlive = TransportKeepAlive(io = io, intervalMs = 1_000L, countMax = 3)
+        keepAlive.start(this)
+
+        // Phase 1: upload streaming (outbound fresh) + replies starved -> ridden through.
+        io.lastActivityNanos = Long.MIN_VALUE
+        io.pingResult = false
+        repeat(5) {
+            io.lastOutboundActivityNanos = System.nanoTime()
+            advanceTimeBy(1_000L); runCurrent()
+        }
+        assertEquals("ridden through while the upload streamed", null, io.deadDeclaredWith)
+
+        // Phase 2: upload DONE (outbound stops) and the link is dead (no inbound) -> dead.
+        io.lastOutboundActivityNanos = Long.MIN_VALUE // no more outbound progress
+        advanceTimeBy(1_000L); runCurrent() // miss 1
+        advanceTimeBy(1_000L); runCurrent() // miss 2
+        advanceTimeBy(1_000L); runCurrent() // miss 3 -> declare dead
+        assertEquals(
+            "once the upload ends AND the link is genuinely dead, the peer must STILL be " +
+                "declared dead within countMax — the #1072 outbound bump must not mask a " +
+                "real death once outbound progress stops",
             3,
             io.deadDeclaredWith,
         )


### PR DESCRIPTION
## v0.4.19 RELEASE BLOCKER — maintainer dogfood: attaching a file breaks the connection + reconnect wedges (must restart)

**Failure 1 — attach breaks the connection.** Keepalive + `isTransportProvenAliveWithinKeepAliveWindow` counted ONLY inbound bytes; a pure-outbound upload (`cat > temp`, silent `-CC`) looked dead → transport closed mid-upload. **Fix:** liveness keys off `maxOf(inbound, outbound)` (finishing #1041's unused `lastOutboundActivityNanos`). #945 genuine-death contract preserved — gates on recent outbound *progress*, so a stalled upload on a dead socket still dies.

**Failure 2 — reconnect wedges (the worse half).** The in-flight upload now is a `viewModelScope` job cancel-and-joined first in `closeCurrentConnectionAndJoin`; an explicit Reconnect preempts the same-target connect dedup guard → a post-drop reconnect always recovers without an app restart.

### Verified gone (D33 — reviewer-driven red→green at three levels)
- JVM `TransportKeepAliveTest` (outbound ride-through + genuine-death-once-outbound-stops)
- Real throttled transport `KeepAliveIntegrationTest` (6 MB over 256 KB/s, Docker)
- **On-device** `AttachmentDropReconnectRecoversE2eTest` (emulator + Docker): `recovered_without_restart_ms=1803`, `client_rebound=1`, post-recovery round-trip ok
- Adjacency sweep green (MultiSessionSwitch / BackgroundGrace / ServerDeath); full `:shared:core-ssh` + `:app` suites green.

Residual synthetic edge (warm-lease evict-on-cancel) is production-unreachable → tracked as **#1073** (D28 rewrite-vs-patch, maintainer's call).

Closes #1072.