### PR TITLE
release: v0.4.21 (versionCode 68)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,8 +65,8 @@ android {
         applicationId = "com.pocketshell.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 67
-        versionName = "0.4.20"
+        versionCode = 68
+        versionName = "0.4.21"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/tools/pocketshell/pyproject.toml
+++ b/tools/pocketshell/pyproject.toml
@@ -8,7 +8,7 @@ name = "pocketshell"
 # scripts/check-pypi-version.sh enforces this; .github/workflows/build.yml
 # runs that check before publishing to PyPI. See
 # tools/pocketshell/README.md ("Release flow") for the bump procedure.
-version = "0.4.20"
+version = "0.4.21"
 description = "Unified server-side Python utility for the PocketShell Android client."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Dogfood reliability follow-up to v0.4.20.

- **#1153** — send-triggered black screen (compose→attach→send) healed. On-device verified.
- **#1158** — Conversation tab restored for recorded-agent sessions (Codex/Z.AI, not just vanilla Claude). On-device verified.
- **#1157** — no false 'Not connected' in the host-CLI-update banner while connected.
- **#1162** — core-ssh timing de-flake.

versionName 0.4.20→0.4.21, versionCode 67→68 (app + tools/pocketshell in lockstep). Release-emulator-validation runs on the bumped `main` before the tag (local; CI emulator lane still infra-down #771).