### PR TITLE
settings: defer SettingsRepository prefs off Main + no-flash preload (#1088)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/settings/SettingsRepository.kt
+++ b/app/src/main/java/com/pocketshell/app/settings/SettingsRepository.kt
@@ -2,11 +2,20 @@ package com.pocketshell.app.settings
 
 import android.content.Context
 import android.content.SharedPreferences
+import androidx.annotation.VisibleForTesting
+import com.pocketshell.app.startup.StartupTiming
 import com.pocketshell.core.terminal.ui.TerminalKeyboardMode
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.runBlocking
+import java.util.concurrent.CountDownLatch
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -34,19 +43,125 @@ import javax.inject.Singleton
  * settings observation and the [SettingsViewModel], so writes in the
  * settings screen are immediately visible at the composable root without
  * any cross-scope plumbing.
+ *
+ * ## Off-main construction + splash preload (issue #1088)
+ *
+ * This `@Singleton` is built during `App.onCreate` Hilt field injection — on
+ * the **Main** thread, before the first frame. The old constructor opened the
+ * `app_settings` prefs file (`getSharedPreferences(...)` does a synchronous
+ * first-touch disk read) AND read ~15 keys (`readSnapshot()`) eagerly, so it
+ * blocked Main during cold launch — the same launch-path freeze class as the
+ * #1087 batch off-main fixes (`UpdateCheckStore`, `LastSessionStore`, …).
+ *
+ * It was deferred from #1087 because [settings] is consumed at FIRST
+ * COMPOSITION (the theme / per-pane config), so a naive async seed would
+ * flash a default→persisted UI config (theme/settings pop). The fix:
+ *
+ * - The prefs open + [readSnapshot] run OFF Main, on [Dispatchers.IO], as an
+ *   eager [async] kicked off from the constructor. Because construction itself
+ *   happens during `App.onCreate`, that async IS the splash/startup-window
+ *   PRELOAD — it warms while the activity inflates, before `setContent`. A
+ *   [StartupTiming] mark fires when it completes for cold-launch observability.
+ * - [settings] is created LAZILY (a getter over the lazy [_settings]); its
+ *   initial value is the warm snapshot. The very first value the composition
+ *   observes is therefore the persisted snapshot — never a default — so there
+ *   is no flash. The first read blocks only on the await, which by first
+ *   composition is already complete (warmed during the splash window), so it
+ *   does not block launch.
+ *
+ * Hard-cut (D22): there is no synchronous on-Main read path. Reads/writes route
+ * through [prefs], which warms-or-awaits the off-main build.
  */
 @Singleton
-class SettingsRepository @Inject constructor(
-    @ApplicationContext context: Context,
+class SettingsRepository @VisibleForTesting internal constructor(
+    context: Context,
+    /**
+     * Test-only gate (#1088). When non-null, the off-main warm-up [async]
+     * blocks on this latch BEFORE it builds the snapshot, so a test can hold
+     * the snapshot build provably in-flight at the moment `settings.value` is
+     * first read — the deterministic TIMING1 seam that proves the no-default-
+     * flash property (a racy seed-default-then-update would expose the default
+     * here, the blocking-await shipped path returns the persisted snapshot).
+     * `null` in production (the [Inject] constructor), so this is a pure
+     * no-op on the real launch path.
+     */
+    private val warmUpGate: CountDownLatch?,
 ) {
 
-    private val prefs: SharedPreferences = context.applicationContext
-        .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    @Inject
+    constructor(@ApplicationContext context: Context) : this(context, warmUpGate = null)
 
-    private val _settings: MutableStateFlow<AppSettings> = MutableStateFlow(readSnapshot())
+    private val appContext: Context = context.applicationContext
 
-    /** Hot, always-current snapshot of [AppSettings]. */
-    val settings: StateFlow<AppSettings> = _settings.asStateFlow()
+    @Volatile
+    private var cachedPrefs: SharedPreferences? = null
+
+    @Volatile
+    private var snapshotBuildThreadName: String? = null
+
+    private val warmUpScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    /**
+     * Eager off-main preload of the prefs file + persisted snapshot. Kicked off
+     * from the constructor (i.e. during `App.onCreate` injection) so it warms
+     * during the splash/startup window and is ready by first composition.
+     */
+    private val snapshotDeferred: Deferred<AppSettings> = warmUpScope.async {
+        // Test-only: hold the build in-flight until the gate opens. No-op in
+        // production (gate == null). Placed BEFORE the snapshot is built so the
+        // deferred cannot complete — and `_settings`' blocking-await cannot
+        // return — while a test is reading the first value.
+        warmUpGate?.await()
+        snapshotBuildThreadName = currentPhysicalThreadName()
+        val prefs = appContext
+            .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .also { cachedPrefs = it }
+        val snapshot = readSnapshot(prefs)
+        StartupTiming.markOnce("settings-snapshot-preloaded")
+        snapshot
+    }
+
+    private val prefs: SharedPreferences
+        get() = cachedPrefs ?: runBlocking {
+            snapshotDeferred.await()
+            cachedPrefs ?: error("settings prefs not cached after off-main build")
+        }
+
+    private val _settings: MutableStateFlow<AppSettings> by lazy {
+        MutableStateFlow(runBlocking { snapshotDeferred.await() })
+    }
+
+    /**
+     * Hot, always-current snapshot of [AppSettings]. A getter (not an eager
+     * `val`) so the backing [_settings] — and its blocking await on the warm
+     * snapshot — is initialised at first read (first composition), NOT at
+     * construction/injection. By first composition the preload is warm, so the
+     * initial value is the persisted snapshot (no default flash) and the read
+     * does not block launch.
+     */
+    val settings: StateFlow<AppSettings>
+        get() = _settings.asStateFlow()
+
+    /**
+     * Test-only: block until the off-main preload completes and return the name
+     * of the PHYSICAL thread it ran on (#1088). Proves the prefs open +
+     * snapshot read did NOT run on the constructing (Main) thread.
+     */
+    @VisibleForTesting
+    internal fun awaitSnapshotBuildThreadNameForTest(): String {
+        runBlocking { snapshotDeferred.await() }
+        return snapshotBuildThreadName
+            ?: error("settings snapshot build thread was not recorded")
+    }
+
+    // The build runs inside a coroutine, whose framework decorates the thread
+    // name with a " @coroutine#N" suffix. Strip it so the recorded value is the
+    // PHYSICAL thread name — otherwise an on-Main build (e.g. the un-fixed base)
+    // would still differ from the captured constructing name by the suffix
+    // alone, giving a false off-main pass (#1088 G6: keep the assertion
+    // load-bearing).
+    private fun currentPhysicalThreadName(): String =
+        Thread.currentThread().name.substringBefore(" @coroutine")
 
     fun setTerminalFontSizeSp(sizeSp: Float) {
         val clamped = sizeSp.coerceIn(
@@ -219,7 +334,7 @@ class SettingsRepository @Inject constructor(
         _settings.value = _settings.value.copy(diagnosticsRecordingEnabled = enabled)
     }
 
-    private fun readSnapshot(): AppSettings {
+    private fun readSnapshot(prefs: SharedPreferences): AppSettings {
         val font = prefs.safeFloat(KEY_TERMINAL_FONT_SP, AppSettings.DEFAULT_TERMINAL_FONT_SP)
             .coerceIn(AppSettings.MIN_TERMINAL_FONT_SP, AppSettings.MAX_TERMINAL_FONT_SP)
         val conversationFont = prefs.safeFloat(

--- a/app/src/test/java/com/pocketshell/app/settings/SettingsRepositoryOffMainTest.kt
+++ b/app/src/test/java/com/pocketshell/app/settings/SettingsRepositoryOffMainTest.kt
@@ -1,0 +1,190 @@
+package com.pocketshell.app.settings
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.pocketshell.core.terminal.ui.TerminalKeyboardMode
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.concurrent.thread
+
+/**
+ * Regression proof for issue #1088: building [SettingsRepository] eagerly in
+ * its constructor ran a synchronous first-touch `getSharedPreferences(...)`
+ * disk read PLUS a ~15-key `readSnapshot()` on the **Main** thread during
+ * `App.onCreate` Hilt field injection — an invisible launch-path freeze (it is
+ * built before `StrictModeInstaller` arms, so the cold-launch StrictMode log
+ * does not flag it, the same as the #1087 batch off-main fixes).
+ *
+ * Reproduce-first (D33 / G10, #780 — no self-skip): the load-bearing assertion
+ * is that the prefs open + snapshot read run on a thread OTHER than the
+ * constructing (Main) thread. On the pre-fix code the read happened in `<init>`
+ * on the constructing thread (RED); with the off-main eager-`async` preload it
+ * runs on the IO dispatcher (GREEN).
+ *
+ * The reason this was DEFERRED from #1087 is the no-flash subtlety: [settings]
+ * is consumed at FIRST COMPOSITION (theme / per-pane config), so a naive async
+ * seed would flash a default→persisted UI config. [persisted snapshot is the
+ * initial value][persisted_snapshot_is_the_initial_value_no_default_flash]
+ * proves the very first value the composition observes is already the persisted
+ * snapshot, never a default.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class SettingsRepositoryOffMainTest {
+
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        clearPrefs()
+    }
+
+    @After
+    fun tearDown() {
+        clearPrefs()
+    }
+
+    /**
+     * LOAD-BEARING (#1088): the `app_settings` prefs file open + the ~15-key
+     * [SettingsRepository.readSnapshot] must NOT run on the thread that
+     * constructs the store (the Main thread during `App.onCreate` injection in
+     * production).
+     */
+    @Test
+    fun snapshot_build_does_not_run_on_constructing_thread() {
+        val constructingThread = Thread.currentThread().name.substringBefore(" @coroutine")
+
+        val repo = SettingsRepository(context)
+        val buildThread = repo.awaitSnapshotBuildThreadNameForTest()
+
+        assertNotEquals(
+            "app_settings prefs+snapshot must be built off the constructing " +
+                "(Main) thread, not on it (#1088). " +
+                "constructing=$constructingThread build=$buildThread",
+            constructingThread,
+            buildThread,
+        )
+    }
+
+    /**
+     * No default→persisted flash (the reason #1088 was deferred from #1087):
+     * after a non-default value is persisted, a FRESH instance's FIRST observed
+     * [SettingsRepository.settings] value is the persisted snapshot, never the
+     * default. The lazy StateFlow's initial value is the warm preload, so the
+     * composition never sees a default first.
+     *
+     * DETERMINISTIC, not timing-dependent (#1088 reviewer round 2 — the
+     * TIMING1 hardening). The earlier version of this test read
+     * `settings.value` AFTER the off-main `async` had already finished (the IO
+     * preload wins the race under Robolectric), so it proved only "eventually
+     * persisted" — a racy seed-default-then-update variant STILL passed because
+     * the async update landed before the read. That is exactly the timing
+     * sensitivity the reviewer demonstrated.
+     *
+     * This version uses the [SettingsRepository] warm-up GATE seam to hold the
+     * snapshot build provably IN-FLIGHT at the moment `settings.value` is first
+     * read, on a worker thread. The two implementations then diverge
+     * DETERMINISTICALLY, independent of CPU scheduling:
+     *
+     *  - Shipped (blocking-await `_settings by lazy { … runBlocking { await() } }`):
+     *    the first read BLOCKS until the gate opens — so the very first value it
+     *    can ever observe is the persisted snapshot. GREEN.
+     *  - Racy (seed a default StateFlow, then update from the async): the first
+     *    read returns the DEFAULT immediately, BEFORE the gated async can update
+     *    — the visible flash. The captured first value is the default. RED.
+     *
+     * The load-bearing assertion (first observed value == persisted) therefore
+     * goes RED against the seed-default variant and GREEN against the shipped
+     * code, with no reliance on who-wins-the-race timing.
+     */
+    @Test
+    fun persisted_snapshot_is_the_initial_value_no_default_flash() {
+        // Sanity: the values we persist are genuinely NON-default, so a flash
+        // would be visible if the StateFlow seeded a default first.
+        assertNotEquals(
+            AppSettings.DEFAULT_TERMINAL_FONT_SP,
+            PERSISTED_FONT_SP,
+        )
+        assertNotEquals(
+            TerminalKeyboardMode.RawCommand,
+            PERSISTED_KEYBOARD_MODE,
+        )
+
+        // Persist non-default values via a fully-warmed instance (no gate).
+        SettingsRepository(context).apply {
+            setTerminalFontSizeSp(PERSISTED_FONT_SP)
+            setTerminalKeyboardMode(PERSISTED_KEYBOARD_MODE)
+        }
+
+        // A fresh instance = a "process restart", with its off-main snapshot
+        // build GATED so it is provably in-flight when we first read the value.
+        val gate = CountDownLatch(1)
+        val repo = SettingsRepository(context, gate)
+
+        val firstObserved = AtomicReference<AppSettings?>(null)
+        val readEntered = CountDownLatch(1)
+        val readReturned = CountDownLatch(1)
+        val reader = thread(name = "settings-first-read") {
+            readEntered.countDown()
+            // Shipped: this BLOCKS in `runBlocking { await() }` until the gate
+            // opens. Racy seed-default: this returns the default immediately.
+            firstObserved.set(repo.settings.value)
+            readReturned.countDown()
+        }
+
+        // The reader thread is running and about to read.
+        readEntered.await()
+        // Give the read itself a generous window to execute WHILE the gate is
+        // still closed. The racy variant captures the default within this
+        // window (the read does not block); the shipped variant cannot return
+        // here at all (it is blocked on the gated await), which is the whole
+        // point — so a timeout here is expected and correct for the fix.
+        readReturned.await(2, TimeUnit.SECONDS)
+
+        // Open the gate so the off-main build can complete and the shipped
+        // reader can unblock with the persisted snapshot.
+        gate.countDown()
+        reader.join(TimeUnit.SECONDS.toMillis(5))
+
+        val observed = firstObserved.get()
+            ?: error("settings.value read never completed even after the gate opened")
+        // LOAD-BEARING: the FIRST value the composition can observe is the
+        // PERSISTED snapshot, never a default. The seed-default variant captured
+        // the default above → RED here; the shipped blocking-await returns the
+        // persisted snapshot → GREEN.
+        assertEquals(PERSISTED_FONT_SP, observed.terminalFontSizeSp, 0f)
+        assertEquals(PERSISTED_KEYBOARD_MODE, observed.terminalKeyboardMode)
+    }
+
+    /** Defaults read correctly after the off-main build (clean install). */
+    @Test
+    fun defaults_are_correct_after_offmain_build() {
+        val initial = SettingsRepository(context).settings.value
+        assertEquals(
+            AppSettings.DEFAULT_TERMINAL_FONT_SP,
+            initial.terminalFontSizeSp,
+            0f,
+        )
+        assertEquals(TerminalKeyboardMode.RawCommand, initial.terminalKeyboardMode)
+    }
+
+    private fun clearPrefs() {
+        context.getSharedPreferences("app_settings", Context.MODE_PRIVATE)
+            .edit().clear().commit()
+    }
+
+    private companion object {
+        const val PERSISTED_FONT_SP = 19f
+        val PERSISTED_KEYBOARD_MODE = TerminalKeyboardMode.SmartText
+    }
+}


### PR DESCRIPTION
`SettingsRepository.<init>` opened prefs + read ~15 keys on Main at `App.onCreate`. Defer to an eager IO async (splash preload); lazy `_settings` blocks on the await so first composition sees the **persisted** snapshot — no theme flash. `App.kt` untouched (disjoint from #1089).

Reviewer **APPROVED** (after a round to harden the guard) — off-main red→green, and the no-flash guard is now **deterministic + load-bearing**: a `@VisibleForTesting` warm-up latch holds the build in-flight so the racy seed-default variant goes RED (`expected:<19.0> but was:<14.0>` = default-font flash) while shipped blocking-await is GREEN; production no-op: https://github.com/alexeygrigorev/pocketshell/issues/1088#issuecomment-4848765946

Closes #1088