### PR TITLE
test: green 3 nightly test-only artifacts (#1116)

### DIFF
--- a/app/src/androidTest/java/android/content/RecordingClipboardManager.kt
+++ b/app/src/androidTest/java/android/content/RecordingClipboardManager.kt
@@ -1,0 +1,59 @@
+package android.content
+
+/**
+ * Test-only [ClipboardManager] subclass for the app module's connected
+ * Compose tests. Lives in package `android.content` so it can call
+ * ClipboardManager's package-private no-arg constructor — the public class
+ * exposes no `public` constructor, but a class declared in the same package
+ * can still see and invoke the package-private one.
+ *
+ * This mirrors the established
+ * `shared/core-terminal/.../android/content/RecordingClipboardManager.kt`
+ * helper (it cannot be shared across module test source sets, so the app
+ * module carries its own copy).
+ *
+ * Records every [setPrimaryClip] call in [recordedClips]. Production copy
+ * code (`ConversationCopyAction.copyConversationTextToClipboard`,
+ * `FileViewerScreen.copyTextToClipboard`) resolves
+ * `context.getSystemService(CLIPBOARD_SERVICE) as? ClipboardManager` and
+ * calls `setPrimaryClip(...)`; routing that lookup through this recording
+ * subclass (via [com.pocketshell.app.test.ClipboardOverrideContext]) lets
+ * the test observe the call deterministically.
+ *
+ * Why this exists: the Android emulator (API 29+) enforces a foreground-
+ * focus policy on `ClipboardManager` reads/writes — the system service
+ * silently returns `null`/no-ops for windows that do not hold focus, which
+ * is exactly the AOSP API 35 swiftshader AVD's default state for a
+ * `createAndroidComposeRule<ComponentActivity>()` activity. Reading the
+ * system clipboard back is therefore flaky; reading [recordedClips] is not.
+ */
+class RecordingClipboardManager : ClipboardManager() {
+
+    private val internalClips = mutableListOf<ClipData>()
+
+    val recordedClips: List<ClipData>
+        get() = synchronized(internalClips) { internalClips.toList() }
+
+    /** The plain text of the most recently recorded primary clip, or `null`. */
+    val lastText: String?
+        get() = synchronized(internalClips) {
+            internalClips.lastOrNull()?.takeIf { it.itemCount > 0 }
+                ?.getItemAt(0)?.text?.toString()
+        }
+
+    override fun setPrimaryClip(clip: ClipData) {
+        synchronized(internalClips) { internalClips += clip }
+    }
+
+    override fun getPrimaryClip(): ClipData? {
+        return synchronized(internalClips) { internalClips.lastOrNull() }
+    }
+
+    override fun clearPrimaryClip() {
+        synchronized(internalClips) { internalClips.clear() }
+    }
+
+    override fun hasPrimaryClip(): Boolean {
+        return synchronized(internalClips) { internalClips.isNotEmpty() }
+    }
+}

--- a/app/src/androidTest/java/com/pocketshell/app/conversation/ConversationCopyActionTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/conversation/ConversationCopyActionTest.kt
@@ -1,13 +1,16 @@
 package com.pocketshell.app.conversation
 
-import android.content.ClipboardManager
+import android.content.RecordingClipboardManager
 import androidx.activity.ComponentActivity
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.test.ClipboardOverrideContext
 import com.pocketshell.app.tmux.TMUX_CONVERSATION_TOOL_ROW_TAG_PREFIX
 import com.pocketshell.app.tmux.TmuxConversationPane
 import com.pocketshell.core.agents.AgentKind
@@ -25,10 +28,29 @@ class ConversationCopyActionTest {
     @get:Rule
     val compose = createAndroidComposeRule<ComponentActivity>()
 
+    // Production copy resolves `LocalContext.current.getSystemService(
+    // CLIPBOARD_SERVICE)`; routing that lookup through this recording subclass
+    // (via ClipboardOverrideContext provided over LocalContext) lets the test
+    // observe `setPrimaryClip` deterministically. Reading the real system
+    // clipboard back returns `null` on the un-focused AOSP API 35 AVD window
+    // (the API 29+ foreground-focus policy), which is the test-only artifact
+    // this avoids — production `copyConversationTextToClipboard` is unchanged.
+    private val recording = RecordingClipboardManager()
+
+    @Composable
+    private fun WithRecordingClipboard(content: @Composable () -> Unit) {
+        val base = LocalContext.current
+        CompositionLocalProvider(
+            LocalContext provides ClipboardOverrideContext(base, recording),
+        ) {
+            PocketShellTheme { content() }
+        }
+    }
+
     @Test
     fun messageCopyPutsMessageTextOnClipboard() {
         compose.setContent {
-            PocketShellTheme {
+            WithRecordingClipboard {
                 ConversationMessageTurn(
                     event = ConversationEvent.Message(
                         id = "m1",
@@ -45,13 +67,13 @@ class ConversationCopyActionTest {
             .performClick()
         compose.waitForIdle()
 
-        assertEquals("copy this conversation message", clipboardText())
+        assertEquals("copy this conversation message", recording.lastText)
     }
 
     @Test
     fun userMessageCopyPutsMessageTextOnClipboard() {
         compose.setContent {
-            PocketShellTheme {
+            WithRecordingClipboard {
                 ConversationMessageTurn(
                     event = ConversationEvent.Message(
                         id = "user-message",
@@ -68,13 +90,13 @@ class ConversationCopyActionTest {
             .performClick()
         compose.waitForIdle()
 
-        assertEquals("move this prompt into another window", clipboardText())
+        assertEquals("move this prompt into another window", recording.lastText)
     }
 
     @Test
     fun expandedToolCallInputCopyPutsToolInputOnClipboard() {
         compose.setContent {
-            PocketShellTheme {
+            WithRecordingClipboard {
                 TmuxConversationPane(
                     events = listOf(
                         ConversationEvent.ToolCall(
@@ -103,17 +125,6 @@ class ConversationCopyActionTest {
             .performClick()
         compose.waitForIdle()
 
-        assertEquals("kubectl logs deploy/api --tail=80", clipboardText())
-    }
-
-    private fun clipboardText(): String? {
-        val instrumentation = InstrumentationRegistry.getInstrumentation()
-        var clipText: String? = null
-        instrumentation.runOnMainSync {
-            val clipboard = instrumentation.targetContext
-                .getSystemService(android.content.Context.CLIPBOARD_SERVICE) as ClipboardManager
-            clipText = clipboard.primaryClip?.getItemAt(0)?.text?.toString()
-        }
-        return clipText
+        assertEquals("kubectl logs deploy/api --tail=80", recording.lastText)
     }
 }

--- a/app/src/androidTest/java/com/pocketshell/app/fileviewer/FileViewerScaffoldTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/fileviewer/FileViewerScaffoldTest.kt
@@ -1,7 +1,10 @@
 package com.pocketshell.app.fileviewer
 
-import android.content.ClipboardManager
+import android.content.ClipData
+import android.content.RecordingClipboardManager
 import androidx.activity.ComponentActivity
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -10,6 +13,7 @@ import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.pocketshell.app.proof.signals.assertNodeFullyWithinRoot
+import com.pocketshell.app.test.ClipboardOverrideContext
 import com.pocketshell.uikit.theme.PocketShellTheme
 import org.junit.Assert.assertEquals
 import org.junit.Rule
@@ -347,31 +351,35 @@ class FileViewerScaffoldTest {
 
     @Test
     fun copyAllPutsTextOnTheClipboard() {
-        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        // Production "Copy all" calls `copyTextToClipboard(context, content)`
+        // with `context = LocalContext.current`; route that lookup through a
+        // recording subclass so the write is observable deterministically.
+        // Reading the real system clipboard back returns `null` on the
+        // un-focused AOSP API 35 AVD window (API 29+ foreground-focus policy)
+        // — a test-only artifact; production copy is unchanged.
+        val recording = RecordingClipboardManager()
         compose.setContent {
-            PocketShellTheme {
-                FileViewerScaffold(
-                    hostName = "agents",
-                    state = FileViewerUiState.TextContent(
-                        displayPath = "/tmp/copyme.txt",
-                        content = "clipboard payload 559",
-                        sizeBytes = 21,
-                    ),
-                    onBack = {},
-                    onRetry = {},
-                )
+            val base = LocalContext.current
+            CompositionLocalProvider(
+                LocalContext provides ClipboardOverrideContext(base, recording),
+            ) {
+                PocketShellTheme {
+                    FileViewerScaffold(
+                        hostName = "agents",
+                        state = FileViewerUiState.TextContent(
+                            displayPath = "/tmp/copyme.txt",
+                            content = "clipboard payload 559",
+                            sizeBytes = 21,
+                        ),
+                        onBack = {},
+                        onRetry = {},
+                    )
+                }
             }
         }
         compose.onNodeWithTag(FILE_VIEWER_COPY_ALL_TAG).performClick()
         compose.waitForIdle()
-        // Read the primary clip back from the app context's clipboard.
-        var clipText: String? = null
-        instrumentation.runOnMainSync {
-            val cm = instrumentation.targetContext
-                .getSystemService(android.content.Context.CLIPBOARD_SERVICE) as ClipboardManager
-            clipText = cm.primaryClip?.getItemAt(0)?.text?.toString()
-        }
-        assertEquals("clipboard payload 559", clipText)
+        assertEquals("clipboard payload 559", recording.lastText)
     }
 
     @Test
@@ -521,7 +529,13 @@ class FileViewerScaffoldTest {
                 )
             }
         }
-        compose.assertNodeFullyWithinRoot(FILE_VIEWER_ANNOTATE_SAVED_SHEET_TAG)
+        // The saved-path confirmation renders inside a Material3
+        // [ModalBottomSheet], which composes into its OWN platform window/root.
+        // `assertNodeFullyWithinRoot` reads a single `onRoot()` and so throws
+        // "found 2 nodes that satisfy (isRoot)" once the sheet window is up;
+        // for sheet-internal controls we use `assertIsDisplayed()` instead
+        // (same precedent as GitHistoryScaffoldTest's create-issue sheet).
+        compose.onNodeWithTag(FILE_VIEWER_ANNOTATE_SAVED_SHEET_TAG).assertIsDisplayed()
         compose.onNodeWithText(savedPath).assertIsDisplayed()
         // The path Text is inside a merged clickable row; click via the unmerged
         // tree so the tagged node is addressable.
@@ -723,14 +737,25 @@ class FileViewerScaffoldTest {
             }
         }
         compose.waitForIdle()
-        compose.assertNodeFullyWithinRoot(FILE_VIEWER_REVIEW_SAVED_SHEET_TAG)
+        // The review-saved sheet is a Material3 [ModalBottomSheet] in its own
+        // platform window/root, so `assertNodeFullyWithinRoot` (single
+        // `onRoot()`) throws "found 2 nodes that satisfy (isRoot)". Assert the
+        // sheet-internal controls with `assertIsDisplayed()` (GitHistoryScaffold
+        // create-issue-sheet precedent).
+        compose.onNodeWithTag(FILE_VIEWER_REVIEW_SAVED_SHEET_TAG).assertIsDisplayed()
         compose.onNodeWithText(savedPath).assertIsDisplayed()
-        compose.assertNodeFullyWithinRoot(FILE_VIEWER_REVIEW_ATTACH_TAG)
+        compose.onNodeWithTag(FILE_VIEWER_REVIEW_ATTACH_TAG).assertIsDisplayed()
     }
 
     @Test
     fun tappingSavedPathCopiesItToClipboard() {
-        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        // Tapping the saved-path row fires `onCopyReviewPath(path)` (the screen
+        // wires it to the production `copyTextToClipboard`). Record the copy
+        // through a recording subclass so the write is observable
+        // deterministically — reading the real system clipboard back returns
+        // `null` on the un-focused AOSP API 35 AVD window (API 29+ focus
+        // policy), a test-only artifact.
+        val recording = RecordingClipboardManager()
         compose.setContent {
             PocketShellTheme {
                 FileViewerScaffold(
@@ -745,9 +770,7 @@ class FileViewerScaffoldTest {
                     onBack = {},
                     onRetry = {},
                     onCopyReviewPath = { path ->
-                        val cm = instrumentation.targetContext
-                            .getSystemService(android.content.Context.CLIPBOARD_SERVICE) as ClipboardManager
-                        cm.setPrimaryClip(android.content.ClipData.newPlainText("review path", path))
+                        recording.setPrimaryClip(ClipData.newPlainText("review path", path))
                     },
                 )
             }
@@ -758,13 +781,7 @@ class FileViewerScaffoldTest {
         compose.onNodeWithTag(FILE_VIEWER_REVIEW_SAVED_PATH_TAG, useUnmergedTree = true)
             .performClick()
         compose.waitForIdle()
-        var clipText: String? = null
-        instrumentation.runOnMainSync {
-            val cm = instrumentation.targetContext
-                .getSystemService(android.content.Context.CLIPBOARD_SERVICE) as ClipboardManager
-            clipText = cm.primaryClip?.getItemAt(0)?.text?.toString()
-        }
-        assertEquals(savedPath, clipText)
+        assertEquals(savedPath, recording.lastText)
     }
 
     @Test

--- a/app/src/androidTest/java/com/pocketshell/app/projects/RepoBrowserSessionPickerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/RepoBrowserSessionPickerTest.kt
@@ -119,10 +119,13 @@ class RepoBrowserSessionPickerTest {
         assertEquals(SessionType.Agent, agentChoice.type)
         assertEquals(AgentCli.Codex, agentChoice.agent)
         assertEquals(repoPath, agentChoice.startDirectory)
-        // The agent CLI is launched in the new pane — same command the
-        // folder Agent flow produces.
+        // The agent CLI is launched in the new pane through the SAME
+        // `pocketshell agent <kind> --dir '<dir>'` wrapper the folder Agent
+        // flow now produces (AgentLaunchVersionCheck.AGENT_COMMAND_PREFIX /
+        // SessionTypePickerSheet.buildAgentCommand) — not the pre-wrapper raw
+        // CLI line.
         assertEquals(
-            "codex --dangerously-bypass-approvals-and-sandbox",
+            "pocketshell agent codex --dir '$repoPath'",
             agentChoice.startCommand(),
         )
 

--- a/app/src/androidTest/java/com/pocketshell/app/test/ClipboardOverrideContext.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/test/ClipboardOverrideContext.kt
@@ -1,0 +1,45 @@
+package com.pocketshell.app.test
+
+import android.content.Context
+import android.content.ContextWrapper
+import android.content.RecordingClipboardManager
+
+/**
+ * [ContextWrapper] that routes `getSystemService(CLIPBOARD_SERVICE)` to the
+ * supplied [recording] subclass. Provide it via
+ * `CompositionLocalProvider(LocalContext provides ClipboardOverrideContext(...))`
+ * around the composable under test so the production copy code's
+ * `LocalContext.current.getSystemService(CLIPBOARD_SERVICE)` resolves to the
+ * recording instance instead of the real system clipboard.
+ *
+ * This is the app-module twin of the `ClipboardOverrideContext` proven in
+ * `shared/core-terminal/.../TerminalSurfaceComposeIntegrationTest`. It makes
+ * clipboard assertions deterministic on the AOSP API 35 swiftshader AVD,
+ * whose default un-focused activity window makes a real
+ * `clipboard.primaryClip` read return `null` (the foreground-focus policy on
+ * API 29+).
+ *
+ * [getApplicationContext] also returns a wrapper that routes
+ * CLIPBOARD_SERVICE to the same recording instance, so copy paths that look
+ * the service up on `context.applicationContext` are covered too. Every other
+ * system service passes through to [base].
+ */
+class ClipboardOverrideContext(
+    base: Context,
+    private val recording: RecordingClipboardManager,
+) : ContextWrapper(base) {
+    override fun getSystemService(name: String): Any? {
+        if (name == Context.CLIPBOARD_SERVICE) return recording
+        return super.getSystemService(name)
+    }
+
+    override fun getApplicationContext(): Context {
+        val baseApp = super.getApplicationContext()
+        return object : ContextWrapper(baseApp) {
+            override fun getSystemService(name: String): Any? {
+                if (name == Context.CLIPBOARD_SERVICE) return recording
+                return super.getSystemService(name)
+            }
+        }
+    }
+}


### PR DESCRIPTION
v0.4.20 cleanup (approved during the v0.4.19 freeze). Three nightly failures confirmed test/AVD artifacts (production correct): stale `RepoBrowserSessionPickerTest` wrapper assertion, clipboard-read-needs-focus (routed through `RecordingClipboardManager`), and ModalBottomSheet 2-roots (`assertIsDisplayed`). Test-only.

Reviewer **APPROVED** — production untouched, 30/30 green, clipboard override genuinely wraps production copy (non-vacuous): https://github.com/alexeygrigorev/pocketshell/issues/1116#issuecomment-4845430062

Closes #1116