### PR TITLE
release: v0.4.19

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,8 +65,8 @@ android {
         applicationId = "com.pocketshell.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 65
-        versionName = "0.4.18"
+        versionCode = 66
+        versionName = "0.4.19"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/tools/pocketshell/pyproject.toml
+++ b/tools/pocketshell/pyproject.toml
@@ -8,7 +8,7 @@ name = "pocketshell"
 # scripts/check-pypi-version.sh enforces this; .github/workflows/build.yml
 # runs that check before publishing to PyPI. See
 # tools/pocketshell/README.md ("Release flow") for the bump procedure.
-version = "0.4.18"
+version = "0.4.19"
 description = "Unified server-side Python utility for the PocketShell Android client."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Version bump for the **v0.4.19 connection-stability wave**. Lockstep: `app/build.gradle.kts` versionName "0.4.19" / versionCode 66 (mono +1 from 65), `tools/pocketshell/pyproject.toml` 0.4.19.

## Wave contents (already merged to main)
- #1074 — outbound-aware liveness (`maxOf(inbound,outbound)`) so a pure-outbound upload no longer looks dead and kills the transport; explicit Reconnect preempts the dedup guard → reconnect always recovers without an app restart
- #1076 — bound create-session SSH execs (no freeze) + durable regression test + progress/failure UI surface
- #1077 — live upload byte-progress (distinguish real progress from a hung/dropped connection)

## Pre-tag readiness
- Dogfood-readiness scan #1071: **GO** — wave composes cleanly (no two-writer transport hazard), no tag-blocking connection bug, version metadata clean (nothing claims 0.4.19).
- Cheap required checks green on the batch head; the authoritative emulator gate is `scripts/release-emulator-validation.sh`, run after this bump merges. Any emulator-journey RED is classified against the #788/#1056 swiftshader flake signature, not a regression.

Known residuals shipping with eyes open: #1078 (WIFI→cellular handoff stall, → v0.4.20), #1073 (production-unreachable D28 residual), #874/#895 (pre-wave black-screen long-tail).

No `Closes` — release bump only.