### PR TITLE
terminal: force a surface repaint to recover surface-only-black (#1203)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -4048,6 +4048,19 @@ public class TmuxSessionViewModel @Inject constructor(
             // any OTHER visible pane. skipWhenFreshlySeeded=false forces the recapture even
             // for a pane already seeded this attach — the whole point of a manual Redraw.
             reseedActivePaneForReattach(guard, skipWhenFreshlySeeded = false)
+            // Issue #1203: the model reseed above recovers a MODEL-black pane (the grid
+            // lost tmux's frame). But the maintainer's "Redraw doesn't work" report is a
+            // SURFACE-only-black: the model grid already matches tmux, so the reseed
+            // restores NOTHING and the surface stays black. Redraw is architecturally
+            // incapable of recovering that with a model reseed alone. Fire an
+            // UNCONDITIONAL surface force-repaint too (re-bind the View's emulator +
+            // full-clip invalidate) so the manual escape hatch recovers BOTH the
+            // model-black AND the surface-only-black classes — the whole point of Redraw
+            // being the user's last-resort recovery. Cheap + idempotent: on a genuinely
+            // healthy pane it is one extra full-clip invalidate, no round-trip.
+            if (isCurrentRuntime(guard)) {
+                activeVisiblePane()?.terminalState?.requestSurfaceRepaint()
+            }
         }
     }
 
@@ -11586,13 +11599,27 @@ public class TmuxSessionViewModel @Inject constructor(
             // exact site the oracle short-circuits — ONLY when the paint-confirmation
             // seam says the surface is CONFIRMED black while the model holds content.
             // Rides this same already-paid capture tick: NO new poll/timer (#1164).
-            // Diagnostics only — no reseed/heal (#721 self-heals known surface-blanks).
             if (pane.terminalState.surfaceIsBlackWhileModelHasContent()) {
                 recordBlackFrameObserved(
                     pane,
                     BLACK_FRAME_CLASS_SURFACE_BLACK_MODEL_INTACT,
                     captureText,
                 )
+                // Issue #1203: the AUTO-HEAL recovery for this class. A model reseed
+                // restores nothing here (the model already matches tmux — the oracle is
+                // blind to this class by construction), so the recovery is a SURFACE
+                // force-repaint: re-bind the View's emulator + full-clip invalidate so
+                // the surface repaints what the model already holds. This is the
+                // self-heal without user action — the maintainer no longer has to tap
+                // Redraw for a surface-only-black.
+                Log.i(
+                    ISSUE_145_RECONNECT_TAG,
+                    "tmux-surface-black-model-intact-heal pane=${pane.paneId} " +
+                        "window=${pane.windowId} session=${activeTarget?.sessionName} " +
+                        "status=${_connectionStatus.value} " +
+                        "rendered=${pane.terminalState.renderedNonBlankCharCount()}",
+                )
+                pane.terminalState.requestSurfaceRepaint()
             }
             return false
         }

--- a/app/src/test/java/com/pocketshell/app/tmux/SurfaceBlackModelIntactDiagnosticTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/SurfaceBlackModelIntactDiagnosticTest.kt
@@ -122,10 +122,23 @@ class SurfaceBlackModelIntactDiagnosticTest {
             pane.terminalState.surfaceIsBlackWhileModelHasContent(),
         )
 
+        val surfaceRepaintsBefore = pane.terminalState.surfaceRepaintRequestCountForTest()
         val healed = vm.healActivePaneIfStaleRenderForTest()
         advanceUntilIdle()
 
-        assertFalse("a model-healthy pane is not healed (diagnostics only, no reseed)", healed)
+        assertFalse(
+            "a model-healthy pane is not MODEL-reseeded (no capture-pane swap) — the recovery is " +
+                "a surface repaint, not a model heal",
+            healed,
+        )
+        // Issue #1203: the auto-heal now RECOVERS this class with a SURFACE force-repaint
+        // (re-bind emulator + full-clip invalidate) instead of only fingerprinting it.
+        assertEquals(
+            "the auto-heal must request exactly one surface force-repaint to recover the " +
+                "surface-only-black the model reseed cannot touch",
+            surfaceRepaintsBefore + 1,
+            pane.terminalState.surfaceRepaintRequestCountForTest(),
+        )
         val event = sink.singleBlackFrameEvent()
         assertEquals("surface_black_model_intact", event.fields["class"])
         assertEquals("%1", event.fields["paneId"])
