### PR TITLE
app: recover terminal after network blip (#1098 item 5)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/BareNetworkLossRestoreReconnectE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/BareNetworkLossRestoreReconnectE2eTest.kt
@@ -143,6 +143,9 @@ class BareNetworkLossRestoreReconnectE2eTest {
         runCatching {
             compose.activityRule.scenario.moveToState(Lifecycle.State.RESUMED)
         }
+        // Issue #1098 (item 5): re-enable real network callbacks for any sibling
+        // test sharing this singleton observer in the same instrumentation process.
+        runCatching { terminalNetworkObserver().ignoreRealNetworkCallbacksForTest = false }
         diagnostics?.close()
         diagnostics = null
         clearLastSessionPrefs()
@@ -162,6 +165,12 @@ class BareNetworkLossRestoreReconnectE2eTest {
         diagnostics!!.clear()
 
         val observer = terminalNetworkObserver()
+        // Issue #1098 (item 5): isolate the synthetic loss/restore sequence from the
+        // AVD's own real ConnectivityManager callbacks, which feed the SAME detector
+        // and would otherwise consume the loss window mid-sequence (corrupting the
+        // same-identity restore). Production always processes real callbacks; this
+        // only quiets them for the deterministic injection.
+        observer.ignoreRealNetworkCallbacksForTest = true
 
         // Seed a baseline validated identity so the detector's `current` is a known
         // pure-WIFI network before the loss (so the restore below is a same-identity
@@ -197,11 +206,7 @@ class BareNetworkLossRestoreReconnectE2eTest {
         // redial ladder starts (`network_reconnect_start` / `network_restore_reconnect_start`
         // must be absent while we are still in the loss window).
         watchNoRedialDiagnostics("during the loss window", WATCH_NO_CHURN_MS)
-        assertTrue(
-            "the VM must record a network_loss_hold for the bare loss (proves the hold " +
-                "arm fired, not a vacuous pass); events=${diagnostics!!.events.map { it.name }}",
-            diagnostics!!.eventsNamed("network_loss_hold").isNotEmpty(),
-        )
+        awaitNetworkLossHold("after the bare loss")
         captureViewport("issue997-02-loss-held")
 
         diagnostics!!.clear()
@@ -309,6 +314,10 @@ class BareNetworkLossRestoreReconnectE2eTest {
 
         val vm = currentViewModel()
         val observer = terminalNetworkObserver()
+        // Issue #1098 (item 5): see [bareLossHoldsTheLeaseThenRestoreDrivesAFastReconnect]
+        // — quiet the AVD's real ConnectivityManager callbacks so the synthetic
+        // loss/restore sequence runs uncontended through the shared detector.
+        observer.ignoreRealNetworkCallbacksForTest = true
 
         // Baseline validated WIFI identity (proven-alive pinned so the baseline
         // transition never tears the session before the load-bearing chain).
@@ -331,11 +340,12 @@ class BareNetworkLossRestoreReconnectE2eTest {
             TerminalNetworkChangeKind.NetworkLost,
             lost!!.kind,
         )
-        assertTrue(
-            "the VM must record a network_loss_hold for the bare loss (proves the hold " +
-                "arm fired, not a vacuous pass); events=${diagnostics!!.events.map { it.name }}",
-            diagnostics!!.eventsNamed("network_loss_hold").isNotEmpty(),
-        )
+        // Issue #1098 (item 5): the App fans the loss out to the VM hook on the
+        // terminal-network scope ASYNCHRONOUSLY, so wait (bounded) for the hold to be
+        // recorded rather than asserting synchronously right after the emit (the
+        // round-2 async-fanout flake). A hard-failing bounded wait still proves the
+        // hold actually fired — it does not mask a real failure to hold.
+        awaitNetworkLossHold("after the bare loss")
 
         // SURVIVE THE LONG IDLE OUTAGE: no churn across the whole idle window.
         watchNoRedialDiagnostics("across the long idle outage", LONG_IDLE_OUTAGE_MS)
@@ -525,6 +535,27 @@ class BareNetworkLossRestoreReconnectE2eTest {
         }
     }
 
+    /**
+     * Issue #1098 (item 5): the bare loss is fanned out to the VM hook on the
+     * App's terminal-network scope asynchronously (`terminalNetworkScope.launch`).
+     * Wait (bounded, hard-failing) for the `network_loss_hold` diagnostic to be
+     * recorded instead of asserting synchronously right after the emit. The wait
+     * does not mask a real failure: if the hold never fires, the bounded
+     * `waitUntil` times out and the assertion below fails.
+     */
+    private fun awaitNetworkLossHold(label: String) {
+        runCatching {
+            compose.waitUntil(timeoutMillis = LOSS_HOLD_TIMEOUT_MS) {
+                diagnostics!!.eventsNamed("network_loss_hold").isNotEmpty()
+            }
+        }
+        assertTrue(
+            "the VM must record a network_loss_hold for the bare loss $label (proves the " +
+                "hold arm fired, not a vacuous pass); events=${diagnostics!!.events.map { it.name }}",
+            diagnostics!!.eventsNamed("network_loss_hold").isNotEmpty(),
+        )
+    }
+
     private fun assertNoRedialDiagnostics(label: String) {
         val events = diagnostics!!.events
         val forbidden = events.filter { event ->
@@ -693,6 +724,10 @@ class BareNetworkLossRestoreReconnectE2eTest {
         const val READY_MARKER: String = "ISSUE997-LOSS-READY"
 
         const val WATCH_NO_CHURN_MS: Long = 1_500L
+
+        // Issue #1098 (item 5): bounded wait for the async network_loss_hold fanout.
+        val LOSS_HOLD_TIMEOUT_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 20_000L else 10_000L
 
         // Issue #1065 (R5): the modelled long idle outage held across the loss window.
         // Bounded so the connected journey stays affordable; long enough to be a

--- a/app/src/main/java/com/pocketshell/app/App.kt
+++ b/app/src/main/java/com/pocketshell/app/App.kt
@@ -768,23 +768,41 @@ internal class TerminalNetworkLifecycleGate(
     ): TerminalNetworkDecision {
         val suppression = postResumeNetworkSuppression
         if (suppression != null) {
-            if (nowMillis() <= suppression.untilMillis && hasLiveTerminalRuntime) {
-                return TerminalNetworkDecision.Suppress(
-                    change,
-                    gateDiagnostics = TerminalNetworkGateDiagnostics(
-                        decision = "suppress",
-                        reason = "post_resume_within_grace_live_runtime",
-                        processForeground = processForeground,
-                        foregroundResumePending = foregroundResumePending,
-                        resumedWithinGrace = true,
-                        hasLiveTerminalRuntime = true,
-                        backgroundCycleId = suppression.backgroundCycleId,
-                        pendingNetworkChange = true,
-                        pendingNetworkClassification = change.networkClassification(),
-                    ),
-                )
+            val withinSuppressionWindow =
+                nowMillis() <= suppression.untilMillis && hasLiveTerminalRuntime
+            if (withinSuppressionWindow) {
+                // Issue #1098 (item 5): the post-resume attribution window exists
+                // ONLY to drop a STALE *validated-identity-change* callback that
+                // Android queued during the just-ended background interval (the
+                // #548 handoff path — see [postResumeNetworkSuppressionUntilMillis]).
+                // A bare availability LOSS / RESTORE (`onLost` / airplane-mode
+                // round-trip — the orthogonal #997 signal) is a CURRENT, meaningful
+                // event, not a stale handoff. Swallowing it here left the lease
+                // un-held during the loss and the restore-driven fast reconnect
+                // never fired, so a real network blip never recovered the terminal.
+                // Only ValidatedIdentityChange is suppressed in this window;
+                // loss/restore fall through to the dispatch path below. The window
+                // stays armed so a later stale validated-identity callback is still
+                // suppressed.
+                if (change.kind == TerminalNetworkChangeKind.ValidatedIdentityChange) {
+                    return TerminalNetworkDecision.Suppress(
+                        change,
+                        gateDiagnostics = TerminalNetworkGateDiagnostics(
+                            decision = "suppress",
+                            reason = "post_resume_within_grace_live_runtime",
+                            processForeground = processForeground,
+                            foregroundResumePending = foregroundResumePending,
+                            resumedWithinGrace = true,
+                            hasLiveTerminalRuntime = true,
+                            backgroundCycleId = suppression.backgroundCycleId,
+                            pendingNetworkChange = true,
+                            pendingNetworkClassification = change.networkClassification(),
+                        ),
+                    )
+                }
+            } else {
+                postResumeNetworkSuppression = null
             }
-            postResumeNetworkSuppression = null
         }
 
         return if (processForeground && !foregroundResumePending) {

--- a/app/src/main/java/com/pocketshell/app/connectivity/TerminalNetworkObserver.kt
+++ b/app/src/main/java/com/pocketshell/app/connectivity/TerminalNetworkObserver.kt
@@ -53,6 +53,27 @@ class TerminalNetworkObserver @Inject constructor(
     @Volatile
     private var closed: Boolean = false
 
+    /**
+     * Issue #1098 (item 5) test seam. The synthetic loss/restore proofs
+     * ([emitSyntheticSnapshotForTest]) drive a NoValidatedNetwork → Validated
+     * sequence through the SAME shared [detector] the real platform callbacks
+     * feed. On a live emulator the AVD's own `ConnectivityManager` keeps firing
+     * real `onAvailable` / `onCapabilitiesChanged` callbacks for its validated
+     * Wi-Fi, and one of those interleaving mid-sequence would consume the
+     * synthetic loss window (a real validated callback while `lost==true` is
+     * treated as the RESTORE), corrupting the test's same-identity restore
+     * (`detector.update` then returns null → `assertNotNull(restored)` fails).
+     *
+     * When set, the real platform [ConnectivityManager.NetworkCallback]
+     * callbacks no-op so a synthetic sequence runs uncontended. The synthetic
+     * emit path ([emitSyntheticSnapshotForTest]) bypasses this guard. ALWAYS
+     * false in production — real callbacks are always processed there; this only
+     * isolates the deterministic connected proofs.
+     */
+    @Volatile
+    @androidx.annotation.VisibleForTesting
+    var ignoreRealNetworkCallbacksForTest: Boolean = false
+
     init {
         val manager = cm
         if (manager == null) {
@@ -60,10 +81,12 @@ class TerminalNetworkObserver @Inject constructor(
         } else {
             val cb = object : ConnectivityManager.NetworkCallback() {
                 override fun onAvailable(network: Network) {
+                    if (ignoreRealNetworkCallbacksForTest) return
                     refresh("default-network-available")
                 }
 
                 override fun onLost(network: Network) {
+                    if (ignoreRealNetworkCallbacksForTest) return
                     refresh("default-network-lost")
                 }
 
@@ -71,6 +94,7 @@ class TerminalNetworkObserver @Inject constructor(
                     network: Network,
                     networkCapabilities: NetworkCapabilities,
                 ) {
+                    if (ignoreRealNetworkCallbacksForTest) return
                     updateFromSnapshot(
                         snapshotFrom(network, networkCapabilities),
                         "default-network-capabilities",
@@ -78,6 +102,7 @@ class TerminalNetworkObserver @Inject constructor(
                 }
 
                 override fun onUnavailable() {
+                    if (ignoreRealNetworkCallbacksForTest) return
                     updateFromSnapshot(
                         TerminalNetworkSnapshot.NoValidatedNetwork,
                         "default-network-unavailable",

--- a/app/src/test/java/com/pocketshell/app/BackgroundGraceControllerTest.kt
+++ b/app/src/test/java/com/pocketshell/app/BackgroundGraceControllerTest.kt
@@ -1,6 +1,7 @@
 package com.pocketshell.app
 
 import com.pocketshell.app.connectivity.TerminalNetworkChange
+import com.pocketshell.app.connectivity.TerminalNetworkChangeKind
 import com.pocketshell.app.connectivity.TerminalNetworkSnapshot
 import com.pocketshell.app.diagnostics.installRecordingDiagnosticSink
 import com.pocketshell.app.sessions.ActiveTmuxClients
@@ -1030,6 +1031,70 @@ class BackgroundGraceControllerTest {
         assertEquals("post_resume_within_grace_live_runtime", secondSuppress.gateDiagnostics.reason)
         assertEquals(1L, secondSuppress.gateDiagnostics.backgroundCycleId)
         assertEquals("late post-resume callbacks must not fan out to terminal reconnect", emptyList<String>(), events)
+    }
+
+    @Test
+    fun `bare network loss and restore are not swallowed by post resume suppression window`() {
+        // Issue #1098 (item 5): the post-resume attribution window legitimately
+        // drops a STALE validated-identity-change callback queued during the just-
+        // ended background interval — but it was ALSO swallowing a CURRENT bare
+        // NetworkLost / NetworkRestored (the orthogonal #997 signal), so the
+        // network_loss_hold arm never fired and a real network blip never recovered
+        // the terminal. The fix exempts loss/restore from this window while keeping
+        // it armed for stale validated handoffs.
+        var now = 10_000L
+        val gate = TerminalNetworkLifecycleGate(nowMillis = { now })
+        gate.onBackground()
+        gate.onForegroundResumeStarted()
+        gate.onForegroundResumeFinished(resumedWithinGrace = true, hasLiveTerminalRuntime = true)
+
+        now += 1_000L // still inside the attribution window
+
+        val loss = TerminalNetworkChange(
+            previous = TerminalNetworkSnapshot.Validated("wifi"),
+            current = TerminalNetworkSnapshot.NoValidatedNetwork,
+            previousValidated = TerminalNetworkSnapshot.Validated("wifi"),
+            reason = "bare-network-loss",
+            sequence = 1L,
+            kind = TerminalNetworkChangeKind.NetworkLost,
+        )
+        assertTrue(
+            "a bare NetworkLost must NOT be swallowed by the post-resume suppression window",
+            gate.onNetworkChange(loss, hasLiveTerminalRuntime = true) is TerminalNetworkDecision.Dispatch,
+        )
+
+        val restore = TerminalNetworkChange(
+            previous = TerminalNetworkSnapshot.NoValidatedNetwork,
+            current = TerminalNetworkSnapshot.Validated("wifi"),
+            previousValidated = TerminalNetworkSnapshot.Validated("wifi"),
+            reason = "network-restored",
+            sequence = 2L,
+            kind = TerminalNetworkChangeKind.NetworkRestored,
+        )
+        assertTrue(
+            "a NetworkRestored must NOT be swallowed by the post-resume suppression window",
+            gate.onNetworkChange(restore, hasLiveTerminalRuntime = true) is TerminalNetworkDecision.Dispatch,
+        )
+
+        // The window is still armed: a STALE validated-identity handoff in the same
+        // window is still suppressed (the legitimate purpose is preserved).
+        val staleHandoff = TerminalNetworkChange(
+            previous = TerminalNetworkSnapshot.Validated("wifi"),
+            current = TerminalNetworkSnapshot.Validated("cell"),
+            previousValidated = TerminalNetworkSnapshot.Validated("wifi"),
+            reason = "stale-validated-handoff",
+            sequence = 3L,
+            kind = TerminalNetworkChangeKind.ValidatedIdentityChange,
+        )
+        val suppress = gate.onNetworkChange(staleHandoff, hasLiveTerminalRuntime = true)
+        assertTrue(
+            "a stale validated-identity handoff inside the still-armed window must be suppressed",
+            suppress is TerminalNetworkDecision.Suppress,
+        )
+        assertEquals(
+            "post_resume_within_grace_live_runtime",
+            (suppress as TerminalNetworkDecision.Suppress).gateDiagnostics.reason,
+        )
     }
 
     @Test


### PR DESCRIPTION
Part of the connection-lifecycle reliability cluster (#1098). After a network blip the terminal never recovered — the `TerminalNetworkLifecycleGate` post-resume suppression window swallowed the bare `NetworkLost`/`NetworkRestored`, so the `network_loss_hold`→fast-reconnect ladder (#1045/#1078) never fired.

- **App.kt:** in the post-resume window suppress ONLY `ValidatedIdentityChange` (the stale-handoff case the window guards); let loss/restore fall through to dispatch.
- **TerminalNetworkObserver:** test-only seam to ignore real `ConnectivityManager` callbacks during synthetic injection (always false in production).

Terminal recovers ~75–145ms after restore.

Reviewer **APPROVED** (corrected scope) — BareNetworkLoss real-path red→green (`restore_reconnect_signal_ms=75`, `ISSUE997-LOSS-READY` repaint confirmed), JVM gate red→green (new `BackgroundGraceControllerTest`), narrowing production-safe, seam neutral: https://github.com/alexeygrigorev/pocketshell/issues/1098#issuecomment-4842266462

Note: `SshReconnectE2eTest` was split out to #1104 (separate chunked-IME garble root), not part of this scope.

Refs #1098