### PR TITLE
tmux: fix send-keys arg order — stop corrupting input on every attach (#1104)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/SshReconnectE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/SshReconnectE2eTest.kt
@@ -643,6 +643,21 @@ class SshReconnectE2eTest {
                 terminalCols = terminalGridSize().columns,
             )
         }
+        // Issue #1104: the `containsWrapTolerant` substring match above passes
+        // even when the command echo is corrupted, because the command still
+        // appears as a substring. Before the fix, the attach/reseed repaint
+        // (`forceFullRepaint`) ran `send-keys C-l -t <pane>` with the key before
+        // the `-t` option, so tmux typed the literal target token (e.g. `-t%0`)
+        // into the pane ahead of the command: `printf ...` reached the shell as
+        // `-t%0printf ...`. Hard-assert that leaked target token is absent so a
+        // regression of this class FAILS the E2E (not just the focused tests).
+        val echoTranscript = visibleTerminalText()
+        assertFalse(
+            "issue #1104: a `send-keys -t <pane>` target token leaked into the " +
+                "terminal as literal keystrokes, corrupting `$label` input. " +
+                "Visible terminal:\n${echoTranscript.printableForFailure()}",
+            echoTranscript.contains("-t%"),
+        )
         val enterCommitted = terminalInputConnection().commitText("\n", 1)
         assertTrue("expected terminal input connection to submit $label", enterCommitted)
     }

