### PR TITLE
core-terminal: fix stop() deadlock (on-device ANR + 3h release-gate wedge) (#1117)

### DIFF
--- a/shared/core-terminal/build.gradle.kts
+++ b/shared/core-terminal/build.gradle.kts
@@ -33,6 +33,19 @@ android {
         minSdk = 26
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
+        // Gate hardening (v0.4.19 release-gate hang): AndroidJUnitRunner applies
+        // `timeout_msec` as a PER-TEST timeout, so a single wedged connected test
+        // FAILS FAST instead of consuming the whole stage budget. The v0.4.19
+        // pre-release confidence gate stage [12] (this module's
+        // connectedDebugAndroidTest) wedged the entire 3h ceiling THREE times when
+        // one test deadlocked at ~9/45 — none of the heavy proof tests here carry
+        // their own @Test(timeout), so there was no backstop. 180 s is far above
+        // the slowest legitimate test in this suite (the #796 keyboard-up burst is
+        // a 6 s burst + settle; ~tens of seconds worst case on a contended
+        // swiftshader emulator) yet turns a future hang into a ~3 min failure
+        // instead of a 3 h gate wedge.
+        testInstrumentationRunnerArguments["timeout_msec"] = "180000"
+
         // Issue #9: a stub `libtermux.so` ships in the AAR so the vendored
         // `com.termux.terminal.JNI` static initializer (`System.loadLibrary`)
         // does not throw `UnsatisfiedLinkError`. Limit the ABIs to the

--- a/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/bridge/SshTerminalBridge.kt
+++ b/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/bridge/SshTerminalBridge.kt
@@ -761,6 +761,25 @@ public class SshTerminalBridge(
         // Issue #803: drop any scheduled main-looper drain turn so a torn-down
         // session leaves no posted runnable behind.
         drainScheduler.cancel()
+        // Release a producer that is BLOCKED inside [feedChunks] ->
+        // writeProcessToTerminalQueue (ByteQueue.write) on a FULL process->terminal
+        // queue BEFORE we take [feedLock] below. Such a producer holds [feedLock]
+        // (locked at the top of [feedChunks]) and is parked in ByteQueue.write's
+        // `wait()` for the main-looper drain we JUST cancelled — so the queue can
+        // no longer make room, and without this the `synchronized(feedLock)` below
+        // would block the caller FOREVER. That is the v0.4.19 release-gate hang:
+        // the :shared:core-terminal connected suite wedged the whole 3h ceiling at
+        // ~9/45 when CodexOutputBurstImeMainThreadProofTest's teardown called
+        // stop() while its %output-burst producer was still blocked on a full
+        // queue. On-device this is worse than a hung test: stop() also runs on the
+        // MAIN thread (detachCompletedExternalProducer uses Dispatchers.Main.immediate
+        // when a producer flow completes), so the same race ANRs the app. Closing
+        // the output queue flips ByteQueue.mOpen=false + notify(), so the blocked
+        // write returns `false`; the producer then unwinds out of [feedChunks]
+        // (`if (!written) return`) and releases [feedLock]. No-op / safe when no
+        // producer is blocked — teardown discards any unparsed tail either way
+        // (drainScheduler.cancel() above already stopped draining it).
+        SessionReflection.closeProcessToTerminalQueue(session)
         // Issue #866: drop any in-flight seed tail so the torn-down session leaves
         // no pending pump work. The pump turn itself guards on stopped.get() and
         // returns early; clearing the FIFO frees the retained byte arrays.
@@ -1167,6 +1186,21 @@ private object SessionReflection {
 
     fun closeTerminalToProcessQueue(session: TerminalSession) {
         val queue = mTerminalToProcessIOQueueField.get(session)
+        byteQueueCloseMethod.invoke(queue)
+    }
+
+    /**
+     * Close the session's "incoming from PTY" (process->terminal) queue. Flips
+     * `ByteQueue.mOpen=false` + `notify()`, which wakes a producer thread BLOCKED
+     * in `ByteQueue.write` on a full queue: its blocked write returns `false`
+     * (the closed-before contract) so the producer can unwind out of
+     * [SshTerminalBridge.feedChunks] and release [SshTerminalBridge.feedLock].
+     * Called by [SshTerminalBridge.stop] so a torn-down bridge can never deadlock
+     * the caller (or ANR the main thread) waiting on [feedLock] held by a producer
+     * stranded on a no-longer-draining full queue.
+     */
+    fun closeProcessToTerminalQueue(session: TerminalSession) {
+        val queue = mProcessToTerminalIOQueueField.get(session)
         byteQueueCloseMethod.invoke(queue)
     }
 

--- a/shared/core-terminal/src/test/java/com/pocketshell/core/terminal/bridge/SshTerminalBridgeTest.kt
+++ b/shared/core-terminal/src/test/java/com/pocketshell/core/terminal/bridge/SshTerminalBridgeTest.kt
@@ -80,6 +80,88 @@ class SshTerminalBridgeTest {
         }
     }
 
+    /**
+     * Regression for the v0.4.19 release-gate HANG: the :shared:core-terminal
+     * connected suite wedged the 3h ceiling at ~9/45 because
+     * `CodexOutputBurstImeMainThreadProofTest.shellPaneStillRunsAffordanceScanners`'s
+     * teardown ([TerminalSurfaceState.detachExternalProducer] -> [SshTerminalBridge.stop])
+     * deadlocked: its `%output`-burst producer coroutine was BLOCKED inside
+     * `feedChunks` -> writeProcessToTerminalQueue (ByteQueue.write) on a FULL
+     * process->terminal queue, holding `feedLock`; `stop()` first cancelled the
+     * only main-looper drain turn (so the queue could never make room) and THEN
+     * tried to take `feedLock` -> it waited on the blocked producer forever, and
+     * the producer waited on a drain that would never run. A thread dump from the
+     * wedged emulator process confirmed exactly this: the Instr test thread blocked
+     * in `SshTerminalBridge.stop` "waiting to lock <feedLock> held by" the producer
+     * worker, which was parked in `ByteQueue.write` on the full queue, while the
+     * MAIN thread sat idle in `nativePollOnce` (no drain pending).
+     *
+     * This reproduces it WITHOUT an emulator: under the PAUSED Robolectric looper
+     * the posted drain never runs unless we pump it, so a >64 KB feed on a worker
+     * thread blocks in `ByteQueue.write` holding `feedLock` — the identical
+     * precondition. We then call `stop()` on its own thread and require it to
+     * COMPLETE (it must unblock the producer by closing the output queue) rather
+     * than hang. On the pre-fix `stop()` the stop thread stays blocked on
+     * `feedLock` forever -> `join(5s)` leaves it alive -> RED. With the fix
+     * (`stop()` closes the process->terminal queue before taking `feedLock`) the
+     * blocked write returns `false`, the producer releases `feedLock`, and `stop()`
+     * returns promptly -> GREEN. The outer `@Test(timeout)` is a backstop only; the
+     * load-bearing signal is the `stopThread.isAlive` assertion, which fails fast.
+     */
+    @Test(timeout = 30_000)
+    fun stopUnblocksProducerBlockedOnFullQueueInsteadOfDeadlocking() {
+        val bridge = SshTerminalBridge(
+            columns = LINE_LENGTH,
+            rows = 24,
+            transcriptRows = 1_000,
+        )
+        val payload = largePayload()
+        val executor = Executors.newSingleThreadExecutor { runnable ->
+            Thread(runnable, "SshTerminalBridgeBlockedProducer").apply { isDaemon = true }
+        }
+        val feed = executor.submit { bridge.feedBytes(payload.bytes) }
+        try {
+            // Deliberately DO NOT pump the PAUSED main looper: the queue fills and
+            // the producer blocks in ByteQueue.write holding `feedLock` — the exact
+            // deadlock precondition observed on the wedged emulator.
+            Thread.sleep(300)
+            assertFalse(
+                "producer must be BLOCKED on the full process->terminal queue (holding " +
+                    "feedLock) for this to reproduce the stop() deadlock; it completed early",
+                feed.isDone,
+            )
+
+            // stop() must NOT deadlock on `feedLock`: it has to release the blocked
+            // producer first (by closing the output queue). Run it off the test
+            // thread and bound the wait so a deadlock FAILS FAST instead of hanging.
+            val stopThread = Thread({ bridge.stop() }, "SshTerminalBridgeStop").apply {
+                isDaemon = true
+                start()
+            }
+            stopThread.join(5_000)
+            assertFalse(
+                "stop() DEADLOCKED: it waited on feedLock held by a producer blocked on a " +
+                    "full, no-longer-draining process->terminal queue (the v0.4.19 release-gate " +
+                    "hang). stop() must close the output queue to release the producer before " +
+                    "taking feedLock.",
+                stopThread.isAlive,
+            )
+
+            // And the producer must actually have been released (its blocked write
+            // returned false on close), so no wedged producer leaks past teardown.
+            val producerReleasedDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+            while (!feed.isDone && System.nanoTime() < producerReleasedDeadline) {
+                Thread.sleep(10)
+            }
+            assertTrue(
+                "the blocked producer must unwind once stop() closes the output queue",
+                feed.isDone,
+            )
+        } finally {
+            executor.shutdownNow()
+        }
+    }
+
     @Test(timeout = 5_000)
     fun feedBytesOnMainLooperDrainsLargePayloadWithoutDeadlockOrLoss() {
         assertEquals(Looper.getMainLooper(), Looper.myLooper())


### PR DESCRIPTION
**Release blocker + real on-device ANR.** `SshTerminalBridge.stop()` cancelled the drain scheduler then took `feedLock`, while the producer held `feedLock` parked in `ByteQueue.write`'s uninterruptible native `Object.wait` on a full, no-longer-draining queue → deadlock forever. `detachCompletedExternalProducer()` calls `stop()` on `Dispatchers.Main.immediate` → on-device app ANR; in CI it wedged `:shared:core-terminal:connectedDebugAndroidTest` at ~10/45 and burned the 3h release-validation budget (3 runs).

Fix: `stop()` closes the process→terminal queue (`close()` does `mOpen=false`+`notify()`, waking the parked writer to release the lock) BEFORE taking `feedLock`. Plus `timeout_msec=180000` in the module defaultConfig so a future wedge fails fast.

Full connected suite now **45/45 in ~1m16s** (was a 3h wedge).

Reviewer **APPROVED** — red→green proven (revert → JVM deadlock test fails at :142; restore → green), lock-ordering verified against `ByteQueue` (single parked writer, notify reaches it, idempotent, null-safe reflection), 45/45 on-device, #866 seed proof still green, 180s timeout safe vs slowest test 8.37s: https://github.com/alexeygrigorev/pocketshell/issues/1117#issuecomment-4846284940

Closes #1117