### PR TITLE
portfwd: AutoForwarder/Supervisor stop() no longer freezes Main on wedged-socket close (#1128)

### DIFF
--- a/shared/core-portfwd/src/main/java/com/pocketshell/core/portfwd/AutoForwarder.kt
+++ b/shared/core-portfwd/src/main/java/com/pocketshell/core/portfwd/AutoForwarder.kt
@@ -2,16 +2,21 @@ package com.pocketshell.core.portfwd
 
 import com.pocketshell.core.ssh.SshPortForward
 import com.pocketshell.core.ssh.SshSession
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeoutOrNull
 import java.net.InetAddress
 import java.net.InetSocketAddress
 import java.net.ServerSocket
@@ -107,6 +112,24 @@ public class AutoForwarder(
     // for the TTL eviction logic.
     private val clock: () -> Long = { System.currentTimeMillis() },
     private val localPortAvailability: LocalPortAvailability = DefaultLocalPortAvailability,
+    /**
+     * Dispatcher the terminal [stop] teardown closes forwards on. [stop] is
+     * reached on the Android Main thread (the port-forward panel's
+     * auto-forward toggle-off and the foreground service's `ACTION_STOP`
+     * both call it synchronously up the chain), and each forward's
+     * `close()` drives an SSH `direct-tcpip` channel-teardown packet that
+     * can block on a wedged socket — closing them on the caller's thread
+     * froze the UI (the #1085 freeze-hunt F-E finding). Defaults to
+     * [Dispatchers.IO] so the close runs off the caller's thread;
+     * injectable so tests can pin it.
+     */
+    private val teardownDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    /**
+     * Per-forward bound on the [stop] teardown close (see [teardownDispatcher]).
+     * A single wedged socket can't pin the teardown worker past this; the
+     * close is run interruptibly so the timeout interrupts the blocked call.
+     */
+    private val closeTimeoutMs: Long = CLOSE_TIMEOUT_MS_DEFAULT,
 ) {
 
     // We use a StateFlow so the UI can render the current set of tunnels
@@ -185,7 +208,35 @@ public class AutoForwarder(
                 captured
             }
         }
-        tunnelsToClose.forEach { runCatching { it.close() } }
+        closeForwardsOffCallerThread(tunnelsToClose)
+    }
+
+    /**
+     * Close every captured forward OFF the caller's thread (see
+     * [teardownDispatcher]). [stop] runs on the Android Main thread, and a
+     * forward's `close()` drives an SSH channel-teardown packet that can
+     * block on a wedged socket — closing them inline froze the UI thread
+     * (the #1085 freeze-hunt F-E finding). The teardown still happens; it
+     * just no longer rides the caller's thread. Each close is bounded +
+     * interruptible so one stuck socket can't pin the teardown worker
+     * either (the others still close). Fire-and-forget on a detached scope:
+     * [stop] is terminal + single-shot, so this batch launches exactly once.
+     */
+    private fun closeForwardsOffCallerThread(tunnelsToClose: List<SshPortForward>) {
+        if (tunnelsToClose.isEmpty()) return
+        CoroutineScope(SupervisorJob() + teardownDispatcher).launch {
+            tunnelsToClose.forEach { tunnel ->
+                // One child coroutine per forward so a wedged close can't
+                // delay closing its siblings.
+                launch {
+                    runCatching {
+                        withTimeoutOrNull(closeTimeoutMs) {
+                            runInterruptible { tunnel.close() }
+                        }
+                    }
+                }
+            }
+        }
     }
 
     /**
@@ -518,5 +569,12 @@ public class AutoForwarder(
             )
         }
         tunnelsState.value = snapshot
+    }
+
+    private companion object {
+        // Per-forward teardown-close bound (see [teardownDispatcher]). Long
+        // enough that a healthy channel close always completes inside it,
+        // short enough that a wedged socket can't pin the teardown worker.
+        private const val CLOSE_TIMEOUT_MS_DEFAULT = 5_000L
     }
 }

--- a/shared/core-portfwd/src/main/java/com/pocketshell/core/portfwd/AutoForwarderSupervisor.kt
+++ b/shared/core-portfwd/src/main/java/com/pocketshell/core/portfwd/AutoForwarderSupervisor.kt
@@ -3,8 +3,11 @@ package com.pocketshell.core.portfwd
 import com.pocketshell.core.ssh.SshSession
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -15,6 +18,7 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeoutOrNull
@@ -101,6 +105,19 @@ public class AutoForwarderSupervisor(
      * tighten it for deterministic test runtime.
      */
     private val sessionHealthPollMs: Long = 1_000L,
