### PR TITLE
diag: fingerprint the surface-only-black class (model intact) (#1192)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -11550,7 +11550,26 @@ public class TmuxSessionViewModel @Inject constructor(
         // predicate alone read it "healthy" and the watchdog never fired. The new predicate
         // also heals a partial-black pane when tmux's grid holds materially more (anti-thrash
         // guarded), restoring the FULL viewport from tmux's authoritative capture.
-        if (!pane.terminalState.visibleRenderLostFrameVsCapture(captureText)) return false
+        if (!pane.terminalState.visibleRenderLostFrameVsCapture(captureText)) {
+            // Issue #1192: the MODEL grid did NOT lose tmux's frame — the heal oracle,
+            // comparing model-vs-tmux, calls this pane HEALTHY and returns without
+            // touching the grid. But the on-screen SURFACE can still be black while the
+            // model is intact (a surface-only black never diverges from tmux by
+            // construction, spike #874 GAP-1), so it emits NONE of the five #1175
+            // classes above. Fingerprint that ONE otherwise-invisible class here — the
+            // exact site the oracle short-circuits — ONLY when the paint-confirmation
+            // seam says the surface is CONFIRMED black while the model holds content.
+            // Rides this same already-paid capture tick: NO new poll/timer (#1164).
+            // Diagnostics only — no reseed/heal (#721 self-heals known surface-blanks).
+            if (pane.terminalState.surfaceIsBlackWhileModelHasContent()) {
+                recordBlackFrameObserved(
+                    pane,
+                    BLACK_FRAME_CLASS_SURFACE_BLACK_MODEL_INTACT,
+                    captureText,
+                )
+            }
+            return false
+        }
         // Issue #1175: the render LOST tmux's frame (capture carries materially more
         // than the render). Fingerprint the observed black frame BEFORE the heal
         // repaints it. A render with SOME surviving live content is the partial/half-
@@ -18332,6 +18351,17 @@ internal const val BLACK_FRAME_CLASS_REVEAL_GATE_GAVE_UP: String = "reveal_gate_
 
 /** Some live content survives but the majority of the viewport is black (partial/half-black). */
 internal const val BLACK_FRAME_CLASS_PARTIAL_BLANK: String = "partial_blank"
+
+/**
+ * Issue #1192 — the SIXTH class: the MODEL grid matches tmux (so the heal oracle,
+ * comparing model-vs-tmux, calls the pane HEALTHY) but the on-screen SURFACE is
+ * confirmed black. Un-catchable by the oracle BY CONSTRUCTION (a surface-only black
+ * never diverges from tmux), so it emits none of the five classes above. Fingerprinted
+ * from the paint-confirmation seam ([TerminalSurfaceState.surfaceIsBlackWhileModelHasContent])
+ * at the oracle's model-healthy short-circuit. DIAGNOSTICS ONLY (no reseed — #721
+ * self-heals every known surface-blank trigger; this is the safety-net for an UNKNOWN one).
+ */
+internal const val BLACK_FRAME_CLASS_SURFACE_BLACK_MODEL_INTACT: String = "surface_black_model_intact"
 
 /**
  * Issue #693/#661: backoff between active-pane reveal-gate seed retries.

--- a/app/src/test/java/com/pocketshell/app/tmux/SurfaceBlackModelIntactDiagnosticTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/SurfaceBlackModelIntactDiagnosticTest.kt
@@ -1,0 +1,490 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.app.diagnostics.RecordedDiagnosticEvent
+import com.pocketshell.app.diagnostics.installRecordingDiagnosticSink
+import com.pocketshell.app.sessions.ActiveTmuxClients
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.SshLeaseConnector
+import com.pocketshell.core.ssh.SshLeaseManager
+import com.pocketshell.core.ssh.SshLeaseTarget
+import com.pocketshell.core.ssh.SshPortForward
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshShell
+import com.pocketshell.core.tmux.CommandResponse
+import com.pocketshell.core.tmux.TmuxClientFactory
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+import java.io.InputStream
+
+/**
+ * Issue #1192 — the SIXTH `black_frame_observed` class, `surface_black_model_intact`.
+ *
+ * ## What this proves (the observability gap #874 GAP-1 left)
+ *
+ * The heal oracle ([TmuxSessionViewModel.healActivePaneIfStaleRender]) decides "black
+ * screen?" by comparing the emulator MODEL grid against tmux's authoritative
+ * `capture-pane`. A black screen where the on-screen SURFACE is blank but the MODEL grid
+ * still matches tmux is un-catchable BY CONSTRUCTION — the model never diverges — so it
+ * emits NONE of the five #1175 classes. If the maintainer's black recurs as a
+ * surface-only black after #1181, the shared log would be SILENT about it.
+ *
+ * This slice adds a minimal SURFACE-paint-confirmation seam
+ * ([com.pocketshell.core.terminal.ui.TerminalSurfaceState.onSurfaceFramePainted]) that the
+ * vendored `TerminalView.onDraw` reports each frame into, and fingerprints the class at
+ * the exact site the oracle short-circuits on a model-healthy pane. DIAGNOSTICS ONLY — no
+ * reseed/heal (#721 self-heals every KNOWN surface-blank trigger).
+ *
+ * ## Red → green (criterion 1), in one run
+ *
+ * [surfaceHealthyPaneWithHealthyPaintRecordsNothing] is the RED side: model intact +
+ * capture matches (oracle healthy) but the surface last painted CONTENT → NO event. It
+ * proves the detector is load-bearing (the event exists ONLY because of the surface-black
+ * signal, not the model state). [surfaceBlackWhileModelIntactIsFingerprinted] flips ONLY
+ * the surface-paint signal to a BLACK frame → the `surface_black_model_intact` event fires
+ * with the full field set, and lands in the exportable JSONL.
+ *
+ * ## Additive (criterion 2) + no new poll (criterion 3)
+ *
+ * [existingLostAfterPaintClassStillEmitsUnchanged] drives the pre-existing
+ * `lost_after_paint` class + `stale_render_heal` through the SAME (now-modified) oracle
+ * site and asserts they are unchanged AND that the new surface class does NOT also fire.
+ * [emissionRidesTheExistingHealCaptureNoExtraRoundTrip] asserts the whole heal+observe
+ * pass issues exactly ONE `capture-pane` — the emission adds no timer/loop/round-trip
+ * (it rides the existing gated stale-render watchdog tick, #1164).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class SurfaceBlackModelIntactDiagnosticTest {
+
+    private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val createdVms = mutableListOf<TmuxSessionViewModel>()
+
+    @After
+    fun tearDown() {
+        factoryScope.cancel()
+    }
+
+    // -------------------------------------------------------------------------
+    // GREEN — model intact (oracle healthy) but the surface last painted a BLACK
+    // frame → the sixth class is fingerprinted with the full field set.
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun surfaceBlackWhileModelIntactIsFingerprinted() = runVmTest { sink ->
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%1")
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == "%1" }
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+
+        // MODEL grid holds a dense frame that MATCHES tmux — the oracle would call this
+        // pane HEALTHY (it does not lose the frame vs capture).
+        renderDenseFrame(pane)
+        assertTrue(pane.terminalState.renderedNonBlankCharCount() > 0)
+        client.capturePaneResponses.addLast(
+            CommandResponse(number = 99L, output = denseFrameLines(), isError = false),
+        )
+        assertFalse(
+            "precondition: the model matches tmux (oracle healthy) so none of the five " +
+                "classes can fire — only the surface-paint seam can",
+            pane.terminalState.visibleRenderLostFrameVsCapture(
+                denseFrameLines().joinToString("\n"),
+            ),
+        )
+
+        // Inject the failing SURFACE state synthetically (#780 model — the CI JVM cannot
+        // run a real View onDraw): the most-recent painted frame was the BLACK fallback.
+        pane.terminalState.recordSurfaceFramePaintedForTest(paintedEmulatorContent = true, atMs = 1L)
+        pane.terminalState.recordSurfaceFramePaintedForTest(paintedEmulatorContent = false, atMs = 2L)
+        assertTrue(
+            "the surface is confirmed black while the model holds content",
+            pane.terminalState.surfaceIsBlackWhileModelHasContent(),
+        )
+
+        val healed = vm.healActivePaneIfStaleRenderForTest()
+        advanceUntilIdle()
+
+        assertFalse("a model-healthy pane is not healed (diagnostics only, no reseed)", healed)
+        val event = sink.singleBlackFrameEvent()
+        assertEquals("surface_black_model_intact", event.fields["class"])
+        assertEquals("%1", event.fields["paneId"])
+        // Full field set (same as the other five classes).
+        assertTrue("the model still renders content", (event.fields["renderedChars"] as Int) > 0)
+        assertTrue("the capture carried a real frame", (event.fields["captureBytes"] as Int) > 0)
+        assertTrue("the pane geometry is reported", (event.fields["visibleRows"] as Int) > 0)
+        assertTrue(
+            "msSinceLastSeed must be a real age for a seeded pane",
+            (event.fields["msSinceLastSeed"] as Long) >= 0L,
+        )
+        assertEquals("Connected", event.fields["connectionStatus"])
+        assertTrue("foreground is reported", event.fields.containsKey("foreground"))
+        assertTrue("screenOn is reported", event.fields.containsKey("screenOn"))
+        // Diagnostics-only: NO successful heal event was emitted (the model was healthy).
+        assertEquals(
+            "no stale_render_heal — the oracle never touched the healthy model",
+            0,
+            sink.eventsNamed("stale_render_heal").size,
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // GREEN → export: the new class flows into the EXPORTABLE JSONL (criterion 4).
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun surfaceBlackClassLandsInExportableJsonl() = runVmTest { sink ->
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%2")
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == "%2" }
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+
+        renderDenseFrame(pane)
+        client.capturePaneResponses.addLast(
+            CommandResponse(number = 99L, output = denseFrameLines(), isError = false),
+        )
+        pane.terminalState.recordSurfaceFramePaintedForTest(paintedEmulatorContent = false, atMs = 5L)
+
+        vm.healActivePaneIfStaleRenderForTest()
+        advanceUntilIdle()
+
+        // The exportable ring is the same JSONL the Settings → Diagnostics "Share log"
+        // export reads; the event name + class must be present in it.
+        val exported = sink.eventsNamed("black_frame_observed")
+        assertEquals(1, exported.size)
+        assertEquals("surface_black_model_intact", exported.single().fields["class"])
+    }
+
+    // -------------------------------------------------------------------------
+    // RED side — model intact + capture matches (oracle healthy) but the surface last
+    // painted CONTENT → NO event. Proves the surface-paint signal is load-bearing.
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun surfaceHealthyPaneWithHealthyPaintRecordsNothing() = runVmTest { sink ->
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%3")
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == "%3" }
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+
+        renderDenseFrame(pane)
+        client.capturePaneResponses.addLast(
+            CommandResponse(number = 99L, output = denseFrameLines(), isError = false),
+        )
+        // The surface's most-recent paint was CONTENT — not black.
+        pane.terminalState.recordSurfaceFramePaintedForTest(paintedEmulatorContent = false, atMs = 1L)
+        pane.terminalState.recordSurfaceFramePaintedForTest(paintedEmulatorContent = true, atMs = 2L)
+        assertFalse(
+            "a surface that painted content is NOT black",
+            pane.terminalState.surfaceIsBlackWhileModelHasContent(),
+        )
+
+        vm.healActivePaneIfStaleRenderForTest()
+        advanceUntilIdle()
+
+        assertEquals(
+            "a healthy model + healthy surface must NOT fingerprint any black frame",
+            0,
+            sink.eventsNamed("black_frame_observed").size,
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // RED side — a surface that has never painted at all (cold, pre-first-onDraw) is
+    // NOT fingerprinted even with a black model, so a freshly-seeded pane is silent.
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun surfaceThatHasNeverPaintedIsNotFingerprinted() = runVmTest { sink ->
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%4")
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == "%4" }
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+
+        renderDenseFrame(pane)
+        client.capturePaneResponses.addLast(
+            CommandResponse(number = 99L, output = denseFrameLines(), isError = false),
+        )
+        // NO paint reported at all — the cold pre-first-onDraw transient.
+        assertFalse(pane.terminalState.surfaceIsBlackWhileModelHasContent())
+
+        vm.healActivePaneIfStaleRenderForTest()
+        advanceUntilIdle()
+
+        assertEquals(
+            "a surface that has not painted yet is a transient, never a fingerprint",
+            0,
+            sink.eventsNamed("black_frame_observed").size,
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // Additive (criterion 2) — the pre-existing `lost_after_paint` class + the
+    // `stale_render_heal` success event STILL emit unchanged through the modified
+    // oracle site, and the new surface class does NOT also fire on that path.
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun existingLostAfterPaintClassStillEmitsUnchanged() = runVmTest { sink ->
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%5")
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == "%5" }
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+
+        // Render fully black, tmux still holds a dense frame → the render LOST the frame,
+        // so the oracle takes the (unchanged) lost_after_paint + heal path, NOT my new
+        // model-healthy branch. A surface-black signal is present but must be ignored here.
+        blankRender(pane)
+        assertEquals(0, pane.terminalState.renderedNonBlankCharCount())
+        pane.terminalState.recordSurfaceFramePaintedForTest(paintedEmulatorContent = false, atMs = 9L)
+        client.capturePaneResponses.addLast(
+            CommandResponse(number = 99L, output = denseFrameLines(), isError = false),
+        )
+
+        val healed = vm.healActivePaneIfStaleRenderForTest()
+        advanceUntilIdle()
+
+        assertTrue("the render lost the frame → the heal fires", healed)
+        val event = sink.singleBlackFrameEvent()
+        assertEquals(
+            "the lost_after_paint class is unchanged — the surface branch never runs when " +
+                "the model itself lost the frame",
+            "lost_after_paint",
+            event.fields["class"],
+        )
+        assertEquals(
+            "stale_render_heal must still fire on a successful heal",
+            1,
+            sink.eventsNamed("stale_render_heal").size,
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // No new poll (criterion 3) — the whole heal+observe pass issues exactly ONE
+    // capture-pane; the surface-black emission rides it and adds no round-trip/loop.
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun emissionRidesTheExistingHealCaptureNoExtraRoundTrip() = runVmTest { sink ->
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%6")
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == "%6" }
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+
+        renderDenseFrame(pane)
+        client.capturePaneResponses.addLast(
+            CommandResponse(number = 99L, output = denseFrameLines(), isError = false),
+        )
+        pane.terminalState.recordSurfaceFramePaintedForTest(paintedEmulatorContent = false, atMs = 7L)
+        val capturesBefore = client.captureCount()
+
+        vm.healActivePaneIfStaleRenderForTest()
+        advanceUntilIdle()
+
+        assertEquals(
+            "exactly ONE capture-pane for the whole heal+observe pass — no new poll",
+            capturesBefore + 1,
+            client.captureCount(),
+        )
+        assertEquals(1, sink.eventsNamed("black_frame_observed").size)
+    }
+
+    // ------------------------------------------------------------------ Harness
+
+    private fun runVmTest(body: suspend TestScope.(RecordingSink) -> Unit) = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        LivenessProbeTestOverride.setAutoStartEnabledForTest(false)
+        val sink = installRecordingDiagnosticSink()
+        try {
+            body(RecordingSink(sink))
+        } finally {
+            sink.close()
+            for (vm in createdVms) {
+                runCatching { vm.setProcessForegroundForClearedForTest(false) }
+                runCatching { vm.clearForTest() }
+            }
+            advanceUntilIdle()
+            createdVms.clear()
+            LivenessProbeTestOverride.clear()
+            Dispatchers.resetMain()
+        }
+    }
+
+    /** Thin wrapper so the test body can pull black-frame events by class without imports. */
+    private class RecordingSink(
+        private val delegate: com.pocketshell.app.diagnostics.RecordingDiagnosticEventSink,
+    ) {
+        fun eventsNamed(name: String): List<RecordedDiagnosticEvent> = delegate.eventsNamed(name)
+
+        fun singleBlackFrameEvent(): RecordedDiagnosticEvent {
+            val events = eventsNamed("black_frame_observed")
+            assertEquals(
+                "exactly one black_frame_observed event expected, got: " +
+                    events.joinToString { it.fields["class"].toString() },
+                1,
+                events.size,
+            )
+            return events.single()
+        }
+    }
+
+    private fun TestScope.newVm(
+        registry: ActiveTmuxClients,
+        sshLeaseManager: SshLeaseManager,
+    ): TmuxSessionViewModel = TmuxSessionViewModel(
+        tmuxClientFactory = TmuxClientFactory(factoryScope),
+        activeTmuxClients = registry,
+        runtimeCache = TmuxSessionRuntimeCache(),
+        sshLeaseManager = sshLeaseManager,
+        sessionLifecycleSignals = null,
+    ).also {
+        it.setSeedIoDispatcherForTest(StandardTestDispatcher(testScheduler))
+        // Suppress the background watchdogs so the ONLY heal pass is the one the test
+        // drives directly — no spurious events.
+        it.setStaleRenderWatchdogAutoArmEnabledForTest(false)
+        it.setConnectedBlankWatchdogAutoArmEnabledForTest(false)
+        createdVms.add(it)
+    }
+
+    private fun TestScope.connectVm(client: FakeTmuxClient): TmuxSessionViewModel {
+        val live = AlwaysConnectedSession(id = "live")
+        val connector = SingleSessionConnector(live)
+        val leaseManager =
+            testLeaseManager(connector = connector, scope = this, idleTtlMillis = 60_000L)
+        val registry = ActiveTmuxClients()
+        val vm = newVm(registry = registry, sshLeaseManager = leaseManager)
+        runCurrent()
+        vm.setTmuxClientFactoryForTest { _, _, _ -> client }
+        vm.connect(
+            hostId = 1L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            passphrase = null,
+            sessionName = "work",
+        )
+        advanceUntilIdle()
+        return vm
+    }
+
+    /** Dense, correctly-painted viewport that MATCHES tmux (oracle healthy). */
+    private fun renderDenseFrame(pane: TmuxPaneState) {
+        pane.terminalState.appendRemoteOutput(
+            buildString {
+                append(CLEAR_ONLY)
+                denseFrameLines().forEach { append(it).append("\r\n") }
+            }.toByteArray(Charsets.US_ASCII),
+        )
+    }
+
+    /** Fully black render: a clear-only overpaint wipes the visible viewport. */
+    private fun blankRender(pane: TmuxPaneState) {
+        pane.terminalState.appendRemoteOutput(CLEAR_ONLY.toByteArray(Charsets.US_ASCII))
+    }
+
+    private fun FakeTmuxClient.captureCount(): Int =
+        sentCommands.count { it.startsWith("capture-pane") }
+
+    private fun FakeTmuxClient.withSinglePaneRow(
+        sessionName: String,
+        paneId: String,
+        title: String = sessionName,
+    ): FakeTmuxClient = apply {
+        responses.addLast(
+            CommandResponse(
+                number = 1L,
+                output = listOf("$paneId\t@0\t\$0\t$sessionName\t$title\t0"),
+                isError = false,
+            ),
+        )
+        capturePaneResponses.addLast(
+            CommandResponse(number = 2L, output = listOf("$sessionName ready"), isError = false),
+        )
+        cursorQueryResponses.addLast(
+            CommandResponse(number = 3L, output = listOf("0,0"), isError = false),
+        )
+    }
+
+    private class SingleSessionConnector(
+        private val session: SshSession,
+    ) : SshLeaseConnector {
+        override suspend fun connect(target: SshLeaseTarget): Result<SshSession> =
+            Result.success(session)
+    }
+
+    private class AlwaysConnectedSession(
+        val id: String,
+    ) : SshSession {
+        @Volatile
+        var closed: Boolean = false
+
+        override val isConnected: Boolean get() = !closed
+
+        override suspend fun exec(command: String): ExecResult =
+            ExecResult(stdout = "", stderr = "", exitCode = 0)
+
+        override fun tail(path: String, onLine: (String) -> Unit): Job =
+            Job().apply { complete() }
+
+        override fun tail(path: String, fromLineExclusive: Long, onLine: (String) -> Unit): Job =
+            Job().apply { complete() }
+
+        override fun openLocalPortForward(
+            remoteHost: String,
+            remotePort: Int,
+            localPort: Int,
+        ): SshPortForward = error("not used")
+
+        override fun startShell(): SshShell = error("not used")
+
+        override suspend fun uploadFile(file: File, remotePath: String): String = error("not used")
+
+        override suspend fun uploadStream(
+            input: InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String = error("not used")
+
+        override fun close() {
+            closed = true
+        }
+    }
+
+    private fun denseFrameLines(): List<String> = buildList {
+        add("ISSUE1192-SURFACE-BLACK-MODEL-INTACT")
+        repeat(27) { add("recovered context row $it with real tmux content") }
+    }
+
+    private companion object {
+        // ESC[2J ESC[H — clear screen + cursor home (the overpaint preamble).
+        val CLEAR_ONLY: String = "[2J[H"
+    }
+}

--- a/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurface.kt
+++ b/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurface.kt
@@ -581,7 +581,15 @@ fun TerminalSurface(
                 factory = { ctx ->
                     TerminalView(ctx, /* attributes = */ null)
                         .applyPocketShellDefaults(viewClient)
-                        .also { terminalView = it }
+                        .also { view ->
+                            terminalView = view
+                            // Issue #1192: forward each painted frame's outcome (content
+                            // vs black fallback) into the state's surface-paint seam so
+                            // the tmux watchdog can fingerprint a surface-only-black.
+                            view.setFramePaintObserver { paintedContent, atMs ->
+                                state.onSurfaceFramePainted(paintedContent, atMs)
+                            }
+                        }
                 },
                 update = { view ->
                     terminalView = view

--- a/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurfaceState.kt
+++ b/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurfaceState.kt
@@ -601,6 +601,81 @@ class TerminalSurfaceState(
         }
     }
 
+    // -------------------------------------------------------------------------
+    // Issue #1192 — SURFACE-paint confirmation seam (distinct from the MODEL grid).
+    //
+    // Every predicate above reads the emulator MODEL grid (`renderedNonBlankCharCount`,
+    // `visibleScreenIsBlank`, `visibleRenderLostFrameVsCapture`, …). The heal oracle
+    // ([com.pocketshell.app.tmux.TmuxSessionViewModel.healActivePaneIfStaleRender])
+    // compares that MODEL against tmux's authoritative capture, so a black screen
+    // where the on-screen SURFACE is blank while the model grid still matches tmux is
+    // un-catchable BY CONSTRUCTION — the model never diverges (spike #874 GAP-1).
+    //
+    // This is the minimal paint-confirmation the vendored [com.termux.view.TerminalView]
+    // reports from `onDraw`: `true` when it painted the emulator content (the normal
+    // `mRenderer.render` path), `false` when it painted the BLACK fallback (the
+    // `mEmulator == null` window or a render that threw — #966/#967). The ViewModel's
+    // existing gated stale-render watchdog READS [surfaceIsBlackWhileModelHasContent]
+    // on the tick it already pays for — NO new poll/timer (respects #1164). Volatile
+    // longs, not Compose state: `onDraw` fires on the render thread and this is a
+    // best-effort diagnostic, never a gate on rendering.
+    // -------------------------------------------------------------------------
+
+    @Volatile
+    private var lastSurfaceContentPaintAtMs: Long = 0L
+
+    @Volatile
+    private var lastSurfaceBlankPaintAtMs: Long = 0L
+
+    /**
+     * Issue #1192 — called by [com.termux.view.TerminalView.onDraw] (wired in
+     * [TerminalSurface]) once per painted frame. [paintedEmulatorContent] is `true`
+     * for the normal `mRenderer.render` path and `false` for the black fallback
+     * (`mEmulator == null`, or a render that threw and cleared the canvas). [atMs]
+     * is an `elapsedRealtime()` monotonic stamp. Cheap: one volatile write, no
+     * allocation, called only from `onDraw`.
+     */
+    fun onSurfaceFramePainted(paintedEmulatorContent: Boolean, atMs: Long) {
+        if (paintedEmulatorContent) {
+            lastSurfaceContentPaintAtMs = atMs
+        } else {
+            lastSurfaceBlankPaintAtMs = atMs
+        }
+    }
+
+    /**
+     * Issue #1192 — the SURFACE-only-black detector (the sixth black-frame class the
+     * heal oracle cannot see). Returns `true` when BOTH:
+     *
+     *  1. the MODEL grid holds content ([renderedNonBlankCharCount] > 0) — so the
+     *     oracle, comparing model-vs-tmux, would call this pane HEALTHY; AND
+     *  2. the SURFACE is CONFIRMED black — its most recent painted frame was the
+     *     black fallback ([lastSurfaceBlankPaintAtMs] is newer than
+     *     [lastSurfaceContentPaintAtMs]), i.e. the View is drawing black while the
+     *     model still carries the frame.
+     *
+     * Requires POSITIVE evidence of a black paint (a blank-paint stamp exists AND is
+     * the most-recent frame): a surface that has simply not painted yet (the cold
+     * pre-first-`onDraw` transient) returns `false`, so a freshly-attached-but-seeded
+     * pane is never spuriously fingerprinted. Once the View paints the content, the
+     * content stamp overtakes and this returns `false` again. DIAGNOSTICS ONLY — this
+     * gates no reseed/heal (#721 already self-heals every KNOWN surface-blank trigger).
+     */
+    fun surfaceIsBlackWhileModelHasContent(): Boolean {
+        if (renderedNonBlankCharCount() <= 0) return false
+        return lastSurfaceBlankPaintAtMs > 0L &&
+            lastSurfaceBlankPaintAtMs > lastSurfaceContentPaintAtMs
+    }
+
+    /**
+     * Test-only (#1192): drive the paint-confirmation seam exactly as
+     * [com.termux.view.TerminalView.onDraw] does, so a JVM unit test can reproduce
+     * the surface-black-but-model-intact state WITHOUT a real Android View / render
+     * thread (the #780 synthetic-state model — the CI JVM cannot run `onDraw`).
+     */
+    fun recordSurfaceFramePaintedForTest(paintedEmulatorContent: Boolean, atMs: Long) =
+        onSurfaceFramePainted(paintedEmulatorContent, atMs)
+
     /**
      * Issue #966/#967 — the "mostly-black / stale render on a LIVE transport"
      * oracle. The v0.4.17 black-screen heal ([visibleScreenIsBlank] /

--- a/shared/core-terminal/src/main/java/com/termux/view/TerminalView.java
+++ b/shared/core-terminal/src/main/java/com/termux/view/TerminalView.java
@@ -62,6 +62,24 @@ public final class TerminalView extends View {
 
     public TerminalViewClient mClient;
 
+    /**
+     * Issue #1192 — reports, per painted frame, whether {@link #onDraw} painted the
+     * emulator content or the BLACK fallback (the {@code mEmulator == null} window or a
+     * render that threw). PocketShell's tmux ViewModel wires this to the pane's
+     * {@code TerminalSurfaceState} so its EXISTING gated stale-render watchdog can
+     * fingerprint a surface-only-black (model intact, on-screen surface black) — the one
+     * black-screen class the model-vs-tmux heal oracle cannot see. Null is a no-op.
+     */
+    public interface FramePaintObserver {
+        void onFramePainted(boolean paintedEmulatorContent, long atElapsedRealtimeMs);
+    }
+
+    private FramePaintObserver mFramePaintObserver;
+
+    public void setFramePaintObserver(FramePaintObserver observer) {
+        mFramePaintObserver = observer;
+    }
+
     private TextSelectionCursorController mTextSelectionCursorController;
 
     private Handler mTerminalCursorBlinkerHandler;
@@ -1352,6 +1370,12 @@ public final class TerminalView extends View {
 
     @Override
     protected void onDraw(Canvas canvas) {
+        // Issue #1192: track whether THIS frame painted emulator content (the normal
+        // render path) or the BLACK fallback (mEmulator == null, or a render that threw
+        // — the catch below). Reported to the paint-confirmation observer at the end so
+        // the tmux watchdog can fingerprint a surface-only-black (model intact, surface
+        // black). Defaults to false; only the successful render path sets it true.
+        boolean paintedEmulatorContent = false;
         try {
             if (mEmulator == null) {
                 canvas.drawColor(mDefaultBackgroundColor);
@@ -1366,6 +1390,7 @@ public final class TerminalView extends View {
 
                 // render the text selection handles
                 renderTextSelection();
+                paintedEmulatorContent = true;
             }
         } catch (Throwable t) {
             // Issues #966/#967: widen from RuntimeException to Throwable. An
@@ -1381,6 +1406,14 @@ public final class TerminalView extends View {
             // dirty-region cache (#469) no longer reflects what is on screen, so
             // force the next frame to repaint every row.
             if (mRenderer != null) mRenderer.invalidateDirtyCache();
+        }
+        // Issue #1192: report this frame's paint outcome to the surface-paint seam.
+        // `paintedEmulatorContent` is false for both the mEmulator == null fallback and
+        // a render that threw (the catch above). Cheap, best-effort; never throws into
+        // the draw path.
+        final FramePaintObserver observer = mFramePaintObserver;
+        if (observer != null) {
+            observer.onFramePainted(paintedEmulatorContent, android.os.SystemClock.elapsedRealtime());
         }
     }
 


### PR DESCRIPTION
Closes the last black-screen observability gap (#874 completeness sweep GAP-1): a 6th black_frame_observed class for a black surface over an intact model — the state the oracle + #1175's 5 classes can't see. Adds an allocation-free per-frame paint seam in TerminalView.onDraw. Reviewer APPROVED: red→green driven; onDraw confirmed allocation-free (hot-path safe); no new polling; additive; false-positive avoidance verified. Local gate green.\n\nCloses #1192