### PR TITLE
terminal: offload TerminalLab session close off Main on destroy (#1134)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/terminal/TerminalLabActivity.kt
+++ b/app/src/main/java/com/pocketshell/app/terminal/TerminalLabActivity.kt
@@ -39,9 +39,11 @@ import com.pocketshell.core.terminal.ui.TerminalSurface
 import com.pocketshell.core.terminal.ui.TerminalSurfaceState
 import com.pocketshell.uikit.theme.PocketShellColors
 import com.pocketshell.uikit.theme.PocketShellTheme
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -50,7 +52,9 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 
 class TerminalLabActivity : FragmentActivity() {
 
@@ -142,8 +146,19 @@ data class TerminalLabTarget(
 
 class TerminalLabController(
     private val target: TerminalLabTarget,
+    // Freeze sweep (follow-up to #1128 / #1085 F-E): the dispatcher the
+    // socket-touching SSH close is offloaded to in [close]. Defaults to
+    // [Dispatchers.IO] so a wedged `SSH_MSG_DISCONNECT` write can never pin the
+    // caller thread; a unit test injects a single-thread dispatcher to prove the
+    // caller (`onDestroy` on Main) is not blocked.
+    private val teardownDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : AutoCloseable {
     val terminalState: TerminalSurfaceState = TerminalSurfaceState()
+
+    // Application-independent scope for the off-thread SSH teardown. It outlives
+    // this controller (the Activity is already being destroyed) so the disconnect
+    // still runs to completion off Main.
+    private val teardownScope: CoroutineScope = CoroutineScope(SupervisorJob() + teardownDispatcher)
 
     private val _uiState = MutableStateFlow(
         TerminalLabUiState(status = "connecting to ${target.user}@${target.host}:${target.port}"),
@@ -313,8 +328,36 @@ class TerminalLabController(
         connectJob?.cancel()
         producerJob?.cancel()
         terminalState.detachExternalProducer()
-        ignoreClose { shell?.close() }
-        ignoreClose { session?.close() }
+        // Freeze sweep (follow-up to #1128 / #1085 F-E): [close] runs on the Main
+        // thread (the Activity's `onDestroy`). `SshShell.close()` and
+        // `SshSession.close()` (→ `RealSshSession.close()`) BLOCK the caller until
+        // the `SSH_MSG_DISCONNECT` socket write finishes — on a wedged socket that
+        // froze the UI. Offload both to the teardown dispatcher, bounded +
+        // interruptible, so `onDestroy` returns promptly even when the disconnect
+        // hangs. The disconnect still happens; it just no longer rides Main.
+        if (shell != null || session != null) {
+            teardownScope.launch {
+                ignoreClose {
+                    withTimeoutOrNull(SESSION_CLOSE_TIMEOUT_MS) {
+                        runInterruptible {
+                            ignoreClose { shell?.close() }
+                            ignoreClose { session?.close() }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Test seam (freeze sweep): install a live shell/session so a unit test can
+     * drive [close] against a hung-close transport WITHOUT a real SSH handshake.
+     * Production sets these fields only from [connect].
+     */
+    @androidx.annotation.VisibleForTesting
+    internal fun installTransportForTest(session: SshSession?, shell: SshShell?) {
+        sessionRef = session
+        shellRef = shell
     }
 
     private companion object {
@@ -329,6 +372,14 @@ class TerminalLabController(
          * at its full 24 KB cap.
          */
         const val LooksLikePromptWindowChars: Int = 1_024
+
+        /**
+         * Wall-clock ceiling for the off-thread SSH teardown in [close], mirroring
+         * `RealSshSession.SESSION_CLOSE_TIMEOUT_MS` and the AutoForwarderSupervisor
+         * teardown bound (#1128): a wedged disconnect socket cannot pin the
+         * teardown worker forever either.
+         */
+        const val SESSION_CLOSE_TIMEOUT_MS: Long = 2_000L
     }
 }
 

--- a/app/src/test/java/com/pocketshell/app/terminal/TerminalLabCloseOffMainTest.kt
+++ b/app/src/test/java/com/pocketshell/app/terminal/TerminalLabCloseOffMainTest.kt
@@ -1,0 +1,114 @@
+package com.pocketshell.app.terminal
+
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.SshKey
+import com.pocketshell.core.ssh.SshPortForward
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshShell
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.asCoroutineDispatcher
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+import java.io.InputStream
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+/**
+ * Freeze sweep (follow-up to #1128 / #1085 freeze-hunt F-E): the campaign root
+ * is that `RealSshSession.close()` BLOCKS its caller until the
+ * `SSH_MSG_DISCONNECT` socket write finishes — on a wedged socket that pins the
+ * caller thread. #1128 neutralised the AutoForwarderSupervisor Main caller. This
+ * proves the OTHER surviving Main caller — [TerminalLabController.close], reached
+ * on the Main thread from `TerminalLabActivity.onDestroy()` — no longer freezes
+ * the caller.
+ *
+ * RED on base: `close()` calls `ignoreClose { session.close() }` inline on the
+ * caller thread, so closing while the session's `close()` hangs blocks the caller
+ * until the latch releases → the caller thread is still alive after the join.
+ * GREEN with the fix: the socket-touching close is dispatched to the teardown
+ * dispatcher, so `close()` returns promptly while the disconnect is still
+ * dispatched (teardown not dropped).
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class TerminalLabCloseOffMainTest {
+
+    @Test
+    fun `close does not block the caller when the session close hangs`() {
+        val closeEntered = CountDownLatch(1)
+        val closeRelease = CountDownLatch(1)
+        val session = HangingCloseSession(closeEntered, closeRelease)
+
+        val executor = Executors.newSingleThreadExecutor()
+        val teardownDispatcher = executor.asCoroutineDispatcher()
+        val target = TerminalLabTarget(
+            host = "127.0.0.1",
+            port = 2222,
+            user = "app",
+            key = SshKey.Pem("unused-pem"),
+        )
+        val controller = TerminalLabController(
+            target = target,
+            teardownDispatcher = teardownDispatcher,
+        )
+        controller.installTransportForTest(session = session, shell = null)
+
+        try {
+            // Drive close() from a dedicated "caller" thread (stands in for the
+            // Main thread that runs `onDestroy`) and prove it returns without
+            // waiting on the hung disconnect.
+            val callerThread = Thread { controller.close() }
+            callerThread.start()
+            callerThread.join(2_000L)
+            assertFalse(
+                "close() must return without blocking on the hung session close",
+                callerThread.isAlive,
+            )
+            assertTrue(
+                "the session's close() must still be invoked (teardown not dropped)",
+                closeEntered.await(2, TimeUnit.SECONDS),
+            )
+        } finally {
+            closeRelease.countDown()
+            teardownDispatcher.close()
+            executor.shutdownNow()
+        }
+    }
+
+    /**
+     * [SshSession] fake whose [close] parks on a latch — reproducing a wedged
+     * `SSH_MSG_DISCONNECT` socket write. Only the members [TerminalLabController]
+     * touches are meaningful; the rest error out.
+     */
+    private class HangingCloseSession(
+        private val closeEntered: CountDownLatch,
+        private val closeRelease: CountDownLatch,
+    ) : SshSession {
+        @Volatile
+        var closed: Boolean = false
+
+        override val isConnected: Boolean get() = !closed
+
+        override suspend fun exec(command: String): ExecResult = error("not used")
+        override fun tail(path: String, onLine: (String) -> Unit): Job = error("not used")
+        override fun openLocalPortForward(remoteHost: String, remotePort: Int, localPort: Int): SshPortForward =
+            error("not used")
+        override fun startShell(): SshShell = error("not used")
+        override suspend fun uploadFile(file: File, remotePath: String): String = error("not used")
+        override suspend fun uploadStream(input: InputStream, length: Long, name: String, remotePath: String): String =
+            error("not used")
+
+        override fun close() {
+            closeEntered.countDown()
+            // Park like a wedged disconnect socket until the test releases us.
+            closeRelease.await()
+            closed = true
+        }
+    }
+}


### PR DESCRIPTION
Confirmed real Main freeze (#1085 SSH-close sweep): `TerminalLabActivity.onDestroy()` (Main) closed a raw SSH session inline; `RealSshSession.close()` blocks up to 2s on a wedged socket → screen-exit freeze. Offload to `Dispatchers.IO` (bounded 2s, interruptible); disconnect still runs.

Reviewer **APPROVED** — premise confirmed real (manifest L128, onDestroy on Main), red→green (revert→'must return without blocking' FAILS; restore→pass), teardown-not-dropped, scope = 2 files: https://github.com/alexeygrigorev/pocketshell/issues/1134#issuecomment-4849145206

Closes #1134