+    /**
+     * Dispatcher the terminal [stop] teardown closes the live SSH session
+     * on. [stop] is reached on the Android Main thread (the port-forward
+     * panel's auto-forward toggle-off and the foreground service's
+     * `ACTION_STOP` both call it synchronously via
+     * `ForwardingController.stopForwarding`/`stopAllForwarding` →
+     * `ActiveHost.stopOwnedSupervisor`), and `SshSession.close()` drives an
+     * `SSH_MSG_DISCONNECT` socket write that blocks the caller until the
+     * disconnect finishes — on a wedged socket that froze the UI (the #1085
+     * freeze-hunt F-E finding). Defaults to [Dispatchers.IO] so the session
+     * close runs off the caller's thread; injectable so tests can pin it.
+     */
+    private val teardownDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) {
     /** Connection-level events emitted to the caller (service / UI). */
     public sealed class Event {
@@ -234,12 +251,32 @@ public class AutoForwarderSupervisor(
         supervisorJob?.cancel()
         supervisorJob = null
         supervisorScope = null
-        currentForwarder?.stop()
+        // AutoForwarder.stop() already closes its forwards off the caller's
+        // thread (it offloads to its own teardownDispatcher), so this call
+        // returns promptly.
+        val forwarder = currentForwarder
         currentForwarder = null
-        runCatching { currentSession?.close() }
+        forwarder?.stop()
+        val session = currentSession
         currentSession = null
         connectionState.value = ConnectionState.Idle
         tunnelsState.value = emptyList()
+        // Close the live SSH session OFF the caller's thread. stop() is
+        // reached on the Android Main thread, and RealSshSession.close()
+        // blocks the caller until the SSH_MSG_DISCONNECT socket write
+        // finishes — on a wedged socket that froze the UI (the #1085
+        // freeze-hunt F-E finding). The disconnect still happens; it just no
+        // longer rides the caller's thread. Bounded + interruptible so a
+        // wedged socket can't pin the teardown worker either.
+        if (session != null) {
+            CoroutineScope(SupervisorJob() + teardownDispatcher).launch {
+                runCatching {
+                    withTimeoutOrNull(SESSION_CLOSE_TIMEOUT_MS) {
+                        runInterruptible { session.close() }
+                    }
+                }
+            }
+        }
     }
 
     /**
@@ -477,5 +514,12 @@ public class AutoForwarderSupervisor(
         val current = tunnelsState.value
         if (current.isEmpty()) return
         tunnelsState.value = current.map { it.copy(status = TunnelInfo.Status.STOPPED) }
+    }
+
+    private companion object {
+        // Bound on the terminal [stop] session-close (see [teardownDispatcher]).
+        // Long enough for a healthy disconnect, short enough that a wedged
+        // socket can't pin the teardown worker.
+        private const val SESSION_CLOSE_TIMEOUT_MS = 5_000L
     }
 }

--- a/shared/core-portfwd/src/test/java/com/pocketshell/core/portfwd/AutoForwarderSupervisorTest.kt
+++ b/shared/core-portfwd/src/test/java/com/pocketshell/core/portfwd/AutoForwarderSupervisorTest.kt
@@ -4,17 +4,25 @@ import com.pocketshell.core.ssh.ExecResult
 import com.pocketshell.core.ssh.SshPortForward
 import com.pocketshell.core.ssh.SshSession
 import com.pocketshell.core.ssh.SshShell
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNotSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 
 /**
@@ -346,7 +354,14 @@ class AutoForwarderSupervisorTest {
         supervisor.stop()
         supervisor.stop() // idempotent
 
-        assertTrue("stop() must close the live session", !session.isConnected)
+        // stop() now closes the live SSH session OFF the caller thread (on
+        // the teardown dispatcher) so a wedged disconnect socket can't freeze
+        // the UI — see `stop() does not block the caller when the session
+        // close hangs`. The disconnect still happens; we await it.
+        assertTrue(
+            "stop() must close the live session",
+            waitUntilReal(2_000L) { !session.isConnected },
+        )
         assertEquals(emptyList<TunnelInfo>(), supervisor.flowOfTunnels().first())
         assertEquals(
             AutoForwarderSupervisor.ConnectionState.Idle,
@@ -354,6 +369,74 @@ class AutoForwarderSupervisorTest {
         )
         job.cancel()
         runCurrent()
+    }
+
+    @Test
+    fun `stop() does not block the caller when the session close hangs`() {
+        // #1085 freeze-hunt F-E: supervisor.stop() is reached on the Android
+        // Main thread (panel auto-forward toggle-off / foreground-service
+        // ACTION_STOP → ForwardingController → ActiveHost.stopOwnedSupervisor
+        // → supervisor.stop()), and RealSshSession.close() blocks the caller
+        // until the SSH_MSG_DISCONNECT socket write finishes — on a wedged
+        // socket that froze the UI. Before the fix stop() closed the session
+        // inline. This holds the session's close() open and asserts stop()
+        // returns promptly anyway, while still confirming the disconnect is
+        // dispatched (teardown not dropped). RED on base (stop() blocks until
+        // the latch releases), GREEN with the off-thread teardown.
+        val factory = SequentialSessionFactory().apply {
+            addSession { setListening("0.0.0.0:3000 users:((\"app\",pid=1,fd=4))") }
+        }
+        val closeEntered = CountDownLatch(1)
+        val closeRelease = CountDownLatch(1)
+        factory.blockClose(closeEntered, closeRelease)
+
+        val executor = Executors.newSingleThreadExecutor()
+        val dispatcher = executor.asCoroutineDispatcher()
+        val loopScope = CoroutineScope(SupervisorJob() + dispatcher)
+        // Default teardownDispatcher = Dispatchers.IO, so the hung session
+        // close runs off the caller thread — exactly the production wiring.
+        val supervisor = AutoForwarderSupervisor(
+            sessionFactory = { factory.next() },
+            config = smallConfig(),
+            sessionHealthPollMs = 100L,
+        )
+        try {
+            supervisor.start(loopScope)
+            assertTrue(
+                "supervisor should reach Connected with a live session",
+                waitUntilReal(2_000L) {
+                    factory.last?.isConnected == true &&
+                        supervisor.flowOfConnectionState().value ==
+                        AutoForwarderSupervisor.ConnectionState.Connected
+                },
+            )
+
+            val stopThread = Thread { supervisor.stop() }
+            stopThread.start()
+            stopThread.join(2_000L)
+            assertFalse(
+                "stop() must return without blocking on the hung session close",
+                stopThread.isAlive,
+            )
+            assertTrue(
+                "the session's close() must still be invoked (teardown not dropped)",
+                closeEntered.await(2, TimeUnit.SECONDS),
+            )
+        } finally {
+            closeRelease.countDown()
+            loopScope.cancel()
+            dispatcher.close()
+            executor.shutdownNow()
+        }
+    }
+
+    private fun waitUntilReal(timeoutMs: Long, predicate: () -> Boolean): Boolean {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            if (predicate()) return true
+            Thread.sleep(10)
+        }
+        return predicate()
     }
 
     @Test
@@ -607,9 +690,20 @@ class AutoForwarderSupervisorTest {
         private val attempts = AtomicInteger(0)
 
         @Volatile var last: FakeSession? = null
+        @Volatile private var closeBlock: Pair<CountDownLatch, CountDownLatch>? = null
 
         fun addSession(init: FakeSession.() -> Unit) {
             queue += Lambda.Session(init)
+        }
+
+        /**
+         * Make every session this factory hands out block inside its
+         * `close()` — it counts down [entered] and waits on [release]. Lets a
+         * test hold an SSH disconnect open while asserting the caller of
+         * `stop()` is not blocked (#1085 F-E).
+         */
+        fun blockClose(entered: CountDownLatch, release: CountDownLatch) {
+            closeBlock = entered to release
         }
 
         fun failNext(n: Int) {
@@ -624,6 +718,7 @@ class AutoForwarderSupervisorTest {
                 is Lambda.Failure -> throw RuntimeException("scripted factory failure")
                 is Lambda.Session -> {
                     val s = FakeSession().apply(entry.init)
+                    s.closeBlock = closeBlock
                     last = s
                     s
                 }
@@ -651,6 +746,10 @@ class AutoForwarderSupervisorTest {
         @Volatile private var output: String = ""
         @Volatile private var connected: Boolean = true
         val openForwards: MutableList<FakeForward> = mutableListOf()
+
+        // When set, close() signals [first] then blocks on [second] —
+        // models a wedged SSH_MSG_DISCONNECT socket write (#1085 F-E).
+        @Volatile var closeBlock: Pair<CountDownLatch, CountDownLatch>? = null
 
         fun setListening(ssOutput: String) {
             output = ssOutput
@@ -694,6 +793,14 @@ class AutoForwarderSupervisorTest {
             remotePath: String,
         ): String = error("uploadStream not used by supervisor tests")
         override fun close() {
+            closeBlock?.let { (entered, release) ->
+                entered.countDown()
+                try {
+                    release.await(10, TimeUnit.SECONDS)
+                } catch (_: InterruptedException) {
+                    Thread.currentThread().interrupt()
+                }
+            }
             connected = false
             openForwards.forEach { it.close() }
         }

--- a/shared/core-portfwd/src/test/java/com/pocketshell/core/portfwd/AutoForwarderTest.kt
+++ b/shared/core-portfwd/src/test/java/com/pocketshell/core/portfwd/AutoForwarderTest.kt
@@ -214,13 +214,67 @@ class AutoForwarderTest {
 
         forwarder.stop()
 
+        // stop() now closes forwards OFF the caller thread (on the teardown
+        // dispatcher) so a wedged SSH socket can't freeze the UI — see
+        // `stop() does not block the caller when a forward's close hangs`.
+        // The teardown still happens; we just await it rather than asserting
+        // it ran inline.
         assertTrue(
             "all forwards should have been closed by stop()",
-            session.openForwards.values.all { !it.isActive },
+            waitUntilReal(2_000L) { session.openForwards.values.all { !it.isActive } },
         )
         assertEquals(0, forwarder.flowOfTunnels().first().size)
         job.cancel()
         runCurrent()
+    }
+
+    @Test
+    fun `stop() does not block the caller when a forwards close hangs`() {
+        // #1085 freeze-hunt F-E: stop() is reached on the Android Main thread
+        // (panel auto-forward toggle-off / foreground-service ACTION_STOP),
+        // and a forward's close() drives an SSH channel-teardown packet that
+        // can block on a wedged socket. Before the fix stop() closed forwards
+        // inline on the caller's thread, so a hung close froze the caller.
+        // This test holds a forward's close() open and asserts stop() returns
+        // promptly anyway, while still confirming the close is dispatched
+        // (teardown not dropped). RED on base (stop() blocks until the latch
+        // releases), GREEN with the off-thread teardown.
+        val session = FakeSession()
+        session.setListening("0.0.0.0:3000 users:((\"app\",pid=1,fd=4))")
+        val closeEntered = CountDownLatch(1)
+        val closeRelease = CountDownLatch(1)
+        session.blockForwardClose(closeEntered, closeRelease)
+
+        val executor = Executors.newSingleThreadExecutor()
+        val dispatcher = executor.asCoroutineDispatcher()
+        val loopScope = kotlinx.coroutines.CoroutineScope(SupervisorJob() + dispatcher)
+        // Default teardownDispatcher = Dispatchers.IO, so the hung close runs
+        // off the caller thread — exactly the production wiring.
+        val forwarder = AutoForwarder(session, smallConfig())
+        try {
+            forwarder.start(loopScope)
+            assertTrue(
+                "a forward should have been opened by the first scan",
+                waitUntilReal(2_000L) { session.openForwards.values.any { it.isActive } },
+            )
+
+            val stopThread = Thread { forwarder.stop() }
+            stopThread.start()
+            stopThread.join(2_000L)
+            assertFalse(
+                "stop() must return without blocking on the hung forward close",
+                stopThread.isAlive,
+            )
+            assertTrue(
+                "the forward's close() must still be invoked (teardown not dropped)",
+                closeEntered.await(2, TimeUnit.SECONDS),
+            )
+        } finally {
+            closeRelease.countDown()
+            loopScope.cancel()
+            dispatcher.close()
+            executor.shutdownNow()
+        }
     }
 
     @Test
@@ -715,6 +769,7 @@ class AutoForwarderTest {
         private val failForever = AtomicBoolean(false)
         private val nextChannelId = AtomicInteger(0)
         @Volatile private var blockedOpen: Pair<CountDownLatch, CountDownLatch>? = null
+        @Volatile private var blockedClose: Pair<CountDownLatch, CountDownLatch>? = null
 
         fun setListening(ssOutput: String) {
             output = ssOutput
@@ -722,6 +777,16 @@ class AutoForwarderTest {
 
         fun blockNextOpen(entered: CountDownLatch, release: CountDownLatch) {
             blockedOpen = entered to release
+        }
+
+        /**
+         * Make every forward produced by [openLocalPortForward] block inside
+         * its `close()` — it counts down [entered] and waits on [release].
+         * Lets a test hold an SSH-channel teardown open while asserting the
+         * caller of `stop()` is not blocked (#1085 F-E).
+         */
+        fun blockForwardClose(entered: CountDownLatch, release: CountDownLatch) {
+            blockedClose = entered to release
         }
 
         /** Make the next [n] openLocalPortForward calls throw. */
@@ -766,7 +831,13 @@ class AutoForwarderTest {
             if (failuresRemaining.getAndUpdate { if (it > 0) it - 1 else 0 } > 0) {
                 throw RuntimeException("fake open failure (countdown)")
             }
-            val f = FakeForward(remoteHost, remotePort, localPort, nextChannelId.incrementAndGet())
+            val f = FakeForward(
+                remoteHost,
+                remotePort,
+                localPort,
+                nextChannelId.incrementAndGet(),
+                closeBlock = blockedClose,
+            )
             openForwards[remotePort] = f
             completedOpenAttempts.incrementAndGet()
             return f
@@ -787,6 +858,7 @@ class AutoForwarderTest {
         override val remotePort: Int,
         override val localPort: Int,
         @Suppress("unused") val channelId: Int,
+        private val closeBlock: Pair<CountDownLatch, CountDownLatch>? = null,
     ) : SshPortForward {
         val bytesForwardedAtomic = AtomicLong(0)
         val bytesReceivedAtomic = AtomicLong(0)
@@ -794,6 +866,20 @@ class AutoForwarderTest {
         override val isActive: Boolean get() = open
         override val bytesForwarded: Long get() = bytesForwardedAtomic.get()
         override val bytesReceived: Long get() = bytesReceivedAtomic.get()
-        override fun close() { open = false }
+        override fun close() {
+            // Model a wedged SSH channel teardown: signal we entered close,
+            // then block until released (or interrupted by the bounded
+            // teardown timeout). Mirrors RealSshPortForward.close() funnelling
+            // its channel-close packet through a transport that can stall.
+            closeBlock?.let { (entered, release) ->
+                entered.countDown()
+                try {
+                    release.await(10, TimeUnit.SECONDS)
+                } catch (_: InterruptedException) {
+                    Thread.currentThread().interrupt()
+                }
+            }
+            open = false
+        }
     }
 }


### PR DESCRIPTION
Confirmed real freeze (#1085 F-E): `AutoForwarder/Supervisor.stop()` closed SSH channels/session INLINE on Main (reached via the Compose 'turn auto-forward off' callback and `ForwardingService` ACTION_STOP) — a wedged socket froze the UI.

Offload the closes to `Dispatchers.IO` (injectable), bounded+interruptible per close (5s); caller stays non-suspend; teardown preserved (every tunnel + session still closed).

Reviewer **APPROVED** — Main-path premise confirmed, red→green (revert→2 reproduce tests hang past 2s bound; restore→pass, supervisor returns 0.003s), teardown-not-dropped verified, 123 portfwd tests pass, scope clean: https://github.com/alexeygrigorev/pocketshell/issues/1128#issuecomment-4848584996

Closes #1128