### PR TITLE
tmux: surface 'Disconnected from' on genuine reconnect exhaustion (#1098 item 3)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/BackgroundResumeSocketDeathE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/BackgroundResumeSocketDeathE2eTest.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.ViewModelProvider
 import androidx.room.Room
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -20,7 +21,10 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.pocketshell.app.MainActivity
 import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
 import com.pocketshell.app.hosts.SshKeyStorage
+import com.pocketshell.app.tmux.TMUX_SESSION_ERROR_TAG
+import com.pocketshell.app.tmux.TMUX_SESSION_RECONNECT_TAG
 import com.pocketshell.app.tmux.TMUX_SESSION_SCREEN_TAG
+import com.pocketshell.app.tmux.TmuxSessionViewModel
 import com.pocketshell.core.ssh.KnownHostsPolicy
 import com.pocketshell.core.ssh.SshConnection
 import com.pocketshell.core.ssh.SshKey
@@ -39,28 +43,33 @@ import java.io.File
 import java.io.FileOutputStream
 
 /**
- * Issue #173 — regression test for the v0.2.7 crash on resume after a
- * pause-only lifecycle transition.
+ * Issue #173 / #1098 (item 3) — regression test for the crash-on-resume AND the
+ * "frozen-but-live screen on a genuinely DEAD host" symptom, on the deterministic
+ * Docker `agents` fixture.
  *
- * Reproduces the user-reported sequence on the deterministic Docker `agents`
- * fixture:
+ * Reproduces the user-reported sequence:
  *
  *  1. Attach to a seeded tmux session through the normal app journey
  *     (host picker -> session picker -> Attach), proving the live
  *     control channel + per-pane TerminalView is in place.
- *  2. Send a marker command to confirm the wire is alive end-to-end.
- *  3. `ActivityScenario.moveToState(Lifecycle.State.STARTED)` to mimic a
- *     pause-only interruption (e.g. a transient overlay) while keeping the
- *     process foregrounded.
- *  4. From a sidecar SSH session, identify the sshd worker process that
- *     belongs to the app's tmux-CC connection and `kill -9` it. This
- *     reproduces the kernel-side ECONNABORTED ("Software caused connection
- *     abort") that sshj's `Reader.run` blocking `SocketInputStream.read`
- *     observes when Android (or any peer) tears down the TCP socket while
- *     a read is in flight. Killing the remote sshd is the closest
- *     deterministic local trigger to what Android did to the user.
- *  5. `ActivityScenario.moveToState(Lifecycle.State.RESUMED)` to mimic the
- *     user returning from the interruption.
+ *  2. Confirm the wire is alive end-to-end (visible terminal text).
+ *  3. ARM the genuinely-unrecoverable-host seam
+ *     ([TmuxSessionViewModel.forceUnrecoverableHostForTest]) + compress the
+ *     reconnect timings. This is the #1098-item-3 fixture for the maintainer's
+ *     real symptom: a kill-the-worker-only fixture leaves the sshd LISTENER up, so
+ *     the items-1+2 silent fresh-transport re-dial RECOVERS (the calm ride-through
+ *     — round-3 finding) and no band ever surfaces. The seam makes BOTH the
+ *     silent-reattach grace loop AND the auto-reconnect ladder's fresh dial
+ *     fail-fast, modelling a host that is truly gone, so the bounded ladder
+ *     genuinely EXHAUSTS.
+ *  4. `moveToState(Lifecycle.State.STARTED)` to mimic a pause-only interruption
+ *     while keeping the process foregrounded.
+ *  5. From a sidecar SSH session, identify the sshd worker that belongs to the
+ *     app's tmux-CC connection and `kill -9` it — the real kernel-side
+ *     ECONNABORTED sshj's `Reader.run` observes on the device (the #173 real
+ *     SSHException). With the seam armed every recovery attempt fails, so the
+ *     drop is genuinely unrecoverable instead of silently healing.
+ *  6. `moveToState(Lifecycle.State.RESUMED)` to mimic the user returning.
  *
  * Note: this intentionally does not move to [Lifecycle.State.CREATED].
  * The issue #235 production behavior auto-detaches tmux `-CC` clients on
@@ -71,19 +80,15 @@ import java.io.FileOutputStream
  *
  * Acceptance:
  *
- *  - The activity must still be alive after resume (no crash; no
- *    `Thread.UncaughtExceptionHandler` was driven). Without the fix the
- *    SSHException from `Reader.run` escapes the StandaloneCoroutine that
- *    owns `stdout.collect` in [TerminalSurfaceState.attachExternalProducer]
- *    and crashes the app exactly the way the maintainer reported on the
- *    Pixel 7a / Android 16 device.
- *  - The visible Compose tree must show a "Disconnected from ..." status
- *    line so the user can see the failure instead of staring at a frozen
- *    terminal. [TmuxSessionScreen] renders a `FailedConnectionRow` for
- *    `ConnectionStatus.Failed`; we assert the text contains the
- *    "Disconnected from" marker the TmuxSessionViewModel writes in its
- *    `attachClient` `client.disconnected` observer (unified by #145
- *    round-3 across the previous "connection lost: ..." wording).
+ *  - The activity must still be alive after resume (no crash; the #173 contract).
+ *  - On GENUINE ladder exhaustion the visible Compose tree must show the
+ *    disconnect band ([TMUX_SESSION_ERROR_TAG] `FailedConnectionRow` + a
+ *    "Tap to reconnect" affordance) whose message reads the unified #145
+ *    "Disconnected from <user>@<host>:<port>." wording — so the user sees a clear
+ *    disconnected indicator instead of a frozen-but-live terminal.
+ *  - NO false-alarm permanence: once the host is reachable again (seam disarmed)
+ *    tapping Reconnect recovers the SAME session — proving the band is the honest,
+ *    recoverable error and the fix did not turn a recoverable blip into a dead end.
  *
  * Artifact contract (see process.md "Terminal Artifact Review"):
  *
@@ -91,7 +96,7 @@ import java.io.FileOutputStream
  *    the tmux session attached cleanly before the test broke the socket.
  *  - `issue173-02-after-resume-viewport.png` +
  *    `-visible-terminal.txt` — proof the app survived the resume with no
- *    crash.
+ *    crash, with the disconnect band surfaced.
  *  - `timings.txt` — pause-to-kill, kill-to-resume, resume-to-failed-status
  *    timings so a reviewer can tell apart "responsiveness regressed" from
  *    "didn't crash but UI never updated".
@@ -99,7 +104,12 @@ import java.io.FileOutputStream
 @RunWith(AndroidJUnit4::class)
 class BackgroundResumeSocketDeathE2eTest {
 
+    // The #173 reproduction needs MANUAL ActivityScenario lifecycle control (moveToState
+    // STARTED -> kill -> RESUMED) to drive the pause-only socket-death sequence;
+    // createAndroidComposeRule<MainActivity>() owns the launch and cannot drive that
+    // pause/resume cycle, so the manual ActivityScenario harness is required here.
     @get:Rule
+    // JOURNEY_HARNESS_JUSTIFIED: #173 pause/resume needs manual ActivityScenario (above).
     val compose = createEmptyComposeRule()
 
     // Issue #470 blocker #1: grant runtime permissions before the activity
@@ -139,6 +149,8 @@ class BackgroundResumeSocketDeathE2eTest {
         }
 
         val hostRowTag = seedDockerHost(key)
+        // JOURNEY_HARNESS_JUSTIFIED: manual ActivityScenario is required for the #173
+        // pause -> kill -> resume lifecycle sequence (see the class-level rule comment).
         launchedActivity = ActivityScenario.launch(MainActivity::class.java)
 
         // ---- (1) Tap host, then attach to the seeded session.
@@ -168,7 +180,20 @@ class BackgroundResumeSocketDeathE2eTest {
             initialTerminal.isNotBlank(),
         )
 
-        // ---- (3) Snapshot the sshd PIDs again. Any new PID compared to
+        // ---- (3) ARM the genuinely-unrecoverable-host fixture + compress the
+        // reconnect timings (issue #1098 item 3). Without this, the kill-the-worker
+        // step below leaves the sshd LISTENER up, so the items-1+2 silent fresh-
+        // transport re-dial RECOVERS (calm ride-through) and no band ever surfaces
+        // — the round-3 finding that the app is RIGHT but the fixture can't enter the
+        // failing state. The seam makes BOTH the silent-reattach grace loop and the
+        // auto-reconnect ladder's fresh dial fail-fast, so the bounded ladder
+        // genuinely exhausts to the honest "Disconnected from …" band. The compressed
+        // grace/ladder timings keep that exhaustion inside the test budget (production
+        // keeps the 60s grace / backoff defaults).
+        setUnrecoverableHostForTest(true)
+        setReconnectTimingForTest()
+
+        // ---- (4) Snapshot the sshd PIDs again. Any new PID compared to
         // [baselineSshdPids] is the app's tmux-CC connection.
         val attachedPids = listSshdPidsForTestuser(key)
         val appSshdPids = attachedPids - baselineSshdPids
@@ -178,7 +203,7 @@ class BackgroundResumeSocketDeathE2eTest {
             appSshdPids.isNotEmpty(),
         )
 
-        // ---- (4) Pause the activity without stopping the process.
+        // ---- (5) Pause the activity without stopping the process.
         // Moving to CREATED would now trigger the issue #235
         // ProcessLifecycleOwner.ON_STOP auto-detach path, intentionally
         // closing the tmux control socket before this test can kill it.
@@ -189,7 +214,7 @@ class BackgroundResumeSocketDeathE2eTest {
         delay(LIFECYCLE_DRAIN_MS)
         recordTiming("pause_drain_ms", SystemClock.elapsedRealtime() - pausedAt)
 
-        // ---- (5) Kill the app's sshd worker from a sidecar SSH session.
+        // ---- (6) Kill the app's sshd worker from a sidecar SSH session.
         // The Docker testuser is non-root, so we can only kill processes
         // we own — sshd worker processes are owned by the logged-in user,
         // which is exactly what we want. `kill -9` causes the TCP socket
@@ -207,14 +232,14 @@ class BackgroundResumeSocketDeathE2eTest {
         // ConnectionStatus.Failed transition.
         delay(POST_KILL_DRAIN_MS)
 
-        // ---- (6) Resume. Without the fix, the crashed coroutine's
+        // ---- (7) Resume. Without the fix, the crashed coroutine's
         // exception would have already triggered the uncaught-exception
         // handler and the ActivityScenario would now be DESTROYED.
         val resumeAt = SystemClock.elapsedRealtime()
         launchedActivity?.moveToState(Lifecycle.State.RESUMED)
         recordTiming("resume_drain_ms", SystemClock.elapsedRealtime() - resumeAt)
 
-        // ---- (7) Assert: no crash. The activity must still exist and be
+        // ---- (8) Assert: no crash. The activity must still exist and be
         // navigable. Reaching findTerminalView via onActivity proves the
         // scenario is still alive.
         var activityAlive = false
@@ -227,20 +252,20 @@ class BackgroundResumeSocketDeathE2eTest {
             activityAlive,
         )
 
-        // ---- (8) Assert: the user sees a clear "connection lost" state.
-        // [TmuxSessionViewModel] flips _connectionStatus to Failed on
-        // eventsJob completion with cause; [TmuxSessionScreen] renders a
-        // StatusLine for the Failed branch. We poll for the canonical
-        // marker substring.
+        // ---- (9) Assert: on GENUINE ladder exhaustion the user sees the disconnect
+        // BAND — the rendered [TMUX_SESSION_ERROR_TAG] FailedConnectionRow + the
+        // "Tap to reconnect" affordance — and its message is the unified #145
+        // "Disconnected from …" wording. This is the user-visible contract: a clear
+        // disconnected indicator instead of a frozen-but-live terminal. (Asserting the
+        // rendered band tag is the robust contract; the "Disconnected from" wording is
+        // the maintainer's requested clarity. Both are checked.)
         val failedDeadline = SystemClock.elapsedRealtime() + FAILED_STATUS_TIMEOUT_MS
-        var failedVisible = false
+        var bandVisible = false
         while (SystemClock.elapsedRealtime() < failedDeadline) {
-            failedVisible = compose.onAllNodesWithText(
-                CONNECTION_LOST_MARKER,
-                substring = true,
-                useUnmergedTree = true,
-            ).fetchSemanticsNodes().isNotEmpty()
-            if (failedVisible) break
+            bandVisible = compose.onAllNodesWithTag(TMUX_SESSION_ERROR_TAG, useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+            if (bandVisible) break
             SystemClock.sleep(100)
         }
         recordTiming(
@@ -249,13 +274,71 @@ class BackgroundResumeSocketDeathE2eTest {
         )
         captureViewport("issue173-02-after-resume")
         assertTrue(
-            "expected `$CONNECTION_LOST_MARKER` (or similar) status line within ${FAILED_STATUS_TIMEOUT_MS}ms of resume; " +
-                "the fix should route the SSHException via flow termination -> Failed connection state",
-            failedVisible,
+            "expected the disconnect band ([$TMUX_SESSION_ERROR_TAG] FailedConnectionRow) within " +
+                "${FAILED_STATUS_TIMEOUT_MS}ms of resume; the fix should route the genuine ladder " +
+                "exhaustion -> Failed connection state -> disconnect band",
+            bandVisible,
+        )
+        val disconnectMarkerVisible = compose.onAllNodesWithText(
+            CONNECTION_LOST_MARKER,
+            substring = true,
+            useUnmergedTree = true,
+        ).fetchSemanticsNodes().isNotEmpty()
+        assertTrue(
+            "expected the disconnect band message to contain `$CONNECTION_LOST_MARKER` " +
+                "(the unified #145 wording) so the user sees a clear disconnected indicator",
+            disconnectMarkerVisible,
+        )
+
+        // ---- (10) NO false-alarm permanence: the band is the HONEST, recoverable
+        // error — not a dead end. Disarm the unrecoverable seam (the host is reachable
+        // again — the listener was always up) and tap Reconnect; the SAME session must
+        // recover and the band must clear. This is the adjacency guarantee that the fix
+        // surfaces the band ONLY on genuine exhaustion and a recoverable host still heals.
+        setUnrecoverableHostForTest(false)
+        val reconnectAt = SystemClock.elapsedRealtime()
+        compose.onNodeWithTag(TMUX_SESSION_RECONNECT_TAG, useUnmergedTree = true).performClick()
+        val recovered = runCatching {
+            compose.waitUntil(timeoutMillis = RECOVER_TIMEOUT_MS) {
+                compose.onAllNodesWithTag(TMUX_SESSION_ERROR_TAG, useUnmergedTree = true)
+                    .fetchSemanticsNodes()
+                    .isEmpty()
+            }
+            true
+        }.getOrDefault(false)
+        recordTiming("reconnect_recover_ms", SystemClock.elapsedRealtime() - reconnectAt)
+        assertTrue(
+            "expected the SAME session to recover (band cleared) within ${RECOVER_TIMEOUT_MS}ms of " +
+                "tapping Reconnect once the host is reachable again — the disconnect band must be a " +
+                "recoverable honest error, not a permanent dead end (no false-alarm regression)",
+            recovered,
         )
 
         writeTimings()
         Unit
+    }
+
+    /** Arm/disarm the genuinely-unrecoverable-host seam on the live VM (main thread). */
+    private fun setUnrecoverableHostForTest(value: Boolean) {
+        launchedActivity?.onActivity { activity ->
+            ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+                .forceUnrecoverableHostForTest = value
+        }
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+    }
+
+    /** Compress the passive-disconnect grace + auto-reconnect ladder so a genuine
+     *  exhaustion lands inside the test budget. Production keeps its defaults. */
+    private fun setReconnectTimingForTest() {
+        launchedActivity?.onActivity { activity ->
+            val vm = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+            vm.setPassiveDisconnectRecoveryForTest(
+                graceMs = GRACE_MS,
+                silentReattachTimeoutMs = REATTACH_TIMEOUT_MS,
+            )
+            vm.setAutoReconnectDelaysForTest(listOf(0L, 0L, 0L, 0L))
+        }
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
     }
 
     // ---------------------------------------------------------------- Helpers
@@ -530,14 +613,13 @@ class BackgroundResumeSocketDeathE2eTest {
 
         /**
          * Substring rendered by [TmuxSessionViewModel] in the Failed
-         * connection-status message. Issue #145 unified the disconnect
-         * wording across `client.disconnected` observer paths to read
-         * `"Disconnected from <user>@<host>:<port>. Tap Reconnect to
-         * retry."` so this marker matches that prefix. The old
-         * `"connection lost: tmux control channel closed"` wording was
-         * replaced because the new one is actionable (the user knows
-         * to tap Reconnect) while still being scope-faithful to the
-         * #173 regression: the user sees a Failed status, not a crash.
+         * connection-status (disconnect band) message. Issue #145 unified the
+         * disconnect wording to `"Disconnected from <user>@<host>:<port>. Tap
+         * Reconnect to retry."`; issue #1098 item 3 restores that unified wording on
+         * the genuine auto-reconnect-ladder exhaustion path (it had regressed to the
+         * jargon-y "Transport EOF …; reconnecting. Auto reconnect failed after N
+         * attempts."). The user sees a clear, actionable disconnected indicator
+         * instead of a frozen-but-live terminal.
          */
         const val CONNECTION_LOST_MARKER: String = "Disconnected from"
 
@@ -558,14 +640,29 @@ class BackgroundResumeSocketDeathE2eTest {
         const val POST_KILL_DRAIN_MS: Long = 2_000L
 
         /**
-         * Ceiling on how long we wait after resume for the
-         * ConnectionStatus.Failed StatusLine to become visible. The
-         * eventsJob.invokeOnCompletion handler runs synchronously when
-         * the flow ends, so the state should flip immediately and
-         * Compose recomposition lands within a frame; 5 s leaves
-         * generous head-room for the lifecycle resume path on a CI
-         * emulator.
+         * Compressed passive-disconnect grace window (issue #1098 item 3). Must
+         * EXCEED nothing in particular — with the unrecoverable seam armed every
+         * re-dial fails fast, so the grace loop bounds itself here and then hands off
+         * to the auto-reconnect ladder. Kept a few seconds so the genuine exhaustion
+         * lands well inside [FAILED_STATUS_TIMEOUT_MS]. Production keeps the 60s default.
          */
-        const val FAILED_STATUS_TIMEOUT_MS: Long = 5_000L
+        val GRACE_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 3_000L else 2_000L
+
+        /** Per-attempt reattach timeout — short so each failed re-dial returns fast. */
+        const val REATTACH_TIMEOUT_MS: Long = 2_000L
+
+        /**
+         * Ceiling on how long we wait after resume for the disconnect band to become
+         * visible. The grace loop (≤[GRACE_MS]) + the four-rung ladder (all failing
+         * fast against the unrecoverable seam) settle well within this window; the
+         * generous CI value absorbs swiftshader scheduling jitter.
+         */
+        val FAILED_STATUS_TIMEOUT_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 30_000L else 20_000L
+
+        /** Ceiling on the post-disarm Reconnect recovery (the SAME session heals). */
+        val RECOVER_TIMEOUT_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 45_000L else 30_000L
     }
 }

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -1189,6 +1189,29 @@ public class TmuxSessionViewModel @Inject constructor(
     internal var forceCleanOutageForTest: Boolean = false
 
     /**
+     * Issue #1098 (item 3) test seam (#780 synthetic-injection model): when set, the
+     * host is GENUINELY UNRECOVERABLE — every bounded reattach/reconnect attempt fails
+     * for the whole window, modelling a host that is truly gone (sshd dead / port
+     * blackholed / a network cut that stays cut past the reconnect ladder's bound). It
+     * makes BOTH the silent-reattach grace-loop primitives ([silentlyReattachAfterPassiveDisconnect]
+     * / [silentlyReconnectTransportAfterPassiveDisconnect]) AND the auto-reconnect ladder's
+     * fresh-dial ([runConnect] on a reconnect trigger) fail-fast, so the bounded ladder
+     * genuinely EXHAUSTS and the controller reaches the honest [ConnectionState.Unreachable]
+     * → the visible "Disconnected from …" band.
+     *
+     * Unlike [forceCleanOutageForTest] (a RECOVERABLE outage that clears so the SAME
+     * session auto-recovers silently — the items-1+2 calm ride-through), this seam stays
+     * armed: it reproduces the maintainer's "frozen-but-live screen on a DEAD host"
+     * symptom that a kill-the-worker-only fixture cannot, because there the sshd LISTENER
+     * stays up so the fresh-transport re-dial recovers (the round-3 finding). The cold
+     * OPEN (a non-reconnect trigger) is left alone so the test's initial attach still
+     * succeeds. Production never sets it (default false). `@Volatile` so the grace-loop /
+     * reconnect coroutines see the flip from the instrumentation thread.
+     */
+    @Volatile
+    internal var forceUnrecoverableHostForTest: Boolean = false
+
+    /**
      * Issue #959 test seam (#780 synthetic-injection model): when set, the
      * background teardown ([closeCurrentConnectionAndJoin]) closes the live `-CC`
      * client but PRESERVES the pane runtime — `paneRows`, their `TerminalSurfaceState`s,
@@ -5939,6 +5962,18 @@ public class TmuxSessionViewModel @Inject constructor(
         lastConnectFailureCause = null
         lastSuppressedDropDiagnostic = null
         try {
+            // Issue #1098 item 3 test seam: a GENUINELY-unrecoverable host fails every
+            // fresh-dial of the auto-reconnect ladder (a reconnect trigger), so the
+            // bounded ladder exhausts and the honest "Disconnected from …" band
+            // surfaces — modelling sshd dead / port blackholed / a network cut that
+            // stays cut. The cold OPEN (a non-reconnect trigger) is left alone so the
+            // test's initial attach still succeeds. Production never arms it; the throw
+            // routes through the same `catch` a real connection-refused does.
+            if (forceUnrecoverableHostForTest && trigger.isReconnectTrigger) {
+                throw IOException(
+                    "synthetic unrecoverable host: connection refused (issue #1098 item 3 test seam)",
+                )
+            }
             val lease = acquireLeaseForTmux(target, attempt, trigger, startedAtMs)
                 ?: return
             val session = lease.session
@@ -7987,7 +8022,9 @@ public class TmuxSessionViewModel @Inject constructor(
         // EPIC #792 #833 test seam: while a synthetic clean outage is armed, every
         // reattach fails as if the link were down — so the grace loop must keep
         // re-dialling until the outage clears (see [forceCleanOutageForTest]).
-        if (forceCleanOutageForTest) return false
+        // Issue #1098 item 3: a GENUINELY-unrecoverable host fails this primitive for
+        // the whole window so the ladder exhausts instead of recovering.
+        if (forceCleanOutageForTest || forceUnrecoverableHostForTest) return false
         val session = sessionRef?.takeIf { it.isConnected } ?: return false
         val startedAtMs = SystemClock.elapsedRealtime()
         val replacement = createTmuxClient(
@@ -8185,7 +8222,9 @@ public class TmuxSessionViewModel @Inject constructor(
         // rest of the grace window. The resilient loop must keep RE-DIALLING a fresh
         // transport until the outage clears (see [forceCleanOutageForTest]).
         // Production never arms it.
-        if (forceCleanOutageForTest) {
+        // Issue #1098 item 3: a GENUINELY-unrecoverable host fails the fresh-transport
+        // re-dial too, so the bounded ladder exhausts to the honest Unreachable band.
+        if (forceCleanOutageForTest || forceUnrecoverableHostForTest) {
             sessionRef = null
             leaseRef = null
             return false
@@ -8772,9 +8811,17 @@ public class TmuxSessionViewModel @Inject constructor(
             }
             connectingTarget = target
             refreshReconnectAvailability()
+            // Issue #1098 item 3 / #145: once the bounded auto-reconnect ladder
+            // genuinely EXHAUSTS against an unreachable host, surface the CLEAR,
+            // unified "Disconnected from <user>@<host>:<port>. Tap Reconnect to retry."
+            // band — never the jargon-y, self-contradictory "Transport EOF …;
+            // reconnecting. Auto reconnect failed after N attempts." The cause is
+            // captured in the diagnostics below; the user sees a calm, honest,
+            // tappable disconnect state instead of a frozen-but-live screen.
             setConnectionState(
                 ConnectionState.Unreachable(
-                    "$reason Auto reconnect failed after ${delays.size} attempts.",
+                    "Disconnected from ${target.user}@${target.host}:${target.port}. " +
+                        "Tap Reconnect to retry.",
                 ),
             )
             recordAutoReconnectDecision(

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
@@ -5086,6 +5086,83 @@ class TmuxSessionViewModelTest {
     }
 
     @Test
+    fun autoReconnectExhaustionAgainstUnreachableHostSurfacesDisconnectedFromBand() =
+        runTest(scheduler) {
+            // Issue #1098 item 3: when the host is GENUINELY unrecoverable, the bounded
+            // auto-reconnect ladder must EXHAUST and surface a CLEAR "Disconnected from
+            // <user>@<host>:<port>. Tap Reconnect to retry." Failed band — never leave a
+            // frozen-but-live screen, and never the jargon-y, self-contradictory
+            // "Transport EOF …; reconnecting. Auto reconnect failed after N attempts."
+            //
+            // RED on base: the exhaustion message reads "Transport EOF from
+            // alex@alpha.example:22; reconnecting. Auto reconnect failed after 2
+            // attempts." so the assertEquals below fails. GREEN with the fix: the unified
+            // #145 "Disconnected from …" wording.
+            //
+            // This is the per-push (Unit job) sibling of the connected end-to-end
+            // BackgroundResumeSocketDeathE2eTest (which arms `forceUnrecoverableHostForTest`
+            // on the real `agents:2222` path). Here a FailingLeaseConnector fails every
+            // fresh dial (a retryable connection-refused), so the ladder runs every rung
+            // and exhausts.
+            TMUX_CONNECT_ATTEMPTS.set(0)
+            val registry = ActiveTmuxClients()
+            val connector = FailingLeaseConnector(
+                SshException(
+                    "SSH connect to alex@alpha.example:22 failed: ConnectException: Connection refused",
+                    ConnectException("Connection refused"),
+                ),
+            )
+            val vm = newVm(
+                registry = registry,
+                sshLeaseManager = testLeaseManager(connector = connector, scope = this, idleTtlMillis = 0L),
+            )
+            // graceMs=0 so the silent-reattach grace loop returns immediately and the
+            // structured EOF enters the bounded auto-reconnect ladder; two rungs so the
+            // ladder genuinely exhausts both before surfacing the band.
+            vm.setPassiveDisconnectRecoveryForTest(graceMs = 0L, silentReattachTimeoutMs = 1L)
+            vm.setAutoReconnectDelaysForTest(listOf(0L, 0L))
+            val deadClient = FakeTmuxClient()
+            vm.replaceClientForTest(
+                hostId = 7L,
+                hostName = "alpha",
+                host = "alpha.example",
+                port = 22,
+                user = "alex",
+                keyPath = "/keys/a",
+                sessionName = "work",
+                client = deadClient,
+            )
+
+            deadClient.markDisconnectedForTest(
+                TmuxDisconnectEvent(
+                    reason = TmuxDisconnectReason.ReaderEof,
+                    source = "eof",
+                    intent = "unknown",
+                ),
+            )
+            advanceUntilIdle()
+
+            assertEquals(
+                "a genuinely unreachable host must exhaust every reconnect rung",
+                2,
+                connector.connectCount,
+            )
+            val status = vm.connectionStatus.value
+            assertTrue(
+                "expected Failed (Disconnected band) after the ladder exhausts, got $status",
+                status is TmuxSessionViewModel.ConnectionStatus.Failed,
+            )
+            assertEquals(
+                "Disconnected from alex@alpha.example:22. Tap Reconnect to retry.",
+                (status as TmuxSessionViewModel.ConnectionStatus.Failed).message,
+            )
+            assertTrue(
+                "the honest disconnect band must keep the manual Reconnect affordance",
+                vm.canReconnect.value,
+            )
+        }
+
+    @Test
     fun explicitReconnectAfterEofReportsNonRetryableAuthFailureOnce() = runTest(scheduler) {
         // Issue #440: a non-retryable failure (auth rejection) must NOT burn
         // the whole backoff schedule when a passive EOF has already surfaced

--- a/scripts/check-ci-journey-harness.sh
+++ b/scripts/check-ci-journey-harness.sh
@@ -103,7 +103,6 @@ KNOWN_UNWIRED_ANDROID_E2E_DOCKER_CLASSES=(
   "com.pocketshell.app.projects.FolderListSessionResumeDockerTest"
   "com.pocketshell.app.projects.FolderListTreeStopSessionDockerTest"
   "com.pocketshell.app.projects.WatchedFoldersE2eTest"
-  "com.pocketshell.app.proof.BackgroundResumeSocketDeathE2eTest"
   "com.pocketshell.app.proof.CodexOverflowNoReconnectE2eTest"
   "com.pocketshell.app.proof.CodexRedrawOverflowReconnectE2eTest"
   "com.pocketshell.app.proof.CodexWindowStartupControlSequenceE2eTest"

--- a/scripts/check-test-validity.sh
+++ b/scripts/check-test-validity.sh
@@ -224,7 +224,6 @@ J1_UNWIRED_ANDROID_E2E_DOCKER_BASELINE=(
   "com.pocketshell.app.projects.FolderListSessionResumeDockerTest"
   "com.pocketshell.app.projects.FolderListTreeStopSessionDockerTest"
   "com.pocketshell.app.projects.WatchedFoldersE2eTest"
-  "com.pocketshell.app.proof.BackgroundResumeSocketDeathE2eTest"
   "com.pocketshell.app.proof.CodexOverflowNoReconnectE2eTest"
   "com.pocketshell.app.proof.CodexRedrawOverflowReconnectE2eTest"
   "com.pocketshell.app.proof.CodexWindowStartupControlSequenceE2eTest"

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -976,6 +976,27 @@ JOURNEY_CLASSES=(
   # NOT self-skip on CI (no assumeFalse(isRunningOnCi()) on the load-bearing
   # assertions — process.md F3 / D31). It lives under com.pocketshell.app.proof.
   "$FQCN_PREFIX.CleanOutageReattachResilienceE2eTest"
+  # Issue #1098 (item 3): the genuinely-UNRECOVERABLE-host counterpart of the clean
+  # outage above. When the host is truly gone (sshd dead / port blackholed / a cut
+  # that stays cut past the reconnect ladder's bound), the bounded ladder must
+  # EXHAUST and surface a CLEAR disconnect band (TMUX_SESSION_ERROR_TAG
+  # FailedConnectionRow + "Tap to reconnect", message "Disconnected from …") instead
+  # of leaving the maintainer's reported frozen-but-live screen — WITHOUT re-alarming
+  # the items-1+2 recoverable ride-through. A kill-the-worker-only fixture cannot
+  # reach the failing state (the sshd LISTENER stays up so the fresh-transport re-dial
+  # recovers — the round-3 finding), so this journey ARMS the genuinely-unrecoverable
+  # seam (TmuxSessionViewModel.forceUnrecoverableHostForTest) which fails BOTH the
+  # silent-reattach grace loop AND the auto-reconnect ladder's fresh dial, then does
+  # the real pause->kill-app-sshd-worker->resume sequence (#173 real SSHException) so
+  # the drop genuinely exhausts. It asserts the USER-VISIBLE contract: no crash on
+  # resume, the disconnect band surfaces on genuine exhaustion, and once the seam is
+  # disarmed (host reachable again) tapping Reconnect heals the SAME session — proving
+  # the band is the honest recoverable error, not a permanent dead end (no false-alarm
+  # regression). It drives ONLY the deterministic agents:2222 fixture
+  # (DEFAULT_HOST/PORT/USER -> 10.0.2.2:2222) tests.yml already brings up, and does
+  # NOT self-skip on CI (no assumeFalse(isRunningOnCi()) on the load-bearing
+  # assertions — process.md F3 / D31). It lives under com.pocketshell.app.proof.
+  "$FQCN_PREFIX.BackgroundResumeSocketDeathE2eTest"
   # Issue #895 (switch-while-black freeze): the R1 trigger — a transport drop that
   # lands while the VM is in the Switching (Attaching) window was SWALLOWED by the
   # old `inlineConnectionStatus as? Connected ?: return` gate, leaving the user


### PR DESCRIPTION
v0.4.20 reliability slice (approved during the v0.4.19 freeze). On a GENUINELY unrecoverable host (bounded reconnect/probe ladder exhausts against an unreachable host), surface the unified 'Disconnected from <user>@<host>:<port>. Tap Reconnect to retry.' band instead of a frozen-but-live screen — without re-alarming the recoverable blips items 1+2 ride through silently.

Reviewer **APPROVED** — red→green (JVM exhaustion test + connected `BackgroundResumeSocketDeathE2eTest`, band at 239ms / recovers at 207ms), D31 adjacency clean across 10 journeys (no false-alarm on recoverable drops), seam production-neutral: https://github.com/alexeygrigorev/pocketshell/issues/1098#issuecomment-4845065118

Refs #1098 (item 3; items 1/2/4/5 shipped in v0.4.19; item 7 awaits maintainer decision)