### PR TITLE
test: wire MainThreadResponsivenessProbe into freeze journeys (#1084)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/BackgroundGraceReconnectE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/BackgroundGraceReconnectE2eTest.kt
@@ -23,6 +23,7 @@ import com.pocketshell.app.MainActivity
 import com.pocketshell.app.diagnostics.DiagnosticEvents
 import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
 import com.pocketshell.app.hosts.SshKeyStorage
+import com.pocketshell.app.proof.signals.MainThreadResponsivenessProbe
 import com.pocketshell.app.tmux.TMUX_CONNECTING_PROGRESS_TAG
 import com.pocketshell.app.tmux.TMUX_CONNECTION_STATUS_PILL_TAG
 import com.pocketshell.app.tmux.TMUX_SESSION_ERROR_TAG
@@ -164,6 +165,20 @@ class BackgroundGraceReconnectE2eTest {
         captureViewport("issue548-01-attached")
         diagnostics!!.clear()
 
+        // Issue #1084: wire the direct main-thread responsiveness probe across the
+        // WHOLE background->grace->foreground reconnect cycle (within-grace
+        // ride-through AND the post-grace teardown + lifecycle reattach). The
+        // grace/reconnect path (Vector 2/3) must never park Dispatchers.Main — a
+        // teardown/reattach that blocks Main is the #895/#928 freeze class. This
+        // HARD-asserts Main responsiveness (no self-skip on the load-bearing
+        // assertion). The probe is a non-blocking Handler heartbeat, so it records
+        // any Main-thread park across the bg<->fg cycles without itself hanging.
+        val mainProbe = MainThreadResponsivenessProbe(
+            intervalMs = MAIN_PROBE_INTERVAL_MS,
+            budgetMs = MAIN_STALL_BUDGET_MS,
+        )
+        mainProbe.start()
+
         // Within-grace branch: ProcessLifecycle ON_STOP starts the timer,
         // but foreground arrives before the short injected window elapses.
         BackgroundGraceTestOverride.setForTest(WITHIN_GRACE_MS)
@@ -234,6 +249,22 @@ class BackgroundGraceReconnectE2eTest {
         waitForVisibleTerminal("post-grace terminal") { it.contains(READY_MARKER) }
         recordTiming("post_grace_cycle_ms", SystemClock.elapsedRealtime() - postStart)
         captureViewport("issue548-03-post-grace-reattached")
+
+        // Issue #1084 (load-bearing): Main stayed responsive across the whole
+        // within-grace + post-grace teardown/reattach cycle. RED if any grace or
+        // reconnect step parked Dispatchers.Main beyond budget (the freeze class).
+        val mainResult = mainProbe.stop(minExpectedSamples = MAIN_PROBE_MIN_SAMPLES)
+        recordTiming("main_max_stall_ms", mainResult.maxGapMs)
+        recordTiming("main_probe_samples", mainResult.sampleCount.toLong())
+        writeText("main-thread-probe.txt", mainResult.message)
+        assertTrue(
+            "MAIN-THREAD FREEZE during the background grace/reconnect cycle: " +
+                "${mainResult.message}. maxStall=${mainResult.maxGapMs}ms exceeds the " +
+                "${MAIN_STALL_BUDGET_MS}ms budget — a grace/reattach step parked " +
+                "Dispatchers.Main (the #895/#928 freeze class this gate guards).",
+            mainResult.responsive,
+        )
+
         writeTimings()
     } }
 
@@ -1033,6 +1064,18 @@ class BackgroundGraceReconnectE2eTest {
 
         const val WITHIN_GRACE_MS: Long = 3_000L
         const val POST_GRACE_MS: Long = 500L
+
+        // Issue #1084 — main-thread responsiveness probe wiring. See the twin
+        // constants in MultiSessionSwitchJourneyE2eTest for the budget rationale:
+        // the freeze class parks Main for SECONDS, so a budget above legitimate
+        // grace/reattach frame jank avoids per-push flake while still catching a
+        // multi-second block. The bounded teardown block (closeCachedRuntimes,
+        // up to ~600ms x N cached runtimes) is well under this with the single
+        // session this journey holds.
+        const val MAIN_PROBE_INTERVAL_MS: Long = 100L
+        const val MAIN_PROBE_MIN_SAMPLES: Int = 10
+        val MAIN_STALL_BUDGET_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 2_000L else 1_200L
         const val SIX_SECOND_APP_SWITCH_MS: Long = 6_000L
         const val WATCH_NO_RECONNECT_MS: Long = 1_200L
 

--- a/app/src/androidTest/java/com/pocketshell/app/proof/MobileSpuriousReconnectE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/MobileSpuriousReconnectE2eTest.kt
@@ -24,6 +24,7 @@ import com.pocketshell.app.diagnostics.DiagnosticEvents
 import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
 import com.pocketshell.app.hosts.SshKeyStorage
 import com.pocketshell.app.MainActivity
+import com.pocketshell.app.proof.signals.MainThreadResponsivenessProbe
 import com.pocketshell.app.testaccess.TestAccessEntryPoint
 import com.pocketshell.app.tmux.TMUX_SESSION_SCREEN_TAG
 import com.pocketshell.app.tmux.TMUX_SWITCHING_LOADING_TAG
@@ -223,6 +224,93 @@ class MobileSpuriousReconnectE2eTest {
         waitForVisibleTerminal("after ride-through terminal") { it.contains(READY_MARKER) }
         captureViewport("issue1042a-02-rode-through")
         writeTimings("issue1042a")
+    } }
+
+    /**
+     * Issue #1084 — the cellular NETWORK-FLAP STORM main-thread responsiveness
+     * guard (Vector 4, the maintainer's cellular case). This is the flap-journey
+     * arm of wiring [MainThreadResponsivenessProbe] into the load-bearing
+     * connection journeys: a REPEATED loss->restore storm drives the production
+     * [TmuxSessionViewModel.onNetworkChanged] reducer ON the main thread over and
+     * over while the direct Main-stall probe measures inter-heartbeat gaps. If any
+     * network-change step parks Dispatchers.Main beyond budget (the #895/#928
+     * freeze class), the probe balloons a gap -> RED. HARD-asserts (no self-skip).
+     *
+     * The storm is pinned proven-alive so each restore rides through (no Docker
+     * redial churn) — the point is that the reducer runs repeatedly on Main and
+     * must never park it, not to exercise the redial path (covered by the
+     * dedicated redial journeys). Uses only the deterministic `agents:2222`
+     * fixture (no toxiproxy), so it slots into the per-push journey gate.
+     */
+    @Test
+    fun networkFlapStormKeepsMainThreadResponsive() { runBlocking<Unit> {
+        val hostRowTag = requireNotNull(seededHostRowTag)
+        attachSeededTmuxSession(hostRowTag)
+        waitForVisibleTerminal("initial attach") { it.contains(READY_MARKER) }
+        waitForConnected("initial attach")
+        waitForNoSwitchingOverlay("pre-storm attach settle")
+        captureViewport("issue1084-flap-01-attached")
+
+        val vm = currentViewModel()
+        // Keep the storm a deterministic pure ride-through flap (proven-alive) so it
+        // does not churn Docker reconnects; the property under test is that the
+        // repeatedly-driven network reducer never parks Main.
+        vm.forceTransportProvenAliveForTest = true
+        diagnostics!!.clear()
+
+        val baseline = TerminalNetworkSnapshot.Validated(networkHandle = "wifi-A", transports = setOf("WIFI"))
+        val probe = MainThreadResponsivenessProbe(
+            intervalMs = MAIN_PROBE_INTERVAL_MS,
+            budgetMs = MAIN_STALL_BUDGET_MS,
+        )
+        val stormStart = SystemClock.elapsedRealtime()
+        probe.start()
+        var seq = 0L
+        repeat(FLAP_STORM_ITERATIONS) { i ->
+            val loss = TerminalNetworkChange(
+                previous = baseline,
+                current = TerminalNetworkSnapshot.NoValidatedNetwork,
+                previousValidated = baseline,
+                reason = "issue1084-flap-loss-$i",
+                sequence = ++seq,
+                kind = TerminalNetworkChangeKind.NetworkLost,
+            )
+            val restore = TerminalNetworkChange(
+                previous = TerminalNetworkSnapshot.NoValidatedNetwork,
+                current = baseline,
+                previousValidated = baseline,
+                reason = "issue1084-flap-restore-$i",
+                sequence = ++seq,
+                kind = TerminalNetworkChangeKind.NetworkRestored,
+            )
+            // onActivity runs the lambda ON the main thread — the production
+            // reducer is exercised on Main, exactly like a real network callback.
+            compose.activityRule.scenario.onActivity {
+                vm.onNetworkChanged(loss)
+                vm.onNetworkChanged(restore)
+            }
+            SystemClock.sleep(FLAP_STORM_STEP_MS)
+        }
+        val result = probe.stop(minExpectedSamples = MAIN_PROBE_MIN_SAMPLES)
+        timings += "flap_storm_ms=${SystemClock.elapsedRealtime() - stormStart}"
+        timings += "flap_storm_iterations=$FLAP_STORM_ITERATIONS"
+        timings += "main_max_stall_ms=${result.maxGapMs}"
+        timings += "main_probe_samples=${result.sampleCount}"
+        writeText("main-thread-flap-probe.txt", result.message)
+        captureViewport("issue1084-flap-02-after-storm")
+
+        // The session must still be connected after the storm (a torn-down screen
+        // would be a crash, not the freeze under test).
+        waitForConnected("after flap storm")
+
+        assertTrue(
+            "MAIN-THREAD FREEZE during the cellular network-flap storm (Vector 4): " +
+                "${result.message}. maxStall=${result.maxGapMs}ms exceeds the " +
+                "${MAIN_STALL_BUDGET_MS}ms budget — a network-change step parked " +
+                "Dispatchers.Main (the #895/#928 freeze class this gate guards).",
+            result.responsive,
+        )
+        writeTimings("issue1084-flap")
     } }
 
     // (b2) cause #1 ARM 2 — keepalive aged out but the bounded probe ANSWERS over the
@@ -815,6 +903,19 @@ class MobileSpuriousReconnectE2eTest {
         const val READY_MARKER: String = "ISSUE1042-SPURIOUS-READY"
 
         const val WATCH_NO_REDIAL_AFTER_RESTORE_MS: Long = 3_000L
+
+        // Issue #1084 — main-thread responsiveness probe wiring for the flap storm.
+        // See MultiSessionSwitchJourneyE2eTest for the budget rationale: the freeze
+        // class parks Main for SECONDS, so a budget above legitimate reducer/frame
+        // jank avoids per-push flake while still catching a multi-second block.
+        const val MAIN_PROBE_INTERVAL_MS: Long = 100L
+        const val MAIN_PROBE_MIN_SAMPLES: Int = 10
+        val MAIN_STALL_BUDGET_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 2_000L else 1_200L
+        // A short, bounded flap STORM: enough loss/restore cycles to be a genuine
+        // storm while keeping the connected journey affordable for the per-push gate.
+        const val FLAP_STORM_ITERATIONS: Int = 12
+        const val FLAP_STORM_STEP_MS: Long = 150L
 
         // Issue #1065 (R5): the modelled long idle outage held across the loss window.
         // Bounded so the connected journey stays affordable; long enough to be a

--- a/app/src/androidTest/java/com/pocketshell/app/proof/MultiSessionSwitchJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/MultiSessionSwitchJourneyE2eTest.kt
@@ -24,6 +24,7 @@ import com.pocketshell.app.MainActivity
 import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
 import com.pocketshell.app.hosts.SshKeyStorage
 import com.pocketshell.app.projects.FOLDER_LIST_BACK_TAG
+import com.pocketshell.app.proof.signals.MainThreadResponsivenessProbe
 import com.pocketshell.app.proof.signals.waitForSessionInPicker
 import com.pocketshell.app.tmux.SSH_HANDSHAKE_ATTEMPTS
 import com.pocketshell.app.tmux.TMUX_COMPACT_CHROME_BACK_BUTTON_TAG
@@ -253,6 +254,22 @@ class MultiSessionSwitchJourneyE2eTest {
         // racing the lease lifecycle.
         val ring = listOf(SESSION_B, SESSION_C, SESSION_A)
 
+        // Issue #1084: wire the direct main-thread responsiveness probe around the
+        // WHOLE A->B->C->A switch ring. A switch that parks Dispatchers.Main (the
+        // #895 black->disconnect->freeze cascade class, or an unbounded
+        // runBlocking / parked mutex on the attach/reattach path) would balloon a
+        // heartbeat inter-arrival gap past budget -> RED. This HARD-asserts Main
+        // responsiveness through the rapid-switch journey (no assumeTrue/assumeFalse
+        // self-skip on the load-bearing assertion). The reproduce-first, non-vacuous
+        // proof that this probe actually fires on this path lives in
+        // [mainThreadProbeDetectsInjectedMainBlockDuringSwitch].
+        val mainProbe = MainThreadResponsivenessProbe(
+            intervalMs = MAIN_PROBE_INTERVAL_MS,
+            budgetMs = MAIN_STALL_BUDGET_MS,
+        )
+        val ringStart = SystemClock.elapsedRealtime()
+        mainProbe.start()
+
         ring.forEachIndexed { index, target ->
             switchAndAssert(
                 step = index + 1,
@@ -261,6 +278,18 @@ class MultiSessionSwitchJourneyE2eTest {
             )
             previousSession = target
         }
+
+        val mainResult = mainProbe.stop(minExpectedSamples = MAIN_PROBE_MIN_SAMPLES)
+        recordTiming("switch_ring_ms", SystemClock.elapsedRealtime() - ringStart)
+        recordTiming("main_max_stall_ms", mainResult.maxGapMs)
+        recordTiming("main_probe_samples", mainResult.sampleCount.toLong())
+        writeText("main-thread-probe.txt", mainResult.message)
+        assertTrue(
+            "MAIN-THREAD FREEZE during the A->B->C->A switch ring: ${mainResult.message}. " +
+                "maxStall=${mainResult.maxGapMs}ms exceeds the ${MAIN_STALL_BUDGET_MS}ms budget — a " +
+                "switch parked Dispatchers.Main (the #895/#928 freeze class this gate guards).",
+            mainResult.responsive,
+        )
 
         writeSummary(
             lines = listOf(
@@ -272,6 +301,84 @@ class MultiSessionSwitchJourneyE2eTest {
             ),
         )
         writeTimings()
+        Unit
+    } }
+
+    /**
+     * Issue #1084 (reproduce-first, G6/G10) — the NON-VACUOUS proof that the
+     * [MainThreadResponsivenessProbe] wired into
+     * [rapidMultiSessionSwitchAlwaysShowsCorrectSessionWithoutSpuriousReconnect]
+     * actually FIRES when Dispatchers.Main is blocked ON the real switch path. A
+     * probe that can never go red proves nothing (the #635 vacuous-pass trap), so
+     * this test injects a deliberate synthetic main-thread block DURING a real
+     * session switch and asserts the probe DETECTS it (RED), then confirms a clean
+     * switch stays responsive (GREEN). Together with the green assertion in the
+     * ring journey this is the durable red->green pair on the real path.
+     *
+     * The injected block (a [SystemClock.sleep] parking Main via `runOnMainSync`)
+     * is exactly what an unbounded `runBlocking` disk read / parked mutex on the
+     * attach/reattach path would do — the regression class this whole gate guards.
+     * Runs on the plain Docker `agents` fixture, no toxiproxy, no self-skip.
+     */
+    @Test
+    fun mainThreadProbeDetectsInjectedMainBlockDuringSwitch() { runBlocking {
+        // Seeded (three sessions + host row + flat mode) BEFORE launch by the rule
+        // chain — the same seed the ring journey uses (the `else` branch of
+        // [seedForCurrentTest]).
+        waitForHostRowPresent(hostRowTag)
+        compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick()
+        waitForFolderListReady(hostRowTag)
+        waitForText(SESSION_A, timeoutMs = pickerWaitMs)
+        compose.onNodeWithText(SESSION_A, useUnmergedTree = true).performClick()
+        compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertExists()
+        waitForTerminalViewAttached()
+        waitForTerminalContains(SESSION_A_MARKER, "injection-proof attach to A")
+
+        expectedMarker[SESSION_A] = SESSION_A_MARKER
+        expectedMarker[SESSION_B] = SESSION_B_MARKER
+        expectedMarker[SESSION_C] = SESSION_C_MARKER
+        assertInputRoutesToShownSession(SESSION_A, "injection-proof initial")
+
+        // GREEN: a clean switch A->B keeps Main responsive under a TIGHT budget.
+        val cleanProbe = MainThreadResponsivenessProbe(
+            intervalMs = MAIN_PROBE_INTERVAL_MS,
+            budgetMs = INJECTION_PROBE_BUDGET_MS,
+        )
+        cleanProbe.start()
+        switchAndAssert(step = 1, fromSession = SESSION_A, toSession = SESSION_B)
+        val clean = cleanProbe.stop(minExpectedSamples = MAIN_PROBE_MIN_SAMPLES)
+        writeText("main-thread-injection-clean.txt", clean.message)
+        assertTrue(
+            "control: a clean switch must keep Main responsive under the tight " +
+                "${INJECTION_PROBE_BUDGET_MS}ms budget: ${clean.message}",
+            clean.responsive,
+        )
+
+        // RED: the SAME switch path (B->A), but park Main for a large synthetic
+        // block INSIDE the probe window. The probe MUST detect the stall — proving
+        // it is non-vacuous on the real switch path (it would catch a genuine
+        // Main-blocking regression here).
+        val redProbe = MainThreadResponsivenessProbe(
+            intervalMs = MAIN_PROBE_INTERVAL_MS,
+            budgetMs = INJECTION_PROBE_BUDGET_MS,
+        )
+        redProbe.start()
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            SystemClock.sleep(INJECTED_MAIN_BLOCK_MS)
+        }
+        switchAndAssert(step = 2, fromSession = SESSION_B, toSession = SESSION_A)
+        val red = redProbe.stop(minExpectedSamples = MAIN_PROBE_MIN_SAMPLES)
+        writeText("main-thread-injection-red.txt", red.message)
+        assertFalse(
+            "an injected ${INJECTED_MAIN_BLOCK_MS}ms Main block during the switch MUST be " +
+                "detected as a stall — the wired probe is non-vacuous on the real switch " +
+                "path: ${red.message}",
+            red.responsive,
+        )
+        assertTrue(
+            "the detected gap (${red.maxGapMs}ms) must exceed the ${INJECTION_PROBE_BUDGET_MS}ms budget",
+            red.maxGapMs > INJECTION_PROBE_BUDGET_MS,
+        )
         Unit
     } }
 
@@ -1607,6 +1714,25 @@ class MultiSessionSwitchJourneyE2eTest {
             "network-reconnect",
             "lifecycle-reattach",
         )
+
+        // Issue #1084 — main-thread responsiveness probe wiring.
+        // Heartbeat post interval (ms) for the direct Main-stall detector.
+        const val MAIN_PROBE_INTERVAL_MS: Long = 100L
+        // Floor on heartbeats the window must have produced — guards the G3
+        // vacuous "0 samples = pass" trap; a Main wedged the whole window
+        // produces far fewer and fails.
+        const val MAIN_PROBE_MIN_SAMPLES: Int = 10
+        // Generous stall budget for the per-push swiftshader gate. The freeze
+        // class this guards (the #895 black->disconnect->freeze cascade) parks
+        // Main for SECONDS; a budget well above legitimate heavy-switch frame
+        // jank avoids per-push flake while still catching a multi-second block.
+        // Tighten as the journey proves stable (analyzer docstring guidance).
+        val MAIN_STALL_BUDGET_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 2_000L else 1_200L
+        // The reproduce-first injection proof uses a TIGHT budget + a large
+        // block so detection is unambiguous.
+        const val INJECTION_PROBE_BUDGET_MS: Long = 700L
+        const val INJECTED_MAIN_BLOCK_MS: Long = 2_000L
 
         // Strings the Disconnected/broken-transport path surfaces. None must
         // appear in the visible transcript on a healthy switch.


### PR DESCRIPTION
Wires the freeze detector into the rapid-switch / flap-storm / grace-reconnect journeys so a Main-thread stall can't ship green. Reviewer APPROVED on the real emulator path: drove the injected-2s-Main-block RED proof (non-vacuous, G6), no self-skip (F3), all 3 carrier classes gate-wired, 3/3 green journeys 0-skipped, test-side only. Local gate: harness + validity guards PASS, androidTest compiles.

From the #895/#843 freeze audit. Test-only — disjoint from the connection-core cluster.

Closes #1084