### PR TITLE
terminal: heal send-triggered >3-line half-black agent/shell pane (#1153)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/SendWithAttachmentStaysVisibleE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/SendWithAttachmentStaysVisibleE2eTest.kt
@@ -1,0 +1,715 @@
+package com.pocketshell.app.proof
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.util.Log
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.ViewModelProvider
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.BackgroundGraceTestOverride
+import com.pocketshell.app.MainActivity
+import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
+import com.pocketshell.app.hosts.SshKeyStorage
+import com.pocketshell.app.tmux.TMUX_SESSION_ERROR_TAG
+import com.pocketshell.app.tmux.TMUX_SESSION_RECONNECT_TAG
+import com.pocketshell.app.tmux.TMUX_SESSION_SCREEN_TAG
+import com.pocketshell.app.tmux.TmuxSessionViewModel
+import com.pocketshell.core.agents.AgentKind
+import com.pocketshell.core.ssh.KnownHostsPolicy
+import com.pocketshell.core.ssh.SshConnection
+import com.pocketshell.core.ssh.SshKey
+import com.pocketshell.core.storage.AppDatabase
+import com.pocketshell.core.storage.entity.HostEntity
+import com.termux.view.TerminalView
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+
+/**
+ * Issue #1153 — the DISCRIMINATING on-device journey for the maintainer's "I attach something and
+ * I send it, my screen went dark / black … it partly redrew itself but it was still too black …
+ * there was no reconnect" (v0.4.21 dogfood, 2026-07-01).
+ *
+ * ## The maintainer's report + root cause
+ *
+ * A composer Send WITH AN ATTACHMENT is ALWAYS multi-line (it appends an "Attached files:" block),
+ * so it takes the bracketed-paste + submit branch and the alt-screen agent clear+cursor-address-
+ * redraws its WHOLE viewport. The overpaint blanks the local grid and the agent only PARTIALLY
+ * repaints, leaving a large black BAND above a surviving input box + a few conversation lines +
+ * status — MORE than the ≤3 live lines the pre-#1153 partial-black heuristic capped at. The
+ * transport never dropped (no reconnect). The #941 post-send heal was supposed to catch this but
+ * gated on the LOCAL-ONLY `blank || partialBlank` heuristic and SKIPPED a >3-line half-black
+ * frame, and its single fixed 350 ms one-shot lost the race against the bigger attachment redraw.
+ *
+ * ## What this journey PROVES (D33 / G10 — real path, guaranteed-live transport)
+ *
+ * Seed a tmux session running a FULL-screen frame, attach, then:
+ *  1. Inject the >3-line HALF-BLACK overpaint (clear + a handful of live lines, NO frame marker)
+ *     straight into the SAME live emulator the app renders — the REMOTE tmux grid keeps the full
+ *     frame, so the transport is GUARANTEED LIVE.
+ *  2. Drive the REAL production send path with a WITH-ATTACHMENT (multi-line) payload.
+ *  3. Assert the SEND heal REPAINTS the visible render to MATCH tmux's authoritative `capture-pane`
+ *     (the marker re-renders across the upper rows AND the render is no longer a lost-frame vs the
+ *     capture — [TerminalSurfaceState.visibleRenderLostFrameVsCapture] goes TRUE→FALSE across the
+ *     send), the transport stays `Connected`, and NO reconnect surface appears.
+ *
+ * ## Why the acceptance is "matches tmux's capture", NOT an absolute row-fraction
+ *
+ * The heal's real contract is "the visible render is repainted to the SAME content tmux holds"
+ * ([TerminalSurfaceState.visibleRenderLostFrameVsCapture] false), NOT "the live rows exceed some
+ * fraction of the viewport". A correctly-restored agent frame can legitimately be a small fraction
+ * of a tall (e.g. 56-row) emulator viewport — the cheap send-heal pre-check
+ * [TerminalSurfaceState.visibleScreenLooksSparseForSendHeal] (a 0.5 live-fraction cost-gate) reads
+ * such a frame "sparse", which is HARMLESS: the authoritative `capture-pane` diff is the load-bearing
+ * guard and refuses to re-heal a frame that already matches tmux (proven at the JVM level by
+ * `shortPromptDoesNotThrashHeal`). So the final acceptance compares visible-vs-capture, not a
+ * viewport-relative row-fraction that a legitimate restored frame fails on a tall CI viewport.
+ *
+ * The steady-state stale-render watchdog is DISABLED for the run
+ * ([TmuxSessionViewModel.setStaleRenderWatchdogAutoArmEnabledForTest] false BEFORE attach), so ONLY
+ * the immediate SEND heal can green the pane — proving the fix is on the send path, not a slow
+ * background watchdog tick. The half-black is injected SYNTHETICALLY (the CI swiftshader AVD can't
+ * run a real agent redraw) and the load-bearing assertions HARD-fail otherwise — no
+ * `Assume.assumeFalse(isRunningOnCi())` self-skip (the #780/#1138 model).
+ *
+ * Runs on the per-PR emulator-journey job once wired into `scripts/ci-journey-suite.sh`.
+ */
+@RunWith(AndroidJUnit4::class)
+class SendWithAttachmentStaysVisibleE2eTest {
+
+    // Launch-owned MainActivity rule (#788/#848): the Compose test clock drives the SAME
+    // foreground MainActivity the Termux TerminalView interop child is placed into.
+    val compose = createAndroidComposeRule<MainActivity>()
+
+    @get:Rule
+    val ruleChain: org.junit.rules.RuleChain = org.junit.rules.RuleChain
+        .outerRule(PreGrantPermissionsRule())
+        .around(SeedBeforeLaunchRule { seedBeforeLaunch() })
+        .around(compose)
+
+    private lateinit var fixtureKey: String
+    private lateinit var hostRowTag: String
+
+    private suspend fun seedBeforeLaunch() {
+        BackgroundGraceTestOverride.setForTest(null)
+        val key = readFixtureKey()
+        fixtureKey = key
+        waitForSshFixtureReady(SshKey.Pem(key))
+        seedFullFrameSession(key)
+        hostRowTag = seedDockerHost(key)
+    }
+
+    @After
+    fun tearDown() {
+        BackgroundGraceTestOverride.setForTest(null)
+        if (::fixtureKey.isInitialized) {
+            runCatching { runBlocking { cleanupRemoteTmuxSession(fixtureKey) } }
+        }
+    }
+
+    @Test
+    fun sendWithAttachmentHealsHalfBlackActivePane() { runBlocking {
+        attachSeededTmuxSession(hostRowTag)
+
+        // Disable the steady-state stale-render watchdog for the run BEFORE the pane streams, so
+        // ONLY the immediate send heal can green a half-black pane (a clean discriminator).
+        disableStaleRenderWatchdog()
+
+        // Baseline: the full frame is on screen and the session is Connected.
+        waitForVisibleTerminal("initial full frame") { frameRowCount(it) >= MIN_RESTORED_FRAME_ROWS }
+        waitForConnected("initial attach")
+        capturePaintedRows("issue1153-00-attached")
+
+        // tmux's AUTHORITATIVE grid (via `capture-pane -p`) — the full frame. The test NEVER mutates
+        // the REMOTE session (the half-black is injected LOCAL-only), so this authoritative capture
+        // holds the full frame throughout and is the ground truth the send heal must repaint back to.
+        val authoritativeCapture = captureRemoteTmuxPane()
+        assertTrue(
+            "sanity: tmux's authoritative capture must hold the full frame marker; capture:\n$authoritativeCapture",
+            authoritativeCapture.contains(FRAME_MARKER),
+        )
+
+        // ===== Inject the >3-line HALF-BLACK overpaint on the LIVE, retained emulator. =====
+        // Clear + a handful of live lines (NO frame marker), leaving a large black band. The
+        // REMOTE tmux grid keeps the full frame, so the transport stays GUARANTEED LIVE.
+        val esc = ""
+        val halfBlack = buildString {
+            append("$esc[2J$esc[H")
+            // Cursor-address each live line onto a row SPACED [HALF_BLACK_ROW_STRIDE] apart, so a
+            // blank row separates them and `getSelectedText(joinBackLines=true)` cannot fold
+            // adjacent short lines into one logical line (contiguous short lines pack/join on the
+            // wide phone viewport and read as fewer live lines). The interspersed blank rows also
+            // ARE the black band this reproduces.
+            for (line in 0 until HALF_BLACK_LIVE_LINES) {
+                val row = 1 + line * HALF_BLACK_ROW_STRIDE
+                append("$esc[$row;1H$HALF_BLACK_MARKER live line $line after send overpaint")
+            }
+        }
+        feedFrameToEmulator(halfBlack)
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        capturePaintedRows("issue1153-01-half-black")
+
+        // ----- Symptom precondition: the injected pane is the >3-line HALF-BLACK send state. -----
+        val afterInject = visibleTerminalText()
+        assertFalse(
+            "the injected half-black must have WIPED the full frame (marker gone from the visible " +
+                "grid); visible:\n$afterInject",
+            afterInject.contains(FRAME_MARKER),
+        )
+        assertTrue(
+            "the injected pane must keep MORE than 3 live lines (the >3-line half-black band the " +
+                "pre-#1153 heal skipped), found ${frameRowCount(afterInject)}",
+            frameRowCount(afterInject) > 3,
+        )
+        assertFalse(
+            "precondition (#1153 RED gap): the pane is NOT the ≤3-line partial-black the pre-#1153 " +
+                "send heal covered",
+            activePanePartiallyBlank(),
+        )
+        // The cheap send-heal pre-check flags the half-black as worth paying for the authoritative
+        // `capture-pane` diff (a >3-line half-black is at/under the 0.5 live-fraction cost-gate).
+        assertTrue(
+            "precondition: the send-heal pre-check must flag the half-black render as sparse enough " +
+                "to pay for the authoritative capture diff",
+            activePaneLooksSparse(),
+        )
+        // LOAD-BEARING precondition (RED): the injected half-black render is a genuine LOST FRAME
+        // vs tmux's authoritative capture — tmux holds MATERIALLY MORE than the render shows. This
+        // is the exact predicate the production send heal keys off, so it goes TRUE here (lost) and
+        // must go FALSE after the heal (matches tmux).
+        assertTrue(
+            "precondition: the half-black render must be a LOST FRAME vs tmux's authoritative " +
+                "capture (tmux holds materially more than the render shows)",
+            activePaneLostFrameVsCapture(authoritativeCapture),
+        )
+
+        // ----- DISCRIMINATOR: the transport is GUARANTEED LIVE (a render bug, not a drop). -----
+        assertTrue(
+            "the transport must stay Connected with a half-black render, observed=${currentConnectionStatus()}",
+            currentConnectionStatus() is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+        assertFalse("the tmux client must NOT be disconnected", clientDisconnected())
+        assertNoVisibleReconnect("half-black (no reconnect surface)")
+
+        // Keep the activity RESUMED across the send + heal window so a loaded CI emulator's
+        // spurious onStop cannot park/clear the runtime mid-send (the runtime the heal runs on
+        // must stay alive through drive+assert).
+        runCatching { compose.activityRule.scenario.moveToState(Lifecycle.State.RESUMED) }
+
+        // ===== Drive the REAL production send path with a WITH-ATTACHMENT (multi-line) payload. =====
+        val sendResult = driveWithAttachmentSend()
+        assertTrue("the with-attachment send itself must succeed", sendResult)
+
+        // ----- GREEN: the SEND heal must restore the FULL frame (the upper black band repainted). -----
+        val visibleAfter = waitForVisibleTerminal(
+            "send-heal full-frame restore",
+            timeoutMillis = RESTORE_TIMEOUT_MS,
+        ) { it.contains(FRAME_MARKER) && frameRowCount(it) >= MIN_RESTORED_FRAME_ROWS }
+        assertTrue(
+            "REGRESSION (#1153): the with-attachment send heal must restore the FULL frame (the " +
+                "marker + the upper rows that were black). On base the LOCAL-ONLY blank/partial-black " +
+                "gate skipped the >3-line half-black and the pane stayed too black. Found rows=" +
+                "${frameRowCount(visibleAfter)}.\n$visibleAfter",
+            visibleAfter.contains(FRAME_MARKER) && frameRowCount(visibleAfter) >= MIN_RESTORED_FRAME_ROWS,
+        )
+        // LOAD-BEARING GREEN: the heal's REAL contract — the visible render is repainted to MATCH
+        // tmux's authoritative capture, so it is no longer a LOST FRAME (the frame is NOT left
+        // partial-black relative to what tmux actually holds). This is the same production predicate
+        // the send heal keys off, now FALSE. NOTE: it is deliberately NOT an absolute row-fraction
+        // ("looks sparse"): a correctly-restored agent frame can legitimately be a small fraction of
+        // a tall CI viewport, which the cheap 0.5 cost-gate would still flag "sparse" — harmless,
+        // because the capture diff (this assertion) is the real acceptance.
+        assertFalse(
+            "REGRESSION (#1153): after the send heal the render must MATCH tmux's authoritative " +
+                "capture (no longer a lost-frame / left partial-black relative to what tmux holds). " +
+                "On base the LOCAL-ONLY blank/partial-black gate skipped the >3-line half-black and " +
+                "the render stayed too black while tmux held the full frame.\n$visibleAfter",
+            activePaneLostFrameVsCapture(authoritativeCapture),
+        )
+        capturePaintedRows("issue1153-02-healed")
+
+        // ----- DISCRIMINATOR: still Connected, no reconnect across the send + heal. -----
+        assertNoVisibleReconnect("post-heal (no reconnect surface)")
+        assertTrue(
+            "session must stay Connected after the send heal (render fix, no reconnect), " +
+                "observed=${currentConnectionStatus()}",
+            currentConnectionStatus() is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+        writeSummary()
+    } }
+
+    // ---------------------------------------------------------------- Drive the send
+
+    /**
+     * Drive the REAL production send path with a WITH-ATTACHMENT (multi-line) payload. Neutralizes
+     * the #869 submit-ack gate (against the idle fixture the paste never echoes, so the ack never
+     * matches) so the send returns promptly, then the internal
+     * [TmuxSessionViewModel.sendAgentPayloadToPaneResult] runs — including scheduling the post-send
+     * overpaint heal this journey exercises.
+     */
+    private fun driveWithAttachmentSend(): Boolean {
+        var ok = false
+        compose.activityRule.scenario.onActivity { activity ->
+            val vm = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+            val paneId = vm.panes.value.firstOrNull()?.paneId ?: return@onActivity
+            vm.setAgentSubmitEnterDelayForTest(0)
+            vm.setAgentSubmitAckTimeoutForTest(ACK_TIMEOUT_MS)
+            ok = runBlocking {
+                vm.sendAgentPayloadToPaneResult(paneId, WITH_ATTACHMENT_PAYLOAD, AgentKind.Codex).isSuccess
+            }
+        }
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        return ok
+    }
+
+    private fun disableStaleRenderWatchdog() {
+        compose.activityRule.scenario.onActivity { activity ->
+            ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+                .setStaleRenderWatchdogAutoArmEnabledForTest(false)
+        }
+    }
+
+    private fun activePanePartiallyBlank(): Boolean {
+        var hit = false
+        compose.activityRule.scenario.onActivity { activity ->
+            hit = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+                .panes.value.firstOrNull()
+                ?.terminalState
+                ?.visibleScreenIsPartiallyBlank() ?: false
+        }
+        return hit
+    }
+
+    private fun activePaneLooksSparse(): Boolean {
+        var hit = false
+        compose.activityRule.scenario.onActivity { activity ->
+            hit = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+                .panes.value.firstOrNull()
+                ?.terminalState
+                ?.visibleScreenLooksSparseForSendHeal() ?: false
+        }
+        return hit
+    }
+
+    /**
+     * The heal's REAL contract, keyed off the SAME production predicate the send heal uses
+     * ([TerminalSurfaceState.visibleRenderLostFrameVsCapture]): is the active pane's visible render a
+     * LOST FRAME relative to tmux's authoritative `capture-pane` — tmux holds materially MORE than
+     * the render shows? TRUE = the render is left partial-black vs what tmux actually has; FALSE =
+     * the render matches tmux's grid (nothing lost). Viewport-independent — the acceptance the
+     * geometrically-fixed 0.5 row-fraction "looks sparse" check cannot express.
+     */
+    private fun activePaneLostFrameVsCapture(capture: String): Boolean {
+        var hit = false
+        compose.activityRule.scenario.onActivity { activity ->
+            hit = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+                .panes.value.firstOrNull()
+                ?.terminalState
+                ?.visibleRenderLostFrameVsCapture(capture) ?: false
+        }
+        return hit
+    }
+
+    private fun clientDisconnected(): Boolean {
+        var disconnected = false
+        compose.activityRule.scenario.onActivity { activity ->
+            disconnected = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+                .clientDisconnectedForTest()
+        }
+        return disconnected
+    }
+
+    // ---------------------------------------------------------------- Emulator feed
+
+    private fun feedFrameToEmulator(frame: String) {
+        val bytes = frame.toByteArray(Charsets.UTF_8)
+        var fed = false
+        compose.activityRule.scenario.onActivity { activity ->
+            val view = activity.window.decorView.findTerminalView() ?: return@onActivity
+            val emulator = view.mEmulator ?: return@onActivity
+            emulator.append(bytes, bytes.size)
+            view.invalidate()
+            fed = true
+        }
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        assertTrue("expected to feed the half-black frame to the live emulator", fed)
+    }
+
+    // ---------------------------------------------------------------- Render capture
+
+    private fun capturePaintedRows(name: String): Int {
+        val bitmap = renderViewportBitmap() ?: return 0
+        writeBitmap("$name-viewport", bitmap)
+        writeText("$name-visible-terminal.txt", visibleTerminalText())
+        val rows = paintedRowCount(bitmap)
+        bitmap.recycle()
+        return rows
+    }
+
+    private fun renderViewportBitmap(): Bitmap? {
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        var bitmap: Bitmap? = null
+        compose.activityRule.scenario.onActivity { activity ->
+            val view = activity.window.decorView.findTerminalView() ?: return@onActivity
+            if (view.width <= 0 || view.height <= 0) return@onActivity
+            val b = Bitmap.createBitmap(view.width, view.height, Bitmap.Config.ARGB_8888)
+            view.draw(Canvas(b))
+            bitmap = b
+        }
+        return bitmap
+    }
+
+    private fun paintedRowCount(bitmap: Bitmap): Int {
+        var painted = 0
+        var y = 0
+        while (y < bitmap.height) {
+            var x = 0
+            var rowPainted = false
+            while (x < bitmap.width) {
+                val p = bitmap.getPixel(x, y)
+                if (android.graphics.Color.red(p) > 40 ||
+                    android.graphics.Color.green(p) > 40 ||
+                    android.graphics.Color.blue(p) > 40
+                ) {
+                    rowPainted = true
+                    break
+                }
+                x += 4
+            }
+            if (rowPainted) painted++
+            y += 4
+        }
+        return painted
+    }
+
+    private fun frameRowCount(text: String): Int =
+        text.split('\n').count { it.isNotBlank() }
+
+    // ---------------------------------------------------------------- Attach / wait
+
+    private fun attachSeededTmuxSession(hostRowTag: String) {
+        compose.waitUntil(timeoutMillis = TerminalTestTimeouts.screenRenderPresenceTimeoutMs()) {
+            runCatching {
+                compose.onAllNodesWithTag(hostRowTag, useUnmergedTree = true)
+                    .fetchSemanticsNodes().isNotEmpty()
+            }.getOrDefault(false)
+        }
+        compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick()
+        compose.waitUntil(timeoutMillis = TerminalTestTimeouts.terminalVisibilityTimeoutMs()) {
+            runCatching {
+                compose.onAllNodesWithText(SESSION_NAME, useUnmergedTree = true)
+                    .fetchSemanticsNodes().isNotEmpty()
+            }.getOrDefault(false)
+        }
+        compose.onNodeWithText(SESSION_NAME, useUnmergedTree = true).performClick()
+        compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertExists()
+        waitForTerminalViewAttached()
+    }
+
+    private fun waitForTerminalViewAttached() {
+        compose.waitUntil(timeoutMillis = 30_000) {
+            var attached = false
+            compose.activityRule.scenario.onActivity { activity ->
+                val view = activity.window.decorView.findTerminalView()
+                attached = view?.currentSession != null && view.mEmulator != null
+            }
+            attached
+        }
+    }
+
+    private fun waitForConnected(label: String) {
+        compose.waitUntil(timeoutMillis = CONNECTED_TIMEOUT_MS) {
+            currentConnectionStatus() is TmuxSessionViewModel.ConnectionStatus.Connected
+        }
+        assertTrue(
+            "expected Connected after $label, observed=${currentConnectionStatus()}",
+            currentConnectionStatus() is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+    }
+
+    private fun currentConnectionStatus(): TmuxSessionViewModel.ConnectionStatus {
+        var status: TmuxSessionViewModel.ConnectionStatus = TmuxSessionViewModel.ConnectionStatus.Idle
+        compose.activityRule.scenario.onActivity { activity ->
+            status = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+                .connectionStatus.value
+        }
+        return status
+    }
+
+    private fun waitForVisibleTerminal(
+        label: String,
+        timeoutMillis: Long = TerminalTestTimeouts.terminalVisibilityTimeoutMs(),
+        predicate: (String) -> Boolean,
+    ): String {
+        var last = ""
+        val satisfied = runCatching {
+            compose.waitUntil(timeoutMillis = timeoutMillis) {
+                last = visibleTerminalText()
+                predicate(last)
+            }
+            true
+        }.getOrDefault(false)
+        if (!satisfied) writeText("failure-$label-visible-terminal.txt", last)
+        assertTrue("expected visible terminal for $label; got:\n$last", predicate(last))
+        return last
+    }
+
+    private fun visibleTerminalText(): String {
+        var text = ""
+        compose.activityRule.scenario.onActivity { activity ->
+            text = activity.window.decorView
+                .findTerminalView()?.currentSession?.emulator?.screen?.transcriptText.orEmpty()
+        }
+        return text
+    }
+
+    private fun assertNoVisibleReconnect(label: String) {
+        org.junit.Assert.assertEquals(
+            "expected no disconnect band for $label", 0,
+            compose.onAllNodesWithTag(TMUX_SESSION_ERROR_TAG, useUnmergedTree = true)
+                .fetchSemanticsNodes().size,
+        )
+        org.junit.Assert.assertEquals(
+            "expected no Tap Reconnect button for $label", 0,
+            compose.onAllNodesWithTag(TMUX_SESSION_RECONNECT_TAG, useUnmergedTree = true)
+                .fetchSemanticsNodes().size,
+        )
+        listOf("Reconnecting", "Disconnected", "Tap Reconnect").forEach { text ->
+            org.junit.Assert.assertEquals(
+                "expected no visible '$text' text for $label", 0,
+                compose.onAllNodesWithText(text, substring = true, useUnmergedTree = true)
+                    .fetchSemanticsNodes().size,
+            )
+        }
+    }
+
+    // ---------------------------------------------------------------- Fixture
+
+    private fun readFixtureKey(): String =
+        InstrumentationRegistry.getInstrumentation()
+            .context.assets.open("test_key").bufferedReader().use { it.readText() }
+
+    private suspend fun seedDockerHost(key: String): String {
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
+        val db = Room.databaseBuilder(appContext, AppDatabase::class.java, DATABASE_NAME)
+            .fallbackToDestructiveMigration(dropAllTables = true)
+            .build()
+        return try {
+            db.clearAllTables()
+            val storedKey = SshKeyStorage.persistKey(
+                context = appContext,
+                sshKeyDao = db.sshKeyDao(),
+                name = "issue1153-key-${System.currentTimeMillis()}",
+                content = key,
+            )
+            val hostId = db.hostDao().insert(
+                HostEntity(
+                    name = "Issue1153 Send-With-Attachment Half Black",
+                    hostname = DEFAULT_HOST,
+                    port = DEFAULT_PORT,
+                    username = DEFAULT_USER,
+                    keyId = storedKey.id,
+                    tmuxInstalled = true,
+                    lastBootstrapAt = System.currentTimeMillis(),
+                ),
+            )
+            HOST_ROW_TAG_PREFIX + hostId
+        } finally {
+            db.close()
+        }
+    }
+
+    /**
+     * Seed a tmux session running a FULL-screen frame: ~20 marker rows the app renders on attach
+     * (dense enough that tmux's authoritative `capture-pane` holds MATERIALLY MORE than the
+     * injected half-black band, so the send heal has a real frame to restore).
+     */
+    private suspend fun seedFullFrameSession(key: String) {
+        val e = "\\033"
+        val frame = buildString {
+            append("$e[?1049h")   // enter alternate screen buffer
+            append("$e[2J$e[H")   // clear + home
+            for (row in 1..FULL_FRAME_ROWS) {
+                append("$e[$row;1H$FRAME_MARKER row $row : real agent conversation content here padding")
+            }
+        }
+        val payload = "printf '$frame'; while true; do sleep 3600; done"
+        val script = buildString {
+            appendLine("set -eu")
+            appendLine("tmux kill-session -t ${shellQuote(SESSION_NAME)} 2>/dev/null || true")
+            appendLine("tmux new-session -d -s ${shellQuote(SESSION_NAME)} ${shellQuote(payload)}")
+            appendLine("sleep 2")
+            appendLine("tmux list-sessions")
+        }
+        val result = SshConnection.connect(
+            host = DEFAULT_HOST,
+            port = DEFAULT_PORT,
+            user = DEFAULT_USER,
+            key = SshKey.Pem(key),
+            knownHosts = KnownHostsPolicy.AcceptAll,
+            timeoutMs = 15_000,
+        ).mapCatching { session -> session.use { it.exec(script) } }
+        val exec = result.getOrNull()
+        assertTrue(
+            "expected tmux seeding to succeed; exception=${result.exceptionOrNull()} stderr='${exec?.stderr}'",
+            exec?.exitCode == 0,
+        )
+        Log.i(LOG_TAG, "seeded full-frame session: ${exec?.stdout?.trim()}")
+    }
+
+    /**
+     * Fetch tmux's AUTHORITATIVE visible-pane content via `capture-pane -p` (plain text, NO `-e`
+     * escapes — so its non-whitespace glyph count is comparable to the render's, the way
+     * [TerminalSurfaceState.visibleRenderLostFrameVsCapture] measures both sides). This is the
+     * ground-truth frame the send heal must repaint the local render back to.
+     */
+    private suspend fun captureRemoteTmuxPane(): String {
+        val script = "tmux capture-pane -p -t ${shellQuote(SESSION_NAME)}"
+        val result = SshConnection.connect(
+            host = DEFAULT_HOST,
+            port = DEFAULT_PORT,
+            user = DEFAULT_USER,
+            key = SshKey.Pem(fixtureKey),
+            knownHosts = KnownHostsPolicy.AcceptAll,
+            timeoutMs = 15_000,
+        ).mapCatching { session -> session.use { it.exec(script) } }
+        val exec = result.getOrNull()
+        assertTrue(
+            "expected `capture-pane` to succeed; exception=${result.exceptionOrNull()} stderr='${exec?.stderr}'",
+            exec?.exitCode == 0,
+        )
+        return exec?.stdout.orEmpty()
+    }
+
+    private suspend fun cleanupRemoteTmuxSession(key: String) {
+        runCatching {
+            SshConnection.connect(
+                host = DEFAULT_HOST,
+                port = DEFAULT_PORT,
+                user = DEFAULT_USER,
+                key = SshKey.Pem(key),
+                knownHosts = KnownHostsPolicy.AcceptAll,
+                timeoutMs = 15_000,
+            ).mapCatching { session ->
+                session.use { it.exec("tmux kill-session -t ${shellQuote(SESSION_NAME)} 2>/dev/null || true") }
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------- Artifacts
+
+    private fun writeBitmap(name: String, bitmap: Bitmap): File {
+        val file = artifactFile("$name.png")
+        java.io.FileOutputStream(file).use { out ->
+            check(bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)) {
+                "failed to write bitmap to ${file.absolutePath}"
+            }
+        }
+        println("ISSUE1153_VIEWPORT ${file.absolutePath}")
+        return file
+    }
+
+    private fun writeText(name: String, text: String): File {
+        val file = artifactFile(name)
+        file.writeText(text)
+        println("ISSUE1153_TEXT ${file.absolutePath}")
+        return file
+    }
+
+    private fun writeSummary(): File =
+        writeText(
+            "issue1153-summary.txt",
+            buildString {
+                appendLine("test=SendWithAttachmentStaysVisibleE2eTest")
+                appendLine("issue=1153")
+                appendLine("fixture=tests/docker agents ($DEFAULT_HOST:$DEFAULT_PORT), full-screen frame")
+                appendLine("running_on_ci=${TerminalTestTimeouts.isRunningOnCi()}")
+                appendLine("session=$SESSION_NAME")
+                appendLine("frame_marker=$FRAME_MARKER")
+                appendLine("watchdog=disabled (only the SEND heal can green the pane)")
+                appendLine(
+                    "scenario=attach a full-screen frame, inject a >3-line HALF-BLACK overpaint on " +
+                        "the LIVE emulator, drive a REAL with-attachment (multi-line) send, assert " +
+                        "the SEND heal restores the full frame with the transport still Connected",
+                )
+                appendLine(
+                    "expectation=transport ALIVE (Connected, no reconnect surface) AND render HEALS " +
+                        "on the SEND path (full frame restored from tmux's authoritative capture)",
+                )
+            },
+        )
+
+    private fun artifactFile(name: String): File {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val mediaRoot = com.pocketshell.app.test.testArtifactsRoot(instrumentation.targetContext)
+        val dir = File(mediaRoot, "additional_test_output/$DEVICE_DIR_NAME")
+        check(dir.exists() || dir.mkdirs()) { "could not create artifact directory ${dir.absolutePath}" }
+        return File(dir, name)
+    }
+
+    private fun View.findTerminalView(): TerminalView? {
+        if (this is TerminalView) return this
+        if (this !is ViewGroup) return null
+        for (index in 0 until childCount) {
+            val match = getChildAt(index).findTerminalView()
+            if (match != null) return match
+        }
+        return null
+    }
+
+    private fun shellQuote(value: String): String =
+        "'" + value.replace("'", "'\"'\"'") + "'"
+
+    private companion object {
+        const val DATABASE_NAME: String = "pocketshell.db"
+        const val LOG_TAG: String = "Issue1153SendHalfBlack"
+        const val DEVICE_DIR_NAME: String = "issue1153-send-with-attachment-half-black"
+        const val SESSION_NAME: String = "issue1153-send-halfblack"
+        const val FRAME_MARKER: String = "ISSUE1153-FRAME"
+        const val HALF_BLACK_MARKER: String = "ISSUE1153-HALFBLACK"
+
+        // NOTE: DEFAULT_HOST / DEFAULT_PORT / DEFAULT_USER are the pool-aware package-level vals
+        // from AndroidSshTestFixtures.kt (backed by the `agentsPort` instrumentation arg), NOT
+        // hardcoded here — so this journey runs correctly under both single-lane (2222) and
+        // `--pool` (self-allocated fixture port) modes.
+
+        // A dense full-screen frame so tmux holds materially more than the injected half-black band.
+        const val FULL_FRAME_ROWS: Int = 20
+
+        // >3 live lines (so NOT the ≤3-line partial-black) yet a small fraction of any real phone
+        // viewport (≥ ~24 rows) — the >3-line half-black band the pre-#1153 heal missed.
+        const val HALF_BLACK_LIVE_LINES: Int = 6
+
+        // Rows between successive live lines (a blank row between each) so `transcriptText`
+        // cannot fold adjacent short lines into one logical line, and the gaps form the band.
+        const val HALF_BLACK_ROW_STRIDE: Int = 2
+
+        const val MIN_RESTORED_FRAME_ROWS: Int = 10
+
+        // A with-attachment composer payload: the draft plus the "Attached files:" block the
+        // composer appends, which makes every with-attachment send multi-line (bracketed paste).
+        const val WITH_ATTACHMENT_PAYLOAD: String =
+            "please review this\n\nAttached files:\n- /home/testuser/report.txt"
+
+        val ACK_TIMEOUT_MS: Long = 800L
+        val RESTORE_TIMEOUT_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 20_000L else 12_000L
+        val CONNECTED_TIMEOUT_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 30_000L else 15_000L
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -13026,50 +13026,78 @@ public class TmuxSessionViewModel @Inject constructor(
     }
 
     /**
-     * Issue #941 (black-screen B1): after a send's submit Enter, the agent's
-     * `%output` overpaint can leave the active pane partial-black. Wait one settle
-     * tick for the overpaint to land, then — ONLY if the active pane is blank /
-     * partial-black — do the UNCONDITIONAL active-pane full-viewport restore
-     * ([reseedActivePaneForReattach], a `capture-pane` clear+repaint). Guarded by a
-     * [RuntimeRefreshGuard] keyed to the current generation + target + client so a
-     * late heal can never paint a switched-away session, and scoped to the pane the
-     * user is actually looking at (the active visible pane), since only that pane's
-     * overpaint is the reported "everything went black".
+     * Issue #941 (black-screen B1) + issue #1153 (send-with-attachment half-black): after a
+     * send's submit Enter, the agent's `%output` overpaint can leave the active pane BLACK or
+     * partial-black. A composer Send WITH AN ATTACHMENT is always multi-line (it appends an
+     * "Attached files:" block), so it takes the bracketed-paste + submit branch and the
+     * alt-screen agent clear+cursor-address-redraws its WHOLE viewport — the overpaint blanks
+     * the grid and the agent only PARTIALLY repaints, leaving the maintainer's "partly redrew
+     * but still too black" pane on a LIVE transport (no reconnect).
      *
-     * One-shot, no loop: a real one-line agent prompt looks partial-black too, and
-     * re-capturing it just re-paints the same authoritative content, so there is no
-     * reseed-thrash. The heal is a no-op when the overpaint left a normally-painted
-     * pane (the common case — a multi-line agent response), so a healthy send costs
-     * nothing beyond the cheap blank/partial-blank pre-check.
+     * The pre-#1153 heal had TWO gaps this closes:
+     *  1. It gated on the LOCAL-ONLY `visibleScreenIsBlank() || visibleScreenIsPartiallyBlank()`
+     *     heuristic (≤3 live lines / ≤25% rows). A "partly redrew" frame has MORE than 3 live
+     *     lines (input box + a few conversation lines + status) yet materially less than tmux's
+     *     full grid, so it failed the gate and the heal skipped. Now the heal judges the pane
+     *     against tmux's AUTHORITATIVE `capture-pane` via [healActivePaneIfStaleRender] — the
+     *     #1138 union oracle [TerminalSurfaceState.visibleRenderLostFrameVsCapture], widened for
+     *     #1153 to catch the >3-line half-black band — so it fires whenever the on-screen frame
+     *     is materially less than the authoritative grid, not only when ≤3 lines survive.
+     *  2. Its fixed 350 ms one-shot lost the race against the bigger attachment redraw (the pane
+     *     could still be mid-clear at 350 ms, or the redraw could land AFTER it). Now it re-checks
+     *     on a bounded cadence ([SEND_OVERPAINT_HEAL_MAX_TICKS] settle ticks), so a late/large
+     *     redraw is still caught and a re-overpaint after an early heal is re-healed.
+     *
+     * A DENSE, normally-painted response is a no-op: each tick pays only the cheap LOCAL
+     * [TerminalSurfaceState.visibleScreenLooksSparseForSendHeal] pre-check and pays for the
+     * authoritative `capture-pane` diff ONLY when the render looks sparse enough to possibly be
+     * a lost frame. The heal is guarded by a [RuntimeRefreshGuard] keyed to the current
+     * generation + target + client so a late heal can never paint a switched-away session, and
+     * is scoped to the pane the send targeted while it is still the active pane.
      */
     private fun scheduleSendOverpaintHeal(client: TmuxClient, paneId: String) {
         val target = activeTarget ?: return
         val healGeneration = connectGeneration
+        val guard = RuntimeRefreshGuard(
+            generation = healGeneration,
+            target = target,
+            client = client,
+        )
         bridgeScope.launch {
-            // Let the post-submit agent overpaint land before judging the pane.
-            delay(SEND_OVERPAINT_HEAL_SETTLE_MS)
-            if (clientRef !== client) return@launch
-            if (client.disconnected.value) return@launch
-            val activePane = activeVisiblePane() ?: return@launch
-            // Heal only the pane the send targeted while it is still the active pane
-            // (the reported "sent a message → everything black" is the focused pane).
-            if (activePane.paneId != paneId) return@launch
-            val blank = activePane.terminalState.visibleScreenIsBlank()
-            val partialBlank = activePane.terminalState.visibleScreenIsPartiallyBlank()
-            if (!blank && !partialBlank) return@launch
-            Log.i(
-                ISSUE_145_RECONNECT_TAG,
-                "tmux-send-overpaint-active-pane-heal pane=${activePane.paneId} " +
-                    "window=${activePane.windowId} session=${target.sessionName} " +
-                    "blank=$blank partialBlank=$partialBlank",
-            )
-            reseedActivePaneForReattach(
-                RuntimeRefreshGuard(
-                    generation = healGeneration,
-                    target = target,
-                    client = client,
-                ),
-            )
+            repeat(SEND_OVERPAINT_HEAL_MAX_TICKS) { tick ->
+                // Let the post-submit agent overpaint land (and re-check on later ticks for a
+                // late/large attachment redraw) before judging the pane.
+                delay(SEND_OVERPAINT_HEAL_SETTLE_MS)
+                if (clientRef !== client) return@launch
+                if (client.disconnected.value) return@launch
+                if (inlineConnectionStatus !is ConnectionStatus.Connected) return@launch
+                if (!isCurrentRuntime(guard)) return@launch
+                val activePane = activeVisiblePane() ?: return@launch
+                // Heal only the pane the send targeted while it is still the active pane
+                // (the reported "sent a message → everything black" is the focused pane).
+                if (activePane.paneId != paneId) return@launch
+                // Cheap LOCAL pre-check: skip the capture round-trip on a dense, normally-painted
+                // response (its live rows sit above the sparse ceiling). Only a fully-blank /
+                // partial-black / >3-line half-black render pays for the authoritative diff.
+                if (!activePane.terminalState.visibleScreenLooksSparseForSendHeal()) return@repeat
+                Log.i(
+                    ISSUE_145_RECONNECT_TAG,
+                    "tmux-send-overpaint-active-pane-heal-check pane=${activePane.paneId} " +
+                        "window=${activePane.windowId} session=${target.sessionName} tick=$tick",
+                )
+                // Authoritative heal: capture tmux's grid, diff it against the render, and
+                // re-seed ONLY when the render is materially less than the authoritative frame.
+                val healed = runCatching {
+                    healActivePaneIfStaleRender(client, activePane, guard)
+                }.getOrDefault(false)
+                if (healed) {
+                    Log.i(
+                        ISSUE_145_RECONNECT_TAG,
+                        "tmux-send-overpaint-active-pane-heal-applied pane=${activePane.paneId} " +
+                            "session=${target.sessionName} tick=$tick",
+                    )
+                }
+            }
         }
     }
 
@@ -14256,6 +14284,16 @@ public class TmuxSessionViewModel @Inject constructor(
         bytes: ByteArray,
     ): Result<Unit> = runCatching {
         sendInputBytesToPane(client, paneId, bytes)
+        // Issue #1153 (class coverage — shell pane): the agent send path
+        // ([sendAgentPayloadToPaneResult]) already schedules the post-send overpaint heal, but
+        // the shell `RawBytes` route had NONE. A MULTI-LINE paste into a full-screen shell TUI
+        // (vim/htop/less/…) can trigger the same clear+redraw overpaint that leaves the pane
+        // half-black on a live transport. Schedule the same bounded, capture-diff-gated heal
+        // ONLY for a multi-line payload — a single keystroke never overpaints the whole
+        // viewport, so per-keystroke input pays nothing.
+        if (BracketedPaste.containsLineBreak(bytes)) {
+            scheduleSendOverpaintHeal(client, paneId)
+        }
     }
 
     internal fun sendControlInputToPane(
@@ -17571,6 +17609,17 @@ internal const val STALE_RENDER_WATCHDOG_MAX_TICKS: Int = 10_000
  * multi-line agent response has painted (so the heal correctly no-ops).
  */
 internal const val SEND_OVERPAINT_HEAL_SETTLE_MS: Long = 350L
+
+/**
+ * Issue #1153: the post-send overpaint heal re-checks the active pane this many times, once
+ * per [SEND_OVERPAINT_HEAL_SETTLE_MS] settle tick. The pre-#1153 heal was a SINGLE fixed
+ * 350 ms one-shot, which lost the race against the bigger with-attachment (multi-line paste)
+ * agent redraw — the pane could still be mid-clear at 350 ms, or the redraw could land AFTER
+ * it. A short bounded poll (≈1.4 s over 4 ticks) catches a late/large redraw and re-heals a
+ * re-overpaint after an early heal, while a dense normally-painted response pays only the cheap
+ * local pre-check each tick (no capture). Bounded so a send never leaves a lingering poll.
+ */
+internal const val SEND_OVERPAINT_HEAL_MAX_TICKS: Int = 4
 
 /**
  * Parse a tmux `display-message -p '#{cursor_x},#{cursor_y}'` reply line

--- a/app/src/test/java/com/pocketshell/app/tmux/PartialBlackPaneHealTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/PartialBlackPaneHealTest.kt
@@ -291,11 +291,13 @@ class PartialBlackPaneHealTest {
         advanceUntilIdle()
         neutralizeSubmitAckGate(vm, client)
 
-        // A normal multi-line agent response: many live rows -> neither blank nor
-        // partial-black -> the post-send heal must correctly no-op.
+        // A normal multi-line agent response: a DENSE viewport (well over half the 40 rows
+        // live) -> neither blank, nor partial-black, nor sparse-half-black
+        // ([TerminalSurfaceState.visibleScreenLooksSparseForSendHeal] false) -> the post-send
+        // heal must correctly no-op and never pay for a `capture-pane` diff (#1153).
         val fullFrame = buildString {
             append(CLEAR_ONLY)
-            repeat(20) { append("agent response line $it with real content\r\n") }
+            repeat(32) { append("agent response line $it with real content\r\n") }
         }
         pane.terminalState.appendRemoteOutput(fullFrame.toByteArray(Charsets.US_ASCII))
         advanceUntilIdle()
@@ -428,6 +430,190 @@ class PartialBlackPaneHealTest {
         )
     }
 
+    // -------------------------------------------------------------------------
+    // (8) Issue #1153: a composer Send WITH AN ATTACHMENT is ALWAYS multi-line (it
+    //     appends an "Attached files:" block), so it takes the bracketed-paste +
+    //     submit branch and the alt-screen agent clear+redraws its WHOLE viewport.
+    //     The overpaint leaves the pane HALF-black: >3 live lines (input box + a few
+    //     conversation lines + status) over a large black upper band. This is NEITHER
+    //     fully blank NOR the ≤3-line partial-black, so the pre-#1153 send heal's
+    //     LOCAL-ONLY `blank || partialBlank` gate SKIPPED it (RED). With the fix the
+    //     heal judges the pane against tmux's authoritative capture and restores the
+    //     full frame (GREEN). AGENT pane, with-attachment payload.
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun sendWithAttachmentHealsHalfBlackAgentPane() = runVmTest {
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%8", title = "codex")
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == "%8" }
+
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+        neutralizeSubmitAckGate(vm, client)
+
+        // The send's overpaint leaves the pane HALF-black (>3 live lines, large black band).
+        overpaintAltScreenHalfBlack(pane)
+        assertFalse(
+            "precondition: a half-black pane is NOT fully blank",
+            pane.terminalState.visibleScreenIsBlank(),
+        )
+        assertFalse(
+            "precondition (#1153 RED gap): the half-black pane has MORE than 3 live lines so it " +
+                "is NOT the ≤3-line partial-black the pre-#1153 send heal covered — its LOCAL-ONLY " +
+                "`blank || partialBlank` gate would SKIP it",
+            pane.terminalState.visibleScreenIsPartiallyBlank(),
+        )
+        assertFalse(
+            "precondition (#1153 RED gap): the #966 divergence oracle ALSO misses the half-black " +
+                "band (its surviving content exceeds the 25% ceiling of the full frame)",
+            pane.terminalState.visibleScreenDivergesFromCapture(HALF_BLACK_FULL_FRAME.joinToString("\n")),
+        )
+
+        // Queue the FULL frame tmux's grid returns on the post-send HEAL capture.
+        client.capturePaneResponses.addLast(
+            CommandResponse(number = 99L, output = HALF_BLACK_FULL_FRAME, isError = false),
+        )
+        val healCapturesBefore = client.healCaptureCount()
+
+        // THE REAL SEND PATH with a WITH-ATTACHMENT (multi-line) payload.
+        val result = vm.sendAgentPayloadToPaneResult("%8", WITH_ATTACHMENT_PAYLOAD, AgentKind.Codex)
+        advanceUntilIdle()
+
+        assertTrue("the send itself must succeed", result.isSuccess)
+        assertTrue(
+            "REGRESSION (#1153): a with-attachment send whose overpaint left the active pane " +
+                "HALF-black (>3 live lines) must trigger the post-send HEAL. On base the " +
+                "LOCAL-ONLY blank/partial-black gate skipped it and the pane stayed too black.",
+            client.healCaptureCount() > healCapturesBefore,
+        )
+        assertTrue(
+            "the heal restored tmux's authoritative FULL frame",
+            renderedTranscriptFor(pane).contains(HALF_BLACK_MARKER + " full"),
+        )
+        assertFalse(
+            "after the heal the pane is no longer sparse/half-black",
+            pane.terminalState.visibleScreenLooksSparseForSendHeal(),
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // (9) Issue #1153 class coverage: a MULTI-LINE TEXT-ONLY send (no attachment)
+    //     hits the SAME bracketed-paste + submit branch, so it must heal the same
+    //     half-black overpaint. AGENT pane, multi-line text-only payload.
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun multilineTextOnlySendHealsHalfBlackAgentPane() = runVmTest {
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%9", title = "codex")
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == "%9" }
+
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+        neutralizeSubmitAckGate(vm, client)
+
+        overpaintAltScreenHalfBlack(pane)
+        assertFalse(pane.terminalState.visibleScreenIsPartiallyBlank())
+
+        client.capturePaneResponses.addLast(
+            CommandResponse(number = 99L, output = HALF_BLACK_FULL_FRAME, isError = false),
+        )
+        val healCapturesBefore = client.healCaptureCount()
+
+        val result = vm.sendAgentPayloadToPaneResult(
+            "%9",
+            "first line of the prompt\nsecond line of the prompt",
+            AgentKind.Codex,
+        )
+        advanceUntilIdle()
+
+        assertTrue(result.isSuccess)
+        assertTrue(
+            "REGRESSION (#1153, multi-line text-only): a multi-line text send that half-blacks " +
+                "the pane must heal too (same bracketed-paste + submit branch as with-attachment)",
+            client.healCaptureCount() > healCapturesBefore,
+        )
+        assertFalse(pane.terminalState.visibleScreenLooksSparseForSendHeal())
+    }
+
+    // -------------------------------------------------------------------------
+    // (10) Issue #1153 class coverage: the SHELL `RawBytes` send path
+    //      ([TmuxSessionViewModel.writeInputToPaneResult]) had NO send-overpaint heal
+    //      at all. A MULTI-LINE paste into a full-screen shell TUI can half-black the
+    //      pane the same way. On base: no heal → RED. With the fix the shell path
+    //      schedules the same heal for a multi-line payload → GREEN. SHELL pane.
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun multilineShellPasteHealsHalfBlackShellPane() = runVmTest {
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%10")
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == "%10" }
+
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+
+        overpaintAltScreenHalfBlack(pane)
+        assertFalse(pane.terminalState.visibleScreenIsPartiallyBlank())
+
+        client.capturePaneResponses.addLast(
+            CommandResponse(number = 99L, output = HALF_BLACK_FULL_FRAME, isError = false),
+        )
+        val healCapturesBefore = client.healCaptureCount()
+
+        // THE REAL SHELL SEND PATH: a multi-line raw paste.
+        val result = vm.writeInputToPaneResult(
+            "%10",
+            "vim command line one\nvim command line two\n".toByteArray(Charsets.UTF_8),
+        )
+        advanceUntilIdle()
+
+        assertTrue(result.isSuccess)
+        assertTrue(
+            "REGRESSION (#1153, shell pane): the shell RawBytes path had NO send-overpaint heal; " +
+                "a multi-line paste that half-blacks the pane must now trigger the heal too",
+            client.healCaptureCount() > healCapturesBefore,
+        )
+        assertFalse(pane.terminalState.visibleScreenLooksSparseForSendHeal())
+    }
+
+    // -------------------------------------------------------------------------
+    // (11) Issue #1153 OVER-HEAL GUARD (shell): a SINGLE-keystroke shell write (no
+    //      line break) must NOT schedule any heal — per-keystroke input never
+    //      overpaints the whole viewport, so it must pay nothing even on a
+    //      (coincidentally) half-black pane.
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun singleKeystrokeShellWriteDoesNotHeal() = runVmTest {
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%11")
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == "%11" }
+
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+
+        overpaintAltScreenHalfBlack(pane)
+
+        client.capturePaneResponses.addLast(
+            CommandResponse(number = 99L, output = HALF_BLACK_FULL_FRAME, isError = false),
+        )
+        val healCapturesBefore = client.healCaptureCount()
+
+        // A single keystroke (no line break) — the common shell-typing case.
+        val result = vm.writeInputToPaneResult("%11", "x".toByteArray(Charsets.UTF_8))
+        advanceUntilIdle()
+
+        assertTrue(result.isSuccess)
+        org.junit.Assert.assertEquals(
+            "OVER-HEAL GUARD (#1153): a single-keystroke shell write (no line break) must NOT " +
+                "schedule any post-send heal capture",
+            healCapturesBefore,
+            client.healCaptureCount(),
+        )
+    }
+
     // ------------------------------------------------------------------ Harness
 
     private fun runVmTest(body: suspend TestScope.() -> Unit) = runTest {
@@ -504,6 +690,29 @@ class PartialBlackPaneHealTest {
     private fun overpaintAltScreenPartialBlack(pane: TmuxPaneState) {
         val esc = ""
         val frame = "$esc[?1049h$esc[2J$esc[H$esc[24;1H Working 7  esc to interrupt streaming the reply"
+        pane.terminalState.appendRemoteOutput(frame.toByteArray(Charsets.US_ASCII))
+    }
+
+    /**
+     * Issue #1153: drive the pane onto the ALTERNATE screen and paint ~12 content lines to the
+     * LOWER rows (cursor-addressed), leaving the upper ~2/3 of the 40-row viewport BLACK — the
+     * maintainer's "partly redrew but still too black" send-overpaint state. Deliberately MORE
+     * than 3 live lines so it is NOT the ≤3-line [visibleScreenIsPartiallyBlank] the pre-#1153
+     * heal covered, yet its live share of the visible rows (~12/40) is well below a fully-painted
+     * frame — the exact half-black band the widened heal must catch.
+     */
+    private fun overpaintAltScreenHalfBlack(pane: TmuxPaneState) {
+        val esc = ""
+        // Hard `\r\n` lines (NOT cursor-addressed): contiguous cursor-positioned short lines are
+        // joined into ONE logical line by `getSelectedText`, which would read as a single live
+        // line. 12 live lines over a 40-row viewport = ~0.3 live fraction, below the half-black
+        // ceiling, yet > 3 lines so it is NOT the ≤3-line partial-black.
+        val frame = buildString {
+            append("$esc[?1049h$esc[2J$esc[H")
+            for (row in 0 until 12) {
+                append("$HALF_BLACK_MARKER conversation/status line $row filler content here padding\r\n")
+            }
+        }
         pane.terminalState.appendRemoteOutput(frame.toByteArray(Charsets.US_ASCII))
     }
 
@@ -617,7 +826,12 @@ class PartialBlackPaneHealTest {
      */
     private fun recoveredFrameLines(): List<String> = buildList {
         add(RECOVERED_FRAME)
-        repeat(12) { add("recovered context row $it") }
+        // Issue #1153: a DENSE recovered frame (well over half the 40-row viewport) so that
+        // after the heal the restored pane reads NON-sparse
+        // ([TerminalSurfaceState.visibleScreenLooksSparseForSendHeal] false) and the bounded
+        // send-heal poll stops paying for further `capture-pane` diffs — mirroring production,
+        // where tmux's authoritative frame fills the viewport.
+        repeat(27) { add("recovered context row $it") }
     }
 
     private companion object {
@@ -631,6 +845,21 @@ class PartialBlackPaneHealTest {
         // sparse part) and the input/status line. Its non-blank content is small enough that
         // the surviving status line is > 25% of it (so the #966 divergence oracle MISSES it),
         // yet > 3 non-blank lines so the healed pane is no longer partial-black.
+        // Issue #1153: a with-attachment composer payload — the draft text plus the
+        // "Attached files:" block the composer appends, which makes EVERY with-attachment
+        // send multi-line (so it takes the bracketed-paste + submit branch).
+        const val WITH_ATTACHMENT_PAYLOAD: String =
+            "please review this\n\nAttached files:\n- /home/alex/report.txt"
+
+        // Issue #1153: the HALF-BLACK send-overpaint frame + the full frame tmux restores.
+        const val HALF_BLACK_MARKER: String = "ISSUE1153-HALFBLACK"
+        val HALF_BLACK_FULL_FRAME: List<String> = buildList {
+            add("HEADER $HALF_BLACK_MARKER full agent conversation restored from tmux")
+            repeat(29) {
+                add("$HALF_BLACK_MARKER full frame row $it with real agent conversation content here")
+            }
+        }
+
         const val AGENT_FRAME_MARKER: String = "ISSUE1138-AGENT-FRAME"
         val SPARSE_AGENT_FRAME: List<String> = buildList {
             add("HEADER $AGENT_FRAME_MARKER codex podwiki")

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -500,6 +500,22 @@ JOURNEY_CLASSES=(
   # UNCONDITIONAL `reseedActivePaneForReattach`, not blank-only). Uses ONLY the
   # deterministic agents:2222 fixture (no toxiproxy) and does NOT self-skip on CI.
   "$FQCN_PREFIX.VoiceSendActivePaneStaysVisibleE2eTest"
+  # ADDED (#1153 — send-with-attachment half-black, v0.4.21 dogfood): a composer Send WITH AN
+  # ATTACHMENT is ALWAYS multi-line (it appends an "Attached files:" block), so it takes the
+  # bracketed-paste + submit branch and the alt-screen agent clear+redraws its WHOLE viewport; the
+  # overpaint leaves a >3-line HALF-BLACK band (input box + a few conversation lines + status) over
+  # a large black region, on a LIVE transport (no reconnect). The pre-#1153 #941 send heal gated on
+  # the LOCAL-ONLY `blank || partialBlank` heuristic (≤3 live lines) and SKIPPED the >3-line band,
+  # and its fixed 350 ms one-shot lost the race against the bigger attachment redraw. This journey
+  # seeds a FULL-screen frame, attaches, DISABLES the steady-state watchdog (so ONLY the SEND heal
+  # can green the pane), injects the >3-line half-black on the LIVE emulator (REMOTE tmux grid keeps
+  # the full frame → transport GUARANTEED LIVE), then drives a REAL with-attachment (multi-line)
+  # send and asserts the SEND heal restores the full frame with the transport still Connected and
+  # NO reconnect. RED on base (the local-only gate skips the >3-line band — unit-proven in
+  # PartialBlackPaneHealTest); GREEN with the widened capture-diff heal
+  # (`visibleRenderLostFrameVsCapture` case c + the bounded send-heal poll). Uses ONLY the
+  # deterministic agents:2222 fixture (state injected LOCALLY, no toxiproxy) and does NOT self-skip.
+  "$FQCN_PREFIX.SendWithAttachmentStaysVisibleE2eTest"
   # ADDED (#782, D30 / D28(3)): the pre-existing multi-window `[wN]`
   # switcher-entry journey. PocketShell no longer manages tmux windows; a session
   # that already has >1 window on the remote is surfaced as separate `<session>

--- a/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurfaceState.kt
+++ b/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurfaceState.kt
@@ -741,8 +741,6 @@ class TerminalSurfaceState(
     fun visibleRenderLostFrameVsCapture(captureText: String): Boolean {
         // (a) The #966 dramatic-divergence case (unchanged oracle).
         if (visibleScreenDivergesFromCapture(captureText)) return true
-        // (b) The #1138 partial-black-vs-fuller-capture case.
-        if (!visibleScreenIsPartiallyBlank()) return false
         val emulator = bridge?.emulator ?: _session?.emulator ?: return false
         val visibleRows = try {
             emulator.screen.visibleScreenRows
@@ -759,10 +757,78 @@ class TerminalSurfaceState(
         // alt-screen void). Defer — do NOT heal a genuinely-empty pane to itself.
         if (captureVisibleNonBlank < STALE_RENDER_MIN_CAPTURE_CHARS) return false
         val renderedNonBlank = renderedNonBlankCharCount()
-        // tmux carries MATERIALLY MORE than the render → the upper rows the render lost are
-        // still in tmux's grid; re-seed to restore them. A near-equal capture (short prompt /
-        // by-design void) sits under the gap and is left alone.
-        return captureVisibleNonBlank - renderedNonBlank >= PARTIAL_BLACK_HEAL_MIN_EXTRA_CHARS
+        // tmux carries MATERIALLY MORE than the render → the frame the render lost is still in
+        // tmux's grid; re-seed to restore it. A near-equal capture (short prompt / by-design
+        // void) sits under the gap and is left alone — the anti-thrash / distinguish-by-design
+        // guard shared by both partial-black branches below.
+        if (captureVisibleNonBlank - renderedNonBlank < PARTIAL_BLACK_HEAL_MIN_EXTRA_CHARS) return false
+        // (b) The #1138 partial-black render (≤3 live lines): an alt-screen agent's surviving
+        //     status line, the upper rows black.
+        if (visibleScreenIsPartiallyBlank()) return true
+        // (c) Issue #1153 — the >3-live-line HALF-BLACK render. A composer Send whose multi-line
+        //     payload (a with-attachment send is ALWAYS multi-line — it appends an "Attached
+        //     files:" block) takes the bracketed-paste + submit branch; the alt-screen agent then
+        //     clear+cursor-address-redraws its WHOLE viewport, and the overpaint blanks the grid
+        //     while the agent only PARTIALLY repaints — leaving a large black BAND above a
+        //     surviving input box + a few conversation lines + status. That band carries MORE
+        //     than the ≤3 live lines the partial-black heuristic (b) caps at (so (b) misses it),
+        //     yet its live share of the visible rows is still materially below a fully-painted
+        //     frame. Combined with the "tmux holds materially more" gate already passed above,
+        //     heal it too — the maintainer's "partly redrew but still too black" send state
+        //     (#1153). The fraction ceiling keeps a DENSE healthy pane (its live rows sit ABOVE
+        //     the ceiling) from firing; the capture-diff gate already excluded a legitimately
+        //     sparse-but-correct pane (capture ≈ render).
+        val renderedLiveLines = renderedVisibleNonBlankLineCount()
+        if (renderedLiveLines <= 0) return false
+        return renderedLiveLines.toDouble() / visibleRows.toDouble() <= LOST_FRAME_MAX_LIVE_FRACTION
+    }
+
+    /**
+     * Issue #1153 — the count of non-blank lines the emulator has actually rendered onto its
+     * currently VISIBLE viewport (scrollback excluded), the sibling of [renderedNonBlankCharCount]
+     * measured in LINES. Used to judge the live-line FRACTION of the visible grid — how large the
+     * black BAND left by a half-repainted send overpaint is — for [visibleRenderLostFrameVsCapture]
+     * case (c) and the cheap send-heal pre-check [visibleScreenLooksSparseForSendHeal].
+     *
+     * Returns 0 when no emulator is attached or the visible screen is blank.
+     */
+    private fun renderedVisibleNonBlankLineCount(): Int {
+        val emulator = bridge?.emulator ?: _session?.emulator ?: return 0
+        val text = try {
+            emulator.screen.visibleScreenText
+        } catch (_: Throwable) {
+            return 0
+        }
+        if (text.isBlank()) return 0
+        return text.split('\n').count { it.isNotBlank() }
+    }
+
+    /**
+     * Issue #1153 — a CHEAP, LOCAL-ONLY pre-check the post-send overpaint heal
+     * ([com.pocketshell.app.tmux.TmuxSessionViewModel.scheduleSendOverpaintHeal]) runs each
+     * settle tick to decide whether paying for an authoritative `capture-pane` diff is
+     * worthwhile. It is TRUE when the rendered viewport is sparse enough to POSSIBLY be a
+     * half-repainted send overpaint: fully blank, the ≤3-line partial-black
+     * ([visibleScreenIsBlankOrPartiallyBlank]), OR a >3-line half-black band whose live share
+     * of the visible rows is at most [LOST_FRAME_MAX_LIVE_FRACTION].
+     *
+     * It does NOT confirm a lost frame — only the `capture-pane` diff ([visibleRenderLostFrameVsCapture])
+     * can, since a legitimately-sparse-but-correct pane looks identical locally. This gate exists
+     * only to keep a DENSE, normally-painted agent response (its live rows sit above the ceiling)
+     * from paying for a capture round-trip on every send.
+     */
+    fun visibleScreenLooksSparseForSendHeal(): Boolean {
+        if (visibleScreenIsBlankOrPartiallyBlank()) return true
+        val emulator = bridge?.emulator ?: _session?.emulator ?: return false
+        val visibleRows = try {
+            emulator.screen.visibleScreenRows
+        } catch (_: Throwable) {
+            return false
+        }
+        if (visibleRows <= 0) return false
+        val liveLines = renderedVisibleNonBlankLineCount()
+        if (liveLines <= 0) return false
+        return liveLines.toDouble() / visibleRows.toDouble() <= LOST_FRAME_MAX_LIVE_FRACTION
     }
 
     /**
@@ -1070,6 +1136,23 @@ class TerminalSurfaceState(
          * clears it. One line's worth of real content (≈40 chars).
          */
         private const val PARTIAL_BLACK_HEAL_MIN_EXTRA_CHARS = 40
+
+        /**
+         * Issue #1153: the upper bound on the rendered live-line FRACTION of the visible rows for
+         * [visibleRenderLostFrameVsCapture]'s >3-live-line HALF-BLACK branch (and the cheap
+         * send-heal pre-check [visibleScreenLooksSparseForSendHeal]). The maintainer's composer
+         * Send (with-attachment, so multi-line → bracketed-paste + submit) left the alt-screen
+         * agent pane "partly redrew but still too black": a surviving input box + a few
+         * conversation lines + status (MORE than the ≤3 live lines
+         * [PARTIAL_BLANK_MAX_LIVE_LINES] caps at) over a large black BAND. Half-or-more of the
+         * visible rows black is "materially black"; a DENSE, normally-painted response paints
+         * well over half its rows and sits ABOVE this ceiling, so it never heals. It is HIGHER
+         * than [PARTIAL_BLANK_MAX_LIVE_FRACTION] (0.25) precisely to catch the >3-line band the
+         * narrow partial-black heuristic misses, and the capture-diff gate
+         * ([PARTIAL_BLACK_HEAL_MIN_EXTRA_CHARS]) still guards against healing a sparse-but-correct
+         * pane where tmux holds no more content than the render.
+         */
+        private const val LOST_FRAME_MAX_LIVE_FRACTION = 0.5
     }
 }
 

--- a/shared/core-terminal/src/test/java/com/pocketshell/core/terminal/ui/TerminalSurfaceStateAgentPartialBlackTest.kt
+++ b/shared/core-terminal/src/test/java/com/pocketshell/core/terminal/ui/TerminalSurfaceStateAgentPartialBlackTest.kt
@@ -91,6 +91,36 @@ class TerminalSurfaceStateAgentPartialBlackTest {
         append(" Working 7  esc to interrupt\n")
     }
 
+    /**
+     * Issue #1153 — the full alt-screen agent frame tmux's grid holds after a multi-line send:
+     * a header + a real (non-sparse) conversation body filling ~20 rows. Its non-blank content
+     * is LARGE, so the surviving half-black band (~8 lines) is well under the 25% divergence
+     * ceiling of it — the RED gap the #966 oracle leaves.
+     */
+    private fun fullAgentFrame(): String = buildString {
+        append("HEADER: codex full conversation frame on podwiki host\n")
+        repeat(19) { row -> append("Codex conversation row $row : a real line of agent output with content\n") }
+    }
+
+    /**
+     * Issue #1153 — drive the emulator onto the alt screen, clear, and paint 8 HARD-newline
+     * content lines, leaving the remaining ~2/3 of the 24-row viewport BLACK. MORE than 3 live
+     * lines (so NOT the ≤3-line partial-black) yet only ~1/3 of the visible rows live — the
+     * half-black band. (Hard `\r\n` lines, NOT cursor-addressed: contiguous cursor-positioned
+     * short lines are joined into ONE logical line by `getSelectedText`, which would read as a
+     * single live line.)
+     */
+    private fun paintHalfBlackBand(state: TerminalSurfaceState) {
+        val frame = buildString {
+            append("$esc[?1049h$esc[2J$esc[H")
+            for (row in 0 until 8) {
+                append("ISSUE1153 half-black conversation/status line $row filler content here\r\n")
+            }
+        }
+        state.appendRemoteOutput(frame.toByteArray(Charsets.US_ASCII))
+        shadowOf(Looper.getMainLooper()).idle()
+    }
+
     /** Drive the emulator onto the alt screen and paint ONLY the live status line. */
     private fun paintAltScreenPartialBlack(state: TerminalSurfaceState) {
         val frame = buildString {
@@ -129,6 +159,68 @@ class TerminalSurfaceStateAgentPartialBlackTest {
             "GREEN (#1138): the union predicate must detect the alt-screen partial-black " +
                 "against the agent's authoritative full capture and heal it",
             state.visibleRenderLostFrameVsCapture(fullAgentAltCapture()),
+        )
+    }
+
+    /**
+     * Issue #1153 — the >3-live-line HALF-BLACK render the pre-#1153 union oracle MISSED. A
+     * composer Send with an attachment is always multi-line → bracketed-paste + submit → the
+     * alt-screen agent clear+redraws its WHOLE viewport, and the overpaint leaves a large black
+     * BAND above a surviving input box + a few conversation lines + status. That band has MORE
+     * than the ≤3 live lines the partial-black heuristic caps at, so BOTH the #966 divergence
+     * oracle (surviving band > 25% of the frame) AND the pre-#1153 case (b) (requires
+     * partial-black) MISS it — the "partly redrew but still too black" state.
+     */
+    @Test
+    fun halfBlackOverThreeLinesIsMissedByDivergenceButHealedByUnion() = withAttachedSurface { state ->
+        paintHalfBlackBand(state)
+
+        assertFalse(
+            "precondition: a half-black band is NOT fully blank",
+            state.visibleScreenIsBlank(),
+        )
+        assertFalse(
+            "precondition (#1153): the half-black band has MORE than 3 live lines, so it is NOT " +
+                "the ≤3-line partial-black the pre-#1153 case (b) required",
+            state.visibleScreenIsPartiallyBlank(),
+        )
+        // RED gap: the #966 divergence oracle reads the >3-line band "healthy" (its surviving
+        // content exceeds the 25% ceiling of the full frame), so the pre-#1153 union missed it.
+        assertFalse(
+            "RED (#1153): the #966 divergence oracle MISSES the >3-line half-black band",
+            state.visibleScreenDivergesFromCapture(fullAgentFrame()),
+        )
+        // GREEN: the widened union predicate heals it — the render lost most of the frame tmux
+        // still holds, and its live share of the visible rows is below the ceiling.
+        assertTrue(
+            "GREEN (#1153): the widened union predicate must heal a >3-line half-black band " +
+                "against tmux's authoritative full frame",
+            state.visibleRenderLostFrameVsCapture(fullAgentFrame()),
+        )
+    }
+
+    /**
+     * Issue #1153 over-heal guard: a DENSE render (well over half the visible rows live) must
+     * NOT heal even when tmux's capture carries somewhat MORE — the fraction ceiling keeps a
+     * normally-painted, slightly-lagging pane from re-seeding on every send/watchdog tick.
+     */
+    @Test
+    fun denseRenderDoesNotHealEvenWhenCaptureHasSomewhatMore() = withAttachedSurface { state ->
+        val frame = buildString {
+            append("$esc[2J$esc[H")
+            repeat(20) { row -> append("dense row $row : lots of real painted agent content here padding text\r\n") }
+        }
+        state.appendRemoteOutput(frame.toByteArray(Charsets.US_ASCII))
+        shadowOf(Looper.getMainLooper()).idle()
+        // tmux holds a few MORE rows than the render (a slight stream lag), but the render is
+        // DENSE (20 of 24 rows live) — above the half-black ceiling — so it must NOT heal.
+        val fullerCapture = buildString {
+            repeat(24) { row -> append("dense row $row : lots of real painted agent content here padding text\n") }
+        }
+        assertFalse(
+            "a dense render (live rows above the ceiling) must NOT heal even when tmux holds a " +
+                "few more rows — no reseed-thrash on a slightly-lagging healthy pane",
+            state.visibleRenderLostFrameVsCapture(fullerCapture),
         )
     }
 


### PR DESCRIPTION
Fixes the maintainer's active black-screen: Prompt Composer → attach → Send leaves the pane partial-black (partly redraws, stays black, no reconnect).

**Root cause:** a with-attachment send is multi-line → bracketed-paste+submit → the alt-screen agent clears + full-viewport-redraws → a >3-live-line half-black band on a live transport. The #941 send heal gated on the ≤3-line heuristic (skipped it); its 350ms one-shot lost the race.

**Fix (render/heal layer only):** widen `visibleRenderLostFrameVsCapture` case (c) — heal when live-line fraction ≤0.5 AND tmux holds materially more (also extends the #1138 watchdog) — and make `scheduleSendOverpaintHeal` a bounded 4-tick capture-pane-diff poll robust to a late redraw, extended to the shell path. Never over-heals a frame that already matches tmux.

**Reviewer APPROVED** (https://github.com/alexeygrigorev/pocketshell/issues/1153#issuecomment-4855040157): JVM red→green for all 4 send-class combos + black-screen-family adjacency clean (#1138/#941/#807/#966), and the on-device journey `SendWithAttachmentStaysVisibleE2eTest` verified — attach→send→half-black **healed to the full frame matching tmux's capture**, transport Connected, no reconnect (artifacts: 20-row frame wiped to 6 half-black lines → fully restored).

Closes #1153