### PR TITLE
terminal: bound on-main inline seed drain by bytes, not just wall time (#866)

### DIFF
--- a/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/bridge/SshTerminalBridge.kt
+++ b/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/bridge/SshTerminalBridge.kt
@@ -334,6 +334,11 @@ public class SshTerminalBridge(
         val feedStartedAtNanos = System.nanoTime()
         val seedDrainStartedAtMillis = nowMillis()
         var chunks = 0
+        // #866 fast-device fix: bytes drained INLINE so far across this whole
+        // on-main feed. Feeds the byte budget ([SEED_INLINE_MAX_BYTES]) checked in
+        // [dispatchMainLooperDrains] so the inline parse stops after a bounded
+        // number of bytes regardless of how fast the device parses a slice.
+        var inlineDrainedBytes = 0
         synchronized(feedLock) {
             // Re-entrant on-looper feed while a seed tail is already being pumped:
             // append to the FIFO so ordering (seed tail -> this feed) is preserved,
@@ -382,11 +387,18 @@ public class SshTerminalBridge(
                 }
 
                 // On-main seed/reattach feed: drain inline (snapshot before live),
-                // bounded across the WHOLE feed by SEED_DRAIN_MAX_MILLIS (#866).
+                // bounded across the WHOLE feed by BOTH a wall-time budget
+                // (SEED_DRAIN_MAX_MILLIS, #866) AND a byte budget
+                // (SEED_INLINE_MAX_BYTES, the fast-device fix): on a fast/warm
+                // device the time budget alone lets the bulk of a multi-chunk seed
+                // parse inline within 24 ms (the regression that brought #866 back),
+                // so the byte budget caps the inline parse regardless of per-slice
+                // speed and the rest is always deferred to the frame-yielding pump.
                 val budgetExhausted = dispatchMainLooperDrains(
                     handler = handler,
                     queuedBytes = chunkLength,
                     startedAtMillis = seedDrainStartedAtMillis,
+                    feedDrainedBytesBefore = inlineDrainedBytes,
                     traceState = traceState,
                 )
                 if (budgetExhausted) {
@@ -419,6 +431,10 @@ public class SshTerminalBridge(
                     )
                     return
                 }
+                // The whole chunk drained inline within both budgets; accrue it so a
+                // later chunk's drain sees the running inline byte total (the byte
+                // budget is feed-scoped, like the wall-time budget).
+                inlineDrainedBytes += chunkLength
             }
         }
         traceState?.traceSink?.onFeedCompleted(
@@ -578,17 +594,22 @@ public class SshTerminalBridge(
      * one-shot before live bytes flow), so it deliberately drains inline so the
      * `capture-pane` snapshot paints before the live stream starts.
      *
-     * Issue #829/#866: the seed drain is TIME-BOUNDED for symmetry with the live
-     * [MainThreadDrainScheduler] turn budget. The budget is measured from
-     * [startedAtMillis] (the start of the WHOLE on-main feed, shared across its
-     * chunks), so a pathologically large seed cannot pin the main thread in one
-     * unbounded inline run. After at least one slice (forward progress), if the
-     * feed has spent more than [SEED_DRAIN_MAX_MILLIS] of main-thread wall time
-     * this stops early and returns `true`; the caller ([feedChunks]) then hands
-     * the remainder — the already-queued tail of THIS chunk plus the untouched
-     * later chunks — to the frame-budgeted path, which paces the rest across
-     * frames. The granularity floor is one slice, so the worst-case inline cost is
-     * [SEED_DRAIN_MAX_MILLIS] plus one 2 KB slice's parse.
+     * Issue #829/#866: the seed drain is DUAL-BOUNDED — by wall time AND by bytes,
+     * both feed-scoped — for symmetry with the live [MainThreadDrainScheduler] turn
+     * budget. The wall-time budget is measured from [startedAtMillis] (the start of
+     * the WHOLE on-main feed, shared across its chunks); the byte budget is measured
+     * from [feedDrainedBytesBefore] (the inline bytes already drained in earlier
+     * chunks of this feed) plus what this call drains. After at least one slice
+     * (forward progress), if the feed has spent more than [SEED_DRAIN_MAX_MILLIS] of
+     * main-thread wall time OR drained more than [SEED_INLINE_MAX_BYTES] inline, this
+     * stops early and returns `true`; the caller ([feedChunks]) then hands the
+     * remainder — the already-queued tail of THIS chunk plus the untouched later
+     * chunks — to the frame-budgeted path, which paces the rest across frames. The
+     * byte budget is the load-bearing guard on a FAST/warm device, where 24 ms of
+     * inline parsing would otherwise let the bulk of a multi-chunk seed through
+     * inline before the time budget could trip (the regression that reopened #866).
+     * The granularity floor is one slice, so the worst-case inline cost is bounded
+     * by whichever budget trips plus one 2 KB slice's parse.
      *
      * Deadlock-safety (#866): the budget is now honored for ANY chunk, not only
      * the final one. The pre-#866 code drained every non-final chunk FULLY inline
@@ -600,17 +621,21 @@ public class SshTerminalBridge(
      * looper, and yields a frame between turns) — so there is no full-queue
      * deadlock and no unbounded inline parse.
      *
-     * @return `true` if the on-main feed has spent its [SEED_DRAIN_MAX_MILLIS]
-     *   budget (the caller hands the remaining tail to the frame-yielding pump);
-     *   `false` if this chunk fully drained within budget.
+     * @param feedDrainedBytesBefore inline bytes already drained in earlier chunks
+     *   of this same on-main feed, so the byte budget is feed-scoped (not per-chunk).
+     * @return `true` if the on-main feed has spent its [SEED_DRAIN_MAX_MILLIS] OR
+     *   [SEED_INLINE_MAX_BYTES] budget (the caller hands the remaining tail to the
+     *   frame-yielding pump); `false` if this chunk fully drained within both budgets.
      */
     private inline fun dispatchMainLooperDrains(
         handler: Handler,
         queuedBytes: Int,
         startedAtMillis: Long,
+        feedDrainedBytesBefore: Int,
         traceState: TraceState?,
     ): Boolean {
         var remaining = queuedBytes
+        var drainedThisCall = 0
         while (remaining > 0) {
             val drainBudget = minOf(remaining, PROCESS_TO_TERMINAL_DRAIN_SLICE_BYTES)
             val dispatchStartedAtNanos = System.nanoTime()
@@ -620,11 +645,18 @@ public class SshTerminalBridge(
                 durationNanos = System.nanoTime() - dispatchStartedAtNanos,
             )
             remaining -= drainBudget
-            // Time budget (#829/#866): checked AFTER at least one slice so the seed
-            // always makes forward progress. Stop inline draining once the on-main
-            // feed has exceeded its wall-time budget, on ANY chunk; the caller hands
-            // the remaining tail to the frame-yielding pump (see deadlock-safety).
-            if (nowMillis() - startedAtMillis >= SEED_DRAIN_MAX_MILLIS) {
+            drainedThisCall += drainBudget
+            // Dual budget (#829/#866 + fast-device fix): checked AFTER at least one
+            // slice so the seed always makes forward progress. Stop inline draining
+            // on ANY chunk once the on-main feed has spent EITHER its wall-time
+            // budget (SEED_DRAIN_MAX_MILLIS) OR its byte budget (SEED_INLINE_MAX_BYTES,
+            // feed-scoped). The byte budget is what makes the bound robust on a fast/
+            // warm device, where 24 ms of inline parsing would otherwise let the bulk
+            // of a multi-chunk seed through inline (the regression that reopened #866).
+            // The caller hands the remaining tail to the frame-yielding pump.
+            if (nowMillis() - startedAtMillis >= SEED_DRAIN_MAX_MILLIS ||
+                feedDrainedBytesBefore + drainedThisCall >= SEED_INLINE_MAX_BYTES
+            ) {
                 return true
             }
         }
@@ -896,6 +928,29 @@ public class SshTerminalBridge(
          * only bounds the pathological case.
          */
         internal const val SEED_DRAIN_MAX_MILLIS: Long = 24L
+
+        /**
+         * Issue #866 (fast-device fix): byte budget for the on-main, synchronous
+         * seed drain ([dispatchMainLooperDrains]), enforced ACROSS the whole feed
+         * alongside the [SEED_DRAIN_MAX_MILLIS] wall-time budget.
+         *
+         * The original #866 fix bounded the inline seed drain by wall time only. On
+         * a SLOW device (the maintainer's phone) 24 ms parses only ~one slice inline
+         * and the multi-chunk tail is deferred — no ANR. But on a FAST/warm device
+         * (a hot-JIT emulator, or a flagship phone after warm-up) 24 ms parses the
+         * BULK of a multi-chunk seed inline before the time budget can trip, so the
+         * tail is NOT deferred — the #866 "Attaching…" ANR returns under load. (This
+         * is exactly how the on-device proof regressed: green cold/isolated, RED warm
+         * at test 9/45.) A pure time budget cannot bound inline WORK on a fast CPU;
+         * only a byte budget can. Capping the inline drain to one quarter of a queue
+         * chunk keeps the inline parse small (well under the on-device proof's
+         * full/4 deferral threshold) regardless of per-slice speed; the rest always
+         * goes to the frame-yielding [runSeedTailPumpTurn] pump. Set ABOVE the JVM
+         * budget tests' time-trip slice count (6 * 2 KB = 12 KB) so those tests
+         * still trip on time (their injected clock), and the byte budget is the
+         * real-wall-clock guard.
+         */
+        internal const val SEED_INLINE_MAX_BYTES: Int = PROCESS_TO_TERMINAL_QUEUE_CAPACITY_BYTES / 4
 
         private const val TRACE_WAIT_THRESHOLD_NANOS: Long = 1_000_000
     }

--- a/shared/core-terminal/src/test/java/com/pocketshell/core/terminal/bridge/SshTerminalBridgeTest.kt
+++ b/shared/core-terminal/src/test/java/com/pocketshell/core/terminal/bridge/SshTerminalBridgeTest.kt
@@ -81,7 +81,7 @@ class SshTerminalBridgeTest {
     }
 
     @Test(timeout = 5_000)
-    fun feedBytesOnMainLooperDrainsLargePayloadWithoutWaitingForPostedMessage() {
+    fun feedBytesOnMainLooperDrainsLargePayloadWithoutDeadlockOrLoss() {
         assertEquals(Looper.getMainLooper(), Looper.myLooper())
         val trace = RecordingTraceSink()
         val bridge = SshTerminalBridge(
@@ -97,15 +97,47 @@ class SshTerminalBridgeTest {
                 SshTerminalBridge.PROCESS_TO_TERMINAL_QUEUE_CAPACITY_BYTES +
                 SshTerminalBridge.PROCESS_TO_TERMINAL_DRAIN_SLICE_BYTES,
         )
+        // The payload must exceed the inline BYTE budget so the on-main feed cannot
+        // drain it all inline — it must defer the tail to the pump (#866 fast-device).
+        assertTrue(
+            "regression payload must exceed the inline byte budget so the tail defers",
+            payload.bytes.size > SshTerminalBridge.SEED_INLINE_MAX_BYTES,
+        )
 
         bridge.feedBytes(payload.bytes)
+
+        // #866 fast-device fix: a large on-main feed no longer drains the WHOLE
+        // payload inline (that synchronous parse is the "Attaching…" ANR on a
+        // multi-chunk seed). The inline drain is bounded by SEED_INLINE_MAX_BYTES;
+        // the untouched tail is handed to the frame-yielding pump. The producer must
+        // NOT deadlock waiting on a posted message it can't run, and the WHOLE
+        // payload must still render losslessly once the looper advances.
+        val expectedInline =
+            (
+                SshTerminalBridge.SEED_INLINE_MAX_BYTES +
+                    SshTerminalBridge.PROCESS_TO_TERMINAL_DRAIN_SLICE_BYTES - 1
+                ) / SshTerminalBridge.PROCESS_TO_TERMINAL_DRAIN_SLICE_BYTES
+        val inlineSlices = trace.directDrains.size
+        assertEquals(
+            "the on-main inline drain must stop at the byte budget, not run all slices " +
+                "inline (the #866 fast-device ANR); trace=$trace",
+            expectedInline,
+            inlineSlices,
+        )
+        assertTrue(
+            "the bounded inline drain must leave the bulk for the pump; inline=$inlineSlices " +
+                "total=${expectedDrainSlices(payload.bytes.size)}",
+            inlineSlices < expectedDrainSlices(payload.bytes.size),
+        )
+
+        // Advance the looper so the pump + frame-budgeted scheduler drain the tail.
+        drainMainLooperUntil { trace.outputDrainSnapshot().sum() >= payload.bytes.size }
         shadowOf(Looper.getMainLooper()).idle()
 
         assertEquals(payload.transcriptText, bridge.emulator.screen.transcriptText)
-        assertEquals(expectedChunks(payload.bytes.size), trace.queueWrites.size)
-        assertEquals(expectedDrainSlices(payload.bytes.size), trace.directDrains.size)
+        assertEquals(payload.bytes.size, trace.outputDrainSnapshot().sum())
         assertTrue(
-            "direct main-looper drains should stay within the bounded drain budget",
+            "every drain (inline + pump) must stay within the bounded drain slice",
             trace.directDrains.all {
                 it.bytes in 1..SshTerminalBridge.PROCESS_TO_TERMINAL_DRAIN_SLICE_BYTES
             },
@@ -246,6 +278,79 @@ class SshTerminalBridgeTest {
         // frame-yielding pump once the looper advances — the FULL payload must render
         // with no lost bytes and no deadlock (the test's 10s timeout guards the
         // would-be full-queue deadlock if the tail were written inline).
+        drainMainLooperUntil { trace.outputDrainSnapshot().sum() >= payload.bytes.size }
+        assertEquals(payload.bytes.size, trace.outputDrainSnapshot().sum())
+        assertEquals(payload.transcriptText, bridge.emulator.screen.transcriptText)
+    }
+
+    /**
+     * Issue #866 REOPEN (fast-device fix): on a FAST/warm device the wall-time
+     * budget alone does NOT bound the inline seed drain — the regression that
+     * brought #866 back. A pure time budget caps WALL TIME, not WORK: when each
+     * 2 KB slice parses in well under [SshTerminalBridge.SEED_DRAIN_MAX_MILLIS] /
+     * sliceCount, 24 ms of inline parsing chews through the BULK of a multi-chunk
+     * seed before the time budget can trip, so the tail is NOT deferred and the
+     * "Attaching…" ANR returns under load (the on-device proof was green cold/
+     * isolated but RED warm at test 9/45, where hot-JIT slices parse fast).
+     *
+     * This reproduces that deterministically by holding the clock STABLE
+     * (`nowMillis = { 0L }`), so the wall-time budget can NEVER trip — exactly the
+     * limit of an infinitely-fast device. RED on the time-budget-only code: the
+     * inline drain runs EVERY slice of the whole multi-chunk feed inline
+     * (`directDrains == totalSlices`, the ANR). GREEN with the byte budget: the
+     * inline drain stops after [SshTerminalBridge.SEED_INLINE_MAX_BYTES] and hands
+     * the untouched tail to the frame-yielding pump — bounded inline parse, no
+     * lost bytes, no deadlock (the 10s timeout guards the would-be full-queue
+     * deadlock if the tail were written inline).
+     */
+    @Test(timeout = 10_000)
+    fun onMainMultiChunkSeedBoundsInlineDrainByBytesWhenTheClockNeverAdvances() {
+        assertEquals(Looper.getMainLooper(), Looper.myLooper())
+        val trace = RecordingTraceSink()
+        // Stable clock: elapsed wall time is ALWAYS 0, so SEED_DRAIN_MAX_MILLIS can
+        // never trip — the fast-device case the byte budget exists to bound.
+        val bridge = SshTerminalBridge(
+            columns = LINE_LENGTH,
+            rows = 24,
+            transcriptRows = MULTI_CHUNK_SEED_LINES + 100,
+            traceSink = trace,
+            nowMillis = { 0L },
+        )
+        val payload = multiChunkDenseSgrSeedPayload()
+        val totalChunks = expectedChunks(payload.bytes.size)
+        val totalSlices = expectedDrainSlices(payload.bytes.size)
+        assertTrue(
+            "fixture must span MULTIPLE process-to-terminal queue chunks (the #866 ANR shape)",
+            totalChunks >= 3,
+        )
+
+        bridge.feedBytes(payload.bytes)
+
+        // Load-bearing assertion: with the clock frozen the ONLY thing that can stop
+        // the inline drain is the byte budget. The inline drain must stop after
+        // ceil(SEED_INLINE_MAX_BYTES / slice) slices — NOT run every slice inline
+        // (the time-budget-only code drained all totalSlices here → the ANR).
+        val inlineSlices = trace.directDrains.size
+        val expectedInline =
+            (
+                SshTerminalBridge.SEED_INLINE_MAX_BYTES +
+                    SshTerminalBridge.PROCESS_TO_TERMINAL_DRAIN_SLICE_BYTES - 1
+                ) / SshTerminalBridge.PROCESS_TO_TERMINAL_DRAIN_SLICE_BYTES
+        assertEquals(
+            "frozen-clock multi-chunk seed must stop inline draining at the BYTE budget " +
+                "(time-budget-only code drained all $totalSlices slices inline → the #866 " +
+                "fast-device ANR); trace=$trace",
+            expectedInline,
+            inlineSlices,
+        )
+        assertTrue(
+            "the byte-bounded inline drain must leave the bulk of the seed for the pump; " +
+                "inline=$inlineSlices total=$totalSlices",
+            inlineSlices < totalSlices,
+        )
+
+        // The handed-off tail drains via the frame-yielding pump once the looper
+        // advances — the FULL payload must render losslessly and without deadlock.
         drainMainLooperUntil { trace.outputDrainSnapshot().sum() >= payload.bytes.size }
         assertEquals(payload.bytes.size, trace.outputDrainSnapshot().sum())
         assertEquals(payload.transcriptText, bridge.emulator.screen.transcriptText)


### PR DESCRIPTION
## Summary

Reopen of **#866** ("ANR: app freezes on 'Attaching…' when opening a Codex session"). The proof test `CodexMultiChunkSeedAttachMainThreadProofTest` regressed to RED on `main` and blocked the v0.4.19 release-emulator-validation gate (two runs auto-cancelled at the 3h ceiling after the ANR'd connected suite wedged).

## Root cause

The original #866 fix bounded the inline seed drain by **wall-time only** (`SEED_DRAIN_MAX_MILLIS=24ms`). A time budget caps wall time, not *work*. On a warm/JIT'd device each `dispatchMessage` parse slice runs ~30× faster, so ~33 slices (~66KB) fit inside the 24ms window instead of ~1 — the bulk of a multi-chunk Codex seed parses inline on the main thread again → the attach ANR. That is exactly why the proof was green cold/isolated but **RED warm at 9/45** in the release gate.

## Fix

Feed-scoped **byte budget** (`SEED_INLINE_MAX_BYTES = 64KB/4 = 16KB`) checked alongside the time budget at the single `feedChunks` chokepoint every on-main feed routes through; the tail always goes to the frame-yielding pump. Bounds work regardless of device speed. Hard-cut (D22), no fallback path.

## Evidence (reviewer-reproduced, this run)

- **On-device real connected path, warm (emulator-5554):** BASE → proof FAILS `inline_transcript_length=74350 > full/4=31473`, `deferred=false`; FIX → PASSES `inline=2895`, `deferred=true`, painted to end.
- **JVM red→green:** byte-budget disabled (= base) → 2 failures ("drained all 352 slices inline → fast-device ANR"); restored → 18/18. New frozen-clock byte-budget regression test wired into the Unit job.
- **Class coverage (G2/D31):** budget sits at the single `feedChunks` chokepoint; every on-main feed (attach seed, #721 full-repaint reseed, no-seed flush, buffered-live flush, re-entrant tail) routes through it; off-main `%output` byte-identical to base.

Implementer + reviewer (APPROVED) loop complete; durable-fix gate D31/D33 + universal gates G1–G10 satisfied.

Closes #866