### PR TITLE
ci(nightly): wire 2238/2239 fixtures, pin API-35, shard 3-way (#1099)

### DIFF
--- a/.github/workflows/nightly-extensive.yml
+++ b/.github/workflows/nightly-extensive.yml
@@ -116,10 +116,30 @@ jobs:
   # Only runs when the guard says so.
   # ---------------------------------------------------------------------------
   extensive:
-    name: Extensive emulator + Docker journey/E2E + network-fault + bootstrap
+    name: "Extensive journey/E2E + network-fault + bootstrap (shard ${{ matrix.shard }})"
     needs: guard
     if: needs.guard.outputs.should_run == 'true'
     runs-on: ubuntu-latest
+    # SHARD (issue #835 follow-up): the full connected suite is ~680 tests and
+    # could NOT finish serially on ONE swiftshader AVD inside this ceiling
+    # (a triage run reached only 544/683 at the 150-min timeout, so phases 2 & 3
+    # never ran and the release gate kept reporting phantom failures). Fan the
+    # job out across a matrix of runners — each its OWN cold-booted emulator +
+    # Docker fixtures — so each leg runs only its round-robin 1/N slice of phase
+    # 1 (the suite reads POCKETSHELL_NIGHTLY_SHARD_INDEX/_TOTAL and hands them to
+    # AndroidJUnitRunner numShards/shardIndex). Each leg now finishes well inside
+    # the 150-min cap. `fail-fast: false` so one shard's failure does not cancel
+    # the others (we want every shard's verdict).
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2]
+    env:
+      # Set by the matrix; the suite partitions the phase-1 selection round-robin
+      # by (shardIndex % numShards). Keep _TOTAL in sync with matrix.shard length.
+      # Phases 2 (network-fault) & 3 (bootstrap) run ONCE, on shard 0 only.
+      POCKETSHELL_NIGHTLY_SHARD_INDEX: ${{ matrix.shard }}
+      POCKETSHELL_NIGHTLY_SHARD_TOTAL: 3
     timeout-minutes: 150
     # Long and historically flaky; keep it non-blocking so a single flaky
     # emulator boot does not poison the nightly signal. Failures still show in
@@ -171,11 +191,24 @@ jobs:
       # (2231), and bootstrap-uv-upgrade (2236, reused by the appUpdateRequired
       # scenario). HostBootstrapScenarioSuiteTest connects to these by host port
       # (10.0.2.2:2230/2231/2236), so they must be up before the emulator runs.
-      - name: Start Docker fixtures (agents, flaky-agent, tmux + toxiproxy + bootstrap)
+      #
+      # It ALSO brings up the deterministic `agents-old-cli` (2238, issue #849)
+      # and `agents-daemon` (2239, issue #839) fixtures. The phase-1 connected
+      # suite includes FolderListOldCliHydrateDockerTest +
+      # FolderListBootstrapSkipTreeLoadsDockerTest (2238) and
+      # FolderListDurableTreeDaemonDockerTest (2239) — those tests target the
+      # fixtures by host port and FAIL hard ("SSH fixture on 10.0.2.2:223x was
+      # not ready") if the port is unforwarded, which is exactly the phantom
+      # failure this workflow used to produce by NOT starting them. They can land
+      # on ANY shard (round-robin), so every shard starts them. This mirrors how
+      # the per-push emulator-journey job (.github/workflows/tests.yml) and the
+      # release gate (scripts/pre-release-confidence-gate.sh) wire them.
+      - name: Start Docker fixtures (agents, flaky-agent, tmux + toxiproxy + bootstrap + old-cli + daemon)
         run: |
           docker compose -f tests/docker/docker-compose.yml up -d --build --no-deps \
             agents flaky-agent tmux network-fault-proxy packet-loss-proxy \
-            bootstrap-ready bootstrap-uv-install bootstrap-uv-upgrade
+            bootstrap-ready bootstrap-uv-install bootstrap-uv-upgrade \
+            agents-old-cli agents-daemon
 
       - name: Wait for fixture containers to report healthy
         run: |
@@ -193,6 +226,15 @@ jobs:
           cat /tmp/bootstrap-uv-install-health.log
           wait_for_container_healthy tests/docker/docker-compose.yml bootstrap-uv-upgrade /tmp/bootstrap-uv-upgrade-health.log 60
           cat /tmp/bootstrap-uv-upgrade-health.log