--- a/app/src/test/java/com/pocketshell/app/tmux/RedrawNonDestructiveReseedTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/RedrawNonDestructiveReseedTest.kt
@@ -226,10 +226,14 @@ class RedrawNonDestructiveReseedTest {
         // FIX part 1: Redraw FORCED a repaint before it captured.
         val sentDuringRedraw = client.sentCommands.drop(sentBefore)
         val forceRepaintIndex = sentDuringRedraw.indexOfFirst {
-            it.startsWith("send-keys C-l -t %1")
+            // Issue #1104: flags BEFORE the key operand — `send-keys -t %1 C-l`.
+            // The old `send-keys C-l -t %1` ordering made tmux treat `-t` as a
+            // literal key and never targeted the pane, so this must pin the
+            // correct order (it FAILS if the key-before-`-t` bug returns).
+            it == "send-keys -t %1 C-l"
         }
         assertTrue(
-            "Redraw must send `send-keys C-l -t %1` to FORCE the app to repaint " +
+            "Redraw must send `send-keys -t %1 C-l` to FORCE the app to repaint " +
                 "(sent during redraw: $sentDuringRedraw)",
             forceRepaintIndex >= 0,
         )
@@ -317,8 +321,11 @@ class RedrawNonDestructiveReseedTest {
 
         val sentDuring = client.sentCommands.drop(sentBefore)
         assertTrue(
-            "the attach/return reseed must FORCE a repaint too (sent: $sentDuring)",
-            sentDuring.any { it.startsWith("send-keys C-l -t %1") },
+            // Issue #1104: correct arg order — flags (`-t %1`) BEFORE the `C-l`
+            // key operand; pins it so the key-before-`-t` bug can't silently return.
+            "the attach/return reseed must FORCE a repaint too with `send-keys -t %1 C-l` " +
+                "(sent: $sentDuring)",
+            sentDuring.any { it == "send-keys -t %1 C-l" },
         )
         val renderedAfter = pane.terminalState.renderedNonBlankCharCount()
         assertTrue(

--- a/shared/core-tmux/src/integrationTest/java/com/pocketshell/core/tmux/TmuxClientIntegrationTest.kt
+++ b/shared/core-tmux/src/integrationTest/java/com/pocketshell/core/tmux/TmuxClientIntegrationTest.kt
@@ -419,4 +419,93 @@ class TmuxClientIntegrationTest {
             scope.cancel()
         }
     }
+
+    @Test
+    fun `forceFullRepaint does not type the -t target option into the pane (issue 1104)`() = runBlocking {
+        // Issue #1104: `send-keys C-l -t <pane>` (key BEFORE the `-t` option)
+        // makes tmux's argument parser treat `-t` and the pane id as literal
+        // keystrokes — and ignore the target — so a stray `-t<pane>` is typed
+        // into the active pane. On every attach/reseed this prefixed the user's
+        // next command, e.g. `printf ...` arrived at the shell as `-t%0printf
+        // ...` (`sh: -t%0printf: not found`). The fix sends `send-keys -t <pane>
+        // C-l` (flags before operand). This drives the REAL tmux server and
+        // asserts the leaked target token never reaches the pane.
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        try {
+            connectSession().use { session ->
+                val client: TmuxClient = TmuxClientFactory(scope).create(
+                    session,
+                    sessionName = "it-${System.nanoTime()}",
+                )
+                client.use {
+                    it.connect()
+                    delay(500)
+
+                    val paneIdResp = withTimeout(10_000) {
+                        it.sendCommand("display-message -p \"#{pane_id}\"")
+                    }
+                    assertFalse(
+                        "display-message must succeed; got ${paneIdResp.output}",
+                        paneIdResp.isError,
+                    )
+                    val paneId = paneIdResp.output.firstOrNull()?.trim().orEmpty()
+                    assertTrue(
+                        "display-message returned no pane id; got ${paneIdResp.output}",
+                        paneId.startsWith("%"),
+                    )
+
+                    // Drive the repaint primitive the attach/reseed path runs.
+                    val repaintResp = withTimeout(10_000) { it.forceFullRepaint(paneId) }
+                    assertFalse(
+                        "forceFullRepaint must not error; got ${repaintResp.output}",
+                        repaintResp.isError,
+                    )
+                    // Give tmux/the shell a beat to render any (leaked) keystrokes.
+                    delay(500)
+
+                    // Capture the authoritative pane content from the real server.
+                    // With the bug the input line shows the leaked `-t<pane>`
+                    // token; with the fix only Ctrl-L (a redraw) was delivered.
+                    val capResp = withTimeout(10_000) {
+                        it.sendCommand("capture-pane -p -t $paneId")
+                    }
+                    assertFalse(
+                        "capture-pane must succeed; got ${capResp.output}",
+                        capResp.isError,
+                    )
+                    val captured = capResp.output.joinToString("\n")
+                    assertFalse(
+                        "send-keys `-t` target option leaked into pane $paneId as " +
+                            "literal keystrokes; pane content:\n$captured",
+                        captured.contains("-t$paneId") || captured.contains("-t $paneId"),
+                    )
+
+                    // Also prove input still arrives intact AFTER a repaint: type
+                    // a marker command and confirm the shell sees exactly it (no
+                    // `-t<pane>` prefix corrupting the token).
+                    val marker = "PS1104OK${System.nanoTime()}"
+                    withTimeout(10_000) {
+                        it.sendCommand("send-keys -l -t $paneId -- 'echo $marker'")
+                    }
+                    delay(300)
+                    val afterTypeResp = withTimeout(10_000) {
+                        it.sendCommand("capture-pane -p -t $paneId")
+                    }
+                    val afterType = afterTypeResp.output.joinToString("\n")
+                    assertTrue(
+                        "expected the typed command `echo $marker` intact on the " +
+                            "input line; pane content:\n$afterType",
+                        afterType.contains("echo $marker"),
+                    )
+                    assertFalse(
+                        "typed command was corrupted by a leaked `-t$paneId` prefix; " +
+                            "pane content:\n$afterType",
+                        afterType.contains("-t${paneId}echo") || afterType.contains("-t$paneId echo"),
+                    )
+                }
+            }
+        } finally {
+            scope.cancel()
+        }
+    }
 }

--- a/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxClient.kt
+++ b/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxClient.kt
@@ -285,7 +285,14 @@ public interface TmuxClient : AutoCloseable {
      * implementation routes through [sendCommand] for [TmuxClient] doubles.
      */
     public suspend fun forceFullRepaint(paneId: String): CommandResponse =
-        sendCommand("send-keys C-l -t $paneId")
+        // Issue #1104: the `-t <pane>` target option MUST precede the `C-l` key
+        // operand. tmux's `send-keys` argument parser stops treating tokens as
+        // options once the first operand (the key) appears, so the old
+        // `send-keys C-l -t $paneId` form made tmux send `C-l`, then the LITERAL
+        // keystrokes `-t` and `$paneId` into the *active* pane (the target was
+        // also ignored) — typing e.g. `-t%0` straight into the shell ahead of
+        // the user's command. Flags-before-operand is the only correct order.
+        sendCommand("send-keys -t $paneId C-l")
 
     /**
      * Issue #927: milliseconds since the control-mode reader last parsed ANY
@@ -1612,8 +1619,13 @@ internal class RealTmuxClient(
         // reply during an output storm fails open locally instead of being
         // mistaken for a fatal transport drop — this MUST NOT take the FatalClose
         // structural-command path (#979 owns that timeout behaviour).
+        //
+        // Issue #1104: `-t <pane>` MUST come before the `C-l` key operand. With
+        // the key first, tmux's send-keys parser treats `-t` and `$paneId` as
+        // literal keystrokes (and ignores the target), typing e.g. `-t%0` into
+        // the active pane ahead of the user's command. Flags-before-operand.
         sendCommandInternal(
-            "send-keys C-l -t $paneId",
+            "send-keys -t $paneId C-l",
             timeoutMode = CommandTimeoutMode.FailOpenDrain,
         )
 

--- a/shared/core-tmux/src/test/java/com/pocketshell/core/tmux/TmuxClientTest.kt
+++ b/shared/core-tmux/src/test/java/com/pocketshell/core/tmux/TmuxClientTest.kt
@@ -538,6 +538,40 @@ class TmuxClientTest {
     }
 
     @Test
+    fun `forceFullRepaint puts -t target before the C-l key operand (issue 1104)`() = runBlocking {
+        // Issue #1104: `send-keys` requires options BEFORE the key operand.
+        // The pre-fix `send-keys C-l -t <pane>` form made tmux treat `-t` and
+        // the pane id as LITERAL keystrokes (and ignore the target), so a stray
+        // `-t%0` was typed into the active pane on every attach/reseed repaint,
+        // garbling the user's command (`printf` -> `-t%0printf`). The only
+        // correct order is flags-before-operand: `send-keys -t <pane> C-l`.
+        val shell = FakeShell()
+        val session = FakeSession(shell)
+        val client = RealTmuxClient(session, scope)
+        try {
+            client.connect()
+            // Eat the spawn line so the assertion sees only the repaint command.
+            withTimeout(2_000) {
+                while (shell.stdinBytes().isEmpty()) { yield(); delay(10) }
+            }
+            shell.resetStdin()
+
+            val response = scope.async { client.forceFullRepaint("%0") }
+            withTimeout(2_000) {
+                while (shell.stdinBytes().isEmpty()) { yield(); delay(10) }
+            }
+            assertEquals("send-keys -t %0 C-l\n", shell.stdinAsString())
+
+            // Complete the pending command so the coroutine doesn't leak.
+            shell.feed("%begin 1700000000 5 0\n%end 1700000000 5 0\n")
+            withTimeout(ASYNC_AWAIT_TIMEOUT_MS) { response.await() }
+            Unit
+        } finally {
+            client.close()
+        }
+    }
+
+    @Test
     fun `sendCommand correlates response between begin and end`() = runBlocking {
         val shell = FakeShell()
         val session = FakeSession(shell)


### PR DESCRIPTION
**High-severity reliability fix.** `TmuxClient.forceFullRepaint()` (the redraw run on EVERY session attach/reseed) had its `send-keys` arguments in the wrong order — `send-keys C-l -t \$paneId` instead of `send-keys -t \$paneId C-l`. tmux stops parsing options after the first operand, so it typed the literal `-t` + `\$paneId` into the active pane, **prefixing the user's next command with `-t%0`**. Every attach corrupted the next typed command — a core part of 'impossible to use'.

Fix: flags before the key operand at both sites. Audited the tree — these were the only two offenders.

Reviewer **APPROVED** — severity confirmed (normal attach chokepoint), JVM red→green on `TmuxClientTest` (arg order is the load-bearing assertion), real-tmux integration + E2E `SshReconnectE2eTest` green, G2 production audit clean, `:app:testDebugUnitTest` green (stale `RedrawNonDestructiveReseedTest` assertions corrected): https://github.com/alexeygrigorev/pocketshell/issues/1104#issuecomment-4842661621

Closes #1104