@@ -145,6 +158,215 @@ class SurfaceBlackModelIntactDiagnosticTest {
             "no stale_render_heal — the oracle never touched the healthy model",
             0,
             sink.eventsNamed("stale_render_heal").size,
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // Issue #1203 — RECOVERY red→green. The MANUAL Redraw forces a SURFACE repaint
+    // that recovers a surface-only-black (model intact, surface black); the model
+    // reseed alone (base) does NOT.
+    //
+    // RED (base, pre-fix): redrawActivePane only runs the model reseed
+    // (reseedActivePaneForReattach). The model already matches tmux, so the reseed
+    // restores nothing and the surface stays black — surfaceRepaintRequestCount stays 0
+    // (no surface repaint requested) and surfaceIsBlackWhileModelHasContent() stays true.
+    //
+    // GREEN (fixed): redrawActivePane ALSO fires requestSurfaceRepaint(); driving that
+    // request through the surface (as TerminalSurface's collector → onDraw content paint
+    // does) clears the surface-black.
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun manualRedrawForcesSurfaceRepaintForSurfaceOnlyBlack() = runVmTest { sink ->
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%10")
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == "%10" }
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+
+        // MODEL intact + capture matches tmux (oracle healthy), surface confirmed black.
+        renderDenseFrame(pane)
+        assertTrue(pane.terminalState.renderedNonBlankCharCount() > 0)
+        // Redraw's reseed pays a capture-pane; return the SAME dense frame so the
+        // non-destructive-swap guard would keep the model intact (nothing to restore).
+        client.capturePaneResponses.addLast(
+            CommandResponse(number = 99L, output = denseFrameLines(), isError = false),
+        )
+        pane.terminalState.recordSurfaceFramePaintedForTest(paintedEmulatorContent = true, atMs = 1L)
+        pane.terminalState.recordSurfaceFramePaintedForTest(paintedEmulatorContent = false, atMs = 2L)
+        assertTrue(
+            "precondition: the surface is confirmed black while the model holds content",
+            pane.terminalState.surfaceIsBlackWhileModelHasContent(),
+        )
+
+        vm.redrawActivePane()
+        advanceUntilIdle()
+
+        // LOAD-BEARING (RED on base = 0): Redraw fired the surface force-repaint. Without
+        // the fix redrawActivePane only reseeds the model, which restores nothing here (the
+        // model already matches tmux) → this count stays 0 and the surface stays black.
+        assertTrue(
+            "manual Redraw must request a surface force-repaint to recover a surface-only-black " +
+                "(the model reseed alone recovers nothing here)",
+            pane.terminalState.surfaceRepaintRequestCountForTest() >= 1,
+        )
+
+        // The requested surface repaint drives the real production path
+        // (TerminalSurface's collector → view.forceSurfaceRepaint() → the next onDraw takes
+        // the CONTENT path and reports it via the paint-confirmation seam). We mirror that
+        // resulting content paint here to prove the recovery actually CLEARS the
+        // surface-black. On base (no fix) no repaint is requested, so the maintainer would
+        // never reach this content paint and the surface stays black.
+        pane.terminalState.recordSurfaceFramePaintedForTest(paintedEmulatorContent = true, atMs = 100L)
+        assertFalse(
+            "after Redraw's surface repaint drove a content paint, the surface is no longer black",
+            pane.terminalState.surfaceIsBlackWhileModelHasContent(),
+        )
+    }
+
+    @Test
+    fun manualRedrawDoesNotSpuriouslyRepaintAHealthySurface() = runVmTest { sink ->
+        // Redraw always fires ONE surface repaint (idempotent full-clip invalidate). This
+        // pins that a healthy surface is recovered by exactly ONE request, never a loop.
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%11")
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == "%11" }
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+
+        renderDenseFrame(pane)
+        client.capturePaneResponses.addLast(
+            CommandResponse(number = 99L, output = denseFrameLines(), isError = false),
+        )
+        // A healthy, content-painted surface.
+        pane.terminalState.recordSurfaceFramePaintedForTest(paintedEmulatorContent = true, atMs = 2L)
+        assertFalse(pane.terminalState.surfaceIsBlackWhileModelHasContent())
+
+        vm.redrawActivePane()
+        advanceUntilIdle()
+
+        assertEquals(
+            "one surface repaint per Redraw tap — no thrash loop on a healthy pane",
+            1,
+            pane.terminalState.surfaceRepaintRequestCountForTest(),
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // Issue #1203 — class coverage (G2): the AUTO-HEAL fires the surface repaint for an
+    // ALT-SCREEN / agent pane too (Claude/Codex idle alt-screen never re-emits %output),
+    // not just a shell pane. Same detector, different pane content.
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun autoHealForcesSurfaceRepaintForAgentAltScreenPane() = runVmTest { sink ->
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%12")
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == "%12" }
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+
+        // A sparse alt-screen agent frame that still MATCHES tmux (oracle healthy).
+        renderAgentAltScreenFrame(pane)
+        assertTrue(pane.terminalState.renderedNonBlankCharCount() > 0)
+        client.capturePaneResponses.addLast(
+            CommandResponse(number = 99L, output = agentAltScreenLines(), isError = false),
+        )
+        assertFalse(
+            "precondition: the agent pane's model matches tmux (oracle healthy)",
+            pane.terminalState.visibleRenderLostFrameVsCapture(
+                agentAltScreenLines().joinToString("\n"),
+            ),
+        )
+        pane.terminalState.recordSurfaceFramePaintedForTest(paintedEmulatorContent = false, atMs = 3L)
+        assertTrue(pane.terminalState.surfaceIsBlackWhileModelHasContent())
+
+        val healed = vm.healActivePaneIfStaleRenderForTest()
+        advanceUntilIdle()
+
+        assertFalse("no model reseed for an oracle-healthy agent pane", healed)
+        assertTrue(
+            "the auto-heal must request a surface force-repaint for a surface-only-black " +
+                "agent/alt-screen pane too (class coverage, not just shell panes)",
+            pane.terminalState.surfaceRepaintRequestCountForTest() >= 1,
+        )
+        val event = sink.singleBlackFrameEvent()
+        assertEquals("surface_black_model_intact", event.fields["class"])
+    }
+
+    // -------------------------------------------------------------------------
+    // Issue #1203 — class coverage (G2): with MULTIPLE panes present, the auto-heal's
+    // surface repaint targets the ACTIVE VISIBLE pane (page 0) — the one the user is
+    // looking at after a reveal/switch — not a background pane. Proves the recovery is
+    // pane-local and reaches whichever pane is active, the on-device "black after switch".
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun autoHealForcesSurfaceRepaintOnActiveVisiblePaneWithMultiplePanes() = runVmTest { sink ->
+        val client = FakeTmuxClient().withTwoPaneRows("work", "%13", "%14")
+        val vm = connectVm(client)
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+
+        // The active visible pane is page 0 — the head of the published pane list.
+        val activePane = vm.panes.value.first()
+        val backgroundPane = vm.panes.value.first { it.paneId != activePane.paneId }
+
+        renderDenseFrame(activePane)
+        assertTrue(activePane.terminalState.renderedNonBlankCharCount() > 0)
+        client.capturePaneResponses.addLast(
+            CommandResponse(number = 99L, output = denseFrameLines(), isError = false),
+        )
+        // The ACTIVE pane's surface goes black while its model is intact.
+        activePane.terminalState.recordSurfaceFramePaintedForTest(paintedEmulatorContent = false, atMs = 4L)
+        assertTrue(activePane.terminalState.surfaceIsBlackWhileModelHasContent())
+
+        vm.healActivePaneIfStaleRenderForTest()
+        advanceUntilIdle()
+
+        assertTrue(
+            "the auto-heal must recover the surface-only-black on the ACTIVE visible pane",
+            activePane.terminalState.surfaceRepaintRequestCountForTest() >= 1,
+        )
+        assertEquals(
+            "the background pane must NOT be surface-repainted (the heal is pane-local to the " +
+                "active visible pane)",
+            0,
+            backgroundPane.terminalState.surfaceRepaintRequestCountForTest(),
+        )
+        assertEquals(
+            "surface_black_model_intact",
+            sink.singleBlackFrameEvent().fields["class"],
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // Issue #1203 — a MODEL-healthy + SURFACE-healthy pane must NOT request a surface
+    // repaint from the auto-heal (no thrash on a genuinely-fine pane).
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun autoHealDoesNotForceSurfaceRepaintWhenSurfaceIsHealthy() = runVmTest { sink ->
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%15")
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == "%15" }
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+
+        renderDenseFrame(pane)
+        client.capturePaneResponses.addLast(
+            CommandResponse(number = 99L, output = denseFrameLines(), isError = false),
+        )
+        pane.terminalState.recordSurfaceFramePaintedForTest(paintedEmulatorContent = true, atMs = 5L)
+        assertFalse(pane.terminalState.surfaceIsBlackWhileModelHasContent())
+
+        vm.healActivePaneIfStaleRenderForTest()
+        advanceUntilIdle()
+
+        assertEquals(
+            "a healthy surface must NOT trigger a surface repaint from the auto-heal",
+            0,
+            pane.terminalState.surfaceRepaintRequestCountForTest(),
         )
     }
 
@@ -409,6 +631,25 @@ class SurfaceBlackModelIntactDiagnosticTest {
         pane.terminalState.appendRemoteOutput(CLEAR_ONLY.toByteArray(Charsets.US_ASCII))
     }
 
+    /**
+     * A sparse alt-screen AGENT viewport (Claude/Codex idle) that still MATCHES tmux —
+     * fewer live rows than a shell frame, but enough non-blank content that the model
+     * grid holds a frame (oracle healthy). Used to prove the recovery covers agent panes.
+     */
+    private fun renderAgentAltScreenFrame(pane: TmuxPaneState) {
+        pane.terminalState.appendRemoteOutput(
+            buildString {
+                append(CLEAR_ONLY)
+                agentAltScreenLines().forEach { append(it).append("\r\n") }
+            }.toByteArray(Charsets.US_ASCII),
+        )
+    }
+
+    private fun agentAltScreenLines(): List<String> = buildList {
+        add("ISSUE1203-AGENT-ALT-SCREEN")
+        repeat(10) { add("claude idle alt-screen row $it with real agent content") }
+    }
+
     private fun FakeTmuxClient.captureCount(): Int =
         sentCommands.count { it.startsWith("capture-pane") }
 
@@ -429,6 +670,36 @@ class SurfaceBlackModelIntactDiagnosticTest {
         )
         cursorQueryResponses.addLast(
             CommandResponse(number = 3L, output = listOf("0,0"), isError = false),
+        )
+    }
+
+    private fun FakeTmuxClient.withTwoPaneRows(
+        sessionName: String,
+        firstPaneId: String,
+        secondPaneId: String,
+        title: String = sessionName,
+    ): FakeTmuxClient = apply {
+        responses.addLast(
+            CommandResponse(
+                number = 1L,
+                output = listOf(
+                    "$firstPaneId\t@0\t\$0\t$sessionName\t$title\t0",
+                    "$secondPaneId\t@1\t\$0\t$sessionName\t$title\t0",
+                ),
+                isError = false,
+            ),
+        )
+        capturePaneResponses.addLast(
+            CommandResponse(number = 2L, output = listOf("$sessionName ready"), isError = false),
+        )
+        capturePaneResponses.addLast(
+            CommandResponse(number = 3L, output = listOf("$sessionName ready"), isError = false),
+        )
+        cursorQueryResponses.addLast(
+            CommandResponse(number = 4L, output = listOf("0,0"), isError = false),
+        )
+        cursorQueryResponses.addLast(
+            CommandResponse(number = 5L, output = listOf("0,0"), isError = false),
         )
     }
 

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -2371,6 +2371,50 @@ else
   fi
 fi
 
