### PR TITLE
terminal: heal the silent-reattach black pane instead of exiting silent (#1177)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -10674,13 +10674,38 @@ public class TmuxSessionViewModel @Inject constructor(
             // old code fell off the end here SILENTLY, leaving the reveal stuck
             // in Seeding with a green dot. For a COLD/SWITCH ATTACH reveal, surface
             // a retryable error + the #823 Reconnect affordance instead of an
-            // infinite spinner. (Reattach/reconnect reseed nets pass
-            // surfaceErrorOnExhaustion=false and keep the old silent exit — the
-            // transport is healthy and later %output still heals the pane.)
-            if (!surfaceErrorOnExhaustion) return@launch
+            // infinite spinner.
             if (!isCurrentRuntime(refreshGuard)) return@launch
             if (clientRef?.disconnected?.value == true) return@launch
             if (inlineConnectionStatus !is ConnectionStatus.Connected) return@launch
+            if (!surfaceErrorOnExhaustion) {
+                // Issue #1177 (black-screen GAP B): the passive/transport SILENT-
+                // REATTACH paths (:8077/:8319) arm this watchdog with
+                // surfaceErrorOnExhaustion=false. Before, when the reconnect seed
+                // NEVER landed within the blank window this branch fell off the end
+                // SILENTLY — leaving a PERMANENT BLACK pane on a LIVE (green)
+                // transport with no error, no heal, no reconnect (the maintainer's
+                // post_grace_foreground full-reconnect black, #874). The transport
+                // IS healthy, so declaring a stuck attach (failStuckAttachReveal)
+                // would be wrong; instead HAND OFF to the lifetime stale-render heal
+                // watchdog so a seed that never landed keeps being re-captured and
+                // healed against tmux's authoritative grid. A fully-black pane IS
+                // caught by the heal oracle (visibleRenderLostFrameVsCapture), so
+                // once tmux carries a frame the pane is repainted rather than
+                // stranded black. This adds NO new polling (#1164): it arms the
+                // EXISTING #966/#1166 stale-render watchdog on a path that
+                // previously armed nothing on exhaustion.
+                Log.i(
+                    ISSUE_145_RECONNECT_TAG,
+                    "tmux-connected-blank-watchdog exhausted on a reattach reseed " +
+                        "(surfaceErrorOnExhaustion=false) with a still-blank active " +
+                        "pane on a LIVE transport — arming the stale-render heal " +
+                        "watchdog instead of exiting silently into a black pane " +
+                        "(#1177). session=${activeTarget?.sessionName}",
+                )
+                armActivePaneStaleRenderWatchdog(refreshGuard)
+                return@launch
+            }
             val stillBlank = activeVisiblePane()?.terminalState?.visibleScreenIsBlank() ?: false
             if (stillBlank) {
                 failStuckAttachReveal()

--- a/app/src/test/java/com/pocketshell/app/tmux/ReseedBlankWatchdogCharacterizationTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/ReseedBlankWatchdogCharacterizationTest.kt
@@ -181,6 +181,51 @@ class ReseedBlankWatchdogCharacterizationTest {
     }
 
     /**
+     * Issue #1177 (black-screen GAP B): connect a VM the way [connectVm] does —
+     * suppress the connect()-auto-armed BLANK watchdog so a manually-armed one runs
+     * in isolation — but LEAVE the #966/#1166 stale-render auto-arm ENABLED (the
+     * production default). This lets the blank-watchdog EXHAUSTION hand-off actually
+     * arm the stale-render heal watchdog (the fix), which a stale-render-disabled VM
+     * would silently suppress.
+     */
+    private fun TestScope.connectVmReattachBlack(client: FakeTmuxClient): TmuxSessionViewModel {
+        val live = AlwaysConnectedSession(id = "live")
+        val connector = SingleSessionConnector(live)
+        val leaseManager =
+            testLeaseManager(connector = connector, scope = this, idleTtlMillis = 60_000L)
+        val registry = ActiveTmuxClients()
+        val vm = newVm(registry = registry, sshLeaseManager = leaseManager)
+        runCurrent()
+        // Isolate the manually-armed blank watchdog (as connectVm does), but keep
+        // the stale-render auto-arm ON so the GAP B exhaustion hand-off can fire.
+        vm.setConnectedBlankWatchdogAutoArmEnabledForTest(false)
+        vm.setTmuxClientFactoryForTest { _, _, _ -> client }
+        vm.connect(
+            hostId = 1L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            passphrase = null,
+            sessionName = "work",
+        )
+        advanceUntilIdle()
+        return vm
+    }
+
+    /**
+     * Issue #1177: a recovery `capture-pane` frame rich enough to clear the
+     * STALE_RENDER_MIN_CAPTURE_CHARS floor (a single short line is below it, so the
+     * heal oracle would not fire on it). The marker line proves the healed frame
+     * landed on the pane's grid.
+     */
+    private fun issue1177RecoveredFrame(): List<String> = buildList {
+        add("ISSUE1177-REATTACH-HEALED — recovered viewport after silent-reattach")
+        repeat(24) { add("recovered context row $it xxxxxxxxxxxxxxxxxxxxxxxxxxxx") }
+    }
+
+    /**
      * Issue #886: connect a VM whose active pane never seeds, leaving the
      * connect()-auto-armed blank-watchdog at the PRODUCTION bound, then drain to
      * idle so the watchdog runs to EXHAUSTION end-to-end through the real
@@ -615,6 +660,95 @@ class ReseedBlankWatchdogCharacterizationTest {
         assertFalse(
             "a healed reveal must NOT be the honest-error surface (was $reveal)",
             reveal is com.pocketshell.core.connection.RevealState.Error,
+        )
+    }
+
+    // ---------------------------------------------------------------------
+    // (e) Issue #1177 (black-screen GAP B) — the SILENT-REATTACH hole.
+    //     The passive/transport silent-reattach paths (:8077/:8319) arm the
+    //     blank watchdog with surfaceErrorOnExhaustion=false. When the reconnect
+    //     seed NEVER lands within the blank window the watchdog used to fall off
+    //     the end SILENTLY (:10658) — a PERMANENT BLACK pane on a LIVE (green)
+    //     transport (the maintainer's post_grace_foreground full-reconnect black,
+    //     #874). The fix: on exhaustion, hand off to the lifetime stale-render
+    //     heal watchdog so a seed that never landed keeps being healed against
+    //     tmux's authoritative grid (a fully-black pane IS caught by the heal
+    //     oracle, visibleRenderLostFrameVsCapture).
+    // ---------------------------------------------------------------------
+
+    @Test
+    fun reattachBlankWatchdogExhaustionArmsStaleRenderHealInsteadOfSilentBlack() = runVmTest {
+        // Model the reattach silent-black: a reconnected session (green dot) whose
+        // active pane's seed keeps coming back EMPTY — the pane is BLACK on a live
+        // transport, exactly the surface armConnectedBlankWatchdog(false) guards on
+        // the :8077/:8319 reattach paths. Stale-render auto-arm is LEFT ON (the
+        // production default) so the exhaustion hand-off can arm it.
+        val client = FakeTmuxClient().withSinglePaneRowButEmptyCapture("work", "%1")
+        val vm = connectVmReattachBlack(client)
+        val pane = vm.panes.value.single { it.paneId == "%1" }
+        assertTrue(
+            "precondition: the reconnect seed came back empty -> the pane is BLACK on a live transport",
+            pane.terminalState.visibleScreenIsBlank(),
+        )
+        // Foreground + screen-on so the stale-render watchdog actually captures
+        // once it is armed (#1166 gate).
+        vm.setProcessForegroundForClearedForTest(true)
+        vm.setScreenInteractiveForTest(true)
+        vm.setStaleRenderWatchdogMaxTicksForTest(1000)
+
+        // Baseline: right after connect no stale-render watchdog is running (the
+        // reveal skips arming it while the pane is blank).
+        vm.staleRenderWatchdogJobForTest().let {
+            assertTrue(
+                "precondition: no stale-render watchdog is armed before the blank watchdog exhausts",
+                it == null || it.isCancelled,
+            )
+        }
+
+        // Arm the blank watchdog the way the reattach paths do
+        // (armConnectedBlankWatchdogForTest passes the default
+        // surfaceErrorOnExhaustion=false), and drive it to EXHAUSTION with every
+        // capture empty — the pane stays black for the whole window.
+        val guard = requireNotNull(vm.currentRuntimeGuardForTest())
+        vm.armConnectedBlankWatchdogForTest(guard)
+        // Each blank-watchdog tick also runs the bounded empty-capture reseed retry
+        // (500ms tick + up to 4 attempts x 120ms), so 20 ticks span ~17s of virtual
+        // time. Advance a comfortable margin past that so the watchdog fully
+        // EXHAUSTS on a still-blank pane (the GAP B condition).
+        advanceTimeBy(CONNECTED_BLANK_WATCHDOG_TICK_MS * CONNECTED_BLANK_WATCHDOG_MAX_TICKS * 4)
+        runCurrent()
+
+        // GAP B fix: on exhaustion the reattach path MUST hand off to the stale-
+        // render heal watchdog rather than exiting silently into a permanent black.
+        // RED (base): the branch returns silently -> no watchdog armed -> the pane
+        // is stranded BLACK forever. GREEN (fix): a live stale-render watchdog runs.
+        val staleJob = vm.staleRenderWatchdogJobForTest()
+        assertTrue(
+            "Issue #1177: on blank-watchdog exhaustion the silent-reattach path MUST " +
+                "arm the stale-render heal watchdog (not exit silently into a permanent " +
+                "black on a live transport). job=$staleJob",
+            staleJob != null && staleJob.isActive,
+        )
+
+        // ...and it actually HEALS the black pane: tmux's grid now carries a real
+        // frame, so the next stale-render capture repaints the pane. The recovery
+        // frame is rich enough to clear the STALE_RENDER_MIN_CAPTURE_CHARS floor.
+        client.capturePaneResponses.addLast(
+            CommandResponse(number = 99L, output = issue1177RecoveredFrame(), isError = false),
+        )
+        // The stale-render watchdog's first tick fires 4s after it was armed; a
+        // generous advance past the widest backed-off interval guarantees a tick.
+        advanceTimeBy(STALE_RENDER_WATCHDOG_MAX_INTERVAL_MS + STALE_RENDER_WATCHDOG_TICK_MS + 100)
+        runCurrent()
+
+        assertFalse(
+            "Issue #1177: the stale-render heal must repaint the black reattached pane " +
+                "on a live transport — never a permanent black.",
+            pane.terminalState.visibleScreenIsBlank(),
+        )
+        assertTrue(
+            "the recovered frame must be on the pane's grid",
+            renderedTranscriptFor(pane).contains("ISSUE1177-REATTACH-HEALED"),
         )
     }
 

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
@@ -3247,6 +3247,162 @@ class TmuxSessionViewModelTest {
         )
     }
 
+    // ------------------------------------------------------------------
+    // Issue #1177 (black-screen GAP B) — the silent-reattach paths (:8077
+    // warm same-SSH reattach, :8319 fresh-transport reattach) arm the blank
+    // watchdog with surfaceErrorOnExhaustion=false. When the reattach SEED
+    // stays blank for the whole blank-watchdog window the watchdog used to
+    // exit SILENTLY, leaving a PERMANENT BLACK pane on a live (green) transport
+    // (the maintainer's #874 fully-black-on-green). Class coverage: both real
+    // reattach call sites must now hand off to the lifetime stale-render heal
+    // watchdog on exhaustion (never silent black), and it must actually heal
+    // the pane once tmux carries a frame.
+    // ------------------------------------------------------------------
+
+    @Test
+    fun passiveSilentReattachThatSeedsBlankArmsStaleRenderHealNotSilentBlack() = runTest(scheduler) {
+        // :8077 — the WARM same-SSH silent reattach. The replacement client's
+        // list-panes row resolves (reattach reaches Live) but every capture is
+        // empty, so the reattached active pane is BLACK on a live transport.
+        TMUX_CONNECT_ATTEMPTS.set(1)
+        val registry = ActiveTmuxClients()
+        val vm = newVm(registry)
+        vm.setPassiveDisconnectRecoveryForTest(graceMs = 5_000L, silentReattachTimeoutMs = 5_000L)
+        // Foreground + screen-on so the armed stale-render watchdog actually
+        // captures (the #1166 heat gate) and can heal.
+        vm.setProcessForegroundForClearedForTest(true)
+        vm.setScreenInteractiveForTest(true)
+        vm.setStaleRenderWatchdogMaxTicksForTest(1000)
+        val session = FakeSshSession()
+        val deadClient = FakeTmuxClient()
+        val replacementClient =
+            FakeTmuxClient().withSinglePaneRowButEmptyCapture("work", "%1")
+        vm.setTmuxClientFactoryForTest { _, sessionName, _ ->
+            assertEquals("work", sessionName)
+            replacementClient
+        }
+        vm.replaceClientForTest(
+            hostId = 7L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            sessionName = "work",
+            client = deadClient,
+            session = session,
+        )
+        runCurrent()
+
+        deadClient.disconnectedSignal.value = true
+        // Complete the warm reattach (reaches Live) but DON'T drain the lifetime
+        // watchdog: advance a bounded window that (a) settles the reattach and
+        // (b) exhausts the ~17s blank-watchdog run on the still-black pane.
+        advanceTimeBy(CONNECTED_BLANK_WATCHDOG_TICK_MS * CONNECTED_BLANK_WATCHDOG_MAX_TICKS * 4)
+        runCurrent()
+
+        assertSame(
+            "the warm reattach reached Live on the fresh client",
+            replacementClient,
+            registry.clients.value[7L]?.client,
+        )
+        val pane = vm.panes.value.single { it.paneId == "%1" }
+        assertTrue(
+            "the reattached pane's seed stayed empty -> black on a live transport",
+            pane.terminalState.visibleScreenIsBlank(),
+        )
+        // GAP B fix: on blank-watchdog exhaustion the :8077 path hands off to the
+        // stale-render heal watchdog instead of exiting silently into permanent
+        // black. RED (base): no watchdog armed (job null). GREEN: it is running.
+        val staleJob = vm.staleRenderWatchdogJobForTest()
+        assertTrue(
+            "Issue #1177 (:8077 warm reattach): a blank reattach seed must arm the " +
+                "stale-render heal watchdog, never a permanent silent black. job=$staleJob",
+            staleJob != null && staleJob.isActive,
+        )
+        // ...and it HEALS the black pane once tmux carries a real frame.
+        replacementClient.capturePaneResponses.addLast(
+            CommandResponse(number = 99L, output = issue1177RecoveredFrame(), isError = false),
+        )
+        advanceTimeBy(STALE_RENDER_WATCHDOG_MAX_INTERVAL_MS + STALE_RENDER_WATCHDOG_TICK_MS + 100)
+        runCurrent()
+        assertFalse(
+            "Issue #1177 (:8077): the stale-render heal must repaint the black " +
+                "reattached pane — never a permanent black on a live transport.",
+            pane.terminalState.visibleScreenIsBlank(),
+        )
+    }
+
+    @Test
+    fun transportSilentReattachThatSeedsBlankArmsStaleRenderHealNotSilentBlack() = runTest(scheduler) {
+        // :8319 — the FRESH-TRANSPORT silent reattach. The old session is broken
+        // (isConnected=false) so the warm reattach fails and a fresh transport is
+        // reacquired via the lease connector; its replacement client's row resolves
+        // but every capture is empty, so the reattached pane is BLACK on green.
+        TMUX_CONNECT_ATTEMPTS.set(1)
+        val registry = ActiveTmuxClients()
+        val connector = QueueLeaseConnector(FakeSshSession())
+        val vm = newVm(
+            registry = registry,
+            sshLeaseManager = testLeaseManager(connector = connector, scope = this, idleTtlMillis = 0L),
+        )
+        vm.setPassiveDisconnectRecoveryForTest(graceMs = 5_000L, silentReattachTimeoutMs = 5_000L)
+        vm.setProcessForegroundForClearedForTest(true)
+        vm.setScreenInteractiveForTest(true)
+        vm.setStaleRenderWatchdogMaxTicksForTest(1000)
+        val deadClient = FakeTmuxClient()
+        val replacementClient =
+            FakeTmuxClient().withSinglePaneRowButEmptyCapture("work", "%1")
+        vm.setTmuxClientFactoryForTest { _, sessionName, _ ->
+            assertEquals("work", sessionName)
+            replacementClient
+        }
+        vm.replaceClientForTest(
+            hostId = 7L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            sessionName = "work",
+            client = deadClient,
+            session = FakeSshSession(isConnectedValue = false),
+        )
+        runCurrent()
+
+        deadClient.disconnectedSignal.value = true
+        advanceTimeBy(CONNECTED_BLANK_WATCHDOG_TICK_MS * CONNECTED_BLANK_WATCHDOG_MAX_TICKS * 4)
+        runCurrent()
+
+        assertSame(
+            "the fresh-transport reattach reached Live on the fresh client",
+            replacementClient,
+            registry.clients.value[7L]?.client,
+        )
+        assertEquals("a fresh transport was reacquired", 1, connector.connectCount)
+        val pane = vm.panes.value.single { it.paneId == "%1" }
+        assertTrue(
+            "the fresh-transport reattach's seed stayed empty -> black on a live transport",
+            pane.terminalState.visibleScreenIsBlank(),
+        )
+        val staleJob = vm.staleRenderWatchdogJobForTest()
+        assertTrue(
+            "Issue #1177 (:8319 fresh-transport reattach): a blank reattach seed must " +
+                "arm the stale-render heal watchdog, never a permanent silent black. job=$staleJob",
+            staleJob != null && staleJob.isActive,
+        )
+        replacementClient.capturePaneResponses.addLast(
+            CommandResponse(number = 99L, output = issue1177RecoveredFrame(), isError = false),
+        )
+        advanceTimeBy(STALE_RENDER_WATCHDOG_MAX_INTERVAL_MS + STALE_RENDER_WATCHDOG_TICK_MS + 100)
+        runCurrent()
+        assertFalse(
+            "Issue #1177 (:8319): the stale-render heal must repaint the black " +
+                "reattached pane — never a permanent black on a live transport.",
+            pane.terminalState.visibleScreenIsBlank(),
+        )
+    }
+
     /**
      * Issue #685 (Bug B): the "control channel closed before response /
      * mid-command" error in the maintainer's screenshot is the beyond-grace
@@ -16699,6 +16855,39 @@ class TmuxSessionViewModelTest {
         cursorQueryResponses.addLast(
             CommandResponse(number = 3L, output = listOf("0,0"), isError = false),
         )
+    }
+
+    /**
+     * Issue #1177 (black-screen GAP B): a replacement/reattach client whose
+     * `list-panes` row RESOLVES (so the reattach reaches Live — panes-ready gates
+     * on the row, not the capture) but whose `capture-pane` seed keeps coming back
+     * EMPTY — so the reattached active pane stays BLACK on a live (green) transport.
+     * This is the exact silent-reattach surface the :8077/:8319 paths arm the blank
+     * watchdog for.
+     */
+    private fun FakeTmuxClient.withSinglePaneRowButEmptyCapture(
+        sessionName: String,
+        paneId: String,
+    ): FakeTmuxClient = apply {
+        responses.addLast(
+            CommandResponse(
+                number = 1L,
+                output = listOf("$paneId\t@0\t\$0\t$sessionName\t$sessionName\t0"),
+                isError = false,
+            ),
+        )
+        // No capturePaneResponses queued: every capture falls back to the default
+        // empty response -> the reattached pane stays black.
+    }
+
+    /**
+     * Issue #1177: a recovery `capture-pane` frame rich enough to clear the heal
+     * oracle's STALE_RENDER_MIN_CAPTURE_CHARS floor (a single short line is below
+     * it). The marker line proves the healed frame landed on the pane's grid.
+     */
+    private fun issue1177RecoveredFrame(): List<String> = buildList {
+        add("ISSUE1177-REATTACH-HEALED — recovered viewport after silent-reattach")
+        repeat(24) { add("recovered context row $it xxxxxxxxxxxxxxxxxxxxxxxxxxxx") }
     }
 
     private fun tmuxRuntimeKeyForTest(


### PR DESCRIPTION
GAP B of the #874 black-screen spike + the maintainer's CONFIRMED live-log symptom (fully-black on a green connection after a post-grace reconnect). The silent-reattach exhaustion branch fell off silently → permanent black; now hands off to the existing stale-render heal watchdog. Reviewer APPROVED: red→green driven on both :8077+:8319 (base asserts job=null permanent black; fix heals), 365 tests 0 regressions, no new polling, scope clean. Paired with #1176 (GAP A) covers the full symptom. Local gate on the rebased tree: reattach + diagnostics tests green.\n\nCloses #1177