### PR TITLE
test: fix stale composer failed-send attachment assertion + wire journey (#1108)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerSendDismissE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerSendDismissE2eTest.kt
@@ -233,8 +233,12 @@ class PromptComposerSendDismissE2eTest {
         val visible = mutableStateOf(true)
         val attachPath = "~/.pocketshell/attachments/host-1/20260611-report.png"
         var sendSucceeds = false
+        // Record every SendRequest the host receives so the resend assertion can
+        // prove the attachment still travels (it must NOT be silently dropped).
+        val received = java.util.concurrent.CopyOnWriteArrayList<PromptComposerViewModel.SendRequest>()
         collectorScope.launch {
             vm.sendRequests.collect { request ->
+                received += request
                 if (sendSucceeds) visible.value = false else vm.restoreFailedSend(request)
             }
         }
@@ -268,8 +272,10 @@ class PromptComposerSendDismissE2eTest {
         assertEquals(1, vm.uiState.value.attachments.size)
         WalkthroughScreenshotArtifacts.capture("issue-694-01-attach-then-type")
 
-        // Send while degraded: it fails. The restored draft keeps the
-        // attachment path so it is not silently dropped.
+        // Send while degraded: it fails. Issue #872/#971: the failed send
+        // restores the CLEAN typed draft AND re-shows the attachment as a TILE —
+        // the path lives in the attachment list, NOT folded into the draft text.
+        // The attachment must NEVER be silently dropped (#694/#1108).
         compose.onNodeWithTag(COMPOSER_SEND_ENTER_TAG)
             .assertIsEnabled()
             .performClick()
@@ -277,12 +283,14 @@ class PromptComposerSendDismissE2eTest {
             vm.uiState.value.error?.contains("Not sent") == true
         }
         compose.waitForIdle()
-        val restored = vm.uiState.value.draft
+        // The clean typed text comes back in the draft …
+        assertEquals("what is wrong here", vm.uiState.value.draft)
+        // … and the attachment survives as a TILE so the resend still carries it.
         assertTrue(
-            "restored draft must keep the attachment path for resend (#694)",
-            restored.contains("20260611-report.png"),
+            "failed send must keep the attachment tile for resend (#694/#1108)",
+            vm.uiState.value.attachments.any { it.remotePath.contains("20260611-report.png") },
         )
-        assertTrue(restored.contains("what is wrong here"))
+        compose.onNodeWithTag(COMPOSER_ATTACHMENT_CHIPS_TAG).assertIsDisplayed()
         compose.onNodeWithTag(COMPOSER_DRAFT_TAG).assertIsDisplayed()
         WalkthroughScreenshotArtifacts.capture("issue-694-02-not-sent-keeps-attachment")
 
@@ -296,6 +304,14 @@ class PromptComposerSendDismissE2eTest {
             compose.onAllNodesWithTag(COMPOSER_DRAFT_TAG).fetchSemanticsNodes().isEmpty()
         }
         compose.onNodeWithTag(COMPOSER_DRAFT_TAG).assertDoesNotExist()
+        // Load-bearing: the resend STILL carries the attachment — no silent drop.
+        compose.waitUntil(timeoutMillis = 5_000) { received.size >= 2 }
+        val resend = received.last()
+        assertTrue(
+            "resend must still carry the attachment path (#694/#1108)",
+            resend.text.contains("20260611-report.png") &&
+                resend.attachments.any { it.remotePath.contains("20260611-report.png") },
+        )
         WalkthroughScreenshotArtifacts.capture("issue-694-03-resend-after-reconnect")
     }
 }

--- a/app/src/test/java/com/pocketshell/app/composer/PromptComposerFailedSendAttachmentResendTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/PromptComposerFailedSendAttachmentResendTest.kt
@@ -1,0 +1,154 @@
+package com.pocketshell.app.composer
+
+import androidx.lifecycle.SavedStateHandle
+import com.pocketshell.app.composer.PromptComposerViewModel.ApiKeyVault
+import com.pocketshell.app.di.WhisperClientFactory
+import com.pocketshell.app.hosts.MainDispatcherRule
+import com.pocketshell.core.voice.WhisperClient
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Issue #1108 — a failed send must NOT silently drop the attachment, so the
+ * reconnect-then-resend still carries the file (#694 regression guard).
+ *
+ * This mirrors the on-device journey locked by
+ * [PromptComposerSendDismissE2eTest.attachThenTypeShowsBothAndFailedSendKeepsAttachmentPaths]
+ * at the JVM/Robolectric level (no emulator) so it runs in the per-push Unit
+ * gate. The E2E variant asserted on the wrong surface — it checked the DRAFT
+ * TEXT for the attachment path, but the #872/#971 composer model keeps the
+ * draft CLEAN and re-shows the attachment as a separate TILE
+ * ([PromptComposerViewModel.UiState.attachments]). The path was never dropped;
+ * it just lives in the tile, not the text. This test asserts the real property:
+ *
+ *  - after a degraded-connection "Not sent", the typed draft AND the attachment
+ *    tile both survive, and
+ *  - the resend STILL carries the attachment (text + tiles), never a silent drop.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class PromptComposerFailedSendAttachmentResendTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val createdViewModels = mutableListOf<PromptComposerViewModel>()
+
+    @After
+    fun tearDown() {
+        createdViewModels.forEach { it.clearForTest() }
+        createdViewModels.clear()
+    }
+
+    private class TestMicCapture : PromptComposerViewModel.MicCapture {
+        override fun start() {}
+        override fun stop(): ByteArray = ByteArray(0)
+        override fun currentAmplitude(): Float = 0f
+    }
+
+    private class TestVault : ApiKeyVault {
+        private var key: CharArray? = "sk-test".toCharArray()
+        override fun save(key: CharArray) { this.key = key.copyOf() }
+        override fun load(): CharArray? = key?.copyOf()
+        override fun clear() { key = null }
+    }
+
+    private class TestVoiceSettings : PromptComposerViewModel.VoiceSettingsSnapshot {
+        override fun silenceWindowMs(): Long = PromptComposerViewModel.SILENCE_WINDOW_MS
+        override fun whisperLanguageHint(): String? = null
+    }
+
+    private fun newViewModel(): PromptComposerViewModel = PromptComposerViewModel(
+        audioRecorder = TestMicCapture(),
+        whisperClientFactory = WhisperClientFactory {
+            object : WhisperClient {
+                override suspend fun transcribe(audio: ByteArray, language: String?): Result<String> =
+                    Result.success("")
+            }
+        },
+        apiKeyStorage = TestVault(),
+        voiceSettings = TestVoiceSettings(),
+        savedStateHandle = SavedStateHandle(),
+    ).also {
+        createdViewModels += it
+        // The overall-send watchdog (#891) is irrelevant here and its long delay
+        // would be drained by runTest's terminal advanceUntilIdle; disable it so
+        // the failed/resend path is driven only by the explicit collector below.
+        it.setSendWatchdogTimeoutForTest(null)
+    }
+
+    @Test
+    fun failedSendKeepsAttachmentTileAndResendStillCarriesIt() = runTest {
+        val attachPath = "~/.pocketshell/attachments/host-1/20260611-report.png"
+        val vm = newViewModel()
+
+        // Attach a single file (no preview — the SAF path the picker callback
+        // takes), then type after it. Both the chip and the typed text survive.
+        vm.attachFiles(count = 1) { Result.success(listOf(attachPath)) }
+        advanceUntilIdle()
+        assertEquals(1, vm.uiState.value.attachments.size)
+        vm.onDraftChange("what is wrong here")
+        assertEquals(1, vm.uiState.value.attachments.size)
+
+        // Host whose send fails on a degraded connection -> restoreFailedSend.
+        // Record every request so the resend assertion can prove the attachment
+        // still travels.
+        val received = mutableListOf<PromptComposerViewModel.SendRequest>()
+        var sendSucceeds = false
+        val collector: Job = launch {
+            vm.sendRequests.collect { request ->
+                received += request
+                if (!sendSucceeds) vm.restoreFailedSend(request)
+            }
+        }
+
+        // First send fails.
+        vm.requestSend(withEnter = true)
+        advanceUntilIdle()
+
+        // #872/#971: the CLEAN typed draft comes back …
+        assertEquals("what is wrong here", vm.uiState.value.draft)
+        assertFalse(vm.uiState.value.sendInFlight)
+        // … and the attachment survives as a TILE (NOT folded into draft text),
+        // so it is not silently dropped (#1108).
+        assertEquals(
+            listOf(attachPath),
+            vm.uiState.value.attachments.map { it.remotePath },
+        )
+        assertTrue(
+            "draft must stay clean — the path lives in the tile, not the text",
+            !vm.uiState.value.draft.contains("20260611-report.png"),
+        )
+
+        // Reconnect: the resend STILL carries the attachment, never a silent drop.
+        sendSucceeds = true
+        vm.requestSend(withEnter = true)
+        advanceUntilIdle()
+        collector.cancel()
+
+        assertEquals(2, received.size)
+        val resend = received.last()
+        assertTrue(
+            "resend text must carry the attachment path",
+            resend.text.contains("20260611-report.png"),
+        )
+        assertEquals(
+            "resend must carry the attachment tile",
+            listOf(attachPath),
+            resend.attachments.map { it.remotePath },
+        )
+    }
+}

--- a/scripts/check-ci-journey-harness.sh
+++ b/scripts/check-ci-journey-harness.sh
@@ -79,7 +79,6 @@ REQUIRED_PER_PUSH_ANDROID_TEST_CLASSES=(
 KNOWN_UNWIRED_ANDROID_E2E_DOCKER_CLASSES=(
   "com.pocketshell.app.composer.AttachmentStagerRealUploadDockerTest"
   "com.pocketshell.app.composer.ComposerPartialExpandE2eTest"
-  "com.pocketshell.app.composer.PromptComposerSendDismissE2eTest"
   "com.pocketshell.app.costs.CostsScreenE2eTest"
   "com.pocketshell.app.crash.ShareAllReportsDockerTest"
   "com.pocketshell.app.env.EnvScreenE2eTest"

--- a/scripts/check-test-validity.sh
+++ b/scripts/check-test-validity.sh
@@ -200,7 +200,6 @@ AWAIT1_BASELINE=(
 J1_UNWIRED_ANDROID_E2E_DOCKER_BASELINE=(
   "com.pocketshell.app.composer.AttachmentStagerRealUploadDockerTest"
   "com.pocketshell.app.composer.ComposerPartialExpandE2eTest"
-  "com.pocketshell.app.composer.PromptComposerSendDismissE2eTest"
   "com.pocketshell.app.costs.CostsScreenE2eTest"
   "com.pocketshell.app.crash.ShareAllReportsDockerTest"
   "com.pocketshell.app.env.EnvScreenE2eTest"

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -318,6 +318,17 @@ JOURNEY_CLASSES=(
   # collector parks on a test-controlled CompletableDeferred), so it does not
   # race a wall-clock timeout. It carries its fully-qualified name directly.
   "com.pocketshell.app.composer.PromptComposerDegradedSendE2eTest"
+  # ADDED (#1108): the composer send/dismiss + ATTACHMENT-on-failed-send journey.
+  # The maintainer hit a "resend loses the file" report (#694 regression): on a
+  # degraded-connection "Not sent" the composer must keep the attachment as a
+  # TILE (the #872/#971 model — the path lives in the tile, NOT folded into the
+  # draft text) so the reconnect-then-resend STILL carries the file. It uses NO
+  # Docker fixture (pure Compose-rule UI test driving the real
+  # PromptComposerViewModel send wiring) and does NOT self-skip on CI, so per the
+  # "load-bearing journeys run at PR time" principle (#638/#691) it runs per-push
+  # and the silent-drop regression cannot return. It lives under
+  # com.pocketshell.app.composer, so it carries its fully-qualified name directly.
+  "com.pocketshell.app.composer.PromptComposerSendDismissE2eTest"
   # ADDED (#848 audit / #900): the foreground outbound queue surface was covered
   # by a connected androidTest but was not in any per-push gate. This pins the
   # visible queued/failed/in-flight composer rows, collapsed count, delete, and


### PR DESCRIPTION
Investigated as 'composer drops attachment on failed send (data loss)' — turned out to be **no production bug**. The E2E test asserted the attachment path on the draft *text*, but the #872/#971 model keeps draft text clean and holds the attachment as a separate *tile* (`restoreFailedSend` retains it; the resend `SendRequest` carries it). The assertion was stale (pre-#872 model).

- Corrected the E2E assertion (tile + clean draft + resend carries path).
- Added gate-wired JVM regression `PromptComposerFailedSendAttachmentResendTest` (proven red→green: breaking retention fails it).
- Wired the journey into `ci-journey-suite.sh` (was unwired) + updated guard baselines.

Zero production change (D33: symptom never occurs). Reviewer **APPROVED** — independently confirmed retention is real (broke `restoreFailedSend` → test failed; restored → passed): https://github.com/alexeygrigorev/pocketshell/issues/1108#issuecomment-4843416395

Closes #1108