### PR TITLE
test: void @Test lifecycle methods + V1 validity guard (#1154)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/bootstrap/HostBootstrapScenarioSuiteTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/bootstrap/HostBootstrapScenarioSuiteTest.kt
@@ -64,7 +64,7 @@ class HostBootstrapScenarioSuiteTest {
     }
 
     @Test
-    fun ready() = scenario("ready") {
+    fun ready() { scenario("ready") {
         launchSeededHost()
         capture("01-host-list")
         tapSeededHost()
@@ -74,10 +74,10 @@ class HostBootstrapScenarioSuiteTest {
         assertRemote("ready profile should expose all server tools and an enabled daemon") {
             installedToolsAndEnabledDaemonCommand()
         }
-    }
+    } }
 
     @Test
-    fun uvInstall() = scenario("uv-install") {
+    fun uvInstall() { scenario("uv-install") {
         launchSeededHost()
         tapSeededHost()
 
@@ -96,10 +96,10 @@ class HostBootstrapScenarioSuiteTest {
         assertRemote("uv install should leave all server tools available") {
             installedToolsAndEnabledDaemonCommand()
         }
-    }
+    } }
 
     @Test
-    fun uvUpgrade() = scenario("uv-upgrade") {
+    fun uvUpgrade() { scenario("uv-upgrade") {
         launchSeededHost()
         tapSeededHost()
 
@@ -125,10 +125,10 @@ class HostBootstrapScenarioSuiteTest {
         assertRemote("uv upgrade should leave an app-compatible pocketshell CLI") {
             installedToolsAndEnabledDaemonCommand(targetAppVersion())
         }
-    }
+    } }
 
     @Test
-    fun uvUpgradeFailure() = scenario("uv-upgrade-failure") {
+    fun uvUpgradeFailure() { scenario("uv-upgrade-failure") {
         launchSeededHost()
         tapSeededHost()
 
@@ -156,10 +156,10 @@ class HostBootstrapScenarioSuiteTest {
         assertRemote("failed uv upgrade should leave the old pocketshell CLI in place") {
             installedToolsAndEnabledDaemonCommand("0.1.0")
         }
-    }
+    } }
 
     @Test
-    fun appUpdateRequired() = scenario("app-update-required") {
+    fun appUpdateRequired() { scenario("app-update-required") {
         // Issue #514 (DESIGN REFINEMENT 2026-06-05): remote pocketshell CLI
         // is NEWER than this app build. A minor delta rarely breaks
         // compatibility, so the host must stay fully usable — usage panel,
@@ -224,10 +224,10 @@ class HostBootstrapScenarioSuiteTest {
         assertRemote("app-update-required profile should still expose the newer host CLI") {
             installedToolsAndEnabledDaemonCommand()
         }
-    }
+    } }
 
     @Test
-    fun unsupported() = scenario("unsupported") {
+    fun unsupported() { scenario("unsupported") {
         launchSeededHost()
         tapSeededHost()
 
@@ -251,10 +251,10 @@ class HostBootstrapScenarioSuiteTest {
                 "! command -v uv >/dev/null 2>&1 && " +
                 "! command -v pipx >/dev/null 2>&1"
         }
-    }
+    } }
 
     @Test
-    fun daemonDisabled() = scenario("daemon-disabled") {
+    fun daemonDisabled() { scenario("daemon-disabled") {
         launchSeededHost()
         tapSeededHost()
 
@@ -265,10 +265,10 @@ class HostBootstrapScenarioSuiteTest {
                 "command -v pocketshell >/dev/null && " +
                 "! systemctl --user is-enabled pocketshell-jobs.service >/dev/null'"
         }
-    }
+    } }
 
     @Test
-    fun userLocalPath() = scenario("user-local-path") {
+    fun userLocalPath() { scenario("user-local-path") {
         launchSeededHost()
         tapSeededHost()
 
@@ -277,10 +277,10 @@ class HostBootstrapScenarioSuiteTest {
         assertRemote("user-local-path profile should expose all server tools through expanded PATH") {
             installedToolsAndEnabledDaemonCommand()
         }
-    }
+    } }
 
     @Test
-    fun fishUserLocalPath() = scenario("fish-user-local-path") {
+    fun fishUserLocalPath() { scenario("fish-user-local-path") {
         launchSeededHost()
         tapSeededHost()
 
@@ -289,7 +289,7 @@ class HostBootstrapScenarioSuiteTest {
         assertRemote("fish-user-local-path profile should expose all server tools through login PATH handling") {
             installedToolsAndEnabledDaemonCommand()
         }
-    }
+    } }
 
     private fun scenario(name: String, block: ScenarioContext.() -> Unit) = runBlocking {
         assumeScenariosEnabled()

--- a/app/src/androidTest/java/com/pocketshell/app/cards/SessionChecklistPushJourneyDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/cards/SessionChecklistPushJourneyDockerTest.kt
@@ -83,7 +83,7 @@ class SessionChecklistPushJourneyDockerTest {
     private val cleanupCommands = mutableListOf<String>()
 
     @After
-    fun tearDown(): Unit = runBlocking {
+    fun tearDown(): Unit { runBlocking {
         if (cleanupCommands.isNotEmpty()) {
             runCatching {
                 withTimeout(15_000) {
@@ -94,10 +94,10 @@ class SessionChecklistPushJourneyDockerTest {
             }
         }
         runCatching { keyFile.delete() }
-    }
+    } }
 
     @Test
-    fun hostPushChecklistRendersInAppFeedAndTickRoundTripsToHost(): Unit = runBlocking {
+    fun hostPushChecklistRendersInAppFeedAndTickRoundTripsToHost(): Unit { runBlocking {
         bootstrapKey()
         waitForSshFixtureReady(sshKey, port = DEFAULT_PORT)
 
@@ -282,10 +282,10 @@ class SessionChecklistPushJourneyDockerTest {
             "after the app untick the host store must clear run-the-tests-1",
             "run-the-tests-1" in afterUntick.checkedIds,
         )
-    }
+    } }
 
     @Test
-    fun noChecklistPushedYieldsEmptyFeedAndNoChip(): Unit = runBlocking {
+    fun noChecklistPushedYieldsEmptyFeedAndNoChip(): Unit { runBlocking {
         bootstrapKey()
         waitForSshFixtureReady(sshKey, port = DEFAULT_PORT)
 
@@ -317,7 +317,7 @@ class SessionChecklistPushJourneyDockerTest {
             }
         }
         composeRule.onNodeWithTag(SESSION_CHECKLIST_CHIP_TAG).assertDoesNotExist()
-    }
+    } }
 
     /**
      * RED→GREEN guard (D32 G10): the load-bearing "card reaches the feed"
@@ -330,7 +330,7 @@ class SessionChecklistPushJourneyDockerTest {
      * THIS test would fail. The two together pin the real path.
      */
     @Test
-    fun readPathBroken_wrongSessionName_yieldsEmptyFeed_redGuard(): Unit = runBlocking {
+    fun readPathBroken_wrongSessionName_yieldsEmptyFeed_redGuard(): Unit { runBlocking {
         bootstrapKey()
         waitForSshFixtureReady(sshKey, port = DEFAULT_PORT)
 
@@ -374,7 +374,7 @@ class SessionChecklistPushJourneyDockerTest {
                 wrong.cards.filterIsInstance<SessionCardsRemoteSource.ChecklistCard>(),
             ),
         )
-    }
+    } }
 
     // ----------------------------------------------------------- Helpers
 

--- a/app/src/androidTest/java/com/pocketshell/app/composer/AttachmentStagerRealUploadDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/composer/AttachmentStagerRealUploadDockerTest.kt
@@ -95,7 +95,7 @@ class AttachmentStagerRealUploadDockerTest {
     }
 
     @Test
-    fun stagesAttachmentThroughRealUploadFileAndBytesLandOnHost() = runBlocking {
+    fun stagesAttachmentThroughRealUploadFileAndBytesLandOnHost() { runBlocking {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         // The size-less test provider is registered in the androidTest
         // manifest, so it lives in the TEST APK process and is only
@@ -248,7 +248,7 @@ class AttachmentStagerRealUploadDockerTest {
         )
 
         Unit
-    }
+    } }
 
     private fun md5Hex(bytes: ByteArray): String =
         MessageDigest.getInstance("MD5").digest(bytes)

--- a/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerImeDeadSpaceScreenshotHarness.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerImeDeadSpaceScreenshotHarness.kt
@@ -90,23 +90,23 @@ class PromptComposerImeDeadSpaceScreenshotHarness {
     )
 
     @Test
-    fun emptyDraftKeyboardUpHold() = stageAndHold(draft = null)
+    fun emptyDraftKeyboardUpHold() { stageAndHold(draft = null) }
 
     // Issue #873: the maintainer's EXACT reported state — a SHORT one-word draft
     // ("gghh") with the keyboard up. Stages it for the keyboard-up screenshot that
     // must show the compact field with NO ~1cm dead band below the text.
     @Test
-    fun shortDraftKeyboardUpHold() = stageAndHold(draft = "gghh")
+    fun shortDraftKeyboardUpHold() { stageAndHold(draft = "gghh") }
 
     @Test
-    fun longDraftKeyboardUpHold() = stageAndHold(
+    fun longDraftKeyboardUpHold() { stageAndHold(
         draft = "Reduce the connector/indent cell width so the tree lines stop " +
             "overlapping the file name.\n" +
             "Then wrap the long folder paths instead of clipping them.\n" +
             "Wrote 23 lines to issue.md describing the repro.\n" +
             "Make the attachment tiles compact and re-check the keyboard-up layout.\n" +
             "Finally, confirm Send and the paperclip stay reachable above the IME.",
-    )
+    ) }
 
     private fun stageAndHold(draft: String?) {
         val holdMs = InstrumentationRegistry.getArguments()

--- a/app/src/androidTest/java/com/pocketshell/app/crash/ShareAllReportsDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/crash/ShareAllReportsDockerTest.kt
@@ -34,7 +34,7 @@ class ShareAllReportsDockerTest {
     }
 
     @Test
-    fun shareAllPreparesZipForShareSheetThenDeleteAllClearsReports() = runBlocking {
+    fun shareAllPreparesZipForShareSheetThenDeleteAllClearsReports() { runBlocking {
         val context = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
         clearReportsDir()
         clearArchivesDir()
@@ -111,7 +111,7 @@ class ShareAllReportsDockerTest {
         assertEquals(0, store.list().size)
 
         writeEvidence(evidence.toString())
-    }
+    } }
 
     private fun clearReportsDir() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext

--- a/app/src/androidTest/java/com/pocketshell/app/diagnostics/ConnectionLogHostMirrorReconnectDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/diagnostics/ConnectionLogHostMirrorReconnectDockerTest.kt
@@ -132,7 +132,7 @@ class ConnectionLogHostMirrorReconnectDockerTest {
     }
 
     @Test
-    fun mirrorWritesConnectionLogOverTheWarmLeaseOnReconnect() = runBlocking {
+    fun mirrorWritesConnectionLogOverTheWarmLeaseOnReconnect() { runBlocking {
         waitForSshFixtureReady(sshKey, port = DEFAULT_PORT)
 
         val marker = "k${System.currentTimeMillis().toString(36).takeLast(6)}"
@@ -215,10 +215,10 @@ class ConnectionLogHostMirrorReconnectDockerTest {
             warmLease.release()
         }
         Unit
-    }
+    } }
 
     @Test
-    fun wrongLeaseKeyMappingDoesNotLandOverTheWarmLease() = runBlocking {
+    fun wrongLeaseKeyMappingDoesNotLandOverTheWarmLease() { runBlocking {
         // G6/G10 RED guard: this pins the byte-identical-key property as the
         // LOAD-BEARING assertion of the GREEN test. It drives the SAME warm-lease
         // write helper the mirror uses ([com.pocketshell.app.sessions.LeaseSessionExec]
@@ -278,7 +278,7 @@ class ConnectionLogHostMirrorReconnectDockerTest {
             warmLease.release()
         }
         Unit
-    }
+    } }
 
     // ---- helpers ----
 

--- a/app/src/androidTest/java/com/pocketshell/app/env/EnvScreenE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/env/EnvScreenE2eTest.kt
@@ -69,7 +69,7 @@ class EnvScreenE2eTest {
     private val secret = "sk-ENVSCREEN-SECRET-264"
 
     @Before
-    fun openDatabase(): Unit = runBlocking {
+    fun openDatabase(): Unit { runBlocking {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
             .allowMainThreadQueries()
@@ -87,7 +87,7 @@ class EnvScreenE2eTest {
                 keyId = keyId,
             ),
         )
-    }
+    } }
 
     @After
     fun closeDatabase() {

--- a/app/src/androidTest/java/com/pocketshell/app/fileexplorer/FileExplorerDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/fileexplorer/FileExplorerDockerTest.kt
@@ -71,7 +71,7 @@ class FileExplorerDockerTest {
         FileExplorerViewModel(leaseManager)
 
     @Before
-    fun setUp(): Unit = runBlocking {
+    fun setUp(): Unit { runBlocking {
         val keyText = InstrumentationRegistry.getInstrumentation()
             .context.assets.open("test_key").bufferedReader().use { it.readText() }
         sshKey = SshKey.Pem(keyText)
@@ -84,10 +84,10 @@ class FileExplorerDockerTest {
             setReadable(true, true)
         }
         waitForSshFixtureReady(sshKey)
-    }
+    } }
 
     @After
-    fun tearDown(): Unit = runBlocking {
+    fun tearDown(): Unit { runBlocking {
         seededRoot?.let { root ->
             withTimeout(15_000) {
                 connect()?.use { session -> runCatching { session.exec("rm -rf '$root'") } }
@@ -95,10 +95,10 @@ class FileExplorerDockerTest {
         }
         runCatching { keyFile.delete() }
         runCatching { leaseManager.close() }
-    }
+    } }
 
     @Test
-    fun browsesDirectoriesAndOpensAFile(): Unit = runBlocking {
+    fun browsesDirectoriesAndOpensAFile(): Unit { runBlocking {
         val suffix = System.currentTimeMillis().toString().takeLast(6)
         val root = "/tmp/issue528-$suffix"
         seededRoot = root
@@ -163,10 +163,10 @@ class FileExplorerDockerTest {
             "resolved path should end with /readme.txt, was $openedFilePath",
             openedFilePath!!.endsWith("/readme.txt"),
         )
-    }
+    } }
 
     @Test
-    fun uploadsADeviceFileThenDownloadsItBack(): Unit = runBlocking {
+    fun uploadsADeviceFileThenDownloadsItBack(): Unit { runBlocking {
         val suffix = System.currentTimeMillis().toString().takeLast(6)
         val root = "/tmp/issue643-$suffix"
         seededRoot = root
@@ -248,10 +248,10 @@ class FileExplorerDockerTest {
             "issue643 round-trip payload",
             String(downloaded!!),
         )
-    }
+    } }
 
     @Test
-    fun showsPermissionDeniedForUnreadableDirectory(): Unit = runBlocking {
+    fun showsPermissionDeniedForUnreadableDirectory(): Unit { runBlocking {
         val suffix = System.currentTimeMillis().toString().takeLast(6)
         val root = "/tmp/issue528-perm-$suffix"
         seededRoot = root
@@ -286,10 +286,10 @@ class FileExplorerDockerTest {
         }
         composeRule.onNodeWithTag(FILE_EXPLORER_ERROR_TAG).assertExists()
         WalkthroughScreenshotArtifacts.capture("issue528-explorer-permission-denied")
-    }
+    } }
 
     @Test
-    fun browseReusesTheWarmLeaseInsteadOfHandshakingAgain(): Unit = runBlocking {
+    fun browseReusesTheWarmLeaseInsteadOfHandshakingAgain(): Unit { runBlocking {
         val suffix = System.currentTimeMillis().toString().takeLast(6)
         val root = "/tmp/issue697-$suffix"
         seededRoot = root
@@ -365,7 +365,7 @@ class FileExplorerDockerTest {
             handshakeCount.get(),
         )
         warmLease.release()
-    }
+    } }
 
     private suspend fun connect() = SshConnection.connect(
         host = DEFAULT_HOST,

--- a/app/src/androidTest/java/com/pocketshell/app/fileviewer/FileViewerDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/fileviewer/FileViewerDockerTest.kt
@@ -67,7 +67,7 @@ class FileViewerDockerTest {
     private lateinit var leasing: CountingLeaseManager
 
     @Before
-    fun setUp(): Unit = runBlocking {
+    fun setUp(): Unit { runBlocking {
         val keyText = InstrumentationRegistry.getInstrumentation()
             .context.assets.open("test_key").bufferedReader().use { it.readText() }
         sshKey = SshKey.Pem(keyText)
@@ -80,10 +80,10 @@ class FileViewerDockerTest {
             setReadable(true, true)
         }
         waitForSshFixtureReady(sshKey)
-    }
+    } }
 
     @After
-    fun tearDown(): Unit = runBlocking {
+    fun tearDown(): Unit { runBlocking {
         if (seededPaths.isNotEmpty()) {
             withTimeout(15_000) {
                 connect()?.use { session ->
@@ -97,10 +97,10 @@ class FileViewerDockerTest {
         }
         runCatching { keyFile.delete() }
         runCatching { leasing.manager.close() }
-    }
+    } }
 
     @Test
-    fun viewsRemotePngAndTextFromFixture(): Unit = runBlocking {
+    fun viewsRemotePngAndTextFromFixture(): Unit { runBlocking {
         val suffix = System.currentTimeMillis().toString().takeLast(6)
         val pngPath = "/tmp/issue497-image-$suffix.png"
         val textPath = "/tmp/issue497-notes-$suffix.txt"
@@ -145,10 +145,10 @@ class FileViewerDockerTest {
         }
         composeRule.onNodeWithTag(FILE_VIEWER_IMAGE_TAG).assertExists()
         WalkthroughScreenshotArtifacts.capture("issue497-file-viewer-image")
-    }
+    } }
 
     @Test
-    fun viewsRemoteTextFromFixture(): Unit = runBlocking {
+    fun viewsRemoteTextFromFixture(): Unit { runBlocking {
         val suffix = System.currentTimeMillis().toString().takeLast(6)
         val textPath = "/tmp/issue497-text-$suffix.txt"
         val textBody = "PocketShell file viewer issue #497\nrelative-path + size-cap covered by unit tests\n"
@@ -183,10 +183,10 @@ class FileViewerDockerTest {
         }
         composeRule.onNodeWithTag(FILE_VIEWER_TEXT_TAG).assertExists()
         WalkthroughScreenshotArtifacts.capture("issue497-file-viewer-text")
-    }
+    } }
 
     @Test
-    fun viewsRemotePdfPagesFromFixture(): Unit = runBlocking {
+    fun viewsRemotePdfPagesFromFixture(): Unit { runBlocking {
         val suffix = System.currentTimeMillis().toString().takeLast(6)
         val pdfPath = "/tmp/issue498-doc-$suffix.pdf"
 
@@ -248,10 +248,10 @@ class FileViewerDockerTest {
         composeRule.waitUntil(timeoutMillis = 15_000) {
             composeRule.onAllNodesWithText("Page 2 / 3").fetchSemanticsNodes().isNotEmpty()
         }
-    }
+    } }
 
     @Test
-    fun playsRemoteAudioFromFixture(): Unit = runBlocking {
+    fun playsRemoteAudioFromFixture(): Unit { runBlocking {
         val suffix = System.currentTimeMillis().toString().takeLast(6)
         val wavPath = "/tmp/issue499-clip-$suffix.wav"
 
@@ -313,10 +313,10 @@ class FileViewerDockerTest {
         composeRule.waitForIdle()
         composeRule.onNodeWithTag(FILE_VIEWER_AUDIO_TAG).assertExists()
         WalkthroughScreenshotArtifacts.capture("issue499-audio-after-seek")
-    }
+    } }
 
     @Test
-    fun opensAFileReusingTheWarmLeaseInsteadOfHandshakingAgain(): Unit = runBlocking {
+    fun opensAFileReusingTheWarmLeaseInsteadOfHandshakingAgain(): Unit { runBlocking {
         val suffix = System.currentTimeMillis().toString().takeLast(6)
         val textPath = "/tmp/issue697-viewer-$suffix.txt"
         val textBody = "issue #697 — file open reuses the warm transport\nno per-open handshake\n"
@@ -378,10 +378,10 @@ class FileViewerDockerTest {
             leasing.handshakeCount.get(),
         )
         warmLease.release()
-    }
+    } }
 
     @Test
-    fun submitsAReviewYamlToTheReviewsInboxOverTheReusedLease(): Unit = runBlocking {
+    fun submitsAReviewYamlToTheReviewsInboxOverTheReusedLease(): Unit { runBlocking {
         val suffix = System.currentTimeMillis().toString().takeLast(6)
         val srcPath = "/tmp/issue714-review-$suffix.kt"
         val srcBody = "val x = doThing(y)\nreturn null\n"
@@ -495,7 +495,7 @@ class FileViewerDockerTest {
         composeRule.onNodeWithTag(FILE_VIEWER_REVIEW_ATTACH_TAG).performClick()
         composeRule.waitUntil(timeoutMillis = 5_000) { attachedPrompts.isNotEmpty() }
         assertEquals(reviewAttachPrompt(surfacedPath), attachedPrompts.single())
-    }
+    } }
 
     private suspend fun connect() = SshConnection.connect(
         host = DEFAULT_HOST,

--- a/app/src/androidTest/java/com/pocketshell/app/fileviewer/LinkTapParsingDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/fileviewer/LinkTapParsingDockerTest.kt
@@ -60,7 +60,7 @@ class LinkTapParsingDockerTest {
     private val seededDirs = mutableListOf<String>()
 
     @Before
-    fun setUp(): Unit = runBlocking {
+    fun setUp(): Unit { runBlocking {
         val keyText = InstrumentationRegistry.getInstrumentation()
             .context.assets.open("test_key").bufferedReader().use { it.readText() }
         sshKey = SshKey.Pem(keyText)
@@ -72,10 +72,10 @@ class LinkTapParsingDockerTest {
             setReadable(true, true)
         }
         waitForSshFixtureReady(sshKey)
-    }
+    } }
 
     @After
-    fun tearDown(): Unit = runBlocking {
+    fun tearDown(): Unit { runBlocking {
         if (seededDirs.isNotEmpty()) {
             withTimeout(15_000) {
                 connect()?.use { session ->
@@ -84,12 +84,12 @@ class LinkTapParsingDockerTest {
             }
         }
         runCatching { keyFile.delete() }
-    }
+    } }
 
     // --- #558 bug 3: `~` expands to $HOME --------------------------------------
 
     @Test
-    fun tildePathExpandsToHomeAndOpensTheImageViewer(): Unit = runBlocking {
+    fun tildePathExpandsToHomeAndOpensTheImageViewer(): Unit { runBlocking {
         val suffix = System.currentTimeMillis().toString().takeLast(6)
         // Seed a real PNG under $HOME so a `~/...` path must expand to open it.
         val relUnderHome = "issue558-tilde-$suffix/shot.png"
@@ -128,12 +128,12 @@ class LinkTapParsingDockerTest {
         }
         composeRule.onNodeWithTag(FILE_VIEWER_IMAGE_TAG).assertExists()
         WalkthroughScreenshotArtifacts.capture("issue558-tilde-path-opens")
-    }
+    } }
 
     // --- #558 bug 1: relative `../` normalizes for resolution + breadcrumb -----
 
     @Test
-    fun relativeDotDotPathResolvesAndShowsNormalizedBreadcrumb(): Unit = runBlocking {
+    fun relativeDotDotPathResolvesAndShowsNormalizedBreadcrumb(): Unit { runBlocking {
         val suffix = System.currentTimeMillis().toString().takeLast(6)
         // Seed the file at a known absolute path.
         val baseDir = "/tmp/issue558-rel-$suffix"
@@ -181,7 +181,7 @@ class LinkTapParsingDockerTest {
         val resolved = RemotePathResolver.resolve(relInput, cwd)
         assertEquals("$baseDir/target/shot.png", resolved)
         assertTrue("breadcrumb path must not contain literal ..", !resolved.contains(".."))
-    }
+    } }
 
     // (The #558 bug-2 wrapped-URL reassembly is covered on the live grid by
     // core-terminal's WrappedUrlReassemblyInstrumentedTest, which can reach the
@@ -190,7 +190,7 @@ class LinkTapParsingDockerTest {
     // --- #557: conversation-view path opens the viewer, not the keyboard ------
 
     @Test
-    fun conversationPathTapOpensFileViewer(): Unit = runBlocking {
+    fun conversationPathTapOpensFileViewer(): Unit { runBlocking {
         val suffix = System.currentTimeMillis().toString().takeLast(6)
         val cwd = "/tmp/issue557-convo-$suffix"
         val relPath = "out/shot.png"
@@ -269,7 +269,7 @@ class LinkTapParsingDockerTest {
         }
         composeRule.onNodeWithTag(FILE_VIEWER_IMAGE_TAG).assertExists()
         WalkthroughScreenshotArtifacts.capture("issue557-conversation-path-opens-viewer")
-    }
+    } }
 
     private fun instrumentationRunOnMain(block: () -> Unit) {
         InstrumentationRegistry.getInstrumentation().runOnMainSync(block)

--- a/app/src/androidTest/java/com/pocketshell/app/fileviewer/TerminalFilePathTapToViewerDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/fileviewer/TerminalFilePathTapToViewerDockerTest.kt
@@ -62,7 +62,7 @@ class TerminalFilePathTapToViewerDockerTest {
     private var seededDir: String? = null
 
     @Before
-    fun setUp(): Unit = runBlocking {
+    fun setUp(): Unit { runBlocking {
         val keyText = InstrumentationRegistry.getInstrumentation()
             .context.assets.open("test_key").bufferedReader().use { it.readText() }
         sshKey = SshKey.Pem(keyText)
@@ -74,10 +74,10 @@ class TerminalFilePathTapToViewerDockerTest {
             setReadable(true, true)
         }
         waitForSshFixtureReady(sshKey)
-    }
+    } }
 
     @After
-    fun tearDown(): Unit = runBlocking {
+    fun tearDown(): Unit { runBlocking {
         if (seededPaths.isNotEmpty() || seededDir != null) {
             withTimeout(15_000) {
                 connect()?.use { session ->
@@ -89,10 +89,10 @@ class TerminalFilePathTapToViewerDockerTest {
             }
         }
         runCatching { keyFile.delete() }
-    }
+    } }
 
     @Test
-    fun detectedRelativePngPathOpensImageViewerResolvedAgainstCwd(): Unit = runBlocking {
+    fun detectedRelativePngPathOpensImageViewerResolvedAgainstCwd(): Unit { runBlocking {
         val suffix = System.currentTimeMillis().toString().takeLast(6)
         // Seed under a unique cwd so a project-relative `out/<png>` resolves to
         // the seeded file the same way the live pane's cwd would resolve it.
@@ -147,7 +147,7 @@ class TerminalFilePathTapToViewerDockerTest {
         }
         composeRule.onNodeWithTag(FILE_VIEWER_IMAGE_TAG).assertExists()
         WalkthroughScreenshotArtifacts.capture("issue500-tap-opens-image-viewer")
-    }
+    } }
 
     private suspend fun connect() = SshConnection.connect(
         host = DEFAULT_HOST,

--- a/app/src/androidTest/java/com/pocketshell/app/git/GitHistoryDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/git/GitHistoryDockerTest.kt
@@ -54,7 +54,7 @@ class GitHistoryDockerTest {
     private var seededRoot: String? = null
 
     @Before
-    fun setUp(): Unit = runBlocking {
+    fun setUp(): Unit { runBlocking {
         val keyText = InstrumentationRegistry.getInstrumentation()
             .context.assets.open("test_key").bufferedReader().use { it.readText() }
         sshKey = SshKey.Pem(keyText)
@@ -66,20 +66,20 @@ class GitHistoryDockerTest {
             setReadable(true, true)
         }
         waitForSshFixtureReady(sshKey)
-    }
+    } }
 
     @After
-    fun tearDown(): Unit = runBlocking {
+    fun tearDown(): Unit { runBlocking {
         seededRoot?.let { root ->
             withTimeout(15_000) {
                 connect()?.use { session -> runCatching { session.exec("rm -rf '$root'") } }
             }
         }
         runCatching { keyFile.delete() }
-    }
+    } }
 
     @Test
-    fun rendersSeededCommitHistory(): Unit = runBlocking {
+    fun rendersSeededCommitHistory(): Unit { runBlocking {
         val suffix = System.currentTimeMillis().toString().takeLast(6)
         val root = "/tmp/issue646-$suffix"
         val repo = "$root/proj"
@@ -148,10 +148,10 @@ class GitHistoryDockerTest {
             dialCount.get(),
         )
         WalkthroughScreenshotArtifacts.capture("issue646-git-history")
-    }
+    } }
 
     @Test
-    fun rendersBranchesWorktreesAndStatusOverview(): Unit = runBlocking {
+    fun rendersBranchesWorktreesAndStatusOverview(): Unit { runBlocking {
         val suffix = System.currentTimeMillis().toString().takeLast(6)
         val root = "/tmp/issue647-$suffix"
         val repo = "$root/proj"
@@ -206,10 +206,10 @@ class GitHistoryDockerTest {
         composeRule.onNodeWithTag(GIT_WORKTREE_ROW_TAG_PREFIX + repo).assertExists()
         composeRule.onNodeWithTag(GIT_WORKTREE_ROW_TAG_PREFIX + "$root/proj-feature").assertExists()
         WalkthroughScreenshotArtifacts.capture("issue647-git-overview")
-    }
+    } }
 
     @Test
-    fun gitHubOriginShowsOpenOnGitHubAction(): Unit = runBlocking {
+    fun gitHubOriginShowsOpenOnGitHubAction(): Unit { runBlocking {
         val suffix = System.currentTimeMillis().toString().takeLast(6)
         val root = "/tmp/issue648-$suffix"
         val repo = "$root/proj"
@@ -261,10 +261,10 @@ class GitHistoryDockerTest {
         composeRule.onNodeWithTag(GIT_OPEN_ON_GITHUB_TAG).assertExists()
         composeRule.onNodeWithText("github.com/pocketshell/demo").assertExists()
         WalkthroughScreenshotArtifacts.capture("issue648-open-on-github")
-    }
+    } }
 
     @Test
-    fun issuesTabShowsConfigureGhHintWhenGhNotConfigured(): Unit = runBlocking {
+    fun issuesTabShowsConfigureGhHintWhenGhNotConfigured(): Unit { runBlocking {
         // The deterministic `agents` fixture has no authenticated `gh` (and most
         // likely no `pocketshell` either), so the Issues tab must degrade to the
         // "configure gh" hint rather than show a list — issue #649's gated path.
@@ -318,10 +318,10 @@ class GitHistoryDockerTest {
         }
         composeRule.onNodeWithTag(GIT_ISSUES_HINT_TAG).assertExists()
         WalkthroughScreenshotArtifacts.capture("issue649-configure-gh-hint")
-    }
+    } }
 
     @Test
-    fun nonGitDirectoryShowsNotARepoState(): Unit = runBlocking {
+    fun nonGitDirectoryShowsNotARepoState(): Unit { runBlocking {
         val suffix = System.currentTimeMillis().toString().takeLast(6)
         val root = "/tmp/issue646-plain-$suffix"
         seededRoot = root
@@ -353,7 +353,7 @@ class GitHistoryDockerTest {
         }
         composeRule.onNodeWithTag(GIT_HISTORY_NOT_A_REPO_TAG).assertExists()
         WalkthroughScreenshotArtifacts.capture("issue646-git-not-a-repo")
-    }
+    } }
 
     private suspend fun connect() = SshConnection.connect(
         host = DEFAULT_HOST,

--- a/app/src/androidTest/java/com/pocketshell/app/hosts/HostAndFolderListScrollE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/hosts/HostAndFolderListScrollE2eTest.kt
@@ -94,7 +94,7 @@ class HostAndFolderListScrollE2eTest {
     }
 
     @Test
-    fun hostListScrollsToLastHostWithoutVersionFooterAboveFab(): Unit = runBlocking {
+    fun hostListScrollsToLastHostWithoutVersionFooterAboveFab(): Unit { runBlocking {
         val lastHostId = seedOverflowHosts(count = 24)
         val lastHostTag = HOST_ROW_TAG_PREFIX + lastHostId
 
@@ -115,7 +115,7 @@ class HostAndFolderListScrollE2eTest {
                 .fetchSemanticsNodes().isEmpty(),
         )
         captureFullDevice("02-host-list-bottom-viewport.png")
-    }
+    } }
 
     private suspend fun seedOverflowHosts(count: Int): Long {
         val appContext = InstrumentationRegistry.getInstrumentation().targetContext
@@ -187,7 +187,7 @@ class FolderListScrollE2eTest {
     }
 
     @Test
-    fun folderSessionListScrollsToLastSessionInTreeAndFlatModes(): Unit = runBlocking {
+    fun folderSessionListScrollsToLastSessionInTreeAndFlatModes(): Unit { runBlocking {
         val database = Room.inMemoryDatabaseBuilder(
             InstrumentationRegistry.getInstrumentation().targetContext,
             AppDatabase::class.java,
@@ -275,7 +275,7 @@ class FolderListScrollE2eTest {
         compose.waitForIdle()
         compose.onNodeWithTag(lastFlatRowTag, useUnmergedTree = true).assertIsDisplayed()
         captureFullDevice("05-folder-flat-bottom-viewport.png")
-    }
+    } }
 
     private suspend fun seedFolderHost(db: AppDatabase): Long {
         db.clearAllTables()

--- a/app/src/androidTest/java/com/pocketshell/app/portfwd/AutoForwardControlScreenshotTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/portfwd/AutoForwardControlScreenshotTest.kt
@@ -58,7 +58,7 @@ class AutoForwardControlScreenshotTest {
     }
 
     @Test
-    fun capturesAutoForwardOffAndOn() = runBlocking {
+    fun capturesAutoForwardOffAndOn() { runBlocking {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val targetContext = instrumentation.targetContext
 
@@ -139,7 +139,7 @@ class AutoForwardControlScreenshotTest {
         }
 
         withContext(Dispatchers.Main) { viewModel.leavePanel() }
-    }
+    } }
 
     private fun ensureArtifactDir(): File {
         val instrumentation = InstrumentationRegistry.getInstrumentation()

--- a/app/src/androidTest/java/com/pocketshell/app/portfwd/PortForwardPanelLifecycleE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/portfwd/PortForwardPanelLifecycleE2eTest.kt
@@ -83,7 +83,7 @@ class PortForwardPanelLifecycleE2eTest {
     }
 
     @Test
-    fun lifecycleStopKeepsTunnels_lifecycleStartDoesNotReconnectThem() = runBlocking {
+    fun lifecycleStopKeepsTunnels_lifecycleStartDoesNotReconnectThem() { runBlocking {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val targetContext = instrumentation.targetContext
 
@@ -190,7 +190,7 @@ class PortForwardPanelLifecycleE2eTest {
         withContext(Dispatchers.Main) {
             viewModel.leavePanel()
         }
-    }
+    } }
 
     private suspend fun waitFor(label: String, predicate: () -> Boolean) {
         while (!predicate()) {

--- a/app/src/androidTest/java/com/pocketshell/app/portfwd/PortForwardScanningStateScreenshotTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/portfwd/PortForwardScanningStateScreenshotTest.kt
@@ -54,7 +54,7 @@ class PortForwardScanningStateScreenshotTest {
     }
 
     @Test
-    fun capturesScanningEmptyState() = runBlocking {
+    fun capturesScanningEmptyState() { runBlocking {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val targetContext = instrumentation.targetContext
 
@@ -122,7 +122,7 @@ class PortForwardScanningStateScreenshotTest {
         captureFullDevice(File(ensureArtifactDir(), "portfwd-scanning-empty.png"))
 
         withContext(Dispatchers.Main) { viewModel.leavePanel() }
-    }
+    } }
 
     private fun ensureArtifactDir(): File {
         val instrumentation = InstrumentationRegistry.getInstrumentation()

--- a/app/src/androidTest/java/com/pocketshell/app/portfwd/ShowAllPortsScreenshotTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/portfwd/ShowAllPortsScreenshotTest.kt
@@ -60,7 +60,7 @@ class ShowAllPortsScreenshotTest {
     }
 
     @Test
-    fun capturesDefaultFilteredAndShowAllTables() = runBlocking {
+    fun capturesDefaultFilteredAndShowAllTables() { runBlocking {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val targetContext = instrumentation.targetContext
 
@@ -135,7 +135,7 @@ class ShowAllPortsScreenshotTest {
         captureFullDevice(File(ensureArtifactDir(), "show-all-ports-checked.png"))
 
         withContext(Dispatchers.Main) { viewModel.leavePanel() }
-    }
+    } }
 
     private fun ensureArtifactDir(): File {
         val instrumentation = InstrumentationRegistry.getInstrumentation()

--- a/app/src/androidTest/java/com/pocketshell/app/projects/AgentLaunchCommandDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/AgentLaunchCommandDockerTest.kt
@@ -58,7 +58,7 @@ class AgentLaunchCommandDockerTest {
     private lateinit var artifactDir: File
 
     @Before
-    fun setUp(): Unit = runBlocking {
+    fun setUp(): Unit { runBlocking {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val keyText = instrumentation.context.assets.open("test_key")
             .bufferedReader().use { it.readText() }
@@ -75,10 +75,10 @@ class AgentLaunchCommandDockerTest {
             "agent-launch-command",
         ).apply { mkdirs() }
         waitForSshFixtureReady(sshKey)
-    }
+    } }
 
     @After
-    fun tearDown(): Unit = runBlocking {
+    fun tearDown(): Unit { runBlocking {
         if (createdSessions.isNotEmpty()) {
             withTimeout(15_000) {
                 SshConnection.connect(
@@ -96,10 +96,10 @@ class AgentLaunchCommandDockerTest {
             }
         }
         runCatching { keyFile.delete() }
-    }
+    } }
 
     @Test
-    fun shortWrapperCommandLaunchesAgentToReadyState(): Unit = runBlocking {
+    fun shortWrapperCommandLaunchesAgentToReadyState(): Unit { runBlocking {
         val gateway = SshFolderListGateway()
         val host = dockerHost()
         val suffix = System.currentTimeMillis().toString().takeLast(6)
@@ -196,7 +196,7 @@ class AgentLaunchCommandDockerTest {
         }
 
         File(artifactDir, "agent-launch-command-summary.txt").writeText(summary.toString())
-    }
+    } }
 
     private fun agentChoice(agent: AgentCli, skip: Boolean, cwd: String) =
         SessionTypeChoice(

--- a/app/src/androidTest/java/com/pocketshell/app/projects/AgentLaunchVersionMismatchHintE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/AgentLaunchVersionMismatchHintE2eTest.kt
@@ -38,7 +38,7 @@ import java.io.File
 class AgentLaunchVersionMismatchHintE2eTest {
 
     @Test
-    fun outdatedHostAgentLaunchSurfacesFriendlyHintOnDevice(): Unit = runBlocking {
+    fun outdatedHostAgentLaunchSurfacesFriendlyHintOnDevice(): Unit { runBlocking {
         val gateway = SshFolderListGateway()
         // Reusable extracted seam (issue #853): an old host that rejects the
         // new-in-this-release subcommands (here: `agent`, surfaced by the
@@ -88,7 +88,7 @@ class AgentLaunchVersionMismatchHintE2eTest {
         )
 
         writeArtifact(hint, session.execCommands)
-    }
+    } }
 
     private fun writeArtifact(hint: String, commands: List<String>) {
         val dir = File(

--- a/app/src/androidTest/java/com/pocketshell/app/projects/AgentRecordedKindReadBackDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/AgentRecordedKindReadBackDockerTest.kt
@@ -47,7 +47,7 @@ class AgentRecordedKindReadBackDockerTest {
     private val cleanupCommands = mutableListOf<String>()
 
     @Before
-    fun setUp(): Unit = runBlocking {
+    fun setUp(): Unit { runBlocking {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val keyText = instrumentation.context.assets.open("test_key")
             .bufferedReader().use { it.readText() }
@@ -60,10 +60,10 @@ class AgentRecordedKindReadBackDockerTest {
             setReadable(true, true)
         }
         waitForSshFixtureReady(sshKey)
-    }
+    } }
 
     @After
-    fun tearDown(): Unit = runBlocking {
+    fun tearDown(): Unit { runBlocking {
         if (cleanupCommands.isNotEmpty()) {
             runCatching {
                 withTimeout(15_000) {
@@ -74,10 +74,10 @@ class AgentRecordedKindReadBackDockerTest {
             }
         }
         runCatching { keyFile.delete() }
-    }
+    } }
 
     @Test
-    fun launchedAgentsRecordKindAndGatewayReadsBackTheSameKind(): Unit = runBlocking {
+    fun launchedAgentsRecordKindAndGatewayReadsBackTheSameKind(): Unit { runBlocking {
         val gateway = SshFolderListGateway()
         val host = dockerHost()
         val suffix = System.currentTimeMillis().toString().takeLast(8)
@@ -136,7 +136,7 @@ class AgentRecordedKindReadBackDockerTest {
                 row.agentKind,
             )
         }
-    }
+    } }
 
     private suspend fun ensureRemoteDir(path: String) {
         withTimeout(15_000) {

--- a/app/src/androidTest/java/com/pocketshell/app/projects/FolderListClientCacheInstantRenderDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/FolderListClientCacheInstantRenderDockerTest.kt
@@ -64,7 +64,7 @@ class FolderListClientCacheInstantRenderDockerTest {
     private val fixturePort: Int get() = DEFAULT_PORT
 
     @Before
-    fun setUp(): Unit = runBlocking {
+    fun setUp(): Unit { runBlocking {
         val keyText = InstrumentationRegistry.getInstrumentation()
             .context
             .assets
@@ -84,10 +84,10 @@ class FolderListClientCacheInstantRenderDockerTest {
             .build()
         cache = TreeClientCache(context)
         waitForSshFixtureReady(sshKey, port = fixturePort)
-    }
+    } }
 
     @After
-    fun tearDown(): Unit = runBlocking {
+    fun tearDown(): Unit { runBlocking {
         viewModelStore.clear()
         if (createdSessions.isNotEmpty()) {
             runCatching {
@@ -112,10 +112,10 @@ class FolderListClientCacheInstantRenderDockerTest {
         runCatching { db.close() }
         runCatching { keyFile.delete() }
         runCatching { cache.write(HOST_NAME, TreeClientCache.CachedTree(nodes = emptyList())) }
-    }
+    } }
 
     @Test
-    fun coldConnectRendersCachedTreeInstantly_thenReconcilesAgainstLiveHost(): Unit = runBlocking {
+    fun coldConnectRendersCachedTreeInstantly_thenReconcilesAgainstLiveHost(): Unit { runBlocking {
         val suffix = System.currentTimeMillis().toString().takeLast(6)
         val folder = "/tmp/issue867-$suffix"
         val sessionName = "issue867-$suffix"
@@ -256,7 +256,7 @@ class FolderListClientCacheInstantRenderDockerTest {
                 "(authoritative confirm) — state=$finalState",
             finalState.flatSessions.any { it.sessionName == sessionName },
         )
-    }
+    } }
 
     private fun newViewModel(): FolderListViewModel {
         val context = InstrumentationRegistry.getInstrumentation().targetContext

--- a/app/src/androidTest/java/com/pocketshell/app/projects/FolderListDurableTreeDaemonDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/FolderListDurableTreeDaemonDockerTest.kt
@@ -107,7 +107,7 @@ class FolderListDurableTreeDaemonDockerTest {
     private var hostName: String = "issue839-host"
 
     @Before
-    fun setUp(): Unit = runBlocking {
+    fun setUp(): Unit { runBlocking {
         // Issue #839: NO assumeFalse(isRunningOnCi()) self-skip. The
         // emulator-journey workflow now brings up the `agents-daemon` fixture on
         // port 2239 (and verifies its real `pocketshell tree` persists) AND this
@@ -135,10 +135,10 @@ class FolderListDurableTreeDaemonDockerTest {
             .allowMainThreadQueries()
             .build()
         waitForSshFixtureReady(sshKey, port = DAEMON_PORT)
-    }
+    } }
 
     @After
-    fun tearDown(): Unit = runBlocking {
+    fun tearDown(): Unit { runBlocking {
         viewModelStore.clear()
         runCatching {
             withTimeout(20_000) {
@@ -161,7 +161,7 @@ class FolderListDurableTreeDaemonDockerTest {
         }
         runCatching { db.close() }
         runCatching { keyFile.delete() }
-    }
+    } }
 
     /**
      * The load-bearing journey: collapse a folder + hold an order, KILL +
@@ -170,7 +170,7 @@ class FolderListDurableTreeDaemonDockerTest {
      * a delta and a refresh picks up an added session.
      */
     @Test
-    fun durableTreeSurvivesAppKillAndRelaunch_thenReconcilesDeltas(): Unit = runBlocking {
+    fun durableTreeSurvivesAppKillAndRelaunch_thenReconcilesDeltas(): Unit { runBlocking {
         val suffix = System.currentTimeMillis().toString().takeLast(6)
         hostName = "issue839-host-$suffix"
         val rootDir = "/tmp/issue839-$suffix"
@@ -376,7 +376,7 @@ class FolderListDurableTreeDaemonDockerTest {
             afterAdd.flatSessions.any { it.sessionName == gammaSession } &&
                 afterAdd.flatSessions.any { it.sessionName == alphaSession },
         )
-    }
+    } }
 
     private fun bind(vm: FolderListViewModel, host: HostEntity) {
         vm.bind(

--- a/app/src/androidTest/java/com/pocketshell/app/projects/FolderListGatewayDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/FolderListGatewayDockerTest.kt
@@ -61,7 +61,7 @@ class FolderListGatewayDockerTest {
     private val createdSessions = mutableListOf<String>()
 
     @Before
-    fun setUp(): Unit = runBlocking {
+    fun setUp(): Unit { runBlocking {
         val keyText = InstrumentationRegistry.getInstrumentation()
             .context
             .assets
@@ -80,10 +80,10 @@ class FolderListGatewayDockerTest {
             setReadable(true, true)
         }
         waitForSshFixtureReady(sshKey)
-    }
+    } }
 
     @After
-    fun tearDown(): Unit = runBlocking {
+    fun tearDown(): Unit { runBlocking {
         // Best-effort cleanup — kill any tmux sessions we created so
         // re-runs / sibling tests start from a clean slate.
         if (createdSessions.isEmpty()) return@runBlocking
@@ -102,10 +102,10 @@ class FolderListGatewayDockerTest {
             }
         }
         runCatching { keyFile.delete() }
-    }
+    } }
 
     @Test
-    fun gatewayGroupsThreeSessionsAcrossTwoFolders(): Unit = runBlocking {
+    fun gatewayGroupsThreeSessionsAcrossTwoFolders(): Unit { runBlocking {
         val suffix = System.currentTimeMillis().toString().takeLast(6)
         val folderA = "/tmp/issue171-folder-a-$suffix"
         val folderB = "/tmp/issue171-folder-b-$suffix"
@@ -230,5 +230,5 @@ class FolderListGatewayDockerTest {
         assertEquals(SessionAgentKind.Shell, entries.first().agentKind)
         assertNotNull(rowA)
         assertNotNull(rowB)
-    }
+    } }
 }

--- a/app/src/androidTest/java/com/pocketshell/app/projects/FolderListGatewayStaleChannelHealDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/FolderListGatewayStaleChannelHealDockerTest.kt
@@ -71,7 +71,7 @@ class FolderListGatewayStaleChannelHealDockerTest {
     private val createdSessions = mutableListOf<String>()
 
     @Before
-    fun setUp(): Unit = runBlocking {
+    fun setUp(): Unit { runBlocking {
         val keyText = InstrumentationRegistry.getInstrumentation()
             .context
             .assets
@@ -87,10 +87,10 @@ class FolderListGatewayStaleChannelHealDockerTest {
             setReadable(true, true)
         }
         waitForSshFixtureReady(sshKey)
-    }
+    } }
 
     @After
-    fun tearDown(): Unit = runBlocking {
+    fun tearDown(): Unit { runBlocking {
         if (createdSessions.isEmpty()) {
             runCatching { keyFile.delete() }
             return@runBlocking
@@ -110,10 +110,10 @@ class FolderListGatewayStaleChannelHealDockerTest {
             }
         }
         runCatching { keyFile.delete() }
-    }
+    } }
 
     @Test
-    fun staleLeaseHealsToFreshDockerDialWithinSameRefresh(): Unit = runBlocking {
+    fun staleLeaseHealsToFreshDockerDialWithinSameRefresh(): Unit { runBlocking {
         val suffix = System.currentTimeMillis().toString().takeLast(6)
         val folder = "/tmp/issue680-heal-$suffix"
         val session = "issue680-heal-$suffix"
@@ -180,10 +180,10 @@ class FolderListGatewayStaleChannelHealDockerTest {
             2,
             connectCount.get(),
         )
-    }
+    } }
 
     @Test
-    fun genuineDisconnectStillSurfacesAnError(): Unit = runBlocking {
+    fun genuineDisconnectStillSurfacesAnError(): Unit { runBlocking {
         // Point the gateway at a dead port so BOTH the initial dial and the
         // heal retry genuinely fail to connect — the refresh must NOT pretend
         // success; it surfaces an accurate error.
@@ -203,7 +203,7 @@ class FolderListGatewayStaleChannelHealDockerTest {
             "a genuine disconnect must surface an error, got $result",
             result is FolderListResult.ConnectFailed || result is FolderListResult.Failed,
         )
-    }
+    } }
 
     /**
      * Pooled session that LIES about connectivity (sshj reports a silently-dead

--- a/app/src/androidTest/java/com/pocketshell/app/projects/FolderListKillSessionDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/FolderListKillSessionDockerTest.kt
@@ -69,7 +69,7 @@ class FolderListKillSessionDockerTest {
     private val createdSessions = mutableListOf<String>()
 
     @Before
-    fun setUp(): Unit = runBlocking {
+    fun setUp(): Unit { runBlocking {
         val keyText = InstrumentationRegistry.getInstrumentation()
             .context
             .assets
@@ -89,10 +89,10 @@ class FolderListKillSessionDockerTest {
             AppDatabase::class.java,
         ).allowMainThreadQueries().build()
         waitForSshFixtureReady(sshKey)
-    }
+    } }
 
     @After
-    fun tearDown(): Unit = runBlocking {
+    fun tearDown(): Unit { runBlocking {
         viewModelStore.clear()
         factoryScope.cancel()
         if (createdSessions.isNotEmpty()) {
@@ -117,10 +117,10 @@ class FolderListKillSessionDockerTest {
         }
         runCatching { db.close() }
         runCatching { keyFile.delete() }
-    }
+    } }
 
     @Test
-    fun killSessionDropsRowFromFolderTreePromptly(): Unit = runBlocking {
+    fun killSessionDropsRowFromFolderTreePromptly(): Unit { runBlocking {
         val suffix = System.currentTimeMillis().toString().takeLast(6)
         val folder = "/tmp/issue464-kill-$suffix"
         val keep = "issue464-keep-$suffix"
@@ -268,7 +268,7 @@ class FolderListKillSessionDockerTest {
             tmuxVm.clearForTest()
             folderVm.stopPolling()
         }
-    }
+    } }
 
     private fun hasSession(vm: FolderListViewModel, sessionName: String): Boolean {
         val state = vm.state.value as? FolderListUiState.Ready ?: return false

--- a/app/src/androidTest/java/com/pocketshell/app/projects/FolderListKillWindowDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/FolderListKillWindowDockerTest.kt
@@ -74,7 +74,7 @@ class FolderListKillWindowDockerTest {
     private val createdSessions = mutableListOf<String>()
 
     @Before
-    fun setUp(): Unit = runBlocking {
+    fun setUp(): Unit { runBlocking {
         val keyText = InstrumentationRegistry.getInstrumentation()
             .context
             .assets
@@ -94,10 +94,10 @@ class FolderListKillWindowDockerTest {
             AppDatabase::class.java,
         ).allowMainThreadQueries().build()
         waitForSshFixtureReady(sshKey)
-    }
+    } }
 
     @After
-    fun tearDown(): Unit = runBlocking {
+    fun tearDown(): Unit { runBlocking {
         viewModelStore.clear()
         factoryScope.cancel()
         if (createdSessions.isNotEmpty()) {
@@ -122,10 +122,10 @@ class FolderListKillWindowDockerTest {
         }
         runCatching { db.close() }
         runCatching { keyFile.delete() }
-    }
+    } }
 
     @Test
-    fun stopOnWindowRowKillsOnlyThatWindowAndKeepsTheSession(): Unit = runBlocking {
+    fun stopOnWindowRowKillsOnlyThatWindowAndKeepsTheSession(): Unit { runBlocking {
         val suffix = System.currentTimeMillis().toString().takeLast(6)
         val folder = "/tmp/issue883-killwindow-$suffix"
         val multi = "issue883-multi-$suffix"
@@ -258,7 +258,7 @@ class FolderListKillWindowDockerTest {
             tmuxVm.clearForTest()
             folderVm.stopPolling()
         }
-    }
+    } }
 
     private fun hasSession(vm: FolderListViewModel, sessionName: String): Boolean {
         val state = vm.state.value as? FolderListUiState.Ready ?: return false

--- a/app/src/androidTest/java/com/pocketshell/app/projects/FolderListOldCliHydrateDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/FolderListOldCliHydrateDockerTest.kt
@@ -76,7 +76,7 @@ class FolderListOldCliHydrateDockerTest {
     private val createdSessions = mutableListOf<String>()
 
     @Before
-    fun setUp(): Unit = runBlocking {
+    fun setUp(): Unit { runBlocking {
         // Issue #849: NO assumeFalse(isRunningOnCi()) self-skip. The
         // emulator-journey workflow (and the pre-release gate) now start the
         // agents-old-cli fixture on 2238, so this connect-break regression
@@ -102,10 +102,10 @@ class FolderListOldCliHydrateDockerTest {
             AppDatabase::class.java,
         ).allowMainThreadQueries().build()
         waitForSshFixtureReady(sshKey, port = OLD_CLI_PORT)
-    }
+    } }
 
     @After
-    fun tearDown(): Unit = runBlocking {
+    fun tearDown(): Unit { runBlocking {
         viewModelStore.clear()
         if (createdSessions.isNotEmpty()) {
             runCatching {
@@ -129,7 +129,7 @@ class FolderListOldCliHydrateDockerTest {
         }
         runCatching { db.close() }
         runCatching { keyFile.delete() }
-    }
+    } }
 
     /**
      * RED on v0.4.10: with a host whose CLI lacks `tree`, the cold-start hydrate
@@ -137,7 +137,7 @@ class FolderListOldCliHydrateDockerTest {
      * LIVE tree (the seeded session appears) within the connect window.
      */
     @Test
-    fun connectsToLiveTree_onHostWithOldCliLackingTreeCommand(): Unit = runBlocking {
+    fun connectsToLiveTree_onHostWithOldCliLackingTreeCommand(): Unit { runBlocking {
         val suffix = System.currentTimeMillis().toString().takeLast(6)
         val folder = "/tmp/issue847-old-cli-$suffix"
         val sessionName = "issue847-old-cli-$suffix"
@@ -216,7 +216,7 @@ class FolderListOldCliHydrateDockerTest {
                 (finalState as FolderListUiState.Ready).flatSessions
                     .any { it.sessionName == sessionName },
         )
-    }
+    } }
 
     private fun newViewModel(): FolderListViewModel {
         val context = InstrumentationRegistry.getInstrumentation().targetContext

--- a/app/src/androidTest/java/com/pocketshell/app/projects/FolderListOutOfBandSessionDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/FolderListOutOfBandSessionDockerTest.kt
@@ -87,7 +87,7 @@ class FolderListOutOfBandSessionDockerTest {
     private val createdSessions = mutableListOf<String>()
 
     @Before
-    fun setUp(): Unit = runBlocking {
+    fun setUp(): Unit { runBlocking {
         val keyText = InstrumentationRegistry.getInstrumentation()
             .context
             .assets
@@ -107,10 +107,10 @@ class FolderListOutOfBandSessionDockerTest {
             AppDatabase::class.java,
         ).allowMainThreadQueries().build()
         waitForSshFixtureReady(sshKey)
-    }
+    } }
 
     @After
-    fun tearDown(): Unit = runBlocking {
+    fun tearDown(): Unit { runBlocking {
         viewModelStore.clear()
         runCatching { ccClient?.close() }
         runCatching { ccSession?.close() }
@@ -135,10 +135,10 @@ class FolderListOutOfBandSessionDockerTest {
         }
         runCatching { db.close() }
         runCatching { keyFile.delete() }
-    }
+    } }
 
     @Test
-    fun outOfBandSessionAppearsInPickerWithinSeconds(): Unit = runBlocking {
+    fun outOfBandSessionAppearsInPickerWithinSeconds(): Unit { runBlocking {
         val suffix = System.currentTimeMillis().toString().takeLast(6)
         val anchorFolder = "/tmp/issue706-anchor-$suffix"
         val anchorSession = "issue706-anchor-$suffix"
@@ -271,7 +271,7 @@ class FolderListOutOfBandSessionDockerTest {
         )
         // Sanity: the anchor session is still listed too.
         assertTrue("anchor session must remain listed", hasSession(vm, anchorSession))
-    }
+    } }
 
     private fun hasSession(vm: FolderListViewModel, sessionName: String): Boolean {
         val state = vm.state.value as? FolderListUiState.Ready ?: return false

--- a/app/src/androidTest/java/com/pocketshell/app/projects/FolderListScreenE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/FolderListScreenE2eTest.kt
@@ -89,7 +89,7 @@ class FolderListScreenE2eTest {
     private val hostId: Long = 7L
 
     @Before
-    fun openDatabase(): Unit = runBlocking {
+    fun openDatabase(): Unit { runBlocking {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
             .allowMainThreadQueries()
@@ -131,7 +131,7 @@ class FolderListScreenE2eTest {
                 path = "~/archive",
             ),
         )
-    }
+    } }
 
     @After
     fun closeDatabase() {

--- a/app/src/androidTest/java/com/pocketshell/app/projects/FolderListSessionClickTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/FolderListSessionClickTest.kt
@@ -57,7 +57,7 @@ class FolderListSessionClickTest {
     private val hostId: Long = 11L
 
     @Before
-    fun openDatabase(): Unit = runBlocking {
+    fun openDatabase(): Unit { runBlocking {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
             .allowMainThreadQueries()
@@ -75,7 +75,7 @@ class FolderListSessionClickTest {
                 keyId = keyId,
             ),
         )
-    }
+    } }
 
     @After
     fun closeDatabase() {

--- a/app/src/androidTest/java/com/pocketshell/app/projects/FolderListSessionResumeDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/FolderListSessionResumeDockerTest.kt
@@ -78,7 +78,7 @@ class FolderListSessionResumeDockerTest {
     private val createdSessions = mutableListOf<String>()
 
     @Before
-    fun setUp(): Unit = runBlocking {
+    fun setUp(): Unit { runBlocking {
         val keyText = InstrumentationRegistry.getInstrumentation()
             .context
             .assets
@@ -99,10 +99,10 @@ class FolderListSessionResumeDockerTest {
             AppDatabase::class.java,
         ).allowMainThreadQueries().build()
         waitForSshFixtureReady(sshKey)
-    }
+    } }
 
     @After
-    fun tearDown(): Unit = runBlocking {
+    fun tearDown(): Unit { runBlocking {
         viewModelStore.clear()
         if (createdSessions.isNotEmpty()) {
             runCatching {
@@ -126,10 +126,10 @@ class FolderListSessionResumeDockerTest {
         }
         runCatching { db.close() }
         runCatching { keyFile.delete() }
-    }
+    } }
 
     @Test
-    fun sessionReappearsOnFolderTreeAfterBackgroundResume(): Unit = runBlocking {
+    fun sessionReappearsOnFolderTreeAfterBackgroundResume(): Unit { runBlocking {
         val suffix = System.currentTimeMillis().toString().takeLast(6)
         val folder = "/tmp/issue430-resume-$suffix"
         val sessionName = "issue430-resume-$suffix"
@@ -191,7 +191,7 @@ class FolderListSessionResumeDockerTest {
         // 5. Foreground / resume → immediate probe → session reappears.
         relaunchVm.setProcessStartedForTest(true)
         awaitSession(relaunchVm, sessionName)
-    }
+    } }
 
     private fun newViewModel(): FolderListViewModel {
         val context = InstrumentationRegistry.getInstrumentation().targetContext

--- a/app/src/androidTest/java/com/pocketshell/app/projects/FolderListStopSessionTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/FolderListStopSessionTest.kt
@@ -75,7 +75,7 @@ class FolderListStopSessionTest {
     private val doomed = "doomed-agent"
 
     @Before
-    fun openDatabase(): Unit = runBlocking {
+    fun openDatabase(): Unit { runBlocking {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
             .allowMainThreadQueries()
@@ -96,7 +96,7 @@ class FolderListStopSessionTest {
         db.projectRootDao().insert(
             ProjectRootEntity(hostId = hostId, label = "[00] git", path = "~/git"),
         )
-    }
+    } }
 
     @After
     fun closeDatabase() {

--- a/app/src/androidTest/java/com/pocketshell/app/projects/FolderListTreeStopSessionDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/FolderListTreeStopSessionDockerTest.kt
@@ -58,7 +58,7 @@ class FolderListTreeStopSessionDockerTest {
     private val createdSessions = mutableListOf<String>()
 
     @Before
-    fun setUp(): Unit = runBlocking {
+    fun setUp(): Unit { runBlocking {
         val keyText = InstrumentationRegistry.getInstrumentation()
             .context
             .assets
@@ -78,10 +78,10 @@ class FolderListTreeStopSessionDockerTest {
             AppDatabase::class.java,
         ).allowMainThreadQueries().build()
         waitForSshFixtureReady(sshKey)
-    }
+    } }
 
     @After
-    fun tearDown(): Unit = runBlocking {
+    fun tearDown(): Unit { runBlocking {
         viewModelStore.clear()
         if (createdSessions.isNotEmpty()) {
             runCatching {
@@ -105,10 +105,10 @@ class FolderListTreeStopSessionDockerTest {
         }
         runCatching { db.close() }
         runCatching { keyFile.delete() }
-    }
+    } }
 
     @Test
-    fun stopSessionFromTreeKillsRemoteAndDropsRow(): Unit = runBlocking {
+    fun stopSessionFromTreeKillsRemoteAndDropsRow(): Unit { runBlocking {
         val suffix = System.currentTimeMillis().toString().takeLast(6)
         val folder = "/tmp/issue518-stop-$suffix"
         val keep = "issue518-keep-$suffix"
@@ -209,7 +209,7 @@ class FolderListTreeStopSessionDockerTest {
         } finally {
             folderVm.stopPolling()
         }
-    }
+    } }
 
     private fun hasSession(vm: FolderListViewModel, sessionName: String): Boolean {
         val state = vm.state.value as? FolderListUiState.Ready ?: return false

--- a/app/src/androidTest/java/com/pocketshell/app/projects/FolderListWindowCloseAfterStopPollingDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/FolderListWindowCloseAfterStopPollingDockerTest.kt
@@ -86,7 +86,7 @@ class FolderListWindowCloseAfterStopPollingDockerTest {
     private val createdSessions = mutableListOf<String>()
 
     @Before
-    fun setUp(): Unit = runBlocking {
+    fun setUp(): Unit { runBlocking {
         val keyText = InstrumentationRegistry.getInstrumentation()
             .context
             .assets
@@ -106,10 +106,10 @@ class FolderListWindowCloseAfterStopPollingDockerTest {
             AppDatabase::class.java,
         ).allowMainThreadQueries().build()
         waitForSshFixtureReady(sshKey)
-    }
+    } }
 
     @After
-    fun tearDown(): Unit = runBlocking {
+    fun tearDown(): Unit { runBlocking {
         viewModelStore.clear()
         runCatching { ccClient?.close() }
         runCatching { ccSession?.close() }
@@ -134,10 +134,10 @@ class FolderListWindowCloseAfterStopPollingDockerTest {
         }
         runCatching { db.close() }
         runCatching { keyFile.delete() }
-    }
+    } }
 
     @Test
-    fun windowClosedOnHostWhileOffTreeScreenIsPrunedWithoutRefresh(): Unit = runBlocking {
+    fun windowClosedOnHostWhileOffTreeScreenIsPrunedWithoutRefresh(): Unit { runBlocking {
         val suffix = System.currentTimeMillis().toString().takeLast(6)
         val folder = "/tmp/issue783-$suffix"
         val sessionName = "issue783-$suffix"
@@ -282,7 +282,7 @@ class FolderListWindowCloseAfterStopPollingDockerTest {
             1,
             windowIdsAfter.size,
         )
-    }
+    } }
 
     private fun windowIds(vm: FolderListViewModel, sessionName: String): List<String?> {
         val state = vm.state.value as? FolderListUiState.Ready ?: return emptyList()

--- a/app/src/androidTest/java/com/pocketshell/app/projects/HostDetailAssistantFlowTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/HostDetailAssistantFlowTest.kt
@@ -79,7 +79,7 @@ class HostDetailAssistantFlowTest {
     private val hostId = 334L
 
     @Before
-    fun setUp(): Unit = runBlocking {
+    fun setUp(): Unit { runBlocking {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val context = instrumentation.targetContext
         runCatching {
@@ -111,7 +111,7 @@ class HostDetailAssistantFlowTest {
                 path = "/home/u/code",
             ),
         )
-    }
+    } }
 
     @After
     fun tearDown() {

--- a/app/src/androidTest/java/com/pocketshell/app/projects/HostDetailAssistantFolderDisambiguationTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/HostDetailAssistantFolderDisambiguationTest.kt
@@ -86,7 +86,7 @@ class HostDetailAssistantFolderDisambiguationTest {
     private val workshopB = "/home/u/code/notes/workshop"
 
     @Before
-    fun setUp(): Unit = runBlocking {
+    fun setUp(): Unit { runBlocking {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val context = instrumentation.targetContext
         runCatching {
@@ -118,7 +118,7 @@ class HostDetailAssistantFolderDisambiguationTest {
                 path = "/home/u/code",
             ),
         )
-    }
+    } }
 
     @After
     fun tearDown() {

--- a/app/src/androidTest/java/com/pocketshell/app/projects/ManualKindWriterDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/ManualKindWriterDockerTest.kt
@@ -53,7 +53,7 @@ class ManualKindWriterDockerTest {
     private val cleanupCommands = mutableListOf<String>()
 
     @After
-    fun tearDown(): Unit = runBlocking {
+    fun tearDown(): Unit { runBlocking {
         if (cleanupCommands.isNotEmpty()) {
             runCatching {
                 withTimeout(15_000) {
@@ -64,10 +64,10 @@ class ManualKindWriterDockerTest {
             }
         }
         runCatching { keyFile.delete() }
-    }
+    } }
 
     @Test
-    fun foreignSessionStartsUnknownThenManualPickAndChangeAreDurable(): Unit = runBlocking {
+    fun foreignSessionStartsUnknownThenManualPickAndChangeAreDurable(): Unit { runBlocking {
         bootstrapKey()
         waitForSshFixtureReady(sshKey)
 
@@ -164,7 +164,7 @@ class ManualKindWriterDockerTest {
             ).stdout.trim()
             assertEquals("manual shell classification must persist host-side", "shell", raw)
         }
-    }
+    } }
 
     // ----------------------------------------------------------- Helpers
 

--- a/app/src/androidTest/java/com/pocketshell/app/projects/ProfileChipRelaunchDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/ProfileChipRelaunchDockerTest.kt
@@ -60,7 +60,7 @@ class ProfileChipRelaunchDockerTest {
     private val zaiProfileLabel = "Claude (Z.AI)"
 
     @After
-    fun tearDown(): Unit = runBlocking {
+    fun tearDown(): Unit { runBlocking {
         if (cleanupCommands.isNotEmpty()) {
             runCatching {
                 withTimeout(15_000) {
@@ -69,10 +69,10 @@ class ProfileChipRelaunchDockerTest {
             }
         }
         runCatching { keyFile.delete() }
-    }
+    } }
 
     @Test
-    fun zaiSessionRelaunchedAsDefaultClaudeDropsTheStaleProfileChip(): Unit = runBlocking {
+    fun zaiSessionRelaunchedAsDefaultClaudeDropsTheStaleProfileChip(): Unit { runBlocking {
         bootstrapKey()
         waitForSshFixtureReady(sshKey)
 
@@ -153,7 +153,7 @@ class ProfileChipRelaunchDockerTest {
                 "was '${finalEntry.recordedProfile}'",
             finalEntry.recordedProfile,
         )
-    }
+    } }
 
     // ----------------------------------------------------------- Helpers
 

--- a/app/src/androidTest/java/com/pocketshell/app/projects/ProfileDiscoveryPickerDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/ProfileDiscoveryPickerDockerTest.kt
@@ -62,7 +62,7 @@ class ProfileDiscoveryPickerDockerTest {
     private lateinit var keyFile: File
 
     @Before
-    fun setUp(): Unit = runBlocking {
+    fun setUp(): Unit { runBlocking {
         val keyText = InstrumentationRegistry.getInstrumentation()
             .context.assets.open("test_key").bufferedReader().use { it.readText() }
         sshKey = SshKey.Pem(keyText)
@@ -74,10 +74,10 @@ class ProfileDiscoveryPickerDockerTest {
             setReadable(true, true)
         }
         waitForSshFixtureReady(sshKey)
-    }
+    } }
 
     @Test
-    fun discoversSeededHostProfilesAndSelectsOneEndToEnd(): Unit = runBlocking {
+    fun discoversSeededHostProfilesAndSelectsOneEndToEnd(): Unit { runBlocking {
         val leaseManager = SshLeaseManager(connector = DefaultSshLeaseConnector())
         val gateway = SshProfilesGateway(leaseManager)
         val host = HostEntity(
@@ -189,5 +189,5 @@ class ProfileDiscoveryPickerDockerTest {
                 "${banner.stdout} stderr=${banner.stderr}",
             (banner.stdout + banner.stderr).contains("claude", ignoreCase = true),
         )
-    }
+    } }
 }

--- a/app/src/androidTest/java/com/pocketshell/app/projects/WatchedFoldersE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/WatchedFoldersE2eTest.kt
@@ -100,7 +100,7 @@ class WatchedFoldersE2eTest {
     }
 
     @Test
-    fun addFolderRoundTripsThroughDao(): Unit = runBlocking {
+    fun addFolderRoundTripsThroughDao(): Unit { runBlocking {
         val dao = db.projectRootDao()
         val hostId = 17L
 
@@ -147,10 +147,10 @@ class WatchedFoldersE2eTest {
         // The empty-state hint is replaced by the row.
         compose.onNodeWithTag(WATCHED_FOLDERS_EMPTY_HINT_TAG).assertDoesNotExist()
         compose.onNodeWithTag(watchedFolderRowTestTag(saved.id)).assertExists()
-    }
+    } }
 
     @Test
-    fun chipRowRendersConfiguredFoldersAndCallsBack(): Unit = runBlocking {
+    fun chipRowRendersConfiguredFoldersAndCallsBack(): Unit { runBlocking {
         val dao = db.projectRootDao()
         val hostId = 33L
         dao.insert(
@@ -180,10 +180,10 @@ class WatchedFoldersE2eTest {
             .performClick()
 
         assertEquals("~/code/site", lastChip)
-    }
+    } }
 
     @Test
-    fun chipRowShowsEmptyNudgeWhenNoFolders(): Unit = runBlocking {
+    fun chipRowShowsEmptyNudgeWhenNoFolders(): Unit { runBlocking {
         val chipsVm = WatchedFoldersChipsViewModel(projectRootDao = db.projectRootDao())
         compose.setContent {
             PocketShellTheme {
@@ -195,10 +195,10 @@ class WatchedFoldersE2eTest {
             }
         }
         compose.onNodeWithTag(WATCHED_FOLDERS_CHIP_EMPTY_NUDGE_TAG).assertExists()
-    }
+    } }
 
     @Test
-    fun deletingFolderDropsItFromDao(): Unit = runBlocking {
+    fun deletingFolderDropsItFromDao(): Unit { runBlocking {
         val dao = db.projectRootDao()
         val hostId = 8L
         val insertedId = dao.insert(
@@ -239,10 +239,10 @@ class WatchedFoldersE2eTest {
             vm.state.value.roots.none { it.id == insertedId }
         }
         compose.onNodeWithTag(WATCHED_FOLDERS_EMPTY_HINT_TAG).assertExists()
-    }
+    } }
 
     @Test
-    fun hostDetailViewModeRowsDispatchPreferenceChanges(): Unit = runBlocking {
+    fun hostDetailViewModeRowsDispatchPreferenceChanges(): Unit { runBlocking {
         val vm = WatchedFoldersViewModel(
             projectRootDao = db.projectRootDao(),
             sshLeaseManager = SshLeaseManager(connector = DefaultSshLeaseConnector()),
@@ -269,5 +269,5 @@ class WatchedFoldersE2eTest {
             .performClick()
 
         assertEquals(HostDetailViewMode.Flat, selected)
-    }
+    } }
 }

--- a/app/src/androidTest/java/com/pocketshell/app/proof/AgentAltScreenPartialBlackHealJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/AgentAltScreenPartialBlackHealJourneyE2eTest.kt
@@ -130,7 +130,7 @@ class AgentAltScreenPartialBlackHealJourneyE2eTest {
     }
 
     @Test
-    fun steadyStateWatchdogHealsPartialBlackAltScreenAgentPane() = runBlocking {
+    fun steadyStateWatchdogHealsPartialBlackAltScreenAgentPane() { runBlocking {
         // Issue #788/#848: the sparse alt-screen tmux session + DB host row were
         // already seeded BEFORE MainActivity launched, by [seedBeforeLaunch] in
         // the rule chain's `before()`. Attach to it from the freshly-launched app.
@@ -145,7 +145,12 @@ class AgentAltScreenPartialBlackHealJourneyE2eTest {
         // Clear the alt screen and paint ONLY the live status line (cursor-addressed) — the
         // maintainer's semi-black: upper rows black, only the status line survives. The REMOTE
         // tmux grid keeps the full sparse frame, so the transport stays GUARANTEED LIVE.
-        feedFrameToEmulator("[2J[H[24;1H Working 7  esc to interrupt streaming the reply")
+        // Real ESC (0x1B) bytes: this feeds the LOCAL emulator directly via
+        // emulator.append() (no remote printf to expand octal \033), so the CSI
+        // control sequences must carry an actual ESC or they paint as literal
+        // text and never clear the screen (the injected partial-black is a no-op).
+        val esc = ""
+        feedFrameToEmulator("$esc[2J$esc[H$esc[24;1H Working 7  esc to interrupt streaming the reply")
         InstrumentationRegistry.getInstrumentation().waitForIdleSync()
         capturePaintedRows("issue1138-01-partial-black")
 
@@ -198,7 +203,7 @@ class AgentAltScreenPartialBlackHealJourneyE2eTest {
             currentConnectionStatus() is TmuxSessionViewModel.ConnectionStatus.Connected,
         )
         writeSummary()
-    }
+    } }
 
     // ---------------------------------------------------------------- Heal driver
 

--- a/app/src/androidTest/java/com/pocketshell/app/proof/AgentSubmitAckJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/AgentSubmitAckJourneyE2eTest.kt
@@ -122,7 +122,7 @@ class AgentSubmitAckJourneyE2eTest {
     }
 
     @Test
-    fun composerSendSubmitsPromptIncludingWrappedLongPromptOnAgentPane() = runBlocking<Unit> {
+    fun composerSendSubmitsPromptIncludingWrappedLongPromptOnAgentPane() { runBlocking<Unit> {
         val hostRowTag = requireNotNull(seededHostRowTag)
         attachSeededTmuxSession(hostRowTag)
         waitForVisibleTerminal("initial attach") { it.contains(FAKE_AGENT_READY) }
@@ -216,7 +216,7 @@ class AgentSubmitAckJourneyE2eTest {
             appendLine("short_prompt=$shortPrompt")
             appendLine("long_prompt=$longPrompt")
         })
-    }
+    } }
 
     /**
      * Sidecar SSH `capture-pane -p` of the seeded session, polled until the

--- a/app/src/androidTest/java/com/pocketshell/app/proof/AttachmentDropReconnectRecoversE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/AttachmentDropReconnectRecoversE2eTest.kt
@@ -144,7 +144,7 @@ class AttachmentDropReconnectRecoversE2eTest {
      * drop fires), and assert the teardown OWNS + CANCELS the in-flight upload.
      */
     @Test
-    fun attachUploadTornDownOnRealTransportIsOwnedAndCancelled() = runBlocking<Unit> {
+    fun attachUploadTornDownOnRealTransportIsOwnedAndCancelled() { runBlocking<Unit> {
         val key = requireNotNull(seededKey)
         val hostRowTag = requireNotNull(seededHostRowTag)
         attachSeededTmuxSession(hostRowTag)
@@ -203,7 +203,7 @@ class AttachmentDropReconnectRecoversE2eTest {
         )
         captureViewport("issue1072-A-upload-torn-down")
         writeTimings("upload-torn-down")
-    }
+    } }
 
     /**
      * The literal #1072 acceptance criterion, faithful + end-to-end: a GENUINE clean
@@ -223,7 +223,7 @@ class AttachmentDropReconnectRecoversE2eTest {
      * false`, so the lease never reuses the upload-poisoned one).
      */
     @Test
-    fun genuineDropDuringUploadRecoversToLiveWithoutRestart() = runBlocking<Unit> {
+    fun genuineDropDuringUploadRecoversToLiveWithoutRestart() { runBlocking<Unit> {
         val key = requireNotNull(seededKey)
         val hostRowTag = requireNotNull(seededHostRowTag)
         attachSeededTmuxSession(hostRowTag)
@@ -343,7 +343,7 @@ class AttachmentDropReconnectRecoversE2eTest {
         } finally {
             runCatching { killer.close() }
         }
-    }
+    } }
 
     // -- upload + in-flight helpers ------------------------------------------------
 

--- a/app/src/androidTest/java/com/pocketshell/app/proof/AttachmentNoReconnectE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/AttachmentNoReconnectE2eTest.kt
@@ -153,7 +153,7 @@ class AttachmentNoReconnectE2eTest {
     }
 
     @Test
-    fun addingAttachmentWithinGraceDoesNotReconnectOrBlankViewport() = runBlocking<Unit> {
+    fun addingAttachmentWithinGraceDoesNotReconnectOrBlankViewport() { runBlocking<Unit> {
         val key = requireNotNull(seededKey)
         // Session seeded by [seedFixtureRule] before MainActivity launched.
         val hostRowTag = requireNotNull(seededHostRowTag)
@@ -226,7 +226,7 @@ class AttachmentNoReconnectE2eTest {
         assertNoReconnectDiagnostics("after attachment")
         captureViewport("issue785-02-after-attachment")
         writeTimings()
-    }
+    } }
 
     private fun attachSeededTmuxSession(hostRowTag: String) {
         compose.waitUntil(timeoutMillis = HOST_ROW_TIMEOUT_MS) {

--- a/app/src/androidTest/java/com/pocketshell/app/proof/BackThenOpenSecondSessionReusesWarmLeaseE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/BackThenOpenSecondSessionReusesWarmLeaseE2eTest.kt
@@ -168,7 +168,7 @@ class BackThenOpenSecondSessionReusesWarmLeaseE2eTest {
     }
 
     @Test
-    fun backThenOpenSecondSessionReusesWarmLeaseNoReconnect() = runBlocking {
+    fun backThenOpenSecondSessionReusesWarmLeaseNoReconnect() { runBlocking {
         // Issue #788: sessions + watched-root host seeded BEFORE launch by the
         // rule chain's `before()`; the forced-symptom hook was disarmed there too.
 
@@ -350,7 +350,7 @@ class BackThenOpenSecondSessionReusesWarmLeaseE2eTest {
         )
         writeTimings()
         Unit
-    }
+    } }
 
     // ---------------------------------------------------------------- Helpers
 

--- a/app/src/androidTest/java/com/pocketshell/app/proof/BackgroundGraceReconnectE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/BackgroundGraceReconnectE2eTest.kt
@@ -156,7 +156,7 @@ class BackgroundGraceReconnectE2eTest {
     }
 
     @Test
-    fun quickAppSwitchWithinBackgroundGraceDoesNotShowOrRecordReconnect() = runBlocking<Unit> {
+    fun quickAppSwitchWithinBackgroundGraceDoesNotShowOrRecordReconnect() { runBlocking<Unit> {
         attachSeededTmuxSession(hostRowTag)
         waitForVisibleTerminal("initial attach") { it.contains(READY_MARKER) }
         waitForConnected("initial attach")
@@ -235,7 +235,7 @@ class BackgroundGraceReconnectE2eTest {
         recordTiming("post_grace_cycle_ms", SystemClock.elapsedRealtime() - postStart)
         captureViewport("issue548-03-post-grace-reattached")
         writeTimings()
-    }
+    } }
 
     /**
      * Issue #959 — DURABLE END-TO-END REGRESSION for the beyond-grace
@@ -260,7 +260,7 @@ class BackgroundGraceReconnectE2eTest {
      * GREEN once the producer + input re-bind to the new client.
      */
     @Test
-    fun postGraceReattachLeavesTerminalLiveWithFreshInputEcho() = runBlocking<Unit> {
+    fun postGraceReattachLeavesTerminalLiveWithFreshInputEcho() { runBlocking<Unit> {
         attachSeededTmuxSession(hostRowTag)
         waitForVisibleTerminal("initial attach") { it.contains(READY_MARKER) }
         waitForConnected("initial attach")
@@ -333,7 +333,7 @@ class BackgroundGraceReconnectE2eTest {
         waitForVisibleTerminal("post-grace fresh input echo") { it.contains(postToken) }
         captureViewport("issue959-03-post-grace-fresh-echo")
         writeTimings()
-    }
+    } }
 
     /**
      * Issue #959: send a line of text + Enter to the active pane through the
@@ -378,7 +378,7 @@ class BackgroundGraceReconnectE2eTest {
     }
 
     @Test
-    fun sixSecondAppSwitchWithProductionGraceDoesNotShowOrRecordReconnect() = runBlocking<Unit> {
+    fun sixSecondAppSwitchWithProductionGraceDoesNotShowOrRecordReconnect() { runBlocking<Unit> {
         attachSeededTmuxSession(hostRowTag)
         waitForVisibleTerminal("initial attach") { it.contains(READY_MARKER) }
         waitForConnected("initial attach")
@@ -424,7 +424,7 @@ class BackgroundGraceReconnectE2eTest {
         assertWithinGraceReseedOnlyDriverOwned("six-second production-grace foreground")
         captureViewport("issue548-sixsec-02-foreground")
         writeTimings()
-    }
+    } }
 
     /**
      * Issue #743 de-flake: a plain WALL-CLOCK poll loop, DECOUPLED from the Compose

--- a/app/src/androidTest/java/com/pocketshell/app/proof/BackgroundResumeSocketDeathE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/BackgroundResumeSocketDeathE2eTest.kt
@@ -131,7 +131,7 @@ class BackgroundResumeSocketDeathE2eTest {
     }
 
     @Test
-    fun socketDeathDuringPauseDoesNotCrashOnResume() = runBlocking {
+    fun socketDeathDuringPauseDoesNotCrashOnResume() { runBlocking {
         val key = readFixtureKey()
         waitForSshFixtureReady(SshKey.Pem(key))
 
@@ -316,7 +316,7 @@ class BackgroundResumeSocketDeathE2eTest {
 
         writeTimings()
         Unit
-    }
+    } }
 
     /** Arm/disarm the genuinely-unrecoverable-host seam on the live VM (main thread). */
     private fun setUnrecoverableHostForTest(value: Boolean) {

--- a/app/src/androidTest/java/com/pocketshell/app/proof/BareNetworkLossRestoreReconnectE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/BareNetworkLossRestoreReconnectE2eTest.kt
@@ -155,7 +155,7 @@ class BareNetworkLossRestoreReconnectE2eTest {
     }
 
     @Test
-    fun bareLossHoldsTheLeaseThenRestoreDrivesAFastReconnect() = runBlocking<Unit> {
+    fun bareLossHoldsTheLeaseThenRestoreDrivesAFastReconnect() { runBlocking<Unit> {
         val hostRowTag = requireNotNull(seededHostRowTag)
         attachSeededTmuxSession(hostRowTag)
         waitForVisibleTerminal("initial attach") { it.contains(READY_MARKER) }
@@ -276,7 +276,7 @@ class BareNetworkLossRestoreReconnectE2eTest {
         captureViewport("issue997-03-after-restore")
 
         writeTimings()
-    }
+    } }
 
     /**
      * ISSUE #1065 (R5, audit C5) — the BOUNDED-PROBE redial arm after a LONG IDLE
@@ -304,7 +304,7 @@ class BareNetworkLossRestoreReconnectE2eTest {
      * won — neither is true here) → recovers Connected with a painted viewport.
      */
     @Test
-    fun longIdleOutageThenRestoreRedialsViaBoundedProbeNotFastPath() = runBlocking<Unit> {
+    fun longIdleOutageThenRestoreRedialsViaBoundedProbeNotFastPath() { runBlocking<Unit> {
         val hostRowTag = requireNotNull(seededHostRowTag)
         attachSeededTmuxSession(hostRowTag)
         waitForVisibleTerminal("initial attach") { it.contains(READY_MARKER) }
@@ -408,7 +408,7 @@ class BareNetworkLossRestoreReconnectE2eTest {
         captureViewport("issue1065redial-03-redialled")
 
         writeTimings()
-    }
+    } }
 
     private fun currentViewModel(): TmuxSessionViewModel {
         lateinit var vm: TmuxSessionViewModel

--- a/app/src/androidTest/java/com/pocketshell/app/proof/BoundedGraceSessionHoldJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/BoundedGraceSessionHoldJourneyE2eTest.kt
@@ -131,7 +131,7 @@ class BoundedGraceSessionHoldJourneyE2eTest {
     }
 
     @Test
-    fun withinGraceHoldsSeamlessly_thenBeyondGraceTearsDownAndReattaches() = runBlocking<Unit> {
+    fun withinGraceHoldsSeamlessly_thenBeyondGraceTearsDownAndReattaches() { runBlocking<Unit> {
         assertEquals("API 35 evidence must run on Android 15", 35, android.os.Build.VERSION.SDK_INT)
 
         val attachStart = SystemClock.elapsedRealtime()
@@ -233,7 +233,7 @@ class BoundedGraceSessionHoldJourneyE2eTest {
         )
         captureViewport("issue1123-04-foreground-reattached")
         writeSummary()
-    }
+    } }
 
     private suspend fun seedBeforeLaunch() {
         notificationManager.cancelAll()

--- a/app/src/androidTest/java/com/pocketshell/app/proof/CleanOutageReattachResilienceE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/CleanOutageReattachResilienceE2eTest.kt
@@ -123,7 +123,7 @@ class CleanOutageReattachResilienceE2eTest {
     }
 
     @Test
-    fun cleanSustainedOutageAutoRecoversWithoutSessionSwitchDance() = runBlocking<Unit> {
+    fun cleanSustainedOutageAutoRecoversWithoutSessionSwitchDance() { runBlocking<Unit> {
         val hostRowTag = requireNotNull(seededHostRowTag)
         attachSeededTmuxSession(hostRowTag)
         waitForVisibleTerminal("initial attach") { it.contains(READY_MARKER) }
@@ -220,7 +220,7 @@ class CleanOutageReattachResilienceE2eTest {
             roundTripped,
         )
         writeTimings()
-    }
+    } }
 
     // -- user-visible recovery helpers (parity with the Slice D specs) -------------
 

--- a/app/src/androidTest/java/com/pocketshell/app/proof/CodexOverflowNoReconnectE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/CodexOverflowNoReconnectE2eTest.kt
@@ -94,7 +94,7 @@ class CodexOverflowNoReconnectE2eTest {
     }
 
     @Test
-    fun codexStyleTerminalFloodWithComposerSendKeysDoesNotShowReconnect() = runBlocking<Unit> {
+    fun codexStyleTerminalFloodWithComposerSendKeysDoesNotShowReconnect() { runBlocking<Unit> {
         val key = readFixtureKey()
         seededKey = key
         waitForSshFixtureReady(SshKey.Pem(key))
@@ -160,7 +160,7 @@ class CodexOverflowNoReconnectE2eTest {
             Log.i(LOG_TAG, "grid before=$gridBefore after=$gridAfter")
         }
         writeTimings()
-    }
+    } }
 
     private fun attachSeededSession(hostRowTag: String) {
         compose.waitUntil(timeoutMillis = 15_000) {

--- a/app/src/androidTest/java/com/pocketshell/app/proof/CodexRedrawOverflowReconnectE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/CodexRedrawOverflowReconnectE2eTest.kt
@@ -124,7 +124,7 @@ class CodexRedrawOverflowReconnectE2eTest : NetworkFaultProofBase() {
     }
 
     @Test
-    fun codexAltScreenRedrawOverflowTimesOutFatalAndReconnects() = runBlocking {
+    fun codexAltScreenRedrawOverflowTimesOutFatalAndReconnects() { runBlocking {
         assumeNetworkFaultProofsEnabled()
 
         val key = readFixtureKey()
@@ -292,7 +292,7 @@ class CodexRedrawOverflowReconnectE2eTest : NetworkFaultProofBase() {
                 "disconnected=$clientDisconnected band(diagnostic)=$sawReconnectBand",
         )
         Unit
-    }
+    } }
 
     // ---------------------------------------------------------------- Helpers
 

--- a/app/src/androidTest/java/com/pocketshell/app/proof/CodexWindowStartupControlSequenceE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/CodexWindowStartupControlSequenceE2eTest.kt
@@ -127,7 +127,7 @@ class CodexWindowStartupControlSequenceE2eTest {
     }
 
     @Test
-    fun secondaryWindowStartupDropsRawControlSequence() = runBlocking {
+    fun secondaryWindowStartupDropsRawControlSequence() { runBlocking {
         val key = readTestKeyOrNull()
             ?: error("test_key asset missing; cannot reach Docker agents fixture")
 
@@ -299,7 +299,7 @@ class CodexWindowStartupControlSequenceE2eTest {
             },
         )
         Unit
-    }
+    } }
 
     // ----------------------------------------------------------------
     // helpers

--- a/app/src/androidTest/java/com/pocketshell/app/proof/ColdDialUnderBandwidthLimitE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/ColdDialUnderBandwidthLimitE2eTest.kt
@@ -61,7 +61,7 @@ class ColdDialUnderBandwidthLimitE2eTest : NetworkFaultProofBase() {
      * cover a multi-second handshake, the dial would abort and this goes red.
      */
     @Test
-    fun coldDialUnderBufferbloatCompletesWithinBudget() = runBlocking {
+    fun coldDialUnderBufferbloatCompletesWithinBudget() { runBlocking {
         assumeNetworkFaultProofsEnabled()
 
         val key = readFixtureKey()
@@ -133,7 +133,7 @@ class ColdDialUnderBandwidthLimitE2eTest : NetworkFaultProofBase() {
             ),
         )
         Unit
-    }
+    } }
 
     /**
      * (2) Genuinely STALLED cold dial: the link is up (TCP connects through the
@@ -143,7 +143,7 @@ class ColdDialUnderBandwidthLimitE2eTest : NetworkFaultProofBase() {
      * indefinite spinner. The retry affordance proves the failure is recoverable.
      */
     @Test
-    fun stalledColdDialFailsCleanlyToRetryablePickerWithoutWedge() = runBlocking {
+    fun stalledColdDialFailsCleanlyToRetryablePickerWithoutWedge() { runBlocking {
         assumeNetworkFaultProofsEnabled()
 
         val key = readFixtureKey()
@@ -204,7 +204,7 @@ class ColdDialUnderBandwidthLimitE2eTest : NetworkFaultProofBase() {
             ),
         )
         Unit
-    }
+    } }
 
     private fun waitForHostRow(hostRowTag: String) {
         compose.waitUntil(timeoutMillis = TerminalTestTimeouts.screenRenderPresenceTimeoutMs()) {

--- a/app/src/androidTest/java/com/pocketshell/app/proof/ColdInstallE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/ColdInstallE2eTest.kt
@@ -157,7 +157,7 @@ class ColdInstallE2eTest {
     }
 
     @Test
-    fun coldInstallJourney_addsHost_attachesTmuxSession_runsCommand_andDefaultsAreSane() = runBlocking {
+    fun coldInstallJourney_addsHost_attachesTmuxSession_runsCommand_andDefaultsAreSane() { runBlocking {
         // ---------------------------------------------------------------
         // Phase 1 — "uninstall + install". We replay an effective cold
         // install by wiping every persistent PocketShell artifact the app
@@ -408,7 +408,7 @@ class ColdInstallE2eTest {
             "HOST_ROW_TAG_PREFIX should remain non-empty (used to namespace host rows)",
             newHostRowTagPrefix.isNotEmpty(),
         )
-    }
+    } }
 
     // ---------------------------------------------------------------------
     // Helpers

--- a/app/src/androidTest/java/com/pocketshell/app/proof/ColdRestoreGoneSessionNoResurrectE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/ColdRestoreGoneSessionNoResurrectE2eTest.kt
@@ -126,7 +126,7 @@ class ColdRestoreGoneSessionNoResurrectE2eTest {
     }
 
     @Test
-    fun coldRestoreToKilledSessionDoesNotRecreateAndLandsOnList() = runBlocking {
+    fun coldRestoreToKilledSessionDoesNotRecreateAndLandsOnList() { runBlocking {
         val key = fixtureKey
 
         // ---- (1) Attach to the seeded session via the normal journey.
@@ -204,7 +204,7 @@ class ColdRestoreGoneSessionNoResurrectE2eTest {
         recordTiming("restore_to_list_ms", SystemClock.elapsedRealtime() - resumeAt)
         writeTimings()
         Unit
-    }
+    } }
 
     /**
      * Issue #834 — DELETING an agent session must NOT auto-open the (deleted)
@@ -236,7 +236,7 @@ class ColdRestoreGoneSessionNoResurrectE2eTest {
      * for the deleted session.
      */
     @Test
-    fun deletingActiveSessionDoesNotAutoOpenItOnResume() = runBlocking {
+    fun deletingActiveSessionDoesNotAutoOpenItOnResume() { runBlocking {
         val key = fixtureKey
 
         // ---- (1) Attach to the seeded session via the normal journey.
@@ -317,7 +317,7 @@ class ColdRestoreGoneSessionNoResurrectE2eTest {
             !sessionScreenStillUp,
         )
         Unit
-    }
+    } }
 
     // ---------------------------------------------------------------- Helpers
 

--- a/app/src/androidTest/java/com/pocketshell/app/proof/ComposerAlwaysPresentSwitchJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/ComposerAlwaysPresentSwitchJourneyE2eTest.kt
@@ -118,7 +118,7 @@ class ComposerAlwaysPresentSwitchJourneyE2eTest {
     }
 
     @Test
-    fun composerLauncherPresentAndContainedAfterEverySwitchAcrossAgentAndShell() = runBlocking {
+    fun composerLauncherPresentAndContainedAfterEverySwitchAcrossAgentAndShell() { runBlocking {
         val key = readFixtureKey()
         waitForSshFixtureReady(SshKey.Pem(key))
 
@@ -188,7 +188,7 @@ class ComposerAlwaysPresentSwitchJourneyE2eTest {
         )
         writeTimings()
         Unit
-    }
+    } }
 
     /**
      * Drive ONE switch [fromSession] -> [toSession] via the Back -> session-list

--- a/app/src/androidTest/java/com/pocketshell/app/proof/DeepLinkSessionSwitchE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/DeepLinkSessionSwitchE2eTest.kt
@@ -95,7 +95,7 @@ class DeepLinkSessionSwitchE2eTest {
     }
 
     @Test
-    fun deepLinkAttachShowsCorrectSessionContentWithoutPickerAndSwitchesCleanly() = runBlocking {
+    fun deepLinkAttachShowsCorrectSessionContentWithoutPickerAndSwitchesCleanly() { runBlocking {
         val key = readFixtureKey()
         waitForSshFixtureReady(SshKey.Pem(key))
         seedTmuxSessions(key)
@@ -124,7 +124,7 @@ class DeepLinkSessionSwitchE2eTest {
 
         writeTimings()
         Unit
-    }
+    } }
 
     private fun attachViaDeepLinkAndAssert(
         seeded: SeededHost,

--- a/app/src/androidTest/java/com/pocketshell/app/proof/DisconnectBlackholeE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/DisconnectBlackholeE2eTest.kt
@@ -22,7 +22,7 @@ import org.junit.runner.RunWith
 class DisconnectBlackholeE2eTest : NetworkFaultProofBase() {
 
     @Test
-    fun halfOpenBlackholeSurfacesErrorAndReconnectsExplicitly() = runBlocking {
+    fun halfOpenBlackholeSurfacesErrorAndReconnectsExplicitly() { runBlocking {
         assumeNetworkFaultProofsEnabled()
 
         val key = readFixtureKey()
@@ -69,5 +69,5 @@ class DisconnectBlackholeE2eTest : NetworkFaultProofBase() {
                 "connect_attempt_delta=${TMUX_CONNECT_ATTEMPTS.get() - attemptsBefore}",
             ),
         )
-    }
+    } }
 }

--- a/app/src/androidTest/java/com/pocketshell/app/proof/DisconnectFlapSoakE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/DisconnectFlapSoakE2eTest.kt
@@ -40,7 +40,7 @@ class DisconnectFlapSoakE2eTest : NetworkFaultProofBase() {
     }
 
     @Test
-    fun repeatedBlackholeFlapsRecoverWithoutStaleClientsOrUnboundedMemoryGrowth() = runBlocking {
+    fun repeatedBlackholeFlapsRecoverWithoutStaleClientsOrUnboundedMemoryGrowth() { runBlocking {
         assumeNetworkFaultProofsEnabled()
 
         val key = readFixtureKey()
@@ -119,7 +119,7 @@ class DisconnectFlapSoakE2eTest : NetworkFaultProofBase() {
                 "explicit_connect_attempts=$explicitConnectAttempts",
             ),
         )
-    }
+    } }
 
     private fun usedHeapKb(): Long {
         Runtime.getRuntime().gc()

--- a/app/src/androidTest/java/com/pocketshell/app/proof/EmulatorDockerSshSmokeTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/EmulatorDockerSshSmokeTest.kt
@@ -91,7 +91,7 @@ class EmulatorDockerSshSmokeTest {
     }
 
     @Test
-    fun debugAppConnectsToDockerAgentTargetViaEmulatorHostAlias() = runBlocking {
+    fun debugAppConnectsToDockerAgentTargetViaEmulatorHostAlias() { runBlocking {
         val key = InstrumentationRegistry.getInstrumentation()
             .context
             .assets
@@ -240,10 +240,10 @@ class EmulatorDockerSshSmokeTest {
                 )
             }
         }
-    }
+    } }
 
     @Test
-    fun walkthroughJourneyOpensAppSessionAndRunsShellAndTmuxCommands() = runBlocking {
+    fun walkthroughJourneyOpensAppSessionAndRunsShellAndTmuxCommands() { runBlocking {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val appContext = instrumentation.targetContext
         val appVersion = appContext.packageManager
@@ -517,7 +517,7 @@ class EmulatorDockerSshSmokeTest {
             )
         }
         Unit
-    }
+    } }
 
     /**
      * Issue #532 root cause + fix. The host-detail tree auto-expands any

--- a/app/src/androidTest/java/com/pocketshell/app/proof/EmulatorWorkflowE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/EmulatorWorkflowE2eTest.kt
@@ -86,7 +86,7 @@ class EmulatorWorkflowE2eTest {
     }
 
     @Test
-    fun realAppTmuxJourneyAttachesSessionAndAcceptsTerminalInput() = runBlocking {
+    fun realAppTmuxJourneyAttachesSessionAndAcceptsTerminalInput() { runBlocking {
         // STOPGAP — tracked in #207/#470/#835. The historical terminal-input
         // assertion is wrap-tolerant now, but PR #905 proved the journey still
         // reaches terminal input through the tmux picker enumeration path. On CI
@@ -146,7 +146,7 @@ class EmulatorWorkflowE2eTest {
         )
 
         writeSummary("tmux-workflow")
-    }
+    } }
 
     private fun readFixtureKey(): String =
         InstrumentationRegistry.getInstrumentation()

--- a/app/src/androidTest/java/com/pocketshell/app/proof/FastResumeReconnectE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/FastResumeReconnectE2eTest.kt
@@ -137,7 +137,7 @@ class FastResumeReconnectE2eTest {
     }
 
     @Test
-    fun resumeAfterBackgroundRestoresCachedViewFastThenReconnects() = runBlocking {
+    fun resumeAfterBackgroundRestoresCachedViewFastThenReconnects() { runBlocking {
         val key = readFixtureKey()
         waitForSshFixtureReady(SshKey.Pem(key))
         seedTmuxSession(key)
@@ -254,7 +254,7 @@ class FastResumeReconnectE2eTest {
 
         writeTimings()
         Unit
-    }
+    } }
 
     // ---------------------------------------------------------------- Helpers
 

--- a/app/src/androidTest/java/com/pocketshell/app/proof/Issue1078DeadSocketHandoffRedialJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/Issue1078DeadSocketHandoffRedialJourneyE2eTest.kt
@@ -176,7 +176,7 @@ class Issue1078DeadSocketHandoffRedialJourneyE2eTest {
     // AC1 — the dead-socket handoff must REDIAL within the probe budget (NOT a
     // ~90s frozen-Live stall), with input routing restored after.
     @Test
-    fun deadSocketWifiCellularHandoffRedialsWithinProbeBudgetNotFrozenLive() = runBlocking<Unit> {
+    fun deadSocketWifiCellularHandoffRedialsWithinProbeBudgetNotFrozenLive() { runBlocking<Unit> {
         val hostRowTag = requireNotNull(seededHostRowTag)
         attachSeededTmuxSession(hostRowTag)
         waitForVisibleTerminal("initial attach") { it.contains(READY_MARKER) }
@@ -266,12 +266,12 @@ class Issue1078DeadSocketHandoffRedialJourneyE2eTest {
         ) { it.contains("AFTER-$MARKER") }
         captureViewport("issue1078a-02-redialled-input-restored")
         writeTimings("issue1078a")
-    }
+    } }
 
     // AC2 — class coverage: the ALIVE-socket handoff must RIDE THROUGH with NO
     // spurious redial (the #981/#974/#1058 win preserved), attributed to the probe.
     @Test
-    fun aliveSocketWifiCellularHandoffRidesThroughWithNoSpuriousRedial() = runBlocking<Unit> {
+    fun aliveSocketWifiCellularHandoffRidesThroughWithNoSpuriousRedial() { runBlocking<Unit> {
         val hostRowTag = requireNotNull(seededHostRowTag)
         attachSeededTmuxSession(hostRowTag)
         waitForVisibleTerminal("initial attach") { it.contains(READY_MARKER) }
@@ -343,7 +343,7 @@ class Issue1078DeadSocketHandoffRedialJourneyE2eTest {
         ) { it.contains("AFTER-$MARKER") }
         captureViewport("issue1078b-02-rode-through")
         writeTimings("issue1078b")
-    }
+    } }
 
     // ---------------------------------------------------------------- Helpers
 

--- a/app/src/androidTest/java/com/pocketshell/app/proof/Issue895SwitchWhileBlackBandJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/Issue895SwitchWhileBlackBandJourneyE2eTest.kt
@@ -115,7 +115,7 @@ class Issue895SwitchWhileBlackBandJourneyE2eTest {
     }
 
     @Test
-    fun dropDuringSwitchingWindowSurfacesEscapableBand() = runBlocking<Unit> {
+    fun dropDuringSwitchingWindowSurfacesEscapableBand() { runBlocking<Unit> {
         val hostRowTag = requireNotNull(seededHostRowTag)
         attachSeededTmuxSession(hostRowTag)
         waitForVisibleTerminal("initial attach") { it.contains(READY_MARKER) }
@@ -164,7 +164,7 @@ class Issue895SwitchWhileBlackBandJourneyE2eTest {
             hasTag(TMUX_SESSION_SCREEN_TAG),
         )
         writeTimings()
-    }
+    } }
 
     // -- escapable-band helpers ----------------------------------------------------
 

--- a/app/src/androidTest/java/com/pocketshell/app/proof/LongRunningSessionStabilityTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/LongRunningSessionStabilityTest.kt
@@ -158,7 +158,7 @@ class LongRunningSessionStabilityTest {
     }
 
     @Test
-    fun tenMinuteForegroundHoldRetainsTmuxSessionWithoutReconnectsOrMemoryGrowth() = runBlocking {
+    fun tenMinuteForegroundHoldRetainsTmuxSessionWithoutReconnectsOrMemoryGrowth() { runBlocking {
         assumeLongRunningTestEnabled()
         val key = readFixtureKey()
         waitForSshFixtureReady(SshKey.Pem(key))
@@ -314,7 +314,7 @@ class LongRunningSessionStabilityTest {
             runCatching { cleanupTmuxSession(key, sessionName, workDir) }
         }
         Unit
-    }
+    } }
 
     /**
      * Issue #794 fast regression: a ~90s STEADY foreground hold that
@@ -337,7 +337,7 @@ class LongRunningSessionStabilityTest {
      * assertEquals(0, reconnectEvents).
      */
     @Test
-    fun steadyForegroundHoldDoesNotFlapTransportEveryTenSeconds() = runBlocking {
+    fun steadyForegroundHoldDoesNotFlapTransportEveryTenSeconds() { runBlocking {
         val key = readFixtureKey()
         waitForSshFixtureReady(SshKey.Pem(key))
 
@@ -388,7 +388,7 @@ class LongRunningSessionStabilityTest {
             runCatching { cleanupTmuxSession(key, sessionName, workDir) }
         }
         Unit
-    }
+    } }
 
     // ---------------- helpers ----------------
 

--- a/app/src/androidTest/java/com/pocketshell/app/proof/MobileSpuriousReconnectE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/MobileSpuriousReconnectE2eTest.kt
@@ -149,7 +149,7 @@ class MobileSpuriousReconnectE2eTest {
 
     // (a) cause #1 — the link SURVIVED the brief dip: ride through, NO redial.
     @Test
-    fun briefLossRestoreWithSurvivingSocketRidesThroughWithNoRedial() = runBlocking<Unit> {
+    fun briefLossRestoreWithSurvivingSocketRidesThroughWithNoRedial() { runBlocking<Unit> {
         val hostRowTag = requireNotNull(seededHostRowTag)
         attachSeededTmuxSession(hostRowTag)
         waitForVisibleTerminal("initial attach") { it.contains(READY_MARKER) }
@@ -223,12 +223,12 @@ class MobileSpuriousReconnectE2eTest {
         waitForVisibleTerminal("after ride-through terminal") { it.contains(READY_MARKER) }
         captureViewport("issue1042a-02-rode-through")
         writeTimings("issue1042a")
-    }
+    } }
 
     // (b2) cause #1 ARM 2 — keepalive aged out but the bounded probe ANSWERS over the
     // live socket: must RIDE THROUGH with no redial (cause="probe_answered").
     @Test
-    fun briefLossRestoreWhereBoundedProbeAnswersRidesThrough() = runBlocking<Unit> {
+    fun briefLossRestoreWhereBoundedProbeAnswersRidesThrough() { runBlocking<Unit> {
         val hostRowTag = requireNotNull(seededHostRowTag)
         attachSeededTmuxSession(hostRowTag)
         waitForVisibleTerminal("initial attach") { it.contains(READY_MARKER) }
@@ -289,7 +289,7 @@ class MobileSpuriousReconnectE2eTest {
         waitForVisibleTerminal("after probe-answered terminal") { it.contains(READY_MARKER) }
         captureViewport("issue1042b2-02-rode-through")
         writeTimings("issue1042b2")
-    }
+    } }
 
     // (b3) ISSUE #1065 (R5, audit C5) — the BOUNDED-PROBE ride-through arm after a
     // LONG IDLE OUTAGE, distinct from the keepalive-proven FAST PATH.
@@ -324,7 +324,7 @@ class MobileSpuriousReconnectE2eTest {
     //      "transport_proven_alive", which would mean step 1 won) and ZERO redial.
     //   7. the session rides through to Connected with a painted viewport — recovered.
     @Test
-    fun longIdleOutageThenRestoreRidesThroughViaBoundedProbeNotFastPath() = runBlocking<Unit> {
+    fun longIdleOutageThenRestoreRidesThroughViaBoundedProbeNotFastPath() { runBlocking<Unit> {
         val hostRowTag = requireNotNull(seededHostRowTag)
         attachSeededTmuxSession(hostRowTag)
         waitForVisibleTerminal("initial attach") { it.contains(READY_MARKER) }
@@ -421,11 +421,11 @@ class MobileSpuriousReconnectE2eTest {
         waitForVisibleTerminal("after bounded-probe terminal") { it.contains(READY_MARKER) }
         captureViewport("issue1065-03-rode-through")
         writeTimings("issue1065")
-    }
+    } }
 
     // (c) cause #2 — a same-identity {CELLULAR} reassoc must NOT redial.
     @Test
-    fun cellularSameIdentityReassocDoesNotRedial() = runBlocking<Unit> {
+    fun cellularSameIdentityReassocDoesNotRedial() { runBlocking<Unit> {
         val hostRowTag = requireNotNull(seededHostRowTag)
         attachSeededTmuxSession(hostRowTag)
         waitForVisibleTerminal("initial attach") { it.contains(READY_MARKER) }
@@ -473,11 +473,11 @@ class MobileSpuriousReconnectE2eTest {
         waitForVisibleTerminal("after cellular reassoc terminal") { it.contains(READY_MARKER) }
         captureViewport("issue1042c-02-no-redial")
         writeTimings("issue1042c")
-    }
+    } }
 
     // (d) cause #2 scope guard — a REAL cross-transport handoff must STILL redial.
     @Test
-    fun crossTransportHandoffStillRedials() = runBlocking<Unit> {
+    fun crossTransportHandoffStillRedials() { runBlocking<Unit> {
         val hostRowTag = requireNotNull(seededHostRowTag)
         attachSeededTmuxSession(hostRowTag)
         waitForVisibleTerminal("initial attach") { it.contains(READY_MARKER) }
@@ -526,7 +526,7 @@ class MobileSpuriousReconnectE2eTest {
         waitForVisibleTerminal("after cross-transport terminal") { it.contains(READY_MARKER) }
         captureViewport("issue1042d-02-redialled")
         writeTimings("issue1042d")
-    }
+    } }
 
     private fun currentViewModel(): TmuxSessionViewModel {
         lateinit var vm: TmuxSessionViewModel

--- a/app/src/androidTest/java/com/pocketshell/app/proof/MultiHostSessionE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/MultiHostSessionE2eTest.kt
@@ -89,7 +89,7 @@ class MultiHostSessionE2eTest {
     }
 
     @Test
-    fun switchingBetweenHostsPreservesRemoteSessionTranscript() = runBlocking {
+    fun switchingBetweenHostsPreservesRemoteSessionTranscript() { runBlocking {
         val key = readFixtureKey()
         val pem = SshKey.Pem(key)
         waitForSshFixtureReady(pem, port = AGENTS_PORT)
@@ -163,7 +163,7 @@ class MultiHostSessionE2eTest {
 
         writeTimings()
         Unit
-    }
+    } }
 
     private fun readFixtureKey(): String =
         InstrumentationRegistry.getInstrumentation()

--- a/app/src/androidTest/java/com/pocketshell/app/proof/MultiSessionSwitchJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/MultiSessionSwitchJourneyE2eTest.kt
@@ -205,7 +205,7 @@ class MultiSessionSwitchJourneyE2eTest {
     }
 
     @Test
-    fun rapidMultiSessionSwitchAlwaysShowsCorrectSessionWithoutSpuriousReconnect() = runBlocking {
+    fun rapidMultiSessionSwitchAlwaysShowsCorrectSessionWithoutSpuriousReconnect() { runBlocking {
         // Issue #788: the three live sessions (A/B/C) + DB host row + flat
         // host-detail mode were already seeded BEFORE MainActivity launched, by
         // [seedForCurrentTest] in the rule chain's `before()`. The journey is
@@ -273,7 +273,7 @@ class MultiSessionSwitchJourneyE2eTest {
         )
         writeTimings()
         Unit
-    }
+    } }
 
     /**
      * Issue #620 (the maintainer's #1 recurring ask) — the FIRST session open
@@ -297,7 +297,7 @@ class MultiSessionSwitchJourneyE2eTest {
      * is caught at PR time, not only in the release gate.
      */
     @Test
-    fun firstOpenFromHostDetailReusesWarmLeaseNoFreshHandshake() = runBlocking {
+    fun firstOpenFromHostDetailReusesWarmLeaseNoFreshHandshake() { runBlocking {
         // Issue #788: sessions + DB host row + flat mode seeded BEFORE launch by
         // the rule chain's `before()`.
         waitForHostRowPresent(hostRowTag)
@@ -371,7 +371,7 @@ class MultiSessionSwitchJourneyE2eTest {
         )
         writeTimings()
         Unit
-    }
+    } }
 
     /**
      * Issue #686 (D28, reveal/session-identity slice 1) — the SINGLE-IDENTITY
@@ -407,7 +407,7 @@ class MultiSessionSwitchJourneyE2eTest {
      * toxiproxy, no [assumeFalse(isRunningOnCi())].
      */
     @Test
-    fun backToPickerThenOpenShowsSingleTargetIdentityNeverStaleProjectCrumb() = runBlocking {
+    fun backToPickerThenOpenShowsSingleTargetIdentityNeverStaleProjectCrumb() { runBlocking {
         // Issue #788: the three sessions in DISTINCT project directories
         // (proj-a / proj-b / proj-c) + DB host row + flat mode were seeded
         // BEFORE launch by the rule chain's `before()`. With distinct crumbs a
@@ -458,7 +458,7 @@ class MultiSessionSwitchJourneyE2eTest {
         )
         writeTimings()
         Unit
-    }
+    } }
 
     /**
      * Issue #686 — back->picker->open [toSession], then assert the header is

--- a/app/src/androidTest/java/com/pocketshell/app/proof/NatIdleMappingSurvivalE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/NatIdleMappingSurvivalE2eTest.kt
@@ -90,7 +90,7 @@ class NatIdleMappingSurvivalE2eTest : NetworkFaultProofBase() {
      * Connected and a post-recovery send round-trips.
      */
     @Test
-    fun severedIdleNatMappingRecoversWithinKeepAliveBudget() = runBlocking<Unit> {
+    fun severedIdleNatMappingRecoversWithinKeepAliveBudget() { runBlocking<Unit> {
         assumeNetworkFaultProofsEnabled()
         // SHORT keepalive so the dead-transport detection budget (interval × count)
         // is small and deterministic: 3s × 3 = ~9s.
@@ -158,7 +158,7 @@ class NatIdleMappingSurvivalE2eTest : NetworkFaultProofBase() {
                 "expectation=keepalive detects half-open within budget => recovery + send",
             ),
         )
-    }
+    } }
 
     // -- helpers ------------------------------------------------------------------
 

--- a/app/src/androidTest/java/com/pocketshell/app/proof/NetworkLatencyModelE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/NetworkLatencyModelE2eTest.kt
@@ -35,7 +35,7 @@ class NetworkLatencyModelE2eTest : NetworkFaultProofBase() {
     }
 
     @Test
-    fun delayedJitteredSshRemainsUsableWithoutFalseDisconnects() = runBlocking {
+    fun delayedJitteredSshRemainsUsableWithoutFalseDisconnects() { runBlocking {
         assumeNetworkFaultProofsEnabled()
 
         val key = readFixtureKey()
@@ -88,7 +88,7 @@ class NetworkLatencyModelE2eTest : NetworkFaultProofBase() {
                 "explicit_connect_attempts=$explicitConnectAttempts",
             ),
         )
-    }
+    } }
 
     private companion object {
         const val DEGRADED_STABILITY_WINDOW_MS: Long = 5_000L

--- a/app/src/androidTest/java/com/pocketshell/app/proof/NoBackgroundWorkE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/NoBackgroundWorkE2eTest.kt
@@ -102,7 +102,7 @@ class NoBackgroundWorkE2eTest {
     }
 
     @Test
-    fun usageScheduler_doesNotTickWhileBackgrounded() = runBlocking {
+    fun usageScheduler_doesNotTickWhileBackgrounded() { runBlocking {
         val key = readFixtureKey()
         seedHostWithPocketshell(key)
 
@@ -188,7 +188,7 @@ class NoBackgroundWorkE2eTest {
             "scheduler must resume ticking on ON_START; snapshot=$snapshot final=${scheduler.tickCount}",
             scheduler.tickCount > snapshot,
         )
-    }
+    } }
 
     /**
      * Issue #450: a foreground within the grace window must cancel the
@@ -197,7 +197,7 @@ class NoBackgroundWorkE2eTest {
      * relaxation did not introduce an unbounded background timer.
      */
     @Test
-    fun graceWindow_foregroundWithinWindow_neverTearsDownAndHoldsNoTimer() = runBlocking {
+    fun graceWindow_foregroundWithinWindow_neverTearsDownAndHoldsNoTimer() { runBlocking {
         val teardowns = AtomicInteger(0)
         val foregrounds = mutableListOf<Boolean>()
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
@@ -231,7 +231,7 @@ class NoBackgroundWorkE2eTest {
         } finally {
             scope.cancel()
         }
-    }
+    } }
 
     /**
      * Issue #450: staying backgrounded past the grace window must run the
@@ -240,7 +240,7 @@ class NoBackgroundWorkE2eTest {
      * repeating background job.
      */
     @Test
-    fun graceWindow_stayingBackgroundedPastWindow_tearsDownExactlyOnce() = runBlocking {
+    fun graceWindow_stayingBackgroundedPastWindow_tearsDownExactlyOnce() { runBlocking {
         val teardowns = AtomicInteger(0)
         val foregrounds = mutableListOf<Boolean>()
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
@@ -281,7 +281,7 @@ class NoBackgroundWorkE2eTest {
         } finally {
             scope.cancel()
         }
-    }
+    } }
 
     private suspend fun waitForTickCountAtLeast(
         scheduler: UsageScheduler,

--- a/app/src/androidTest/java/com/pocketshell/app/proof/PacketLossNetworkFaultE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/PacketLossNetworkFaultE2eTest.kt
@@ -24,7 +24,7 @@ import org.junit.runner.RunWith
 class PacketLossNetworkFaultE2eTest : NetworkFaultProofBase() {
 
     @Test
-    fun sshTmuxSessionSurvivesPacketLossWithoutFalseDisconnectOrDuplicateReconnects() = runBlocking {
+    fun sshTmuxSessionSurvivesPacketLossWithoutFalseDisconnectOrDuplicateReconnects() { runBlocking {
         assumeNetworkFaultProofsEnabled()
 
         val key = readFixtureKey()
@@ -78,7 +78,7 @@ class PacketLossNetworkFaultE2eTest : NetworkFaultProofBase() {
                 "expected_duplicate_reconnects=0",
             ),
         )
-    }
+    } }
 
     private companion object {
         const val PACKET_LOSS_RATE: String = "5%"

--- a/app/src/androidTest/java/com/pocketshell/app/proof/PreExistingMultiWindowSeedE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/PreExistingMultiWindowSeedE2eTest.kt
@@ -104,7 +104,7 @@ class PreExistingMultiWindowSeedE2eTest {
     }
 
     @Test
-    fun preExistingMultiWindowSurfacesPerWindowSwitcherEntriesAndSeedsEach() = runBlocking {
+    fun preExistingMultiWindowSurfacesPerWindowSwitcherEntriesAndSeedsEach() { runBlocking {
         val hostRowTag = requireNotNull(seededHostRowTag) { "seed-before-launch host row missing" }
 
         // Open the host tree. Under createAndroidComposeRule, MainActivity cold
@@ -179,7 +179,7 @@ class PreExistingMultiWindowSeedE2eTest {
         captureViewport("issue782-03-window0-after-reselect")
 
         Unit
-    }
+    } }
 
     // ---------------------------------------------------------------- Helpers
 

--- a/app/src/androidTest/java/com/pocketshell/app/proof/ProjectSwitcherDropdownE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/ProjectSwitcherDropdownE2eTest.kt
@@ -91,7 +91,7 @@ class ProjectSwitcherDropdownE2eTest {
     }
 
     @Test
-    fun projectCrumbDropdownWarmSwitchesToSiblingSession() = runBlocking {
+    fun projectCrumbDropdownWarmSwitchesToSiblingSession() { runBlocking {
         val key = readFixtureKey()
         waitForSshFixtureReady(SshKey.Pem(key))
 
@@ -219,7 +219,7 @@ class ProjectSwitcherDropdownE2eTest {
 
         writeTimings()
         Unit
-    }
+    } }
 
     // ---------------------------------------------------------------- Helpers
 

--- a/app/src/androidTest/java/com/pocketshell/app/proof/PushResumeDeadSocketMainResponsiveE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/PushResumeDeadSocketMainResponsiveE2eTest.kt
@@ -137,7 +137,7 @@ class PushResumeDeadSocketMainResponsiveE2eTest : NetworkFaultProofBase() {
     }
 
     @Test
-    fun withinGraceResumeOntoDeadHeldSocketKeepsMainResponsiveDuringGraceLoopClose() =
+    fun withinGraceResumeOntoDeadHeldSocketKeepsMainResponsiveDuringGraceLoopClose() {
         runBlocking {
             assumeNetworkFaultProofsEnabled()
 
@@ -276,7 +276,7 @@ class PushResumeDeadSocketMainResponsiveE2eTest : NetworkFaultProofBase() {
                 ),
             )
             Unit
-        }
+        } }
 
     // ---- VM seams (accessed on the live VM via the launched activity) --------------
 

--- a/app/src/androidTest/java/com/pocketshell/app/proof/RealAgentReleaseGateTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/RealAgentReleaseGateTest.kt
@@ -109,7 +109,7 @@ class RealAgentReleaseGateTest {
     }
 
     @Test
-    fun seedDockerHostWritesCompleteReadyBootstrapCache() = runBlocking {
+    fun seedDockerHostWritesCompleteReadyBootstrapCache() { runBlocking {
         assumeReleaseGateEnabled()
         val key = readFixtureKey()
         val hostRowTag = seedDockerHost(key, "Real Agent Ready Cache")
@@ -138,10 +138,10 @@ class RealAgentReleaseGateTest {
             "expected release-gate seed to model an enabled pocketshell daemon",
             host.pocketshellDaemonEnabled == true,
         )
-    }
+    } }
 
     @Test
-    fun realClaudeCliRunsInTmuxPaneAndProducesJsonlConversationLog() = runBlocking {
+    fun realClaudeCliRunsInTmuxPaneAndProducesJsonlConversationLog() { runBlocking {
         assumeReleaseGateEnabled()
         val key = readFixtureKey()
         waitForSshFixtureReady(SshKey.Pem(key), port = REAL_AGENT_PORT)
@@ -193,10 +193,10 @@ class RealAgentReleaseGateTest {
             cleanupRemoteFixture(key, workDir, sessionName, claudeProjectsCwd = workDir)
         }
         Unit
-    }
+    } }
 
     @Test
-    fun realCodexCliRunsInTmuxPaneAndProducesJsonlRolloutLog() = runBlocking {
+    fun realCodexCliRunsInTmuxPaneAndProducesJsonlRolloutLog() { runBlocking {
         assumeReleaseGateEnabled()
         val key = readFixtureKey()
         waitForSshFixtureReady(SshKey.Pem(key), port = REAL_AGENT_PORT)
@@ -241,7 +241,7 @@ class RealAgentReleaseGateTest {
             cleanupRemoteFixture(key, workDir, sessionName, claudeProjectsCwd = null)
         }
         Unit
-    }
+    } }
 
     // ---------------- helpers ----------------
 

--- a/app/src/androidTest/java/com/pocketshell/app/proof/RealisticWifiStabilityNoSpuriousReconnectE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/RealisticWifiStabilityNoSpuriousReconnectE2eTest.kt
@@ -182,7 +182,7 @@ class RealisticWifiStabilityNoSpuriousReconnectE2eTest : NetworkFaultProofBase()
      * coordinates the probe to defer to the keepalive.
      */
     @Test
-    fun stableSlowControlChannelOnLiveTransportNeverRedials() = runBlocking<Unit> {
+    fun stableSlowControlChannelOnLiveTransportNeverRedials() { runBlocking<Unit> {
         val key = readFixtureKey()
         val marker = "rw${System.currentTimeMillis().toString(36).takeLast(5)}"
         val sessionName = "issue970-stable-$marker"
@@ -288,7 +288,7 @@ class RealisticWifiStabilityNoSpuriousReconnectE2eTest : NetworkFaultProofBase()
                 "expected_base=RED (probe redials at its budget regardless of keepalive)",
             ),
         )
-    }
+    } }
 
     /**
      * THE SYNTHETIC-JITTER, PER-PUSH CI VARIANT (issue #1081 — no toxiproxy, no
@@ -305,7 +305,7 @@ class RealisticWifiStabilityNoSpuriousReconnectE2eTest : NetworkFaultProofBase()
      * N-consecutive reset) is proven RED→GREEN by the pure-JVM `LivenessProbeTest`.
      */
     @Test
-    fun realisticJitteryWifiOnRealLinkNeverRedials() = runBlocking<Unit> {
+    fun realisticJitteryWifiOnRealLinkNeverRedials() { runBlocking<Unit> {
         val key = readFixtureKey()
         val marker = "jw${System.currentTimeMillis().toString(36).takeLast(5)}"
         val sessionName = "issue970-jitter-$marker"
@@ -409,7 +409,7 @@ class RealisticWifiStabilityNoSpuriousReconnectE2eTest : NetworkFaultProofBase()
                 "expected_base=RED (over-budget burst redials at its budget regardless of keepalive)",
             ),
         )
-    }
+    } }
 
     // -- ZERO-reconnect assertions (the load-bearing ones) ------------------------
 

--- a/app/src/androidTest/java/com/pocketshell/app/proof/ReconnectKebabInPlaceJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/ReconnectKebabInPlaceJourneyE2eTest.kt
@@ -129,7 +129,7 @@ class ReconnectKebabInPlaceJourneyE2eTest {
     }
 
     @Test
-    fun kebabReconnectRecoversDroppedSessionInPlaceThenSendRoundTrips() = runBlocking<Unit> {
+    fun kebabReconnectRecoversDroppedSessionInPlaceThenSendRoundTrips() { runBlocking<Unit> {
         val hostRowTag = requireNotNull(seededHostRowTag)
         val key = requireNotNull(seededKey)
         attachSeededTmuxSession(hostRowTag)
@@ -204,7 +204,7 @@ class ReconnectKebabInPlaceJourneyE2eTest {
         )
 
         writeSummary()
-    }
+    } }
 
     // -- kebab + indicator helpers -------------------------------------------------
 

--- a/app/src/androidTest/java/com/pocketshell/app/proof/ReconnectPartialBlankReseedJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/ReconnectPartialBlankReseedJourneyE2eTest.kt
@@ -167,7 +167,7 @@ class ReconnectPartialBlankReseedJourneyE2eTest {
     }
 
     @Test
-    fun withinGraceReattachRestoresFullViewportNotJustTheLiveLine() = runBlocking {
+    fun withinGraceReattachRestoresFullViewportNotJustTheLiveLine() { runBlocking {
         val key = readFixtureKey()
         seededKey = key
         waitForSshFixtureReady(SshKey.Pem(key))
@@ -255,7 +255,7 @@ class ReconnectPartialBlankReseedJourneyE2eTest {
         writeSummary()
         writeTimings()
         Unit
-    }
+    } }
 
     /**
      * Issue #879 — a BEYOND-GRACE reconnect of a static-banner SHELL pane must come back
@@ -273,9 +273,9 @@ class ReconnectPartialBlankReseedJourneyE2eTest {
      * assertion fails. GREEN with the fix.
      */
     @Test
-    fun beyondGraceReconnectFullyRepaintsShellPane() = runBlocking {
+    fun beyondGraceReconnectFullyRepaintsShellPane() { runBlocking {
         runBeyondGraceFullyRepaintsJourney(altScreen = false, namePrefix = "issue879-shell")
-    }
+    } }
 
     /**
      * Issue #879 — class coverage (D32 G2): a BEYOND-GRACE reconnect of an IDLE
@@ -289,9 +289,9 @@ class ReconnectPartialBlankReseedJourneyE2eTest {
      * painted on the fresh View.
      */
     @Test
-    fun beyondGraceReconnectFullyRepaintsIdleAltScreenPane() = runBlocking {
+    fun beyondGraceReconnectFullyRepaintsIdleAltScreenPane() { runBlocking {
         runBeyondGraceFullyRepaintsJourney(altScreen = true, namePrefix = "issue879-altscreen")
-    }
+    } }
 
     /**
      * Shared body for both #879 beyond-grace tests. [altScreen] selects whether the seeded

--- a/app/src/androidTest/java/com/pocketshell/app/proof/ReconnectRepaintE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/ReconnectRepaintE2eTest.kt
@@ -137,7 +137,7 @@ class ReconnectRepaintE2eTest {
     }
 
     @Test
-    fun reconnectRepaintsFullPaneContentNotJustLiveDeltas() = runBlocking {
+    fun reconnectRepaintsFullPaneContentNotJustLiveDeltas() { runBlocking {
         val key = fixtureKey
 
         // ---- (1) Tap host, attach to the seeded session.
@@ -212,7 +212,7 @@ class ReconnectRepaintE2eTest {
         writeTimings()
         writeSummary()
         Unit
-    }
+    } }
 
     // ---------------------------------------------------------------- Helpers
 

--- a/app/src/androidTest/java/com/pocketshell/app/proof/RedrawFullViewportReseedJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/RedrawFullViewportReseedJourneyE2eTest.kt
@@ -133,9 +133,9 @@ class RedrawFullViewportReseedJourneyE2eTest {
      * over the warm session, with no reconnect surface.
      */
     @Test
-    fun redrawRestoresFullViewportOnPartialBlackShellPane() = runBlocking {
+    fun redrawRestoresFullViewportOnPartialBlackShellPane() { runBlocking {
         runRedrawJourney(altScreen = false, namePrefix = "issue892-shell")
-    }
+    } }
 
     /**
      * Issue #892 — class coverage (D32 G2): Redraw must ALSO restore an idle
@@ -144,9 +144,9 @@ class RedrawFullViewportReseedJourneyE2eTest {
      * nothing incrementally heals it — without Redraw it stays black indefinitely.
      */
     @Test
-    fun redrawRestoresFullViewportOnIdleAltScreenPane() = runBlocking {
+    fun redrawRestoresFullViewportOnIdleAltScreenPane() { runBlocking {
         runRedrawJourney(altScreen = true, namePrefix = "issue892-altscreen")
-    }
+    } }
 
     private suspend fun runRedrawJourney(altScreen: Boolean, namePrefix: String) {
         val key = readFixtureKey()

--- a/app/src/androidTest/java/com/pocketshell/app/proof/RedrawNonDestructiveNearBlankCaptureE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/RedrawNonDestructiveNearBlankCaptureE2eTest.kt
@@ -101,7 +101,7 @@ class RedrawNonDestructiveNearBlankCaptureE2eTest {
     }
 
     @Test
-    fun redrawKeepsRichContentWhenRemoteCaptureIsNearBlank(): Unit = runBlocking {
+    fun redrawKeepsRichContentWhenRemoteCaptureIsNearBlank(): Unit { runBlocking {
         val key = readFixtureKey()
         seededKey = key
         waitForSshFixtureReady(SshKey.Pem(key))
@@ -157,7 +157,7 @@ class RedrawNonDestructiveNearBlankCaptureE2eTest {
         )
 
         writeSummary()
-    }
+    } }
 
     // ---------------------------------------------------------------- Helpers
 

--- a/app/src/androidTest/java/com/pocketshell/app/proof/RideThroughInterruptionE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/RideThroughInterruptionE2eTest.kt
@@ -35,7 +35,7 @@ import org.junit.runner.RunWith
 class RideThroughInterruptionE2eTest : NetworkFaultProofBase() {
 
     @Test
-    fun briefLinkCutRidesThroughWithoutDisconnectOrTeardown() = runBlocking {
+    fun briefLinkCutRidesThroughWithoutDisconnectOrTeardown() { runBlocking {
         assumeNetworkFaultProofsEnabled()
 
         val key = readFixtureKey()
@@ -81,10 +81,10 @@ class RideThroughInterruptionE2eTest : NetworkFaultProofBase() {
                 "connect_attempt_delta=${TMUX_CONNECT_ATTEMPTS.get() - attemptsBefore}",
             ),
         )
-    }
+    } }
 
     @Test
-    fun sustainedLinkCutReconnectsCleanlyWithoutHang() = runBlocking {
+    fun sustainedLinkCutReconnectsCleanlyWithoutHang() { runBlocking {
         assumeNetworkFaultProofsEnabled()
 
         val key = readFixtureKey()
@@ -135,7 +135,7 @@ class RideThroughInterruptionE2eTest : NetworkFaultProofBase() {
                 "connect_attempt_delta=${TMUX_CONNECT_ATTEMPTS.get() - attemptsBefore}",
             ),
         )
-    }
+    } }
 
     private companion object {
         const val BRIEF_BLIP_MS: Long = 5_000L

--- a/app/src/androidTest/java/com/pocketshell/app/proof/SendNoReconnectE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/SendNoReconnectE2eTest.kt
@@ -140,7 +140,7 @@ class SendNoReconnectE2eTest {
     }
 
     @Test
-    fun sendingOnAWarmConnectionDoesNotReconnectOrBlankViewport() = runBlocking<Unit> {
+    fun sendingOnAWarmConnectionDoesNotReconnectOrBlankViewport() { runBlocking<Unit> {
         val key = requireNotNull(seededKey)
         val hostRowTag = requireNotNull(seededHostRowTag)
         val baselineSshdPids = listSshdPidsForTestuser(key)
@@ -207,7 +207,7 @@ class SendNoReconnectE2eTest {
         assertNoReconnectDiagnostics("after send")
         captureViewport("issue872-02-after-send")
         writeTimings()
-    }
+    } }
 
     private fun attachSeededTmuxSession(hostRowTag: String) {
         compose.waitUntil(timeoutMillis = HOST_ROW_TIMEOUT_MS) {

--- a/app/src/androidTest/java/com/pocketshell/app/proof/ServerDeathReconnectNoResurrectE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/ServerDeathReconnectNoResurrectE2eTest.kt
@@ -125,7 +125,7 @@ class ServerDeathReconnectNoResurrectE2eTest {
     }
 
     @Test
-    fun serverDeathOnReconnectDropsToListAndNeverResurrects() = runBlocking {
+    fun serverDeathOnReconnectDropsToListAndNeverResurrects() { runBlocking {
         val key = fixtureKey
 
         // ---- (1) Attach to the primary seeded session via the normal journey.
@@ -206,7 +206,7 @@ class ServerDeathReconnectNoResurrectE2eTest {
 
         writeTimings()
         Unit
-    }
+    } }
 
     // ---------------------------------------------------------------- Helpers
 

--- a/app/src/androidTest/java/com/pocketshell/app/proof/SessionSwipeSwitchE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/SessionSwipeSwitchE2eTest.kt
@@ -149,7 +149,7 @@ class SessionSwipeSwitchE2eTest {
     }
 
     @Test
-    fun swipeDownPagerSwitchesSessionReusingSshAndDetaching() = runBlocking {
+    fun swipeDownPagerSwitchesSessionReusingSshAndDetaching() { runBlocking {
         val key = readFixtureKey()
         waitForSshFixtureReady(SshKey.Pem(key))
 
@@ -319,7 +319,7 @@ class SessionSwipeSwitchE2eTest {
         )
 
         Unit
-    }
+    } }
 
     /**
      * Open the session pager with a swipe-DOWN gesture, then swipe it one page

--- a/app/src/androidTest/java/com/pocketshell/app/proof/SilentDropSyntheticSeamJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/SilentDropSyntheticSeamJourneyE2eTest.kt
@@ -131,7 +131,7 @@ class SilentDropSyntheticSeamJourneyE2eTest {
     }
 
     @Test
-    fun syntheticSilentDropSurfacesIndicatorThenAutoRecoversWithoutSwitchDance() =
+    fun syntheticSilentDropSurfacesIndicatorThenAutoRecoversWithoutSwitchDance() {
         runBlocking<Unit> {
             val hostRowTag = requireNotNull(seededHostRowTag)
             attachSeededTmuxSession(hostRowTag)
@@ -204,7 +204,7 @@ class SilentDropSyntheticSeamJourneyE2eTest {
                 roundTripped,
             )
             writeTimings()
-        }
+        } }
 
     /**
      * Issue #964 / #822 — the slow-but-live wifi journey, threaded against the
@@ -228,7 +228,7 @@ class SilentDropSyntheticSeamJourneyE2eTest {
      * assertions (D31/F3).
      */
     @Test
-    fun slowButLiveWifiKeepaliveRidesThroughButWedgedControlChannelStillRecovers() =
+    fun slowButLiveWifiKeepaliveRidesThroughButWedgedControlChannelStillRecovers() {
         runBlocking<Unit> {
             val hostRowTag = requireNotNull(seededHostRowTag)
             attachSeededTmuxSession(hostRowTag)
@@ -308,7 +308,7 @@ class SilentDropSyntheticSeamJourneyE2eTest {
                 recovered,
             )
             writeTimings()
-        }
+        } }
 
     // -- user-visible indicator helpers (parity with the toxiproxy spec) -----------
 

--- a/app/src/androidTest/java/com/pocketshell/app/proof/SilentMidSessionDropDetectionE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/SilentMidSessionDropDetectionE2eTest.kt
@@ -142,7 +142,7 @@ class SilentMidSessionDropDetectionE2eTest : NetworkFaultProofBase() {
      * connection-lost indicator never appears inside [DROP_DETECT_WINDOW_MS].
      */
     @Test
-    fun silentIdleDropSurfacesConnectionLostIndicatorWithoutSending() = runBlocking {
+    fun silentIdleDropSurfacesConnectionLostIndicatorWithoutSending() { runBlocking {
         assumeNetworkFaultProofsEnabled()
 
         val key = readFixtureKey()
@@ -223,7 +223,7 @@ class SilentMidSessionDropDetectionE2eTest : NetworkFaultProofBase() {
                 "FAIL until the LivenessProbe (Slice D) lands.",
             detected,
         )
-    }
+    } }
 
     /**
      * #822: after a silent drop, the SAME session must auto-recover (or recover via
@@ -236,7 +236,7 @@ class SilentMidSessionDropDetectionE2eTest : NetworkFaultProofBase() {
      * accepting state on its own.
      */
     @Test
-    fun silentDropAutoRecoversWithoutSessionSwitchDance() = runBlocking {
+    fun silentDropAutoRecoversWithoutSessionSwitchDance() { runBlocking {
         assumeNetworkFaultProofsEnabled()
 
         val key = readFixtureKey()
@@ -323,7 +323,7 @@ class SilentMidSessionDropDetectionE2eTest : NetworkFaultProofBase() {
                 "reconnect ladder (Slice C) lands.",
             recovered && roundTripped,
         )
-    }
+    } }
 
     // -- user-visible state helpers ------------------------------------------------
 

--- a/app/src/androidTest/java/com/pocketshell/app/proof/SshReconnectE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/SshReconnectE2eTest.kt
@@ -134,7 +134,7 @@ class SshReconnectE2eTest {
     }
 
     @Test
-    fun transportDropSilentlyRidesThroughAndRecoversWithoutManualTap() = runBlocking {
+    fun transportDropSilentlyRidesThroughAndRecoversWithoutManualTap() { runBlocking {
         val key = readFixtureKey()
         // Wait for the flaky-agent fixture port (2226) to accept SSH.
         // The fixture kills each accepted SSH session after ~12s, but
@@ -252,10 +252,10 @@ class SshReconnectE2eTest {
         val artifactsDir = ensureArtifactDir()
         writeSummary(artifactsDir, sessionName, marker, totalAttempts)
         Unit
-    }
+    } }
 
     @Test
-    fun nonRetryableDropShortCircuitsToManualReconnectAffordance() = runBlocking {
+    fun nonRetryableDropShortCircuitsToManualReconnectAffordance() { runBlocking {
         // Issue #440 / #444: a non-retryable failure during the auto-reconnect
         // loop (bad auth, unknown host, missing key) must NOT burn the whole
         // backoff schedule — it short-circuits straight to the manual
@@ -352,7 +352,7 @@ class SshReconnectE2eTest {
             vm.clearForTest()
         }
         Unit
-    }
+    } }
 
     // ---- helpers ----
 

--- a/app/src/androidTest/java/com/pocketshell/app/proof/StableWifiNoSpuriousReconnectE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/StableWifiNoSpuriousReconnectE2eTest.kt
@@ -150,7 +150,7 @@ class StableWifiNoSpuriousReconnectE2eTest {
     }
 
     @Test
-    fun sameSsidWifiReassociationDoesNotReconnectOrBlankViewport() = runBlocking<Unit> {
+    fun sameSsidWifiReassociationDoesNotReconnectOrBlankViewport() { runBlocking<Unit> {
         val hostRowTag = requireNotNull(seededHostRowTag)
         attachSeededTmuxSession(hostRowTag)
         waitForVisibleTerminal("initial attach") { it.contains(READY_MARKER) }
@@ -214,7 +214,7 @@ class StableWifiNoSpuriousReconnectE2eTest {
         )
 
         writeTimings()
-    }
+    } }
 
     /**
      * ISSUE #981 — a REAL validated WIFI→CELLULAR identity flip (which DOES emit,
@@ -240,7 +240,7 @@ class StableWifiNoSpuriousReconnectE2eTest {
      * viewport painted, session stays Connected (GREEN).
      */
     @Test
-    fun realValidatedHandoffWhileTransportProvenAliveDoesNotReconnect() = runBlocking<Unit> {
+    fun realValidatedHandoffWhileTransportProvenAliveDoesNotReconnect() { runBlocking<Unit> {
         val hostRowTag = requireNotNull(seededHostRowTag)
         attachSeededTmuxSession(hostRowTag)
         waitForVisibleTerminal("initial attach") { it.contains(READY_MARKER) }
@@ -321,7 +321,7 @@ class StableWifiNoSpuriousReconnectE2eTest {
         }
 
         writeTimings()
-    }
+    } }
 
     private fun currentViewModel(): TmuxSessionViewModel {
         lateinit var vm: TmuxSessionViewModel

--- a/app/src/androidTest/java/com/pocketshell/app/proof/StaleLeaseSwitchRecoveryE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/StaleLeaseSwitchRecoveryE2eTest.kt
@@ -35,7 +35,7 @@ import org.junit.runner.RunWith
 class StaleLeaseSwitchRecoveryE2eTest : NetworkFaultProofBase() {
 
     @Test
-    fun openingSecondSessionOverStaleLeaseAutoRecoversWithoutDisconnectBand() = runBlocking {
+    fun openingSecondSessionOverStaleLeaseAutoRecoversWithoutDisconnectBand() { runBlocking {
         assumeNetworkFaultProofsEnabled()
 
         val key = readFixtureKey()
@@ -103,7 +103,7 @@ class StaleLeaseSwitchRecoveryE2eTest : NetworkFaultProofBase() {
             ),
         )
         Unit
-    }
+    } }
 
     private companion object {
         // Long enough that the clean socket drop has fully killed the warm

--- a/app/src/androidTest/java/com/pocketshell/app/proof/StaleRenderHealOnLiveTransportJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/StaleRenderHealOnLiveTransportJourneyE2eTest.kt
@@ -131,7 +131,7 @@ class StaleRenderHealOnLiveTransportJourneyE2eTest {
      * (D32 G2).
      */
     @Test
-    fun staleRenderHealsWhileTransportStaysConnectedAcrossAllKinds() = runBlocking {
+    fun staleRenderHealsWhileTransportStaysConnectedAcrossAllKinds() { runBlocking {
         val key = readFixtureKey()
         seededKey = key
         waitForSshFixtureReady(SshKey.Pem(key))
@@ -155,7 +155,7 @@ class StaleRenderHealOnLiveTransportJourneyE2eTest {
         for (kind in StaleKind.values()) {
             runStaleKind(kind)
         }
-    }
+    } }
 
     private enum class StaleKind { FULLY_BLANK, SCATTERED_FRAGMENT, STALE_AFTER_BURST }
 

--- a/app/src/androidTest/java/com/pocketshell/app/proof/StrictModeNoNetworkOnMainE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/StrictModeNoNetworkOnMainE2eTest.kt
@@ -147,7 +147,7 @@ class StrictModeNoNetworkOnMainE2eTest {
     }
 
     @Test
-    fun fullAttachAndDisconnectCycleEmitsNoNetworkOnMainViolation() = runBlocking {
+    fun fullAttachAndDisconnectCycleEmitsNoNetworkOnMainViolation() { runBlocking {
         val key = InstrumentationRegistry.getInstrumentation()
             .context
             .assets
@@ -238,7 +238,7 @@ class StrictModeNoNetworkOnMainE2eTest {
             "expected the SSH session smoke test to have produced a live session",
             session,
         )
-    }
+    } }
 
     private companion object {
         const val LOG_TAG = "Issue166StrictModeNet"

--- a/app/src/androidTest/java/com/pocketshell/app/proof/SwitchStaleCaptureSessionBodyJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/SwitchStaleCaptureSessionBodyJourneyE2eTest.kt
@@ -116,7 +116,7 @@ class SwitchStaleCaptureSessionBodyJourneyE2eTest {
     }
 
     @Test
-    fun switchToBWhileAStillStreamsShowsBInBodyAndHeaderNoStaleBoundary() = runBlocking {
+    fun switchToBWhileAStillStreamsShowsBInBodyAndHeaderNoStaleBoundary() { runBlocking {
         val key = requireNotNull(seededKey) { "seed-before-launch key missing" }
         val hostRowTag = requireNotNull(seededHostRowTag) { "seed-before-launch host row missing" }
 
@@ -160,7 +160,7 @@ class SwitchStaleCaptureSessionBodyJourneyE2eTest {
         writeSummary()
         writeTimings()
         Unit
-    }
+    } }
 
     /**
      * Switch A→B (Back → picker → tap B), then assert from the rendered PANE

--- a/app/src/androidTest/java/com/pocketshell/app/proof/SystemBackForegroundE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/SystemBackForegroundE2eTest.kt
@@ -80,7 +80,7 @@ class SystemBackForegroundE2eTest {
     }
 
     @Test
-    fun systemBackOnHostDetailAndTerminalKeepsAppForegrounded() = kotlinx.coroutines.runBlocking {
+    fun systemBackOnHostDetailAndTerminalKeepsAppForegrounded() { kotlinx.coroutines.runBlocking {
         val key = readFixtureKey()
         waitForSshFixtureReady(SshKey.Pem(key))
         seedTmuxSession(key)
@@ -167,7 +167,7 @@ class SystemBackForegroundE2eTest {
             )
         }
         Unit
-    }
+    } }
 
     /**
      * Wait until the host-detail (FolderList) screen is mounted. Gates on the

--- a/app/src/androidTest/java/com/pocketshell/app/proof/TmuxBracketedPasteDictationE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/TmuxBracketedPasteDictationE2eTest.kt
@@ -117,7 +117,7 @@ class TmuxBracketedPasteDictationE2eTest {
     }
 
     @Test
-    fun multiLineDictationArrivesAsBracketedPasteBlock() = runBlocking {
+    fun multiLineDictationArrivesAsBracketedPasteBlock() { runBlocking {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val key = instrumentation.context
             .assets
@@ -290,7 +290,7 @@ class TmuxBracketedPasteDictationE2eTest {
             0,
             crCount,
         )
-    }
+    } }
 
     // ----------------------------------------------------------------
     // helpers

--- a/app/src/androidTest/java/com/pocketshell/app/proof/TmuxDetachOnBackgroundE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/TmuxDetachOnBackgroundE2eTest.kt
@@ -135,7 +135,7 @@ class TmuxDetachOnBackgroundE2eTest {
     }
 
     @Test
-    fun backgroundingTheAppDetachesTmuxAndDesktopGetsFullSize() = runBlocking {
+    fun backgroundingTheAppDetachesTmuxAndDesktopGetsFullSize() { runBlocking {
         val key = readFixtureKey()
         waitForSshFixtureReady(SshKey.Pem(key))
         seedTmuxSession(key)
@@ -292,7 +292,7 @@ class TmuxDetachOnBackgroundE2eTest {
 
         writeTimings()
         Unit
-    }
+    } }
 
     // ---------------------------------------------------------------- Helpers
 

--- a/app/src/androidTest/java/com/pocketshell/app/proof/TmuxExternalUpdateDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/TmuxExternalUpdateDockerTest.kt
@@ -146,7 +146,7 @@ class TmuxExternalUpdateDockerTest {
     }
 
     @Test
-    fun externalTmuxWriteRepaintsAttachedPocketShellViewport() = runBlocking {
+    fun externalTmuxWriteRepaintsAttachedPocketShellViewport() { runBlocking {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val key = instrumentation.context
             .assets
@@ -371,10 +371,10 @@ class TmuxExternalUpdateDockerTest {
             externalRepaintMs = externalRepaintMs,
         )
         Unit
-    }
+    } }
 
     @Test
-    fun codexScaleExternalTmuxBurstKeepsViewportResponsive() = runBlocking {
+    fun codexScaleExternalTmuxBurstKeepsViewportResponsive() { runBlocking {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val key = instrumentation.context
             .assets
@@ -542,7 +542,7 @@ class TmuxExternalUpdateDockerTest {
             doneMarker in afterArtifact.visibleText || doneMarker in synchronized(outputDrain) { outputDrain.toString() },
         )
         Unit
-    }
+    } }
 
     // ----------------------------------------------------------------
     // helpers

--- a/app/src/androidTest/java/com/pocketshell/app/proof/TmuxKeyBarCtrlComboE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/TmuxKeyBarCtrlComboE2eTest.kt
@@ -110,7 +110,7 @@ class TmuxKeyBarCtrlComboE2eTest {
     }
 
     @Test
-    fun hotkeysPanelCtrlCInterruptsRunningProcessAndEnterSubmits() = runBlocking {
+    fun hotkeysPanelCtrlCInterruptsRunningProcessAndEnterSubmits() { runBlocking {
         val key = readFixtureKey()
         waitForSshFixtureReady(SshKey.Pem(key))
         seedTmuxSession(key)
@@ -344,7 +344,7 @@ class TmuxKeyBarCtrlComboE2eTest {
                 "key-bar Enter submitted the pending line; got:\n$transcript",
             transcript.split(ENTER_MARKER).size >= 3,
         )
-    }
+    } }
 
     /**
      * Issue #1091 / AC1 — the maintainer was TRAPPED in `nano` (a fully
@@ -369,7 +369,7 @@ class TmuxKeyBarCtrlComboE2eTest {
      * `*-visible-terminal.txt` + `nano-summary.txt` + `timings.txt`.
      */
     @Test
-    fun hotkeysPanelCtrlOAndCtrlXSaveAndExitNanoFromPanelControls() = runBlocking {
+    fun hotkeysPanelCtrlOAndCtrlXSaveAndExitNanoFromPanelControls() { runBlocking {
         val key = readFixtureKey()
         waitForSshFixtureReady(SshKey.Pem(key))
         seedTmuxSession(key)
@@ -507,7 +507,7 @@ class TmuxKeyBarCtrlComboE2eTest {
                 "'$NANO_CONTENT' from disk, proving the `^O` save persisted; got tail:\n$catOutput",
             catOutput.contains(NANO_CONTENT),
         )
-    }
+    } }
 
     private fun buildNanoSummary(nanoFile: String): String = buildString {
         appendLine("issue=1091 scenario=nano-save-exit-from-hotkeys-panel")

--- a/app/src/androidTest/java/com/pocketshell/app/proof/TmuxOrphanClientCleanupE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/TmuxOrphanClientCleanupE2eTest.kt
@@ -116,7 +116,7 @@ class TmuxOrphanClientCleanupE2eTest {
     }
 
     @Test
-    fun closingTheAppDoesNotLeaveAnOrphanCcClient() = runBlocking {
+    fun closingTheAppDoesNotLeaveAnOrphanCcClient() { runBlocking {
         val key = readFixtureKey()
         waitForSshFixtureReady(SshKey.Pem(key))
 
@@ -229,7 +229,7 @@ class TmuxOrphanClientCleanupE2eTest {
 
         writeTimings()
         Unit
-    }
+    } }
 
     // ---------------------------------------------------------------- Helpers
 

--- a/app/src/androidTest/java/com/pocketshell/app/proof/TmuxSessionSwitchE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/TmuxSessionSwitchE2eTest.kt
@@ -112,7 +112,7 @@ class TmuxSessionSwitchE2eTest {
     }
 
     @Test
-    fun switchingBetweenTmuxSessionsViaDrawerDoesNotCrash() = runBlocking {
+    fun switchingBetweenTmuxSessionsViaDrawerDoesNotCrash() { runBlocking {
         val key = readFixtureKey()
         waitForSshFixtureReady(SshKey.Pem(key))
 
@@ -217,7 +217,7 @@ class TmuxSessionSwitchE2eTest {
 
         writeTimings()
         Unit
-    }
+    } }
 
     /**
      * Issue #652 (epic #636): the SEVERE wrong-project regression. The
@@ -238,7 +238,7 @@ class TmuxSessionSwitchE2eTest {
      * typed now reaches A.
      */
     @Test
-    fun backThenTapSessionRowLandsInThatSessionNotAnotherOne() = runBlocking {
+    fun backThenTapSessionRowLandsInThatSessionNotAnotherOne() { runBlocking {
         val key = readFixtureKey()
         waitForSshFixtureReady(SshKey.Pem(key))
         seedTmuxSessions(key)
@@ -349,7 +349,7 @@ class TmuxSessionSwitchE2eTest {
 
         writeTimings()
         Unit
-    }
+    } }
 
     // ---------------------------------------------------------------- Helpers
 

--- a/app/src/androidTest/java/com/pocketshell/app/proof/TmuxSessionSwitchSameHostReusesSshE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/TmuxSessionSwitchSameHostReusesSshE2eTest.kt
@@ -128,7 +128,7 @@ class TmuxSessionSwitchSameHostReusesSshE2eTest {
     }
 
     @Test
-    fun sameHostSessionSwitchReusesSshTransport() = runBlocking {
+    fun sameHostSessionSwitchReusesSshTransport() { runBlocking {
         val key = readFixtureKey()
         waitForSshFixtureReady(SshKey.Pem(key))
 
@@ -283,10 +283,10 @@ class TmuxSessionSwitchSameHostReusesSshE2eTest {
 
         writeTimings()
         Unit
-    }
+    } }
 
     @Test
-    fun dashboardSameHostSessionTapReusesSshTransport() = runBlocking {
+    fun dashboardSameHostSessionTapReusesSshTransport() { runBlocking {
         val key = readFixtureKey()
         waitForSshFixtureReady(SshKey.Pem(key))
 
@@ -363,10 +363,10 @@ class TmuxSessionSwitchSameHostReusesSshE2eTest {
 
         writeTimings()
         Unit
-    }
+    } }
 
     @Test
-    fun sameHostWarmSwitchBenchmarkReportsRepeatedStats() = runBlocking {
+    fun sameHostWarmSwitchBenchmarkReportsRepeatedStats() { runBlocking {
         val key = readFixtureKey()
         waitForSshFixtureReady(SshKey.Pem(key))
 
@@ -456,7 +456,7 @@ class TmuxSessionSwitchSameHostReusesSshE2eTest {
             writeTimings()
         }
         Unit
-    }
+    } }
 
     // ---------------------------------------------------------------- Helpers
 

--- a/app/src/androidTest/java/com/pocketshell/app/proof/TmuxTerminalSurfaceFailureE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/TmuxTerminalSurfaceFailureE2eTest.kt
@@ -116,7 +116,7 @@ class TmuxTerminalSurfaceFailureE2eTest {
     }
 
     @Test
-    fun keyboardSurfaceFailureAfterLargePromptRecoversWithoutSshReconnect() = runBlocking<Unit> {
+    fun keyboardSurfaceFailureAfterLargePromptRecoversWithoutSshReconnect() { runBlocking<Unit> {
         val key = readFixtureKey()
         seededKey = key
         waitForSshFixtureReady(SshKey.Pem(key))
@@ -239,7 +239,7 @@ class TmuxTerminalSurfaceFailureE2eTest {
         )
 
         writeTimings()
-    }
+    } }
 
     // ----------------------------------------------------------------
     // ViewModel access (production seam used by the screen)

--- a/app/src/androidTest/java/com/pocketshell/app/proof/VoiceSendActivePaneStaysVisibleE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/VoiceSendActivePaneStaysVisibleE2eTest.kt
@@ -123,7 +123,7 @@ class VoiceSendActivePaneStaysVisibleE2eTest {
     }
 
     @Test
-    fun voiceSendComposerDismissResizeKeepsActivePaneVisible() = runBlocking {
+    fun voiceSendComposerDismissResizeKeepsActivePaneVisible() { runBlocking {
         val hostRowTag = requireNotNull(seededHostRowTag) { "seed-before-launch host row missing" }
         attachSeededTmuxSession(hostRowTag)
 
@@ -212,7 +212,7 @@ class VoiceSendActivePaneStaysVisibleE2eTest {
         writeSummary()
         writeTimings()
         Unit
-    }
+    } }
 
     // ---------------------------------------------------------------- Helpers
 

--- a/app/src/androidTest/java/com/pocketshell/app/proof/WarmLeaseReuseBatchCDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/WarmLeaseReuseBatchCDockerTest.kt
@@ -66,7 +66,7 @@ class WarmLeaseReuseBatchCDockerTest {
     }
 
     @Test
-    fun usageRepoBrowserAndWatchedFoldersAllReuseOneWarmTransport() = runBlocking {
+    fun usageRepoBrowserAndWatchedFoldersAllReuseOneWarmTransport() { runBlocking {
         val keyContent = InstrumentationRegistry.getInstrumentation()
             .context.assets.open("test_key").bufferedReader().use { it.readText() }
         val key = SshKey.Pem(keyContent)
@@ -185,7 +185,7 @@ class WarmLeaseReuseBatchCDockerTest {
         } finally {
             db.close()
         }
-    }
+    } }
 
     private fun writeKeyToFile(content: String): String {
         val ctx = InstrumentationRegistry.getInstrumentation().targetContext

--- a/app/src/androidTest/java/com/pocketshell/app/proof/WarmLeaseReuseDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/WarmLeaseReuseDockerTest.kt
@@ -55,7 +55,7 @@ class WarmLeaseReuseDockerTest {
     }
 
     @Test
-    fun autocompleteAssistantAndEnvAllReuseOneWarmTransport() = runBlocking {
+    fun autocompleteAssistantAndEnvAllReuseOneWarmTransport() { runBlocking {
         val keyContent = InstrumentationRegistry.getInstrumentation()
             .context.assets.open("test_key").bufferedReader().use { it.readText() }
         val key = SshKey.Pem(keyContent)
@@ -160,7 +160,7 @@ class WarmLeaseReuseDockerTest {
             "warm autocomplete probes should be faster than the cold handshake\n$summary",
             warmAvg < firstLatency.toDouble() || firstLatency < 1_000L,
         )
-    }
+    } }
 
     private fun writeKeyToFile(content: String): String {
         val ctx = InstrumentationRegistry.getInstrumentation().targetContext

--- a/app/src/androidTest/java/com/pocketshell/app/proof/WithinGraceResumeRideThroughE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/WithinGraceResumeRideThroughE2eTest.kt
@@ -74,7 +74,7 @@ class WithinGraceResumeRideThroughE2eTest : NetworkFaultProofBase() {
     }
 
     @Test
-    fun withinGraceForegroundDuringLinkCutRidesThroughWithoutReconnect() = runBlocking {
+    fun withinGraceForegroundDuringLinkCutRidesThroughWithoutReconnect() { runBlocking {
         assumeNetworkFaultProofsEnabled()
 
         val key = readFixtureKey()
@@ -183,7 +183,7 @@ class WithinGraceResumeRideThroughE2eTest : NetworkFaultProofBase() {
                 "probe_results=" + causeTrail.count { it.fields["stage"] == "tmux_probe_result" },
             ),
         )
-    }
+    } }
 
     /**
      * Issue #754 (slice 1c-iv-c): the maintainer's #1 dogfood blocker, reproduced as the
@@ -223,7 +223,7 @@ class WithinGraceResumeRideThroughE2eTest : NetworkFaultProofBase() {
      * PASSES after the fix.
      */
     @Test
-    fun withinGraceForegroundConfirmedDeadDoesNotShowAttachingOverlayOrReconnect() = runBlocking {
+    fun withinGraceForegroundConfirmedDeadDoesNotShowAttachingOverlayOrReconnect() { runBlocking {
         assumeNetworkFaultProofsEnabled()
 
         val key = readFixtureKey()
@@ -327,7 +327,7 @@ class WithinGraceResumeRideThroughE2eTest : NetworkFaultProofBase() {
                     .joinToString(",") { "${it.fields["outcome"]}" },
             ),
         )
-    }
+    } }
 
     /**
      * Issue #754: assert the "Attaching…" SwitchingLoadingPlaceholder overlay

--- a/app/src/androidTest/java/com/pocketshell/app/proof/WithinGraceSocketDropForegroundJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/WithinGraceSocketDropForegroundJourneyE2eTest.kt
@@ -139,7 +139,7 @@ class WithinGraceSocketDropForegroundJourneyE2eTest {
     }
 
     @Test
-    fun withinGraceForegroundAfterSocketDropReseedsWithoutReconnect() = runBlocking {
+    fun withinGraceForegroundAfterSocketDropReseedsWithoutReconnect() { runBlocking {
         val key = readFixtureKey()
         seededKey = key
         waitForSshFixtureReady(SshKey.Pem(key))
@@ -236,7 +236,7 @@ class WithinGraceSocketDropForegroundJourneyE2eTest {
         writeSummary()
         writeTimings()
         Unit
-    }
+    } }
 
     // ---------------------------------------------------------------- Helpers
 

--- a/app/src/androidTest/java/com/pocketshell/app/release/ReleaseCheckerInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/release/ReleaseCheckerInstrumentedTest.kt
@@ -10,7 +10,7 @@ import org.junit.Test
 class ReleaseCheckerInstrumentedTest {
 
     @Test
-    fun check_usesFakeReleaseFeedAndReturnsExactDottedApk() = runTest {
+    fun check_usesFakeReleaseFeedAndReturnsExactDottedApk() { runTest {
         val server = MockWebServer()
         server.enqueue(
             MockResponse()
@@ -53,10 +53,10 @@ class ReleaseCheckerInstrumentedTest {
         } finally {
             server.shutdown()
         }
-    }
+    } }
 
     @Test
-    fun check_returnsNullForEqualFakeRelease() = runTest {
+    fun check_returnsNullForEqualFakeRelease() { runTest {
         val server = MockWebServer()
         server.enqueue(
             MockResponse()
@@ -85,5 +85,5 @@ class ReleaseCheckerInstrumentedTest {
         } finally {
             server.shutdown()
         }
-    }
+    } }
 }

--- a/app/src/androidTest/java/com/pocketshell/app/session/ShowKeyboardChipE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/session/ShowKeyboardChipE2eTest.kt
@@ -88,7 +88,7 @@ class ShowKeyboardChipE2eTest {
     }
 
     @Test
-    fun showKeyboardChipBringsUpSoftInput() = runBlocking {
+    fun showKeyboardChipBringsUpSoftInput() { runBlocking {
         // Issue #171 (round 2, D22 hard-cut): the "Continue with SSH"
         // raw-shell escape hatch was deleted when the host-tap surface
         // flipped to FolderListScreen. The chip behaviour this test
@@ -198,7 +198,7 @@ class ShowKeyboardChipE2eTest {
                 "ime_visible_after_tap=$shown raisedMs=$raisedMs",
             shown,
         )
-    }
+    } }
 
     // --- Host seeding ------------------------------------------------------
 

--- a/app/src/androidTest/java/com/pocketshell/app/share/SharePasteIntoSessionE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/share/SharePasteIntoSessionE2eTest.kt
@@ -117,7 +117,7 @@ class SharePasteIntoSessionE2eTest {
     }
 
     @Test
-    fun shareIntentPastesTextIntoAttachedSession() = runBlocking {
+    fun shareIntentPastesTextIntoAttachedSession() { runBlocking {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val targetContext = instrumentation.targetContext
         val key = instrumentation.context
@@ -267,7 +267,7 @@ class SharePasteIntoSessionE2eTest {
             // teardown() unregisters and closes; nothing extra here.
         }
         Unit
-    }
+    } }
 
     private suspend fun pollForPayloadInPane(
         client: TmuxClient,

--- a/app/src/androidTest/java/com/pocketshell/app/share/ShareTargetE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/share/ShareTargetE2eTest.kt
@@ -122,7 +122,7 @@ class ShareTargetE2eTest {
     }
 
     @Test
-    fun shareIntentUploadsFileToHostInbox() = runBlocking {
+    fun shareIntentUploadsFileToHostInbox() { runBlocking {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val targetContext = instrumentation.targetContext
         val key = instrumentation.context
@@ -234,7 +234,7 @@ class ShareTargetE2eTest {
             cleanInboxOnRemote(key)
         }
         Unit
-    }
+    } }
 
     /**
      * Issue #258: selecting several files and sharing them must upload
@@ -244,7 +244,7 @@ class ShareTargetE2eTest {
      * round-tripped contents.
      */
     @Test
-    fun shareMultipleIntentUploadsEveryFileToHostInbox() = runBlocking {
+    fun shareMultipleIntentUploadsEveryFileToHostInbox() { runBlocking {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val targetContext = instrumentation.targetContext
         val key = instrumentation.context
@@ -366,7 +366,7 @@ class ShareTargetE2eTest {
             cleanInboxOnRemote(key)
         }
         Unit
-    }
+    } }
 
     /**
      * Issue #473: share a file targeting a specific PROJECT. Seeds a
@@ -376,7 +376,7 @@ class ShareTargetE2eTest {
      * round-tripped contents (and that `.inbox/` was created on demand).
      */
     @Test
-    fun shareIntentUploadsFileToProjectInbox() = runBlocking {
+    fun shareIntentUploadsFileToProjectInbox() { runBlocking {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val targetContext = instrumentation.targetContext
         val key = instrumentation.context
@@ -470,7 +470,7 @@ class ShareTargetE2eTest {
             cleanProjectOnRemote(key, projectPath)
         }
         Unit
-    }
+    } }
 
     /**
      * Issue #507: the share destination picker must offer the
@@ -490,7 +490,7 @@ class ShareTargetE2eTest {
      * project) is captured as authoritative UI evidence.
      */
     @Test
-    fun shareIntentUploadsFileToOpenSessionProject() = runBlocking {
+    fun shareIntentUploadsFileToOpenSessionProject() { runBlocking {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val targetContext = instrumentation.targetContext
         val key = instrumentation.context
@@ -652,7 +652,7 @@ class ShareTargetE2eTest {
             cleanProjectOnRemote(key, projectPath)
         }
         Unit
-    }
+    } }
 
     /**
      * Issue #560: an active session must be offered as a share destination,
@@ -668,7 +668,7 @@ class ShareTargetE2eTest {
      * row) is captured as authoritative UI evidence.
      */
     @Test
-    fun shareIntentStagesFileIntoActiveSession() = runBlocking {
+    fun shareIntentStagesFileIntoActiveSession() { runBlocking {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val targetContext = instrumentation.targetContext
         val key = instrumentation.context
@@ -834,7 +834,7 @@ class ShareTargetE2eTest {
             runCatching { cleanAttachmentScope(key, hostId, sessionName) }
         }
         Unit
-    }
+    } }
 
     private suspend fun pollRemoteUntilAttachmentExists(
         key: String,

--- a/app/src/androidTest/java/com/pocketshell/app/snippets/SnippetPickerTmuxZOrderDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/snippets/SnippetPickerTmuxZOrderDockerTest.kt
@@ -88,7 +88,7 @@ class SnippetPickerTmuxZOrderDockerTest {
     }
 
     @Test
-    fun snippetPickerIsFullyVisibleAboveKeyBarOnTmuxScreen() = runBlocking {
+    fun snippetPickerIsFullyVisibleAboveKeyBarOnTmuxScreen() { runBlocking {
         val sshPort = resolveSshPort()
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val appContext = instrumentation.targetContext
@@ -175,7 +175,7 @@ class SnippetPickerTmuxZOrderDockerTest {
             runCatching { withTimeout(20_000) { killStaleTmuxSession(sshKey, sshPort) } }
         }
         Unit
-    }
+    } }
 
     // Issue #761: ensure the seeded folder ends EXPANDED with its session row
     // visible, independent of #471's auto-expand starting state. Toggle the

--- a/app/src/androidTest/java/com/pocketshell/app/snippets/SnippetsScreenTabsTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/snippets/SnippetsScreenTabsTest.kt
@@ -42,7 +42,7 @@ class SnippetsScreenTabsTest {
     private var hostId: Long = 0L
 
     @Before
-    fun setUp() = runBlocking {
+    fun setUp() { runBlocking {
         db = Room.inMemoryDatabaseBuilder(
             ApplicationProvider.getApplicationContext(),
             AppDatabase::class.java,
@@ -66,7 +66,7 @@ class SnippetsScreenTabsTest {
         )
         viewModel = SnippetsViewModel(db.snippetDao())
         commandTemplatesViewModel = CommandTemplatesViewModel(db.commandTemplateDao())
-    }
+    } }
 
     @After
     fun tearDown() {
@@ -74,7 +74,7 @@ class SnippetsScreenTabsTest {
     }
 
     @Test
-    fun managerTabs_filterPromptsAndCommands() = runBlocking {
+    fun managerTabs_filterPromptsAndCommands() { runBlocking {
         db.snippetDao().insert(
             SnippetEntity(
                 hostId = hostId,
@@ -112,7 +112,7 @@ class SnippetsScreenTabsTest {
 
         compose.onNodeWithText("List files").assertIsDisplayed()
         compose.onNodeWithText("Continue task").assertDoesNotExist()
-    }
+    } }
 
     @Test
     fun addSnippet_defaultsToSelectedTabKind() {

--- a/app/src/androidTest/java/com/pocketshell/app/terminal/TerminalKeyboardStressTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/terminal/TerminalKeyboardStressTest.kt
@@ -109,7 +109,7 @@ class TerminalKeyboardStressTest {
     }
 
     @Test
-    fun typingAndKeyboardToggleStayResponsiveUnderLiveOutput() = runBlocking {
+    fun typingAndKeyboardToggleStayResponsiveUnderLiveOutput() { runBlocking {
         // Issue #142 re-enabled this test on CI by decoupling the IME-ack
         // measurement from the layout-stable measurement. The old
         // `totalHideMs < 3000` ceiling conflated a slow `dumpsys input_method`
@@ -476,7 +476,7 @@ class TerminalKeyboardStressTest {
                 "be observing a frozen frame); distinct=${viewportHashes.toSet().size} samples=${viewportHashes.size}",
             viewportHashes.toSet().size >= 3,
         )
-    }
+    } }
 
     // --- IME helpers -------------------------------------------------------
 

--- a/app/src/androidTest/java/com/pocketshell/app/terminal/TerminalLabDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/terminal/TerminalLabDockerTest.kt
@@ -65,16 +65,16 @@ class TerminalLabDockerTest {
     }
 
     @Test
-    fun terminalLabConnectsAndRunsStressCommandsThroughInputPath() = runBlocking {
+    fun terminalLabConnectsAndRunsStressCommandsThroughInputPath() { runBlocking {
         runTerminalWorkbench(
             markerPrefix = "pslab",
             capturePrefix = "",
             holdOpenMs = 0L,
         )
-    }
+    } }
 
     @Test
-    fun terminalWorkbenchKeepsDockerShellOpenForVisualIteration() = runBlocking {
+    fun terminalWorkbenchKeepsDockerShellOpenForVisualIteration() { runBlocking {
         val holdOpenMs = InstrumentationRegistry.getArguments()
             .getString("terminalWorkbenchHoldMs")
             ?.toLongOrNull()
@@ -84,10 +84,10 @@ class TerminalLabDockerTest {
             capturePrefix = "workbench-",
             holdOpenMs = holdOpenMs,
         )
-    }
+    } }
 
     @Test
-    fun terminalWorkbenchCapturesRealAgentCliScreens() = runBlocking {
+    fun terminalWorkbenchCapturesRealAgentCliScreens() { runBlocking {
         assumeRealAgentCliScreensEnabled()
         launchTerminalWorkbench(markerPrefix = "psagent")
         assertRemotePtyMatchesTerminalGrid("agents")
@@ -143,7 +143,7 @@ class TerminalLabDockerTest {
         TerminalLabArtifacts.writeTimings(timings)
         writeArtifactSummary("agents")
         Unit
-    }
+    } }
 
     private fun assumeRealAgentCliScreensEnabled() {
         val enabled = InstrumentationRegistry.getArguments()

--- a/app/src/androidTest/java/com/pocketshell/app/terminal/TerminalLabInteractiveInputTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/terminal/TerminalLabInteractiveInputTest.kt
@@ -46,7 +46,7 @@ class TerminalLabInteractiveInputTest {
     private val captures = mutableListOf<InteractiveCapture>()
 
     @Test
-    fun fullScreenTuiAcceptsEditingNavigationEnterAndCtrlCThroughTerminalView() = runBlocking {
+    fun fullScreenTuiAcceptsEditingNavigationEnterAndCtrlCThroughTerminalView() { runBlocking {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val appContext = instrumentation.targetContext
         val key = instrumentation.context
@@ -149,7 +149,7 @@ class TerminalLabInteractiveInputTest {
             InteractiveArtifacts.writeTimings(timings)
             Unit
         }
-    }
+    } }
 
     private fun withTerminalInputConnection(
         scenario: ActivityScenario<TerminalLabActivity>,

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/AgentConversationReconnectDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/AgentConversationReconnectDockerTest.kt
@@ -130,7 +130,7 @@ class AgentConversationReconnectDockerTest {
     }
 
     @Test
-    fun reconnectRestoresConversationTabImmediatelyForAgentSession() = runBlocking {
+    fun reconnectRestoresConversationTabImmediatelyForAgentSession() { runBlocking {
         // Local-only reconnect evidence. The remember/restore/reconcile/tab
         // logic is owned on CI by AgentSessionMemoryTest + the
         // TmuxSessionViewModelTest reconnect cases; this connected reconnect
@@ -455,7 +455,7 @@ class AgentConversationReconnectDockerTest {
         } finally {
             vm.clearForTest()
         }
-    }
+    } }
 
     /**
      * Issue #778 — tapping the Conversation tab must NOT be a no-op while live
@@ -480,7 +480,7 @@ class AgentConversationReconnectDockerTest {
      * real-transcript path).
      */
     @Test
-    fun conversationTapIsHonouredBeforeDetectionLands(): Unit = runBlocking {
+    fun conversationTapIsHonouredBeforeDetectionLands(): Unit { runBlocking {
         val key = readFixtureKey()
         waitForSshFixtureReady(SshKey.Pem(key))
 
@@ -588,7 +588,7 @@ class AgentConversationReconnectDockerTest {
         } finally {
             vm.clearForTest()
         }
-    }
+    } }
 
     /**
      * Issue #818 — an AGENT session OPENS on the configured default tab
@@ -623,7 +623,7 @@ class AgentConversationReconnectDockerTest {
      *    conversation row is ever created → it stays on the raw Terminal.
      */
     @Test
-    fun agentOpensOnDefaultViewAndIsNotYankedMidSessionShellGetsNoConversationRow(): Unit = runBlocking {
+    fun agentOpensOnDefaultViewAndIsNotYankedMidSessionShellGetsNoConversationRow(): Unit { runBlocking {
         val key = readFixtureKey()
         waitForSshFixtureReady(SshKey.Pem(key))
 
@@ -1031,7 +1031,7 @@ class AgentConversationReconnectDockerTest {
         } finally {
             shellVm.clearForTest()
         }
-    }
+    } }
 
     /**
      * Issue #874 (residual black-screen): a presumed-agent pane that is
@@ -1062,7 +1062,7 @@ class AgentConversationReconnectDockerTest {
      * invokes; no synthetic stand-in for the surface logic itself.
      */
     @Test
-    fun reconciledPresumedAgentWithDroppedRowReseedsConversationPlaceholderOnDevice(): Unit = runBlocking {
+    fun reconciledPresumedAgentWithDroppedRowReseedsConversationPlaceholderOnDevice(): Unit { runBlocking {
         val key = readFixtureKey()
         waitForSshFixtureReady(SshKey.Pem(key))
 
@@ -1207,7 +1207,7 @@ class AgentConversationReconnectDockerTest {
         } finally {
             vm.clearForTest()
         }
-    }
+    } }
 
     private suspend inline fun <reified T : TmuxSessionViewModel.ConnectionStatus> waitForStatus(
         vm: TmuxSessionViewModel,

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/ConversationOpenLatencyRttDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/ConversationOpenLatencyRttDockerTest.kt
@@ -107,7 +107,7 @@ class ConversationOpenLatencyRttDockerTest {
     }
 
     @Test
-    fun coldOpenAndWarmSwitchUnderRealisticRtt(): Unit = runBlocking {
+    fun coldOpenAndWarmSwitchUnderRealisticRtt(): Unit { runBlocking {
         // Opt-in, local-only: the network-fault-proxy is not started by CI.
         Assume.assumeFalse(
             "network-fault-proxy is an opt-in Docker fixture; tests.yml does not start it",
@@ -135,7 +135,7 @@ class ConversationOpenLatencyRttDockerTest {
         // One-way latencies of 75 / 40 ms; toxiproxy delays each direction.
         measureAtRtt(key, keyPath, oneWayMs = 75)
         measureAtRtt(key, keyPath, oneWayMs = 40)
-    }
+    } }
 
     private suspend fun measureAtRtt(key: String, keyPath: String, oneWayMs: Int) {
         val rttMs = oneWayMs * 2

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/ConversationStaysReachableAfterDetectionDropsDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/ConversationStaysReachableAfterDetectionDropsDockerTest.kt
@@ -142,7 +142,7 @@ class ConversationStaysReachableAfterDetectionDropsDockerTest {
      * exists stays reachable + readable after live detection drops.
      */
     @Test
-    fun conversationStaysReachableAfterLiveDetectionDropsWithLoadedTranscript() = runBlocking {
+    fun conversationStaysReachableAfterLiveDetectionDropsWithLoadedTranscript() { runBlocking {
         val hostRowTag = requireNotNull(seededHostRowTag) { "seed-before-launch host row missing" }
         val sessionName = requireNotNull(seededSessionName) { "seed-before-launch session missing" }
 
@@ -234,7 +234,7 @@ class ConversationStaysReachableAfterDetectionDropsDockerTest {
         captureFullFrame("issue1057-conversation-after-detection-drop")
         stamp("tap_to_switch_shows_transcript_after_exit_ok")
         Unit
-    }
+    } }
 
     /**
      * #894 no-flap adjacency control: a genuine no-agent recorded shell shows NO
@@ -243,7 +243,7 @@ class ConversationStaysReachableAfterDetectionDropsDockerTest {
      * conversation-less shell.
      */
     @Test
-    fun plainShellShowsNoConversationToggleEvenThroughTeardown() = runBlocking {
+    fun plainShellShowsNoConversationToggleEvenThroughTeardown() { runBlocking {
         val hostRowTag = requireNotNull(seededHostRowTag) { "seed-before-launch host row missing" }
         val sessionName = requireNotNull(seededSessionName) { "seed-before-launch session missing" }
 
@@ -270,7 +270,7 @@ class ConversationStaysReachableAfterDetectionDropsDockerTest {
         captureFullFrame("issue1057-plain-shell-no-toggle")
         stamp("plain_shell_no_toggle_through_teardown_ok")
         Unit
-    }
+    } }
 
     // -------------------------------------------------------------- seed-before-launch
 

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/ConversationToggleVisibleForLiveAgentInShellRecordedSessionDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/ConversationToggleVisibleForLiveAgentInShellRecordedSessionDockerTest.kt
@@ -145,7 +145,7 @@ class ConversationToggleVisibleForLiveAgentInShellRecordedSessionDockerTest {
      * Runs unchanged in-fixture (the absence assertion needs no daemon classify).
      */
     @Test
-    fun plainShellRecordedSessionShowsNoConversationToggle() = runBlocking {
+    fun plainShellRecordedSessionShowsNoConversationToggle() { runBlocking {
         val hostRowTag = requireNotNull(seededHostRowTag) { "seed-before-launch host row missing" }
         val sessionName = requireNotNull(seededSessionName) { "seed-before-launch session missing" }
 
@@ -168,7 +168,7 @@ class ConversationToggleVisibleForLiveAgentInShellRecordedSessionDockerTest {
         captureFullFrame("issue962-plain-shell-no-toggle")
         stamp("plain_shell_no_toggle_ok")
         Unit
-    }
+    } }
 
     /**
      * Issue #975 (B1, classify-miss) — the REAL-PATH reproduction of the
@@ -185,7 +185,7 @@ class ConversationToggleVisibleForLiveAgentInShellRecordedSessionDockerTest {
      * "Conversation" segment.
      */
     @Test
-    fun conversationToggleReturnsForMaskedLiveClaudeInRecordedShellSession() = runBlocking {
+    fun conversationToggleReturnsForMaskedLiveClaudeInRecordedShellSession() { runBlocking {
         val hostRowTag = requireNotNull(seededHostRowTag) { "seed-before-launch host row missing" }
         val sessionName = requireNotNull(seededSessionName) { "seed-before-launch session missing" }
 
@@ -255,7 +255,7 @@ class ConversationToggleVisibleForLiveAgentInShellRecordedSessionDockerTest {
         captureFullFrame("issue975-masked-claude-toggle-returns")
         stamp("masked_claude_toggle_returned_ok")
         Unit
-    }
+    } }
 
     // -------------------------------------------------------------- seed-before-launch
 

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/Issue796ComposerOpenDuringCodexBurstProofTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/Issue796ComposerOpenDuringCodexBurstProofTest.kt
@@ -98,7 +98,7 @@ class Issue796ComposerOpenDuringCodexBurstProofTest {
     private var observedImeBottomPx: Int = 0
 
     @Test
-    fun openingComposerDuringCodexBurstDoesNotRecomposeTerminalPager() = runBlocking {
+    fun openingComposerDuringCodexBurstDoesNotRecomposeTerminalPager() { runBlocking {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val state = TerminalSurfaceState()
         val stdout = MutableSharedFlow<ByteArray>(extraBufferCapacity = 256)
@@ -282,7 +282,7 @@ class Issue796ComposerOpenDuringCodexBurstProofTest {
             state.detachExternalProducer()
         }
         Unit
-    }
+    } }
 
     // --------------------------------------------------------------- harness
 

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/Issue796ImeRecompositionProofTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/Issue796ImeRecompositionProofTest.kt
@@ -149,7 +149,7 @@ class Issue796ImeRecompositionProofTest {
     }
 
     @Test
-    fun imeInsetBurstDoesNotRecomposeTerminalSubtreeDuringCodexOutputStorm() = runBlocking {
+    fun imeInsetBurstDoesNotRecomposeTerminalSubtreeDuringCodexOutputStorm() { runBlocking {
         val sshPort = resolveSshPort()
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val appContext = instrumentation.targetContext
@@ -288,7 +288,7 @@ class Issue796ImeRecompositionProofTest {
             runCatching { withTimeout(20_000) { killSession(sshKey, sshPort) } }
         }
         Unit
-    }
+    } }
 
     // ----------------------------------------------------- keyboard-up containment
 

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/Issue887TerminalFixedUnderImeE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/Issue887TerminalFixedUnderImeE2eTest.kt
@@ -96,7 +96,7 @@ class Issue887TerminalFixedUnderImeE2eTest {
     }
 
     @Test
-    fun terminalDoesNotPanOrResizeWhenSoftKeyboardShows() = runBlocking {
+    fun terminalDoesNotPanOrResizeWhenSoftKeyboardShows() { runBlocking {
         val key = readFixtureKey()
         waitForSshFixtureReady(SshKey.Pem(key))
         seedShellSession(key)
@@ -226,7 +226,7 @@ class Issue887TerminalFixedUnderImeE2eTest {
             slopPx,
         )
         Unit
-    }
+    } }
 
     // ---------------------------------------------------------------- geometry
 

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxAttachPrefillDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxAttachPrefillDockerTest.kt
@@ -106,7 +106,7 @@ class TmuxAttachPrefillDockerTest {
     }
 
     @Test
-    fun attachExistingTmuxSessionPrefillsFullScreenQuickly() = runBlocking {
+    fun attachExistingTmuxSessionPrefillsFullScreenQuickly() { runBlocking {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val appContext = instrumentation.targetContext
         val key = instrumentation.context.assets
@@ -330,7 +330,7 @@ class TmuxAttachPrefillDockerTest {
             cleanupRemoteTmuxSession(key, sessionName)
         }
         Unit
-    }
+    } }
 
     /**
      * Issue #259 — the reattach seed must restore tmux's true cursor so the
@@ -356,7 +356,7 @@ class TmuxAttachPrefillDockerTest {
      *    after the live rewrite.
      */
     @Test
-    fun reattachSeedRestoresCursorSoLiveSpinnerRewriteDoesNotGarble() = runBlocking {
+    fun reattachSeedRestoresCursorSoLiveSpinnerRewriteDoesNotGarble() { runBlocking {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val appContext = instrumentation.targetContext
         val key = instrumentation.context.assets
@@ -473,7 +473,7 @@ class TmuxAttachPrefillDockerTest {
             cleanupRemoteTmuxSession(key, sessionName)
         }
         Unit
-    }
+    } }
 
     // ---------------------------------------------------------------- Helpers
 

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxDetectedPortForwardDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxDetectedPortForwardDockerTest.kt
@@ -98,7 +98,7 @@ class TmuxDetectedPortForwardDockerTest {
     }
 
     @Test
-    fun detectedPortOverlayForwardsAndReturnsToSession() = runBlocking {
+    fun detectedPortOverlayForwardsAndReturnsToSession() { runBlocking {
         val sshPort = resolveSshPort()
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val appContext = instrumentation.targetContext
@@ -198,7 +198,7 @@ class TmuxDetectedPortForwardDockerTest {
             runCatching { withTimeout(20_000) { killTmuxSession(sshKey, sshPort) } }
         }
         Unit
-    }
+    } }
 
     // ====================================================== fixture helpers
 

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxInSessionNewSessionCollisionDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxInSessionNewSessionCollisionDockerTest.kt
@@ -132,7 +132,7 @@ class TmuxInSessionNewSessionCollisionDockerTest {
     }
 
     @Test
-    fun inSessionNewSessionInSameFolderGetsSuffixedSessionNotCollisionAllEntryPoints() = runBlocking {
+    fun inSessionNewSessionInSameFolderGetsSuffixedSessionNotCollisionAllEntryPoints() { runBlocking {
         val key = readFixtureKey()
         waitForSshFixtureReady(SshKey.Pem(key))
         // Fresh summary file for this run (both entry points append to it).
@@ -144,7 +144,7 @@ class TmuxInSessionNewSessionCollisionDockerTest {
         // folder/session so the two runs don't interfere.
         runEntryPoint(EntryPoint.KEBAB, hostRowTag)
         runEntryPoint(EntryPoint.SWITCHER, hostRowTag)
-    }
+    } }
 
     private enum class EntryPoint(val slug: String) {
         KEBAB("kebab"),

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxResizeSessionE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxResizeSessionE2eTest.kt
@@ -88,7 +88,7 @@ class TmuxResizeSessionE2eTest {
     }
 
     @Test
-    fun attachAutomaticallySizesTmuxToPhoneViewport() = runBlocking {
+    fun attachAutomaticallySizesTmuxToPhoneViewport() { runBlocking {
         val key = readFixtureKey()
         waitForSshFixtureReady(SshKey.Pem(key))
         seedDesktopSizedSession(key)
@@ -195,7 +195,7 @@ class TmuxResizeSessionE2eTest {
             clients = clients,
         )
         Unit
-    }
+    } }
 
     // ---------------------------------------------------------------- Helpers
 

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxSessionOpencodeInputDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxSessionOpencodeInputDockerTest.kt
@@ -174,7 +174,7 @@ class TmuxSessionOpencodeInputDockerTest {
     }
 
     @Test
-    fun typedPromptLandsInOpencodeInputFrameOnTmuxSessionScreen() = runBlocking {
+    fun typedPromptLandsInOpencodeInputFrameOnTmuxSessionScreen() { runBlocking {
         val sshPort = resolveSshPort()
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val appContext = instrumentation.targetContext
@@ -352,10 +352,10 @@ class TmuxSessionOpencodeInputDockerTest {
             runCatching { withTimeout(20_000) { killStaleTmuxSession(sshKey, sshPort) } }
         }
         Unit
-    }
+    } }
 
     @Test
-    fun issue303TerminalConversationPillStaysInToolbarRow() = runBlocking {
+    fun issue303TerminalConversationPillStaysInToolbarRow() { runBlocking {
         val sshPort = resolveSshPort()
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val appContext = instrumentation.targetContext
@@ -473,10 +473,10 @@ class TmuxSessionOpencodeInputDockerTest {
             runCatching { withTimeout(20_000) { killTmuxSession(sshKey, sshPort, ISSUE_303_PLAIN_SESSION_NAME) } }
         }
         Unit
-    }
+    } }
 
     @Test
-    fun keyBarCtrlCAndCtrlDExitRunningAgentOnTmuxSessionScreen() = runBlocking {
+    fun keyBarCtrlCAndCtrlDExitRunningAgentOnTmuxSessionScreen() { runBlocking {
         val sshPort = resolveSshPort()
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val appContext = instrumentation.targetContext
@@ -551,7 +551,7 @@ class TmuxSessionOpencodeInputDockerTest {
             runCatching { withTimeout(20_000) { killTmuxSession(sshKey, sshPort, ISSUE_297_SESSION_NAME) } }
         }
         Unit
-    }
+    } }
 
     // ============================================================ Test helpers
 

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxShellComposerOcclusionE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxShellComposerOcclusionE2eTest.kt
@@ -95,7 +95,7 @@ class TmuxShellComposerOcclusionE2eTest {
     }
 
     @Test
-    fun shellComposerControlsAreVisibleAndReachableInBothKeyboardStates() = runBlocking {
+    fun shellComposerControlsAreVisibleAndReachableInBothKeyboardStates() { runBlocking {
         val key = readFixtureKey()
         waitForSshFixtureReady(SshKey.Pem(key))
         seedShellSession(key)
@@ -213,7 +213,7 @@ class TmuxShellComposerOcclusionE2eTest {
             keyBarBottomScreenPx < 0,
         )
         Unit
-    }
+    } }
 
     // ---------------------------------------------------------------- IME insets
 

--- a/app/src/androidTest/java/com/pocketshell/app/usage/UsageScreenE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/usage/UsageScreenE2eTest.kt
@@ -80,7 +80,7 @@ class UsageScreenE2eTest {
     }
 
     @Test
-    fun usagePanel_populatedCell_showsProviderCards() = runBlocking {
+    fun usagePanel_populatedCell_showsProviderCards() { runBlocking {
         val key = readFixtureKey()
         waitForSshFixtureReady(SshKey.Pem(key))
 
@@ -166,10 +166,10 @@ class UsageScreenE2eTest {
                 appendLine("route=HostList → Settings gear → Usage row → UsageScreen")
             },
         )
-    }
+    } }
 
     @Test
-    fun usagePanel_staleIncompatFlag_remoteNewerHost_stillShowsUsage() = runBlocking {
+    fun usagePanel_staleIncompatFlag_remoteNewerHost_stillShowsUsage() { runBlocking {
         // Issue #525 regression on-device: a reachable host that carries a
         // STALE `pocketshellVersionCompatible = false` (written before #514
         // replaced exact-`==` with semver, when the remote CLI 0.3.23 was
@@ -234,10 +234,10 @@ class UsageScreenE2eTest {
                 appendLine("route=HostList → Settings gear → Usage row → UsageScreen")
             },
         )
-    }
+    } }
 
     @Test
-    fun usagePanel_emptyCell_rendersBreadcrumbAndEmptyState() = runBlocking {
+    fun usagePanel_emptyCell_rendersBreadcrumbAndEmptyState() { runBlocking {
         val key = readFixtureKey()
         // Best-effort probe; an unreachable agents target still lets the
         // empty-cell test prove the panel renders for hosts that can't
@@ -299,7 +299,7 @@ class UsageScreenE2eTest {
                 appendLine("route=HostList → Settings gear → Usage row → UsageScreen")
             },
         )
-    }
+    } }
 
     private fun readFixtureKey(): String =
         InstrumentationRegistry.getInstrumentation()

--- a/scripts/check-test-validity.sh
+++ b/scripts/check-test-validity.sh
@@ -145,6 +145,24 @@ collect_test_files() {
 }
 mapfile -t ALL_TEST_FILES < <(collect_test_files)
 
+# --------------------------------------------------------------------------
+# #1154: the androidTest (connected/instrumented) roots — app/src/androidTest
+# plus every shared/*/src/androidTest. V1 (non-void @Test) is scoped to these
+# because a non-void @Test fails JUnit init SILENTLY here: when the emulator
+# journey lane is infra-down (#771) the whole test class InvalidTestClassErrors
+# and simply never runs, so the guard shows green with zero coverage (the
+# #1138 black-screen journey shipped exactly this way). Unit-job src/test
+# @Test failures are LOUD by contrast (./gradlew test runs them directly), and
+# src/test legitimately holds ~1400 void expression-body `= runTest { }`
+# methods — so V1 does NOT scan src/test.
+# --------------------------------------------------------------------------
+collect_android_test_files() {
+  [[ -d app/src/androidTest ]] && find app/src/androidTest -type f -name '*.kt'
+  find shared -maxdepth 4 -type d -path 'shared/*/src/androidTest' 2>/dev/null \
+    | while IFS= read -r d; do find "$d" -type f -name '*.kt'; done
+}
+mapfile -t ANDROID_TEST_FILES < <(collect_android_test_files)
+
 REPORT_MODE=0
 if [[ "${1:-}" == "--report" ]]; then
   REPORT_MODE=1
@@ -845,6 +863,74 @@ scan_timing1() {
 }
 
 # --------------------------------------------------------------------------
+# V1 scan (#1154) — non-void @Test (and @Before/@After lifecycle) methods in
+# androidTest. A Kotlin EXPRESSION body — `@Test fun x() = runBlocking { … }` —
+# returns the block's last expression. When that is non-Unit (e.g. the block
+# ends with `writeSummary(): File` or `capturePaintedRows(): File`), the method
+# compiles fine but is NON-VOID, so JUnit4 rejects the ENTIRE class at load with
+#   InvalidTestClassError: Method x() should be void
+# and every test in that class NEVER RUNS. The #1138 connected journey shipped
+# broken exactly this way (found in v0.4.20 release validation). It slips every
+# other gate: it COMPILES, passes check-ci-journey-harness.sh (shape only), and
+# the batched emulator lane where it would surface is infra-down (#771).
+#
+# The bulletproof, non-fragile static rule is: an androidTest JUnit lifecycle
+# method MUST use a BLOCK body (which is always Unit), never an expression body
+# (which MAY be non-Unit and cannot be statically type-checked here). So V1
+# HARD-FAILS on ANY `@Test`/`@Before`/`@After`/`@BeforeClass`/`@AfterClass`
+# method declared with an expression body `fun name(...) [: T] = …`. The fix is
+# a void block body: `fun name(...) { … }` (or wrap the call — the expression
+# body's value is discarded and the method returns Unit). No baseline: the
+# #1154 sweep converted every androidTest occurrence, so this must stay at zero.
+# --------------------------------------------------------------------------
+declare -a V1_NEW=()
+
+# JUnit4 lifecycle annotations whose method MUST be void.
+V1_JUNIT_ANNOT='@(Test|Before|After|BeforeClass|AfterClass)([[:space:](]|$)'
+# An expression-bodied fun declaration: `fun name(<no nested paren>) [: T] = <expr>`.
+# The `=` must be OUTSIDE the parens (a default-arg `=` sits inside `(...)` and is
+# excluded by `[^)]*`), so this does not false-positive on `fun f(a: Int = 5) { }`.
+V1_FUN_EXPR='^[[:space:]]*(override[[:space:]]+|public[[:space:]]+|internal[[:space:]]+|private[[:space:]]+)*fun[[:space:]]+[A-Za-z0-9_]+[[:space:]]*\([^)]*\)[[:space:]]*(:[[:space:]]*[^={]+)?='
+
+scan_void1() {
+  local file
+  for file in "${ANDROID_TEST_FILES[@]}"; do
+    [[ -z "$file" ]] && continue
+    # Cheap pre-filter: only files that even have a lifecycle annotation.
+    grep -Eq "$V1_JUNIT_ANNOT" "$file" || continue
+    local total lineno
+    total="$(wc -l < "$file")"
+    while IFS= read -r lineno; do
+      [[ -z "$lineno" ]] && continue
+      # Same-line form: `@Test fun x() = …` on the annotation line itself.
+      local annline
+      annline="$(sed -n "${lineno}p" "$file")"
+      if printf '%s' "$annline" | grep -Eq "$V1_FUN_EXPR"; then
+        V1_NEW+=("$file:$lineno")
+        continue
+      fi
+      # Otherwise walk forward to the next `fun` declaration, skipping further
+      # annotations, blank lines, and comment lines.
+      local j="$((lineno + 1))" text
+      while [[ "$j" -le "$total" ]]; do
+        text="$(sed -n "${j}p" "$file")"
+        case "$(printf '%s' "$text" | sed -e 's/^[[:space:]]*//')" in
+          '@'*|''|'//'*|'/*'*|'*'*) j=$((j + 1)); continue ;;
+        esac
+        break
+      done
+      [[ "$j" -gt "$total" ]] && continue
+      text="$(sed -n "${j}p" "$file")"
+      # Only flag when this is actually a `fun` declaration (an expression body).
+      if printf '%s' "$text" | grep -Eq '^[[:space:]]*(override[[:space:]]+|public[[:space:]]+|internal[[:space:]]+|private[[:space:]]+)*fun[[:space:]]' \
+         && printf '%s' "$text" | grep -Eq "$V1_FUN_EXPR"; then
+        V1_NEW+=("$file:$j")
+      fi
+    done < <(grep -nE "$V1_JUNIT_ANNOT" "$file" | cut -d: -f1)
+  done
+}
+
+# --------------------------------------------------------------------------
 # Validate baselines: prune entries whose file no longer exists.
 # --------------------------------------------------------------------------
 declare -a STALE_BASELINE=()
@@ -859,6 +945,7 @@ scan_fake1
 scan_await1
 scan_j1
 scan_timing1
+scan_void1
 
 echo "=============================================================="
 echo " Test-validity guard (issue #657 / F4; extended #848 / #850 / #1048)"
@@ -908,6 +995,7 @@ print_list "TIMING1 — NEW bare Thread.sleep(N) before a load-bearing assert, n
 print_list "TIMING1 — NEW runTest over a real dispatcher/thread without a pinned seam or bounded pump [advisory]" "${TIMING1_FINDINGS[@]:-}"
 print_list "TIMING1 — KNOWN baseline (real-dispatcher/thread runTest catalogued; seam adoption is per-test follow-up) [advisory]" "${TIMING1_KNOWN[@]:-}"
 print_list "TIMING1 — JUSTIFIED (opted out via // JUSTIFIED:) [advisory]" "${TIMING1_JUSTIFIED[@]:-}"
+print_list "V1 — NEW non-void expression-body @Test/@Before/@After in androidTest (JUnit InvalidTestClassError -> class never runs) [HARD FAIL]" "${V1_NEW[@]:-}"
 
 if [[ "${#STALE_BASELINE[@]}" -gt 0 ]]; then
   echo
@@ -936,6 +1024,10 @@ echo "        Shape B: drive an Android Handler/Thread worker with a bounded"
 echo "        advanceUntilIdle()+idleFor(16ms) pump to a currentTimeMillis/"
 echo "        nanoTime deadline that HARD-FAILS (TmuxSessionWarmOpenTest.pumpUntil"
 echo "        :131-150; codex pump TmuxSessionViewModelTest:5602-5657)."
+echo " V1     androidTest @Test/@Before/@After must use a VOID BLOCK body, not an"
+echo "        expression body. Change  fun x() = runBlocking { … }  to"
+echo "        fun x() { runBlocking { … } }  (the block body is always Unit; the"
+echo "        expression-body value that made the method non-void is discarded)."
 echo "--------------------------------------------------------------"
 
 # Collect the HARD-FAIL categories (A5 + C1 + J1 + TIMING1).
@@ -946,7 +1038,8 @@ for x in \
   "${J1_NEW[@]:-}" \
   "${J1_STALE_BASELINE[@]:-}" \
   "${J1_PARSER_FAILURE[@]:-}" \
-  "${TIMING1_NEW_HARD[@]:-}"; do
+  "${TIMING1_NEW_HARD[@]:-}" \
+  "${V1_NEW[@]:-}"; do
   [[ -n "$x" ]] && real_hard_fail+=("$x")
 done
 
@@ -958,12 +1051,12 @@ fi
 
 if [[ "${#real_hard_fail[@]}" -gt 0 ]]; then
   echo
-  echo "::error title=Test-validity guard (issue #657/#848/#1048)::A NEW load-bearing self-skip, ungated androidTest journey, or fixed-sleep-before-assert was found. An IME/keyboard/geometry test must not gate its assertion behind assumeTrue(...) (convert to the synthetic-inset model, #780), a connect/journey test must not gate behind assumeFalse(isRunningOnCi()) outside a genuine opt-in fault/Docker fixture (inject the state and HARD-assert, or add an inline // JUSTIFIED: comment naming the opt-in fixture), a new androidTest *E2eTest/*DockerTest class must be wired into scripts/ci-journey-suite.sh or carry a local // CI_JOURNEY_SUITE_JUSTIFIED: reason, and a connection/terminal runTest test must not use a bare Thread.sleep(N) as the only sync before a load-bearing assert (use a StandardTestDispatcher seam or a bounded advanceUntilIdle()+idleFor() deadline pump per #1048). Remove stale J1 baselines when a class is promoted or deleted."
+  echo "::error title=Test-validity guard (issue #657/#848/#1048/#1154)::A NEW load-bearing self-skip, ungated androidTest journey, fixed-sleep-before-assert, or non-void androidTest @Test method was found. An androidTest @Test/@Before/@After must use a VOID BLOCK body (fun x() { … }), never an expression body (fun x() = …) — a non-Unit expression body makes the method non-void and JUnit rejects the ENTIRE class at load (InvalidTestClassError), so it never runs (#1154). An IME/keyboard/geometry test must not gate its assertion behind assumeTrue(...) (convert to the synthetic-inset model, #780), a connect/journey test must not gate behind assumeFalse(isRunningOnCi()) outside a genuine opt-in fault/Docker fixture (inject the state and HARD-assert, or add an inline // JUSTIFIED: comment naming the opt-in fixture), a new androidTest *E2eTest/*DockerTest class must be wired into scripts/ci-journey-suite.sh or carry a local // CI_JOURNEY_SUITE_JUSTIFIED: reason, and a connection/terminal runTest test must not use a bare Thread.sleep(N) as the only sync before a load-bearing assert (use a StandardTestDispatcher seam or a bounded advanceUntilIdle()+idleFor() deadline pump per #1048). Remove stale J1 baselines when a class is promoted or deleted."
   echo
-  echo "FAIL: ${#real_hard_fail[@]} unjustified hard-fail occurrence(s) (A5 + C1 + J1 + TIMING1)."
+  echo "FAIL: ${#real_hard_fail[@]} unjustified hard-fail occurrence(s) (A5 + C1 + J1 + TIMING1 + V1)."
   exit 1
 fi
 
 echo
-echo "PASS: no new unjustified load-bearing self-skips, ungated androidTest journeys, or fixed-sleep-before-assert flakes (A5 + C1 + J1 + TIMING1)."
+echo "PASS: no new unjustified load-bearing self-skips, ungated androidTest journeys, fixed-sleep-before-assert flakes, or non-void androidTest @Test methods (A5 + C1 + J1 + TIMING1 + V1)."
 exit 0

--- a/shared/core-terminal/src/androidTest/java/com/pocketshell/core/terminal/ui/AgentPaneLinkAffordanceOffMainProofTest.kt
+++ b/shared/core-terminal/src/androidTest/java/com/pocketshell/core/terminal/ui/AgentPaneLinkAffordanceOffMainProofTest.kt
@@ -105,7 +105,7 @@ class AgentPaneLinkAffordanceOffMainProofTest {
      * (the agent pane wired no scanner), GREEN with the off-main overlay.
      */
     @Test
-    fun codexAgentPaneFilePathAndUrlAreTappable() = runBlocking {
+    fun codexAgentPaneFilePathAndUrlAreTappable() { runBlocking {
         agentPaneFilePathAndUrlAreTappable(
             kindLabel = "Codex",
             filePath = "tmp/bathtub_central_cavity_new_feedback.png",
@@ -114,7 +114,7 @@ class AgentPaneLinkAffordanceOffMainProofTest {
             urlPrefix = "See ",
             artifactName = "issue871-codex-agent-pane-tappable",
         )
-    }
+    } }
 
     /**
      * Issue #871 / G2 class coverage — CLAUDE agent pane: an ABSOLUTE file path
@@ -135,7 +135,7 @@ class AgentPaneLinkAffordanceOffMainProofTest {
      * same two shapes through the identical code.
      */
     @Test
-    fun claudeAgentPaneFilePathAndUrlAreTappable() = runBlocking {
+    fun claudeAgentPaneFilePathAndUrlAreTappable() { runBlocking {
         agentPaneFilePathAndUrlAreTappable(
             kindLabel = "Claude",
             filePath = "/home/alexey/git/pocketshell/src/MainActivity.kt",
@@ -144,7 +144,7 @@ class AgentPaneLinkAffordanceOffMainProofTest {
             urlPrefix = "Reference: ",
             artifactName = "issue871-claude-agent-pane-tappable",
         )
-    }
+    } }
 
     private suspend fun agentPaneFilePathAndUrlAreTappable(
         kindLabel: String,
@@ -313,7 +313,7 @@ class AgentPaneLinkAffordanceOffMainProofTest {
      * If this is violated the #803/#866/#796 ANR comes straight back.
      */
     @Test
-    fun agentPaneScanRunsOffMainNotPerFrame() = runBlocking {
+    fun agentPaneScanRunsOffMainNotPerFrame() { runBlocking {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val state = TerminalSurfaceState()
         val stdout = MutableSharedFlow<ByteArray>(extraBufferCapacity = 256)
@@ -440,7 +440,7 @@ class AgentPaneLinkAffordanceOffMainProofTest {
             state.detachExternalProducer()
         }
         Unit
-    }
+    } }
 
     // ---------------------------------------------------------------- Helpers
 

--- a/shared/core-terminal/src/androidTest/java/com/pocketshell/core/terminal/ui/CodexAppendBurstMainThreadProofTest.kt
+++ b/shared/core-terminal/src/androidTest/java/com/pocketshell/core/terminal/ui/CodexAppendBurstMainThreadProofTest.kt
@@ -94,7 +94,7 @@ class CodexAppendBurstMainThreadProofTest {
     val compose = createAndroidComposeRule<ComponentActivity>()
 
     @Test
-    fun denseColoredDiffAppendBurstKeepsMainThreadResponsiveAndRendersFinalState() = runBlocking {
+    fun denseColoredDiffAppendBurstKeepsMainThreadResponsiveAndRendersFinalState() { runBlocking {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val state = TerminalSurfaceState()
         val stdout = MutableSharedFlow<ByteArray>(extraBufferCapacity = 256)
@@ -251,7 +251,7 @@ class CodexAppendBurstMainThreadProofTest {
             state.detachExternalProducer()
         }
         Unit
-    }
+    } }
 
     // ---------------------------------------------------------------- Helpers
 

--- a/shared/core-terminal/src/androidTest/java/com/pocketshell/core/terminal/ui/CodexMultiChunkSeedAttachMainThreadProofTest.kt
+++ b/shared/core-terminal/src/androidTest/java/com/pocketshell/core/terminal/ui/CodexMultiChunkSeedAttachMainThreadProofTest.kt
@@ -82,7 +82,7 @@ class CodexMultiChunkSeedAttachMainThreadProofTest {
     val compose = createAndroidComposeRule<ComponentActivity>()
 
     @Test
-    fun multiChunkSeedAttachDoesNotPinTheMainThread() = runBlocking {
+    fun multiChunkSeedAttachDoesNotPinTheMainThread() { runBlocking {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val state = TerminalSurfaceState()
         val stdout = MutableSharedFlow<ByteArray>(extraBufferCapacity = 256)
@@ -316,7 +316,7 @@ class CodexMultiChunkSeedAttachMainThreadProofTest {
             state.detachExternalProducer()
         }
         Unit
-    }
+    } }
 
     // ---------------------------------------------------------------- Helpers
 

--- a/shared/core-terminal/src/androidTest/java/com/pocketshell/core/terminal/ui/CodexOutputBurstImeMainThreadProofTest.kt
+++ b/shared/core-terminal/src/androidTest/java/com/pocketshell/core/terminal/ui/CodexOutputBurstImeMainThreadProofTest.kt
@@ -110,7 +110,7 @@ class CodexOutputBurstImeMainThreadProofTest {
     private var observedImeBottomPx: Int = 0
 
     @Test
-    fun codexOutputBurstWithKeyboardUpKeepsMainThreadResponsive() = runBlocking {
+    fun codexOutputBurstWithKeyboardUpKeepsMainThreadResponsive() { runBlocking {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val state = TerminalSurfaceState()
         val stdout = MutableSharedFlow<ByteArray>(extraBufferCapacity = 256)
@@ -483,7 +483,7 @@ class CodexOutputBurstImeMainThreadProofTest {
             state.detachExternalProducer()
         }
         Unit
-    }
+    } }
 
     /**
      * Issue #796 (REOPENED) — the OTHER half of the gate: a SHELL / non-agent pane
@@ -500,7 +500,7 @@ class CodexOutputBurstImeMainThreadProofTest {
      * and scanning the viewport for a non-agent pane.
      */
     @Test
-    fun shellPaneStillRunsAffordanceScanners() = runBlocking {
+    fun shellPaneStillRunsAffordanceScanners() { runBlocking {
         val state = TerminalSurfaceState()
         val stdout = MutableSharedFlow<ByteArray>(extraBufferCapacity = 256)
         val producerScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
@@ -571,7 +571,7 @@ class CodexOutputBurstImeMainThreadProofTest {
             state.detachExternalProducer()
         }
         Unit
-    }
+    } }
 
     // ---------------------------------------------------------------- Helpers
 

--- a/shared/core-terminal/src/androidTest/java/com/pocketshell/core/terminal/ui/EngineCommandTapInstrumentedTest.kt
+++ b/shared/core-terminal/src/androidTest/java/com/pocketshell/core/terminal/ui/EngineCommandTapInstrumentedTest.kt
@@ -54,7 +54,7 @@ class EngineCommandTapInstrumentedTest {
     private val claudeCommands = setOf("/clear", "/compact", "/rewind", "/model")
 
     @Test
-    fun clearTokenIsTappableAndRoutesTheCommandWhileNonCommandFallsThrough() = runBlocking {
+    fun clearTokenIsTappableAndRoutesTheCommandWhileNonCommandFallsThrough() { runBlocking {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val context = instrumentation.targetContext
         val state = TerminalSurfaceState()
@@ -204,7 +204,7 @@ class EngineCommandTapInstrumentedTest {
             producerScope.cancel()
             state.detachExternalProducer()
         }
-    }
+    } }
 
     /**
      * Render the live [TerminalView] off-screen to a bitmap and persist it under

--- a/shared/core-terminal/src/androidTest/java/com/pocketshell/core/terminal/ui/FilePathTapInstrumentedTest.kt
+++ b/shared/core-terminal/src/androidTest/java/com/pocketshell/core/terminal/ui/FilePathTapInstrumentedTest.kt
@@ -52,7 +52,7 @@ import java.io.FileOutputStream
 class FilePathTapInstrumentedTest {
 
     @Test
-    fun pngAndTextPathsAreScannedAndTapRoutesToFileViewerPath() = runBlocking {
+    fun pngAndTextPathsAreScannedAndTapRoutesToFileViewerPath() { runBlocking {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val context = instrumentation.targetContext
         val state = TerminalSurfaceState()
@@ -215,10 +215,10 @@ class FilePathTapInstrumentedTest {
             producerScope.cancel()
             state.detachExternalProducer()
         }
-    }
+    } }
 
     @Test
-    fun generatedImagePathsWrappedAcrossRowsRouteFullFileViewerPath() = runBlocking {
+    fun generatedImagePathsWrappedAcrossRowsRouteFullFileViewerPath() { runBlocking {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val context = instrumentation.targetContext
         val state = TerminalSurfaceState()
@@ -355,7 +355,7 @@ class FilePathTapInstrumentedTest {
             producerScope.cancel()
             state.detachExternalProducer()
         }
-    }
+    } }
 
     private fun centerX(region: FilePathRegion, view: TerminalView): Float {
         val renderer = requireNotNull(view.mRenderer) { "renderer should be initialised" }

--- a/shared/core-terminal/src/androidTest/java/com/pocketshell/core/terminal/ui/LocalhostUrlTapInstrumentedTest.kt
+++ b/shared/core-terminal/src/androidTest/java/com/pocketshell/core/terminal/ui/LocalhostUrlTapInstrumentedTest.kt
@@ -54,7 +54,7 @@ import java.io.FileOutputStream
 class LocalhostUrlTapInstrumentedTest {
 
     @Test
-    fun localhostReferencesTapClassifiesAsServerLocalWhileRealHostStaysBrowser() = runBlocking {
+    fun localhostReferencesTapClassifiesAsServerLocalWhileRealHostStaysBrowser() { runBlocking {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val context = instrumentation.targetContext
         val state = TerminalSurfaceState()
@@ -192,7 +192,7 @@ class LocalhostUrlTapInstrumentedTest {
             state.detachExternalProducer()
         }
         assertTrue(true)
-    }
+    } }
 
     /**
      * Render the live [TerminalView] off-screen to a bitmap and persist it

--- a/shared/core-terminal/src/androidTest/java/com/pocketshell/core/terminal/ui/TerminalSurfaceComposeIntegrationTest.kt
+++ b/shared/core-terminal/src/androidTest/java/com/pocketshell/core/terminal/ui/TerminalSurfaceComposeIntegrationTest.kt
@@ -186,7 +186,7 @@ class TerminalSurfaceComposeIntegrationTest {
     }
 
     @Test
-    fun copyActionRoutesSelectedTextThroughRealClipboardManager() = runBlocking {
+    fun copyActionRoutesSelectedTextThroughRealClipboardManager() { runBlocking {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val state = TerminalSurfaceState()
         val stdout = MutableSharedFlow<ByteArray>(extraBufferCapacity = 1)
@@ -353,7 +353,7 @@ class TerminalSurfaceComposeIntegrationTest {
             producerScope.cancel()
             state.detachExternalProducer()
         }
-    }
+    } }
 
     /**
      * [ContextWrapper] that pretends to be a complete context but routes
@@ -393,7 +393,7 @@ class TerminalSurfaceComposeIntegrationTest {
     }
 
     @Test
-    fun tappingDetectedUrlFiresIntentActionView() = runBlocking {
+    fun tappingDetectedUrlFiresIntentActionView() { runBlocking {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val state = TerminalSurfaceState()
         val stdout = MutableSharedFlow<ByteArray>(extraBufferCapacity = 1)
@@ -579,10 +579,10 @@ class TerminalSurfaceComposeIntegrationTest {
             producerScope.cancel()
             state.detachExternalProducer()
         }
-    }
+    } }
 
     @Test
-    fun tappingEmptyAreaDoesNotFocusOrRequestSoftInput() = runBlocking {
+    fun tappingEmptyAreaDoesNotFocusOrRequestSoftInput() { runBlocking {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val state = TerminalSurfaceState()
         val stdout = MutableSharedFlow<ByteArray>(extraBufferCapacity = 1)
@@ -669,10 +669,10 @@ class TerminalSurfaceComposeIntegrationTest {
             producerScope.cancel()
             state.detachExternalProducer()
         }
-    }
+    } }
 
     @Test
-    fun longPressOnTextSelectsAndCopyRoutesThroughClipboard() = runBlocking {
+    fun longPressOnTextSelectsAndCopyRoutesThroughClipboard() { runBlocking {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val state = TerminalSurfaceState()
         val stdout = MutableSharedFlow<ByteArray>(extraBufferCapacity = 1)
@@ -852,7 +852,7 @@ class TerminalSurfaceComposeIntegrationTest {
             producerScope.cancel()
             state.detachExternalProducer()
         }
-    }
+    } }
 
     /**
      * Find the [TerminalView] AndroidView interop pushes into the activity's

--- a/shared/core-terminal/src/androidTest/java/com/pocketshell/core/terminal/ui/TerminalSurfaceInputInstrumentedTest.kt
+++ b/shared/core-terminal/src/androidTest/java/com/pocketshell/core/terminal/ui/TerminalSurfaceInputInstrumentedTest.kt
@@ -31,7 +31,7 @@ import java.io.OutputStream
 class TerminalSurfaceInputInstrumentedTest {
 
     @Test
-    fun rawCommandImeCommitRoutesTextAndEnterToRemoteStdin() = runBlocking {
+    fun rawCommandImeCommitRoutesTextAndEnterToRemoteStdin() { runBlocking {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val context = instrumentation.targetContext
         val state = TerminalSurfaceState()
@@ -80,10 +80,10 @@ class TerminalSurfaceInputInstrumentedTest {
             producerScope.cancel()
             state.detachExternalProducer()
         }
-    }
+    } }
 
     @Test
-    fun rawMultiLineImeCommitRoutesAsOneBracketedPasteBlock() = runBlocking {
+    fun rawMultiLineImeCommitRoutesAsOneBracketedPasteBlock() { runBlocking {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val context = instrumentation.targetContext
         val state = TerminalSurfaceState()
@@ -123,10 +123,10 @@ class TerminalSurfaceInputInstrumentedTest {
             producerScope.cancel()
             state.detachExternalProducer()
         }
-    }
+    } }
 
     @Test
-    fun smartTextImeStagesCommittedTextUntilEnterConfirms() = runBlocking {
+    fun smartTextImeStagesCommittedTextUntilEnterConfirms() { runBlocking {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val context = instrumentation.targetContext
         val state = TerminalSurfaceState()
@@ -191,10 +191,10 @@ class TerminalSurfaceInputInstrumentedTest {
             producerScope.cancel()
             state.detachExternalProducer()
         }
-    }
+    } }
 
     @Test
-    fun smartTextSendKeyEventEnterFlushesStagedTextBeforeCarriageReturn() = runBlocking {
+    fun smartTextSendKeyEventEnterFlushesStagedTextBeforeCarriageReturn() { runBlocking {
         withSmartTextInputConnection { instrumentation, inputConnection, remoteStdin ->
             instrumentation.runOnMainSync {
                 inputConnection.commitText("echo ok", 1)
@@ -205,10 +205,10 @@ class TerminalSurfaceInputInstrumentedTest {
             remoteStdin.awaitSnapshot("echo ok\r")
             assertEquals("echo ok\r", remoteStdin.snapshot())
         }
-    }
+    } }
 
     @Test
-    fun smartTextMultiLineImeCommitBypassesStaleStagingAndRoutesAsBracketedPaste() = runBlocking {
+    fun smartTextMultiLineImeCommitBypassesStaleStagingAndRoutesAsBracketedPaste() { runBlocking {
         withSmartTextInputConnection { instrumentation, inputConnection, remoteStdin ->
             val paste = "alpha\nbeta\ngamma"
             val expected = "\u001B[200~$paste\u001B[201~"
@@ -224,10 +224,10 @@ class TerminalSurfaceInputInstrumentedTest {
             assertTrue("staged smart text must not prefix paste payload", !remoteStdin.snapshot().contains("discard me"))
             assertTrue("multi-line smart IME paste must not send Enter bytes", !remoteStdin.snapshot().contains("\r"))
         }
-    }
+    } }
 
     @Test
-    fun smartTextComposingTextWaitsForEditorConfirmation() = runBlocking {
+    fun smartTextComposingTextWaitsForEditorConfirmation() { runBlocking {
         withSmartTextInputConnection { instrumentation, inputConnection, remoteStdin ->
             instrumentation.runOnMainSync {
                 inputConnection.setComposingText("echo composed", 1)
@@ -242,10 +242,10 @@ class TerminalSurfaceInputInstrumentedTest {
             remoteStdin.awaitSnapshot("echo composed\r")
             assertEquals("echo composed\r", remoteStdin.snapshot())
         }
-    }
+    } }
 
     @Test
-    fun smartTextStagingClearsBeforeCtrlCAndEscapeControls() = runBlocking {
+    fun smartTextStagingClearsBeforeCtrlCAndEscapeControls() { runBlocking {
         withSmartTextInputConnection { instrumentation, inputConnection, remoteStdin ->
             instrumentation.runOnMainSync {
                 inputConnection.commitText("discard me", 1)
@@ -267,10 +267,10 @@ class TerminalSurfaceInputInstrumentedTest {
             remoteStdin.awaitSnapshot("\u001B\r")
             assertEquals("\u001B\r", remoteStdin.snapshot())
         }
-    }
+    } }
 
     @Test
-    fun smartTextStagingClearsBeforePasteActionAndHotkey() = runBlocking {
+    fun smartTextStagingClearsBeforePasteActionAndHotkey() { runBlocking {
         withSmartTextInputConnection { instrumentation, inputConnection, remoteStdin ->
             instrumentation.runOnMainSync {
                 inputConnection.commitText("discard me", 1)
@@ -292,7 +292,7 @@ class TerminalSurfaceInputInstrumentedTest {
             remoteStdin.awaitSnapshot("\u0016\r")
             assertEquals("\u0016\r", remoteStdin.snapshot())
         }
-    }
+    } }
 
     private suspend fun withSmartTextInputConnection(
         block: suspend (Instrumentation, InputConnection, RecordingOutputStream) -> Unit,

--- a/shared/core-terminal/src/androidTest/java/com/pocketshell/core/terminal/ui/TerminalSurfaceSelectionInstrumentedTest.kt
+++ b/shared/core-terminal/src/androidTest/java/com/pocketshell/core/terminal/ui/TerminalSurfaceSelectionInstrumentedTest.kt
@@ -70,7 +70,7 @@ class TerminalSurfaceSelectionInstrumentedTest {
     }
 
     @Test
-    fun selectingTextAndCopyingRoutesPlainTextThroughClipboardSink() = runBlocking {
+    fun selectingTextAndCopyingRoutesPlainTextThroughClipboardSink() { runBlocking {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val context = instrumentation.targetContext
         val state = TerminalSurfaceState()
@@ -178,10 +178,10 @@ class TerminalSurfaceSelectionInstrumentedTest {
             state.detachExternalProducer()
             state.setOnCopySelection(null)
         }
-    }
+    } }
 
     @Test
-    fun visibleUrlIsScannedAndHitTestRoutesTapToUrl() = runBlocking {
+    fun visibleUrlIsScannedAndHitTestRoutesTapToUrl() { runBlocking {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val context = instrumentation.targetContext
         val state = TerminalSurfaceState()
@@ -360,10 +360,10 @@ class TerminalSurfaceSelectionInstrumentedTest {
             producerScope.cancel()
             state.detachExternalProducer()
         }
-    }
+    } }
 
     @Test
-    fun visibleSmartSelectionHitTestChoosesPressedSameLineMatch() = runBlocking {
+    fun visibleSmartSelectionHitTestChoosesPressedSameLineMatch() { runBlocking {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val context = instrumentation.targetContext
         val state = TerminalSurfaceState()
@@ -454,10 +454,10 @@ class TerminalSurfaceSelectionInstrumentedTest {
             producerScope.cancel()
             state.detachExternalProducer()
         }
-    }
+    } }
 
     @Test
-    fun visibleSmartSelectionAffordancesUseQuietChromeForPathAndError() = runBlocking {
+    fun visibleSmartSelectionAffordancesUseQuietChromeForPathAndError() { runBlocking {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val context = instrumentation.targetContext
         val state = TerminalSurfaceState()
@@ -546,10 +546,10 @@ class TerminalSurfaceSelectionInstrumentedTest {
             producerScope.cancel()
             state.detachExternalProducer()
         }
-    }
+    } }
 
     @Test
-    fun visibleSmartSelectionSupportsLegacyValueOnlyMatcherForHitTesting() = runBlocking {
+    fun visibleSmartSelectionSupportsLegacyValueOnlyMatcherForHitTesting() { runBlocking {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val context = instrumentation.targetContext
         val state = TerminalSurfaceState()
@@ -610,10 +610,10 @@ class TerminalSurfaceSelectionInstrumentedTest {
             producerScope.cancel()
             state.detachExternalProducer()
         }
-    }
+    } }
 
     @Test
-    fun visibleSmartSelectionCanBeRecomputedAfterScrollWithoutNewOutput() = runBlocking {
+    fun visibleSmartSelectionCanBeRecomputedAfterScrollWithoutNewOutput() { runBlocking {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val context = instrumentation.targetContext
         val state = TerminalSurfaceState()
@@ -684,10 +684,10 @@ class TerminalSurfaceSelectionInstrumentedTest {
             producerScope.cancel()
             state.detachExternalProducer()
         }
-    }
+    } }
 
     @Test
-    fun visibleUrlRegionsCanBeRecomputedAfterScrollWithoutNewOutput() = runBlocking {
+    fun visibleUrlRegionsCanBeRecomputedAfterScrollWithoutNewOutput() { runBlocking {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val context = instrumentation.targetContext
         val state = TerminalSurfaceState()
@@ -758,10 +758,10 @@ class TerminalSurfaceSelectionInstrumentedTest {
             producerScope.cancel()
             state.detachExternalProducer()
         }
-    }
+    } }
 
     @Test
-    fun emulatorSetInvalidatesViewportForOverlayRecompute() = runBlocking {
+    fun emulatorSetInvalidatesViewportForOverlayRecompute() { runBlocking {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val context = instrumentation.targetContext
         val state = TerminalSurfaceState()
@@ -809,7 +809,7 @@ class TerminalSurfaceSelectionInstrumentedTest {
             producerScope.cancel()
             state.detachExternalProducer()
         }
-    }
+    } }
 
     private object LegacyTicketMatcher : TerminalMatcher {
         override fun matches(text: String): List<TerminalMatch> =

--- a/shared/core-terminal/src/androidTest/java/com/pocketshell/core/terminal/ui/WrappedUrlReassemblyInstrumentedTest.kt
+++ b/shared/core-terminal/src/androidTest/java/com/pocketshell/core/terminal/ui/WrappedUrlReassemblyInstrumentedTest.kt
@@ -44,7 +44,7 @@ import java.io.FileOutputStream
 class WrappedUrlReassemblyInstrumentedTest {
 
     @Test
-    fun urlWrappedAcrossRowsIsReassembledIntoOneFullTarget() = runBlocking {
+    fun urlWrappedAcrossRowsIsReassembledIntoOneFullTarget() { runBlocking {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val context = instrumentation.targetContext
         val state = TerminalSurfaceState()
@@ -139,7 +139,7 @@ class WrappedUrlReassemblyInstrumentedTest {
             producerScope.cancel()
             state.detachExternalProducer()
         }
-    }
+    } }
 
     private fun centerX(region: UrlRegion, view: TerminalView): Float {
         val renderer = requireNotNull(view.mRenderer) { "renderer should be initialised" }

--- a/shared/core-terminal/src/androidTest/java/com/termux/view/TerminalViewReattachLateSubscribeRepaintInstrumentedTest.kt
+++ b/shared/core-terminal/src/androidTest/java/com/termux/view/TerminalViewReattachLateSubscribeRepaintInstrumentedTest.kt
@@ -143,7 +143,7 @@ class TerminalViewReattachLateSubscribeRepaintInstrumentedTest {
     }
 
     @Test
-    fun lateSubscribeAfterReattachSeedRepaintsRealViewWholeBuffer() = runBlocking {
+    fun lateSubscribeAfterReattachSeedRepaintsRealViewWholeBuffer() { runBlocking {
         val instr = InstrumentationRegistry.getInstrumentation()
         val context = instr.targetContext
 
@@ -267,7 +267,7 @@ class TerminalViewReattachLateSubscribeRepaintInstrumentedTest {
             paintedRows,
         )
         assertNonBackgroundPixelsAcrossAllRows(bitmap, renderer)
-    }
+    } }
 
     private fun assertNonBackgroundPixelsAcrossAllRows(bitmap: Bitmap, renderer: TerminalRenderer) {
         for (i in 0 until rows) {


### PR DESCRIPTION
Fixes a G3-at-scale gap found during v0.4.20 release validation: expression-body `@Test fun x() = runBlocking { }` methods whose block ends non-Unit are non-void, so JUnit rejects the class at load (`InvalidTestClassError`) and the journey **never runs** — silently, because the emulator lane is infra-down (#771).

- **#1138 fixed + proven on-device:** its journey was doubly broken (non-void method + an inject frame with no ESC bytes → literal text). Fixed both; reviewer independently re-ran on emulator: `tests=1 failures=0`, partial-black injected + full alt frame healed (ESC-byte fix confirmed at hexdump level). This is #1138's on-device evidence.
- **Class sweep:** 290 expression-body lifecycle methods → void block bodies (2 genuinely broken, rest no-op conversions).
- **Permanent guard:** new `V1` smell in `check-test-validity.sh` (Unit CI job, no emulator) hard-fails any non-void androidTest lifecycle method. Red→green: base V1=290 → 0.

Test-only, zero `src/main` touched. **Reviewer APPROVED** (https://github.com/alexeygrigorev/pocketshell/issues/1154#issuecomment-4853295960): re-ran #1138 on-device, verified the guard red→green in the Unit job, spot-checked the sweep + full androidTest compile, zero production code.

Closes #1154