### PR TITLE
terminal: gate the 4s stale-render watchdog to fg+screen-on + back off when stable (#1166)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -2,6 +2,7 @@ package com.pocketshell.app.tmux
 
 import android.content.Context
 import android.net.Uri
+import android.os.PowerManager
 import android.os.SystemClock
 import android.util.Log
 import androidx.lifecycle.Lifecycle
@@ -1804,6 +1805,59 @@ public class TmuxSessionViewModel @Inject constructor(
 
     internal fun setStaleRenderWatchdogAutoArmEnabledForTest(enabled: Boolean) {
         staleRenderWatchdogAutoArmEnabled = enabled
+    }
+
+    // Issue #1166: the single active stale-render watchdog loop. Cancelled and
+    // replaced on every (re-)arm so rapid A→B→A session switching can never
+    // stack multiple concurrent 4s `capture-pane` loops (arm-dedup).
+    private var staleRenderWatchdogJob: Job? = null
+
+    @androidx.annotation.VisibleForTesting
+    internal fun staleRenderWatchdogJobForTest(): Job? = staleRenderWatchdogJob
+
+    // Issue #1166 (heal-latency fix): a WAKE signal so fresh `%output` on the
+    // ACTIVE visible pane snaps a BACKED-OFF watchdog straight back to the hot
+    // cadence instead of waiting out the current long (8s/16s) `delay(...)`.
+    // Without this the back-off is purely poll-based: a redraw arriving ~1s into
+    // a 16s backed-off window would not be captured/diffed/healed until the tick
+    // ~15s later — a visible partial-black regression vs the ≤4s hot bound. The
+    // watchdog loop RACES its backed-off delay against a receive on this channel;
+    // [recordVisiblePaneOutput] fires it on every active-pane %output. CONFLATED
+    // so a burst of output collapses to one pending wake and the streaming path's
+    // trySend never suspends.
+    private val staleRenderWatchdogWake = Channel<Unit>(Channel.CONFLATED)
+
+    /**
+     * Issue #1166 test seam: fire the stale-render watchdog wake directly, so a
+     * JVM test can assert that a backed-off watchdog snaps to the hot cadence on a
+     * fresh `%output` wake WITHOUT standing up the real `-CC` output stream. The
+     * production wake is fired from [recordVisiblePaneOutput] on every active-pane
+     * output chunk (see [recordPaneOutputActivityForTest], which drives that real
+     * path end-to-end).
+     */
+    @androidx.annotation.VisibleForTesting
+    internal fun signalStaleRenderWatchdogWakeForTest() {
+        staleRenderWatchdogWake.trySend(Unit)
+    }
+
+    // Issue #1166: a test override for [PowerManager.isInteractive] (screen-on).
+    // Null → read the real PowerManager (or default on when no context). A JVM
+    // test drives the foreground/screen gate deterministically without an AVD.
+    private var screenInteractiveOverrideForTest: Boolean? = null
+
+    @androidx.annotation.VisibleForTesting
+    internal fun setScreenInteractiveForTest(interactive: Boolean?) {
+        screenInteractiveOverrideForTest = interactive
+    }
+
+    // Issue #1166 test seam: set the active pane's last-`%output` wall-clock so a
+    // JVM test can deterministically simulate "the pane streamed new output since
+    // the last watchdog tick" (the back-off snap-to-hot signal) without depending
+    // on the real elapsedRealtime clock, which the coroutine test scheduler does
+    // not advance.
+    @androidx.annotation.VisibleForTesting
+    internal fun setPaneLastOutputAtMsForTest(paneId: String, atMs: Long) {
+        paneLastOutputAtMs[paneId] = atMs
     }
 
     /**
@@ -9685,6 +9739,15 @@ public class TmuxSessionViewModel @Inject constructor(
         // apart from a genuinely-exited agent (no output) before it counts the
         // empty detection toward agent-exit confirmation.
         paneLastOutputAtMs[event.paneId] = SystemClock.elapsedRealtime()
+        // Issue #1166 (heal-latency fix): fresh output on the ACTIVE visible pane
+        // WAKES a backed-off stale-render watchdog so a redraw during a long
+        // (8s/16s) backed-off window is captured/diffed/healed within the hot
+        // bound (≤4s) instead of the next backed-off tick. Gated to the active
+        // pane so a busy BACKGROUND pane can't defeat the battery back-off; the
+        // trySend is cheap + non-suspending (CONFLATED channel).
+        if (event.paneId == activeVisiblePane()?.paneId) {
+            staleRenderWatchdogWake.trySend(Unit)
+        }
         logFirstPaneOutput(event)
     }
 
@@ -10620,33 +10683,171 @@ public class TmuxSessionViewModel @Inject constructor(
      * watchdog is the missing oracle, gated by a `capture-pane` DIFF so it never
      * over-fires on a legitimately sparse-but-correct pane.
      *
-     * Cost: ONE `capture-pane` round-trip per [STALE_RENDER_WATCHDOG_TICK_MS], and
-     * only while the pane is NON-blank (the blank watchdog owns the blank case).
-     * The diff is computed from the captured text, so a healthy pane pays just the
-     * one cheap round-trip and never relayouts.
+     * Cost: ONE `capture-pane` round-trip per tick, and only while the pane is
+     * NON-blank (the blank watchdog owns the blank case). The diff is computed from
+     * the captured text, so a healthy pane pays just the one cheap round-trip and
+     * never relayouts.
+     *
+     * Issue #1166 (battery/heat) — the watchdog exists to heal the VISIBLE pane, so
+     * it is gated + backed off so an idle/hidden pane stops hammering `capture-pane`
+     * while a churning/agent pane still heals as fast as before:
+     *
+     *  - **Foreground + screen-on gate.** When the app is backgrounded OR the screen
+     *    is off there is nothing on screen to heal, so the tick SKIPS the capture
+     *    round-trip entirely (0 captures/min while backgrounded or screen-off). On
+     *    resume the back-off is reset so the FIRST foreground tick captures at the
+     *    hot 4s cadence — a pane that changed while away heals right on return.
+     *  - **Back-off when stable.** A tick that finds NO divergence AND saw no new
+     *    streamed `%output` widens the next interval (4s → 8s → 16s, capped). ANY
+     *    detected divergence, new streamed output, session switch (fresh arm), or a
+     *    reconnecting band snaps the cadence back to 4s so a black/partial-black
+     *    pane heals within the same bound as today (#1138/#1153/#874).
+     *  - **Immediate wake on output (issue #1166 heal-latency fix).** The back-off
+     *    is NOT purely poll-based: a fresh active-pane `%output` fires
+     *    [staleRenderWatchdogWake] (see [recordVisiblePaneOutput]) and the loop
+     *    RACES its backed-off `delay(...)` against that wake (see
+     *    [awaitStaleRenderWatchdogTick]). So a redraw arriving ~1s into a 16s
+     *    backed-off window is captured/diffed/healed within the hot bound (≤4s),
+     *    not up to 16s later — the partial-black (#1138) case whose sole steady-
+     *    state oracle is this watchdog can never sit visibly broken for a whole
+     *    backed-off interval.
+     *  - **Arm-dedup.** [staleRenderWatchdogJob] is cancelled before each re-arm so
+     *    rapid A→B→A switching can never stack multiple concurrent 4s loops.
      */
     private fun armActivePaneStaleRenderWatchdog(refreshGuard: RuntimeRefreshGuard) {
         if (!staleRenderWatchdogAutoArmEnabled) return
-        bridgeScope.launch {
+        launchActivePaneStaleRenderWatchdog(refreshGuard)
+    }
+
+    private fun launchActivePaneStaleRenderWatchdog(refreshGuard: RuntimeRefreshGuard) {
+        // Issue #1166 arm-dedup: cancel any prior loop before launching a new one.
+        // A stale loop otherwise only self-terminates on its NEXT tick via
+        // isCurrentRuntime (up to one full tick of double/triple captures per switch).
+        staleRenderWatchdogJob?.cancel()
+        staleRenderWatchdogJob = bridgeScope.launch {
             var tick = 0
+            // Issue #1166: consecutive stable ticks drive the back-off interval.
+            var stableTicks = 0
+            // Issue #1166: the last `%output` wall-clock we saw for the active pane;
+            // a newer stamp means the pane streamed output since the previous tick,
+            // so we snap the cadence back to hot rather than backing off a live pane.
+            var lastSeenOutputAtMs = 0L
             while (tick < staleRenderWatchdogMaxTicks) {
-                delay(STALE_RENDER_WATCHDOG_TICK_MS)
+                // Issue #1166: wait out the (possibly backed-off) interval, but a
+                // fresh active-pane %output wake cuts a backed-off wait short so the
+                // redraw is captured within the hot bound, not the next long tick.
+                val wokenByOutput = awaitStaleRenderWatchdogTick(stableTicks)
                 if (!isCurrentRuntime(refreshGuard)) return@launch
                 val client = clientRef ?: return@launch
                 if (client.disconnected.value) return@launch
                 if (inlineConnectionStatus !is ConnectionStatus.Connected) {
                     // Paused mid-runtime (a transient reconnecting band): keep the
-                    // watchdog alive but skip the heal until Connected resumes.
+                    // watchdog alive but skip the heal until Connected resumes. Reset
+                    // the back-off so the resume tick captures at the hot cadence.
+                    stableTicks = 0
+                    tick += 1
+                    continue
+                }
+                // Issue #1166 foreground + screen-on gate: nothing to heal when the
+                // pane is not on screen. Skip the capture round-trip entirely and
+                // reset the back-off so the first tick after resume captures hot.
+                if (!shouldRunStaleRenderWatchdogCapture()) {
+                    stableTicks = 0
                     tick += 1
                     continue
                 }
                 val activePane = activeVisiblePane()
                 if (activePane != null) {
-                    runCatching { healActivePaneIfStaleRender(client, activePane, refreshGuard) }
+                    // Issue #1166: did the pane stream NEW %output since last tick?
+                    val lastOutputAtMs = paneLastOutputAtMs[activePane.paneId] ?: 0L
+                    val hadNewOutput = lastOutputAtMs > lastSeenOutputAtMs
+                    lastSeenOutputAtMs = lastOutputAtMs
+                    val healed = runCatching {
+                        healActivePaneIfStaleRender(client, activePane, refreshGuard)
+                    }.getOrDefault(false)
+                    // Back off ONLY a truly-idle, non-diverging pane; a divergence
+                    // (heal fired), fresh streamed output, OR an output WAKE that cut
+                    // the backed-off wait short (issue #1166) keeps the cadence at 4s.
+                    stableTicks =
+                        if (healed || hadNewOutput || wokenByOutput) 0 else stableTicks + 1
                 }
                 tick += 1
             }
         }
+    }
+
+    /**
+     * Issue #1166 (heal-latency fix): wait out the watchdog interval for the
+     * current run of [stableTicks] stable ticks, but make the wait WAKEABLE while
+     * backed off. Returns `true` when a fresh active-pane `%output` wake cut the
+     * wait short (the caller then re-checks the pane immediately and snaps the
+     * cadence back to hot), `false` when the full interval simply elapsed.
+     *
+     * At the HOT cadence (interval == [STALE_RENDER_WATCHDOG_TICK_MS]) there is
+     * nothing to snap back to, so it drains any stale wake and plain-delays — the
+     * churning-pane behavior is unchanged (still a capture every 4s, no extra
+     * captures from output bursts). Only a BACKED-OFF wait (8s/16s) races the
+     * delay against a wake, so a redraw during the long window is captured within
+     * the hot bound instead of being deferred to the next backed-off tick.
+     */
+    private suspend fun awaitStaleRenderWatchdogTick(stableTicks: Int): Boolean {
+        val interval = staleRenderWatchdogIntervalMs(stableTicks)
+        if (interval <= STALE_RENDER_WATCHDOG_TICK_MS) {
+            // Hot cadence: drain a possibly-stale wake so it can't fire the FIRST
+            // backed-off wait spuriously, then plain-delay the hot interval.
+            staleRenderWatchdogWake.tryReceive()
+            delay(interval)
+            return false
+        }
+        // Backed off: whichever finishes first wins — the long delay OR a wake.
+        return withTimeoutOrNull(interval) { staleRenderWatchdogWake.receive() } != null
+    }
+
+    /**
+     * Issue #1166: the stale-render watchdog interval for the given run of
+     * consecutive stable (no-divergence, no-new-output) ticks. A steady pane
+     * widens 4s → 8s → 16s (capped); [stableTicks] is reset to 0 on any
+     * divergence / new output / switch, snapping the next interval back to 4s.
+     */
+    @androidx.annotation.VisibleForTesting
+    internal fun staleRenderWatchdogIntervalMs(stableTicks: Int): Long {
+        if (stableTicks <= 0) return STALE_RENDER_WATCHDOG_TICK_MS
+        val doublings = stableTicks.coerceAtMost(STALE_RENDER_WATCHDOG_BACKOFF_MAX_DOUBLINGS)
+        return (STALE_RENDER_WATCHDOG_TICK_MS shl doublings)
+            .coerceAtMost(STALE_RENDER_WATCHDOG_MAX_INTERVAL_MS)
+    }
+
+    /**
+     * Issue #1166: the watchdog heals the VISIBLE pane, so it only pays the
+     * `capture-pane` round-trip while the app is foregrounded AND the screen is
+     * interactive (on). A backgrounded/screen-off stale render is invisible and is
+     * re-healed on the next foreground+screen-on tick anyway.
+     */
+    private fun shouldRunStaleRenderWatchdogCapture(): Boolean =
+        isProcessForegroundForCleared() && isScreenInteractive()
+
+    /**
+     * Issue #1166: true when the device screen is interactive (on). Reads the real
+     * [PowerManager.isInteractive]; a test override or a missing context (JVM unit
+     * test) defaults to "on" so non-gating tests keep their behavior.
+     */
+    private fun isScreenInteractive(): Boolean {
+        screenInteractiveOverrideForTest?.let { return it }
+        val ctx = applicationContext ?: return true
+        return runCatching {
+            (ctx.getSystemService(Context.POWER_SERVICE) as? PowerManager)?.isInteractive ?: true
+        }.getOrDefault(true)
+    }
+
+    /**
+     * Issue #1166 test seam: drive the stale-render watchdog loop directly (bypasses
+     * the [staleRenderWatchdogAutoArmEnabled] auto-arm suppression a test sets to
+     * stop `connect()` from arming its own loop), so a JVM test can exercise the
+     * foreground/screen gate + back-off + arm-dedup deterministically.
+     */
+    @androidx.annotation.VisibleForTesting
+    internal fun armActivePaneStaleRenderWatchdogForTest(refreshGuard: RuntimeRefreshGuard) {
+        launchActivePaneStaleRenderWatchdog(refreshGuard)
     }
 
     /**
@@ -17660,6 +17861,21 @@ internal const val CONNECTED_BLANK_WATCHDOG_MAX_TICKS: Int = 20
  * pane within a few seconds.
  */
 internal const val STALE_RENDER_WATCHDOG_TICK_MS: Long = 4_000L
+
+/**
+ * Issue #1166 (battery/heat): the stale-render watchdog interval ceiling. A stable
+ * foreground pane backs off 4s → 8s → 16s (each stable tick doubles the interval,
+ * capped here) so an idle pane stops paying ~15 `capture-pane` round-trips/min; any
+ * divergence / new streamed output / switch snaps the cadence back to
+ * [STALE_RENDER_WATCHDOG_TICK_MS] so a churning/agent pane heals as fast as before.
+ */
+internal const val STALE_RENDER_WATCHDOG_MAX_INTERVAL_MS: Long = 16_000L
+
+/**
+ * Issue #1166: the number of interval doublings from [STALE_RENDER_WATCHDOG_TICK_MS]
+ * to reach [STALE_RENDER_WATCHDOG_MAX_INTERVAL_MS] (4s → 8s → 16s = 2 doublings).
+ */
+internal const val STALE_RENDER_WATCHDOG_BACKOFF_MAX_DOUBLINGS: Int = 2
 
 /**
  * Issue #966/#967: upper bound on stale-render watchdog ticks for the runtime's

--- a/app/src/test/java/com/pocketshell/app/tmux/StaleRenderWatchdogGatingTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/StaleRenderWatchdogGatingTest.kt
@@ -1,0 +1,583 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.app.sessions.ActiveTmuxClients
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.SshLeaseConnector
+import com.pocketshell.core.ssh.SshLeaseManager
+import com.pocketshell.core.ssh.SshLeaseTarget
+import com.pocketshell.core.ssh.SshPortForward
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshShell
+import com.pocketshell.core.tmux.CommandResponse
+import com.pocketshell.core.tmux.TmuxClientFactory
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+import java.io.InputStream
+
+/**
+ * Issue #1166 (battery/heat) — DURABLE JVM REGRESSION GUARD for the phone-heat fix:
+ * gate the 4s stale-render `capture-pane` watchdog on foreground + screen-on and
+ * back it off when the pane is stable, WITHOUT reducing heal reliability
+ * (#1138/#1153/#874 must still heal within the same bound).
+ *
+ * ## The drain (#1164 audit)
+ *
+ * [TmuxSessionViewModel.armActivePaneStaleRenderWatchdog] fired a real `capture-pane`
+ * SSH round-trip every [STALE_RENDER_WATCHDOG_TICK_MS] (4s) for the whole life of
+ * every open session with NO foreground/background/screen-off gating and NO back-off
+ * — a healthy unchanging pane paid ~15 captures/min forever, and rapid switching
+ * stacked multiple loops (no arm-dedup).
+ *
+ * ## Red -> green
+ *
+ * Each test drives the REAL watchdog loop
+ * ([TmuxSessionViewModel.armActivePaneStaleRenderWatchdogForTest]) on the virtual
+ * test clock and counts `capture-pane` round-trips ([FakeTmuxClient.sentCommands]):
+ *  - [backgroundedPaneDoesNotCapture] / [screenOffPaneDoesNotCapture]: on base
+ *    (ungated loop) the watchdog captured every 4s regardless of lifecycle -> RED.
+ *    With the fix the gate skips the round-trip entirely -> 0 captures -> GREEN.
+ *  - [foregroundScreenOnResumesCapturing]: resuming foreground + screen-on captures
+ *    again (immediate heal on return).
+ *  - [stableForegroundPaneBacksOff]: a steady non-diverging pane widens 4s -> 8s ->
+ *    16s so it stops hammering capture-pane.
+ *  - [newStreamedOutputSnapsCadenceBackToHot]: fresh active-pane %output during a
+ *    BACKED-OFF (16s) window WAKES the watchdog immediately — the redraw is captured
+ *    within the HOT bound (≤4s), NOT deferred ~15s to the next backed-off tick (the
+ *    #1166 heal-latency fix; the back-off is not purely poll-based).
+ *  - [backedOffPartialBlackRedrawHealsWithinHotBound]: the #1138 no-black-screen bar —
+ *    a partial-black redraw during a backed-off window heals within ≤4s, not up to 16s.
+ *  - [divergingTickSnapsCadenceBackToHot]: a detected divergence (heal fired) snaps the
+ *    cadence back to 4s so the following ticks stay hot (#1138/#1153 heal preservation).
+ *  - [staleRenderWatchdogIntervalCurve]: the pure back-off curve (4/8/16, capped).
+ *  - [rapidRearmCancelsPriorWatchdogLoop]: arm-dedup — a second arm cancels the first
+ *    loop so rapid A->B->A switching can't stack concurrent 4s loops.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class StaleRenderWatchdogGatingTest {
+
+    private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val createdVms = mutableListOf<TmuxSessionViewModel>()
+
+    @After
+    fun tearDown() {
+        factoryScope.cancel()
+    }
+
+    // -------------------------------------------------------------------------
+    // (1) Back-off curve — the pure interval function. 4s -> 8s -> 16s, capped.
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun staleRenderWatchdogIntervalCurve() = runVmTest {
+        val vm = connectVm(FakeTmuxClient().withSinglePaneRow("work", "%1"))
+        assertEquals("0 stable ticks -> hot 4s", 4_000L, vm.staleRenderWatchdogIntervalMs(0))
+        assertEquals("1 stable tick -> 8s", 8_000L, vm.staleRenderWatchdogIntervalMs(1))
+        assertEquals("2 stable ticks -> 16s (cap)", 16_000L, vm.staleRenderWatchdogIntervalMs(2))
+        assertEquals("3 stable ticks -> capped 16s", 16_000L, vm.staleRenderWatchdogIntervalMs(3))
+        assertEquals("many stable ticks -> capped 16s", 16_000L, vm.staleRenderWatchdogIntervalMs(50))
+    }
+
+    // -------------------------------------------------------------------------
+    // (2) FOREGROUND + SCREEN-ON GATE — backgrounded pane pays 0 captures.
+    //     RED on base (ungated loop captured every 4s). GREEN: 0 captures.
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun backgroundedPaneDoesNotCapture() = runVmTest {
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%1")
+        val vm = armIdleWatchdog(client, paneId = "%1")
+
+        // App BACKGROUNDED (screen may be on, but nothing visible to heal).
+        vm.setProcessForegroundForClearedForTest(false)
+        vm.setScreenInteractiveForTest(true)
+
+        val before = client.captureCount()
+        // 6 ticks' worth of virtual time at the hottest cadence. Use advanceTimeBy
+        // (NOT advanceUntilIdle, which would drain the bounded loop to maxTicks).
+        advanceTimeBy(6 * STALE_RENDER_WATCHDOG_TICK_MS + 100)
+        runCurrent()
+
+        assertEquals(
+            "REGRESSION (#1166): a BACKGROUNDED pane must pay ZERO stale-render " +
+                "capture-pane round-trips (nothing on screen to heal). On base the " +
+                "ungated watchdog captured every 4s.",
+            before,
+            client.captureCount(),
+        )
+    }
+
+    @Test
+    fun screenOffPaneDoesNotCapture() = runVmTest {
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%1")
+        val vm = armIdleWatchdog(client, paneId = "%1")
+
+        // App FOREGROUNDED but the SCREEN IS OFF -> still nothing visible to heal.
+        vm.setProcessForegroundForClearedForTest(true)
+        vm.setScreenInteractiveForTest(false)
+
+        val before = client.captureCount()
+        advanceTimeBy(6 * STALE_RENDER_WATCHDOG_TICK_MS + 100)
+        runCurrent()
+
+        assertEquals(
+            "REGRESSION (#1166): a SCREEN-OFF pane must pay ZERO stale-render " +
+                "capture-pane round-trips.",
+            before,
+            client.captureCount(),
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // (3) RESUME — foreground + screen-on resumes capturing (immediate heal on
+    //     return). While gated: 0 captures; on the first ungated tick: captures.
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun foregroundScreenOnResumesCapturing() = runVmTest {
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%1")
+        val vm = armIdleWatchdog(client, paneId = "%1")
+
+        // Backgrounded window: 0 captures. advanceTimeBy (NOT advanceUntilIdle) so
+        // the loop stays parked and can resume when we foreground it below.
+        vm.setProcessForegroundForClearedForTest(false)
+        vm.setScreenInteractiveForTest(true)
+        val gatedBefore = client.captureCount()
+        advanceTimeBy(4 * STALE_RENDER_WATCHDOG_TICK_MS + 100)
+        runCurrent()
+        assertEquals(
+            "no captures while backgrounded",
+            gatedBefore,
+            client.captureCount(),
+        )
+
+        // Return to foreground + screen-on: the watchdog resumes and captures.
+        vm.setProcessForegroundForClearedForTest(true)
+        vm.setScreenInteractiveForTest(true)
+        val resumeBefore = client.captureCount()
+        advanceTimeBy(STALE_RENDER_WATCHDOG_TICK_MS + 100)
+        runCurrent()
+
+        assertTrue(
+            "REGRESSION (#1166): on foreground + screen-on the watchdog must resume " +
+                "and capture again (heal a pane that changed while away). Captured " +
+                "${client.captureCount() - resumeBefore} times after resume.",
+            client.captureCount() > resumeBefore,
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // (4) BACK-OFF WHEN STABLE — a steady non-diverging pane widens its cadence,
+    //     so over a fixed window it pays fewer captures than a flat 4s loop would.
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun stableForegroundPaneBacksOff() = runVmTest {
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%1")
+        val vm = armIdleWatchdog(client, paneId = "%1")
+
+        vm.setProcessForegroundForClearedForTest(true)
+        vm.setScreenInteractiveForTest(true)
+        // No streamed output -> the pane is fully idle/stable (empty capture queue
+        // -> healActivePaneIfStaleRender no-ops, healed=false every tick).
+        vm.setPaneLastOutputAtMsForTest("%1", 0L)
+
+        val before = client.captureCount()
+        // Captures land at t=4s (#1, stableTicks->1), t=12s (#2, ->2), t=28s (#3, cap).
+        // advanceTimeBy (NOT advanceUntilIdle, which would run the loop to maxTicks).
+        advanceTimeBy(20 * 1000L + 100)
+        runCurrent()
+
+        val captures = client.captureCount() - before
+        assertEquals(
+            "REGRESSION (#1166): a STABLE foreground pane must back off (4s->8s->16s). " +
+                "Over 20s it should capture 2 times (t=4s, t=12s), NOT the 5 a flat 4s " +
+                "cadence would pay. Observed $captures.",
+            2,
+            captures,
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // (5) NEW STREAMED OUTPUT during a BACKED-OFF window WAKES the watchdog
+    //     IMMEDIATELY (issue #1166 heal-latency fix). The back-off is NOT purely
+    //     poll-based: a fresh active-pane %output must cut the long (16s) backed-
+    //     off wait short so the redraw is captured/diffed/healed within the HOT
+    //     bound (≤4s), NOT deferred ~15s to the next backed-off tick. This is the
+    //     no-black-screen-regression bar — the #1138 partial-black case has this
+    //     watchdog as its sole steady-state oracle.
+    //
+    //     RED (base, poll-only back-off): setting the output stamp did not wake the
+    //     pending delay(16s), so no capture landed until t=28s -> the ≤4s assertion
+    //     below fails. GREEN (wake): the %output fires the wake, the backed-off
+    //     receive() returns at once, and the capture lands within the hot bound.
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun newStreamedOutputSnapsCadenceBackToHot() = runVmTest {
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%1")
+        val vm = armIdleWatchdog(client, paneId = "%1")
+
+        vm.setProcessForegroundForClearedForTest(true)
+        vm.setScreenInteractiveForTest(true)
+        vm.setPaneLastOutputAtMsForTest("%1", 0L)
+
+        // Let it back off to the widest interval: captures at t=4s (stableTicks->1)
+        // and t=12s (->2); the loop is now parked in a 16s backed-off wait that,
+        // on base, would not fire again until t=28s.
+        val before = client.captureCount()
+        advanceTimeBy(13 * 1000L)
+        runCurrent()
+        assertEquals("backed off to 2 captures by t=13s", 2, client.captureCount() - before)
+
+        // ~1s into the 16s backed-off window a fresh %output lands on the ACTIVE
+        // pane — drive the REAL output path ([recordVisiblePaneOutput]) end-to-end
+        // so the wire from output -> wake is exercised, not just the stamp.
+        val beforeWake = client.captureCount()
+        vm.recordPaneOutputActivityForTest("%1")
+
+        // The wake cuts the backed-off wait short: a sub-hot advance (0.5s, far
+        // under both the 4s hot bound AND the ~15s remaining on the backed-off
+        // tick) already yields the capture. On base the poll-only back-off deferred
+        // it to t=28s, so 0.5s later NOTHING would have captured -> RED. GREEN: the
+        // wake fires the capture at once, well within the hot bound.
+        advanceTimeBy(500L)
+        runCurrent()
+        assertTrue(
+            "REGRESSION (#1166 heal-latency): a fresh %output during a BACKED-OFF " +
+                "(16s) window must WAKE the watchdog and capture WITHIN the hot bound " +
+                "(≤${STALE_RENDER_WATCHDOG_TICK_MS}ms — here at once), NOT wait out the " +
+                "remaining ~15s. Captured ${client.captureCount() - beforeWake} in 0.5s.",
+            client.captureCount() > beforeWake,
+        )
+
+        // The wake tick reset the back-off, so the very next tick is HOT again: a
+        // single 4s advance yields a further capture before any re-back-off widens.
+        val afterWakeCapture = client.captureCount()
+        advanceTimeBy(STALE_RENDER_WATCHDOG_TICK_MS + 100)
+        runCurrent()
+        assertTrue(
+            "after the wake the FOLLOWING tick fires at the hot 4s cadence (the " +
+                "back-off was reset), before an idle pane re-widens the interval.",
+            client.captureCount() > afterWakeCapture,
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // (5b) A PARTIAL-BLACK REDRAW during a BACKED-OFF window HEALS within the hot
+    //      bound (issue #1166 heal-latency fix, the #1138 no-black-screen bar). A
+    //      redraw on device arrives AS %output, so it wakes the backed-off watchdog
+    //      -> the divergence is captured + healed within ≤4s, not up to 16s later.
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun backedOffPartialBlackRedrawHealsWithinHotBound() = runVmTest {
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%1")
+        // Connect + resize BEFORE arming so the watchdog loop is not drained by the
+        // resize's advanceUntilIdle (auto-arm is disabled in newVm).
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == "%1" }
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+
+        vm.setStaleRenderWatchdogMaxTicksForTest(1000)
+        vm.setPaneLastOutputAtMsForTest("%1", 0L)
+        vm.setProcessForegroundForClearedForTest(true)
+        vm.setScreenInteractiveForTest(true)
+        val guard = requireNotNull(vm.currentRuntimeGuardForTest())
+        vm.armActivePaneStaleRenderWatchdogForTest(guard)
+        runCurrent()
+
+        // Back off to the widest (16s) interval: captures at t=4s, t=12s.
+        val before = client.captureCount()
+        advanceTimeBy(13 * 1000L)
+        runCurrent()
+        assertEquals("backed off to 2 captures by t=13s", 2, client.captureCount() - before)
+
+        // The agent redraws its viewport partial-black and tmux holds the
+        // authoritative rich frame — so the NEXT capture DIVERGES and heals. On
+        // device this redraw arrives AS %output, which must WAKE the backed-off
+        // watchdog rather than waiting out the remaining ~15s.
+        pane.terminalState.appendRemoteOutput(
+            ("[2J[H" + "ISSUE1166-ONE-LIVE-LINE\r\n").toByteArray(Charsets.US_ASCII),
+        )
+        client.capturePaneResponses.addLast(
+            CommandResponse(number = 90L, output = richFrameLines(), isError = false),
+        )
+        val beforeWake = client.captureCount()
+        vm.recordPaneOutputActivityForTest("%1")
+
+        // Within the HOT bound (≤4s) the heal must have fired — the capture that
+        // detects + repairs the partial-black divergence lands now, NOT at t=28s.
+        advanceTimeBy(STALE_RENDER_WATCHDOG_TICK_MS + 100)
+        runCurrent()
+        assertTrue(
+            "REGRESSION (#1166 heal-latency, #1138 no-black-screen): a partial-black " +
+                "redraw during a BACKED-OFF window must be captured + healed within the " +
+                "hot bound (≤${STALE_RENDER_WATCHDOG_TICK_MS}ms), NOT up to 16s later. " +
+                "Captured ${client.captureCount() - beforeWake} within the hot bound.",
+            client.captureCount() > beforeWake,
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // (6) A DETECTED DIVERGENCE (the heal fired) snaps the cadence back to hot —
+    //     so a pane that just went partial-black (#1138) is re-checked at 4s,
+    //     not at the backed-off interval.
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun divergingTickSnapsCadenceBackToHot() = runVmTest {
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%1")
+        // Connect + resize BEFORE arming so the watchdog loop is not drained by the
+        // resize's advanceUntilIdle (auto-arm is disabled in newVm).
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == "%1" }
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+
+        vm.setStaleRenderWatchdogMaxTicksForTest(1000)
+        vm.setPaneLastOutputAtMsForTest("%1", 0L)
+        vm.setProcessForegroundForClearedForTest(true)
+        vm.setScreenInteractiveForTest(true)
+        val guard = requireNotNull(vm.currentRuntimeGuardForTest())
+        vm.armActivePaneStaleRenderWatchdogForTest(guard)
+        runCurrent()
+
+        // Let it back off to stableTicks>=2 (interval 16s): captures at t=4s, t=12s.
+        val before = client.captureCount()
+        advanceTimeBy(13 * 1000L)
+        runCurrent()
+        assertEquals("backed off to 2 captures by t=13s", 2, client.captureCount() - before)
+
+        // Drive the pane partial-black and queue tmux's authoritative rich frame so
+        // the NEXT watchdog capture DIVERGES -> heals -> resets the back-off.
+        pane.terminalState.appendRemoteOutput(
+            ("[2J[H" + "ISSUE1166-ONE-LIVE-LINE\r\n").toByteArray(Charsets.US_ASCII),
+        )
+        client.capturePaneResponses.addLast(
+            CommandResponse(number = 90L, output = richFrameLines(), isError = false),
+        )
+        // The backed-off tick fires at t=28s, heals (healed=true) -> stableTicks=0.
+        advanceTimeBy(16 * 1000L + 100)
+        runCurrent()
+        val afterHeal = client.captureCount()
+
+        // Now hot again: one 4s advance yields another capture.
+        advanceTimeBy(STALE_RENDER_WATCHDOG_TICK_MS + 100)
+        runCurrent()
+
+        assertTrue(
+            "REGRESSION (#1166): a tick that DETECTED a divergence (heal fired) must snap " +
+                "the cadence back to 4s, so a just-blacked pane is re-checked hot.",
+            client.captureCount() > afterHeal,
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // (7) ARM-DEDUP — a second arm cancels the prior watchdog loop, so rapid
+    //     A->B->A switching can never stack concurrent 4s capture loops.
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun rapidRearmCancelsPriorWatchdogLoop() = runVmTest {
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%1")
+        val vm = connectVm(client)
+        vm.setStaleRenderWatchdogAutoArmEnabledForTest(false)
+        vm.setStaleRenderWatchdogMaxTicksForTest(1000)
+        val guard = requireNotNull(vm.currentRuntimeGuardForTest())
+
+        vm.armActivePaneStaleRenderWatchdogForTest(guard)
+        val first = requireNotNull(vm.staleRenderWatchdogJobForTest())
+        assertTrue("first watchdog loop is active", first.isActive)
+
+        // Rapid re-arm (models a fast A->B->A reveal re-arming the watchdog).
+        vm.armActivePaneStaleRenderWatchdogForTest(guard)
+        val second = requireNotNull(vm.staleRenderWatchdogJobForTest())
+
+        assertTrue(
+            "REGRESSION (#1166): the prior watchdog loop must be CANCELLED on re-arm so " +
+                "rapid switching can't stack multiple concurrent 4s capture loops.",
+            first.isCancelled,
+        )
+        assertTrue("the new watchdog loop is active", second.isActive)
+        assertFalse("re-arm produced a fresh loop", first === second)
+    }
+
+    // ------------------------------------------------------------------ Harness
+
+    /**
+     * Connect a VM, disable the auto-arm (so `connect()` doesn't arm its own loop),
+     * and drive the watchdog loop directly via the #1166 test seam with a small tick
+     * ceiling. The pane starts with an empty capture queue so a tick that DOES run
+     * is a stable no-op (healed=false) unless the test queues a diverging frame.
+     */
+    private fun TestScope.armIdleWatchdog(
+        client: FakeTmuxClient,
+        paneId: String,
+    ): TmuxSessionViewModel {
+        val vm = connectVm(client)
+        vm.setStaleRenderWatchdogAutoArmEnabledForTest(false)
+        vm.setStaleRenderWatchdogMaxTicksForTest(1000)
+        vm.setPaneLastOutputAtMsForTest(paneId, 0L)
+        val guard = requireNotNull(vm.currentRuntimeGuardForTest())
+        vm.armActivePaneStaleRenderWatchdogForTest(guard)
+        runCurrent()
+        return vm
+    }
+
+    private fun richFrameLines(): List<String> = buildList {
+        add("ISSUE1166-RECOVERED-VIEWPORT")
+        repeat(27) { add("recovered context row $it") }
+    }
+
+    private fun runVmTest(body: suspend TestScope.() -> Unit) = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        LivenessProbeTestOverride.setAutoStartEnabledForTest(false)
+        try {
+            body()
+        } finally {
+            for (vm in createdVms) {
+                runCatching { vm.setProcessForegroundForClearedForTest(false) }
+                runCatching { vm.clearForTest() }
+            }
+            advanceUntilIdle()
+            createdVms.clear()
+            LivenessProbeTestOverride.clear()
+            Dispatchers.resetMain()
+        }
+    }
+
+    private fun TestScope.newVm(
+        registry: ActiveTmuxClients,
+        sshLeaseManager: SshLeaseManager,
+    ): TmuxSessionViewModel = TmuxSessionViewModel(
+        tmuxClientFactory = TmuxClientFactory(factoryScope),
+        activeTmuxClients = registry,
+        runtimeCache = TmuxSessionRuntimeCache(),
+        sshLeaseManager = sshLeaseManager,
+        sessionLifecycleSignals = null,
+    ).also {
+        it.setSeedIoDispatcherForTest(StandardTestDispatcher(testScheduler))
+        // Keep connect()'s reveal from auto-arming its own stale-render watchdog: this
+        // suite drives the watchdog loop explicitly via the #1166 test seam so the
+        // capture counts + timings are deterministic (and connect()'s advanceUntilIdle
+        // stays cheap). Tests re-enable / re-arm as needed.
+        it.setStaleRenderWatchdogAutoArmEnabledForTest(false)
+        createdVms.add(it)
+    }
+
+    private fun TestScope.connectVm(client: FakeTmuxClient): TmuxSessionViewModel {
+        val live = AlwaysConnectedSession(id = "live")
+        val connector = SingleSessionConnector(live)
+        val leaseManager =
+            testLeaseManager(connector = connector, scope = this, idleTtlMillis = 60_000L)
+        val registry = ActiveTmuxClients()
+        val vm = newVm(registry = registry, sshLeaseManager = leaseManager)
+        runCurrent()
+        vm.setTmuxClientFactoryForTest { _, _, _ -> client }
+        vm.connect(
+            hostId = 1L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            passphrase = null,
+            sessionName = "work",
+        )
+        advanceUntilIdle()
+        return vm
+    }
+
+    private fun FakeTmuxClient.withSinglePaneRow(
+        sessionName: String,
+        paneId: String,
+        title: String = sessionName,
+    ): FakeTmuxClient = apply {
+        responses.addLast(
+            CommandResponse(
+                number = 1L,
+                output = listOf("$paneId\t@0\t\$0\t$sessionName\t$title\t0"),
+                isError = false,
+            ),
+        )
+        capturePaneResponses.addLast(
+            CommandResponse(number = 2L, output = listOf("$sessionName ready"), isError = false),
+        )
+        cursorQueryResponses.addLast(
+            CommandResponse(number = 3L, output = listOf("0,0"), isError = false),
+        )
+    }
+
+    private fun FakeTmuxClient.captureCount(): Int =
+        sentCommands.count { it.startsWith("capture-pane") }
+
+    private class SingleSessionConnector(
+        private val session: SshSession,
+    ) : SshLeaseConnector {
+        override suspend fun connect(target: SshLeaseTarget): Result<SshSession> =
+            Result.success(session)
+    }
+
+    private class AlwaysConnectedSession(
+        val id: String,
+    ) : SshSession {
+        @Volatile
+        var closed: Boolean = false
+
+        override val isConnected: Boolean get() = !closed
+
+        override suspend fun exec(command: String): ExecResult =
+            ExecResult(stdout = "", stderr = "", exitCode = 0)
+
+        override fun tail(path: String, onLine: (String) -> Unit): Job =
+            Job().apply { complete() }
+
+        override fun tail(path: String, fromLineExclusive: Long, onLine: (String) -> Unit): Job =
+            Job().apply { complete() }
+
+        override fun openLocalPortForward(
+            remoteHost: String,
+            remotePort: Int,
+            localPort: Int,
+        ): SshPortForward = error("not used")
+
+        override fun startShell(): SshShell = error("not used")
+
+        override suspend fun uploadFile(file: File, remotePath: String): String = error("not used")
+
+        override suspend fun uploadStream(
+            input: InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String = error("not used")
+
+        override fun close() {
+            closed = true
+        }
+    }
+}


### PR DESCRIPTION
The phone-HEAT fix (from the #1164 audit): the 4s stale-render watchdog fired a real `capture-pane` SSH round-trip for the whole life of every open session, ungated — ~15 captures/min forever, the drain that runs the phone warm.

**Fix (heal LOGIC untouched — only WHEN the heal is attempted):**
- **Foreground + screen-on gate** — backgrounded/screen-off ticks skip the capture entirely (0 captures).
- **Back off when stable** — 4→8→16s on idle; snaps back on divergence/output/switch.
- **Wake on output** — a conflated `staleRenderWatchdogWake` channel lets active-pane `%output` wake the backed-off loop immediately (races the long delay), so a redraw during a backed-off window heals within the hot bound (no #1138 latency regression).
- Arm-dedup cancels the prior job on re-arm.

**Reviewer APPROVED** (https://github.com/alexeygrigorev/pocketshell/issues/1166#issuecomment-4856654697): reviewer-run red→green (disable the wake → the 2 latency tests fail, incl. `backedOffPartialBlackRedrawHealsWithinHotBound` the #1138 bar → 9/9 green), battery back-off preserved for genuine idle, no heal regression (#1138/#1153/#941 suites green). Applied clean onto the #1169-updated TmuxSessionViewModel (resize vs watchdog regions disjoint).

Closes #1166