### PR TITLE
prefs: defer eager SharedPreferences opens off Main in 7 stores (#1125)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/composer/ComposerDraftStore.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/ComposerDraftStore.kt
@@ -2,6 +2,8 @@ package com.pocketshell.app.composer
 
 import android.content.Context
 import android.content.SharedPreferences
+import androidx.annotation.VisibleForTesting
+import com.pocketshell.app.prefs.DeferredPrefs
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -179,8 +181,15 @@ public class SharedPrefsComposerDraftStore @Inject constructor(
     @ApplicationContext context: Context,
 ) : ComposerDraftStore {
 
-    private val prefs: SharedPreferences = context.applicationContext
-        .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    // Issue #1125: open the prefs file off the Main thread (it is opened at
+    // first-composer-open Hilt injection on Main otherwise — the composer is
+    // always-present per #809, so this fired on every session open).
+    private val deferredPrefs = DeferredPrefs(context, PREFS_NAME)
+    private val prefs: SharedPreferences get() = deferredPrefs.get()
+
+    @VisibleForTesting
+    internal fun awaitPrefsBuildThreadNameForTest(): String =
+        deferredPrefs.awaitBuildThreadNameForTest()
 
     override fun load(sessionKey: String): String? {
         if (sessionKey.isEmpty()) return null

--- a/app/src/main/java/com/pocketshell/app/composer/OutboundAttachmentSidecarStore.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/OutboundAttachmentSidecarStore.kt
@@ -1,8 +1,11 @@
 package com.pocketshell.app.composer
 
 import android.content.Context
+import android.content.SharedPreferences
 import android.net.Uri
 import android.provider.OpenableColumns
+import androidx.annotation.VisibleForTesting
+import com.pocketshell.app.prefs.DeferredPrefs
 import com.pocketshell.app.share.FilenameSanitiser
 import com.pocketshell.app.share.ShareUploader
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -26,7 +29,15 @@ import javax.inject.Singleton
 class OutboundAttachmentSidecarStore @Inject constructor(
     @ApplicationContext private val appContext: Context,
 ) {
-    private val prefs = appContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    // Issue #1125: open the prefs file off the Main thread (it is opened at
+    // Hilt injection on Main otherwise; the actual reads/writes already run on
+    // Dispatchers.IO inside the suspend methods below).
+    private val deferredPrefs = DeferredPrefs(appContext, PREFS_NAME)
+    private val prefs: SharedPreferences get() = deferredPrefs.get()
+
+    @VisibleForTesting
+    internal fun awaitPrefsBuildThreadNameForTest(): String =
+        deferredPrefs.awaitBuildThreadNameForTest()
 
     internal var idGenerator: () -> String = { UUID.randomUUID().toString() }
     internal var clock: () -> Long = { System.currentTimeMillis() }

--- a/app/src/main/java/com/pocketshell/app/composer/OutboundQueueStore.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/OutboundQueueStore.kt
@@ -2,6 +2,8 @@ package com.pocketshell.app.composer
 
 import android.content.Context
 import android.content.SharedPreferences
+import androidx.annotation.VisibleForTesting
+import com.pocketshell.app.prefs.DeferredPrefs
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.util.UUID
 import javax.inject.Inject
@@ -627,8 +629,15 @@ public class SharedPrefsOutboundQueueStore @Inject constructor(
     @ApplicationContext context: Context,
 ) : OutboundQueueStore {
 
-    private val prefs: SharedPreferences = context.applicationContext
-        .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    // Issue #1125: open the prefs file off the Main thread (it is opened at
+    // first-composer-open Hilt injection on Main otherwise — touched on every
+    // session open via the always-present composer, #809).
+    private val deferredPrefs = DeferredPrefs(context, PREFS_NAME)
+    private val prefs: SharedPreferences get() = deferredPrefs.get()
+
+    @VisibleForTesting
+    internal fun awaitPrefsBuildThreadNameForTest(): String =
+        deferredPrefs.awaitBuildThreadNameForTest()
 
     private val lock = Any()
 

--- a/app/src/main/java/com/pocketshell/app/fileviewer/FileViewerPrefsStore.kt
+++ b/app/src/main/java/com/pocketshell/app/fileviewer/FileViewerPrefsStore.kt
@@ -2,6 +2,8 @@ package com.pocketshell.app.fileviewer
 
 import android.content.Context
 import android.content.SharedPreferences
+import androidx.annotation.VisibleForTesting
+import com.pocketshell.app.prefs.DeferredPrefs
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -33,8 +35,14 @@ class FileViewerPrefsStore @Inject constructor(
     @ApplicationContext context: Context,
 ) {
 
-    private val prefs: SharedPreferences = context.applicationContext
-        .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    // Issue #1125: open the prefs file off the Main thread (it is opened at
+    // file-viewer-open Hilt injection on Main otherwise).
+    private val deferredPrefs = DeferredPrefs(context, PREFS_NAME)
+    private val prefs: SharedPreferences get() = deferredPrefs.get()
+
+    @VisibleForTesting
+    internal fun awaitPrefsBuildThreadNameForTest(): String =
+        deferredPrefs.awaitBuildThreadNameForTest()
 
     /** True when long lines should wrap (default off → horizontal scroll). */
     fun isWordWrap(): Boolean =

--- a/app/src/main/java/com/pocketshell/app/messaging/FcmTokenRegistrar.kt
+++ b/app/src/main/java/com/pocketshell/app/messaging/FcmTokenRegistrar.kt
@@ -2,7 +2,9 @@ package com.pocketshell.app.messaging
 
 import android.content.Context
 import android.content.SharedPreferences
+import androidx.annotation.VisibleForTesting
 import com.pocketshell.app.pocketshell.PocketshellCommand
+import com.pocketshell.app.prefs.DeferredPrefs
 
 /**
  * Owns the device's FCM token and the path that delivers it to the host (issue
@@ -29,12 +31,22 @@ import com.pocketshell.app.pocketshell.PocketshellCommand
  * pocketshell config dir) is a later server slice; THIS class defines the
  * client contract it must honour.
  */
-public class FcmTokenRegistrar(
-    private val prefs: SharedPreferences,
+public class FcmTokenRegistrar internal constructor(
+    private val deferredPrefs: DeferredPrefs,
 ) {
-    public constructor(context: Context) : this(
-        context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE),
-    )
+    /** Direct-injection / test seam: wrap an already-built prefs. */
+    public constructor(prefs: SharedPreferences) : this(DeferredPrefs(opener = { prefs }))
+
+    // Issue #1125: open the prefs file off the Main thread (the push-token
+    // registrar is built on Main when the usage-panel Hilt graph injects it;
+    // the messaging service builds it on its FCM callback thread).
+    public constructor(context: Context) : this(DeferredPrefs(context, PREFS_NAME))
+
+    private val prefs: SharedPreferences get() = deferredPrefs.get()
+
+    @VisibleForTesting
+    internal fun awaitPrefsBuildThreadNameForTest(): String =
+        deferredPrefs.awaitBuildThreadNameForTest()
 
     /** Cache the freshest device token (called from FCM's `onNewToken`). */
     public fun onTokenRefreshed(token: String) {

--- a/app/src/main/java/com/pocketshell/app/messaging/PushDedupStore.kt
+++ b/app/src/main/java/com/pocketshell/app/messaging/PushDedupStore.kt
@@ -2,6 +2,8 @@ package com.pocketshell.app.messaging
 
 import android.content.Context
 import android.content.SharedPreferences
+import androidx.annotation.VisibleForTesting
+import com.pocketshell.app.prefs.DeferredPrefs
 
 /**
  * Persistent "already notified for this reset" guard (issue #690, #619
@@ -13,13 +15,29 @@ import android.content.SharedPreferences
  * does not produce a second notification. The set is bounded so a long-running
  * install doesn't grow it without limit; the oldest keys age out first.
  */
-public class PushDedupStore(
-    private val prefs: SharedPreferences,
+public class PushDedupStore internal constructor(
+    private val deferredPrefs: DeferredPrefs,
     private val maxKeys: Int = DEFAULT_MAX_KEYS,
 ) {
-    public constructor(context: Context) : this(
-        context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE),
+    /** Direct-injection / test seam: wrap an already-built prefs. */
+    public constructor(prefs: SharedPreferences, maxKeys: Int = DEFAULT_MAX_KEYS) : this(
+        DeferredPrefs(opener = { prefs }),
+        maxKeys,
     )
+
+    // Issue #1125: open the prefs file off the Main thread (the FCM-token
+    // registrar graph builds this on Main at usage-panel injection; the
+    // messaging service builds it on its FCM callback thread).
+    public constructor(context: Context, maxKeys: Int = DEFAULT_MAX_KEYS) : this(
+        DeferredPrefs(context, PREFS_NAME),
+        maxKeys,
+    )
+
+    private val prefs: SharedPreferences get() = deferredPrefs.get()
+
+    @VisibleForTesting
+    internal fun awaitPrefsBuildThreadNameForTest(): String =
+        deferredPrefs.awaitBuildThreadNameForTest()
 
     /**
      * Record [resetKey] as notified. Returns true if it was NOT previously

--- a/app/src/main/java/com/pocketshell/app/portfwd/ShowAllPortsStore.kt
+++ b/app/src/main/java/com/pocketshell/app/portfwd/ShowAllPortsStore.kt
@@ -2,6 +2,8 @@ package com.pocketshell.app.portfwd
 
 import android.content.Context
 import android.content.SharedPreferences
+import androidx.annotation.VisibleForTesting
+import com.pocketshell.app.prefs.DeferredPrefs
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -41,8 +43,14 @@ class ShowAllPortsStore @Inject constructor(
     @ApplicationContext context: Context,
 ) {
 
-    private val prefs: SharedPreferences = context.applicationContext
-        .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    // Issue #1125: open the prefs file off the Main thread (it is opened at
+    // port-forward-panel-open Hilt injection on Main otherwise).
+    private val deferredPrefs = DeferredPrefs(context, PREFS_NAME)
+    private val prefs: SharedPreferences get() = deferredPrefs.get()
+
+    @VisibleForTesting
+    internal fun awaitPrefsBuildThreadNameForTest(): String =
+        deferredPrefs.awaitBuildThreadNameForTest()
 
     /** True when the user has opted to show every discovered port. */
     fun isShowAll(): Boolean =

--- a/app/src/main/java/com/pocketshell/app/prefs/DeferredPrefs.kt
+++ b/app/src/main/java/com/pocketshell/app/prefs/DeferredPrefs.kt
@@ -1,0 +1,95 @@
+package com.pocketshell.app.prefs
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.annotation.VisibleForTesting
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Issue #1125 / #1087 (freeze cause F6, class sweep): open a
+ * [SharedPreferences] file OFF the Main thread.
+ *
+ * `Context.getSharedPreferences(...)` does a synchronous first-touch disk read.
+ * Opening it eagerly in a store's field initializer blocks whatever thread
+ * constructs the store. For screen/VM-scoped stores (composer draft + outbound
+ * queue, port-forward panel, file viewer, messaging) that constructing thread
+ * is **Main**, at first-screen-open — so each was a per-screen-open Main-thread
+ * block (not on the cold-launch graph, so StrictMode flagged it only once #1089
+ * lands, but the block is real on every screen open).
+ *
+ * This helper kicks the open + first-touch off onto [ioDispatcher] (an eager
+ * [async]) at construction time and exposes the prefs via [get], which
+ * warms-or-awaits. The build is started immediately, so by the time a consumer
+ * actually reads (a draft load, a toggle read, a dedup check) the cache is
+ * typically already warm; the worst case blocks the caller waiting for the IO
+ * build, but the disk read itself never runs on the constructing/Main thread.
+ * Hard-cut (D22): there is no synchronous on-Main open fallback.
+ *
+ * This is the reusable extraction of the inlined pattern that already lives in
+ * [com.pocketshell.app.release.UpdateCheckStore],
+ * [com.pocketshell.app.session.LastSessionStore], and siblings.
+ */
+internal class DeferredPrefs(
+    private val opener: () -> SharedPreferences,
+    ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+) {
+    /**
+     * Open the named prefs file off-main. The opener captures [context]'s
+     * application context so it does not retain an Activity/screen Context.
+     */
+    constructor(
+        context: Context,
+        prefsName: String,
+        ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    ) : this(
+        opener = {
+            context.applicationContext.getSharedPreferences(prefsName, Context.MODE_PRIVATE)
+        },
+        ioDispatcher = ioDispatcher,
+    )
+
+    // Written on [ioDispatcher] when the async build completes; read from any
+    // thread via [get]. @Volatile so the warm value publishes across threads and
+    // a later reader never re-enters runBlocking once the build is done.
+    @Volatile
+    private var cachedPrefs: SharedPreferences? = null
+
+    // The PHYSICAL thread name the open ran on, for the off-main regression
+    // proof. Written on [ioDispatcher].
+    @Volatile
+    private var buildThreadName: String? = null
+
+    private val warmUpScope = CoroutineScope(SupervisorJob() + ioDispatcher)
+    private val deferred: Deferred<SharedPreferences> = warmUpScope.async {
+        buildThreadName = currentPhysicalThreadName()
+        opener().also { cachedPrefs = it }
+    }
+
+    /** The opened prefs — warm if the off-main build finished, else await it. */
+    fun get(): SharedPreferences = cachedPrefs ?: runBlocking { deferred.await() }
+
+    /**
+     * Test-only: block until the off-main open completes and return the name of
+     * the thread it ran on (#1125 / #1087). Proves the prefs-file open did NOT
+     * run on the constructing/Main thread.
+     */
+    @VisibleForTesting
+    internal fun awaitBuildThreadNameForTest(): String {
+        runBlocking { deferred.await() }
+        return buildThreadName ?: error("prefs build thread was not recorded")
+    }
+
+    // The open runs inside a coroutine, whose framework decorates the thread
+    // name with a " @coroutine#N" suffix. Strip it so the recorded value is the
+    // PHYSICAL thread name — otherwise an on-Main open (the un-fixed base) would
+    // still differ from the captured constructing name by the suffix alone,
+    // giving a false off-main pass (#1087 G6: keep the assertion load-bearing).
+    private fun currentPhysicalThreadName(): String =
+        Thread.currentThread().name.substringBefore(" @coroutine")
+}

--- a/app/src/test/java/com/pocketshell/app/composer/ComposerStoresOffMainTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/ComposerStoresOffMainTest.kt
@@ -1,0 +1,115 @@
+package com.pocketshell.app.composer
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Regression proof for issue #1125 (freeze cause F6 class sweep): the composer
+ * stores opened their SharedPreferences file EAGERLY in a field initializer, so
+ * the synchronous first-touch disk read ran on whatever thread constructed the
+ * store. The composer is always-present (#809) and constructed via Hilt on the
+ * Main thread at first-session-open, so each open was a per-session-open
+ * Main-thread block.
+ *
+ * Reproduce-first (D33 / G10, #780 — no self-skip): the LOAD-BEARING assertion
+ * is that the prefs-file open runs on a thread OTHER than the constructing
+ * (Main) thread. On the pre-fix code the open happened in the field initializer
+ * on the constructing thread (RED); with the off-main eager-`async`
+ * [com.pocketshell.app.prefs.DeferredPrefs] build it runs on the IO dispatcher
+ * (GREEN). Class coverage (G2): all three composer-package stores
+ * ([SharedPrefsComposerDraftStore], [SharedPrefsOutboundQueueStore],
+ * [OutboundAttachmentSidecarStore]) are covered, plus a behavior round-trip so
+ * the off-main move did not break persistence.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class ComposerStoresOffMainTest {
+
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        clearAll()
+    }
+
+    @After
+    fun tearDown() {
+        clearAll()
+    }
+
+    @Test
+    fun composer_draft_prefs_build_does_not_run_on_constructing_thread() {
+        val constructing = Thread.currentThread().name
+        val build = SharedPrefsComposerDraftStore(context).awaitPrefsBuildThreadNameForTest()
+        assertNotEquals(
+            "composer_drafts prefs must open off the constructing (Main) thread " +
+                "(#1125). constructing=$constructing build=$build",
+            constructing,
+            build,
+        )
+    }
+
+    @Test
+    fun outbound_queue_prefs_build_does_not_run_on_constructing_thread() {
+        val constructing = Thread.currentThread().name
+        val build = SharedPrefsOutboundQueueStore(context).awaitPrefsBuildThreadNameForTest()
+        assertNotEquals(
+            "outbound_queue prefs must open off the constructing (Main) thread " +
+                "(#1125). constructing=$constructing build=$build",
+            constructing,
+            build,
+        )
+    }
+
+    @Test
+    fun outbound_attachment_sidecar_prefs_build_does_not_run_on_constructing_thread() {
+        val constructing = Thread.currentThread().name
+        val build = OutboundAttachmentSidecarStore(context).awaitPrefsBuildThreadNameForTest()
+        assertNotEquals(
+            "outbound_attachment_sidecars prefs must open off the constructing " +
+                "(Main) thread (#1125). constructing=$constructing build=$build",
+            constructing,
+            build,
+        )
+    }
+
+    /** The off-main move must not break persistence: draft round-trips + survives restart. */
+    @Test
+    fun composer_draft_round_trips_after_offmain_build() {
+        SharedPrefsComposerDraftStore(context).save("host:1", "hello there")
+        assertEquals("hello there", SharedPrefsComposerDraftStore(context).load("host:1"))
+    }
+
+    /** The off-main move must not break persistence: queued item survives a fresh instance. */
+    @Test
+    fun outbound_queue_round_trips_after_offmain_build() {
+        val store = SharedPrefsOutboundQueueStore(context)
+        val item = store.enqueue(sessionKey = "host:1", cleanText = "ls -la")
+        val restarted = SharedPrefsOutboundQueueStore(context)
+        assertEquals(item.id, restarted.item(item.id)?.id)
+    }
+
+    /** The off-main move must not break persistence: a staged sidecar ref is readable. */
+    @Test
+    fun outbound_sidecar_round_trips_after_offmain_build() = runBlocking {
+        val store = OutboundAttachmentSidecarStore(context)
+        // refsFor on an unknown id returns empty without throwing after off-main build.
+        assertEquals(emptyList<LocalAttachmentSidecarRef>(), store.refsFor("nope"))
+    }
+
+    private fun clearAll() {
+        listOf("composer_drafts", "outbound_queue", "outbound_attachment_sidecars").forEach {
+            context.getSharedPreferences(it, Context.MODE_PRIVATE).edit().clear().commit()
+        }
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/fileviewer/FileViewerPrefsStoreOffMainTest.kt
+++ b/app/src/test/java/com/pocketshell/app/fileviewer/FileViewerPrefsStoreOffMainTest.kt
@@ -1,0 +1,68 @@
+package com.pocketshell.app.fileviewer
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Regression proof for issue #1125: [FileViewerPrefsStore] opened its
+ * `file_viewer_prefs` SharedPreferences eagerly in a field initializer, so the
+ * first-touch disk read blocked the Main thread at file-viewer-open Hilt
+ * injection. The off-main [com.pocketshell.app.prefs.DeferredPrefs] build moves
+ * it onto the IO dispatcher.
+ *
+ * LOAD-BEARING (#1125, #780 model, no self-skip): the prefs open must run on a
+ * thread OTHER than the constructing (Main) thread.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class FileViewerPrefsStoreOffMainTest {
+
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        clear()
+    }
+
+    @After
+    fun tearDown() {
+        clear()
+    }
+
+    @Test
+    fun prefs_build_does_not_run_on_constructing_thread() {
+        val constructing = Thread.currentThread().name
+        val build = FileViewerPrefsStore(context).awaitPrefsBuildThreadNameForTest()
+        assertNotEquals(
+            "file_viewer_prefs must open off the constructing (Main) thread " +
+                "(#1125). constructing=$constructing build=$build",
+            constructing,
+            build,
+        )
+    }
+
+    @Test
+    fun reading_prefs_round_trip_after_offmain_build() {
+        val store = FileViewerPrefsStore(context)
+        store.setWordWrap(true)
+        store.setRenderMarkdown(false)
+        val restarted = FileViewerPrefsStore(context)
+        assertTrue(restarted.isWordWrap())
+        assertFalse(restarted.isRenderMarkdown())
+    }
+
+    private fun clear() {
+        context.getSharedPreferences("file_viewer_prefs", Context.MODE_PRIVATE)
+            .edit().clear().commit()
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/messaging/MessagingStoresOffMainTest.kt
+++ b/app/src/test/java/com/pocketshell/app/messaging/MessagingStoresOffMainTest.kt
@@ -1,0 +1,86 @@
+package com.pocketshell.app.messaging
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Regression proof for issue #1125: [PushDedupStore] and [FcmTokenRegistrar]
+ * opened their SharedPreferences eagerly in the `(context)` constructor, so the
+ * first-touch disk read blocked the constructing thread. The push-token
+ * registrar graph builds [FcmTokenRegistrar] on the Main thread when the usage
+ * panel injects it, so that was a per-usage-panel-open Main-thread block; the
+ * off-main [com.pocketshell.app.prefs.DeferredPrefs] build moves it onto the IO
+ * dispatcher.
+ *
+ * LOAD-BEARING (#1125, #780 model, no self-skip): the prefs open run by the
+ * `(context)` constructor must NOT run on the constructing thread.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class MessagingStoresOffMainTest {
+
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        clear()
+    }
+
+    @After
+    fun tearDown() {
+        clear()
+    }
+
+    @Test
+    fun push_dedup_prefs_build_does_not_run_on_constructing_thread() {
+        val constructing = Thread.currentThread().name
+        val build = PushDedupStore(context).awaitPrefsBuildThreadNameForTest()
+        assertNotEquals(
+            "push_dedup prefs must open off the constructing thread (#1125). " +
+                "constructing=$constructing build=$build",
+            constructing,
+            build,
+        )
+    }
+
+    @Test
+    fun fcm_registrar_prefs_build_does_not_run_on_constructing_thread() {
+        val constructing = Thread.currentThread().name
+        val build = FcmTokenRegistrar(context).awaitPrefsBuildThreadNameForTest()
+        assertNotEquals(
+            "fcm prefs must open off the constructing thread (#1125). " +
+                "constructing=$constructing build=$build",
+            constructing,
+            build,
+        )
+    }
+
+    @Test
+    fun push_dedup_round_trips_after_offmain_build() {
+        assertTrue(PushDedupStore(context).markNotifiedIfNew("codex|short_term|reset-A"))
+        // A fresh instance (process restart) still sees the persisted key.
+        assertTrue(PushDedupStore(context).hasNotified("codex|short_term|reset-A"))
+    }
+
+    @Test
+    fun fcm_registrar_round_trips_after_offmain_build() {
+        FcmTokenRegistrar(context).onTokenRefreshed("tok-123")
+        assertEquals("tok-123", FcmTokenRegistrar(context).pendingToken())
+    }
+
+    private fun clear() {
+        listOf(PushDedupStore.PREFS_NAME, FcmTokenRegistrar.PREFS_NAME).forEach {
+            context.getSharedPreferences(it, Context.MODE_PRIVATE).edit().clear().commit()
+        }
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/portfwd/ShowAllPortsStoreOffMainTest.kt
+++ b/app/src/test/java/com/pocketshell/app/portfwd/ShowAllPortsStoreOffMainTest.kt
@@ -1,0 +1,63 @@
+package com.pocketshell.app.portfwd
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.After
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Regression proof for issue #1125: [ShowAllPortsStore] opened its
+ * `port_forward_panel` SharedPreferences eagerly in a field initializer, so the
+ * first-touch disk read blocked the Main thread at port-forward-panel-open Hilt
+ * injection. The off-main [com.pocketshell.app.prefs.DeferredPrefs] build moves
+ * it onto the IO dispatcher.
+ *
+ * LOAD-BEARING (#1125, #780 model, no self-skip): the prefs open must run on a
+ * thread OTHER than the constructing (Main) thread.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class ShowAllPortsStoreOffMainTest {
+
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        clear()
+    }
+
+    @After
+    fun tearDown() {
+        clear()
+    }
+
+    @Test
+    fun prefs_build_does_not_run_on_constructing_thread() {
+        val constructing = Thread.currentThread().name
+        val build = ShowAllPortsStore(context).awaitPrefsBuildThreadNameForTest()
+        assertNotEquals(
+            "port_forward_panel prefs must open off the constructing (Main) " +
+                "thread (#1125). constructing=$constructing build=$build",
+            constructing,
+            build,
+        )
+    }
+
+    @Test
+    fun show_all_round_trips_after_offmain_build() {
+        ShowAllPortsStore(context).setShowAll(true)
+        assertTrue(ShowAllPortsStore(context).isShowAll())
+    }
+
+    private fun clear() {
+        context.getSharedPreferences("port_forward_panel", Context.MODE_PRIVATE)
+            .edit().clear().commit()
+    }
+}


### PR DESCRIPTION
7 stores (composer draft/queue/sidecar, portfwd show-all, fileviewer prefs, push-dedup, FCM-token) opened `getSharedPreferences` (first-touch disk read) eagerly in a field initializer → Main-thread block on first-screen-open. Extract a reusable `DeferredPrefs` helper (eager async-on-IO open + warm/await `get()`, the #1087 pattern); route all 7 through it. Public contracts unchanged.

Reviewer **APPROVED** — red→green (revert→all 7 off-main asserts FAIL; restore→14 pass), class coverage (all 7, zero eager left), `DeferredPrefs` correct (no write-to-unopened race, no lost write): https://github.com/alexeygrigorev/pocketshell/issues/1125#issuecomment-4848715986

Closes #1125