### PR TITLE
terminal: floor-guard tmux window size so an agent pane is never left cut (#1169)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxResizeSessionE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxResizeSessionE2eTest.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.lifecycle.ViewModelProvider
 import androidx.room.Room
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -197,7 +198,152 @@ class TmuxResizeSessionE2eTest {
         Unit
     } }
 
+    /**
+     * Issue #1169 — connected reproduction of the Codex/agent pane CUT (only top
+     * rows, rest black) caused by the tmux window being resized too small and not
+     * restored.
+     *
+     * Mechanism (confirmed): PocketShell is the sole tmux window-size authority
+     * (`refresh-client -C` under `window-size latest`). The live emulator grid is
+     * measured from pixels, but a warm reattach / within-grace foreground return /
+     * session switch REPLAYS a CACHED (possibly transiently-shrunk) grid through
+     * `maybeRefreshControlClientSize` rather than re-deriving the current viewport.
+     * SOFT_INPUT_ADJUST_NOTHING means Compose does NOT re-measure on return, so the
+     * cached replay is the only size assertion — and if that cached value is small,
+     * the tmux window shrinks, the alt-screen agent TUI redraws into the small
+     * window, and the taller emulator paints those rows at the top with BLACK
+     * below (and, via `window-size latest`, a second client such as Terminus
+     * inherits the identical cut).
+     *
+     * Reproduction (the #780 synthetic-injection model — deterministic, no self-
+     * skip): attach at the full phone grid (auto-resize syncs the window), then
+     * drive the EXACT production cached-replay path with a SHRUNK grid via
+     * [TmuxSessionViewModel.replayCachedControlClientSizeForTest] — which is
+     * verbatim what [restoreCachedRuntime] + [launchCachedRuntimeRemoteRefresh] do
+     * on a real warm reattach / foreground return / switch. On base this leaves
+     * `#{window_width}x#{window_height}` STUCK at the shrunk size (the pane is cut);
+     * with the floor guard the window returns to the full live viewport and the
+     * pane fills the screen (no black-below). This is the load-bearing red→green.
+     *
+     * The cached-replay path is the shared sink for EVERY shrinking transient the
+     * maintainer listed (keyboard up→down, composer open→close, session switch,
+     * background→foreground within grace) — they all end up re-asserting a
+     * cached/computed size through `maybeRefreshControlClientSize`, so restoring
+     * the floor here covers the class.
+     */
+    @Test
+    fun cachedSizeReplayRestoresFullWindowAndAgentPaneIsNotCut() { runBlocking {
+        val key = readFixtureKey()
+        waitForSshFixtureReady(SshKey.Pem(key))
+        seedDesktopSizedSession(key)
+        val hostRowTag = seedDockerHost(key, "Issue1169 Agent Cut")
+
+        launchedActivity = ActivityScenario.launch(MainActivity::class.java)
+
+        // --- Attach to the seeded session via the picker.
+        compose.waitUntil(timeoutMillis = 10_000) {
+            compose.onAllNodesWithTag(hostRowTag, useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
+        compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick()
+        compose.waitUntil(timeoutMillis = 30_000) {
+            compose.onAllNodesWithText(SESSION_LAB, useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
+        compose.onNodeWithText(SESSION_LAB).performClick()
+
+        compose.waitUntil(timeoutMillis = 30_000) {
+            compose.onAllNodesWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
+        compose.waitUntil(timeoutMillis = 30_000) { terminalGridSizeOrNull() != null }
+
+        // --- Wait for the auto-resize to sync the tmux window to the phone grid.
+        var phoneGrid = terminalGridSize()
+        var remotePaneSize = readRemotePaneSize(key)
+        val syncDeadline = SystemClock.elapsedRealtime() + RESIZE_TIMEOUT_MS
+        while (remotePaneSize != phoneGrid && SystemClock.elapsedRealtime() < syncDeadline) {
+            kotlinx.coroutines.delay(200)
+            phoneGrid = terminalGridSize()
+            remotePaneSize = readRemotePaneSize(key)
+        }
+        assertEquals(
+            "baseline: tmux pane should auto-size to the phone viewport before the transient",
+            phoneGrid,
+            remotePaneSize,
+        )
+        val fullWindowDims = readRemoteDims(key)
+        assertEquals(
+            "baseline: window should equal the full phone grid; got $fullWindowDims",
+            "${phoneGrid.columns}x${phoneGrid.rows}",
+            fullWindowDims,
+        )
+        captureFullDevice("01-full-before-transient")
+
+        // --- Drive the production cached-replay of a SHRUNK grid (a transient /
+        //     warm reattach parked a small size in the runtime cache). The shrunk
+        //     grid is deliberately far smaller than the phone viewport so a stuck
+        //     window is unambiguous.
+        val shrunkCols = 40
+        val shrunkRows = 8
+        require(shrunkCols < phoneGrid.columns && shrunkRows < phoneGrid.rows) {
+            "shrunk grid ${shrunkCols}x${shrunkRows} must be smaller than phone grid $phoneGrid"
+        }
+        replayCachedSize(shrunkCols, shrunkRows)
+
+        // --- The floor guard must re-derive the full live viewport: the window
+        //     must NOT be left stuck at the shrunk size, and the pane must fill the
+        //     viewport (no black-below).
+        var windowDims = readRemoteDims(key)
+        var paneAfter = readRemotePaneSize(key)
+        val restoreDeadline = SystemClock.elapsedRealtime() + RESIZE_TIMEOUT_MS
+        val expectedWindow = "${phoneGrid.columns}x${phoneGrid.rows}"
+        while (
+            (windowDims != expectedWindow || paneAfter != phoneGrid) &&
+            SystemClock.elapsedRealtime() < restoreDeadline
+        ) {
+            kotlinx.coroutines.delay(200)
+            windowDims = readRemoteDims(key)
+            paneAfter = readRemotePaneSize(key)
+        }
+        captureFullDevice("02-restored-after-transient")
+
+        assertTrue(
+            "tmux window must NOT be left stuck at the shrunk size " +
+                "${shrunkCols}x${shrunkRows}; got $windowDims",
+            windowDims != "${shrunkCols}x${shrunkRows}",
+        )
+        assertEquals(
+            "tmux window must return to the full phone viewport after the transient",
+            expectedWindow,
+            windowDims,
+        )
+        assertEquals(
+            "tmux pane must fill the phone viewport (no black-below cut)",
+            phoneGrid,
+            paneAfter,
+        )
+        Unit
+    } }
+
     // ---------------------------------------------------------------- Helpers
+
+    /**
+     * Issue #1169: reach the live activity-scoped [TmuxSessionViewModel] and drive
+     * the production cached-runtime size replay. Runs on the main thread via
+     * `onActivity`.
+     */
+    private fun replayCachedSize(cachedColumns: Int, cachedRows: Int) {
+        val scenario = launchedActivity ?: error("activity not launched")
+        scenario.onActivity { activity ->
+            ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+                .replayCachedControlClientSizeForTest(cachedColumns, cachedRows)
+        }
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+    }
 
     private fun readFixtureKey(): String =
         InstrumentationRegistry.getInstrumentation()

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -2105,6 +2105,20 @@ public class TmuxSessionViewModel @Inject constructor(
     // known, the VM reports this size through `refresh-client -C`.
     private var remoteColumns: Int = 0
     private var remoteRows: Int = 0
+    // Issue #1169: the live on-screen viewport grid, fed ONLY by the real
+    // Compose measure ([resizeRemotePty] / `onTerminalSizeChanged`). Unlike
+    // remoteColumns/remoteRows — which [restoreCachedRuntime] OVERWRITES with a
+    // parked (possibly stale/shrunk) value on a warm reattach — this survives
+    // cached-runtime restores and session switches because the phone's physical
+    // viewport is the same across every session on the device. It is the FLOOR
+    // for any size sent to tmux: the tmux window (and therefore the alt-screen
+    // agent TUI) must never be left SMALLER than what the emulator will actually
+    // render, or the pane is drawn cut with black below (the maintainer's
+    // Codex-cut symptom). SOFT_INPUT_ADJUST_NOTHING means the view pixel size
+    // does NOT re-measure on a within-grace foreground return, so the cached
+    // replay path never re-derives the full grid on its own — the floor does.
+    private var liveMeasuredColumns: Int = 0
+    private var liveMeasuredRows: Int = 0
     private var appliedControlClientColumns: Int = 0
     private var appliedControlClientRows: Int = 0
     private var controlClientSizeGeneration: Long = 0L
@@ -14769,6 +14783,14 @@ public class TmuxSessionViewModel @Inject constructor(
      */
     public fun resizeRemotePty(columns: Int, rows: Int) {
         if (columns <= 0 || rows <= 0) return
+        // Issue #1169: record the current on-screen viewport grid as the floor
+        // for every size we subsequently send to tmux. This is set on EVERY real
+        // Compose measure (before the no-op short-circuit below) so it always
+        // tracks the true emulator viewport; the floor guard in
+        // [maybeRefreshControlClientSize] then keeps a warm reattach / cached
+        // replay / session switch from shrinking the tmux window below it.
+        liveMeasuredColumns = columns
+        liveMeasuredRows = rows
         if (columns == remoteColumns && rows == remoteRows) {
             // Issue #717 (the missed-heal gate): a composer/keyboard-dismiss after a
             // voice-send fires `onTerminalSizeChanged` with the EXACT same grid the
@@ -14800,11 +14822,28 @@ public class TmuxSessionViewModel @Inject constructor(
         maybeRefreshControlClientSize()
     }
 
+    /**
+     * Issue #1169: the size to send to tmux is the FLOOR-GUARDED, re-derived
+     * grid — never smaller than the live on-screen viewport
+     * ([liveMeasuredColumns]/[liveMeasuredRows]). The cached remoteColumns/
+     * remoteRows a warm reattach / session switch / within-grace foreground
+     * replays can be a stale or transiently-shrunk value; the live measured grid
+     * is the authority for how tall the emulator will actually render. Sending
+     * the LARGER of the two guarantees the tmux window (and therefore the
+     * alt-screen agent TUI) fills the viewport with no top-rows-then-black cut,
+     * and because `window-size latest` makes the phone authoritative, a second
+     * client (Terminus) attached to the same window inherits the full size too.
+     * A too-small window is the reported bug; a window >= the view is safe.
+     */
+    private fun effectiveControlClientColumns(): Int = maxOf(remoteColumns, liveMeasuredColumns)
+
+    private fun effectiveControlClientRows(): Int = maxOf(remoteRows, liveMeasuredRows)
+
     private fun maybeRefreshControlClientSize() {
         val client = clientRef ?: return
         val target = activeTarget ?: return
-        val cols = remoteColumns
-        val rows = remoteRows
+        val cols = effectiveControlClientColumns()
+        val rows = effectiveControlClientRows()
         if (cols <= 0 || rows <= 0) return
         if (cols == appliedControlClientColumns && rows == appliedControlClientRows) {
             // EPIC #687 slice 2 (#717): same-dimension short-circuit. A repeated
@@ -14857,7 +14896,12 @@ public class TmuxSessionViewModel @Inject constructor(
                 return@launch
             }
             if (controlClientSizeGeneration != generation) return@launch
-            if (remoteColumns != cols || remoteRows != rows) return@launch
+            // Issue #1169: re-derive the floor-guarded size; a mid-flight change
+            // to either the cached target or the live measured viewport
+            // invalidates this in-flight refresh (a newer one will run).
+            if (effectiveControlClientColumns() != cols || effectiveControlClientRows() != rows) {
+                return@launch
+            }
             val policyResponse = policyResult.getOrNull()
             if (policyResult.isFailure || policyResponse?.isError == true) {
                 Log.w(
@@ -15776,6 +15820,30 @@ public class TmuxSessionViewModel @Inject constructor(
 
     /** Issue #285 test seam: snapshot the latest phone grid reported by Compose. */
     internal fun remoteDimensionsForTest(): Pair<Int, Int> = remoteColumns to remoteRows
+
+    /** Issue #1169 test seam: the live measured viewport floor. */
+    internal fun liveMeasuredDimensionsForTest(): Pair<Int, Int> =
+        liveMeasuredColumns to liveMeasuredRows
+
+    /**
+     * Issue #1169 test seam: faithfully reproduce the cached-runtime size replay
+     * of a warm reattach / within-grace foreground return / session switch. This
+     * is exactly what [restoreCachedRuntime] (`remoteColumns/remoteRows =
+     * runtime.remoteColumns/remoteRows; resetControlClientSizeForAttach()`) plus
+     * [launchCachedRuntimeRemoteRefresh] (`maybeRefreshControlClientSize()`) do —
+     * it sets the cached (possibly shrunk) target, resets the applied cache, and
+     * re-drives the control-client size. On base this REPLAYS the small cached
+     * value and shrinks the tmux window; with the floor guard it re-derives the
+     * full live viewport so the window is never left cut. A passthrough — no
+     * test-only behavior.
+     */
+    @androidx.annotation.VisibleForTesting
+    internal fun replayCachedControlClientSizeForTest(cachedColumns: Int, cachedRows: Int) {
+        remoteColumns = cachedColumns
+        remoteRows = cachedRows
+        resetControlClientSizeForAttach()
+        maybeRefreshControlClientSize()
+    }
 
     /**
      * Quote a string for inclusion inside single quotes in a tmux command

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
@@ -1800,6 +1800,110 @@ class TmuxSessionViewModelTest {
         TmuxSessionLatencyTelemetry.resetForTest()
     }
 
+    /**
+     * Issue #1169 (Codex/agent pane cut — tmux window resized too small and not
+     * restored). Reproduce the maintainer's mechanism at the size-derivation
+     * layer: PocketShell measures the live viewport once (full grid), then a warm
+     * reattach / within-grace foreground return / session switch REPLAYS a cached
+     * (shrunk) grid through the same `maybeRefreshControlClientSize` path. On base
+     * that replays the SMALL cached size — `refresh-client -C 80x12` — which
+     * shrinks the shared tmux window so the alt-screen agent TUI draws cut with
+     * black below (and, via `window-size latest`, a second client inherits the
+     * cut). The fix floor-guards the size to the live measured viewport, so the
+     * replay never sends a size smaller than what the emulator will render.
+     */
+    @Test
+    fun cachedSizeReplayNeverShrinksTmuxBelowLiveViewport() = runTest(scheduler) {
+        val vm = newVm()
+        val client = FakeTmuxClient()
+        client.responses.addLast(
+            CommandResponse(
+                number = 1L,
+                output = listOf("%0\t@0\t\$0\tcodex\tshell\t0"),
+                isError = false,
+            ),
+        )
+        client.responses.addLast(
+            CommandResponse(
+                number = 4L,
+                output = listOf("%0\t@0\t\$0\tcodex\tshell\t0"),
+                isError = false,
+            ),
+        )
+        client.capturePaneResponses.addLast(
+            CommandResponse(number = 2L, output = listOf("codex seed"), isError = false),
+        )
+        client.cursorQueryResponses.addLast(
+            CommandResponse(number = 3L, output = listOf("0,0"), isError = false),
+        )
+
+        vm.attachClientWithReadinessForTest(
+            hostId = 1L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            sessionName = "codex",
+            client = client,
+            trigger = TmuxConnectTrigger.FastSwitch,
+        )
+
+        // (1) Live viewport measured once at the FULL Pixel-7-ish grid.
+        val fullCols = 85
+        val fullRows = 40
+        vm.resizeRemotePty(columns = fullCols, rows = fullRows)
+        advanceUntilIdle()
+        assertTrue(
+            "the initial full-viewport measure must reach tmux; sent=${client.sentCommands}",
+            client.sentCommands.contains("refresh-client -C ${fullCols}x${fullRows}"),
+        )
+
+        // (2) A warm reattach / within-grace foreground return / switch REPLAYS a
+        //     cached, shrunk grid (what a transient keyboard/composer/switch parked
+        //     in the runtime cache). SOFT_INPUT_ADJUST_NOTHING means Compose does
+        //     NOT re-measure on return, so this replay is the only size assertion.
+        val shrunkCols = 80
+        val shrunkRows = 12
+        vm.replayCachedControlClientSizeForTest(cachedColumns = shrunkCols, cachedRows = shrunkRows)
+        advanceUntilIdle()
+
+        // (3) The load-bearing assertion: the shrunk size must NEVER have been sent
+        //     to tmux. On base this fails (the replay sends `refresh-client -C
+        //     80x12`); with the floor guard the replay re-derives the full live
+        //     viewport instead.
+        assertFalse(
+            "cached replay must not shrink the tmux window below the live viewport; " +
+                "sent=${client.sentCommands}",
+            client.sentCommands.contains("refresh-client -C ${shrunkCols}x${shrunkRows}"),
+        )
+        // The live viewport floor is preserved across the cached replay.
+        assertEquals(
+            "live measured viewport must remain the full grid",
+            fullCols to fullRows,
+            vm.liveMeasuredDimensionsForTest(),
+        )
+        // Every refresh-client the VM emitted is at least as tall/wide as the live
+        // viewport — the window is never left cut.
+        val refreshDims = client.sentCommands
+            .filter { it.startsWith("refresh-client -C ") }
+            .map { it.removePrefix("refresh-client -C ") }
+            .mapNotNull { spec ->
+                val parts = spec.split('x')
+                val c = parts.getOrNull(0)?.toIntOrNull()
+                val r = parts.getOrNull(1)?.toIntOrNull()
+                if (c != null && r != null) c to r else null
+            }
+        assertTrue(
+            "expected at least one refresh-client size; sent=${client.sentCommands}",
+            refreshDims.isNotEmpty(),
+        )
+        assertTrue(
+            "no refresh-client may drop the window below the live viewport; dims=$refreshDims",
+            refreshDims.all { (c, r) -> c >= fullCols && r >= fullRows },
+        )
+    }
+
     @Test
     fun parseTmuxPaneCursorReadsWellFormedReply() {
         // Issue #259: the cursor reply is `cursor_x,cursor_y` (0-based).

--- a/scripts/check-ci-journey-harness.sh
+++ b/scripts/check-ci-journey-harness.sh
@@ -173,7 +173,6 @@ KNOWN_UNWIRED_ANDROID_E2E_DOCKER_CLASSES=(
   "com.pocketshell.app.tmux.TmuxAttachPrefillDockerTest"
   "com.pocketshell.app.tmux.TmuxAttachTimeoutDockerTest"
   "com.pocketshell.app.tmux.TmuxDetectedPortForwardDockerTest"
-  "com.pocketshell.app.tmux.TmuxResizeSessionE2eTest"
   "com.pocketshell.app.tmux.TmuxSessionOpencodeInputDockerTest"
   "com.pocketshell.app.tmux.TmuxShellComposerOcclusionE2eTest"
   "com.pocketshell.app.usage.UsageScreenE2eTest"

--- a/scripts/check-test-validity.sh
+++ b/scripts/check-test-validity.sh
@@ -290,7 +290,6 @@ J1_UNWIRED_ANDROID_E2E_DOCKER_BASELINE=(
   "com.pocketshell.app.tmux.TmuxAttachPrefillDockerTest"
   "com.pocketshell.app.tmux.TmuxAttachTimeoutDockerTest"
   "com.pocketshell.app.tmux.TmuxDetectedPortForwardDockerTest"
-  "com.pocketshell.app.tmux.TmuxResizeSessionE2eTest"
   "com.pocketshell.app.tmux.TmuxSessionOpencodeInputDockerTest"
   "com.pocketshell.app.tmux.TmuxShellComposerOcclusionE2eTest"
   "com.pocketshell.app.usage.UsageScreenE2eTest"

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -1420,6 +1420,22 @@ JOURNEY_CLASSES=(
   # self-skip on CI (no assumeTrue / assumeFalse(isRunningOnCi())). It lives under
   # com.pocketshell.app.env, so it carries its FQCN directly.
   "com.pocketshell.app.env.EnvScreenE2eTest"
+  # ADDED (#1169 — Codex/agent pane rendered CUT: tmux window resized too small
+  # and NOT restored). The maintainer's agent pane showed only the top ~10 rows
+  # with the rest BLACK because a transient (keyboard/composer/switch/within-grace
+  # foreground) shrank the tmux window and the warm-reattach REPLAYED the cached
+  # shrunk size instead of re-deriving the live viewport (`window-size latest`
+  # makes the shrink persist, so Terminus inherits the cut too). This journey
+  # attaches at the full phone grid, drives the EXACT production cached-replay path
+  # with a shrunk grid (TmuxSessionViewModel.replayCachedControlClientSizeForTest —
+  # verbatim what restoreCachedRuntime + launchCachedRuntimeRemoteRefresh do), then
+  # asserts `#{window_width}x#{window_height}` returns to the full viewport (NOT
+  # stuck shrunk) and the pane fills the screen (no black-below). Load-bearing
+  # red→green; runs the specific method so the pre-existing #285 auto-resize test
+  # in the same class is unaffected. Uses only the deterministic agents:2222
+  # fixture tests.yml already brings up (no toxiproxy / new port), and does NOT
+  # self-skip on CI. Lives under com.pocketshell.app.tmux, so it carries its FQCN.
+  "com.pocketshell.app.tmux.TmuxResizeSessionE2eTest#cachedSizeReplayRestoresFullWindowAndAgentPaneIsNotCut"
 )
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes the maintainer's cut Codex pane (only top rows render, rest black — same cut in Terminus because both clients share the tmux window size).

**Root cause:** on attach/reattach/switch/within-grace-foreground PocketShell REPLAYED a cached (possibly-shrunk) tmux window size instead of re-measuring, leaving the window too small so the alt-screen agent drew only into it (rows on top + black below); `window-size latest` persists it into the shared session.

**Fix:** track `liveMeasuredColumns/Rows` from the real Compose measure and send a FLOOR-GUARDED `max(remote_cached, liveMeasured)` from the single sink `maybeRefreshControlClientSize` — a restore can never leave the window smaller than the live viewport (it's a floor, not a cap; a legitimately larger remote size is still allowed).

**Reviewer APPROVED** (https://github.com/alexeygrigorev/pocketshell/issues/1169#issuecomment-4856616680): JVM red→green (base replays `80x12` → fix never sends it), **on-device journey** `cachedSizeReplayRestoresFullWindowAndAgentPaneIsNotCut` PASSED (tmux dims restored to 62x56, shrink never emitted, pane filled), #638 background-grace-reconnect adjacency clean, single-sink class coverage (9 callers floor-guarded), 363/0/0 ViewModel tests.

Closes #1169