### PR TITLE
release: v0.4.19 — fold held freeze/black-screen fixes into the normal cycle

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/tmux/Issue1085RecompositionScopeProofTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/Issue1085RecompositionScopeProofTest.kt
@@ -1,0 +1,441 @@
+package com.pocketshell.app.tmux
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.pocketshell.app.session.AgentConversationUiState
+import com.pocketshell.app.session.InlineDictationViewModel
+import com.pocketshell.core.agents.AgentDetection
+import com.pocketshell.core.agents.AgentKind
+import com.pocketshell.core.agents.ConversationEvent
+import com.pocketshell.core.agents.ConversationRole
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Issue #1085 (freeze F3) — DETERMINISTIC recomposition-scoping proof for the
+ * two voice-first jank vectors that recomposed the whole 7k-line
+ * [TmuxSessionScreen] body at a high frequency:
+ *
+ *  - **R1 — inline-dictation amplitude (20 Hz).** The silence watchdog rewrites
+ *    `InlineDictationViewModel.uiState` with a fresh `amplitude` every 50ms while
+ *    recording. The body read the WHOLE `uiState` (a delegated `by` read), so the
+ *    body's ROOT restart group — the one that hosts the terminal-render subtree —
+ *    recomposed 20×/s while the user dictated. The fix derives just the
+ *    (low-frequency) `mode` via `derivedStateOf`, so the amplitude churn never
+ *    invalidates the body.
+ *  - **R2 — agent-transcript streaming (≈16 Hz).** `AgentConversationRepository`
+ *    flushes a fresh `agentConversations` map every `tailBatchWindowMillis`=60ms
+ *    while an agent streams. The body read `agentConversations[paneId]` directly,
+ *    so the body recomposed once per flush. The fix reads only a STABLE
+ *    [SurfaceConversationChrome] projection (detection / selectedTab / hasEvents /
+ *    exists — all stable mid-stream) via `derivedStateOf` in the body, and reads
+ *    the high-frequency `events` LIST inside the `surfaceContent` child scope (its
+ *    own restart group), so a flush recomposes only the transcript.
+ *
+ * ## Why this is a faithful scope proof, not a `*StandIn`/`*Proxy`
+ *
+ * The symptom under test is a Compose **invalidation-scope** defect: "does a
+ * high-frequency state emission re-run the body's ROOT restart group?" That
+ * property is a function of HOW the hot state is read (whole-object read in the
+ * body vs a `derivedStateOf` projection + a deferred child read), independent of
+ * the SSH/tmux/render machinery the body also hosts. So — exactly like the #796
+ * H4 scope proof ([Issue796ImeRecompositionScopeProofTest]) — these harnesses
+ * compose the EXACT production read structure (the production
+ * [SurfaceConversationChrome] data class and the production `derivedStateOf`
+ * projection; the real [InlineDictationViewModel.UiState] data class) and count
+ * re-executions of the body group. A heavyweight terminal stand-in is irrelevant
+ * to the invalidation-scope question, so counting the body group's re-execution
+ * is the faithful probe (process.md F2). The companion full-journey acceptance —
+ * the real [TmuxSessionScreen] over Docker while dictating / while an agent
+ * streams — is the on-device proof; this is the deterministic regression guard
+ * that catches the scope regression at PR time.
+ *
+ * The hot state is driven directly via a `mutableStateOf` the test mutates
+ * (`collectAsState` merely turns the production `StateFlow` into exactly such a
+ * `State`; the scoping property is identical). Fully deterministic and
+ * environment-independent — no real recorder, no Docker, NO `assumeTrue` /
+ * CI-skip on the load-bearing assertion (process.md F3, #780 model).
+ *
+ * Each path pins BOTH the production O(1) ceiling AND the pre-fix O(N) floor, so
+ * the assertions are a real red/green guard rather than a vacuous pass (G6: the
+ * load-bearing assertion is the flat body-recomposition count).
+ */
+@RunWith(AndroidJUnit4::class)
+class Issue1085RecompositionScopeProofTest {
+
+    @get:Rule
+    val compose = createAndroidComposeRule<ComponentActivity>()
+
+    // ----------------------------------------------------------- R1: dictation
+
+    /**
+     * The production fix: deriving `mode` keeps the body OFF the 20 Hz dictation
+     * amplitude churn — the body recomposes O(1) across an N-sample burst.
+     */
+    @Test
+    fun productionDerivedModeKeepsBodyOffDictationAmplitudeChurn() {
+        val dictation = mutableStateOf(InlineDictationViewModel.UiState())
+        val bodyRecompositions = AtomicLong(0L)
+
+        compose.setContent {
+            ProductionDictationBody(dictation = dictation, onBodyRecompose = {
+                bodyRecompositions.incrementAndGet()
+            })
+        }
+        compose.waitForIdle()
+
+        val recomps = driveDictationAmplitudeBurst(dictation, bodyRecompositions)
+        println(
+            "ISSUE1085_F3 R1 production_derived_mode amplitude_ticks=$TICKS " +
+                "body_recompositions=$recomps ceiling=$MAX_BODY_RECOMPOSITIONS",
+        )
+        assertTrue(
+            "#1085 (F3/R1): deriving the dictation MODE must keep the " +
+                "TmuxSessionScreen body OFF the 20 Hz amplitude churn. Over a " +
+                "$TICKS-sample amplitude burst (mode constant) the body recomposed " +
+                "$recomps times; the O(1) ceiling is $MAX_BODY_RECOMPOSITIONS.",
+            recomps <= MAX_BODY_RECOMPOSITIONS,
+        )
+    }
+
+    /**
+     * Pins the PRE-FIX behaviour: reading the WHOLE `uiState` in the body
+     * recomposes it once per amplitude sample (≈ N). Proves the assertion above is
+     * not vacuous — the regression is genuinely detectable.
+     */
+    @Test
+    fun legacyFullDictationStateReadRecomposesBodyPerAmplitudeTick() {
+        val dictation = mutableStateOf(InlineDictationViewModel.UiState())
+        val bodyRecompositions = AtomicLong(0L)
+
+        compose.setContent {
+            LegacyDictationBody(dictation = dictation, onBodyRecompose = {
+                bodyRecompositions.incrementAndGet()
+            })
+        }
+        compose.waitForIdle()
+
+        val recomps = driveDictationAmplitudeBurst(dictation, bodyRecompositions)
+        println(
+            "ISSUE1085_F3 R1 legacy_full_state_read amplitude_ticks=$TICKS " +
+                "body_recompositions=$recomps floor=$MIN_LEGACY_RECOMPOSITIONS",
+        )
+        assertTrue(
+            "#1085 (F3/R1) guard: the PRE-FIX whole-`uiState` read must recompose " +
+                "the body per amplitude sample (the regression the fix removes). " +
+                "Over a $TICKS-sample burst the legacy body recomposed only " +
+                "$recomps times — the test would not catch the regression. " +
+                "Expected >= $MIN_LEGACY_RECOMPOSITIONS.",
+            recomps >= MIN_LEGACY_RECOMPOSITIONS,
+        )
+    }
+
+    // ------------------------------------------------------- R2: agent stream
+
+    /**
+     * The production fix: reading only the STABLE [SurfaceConversationChrome]
+     * projection in the body keeps it OFF the 60ms agent-streaming flush — the
+     * body recomposes O(1) while the transcript child (which DOES read `events`)
+     * recomposes per flush (as it must, to show the stream).
+     */
+    @Test
+    fun productionSurfaceChromeKeepsBodyOffAgentStreamingFlush() {
+        val conversations = mutableStateOf(initialConversationMap())
+        val bodyRecompositions = AtomicLong(0L)
+        val transcriptRecompositions = AtomicLong(0L)
+
+        compose.setContent {
+            ProductionConversationBody(
+                conversations = conversations,
+                onBodyRecompose = { bodyRecompositions.incrementAndGet() },
+                onTranscriptRecompose = { transcriptRecompositions.incrementAndGet() },
+            )
+        }
+        compose.waitForIdle()
+
+        val (bodyRecomps, transcriptRecomps) =
+            driveStreamingFlushBurst(conversations, bodyRecompositions, transcriptRecompositions)
+        println(
+            "ISSUE1085_F3 R2 production_surface_chrome stream_flushes=$TICKS " +
+                "body_recompositions=$bodyRecomps transcript_recompositions=$transcriptRecomps " +
+                "body_ceiling=$MAX_BODY_RECOMPOSITIONS",
+        )
+        // LOAD-BEARING (G6): the body group stays flat across the streaming burst.
+        assertTrue(
+            "#1085 (F3/R2): reading the STABLE SurfaceConversationChrome projection " +
+                "must keep the TmuxSessionScreen body OFF the 60ms agent-streaming " +
+                "flush. Over $TICKS streaming flushes the body recomposed " +
+                "$bodyRecomps times; the O(1) ceiling is $MAX_BODY_RECOMPOSITIONS.",
+            bodyRecomps <= MAX_BODY_RECOMPOSITIONS,
+        )
+        // Sanity: the transcript child SHOULD recompose per flush — that is where
+        // the stream is shown. If it didn't, the test would be vacuously flat
+        // (nothing actually streaming).
+        assertTrue(
+            "#1085 (F3/R2): the transcript child must still recompose as the stream " +
+                "flushes ($transcriptRecomps over $TICKS flushes) — otherwise the " +
+                "burst is not exercising a real stream.",
+            transcriptRecomps >= MIN_LEGACY_RECOMPOSITIONS,
+        )
+    }
+
+    /**
+     * Pins the PRE-FIX behaviour: reading `agentConversations[paneId]` directly in
+     * the body recomposes it once per streaming flush (≈ N). Proves the production
+     * assertion above is not vacuous.
+     */
+    @Test
+    fun legacyDirectConversationReadRecomposesBodyPerStreamingFlush() {
+        val conversations = mutableStateOf(initialConversationMap())
+        val bodyRecompositions = AtomicLong(0L)
+        val transcriptRecompositions = AtomicLong(0L)
+
+        compose.setContent {
+            LegacyConversationBody(
+                conversations = conversations,
+                onBodyRecompose = { bodyRecompositions.incrementAndGet() },
+                onTranscriptRecompose = { transcriptRecompositions.incrementAndGet() },
+            )
+        }
+        compose.waitForIdle()
+
+        val (bodyRecomps, _) =
+            driveStreamingFlushBurst(conversations, bodyRecompositions, transcriptRecompositions)
+        println(
+            "ISSUE1085_F3 R2 legacy_direct_read stream_flushes=$TICKS " +
+                "body_recompositions=$bodyRecomps floor=$MIN_LEGACY_RECOMPOSITIONS",
+        )
+        assertTrue(
+            "#1085 (F3/R2) guard: the PRE-FIX direct agentConversations[paneId] read " +
+                "must recompose the body per streaming flush (the regression the fix " +
+                "removes). Over $TICKS flushes the legacy body recomposed only " +
+                "$bodyRecomps times — the test would not catch the regression. " +
+                "Expected >= $MIN_LEGACY_RECOMPOSITIONS.",
+            bodyRecomps >= MIN_LEGACY_RECOMPOSITIONS,
+        )
+    }
+
+    // --------------------------------------------------------------- drivers
+
+    /**
+     * Reset the counter, then emit [TICKS] amplitude samples (mode held constant,
+     * recording active) — the silence watchdog's 20 Hz `amplitude` rewrites.
+     * Returns the body recomposition count attributable to the burst.
+     */
+    private fun driveDictationAmplitudeBurst(
+        dictation: MutableState<InlineDictationViewModel.UiState>,
+        bodyRecompositions: AtomicLong,
+    ): Long {
+        compose.runOnIdle {
+            dictation.value = InlineDictationViewModel.UiState(
+                mode = InlineDictationViewModel.DictationMode.Prompt,
+                recording = InlineDictationViewModel.RecordingState.Recording,
+                amplitude = 0f,
+            )
+        }
+        compose.waitForIdle()
+        bodyRecompositions.set(0L)
+
+        for (tick in 1..TICKS) {
+            compose.runOnIdle {
+                // ONLY the amplitude changes — the mode is constant, exactly as the
+                // silence watchdog rewrites it every SAMPLE_INTERVAL_MS.
+                dictation.value = dictation.value.copy(amplitude = (tick % 10) / 10f)
+            }
+            compose.waitForIdle()
+        }
+        return bodyRecompositions.get()
+    }
+
+    /**
+     * Reset the counters, then emit [TICKS] streaming flushes (a fresh map with a
+     * growing `events` list; detection + selectedTab held constant) — the
+     * `tailBatchWindowMillis`=60ms agent-transcript flush. Returns
+     * `(body recompositions, transcript recompositions)` attributable to the burst.
+     */
+    private fun driveStreamingFlushBurst(
+        conversations: MutableState<Map<String, AgentConversationUiState>>,
+        bodyRecompositions: AtomicLong,
+        transcriptRecompositions: AtomicLong,
+    ): Pair<Long, Long> {
+        compose.runOnIdle { conversations.value = initialConversationMap() }
+        compose.waitForIdle()
+        bodyRecompositions.set(0L)
+        transcriptRecompositions.set(0L)
+
+        for (tick in 1..TICKS) {
+            compose.runOnIdle {
+                val prev = conversations.value.getValue(PANE_ID)
+                // A streaming flush: a FRESH map with one more event appended (the
+                // detection + selectedTab are unchanged — the stable projections).
+                conversations.value = mapOf(
+                    PANE_ID to prev.copy(events = prev.events + streamingEvent(tick)),
+                )
+            }
+            compose.waitForIdle()
+        }
+        return bodyRecompositions.get() to transcriptRecompositions.get()
+    }
+
+    // -------------------------------------------------------------- harnesses
+
+    /**
+     * PRODUCTION read structure for R1: derive just `mode` via `derivedStateOf`
+     * (exactly as [TmuxSessionScreen] does). The body reads only `mode`; a leaf
+     * reads the amplitude. The amplitude churn never invalidates the body group.
+     */
+    @Composable
+    private fun ProductionDictationBody(
+        dictation: MutableState<InlineDictationViewModel.UiState>,
+        onBodyRecompose: () -> Unit,
+    ) {
+        val dictationMode by remember(dictation) {
+            derivedStateOf { dictation.value.mode }
+        }
+        // Body reads ONLY the derived mode — record this body group's re-execution.
+        @Suppress("UNUSED_VARIABLE")
+        val modeForBody = dictationMode
+        onBodyRecompose()
+        // The amplitude is consumed by a leaf (the mic UI), which may recompose at
+        // 20 Hz — but it is its own restart group, not the body.
+        AmplitudeLeaf(dictation = dictation)
+    }
+
+    /**
+     * PRE-FIX read structure for R1: read the WHOLE `uiState` in the body, so every
+     * amplitude sample re-runs the body group.
+     */
+    @Composable
+    private fun LegacyDictationBody(
+        dictation: MutableState<InlineDictationViewModel.UiState>,
+        onBodyRecompose: () -> Unit,
+    ) {
+        val full by dictation
+        @Suppress("UNUSED_VARIABLE")
+        val modeForBody = full.mode
+        onBodyRecompose()
+        Box(modifier = Modifier.fillMaxSize())
+    }
+
+    @Composable
+    private fun AmplitudeLeaf(dictation: MutableState<InlineDictationViewModel.UiState>) {
+        @Suppress("UNUSED_VARIABLE")
+        val amplitude = dictation.value.amplitude
+        Box(modifier = Modifier.fillMaxSize())
+    }
+
+    /**
+     * PRODUCTION read structure for R2: the body reads only the STABLE
+     * [SurfaceConversationChrome] projection (the production data class) via
+     * `derivedStateOf`; the transcript child reads the high-frequency `events` list
+     * in its OWN restart group (mirroring the `surfaceContent` deferred read).
+     */
+    @Composable
+    private fun ProductionConversationBody(
+        conversations: MutableState<Map<String, AgentConversationUiState>>,
+        onBodyRecompose: () -> Unit,
+        onTranscriptRecompose: () -> Unit,
+    ) {
+        val surfaceChrome by remember(conversations) {
+            derivedStateOf {
+                val convo = conversations.value[PANE_ID]
+                SurfaceConversationChrome(
+                    detection = convo?.detection,
+                    selectedTab = convo?.selectedTab,
+                    hasEvents = convo?.events?.isNotEmpty() == true,
+                    exists = convo != null,
+                )
+            }
+        }
+        // Body reads ONLY the stable projection — record this body group's
+        // re-execution. The 60ms flush re-runs the projection lambda but, because
+        // the projected value is structurally equal mid-stream, does NOT invalidate
+        // the body.
+        @Suppress("UNUSED_VARIABLE")
+        val hasDetection = surfaceChrome.detection != null
+        @Suppress("UNUSED_VARIABLE")
+        val hasEvents = surfaceChrome.hasEvents
+        onBodyRecompose()
+        // The transcript reads the full conversation (its `events`) in its OWN
+        // restart group — exactly the `surfaceContent` non-inline child scope.
+        TranscriptChild(conversations = conversations, onTranscriptRecompose = onTranscriptRecompose)
+    }
+
+    /**
+     * PRE-FIX read structure for R2: read `agentConversations[paneId]` directly in
+     * the body, so every streaming flush re-runs the body group.
+     */
+    @Composable
+    private fun LegacyConversationBody(
+        conversations: MutableState<Map<String, AgentConversationUiState>>,
+        onBodyRecompose: () -> Unit,
+        onTranscriptRecompose: () -> Unit,
+    ) {
+        val convo = conversations.value[PANE_ID]
+        @Suppress("UNUSED_VARIABLE")
+        val hasDetection = convo?.detection != null
+        @Suppress("UNUSED_VARIABLE")
+        val events = convo?.events
+        onBodyRecompose()
+        TranscriptChild(conversations = conversations, onTranscriptRecompose = onTranscriptRecompose)
+    }
+
+    @Composable
+    private fun TranscriptChild(
+        conversations: MutableState<Map<String, AgentConversationUiState>>,
+        onTranscriptRecompose: () -> Unit,
+    ) {
+        @Suppress("UNUSED_VARIABLE")
+        val events = conversations.value[PANE_ID]?.events.orEmpty()
+        onTranscriptRecompose()
+        Box(modifier = Modifier.fillMaxSize())
+    }
+
+    private companion object {
+        const val TICKS = 20
+        const val PANE_ID = "%1"
+
+        // O(1) ceiling: the body recomposes at most a small constant across the
+        // N-tick burst (the stable projection changes 0–1 times). 3 leaves slack
+        // for a settling frame.
+        const val MAX_BODY_RECOMPOSITIONS = 3L
+
+        // The pre-fix read recomposes the body ~once per tick; require most of the
+        // N ticks so the guard genuinely proves the regression is detectable.
+        const val MIN_LEGACY_RECOMPOSITIONS = (TICKS - 4).toLong()
+
+        fun initialConversationMap(): Map<String, AgentConversationUiState> = mapOf(
+            PANE_ID to AgentConversationUiState(
+                detection = AgentDetection(
+                    agent = AgentKind.ClaudeCode,
+                    sourcePath = "/home/dev/.claude/projects/x/session.jsonl",
+                    sessionId = "sess-1",
+                    confidence = AgentDetection.Confidence.ProcessConfirmed,
+                ),
+                events = listOf(streamingEvent(0)),
+                selectedTab = com.pocketshell.app.session.SessionTab.Conversation,
+            ),
+        )
+
+        fun streamingEvent(seq: Int): ConversationEvent = ConversationEvent.Message(
+            id = "evt-$seq",
+            agent = AgentKind.ClaudeCode,
+            role = ConversationRole.Assistant,
+            text = "streamed chunk $seq",
+            streaming = true,
+        )
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/App.kt
+++ b/app/src/main/java/com/pocketshell/app/App.kt
@@ -1,6 +1,7 @@
 package com.pocketshell.app
 
 import android.app.Application
+import android.os.SystemClock
 import android.util.Log
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
@@ -156,7 +157,15 @@ class App : Application() {
     private val terminalNetworkScope: CoroutineScope =
         CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
 
-    private val terminalNetworkLifecycleGate = TerminalNetworkLifecycleGate()
+    private val terminalNetworkLifecycleGate = TerminalNetworkLifecycleGate(
+        // Issue #1080 — wall-elapsed boot clock (counts deep sleep). The
+        // background-elapsed / post-resume-suppression decisions here are the
+        // App-level sibling of the transport-liveness staleness clock; on
+        // System.nanoTime they froze across a Doze gap and mis-evaluated the
+        // grace/suppression windows. Production injects the boot clock; the unit
+        // tests keep the System.nanoTime default (android.jar stub).
+        nowMillis = { SystemClock.elapsedRealtime() },
+    )
 
     /**
      * Issue #450: scope that runs the bounded grace-window timer. Uses
@@ -253,6 +262,17 @@ class App : Application() {
                     hasLiveTerminalRuntime = runtimeDiagnostics.hasLiveTerminalRuntime,
                 ).diagnosticFields()
         },
+        // Issue #1080 — wall-elapsed boot clock so the within-grace vs
+        // beyond-grace decision (`resumedWithinGrace`, `backgroundDeadlineAtMs`,
+        // background elapsed) counts time spent in deep sleep. On System.nanoTime
+        // (CLOCK_MONOTONIC, frozen in deep Doze) a Doze gap that began within the
+        // ~60s grace window made the frozen clock under-count elapsed time and
+        // `resumedWithinGrace` could wrongly evaluate true — routing the resume
+        // into the within-grace reseed-only fast path that does ZERO liveness
+        // check over a now-dead socket. The boot clock makes the window math
+        // reflect real elapsed time so the beyond-grace arm (which verifies
+        // liveness) runs. Unit tests keep the System.nanoTime default.
+        nowMillis = { SystemClock.elapsedRealtime() },
     )
 
     private val terminalLifecycleObserver = LifecycleEventObserver { _: LifecycleOwner, event ->
@@ -655,6 +675,9 @@ internal fun shouldDispatchPendingTerminalNetworkChange(
 }
 
 internal class TerminalNetworkLifecycleGate(
+    // Issue #1080 — production injects `SystemClock.elapsedRealtime()` (counts
+    // deep sleep). This System.nanoTime default is the pure-JVM unit-test
+    // fallback only (the android.jar stub throws on SystemClock).
     private val nowMillis: () -> Long = { System.nanoTime() / 1_000_000L },
 ) {
     private var processForeground: Boolean = false
@@ -998,6 +1021,11 @@ internal class BackgroundGraceController(
     private var graceMillis: Long,
     private val onGraceElapsed: suspend () -> Unit,
     private val onForeground: suspend (resumedWithinGrace: Boolean) -> Unit,
+    // Issue #1080 — production injects `SystemClock.elapsedRealtime()` (counts
+    // deep sleep) so the within-grace/beyond-grace window math reflects real
+    // elapsed time across a Doze gap. This System.nanoTime default is the
+    // pure-JVM unit-test fallback only (the android.jar stub throws on
+    // SystemClock); the deterministic tests inject their own virtual clock.
     private val nowMillis: () -> Long = { System.nanoTime() / 1_000_000L },
     private val foregroundDiagnosticFields: (resumedWithinGrace: Boolean) -> List<Pair<String, Any?>> = {
         emptyList()

--- a/app/src/main/java/com/pocketshell/app/AppTeardownScope.kt
+++ b/app/src/main/java/com/pocketshell/app/AppTeardownScope.kt
@@ -1,0 +1,47 @@
+package com.pocketshell.app
+
+import android.util.Log
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+
+/**
+ * Issue #1085 (F2): a single process-lifetime [CoroutineScope] that owns the
+ * SLOW connection-teardown IO handed off from a ViewModel's `onCleared` —
+ * the warm-lease refcount-- ([com.pocketshell.core.ssh.SshLease.release]), the
+ * raw SSH-socket close, and the tmux `detach-client` round-trip.
+ *
+ * `onCleared` runs on the MAIN thread. On a half-open / wedged transport (the
+ * maintainer's WIFI↔cellular handoff scenario), the SSH/lease close rides its
+ * full bounded ceiling, and a nested `runBlocking` socket close in
+ * `RealSshShell` / `RealSshSession` cannot be interrupted by a coroutine
+ * timeout — so doing the teardown synchronously on Main parks the UI thread for
+ * multiple seconds, an ANR backing out of a screen (#1085 F2). Handing the work
+ * to THIS scope lets `onCleared` return immediately while the slow close still
+ * runs to COMPLETION in the background:
+ *
+ * - The scope is a process singleton — it OUTLIVES every ViewModel and is never
+ *   cancelled, so the refcount is always decremented and the socket always
+ *   closed even though the VM is already gone (no lease leak).
+ * - [SupervisorJob] so one VM's teardown failure cannot cancel another's.
+ * - [Dispatchers.IO] because the work is blocking socket / transport IO.
+ * - A [CoroutineExceptionHandler] is installed so an unexpected uncaught throw
+ *   in a teardown coroutine is logged rather than reaching the thread's
+ *   default uncaught handler (process death). Callers still wrap each step in
+ *   `runCatching`; this is the belt-and-suspenders net.
+ *
+ * ViewModels default their teardown scope to [scope] and override it in tests
+ * (via a `setTeardownScopeForTest` seam) so a unit test can drive the hand-off
+ * deterministically and confirm the teardown completed off the Main thread.
+ */
+public object AppTeardownScope {
+    private const val TAG = "AppTeardownScope"
+
+    private val exceptionHandler = CoroutineExceptionHandler { _, throwable ->
+        Log.w(TAG, "connection teardown coroutine failed", throwable)
+    }
+
+    public val scope: CoroutineScope =
+        CoroutineScope(SupervisorJob() + Dispatchers.IO + exceptionHandler)
+}

--- a/app/src/main/java/com/pocketshell/app/git/GitHistoryViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/git/GitHistoryViewModel.kt
@@ -2,6 +2,7 @@ package com.pocketshell.app.git
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.pocketshell.app.AppTeardownScope
 import com.pocketshell.core.ssh.KnownHostsPolicy
 import com.pocketshell.core.ssh.SshKey
 import com.pocketshell.core.ssh.SshLease
@@ -12,10 +13,10 @@ import com.pocketshell.core.ssh.SshSession
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -143,6 +144,38 @@ class GitHistoryViewModel @Inject constructor(
     private var ioDispatcher: CoroutineDispatcher = Dispatchers.IO
     private var bestEffortProbeTimeoutMs: Long = BEST_EFFORT_PROBE_TIMEOUT_MS
     private var createIssueTimeoutMs: Long = CREATE_ISSUE_TIMEOUT_MS
+
+    /**
+     * Issue #1085 (F2): the application-scoped coroutine the warm-lease
+     * refcount-- is handed to so [onCleared] never parks the Main thread on a
+     * wedged transport close. Defaults to the process singleton
+     * [AppTeardownScope.scope]; a unit test pins it via
+     * [setTeardownScopeForTest] to observe the off-Main hand-off
+     * deterministically.
+     */
+    private var teardownScope: CoroutineScope = AppTeardownScope.scope
+
+    @androidx.annotation.VisibleForTesting
+    internal fun setTeardownScopeForTest(scope: CoroutineScope) {
+        teardownScope = scope
+    }
+
+    /**
+     * Test seam: drive the protected [onCleared] lifecycle event (the
+     * nav-scoped back/navigate-away teardown) without booting an Android
+     * lifecycle owner. Mirrors [com.pocketshell.app.tmux.TmuxSessionViewModel]'s
+     * `clearForTest`.
+     */
+    @androidx.annotation.VisibleForTesting
+    internal fun clearForTest() {
+        onCleared()
+    }
+
+    /** Test seam (#1085 F2): seed the held warm lease the teardown releases. */
+    @androidx.annotation.VisibleForTesting
+    internal fun setLeaseForTest(lease: SshLease?) {
+        this.lease = lease
+    }
 
     /**
      * Bind host credentials + the project directory and load it. Idempotent for
@@ -352,17 +385,24 @@ class GitHistoryViewModel @Inject constructor(
     override fun onCleared() {
         loadJob?.cancel()
         createJob?.cancel()
-        // Issue #699: refcount-- the warm transport SYNCHRONOUSLY before the VM
-        // dies. A viewModelScope.launch here would race the framework's
-        // post-onCleared scope cancellation and could leak the refcount, so we
-        // release on a bounded IO hop — mirroring TmuxSessionViewModel's
-        // teardown. Releasing only decrements the pool refcount; the warm
+        // Issue #1085 (F2): refcount-- the warm transport OFF the Main thread.
+        // This screen's VM is `hiltViewModel()` nav-scoped, so `onCleared` fires
+        // on an ordinary foreground back/navigate-away ON the Main thread. The
+        // previous `runBlocking(Dispatchers.IO){ withTimeoutOrNull(2000){
+        // release() } }` parked Main for up to the full ceiling on a half-open
+        // transport (post WIFI↔cellular handoff) — a multi-second UI freeze
+        // backing out of git history. We instead hand the release to the
+        // application-scoped [teardownScope] (it OUTLIVES this VM and is never
+        // cancelled, so the refcount is still decremented to completion — no
+        // race with the framework's post-onCleared scope cancellation that the
+        // #699 comment worried about, because this scope is NOT viewModelScope,
+        // and no leak). Releasing only decrements the pool refcount; the warm
         // transport itself stays pooled (idle-TTL) for the next surface.
         val toRelease = lease
         lease = null
         if (toRelease != null) {
-            runCatching {
-                runBlocking(Dispatchers.IO + NonCancellable) {
+            teardownScope.launch {
+                runCatching {
                     withTimeoutOrNull(LEASE_RELEASE_TIMEOUT_MS) { toRelease.release() }
                 }
             }

--- a/app/src/main/java/com/pocketshell/app/hosts/HostListViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/hosts/HostListViewModel.kt
@@ -695,7 +695,12 @@ class HostListViewModel internal constructor(
                     .forEach { host ->
                         val key = sshKeyDao.getById(host.keyId) ?: return@forEach
                         if (key.hasPassphrase) return@forEach
-                        if (!File(key.privateKeyPath).exists()) return@forEach
+                        // #1085: this launch runs on Dispatchers.Main.immediate;
+                        // keep the key-file disk stat off the Main thread.
+                        val keyFileExists = withContext(Dispatchers.IO) {
+                            File(key.privateKeyPath).exists()
+                        }
+                        if (!keyFileExists) return@forEach
                         StartupTiming.markOnce(
                             "hostlist-reprobe-ssh-start",
                             "hostId" to host.id,
@@ -1792,8 +1797,12 @@ internal class LeaseBackedHostSessionOpener(
         java.util.Collections.synchronizedMap(IdentityHashMap())
 
     override suspend fun open(host: HostEntity, keyPath: String, passphrase: CharArray?): SshSession? {
+        // #1085 (freeze cause F1, secondary): `File.exists()` is a synchronous
+        // disk stat. This suspend fn can be driven on the Main dispatcher on the
+        // hot session-open/retry path, so probe the key file off-main.
         val file = File(keyPath)
-        if (!file.exists()) return null
+        val exists = withContext(Dispatchers.IO) { file.exists() }
+        if (!exists) return null
         val target = SshLeaseTarget(
             leaseKey = SshLeaseKey(
                 host = host.hostname,

--- a/app/src/main/java/com/pocketshell/app/jobs/RecurringJobsViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/jobs/RecurringJobsViewModel.kt
@@ -2,6 +2,7 @@ package com.pocketshell.app.jobs
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.pocketshell.app.AppTeardownScope
 import com.pocketshell.core.ssh.KnownHostsPolicy
 import com.pocketshell.core.ssh.SshKey
 import com.pocketshell.core.ssh.SshLease
@@ -11,6 +12,7 @@ import com.pocketshell.core.ssh.SshLeaseTarget
 import com.pocketshell.core.ssh.SshSession
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -20,7 +22,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeoutOrNull
@@ -57,6 +58,32 @@ public class RecurringJobsViewModel @Inject constructor(
     private var leaseTarget: Target? = null
     private var commandMutex = Mutex()
     private val activeOperations = mutableSetOf<Job>()
+
+    /**
+     * Issue #1085 (F2): the application-scoped coroutine the warm-lease
+     * refcount-- is handed to so [onCleared] never parks the Main thread on a
+     * wedged transport close. Defaults to the process singleton
+     * [AppTeardownScope.scope]; a unit test pins it via
+     * [setTeardownScopeForTest] to observe the off-Main hand-off
+     * deterministically.
+     */
+    private var teardownScope: CoroutineScope = AppTeardownScope.scope
+
+    @androidx.annotation.VisibleForTesting
+    internal fun setTeardownScopeForTest(scope: CoroutineScope) {
+        teardownScope = scope
+    }
+
+    /**
+     * Test seam: drive the protected [onCleared] lifecycle event (the
+     * nav-scoped back/navigate-away teardown) without booting an Android
+     * lifecycle owner. Mirrors [com.pocketshell.app.tmux.TmuxSessionViewModel]'s
+     * `clearForTest`.
+     */
+    @androidx.annotation.VisibleForTesting
+    internal fun clearForTest() {
+        onCleared()
+    }
 
     public fun load(
         hostId: Long,
@@ -254,19 +281,27 @@ public class RecurringJobsViewModel @Inject constructor(
     }
 
     override fun onCleared() {
-        // Issue #699: refcount-- the warm transport SYNCHRONOUSLY before the VM
-        // dies. A viewModelScope.launch here would race the framework's
-        // post-onCleared scope cancellation and could leak the refcount, so we
-        // release on a bounded IO hop — mirroring TmuxSessionViewModel's
-        // teardown. Releasing only decrements the pool refcount; the warm
-        // transport itself stays pooled (idle-TTL) for the next surface.
+        // Issue #1085 (F2): refcount-- the warm transport OFF the Main thread.
+        // This screen's VM is `hiltViewModel()` nav-scoped, so `onCleared` fires
+        // on an ordinary foreground back/navigate-away ON the Main thread. The
+        // previous `runBlocking(Dispatchers.IO){ withTimeoutOrNull(2000){
+        // release() } }` parked Main for up to the full ceiling on a half-open
+        // transport (post WIFI↔cellular handoff) — a multi-second UI freeze
+        // backing out of the recurring-jobs panel. We instead hand the release
+        // to the application-scoped [teardownScope] (it OUTLIVES this VM and is
+        // never cancelled, so the refcount is still decremented to completion —
+        // no race with the framework's post-onCleared scope cancellation that
+        // the #699 comment worried about, because this scope is NOT
+        // viewModelScope, and no leak). Releasing only decrements the pool
+        // refcount; the warm transport itself stays pooled (idle-TTL) for the
+        // next surface.
         val toRelease = lease
         lease = null
         leaseTarget = null
         cancelActiveOperations()
         if (toRelease != null) {
-            runCatching {
-                runBlocking(Dispatchers.IO + NonCancellable) {
+            teardownScope.launch {
+                runCatching {
                     withTimeoutOrNull(LEASE_RELEASE_TIMEOUT_MS) { toRelease.release() }
                 }
             }

--- a/app/src/main/java/com/pocketshell/app/notifications/UpdateNotificationStore.kt
+++ b/app/src/main/java/com/pocketshell/app/notifications/UpdateNotificationStore.kt
@@ -2,6 +2,14 @@ package com.pocketshell.app.notifications
 
 import android.content.Context
 import android.content.SharedPreferences
+import androidx.annotation.VisibleForTesting
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
 
 /**
  * De-dupe ledger for the "new app version available" notification
@@ -22,11 +30,62 @@ import android.content.SharedPreferences
  * release that is strictly newer than the installed version, so the last
  * notified tag changes monotonically and an exact match is sufficient to
  * mean "already notified this exact release".
+ *
+ * ## Off-main construction (issue #1087, freeze cause F6 class sweep)
+ *
+ * This store is built during `App.onCreate` Hilt injection (the `@Singleton`
+ * `UpdateNotifier` graph) — on the Main thread, before the first frame.
+ * `getSharedPreferences(...)` does a synchronous first-touch disk read, so
+ * building it eagerly in the constructor blocked Main during cold launch (the
+ * identical class StrictMode flagged for `LastSessionStore.<init>`; built
+ * before `StrictModeInstaller` arms so it is not in the log but is the same
+ * Main-thread launch cost). The build is moved off-main onto [ioDispatcher]
+ * (eager [async]); the getter warms-or-awaits. Reads run off-main from the
+ * scheduler IO scope / the notifier, so the cache is warm before any read.
+ * Hard-cut (D22): no synchronous on-Main fallback.
  */
-class UpdateNotificationStore(context: Context) {
+class UpdateNotificationStore @JvmOverloads constructor(
+    context: Context,
+    ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+) {
 
-    private val prefs: SharedPreferences = context.applicationContext
-        .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    private val appContext: Context = context.applicationContext
+
+    @Volatile
+    private var cachedPrefs: SharedPreferences? = null
+
+    @Volatile
+    private var prefsBuildThreadName: String? = null
+
+    private val warmUpScope = CoroutineScope(SupervisorJob() + ioDispatcher)
+    private val prefsDeferred: Deferred<SharedPreferences> = warmUpScope.async {
+        prefsBuildThreadName = currentPhysicalThreadName()
+        appContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .also { cachedPrefs = it }
+    }
+
+    private val prefs: SharedPreferences
+        get() = cachedPrefs ?: runBlocking { prefsDeferred.await() }
+
+    /**
+     * Test-only: block until the off-main build completes and return the name
+     * of the thread it ran on (#1087). Proves the prefs-file build did NOT run
+     * on the constructing/Main thread.
+     */
+    @VisibleForTesting
+    internal fun awaitPrefsBuildThreadNameForTest(): String {
+        runBlocking { prefsDeferred.await() }
+        return prefsBuildThreadName
+            ?: error("prefs build thread was not recorded")
+    }
+
+    // The build runs inside a coroutine, whose framework decorates the thread
+    // name with a " @coroutine#N" suffix. Strip it so the recorded value is the
+    // PHYSICAL thread name — otherwise an on-Main build (e.g. the un-fixed base)
+    // would still differ from the captured constructing name by the suffix alone,
+    // giving a false off-main pass (#1087 G6: keep the assertion load-bearing).
+    private fun currentPhysicalThreadName(): String =
+        Thread.currentThread().name.substringBefore(" @coroutine")
 
     /** The release tag last surfaced as a notification, or `null`. */
     fun lastNotifiedTag(): String? =

--- a/app/src/main/java/com/pocketshell/app/release/UpdateCheckStore.kt
+++ b/app/src/main/java/com/pocketshell/app/release/UpdateCheckStore.kt
@@ -2,6 +2,14 @@ package com.pocketshell.app.release
 
 import android.content.Context
 import android.content.SharedPreferences
+import androidx.annotation.VisibleForTesting
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
 
 /**
  * Throttle ledger for the foreground update check (issue #698). Persists
@@ -22,11 +30,62 @@ import android.content.SharedPreferences
  * [com.pocketshell.app.settings.AppSettings] because this is bookkeeping
  * state, not a user-facing preference. Mirrors the lightweight pref-store
  * pattern already used by [com.pocketshell.app.notifications.UpdateNotificationStore].
+ *
+ * ## Off-main construction (issue #1087, freeze cause F6 class sweep)
+ *
+ * This store is built during `App.onCreate` Hilt injection (the `@Singleton`
+ * [UpdateCheckScheduler] graph) — on the Main thread, before the first frame.
+ * `getSharedPreferences(...)` does a synchronous first-touch disk read, so
+ * building it eagerly in the constructor blocked Main during cold launch (the
+ * same class StrictMode flagged for `LastSessionStore.<init>`; this one is
+ * built before `StrictModeInstaller` arms, so it is not in the log but is the
+ * identical Main-thread launch cost). The build is moved off-main onto
+ * [ioDispatcher] (eager [async]); the getter warms-or-awaits. Reads run on the
+ * scheduler's `Dispatchers.IO` scope, so the cache is warm before any read.
+ * Hard-cut (D22): no synchronous on-Main fallback.
  */
-class UpdateCheckStore(context: Context) {
+class UpdateCheckStore @JvmOverloads constructor(
+    context: Context,
+    ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+) {
 
-    private val prefs: SharedPreferences = context.applicationContext
-        .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    private val appContext: Context = context.applicationContext
+
+    @Volatile
+    private var cachedPrefs: SharedPreferences? = null
+
+    @Volatile
+    private var prefsBuildThreadName: String? = null
+
+    private val warmUpScope = CoroutineScope(SupervisorJob() + ioDispatcher)
+    private val prefsDeferred: Deferred<SharedPreferences> = warmUpScope.async {
+        prefsBuildThreadName = currentPhysicalThreadName()
+        appContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .also { cachedPrefs = it }
+    }
+
+    private val prefs: SharedPreferences
+        get() = cachedPrefs ?: runBlocking { prefsDeferred.await() }
+
+    /**
+     * Test-only: block until the off-main build completes and return the name
+     * of the thread it ran on (#1087). Proves the prefs-file build did NOT run
+     * on the constructing/Main thread.
+     */
+    @VisibleForTesting
+    internal fun awaitPrefsBuildThreadNameForTest(): String {
+        runBlocking { prefsDeferred.await() }
+        return prefsBuildThreadName
+            ?: error("prefs build thread was not recorded")
+    }
+
+    // The build runs inside a coroutine, whose framework decorates the thread
+    // name with a " @coroutine#N" suffix. Strip it so the recorded value is the
+    // PHYSICAL thread name — otherwise an on-Main build (e.g. the un-fixed base)
+    // would still differ from the captured constructing name by the suffix alone,
+    // giving a false off-main pass (#1087 G6: keep the assertion load-bearing).
+    private fun currentPhysicalThreadName(): String =
+        Thread.currentThread().name.substringBefore(" @coroutine")
 
     /**
      * The wall-clock millis of the last completed update check, or `0L`

--- a/app/src/main/java/com/pocketshell/app/session/LastSessionStore.kt
+++ b/app/src/main/java/com/pocketshell/app/session/LastSessionStore.kt
@@ -3,8 +3,16 @@ package com.pocketshell.app.session
 import android.content.Context
 import android.content.SharedPreferences
 import android.util.Log
+import androidx.annotation.VisibleForTesting
 import com.pocketshell.app.nav.AppDestination
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -39,14 +47,81 @@ import javax.inject.Singleton
  *
  * Singleton scope so the activity and any future consumer share one
  * instance over the same prefs file.
+ *
+ * ## Off-main construction (issue #1087, freeze cause F6)
+ *
+ * `getSharedPreferences(...)` does a synchronous disk read the first time a
+ * prefs file is touched in a process. Building it eagerly in the constructor
+ * ran that read **on the Main thread** — StrictMode captured a 69–117ms
+ * `DiskReadViolation` in `LastSessionStore.<init>` during cold-launch Hilt
+ * injection (`MainActivity.onCreate` → `injectMainActivity2`). It was the next
+ * dominant cold-launch stall after the F1 keystore (#1085) and F5
+ * `SystemSurfaceStateStore` (#1086) blocks were fixed.
+ *
+ * The fix mirrors F5's [com.pocketshell.app.systemsurfaces.SystemSurfaceStateStore]:
+ * the constructor never reads the prefs file on the calling thread. It only
+ * *kicks off* the build on [ioDispatcher] (an eager [async]) and returns
+ * immediately, so `<init>` never blocks the constructing (Main) thread. The
+ * first read warms-or-awaits that background result; on a fresh cold launch
+ * [read] is never called (only on the process-death resume path), so the
+ * background build is virtually always warm before any read. Hard-cut (D22):
+ * there is no synchronous on-Main fallback.
  */
 @Singleton
-class LastSessionStore @Inject constructor(
-    @ApplicationContext context: Context,
+class LastSessionStore @VisibleForTesting internal constructor(
+    context: Context,
+    ioDispatcher: CoroutineDispatcher,
 ) {
 
-    private val prefs: SharedPreferences = context.applicationContext
-        .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    @Inject
+    constructor(@ApplicationContext context: Context) : this(context, Dispatchers.IO)
+
+    private val appContext: Context = context.applicationContext
+
+    // Once the background build completes, the result is cached here so reads
+    // never re-enter runBlocking. @Volatile: written on [ioDispatcher], read
+    // from any consumer thread.
+    @Volatile
+    private var cachedPrefs: SharedPreferences? = null
+
+    // Test seam (#1087): records the name of the thread the prefs-file build
+    // actually ran on, so the regression test can hard-assert it is NOT the
+    // constructing/Main thread. Written on [ioDispatcher].
+    @Volatile
+    private var prefsBuildThreadName: String? = null
+
+    // Eager async: the build STARTS at construction but on a background thread.
+    // `async` (DEFAULT start) dispatches immediately and returns without
+    // blocking the caller.
+    private val warmUpScope = CoroutineScope(SupervisorJob() + ioDispatcher)
+    private val prefsDeferred: Deferred<SharedPreferences> = warmUpScope.async {
+        prefsBuildThreadName = currentPhysicalThreadName()
+        appContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .also { cachedPrefs = it }
+    }
+
+    private val prefs: SharedPreferences
+        get() = cachedPrefs ?: runBlocking { prefsDeferred.await() }
+
+    /**
+     * Test-only: block until the off-main build completes and return the name
+     * of the thread it ran on. Lets the regression test prove the prefs-file
+     * construction did NOT happen on the constructing/Main thread (#1087).
+     */
+    @VisibleForTesting
+    internal fun awaitPrefsBuildThreadNameForTest(): String {
+        runBlocking { prefsDeferred.await() }
+        return prefsBuildThreadName
+            ?: error("prefs build thread was not recorded")
+    }
+
+    // The build runs inside a coroutine, whose framework decorates the thread
+    // name with a " @coroutine#N" suffix. Strip it so the recorded value is the
+    // PHYSICAL thread name — otherwise an on-Main build (e.g. the un-fixed base)
+    // would still differ from the captured constructing name by the suffix alone,
+    // giving a false off-main pass (#1087 G6: keep the assertion load-bearing).
+    private fun currentPhysicalThreadName(): String =
+        Thread.currentThread().name.substringBefore(" @coroutine")
 
     /**
      * Issue #834: identity of the most recently killed session, remembered in

--- a/app/src/main/java/com/pocketshell/app/sessions/SessionsDashboardViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/sessions/SessionsDashboardViewModel.kt
@@ -10,7 +10,9 @@ import com.pocketshell.core.tmux.TmuxClient
 import com.pocketshell.core.tmux.protocol.ControlEvent
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
@@ -87,6 +89,13 @@ class SessionsDashboardViewModel @Inject constructor(
 
     /** Override hook for tests — see [SessionsDashboardViewModelTest]. */
     internal var pollIntervalMs: Long = DEFAULT_POLL_INTERVAL_MS
+
+    /**
+     * Dispatcher the active-session-count persistence runs on. Defaults to
+     * [Dispatchers.IO] so the [SystemSurfaceStateStore] disk read never lands
+     * on the Main thread (issue #1086, freeze cause F5). Overridable for tests.
+     */
+    internal var ioDispatcher: CoroutineDispatcher = Dispatchers.IO
 
     private val _sessions: MutableStateFlow<List<SessionSummary>> =
         MutableStateFlow(emptyList())
@@ -240,10 +249,25 @@ class SessionsDashboardViewModel @Inject constructor(
         persistActiveSessionCount(sorted.size)
     }
 
+    /**
+     * Persist the live active-session count to the cross-surface store and
+     * refresh the home-screen widget.
+     *
+     * Issue #1086 (freeze cause F5): the [SystemSurfaceStateStore] prefs-file
+     * read is a ~648ms first-touch disk read. This is reached from
+     * [emitAggregate] on `viewModelScope` (Main), so it used to stall the
+     * cold-launch UI thread. We dispatch the construct-and-write onto
+     * [ioDispatcher] (default [Dispatchers.IO]) so neither the store build nor
+     * the write ever blocks Main. The count is idempotent (last write wins) and
+     * `apply()` writes are serialised by SharedPreferences, so dispatching each
+     * emission is safe.
+     */
     private fun persistActiveSessionCount(count: Int) {
         val context = appContext ?: return
-        SystemSurfaceStateStore(context).setActiveSessionCount(count)
-        ActiveSessionsWidgetProvider.updateAll(context)
+        viewModelScope.launch(ioDispatcher) {
+            SystemSurfaceStateStore(context).setActiveSessionCount(count)
+            ActiveSessionsWidgetProvider.updateAll(context)
+        }
     }
 
     override fun onCleared() {

--- a/app/src/main/java/com/pocketshell/app/systemsurfaces/SystemSurfaceState.kt
+++ b/app/src/main/java/com/pocketshell/app/systemsurfaces/SystemSurfaceState.kt
@@ -2,15 +2,88 @@ package com.pocketshell.app.systemsurfaces
 
 import android.content.Context
 import android.content.SharedPreferences
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
 
 data class SessionWidgetState(
     val activeSessionCount: Int,
 )
 
-class SystemSurfaceStateStore(
+/**
+ * Plaintext SharedPreferences store for cross-surface session state
+ * (the active-session widget count).
+ *
+ * ## Off-main construction (issue #1086, freeze cause F5)
+ *
+ * `getSharedPreferences(...)` does a synchronous disk read the first time a
+ * prefs file is touched in a process. Building it eagerly in the constructor
+ * ran that read **on the Main thread** — StrictMode captured a ~648ms
+ * `DiskReadViolation` in `SystemSurfaceStateStore.<init>` during cold-launch
+ * composition (reached via
+ * [com.pocketshell.app.sessions.SessionsDashboardViewModel.persistActiveSessionCount]).
+ * It was previously masked behind the F1 keystore block (#1085); once F1 was
+ * fixed this became the dominant remaining cold-launch stall.
+ *
+ * The fix mirrors F1's `AndroidKeystoreAssistantConfigStore`: the constructor
+ * never reads the prefs file on the calling thread. It only *kicks off* the
+ * build on [ioDispatcher] (an eager [async]) and returns immediately. The
+ * build runs on a background thread, so `<init>` never blocks the constructing
+ * (Main) thread. The first read warms-or-awaits that background result; the
+ * [com.pocketshell.app.sessions.SessionsDashboardViewModel] persist path is
+ * itself dispatched off-main so its first read also never lands on Main.
+ * Hard-cut (D22): there is no synchronous on-Main fallback.
+ *
+ * @param context any Context; the application context is held internally so an
+ *   Activity isn't pinned.
+ * @param ioDispatcher dispatcher the prefs file is built on; defaults to
+ *   [Dispatchers.IO]. Overridable for tests.
+ */
+class SystemSurfaceStateStore @JvmOverloads constructor(
     context: Context,
+    ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) {
-    private val prefs = context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    private val appContext = context.applicationContext
+
+    // Once the background build completes, the result is cached here so reads
+    // never re-enter runBlocking. @Volatile: written on [ioDispatcher], read
+    // from any consumer thread.
+    @Volatile
+    private var cachedPrefs: SharedPreferences? = null
+
+    // Test seam (issue #1086): records the name of the thread the prefs file
+    // build actually ran on, so a regression test can hard-assert it is NOT
+    // the constructing/Main thread. Written on [ioDispatcher].
+    @Volatile
+    private var prefsBuildThreadName: String? = null
+
+    // Eager async: the build STARTS at construction but on a background thread.
+    // `async` (DEFAULT start) dispatches immediately and returns without
+    // blocking the caller.
+    private val warmUpScope = CoroutineScope(SupervisorJob() + ioDispatcher)
+    private val prefsDeferred: Deferred<SharedPreferences> = warmUpScope.async {
+        prefsBuildThreadName = Thread.currentThread().name
+        appContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .also { cachedPrefs = it }
+    }
+
+    private val prefs: SharedPreferences
+        get() = cachedPrefs ?: runBlocking { prefsDeferred.await() }
+
+    /**
+     * Test-only: block until the off-main build completes and return the name
+     * of the thread it ran on. Lets a regression test prove the prefs-file
+     * construction did NOT happen on the constructing/Main thread (#1086).
+     */
+    internal fun awaitPrefsBuildThreadNameForTest(): String {
+        runBlocking { prefsDeferred.await() }
+        return prefsBuildThreadName
+            ?: error("prefs build thread was not recorded")
+    }
 
     fun readSessionWidgetState(): SessionWidgetState =
         SessionWidgetState(

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
@@ -170,6 +170,7 @@ import com.pocketshell.uikit.components.ButtonVariant
 import com.pocketshell.uikit.components.CommandChip
 import com.pocketshell.uikit.components.DisclosureIcon
 import com.pocketshell.uikit.components.PocketShellButton
+import com.pocketshell.core.agents.AgentDetection
 import com.pocketshell.core.agents.AgentKind
 import com.pocketshell.core.agents.ConversationEvent
 import com.pocketshell.core.agents.ToolArgsView
@@ -498,14 +499,41 @@ public fun TmuxSessionScreen(
     // bottom now shares the unified [PromptComposerSheet], whose draft
     // persists in [PromptComposerViewModel], so there is nothing to seed
     // here on the screen.
-    val agentConversations by viewModel.agentConversations.collectAsState()
+    // Issue #1085 (freeze F3 / R2 — agent-streaming recomposition jank): the
+    // agent transcript tail flushes a fresh `agentConversations` map every
+    // `tailBatchWindowMillis`=60ms while an agent is streaming (~16 Hz). Held as
+    // a `State<Map<...>>` (NOT a delegated `by` read) so the body's ROOT restart
+    // group is never subscribed to that 16 Hz churn directly: the body reads
+    // only STABLE projections of the surface pane's conversation via
+    // `derivedStateOf` (below), and the high-frequency `events` list is read
+    // inside the `surfaceContent` child scope — its OWN restart group — so a
+    // streaming flush recomposes ONLY the transcript view, not the chrome /
+    // composer / terminal scaffolding.
+    val agentConversationsState = viewModel.agentConversations.collectAsState()
     val sessionPickerState by sessionPickerViewModel.state.collectAsState()
     // Issue #463: the in-session project switcher's sibling list, sourced
     // from the warm live `-CC` client only (no SSH handshake) so tapping the
     // header project crumb and switching stays instant.
     val projectSwitcherState by sessionPickerViewModel.projectSwitcher.collectAsState()
     val assistantState by viewModel.assistantState.collectAsState()
-    val dictationState by inlineDictationViewModel.uiState.collectAsState()
+    // Issue #1085 (freeze F3 / R1 — dictation amplitude recomposition jank):
+    // the inline-dictation silence watchdog rewrites `uiState` with a fresh
+    // amplitude sample every SAMPLE_INTERVAL_MS=50ms (20 Hz) for the whole
+    // recording. Reading the WHOLE `uiState` State in this body (the old
+    // `val dictationState by ...collectAsState()`) subscribed the
+    // `TmuxSessionScreen` ROOT restart group — the group that hosts the
+    // terminal-render subtree — to that 20 Hz churn, so the entire ~7k-line body
+    // recomposed 20×/s while the user dictates (the voice-first jank vector).
+    // The body never reads the amplitude; it only needs the (low-frequency)
+    // dictation MODE (the transcript-routing LaunchedEffect below). Deriving
+    // just `mode` via `derivedStateOf` keeps the body OFF the 20 Hz path: the
+    // derived value only changes when the mode flips, so the amplitude emissions
+    // no longer recompose the body. The amplitude is consumed by the leaf mic UI
+    // ([KeyBarWithMic]), not here.
+    val dictationUiState = inlineDictationViewModel.uiState.collectAsState()
+    val dictationMode by remember(dictationUiState) {
+        derivedStateOf { dictationUiState.value.mode }
+    }
     // Issue #176: collected once at the screen root so the conversation
     // pane recomposes when the toggle flips in Settings.
     val appSettings by settingsViewModel.state.collectAsState()
@@ -658,7 +686,32 @@ public fun TmuxSessionScreen(
     // visible pane), not the active-only `currentPane` — so a cached-pane
     // detection (once promotion fires) and the presumed-agent default both reach
     // the surface the user is looking at.
-    val currentAgentConversation = surfacePane?.paneId?.let { agentConversations[it] }
+    val surfaceConversationPaneId = surfacePane?.paneId
+    // Issue #1085 (freeze F3 / R2): the body chrome needs only the STABLE
+    // projections of the surface pane's conversation — its detection, its
+    // selected tab, whether it has any events, and whether a row exists. The
+    // agent-streaming flush (60ms) changes the conversation's `events` LIST but
+    // NOT these projections (detection/selectedTab are unchanged mid-stream;
+    // `hasEvents`/`exists` only flip ONCE, on the first event / first row).
+    // Reading them through ONE `derivedStateOf` keeps the body's ROOT restart
+    // group OFF the per-flush invalidation path: `derivedStateOf` re-runs its
+    // (cheap) projection on each flush but only invalidates the body when the
+    // projected value actually changes — so the 16 Hz transcript stream no
+    // longer recomposes the chrome. The high-frequency `events` list itself is
+    // read inside `surfaceContent` (its own restart scope) for the transcript.
+    val surfaceChrome by remember(surfaceConversationPaneId) {
+        derivedStateOf {
+            val convo = surfaceConversationPaneId?.let { agentConversationsState.value[it] }
+            SurfaceConversationChrome(
+                detection = convo?.detection,
+                selectedTab = convo?.selectedTab,
+                hasEvents = convo?.events?.isNotEmpty() == true,
+                exists = convo != null,
+            )
+        }
+    }
+    val currentDetection: AgentDetection? = surfaceChrome.detection
+    val currentSelectedTab: SessionTab? = surfaceChrome.selectedTab
     val scope = rememberCoroutineScope()
 
     // Issue #463: the current session's project path (the active pane's
@@ -793,7 +846,7 @@ public fun TmuxSessionScreen(
     // record it as the sticky value for that pane id. A subsequent transient
     // `detection == null` leaves the recorded value intact, so the header
     // affordance and the palette keep working through the gap.
-    val liveAgentForPane = currentAgentConversation?.detection?.agent
+    val liveAgentForPane = currentDetection?.agent
     // Issue #797: the sticky/palette agent key follows the SURFACE pane so the
     // last-known agent kind sticks to the visible pane (active OR cached),
     // keeping the agent affordances and presumed-agent default reachable across
@@ -887,7 +940,7 @@ public fun TmuxSessionScreen(
     // exactly as it does on a fresh active pane.
     val presumedAgent = surfacePane != null &&
         tmuxSessionPresumedAgent(
-            hasLiveDetection = currentAgentConversation?.detection != null,
+            hasLiveDetection = currentDetection != null,
             stickyAgent = paletteAgent,
             // Issue #894 (Slice C): the visible pane's durable confirmed-shell
             // verdict — true only when the tree recorded `@ps_agent_kind=shell`.
@@ -897,7 +950,7 @@ public fun TmuxSessionScreen(
     // live detection/transcript yet: the sticky/last-known kind. Null when this
     // pane has never been an agent in the current attach (then a presumed send
     // falls back to raw bytes).
-    val presumedAgentKind: AgentKind? = if (currentAgentConversation?.detection == null) {
+    val presumedAgentKind: AgentKind? = if (currentDetection == null) {
         paletteAgent
     } else {
         null
@@ -1050,10 +1103,10 @@ public fun TmuxSessionScreen(
     // dictation while parked on a settled cached pane reaches the session the
     // user is looking at once promotion makes it active — not a no-op.
     val focusedPaneId = surfacePane?.paneId
-    LaunchedEffect(inlineDictationViewModel, dictationState.mode, focusedPaneId) {
+    LaunchedEffect(inlineDictationViewModel, dictationMode, focusedPaneId) {
         inlineDictationViewModel.transcriptions.collect { text ->
             val paneId = focusedPaneId ?: return@collect
-            when (dictationState.mode) {
+            when (dictationMode) {
                 InlineDictationViewModel.DictationMode.Prompt -> {
                     if (text.isNotEmpty()) {
                         viewModel.writeInputToPane(paneId, text.toByteArray(Charsets.UTF_8))
@@ -1469,7 +1522,22 @@ public fun TmuxSessionScreen(
             // currently visible pane only. A sibling pane/window's agent
             // no longer keeps Conversation mounted or routes sends away
             // from what the user is looking at.
-            val tabState = tmuxSessionTabState(currentAgentConversation, presumedAgent)
+            // Issue #1085 (freeze F3 / R2): derive `tabState` via `derivedStateOf`
+            // rather than reading the surface pane's conversation directly here.
+            // `tmuxSessionTabState` only consults `events.isNotEmpty()` (flips
+            // once), the placeholder flags, detection and selectedTab — all
+            // stable mid-stream — so deriving it keeps the body's tab-bar chrome
+            // OFF the 60ms agent-streaming flush. The projection re-runs each
+            // flush but the resulting [TmuxSessionTabState] is structurally equal,
+            // so the body is not invalidated.
+            val tabState by remember(surfaceConversationPaneId, presumedAgent) {
+                derivedStateOf {
+                    tmuxSessionTabState(
+                        surfaceConversationPaneId?.let { agentConversationsState.value[it] },
+                        presumedAgent,
+                    )
+                }
+            }
             val onTabSelected: (Int) -> Unit = { index ->
                 if (index == 1) {
                     // Issue #778: honour a Conversation tap whenever the tab is
@@ -1554,7 +1622,7 @@ public fun TmuxSessionScreen(
                                 agentName = if (effectiveHidesTerminal) {
                                     null
                                 } else {
-                                    currentAgentConversation?.detection?.agent?.displayName
+                                    currentDetection?.agent?.displayName
                                 },
                                 tabLabels = tabState.labels,
                                 selectedTabIndex = tabState.selectedIndex,
@@ -1713,7 +1781,6 @@ public fun TmuxSessionScreen(
             // still additionally requires the pane to be ACTIVE (`currentPane`)
             // because a real transcript only exists once the warm switch
             // promoted the pane and detection seeded on the active runtime.
-            val visibleConversation = surfacePane?.paneId?.let { agentConversations[it] }
             // Whether to render the Conversation *content* (real transcript) in
             // place of the terminal pager. This is the actual content swap,
             // distinct from whether the Conversation *tab* exists (#716
@@ -1727,19 +1794,27 @@ public fun TmuxSessionScreen(
             // Conversation→Terminal swap latch); it now also fires for an existing
             // events transcript whose detection is currently null (an agent that
             // exited / a recorded-shell pane), not solely live detection.
+            //
+            // Issue #1085 (freeze F3 / R2): the routing inputs come from the
+            // STABLE [surfaceChrome] derivation, NOT a direct read of the surface
+            // pane's conversation here. Routing only depends on selectedTab,
+            // whether detection exists, and whether ANY events exist — all stable
+            // mid-stream — so computing it from `surfaceChrome` keeps this body
+            // group OFF the 60ms agent-streaming flush. The actual `events` LIST
+            // is read inside `surfaceContent` (its own restart scope) for the
+            // transcript render below.
             val conversationSurface = tmuxSessionConversationSurface(
                 showsConversationTab = tabState.showsConversationTab,
                 isActivePane = currentPane != null,
                 hasSurfacePane = surfacePane != null,
-                selectedTab = visibleConversation?.selectedTab,
-                hasDetection = visibleConversation?.detection != null,
-                hasEvents = visibleConversation?.events?.isNotEmpty() == true,
+                selectedTab = currentSelectedTab,
+                hasDetection = currentDetection != null,
+                hasEvents = surfaceChrome.hasEvents,
             )
-            // The leading `visibleConversation != null` keeps the K2 smart-cast
-            // for the `showConversation` content branches below (they read
-            // `visibleConversation.events` / `.loadState` non-null); the surface
-            // routing already requires a non-null row to reach Transcript.
-            val showConversation = visibleConversation != null &&
+            // `surfaceChrome.exists` mirrors the old `visibleConversation != null`
+            // guard (a row exists for the surface pane) so the Transcript branch
+            // is only chosen when there is a real conversation row to render.
+            val showConversation = surfaceChrome.exists &&
                 conversationSurface == TmuxConversationSurface.Transcript
             // Issue #778/#1057: a lightweight "Loading conversation…" / Failed
             // placeholder when the user opened the Conversation tab on a pane with
@@ -1892,7 +1967,7 @@ public fun TmuxSessionScreen(
                     // signal that drives the agent chips below — a stable Boolean, so
                     // the pager stays skippable across overlay toggles (#796 H3).
                     val terminalIsAgentPane = tmuxSessionIsAgentPane(
-                        hasLiveDetection = currentAgentConversation?.detection != null,
+                        hasLiveDetection = currentDetection != null,
                         presumedAgent = presumedAgent,
                     )
                     TmuxTerminalPager(
@@ -1911,6 +1986,20 @@ public fun TmuxSessionScreen(
                         onEngineCommandTap = stableEngineCommandTap,
                     )
                 }
+                // Issue #1085 (freeze F3 / R2): read the surface pane's FULL
+                // conversation — including the high-frequency `events` list — HERE,
+                // inside `surfaceContent`. This lambda is a non-inline
+                // `@Composable () -> Unit` passed as `content` to
+                // [SessionSurfaceReconnectWrapper], so it is its OWN Compose restart
+                // group: subscribing to the 60ms agent-streaming flush at THIS read
+                // recomposes ONLY the transcript subtree, never the
+                // `TmuxSessionScreen` body (chrome/composer/terminal). The body
+                // reads only the STABLE [surfaceChrome] projection (above). Within a
+                // single recomposition this read sees the same snapshot the chrome
+                // derivation did, so `showConversation` ⇒ a non-null row (the
+                // `!= null` guards below are for the compiler's smart-cast).
+                val visibleConversation =
+                    surfaceConversationPaneId?.let { agentConversationsState.value[it] }
                 if (effectiveHidesTerminal) {
                     // Issue #661 / EPIC #687 P1: a cross-session switch is in flight —
                     // never paint the leaving session's terminal (or its agent
@@ -1931,6 +2020,7 @@ public fun TmuxSessionScreen(
                     // teardown. The latch self-clears after one frame.
                     SwitchingLoadingPlaceholder()
                 } else if (showConversation &&
+                    visibleConversation != null &&
                     visibleConversation.events.isEmpty() &&
                     visibleConversation.loadState == ConversationLoadState.Loading
                 ) {
@@ -1944,6 +2034,7 @@ public fun TmuxSessionScreen(
                         loadState = ConversationLoadState.Loading,
                     )
                 } else if (showConversation &&
+                    visibleConversation != null &&
                     visibleConversation.events.isEmpty() &&
                     visibleConversation.loadState == ConversationLoadState.Failed
                 ) {
@@ -1954,7 +2045,7 @@ public fun TmuxSessionScreen(
                         loadState = ConversationLoadState.Failed,
                         onRetry = { viewModel.retryAgentConversationLoad(paneIdForSend) },
                     )
-                } else if (showConversation) {
+                } else if (showConversation && visibleConversation != null) {
                     val paneIdForSend = currentPane!!.paneId
                     // Issue #842: bind the image loader to THIS host + the active
                     // pane cwd (a relative pasted path resolves where the agent
@@ -2161,7 +2252,7 @@ public fun TmuxSessionScreen(
                 // not just live detection, so they don't flip to shell chips
                 // during the slow-detection window.
                 val isAgentPane = tmuxSessionIsAgentPane(
-                    hasLiveDetection = currentAgentConversation?.detection != null,
+                    hasLiveDetection = currentDetection != null,
                     presumedAgent = presumedAgent,
                 )
                 val bottomControlsModifier = if (isImeVisible) {
@@ -2245,7 +2336,7 @@ public fun TmuxSessionScreen(
                         pane != null &&
                         tmuxSessionShowsSnippetChip(
                             hasHost = hostId != 0L,
-                            hasLiveDetection = currentAgentConversation?.detection != null,
+                            hasLiveDetection = currentDetection != null,
                             hasStickyAgent = paletteAgent != null,
                         )
                     ) {
@@ -2658,9 +2749,15 @@ public fun TmuxSessionScreen(
             connectionLost = !sessionLive,
             sendTargetSnapshotProvider = { withEnter ->
                 val pane = surfacePane
-                val liveAgent = currentAgentConversation?.detection?.agent
-                val viewingConversationNow = currentAgentConversation?.detection != null &&
-                    currentAgentConversation.selectedTab == SessionTab.Conversation
+                // Issue #1085 (freeze F3 / R2): the send-route snapshot needs only
+                // the surface pane's detection + selected tab — both STABLE
+                // projections carried by [surfaceChrome] (`currentDetection` /
+                // `currentSelectedTab`). Same composition-time snapshot the old
+                // `currentAgentConversation` capture provided; they update whenever
+                // the body recomposes, which is exactly when detection/tab change.
+                val liveAgent = currentDetection?.agent
+                val viewingConversationNow = currentDetection != null &&
+                    currentSelectedTab == SessionTab.Conversation
                 val route = tmuxComposerSendRoute(
                     viewingConversation = viewingConversationNow,
                     liveAgent = liveAgent,
@@ -2701,7 +2798,7 @@ public fun TmuxSessionScreen(
         SnippetPickerSheet(
             hostId = hostId,
             onDismiss = { showSnippetPicker = false },
-            kindFilter = if (currentAgentConversation?.detection != null) {
+            kindFilter = if (currentDetection != null) {
                 SnippetKind.Prompt
             } else {
                 SnippetKind.Command
@@ -3302,6 +3399,30 @@ internal data class TmuxSessionTabState(
     val labels: List<String>,
     val selectedIndex: Int,
     val showsConversationTab: Boolean,
+)
+
+/**
+ * Issue #1085 (freeze F3 / R2): the STABLE projection of the surface pane's
+ * agent conversation that the [TmuxSessionScreen] body chrome reads. The agent
+ * transcript tail flushes a fresh `agentConversations` map every ~60ms while an
+ * agent streams; that flush changes the conversation's `events` list but NOT
+ * these fields ([detection] / [selectedTab] are unchanged mid-stream, and
+ * [hasEvents] / [exists] only flip ONCE — on the first event / first row).
+ *
+ * The body derives this via `derivedStateOf`, so the per-flush map churn
+ * re-runs only the (cheap) projection lambda and invalidates the body's ROOT
+ * restart group ONLY when one of these stable fields actually changes — never
+ * once per streaming flush. It is a `data class` so `derivedStateOf`'s default
+ * structural-equality policy correctly suppresses no-op notifications. The
+ * high-frequency `events` list is deliberately NOT a field here: it is read
+ * inside the `surfaceContent` child scope (its own restart group) so a flush
+ * recomposes only the transcript, not the chrome/composer/terminal.
+ */
+internal data class SurfaceConversationChrome(
+    val detection: AgentDetection?,
+    val selectedTab: SessionTab?,
+    val hasEvents: Boolean,
+    val exists: Boolean,
 )
 
 /**

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -4782,17 +4782,59 @@ public class TmuxSessionViewModel @Inject constructor(
     }
 
     /**
-     * Issue #981: the [ConnectionDecision.SuppressNetworkTransportProvenAlive]
+     * Issue #981 / #1042 / #1078: the [ConnectionDecision.SuppressNetworkTransportProvenAlive]
      * body. A real validated identity change WAS observed (we are past the
-     * `realValidatedIdentityChange` gate), but the live transport's keepalive
-     * has seen inbound bytes within its ride-through window, so the old socket
-     * is provably alive and a teardown+redial here would be the #974 spurious
-     * stable-wifi drop. We ride it through (no `unregisterCurrentClient` / no
-     * `scheduleAutoReconnect`) and emit the device trail showing WHY, mirroring
-     * [suppressNetworkNotValidated]. `realValidatedIdentityChange` is always
-     * `true` here (only a real handoff reaches this gate).
+     * `realValidatedIdentityChange` gate), and the live transport's keepalive
+     * has seen inbound bytes within its ride-through window — so the old socket
+     * is PASSIVELY proven alive and a teardown+redial would be the #974 spurious
+     * stable-wifi drop.
+     *
+     * Issue #1078: the passive keepalive timestamp only proves the link was alive
+     * RECENTLY. A genuine WIFI→CELLULAR handoff can leave the old socket DEAD while
+     * its last-inbound-byte age is still under the ~90s keepalive budget
+     * ([com.pocketshell.core.ssh.TransportKeepAlive]) — so a purely passive suppress
+     * here shows the session Live-but-FROZEN until that full budget finally trips
+     * (up to ~90s). The #1042 restore arm already solved the equivalent problem with
+     * a bounded ACTIVE probe; mirror it here through the SAME mechanism
+     * ([runLivenessProbePing] bounded by [RESTORE_LIVENESS_PROBE_BUDGET_MS], the
+     * authority the restore arm uses): confirm liveness with ONE bounded probe over
+     * the warm control channel before riding through. If it answers, RIDE THROUGH
+     * (the #981/#974/#1058 spurious-drop ride-through win is preserved); if it does
+     * NOT, the socket is dead post-handoff, so redial PROMPTLY via the SAME dead-link
+     * handoff authority the reducer already dispatches ([scheduleNetworkReconnect])
+     * instead of waiting out the keepalive budget. The probe is bounded so it cannot
+     * itself hang; the session stays Connected (no overlay) for at most the probe
+     * budget on the dead path. `realValidatedIdentityChange` is always `true` here
+     * (only a real handoff reaches this gate).
      */
     private fun suppressNetworkTransportProvenAlive(
+        change: TerminalNetworkChange,
+        target: ConnectionTarget,
+    ) {
+        viewModelScope.launch {
+            val alive = withTimeoutOrNull(RESTORE_LIVENESS_PROBE_BUDGET_MS) {
+                runLivenessProbePing()
+            } ?: false
+            if (alive) {
+                rideThroughNetworkHandoffProvenAlive(change, target)
+            } else {
+                // Issue #1078: passively proven alive but the bounded active probe
+                // did NOT answer — the old socket is genuinely dead after the
+                // handoff. Redial now rather than freezing Live for ~90s.
+                scheduleNetworkReconnect(change, target)
+            }
+        }
+    }
+
+    /**
+     * Issue #1078: the handoff RIDE-THROUGH arm — the bounded active probe
+     * ([suppressNetworkTransportProvenAlive]) confirmed the old socket is still
+     * alive after the validated handoff, so we do NOT redial (preserving the
+     * #981/#974/#1058 spurious-drop win). Emits the same `network_reconnect_skip`
+     * device trail as before, tagged `probeConfirmed=true` so a field log can tell
+     * the #1078 probe-confirmed ride-through apart from a purely passive suppress.
+     */
+    private fun rideThroughNetworkHandoffProvenAlive(
         change: TerminalNetworkChange,
         target: ConnectionTarget,
     ) {
@@ -4816,6 +4858,9 @@ public class TmuxSessionViewModel @Inject constructor(
                 "cause" to "transport_proven_alive",
                 "classification" to "network_handoff_transport_alive",
                 "reconnect" to false,
+                // Issue #1078: this ride-through is now confirmed by a bounded
+                // ACTIVE probe, not the passive keepalive timestamp alone.
+                "probeConfirmed" to true,
                 "realValidatedIdentityChange" to true,
                 "sequence" to change.sequence,
                 "hostId" to target.hostId,

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.qualifiers.ApplicationContext
+import com.pocketshell.app.AppTeardownScope
 import com.pocketshell.app.assistant.AppAssistantActions
 import com.pocketshell.app.assistant.AssistantActions
 import com.pocketshell.app.assistant.AssistantInstallId
@@ -372,6 +373,31 @@ public class TmuxSessionViewModel @Inject constructor(
     internal fun setSessionCardsDispatcherForTest(dispatcher: CoroutineDispatcher) {
         sessionCardsDispatcher = dispatcher
         sessionCardsRemoteSource.setExecDispatcherForTest(dispatcher)
+    }
+
+    /**
+     * Issue #1085 (F2): the application-scoped coroutine the SLOW
+     * connection-teardown IO ([closeCurrentConnection]'s tmux `detach-client`
+     * round-trip, the cached-runtime closes, and the warm-lease refcount-- /
+     * raw-socket close) is handed to so `onCleared()` returns IMMEDIATELY
+     * instead of parking the Main thread. The previous synchronous
+     * `runBlocking(Dispatchers.IO){ withTimeoutOrNull(...){ … } }` blocks
+     * DEFEATED their own coroutine timeouts: the underlying close is a
+     * non-suspending `AutoCloseable.close()` doing a nested `runBlocking` socket
+     * close, and a coroutine cancel cannot interrupt a thread parked in nested
+     * `runBlocking` — so on a wedged socket the real bound was the SUM of the
+     * per-resource ceilings (shell + session + N cached runtimes), a
+     * multi-second / ANR-class Main park. [AppTeardownScope] OUTLIVES this VM
+     * and is never cancelled, so the teardown still runs to COMPLETION off-Main
+     * (no leak). NOT a constructor parameter, for the same Hilt-graph reason as
+     * [reconcileDispatcher]; a unit test pins it via [setTeardownScopeForTest]
+     * so the off-Main hand-off is directly observable.
+     */
+    private var teardownScope: CoroutineScope = AppTeardownScope.scope
+
+    @androidx.annotation.VisibleForTesting
+    internal fun setTeardownScopeForTest(scope: CoroutineScope) {
+        teardownScope = scope
     }
 
     /**
@@ -5477,21 +5503,22 @@ public class TmuxSessionViewModel @Inject constructor(
         }
     }
 
-    private fun closeCachedRuntimesBlocking(runtimes: List<CachedTmuxRuntime>) {
+    private suspend fun closeCachedRuntimesBounded(runtimes: List<CachedTmuxRuntime>) {
         if (runtimes.isEmpty()) return
-        // Issue #710: this runs on the MAIN thread (onCleared park-on-clear).
-        // [closeCachedRuntime] already bounds its own suspending steps at
-        // SYNC_DETACH_TIMEOUT_MS, but we add a belt-and-suspenders outer ceiling
-        // so the main thread is GUARANTEED to return even if a future teardown
-        // step regresses to unbounded. The outer budget scales with the runtime
-        // count (each runtime gets its detach budget) so the normal one/two
-        // runtime park stays fast.
+        // Issue #1085 (F2): this is invoked from [deferConnectionTeardownOffMain]
+        // on the application-scoped [teardownScope], NOT on the Main thread — the
+        // previous `closeCachedRuntimesBlocking` ran `runBlocking(Dispatchers.IO)`
+        // directly from `onCleared` (Main), and because each cached runtime's
+        // close does a non-suspending nested-`runBlocking` socket close that a
+        // coroutine timeout cannot interrupt, the real Main park was the SUM of
+        // the N per-runtime ceilings (a multi-second / ANR-class freeze on a
+        // wedged transport). [closeCachedRuntime] still bounds its own suspending
+        // steps at SYNC_DETACH_TIMEOUT_MS; the outer ceiling here is a
+        // belt-and-suspenders guard that scales with the runtime count.
         runCatching {
-            runBlocking(Dispatchers.IO) {
-                withTimeoutOrNull(SYNC_DETACH_TIMEOUT_MS * runtimes.size) {
-                    runtimes.forEach { runtime ->
-                        runtime.closeCachedRuntime(detachTimeoutMs = SYNC_DETACH_TIMEOUT_MS)
-                    }
+            withTimeoutOrNull(SYNC_DETACH_TIMEOUT_MS * runtimes.size) {
+                runtimes.forEach { runtime ->
+                    runtime.closeCachedRuntime(detachTimeoutMs = SYNC_DETACH_TIMEOUT_MS)
                 }
             }
         }
@@ -8707,7 +8734,16 @@ public class TmuxSessionViewModel @Inject constructor(
             sessionName = sessionName,
             startDirectory = null,
         )
-        closeCurrentConnection()
+        // Issue #1085 (F2) test isolation: tear the OLD connection down
+        // SYNCHRONOUSLY for this test seam. `closeCurrentConnection`'s
+        // production caller (`onCleared`) defers the slow detach/close off the
+        // Main thread (the F2 fix), but callers of this synchronous seam assert
+        // the replaced client is closed the instant the seam returns (e.g.
+        // `replacingClientClosesOldClientAndUpdatesRegistry` checks
+        // `oldClient.closed`). `deferTeardown = false` runs the same teardown
+        // body inline so the seam keeps its synchronous contract — independent
+        // of whichever teardown scope a test injected.
+        closeCurrentConnection(deferTeardown = false)
         // Issue #178: tests for the same-host fast-switch path need a
         // way to inject a live `SshSession` into the VM so a follow-up
         // `connect()` to the same host re-uses it instead of going
@@ -15611,7 +15647,16 @@ public class TmuxSessionViewModel @Inject constructor(
             ISSUE_235_LIFECYCLE_TAG,
             "tmux-viewmodel-cleared-park-runtime " + targetLogFields(target),
         )
-        closeCachedRuntimesBlocking(deactivateCurrentRuntimeToCache())
+        // Issue #1085 (F2): close the evicted cached runtimes OFF the Main
+        // thread. This park path also runs from `onCleared` (Main); closing the
+        // runtimes synchronously parked Main on a wedged socket. The live
+        // runtime stays parked in the cache; only the evicted ones are closed.
+        deferConnectionTeardownOffMain(
+            clientToDetach = null,
+            runtimesToClose = deactivateCurrentRuntimeToCache(),
+            leaseToRelease = null,
+            sessionToClose = null,
+        )
         return true
     }
 
@@ -15626,18 +15671,88 @@ public class TmuxSessionViewModel @Inject constructor(
         }
     }
 
-    private fun releaseCurrentLeaseOrCloseRawSessionBlocking() {
-        val lease = leaseRef
-        if (lease != null) {
+    /**
+     * Issue #1085 (F2): hand the SLOW connection-teardown IO to the
+     * application-scoped [teardownScope] so the calling `onCleared()` returns
+     * IMMEDIATELY instead of parking the Main thread.
+     *
+     * The work — the tmux `detach-client` round-trip + local client close, the
+     * cached-runtime closes, and the warm-lease refcount-- ([SshLease.release])
+     * or raw-[SshSession] close — is exactly what [closeCurrentConnection] used
+     * to run synchronously via three `runBlocking(Dispatchers.IO)` blocks on
+     * Main. Each step keeps its prior bounded ceiling
+     * ([SYNC_DETACH_TIMEOUT_MS]); the close SEMANTICS are unchanged (same
+     * detach, same per-runtime close, same lease release, same ordering) — only
+     * the THREAD moves off Main.
+     *
+     * Correctness: every reference is captured + nulled on Main by the caller
+     * BEFORE the hand-off, so there is no double-release and the VM's fields
+     * never observe a half-torn-down connection. [teardownScope] outlives this
+     * VM and is never cancelled, so the teardown runs to COMPLETION (refcount
+     * decremented, sockets closed) even though the VM is already gone — no leak.
+     * Each step is `runCatching`-wrapped so a wedged close never escapes.
+     */
+    private fun deferConnectionTeardownOffMain(
+        clientToDetach: TmuxClient?,
+        runtimesToClose: List<CachedTmuxRuntime>,
+        leaseToRelease: SshLease?,
+        sessionToClose: SshSession?,
+    ) {
+        if (clientToDetach == null &&
+            runtimesToClose.isEmpty() &&
+            leaseToRelease == null &&
+            sessionToClose == null
+        ) {
+            return
+        }
+        teardownScope.launch {
+            runConnectionTeardown(
+                clientToDetach = clientToDetach,
+                runtimesToClose = runtimesToClose,
+                leaseToRelease = leaseToRelease,
+                sessionToClose = sessionToClose,
+            )
+        }
+    }
+
+    /**
+     * The actual SLOW connection-teardown body (#1085 F2): the tmux
+     * `detach-client` round-trip + local client close, the evicted cached-runtime
+     * closes, and the warm-lease refcount-- ([SshLease.release]) or raw-session
+     * close. Each step keeps its bounded ceiling ([SYNC_DETACH_TIMEOUT_MS]) and
+     * is `runCatching`-wrapped so a wedged close never escapes.
+     *
+     * Production runs this off the Main thread via [deferConnectionTeardownOffMain]
+     * ([teardownScope]); the synchronous `replaceClientForTest` test seam runs it
+     * inline via `runBlocking` so the replaced client is closed before the seam
+     * returns. The body is identical either way — only the THREAD differs.
+     */
+    private suspend fun runConnectionTeardown(
+        clientToDetach: TmuxClient?,
+        runtimesToClose: List<CachedTmuxRuntime>,
+        leaseToRelease: SshLease?,
+        sessionToClose: SshSession?,
+    ) {
+        if (clientToDetach != null) {
+            // Issue #215: notify tmux server-side before the local close so
+            // the `-CC` control client does not linger as an orphan. Bounded
+            // so a wedged socket cannot stall the teardown.
             runCatching {
-                runBlocking(Dispatchers.IO) {
-                    withTimeoutOrNull(SYNC_DETACH_TIMEOUT_MS) {
-                        lease.release()
-                    }
+                withTimeoutOrNull(SYNC_DETACH_TIMEOUT_MS) {
+                    clientToDetach.detachCleanly(timeoutMs = SYNC_DETACH_TIMEOUT_MS)
                 }
             }
-        } else {
-            runCatching { sessionRef?.close() }
+            // [detachCleanly] already invokes [close]; this is a no-op when
+            // it ran and the real teardown when the detach hop failed.
+            runCatching { clientToDetach.close() }
+        }
+        closeCachedRuntimesBounded(runtimesToClose)
+        if (leaseToRelease != null) {
+            runCatching {
+                withTimeoutOrNull(SYNC_DETACH_TIMEOUT_MS) { leaseToRelease.release() }
+            }
+        } else if (sessionToClose != null) {
+            runCatching { sessionToClose.close() }
         }
     }
 
@@ -15823,7 +15938,7 @@ public class TmuxSessionViewModel @Inject constructor(
      * [SYNC_DETACH_TIMEOUT_MS] so a wedged socket cannot stall the
      * activity teardown beyond a fraction of a second.
      */
-    private fun closeCurrentConnection() {
+    private fun closeCurrentConnection(deferTeardown: Boolean = true) {
         val closingHostId = activeTarget?.hostId ?: registeredHostId
         // Issue #257: cancel any in-flight background detach from a prior
         // fast-switch. This path runs from [onCleared] (and the sync test
@@ -15893,37 +16008,58 @@ public class TmuxSessionViewModel @Inject constructor(
         paneRows.clear()
         _panes.value = emptyList()
         rebuildUnifiedPanes()
-        // Issue #215: run `detach-client` synchronously over an IO
-        // worker before the local close. The `runBlocking` hop matches
-        // [RealSshSession.close]'s pattern for non-suspending lifecycle
-        // teardown that needs a brief network round-trip. The timeout
-        // ceiling keeps the activity-destroy / onCleared path bounded
-        // — losing the wire mid-detach falls through to the immediate
-        // [TmuxClient.close] below.
+        // Issue #1085 (F2): the SLOW teardown IO — the tmux `detach-client`
+        // round-trip + local client close, the evicted cached-runtime closes,
+        // and the warm-lease refcount-- / raw-session close — used to run here
+        // on the Main thread via three `runBlocking(Dispatchers.IO)` blocks.
+        // Each block's coroutine timeout was DEFEATED by the underlying
+        // non-suspending nested-`runBlocking` socket close (a coroutine cancel
+        // cannot interrupt a thread parked in nested `runBlocking`), so on a
+        // wedged transport the real Main park was the SUM of the per-resource
+        // ceilings — a multi-second / ANR-class freeze finishing a session. We
+        // capture the references, null the VM fields on Main (no double-release,
+        // no half-torn-down state observed), and hand the actual closes to the
+        // application-scoped [teardownScope] so `onCleared` returns immediately
+        // while the teardown still runs to completion off-Main.
         val toDetach = clientRef
         if (toDetach != null) {
             connectionTmuxPort.setClient(null)
-            runCatching {
-                runBlocking(Dispatchers.IO) {
-                    withTimeoutOrNull(SYNC_DETACH_TIMEOUT_MS) {
-                        toDetach.detachCleanly(timeoutMs = SYNC_DETACH_TIMEOUT_MS)
-                    }
-                }
-            }
         }
-        // [detachCleanly] already invokes [close]; the call below is a
-        // belt-and-suspenders no-op when detachCleanly ran successfully
-        // and the real teardown path when the runBlocking hop above
-        // failed or was a no-op (clientRef was null).
-        runCatching { clientRef?.close() }
         clientRef = null
         unregisterCurrentClient()
-        closingHostId?.let { hostId ->
-            closeCachedRuntimesBlocking(runtimeCache.removeHost(hostId))
-        }
-        releaseCurrentLeaseOrCloseRawSessionBlocking()
+        val runtimesToClose = closingHostId?.let { hostId ->
+            runtimeCache.removeHost(hostId)
+        } ?: emptyList()
+        val leaseToRelease = leaseRef
+        val sessionToClose = sessionRef
         sessionRef = null
         leaseRef = null
+        if (deferTeardown) {
+            // Production `onCleared` path: hand the slow detach/close to the
+            // off-Main [teardownScope] so `onCleared` returns immediately
+            // (#1085 F2). Byte-identical to the pre-test-isolation behavior.
+            deferConnectionTeardownOffMain(
+                clientToDetach = toDetach,
+                runtimesToClose = runtimesToClose,
+                leaseToRelease = leaseToRelease,
+                sessionToClose = sessionToClose,
+            )
+        } else {
+            // Synchronous `replaceClientForTest` test seam: run the SAME
+            // teardown body inline so the replaced client is closed before the
+            // seam returns. Each step is internally bounded
+            // ([SYNC_DETACH_TIMEOUT_MS]) so a wedged fake cannot hang it, and it
+            // is scope-independent (does not depend on a test-injected teardown
+            // dispatcher being advanced).
+            runBlocking {
+                runConnectionTeardown(
+                    clientToDetach = toDetach,
+                    runtimesToClose = runtimesToClose,
+                    leaseToRelease = leaseToRelease,
+                    sessionToClose = sessionToClose,
+                )
+            }
+        }
         activeTarget = null
         connectingTarget = null
         // Issue #145: a sync teardown (onCleared / test-replacement seam)

--- a/app/src/main/java/com/pocketshell/app/usage/UsageNotificationStateStore.kt
+++ b/app/src/main/java/com/pocketshell/app/usage/UsageNotificationStateStore.kt
@@ -1,7 +1,16 @@
 package com.pocketshell.app.usage
 
 import android.content.Context
+import android.content.SharedPreferences
+import androidx.annotation.VisibleForTesting
 import com.pocketshell.core.usage.UsageThresholdState
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
 
 /**
  * Durable record of which usage warning crossings have already been
@@ -84,12 +93,62 @@ public data class UsageNotificationKey(
  * [android.content.SharedPreferences] file. Deliberately separate from
  * user-facing settings (`app_settings`) so it never appears in the Settings
  * UI or backup/restore of user preferences.
+ *
+ * ## Off-main construction (issue #1087, freeze cause F6 class sweep)
+ *
+ * This store is built during `App.onCreate` Hilt injection (the `@Singleton`
+ * `UsageNotifier` graph, via `UsageScheduler`) — on the Main thread, before
+ * the first frame. `getSharedPreferences(...)` does a synchronous first-touch
+ * disk read, so building it eagerly in the constructor blocked Main during
+ * cold launch (the identical class StrictMode flagged for
+ * `LastSessionStore.<init>`; built before `StrictModeInstaller` arms so it is
+ * not in the log but is the same Main-thread launch cost). The build is moved
+ * off-main onto [ioDispatcher] (eager [async]); the getter warms-or-awaits.
+ * Reads run off-main from the usage scheduler IO loop, so the cache is warm
+ * before any read. Hard-cut (D22): no synchronous on-Main fallback.
  */
-public class SharedPreferencesUsageNotificationStateStore(
+public class SharedPreferencesUsageNotificationStateStore @JvmOverloads constructor(
     context: Context,
+    ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : UsageNotificationStateStore {
-    private val prefs =
-        context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    private val appContext: Context = context.applicationContext
+
+    @Volatile
+    private var cachedPrefs: SharedPreferences? = null
+
+    @Volatile
+    private var prefsBuildThreadName: String? = null
+
+    private val warmUpScope = CoroutineScope(SupervisorJob() + ioDispatcher)
+    private val prefsDeferred: Deferred<SharedPreferences> = warmUpScope.async {
+        prefsBuildThreadName = currentPhysicalThreadName()
+        appContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .also { cachedPrefs = it }
+    }
+
+    private val prefs: SharedPreferences
+        get() = cachedPrefs ?: runBlocking { prefsDeferred.await() }
+
+    /**
+     * Test-only: block until the off-main build completes and return the name
+     * of the thread it ran on (#1087). Proves the prefs-file build did NOT run
+     * on the constructing/Main thread.
+     */
+    @VisibleForTesting
+    internal fun awaitPrefsBuildThreadNameForTest(): String {
+        runBlocking { prefsDeferred.await() }
+        return prefsBuildThreadName
+            ?: error("prefs build thread was not recorded")
+    }
+
+    // The build runs inside a coroutine, whose framework decorates the thread
+    // name with a " @coroutine#N" suffix. Strip it so the recorded value is the
+    // PHYSICAL thread name — otherwise an on-Main build (e.g. the un-fixed base)
+    // would still differ from the captured constructing name by the suffix alone,
+    // giving a false off-main pass (#1087 G6: keep the assertion load-bearing).
+    private fun currentPhysicalThreadName(): String =
+        Thread.currentThread().name.substringBefore(" @coroutine")
 
     override fun notifiedKeys(): Set<UsageNotificationKey> =
         prefs.getStringSet(KEY_NOTIFIED, emptySet())

--- a/app/src/test/java/com/pocketshell/app/git/GitHistoryViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/git/GitHistoryViewModelTest.kt
@@ -1,0 +1,177 @@
+package com.pocketshell.app.git
+
+import com.pocketshell.app.hosts.MainDispatcherRule
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.SshLease
+import com.pocketshell.core.ssh.SshLeaseConnector
+import com.pocketshell.core.ssh.SshLeaseKey
+import com.pocketshell.core.ssh.SshLeaseManager
+import com.pocketshell.core.ssh.SshPortForward
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshShell
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.job
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeoutOrNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import java.io.File
+import java.io.InputStream
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.coroutines.Continuation
+import kotlin.system.measureTimeMillis
+
+/**
+ * Issue #1085 (F2) reproduce-first for the OTHER nav-scoped screen that copies
+ * the same teardown shape ([RecurringJobsViewModel] is the sibling). The git
+ * history VM is `hiltViewModel()` nav-scoped, so `onCleared` fires on an
+ * ordinary foreground back/navigate-away ON the Main thread; on a half-open
+ * transport the warm-lease release rides its full ceiling.
+ *
+ * RED on base: `onCleared` ran
+ * `runBlocking(Dispatchers.IO){ withTimeoutOrNull(2000){ release() } }`, so
+ * backing out of git history parked the Main thread for the whole wedge (~1.8s)
+ * — a multi-second UI freeze.
+ *
+ * GREEN with the fix: the release is handed to the application-scoped teardown
+ * scope, so `onCleared` returns immediately while the release still runs to
+ * completion off-Main (no leak, no Main park).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class GitHistoryViewModelTest {
+
+    private val scheduler = TestCoroutineScheduler()
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule(StandardTestDispatcher(scheduler))
+
+    // The off-Main hand-off must let onCleared return within a small budget; on
+    // base the wedged release parks the calling thread ~1.8s.
+    private val parkBudgetMs = 300L
+
+    @Test
+    fun onClearedReleasesWarmLeaseOffMainAndNeverParksTheCallingThread() = runTest(scheduler) {
+        val released = CountDownLatch(1)
+        // A wedge that EXCEEDS the 2s release ceiling so the bound is provably
+        // defeated on base: a non-suspending blocking park (a wedged half-open
+        // socket close) a coroutine timeout cannot interrupt.
+        val wedgeMs = 1_800L
+        val teardownScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        val viewModel = GitHistoryViewModel(
+            sshLeaseManager = neverConnectingLeaseManager(),
+            ioDispatcher = StandardTestDispatcher(scheduler),
+        )
+        viewModel.setTeardownScopeForTest(teardownScope)
+        viewModel.setLeaseForTest(
+            wedgedLease(
+                key = SshLeaseKey(
+                    host = "lab.local",
+                    port = 22,
+                    user = "alexey",
+                    credentialId = "1:/tmp/key",
+                    knownHostsId = "accept-all",
+                ),
+                session = NoopSshSession(),
+                wedgeMs = wedgeMs,
+                onReleased = { released.countDown() },
+            ),
+        )
+        try {
+            val elapsedMs = measureTimeMillis { viewModel.clearForTest() }
+
+            assertTrue(
+                "onCleared parked the calling (Main) thread for ${elapsedMs}ms releasing a " +
+                    "wedged lease — the #1085 F2 ANR. The release must be handed to the " +
+                    "application-scoped teardown scope so onCleared returns immediately.",
+                elapsedMs < parkBudgetMs,
+            )
+            assertTrue(
+                "the warm-lease refcount-- must still run to COMPLETION off the Main thread " +
+                    "(no leak) — the app-scoped release never fired.",
+                released.await(8, TimeUnit.SECONDS),
+            )
+        } finally {
+            // Issue #1085 (F2) test isolation: JOIN the launched teardown
+            // coroutine to FULL completion before the test ends, then cancel.
+            // The latch fires mid-coroutine (right after the wedge's
+            // `Thread.sleep`), so awaiting it alone can let the real-IO
+            // coroutine finish unwinding after `runTest`/`resetMain`. Joining
+            // the scope's children makes tear-down fully quiescent so nothing
+            // touches Main concurrently with the next class's `setMain`.
+            runBlocking {
+                withTimeoutOrNull(8_000) {
+                    teardownScope.coroutineContext.job.children.forEach { it.join() }
+                }
+            }
+            teardownScope.cancel()
+        }
+    }
+
+    private fun neverConnectingLeaseManager(): SshLeaseManager =
+        SshLeaseManager(
+            connector = SshLeaseConnector { target ->
+                error("unexpected SSH lease connect for ${target.leaseKey}")
+            },
+            connectTimeoutContext = StandardTestDispatcher(scheduler),
+            nowMillis = { scheduler.currentTime },
+        )
+
+    /**
+     * Build an [SshLease] (internal constructor) whose `releaseAction` blocks
+     * the calling thread for [wedgeMs] then signals [onReleased] — a wedged
+     * transport close whose bounded ceiling is defeated because a coroutine
+     * cancel cannot unpark a parked thread.
+     */
+    private fun wedgedLease(
+        key: SshLeaseKey,
+        session: SshSession,
+        wedgeMs: Long,
+        onReleased: () -> Unit,
+    ): SshLease {
+        val releaseAction = { _: SshLeaseKey, _: Long, _: Continuation<Unit> ->
+            Thread.sleep(wedgeMs)
+            onReleased()
+            Unit
+        }
+        val constructor = SshLease::class.java.declaredConstructors.single()
+        return constructor.newInstance(key, session, false, 0L, releaseAction) as SshLease
+    }
+
+    private class NoopSshSession : SshSession {
+        override val isConnected: Boolean = true
+
+        override suspend fun exec(command: String): ExecResult = ExecResult("", "", 0)
+
+        override fun tail(path: String, onLine: (String) -> Unit): Job = error("tail not used")
+
+        override fun openLocalPortForward(
+            remoteHost: String,
+            remotePort: Int,
+            localPort: Int,
+        ): SshPortForward = error("port forward not used")
+
+        override fun startShell(): SshShell = error("shell not used")
+
+        override suspend fun uploadFile(file: File, remotePath: String): String =
+            error("uploadFile not used")
+
+        override suspend fun uploadStream(
+            input: InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String = error("uploadStream not used")
+
+        override fun close() = Unit
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/hosts/LeaseBackedHostSessionOpenerTest.kt
+++ b/app/src/test/java/com/pocketshell/app/hosts/LeaseBackedHostSessionOpenerTest.kt
@@ -1,0 +1,71 @@
+package com.pocketshell.app.hosts
+
+import com.pocketshell.core.ssh.SshLeaseConnector
+import com.pocketshell.core.ssh.SshLeaseManager
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.storage.entity.HostEntity
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Class coverage for issue #1085 freeze cause F1 (secondary): the
+ * session-open key-file `File.exists()` disk stat was moved off the Main
+ * thread into `withContext(Dispatchers.IO)`. These tests prove that move did
+ * not change the early-return contract:
+ *
+ * - a MISSING key file still short-circuits to `null` WITHOUT dialing, and
+ * - an EXISTING key file still proceeds past the gate to dial the lease.
+ *
+ * (The off-main move itself is verified by the StrictMode/responsiveness
+ * journey; this is the behavioural-correctness guard so the dispatcher hop
+ * can't silently break the gate.)
+ */
+class LeaseBackedHostSessionOpenerTest {
+
+    private val host = HostEntity(
+        name = "h",
+        hostname = "h.example",
+        username = "u",
+        keyId = 1L,
+    )
+
+    @Test
+    fun open_returns_null_without_dialing_when_key_file_missing() = runBlocking {
+        val dialed = AtomicBoolean(false)
+        val connector = SshLeaseConnector { _ ->
+            dialed.set(true)
+            Result.failure(IllegalStateException("should not dial for a missing key file"))
+        }
+        val opener = LeaseBackedHostSessionOpener(SshLeaseManager(connector))
+
+        val result: SshSession? =
+            opener.open(host, keyPath = "/does/not/exist/key.pem", passphrase = null)
+
+        assertNull("missing key file must short-circuit to null", result)
+        assertFalse("must not dial when the key file is missing", dialed.get())
+    }
+
+    @Test
+    fun open_dials_when_key_file_exists() = runBlocking {
+        val keyFile = File.createTempFile("pocketshell-key", ".pem").apply { deleteOnExit() }
+        val dialed = AtomicBoolean(false)
+        val connector = SshLeaseConnector { _ ->
+            dialed.set(true)
+            // Fail the dial so acquire returns a failure and open() returns
+            // null — we only need to prove the file-exists gate let us through.
+            Result.failure(IllegalStateException("dial refused by fake"))
+        }
+        val opener = LeaseBackedHostSessionOpener(SshLeaseManager(connector))
+
+        val result: SshSession? =
+            opener.open(host, keyPath = keyFile.absolutePath, passphrase = null)
+
+        assertNull("a refused dial yields null", result)
+        assertTrue("an existing key file must proceed to dial the lease", dialed.get())
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/jobs/RecurringJobsViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/jobs/RecurringJobsViewModelTest.kt
@@ -11,19 +11,31 @@ import com.pocketshell.core.ssh.SshPortForward
 import com.pocketshell.core.ssh.SshSession
 import com.pocketshell.core.ssh.SshShell
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.job
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.coroutines.Continuation
 import kotlin.math.max
+import kotlin.system.measureTimeMillis
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class RecurringJobsViewModelTest {
@@ -39,6 +51,10 @@ class RecurringJobsViewModelTest {
     val mainDispatcherRule = MainDispatcherRule(StandardTestDispatcher(scheduler))
 
     private val remoteSource = PocketshellJobsRemoteSource(RecurringJobsParser())
+
+    // Issue #1085 (F2): the off-Main hand-off must let onCleared return within a
+    // small budget; on base the wedged release parks the calling thread ~1.8s.
+    private val NAV_TEARDOWN_PARK_BUDGET_MS = 300L
 
     @Test
     fun loadConnectsAndFetchesJobsForSession() = runTest(scheduler) {
@@ -305,6 +321,101 @@ class RecurringJobsViewModelTest {
     }
 
     /**
+     * Issue #1085 (F2) reproduce-first. This screen's VM is `hiltViewModel()`
+     * nav-scoped, so `onCleared` fires on an ordinary foreground back/
+     * navigate-away ON the Main thread. On a half-open transport (post
+     * WIFI↔cellular handoff) `lease.release()` does not return fast — it rides
+     * its full ceiling — so releasing it synchronously parks the Main thread for
+     * multiple seconds (the maintainer's "keeps freezing" backing out of a
+     * screen).
+     *
+     * RED on base: `onCleared` ran
+     * `runBlocking(Dispatchers.IO){ withTimeoutOrNull(2000){ release() } }`, so
+     * `clearForTest()` parks the CALLING (Main) thread for the whole wedge
+     * (~1.8s) — the elapsed assertion fails.
+     *
+     * GREEN with the fix: the release is handed to the application-scoped
+     * [teardownScope], so `onCleared` returns immediately (elapsed well under
+     * the budget) AND the release still runs to COMPLETION off-Main (the latch
+     * fires) — no leak, no Main park.
+     */
+    @Test
+    fun onClearedReleasesWarmLeaseOffMainAndNeverParksTheCallingThread() = runTest(scheduler) {
+        val released = CountDownLatch(1)
+        // A wedge that EXCEEDS the 2s release ceiling so the bound is provably
+        // defeated on base: a non-suspending blocking park (mirroring a wedged
+        // half-open socket close) a coroutine timeout cannot interrupt.
+        val wedgeMs = 1_800L
+        val session = FakeSshSession(
+            pathAware("pocketshell jobs list --session 'codex'") to listOutput(id = 1, sessionName = "codex"),
+        )
+        val teardownScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        val viewModel = RecurringJobsViewModel(
+            remoteSource = remoteSource,
+            connector = WedgedLeaseConnector(session, wedgeMs) { released.countDown() },
+        )
+        viewModel.setTeardownScopeForTest(teardownScope)
+        try {
+            viewModel.load(
+                hostId = 1L,
+                hostName = "Lab",
+                hostname = "lab.local",
+                port = 22,
+                username = "alexey",
+                keyPath = "/tmp/key",
+                passphrase = null,
+                sessionName = "codex",
+            )
+            advanceUntilIdle()
+            // The warm lease is now held — the next teardown must release it.
+
+            val elapsedMs = measureTimeMillis { viewModel.clearForTest() }
+
+            assertTrue(
+                "onCleared parked the calling (Main) thread for ${elapsedMs}ms releasing a " +
+                    "wedged lease — the #1085 F2 ANR. The release must be handed to the " +
+                    "application-scoped teardown scope so onCleared returns immediately.",
+                elapsedMs < NAV_TEARDOWN_PARK_BUDGET_MS,
+            )
+            assertTrue(
+                "the warm-lease refcount-- must still run to COMPLETION off the Main thread " +
+                    "(no leak) — the app-scoped release never fired.",
+                released.await(8, TimeUnit.SECONDS),
+            )
+        } finally {
+            // Issue #1085 (F2) test isolation: JOIN the launched teardown
+            // coroutine to FULL completion before the test ends, then cancel.
+            // The latch fires mid-coroutine (right after the wedge's
+            // `Thread.sleep`), so awaiting it alone can let the real-IO
+            // coroutine finish unwinding after `runTest`/`resetMain`. Joining
+            // the scope's children makes tear-down fully quiescent so nothing
+            // touches Main concurrently with the next class's `setMain`.
+            runBlocking {
+                withTimeoutOrNull(8_000) {
+                    teardownScope.coroutineContext.job.children.forEach { it.join() }
+                }
+            }
+            teardownScope.cancel()
+        }
+    }
+
+    /**
+     * A connector whose lease release WEDGES — its [SshLease.release] blocks the
+     * calling thread for [wedgeMs] (a non-suspending park, like a half-open
+     * socket close that a coroutine timeout cannot interrupt).
+     */
+    private class WedgedLeaseConnector(
+        private val session: SshSession,
+        private val wedgeMs: Long,
+        private val onReleased: () -> Unit,
+    ) : RecurringJobsViewModel.RecurringJobsSshConnector {
+        override suspend fun acquire(target: RecurringJobsViewModel.Target): Result<SshLease> =
+            Result.success(
+                wedgedLeaseForTest(target.toLeaseTarget().leaseKey, session, wedgeMs, onReleased),
+            )
+    }
+
+    /**
      * Build a VM whose connector borrows from a REAL [SshLeaseManager] wrapping
      * [connector]. This exercises the actual #699 warm-lease path: acquire →
      * reuse → release, so `connector.connectCount` proves the screen rides ONE
@@ -455,4 +566,27 @@ class RecurringJobsViewModelTest {
     // real PATH-robust invocation (issue #484).
     private fun pathAware(command: String): String =
         PocketshellJobsRemoteSource.pathAwareCommand(command)
+}
+
+/**
+ * Issue #1085 (F2): build an [SshLease] (internal constructor) whose
+ * `releaseAction` blocks the calling thread for [wedgeMs] then signals
+ * [onReleased]. Mirrors the reflection-built `fakeLease` already used in this
+ * suite; the blocking `Thread.sleep` reproduces a wedged transport close whose
+ * bounded ceiling is defeated because a coroutine cancel cannot unpark a parked
+ * thread. Top-level so the static nested [WedgedLeaseConnector] can call it.
+ */
+private fun wedgedLeaseForTest(
+    key: SshLeaseKey,
+    session: SshSession,
+    wedgeMs: Long,
+    onReleased: () -> Unit,
+): SshLease {
+    val releaseAction = { _: SshLeaseKey, _: Long, _: Continuation<Unit> ->
+        Thread.sleep(wedgeMs)
+        onReleased()
+        Unit
+    }
+    val constructor = SshLease::class.java.declaredConstructors.single()
+    return constructor.newInstance(key, session, false, 0L, releaseAction) as SshLease
 }

--- a/app/src/test/java/com/pocketshell/app/notifications/UpdateNotificationStoreOffMainTest.kt
+++ b/app/src/test/java/com/pocketshell/app/notifications/UpdateNotificationStoreOffMainTest.kt
@@ -1,0 +1,97 @@
+package com.pocketshell.app.notifications
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Regression proof for issue #1087 freeze cause F6 (class sweep): building the
+ * `update_notifications` SharedPreferences eagerly in
+ * [UpdateNotificationStore]'s constructor ran a synchronous first-touch disk
+ * read on the **Main** thread. This store is built during `App.onCreate` Hilt
+ * injection (the `@Singleton` `UpdateNotifier` graph) — before
+ * `StrictModeInstaller` arms, so it is not in the cold-launch StrictMode log,
+ * but it is the identical Main-thread launch cost as the flagged
+ * `LastSessionStore.<init>`.
+ *
+ * Reproduce-first (D33 / G10, #780 — no self-skip): the load-bearing assertion
+ * is that the prefs-file build runs on a thread OTHER than the constructing
+ * (Main) thread. Pre-fix the read happened in `<init>` on the constructing
+ * thread (RED); with the off-main eager-`async` build it runs on the IO
+ * dispatcher (GREEN).
+ *
+ * Class coverage (G2): the default read is null and a write→fresh-instance read
+ * ("process restart") returns the persisted tag and drives `shouldNotify`.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class UpdateNotificationStoreOffMainTest {
+
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        clearPrefs()
+    }
+
+    @After
+    fun tearDown() {
+        clearPrefs()
+    }
+
+    /**
+     * LOAD-BEARING (#1087 F6): the `update_notifications` prefs file must NOT
+     * be built on the thread that constructs the store (the Main thread during
+     * `App.onCreate` Hilt injection in production).
+     */
+    @Test
+    fun prefs_build_does_not_run_on_constructing_thread() {
+        val constructingThread = Thread.currentThread().name
+
+        val store = UpdateNotificationStore(context)
+        val buildThread = store.awaitPrefsBuildThreadNameForTest()
+
+        assertNotEquals(
+            "update_notifications prefs must be built off the constructing " +
+                "(Main) thread, not on it (#1087 F6). " +
+                "constructing=$constructingThread build=$buildThread",
+            constructingThread,
+            buildThread,
+        )
+    }
+
+    /** No empty/racey first read: the default tag is null after the off-main build. */
+    @Test
+    fun default_last_notified_is_null_after_offmain_build() {
+        val store = UpdateNotificationStore(context)
+        assertNull(store.lastNotifiedTag())
+        assertTrue(store.shouldNotify("v9.9.9"))
+    }
+
+    /** Write→fresh-instance read survives the off-main build (process restart). */
+    @Test
+    fun last_notified_round_trips_and_survives_restart_after_offmain_build() {
+        UpdateNotificationStore(context).markNotified("v1.2.3")
+
+        val restarted = UpdateNotificationStore(context)
+        assertEquals("v1.2.3", restarted.lastNotifiedTag())
+        assertFalse(restarted.shouldNotify("v1.2.3"))
+        assertTrue(restarted.shouldNotify("v1.2.4"))
+    }
+
+    private fun clearPrefs() {
+        context.getSharedPreferences("update_notifications", Context.MODE_PRIVATE)
+            .edit().clear().commit()
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/release/UpdateCheckStoreOffMainTest.kt
+++ b/app/src/test/java/com/pocketshell/app/release/UpdateCheckStoreOffMainTest.kt
@@ -1,0 +1,89 @@
+package com.pocketshell.app.release
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Regression proof for issue #1087 freeze cause F6 (class sweep): building the
+ * `update_check_throttle` SharedPreferences eagerly in [UpdateCheckStore]'s
+ * constructor ran a synchronous first-touch disk read on the **Main** thread.
+ * This store is built during `App.onCreate` Hilt injection (the `@Singleton`
+ * `UpdateCheckScheduler` graph) — before `StrictModeInstaller` arms, so the
+ * cold-launch StrictMode log does not flag it, but it is the identical
+ * Main-thread launch cost as the flagged `LastSessionStore.<init>`.
+ *
+ * Reproduce-first (D33 / G10, #780 — no self-skip): the load-bearing assertion
+ * is that the prefs-file build runs on a thread OTHER than the constructing
+ * (Main) thread. On the pre-fix code the read happened in `<init>` on the
+ * constructing thread (RED); with the off-main eager-`async` build it runs on
+ * the IO dispatcher (GREEN).
+ *
+ * Class coverage (G2): the default read is 0 and a write→fresh-instance read
+ * ("process restart") returns the persisted value after the off-main build.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class UpdateCheckStoreOffMainTest {
+
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        clearPrefs()
+    }
+
+    @After
+    fun tearDown() {
+        clearPrefs()
+    }
+
+    /**
+     * LOAD-BEARING (#1087 F6): the `update_check_throttle` prefs file must NOT
+     * be built on the thread that constructs the store (the Main thread during
+     * `App.onCreate` Hilt injection in production).
+     */
+    @Test
+    fun prefs_build_does_not_run_on_constructing_thread() {
+        val constructingThread = Thread.currentThread().name
+
+        val store = UpdateCheckStore(context)
+        val buildThread = store.awaitPrefsBuildThreadNameForTest()
+
+        assertNotEquals(
+            "update_check_throttle prefs must be built off the constructing " +
+                "(Main) thread, not on it (#1087 F6). " +
+                "constructing=$constructingThread build=$buildThread",
+            constructingThread,
+            buildThread,
+        )
+    }
+
+    /** No empty/racey first read: the default is 0 after the off-main build. */
+    @Test
+    fun default_last_checked_is_zero_after_offmain_build() {
+        assertEquals(0L, UpdateCheckStore(context).lastCheckedAtMillis())
+    }
+
+    /** Write→fresh-instance read survives the off-main build (process restart). */
+    @Test
+    fun last_checked_round_trips_and_survives_restart_after_offmain_build() {
+        UpdateCheckStore(context).markCheckedAt(1_700_000_123L)
+
+        val restarted = UpdateCheckStore(context)
+        assertEquals(1_700_000_123L, restarted.lastCheckedAtMillis())
+    }
+
+    private fun clearPrefs() {
+        context.getSharedPreferences("update_check_throttle", Context.MODE_PRIVATE)
+            .edit().clear().commit()
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/session/LastSessionStoreOffMainTest.kt
+++ b/app/src/test/java/com/pocketshell/app/session/LastSessionStoreOffMainTest.kt
@@ -1,0 +1,114 @@
+package com.pocketshell.app.session
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Regression proof for issue #1087 freeze cause F6: building the
+ * `last_session` SharedPreferences eagerly in [LastSessionStore]'s
+ * constructor ran a synchronous first-touch disk read on the **Main**
+ * thread — StrictMode captured a 69–117ms `DiskReadViolation` in
+ * `LastSessionStore.<init>` during cold-launch Hilt injection
+ * (`MainActivity.onCreate` → `injectMainActivity2`). It was the next dominant
+ * cold-launch stall after F1 (keystore, #1085) and F5
+ * (`SystemSurfaceStateStore`, #1086) were fixed.
+ *
+ * Reproduce-first (D33 / G10, #780 model — no self-skip): the load-bearing
+ * assertion is that the prefs-file build runs on a thread OTHER than the
+ * constructing (Main) thread. On the pre-fix code the `getSharedPreferences(...)`
+ * read happened in `<init>` on the constructing thread, so
+ * [prefs_build_does_not_run_on_constructing_thread] FAILS RED; with the
+ * off-main eager-`async` build it runs on the IO dispatcher and PASSES GREEN.
+ *
+ * Class coverage (G2): the remaining tests prove the off-main init does not
+ * introduce an empty/racey first read — the default read returns null, and a
+ * save→fresh-instance read ("process restart") returns the persisted value.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class LastSessionStoreOffMainTest {
+
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        clearPrefs()
+    }
+
+    @After
+    fun tearDown() {
+        clearPrefs()
+    }
+
+    /**
+     * LOAD-BEARING (#1087 F6): the `last_session` prefs file must NOT be built
+     * on the thread that constructs the store (which, in production, is the
+     * Main thread during `MainActivity.onCreate` Hilt injection).
+     */
+    @Test
+    fun prefs_build_does_not_run_on_constructing_thread() {
+        val constructingThread = Thread.currentThread().name
+
+        val store = LastSessionStore(context)
+        val buildThread = store.awaitPrefsBuildThreadNameForTest()
+
+        assertNotEquals(
+            "last_session prefs must be built off the constructing (Main) " +
+                "thread, not on it (#1087 F6). " +
+                "constructing=$constructingThread build=$buildThread",
+            constructingThread,
+            buildThread,
+        )
+    }
+
+    /** No empty/racey first read: a never-saved store reads null after off-main build. */
+    @Test
+    fun default_read_is_null_after_offmain_build() {
+        val read = LastSessionStore(context).read(nowMillis = 2_000L)
+        assertNull(read)
+    }
+
+    /** Save→fresh-instance read survives the off-main build (process restart). */
+    @Test
+    fun saved_session_round_trips_and_survives_restart_after_offmain_build() {
+        val session = LastSessionStore.LastSession(
+            hostId = 42L,
+            hostName = "prod-box",
+            hostname = "10.0.0.9",
+            port = 2022,
+            username = "alex",
+            keyPath = "/data/keys/id_ed25519",
+            sessionName = "claude-main",
+            startDirectory = "/srv/app",
+            tmuxSessionId = "\$3",
+            sessionCreated = 1_700_000_000L,
+            composerDraft = "deploy please",
+            savedAtMillis = 1_000L,
+        )
+        LastSessionStore(context).save(session)
+
+        // A brand-new instance reads its prefs off-main; the first read must
+        // return the persisted snapshot, not an empty/default one.
+        val restored = LastSessionStore(context).read(
+            nowMillis = 1_500L,
+            maxAgeMillis = Long.MAX_VALUE,
+        )
+
+        assertEquals(session, restored)
+    }
+
+    private fun clearPrefs() {
+        context.getSharedPreferences("last_session", Context.MODE_PRIVATE)
+            .edit().clear().commit()
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/sessions/SessionsDashboardPersistOffMainTest.kt
+++ b/app/src/test/java/com/pocketshell/app/sessions/SessionsDashboardPersistOffMainTest.kt
@@ -1,0 +1,145 @@
+package com.pocketshell.app.sessions
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.pocketshell.app.hosts.MainDispatcherRule
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Regression proof for issue #1086 freeze cause F5 at the call site:
+ * [SessionsDashboardViewModel.persistActiveSessionCount] used to construct a
+ * [com.pocketshell.app.systemsurfaces.SystemSurfaceStateStore] and write to it
+ * **inline on `viewModelScope` (Main)**, dragging the store's ~648ms
+ * first-touch disk read onto the cold-launch UI thread.
+ *
+ * The fix dispatches the construct-and-write onto an injectable `ioDispatcher`.
+ * This test proves, on the real production path
+ * (`emitAggregate -> persistActiveSessionCount`):
+ *  - the persist work is dispatched off the Main path — the injected dispatcher
+ *    is actually used (the LOAD-BEARING off-main assertion at this layer), and
+ *  - the live session count is still persisted correctly afterwards (G2: no
+ *    regression to the visible widget count).
+ *
+ * The persist runs on a real `Dispatchers.IO`-backed recording dispatcher (not
+ * the virtual test clock). The VM's `init` collect persists count=0 for the
+ * empty registry first; the test bounded-awaits that landing before switching
+ * to the recording dispatcher and driving the count=2 write, so there is only
+ * ever one outstanding writer and the final value is deterministically 2. The
+ * assertions hard-fail on timeout rather than self-skipping.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class SessionsDashboardPersistOffMainTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        clearPrefs()
+    }
+
+    @After
+    fun tearDown() {
+        clearPrefs()
+    }
+
+    /**
+     * Records whether it was ever asked to dispatch a coroutine, so the test
+     * can assert the persist path actually went through `ioDispatcher` rather
+     * than running inline on the Main path.
+     */
+    private class RecordingDispatcher(
+        private val delegate: CoroutineDispatcher,
+    ) : CoroutineDispatcher() {
+        @Volatile
+        var dispatched: Boolean = false
+
+        override fun dispatch(context: CoroutineContext, block: Runnable) {
+            dispatched = true
+            delegate.dispatch(context, block)
+        }
+    }
+
+    @Test
+    fun persistActiveSessionCountDispatchesOffMainAndPersistsCount() {
+        val recording = RecordingDispatcher(Dispatchers.IO)
+        val vm = SessionsDashboardViewModel(
+            activeClients = ActiveTmuxClients(),
+            appContext = context,
+        )
+
+        try {
+            // The VM init collect persists count=0 for the empty registry on
+            // the default dispatcher; wait for it to land so it cannot race the
+            // count=2 write driven below (one outstanding writer at a time).
+            assertEquals(0, awaitPersistedCount(expected = 0, timeoutMs = 5_000))
+
+            vm.ioDispatcher = recording
+
+            // Drive a two-session aggregate through the real production path
+            // (emitAggregate -> persistActiveSessionCount).
+            vm.applyHostSnapshotForTest(
+                hostId = 1L,
+                summaries = listOf(
+                    SessionSummary(1L, "alpha", "work", lastActivity = 200, attached = true),
+                    SessionSummary(1L, "alpha", "logs", lastActivity = 100, attached = false),
+                ),
+            )
+
+            // G2: the live count is persisted correctly after the off-main
+            // construct-and-write completes (bounded-await the raw prefs value;
+            // hard-fails on timeout, never self-skips).
+            assertEquals(2, awaitPersistedCount(expected = 2, timeoutMs = 5_000))
+
+            // LOAD-BEARING (#1086 F5): the count=2 persist was dispatched onto
+            // the injected ioDispatcher, i.e. NOT run inline on the Main path.
+            assertTrue(
+                "persistActiveSessionCount must dispatch onto ioDispatcher " +
+                    "(off Main), not run inline (#1086 F5)",
+                recording.dispatched,
+            )
+        } finally {
+            vm.stopForTest()
+        }
+    }
+
+    /**
+     * Bounded-await the raw persisted count, reading the same in-memory
+     * SharedPreferences instance the off-main write targets. Returns the last
+     * observed value (which hard-fails the assertion) if [expected] never
+     * appears within [timeoutMs].
+     */
+    private fun awaitPersistedCount(expected: Int, timeoutMs: Long): Int {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        var last = -1
+        while (System.currentTimeMillis() < deadline) {
+            last = context.getSharedPreferences("system_surfaces", Context.MODE_PRIVATE)
+                .getInt("active_session_count", -1)
+            if (last == expected) return last
+            Thread.sleep(20)
+        }
+        return last
+    }
+
+    private fun clearPrefs() {
+        context.getSharedPreferences("system_surfaces", Context.MODE_PRIVATE)
+            .edit().clear().commit()
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/systemsurfaces/SystemSurfaceStateStoreOffMainTest.kt
+++ b/app/src/test/java/com/pocketshell/app/systemsurfaces/SystemSurfaceStateStoreOffMainTest.kt
@@ -1,0 +1,114 @@
+package com.pocketshell.app.systemsurfaces
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Regression proof for issue #1086 freeze cause F5: building the
+ * `system_surfaces` SharedPreferences eagerly in
+ * [SystemSurfaceStateStore]'s constructor ran a synchronous first-touch disk
+ * read on the **Main** thread — StrictMode captured a ~648ms `DiskReadViolation`
+ * in `SystemSurfaceStateStore.<init>` during cold-launch composition, reached
+ * via
+ * [com.pocketshell.app.sessions.SessionsDashboardViewModel.persistActiveSessionCount].
+ * It was masked behind the F1 keystore block (#1085) until F1 was fixed.
+ *
+ * Reproduce-first (D33 / G10, #780 model — no self-skip): the load-bearing
+ * assertion is that the prefs-file build runs on a thread OTHER than the
+ * constructing (Main) thread. On the pre-fix code the
+ * `getSharedPreferences(...)` read happened in `<init>` on the constructing
+ * thread, so [prefs_build_does_not_run_on_constructing_thread] FAILS RED; with
+ * the off-main eager-`async` build it runs on the IO dispatcher and PASSES
+ * GREEN.
+ *
+ * Class coverage (G2): the remaining tests prove the off-main init does not
+ * introduce an empty/racey first read — defaults, a write→fresh-instance read
+ * ("process restart"), and the wrong-type fallback all return the correct
+ * values after the build is awaited.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class SystemSurfaceStateStoreOffMainTest {
+
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        clearPrefs()
+    }
+
+    @After
+    fun tearDown() {
+        clearPrefs()
+    }
+
+    /**
+     * LOAD-BEARING (#1086 F5): the `system_surfaces` prefs file must NOT be
+     * built on the thread that constructs the store (which, in production, is
+     * the Main thread during the first Compose frame).
+     */
+    @Test
+    fun prefs_build_does_not_run_on_constructing_thread() {
+        val constructingThread = Thread.currentThread().name
+
+        val store = SystemSurfaceStateStore(context)
+        val buildThread = store.awaitPrefsBuildThreadNameForTest()
+
+        assertNotEquals(
+            "system_surfaces prefs must be built off the constructing (Main) " +
+                "thread, not on it (#1086 F5). " +
+                "constructing=$constructingThread build=$buildThread",
+            constructingThread,
+            buildThread,
+        )
+    }
+
+    /** No empty/racey first read: the default is 0 after the off-main build. */
+    @Test
+    fun default_count_is_zero_after_offmain_build() {
+        val state = SystemSurfaceStateStore(context).readSessionWidgetState()
+        assertEquals(SessionWidgetState(activeSessionCount = 0), state)
+    }
+
+    /** Write→fresh-instance read survives the off-main build (process restart). */
+    @Test
+    fun count_round_trips_and_survives_restart_after_offmain_build() {
+        SystemSurfaceStateStore(context).setActiveSessionCount(7)
+
+        val restarted = SystemSurfaceStateStore(context)
+        assertEquals(
+            SessionWidgetState(activeSessionCount = 7),
+            restarted.readSessionWidgetState(),
+        )
+    }
+
+    /** The wrong-type fallback still applies after the off-main build. */
+    @Test
+    fun wrong_type_falls_back_to_zero_after_offmain_build() {
+        context.getSharedPreferences("system_surfaces", Context.MODE_PRIVATE)
+            .edit()
+            .putString("active_session_count", "many")
+            .commit()
+
+        val store = SystemSurfaceStateStore(context)
+
+        assertEquals(
+            SessionWidgetState(activeSessionCount = 0),
+            store.readSessionWidgetState(),
+        )
+    }
+
+    private fun clearPrefs() {
+        context.getSharedPreferences("system_surfaces", Context.MODE_PRIVATE)
+            .edit().clear().commit()
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/CloseCachedRuntimeBoundedTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/CloseCachedRuntimeBoundedTest.kt
@@ -12,14 +12,15 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * Issue #710 regression: the VM-clear park path
- * ([TmuxSessionViewModel.closeCachedRuntimesBlocking]) calls
- * [CachedTmuxRuntime.closeCachedRuntime] inside `runBlocking` ON THE MAIN
- * THREAD. A pane producer/input/agent job wedged in a non-cooperative `-CC`
- * socket read never honours cancellation, so an unbounded
- * `cancelAndJoin()` (or `NonCancellable` `lease.release()`) would freeze the
- * main thread indefinitely — activity never DESTROYED, real-device freeze on
- * background-mid-rapid-switch.
+ * Issue #710 regression: the VM-clear path
+ * ([TmuxSessionViewModel.closeCachedRuntimesBounded], handed off the Main
+ * thread to the application-scoped teardown scope per #1085 F2) calls
+ * [CachedTmuxRuntime.closeCachedRuntime]. A pane producer/input/agent job
+ * wedged in a non-cooperative `-CC` socket read never honours cancellation, so
+ * an unbounded `cancelAndJoin()` (or `NonCancellable` `lease.release()`) would
+ * hang the teardown indefinitely — the lease/runtime never released, freezing
+ * background-mid-rapid-switch. This test pins the per-step bound inside
+ * [CachedTmuxRuntime.closeCachedRuntime] itself (independent of where it runs).
  *
  * These tests deliberately wedge each job slot (producer / input / agent) in a
  * non-cancellable infinite suspension and assert `closeCachedRuntime` returns

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
@@ -4172,6 +4172,140 @@ class TmuxSessionViewModelTest {
         }
     }
 
+    // ---- Issue #1080: Doze/app-standby wake must NOT ride through a dead socket ----
+    //
+    // Android deep Doze suspends the network so the keepalive cannot keep the NAT
+    // mapping alive; the socket is silently dead on wake. The KEYSTONE fix is that
+    // the transport-liveness oracle (RealSshSession.isTransportProvenAliveWithin-
+    // KeepAliveWindow) now uses the wall-elapsed boot clock that COUNTS deep sleep,
+    // so after a real Doze gap it correctly reports STALE (proven at the core-ssh
+    // layer by RealSshSessionDozeClockTest). These VM tests pin the DOWNSTREAM
+    // consequence: when the oracle reports stale on a post-Doze restore the
+    // #1042/#1078 restore path must redial (issue ONE bounded probe, then a fresh
+    // lease), NOT ride through the dead socket; and when the oracle is still alive
+    // (a short background, not deep sleep) the restore must still ride through.
+
+    @Test
+    fun issue1080PostDozeWakeStaleTransportRedialsInsteadOfRidingThrough() = runTest(scheduler) {
+        // Post-deep-Doze wake: the NAT mapping died during sleep, and because the
+        // oracle now counts deep sleep (the #1080 boot-clock fix) it correctly
+        // reports STALE — model that with transportProvenAlive=false (oracle aged
+        // out) AND a DEAD bounded probe (the dead socket cannot answer). The restore
+        // path MUST fall through to a fresh-lease redial, NOT ride through. Without
+        // the #1080 clock fix the real on-device oracle would have falsely reported
+        // ALIVE here (frozen monotonic clock under-counting the sleep) and the
+        // restore would have ridden through the dead socket — the bug this guards.
+        TMUX_CONNECT_ATTEMPTS.set(0)
+        val registry = ActiveTmuxClients()
+        val connector = QueueLeaseConnector(FakeSshSession())
+        val reconnectClient = FakeTmuxClient().withSinglePane("work", "%1")
+        val vm = newVm(
+            registry = registry,
+            sshLeaseManager = testLeaseManager(connector = connector, scope = this, idleTtlMillis = 0L),
+        )
+        vm.setTmuxClientFactoryForTest { _, sessionName, _ ->
+            assertEquals("work", sessionName)
+            reconnectClient
+        }
+        vm.setAutoReconnectDelaysForTest(listOf(0L))
+        // The live session whose keepalive aged out across the Doze gap (oracle stale).
+        val session = FakeSshSession().apply { transportProvenAlive = false }
+        vm.replaceClientForTest(
+            hostId = 7L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            sessionName = "work",
+            client = FakeTmuxClient(),
+            session = session,
+        )
+        runCurrent()
+        // The dead post-Doze socket cannot answer the bounded restore probe either.
+        vm.forceLivenessProbeDeadForTest = true
+        assertFalse(
+            "precondition: a post-Doze stale transport must NOT report proven-alive",
+            vm.isTransportKeepAliveProvenAliveRecentlyForTest(),
+        )
+
+        // The Doze interval: network drops while backgrounded, then restores on wake.
+        registry.lifecycleHooksSnapshot().single().onNetworkChanged(networkLoss())
+        runCurrent()
+        assertTrue(
+            "the loss leaves the session in the loss-suspended Reconnecting state",
+            vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Reconnecting,
+        )
+        registry.lifecycleHooksSnapshot().single().onNetworkChanged(networkRestore())
+        advanceUntilIdle()
+
+        assertEquals(
+            "a post-Doze restore over a STALE/dead transport (oracle aged out + probe dead) " +
+                "MUST redial — it must NOT ride through the dead socket (#1080)",
+            TmuxConnectTrigger.NetworkReconnect,
+            vm.latestRestoreIntentSnapshot()?.trigger,
+        )
+        assertEquals("exactly one fresh-lease redial on the post-Doze restore", 1, connector.connectCount)
+        assertSame(reconnectClient, registry.clients.value[7L]?.client)
+
+        vm.forceLivenessProbeDeadForTest = false
+    }
+
+    @Test
+    fun issue1080ShortBackgroundWakeAliveTransportStillRidesThrough() = runTest(scheduler) {
+        // Class-coverage (G2): the #1080 fix must NOT turn every background wake into
+        // a reconnect. A short background (screen-off, app-switch — NOT deep sleep)
+        // leaves the keepalive proving the link alive; the oracle still reports ALIVE
+        // and the restore must RIDE THROUGH with zero redials, exactly as #1042.
+        TMUX_CONNECT_ATTEMPTS.set(0)
+        val registry = ActiveTmuxClients()
+        val connector = QueueLeaseConnector(FakeSshSession())
+        val reconnectClient = FakeTmuxClient().withSinglePane("work", "%1")
+        val vm = newVm(
+            registry = registry,
+            sshLeaseManager = testLeaseManager(connector = connector, scope = this, idleTtlMillis = 0L),
+        )
+        vm.setTmuxClientFactoryForTest { _, _, _ -> reconnectClient }
+        vm.setAutoReconnectDelaysForTest(listOf(0L))
+        val session = FakeSshSession().apply { transportProvenAlive = true }
+        vm.replaceClientForTest(
+            hostId = 7L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            sessionName = "work",
+            client = FakeTmuxClient(),
+            session = session,
+        )
+        runCurrent()
+        assertTrue(
+            "precondition: a short-background link is still proven-alive (no deep sleep)",
+            vm.isTransportKeepAliveProvenAliveRecentlyForTest(),
+        )
+
+        registry.lifecycleHooksSnapshot().single().onNetworkChanged(networkLoss())
+        runCurrent()
+        registry.lifecycleHooksSnapshot().single().onNetworkChanged(networkRestore())
+        advanceUntilIdle()
+
+        assertEquals(
+            "a wake over a PROVEN-ALIVE transport must ride through with no redial (#1080 must " +
+                "not over-reconnect a healthy short-background link)",
+            0,
+            connector.connectCount,
+        )
+        assertNull(
+            "a ride-through wake must not schedule a network-reconnect redial",
+            vm.latestRestoreIntentSnapshot(),
+        )
+        assertTrue(
+            "the ride-through clears the loss-hold band back to Connected",
+            vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+    }
+
     @Test
     fun networkReconnectAndPassiveDisconnectAreCoalescedIntoOneAttempt() = runTest(scheduler) {
         TMUX_CONNECT_ATTEMPTS.set(0)

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
@@ -4173,6 +4173,170 @@ class TmuxSessionViewModelTest {
     }
 
     @Test
+    fun issue1078HandoffProbesAndRedialsWhenSocketDeadButPassivelyProvenAlive() = runTest(scheduler) {
+        // Issue #1078 reproduce-first (RED on base): the headline residual cellular
+        // stall. A REAL validated WIFI→CELLULAR handoff arrives while the transport is
+        // only PASSIVELY proven alive — the keepalive's last-inbound-byte age is still
+        // under the ~90s budget (forceTransportProvenAliveForTest=true → the reducer
+        // returns SuppressNetworkTransportProvenAlive) — but the old socket is GENUINELY
+        // DEAD post-handoff (an active probe fails, forceLivenessProbeDeadForTest=true).
+        //
+        // BASE BEHAVIOUR (the bug): the handoff suppress arm rode through on the passive
+        // timestamp ALONE with no active probe, so the session showed Live-but-FROZEN for
+        // up to ~90s until the keepalive budget finally tripped — no redial was ever
+        // scheduled. This test asserts a redial DOES fire, so it FAILS red on base.
+        //
+        // FIXED BEHAVIOUR (#1078, mirroring the #1042 restore arm): the suppress arm now
+        // issues ONE bounded active probe; it does not answer (dead socket), so it redials
+        // promptly via the SAME dead-link handoff authority (scheduleNetworkReconnect)
+        // within the probe budget instead of waiting out the ~90s keepalive.
+        TMUX_CONNECT_ATTEMPTS.set(0)
+        val registry = ActiveTmuxClients()
+        val connector = QueueLeaseConnector(FakeSshSession())
+        val reconnectClient = FakeTmuxClient().withSinglePane("work", "%1")
+        val vm = newVm(
+            registry = registry,
+            sshLeaseManager = testLeaseManager(connector = connector, scope = this, idleTtlMillis = 0L),
+        )
+        vm.setTmuxClientFactoryForTest { _, sessionName, _ ->
+            assertEquals("work", sessionName)
+            reconnectClient
+        }
+        vm.setAutoReconnectDelaysForTest(listOf(0L))
+        vm.replaceClientForTest(
+            hostId = 7L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            sessionName = "work",
+            client = FakeTmuxClient(),
+        )
+        runCurrent()
+        assertTrue(
+            "precondition: a healthy live session before the handoff",
+            vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+
+        // Passively proven alive (recent inbound byte) but the active probe is DEAD:
+        // exactly the dead-socket-after-handoff state the keepalive timestamp masks.
+        vm.forceTransportProvenAliveForTest = true
+        vm.forceLivenessProbeDeadForTest = true
+
+        registry.lifecycleHooksSnapshot().single().onNetworkChanged(
+            networkChange(
+                previous = TerminalNetworkSnapshot.Validated("wifi"),
+                current = TerminalNetworkSnapshot.Validated("cell"),
+                previousValidated = TerminalNetworkSnapshot.Validated("wifi"),
+                reason = "wifi-cellular-handoff-dead-socket-recent-inbound",
+            ),
+        )
+        advanceUntilIdle()
+
+        assertEquals(
+            "a handoff whose bounded probe does NOT answer must redial promptly (not freeze " +
+                "Live for ~90s) — #1078",
+            TmuxConnectTrigger.NetworkReconnect,
+            vm.latestRestoreIntentSnapshot()?.trigger,
+        )
+        assertEquals(
+            "exactly one fresh-lease redial after the dead-socket handoff probe fails",
+            1,
+            connector.connectCount,
+        )
+        assertSame(reconnectClient, registry.clients.value[7L]?.client)
+
+        vm.forceTransportProvenAliveForTest = null
+        vm.forceLivenessProbeDeadForTest = false
+    }
+
+    @Test
+    fun issue1078HandoffRidesThroughWhenProbeAnswersOnAliveSocket() = runTest(scheduler) {
+        // Issue #1078 class-coverage (D32 G2): the alive-socket handoff case. Same
+        // WIFI→CELLULAR validated handoff while passively proven alive
+        // (forceTransportProvenAliveForTest=true), but here the bounded active probe
+        // ANSWERS (forceLivenessProbeDeadForTest=false → the FakeTmuxClient refresh-client
+        // round-trips). The genuine ride-through win (#981/#974/#1058) MUST be preserved:
+        // NO spurious redial, the session stays Connected, and the ride-through is
+        // attributed to the probe (probeConfirmed=true) so the pass is not vacuous.
+        TMUX_CONNECT_ATTEMPTS.set(0)
+        val registry = ActiveTmuxClients()
+        val connector = QueueLeaseConnector(FakeSshSession())
+        val reconnectClient = FakeTmuxClient().withSinglePane("work", "%1")
+        val vm = newVm(
+            registry = registry,
+            sshLeaseManager = testLeaseManager(connector = connector, scope = this, idleTtlMillis = 0L),
+        )
+        vm.setTmuxClientFactoryForTest { _, _, _ -> reconnectClient }
+        vm.setAutoReconnectDelaysForTest(listOf(0L))
+        vm.replaceClientForTest(
+            hostId = 7L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            sessionName = "work",
+            client = FakeTmuxClient(),
+        )
+        runCurrent()
+
+        vm.forceTransportProvenAliveForTest = true
+        vm.forceLivenessProbeDeadForTest = false
+
+        val diagnostics = installRecordingDiagnosticSink()
+        try {
+            registry.lifecycleHooksSnapshot().single().onNetworkChanged(
+                networkChange(
+                    previous = TerminalNetworkSnapshot.Validated("wifi"),
+                    current = TerminalNetworkSnapshot.Validated("cell"),
+                    previousValidated = TerminalNetworkSnapshot.Validated("wifi"),
+                    reason = "wifi-cellular-handoff-alive-socket",
+                ),
+            )
+            advanceUntilIdle()
+
+            assertEquals(
+                "a handoff whose bounded probe ANSWERS must NOT redial (rides through) — #1078",
+                0,
+                connector.connectCount,
+            )
+            assertNull(
+                "a probe-confirmed handoff ride-through must not schedule a network-reconnect redial",
+                vm.latestRestoreIntentSnapshot(),
+            )
+            assertTrue(
+                "the ride-through keeps the session Connected (no Reconnecting overlay)",
+                vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected,
+            )
+            assertTrue(
+                "no redial diagnostic may fire on the probe-confirmed handoff ride-through; events=" +
+                    diagnostics.events.map { it.name },
+                diagnostics.eventsNamed("network_reconnect_start").isEmpty() &&
+                    diagnostics.eventsNamed("reconnect_start").isEmpty(),
+            )
+            val rideThrough = diagnostics.eventsNamed("network_reconnect_skip").filter {
+                it.fields["cause"] == "transport_proven_alive"
+            }
+            assertTrue(
+                "expected a transport_proven_alive network_reconnect_skip (proves the ride-through " +
+                    "arm fired, not a vacuous pass); events=${diagnostics.events.map { it.name }}",
+                rideThrough.isNotEmpty(),
+            )
+            assertEquals(
+                "the ride-through must be attributed to the bounded ACTIVE probe answering, not " +
+                    "the passive keepalive timestamp alone (distinguishes #1078 from a passive suppress)",
+                true,
+                rideThrough.single().fields["probeConfirmed"],
+            )
+        } finally {
+            diagnostics.close()
+            vm.forceTransportProvenAliveForTest = null
+        }
+    }
+
+    @Test
     fun networkReconnectAndPassiveDisconnectAreCoalescedIntoOneAttempt() = runTest(scheduler) {
         TMUX_CONNECT_ATTEMPTS.set(0)
         val registry = ActiveTmuxClients()

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
@@ -99,9 +99,13 @@ import org.json.JSONObject
 import java.io.File
 import java.io.IOException
 import java.io.InputStream
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
+import kotlin.coroutines.Continuation
 import kotlin.coroutines.CoroutineContext
+import kotlin.system.measureTimeMillis
 
 /**
  * Unit tests for [TmuxSessionViewModel] that exercise the per-pane
@@ -146,6 +150,22 @@ class TmuxSessionViewModelTest {
     // `codexLikeTmuxOutputWithSlowTerminalSideChannel...` (verified empirically:
     // 30/30 green on IO vs ~8% failure on the virtual scheduler).
     private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    // Issue #1085 (F2) test isolation: the application-scoped teardown work
+    // ([TmuxSessionViewModel.deferConnectionTeardownOffMain]) is now handed off
+    // `onCleared`'s Main thread to a CoroutineScope. In production that is the
+    // never-cancelled process singleton [AppTeardownScope.scope]; under unit
+    // tests that real-`Dispatchers.IO` singleton is never drained, so every
+    // `clearForTest()` (including the `@After` clear of still-connected VMs)
+    // would leak an IO teardown coroutine past `runTest`/`resetMain` — and that
+    // coroutine touches the test Main dispatcher as it cancels viewModelScope
+    // pane jobs, racing the NEXT class's `setMain` ("Dispatchers.Main is used
+    // concurrently with setting it"). We instead inject THIS per-test-instance
+    // scope into every `newVm`, then cancel+JOIN it in `@After` (exactly like
+    // `factoryScope`) so no teardown coroutine survives into the next class.
+    // It is a real `Dispatchers.IO` scope (off-Main), so the F2 off-Main
+    // hand-off it backs is genuine, not a virtual-clock proxy.
+    private val defaultTeardownScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val createdViewModels = mutableListOf<TmuxSessionViewModel>()
 
     private fun newVm(
@@ -233,6 +253,12 @@ class TmuxSessionViewModelTest {
             // Pin the card source calls to the test scheduler so card feed
             // assertions cannot time out before a background continuation runs.
             it.setSessionCardsDispatcherForTest(testMainDispatcher)
+            // Issue #1085 (F2) test isolation: route the off-Main connection
+            // teardown to this per-test-instance scope (drained in `@After`)
+            // instead of the never-cancelled production singleton, so no
+            // teardown coroutine leaks into the next test class. Individual F2
+            // off-Main tests may override this with a virtual-clock scope.
+            it.setTeardownScopeForTest(defaultTeardownScope)
             createdViewModels += it
         }
 
@@ -320,7 +346,20 @@ class TmuxSessionViewModelTest {
             withTimeoutOrNull(SLOW_FEED_DRAIN_TIMEOUT_MS) {
                 factoryScope.coroutineContext.job.children.forEach { it.join() }
             }
+            // Issue #1085 (F2) test isolation: JOIN the off-Main teardown
+            // coroutines the `@After` clears (and any in-test `clearForTest`)
+            // launched onto `defaultTeardownScope` BEFORE the rule's
+            // `resetMain()` runs. Join first (the teardown closes are FINITE —
+            // they complete after each close returns — so a natural join
+            // terminates without needing a cancel), then cancel as a safety
+            // net. Without this drain the IO teardown coroutine survives into
+            // the next class's `setMain` and throws "Dispatchers.Main is used
+            // concurrently with setting it".
+            withTimeoutOrNull(SLOW_FEED_DRAIN_TIMEOUT_MS) {
+                defaultTeardownScope.coroutineContext.job.children.forEach { it.join() }
+            }
         }
+        defaultTeardownScope.cancel()
     }
 
     @Test
@@ -14883,6 +14922,11 @@ class TmuxSessionViewModelTest {
             ),
         )
         val vm = newVm(runtimeCache = runtimeCache)
+        // Issue #1085 (F2): the teardown closes evicted runtimes on the
+        // application-scoped teardown scope (off Main). Pin it to the shared
+        // virtual-clock scheduler so `advanceUntilIdle()` drives the async
+        // close deterministically (no real-IO race).
+        vm.setTeardownScopeForTest(CoroutineScope(StandardTestDispatcher(scheduler)))
         val activeClient = FakeTmuxClient()
         val activeSession = FakeSshSession()
         vm.replaceClientForTest(
@@ -14899,7 +14943,7 @@ class TmuxSessionViewModelTest {
         vm.setProcessForegroundForClearedForTest(false)
 
         vm.clearForTest()
-        runCurrent()
+        advanceUntilIdle()
 
         assertTrue("evicted parked client must detach during background clear", evictedClient.detachCleanlyCalled)
         assertTrue("evicted parked client must close during background clear", evictedClient.closed)
@@ -14914,6 +14958,11 @@ class TmuxSessionViewModelTest {
     fun foregroundOnClearedStillClosesLiveRuntimeForUserNavigation() = runTest(scheduler) {
         val runtimeCache = TmuxSessionRuntimeCache()
         val vm = newVm(runtimeCache = runtimeCache)
+        // Issue #1085 (F2): the foreground clear hands the live runtime's
+        // detach/close to the application-scoped teardown scope (off Main).
+        // Pin it to the shared virtual-clock scheduler so `advanceUntilIdle()`
+        // drives the async close deterministically.
+        vm.setTeardownScopeForTest(CoroutineScope(StandardTestDispatcher(scheduler)))
         val client = FakeTmuxClient()
         val session = FakeSshSession()
         vm.replaceClientForTest(
@@ -14930,7 +14979,7 @@ class TmuxSessionViewModelTest {
         vm.setProcessForegroundForClearedForTest(true)
 
         vm.clearForTest()
-        runCurrent()
+        advanceUntilIdle()
 
         assertTrue("foreground clear must keep the explicit detach/close behavior", client.detachCleanlyCalled)
         assertTrue("foreground clear must close the tmux client", client.closed)
@@ -15889,6 +15938,109 @@ class TmuxSessionViewModelTest {
         )
     }
 
+    /**
+     * Issue #1085 (F2) reproduce-first — the MULTI-RUNTIME teardown class.
+     * `onCleared` → `closeCurrentConnection` runs on the Main thread and used to
+     * close every host-cached runtime via `runBlocking(Dispatchers.IO)` ON Main.
+     * Each runtime's `lease.release()` is a NON-suspending park whose bounded
+     * `SYNC_DETACH_TIMEOUT_MS` ceiling a coroutine cancel cannot interrupt — so
+     * on a wedged transport the real Main park is the SUM of the N runtimes'
+     * wedges (a multi-second / ANR-class freeze finishing a session).
+     *
+     * RED on base: `clearForTest()` parks the calling (Main) thread for ~3×800ms
+     * — the elapsed assertion fails.
+     *
+     * GREEN with the fix: `closeCurrentConnection` captures the runtimes, nulls
+     * the fields on Main, and hands the closes to the application-scoped teardown
+     * scope, so `onCleared` returns immediately AND every runtime is still closed
+     * to completion off-Main (all three latches fire) — no leak, no Main park.
+     */
+    @Test
+    fun onClearedClosesCachedRuntimesOffMainAndNeverParksTheCallingThread() = runTest(scheduler) {
+        val hostId = 7L
+        val released = CountDownLatch(3)
+        val wedgeMs = 800L
+        // maxEntries high enough that the three same-host runtimes coexist (the
+        // default per-host cap would evict one); nowMs pinned so no TTL expiry.
+        val runtimeCache = TmuxSessionRuntimeCache(maxEntries = 8, nowMs = { 0L })
+        // Issue #1085 (F2) test isolation: run the teardown on the per-test
+        // `defaultTeardownScope` `newVm` injects — a real `Dispatchers.IO` scope
+        // (so the hand-off genuinely leaves Main) that `@After` cancels+JOINs,
+        // so the wedged release coroutines cannot escape `runTest`/`resetMain`.
+        val vm = newVm(runtimeCache = runtimeCache)
+        try {
+            vm.replaceClientForTest(
+                hostId = hostId,
+                hostName = "alpha",
+                host = "alpha.example",
+                port = 22,
+                user = "alex",
+                keyPath = "/keys/a",
+                sessionName = "work",
+                client = FakeTmuxClient(),
+                session = FakeSshSession(),
+            )
+            runCurrent()
+            // Park three wedged cached runtimes under the ACTIVE host; the
+            // teardown's `runtimeCache.removeHost(hostId)` returns all three and
+            // must close every one off the Main thread.
+            repeat(3) { i ->
+                runtimeCache.put(
+                    cachedRuntimeForTest(
+                        sessionName = "cached-$i",
+                        hostId = hostId,
+                        lease = wedgedLeaseForTest(
+                            SshLeaseKey("alpha.example", 22, "alex", "$hostId:/keys/a-$i"),
+                            FakeSshSession(),
+                            wedgeMs,
+                        ) { released.countDown() },
+                    ),
+                )
+            }
+            assertEquals(3, runtimeCache.size())
+            vm.setProcessForegroundForClearedForTest(true)
+
+            val elapsedMs = measureTimeMillis { vm.clearForTest() }
+
+            assertTrue(
+                "onCleared parked the calling (Main) thread for ${elapsedMs}ms closing 3 wedged " +
+                    "cached runtimes — the #1085 F2 multi-runtime teardown ANR. The closes must " +
+                    "be handed to the application-scoped teardown scope so onCleared returns " +
+                    "immediately.",
+                elapsedMs < TEARDOWN_PARK_BUDGET_MS,
+            )
+            assertTrue(
+                "every cached runtime's lease release must still run to COMPLETION off the Main " +
+                    "thread (no leak) — only ${3 - released.count} of 3 fired.",
+                released.await(10, TimeUnit.SECONDS),
+            )
+        } finally {
+            vm.setProcessForegroundForClearedForTest(null)
+        }
+    }
+
+    /**
+     * Build an [SshLease] (internal constructor) whose `releaseAction` blocks
+     * the calling thread for [wedgeMs] then signals [onReleased] — a wedged
+     * transport close whose bounded ceiling is defeated because a coroutine
+     * cancel cannot unpark a parked thread. Mirrors the reflection-built lease
+     * the sibling nav-scoped suites use.
+     */
+    private fun wedgedLeaseForTest(
+        key: SshLeaseKey,
+        session: SshSession,
+        wedgeMs: Long,
+        onReleased: () -> Unit,
+    ): SshLease {
+        val releaseAction = { _: SshLeaseKey, _: Long, _: Continuation<Unit> ->
+            Thread.sleep(wedgeMs)
+            onReleased()
+            Unit
+        }
+        val constructor = SshLease::class.java.declaredConstructors.single()
+        return constructor.newInstance(key, session, false, 0L, releaseAction) as SshLease
+    }
+
     private fun cachedRuntimeForTest(
         sessionName: String,
         hostId: Long = 1L,
@@ -16711,6 +16863,11 @@ class TmuxSessionViewModelTest {
         // box (observed >5s under 15+ load) WITHOUT slowing a passing run. A
         // genuinely stuck feed still times out and fails the assertion below.
         const val SLOW_FEED_DRAIN_TIMEOUT_MS = 30_000L
+
+        // Issue #1085 (F2): the off-Main hand-off must let onCleared return
+        // within a small budget; on base closing the 3 wedged runtimes parks the
+        // calling thread for ~3×800ms.
+        const val TEARDOWN_PARK_BUDGET_MS = 500L
 
         // Issue #713: `runTest` enforces its OWN default 60s wall-clock budget.
         // The slow-feed drains above busy-wait (Thread.sleep / real-IO feed) for

--- a/app/src/test/java/com/pocketshell/app/usage/UsageNotificationStateStoreOffMainTest.kt
+++ b/app/src/test/java/com/pocketshell/app/usage/UsageNotificationStateStoreOffMainTest.kt
@@ -1,0 +1,108 @@
+package com.pocketshell.app.usage
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.pocketshell.core.usage.UsageThresholdState
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Regression proof for issue #1087 freeze cause F6 (class sweep): building the
+ * `usage_notification_state` SharedPreferences eagerly in
+ * [SharedPreferencesUsageNotificationStateStore]'s constructor ran a
+ * synchronous first-touch disk read on the **Main** thread. This store is
+ * built during `App.onCreate` Hilt injection (the `@Singleton` `UsageNotifier`
+ * graph, via `UsageScheduler`) — before `StrictModeInstaller` arms, so it is
+ * not in the cold-launch StrictMode log, but it is the identical Main-thread
+ * launch cost as the flagged `LastSessionStore.<init>`.
+ *
+ * Reproduce-first (D33 / G10, #780 — no self-skip): the load-bearing assertion
+ * is that the prefs-file build runs on a thread OTHER than the constructing
+ * (Main) thread. Pre-fix the read happened in `<init>` on the constructing
+ * thread (RED); with the off-main eager-`async` build it runs on the IO
+ * dispatcher (GREEN).
+ *
+ * Class coverage (G2): the default set is empty and a write→fresh-instance read
+ * ("process restart") returns the persisted notified keys after the off-main
+ * build.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class UsageNotificationStateStoreOffMainTest {
+
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        clearPrefs()
+    }
+
+    @After
+    fun tearDown() {
+        clearPrefs()
+    }
+
+    /**
+     * LOAD-BEARING (#1087 F6): the `usage_notification_state` prefs file must
+     * NOT be built on the thread that constructs the store (the Main thread
+     * during `App.onCreate` Hilt injection in production).
+     */
+    @Test
+    fun prefs_build_does_not_run_on_constructing_thread() {
+        val constructingThread = Thread.currentThread().name
+
+        val store = SharedPreferencesUsageNotificationStateStore(context)
+        val buildThread = store.awaitPrefsBuildThreadNameForTest()
+
+        assertNotEquals(
+            "usage_notification_state prefs must be built off the constructing " +
+                "(Main) thread, not on it (#1087 F6). " +
+                "constructing=$constructingThread build=$buildThread",
+            constructingThread,
+            buildThread,
+        )
+    }
+
+    /** No empty/racey first read: the default set is empty after the off-main build. */
+    @Test
+    fun default_notified_keys_empty_after_offmain_build() {
+        val store = SharedPreferencesUsageNotificationStateStore(context)
+        assertTrue(store.notifiedKeys().isEmpty())
+    }
+
+    /** Write→fresh-instance read survives the off-main build (process restart). */
+    @Test
+    fun notified_keys_round_trip_and_survive_restart_after_offmain_build() {
+        val keys = setOf(
+            UsageNotificationKey(
+                hostId = 7L,
+                provider = "anthropic",
+                state = UsageThresholdState.Critical,
+                windowName = "5h",
+            ),
+            UsageNotificationKey(
+                hostId = 9L,
+                provider = "openai",
+                state = UsageThresholdState.Exceeded,
+                windowName = null,
+            ),
+        )
+        SharedPreferencesUsageNotificationStateStore(context).setNotifiedKeys(keys)
+
+        val restarted = SharedPreferencesUsageNotificationStateStore(context)
+        assertEquals(keys, restarted.notifiedKeys())
+    }
+
+    private fun clearPrefs() {
+        context.getSharedPreferences("usage_notification_state", Context.MODE_PRIVATE)
+            .edit().clear().commit()
+    }
+}

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -673,6 +673,24 @@ JOURNEY_CLASSES=(
   # fully-qualified name directly. The heavier live-burst on-device acceptance
   # (Issue796ComposerOpenDuringCodexBurstProofTest) stays out of this fast subset.
   "com.pocketshell.app.tmux.Issue796ComposerOpenTerminalScopeProofTest"
+  # ADDED (#1085 F3): the voice-first recomposition-jank scope proof. The
+  # maintainer's "app KEEPS FREEZING" report; F3 is the recomposition vector —
+  # inline-dictation amplitude (20 Hz) and agent-transcript streaming (60ms) were
+  # read at the ROOT of the 7k-line TmuxSessionScreen body, so the whole body
+  # recomposed at the flow's frequency while dictating / while an agent streamed.
+  # The fix derives the dictation MODE (not the amplitude) and a STABLE
+  # SurfaceConversationChrome projection (not the streaming events) in the body,
+  # and reads the high-frequency events list inside the surfaceContent child
+  # scope. This DETERMINISTIC scope proof drives a 20-sample amplitude burst and a
+  # 20-flush streaming burst against the production read structure (the real
+  # SurfaceConversationChrome data class + derivedStateOf projection) and
+  # HARD-asserts O(1) body recompositions, with sibling RED guards pinning the
+  # pre-fix whole-state / direct-map reads at ~N. In-process Compose UI test, NO
+  # Docker fixture, NO assumeTrue / assumeFalse(isRunningOnCi()) on the
+  # load-bearing assertion (process.md F3). Runs per-push so the recomposition
+  # jank cannot silently return (#638/#657). Lives under com.pocketshell.app.tmux,
+  # so it carries its fully-qualified name directly.
+  "com.pocketshell.app.tmux.Issue1085RecompositionScopeProofTest"
   # ADDED (#810): the composer-launcher ALWAYS-PRESENT switch journey. The
   # maintainer dogfooded the composer launcher DROPPING OUT after a session
   # switch (A->B->C->A): the launcher chip rendered on the first session but

--- a/shared/core-assistant/src/main/java/com/pocketshell/core/assistant/store/AssistantConfigStore.kt
+++ b/shared/core-assistant/src/main/java/com/pocketshell/core/assistant/store/AssistantConfigStore.kt
@@ -14,6 +14,13 @@ import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
 import com.pocketshell.core.assistant.AssistantProvider
 import com.pocketshell.core.assistant.AssistantSettings
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
 
 /**
  * Secret-safe interface the app / view-model consumes. Mirrors the
@@ -61,16 +68,74 @@ public interface AssistantConfigStore {
  * disturb the Whisper key entry. Decision D25 + the issue's non-goal "no
  * change to voice transcription provider".
  *
+ * ## Off-main construction (issue #1085, freeze cause F1)
+ *
+ * Building [EncryptedSharedPreferences] eagerly in the constructor used to
+ * run Tink / Android-Keystore init (~1.2-1.3s cold) **on the Main thread**,
+ * because Hilt constructs this `@Singleton` the moment the activity's
+ * `TmuxSessionViewModel` is first dereferenced — and that deref happens
+ * inside the first `setContent {}` composition frame. The keystore build
+ * froze the first frame on every cold launch.
+ *
+ * The fix: never build the encrypted prefs on the calling thread. The
+ * constructor only *kicks off* the build on [ioDispatcher] (an eager
+ * [kotlinx.coroutines.async]); it returns immediately. The build runs on a
+ * background thread, so neither `<init>` nor composition blocks the UI
+ * thread. The first read warms-or-awaits that background result (the build
+ * is started at launch, so by the time the user opens Settings / sends an
+ * assistant message the value is ready and the read does not block). The
+ * encrypted-at-rest guarantee is unchanged — it is still
+ * [EncryptedSharedPreferences], just constructed off-main. Hard-cut (D22):
+ * there is no synchronous fallback path.
+ *
  * @param context any Context; the application context is held internally so
  *   an Activity isn't pinned.
  * @param fileName encrypted prefs file name; overridable for tests.
+ * @param ioDispatcher dispatcher the keystore-backed prefs are built on;
+ *   defaults to [Dispatchers.IO]. Overridable for tests.
  */
-public class AndroidKeystoreAssistantConfigStore(
+public class AndroidKeystoreAssistantConfigStore @JvmOverloads constructor(
     context: Context,
     fileName: String = DEFAULT_PREFERENCES_FILE,
+    ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : AssistantConfigStore {
 
-    private val prefs: SharedPreferences = buildPrefs(context.applicationContext, fileName)
+    private val appContext = context.applicationContext
+
+    // Once the background build completes, the result is cached here so reads
+    // never re-enter runBlocking. @Volatile: written on [ioDispatcher],
+    // read from any consumer thread.
+    @Volatile
+    private var cachedPrefs: SharedPreferences? = null
+
+    // Test seam (issue #1085): records the name of the thread the keystore
+    // build actually ran on, so a regression test can hard-assert it is NOT
+    // the constructing/Main thread. Written on [ioDispatcher].
+    @Volatile
+    private var prefsBuildThreadName: String? = null
+
+    // Eager async: the build STARTS at construction (i.e. at launch) but on a
+    // background thread. `async` (DEFAULT start) dispatches immediately and
+    // returns without blocking the caller.
+    private val warmUpScope = CoroutineScope(SupervisorJob() + ioDispatcher)
+    private val prefsDeferred: Deferred<SharedPreferences> = warmUpScope.async {
+        prefsBuildThreadName = Thread.currentThread().name
+        buildPrefs(appContext, fileName).also { cachedPrefs = it }
+    }
+
+    private val prefs: SharedPreferences
+        get() = cachedPrefs ?: runBlocking { prefsDeferred.await() }
+
+    /**
+     * Test-only: block until the off-main build completes and return the name
+     * of the thread it ran on. Lets a regression test prove the keystore
+     * construction did NOT happen on the constructing/Main thread (#1085).
+     */
+    internal fun awaitPrefsBuildThreadNameForTest(): String {
+        runBlocking { prefsDeferred.await() }
+        return prefsBuildThreadName
+            ?: error("prefs build thread was not recorded")
+    }
 
     override fun loadSettings(): AssistantSettings {
         val provider = AssistantProvider.fromName(prefs.getString(KEY_PROVIDER, null))

--- a/shared/core-assistant/src/test/java/com/pocketshell/core/assistant/AssistantConfigStoreOffMainTest.kt
+++ b/shared/core-assistant/src/test/java/com/pocketshell/core/assistant/AssistantConfigStoreOffMainTest.kt
@@ -1,0 +1,113 @@
+package com.pocketshell.core.assistant
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.pocketshell.core.assistant.store.AndroidKeystoreAssistantConfigStore
+import org.junit.After
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+
+/**
+ * Regression proof for issue #1085 freeze cause F1: the
+ * `EncryptedSharedPreferences` / Android-Keystore (Tink) build used to run
+ * synchronously in [AndroidKeystoreAssistantConfigStore]'s constructor — and
+ * Hilt constructs that `@Singleton` inside the first Compose frame (Main
+ * thread), so every cold launch froze the UI thread for ~1.2-1.3s while Tink
+ * initialised.
+ *
+ * Reproduce-first (D33 / G10): the load-bearing assertion is that the keystore
+ * build runs on a thread OTHER than the constructing (Main) thread. On the
+ * pre-fix code `buildPrefs` ran in `<init>` on the constructing thread, so
+ * [no_keystore_build_on_constructing_thread] FAILS RED; with the off-main
+ * build it runs on the IO dispatcher and PASSES GREEN.
+ *
+ * Class coverage (G2): the remaining tests prove the off-main init does not
+ * introduce an empty/racey first read — defaults, key round-trip, and a
+ * fresh-instance ("process restart") read all return the correct values after
+ * the build is awaited.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class AssistantConfigStoreOffMainTest {
+
+    private lateinit var context: Context
+    private val prefsFile = "test-assistant-offmain-secrets"
+
+    @Before
+    fun setUp() {
+        FakeAndroidKeyStore.install()
+        context = ApplicationProvider.getApplicationContext()
+        clearPrefs()
+    }
+
+    @After
+    fun tearDown() {
+        clearPrefs()
+    }
+
+    private fun newStore() = AndroidKeystoreAssistantConfigStore(context, prefsFile)
+
+    /**
+     * LOAD-BEARING (#1085 F1): the keystore-backed prefs must NOT be built on
+     * the thread that constructs the store (which, in production, is the Main
+     * thread during the first Compose frame).
+     */
+    @Test
+    fun no_keystore_build_on_constructing_thread() {
+        val constructingThread = Thread.currentThread().name
+        val store = newStore()
+
+        val buildThread = store.awaitPrefsBuildThreadNameForTest()
+
+        assertNotEquals(
+            "EncryptedSharedPreferences/Keystore must be built off the " +
+                "constructing (Main) thread, not on it (#1085 F1). " +
+                "constructing=$constructingThread build=$buildThread",
+            constructingThread,
+            buildThread,
+        )
+    }
+
+    /** No empty/racey first read: defaults are correct after off-main build. */
+    @Test
+    fun defaults_are_correct_after_offmain_build() {
+        val settings = newStore().loadSettings()
+        assertEquals(AssistantProvider.OpenAi, settings.provider)
+        assertEquals(AssistantSettings.DEFAULT_OPENAI_BASE_URL, settings.openAiBaseUrl)
+        assertEquals(AssistantSettings.DEFAULT_OPENAI_MODEL, settings.openAiModel)
+        assertNull(newStore().loadKey(AssistantProvider.OpenAi))
+    }
+
+    /** Round-trip + fresh-instance read survives the off-main build. */
+    @Test
+    fun config_round_trips_and_survives_restart_after_offmain_build() {
+        newStore().apply {
+            setProvider(AssistantProvider.Anthropic)
+            setEndpoint(AssistantProvider.Anthropic, "https://anth.example/v1", "claude-test")
+            saveKey(AssistantProvider.Anthropic, "sk-offmain-123".toCharArray())
+        }
+
+        val restarted = newStore()
+        val settings = restarted.loadSettings()
+        assertEquals(AssistantProvider.Anthropic, settings.provider)
+        assertEquals("https://anth.example/v1", settings.anthropicBaseUrl)
+        assertEquals("claude-test", settings.anthropicModel)
+        assertArrayEquals(
+            "sk-offmain-123".toCharArray(),
+            restarted.loadKey(AssistantProvider.Anthropic),
+        )
+    }
+
+    private fun clearPrefs() {
+        context.getSharedPreferences(prefsFile, Context.MODE_PRIVATE).edit().clear().commit()
+        File(context.filesDir.parentFile, "shared_prefs/$prefsFile.xml").delete()
+    }
+}

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshSession.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshSession.kt
@@ -71,6 +71,33 @@ internal class RealSshSession(
      * interval.
      */
     private val downloadStallTimeoutMs: Long = DOWNLOAD_STALL_TIMEOUT_MS,
+    /**
+     * Issue #1080 — the wall-elapsed "now" clock (nanos) used for the
+     * transport-liveness STALENESS decision
+     * ([isTransportProvenAliveWithinKeepAliveWindow]) and for stamping the
+     * activity watermarks it compares against ([lastInboundActivityNanos] /
+     * [lastOutboundActivityNanos], the keepalive's reset-on-activity inputs).
+     *
+     * Production injects `SystemClock.elapsedRealtimeNanos()` (CLOCK_BOOTTIME),
+     * which COUNTS time the device spends in deep sleep. The old code used
+     * [System.nanoTime] (CLOCK_MONOTONIC), which STOPS during deep sleep — so
+     * after an Android Doze gap (carrier NAT mapping already timed out, socket
+     * silently half-open) the monotonic delta under-counted the real elapsed
+     * time and the staleness oracle FALSELY reported the dead socket "alive
+     * within the keepalive window," letting the #1042 restore ride-through and
+     * the #1078 handoff arm sail through a DEAD transport instead of redialing.
+     * Counting the sleep makes the oracle correctly report STALE so the existing
+     * reconnect machinery recovers (no new mechanism — D28).
+     *
+     * The default is [System.nanoTime] because the pure-JVM unit tests run
+     * against the android.jar stub where `SystemClock` throws "not mocked"; the
+     * single PRODUCTION construction site (`SshConnection.toSession`) injects the
+     * real boot clock, and the #1080 reproduce-first test injects a synthetic
+     * clock to model the frozen-monotonic-but-advancing-wall-time Doze gap. The
+     * SAME clock is handed to [keepAlive] so the loop's reset-on-activity
+     * `now - lastActivity` math never mixes clock domains.
+     */
+    private val nowNanos: () -> Long = { System.nanoTime() },
 ) : SshSession {
 
     /**
@@ -118,7 +145,8 @@ internal class RealSshSession(
     }
 
     /**
-     * Monotonic ([System.nanoTime]) timestamp of the most recent inbound
+     * Wall-elapsed timestamp ([nowNanos] — `SystemClock.elapsedRealtimeNanos()`
+     * in production, counting deep sleep; issue #1080) of the most recent inbound
      * transport activity — bumped on a successful keepalive reply (issue #945)
      * AND on ANY decoded application bytes the server sends back over the
      * transport: the live `-CC` control-mode reader's output, an exec/list/cat
@@ -152,16 +180,17 @@ internal class RealSshSession(
      * promptly (the fix must not make a dead link look alive forever).
      */
     @Volatile
-    private var lastInboundActivityNanos: Long = System.nanoTime()
+    private var lastInboundActivityNanos: Long = nowNanos()
 
     /**
-     * Monotonic timestamp of the most recent outbound upload payload bytes. This
+     * Wall-elapsed timestamp ([nowNanos], counting deep sleep; issue #1080) of
+     * the most recent outbound upload payload bytes. This
      * mirrors [lastInboundActivityNanos] for the high-volume client-to-server
      * path: an upload that is steadily writing payload is active even when the
      * server is quiet until EOF.
      */
     @Volatile
-    private var lastOutboundActivityNanos: Long = System.nanoTime()
+    private var lastOutboundActivityNanos: Long = nowNanos()
 
     /**
      * Record inbound transport activity (issue #974). Called from EVERY path
@@ -173,7 +202,7 @@ internal class RealSshSession(
      * promises. Cheap volatile store, safe to call from any reader thread.
      */
     private fun recordInboundActivity() {
-        lastInboundActivityNanos = System.nanoTime()
+        lastInboundActivityNanos = nowNanos()
     }
 
     /**
@@ -183,7 +212,7 @@ internal class RealSshSession(
      * not stalled.
      */
     private fun recordOutboundActivity() {
-        lastOutboundActivityNanos = System.nanoTime()
+        lastOutboundActivityNanos = nowNanos()
     }
 
     /**
@@ -281,6 +310,11 @@ internal class RealSshSession(
         // the 30s / 3 defaults (the override is null unless a test set it).
         intervalMs = KeepAliveTestOverride.intervalMs(),
         countMax = KeepAliveTestOverride.countMax(),
+        // Issue #1080 — feed the keepalive loop the SAME wall-elapsed clock the
+        // activity watermarks are stamped with, so its reset-on-activity
+        // `now - lastActivity` elapsed math stays in one clock domain (and counts
+        // deep sleep in production exactly like the staleness oracle above).
+        now = nowNanos,
         log = { msg -> KEEPALIVE_LOGGER.log(Level.FINE, "[$KEEPALIVE_LOG_TAG] $msg") },
     )
 
@@ -324,7 +358,13 @@ internal class RealSshSession(
         // writes, outbound stops advancing, and BOTH timestamps age out past the
         // ride-through window → returns false → the keepalive's own budget closes it.
         val mostRecentActivityNanos = maxOf(lastInboundActivityNanos, lastOutboundActivityNanos)
-        val sinceActivityNanos = System.nanoTime() - mostRecentActivityNanos
+        // Issue #1080 — [nowNanos] is the wall-elapsed boot clock in production
+        // (counts deep sleep), so after a Doze gap this delta reflects the REAL
+        // elapsed time and correctly ages past the ride-through window → returns
+        // false → the restore/handoff redials a dead socket instead of riding
+        // through it. With the old System.nanoTime() the monotonic clock froze in
+        // deep sleep, this delta under-counted, and a dead socket looked alive.
+        val sinceActivityNanos = nowNanos() - mostRecentActivityNanos
         val rideThroughNanos = TransportKeepAlive.RIDE_THROUGH_BUDGET_MS * 1_000_000L
         return sinceActivityNanos in 0 until rideThroughNanos
     }
@@ -483,6 +523,14 @@ internal class RealSshSession(
         // timestamp to advance (a reply OR any reader byte). "No inbound activity
         // within the budget" IS the liveness question, and it leaves the promise
         // intact — the late reply is delivered to its OWN promise, not the next one.
+        // Issue #1080 — this is a SHORT (≤ KEEPALIVE_REPLY_TIMEOUT_MS) local
+        // reply wait, and it stays on [System.nanoTime] DELIBERATELY: both ends of
+        // the deadline are monotonic so the elapsed math is self-consistent, and
+        // the liveness check below is an EQUALITY test on the watermark
+        // (`lastInboundActivityNanos != before`), not a staleness `now - watermark`
+        // subtraction — so it never mixes the boot-clock watermark with a
+        // monotonic now. The Doze-gap staleness decision lives in
+        // [isTransportProvenAliveWithinKeepAliveWindow], which uses [nowNanos].
         val deadline = System.nanoTime() + KEEPALIVE_REPLY_TIMEOUT_MS * 1_000_000L
         while (System.nanoTime() < deadline) {
             if (lastInboundActivityNanos != before) return true

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshConnection.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshConnection.kt
@@ -1,5 +1,6 @@
 package com.pocketshell.core.ssh
 
+import android.os.SystemClock
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -369,7 +370,16 @@ public object SshConnection {
             clearLiveChannelReadTimeout(client)
         }
 
-        override fun toSession(client: SSHClient): SshSession = RealSshSession(client)
+        override fun toSession(client: SSHClient): SshSession =
+            // Issue #1080 — inject the wall-elapsed boot clock
+            // (`SystemClock.elapsedRealtimeNanos()`, CLOCK_BOOTTIME) so the
+            // transport-liveness staleness oracle COUNTS deep sleep. System.nanoTime
+            // (CLOCK_MONOTONIC) freezes in deep Doze, so after a Doze gap a dead
+            // socket looked "alive within the keepalive window" and the restore /
+            // handoff ride-through sailed through it instead of redialing. This is
+            // the single production construction site; the unit tests keep the
+            // System.nanoTime default (the android.jar stub can't run SystemClock).
+            RealSshSession(client, nowNanos = { SystemClock.elapsedRealtimeNanos() })
 
         override fun disconnect(client: SSHClient) {
             client.disconnect()

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/TransportKeepAlive.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/TransportKeepAlive.kt
@@ -61,6 +61,20 @@ internal class TransportKeepAlive(
     private val io: KeepAliveIo,
     private val intervalMs: Long = DEFAULT_INTERVAL_MS,
     private val countMax: Int = DEFAULT_COUNT_MAX,
+    /**
+     * Issue #1080 — the "now" clock the reset-on-activity shortcut compares the
+     * [KeepAliveIo] activity watermarks against. It MUST be the SAME clock domain
+     * the session stamps [KeepAliveIo.lastInboundActivityNanos] /
+     * [KeepAliveIo.lastOutboundActivityNanos] with, or the
+     * `now() - lastActivity` elapsed math mixes domains and is garbage.
+     * Production [RealSshSession] stamps those watermarks with
+     * `SystemClock.elapsedRealtimeNanos()` (CLOCK_BOOTTIME, which COUNTS deep
+     * sleep) and passes the same clock here. Default is [System.nanoTime] so the
+     * pure-JVM unit tests (which run against the android.jar stub where
+     * `SystemClock` throws "not mocked") keep working — the [FakeIo] in those
+     * tests supplies its watermarks in whatever domain matches this default.
+     */
+    private val now: () -> Long = { System.nanoTime() },
     private val log: (String) -> Unit = {},
 ) {
     init {
@@ -83,7 +97,9 @@ internal class TransportKeepAlive(
         fun isAlive(): Boolean
 
         /**
-         * Nanos (monotonic, [System.nanoTime] domain) of the most recent inbound
+         * Nanos (in the loop's [now] clock domain — production uses the wall-
+         * elapsed `SystemClock.elapsedRealtimeNanos()`, issue #1080) of the most
+         * recent inbound
          * transport activity the session has observed — a keepalive reply, an
          * exec/tail round-trip, any bytes from the server. The loop SKIPS the
          * explicit ping when this is within [intervalMs] of now, so a busy link
@@ -93,7 +109,9 @@ internal class TransportKeepAlive(
         fun lastInboundActivityNanos(): Long
 
         /**
-         * Issue #1072 — nanos (monotonic, [System.nanoTime] domain) of the most
+         * Issue #1072 — nanos (in the loop's [now] clock domain — production uses
+         * the wall-elapsed `SystemClock.elapsedRealtimeNanos()`, issue #1080) of
+         * the most
          * recent OUTBOUND payload progress the session has made: a steadily
          * advancing file/attachment upload pushing client→server bytes.
          *
@@ -194,7 +212,7 @@ internal class TransportKeepAlive(
                 // This is why a heavy `%output` burst is POSITIVE proof of life,
                 // not a missed probe; and why a steadily-streaming attachment
                 // upload (pure outbound) must NOT be torn down mid-upload (#1072).
-                val sinceActivityNanos = System.nanoTime() - io.lastActivityNanos()
+                val sinceActivityNanos = now() - io.lastActivityNanos()
                 if (sinceActivityNanos in 0 until intervalNanos()) {
                     if (consecutiveMisses != 0) {
                         log("keepalive: inbound activity, reset after $consecutiveMisses miss(es)")

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshSessionDozeClockTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshSessionDozeClockTest.kt
@@ -1,0 +1,189 @@
+package com.pocketshell.core.ssh
+
+import net.schmizz.sshj.SSHClient
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1080 — reproduce-first JVM proof for the Doze clock-domain bug (D33/G10,
+ * the #780 synthetic-clock model, NO `assumeTrue` self-skip on the load-bearing
+ * assertion).
+ *
+ * ## The bug
+ *
+ * Android **deep Doze** suspends network access and ignores wake locks, so the
+ * always-on keepalive ([TransportKeepAlive]) cannot keep the carrier NAT mapping
+ * alive — the socket is silently half-open by the time the device wakes. That
+ * part is ACCEPTED (we can't keep the mapping alive in deep Doze). The KEYSTONE
+ * defect is the WAKE-side liveness gate
+ * [RealSshSession.isTransportProvenAliveWithinKeepAliveWindow]: it used
+ * `System.nanoTime()` (`CLOCK_MONOTONIC`), which **STOPS during deep sleep**. So
+ * after a Doze gap the monotonic delta `now - lastActivity` UNDER-counts the real
+ * elapsed time, the oracle FALSELY reports the (now-dead) socket "alive within the
+ * keepalive window," and the #1042 restore ride-through / #1078 handoff arm sail
+ * through a DEAD transport instead of redialing.
+ *
+ * The fix injects the wall-elapsed boot clock
+ * (`SystemClock.elapsedRealtimeNanos()`, `CLOCK_BOOTTIME`, which COUNTS deep
+ * sleep) for both the activity watermarks and the oracle's comparison, so after a
+ * real deep-sleep gap the oracle correctly reports STALE → the existing reconnect
+ * machinery redials (no new mechanism — D28).
+ *
+ * ## Why a synthetic clock
+ *
+ * `SystemClock` is an `android.os` API; in these pure host-JVM unit tests it runs
+ * against the android.jar stub and throws "not mocked." So [RealSshSession] takes
+ * an injectable `nowNanos` clock (default `System.nanoTime` for tests; production
+ * injects the boot clock at `SshConnection.toSession`). These tests inject a
+ * [FakeNanoClock] so they can model the EXACT failing state — "the device slept
+ * for 95s; the boot clock counted it" vs "the monotonic clock froze across it" —
+ * deterministically, with zero wall-clock waiting and no self-skip.
+ *
+ * ## Reviewer red→green procedure (the load-bearing assertion is the GREEN one)
+ *
+ * To reproduce RED on the unfixed code, revert the #1080 migration in
+ * [RealSshSession] (keep the `nowNanos` ctor seam, but change the watermark field
+ * initializers + `recordInboundActivity`/`recordOutboundActivity` + the oracle's
+ * `nowNanos()` calls back to `System.nanoTime()`):
+ *  - [oracle reports STALE after a deep-sleep gap the boot clock counted] FAILS —
+ *    the real monotonic clock barely moved and ignores the injected clock's
+ *    advance, so the dead socket reads "alive" (assertFalse fails). RED.
+ *  - [activity watermark is stamped from the injected clock - no mixed domain]
+ *    FAILS — the watermark is the real `System.nanoTime` value, not the injected
+ *    clock's. RED.
+ * Re-applying the fix turns both GREEN.
+ */
+class RealSshSessionDozeClockTest {
+
+    /** Production ride-through budget = 30s × 3 = 90s (the window the oracle uses). */
+    private val rideThroughMs = TransportKeepAlive.RIDE_THROUGH_BUDGET_MS
+
+    @Test
+    fun `oracle reports STALE after a deep-sleep gap the boot clock counted`() {
+        // The boot clock (CLOCK_BOOTTIME) COUNTS deep sleep: a 95s Doze gap shows up
+        // as +95s of elapsed time. The NAT mapping is long dead, so the oracle MUST
+        // report STALE → the #1042 restore / #1078 handoff redials instead of riding
+        // through a dead socket.
+        val clock = FakeNanoClock(startNanos = 1_000_000_000L)
+        val session = RealSshSession(connectedClient(), nowNanos = clock::now)
+        try {
+            assertTrue(
+                "precondition: a freshly-stamped session is alive within the window (gap = 0)",
+                session.isTransportProvenAliveWithinKeepAliveWindow(),
+            )
+
+            // Deep sleep: the boot clock counts the whole 95s gap (> the 90s budget).
+            clock.advanceMs(rideThroughMs + 5_000L)
+
+            assertFalse(
+                "after a ${rideThroughMs + 5_000L}ms deep-sleep gap that the boot clock " +
+                    "COUNTED, the transport-liveness oracle MUST report STALE so the dead " +
+                    "socket is redialed, not ridden through (#1080 keystone fix)",
+                session.isTransportProvenAliveWithinKeepAliveWindow(),
+            )
+        } finally {
+            session.close()
+        }
+    }
+
+    @Test
+    fun `oracle still reports ALIVE when activity is recent - no false-stale regression`() {
+        // Class-coverage (G2): the fix must NOT make a genuinely-recent link look
+        // stale. A short 10s gap (well inside the 90s budget) is still ALIVE — a
+        // backgrounded-but-not-deep-asleep app, or a quick screen-off, must ride
+        // through exactly as before.
+        val clock = FakeNanoClock(startNanos = 1_000_000_000L)
+        val session = RealSshSession(connectedClient(), nowNanos = clock::now)
+        try {
+            clock.advanceMs(10_000L)
+            assertTrue(
+                "a recent (10s < 90s budget) gap must still report ALIVE — no false-stale " +
+                    "regression from the boot-clock migration (#1080)",
+                session.isTransportProvenAliveWithinKeepAliveWindow(),
+            )
+        } finally {
+            session.close()
+        }
+    }
+
+    @Test
+    fun `a clock frozen across the sleep under-counts the gap and falsely reports ALIVE`() {
+        // The BUG MECHANISM, made explicit: `System.nanoTime()` (CLOCK_MONOTONIC)
+        // FREEZES during deep sleep, so a 95s Doze gap advances it by ~0. With such a
+        // frozen clock the oracle's `now - lastActivity` delta stays tiny and the
+        // DEAD socket FALSELY reads "alive within the window." This is exactly the
+        // #1080 defect — and exactly why production must inject the boot clock
+        // (which counts the sleep, asserted by the STALE test above). A frozen clock
+        // is modelled here by simply NOT advancing it across the gap.
+        val clock = FakeNanoClock(startNanos = 0L)
+        val session = RealSshSession(connectedClient(), nowNanos = clock::now)
+        try {
+            // 95s of deep sleep elapses in the real world, but the frozen monotonic
+            // clock does not advance — the gap is invisible to it.
+            assertTrue(
+                "a clock that FREEZES across deep sleep under-counts the elapsed time and " +
+                    "FALSELY reports a dead socket alive — the System.nanoTime bug the boot " +
+                    "clock fixes (#1080)",
+                session.isTransportProvenAliveWithinKeepAliveWindow(),
+            )
+        } finally {
+            session.close()
+        }
+    }
+
+    @Test
+    fun `activity watermark is stamped from the injected clock - no mixed domain`() {
+        // The oracle subtracts the activity watermark from `nowNanos()`; if the
+        // watermark were stamped from a DIFFERENT clock domain (e.g. System.nanoTime
+        // while the oracle reads the boot clock) the elapsed math would be garbage.
+        // Pin that BOTH the inbound and outbound watermarks are stamped from the SAME
+        // injected clock the oracle reads — no mixed clock domains (#1080).
+        val stamp = 424_242_000_000L
+        val clock = FakeNanoClock(startNanos = stamp)
+        val session = RealSshSession(connectedClient(), nowNanos = clock::now)
+        try {
+            assertEquals(
+                "the inbound-activity watermark must be stamped from the injected wall-elapsed " +
+                    "clock (no System.nanoTime mixed-domain) — #1080",
+                stamp,
+                session.lastInboundActivityNanosForTest(),
+            )
+            assertEquals(
+                "the outbound-activity watermark must be stamped from the same injected clock",
+                stamp,
+                session.lastOutboundActivityNanosForTest(),
+            )
+        } finally {
+            session.close()
+        }
+    }
+
+    /**
+     * A controllable wall-elapsed clock seam. Models the boot clock by [advanceMs]
+     * (counts the sleep) or a frozen monotonic clock by simply not advancing it.
+     * Single-threaded use in these tests, but volatile for safety against the
+     * keepalive loop coroutine that [RealSshSession] starts in its `init`.
+     */
+    private class FakeNanoClock(startNanos: Long) {
+        @Volatile
+        private var nanos: Long = startNanos
+        fun now(): Long = nanos
+        fun advanceMs(ms: Long) {
+            nanos += ms * 1_000_000L
+        }
+    }
+
+    /**
+     * Minimal connected sshj client: the oracle only consults
+     * `isConnected`/`isAuthenticated` (and never the connection itself in these
+     * sub-second tests — the 30s keepalive loop never ticks). `disconnect()` is a
+     * no-op since no real socket is opened.
+     */
+    private fun connectedClient(): SSHClient = object : SSHClient() {
+        override fun isConnected(): Boolean = true
+        override fun isAuthenticated(): Boolean = true
+        override fun disconnect() = Unit
+    }
+}


### PR DESCRIPTION
## v0.4.19 — fold the held freeze/black-screen fixes into the normal release

Maintainer directive (2026-06-29): stop the side-load `com.pocketshell.app.freeze`
dogfood-package dance — land the freeze fixes in the **main app** and ship them
through the normal release cycle, and **include all the recent changes in 4.19**.

This branch is `origin/main` (`8b460efc`, the already-bumped versionName 0.4.19 /
versionCode 66) **+ the 7 reviewer-APPROVED held fixes** that were previously
parked for "v0.4.20" — the exact bundle the dogfood APK (`15dabb12`) was built from:

| Fix | What | Verdict |
|---|---|---|
| #1085 F1 | keystore init off main — kills the ~1.3s cold-launch freeze (+ host-list `File.exists` off main) | APPROVED |
| #1085 F2 | defer connection teardown off main (app-scope) | APPROVED |
| #1085 F3 | scope dictation/streaming reads out of the screen body (recomposition jank) | APPROVED |
| #1080 | Doze `elapsedRealtime` transport-liveness clock — frozen-but-Live after wake | APPROVED |
| #1078 | bounded active probe on WIFI→cellular handoff — 90s frozen-Live stall | APPROVED |
| #1086 F5 | `SystemSurfaceStateStore` launch disk-read off main | APPROVED |
| #1087 F6 | launch-path prefs stores off main (LastSession/UpdateCheck/UpdateNotification/UsageNotification) | APPROVED |

Each fix shipped reproduce-first (red→green) with an off-main regression test
(see the `*OffMainTest` / `*ProofTest` files in the diff).

Closes #1078
Closes #1080
Closes #1086
Closes #1087

#1085 (F1/F2/F3 hub) stays OPEN for maintainer dogfood confirmation that the
freezing is verified gone on the shipped build (D33), then gets
`needs-human-confirmation`.

### Release gate (run on the merged main commit, not here)
- [ ] cheap required: `Unit tests`, `Python utility tests`
- [ ] local integration gate: compile app + core-ssh + core-assistant, focused JVM tests for all 7 fixes together
- [ ] Nightly Extensive Tests green on the release commit
- [ ] Release Emulator Validation green on the release commit
- [ ] tag `v0.4.19`
