### PR TITLE
test: consolidate settle-pumps + widen TIMING1 lint (#1048 preventive)

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -423,13 +423,24 @@ are looking at before proposing a fix:
     `shadowOf(Looper.getMainLooper()).idleFor(16ms)` + small sleep to a
     `System.currentTimeMillis()` deadline that HARD-FAILS; assert the exit
     condition, never the loop body. Reference: `TmuxSessionWarmOpenTest.pumpUntil`
-    (`:131-150`), codex pump (`TmuxSessionViewModelTest.kt:5602-5657`).
+    (`:131-150`), codex pump (`TmuxSessionViewModelTest.kt:5602-5657`). The
+    drifting hand-rolled Shape-B pumps now share ONE audited helper —
+    `drainMainLooperUntil` in the test-only module `:shared:test-support`
+    (`shared/test-support/src/main/java/com/pocketshell/testsupport/SettlePump.kt`,
+    `testImplementation(project(":shared:test-support"))`). It owns the generous
+    wall-clock deadline + the HARD `false`-on-timeout return + the "never touch a
+    clock" guarantee; the per-tick drain (`runCurrent()` / `idleFor` / both) is
+    injected per call site because those drains are genuinely different (idle
+    nothing to spare the #793 watchdog vs idle a frame for the #803 drain vs no
+    `TestScope` at all) and must not be forced into one. Clock-advancing pumps
+    (`advanceSchedulerUntil`, `pumpUntil`) stay separate by design.
   - **Banned:** a single `advanceUntilIdle()`+`idle()` then assert on real-thread
     output; a bare fixed `Thread.sleep(N)` as the only sync before a load-bearing
     assert. `scripts/check-test-validity.sh`'s advisory `TIMING1` smell surfaces
-    connection/terminal `runTest` tests that touch a real dispatcher/thread
-    without a pinned seam or bounded pump, and hard-fails a NEW bare
-    `Thread.sleep(N)`-before-assert with no bounded loop.
+    `runTest` tests that touch a real dispatcher/thread without a pinned seam or
+    bounded pump, and hard-fails a NEW bare `Thread.sleep(N)`-before-assert with
+    no bounded loop. Scope: the connection/terminal roots plus (widened in #1048)
+    the app `composer`/`hosts`/`projects` test dirs where #1102/#1110 flaked.
 - **File CI failures as issues.** Every red CI run on `main` (or local release-gate
   failure) becomes a GitHub issue with the run URL, failure snippet, and fix
   proposal — don't retry silently. Recurring classes (AVD contention) get one

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -289,6 +289,9 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.testcontainers)
+    // Issue #1048: the ONE audited shared de-flake settle-pump
+    // (`drainMainLooperUntil`) the tmux/composer wall-clock pumps converge on.
+    testImplementation(project(":shared:test-support"))
     testRuntimeOnly(libs.slf4j.nop)
 
     // Robolectric provides a Looper / Handler / Context implementation so

--- a/app/src/test/java/com/pocketshell/app/composer/PromptComposerViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/PromptComposerViewModelTest.kt
@@ -3123,6 +3123,14 @@ class PromptComposerViewModelTest {
      * after an arbitrary tick budget. Callers HARD-FAIL on the boolean result
      * ([settleUntil] / [waitForSidecarsCleared] / [waitForSendCount]); the
      * pump's exit condition is the load-bearing assertion, never the loop body.
+     *
+     * Issue #1048: this pump is deliberately NOT migrated onto the shared
+     * `drainMainLooperUntil` settle-pump. It intentionally `advanceTimeBy`s /
+     * `advanceUntilIdle`s the kotlinx VIRTUAL clock AND yields to the real
+     * `Dispatchers.IO` each tick — that virtual-clock advance is incompatible with
+     * the shared pump's "never touch a clock" invariant and is genuinely required
+     * here to flush the sidecar store's timed work, so it stays separate (the
+     * #1048 brief's "do NOT force genuinely-different pumps into one" rule).
      */
     private suspend fun kotlinx.coroutines.test.TestScope.advanceSchedulerUntil(
         predicate: suspend () -> Boolean,

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
@@ -49,6 +49,7 @@ import com.pocketshell.core.tmux.TmuxDisconnectReason
 import com.pocketshell.core.tmux.TmuxOutputBacklogOverflow
 import com.pocketshell.core.tmux.protocol.ControlEvent
 import com.pocketshell.core.terminal.ui.TerminalRawInputPolicy
+import com.pocketshell.testsupport.drainMainLooperUntil as drainMainLooperUntilShared
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
@@ -297,19 +298,24 @@ class TmuxSessionViewModelTest {
      * real-wall-clock-drain shape as [waitForSentCommandCount].
      */
     private fun TestScope.awaitCondition(predicate: () -> Boolean) {
-        val deadline = System.currentTimeMillis() + AWAIT_CONDITION_TIMEOUT_MS
-        while (true) {
-            runCurrent()
-            if (predicate()) return
-            if (System.currentTimeMillis() >= deadline) break
-            Thread.sleep(1L)
-        }
-        runCurrent()
+        // Issue #1048: the bounded-wall-clock loop + the HARD deadline now live in
+        // the ONE shared, audited settle-pump. The per-tick drain here is
+        // `runCurrent()` ONLY — it deliberately does NOT idle the main looper,
+        // because advancing the looper clock could trip the #793 re-seed watchdog
+        // (the #1110 lesson). `runCurrent()` drains Main continuations after the
+        // real-Dispatchers.IO recorded-kind read WITHOUT advancing the virtual
+        // clock.
+        val settled = drainMainLooperUntilShared(
+            deadlineMs = AWAIT_CONDITION_TIMEOUT_MS,
+            sleepMs = 1L,
+            onTick = { runCurrent() },
+            condition = predicate,
+        )
         assertTrue(
             "awaitCondition timed out after ${AWAIT_CONDITION_TIMEOUT_MS}ms wall-clock before the " +
                 "predicate held — the work it awaits (e.g. the real-Dispatchers.IO recorded-kind " +
                 "read driving the cache-restore re-seed) never drained (issue #1110)",
-            predicate(),
+            settled,
         )
     }
 
@@ -7495,17 +7501,24 @@ class TmuxSessionViewModelTest {
     private fun TestScope.drainMainLooperUntil(
         deadlineMs: Long = SLOW_FEED_DRAIN_TIMEOUT_MS,
         condition: () -> Boolean,
-    ): Boolean {
-        val deadline = System.currentTimeMillis() + deadlineMs
-        do {
-            shadowOf(Looper.getMainLooper())
-                .idleFor(16L, java.util.concurrent.TimeUnit.MILLISECONDS)
-            runCurrent()
-            if (condition()) return true
-            Thread.sleep(20)
-        } while (System.currentTimeMillis() < deadline)
-        return false
-    }
+    ): Boolean =
+        // Issue #1048: delegates the bounded-wall-clock loop + HARD deadline to the
+        // ONE shared, audited settle-pump. The SshTerminalBridge-fed flood/codex
+        // drain is frame-paced (#803/#804), so the per-tick drain MUST idle the main
+        // looper one frame (to fire the `postDelayed` continuation — a bare `idle()`
+        // never runs it) AND `runCurrent()` (to progress suspended coroutines);
+        // neither advances the kotlinx virtual clock. Returns false on the wall-clock
+        // deadline — callers HARD-FAIL on it (the load-bearing assertion).
+        drainMainLooperUntilShared(
+            deadlineMs = deadlineMs,
+            sleepMs = 20L,
+            onTick = {
+                shadowOf(Looper.getMainLooper())
+                    .idleFor(16L, java.util.concurrent.TimeUnit.MILLISECONDS)
+                runCurrent()
+            },
+            condition = condition,
+        )
 
     private fun TestScope.waitForSentCommandCount(client: FakeTmuxClient, expectedCount: Int) {
         repeat(100) {

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionWarmOpenTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionWarmOpenTest.kt
@@ -127,6 +127,13 @@ class TmuxSessionWarmOpenTest {
      * REAL time for the IO continuation to re-enqueue, then pumps again, looping
      * up to a hard deadline. It HARD-FAILS (never self-skips) if the condition is
      * not met within the budget, so a genuine routing regression still reds.
+     *
+     * Issue #1048: this pump is deliberately NOT migrated onto the shared
+     * `drainMainLooperUntil` settle-pump. It intentionally `advanceUntilIdle()`s
+     * the kotlinx VIRTUAL clock each tick, which is incompatible with the shared
+     * pump's "never advance/​touch a clock" invariant. Advancing the virtual clock
+     * is the whole point here (pump the scheduler to idle), so it stays separate —
+     * forcing it onto the shared helper would mask its real wait.
      */
     private fun TestScope.pumpUntil(
         timeoutMillis: Long = 5_000L,

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1083,13 +1083,32 @@ condition.
   condition, never the loop body. Reference: `TmuxSessionWarmOpenTest.pumpUntil`
   (`:131-150`), codex pump (`TmuxSessionViewModelTest.kt:5602-5657`).
 
+**One shared Shape-B settle-pump (`drainMainLooperUntil`, #1048 criterion M).**
+The historically drifting, hand-rolled Shape-B pumps now converge on ONE
+audited helper in the test-only module `:shared:test-support`
+(`shared/test-support/src/main/java/com/pocketshell/testsupport/SettlePump.kt`),
+consumed via `testImplementation(project(":shared:test-support"))`. The helper
+owns the load-bearing invariants — a generous wall-clock deadline, a HARD
+`false` return on timeout (the caller `assertTrue`/​`throw`s on it, #1102), and it
+NEVER touches a clock itself (no kotlinx virtual-clock advance — the #1110/#793
+watchdog trap). The per-tick drain is injected because the callers' drains are
+genuinely different and must NOT be forced into one: `awaitCondition` idles
+NOTHING and only `runCurrent()`s (idling would risk the #793 re-seed watchdog);
+the SshTerminalBridge-fed flood pumps `idleFor(16ms)` + `runCurrent()` for the
+#803 frame-paced drain; `SshTerminalBridgeTest` has no `TestScope` so idles the
+looper only. The two pumps that intentionally advance the virtual clock
+(`PromptComposerViewModelTest.advanceSchedulerUntil`,
+`TmuxSessionWarmOpenTest.pumpUntil`) stay separate by design.
+
 **Banned:** a single `advanceUntilIdle()`+`idle()` then assert on real-thread
 output; a bare fixed `Thread.sleep(N)` as the only sync before a load-bearing
 assert.
 
 `scripts/check-test-validity.sh` carries an advisory `TIMING1` smell scoped to
 the connection/terminal test roots (`core-ssh`, `core-tmux`, `core-connection`,
-and the app `tmux`/`connectivity` test dirs): it flags a `runTest` test that
+the app `tmux`/`connectivity` test dirs, and — widened in #1048 to the areas
+that actually flaked this class — the app `composer` (#1102), `hosts` (#1110),
+and `projects` test dirs): it flags a `runTest` test that
 touches a real dispatcher/thread (`Dispatchers.IO`/`Dispatchers.Default`/
 `Executors.new`/`Thread.sleep`/`Thread(`/`CountDownLatch`) WITHOUT (a) a
 `StandardTestDispatcher`/`UnconfinedTestDispatcher` seam, (b) the bounded-pump

--- a/scripts/check-test-validity.sh
+++ b/scripts/check-test-validity.sh
@@ -294,6 +294,13 @@ TIMING1_BASELINE=(
   "app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelVoiceTest.kt"                # real-IO factoryScope
   "shared/core-ssh/src/test/java/com/pocketshell/core/ssh/SshConnectionCancellationTest.kt"    # CountDownLatch cross-thread sync
   "shared/core-ssh/src/test/java/com/pocketshell/core/ssh/TransportDispatcherWedgeBoundTest.kt" # deliberate wall-clock wedge harness
+  # Issue #1048: surfaced when the TIMING1 scope widened to app/hosts. This is the
+  # #1110 fix's deliberate Shape-B real-await — the off-main close assertion needs
+  # a REAL background thread, so it bounds completion with a generous wall-clock
+  # CountDownLatch.await(10s) (not the idleFor+currentTimeMillis loop the lint can
+  # auto-recognise). Legitimate convention shape, not a smell — same as
+  # SshConnectionCancellationTest above.
+  "app/src/test/java/com/pocketshell/app/hosts/HostListViewModelTest.kt"                        # CountDownLatch off-main close await (#1110 Shape-B)
 )
 
 # Connection/terminal test roots TIMING1 is scoped to (path-prefix match).
@@ -306,6 +313,16 @@ timing1_in_scope() {
     app/src/androidTest/java/com/pocketshell/app/tmux/*) return 0 ;;
     app/src/test/java/com/pocketshell/app/connectivity/*) return 0 ;;
     app/src/androidTest/java/com/pocketshell/app/connectivity/*) return 0 ;;
+    # Issue #1048: widened to the areas that actually flaked this class —
+    # composer (#1102, sidecar-store real-IO drain) and hosts (#1110, real
+    # off-main close) — plus projects, the sibling source-binding area, so a
+    # future virtual-clock-vs-real-dispatcher timing flake there gets linted.
+    app/src/test/java/com/pocketshell/app/composer/*) return 0 ;;
+    app/src/androidTest/java/com/pocketshell/app/composer/*) return 0 ;;
+    app/src/test/java/com/pocketshell/app/hosts/*) return 0 ;;
+    app/src/androidTest/java/com/pocketshell/app/hosts/*) return 0 ;;
+    app/src/test/java/com/pocketshell/app/projects/*) return 0 ;;
+    app/src/androidTest/java/com/pocketshell/app/projects/*) return 0 ;;
   esac
   return 1
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -40,3 +40,7 @@ include(":shared:core-voice")
 include(":shared:core-assistant")
 include(":shared:core-connection")
 include(":shared:ui-kit")
+
+// Test-only support module (issue #1048): the ONE audited shared de-flake
+// settle-pump, consumed via `testImplementation` only — never ships in the APK.
+include(":shared:test-support")

--- a/shared/core-terminal/build.gradle.kts
+++ b/shared/core-terminal/build.gradle.kts
@@ -151,6 +151,9 @@ dependencies {
     // (RenderFrameCoalescerTest) — runTest + advanceTimeBy, the same harness
     // LayoutChangeCoalescerTest uses in core-tmux.
     testImplementation(libs.kotlinx.coroutines.test)
+    // Issue #1048: the ONE audited shared de-flake settle-pump
+    // (`drainMainLooperUntil`) the SshTerminalBridge flood pump converges on.
+    testImplementation(project(":shared:test-support"))
 
     androidTestImplementation(libs.androidx.test.runner)
     androidTestImplementation(libs.androidx.test.core)

--- a/shared/core-terminal/src/test/java/com/pocketshell/core/terminal/bridge/SshTerminalBridgeTest.kt
+++ b/shared/core-terminal/src/test/java/com/pocketshell/core/terminal/bridge/SshTerminalBridgeTest.kt
@@ -1,6 +1,7 @@
 package com.pocketshell.core.terminal.bridge
 
 import android.os.Looper
+import com.pocketshell.testsupport.drainMainLooperUntil as drainMainLooperUntilShared
 import com.termux.terminal.TerminalEmulator
 import com.termux.terminal.TerminalSession
 import com.termux.terminal.TerminalSessionClient
@@ -1088,19 +1089,23 @@ class SshTerminalBridgeTest {
             SshTerminalBridge.PROCESS_TO_TERMINAL_DRAIN_SLICE_BYTES
 
     private fun drainMainLooperUntil(done: () -> Boolean) {
-        val deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(10)
-        while (!done()) {
-            // Issue #803: the off-main live drain is now frame-paced — the
-            // MainThreadDrainScheduler `postDelayed`s its continuation one frame
-            // (16ms) out so the main looper is guaranteed a servicing gap between
-            // parse turns. Under Robolectric PAUSED looper a plain `idle()` only
-            // runs tasks already DUE, so advance the virtual clock one frame per
-            // pump to fire the delayed continuations and let the whole queue drain.
-            shadowOf(Looper.getMainLooper()).idleFor(16L, TimeUnit.MILLISECONDS)
-            if (System.nanoTime() > deadlineNanos) {
-                throw AssertionError("timed out waiting for feedBytes burst to drain")
-            }
-            Thread.sleep(1)
+        // Issue #1048: the bounded-wall-clock loop + the HARD deadline now live in
+        // the ONE shared, audited settle-pump. This test is NOT inside a `runTest`,
+        // so it has no `TestScope` and cannot `runCurrent()` — its only per-tick
+        // drain is idling the main looper a frame. Issue #803: the off-main live
+        // drain is frame-paced — the MainThreadDrainScheduler `postDelayed`s its
+        // continuation one frame (16ms) out so the main looper is guaranteed a
+        // servicing gap between parse turns. Under Robolectric PAUSED looper a
+        // plain `idle()` only runs tasks already DUE, so advance the looper one
+        // frame per tick to fire the delayed continuations and let the queue drain.
+        val drained = drainMainLooperUntilShared(
+            deadlineMs = TimeUnit.SECONDS.toMillis(10),
+            sleepMs = 1L,
+            onTick = { shadowOf(Looper.getMainLooper()).idleFor(16L, TimeUnit.MILLISECONDS) },
+            condition = done,
+        )
+        if (!drained) {
+            throw AssertionError("timed out waiting for feedBytes burst to drain")
         }
         // Final flush: drain any trailing scheduled continuation.
         shadowOf(Looper.getMainLooper()).idleFor(64L, TimeUnit.MILLISECONDS)

--- a/shared/test-support/build.gradle.kts
+++ b/shared/test-support/build.gradle.kts
@@ -1,0 +1,34 @@
+plugins {
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.kotlin.android)
+}
+
+// Test-only support module (issue #1048). It is consumed exclusively as a
+// `testImplementation` dependency by other modules' unit-test source sets, so
+// nothing here ever ships into the app APK. It holds the ONE audited de-flake
+// settle-pump (`drainMainLooperUntil`) shared across modules so the historically
+// drifting hand-rolled wall-clock pumps converge on a single, reviewed boundary.
+//
+// The pump itself is pure JVM (Long deadlines + lambdas) — it deliberately does
+// NOT depend on Robolectric or kotlinx-coroutines-test. The per-tick drain
+// (looper idle / `runCurrent()`) is injected by each caller, which already has
+// those libraries on its own test classpath. This keeps the genuinely different
+// drains (issue #1110 must-NOT-idle vs issue #803 must-idle vs the non-`runTest`
+// bridge test) honest while sharing the bounded-deadline core.
+android {
+    namespace = "com.pocketshell.testsupport"
+    compileSdk = 35
+
+    defaultConfig {
+        minSdk = 26
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+}

--- a/shared/test-support/src/main/AndroidManifest.xml
+++ b/shared/test-support/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest />

--- a/shared/test-support/src/main/java/com/pocketshell/testsupport/SettlePump.kt
+++ b/shared/test-support/src/main/java/com/pocketshell/testsupport/SettlePump.kt
@@ -1,0 +1,78 @@
+package com.pocketshell.testsupport
+
+/**
+ * The ONE audited settle-pump for the #1048 de-flake convention (Shape B —
+ * wall-clock-bounded pump). It replaces 5+ hand-rolled, drifting near-duplicate
+ * wall-clock pumps across the `:app` and `:shared:core-terminal` unit tests
+ * (`awaitCondition`, two `drainMainLooperUntil`s, the SshTerminalBridge flood
+ * pump). Consolidating the boundary in one reviewed place is what stops the
+ * NEXT timing flake.
+ *
+ * ## What this owns (the load-bearing, audited invariants)
+ * - **A GENEROUS wall-clock deadline** measured on [System.currentTimeMillis].
+ *   The loop returns the instant [condition] holds (no slowdown on a healthy
+ *   run) and returns `false` the moment the deadline passes.
+ * - **A HARD boundary, never a silent swallow (#1102 lesson).** This function
+ *   returns a `Boolean`; the deadline is the load-bearing assertion and the
+ *   CALLER must `assertTrue(...)`/`throw` on `false`. It never weakens the
+ *   caller's assertion — a genuine stall still exhausts the deadline and reds.
+ * - **It NEVER touches a clock itself.** It does not advance the kotlinx
+ *   `runTest` virtual scheduler and does not idle any Android looper. Advancing
+ *   the virtual clock prematurely trips production watchdogs (e.g. the #793
+ *   black-screen re-seed watchdog) — that is exactly the #1110 flake this
+ *   consolidation must not reintroduce. All per-tick draining is delegated to
+ *   [onTick].
+ *
+ * ## Why the per-tick drain is injected ([onTick]) rather than baked in
+ * The migrated pumps have GENUINELY DIFFERENT, irreconcilable per-tick drains —
+ * forcing them into one body would mask a real wait (the #1048 brief's explicit
+ * "do NOT force them into one" rule):
+ * - `awaitCondition` (cache-restore re-seed, #1110): must `runCurrent()` to
+ *   drain Main continuations after a real `Dispatchers.IO` read, but must NOT
+ *   idle the looper — idling would advance the looper clock and risk firing the
+ *   #793 watchdog. Drain: `{ runCurrent() }`.
+ * - The SshTerminalBridge-fed flood/codex pumps (#1042/#1050): the #803/#804
+ *   `MainThreadDrainScheduler` `postDelayed`s its continuation one frame out, so
+ *   they MUST idle the looper a frame (`idleFor(16ms)`) AND `runCurrent()`.
+ *   Drain: `{ idleFor(16ms); runCurrent() }`.
+ * - `SshTerminalBridgeTest` (#803): a direct-bridge test that is NOT inside a
+ *   `runTest`, so it has no `TestScope` and cannot `runCurrent()` at all — it
+ *   only idles the looper. Drain: `{ idleFor(16ms) }`.
+ *
+ * Each call site keeps its own thin, descriptively-named wrapper (so its call
+ * sites are untouched) and passes the drain it genuinely needs; the bounded
+ * loop and the hard deadline live here, once.
+ *
+ * The two pumps that intentionally advance the kotlinx VIRTUAL clock
+ * (`PromptComposerViewModelTest.advanceSchedulerUntil`, which `advanceTimeBy`s
+ * and yields to real `Dispatchers.IO`, and `TmuxSessionWarmOpenTest.pumpUntil`,
+ * which `advanceUntilIdle`s) are deliberately NOT migrated onto this helper —
+ * advancing the virtual clock is their whole point and is incompatible with the
+ * "never touch a clock" invariant above. They stay separate, by design.
+ *
+ * @param deadlineMs generous wall-clock budget; the pump returns `false` once it
+ *   elapses without [condition] holding.
+ * @param sleepMs real-wall-clock yield per tick so off-Main / real-IO threads
+ *   get scheduling time before the next drain.
+ * @param onTick the per-tick drain (see above); defaults to a no-op pure poll.
+ * @param condition the load-bearing exit predicate.
+ * @return `true` if [condition] held within [deadlineMs]; `false` on timeout.
+ */
+fun drainMainLooperUntil(
+    deadlineMs: Long,
+    sleepMs: Long = 2L,
+    onTick: () -> Unit = {},
+    condition: () -> Boolean,
+): Boolean {
+    require(deadlineMs > 0) { "deadlineMs must be > 0, was $deadlineMs" }
+    val deadline = System.currentTimeMillis() + deadlineMs
+    do {
+        onTick()
+        if (condition()) return true
+        Thread.sleep(sleepMs)
+    } while (System.currentTimeMillis() < deadline)
+    // One final drain so a continuation that became ready right at the boundary
+    // still counts before we report a hard timeout.
+    onTick()
+    return condition()
+}


### PR DESCRIPTION
Preventive close-out of #1048 (criterion M + the lint-scope gap). The recurring Unit-check flakes were already fixed (#1110/#1102); this stops the NEXT one:
- One audited shared `SettlePump` helper (`:shared:test-support`, test-only) replacing 5 hand-rolled drifting pumps; invariants preserved (no virtual-clock advance, hard-fail on timeout, per-caller drain via `onTick`). The 2 clock-advancing pumps kept separate by design.
- `check-test-validity.sh` TIMING1 scope widened to composer/hosts/projects (the areas that flaked but weren't linted); one legitimate bounded-await baselined.

Reviewer **APPROVED** — helper invariants verified (empirical: 165ms≥150ms hard-fail, no swallow; drains preserved), tests green on forced re-run (362/12/181/59/19, 0 skipped), lint exit 0 / 0 NEW TIMING1, no production code (module is `testImplementation`-only): https://github.com/alexeygrigorev/pocketshell/issues/1048#issuecomment-4849066727

Refs #1048