### PR TITLE
share: live byte-progress for isolated uploads (#1037)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/share/ShareUploader.kt
+++ b/app/src/main/java/com/pocketshell/app/share/ShareUploader.kt
@@ -10,6 +10,7 @@ import com.pocketshell.core.ssh.SshConnection
 import com.pocketshell.core.ssh.SshException
 import com.pocketshell.core.ssh.SshKey
 import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshUploadProgress
 import com.pocketshell.core.storage.entity.HostEntity
 import com.pocketshell.core.storage.entity.SshKeyEntity
 import kotlinx.coroutines.Dispatchers
@@ -54,6 +55,7 @@ internal interface ShareItemUploader {
         keyEntity: SshKeyEntity,
         item: ShareableItem,
         target: ShareTarget = ShareTarget.HostInbox,
+        onProgress: ((SshUploadProgress) -> Unit)? = null,
     ): Result<String>
 }
 
@@ -124,6 +126,7 @@ internal class ShareUploader(
         keyEntity: SshKeyEntity,
         item: ShareableItem,
         target: ShareTarget,
+        onProgress: ((SshUploadProgress) -> Unit)?,
     ): Result<String> = withContext(Dispatchers.IO) {
         val preparedUriFile = if (item is ShareableItem.UriItem) {
             val resolver = context.contentResolver
@@ -167,9 +170,10 @@ internal class ShareUploader(
                         preparedUriFile
                             ?: throw SshException("Could not read shared file before upload"),
                         remotePath,
+                        onProgress,
                     )
-                    is ShareableItem.TextItem -> uploadText(live, item, remotePath, remoteName)
-                    is ShareableItem.FileItem -> live.uploadFile(item.file, remotePath)
+                    is ShareableItem.TextItem -> uploadText(live, item, remotePath, remoteName, onProgress)
+                    is ShareableItem.FileItem -> live.uploadFile(item.file, remotePath, onProgress)
                 }
                 Result.success("${destination.displayDirectory}/$remoteName")
             }
@@ -276,6 +280,7 @@ internal class ShareUploader(
         item: ShareableItem.TextItem,
         remotePath: String,
         remoteName: String,
+        onProgress: ((SshUploadProgress) -> Unit)?,
     ) {
         val bytes = item.text.toByteArray(Charsets.UTF_8)
         bytes.inputStream().use { input ->
@@ -284,6 +289,7 @@ internal class ShareUploader(
                 length = bytes.size.toLong(),
                 name = remoteName,
                 remotePath = remotePath,
+                onProgress = onProgress,
             )
         }
     }

--- a/app/src/main/java/com/pocketshell/app/share/ShareViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/share/ShareViewModel.kt
@@ -16,6 +16,7 @@ import com.pocketshell.core.ssh.SshLeaseManager
 import com.pocketshell.core.ssh.SshLeaseTarget
 import com.pocketshell.core.ssh.SshKey
 import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshUploadProgress
 import com.pocketshell.core.storage.dao.HostDao
 import com.pocketshell.core.storage.dao.ProjectRootDao
 import com.pocketshell.core.storage.dao.SshKeyDao
