### PR TITLE
ci: wire EnvScreenE2eTest into the journey suite (#1094)

### DIFF
--- a/scripts/check-ci-journey-harness.sh
+++ b/scripts/check-ci-journey-harness.sh
@@ -81,7 +81,6 @@ KNOWN_UNWIRED_ANDROID_E2E_DOCKER_CLASSES=(
   "com.pocketshell.app.composer.ComposerPartialExpandE2eTest"
   "com.pocketshell.app.costs.CostsScreenE2eTest"
   "com.pocketshell.app.crash.ShareAllReportsDockerTest"
-  "com.pocketshell.app.env.EnvScreenE2eTest"
   "com.pocketshell.app.fileexplorer.FileExplorerDockerTest"
   "com.pocketshell.app.fileviewer.FileViewerDockerTest"
   "com.pocketshell.app.fileviewer.LinkTapParsingDockerTest"

--- a/scripts/check-test-validity.sh
+++ b/scripts/check-test-validity.sh
@@ -202,7 +202,6 @@ J1_UNWIRED_ANDROID_E2E_DOCKER_BASELINE=(
   "com.pocketshell.app.composer.ComposerPartialExpandE2eTest"
   "com.pocketshell.app.costs.CostsScreenE2eTest"
   "com.pocketshell.app.crash.ShareAllReportsDockerTest"
-  "com.pocketshell.app.env.EnvScreenE2eTest"
   "com.pocketshell.app.fileexplorer.FileExplorerDockerTest"
   "com.pocketshell.app.fileviewer.FileViewerDockerTest"
   "com.pocketshell.app.fileviewer.LinkTapParsingDockerTest"

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -1334,6 +1334,23 @@ JOURNEY_CLASSES=(
   # assumeFalse(isRunningOnCi()) on the load-bearing assertions). It lives under
   # com.pocketshell.app.diagnostics, so it carries its FQCN directly.
   "com.pocketshell.app.diagnostics.ConnectionLogHostMirrorReconnectDockerTest"
+  # ADDED (#1094, durability for #1092): the env edit/add on-device journeys. The
+  # #1092 review shipped the edit-in-place + empty-state-CTA fix proven by a
+  # reviewer-run local connected pass + gated JVM tests, but EnvScreenE2eTest
+  # itself sat on the pre-existing unwired allowlist, so the env journeys did NOT
+  # auto-run in CI — a D31/G9 durability gap for the env feature class
+  # (edit-in-place, reveal-into-editor, add/create first key, D24 stdin-not-argv).
+  # Wiring the whole class here runs ALL its methods at PR/batched time:
+  # envScreenListsRevealsAddsAndCopies, editExistingKeyInPlaceUpdatesValueViaSetKeys
+  # (the #1092 fix), and emptyFolderSurfacesAddKeyCtaThatCreatesFirstKey. The class
+  # drives the production EnvScreen via createComposeRule against an in-memory DAO +
+  # a fake EnvGateway (the env CLI wire contract is proven separately against the
+  # real `pocketshell env` CLI), so it needs NO Docker fixture / SSH / tmux /
+  # toxiproxy / port — a pure Compose-rule UI journey, deterministic on the CI
+  # swiftshader AVD, so it needs no tests.yml service change — and it does NOT
+  # self-skip on CI (no assumeTrue / assumeFalse(isRunningOnCi())). It lives under
+  # com.pocketshell.app.env, so it carries its FQCN directly.
+  "com.pocketshell.app.env.EnvScreenE2eTest"
 )
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Wires the env connected journey (`EnvScreenE2eTest`) into the CI journey gate so the #1092 edit-existing-key fix is durably covered.

Scripts-only: adds the class to `JOURNEY_CLASSES` and prunes it from the two unwired baselines. Pure in-memory Compose test — no Docker/SSH/tmux fixture, so no `tests.yml` service change needed.

Reviewer: APPROVED (https://github.com/alexeygrigorev/pocketshell/issues/1094#issuecomment-4850585997). Verified: `test-ci-journey-budget.sh`, `check-ci-journey-harness.sh`, `check-test-validity.sh` all pass; 91 classes, launched==class_count invariant holds.

Closes #1094