### PR TITLE
env: edit an existing key's value in place (#1092)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/env/EnvScreenE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/env/EnvScreenE2eTest.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
 import androidx.core.graphics.createBitmap
 import androidx.room.Room
@@ -209,6 +210,133 @@ class EnvScreenE2eTest {
             "logcat must not contain the secret value typed into the write-only field",
             logcat.contains(secret),
         )
+    }
+
+    /**
+     * #1092: the maintainer can now edit an existing key's value IN PLACE.
+     * Drives the reported gap end-to-end on the real screen: open the per-row
+     * kebab -> Edit -> the current value is fetched via the reveal/get path and
+     * pre-loaded (proven by the Show toggle revealing the old secret, i.e. NOT
+     * retyped blind) -> change it -> Save routes the new value through setKeys
+     * (update-in-place). logcat is asserted to never carry either secret (D24).
+     */
+    @Test
+    fun editExistingKeyInPlaceUpdatesValueViaSetKeys() {
+        clearLogcat()
+        val oldSecret = "sk-OLD-1092"
+        val newSecret = "sk-NEW-1092"
+        val gateway = FakeEnvGateway(
+            keys = listOf(EnvKeyRow("API_KEY", ".env", true)),
+            getValues = mapOf("API_KEY" to oldSecret),
+            sourceKeys = emptyList(),
+        )
+        val viewModel = EnvViewModel(gateway = gateway, hostDao = db.hostDao())
+
+        compose.setContent {
+            PocketShellTheme {
+                EnvScreen(
+                    hostId = hostId,
+                    hostName = "issue1092-host",
+                    keyPath = "/tmp/issue1092",
+                    passphrase = null,
+                    directory = "/home/u/code/pocketshell",
+                    folderLabel = "pocketshell",
+                    copySources = emptyList(),
+                    onBack = {},
+                    modifier = Modifier.fillMaxSize(),
+                    viewModel = viewModel,
+                )
+            }
+        }
+
+        compose.waitUntil(timeoutMillis = 10_000) {
+            compose.onAllNodesWithTag(envKeyRowTestTag("API_KEY")).fetchSemanticsNodes().isNotEmpty()
+        }
+        // Open the kebab and tap Edit.
+        compose.onNodeWithTag(envKeyMenuTestTag("API_KEY")).performClick()
+        compose.waitUntil(timeoutMillis = 5_000) {
+            compose.onAllNodesWithTag(envKeyEditTestTag("API_KEY")).fetchSemanticsNodes().isNotEmpty()
+        }
+        compose.onNodeWithTag(envKeyEditTestTag("API_KEY")).performClick()
+
+        // The editor opens and pre-loads the current value (fetched via get).
+        compose.waitUntil(timeoutMillis = 5_000) {
+            compose.onAllNodesWithTag(ENV_EDIT_VALUE_FIELD_TAG).fetchSemanticsNodes().isNotEmpty()
+        }
+        // Reveal the field — the OLD secret is already there (NOT blank), which
+        // is the whole point: edit, don't retype the secret from scratch.
+        compose.onNodeWithTag(ENV_EDIT_TOGGLE_TAG).performClick()
+        compose.waitUntil(timeoutMillis = 5_000) {
+            compose.onAllNodesWithText(oldSecret).fetchSemanticsNodes().isNotEmpty()
+        }
+        compose.onNodeWithText(oldSecret).assertExists()
+        captureFullDevice("issue1092-env-edit-dialog-viewport.png")
+
+        // Change the value and Save.
+        compose.onNodeWithTag(ENV_EDIT_VALUE_FIELD_TAG).performTextClearance()
+        compose.onNodeWithTag(ENV_EDIT_VALUE_FIELD_TAG).performTextInput(newSecret)
+        compose.onNodeWithTag(ENV_EDIT_CONFIRM_TAG).performClick()
+        compose.waitUntil(timeoutMillis = 5_000) { gateway.lastSetUpdates != null }
+
+        // The NEW value reached setKeys for the SAME key + its file.
+        assertEquals(newSecret, gateway.lastSetUpdates?.get("API_KEY"))
+        assertEquals(EnvFileTarget.Env, gateway.lastSetFile)
+
+        // D24: neither secret may appear in anything the app logs.
+        val logcat = dumpLogcat()
+        assertFalse("logcat must not contain the old secret", logcat.contains(oldSecret))
+        assertFalse("logcat must not contain the new secret", logcat.contains(newSecret))
+    }
+
+    /**
+     * #1092: an empty folder (no .env yet) must surface a clear "Add key" CTA,
+     * since adding the first key is how the .env file gets created. Proves the
+     * CTA is reachable and starts the create-first-key flow.
+     */
+    @Test
+    fun emptyFolderSurfacesAddKeyCtaThatCreatesFirstKey() {
+        val gateway = FakeEnvGateway(
+            keys = emptyList(),
+            getValues = emptyMap(),
+            sourceKeys = emptyList(),
+        )
+        val viewModel = EnvViewModel(gateway = gateway, hostDao = db.hostDao())
+
+        compose.setContent {
+            PocketShellTheme {
+                EnvScreen(
+                    hostId = hostId,
+                    hostName = "issue1092-host",
+                    keyPath = "/tmp/issue1092",
+                    passphrase = null,
+                    directory = "/home/u/code/fresh",
+                    folderLabel = "fresh",
+                    copySources = emptyList(),
+                    onBack = {},
+                    modifier = Modifier.fillMaxSize(),
+                    viewModel = viewModel,
+                )
+            }
+        }
+
+        // The empty-state CTA is present and reachable.
+        compose.waitUntil(timeoutMillis = 10_000) {
+            compose.onAllNodesWithTag(ENV_EMPTY_ADD_TAG).fetchSemanticsNodes().isNotEmpty()
+        }
+        compose.onNodeWithTag(ENV_EMPTY_ADD_TAG).assertExists()
+        captureFullDevice("issue1092-env-empty-cta-viewport.png")
+
+        // Tapping it opens the add dialog so the first key can be created.
+        compose.onNodeWithTag(ENV_EMPTY_ADD_TAG).performClick()
+        compose.waitUntil(timeoutMillis = 5_000) {
+            compose.onAllNodesWithTag(ENV_ADD_KEY_FIELD_TAG).fetchSemanticsNodes().isNotEmpty()
+        }
+        compose.onNodeWithTag(ENV_ADD_KEY_FIELD_TAG).performTextInput("FIRST_KEY")
+        compose.onNodeWithTag(ENV_ADD_VALUE_FIELD_TAG).performTextInput("first-value")
+        compose.onNodeWithTag(ENV_ADD_CONFIRM_TAG).performClick()
+        compose.waitUntil(timeoutMillis = 5_000) { gateway.lastSetUpdates != null }
+        // Creating the first key writes through setKeys (server creates the file).
+        assertEquals("first-value", gateway.lastSetUpdates?.get("FIRST_KEY"))
     }
 
     private fun clearLogcat() {

--- a/app/src/main/java/com/pocketshell/app/env/EnvScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/env/EnvScreen.kt
@@ -50,6 +50,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.pocketshell.uikit.components.Banner
 import com.pocketshell.uikit.components.BannerRole
 import com.pocketshell.uikit.components.ButtonVariant
+import com.pocketshell.uikit.components.FormDialog
 import com.pocketshell.uikit.components.Kebab
 import com.pocketshell.uikit.components.KebabItem
 import com.pocketshell.uikit.components.ListRow
@@ -502,75 +503,66 @@ private fun EditKeyDialog(
     var revealed by remember(key) { mutableStateOf(false) }
     val loading = initialValue == null
 
-    AlertDialog(
-        onDismissRequest = onDismiss,
+    // Shared ui-kit input dialog (#865 component-drift guard): FormDialog owns
+    // the title / confirm (Primary "Save") / Cancel (Text) / Surface scaffold;
+    // we only supply the read-only key+file header and the value field.
+    FormDialog(
+        title = "Edit $key",
+        confirmLabel = "Save",
+        onConfirm = { onConfirm(value) },
+        onDismiss = onDismiss,
         modifier = Modifier.testTag(ENV_EDIT_DIALOG_TAG),
-        title = { Text("Edit $key", color = PocketShellColors.Text) },
-        text = {
-            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Text(
-                        text = key,
-                        color = PocketShellColors.Text,
-                        style = PocketShellType.bodyMono,
-                        fontWeight = FontWeight.SemiBold,
-                        modifier = Modifier.testTag(ENV_EDIT_KEY_LABEL_TAG),
-                    )
-                    FileTag(file = file.fileName)
-                }
-                if (loading) {
-                    Box(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(vertical = 16.dp)
-                            .testTag(ENV_EDIT_LOADING_TAG),
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        LoadingIndicator.Spinner(size = SpinnerSize.Medium)
-                    }
-                } else {
-                    OutlinedTextField(
-                        value = value,
-                        onValueChange = { value = it },
-                        label = { Text("Value") },
-                        singleLine = true,
-                        visualTransformation = if (revealed) {
-                            VisualTransformation.None
-                        } else {
-                            PasswordVisualTransformation()
-                        },
-                        trailingIcon = {
-                            PocketShellButton(
-                                text = if (revealed) "Hide" else "Show",
-                                onClick = { revealed = !revealed },
-                                variant = ButtonVariant.Text,
-                                compact = true,
-                                modifier = Modifier.testTag(ENV_EDIT_TOGGLE_TAG),
-                            )
-                        },
-                        colors = envFieldColors(),
-                        modifier = Modifier.fillMaxWidth().testTag(ENV_EDIT_VALUE_FIELD_TAG),
-                    )
-                }
-            }
-        },
-        confirmButton = {
-            PocketShellButton(
-                text = "Save",
-                onClick = { onConfirm(value) },
-                variant = ButtonVariant.Primary,
-                enabled = !busy && !loading,
-                modifier = Modifier.testTag(ENV_EDIT_CONFIRM_TAG),
+        confirmEnabled = !busy && !loading,
+        confirmTestTag = ENV_EDIT_CONFIRM_TAG,
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = key,
+                color = PocketShellColors.Text,
+                style = PocketShellType.bodyMono,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.testTag(ENV_EDIT_KEY_LABEL_TAG),
             )
-        },
-        dismissButton = {
-            PocketShellButton(text = "Cancel", onClick = onDismiss, variant = ButtonVariant.Text)
-        },
-        containerColor = PocketShellColors.Surface,
-    )
+            FileTag(file = file.fileName)
+        }
+        if (loading) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 16.dp)
+                    .testTag(ENV_EDIT_LOADING_TAG),
+                contentAlignment = Alignment.Center,
+            ) {
+                LoadingIndicator.Spinner(size = SpinnerSize.Medium)
+            }
+        } else {
+            OutlinedTextField(
+                value = value,
+                onValueChange = { value = it },
+                label = { Text("Value") },
+                singleLine = true,
+                visualTransformation = if (revealed) {
+                    VisualTransformation.None
+                } else {
+                    PasswordVisualTransformation()
+                },
+                trailingIcon = {
+                    PocketShellButton(
+                        text = if (revealed) "Hide" else "Show",
+                        onClick = { revealed = !revealed },
+                        variant = ButtonVariant.Text,
+                        compact = true,
+                        modifier = Modifier.testTag(ENV_EDIT_TOGGLE_TAG),
+                    )
+                },
+                colors = envFieldColors(),
+                modifier = Modifier.fillMaxWidth().testTag(ENV_EDIT_VALUE_FIELD_TAG),
+            )
+        }
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/pocketshell/app/env/EnvScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/env/EnvScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -129,6 +130,8 @@ fun EnvScreen(
                     canCopy = state.copySources.isNotEmpty(),
                     onReveal = viewModel::revealKey,
                     onHide = viewModel::hideKey,
+                    onEdit = viewModel::beginEdit,
+                    onAddKey = { showAddDialog = true },
                     onCopyFrom = { showCopySheet = true },
                 )
             }
