### PR TITLE
projects: instant cached folder-tree render without a Main-thread read (#1109)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/projects/FolderListViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListViewModel.kt
@@ -749,13 +749,17 @@ class FolderListViewModel internal constructor(
     private var hydrateTreeJob: Job? = null
 
     /**
-     * Issue #965: the OFF-Main client-cache seed coroutine for this open (the
-     * read + JSON parse + advisory hydrate). The cold-start reconcile path awaits
-     * it so the instant cache paint lands BEFORE the freshening reconcile — the
-     * stale-while-revalidate ordering (#867) the synchronous-on-Main seed used to
-     * give implicitly, now preserved explicitly across the dispatcher hop.
+     * Issue #1109: the OFF-Main client-cache read coroutine for the cold-MISS
+     * fallback only (the in-memory snapshot was not warmed in time, so [bind]'s
+     * synchronous [peek][TreeClientCache.peek] missed). It reads + parses the file
+     * OFF Main, then hydrates the held tree + emits the advisory paint — the #965
+     * off-Main behaviour, used only on a miss. The cold-start reconcile path awaits
+     * it so the advisory paint lands BEFORE the freshening reconcile (the #867
+     * stale-while-revalidate ordering). `null`/already-completed on the common
+     * warm-hit path (the seed already painted synchronously inside `bind`).
      */
     private var clientCacheSeedJob: Job? = null
+
     @androidx.annotation.VisibleForTesting
     internal var warmLeaseAcquiredForTest: (() -> Unit)? = null
     @androidx.annotation.VisibleForTesting
@@ -958,6 +962,18 @@ class FolderListViewModel internal constructor(
                 if (started) maybeReconcileOnResume()
             }
         }
+        // Issue #1109: pre-warm the per-host PARSED client-cache snapshots into
+        // memory OFF Main, so by the time the user navigates in and [bind] runs its
+        // SYNCHRONOUS seed, [TreeClientCache.peek] hits without a Main-thread file
+        // read + JSON parse (the #965 ANR cause). This runs at VM construction — one
+        // composition + LaunchedEffect ahead of `bind` — so the warm normally wins
+        // the race and the cold connect paints instantly; if it loses, `bind` falls
+        // back to the brief Loading + the off-Main read (never a Main-thread read).
+        treeClientCache?.let { cache ->
+            viewModelScope.launch(ioDispatcher) {
+                runCatching { cache.warmAll() }
+            }
+        }
         if (attachLifecycle) attachProcessLifecycle()
     }
 
