### PR TITLE
release: v0.4.22 (versionCode 69)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,8 +65,8 @@ android {
         applicationId = "com.pocketshell.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 68
-        versionName = "0.4.21"
+        versionCode = 69
+        versionName = "0.4.22"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/tools/pocketshell/pyproject.toml
+++ b/tools/pocketshell/pyproject.toml
@@ -8,7 +8,7 @@ name = "pocketshell"
 # scripts/check-pypi-version.sh enforces this; .github/workflows/build.yml
 # runs that check before publishing to PyPI. See
 # tools/pocketshell/README.md ("Release flow") for the bump procedure.
-version = "0.4.21"
+version = "0.4.22"
 description = "Unified server-side Python utility for the PocketShell Android client."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Version bump for the connection-stability + black-screen dogfood release. Contains: #1176/#1177/#1181 (all 3 black-screen variants), #1185 (connect-strand recovery), #1151 (Ctrl+L), #1175 (diagnostics), #1084 (freeze gate), #1155 (tree + shell-recreate), #1152 (composer), #1184 (session name). versionCode 68→69, versionName + pyproject 0.4.21→0.4.22 in lockstep.