### PR TITLE
diag: fingerprint black-pane classes into exportable log (#1175)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -2252,6 +2252,15 @@ public class TmuxSessionViewModel @Inject constructor(
     // `Resolved(null)` branch. A genuinely-exited agent stops emitting output, so
     // its empty grep arrives with NO recent activity and tears down correctly.
     private val paneLastOutputAtMs: MutableMap<String, Long> = ConcurrentHashMap()
+    // Issue #1175: the wall-clock (elapsedRealtime) of the last time a `capture-pane`
+    // seed successfully LANDED into this pane's emulator (stamped in
+    // [seedPaneFromCaptureOnce] at the same point [panesSeededThisAttach] records the
+    // seed). An ABSENT entry means "no seed has ever landed for this pane" — the
+    // discriminator between the `never_seeded` and `capture_empty` black-frame classes —
+    // and its age (now - stamp) is the `msSinceLastSeed` fingerprint field on the
+    // `black_frame_observed` diagnostic. Diagnostic accounting only; it never gates a
+    // heal decision.
+    private val paneLastSeedAtMs: MutableMap<String, Long> = ConcurrentHashMap()
     // Issue #793: per-pane conversation-load watchdog. Flips a never-completing
     // "Loading conversation…" state to Failed so the tab can't spin forever.
     private val conversationLoadWatchdogJobs: MutableMap<String, Job> = ConcurrentHashMap()
@@ -5514,6 +5523,7 @@ public class TmuxSessionViewModel @Inject constructor(
         paneAgentInputs.clear()
         paneAgentNullDetections.clear()
         paneLastOutputAtMs.clear()
+        paneLastSeedAtMs.clear()
         paneConversationOpenStartedAtMs.clear()
         sessionRecordedKindCache.clear()
         sessionForeignKindGuessCache.clear()
@@ -5639,6 +5649,7 @@ public class TmuxSessionViewModel @Inject constructor(
         paneAgentInputs.clear()
         paneAgentNullDetections.clear()
         paneLastOutputAtMs.clear()
+        paneLastSeedAtMs.clear()
         paneConversationOpenStartedAtMs.clear()
         sessionRecordedKindCache.clear()
         sessionForeignKindGuessCache.clear()
@@ -9639,6 +9650,7 @@ public class TmuxSessionViewModel @Inject constructor(
             paneAgentInputs.remove(paneId)
             paneAgentNullDetections.remove(paneId)
             paneLastOutputAtMs.remove(paneId)
+            paneLastSeedAtMs.remove(paneId)
             paneInputJobs.remove(paneId)?.cancel()
             paneInputQueues.remove(paneId)?.close()
             paneSurfaceRecoveryTimestamps.remove(paneId)
@@ -10560,6 +10572,16 @@ public class TmuxSessionViewModel @Inject constructor(
                         "after=$attempt session=${activeTarget?.sessionName} " +
                         "-> reveal deferred to blank watchdog",
                 )
+                // Issue #1175: the single most user-visible black screen — the reveal
+                // gate exhausted its bounded reseed retries and the active pane is STILL
+                // blank as it hands off to the blank watchdog. Previously logcat-only
+                // (unretrievable on-device); fingerprint it into the exportable JSONL.
+                // This rides the existing reveal-gate path — no new poll.
+                recordBlackFrameObserved(
+                    activePane,
+                    BLACK_FRAME_CLASS_REVEAL_GATE_GAVE_UP,
+                    captureText = null,
+                )
                 return false
             }
             delay(ACTIVE_PANE_REVEAL_SEED_DELAY_MS)
@@ -11075,6 +11097,60 @@ public class TmuxSessionViewModel @Inject constructor(
      * `capture-pane` round-trip is paid ONLY on the watchdog cadence (the caller
      * gates frequency), never per frame, so steady-state rendering is untouched.
      */
+    /**
+     * Issue #1175 — fingerprint a degenerate (black / partial-black) frame into the
+     * EXPORTABLE diagnostics JSONL (the same ring the Settings → Diagnostics "Share
+     * log" export reads), so a maintainer who hits a black screen can SHARE the log and
+     * we can tell WHICH class of black screen it was.
+     *
+     * This is emitted ONLY from points the heal/reveal path ALREADY reaches on the
+     * existing gated, backed-off stale-render watchdog tick and the connect/switch
+     * reveal gate — it adds NO new timer/poll/coroutine loop (the deliberate contrast
+     * with the #1164 heat regression). It rides the same `capture-pane` round-trip the
+     * heal already pays; it never issues its own.
+     *
+     * Additive on the OBSERVE side: the successful-heal event (`stale_render_heal`)
+     * still fires from [healActivePaneIfStaleRender]; this fingerprints the frame that
+     * was observed degenerate regardless of whether a heal follows.
+     *
+     * The `class` discriminator is computed at each call site (deterministic per site,
+     * so a unit test can drive every class); this builder just attaches the shared
+     * geometry / lifecycle field set — all redacted by [DiagnosticRedactor] before it
+     * reaches disk (only `session` is host-identifying, as it already is on
+     * `stale_render_heal`).
+     */
+    private fun recordBlackFrameObserved(
+        pane: TmuxPaneState,
+        blackClass: String,
+        captureText: String?,
+    ) {
+        val nowMs = SystemClock.elapsedRealtime()
+        val lastSeedAtMs = paneLastSeedAtMs[pane.paneId]
+        val lastOutputAtMs = paneLastOutputAtMs[pane.paneId]
+        val state = pane.terminalState
+        DiagnosticEvents.record(
+            "terminal",
+            BLACK_FRAME_OBSERVED_EVENT,
+            "class" to blackClass,
+            "paneId" to pane.paneId,
+            "windowId" to pane.windowId,
+            "session" to activeTarget?.sessionName,
+            "renderedChars" to state.renderedNonBlankCharCount(),
+            // Byte count of the authoritative capture this observation was judged
+            // against; 0 when the capture was empty/errored (the capture_empty /
+            // never_seeded classes) or unavailable at the site (the reveal gate).
+            "captureBytes" to (captureText?.length ?: 0),
+            "visibleRows" to state.visibleRowCount(),
+            // -1 means the field is unavailable (never seeded / never streamed output).
+            "msSinceLastSeed" to (lastSeedAtMs?.let { nowMs - it } ?: -1L),
+            "msSinceLastOutput" to (lastOutputAtMs?.let { nowMs - it } ?: -1L),
+            "connectionStatus" to (_connectionStatus.value::class.simpleName ?: "unknown"),
+            "foreground" to isProcessForegroundForCleared(),
+            "screenOn" to isScreenInteractive(),
+            "partialBlank" to state.visibleScreenIsPartiallyBlank(),
+        )
+    }
+
     private suspend fun healActivePaneIfStaleRender(
         client: TmuxClient,
         pane: TmuxPaneState,
@@ -11102,6 +11178,23 @@ public class TmuxSessionViewModel @Inject constructor(
         if (refreshGuard != null && !isCurrentRuntime(refreshGuard)) return false
         val captureResponse = combined?.capture
         if (captureResponse == null || captureResponse.isError || captureResponse.output.isEmpty()) {
+            // Issue #1175: capture-pane came back empty/errored on a LIVE transport.
+            // Fingerprint it ONLY when the render is actually degenerate (a healthy
+            // pane whose capture momentarily failed is NOT a black screen — stay
+            // silent so healthy ticks never record). A never-seeded pane (no seed has
+            // ever landed) is the distinct `never_seeded` class; otherwise this is the
+            // server-side `capture_empty` class. Rides the heal's existing capture — no
+            // new round-trip, no new poll.
+            if (pane.terminalState.renderedNonBlankCharCount() == 0 ||
+                pane.terminalState.visibleScreenIsBlankOrPartiallyBlank()
+            ) {
+                val blackClass = if (paneLastSeedAtMs[pane.paneId] == null) {
+                    BLACK_FRAME_CLASS_NEVER_SEEDED
+                } else {
+                    BLACK_FRAME_CLASS_CAPTURE_EMPTY
+                }
+                recordBlackFrameObserved(pane, blackClass, captureText = null)
+            }
             return false
         }
         val captureText = captureResponse.output.joinToString(separator = "\n")
@@ -11117,6 +11210,19 @@ public class TmuxSessionViewModel @Inject constructor(
         // also heals a partial-black pane when tmux's grid holds materially more (anti-thrash
         // guarded), restoring the FULL viewport from tmux's authoritative capture.
         if (!pane.terminalState.visibleRenderLostFrameVsCapture(captureText)) return false
+        // Issue #1175: the render LOST tmux's frame (capture carries materially more
+        // than the render). Fingerprint the observed black frame BEFORE the heal
+        // repaints it. A render with SOME surviving live content is the partial/half-
+        // black class; a fully-blank render (renderedChars == 0) that was previously
+        // painted is `lost_after_paint`. This rides the heal's already-paid capture —
+        // no new poll, and it is additive to `stale_render_heal` below (which still
+        // fires on the successful heal).
+        val observedClass = if (pane.terminalState.renderedNonBlankCharCount() > 0) {
+            BLACK_FRAME_CLASS_PARTIAL_BLANK
+        } else {
+            BLACK_FRAME_CLASS_LOST_AFTER_PAINT
+        }
+        recordBlackFrameObserved(pane, observedClass, captureText)
         val cursor = parseTmuxPaneCursor(combined.cursorReply)
         Log.i(
             ISSUE_145_RECONNECT_TAG,
@@ -11248,6 +11354,12 @@ public class TmuxSessionViewModel @Inject constructor(
         // attach so the post-attach reveal can skip the redundant second full
         // reseed for panes already painted in this pass.
         panesSeededThisAttach.add(pane.paneId)
+        // Issue #1175: stamp the successful seed landing (same point the attach set
+        // records it) so the `black_frame_observed` diagnostic can report
+        // `msSinceLastSeed`, and so an ABSENT stamp cleanly discriminates the
+        // `never_seeded` black-frame class from `capture_empty`. Diagnostic accounting
+        // only — no write-path control-flow change.
+        paneLastSeedAtMs[pane.paneId] = SystemClock.elapsedRealtime()
         // EPIC #792 Slice E: feed the AUTHORITATIVE controller the REAL "seed/capture
         // landed" signal at the EXISTING point a capture-pane lands for a pane — placed
         // AFTER the panesSeededThisAttach write above, so it adds no write-path control
@@ -14278,6 +14390,25 @@ public class TmuxSessionViewModel @Inject constructor(
     }
 
     /**
+     * Issue #1175 test seam: synthetically inject the "no seed has ever landed"
+     * state for a pane by dropping its seed stamp, so a JVM test can drive the
+     * `never_seeded` black-frame class deterministically (the connect flow otherwise
+     * stamps a seed). Diagnostic accounting only — never touches render/heal state.
+     */
+    @androidx.annotation.VisibleForTesting
+    internal fun clearPaneSeedStampForTest(paneId: String) {
+        paneLastSeedAtMs.remove(paneId)
+    }
+
+    /**
+     * Issue #1175 test seam: the recorded last-seed stamp for a pane, or null when no
+     * seed has landed. Lets a test assert the successful-seed stamp is set (so
+     * `msSinceLastSeed` is a real age, not the never-seeded -1 sentinel).
+     */
+    @androidx.annotation.VisibleForTesting
+    internal fun paneLastSeedAtMsForTest(paneId: String): Long? = paneLastSeedAtMs[paneId]
+
+    /**
      * Issue #942 test seam: true when [paneId]'s channel currently reads as
      * wedged-but-alive (recent `%output`). Lets a JVM test assert the signal
      * itself flips with activity vs idleness, independent of the routing.
@@ -16336,6 +16467,7 @@ public class TmuxSessionViewModel @Inject constructor(
         paneAgentInputs.clear()
         paneAgentNullDetections.clear()
         paneLastOutputAtMs.clear()
+        paneLastSeedAtMs.clear()
         paneConversationOpenStartedAtMs.clear()
         sessionRecordedKindCache.clear()
         sessionForeignKindGuessCache.clear()
@@ -16494,6 +16626,7 @@ public class TmuxSessionViewModel @Inject constructor(
         paneAgentInputs.clear()
         paneAgentNullDetections.clear()
         paneLastOutputAtMs.clear()
+        paneLastSeedAtMs.clear()
         paneConversationOpenStartedAtMs.clear()
         sessionRecordedKindCache.clear()
         sessionForeignKindGuessCache.clear()
@@ -17830,6 +17963,30 @@ internal const val REDRAW_UNAVAILABLE_MESSAGE: String = "Can't redraw — reconn
  * Connected pane.
  */
 internal const val ACTIVE_PANE_REVEAL_SEED_ATTEMPTS: Int = 5
+
+/**
+ * Issue #1175 — the exportable `black_frame_observed` diagnostic event name and its
+ * `class` discriminator values. The event fingerprints every class of degenerate
+ * (black / partial-black) frame into the JSONL ring the Settings → Diagnostics
+ * "Share log" export reads, riding the existing gated stale-render watchdog / reveal-
+ * gate accounting (NO new poll). Exposed for the JVM unit tests that drive each class.
+ */
+internal const val BLACK_FRAME_OBSERVED_EVENT: String = "black_frame_observed"
+
+/** Server-side black: capture-pane also empty/errored while the render is degenerate. */
+internal const val BLACK_FRAME_CLASS_CAPTURE_EMPTY: String = "capture_empty"
+
+/** No seed has ever landed for this pane (an empty capture with no prior seed stamp). */
+internal const val BLACK_FRAME_CLASS_NEVER_SEEDED: String = "never_seeded"
+
+/** Was painted, then the visible frame went fully degenerate while tmux still holds it. */
+internal const val BLACK_FRAME_CLASS_LOST_AFTER_PAINT: String = "lost_after_paint"
+
+/** The reveal gate exhausted its bounded reseed retries and the pane is STILL blank. */
+internal const val BLACK_FRAME_CLASS_REVEAL_GATE_GAVE_UP: String = "reveal_gate_gave_up_still_blank"
+
+/** Some live content survives but the majority of the viewport is black (partial/half-black). */
+internal const val BLACK_FRAME_CLASS_PARTIAL_BLANK: String = "partial_blank"
 
 /**
  * Issue #693/#661: backoff between active-pane reveal-gate seed retries.

--- a/app/src/test/java/com/pocketshell/app/diagnostics/BlackFrameObservedExportTest.kt
+++ b/app/src/test/java/com/pocketshell/app/diagnostics/BlackFrameObservedExportTest.kt
@@ -1,0 +1,94 @@
+package com.pocketshell.app.diagnostics
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.pocketshell.app.settings.SettingsRepository
+import kotlinx.coroutines.test.runTest
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+
+/**
+ * Issue #1175 — the `black_frame_observed` fingerprint must reach the SAME exportable
+ * JSONL the Settings → Diagnostics "Share log" path reads (acceptance criterion 3).
+ *
+ * `SettingsViewModel.shareDiagnosticsLog()` calls `DiagnosticRecorder.exportSnapshot()`,
+ * which is exactly what this test exercises: record a `black_frame_observed` event, then
+ * assert the exported `*.jsonl` file carries it — the `class` discriminator and the
+ * geometry/lifecycle fields intact — so a shared log fingerprints the black-screen class.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class BlackFrameObservedExportTest {
+    private lateinit var context: Context
+    private lateinit var settingsRepository: SettingsRepository
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        context.getSharedPreferences("app_settings", Context.MODE_PRIVATE)
+            .edit().clear().commit()
+        File(context.filesDir, "diagnostics").deleteRecursively()
+        File(context.cacheDir, DIAGNOSTICS_EXPORT_CACHE_DIR).deleteRecursively()
+        settingsRepository = SettingsRepository(context)
+        DiagnosticEvents.install(DiagnosticEventSink.Noop)
+    }
+
+    @Test
+    fun `black_frame_observed lands in the shareable diagnostics export`() = runTest {
+        val recorder = DiagnosticRecorder(context, settingsRepository)
+
+        recorder.record(
+            "terminal",
+            "black_frame_observed",
+            mapOf(
+                "class" to "reveal_gate_gave_up_still_blank",
+                "paneId" to "%1",
+                "renderedChars" to 0,
+                "captureBytes" to 0,
+                "visibleRows" to 40,
+                "msSinceLastSeed" to 1_200L,
+                "partialBlank" to false,
+            ),
+        )
+
+        // The exact path Settings → Diagnostics → "Share log" uses.
+        val exported = recorder.exportSnapshot()
+        assertNotNull("the exportable JSONL must be produced", exported)
+        assertTrue(exported!!.name.endsWith(".jsonl"))
+
+        val eventLine = exported.readLines()
+            .last { JSONObject(it).getString("name") == "black_frame_observed" }
+        val json = JSONObject(eventLine)
+        assertEquals("terminal", json.getString("category"))
+        val metadata = json.getJSONObject("metadata")
+        assertEquals("reveal_gate_gave_up_still_blank", metadata.getString("class"))
+        assertEquals(0, metadata.getInt("renderedChars"))
+        assertEquals(40, metadata.getInt("visibleRows"))
+        assertEquals(1_200L, metadata.getLong("msSinceLastSeed"))
+        assertEquals(false, metadata.getBoolean("partialBlank"))
+    }
+
+    @Test
+    fun `export summary counts the terminal black-frame category`() = runTest {
+        val recorder = DiagnosticRecorder(context, settingsRepository)
+        recorder.record("terminal", "black_frame_observed", mapOf("class" to "capture_empty"))
+
+        val exported = recorder.exportSnapshot()
+        assertNotNull(exported)
+        // The one-line export_summary header (#549) indexes the new event's category.
+        val header = JSONObject(exported!!.readLines().first())
+        assertEquals("export_summary", header.getString("name"))
+        assertEquals(
+            1,
+            header.getJSONObject("metadata").getJSONObject("categories").getInt("terminal"),
+        )
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/BlackFrameObservedDiagnosticTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/BlackFrameObservedDiagnosticTest.kt
@@ -1,0 +1,496 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.app.diagnostics.RecordedDiagnosticEvent
+import com.pocketshell.app.diagnostics.installRecordingDiagnosticSink
+import com.pocketshell.app.sessions.ActiveTmuxClients
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.SshLeaseConnector
+import com.pocketshell.core.ssh.SshLeaseManager
+import com.pocketshell.core.ssh.SshLeaseTarget
+import com.pocketshell.core.ssh.SshPortForward
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshShell
+import com.pocketshell.core.tmux.CommandResponse
+import com.pocketshell.core.tmux.TmuxClientFactory
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+import java.io.InputStream
+
+/**
+ * Issue #1175 — the `black_frame_observed` diagnostic fingerprint.
+ *
+ * ## What this proves
+ *
+ * When the maintainer hits a black screen and taps Settings → Diagnostics → Share
+ * log, the export must say WHICH class of black screen it was. Today only
+ * `stale_render_heal` (fires on a SUCCESSFUL heal) reaches the exportable JSONL;
+ * every other black-screen class is silent or logcat-only (unretrievable on-device).
+ * This slice emits ONE richer `black_frame_observed` event with a `class`
+ * discriminator + geometry/lifecycle fields at the points the heal/reveal path
+ * ALREADY reaches — riding the existing gated, backed-off stale-render watchdog
+ * capture and the reveal gate, adding NO new polling (the #1164 heat contrast).
+ *
+ * ## Class coverage (G2)
+ *
+ * Each of the FIVE classes is driven through the REAL production path
+ * ([TmuxSessionViewModel.healActivePaneIfStaleRender] via its test seam, and the
+ * switch-reveal gate [TmuxSessionViewModel.awaitActivePaneSeededOrLoading]):
+ *  - `capture_empty`  — capture-pane empty on a live transport, pane WAS seeded.
+ *  - `never_seeded`   — capture-pane empty, no seed has EVER landed (stamp absent).
+ *  - `lost_after_paint` — render fully lost tmux's frame (renderedChars == 0).
+ *  - `partial_blank`  — some live content survives, majority black.
+ *  - `reveal_gate_gave_up_still_blank` — reveal gate exhausted its reseed retries.
+ *
+ * ## No new polling (acceptance criterion 2)
+ *
+ * [emissionRidesTheExistingHealCaptureNoExtraRoundTrip] proves the emission pays NO
+ * capture beyond the one the heal already issues: a single
+ * `healActivePaneIfStaleRenderForTest()` increments the capture-pane count by exactly
+ * one. The emission adds a `Map` lookup + a `trySend` to the (off-main, bounded)
+ * recorder — no new coroutine, timer, or `capture-pane` round-trip.
+ *
+ * ## `stale_render_heal` preserved (acceptance criterion 4)
+ *
+ * The successful-heal event still fires alongside the new observe-side event
+ * ([lostAfterPaintAlsoPreservesStaleRenderHeal]).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class BlackFrameObservedDiagnosticTest {
+
+    private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val createdVms = mutableListOf<TmuxSessionViewModel>()
+
+    @After
+    fun tearDown() {
+        factoryScope.cancel()
+    }
+
+    // -------------------------------------------------------------------------
+    // (1) capture_empty — capture-pane empty on a live transport, pane WAS seeded.
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun captureEmptyClassIsFingerprintedWhenSeededPaneGoesBlackAndCaptureIsAlsoEmpty() =
+        runVmTest { sink ->
+            val client = FakeTmuxClient().withSinglePaneRow("work", "%1")
+            val vm = connectVm(client)
+            val pane = vm.panes.value.single { it.paneId == "%1" }
+            vm.resizeRemotePty(80, 40)
+            advanceUntilIdle()
+
+            // The connect seed stamped paneLastSeedAtMs — this pane WAS seeded.
+            assertNotNull(
+                "precondition: the connect seed landed (so this is capture_empty, not never_seeded)",
+                vm.paneLastSeedAtMsForTest("%1"),
+            )
+            // The render went fully black on a live transport.
+            blankRender(pane)
+            assertTrue(pane.terminalState.visibleScreenIsBlank())
+
+            // No capture queued → the heal's capture-pane comes back EMPTY (server-side black).
+            val capturesBefore = client.captureCount()
+            val healed = vm.healActivePaneIfStaleRenderForTest()
+            advanceUntilIdle()
+
+            assertFalse("an empty capture cannot heal", healed)
+            val event = sink.singleBlackFrameEvent()
+            assertEquals("capture_empty", event.fields["class"])
+            assertEquals("%1", event.fields["paneId"])
+            assertEquals(0, event.fields["captureBytes"])
+            // Seeded → msSinceLastSeed is a real age, not the -1 never-seeded sentinel.
+            assertTrue(
+                "msSinceLastSeed must be a real age (>= 0) for a seeded pane",
+                (event.fields["msSinceLastSeed"] as Long) >= 0L,
+            )
+            assertEquals("Connected", event.fields["connectionStatus"])
+            // NO new poll: the heal issued exactly ONE capture; the emission adds none.
+            assertEquals(
+                "the emission rides the heal's own capture — no extra round-trip",
+                capturesBefore + 1,
+                client.captureCount(),
+            )
+        }
+
+    // -------------------------------------------------------------------------
+    // (2) never_seeded — capture-pane empty, no seed has EVER landed for the pane.
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun neverSeededClassIsFingerprintedWhenNoSeedHasEverLanded() = runVmTest { sink ->
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%2")
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == "%2" }
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+
+        // Synthetically inject the "no seed ever landed" state (the connect flow
+        // otherwise stamps a seed) — the #780 model: inject the failing state.
+        vm.clearPaneSeedStampForTest("%2")
+        blankRender(pane)
+
+        val healed = vm.healActivePaneIfStaleRenderForTest()
+        advanceUntilIdle()
+
+        assertFalse(healed)
+        val event = sink.singleBlackFrameEvent()
+        assertEquals("never_seeded", event.fields["class"])
+        assertEquals(0, event.fields["captureBytes"])
+        assertEquals(
+            "an unseeded pane reports msSinceLastSeed = -1 (unavailable)",
+            -1L,
+            event.fields["msSinceLastSeed"],
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // (3) lost_after_paint — render fully lost tmux's frame (renderedChars == 0),
+    //     tmux still holds the content. Also proves stale_render_heal is preserved.
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun lostAfterPaintAlsoPreservesStaleRenderHeal() = runVmTest { sink ->
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%3")
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == "%3" }
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+
+        // Render fully black, but tmux's grid still holds a dense frame.
+        blankRender(pane)
+        assertEquals(0, pane.terminalState.renderedNonBlankCharCount())
+        client.capturePaneResponses.addLast(
+            CommandResponse(number = 99L, output = denseFrameLines(), isError = false),
+        )
+
+        val healed = vm.healActivePaneIfStaleRenderForTest()
+        advanceUntilIdle()
+
+        assertTrue("the render lost the frame → the heal fires", healed)
+        val event = sink.singleBlackFrameEvent()
+        assertEquals("lost_after_paint", event.fields["class"])
+        assertEquals(0, event.fields["renderedChars"])
+        assertTrue("the capture carried a real frame", (event.fields["captureBytes"] as Int) > 0)
+        assertTrue("the pane geometry is reported", (event.fields["visibleRows"] as Int) > 0)
+        assertEquals(false, event.fields["partialBlank"])
+        // Additive (criterion 4): the successful-heal event STILL fires alongside the observe event.
+        assertEquals(
+            "stale_render_heal must still be emitted on a successful heal",
+            1,
+            sink.eventsNamed("stale_render_heal").size,
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // (4) partial_blank — some live content survives, majority of the viewport black.
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun partialBlankClassIsFingerprintedWhenSomeLiveContentSurvives() = runVmTest { sink ->
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%4", title = "codex")
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == "%4" }
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+
+        // One live line, the rest of the viewport black (the #941 partial-black symptom).
+        partialBlackRender(pane)
+        assertFalse(pane.terminalState.visibleScreenIsBlank())
+        assertTrue(pane.terminalState.visibleScreenIsPartiallyBlank())
+        client.capturePaneResponses.addLast(
+            CommandResponse(number = 99L, output = denseFrameLines(), isError = false),
+        )
+
+        val healed = vm.healActivePaneIfStaleRenderForTest()
+        advanceUntilIdle()
+
+        assertTrue(healed)
+        val event = sink.singleBlackFrameEvent()
+        assertEquals("partial_blank", event.fields["class"])
+        assertTrue("partial-black keeps SOME rendered content", (event.fields["renderedChars"] as Int) > 0)
+        assertEquals(true, event.fields["partialBlank"])
+    }
+
+    // -------------------------------------------------------------------------
+    // (5) reveal_gate_gave_up_still_blank — the reveal gate exhausted its bounded
+    //     reseed retries and the active pane is STILL blank (the single most
+    //     user-visible black screen). Previously logcat-only.
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun revealGateGaveUpClassIsFingerprintedWhenReseedRetriesExhaust() = runVmTest { sink ->
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%5")
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == "%5" }
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+
+        // The active pane is fully blank and every reveal-gate reseed capture returns
+        // empty (no capturePaneResponses queued) → the gate exhausts its retries.
+        blankRender(pane)
+        assertTrue(pane.terminalState.visibleScreenIsBlank())
+
+        val revealed = vm.awaitActivePaneSeededOrLoadingForTest(client)
+        advanceUntilIdle()
+
+        assertFalse("the gate could not seed the pane → it defers (returns false)", revealed)
+        val event = sink.singleBlackFrameEvent()
+        assertEquals("reveal_gate_gave_up_still_blank", event.fields["class"])
+        assertEquals("%5", event.fields["paneId"])
+    }
+
+    // -------------------------------------------------------------------------
+    // No-new-poll acceptance (criterion 2): the emission never issues its own
+    // capture-pane round-trip; it rides the heal's single capture.
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun emissionRidesTheExistingHealCaptureNoExtraRoundTrip() = runVmTest { sink ->
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%6")
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == "%6" }
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+
+        blankRender(pane)
+        client.capturePaneResponses.addLast(
+            CommandResponse(number = 99L, output = denseFrameLines(), isError = false),
+        )
+        val capturesBefore = client.captureCount()
+
+        vm.healActivePaneIfStaleRenderForTest()
+        advanceUntilIdle()
+
+        // Exactly ONE capture-pane for the whole heal+observe pass: the emission adds none.
+        assertEquals(capturesBefore + 1, client.captureCount())
+        assertEquals(1, sink.eventsNamed("black_frame_observed").size)
+    }
+
+    // -------------------------------------------------------------------------
+    // A healthy pane records NOTHING (the degenerate-frame gate keeps healthy
+    // watchdog ticks silent — no over-recording flood, the #1164 contrast).
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun healthyPaneRecordsNoBlackFrameEvent() = runVmTest { sink ->
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%7")
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == "%7" }
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+
+        // A normally-painted, dense viewport — NOT degenerate. The heal's capture
+        // comes back empty (no reseed to do); nothing should be fingerprinted.
+        pane.terminalState.appendRemoteOutput(
+            buildString {
+                append(CLEAR_ONLY)
+                repeat(30) { append("healthy content line $it with real text\r\n") }
+            }.toByteArray(Charsets.US_ASCII),
+        )
+        advanceUntilIdle()
+        assertFalse(pane.terminalState.visibleScreenIsBlank())
+        assertFalse(pane.terminalState.visibleScreenIsPartiallyBlank())
+
+        vm.healActivePaneIfStaleRenderForTest()
+        advanceUntilIdle()
+
+        assertEquals(
+            "a healthy pane must NOT fingerprint a black frame (no over-recording)",
+            0,
+            sink.eventsNamed("black_frame_observed").size,
+        )
+    }
+
+    // ------------------------------------------------------------------ Harness
+
+    private fun runVmTest(body: suspend TestScope.(RecordingSink) -> Unit) = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        LivenessProbeTestOverride.setAutoStartEnabledForTest(false)
+        val sink = installRecordingDiagnosticSink()
+        try {
+            body(RecordingSink(sink))
+        } finally {
+            sink.close()
+            for (vm in createdVms) {
+                runCatching { vm.setProcessForegroundForClearedForTest(false) }
+                runCatching { vm.clearForTest() }
+            }
+            advanceUntilIdle()
+            createdVms.clear()
+            LivenessProbeTestOverride.clear()
+            Dispatchers.resetMain()
+        }
+    }
+
+    /** Thin wrapper so the test body can pull black-frame events by class without imports. */
+    private class RecordingSink(
+        private val delegate: com.pocketshell.app.diagnostics.RecordingDiagnosticEventSink,
+    ) {
+        fun eventsNamed(name: String): List<RecordedDiagnosticEvent> = delegate.eventsNamed(name)
+
+        fun singleBlackFrameEvent(): RecordedDiagnosticEvent {
+            val events = eventsNamed("black_frame_observed")
+            assertEquals(
+                "exactly one black_frame_observed event expected, got: " +
+                    events.joinToString { it.fields["class"].toString() },
+                1,
+                events.size,
+            )
+            return events.single()
+        }
+    }
+
+    private fun TestScope.newVm(
+        registry: ActiveTmuxClients,
+        sshLeaseManager: SshLeaseManager,
+    ): TmuxSessionViewModel = TmuxSessionViewModel(
+        tmuxClientFactory = TmuxClientFactory(factoryScope),
+        activeTmuxClients = registry,
+        runtimeCache = TmuxSessionRuntimeCache(),
+        sshLeaseManager = sshLeaseManager,
+        sessionLifecycleSignals = null,
+    ).also {
+        it.setSeedIoDispatcherForTest(StandardTestDispatcher(testScheduler))
+        // Suppress the background stale-render + blank watchdogs so the ONLY heal /
+        // reveal-gate pass is the one the test drives directly — no spurious events.
+        it.setStaleRenderWatchdogAutoArmEnabledForTest(false)
+        it.setConnectedBlankWatchdogAutoArmEnabledForTest(false)
+        createdVms.add(it)
+    }
+
+    private fun TestScope.connectVm(client: FakeTmuxClient): TmuxSessionViewModel {
+        val live = AlwaysConnectedSession(id = "live")
+        val connector = SingleSessionConnector(live)
+        val leaseManager =
+            testLeaseManager(connector = connector, scope = this, idleTtlMillis = 60_000L)
+        val registry = ActiveTmuxClients()
+        val vm = newVm(registry = registry, sshLeaseManager = leaseManager)
+        runCurrent()
+        vm.setTmuxClientFactoryForTest { _, _, _ -> client }
+        vm.connect(
+            hostId = 1L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            passphrase = null,
+            sessionName = "work",
+        )
+        advanceUntilIdle()
+        return vm
+    }
+
+    /** Fully black render: a clear-only overpaint wipes the visible viewport. */
+    private fun blankRender(pane: TmuxPaneState) {
+        pane.terminalState.appendRemoteOutput(CLEAR_ONLY.toByteArray(Charsets.US_ASCII))
+    }
+
+    /** Partial-black render: a clear + ONE live line (the #941 "one live line, rest black"). */
+    private fun partialBlackRender(pane: TmuxPaneState) {
+        pane.terminalState.appendRemoteOutput(
+            (CLEAR_ONLY + "ISSUE1175-LIVE-LINE 7\r\n").toByteArray(Charsets.US_ASCII),
+        )
+    }
+
+    private fun FakeTmuxClient.captureCount(): Int =
+        sentCommands.count { it.startsWith("capture-pane") }
+
+    private fun FakeTmuxClient.withSinglePaneRow(
+        sessionName: String,
+        paneId: String,
+        title: String = sessionName,
+    ): FakeTmuxClient = apply {
+        responses.addLast(
+            CommandResponse(
+                number = 1L,
+                output = listOf("$paneId\t@0\t\$0\t$sessionName\t$title\t0"),
+                isError = false,
+            ),
+        )
+        capturePaneResponses.addLast(
+            CommandResponse(number = 2L, output = listOf("$sessionName ready"), isError = false),
+        )
+        cursorQueryResponses.addLast(
+            CommandResponse(number = 3L, output = listOf("0,0"), isError = false),
+        )
+    }
+
+    private class SingleSessionConnector(
+        private val session: SshSession,
+    ) : SshLeaseConnector {
+        override suspend fun connect(target: SshLeaseTarget): Result<SshSession> =
+            Result.success(session)
+    }
+
+    private class AlwaysConnectedSession(
+        val id: String,
+    ) : SshSession {
+        @Volatile
+        var closed: Boolean = false
+
+        override val isConnected: Boolean get() = !closed
+
+        override suspend fun exec(command: String): ExecResult =
+            ExecResult(stdout = "", stderr = "", exitCode = 0)
+
+        override fun tail(path: String, onLine: (String) -> Unit): Job =
+            Job().apply { complete() }
+
+        override fun tail(path: String, fromLineExclusive: Long, onLine: (String) -> Unit): Job =
+            Job().apply { complete() }
+
+        override fun openLocalPortForward(
+            remoteHost: String,
+            remotePort: Int,
+            localPort: Int,
+        ): SshPortForward = error("not used")
+
+        override fun startShell(): SshShell = error("not used")
+
+        override suspend fun uploadFile(file: File, remotePath: String): String = error("not used")
+
+        override suspend fun uploadStream(
+            input: InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String = error("not used")
+
+        override fun close() {
+            closed = true
+        }
+    }
+
+    private fun denseFrameLines(): List<String> = buildList {
+        add("ISSUE1175-RECOVERED-VIEWPORT")
+        repeat(27) { add("recovered context row $it with real tmux content") }
+    }
+
+    private companion object {
+        // ESC[2J ESC[H — clear screen + cursor home (the overpaint preamble).
+        val CLEAR_ONLY: String = "[2J[H"
+    }
+}

--- a/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurfaceState.kt
+++ b/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurfaceState.kt
@@ -582,6 +582,26 @@ class TerminalSurfaceState(
     }
 
     /**
+     * Issue #1175 — the number of VISIBLE viewport rows the emulator's grid holds
+     * (the pane's on-screen height). NOT a black/blank predicate: a plain geometry
+     * read of the same `emulator.screen.visibleScreenRows` the divergence/lost-frame
+     * predicates already use, exposed so the `black_frame_observed` diagnostic can
+     * carry the pane geometry that distinguishes a tall-grid black pane (#807) from a
+     * short one. Reuses the existing emulator read; adds no new black/blank predicate.
+     *
+     * Returns 0 when no emulator is attached or the emulator throws mid-resize
+     * ("unknown" → 0), matching the defensive contract of the predicates above.
+     */
+    fun visibleRowCount(): Int {
+        val emulator = bridge?.emulator ?: _session?.emulator ?: return 0
+        return try {
+            emulator.screen.visibleScreenRows
+        } catch (_: Throwable) {
+            0
+        }
+    }
+
+    /**
      * Issue #966/#967 — the "mostly-black / stale render on a LIVE transport"
      * oracle. The v0.4.17 black-screen heal ([visibleScreenIsBlank] /
      * [visibleScreenIsPartiallyBlank]) only engages when the pane is FULLY blank


### PR DESCRIPTION
Emits `black_frame_observed` with a `class` discriminator at the existing gated heal/reveal sites (zero new polling), so a shared log fingerprints the black-screen class. Reviewer APPROVED (drove red→green: neutered emitter → 6/7 fail, restored → 9/9; no-poll invariant asserted; all 5 classes covered; export-path proven; stale_render_heal preserved). Local gate: 8/8 diagnostic tests pass, git diff --check clean.

Part of the black-screen campaign (#843/#874). Diagnostics-only; first of the connection-core cluster to merge so #1176/#1177 rebase onto it.

Closes #1175