### PR TITLE
app: arm StrictMode before super.onCreate() — detect launch-path main-thread IO (#1089)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/App.kt
+++ b/app/src/main/java/com/pocketshell/app/App.kt
@@ -299,6 +299,25 @@ class App : Application() {
     }
 
     override fun onCreate() {
+        // Issue #1089 (#933 / #928 D9 / P1): arm the process-wide Main-thread
+        // StrictMode tripwire as the VERY FIRST statement — BEFORE
+        // super.onCreate() runs Hilt field injection. Hilt injects the App-level
+        // singletons (settingsRepository / usageScheduler / diagnosticRecorder /
+        // …) inside super.onCreate(); arming the policy AFTER super.onCreate()
+        // (where it used to sit, ~17 lines too late) left every injection-time
+        // main-thread disk read INVISIBLE to StrictMode and undercounted the
+        // cold-launch freeze measurement — the exact detection gap that hid the
+        // #1124 (DiagnosticRecorder) and #1088 (SettingsRepository) launch
+        // freezes. Arming before injection routes those disk reads / writes /
+        // mutex waits (the #926/#928-D1 freeze class `detectNetwork()` misses)
+        // into DiagnosticEvents as a `strictmode.violation` for the load-bearing
+        // journeys to HARD-assert. DEBUG/TEST-scoped (no-op on the signed
+        // release APK — the app is debuggable here, the framework has already run
+        // attachBaseContext so applicationInfo is available) and penaltyLog only
+        // — NEVER penaltyDeath (legitimate rare startup reads exist; the journey
+        // is the gate, not a process kill).
+        StrictModeInstaller.installIfDebuggable(this)
+        StartupTiming.mark("strict-mode-installed")
         StartupTiming.mark("app-on-create-start")
         super.onCreate()
         DiagnosticEvents.install(diagnosticRecorder)
@@ -308,17 +327,6 @@ class App : Application() {
         DiagnosticEvents.record("app", "created")
         CrashReporter.install(this)
         StartupTiming.mark("app-crash-reporter-installed")
-        // Issue #933 (#928 D9 / P1): install the process-wide Main-thread
-        // StrictMode tripwire so a main-thread disk read / write / mutex wait
-        // (the #926/#928-D1 freeze class — `runBlocking { … }` Room reads that
-        // `detectNetwork()` misses) is routed into DiagnosticEvents as a
-        // `strictmode.violation` for the load-bearing journeys to HARD-assert.
-        // DEBUG/TEST-scoped (no-op on the signed release APK) and NEVER
-        // penaltyDeath — the journey is the gate, not a process kill. Installed
-        // right after the crash reporter and before the rest of onCreate so the
-        // startup hot window is itself observed.
-        StrictModeInstaller.installIfDebuggable(this)
-        StartupTiming.mark("strict-mode-installed")
         // No-background-work hook-up (issue #161 / D21). Attach the
         // ProcessLifecycleOwner observer before starting the loop so
         // the loop's `processStarted.first { it }` gate sees the

--- a/app/src/test/java/com/pocketshell/app/AppStrictModeArmOrderTest.kt
+++ b/app/src/test/java/com/pocketshell/app/AppStrictModeArmOrderTest.kt
@@ -1,0 +1,83 @@
+package com.pocketshell.app
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * Issue #1089 — install-order guard for the process-wide Main-thread
+ * [com.pocketshell.app.diagnostics.StrictModeInstaller].
+ *
+ * The StrictMode thread policy MUST be armed as the first statement of
+ * `App.onCreate()`, **before** `super.onCreate()` runs Hilt field injection.
+ * Hilt injects the App-level singletons (settingsRepository / usageScheduler /
+ * diagnosticRecorder / …) inside `super.onCreate()`, so any launch-path
+ * main-thread disk read that happens DURING injection (the #1124
+ * DiagnosticRecorder and #1088 SettingsRepository launch-freeze class) is
+ * invisible to StrictMode — and undercounts the cold-launch freeze measurement —
+ * when the policy is armed AFTER `super.onCreate()` (where it sat ~17 lines too
+ * late).
+ *
+ * This is the reproduce-first red→green guard: it FAILS on the pre-fix code
+ * where `StrictModeInstaller.installIfDebuggable(this)` sits below
+ * `super.onCreate()`, and PASSES once arming is the first statement before
+ * `super.onCreate()`. It is a pure-JVM source-structure check (no emulator), so
+ * it runs for free in the Unit job and catches the exact placement regression
+ * that hid #1124 / #1088.
+ */
+class AppStrictModeArmOrderTest {
+
+    // Code only — comment lines are stripped so a prose mention of
+    // `super.onCreate()` in the explanatory comment can't be matched as the call.
+    private val source: String = locate("App.kt")
+        .lineSequence()
+        .filterNot { it.trimStart().startsWith("//") }
+        .joinToString("\n")
+
+    @Test
+    fun strictModeIsArmedBeforeSuperOnCreate() {
+        val installIdx = source.indexOf(STRICT_MODE_INSTALL_CALL)
+        assertTrue(
+            "App.onCreate must call $STRICT_MODE_INSTALL_CALL",
+            installIdx >= 0,
+        )
+        val superIdx = source.indexOf(SUPER_ON_CREATE_CALL)
+        assertTrue("App.onCreate must call $SUPER_ON_CREATE_CALL", superIdx >= 0)
+        assertTrue(
+            "StrictMode thread policy must be armed BEFORE super.onCreate() (Hilt field " +
+                "injection), so injection-time main-thread disk IO (the #1124 / #1088 " +
+                "launch-freeze class) is detected. installIdx=$installIdx superIdx=$superIdx",
+            installIdx < superIdx,
+        )
+    }
+
+    @Test
+    fun noStrictModeInstallRunsAfterSuperOnCreate() {
+        // A future edit that re-adds a post-injection arm (the regression that
+        // hid #1124 / #1088) is caught here: the LAST install call must still
+        // precede super.onCreate(), so the entire injection window is observed.
+        val superIdx = source.indexOf(SUPER_ON_CREATE_CALL)
+        assertTrue("App.onCreate must call $SUPER_ON_CREATE_CALL", superIdx >= 0)
+        val lastInstallIdx = source.lastIndexOf(STRICT_MODE_INSTALL_CALL)
+        assertTrue(
+            "No StrictMode install may run after super.onCreate(); the injection window must " +
+                "be observed. lastInstallIdx=$lastInstallIdx superIdx=$superIdx",
+            lastInstallIdx in 0 until superIdx,
+        )
+    }
+
+    private fun locate(name: String): String {
+        val candidates = listOf(
+            File("app/src/main/java/com/pocketshell/app/$name"),
+            File("src/main/java/com/pocketshell/app/$name"),
+        )
+        val file = candidates.firstOrNull { it.isFile }
+            ?: error("Could not locate $name from ${File(".").absolutePath}")
+        return file.readText()
+    }
+
+    private companion object {
+        const val STRICT_MODE_INSTALL_CALL = "StrictModeInstaller.installIfDebuggable(this)"
+        const val SUPER_ON_CREATE_CALL = "super.onCreate()"
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/diagnostics/StrictModeInstallerTest.kt
+++ b/app/src/test/java/com/pocketshell/app/diagnostics/StrictModeInstallerTest.kt
@@ -6,6 +6,7 @@ import androidx.test.core.app.ApplicationProvider
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -112,6 +113,33 @@ class StrictModeInstallerTest {
             "installIfDebuggable must install on a debuggable build",
             StrictModeInstaller.installIfDebuggable(app),
         )
+    }
+
+    @Test
+    fun installIfDebuggableActuallyActivatesNewThreadPolicy() {
+        // Issue #1089: arming must actually swap the Main-thread policy for a NEW
+        // one (not a no-op) so a disk read during the App-init injection window is
+        // observed. App.onCreate calls this as its first statement, before
+        // super.onCreate()'s Hilt injection — see AppStrictModeArmOrderTest for
+        // the install-order guard; this proves the call has a real effect.
+        val app = ApplicationProvider.getApplicationContext<Application>()
+        app.applicationInfo.flags = app.applicationInfo.flags or ApplicationInfo.FLAG_DEBUGGABLE
+        val before = android.os.StrictMode.getThreadPolicy()
+        try {
+            assertTrue(
+                "installIfDebuggable must install on a debuggable build",
+                StrictModeInstaller.installIfDebuggable(app),
+            )
+            val after = android.os.StrictMode.getThreadPolicy()
+            assertNotSame(
+                "installIfDebuggable must arm a NEW Main-thread thread policy so " +
+                    "injection-time disk IO is detected — not leave the default LAX policy",
+                before,
+                after,
+            )
+        } finally {
+            android.os.StrictMode.setThreadPolicy(before)
+        }
     }
 
     @Test


### PR DESCRIPTION
Closes the detection gap that hid #1124/#1088: StrictMode armed AFTER `super.onCreate()`, so injection-window main-thread disk reads were invisible. Move the thread-policy arm to the first statement of `onCreate()` (before `super.onCreate()`), delete the old post-super block (single site, hard-cut). Safe pre-super (only reads `applicationInfo.flags`); debug-gated, `penaltyLog` only.

Reviewer **APPROVED** — red→green (revert→install-order guard FAILS; restore→passes), early-arm safety verified, item-7 grace wiring untouched, connected `StrictModeMainThreadIoDetectorE2eTest` covers real-IO detection: https://github.com/alexeygrigorev/pocketshell/issues/1089#issuecomment-4848683482

Closes #1089