### PR TITLE
terminal: Ctrl+<any key> sticky modifier + fill ^X/^O/^K… nano keys (#1091)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/TmuxKeyBarCtrlComboE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/TmuxKeyBarCtrlComboE2eTest.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.test.hasAnyAncestor
 import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
@@ -28,6 +29,9 @@ import com.pocketshell.app.hosts.SshKeyStorage
 import com.pocketshell.app.proof.signals.waitForSessionInPicker
 import com.pocketshell.app.tmux.TERMINAL_HOTKEYS_LAUNCHER_TAG
 import com.pocketshell.app.tmux.TMUX_SESSION_SCREEN_TAG
+import com.pocketshell.app.tmux.TmuxHotkeyCtrlModifierLabel
+import com.pocketshell.app.tmux.TmuxHotkeyEnterLabel
+import com.pocketshell.uikit.components.HotkeyModifierActiveKey
 import com.pocketshell.uikit.components.TERMINAL_HOTKEYS_PANEL_TAG
 import com.pocketshell.core.ssh.KnownHostsPolicy
 import com.pocketshell.core.ssh.SshConnection
@@ -140,17 +144,24 @@ class TmuxKeyBarCtrlComboE2eTest {
                 .isNotEmpty()
         }
         compose.onNodeWithTag(TERMINAL_HOTKEYS_LAUNCHER_TAG, useUnmergedTree = true).performClick()
-        // The panel shows EVERY key at once in a tidy grid — Esc / Tab / Enter,
-        // the de-duped Ctrl combos incl. the restored ^B (tmux prefix), and the
-        // clean arrow glyphs. No `…` overflow, no lone Ctrl, no duplicate `/`.
+        // The panel shows EVERY key at once in a tidy grid — Esc / Tab / ⇧Tab /
+        // Enter, the de-duped Ctrl combos incl. the restored ^B (tmux prefix) AND
+        // the #1091-filled nano/TUI control keys (^G ^J ^K ^O ^T ^U ^W ^X ^\), the
+        // re-homed doubled interrupt/EOF chords, the sticky `Ctrl` modifier, and
+        // the clean arrow glyphs. No `…` overflow, no duplicate `/`.
         compose.waitUntil(timeoutMillis = 10_000) {
             compose.onAllNodesWithText("^C", useUnmergedTree = true)
                 .fetchSemanticsNodes()
                 .isNotEmpty()
         }
-        // Issue #787: the re-homed doubled interrupt/EOF controls are present too.
-        listOf("Esc", "Tab", "Enter", "^A", "^B", "^C", "^D", "^E", "^L", "^R", "^C×2", "^D×2", "←", "→")
-            .forEach { label ->
+        // Issue #787: doubled interrupt/EOF controls; issue #893: ⇧Tab; issue
+        // #1091: the previously-missing nano/TUI control keys are now present too.
+        listOf(
+            "Esc", "Tab", "⇧Tab", "Enter",
+            "^A", "^B", "^C", "^D", "^E", "^G", "^J", "^K", "^L", "^O",
+            "^R", "^T", "^U", "^W", "^X", "^Z", "^\\",
+            "^C×2", "^D×2", "←", "→",
+        ).forEach { label ->
                 assertTrue(
                     "expected the hotkeys panel to show '$label'",
                     compose.onAllNodesWithText(label, useUnmergedTree = true)
@@ -158,10 +169,25 @@ class TmuxKeyBarCtrlComboE2eTest {
                         .isNotEmpty(),
                 )
             }
-        // No lone Ctrl modifier and no `/` key — the maintainer's complaints.
+        // Issue #1091: the sticky `Ctrl` modifier is now INTENTIONALLY present —
+        // it is the general `Ctrl+<any letter>` escape hatch that frees the user
+        // from a TUI like `nano` whose keys the curated subset can't cover. It
+        // must render as a Modifier-kind key (carrying the HotkeyModifierActive
+        // semantics flag set only on `KeyKind.Modifier` slots), NOT a lone Regular
+        // button — mirroring the JVM guard `hotkeyPanelSectionsAreDeDupedAndCarry…`.
+        // Use the MERGED tree: HotkeySlot publishes the label `Text` and the
+        // `HotkeyModifierActive` flag onto the SAME merged node
+        // (`semantics(mergeDescendants = true)`), so only the merged node carries
+        // both the text and the property.
+        compose.onNode(
+            hasText(TmuxHotkeyCtrlModifierLabel)
+                .and(hasAnyAncestor(hasTestTag(TERMINAL_HOTKEYS_PANEL_TAG)))
+                .and(SemanticsMatcher.keyIsDefined(HotkeyModifierActiveKey)),
+        ).assertExists()
+        // No `/` key in the panel (the maintainer's "duplicate /" complaint).
         assertTrue(
-            "the hotkeys panel must NOT show a lone Ctrl modifier",
-            compose.onAllNodesWithText("Ctrl", useUnmergedTree = true).fetchSemanticsNodes().isEmpty(),
+            "the hotkeys panel must NOT show a `/` key",
+            compose.onAllNodesWithText("/", useUnmergedTree = true).fetchSemanticsNodes().isEmpty(),
         )
         captureViewport("issue784-02-hotkeys-panel-visible")
         // Advisory full-device frame so the reviewer sees the actual panel grid
@@ -318,6 +344,202 @@ class TmuxKeyBarCtrlComboE2eTest {
                 "key-bar Enter submitted the pending line; got:\n$transcript",
             transcript.split(ENTER_MARKER).size >= 3,
         )
+    }
+
+    /**
+     * Issue #1091 / AC1 — the maintainer was TRAPPED in `nano` (a fully
+     * Ctrl-driven TUI) on a real dogfood session: none of the keys nano needs to
+     * save/exit (`^O` Write Out, `^X` Exit) were reachable from PocketShell. This
+     * is the end-to-end reproduction on the real path (emulator + Docker `agents`
+     * shell, the `nano` fixture added to `Dockerfile.agents`): open a fresh nano
+     * buffer, type a marker line, then **save and exit entirely from the hotkeys
+     * panel** — tap `^O` (Write Out), tap `Enter` to confirm the filename, tap
+     * `^X` (Exit) — and prove from the authoritative visible-terminal transcript
+     * that nano actually wrote the file to disk and the shell prompt returned.
+     *
+     * Load-bearing assertions (NOT a byte-level proxy — the real nano TUI):
+     *  - nano prints `Wrote` only on a successful disk write → `^O` + `Enter`
+     *    reached nano and saved.
+     *  - a shell sentinel echoed AFTER `^X` proves nano exited back to an
+     *    interactive prompt.
+     *  - `cat` of the saved file reprints the typed marker → the bytes the panel
+     *    sent through `sendControlInputToPane` genuinely persisted to disk.
+     *
+     * Authoritative artifacts: `issue1091-nano-*-viewport.png` +
+     * `*-visible-terminal.txt` + `nano-summary.txt` + `timings.txt`.
+     */
+    @Test
+    fun hotkeysPanelCtrlOAndCtrlXSaveAndExitNanoFromPanelControls() = runBlocking {
+        val key = readFixtureKey()
+        waitForSshFixtureReady(SshKey.Pem(key))
+        seedTmuxSession(key)
+
+        val hostRowTag = seedDockerHost(key, "Issue1091 Nano")
+        launchedActivity = ActivityScenario.launch(MainActivity::class.java)
+
+        // ===== Attach to the session =====
+        compose.waitUntil(timeoutMillis = 10_000) {
+            compose.onAllNodesWithTag(hostRowTag, useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
+        val attachAt = SystemClock.elapsedRealtime()
+        compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick()
+        waitForSessionInPicker(rule = compose, sessionName = SESSION_NAME, timeoutMs = 20_000)
+        compose.onNodeWithText(SESSION_NAME).performClick()
+        compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertExists()
+        waitForTerminalViewAttached()
+        waitForVisibleTerminal("nano-prompt-ready") { it.isNotBlank() }
+        recordTiming("nano_attach_ms", SystemClock.elapsedRealtime() - attachAt)
+        captureViewport("issue1091-nano-01-attached")
+
+        // ===== Open the hotkeys panel =====
+        compose.waitUntil(timeoutMillis = 30_000) {
+            compose.onAllNodesWithTag(TERMINAL_HOTKEYS_LAUNCHER_TAG, useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
+        compose.onNodeWithTag(TERMINAL_HOTKEYS_LAUNCHER_TAG, useUnmergedTree = true).performClick()
+        // The #1091-filled nano control keys (incl. `^O` Write Out, `^X` Exit)
+        // must be present as direct buttons.
+        compose.waitUntil(timeoutMillis = 10_000) {
+            compose.onAllNodesWithText("^X", useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
+        listOf("^G", "^J", "^K", "^O", "^T", "^U", "^W", "^X", "^\\").forEach { label ->
+            assertTrue(
+                "expected the hotkeys panel to expose the nano control key '$label'",
+                compose.onAllNodesWithText(label, useUnmergedTree = true)
+                    .fetchSemanticsNodes()
+                    .isNotEmpty(),
+            )
+        }
+
+        // ===== Open a fresh nano buffer in the pane =====
+        // Absorb the one-time first-send stray fragment: the VERY FIRST
+        // onCreateInputConnection/commitText after attach can prepend a `-t%0`
+        // tmux control-mode fragment to the line (observed `~ $ -t%0nano … :
+        // not found`). Fire a throwaway Enter first so that fragment errors
+        // harmlessly on its own line and the nano command lands on a clean prompt.
+        terminalInputConnection().commitText("\n", 1)
+        SystemClock.sleep(1_000)
+        val nanoFile = "/tmp/ps-nano-$NANO_MARKER.txt"
+        sendCommandThroughTerminalInput("nano $nanoFile", "nano-launch")
+        waitForVisibleTerminal("nano-loaded", timeoutMillis = 30_000) { transcript ->
+            // Wait for nano's ACTUAL UI (alt-screen) — its title bar `GNU nano`
+            // or the `Write Out` / `Exit` helpbar entries. Crucially NOT a bare
+            // `contains("nano")`, which would match the echoed `nano …` command
+            // line and pass vacuously even if nano never launched.
+            transcript.contains("GNU nano") ||
+                transcript.contains("Write Out") ||
+                transcript.contains("^X Exit")
+        }
+        captureViewport("issue1091-nano-02-editor-open")
+
+        // Type a unique marker line into nano's buffer (no trailing newline — it
+        // becomes the buffer's first line). This is what must end up on disk.
+        typePendingLine(NANO_CONTENT, "nano-type")
+        waitForVisibleTerminal("nano-typed", timeoutMillis = 20_000) { transcript ->
+            transcript.contains(NANO_CONTENT)
+        }
+        captureViewport("issue1091-nano-03-typed")
+
+        // ===== Save: tap `^O` (Write Out) from the panel, confirm with Enter ====
+        val saveAt = SystemClock.elapsedRealtime()
+        tapPanelKey("^O")
+        // nano prompts `File Name to Write: <nanoFile>` (pre-filled from the arg).
+        waitForVisibleTerminal("nano-write-prompt", timeoutMillis = 20_000) { transcript ->
+            transcript.contains("File Name to Write") || transcript.contains("Write")
+        }
+        captureViewport("issue1091-nano-04-write-prompt")
+        // Confirm the write with the panel's dedicated Enter key.
+        tapPanelKey(TmuxHotkeyEnterLabel)
+        waitForVisibleTerminal("nano-wrote", timeoutMillis = 20_000) { transcript ->
+            // nano prints `[ Wrote N line(s) ]` ONLY on a successful disk write.
+            transcript.contains("Wrote")
+        }
+        recordTiming("nano_ctrl_o_save_ms", SystemClock.elapsedRealtime() - saveAt)
+        captureViewport("issue1091-nano-05-saved")
+
+        // ===== Exit: tap `^X` from the panel =====
+        val exitAt = SystemClock.elapsedRealtime()
+        tapPanelKey("^X")
+        // Back at the shell — prove interactivity AND that the file persisted by
+        // cat-ing it and echoing a post-exit sentinel.
+        SystemClock.sleep(750)
+        sendCommandThroughTerminalInput(
+            "echo $NANO_CAT_TAG; cat $nanoFile; echo $NANO_DONE",
+            "nano-verify",
+        )
+        waitForVisibleTerminal("nano-exited-verified", timeoutMillis = 20_000) { transcript ->
+            transcript.contains(NANO_DONE)
+        }
+        recordTiming("nano_ctrl_x_exit_to_prompt_ms", SystemClock.elapsedRealtime() - exitAt)
+        captureViewport("issue1091-nano-06-exited-verified")
+
+        writeText("nano-summary.txt", buildNanoSummary(nanoFile))
+        writeTimings()
+
+        // NOTE on durability: nano's `[ Wrote 1 line ]` confirmation is HARD-
+        // asserted in-flow above (`waitForVisibleTerminal("nano-wrote") { contains
+        // ("Wrote") }` throws if it never appears) and captured durably in
+        // `issue1091-nano-05-saved-visible-terminal.txt`. It lives on nano's
+        // ALTERNATE screen, which `^X` discards — so the final post-exit transcript
+        // (the MAIN screen) no longer contains it. The durable post-exit proof of
+        // the save is the `cat` re-read below: the bytes are on disk only if `^O`
+        // + Enter actually wrote them.
+        val transcript = visibleTerminalText()
+        // AC1 — `^X` Exit returned to an interactive shell (the post-exit sentinel
+        // only runs if nano actually quit and handed the PTY back to `sh`).
+        assertTrue(
+            "expected the post-exit sentinel '$NANO_DONE' proving `^X` exited nano " +
+                "back to the shell prompt; got:\n$transcript",
+            transcript.contains(NANO_DONE),
+        )
+        // AC1 — the file on disk holds exactly what we typed (cat reprints it after
+        // the LAST `$NANO_CAT_TAG`, i.e. the command's output, not its echo), so
+        // the panel's `^O` + Enter genuinely persisted the buffer through the real
+        // path — the durable equivalent of nano's transient `Wrote` message.
+        val catOutput = transcript.substringAfterLast(NANO_CAT_TAG)
+        assertTrue(
+            "expected `cat $nanoFile` after the `^X` exit to reprint the typed marker " +
+                "'$NANO_CONTENT' from disk, proving the `^O` save persisted; got tail:\n$catOutput",
+            catOutput.contains(NANO_CONTENT),
+        )
+    }
+
+    private fun buildNanoSummary(nanoFile: String): String = buildString {
+        appendLine("issue=1091 scenario=nano-save-exit-from-hotkeys-panel")
+        appendLine("host=$DEFAULT_HOST port=$DEFAULT_PORT user=$DEFAULT_USER session=$SESSION_NAME")
+        appendLine("nano_file=$nanoFile")
+        appendLine("nano_marker=$NANO_CONTENT")
+        appendLine("saved_via=^O(panel)+Enter(panel)")
+        appendLine("exited_via=^X(panel)")
+        appendLine("artifacts:")
+        listOf(
+            "issue1091-nano-01-attached",
+            "issue1091-nano-02-editor-open",
+            "issue1091-nano-03-typed",
+            "issue1091-nano-04-write-prompt",
+            "issue1091-nano-05-saved",
+            "issue1091-nano-06-exited-verified",
+        ).forEach { appendLine("  $it-viewport.png + $it-visible-terminal.txt") }
+    }
+
+    /**
+     * Tap a key labelled [label] inside the hotkeys panel sheet (scoped to a
+     * descendant of [TERMINAL_HOTKEYS_PANEL_TAG] so it never collides with a
+     * same-text chip elsewhere — e.g. the keyboard-down Enter chip).
+     */
+    private fun tapPanelKey(label: String) {
+        compose.onNode(
+            hasText(label)
+                .and(hasClickAction())
+                .and(hasAnyAncestor(hasTestTag(TERMINAL_HOTKEYS_PANEL_TAG))),
+        ).performClick()
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        SystemClock.sleep(150)
     }
 
     private fun buildSummary(
@@ -659,5 +881,10 @@ class TmuxKeyBarCtrlComboE2eTest {
         val RESUME_MARKER: String = "RESUMED-${System.currentTimeMillis().toString().takeLast(6)}"
         val RESUME_X2_MARKER: String = "RESUMEDX2-${System.currentTimeMillis().toString().takeLast(6)}"
         val ENTER_MARKER: String = "ENTERKEY-${System.currentTimeMillis().toString().takeLast(6)}"
+        // Issue #1091 nano leg.
+        val NANO_MARKER: String = System.currentTimeMillis().toString().takeLast(6)
+        val NANO_CONTENT: String = "ISSUE1091-NANO-$NANO_MARKER"
+        val NANO_CAT_TAG: String = "NANOCAT-$NANO_MARKER"
+        val NANO_DONE: String = "NANODONE-$NANO_MARKER"
     }
 }

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxSessionVoiceSurfaceUiTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxSessionVoiceSurfaceUiTest.kt
@@ -599,7 +599,10 @@ class TmuxSessionVoiceSurfaceUiTest {
     @Test
     fun tmuxHotkeysPanelExposesEmergencyKeysAndRestoredCtrlB() {
         // Issue #784: Esc / ^C / ^D plus the restored ^B (tmux prefix) all show
-        // as direct, tappable buttons — no `…` overflow, no lone Ctrl.
+        // as direct, tappable buttons — no `…` overflow. (Issue #1091 added a
+        // sticky `Ctrl` MODIFIER for the general `Ctrl+<letter>` escape hatch; the
+        // direct combos below are unchanged and this test does not assert against
+        // the modifier.)
         val taps = mutableListOf<String>()
         compose.setContent {
             PocketShellTheme {

--- a/app/src/main/java/com/pocketshell/app/tmux/TerminalHotkeysSheet.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TerminalHotkeysSheet.kt
@@ -15,6 +15,7 @@ import com.pocketshell.uikit.components.HotkeySection
 import com.pocketshell.uikit.components.TERMINAL_HOTKEYS_PANEL_TAG
 import com.pocketshell.uikit.components.TerminalHotkeysPanel
 import com.pocketshell.uikit.model.KeyBinding
+import com.pocketshell.uikit.model.KeyModifierState
 import com.pocketshell.uikit.theme.PocketShellColors
 import androidx.compose.ui.platform.testTag
 
@@ -39,6 +40,9 @@ internal fun TerminalHotkeysSheet(
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
+    // Issue #1091: the sticky `Ctrl` modifier state so the panel can render the
+    // active accent on the `Ctrl` key.
+    ctrlModifierState: KeyModifierState = KeyModifierState.Off,
     // Skip the half-expand stop: the panel is short content-height chrome, so
     // it should land fully open in one go like the agent-command palette.
     sheetState: SheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
@@ -60,6 +64,7 @@ internal fun TerminalHotkeysSheet(
             onKey = onKey,
             onClose = onDismiss,
             enabled = enabled,
+            modifierState = ctrlModifierState,
             modifier = Modifier
                 .navigationBarsPadding()
                 .testTag(TERMINAL_HOTKEYS_PANEL_TAG),

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
@@ -2849,9 +2849,14 @@ public fun TmuxSessionScreen(
     // a settled (promoted) pane reaches the session the user is looking at.
     val hotkeysPane = surfacePane
     if (showHotkeysPanel && hotkeysPane != null) {
+        // Issue #1091: the sticky `Ctrl` modifier state drives the panel's
+        // accent on the `Ctrl` key (and `onKeyBarKey` consults it to compose
+        // `Ctrl+<letter>`).
+        val ctrlModifierState by viewModel.ctrlModifier.collectAsState()
         TerminalHotkeysSheet(
             sections = TmuxHotkeyPanelSections,
             enabled = sessionLive,
+            ctrlModifierState = ctrlModifierState,
             onKey = { binding ->
                 if (sessionLive) {
                     DiagnosticEvents.record(
@@ -7058,6 +7063,15 @@ internal fun tmuxTerminalKeyboardChromeMode(
  */
 internal const val TmuxHotkeyEnterLabel: String = "Enter"
 
+// Issue #1091: the sticky `Ctrl` modifier label. Tapping it cycles the
+// modifier (Off -> OneShot -> Locked -> Off) via
+// [TmuxSessionViewModel.onCtrlModifierTap]; the next key from the LETTERS
+// section is then sent as its control char so `Ctrl+<any letter>` (and the
+// caret-range symbols) is reachable — the general escape hatch beyond the
+// curated direct buttons. The maintainer was trapped in `nano` because the
+// old fixed subset could not send arbitrary control combos.
+internal const val TmuxHotkeyCtrlModifierLabel: String = "Ctrl"
+
 // Issue #787: the DOUBLED interrupt/EOF controls, re-homed into the hotkeys
 // panel from the deleted `/ commands` palette (where they were the only home —
 // originally #453/#543). The double-press is a DISTINCT sequence from the single
@@ -7083,6 +7097,11 @@ internal val TmuxHotkeyPanelSections: List<com.pocketshell.uikit.components.Hotk
         ),
         columns = 4,
     ),
+    // Issue #1091: the curated one-tap control combos — the existing 8 plus the
+    // control keys nano (and many TUIs) need that were missing: `^G` Help, `^J`
+    // Justify, `^K` Cut, `^O` Write Out, `^T` Execute, `^U` cut-to-start, `^W`
+    // Where-Is, `^X` Exit, `^\` Replace. Ordered by control byte so the grid
+    // reads predictably. Each routes to its byte via [onKeyBarKey].
     com.pocketshell.uikit.components.HotkeySection(
         title = "CTRL COMBOS",
         keys = listOf(
@@ -7091,9 +7110,18 @@ internal val TmuxHotkeyPanelSections: List<com.pocketshell.uikit.components.Hotk
             KeyBinding(label = "^C", kind = KeyKind.Regular),
             KeyBinding(label = "^D", kind = KeyKind.Regular),
             KeyBinding(label = "^E", kind = KeyKind.Regular),
+            KeyBinding(label = "^G", kind = KeyKind.Regular),
+            KeyBinding(label = "^J", kind = KeyKind.Regular),
+            KeyBinding(label = "^K", kind = KeyKind.Regular),
             KeyBinding(label = "^L", kind = KeyKind.Regular),
+            KeyBinding(label = "^O", kind = KeyKind.Regular),
             KeyBinding(label = "^R", kind = KeyKind.Regular),
+            KeyBinding(label = "^T", kind = KeyKind.Regular),
+            KeyBinding(label = "^U", kind = KeyKind.Regular),
+            KeyBinding(label = "^W", kind = KeyKind.Regular),
+            KeyBinding(label = "^X", kind = KeyKind.Regular),
             KeyBinding(label = "^Z", kind = KeyKind.Regular),
+            KeyBinding(label = "^\\", kind = KeyKind.Regular),
         ),
         columns = 4,
     ),
@@ -7107,6 +7135,23 @@ internal val TmuxHotkeyPanelSections: List<com.pocketshell.uikit.components.Hotk
             KeyBinding(label = TmuxHotkeyEofX2Label, kind = KeyKind.Regular),
         ),
         columns = 2,
+    ),
+    // Issue #1091: the general `Ctrl + <any letter>` escape hatch. Tap `Ctrl`
+    // (a sticky modifier — single tap = one-shot, double tap = locked, accent
+    // when active) then a letter to send that letter's control byte. With
+    // `Ctrl` off a letter types literally. Covers every `Ctrl+<a–z>` combo, not
+    // just the curated subset above — so no TUI key is ever unreachable.
+    com.pocketshell.uikit.components.HotkeySection(
+        title = "CTRL + LETTER",
+        keys = listOf(
+            KeyBinding(label = TmuxHotkeyCtrlModifierLabel, kind = KeyKind.Modifier),
+        ),
+        columns = 4,
+    ),
+    com.pocketshell.uikit.components.HotkeySection(
+        title = "LETTERS",
+        keys = ('a'..'z').map { KeyBinding(label = it.toString(), kind = KeyKind.Regular) },
+        columns = 7,
     ),
     com.pocketshell.uikit.components.HotkeySection(
         title = "ARROWS",

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -39,6 +39,7 @@ import com.pocketshell.app.projects.FolderListGateway
 import com.pocketshell.app.projects.ManualKindWriter
 import com.pocketshell.app.projects.ProfilesResult
 import com.pocketshell.app.projects.RemoteProfile
+import com.pocketshell.uikit.model.KeyModifierState
 import com.pocketshell.uikit.model.SessionAgentKind
 import com.pocketshell.uikit.model.sessionAgentKindFromOption
 import com.pocketshell.app.share.FilenameSanitiser
@@ -15446,11 +15447,37 @@ public class TmuxSessionViewModel @Inject constructor(
      * choose the cursor-key encoding is more correct than us baking
      * ESC[A in here.
      */
+    /**
+     * Issue #1091: the sticky `Ctrl` modifier state, surfaced so the hotkeys
+     * panel can render the active (accent) treatment. `Off` -> not armed;
+     * `OneShot` -> the next composable key is sent as a control char then the
+     * modifier auto-releases; `Locked` -> stays armed until tapped off.
+     */
+    private val _ctrlModifier = MutableStateFlow(KeyModifierState.Off)
+    public val ctrlModifier: StateFlow<KeyModifierState> = _ctrlModifier.asStateFlow()
+
+    /**
+     * Issue #1091: cycle the sticky `Ctrl` modifier on each tap of the `Ctrl`
+     * key — `Off -> OneShot -> Locked -> Off`. A single tap arms it for the
+     * next key; a second consecutive tap (the "double tap") locks it on; a
+     * third tap releases it. Matches the `docs/input-methods.md` key-bar
+     * modifier spec.
+     */
+    public fun onCtrlModifierTap() {
+        _ctrlModifier.value = when (_ctrlModifier.value) {
+            KeyModifierState.Off -> KeyModifierState.OneShot
+            KeyModifierState.OneShot -> KeyModifierState.Locked
+            KeyModifierState.Locked -> KeyModifierState.Off
+        }
+    }
+
     public fun onKeyBarKey(paneId: String, label: String) {
-        // Issue #784: every hotkey is now a DIRECT button (the lone `Ctrl`
-        // modifier + its armed-chord FSM were removed — the maintainer's "lone
-        // Ctrl does nothing useful" complaint). The label is mapped straight to
-        // its control byte (`send-keys -H` overlay) or tmux named key below.
+        // Issue #1091: the lone-`Ctrl` modifier is BACK (it was removed in #784)
+        // — but now as a real sticky modifier that composes with the panel's
+        // LETTERS section so the maintainer can send `Ctrl+<any key>` (the
+        // `nano`-trapped report). Direct one-tap control buttons (incl. the
+        // newly-filled `^X`/`^O`/`^K`/…) stay too; both routes go through the
+        // same `send-keys -H` overlay below — no new transport.
         DiagnosticEvents.record(
             "action",
             "shortcut_sent",
@@ -15458,6 +15485,31 @@ public class TmuxSessionViewModel @Inject constructor(
             "paneId" to paneId,
             "key" to label,
         )
+
+        // Issue #1091: tapping the `Ctrl` modifier only cycles the sticky state
+        // (no byte is sent — it decorates the NEXT key), like the key-bar spec.
+        if (label == TmuxHotkeyCtrlModifierLabel) {
+            onCtrlModifierTap()
+            return
+        }
+
+        // Issue #1091: a single composable char (the LETTERS section, a–z and
+        // the caret-range symbols). With `Ctrl` armed it is sent as its control
+        // byte (`Ctrl+<letter>`); with `Ctrl` off it is typed literally. A
+        // OneShot modifier auto-releases after the key; Locked persists.
+        val composable = singleControlComposableChar(label)
+        if (composable != null) {
+            val armed = _ctrlModifier.value
+            if (armed != KeyModifierState.Off) {
+                controlByteForChar(composable)?.let { sendControlInputToPane(paneId, it) }
+                if (armed == KeyModifierState.OneShot) {
+                    _ctrlModifier.value = KeyModifierState.Off
+                }
+            } else {
+                writeInputToPane(paneId, composable.toString().toByteArray(Charsets.UTF_8))
+            }
+            return
+        }
 
         val named = when (label) {
             "Esc" -> "Escape"
@@ -15536,6 +15588,37 @@ public class TmuxSessionViewModel @Inject constructor(
             }
             "^X", "Ctrl-X" -> {
                 sendControlInputToPane(paneId, CtrlXByte)
+                null
+            }
+            // Issue #1091: the control keys nano (and many TUIs) need that were
+            // missing — `^G` `^J` `^K` `^T` `^U` `^W` `^\`. Direct one-tap
+            // buttons routed through the same `send-keys -H` overlay path.
+            "^G", "Ctrl-G" -> {
+                sendControlInputToPane(paneId, CtrlGByte)
+                null
+            }
+            "^J", "Ctrl-J" -> {
+                sendControlInputToPane(paneId, CtrlJByte)
+                null
+            }
+            "^K", "Ctrl-K" -> {
+                sendControlInputToPane(paneId, CtrlKByte)
+                null
+            }
+            "^T", "Ctrl-T" -> {
+                sendControlInputToPane(paneId, CtrlTByte)
+                null
+            }
+            "^U", "Ctrl-U" -> {
+                sendControlInputToPane(paneId, CtrlUByte)
+                null
+            }
+            "^W", "Ctrl-W" -> {
+                sendControlInputToPane(paneId, CtrlWByte)
+                null
+            }
+            "^\\", "Ctrl-\\" -> {
+                sendControlInputToPane(paneId, CtrlBackslashByte)
                 null
             }
             // Issue #784: clean arrow glyphs (← ↑ ↓ →) replace the old
@@ -17487,6 +17570,48 @@ internal const val CtrlRByte: Int = 0x12
 internal const val CtrlZByte: Int = 0x1A
 internal const val CtrlOByte: Int = 0x0F
 internal const val CtrlXByte: Int = 0x18
+// Issue #1091: the control keys nano (and many TUIs) need that were missing
+// from the hotkey set — `^G` Help, `^J` Justify/newline, `^K` Cut, `^T`
+// Execute, `^U` cut-to-start, `^W` Where-Is, `^\` Replace. Each is
+// `(uppercase letter - 0x40)`; `^\` is 0x1C.
+internal const val CtrlGByte: Int = 0x07
+internal const val CtrlJByte: Int = 0x0A
+internal const val CtrlKByte: Int = 0x0B
+internal const val CtrlTByte: Int = 0x14
+internal const val CtrlUByte: Int = 0x15
+internal const val CtrlWByte: Int = 0x17
+internal const val CtrlBackslashByte: Int = 0x1C
+
+/**
+ * Issue #1091: control byte for a single printable [c] composed with the
+ * sticky `Ctrl` modifier. Letters map to `0x01..0x1A` (`Ctrl+A`..`Ctrl+Z`);
+ * the caret-range symbols map to `0x1B..0x1F` and `Ctrl+@`/`Ctrl+Space` to
+ * `0x00`. Returns null for a char that has no control encoding. Mirrors the
+ * canonical xterm/VT control-char table so the byte the terminal receives is
+ * exactly what a hardware `Ctrl` chord would produce.
+ */
+internal fun controlByteForChar(c: Char): Int? {
+    val upper = c.uppercaseChar()
+    return when (upper) {
+        in 'A'..'Z' -> upper.code - 0x40
+        '@', ' ' -> 0x00
+        '[' -> 0x1B
+        '\\' -> 0x1C
+        ']' -> 0x1D
+        '^' -> 0x1E
+        '_' -> 0x1F
+        else -> null
+    }
+}
+
+/**
+ * Issue #1091: the single-character key label (the panel's LETTERS section)
+ * that the sticky `Ctrl` modifier composes with, or null when [label] is not a
+ * single control-composable char (e.g. multi-char `Esc`/`^X`, or an arrow
+ * glyph).
+ */
+internal fun singleControlComposableChar(label: String): Char? =
+    label.singleOrNull()?.takeIf { controlByteForChar(it) != null }
 
 /**
  * Issue #215: ceiling on the synchronous `detach-client` round-trip the

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
@@ -40,6 +40,7 @@ import com.pocketshell.core.terminal.ui.TerminalSurfaceState
 import com.pocketshell.core.tmux.CommandResponse
 import com.pocketshell.core.tmux.TmuxClient
 import com.pocketshell.uikit.model.KeyKind
+import com.pocketshell.uikit.model.KeyModifierState
 import com.pocketshell.uikit.model.SessionAgentKind
 import com.pocketshell.core.tmux.TmuxClientException
 import com.pocketshell.core.tmux.TmuxClientFactory
@@ -7216,19 +7217,32 @@ class TmuxSessionViewModelTest {
 
     @Test
     fun hotkeyPanelSectionsAreDeDupedAndCarryTheAuditedSet() {
-        // Issue #784: the dedicated panel set — no duplicate `/`, no lone
-        // `Ctrl`, `^B` present, clean arrow glyphs. Issue #787 added the
-        // INTERRUPT / EOF doubled chords (`^C×2` / `^D×2`), re-homed from the
-        // deleted palette. Verify the curated set is exactly what we expect and
-        // has no duplicate labels.
+        // Issue #784: the dedicated panel set — no duplicate `/`, `^B` present,
+        // clean arrow glyphs. Issue #787 added the INTERRUPT / EOF doubled
+        // chords (`^C×2` / `^D×2`), re-homed from the deleted palette. Issue
+        // #1091 FILLED the missing nano/TUI control keys into CTRL COMBOS
+        // (`^G ^J ^K ^O ^T ^U ^W ^X ^\`) and DELIBERATELY restored a sticky
+        // `Ctrl` modifier plus the a–z LETTERS grid so `Ctrl+<any letter>` is
+        // reachable. Verify the curated set is exactly what we expect and has
+        // no duplicate labels.
         val labels = TmuxHotkeyPanelSections.flatMap { it.keys }.map { it.label }
         assertEquals(
             listOf(
-                // Issue #893: ⇧Tab (back-tab / Shift+Tab) sits between Tab and
-                // Enter in the KEYS section.
+                // KEYS — Issue #893: ⇧Tab (back-tab / Shift+Tab) sits between
+                // Tab and Enter.
                 "Esc", "Tab", "⇧Tab", "Enter",
-                "^A", "^B", "^C", "^D", "^E", "^L", "^R", "^Z",
+                // CTRL COMBOS — Issue #1091 ordered by control byte; the
+                // previously-missing nano/TUI keys are filled in.
+                "^A", "^B", "^C", "^D", "^E", "^G", "^J", "^K", "^L", "^O",
+                "^R", "^T", "^U", "^W", "^X", "^Z", "^\\",
+                // INTERRUPT / EOF — Issue #787 doubled chords.
                 TmuxHotkeyInterruptX2Label, TmuxHotkeyEofX2Label,
+                // CTRL + LETTER — Issue #1091 sticky modifier.
+                TmuxHotkeyCtrlModifierLabel,
+                // LETTERS — Issue #1091 a–z grid for Ctrl composition.
+                "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m",
+                "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z",
+                // ARROWS.
                 "←", "↑", "↓", "→",
             ),
             labels,
@@ -7236,13 +7250,27 @@ class TmuxSessionViewModelTest {
         // Issue #893: the back-tab key is present in the KEYS section.
         assertTrue(labels.contains("⇧Tab"))
         // No duplicates (the maintainer's "/ appears twice" / "Esc duplicated"
-        // complaints).
+        // complaints) — still holds with the filled keys + LETTERS grid added.
         assertEquals(labels.size, labels.toSet().size)
-        // No lone Ctrl modifier and no `/` key in the panel.
-        assertFalse(labels.contains("Ctrl"))
+        // Issue #1091: the sticky `Ctrl` modifier is now INTENTIONALLY present
+        // (it is the general `Ctrl+<letter>` escape hatch), and it is a
+        // Modifier-kind key, not a lone Regular button.
+        assertTrue(labels.contains(TmuxHotkeyCtrlModifierLabel))
+        val ctrlKey = TmuxHotkeyPanelSections.flatMap { it.keys }
+            .single { it.label == TmuxHotkeyCtrlModifierLabel }
+        assertEquals(KeyKind.Modifier, ctrlKey.kind)
+        // No `/` key in the panel.
         assertFalse(labels.contains("/"))
         // ^B (tmux prefix) restored.
         assertTrue(labels.contains("^B"))
+        // Issue #1091: the filled nano/TUI control keys are present.
+        listOf("^G", "^J", "^K", "^O", "^T", "^U", "^W", "^X", "^\\").forEach {
+            assertTrue("CTRL COMBOS must offer the filled key $it", labels.contains(it))
+        }
+        // Issue #1091: the full a–z LETTERS grid is present for Ctrl composition.
+        ('a'..'z').forEach { c ->
+            assertTrue("LETTERS must offer '$c'", labels.contains(c.toString()))
+        }
         // Issue #787: the doubled interrupt/EOF chords are present and DISTINCT
         // from the single `^C`/`^D` (they're not aliases of the same label).
         assertTrue(labels.contains(TmuxHotkeyInterruptX2Label))
@@ -17727,5 +17755,257 @@ class TmuxSessionViewModelTest {
         private companion object {
             val PANE_ID_RE = Regex("\"pane_id\":\"([^\"]+)\"")
         }
+    }
+
+    // ---------------------------------------------------------------------
+    // Issue #1091: terminal hotkeys — Ctrl+<any key> (sticky Ctrl modifier) +
+    // fill the missing control keys (nano's ^X/^O/^K/^W/^G/^T/^J/^\ …).
+    // ---------------------------------------------------------------------
+
+    private fun TmuxSessionViewModel.attachWithShellPaneForHotkeys(): FakeTmuxClient {
+        val client = FakeTmuxClient()
+        attachClientForTest(client)
+        applyParsedPanesForTest(
+            listOf(TmuxSessionViewModel.ParsedPane("%0", "@0", "\$0", "shell", paneIndex = 0)),
+        )
+        return client
+    }
+
+    private fun FakeTmuxClient.lastControlHexAfter(before: Int): String? =
+        sentCommands.drop(before)
+            .lastOrNull { it.startsWith("send-keys -H -t %0 ") }
+            ?.removePrefix("send-keys -H -t %0 ")
+
+    /**
+     * Issue #1091 — REPRODUCE-FIRST (D33/G10). Uses ONLY the existing public
+     * symbols (string labels + `sentCommands`) so it compiles against the
+     * UNFIXED code and fails at runtime:
+     *  - nano's essential control keys (`^K`/`^W`/`^G`/`^U`/`^T`/`^J`/`^\`)
+     *    are not mapped in `onKeyBarKey`, so tapping them sends nothing.
+     *  - there is no Ctrl modifier, so arming `Ctrl` then tapping a letter
+     *    sends nothing.
+     * RED on base, GREEN with the fix.
+     */
+    @Test
+    fun reproduceNanoControlKeysAndStickyCtrlGap() = runTest(scheduler) {
+        val vm = newVm()
+        val client = vm.attachWithShellPaneForHotkeys()
+        advanceUntilIdle()
+
+        val nano = mapOf(
+            "^K" to "0b", "^W" to "17", "^G" to "07", "^U" to "15",
+            "^T" to "14", "^J" to "0a", "^\\" to "1c",
+        )
+        nano.forEach { (label, hex) ->
+            val before = client.sentCommands.size
+            vm.onKeyBarKey("%0", label)
+            advanceUntilIdle()
+            assertEquals(
+                "hotkey $label must emit control byte 0x$hex; got ${client.sentCommands.drop(before)}",
+                hex,
+                client.lastControlHexAfter(before),
+            )
+        }
+
+        val before = client.sentCommands.size
+        vm.onKeyBarKey("%0", "Ctrl")
+        vm.onKeyBarKey("%0", "x")
+        advanceUntilIdle()
+        assertEquals(
+            "sticky Ctrl + x must emit ^X (0x18); got ${client.sentCommands.drop(before)}",
+            "18",
+            client.lastControlHexAfter(before),
+        )
+    }
+
+    /**
+     * Issue #1091 acceptance: the panel OFFERS the previously-missing control
+     * keys, keeps the existing 8 + the interrupt/EOF chords, and adds the
+     * sticky `Ctrl` modifier + the a–z LETTERS section. This is the "fill the
+     * missing control keys" + "restore a Ctrl modifier" UI-offering gap (the
+     * send path already mapped `^X`/`^O`, the panel just never showed them).
+     */
+    @Test
+    fun hotkeyPanelOffersNanoKeysStickyCtrlAndLetters() {
+        val labels = TmuxHotkeyPanelSections.flatMap { it.keys }.map { it.label }
+
+        listOf("^X", "^O", "^K", "^W", "^G", "^U", "^T", "^J", "^\\").forEach {
+            assertTrue("panel must offer the filled control key $it; has $labels", labels.contains(it))
+        }
+        listOf("^A", "^B", "^C", "^D", "^E", "^L", "^R", "^Z").forEach {
+            assertTrue("panel must keep existing control key $it", labels.contains(it))
+        }
+        assertTrue("panel must keep ^C×2", labels.contains(TmuxHotkeyInterruptX2Label))
+        assertTrue("panel must keep ^D×2", labels.contains(TmuxHotkeyEofX2Label))
+
+        val ctrl = TmuxHotkeyPanelSections.flatMap { it.keys }
+            .firstOrNull { it.label == TmuxHotkeyCtrlModifierLabel }
+        assertNotNull("panel must offer a sticky Ctrl modifier", ctrl)
+        assertEquals("Ctrl must be a Modifier key", KeyKind.Modifier, ctrl!!.kind)
+
+        ('a'..'z').forEach { c ->
+            assertTrue("panel must offer letter '$c' for Ctrl composition", labels.contains(c.toString()))
+        }
+    }
+
+    /**
+     * Issue #1091 acceptance: every direct control hotkey emits its exact
+     * control byte through the `send-keys -H` overlay (class coverage over the
+     * whole filled set, not just the reported `^X`/`^O`).
+     */
+    @Test
+    fun everyDirectControlHotkeyEmitsItsByte() = runTest(scheduler) {
+        val vm = newVm()
+        val client = vm.attachWithShellPaneForHotkeys()
+        advanceUntilIdle()
+
+        val expected = mapOf(
+            "^A" to "01", "^B" to "02", "^C" to "03", "^D" to "04", "^E" to "05",
+            "^G" to "07", "^J" to "0a", "^K" to "0b", "^L" to "0c", "^O" to "0f",
+            "^R" to "12", "^T" to "14", "^U" to "15", "^W" to "17", "^X" to "18",
+            "^Z" to "1a", "^\\" to "1c",
+        )
+        expected.forEach { (label, hex) ->
+            val before = client.sentCommands.size
+            vm.onKeyBarKey("%0", label)
+            advanceUntilIdle()
+            assertEquals(
+                "hotkey $label must emit 0x$hex; got ${client.sentCommands.drop(before)}",
+                "send-keys -H -t %0 $hex",
+                client.sentCommands.drop(before).lastOrNull { it.startsWith("send-keys -H -t %0 ") },
+            )
+        }
+    }
+
+    /**
+     * Issue #1091 acceptance: a one-shot sticky `Ctrl` composes with ANY letter
+     * a–z to its correct control byte (0x01–0x1A) and then AUTO-RELEASES after
+     * the single key.
+     */
+    @Test
+    fun stickyCtrlOneShotComposesWithAnyLetterThenAutoReleases() = runTest(scheduler) {
+        val vm = newVm()
+        val client = vm.attachWithShellPaneForHotkeys()
+        advanceUntilIdle()
+
+        val cases = mapOf(
+            'a' to "01", 'c' to "03", 'k' to "0b", 'o' to "0f",
+            'x' to "18", 'z' to "1a",
+        )
+        cases.forEach { (letter, hex) ->
+            assertEquals("Ctrl must start Off", KeyModifierState.Off, vm.ctrlModifier.value)
+            vm.onKeyBarKey("%0", "Ctrl")
+            assertEquals("single tap arms one-shot", KeyModifierState.OneShot, vm.ctrlModifier.value)
+            val before = client.sentCommands.size
+            vm.onKeyBarKey("%0", letter.toString())
+            advanceUntilIdle()
+            assertEquals(
+                "Ctrl+$letter must emit 0x$hex; got ${client.sentCommands.drop(before)}",
+                hex,
+                client.lastControlHexAfter(before),
+            )
+            assertEquals("one-shot Ctrl must auto-release", KeyModifierState.Off, vm.ctrlModifier.value)
+        }
+
+        // With Ctrl OFF a letter is typed literally — NOT a control byte.
+        val before = client.sentCommands.size
+        vm.onKeyBarKey("%0", "a")
+        advanceUntilIdle()
+        val after = client.sentCommands.drop(before)
+        assertTrue(
+            "Ctrl off: letter must be a literal send-keys; got $after",
+            after.any { it == "send-keys -l -t %0 -- 'a'" },
+        )
+        assertFalse(
+            "Ctrl off: letter must NOT be a control byte; got $after",
+            after.any { it == "send-keys -H -t %0 01" },
+        )
+    }
+
+    /**
+     * Issue #1091 acceptance: a double tap LOCKS `Ctrl` sticky — it survives
+     * each composed key and stays until tapped off.
+     */
+    @Test
+    fun stickyCtrlDoubleTapLocksAndPersists() = runTest(scheduler) {
+        val vm = newVm()
+        val client = vm.attachWithShellPaneForHotkeys()
+        advanceUntilIdle()
+
+        vm.onKeyBarKey("%0", "Ctrl")
+        vm.onKeyBarKey("%0", "Ctrl")
+        assertEquals("double tap locks", KeyModifierState.Locked, vm.ctrlModifier.value)
+
+        var before = client.sentCommands.size
+        vm.onKeyBarKey("%0", "x")
+        advanceUntilIdle()
+        assertEquals("locked Ctrl+x -> 0x18", "18", client.lastControlHexAfter(before))
+        assertEquals("locked Ctrl survives the key", KeyModifierState.Locked, vm.ctrlModifier.value)
+
+        before = client.sentCommands.size
+        vm.onKeyBarKey("%0", "k")
+        advanceUntilIdle()
+        assertEquals("locked Ctrl+k -> 0x0b", "0b", client.lastControlHexAfter(before))
+        assertEquals("locked Ctrl still survives", KeyModifierState.Locked, vm.ctrlModifier.value)
+
+        // A third tap on the modifier releases it.
+        vm.onKeyBarKey("%0", "Ctrl")
+        assertEquals("tapping a locked Ctrl releases it", KeyModifierState.Off, vm.ctrlModifier.value)
+    }
+
+    /**
+     * Issue #1091 acceptance: the active modifier state is exposed (drives the
+     * panel accent) — Off -> OneShot -> Locked -> Off on consecutive taps.
+     */
+    @Test
+    fun ctrlModifierActiveStateCyclesForAccentRendering() = runTest(scheduler) {
+        val vm = newVm()
+        vm.attachWithShellPaneForHotkeys()
+        advanceUntilIdle()
+
+        assertEquals(KeyModifierState.Off, vm.ctrlModifier.value)
+        vm.onKeyBarKey("%0", "Ctrl")
+        assertEquals(KeyModifierState.OneShot, vm.ctrlModifier.value)
+        vm.onKeyBarKey("%0", "Ctrl")
+        assertEquals(KeyModifierState.Locked, vm.ctrlModifier.value)
+        vm.onKeyBarKey("%0", "Ctrl")
+        assertEquals(KeyModifierState.Off, vm.ctrlModifier.value)
+    }
+
+    /**
+     * Issue #1091 acceptance: the existing single `^C`/`^D`/`^Z` and the
+     * doubled `^C×2`/`^D×2` interrupt/EOF chords are unchanged (no #787/#784
+     * regression).
+     */
+    @Test
+    fun interruptAndEofChordsUnchanged() = runTest(scheduler) {
+        val vm = newVm()
+        val client = vm.attachWithShellPaneForHotkeys()
+        advanceUntilIdle()
+
+        var before = client.sentCommands.size
+        vm.onKeyBarKey("%0", "^C")
+        advanceUntilIdle()
+        assertEquals("single ^C -> 0x03", "03", client.lastControlHexAfter(before))
+
+        before = client.sentCommands.size
+        vm.onKeyBarKey("%0", "^D")
+        advanceUntilIdle()
+        assertEquals("single ^D -> 0x04", "04", client.lastControlHexAfter(before))
+
+        before = client.sentCommands.size
+        vm.onKeyBarKey("%0", "^Z")
+        advanceUntilIdle()
+        assertEquals("single ^Z -> 0x1a", "1a", client.lastControlHexAfter(before))
+
+        before = client.sentCommands.size
+        vm.onKeyBarKey("%0", TmuxHotkeyInterruptX2Label)
+        advanceUntilIdle()
+        assertEquals("^C×2 -> doubled 0x03 byte", "03 03", client.lastControlHexAfter(before))
+
+        before = client.sentCommands.size
+        vm.onKeyBarKey("%0", TmuxHotkeyEofX2Label)
+        advanceUntilIdle()
+        assertEquals("^D×2 -> doubled 0x04 byte", "04 04", client.lastControlHexAfter(before))
     }
 }

--- a/docs/input-methods.md
+++ b/docs/input-methods.md
@@ -7,8 +7,8 @@ The full alternative-to-typing strategy. PocketShell reduces keyboard reliance t
 | Surface | Purpose | Trigger |
 |---|---|---|
 | Prompt Composer | Voice/text composing for agent prompts | Tap mic FAB on session view |
-| Inline dictation | Voice straight into the terminal at cursor | Tap mic icon in the key bar |
-| Key bar | Single special keys + sticky modifiers (Esc, Tab, Ctrl, Alt, arrows) | Always visible above the system keyboard |
+| Inline dictation | Voice straight into the terminal at cursor | Tap mic icon in the bottom controls |
+| Terminal hotkeys panel | Special keys, control combos, the sticky `Ctrl` modifier + a–z letters, arrows | Tap the `⌨` launcher on the Terminal tab |
 | Command chips / snippets | Whole commands or prompt templates | Always-visible chip row when keyboard is down |
 
 For tmux operations (detach, switch sessions, etc.) PocketShell uses native UI controls rather than a chord palette — see [Quick navigation](#quick-navigation-replaces-chord-palette) below.
@@ -102,26 +102,47 @@ Composer remains the preferred surface for prose and longer agent prompts.
 
 ---
 
-## Key bar
+## Terminal hotkeys panel
 
-Always visible above the system keyboard, only while the keyboard is up. Eight slots:
+The terminal control keys live in a dedicated **hotkeys panel** — its own
+bottom-sheet surface opened from the Terminal tab's `⌨` launcher (NOT crammed
+above the soft keyboard; #784/#789 hard-cut the old in-keyboard bar). The panel
+shows every key at once in a tidy grid and stays open after a tap so you can
+fire several keys in a row. It routes every tap through
+`TmuxSessionViewModel.onKeyBarKey`, which maps the visible label to its control
+byte (`send-keys -H` overlay) or tmux named key — no terminal resize / redraw.
+
+Sections:
 
 ```
-├─────────────────────────────────────────┤
-│ [Esc] [Tab] [Ctrl] [Alt] [<][^][v][>]   │
-├─────────────────────────────────────────┤
-│  q w e r t y u i o p                    │
-│   a s d f g h j k l                     │  system keyboard
-│    z x c v b n m  ⌫                     │
-└─────────────────────────────────────────┘
+KEYS             Esc  Tab  ⇧Tab  Enter
+CTRL COMBOS      ^A ^B ^C ^D ^E ^G ^J ^K ^L ^O ^R ^T ^U ^W ^X ^Z ^\
+INTERRUPT/EOF    ^C×2  ^D×2
+CTRL + LETTER    [Ctrl]                         ← sticky modifier
+LETTERS          a b c d e f g … x y z
+ARROWS           ←  ↑  ↓  →
 ```
 
-Interactions:
-- Tap a modifier (Ctrl/Alt) → next key sent with modifier; modifier auto-releases
-- Double-tap a modifier → sticky (stays on until tapped again or auto-releases after timeout)
-- Tap Esc/Tab/arrows → sends key immediately
+- **CTRL COMBOS** are one-tap direct buttons — the curated common chords plus
+  the keys nano (and many TUIs) need: `^G` Help, `^J` Justify, `^K` Cut, `^O`
+  Write Out, `^T` Execute, `^U` cut-to-start, `^W` Where-Is, `^X` Exit, `^\`
+  Replace. So you can save-and-exit `nano` (`^O`,Enter then `^X`) entirely from
+  PocketShell, no modifier dance (issue #1091).
+- **CTRL + LETTER** is the general escape hatch: tap the sticky **`Ctrl`**
+  modifier, then any letter in the **LETTERS** grid → that letter's control byte
+  (`Ctrl+A`=0x01 … `Ctrl+Z`=0x1A), so `Ctrl+<any key>` is reachable, not just
+  the curated subset.
 
-Active modifiers light up in the accent colour. Bar height ~40dp. For Ctrl+C, Ctrl+R, etc. — tap `Ctrl` then the letter (two taps).
+Modifier interactions (the `Ctrl` key):
+- Single tap → armed for the **next** key (one-shot), then auto-releases.
+- Double tap → **locked** sticky: stays on until tapped again, so you can fire
+  several `Ctrl+<letter>` combos in a row.
+- Active `Ctrl` lights up in the accent colour (accent-soft fill, accent-dim
+  border).
+- With `Ctrl` off, a LETTERS tap types that letter literally.
+- The doubled `^C×2`/`^D×2` send the byte twice (the "press again to
+  interrupt/exit" chord many REPLs/agents need; #787) — distinct from a single
+  `^C`/`^D`.
 
 ---
 
@@ -138,7 +159,7 @@ The original plan had a chord palette for tmux sequences (`Ctrl+B D` detach, `Ct
 | Next/prev window | Swipe within session |
 | Kill / rename | `⋮` menu on the breadcrumb |
 
-For things genuinely without native UI (vim `Esc :wq`, less `q`, copy mode entry) → key bar modifiers handle them via two-tap sequences.
+For things genuinely without native UI (vim `Esc :wq`, less `q`, copy mode entry) → the terminal hotkeys panel handles them (direct keys, or the sticky `Ctrl` + a letter).
 
 A power-user chord palette may return as opt-in settings post-v1 if real demand appears. v1 stays simple.
 
@@ -148,7 +169,7 @@ A power-user chord palette may return as opt-in settings post-v1 if real demand 
 
 Already covered in [vision.md](vision.md) §4. Whole commands or prompt templates. Per-host library.
 
-Distinct from key bar entries: chips send literal text strings; key bar sends key codes with modifier timing.
+Distinct from the terminal hotkeys panel: chips send literal text strings; the hotkeys panel sends key codes / control bytes (and `Ctrl+<key>` via the sticky modifier).
 
 ---
 
@@ -160,13 +181,16 @@ Keyboard up:
 ┌────────────────────────────┐
 │   terminal output          │
 ├────────────────────────────┤
-│ [Esc][Tab][Ctrl]...        │  key bar (~40dp)
+│                  [⌨ hotkeys]│  compact launcher above the IME
 ├────────────────────────────┤
 │  q w e r t y u i o p       │
 │   a s d f g h j k l        │  system keyboard
 │    z x c v b n m  ⌫        │
 └────────────────────────────┘
 ```
+
+(Tapping `⌨ hotkeys` opens the terminal hotkeys panel bottom-sheet described
+above.)
 
 Keyboard down:
 
@@ -186,7 +210,7 @@ Keyboard down:
 
 Single "Input methods" settings screen with sub-pages:
 - Voice: transcription provider, Whisper API key, language, auto-stop silence threshold for Whisper (30s default, 2s-60s range)
-- Key bar: which keys appear, ordering
+- Terminal hotkeys panel: which keys appear, ordering
 - Snippets: organize, share, per-host
 
 ---

--- a/shared/ui-kit/src/main/java/com/pocketshell/uikit/components/TerminalHotkeysPanel.kt
+++ b/shared/ui-kit/src/main/java/com/pocketshell/uikit/components/TerminalHotkeysPanel.kt
@@ -11,7 +11,9 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -33,6 +35,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.pocketshell.uikit.model.KeyBinding
 import com.pocketshell.uikit.model.KeyKind
+import com.pocketshell.uikit.model.KeyModifierState
 import com.pocketshell.uikit.theme.JetBrainsMonoFamily
 import com.pocketshell.uikit.theme.PocketShellColors
 
@@ -87,6 +90,16 @@ val HotkeyLabelTruncatedKey: SemanticsPropertyKey<Boolean> =
     SemanticsPropertyKey("HotkeyLabelTruncated")
 var SemanticsPropertyReceiver.hotkeyLabelTruncated: Boolean by HotkeyLabelTruncatedKey
 
+/**
+ * Issue #1091: test-readable flag, `true` on a `KeyKind.Modifier` slot that is
+ * currently armed (one-shot OR locked) — i.e. rendering the active accent
+ * treatment. A connected test reads it off the `Ctrl` key node to assert the
+ * sticky modifier's active state is visible. Render-only; no behaviour.
+ */
+val HotkeyModifierActiveKey: SemanticsPropertyKey<Boolean> =
+    SemanticsPropertyKey("HotkeyModifierActive")
+var SemanticsPropertyReceiver.hotkeyModifierActive: Boolean by HotkeyModifierActiveKey
+
 @Composable
 fun TerminalHotkeysPanel(
     sections: List<HotkeySection>,
@@ -94,11 +107,21 @@ fun TerminalHotkeysPanel(
     onClose: () -> Unit,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
+    // Issue #1091: the sticky `Ctrl` modifier state. A `KeyKind.Modifier` slot
+    // renders the active (accent) treatment when this is not `Off`, mirroring
+    // the [KeyBar] modifier visual. The single shared state is enough because
+    // the panel has exactly one modifier (`Ctrl`).
+    modifierState: KeyModifierState = KeyModifierState.Off,
 ) {
     Column(
         modifier = modifier
             .fillMaxWidth()
             .background(PocketShellColors.Surface)
+            // Issue #1091: the key set grew (filled CTRL COMBOS + the a–z
+            // LETTERS grid for the sticky Ctrl), so scroll the panel body — on a
+            // short device the modal sheet would otherwise clip the lower
+            // sections (ARROWS / LETTERS) and leave keys unreachable.
+            .verticalScroll(rememberScrollState())
             .padding(horizontal = 18.dp)
             .padding(bottom = 8.dp)
             .semantics { contentDescription = "Terminal hotkeys" },
@@ -117,6 +140,7 @@ fun TerminalHotkeysPanel(
                 section = section,
                 onKey = onKey,
                 enabled = enabled,
+                modifierState = modifierState,
             )
         }
     }
@@ -127,6 +151,7 @@ private fun HotkeySectionGrid(
     section: HotkeySection,
     onKey: (KeyBinding) -> Unit,
     enabled: Boolean,
+    modifierState: KeyModifierState,
 ) {
     Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
         Text(
@@ -145,6 +170,10 @@ private fun HotkeySectionGrid(
                     HotkeySlot(
                         binding = binding,
                         enabled = enabled,
+                        // Issue #1091: a modifier slot (the sticky `Ctrl`)
+                        // renders active when armed; non-modifier keys never do.
+                        isActive = binding.kind == KeyKind.Modifier &&
+                            modifierState != KeyModifierState.Off,
                         onTap = { onKey(binding) },
                         modifier = Modifier.weight(1f),
                     )
@@ -164,14 +193,24 @@ private fun HotkeySectionGrid(
 private fun HotkeySlot(
     binding: KeyBinding,
     enabled: Boolean,
+    isActive: Boolean,
     onTap: () -> Unit,
     modifier: Modifier,
 ) {
+    // Issue #1091: an armed sticky modifier (`Ctrl`) renders the accent
+    // treatment — accent foreground, accent-soft fill, accent-dim border —
+    // exactly like the [KeyBar] active modifier, so the active state is
+    // visible.
     val textColor: Color = when {
         !enabled -> PocketShellColors.TextMuted
+        isActive -> PocketShellColors.Accent
         binding.kind == KeyKind.Arrow -> PocketShellColors.TextSecondary
         else -> PocketShellColors.Text
     }
+    val backgroundColor: Color =
+        if (isActive) PocketShellColors.AccentSoft else PocketShellColors.SurfaceElev
+    val borderColor: Color =
+        if (isActive) PocketShellColors.AccentDim else PocketShellColors.Border
     // Tracks whether this key's label was truncated (glyph clipped) at the slot's
     // measured width — exposed via [hotkeyLabelTruncated] for the #755 regression
     // guard. Render-only.
@@ -179,17 +218,23 @@ private fun HotkeySlot(
     Box(
         modifier = modifier
             .height(44.dp)
-            .background(PocketShellColors.SurfaceElev, RoundedCornerShape(8.dp))
+            .background(backgroundColor, RoundedCornerShape(8.dp))
             .border(
-                border = BorderStroke(1.dp, PocketShellColors.Border),
+                border = BorderStroke(1.dp, borderColor),
                 shape = RoundedCornerShape(8.dp),
             )
             .let { if (enabled) it.clickable(role = Role.Button, onClick = onTap) else it }
             // Merge the label Text into this clickable node so a test can match
             // a key by "label text + click action" (disambiguating the panel key
             // from identically-labelled terminal content). Also publish the
-            // truncation flag so the #755 guard can read it off this node.
-            .semantics(mergeDescendants = true) { hotkeyLabelTruncated = labelTruncated }
+            // truncation flag so the #755 guard can read it off this node, and
+            // the modifier-active flag (#1091) for the sticky-Ctrl accent guard.
+            .semantics(mergeDescendants = true) {
+                hotkeyLabelTruncated = labelTruncated
+                if (binding.kind == KeyKind.Modifier) {
+                    hotkeyModifierActive = isActive
+                }
+            }
             .padding(horizontal = 4.dp),
         contentAlignment = Alignment.Center,
     ) {

--- a/shared/ui-kit/src/test/java/com/pocketshell/uikit/components/TerminalHotkeysPanelCtrlModifierTest.kt
+++ b/shared/ui-kit/src/test/java/com/pocketshell/uikit/components/TerminalHotkeysPanelCtrlModifierTest.kt
@@ -1,0 +1,106 @@
+package com.pocketshell.uikit.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.pocketshell.uikit.model.KeyBinding
+import com.pocketshell.uikit.model.KeyKind
+import com.pocketshell.uikit.model.KeyModifierState
+import com.pocketshell.uikit.theme.PocketShellTheme
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * Issue #1091: the sticky `Ctrl` modifier's ACTIVE (accent) state must be
+ * visible in the terminal-hotkeys panel, and the modifier + letter keys must
+ * fire `onKey`. This JVM Robolectric Compose test (Unit job, no emulator)
+ * covers the "active state is visible" acceptance criterion via the
+ * [hotkeyModifierActive] semantics flag the panel publishes only on the active
+ * modifier slot, plus that the panel emits the taps the screen needs to arm /
+ * compose the modifier.
+ */
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(qualifiers = "w412dp-h915dp-night-xxhdpi")
+class TerminalHotkeysPanelCtrlModifierTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    private val sections = listOf(
+        HotkeySection(
+            title = "CTRL + LETTER",
+            keys = listOf(KeyBinding("Ctrl", KeyKind.Modifier)),
+            columns = 4,
+        ),
+        HotkeySection(
+            title = "LETTERS",
+            keys = ('a'..'z').map { KeyBinding(it.toString(), KeyKind.Regular) },
+            columns = 7,
+        ),
+    )
+
+    private fun activeModifierNodes() =
+        composeRule.onAllNodes(
+            SemanticsMatcher.expectValue(HotkeyModifierActiveKey, true),
+        )
+
+    private fun setPanel(state: KeyModifierState, onKey: (KeyBinding) -> Unit = {}) {
+        composeRule.setContent {
+            PocketShellTheme {
+                Box {
+                    TerminalHotkeysPanel(
+                        sections = sections,
+                        onKey = onKey,
+                        onClose = {},
+                        modifierState = state,
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun ctrlSlotIsInactiveWhenModifierOff() {
+        setPanel(KeyModifierState.Off)
+        // No slot publishes an ACTIVE modifier: the Ctrl key reads `false`,
+        // letters never publish the flag at all.
+        activeModifierNodes().assertCountEquals(0)
+    }
+
+    @Test
+    fun ctrlSlotIsActiveAccentWhenOneShotArmed() {
+        setPanel(KeyModifierState.OneShot)
+        activeModifierNodes().assertCountEquals(1)
+    }
+
+    @Test
+    fun ctrlSlotIsActiveAccentWhenLocked() {
+        setPanel(KeyModifierState.Locked)
+        activeModifierNodes().assertCountEquals(1)
+    }
+
+    @Test
+    fun ctrlAndLetterKeysEmitTaps() {
+        val taps = mutableListOf<String>()
+        setPanel(KeyModifierState.Off) { taps += it.label }
+
+        composeRule.onNodeWithText("Ctrl").performClick()
+        composeRule.onNodeWithText("x").performClick()
+
+        assertEquals(
+            "tapping Ctrl then a letter must emit both labels so the screen can " +
+                "arm and compose the sticky modifier",
+            listOf("Ctrl", "x"),
+            taps,
+        )
+    }
+}

--- a/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenders.kt
+++ b/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenders.kt
@@ -126,71 +126,97 @@ class DesignRenders {
      * Issue #784: the dedicated terminal-hotkeys PANEL — its own bottom-sheet
      * surface (NOT inside the composer, NOT part of the soft keyboard). Shows
      * EVERY key at once in a tidy multi-row grid: no `…` overflow, no horizontal
-     * scroll, no lone `Ctrl` modifier, no duplicate `/`. `^B` (tmux prefix) is
-     * restored and every `^X` label is the byte it sends. Arrows use clean
-     * `← ↑ ↓ →` glyphs. This is the fast JVM-level visual check that the whole
-     * grid lays out cleanly; the emulator panel + keyboard-up composer
-     * screenshots are the acceptance.
+     * scroll, no duplicate `/`. `^B` (tmux prefix) is restored and every `^X`
+     * label is the byte it sends. Arrows use clean `← ↑ ↓ →` glyphs. Issue #1091
+     * adds the filled nano control keys, the sticky `Ctrl` MODIFIER (rendered
+     * ARMED here so its accent treatment is visually checked), and the a–z
+     * LETTERS grid for `Ctrl+<any letter>`. This is the fast JVM-level visual
+     * check that the whole grid lays out cleanly; the emulator panel +
+     * keyboard-up composer screenshots are the acceptance.
      */
     @Test
     fun terminalHotkeysPanel() = render("terminal-hotkeys-panel") {
         Surface(color = PocketShellColors.Surface) {
             com.pocketshell.uikit.components.TerminalHotkeysPanel(
-                sections = listOf(
-                    com.pocketshell.uikit.components.HotkeySection(
-                        title = "KEYS",
-                        keys = listOf(
-                            KeyBinding("Esc", KeyKind.Regular),
-                            KeyBinding("Tab", KeyKind.Regular),
-                            // Issue #893: ⇧Tab (back-tab / Shift+Tab) — cycles
-                            // Claude Code plan/permission mode. 4 columns keep
-                            // every label readable (Esc / Tab / ⇧Tab / Enter).
-                            KeyBinding("⇧Tab", KeyKind.Regular),
-                            KeyBinding("Enter", KeyKind.Regular),
-                        ),
-                        columns = 4,
-                    ),
-                    com.pocketshell.uikit.components.HotkeySection(
-                        title = "CTRL COMBOS",
-                        keys = listOf(
-                            KeyBinding("^A", KeyKind.Regular),
-                            KeyBinding("^B", KeyKind.Regular),
-                            KeyBinding("^C", KeyKind.Regular),
-                            KeyBinding("^D", KeyKind.Regular),
-                            KeyBinding("^E", KeyKind.Regular),
-                            KeyBinding("^L", KeyKind.Regular),
-                            KeyBinding("^R", KeyKind.Regular),
-                            KeyBinding("^Z", KeyKind.Regular),
-                        ),
-                        columns = 4,
-                    ),
-                    // Issue #787: the doubled interrupt/EOF chords re-homed from
-                    // the deleted `/ commands` palette (distinct from single
-                    // `^C`/`^D` — these send the byte twice).
-                    com.pocketshell.uikit.components.HotkeySection(
-                        title = "INTERRUPT / EOF",
-                        keys = listOf(
-                            KeyBinding("^C×2", KeyKind.Regular),
-                            KeyBinding("^D×2", KeyKind.Regular),
-                        ),
-                        columns = 2,
-                    ),
-                    com.pocketshell.uikit.components.HotkeySection(
-                        title = "ARROWS",
-                        keys = listOf(
-                            KeyBinding("←", KeyKind.Arrow),
-                            KeyBinding("↑", KeyKind.Arrow),
-                            KeyBinding("↓", KeyKind.Arrow),
-                            KeyBinding("→", KeyKind.Arrow),
-                        ),
-                        columns = 4,
-                    ),
-                ),
+                sections = sampleHotkeySections(),
                 onKey = {},
                 onClose = {},
+                // Issue #1091: render the sticky `Ctrl` modifier ARMED so the
+                // accent treatment on the `Ctrl` key is visually checked.
+                modifierState = com.pocketshell.uikit.model.KeyModifierState.OneShot,
             )
         }
     }
+
+    /**
+     * Issue #1091: the post-#1091 hotkeys panel — `CTRL COMBOS` filled with the
+     * nano keys (`^G`/`^J`/`^K`/`^O`/`^T`/`^U`/`^W`/`^X`/`^\`), the sticky
+     * `Ctrl` modifier, and the a–z LETTERS grid for `Ctrl+<any letter>`.
+     */
+    private fun sampleHotkeySections(): List<com.pocketshell.uikit.components.HotkeySection> =
+        listOf(
+            com.pocketshell.uikit.components.HotkeySection(
+                title = "KEYS",
+                keys = listOf(
+                    KeyBinding("Esc", KeyKind.Regular),
+                    KeyBinding("Tab", KeyKind.Regular),
+                    KeyBinding("⇧Tab", KeyKind.Regular),
+                    KeyBinding("Enter", KeyKind.Regular),
+                ),
+                columns = 4,
+            ),
+            com.pocketshell.uikit.components.HotkeySection(
+                title = "CTRL COMBOS",
+                keys = listOf(
+                    KeyBinding("^A", KeyKind.Regular),
+                    KeyBinding("^B", KeyKind.Regular),
+                    KeyBinding("^C", KeyKind.Regular),
+                    KeyBinding("^D", KeyKind.Regular),
+                    KeyBinding("^E", KeyKind.Regular),
+                    KeyBinding("^G", KeyKind.Regular),
+                    KeyBinding("^J", KeyKind.Regular),
+                    KeyBinding("^K", KeyKind.Regular),
+                    KeyBinding("^L", KeyKind.Regular),
+                    KeyBinding("^O", KeyKind.Regular),
+                    KeyBinding("^R", KeyKind.Regular),
+                    KeyBinding("^T", KeyKind.Regular),
+                    KeyBinding("^U", KeyKind.Regular),
+                    KeyBinding("^W", KeyKind.Regular),
+                    KeyBinding("^X", KeyKind.Regular),
+                    KeyBinding("^Z", KeyKind.Regular),
+                    KeyBinding("^\\", KeyKind.Regular),
+                ),
+                columns = 4,
+            ),
+            com.pocketshell.uikit.components.HotkeySection(
+                title = "INTERRUPT / EOF",
+                keys = listOf(
+                    KeyBinding("^C×2", KeyKind.Regular),
+                    KeyBinding("^D×2", KeyKind.Regular),
+                ),
+                columns = 2,
+            ),
+            com.pocketshell.uikit.components.HotkeySection(
+                title = "CTRL + LETTER",
+                keys = listOf(KeyBinding("Ctrl", KeyKind.Modifier)),
+                columns = 4,
+            ),
+            com.pocketshell.uikit.components.HotkeySection(
+                title = "LETTERS",
+                keys = ('a'..'z').map { KeyBinding(it.toString(), KeyKind.Regular) },
+                columns = 7,
+            ),
+            com.pocketshell.uikit.components.HotkeySection(
+                title = "ARROWS",
+                keys = listOf(
+                    KeyBinding("←", KeyKind.Arrow),
+                    KeyBinding("↑", KeyKind.Arrow),
+                    KeyBinding("↓", KeyKind.Arrow),
+                    KeyBinding("→", KeyKind.Arrow),
+                ),
+                columns = 4,
+            ),
+        )
 
     /** Host-list header (`ScreenHeader`) with a trailing status pill. */
     @Test

--- a/tests/docker/Dockerfile.agents
+++ b/tests/docker/Dockerfile.agents
@@ -5,7 +5,11 @@
 # credentials. Use it for local emulator + Docker smoke tests only.
 FROM alpine:latest
 
-RUN apk add --no-cache openssh-server openssh-client tmux procps bash sqlite git \
+# Issue #1091: `nano` is the maintainer's real dogfood TUI (he was trapped in
+# GNU nano, unable to save/exit from PocketShell). The connected nano save/exit
+# journey (`TmuxKeyBarCtrlComboE2eTest`) opens a real nano buffer and drives
+# `^O`/`^X` from the hotkeys panel, so the fixture must ship a real `nano`.
+RUN apk add --no-cache openssh-server openssh-client tmux procps bash sqlite git nano \
     && ssh-keygen -A \
     && adduser -D -s /bin/sh testuser \
     && passwd -u testuser \


### PR DESCRIPTION
Closes #1091. Reviewer APPROVED (3 rounds). Sticky `Ctrl` modifier (tap Ctrl → next key as its control byte) + a–z grid + filled CTRL COMBOS (`^G ^J ^K ^O ^T ^U ^W ^X ^\`). 

On-device proven: connected `TmuxKeyBarCtrlComboE2eTest` drives real GNU nano — panel `^O`+Enter → `[ Wrote 1 line ]`, panel `^X` → back at shell, file persisted (`cat` re-read). `nano` added to `Dockerfile.agents`; CI rebuilds the fixture (`tests.yml:606 --build`). Unit `TmuxSessionViewModelTest` 361/0; stale connected/JVM `Ctrl` guards reconciled; `docs/input-methods.md` hard-cut to match.