### PR TITLE
sessions: let the user name a new session (custom label) (#1184)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/projects/SessionTypePickerNameFieldUiTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/SessionTypePickerNameFieldUiTest.kt
@@ -1,0 +1,106 @@
+package com.pocketshell.app.projects
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextClearance
+import androidx.compose.ui.test.performTextInput
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.pocketshell.uikit.theme.PocketShellTheme
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * UI proof for issue #1184: the new-session picker exposes an editable
+ * "Session name" field prefilled with the directory-derived default, and the
+ * user's typed label is threaded onto [SessionTypeChoice.customName] (which
+ * the caller sanitises + disambiguates via
+ * [SessionNameDerivation.resolveSessionName]).
+ *
+ * Drives [SessionTypePickerContent] directly (no SSH / Compose sheet
+ * animation), mirroring [SessionTypePickerSkipPermissionsUiTest]. The wiring
+ * from `customName` → the final tmux name is JVM-tested in
+ * [SessionNameDerivationTest]; this pins the UI-boundary behaviour:
+ *
+ *  - the field is PREFILLED with the derived default (accepting it unchanged
+ *    reproduces today's behaviour — no regression),
+ *  - a typed custom label is emitted on the choice,
+ *  - clearing the field emits `null` so the caller falls back to the derived
+ *    default (blank → default).
+ */
+@RunWith(AndroidJUnit4::class)
+class SessionTypePickerNameFieldUiTest {
+
+    @get:Rule
+    val compose = createAndroidComposeRule<ComponentActivity>()
+
+    private fun content(onCreate: (SessionTypeChoice) -> Unit) {
+        compose.setContent {
+            PocketShellTheme {
+                SessionTypePickerContent(
+                    folderPath = "/home/alexey/git/pocketshell",
+                    folderLabel = "pocketshell",
+                    onCancel = {},
+                    onCreate = onCreate,
+                    // Same deriver the production folder flow wires in.
+                    deriveDefaultName = { dir ->
+                        defaultSessionBaseName(dir, "/home/alexey")
+                    },
+                )
+            }
+        }
+    }
+
+    @Test
+    fun nameFieldIsPrefilledWithDerivedDefault() {
+        content(onCreate = {})
+        // Prefilled with the directory-derived default `git-pocketshell`.
+        compose.onNodeWithTag(SESSION_TYPE_PICKER_NAME_TAG)
+            .assertTextEquals("git-pocketshell")
+    }
+
+    @Test
+    fun acceptingPrefilledNameUnchangedEmitsDerivedDefault() {
+        var lastChoice: SessionTypeChoice? = null
+        content(onCreate = { lastChoice = it })
+
+        compose.onNodeWithTag(SESSION_TYPE_PICKER_CREATE_TAG).performClick()
+        compose.waitForIdle()
+        // No regression: the derived default flows through as the custom label.
+        assertEquals("git-pocketshell", lastChoice?.customName)
+    }
+
+    @Test
+    fun typedCustomLabelIsThreadedOntoTheChoice() {
+        var lastChoice: SessionTypeChoice? = null
+        content(onCreate = { lastChoice = it })
+
+        val field = compose.onNodeWithTag(SESSION_TYPE_PICKER_NAME_TAG)
+        field.performTextClearance()
+        field.performTextInput("git-pocketshell-review")
+        compose.waitForIdle()
+
+        compose.onNodeWithTag(SESSION_TYPE_PICKER_CREATE_TAG).performClick()
+        compose.waitForIdle()
+        assertEquals("git-pocketshell-review", lastChoice?.customName)
+    }
+
+    @Test
+    fun clearingNameEmitsNullSoCallerFallsBackToDerivedDefault() {
+        var lastChoice: SessionTypeChoice? = null
+        content(onCreate = { lastChoice = it })
+
+        compose.onNodeWithTag(SESSION_TYPE_PICKER_NAME_TAG).performTextClearance()
+        compose.waitForIdle()
+
+        compose.onNodeWithTag(SESSION_TYPE_PICKER_CREATE_TAG).performClick()
+        compose.waitForIdle()
+        // Blank field → null customName → caller uses the derived default.
+        assertNull(lastChoice?.customName)
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/projects/FolderListScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListScreen.kt
@@ -482,6 +482,11 @@ fun FolderListScreen(
             claudeProfiles = claudeProfiles,
             codexProfiles = codexProfiles,
             creating = (state as? FolderListUiState.Ready)?.isCreatingSession == true,
+            // Issue #1184: prefill the editable "Session name" field with the
+            // directory-derived default for the chosen start folder.
+            deriveDefaultName = { dir ->
+                defaultSessionBaseName(dir, conventionalRemoteHome(username))
+            },
             onCreate = { choice ->
                 val newName = derivedSessionName(
                     choice = choice,
@@ -713,15 +718,27 @@ internal fun derivedSessionName(
     choice: SessionTypeChoice,
     homeDirectory: String? = null,
     existingNames: Set<String> = emptySet(),
-): String = SessionNameDerivation.derive(
+): String = SessionNameDerivation.resolveSessionName(
+    // Issue #1184: honour a user-entered custom label when present; a blank
+    // custom name falls back to the directory-derived default (#429/#642),
+    // and either base is disambiguated against [existingNames].
+    customName = choice.customName,
     startDirectory = choice.startDirectory,
     homeDirectory = homeDirectory,
-    agentCommand = when (choice.type) {
-        SessionType.Shell -> null
-        SessionType.Agent -> choice.agent?.command
-    },
     existingNames = existingNames,
 )
+
+/**
+ * The directory-derived DEFAULT session name (no collision suffix) used to
+ * prefill the "Session name" field in the new-session picker — issue #1184.
+ * The picker keeps this in sync with the chosen start folder until the user
+ * types their own label; the final collision `disambiguate` still runs at
+ * create time in [derivedSessionName].
+ */
+internal fun defaultSessionBaseName(
+    startDirectory: String,
+    homeDirectory: String?,
+): String = SessionNameDerivation.baseName(startDirectory, homeDirectory)
 
 /**
  * Conventional remote `$HOME` inferred from the SSH [username] — issue

--- a/app/src/main/java/com/pocketshell/app/projects/RepoBrowserScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/RepoBrowserScreen.kt
@@ -155,6 +155,11 @@ fun RepoBrowserScreen(
             folderLabel = repoFolderLabel(repoPath),
             onDismiss = { pickerRepoPath = null },
             suggestStartDirectories = suggestStartDirectories,
+            // Issue #1184: prefill the editable "Session name" field with the
+            // directory-derived default for the chosen start folder.
+            deriveDefaultName = { dir ->
+                defaultSessionBaseName(dir, conventionalRemoteHome(username))
+            },
             onCreate = { choice ->
                 pickerRepoPath = null
                 val newName = derivedSessionName(

--- a/app/src/main/java/com/pocketshell/app/projects/SessionNameDerivation.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/SessionNameDerivation.kt
@@ -72,6 +72,50 @@ internal object SessionNameDerivation {
     }
 
     /**
+     * Resolve the final tmux session name for a NEW session, honouring an
+     * optional user-entered custom label (issue #1184).
+     *
+     * The directory-derived default ([derive]/#429/#642) is preserved as the
+     * fallback — this ADDS a user override, it does not replace the default
+     * (D22 hard-cut: no fork of the naming convention). Behaviour:
+     *
+     *  - A meaningful [customName] is sanitised to a tmux-safe name via
+     *    [sanitiseName] (spaces / `.` / `:` and other disallowed characters
+     *    are normalised) and used as the base.
+     *  - A blank/`null` [customName] — including one with no real content once
+     *    sanitised (all whitespace, or all-punctuation such as `...`/`:::`
+     *    that leaves only `_`/`-` separators) — falls back to the
+     *    directory-derived [baseName]. "Meaningful" means the sanitised label
+     *    contains at least one letter or digit.
+     *  - Either way the base is run through [disambiguate] against
+     *    [existingNames], so a duplicate label gets a deterministic `-2`,
+     *    `-3`, … suffix and can never silently attach to a DIFFERENT
+     *    session's tmux.
+     */
+    fun resolveSessionName(
+        customName: String?,
+        startDirectory: String,
+        homeDirectory: String?,
+        existingNames: Set<String> = emptySet(),
+    ): String {
+        val custom = customName
+            ?.let { sanitiseName(it) }
+            ?.takeIf { name -> name.any(Char::isLetterOrDigit) }
+        val base = custom ?: baseName(startDirectory, homeDirectory)
+        return disambiguate(base, existingNames)
+    }
+
+    /**
+     * Sanitise a whole user-entered custom label to a tmux-safe name (issue
+     * #1184), reusing the per-component [sanitisePart] rules: `.`/`:` → `_`
+     * (tmux forbids `.` and `:` in session names), any other disallowed run
+     * → `-`, then strip leading/trailing `-`. Leading/trailing whitespace is
+     * trimmed first. An all-punctuation label sanitises to the empty string,
+     * which the caller treats as "fall back to the derived default".
+     */
+    fun sanitiseName(name: String): String = sanitisePart(name.trim())
+
+    /**
      * The directory-derived part of the name (no agent prefix, no
      * collision suffix). Exposed for focused unit tests of the tmuxctl
      * path logic.
@@ -125,7 +169,7 @@ internal object SessionNameDerivation {
      * session names), then any other disallowed run collapses to `-`, then
      * strip leading/trailing `-`.
      */
-    private fun sanitisePart(part: String): String =
+    internal fun sanitisePart(part: String): String =
         part
             .replace(Regex("[.:]+"), "_")
             .replace(Regex("[^A-Za-z0-9_-]+"), "-")

--- a/app/src/main/java/com/pocketshell/app/projects/SessionTypePickerSheet.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/SessionTypePickerSheet.kt
@@ -19,9 +19,11 @@ import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CheckboxDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -82,6 +84,12 @@ fun SessionTypePickerSheet(
     // (shell-vs-agent toggle, agent CLI sub-picker, profiles, skip-permissions)
     // is reused verbatim. Defaults to "New session" for the folder flow.
     title: String = "New session",
+    // Issue #1184: derive the DEFAULT session label to prefill the editable
+    // "Session name" field from the currently-chosen start folder. The caller
+    // wires in the host's `$HOME` so the default matches the directory-derived
+    // convention (#429/#642). Defaults to the folder's trailing segment when a
+    // caller doesn't supply the deriver.
+    deriveDefaultName: (startDirectory: String) -> String = { it.trimEnd('/').substringAfterLast('/') },
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val autocompleteController = rememberStartDirectoryAutocompleteController(suggestStartDirectories)
@@ -101,6 +109,7 @@ fun SessionTypePickerSheet(
             codexProfiles = codexProfiles,
             creating = creating,
             title = title,
+            deriveDefaultName = deriveDefaultName,
         )
     }
 }
@@ -121,6 +130,7 @@ internal fun SessionTypePickerContent(
     codexProfiles: List<CodexProfile> = emptyList(),
     creating: Boolean = false,
     title: String = "New session",
+    deriveDefaultName: (startDirectory: String) -> String = { it.trimEnd('/').substringAfterLast('/') },
 ) {
     var sessionType by remember { mutableStateOf(SessionType.Agent) }
     var agentKind by remember { mutableStateOf(AgentCli.Claude) }
@@ -128,6 +138,17 @@ internal fun SessionTypePickerContent(
     // agent launched without per-action approval prompts.
     var skipPermissions by remember { mutableStateOf(true) }
     var startDirectory by remember { mutableStateOf(folderPath) }
+    // Issue #1184: editable custom session label, prefilled with the
+    // directory-derived default so the common case stays one tap. Until the
+    // user types their own label ([nameManuallyEdited]), the field tracks the
+    // chosen start folder; once edited, it is left alone.
+    var sessionName by remember { mutableStateOf(deriveDefaultName(folderPath)) }
+    var nameManuallyEdited by remember { mutableStateOf(false) }
+    LaunchedEffect(startDirectory) {
+        if (!nameManuallyEdited) {
+            sessionName = deriveDefaultName(startDirectory)
+        }
+    }
     // Issue #627: selected Claude profile. null = default (no config dir override).
     var claudeProfile by remember { mutableStateOf<String?>(null) }
     // Issue #631: selected Codex profile. null = default (no config dir override).
@@ -156,6 +177,26 @@ internal fun SessionTypePickerContent(
                 subtitle = "in $folderLabel",
                 subtitleStyle = PocketShellType.bodyMono,
             )
+
+            // Session name — editable custom label (issue #1184), prefilled
+            // with the directory-derived default. Accepting it unchanged
+            // reproduces the derived-name behaviour; a blank field falls back
+            // to the derived default at create time.
+            Column(verticalArrangement = Arrangement.spacedBy(PocketShellSpacing.xs)) {
+                SectionHeader(label = "Session name")
+                OutlinedTextField(
+                    value = sessionName,
+                    onValueChange = {
+                        sessionName = it
+                        nameManuallyEdited = true
+                    },
+                    singleLine = true,
+                    placeholder = { Text(deriveDefaultName(startDirectory)) },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag(SESSION_TYPE_PICKER_NAME_TAG),
+                )
+            }
 
             // Start folder — pre-filled, editable. Keep this inside the
             // scrollable sheet body so the autocomplete can request enough
@@ -320,6 +361,10 @@ internal fun SessionTypePickerContent(
                                 } else {
                                     null
                                 },
+                                // Issue #1184: carry the user's custom label.
+                                // Blank falls back to the derived default at
+                                // create time (SessionNameDerivation).
+                                customName = sessionName.trim().ifBlank { null },
                             ),
                         )
                     }
@@ -393,6 +438,14 @@ data class SessionTypeChoice(
      * sessions.
      */
     val codexProfileName: String? = null,
+    /**
+     * The user-entered custom session label (issue #1184). `null`/blank means
+     * "use the directory-derived default" (#429/#642). When present it is
+     * sanitised to a tmux-safe name and disambiguated against the known
+     * session names by [SessionNameDerivation.resolveSessionName] at create
+     * time — it never bypasses collision handling.
+     */
+    val customName: String? = null,
 ) {
     /**
      * The start command to invoke inside the new tmux pane after
@@ -567,6 +620,7 @@ const val SESSION_TYPE_PICKER_AGENT_CODEX_TAG: String = "session-type-picker:age
 const val SESSION_TYPE_PICKER_AGENT_OPENCODE_TAG: String = "session-type-picker:agent:opencode"
 const val SESSION_TYPE_PICKER_SKIP_PERMISSIONS_TAG: String = "session-type-picker:skip-permissions"
 const val SESSION_TYPE_PICKER_CWD_TAG: String = "session-type-picker:cwd"
+const val SESSION_TYPE_PICKER_NAME_TAG: String = "session-type-picker:name"
 const val SESSION_TYPE_PICKER_CANCEL_TAG: String = "session-type-picker:cancel"
 const val SESSION_TYPE_PICKER_CREATE_TAG: String = "session-type-picker:create"
 const val SESSION_TYPE_PICKER_CLAUDE_PROFILE_TAG: String = "session-type-picker:claude-profile"

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
@@ -129,6 +129,7 @@ import com.pocketshell.app.layout.rememberTmuxImeLayoutState
 import com.pocketshell.app.projects.FolderListViewModel
 import com.pocketshell.app.projects.SessionTypePickerSheet
 import com.pocketshell.app.projects.conventionalRemoteHome
+import com.pocketshell.app.projects.defaultSessionBaseName
 import com.pocketshell.app.projects.derivedSessionName
 import com.pocketshell.app.session.AgentConversationSyncStatus
 import com.pocketshell.app.session.ConversationLoadState
@@ -2450,6 +2451,11 @@ public fun TmuxSessionScreen(
                 suggestStartDirectories = suggestStartDirectories,
                 claudeProfiles = newSessionClaudeProfiles,
                 codexProfiles = newSessionCodexProfiles,
+                // Issue #1184: prefill the editable "Session name" field with
+                // the directory-derived default for the chosen start folder.
+                deriveDefaultName = { dir ->
+                    defaultSessionBaseName(dir, conventionalRemoteHome(user))
+                },
                 onCreate = { choice ->
                     showNewSessionSheet = false
                     // Issue #898 (Finding 1): pass the host's already-known

--- a/app/src/test/java/com/pocketshell/app/projects/SessionNameDerivationTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/SessionNameDerivationTest.kt
@@ -314,6 +314,154 @@ class SessionNameDerivationTest {
         assertEquals("tmp-issue898", name)
     }
 
+    // --- Issue #1184: user-entered custom session label (resolveSessionName /
+    // the derivedSessionName(choice, …) wrapper carrying choice.customName).
+    // These pin every acceptance criterion: default accepted → derived name;
+    // custom sanitised; collision disambiguated (never silently attaches to a
+    // different session's tmux); blank → derived default. ---
+
+    @Test
+    fun customNameNullFallsBackToDerivedDefault() {
+        // Acceptance: accepting the prefilled default unchanged reproduces
+        // today's derived-name behaviour (no regression).
+        val name = SessionNameDerivation.resolveSessionName(
+            customName = null,
+            startDirectory = "~/git/pocketshell",
+            homeDirectory = home,
+        )
+        assertEquals("git-pocketshell", name)
+    }
+
+    @Test
+    fun customNameEqualToDerivedDefaultIsUnchanged() {
+        // The picker prefills the field with the derived base; submitting it
+        // verbatim must yield exactly the derived name.
+        val name = SessionNameDerivation.resolveSessionName(
+            customName = "git-pocketshell",
+            startDirectory = "~/git/pocketshell",
+            homeDirectory = home,
+        )
+        assertEquals("git-pocketshell", name)
+    }
+
+    @Test
+    fun customNameWithSpacesIsSanitisedToValidTmuxName() {
+        val name = SessionNameDerivation.resolveSessionName(
+            customName = "git pocketshell review",
+            startDirectory = "~/git/pocketshell",
+            homeDirectory = home,
+        )
+        assertEquals("git-pocketshell-review", name)
+        assertNoTmuxForbidden(name)
+    }
+
+    @Test
+    fun customNameWithDotsAndColonsIsSanitised() {
+        // tmux forbids `.` and `:` — they must collapse to `_`.
+        val name = SessionNameDerivation.resolveSessionName(
+            customName = "my.session:name",
+            startDirectory = "~/git/pocketshell",
+            homeDirectory = home,
+        )
+        assertEquals("my_session_name", name)
+        assertNoTmuxForbidden(name)
+    }
+
+    @Test
+    fun customNameCollidingWithExistingIsDisambiguated() {
+        // Acceptance: a custom label that collides with an existing session
+        // must be disambiguated, never silently attach to a different
+        // session's tmux (which `new-session -A` would otherwise do).
+        val name = SessionNameDerivation.resolveSessionName(
+            customName = "review",
+            startDirectory = "~/git/pocketshell",
+            homeDirectory = home,
+            existingNames = setOf("review"),
+        )
+        assertEquals("review-2", name)
+    }
+
+    @Test
+    fun customNameCollisionWalksUpUntilFreeSlot() {
+        val name = SessionNameDerivation.resolveSessionName(
+            customName = "review",
+            startDirectory = "~/git/pocketshell",
+            homeDirectory = home,
+            existingNames = setOf("review", "review-2", "review-3"),
+        )
+        assertEquals("review-4", name)
+    }
+
+    @Test
+    fun blankCustomNameFallsBackToDerivedDefault() {
+        // Acceptance: an empty/blank custom name falls back to the derived
+        // default. Covers "", whitespace-only, and punctuation-only (which
+        // sanitises to empty).
+        listOf("", "   ", "...", ":::", "---").forEach { blank ->
+            val name = SessionNameDerivation.resolveSessionName(
+                customName = blank,
+                startDirectory = "~/git/pocketshell",
+                homeDirectory = home,
+            )
+            assertEquals("git-pocketshell", name)
+        }
+    }
+
+    @Test
+    fun sanitiseNameNeverContainsTmuxForbiddenCharacters() {
+        listOf("a.b:c", "weird name!", "tab\tsep", "slash/path").forEach {
+            assertNoTmuxForbidden(SessionNameDerivation.sanitiseName(it))
+        }
+    }
+
+    @Test
+    fun derivedSessionNameWrapperUsesCustomLabel() {
+        // The UI carries the user's label on choice.customName; the wrapper
+        // must sanitise + use it instead of the directory-derived default.
+        val choice = SessionTypeChoice(
+            type = SessionType.Agent,
+            agent = AgentCli.Claude,
+            startDirectory = "~/git/pocketshell",
+            customName = "git pocketshell review",
+        )
+        val name = derivedSessionName(
+            choice = choice,
+            homeDirectory = home,
+        )
+        assertEquals("git-pocketshell-review", name)
+    }
+
+    @Test
+    fun derivedSessionNameWrapperDisambiguatesCustomLabel() {
+        val choice = SessionTypeChoice(
+            type = SessionType.Shell,
+            agent = null,
+            startDirectory = "~/git/pocketshell",
+            customName = "review",
+        )
+        val name = derivedSessionName(
+            choice = choice,
+            homeDirectory = home,
+            existingNames = setOf("review"),
+        )
+        assertEquals("review-2", name)
+    }
+
+    @Test
+    fun derivedSessionNameWrapperBlankCustomFallsBackToDerived() {
+        val choice = SessionTypeChoice(
+            type = SessionType.Shell,
+            agent = null,
+            startDirectory = "~/git/pocketshell",
+            customName = "   ",
+        )
+        val name = derivedSessionName(
+            choice = choice,
+            homeDirectory = home,
+        )
+        assertEquals("git-pocketshell", name)
+    }
+
     // --- conventionalRemoteHome / knownSessionNames helpers ---
 
     @Test

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -1246,6 +1246,13 @@ JOURNEY_CLASSES=(
   # so they carry their fully-qualified names directly.
   "com.pocketshell.app.projects.FolderListScreenE2eTest#profiledSessionsShowProfileChipDefaultSessionsDoNot"
   "com.pocketshell.app.projects.SessionKindPickerUiTest"
+  # ADDED (#1184, D32 G9): the new-session picker's editable "Session name"
+  # field — prefilled with the directory-derived default, threads a typed
+  # custom label onto SessionTypeChoice.customName, and emits null when blank
+  # so the caller falls back to the derived default. Component test (drives
+  # SessionTypePickerContent directly, no SSH), so its FQCN is listed here to
+  # run in the emulator-journey gate.
+  "com.pocketshell.app.projects.SessionTypePickerNameFieldUiTest"
   # ADDED (#863, D32 G9): per-criterion gate for the residual-TextButton sweep.
   # #863 migrated raw Material TextButtons (+ a private AppBarTextButton wrapper)
   # in FileExplorerScreen, FileViewerScreen, SnippetPickerSheet, FolderListScreen


### PR DESCRIPTION
Maintainer request: type a custom session label instead of the auto -2/-3 suffix. Editable name field prefilled with the derived default, sanitized to tmux-safe + disambiguated, blank→default. Reviewer APPROVED: on-device UI test 4/4 (prefill/accept/custom/clear), JVM 38 tests non-vacuous, FolderListViewModel untouched (clean rebase w/ #1155). Local gate: SessionNameDerivation tests green, androidTest compiles.\n\nCloses #1184