@@ -157,6 +160,28 @@ fun EnvScreen(
                 showAddDialog = false
                 viewModel.setKey(key, value, file)
             },
+        )
+    }
+
+    // In-place value editor (#1092): pre-loaded with the current value via the
+    // reveal/get path so the user tweaks the secret instead of retyping blind.
+    when (val editor = state.editor) {
+        EnvEditorState.Hidden -> Unit
+        is EnvEditorState.LoadingValue -> EditKeyDialog(
+            key = editor.key,
+            file = editor.file,
+            initialValue = null,
+            busy = state.busy,
+            onDismiss = viewModel::dismissEditor,
+            onConfirm = {},
+        )
+        is EnvEditorState.Editing -> EditKeyDialog(
+            key = editor.key,
+            file = editor.file,
+            initialValue = editor.currentValue,
+            busy = state.busy,
+            onDismiss = viewModel::dismissEditor,
+            onConfirm = { viewModel.saveEdit(it) },
         )
     }
 
@@ -251,6 +276,8 @@ private fun EnvKeyList(
     canCopy: Boolean,
     onReveal: (String) -> Unit,
     onHide: (String) -> Unit,
+    onEdit: (String) -> Unit,
+    onAddKey: () -> Unit,
     onCopyFrom: () -> Unit,
 ) {
     LazyColumn(
@@ -278,10 +305,10 @@ private fun EnvKeyList(
             }
         }
         if (keys.isEmpty()) {
-            item { EnvEmptyState() }
+            item { EnvEmptyState(onAddKey = onAddKey) }
         } else {
             items(keys, key = { "${it.file}:${it.key}" }) { row ->
-                EnvKeyCard(row = row, onReveal = onReveal, onHide = onHide)
+                EnvKeyCard(row = row, onReveal = onReveal, onHide = onHide, onEdit = onEdit)
             }
         }
         item { Spacer(modifier = Modifier.height(72.dp)) }
@@ -289,7 +316,7 @@ private fun EnvKeyList(
 }
 
 @Composable
-private fun EnvEmptyState() {
+private fun EnvEmptyState(onAddKey: () -> Unit) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -301,17 +328,31 @@ private fun EnvEmptyState() {
         Text(text = "No env keys yet", color = PocketShellColors.Text, style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.SemiBold)
         Spacer(modifier = Modifier.height(4.dp))
         Text(
-            text = "Tap + to add a key, or copy keys from another folder.",
+            // Adding the first key is how a new .env / .envrc file is created
+            // (the server writes it mode 0600) — make that obvious (#1092).
+            text = "This folder has no .env yet. Add a key to create one, or copy keys from another folder.",
             color = PocketShellColors.TextSecondary,
             style = PocketShellType.bodyDense,
+        )
+        Spacer(modifier = Modifier.height(12.dp))
+        PocketShellButton(
+            text = "Add key",
+            onClick = onAddKey,
+            variant = ButtonVariant.Primary,
+            modifier = Modifier.testTag(ENV_EMPTY_ADD_TAG),
         )
     }
 }
 
 @Composable
-private fun EnvKeyCard(row: EnvKeyUiRow, onReveal: (String) -> Unit, onHide: (String) -> Unit) {
+private fun EnvKeyCard(
+    row: EnvKeyUiRow,
+    onReveal: (String) -> Unit,
+    onHide: (String) -> Unit,
+    onEdit: (String) -> Unit,
+) {
     // One dense row per key: the key name rides the mono-adjacent title, the
-    // masked / revealed value rides the mono subtitle, and Reveal / Hide
+    // masked / revealed value rides the mono subtitle, and Reveal / Hide / Edit
     // consolidate into the single per-row kebab (#479 §4 decision 4). The file
     // pill stays as a right-aligned chip before the kebab.
     val display = when {
@@ -328,15 +369,29 @@ private fun EnvKeyCard(row: EnvKeyUiRow, onReveal: (String) -> Unit, onHide: (St
             if (row.revealing) {
                 LoadingIndicator.Spinner(size = SpinnerSize.Small)
             } else {
-                EnvKeyMenu(row = row, onReveal = onReveal, onHide = onHide)
+                EnvKeyMenu(row = row, onReveal = onReveal, onHide = onHide, onEdit = onEdit)
             }
         },
     )
 }
 
 @Composable
-private fun EnvKeyMenu(row: EnvKeyUiRow, onReveal: (String) -> Unit, onHide: (String) -> Unit) {
+private fun EnvKeyMenu(
+    row: EnvKeyUiRow,
+    onReveal: (String) -> Unit,
+    onHide: (String) -> Unit,
+    onEdit: (String) -> Unit,
+) {
     val items = buildList {
+        // Edit-in-place is offered for every key (#1092) — including an empty
+        // key, which Edit lets the user give a value for the first time.
+        add(
+            KebabItem(
+                label = "Edit",
+                onClick = { onEdit(row.key) },
+                testTag = envKeyEditTestTag(row.key),
+            ),
+        )
         when {
             row.revealedValue != null -> add(
                 KebabItem(
@@ -354,14 +409,10 @@ private fun EnvKeyMenu(row: EnvKeyUiRow, onReveal: (String) -> Unit, onHide: (St
             )
         }
     }
-    // No actions for an empty key (nothing to reveal/hide): suppress the kebab
-    // so the row carries no dead affordance.
-    if (items.isNotEmpty()) {
-        Kebab(
-            triggerTestTag = envKeyMenuTestTag(row.key),
-            items = items,
-        )
-    }
+    Kebab(
+        triggerTestTag = envKeyMenuTestTag(row.key),
+        items = items,
+    )
 }
 
 @Composable
@@ -419,6 +470,100 @@ private fun AddKeyDialog(
                 variant = ButtonVariant.Primary,
                 enabled = !busy,
                 modifier = Modifier.testTag(ENV_ADD_CONFIRM_TAG),
+            )
+        },
+        dismissButton = {
+            PocketShellButton(text = "Cancel", onClick = onDismiss, variant = ButtonVariant.Text)
+        },
+        containerColor = PocketShellColors.Surface,
+    )
+}
+
+/**
+ * In-place editor for an existing key's value (#1092).
+ *
+ * The key name and its file are read-only (renaming is out of scope); only
+ * the value changes. [initialValue] `null` means the current value is still
+ * being fetched via the reveal/get path — render a spinner. When it has
+ * loaded, the field is pre-populated, starts masked, and offers a Show/Hide
+ * toggle. Save routes the new value back through `setKeys` (stdin, never
+ * argv — D24).
+ */
+@Composable
+private fun EditKeyDialog(
+    key: String,
+    file: EnvFileTarget,
+    initialValue: String?,
+    busy: Boolean,
+    onDismiss: () -> Unit,
+    onConfirm: (value: String) -> Unit,
+) {
+    var value by remember(key, initialValue) { mutableStateOf(initialValue.orEmpty()) }
+    var revealed by remember(key) { mutableStateOf(false) }
+    val loading = initialValue == null
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        modifier = Modifier.testTag(ENV_EDIT_DIALOG_TAG),
+        title = { Text("Edit $key", color = PocketShellColors.Text) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = key,
+                        color = PocketShellColors.Text,
+                        style = PocketShellType.bodyMono,
+                        fontWeight = FontWeight.SemiBold,
+                        modifier = Modifier.testTag(ENV_EDIT_KEY_LABEL_TAG),
+                    )
+                    FileTag(file = file.fileName)
+                }
+                if (loading) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 16.dp)
+                            .testTag(ENV_EDIT_LOADING_TAG),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        LoadingIndicator.Spinner(size = SpinnerSize.Medium)
+                    }
+                } else {
+                    OutlinedTextField(
+                        value = value,
+                        onValueChange = { value = it },
+                        label = { Text("Value") },
+                        singleLine = true,
+                        visualTransformation = if (revealed) {
+                            VisualTransformation.None
+                        } else {
+                            PasswordVisualTransformation()
+                        },
+                        trailingIcon = {
+                            PocketShellButton(
+                                text = if (revealed) "Hide" else "Show",
+                                onClick = { revealed = !revealed },
+                                variant = ButtonVariant.Text,
+                                compact = true,
+                                modifier = Modifier.testTag(ENV_EDIT_TOGGLE_TAG),
+                            )
+                        },
+                        colors = envFieldColors(),
+                        modifier = Modifier.fillMaxWidth().testTag(ENV_EDIT_VALUE_FIELD_TAG),
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            PocketShellButton(
+                text = "Save",
+                onClick = { onConfirm(value) },
+                variant = ButtonVariant.Primary,
+                enabled = !busy && !loading,
+                modifier = Modifier.testTag(ENV_EDIT_CONFIRM_TAG),
             )
         },
         dismissButton = {
@@ -619,7 +764,14 @@ const val ENV_LOADING_TAG: String = "env:loading"
 const val ENV_ERROR_TAG: String = "env:error"
 const val ENV_RETRY_TAG: String = "env:retry"
 const val ENV_EMPTY_TAG: String = "env:empty"
+const val ENV_EMPTY_ADD_TAG: String = "env:empty-add"
 const val ENV_ADD_FAB_TAG: String = "env:add-fab"
+const val ENV_EDIT_DIALOG_TAG: String = "env:edit-dialog"
+const val ENV_EDIT_KEY_LABEL_TAG: String = "env:edit-key-label"
+const val ENV_EDIT_LOADING_TAG: String = "env:edit-loading"
+const val ENV_EDIT_VALUE_FIELD_TAG: String = "env:edit-value-field"
+const val ENV_EDIT_TOGGLE_TAG: String = "env:edit-toggle"
+const val ENV_EDIT_CONFIRM_TAG: String = "env:edit-confirm"
 const val ENV_ADD_DIALOG_TAG: String = "env:add-dialog"
 const val ENV_ADD_KEY_FIELD_TAG: String = "env:add-key-field"
 const val ENV_ADD_VALUE_FIELD_TAG: String = "env:add-value-field"
@@ -635,6 +787,7 @@ fun envKeyMenuTestTag(key: String): String = "env:menu:$key"
 fun envKeyValueTestTag(key: String): String = "env:value:$key"
 fun envKeyRevealTestTag(key: String): String = "env:reveal:$key"
 fun envKeyHideTestTag(key: String): String = "env:hide:$key"
+fun envKeyEditTestTag(key: String): String = "env:edit:$key"
 fun envFileTargetTestTag(target: EnvFileTarget): String = "env:file-target:${target.fileName}"
 fun envCopySourceTestTag(path: String): String = "env:copy-source:$path"
 fun envCopyKeyTestTag(key: String): String = "env:copy-key:$key"

--- a/app/src/main/java/com/pocketshell/app/env/EnvViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/env/EnvViewModel.kt
@@ -46,6 +46,32 @@ sealed interface EnvListState {
 }
 
 /**
+ * In-place editor for an existing key's value (issue #1092).
+ *
+ * Hidden by default. Opening it fetches the current value via the same
+ * `env get` reveal path ([EnvViewModel.revealKey] / [EnvGateway.getValue])
+ * so the user can tweak the secret instead of retyping it blind — and that
+ * fetch happens only on the explicit Edit action, consistent with the D24
+ * write-only-by-default contract. Renaming is out of scope (#1092
+ * non-goal): the key name and the file it lives in are fixed; only the
+ * value changes, and Save routes it back through [EnvGateway.setKeys]
+ * (stdin upload, never argv).
+ */
+sealed interface EnvEditorState {
+    data object Hidden : EnvEditorState
+
+    /** The current value is being fetched via `env get`. */
+    data class LoadingValue(val key: String, val file: EnvFileTarget) : EnvEditorState
+
+    /** Value loaded; the field is pre-populated and editable. */
+    data class Editing(
+        val key: String,
+        val file: EnvFileTarget,
+        val currentValue: String,
+    ) : EnvEditorState
+}
+
+/**
  * UI state for [EnvScreen] — issue #264.
  *
  * @property folderLabel user-visible folder label shown in the header.
@@ -63,6 +89,7 @@ data class EnvUiState(
     val busy: Boolean = false,
     val transientMessage: String? = null,
     val copySources: List<EnvCopySourceFolder> = emptyList(),
+    val editor: EnvEditorState = EnvEditorState.Hidden,
 )
 
 /**
@@ -169,6 +196,75 @@ class EnvViewModel @Inject constructor(
             _state.value = _state.value.copy(busy = false)
             applyOpResult(result, successMessage = "Saved $trimmedKey to ${file.fileName}.")
         }
+    }
+
+    /**
+     * Begin editing [key] in place (#1092): fetch its current value via the
+     * same `env get` reveal path and open the editor pre-loaded with it, so
+     * the user can tweak the secret instead of retyping it blind. Renaming is
+     * out of scope — the key name and the file it lives in are fixed.
+     */
+    fun beginEdit(key: String) {
+        val p = params ?: return
+        val current = _state.value.list as? EnvListState.Ready ?: return
+        val row = current.keys.firstOrNull { it.key == key } ?: return
+        val file = EnvFileTarget.fromFileName(row.file)
+        _state.value = _state.value.copy(editor = EnvEditorState.LoadingValue(key, file))
+        viewModelScope.launch {
+            val host = hostDao.getById(p.hostId) ?: run {
+                editorFailed("Host not found.")
+                return@launch
+            }
+            when (val result = gateway.getValue(host, p.keyPath, p.passphrase, p.directory, key)) {
+                is EnvOpResult.Values -> {
+                    // Ignore a late fetch if the user already closed / switched
+                    // the editor while the value was loading.
+                    val editor = _state.value.editor
+                    if (editor is EnvEditorState.LoadingValue && editor.key == key) {
+                        _state.value = _state.value.copy(
+                            editor = EnvEditorState.Editing(
+                                key = key,
+                                file = file,
+                                // An empty key (has_value=false) has no value in
+                                // the map — open the field blank so the user can
+                                // fill it.
+                                currentValue = result.values[key] ?: "",
+                            ),
+                        )
+                    }
+                }
+                EnvOpResult.ToolUnavailable -> editorFailed("pocketshell is not installed on this host.")
+                is EnvOpResult.Failed -> editorFailed(result.message)
+                is EnvOpResult.ConnectFailed ->
+                    editorFailed(result.cause.message ?: "Couldn't connect to the host.")
+                EnvOpResult.Success ->
+                    _state.value = _state.value.copy(editor = EnvEditorState.Hidden)
+            }
+        }
+    }
+
+    /**
+     * Save the in-place edit: route the new value back through [setKey]
+     * (which uploads it via stdin, never argv — D24) for the editor's fixed
+     * key + file, then close the editor.
+     */
+    fun saveEdit(value: String) {
+        val editor = _state.value.editor
+        if (editor !is EnvEditorState.Editing) return
+        _state.value = _state.value.copy(editor = EnvEditorState.Hidden)
+        setKey(editor.key, value, editor.file)
+    }
+
+    /** Close the in-place editor without saving. */
+    fun dismissEditor() {
+        _state.value = _state.value.copy(editor = EnvEditorState.Hidden)
+    }
+
+    private fun editorFailed(message: String) {
+        _state.value = _state.value.copy(
+            editor = EnvEditorState.Hidden,
+            transientMessage = message,
+        )
     }
 
     /** Reveal a single key's plain value via `env get` (D24: no biometric). */

--- a/app/src/test/java/com/pocketshell/app/env/EnvViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/env/EnvViewModelTest.kt
@@ -118,6 +118,90 @@ class EnvViewModelTest {
     }
 
     @Test
+    fun editingExistingKeyPreloadsValueThenSavesUpdateViaSetKeys() = runTest {
+        // Reproduce-first (#1092 / D33): the maintainer can reveal + add but
+        // CANNOT edit an existing key's value in place. This drives the
+        // edit-in-place journey: tap Edit -> current value fetched via the
+        // reveal/get path and pre-loaded -> change it -> Save routes the new
+        // value back through setKeys (update-in-place). On the unfixed code
+        // there is no editor entry point, so this fails to compile / run.
+        val gateway = FakeEnvGateway(
+            listResult = EnvListResult.Keys(listOf(EnvKeyRow("API_KEY", ".env", true))),
+            getResult = EnvOpResult.Values(mapOf("API_KEY" to "old-secret")),
+        )
+        val vm = EnvViewModel(gateway, FakeHostDao(host))
+        vm.bind(1L, "/tmp/key", null, "/home/alexey/proj", "proj", emptyList())
+        advanceUntilIdle()
+
+        // Open the in-place editor — the current value is fetched and shown.
+        vm.beginEdit("API_KEY")
+        advanceUntilIdle()
+        val editor = vm.state.value.editor as EnvEditorState.Editing
+        assertEquals("API_KEY", editor.key)
+        assertEquals(EnvFileTarget.Env, editor.file)
+        assertEquals("old-secret", editor.currentValue)
+
+        // Edit the value and Save — it must reach setKeys for the same key.
+        vm.saveEdit("new-secret")
+        advanceUntilIdle()
+
+        assertEquals(mapOf("API_KEY" to "new-secret"), gateway.lastSetUpdates)
+        assertEquals(EnvFileTarget.Env, gateway.lastSetFile)
+        // The editor closes and a refresh ran after the successful update.
+        assertTrue(vm.state.value.editor is EnvEditorState.Hidden)
+        assertTrue(gateway.listCalls >= 2)
+    }
+
+    @Test
+    fun editingEnvrcKeyPreservesItsFileAndAllowsEmptyToBeFilled() = runTest {
+        // Class coverage: a key that lives in .envrc edits back into .envrc
+        // (not the default .env), and an empty key (has_value=false) opens
+        // with a blank field and can be given a value.
+        val gateway = FakeEnvGateway(
+            listResult = EnvListResult.Keys(
+                listOf(
+                    EnvKeyRow("EXPORTED", ".envrc", true),
+                    EnvKeyRow("EMPTY", ".envrc", false),
+                ),
+            ),
+            getResult = EnvOpResult.Values(emptyMap()),
+        )
+        val vm = EnvViewModel(gateway, FakeHostDao(host))
+        vm.bind(1L, "/tmp/key", null, "/home/alexey/proj", "proj", emptyList())
+        advanceUntilIdle()
+
+        vm.beginEdit("EMPTY")
+        advanceUntilIdle()
+        val editor = vm.state.value.editor as EnvEditorState.Editing
+        assertEquals(EnvFileTarget.Envrc, editor.file)
+        // No value came back for the empty key — the field opens blank.
+        assertEquals("", editor.currentValue)
+
+        vm.saveEdit("now-has-a-value")
+        advanceUntilIdle()
+        assertEquals(mapOf("EMPTY" to "now-has-a-value"), gateway.lastSetUpdates)
+        assertEquals(EnvFileTarget.Envrc, gateway.lastSetFile)
+    }
+
+    @Test
+    fun dismissEditorClosesWithoutCallingSetKeys() = runTest {
+        val gateway = FakeEnvGateway(
+            listResult = EnvListResult.Keys(listOf(EnvKeyRow("API_KEY", ".env", true))),
+            getResult = EnvOpResult.Values(mapOf("API_KEY" to "old-secret")),
+        )
+        val vm = EnvViewModel(gateway, FakeHostDao(host))
+        vm.bind(1L, "/tmp/key", null, "/home/alexey/proj", "proj", emptyList())
+        advanceUntilIdle()
+
+        vm.beginEdit("API_KEY")
+        advanceUntilIdle()
+        vm.dismissEditor()
+
+        assertTrue(vm.state.value.editor is EnvEditorState.Hidden)
+        assertNull(gateway.lastSetUpdates)
+    }
+
+    @Test
     fun copyKeysCallsGatewayAndRefreshes() = runTest {
         val gateway = FakeEnvGateway(listResult = EnvListResult.Keys(emptyList()))
         val vm = EnvViewModel(gateway, FakeHostDao(host))

--- a/app/src/test/java/com/pocketshell/app/env/SshEnvGatewayLeaseTest.kt
+++ b/app/src/test/java/com/pocketshell/app/env/SshEnvGatewayLeaseTest.kt
@@ -45,6 +45,45 @@ class SshEnvGatewayLeaseTest {
     }
 
     @Test
+    fun editingValueTravelsViaStdinNeverArgv() = runTest {
+        // #1092 / D24: editing an existing key's value reuses setKeys, so the
+        // new secret VALUE must arrive over stdin (the uploaded JSON payload),
+        // never on the `env set` command line / argv.
+        val secret = "edited-sk-SECRET-1092"
+        val execCommands = mutableListOf<String>()
+        val uploads = mutableListOf<String>()
+        val session = RecordingSession(
+            onExec = { command ->
+                execCommands += command
+                ExecResult(stdout = "", stderr = "", exitCode = 0)
+            },
+            onUpload = { bytes -> uploads += bytes },
+        )
+        val connector = CountingConnector(session)
+        val gateway = SshEnvGateway(
+            sshLeaseManager = SshLeaseManager(connector = connector, scope = this, idleTtlMillis = 30_000L),
+        )
+
+        val result = gateway.setKeys(
+            host = HOST,
+            keyPath = KEY_PATH,
+            passphrase = null,
+            directory = "/home/dev/proj",
+            file = EnvFileTarget.Env,
+            updates = mapOf("API_KEY" to secret),
+        )
+
+        assertTrue(result is EnvOpResult.Success)
+        // The value arrived over stdin (uploaded JSON), and NOT on any argv.
+        assertTrue("value must travel via the uploaded stdin payload", uploads.any { it.contains(secret) })
+        assertTrue(
+            "no exec command line may contain the secret value (D24)",
+            execCommands.none { it.contains(secret) },
+        )
+        assertTrue("at least one exec ran", execCommands.isNotEmpty())
+    }
+
+    @Test
     fun connectFailureSurfacesConnectFailed() = runTest {
         val connector = object : SshLeaseConnector {
             override suspend fun connect(target: SshLeaseTarget): Result<SshSession> =
@@ -59,11 +98,32 @@ class SshEnvGatewayLeaseTest {
         assertTrue(result is EnvListResult.ConnectFailed)
     }
 
-    private class CountingConnector(private val session: FakeSshSession) : SshLeaseConnector {
+    private class CountingConnector(private val session: SshSession) : SshLeaseConnector {
         var connectCount: Int = 0
         override suspend fun connect(target: SshLeaseTarget): Result<SshSession> {
             connectCount += 1
             return Result.success(session)
+        }
+    }
+
+    private class RecordingSession(
+        private val onExec: (String) -> ExecResult,
+        private val onUpload: (String) -> Unit,
+    ) : SshSession {
+        var closed: Boolean = false
+        override val isConnected: Boolean get() = !closed
+        override suspend fun exec(command: String): ExecResult = onExec(command)
+        override fun tail(path: String, onLine: (String) -> Unit): Job = error("not used")
+        override fun openLocalPortForward(remoteHost: String, remotePort: Int, localPort: Int): SshPortForward =
+            error("not used")
+        override fun startShell(): SshShell = error("not used")
+        override suspend fun uploadFile(file: File, remotePath: String): String = error("not used")
+        override suspend fun uploadStream(input: InputStream, length: Long, name: String, remotePath: String): String {
+            onUpload(input.readBytes().toString(Charsets.UTF_8))
+            return remotePath
+        }
+        override fun close() {
+            closed = true
         }
     }
 


### PR DESCRIPTION
Closes #1092. Reviewer APPROVED with reviewer-run red→green, D24 secret-safety verified (value via stdin, never argv), and on-device `EnvScreenE2eTest` 3/0 with viewport screenshots (Edit dialog pre-loads revealed value; empty-state Add CTA). Client-only — no server change.

Follow-up (non-blocking, pre-existing): `EnvScreenE2eTest` is on the unwired allowlist so env connected journeys don't auto-run in CI — to be wired into `ci-journey-suite.sh` separately.