### PR TITLE
connection: FGS only in background + grace 90s (configurable) + port-forward always-on (#1159)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/sessions/service/SessionConnectionServiceE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/sessions/service/SessionConnectionServiceE2eTest.kt
@@ -22,8 +22,6 @@ import dagger.hilt.android.EntryPointAccessors
 import java.io.BufferedReader
 import java.io.FileInputStream
 import java.io.InputStreamReader
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -43,13 +41,22 @@ import org.junit.runner.RunWith
  * API-35 emulator proof for the session foreground-service envelope.
  *
  * This registers a live entry in the production [ActiveTmuxClients] singleton,
- * so [SessionServiceController] starts the real foreground service exactly as a
+ * so [SessionServiceController] drives the real foreground service exactly as a
  * live session does. The client is an in-process [TmuxClient] double; this
- * on-device test proves the Android surface: notification/channel, partial
- * wakelock, and — issue #1123 (bounded-grace D21 update) — that once the grace
- * window ELAPSES the bounded hold tears down automatically (the teardown hook
- * fires, the notification clears, the wakelock releases) with NO indefinite hold
- * and NO manual Stop required.
+ * on-device test proves the Android surface.
+ *
+ * Issue #1159 (Part 1): the foreground service now runs ONLY while the app is
+ * BACKGROUNDED. In the foreground the Activity holds the connection, so there is
+ * NO "Session connected" tray notification (and no Stop-action footgun). This test
+ * reproduces the maintainer's reported scenario on-device:
+ *   1. Foreground + live session → NO session notification.
+ *   2. Background → the FGS starts, its notification + wakelock appear.
+ *   3. Return to foreground within grace → the FGS stops, notification + wakelock
+ *      clear, and the live connection is NOT dropped (starting/stopping the FGS
+ *      never touches the connection).
+ *
+ * The grace-window teardown math (#1123) and the port-forward always-on hold
+ * (#1159 Part 3) are covered deterministically by the JVM/Robolectric suites.
  */
 @RunWith(AndroidJUnit4::class)
 class SessionConnectionServiceE2eTest {
@@ -81,7 +88,7 @@ class SessionConnectionServiceE2eTest {
     }
 
     @Test
-    fun liveSessionServicePostsWakeLockAndNotification_thenGraceElapsedTearsDown() {
+    fun sessionFgsRunsOnlyWhileBackgrounded_foregroundHasNoNotification_connectionSurvives() {
         assertEquals(
             "API 35 evidence must run on Android 15",
             35,
@@ -89,19 +96,17 @@ class SessionConnectionServiceE2eTest {
         )
         grantNotifications()
         notificationManager.cancelAll()
-        BackgroundGraceTestOverride.setForTest(SHORT_GRACE_MS)
+        // A long grace so the backgrounded FGS stays up long enough to observe, and a
+        // return to the foreground is comfortably WITHIN grace (no teardown).
+        BackgroundGraceTestOverride.setForTest(LONG_GRACE_MS)
         scenario = ActivityScenario.launch(MainActivity::class.java)
 
         val registry = entryPoint().activeTmuxClients()
         val fakeClient = ConnectedTmuxClient()
-        val backgroundTeardown = CountDownLatch(1)
         lifecycleRegistration = registry.registerLifecycleHooks(
             hostId = HOST_ID,
             hooks = ActiveTmuxClients.LifecycleHooks(
-                onBackground = {
-                    fakeClient.markDisconnected()
-                    backgroundTeardown.countDown()
-                },
+                onBackground = {},
                 onForeground = {},
             ),
         )
@@ -115,8 +120,16 @@ class SessionConnectionServiceE2eTest {
             client = fakeClient,
         )
 
+        // Part 1 — FOREGROUND: a live session in the foreground must NOT post the
+        // "Session connected" notification (the Activity holds the connection; a Stop-able
+        // tray status is a footgun). Assert it stays absent through a settle window.
+        assertSessionNotificationAbsentWhileForeground()
+
+        // Part 1 — BACKGROUND: moving to CREATED backgrounds the process
+        // (ProcessLifecycleOwner ON_STOP), which starts the FGS + its notification + wakelock.
+        scenario!!.moveToState(androidx.lifecycle.Lifecycle.State.CREATED)
         val posted = waitForSessionNotification()
-        assertNotNull("live registry entry must start the session foreground notification", posted)
+        assertNotNull("backgrounding a live session must start the session foreground notification", posted)
         val notification = posted!!.notification
         assertEquals("pocketshell_session_status_v1", notification.channelId)
         val channel = notificationManager.getNotificationChannel(notification.channelId)
@@ -132,26 +145,32 @@ class SessionConnectionServiceE2eTest {
             "session notification must be non-clearable",
             notification.flags and Notification.FLAG_NO_CLEAR != 0,
         )
-        assertTrue(
-            "session notification must include Stop",
-            notification.actions?.any { it.title?.toString() == "Stop" } == true,
-        )
         waitForWakeLockHeld()
 
-        // Bounded-grace D21 update (#1123): background past the (short) grace window.
-        // The teardown must run AUTOMATICALLY at grace-elapsed — NO manual Stop, NO
-        // indefinite preserve. The fan-out fires the lifecycle `onBackground` hook
-        // (which here marks the fake client disconnected); the controller then stops the
-        // bounded service, clearing the notification + releasing the wakelock.
-        scenario!!.moveToState(androidx.lifecycle.Lifecycle.State.CREATED)
-
-        assertTrue(
-            "grace elapsing must fan out the destructive background teardown (no indefinite hold)",
-            backgroundTeardown.await(10, TimeUnit.SECONDS),
-        )
+        // Part 1 — FOREGROUND AGAIN (within grace): returning to the foreground stops the
+        // FGS (notification + wakelock clear) WITHOUT dropping the live connection —
+        // starting/stopping the service never touches the connection itself.
+        scenario!!.moveToState(androidx.lifecycle.Lifecycle.State.RESUMED)
         waitForSessionNotificationGone()
         waitForWakeLockReleased()
-        assertTrue("test client must be marked disconnected by the teardown hook", fakeClient.disconnected.value)
+        assertFalse(
+            "returning to the foreground must NOT drop the live connection (FGS stop is envelope-only)",
+            fakeClient.disconnected.value,
+        )
+    }
+
+    private fun assertSessionNotificationAbsentWhileForeground() {
+        val deadline = System.currentTimeMillis() + FOREGROUND_SETTLE_MS
+        while (System.currentTimeMillis() < deadline) {
+            assertNull(
+                "a foregrounded live session must NOT post the session notification (#1159 Part 1); " +
+                    "active titles=" + notificationManager.activeNotifications.map {
+                        it.notification.extras.getCharSequence("android.title")
+                    },
+                sessionNotification(),
+            )
+            Thread.sleep(POLL_MS)
+        }
     }
 
     private fun grantNotifications() {
@@ -282,7 +301,11 @@ class SessionConnectionServiceE2eTest {
 
     private companion object {
         const val HOST_ID: Long = 1_021_001L
-        const val SHORT_GRACE_MS: Long = 500L
+        // Long enough that the backgrounded FGS stays up for observation and a return to
+        // the foreground is comfortably within grace (no teardown).
+        const val LONG_GRACE_MS: Long = 120_000L
+        // Settle window over which the foreground must stay notification-free (#1159 Part 1).
+        const val FOREGROUND_SETTLE_MS: Long = 3_000L
         const val POLL_MS: Long = 100L
         const val WAKE_LOCK_TAG: String = "PocketShell:session"
     }

--- a/app/src/main/java/com/pocketshell/app/App.kt
+++ b/app/src/main/java/com/pocketshell/app/App.kt
@@ -17,6 +17,7 @@ import com.pocketshell.app.diagnostics.DiagnosticEvents
 import com.pocketshell.app.diagnostics.DiagnosticRecorder
 import com.pocketshell.app.diagnostics.ReconnectCauseTrail
 import com.pocketshell.app.diagnostics.StrictModeInstaller
+import com.pocketshell.app.portfwd.ForwardingController
 import com.pocketshell.app.portfwd.ForwardingResumeScheduler
 import com.pocketshell.app.release.UpdateCheckScheduler
 import com.pocketshell.app.settings.AppSettings
@@ -136,6 +137,15 @@ class App : Application() {
     lateinit var sessionServiceController: SessionServiceController
 
     /**
+     * Issue #1159 (Part 3): read-only source of "is a port-forward active" — the D21
+     * always-on carve-out. When `activeHostCount > 0` the App-level grace teardown is
+     * suppressed (the connection is pinned indefinitely) and the session foreground-service
+     * notification is worded "Port forwarding active" (no count-down). Never mutated here.
+     */
+    @Inject
+    lateinit var forwardingController: ForwardingController
+
+    /**
      * Issue #235: scope for fanning out tmux detach/reattach hooks
      * driven by the lifecycle observer. The dispatcher is
      * [Dispatchers.Main.immediate]: each hook posts work back into a
@@ -194,6 +204,12 @@ class App : Application() {
     private val backgroundGraceController = BackgroundGraceController(
         scope = graceLifecycleScope,
         graceMillis = BACKGROUND_GRACE_MILLIS,
+        // Issue #1159 (Part 3): while a port-forward is active the connection is pinned
+        // always-on — the bounded-grace teardown is SUPPRESSED (explicit user intent, the
+        // D21 carve-out). When the forward later stops, [BackgroundGraceController.onPinReleased]
+        // (driven by the forward-count observer in onCreate) resumes the normal teardown if
+        // the app is still backgrounded past the deadline.
+        holdWhilePinned = { forwardingController.flowOfActiveHostCount().value > 0 },
         onGraceElapsed = {
             // Issue #1123 (bounded-grace D21 update): once the grace window elapses the
             // app FULLY tears down — detach the `-CC` control client cleanly (no orphan,
@@ -273,10 +289,13 @@ class App : Application() {
                 )
                 backgroundGraceController.setGraceMillis(terminalGraceMillis)
                 backgroundGraceController.onBackground()
-                // Issue #1123: stamp the wall-clock disconnect deadline so the bounded
-                // session-hold notification renders a live count-down to teardown. Posted
-                // ONCE; the system chronometer does the per-second rendering (no wakeups).
-                sessionServiceController.onBackgroundGraceStarted(
+                // Issue #1159 (Part 1): the app is now backgrounded — start the session
+                // foreground service (if a live session is held) and stamp the wall-clock
+                // disconnect deadline so the bounded notification renders a live count-down
+                // to teardown. Posted ONCE; the system chronometer does the per-second
+                // rendering (no wakeups). In the foreground the FGS never runs (no tray
+                // notification, no Stop-action footgun).
+                sessionServiceController.onAppBackgrounded(
                     System.currentTimeMillis() + terminalGraceMillis.coerceAtLeast(0L),
                 )
             }
@@ -289,10 +308,10 @@ class App : Application() {
                     "trigger" to "on_start",
                 )
                 backgroundGraceController.onForeground()
-                // Issue #1123: returned within grace — clear the disconnect count-down so
-                // the notification reverts to its steady "connected" state. (Beyond grace
-                // the teardown stops the service entirely.)
-                sessionServiceController.onForegroundResumed()
+                // Issue #1159 (Part 1): back in the foreground — the Activity holds the
+                // connection, so stop the session foreground service and clear the
+                // disconnect count-down. Stopping the service never drops the connection.
+                sessionServiceController.onAppForegrounded()
             }
             else -> Unit
         }
@@ -358,16 +377,31 @@ class App : Application() {
         forwardingResumeScheduler.observeProcessLifecycle()
         StartupTiming.mark("forwarding-resume-lifecycle-observed")
 
-        // Issue #977 + #1123: BOUNDED foreground-service hold for live SSH/tmux
-        // sessions. The service runs while a live tmux client is attached so the OS
-        // sees an explicit foreground service + wakelock that keeps the connection
-        // alive through Doze during the (now 5-min, #1123) background grace window. The
-        // hold is BOUNDED, not indefinite: once the grace window elapses the terminal
-        // teardown unregisters the live client, which stops this service (no wake-lock
-        // or hold beyond grace). The old indefinite-hold "preserve past grace" + the
-        // notification-Stop-after-grace teardown plumbing are removed (#1123).
+        // Issue #977 + #1123 + #1159: BOUNDED foreground-service hold for live SSH/tmux
+        // sessions. Issue #1159 (Part 1): the service now runs ONLY while the app is
+        // BACKGROUNDED — in the foreground the Activity holds the connection, so no FGS and
+        // no Stop-able tray notification. The App lifecycle observer drives
+        // onAppBackgrounded/onAppForegrounded (below). The hold is BOUNDED (grace teardown)
+        // unless a port-forward pins it always-on (Part 3, wired next).
         sessionServiceController.observeActiveSessions()
         StartupTiming.mark("session-service-lifecycle-observed")
+
+        // Issue #1159 (Part 3): mirror the active-port-forward count into the session
+        // service (for the "Port forwarding active" notification wording) and, when the
+        // last forward stops while backgrounded, resume the bounded-grace teardown that was
+        // suppressed while the forward pinned the connection always-on. Event-driven read of
+        // a StateFlow — no timer / polling (D21). Foreground-safe: onPinReleased no-ops
+        // unless we are still backgrounded past the deadline.
+        graceLifecycleScope.launch {
+            forwardingController.flowOfActiveHostCount().collect { activeHostCount ->
+                val active = activeHostCount > 0
+                sessionServiceController.setPortForwardActive(active)
+                if (!active) {
+                    backgroundGraceController.onPinReleased()
+                }
+            }
+        }
+        StartupTiming.mark("port-forward-status-observed")
 
         // Issue #235 + #450: auto-detach tmux `-CC` clients on lifecycle
         // background + reattach on foreground, but only after the bounded
@@ -1027,6 +1061,12 @@ internal class BackgroundGraceController(
     private var graceMillis: Long,
     private val onGraceElapsed: suspend () -> Unit,
     private val onForeground: suspend (resumedWithinGrace: Boolean) -> Unit,
+    // Issue #1159 (Part 3): the port-forward always-on carve-out. When this predicate
+    // returns true at grace-elapse time the teardown is SUPPRESSED (the connection is
+    // pinned indefinitely — explicit user intent, the D21 carve-out) and `teardownFired`
+    // is left false so [onPinReleased] can resume the teardown once the pin drops. Defaults
+    // to `{ false }` so the bounded behaviour is unchanged when no forward is active.
+    private val holdWhilePinned: () -> Boolean = { false },
     // Issue #1080 — production injects `SystemClock.elapsedRealtime()` (counts
     // deep sleep) so the within-grace/beyond-grace window math reflects real
     // elapsed time across a Doze gap. This System.nanoTime default is the
@@ -1055,6 +1095,14 @@ internal class BackgroundGraceController(
     private var teardownFired: Boolean = false
 
     /**
+     * Issue #1159 (Part 3): true once the grace deadline elapsed for this background cycle
+     * but the teardown was SUPPRESSED because a port-forward pinned the connection always-on.
+     * The deadline has passed, so if the forward later stops while still backgrounded,
+     * [onPinReleased] resumes the teardown immediately. Reset on the next [onBackground].
+     */
+    private var pinnedHoldActive: Boolean = false
+
+    /**
      * Update the grace window used by the next [onBackground] call. An
      * already-running timer keeps its original deadline so changing Settings
      * cannot unexpectedly prolong a backgrounded connection.
@@ -1076,6 +1124,7 @@ internal class BackgroundGraceController(
         backgroundDeadlineAtMs = backgroundStartedAtMs + backgroundGraceMillisForCycle
         backgrounded = true
         teardownFired = false
+        pinnedHoldActive = false
         Log.i(GRACE_LIFECYCLE_TAG, "grace-window-start millis=$backgroundGraceMillisForCycle")
         DiagnosticEvents.record(
             "app",
@@ -1132,7 +1181,38 @@ internal class BackgroundGraceController(
 
     private suspend fun dispatchGraceElapsedIfNeeded(source: String, trigger: String): Boolean {
         if (teardownFired) return false
+        // Issue #1159 (Part 3): a port-forward pins the connection always-on — SUPPRESS the
+        // bounded teardown. Leave `teardownFired` false so [onPinReleased] can run the
+        // teardown once the forward stops (the deadline has already passed). Recorded once
+        // per cycle so the diagnostics don't spam if the timer + a lifecycle re-check both hit.
+        if (holdWhilePinned()) {
+            if (!pinnedHoldActive) {
+                pinnedHoldActive = true
+                Log.i(GRACE_LIFECYCLE_TAG, "grace-window-held-by-port-forward (always-on)")
+                DiagnosticEvents.record(
+                    "app",
+                    "background_grace_held_by_port_forward",
+                    "elapsedMs" to elapsedMs(),
+                    "millis" to backgroundGraceMillisForCycle,
+                    "deadlineMs" to backgroundDeadlineAtMs,
+                    "backgroundCycleId" to backgroundCycleId,
+                    "source" to source,
+                    "trigger" to trigger,
+                )
+                ReconnectCauseTrail.record(
+                    stage = "background_grace",
+                    outcome = "held_by_port_forward",
+                    cause = "port_forward_active",
+                    trigger = trigger,
+                    "graceMs" to backgroundGraceMillisForCycle,
+                    "deadlineMs" to backgroundDeadlineAtMs,
+                    "backgroundCycleId" to backgroundCycleId,
+                )
+            }
+            return false
+        }
         teardownFired = true
+        pinnedHoldActive = false
         val now = nowMillis()
         val elapsedMs = elapsedMs(now)
         Log.i(GRACE_LIFECYCLE_TAG, "grace-window-deadline-elapsed")
@@ -1197,9 +1277,29 @@ internal class BackgroundGraceController(
     private fun elapsedMs(now: Long = nowMillis()): Long =
         (now - backgroundStartedAtMs).coerceAtLeast(0L)
 
+    /**
+     * Issue #1159 (Part 3): the port-forward that was pinning the connection stopped. If we
+     * are STILL backgrounded and the grace deadline has already passed (the teardown was
+     * suppressed while the forward was active), resume the bounded teardown now — "when the
+     * port-forward stops (and nothing else pins the connection), normal bounded-grace
+     * applies again". Event-driven (fired by the forward-count observer), NOT a timer, so it
+     * respects D21. A no-op in the foreground or before the deadline.
+     */
+    fun onPinReleased() {
+        if (!backgrounded || teardownFired) return
+        if (holdWhilePinned()) return
+        if (nowMillis() < backgroundDeadlineAtMs) return
+        scope.launch {
+            dispatchGraceElapsedIfNeeded(source = "pin_released", trigger = "port_forward_stopped")
+        }
+    }
+
     /** Test seam: true while the current background cycle is still inside its deadline. */
     internal fun isGracePendingForTest(): Boolean =
         backgrounded && !teardownFired && nowMillis() < backgroundDeadlineAtMs
+
+    /** Test seam: true once the grace deadline elapsed but a port-forward pinned the hold (#1159). */
+    internal fun isPinnedHoldActiveForTest(): Boolean = pinnedHoldActive
 }
 
 internal class SshLeaseLifecycleDispatcher(

--- a/app/src/main/java/com/pocketshell/app/sessions/service/SessionConnectionService.kt
+++ b/app/src/main/java/com/pocketshell/app/sessions/service/SessionConnectionService.kt
@@ -224,18 +224,28 @@ class SessionConnectionService : Service() {
         // chronometer anchored on the wall-clock deadline (`when`) — the app posts the
         // notification ONCE and never schedules a per-second update / wakeup. A
         // contentTextOverride (the initial "Connecting session") never counts down.
+        //
+        // Issue #1159 (Part 3): a port-forward pins the connection always-on — there is no
+        // teardown to count down to, so the snapshot carries a null deadline and the
+        // notification is worded for the forward ("Port forwarding active") instead.
         val countdownDeadline =
-            if (contentTextOverride == null) snapshot.disconnectAtWallClockMillis else null
+            if (contentTextOverride == null && !snapshot.portForwardActive) {
+                snapshot.disconnectAtWallClockMillis
+            } else {
+                null
+            }
+
+        val title = if (snapshot.portForwardActive) "Port forwarding active" else "Session connected"
 
         val detail = contentTextOverride
-            ?: if (countdownDeadline != null) {
-                "Holding $hostLabel — disconnecting in"
-            } else {
-                "Keeping $hostLabel connected in the background"
+            ?: when {
+                snapshot.portForwardActive -> "Keeping $hostLabel connected for port forwarding"
+                countdownDeadline != null -> "Holding $hostLabel — disconnecting in"
+                else -> "Keeping $hostLabel connected in the background"
             }
 
         val builder = NotificationCompat.Builder(this, CHANNEL_ID)
-            .setContentTitle("Session connected")
+            .setContentTitle(title)
             .setContentText(detail)
             .setStyle(NotificationCompat.BigTextStyle().bigText(detail))
             .setSmallIcon(R.drawable.ic_stat_session)

--- a/app/src/main/java/com/pocketshell/app/sessions/service/SessionConnectionSnapshot.kt
+++ b/app/src/main/java/com/pocketshell/app/sessions/service/SessionConnectionSnapshot.kt
@@ -10,9 +10,17 @@ data class SessionConnectionSnapshot(
      * wall-clock (`System.currentTimeMillis()`) instant the session will be torn down —
      * the deadline the bounded foreground-service notification renders as a live
      * count-down ("disconnecting in MM:SS") via the system chronometer. Null while
-     * foreground (no count-down) or when there is no live hold.
+     * foreground (no count-down), while a port-forward pins the connection always-on
+     * (issue #1159 Part 3 — no teardown, so no count-down), or when there is no live hold.
      */
     val disconnectAtWallClockMillis: Long? = null,
+    /**
+     * Issue #1159 (Part 3): true while a port-forward is active, pinning the connection
+     * always-on (no bounded-grace teardown — explicit user intent, the D21 carve-out).
+     * The foreground-service notification then reads "Port forwarding active" instead of
+     * a count-down.
+     */
+    val portForwardActive: Boolean = false,
 ) {
     val isHoldingConnection: Boolean
         get() = liveSessionCount > 0
@@ -22,6 +30,7 @@ data class SessionConnectionSnapshot(
             liveSessionCount = 0,
             primaryHostName = "",
             disconnectAtWallClockMillis = null,
+            portForwardActive = false,
         )
 
         fun fromEntries(entries: Collection<ActiveTmuxClients.Entry>): SessionConnectionSnapshot {

--- a/app/src/main/java/com/pocketshell/app/sessions/service/SessionServiceController.kt
+++ b/app/src/main/java/com/pocketshell/app/sessions/service/SessionServiceController.kt
@@ -26,16 +26,25 @@ import kotlinx.coroutines.launch
  *
  * The tmux client registry remains the source of truth for whether a user has an
  * attached, live terminal session. This controller only translates that signal into
- * foreground-service start/stop intents: the service runs while a live tmux client is
- * attached so the OS keeps the connection alive through Doze during the background grace
- * window, and stops as soon as the last live client unregisters.
+ * foreground-service start/stop intents.
  *
  * Issue #1123 (bounded-grace D21 update): the hold is BOUNDED, not indefinite. Once the
  * App-level grace window elapses the terminal teardown unregisters the live client, which
  * drops the snapshot to empty and stops this service — so no wake-lock or hold persists in
- * the background beyond the grace window. The old indefinite-hold
- * `isHoldingSessionConnection` preserve gate and the notification-Stop-after-grace
- * teardown plumbing are removed.
+ * the background beyond the grace window.
+ *
+ * Issue #1159 (Part 1 + Part 3):
+ *  - **Part 1**: the FGS now runs ONLY while the app is BACKGROUNDED. In the foreground the
+ *    Activity itself holds the SSH/tmux connection, so there is no need for the service —
+ *    and no reason to sit a Stop-able "Session connected" notification in the tray where an
+ *    accidental tap would kill the live connection. App lifecycle drives
+ *    [onAppForegrounded]/[onAppBackgrounded]; the service only starts on background and
+ *    stops on foreground. Starting/stopping the service never touches the connection itself
+ *    (the service owns only Android process-survival mechanics).
+ *  - **Part 3**: while a port-forward is active ([setPortForwardActive]) the notification
+ *    reads "Port forwarding active" and shows NO count-down — the connection is pinned
+ *    always-on (the App-level grace teardown is suppressed), so there is no disconnect
+ *    deadline to count down to.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 @Singleton
@@ -50,44 +59,73 @@ class SessionServiceController @Inject constructor(
     private var observeJob: Job? = null
     private var holdStoppedByUser: Boolean = false
 
+    /**
+     * Issue #1159 (Part 1): whether the app is currently foregrounded. The FGS runs ONLY
+     * when this is false. Defaults to `true` (a cold start opens into a foreground Activity),
+     * so a session that connects in the foreground does NOT start the service until the app
+     * is backgrounded.
+     */
+    private val appForegrounded = MutableStateFlow(true)
+
+    /** Issue #1159 (Part 3): whether a port-forward is active (pins the notification wording). */
+    private val portForwardActive = MutableStateFlow(false)
+
     // Issue #1123: the wall-clock disconnect deadline shown as the bounded notification's
-    // live count-down while backgrounded. Set on background grace start, cleared on
-    // foreground. Merged into every emitted snapshot so a client-liveness update never
-    // drops the count-down mid-window.
-    private var graceDisconnectAtWallClockMillis: Long? = null
+    // live count-down while backgrounded. Set on background, cleared on foreground. Merged
+    // into every emitted snapshot so a client-liveness update never drops the count-down
+    // mid-window. Null while a port-forward pins the connection (#1159 Part 3 — no teardown).
+    private val graceDisconnectAtWallClockMillis = MutableStateFlow<Long?>(null)
 
     fun flowOfSnapshot(): StateFlow<SessionConnectionSnapshot> = _snapshot.asStateFlow()
 
     fun observeActiveSessions() {
         if (observeJob?.isActive == true) return
-        observeJob = scope.launch {
-            activeTmuxClients.clients
-                .flatMapLatest { clients ->
-                    val entries = clients.values.toList()
-                    if (entries.isEmpty()) {
-                        flowOf(SessionConnectionSnapshot.Empty)
-                    } else {
-                        combine(
-                            entries.map { entry ->
-                                entry.client.disconnected.map { disconnected -> entry to disconnected }
-                            },
-                        ) { states ->
-                            val liveEntries = states
-                                .filter { (_, disconnected) -> !disconnected }
-                                .map { (entry, _) -> entry }
-                            SessionConnectionSnapshot.fromEntries(liveEntries)
-                        }
+        val rawSnapshots = activeTmuxClients.clients
+            .flatMapLatest { clients ->
+                val entries = clients.values.toList()
+                if (entries.isEmpty()) {
+                    flowOf(SessionConnectionSnapshot.Empty)
+                } else {
+                    combine(
+                        entries.map { entry ->
+                            entry.client.disconnected.map { disconnected -> entry to disconnected }
+                        },
+                    ) { states ->
+                        val liveEntries = states
+                            .filter { (_, disconnected) -> !disconnected }
+                            .map { (entry, _) -> entry }
+                        SessionConnectionSnapshot.fromEntries(liveEntries)
                     }
                 }
+            }
+        observeJob = scope.launch {
+            combine(
+                rawSnapshots,
+                appForegrounded,
+                portForwardActive,
+                graceDisconnectAtWallClockMillis,
+            ) { rawSnapshot, foreground, pfActive, deadline ->
+                EffectiveInputs(rawSnapshot, foreground, pfActive, deadline)
+            }
                 .distinctUntilChanged()
-                .collect { rawSnapshot ->
+                .collect { (rawSnapshot, foreground, pfActive, deadline) ->
                     if (!rawSnapshot.isHoldingConnection) {
                         holdStoppedByUser = false
                     }
-                    val snapshot = if (holdStoppedByUser) {
+                    // Issue #1159 (Part 1): hold the FGS ONLY while backgrounded. In the
+                    // foreground the Activity holds the connection — no service, no tray
+                    // notification (and no Stop-action footgun).
+                    val shouldHold = rawSnapshot.isHoldingConnection && !foreground
+                    val snapshot = if (holdStoppedByUser || !shouldHold) {
                         SessionConnectionSnapshot.Empty
                     } else {
-                        rawSnapshot.withCurrentDeadline()
+                        rawSnapshot.copy(
+                            portForwardActive = pfActive,
+                            // Part 3: a port-forward pins the connection always-on (no
+                            // teardown) → no count-down deadline. Otherwise the bounded
+                            // grace count-down.
+                            disconnectAtWallClockMillis = if (pfActive) null else deadline,
+                        )
                     }
                     val wasHolding = _snapshot.value.isHoldingConnection
                     _snapshot.value = snapshot
@@ -102,38 +140,34 @@ class SessionServiceController @Inject constructor(
     }
 
     /**
-     * Issue #1123: the app backgrounded and the (5-min) grace window started. Stamp the
-     * wall-clock disconnect deadline so the bounded foreground-service notification renders
-     * a live count-down to teardown. The system chronometer (`setChronometerCountDown`)
-     * does the per-second rendering — no app-side per-second wakeups.
+     * Issue #1159 (Part 1): the app moved to the background. The FGS is (re)evaluated and
+     * started if a live session is held. [disconnectAtWallClockMillis] stamps the bounded
+     * count-down deadline (issue #1123) rendered by the system chronometer — no app-side
+     * per-second wakeups. While a port-forward is active the deadline is ignored (Part 3).
      */
-    fun onBackgroundGraceStarted(disconnectAtWallClockMillis: Long) {
-        graceDisconnectAtWallClockMillis = disconnectAtWallClockMillis
-        val current = _snapshot.value
-        if (current.isHoldingConnection) {
-            _snapshot.value = current.copy(disconnectAtWallClockMillis = disconnectAtWallClockMillis)
-        }
+    fun onAppBackgrounded(disconnectAtWallClockMillis: Long) {
+        graceDisconnectAtWallClockMillis.value = disconnectAtWallClockMillis
+        appForegrounded.value = false
     }
 
     /**
-     * Issue #1123: the app returned to the foreground (within grace) — clear the count-down
-     * so the notification goes back to its steady "connected" state. (Beyond grace the
-     * teardown stops the service entirely, so this is the within-grace return path.)
+     * Issue #1159 (Part 1): the app returned to the foreground. The Activity now holds the
+     * connection, so the FGS + its tray notification are stopped and the count-down cleared.
      */
-    fun onForegroundResumed() {
-        graceDisconnectAtWallClockMillis = null
-        val current = _snapshot.value
-        if (current.disconnectAtWallClockMillis != null) {
-            _snapshot.value = current.copy(disconnectAtWallClockMillis = null)
-        }
+    fun onAppForegrounded() {
+        graceDisconnectAtWallClockMillis.value = null
+        appForegrounded.value = true
     }
 
-    private fun SessionConnectionSnapshot.withCurrentDeadline(): SessionConnectionSnapshot =
-        if (isHoldingConnection && graceDisconnectAtWallClockMillis != null) {
-            copy(disconnectAtWallClockMillis = graceDisconnectAtWallClockMillis)
-        } else {
-            this
-        }
+    /**
+     * Issue #1159 (Part 3): mark whether a port-forward is currently active. When true the
+     * notification reads "Port forwarding active" with no count-down (the connection is
+     * pinned always-on); when it drops back to false the normal bounded-grace count-down
+     * applies again on the next background.
+     */
+    fun setPortForwardActive(active: Boolean) {
+        portForwardActive.value = active
+    }
 
     fun currentSnapshot(): SessionConnectionSnapshot =
         SessionConnectionSnapshot.fromEntries(activeTmuxClients.clients.value.values)
@@ -147,7 +181,7 @@ class SessionServiceController @Inject constructor(
         if (holdStoppedByUser) return
         if (!currentSnapshot().isHoldingConnection) return
         holdStoppedByUser = true
-        graceDisconnectAtWallClockMillis = null
+        graceDisconnectAtWallClockMillis.value = null
         _snapshot.value = SessionConnectionSnapshot.Empty
         if (requestServiceStop) {
             SessionConnectionService.stop(appContext)
@@ -159,7 +193,16 @@ class SessionServiceController @Inject constructor(
         observeJob?.cancel()
         observeJob = null
         holdStoppedByUser = false
-        graceDisconnectAtWallClockMillis = null
+        graceDisconnectAtWallClockMillis.value = null
+        appForegrounded.value = true
+        portForwardActive.value = false
         _snapshot.value = SessionConnectionSnapshot.Empty
     }
+
+    private data class EffectiveInputs(
+        val rawSnapshot: SessionConnectionSnapshot,
+        val foreground: Boolean,
+        val portForwardActive: Boolean,
+        val disconnectDeadline: Long?,
+    )
 }

--- a/app/src/main/java/com/pocketshell/app/settings/SettingsModels.kt
+++ b/app/src/main/java/com/pocketshell/app/settings/SettingsModels.kt
@@ -354,24 +354,27 @@ data class AppSettings(
             DefaultAgentSessionView.Conversation
 
         const val BACKGROUND_GRACE_30_SECONDS_MS: Long = 30_000L
+        const val BACKGROUND_GRACE_90_SECONDS_MS: Long = 90_000L
         const val BACKGROUND_GRACE_1_MINUTE_MS: Long = 60_000L
         const val BACKGROUND_GRACE_5_MINUTES_MS: Long = 5 * 60_000L
         const val BACKGROUND_GRACE_10_MINUTES_MS: Long = 10 * 60_000L
 
         /**
-         * Issue #1123 (sanctioned D21 update): the background grace window defaults to
-         * **5 minutes**, raised from the original 60 s. The maintainer is fine with a
-         * bounded background hold ("I'm okay if I need to reconnect after 5 minutes but
-         * not after 60 seconds") — within this window a return is seamless (the
-         * connection is held, no reconnect band); once it elapses the app fully tears
-         * down (detach `-CC` cleanly, stop the foreground service + wake-lock, release
-         * the SSH lease) so NOTHING runs in the background beyond the grace window. The
-         * #977/#1021 INDEFINITE foreground-service hold is removed.
+         * Issue #1159 (maintainer directive 2026-07-01): the background grace window
+         * defaults to **90 seconds**, lowered from the #1123 5-minute value ("make the
+         * default like 90 seconds… 5 minutes is longer than needed"). The user can raise
+         * or lower it via Settings → Terminal → Background grace. Within the window a
+         * return is seamless (the connection is held, no reconnect band); once it elapses
+         * the app fully tears down (detach `-CC` cleanly, stop the foreground service +
+         * wake-lock, release the SSH lease) so NOTHING runs in the background beyond the
+         * grace window — EXCEPT while a port-forward is active (issue #1159 Part 3), which
+         * pins the connection always-on (explicit user intent, the D21 carve-out).
          */
-        const val DEFAULT_BACKGROUND_GRACE_MILLIS: Long = BACKGROUND_GRACE_5_MINUTES_MS
+        const val DEFAULT_BACKGROUND_GRACE_MILLIS: Long = BACKGROUND_GRACE_90_SECONDS_MS
 
         val BACKGROUND_GRACE_OPTIONS: List<BackgroundGraceOption> = listOf(
             BackgroundGraceOption(BACKGROUND_GRACE_30_SECONDS_MS, "30 sec"),
+            BackgroundGraceOption(BACKGROUND_GRACE_90_SECONDS_MS, "90 sec"),
             BackgroundGraceOption(BACKGROUND_GRACE_1_MINUTE_MS, "1 min"),
             BackgroundGraceOption(BACKGROUND_GRACE_5_MINUTES_MS, "5 min"),
             BackgroundGraceOption(BACKGROUND_GRACE_10_MINUTES_MS, "10 min"),

--- a/app/src/test/java/com/pocketshell/app/BackgroundGraceControllerTest.kt
+++ b/app/src/test/java/com/pocketshell/app/BackgroundGraceControllerTest.kt
@@ -1363,6 +1363,106 @@ class BackgroundGraceControllerTest {
         assertEquals(true, forwardingActive)
     }
 
+    @Test
+    fun `issue 1159 port-forward pins the connection - grace elapse suppresses the teardown`() = runTest {
+        // Part 3: while a port-forward is active the bounded teardown is SUPPRESSED — the
+        // connection is pinned always-on (explicit user intent, the D21 carve-out). The
+        // grace deadline elapses but onGraceElapsed never runs.
+        val events = mutableListOf<String>()
+        val controller = BackgroundGraceController(
+            scope = backgroundScope,
+            graceMillis = graceMillis,
+            holdWhilePinned = { true },
+            onGraceElapsed = { events += "teardown" },
+            onForeground = { resumedWithinGrace -> events += "foreground:$resumedWithinGrace" },
+            nowMillis = { currentTime },
+        )
+
+        controller.onBackground()
+        runCurrent()
+        advanceTimeBy(graceMillis + 1)
+        runCurrent()
+
+        assertEquals(
+            "a port-forward pins the connection always-on — the teardown must NOT run",
+            emptyList<String>(),
+            events,
+        )
+        assertTrue(
+            "the pinned-hold state must be active after the suppressed deadline",
+            controller.isPinnedHoldActiveForTest(),
+        )
+        assertFalse("the timer must be complete (deadline passed)", controller.isGracePendingForTest())
+    }
+
+    @Test
+    fun `issue 1159 dropping the port-forward past the deadline resumes the bounded teardown`() = runTest {
+        // Part 3: "when the port-forward stops (and nothing else pins the connection),
+        // normal bounded-grace applies again". The suppressed teardown runs on onPinReleased.
+        val events = mutableListOf<String>()
+        var pinned = true
+        val controller = BackgroundGraceController(
+            scope = backgroundScope,
+            graceMillis = graceMillis,
+            holdWhilePinned = { pinned },
+            onGraceElapsed = { events += "teardown" },
+            onForeground = { resumedWithinGrace -> events += "foreground:$resumedWithinGrace" },
+            nowMillis = { currentTime },
+        )
+
+        controller.onBackground()
+        runCurrent()
+        advanceTimeBy(graceMillis + 1)
+        runCurrent()
+        assertEquals("held while the forward pinned it", emptyList<String>(), events)
+
+        // The forward stops while still backgrounded, past the deadline.
+        pinned = false
+        controller.onPinReleased()
+        runCurrent()
+
+        assertEquals(
+            "dropping the forward past the deadline must run the suppressed teardown",
+            listOf("teardown"),
+            events,
+        )
+        assertFalse(controller.isPinnedHoldActiveForTest())
+    }
+
+    @Test
+    fun `issue 1159 pin released before the deadline does not tear down early`() = runTest {
+        val events = mutableListOf<String>()
+        var pinned = true
+        val controller = BackgroundGraceController(
+            scope = backgroundScope,
+            graceMillis = graceMillis,
+            holdWhilePinned = { pinned },
+            onGraceElapsed = { events += "teardown" },
+            onForeground = { resumedWithinGrace -> events += "foreground:$resumedWithinGrace" },
+            nowMillis = { currentTime },
+        )
+
+        controller.onBackground()
+        runCurrent()
+        advanceTimeBy(graceMillis / 2)
+        runCurrent()
+
+        // Forward stops mid-window: this is a no-op (the deadline has not passed); the still
+        // pending timer keeps the ordinary bounded window.
+        pinned = false
+        controller.onPinReleased()
+        runCurrent()
+        assertEquals("pin released before the deadline must not tear down early", emptyList<String>(), events)
+
+        advanceTimeBy(graceMillis)
+        runCurrent()
+        assertEquals(
+            "the ordinary bounded timer still fires the teardown at its deadline",
+            listOf("teardown"),
+            events,
+        )
+    }
+
     private fun kotlinx.coroutines.test.TestScope.controller(
         events: MutableList<String>,
     ): BackgroundGraceController =

--- a/app/src/test/java/com/pocketshell/app/sessions/service/SessionConnectionServiceTest.kt
+++ b/app/src/test/java/com/pocketshell/app/sessions/service/SessionConnectionServiceTest.kt
@@ -83,6 +83,58 @@ class SessionConnectionServiceTest {
     }
 
     @Test
+    fun `port-forward active notification reads Port forwarding active with no count-down`() {
+        // Issue #1159 (Part 3): a port-forward pins the connection always-on — the snapshot
+        // carries portForwardActive=true and a null deadline, and the notification is worded
+        // for the forward with NO count-down chronometer (there is no teardown to count to).
+        val notification = buildServiceNotification(
+            SessionConnectionSnapshot(
+                liveSessionCount = 1,
+                primaryHostName = "alpha",
+                disconnectAtWallClockMillis = null,
+                portForwardActive = true,
+            ),
+        )
+
+        assertEquals(
+            "Port forwarding active",
+            notification.extras.getCharSequence("android.title")?.toString(),
+        )
+        val body = notification.extras.getCharSequence("android.text")?.toString().orEmpty()
+        assertTrue(
+            "body must be worded for the forward, not a count-down: '$body'",
+            body.contains("port forwarding"),
+        )
+        assertFalse(
+            "a port-forward-pinned hold must NOT show a count-down chronometer",
+            notification.extras.getBoolean(Notification.EXTRA_SHOW_CHRONOMETER),
+        )
+    }
+
+    @Test
+    fun `port-forward active suppresses the count-down even when a deadline is present`() {
+        // Defensive: even if a stale deadline leaks into the snapshot, port-forward-active
+        // must win and suppress the chronometer (the connection is pinned, not counting down).
+        val notification = buildServiceNotification(
+            SessionConnectionSnapshot(
+                liveSessionCount = 1,
+                primaryHostName = "alpha",
+                disconnectAtWallClockMillis = System.currentTimeMillis() + 90_000L,
+                portForwardActive = true,
+            ),
+        )
+
+        assertFalse(
+            "port-forward-active must suppress the count-down chronometer",
+            notification.extras.getBoolean(Notification.EXTRA_SHOW_CHRONOMETER),
+        )
+        assertEquals(
+            "Port forwarding active",
+            notification.extras.getCharSequence("android.title")?.toString(),
+        )
+    }
+
+    @Test
     fun `notification collapses multiple hosts`() {
         val notification = buildServiceNotification(
             SessionConnectionSnapshot(liveSessionCount = 3, primaryHostName = "alpha"),

--- a/app/src/test/java/com/pocketshell/app/sessions/service/SessionServiceControllerTest.kt
+++ b/app/src/test/java/com/pocketshell/app/sessions/service/SessionServiceControllerTest.kt
@@ -25,12 +25,16 @@ import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowApplication
 
 /**
- * Issue #1123 (bounded-grace D21 update): the controller is now a simple BOUNDED
- * keepalive — it starts the foreground service on the first live tmux client and stops it
- * when the last live client goes away. The old indefinite-hold gate
- * (`isHoldingSessionConnection` + the foreground-promotion tracking) and the
- * notification-Stop-after-grace event flows are removed, so these tests assert only the
- * start/stop transitions + the snapshot.
+ * Issue #1159 (Part 1 + Part 3): the session foreground-service hold.
+ *
+ * Part 1: the FGS runs ONLY while the app is BACKGROUNDED. A live session in the
+ * foreground does NOT start the service (the Activity holds the connection — no tray
+ * notification, no Stop footgun); backgrounding starts it, foregrounding stops it, and
+ * neither transition touches the connection itself.
+ *
+ * Part 3: while a port-forward is active the emitted snapshot is flagged `portForwardActive`
+ * with NO count-down deadline (the connection is pinned always-on, so there is nothing to
+ * count down to); dropping the forward restores the normal bounded-grace count-down.
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(manifest = Config.NONE, sdk = [33])
@@ -48,33 +52,113 @@ class SessionServiceControllerTest {
     }
 
     @Test
-    fun `first live tmux client starts the session foreground service`() = runTest {
+    fun `live tmux client in the foreground does NOT start the service`() = runTest {
         val activeClients = ActiveTmuxClients()
         val controller = controller(activeClients, testScheduler)
 
         controller.observeActiveSessions()
         runCurrent()
-        activeClients.register(
-            hostId = 1L,
-            hostName = "alpha",
-            hostname = "alpha.example",
-            port = 22,
-            username = "alexey",
-            keyPath = "/tmp/key",
-            client = FakeTmuxClient(),
-        )
+        // Default state is foreground (a cold start opens into a foreground Activity).
+        registerLive(activeClients, "alpha")
         runCurrent()
 
-        val started = shadow.nextStartedService
-        assertNotNull("first live session must start SessionConnectionService", started)
-        assertEquals(SessionConnectionService::class.java.name, started?.component?.className)
-        assertEquals(SessionConnectionService.ACTION_START, started?.action)
-        assertTrue(controller.flowOfSnapshot().value.isHoldingConnection)
-        assertEquals("alpha", controller.flowOfSnapshot().value.primaryHostName)
+        assertNull(
+            "a foregrounded live session must NOT start the FGS (#1159 Part 1)",
+            shadow.nextStartedService,
+        )
+        assertFalse(
+            "the snapshot must not hold while foregrounded",
+            controller.flowOfSnapshot().value.isHoldingConnection,
+        )
     }
 
     @Test
-    fun `disconnecting the last live tmux client stops the session foreground service`() = runTest {
+    fun `backgrounding a live session starts the service and foregrounding stops it`() = runTest {
+        val activeClients = ActiveTmuxClients()
+        val controller = controller(activeClients, testScheduler)
+
+        controller.observeActiveSessions()
+        runCurrent()
+        registerLive(activeClients, "alpha")
+        runCurrent()
+        drainStartedServices()
+
+        val deadline = 1_000L
+        controller.onAppBackgrounded(disconnectAtWallClockMillis = deadline)
+        runCurrent()
+
+        val started = shadow.nextStartedService
+        assertNotNull("backgrounding a live session must start SessionConnectionService", started)
+        assertEquals(SessionConnectionService::class.java.name, started?.component?.className)
+        assertEquals(SessionConnectionService.ACTION_START, started?.action)
+        val bgSnapshot = controller.flowOfSnapshot().value
+        assertTrue(bgSnapshot.isHoldingConnection)
+        assertEquals("alpha", bgSnapshot.primaryHostName)
+        assertEquals(
+            "backgrounded hold must carry the bounded count-down deadline",
+            deadline,
+            bgSnapshot.disconnectAtWallClockMillis,
+        )
+
+        controller.onAppForegrounded()
+        runCurrent()
+
+        val stopped = shadow.nextStartedService
+        assertNotNull("returning to the foreground must stop the FGS", stopped)
+        assertEquals(SessionConnectionService.ACTION_STOP, stopped?.action)
+        assertFalse(controller.flowOfSnapshot().value.isHoldingConnection)
+    }
+
+    @Test
+    fun `port-forward active flags the snapshot with no count-down`() = runTest {
+        val activeClients = ActiveTmuxClients()
+        val controller = controller(activeClients, testScheduler)
+
+        controller.observeActiveSessions()
+        runCurrent()
+        registerLive(activeClients, "alpha")
+        runCurrent()
+        controller.setPortForwardActive(true)
+        controller.onAppBackgrounded(disconnectAtWallClockMillis = 5_000L)
+        runCurrent()
+
+        val snapshot = controller.flowOfSnapshot().value
+        assertTrue("a port-forward-pinned session must still hold", snapshot.isHoldingConnection)
+        assertTrue("port-forward-active must flag the snapshot", snapshot.portForwardActive)
+        assertNull(
+            "a port-forward pins the connection always-on — NO count-down deadline (#1159 Part 3)",
+            snapshot.disconnectAtWallClockMillis,
+        )
+    }
+
+    @Test
+    fun `dropping the port-forward restores the bounded count-down while still backgrounded`() = runTest {
+        val activeClients = ActiveTmuxClients()
+        val controller = controller(activeClients, testScheduler)
+
+        controller.observeActiveSessions()
+        runCurrent()
+        registerLive(activeClients, "alpha")
+        controller.setPortForwardActive(true)
+        controller.onAppBackgrounded(disconnectAtWallClockMillis = 5_000L)
+        runCurrent()
+        assertTrue(controller.flowOfSnapshot().value.portForwardActive)
+        assertNull(controller.flowOfSnapshot().value.disconnectAtWallClockMillis)
+
+        controller.setPortForwardActive(false)
+        runCurrent()
+
+        val snapshot = controller.flowOfSnapshot().value
+        assertFalse("dropping the forward must clear the flag", snapshot.portForwardActive)
+        assertEquals(
+            "dropping the forward restores the bounded count-down deadline",
+            5_000L,
+            snapshot.disconnectAtWallClockMillis,
+        )
+    }
+
+    @Test
+    fun `disconnecting the last live tmux client stops the backgrounded service`() = runTest {
         val activeClients = ActiveTmuxClients()
         val client = FakeTmuxClient()
         val controller = controller(activeClients, testScheduler)
@@ -90,6 +174,7 @@ class SessionServiceControllerTest {
             keyPath = "/tmp/key",
             client = client,
         )
+        controller.onAppBackgrounded(disconnectAtWallClockMillis = 1_000L)
         runCurrent()
         drainStartedServices()
 
@@ -137,7 +222,7 @@ class SessionServiceControllerTest {
     }
 
     @Test
-    fun `notification stop stops the foreground service for the current live session set`() = runTest {
+    fun `notification stop stops the foreground service for the current backgrounded session`() = runTest {
         val activeClients = ActiveTmuxClients()
         val client = FakeTmuxClient()
         val controller = controller(activeClients, testScheduler)
@@ -153,6 +238,7 @@ class SessionServiceControllerTest {
             keyPath = "/tmp/key",
             client = client,
         )
+        controller.onAppBackgrounded(disconnectAtWallClockMillis = 1_000L)
         runCurrent()
         drainStartedServices()
 
@@ -173,17 +259,6 @@ class SessionServiceControllerTest {
             "duplicate Stop delivery must not re-issue a service intent",
             shadow.nextStartedService,
         )
-
-        // After an all-clear / re-connect transition the bounded hold may start again.
-        client.disconnectedSignal.value = true
-        runCurrent()
-        client.disconnectedSignal.value = false
-        runCurrent()
-
-        val restarted = shadow.nextStartedService
-        assertNotNull("a fresh live-client transition after all-clear may start the hold again", restarted)
-        assertEquals(SessionConnectionService.ACTION_START, restarted?.action)
-        assertTrue(controller.flowOfSnapshot().value.isHoldingConnection)
     }
 
     @Test
@@ -192,9 +267,23 @@ class SessionServiceControllerTest {
 
         controller.observeActiveSessions()
         runCurrent()
+        controller.onAppBackgrounded(disconnectAtWallClockMillis = 1_000L)
+        runCurrent()
 
         assertNull(shadow.nextStartedService)
         assertFalse(controller.flowOfSnapshot().value.isHoldingConnection)
+    }
+
+    private fun registerLive(activeClients: ActiveTmuxClients, hostName: String) {
+        activeClients.register(
+            hostId = 1L,
+            hostName = hostName,
+            hostname = "$hostName.example",
+            port = 22,
+            username = "alexey",
+            keyPath = "/tmp/key",
+            client = FakeTmuxClient(),
+        )
     }
 
     private fun controller(

--- a/app/src/test/java/com/pocketshell/app/settings/BackgroundGraceDefaultTest.kt
+++ b/app/src/test/java/com/pocketshell/app/settings/BackgroundGraceDefaultTest.kt
@@ -5,31 +5,36 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * Issue #1123 (bounded-grace D21 update): the background grace window defaults to 5
- * minutes, raised from the original 60 s. Pins the constant + the Settings option list so
- * a regression that drops it back to 60 s (the symptom the maintainer rejected — "not
- * after 60 seconds") fails at PR time.
+ * Issue #1159 (maintainer directive 2026-07-01): the background grace window defaults to
+ * **90 seconds**, lowered from the #1123 5-minute value ("make the default like 90 seconds…
+ * 5 minutes is longer than needed"). Pins the constant + the Settings option list so a
+ * regression back to 5 minutes fails at PR time.
  */
 class BackgroundGraceDefaultTest {
 
     @Test
-    fun `default background grace is five minutes`() {
+    fun `default background grace is ninety seconds`() {
         assertEquals(
-            "background grace default must be 5 minutes (#1123)",
-            5 * 60_000L,
+            "background grace default must be 90 seconds (#1159)",
+            90_000L,
             AppSettings.DEFAULT_BACKGROUND_GRACE_MILLIS,
         )
         assertEquals(
-            AppSettings.BACKGROUND_GRACE_5_MINUTES_MS,
+            AppSettings.BACKGROUND_GRACE_90_SECONDS_MS,
             AppSettings.DEFAULT_BACKGROUND_GRACE_MILLIS,
         )
     }
 
     @Test
-    fun `grace options expose 5 minute default with correct labels and no duplicate values`() {
+    fun `grace options expose the 90 second default with correct labels and no duplicate values`() {
         val options = AppSettings.BACKGROUND_GRACE_OPTIONS
         val byMillis = options.associate { it.millis to it.label }
 
+        assertEquals(
+            "the 90-second option must exist and be labelled correctly",
+            "90 sec",
+            byMillis[AppSettings.BACKGROUND_GRACE_90_SECONDS_MS],
+        )
         assertEquals(
             "the 1-minute option must still exist and be labelled correctly",
             "1 min",
@@ -37,7 +42,7 @@ class BackgroundGraceDefaultTest {
         )
         assertEquals("5 min", byMillis[AppSettings.BACKGROUND_GRACE_5_MINUTES_MS])
         assertTrue(
-            "the default (5 min) must be a selectable option",
+            "the default (90 sec) must be a selectable option",
             options.any { it.millis == AppSettings.DEFAULT_BACKGROUND_GRACE_MILLIS },
         )
         assertEquals(

--- a/shared/core-connection/src/main/java/com/pocketshell/core/connection/ConnectionController.kt
+++ b/shared/core-connection/src/main/java/com/pocketshell/core/connection/ConnectionController.kt
@@ -296,12 +296,13 @@ class ConnectionController(
 
     companion object {
         /**
-         * Single lease-anchored grace window. Issue #1123 (sanctioned D21 update):
-         * raised 60 s -> 5 min so a background return is seamless for up to five
-         * minutes; beyond it the connection fully tears down (no indefinite hold).
-         * Mirrors `AppSettings.DEFAULT_BACKGROUND_GRACE_MILLIS`.
+         * Single lease-anchored grace window. Issue #1159 (maintainer directive
+         * 2026-07-01): lowered 5 min -> **90 s** ("5 minutes is longer than needed");
+         * within the window a background return is seamless, beyond it the connection
+         * fully tears down (no indefinite hold) unless a port-forward pins it always-on
+         * (issue #1159 Part 3). Mirrors `AppSettings.DEFAULT_BACKGROUND_GRACE_MILLIS`.
          */
-        const val DEFAULT_GRACE_MS: Long = 5 * 60_000L
+        const val DEFAULT_GRACE_MS: Long = 90_000L
 
         /** Silent reconnect attempts before the only honest error ([Unreachable]). */
         const val DEFAULT_MAX_RECONNECT_ATTEMPTS: Int = 4

--- a/shared/core-connection/src/test/java/com/pocketshell/core/connection/ControllerGraceDefaultTest.kt
+++ b/shared/core-connection/src/test/java/com/pocketshell/core/connection/ControllerGraceDefaultTest.kt
@@ -4,18 +4,18 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 
 /**
- * Issue #1123 (bounded-grace D21 update): the controller grace window — the period a
- * backgrounded connection is held before it tears down — is 5 minutes, aligned with
+ * Issue #1159 (maintainer directive 2026-07-01): the controller grace window — the period a
+ * backgrounded connection is held before it tears down — is 90 seconds, aligned with
  * `AppSettings.DEFAULT_BACKGROUND_GRACE_MILLIS`. Pins the constant so a regression back to
- * the old 60 s value (which the maintainer rejected) fails at PR time.
+ * the #1123 5-minute value ("5 minutes is longer than needed") fails at PR time.
  */
 class ControllerGraceDefaultTest {
 
     @Test
-    fun `controller grace default is five minutes`() {
+    fun `controller grace default is ninety seconds`() {
         assertEquals(
-            "controller grace default must be 5 minutes (#1123)",
-            5 * 60_000L,
+            "controller grace default must be 90 seconds (#1159)",
+            90_000L,
             ConnectionController.DEFAULT_GRACE_MS,
         )
     }


### PR DESCRIPTION
Maintainer-specified connection-lifecycle + notification UX (also a battery win, complementary to #1166).

- **Part 1** — the foreground connection notification is Android-mandated (FGS ongoing notification), so run the FGS **only while backgrounded** (start ON_STOP, stop ON_START): no foreground tray notification, no Stop-action footgun, connection stays live across the transition.
- **Part 2** — grace default 300s→**90s**, user-configurable ('90 sec' settings option); count-down uses the configured value.
- **Part 3** — a live **port-forward pins the connection always-on** (no grace teardown), notification reads 'Port forwarding active'; reverts to bounded grace when the forward stops. Reads forward state read-only from `flowOfActiveHostCount()`.

**Reviewer APPROVED** (https://github.com/alexeygrigorev/pocketshell/issues/1159#issuecomment-4856737904): **on-device** `SessionConnectionServiceE2eTest` proves fg=no-notification → bg=FGS → fg=cleared with the **connection staying live across the handoff** (`disconnected==false`); Part 1/2/3 reviewer-run red→green; no ForwardingController/core-portfwd edits; TmuxSessionViewModel/FolderList untouched; JVM suites green.

Closes #1159