@@ -1158,15 +1174,27 @@ class FolderListViewModel internal constructor(
         // diff, no rebuild), and [HostTreeModel.hydrate] skips clobbering an
         // already-populated tree — so a stale cache entry can never survive past
         // the first refresh (#679 stale-type guard, D22).
-        // Issue #965 (ANR off-Main): show the brief Loading IMMEDIATELY on Main,
-        // then read + JSON-parse the per-host client cache OFF Main and hydrate
-        // the held tree. The previous code did the file read + full `JSONObject`
-        // parse SYNCHRONOUSLY on Main inside bind() (a StrictMode disk_read on the
-        // Main thread) — at 71 projects / 12 sessions that parse, stacked with the
-        // projection + first composition, crossed the ANR bar. The cache is still
-        // ADVISORY: the silent reconcile below overwrites the seeded placeholders.
-        _state.value = loadingState()
-        hydrateFromClientCache(params)
+        // Issue #1109 (regression of the #867 instant-render promise) + #965 (ANR
+        // off-Main): hydrate the per-host CLIENT cache + emit Ready SYNCHRONOUSLY on
+        // the calling (Main) thread so the FIRST painted frame on a cold connect is
+        // already the cached tree — NO visible Loading rebuild flash. #965 had moved
+        // the cache read OFF Main, which (with the StateFlow starting at `Loading()`)
+        // meant the screen always composed the empty Loading frame first and only
+        // flipped to Ready a couple of async hops later — the exact flash the
+        // maintainer re-reported. The fix DECOUPLES the parse from the hydrate: the
+        // expensive file read + JSON parse run OFF Main (warmed into [TreeClientCache]'s
+        // in-memory snapshot by the init pre-warm + each reconcile's `write`), so the
+        // synchronous seed below reads the ALREADY-PARSED snapshot via [peek] with NO
+        // Main-thread `disk_read` (the #965 ANR cause stays gone — see
+        // [FolderListScaleAnrStrictModeDockerTest]). On a genuine cold MISS (the
+        // snapshot was not warmed in time) the seed returns false and we fall back to
+        // the brief Loading + an OFF-Main read, never a Main-thread file read. The
+        // cache stays ADVISORY: the silent reconcile overwrites the seeded
+        // placeholders in place.
+        if (!hydrateFromClientCache(params)) {
+            _state.value = loadingState()
+            warmFromClientCacheOffMain(params)
+        }
         // The maintained in-memory tree is held across opens of the SAME host
         // (so a re-open renders instantly), the daemon registry (#837) makes the
         // presentation state durable host-side, and this client cache makes the
@@ -1812,10 +1840,12 @@ class FolderListViewModel internal constructor(
     private fun hydrateTreeOnColdStart(params: BoundParams) {
         val source = treeRemoteSource
         if (source == null) {
-            // No durable source (unit tests / never-installed daemon): await the
-            // OFF-Main client-cache seed (#965) so its advisory instant paint
-            // lands BEFORE the freshening reconcile (the #867 stale-while-
-            // revalidate ordering), then reconcile.
+            // No durable source (unit tests / never-installed daemon): on the common
+            // warm-HIT path the synchronous client-cache seed (#1109) already painted
+            // the advisory instant tree within bind(), so [clientCacheSeedJob] is null
+            // and this falls straight through. On a cold MISS it awaits the OFF-Main
+            // seed (#965) so its advisory paint lands BEFORE the freshening reconcile
+            // (the #867 stale-while-revalidate ordering), then reconciles.
             viewModelScope.launch {
                 clientCacheSeedJob?.join()
                 if (bound != params) return@launch
@@ -1825,8 +1855,9 @@ class FolderListViewModel internal constructor(
         }
         hydrateTreeJob?.cancel()
         hydrateTreeJob = viewModelScope.launch {
-            // Issue #965: await the OFF-Main client-cache seed so its advisory
-            // paint precedes the durable hydrate + freshening reconcile.
+            // On a cold MISS await the OFF-Main client-cache seed so its advisory
+            // paint precedes the durable hydrate + freshening reconcile (#965/#867);
+            // null/already-complete on the synchronous warm-hit path (#1109).
             clientCacheSeedJob?.join()
             if (bound != params) return@launch
             // Foreground-gated, mirroring the reconcile path (D21-clean).
@@ -1887,21 +1918,60 @@ class FolderListViewModel internal constructor(
     }
 
     /**
-     * Issue #867 (stale-while-revalidate) + #965 (ANR off-Main): seed the held
-     * tree from the per-host CLIENT cache so a cold start paints the last-known
-     * tree quickly.
+     * Issue #867 (stale-while-revalidate) + #1109 (instant-render restore) + #965
+     * (ANR off-Main): seed the held tree from the per-host CLIENT cache and emit
+     * Ready SYNCHRONOUSLY on the calling (Main) thread, so a cold connect's FIRST
+     * painted frame is already the last-known tree — NO Loading flash. Returns
+     * `true` when a WARMED snapshot seeded a non-empty tree (the caller then skips
+     * the Loading emit) and `false` on a cold MISS (the snapshot was not warmed in
+     * time / no cache yet) — the caller then shows the brief Loading and reads OFF
+     * Main via [warmFromClientCacheOffMain].
      *
-     * The expensive part — the file read + full `JSONObject` parse — runs OFF
-     * Main on [ioDispatcher]. The previous implementation read + parsed the cache
-     * SYNCHRONOUSLY on the Main thread inside `bind()` (a StrictMode-flagged
-     * `disk_read` on Main); at 71 projects / 12 sessions that parse, stacked with
-     * the projection and the first composition, was a dominant contributor to the
-     * folder-list ANR. The cheap structural hydrate of the parsed result happens
-     * back on Main (consistent with every other tree mutation) and `emitReady`
-     * then runs the projection off-Main. If the host changed while the read was
-     * in flight, the stale result is dropped.
+     * ## How it is synchronous WITHOUT a Main-thread `disk_read` (the #965 fix held)
+     *
+     * The expensive part — the file read + full `JSONObject` parse — is DECOUPLED
+     * from the hydrate. It runs OFF Main (the init pre-warm [TreeClientCache.warmAll]
+     * + each reconcile's [persistClientCache] write) into [TreeClientCache]'s
+     * in-memory PARSED snapshot. This method reads that already-parsed snapshot via
+     * [TreeClientCache.peek] — a pure in-memory lookup, NO disk I/O — and hydrates +
+     * projects it inline. So Main does ZERO file reads here (the StrictMode tripwire
+     * in [FolderListScaleAnrStrictModeDockerTest] stays green at 71/12 scale), yet
+     * the seed is fully synchronous (the instant render in
+     * [FolderListClientCacheInstantRenderDockerTest] stays green). The one-time inline
+     * `buildFolderTree` projection is bounded and the row VIRTUALIZATION restored by
+     * #965 keeps the first composition cheap; the REPEATED reconcile-driven emits
+     * still run the projection off Main (see [emitReady]).
+     *
+     * The cache stays ADVISORY: [HostTreeModel.hydrate]/[hydrateStructure]
+     * self-guard against clobbering an already-populated (fresher, authoritative)
+     * tree, and the silent reconcile overwrites the seeded placeholders + the
+     * structural maps wholesale, so a stale cache entry can never survive the
+     * first refresh (#679 stale-type guard, D22).
      */
-    private fun hydrateFromClientCache(params: BoundParams) {
+    private fun hydrateFromClientCache(params: BoundParams): Boolean {
+        val cache = treeClientCache ?: return false
+        // SYNCHRONOUS, NO disk I/O on Main: the in-memory parsed snapshot only.
+        val cached = cache.peek(params.hostName) ?: return false
+        if (cached.isEmpty) return false
+        if (!applyCachedTree(cached)) return false
+        // Render the seeded order / placement / collapse + grouping INLINE — the
+        // held shape on the FIRST frame, no empty-rebuild flash. The confirmed
+        // kinds + the authoritative session set arrive with the first reconcile
+        // and update in place.
+        emitReady(synchronous = true)
+        return true
+    }
+
+    /**
+     * Issue #1109 cold-MISS fallback (the #965 off-Main path): the in-memory snapshot
+     * was not warmed before [bind] ran, so read + parse the per-host cache file OFF
+     * Main on [ioDispatcher], then hydrate the held tree + emit the advisory paint.
+     * Used ONLY on a [hydrateFromClientCache] miss — never on Main. The cold-start
+     * reconcile path joins [clientCacheSeedJob] so this advisory paint precedes the
+     * freshening reconcile (the #867 stale-while-revalidate ordering). A stale read
+     * (host changed mid-flight) is dropped.
+     */
+    private fun warmFromClientCacheOffMain(params: BoundParams) {
         val cache = treeClientCache ?: return
         clientCacheSeedJob?.cancel()
         clientCacheSeedJob = viewModelScope.launch {
@@ -1909,47 +1979,47 @@ class FolderListViewModel internal constructor(
                 runCatching { cache.read(params.hostName) }
                     .getOrDefault(TreeClientCache.CachedTree(nodes = emptyList()))
             }
-            // Drop a stale read if the host changed while we were reading the file.
             if (bound != params) return@launch
             if (cached.isEmpty) return@launch
-            // A reconcile/hydrate may have populated the tree while the read was in
-            // flight — [HostTreeModel.hydrate]/[hydrateStructure] self-guard against
-            // clobbering an already-populated (fresher, authoritative) tree, so the
-            // seed below is a no-op in that case and `emitReady` simply re-paints
-            // the held shape.
-            // Issue #867 (REOPEN): seed the watched-root overlay + the structural
-            // maps the grouping needs BEFORE the per-session hydrate's emit, so
-            // the cold-start frame shows the SETTLED tree — sessions bucketed
-            // under their watched root, the project subfolders + counts visible —
-            // not "0 projects" with everything dumped into "Other folders". The
-            // authoritative Room `project_roots` Flow overwrites the seeded
-            // watched folders the moment it emits (advisory), and the first
-            // reconcile overwrites the structural maps wholesale.
-            if (cached.watchedFolders.isNotEmpty()) {
-                tree.setWatchedFolders(cached.watchedFolders)
-            }
-            // Hydrate the per-session nodes FIRST (populates `sessionFolderPaths`),
-            // then the structure — so [HostTreeModel.hydrateStructure]'s
-            // sticky-bucket seed sees the sessions and can place them under their
-            // root by id.
-            tree.hydrate(cached.nodes.map { it.toHydratedNode() })
-            tree.hydrateStructure(
-                resolvedWatchedRootPaths = cached.resolvedWatchedRootPaths,
-                scannedProjectFoldersByRoot = cached.scannedProjectFoldersByRoot,
-                historyProjectFoldersByRoot = cached.historyProjectFoldersByRoot,
-            )
-            if (!tree.hasSnapshot) return@launch
-            // Render the seeded order / placement / collapse + grouping — the held
-            // shape, no empty-rebuild grouping. The confirmed kinds arrive with
-            // the first reconcile and update in place. AWAIT the (off-Main)
-            // projection so the advisory paint is on screen BEFORE this seed job
-            // completes — the cold-start reconcile path joins this job, so this is
-            // what guarantees the instant cache paint precedes the freshening
-            // reconcile (the #867 stale-while-revalidate ordering, preserved
-            // across the #965 dispatcher hop).
+            if (!applyCachedTree(cached)) return@launch
+            // AWAIT the (off-Main) projection so the advisory paint is on screen
+            // BEFORE this seed job completes — the cold-start reconcile path joins
+            // this job, so this is what preserves the #867 ordering across the hop.
             emitReady()
             emitJob?.join()
         }
+    }
+
+    /**
+     * Hydrate the held tree from a (warmed or freshly-read) [TreeClientCache.CachedTree]
+     * — the watched-root overlay + the structural maps + the per-session nodes.
+     * Shared by the synchronous seed ([hydrateFromClientCache]) and the off-Main
+     * cold-miss fallback ([warmFromClientCacheOffMain]). Pure in-memory tree
+     * mutation (no I/O), so it is safe on either thread. Returns whether the tree now
+     * has a renderable snapshot.
+     */
+    private fun applyCachedTree(cached: TreeClientCache.CachedTree): Boolean {
+        // Issue #867 (REOPEN): seed the watched-root overlay + the structural maps
+        // the grouping needs BEFORE the per-session hydrate's emit, so the
+        // cold-start frame shows the SETTLED tree — sessions bucketed under their
+        // watched root, the project subfolders + counts visible — not "0 projects"
+        // with everything dumped into "Other folders". The authoritative Room
+        // `project_roots` Flow overwrites the seeded watched folders the moment it
+        // emits (advisory), and the first reconcile overwrites the structural maps
+        // wholesale.
+        if (cached.watchedFolders.isNotEmpty()) {
+            tree.setWatchedFolders(cached.watchedFolders)
+        }
+        // Hydrate the per-session nodes FIRST (populates `sessionFolderPaths`),
+        // then the structure — so [HostTreeModel.hydrateStructure]'s sticky-bucket
+        // seed sees the sessions and can place them under their root by id.
+        tree.hydrate(cached.nodes.map { it.toHydratedNode() })
+        tree.hydrateStructure(
+            resolvedWatchedRootPaths = cached.resolvedWatchedRootPaths,
+            scannedProjectFoldersByRoot = cached.scannedProjectFoldersByRoot,
+            historyProjectFoldersByRoot = cached.historyProjectFoldersByRoot,
+        )
+        return tree.hasSnapshot
     }
 
     /**
@@ -2677,7 +2747,7 @@ class FolderListViewModel internal constructor(
      * the legacy rebuild used — but order, expansion, and node identity are now
      * intrinsic to the held tree (no per-emit re-derivation, no flash).
      */
-    private fun emitReady() {
+    private fun emitReady(synchronous: Boolean = false) {
         if (bound == null) return
         if (!tree.hasSnapshot) return
         // Issue #965 (ANR off-Main): take a CHEAP immutable snapshot of the held
@@ -2690,6 +2760,18 @@ class FolderListViewModel internal constructor(
         val snapshot = tree.snapshotForProjection()
         val generation = ++emitGeneration
         val refreshing = sessionRefreshInFlight
+        if (synchronous) {
+            // Issue #1109: the cold-start client-cache seed projects + emits Ready
+            // INLINE on the calling (Main) thread so the FIRST painted frame is the
+            // cached tree (no Loading flash). One-time per connect and bounded by
+            // the cached tree size; with the folder-list row virtualization (#965)
+            // in place this cannot reintroduce the ANR. The repeated reconcile-
+            // driven emits below still run the projection OFF Main.
+            val result = HostTreeModel.buildProjection(snapshot)
+            if (generation != emitGeneration || bound == null) return
+            applyReadyProjection(result, refreshing)
+            return
+        }
         emitJob = viewModelScope.launch {
             val result = withContext(treeDispatcher) {
                 HostTreeModel.buildProjection(snapshot)
@@ -2697,18 +2779,31 @@ class FolderListViewModel internal constructor(
             // A newer emit superseded this one (or the host changed) — drop it so
             // an out-of-order older projection can't clobber fresher state.
             if (generation != emitGeneration || bound == null) return@launch
-            tree.applyProjection(result)
-            val projection = result.projection
-            _state.value = FolderListUiState.Ready(
-                folders = projection.folders,
-                treeRoots = projection.treeRoots,
-                flatSessions = projection.flatSessions,
-                expandedProjectPaths = projection.expandedProjectPaths,
-                isRefreshing = refreshing,
-                isCreatingSession = createSessionInFlight,
-                portForwarding = forwardingSummary(),
-            )
+            applyReadyProjection(result, refreshing)
         }
+    }
+
+    /**
+     * Apply a freshly-built [HostTreeModel.ProjectionResult] to the held tree and
+     * publish the [FolderListUiState.Ready] state. Shared by the synchronous
+     * cold-start seed ([hydrateFromClientCache]) and the off-Main reconcile-driven
+     * emit ([emitReady]). Must run on Main (it writes [_state]).
+     */
+    private fun applyReadyProjection(
+        result: HostTreeModel.ProjectionResult,
+        refreshing: Boolean,
+    ) {
+        tree.applyProjection(result)
+        val projection = result.projection
+        _state.value = FolderListUiState.Ready(
+            folders = projection.folders,
+            treeRoots = projection.treeRoots,
+            flatSessions = projection.flatSessions,
+            expandedProjectPaths = projection.expandedProjectPaths,
+            isRefreshing = refreshing,
+            isCreatingSession = createSessionInFlight,
+            portForwarding = forwardingSummary(),
+        )
     }
 
     private fun setCreateSessionInFlight(inFlight: Boolean) {

--- a/app/src/main/java/com/pocketshell/app/projects/TreeClientCache.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/TreeClientCache.kt
@@ -6,7 +6,9 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import org.json.JSONArray
 import org.json.JSONObject
 import java.io.File
+import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
+import javax.inject.Singleton
 
 /**
  * Issue #867: the per-host CLIENT-SIDE cold cache of the last-rendered project
@@ -68,7 +70,25 @@ import javax.inject.Inject
  * sanitised host name. Synchronous, tiny reads/writes on a background
  * dispatcher; any IO failure degrades to "no cache" (the screen falls back to
  * the brief Loading exactly as before) and is never surfaced to the user.
+ *
+ * ## Issue #1109 — an in-memory PARSED snapshot so the seed never reads disk on Main
+ *
+ * The cold-connect instant render needs the cached tree SYNCHRONOUSLY inside
+ * [FolderListViewModel.bind] (the first painted frame must already be Ready, or the
+ * empty rebuild flashes). But the file read + full `JSONObject` parse is exactly the
+ * Main-thread `disk_read` that produced the #965 folder-list ANR at scale (71
+ * projects / 12 sessions). The two are reconciled by DECOUPLING the parse from the
+ * hydrate: every persisted snapshot is also held PARSED in an in-memory map, keyed
+ * by the same sanitised host. [peek] reads that map SYNCHRONOUSLY with NO disk I/O —
+ * so `bind` hydrates instantly and Main never reads the file. The map is populated
+ * OFF Main by [warmAll] (the cold-start pre-warm) and synchronously by [write]
+ * (which already holds the parsed tree, so the just-rendered snapshot is hot for the
+ * rest of the process). A genuine cold MISS (the entry was not warmed in time) is
+ * the caller's signal to fall back to the brief Loading and read OFF Main via [read]
+ * — never a Main-thread file read. This is why the type is `@Singleton`: one
+ * process-wide parsed map shared across every [FolderListViewModel] instance.
  */
+@Singleton
 public class TreeClientCache @Inject constructor(
     @ApplicationContext private val context: Context,
 ) {
@@ -76,6 +96,15 @@ public class TreeClientCache @Inject constructor(
     private val cacheDir: File by lazy {
         File(context.filesDir, CACHE_DIR_NAME).apply { mkdirs() }
     }
+
+    /**
+     * Issue #1109: the in-memory PARSED snapshot per host (keyed by the sanitised
+     * host name, the same key the file uses). [peek] returns from here SYNCHRONOUSLY
+     * with no disk I/O; [write] keeps it hot; [warmAll]/[read] populate it OFF Main.
+     * Concurrent because the off-Main warm/read and the on-Main `peek` touch it from
+     * different threads.
+     */
+    private val parsed = ConcurrentHashMap<String, CachedTree>()
 
     /**
      * The full advisory presentation snapshot persisted for one host: the
@@ -93,19 +122,52 @@ public class TreeClientCache @Inject constructor(
     }
 
     /**
-     * Read the cached snapshot for [host] (the cold-start instant-seed read).
-     * Returns an empty [CachedTree] when there is no cache yet, or on any
-     * IO/parse failure — both collapse to "no instant seed", and the caller
-     * shows the brief Loading until the first reconcile, exactly as before the
-     * cache.
+     * Issue #1109: the SYNCHRONOUS, NO-DISK-I/O peek used by the cold-connect
+     * instant seed ([FolderListViewModel.hydrateFromClientCache]). Returns the
+     * in-memory parsed snapshot for [host] if it has been warmed (by [warmAll] or a
+     * prior [write]/[read]), or `null` if it has not — the caller's signal to fall
+     * back to the brief Loading and read OFF Main via [read]. Safe to call on the
+     * Main thread: it only touches the in-memory map.
+     */
+    public fun peek(host: String): CachedTree? = parsed[sanitise(host)]
+
+    /**
+     * Read the cached snapshot for [host] (the OFF-Main cold-miss / warm read).
+     * Returns the in-memory snapshot if already warmed, otherwise reads + parses the
+     * file and caches it, or an empty [CachedTree] when there is no cache yet / on
+     * any IO/parse failure. This DOES touch disk on a miss, so it must run off the
+     * Main thread; the Main-thread seed uses [peek] instead (issue #1109 / #965).
      */
     public fun read(host: String): CachedTree {
+        val key = sanitise(host)
+        parsed[key]?.let { return it }
         val file = fileFor(host)
         if (!file.exists()) return EMPTY
         return try {
-            parse(file.readText(), hostId = host)
+            val tree = parse(file.readText(), hostId = host)
+            // Cache the parse, but never clobber a snapshot a concurrent [write]
+            // already landed (the write is the authoritative just-rendered tree).
+            if (!tree.isEmpty) parsed.putIfAbsent(key, tree)
+            parsed[key] ?: tree
         } catch (_: Throwable) {
             EMPTY
+        }
+    }
+
+    /**
+     * Issue #1109: warm the in-memory parsed snapshot from every persisted host file
+     * so the FIRST cold connect's [peek] hits without a Main-thread read. Best-effort
+     * and OFF Main (a few small JSON files); a missing/corrupt file just stays a cold
+     * miss. Never clobbers an entry a [write] already landed (`putIfAbsent`).
+     */
+    public fun warmAll() {
+        val files = runCatching { cacheDir.listFiles() }.getOrNull() ?: return
+        for (file in files) {
+            if (!file.isFile || !file.name.endsWith(".json")) continue
+            val key = file.name.removeSuffix(".json")
+            if (parsed.containsKey(key)) continue
+            val tree = runCatching { parse(file.readText(), hostId = key) }.getOrNull() ?: continue
+            if (!tree.isEmpty) parsed.putIfAbsent(key, tree)
         }
     }
 
@@ -117,6 +179,15 @@ public class TreeClientCache @Inject constructor(
      * memory; the next write re-persists).
      */
     public fun write(host: String, tree: CachedTree) {
+        val key = sanitise(host)
+        // Issue #1109: keep the in-memory parsed snapshot hot with the just-rendered
+        // tree so the NEXT cold connect of this host in the same process [peek]s it
+        // synchronously (no Main-thread re-read). An empty tree evicts the entry.
+        if (tree.isEmpty) {
+            parsed.remove(key)
+        } else {
+            parsed[key] = tree
+        }
         val file = fileFor(host)
         try {
             if (tree.isEmpty) {
@@ -125,7 +196,8 @@ public class TreeClientCache @Inject constructor(
             }
             file.writeText(serialise(tree))
         } catch (_: Throwable) {
-            // Best-effort cache; a failed write is a no-op.
+            // Best-effort cache; a failed write is a no-op (the in-memory snapshot
+            // above is still correct; the next write re-persists).
         }
     }
 

--- a/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelClientCacheTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelClientCacheTest.kt
@@ -96,7 +96,7 @@ class FolderListViewModelClientCacheTest {
     // ---- GREEN: cold start WITH a populated cache renders the held tree -------
 
     @Test
-    fun coldStartWithCacheRendersHeldTreeAfterOffMainRead() = runTest {
+    fun coldStartWithCacheRendersHeldTreeInstantlyNoLoadingFlash() = runTest {
         val cache = newCache()
         // The PREVIOUS app session left a settled tree in the client cache.
         writeNodes(
@@ -109,22 +109,121 @@ class FolderListViewModelClientCacheTest {
 
         bind(vm)
 
-        // Issue #965 (ANR off-Main): the per-host cache file read + JSON parse now
-        // run OFF the Main thread (they were a StrictMode-flagged Main-thread
-        // `disk_read` inside bind() before — a dominant contributor to the
-        // 71-project folder ANR). So the cold start shows the brief Loading on
-        // Main, then paints the cached held tree the instant the OFF-Main read
-        // completes. After draining the (virtual-time) dispatcher the held shape
-        // is rendered, carrying the cached sessions in order — not the empty
-        // 'Other folders' rebuild.
+        // Issue #1109 (regression of the #867 instant-render promise): with a
+        // populated client cache the cold connect paints the held tree
+        // SYNCHRONOUSLY inside bind() — the FIRST state read (before any coroutine
+        // runs / before runCurrent) is already Ready, so the screen never composes
+        // the empty Loading frame. #965 had moved the read + projection OFF Main,
+        // which made the cold connect always flash Loading first; this is the
+        // load-bearing fast-gate proof that the flash is gone. RED on #965's
+        // off-Main code (this is Loading until runCurrent), GREEN with the
+        // synchronous seed.
+        val first = vm.state.value
+        assertTrue(
+            "cold connect must render the cached tree INSTANTLY (Ready, not the " +
+                "Loading rebuild flash) — got $first",
+            first is FolderListUiState.Ready,
+        )
+        assertEquals(
+            "the cached sessions paint in order on the FIRST frame",
+            listOf("alpha", "beta"),
+            (first as FolderListUiState.Ready).flatSessions.map { it.sessionName },
+        )
+
+        // The silent reconcile then keeps the instantly-rendered tree authoritative
+        // against the live probe (advisory cache) — still the same sessions here.
+        runCurrent()
+        val reconciled = vm.state.value
+        assertTrue(reconciled is FolderListUiState.Ready)
+        assertEquals(
+            listOf("alpha", "beta"),
+            (reconciled as FolderListUiState.Ready).flatSessions.map { it.sessionName },
+        )
+    }
+
+    // ---- Issue #1109: the parse is DECOUPLED from the synchronous hydrate --------
+
+    /**
+     * Issue #1109 (the #965-regression guard): [TreeClientCache.peek] — the lookup
+     * the SYNCHRONOUS cold-connect seed uses inside `bind` — is a pure IN-MEMORY
+     * read that does NO file read + JSON parse. A FRESH cache instance (the cold
+     * app-restart case: the file is on disk but memory is cold) MISSES on `peek`
+     * until [TreeClientCache.warmAll] has parsed the file OFF Main; only then does
+     * `peek` hit. This is what lets `bind` paint synchronously without the
+     * Main-thread `disk_read` that produced the #965 ANR — proven directly at the
+     * cache seam, independent of the VM.
+     */
+    @Test
+    fun peekIsInMemoryOnly_missesUntilWarmedThenHitsFromDisk() {
+        val writer = newCache()
+        writer.write(
+            HOST.name,
+            TreeClientCache.CachedTree(
+                nodes = listOf(node("alpha", 0, folderPath("alpha"))),
+            ),
+        )
+
+        // A fresh instance = a new process: the snapshot is on DISK but its parsed
+        // in-memory map is cold. `peek` does NOT read the file, so it misses.
+        val reader = newCache()
+        assertEquals(
+            "peek must be in-memory only — a fresh (un-warmed) instance has no Main-" +
+                "thread read, so it MISSES the on-disk snapshot",
+            null,
+            reader.peek(HOST.name),
+        )
+
+        // The OFF-Main warm parses the file into memory; now (and only now) peek hits.
+        reader.warmAll()
+        val warmed = reader.peek(HOST.name)
+        assertTrue("warmAll must parse the on-disk snapshot into memory", warmed != null)
+        assertEquals(
+            listOf("alpha"),
+            warmed!!.nodes.map { it.session },
+        )
+    }
+
+    /**
+     * Issue #1109 cold-MISS fallback: when the in-memory snapshot was NOT warmed
+     * before `bind` (a brand-new cache instance, file on disk, cold memory), the
+     * synchronous seed MISSES, so the first frame is the brief Loading and the cache
+     * is read OFF Main — NOT on the Main thread inside `bind`. After the off-Main
+     * read drains, the held tree paints. This pins the graceful fallback the
+     * reviewer required (the seed never blocks Main on a miss).
+     */
+    @Test
+    fun coldStartCacheMiss_readsOffMainThenPaintsHeldTree() = runTest {
+        // Write via one instance (disk + that instance's memory), then bind a VM with
+        // a DIFFERENT, cold-memory instance — the file is on disk but un-warmed.
+        newCache().write(
+            HOST.name,
+            TreeClientCache.CachedTree(
+                nodes = listOf(node("gamma", 0, folderPath("gamma"))),
+            ),
+        )
+        val coldCache = newCache()
+        val gateway = StubGateway(listOf(sessionRow("gamma")))
+        val vm = newViewModel(gateway, coldCache)
+
+        bind(vm)
+        // SYNCHRONOUSLY after bind (before any coroutine runs): the cold-memory
+        // instance misses the in-memory peek, so the seed does NOT read the file on
+        // Main — the first frame is the brief Loading.
+        assertTrue(
+            "a cold-memory cache miss must fall back to Loading (no Main-thread " +
+                "file read in bind) — got ${vm.state.value}",
+            vm.state.value is FolderListUiState.Loading,
+        )
+
+        // The OFF-Main warm + read then paint the held tree.
         runCurrent()
         val ready = vm.state.value
         assertTrue(
-            "with a populated client cache the off-Main read paints the held tree",
+            "the off-Main read paints the held tree — got $ready",
             ready is FolderListUiState.Ready,
         )
         assertEquals(
-            listOf("alpha", "beta"),
+            listOf("gamma"),
             (ready as FolderListUiState.Ready).flatSessions.map { it.sessionName },
         )
     }
@@ -323,18 +422,15 @@ class FolderListViewModelClientCacheTest {
         val gateway = StubGateway(rows = null)
         val vm = newViewModel(gateway, cache, watchedRoots = listOf(watchedRoot("git", gitRoot)))
 
-        val states = collectStates(vm)
         bind(vm)
-        runCurrent()
 
-        // Issue #965 (ANR off-Main): the cache read is OFF Main, so bind first
-        // emits the brief Loading then the seeded Ready once the read completes.
-        // The FIRST Ready (the cache-seeded instant render) shows the GROUPED
-        // tree — the "git" watched root with its project subfolders and the two
-        // sessions bucketed UNDER it, NOT a flat list dumped into "Other folders"
-        // with "0 projects".
-        val ready = states.filterIsInstance<FolderListUiState.Ready>().firstOrNull()
-            ?: error("cold start must paint Ready from the off-Main cache read, got $states")
+        // Issue #1109: the cache seed is SYNCHRONOUS, so the FIRST state read
+        // (before any coroutine runs) is already the cache-seeded Ready — the
+        // GROUPED tree, no Loading flash. The "git" watched root paints with its
+        // project subfolders and the two sessions bucketed UNDER it, NOT a flat
+        // list dumped into "Other folders" with "0 projects".
+        val ready = vm.state.value as? FolderListUiState.Ready
+            ?: error("cold start must paint the cached grouped tree INSTANTLY, got ${vm.state.value}")
         val gitTreeRoot = ready.treeRoots.firstOrNull { it.path == gitRoot }
             ?: error(
                 "the cached 'git' watched root must paint instantly with its grouping; " +


### PR DESCRIPTION
Cold connect flashed Loading before the cached tree (#965 made the seed async). Round-1 made it synchronous but reintroduced the #965 ANR (file read + 71-project parse on Main in `bind()`). 

Fix: decouple parse from hydrate. `TreeClientCache` is `@Singleton` with a per-host in-memory parsed snapshot; `bind()`'s synchronous seed reads it via `peek()` — pure in-memory lookup, no disk I/O — so cold connect paints Ready instantly with **zero Main-thread read**. read+parse runs off-Main (warmAll from init + each reconcile's write); a genuine cold miss falls back to brief Loading + off-Main read.

Reviewer **APPROVED** (after catching+rejecting the round-1 ANR) — BOTH gates green: `FolderListClientCacheInstantRenderDockerTest` (instant, no flash, reconcile converges) and the #965 `FolderListScaleAnrStrictModeDockerTest` (disk_read=0 on Main at 71 projects/12 sessions); JVM 10/10 incl 2 new class-coverage tests proving `peek` is in-memory-only: https://github.com/alexeygrigorev/pocketshell/issues/1109#issuecomment-4844115926

Closes #1109