### PR TITLE
ci: hard-kill wedged journey child + confirm shard partition (#1056)

### DIFF
--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -1507,6 +1507,34 @@ JOURNEY_CLASS_TIMEOUT_SECS="${JOURNEY_CLASS_TIMEOUT_SECS:-420}"
 JOURNEY_GRADLE_STOP_TIMEOUT_SECS="${JOURNEY_GRADLE_STOP_TIMEOUT_SECS:-60}"
 JOURNEY_CLASS_KILL_AFTER_SECS="${JOURNEY_CLASS_KILL_AFTER_SECS:-30}"
 
+# ---------------------------------------------------------------------------
+# Issue #1056: NO-OUTPUT (silence) watchdog — hard-kill a WEDGED child.
+#
+# The wall-clock `timeout` cap above bounds the TOTAL duration of a class
+# attempt, but it is a coarse backstop: a `connectedDebugAndroidTest` that WEDGES
+# and emits ZERO output still burns the full `JOURNEY_CLASS_TIMEOUT_SECS` ceiling
+# (and its retry burns it again) before the summary can be written. In run
+# 28307686762 a wedged child that emitted nothing for ~24 min let the job-level
+# 95-min wall CANCEL the whole step — beating the #835 STEP_TIMEOUT classifier so
+# the verdict was LOST (no trustworthy summary.md at all).
+#
+# A wedged instrumentation child is SILENT while it hangs, so silence is the
+# earliest, most reliable wedge signal — far tighter than the wall cap. This
+# watchdog streams every attempt's combined output live AND resets a silence
+# timer on each line; the instant an attempt emits nothing for
+# JOURNEY_NO_OUTPUT_TIMEOUT_SECS it hard-kills the child tree (TERM then a SIGKILL
+# backstop) and reports a uniform `timeout` exit (124). That (a) frees budget
+# faster than the coarse wall cap so more classes reach a verdict, and (b)
+# GUARANTEES the #835 STEP_TIMEOUT classifier always fires a trustworthy summary
+# well before the job-level wall — the verdict is never lost to a job cancel.
+#
+# Default 300s of silence sits BELOW the 420s wall cap (so a silent wedge dies on
+# silence, not on the coarse wall bound) yet comfortably ABOVE any legitimate
+# quiet stretch (APK install + `am instrument` spin-up + the first generous
+# `pocketshellCi=true` E2E wait all emit progress inside ~2 min). The window is
+# always clamped to the wall cap so a tiny cap in the self-test still governs.
+JOURNEY_NO_OUTPUT_TIMEOUT_SECS="${JOURNEY_NO_OUTPUT_TIMEOUT_SECS:-300}"
+
 # budget_remaining — seconds left in the suite-level budget (never negative).
 budget_remaining() {
   local elapsed=$((SECONDS - SUITE_START))
@@ -1553,6 +1581,85 @@ needs_gradle_cleanup_after_class_abort() {
   [[ "$1" -eq 124 || "$1" -eq 137 ]]
 }
 
+# run_bounded <wall_cap_secs> <cmd...> — issue #1056.
+#
+# Runs <cmd> bounded by BOTH a wall-clock cap (the existing #835 `timeout`) AND a
+# NO-OUTPUT (silence) watchdog. The command's combined output is written to a FIFO
+# that this function reads line-by-line with a per-read timeout equal to the
+# silence window; every line is echoed live (so CI logs still stream) and resets
+# the silence timer. If the command emits NOTHING for JOURNEY_NO_OUTPUT_TIMEOUT_SECS
+# while still alive, the wrapping `timeout` process (and thus the wedged child) is
+# hard-killed — TERM, then a SIGKILL backstop — and the function returns 124, the
+# SAME uniform `timeout` exit the wall cap uses, so every downstream caller
+# (LAST_RUN_CLASS_TIMEOUT_HIT, is_timeout_rc, needs_gradle_cleanup_after_class_abort)
+# treats a silence-kill identically to a wall-cap timeout with no extra branching.
+#
+# Return codes:
+#   * 124 — the silence watchdog fired (wedged, no output), OR the wall `timeout`
+#     hit its ceiling (GNU timeout's own 124).
+#   * 137 — the wall `timeout` SIGKILL backstop fired (child ignored TERM).
+#   * <cmd rc> — the command finished on its own.
+#
+# The wall `timeout` still owns the total-duration ceiling; this wrapper only ADDS
+# the tighter silence bound. A command that streams output steadily runs until the
+# wall cap; a command that WEDGES silently dies at the silence bound, well before
+# the wall cap or the job-level 95-min wall.
+run_bounded() {
+  local wall_cap="$1"; shift
+  local no_output="$JOURNEY_NO_OUTPUT_TIMEOUT_SECS"
+  # Clamp the silence window to the wall cap so a tiny cap (self-test) still
+  # governs, and never let a mis-set 0/negative window disable the read timeout.
+  (( no_output <= 0 || no_output > wall_cap )) && no_output="$wall_cap"
+
+  local tmpdir fifo to_pid rc read_rc line rfd killer
+  tmpdir="$(mktemp -d)"
+  fifo="$tmpdir/out"
+  mkfifo "$fifo"
+
+  # Start the command under the wall-clock `timeout` (TERM + SIGKILL backstop),
+  # combined output to the FIFO. Backgrounded: `$!` is the `timeout` pid, which we
+  # signal on a silence breach so `timeout` forwards TERM to the wedged child.
+  timeout --signal=TERM --kill-after="$JOURNEY_CLASS_KILL_AFTER_SECS" "${wall_cap}s" \
+    "$@" > "$fifo" 2>&1 &
+  to_pid=$!
+
+  # Reader = the silence watchdog. `read -t <window>` returns >128 on a silence
+  # timeout, 1 on EOF (command finished OR the wall `timeout` closed the pipe).
+  # Capture the read's OWN exit code at the break — a bare `read_rc=$?` after the
+  # `while` would capture the WHILE loop's status (0 when the condition is false
+  # on the first eval, i.e. a silence timeout with no body run), silently losing
+  # the >128 timeout code.
+  exec {rfd}<"$fifo"
+  read_rc=0
+  while :; do
+    if IFS= read -r -t "$no_output" -u "$rfd" line; then
+      printf '%s\n' "$line"
+    else
+      read_rc=$?
+      break
+    fi
+  done
+  exec {rfd}<&-
+
+  if (( read_rc > 128 )); then
+    # Silence bound breached while the child is still alive: hard-kill the tree.
+    echo "JOURNEY_NO_OUTPUT_WATCHDOG: no output for ${no_output}s — hard-killing wedged connectedDebugAndroidTest (issue #1056)" >&2
+    kill -TERM "$to_pid" 2>/dev/null || true
+    ( sleep "$JOURNEY_CLASS_KILL_AFTER_SECS"; kill -KILL "$to_pid" 2>/dev/null || true ) &
+    killer=$!
+    wait "$to_pid" 2>/dev/null
+    kill "$killer" 2>/dev/null || true
+    wait "$killer" 2>/dev/null || true
+    rm -rf "$tmpdir"
+    return 124
+  fi
+
+  wait "$to_pid" 2>/dev/null
+  rc=$?
+  rm -rf "$tmpdir"
+  return "$rc"
+}
+
 # run_class <FQCN> — runs ONE journey class as its own gradle connected-test
 # invocation and returns gradle's exit code (0 == that class passed). Running
 # one class per invocation (rather than all classes comma-joined into a single
@@ -1592,7 +1699,10 @@ run_class() {
     return 124
   fi
   attempt_start=$SECONDS
-  timeout --signal=TERM --kill-after="$JOURNEY_CLASS_KILL_AFTER_SECS" "${cap}s" \
+  # Issue #1056: run_bounded adds a NO-OUTPUT (silence) watchdog on top of the
+  # #835 wall-clock `timeout` cap, so a wedged child that emits nothing is
+  # hard-killed on silence — well before the wall cap or the job-level wall.
+  run_bounded "$cap" \
     "$GRADLEW" :app:connectedDebugAndroidTest \
     -Pandroid.testInstrumentationRunnerArguments.pocketshellCi=true \
     -Pandroid.testInstrumentationRunnerArguments.timeout_msec=300000 \
@@ -1642,7 +1752,10 @@ run_ct_class() {
     return 124
   fi
   attempt_start=$SECONDS
-  timeout --signal=TERM --kill-after="$JOURNEY_CLASS_KILL_AFTER_SECS" "${cap}s" \
+  # Issue #1056: same NO-OUTPUT (silence) watchdog as the journey path — a wedged
+  # core-terminal proof (e.g. the #796 output-burst-IME proof that hung ~24 min
+  # in run 28307686762) is hard-killed on silence, never a job-cap cancel.
+  run_bounded "$cap" \
     "$GRADLEW" :shared:core-terminal:connectedDebugAndroidTest \
     -Pandroid.testInstrumentationRunnerArguments.class="$fqcn" \
     --stacktrace

--- a/scripts/test-ci-journey-budget.sh
+++ b/scripts/test-ci-journey-budget.sh
@@ -80,6 +80,23 @@ remaining_slack_secs=$((job_cap_secs - emulator_boot_timeout_secs - default_suit
 [[ "$remaining_slack_secs" -ge 600 ]] \
   || fail "(pre) insufficient post-boot slack: ${job_cap_secs}s job cap - ${emulator_boot_timeout_secs}s boot - ${default_suite_budget_secs}s suite = ${remaining_slack_secs}s (< 600s)"
 
+# (pre) #1056 no-output watchdog: pin the default silence window and require it to
+# sit BELOW the per-class wall cap, so a silent wedge dies on silence (the tight,
+# fast bound) rather than on the coarse wall cap — and never above it (which would
+# make the read timeout a no-op). Both parse the literal shell assignments.
+default_no_output_secs="$(sed -n 's/^JOURNEY_NO_OUTPUT_TIMEOUT_SECS="${JOURNEY_NO_OUTPUT_TIMEOUT_SECS:-\([0-9][0-9]*\)}"$/\1/p' "$REAL_SUITE")"
+default_class_timeout_secs="$(sed -n 's/^JOURNEY_CLASS_TIMEOUT_SECS="${JOURNEY_CLASS_TIMEOUT_SECS:-\([0-9][0-9]*\)}"$/\1/p' "$REAL_SUITE")"
+[[ "$default_no_output_secs" =~ ^[0-9]+$ ]] \
+  || fail "(pre) could not parse default JOURNEY_NO_OUTPUT_TIMEOUT_SECS from ci-journey-suite.sh"
+[[ "$default_class_timeout_secs" =~ ^[0-9]+$ ]] \
+  || fail "(pre) could not parse default JOURNEY_CLASS_TIMEOUT_SECS from ci-journey-suite.sh"
+[[ "$default_no_output_secs" -lt "$default_class_timeout_secs" ]] \
+  || fail "(pre) default silence window (${default_no_output_secs}s) must be BELOW the per-class wall cap (${default_class_timeout_secs}s) so a silent wedge dies on silence, not the coarse wall cap"
+grep -q 'NO-OUTPUT (silence) watchdog' "$REAL_SUITE" \
+  || fail "(pre) ci-journey-suite.sh must document the #1056 no-output silence watchdog"
+grep -q 'run_bounded' "$REAL_SUITE" \
+  || fail "(pre) ci-journey-suite.sh must route class attempts through run_bounded (the #1056 silence watchdog wrapper)"
+
 grep -q '95-min job cap (5700s) - worst-case emulator boot (900s) - default suite' "$REAL_SUITE" \
   || fail "(pre) ci-journey-suite.sh budget comment must show the right-sized arithmetic"
 grep -q 'budget (4200s) = 600s' "$REAL_SUITE" \
@@ -450,7 +467,11 @@ if [[ "$*" == *":app:connectedDebugAndroidTest"* ]]; then
   if [[ "$count" -eq 1 ]]; then
     trap '' TERM
     touch "$state_dir/poisoned-lock"
-    sleep 30
+    # Emit keepalive output faster than the silence window so the #1056 no-output
+    # watchdog does NOT preempt — this must exercise the WALL-cap SIGKILL backstop
+    # (rc=137): TERM is trapped/ignored, so `timeout --kill-after` SIGKILLs us.
+    end=$((SECONDS + 30))
+    while (( SECONDS < end )); do echo "PS_KEEPALIVE_1"; sleep 0.2; done
     exit 0
   fi
 
@@ -514,7 +535,12 @@ if [[ "$*" == *":app:connectedDebugAndroidTest"* ]]; then
   printf '%s' "$count" > "$state_dir/app-count"
   trap '' TERM
   touch "$state_dir/poisoned-lock"
-  sleep 30
+  # Emit keepalive output faster than the silence window so the #1056 no-output
+  # watchdog does NOT preempt — this must exercise the WALL-cap SIGKILL backstop
+  # (rc=137) on EVERY attempt: TERM is trapped/ignored, so `timeout --kill-after`
+  # SIGKILLs us each time.
+  end=$((SECONDS + 30))
+  while (( SECONDS < end )); do echo "PS_KEEPALIVE_$count"; sleep 0.2; done
   exit 0
 fi
 
@@ -611,6 +637,138 @@ fi
 [[ -s "$early_kill_stub_dir/stop.log" ]] \
   || fail "(l) immediate SIGKILL still should run Gradle cleanup before retry"
 pass "(l) immediate SIGKILL remains JOURNEY_FAILED even when cleanup spends the budget"
+
+# ---------------------------------------------------------------------------
+# Issue #1056: the NO-OUTPUT (silence) watchdog HARD-KILLS a wedged child.
+#
+# The reopen symptom: a `connectedDebugAndroidTest` child WEDGED and emitted zero
+# output for ~24 min until the job-level 95-min wall CANCELLED the whole step,
+# beating the #835 STEP_TIMEOUT classifier so the verdict was LOST. The watchdog
+# must hard-kill a SILENT child at the small silence bound — WELL BELOW a large
+# wall cap — and still route the class through the STEP_TIMEOUT classifier so a
+# trustworthy timeout-only summary is always written.
+#
+# This models ONE class that wedges SILENTLY (emits NOTHING, hangs 30s) on BOTH
+# attempts, under a LARGE wall cap (30s) and generous budget, with a tiny 2s
+# silence window. If the wall cap (not silence) were the only bound, this run
+# would take ~60s (2 attempts × 30s); the watchdog must cut each attempt at ~2s.
+# `exec sleep` so the watchdog's TERM terminates the wedge immediately (no
+# lingering child). All OTHER classes pass instantly so the run stays fast.
+echo "== #1056 no-output watchdog: a SILENT wedge is hard-killed at the silence bound =="
+cat > "$SANDBOX/gradlew" <<'STUB'
+#!/usr/bin/env bash
+set -u
+[[ "${1:-}" == "--stop" ]] && exit 0
+if [[ "$*" == *":app:connectedDebugAndroidTest"* && "$*" == *"DeepLinkSessionSwitchE2eTest"* ]]; then
+  # SILENT wedge: emit NOTHING and hang far past the 2s silence window.
+  exec sleep 30
+fi
+exit 0
+STUB
+chmod +x "$SANDBOX/gradlew"
+
+out_wedge="$SANDBOX/run-no-output-wedge.log"
+wedge_start=$SECONDS
+set +e
+PATH="$STUBBIN:$PATH" \
+  JOURNEY_STEP_BUDGET_SECS=600 \
+  JOURNEY_CLASS_TIMEOUT_SECS=30 \
+  JOURNEY_NO_OUTPUT_TIMEOUT_SECS=2 \
+  JOURNEY_CLASS_KILL_AFTER_SECS=1 \
+  JOURNEY_GRADLE_STOP_TIMEOUT_SECS=5 \
+  bash "$SANDBOX/scripts/ci-journey-suite.sh" > "$out_wedge" 2>&1
+rc_wedge=$?
+set -e
+wedge_elapsed=$((SECONDS - wedge_start))
+
+summary_wedge="$SANDBOX/artifacts/ci-journey/summary.md"
+# (o1) the watchdog fired with the exact silence-window marker (silence path, not
+#      the coarse wall cap).
+grep -q 'JOURNEY_NO_OUTPUT_WATCHDOG: no output for 2s' "$out_wedge" \
+  || { sed -n '1,80p' "$out_wedge"; fail "(o) no-output watchdog did not fire on a silent wedge"; }
+pass "(o1) silence watchdog fired (JOURNEY_NO_OUTPUT_WATCHDOG logged for the 2s window)"
+
+# (o2) the silence watchdog — NOT the 30s wall cap — killed the wedge: each of the
+#      two attempts was cut at ~2s, so the whole run finished far under 2×30s. A
+#      generous ceiling (25s) still proves the watchdog beat the wall cap while
+#      tolerating the instant-pass tail + cleanup.
+[[ "$wedge_elapsed" -lt 25 ]] \
+  || { sed -n '1,80p' "$out_wedge"; fail "(o) run took ${wedge_elapsed}s — the wall cap, not the 2s silence watchdog, bounded the wedge"; }
+pass "(o2) run finished in ${wedge_elapsed}s (< 25s) — the silence watchdog, not the 30s wall cap, killed the wedge"
+
+# (o3) despite the wedge, summary.md was written (the verdict is NEVER lost to a
+#      job-level wall) and carries the STEP_TIMEOUT marker for the wedged class.
+[[ -f "$summary_wedge" ]] \
+  || fail "(o) no-output wedge did not write summary.md — the verdict would be lost to the job wall"
+grep -q 'JOURNEY_STEP_TIMEOUT' "$summary_wedge" \
+  || { cat "$summary_wedge"; fail "(o) no-output wedge summary missing JOURNEY_STEP_TIMEOUT marker"; }
+grep -q 'DeepLinkSessionSwitchE2eTest' "$summary_wedge" \
+  || { cat "$summary_wedge"; fail "(o) no-output wedge summary did not name the wedged class"; }
+# The wedge is a timeout casualty, NOT a genuine twice-failed regression.
+if grep -qE 'Failed BOTH attempts' "$summary_wedge"; then
+  cat "$summary_wedge"
+  fail "(o) no-output wedge was misclassified as a genuine Failed BOTH regression"
+fi
+pass "(o3) summary.md written with a timeout-only STEP_TIMEOUT verdict (verdict never lost)"
+
+# (o4) the suite exited non-zero AND the workflow classifier routes it to a HARD
+#      RED timeout verdict — the whole point of AC1 (the STEP_TIMEOUT classifier
+#      always fires a trustworthy summary, never a lost job-cancel).
+[[ "$rc_wedge" -ne 0 ]] \
+  || fail "(o) no-output wedge exited 0 — the classifier would never inspect the timeout summary"
+wedge_verdict="$(classify "$summary_wedge")"
+[[ "$wedge_verdict" == "FIRST_TIMEOUT_RED" ]] \
+  || fail "(o) no-output wedge routed to '$wedge_verdict', expected FIRST_TIMEOUT_RED"
+verdict_is_red "$wedge_verdict" \
+  || fail "(o) no-output wedge verdict '$wedge_verdict' was classified GREEN"
+pass "(o4) suite exited non-zero (rc=$rc_wedge); classifier routes the wedge to FIRST_TIMEOUT_RED"
+
+# (n) Positive control: a class that STREAMS output steadily inside the silence
+#     window must NOT be killed by the watchdog — every emitted line resets the
+#     silence timer. This proves no false-positive: a slow-but-progressing class
+#     runs to completion, it is only a SILENT wedge that dies.
+echo "== #1056 no-output watchdog: a streaming class is NOT falsely killed =="
+cat > "$SANDBOX/gradlew" <<'STUB'
+#!/usr/bin/env bash
+set -u
+[[ "${1:-}" == "--stop" ]] && exit 0
+if [[ "$*" == *":app:connectedDebugAndroidTest"* && "$*" == *"DeepLinkSessionSwitchE2eTest"* ]]; then
+  # Emit a line each second for 4s — longer than the 2s silence window, but every
+  # line resets the timer so the watchdog must NOT fire.
+  for i in 1 2 3 4; do echo "PS_STREAM_LINE_$i"; sleep 1; done
+  exit 0
+fi
+exit 0
+STUB
+chmod +x "$SANDBOX/gradlew"
+
+out_stream="$SANDBOX/run-no-output-stream.log"
+set +e
+PATH="$STUBBIN:$PATH" \
+  JOURNEY_STEP_BUDGET_SECS=600 \
+  JOURNEY_CLASS_TIMEOUT_SECS=30 \
+  JOURNEY_NO_OUTPUT_TIMEOUT_SECS=2 \
+  JOURNEY_CLASS_KILL_AFTER_SECS=1 \
+  bash "$SANDBOX/scripts/ci-journey-suite.sh" > "$out_stream" 2>&1
+rc_stream=$?
+set -e
+
+summary_stream="$SANDBOX/artifacts/ci-journey/summary.md"
+if grep -q 'JOURNEY_NO_OUTPUT_WATCHDOG' "$out_stream"; then
+  sed -n '1,80p' "$out_stream"
+  fail "(n) watchdog FALSELY killed a class that streamed output within the window"
+fi
+# The streamed lines were echoed live (proves run_bounded relays output).
+grep -q 'PS_STREAM_LINE_4' "$out_stream" \
+  || { sed -n '1,80p' "$out_stream"; fail "(n) streamed output was not relayed live by run_bounded"; }
+[[ -f "$summary_stream" ]] || fail "(n) streaming control did not write summary.md"
+if grep -q 'JOURNEY_STEP_TIMEOUT' "$summary_stream"; then
+  cat "$summary_stream"
+  fail "(n) streaming class wrongly produced a JOURNEY_STEP_TIMEOUT marker"
+fi
+[[ "$rc_stream" -eq 0 ]] \
+  || { sed -n '1,80p' "$out_stream"; fail "(n) streaming control exited non-zero (rc=$rc_stream)"; }
+pass "(n) a steadily-streaming class is NOT killed (no false positive; output relayed live)"
 
 # ---------------------------------------------------------------------------
 # Negative control: a clean PASS run (generous budget, fast gradle stub) must


### PR DESCRIPTION
Fixes why the journey gate (and release-validation) can't reach a trustworthy verdict: a wedged `connectedDebugAndroidTest` child emitting zero output let the 95-min job wall cancel the step before the #835 STEP_TIMEOUT classifier could fire, losing the verdict.

**AC1 (hard-kill):** new `run_bounded` silence-watchdog wraps every class attempt; a child silent for `JOURNEY_NO_OUTPUT_TIMEOUT_SECS`=300s (clamped below the 420s wall cap) is hard-killed → uniform `124` → trustworthy timeout-only summary. Fixed the load-bearing `read_rc` capture bug (captured the while-loop status, not the read `>128` timeout — without which the watchdog never fires).
**AC2 (shard):** verified the 3-way matrix + round-robin partition (landed via #1061/#1055) covers all 90 classes disjointly.
**AC3 (flake):** retry-once + watchdog budget savings; deeper swiftshader root-cause split to a follow-up (brief-permitted).

Scripts-only, no product code / no yaml. **Reviewer APPROVED** (https://github.com/alexeygrigorev/pocketshell/issues/1056#issuecomment-4850740682): 23 self-test checks pass; non-vacuity proven by reintroducing the `read_rc` bug (watchdog fails to fire) then reverting; arithmetic 300s<420s<4200s<5700s so the suite classifier always preempts the job wall.

Closes #1056