+# Issue #1203 surface-only-black recovery proof (core-terminal androidTest).
+# v0.4.23 shipped a 6th black-frame class, `surface_black_model_intact` (#1192):
+# the terminal MODEL grid matches tmux (the model-vs-tmux heal oracle says
+# healthy and never fires), but the on-screen SURFACE is confirmed black — the
+# View's own emulator binding (mEmulator) is null while the session still holds
+# a live emulator, so every onDraw takes the BLACK fallback. The manual Redraw /
+# stale-render heal only RESEED the MODEL (capture-pane → appendRemoteOutput →
+# forceFullRepaint), which restores NOTHING here (the model already matches
+# tmux) → "Redraw doesn't work". This proof drives a REAL TerminalView through
+# the REAL onDraw + the REAL FramePaintObserver seam: RED with mEmulator == null
+# (the black fallback paints, observer reports paintedEmulatorContent=false),
+# then forceSurfaceRepaint() re-binds the emulator and GREEN — the next real
+# onDraw paints CONTENT (observer reports true). Proves the surface re-bind is
+# the load-bearing recovery, not another invalidate(). Uses NO Docker fixture
+# (in-process render test). Lives under com.termux.view.
+CORE_TERMINAL_SURFACE_REPAINT_CLASS="com.termux.view.TerminalViewForceSurfaceRepaintInstrumentedTest"
+SURFACE_REPAINT_STATUS="PASS"
+
+run_core_terminal_surface_repaint() {
+  run_ct_class "$CORE_TERMINAL_SURFACE_REPAINT_CLASS"
+}
+
+if budget_exhausted; then
+  STEP_TIMEOUT_HIT=1
+  SURFACE_REPAINT_STATUS="SKIPPED"
+  echo "JOURNEY_STEP_TIMEOUT: skipping #1203 surface-repaint proof — suite budget exhausted (issue #835 / #470 stall)"
+else
+  echo "=========================================================="
+  echo ">>> CORE-TERMINAL #1203 SURFACE-REPAINT PROOF: $CORE_TERMINAL_SURFACE_REPAINT_CLASS (attempt 1)"
+  echo "=========================================================="
+  surface_repaint_start=$SECONDS
+  if run_core_terminal_surface_repaint; then
+    echo "SURFACE_REPAINT_PASS: passed on attempt 1 (elapsed $((SECONDS - surface_repaint_start))s)"
+  else
+    echo ">>> SURFACE-REPAINT PROOF FAILED attempt 1 — retrying once (CI-AVD infra flake / sibling-install)"
+    if run_core_terminal_surface_repaint; then
+      echo "SURFACE_REPAINT_FLAKE_RECOVERED: passed on retry (attempt 2)"
+    else
+      echo "SURFACE_REPAINT_FAILED: #1203 proof failed twice"
+      SURFACE_REPAINT_STATUS="FAIL"
+    fi
+  fi
+fi
+
 SUITE_ELAPSED=$((SECONDS - SUITE_START))
 
 # The job is red iff at least one class failed BOTH attempts, OR the #803
