### PR TITLE
env: fix edit-in-place LazyColumn duplicate-key crash (#1092)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/env/EnvScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/env/EnvScreen.kt
@@ -308,7 +308,7 @@ private fun EnvKeyList(
         if (keys.isEmpty()) {
             item { EnvEmptyState(onAddKey = onAddKey) }
         } else {
-            items(keys, key = { "${it.file}:${it.key}" }) { row ->
+            items(keys, key = { envRowItemKey(it) }) { row ->
                 EnvKeyCard(row = row, onReveal = onReveal, onHide = onHide, onEdit = onEdit)
             }
         }
@@ -773,6 +773,16 @@ const val ENV_COPY_SHEET_TAG: String = "env:copy-sheet"
 const val ENV_COPY_CONFIRM_TAG: String = "env:copy-confirm"
 const val ENV_COPY_SOURCE_ERROR_TAG: String = "env:copy-source-error"
 const val ENV_COPY_SOURCE_EMPTY_TAG: String = "env:copy-source-empty"
+
+/**
+ * The LazyColumn item key for an env row. Must be unique across the whole
+ * list or Compose hard-crashes ("Key '…' was already used"). We key on the
+ * row's pre-disambiguated [EnvKeyUiRow.id] (stable identity, not the mutable
+ * `file:key` string) so two rows sharing the same (file, key) — a repeated
+ * key in a real `.env`, or the old + edited entry during an in-place edit —
+ * never collide.
+ */
+fun envRowItemKey(row: EnvKeyUiRow): String = row.id
 
 fun envKeyRowTestTag(key: String): String = "env:key:$key"
 fun envKeyMenuTestTag(key: String): String = "env:menu:$key"

--- a/app/src/main/java/com/pocketshell/app/env/EnvViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/env/EnvViewModel.kt
@@ -15,6 +15,14 @@ import javax.inject.Inject
  * user has explicitly tapped "Reveal") alongside the masked default.
  */
 data class EnvKeyUiRow(
+    /**
+     * Stable, list-unique identity used as the LazyColumn item key. Derived
+     * from `file:key` but disambiguated by occurrence so two rows that share
+     * the same (file, key) — a real `.env` may legitimately repeat a key, and
+     * an in-place edit transiently surfaces the old + edited entry — never
+     * collide on the LazyColumn key (Compose hard-crashes on duplicate keys).
+     */
+    val id: String,
     val key: String,
     val file: String,
     val hasValue: Boolean,
@@ -145,7 +153,7 @@ class EnvViewModel @Inject constructor(
             when (val result = gateway.listKeys(host, p.keyPath, p.passphrase, p.directory)) {
                 is EnvListResult.Keys -> {
                     _state.value = _state.value.copy(
-                        list = EnvListState.Ready(result.keys.map { it.toUiRow() }),
+                        list = EnvListState.Ready(result.keys.toUiRows()),
                     )
                 }
                 EnvListResult.ToolUnavailable -> {
@@ -436,7 +444,26 @@ class EnvViewModel @Inject constructor(
         /** POSIX-ish shell identifier check, matching the CLI's `_is_valid_key`. */
         fun isValidKey(key: String): Boolean = KEY_PATTERN.matches(key)
 
-        private fun EnvKeyRow.toUiRow(): EnvKeyUiRow =
-            EnvKeyUiRow(key = key, file = file, hasValue = hasValue)
+        /**
+         * Map gateway rows to UI rows, assigning each a list-unique [id]. The
+         * first occurrence of a `file:key` tuple keeps the bare `file:key` id
+         * (stable across refreshes for the common no-duplicate case); any
+         * further occurrence is suffixed `#1`, `#2`, … so the LazyColumn item
+         * key is always unique even when the same (file, key) appears twice.
+         */
+        fun List<EnvKeyRow>.toUiRows(): List<EnvKeyUiRow> {
+            val occurrences = HashMap<String, Int>()
+            return map { row ->
+                val base = "${row.file}:${row.key}"
+                val seen = occurrences.getOrDefault(base, 0)
+                occurrences[base] = seen + 1
+                EnvKeyUiRow(
+                    id = if (seen == 0) base else "$base#$seen",
+                    key = row.key,
+                    file = row.file,
+                    hasValue = row.hasValue,
+                )
+            }
+        }
     }
 }

--- a/app/src/test/java/com/pocketshell/app/env/EnvViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/env/EnvViewModelTest.kt
@@ -202,6 +202,56 @@ class EnvViewModelTest {
     }
 
     @Test
+    fun duplicateFileKeyRowsGetUniqueLazyColumnItemKeys() = runTest {
+        // Reproduce-first (crash regression from #1093): editing a key's value
+        // in place transiently surfaces the old + edited entry for the SAME
+        // (file, key), and a real .env may literally repeat a key. The env
+        // LazyColumn keyed each item on "file:key", so two such rows collided
+        // and Compose hard-crashed with
+        //   IllegalArgumentException: Key '.env:API_KEY' was already used.
+        // The load-bearing invariant: the item key the screen actually uses
+        // (envRowItemKey) must be unique across the whole list.
+        val gateway = FakeEnvGateway(
+            listResult = EnvListResult.Keys(
+                listOf(
+                    EnvKeyRow("API_KEY", ".env", true),
+                    EnvKeyRow("API_KEY", ".env", true),
+                    EnvKeyRow("API_KEY", ".envrc", true),
+                ),
+            ),
+        )
+        val vm = EnvViewModel(gateway, FakeHostDao(host))
+        vm.bind(1L, "/tmp/key", null, "/home/alexey/proj", "proj", emptyList())
+        advanceUntilIdle()
+
+        val rows = (vm.state.value.list as EnvListState.Ready).keys
+        // All three rows survive (the duplicate is NOT silently dropped) …
+        assertEquals(3, rows.size)
+        // … and the keys the LazyColumn uses are all distinct (no crash).
+        val itemKeys = rows.map { envRowItemKey(it) }
+        assertEquals(
+            "LazyColumn item keys must be unique to avoid the duplicate-key crash",
+            itemKeys.size,
+            itemKeys.toSet().size,
+        )
+    }
+
+    @Test
+    fun singleKeyKeepsBareFileKeyItemKey() = runTest {
+        // The common no-duplicate case keeps the stable bare "file:key" id so
+        // per-row state (reveal toggle, animations) survives a refresh.
+        val gateway = FakeEnvGateway(
+            listResult = EnvListResult.Keys(listOf(EnvKeyRow("API_KEY", ".env", true))),
+        )
+        val vm = EnvViewModel(gateway, FakeHostDao(host))
+        vm.bind(1L, "/tmp/key", null, "/home/alexey/proj", "proj", emptyList())
+        advanceUntilIdle()
+
+        val row = (vm.state.value.list as EnvListState.Ready).keys.single()
+        assertEquals(".env:API_KEY", envRowItemKey(row))
+    }
+
+    @Test
     fun copyKeysCallsGatewayAndRefreshes() = runTest {
         val gateway = FakeEnvGateway(listResult = EnvListResult.Keys(emptyList()))
         val vm = EnvViewModel(gateway, FakeHostDao(host))


### PR DESCRIPTION
Reopen fix. Editing an existing env key crashed the screen (`IllegalArgumentException: Key '.env:API_KEY' was already used`) — LazyColumn keyed on the mutable `${file}:${key}`, so the edit transition (and any real `.env` with a repeated key) produced duplicate keys → Compose crash (same class as #931).

Fix: stable list-unique row `id` via `toUiRows()`; LazyColumn keys on `envRowItemKey(row)=row.id`.

Reviewer APPROVED — red→green (revert→FAIL `expected:<3> but was:<2>`, restore→PASS), 13 unit tests/0 skipped, class coverage (same-file + cross-file repeats + single-key stability), on-device `EnvScreenE2eTest` 3/3: https://github.com/alexeygrigorev/pocketshell/issues/1092#issuecomment-4840976236

Closes #1092