### PR TITLE
connection: recover the selected session when a coalesced connect is cancelled (#1185)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -102,6 +102,7 @@ import com.pocketshell.core.portfwd.PortScanner
 import com.pocketshell.core.ssh.KnownHostsPolicy
 import com.pocketshell.core.ssh.SshKey
 import com.pocketshell.core.ssh.SshLease
+import com.pocketshell.core.ssh.SshLeaseConnectCoalescedCancelException
 import com.pocketshell.core.ssh.SshLeaseConnector
 import com.pocketshell.core.ssh.SshLeaseKey
 import com.pocketshell.core.ssh.SshLeaseManager
@@ -2060,6 +2061,16 @@ public class TmuxSessionViewModel @Inject constructor(
     // host cannot loop forever. Reset to 0 on a successful attach.
     private var staleLeaseAutoRecoverAttempts: Int = 0
 
+    // Issue #1185: how many times the SELECTED session has transparently
+    // re-dialled after its lease acquire was woken with a coalesced-connect
+    // cancel (the create-then-switch supersede). The pool slot is already
+    // cleared, so a re-dial normally becomes a fresh owner and connects on the
+    // first retry; the cap only stops a pathological repeat (a host that keeps
+    // getting its in-flight connect cancelled) from looping forever, at which
+    // point the honest terminal error + working Retry surfaces. Reset to 0 on a
+    // successful attach (alongside [staleLeaseAutoRecoverAttempts]).
+    private var coalescedCancelRedialAttempts: Int = 0
+
     // Issue #145: whether [reconnect] would result in a new connect
     // attempt. The screen surfaces a Reconnect button only when this is
     // true; without a known target (e.g. the ViewModel was never opened)
@@ -3061,6 +3072,7 @@ public class TmuxSessionViewModel @Inject constructor(
         // stale-lease heal worked (or was never needed), so the budget resets
         // for the next connect chain.
         staleLeaseAutoRecoverAttempts = 0
+        coalescedCancelRedialAttempts = 0
         lifecycleReattachNetworkCoalesce =
             if (trigger == TmuxConnectTrigger.LifecycleReattach) {
                 LifecycleReattachNetworkCoalesce(
@@ -6952,6 +6964,18 @@ public class TmuxSessionViewModel @Inject constructor(
         // NEXT acquire opens a fresh transport that can open the channel, and
         // force-preserve the reconnect target so the Reconnect affordance has
         // something to retry even when this was the very first connect.
+        // Issue #1185: the acquire that failed here may not be a genuine
+        // unreachable at all — the SELECTED session's lease acquire may have
+        // COALESCED (#620) onto an in-flight connect owned by a just-superseded
+        // create/attach flow on the same host, and the user's own navigation
+        // (create-new → immediately select an existing session) cancelled that
+        // owner. The lease wakes the awaiter with a TYPED
+        // [SshLeaseConnectCoalescedCancelException] (NOT a bare
+        // CancellationException) precisely so this consumer can tell it apart
+        // from an unreachable host and re-dial the selected session's OWN fresh
+        // connect instead of stranding it on a Disconnected pill + "Attaching…"
+        // spinner with no recovery.
+        val coalescedCancel = isCoalescedConnectCancel(cause)
         val staleChannelSymptom = isStaleChannelSymptom(cause)
         if (staleChannelSymptom) {
             withContext(NonCancellable) {
@@ -7012,6 +7036,73 @@ public class TmuxSessionViewModel @Inject constructor(
         }
         activeAttachMilestone = null
         activeTarget = null
+
+        // Issue #1185: a coalesced-connect cancel of the selected session's
+        // superseded owner is NOT a terminal failure. The pool slot is already
+        // cleared, so re-dial the SELECTED session's own fresh connect (which
+        // becomes a new owner and dials cleanly) transparently — the user asked
+        // for THIS session; a supersede of an unrelated flow's connect must never
+        // strand it. Guarded so we never re-dial a session the user has since
+        // navigated away from, and bounded so a pathological repeat cannot loop
+        // forever (then the honest terminal error + working Retry surfaces).
+        if (shouldRedialAfterCoalescedCancel(coalescedCancel, target)) {
+            coalescedCancelRedialAttempts += 1
+            Log.i(
+                ISSUE_145_RECONNECT_TAG,
+                "tmux-coalesced-cancel-redial selected session re-dials own connect after " +
+                    "superseded-owner cancel; " +
+                    "attempt=$coalescedCancelRedialAttempts/$COALESCED_CANCEL_REDIAL_MAX " +
+                    "trigger=${trigger.logValue} ${targetLogFields(target)}",
+            )
+            ReconnectCauseTrail.record(
+                stage = "coalesced_cancel_redial",
+                outcome = "transparent_redial",
+                cause = "connect_cancelled",
+                trigger = trigger.logValue,
+                "attempt" to coalescedCancelRedialAttempts,
+                "maxAttempts" to COALESCED_CANCEL_REDIAL_MAX,
+                "hostId" to target.hostId,
+                "failureClass" to cause.javaClass.simpleName,
+            )
+            // Show a calm Reattaching band immediately so the surface is never a
+            // Disconnected/Failed band (and never a stranded "Attaching…" spinner)
+            // for the brief window before the fresh re-dial coroutine is
+            // dispatched. Leave [connectingTarget] null so the recovery's
+            // [connect] is not swallowed by its in-flight early-return guard while
+            // this failing job unwinds.
+            connectingTarget = null
+            refreshReconnectAvailability()
+            setConnectionState(
+                ConnectionState.Reattaching(
+                    host = target.host,
+                    port = target.port,
+                    user = target.user,
+                    attempt = 1,
+                    maxAttempts = 1,
+                    retryDelayMs = 0L,
+                    reason = "Reattaching ${target.user}@${target.host}:${target.port}.",
+                ),
+            )
+            val recoverTarget = target
+            connectJob = null
+            launchContainedTeardown {
+                connect(
+                    hostId = recoverTarget.hostId,
+                    hostName = recoverTarget.hostName,
+                    host = recoverTarget.host,
+                    port = recoverTarget.port,
+                    user = recoverTarget.user,
+                    keyPath = recoverTarget.keyPath,
+                    passphrase = recoverTarget.passphrase,
+                    sessionName = recoverTarget.sessionName,
+                    startDirectory = recoverTarget.startDirectory,
+                    tmuxSessionId = recoverTarget.tmuxSessionId,
+                    sessionCreated = recoverTarget.sessionCreated,
+                    trigger = TmuxConnectTrigger.AutoReconnect,
+                )
+            }
+            return
+        }
 
         // Issue #621 / #634 / #636 (Slice 4): an open/switch attach that EOFs
         // on a silently-dead warm lease (`tmux -CC` open or `list-panes`) must
@@ -7106,12 +7197,28 @@ public class TmuxSessionViewModel @Inject constructor(
             return
         }
 
-        connectingTarget = if (preserveReconnectTarget || staleChannelSymptom) target else null
+        // Issue #1185: a coalesced-connect cancel that reached the terminal
+        // fallback (its bounded re-dial budget was exhausted) must still leave a
+        // WORKING Retry — preserve the reconnect target so [canReconnect] is true
+        // and the user is never dead-ended on a Disconnected pill with no
+        // Reconnect affordance.
+        connectingTarget =
+            if (preserveReconnectTarget || staleChannelSymptom || coalescedCancel) target else null
         refreshReconnectAvailability()
         // Issue #661: a failed switch must drop the cross-session "hide terminal"
         // gate so the Failed band is shown (not the loading placeholder).
         _switchHidesTerminal.value = false
         setConnectionState(ConnectionState.Unreachable(message))
+        // Issue #1185 (two-holder safety net): drive the reveal machine DIRECTLY
+        // to a terminal error for THIS exact target instead of relying solely on
+        // the ConnectionController's synthetic drop→Unreachable ladder to deliver a
+        // matching-id edge to the reveal collector. This guarantees the reveal
+        // surface ("Attaching…"/Seeding) and the status pill (Disconnected) can
+        // never disagree — a terminal connect failure moves BOTH holders to an
+        // honest error in lockstep, closing the #1185 contradictory Disconnected +
+        // live-spinner surface. Drop-by-id inside the machine makes this a no-op if
+        // the user has since navigated to another session.
+        driveRevealTerminalError(target)
     }
 
     /**
@@ -7140,6 +7247,67 @@ public class TmuxSessionViewModel @Inject constructor(
             autoReconnectDelaysMs.isNotEmpty() &&
             !trigger.isReconnectTrigger &&
             staleLeaseAutoRecoverAttempts < STALE_LEASE_AUTO_RECOVER_MAX
+
+    /**
+     * Issue #1185: decide whether to transparently re-dial the SELECTED session's
+     * own connect after its lease acquire was woken with a coalesced-connect
+     * cancel (a superseded owner on the same host was cancelled by the user's
+     * create-new → immediately-select navigation).
+     *
+     * Conditions:
+     *  - the failure is the typed [SshLeaseConnectCoalescedCancelException]
+     *    ([coalescedCancel]) — never a genuine unreachable/auth/DNS error, which
+     *    must still surface the honest terminal error (no infinite re-dial);
+     *  - the app is foregrounded (a backgrounded app must not burn re-dials);
+     *  - auto-reconnect is enabled (the user hasn't disabled it / a test hasn't
+     *    cleared the delays);
+     *  - the per-chain budget has not been exhausted, so a host whose in-flight
+     *    connect keeps getting cancelled cannot loop forever;
+     *  - the selected session is STILL the latest connect intent — if the user
+     *    navigated away from it, a newer intent supersedes it and we must NOT
+     *    re-dial a session the user abandoned (the top-2 risk the spike flagged).
+     */
+    @androidx.annotation.VisibleForTesting
+    internal fun shouldRedialAfterCoalescedCancel(
+        coalescedCancel: Boolean,
+        target: ConnectionTarget,
+    ): Boolean =
+        coalescedCancel &&
+            appActive &&
+            autoReconnectDelaysMs.isNotEmpty() &&
+            coalescedCancelRedialAttempts < COALESCED_CANCEL_REDIAL_MAX &&
+            latestConnectIntent?.let { sameSessionIdentity(it.target, target) } == true
+
+    /**
+     * Issue #1185: true when [cause] is the typed coalesced-connect cancel the
+     * lease raises when the awaiter's superseded owner was cancelled (#620
+     * coalescing cleanup). Distinct from every [isStaleChannelSymptom] shape and
+     * from a genuine unreachable, so the consumer re-dials the selected session
+     * rather than misclassifying a user-supersede as a terminal failure.
+     */
+    @androidx.annotation.VisibleForTesting
+    internal fun isCoalescedConnectCancel(cause: Throwable?): Boolean {
+        var current: Throwable? = cause
+        var guard = 0
+        while (current != null && guard < 12) {
+            if (current is SshLeaseConnectCoalescedCancelException) return true
+            current = current.cause
+            guard += 1
+        }
+        return false
+    }
+
+    /**
+     * Issue #1185 (two-holder safety net): drive the [RevealStateMachine] to a
+     * terminal honest error for [target] directly, so the reveal surface and the
+     * status pill never disagree on a terminal connect failure. Drop-by-id inside
+     * the machine makes this a no-op when the user has navigated to another
+     * session.
+     */
+    private fun driveRevealTerminalError(target: ConnectionTarget) {
+        revealStateMachine.onTerminalError(controllerSessionId(target))
+        _revealState.value = revealStateMachine.state.value
+    }
 
     @androidx.annotation.VisibleForTesting
     internal fun isStaleChannelSymptom(cause: Throwable?): Boolean =
@@ -18653,6 +18821,16 @@ private val DEFAULT_AUTO_RECONNECT_DELAYS_MS: List<Long> = listOf(0L, 1_000L, 2_
  * looping forever (each fresh transport also EOFing).
  */
 private const val STALE_LEASE_AUTO_RECOVER_MAX: Int = 2
+
+/**
+ * Issue #1185: how many times the selected session may transparently re-dial its
+ * OWN connect after its lease acquire was woken with a coalesced-connect cancel
+ * (the create-then-switch supersede). A re-dial becomes a fresh pool owner and
+ * connects on the first retry in the normal case; the cap only bounds a
+ * pathological repeat so the honest terminal error + working Retry eventually
+ * surfaces instead of an unbounded re-dial loop.
+ */
+private const val COALESCED_CANCEL_REDIAL_MAX: Int = 2
 
 /**
  * Issue #440: simple class names of connect-failure causes that retrying

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionCoalescedCancelRedialTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionCoalescedCancelRedialTest.kt
@@ -1,0 +1,681 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.app.sessions.ActiveTmuxClients
+import com.pocketshell.core.connection.RevealState
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.SshKey
+import com.pocketshell.core.ssh.SshLeaseConnectCoalescedCancelException
+import com.pocketshell.core.ssh.SshLeaseConnector
+import com.pocketshell.core.ssh.SshLeaseKey
+import com.pocketshell.core.ssh.SshLeaseManager
+import com.pocketshell.core.ssh.SshLeaseTarget
+import com.pocketshell.core.ssh.SshPortForward
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshShell
+import com.pocketshell.core.tmux.TmuxClientFactory
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+import java.io.InputStream
+
+/**
+ * Issue #1185: the maintainer, dogfooding, created a NEW session then immediately
+ * SELECTED an existing session in a folder on the SAME host. The select
+ * superseded (cancelled) the create/attach flow's in-flight SSH connect that the
+ * selected session merely COALESCED (#620) onto. On the buggy code the lease woke
+ * the selected session's acquire with a bare `CancellationException`, which the
+ * consumer misclassified as a terminal failure → the selected session stranded on
+ * a red "Disconnected" pill AND a live "Attaching…" spinner with no re-dial and no
+ * working Retry.
+ *
+ * These tests drive the REAL path deterministically: a real [SshLeaseManager]
+ * with a gated connector, a genuinely in-flight OWNER connect the test cancels
+ * (the supersede), and the VM's real `acquireLeaseForTmux`/`failConnectAttempt`/
+ * re-dial machinery. RED on base (Failed band + stranded Seeding reveal), GREEN
+ * with the fix (the selected session re-dials its own fresh connect and reaches
+ * Connected/Live; the reveal + pill agree; a genuine unreachable still surfaces
+ * the honest terminal error without looping).
+ *
+ * The gated OWNER connect must stay PARKED across the coalescing window, so the
+ * window is stepped with [runCurrent] (which never advances the virtual clock)
+ * rather than [advanceUntilIdle] (which would advance past the lease's 35s connect
+ * timeout and time the owner out before the selected session can coalesce). Only
+ * AFTER the re-dial is released is [advanceUntilIdle] safe.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class TmuxSessionCoalescedCancelRedialTest {
+
+    private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    @After
+    fun tearDown() {
+        factoryScope.cancel()
+    }
+
+    private fun runVmTest(body: suspend TestScope.() -> Unit) = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        LivenessProbeTestOverride.setAutoStartEnabledForTest(false)
+        try {
+            body()
+        } finally {
+            LivenessProbeTestOverride.clear()
+            Dispatchers.resetMain()
+        }
+    }
+
+    private fun TestScope.coalescingLeaseManager(connector: SshLeaseConnector): SshLeaseManager =
+        SshLeaseManager(
+            connector = connector,
+            scope = this,
+            idleTtlMillis = 60_000L,
+            connectTimeoutContext = StandardTestDispatcher(testScheduler),
+            // Pin the owned-dial ABORT to the same virtual scheduler as the dial so
+            // cancelling the parked owner is deterministic under runCurrent().
+            abortTimeoutContext = StandardTestDispatcher(testScheduler),
+            nowMillis = { testScheduler.currentTime },
+        )
+
+    private fun TestNewVm(
+        registry: ActiveTmuxClients,
+        sshLeaseManager: SshLeaseManager,
+    ): TmuxSessionViewModel = TmuxSessionViewModel(
+        tmuxClientFactory = TmuxClientFactory(factoryScope),
+        activeTmuxClients = registry,
+        runtimeCache = TmuxSessionRuntimeCache(),
+        sshLeaseManager = sshLeaseManager,
+        sessionLifecycleSignals = null,
+    ).also {
+        it.setSeedIoDispatcherForTest(Dispatchers.Main)
+    }
+
+    /**
+     * The lease key the VM mints for its [connect] target — must match the owner's
+     * key so the selected session COALESCES onto the owner's in-flight connect
+     * (VM: `credentialId = "$hostId:$keyPath"`).
+     */
+    private fun vmLeaseTarget(hostId: Long, host: String, port: Int, user: String, keyPath: String) =
+        SshLeaseTarget(
+            leaseKey = SshLeaseKey(
+                host = host,
+                port = port,
+                user = user,
+                credentialId = "$hostId:$keyPath",
+                knownHostsId = "accept-all",
+            ),
+            key = SshKey.Path(File(keyPath)),
+        )
+
+    /**
+     * Run the reported create→switch scenario for [sessionName] and return the VM +
+     * captured status stream once the re-dial has been released and driven to
+     * completion.
+     */
+    private suspend fun TestScope.driveCreateThenSwitchCoalescedCancel(
+        sessionName: String,
+        paneId: String,
+    ): Pair<TmuxSessionViewModel, List<TmuxSessionViewModel.ConnectionStatus>> {
+        val freshSession = AlwaysConnectedSession("fresh")
+        // slot #0 = the owner (create flow) connect, parked then cancelled;
+        // slot #1 = the selected session's OWN fresh re-dial, released to succeed.
+        val connector = GatedConnector(ownerSlot = null, redialSlot = freshSession)
+        val registry = ActiveTmuxClients()
+        val leaseManager = coalescingLeaseManager(connector)
+        val vm = TestNewVm(registry, leaseManager)
+        vm.setAutoReconnectDelaysForTest(listOf(0L))
+
+        val recovered = fakeClientForSession(sessionName, paneId)
+        vm.setTmuxClientFactoryForTest { _, requested, _ ->
+            assertEquals(sessionName, requested)
+            recovered
+        }
+
+        // Step 1: the create-new-session flow OWNS an in-flight cold connect.
+        val owner = launch {
+            leaseManager.acquire(vmLeaseTarget(1L, "alpha.example", 22, "alex", "/keys/a"))
+        }
+        runCurrent()
+        assertEquals("the create flow owns the only in-flight connect", 1, connector.startedConnects)
+
+        // Step 2: the user selects a session on the SAME host — it coalesces.
+        val statuses = mutableListOf<TmuxSessionViewModel.ConnectionStatus>()
+        val collector = launch { vm.connectionStatus.collect { statuses.add(it) } }
+        vm.connect(
+            hostId = 1L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            passphrase = null,
+            sessionName = sessionName,
+        )
+        runCurrent()
+        assertEquals(
+            "the selected session coalesced onto the in-flight connect (no 2nd dial yet)",
+            1,
+            connector.startedConnects,
+        )
+
+        // Step 3: the select supersedes the create flow — cancel the owner. The
+        // lease wakes the selected session's acquire with the typed coalesced-cancel.
+        owner.cancel()
+        runCurrent()
+
+        // Step 4: the selected session's OWN fresh re-dial should now be parked in
+        // the gate — release it and let the attach complete.
+        assertEquals(
+            "the selected session re-dialed its OWN fresh connect after the coalesced cancel",
+            2,
+            connector.startedConnects,
+        )
+        connector.releaseRedial()
+        advanceUntilIdle()
+        collector.cancel()
+        owner.cancel()
+        return vm to statuses
+    }
+
+    @Test
+    fun createThenSwitchExistingCoalescedCancelRedialsSelectedSessionToLive() = runVmTest {
+        val (vm, statuses) = driveCreateThenSwitchCoalescedCancel("git-rds-export", "%1")
+
+        val terminal = vm.connectionStatus.value
+        assertTrue(
+            "a coalesced-cancel supersede must NOT strand the selected session on Disconnected; got $terminal",
+            terminal is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+        assertTrue(
+            "the reveal surface must reach Live (not a stranded Attaching…/Seeding spinner); got " +
+                vm.revealState.value,
+            vm.revealState.value is RevealState.Live,
+        )
+        assertFalse(
+            "no Disconnected/Failed band may surface on a coalesced-cancel supersede; saw: " +
+                statuses.joinToString { it::class.simpleName ?: "?" },
+            statuses.any { it is TmuxSessionViewModel.ConnectionStatus.Failed },
+        )
+    }
+
+    @Test
+    fun createThenSwitchAnotherNewSessionSurvivorDoesNotStrand() = runVmTest {
+        // Same coalesced-cancel mechanism, but the surviving selection is a
+        // DIFFERENT (newly-created) session name on the same host.
+        val (vm, statuses) = driveCreateThenSwitchCoalescedCancel("brand-new", "%9")
+
+        assertTrue(
+            "the surviving new session must reach Connected, got ${vm.connectionStatus.value}",
+            vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+        assertTrue(vm.revealState.value is RevealState.Live)
+        assertFalse(
+            "no Failed band may surface for the survivor; saw: " +
+                statuses.joinToString { it::class.simpleName ?: "?" },
+            statuses.any { it is TmuxSessionViewModel.ConnectionStatus.Failed },
+        )
+    }
+
+    @Test
+    fun genuineUnreachableStillSurfacesTerminalErrorAndDoesNotRedialLoop() = runVmTest {
+        // The distinction test: a GENUINE connect failure (host unreachable) must
+        // NOT be treated as a coalesced-cancel — it surfaces the honest terminal
+        // error (reveal + pill AGREE), and does NOT loop re-dialing.
+        val connector = AlwaysFailsConnector()
+        val registry = ActiveTmuxClients()
+        val leaseManager = coalescingLeaseManager(connector)
+        val vm = TestNewVm(registry, leaseManager)
+        vm.setAutoReconnectDelaysForTest(listOf(0L))
+
+        vm.connect(
+            hostId = 1L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            passphrase = null,
+            sessionName = "work",
+        )
+        advanceUntilIdle()
+
+        assertTrue(
+            "a genuine unreachable must surface the honest Failed band, got ${vm.connectionStatus.value}",
+            vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Failed,
+        )
+        // The reveal must AGREE with the pill — an honest terminal error, never a
+        // stranded Seeding spinner (the #1185 two-holder safety net covers this
+        // path too).
+        assertTrue(
+            "the reveal must be a terminal Error, not a stranded Seeding spinner; got ${vm.revealState.value}",
+            vm.revealState.value is RevealState.Error,
+        )
+        assertTrue(
+            "a genuine unreachable must not endlessly re-dial (bounded); saw ${connector.connectCount} dials",
+            connector.connectCount <= 2,
+        )
+    }
+
+    @Test
+    fun coalescedCancelRedialIsBoundedByTheCapThenSurfacesRetryableError() = runVmTest {
+        // Item 3 (bounded re-dial cap): a coalesced-cancel that RECURS on every
+        // re-dial (the re-dial's OWN connect also coalesces-and-cancels) must NOT
+        // loop forever — the per-chain budget COALESCED_CANCEL_REDIAL_MAX (2) stops
+        // it, then the honest terminal error surfaces WITH a working Retry.
+        //
+        // Deterministic recurrence: the first hop is a REAL coalesce (a parked owner
+        // the test cancels). Each subsequent re-dial becomes its own owner and its
+        // connector dial returns the SAME typed [SshLeaseConnectCoalescedCancelException]
+        // the lease would raise if that re-dial had itself coalesced onto another
+        // just-cancelled owner — i.e. the consumer sees the exact cause it sees in a
+        // real recurring supersede, so [failConnectAttempt]'s cap branch is driven
+        // faithfully. The connector only SUCCEEDS at a dial index the cap can never
+        // reach, so a broken cap is observable (Connected + more dials) rather than an
+        // infinite hang.
+        val connector = RecurringCoalescedCancelConnector(succeedAtIndex = 5)
+        val registry = ActiveTmuxClients()
+        val leaseManager = coalescingLeaseManager(connector)
+        val vm = TestNewVm(registry, leaseManager)
+        vm.setAutoReconnectDelaysForTest(listOf(0L))
+
+        // Step 1: the create flow owns the in-flight cold connect (dial #0, parked).
+        val owner = launch {
+            leaseManager.acquire(vmLeaseTarget(1L, "alpha.example", 22, "alex", "/keys/a"))
+        }
+        runCurrent()
+        assertEquals("the create flow owns the only in-flight connect", 1, connector.startedConnects)
+
+        // Step 2: the user selects a session on the same host — it coalesces.
+        val statuses = mutableListOf<TmuxSessionViewModel.ConnectionStatus>()
+        val collector = launch { vm.connectionStatus.collect { statuses.add(it) } }
+        vm.connect(
+            hostId = 1L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            passphrase = null,
+            sessionName = "git-rds-export",
+        )
+        runCurrent()
+        assertEquals("the selected session coalesced (no 2nd dial yet)", 1, connector.startedConnects)
+
+        // Step 3: supersede — cancel the owner. The selected session re-dials, and
+        // every re-dial's OWN connect coalesced-cancels again, recurring until the
+        // cap stops it. No parked dial after the owner, so advancing is safe.
+        owner.cancel()
+        advanceUntilIdle()
+        collector.cancel()
+
+        // The re-dial fired exactly COALESCED_CANCEL_REDIAL_MAX (2) times: owner
+        // dial + 2 bounded re-dials = 3 total. It did NOT loop forever (never reached
+        // the connector's succeed-at index 5).
+        assertEquals(
+            "coalesced-cancel re-dial must be bounded at the cap (owner dial + 2 re-dials)",
+            3,
+            connector.startedConnects,
+        )
+        // After the budget is exhausted the honest terminal error surfaces...
+        assertTrue(
+            "a pathological recurring coalesced-cancel must surface the honest terminal error " +
+                "once the cap is hit, got ${vm.connectionStatus.value}",
+            vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Failed,
+        )
+        // ...with a WORKING Retry — the reconnect target is preserved so the user is
+        // never dead-ended on a Disconnected pill with no Reconnect affordance.
+        assertTrue(
+            "the terminal coalesced-cancel fallback must leave a working Retry (canReconnect)",
+            vm.canReconnect.value,
+        )
+        // ...and the reveal surface AGREES (terminal Error, never a stranded spinner).
+        assertTrue(
+            "the reveal must be a terminal Error in lockstep with the pill, got ${vm.revealState.value}",
+            vm.revealState.value is RevealState.Error,
+        )
+    }
+
+    @Test
+    fun coalescedCancelDoesNotRedialASessionTheUserNavigatedAwayFrom() = runVmTest {
+        // Item 3 (navigated-away guard — the spike's flagged top risk): a
+        // coalesced-cancel that arrives AFTER the user navigated to a different
+        // session identity must NOT re-dial the abandoned session. The guard is
+        // [shouldRedialAfterCoalescedCancel]'s `latestConnectIntent` +
+        // `sameSessionIdentity` clause; this drives the REAL intent-setter (`connect`)
+        // and asserts the decision both ways.
+        val connector = AlwaysFailsConnector()
+        val registry = ActiveTmuxClients()
+        val leaseManager = coalescingLeaseManager(connector)
+        val vm = TestNewVm(registry, leaseManager)
+        vm.setAutoReconnectDelaysForTest(listOf(0L))
+
+        val targetA = TmuxSessionViewModel.ConnectionTarget(
+            hostId = 1L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            passphrase = null,
+            sessionName = "git-rds-export",
+            startDirectory = null,
+        )
+        val targetB = targetA.copy(sessionName = "other-session")
+
+        // The user is on session A: intent=A, so a coalesced-cancel on A re-dials A.
+        // (Assert BEFORE advancing — intent is set synchronously at connect() entry.)
+        vm.connect(
+            hostId = 1L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            passphrase = null,
+            sessionName = "git-rds-export",
+        )
+        assertTrue(
+            "still on A → a coalesced-cancel must re-dial A",
+            vm.shouldRedialAfterCoalescedCancel(true, targetA),
+        )
+
+        // The user navigates away to a DIFFERENT session B (a newer intent supersedes
+        // A).
+        vm.connect(
+            hostId = 1L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            passphrase = null,
+            sessionName = "other-session",
+        )
+        assertFalse(
+            "a coalesced-cancel for the ABANDONED session A must NOT re-dial it after " +
+                "the user navigated away (re-dialing an abandoned session is the flagged risk)",
+            vm.shouldRedialAfterCoalescedCancel(true, targetA),
+        )
+        assertTrue(
+            "the now-selected session B still re-dials on its own coalesced-cancel",
+            vm.shouldRedialAfterCoalescedCancel(true, targetB),
+        )
+
+        // Drain the failing connect jobs cleanly (genuine failure → terminal, no loop).
+        advanceUntilIdle()
+    }
+
+    @Test
+    fun rapidSwitchAToBToACoalescedCancelDoesNotStrandTheSelectedSession() = runVmTest {
+        // Item 5 (explicit class-coverage AC / G9): rapid A→B→A switching on one host
+        // where the final selection coalesces onto a cancelled in-flight connect must
+        // land the SELECTED session Live — none of the churned sessions may strand.
+        val freshSession = AlwaysConnectedSession("fresh")
+        val connector = GatedConnector(ownerSlot = null, redialSlot = freshSession)
+        val registry = ActiveTmuxClients()
+        val leaseManager = coalescingLeaseManager(connector)
+        val vm = TestNewVm(registry, leaseManager)
+        vm.setAutoReconnectDelaysForTest(listOf(0L))
+
+        // A tolerant factory: hand back a durable per-session pane fixture for
+        // WHATEVER session the attach asks for (the A→B→A churn advances the reveal
+        // generation several times so the reconcile loop can iterate; a durable stream
+        // keeps the fake from running dry mid-reconcile). Record the attaches so the
+        // test can assert the FINAL selection (session-a) is the one that lands.
+        val attachedSessions = mutableListOf<String>()
+        vm.setTmuxClientFactoryForTest { _, requested, _ ->
+            attachedSessions.add(requested)
+            durableFakeClientForSession(requested, "%1")
+        }
+
+        // The create flow owns the in-flight cold connect.
+        val owner = launch {
+            leaseManager.acquire(vmLeaseTarget(1L, "alpha.example", 22, "alex", "/keys/a"))
+        }
+        runCurrent()
+        assertEquals("the create flow owns the only in-flight connect", 1, connector.startedConnects)
+
+        val statuses = mutableListOf<TmuxSessionViewModel.ConnectionStatus>()
+        val collector = launch { vm.connectionStatus.collect { statuses.add(it) } }
+
+        // Rapid A → B → A on the same host — each selection coalesces onto the one
+        // in-flight owner (no new dial).
+        vm.connect(1L, "alpha", "alpha.example", 22, "alex", "/keys/a", null, "session-a")
+        runCurrent()
+        vm.connect(1L, "alpha", "alpha.example", 22, "alex", "/keys/a", null, "session-b")
+        runCurrent()
+        vm.connect(1L, "alpha", "alpha.example", 22, "alex", "/keys/a", null, "session-a")
+        runCurrent()
+        assertEquals(
+            "every rapid switch coalesced onto the one in-flight connect",
+            1,
+            connector.startedConnects,
+        )
+
+        // Supersede the create flow — cancel the owner. The FINAL selection (A) wakes
+        // with the typed coalesced-cancel and re-dials its own fresh connect.
+        owner.cancel()
+        runCurrent()
+        assertEquals(
+            "the final selection re-dialed its OWN fresh connect after the coalesced cancel",
+            2,
+            connector.startedConnects,
+        )
+        connector.releaseRedial()
+        advanceUntilIdle()
+        collector.cancel()
+        owner.cancel()
+
+        assertTrue(
+            "rapid A→B→A that cancels an in-flight connect must NOT strand the selected " +
+                "session; it recovers to Connected, got ${vm.connectionStatus.value}",
+            vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+        assertEquals(
+            "the FINALLY-selected session (session-a) is the one that lands active",
+            "session-a",
+            attachedSessions.lastOrNull(),
+        )
+        assertTrue(
+            "the reveal surface must reach Live (not a stranded Attaching…/Seeding spinner); got " +
+                vm.revealState.value,
+            vm.revealState.value is RevealState.Live,
+        )
+        assertFalse(
+            "no Disconnected/Failed band may surface for the selected session; saw: " +
+                statuses.joinToString { it::class.simpleName ?: "?" },
+            statuses.any { it is TmuxSessionViewModel.ConnectionStatus.Failed },
+        )
+    }
+
+    // ---- fakes ----
+
+    private fun fakeClientForSession(sessionName: String, paneId: String): FakeTmuxClient =
+        FakeTmuxClient().apply {
+            responses.addLast(
+                com.pocketshell.core.tmux.CommandResponse(
+                    number = 1L,
+                    output = listOf("$paneId\t@0\t\$0\t$sessionName\t$sessionName\t0"),
+                    isError = false,
+                ),
+            )
+            capturePaneResponses.addLast(
+                com.pocketshell.core.tmux.CommandResponse(
+                    number = 2L,
+                    output = listOf("$sessionName ready"),
+                    isError = false,
+                ),
+            )
+            cursorQueryResponses.addLast(
+                com.pocketshell.core.tmux.CommandResponse(number = 3L, output = listOf("0,0"), isError = false),
+            )
+        }
+
+    /**
+     * Like [fakeClientForSession] but seeds a DURABLE stream of identical pane
+     * fixtures so the attach's list-panes/reconcile loop can iterate repeatedly (as it
+     * does after the A→B→A reveal-generation churn) without the fake running dry — a
+     * single response would exhaust and surface as a spurious pane-wait timeout that
+     * masks the real "does the selected session recover" question under test.
+     */
+    private fun durableFakeClientForSession(sessionName: String, paneId: String): FakeTmuxClient =
+        FakeTmuxClient().apply {
+            repeat(16) {
+                responses.addLast(
+                    com.pocketshell.core.tmux.CommandResponse(
+                        number = 1L,
+                        output = listOf("$paneId\t@0\t\$0\t$sessionName\t$sessionName\t0"),
+                        isError = false,
+                    ),
+                )
+                capturePaneResponses.addLast(
+                    com.pocketshell.core.tmux.CommandResponse(
+                        number = 2L,
+                        output = listOf("$sessionName ready"),
+                        isError = false,
+                    ),
+                )
+                cursorQueryResponses.addLast(
+                    com.pocketshell.core.tmux.CommandResponse(number = 3L, output = listOf("0,0"), isError = false),
+                )
+            }
+        }
+
+    /**
+     * Connector where the FIRST connect (the create-flow owner) parks forever
+     * until cancelled, and the SECOND (the selected session's own re-dial) parks
+     * until [releaseRedial] resolves it with [redialSlot].
+     */
+    private class GatedConnector(
+        private val ownerSlot: SshSession?,
+        private val redialSlot: SshSession,
+    ) : SshLeaseConnector {
+        var startedConnects: Int = 0
+            private set
+        private val gates: ArrayDeque<CompletableDeferred<Unit>> = ArrayDeque()
+
+        override suspend fun connect(target: SshLeaseTarget): Result<SshSession> {
+            val index = startedConnects
+            startedConnects += 1
+            val gate = CompletableDeferred<Unit>()
+            gates.addLast(gate)
+            try {
+                gate.await()
+            } finally {
+                gates.remove(gate)
+            }
+            val session = if (index == 0) ownerSlot else redialSlot
+            return session?.let { Result.success(it) }
+                ?: Result.failure(java.io.IOException("connect $index failed"))
+        }
+
+        fun releaseRedial() {
+            val gate = gates.firstOrNull() ?: error("no in-flight re-dial to release")
+            gate.complete(Unit)
+        }
+    }
+
+    /** Every dial fails immediately — a genuinely unreachable host. */
+    private class AlwaysFailsConnector : SshLeaseConnector {
+        var connectCount: Int = 0
+            private set
+
+        override suspend fun connect(target: SshLeaseTarget): Result<SshSession> {
+            connectCount += 1
+            return Result.failure(com.pocketshell.core.ssh.SshException("connection refused"))
+        }
+    }
+
+    /**
+     * Connector for the bounded-cap test: dial #0 PARKS (the create-flow owner the
+     * test cancels to trigger the first REAL coalesced-cancel). Every subsequent dial
+     * (the selected session's own re-dials, each now its own owner) returns the SAME
+     * typed [SshLeaseConnectCoalescedCancelException] the lease raises on a recurring
+     * supersede — so the consumer sees a coalesced-cancel on EVERY re-dial and the
+     * per-chain cap is what must stop it. A dial only SUCCEEDS at [succeedAtIndex],
+     * chosen beyond what the cap can reach, so a broken/removed cap is observable
+     * (Connected + more dials) instead of hanging forever.
+     */
+    private class RecurringCoalescedCancelConnector(
+        private val succeedAtIndex: Int,
+    ) : SshLeaseConnector {
+        var startedConnects: Int = 0
+            private set
+        private val ownerGate = CompletableDeferred<Unit>()
+        private val successSession = AlwaysConnectedSession("recovered")
+
+        override suspend fun connect(target: SshLeaseTarget): Result<SshSession> {
+            val index = startedConnects
+            startedConnects += 1
+            if (index == 0) {
+                // The create-flow owner parks until cancelled (the real supersede).
+                ownerGate.await()
+                error("owner dial is only ever cancelled, never released")
+            }
+            if (index >= succeedAtIndex) {
+                return Result.success(successSession)
+            }
+            // The re-dial's own connect coalesced-cancelled again — hand the consumer
+            // the exact typed failure a recurring supersede produces.
+            return Result.failure(SshLeaseConnectCoalescedCancelException(target.leaseKey))
+        }
+    }
+
+    private class AlwaysConnectedSession(val id: String) : SshSession {
+        @Volatile
+        var closed: Boolean = false
+
+        override val isConnected: Boolean get() = !closed
+
+        override suspend fun exec(command: String): ExecResult =
+            ExecResult(stdout = "", stderr = "", exitCode = 0)
+
+        override fun tail(path: String, onLine: (String) -> Unit): Job =
+            Job().apply { complete() }
+
+        override fun tail(path: String, fromLineExclusive: Long, onLine: (String) -> Unit): Job =
+            Job().apply { complete() }
+
+        override fun openLocalPortForward(
+            remoteHost: String,
+            remotePort: Int,
+            localPort: Int,
+        ): SshPortForward = error("not used")
+
+        override fun startShell(): SshShell = error("not used")
+
+        override suspend fun uploadFile(file: File, remotePath: String): String = error("not used")
+
+        override suspend fun uploadStream(
+            input: InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String = error("not used")
+
+        override fun close() {
+            closed = true
+        }
+    }
+}

--- a/shared/core-connection/src/main/java/com/pocketshell/core/connection/RevealStateMachine.kt
+++ b/shared/core-connection/src/main/java/com/pocketshell/core/connection/RevealStateMachine.kt
@@ -220,6 +220,34 @@ class RevealStateMachine {
     }
 
     /**
+     * Issue #1185: drive the reveal to a terminal honest [RevealState.Error] for
+     * [targetId] DIRECTLY from the VM's connect-failure path, without relying on
+     * the [ConnectionController]'s synthetic drop→[ConnectionState.Unreachable]
+     * ladder to deliver the matching-id edge through [onConnectionState]. Dropped
+     * (no-op) for a non-current target so a superseded switch's failure never
+     * overwrites the live target's surface.
+     *
+     * This closes the two-holder divergence the maintainer hit (create-new →
+     * immediately-select an existing session on the same host): the status pill
+     * read "Disconnected" while this machine stayed in [RevealState.Seeding]
+     * ("Attaching…") because the indirect controller drive never delivered an
+     * [ConnectionState.Unreachable] for the exact id. A terminal connect failure
+     * now moves BOTH holders to an honest error in lockstep — never a red pill
+     * over a live "Attaching…" spinner.
+     */
+    fun onTerminalError(targetId: SessionId) {
+        val target = currentTargetId ?: return
+        if (targetId != target) {
+            return
+        }
+        val targetName = _state.value.targetNameOrNull() ?: return
+        val next = RevealState.Error(target, targetName, retrying = false)
+        if (next != _state.value) {
+            _state.value = next
+        }
+    }
+
+    /**
      * Set the agent display name for the current target's active pane. Only honored
      * in [RevealState.Live] (the spec: agentName overrides the leaf label ONLY once
      * content is live for this id). Dropped for a non-target id.

--- a/shared/core-connection/src/test/java/com/pocketshell/core/connection/RevealStateMachineTest.kt
+++ b/shared/core-connection/src/test/java/com/pocketshell/core/connection/RevealStateMachineTest.kt
@@ -366,4 +366,46 @@ class RevealStateMachineTest {
         // The reveal itself (content) is preserved.
         assertTrue(live.panes.isNotEmpty())
     }
+
+    // --- Issue #1185: the direct terminal-error drive (two-holder safety net) ---
+
+    @Test
+    fun `onTerminalError drives a seeding surface to a terminal error (never left Attaching)`() {
+        // The #1185 contradiction: a terminal connect failure surfaces the red
+        // "Disconnected" pill while the reveal surface stays in Seeding
+        // ("Attaching…"). onTerminalError drives THIS holder to Error directly so
+        // the two can never disagree.
+        val m = RevealStateMachine()
+        m.navigate(a, "git-rds-export")
+        m.onConnectionState(ConnectionState.Attaching(host, a))
+        assertEquals(RevealState.Seeding(a, "git-rds-export"), m.state.value)
+
+        m.onTerminalError(a)
+
+        assertEquals(
+            "a terminal connect failure must move the reveal off Seeding to an honest Error",
+            RevealState.Error(a, "git-rds-export", retrying = false),
+            m.state.value,
+        )
+    }
+
+    @Test
+    fun `onTerminalError for a non-current target is dropped (drop-by-id)`() {
+        // The user navigated away to B; a late terminal-error for the abandoned A
+        // must never overwrite B's live surface.
+        val m = RevealStateMachine()
+        m.bringLive(b, "session-B")
+        val before = m.state.value
+
+        m.onTerminalError(a)
+
+        assertEquals("a terminal error for a superseded id is dropped", before, m.state.value)
+    }
+
+    @Test
+    fun `onTerminalError before any navigation is a no-op`() {
+        val m = RevealStateMachine()
+        m.onTerminalError(a)
+        assertEquals(RevealState.Idle, m.state.value)
+    }
 }

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshLeaseManager.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshLeaseManager.kt
@@ -2,7 +2,6 @@ package com.pocketshell.core.ssh
 
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
@@ -299,11 +298,21 @@ public class SshLeaseManager(
                 withContext(NonCancellable) {
                     mutex.withLock {
                         if (inFlightConnects[key] === deferred) inFlightConnects.remove(key)
-                        retractConnectingHintLocked(key)
+                        retractConnectingHintLocked(key, SshLeaseCloseReason.ConnectCancelled)
                     }
                 }
+                // Issue #1185: wake a coalescing awaiter with a TYPED, retryable
+                // failure — NOT a bare CancellationException value. The awaiter
+                // (a session the user selected that merely JOINED this owner's
+                // in-flight connect) is NOT itself cancelled; its own coroutine is
+                // alive. A bare CancellationException here was indistinguishable
+                // from a genuine unreachable at the consumer, so the selected
+                // session stranded on Disconnected + "Attaching…" with no re-dial.
+                // The typed [SshLeaseConnectCoalescedCancelException] lets the
+                // consumer tell "my superseded owner was cancelled — re-dial my own
+                // fresh connect" apart from "the host is unreachable".
                 deferred.complete(
-                    Result.failure(CancellationException("SSH connect cancelled for $key")),
+                    Result.failure(SshLeaseConnectCoalescedCancelException(key)),
                 )
             }
         }
@@ -772,6 +781,18 @@ public enum class SshLeaseCloseReason {
      * instead of an undifferentiated `lease_down` (the #964 ambiguity).
      */
     KeepaliveDead,
+
+    /**
+     * Issue #1185: the in-flight cold connect that owned this key was CANCELLED
+     * before it produced a live transport — the user superseded the create/attach
+     * flow (e.g. created a new session, then immediately selected an existing one
+     * on the same host) so the owner's acquire coroutine died. Distinct from the
+     * anonymous [Disconnected] so the shareable connection log (#1175) names
+     * `connect_cancelled` instead of an undifferentiated `lease_down`, and so a
+     * coalescing awaiter of that owner can re-dial its own fresh connect rather
+     * than stranding on a terminal "unreachable".
+     */
+    ConnectCancelled,
 }
 
 public data class SshLeaseKey(
@@ -866,3 +887,24 @@ public class SshLeaseConnectTimeoutException(
 ) : IllegalStateException(
     "SSH lease connect to ${key.user}@${key.host}:${key.port} exceeded ${timeoutMillis}ms and was aborted",
 )
+
+/**
+ * Issue #1185: a coalescing awaiter's in-flight connect OWNER (the create/attach
+ * flow it merely joined via #620 coalescing) was cancelled before it produced a
+ * live transport — the user superseded that flow (e.g. created a new session,
+ * then immediately selected an existing session on the SAME host). The awaiter is
+ * NOT itself cancelled; its own coroutine is alive, so it must be able to tell
+ * this superseded-owner cancellation apart from a genuine unreachable/auth/DNS
+ * failure and re-dial its OWN fresh connect (the owner's in-flight slot is already
+ * cleared, so a retry becomes a fresh owner and dials cleanly).
+ *
+ * This is a NORMAL, RETRYABLE failure delivered as a `Result` value — NOT a
+ * [kotlin.coroutines.cancellation.CancellationException] (which the consumer
+ * would misclassify as a terminal connect failure, stranding the selected session
+ * on a Disconnected pill + "Attaching…" spinner with no re-dial — the #1185 bug).
+ * The message is preserved verbatim so any existing diagnostic string continues
+ * to read the same.
+ */
+public class SshLeaseConnectCoalescedCancelException(
+    public val key: SshLeaseKey,
+) : IllegalStateException("SSH connect cancelled for $key")

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/SshLeaseCoalescedCancelTypedTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/SshLeaseCoalescedCancelTypedTest.kt
@@ -1,0 +1,251 @@
+package com.pocketshell.core.ssh
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.IOException
+import java.io.InputStream
+
+/**
+ * Issue #1185: a session the user SELECTED that merely COALESCED (#620) onto an
+ * in-flight connect owned by a just-superseded create/attach flow must be able to
+ * tell a superseded-owner cancellation apart from a genuine unreachable failure.
+ *
+ * These pin the TYPED delivery contract the consumer keys off:
+ *  - owner CANCELLATION wakes a joined awaiter with the typed
+ *    [SshLeaseConnectCoalescedCancelException] (a retryable failure), NOT a bare
+ *    [CancellationException] value — so the consumer re-dials the selected session
+ *    rather than stranding it (the #1185 Disconnected + "Attaching…" bug);
+ *  - owner FAILURE (a genuine connect error) still wakes the awaiter with the
+ *    ORIGINAL failure, NOT the coalesced-cancel type — so a real unreachable still
+ *    surfaces the honest terminal error (no infinite re-dial);
+ *  - the owner-cancel path publishes a distinct
+ *    [SshLeaseCloseReason.ConnectCancelled] edge so the shareable log (#1175)
+ *    fingerprints the cancel instead of an anonymous `lease_down`.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SshLeaseCoalescedCancelTypedTest {
+
+    @Test
+    fun `owner cancellation wakes a joined awaiter with the typed coalesced-cancel failure`() = runTest {
+        // The owner's connect parks in the gate; a second acquire for the SAME
+        // key JOINS it (coalesces). Cancelling the owner (the create-then-switch
+        // supersede) must wake the awaiter with the TYPED failure so the consumer
+        // can distinguish it from a genuine unreachable.
+        val connector = GatedLeaseConnector(FakeSshSession())
+        val manager = leaseManager(connector)
+
+        val owner = async { manager.acquire(TARGET) }
+        runCurrent()
+        assertEquals("owner started the only dial", 1, connector.startedConnects)
+
+        val awaiter = async { manager.acquire(TARGET) }
+        runCurrent()
+        assertEquals("the awaiter coalesced onto the in-flight connect", 1, connector.startedConnects)
+
+        owner.cancel()
+        owner.join()
+        runCurrent()
+
+        val awaiterResult = awaiter.await()
+        assertTrue("the coalescing awaiter is woken with a failure", awaiterResult.isFailure)
+        val error = awaiterResult.exceptionOrNull()
+        assertTrue(
+            "the awaiter must receive the TYPED coalesced-cancel, got ${error?.javaClass?.name}",
+            error is SshLeaseConnectCoalescedCancelException,
+        )
+        assertFalse(
+            "the typed coalesced-cancel must NOT be a CancellationException (the consumer would " +
+                "misclassify it as a terminal failure)",
+            error is CancellationException,
+        )
+        assertEquals(
+            "the coalesced-cancel carries the awaiter's lease key",
+            TARGET.leaseKey,
+            (error as SshLeaseConnectCoalescedCancelException).key,
+        )
+    }
+
+    @Test
+    fun `owner cancellation publishes a distinct ConnectCancelled close edge`() = runTest {
+        val connector = GatedLeaseConnector(FakeSshSession())
+        val manager = leaseManager(connector)
+
+        val events = mutableListOf<SshLeaseStateEvent>()
+        val collector = launch { manager.stateEvents.collect { events.add(it) } }
+        runCurrent()
+
+        val owner = async { manager.acquire(TARGET) }
+        runCurrent()
+        assertTrue(
+            "the optimistic Connecting hint is announced",
+            events.any {
+                it.key == TARGET.leaseKey && it.state == SshLeaseConnectionState.Connecting
+            },
+        )
+
+        owner.cancel()
+        owner.join()
+        runCurrent()
+
+        assertTrue(
+            "owner cancellation must publish a Closed edge with the distinct ConnectCancelled reason " +
+                "(so #1175 fingerprints the cancel, not an anonymous lease_down); saw: " +
+                events.joinToString { "${it.state}/${it.closeReason}" },
+            events.any {
+                it.key == TARGET.leaseKey &&
+                    it.state == SshLeaseConnectionState.Closed &&
+                    it.closeReason == SshLeaseCloseReason.ConnectCancelled
+            },
+        )
+        collector.cancel()
+    }
+
+    @Test
+    fun `a genuine owner connect failure is NOT reported as a coalesced-cancel`() = runTest {
+        // The owner's connect RESOLVES as a failure (a genuine unreachable/auth/
+        // DNS error), not a cancellation. The joined awaiter must receive the
+        // ORIGINAL failure — never the coalesced-cancel type — so the consumer
+        // still surfaces the honest terminal error and does NOT re-dial forever.
+        val connector = GatedLeaseConnector(/* null slot => the connect fails */ null)
+        val manager = leaseManager(connector)
+
+        val owner = async { manager.acquire(TARGET) }
+        runCurrent()
+        val awaiter = async { manager.acquire(TARGET) }
+        runCurrent()
+        assertEquals("the awaiter coalesced onto the in-flight connect", 1, connector.startedConnects)
+
+        connector.releaseConnect() // resolve the owning connect as a FAILURE
+        runCurrent()
+
+        val ownerResult = owner.await()
+        val awaiterResult = awaiter.await()
+        assertTrue("the owner surfaces the genuine connect failure", ownerResult.isFailure)
+        assertTrue("the awaiter is woken with the shared failure", awaiterResult.isFailure)
+        assertFalse(
+            "a genuine connect failure must NOT masquerade as a coalesced-cancel " +
+                "(otherwise a real unreachable would loop re-dialing)",
+            awaiterResult.exceptionOrNull() is SshLeaseConnectCoalescedCancelException,
+        )
+        assertTrue(
+            "the awaiter receives the ORIGINAL IO failure, got ${awaiterResult.exceptionOrNull()?.javaClass?.name}",
+            awaiterResult.exceptionOrNull() is IOException,
+        )
+    }
+
+    // ---- harness (mirrors SshLeaseCoalescingCharacterizationTest's local fakes) ----
+
+    private fun TestScope.leaseManager(
+        connector: SshLeaseConnector,
+        idleTtlMillis: Long = 60_000,
+        maxIdleLeases: Int = 2,
+    ): SshLeaseManager =
+        SshLeaseManager(
+            connector = connector,
+            scope = this,
+            idleTtlMillis = idleTtlMillis,
+            maxIdleLeases = maxIdleLeases,
+            connectTimeoutContext = kotlinx.coroutines.test.StandardTestDispatcher(testScheduler),
+            abortTimeoutContext = kotlinx.coroutines.test.StandardTestDispatcher(testScheduler),
+            nowMillis = { testScheduler.currentTime },
+        )
+
+    /**
+     * Connector whose every `connect` parks until the test releases it (or the
+     * owner is cancelled), so a test can observe the in-flight coalescing window.
+     * A queued session resolves successfully; a `null` slot resolves as a genuine
+     * connect failure.
+     */
+    private class GatedLeaseConnector(
+        private vararg val sessions: FakeSshSession?,
+    ) : SshLeaseConnector {
+        var startedConnects: Int = 0
+        private val gates: ArrayDeque<CompletableDeferred<Unit>> = ArrayDeque()
+
+        override suspend fun connect(target: SshLeaseTarget): Result<SshSession> {
+            val index = startedConnects
+            startedConnects += 1
+            val gate = CompletableDeferred<Unit>()
+            gates.addLast(gate)
+            try {
+                gate.await()
+            } finally {
+                gates.remove(gate)
+            }
+            val session = sessions.getOrNull(index)
+                ?: return Result.failure(IOException("connect $index failed"))
+            return Result.success(session)
+        }
+
+        fun releaseConnect() {
+            val gate = gates.firstOrNull()
+                ?: error("no in-flight connect to release")
+            gate.complete(Unit)
+        }
+    }
+
+    private class FakeSshSession : SshSession {
+        var closed: Boolean = false
+        var connected: Boolean = true
+
+        override val isConnected: Boolean
+            get() = connected && !closed
+
+        override suspend fun exec(command: String): ExecResult =
+            ExecResult(stdout = "", stderr = "", exitCode = 0)
+
+        override fun tail(path: String, onLine: (String) -> Unit): Job = error("not used")
+
+        override fun openLocalPortForward(
+            remoteHost: String,
+            remotePort: Int,
+            localPort: Int,
+        ): SshPortForward = error("not used")
+
+        override fun startShell(): SshShell = object : SshShell {
+            override val stdin = ByteArrayOutputStream()
+            override val stdout = ByteArrayInputStream(ByteArray(0))
+            override val stderr = ByteArrayInputStream(ByteArray(0))
+            override fun close() = Unit
+        }
+
+        override suspend fun uploadFile(file: File, remotePath: String): String = error("not used")
+
+        override suspend fun uploadStream(
+            input: InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String = error("not used")
+
+        override fun close() {
+            closed = true
+        }
+    }
+
+    private companion object {
+        val TARGET: SshLeaseTarget = SshLeaseTarget(
+            leaseKey = SshLeaseKey(
+                host = "10.0.2.2",
+                port = 2222,
+                user = "testuser",
+                credentialId = "/tmp/key-a",
+            ),
+            key = SshKey.Path(File("/tmp/key-a")),
+        )
+    }
+}


### PR DESCRIPTION
The maintainer's create→switch-existing strand (Disconnected + live Attaching spinner, no recovery). Typed coalesced-cancel exception → bounded re-dial of the selected session + two-holder safety net (pill/spinner agree) + working Retry + diagnostics fingerprint. Reviewer APPROVED (2 rounds): primary red→green driven; cap + navigated-away guard + A→B→A tests proven non-vacuous; lease #620 contract intact; typed-cancel-vs-unreachable discriminated; D28-localized. Local gate: coalesced-cancel + lease characterization tests all green.\n\nCloses #1185