@@ -2383,13 +2427,15 @@ SUITE_ELAPSED=$((SECONDS - SUITE_START))
 if [[ "${#FAILED_CLASSES[@]}" -eq 0 && "$STEP_TIMEOUT_HIT" -eq 0 \
       && "$APPEND_BURST_STATUS" == "PASS" && "$OUTPUT_BURST_IME_STATUS" == "PASS" \
       && "$MULTICHUNK_SEED_STATUS" == "PASS" && "$AGENT_LINK_AFFORDANCE_STATUS" == "PASS" \
-      && "$REATTACH_REPAINT_STATUS" == "PASS" && "$OVERLAY_UNBOUNDED_STATUS" == "PASS" ]]; then
+      && "$REATTACH_REPAINT_STATUS" == "PASS" && "$OVERLAY_UNBOUNDED_STATUS" == "PASS" \
+      && "$SURFACE_REPAINT_STATUS" == "PASS" ]]; then
   JOURNEY_EXIT=0
   journey_status="PASS"
 elif [[ "$STEP_TIMEOUT_HIT" -eq 1 && "${#FAILED_CLASSES[@]}" -eq 0 \
         && "$APPEND_BURST_STATUS" != "FAIL" && "$OUTPUT_BURST_IME_STATUS" != "FAIL" \
         && "$MULTICHUNK_SEED_STATUS" != "FAIL" && "$AGENT_LINK_AFFORDANCE_STATUS" != "FAIL" \
-        && "$REATTACH_REPAINT_STATUS" != "FAIL" && "$OVERLAY_UNBOUNDED_STATUS" != "FAIL" ]]; then
+        && "$REATTACH_REPAINT_STATUS" != "FAIL" && "$OVERLAY_UNBOUNDED_STATUS" != "FAIL" \
+        && "$SURFACE_REPAINT_STATUS" != "FAIL" ]]; then
   # Only the budget timeout fired (no class failed BOTH attempts on its own
   # merits): a pure #470-stall time-budget casualty.
   JOURNEY_EXIT=1
