### PR TITLE
release: v0.4.20 (versionCode 67)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,8 +65,8 @@ android {
         applicationId = "com.pocketshell.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 66
-        versionName = "0.4.19"
+        versionCode = 67
+        versionName = "0.4.20"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/tools/pocketshell/pyproject.toml
+++ b/tools/pocketshell/pyproject.toml
@@ -8,7 +8,7 @@ name = "pocketshell"
 # scripts/check-pypi-version.sh enforces this; .github/workflows/build.yml
 # runs that check before publishing to PyPI. See
 # tools/pocketshell/README.md ("Release flow") for the bump procedure.
-version = "0.4.19"
+version = "0.4.20"
 description = "Unified server-side Python utility for the PocketShell Android client."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Version bump for the **v0.4.20 reliability release**.

Both core dogfood blockers fixed + **verified gone on the real device path**:
- **Black screen** on live agent alt-screen panes (#1138) — steady-state watchdog heals sparse partial-black frames (JVM red→green + wired connected journey).
- **Restart-required freeze** (#1139/#1136/#1135) — all six grace-loop close sites made non-blocking-on-caller; reviewer drove the push-resume-onto-dead-socket journey **RED 2037ms → GREEN 131ms** on emulator+Docker (D33/G10).

Supporting: journey-gate hard-kill+shard (#1056), self-skip fix (#1081), env journey wired to CI (#1094), NAT-idle/cold-dial/dead-socket-handoff regression guards (#1063/#1064/#1082).

versionName 0.4.19→0.4.20, versionCode 66→67. Release-emulator-validation runs on this bumped `main` before the tag (locally — the CI emulator lane is infra-down per #771).

Merges after the required cheap checks (Unit + Python) are green.