### PR TITLE
terminal: unify the heal oracle to close the black-band dead-zone (#1176)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -10513,7 +10513,21 @@ public class TmuxSessionViewModel @Inject constructor(
             val activePane = activeVisiblePane() ?: return true
             val blank = activePane.terminalState.visibleScreenIsBlank()
             val partialBlank = activePane.terminalState.visibleScreenIsPartiallyBlank()
-            if (!blank && !partialBlank) return true
+            if (!blank && !partialBlank) {
+                // Issue #1176 (GAP C): a >3-line half-black BAND (the GAP-A dead-zone) reads
+                // NON-blank AND NON-partial-black locally, yet it lost most of the frame tmux
+                // still holds. The pre-#1176 gate revealed it UNHEALED — the black band only
+                // recovered ~4s later at the steady watchdog (or never, in the dead-zone). Route
+                // the reveal through the unified capture-diff oracle so a fast switch reveals a
+                // HEALED pane. Cheap local pre-check first (no capture on a confidently-full
+                // pane); [healActivePaneIfStaleRender] then confirms against tmux's authoritative
+                // capture with [TerminalSurfaceState.visibleRenderLostFrameVsCapture] and heals
+                // ONLY if the frame is truly lost — bounded to ONE capture, no reveal thrash.
+                if (activePane.terminalState.visibleRenderMayHaveLostFrame()) {
+                    healActivePaneIfStaleRender(client, activePane, refreshGuard)
+                }
+                return true
+            }
             // Issue #941 (black-screen B1): a plain session switch can reveal a
             // PARTIAL-black pane (one live line, the rest of the prior viewport
             // gone). That reads "not blank", so the pre-#941 gate passed it and the
@@ -15352,12 +15366,18 @@ public class TmuxSessionViewModel @Inject constructor(
     private fun maybeHealActivePaneOnNoOpResize(client: TmuxClient, target: ConnectionTarget) {
         if (client.disconnected.value) return
         val activePane = activeVisiblePane() ?: return
-        // Only pay for a capture when the active pane looks lost (fully blank or
-        // the "one live line, rest blank" partial-blank). A normally-painted pane
-        // needs no heal — this keeps the no-op resize cheap.
+        // Only pay for a capture when the active pane looks lost. A normally-painted pane needs
+        // no heal — this keeps the no-op resize cheap.
         val blank = activePane.terminalState.visibleScreenIsBlank()
         val partialBlank = activePane.terminalState.visibleScreenIsPartiallyBlank()
-        if (!blank && !partialBlank) return
+        // Issue #1176 (GAP C): a keyboard/resize toggle can leave the idle agent's redraw as a
+        // >3-line half-black BAND (the GAP-A dead-zone) that reads NON-blank and NON-partial-black
+        // locally — the pre-#1176 gate SKIPPED it and left the band until the ~4s watchdog. Widen
+        // the local capture-gate to [visibleRenderMayHaveLostFrame] (a superset of blank/partial
+        // that also catches the band), then route the non-blank band through the unified
+        // capture-diff oracle so a correct-but-sparse pane never flickers.
+        val mayHaveLostFrame = activePane.terminalState.visibleRenderMayHaveLostFrame()
+        if (!mayHaveLostFrame) return
         val attachGeneration = connectGeneration
         Log.i(
             ISSUE_145_RECONNECT_TAG,
@@ -15367,13 +15387,21 @@ public class TmuxSessionViewModel @Inject constructor(
         )
         bridgeScope.launch {
             if (clientRef !== client) return@launch
-            reseedActivePaneForReattach(
-                RuntimeRefreshGuard(
-                    generation = attachGeneration,
-                    target = target,
-                    client = client,
-                ),
+            val guard = RuntimeRefreshGuard(
+                generation = attachGeneration,
+                target = target,
+                client = client,
             )
+            if (blank || partialBlank) {
+                // Fully-blank / ≤3-line partial-black: the existing UNCONDITIONAL full-viewport
+                // restore (forces a `C-l` repaint, then re-captures tmux's authoritative grid).
+                reseedActivePaneForReattach(guard)
+            } else {
+                // Dead-zone half-black BAND: confirm against tmux's capture with the unified
+                // oracle and heal ONLY if the frame is truly lost — no clear-to-repaint flicker
+                // on a legitimately-sparse-but-correct pane (capture ≈ render → no heal).
+                healActivePaneIfStaleRender(client, activePane, guard)
+            }
         }
     }
 

--- a/app/src/test/java/com/pocketshell/app/tmux/DeadZoneBandRevealResizeHealTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/DeadZoneBandRevealResizeHealTest.kt
@@ -1,0 +1,466 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.app.sessions.ActiveTmuxClients
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.SshLeaseConnector
+import com.pocketshell.core.ssh.SshLeaseManager
+import com.pocketshell.core.ssh.SshLeaseTarget
+import com.pocketshell.core.ssh.SshPortForward
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshShell
+import com.pocketshell.core.tmux.CommandResponse
+import com.pocketshell.core.tmux.TmuxClientFactory
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+import java.io.InputStream
+
+/**
+ * Issue #1176 (GAP C) — the switch-reveal gate ([TmuxSessionViewModel.awaitActivePaneSeededOrLoading])
+ * and the no-op-resize heal ([TmuxSessionViewModel.maybeHealActivePaneOnNoOpResize]) now route a
+ * DEAD-ZONE half-black BAND through the UNIFIED [TerminalSurfaceState.visibleRenderLostFrameVsCapture]
+ * oracle, so a fast switch / keyboard toggle reveals a HEALED pane instead of a band that only
+ * recovers ~4s later at the steady watchdog (or never, in the dead-zone).
+ *
+ * ## The dead-zone band
+ *
+ * A render with >50% of the visible rows live (clears the old 0.50 LINE ceiling) AND >25% of
+ * tmux's chars (clears the old 0.25 CHAR ceiling) reads NON-blank AND NON-partial-black locally,
+ * so the pre-#1176 gates (`blank || partialBlank`) SKIPPED it. Both gates now widen their local
+ * cost-gate to [TerminalSurfaceState.visibleRenderMayHaveLostFrame] and confirm against tmux's
+ * authoritative capture before healing.
+ *
+ * ## RED → GREEN (D33/G1/G10) — driving the REAL production entry points
+ *
+ *  - [switchRevealHealsDeadZoneBand] drives the real reveal gate seam; on base it issued NO heal
+ *    capture (the band read non-blank → gate returned "seeded") and revealed unhealed (RED). With
+ *    the fix the gate issues exactly one heal `capture-pane -p -e` and restores the frame (GREEN).
+ *  - [noOpResizeHealsDeadZoneBand] drives the real no-op-resize seam with the same red→green.
+ *
+ * ## Class coverage / over-heal guard
+ *
+ *  - Both a SHELL and an AGENT dead-zone band are covered (the switch case uses each).
+ *  - [switchRevealDoesNotHealADensePane] / [noOpResizeDoesNotHealADensePane] confirm a DENSE,
+ *    correctly-painted pane issues NO heal capture at either gate (no reveal-latency / thrash).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class DeadZoneBandRevealResizeHealTest {
+
+    private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val createdVms = mutableListOf<TmuxSessionViewModel>()
+
+    @After
+    fun tearDown() {
+        factoryScope.cancel()
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // (1) SWITCH-reveal heals a dead-zone band — SHELL pane.
+    // -------------------------------------------------------------------------------------------
+
+    @Test
+    fun switchRevealHealsDeadZoneBand() = runVmTest {
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%1")
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == "%1" }
+
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+
+        overpaintDeadZoneBand(pane)
+        assertDeadZonePreconditions(pane)
+
+        client.capturePaneResponses.addLast(
+            CommandResponse(number = 99L, output = FULL_FRAME, isError = false),
+        )
+        val healCapturesBefore = client.healCaptureCount()
+
+        // THE REAL ENTRY POINT: the switch-reveal gate over the active pane.
+        val revealed = vm.awaitActivePaneSeededOrLoadingForTest(client)
+        advanceUntilIdle()
+
+        assertTrue(
+            "REGRESSION (#1176 GAP C): the switch-reveal gate must confirm a dead-zone band " +
+                "against tmux and heal it (issue exactly one `capture-pane -p -e`). On base the " +
+                "gate saw a non-blank/non-partial band and revealed it UNHEALED.",
+            client.healCaptureCount() > healCapturesBefore,
+        )
+        assertTrue("the gate still reveals (does not spin)", revealed)
+        assertTrue(
+            "the heal restored the FULL frame from tmux's authoritative grid",
+            renderedTranscriptFor(pane).contains(FULL_FRAME_MARKER),
+        )
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // (2) SWITCH-reveal heals a dead-zone band — AGENT pane (class coverage: shell + agent).
+    // -------------------------------------------------------------------------------------------
+
+    @Test
+    fun switchRevealHealsDeadZoneBandAgentPane() = runVmTest {
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%2", title = "codex")
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == "%2" }
+
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+
+        overpaintDeadZoneBand(pane)
+        assertDeadZonePreconditions(pane)
+
+        client.capturePaneResponses.addLast(
+            CommandResponse(number = 99L, output = FULL_FRAME, isError = false),
+        )
+        val healCapturesBefore = client.healCaptureCount()
+
+        val revealed = vm.awaitActivePaneSeededOrLoadingForTest(client)
+        advanceUntilIdle()
+
+        assertTrue(
+            "REGRESSION (#1176 GAP C, agent pane): the reveal gate heals a dead-zone band on an " +
+                "agent pane too",
+            client.healCaptureCount() > healCapturesBefore,
+        )
+        assertTrue(revealed)
+        assertTrue(renderedTranscriptFor(pane).contains(FULL_FRAME_MARKER))
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // (3) NO-OP resize heals a dead-zone band (keyboard/IME toggle) — AGENT pane.
+    // -------------------------------------------------------------------------------------------
+
+    @Test
+    fun noOpResizeHealsDeadZoneBand() = runVmTest {
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%3", title = "codex")
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == "%3" }
+
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+
+        overpaintDeadZoneBand(pane)
+        assertDeadZonePreconditions(pane)
+
+        client.capturePaneResponses.addLast(
+            CommandResponse(number = 99L, output = FULL_FRAME, isError = false),
+        )
+        val healCapturesBefore = client.healCaptureCount()
+
+        // THE REAL ENTRY POINT: a same-dimension (no-op) resize, e.g. a keyboard dismissal.
+        assertTrue(vm.triggerSameDimensionResizeHealForTest())
+        advanceUntilIdle()
+
+        assertTrue(
+            "REGRESSION (#1176 GAP C): a no-op resize (keyboard toggle) must confirm a dead-zone " +
+                "band against tmux and heal it. On base the `blank || partialBlank` pre-check " +
+                "skipped the non-blank band and left it until the ~4s watchdog.",
+            client.healCaptureCount() > healCapturesBefore,
+        )
+        assertTrue(
+            "the heal restored the FULL frame",
+            renderedTranscriptFor(pane).contains(FULL_FRAME_MARKER),
+        )
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // (4) OVER-HEAL GUARD: a DENSE pane must NOT heal at the reveal gate.
+    // -------------------------------------------------------------------------------------------
+
+    @Test
+    fun switchRevealDoesNotHealADensePane() = runVmTest {
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%4")
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == "%4" }
+
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+
+        overpaintDensePane(pane)
+        assertFalse(pane.terminalState.visibleScreenIsBlank())
+        assertFalse(pane.terminalState.visibleScreenIsPartiallyBlank())
+        assertFalse(
+            "precondition: a dense pane is confidently full → the local capture-gate is FALSE, " +
+                "so no capture is paid",
+            pane.terminalState.visibleRenderMayHaveLostFrame(),
+        )
+
+        client.capturePaneResponses.addLast(
+            CommandResponse(number = 99L, output = FULL_FRAME, isError = false),
+        )
+        val healCapturesBefore = client.healCaptureCount()
+
+        vm.awaitActivePaneSeededOrLoadingForTest(client)
+        advanceUntilIdle()
+
+        assertEquals(
+            "OVER-HEAL GUARD (#1176): a dense, correctly-painted pane must issue NO heal capture " +
+                "at the reveal gate (no reveal-latency / thrash)",
+            healCapturesBefore,
+            client.healCaptureCount(),
+        )
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // (5) OVER-HEAL GUARD: a DENSE pane must NOT heal at the no-op resize.
+    // -------------------------------------------------------------------------------------------
+
+    @Test
+    fun noOpResizeDoesNotHealADensePane() = runVmTest {
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%5")
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == "%5" }
+
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+
+        overpaintDensePane(pane)
+        assertFalse(pane.terminalState.visibleRenderMayHaveLostFrame())
+
+        client.capturePaneResponses.addLast(
+            CommandResponse(number = 99L, output = FULL_FRAME, isError = false),
+        )
+        val healCapturesBefore = client.healCaptureCount()
+
+        assertTrue(vm.triggerSameDimensionResizeHealForTest())
+        advanceUntilIdle()
+
+        assertEquals(
+            "OVER-HEAL GUARD (#1176): a dense pane must issue NO heal capture on a no-op resize",
+            healCapturesBefore,
+            client.healCaptureCount(),
+        )
+    }
+
+    // ------------------------------------------------------------------ Fixtures + assertions
+
+    /** ESC (U+001B). */
+    private val esc = "\u001b"
+
+    /** The emulator's actual visible-row count (the local Termux grid, unaffected by resizeRemotePty). */
+    private fun visibleRowsOf(pane: TmuxPaneState): Int {
+        val state = pane.terminalState
+        val bridge = com.pocketshell.core.terminal.ui.TerminalSurfaceState::class.java
+            .getDeclaredField("bridge").apply { isAccessible = true }.get(state)
+            as? com.pocketshell.core.terminal.bridge.SshTerminalBridge ?: return 24
+        return bridge.emulator.screen.visibleScreenRows
+    }
+
+    /**
+     * Drive the active pane into the #1176 DEAD-ZONE band: paint ~0.6 of the visible rows with
+     * non-wrapping content on the alt screen (adaptive to the emulator's real row count, which
+     * resizeRemotePty does NOT change in a headless unit test). ~0.6 live-fraction is NON-blank,
+     * NON-partial-black, and > 0.5 live (clears the old 0.5 send-heal ceiling), yet the render
+     * lost the black band tmux (the dense [FULL_FRAME] capture) still holds → char-coverage ~0.6.
+     */
+    private fun overpaintDeadZoneBand(pane: TmuxPaneState) {
+        val liveRows = (visibleRowsOf(pane) * 0.6).toInt()
+        val frame = buildString {
+            append("$esc[?1049h$esc[2J$esc[H")
+            for (row in 0 until liveRows) {
+                append("$FULL_FRAME_MARKER conversation line $row real agent content padding\r\n")
+            }
+        }
+        pane.terminalState.appendRemoteOutput(frame.toByteArray(Charsets.US_ASCII))
+    }
+
+    /** A DENSE, correctly-painted pane: ~0.92 of the visible rows live — confidently full. */
+    private fun overpaintDensePane(pane: TmuxPaneState) {
+        val liveRows = (visibleRowsOf(pane) * 0.92).toInt()
+        val frame = buildString {
+            append("$esc[2J$esc[H")
+            for (row in 0 until liveRows) {
+                append("$FULL_FRAME_MARKER dense line $row real agent content padding here\r\n")
+            }
+        }
+        pane.terminalState.appendRemoteOutput(frame.toByteArray(Charsets.US_ASCII))
+    }
+
+    private fun assertDeadZonePreconditions(pane: TmuxPaneState) {
+        val s = pane.terminalState
+        assertFalse("dead-zone band is NOT fully blank", s.visibleScreenIsBlank())
+        assertFalse("dead-zone band is NOT ≤3-line partial-black", s.visibleScreenIsPartiallyBlank())
+        assertFalse(
+            "dead-zone band cleared the old 0.5 LINE ceiling (> 50% rows live)",
+            s.visibleScreenLooksSparseForSendHeal(),
+        )
+        assertFalse(
+            "dead-zone band cleared the old 0.25 CHAR ceiling (> 25% of tmux's chars)",
+            s.visibleScreenDivergesFromCapture(FULL_FRAME.joinToString("\n")),
+        )
+        assertTrue(
+            "the #1176 local capture-gate catches the band (worth a capture-diff)",
+            s.visibleRenderMayHaveLostFrame(),
+        )
+        assertTrue(
+            "the unified oracle judges the dead-zone band LOST vs tmux's full frame",
+            s.visibleRenderLostFrameVsCapture(FULL_FRAME.joinToString("\n")),
+        )
+    }
+
+    // ------------------------------------------------------------------ Harness
+
+    private fun runVmTest(body: suspend TestScope.() -> Unit) = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        LivenessProbeTestOverride.setAutoStartEnabledForTest(false)
+        try {
+            body()
+        } finally {
+            for (vm in createdVms) {
+                runCatching { vm.setProcessForegroundForClearedForTest(false) }
+                runCatching { vm.clearForTest() }
+            }
+            advanceUntilIdle()
+            createdVms.clear()
+            LivenessProbeTestOverride.clear()
+            Dispatchers.resetMain()
+        }
+    }
+
+    private fun TestScope.newVm(
+        registry: ActiveTmuxClients,
+        sshLeaseManager: SshLeaseManager,
+    ): TmuxSessionViewModel = TmuxSessionViewModel(
+        tmuxClientFactory = TmuxClientFactory(factoryScope),
+        activeTmuxClients = registry,
+        runtimeCache = TmuxSessionRuntimeCache(),
+        sshLeaseManager = sshLeaseManager,
+        sessionLifecycleSignals = null,
+    ).also {
+        it.setSeedIoDispatcherForTest(StandardTestDispatcher(testScheduler))
+        createdVms.add(it)
+    }
+
+    private fun TestScope.connectVm(client: FakeTmuxClient): TmuxSessionViewModel {
+        val live = AlwaysConnectedSession(id = "live")
+        val connector = SingleSessionConnector(live)
+        val leaseManager =
+            testLeaseManager(connector = connector, scope = this, idleTtlMillis = 60_000L)
+        val registry = ActiveTmuxClients()
+        val vm = newVm(registry = registry, sshLeaseManager = leaseManager)
+        runCurrent()
+        vm.setTmuxClientFactoryForTest { _, _, _ -> client }
+        vm.connect(
+            hostId = 1L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            passphrase = null,
+            sessionName = "work",
+        )
+        advanceUntilIdle()
+        return vm
+    }
+
+    private fun FakeTmuxClient.healCaptureCount(): Int =
+        sentCommands.count { it.startsWith("capture-pane") && it.contains(" -e") }
+
+    private fun FakeTmuxClient.withSinglePaneRow(
+        sessionName: String,
+        paneId: String,
+        title: String = sessionName,
+    ): FakeTmuxClient = apply {
+        responses.addLast(
+            CommandResponse(
+                number = 1L,
+                output = listOf("$paneId\t@0\t\$0\t$sessionName\t$title\t0"),
+                isError = false,
+            ),
+        )
+        capturePaneResponses.addLast(
+            CommandResponse(number = 2L, output = listOf("$sessionName ready"), isError = false),
+        )
+        cursorQueryResponses.addLast(
+            CommandResponse(number = 3L, output = listOf("0,0"), isError = false),
+        )
+    }
+
+    private fun renderedTranscriptFor(pane: TmuxPaneState): String {
+        val state = pane.terminalState
+        val bridgeField = com.pocketshell.core.terminal.ui.TerminalSurfaceState::class.java
+            .getDeclaredField("bridge").apply { isAccessible = true }
+        val bridge = bridgeField.get(state)
+            as? com.pocketshell.core.terminal.bridge.SshTerminalBridge ?: return ""
+        return bridge.emulator.screen.transcriptText
+    }
+
+    private class SingleSessionConnector(
+        private val session: SshSession,
+    ) : SshLeaseConnector {
+        override suspend fun connect(target: SshLeaseTarget): Result<SshSession> =
+            Result.success(session)
+    }
+
+    private class AlwaysConnectedSession(
+        val id: String,
+    ) : SshSession {
+        @Volatile
+        var closed: Boolean = false
+
+        override val isConnected: Boolean get() = !closed
+
+        override suspend fun exec(command: String): ExecResult =
+            ExecResult(stdout = "", stderr = "", exitCode = 0)
+
+        override fun tail(path: String, onLine: (String) -> Unit): Job =
+            Job().apply { complete() }
+
+        override fun tail(path: String, fromLineExclusive: Long, onLine: (String) -> Unit): Job =
+            Job().apply { complete() }
+
+        override fun openLocalPortForward(
+            remoteHost: String,
+            remotePort: Int,
+            localPort: Int,
+        ): SshPortForward = error("not used")
+
+        override fun startShell(): SshShell = error("not used")
+
+        override suspend fun uploadFile(file: File, remotePath: String): String = error("not used")
+
+        override suspend fun uploadStream(
+            input: InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String = error("not used")
+
+        override fun close() {
+            closed = true
+        }
+    }
+
+    private companion object {
+        const val FULL_FRAME_MARKER: String = "ISSUE1176-DEADZONE"
+
+        // tmux's authoritative full 40-row frame (dense) the heal `capture-pane` returns.
+        val FULL_FRAME: List<String> = buildList {
+            add("HEADER $FULL_FRAME_MARKER full agent conversation restored from tmux")
+            repeat(39) {
+                add("$FULL_FRAME_MARKER full frame row $it real agent conversation content here")
+            }
+        }
+    }
+}

--- a/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurfaceState.kt
+++ b/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurfaceState.kt
@@ -726,41 +726,46 @@ class TerminalSurfaceState(
     }
 
     /**
-     * Issue #1138 — the steady-state stale-render watchdog's "the live render LOST the
-     * frame" predicate. It is the UNION of two miss cases against tmux's authoritative
-     * `capture-pane`:
+     * Issue #1176 (unifies #966/#1138/#1153) — the SINGLE coherent "the live render LOST the
+     * frame" oracle. It answers ONE question against tmux's authoritative `capture-pane`: **how
+     * much of the visible content tmux holds for this pane is actually on screen?** The render
+     * has lost the frame when it reproduces at most [LOST_FRAME_MAX_RENDERED_FRACTION] of tmux's
+     * visible non-blank content while tmux holds materially more.
      *
-     *  (a) a DRAMATICALLY-stale render — [visibleScreenDivergesFromCapture] (the #966
-     *      scattered-fragment / mostly-black-on-a-dense-frame case), AND
+     * ## Why one metric (the #1176 dead-zone this closes)
      *
-     *  (b) a PARTIAL-BLACK render — [visibleScreenIsPartiallyBlank] — whose surviving live
-     *      band happens to exceed 25% of tmux's frame, so (a)'s
-     *      [STALE_RENDER_MAX_RENDERED_FRACTION] ceiling reads it "healthy" and skips it.
-     *      This is the maintainer's live-streaming ALT-SCREEN agent pane (Codex + Claude,
-     *      v0.4.19 dogfood #1138): the agent redraws with cursor-addressed writes, so only
-     *      its live status line repaints locally while the upper alt-screen rows stay black.
-     *      An alt-screen agent frame is SPARSE (header + a big blank conversation area +
-     *      an input/status line), so its non-blank content is small and the lone status
-     *      line is a LARGE fraction of it — the #966 divergence oracle therefore never
-     *      fires, and the steady-state watchdog (whose ONLY predicate was that oracle) left
-     *      the pane stuck mostly-black on a live transport.
+     * The pre-#1176 oracle UNIONED two ceilings on DIFFERENT metrics that do not compose:
+     *  - a 25%-**char** ceiling (the #966 [visibleScreenDivergesFromCapture]), and
+     *  - a 50%-**line** ceiling (the #1153 half-black band).
      *
-     * For case (b) the heal fires ONLY when tmux's capture carries MATERIALLY MORE visible
-     * non-blank content than the render (its visible tail has ≥ [STALE_RENDER_MIN_CAPTURE_CHARS]
-     * AND at least [PARTIAL_BLACK_HEAL_MIN_EXTRA_CHARS] more than the render). That gap is the
-     * anti-thrash / distinguish-from-by-design guard:
-     *  - a legitimately-short prompt (tmux ALSO holds only those few lines → capture ≈ render)
-     *    never re-heals — no reseed-thrash on every watchdog tick; and
-     *  - the #807 by-design alt-screen void (the agent's OWN intentionally-empty frame → tmux
-     *    capture ≈ render, near-nothing to restore) is correctly left alone.
-     * Only a genuine unrepainted frame — tmux holds the full frame while the render shows the
-     * band — heals, restoring the FULL viewport from tmux's authoritative grid.
+     * A render carrying >25% of tmux's chars spread across >50% of the rows — a black BAND
+     * covering ~a third-to-a-half of the screen — cleared BOTH ceilings and was judged HEALTHY,
+     * so it was NEVER healed on any path. That was the residual black screen the maintainer kept
+     * hitting on the latest release (spike #874). A char-fraction and a line-fraction ceiling can
+     * each be "just above threshold" while the pane is plainly half-black. Collapsing them into
+     * a SINGLE content-coverage judgment removes the dead-zone: a black band loses chars (fewer
+     * non-blank cells) regardless of whether the loss reads as scattered sparsity (#966), a lone
+     * surviving status line (#1138), or a contiguous band (#1153) — so one char-coverage ceiling
+     * subsumes all three cases with no gap between them.
+     *
+     * ## The anti-thrash / distinguish-by-design gates (preserved from #1138)
+     *
+     *  1. tmux's visible tail must carry ≥ [STALE_RENDER_MIN_CAPTURE_CHARS] non-blank chars —
+     *     there is a REAL frame to restore, not the #807 by-design near-empty alt-screen void; AND
+     *  2. tmux must carry at least [PARTIAL_BLACK_HEAL_MIN_EXTRA_CHARS] MORE non-blank chars than
+     *     the render — a genuine unrepainted frame, not a legitimately-short prompt whose capture
+     *     ≈ render (no reseed-thrash on every watchdog tick).
+     *
+     * Only then does the coverage ceiling decide. A DENSE, correctly-painted pane reproduces
+     * ~all of tmux's visible content (its coverage sits ABOVE the ceiling) and never heals; a
+     * pane that is merely a few rows behind a streaming agent (capture holds slightly more) sits
+     * above the ceiling too and is left alone — no clear-to-repaint flicker on a lagging-but-fine
+     * pane. Re-seeding is idempotent (a full clear+repaint of tmux's authoritative grid), so the
+     * heal only ever swaps TOWARD more content.
      *
      * Returns false when no emulator is attached (nothing rendered to judge).
      */
     fun visibleRenderLostFrameVsCapture(captureText: String): Boolean {
-        // (a) The #966 dramatic-divergence case (unchanged oracle).
-        if (visibleScreenDivergesFromCapture(captureText)) return true
         val emulator = bridge?.emulator ?: _session?.emulator ?: return false
         val visibleRows = try {
             emulator.screen.visibleScreenRows
@@ -773,34 +778,61 @@ class TerminalSurfaceState(
             .filter { it.isNotBlank() }
             .takeLast(visibleRows)
             .sumOf { line -> line.count { !it.isWhitespace() } }
-        // tmux has (near) nothing for this pane → no real frame to restore (the #807
-        // alt-screen void). Defer — do NOT heal a genuinely-empty pane to itself.
+        // Gate 1 — the #807 by-design void: tmux has (near) nothing for this pane, so there is no
+        // real frame to restore. Defer; do NOT heal a genuinely-empty pane to itself.
         if (captureVisibleNonBlank < STALE_RENDER_MIN_CAPTURE_CHARS) return false
         val renderedNonBlank = renderedNonBlankCharCount()
-        // tmux carries MATERIALLY MORE than the render → the frame the render lost is still in
-        // tmux's grid; re-seed to restore it. A near-equal capture (short prompt / by-design
-        // void) sits under the gap and is left alone — the anti-thrash / distinguish-by-design
-        // guard shared by both partial-black branches below.
+        // Gate 2 — anti-thrash / distinguish-by-design: tmux must carry MATERIALLY MORE visible
+        // content than the render (a legitimately-short prompt or the agent's own clear has
+        // capture ≈ render and sits under this gap — left alone).
         if (captureVisibleNonBlank - renderedNonBlank < PARTIAL_BLACK_HEAL_MIN_EXTRA_CHARS) return false
-        // (b) The #1138 partial-black render (≤3 live lines): an alt-screen agent's surviving
-        //     status line, the upper rows black.
-        if (visibleScreenIsPartiallyBlank()) return true
-        // (c) Issue #1153 — the >3-live-line HALF-BLACK render. A composer Send whose multi-line
-        //     payload (a with-attachment send is ALWAYS multi-line — it appends an "Attached
-        //     files:" block) takes the bracketed-paste + submit branch; the alt-screen agent then
-        //     clear+cursor-address-redraws its WHOLE viewport, and the overpaint blanks the grid
-        //     while the agent only PARTIALLY repaints — leaving a large black BAND above a
-        //     surviving input box + a few conversation lines + status. That band carries MORE
-        //     than the ≤3 live lines the partial-black heuristic (b) caps at (so (b) misses it),
-        //     yet its live share of the visible rows is still materially below a fully-painted
-        //     frame. Combined with the "tmux holds materially more" gate already passed above,
-        //     heal it too — the maintainer's "partly redrew but still too black" send state
-        //     (#1153). The fraction ceiling keeps a DENSE healthy pane (its live rows sit ABOVE
-        //     the ceiling) from firing; the capture-diff gate already excluded a legitimately
-        //     sparse-but-correct pane (capture ≈ render).
-        val renderedLiveLines = renderedVisibleNonBlankLineCount()
-        if (renderedLiveLines <= 0) return false
-        return renderedLiveLines.toDouble() / visibleRows.toDouble() <= LOST_FRAME_MAX_LIVE_FRACTION
+        // THE unified judgment: the render reproduces at most [LOST_FRAME_MAX_RENDERED_FRACTION]
+        // of tmux's visible non-blank content → a black band / mostly-black / scattered render
+        // that lost the frame tmux still holds. A fully-painted or only-slightly-behind pane sits
+        // above the ceiling and is not healed.
+        return renderedNonBlank.toDouble() <=
+            captureVisibleNonBlank.toDouble() * LOST_FRAME_MAX_RENDERED_FRACTION
+    }
+
+    /**
+     * Issue #1176 (GAP C) — the CHEAP, LOCAL-ONLY capture-gate the switch-reveal
+     * ([com.pocketshell.app.tmux.TmuxSessionViewModel.awaitActivePaneSeededOrLoading]) and the
+     * no-op-resize heal ([com.pocketshell.app.tmux.TmuxSessionViewModel.maybeHealActivePaneOnNoOpResize])
+     * run to decide whether paying for an authoritative `capture-pane` diff (the unified
+     * [visibleRenderLostFrameVsCapture] oracle) is worthwhile before revealing / after a keyboard
+     * toggle. It is TRUE when the rendered viewport is sparse/banded enough to POSSIBLY be a lost
+     * frame: fully blank, the ≤3-line partial-black, OR a black BAND whose live share of the
+     * visible rows is at most [MAY_HAVE_LOST_FRAME_MAX_LIVE_FRACTION].
+     *
+     * It fires for the SAME two states the pre-#1176 gates already captured for — fully blank OR
+     * the ≤3-line partial-black — PLUS the exact GAP the dead-zone left: a >3-line black BAND with
+     * MORE than half the visible rows live (so the pre-#1176 gates read it "painted") but still up
+     * to [MAY_HAVE_LOST_FRAME_MAX_LIVE_FRACTION] of them — the band between the old 50%-line ceiling
+     * and a confidently-dense pane. A genuinely-sparse-but-correct SMALL pane (≤ half the rows live
+     * — a short prompt) is deliberately NOT flagged: the pre-#1176 no-op-resize contract pays
+     * nothing for it, and the steady-state watchdog remains its net. It does NOT confirm a lost
+     * frame — only the `capture-pane` diff can, since a sparse-but-correct pane looks identical
+     * locally — so a confidently-full pane (live rows ABOVE the ceiling) skips the capture entirely,
+     * and every flagged pane is confirmed against tmux by the unified oracle before any heal fires.
+     */
+    fun visibleRenderMayHaveLostFrame(): Boolean {
+        if (visibleScreenIsBlankOrPartiallyBlank()) return true
+        val emulator = bridge?.emulator ?: _session?.emulator ?: return false
+        val visibleRows = try {
+            emulator.screen.visibleScreenRows
+        } catch (_: Throwable) {
+            return false
+        }
+        if (visibleRows <= 0) return false
+        val liveLines = renderedVisibleNonBlankLineCount()
+        if (liveLines <= 0) return true
+        val liveFraction = liveLines.toDouble() / visibleRows.toDouble()
+        // The #1176 dead-zone the pre-#1176 gates MISSED: MORE than half the rows live yet not
+        // confidently dense. Below the lower bound the pane is genuinely sparse (the pre-#1176
+        // no-op contract skips it — the "cheap no-op" for a short correct prompt); above the upper
+        // bound it is confidently full.
+        return liveFraction > MAY_HAVE_LOST_FRAME_MIN_LIVE_FRACTION &&
+            liveFraction <= MAY_HAVE_LOST_FRAME_MAX_LIVE_FRACTION
     }
 
     /**
@@ -1159,10 +1191,9 @@ class TerminalSurfaceState(
 
         /**
          * Issue #1153: the upper bound on the rendered live-line FRACTION of the visible rows for
-         * [visibleRenderLostFrameVsCapture]'s >3-live-line HALF-BLACK branch (and the cheap
-         * send-heal pre-check [visibleScreenLooksSparseForSendHeal]). The maintainer's composer
-         * Send (with-attachment, so multi-line → bracketed-paste + submit) left the alt-screen
-         * agent pane "partly redrew but still too black": a surviving input box + a few
+         * the cheap send-heal pre-check [visibleScreenLooksSparseForSendHeal]. The maintainer's
+         * composer Send (with-attachment, so multi-line → bracketed-paste + submit) left the
+         * alt-screen agent pane "partly redrew but still too black": a surviving input box + a few
          * conversation lines + status (MORE than the ≤3 live lines
          * [PARTIAL_BLANK_MAX_LIVE_LINES] caps at) over a large black BAND. Half-or-more of the
          * visible rows black is "materially black"; a DENSE, normally-painted response paints
@@ -1171,8 +1202,56 @@ class TerminalSurfaceState(
          * narrow partial-black heuristic misses, and the capture-diff gate
          * ([PARTIAL_BLACK_HEAL_MIN_EXTRA_CHARS]) still guards against healing a sparse-but-correct
          * pane where tmux holds no more content than the render.
+         *
+         * NOTE (#1176): this is now ONLY the send-heal LOCAL cost-gate. The authoritative
+         * capture-vs-render decision moved to the unified [LOST_FRAME_MAX_RENDERED_FRACTION]
+         * char-coverage ceiling in [visibleRenderLostFrameVsCapture]; this 0.5 line-fraction no
+         * longer bounds that oracle.
          */
         private const val LOST_FRAME_MAX_LIVE_FRACTION = 0.5
+
+        /**
+         * Issue #1176 — the SINGLE char-coverage ceiling of the unified
+         * [visibleRenderLostFrameVsCapture] oracle: the render has LOST the frame when its
+         * visible non-blank char count is at most this FRACTION of tmux's authoritative visible
+         * content (with the [STALE_RENDER_MIN_CAPTURE_CHARS] real-frame floor and the
+         * [PARTIAL_BLACK_HEAL_MIN_EXTRA_CHARS] materially-more gate both passed first).
+         *
+         * It REPLACES the pre-#1176 two-cliff union (a 25%-char ceiling OR a 50%-line ceiling)
+         * with one coherent judgment, closing the dead-zone where a black BAND carrying >25% of
+         * tmux's chars across >50% of the rows cleared BOTH old ceilings and was never healed.
+         * At 0.75 it heals a pane missing a quarter or more of tmux's visible content — the whole
+         * "half-to-two-thirds black band" the maintainer kept hitting (spike #874) — while a
+         * DENSE, correct pane (coverage ≈ 1.0) and a merely-a-few-rows-behind streaming pane
+         * (coverage ~0.84+, measured) both sit above the ceiling and are left alone (no
+         * clear-to-repaint flicker on a lagging-but-fine pane).
+         */
+        private const val LOST_FRAME_MAX_RENDERED_FRACTION = 0.75
+
+        /**
+         * Issue #1176 (GAP C) — the live-line FRACTION ceiling of the LOCAL capture-gate
+         * [visibleRenderMayHaveLostFrame] used by the switch-reveal and no-op-resize heals. It is
+         * aligned with the unified oracle's [LOST_FRAME_MAX_RENDERED_FRACTION] (0.75) so a
+         * confidently-full pane (live rows above the ceiling) skips the authoritative
+         * `capture-pane` diff while ANY pane that could be a dead-zone black band (live rows below
+         * it) is confirmed against tmux by [visibleRenderLostFrameVsCapture] before any heal. It
+         * is deliberately HIGHER than the send-heal cost-gate's [LOST_FRAME_MAX_LIVE_FRACTION]
+         * (0.5) so the reveal/resize gates never MISS the #1176 dead-zone band the way the narrow
+         * pre-check did.
+         */
+        private const val MAY_HAVE_LOST_FRAME_MAX_LIVE_FRACTION = 0.75
+
+        /**
+         * Issue #1176 (GAP C) — the LOWER bound of the [visibleRenderMayHaveLostFrame] band
+         * trigger. A >3-line pane with at most this live-fraction is genuinely SPARSE (a short
+         * correct prompt), NOT the dead-zone band the pre-#1176 no-op-resize gate missed — flagging
+         * it would break the "cheap no-op" contract (capturing a correct small pane on routine
+         * layout churn). The dead-zone is specifically the band with MORE than half the rows live
+         * (spike #874: >50% rows + >25% chars), so the local capture-gate only opens ABOVE this
+         * 0.5 boundary; the genuinely-sparse pane's net stays the steady-state watchdog + the
+         * send-heal path (whose own cost-gate is [LOST_FRAME_MAX_LIVE_FRACTION] = 0.5).
+         */
+        private const val MAY_HAVE_LOST_FRAME_MIN_LIVE_FRACTION = 0.5
     }
 }
 

--- a/shared/core-terminal/src/test/java/com/pocketshell/core/terminal/ui/TerminalSurfaceStateDeadZoneHealTest.kt
+++ b/shared/core-terminal/src/test/java/com/pocketshell/core/terminal/ui/TerminalSurfaceStateDeadZoneHealTest.kt
@@ -1,0 +1,238 @@
+package com.pocketshell.core.terminal.ui
+
+import android.os.Looper
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import java.io.OutputStream
+
+/**
+ * Issue #1176 (GAP A) — the heal-oracle DEAD-ZONE the maintainer kept hitting on the latest
+ * release (spike #874). [TerminalSurfaceState.visibleRenderLostFrameVsCapture] used to UNION two
+ * ceilings on DIFFERENT metrics that do not compose: a 25%-**char** ceiling (#966
+ * [TerminalSurfaceState.visibleScreenDivergesFromCapture]) OR a 50%-**line** ceiling (#1153). A
+ * render carrying >25% of tmux's chars spread across >50% of the rows — a black BAND covering
+ * ~a third-to-a-half of the screen — cleared BOTH ceilings, was judged HEALTHY, and was NEVER
+ * healed on any path.
+ *
+ * These tests pin the fix: the oracle is now a SINGLE char-coverage judgment (heal when the
+ * render reproduces at most [LOST_FRAME_MAX_RENDERED_FRACTION] = 0.75 of tmux's visible content),
+ * so a half-to-two-thirds black band is judged LOST — while a dense / only-slightly-behind pane
+ * is not.
+ *
+ * ## RED → GREEN (D33/G1/G10)
+ *
+ * [deadZoneBandClearsBothOldCeilingsYetIsHealedByUnifiedOracle] composes a >3-line half-black
+ * band whose char-coverage is > 0.25 (clears the old CHAR ceiling — `visibleScreenDivergesFromCapture`
+ * is FALSE) AND whose live share of the rows is > 0.50 (clears the old LINE ceiling —
+ * `visibleScreenLooksSparseForSendHeal` is FALSE). On base `visibleRenderLostFrameVsCapture`
+ * returns FALSE (the dead-zone — RED). With the unified oracle it returns TRUE (GREEN). The
+ * geometry is visible-render-vs-capture-pane, not a proxy.
+ *
+ * ## Class coverage (D32-G2)
+ *
+ * [unifiedOracleHealsAcrossTheBlackBandSpectrum] parametrizes 30/40/50/60/70% black measured by
+ * BOTH char-fraction AND line-fraction (uniform-density bands, so the two are equal), asserting
+ * the whole dead-zone is closed as a class — not the single reported band. [regressionCasesStill]
+ * confirms fully-black, ≤3-line partial, the >3-line half-black at the exact #1153 0.50 boundary,
+ * and the scattered-fragment #966 case all still heal, and a DENSE pane does NOT (no over-heal).
+ */
+@RunWith(RobolectricTestRunner::class)
+class TerminalSurfaceStateDeadZoneHealTest {
+
+    private class NoopOutputStream : OutputStream() {
+        override fun write(b: Int) = Unit
+        override fun write(b: ByteArray, off: Int, len: Int) = Unit
+    }
+
+    private fun withAttachedSurface(block: (TerminalSurfaceState) -> Unit) = runBlocking {
+        val state = TerminalSurfaceState()
+        val producerScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val producerJob = state.attachExternalProducer(
+            scope = producerScope,
+            stdout = MutableSharedFlow(extraBufferCapacity = 1),
+            remoteStdin = NoopOutputStream(),
+            suppressQueryResponses = true,
+        )
+        try {
+            block(state)
+        } finally {
+            producerJob.cancel()
+            producerScope.cancel()
+            state.detachExternalProducer()
+        }
+    }
+
+    /** ESC (U+001B), so the test feeds real control sequences (a literal `[2J` is just text). */
+    private val esc = "\u001b"
+
+    /** A single non-wrapping content line: 20 non-blank chars, well under the 80-col grid. */
+    private val contentLine = "abcdefghij klmnopqrst"
+
+    /**
+     * tmux's authoritative capture: a full 24-row viewport of [contentLine] (the emulator's
+     * visible-row count is 24). A render that painted only [liveRows] of those rows lost a black
+     * BAND that tmux still holds — its char-coverage AND its live-line fraction are both
+     * `liveRows / 24` (uniform density), so a band is defined identically by BOTH metrics.
+     */
+    private fun fullCapture(): String = buildString { repeat(24) { append("$contentLine\n") } }
+
+    /** Paint [liveRows] non-wrapping content lines on a cleared screen — a contiguous black band above. */
+    private fun paintBand(state: TerminalSurfaceState, liveRows: Int) {
+        val frame = buildString {
+            append("$esc[2J$esc[H")
+            repeat(liveRows) { append("$contentLine\r\n") }
+        }
+        state.appendRemoteOutput(frame.toByteArray(Charsets.US_ASCII))
+        shadowOf(Looper.getMainLooper()).idle()
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // RED → GREEN: the exact dead-zone band the two old ceilings BOTH judged healthy.
+    // -----------------------------------------------------------------------------------------
+
+    @Test
+    fun deadZoneBandClearsBothOldCeilingsYetIsHealedByUnifiedOracle() = withAttachedSurface { state ->
+        // 14 of 24 rows live (~42% black band): live-fraction 0.58 (> 0.50) AND char-coverage
+        // ~0.58 (> 0.25) — the render cleared BOTH old ceilings.
+        paintBand(state, liveRows = 14)
+        val capture = fullCapture()
+
+        assertFalse(
+            "precondition: a half-black band is NOT fully blank",
+            state.visibleScreenIsBlank(),
+        )
+        assertFalse(
+            "precondition: it has MORE than 3 live lines, so it is NOT the ≤3-line partial-black",
+            state.visibleScreenIsPartiallyBlank(),
+        )
+        // The old CHAR ceiling (25%) judged it healthy: char-coverage > 0.25.
+        assertFalse(
+            "RED premise: the render carries > 25% of tmux's chars → the old 25%-char divergence " +
+                "oracle judged the band HEALTHY (cleared the CHAR ceiling)",
+            state.visibleScreenDivergesFromCapture(capture),
+        )
+        // The old LINE ceiling (50%) judged it healthy: live share of the rows > 0.50, so the
+        // 0.5-live-fraction send-heal pre-check reads NON-sparse.
+        assertFalse(
+            "RED premise: > 50% of the visible rows are live → the old 50%-line ceiling judged " +
+                "the band HEALTHY (cleared the LINE ceiling)",
+            state.visibleScreenLooksSparseForSendHeal(),
+        )
+
+        // GREEN: the unified char-coverage oracle judges the band LOST (on base this returns
+        // FALSE — the dead-zone — so this assertion is the red→green discriminator).
+        assertTrue(
+            "GREEN (#1176): the unified oracle must judge a >3-line, >50%-rows-live half-black " +
+                "band LOST — the render reproduces only ~58% of tmux's visible content",
+            state.visibleRenderLostFrameVsCapture(capture),
+        )
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // Class coverage: 30/40/50/60/70% black measured by BOTH char-fraction AND line-fraction.
+    // -----------------------------------------------------------------------------------------
+
+    @Test
+    fun unifiedOracleHealsAcrossTheBlackBandSpectrum() {
+        // (approxBlackPercent, liveRows-of-24). Uniform density → char-coverage == line-fraction
+        // == liveRows/24, so each band is the target %black by BOTH metrics simultaneously.
+        // The 30% and 40% bands (>50% rows live) are the #1176 dead-zone that was NEVER healed on
+        // base; 50/60/70% were already caught by the old 50%-line ceiling — all must heal now.
+        val spectrum = listOf(
+            30 to 17, // ~29% black, live-fraction 0.71 → DEAD-ZONE (base: not healed)
+            40 to 14, // ~42% black, live-fraction 0.58 → DEAD-ZONE (base: not healed)
+            50 to 12, // 50% black, live-fraction 0.50   → #1153 boundary
+            60 to 10, // ~58% black, live-fraction 0.42
+            70 to 7,  // ~71% black, live-fraction 0.29
+        )
+        val capture = fullCapture()
+        for ((blackPercent, liveRows) in spectrum) {
+            withAttachedSurface { state ->
+                paintBand(state, liveRows)
+                val liveFraction = liveRows / 24.0
+                // Sanity: the band really is ~blackPercent black by the LINE metric.
+                assertTrue(
+                    "band $blackPercent% black: live-fraction $liveFraction should be ~${1 - blackPercent / 100.0}",
+                    kotlin.math.abs((1 - liveFraction) - blackPercent / 100.0) < 0.06,
+                )
+                assertTrue(
+                    "#1176 class coverage: a $blackPercent%-black band (by BOTH char & line " +
+                        "fraction) must be judged LOST by the unified oracle",
+                    state.visibleRenderLostFrameVsCapture(capture),
+                )
+                if (liveFraction > 0.5) {
+                    // The DEAD-ZONE members: confirm they cleared BOTH old ceilings (so they were
+                    // genuinely un-healed on base), closing the dead-zone as a class not a point.
+                    assertFalse(
+                        "band $blackPercent%: cleared the old 25%-char ceiling",
+                        state.visibleScreenDivergesFromCapture(capture),
+                    )
+                    assertFalse(
+                        "band $blackPercent%: cleared the old 50%-line ceiling",
+                        state.visibleScreenLooksSparseForSendHeal(),
+                    )
+                }
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // Regression: the previously-covered cases still heal; a dense pane still does NOT.
+    // -----------------------------------------------------------------------------------------
+
+    @Test
+    fun regressionCasesStill() {
+        val capture = fullCapture()
+
+        // Fully black (clear-only) still heals.
+        withAttachedSurface { state ->
+            state.appendRemoteOutput("$esc[2J$esc[H".toByteArray(Charsets.US_ASCII))
+            shadowOf(Looper.getMainLooper()).idle()
+            assertTrue("precondition: fully blank", state.visibleScreenIsBlank())
+            assertTrue(
+                "regression: a fully-black pane against a full capture still heals",
+                state.visibleRenderLostFrameVsCapture(capture),
+            )
+        }
+
+        // ≤3-line partial-black (#1138 class) still heals.
+        withAttachedSurface { state ->
+            paintBand(state, liveRows = 2)
+            assertTrue("precondition: ≤3-line partial-black", state.visibleScreenIsPartiallyBlank())
+            assertTrue(
+                "regression: a ≤3-line partial-black pane still heals",
+                state.visibleRenderLostFrameVsCapture(capture),
+            )
+        }
+
+        // The >3-line half-black at the exact #1153 0.50 line-fraction boundary still heals.
+        withAttachedSurface { state ->
+            paintBand(state, liveRows = 12)
+            assertFalse("precondition: not ≤3-line partial-black", state.visibleScreenIsPartiallyBlank())
+            assertTrue(
+                "regression (#1153): the >3-line half-black at the 0.50 boundary still heals",
+                state.visibleRenderLostFrameVsCapture(capture),
+            )
+        }
+
+        // A DENSE render (well over 3/4 of the rows live) must NOT heal — no over-heal.
+        withAttachedSurface { state ->
+            paintBand(state, liveRows = 22)
+            assertFalse(
+                "over-heal guard: a dense render (only ~8% black) must NOT heal — a near-complete " +
+                    "pane a few rows behind a streaming agent is not a lost frame",
+                state.visibleRenderLostFrameVsCapture(capture),
+            )
+        }
+    }
+}


### PR DESCRIPTION
GAP A of the #874 black-screen spike: the char/line two-cliff heal oracle had a dead-zone — a half-to-two-thirds black band cleared both ceilings and was never healed. Unifies to one char-coverage judgment (K=0.75, D22 hard-cut) + routes reveal-gate & no-op-resize through it (GAP C). Reviewer APPROVED: drove red→green both gaps, 30–70% class coverage by char+line fraction, no regression (#1138/#1153 still heal), no over-heal of dense panes. Local gate on the #1178-rebased tree: dead-zone + diagnostics tests all green.

Part of the black-screen campaign (#843/#874). Closes #1176