@@ -257,15 +258,9 @@ internal class ShareViewModel internal constructor(
     /**
      * Build the lease target for the share connect.
      *
-     * The [SshLeaseKey] is byte-for-byte identical to the one the live
-     * tmux session uses (`TmuxSessionViewModel.toSshLeaseTarget`) — same
-     * `credentialId` (`"$id:$keyPath"`) and `knownHostsId` — so when the
-     * app already holds a warm lease for this host/key the share REUSES it
-     * (the passphrase is intentionally NOT part of the lease key, so a
-     * warm, already-unlocked lease is shared regardless of whether we have
-     * a passphrase here). The [passphrase] only matters on the
-     * fresh-connect fallback, when no reusable lease exists and the key is
-     * passphrase-protected (issue #654).
+     * File-transfer work gets its own lease-key purpose suffix instead of
+     * borrowing the live tmux terminal transport. A multi-megabyte upload can
+     * otherwise disturb the active control session on the same SSH connection.
      */
     private fun HostEntity.toShareLeaseTarget(
         keyPath: String,
@@ -797,7 +792,36 @@ internal class ShareViewModel internal constructor(
 
             for ((index, item) in payload.withIndex()) {
                 val itemLabel = item.displayName?.takeIf { it.isNotBlank() } ?: "file"
-                val result = uploader.upload(host, keyEntity, item, target)
+                val itemNumber = index + 1
+                val estimatedBytes = estimatedUploadBytes(item)
+                _uploadState.value = UploadState.Running(
+                    host.name,
+                    uploadProgressDetail(
+                        label = itemLabel,
+                        itemNumber = itemNumber,
+                        totalCount = payload.size,
+                        bytesTransferred = 0L,
+                        totalBytes = estimatedBytes,
+                    ),
+                )
+                val result = uploader.upload(
+                    host = host,
+                    keyEntity = keyEntity,
+                    item = item,
+                    target = target,
+                    onProgress = { progress ->
+                        _uploadState.value = UploadState.Running(
+                            host.name,
+                            uploadProgressDetail(
+                                label = itemLabel,
+                                itemNumber = itemNumber,
+                                totalCount = payload.size,
+                                bytesTransferred = progress.bytesTransferred,
+                                totalBytes = progress.totalBytes.takeIf { it > 0L } ?: estimatedBytes,
+                            ),
+                        )
+                    },
+                )
                 val failure = result.exceptionOrNull()
                 // Issue #654: a fresh share connect (when no warm app lease
                 // is reusable — e.g. the live session's lease expired while
@@ -1095,6 +1119,12 @@ internal class ShareViewModel internal constructor(
         ShareUploadNotifications.showFailure(applicationContext, hostName, message)
     }
 
+    private fun estimatedUploadBytes(item: ShareableItem): Long? = when (item) {
+        is ShareableItem.FileItem -> item.file.length().takeIf { it > 0L }
+        is ShareableItem.TextItem -> item.text.toByteArray(Charsets.UTF_8).size.toLong()
+        is ShareableItem.UriItem -> item.size?.takeIf { it > 0L }
+    }
+
     private data class SessionStagingInput(
         val uris: List<Uri>,
         val tempFiles: List<File>,
@@ -1344,6 +1374,32 @@ internal class ShareViewModel internal constructor(
         }
 
         /**
+         * Live per-item upload detail (issue #1037). Unlike [runningDetail]'s
+         * static total computed before the transfer starts, this is rebuilt on
+         * every [SshUploadProgress] callback so the share UI shows bytes moving
+         * (`Uploading report.zip (2.1 MB / 4.8 MB)`), with an `(n/total)` item
+         * counter when more than one item is in the batch. The byte progress
+         * surfaced here rides the ISOLATED transfer lease (the `share-upload`
+         * purpose), never the live terminal tmux connection.
+         */
+        fun uploadProgressDetail(
+            label: String,
+            itemNumber: Int,
+            totalCount: Int,
+            bytesTransferred: Long,
+            totalBytes: Long?,
+        ): String {
+            val counter = if (totalCount > 1) " ($itemNumber/$totalCount)" else ""
+            val sizePart = when {
+                totalBytes != null && totalBytes > 0L ->
+                    "${formatRunningBytes(bytesTransferred)} / ${formatRunningBytes(totalBytes)}"
+                bytesTransferred > 0L -> formatRunningBytes(bytesTransferred)
+                else -> "size unknown"
+            }
+            return "Uploading $label$counter ($sizePart)"
+        }
+
+        /**
          * Single-quote escape for tmux command arguments. Mirrors the
          * private helper in [com.pocketshell.app.tmux.TmuxSessionViewModel] —
          * inlined here to keep the share package decoupled from
@@ -1469,6 +1525,13 @@ private class LeaseBackedShareSession(
     override suspend fun uploadFile(file: File, remotePath: String): String =
         session.uploadFile(file, remotePath)
 
+    override suspend fun uploadFile(
+        file: File,
+        remotePath: String,
+        onProgress: ((SshUploadProgress) -> Unit)?,
+    ): String =
+        session.uploadFile(file, remotePath, onProgress)
+
     override suspend fun downloadFile(remotePath: String, maxBytes: Long): ByteArray =
         session.downloadFile(remotePath, maxBytes)
 
@@ -1479,6 +1542,15 @@ private class LeaseBackedShareSession(
         remotePath: String,
     ): String =
         session.uploadStream(input, length, name, remotePath)
+
+    override suspend fun uploadStream(
+        input: java.io.InputStream,
+        length: Long,
+        name: String,
+        remotePath: String,
+        onProgress: ((SshUploadProgress) -> Unit)?,
+    ): String =
+        session.uploadStream(input, length, name, remotePath, onProgress)
 
     override suspend fun listDirectory(
         remotePath: String,

--- a/app/src/test/java/com/pocketshell/app/share/ShareViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/share/ShareViewModelTest.kt
@@ -480,6 +480,62 @@ class ShareViewModelTest {
     }
 
     @Test
+    fun startUploadSurfacesLiveByteProgressDetailWhileTransferring() = runTest {
+        // Issue #1037 acceptance ("show progress"): the share UI must show bytes
+        // MOVING during a transfer (not just a static up-front total), surfaced
+        // through UploadState.Running.detail. The uploader emits progress ticks
+        // and we snapshot the live detail synchronously after each one.
+        val vm = newVm(ActiveTmuxClients())
+        val host = seededHost(id = 1037L, name = "hetzner")
+        val observedRunningDetails = mutableListOf<String>()
+        val progressUploader = object : ShareItemUploader {
+            override suspend fun upload(
+                host: HostEntity,
+                keyEntity: SshKeyEntity,
+                item: ShareableItem,
+                target: ShareTarget,
+                onProgress: ((com.pocketshell.core.ssh.SshUploadProgress) -> Unit)?,
+            ): Result<String> {
+                fun tick(transferred: Long) {
+                    onProgress?.invoke(
+                        com.pocketshell.core.ssh.SshUploadProgress(
+                            bytesTransferred = transferred,
+                            totalBytes = 4_800_000L,
+                        ),
+                    )
+                    (vm.uploadState.value as? UploadState.Running)?.detail?.let {
+                        observedRunningDetails += it
+                    }
+                }
+                tick(0L)
+                tick(2_400_000L)
+                tick(4_800_000L)
+                return Result.success("~/inbox/pocketshell/${item.displayName}.txt")
+            }
+        }
+        vm.uploader = progressUploader
+        vm.setItem(ShareableItem.TextItem(text = "report body", displayName = "report"))
+
+        vm.startUpload(host)
+        advanceUntilIdle()
+
+        assertTrue(
+            "expected the upload to succeed, state=${vm.uploadState.value}",
+            vm.uploadState.value is UploadState.Success,
+        )
+        assertTrue(
+            "expected a live mid-transfer detail showing 0 B moving toward 4.6 MB, got " +
+                "$observedRunningDetails",
+            observedRunningDetails.any { it.contains("0 B") && it.contains("4.6 MB") },
+        )
+        assertTrue(
+            "expected a live detail showing ~half (2.3 MB) of 4.6 MB transferred, got " +
+                "$observedRunningDetails",
+            observedRunningDetails.any { it.contains("2.3 MB") && it.contains("4.6 MB") },
+        )
+    }
+
+    @Test
     fun startUploadWithSingleItemKeepsSinglePathSuccess() = runTest {
         val vm = newVm(ActiveTmuxClients())
         val host = seededHost(id = 31L, name = "hetzner")
@@ -1698,10 +1754,22 @@ class ShareViewModelTest {
             keyEntity: SshKeyEntity,
             item: ShareableItem,
             target: ShareTarget,
+            onProgress: ((com.pocketshell.core.ssh.SshUploadProgress) -> Unit)?,
         ): Result<String> {
             val name = item.displayName.orEmpty()
             uploadedNames += name
             uploadedTargets += target
+            // Emit a couple of byte-progress ticks (issue #1037) so tests can
+            // observe the live UploadState.Running detail update mid-transfer.
+            onProgress?.invoke(
+                com.pocketshell.core.ssh.SshUploadProgress(bytesTransferred = 0L, totalBytes = 100L),
+            )
+            onProgress?.invoke(
+                com.pocketshell.core.ssh.SshUploadProgress(bytesTransferred = 50L, totalBytes = 100L),
+            )
+            onProgress?.invoke(
+                com.pocketshell.core.ssh.SshUploadProgress(bytesTransferred = 100L, totalBytes = 100L),
+            )
             return if (name in failNames) {
                 Result.failure(IllegalStateException("Permission denied"))
             } else if (name in blankNames) {

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshSession.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshSession.kt
@@ -1048,6 +1048,13 @@ internal class RealSshSession(
     }
 
     override suspend fun uploadFile(file: File, remotePath: String): String =
+        uploadFile(file, remotePath, onProgress = null)
+
+    override suspend fun uploadFile(
+        file: File,
+        remotePath: String,
+        onProgress: ((SshUploadProgress) -> Unit)?,
+    ): String =
         withContext(Dispatchers.IO) {
             ensureConnected()
             if (!file.exists()) {
@@ -1059,6 +1066,7 @@ internal class RealSshSession(
                     length = file.length(),
                     name = file.name,
                     remotePath = remotePath,
+                    onProgress = onProgress,
                 )
             }
             remotePath
@@ -1069,9 +1077,18 @@ internal class RealSshSession(
         length: Long,
         name: String,
         remotePath: String,
+    ): String =
+        uploadStream(input, length, name, remotePath, onProgress = null)
+
+    override suspend fun uploadStream(
+        input: InputStream,
+        length: Long,
+        name: String,
+        remotePath: String,
+        onProgress: ((SshUploadProgress) -> Unit)?,
     ): String = withContext(Dispatchers.IO) {
         ensureConnected()
-        uploadStreamInternal(input, length, name, remotePath)
+        uploadStreamInternal(input, length, name, remotePath, onProgress)
         remotePath
     }
 
@@ -1283,6 +1300,7 @@ internal class RealSshSession(
         length: Long,
         name: String,
         remotePath: String,
+        onProgress: ((SshUploadProgress) -> Unit)?,
     ) {
         // Atomic temp sibling of the final path: `<final>.part-<rand>`. A
         // dropped/timed-out transfer corrupts only THIS temp name, never the
@@ -1290,7 +1308,14 @@ internal class RealSshSession(
         // concurrent retries of the same attachment.
         val tempRemotePath = remotePath + ".part-" + java.util.UUID.randomUUID().toString().take(8)
         try {
-            val copied = streamToRemoteTemp(input, name, remotePath, tempRemotePath, length)
+            val copied = streamToRemoteTemp(
+                input = input,
+                name = name,
+                remotePath = remotePath,
+                tempRemotePath = tempRemotePath,
+                declaredLength = length,
+                onProgress = onProgress,
+            )
 
             // Integrity check BEFORE the rename: the bytes that actually landed
             // in the temp file must match what we copied, and — when the caller
@@ -1345,6 +1370,7 @@ internal class RealSshSession(
         remotePath: String,
         tempRemotePath: String,
         declaredLength: Long,
+        onProgress: ((SshUploadProgress) -> Unit)?,
     ): Long {
         val coroutineJob = currentCoroutineContext()[Job]
         // Channel open + `cat >` exec are transport-mutating packets — serialise
@@ -1393,7 +1419,7 @@ internal class RealSshSession(
             val copied = try {
                 runInterruptible(Dispatchers.IO) {
                     val output = command!!.outputStream
-                    val n = copyToRemoteBlocking(input, output, declaredLength)
+                    val n = copyToRemoteBlocking(input, output, declaredLength, onProgress)
                     runTransferStepWithStallTimeout(
                         operation = "closing upload output",
                         timeoutMs = uploadStallTimeoutMs,
@@ -1546,9 +1572,11 @@ internal class RealSshSession(
         input: InputStream,
         output: OutputStream,
         declaredLength: Long,
+        onProgress: ((SshUploadProgress) -> Unit)?,
     ): Long {
         val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
         var total = 0L
+        onProgress?.invoke(SshUploadProgress(bytesTransferred = 0L, totalBytes = declaredLength))
         while (true) {
             if (Thread.interrupted()) throw InterruptedException("SSH upload interrupted")
             val read = runTransferStepWithStallTimeout(
@@ -1573,6 +1601,7 @@ internal class RealSshSession(
             }
             total += read
             recordOutboundActivity()
+            onProgress?.invoke(SshUploadProgress(bytesTransferred = total, totalBytes = declaredLength))
         }
         runTransferStepWithStallTimeout(
             operation = "flushing upload bytes",

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshSession.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshSession.kt
@@ -4,6 +4,11 @@ import kotlinx.coroutines.Job
 import java.io.File
 import java.io.InputStream
 
+public data class SshUploadProgress(
+    val bytesTransferred: Long,
+    val totalBytes: Long,
+)
+
 /**
  * Live SSH connection to a single host. Obtain instances via
  * [SshConnection.connect].
@@ -121,6 +126,12 @@ public interface SshSession : AutoCloseable {
      */
     public suspend fun uploadFile(file: File, remotePath: String): String
 
+    public suspend fun uploadFile(
+        file: File,
+        remotePath: String,
+        onProgress: ((SshUploadProgress) -> Unit)?,
+    ): String = uploadFile(file, remotePath)
+
     /**
      * Read the contents of a remote file at [remotePath] into memory.
      *
@@ -178,6 +189,14 @@ public interface SshSession : AutoCloseable {
         name: String,
         remotePath: String,
     ): String
+
+    public suspend fun uploadStream(
+        input: InputStream,
+        length: Long,
+        name: String,
+        remotePath: String,
+        onProgress: ((SshUploadProgress) -> Unit)?,
+    ): String = uploadStream(input, length, name, remotePath)
 
     /**
      * List the entries of remote directory [remotePath] (issue #528 — file


### PR DESCRIPTION
Rebased + reconciled replacement for #1040 (force-push blocked by env guardrail; same reviewed commit `997940bd`, cleanly on current `main`).

## Summary
Scope narrowed by reconciliation — `main` already shipped the upload *stability* fix (#1074 outbound-aware liveness; #1041 purpose-suffixed lease isolation so uploads don't ride the live terminal/tmux lease). This PR delivers the remaining maintainer-requested piece: **live byte-progress UI** so the user can distinguish real progress from a hung/dropped connection (#1041 only showed a static total).

- Rebuilds `UploadState.Running(hostName, detail)` on every `SshUploadProgress` tick via a new `uploadProgressDetail()` helper, plus `onProgress` byte-progress plumbing in `RealSshSession.kt`/`SshSession.kt`.
- #1074's liveness path is byte-for-byte untouched (`recordOutboundActivity`/`maxOf(inbound,outbound)` preserved verbatim); uses #1041's single `shareCredentialId`/`leasePurpose` lease authority — no parallel mechanism (D22).

## Verification (reviewer-driven, this run)
- Red→green: disabling `onProgress` made the new `startUploadSurfacesLiveByteProgressDetailWhileTransferring` test fail (detail stuck at static `0 B / 11 B`, the "looks hung" symptom); restored → passes.
- Stability property holds: `startUploadDoesNotReuseGenericInteractiveLease` passes (terminal/generic lease gets zero upload bytes).
- Full `:shared:core-ssh:testDebugUnitTest` 207 tests / 0 failures (incl. #1072/#1074 keepalive + `PublicApiShapeTest`); `ShareViewModelTest` 41/0. `UploadingSurface` net-zero vs main (already emulator-validated by #1041).

Reviewer APPROVED: https://github.com/alexeygrigorev/pocketshell/issues/1037

Closes #1037