### PR TITLE
core-ssh: JVM-safe boot clock — fix PortForwardIntegrationTest 6/6 red on main (#1111)

### DIFF
--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshConnection.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshConnection.kt
@@ -42,6 +42,26 @@ public object SshConnection {
 
     private const val CANCEL_DISCONNECT_TIMEOUT_MS: Long = 2_000L
 
+    /**
+     * Wall-elapsed boot clock for the transport-liveness oracle (#1080 Doze fix):
+     * `SystemClock.elapsedRealtimeNanos()` (`CLOCK_BOOTTIME`) COUNTS deep sleep, so a
+     * socket that died during Doze reads STALE on wake and the existing machinery
+     * redials instead of riding through a dead transport. This is the single
+     * production clock injected at [RealSshConnector.toSession].
+     *
+     * On-device this is ALWAYS the real boot clock — the `runCatching` only catches
+     * the android.jar STUB's `RuntimeException("Stub!")` that `SystemClock` throws in
+     * the forked-JVM integration suite (`core-portfwd:integrationTest` /
+     * `core-ssh` failure tests link the stub, not Robolectric/the emulator). There it
+     * falls back to `System.nanoTime()` so `connect()`/`toSession()` does not die
+     * before any real work runs (#1111). #1080 hard-coded the bare `SystemClock` call
+     * at the construction site, which threw "Stub!" and reddened the Docker integration
+     * job on every push.
+     */
+    internal val bootElapsedNanos: () -> Long = {
+        runCatching { SystemClock.elapsedRealtimeNanos() }.getOrElse { System.nanoTime() }
+    }
+
     private val cancellationCleanupScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     /**
@@ -316,7 +336,7 @@ public object SshConnection {
         fun disconnect(client: C)
     }
 
-    private object RealSshConnector : SshConnector<SSHClient> {
+    internal object RealSshConnector : SshConnector<SSHClient> {
         override fun createClient(): SSHClient = SSHClient(createSshConfig())
 
         override fun applyKnownHostsPolicy(client: SSHClient, policy: KnownHostsPolicy) {
@@ -377,9 +397,11 @@ public object SshConnection {
             // (CLOCK_MONOTONIC) freezes in deep Doze, so after a Doze gap a dead
             // socket looked "alive within the keepalive window" and the restore /
             // handoff ride-through sailed through it instead of redialing. This is
-            // the single production construction site; the unit tests keep the
-            // System.nanoTime default (the android.jar stub can't run SystemClock).
-            RealSshSession(client, nowNanos = { SystemClock.elapsedRealtimeNanos() })
+            // the single production construction site. Issue #1111 — the clock is the
+            // JVM-stub-safe [bootElapsedNanos] (real boot clock on-device; falls back
+            // to System.nanoTime only when the android.jar stub throws "Stub!" in the
+            // forked-JVM integration suite) so `toSession()` never dies pre-work there.
+            RealSshSession(client, nowNanos = bootElapsedNanos)
 
         override fun disconnect(client: SSHClient) {
             client.disconnect()

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/SshConnectionBootClockStubTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/SshConnectionBootClockStubTest.kt
@@ -1,0 +1,110 @@
+package com.pocketshell.core.ssh
+
+import android.os.SystemClock
+import net.schmizz.sshj.SSHClient
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1111 — reproduce-first JVM proof that the production SSH session
+ * construction site survives the forked-JVM android.jar STUB (D33/G10).
+ *
+ * ## The bug
+ *
+ * #1080 (`ef45e95d`) hard-coded the wall-elapsed boot clock at the single session
+ * construction site, [SshConnection.RealSshConnector.toSession]:
+ *
+ * ```
+ * RealSshSession(client, nowNanos = { SystemClock.elapsedRealtimeNanos() })
+ * ```
+ *
+ * [RealSshSession]'s `init` stamps its activity watermarks by CALLING `nowNanos()`
+ * immediately, so constructing the session evaluates `SystemClock`. On-device that
+ * is the real `CLOCK_BOOTTIME` (correct — it must count deep Doze). But in a
+ * forked-JVM test that links the **android.jar STUB** (not Robolectric / the
+ * emulator) — `core-portfwd:integrationTest` and the `core-ssh` failure tests —
+ * `SystemClock.elapsedRealtimeNanos()` throws `RuntimeException("Stub!")`. So the
+ * real `connect()` path (which calls `toSession()` after auth) died with
+ * `SshException at SshConnection.kt:299  Caused by: RuntimeException at
+ * SystemClock.java:-1`, reddening the heavy `Integration tests (Docker)` job
+ * (`PortForwardIntegrationTest` 6/6) on every `main` push.
+ *
+ * ## The fix
+ *
+ * The clock is now the JVM-stub-safe [SshConnection.bootElapsedNanos]:
+ * `runCatching { SystemClock.elapsedRealtimeNanos() }.getOrElse { System.nanoTime() }`.
+ * On-device the `runCatching` never catches anything (the boot clock is real, so the
+ * #1080 Doze contract is intact); only the android.jar stub's `"Stub!"` throw is
+ * caught, falling back to `System.nanoTime()` so the construction site works.
+ *
+ * ## Why this is the real path, not a proxy
+ *
+ * These tests exercise the EXACT production construction site
+ * [SshConnection.RealSshConnector.toSession] under the EXACT failing host-JVM stub
+ * the integration suite runs in. The `[mechanism]` test pins WHY the guard is
+ * needed (the bare stub call throws); the `[toSession]` test is the load-bearing
+ * GREEN assertion — RED on the #1080 base (the unguarded inline call throws while
+ * stamping the watermark in `RealSshSession.init`), GREEN with [bootElapsedNanos].
+ */
+class SshConnectionBootClockStubTest {
+
+    @Test
+    fun `mechanism - the bare SystemClock boot clock throws under the android jar stub`() {
+        // Anchors the root cause: on the host JVM the android.jar stub makes
+        // SystemClock.elapsedRealtimeNanos() throw, which is exactly why the single
+        // construction site must guard it (#1080 hard-coded it bare → #1111 red CI).
+        assertThrows(RuntimeException::class.java) {
+            SystemClock.elapsedRealtimeNanos()
+        }
+    }
+
+    @Test
+    fun `bootElapsedNanos falls back to a real monotonic value instead of throwing`() {
+        // The guarded seam must NEVER throw on the JVM stub, and must return a usable
+        // (positive, monotonic) nanosecond reading from the System.nanoTime fallback.
+        val first = SshConnection.bootElapsedNanos()
+        val second = SshConnection.bootElapsedNanos()
+        assertTrue(
+            "bootElapsedNanos must return a positive nanosecond reading on the JVM stub " +
+                "fallback, got first=$first",
+            first > 0L,
+        )
+        assertTrue(
+            "bootElapsedNanos must be monotonic non-decreasing across calls, " +
+                "got first=$first second=$second",
+            second >= first,
+        )
+    }
+
+    @Test
+    fun `toSession does not throw under the JVM stub - the real construction site`() {
+        // The LOAD-BEARING assertion: building a session at the EXACT production site
+        // (RealSshConnector.toSession, which RealSshSession.init evaluates by calling
+        // nowNanos() to stamp its activity watermarks) must NOT throw under the
+        // android.jar stub. On the #1080 base this throws RuntimeException("Stub!")
+        // (RED); with the bootElapsedNanos guard it returns a live session (GREEN).
+        val session = SshConnection.RealSshConnector.toSession(connectedClient())
+        try {
+            assertNotNull(
+                "toSession() must build a session under the forked-JVM android.jar stub " +
+                    "instead of dying with SystemClock \"Stub!\" — the #1111 regression guard",
+                session,
+            )
+        } finally {
+            session.close()
+        }
+    }
+
+    /**
+     * Minimal connected sshj client: the session construction only stamps activity
+     * watermarks from `nowNanos()` and starts a 30s keepalive loop that never ticks
+     * in this sub-second test. `disconnect()` is a no-op (no real socket).
+     */
+    private fun connectedClient(): SSHClient = object : SSHClient() {
+        override fun isConnected(): Boolean = true
+        override fun isAuthenticated(): Boolean = true
+        override fun disconnect() = Unit
+    }
+}


### PR DESCRIPTION
`PortForwardIntegrationTest` was 6/6 red on main's `Integration tests (Docker)` job: #1080's `SystemClock.elapsedRealtimeNanos()` at the production session-construction site throws "Stub!" in the forked-JVM integration suite (android.jar stub), killing every `connect()`. Port-forwarding is fine on real devices — this is a test-environment gap that red-emails main on every push.

Wrap the boot-clock lambda with `runCatching{...}.getOrElse{ System.nanoTime() }` — on-device the real clock never throws so the #1080 Doze contract is intact; only the JVM stub falls back. Single clean site.

Reviewer **APPROVED** — red→green proven (revert injection → `SshConnectionBootClockStubTest` RED at the stub throw; restore → green), `:shared:core-portfwd:integrationTest` 6/6 GREEN with the fix, full core-ssh 214 tests/0 fail incl `RealSshSessionDozeClockTest` 4/4 (no Doze regression): https://github.com/alexeygrigorev/pocketshell/issues/1111#issuecomment-4843607834

Closes #1111