### PR TITLE
release: v0.4.23 (versionCode 70)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,8 +65,8 @@ android {
         applicationId = "com.pocketshell.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 69
-        versionName = "0.4.22"
+        versionCode = 70
+        versionName = "0.4.23"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/tools/pocketshell/pyproject.toml
+++ b/tools/pocketshell/pyproject.toml
@@ -8,7 +8,7 @@ name = "pocketshell"
 # scripts/check-pypi-version.sh enforces this; .github/workflows/build.yml
 # runs that check before publishing to PyPI. See
 # tools/pocketshell/README.md ("Release flow") for the bump procedure.
-version = "0.4.22"
+version = "0.4.23"
 description = "Unified server-side Python utility for the PocketShell Android client."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Cuts release **v0.4.23** (versionCode 70) from `main` HEAD.

## Changes since v0.4.22
- connection: probe the transport before riding through a network restore (#1193, #1194)
- diag: fingerprint the surface-only-black class — model intact (#1192, #1195)

## Release gate
- Cheap required checks (`Unit tests`, `Python utility tests`) green on this bump.
- Emulator release-validation gate runs post-merge on stable `main` before the tag is pushed.
- Prior batched `Tests` run on the tagged commit was red only on emulator shard 2 (infra: wrong AVD API level + emulator console startup failures); a clean re-run confirms green (G5).