### PR TITLE
ssh: make close() non-blocking-on-caller across the freeze class (#1139)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/PushResumeDeadSocketMainResponsiveE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/PushResumeDeadSocketMainResponsiveE2eTest.kt
@@ -1,0 +1,458 @@
+package com.pocketshell.app.proof
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.os.SystemClock
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.ViewModelProvider
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.BackgroundGraceTestOverride
+import com.pocketshell.app.MainActivity
+import com.pocketshell.app.diagnostics.DiagnosticEvents
+import com.pocketshell.app.diagnostics.MainThreadResponsivenessAnalyzer
+import com.pocketshell.app.proof.signals.MainThreadResponsivenessProbe
+import com.pocketshell.app.tmux.LivenessProbeTestOverride
+import com.pocketshell.app.tmux.TMUX_SESSION_ERROR_TAG
+import com.pocketshell.app.tmux.TMUX_SESSION_SCREEN_TAG
+import com.pocketshell.app.tmux.TmuxSessionViewModel
+import com.termux.view.TerminalView
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+import java.io.FileOutputStream
+
+/**
+ * Issue #1139 (maintainer's #1 freeze, the top v0.4.20 release-gate item) — the
+ * EXECUTED, on-the-real-path red→green proof that the push-notification →
+ * resume-an-idle-overnight-session freeze is GONE (D33 / G4 / G10).
+ *
+ * ## The maintainer's reported symptom
+ *
+ * Left a session connected overnight; tapped the push notification → it navigated
+ * back to the session, but the whole UI was FROZEN (buttons dead to taps) — had to
+ * restart the app. Overnight the SSH/tmux `-CC` socket went half-open (NAT idle
+ * timeout). On resume the app runs its grace-loop close/reconnect against that
+ * DEAD-HELD socket, and the six close sites in [TmuxSessionViewModel]
+ * (`silentlyReattachAfterPassiveDisconnect` / `silentlyReconnectTransportAfter
+ * PassiveDisconnect`) ran on `Dispatchers.Main.immediate`. The fix (#1139) makes
+ * `RealSshShell.close()` / `RealSshSession.close()` non-blocking-on-caller, so the
+ * teardown socket writes no longer park Main.
+ *
+ * ## Why the existing socket-drop journeys do NOT catch this
+ *
+ * The JVM slice proves both `close()` conversions red→green at unit level, and the
+ * six-site trace is a code-read — the exact "non-blocking by construction" shape
+ * that was FALSE in round 1. The existing e2e journeys check the WRONG property:
+ *  - `WithinGraceSocketDropForegroundJourneyE2eTest` asserts reseed + no-reconnect
+ *    (a #635-class proof) — it passes with OR without this fix.
+ *  - `BackgroundResumeSocketDeathE2eTest` asserts post-resume state — a transient
+ *    2–4s Main ANR during the resume passes it.
+ *  - The real freeze detector, [MainThreadResponsivenessProbe], was wired only to
+ *    a synthetic `Thread.sleep` (`StrictModeMainThreadIoDetectorE2eTest` P2), NOT
+ *    to the actual dead-socket grace-loop resume path.
+ *
+ * This journey closes that gap: it enters the dead-socket WITHIN-GRACE RESUME
+ * state and wires the REAL [MainThreadResponsivenessProbe] to measure Main-thread
+ * latency DURING the grace-loop close/reconnect, hard-asserting Main stays
+ * responsive.
+ *
+ * ## How the dead-held socket is produced (why toxiproxy / nightly)
+ *
+ * The freeze only reproduces when the `-CC` teardown socket WRITE genuinely
+ * WEDGES. That needs a HALF-OPEN, no-FIN socket (the overnight NAT death) — the
+ * toxiproxy `addBlackhole()` (`timeout=0`) toxic. A happy `agents:2222` socket, or
+ * a `kill -9`/`proxy.disable()` clean cut (RST → fast close), CANNOT wedge the
+ * close and so cannot reproduce the 2–4s Main block (the v0.4.10/#847 happy-
+ * fixture-masks-reality lesson). Because a blackholed socket stays "established"
+ * (warm lease), the within-grace foreground would otherwise ride through
+ * reseed-only and never run a close; so this ALSO arms
+ * [TmuxSessionViewModel.forceLivenessProbeDeadForTest] (#780 synthetic-state
+ * injection) to make the app DETECT the dead socket and run the grace-loop
+ * close/reconnect over the wedged transport. The close SOCKET-WRITE is real, not
+ * synthetic.
+ *
+ * Toxiproxy is not started by the per-push `tests.yml` job, so this class lives in
+ * the NIGHTLY network-fault lane (`scripts/nightly-extensive-suite.sh`), gated by
+ * [NetworkFaultProofBase.assumeNetworkFaultProofsEnabled] like every other
+ * toxiproxy proof. The nightly lane runs it WITHOUT `pocketshellCi=true` (so
+ * `isRunningOnCi()` is false and the guard passes) and WITH
+ * `pocketshellNetworkFaultProofs=true`. There is NO self-skip on the load-bearing
+ * responsiveness assertion in the lane that runs it (F3): the `assume` only gates
+ * the per-push CI lane that structurally cannot start toxiproxy.
+ *
+ * ## Contract (the load-bearing, freeze-detecting assertion)
+ *
+ * Over the resume + grace-loop close/reconnect window (the wedged socket still
+ * blackholed), the REAL main-thread heartbeat probe's max inter-arrival gap must
+ * stay under [MAIN_STALL_BUDGET_MS] — i.e. Main is NOT parked 2–4s. Then, once the
+ * fault + seam clear, the session must reconnect-or-show-Disconnected (never a
+ * permanent frozen wedge).
+ *
+ * ## Red→green
+ *
+ * On the base blocking `close()` (`runBlocking(Dispatchers.IO)` /
+ * `runBlocking(...)` disconnect), each grace-loop `sshLeaseManager.disconnect()`
+ * (RealSshSession.close, ~4s) and `staleClient.close()` (RealSshShell.close, ~2s)
+ * PARKS `Dispatchers.Main.immediate`, so the probe records a multi-second gap →
+ * `responsive=false` → RED. With the #1139 fix the teardown is launched on an
+ * object-owned IO scope and Main stays free → GREEN.
+ */
+// CI_JOURNEY_SUITE_JUSTIFIED: nightly-only toxiproxy proof (NetworkFaultProofBase
+// subclass). It needs the half-open `addBlackhole` toxic to genuinely WEDGE the
+// `-CC` teardown socket-write — a per-push agents:2222 (happy) fixture cannot
+// reproduce the 2-4s Main-thread close block, so it cannot live in the per-push
+// ci-journey-suite.sh. It runs in the nightly network-fault lane
+// (scripts/nightly-extensive-suite.sh NETWORK_FAULT_CLASSES) via
+// network-fault-proxy:2228 + toxiproxy API:8474, gated by
+// assumeNetworkFaultProofsEnabled() exactly like every other toxiproxy proof.
+@RunWith(AndroidJUnit4::class)
+class PushResumeDeadSocketMainResponsiveE2eTest : NetworkFaultProofBase() {
+
+    private var diagnostics: RecordingDiagnosticSink? = null
+
+    @Before
+    fun installDiagnostics() {
+        BackgroundGraceTestOverride.setForTest(null)
+        diagnostics = RecordingDiagnosticSink().also { DiagnosticEvents.install(it) }
+    }
+
+    @After
+    fun resetOverrides() {
+        // Best-effort: disarm the synthetic dead-socket seam so a teardown reattach
+        // can heal, then clear all test overrides.
+        runCatching { setForceLivenessProbeDead(false) }
+        BackgroundGraceTestOverride.setForTest(null)
+        LivenessProbeTestOverride.clear()
+        diagnostics?.close()
+        diagnostics = null
+    }
+
+    @Test
+    fun withinGraceResumeOntoDeadHeldSocketKeepsMainResponsiveDuringGraceLoopClose() =
+        runBlocking {
+            assumeNetworkFaultProofsEnabled()
+
+            val key = readFixtureKey()
+            val marker = "pr${System.currentTimeMillis().toString(36).takeLast(5)}"
+            val sessionName = "issue1139-pushresume-$marker"
+            val hostName = "Issue1139 PushResume $marker"
+            prepareProxyAndRemoteSession(
+                key = key,
+                sessionName = sessionName,
+                readyText = "ISSUE1139-PUSHRESUME-READY-$marker",
+            )
+            // Host row points at the toxiproxy port (2228), so the app's `-CC`
+            // control channel runs through the proxy we can blackhole.
+            val hostRowTag = seedNetworkFaultHost(key, hostName)
+
+            launchedActivity = ActivityScenario.launch(MainActivity::class.java)
+            val attachStart = SystemClock.elapsedRealtime()
+            attachToSession(hostRowTag, hostName, sessionName)
+            recordTiming("attach_ms", SystemClock.elapsedRealtime() - attachStart)
+
+            // Establish the live baseline: a fresh marker must round-trip through the
+            // live `-CC` channel before we wedge it (a happy fixture that can't wedge
+            // proves nothing).
+            sendCommandThroughTerminalInput("printf 'BEFORE-$marker\\n'", "before")
+            waitForVisibleTerminalText("before") { "BEFORE-$marker" in it }
+            waitForConnected("initial attach")
+            captureViewport("issue1139-01-attached-live")
+            diagnostics!!.clear()
+
+            // Compress the timings so the resume lands well within grace and the
+            // passive disconnect + grace loop fire fast against the wedged socket.
+            // Production keeps its 60s grace / 10s probe defaults.
+            BackgroundGraceTestOverride.setForTest(WITHIN_GRACE_MS)
+            setPassiveDisconnectRecovery(
+                graceMs = GRACE_LOOP_MS,
+                silentReattachTimeoutMs = REATTACH_TIMEOUT_MS,
+            )
+            LivenessProbeTestOverride.setForTest(
+                intervalMs = PROBE_INTERVAL_MS,
+                perProbeTimeoutMs = PROBE_TIMEOUT_MS,
+                failureThreshold = PROBE_FAILURE_THRESHOLD,
+            )
+
+            val proxy = toxiproxy()
+
+            // ---- Background within grace (the overnight idle), then DEAD-HOLD the
+            // socket while away. `addBlackhole` = half-open/no-FIN (NAT idle death):
+            // the close socket-write WEDGES. `forceLivenessProbeDeadForTest` makes the
+            // app DETECT the dead socket so the within-grace resume runs the grace-loop
+            // close/reconnect (a blackhole alone stays "connected" → reseed-only, no
+            // close).
+            launchedActivity?.moveToState(Lifecycle.State.CREATED)
+            waitForDiagnostic("background_grace_start", "within-grace background")
+            proxy.addBlackhole()
+            setForceLivenessProbeDead(true)
+            SystemClock.sleep(BACKGROUND_HOLD_MS)
+
+            // ---- Start the REAL main-thread responsiveness probe, THEN foreground
+            // within grace (the push-notification tap → resume). The within-grace
+            // resume runs the six close sites over the wedged `-CC` socket ON
+            // Dispatchers.Main.immediate:
+            //   sshLeaseManager.disconnect() -> RealSshSession.close()  (base ~4s Main block)
+            //   staleClient.close()          -> RealSshShell.close()    (base ~2s Main block)
+            val probe = MainThreadResponsivenessProbe(
+                intervalMs = HEARTBEAT_INTERVAL_MS,
+                budgetMs = MAIN_STALL_BUDGET_MS,
+            )
+            probe.start()
+            val resumeAt = SystemClock.elapsedRealtime()
+            launchedActivity?.moveToState(Lifecycle.State.RESUMED)
+            waitForDiagnostic(
+                "background_grace_foreground",
+                "within-grace resume onto dead socket",
+            ) { it.fields["withinGrace"] == true }
+
+            // Hold the probe across the whole grace-loop close/reconnect window while
+            // the wedged socket is STILL blackholed — this is the window that ANRs on
+            // base. The probe is non-blocking (a Handler heartbeat), so it records the
+            // Main-thread parks WITHOUT itself hanging the test on base.
+            SystemClock.sleep(GRACE_LOOP_WINDOW_MS)
+            val result = probe.stop(minExpectedSamples = MIN_EXPECTED_HEARTBEATS)
+            recordTiming("main_max_stall_ms", result.maxGapMs)
+            recordTiming("main_probe_samples", result.sampleCount.toLong())
+            recordTiming("resume_window_ms", SystemClock.elapsedRealtime() - resumeAt)
+            captureViewport("issue1139-02-during-grace-loop")
+
+            // The session screen must still be up (a torn-down screen would be a crash,
+            // not the freeze under test).
+            assertTrue(
+                "the tmux session screen must still be present during the resume",
+                hasTagNonBlocking(TMUX_SESSION_SCREEN_TAG),
+            )
+
+            // ---- LOAD-BEARING: Main stayed responsive during the grace-loop close/
+            // reconnect over the dead-held socket. RED on base (a 2–4s Main park from
+            // the blocking close), GREEN with the #1139 fix.
+            writeText("main-thread-probe.txt", result.message)
+            assertTrue(
+                "MAIN-THREAD FREEZE reproduced on the push-resume-onto-dead-socket path: " +
+                    "${result.message}. maxStall=${result.maxGapMs}ms exceeds the " +
+                    "${MAIN_STALL_BUDGET_MS}ms budget — the grace-loop close/reconnect " +
+                    "parked Dispatchers.Main.immediate (the #1139 freeze). The fix must " +
+                    "make RealSshShell.close()/RealSshSession.close() non-blocking-on-caller.",
+                result.responsive,
+            )
+
+            // ---- No permanent wedge: once the fault + seam clear the SAME session must
+            // reconnect-or-show-Disconnected (never a frozen UI needing a restart).
+            setForceLivenessProbeDead(false)
+            proxy.clearToxics()
+            val settled = waitForConnectedOrDisconnectBand(SETTLE_WINDOW_MS)
+            captureViewport("issue1139-03-settled")
+            assertTrue(
+                "after the fault cleared the session must reconnect (Connected) or show a " +
+                    "Disconnected band — not a permanently frozen UI (status=" +
+                    "${currentConnectionStatus()})",
+                settled,
+            )
+
+            writeSummary(
+                testName = "PushResumeDeadSocketMainResponsiveE2eTest",
+                lines = listOf(
+                    "session=$sessionName",
+                    "marker=$marker",
+                    "scenario=attach via proxy, background within grace, addBlackhole " +
+                        "(half-open dead-held socket) + forceLivenessProbeDead, foreground " +
+                        "within grace, measure Main during grace-loop close/reconnect",
+                    "main_max_stall_ms=${result.maxGapMs}",
+                    "main_stall_budget_ms=$MAIN_STALL_BUDGET_MS",
+                    "main_probe_samples=${result.sampleCount}",
+                    "main_responsive=${result.responsive}",
+                    "settled_after_clear=$settled",
+                    "expectation=Main stall < budget (no 2-4s ANR); session " +
+                        "reconnects-or-Disconnected after clear",
+                ),
+            )
+            Unit
+        }
+
+    // ---- VM seams (accessed on the live VM via the launched activity) --------------
+
+    private fun setForceLivenessProbeDead(value: Boolean) {
+        launchedActivity?.onActivity { activity ->
+            ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+                .forceLivenessProbeDeadForTest = value
+        }
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+    }
+
+    private fun setPassiveDisconnectRecovery(graceMs: Long, silentReattachTimeoutMs: Long) {
+        launchedActivity?.onActivity { activity ->
+            ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+                .setPassiveDisconnectRecoveryForTest(
+                    graceMs = graceMs,
+                    silentReattachTimeoutMs = silentReattachTimeoutMs,
+                )
+        }
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+    }
+
+    private fun currentConnectionStatus(): TmuxSessionViewModel.ConnectionStatus {
+        var status: TmuxSessionViewModel.ConnectionStatus =
+            TmuxSessionViewModel.ConnectionStatus.Idle
+        launchedActivity?.onActivity { activity ->
+            status = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+                .connectionStatus
+                .value
+        }
+        return status
+    }
+
+    private fun waitForConnected(label: String, timeoutMs: Long = CONNECTED_TIMEOUT_MS) {
+        compose.waitUntil(timeoutMillis = timeoutMs) {
+            currentConnectionStatus() is TmuxSessionViewModel.ConnectionStatus.Connected
+        }
+        assertTrue(
+            "expected Connected after $label, observed=${currentConnectionStatus()}",
+            currentConnectionStatus() is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+    }
+
+    private fun waitForConnectedOrDisconnectBand(timeoutMs: Long): Boolean {
+        val deadline = SystemClock.elapsedRealtime() + timeoutMs
+        while (SystemClock.elapsedRealtime() < deadline) {
+            if (currentConnectionStatus() is TmuxSessionViewModel.ConnectionStatus.Connected) {
+                return true
+            }
+            if (hasTagNonBlocking(TMUX_SESSION_ERROR_TAG)) return true
+            SystemClock.sleep(250)
+        }
+        return currentConnectionStatus() is TmuxSessionViewModel.ConnectionStatus.Connected ||
+            hasTagNonBlocking(TMUX_SESSION_ERROR_TAG)
+    }
+
+    private fun hasTagNonBlocking(tag: String): Boolean =
+        runCatching {
+            compose.onAllNodesWithTag(tag, useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }.getOrDefault(false)
+
+    private fun waitForDiagnostic(
+        name: String,
+        label: String,
+        timeoutMs: Long = DIAGNOSTIC_TIMEOUT_MS,
+        predicate: (RecordedDiagnosticEvent) -> Boolean = { true },
+    ): RecordedDiagnosticEvent {
+        val deadline = SystemClock.elapsedRealtime() + timeoutMs
+        while (SystemClock.elapsedRealtime() < deadline) {
+            val match = diagnostics!!.eventsNamed(name).filter(predicate)
+            if (match.isNotEmpty()) return match.last()
+            SystemClock.sleep(50)
+        }
+        error("timed out waiting for diagnostic '$name' during $label; events=${diagnostics!!.events}")
+    }
+
+    // ---- artifacts -----------------------------------------------------------------
+
+    private fun captureViewport(name: String) {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.waitForIdleSync()
+        SystemClock.sleep(150)
+        var bitmap: Bitmap? = null
+        launchedActivity?.onActivity { activity ->
+            val view = activity.window.decorView.findTerminalViewLocal() ?: return@onActivity
+            if (view.width <= 0 || view.height <= 0) return@onActivity
+            val b = Bitmap.createBitmap(view.width, view.height, Bitmap.Config.ARGB_8888)
+            view.draw(Canvas(b))
+            bitmap = b
+        }
+        bitmap?.let { writeBitmap("$name-viewport", it) }
+        writeText("$name-visible-terminal.txt", visibleTerminalTextLocal())
+        bitmap?.recycle()
+    }
+
+    private fun writeBitmap(name: String, bitmap: Bitmap): File {
+        val file = artifactFile("$name.png")
+        FileOutputStream(file).use { out ->
+            check(bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)) {
+                "failed to write bitmap to ${file.absolutePath}"
+            }
+        }
+        println("ISSUE1139_VIEWPORT ${file.absolutePath}")
+        return file
+    }
+
+    private fun writeText(name: String, text: String): File {
+        val file = artifactFile(name)
+        file.writeText(text)
+        println("ISSUE1139_TEXT ${file.absolutePath}")
+        return file
+    }
+
+    private fun visibleTerminalTextLocal(): String {
+        var text = ""
+        launchedActivity?.onActivity { activity ->
+            text = activity.window.decorView
+                .findTerminalViewLocal()
+                ?.currentSession
+                ?.emulator
+                ?.screen
+                ?.transcriptText
+                .orEmpty()
+        }
+        return text
+    }
+
+    private fun View.findTerminalViewLocal(): TerminalView? {
+        if (this is TerminalView) return this
+        if (this !is ViewGroup) return null
+        for (index in 0 until childCount) {
+            val match = getChildAt(index).findTerminalViewLocal()
+            if (match != null) return match
+        }
+        return null
+    }
+
+    private companion object {
+        // Background grace window: generous so the resume lands well within grace.
+        val WITHIN_GRACE_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 40_000L else 30_000L
+
+        // Passive-disconnect grace loop (the close/reconnect ladder). Long enough
+        // that the loop keeps re-dialling + closing over the wedged socket across
+        // the whole probe window, so a base build blocks Main repeatedly.
+        val GRACE_LOOP_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 30_000L else 25_000L
+        const val REATTACH_TIMEOUT_MS: Long = 2_000L
+
+        // LivenessProbe knobs: short so the passive disconnect fires fast on the
+        // dead-held socket. threshold=1 (the synthetic seam reports DEAD sustained).
+        const val PROBE_INTERVAL_MS: Long = 1_000L
+        const val PROBE_TIMEOUT_MS: Long = 2_000L
+        const val PROBE_FAILURE_THRESHOLD: Int = 1
+
+        const val BACKGROUND_HOLD_MS: Long = 1_500L
+
+        // The REAL Main-thread heartbeat probe (the #933 freeze detector).
+        const val HEARTBEAT_INTERVAL_MS: Long = 50L
+        // Tight bound: base parks Main 2–4s per close; normal swiftshader jitter is
+        // well under this (the #933 P2 detector uses 700ms for a 2000ms block).
+        const val MAIN_STALL_BUDGET_MS: Long = 750L
+        const val MIN_EXPECTED_HEARTBEATS: Int = 10
+
+        // Window over which Main responsiveness is measured while the socket is
+        // dead-held: multiple grace-loop iterations (each ~2–4s block on base) fall
+        // inside it, so even one blocking close reds the probe.
+        val GRACE_LOOP_WINDOW_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 32_000L else 30_000L
+
+        val SETTLE_WINDOW_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 60_000L else 45_000L
+        val CONNECTED_TIMEOUT_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 30_000L else 20_000L
+        const val DIAGNOSTIC_TIMEOUT_MS: Long = 12_000L
+    }
+}

--- a/scripts/check-ci-journey-harness.sh
+++ b/scripts/check-ci-journey-harness.sh
@@ -116,6 +116,12 @@ KNOWN_UNWIRED_ANDROID_E2E_DOCKER_CLASSES=(
   "com.pocketshell.app.proof.NoBackgroundWorkE2eTest"
   "com.pocketshell.app.proof.PacketLossNetworkFaultE2eTest"
   "com.pocketshell.app.proof.ProjectSwitcherDropdownE2eTest"
+  # Issue #1139: nightly toxiproxy proof (NetworkFaultProofBase subclass) — the
+  # push-resume-onto-dead-socket Main-responsiveness freeze proof. Needs the
+  # half-open blackhole to wedge the real close, so it runs in the nightly
+  # network-fault lane (scripts/nightly-extensive-suite.sh), not the per-push
+  # journey allowlist.
+  "com.pocketshell.app.proof.PushResumeDeadSocketMainResponsiveE2eTest"
   "com.pocketshell.app.proof.RideThroughInterruptionE2eTest"
   "com.pocketshell.app.proof.SessionSwipeSwitchE2eTest"
   "com.pocketshell.app.proof.SilentMidSessionDropDetectionE2eTest"

--- a/scripts/nightly-extensive-suite.sh
+++ b/scripts/nightly-extensive-suite.sh
@@ -100,6 +100,19 @@ NETWORK_FAULT_CLASSES=(
   # D31's per-push gate is met without depending on the toxiproxy family). Reuses
   # network-fault-proxy:2228 + toxiproxy API:8474 (no new fixture).
   "$FQCN_PREFIX.SilentMidSessionDropDetectionE2eTest"
+  # Issue #1139 (maintainer's #1 freeze / top v0.4.20 release-gate item): the
+  # push-notification → resume-an-idle-overnight-session UI freeze. A toxiproxy
+  # `timeout=0` blackhole DEAD-HOLDS the `-CC` socket (half-open, no FIN — the
+  # overnight NAT death) so the grace-loop teardown socket-write genuinely WEDGES,
+  # + `forceLivenessProbeDeadForTest` makes the app DETECT the dead socket and run
+  # its within-grace resume close/reconnect over it. The REAL
+  # MainThreadResponsivenessProbe measures Main-thread latency DURING that
+  # grace-loop close/reconnect and HARD-asserts Main stays responsive (< 750ms, no
+  # 2-4s ANR). RED on the base blocking close(), GREEN with the #1139 non-blocking
+  # RealSshShell/RealSshSession close. Needs the toxiproxy family (a happy or
+  # kill-9'd socket cannot wedge the close), so it is nightly, not per-push. Reuses
+  # network-fault-proxy:2228 + toxiproxy API:8474 (no new fixture).
+  "$FQCN_PREFIX.PushResumeDeadSocketMainResponsiveE2eTest"
 )
 
 # The bootstrap setup-scenario class (opt-in via pocketshellBootstrapScenarios).

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshSession.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshSession.kt
@@ -14,7 +14,6 @@ import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -41,6 +40,7 @@ import java.util.concurrent.ExecutionException
 import java.util.concurrent.Executors
 import java.util.concurrent.Future
 import java.util.concurrent.Semaphore
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 import java.util.logging.Level
 import java.util.logging.Logger
@@ -114,6 +114,41 @@ internal class RealSshSession(
      * `scope.cancel()` erase the cleanup before it reaches the dispatcher.
      */
     private val teardownScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    /**
+     * Issue #1135 / #1139 (D33 / G1 / G2 — the class SOURCE fix): guards the
+     * one-shot async teardown so a repeated [close] (idempotent by contract)
+     * launches the transport-disconnect work at most once.
+     */
+    private val closeStarted = AtomicBoolean(false)
+
+    /**
+     * Issue #1135 / #1139: the [Job] running the bounded transport teardown
+     * launched by [close]. Ordering-sensitive callers await it via [awaitClosed]
+     * (off Main), so a redial that truly needs the old transport fully torn down
+     * first can join without ever parking the caller thread inside [close].
+     */
+    @Volatile
+    private var closeJob: Job? = null
+
+    /**
+     * Issue #1135 / #1139: object-owned scope that runs the final
+     * `client.disconnect()` socket write (and the drain/force-disconnect
+     * fallback) OFF the calling thread. [close] is reached SYNCHRONOUSLY from
+     * `Dispatchers.Main.immediate` on the grace-loop lease-disconnect path
+     * (`TmuxSessionViewModel` → `SshLeaseManager.disconnect` inside
+     * `withContext(NonCancellable)`) and off IO on the port-forward path
+     * (`AutoForwarderSupervisor`). `client.disconnect()` blocks the caller up to
+     * [SESSION_CLOSE_TIMEOUT_MS] (2s) on a wedged socket — on Main that is the
+     * maintainer's "UI fully freezes" wedge. The teardown is launched here and
+     * [close] returns immediately; the caller never parks. `SupervisorJob` so a
+     * wedged/failed disconnect never escalates; `Dispatchers.IO` is the thread
+     * that parks (never Main) if the wire is truly wedged, until the bounded
+     * ceiling + `TransportDispatcher` per-op wall-clock ceiling reclaim it. The
+     * launched job completes within the ceiling; the scope is discarded with this
+     * session after close, so it does not leak.
+     */
+    private val closeScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     /**
      * Single-writer dispatch owner for this connection's transport (issue
@@ -1697,8 +1732,14 @@ internal class RealSshSession(
     )
 
     override fun close() {
+        // Issue #1135 / #1139 (D33 / G1 / G2): idempotent + one-shot. A second
+        // close() is a no-op (contract), and this guard also ensures the async
+        // teardown below is launched at most once.
+        if (!closeStarted.compareAndSet(false, true)) return
         // Issue #945: stop the transport keepalive before tearing the scope down
         // so no keepalive op is submitted to a dispatcher that is about to close.
+        // Both of these are NON-BLOCKING (job cancellations), so they stay on the
+        // caller thread — only the network-touching disconnect is offloaded.
         keepAlive.stop()
         // Cancel active exec/tail/upload jobs before the dispatcher drain. Their
         // cancellation handlers enqueue best-effort channel closes on
@@ -1760,28 +1801,44 @@ internal class RealSshSession(
         // leaving the sshj transport in a half-closed state and producing
         // logcat noise on every teardown.
         //
-        // The fix dispatches the network-touching `disconnect()` call onto
-        // `Dispatchers.IO` via `runBlocking(Dispatchers.IO) { ... }`:
-        // the calling thread (which may be Main) still blocks until the
-        // disconnect finishes (preserving the AutoCloseable ordering
-        // contract), but the actual SSH_MSG_DISCONNECT socket write
-        // happens on an IO worker thread, so the
-        // BlockGuard / StrictMode `onNetwork` probe never fires on Main.
-        // Hopping the suspending boundary higher (e.g. making
-        // `SshSession.close()` itself a suspend) would ripple through
-        // every caller; the AutoCloseable-preserving thread hop is the
-        // surgical fix called for by the issue.
-        try {
-            // Issue #847: drain the dispatcher and run `disconnect()` as the
-            // FINAL serialised operation. `closeAndAwaitDrain` (a) queues the
-            // disconnect BEHIND any in-flight write/channel op so we never tear
-            // the transport down underneath one (which is exactly the
-            // write-racing-`die()` desync the actor exists to prevent), and (b)
-            // marks the dispatcher closed under its lock so any later op is
-            // rejected before it can touch the dead transport. The disconnect
-            // socket write still happens on the dispatch (IO) thread, so the
-            // StrictMode `NetworkOnMainThreadException` guard (issue #166) holds.
-            runBlocking(Dispatchers.IO) {
+        // Issue #1135 / #1139 (D33 / G1 / G2 — HARD-CUT D22): the teardown is
+        // NON-BLOCKING on the caller. The network-touching `client.disconnect()`
+        // (an `SSH_MSG_DISCONNECT` socket write that blocks up to
+        // SESSION_CLOSE_TIMEOUT_MS on a wedged / half-open transport) is launched
+        // on the object-owned IO [closeScope] and close() returns immediately.
+        // The PREVIOUS body wrapped it in `runBlocking(Dispatchers.IO) { … }`,
+        // which kept the socket WRITE off Main (StrictMode-safe, #166) but still
+        // PARKED the CALLING thread for up to 2s. On the grace-loop
+        // lease-disconnect path — `TmuxSessionViewModel` →
+        // `SshLeaseManager.disconnect` inside `withContext(NonCancellable)` on
+        // `viewModelScope` = `Dispatchers.Main.immediate` (no dispatcher hop) —
+        // that 2s park was on Main, the maintainer's "UI fully freezes, buttons
+        // dead, restart required" wedge (#1139 push-resume residual). The
+        // AutoForwarder path (#1135) and every other Main caller hit the SAME
+        // `close()`, so offloading HERE fixes the whole class in one place.
+        //
+        // The bounded ceiling stays INSIDE the launched coroutine, and the
+        // `TransportDispatcher` per-op wall-clock ceiling still interrupts a
+        // wedged socket write and reclaims the dispatch thread — teardown
+        // liveness is unchanged, only the caller no longer waits for it. The 2s
+        // ceiling already tolerated an incomplete teardown, so firing it fully
+        // async is no worse than the pre-existing give-up. Ordering-sensitive
+        // callers (a redial that truly needs the old transport torn down first)
+        // join the teardown via [awaitClosed] OFF Main; the socket write still
+        // runs on the dispatch (IO) thread so the StrictMode
+        // `NetworkOnMainThreadException` guard (#166) holds. Making
+        // `SshSession.close()` itself suspend would ripple through every
+        // AutoCloseable caller, so the non-blocking launch + suspend
+        // [awaitClosed] seam is the surgical shape.
+        closeJob = closeScope.launch {
+            try {
+                // Issue #847: drain the dispatcher and run `disconnect()` as the
+                // FINAL serialised operation. `closeAndAwaitDrain` (a) queues the
+                // disconnect BEHIND any in-flight write/channel op so we never
+                // tear the transport down underneath one (the write-racing-`die()`
+                // desync the actor exists to prevent), and (b) marks the
+                // dispatcher closed under its lock so any later op is rejected
+                // before it can touch the dead transport.
                 val drained = withTimeoutOrNull(SESSION_CLOSE_TIMEOUT_MS) {
                     dispatcher.closeAndAwaitDrain {
                         client.disconnect()
@@ -1797,53 +1854,67 @@ internal class RealSshSession(
                     dispatcher.closeNow()
                     forceDisconnectRawClient()
                 }
+            } catch (e: TransportException) {
+                // Issue #239: close() is idempotent and silent by contract.
+                // Every TransportException here is teardown-time and not
+                // actionable — swallow and log.
+                CLOSE_LOGGER.log(
+                    Level.INFO,
+                    "[$CLOSE_LOG_TAG] swallowed TransportException during close() " +
+                        "(reason=${e.disconnectReason}): ${e.message}",
+                )
+            } catch (e: SSHException) {
+                // sshj's `SSHException` is the parent of `TransportException`
+                // (already handled) and `ConnectionException`. A
+                // `ConnectionException` surfacing here is the same shape of
+                // already-down-transport teardown noise — silently no-op so
+                // the idempotency contract holds.
+                CLOSE_LOGGER.log(
+                    Level.INFO,
+                    "[$CLOSE_LOG_TAG] swallowed SSHException during close(): ${e.message}",
+                )
+            } catch (e: IOException) {
+                // sshj declares `disconnect()` as `throws IOException`. A
+                // non-SSHException IO failure during shutdown is best-effort:
+                // nothing the caller can do, propagating it would defeat the
+                // idempotency contract. Swallowed deliberately to preserve the
+                // pre-#151 `runCatching` semantics for this path.
+                CLOSE_LOGGER.log(
+                    Level.INFO,
+                    "[$CLOSE_LOG_TAG] swallowed IOException during close(): ${e.message}",
+                )
+            } catch (e: RuntimeException) {
+                // Belt-and-suspenders: the pre-#151 implementation wrapped the
+                // whole disconnect in `runCatching`, which silently swallowed
+                // every Throwable. With #166 the socket write now runs on
+                // `Dispatchers.IO` so StrictMode `NetworkOnMainThreadException`
+                // can no longer originate here — but we keep this catch for
+                // any other RuntimeException sshj may surface during teardown
+                // (e.g. an exotic state-machine error) so close() stays
+                // idempotent in the face of unknown teardown failure modes.
+                CLOSE_LOGGER.log(
+                    Level.INFO,
+                    "[$CLOSE_LOG_TAG] swallowed RuntimeException during close(): ${e.message}",
+                )
+            } finally {
+                execDrainExecutor.shutdownNow()
+                teardownScope.cancel()
             }
-        } catch (e: TransportException) {
-            // Issue #239: close() is idempotent and silent by contract.
-            // Every TransportException here is teardown-time and not
-            // actionable — swallow and log.
-            CLOSE_LOGGER.log(
-                Level.INFO,
-                "[$CLOSE_LOG_TAG] swallowed TransportException during close() " +
-                    "(reason=${e.disconnectReason}): ${e.message}",
-            )
-        } catch (e: SSHException) {
-            // sshj's `SSHException` is the parent of `TransportException`
-            // (already handled) and `ConnectionException`. A
-            // `ConnectionException` surfacing here is the same shape of
-            // already-down-transport teardown noise — silently no-op so
-            // the idempotency contract holds.
-            CLOSE_LOGGER.log(
-                Level.INFO,
-                "[$CLOSE_LOG_TAG] swallowed SSHException during close(): ${e.message}",
-            )
-        } catch (e: IOException) {
-            // sshj declares `disconnect()` as `throws IOException`. A
-            // non-SSHException IO failure during shutdown is best-effort:
-            // nothing the caller can do, propagating it would defeat the
-            // idempotency contract. Swallowed deliberately to preserve the
-            // pre-#151 `runCatching` semantics for this path.
-            CLOSE_LOGGER.log(
-                Level.INFO,
-                "[$CLOSE_LOG_TAG] swallowed IOException during close(): ${e.message}",
-            )
-        } catch (e: RuntimeException) {
-            // Belt-and-suspenders: the pre-#151 implementation wrapped the
-            // whole disconnect in `runCatching`, which silently swallowed
-            // every Throwable. With #166 the socket write now runs on
-            // `Dispatchers.IO` so StrictMode `NetworkOnMainThreadException`
-            // can no longer originate here — but we keep this catch for
-            // any other RuntimeException sshj may surface during teardown
-            // (e.g. an exotic state-machine error) so close() stays
-            // idempotent in the face of unknown teardown failure modes.
-            CLOSE_LOGGER.log(
-                Level.INFO,
-                "[$CLOSE_LOG_TAG] swallowed RuntimeException during close(): ${e.message}",
-            )
-        } finally {
-            execDrainExecutor.shutdownNow()
-            teardownScope.cancel()
         }
+    }
+
+    /**
+     * Issue #1135 / #1139: await the bounded transport teardown launched by
+     * [close]. [close] is non-blocking-on-caller by construction, so a caller
+     * that must NOT redial / reuse the transport until the old
+     * `SSH_MSG_DISCONNECT` has drained (the ordering-sensitive teardown-then-
+     * disconnect contract the `RealSshSessionTeardownOrderingTest` pins) joins
+     * the teardown here. Off Main ONLY — this is a suspend seam meant to run on
+     * an IO / background dispatcher. A no-op when [close] was never called
+     * ([closeJob] is null) or when the teardown has already finished.
+     */
+    override suspend fun awaitClosed() {
+        closeJob?.join()
     }
 
     private suspend fun forceDisconnectRawClient() {

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshShell.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshShell.kt
@@ -1,12 +1,15 @@
 package com.pocketshell.core.ssh
 
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
 import net.schmizz.sshj.connection.channel.direct.Session
 import net.schmizz.sshj.connection.channel.direct.SessionChannel
 import java.io.InputStream
 import java.io.OutputStream
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * sshj-backed implementation of [SshShell].
@@ -63,6 +66,26 @@ internal class RealSshShell(
     private val activityStderr: InputStream =
         InboundActivityInputStream(shell.errorStream, onInboundActivity)
 
+    /**
+     * Issue #1139 / #1136: guards the one-shot async teardown so a repeated
+     * [close] (idempotent by contract) launches the channel-close work at most
+     * once.
+     */
+    private val closeStarted = AtomicBoolean(false)
+
+    /**
+     * Issue #1139 / #1136: object-owned scope that runs the channel-close socket
+     * writes OFF the calling thread. [close] is called synchronously from
+     * `Dispatchers.Main.immediate` at the grace/reconnect teardown sites, so the
+     * teardown must never park the caller — it is launched here and the caller
+     * returns immediately. `SupervisorJob` so a wedged/failed close never
+     * escalates; `Dispatchers.IO` is the thread that parks (not Main) if the wire
+     * is truly wedged, until the dispatcher's per-op wall-clock ceiling reclaims
+     * it. The single launched job completes within [CLOSE_TIMEOUT_MS]; the scope
+     * is discarded with this shell instance after close, so it does not leak.
+     */
+    private val closeScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+
     override val stdin: OutputStream
         get() = serializedStdin
 
@@ -91,43 +114,55 @@ internal class RealSshShell(
         // so they go through the dispatcher (issue #847) which also serialises
         // them against any in-flight `-CC` write.
         //
-        // Issue #937 / S1-F1: this `close()` is called SYNCHRONOUSLY from the
-        // Main thread during `TmuxSessionViewModel.onCleared` (activity
-        // destroy). The previous body did a bare `dispatcher.runBlockingDispatch`
-        // which blocks the CALLING thread (Main) until the dispatch-thread op
-        // completes. On a half-open link that channel-close socket write wedges,
-        // so Main parks → ANR and the activity never finishes destroying. We now
-        // hop the whole teardown OFF Main onto `Dispatchers.IO` under a hard
-        // [CLOSE_TIMEOUT_MS] ceiling: the Main thread waits at most that long,
-        // and `Dispatchers.IO` (not Main) is the thread that parks if the wire
-        // is truly wedged. The dispatcher's own per-op ceiling (#937 S4-1) then
-        // interrupts the wedged op and reclaims its thread. The runBlocking here
-        // is a bounded bridge for the non-suspending [SshShell.close] contract,
-        // mirroring the proven `RecurringJobsViewModel`/`GitHistoryViewModel`
-        // off-Main bounded teardown pattern.
+        // Issue #1139 / #1136 / #937 S1-F1 (D33 / G2 class fix): this `close()`
+        // is invoked SYNCHRONOUSLY from `Dispatchers.Main.immediate` at SIX
+        // grace / silent-reattach / transport-reconnect teardown sites in
+        // `TmuxSessionViewModel` (each via `TmuxClient.close()` →
+        // `shell?.close()`), and again from `onCleared` (activity destroy).
         //
-        // sshj's `close` calls are idempotent, so the runCatching guards are
-        // belt-and-braces against the channel already being torn down by the
-        // remote side. If the dispatcher is already closed (parent session
-        // teardown drained it), the operation is rejected — there is nothing
-        // left to close, so swallow that too.
-        runCatching {
-            runBlocking(Dispatchers.IO) {
-                // Call the SUSPENDING `dispatcher.run` (not the blocking
-                // `runBlockingDispatch`) so `withTimeoutOrNull` can actually
-                // cancel the wait when the ceiling trips — a cancellation here
-                // unparks the IO coroutine; the dispatcher's own per-op ceiling
-                // (#937 S4-1) interrupts the wedged socket write and reclaims
-                // the dispatch thread.
-                //
-                // Each channel close is its OWN `dispatcher.run` op so each is
-                // independently bounded + interrupted: a single interrupt only
-                // unblocks ONE blocking call, so two closes in one op would let
-                // the second wedge silently after the first was interrupted.
-                withTimeoutOrNull(CLOSE_TIMEOUT_MS) {
-                    runCatching { dispatcher.run { shell.close() } }
-                    runCatching { dispatcher.run { sessionChannel.close() } }
-                }
+        // The PREVIOUS body wrapped the teardown in `runBlocking(Dispatchers.IO)
+        // { withTimeoutOrNull(CLOSE_TIMEOUT_MS) { … } }`. That kept the socket
+        // WRITE off Main (StrictMode-safe, #166) but `runBlocking` still PARKED
+        // the calling (Main) thread for up to CLOSE_TIMEOUT_MS (2s) waiting for
+        // that write on a degraded / half-open transport. Per stale-client close
+        // that is up to ~2s of Main park — and the grace/reconnect loops chain
+        // several — which is the maintainer's reported "UI fully freezes,
+        // buttons dead, restart required" wedge (#1139 push-resume; the everyday
+        // idle→return journey hits it too).
+        //
+        // HARD-CUT (D22): the default `close()` is now NON-BLOCKING on the
+        // caller. The entire bounded teardown is launched on an object-owned IO
+        // [closeScope] and this method returns immediately; the Main caller
+        // never waits. The [CLOSE_TIMEOUT_MS] ceiling stays INSIDE the launched
+        // coroutine, and the dispatcher's own per-op wall-clock ceiling (#937
+        // S4-1) still interrupts a wedged socket write and reclaims the dispatch
+        // thread — so teardown liveness is unchanged. The 2s ceiling already
+        // tolerated an incomplete teardown, so firing it fully async is no worse
+        // than the pre-existing give-up. This is the single SOURCE fix that makes
+        // all six `TmuxSessionViewModel` close sites (+ any future caller of
+        // `TmuxClient.close()` / `SshShell.close()`) non-blocking-on-Main by
+        // construction, rather than patching each call site.
+        //
+        // Idempotent: a second `close()` is a no-op (the [closeStarted] guard),
+        // and sshj's underlying channel closes are themselves idempotent, so the
+        // `runCatching` guards remain belt-and-braces against the channel already
+        // being torn down by the remote side / a drained dispatcher.
+        if (!closeStarted.compareAndSet(false, true)) return
+        closeScope.launch {
+            // Call the SUSPENDING `dispatcher.run` (not the blocking
+            // `runBlockingDispatch`) so `withTimeoutOrNull` can actually cancel
+            // the wait when the ceiling trips — a cancellation here unparks this
+            // IO coroutine; the dispatcher's own per-op ceiling (#937 S4-1)
+            // interrupts the wedged socket write and reclaims the dispatch
+            // thread.
+            //
+            // Each channel close is its OWN `dispatcher.run` op so each is
+            // independently bounded + interrupted: a single interrupt only
+            // unblocks ONE blocking call, so two closes in one op would let the
+            // second wedge silently after the first was interrupted.
+            withTimeoutOrNull(CLOSE_TIMEOUT_MS) {
+                runCatching { dispatcher.run { shell.close() } }
+                runCatching { dispatcher.run { sessionChannel.close() } }
             }
         }
     }

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshSession.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshSession.kt
@@ -289,8 +289,29 @@ public interface SshSession : AutoCloseable {
      */
     public fun isTransportProvenAliveWithinKeepAliveWindow(): Boolean = false
 
-    /** Disconnect and free all resources. Idempotent. */
+    /**
+     * Disconnect and free all resources. Idempotent.
+     *
+     * Issue #1135 / #1139: [RealSshSession.close] is NON-BLOCKING on the caller
+     * — it launches the bounded `SSH_MSG_DISCONNECT` teardown off the calling
+     * thread and returns immediately, so a Main-thread caller (e.g. the
+     * grace-loop lease-disconnect on `Dispatchers.Main.immediate`) never parks on
+     * a wedged socket. Callers that must observe the transport fully torn down
+     * before proceeding (a redial that reuses nothing but is ordering-sensitive)
+     * await via [awaitClosed] OFF Main.
+     */
     override fun close()
+
+    /**
+     * Await the bounded teardown that [close] launched asynchronously
+     * (issue #1135 / #1139). Suspends until the transport disconnect has drained;
+     * a no-op when [close] was never called or has already finished. Intended to
+     * run on an IO / background dispatcher only — never on Main. The default
+     * body is a no-op so the many per-test [SshSession] fakes (whose `close()` is
+     * already synchronous) need not override it; only [RealSshSession] joins its
+     * real teardown job.
+     */
+    public suspend fun awaitClosed() {}
 
     public companion object {
         /**

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshSessionCloseIdempotencyTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshSessionCloseIdempotencyTest.kt
@@ -1,5 +1,6 @@
 package com.pocketshell.core.ssh
 
+import kotlinx.coroutines.runBlocking
 import net.schmizz.sshj.SSHClient
 import net.schmizz.sshj.common.DisconnectReason
 import net.schmizz.sshj.connection.ConnectionException
@@ -64,7 +65,13 @@ class RealSshSessionCloseIdempotencyTest {
 
         // No exception should propagate — the BY_APPLICATION case is the
         // "transport already gone" no-op `close()` already wanted to be.
-        session.close()
+        // Issue #1135 / #1139: close() is non-blocking; the disconnect runs on the
+        // async close-scope, so await it via [SshSession.awaitClosed] before
+        // asserting the disconnect happened.
+        runBlocking {
+            session.close()
+            session.awaitClosed()
+        }
 
         assertTrue(
             "expected SSHClient.disconnect() to have been called on the first close()",
@@ -93,8 +100,13 @@ class RealSshSessionCloseIdempotencyTest {
         )
         val session = RealSshSession(client)
 
-        session.close()
-        session.close()
+        // Issue #1135 / #1139: close() is non-blocking + one-shot ([closeStarted]
+        // guard). The second close() is a no-op; the first launches the teardown.
+        runBlocking {
+            session.close()
+            session.close()
+            session.awaitClosed()
+        }
 
         assertEquals(
             "expected SSHClient.disconnect() to run exactly once across repeated " +
@@ -120,7 +132,10 @@ class RealSshSessionCloseIdempotencyTest {
         val session = RealSshSession(client)
 
         // Must NOT throw — widened contract per issue #239.
-        session.close()
+        runBlocking {
+            session.close()
+            session.awaitClosed()
+        }
 
         assertEquals(1, client.disconnectCallCount)
     }
@@ -160,7 +175,10 @@ class RealSshSessionCloseIdempotencyTest {
         )
         val session = RealSshSession(client)
 
-        session.close() // must not throw
+        runBlocking {
+            session.close() // must not throw
+            session.awaitClosed()
+        }
 
         assertEquals(1, client.disconnectCallCount)
     }
@@ -176,7 +194,10 @@ class RealSshSessionCloseIdempotencyTest {
         )
         val session = RealSshSession(client)
 
-        session.close() // must not throw
+        runBlocking {
+            session.close() // must not throw
+            session.awaitClosed()
+        }
 
         assertEquals(1, client.disconnectCallCount)
     }
@@ -201,7 +222,6 @@ class RealSshSessionCloseIdempotencyTest {
             ),
         )
         val firstSession = RealSshSession(firstClient)
-        firstSession.close()
         // Second close on an already-disconnected client: raises a
         // raw SocketException (the underlying socket is gone).
         val secondClient = ThrowingDisconnectClient(
@@ -209,7 +229,12 @@ class RealSshSessionCloseIdempotencyTest {
         )
         val secondSession = RealSshSession(secondClient)
 
-        secondSession.close() // must not throw
+        runBlocking {
+            firstSession.close()
+            firstSession.awaitClosed()
+            secondSession.close() // must not throw
+            secondSession.awaitClosed()
+        }
 
         assertEquals(1, firstClient.disconnectCallCount)
         assertEquals(1, secondClient.disconnectCallCount)

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshSessionCloseOffCallerTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshSessionCloseOffCallerTest.kt
@@ -1,0 +1,204 @@
+package com.pocketshell.core.ssh
+
+import kotlinx.coroutines.runBlocking
+import net.schmizz.sshj.SSHClient
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Issue #1135 / #1139 (D33 / G1 / G2 — the SOURCE class fix): [RealSshSession.close]
+ * must be NON-BLOCKING on the calling thread. The blocking `SSH_MSG_DISCONNECT`
+ * socket write (`client.disconnect()`, bounded to ~2s) is launched OFF the caller
+ * onto an object-owned IO scope and joined only through the suspend [SshSession.awaitClosed]
+ * seam.
+ *
+ * This is the load-bearing regression for the maintainer's "UI fully freezes,
+ * buttons dead, restart required" wedge. The OLD body wrapped the teardown in
+ * `runBlocking(Dispatchers.IO) { withTimeoutOrNull(2000) { … } }`, so the socket
+ * write ran off-Main (StrictMode-safe, #166) but the CALLER still PARKED up to
+ * ~2s per stale-session close. Two DIFFERENT Main-thread callers hit that same
+ * blocking `close()`:
+ *
+ *  - the grace-loop lease-disconnect (`TmuxSessionViewModel` →
+ *    `SshLeaseManager.disconnect` inside `withContext(NonCancellable)` on
+ *    `viewModelScope` = `Dispatchers.Main.immediate`, no dispatcher hop) — the
+ *    #1139 push-resume residual, and
+ *  - the port-forward `AutoForwarderSupervisor` reconnect/teardown path (#1135).
+ *
+ * Fixing the single choke point ([RealSshSession.close]) makes EVERY caller
+ * non-blocking-on-caller by construction. These tests assert the caller returns
+ * in well UNDER the 2s ceiling (RED on base ~2–4s park, GREEN with the async
+ * source fix) via BOTH the direct choke point AND the real lease-disconnect
+ * chain, and that the teardown still actually runs off-thread (G6 — not a vacuous
+ * pass).
+ */
+class RealSshSessionCloseOffCallerTest {
+
+    @Test
+    fun `close returns to the caller without parking for the wedged transport disconnect`() {
+        val client = WedgedDisconnectClient()
+        val session = RealSshSession(client)
+        try {
+            // Call close() DIRECTLY on this (caller / Main-equivalent) thread and
+            // measure how long it parks. With the async source fix it launches the
+            // bounded teardown and returns in ~ms; on base it blocks until the 2s
+            // (+2s force fallback) ceiling trips inside runBlocking.
+            val start = System.nanoTime()
+            session.close()
+            val callerBlockedMs = (System.nanoTime() - start) / 1_000_000
+
+            assertTrue(
+                "close() must return to the caller WITHOUT parking for the bounded " +
+                    "transport-disconnect wait — the caller (Main in production) must " +
+                    "not block while a half-open SSH_MSG_DISCONNECT write drains. RED " +
+                    "on base (~2s+ park), GREEN with the async source fix. " +
+                    "caller-blocked=${callerBlockedMs}ms",
+                callerBlockedMs < CALLER_RETURN_BOUND_MS,
+            )
+            // The teardown must still actually run (off the caller thread): the
+            // wedged disconnect is entered on the IO close-scope. Proves the fix
+            // is non-blocking, NOT a no-op (G6 — not a vacuous pass).
+            assertTrue(
+                "the transport-disconnect teardown must still run asynchronously " +
+                    "(entered off the caller thread): caller-blocked=${callerBlockedMs}ms",
+                client.disconnectEntered.await(5, TimeUnit.SECONDS),
+            )
+        } finally {
+            client.release()
+        }
+    }
+
+    @Test
+    fun `lease disconnect returns to the caller without parking on a wedged transport`() = runBlocking {
+        // Class coverage (G2): drive the REAL #1139 residual path end-to-end —
+        // SshLeaseManager.disconnect(key) → Entry.close() → RealSshSession.close().
+        // On the grace loop this runs on Dispatchers.Main.immediate; here we
+        // measure that the disconnect() suspend point returns promptly even though
+        // the underlying transport disconnect is wedged.
+        val client = WedgedDisconnectClient()
+        val session = RealSshSession(client)
+        val manager = SshLeaseManager(connector = SshLeaseConnector { Result.success(session) })
+        try {
+            manager.acquire(TARGET).getOrThrow()
+
+            val start = System.nanoTime()
+            manager.disconnect(TARGET.leaseKey)
+            val callerBlockedMs = (System.nanoTime() - start) / 1_000_000
+
+            assertTrue(
+                "SshLeaseManager.disconnect (grace-loop lease-disconnect, Main in " +
+                    "production) must return WITHOUT parking on the wedged transport " +
+                    "close. RED on base (~2s+ park), GREEN with the async source fix. " +
+                    "caller-blocked=${callerBlockedMs}ms",
+                callerBlockedMs < CALLER_RETURN_BOUND_MS,
+            )
+            assertTrue(
+                "the underlying transport disconnect must still run asynchronously",
+                client.disconnectEntered.await(5, TimeUnit.SECONDS),
+            )
+        } finally {
+            client.release()
+            manager.close()
+        }
+    }
+
+    @Test
+    fun `close is idempotent and drives exactly one teardown`() = runBlocking {
+        // The [closeStarted] guard: a repeated close() (idempotent by contract)
+        // must NOT relaunch the teardown. A non-wedged disconnect drains cleanly
+        // (no force fallback), so the transport disconnect runs EXACTLY once across
+        // both close() calls.
+        val client = CountingDisconnectClient()
+        val session = RealSshSession(client)
+
+        session.close()
+        session.close() // idempotent — must not relaunch teardown
+        session.awaitClosed()
+
+        assertTrue(
+            "the teardown must run (disconnect invoked): count=${client.disconnectCount.get()}",
+            client.disconnectCount.get() >= 1,
+        )
+        assertTrue(
+            "a repeated close() must NOT drive a second teardown: " +
+                "count=${client.disconnectCount.get()}",
+            client.disconnectCount.get() == 1,
+        )
+        assertFalse("closed session must report disconnected", session.isConnected)
+    }
+
+    /**
+     * An [SSHClient] whose `disconnect()` blocks (like a half-open socket write)
+     * until [release] is called or the bounded teardown ceiling interrupts it.
+     */
+    private class WedgedDisconnectClient : SSHClient() {
+        val disconnectEntered = CountDownLatch(1)
+        private val release = CountDownLatch(1)
+
+        @Volatile
+        private var disconnectedFlag = false
+
+        override fun isConnected(): Boolean = !disconnectedFlag
+        override fun isAuthenticated(): Boolean = !disconnectedFlag
+
+        override fun disconnect() {
+            disconnectEntered.countDown()
+            try {
+                // Block like a wedged SSH_MSG_DISCONNECT write; the teardown's
+                // bounded ceiling / dispatcher per-op ceiling interrupts this.
+                release.await(10, TimeUnit.SECONDS)
+            } catch (e: InterruptedException) {
+                Thread.currentThread().interrupt()
+            }
+            disconnectedFlag = true
+        }
+
+        fun release() {
+            release.countDown()
+        }
+    }
+
+    /** An [SSHClient] whose `disconnect()` completes instantly and is counted. */
+    private class CountingDisconnectClient : SSHClient() {
+        val disconnectCount = AtomicInteger(0)
+
+        @Volatile
+        private var disconnectedFlag = false
+
+        override fun isConnected(): Boolean = !disconnectedFlag
+        override fun isAuthenticated(): Boolean = !disconnectedFlag
+
+        override fun disconnect() {
+            disconnectCount.incrementAndGet()
+            disconnectedFlag = true
+        }
+    }
+
+    private companion object {
+        /**
+         * Upper bound on how long the caller thread may block inside a
+         * non-blocking [RealSshSession.close] / lease-disconnect. The async fix
+         * returns in ~ms; the base (blocking runBlocking) parks the caller until
+         * the ~2s `SESSION_CLOSE_TIMEOUT_MS` ceiling (plus the force fallback).
+         * 750ms sits decisively between the two — comfortably above
+         * coroutine-launch + scheduling jitter on a loaded CI box, far below the
+         * base park it must catch.
+         */
+        const val CALLER_RETURN_BOUND_MS: Long = 750L
+
+        val TARGET: SshLeaseTarget = SshLeaseTarget(
+            leaseKey = SshLeaseKey(
+                host = "10.0.2.2",
+                port = 2222,
+                user = "testuser",
+                credentialId = "/tmp/key-a",
+            ),
+            key = SshKey.Path(File("/tmp/key-a")),
+        )
+    }
+}

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshSessionTeardownOrderingTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshSessionTeardownOrderingTest.kt
@@ -44,14 +44,27 @@ class RealSshSessionTeardownOrderingTest {
             client.startSessionEntered.await(5, TimeUnit.SECONDS),
         )
 
-        val elapsedMs = measureTimeMillis {
+        // Issue #1135 / #1139: close() is now NON-BLOCKING on the caller — it
+        // launches the bounded teardown and returns in ~ms even though the
+        // dispatcher is wedged. The bounded-teardown property moved to the
+        // suspend [awaitClosed] seam, which ordering-sensitive callers join OFF
+        // Main.
+        val callerBlockedMs = measureTimeMillis {
             session.close()
         }
-
         assertTrue(
-            "close() must return within the session close budget instead of waiting " +
-                "for the dispatcher's full per-op ceiling; elapsed=${elapsedMs}ms",
-            elapsedMs < 3_500L,
+            "close() must return to the caller WITHOUT parking for the bounded " +
+                "teardown wait; caller-blocked=${callerBlockedMs}ms",
+            callerBlockedMs < 750L,
+        )
+
+        val teardownMs = measureTimeMillis {
+            session.awaitClosed()
+        }
+        assertTrue(
+            "awaitClosed() must return within the session close budget instead of " +
+                "waiting for the dispatcher's full per-op ceiling; elapsed=${teardownMs}ms",
+            teardownMs < 3_500L,
         )
         assertFalse("close must mark the session disconnected", session.isConnected)
         assertTrue(
@@ -81,16 +94,21 @@ class RealSshSessionTeardownOrderingTest {
             client.startSessionEntered.await(5, TimeUnit.SECONDS),
         )
 
-        val closeThread = Thread({ session.close() }, "ps-test-session-close").apply {
-            isDaemon = true
-            start()
+        // Issue #1135 / #1139: close() returns to the caller in ~ms even when the
+        // whole teardown (dispatcher drain + raw disconnect fallback) wedges; the
+        // bounded fallback runs on the object-owned IO close-scope, joined via
+        // [awaitClosed].
+        val callerBlockedMs = measureTimeMillis {
+            session.close()
         }
-        closeThread.join(5_500L)
-
-        assertFalse(
-            "close() must return even when the raw disconnect fallback wedges",
-            closeThread.isAlive,
+        assertTrue(
+            "close() must return to the caller WITHOUT parking even when the raw " +
+                "disconnect fallback wedges; caller-blocked=${callerBlockedMs}ms",
+            callerBlockedMs < 750L,
         )
+        withTimeout(8_000L) {
+            session.awaitClosed()
+        }
         assertTrue(
             "the raw fallback disconnect must have been attempted",
             client.rawDisconnectEntered.await(1, TimeUnit.SECONDS),
@@ -120,7 +138,11 @@ class RealSshSessionTeardownOrderingTest {
             command.readStarted.await(5, TimeUnit.SECONDS),
         )
 
+        // Issue #1135 / #1139: close() is non-blocking; the drain-then-disconnect
+        // ordering now runs inside the async teardown, joined via [awaitClosed]
+        // before we inspect the recorded event order.
         session.close()
+        session.awaitClosed()
         tail.cancelAndJoin()
 
         val snapshot = events.snapshot()

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshShellCloseOffMainTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshShellCloseOffMainTest.kt
@@ -78,6 +78,67 @@ class RealSshShellCloseOffMainTest {
     }
 
     /**
+     * Issue #1139 / #1136 (D33 / G1 / G2 — the class fix): the caller returns
+     * ALMOST IMMEDIATELY, NOT after the bounded [RealSshShell.CLOSE_TIMEOUT_MS]
+     * (2s) wait, when the channel close wedges on a half-open transport.
+     *
+     * This is the load-bearing regression for the maintainer's "UI fully
+     * freezes, buttons dead, restart required" wedge. The OLD body wrapped the
+     * teardown in `runBlocking(Dispatchers.IO) { withTimeoutOrNull(2000) { … } }`,
+     * so while the socket write ran off-Main the CALLER still PARKED for up to
+     * ~2s per stale-client close. The `close returns within the bound` test
+     * above only asserts the caller returns "within the 2s bound" — a 2s Main
+     * park still passes it — so it did NOT catch this class. Here we assert the
+     * caller returns in well UNDER the 2s ceiling: RED on base (blocks ~2s),
+     * GREEN with the async source fix (returns in ~ms while the wedged teardown
+     * drains on the IO close-scope).
+     *
+     * Class coverage (G2): this is the SOURCE guarantee. Every one of the six
+     * `Dispatchers.Main.immediate` teardown sites in `TmuxSessionViewModel`
+     * (`:7932, :8056, :8156, :8196, :8290, :8304`) reaches this method via
+     * `TmuxClient.close()` → `closeInternal()` → `shell?.close()`, and
+     * `closeInternal`'s only other work (state-flag flips, `readerJob.cancel()`,
+     * in-memory pane-pipe closes, `clientScope.cancel()`) is non-blocking. So a
+     * non-blocking `RealSshShell.close()` makes all six sites — and any future
+     * caller of `SshShell.close()` / `TmuxClient.close()` — non-blocking-on-Main
+     * by construction, rather than patching each call site.
+     */
+    @Test
+    fun `close returns to the caller without parking for the bounded teardown wait`() {
+        val closeEntered = CountDownLatch(1)
+        val neverReturns = CountDownLatch(1)
+        val shell = wedgingShell(closeEntered, neverReturns)
+        val session = wedgingSession(closeEntered, neverReturns)
+        val realShell = RealSshShell(session, shell, TransportDispatcher())
+
+        // Call close() DIRECTLY on this (caller/Main-equivalent) thread and
+        // measure how long it parks. With the async source fix it launches the
+        // teardown and returns in ~ms; on base it blocks until the 2s
+        // CLOSE_TIMEOUT_MS ceiling trips inside runBlocking.
+        val start = System.nanoTime()
+        realShell.close()
+        val callerBlockedMs = (System.nanoTime() - start) / 1_000_000
+
+        assertTrue(
+            "close() must return to the caller WITHOUT parking for the bounded " +
+                "teardown wait — the caller (Main in production) must not block " +
+                "while a half-open channel close drains. RED on base (~2s park), " +
+                "GREEN with the async source fix. caller-blocked=${callerBlockedMs}ms",
+            callerBlockedMs < CALLER_RETURN_BOUND_MS,
+        )
+        // The teardown must still actually run (off the caller thread): the
+        // wedged channel close is entered on the IO close-scope. Proves the fix
+        // is non-blocking, NOT a no-op (G6 — not a vacuous pass).
+        assertTrue(
+            "the channel-close teardown must still run asynchronously (entered " +
+                "off the caller thread): caller-blocked=${callerBlockedMs}ms",
+            closeEntered.await(5, TimeUnit.SECONDS),
+        )
+
+        neverReturns.countDown() // let the wedged proxy thread unwind
+    }
+
+    /**
      * The channel-close work runs OFF the calling thread (on Dispatchers.IO),
      * so the Main thread is never the one doing the blocking socket write —
      * the StrictMode/ANR concern (#166/#937 S1-F1).
@@ -165,5 +226,17 @@ class RealSshShellCloseOffMainTest {
         InputStream::class.java -> ByteArrayInputStream(ByteArray(0))
         Void.TYPE -> null
         else -> null
+    }
+
+    private companion object {
+        /**
+         * Upper bound on how long the caller thread may block inside a
+         * non-blocking [RealSshShell.close]. The async fix returns in ~ms; the
+         * base (blocking runBlocking) parks the caller until the 2s
+         * `CLOSE_TIMEOUT_MS` ceiling. 750ms sits decisively between the two:
+         * comfortably above coroutine-launch + scheduling jitter on a loaded CI
+         * box, and far below the ~2000ms base park it must catch.
+         */
+        const val CALLER_RETURN_BOUND_MS: Long = 750L
     }
 }


### PR DESCRIPTION
Fixes the maintainer's #1 reported symptom — **UI fully freezes, restart required** — on the push-resume / idle-return path. Consolidates #1139 + #1136 + #1135 into one class-covering source fix.

## Root cause
The grace / silent-reattach / transport-reconnect loops run on `viewModelScope`=`Dispatchers.Main.immediate` and their `withContext(NonCancellable)` blocks don't hop dispatchers. The **six** close sites in `TmuxSessionViewModel` (`:7932/:8056/:8156/:8196/:8290/:8304`) each synchronously park Main up to ~2s on a wedged socket, via **two** distinct blocking methods:
- `RealSshShell.close()` (2 sites, via `TmuxClient.close()`→`closeInternal()`→`shell.close()`)
- `RealSshSession.close()` (4 sites, via `sshLeaseManager.disconnect()` at `:8129`) — also the #1135 AutoForwarder path + lease eviction.

The first review round fixed only `RealSshShell.close()` and the reviewer correctly caught (G2) that the 4 lease-disconnect sites still parked Main — so this combines both.

## Fix (hard-cut D22)
Both `close()` methods now launch the bounded teardown on an object-owned `CoroutineScope(SupervisorJob()+Dispatchers.IO)` and return immediately (timeout ceiling kept inside the coroutine). `RealSshSession.close()` adds a suspend `awaitClosed()` seam (additive interface default no-op — no caller breaks) so teardown-before-redial ordering is preserved by awaiting on IO, never on Main; `RealSshSessionTeardownOrderingTest`/`...IdempotencyTest` reworked to await via it.

**All six Main-dispatched close sites are non-blocking by construction.**

## Reproduce → verify (D33/G1/G2)
- Red→green: base parks `caller-blocked ~2042ms` (shell) / `4019ms`+`4003ms` (session choke point + real lease-disconnect chain) → **<750ms** with the fix, teardown still runs off-thread (non-vacuous).
- `:shared:core-ssh:testDebugUnitTest` → **217 tests, 0 failed** (combined, run by orchestrator: BUILD SUCCESSFUL).
- Reachability evidence (#1135): AutoForwarder invokers are all on `Dispatchers.IO`; the Main-reachable caller is the grace-loop lease-disconnect — one root, covered here.

Combined from two reviewed slices (RealSshShell round-1 verified correct; RealSshSession source fix). Needs a single combined review confirming all six sites are non-blocking + the D28/D31 connection-teardown adjacency (grace-loop journey).

Closes #1139
Closes #1136
Closes #1135