+          # Old-CLI (2238, #849) + daemon (2239, #839) fixtures: the phase-1
+          # FolderList*DockerTest journeys target these by host port and fail
+          # hard when the port is unforwarded, so wait on them before handing off
+          # to the emulator (this is the fix for the "SSH fixture on
+          # 10.0.2.2:223x was not ready after ~35 attempts" phantom failures).
+          wait_for_container_healthy tests/docker/docker-compose.yml agents-old-cli /tmp/agents-old-cli-health.log 60
+          cat /tmp/agents-old-cli-health.log
+          wait_for_container_healthy tests/docker/docker-compose.yml agents-daemon /tmp/agents-daemon-health.log 60
+          cat /tmp/agents-daemon-health.log
 
       # toxiproxy / packet-loss-proxy do not expose a Docker healthcheck, so
       # poll their listening ports directly before handing off to the emulator.
@@ -230,10 +272,54 @@ jobs:
             testuser@127.0.0.1 \
             'for tool in pocketshell agent-log-explorer tmuxctl quse; do command -v "$tool"; done'
 
+      # Confirm the 2238 fixture really IS an old CLI (rejects `tree` with a
+      # non-zero exit) while staying live (tmux works), so the regression tests
+      # exercise the real CLI-mismatch path and never pass vacuously against a
+      # fixture that silently accepted the new subcommand (mirrors tests.yml #849).
+      - name: Verify agents-old-cli is a CLI mismatch (issue #849)
+        run: |
+          chmod 600 tests/docker/test_key
+          ssh -i tests/docker/test_key -p 2238 \
+            -o BatchMode=yes \
+            -o ConnectTimeout=3 \
+            -o StrictHostKeyChecking=no \
+            -o UserKnownHostsFile=/dev/null \
+            testuser@127.0.0.1 \
+            'pocketshell tree get </dev/null; rc=$?; if [ "$rc" -eq 0 ]; then echo "old-cli fixture unexpectedly accepted tree get (rc=0)" >&2; exit 1; fi; tmux -V >/dev/null && echo "old-cli mismatch confirmed: tree get rc=$rc, host still live"'
+
+      # Confirm the 2239 fixture really IS the REAL daemon: `pocketshell tree`
+      # round-trips a persist (upsert then get over a fresh exec returns the
+      # collapsed node). A broken fixture fails the job loudly here instead of
+      # letting the durable-tree journey pass vacuously (mirrors tests.yml #839).
+      - name: Verify agents-daemon real `pocketshell tree` persists (issue #839)
+        run: |
+          chmod 600 tests/docker/test_key
+          ssh -i tests/docker/test_key -p 2239 \
+            -o BatchMode=yes \
+            -o ConnectTimeout=3 \
+            -o StrictHostKeyChecking=no \
+            -o UserKnownHostsFile=/dev/null \
+            testuser@127.0.0.1 \
+            'set -e;
+             printf "%s" "{\"host\":\"ci\",\"nodes\":[{\"session\":\"s\",\"order\":0,\"folder_path\":\"/p\",\"collapsed\":true}]}" | pocketshell tree upsert >/dev/null;
+             got="$(printf "%s" "{\"host\":\"ci\"}" | pocketshell tree get)";
+             echo "$got" | grep -q "\"session\": \"s\"" || { echo "agents-daemon tree did NOT persist: $got" >&2; exit 1; };
+             echo "$got" | grep -q "\"collapsed\": true" || { echo "agents-daemon tree dropped the collapse: $got" >&2; exit 1; };
+             echo "agents-daemon real-tree persist confirmed: $got"'
+
       - name: Run extensive connected journey/E2E + network-fault + bootstrap scenarios
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 34
+          # API 35 (Android 15): the full connected suite includes two API-35
+          # evidence tests (SessionForegroundServiceLiveHoldJourneyE2eTest +
+          # SessionConnectionServiceE2eTest) that HARD-assert
+          # Build.VERSION.SDK_INT == 35 ("API 35 evidence must run on Android
+          # 15"). Running the API-34 image made them report phantom failures
+          # ("expected:<35> but was:<34>"). No test in the suite hard-requires
+          # API 34 (the others use `>=` comparisons), so pin API 35 here to match
+          # what these tests require. (Per-push / release-gate jobs run their
+          # narrower allowlists on API 34 separately.)
+          api-level: 35
           target: google_apis
           arch: x86_64
           profile: pixel_7
@@ -255,7 +341,11 @@ jobs:
           docker compose -f tests/docker/docker-compose.yml logs --no-color bootstrap-ready > artifacts/docker/bootstrap-ready.log 2>/dev/null || true
           docker compose -f tests/docker/docker-compose.yml logs --no-color bootstrap-uv-install > artifacts/docker/bootstrap-uv-install.log 2>/dev/null || true
           docker compose -f tests/docker/docker-compose.yml logs --no-color bootstrap-uv-upgrade > artifacts/docker/bootstrap-uv-upgrade.log 2>/dev/null || true
+          docker compose -f tests/docker/docker-compose.yml logs --no-color agents-old-cli > artifacts/docker/agents-old-cli.log 2>/dev/null || true
+          docker compose -f tests/docker/docker-compose.yml logs --no-color agents-daemon > artifacts/docker/agents-daemon.log 2>/dev/null || true
           docker inspect pocketshell-test-agents > artifacts/docker/agents-inspect.json 2>/dev/null || true
+          docker inspect pocketshell-test-agents-old-cli > artifacts/docker/agents-old-cli-inspect.json 2>/dev/null || true
+          docker inspect pocketshell-test-agents-daemon > artifacts/docker/agents-daemon-inspect.json 2>/dev/null || true
 
       - name: Publish extensive suite summary
         if: always()
@@ -274,7 +364,9 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: nightly-extensive-android-test-reports
+          # Per-shard name: upload-artifact@v7 errors on a duplicate artifact
+          # name across matrix legs, so each shard uploads its own.
+          name: nightly-extensive-android-test-reports-shard-${{ matrix.shard }}
           path: |
             **/build/reports/androidTests/
             **/build/outputs/androidTest-results/
@@ -286,7 +378,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: nightly-extensive-docker-logs
+          name: nightly-extensive-docker-logs-shard-${{ matrix.shard }}
           path: artifacts/docker/
           if-no-files-found: ignore
 

--- a/scripts/nightly-extensive-suite.sh
+++ b/scripts/nightly-extensive-suite.sh
@@ -140,69 +140,131 @@ join_by() {
 NETWORK_FAULT_CLASS_ARG="$(join_by , "${NETWORK_FAULT_CLASSES[@]}")"
 JOURNEY_NOTCLASS_ARG="$(join_by , "${JOURNEY_EXCLUDED_CLASSES[@]}")"
 
+# ---------------------------------------------------------------------------
+# Sharding (issue #835 follow-up): the full connected journey/E2E suite is
+# ~680 tests. Run serially on ONE swiftshader AVD it cannot finish inside the
+# 150-min job ceiling (the #470 enumeration stall worsens the more the single
+# AVD is churned, so 544/683 at the timeout). The nightly workflow now fans
+# this job out across a matrix of runners — each its OWN cold-booted emulator +
+# Docker fixtures — and sets POCKETSHELL_NIGHTLY_SHARD_INDEX / _TOTAL. We hand
+# those to AndroidJUnitRunner's built-in numShards/shardIndex so each leg runs
+# only its round-robin 1/N slice of phase 1, comfortably inside the ceiling.
+#
+# When the shard env is unset (a single-runner / local run) the suite behaves
+# exactly as before: one leg runs the whole phase-1 suite plus phases 2 & 3.
+SHARD_INDEX="${POCKETSHELL_NIGHTLY_SHARD_INDEX:-}"
+SHARD_TOTAL="${POCKETSHELL_NIGHTLY_SHARD_TOTAL:-}"
+JOURNEY_SHARD_ARGS=()
+SHARDING="no"
+if [[ -n "$SHARD_TOTAL" && "$SHARD_TOTAL" -gt 1 ]]; then
+  SHARDING="yes"
+  JOURNEY_SHARD_ARGS=(
+    "-Pandroid.testInstrumentationRunnerArguments.numShards=$SHARD_TOTAL"
+    "-Pandroid.testInstrumentationRunnerArguments.shardIndex=${SHARD_INDEX:-0}"
+  )
+fi
+
+# Phases 2 (network-fault proofs) and 3 (bootstrap scenarios) are NOT sharded:
+# they are a small fixed set and run only ONCE (on shard 0, or on every run
+# when sharding is disabled). Running them on every shard would needlessly
+# triple the slow toxiproxy soak proofs and bootstrap journeys, and would
+# require the toxiproxy + bootstrap fixtures on every leg.
+RUN_AUX_PHASES="yes"
+if [[ "$SHARDING" == "yes" && "${SHARD_INDEX:-0}" -ne 0 ]]; then
+  RUN_AUX_PHASES="no"
+fi
+
 echo "=========================================================="
 echo "Nightly Extensive Tests — phase 1: journey/E2E (pocketshellCi=true)"
 echo "Excluded classes: $JOURNEY_NOTCLASS_ARG"
+if [[ "$SHARDING" == "yes" ]]; then
+  echo "Sharding: shard ${SHARD_INDEX:-0} of $SHARD_TOTAL (numShards/shardIndex)"
+else
+  echo "Sharding: disabled (single runner runs the full phase-1 suite)"
+fi
 echo "=========================================================="
 
 "$GRADLEW" :app:connectedDebugAndroidTest \
   -Pandroid.testInstrumentationRunnerArguments.pocketshellCi=true \
   -Pandroid.testInstrumentationRunnerArguments.notClass="$JOURNEY_NOTCLASS_ARG" \
+  "${JOURNEY_SHARD_ARGS[@]}" \
   --stacktrace
 JOURNEY_EXIT=$?
 echo "phase 1 (journey/E2E) exit code: $JOURNEY_EXIT"
 
-echo "=========================================================="
-echo "Nightly Extensive Tests — phase 2: network-fault proofs (un-gated)"
-echo "Included classes: $NETWORK_FAULT_CLASS_ARG"
-echo "  (pocketshellNetworkFaultProofs=true, pocketshellCi NOT set)"
-echo "=========================================================="
+# Default the aux phases to SKIPPED; only the shard that owns them flips these.
+NETWORK_FAULT_EXIT=0
+BOOTSTRAP_EXIT=0
+nf_status="SKIP"
+bootstrap_status="SKIP"
 
-# NOTE: pocketshellCi is intentionally NOT passed here so that
-# `TerminalTestTimeouts.isRunningOnCi()` is false and the
-# `assumeFalse(isRunningOnCi())` guard in NetworkFaultProofBase passes.
-"$GRADLEW" :app:connectedDebugAndroidTest \
-  -Pandroid.testInstrumentationRunnerArguments.pocketshellNetworkFaultProofs=true \
-  -Pandroid.testInstrumentationRunnerArguments.class="$NETWORK_FAULT_CLASS_ARG" \
-  --stacktrace
-NETWORK_FAULT_EXIT=$?
-echo "phase 2 (network-fault proofs) exit code: $NETWORK_FAULT_EXIT"
+if [[ "$RUN_AUX_PHASES" == "yes" ]]; then
+  echo "=========================================================="
+  echo "Nightly Extensive Tests — phase 2: network-fault proofs (un-gated)"
+  echo "Included classes: $NETWORK_FAULT_CLASS_ARG"
+  echo "  (pocketshellNetworkFaultProofs=true, pocketshellCi NOT set)"
+  echo "=========================================================="
 
-echo "=========================================================="
-echo "Nightly Extensive Tests — phase 3: bootstrap setup scenarios (opt-in)"
-echo "Selected methods: $BOOTSTRAP_CLASS_ARG"
-echo "  (pocketshellBootstrapScenarios=true, pocketshellCi NOT set)"
-echo "=========================================================="
+  # NOTE: pocketshellCi is intentionally NOT passed here so that
+  # `TerminalTestTimeouts.isRunningOnCi()` is false and the
+  # `assumeFalse(isRunningOnCi())` guard in NetworkFaultProofBase passes.
+  "$GRADLEW" :app:connectedDebugAndroidTest \
+    -Pandroid.testInstrumentationRunnerArguments.pocketshellNetworkFaultProofs=true \
+    -Pandroid.testInstrumentationRunnerArguments.class="$NETWORK_FAULT_CLASS_ARG" \
+    --stacktrace
+  NETWORK_FAULT_EXIT=$?
+  echo "phase 2 (network-fault proofs) exit code: $NETWORK_FAULT_EXIT"
 
-# pocketshellCi is intentionally NOT passed: the bootstrap scenarios drive the
-# real host-list tap path against the bootstrap Docker fixtures and use their
-# own per-scenario timeouts, matching how the release gate / phone-walkthrough
-# run them.
-"$GRADLEW" :app:connectedDebugAndroidTest \
-  -Pandroid.testInstrumentationRunnerArguments.pocketshellBootstrapScenarios=true \
-  -Pandroid.testInstrumentationRunnerArguments.class="$BOOTSTRAP_CLASS_ARG" \
-  --stacktrace
-BOOTSTRAP_EXIT=$?
-echo "phase 3 (bootstrap setup scenarios) exit code: $BOOTSTRAP_EXIT"
+  echo "=========================================================="
+  echo "Nightly Extensive Tests — phase 3: bootstrap setup scenarios (opt-in)"
+  echo "Selected methods: $BOOTSTRAP_CLASS_ARG"
+  echo "  (pocketshellBootstrapScenarios=true, pocketshellCi NOT set)"
+  echo "=========================================================="
+
+  # pocketshellCi is intentionally NOT passed: the bootstrap scenarios drive the
+  # real host-list tap path against the bootstrap Docker fixtures and use their
+  # own per-scenario timeouts, matching how the release gate / phone-walkthrough
+  # run them.
+  "$GRADLEW" :app:connectedDebugAndroidTest \
+    -Pandroid.testInstrumentationRunnerArguments.pocketshellBootstrapScenarios=true \
+    -Pandroid.testInstrumentationRunnerArguments.class="$BOOTSTRAP_CLASS_ARG" \
+    --stacktrace
+  BOOTSTRAP_EXIT=$?
+  echo "phase 3 (bootstrap setup scenarios) exit code: $BOOTSTRAP_EXIT"
+
+  nf_status="PASS"
+  [[ "$NETWORK_FAULT_EXIT" -ne 0 ]] && nf_status="FAIL"
+  bootstrap_status="PASS"
+  [[ "$BOOTSTRAP_EXIT" -ne 0 ]] && bootstrap_status="FAIL"
+else
+  echo "=========================================================="
+  echo "Nightly Extensive Tests — phases 2 & 3 SKIPPED on shard ${SHARD_INDEX:-0}"
+  echo "  (network-fault proofs + bootstrap scenarios run once, on shard 0)"
+  echo "=========================================================="
+fi
 
 journey_status="PASS"
 [[ "$JOURNEY_EXIT" -ne 0 ]] && journey_status="FAIL"
-nf_status="PASS"
-[[ "$NETWORK_FAULT_EXIT" -ne 0 ]] && nf_status="FAIL"
-bootstrap_status="PASS"
-[[ "$BOOTSTRAP_EXIT" -ne 0 ]] && bootstrap_status="FAIL"
 
 overall_status="PASS"
 if [[ "$JOURNEY_EXIT" -ne 0 || "$NETWORK_FAULT_EXIT" -ne 0 || "$BOOTSTRAP_EXIT" -ne 0 ]]; then
   overall_status="FAIL"
 fi
 
+if [[ "$SHARDING" == "yes" ]]; then
+  shard_label="shard ${SHARD_INDEX:-0} of $SHARD_TOTAL (round-robin numShards/shardIndex)"
+else
+  shard_label="single runner (no sharding)"
+fi
+
 {
   echo "# Nightly Extensive — suite summary"
   echo
+  echo "Phase-1 selection: $shard_label"
+  echo
   echo "| Phase | Selection | Args | Exit | Result |"
   echo "| --- | --- | --- | --- | --- |"
-  echo "| Journey / E2E | full connected suite minus network-fault + opt-in classes | \`pocketshellCi=true\` | $JOURNEY_EXIT | **$journey_status** |"
+  echo "| Journey / E2E | full connected suite minus network-fault + opt-in classes ($shard_label) | \`pocketshellCi=true\` | $JOURNEY_EXIT | **$journey_status** |"
   echo "| Network-fault proofs | ${#NETWORK_FAULT_CLASSES[@]} NetworkFaultProofBase classes | \`pocketshellNetworkFaultProofs=true\` (no pocketshellCi) | $NETWORK_FAULT_EXIT | **$nf_status** |"
   echo "| Bootstrap setup scenarios | ${#BOOTSTRAP_METHODS[@]} HostBootstrapScenarioSuiteTest methods (trimmed) | \`pocketshellBootstrapScenarios=true\` | $BOOTSTRAP_EXIT | **$bootstrap_status** |"
   echo


### PR DESCRIPTION
Fixes phantom failures + the 150-min timeout in Nightly Extensive so the release-validation nightly-fault precondition becomes satisfiable.

- Bring up `agents-old-cli`(2238) + `agents-daemon`(2239) with readiness + sanity checks (fixes 3 'fixture not ready' failures).
- Pin emulator api-level 34→35 (two tests hard-assert SDK_INT==35).
- 3-way parallel matrix (`fail-fast:false`), phase-1 sharded via numShards/shardIndex, phases 2&3 on shard 0, per-shard artifacts — each ~228-test leg fits 150 min.

No product code. Reviewer APPROVED (fixtures brought up healthy locally, sharding partition verified no drop/double-run): https://github.com/alexeygrigorev/pocketshell/issues/1099#issuecomment-4840954064

Closes #1099