### PR TITLE
terminal: heal sparse alt-screen partial-black agent pane (#1138)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/AgentAltScreenPartialBlackHealJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/AgentAltScreenPartialBlackHealJourneyE2eTest.kt
@@ -1,0 +1,547 @@
+package com.pocketshell.app.proof
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.util.Log
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.lifecycle.ViewModelProvider
+import androidx.room.Room
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.BackgroundGraceTestOverride
+import com.pocketshell.app.MainActivity
+import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
+import com.pocketshell.app.hosts.SshKeyStorage
+import com.pocketshell.app.tmux.TMUX_SESSION_ERROR_TAG
+import com.pocketshell.app.tmux.TMUX_SESSION_RECONNECT_TAG
+import com.pocketshell.app.tmux.TMUX_SESSION_SCREEN_TAG
+import com.pocketshell.app.tmux.TmuxSessionViewModel
+import com.pocketshell.core.ssh.KnownHostsPolicy
+import com.pocketshell.core.ssh.SshConnection
+import com.pocketshell.core.ssh.SshKey
+import com.pocketshell.core.storage.AppDatabase
+import com.pocketshell.core.storage.entity.HostEntity
+import com.termux.view.TerminalView
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+
+/**
+ * Issue #1138 — the DISCRIMINATING journey for the maintainer's SEMI/PARTIAL-black on a live
+ * AGENT alt-screen pane (v0.4.19 dogfood, 2026-07-01, reproduced on BOTH Codex and Claude).
+ *
+ * ## The maintainer's report
+ *
+ * A connected agent session showed a mostly-BLACK terminal with ONLY the agent's live status
+ * line (`∘ Working 7`) + cursor near the bottom, the upper ALT-SCREEN rows black. The agent
+ * redraws with cursor-addressed writes, so only its live status line repaints locally while
+ * the upper rows the pane lost stay black. An alt-screen agent frame is SPARSE (a header + a
+ * large blank conversation area + an input/status line), so its non-blank content is small and
+ * the surviving status line is a LARGE fraction of it — ABOVE the #966 25% divergence ceiling.
+ * The v0.4.18 steady-state stale-render watchdog's ONLY heal predicate was
+ * [com.pocketshell.core.terminal.ui.TerminalSurfaceState.visibleScreenDivergesFromCapture], so
+ * it read the pane "healthy" and never fired: the pane sat mostly-black on a LIVE transport.
+ *
+ * ## What this journey PROVES (D33 / G10 — real path, guaranteed-live transport)
+ *
+ * Seed a tmux session running a SPARSE ALT-SCREEN app (header + blank body + status), attach,
+ * then inject the partial-black (clear + only the live status line) straight into the SAME
+ * live emulator the app renders — the REMOTE tmux grid keeps the full sparse alt frame, so the
+ * transport is GUARANTEED LIVE. Then assert:
+ *  - **Symptom present:** the active pane reads `visibleScreenIsPartiallyBlank()` (the exact
+ *    #1138 state) — the #941 reveal/send heals would fire IF triggered, but on a passively-
+ *    observed streaming pane there is NO switch/send, so the steady-state watchdog is the only
+ *    net. On base its divergence-only predicate MISSES this sparse frame (unit-proven RED in
+ *    `PartialBlackPaneHealTest#steadyStateWatchdogHealsPartialBlackAltScreenAgentPane`).
+ *  - **Transport ALIVE:** `connectionStatus` stays `Connected`, no reconnect surface.
+ *  - **Render HEALS:** one steady-state watchdog tick re-seeds the pane from tmux's
+ *    authoritative `capture-pane` and the FULL alt-screen frame (its header marker + the upper
+ *    rows) re-renders — GREEN with the union predicate `visibleRenderLostFrameVsCapture`.
+ *
+ * No `Assume.assumeFalse(isRunningOnCi())` on the load-bearing assertions — it RUNS on the
+ * per-PR emulator-journey job once wired into `scripts/ci-journey-suite.sh`.
+ */
+@RunWith(AndroidJUnit4::class)
+class AgentAltScreenPartialBlackHealJourneyE2eTest {
+
+    @get:Rule
+    val compose = createEmptyComposeRule()
+
+    @get:Rule
+    val grantPermissions = PreGrantPermissionsRule()
+
+    private var launchedActivity: ActivityScenario<MainActivity>? = null
+    private var seededKey: String? = null
+
+    @Before
+    fun setUp() {
+        BackgroundGraceTestOverride.setForTest(null)
+    }
+
+    @After
+    fun tearDown() {
+        runCatching { launchedActivity?.close() }
+        launchedActivity = null
+        BackgroundGraceTestOverride.setForTest(null)
+        seededKey?.let { key -> runCatching { runBlocking { cleanupRemoteTmuxSession(key) } } }
+    }
+
+    @Test
+    fun steadyStateWatchdogHealsPartialBlackAltScreenAgentPane() = runBlocking {
+        val key = readFixtureKey()
+        seededKey = key
+        waitForSshFixtureReady(SshKey.Pem(key))
+        seedAltScreenSession(key)
+
+        val hostRowTag = seedDockerHost(key)
+        launchedActivity = ActivityScenario.launch(MainActivity::class.java)
+        attachSeededTmuxSession(hostRowTag)
+
+        // Baseline: the sparse alt-screen frame is in the live pane and the session is Connected.
+        waitForVisibleTerminal("initial alt frame") { it.contains(FRAME_MARKER) }
+        waitForConnected("initial attach")
+        capturePaintedRows("issue1138-00-attached")
+
+        // ===== Inject the partial-black on the LIVE, retained emulator. =====
+        // Clear the alt screen and paint ONLY the live status line (cursor-addressed) — the
+        // maintainer's semi-black: upper rows black, only the status line survives. The REMOTE
+        // tmux grid keeps the full sparse frame, so the transport stays GUARANTEED LIVE.
+        feedFrameToEmulator("[2J[H[24;1H Working 7  esc to interrupt streaming the reply")
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        capturePaintedRows("issue1138-01-partial-black")
+
+        // ----- Symptom precondition: the active pane IS partial-black (the #1138 state). -----
+        assertTrue(
+            "the injected pane must be partial-black (the maintainer's #1138 semi-black state)",
+            activePanePartiallyBlank(),
+        )
+
+        // ----- DISCRIMINATOR half 1: the transport is GUARANTEED LIVE. -----
+        assertTrue(
+            "the transport must stay Connected with a partial-black render (a render bug on a " +
+                "live link, not a drop), observed=${currentConnectionStatus()}",
+            currentConnectionStatus() is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+        assertFalse(
+            "the tmux client must NOT be disconnected (render bug, not a drop)",
+            clientDisconnected(),
+        )
+        assertNoVisibleReconnect("partial-black (no reconnect surface)")
+
+        // ----- GREEN: one steady-state watchdog tick must heal + restore the FULL alt frame. -----
+        val healed = driveStaleRenderHeal()
+        assertTrue(
+            "REGRESSION (#1138): the steady-state watchdog must heal a partial-black alt-screen " +
+                "agent pane. On base (divergence-only predicate) it read the sparse frame " +
+                "'healthy' and skipped it — the pane stayed black on a live transport.",
+            healed,
+        )
+        val visibleAfter = waitForVisibleTerminal(
+            "alt-screen full-frame restore",
+            timeoutMillis = RESTORE_TIMEOUT_MS,
+        ) { it.contains(FRAME_MARKER) && frameRowCount(it) >= MIN_RESTORED_FRAME_ROWS }
+        assertTrue(
+            "the heal must re-render the FULL alt frame (the header marker + the upper rows " +
+                "that were black); found rows=${frameRowCount(visibleAfter)}.\n$visibleAfter",
+            visibleAfter.contains(FRAME_MARKER) && frameRowCount(visibleAfter) >= MIN_RESTORED_FRAME_ROWS,
+        )
+        assertFalse(
+            "after the heal the pane must NO LONGER be partial-black (the upper rows repainted)",
+            activePanePartiallyBlank(),
+        )
+        capturePaintedRows("issue1138-02-healed")
+
+        // ----- DISCRIMINATOR half 2: still Connected, no reconnect across the heal. -----
+        assertNoVisibleReconnect("post-heal (no reconnect surface)")
+        assertTrue(
+            "session must stay Connected after the heal (render fix, no reconnect), " +
+                "observed=${currentConnectionStatus()}",
+            currentConnectionStatus() is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+        writeSummary()
+    }
+
+    // ---------------------------------------------------------------- Heal driver
+
+    private fun driveStaleRenderHeal(): Boolean {
+        var result = false
+        val latch = java.util.concurrent.CountDownLatch(1)
+        launchedActivity?.onActivity { activity ->
+            val vm = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+            runBlocking { result = vm.healActivePaneIfStaleRenderForTest() }
+            latch.countDown()
+        }
+        latch.await(RESTORE_TIMEOUT_MS, java.util.concurrent.TimeUnit.MILLISECONDS)
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        return result
+    }
+
+    private fun activePanePartiallyBlank(): Boolean {
+        var hit = false
+        launchedActivity?.onActivity { activity ->
+            val vm = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+            hit = vm.panes.value.firstOrNull()
+                ?.terminalState
+                ?.visibleScreenIsPartiallyBlank() ?: false
+        }
+        return hit
+    }
+
+    private fun clientDisconnected(): Boolean {
+        var disconnected = false
+        launchedActivity?.onActivity { activity ->
+            val vm = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+            disconnected = vm.clientDisconnectedForTest()
+        }
+        return disconnected
+    }
+
+    // ---------------------------------------------------------------- Emulator feed
+
+    private fun feedFrameToEmulator(frame: String) {
+        val bytes = frame.toByteArray(Charsets.UTF_8)
+        var fed = false
+        launchedActivity?.onActivity { activity ->
+            val view = activity.window.decorView.findTerminalView() ?: return@onActivity
+            val emulator = view.mEmulator ?: return@onActivity
+            emulator.append(bytes, bytes.size)
+            view.invalidate()
+            fed = true
+        }
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        assertTrue("expected to feed the frame to the live emulator", fed)
+    }
+
+    // ---------------------------------------------------------------- Render capture
+
+    private fun capturePaintedRows(name: String): Int {
+        val bitmap = renderViewportBitmap() ?: return 0
+        writeBitmap("$name-viewport", bitmap)
+        writeText("$name-visible-terminal.txt", visibleTerminalText())
+        val rows = paintedRowCount(bitmap)
+        bitmap.recycle()
+        return rows
+    }
+
+    private fun renderViewportBitmap(): Bitmap? {
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        var bitmap: Bitmap? = null
+        launchedActivity?.onActivity { activity ->
+            val view = activity.window.decorView.findTerminalView() ?: return@onActivity
+            if (view.width <= 0 || view.height <= 0) return@onActivity
+            val b = Bitmap.createBitmap(view.width, view.height, Bitmap.Config.ARGB_8888)
+            view.draw(Canvas(b))
+            bitmap = b
+        }
+        return bitmap
+    }
+
+    private fun paintedRowCount(bitmap: Bitmap): Int {
+        var painted = 0
+        var y = 0
+        while (y < bitmap.height) {
+            var x = 0
+            var rowPainted = false
+            while (x < bitmap.width) {
+                val p = bitmap.getPixel(x, y)
+                if (android.graphics.Color.red(p) > 40 ||
+                    android.graphics.Color.green(p) > 40 ||
+                    android.graphics.Color.blue(p) > 40
+                ) {
+                    rowPainted = true
+                    break
+                }
+                x += 4
+            }
+            if (rowPainted) painted++
+            y += 4
+        }
+        return painted
+    }
+
+    /** Count DISTINCT non-blank rows of the restored alt frame (its FRAME row lines). */
+    private fun frameRowCount(text: String): Int =
+        text.split('\n').count { it.isNotBlank() }
+
+    // ---------------------------------------------------------------- Attach / wait
+
+    private fun attachSeededTmuxSession(hostRowTag: String) {
+        compose.waitUntil(timeoutMillis = 15_000) {
+            compose.onAllNodesWithTag(hostRowTag, useUnmergedTree = true)
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+        compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick()
+        compose.waitUntil(timeoutMillis = TerminalTestTimeouts.terminalVisibilityTimeoutMs()) {
+            compose.onAllNodesWithText(SESSION_NAME, useUnmergedTree = true)
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+        compose.onNodeWithText(SESSION_NAME, useUnmergedTree = true).performClick()
+        compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertExists()
+        waitForTerminalViewAttached()
+    }
+
+    private fun waitForTerminalViewAttached() {
+        compose.waitUntil(timeoutMillis = 30_000) {
+            var attached = false
+            launchedActivity?.onActivity { activity ->
+                val view = activity.window.decorView.findTerminalView()
+                attached = view?.currentSession != null && view.mEmulator != null
+            }
+            attached
+        }
+    }
+
+    private fun waitForConnected(label: String) {
+        compose.waitUntil(timeoutMillis = CONNECTED_TIMEOUT_MS) {
+            currentConnectionStatus() is TmuxSessionViewModel.ConnectionStatus.Connected
+        }
+        assertTrue(
+            "expected Connected after $label, observed=${currentConnectionStatus()}",
+            currentConnectionStatus() is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+    }
+
+    private fun currentConnectionStatus(): TmuxSessionViewModel.ConnectionStatus {
+        var status: TmuxSessionViewModel.ConnectionStatus = TmuxSessionViewModel.ConnectionStatus.Idle
+        launchedActivity?.onActivity { activity ->
+            status = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+                .connectionStatus.value
+        }
+        return status
+    }
+
+    private fun waitForVisibleTerminal(
+        label: String,
+        timeoutMillis: Long = TerminalTestTimeouts.terminalVisibilityTimeoutMs(),
+        predicate: (String) -> Boolean,
+    ): String {
+        var last = ""
+        val satisfied = runCatching {
+            compose.waitUntil(timeoutMillis = timeoutMillis) {
+                last = visibleTerminalText()
+                predicate(last)
+            }
+            true
+        }.getOrDefault(false)
+        if (!satisfied) writeText("failure-$label-visible-terminal.txt", last)
+        assertTrue("expected visible terminal for $label; got:\n$last", predicate(last))
+        return last
+    }
+
+    private fun visibleTerminalText(): String {
+        var text = ""
+        launchedActivity?.onActivity { activity ->
+            text = activity.window.decorView
+                .findTerminalView()?.currentSession?.emulator?.screen?.transcriptText.orEmpty()
+        }
+        return text
+    }
+
+    private fun assertNoVisibleReconnect(label: String) {
+        org.junit.Assert.assertEquals(
+            "expected no disconnect band for $label", 0,
+            compose.onAllNodesWithTag(TMUX_SESSION_ERROR_TAG, useUnmergedTree = true)
+                .fetchSemanticsNodes().size,
+        )
+        org.junit.Assert.assertEquals(
+            "expected no Tap Reconnect button for $label", 0,
+            compose.onAllNodesWithTag(TMUX_SESSION_RECONNECT_TAG, useUnmergedTree = true)
+                .fetchSemanticsNodes().size,
+        )
+        listOf("Reconnecting", "Disconnected", "Tap Reconnect").forEach { text ->
+            org.junit.Assert.assertEquals(
+                "expected no visible '$text' text for $label", 0,
+                compose.onAllNodesWithText(text, substring = true, useUnmergedTree = true)
+                    .fetchSemanticsNodes().size,
+            )
+        }
+    }
+
+    // ---------------------------------------------------------------- Fixture
+
+    private fun readFixtureKey(): String =
+        InstrumentationRegistry.getInstrumentation()
+            .context.assets.open("test_key").bufferedReader().use { it.readText() }
+
+    private suspend fun seedDockerHost(key: String): String {
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
+        val db = Room.databaseBuilder(appContext, AppDatabase::class.java, DATABASE_NAME)
+            .fallbackToDestructiveMigration(dropAllTables = true)
+            .build()
+        return try {
+            db.clearAllTables()
+            val storedKey = SshKeyStorage.persistKey(
+                context = appContext,
+                sshKeyDao = db.sshKeyDao(),
+                name = "issue1138-key-${System.currentTimeMillis()}",
+                content = key,
+            )
+            val hostId = db.hostDao().insert(
+                HostEntity(
+                    name = "Issue1138 Alt-Screen Partial Black",
+                    hostname = DEFAULT_HOST,
+                    port = DEFAULT_PORT,
+                    username = DEFAULT_USER,
+                    keyId = storedKey.id,
+                    tmuxInstalled = true,
+                    lastBootstrapAt = System.currentTimeMillis(),
+                ),
+            )
+            HOST_ROW_TAG_PREFIX + hostId
+        } finally {
+            db.close()
+        }
+    }
+
+    /**
+     * Seed a tmux session running a SPARSE ALT-SCREEN app: enter the alternate screen, draw a
+     * header (with the marker) + a couple of conversation lines + an input/status line, leaving
+     * a large BLANK conversation area — a Codex/Claude "Working" frame. Sparse (~110 non-blank
+     * chars over 6 lines): the surviving status line the local emulator keeps is > 25% of it,
+     * so the #966 divergence oracle MISSES it, yet > 3 non-blank lines so a healed pane reads
+     * non-partial-black.
+     */
+    private suspend fun seedAltScreenSession(key: String) {
+        val e = "\\033"
+        val frame = buildString {
+            append("$e[?1049h")           // enter alternate screen buffer
+            append("$e[2J$e[H")            // clear + home
+            append("$e[1;1H$FRAME_MARKER header codex podwiki")
+            append("$e[2;1HYou: fix the bug now")
+            append("$e[3;1HCodex: plan is ready")
+            append("$e[4;1HCodex: editing files")
+            append("$e[22;1Hinput box prompt >_")
+            append("$e[24;1H Working 7  esc to interrupt")
+        }
+        val payload = "printf '$frame'; while true; do sleep 3600; done"
+        val script = buildString {
+            appendLine("set -eu")
+            appendLine("tmux kill-session -t ${shellQuote(SESSION_NAME)} 2>/dev/null || true")
+            appendLine("tmux new-session -d -s ${shellQuote(SESSION_NAME)} ${shellQuote(payload)}")
+            appendLine("sleep 2")
+            appendLine("tmux list-sessions")
+        }
+        val result = SshConnection.connect(
+            host = DEFAULT_HOST,
+            port = DEFAULT_PORT,
+            user = DEFAULT_USER,
+            key = SshKey.Pem(key),
+            knownHosts = KnownHostsPolicy.AcceptAll,
+            timeoutMs = 15_000,
+        ).mapCatching { session -> session.use { it.exec(script) } }
+        val exec = result.getOrNull()
+        assertTrue(
+            "expected tmux seeding to succeed; exception=${result.exceptionOrNull()} stderr='${exec?.stderr}'",
+            exec?.exitCode == 0,
+        )
+        Log.i(LOG_TAG, "seeded alt-screen session: ${exec?.stdout?.trim()}")
+    }
+
+    private suspend fun cleanupRemoteTmuxSession(key: String) {
+        runCatching {
+            SshConnection.connect(
+                host = DEFAULT_HOST,
+                port = DEFAULT_PORT,
+                user = DEFAULT_USER,
+                key = SshKey.Pem(key),
+                knownHosts = KnownHostsPolicy.AcceptAll,
+                timeoutMs = 15_000,
+            ).mapCatching { session ->
+                session.use { it.exec("tmux kill-session -t ${shellQuote(SESSION_NAME)} 2>/dev/null || true") }
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------- Artifacts
+
+    private fun writeBitmap(name: String, bitmap: Bitmap): File {
+        val file = artifactFile("$name.png")
+        java.io.FileOutputStream(file).use { out ->
+            check(bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)) {
+                "failed to write bitmap to ${file.absolutePath}"
+            }
+        }
+        println("ISSUE1138_VIEWPORT ${file.absolutePath}")
+        return file
+    }
+
+    private fun writeText(name: String, text: String): File {
+        val file = artifactFile(name)
+        file.writeText(text)
+        println("ISSUE1138_TEXT ${file.absolutePath}")
+        return file
+    }
+
+    private fun writeSummary(): File =
+        writeText(
+            "issue1138-summary.txt",
+            buildString {
+                appendLine("test=AgentAltScreenPartialBlackHealJourneyE2eTest")
+                appendLine("issue=1138")
+                appendLine("fixture=tests/docker agents ($DEFAULT_HOST:$DEFAULT_PORT), sparse ALT-SCREEN app")
+                appendLine("running_on_ci=${TerminalTestTimeouts.isRunningOnCi()}")
+                appendLine("session=$SESSION_NAME")
+                appendLine("frame_marker=$FRAME_MARKER")
+                appendLine(
+                    "scenario=attach a sparse alt-screen agent frame, inject the partial-black " +
+                        "(clear + only the live status line) on the LIVE emulator, assert transport " +
+                        "stays Connected, then drive ONE steady-state stale-render watchdog tick and " +
+                        "assert the FULL alt frame (marker + upper rows) re-renders",
+                )
+                appendLine(
+                    "expectation=transport ALIVE (Connected, no reconnect surface) AND render HEALS " +
+                        "(full alt frame restored from tmux's authoritative capture)",
+                )
+            },
+        )
+
+    private fun artifactFile(name: String): File {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val mediaRoot = com.pocketshell.app.test.testArtifactsRoot(instrumentation.targetContext)
+        val dir = File(mediaRoot, "additional_test_output/$DEVICE_DIR_NAME")
+        check(dir.exists() || dir.mkdirs()) { "could not create artifact directory ${dir.absolutePath}" }
+        return File(dir, name)
+    }
+
+    private fun View.findTerminalView(): TerminalView? {
+        if (this is TerminalView) return this
+        if (this !is ViewGroup) return null
+        for (index in 0 until childCount) {
+            val match = getChildAt(index).findTerminalView()
+            if (match != null) return match
+        }
+        return null
+    }
+
+    private fun shellQuote(value: String): String =
+        "'" + value.replace("'", "'\"'\"'") + "'"
+
+    private companion object {
+        const val DATABASE_NAME: String = "pocketshell.db"
+        const val LOG_TAG: String = "Issue1138AltBlack"
+        const val DEVICE_DIR_NAME: String = "issue1138-alt-screen-partial-black-heal"
+        const val SESSION_NAME: String = "issue1138-alt-black"
+        const val FRAME_MARKER: String = "ISSUE1138-ALT"
+
+        const val MIN_RESTORED_FRAME_ROWS: Int = 5
+
+        val RESTORE_TIMEOUT_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 30_000L else 20_000L
+        val CONNECTED_TIMEOUT_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 30_000L else 15_000L
+    }
+}

--- a/app/src/androidTest/java/com/pocketshell/app/proof/AgentAltScreenPartialBlackHealJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/AgentAltScreenPartialBlackHealJourneyE2eTest.kt
@@ -5,7 +5,7 @@ import android.graphics.Canvas
 import android.util.Log
 import android.view.View
 import android.view.ViewGroup
-import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
@@ -13,7 +13,6 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.lifecycle.ViewModelProvider
 import androidx.room.Room
-import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.pocketshell.app.BackgroundGraceTestOverride
@@ -34,7 +33,6 @@ import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
-import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -78,37 +76,64 @@ import java.io.File
 @RunWith(AndroidJUnit4::class)
 class AgentAltScreenPartialBlackHealJourneyE2eTest {
 
+    // Issue #788/#848: `createAndroidComposeRule<MainActivity>()` (NOT
+    // `createEmptyComposeRule()` + a hand-rolled `ActivityScenario.launch`) so the
+    // Compose test clock drives the SAME foreground MainActivity the Termux
+    // `TerminalView` AndroidView interop child is placed into — fixing the #470
+    // swiftshader interop-placement / enumeration stall. The rule launches
+    // MainActivity in its own `before()` phase, so the DB host row + remote
+    // alt-screen tmux session must be seeded BEFORE launch — done by
+    // [SeedBeforeLaunchRule] in the RuleChain below.
+    val compose = createAndroidComposeRule<MainActivity>()
+
+    // Deterministic seed-before-launch ordering via RuleChain (outer `before()`
+    // runs first):
+    //   1. PreGrantPermissionsRule — grant runtime perms before launch (no focus
+    //      theft from the system GrantPermissionsActivity, #470 blocker #1).
+    //   2. SeedBeforeLaunchRule     — seed the remote sparse alt-screen tmux
+    //      session + DB host row (resolving [fixtureKey] + [hostRowTag]) BEFORE
+    //      the compose rule launches MainActivity so it reads a populated DB.
+    //   3. compose                  — launch MainActivity.
     @get:Rule
-    val compose = createEmptyComposeRule()
+    val ruleChain: org.junit.rules.RuleChain = org.junit.rules.RuleChain
+        .outerRule(PreGrantPermissionsRule())
+        .around(SeedBeforeLaunchRule { seedBeforeLaunch() })
+        .around(compose)
 
-    @get:Rule
-    val grantPermissions = PreGrantPermissionsRule()
+    // Resolved during [seedBeforeLaunch] (the rule's `before()` phase), read by
+    // the test body after launch.
+    private lateinit var fixtureKey: String
+    private lateinit var hostRowTag: String
 
-    private var launchedActivity: ActivityScenario<MainActivity>? = null
-    private var seededKey: String? = null
-
-    @Before
-    fun setUp() {
+    /**
+     * Seed lambda invoked by [SeedBeforeLaunchRule] in the rule's `before()`
+     * phase, BEFORE [compose] launches MainActivity. Establishes the remote
+     * sparse alt-screen tmux session + DB host row so MainActivity's first
+     * `hostDao.getAll()` read sees the populated DB — exactly the work the body
+     * used to do inline before `ActivityScenario.launch`.
+     */
+    private suspend fun seedBeforeLaunch() {
         BackgroundGraceTestOverride.setForTest(null)
+        val key = readFixtureKey()
+        fixtureKey = key
+        waitForSshFixtureReady(SshKey.Pem(key))
+        seedAltScreenSession(key)
+        hostRowTag = seedDockerHost(key)
     }
 
     @After
     fun tearDown() {
-        runCatching { launchedActivity?.close() }
-        launchedActivity = null
         BackgroundGraceTestOverride.setForTest(null)
-        seededKey?.let { key -> runCatching { runBlocking { cleanupRemoteTmuxSession(key) } } }
+        if (::fixtureKey.isInitialized) {
+            runCatching { runBlocking { cleanupRemoteTmuxSession(fixtureKey) } }
+        }
     }
 
     @Test
     fun steadyStateWatchdogHealsPartialBlackAltScreenAgentPane() = runBlocking {
-        val key = readFixtureKey()
-        seededKey = key
-        waitForSshFixtureReady(SshKey.Pem(key))
-        seedAltScreenSession(key)
-
-        val hostRowTag = seedDockerHost(key)
-        launchedActivity = ActivityScenario.launch(MainActivity::class.java)
+        // Issue #788/#848: the sparse alt-screen tmux session + DB host row were
+        // already seeded BEFORE MainActivity launched, by [seedBeforeLaunch] in
+        // the rule chain's `before()`. Attach to it from the freshly-launched app.
         attachSeededTmuxSession(hostRowTag)
 
         // Baseline: the sparse alt-screen frame is in the live pane and the session is Connected.
@@ -180,7 +205,7 @@ class AgentAltScreenPartialBlackHealJourneyE2eTest {
     private fun driveStaleRenderHeal(): Boolean {
         var result = false
         val latch = java.util.concurrent.CountDownLatch(1)
-        launchedActivity?.onActivity { activity ->
+        compose.activityRule.scenario.onActivity { activity ->
             val vm = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
             runBlocking { result = vm.healActivePaneIfStaleRenderForTest() }
             latch.countDown()
@@ -192,7 +217,7 @@ class AgentAltScreenPartialBlackHealJourneyE2eTest {
 
     private fun activePanePartiallyBlank(): Boolean {
         var hit = false
-        launchedActivity?.onActivity { activity ->
+        compose.activityRule.scenario.onActivity { activity ->
             val vm = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
             hit = vm.panes.value.firstOrNull()
                 ?.terminalState
@@ -203,7 +228,7 @@ class AgentAltScreenPartialBlackHealJourneyE2eTest {
 
     private fun clientDisconnected(): Boolean {
         var disconnected = false
-        launchedActivity?.onActivity { activity ->
+        compose.activityRule.scenario.onActivity { activity ->
             val vm = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
             disconnected = vm.clientDisconnectedForTest()
         }
@@ -215,7 +240,7 @@ class AgentAltScreenPartialBlackHealJourneyE2eTest {
     private fun feedFrameToEmulator(frame: String) {
         val bytes = frame.toByteArray(Charsets.UTF_8)
         var fed = false
-        launchedActivity?.onActivity { activity ->
+        compose.activityRule.scenario.onActivity { activity ->
             val view = activity.window.decorView.findTerminalView() ?: return@onActivity
             val emulator = view.mEmulator ?: return@onActivity
             emulator.append(bytes, bytes.size)
@@ -240,7 +265,7 @@ class AgentAltScreenPartialBlackHealJourneyE2eTest {
     private fun renderViewportBitmap(): Bitmap? {
         InstrumentationRegistry.getInstrumentation().waitForIdleSync()
         var bitmap: Bitmap? = null
-        launchedActivity?.onActivity { activity ->
+        compose.activityRule.scenario.onActivity { activity ->
             val view = activity.window.decorView.findTerminalView() ?: return@onActivity
             if (view.width <= 0 || view.height <= 0) return@onActivity
             val b = Bitmap.createBitmap(view.width, view.height, Bitmap.Config.ARGB_8888)
@@ -280,14 +305,24 @@ class AgentAltScreenPartialBlackHealJourneyE2eTest {
     // ---------------------------------------------------------------- Attach / wait
 
     private fun attachSeededTmuxSession(hostRowTag: String) {
-        compose.waitUntil(timeoutMillis = 15_000) {
-            compose.onAllNodesWithTag(hostRowTag, useUnmergedTree = true)
-                .fetchSemanticsNodes().isNotEmpty()
+        // Issue #788/#848: cold-compose-aware presence poll. Under
+        // createAndroidComposeRule the activity launches in the rule's `before()`;
+        // on a contended swiftshader emulator its cold compose to the HostList
+        // route can take tens of seconds, and the first frames throw
+        // IllegalStateException "No compose hierarchies found" instead of an empty
+        // node list — wrap so the poll keeps trying rather than propagating the ISE.
+        compose.waitUntil(timeoutMillis = TerminalTestTimeouts.screenRenderPresenceTimeoutMs()) {
+            runCatching {
+                compose.onAllNodesWithTag(hostRowTag, useUnmergedTree = true)
+                    .fetchSemanticsNodes().isNotEmpty()
+            }.getOrDefault(false)
         }
         compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick()
         compose.waitUntil(timeoutMillis = TerminalTestTimeouts.terminalVisibilityTimeoutMs()) {
-            compose.onAllNodesWithText(SESSION_NAME, useUnmergedTree = true)
-                .fetchSemanticsNodes().isNotEmpty()
+            runCatching {
+                compose.onAllNodesWithText(SESSION_NAME, useUnmergedTree = true)
+                    .fetchSemanticsNodes().isNotEmpty()
+            }.getOrDefault(false)
         }
         compose.onNodeWithText(SESSION_NAME, useUnmergedTree = true).performClick()
         compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertExists()
@@ -297,7 +332,7 @@ class AgentAltScreenPartialBlackHealJourneyE2eTest {
     private fun waitForTerminalViewAttached() {
         compose.waitUntil(timeoutMillis = 30_000) {
             var attached = false
-            launchedActivity?.onActivity { activity ->
+            compose.activityRule.scenario.onActivity { activity ->
                 val view = activity.window.decorView.findTerminalView()
                 attached = view?.currentSession != null && view.mEmulator != null
             }
@@ -317,7 +352,7 @@ class AgentAltScreenPartialBlackHealJourneyE2eTest {
 
     private fun currentConnectionStatus(): TmuxSessionViewModel.ConnectionStatus {
         var status: TmuxSessionViewModel.ConnectionStatus = TmuxSessionViewModel.ConnectionStatus.Idle
-        launchedActivity?.onActivity { activity ->
+        compose.activityRule.scenario.onActivity { activity ->
             status = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
                 .connectionStatus.value
         }
@@ -344,7 +379,7 @@ class AgentAltScreenPartialBlackHealJourneyE2eTest {
 
     private fun visibleTerminalText(): String {
         var text = ""
-        launchedActivity?.onActivity { activity ->
+        compose.activityRule.scenario.onActivity { activity ->
             text = activity.window.decorView
                 .findTerminalView()?.currentSession?.emulator?.screen?.transcriptText.orEmpty()
         }

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -10893,7 +10893,15 @@ public class TmuxSessionViewModel @Inject constructor(
         // The discriminating check: tmux carries a real frame but the local render
         // shows almost none of it → stale render on a live transport. If the
         // render already matches tmux, this is false and we never touch the grid.
-        if (!pane.terminalState.visibleScreenDivergesFromCapture(captureText)) return false
+        //
+        // Issue #1138: use the UNION predicate so a live-streaming ALT-SCREEN agent pane
+        // (Codex/Claude) that went PARTIAL-BLACK — only the live status line painted, upper
+        // rows black — is healed too. Its sparse alt-screen frame puts the surviving band
+        // ABOVE the #966 25% divergence ceiling, so the old `visibleScreenDivergesFromCapture`
+        // predicate alone read it "healthy" and the watchdog never fired. The new predicate
+        // also heals a partial-black pane when tmux's grid holds materially more (anti-thrash
+        // guarded), restoring the FULL viewport from tmux's authoritative capture.
+        if (!pane.terminalState.visibleRenderLostFrameVsCapture(captureText)) return false
         val cursor = parseTmuxPaneCursor(combined.cursorReply)
         Log.i(
             ISSUE_145_RECONNECT_TAG,

--- a/app/src/test/java/com/pocketshell/app/tmux/PartialBlackPaneHealTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/PartialBlackPaneHealTest.kt
@@ -324,6 +324,110 @@ class PartialBlackPaneHealTest {
         )
     }
 
+    // -------------------------------------------------------------------------
+    // (6) Issue #1138: a LIVE-STREAMING alt-screen AGENT pane (Codex/Claude) goes
+    //     partial-black — only the live status line painted, upper alt-screen rows
+    //     black — with NO user switch/send/reattach. The STEADY-STATE stale-render
+    //     watchdog is the ONLY net on this passively-observed pane. On base its sole
+    //     predicate ([visibleScreenDivergesFromCapture], 25% ceiling) MISSES the
+    //     sparse alt-screen frame (the surviving status line exceeds 25% of the
+    //     frame's few non-blank chars) -> the watchdog SKIPS the heal (RED). With the
+    //     union predicate ([visibleRenderLostFrameVsCapture]) the watchdog heals and
+    //     restores the FULL frame from tmux's authoritative capture (GREEN).
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun steadyStateWatchdogHealsPartialBlackAltScreenAgentPane() = runVmTest {
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%6", title = "codex")
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == "%6" }
+
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+
+        // Drive the pane onto the ALTERNATE screen and paint ONLY the live status line.
+        overpaintAltScreenPartialBlack(pane)
+        assertTrue(
+            "precondition: the live-streaming alt-screen agent pane is partial-black (#1138)",
+            pane.terminalState.visibleScreenIsPartiallyBlank(),
+        )
+        // RED discriminator: the OLD watchdog predicate MISSES the sparse alt-screen frame,
+        // so on base `healActivePaneIfStaleRenderForTest` (which used this oracle) returns
+        // false and the pane stays black on a live transport.
+        assertFalse(
+            "RED (#1138): the #966 divergence oracle ALONE SKIPS the sparse alt-screen " +
+                "partial-black — its surviving band exceeds the 25% ceiling of the frame",
+            pane.terminalState.visibleScreenDivergesFromCapture(SPARSE_AGENT_FRAME.joinToString("\n")),
+        )
+
+        // Queue the FULL sparse agent frame the heal `capture-pane` returns.
+        client.capturePaneResponses.addLast(
+            CommandResponse(number = 99L, output = SPARSE_AGENT_FRAME, isError = false),
+        )
+        val healCapturesBefore = client.healCaptureCount()
+
+        // THE REAL PATH: one steady-state stale-render watchdog tick over the active pane.
+        val healed = vm.healActivePaneIfStaleRenderForTest()
+        advanceUntilIdle()
+
+        assertTrue(
+            "REGRESSION (#1138): the steady-state watchdog must heal a partial-black " +
+                "alt-screen agent pane. On base the divergence-only predicate skipped it.",
+            healed,
+        )
+        assertTrue(
+            "the watchdog issued a heal capture-pane",
+            client.healCaptureCount() > healCapturesBefore,
+        )
+        assertFalse(
+            "the heal restored the FULL frame (no longer partial-black)",
+            pane.terminalState.visibleScreenIsPartiallyBlank(),
+        )
+        assertTrue(
+            "the restored pane shows tmux's authoritative content (the upper rows repainted)",
+            renderedTranscriptFor(pane).contains(AGENT_FRAME_MARKER),
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // (7) Issue #1138 over-heal guard: the SAME steady-state watchdog must NOT heal
+    //     when tmux's alt-screen capture is ALSO near-empty (the #807 by-design void:
+    //     the agent's OWN intentionally-cleared frame). No lost frame to restore ->
+    //     no reseed-thrash every 4s on a legitimately-empty pane.
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun steadyStateWatchdogDoesNotHealByDesignAltScreenVoid() = runVmTest {
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%7", title = "codex")
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == "%7" }
+
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+
+        overpaintAltScreenPartialBlack(pane)
+        assertTrue(pane.terminalState.visibleScreenIsPartiallyBlank())
+
+        // tmux ALSO returns only the status line — the agent genuinely cleared its frame.
+        client.capturePaneResponses.addLast(
+            CommandResponse(number = 98L, output = listOf(" Working 7  esc to interrupt"), isError = false),
+        )
+
+        val healed = vm.healActivePaneIfStaleRenderForTest()
+        advanceUntilIdle()
+
+        assertFalse(
+            "OVER-HEAL GUARD (#1138/#807): when tmux's alt-screen capture is ALSO near-empty " +
+                "there is no lost frame to restore — the watchdog must NOT heal",
+            healed,
+        )
+        assertTrue(
+            "the pane is left untouched (still partial-black) — no reseed-thrash on a " +
+                "by-design void",
+            pane.terminalState.visibleScreenIsPartiallyBlank(),
+        )
+    }
+
     // ------------------------------------------------------------------ Harness
 
     private fun runVmTest(body: suspend TestScope.() -> Unit) = runTest {
@@ -389,6 +493,18 @@ class PartialBlackPaneHealTest {
         pane.terminalState.appendRemoteOutput(
             (CLEAR_ONLY + "ISSUE941-LIVE-LINE 7\r\n").toByteArray(Charsets.US_ASCII),
         )
+    }
+
+    /**
+     * Issue #1138: drive the pane onto the ALTERNATE screen (where Codex/Claude run their
+     * full-screen TUI) and paint ONLY the live status line at the bottom (cursor-addressed) —
+     * the maintainer's partial-black: the agent's status line repaints locally while the
+     * upper alt-screen rows stay black.
+     */
+    private fun overpaintAltScreenPartialBlack(pane: TmuxPaneState) {
+        val esc = ""
+        val frame = "$esc[?1049h$esc[2J$esc[H$esc[24;1H Working 7  esc to interrupt streaming the reply"
+        pane.terminalState.appendRemoteOutput(frame.toByteArray(Charsets.US_ASCII))
     }
 
     private fun FakeTmuxClient.captureCount(): Int =
@@ -509,5 +625,20 @@ class PartialBlackPaneHealTest {
 
         // ESC[2J ESC[H — clear screen + cursor home (the overpaint preamble).
         val CLEAR_ONLY: String = "[2J[H"
+
+        // Issue #1138: the SPARSE alt-screen agent frame tmux's grid holds while "Working" —
+        // a header, a couple of conversation lines, a large BLANK conversation area (the
+        // sparse part) and the input/status line. Its non-blank content is small enough that
+        // the surviving status line is > 25% of it (so the #966 divergence oracle MISSES it),
+        // yet > 3 non-blank lines so the healed pane is no longer partial-black.
+        const val AGENT_FRAME_MARKER: String = "ISSUE1138-AGENT-FRAME"
+        val SPARSE_AGENT_FRAME: List<String> = buildList {
+            add("HEADER $AGENT_FRAME_MARKER codex podwiki")
+            add("You: fix the partial-black bug")
+            add("Codex: sure, here is the plan and the change")
+            repeat(10) { add("") } // blank conversation area while Working (the sparse part)
+            add("input box: >_")
+            add(" Working 7  esc to interrupt")
+        }
     }
 }

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -471,6 +471,21 @@ JOURNEY_CLASSES=(
   # the deterministic agents:2222 fixture (state injected LOCALLY, no toxiproxy) and does
   # NOT self-skip on CI, so it belongs here.
   "$FQCN_PREFIX.StaleRenderHealOnLiveTransportJourneyE2eTest"
+  # ADDED (#1138): the SEMI/PARTIAL-black on a live AGENT ALT-SCREEN pane (v0.4.19 dogfood,
+  # reproduced on BOTH Codex and Claude). The agent redraws with cursor-addressed writes, so
+  # only its live status line repaints locally while the upper ALT-SCREEN rows stay black. An
+  # alt-screen agent frame is SPARSE (header + a big blank conversation area + status), so the
+  # surviving status line is a LARGE fraction of it — ABOVE the #966 25% divergence ceiling, so
+  # the v0.4.18 steady-state stale-render watchdog (whose ONLY predicate was
+  # `visibleScreenDivergesFromCapture`) read it "healthy" and never healed. This journey seeds a
+  # SPARSE alt-screen app, attaches, injects the partial-black (clear + only the status line) on
+  # the LIVE emulator (the REMOTE tmux grid keeps the full sparse alt frame → transport
+  # GUARANTEED LIVE), asserts the pane is partial-black + Connected, then drives ONE watchdog
+  # tick and asserts the FULL alt frame (header marker + upper rows) re-renders. RED on base
+  # (divergence-only skips the sparse frame — unit-proven in PartialBlackPaneHealTest); GREEN
+  # with the union predicate `visibleRenderLostFrameVsCapture`. Uses ONLY the deterministic
+  # agents:2222 fixture (state injected LOCALLY, no toxiproxy) and does NOT self-skip on CI.
+  "$FQCN_PREFIX.AgentAltScreenPartialBlackHealJourneyE2eTest"
   # ADDED (epic #687 slice 2, #717 — reveal/reflow-heal absorbed from #658): after a
   # voice-send the active pane must NEVER go black. The composer/keyboard dismissal
   # shrinks the IME inset → `resizeRemotePty` → `maybeRefreshControlClientSize`; for an

--- a/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurfaceState.kt
+++ b/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurfaceState.kt
@@ -706,6 +706,66 @@ class TerminalSurfaceState(
     }
 
     /**
+     * Issue #1138 — the steady-state stale-render watchdog's "the live render LOST the
+     * frame" predicate. It is the UNION of two miss cases against tmux's authoritative
+     * `capture-pane`:
+     *
+     *  (a) a DRAMATICALLY-stale render — [visibleScreenDivergesFromCapture] (the #966
+     *      scattered-fragment / mostly-black-on-a-dense-frame case), AND
+     *
+     *  (b) a PARTIAL-BLACK render — [visibleScreenIsPartiallyBlank] — whose surviving live
+     *      band happens to exceed 25% of tmux's frame, so (a)'s
+     *      [STALE_RENDER_MAX_RENDERED_FRACTION] ceiling reads it "healthy" and skips it.
+     *      This is the maintainer's live-streaming ALT-SCREEN agent pane (Codex + Claude,
+     *      v0.4.19 dogfood #1138): the agent redraws with cursor-addressed writes, so only
+     *      its live status line repaints locally while the upper alt-screen rows stay black.
+     *      An alt-screen agent frame is SPARSE (header + a big blank conversation area +
+     *      an input/status line), so its non-blank content is small and the lone status
+     *      line is a LARGE fraction of it — the #966 divergence oracle therefore never
+     *      fires, and the steady-state watchdog (whose ONLY predicate was that oracle) left
+     *      the pane stuck mostly-black on a live transport.
+     *
+     * For case (b) the heal fires ONLY when tmux's capture carries MATERIALLY MORE visible
+     * non-blank content than the render (its visible tail has ≥ [STALE_RENDER_MIN_CAPTURE_CHARS]
+     * AND at least [PARTIAL_BLACK_HEAL_MIN_EXTRA_CHARS] more than the render). That gap is the
+     * anti-thrash / distinguish-from-by-design guard:
+     *  - a legitimately-short prompt (tmux ALSO holds only those few lines → capture ≈ render)
+     *    never re-heals — no reseed-thrash on every watchdog tick; and
+     *  - the #807 by-design alt-screen void (the agent's OWN intentionally-empty frame → tmux
+     *    capture ≈ render, near-nothing to restore) is correctly left alone.
+     * Only a genuine unrepainted frame — tmux holds the full frame while the render shows the
+     * band — heals, restoring the FULL viewport from tmux's authoritative grid.
+     *
+     * Returns false when no emulator is attached (nothing rendered to judge).
+     */
+    fun visibleRenderLostFrameVsCapture(captureText: String): Boolean {
+        // (a) The #966 dramatic-divergence case (unchanged oracle).
+        if (visibleScreenDivergesFromCapture(captureText)) return true
+        // (b) The #1138 partial-black-vs-fuller-capture case.
+        if (!visibleScreenIsPartiallyBlank()) return false
+        val emulator = bridge?.emulator ?: _session?.emulator ?: return false
+        val visibleRows = try {
+            emulator.screen.visibleScreenRows
+        } catch (_: Throwable) {
+            return false
+        }
+        if (visibleRows <= 0) return false
+        val captureVisibleNonBlank = captureText
+            .split('\n')
+            .filter { it.isNotBlank() }
+            .takeLast(visibleRows)
+            .sumOf { line -> line.count { !it.isWhitespace() } }
+        // tmux has (near) nothing for this pane → no real frame to restore (the #807
+        // alt-screen void). Defer — do NOT heal a genuinely-empty pane to itself.
+        if (captureVisibleNonBlank < STALE_RENDER_MIN_CAPTURE_CHARS) return false
+        val renderedNonBlank = renderedNonBlankCharCount()
+        // tmux carries MATERIALLY MORE than the render → the upper rows the render lost are
+        // still in tmux's grid; re-seed to restore them. A near-equal capture (short prompt /
+        // by-design void) sits under the gap and is left alone.
+        return captureVisibleNonBlank - renderedNonBlank >= PARTIAL_BLACK_HEAL_MIN_EXTRA_CHARS
+    }
+
+    /**
      * Pull the current visible-transcript text from the attached session and
      * run the matcher across it. Returns an empty list when no session is
      * attached or the session has no emulator yet (the View has not yet laid
@@ -989,6 +1049,27 @@ class TerminalSurfaceState(
          * normally (idempotent re-seed).
          */
         private const val NON_DESTRUCTIVE_SWAP_CLEAR_RATIO = 3
+
+        /**
+         * Issue #1138: the minimum EXTRA non-blank chars tmux's authoritative
+         * `capture-pane` frame must carry OVER the local render before the
+         * steady-state watchdog heals a PARTIAL-BLACK pane ([visibleRenderLostFrameVsCapture]).
+         *
+         * The maintainer's live-streaming ALT-SCREEN agent pane (Codex/Claude) shows only
+         * the live status line while the upper alt-screen rows stayed black. An alt-screen
+         * agent frame is SPARSE (a header + a large blank conversation area + an input/status
+         * line), so its non-blank content is small and the surviving status line is a LARGE
+         * fraction of it — above the 25% [STALE_RENDER_MAX_RENDERED_FRACTION] divergence
+         * ceiling, so the #966 divergence oracle reads it "healthy" and never heals it.
+         *
+         * Requiring tmux to carry at least this many MORE non-blank chars than the render is
+         * the anti-thrash guard: a legitimately-short prompt (tmux ALSO has only those few
+         * lines → capture ≈ render) and the #807 by-design alt-screen void (the agent's OWN
+         * empty frame → capture ≈ render) both sit UNDER this gap and are left alone. Only a
+         * genuine unrepainted frame — tmux holds the full frame, the render shows the band —
+         * clears it. One line's worth of real content (≈40 chars).
+         */
+        private const val PARTIAL_BLACK_HEAL_MIN_EXTRA_CHARS = 40
     }
 }
 

--- a/shared/core-terminal/src/test/java/com/pocketshell/core/terminal/ui/TerminalSurfaceStateAgentPartialBlackTest.kt
+++ b/shared/core-terminal/src/test/java/com/pocketshell/core/terminal/ui/TerminalSurfaceStateAgentPartialBlackTest.kt
@@ -1,0 +1,203 @@
+package com.pocketshell.core.terminal.ui
+
+import android.os.Looper
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import java.io.OutputStream
+
+/**
+ * Issue #1138 — [TerminalSurfaceState.visibleRenderLostFrameVsCapture] is the steady-state
+ * watchdog's "the live render LOST the frame" predicate for a live-streaming AGENT pane.
+ *
+ * ## The maintainer's report (v0.4.19 dogfood, 2026-07-01)
+ *
+ * A connected Claude Code AND a connected Codex session (host `pocketshell` / `podwiki`) each
+ * showed a SEMI/PARTIAL-black terminal: only the agent's live status line (`∘ Working 7`) +
+ * cursor near the bottom, the upper ALT-SCREEN rows black. The agent redraws with cursor-
+ * addressed writes, so only its live status line repaints locally while the upper rows the
+ * pane lost stay black. The pane is on the ALTERNATE screen (Codex/Claude run a full-screen
+ * TUI), and an alt-screen frame is SPARSE: a header + a large blank conversation area + an
+ * input/status line. So its non-blank content is small, and the surviving status line is a
+ * LARGE fraction of it — ABOVE the #966 25% divergence ceiling. The v0.4.18 steady-state
+ * stale-render watchdog's ONLY heal predicate was [visibleScreenDivergesFromCapture], so it
+ * read the pane "healthy" and never fired — the pane sat mostly-black on a LIVE transport.
+ *
+ * ## RED → GREEN (D33/G1/G10)
+ *
+ * Each test drives a REAL emulator onto the alternate screen into the exact partial-black
+ * state, then pins:
+ *  - RED gap: the OLD predicate [visibleScreenDivergesFromCapture] returns FALSE against the
+ *    agent's authoritative full alt-screen capture (so the watchdog would SKIP the heal).
+ *  - GREEN fix: the union predicate [visibleRenderLostFrameVsCapture] returns TRUE (heal fires).
+ *
+ * ## Class coverage (D32-G2) — the whole class, not the one reported instance
+ *  - alt-screen partial-black (status-line-only) against a full agent frame → heals (the bug).
+ *  - the #966 scattered-fragment case still heals (union preserves divergence).
+ *  - anti-thrash: a legitimately-short prompt (tmux ≈ render) → does NOT heal.
+ *  - the #807 by-design alt-screen void (tmux ALSO near-empty) → does NOT heal.
+ *  - a healthy fully-painted pane → does NOT heal.
+ */
+@RunWith(RobolectricTestRunner::class)
+class TerminalSurfaceStateAgentPartialBlackTest {
+
+    private class NoopOutputStream : OutputStream() {
+        override fun write(b: Int) = Unit
+        override fun write(b: ByteArray, off: Int, len: Int) = Unit
+    }
+
+    private fun withAttachedSurface(block: (TerminalSurfaceState) -> Unit) = runBlocking {
+        val state = TerminalSurfaceState()
+        val producerScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val producerJob = state.attachExternalProducer(
+            scope = producerScope,
+            stdout = MutableSharedFlow(extraBufferCapacity = 1),
+            remoteStdin = NoopOutputStream(),
+            suppressQueryResponses = true,
+        )
+        try {
+            block(state)
+        } finally {
+            producerJob.cancel()
+            producerScope.cancel()
+            state.detachExternalProducer()
+        }
+    }
+
+    /** ESC, so the test feeds real control sequences. */
+    private val esc = ""
+
+    /**
+     * The full alt-screen agent frame tmux's grid holds while "Working": a header, a couple
+     * of conversation lines, a large BLANK conversation area (padding — the sparse part), an
+     * input box and the live status line. Sparse: ~120 non-blank chars, so the surviving
+     * status line (~40 chars) is ~33% of it — above the 25% divergence ceiling.
+     */
+    private fun fullAgentAltCapture(): String = buildString {
+        append("HEADER: codex session on podwiki\n")
+        append("You: fix the partial-black bug\n")
+        append("Codex: sure, here is the plan and the details of the change\n")
+        repeat(10) { append("\n") } // blank conversation area while Working (the sparse part)
+        append("input box: >_\n")
+        append(" Working 7  esc to interrupt\n")
+    }
+
+    /** Drive the emulator onto the alt screen and paint ONLY the live status line. */
+    private fun paintAltScreenPartialBlack(state: TerminalSurfaceState) {
+        val frame = buildString {
+            append("$esc[?1049h")   // enter alternate screen buffer
+            append("$esc[2J$esc[H") // clear + home
+            append("$esc[24;1H Working 7  esc to interrupt")
+        }
+        state.appendRemoteOutput(frame.toByteArray(Charsets.US_ASCII))
+        shadowOf(Looper.getMainLooper()).idle()
+    }
+
+    @Test
+    fun altScreenPartialBlackIsMissedByDivergenceButHealedByUnion() = withAttachedSurface { state ->
+        paintAltScreenPartialBlack(state)
+
+        // Preconditions: this IS the maintainer's partial-black, NOT fully blank.
+        assertFalse(
+            "precondition: a live status line makes the pane NOT fully blank",
+            state.visibleScreenIsBlank(),
+        )
+        assertTrue(
+            "precondition: the alt-screen agent pane IS partial-black (#1138 symptom)",
+            state.visibleScreenIsPartiallyBlank(),
+        )
+
+        // RED: the old divergence oracle reads the pane "healthy" — the surviving status
+        // line exceeds 25% of the sparse alt-screen frame, so the v0.4.18 watchdog SKIPS it.
+        assertFalse(
+            "RED (#1138): the #966 divergence oracle MISSES the alt-screen partial-black — " +
+                "its surviving band exceeds the 25% ceiling of the sparse agent frame",
+            state.visibleScreenDivergesFromCapture(fullAgentAltCapture()),
+        )
+
+        // GREEN: the union predicate heals it — tmux holds materially more (the full frame).
+        assertTrue(
+            "GREEN (#1138): the union predicate must detect the alt-screen partial-black " +
+                "against the agent's authoritative full capture and heal it",
+            state.visibleRenderLostFrameVsCapture(fullAgentAltCapture()),
+        )
+    }
+
+    @Test
+    fun scatteredFragmentStillHealsThroughUnion() = withAttachedSurface { state ->
+        // The #966 case: the union must still fire (divergence branch preserved).
+        val fragments = buildString {
+            append("$esc[2J$esc[H")
+            append("3\r\n")
+            append("$esc[10;1H")
+            append("24m 3 / 8 / 4 / 3 / 31\r\n")
+            append("$esc[15;40H")
+            append("x\r\n")
+            append("$esc[20;5H")
+            append("y z\r\n")
+        }
+        state.appendRemoteOutput(fragments.toByteArray(Charsets.US_ASCII))
+        shadowOf(Looper.getMainLooper()).idle()
+        val fullTui = buildString {
+            repeat(24) { row -> append("status row $row : a lot of real agent TUI content here padding\n") }
+        }
+        assertTrue(
+            "the #966 scattered-fragment case must still heal through the union predicate",
+            state.visibleRenderLostFrameVsCapture(fullTui),
+        )
+    }
+
+    @Test
+    fun shortPromptDoesNotThrashHeal() = withAttachedSurface { state ->
+        // A legitimately-short prompt: render matches a short capture — partial-black by the
+        // heuristic, but tmux ALSO has only those few lines, so the union must NOT heal
+        // (no reseed-thrash on every 4s watchdog tick).
+        val sparse = "user@host:~$ ls\r\n"
+        state.appendRemoteOutput("$esc[2J$esc[H$sparse".toByteArray(Charsets.US_ASCII))
+        shadowOf(Looper.getMainLooper()).idle()
+        assertFalse(
+            "anti-thrash: a short prompt whose tmux capture matches the render must NOT heal",
+            state.visibleRenderLostFrameVsCapture("user@host:~$ ls\n"),
+        )
+    }
+
+    @Test
+    fun byDesignAltScreenVoidDoesNotHeal() = withAttachedSurface { state ->
+        // The #807 by-design void: the agent's OWN alt-screen is genuinely near-empty (just
+        // the status line). tmux's capture ALSO carries only the status line → nothing to
+        // restore → the union must NOT heal (distinguish the render bug from a real clear).
+        paintAltScreenPartialBlack(state)
+        val voidCapture = " Working 7  esc to interrupt\n"
+        assertFalse(
+            "#807: when tmux's alt-screen is ALSO near-empty (agent's own clear) the union " +
+                "must NOT heal — there is no lost frame to restore",
+            state.visibleRenderLostFrameVsCapture(voidCapture),
+        )
+    }
+
+    @Test
+    fun healthyFullyPaintedPaneDoesNotHeal() = withAttachedSurface { state ->
+        val frame = buildString {
+            append("$esc[2J$esc[H")
+            repeat(24) { row -> append("status row $row : a lot of real agent TUI content here padding\r\n") }
+        }
+        state.appendRemoteOutput(frame.toByteArray(Charsets.US_ASCII))
+        shadowOf(Looper.getMainLooper()).idle()
+        val fullTui = buildString {
+            repeat(24) { row -> append("status row $row : a lot of real agent TUI content here padding\n") }
+        }
+        assertFalse(
+            "a healthy fully-painted pane (render matches tmux) must NOT heal",
+            state.visibleRenderLostFrameVsCapture(fullTui),
+        )
+    }
+}


### PR DESCRIPTION
Fixes the live dogfood black-screen: a Claude-agent alt-screen pane renders semi/partial-black and never heals.

**Root cause (pinned empirically):** the steady-state stale-render watchdog — the only periodic heal net on a passively-streaming pane — used only the #966 divergence oracle, whose 25% ceiling (`STALE_RENDER_MAX_RENDERED_FRACTION`) structurally misses a *sparse* alt-screen frame: a surviving ~40-char status line exceeds 25% of the sparse frame, so `partialBlank=true` but `diverges=false` and the heal never fires. `capture-pane` returns the full frame and the painter paints all rows — so this is heal-not-firing, not capture/paint.

**Fix:** new union predicate `TerminalSurfaceState.visibleRenderLostFrameVsCapture()` (divergence OR partial-black-with-materially-fuller-capture, anti-thrash `PARTIAL_BLACK_HEAL_MIN_EXTRA_CHARS=40`), wired into `healActivePaneIfStaleRender`. Preserves the #807 by-design void.

**Reviewer APPROVED** (https://github.com/alexeygrigorev/pocketshell/issues/1138#issuecomment-4850686503): personally-verified G1 red→green (`steadyStateWatchdogHealsPartialBlackAltScreenAgentPane` fails on base, passes with fix), G2/G3 class coverage (12 tests, 0 skipped), G10 connected journey `AgentAltScreenPartialBlackHealJourneyE2eTest` reproduces the real alt-screen path on `agents:2222` and is wired into the journey gate, adjacency sweep clean (#807/#966/#941/#717/#989).

On-device green lands with the batched `main` emulator-journey run after merge.

Closes #1138