### PR TITLE
fix: Conversation tab present for recorded-agent sessions regardless of live detection (#1158)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/tmux/ConversationToggleVisibleForLiveAgentInShellRecordedSessionDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/ConversationToggleVisibleForLiveAgentInShellRecordedSessionDockerTest.kt
@@ -31,6 +31,7 @@ import com.pocketshell.core.ssh.SshConnection
 import com.pocketshell.core.ssh.SshKey
 import com.pocketshell.core.storage.AppDatabase
 import com.pocketshell.core.storage.entity.HostEntity
+import com.pocketshell.uikit.model.SessionAgentKind
 import com.termux.view.TerminalView
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
@@ -257,6 +258,103 @@ class ConversationToggleVisibleForLiveAgentInShellRecordedSessionDockerTest {
         Unit
     } }
 
+    /**
+     * Issue #1158 (recurrence of #962/#1057) — a session RECORDED as a non-shell
+     * agent kind (`@ps_agent_kind=codex`) whose conversation SOURCE can't bind
+     * (no cwd-enumerable transcript; Codex needs the `/proc/<pid>/fd` owned-rollout
+     * match the non-systemd fixture can't supply) MUST still show a present +
+     * tappable Terminal/Conversation toggle, and tapping it must route to the
+     * Conversation surface (the loading/placeholder state), NEVER collapse the
+     * whole tab and strand the user on the Terminal.
+     *
+     * This is the SECOND kind in the class (Codex; the masked-Claude sibling above
+     * is the first) and the "source-binding-fails-but-tab-still-present" case. Tab
+     * PRESENCE now follows the RECORDED agent kind
+     * (`tmuxSessionRecordedAgentKind(currentSessionRecordedKind)` →
+     * `tmuxSessionTabState.showsConversationTab`), independent of the fragile live
+     * detection / transcript-source binding — the durable #1158 fix. The
+     * deterministic per-kind red→green (Claude / Codex / glm-Z.AI) lives in the
+     * fast JVM sibling `TmuxSessionScreenTest.tmuxSessionTabStateShowsConversationForRecorded*`;
+     * this is the REAL-path acceptance that the toggle is present, tappable, and
+     * degrades to the Conversation placeholder — not a dead Terminal — when source
+     * binding fails on the maintainer's fleet.
+     *
+     * NOTE (loading state, not loaded content): actually LOADING the Codex/Z.AI
+     * transcript into the surface is the explicit #1158 non-goal (the #820
+     * content-loading class, a separate follow-up). Here the acceptance is the tab
+     * being reachable and reaching the Placeholder/loading surface.
+     */
+    @Test
+    fun conversationTogglePresentForRecordedCodexAgentWhenSourceBindingFails() { runBlocking {
+        val hostRowTag = requireNotNull(seededHostRowTag) { "seed-before-launch host row missing" }
+        val sessionName = requireNotNull(seededSessionName) { "seed-before-launch session missing" }
+
+        attachToSeededSession(hostRowTag, sessionName)
+        waitForTerminalSessionAttached()
+        waitForVisibleTerminalText("issue1158-codex-ready", VISIBLE_TIMEOUT_MS) {
+            "issue1158-codex-ready" in it
+        }
+        stamp("recorded_codex_attached session=$sessionName")
+
+        // STEP 1 — LOAD-BEARING recorded-agent signal: the tree read back
+        // `@ps_agent_kind=codex` for the active session. This is the exact input
+        // the #1158 fix keys on (currentSessionRecordedKind → recordedAgentKind →
+        // showsConversationTab). If this never resolves, the recorded-kind path
+        // isn't exercised and the test would be vacuous — so hard-assert it.
+        val vm = currentViewModel()
+        val recordedCodex = waitForRecordedKind(vm, SessionAgentKind.Codex)
+        assertTrue(
+            "#1158: the active session must read back `@ps_agent_kind=codex` " +
+                "(the recorded-agent signal that drives tab presence). " +
+                "currentSessionRecordedKind=${vm.currentSessionRecordedKind.value}",
+            recordedCodex,
+        )
+        stamp("recorded_codex_kind_resolved")
+
+        // STEP 2 — NO live source binds: the fixture cannot bind a Codex source
+        // (no `/proc` match, no cwd transcript). Detection stays null — proving the
+        // toggle below is NOT coming from live detection but from the recorded
+        // kind. (Best-effort observation; the load-bearing gate is STEP 3.)
+        SystemClock.sleep(SHELL_NO_TOGGLE_SETTLE_MS)
+        val detectionBound = vm.agentConversations.value.values.any { it.detection != null }
+        stamp("recorded_codex_detection_bound=$detectionBound")
+
+        // STEP 3 — DURABLE UI: the Terminal/Conversation toggle is present with a
+        // "Conversation" segment, driven purely by the recorded Codex kind.
+        compose.waitUntil(timeoutMillis = MASKED_TOGGLE_TIMEOUT_MS) {
+            compose.onAllNodesWithTag(TMUX_TABS_TAG, useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
+        compose.onNodeWithTag(TMUX_TABS_TAG, useUnmergedTree = true).assertExists()
+        compose.waitUntil(timeoutMillis = MASKED_TOGGLE_TIMEOUT_MS) {
+            compose.onAllNodesWithText("Conversation", useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
+        compose.onNodeWithText("Conversation", useUnmergedTree = true).assertExists()
+        captureFullFrame("issue1158-recorded-codex-toggle-present")
+        stamp("recorded_codex_toggle_present_ok")
+
+        // STEP 4 — POINT 2 (never collapse the tab on a source-binding hiccup):
+        // tapping Conversation routes to the Conversation surface (the loading /
+        // placeholder state), NOT stranding the user on the Terminal. Assert the
+        // production placeholder [TMUX_CONVERSATION_DETECTING_TAG] appears.
+        clickRobustly {
+            compose.onNodeWithText("Conversation", useUnmergedTree = true).performClick()
+        }
+        compose.waitUntil(timeoutMillis = MASKED_TOGGLE_TIMEOUT_MS) {
+            compose.onAllNodesWithTag(TMUX_CONVERSATION_DETECTING_TAG, useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
+        compose.onNodeWithTag(TMUX_CONVERSATION_DETECTING_TAG, useUnmergedTree = true)
+            .assertExists()
+        captureFullFrame("issue1158-recorded-codex-conversation-placeholder")
+        stamp("recorded_codex_conversation_placeholder_ok")
+        Unit
+    } }
+
     // -------------------------------------------------------------- seed-before-launch
 
     /**
@@ -275,6 +373,8 @@ class ConversationToggleVisibleForLiveAgentInShellRecordedSessionDockerTest {
                 seedMaskedLiveClaudeSession(key)
             "plainShellRecordedSessionShowsNoConversationToggle" ->
                 seedPlainShellSession(key)
+            "conversationTogglePresentForRecordedCodexAgentWhenSourceBindingFails" ->
+                seedRecordedCodexNoTranscriptSession(key)
             else -> error("unexpected test method $methodName")
         }
         seededSessionName = sessionName
@@ -346,7 +446,53 @@ class ConversationToggleVisibleForLiveAgentInShellRecordedSessionDockerTest {
         return sessionName
     }
 
+    /**
+     * Issue #1158: a session RECORDED as an agent kind (`@ps_agent_kind=codex`)
+     * with NO bindable conversation source — no cwd-enumerable transcript, and the
+     * fixture cannot supply the Codex `/proc/<pid>/fd` owned-rollout match — so live
+     * detection / transcript-source binding fails for the life of the session,
+     * exactly the maintainer's Codex fleet. The recorded Codex kind is the durable
+     * signal that keeps the Conversation toggle present regardless.
+     */
+    private suspend fun seedRecordedCodexNoTranscriptSession(key: String): String {
+        val suffix = unique()
+        val sessionName = "issue1158-codex-$suffix"
+        cleanupCommands += "tmux kill-session -t ${shellQuote(sessionName)} 2>/dev/null || true"
+        execRemote(
+            key,
+            buildString {
+                appendLine("set -eu")
+                appendLine("tmux kill-session -t ${shellQuote(sessionName)} 2>/dev/null || true")
+                appendLine(
+                    "tmux new-session -d -x 80 -y 24 -s ${shellQuote(sessionName)} -c /tmp " +
+                        "\"printf 'issue1158-codex-ready\\r\\n'; exec sh\"",
+                )
+                // Record it as a Codex agent (the durable `@ps_agent_kind` the
+                // `pocketshell agent codex` wrapper writes). NO transcript is seeded,
+                // so the conversation source cannot bind.
+                appendLine("tmux set-option -t ${shellQuote(sessionName)} @ps_agent_kind codex")
+                appendLine("sleep 1")
+            },
+        )
+        return sessionName
+    }
+
     // ----------------------------------------------------------------- helpers
+
+    /**
+     * Issue #1158: poll until the active session's recorded `@ps_agent_kind`
+     * resolves to [expected] (read over the warm session by
+     * `refreshCurrentSessionRecordedKind`, which the screen fires on connect). This
+     * is the load-bearing recorded-agent signal the tab-presence fix keys on.
+     */
+    private fun waitForRecordedKind(vm: TmuxSessionViewModel, expected: SessionAgentKind): Boolean {
+        val deadline = SystemClock.elapsedRealtime() + VERDICT_TIMEOUT_MS
+        while (SystemClock.elapsedRealtime() < deadline) {
+            if (vm.currentSessionRecordedKind.value == expected) return true
+            SystemClock.sleep(100)
+        }
+        return vm.currentSessionRecordedKind.value == expected
+    }
 
     private suspend fun persistHost(key: String): String {
         val appContext = InstrumentationRegistry.getInstrumentation().targetContext

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
@@ -196,6 +196,7 @@ import com.pocketshell.uikit.model.Crumb
 import com.pocketshell.uikit.model.ConnectionStatus as UiConnectionStatus
 import com.pocketshell.uikit.model.KeyBinding
 import com.pocketshell.uikit.model.KeyKind
+import com.pocketshell.uikit.model.SessionAgentKind
 import com.pocketshell.uikit.theme.PocketShellColors
 import com.pocketshell.uikit.theme.PocketShellDensity
 import com.pocketshell.uikit.theme.PocketShellShapes
@@ -1530,11 +1531,20 @@ public fun TmuxSessionScreen(
             // OFF the 60ms agent-streaming flush. The projection re-runs each
             // flush but the resulting [TmuxSessionTabState] is structurally equal,
             // so the body is not invalidated.
-            val tabState by remember(surfaceConversationPaneId, presumedAgent) {
+            // Issue #1158: the active session's RECORDED agent kind
+            // (`@ps_agent_kind`, collected above at [currentSessionRecordedKind])
+            // projected to a stable boolean so it can force the Conversation tab
+            // present for a recorded agent even when live detection /
+            // transcript-source binding never bound. Independent of the
+            // per-pane `presumedAgent` gate so a recorded Codex / Z.AI-Claude
+            // session shows the toggle regardless of the fragile binding.
+            val recordedAgentKind = tmuxSessionRecordedAgentKind(currentSessionRecordedKind)
+            val tabState by remember(surfaceConversationPaneId, presumedAgent, recordedAgentKind) {
                 derivedStateOf {
                     tmuxSessionTabState(
                         surfaceConversationPaneId?.let { agentConversationsState.value[it] },
                         presumedAgent,
+                        recordedAgentKind,
                     )
                 }
             }
@@ -3658,9 +3668,45 @@ internal fun tmuxSessionShouldPromoteSettledCachedPane(
     return true
 }
 
+/**
+ * Issue #1158 (recurrence of #962/#1057): whether the tree has RECORDED this
+ * session as a known agent kind (Claude / Codex / OpenCode), independent of
+ * whether live agent-detection or conversation-source binding has succeeded.
+ *
+ * This is the "record, don't guess" signal (epic #821): a session that
+ * PocketShell launched (or the user classified) as an agent carries a durable
+ * `@ps_agent_kind` tmux option that reads back as one of these kinds. The
+ * detection / transcript-source layer FREQUENTLY fails to bind for the
+ * maintainer's real fleet — node-wrapped Claude, Codex (needs a
+ * `/proc/<pid>/fd` process-match), and glm/Z.AI-Claude (transcript at a
+ * different path/format, the #820 class) — but we STILL know it is an agent
+ * because we recorded the kind. So the Conversation tab's *presence* must
+ * follow the recorded kind, not the fragile live binding, or the toggle
+ * vanishes for the life of the session (the maintainer's #1158 symptom).
+ *
+ * [SessionAgentKind.Shell] (a recorded plain shell), [SessionAgentKind.Probing]
+ * / [SessionAgentKind.Exited] (transient), [SessionAgentKind.Unknown], and
+ * `null` (foreign / not-yet-classified) are NOT recorded-agent kinds: they must
+ * NOT force the tab, so the #894 "a confirmed shell with no agent evidence
+ * hides the Conversation tab" no-flap invariant stays intact. (A foreign /
+ * unknown session already keeps the tab via the presumed-agent path.)
+ */
+internal fun tmuxSessionRecordedAgentKind(recordedKind: SessionAgentKind?): Boolean =
+    when (recordedKind) {
+        SessionAgentKind.Claude,
+        SessionAgentKind.Codex,
+        SessionAgentKind.OpenCode -> true
+        SessionAgentKind.Shell,
+        SessionAgentKind.Probing,
+        SessionAgentKind.Exited,
+        SessionAgentKind.Unknown,
+        null -> false
+    }
+
 internal fun tmuxSessionTabState(
     currentAgentConversation: AgentConversationUiState?,
     presumedAgent: Boolean = false,
+    recordedAgentKind: Boolean = false,
 ): TmuxSessionTabState {
     // The Conversation tab exists for a live-detected agent OR a presumed
     // agent (#716). Issue #778: the active index now follows the user's
@@ -3697,8 +3743,22 @@ internal fun tmuxSessionTabState(
     } == true
     val userOpenedConversation =
         currentAgentConversation?.selectedTab == SessionTab.Conversation
+    // Issue #1158 (recurrence of #962/#1057): a RECORDED agent kind
+    // (Claude / Codex / OpenCode) is a first-class tab-presence signal on its
+    // own — the tab shows even when live detection AND transcript-source binding
+    // both failed. This is the durable fix for the maintainer's fleet where the
+    // detection/source layer can't bind (node-wrapped Claude, Codex `/proc`
+    // process-match, glm/Z.AI alternate transcript path) yet the tree KNOWS the
+    // session is an agent. The existing detection/content/presumed-agent signals
+    // are kept as ADDITIONAL signals (recorded-kind OR detection → show tab), so
+    // the vanilla-Claude case and the #894 confirmed-shell-hides-tab no-flap
+    // invariant are unchanged. When the tab is shown but the source can't bind,
+    // the user reaches the existing Placeholder/Failed surface
+    // ([tmuxSessionConversationSurface]) — the whole tab is NEVER collapsed on a
+    // source-binding hiccup.
     val showsConversationTab =
-        hasLiveDetection || presumedAgent || hasConversationContent || userOpenedConversation
+        hasLiveDetection || presumedAgent || hasConversationContent ||
+            userOpenedConversation || recordedAgentKind
     return TmuxSessionTabState(
         labels = if (showsConversationTab) listOf("Terminal", "Conversation") else listOf("Terminal"),
         selectedIndex = if (showsConversationTab && userOpenedConversation) 1 else 0,

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionScreenTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionScreenTest.kt
@@ -14,6 +14,7 @@ import com.pocketshell.core.agents.AgentDetection
 import com.pocketshell.core.agents.AgentKind
 import com.pocketshell.core.storage.entity.HostEntity
 import com.pocketshell.core.terminal.selection.LocalhostUrl
+import com.pocketshell.uikit.model.SessionAgentKind
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -638,6 +639,124 @@ class TmuxSessionScreenTest {
         assertEquals(listOf("Terminal"), state.labels)
         assertEquals(0, state.selectedIndex)
         assertTrue(!state.showsConversationTab)
+    }
+
+    // ─── Issue #1158 (recurrence of #962/#1057): a RECORDED agent kind forces ──
+    // the Conversation tab present even when live detection AND source-binding
+    // both fail. The prior #962/#1057 fixes only covered vanilla Claude via the
+    // detection/transcript path; Codex and glm/Z.AI-Claude regressed silently
+    // because their transcript-source binding fails on the maintainer's fleet
+    // and NOTHING wired the already-recorded kind into tab presence. These tests
+    // cover the WHOLE class (Claude, Codex, glm/Z.AI), not the one reported
+    // instance (D31/D32/G2 class-coverage).
+    //
+    // RED→GREEN: on base — remove the `|| recordedAgentKind` OR-term from
+    // `tmuxSessionTabState.showsConversationTab` — each of the three
+    // recorded-agent cases below FAILS (single "Terminal" pill, no toggle),
+    // exactly the maintainer's #1158 symptom. With the fix the term is present
+    // and all three GREEN, while the recorded-Shell no-flap control (#894) and
+    // the null/unknown control stay GREEN either way. ──────────────────────────
+
+    @Test
+    fun tmuxSessionTabStateShowsConversationForRecordedClaudeWithoutDetectionOrContent() {
+        // Recorded `@ps_agent_kind=claude` (covers vanilla AND node-wrapped
+        // Claude), confirmed-shell surface (presumedAgent == false), NO live
+        // detection, NO transcript content: the tab MUST be present because the
+        // tree recorded the session as an agent. RED on base.
+        val state = tmuxSessionTabState(
+            currentAgentConversation = null,
+            presumedAgent = false,
+            recordedAgentKind = tmuxSessionRecordedAgentKind(SessionAgentKind.Claude),
+        )
+
+        assertEquals(listOf("Terminal", "Conversation"), state.labels)
+        assertEquals(0, state.selectedIndex)
+        assertTrue(state.showsConversationTab)
+    }
+
+    @Test
+    fun tmuxSessionTabStateShowsConversationForRecordedCodexWithoutDetectionOrContent() {
+        // Recorded `@ps_agent_kind=codex`, whose transcript is NOT cwd-enumerable
+        // / daemon classify `unknown` (needs the `/proc/<pid>/fd` process-match
+        // that frequently can't bind). The sibling kind #962/#975 never proved.
+        // RED on base — the tab was permanently gone for the maintainer's Codex
+        // sessions.
+        val state = tmuxSessionTabState(
+            currentAgentConversation = null,
+            presumedAgent = false,
+            recordedAgentKind = tmuxSessionRecordedAgentKind(SessionAgentKind.Codex),
+        )
+
+        assertEquals(listOf("Terminal", "Conversation"), state.labels)
+        assertEquals(0, state.selectedIndex)
+        assertTrue(state.showsConversationTab)
+    }
+
+    @Test
+    fun tmuxSessionTabStateShowsConversationForRecordedZaiClaudeWithoutDetectionOrContent() {
+        // glm / Z.AI-Claude is recorded as the Claude KIND with a non-default
+        // profile (`@ps_agent_profile` = "Claude (Z.AI)"), but its transcript
+        // lives at a different path/format (the #820 class), so live
+        // source-binding fails. Tab presence follows the recorded KIND, so a
+        // recorded Claude-with-Z.AI-profile session still shows the toggle. RED
+        // on base.
+        val state = tmuxSessionTabState(
+            currentAgentConversation = null,
+            presumedAgent = false,
+            // The recorded KIND for a Z.AI-pointed Claude is still Claude; the
+            // provider divergence lives in the profile, not the kind. The tab
+            // signal is kind-driven.
+            recordedAgentKind = tmuxSessionRecordedAgentKind(SessionAgentKind.Claude),
+        )
+
+        assertEquals(listOf("Terminal", "Conversation"), state.labels)
+        assertEquals(0, state.selectedIndex)
+        assertTrue(state.showsConversationTab)
+    }
+
+    @Test
+    fun tmuxSessionTabStateShowsConversationForRecordedOpenCodeWithoutDetectionOrContent() {
+        // OpenCode completes the recorded-agent class; same tab-presence rule.
+        val state = tmuxSessionTabState(
+            currentAgentConversation = null,
+            presumedAgent = false,
+            recordedAgentKind = tmuxSessionRecordedAgentKind(SessionAgentKind.OpenCode),
+        )
+
+        assertEquals(listOf("Terminal", "Conversation"), state.labels)
+        assertTrue(state.showsConversationTab)
+    }
+
+    @Test
+    fun tmuxSessionTabStateHidesConversationForRecordedShellNoFlapControl() {
+        // #894 no-flap invariant: a recorded PLAIN SHELL (`@ps_agent_kind=shell`)
+        // with no agent evidence must NOT force the Conversation tab. This must
+        // stay GREEN both on base and with the fix — the recorded-agent signal
+        // is agent-kinds-only, never Shell.
+        val state = tmuxSessionTabState(
+            currentAgentConversation = null,
+            presumedAgent = false,
+            recordedAgentKind = tmuxSessionRecordedAgentKind(SessionAgentKind.Shell),
+        )
+
+        assertEquals(listOf("Terminal"), state.labels)
+        assertEquals(0, state.selectedIndex)
+        assertTrue(!state.showsConversationTab)
+    }
+
+    @Test
+    fun tmuxSessionRecordedAgentKindClassifiesEveryKind() {
+        // The recorded-agent signal is true ONLY for the agent kinds and never
+        // for shell / transient / unknown / null — locking the classification so
+        // a future kind addition can't silently flip the no-flap control.
+        assertTrue(tmuxSessionRecordedAgentKind(SessionAgentKind.Claude))
+        assertTrue(tmuxSessionRecordedAgentKind(SessionAgentKind.Codex))
+        assertTrue(tmuxSessionRecordedAgentKind(SessionAgentKind.OpenCode))
+        assertTrue(!tmuxSessionRecordedAgentKind(SessionAgentKind.Shell))
+        assertTrue(!tmuxSessionRecordedAgentKind(SessionAgentKind.Probing))
+        assertTrue(!tmuxSessionRecordedAgentKind(SessionAgentKind.Exited))
+        assertTrue(!tmuxSessionRecordedAgentKind(SessionAgentKind.Unknown))
+        assertTrue(!tmuxSessionRecordedAgentKind(null))
     }
 
     @Test

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -833,6 +833,15 @@ JOURNEY_CLASSES=(
   #   - plainShellRecordedSessionShowsNoConversationToggle (#894 no-flap ADJACENCY):
   #     a recorded-shell session with NO agent transcript shows NO toggle (a recorded
   #     shell must not flash the Conversation tab).
+  #   - conversationTogglePresentForRecordedCodexAgentWhenSourceBindingFails (#1158):
+  #     a session recorded `@ps_agent_kind=codex` whose conversation source cannot
+  #     bind (no `/proc` match, no cwd transcript in-fixture) STILL shows a present +
+  #     tappable Terminal/Conversation toggle, and tapping it routes to the
+  #     Conversation placeholder (never collapses the tab). Tab presence follows the
+  #     RECORDED agent kind, independent of the fragile live binding. This is the
+  #     second kind in the class (Codex), covering the recurrence #962/#975 missed by
+  #     only proving vanilla Claude. (Fast JVM sibling: TmuxSessionScreenTest
+  #     .tmuxSessionTabStateShowsConversationForRecorded{Claude,Codex,ZaiClaude,OpenCode}*.)
   # It uses ONLY agents:2222 (DEFAULT_HOST/DEFAULT_PORT -> 10.0.2.2:2222) that
   # tests.yml already brings up, and does NOT self-skip on CI (no assumeTrue /
   # assumeFalse(isRunningOnCi())). Lives under com.pocketshell.app.tmux.


### PR DESCRIPTION
Restores the Conversation tab (maintainer: "I want it back please") — a RECURRENCE of #962/#1057.

**Root cause:** `showsConversationTab` depended only on the fragile live detection / transcript-source binding, which fails for the maintainer's fleet (node-wrapped Claude, Codex `/proc` match, glm/Z.AI alternate path) → tab vanished. The tree already records the kind (`@ps_agent_kind`) but it wasn't wired into tab presence. #962/#975/#1057 only tested vanilla Claude, so Codex/Z.AI regressed silently (the D31/D32 gap).

**Fix (#821 record-don't-guess):** OR the recorded agent kind into `showsConversationTab` — recorded Claude/Codex/OpenCode show the tab regardless of live detection; recorded Shell still hides it (#894 no-flap); an unbindable source routes to the Placeholder, never collapses the tab.

**Reviewer APPROVED** (https://github.com/alexeygrigorev/pocketshell/issues/1158#issuecomment-4854654703) with the D31 durable-fix gate: personally-run per-kind red→green (Claude/Codex/Z.AI/OpenCode fail on base with `[Terminal]`-only → green) in the always-on Unit gate, on-device Codex journey passed (`detection_bound=false` yet toggle present → placeholder), adjacency clean (#894/#815/#819/#820), scope confined (4 files; TmuxSessionViewModel/FolderList untouched).

Non-goal follow-up: generalize the transcript-source fallback so Codex/Z.AI actually LOAD content (#820 class).

Closes #1158