### PR TITLE
diagnostics: defer DiagnosticRecorder JSONL seed off Main (#1124)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/diagnostics/DiagnosticRecorder.kt
+++ b/app/src/main/java/com/pocketshell/app/diagnostics/DiagnosticRecorder.kt
@@ -1,14 +1,18 @@
 package com.pocketshell.app.diagnostics
 
 import android.content.Context
+import androidx.annotation.VisibleForTesting
 import com.pocketshell.app.settings.SettingsRepository
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.time.Clock
@@ -17,25 +21,63 @@ import java.util.concurrent.atomic.AtomicLong
 import javax.inject.Inject
 import javax.inject.Singleton
 
+/**
+ * ## Off-main store build + sequence seed (issue #1124, cold-launch freeze)
+ *
+ * [DiagnosticRecorder] is an `@Inject @Singleton` field on `App`, constructed
+ * during `App.onCreate` Hilt injection — on the **Main thread**, before
+ * `StrictModeInstaller` arms (so it is invisible to the freeze gate). The old
+ * `<init>` computed `AtomicLong(store.lastSequence())`, and
+ * [DiagnosticLogStore.lastSequence] does a **full synchronous `readLines()`** of
+ * the unbounded, ever-growing diagnostics JSONL. That blocked Main at every cold
+ * launch and got *worse with usage* as the file accumulated events — the highest-
+ * impact launch freeze found in the #1085 hunt.
+ *
+ * The store build + `lastSequence()` seed is moved off-main onto the recorder's
+ * `Dispatchers.IO` scope (eager [async], mirroring the #1087
+ * `UpdateCheckStore` pattern). The [AtomicLong] sequence is seeded when that
+ * warm-up completes. Sequence numbers are assigned in the channel-consumer
+ * coroutine (which `await`s the seed before processing any command), so no event
+ * can be numbered before the seed lands — the recorder's monotonic-sequence
+ * contract is preserved. Hard-cut (D22): no synchronous on-Main fallback.
+ */
 @Singleton
 class DiagnosticRecorder @Inject constructor(
     @ApplicationContext private val context: Context,
     private val settingsRepository: SettingsRepository,
 ) : DiagnosticEventSink {
-    private val store = DiagnosticLogStore(
-        logFile = File(context.filesDir, "diagnostics/pocketshell-diagnostics.jsonl"),
-        exportDirectory = File(context.cacheDir, DIAGNOSTICS_EXPORT_CACHE_DIR),
-    )
     private val clock: Clock = Clock.systemUTC()
-    private val sequence = AtomicLong(store.lastSequence())
+    private val sequence = AtomicLong(0L)
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val commands = Channel<RecorderCommand>(capacity = RECORDER_BUFFER_CAPACITY)
 
+    @Volatile
+    private var lastSequenceReadThreadName: String? = null
+
+    /**
+     * The store build + the expensive `lastSequence()` JSONL read, deferred off
+     * the constructing (Main) thread (#1124). Seeds [sequence] when it completes.
+     * Every store consumer (the channel loop, [exportSnapshot], [readEvents])
+     * awaits this, so the warm-up runs exactly once on IO.
+     */
+    private val storeDeferred: Deferred<DiagnosticLogStore> = scope.async {
+        val store = DiagnosticLogStore(
+            logFile = File(context.filesDir, "diagnostics/pocketshell-diagnostics.jsonl"),
+            exportDirectory = File(context.cacheDir, DIAGNOSTICS_EXPORT_CACHE_DIR),
+        )
+        lastSequenceReadThreadName = currentPhysicalThreadName()
+        sequence.set(store.lastSequence())
+        store
+    }
+
     init {
         scope.launch {
+            // Await the off-main seed BEFORE processing any command, so every
+            // sequence assigned below starts from the persisted high-water mark.
+            val store = storeDeferred.await()
             for (command in commands) {
                 when (command) {
-                    is RecorderCommand.Line -> store.appendLine(command.line)
+                    is RecorderCommand.Line -> store.appendLine(encode(command.pending))
                     is RecorderCommand.Flush -> command.done.complete(Unit)
                     is RecorderCommand.Clear -> {
                         store.clear()
@@ -46,7 +88,9 @@ class DiagnosticRecorder @Inject constructor(
                         store.clear()
                         sequence.set(0L)
                         if (settingsRepository.settings.value.diagnosticsRecordingEnabled) {
-                            store.appendLine(eventLine(command.category, command.event, command.fields))
+                            store.appendLine(
+                                encode(pendingEvent(command.category, command.event, command.fields)),
+                            )
                         }
                         command.done.complete(Unit)
                     }
@@ -57,18 +101,16 @@ class DiagnosticRecorder @Inject constructor(
 
     override fun record(category: String, event: String, fields: Map<String, Any?>) {
         if (!settingsRepository.settings.value.diagnosticsRecordingEnabled) return
-        val line = eventLine(category, event, fields)
-        if (commands.trySend(RecorderCommand.Line(line)).isFailure) {
-            val overflow = DiagnosticsEvent(
-                sequence = sequence.incrementAndGet(),
-                wallClockTime = Instant.now(clock),
-                monotonicTimestampNanos = android.os.SystemClock.elapsedRealtimeNanos(),
+        val pending = pendingEvent(category, event, fields)
+        if (commands.trySend(RecorderCommand.Line(pending)).isFailure) {
+            val overflow = PendingEvent(
                 category = "diagnostics",
                 name = "recorder_overflow",
+                wallClockTime = Instant.now(clock),
+                monotonicTimestampNanos = android.os.SystemClock.elapsedRealtimeNanos(),
+                metadata = emptyMap(),
             )
-            commands.trySend(
-                RecorderCommand.Line(DiagnosticEventJson.encode(overflow)),
-            )
+            commands.trySend(RecorderCommand.Line(overflow))
         }
     }
 
@@ -87,14 +129,14 @@ class DiagnosticRecorder @Inject constructor(
     suspend fun exportSnapshot(filter: DiagnosticEventFilter = DiagnosticEventFilter.All): File? {
         flush()
         return withContext(Dispatchers.IO) {
-            store.exportSnapshot(deviceLabel(), appVersion(), filter)
+            storeDeferred.await().exportSnapshot(deviceLabel(), appVersion(), filter)
         }
     }
 
     suspend fun readEvents(filter: DiagnosticEventFilter = DiagnosticEventFilter.All): List<DiagnosticsEvent> {
         flush()
         return withContext(Dispatchers.IO) {
-            store.readEvents(filter)
+            storeDeferred.await().readEvents(filter)
         }
     }
 
@@ -120,21 +162,56 @@ class DiagnosticRecorder @Inject constructor(
         return events.joinToString(separator = "\n") { DiagnosticEventJson.encode(it) }
     }
 
+    /**
+     * Test-only (#1124): block until the off-main store build + `lastSequence()`
+     * read completes and return the name of the thread it ran on. Proves the
+     * unbounded JSONL read did NOT run on the constructing/Main thread.
+     */
+    @VisibleForTesting
+    internal fun awaitLastSequenceReadThreadNameForTest(): String {
+        runBlocking { storeDeferred.await() }
+        return lastSequenceReadThreadName
+            ?: error("lastSequence read thread was not recorded")
+    }
+
     private suspend fun flush() {
         val done = CompletableDeferred<Unit>()
         commands.send(RecorderCommand.Flush(done))
         done.await()
     }
 
-    private fun eventLine(category: String, event: String, fields: Map<String, Any?>): String =
+    // The seed runs inside a coroutine, whose framework decorates the thread name
+    // with a " @coroutine#N" suffix. Strip it so the recorded value is the
+    // PHYSICAL thread name — otherwise an on-Main build (the un-fixed base) would
+    // still differ from the captured constructing name by the suffix alone,
+    // giving a false off-main pass (#1087 G6: keep the assertion load-bearing).
+    private fun currentPhysicalThreadName(): String =
+        Thread.currentThread().name.substringBefore(" @coroutine")
+
+    /**
+     * Builds the event payload at record time (cheap, caller-thread safe). The
+     * monotonic [sequence] is deliberately NOT assigned here — it is assigned in
+     * the channel consumer ([encode]) after the off-main seed completes, so an
+     * event recorded before warm-up still gets a correct, monotonic sequence.
+     */
+    private fun pendingEvent(category: String, event: String, fields: Map<String, Any?>): PendingEvent =
+        PendingEvent(
+            category = category,
+            name = event,
+            wallClockTime = Instant.now(clock),
+            monotonicTimestampNanos = android.os.SystemClock.elapsedRealtimeNanos(),
+            metadata = DiagnosticRedactor.redact(fields),
+        )
+
+    private fun encode(pending: PendingEvent): String =
         DiagnosticEventJson.encode(
             DiagnosticsEvent(
                 sequence = sequence.incrementAndGet(),
-                wallClockTime = Instant.now(clock),
-                monotonicTimestampNanos = android.os.SystemClock.elapsedRealtimeNanos(),
-                category = category,
-                name = event,
-                metadata = DiagnosticRedactor.redact(fields),
+                wallClockTime = pending.wallClockTime,
+                monotonicTimestampNanos = pending.monotonicTimestampNanos,
+                category = pending.category,
+                name = pending.name,
+                metadata = pending.metadata,
             ),
         )
 
@@ -157,8 +234,16 @@ class DiagnosticRecorder @Inject constructor(
             "$name ($code)"
         }.getOrDefault("unknown")
 
+    private class PendingEvent(
+        val category: String,
+        val name: String,
+        val wallClockTime: Instant,
+        val monotonicTimestampNanos: Long,
+        val metadata: Map<String, Any?>,
+    )
+
     private sealed interface RecorderCommand {
-        data class Line(val line: String) : RecorderCommand
+        data class Line(val pending: PendingEvent) : RecorderCommand
         data class Flush(val done: CompletableDeferred<Unit>) : RecorderCommand
         data class Clear(val done: CompletableDeferred<Unit>) : RecorderCommand
         data class ClearAndRecord(

--- a/app/src/test/java/com/pocketshell/app/diagnostics/DiagnosticRecorderOffMainTest.kt
+++ b/app/src/test/java/com/pocketshell/app/diagnostics/DiagnosticRecorderOffMainTest.kt
@@ -1,0 +1,131 @@
+package com.pocketshell.app.diagnostics
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.pocketshell.app.settings.SettingsRepository
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+import java.time.Instant
+
+/**
+ * Regression proof for issue #1124: the highest-impact cold-launch freeze found
+ * in the #1085 hunt. [DiagnosticRecorder] is an `@Inject @Singleton` field on
+ * `App`, constructed during `App.onCreate` on the **Main thread** before
+ * StrictMode arms. The old `<init>` seeded `AtomicLong(store.lastSequence())`,
+ * and [DiagnosticLogStore.lastSequence] does a **full synchronous `readLines()`**
+ * of the unbounded, ever-growing diagnostics JSONL — so the launch cost *grew
+ * with usage* and was invisible to the freeze gate.
+ *
+ * Reproduce-first (D33 / G10, #780 — no self-skip): the LOAD-BEARING assertion is
+ * that the JSONL `lastSequence()` read runs on a thread OTHER than the
+ * constructing (Main) thread. On the pre-fix code the read happened in `<init>`
+ * on the constructing thread (RED); with the off-main eager-`async` build it runs
+ * on the recorder's `Dispatchers.IO` scope (GREEN).
+ *
+ * Class coverage (G2): the off-main move must NOT regress the recorder's
+ * monotonic-sequence contract — events recorded after a process restart (a fresh
+ * instance over an existing JSONL) keep counting up from the persisted
+ * high-water mark, not from 0.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class DiagnosticRecorderOffMainTest {
+
+    private lateinit var context: Context
+    private lateinit var settingsRepository: SettingsRepository
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        context.getSharedPreferences("app_settings", Context.MODE_PRIVATE)
+            .edit().clear().commit()
+        File(context.filesDir, "diagnostics").deleteRecursively()
+        File(context.cacheDir, DIAGNOSTICS_EXPORT_CACHE_DIR).deleteRecursively()
+        settingsRepository = SettingsRepository(context)
+        DiagnosticEvents.install(DiagnosticEventSink.Noop)
+    }
+
+    /**
+     * LOAD-BEARING (#1124): the unbounded diagnostics JSONL `lastSequence()` read
+     * must NOT run on the thread that constructs the recorder (the Main thread
+     * during `App.onCreate` Hilt injection in production).
+     */
+    @Test
+    fun `lastSequence read does not run on the constructing thread`() {
+        val constructingThread = Thread.currentThread().name
+
+        val recorder = DiagnosticRecorder(context, settingsRepository)
+        val readThread = recorder.awaitLastSequenceReadThreadNameForTest()
+
+        assertNotEquals(
+            "the diagnostics JSONL lastSequence() read must run off the " +
+                "constructing (Main) thread, not on it (#1124). " +
+                "constructing=$constructingThread read=$readThread",
+            constructingThread,
+            readThread,
+        )
+    }
+
+    /**
+     * Monotonic-sequence contract preserved (G2): a fresh recorder instance over
+     * an existing JSONL (a process restart) continues numbering from the
+     * persisted high-water mark seeded off-main, never restarting at 1.
+     */
+    @Test
+    fun `sequence resumes from persisted high-water mark after off-main seed`() = runTest {
+        settingsRepository.setDiagnosticsRecordingEnabled(true)
+
+        // Pre-seed the JSONL with three events as a prior process would have.
+        val logFile = File(context.filesDir, "diagnostics/pocketshell-diagnostics.jsonl")
+        logFile.parentFile?.mkdirs()
+        logFile.writeText(
+            (1L..3L).joinToString(separator = "\n", postfix = "\n") { seq ->
+                DiagnosticEventJson.encode(
+                    DiagnosticsEvent(
+                        sequence = seq,
+                        wallClockTime = Instant.EPOCH.plusSeconds(seq),
+                        monotonicTimestampNanos = seq,
+                        category = "app",
+                        name = "prior_$seq",
+                    ),
+                )
+            },
+        )
+
+        // A fresh instance simulates a cold relaunch over the existing file.
+        val recorder = DiagnosticRecorder(context, settingsRepository)
+        recorder.record("app", "after_restart")
+
+        val events = recorder.readEvents()
+        assertEquals(listOf(1L, 2L, 3L, 4L), events.map { it.sequence })
+        assertEquals("after_restart", events.last().name)
+        assertEquals(
+            "the new event must resume from the persisted high-water mark (#1124)",
+            4L,
+            events.last().sequence,
+        )
+    }
+
+    /**
+     * A fresh-install recorder (no prior JSONL) still numbers from 1 after the
+     * off-main seed — the empty-file / missing-data case (G2).
+     */
+    @Test
+    fun `sequence starts at one on a fresh install after off-main seed`() = runTest {
+        settingsRepository.setDiagnosticsRecordingEnabled(true)
+
+        val recorder = DiagnosticRecorder(context, settingsRepository)
+        recorder.record("app", "created")
+        recorder.record("app", "foreground")
+
+        val events = recorder.readEvents()
+        assertEquals(listOf(1L, 2L), events.map { it.sequence })
+    }
+}


### PR DESCRIPTION
Cold-launch freeze: `DiagnosticRecorder.<init>` read the unbounded diagnostics JSONL (`lastSequence()`) synchronously on Main at `App.onCreate`, before StrictMode arms — jank that **worsens the more you dogfood**.

Defer the store build + seed to `Dispatchers.IO`; move sequence numbering into the channel-consumer coroutine (awaits the seed → monotonic even for events recorded before warm-up). `record()` captures timestamp+redacted metadata at record time.

Reviewer **APPROVED** — red→green (revert→thread test FAILS read-on-Main; restore→passes), sequence-contract verified (await happens-after seed, FIFO, redaction preserved, resume-from-high-water-mark `[1,2,3,4]`), scope clean (no App.kt): https://github.com/alexeygrigorev/pocketshell/issues/1124#issuecomment-4848359255

Closes #1124