### PR TITLE
tmux: silent within-grace heal — no spurious 'Attaching…' overlay (#1098 item 4)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -1636,8 +1636,20 @@ public class TmuxSessionViewModel @Inject constructor(
      * reconnect" band ([FailedConnectionRow]) replace the scary error text.
      */
     private fun projectStatusFromController(inlineState: ConnectionState) {
+        val projected = connectionStatusForController(connectionManager.state, inlineState)
         _connectionStatus.value =
-            connectionStatusForController(connectionManager.state, inlineState)
+            if (withinGraceSilentHealInFlight && projected is ConnectionStatus.Reconnecting) {
+                // Issue #1098 (item 4 / #635): the within-grace SILENT heal re-opens the
+                // dropped `-CC` (controller `Reattaching`/`Reconnecting`), but a brief
+                // background→foreground ride-through must read the CALM `Connected` — never
+                // a Reconnecting bar / Connecting overlay. Hold `Connected` (the same
+                // host/port/user payload) for the bounded heal; the heal job's completion
+                // handler clears the flag, after which the live `Live` re-projects naturally
+                // (success) or the normal calm-Reconnecting ladder shows (genuine failure).
+                ConnectionStatus.Connected(projected.host, projected.port, projected.user)
+            } else {
+                projected
+            }
     }
 
     /**
@@ -3176,6 +3188,18 @@ public class TmuxSessionViewModel @Inject constructor(
     private var postGraceHeldForegroundProbeJob: Job? = null
     private var lastSuppressedDropDiagnostic: SuppressedDropDiagnostic? = null
 
+    // Issue #1098 (item 4 / #635): true while the SINGLE-GRACE-OWNER within-grace
+    // SILENT heal of a dropped `-CC` socket is in flight. The heal MUST re-open the
+    // transport (controller `Live -> Reattaching -> Live`), but the user must see the
+    // CALM `Connected` ride-through with NO reconnect surface at all — no top
+    // Reconnecting bar, no "Attaching…" overlay, no disconnect band. While set, the
+    // displayed-status projection ([projectStatusFromController]) holds `Connected`
+    // and the [RevealStateMachine] holds the live frame (see
+    // [RevealStateMachine.setSilentHealInFlight]). Set + cleared together for the
+    // bounded duration of [launchForegroundHealWithinGrace]'s heal job only, so an
+    // unexpected (non-grace) foreground drop keeps its normal calm-Reconnecting band.
+    private var withinGraceSilentHealInFlight: Boolean = false
+
     // EPIC #687 slice 1c-iv-b-B1 (#738): the `preserveConnectingTarget` computed
     // SYNCHRONOUSLY by [detachForBackground] at background time, stashed for the
     // DRIVER-fired teardown ([launchBackgroundDetachTeardown]) to consume. The
@@ -4072,10 +4096,19 @@ public class TmuxSessionViewModel @Inject constructor(
         // ride-through, not a reconnect. Promote the controller back toward Live so the
         // header indicator never shows Reconnecting/Disconnected during the heal.
         connectionManager.observeForegroundReattachLive()
+        // Issue #1098 (item 4 / #635): the within-grace silent heal MUST re-open the
+        // dropped `-CC` transport, which walks the controller `Live -> Reattaching ->
+        // Live`. Without this the [RevealStateMachine] would project that Reattaching as
+        // [RevealState.Seeding] → the screen paints the full-surface "Attaching…" loading
+        // overlay over the live frame (the spurious overlay #635/item-4 reproduces). Hold
+        // the reveal at its current (live) frame for the bounded duration of the heal so
+        // the ride-through stays INVISIBLE; cleared in the job's completion handler below.
+        withinGraceSilentHealInFlight = true
+        revealStateMachine.setSilentHealInFlight(true)
         projectStatusFromController()
         // Issue #935 R1: contained — the within-grace heal re-opens a fresh `-CC`
         // over a fresh lease; a teardown-race throw must not crash the process.
-        launchContainedTeardown {
+        val healJob = launchContainedTeardown {
             // Re-open a fresh `-CC` control client over a freshly-acquired lease and
             // reseed — SILENTLY (the primitive never raises the Connecting overlay or a
             // band; on success it sets [ConnectionStatus.Live] and reseeds every visible
@@ -4104,6 +4137,21 @@ public class TmuxSessionViewModel @Inject constructor(
                     ),
                 )
             }
+        }
+        // Issue #1098 (item 4): release the silent-heal reveal hold once the heal
+        // completes. On success the transport re-promoted the controller to Live, so the
+        // reveal is already a live frame; on failure the calm auto-reconnect ladder takes
+        // over and the next Reconnecting projection may show the normal loading surface.
+        // Cleared in the completion handler (success, failure, OR a teardown-race cancel)
+        // so the hold can never get stuck on, which would freeze the "Attaching…" overlay
+        // suppression across an unrelated later attach.
+        healJob.invokeOnCompletion {
+            withinGraceSilentHealInFlight = false
+            revealStateMachine.setSilentHealInFlight(false)
+            // Re-project so a genuine heal FAILURE (the calm auto-reconnect ladder is now
+            // running) surfaces its normal Reconnecting band the instant the hold lifts,
+            // and a SUCCESS settles on the live `Connected` it already reached.
+            projectStatusFromController()
         }
     }
 

--- a/shared/core-connection/src/main/java/com/pocketshell/core/connection/RevealStateMachine.kt
+++ b/shared/core-connection/src/main/java/com/pocketshell/core/connection/RevealStateMachine.kt
@@ -58,6 +58,34 @@ class RevealStateMachine {
     private var agentName: String? = null
 
     /**
+     * Issue #1098 (item 4 / #635 within-grace ride-through): while the VM is running
+     * the SINGLE-GRACE-OWNER within-grace SILENT heal of a `-CC` socket that dropped
+     * during a brief background, the transport is torn down and re-opened, so the
+     * controller necessarily walks `Live -> Reattaching -> Live`. That is an INVISIBLE
+     * ride-through — the user already has the prior frame on screen and the heal
+     * re-seeds it — so the [ConnectionState.Reattaching]/[ConnectionState.Reconnecting]
+     * projection must NOT drop the reveal to [RevealState.Seeding] (which the screen
+     * renders as the full-surface "Attaching…" loading overlay, hiding the live frame —
+     * the exact #635/item-4 spurious overlay). While this flag is set, a Reattaching/
+     * Reconnecting projection KEEPS the current reveal (a held [RevealState.Live] frame
+     * stays live) instead of resetting to Seeding. The VM sets it for the bounded
+     * duration of the within-grace heal only; every OTHER control-drop heal (an
+     * unexpected foreground drop) keeps the prior calm-loading behaviour
+     * ([ConnectionState.Reattaching] -> [RevealState.Seeding]).
+     */
+    private var silentHealInFlight = false
+
+    /**
+     * Issue #1098 (item 4): mark/unmark a within-grace SILENT heal as in flight. While
+     * in flight, a [ConnectionState.Reattaching]/[ConnectionState.Reconnecting]
+     * projection holds the current reveal (no "Attaching…" overlay) — see
+     * [silentHealInFlight].
+     */
+    fun setSilentHealInFlight(value: Boolean) {
+        silentHealInFlight = value
+    }
+
+    /**
      * Navigation arrived at a (possibly new) target. ALWAYS supersedes whatever is
      * showing: the state is replaced *synchronously* with [RevealState.Navigating]
      * carrying the target name, so the view can never observe an
@@ -118,9 +146,20 @@ class RevealStateMachine {
 
             is ConnectionState.Connecting,
             is ConnectionState.Attaching,
+            -> RevealState.Seeding(target, targetName)
+
             is ConnectionState.Reattaching,
             is ConnectionState.Reconnecting,
-            -> RevealState.Seeding(target, targetName)
+            ->
+                // Issue #1098 (item 4): a within-grace SILENT heal rides through the
+                // transport re-open WITHOUT an "Attaching…" overlay — hold the current
+                // (live) frame. Every other reattach/reconnect keeps the calm-loading
+                // Seeding surface.
+                if (silentHealInFlight) {
+                    _state.value
+                } else {
+                    RevealState.Seeding(target, targetName)
+                }
 
             is ConnectionState.Live ->
                 if (panes.isNotEmpty()) {

--- a/shared/core-connection/src/test/java/com/pocketshell/core/connection/RevealStateMachineTest.kt
+++ b/shared/core-connection/src/test/java/com/pocketshell/core/connection/RevealStateMachineTest.kt
@@ -200,6 +200,60 @@ class RevealStateMachineTest {
         assertEquals("session-A", live.targetName)
     }
 
+    // --- within-grace silent heal rides through WITHOUT an "Attaching…" overlay (#1098 item 4) ---
+
+    @Test
+    fun `within-grace silent heal holds the live frame across Reattaching - no Attaching overlay`() {
+        val m = RevealStateMachine()
+        m.bringLive(a, "session-A")
+        val liveBefore = m.state.value as RevealState.Live
+
+        // The VM marks the within-grace SILENT heal in flight BEFORE the transport
+        // teardown moves the controller off Live (the #635/item-4 ride-through).
+        m.setSilentHealInFlight(true)
+
+        // The silent heal necessarily walks Live -> Reattaching -> (Reconnecting) while it
+        // re-opens the dropped `-CC`. With the heal in flight these MUST NOT drop the reveal
+        // to Seeding (which the screen renders as the full-surface "Attaching…" overlay).
+        m.onConnectionState(ConnectionState.Reattaching(host, a))
+        assertEquals(
+            "within-grace Reattaching must hold the live frame, not show the Attaching overlay",
+            liveBefore,
+            m.state.value,
+        )
+        m.onConnectionState(ConnectionState.Reconnecting(host, a, attempt = 1))
+        assertEquals(
+            "within-grace Reconnecting must hold the live frame, not show the Attaching overlay",
+            liveBefore,
+            m.state.value,
+        )
+
+        // Heal succeeds: the transport re-promotes Live and the reseed lands; reveal is Live.
+        m.onConnectionState(ConnectionState.Live(host, a))
+        m.setSilentHealInFlight(false)
+        assertTrue(m.state.value is RevealState.Live)
+    }
+
+    @Test
+    fun `clearing the silent-heal hold restores the normal Reattaching to Seeding mapping`() {
+        val m = RevealStateMachine()
+        m.bringLive(a, "session-A")
+
+        // Default (no within-grace heal): a control drop shows the calm loading surface —
+        // the existing #685 behavior must be untouched when the hold is not set.
+        m.onConnectionState(ConnectionState.Reattaching(host, a))
+        assertEquals(RevealState.Seeding(a, "session-A"), m.state.value)
+
+        // And after a within-grace heal completes and the hold is cleared, a LATER
+        // unexpected reattach again shows the calm loading surface (the hold cannot get
+        // stuck on).
+        m.onConnectionState(ConnectionState.Live(host, a))
+        m.setSilentHealInFlight(true)
+        m.setSilentHealInFlight(false)
+        m.onConnectionState(ConnectionState.Reattaching(host, a))
+        assertEquals(RevealState.Seeding(a, "session-A"), m.state.value)
+    }
+
     @Test
     fun `exhausted reconnect surfaces honest non-retrying Error`() {
         val m = RevealStateMachine()


### PR DESCRIPTION
Final landable item of the connection cluster. A within-grace socket drop flashed a spurious 'Attaching…' overlay where the D21 grace path should reseed silently — the silent heal re-opens the `-CC` transport (`Live→Reattaching→Live`) and two UI projections surfaced reconnect affordances (`RevealStateMachine` Reattaching→Seeding placeholder; `projectStatusFromController` Reattaching→Reconnecting bar).

Fix: a bounded, grace-scoped 'silent heal in flight' hold — keep the live frame, hold `Connected` for the heal job's duration only (set in `launchForegroundHealWithinGrace`, cleared unconditionally in `invokeOnCompletion`). Masks **only** `Reconnecting`, so a genuine disconnect band and a real beyond-grace reconnect still surface. Flag defaults false (no change outside the heal window).

Reviewer **APPROVED** — connected red→green (`expected:<0> but was:<1>` overlay gone; live frame `ISSUE635-SOCKETDROP-READY` restored, no band), #638 adjacency 8/8 (genuine reconnect still repaints), single-owner hold can't swallow a real reconnect, `:app:testDebugUnitTest` 3202/0-fail: https://github.com/alexeygrigorev/pocketshell/issues/1098#issuecomment-4843615258

Note: items 3 (dead-host fixture) and 7 (orphan -CC vs #1021 live-hold) flagged for maintainer D28 decision — not in this PR.

Refs #1098