@@ -2438,6 +2484,9 @@ echo "=========================================================="
   echo
   echo "Core-terminal v0.4.17 overlay-unbounded-measure crash proof (\`shared:core-terminal\`): **$OVERLAY_UNBOUNDED_STATUS**"
   echo "- \`$CORE_TERMINAL_OVERLAY_UNBOUNDED_CLASS\`"
+  echo
+  echo "Core-terminal #1203 surface-only-black recovery proof (\`shared:core-terminal\`): **$SURFACE_REPAINT_STATUS**"
+  echo "- \`$CORE_TERMINAL_SURFACE_REPAINT_CLASS\`"
   if [[ "${#RECOVERED_CLASSES[@]}" -gt 0 ]]; then
     echo
     echo "Recovered on retry (CI-AVD flake — \`JOURNEY_FLAKE_RECOVERED\`):"

--- a/shared/core-terminal/src/androidTest/java/com/termux/view/TerminalViewForceSurfaceRepaintInstrumentedTest.kt
+++ b/shared/core-terminal/src/androidTest/java/com/termux/view/TerminalViewForceSurfaceRepaintInstrumentedTest.kt
@@ -1,0 +1,197 @@
+package com.termux.view
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.core.terminal.ui.PocketShellTerminalViewClient
+import com.pocketshell.core.terminal.ui.applyPocketShellDefaults
+import com.termux.terminal.TerminalEmulator
+import com.termux.terminal.TerminalOutput
+import com.termux.terminal.TerminalSession
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Issue #1203 — REAL-VIEW device-truth regression for the SURFACE-only-black recovery.
+ *
+ * ## The class this recovers (the #1192 sixth `black_frame_observed` class)
+ *
+ * `surface_black_model_intact`: the MODEL grid (the session/bridge emulator) still holds
+ * the frame — so tmux's model-vs-model heal oracle calls the pane HEALTHY and a model
+ * reseed (manual Redraw / stale-render heal) restores NOTHING — but the on-screen SURFACE
+ * is black. The concrete mechanism: the [TerminalView]'s own emulator binding
+ * ({@link TerminalView#mEmulator}) is `null` even though {@link TerminalView#mTermSession}
+ * still holds a live emulator, so every {@link TerminalView#onDraw} takes the BLACK
+ * fallback (`mEmulator == null` → `canvas.drawColor(black)`).
+ *
+ * ## Why forceFullRepaint (#721) cannot recover it — and forceSurfaceRepaint (#1203) can
+ *
+ * [TerminalView.forceFullRepaint] (what the model reseed's `appendRemoteOutput` fires)
+ * only resets the renderer's dirty cache and calls `invalidate()`. With `mEmulator == null`
+ * the next `onDraw` STILL takes the black fallback → the surface stays black. That is the
+ * maintainer's "Redraw doesn't work". [TerminalView.forceSurfaceRepaint] re-binds
+ * `mEmulator` from the live session BEFORE invalidating, so the next `onDraw` takes the
+ * CONTENT path and the surface recovers.
+ *
+ * ## Red → green (this test, on the REAL View + REAL onDraw)
+ *
+ *  - RED (base / the surface-black state): with `mEmulator == null`, the real `onDraw`
+ *    paints the black fallback and the [TerminalView.FramePaintObserver] reports
+ *    `paintedEmulatorContent = false` — the confirmed surface-black.
+ *  - `forceSurfaceRepaint()` re-binds the emulator from the session.
+ *  - GREEN: the next real `onDraw` paints the emulator content and the observer reports
+ *    `paintedEmulatorContent = true` — the surface recovered.
+ *
+ * If this test is run against a `forceSurfaceRepaint` that does NOT re-bind the emulator
+ * (i.e. behaves like `forceFullRepaint`), `mEmulator` stays null, the second `onDraw`
+ * paints black again, and the GREEN assertion fails — proving the re-bind is the
+ * load-bearing recovery, not merely another `invalidate()`.
+ *
+ * Runs on a REAL device (real font metrics + the real `TerminalRenderer.render`); built in
+ * `com.termux.view` to call the protected `onDraw` via `View.draw(Canvas)` and to touch the
+ * package-visible `mEmulator` / `mTermSession` fields.
+ */
+@RunWith(AndroidJUnit4::class)
+class TerminalViewForceSurfaceRepaintInstrumentedTest {
+
+    private object SinkOutput : TerminalOutput() {
+        override fun write(data: ByteArray?, offset: Int, count: Int) = Unit
+        override fun titleChanged(oldTitle: String?, newTitle: String?) = Unit
+        override fun onCopyTextToClipboard(text: String?) = Unit
+        override fun onPasteTextFromClipboard() = Unit
+        override fun onBell() = Unit
+        override fun onColorsChanged() = Unit
+    }
+
+    private val rows = 14
+    private val columns = 60
+
+    private fun newEmulator(): TerminalEmulator =
+        TerminalEmulator(SinkOutput, columns, rows, 13, 15, rows * 4, null)
+
+    private fun TerminalEmulator.feed(s: String) {
+        val b = s.toByteArray(Charsets.UTF_8)
+        append(b, b.size)
+    }
+
+    /** A bare session with a pre-installed emulator (no shell subprocess) via reflection. */
+    private fun sessionHolding(emulator: TerminalEmulator): TerminalSession {
+        val session = TerminalSession("/bin/sh", "/", arrayOf("sh"), arrayOf(), rows * 4, null)
+        val field = TerminalSession::class.java.getDeclaredField("mEmulator")
+        field.isAccessible = true
+        field.set(session, emulator)
+        return session
+    }
+
+    @Test
+    fun forceSurfaceRepaintRebindsEmulatorAndRecoversContentPaint() {
+        val instr = InstrumentationRegistry.getInstrumentation()
+        val context = instr.targetContext
+
+        lateinit var view: TerminalView
+        instr.runOnMainSync {
+            view = TerminalView(context, null)
+            view.applyPocketShellDefaults(PocketShellTerminalViewClient())
+        }
+        val renderer = view.mRenderer
+        assertTrue(
+            "real-device font metrics expected (fontLineSpacing > 0) so the content render path is active",
+            renderer.fontLineSpacing > 0,
+        )
+
+        // The MODEL is intact: a session whose emulator holds a full dense frame.
+        val emulator = newEmulator()
+        for (i in 0 until rows) emulator.feed("ISSUE1203 recovered row %02d filler abcdefghij\r\n".format(i))
+        val session = sessionHolding(emulator)
+
+        val widthPx = (columns * renderer.fontWidth).toInt().coerceAtLeast(1)
+        val heightPx = rows * renderer.fontLineSpacing + renderer.fontLineSpacingAndAscent
+
+        // The SURFACE-only-black state: the View has the session but LOST its emulator
+        // binding (mEmulator == null → the onDraw black fallback), while the session's
+        // emulator still holds the frame. This is the exact surface_black_model_intact
+        // class the model-vs-tmux oracle cannot see.
+        //
+        // ORDER MATTERS (reviewer #1203): the View must be laid out out at real size
+        // BEFORE we null mEmulator. `view.layout(...)` drives onSizeChanged → updateSize(),
+        // and updateSize() re-binds `mEmulator = mTermSession.getEmulator()` whenever
+        // `mEmulator == null` (TerminalView.java:1396-1398). If we nulled mEmulator BEFORE
+        // layout, that size pass would immediately re-bind it and the RED surface-black
+        // precondition would never actually be entered — a false green. So: lay out first
+        // (which binds the emulator from the live session), THEN drop the binding to enter
+        // the surface_black_model_intact state that the next onDraw must render black.
+        instr.runOnMainSync {
+            view.mTermSession = session
+            view.layout(0, 0, widthPx, heightPx)
+            view.mEmulator = null
+        }
+        // Hard guard: the surface-black precondition MUST actually hold before the RED
+        // onDraw, or the whole red→green is vacuous (G3). Fail loudly if a later size pass
+        // ever re-binds the emulator again.
+        instr.runOnMainSync {
+            assertNull(
+                "precondition: the View must be in the surface_black_model_intact state " +
+                    "(mEmulator == null) BEFORE the RED onDraw — otherwise the black-fallback " +
+                    "render never happens and the test passes vacuously",
+                view.mEmulator,
+            )
+        }
+
+        // Wire the REAL paint-confirmation observer exactly as TerminalSurface does.
+        val lastPaintedContent = AtomicBoolean(false)
+        val paintCount = AtomicInteger(0)
+        instr.runOnMainSync {
+            view.setFramePaintObserver { paintedContent, _ ->
+                lastPaintedContent.set(paintedContent)
+                paintCount.incrementAndGet()
+            }
+        }
+
+        val bitmap = Bitmap.createBitmap(widthPx, heightPx, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bitmap)
+
+        // RED — the real onDraw with mEmulator == null paints the BLACK fallback; the
+        // observer confirms the surface is black (paintedEmulatorContent = false).
+        instr.runOnMainSync { view.draw(canvas) }
+        instr.waitForIdleSync()
+        assertTrue("a frame must have painted", paintCount.get() >= 1)
+        assertFalse(
+            "RED: with mEmulator == null the real onDraw paints the BLACK fallback — the surface " +
+                "is confirmed black (paintedEmulatorContent = false), exactly what forceFullRepaint " +
+                "alone cannot recover",
+            lastPaintedContent.get(),
+        )
+        instr.runOnMainSync { assertNull("precondition: the View lost its emulator binding", view.mEmulator) }
+
+        // THE FIX — forceSurfaceRepaint re-binds the emulator from the live session.
+        instr.runOnMainSync { view.forceSurfaceRepaint() }
+        instr.runOnMainSync {
+            assertSame(
+                "#1203: forceSurfaceRepaint must re-bind mEmulator from the live session (the " +
+                    "load-bearing recovery — a plain forceFullRepaint would leave it null and the " +
+                    "surface black)",
+                emulator,
+                view.mEmulator,
+            )
+        }
+
+        // GREEN — the next real onDraw now takes the CONTENT path; the observer confirms the
+        // surface recovered (paintedEmulatorContent = true).
+        val countBeforeGreen = paintCount.get()
+        instr.runOnMainSync { view.draw(canvas) }
+        instr.waitForIdleSync()
+        assertTrue("a second frame must have painted", paintCount.get() > countBeforeGreen)
+        assertTrue(
+            "GREEN: after forceSurfaceRepaint re-bound the emulator, the real onDraw paints the " +
+                "emulator CONTENT (paintedEmulatorContent = true) — the surface-only-black recovered",
+            lastPaintedContent.get(),
+        )
+    }
+}

--- a/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurface.kt
+++ b/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurface.kt
@@ -372,6 +372,20 @@ fun TerminalSurface(
         }
     }
 
+    // Issue #1203: a SURFACE force-repaint signal (the model grid is intact but the
+    // on-screen surface is black — the #1192 sixth class the model-vs-tmux oracle
+    // cannot see) re-binds the View's emulator and forces a full-clip repaint of
+    // what the model already holds. Unlike fullRepaintRequests (which follows a
+    // MODEL reseed), this recovers the surface WITHOUT a capture-pane round-trip —
+    // the recovery the model reseed is architecturally incapable of providing.
+    LaunchedEffect(state, terminalView) {
+        val view = terminalView ?: return@LaunchedEffect
+        state.surfaceRepaintRequests.collect {
+            runCatching { view.forceSurfaceRepaint() }
+                .onFailure { onLocalTerminalError?.invoke(it) }
+        }
+    }
+
     // If the caller installed an onKeyEvent slot, chain it onto the
     // user-supplied modifier so the Compose focus system routes key events
     // through it before the embedded TerminalView gets a chance. We tack

--- a/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurfaceState.kt
+++ b/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurfaceState.kt
@@ -184,6 +184,57 @@ class TerminalSurfaceState(
     internal val fullRepaintRequests: SharedFlow<Unit> get() = _fullRepaintRequests.asSharedFlow()
 
     /**
+     * Issue #1203 — SURFACE force-repaint requests. Distinct from
+     * [fullRepaintRequests] (which the MODEL reseed [appendRemoteOutput] fires
+     * AFTER writing captured content into the buffer, to repaint the freshly
+     * seeded rows over a stale dirty cache): a signal here means "the MODEL grid
+     * is already intact, but the on-screen SURFACE is black — re-bind the View's
+     * emulator and force a full-clip repaint of what the model already holds".
+     *
+     * This is the recovery the sixth `black_frame_observed` class
+     * (`surface_black_model_intact`, #1192) needs and the model reseed cannot
+     * provide: the surface-only-black never diverges from tmux, so no `capture-pane`
+     * reseed touches it (spike #874 GAP-1). [TerminalSurface] collects this and
+     * calls [com.termux.view.TerminalView.forceSurfaceRepaint].
+     *
+     * `replay = 1` for the same late-subscribe reason as [fullRepaintRequests]
+     * (#879): a request fired during a re-create seed, before the fresh
+     * [TerminalSurface] binds its collector, must still reach the late subscriber.
+     */
+    private val _surfaceRepaintRequests = MutableSharedFlow<Unit>(
+        replay = 1,
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+    internal val surfaceRepaintRequests: SharedFlow<Unit> get() = _surfaceRepaintRequests.asSharedFlow()
+
+    @Volatile
+    private var surfaceRepaintRequestCount: Int = 0
+
+    /**
+     * Issue #1203 — request a SURFACE force-repaint of the bound [TerminalView]
+     * (re-bind emulator + full-clip invalidate) to recover a surface-only-black
+     * pane (model intact, surface black). Called by the tmux ViewModel from the
+     * manual Redraw escape hatch AND from the auto-heal when
+     * [surfaceIsBlackWhileModelHasContent] fingerprints the class the model-vs-tmux
+     * oracle is blind to. Idempotent-cheap: it rides the existing heal/redraw pass,
+     * adds no round-trip, and a couple of extra requests until the real `onDraw`
+     * repaints are harmless (the request is coalesced by the flow).
+     */
+    fun requestSurfaceRepaint() {
+        surfaceRepaintRequestCount += 1
+        _surfaceRepaintRequests.tryEmit(Unit)
+    }
+
+    /**
+     * Test-only (#1203): how many surface force-repaints have been requested. `public`
+     * (not `internal`) so the app-module tmux ViewModel tests — a different Gradle module
+     * — can assert the manual-Redraw / auto-heal recovery fired, mirroring the visibility
+     * of [recordSurfaceFramePaintedForTest].
+     */
+    public fun surfaceRepaintRequestCountForTest(): Int = surfaceRepaintRequestCount
+
+    /**
      * Callback fired when the embedded text-selection action mode's "Copy"
      * button is tapped. Issue #175 wires the [TerminalSurface] composable to
      * install a default sink that copies the selected text into the system

--- a/shared/core-terminal/src/main/java/com/termux/view/TerminalView.java
+++ b/shared/core-terminal/src/main/java/com/termux/view/TerminalView.java
@@ -193,6 +193,54 @@ public final class TerminalView extends View {
         invalidate();
     }
 
+    /**
+     * Issue #1203 — force a SURFACE-level repaint that recovers a
+     * surface-only-black: the on-screen surface is black while the MODEL grid
+     * (the session/bridge emulator) still holds the frame. This is the sixth
+     * {@code black_frame_observed} class (#1192, {@code surface_black_model_intact}),
+     * the ONE the model-vs-tmux heal oracle cannot see — the model never diverges
+     * from tmux, so a model reseed (the manual Redraw / stale-render heal) restores
+     * NOTHING and the surface stays black.
+     *
+     * <p>{@link #forceFullRepaint()} (#721) CANNOT recover this class either: it
+     * only resets the renderer's dirty cache and issues {@code invalidate()}. When
+     * the surface is black because {@link #mEmulator} is {@code null} (the
+     * {@link #onDraw} BLACK fallback), a plain {@code invalidate()} just re-runs
+     * {@code onDraw}, finds {@code mEmulator == null} again, and paints the black
+     * fallback AGAIN. The View lost its emulator binding even though the session
+     * still holds a live emulator with the full grid — no amount of model reseeding
+     * repaints the surface.
+     *
+     * <p>This re-binds {@link #mEmulator} from the live {@link #mTermSession} (so the
+     * next {@code onDraw} takes the CONTENT path instead of {@code drawColor(black)}),
+     * then resets the renderer's dirty cache and forces a full-clip repaint of the
+     * whole surface straight from the buffer — covering both the {@code mEmulator ==
+     * null} case AND the case where the surface holds a stale black hardware buffer
+     * whose #469 dirty cache still thinks every row is painted.
+     */
+    public void forceSurfaceRepaint() {
+        // Re-bind the emulator the View paints from. When the View lost it
+        // (mEmulator == null → the onDraw BLACK fallback) but the session still
+        // holds a live emulator, re-fetch it so the next onDraw takes the content
+        // path instead of drawColor(black) — the surface_black_model_intact fix.
+        if (mEmulator == null && mTermSession != null) {
+            TerminalEmulator sessionEmulator = mTermSession.getEmulator();
+            if (sessionEmulator != null) {
+                mEmulator = sessionEmulator;
+                if (mTerminalCursorBlinkerRunnable != null) {
+                    mTerminalCursorBlinkerRunnable.setEmulator(mEmulator);
+                }
+            }
+        }
+        // Reset the renderer's dirty cache (a stale surface may hold a black
+        // hardware buffer whose cache still thinks every row is painted) and force
+        // a full-clip repaint straight from the buffer.
+        if (mRenderer != null) {
+            mRenderer.invalidateDirtyCache();
+        }
+        invalidate();
+    }
+
     float mScaleFactor = 1.f;
     final GestureAndScaleRecognizer mGestureRecognizer;
 


### PR DESCRIPTION
Closes #1203. Part of the black-screen audit umbrella #1208 (render/surface class B).

Root cause: `TerminalView.mEmulator` is null while the session holds a live emulator → `onDraw` paints the black fallback; Redraw's model reseed + bare `invalidate()` re-runs into the same null ("Redraw doesn't work"). Fix: `forceSurfaceRepaint()` re-binds `mEmulator` from the live session then full-clip invalidates, wired into manual Redraw + the auto-heal at `surfaceIsBlackWhileModelHasContent()`.

Verification: reviewer reproduced red→green on-device (emulator-5554; neutering the re-bind fails the load-bearing `assertSame`, restoring passes) + JVM `SurfaceBlackModelIntactDiagnosticTest` 11/11. Orchestrator gate: compile core-terminal + app, surface tests green.