### PR TITLE
composer: fit the recording row so Send is never clipped (#1152)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerRecordingRowFitProofTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerRecordingRowFitProofTest.kt
@@ -1,0 +1,318 @@
+package com.pocketshell.app.composer
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.requiredHeight
+import androidx.compose.foundation.layout.requiredWidth
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.ime
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
+import androidx.core.graphics.Insets
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.proof.signals.assertNodeFullyWithinRoot
+import com.pocketshell.uikit.theme.PocketShellColors
+import com.pocketshell.uikit.theme.PocketShellTheme
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Issue #1152 — the recording-not-locked composer bottom row overflowed its
+ * width and CLIPPED `Send` off the right edge (the cyan "S/e" sliver the
+ * maintainer circled — audit D1). The old single row packed the editing-tools
+ * group + Lock + Insert + Send onto one line; the content (~421dp of pills + gaps)
+ * exceeded a phone's usable width, and with no scroll/weight the trailing `Send`
+ * fell off the right edge.
+ *
+ * The maintainer's directive is FIT EVERYTHING — never hide a control to make
+ * room. The fix relays the recording states into a TWO-ROW layout (secondary row:
+ * tools + Discard + Lock; primary row: Insert + Send) so EVERY control fits with
+ * the editing tools still mounted.
+ *
+ * ## What this proves (red → green, class-covering)
+ *
+ * It composes the PRODUCTION [SheetContent] in the recording state — both
+ * NOT-LOCKED and LOCKED — pinned to a FIXED phone-width band, keyboard-UP (the
+ * #780 synthetic-inset model), at font scale 1.0 AND 1.3 (the widest-content
+ * case, since this is a width-overflow bug). It then asserts, for every
+ * recording-row pill (Discard / Lock / Insert / Send) AND the editing-tools
+ * group:
+ *  1. the pill is fully within the band horizontally (no edge spill), AND
+ *  2. the pill is NOT CRUSHED — its width stays at/above a not-a-sliver floor.
+ *
+ * Both are needed because at a real phone width the single-row overflow does not
+ * push `Send` cleanly off the edge — the un-weighted Row squeezes the trailing
+ * `Send` down to a ~33dp sliver AT the band edge (the maintainer's cyan "S/e";
+ * base evidence: `Send widthDp=33`). A bare containment / `assertIsDisplayed()`
+ * still passes on that crushed sliver — the exact #657/F1 trap — so the
+ * not-crushed floor is the LOAD-BEARING assertion that goes RED on base and GREEN
+ * with the two-row fit (`Send widthDp≈90`).
+ *
+ * ## Why the band, not just [assertNodeFullyWithinRoot]
+ *
+ * The overflow at a phone width is ~20–30dp — razor-thin against the DEVICE
+ * screen, so a slightly-wider CI AVD would mask it if we measured only against
+ * `onRoot()` (the whole screen). We therefore host [SheetContent] in a
+ * `requiredWidth` band anchored top-START and measure containment RELATIVE to the
+ * band, so the red is DETERMINISTIC on every AVD regardless of physical width
+ * (the #813 model). [assertNodeFullyWithinRoot] is asserted too as an additive
+ * "never off the whole screen" guard, but the band-relative check is the
+ * load-bearing red→green.
+ *
+ * ## Determinism
+ *
+ * Band width + height + the synthetic IME/nav/status insets are all fixed
+ * synthetic inputs, so the geometry is identical on the dev-box AVD and CI
+ * swiftshader. The synthetic ime() inset is HARD-asserted to have applied before
+ * any geometry is judged (no `assumeTrue` skip — the #780/#736 rule): the row is
+ * proven horizontally contained with the keyboard UP.
+ */
+@RunWith(AndroidJUnit4::class)
+class PromptComposerRecordingRowFitProofTest {
+
+    @get:Rule
+    val compose = createAndroidComposeRule<ComponentActivity>()
+
+    private val observedImeBottomPx = mutableStateOf(0)
+    private val observedNavBottomPx = mutableStateOf(0)
+
+    @Test
+    fun recordingNotLockedRowPillsFullyWithinBand_phoneWidth() {
+        assertRecordingRowFits(locked = false, fontScale = 1.0f)
+    }
+
+    @Test
+    fun recordingNotLockedRowPillsFullyWithinBand_largeFont() {
+        // 1.3 is the widest-content case — this is a width-overflow bug, so cover
+        // the class (largest font) not just the reported 1.0 instance.
+        assertRecordingRowFits(locked = false, fontScale = 1.3f)
+    }
+
+    @Test
+    fun recordingLockedRowPillsFullyWithinBand_phoneWidth() {
+        assertRecordingRowFits(locked = true, fontScale = 1.0f)
+    }
+
+    @Test
+    fun recordingLockedRowPillsFullyWithinBand_largeFont() {
+        assertRecordingRowFits(locked = true, fontScale = 1.3f)
+    }
+
+    private fun assertRecordingRowFits(locked: Boolean, fontScale: Float) {
+        compose.activityRule.scenario.onActivity { activity ->
+            WindowCompat.setDecorFitsSystemWindows(activity.window, false)
+        }
+
+        val state = PromptComposerViewModel.UiState(
+            draft = "",
+            recording = PromptComposerViewModel.RecordingState.Recording,
+            recordingLocked = locked,
+            amplitude = 0.5f,
+            hasDetectedSpeech = true,
+            recordingElapsedMs = 14_000L,
+        )
+
+        compose.setContent {
+            PocketShellTheme {
+                val base = LocalDensity.current
+                // Scale the composition's font scale so the widest-content case is
+                // reproduced deterministically (independent of the AVD's own font
+                // setting).
+                CompositionLocalProvider(
+                    LocalDensity provides Density(density = base.density, fontScale = fontScale),
+                ) {
+                    observedImeBottomPx.value = WindowInsets.ime.getBottom(LocalDensity.current)
+                    observedNavBottomPx.value =
+                        WindowInsets.navigationBars.getBottom(LocalDensity.current)
+                    WindowInsets.statusBars.getTop(LocalDensity.current)
+
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .background(PocketShellColors.Background),
+                        // top-START so the row overflow maps predictably off the
+                        // band's RIGHT edge (the clipped-Send symptom), and the
+                        // band's left aligns with the screen left.
+                        contentAlignment = Alignment.TopStart,
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .requiredWidth(BAND_WIDTH_DP.dp)
+                                .requiredHeight(BAND_HEIGHT_DP.dp)
+                                .testTag(BAND_TAG),
+                            contentAlignment = Alignment.TopStart,
+                        ) {
+                            SheetContent(
+                                state = state,
+                                onClose = {},
+                                onDraftChange = {},
+                                onMicTap = {},
+                                onSend = {},
+                                // Non-null so the editing tools + snippets render
+                                // (they must stay MOUNTED during recording, and
+                                // must fit — the maintainer directive).
+                                onAttachFiles = {},
+                                onSnippets = {},
+                                onCancelRecording = {},
+                                onLockRecording = {},
+                            )
+                        }
+                    }
+                }
+            }
+        }
+        compose.waitForIdle()
+
+        applySyntheticInsets(
+            imeBottomPx = (IME_HEIGHT_DP * displayDensity()).toInt(),
+            navBarBottomPx = (NAV_BAR_DP * displayDensity()).toInt(),
+            statusBarTopPx = (STATUS_BAR_DP * displayDensity()).toInt(),
+        )
+        compose.waitForIdle()
+
+        // HARD-assert the synthetic keyboard actually reached Compose — otherwise
+        // we would be judging a keyboard-DOWN layout and the "keyboard up"
+        // acceptance would pass vacuously (the #780/#736 rule; no assumeTrue skip).
+        assertTrue(
+            "Synthetic ime() inset did not reach Compose; cannot validate the " +
+                "keyboard-up recording row. observedImeBottomPx=${observedImeBottomPx.value}",
+            observedImeBottomPx.value > 0,
+        )
+
+        val density = displayDensity()
+        val slopPx = CONTAINMENT_SLOP_DP * density
+        val band = bounds(BAND_TAG)
+
+        // The pills that MUST be present + fully within the band in this state,
+        // each with a not-a-sliver minimum width. A labelled pill's natural width
+        // is 70–102dp; base crushes the trailing `Send` to ~33dp, so a 56dp floor
+        // cleanly separates crushed (red) from intact (green). The editing-tools
+        // group is a fixed 3×40dp icon pill, so it uses the icon-width floor.
+        val pills = buildList {
+            add(Triple("Discard", COMPOSER_CANCEL_RECORDING_TAG, LABELLED_PILL_MIN_DP))
+            if (!locked) add(Triple("Lock", COMPOSER_LOCK_RECORDING_TAG, LABELLED_PILL_MIN_DP))
+            add(Triple("Insert", COMPOSER_TO_FIELD_TAG, LABELLED_PILL_MIN_DP))
+            add(Triple("Send", COMPOSER_STOP_SEND_TAG, LABELLED_PILL_MIN_DP))
+            // The editing tools group stays mounted during recording (the "fit
+            // everything, don't hide" directive) — prove it is present + fits too.
+            add(Triple("Tools(attach)", COMPOSER_ATTACH_TAG, ICON_MIN_DP))
+        }
+
+        for ((label, tag, minDp) in pills) {
+            val pill = bounds(tag)
+            val overflowRightPx = pill.right - band.right
+            val overflowLeftPx = band.left - pill.left
+            val widthDp = (pill.right - pill.left) / density
+            val heightDp = (pill.bottom - pill.top) / density
+            // Log geometry FIRST so a failure is diagnosable straight from the log.
+            println(
+                "ISSUE1152_FIT locked=$locked font=$fontScale $label " +
+                    "pill=[${pill.left}..${pill.right}] band=[${band.left}..${band.right}] " +
+                    "widthDp=$widthDp heightDp=$heightDp minDp=$minDp " +
+                    "overflowRightPx=$overflowRightPx overflowLeftPx=$overflowLeftPx",
+            )
+            // LOAD-BEARING: the pill must not be crushed to a sliver. On base the
+            // un-weighted overflow squeezes `Send` to ~33dp (the "S/e" sliver);
+            // the two-row fit keeps every pill at its full width.
+            assertTrue(
+                "Recording-row pill '$label' is CRUSHED to a sliver (audit D1 — " +
+                    "the overflow squeezes it below a legible width). widthDp=$widthDp " +
+                    "minDp=$minDp locked=$locked font=$fontScale. A crushed pill still " +
+                    "reports assertIsDisplayed() (the #657/F1 trap), so this width " +
+                    "floor is the real check.",
+                widthDp >= minDp,
+            )
+            assertTrue(
+                "Recording-row pill '$label' spills off the RIGHT of the band " +
+                    "(clipped/off-edge — audit D1). pill.right=${pill.right} " +
+                    "band.right=${band.right} overflowRightPx=$overflowRightPx " +
+                    "widthDp=$widthDp locked=$locked font=$fontScale",
+                pill.right <= band.right + slopPx,
+            )
+            assertTrue(
+                "Recording-row pill '$label' spills off the LEFT of the band. " +
+                    "pill.left=${pill.left} band.left=${band.left} " +
+                    "overflowLeftPx=$overflowLeftPx locked=$locked font=$fontScale",
+                pill.left >= band.left - slopPx,
+            )
+            // Additive brief-named guard: never off the WHOLE screen either.
+            compose.assertNodeFullyWithinRoot(tag)
+        }
+    }
+
+    private fun bounds(tag: String): Rect =
+        compose.onNodeWithTag(tag, useUnmergedTree = true).fetchSemanticsNode().boundsInRoot
+
+    private fun applySyntheticInsets(
+        imeBottomPx: Int,
+        navBarBottomPx: Int,
+        statusBarTopPx: Int,
+    ) {
+        compose.activityRule.scenario.onActivity { activity ->
+            val decor = activity.window.decorView
+            val insets = WindowInsetsCompat.Builder()
+                .setInsets(WindowInsetsCompat.Type.ime(), Insets.of(0, 0, 0, imeBottomPx))
+                .setInsets(
+                    WindowInsetsCompat.Type.navigationBars(),
+                    Insets.of(0, 0, 0, navBarBottomPx),
+                )
+                .setInsets(
+                    WindowInsetsCompat.Type.statusBars(),
+                    Insets.of(0, statusBarTopPx, 0, 0),
+                )
+                .setInsets(
+                    WindowInsetsCompat.Type.systemBars(),
+                    Insets.of(0, statusBarTopPx, 0, navBarBottomPx),
+                )
+                .build()
+            ViewCompat.dispatchApplyWindowInsets(decor, insets)
+        }
+    }
+
+    private fun displayDensity(): Float =
+        InstrumentationRegistry.getInstrumentation()
+            .targetContext.resources.displayMetrics.density
+
+    private companion object {
+        const val BAND_TAG = "issue1152-recording-band"
+
+        // A real phone content width (Pixel-class, matches #780's 392dp). The old
+        // single-row content (~421dp) overflows it, so BASE (pre-fix) is RED here;
+        // the two-row fix fits with comfortable margin (secondary row ~330dp,
+        // primary row ~215dp) at both 1.0 and 1.3 font scale.
+        const val BAND_WIDTH_DP = 392f
+        const val BAND_HEIGHT_DP = 760f
+
+        const val IME_HEIGHT_DP = 300f
+        const val NAV_BAR_DP = 24f
+        const val STATUS_BAR_DP = 28f
+
+        const val CONTAINMENT_SLOP_DP = 1f
+
+        // A labelled recording pill's natural width is 70–102dp (Discard/Lock/
+        // Insert/Send) across font scale 1.0–1.3; base crushes the trailing `Send`
+        // to ~33dp. 56dp is the not-a-sliver floor between them.
+        const val LABELLED_PILL_MIN_DP = 56f
+        // The editing-tools group is a fixed 3×40dp icon pill; 36dp is its floor.
+        const val ICON_MIN_DP = 36f
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerSheet.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerSheet.kt
@@ -924,7 +924,6 @@ internal fun SheetContent(
                         // newest words always stay visible.
                         liveTranscript = state.liveTranscript,
                         locked = state.recordingLocked,
-                        onCancel = onCancelRecording,
                     )
                 }
 
@@ -1186,6 +1185,20 @@ internal fun SheetContent(
         //  - Right, Transcribing: Cancel + "Send" (arms the queued send for
         //    the in-flight round-trip).
         val attachmentBusy = attachmentUploading != null
+        // Issue #1152: the maintainer's directive is FIT EVERYTHING — never hide a
+        // control to make room. The old single row packed the tools group + Lock +
+        // Insert + Send onto one line, overflowed the usable width, and clipped
+        // `Send` off the right edge (the cyan "S/e" sliver — audit D1).
+        //
+        // The fix keeps this STABLE outer row (it carries the mic
+        // swipe-up-to-lock pointerInput, which MUST survive the Idle→Recording
+        // recompose — the finger is held continuously through the transition, so
+        // the gesture node cannot be replaced) with the editing-tools group +
+        // weighted gap, and makes only the RIGHT CLUSTER state-driven. The editing
+        // tools (📎 attach · {} snippets · / command) therefore stay MOUNTED in
+        // every state. During Recording the right cluster stacks the four pills as
+        // TWO rows ([Discard · Lock] over [Insert · Send]) so all controls fit —
+        // nothing is clipped or hidden — at font scale 1.0 and 1.3, locked and not.
         Row(
             modifier = Modifier
                 .fillMaxWidth()
@@ -1201,75 +1214,25 @@ internal fun SheetContent(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            // Issue #701: the left tools — 📎 attach + `{}` snippets — sit in a
-            // single rounded `SurfaceElev` group rather than as two bare ghost
-            // icons floating at the far edge. The earlier layout left the row
-            // looking unbalanced: two lonely icons hard-left, a weak Send
-            // hard-right, and a wide dead gap between them (the maintainer's
-            // "big empty gap" complaint). Grouping the secondary tools into one
-            // pill gives the row a deliberate left anchor that visually balances
-            // the filled Send + mic cluster on the right; the `weight(1f)` space
-            // between them now reads as intentional breathing room. Attachment
-            // picking stays single-flight while a batch is uploading, but
-            // typing, editing, dictation, and text-only Send remain live.
-            Row(
-                modifier = Modifier
-                    .clip(RoundedCornerShape(22.dp))
-                    .background(PocketShellColors.SurfaceElev, RoundedCornerShape(22.dp))
-                    .padding(horizontal = 2.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(2.dp),
-            ) {
-                AttachIconButton(
-                    onClick = { onAttachFiles?.invoke() },
-                    enabled = !isTranscribing && !attachmentBusy && onAttachFiles != null,
-                    modifier = Modifier.testTag(COMPOSER_ATTACH_TAG),
-                )
-                SnippetsIconButton(
-                    onClick = { onSnippets?.invoke() },
-                    enabled = !isTranscribing && !attachmentBusy && onSnippets != null,
-                    modifier = Modifier.testTag(COMPOSER_SNIPPETS_TAG),
-                )
-                // Issue #787: the single consolidated `/` slash-command entry.
-                // Disabled on shell panes (`agentKind == null` → empty catalog,
-                // nothing to show), matching the prior key-bar / chip gating.
-                SlashIconButton(
-                    onClick = onSlashTap,
-                    enabled = !isTranscribing && !attachmentBusy && agentKind != null,
-                    modifier = Modifier.testTag(COMPOSER_SLASH_TAG),
-                )
-            }
-            // Issue #453: the separate keyboard icon is removed from the Idle
-            // row — it is not in the mockup and cluttered the clean idle. The
-            // editable draft field itself raises the soft IME the moment it is
-            // tapped/focused (ComposerDraftField), so there is a single,
-            // obvious way to bring up the keyboard: tap the input. The
-            // [draftFocusRequester] is still used to focus the field after a
-            // dictation transcript lands.
-
+            ComposerEditingToolsGroup(
+                isTranscribing = isTranscribing,
+                attachmentBusy = attachmentBusy,
+                agentKind = agentKind,
+                onAttachFiles = onAttachFiles,
+                onSnippets = onSnippets,
+                onSlashTap = onSlashTap,
+            )
             Spacer(modifier = Modifier.weight(1f))
 
-            // Right cluster is state-driven.
             when (state.recording) {
                 PromptComposerViewModel.RecordingState.Idle -> {
-                    // Issue #453: match the mockup's compact toolbar order —
-                    // `Send` (text + arrow) FIRST, then a small mic disc at the
-                    // far right, both sitting tight together. The old order
-                    // (mic-then-Send) was reversed versus the mockup.
-                    //
-                    // Issue #491: gate on the LIVE editor text, not the
-                    // (possibly stale) ViewModel draft — the IME composing
-                    // region lands in `draftFieldValue.text` immediately, so
-                    // a short typed prompt enables Send without waiting for an
-                    // IME commit. Staged attachment chips also enable Send
-                    // for attachment-only prompts. [commitAndSend] flushes
-                    // the live text into the ViewModel before dispatching, so
-                    // the tap always delivers.
+                    // Issue #453/#701: single primary Send pill + the mic disc.
+                    // Issue #491: gate Send on the LIVE editor text (or staged
+                    // attachments), not the possibly-stale ViewModel draft, and
+                    // disable while a send is in flight (#745). [commitAndSend]
+                    // flushes the live text before dispatching so the tap delivers.
                     val sendEnabled =
                         (draftFieldValue.text.isNotEmpty() || state.attachments.isNotEmpty()) &&
-                            // Issue #745: while a send is in flight the button is
-                            // disabled and shows "Sending…" — a second tap can't
-                            // queue another request on top of the one resolving.
                             !state.sendInFlight
                     SendButton(
                         onClick = commitAndSend,
@@ -1278,8 +1241,9 @@ internal fun SheetContent(
                         modifier = Modifier.testTag(COMPOSER_SEND_ENTER_TAG),
                     )
                     Spacer(modifier = Modifier.width(8.dp))
-                    // Small cyan mic disc at the far right (the mockup's mic).
-                    // Sits AFTER Send so the row reads "type + send, or dictate".
+                    // Small cyan mic disc at the far right (the mockup's mic). Its
+                    // bounds (relative to THIS outer row — the gesture node) are the
+                    // swipe-up gesture's press-start target.
                     MicTriggerButton(
                         onClick = onMicTap,
                         enabled = true,
@@ -1292,59 +1256,53 @@ internal fun SheetContent(
                 }
 
                 PromptComposerViewModel.RecordingState.Recording -> {
-                    // Issue #508: two explicit stop actions replace the old
-                    // persistent Auto-send toggle. The choice is made
-                    // per-recording, at the moment of stopping:
-                    //  - "Insert": stop + transcribe, drop the text into the
-                    //    editable composer field (nothing sent). The user can
-                    //    then attach a screenshot / edit before sending. This
-                    //    is the historic [onMicTap] stop path — the transcript
-                    //    appends to the draft and the FSM lands back in Idle.
-                    //  - "Send": stop + transcribe + send immediately. Routes
-                    //    through [onSend(true)] which (while Recording) queues
-                    //    the send and stops the recorder; the queued send fires
-                    //    once Whisper returns with the combined transcript.
-                    // The non-transcribing discard action is intentionally in
-                    // the recording panel itself, not this row, so it cannot be
-                    // confused with either stop+transcribe choice.
-                    //
-                    // Issue #585: a DETERMINISTIC hands-free lock affordance.
-                    // The Telegram-style swipe-up-to-lock gesture (below) is the
-                    // one-gesture path, but it competes with the
-                    // ModalBottomSheet's drag-to-dismiss and that velocity-driven
-                    // arbitration repeatedly failed on the maintainer's real
-                    // device while passing every emulator round (this issue's 5
-                    // reopens). A single-tap Lock button cannot be stolen by the
-                    // sheet drag — it is the device-independent way to "release
-                    // the finger and keep recording". It shows only BEFORE the
-                    // recording is locked (once locked, the recording panel shows
-                    // the persistent lock indicator instead).
-                    if (!state.recordingLocked) {
-                        LockRecordingButton(
-                            onClick = onLockRecording,
-                            modifier = Modifier.testTag(COMPOSER_LOCK_RECORDING_TAG),
-                        )
-                        Spacer(modifier = Modifier.width(4.dp))
+                    // Issue #1152: the four recording pills stack as two right-
+                    // aligned rows so they all fit next to the mounted tools group.
+                    //  - [Discard · Lock]: Discard (drop this audio — pulled OUT of
+                    //    the waveform surface into a proper outlined secondary pill
+                    //    so it no longer collides with the bars / reads disabled,
+                    //    audit B/D2/D3) and, until locked, Lock (#585 hands-free).
+                    //  - [Insert · Send]: the two "how do you want to end this
+                    //    dictation" stop actions. Every pill shares one 48dp
+                    //    baseline (audit D4).
+                    Column(
+                        horizontalAlignment = Alignment.End,
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            DiscardRecordingButton(
+                                onClick = onCancelRecording,
+                                modifier = Modifier.testTag(COMPOSER_CANCEL_RECORDING_TAG),
+                            )
+                            if (!state.recordingLocked) {
+                                LockRecordingButton(
+                                    onClick = onLockRecording,
+                                    modifier = Modifier.testTag(COMPOSER_LOCK_RECORDING_TAG),
+                                )
+                            }
+                        }
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            ToFieldButton(
+                                onClick = onMicTap,
+                                modifier = Modifier.testTag(COMPOSER_TO_FIELD_TAG),
+                            )
+                            StopSendButton(
+                                onClick = { onSend(true) },
+                                modifier = Modifier.testTag(COMPOSER_STOP_SEND_TAG),
+                            )
+                        }
                     }
-                    ToFieldButton(
-                        onClick = onMicTap,
-                        modifier = Modifier.testTag(COMPOSER_TO_FIELD_TAG),
-                    )
-                    Spacer(modifier = Modifier.width(4.dp))
-                    StopSendButton(
-                        onClick = { onSend(true) },
-                        modifier = Modifier.testTag(COMPOSER_STOP_SEND_TAG),
-                    )
                 }
 
                 PromptComposerViewModel.RecordingState.Transcribing -> {
-                    // Issue #508: the audio is already captured and the Whisper
-                    // round-trip is in flight, but the user can still pick where
-                    // the transcript lands once it returns. "Insert" is a
-                    // no-op on the in-flight request — the transcript appends to
-                    // the draft by default — so the only extra action surfaced
-                    // here is "Send" (arms the queued send) plus Cancel (aborts
-                    // the round-trip). No persistent Auto-send toggle.
+                    // Issue #508: Cancel aborts the in-flight round-trip; Send arms
+                    // the queued send. These two fit on one line next to the tools.
                     GhostButton(
                         label = "Cancel",
                         onClick = onCancelTranscription,
@@ -1532,7 +1490,6 @@ private fun RecordingSurface(
     elapsedLabel: String,
     liveTranscript: String?,
     locked: Boolean,
-    onCancel: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -1561,10 +1518,13 @@ private fun RecordingSurface(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(12.dp),
         ) {
+            // Issue #1152: the elapsed timer is the primary "how long have I been
+            // recording" signal, so bump it to 15sp SemiBold — it was the smallest
+            // element next to the 32dp waveform (audit D6).
             Text(
                 text = elapsedLabel,
                 color = PocketShellColors.Accent,
-                fontSize = 13.sp,
+                fontSize = 15.sp,
                 fontWeight = FontWeight.SemiBold,
                 modifier = Modifier.testTag(COMPOSER_TIMER_TAG),
             )
@@ -1579,12 +1539,17 @@ private fun RecordingSurface(
                         .semantics { contentDescription = "Recording locked" },
                 )
             }
+            // Issue #1152: Discard moved OUT of this surface into the bottom action
+            // row (an outlined secondary pill), so the surface is now just
+            // [timer · (lock?) · waveform]. A small end inset keeps the amplitude
+            // bars from kissing the surface edge (audit C/D2).
             Waveform(
                 amplitude = amplitude,
                 active = capturing,
                 modifier = Modifier
                     .weight(1f)
                     .height(32.dp)
+                    .padding(end = 4.dp)
                     .testTag(COMPOSER_WAVEFORM_TAG)
                     .semantics {
                         contentDescription = if (capturing) {
@@ -1594,7 +1559,6 @@ private fun RecordingSurface(
                         }
                     },
             )
-            DiscardRecordingButton(onClick = onCancel)
         }
         // Issue #585: until the recording is locked, surface a one-line hint so
         // the user knows the hands-free path exists and how to reach it — "tap
@@ -1772,10 +1736,16 @@ private fun TranscribingSurface(
 }
 
 /**
- * Issue #174: explicit recording-only discard control. It lives inside the
- * active recording panel, next to the waveform, so it reads as "discard this
- * captured audio" rather than the header close `×` that dismisses the whole
- * composer. Tapping it stops the mic/recognizer and drops the live buffer.
+ * Issue #174 / #1152: explicit recording-only discard control. It stops the
+ * mic/recognizer and drops the live buffer, distinct from the header close `×`
+ * that dismisses the whole composer.
+ *
+ * Issue #1152: pulled OUT of the waveform surface (where its bare muted text
+ * collided with the amplitude bars and read as disabled — audit D2/D3) into the
+ * bottom action row as a proper OUTLINED secondary pill on the shared recording
+ * pill baseline (44dp visual / 48dp touch). The `testTag` is now supplied by the
+ * caller via [modifier] (it moved from the surface to the row), so the tap-target
+ * node measured by tests includes the touch inset.
  */
 @Composable
 private fun DiscardRecordingButton(
@@ -1784,11 +1754,13 @@ private fun DiscardRecordingButton(
 ) {
     Row(
         modifier = modifier
-            .heightIn(min = 48.dp)
+            .height(ComposerActionPillHeight)
+            .clip(ComposerActionPillShape)
+            .background(PocketShellColors.SurfaceElev, ComposerActionPillShape)
+            .border(1.dp, PocketShellColors.Border, ComposerActionPillShape)
             .clickable(role = Role.Button, onClick = onClick)
             .semantics { contentDescription = "Discard recording without transcribing" }
-            .testTag(COMPOSER_CANCEL_RECORDING_TAG)
-            .padding(horizontal = 8.dp),
+            .padding(horizontal = 14.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(
@@ -1809,6 +1781,60 @@ private fun DiscardRecordingButton(
 private val ComposerActionPillRadius = 22.dp
 private val ComposerActionPillShape = RoundedCornerShape(ComposerActionPillRadius)
 
+// Issue #1152: one baseline HEIGHT for EVERY recording-row pill (Discard / Lock /
+// Insert / Send) so the row reads as a single deliberate control ladder instead
+// of the old 40/44/48dp mix (audit D4). 48dp is the design-system tapTargetMin,
+// so a single 48dp pill is both the visual baseline and a full touch target —
+// simpler and more robust than a 44dp fill + touch-inset padding (the inset is
+// not reflected in the tagged node's measured bounds, so it under-reports the
+// touch target below 48dp — the PromptComposerCancelRecordingTest ≥48dp guard).
+private val ComposerActionPillHeight = 48.dp
+
+/**
+ * Issue #1152: the editing tools group (📎 attach · {} snippets · / command) as a
+ * single rounded `SurfaceElev` pill. It stays MOUNTED in every composer state
+ * (Idle, Recording, Transcribing) — the maintainer's directive is to fit all
+ * controls, never hide them — so it is factored out here and rendered from each
+ * state branch of the bottom controls. Attachment picking stays single-flight
+ * while a batch is uploading; the slash entry is disabled on shell panes
+ * (`agentKind == null`, #787) and everything is disabled during transcription.
+ */
+@Composable
+private fun ComposerEditingToolsGroup(
+    isTranscribing: Boolean,
+    attachmentBusy: Boolean,
+    agentKind: AgentKind?,
+    onAttachFiles: (() -> Unit)?,
+    onSnippets: (() -> Unit)?,
+    onSlashTap: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .clip(RoundedCornerShape(22.dp))
+            .background(PocketShellColors.SurfaceElev, RoundedCornerShape(22.dp))
+            .padding(horizontal = 2.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+        AttachIconButton(
+            onClick = { onAttachFiles?.invoke() },
+            enabled = !isTranscribing && !attachmentBusy && onAttachFiles != null,
+            modifier = Modifier.testTag(COMPOSER_ATTACH_TAG),
+        )
+        SnippetsIconButton(
+            onClick = { onSnippets?.invoke() },
+            enabled = !isTranscribing && !attachmentBusy && onSnippets != null,
+            modifier = Modifier.testTag(COMPOSER_SNIPPETS_TAG),
+        )
+        SlashIconButton(
+            onClick = onSlashTap,
+            enabled = !isTranscribing && !attachmentBusy && agentKind != null,
+            modifier = Modifier.testTag(COMPOSER_SLASH_TAG),
+        )
+    }
+}
+
 /**
  * Issue #585: the deterministic hands-free LOCK affordance shown while
  * Recording but not yet locked. A single tap calls [onLockRecording] so the
@@ -1827,7 +1853,9 @@ private fun LockRecordingButton(
 ) {
     Row(
         modifier = modifier
-            .heightIn(min = 48.dp)
+            // Issue #1152: shared 48dp recording pill baseline so Lock lines up
+            // with Discard / Insert / Send (audit D4).
+            .height(ComposerActionPillHeight)
             .clip(ComposerActionPillShape)
             .background(
                 color = PocketShellColors.SurfaceElev,
@@ -1947,15 +1975,16 @@ private fun ToFieldButton(
 ) {
     Row(
         modifier = modifier
-            .height(44.dp)
+            // Issue #1152: shared 48dp recording pill baseline.
+            .height(ComposerActionPillHeight)
             .background(
                 color = PocketShellColors.SurfaceElev,
-                shape = RoundedCornerShape(22.dp),
+                shape = ComposerActionPillShape,
             )
             .border(
                 width = 1.dp,
                 color = PocketShellColors.Border,
-                shape = RoundedCornerShape(22.dp),
+                shape = ComposerActionPillShape,
             )
             .clickable(role = Role.Button, onClick = onClick)
             .semantics { contentDescription = "Insert transcript into prompt" }
@@ -1985,10 +2014,11 @@ private fun StopSendButton(
 ) {
     Row(
         modifier = modifier
-            .height(44.dp)
+            // Issue #1152: shared 48dp recording pill baseline.
+            .height(ComposerActionPillHeight)
             .background(
                 color = PocketShellColors.Accent,
-                shape = RoundedCornerShape(22.dp),
+                shape = ComposerActionPillShape,
             )
             .clickable(role = Role.Button, onClick = onClick)
             .semantics { contentDescription = "Stop and send the transcript" }

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -352,6 +352,18 @@ JOURNEY_CLASSES=(
   # regression cannot silently return. It lives under com.pocketshell.app.composer,
   # not the proof prefix, so it carries its fully-qualified name directly.
   "com.pocketshell.app.composer.PromptComposerDiscardE2eTest"
+  # ADDED (#1152): the recording-not-locked composer bottom row overflowed its
+  # width and CLIPPED `Send` off the right edge (the cyan "S/e" sliver — audit
+  # D1). This proof composes the production SheetContent in the recording state
+  # (NOT-LOCKED and LOCKED), keyboard-UP via the #780 synthetic-inset model,
+  # pinned to a fixed phone-width band, at font scale 1.0 AND 1.3, and HARD-asserts
+  # every recording-row pill (Discard/Lock/Insert/Send) + the still-mounted
+  # editing-tools group is fully CONTAINED within the band (band-relative, not a
+  # bare assertIsDisplayed() a clipped pill still passes — #657/F1). RED on the
+  # unfixed single-row layout (Send spills off the band); GREEN with the two-row
+  # fit. No Docker fixture, no self-skip. Lives under com.pocketshell.app.composer,
+  # not the proof prefix, so it carries its fully-qualified name directly.
+  "com.pocketshell.app.composer.PromptComposerRecordingRowFitProofTest"
   # ADDED (#585): Telegram-style hold-and-pull-up on the composer mic must start
   # recording and lock it hands-free in one gesture, with the real
   # ModalBottomSheet still mounted so the mic detector competes with the sheet

--- a/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenders.kt
+++ b/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenders.kt
@@ -2055,6 +2055,178 @@ class DesignRenders {
     }
 
     /**
+     * Issue #1152: static mirror of the redesigned VOICE-RECORDING (not-locked)
+     * composer bottom area. The old single row overflowed and clipped `Send` off
+     * the right edge (audit D1); the maintainer directive is FIT EVERYTHING — keep
+     * the editing tools mounted, hide nothing. This mirrors the fix:
+     *  - recording surface: [00:14 timer · waveform] (Discard pulled out of it);
+     *  - bottom row: the mounted [📎 {} /] tools group anchors the left, then a
+     *    weighted gap, then the four pills stacked as two right-aligned rows —
+     *    [Discard (outlined) · Lock (accent-outlined)] over [Insert · Send].
+     *
+     * Caveat (#555): the real recording row lives in the `app` module's
+     * `SheetContent`, which the ui-kit harness can't import, so this mirrors its
+     * layout with the same tokens. It is the fast first design check for the
+     * fit/regroup; the acceptance is the full-device emulator screenshot in the
+     * recording-not-locked state.
+     */
+    @Test
+    fun composerRecordingControlsRow() = render("composer-recording-controls-row") {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(PocketShellColors.Surface, RoundedCornerShape(20.dp))
+                .padding(horizontal = 18.dp, vertical = 14.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            // Recording surface: timer + waveform (Discard no longer lives here).
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(PocketShellColors.SurfaceElev, RoundedCornerShape(12.dp))
+                    .border(1.dp, PocketShellColors.Border, RoundedCornerShape(12.dp))
+                    .padding(horizontal = 14.dp, vertical = 10.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                Text(
+                    text = "00:14",
+                    color = PocketShellColors.Accent,
+                    fontSize = 15.sp,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Box(
+                    modifier = Modifier
+                        .weight(1f)
+                        .height(32.dp),
+                    contentAlignment = Alignment.CenterStart,
+                ) {
+                    Text(
+                        text = "▁▂▄▆█▆▄▂▁▂▄▆█▆▄▂▁▂▄▆",
+                        color = PocketShellColors.Accent,
+                        fontSize = 16.sp,
+                    )
+                }
+            }
+            // Bottom row: mounted tools group (left) + weighted gap + the four
+            // pills stacked as two right-aligned rows.
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Row(
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(22.dp))
+                        .background(PocketShellColors.SurfaceElev, RoundedCornerShape(22.dp))
+                        .padding(horizontal = 2.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(2.dp),
+                ) {
+                    Box(modifier = Modifier.size(40.dp), contentAlignment = Alignment.Center) {
+                        Text(text = "📎", color = PocketShellColors.TextSecondary, fontSize = 18.sp)
+                    }
+                    Box(modifier = Modifier.size(40.dp), contentAlignment = Alignment.Center) {
+                        Text(
+                            text = "{ }",
+                            color = PocketShellColors.TextSecondary,
+                            fontSize = 16.sp,
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                    }
+                    Box(modifier = Modifier.size(40.dp), contentAlignment = Alignment.Center) {
+                        Text(
+                            text = "/",
+                            color = PocketShellColors.TextSecondary,
+                            fontSize = 20.sp,
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                    }
+                }
+                Spacer(Modifier.weight(1f))
+                Column(
+                    horizontalAlignment = Alignment.End,
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        // Discard — outlined secondary pill (48dp).
+                        Box(
+                            modifier = Modifier
+                                .height(48.dp)
+                                .clip(RoundedCornerShape(22.dp))
+                                .background(PocketShellColors.SurfaceElev, RoundedCornerShape(22.dp))
+                                .border(1.dp, PocketShellColors.Border, RoundedCornerShape(22.dp))
+                                .padding(horizontal = 14.dp),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            Text(
+                                text = "Discard",
+                                color = PocketShellColors.TextSecondary,
+                                fontSize = 13.sp,
+                                fontWeight = FontWeight.SemiBold,
+                            )
+                        }
+                        // Lock — accent-outlined pill (48dp).
+                        Row(
+                            modifier = Modifier
+                                .height(48.dp)
+                                .clip(RoundedCornerShape(22.dp))
+                                .background(PocketShellColors.SurfaceElev, RoundedCornerShape(22.dp))
+                                .border(1.dp, PocketShellColors.Accent, RoundedCornerShape(22.dp))
+                                .padding(horizontal = 12.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(6.dp),
+                        ) {
+                            Text(text = "🔒", fontSize = 13.sp)
+                            Text(
+                                text = "Lock",
+                                color = PocketShellColors.Accent,
+                                fontSize = 13.sp,
+                                fontWeight = FontWeight.SemiBold,
+                            )
+                        }
+                    }
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Box(
+                            modifier = Modifier
+                                .height(48.dp)
+                                .clip(RoundedCornerShape(22.dp))
+                                .background(PocketShellColors.SurfaceElev, RoundedCornerShape(22.dp))
+                                .border(1.dp, PocketShellColors.Border, RoundedCornerShape(22.dp))
+                                .padding(horizontal = 16.dp),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            Text(
+                                text = "Insert",
+                                color = PocketShellColors.Text,
+                                fontSize = 14.sp,
+                                fontWeight = FontWeight.SemiBold,
+                            )
+                        }
+                        Row(
+                            modifier = Modifier
+                                .height(48.dp)
+                                .clip(RoundedCornerShape(22.dp))
+                                .background(PocketShellColors.Accent, RoundedCornerShape(22.dp))
+                                .padding(horizontal = 16.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            Text(
+                                text = "Send",
+                                color = PocketShellColors.OnAccent,
+                                fontSize = 14.sp,
+                                fontWeight = FontWeight.SemiBold,
+                            )
+                            Text(text = "➤", color = PocketShellColors.OnAccent, fontSize = 13.sp)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
      * Issue #765: the LONG-draft, keyboard-up composer. The maintainer reported
      * that with a long multi-line message and the soft keyboard up the draft
      * text gets "cut off" and the caret / last line being typed is not visible.


### PR DESCRIPTION
Maintainer 'it's terrible' + 'fit everything, don't hide'. Fixes the recording-not-locked row overflow that clipped Send off-screen. Reviewer APPROVED on emulator: red→green driven this run (Send 33dp sliver → 90-102dp, containment at 1.0 AND 1.3), full-device screenshot confirms all controls visible + tools mounted (nothing hidden), 15 recording tests green, no regression. Local gate: guards PASS, app+androidTest compile.\n\nCloses #1152