### PR TITLE
test: NAT idle-mapping survival regression guard for keepalive interval (#1063)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/NatIdleMappingSurvivalE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/NatIdleMappingSurvivalE2eTest.kt
@@ -1,0 +1,259 @@
+package com.pocketshell.app.proof
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.os.SystemClock
+import android.view.View
+import android.view.ViewGroup
+import androidx.lifecycle.ViewModelProvider
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.MainActivity
+import com.pocketshell.app.diagnostics.DiagnosticEvents
+import com.pocketshell.app.tmux.LivenessProbeTestOverride
+import com.pocketshell.app.tmux.TmuxSessionViewModel
+import com.pocketshell.core.ssh.KeepAliveTestOverride
+import com.pocketshell.core.ssh.SshKey
+import com.termux.view.TerminalView
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Issue #1063 (R3, from the #843 round-2 mobile audit / gap C2) — the REAL-WIRE
+ * carrier-NAT idle-mapping RECOVERY proof (Arm 2): when the carrier NAT actually
+ * reaps the idle TCP mapping mid-idle (modelled by the toxiproxy `timeout=0`
+ * half-open toxic — no RST/FIN, packets silently dropped), the always-on
+ * [com.pocketshell.core.ssh.TransportKeepAlive] (#945) must DETECT the now-dead
+ * half-open transport within its `countMax × interval` budget and drive recovery,
+ * after which the session returns to Connected and a post-recovery send round-trips.
+ *
+ * CI_JOURNEY_SUITE_JUSTIFIED: this is a toxiproxy `NetworkFaultProofBase` proof; it
+ * needs the `network-fault-proxy` family that `tests.yml` deliberately leaves down,
+ * so it self-skips on CI ([assumeNetworkFaultProofsEnabled]) — wiring it into
+ * `scripts/ci-journey-suite.sh` would only ever ALL-SKIP at PR time (the G3 vacuous-
+ * pass trap the round-1 reviewer flagged). It is the reviewer's real-wire RECOVERY
+ * evidence, run with the proxy family up (the same pattern as the baselined
+ * `PacketLossNetworkFaultE2eTest` / `DisconnectBlackholeE2eTest` siblings).
+ *
+ * The LOAD-BEARING per-push red→green for Arm 1 (idle-mapping SURVIVAL: a keepalive
+ * interval shorter than the NAT idle window keeps the mapping warm; a retune past it
+ * reaps it) lives at the layer where the keepalive IS the deciding factor —
+ * `shared/core-ssh/src/test/.../NatIdleMappingSurvivalKeepAliveTest.kt` — and runs
+ * in the per-push Unit gate. Round 1's connected-oracle survival pair could NOT
+ * isolate the keepalive: the tmux `-CC` control channel itself refreshes inbound
+ * activity (`RealSshSession`, `onInboundActivity = ::recordInboundActivity`), so the
+ * oracle stayed proven-alive even with the keepalive effectively off — the reviewer
+ * proved that pair vacuous on emulator + Docker. Hence the survival pin pivoted to
+ * the keepalive layer; this connected file keeps only the genuinely non-vacuous
+ * recovery proof (the half-open blackhole kills ALL inbound, `-CC` included, so the
+ * keepalive's dead-detection budget is the real variable).
+ */
+@RunWith(AndroidJUnit4::class)
+class NatIdleMappingSurvivalE2eTest : NetworkFaultProofBase() {
+
+    private var diagnostics: RecordingDiagnosticSink? = null
+
+    @Before
+    fun installDiagnostics() {
+        clearLastSessionPrefs()
+        diagnostics = RecordingDiagnosticSink().also { DiagnosticEvents.install(it) }
+        // Disable the foreground `-CC` LivenessProbe so the transport keepalive is
+        // the SOLE dead-transport detector for the recovery arm — i.e. the recovery
+        // is genuinely driven by the keepalive's budget, not the probe's (which would
+        // otherwise race it). The keepalive timing is set per-method below.
+        LivenessProbeTestOverride.setForTest(
+            intervalMs = PROBE_DISABLED_INTERVAL_MS,
+            perProbeTimeoutMs = PROBE_DISABLED_TIMEOUT_MS,
+            failureThreshold = PROBE_FAILURE_THRESHOLD,
+        )
+    }
+
+    @After
+    fun clearOverrides() {
+        LivenessProbeTestOverride.clear()
+        KeepAliveTestOverride.clear()
+        diagnostics?.close()
+        diagnostics = null
+        clearLastSessionPrefs()
+    }
+
+    /**
+     * ARM 2, REAL-WIRE recovery (toxiproxy `timeout=0` half-open). The carrier NAT
+     * reaps the mapping MID-IDLE (half-open blackhole — no RST/FIN). The (short)
+     * keepalive detects the dead transport within its `countMax × interval` budget
+     * and drives recovery; once the link is restored the session returns to
+     * Connected and a post-recovery send round-trips.
+     */
+    @Test
+    fun severedIdleNatMappingRecoversWithinKeepAliveBudget() = runBlocking<Unit> {
+        assumeNetworkFaultProofsEnabled()
+        // SHORT keepalive so the dead-transport detection budget (interval × count)
+        // is small and deterministic: 3s × 3 = ~9s.
+        KeepAliveTestOverride.setForTest(
+            intervalMs = RECOVERY_KEEPALIVE_INTERVAL_MS,
+            countMax = KEEPALIVE_COUNT_MAX,
+        )
+
+        val key = readFixtureKey()
+        val marker = "rc${System.currentTimeMillis().toString(36).takeLast(5)}"
+        val sessionName = "issue1063-recover-$marker"
+        val hostName = "Issue1063 NatRecover $marker"
+        prepareProxyAndRemoteSession(
+            key = key,
+            sessionName = sessionName,
+            readyText = "ISSUE1063-RECOVER-READY-$marker",
+        )
+        val hostRowTag = seedNetworkFaultHost(key, hostName)
+
+        launchedActivity = ActivityScenario.launch(MainActivity::class.java)
+        attachToSession(hostRowTag, hostName, sessionName)
+        sendCommandThroughTerminalInput("printf 'LIVE-$marker\\n'", "pre-sever-live")
+        waitForVisibleTerminalText("pre-sever-live") { "LIVE-$marker" in it }
+        waitForConnected("initial attach")
+        captureViewport("issue1063-recover-01-attached")
+
+        // Idle briefly, then SEVER the mapping mid-idle (half-open blackhole).
+        SystemClock.sleep(2_000)
+        val severStart = SystemClock.elapsedRealtime()
+        toxiproxy().addBlackhole()
+        recordTiming("recover_severed_at_ms", severStart)
+
+        // The keepalive must DETECT the dead half-open transport within its budget
+        // and surface the connection-lost band (the user-visible recovery signal).
+        waitForDisconnectBand("severed NAT mapping", timeoutMillis = KEEPALIVE_DEATH_DETECT_TIMEOUT_MS)
+        val detectMs = SystemClock.elapsedRealtime() - severStart
+        recordTiming("recover_detect_ms", detectMs)
+
+        // Restore the link (the device gets a fresh path / the NAT remaps on the
+        // reconnect) so recovery can complete.
+        toxiproxy().clearToxics()
+
+        // Recovery: the session returns to Connected and a post-recovery send
+        // round-trips — recovery within the keepalive budget + a reconnect.
+        waitForConnected("after severed-mapping recovery", timeoutMs = RECOVERY_CONNECTED_TIMEOUT_MS)
+        sendCommandThroughTerminalInput("printf 'RECOV-$marker\\n'", "post-recovery")
+        waitForVisibleTerminalText("post-recovery round-trip") { "RECOV-$marker" in it }
+        captureViewport("issue1063-recover-02-recovered")
+
+        assertTrue(
+            "the keepalive must detect the severed half-open mapping within its budget " +
+                "(${KEEPALIVE_DEATH_BUDGET_MS}ms = ${RECOVERY_KEEPALIVE_INTERVAL_MS}ms x " +
+                "$KEEPALIVE_COUNT_MAX); detected after ${detectMs}ms",
+            detectMs <= KEEPALIVE_DEATH_DETECT_TIMEOUT_MS,
+        )
+
+        writeSummary(
+            testName = "NatIdleMappingSurvival-recover",
+            lines = listOf(
+                "session=$sessionName",
+                "fixture=network-fault-proxy:$NETWORK_FAULT_SSH_PORT (toxiproxy half-open)",
+                "keepalive_override=${RECOVERY_KEEPALIVE_INTERVAL_MS}ms x $KEEPALIVE_COUNT_MAX (SHORT)",
+                "keepalive_death_budget_ms=$KEEPALIVE_DEATH_BUDGET_MS",
+                "detect_ms=$detectMs",
+                "expectation=keepalive detects half-open within budget => recovery + send",
+            ),
+        )
+    }
+
+    // -- helpers ------------------------------------------------------------------
+
+    private fun currentConnectionStatus(): TmuxSessionViewModel.ConnectionStatus {
+        var status: TmuxSessionViewModel.ConnectionStatus =
+            TmuxSessionViewModel.ConnectionStatus.Idle
+        launchedActivity?.onActivity { activity ->
+            status = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+                .connectionStatus
+                .value
+        }
+        return status
+    }
+
+    private fun waitForConnected(label: String, timeoutMs: Long = CONNECTED_TIMEOUT_MS) {
+        compose.waitUntil(timeoutMillis = timeoutMs) {
+            currentConnectionStatus() is TmuxSessionViewModel.ConnectionStatus.Connected
+        }
+        assertTrue(
+            "expected Connected after $label, observed=${currentConnectionStatus()}",
+            currentConnectionStatus() is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+    }
+
+    private fun captureViewport(name: String) {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.waitForIdleSync()
+        SystemClock.sleep(120)
+        var bitmap: Bitmap? = null
+        launchedActivity?.onActivity { activity ->
+            val view = activity.window.decorView.findTerminalView() ?: return@onActivity
+            if (view.width <= 0 || view.height <= 0) return@onActivity
+            val b = Bitmap.createBitmap(view.width, view.height, Bitmap.Config.ARGB_8888)
+            view.draw(Canvas(b))
+            bitmap = b
+        }
+        bitmap?.let {
+            val file = artifactFile("$name-viewport.png")
+            java.io.FileOutputStream(file).use { out ->
+                check(it.compress(Bitmap.CompressFormat.PNG, 100, out)) {
+                    "failed to write bitmap to ${file.absolutePath}"
+                }
+            }
+            println("ISSUE1063_VIEWPORT ${file.absolutePath}")
+            it.recycle()
+        }
+        artifactFile("$name-visible-terminal.txt").writeText(visibleTerminalText())
+    }
+
+    private fun visibleTerminalText(): String {
+        var text = ""
+        launchedActivity?.onActivity { activity ->
+            text = activity.window.decorView
+                .findTerminalView()
+                ?.currentSession
+                ?.emulator
+                ?.screen
+                ?.transcriptText
+                .orEmpty()
+        }
+        return text
+    }
+
+    private fun View.findTerminalView(): TerminalView? {
+        if (this is TerminalView) return this
+        if (this !is ViewGroup) return null
+        for (index in 0 until childCount) {
+            val match = getChildAt(index).findTerminalView()
+            if (match != null) return match
+        }
+        return null
+    }
+
+    private companion object {
+        // SHORT keepalive (Arm 2 recovery): a small, deterministic dead-transport
+        // detection budget = interval × countMax = 3s × 3 = ~9s.
+        const val RECOVERY_KEEPALIVE_INTERVAL_MS: Long = 3_000L
+        const val KEEPALIVE_COUNT_MAX: Int = 3
+        const val KEEPALIVE_DEATH_BUDGET_MS: Long =
+            RECOVERY_KEEPALIVE_INTERVAL_MS * KEEPALIVE_COUNT_MAX // ~9s
+
+        // Disable the foreground `-CC` LivenessProbe for the recovery arm so the
+        // keepalive is the SOLE dead-transport detector (probe interval ≫ any hold).
+        const val PROBE_DISABLED_INTERVAL_MS: Long = 3_600_000L
+        const val PROBE_DISABLED_TIMEOUT_MS: Long = 5_000L
+        const val PROBE_FAILURE_THRESHOLD: Int = 4
+
+        val CONNECTED_TIMEOUT_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 30_000L else 20_000L
+
+        // Detection budget + a generous reconnect/AVD margin for the half-open
+        // recovery arm.
+        val KEEPALIVE_DEATH_DETECT_TIMEOUT_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 40_000L else 30_000L
+        val RECOVERY_CONNECTED_TIMEOUT_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 60_000L else 45_000L
+    }
+}

--- a/scripts/check-ci-journey-harness.sh
+++ b/scripts/check-ci-journey-harness.sh
@@ -111,6 +111,15 @@ KNOWN_UNWIRED_ANDROID_E2E_DOCKER_CLASSES=(
   "com.pocketshell.app.proof.EmulatorWorkflowE2eTest"
   "com.pocketshell.app.proof.FastResumeReconnectE2eTest"
   "com.pocketshell.app.proof.MultiHostSessionE2eTest"
+  # Nightly-extensive-only carrier-NAT idle-mapping RECOVERY proof (#1063, R3).
+  # A NetworkFaultProofBase toxiproxy half-open proof: it self-skips on CI
+  # (assumeNetworkFaultProofsEnabled -> tests.yml leaves network-fault-proxy:2228 +
+  # toxiproxy:8474 down), so wiring it into the per-PR ci-journey-suite.sh would only
+  # ALL-SKIP (the G3 vacuous-pass trap). It is enrolled in NETWORK_FAULT_CLASSES and
+  # runs via nightly-extensive.yml / scripts/nightly-extensive-suite.sh (proxy up).
+  # The load-bearing per-push red->green survival pin lives in the Unit gate
+  # (shared/core-ssh NatIdleMappingSurvivalKeepAliveTest).
+  "com.pocketshell.app.proof.NatIdleMappingSurvivalE2eTest"
   "com.pocketshell.app.proof.NavigatorBackForegroundNoSshE2eTest"
   "com.pocketshell.app.proof.NetworkLatencyModelE2eTest"
   "com.pocketshell.app.proof.NoBackgroundWorkE2eTest"

--- a/scripts/nightly-extensive-suite.sh
+++ b/scripts/nightly-extensive-suite.sh
@@ -100,6 +100,19 @@ NETWORK_FAULT_CLASSES=(
   # D31's per-push gate is met without depending on the toxiproxy family). Reuses
   # network-fault-proxy:2228 + toxiproxy API:8474 (no new fixture).
   "$FQCN_PREFIX.SilentMidSessionDropDetectionE2eTest"
+  # Issue #1063 (R3, #843 round-2 gap C2): the REAL-WIRE carrier-NAT idle-mapping
+  # RECOVERY proof (Arm 2). A toxiproxy `timeout=0` half-open blackhole models the
+  # carrier NAT reaping an idle TCP mapping mid-idle (no RST/FIN — all bytes,
+  # `-CC` included, silently dropped); the always-on transport keepalive must
+  # DETECT the dead half-open transport within its `countMax × interval` budget and
+  # drive recovery, after which the session returns to Connected and a post-recovery
+  # send round-trips. Self-skips per-push (needs network-fault-proxy:2228 +
+  # toxiproxy API:8474 which tests.yml leaves down), so it is enrolled here with its
+  # toxiproxy siblings. The LOAD-BEARING per-push red→green for Arm 1 (idle-mapping
+  # SURVIVAL: keepalive interval < NAT window keeps the mapping warm) lives at the
+  # keepalive layer in shared/core-ssh (NatIdleMappingSurvivalKeepAliveTest, the
+  # Unit gate). Reuses network-fault-proxy:2228 + toxiproxy API:8474 (no new fixture).
+  "$FQCN_PREFIX.NatIdleMappingSurvivalE2eTest"
 )
 
 # The bootstrap setup-scenario class (opt-in via pocketshellBootstrapScenarios).

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/NatIdleMappingSurvivalKeepAliveTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/NatIdleMappingSurvivalKeepAliveTest.kt
@@ -1,0 +1,297 @@
+package com.pocketshell.core.ssh
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1063 (R3, from the #843 round-2 mobile audit / gap C2) — the carrier-NAT
+ * idle-mapping SURVIVAL regression guard for the always-on transport keepalive
+ * INTERVAL. D31/D32 (G2/G6) / D33 (reproduce → fix → verify) / G9 (a test per
+ * acceptance criterion).
+ *
+ * --------------------------------------------------------------------------
+ * THE REAL-WORLD TRIGGER IT PINS
+ *
+ * A carrier-grade NAT (CGNAT) on a cellular link drops an IDLE TCP mapping after a
+ * per-carrier idle window W (observed in the wild as low as tens of seconds — far
+ * below RFC 5382's 2h4m floor, which mobile carriers routinely violate). Once the
+ * mapping is gone the path is HALF-OPEN: both ends still believe the socket is up,
+ * but packets are silently dropped. PocketShell's always-on
+ * [TransportKeepAlive] (#945) prevents this: on an idle link it sends one
+ * `keepalive@openssh.com` per [TransportKeepAlive] `intervalMs`, and EVERY reply is
+ * inbound traffic that resets the carrier-NAT idle timer — so the mapping never
+ * sits idle long enough to be reaped. This is *by design*, but nothing pinned it.
+ * A future interval retune (e.g. bumping it past W to "save battery") would
+ * silently break long-idle survival on cellular and the maintainer would only find
+ * out by losing a session after reading/recording a voice note for a minute.
+ *
+ * --------------------------------------------------------------------------
+ * WHY THIS LIVES AT THE KEEPALIVE LAYER, NOT THE CONNECTED `-CC` ORACLE (round 2)
+ *
+ * Round 1 tried to prove this on the live connected session by disabling the
+ * foreground `-CC` LivenessProbe and reading the production transport-liveness
+ * oracle [RealSshSession.isTransportProvenAliveWithinKeepAliveWindow] across a long
+ * idle, claiming the keepalive was then the SOLE inbound source. The reviewer RAN
+ * it on emulator + Docker and proved that premise FALSE: with the keepalive retuned
+ * to 600s (effectively OFF) the oracle still stayed proven-alive for the whole 130s
+ * — so something OTHER than the keepalive refreshes inbound activity inside the
+ * window. That something is the tmux `-CC` control channel itself: every byte its
+ * reader decodes calls `recordInboundActivity()`
+ * (`RealSshSession.startInteractiveShell`, `onInboundActivity = ::recordInbound-`
+ * `Activity`), and an attached `-CC` session is never fully silent (status / layout
+ * notifications). On a live attached session the keepalive can therefore NEVER be
+ * isolated as the sole inbound source, so the connected oracle CANNOT give a true
+ * red→green for "interval < NAT window" — the GREEN passes vacuously (it would stay
+ * green through the exact interval regression it claims to guard).
+ *
+ * So the load-bearing red→green pivots HERE, to the layer where the keepalive IS
+ * the deciding factor (the #1059 / [TransportKeepAliveIdleHighRttTest] model): the
+ * real [TransportKeepAlive] loop drives the inbound-refresh cadence, a faithful
+ * carrier-NAT idle-timer model reaps the mapping when an idle gap exceeds W, and
+ * the keepalive INTERVAL is the sole variable. The connected, real-wire RECOVERY
+ * proof (the carrier NAT actually reaps the mapping mid-idle and the keepalive
+ * drives recovery) stays in `app/.../proof/NatIdleMappingSurvivalE2eTest.kt` over
+ * the toxiproxy half-open harness (Arm 2). This JVM pair is Arm 1 (survival) and
+ * runs in the per-push Unit gate (`:shared:core-ssh:test`).
+ *
+ * --------------------------------------------------------------------------
+ * THE MODEL (faithful, deterministic, virtual-time)
+ *
+ * - [CarrierNatIdleMapping] is the carrier NAT's idle timer: it records every
+ *   inbound refresh (the keepalive reply) at the VIRTUAL clock time and is "reaped"
+ *   the instant the gap since the last refresh exceeds the modelled idle window W.
+ *   The session attach itself is the first refresh (t=0), as on the real wire.
+ * - [KeepAliveDrivenNatIo] is the [TransportKeepAlive.KeepAliveIo] the real loop
+ *   ticks. Its [TransportKeepAlive.KeepAliveIo.lastInboundActivityNanos] is reported
+ *   far-older-than-one-interval (the #1059 trick) so reset-on-inbound never skips the
+ *   ping on this idle link — i.e. the loop genuinely sends one ping per interval,
+ *   exactly as on a quiet cellular link. Each
+ *   [TransportKeepAlive.KeepAliveIo.sendKeepAlive] models the server answering: it
+ *   refreshes the NAT mapping at the current virtual time and returns alive=true.
+ *
+ * The mapping survives iff the keepalive refreshes it within W — i.e. iff the
+ * keepalive INTERVAL < W. That is the whole contract, and the interval is the only
+ * thing that differs between the GREEN and the RED-control arms.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class NatIdleMappingSurvivalKeepAliveTest {
+
+    private companion object {
+        /**
+         * The modelled carrier-NAT idle window W. The keepalive must refresh the
+         * mapping more often than this or the NAT reaps it.
+         */
+        const val NAT_WINDOW_MS = 3_000L
+
+        /**
+         * LIVE keepalive (Arm 1, GREEN): a reply lands every 1s, comfortably inside
+         * the 3s NAT window — the NAT idle timer is reset before it can fire.
+         */
+        const val LIVE_INTERVAL_MS = 1_000L
+
+        /**
+         * OVER-LONG keepalive (Arm 1, RED CONTROL / the regression): a reply lands
+         * only every 5s, longer than the 3s NAT window — so the idle mapping ages
+         * past W between refreshes and the carrier NAT reaps it.
+         */
+        const val OVER_LONG_INTERVAL_MS = 5_000L
+
+        const val COUNT_MAX = 3
+
+        /** Idle hold: several NAT windows so the survival/reap outcome is stable. */
+        const val IDLE_HOLD_MS = 24_000L
+
+        /** Sample the NAT idle timer this often (well below W) to catch any reap. */
+        const val SAMPLE_MS = 250L
+
+        /**
+         * The minimum realistic AGGRESSIVE carrier-NAT TCP idle window. Real CGNAT
+         * idle timeouts have been observed this low; OpenSSH ships
+         * `ServerAliveInterval 30` precisely to beat it with margin. The production
+         * keepalive interval MUST stay below this (with headroom) or long-idle
+         * cellular survival breaks.
+         */
+        const val MIN_REALISTIC_CGNAT_IDLE_WINDOW_MS = 60_000L
+    }
+
+    /** The carrier NAT's idle timer, in the test's virtual-clock domain. */
+    private class CarrierNatIdleMapping(private val windowMs: Long) {
+        // The mapping is created (and first refreshed) at attach, t=0.
+        var lastRefreshMs: Long = 0L
+            private set
+        var everReaped: Boolean = false
+            private set
+
+        fun refresh(nowMs: Long) {
+            lastRefreshMs = nowMs
+        }
+
+        /** Sample the mapping at [nowMs]; reaped if idle longer than the window. */
+        fun sample(nowMs: Long) {
+            if (nowMs - lastRefreshMs > windowMs) everReaped = true
+        }
+    }
+
+    /**
+     * The [TransportKeepAlive.KeepAliveIo] the real loop ticks. Each keepalive
+     * reply refreshes the carrier-NAT mapping at the current virtual time.
+     */
+    private class KeepAliveDrivenNatIo(
+        private val intervalMs: Long,
+        private val nat: CarrierNatIdleMapping,
+        private val virtualNowMs: () -> Long,
+    ) : TransportKeepAlive.KeepAliveIo {
+        var pingsSent: Int = 0
+        var deadDeclaredWith: Int? = null
+
+        override fun isAlive(): Boolean = true
+
+        // Far older than one interval (the #1059 trick) so reset-on-inbound never
+        // skips the ping on this idle link: the loop sends exactly one ping per
+        // interval, as on a quiet cellular link.
+        override fun lastInboundActivityNanos(): Long =
+            System.nanoTime() - 100L * intervalMs * 1_000_000L
+
+        override suspend fun sendKeepAlive(): Boolean {
+            pingsSent += 1
+            // The server answered — an inbound byte that resets the carrier-NAT
+            // idle timer at the current virtual time.
+            nat.refresh(virtualNowMs())
+            return true
+        }
+
+        override fun onKeepAliveDead(consecutiveMisses: Int) {
+            deadDeclaredWith = consecutiveMisses
+        }
+    }
+
+    private class IdleHoldResult(
+        val io: KeepAliveDrivenNatIo,
+        val nat: CarrierNatIdleMapping,
+    )
+
+    /**
+     * Drives the real [TransportKeepAlive] loop at [intervalMs] across the idle
+     * hold, sampling the modelled carrier NAT each [SAMPLE_MS] of virtual time.
+     *
+     * Virtual time is driven by a STANDALONE [TestCoroutineScheduler] +
+     * [StandardTestDispatcher], NOT `runTest`. The keepalive loop is `while (isActive)`
+     * and — by design for this model — the IO always reports alive, so it never ends on
+     * its own; it only ends when its job is cancelled. Driving it on a plain
+     * [CoroutineScope] over the test dispatcher (and cancelling that scope at the end)
+     * keeps this a pure deterministic virtual-clock pin WITHOUT entering a `runTest`
+     * body. That matters for the whole-module gate: `runTest` registers a callback with
+     * kotlinx-coroutines-test's process-wide `ExceptionCollector`, and once enabled the
+     * collector intercepts EVERY later uncaught coroutine exception in the JVM worker —
+     * including a PRE-EXISTING latent one in an unrelated sibling
+     * (`RealSshSessionTailRecoverableFailureTest`, whose #239 test intentionally lets a
+     * genuine-bug tail-launch exception reach the crash-reporter / default handler) —
+     * and reports it as `UncaughtExceptionsBeforeTest` against whichever test runs next,
+     * reddening the module suite. Using a standalone scheduler here adds NO such
+     * collector callback, so this pin no longer surfaces that sibling flake. (The
+     * sibling's latent leak is tracked separately; the durable fix is a
+     * `CoroutineExceptionHandler` on `RealSshSession`'s background scope.)
+     */
+    private fun runIdleHold(intervalMs: Long): IdleHoldResult {
+        val scheduler = TestCoroutineScheduler()
+        val scope = CoroutineScope(StandardTestDispatcher(scheduler))
+        val nat = CarrierNatIdleMapping(NAT_WINDOW_MS)
+        val io = KeepAliveDrivenNatIo(
+            intervalMs = intervalMs,
+            nat = nat,
+            virtualNowMs = { scheduler.currentTime },
+        )
+        val keepAlive = TransportKeepAlive(io = io, intervalMs = intervalMs, countMax = COUNT_MAX)
+        keepAlive.start(scope)
+
+        var elapsed = 0L
+        while (elapsed < IDLE_HOLD_MS) {
+            scheduler.advanceTimeBy(SAMPLE_MS)
+            scheduler.runCurrent()
+            elapsed += SAMPLE_MS
+            nat.sample(scheduler.currentTime)
+        }
+        keepAlive.stop()
+        // Cancel the driving scope so the (already stopped) keepalive job and the
+        // dispatcher are torn down deterministically — no coroutine outlives the test.
+        scope.cancel()
+        return IdleHoldResult(io, nat)
+    }
+
+    // ---- ARM 1: idle-mapping survival, the deterministic red→green pin ----
+
+    @Test
+    fun liveKeepAliveKeepsIdleNatMappingWarmAcrossLongIdle() {
+        // GREEN: interval (1s) < NAT window (3s) — every reply resets the idle timer
+        // before it fires, so the carrier NAT never reaps the idle mapping.
+        val result = runIdleHold(LIVE_INTERVAL_MS)
+
+        assertTrue(
+            "the keepalive must have actually pinged the idle link (one per interval)",
+            result.io.pingsSent > 0,
+        )
+        assertNull(
+            "a live link is never declared dead while its keepalive replies keep arriving",
+            result.io.deadDeclaredWith,
+        )
+        assertFalse(
+            "the carrier NAT must NEVER reap the mapping while the keepalive interval " +
+                "(${LIVE_INTERVAL_MS}ms) is shorter than the ${NAT_WINDOW_MS}ms idle " +
+                "window — every reply resets the idle timer. If this fails the keepalive " +
+                "interval was retuned past the NAT window (the regression this guards).",
+            result.nat.everReaped,
+        )
+    }
+
+    @Test
+    fun overLongKeepAliveLetsIdleNatMappingAgeOut() {
+        // RED CONTROL (G6): interval (5s) > NAT window (3s) — between keepalive
+        // refreshes the mapping sits idle longer than W, so the carrier NAT reaps it.
+        // This proves the GREEN assertion above is LOAD-BEARING: with the keepalive
+        // retuned past the NAT window the mapping is genuinely lost.
+        val result = runIdleHold(OVER_LONG_INTERVAL_MS)
+
+        assertTrue(
+            "the over-long keepalive must still have pinged the idle link",
+            result.io.pingsSent > 0,
+        )
+        assertTrue(
+            "with the keepalive interval (${OVER_LONG_INTERVAL_MS}ms) retuned PAST the " +
+                "${NAT_WINDOW_MS}ms NAT idle window, the idle mapping MUST age out between " +
+                "refreshes (the carrier NAT reaps it). If this does not happen the survival " +
+                "assertion in the sibling GREEN test would be vacuous.",
+            result.nat.everReaped,
+        )
+    }
+
+    // ---- ARM 1 (constant guard): the production interval must beat a real CGNAT window ----
+
+    @Test
+    fun productionKeepAliveIntervalStaysBelowRealisticCgnatIdleWindow() {
+        // The concrete regression catcher: a future "battery-saving" retune of the
+        // production keepalive interval past a realistic aggressive-CGNAT idle window
+        // would silently break long-idle cellular survival. Pin the interval below it
+        // WITH ride-through headroom (at least one reply still lands within the window
+        // even if a single keepalive is missed), mirroring OpenSSH's 30s default.
+        assertTrue(
+            "the production keepalive interval (${TransportKeepAlive.DEFAULT_INTERVAL_MS}ms) " +
+                "must stay below the minimum realistic aggressive-CGNAT idle window " +
+                "(${MIN_REALISTIC_CGNAT_IDLE_WINDOW_MS}ms) or idle cellular sessions are " +
+                "reaped — a retune past it is the #1063 regression.",
+            TransportKeepAlive.DEFAULT_INTERVAL_MS < MIN_REALISTIC_CGNAT_IDLE_WINDOW_MS,
+        )
+        assertTrue(
+            "the production keepalive interval must leave ride-through headroom: even if " +
+                "ONE keepalive is missed, the next reply must still land within the " +
+                "${MIN_REALISTIC_CGNAT_IDLE_WINDOW_MS}ms NAT window (2 × interval ≤ window).",
+            TransportKeepAlive.DEFAULT_INTERVAL_MS * 2 <= MIN_REALISTIC_CGNAT_IDLE_WINDOW_MS,
+        )
+    }
+}


### PR DESCRIPTION
Re-land of the previously-approved (PR #1075, 3 review rounds) R3 keepalive regression guard, which was closed on the #848 journey-harness-guard blocker; this cleanly re-applies it onto current `main` with the small already-approved baseline delta.

- **Arm 1 (per-push Unit gate):** `NatIdleMappingSurvivalKeepAliveTest` (shared/core-ssh) — asserts the configured keepalive interval stays within a safe NAT-idle bound; red→green re-driven (interval-constant mutation fails both interval methods, byte-identical restore passes).
- **Arm 2 (nightly network-fault lane):** `NatIdleMappingSurvivalE2eTest` — toxiproxy half-open blackhole → keepalive must detect + recover. Correctly self-skips per-push (needs network-fault-proxy:2228 + toxiproxy), enrolled in `nightly-extensive-suite.sh`; harness baseline updated so the guard stays green.

Test-only, no production code. The 2 test files are **byte-identical** to the approved commit `3ebc0792`. Local gates green: `check-ci-journey-harness.sh`, `check-test-validity.sh`, `test-ci-journey-budget.sh` (93 classes), `:shared:core-ssh:testDebugUnitTest` (NatIdleMappingSurvivalKeepAliveTest 3/0/0), androidTest compile.

Closes #1063