### PR TITLE
connection: probe the transport before riding through a network restore (#1193)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/BareNetworkLossRestoreReconnectE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/BareNetworkLossRestoreReconnectE2eTest.kt
@@ -410,6 +410,124 @@ class BareNetworkLossRestoreReconnectE2eTest {
         writeTimings()
     } }
 
+    /**
+     * ISSUE #1193 — the FRESH-KEEPALIVE + DEAD-SOCKET restore, the gap the #928 spike
+     * identified. The two tests above cover keepalive-AGED-OUT (branch 2 / probe).
+     * This one covers the maintainer's ACTUAL cellular spurious drop: on a
+     * WiFi→cellular restore the OLD socket is silently dead (the new radio's IP/NAT
+     * invalidated the 4-tuple) but the PASSIVE keepalive TIMESTAMP is still fresh
+     * (< 90s). Pre-#1193 `scheduleNetworkReconnectOnRestore` branch 1 rode through on
+     * that timestamp ALONE (a pure clock comparison, NO round-trip) → committed to the
+     * dead transport, flipped back to Live, and the `-CC` reader threw ~157ms later →
+     * `passive_disconnect` + reconnect churn.
+     *
+     * The two seams reproduce that exact state SYNTHETICALLY (the #780 hard-inject
+     * model this file already uses — deterministic on the plain `agents:2222` fixture,
+     * no toxiproxy / workflow change; the seams pin precisely what a real WiFi→cellular
+     * handoff produces — a fresh last-inbound-byte watermark over a dead socket):
+     *   - `forceTransportProvenAliveForTest = true`  → the fresh keepalive TIMESTAMP
+     *     (the maintainer's exact state; pre-#1193 this alone armed branch 1).
+     *   - `forceLivenessProbeDeadForTest = true`     → the post-handoff socket is
+     *     GENUINELY DEAD, so the bounded active probe cannot round-trip.
+     *
+     * RED (branch 1 present): the restore records a `network_restore_ride_through`
+     * (cause `transport_proven_alive`) and does NOT redial — it commits to the dead
+     * transport (the spurious drop the maintainer sees). GREEN (#1193, branch 1
+     * deleted → every restore goes through the bounded probe requiring an answered
+     * round-trip): NO `network_restore_ride_through`; a clean
+     * `network_restore_reconnect_start` fires and the session recovers Connected.
+     */
+    @Test
+    fun freshKeepaliveButDeadSocketRestoreRedialsViaProbeNotPassiveRideThrough() { runBlocking<Unit> {
+        val hostRowTag = requireNotNull(seededHostRowTag)
+        attachSeededTmuxSession(hostRowTag)
+        waitForVisibleTerminal("initial attach") { it.contains(READY_MARKER) }
+        waitForConnected("initial attach")
+        waitForNoSwitchingOverlay("pre-loss attach settle")
+        captureViewport("issue1193-01-attached")
+
+        val vm = currentViewModel()
+        val observer = terminalNetworkObserver()
+        observer.ignoreRealNetworkCallbacksForTest = true
+
+        // Baseline validated WIFI identity (proven-alive pinned so the baseline
+        // transition never tears the session before the load-bearing chain).
+        vm.forceTransportProvenAliveForTest = true
+        observer.emitSyntheticSnapshotForTest(
+            TerminalNetworkSnapshot.Validated(networkHandle = "wifi-A", transports = setOf("WIFI")),
+            reason = "issue1193-baseline-wifi",
+        )
+        waitForConnected("post-baseline wifi")
+        waitForNoSwitchingOverlay("post-baseline wifi settle")
+        diagnostics!!.clear()
+
+        // THE LOSS: a bare NoValidatedNetwork — the WiFi→cellular dip begins.
+        val lost = observer.emitSyntheticSnapshotForTest(
+            TerminalNetworkSnapshot.NoValidatedNetwork,
+            reason = "issue1193-bare-network-loss",
+        )
+        assertEquals(
+            "the surfaced change must be a NetworkLost",
+            TerminalNetworkChangeKind.NetworkLost,
+            lost!!.kind,
+        )
+        awaitNetworkLossHold("after the bare loss")
+        watchNoRedialDiagnostics("during the loss window", WATCH_NO_CHURN_MS)
+        captureViewport("issue1193-02-loss-held")
+
+        // THE MAINTAINER'S EXACT CELLULAR STATE across the restore: the passive
+        // keepalive timestamp is FRESH (proven-alive pinned) BUT the post-handoff
+        // socket is GENUINELY DEAD (the bounded probe cannot answer). Pre-#1193 this
+        // rode through onto the dead transport; #1193 must probe, detect death, and
+        // cleanly redial.
+        vm.forceTransportProvenAliveForTest = true
+        vm.forceLivenessProbeDeadForTest = true
+        diagnostics!!.clear()
+
+        // THE RESTORE: validation returns to the SAME WIFI identity.
+        val restored = observer.emitSyntheticSnapshotForTest(
+            TerminalNetworkSnapshot.Validated(networkHandle = "wifi-A", transports = setOf("WIFI")),
+            reason = "issue1193-network-restored",
+        )
+        assertEquals(
+            "the surfaced change must be a NetworkRestored",
+            TerminalNetworkChangeKind.NetworkRestored,
+            restored!!.kind,
+        )
+
+        // LOAD-BEARING (GREEN with #1193): the bounded probe found the dead socket, so
+        // the restore redials via the fresh lease — network_restore_reconnect_start fires.
+        compose.waitUntil(timeoutMillis = RESTORE_RECONNECT_TIMEOUT_MS) {
+            diagnostics!!.eventsNamed("network_restore_reconnect_start").isNotEmpty()
+        }
+        assertTrue(
+            "expected the dead-socket restore to redial via network_restore_reconnect_start " +
+                "(proves the bounded probe redialled, not a vacuous pass); " +
+                "events=${diagnostics!!.events.map { it.name }}",
+            diagnostics!!.eventsNamed("network_restore_reconnect_start").isNotEmpty(),
+        )
+        // THE #1193 distinction: a fresh-keepalive + dead-socket restore must NOT ride
+        // through on the passive timestamp (that would mean the deleted branch 1 fired
+        // and committed to the dead transport — the maintainer's spurious drop).
+        assertTrue(
+            "a fresh-keepalive-but-DEAD-socket restore must NOT ride through on the passive " +
+                "timestamp (the #1193 bug); events=${diagnostics!!.events.map { it.name }}",
+            diagnostics!!.eventsNamed("network_restore_ride_through").isEmpty(),
+        )
+
+        // Release the synthetic dead-probe seam so the freshly-redialled (real, healthy)
+        // transport is not immediately re-declared dead by the periodic probe loop.
+        vm.forceLivenessProbeDeadForTest = false
+
+        // Recovered: Connected, no overlay, viewport painted.
+        waitForConnected("after dead-socket restore redial")
+        waitForNoSwitchingOverlay("after dead-socket restore redial settle")
+        waitForVisibleTerminal("after dead-socket restore terminal") { it.contains(READY_MARKER) }
+        captureViewport("issue1193-03-redialled")
+
+        writeTimings()
+    } }
+
     private fun currentViewModel(): TmuxSessionViewModel {
         lateinit var vm: TmuxSessionViewModel
         compose.activityRule.scenario.onActivity { activity ->

--- a/app/src/androidTest/java/com/pocketshell/app/proof/MobileSpuriousReconnectE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/MobileSpuriousReconnectE2eTest.kt
@@ -212,9 +212,15 @@ class MobileSpuriousReconnectE2eTest {
                 "not a vacuous pass); events=${diagnostics!!.events.map { it.name }}",
             rideThrough.isNotEmpty(),
         )
+        // Issue #1193: the passive-timestamp ride-through fast-path (cause
+        // "transport_proven_alive") is DELETED — EVERY restore ride-through now goes
+        // through the bounded ACTIVE probe. On a surviving (live) socket the probe
+        // answers fast, so it still rides through with NO redial, but attributed to
+        // the probe answering ("probe_answered"), not the passive keepalive alone.
         assertEquals(
-            "arm 1: the ride-through is attributed to the proven-alive keepalive",
-            "transport_proven_alive",
+            "the surviving-socket ride-through is attributed to the bounded probe answering " +
+                "(the #1193 always-probe restore arm)",
+            "probe_answered",
             rideThrough.first().fields["cause"],
         )
 

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -1087,8 +1087,15 @@ public class TmuxSessionViewModel @Inject constructor(
      * but HEALTHY channel is never torn down by the probe itself. Returns true if
      * the channel answered. The [LivenessProbe] wraps this in its own generous
      * per-probe timeout and N-consecutive-failure criterion.
+     *
+     * Issue #1193: [requireAnsweredRoundTrip] forwards to [TmuxClient.probeLiveness]
+     * so a NETWORK-TRANSITION probe (the restore / handoff arms) demands an actual
+     * answered round-trip over the (possibly new) path — the #927 reader-activity
+     * fallback is NOT valid liveness evidence across a WiFi↔cellular handoff, since
+     * those bytes crossed the OLD, now-dead socket. The steady-state periodic drop
+     * probe leaves it `false` (keeps the #927 busy-vs-dead tolerance).
      */
-    private suspend fun runLivenessProbePing(): Boolean {
+    private suspend fun runLivenessProbePing(requireAnsweredRoundTrip: Boolean = false): Boolean {
         // EPIC #792 Slice D — the per-PR synthetic-drop seam. When the test hook
         // is armed the ping reports DEAD regardless of the real channel, so the
         // silent-drop detection + recovery contract can be exercised
@@ -1097,7 +1104,7 @@ public class TmuxSessionViewModel @Inject constructor(
         // real wire. Production default is false (the real probe runs).
         if (forceLivenessProbeDeadForTest) return false
         val client = clientRef ?: return false
-        return runCatching { client.probeLiveness() }.getOrDefault(false)
+        return runCatching { client.probeLiveness(requireAnsweredRoundTrip) }.getOrDefault(false)
     }
 
     /**
@@ -5012,8 +5019,13 @@ public class TmuxSessionViewModel @Inject constructor(
         target: ConnectionTarget,
     ) {
         viewModelScope.launch {
+            // Issue #1193: this handoff probe is a NETWORK-TRANSITION probe, so it
+            // requires an ANSWERED round-trip (like the restore arm). Recent reader
+            // bytes crossed the OLD socket and are not evidence the new path is
+            // alive — the #927 reader-activity fallback would let a dead post-handoff
+            // cellular socket pass, exactly the residual §4 of the #928 spike.
             val alive = withTimeoutOrNull(RESTORE_LIVENESS_PROBE_BUDGET_MS) {
-                runLivenessProbePing()
+                runLivenessProbePing(requireAnsweredRoundTrip = true)
             } ?: false
             if (alive) {
                 rideThroughNetworkHandoffProvenAlive(change, target)
@@ -5244,32 +5256,46 @@ public class TmuxSessionViewModel @Inject constructor(
      * restore. On cellular the device dips into no-validated-network constantly
      * (tunnel, elevator, RAT handover, congestion re-validation) WITHOUT the TCP
      * socket dying, so that unconditional redial was the maintainer's "constant
-     * reconnects on mobile internet". We now check whether the EXISTING transport
-     * survived the dip before tearing it down:
-     *   1. if the always-on transport keepalive proves the link alive within its
-     *      ride-through window (a sub-budget loss never ages it out), RIDE THROUGH
-     *      synchronously with no redial; otherwise
-     *   2. issue ONE bounded control-channel probe — if it answers, ride through.
-     * Only when the transport does NOT answer (or the bounded probe times out) do we
-     * fall back to the #997 fresh-lease redial. A genuinely dead post-outage socket
-     * therefore STILL reconnects (BareNetworkLossRestoreReconnectE2eTest guards it).
+     * reconnects on mobile internet". We check whether the EXISTING transport
+     * survived the dip before tearing it down.
+     *
+     * Issue #1193 — the restore ride-through decision now goes through ONE
+     * mechanism only: a bounded ACTIVE probe. The pre-#1193 fast-path rode through
+     * whenever the passive transport keepalive TIMESTAMP was fresh
+     * ([isTransportKeepAliveProvenAliveRecently], a pure < 90s clock comparison —
+     * NO round-trip). On a WiFi→cellular handoff the old socket is silently dead
+     * (the new radio's IP/NAT invalidates the 4-tuple) while the last-inbound-byte
+     * age is still under the ~90s keepalive budget, so that fast-path committed to
+     * a DEAD transport, flipped back to Live, and the `-CC` reader threw ~157ms
+     * later → `passive_disconnect` + reconnect churn (the maintainer's 2026-07-02
+     * cellular spurious drop). This is the SAME defect #1078 already fixed on the
+     * sibling validated-identity-change arm ([suppressNetworkTransportProvenAlive]),
+     * which a real cellular flap bypasses because it arrives via loss→restore, not
+     * identity-change. We mirror that fix here: issue ONE bounded control-channel
+     * probe that requires an ANSWERED round-trip (#1193 `requireAnsweredRoundTrip`,
+     * so stale reader activity over the OLD socket cannot mask a dead new path). If
+     * it answers, RIDE THROUGH (the #974/#981/#1042 spurious-drop-suppression win is
+     * preserved — a truly-live transport answers fast, well inside the 2s budget).
+     * Only when the probe does NOT answer (or times out) do we fall back to the #997
+     * fresh-lease redial — a genuinely dead post-handoff socket therefore redials
+     * PROMPTLY instead of freezing Live-but-dead for ~90s
+     * (BareNetworkLossRestoreReconnectE2eTest guards both outcomes). The passive
+     * keepalive check remains a NEGATIVE signal elsewhere (the #964 probe deferral,
+     * the handoff classifier) but is NO LONGER a positive ride-through authority on
+     * restore (D22 hard-cut — the passive fast-path is deleted, not flagged).
      */
     private fun scheduleNetworkReconnectOnRestore(
         change: TerminalNetworkChange,
         target: ConnectionTarget,
     ) {
-        // (1) Fast synchronous ride-through: the keepalive already proves the link
-        // alive within its window, so the brief loss did not kill the socket.
-        if (isTransportKeepAliveProvenAliveRecently()) {
-            rideThroughNetworkRestore(change, target, cause = "transport_proven_alive")
-            return
-        }
-        // (2) The keepalive aged out (a quiet/idle link). Do not blindly redial —
-        // issue ONE bounded probe over the warm control channel; ride through if it
-        // answers, redial only if it does not.
+        // Issue #1193: EVERY restore ride-through decision goes through the bounded
+        // ACTIVE probe (require an answered round-trip). Ride through only if the
+        // (possibly new) path answers; redial via the #997 fresh lease if it does
+        // not. No passive-timestamp fast-path — that is what committed to a dead
+        // cellular socket.
         viewModelScope.launch {
             val alive = withTimeoutOrNull(RESTORE_LIVENESS_PROBE_BUDGET_MS) {
-                runLivenessProbePing()
+                runLivenessProbePing(requireAnsweredRoundTrip = true)
             } ?: false
             if (alive) {
                 rideThroughNetworkRestore(change, target, cause = "probe_answered")

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
@@ -4517,6 +4517,179 @@ class TmuxSessionViewModelTest {
         }
     }
 
+    @Test
+    fun issue1193NetworkRestoreFreshKeepaliveButDeadSocketRedialsViaProbeNotPassiveRideThrough() =
+        runTest(scheduler) {
+            // Issue #1193 REPRODUCE-FIRST (D33/G10): the maintainer's 2026-07-02
+            // cellular spurious drop. On a WiFi→cellular restore the OLD socket is
+            // silently dead (the new radio's IP/NAT invalidates the 4-tuple) but the
+            // PASSIVE keepalive TIMESTAMP is still fresh (< 90s). Pre-#1193 branch 1 of
+            // scheduleNetworkReconnectOnRestore rode through on that timestamp ALONE
+            // (isTransportKeepAliveProvenAliveRecently — a pure clock comparison, NO
+            // round-trip) → committed to the dead transport, flipped back to Live, and
+            // the `-CC` reader threw ~157ms later → passive_disconnect + reconnect
+            // churn. This pins BOTH the fresh keepalive (forceTransportProvenAliveForTest
+            // = true, the maintainer's EXACT state) AND a genuinely dead socket
+            // (forceLivenessProbeDeadForTest = true — the bounded probe won't answer).
+            //
+            // RED (branch 1 present): records a network_restore_ride_through
+            //   cause=transport_proven_alive and does NOT redial (connectCount == 0) —
+            //   the app commits to the dead transport.
+            // GREEN (#1193, branch 1 deleted → all restores go through the bounded
+            //   probe): the probe requires an answered round-trip, finds the socket
+            //   dead, and cleanly redials — network_restore_reconnect_start fires,
+            //   connectCount == 1, and there is NO network_restore_ride_through.
+            TMUX_CONNECT_ATTEMPTS.set(0)
+            val registry = ActiveTmuxClients()
+            val connector = QueueLeaseConnector(FakeSshSession())
+            val reconnectClient = FakeTmuxClient().withSinglePane("work", "%1")
+            val vm = newVm(
+                registry = registry,
+                sshLeaseManager = testLeaseManager(connector = connector, scope = this, idleTtlMillis = 0L),
+            )
+            vm.setTmuxClientFactoryForTest { _, _, _ -> reconnectClient }
+            vm.setAutoReconnectDelaysForTest(listOf(0L))
+            vm.replaceClientForTest(
+                hostId = 7L,
+                hostName = "alpha",
+                host = "alpha.example",
+                port = 22,
+                user = "alex",
+                keyPath = "/keys/a",
+                sessionName = "work",
+                client = FakeTmuxClient(),
+            )
+            runCurrent()
+
+            // The maintainer's exact cellular state: keepalive timestamp FRESH (the
+            // passive check would say "proven alive") but the post-handoff socket
+            // GENUINELY DEAD (the bounded probe cannot round-trip).
+            vm.forceTransportProvenAliveForTest = true
+            vm.forceLivenessProbeDeadForTest = true
+
+            val diagnostics = installRecordingDiagnosticSink()
+            try {
+                registry.lifecycleHooksSnapshot().single().onNetworkChanged(networkLoss())
+                runCurrent()
+                registry.lifecycleHooksSnapshot().single().onNetworkChanged(networkRestore())
+                advanceUntilIdle()
+
+                // GREEN load-bearing #1: the restore must NOT ride through onto the
+                // dead transport on a fresh-keepalive timestamp — that passive
+                // ride-through is the #1193 bug.
+                assertTrue(
+                    "a fresh-keepalive-but-DEAD-socket restore must NOT ride through the dead " +
+                        "transport on the passive timestamp (the #1193 cellular spurious drop); " +
+                        "events=${diagnostics.events.map { it.name }}",
+                    diagnostics.eventsNamed("network_restore_ride_through").isEmpty(),
+                )
+                // GREEN load-bearing #2: the bounded probe detected the dead socket and
+                // cleanly redialled via the #997 fresh lease.
+                assertEquals(
+                    "the dead-socket restore must redial via the bounded-probe fresh lease",
+                    1,
+                    connector.connectCount,
+                )
+                assertEquals(
+                    "the redial fires with the network-reconnect trigger",
+                    TmuxConnectTrigger.NetworkReconnect,
+                    vm.latestRestoreIntentSnapshot()?.trigger,
+                )
+                assertTrue(
+                    "the redial records the fast restore signal (not a vacuous pass); " +
+                        "events=${diagnostics.events.map { it.name }}",
+                    diagnostics.eventsNamed("network_restore_reconnect_start").isNotEmpty(),
+                )
+            } finally {
+                diagnostics.close()
+                vm.forceTransportProvenAliveForTest = null
+            }
+        }
+
+    @Test
+    fun issue1193NetworkRestoreFreshKeepaliveAndAliveSocketStillRidesThroughViaProbe() =
+        runTest(scheduler) {
+            // Issue #1193 NO-REGRESSION (G2 class coverage): the genuine happy cellular
+            // dip — a fresh keepalive timestamp AND a truly-alive socket. With the
+            // passive fast-path deleted the restore now proves liveness with the bounded
+            // ACTIVE probe; on a live socket the probe ANSWERS fast (well inside the 2s
+            // budget) so the session still RIDES THROUGH with no redial — the
+            // #974/#981/#1042 spurious-drop-suppression win is preserved. The
+            // distinguishing assertion is cause == "probe_answered" (NOT
+            // "transport_proven_alive"): even with a fresh keepalive the decision now
+            // runs through the probe, never the deleted passive gate.
+            TMUX_CONNECT_ATTEMPTS.set(0)
+            val registry = ActiveTmuxClients()
+            val connector = QueueLeaseConnector(FakeSshSession())
+            val reconnectClient = FakeTmuxClient().withSinglePane("work", "%1")
+            val vm = newVm(
+                registry = registry,
+                sshLeaseManager = testLeaseManager(connector = connector, scope = this, idleTtlMillis = 0L),
+            )
+            vm.setTmuxClientFactoryForTest { _, _, _ -> reconnectClient }
+            vm.setAutoReconnectDelaysForTest(listOf(0L))
+            vm.replaceClientForTest(
+                hostId = 7L,
+                hostName = "alpha",
+                host = "alpha.example",
+                port = 22,
+                user = "alex",
+                keyPath = "/keys/a",
+                sessionName = "work",
+                client = FakeTmuxClient(),
+            )
+            runCurrent()
+
+            // Fresh keepalive timestamp AND a live socket (probe-dead seam OFF, so the
+            // FakeTmuxClient's refresh-client round-trip answers).
+            vm.forceTransportProvenAliveForTest = true
+            vm.forceLivenessProbeDeadForTest = false
+
+            val diagnostics = installRecordingDiagnosticSink()
+            try {
+                registry.lifecycleHooksSnapshot().single().onNetworkChanged(networkLoss())
+                runCurrent()
+                registry.lifecycleHooksSnapshot().single().onNetworkChanged(networkRestore())
+                advanceUntilIdle()
+
+                assertEquals(
+                    "a fresh-keepalive + ALIVE-socket restore must still ride through (no redial)",
+                    0,
+                    connector.connectCount,
+                )
+                assertNull(
+                    "a ride-through restore must not schedule a network-reconnect redial",
+                    vm.latestRestoreIntentSnapshot(),
+                )
+                assertTrue(
+                    "the ride-through clears the loss-hold band back to Connected",
+                    vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected,
+                )
+                assertTrue(
+                    "no redial diagnostic may fire on the alive-socket ride-through; events=" +
+                        diagnostics.events.map { it.name },
+                    diagnostics.eventsNamed("network_restore_reconnect_start").isEmpty() &&
+                        diagnostics.eventsNamed("reconnect_start").isEmpty(),
+                )
+                val rideThrough = diagnostics.eventsNamed("network_restore_ride_through")
+                assertTrue(
+                    "expected a network_restore_ride_through (proves the ride-through fired, " +
+                        "not a vacuous pass); events=${diagnostics.events.map { it.name }}",
+                    rideThrough.isNotEmpty(),
+                )
+                assertEquals(
+                    "even with a fresh keepalive the restore now rides through via the bounded " +
+                        "PROBE (cause=probe_answered), NOT the deleted passive transport_proven_alive " +
+                        "fast-path — this is the #1193 behavior change",
+                    "probe_answered",
+                    rideThrough.single().fields["cause"],
+                )
+            } finally {
+                diagnostics.close()
+                vm.forceTransportProvenAliveForTest = null
+            }
+        }
+
     // ---- Issue #1080: Doze/app-standby wake must NOT ride through a dead socket ----
     //
     // Android deep Doze suspends the network so the keepalive cannot keep the NAT

--- a/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxClient.kt
+++ b/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxClient.kt
@@ -316,18 +316,39 @@ public interface TmuxClient : AutoCloseable {
      * control command with a small reply, already on tmux's best-effort
      * allow-list) and returns whether a non-error response came back, falling back
      * to the recent-reader-activity evidence when the reply did not arrive.
+     *
+     * Issue #1193 — [requireAnsweredRoundTrip] hardens the probe for a
+     * NETWORK-TRANSITION call site (a WiFi↔cellular restore / handoff). On a
+     * transition the recent reader bytes crossed the OLD socket's 4-tuple, so they
+     * do NOT prove the NEW default network's path is alive — the #927
+     * reader-activity fallback would let a silently-dead post-handoff socket pass as
+     * "alive" (the maintainer's cellular spurious drop, where a fresh keepalive
+     * timestamp masked a dead socket until the reader threw ~157ms later). When
+     * `true`, the probe requires an actual ANSWERED round-trip over the (possibly
+     * new) path and ignores the reader-activity fallback, so a dead cellular socket
+     * is detected UP-FRONT before the restore arm rides through onto it. The
+     * steady-state periodic drop probe keeps the default `false` (the #927
+     * busy-vs-dead tolerance a live-but-slow link needs).
      */
-    public suspend fun probeLiveness(): Boolean =
+    public suspend fun probeLiveness(requireAnsweredRoundTrip: Boolean = false): Boolean =
         if (disconnected.value) {
             false
         } else {
             val answered = runCatching { sendBestEffortCommand("refresh-client") }
                 .map { !it.isError }
                 .getOrDefault(false)
-            // Busy ≠ dead (#927): a parked/failed reply over a channel that is
-            // STILL delivering `%output` (or any control block) is alive, not a
-            // miss. A dead half-open link parses nothing, so this stays false.
-            answered || millisSinceLastReaderActivity() <= readerActivityLivenessWindowMs
+            if (requireAnsweredRoundTrip) {
+                // Issue #1193: a network-transition probe demands proof the NEW path
+                // round-trips. Recent reader bytes crossed the OLD socket, so they are
+                // NOT evidence of the new path's liveness — require an answered
+                // round-trip only.
+                answered
+            } else {
+                // Busy ≠ dead (#927): a parked/failed reply over a channel that is
+                // STILL delivering `%output` (or any control block) is alive, not a
+                // miss. A dead half-open link parses nothing, so this stays false.
+                answered || millisSinceLastReaderActivity() <= readerActivityLivenessWindowMs
+            }
         }
 
     /**

--- a/shared/core-tmux/src/test/java/com/pocketshell/core/tmux/ProbeLivenessBusyVsDeadTest.kt
+++ b/shared/core-tmux/src/test/java/com/pocketshell/core/tmux/ProbeLivenessBusyVsDeadTest.kt
@@ -142,4 +142,59 @@ class ProbeLivenessBusyVsDeadTest {
             client.probeLiveness(),
         )
     }
+
+    // ---- Issue #1193: NETWORK-TRANSITION probe (requireAnsweredRoundTrip) ----
+    //
+    // The #927 reader-activity fallback is correct for a STEADY-STATE periodic probe
+    // (a busy-but-alive link mid-`%output`-burst). But on a WiFi↔cellular
+    // restore/handoff those recent reader bytes crossed the OLD socket's 4-tuple —
+    // they do NOT prove the NEW default network's path is alive. On the maintainer's
+    // cellular flap the old socket was silently dead while the last-inbound-byte age
+    // was still fresh, so a fallback-tolerant probe would ride through onto the dead
+    // transport and the reader threw ~157ms later. A transition probe must require an
+    // actual ANSWERED round-trip.
+
+    @Test
+    fun `transition probe ignores the reader-activity fallback - a busy channel is DEAD`() = runTest {
+        // The exact #927 busy case, but as a NETWORK-TRANSITION probe: the
+        // refresh-client reply did NOT come back and only stale (old-socket) reader
+        // activity is present. The steady-state probe tolerates it (#927); the
+        // transition probe must report DEAD so the restore arm redials the new path.
+        val client = FakeProbeClient(bestEffortIsError = true, readerActivityAgeMs = 100)
+        assertTrue(
+            "the steady-state probe still tolerates the busy channel (#927 preserved)",
+            client.probeLiveness(),
+        )
+        assertFalse(
+            "a network-transition probe must require an ANSWERED round-trip and ignore the " +
+                "reader-activity fallback — recent bytes crossed the OLD socket (#1193)",
+            client.probeLiveness(requireAnsweredRoundTrip = true),
+        )
+    }
+
+    @Test
+    fun `transition probe is ALIVE when the round-trip actually answers`() = runTest {
+        // A truly-live new path answers refresh-client fast — the happy reattach that
+        // must NOT regress: the transition probe rides through when the round-trip
+        // answers, regardless of reader-activity.
+        val client = FakeProbeClient(bestEffortIsError = false, readerActivityAgeMs = Long.MAX_VALUE)
+        assertTrue(
+            "a transition probe with a clean answered round-trip is alive (happy reattach " +
+                "preserved)",
+            client.probeLiveness(requireAnsweredRoundTrip = true),
+        )
+    }
+
+    @Test
+    fun `transition probe on a disconnected client is DEAD`() = runTest {
+        val client = FakeProbeClient(
+            bestEffortIsError = false,
+            readerActivityAgeMs = 0,
+            isDisconnected = true,
+        )
+        assertFalse(
+            "a disconnected client is dead on a transition probe too",
+            client.probeLiveness(requireAnsweredRoundTrip = true),
+        )
+    }
 }


### PR DESCRIPTION
Root cause of the maintainer's cellular spurious-drop (upstream of #1177 black + #1185 strand). Deletes the passive-timestamp ride-through fast-path so all network-restore ride-throughs probe the transport first (mirrors #1078); hardens probeLiveness to require an answered round-trip on transition probes. Reviewer APPROVED: red→green on fresh-keepalive+dead-socket; alive-socket still fast-rides (367 tests, 0 fail, no added latency); probe hardening scoped to transitions only (#927 reader-activity preserved for steady-state); #1084 assertions not weakened; D28-localized. Local gate green. Toxiproxy E2E wired to ci-journey-suite for the batched emulator run.\n\nCloses #1193