### PR TITLE
test: await awaitClosed() before post-close asserts in core-ssh integration (#1149)

### DIFF
--- a/shared/core-ssh/src/integrationTest/java/com/pocketshell/core/ssh/KeepAliveIntegrationTest.kt
+++ b/shared/core-ssh/src/integrationTest/java/com/pocketshell/core/ssh/KeepAliveIntegrationTest.kt
@@ -205,6 +205,19 @@ class KeepAliveIntegrationTest {
             // A genuinely dead transport: once closed, the guard reports DEAD so the
             // probe regains authority (no infinite deferral).
             session.close()
+            // Issue #1149 / #1135 / #1139: close() is NON-BLOCKING on the caller —
+            // it launches the bounded transport teardown off the calling thread and
+            // returns immediately (the #1139 freeze fix). The liveness guard first
+            // checks isConnected, which only flips false once that async teardown
+            // drains the dispatcher; a keepalive succeeded moments ago so the
+            // activity watermark is still fresh, meaning the guard reports ALIVE in
+            // the intermediate window. Join the teardown via awaitClosed() OFF the
+            // caller thread before reading the post-teardown state. No production
+            // caller reads this guard on a session it just close()'d without
+            // awaiting (redials acquire a FRESH session), so this is a
+            // test-contract migration mirroring RealSshSessionTeardownOrderingTest,
+            // not a regression.
+            session.awaitClosed()
             assertFalse(
                 "on a closed/dead transport the liveness guard must report DEAD so the " +
                     "probe is free to declare the drop (#964 — deferral is not an " +

--- a/shared/core-ssh/src/integrationTest/java/com/pocketshell/core/ssh/SshIntegrationTest.kt
+++ b/shared/core-ssh/src/integrationTest/java/com/pocketshell/core/ssh/SshIntegrationTest.kt
@@ -304,6 +304,17 @@ class SshIntegrationTest {
             knownHosts = KnownHostsPolicy.AcceptAll,
         ).getOrThrow()
         session.close()
+        // Issue #1149 / #1135 / #1139: close() is NON-BLOCKING on the caller —
+        // it launches the bounded transport teardown off the calling thread and
+        // returns immediately (the #1139 freeze fix). startShell() throws only
+        // once isConnected has flipped false, which happens when that async
+        // teardown drains the dispatcher; join it via awaitClosed() OFF the
+        // caller thread before probing the post-teardown state. No production
+        // caller starts a shell on a session it just close()'d without awaiting
+        // (redials acquire a FRESH session), so this is a test-contract
+        // migration mirroring RealSshSessionTeardownOrderingTest, not a
+        // regression.
+        session.awaitClosed()
         val ex = runCatching { session.startShell() }.exceptionOrNull()
         assertTrue(
             "expected SshException after close, got $ex",
@@ -753,6 +764,16 @@ class SshIntegrationTest {
 
         assertTrue(session.isConnected)
         session.close()
+        // Issue #1149 / #1135 / #1139: close() is NON-BLOCKING on the caller — it
+        // launches the bounded transport teardown off the calling thread and
+        // returns immediately (the #1139 freeze fix). isConnected only flips false
+        // once that teardown drains the dispatcher, so an ordering-sensitive
+        // observer joins it via awaitClosed() OFF the caller thread before reading
+        // the post-teardown state. No production caller reads synchronous
+        // post-close isConnected on the same session (redials acquire a FRESH
+        // session), so this is a test-contract migration mirroring
+        // RealSshSessionTeardownOrderingTest, not a regression.
+        session.awaitClosed()
         assertTrue("session should report disconnected after close", !session.isConnected)
     }
 


### PR DESCRIPTION
Fixes the v0.4.20 release-blocker: 3 `:shared:core-ssh:integrationTest` cases went red on the batched Docker Integration job after #1144's async-`close()` change.

**Test-contract alignment (not a regression).** #1144's `close()` returns before the async transport teardown drains (with an `awaitClosed()` seam). The 3 tests asserted *synchronous* post-close state. Caller audit re-verified (reviewer-confirmed): no production caller relies on synchronous post-close state — `SshLeaseManager`, `AutoForwarderSupervisor`, and the `TmuxSessionViewModel` redial all discard the closed session and dial fresh. Fix: `await awaitClosed()` before the post-teardown assertions.

**Reviewer APPROVED** (https://github.com/alexeygrigorev/pocketshell/issues/1149#issuecomment-4852053405): caller audit re-verified independently, real Docker/Testcontainers red→green (full 34-test suite green, `--rerun-tasks`, not cached, G3), #1139 freeze proofs (`RealSshShellCloseOffMainTest`/`RealSshSessionCloseOffCallerTest`) stay green. Test-only, 2 files.

Closes #1149