### PR TITLE
portfwd: one notification whose Stop actually stops forwarding (#1202, #1198)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/portfwd/ForwardingNotificationE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/portfwd/ForwardingNotificationE2eTest.kt
@@ -3,12 +3,27 @@ package com.pocketshell.app.portfwd
 import android.app.NotificationManager
 import android.content.Context
 import android.content.pm.PackageManager
+import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.BackgroundGraceTestOverride
+import com.pocketshell.app.MainActivity
+import com.pocketshell.app.proof.PreGrantPermissionsRule
 import com.pocketshell.app.proof.TerminalTestTimeouts
+import com.pocketshell.app.sessions.ActiveTmuxClients
 import com.pocketshell.app.testaccess.TestAccessEntryPoint
+import com.pocketshell.core.tmux.CommandResponse
+import com.pocketshell.core.tmux.TmuxClient
+import com.pocketshell.core.tmux.TmuxDisconnectEvent
+import com.pocketshell.core.tmux.TmuxOutputBacklogOverflow
+import com.pocketshell.core.tmux.protocol.ControlEvent
 import dagger.hilt.android.EntryPointAccessors
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.emptyFlow
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -17,6 +32,7 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Assume
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.io.BufferedReader
@@ -38,16 +54,43 @@ import java.io.InputStreamReader
  * flow) and proves the ongoing notification actually lands in the status bar on
  * a default-importance channel.
  *
+ * ## Issue #1202 — one forward notification whose Stop actually stops (this file)
+ *
+ * The maintainer reported on-device (v0.4.23): while a session is pinned for a
+ * port-forward, TWO tray notifications stack — "Port forwarding running"
+ * (ForwardingService) and "Port forwarding active" (SessionConnectionService) —
+ * and tapping **Stop** on the "active" one only ended the session hold, leaving
+ * the tunnels running (a no-op for forwarding). The fix (#1202/#1198, hard-cut
+ * D22) SUPPRESSES the session FGS while a port-forward is active so
+ * ForwardingService is the SOLE owner of the notification, and its Stop tears
+ * down the tunnels. [sessionPinnedForForward_hasExactlyOneForwardNotification_andStopTearsDownTunnels]
+ * is the on-device durable regression for that: it reproduces the maintainer's
+ * exact reported state (a live session + an active hetzner forward, backgrounded)
+ * on the REAL path (App.kt mirrors the active-host count into
+ * `SessionServiceController.setPortForwardActive`, exactly as production), then
+ * HARD-asserts the real notification tray — exactly ONE app foreground
+ * notification for the forward (NOT the old running+active pair) — and fires the
+ * Stop action's `PendingIntent`, asserting the forward is actually torn down
+ * (active host count → 0) and the notification is gone. It runs on CI (no
+ * screenshot, no Docker) so the double-notification / no-op-Stop class cannot
+ * silently regress.
+ *
  * Determinism mirrors `UpdateAvailableNotificationE2eTest` (#502): grant
  * propagation and `notify()`/`startForeground()` → `activeNotifications` are
- * both async, so we poll both. On CI the connected status-bar assertion is
- * skipped (`Assume.assumeFalse(isRunningOnCi())`) because the swiftshader
- * emulator is unstable under parallel connected-test load; the post path's
- * logic is covered authoritatively by the JVM unit tests
- * (`ForwardingControllerTest`, `SessionForwardingIndicatorViewModelTest`).
+ * both async, so we poll both. The status-bar SCREENSHOT capture in
+ * [ongoingNotification_appearsWhileForwarding_andClearsWhenStopped] is skipped on
+ * CI (`Assume.assumeFalse(isRunningOnCi())`) because the swiftshader emulator is
+ * unstable under parallel connected-test load for `screencap`; the
+ * `activeNotifications` post path is covered authoritatively by the JVM unit
+ * tests (`ForwardingControllerTest`, `SessionForwardingIndicatorViewModelTest`)
+ * AND — for the #1202 tray-count + Stop behaviour — by the on-CI regression below,
+ * which does NOT self-skip.
  */
 @RunWith(AndroidJUnit4::class)
 class ForwardingNotificationE2eTest {
+
+    @get:Rule
+    val permissions = PreGrantPermissionsRule()
 
     private val instrumentation = InstrumentationRegistry.getInstrumentation()
     private val context: Context = ApplicationProvider.getApplicationContext()
@@ -60,17 +103,19 @@ class ForwardingNotificationE2eTest {
             .fromApplication(context.applicationContext, TestAccessEntryPoint::class.java)
             .forwardingController()
 
+    private fun entryPoint(): TestAccessEntryPoint =
+        EntryPointAccessors
+            .fromApplication(context.applicationContext, TestAccessEntryPoint::class.java)
+
     private var registeredHostId: Long? = null
+
+    // Issue #1202 harness state.
+    private var scenario: ActivityScenario<MainActivity>? = null
+    private var sessionClientRegistration: ActiveTmuxClients.Registration? = null
+    private var sessionLifecycleRegistration: ActiveTmuxClients.LifecycleRegistration? = null
 
     @Before
     fun grantNotificationPermission() {
-        Assume.assumeFalse(
-            "Skipping the on-device status-bar assertion on CI; the post path " +
-                "is covered by the JVM unit tests and the swiftshader emulator " +
-                "is too unstable under load for this status-bar capture.",
-            TerminalTestTimeouts.isRunningOnCi(),
-        )
-
         // Clear any stale registration / notification so a leftover can't
         // satisfy the assertion.
         controller().activeHostIdsSnapshot().forEach { controller().unregisterActiveHost(it) }
@@ -106,13 +151,36 @@ class ForwardingNotificationE2eTest {
 
     @After
     fun cleanup() {
+        BackgroundGraceTestOverride.setForTest(null)
+        runCatching { scenario?.moveToState(androidx.lifecycle.Lifecycle.State.RESUMED) }
+        scenario?.close()
+        scenario = null
+        val registry = entryPoint().activeTmuxClients()
+        sessionClientRegistration?.let { runCatching { registry.unregister(it) } }
+        sessionLifecycleRegistration?.let { runCatching { registry.unregisterLifecycleHooks(it) } }
+        sessionClientRegistration = null
+        sessionLifecycleRegistration = null
         registeredHostId?.let { runCatching { controller().unregisterActiveHost(it) } }
         registeredHostId = null
+        // Also sweep any forward the #1202 test left active (Stop should have
+        // cleared it, but a failed run must not leak an active host).
+        controller().activeHostIdsSnapshot().forEach { runCatching { controller().unregisterActiveHost(it) } }
         notificationManager.cancelAll()
     }
 
     @Test
     fun ongoingNotification_appearsWhileForwarding_andClearsWhenStopped() {
+        // The status-bar SCREENSHOT capture (screencap) is unstable on the CI
+        // swiftshader AVD under parallel connected-test load. The tray post path
+        // is covered on CI by the #1202 regression below (no screenshot); this
+        // screenshot proof stays a dev-box artifact only.
+        Assume.assumeFalse(
+            "Skipping the on-device status-bar SCREENSHOT capture on CI; the " +
+                "swiftshader emulator is too unstable under load for screencap. The " +
+                "tray post path is covered on CI by the #1202 regression below.",
+            TerminalTestTimeouts.isRunningOnCi(),
+        )
+
         // 1. No forwards → no port-forward notification.
         assertNull(
             "no forwarding notification should exist before a forward starts",
@@ -287,12 +355,209 @@ class ForwardingNotificationE2eTest {
         )
     }
 
+    /**
+     * Issue #1202 (on-device durable regression, G1/G10) — the maintainer's exact
+     * reported state, on the REAL path, asserting the REAL notification tray.
+     *
+     * Reproduces "a session pinned for a hetzner forward": a live tmux session is
+     * held AND an active port-forward is running, then the app is backgrounded.
+     * The active-host count is mirrored into
+     * `SessionServiceController.setPortForwardActive(true)` by the production
+     * `App.kt` collector (NOT called by the test) — the same wiring the device
+     * uses. So this exercises the true pin path.
+     *
+     * BASE (revert the two production hunks in `SessionConnectionService.kt` +
+     * `SessionServiceController.kt`): backgrounding a pinned session runs the
+     * session FGS in parallel with the ForwardingService, posting a SECOND tray
+     * notification ("Port forwarding active"), and its Stop only ends the session
+     * hold — a no-op for the tunnels. → the tray-count assertion below FAILS RED
+     * (two app FGS notifications, the session-channel one present).
+     *
+     * FIX: while pinned the session FGS is SUPPRESSED, so ForwardingService is the
+     * sole owner of exactly ONE notification, and firing its Stop action tears
+     * down the tunnels (`stopAllForwarding`) → active host count 0 + notification
+     * gone. → GREEN.
+     *
+     * Load-bearing assertions (must run — no `assumeFalse(isRunningOnCi())`):
+     *   - AC1: exactly ONE app foreground notification for the forward while
+     *     pinned (the session-channel "Port forwarding active" second notification
+     *     is ABSENT).
+     *   - AC2: tapping Stop tears the forward down (active host count → 0) AND the
+     *     forwarding notification clears; the forward is NOT re-established.
+     *
+     * No Docker fixture / SSH / port — in-process `ActiveTmuxClients` +
+     * `ForwardingController` doubles — so it needs no `tests.yml` service change.
+     */
+    @Test
+    fun sessionPinnedForForward_hasExactlyOneForwardNotification_andStopTearsDownTunnels() {
+        // Runs on the per-push emulator-journey job (api-level 34) as well as the
+        // dev-box API-35 AVD — the FGS notification/Stop behaviour is identical on
+        // both (SPECIAL_USE FGS is API 34+), so no SDK-level gate here.
+        notificationManager.cancelAll()
+
+        // A long grace so the backgrounded session hold (on the BASE path) stays
+        // up long enough to observe the second notification, and the return to the
+        // foreground in @After is comfortably within grace (no teardown surprises).
+        BackgroundGraceTestOverride.setForTest(LONG_GRACE_MS)
+        scenario = ActivityScenario.launch(MainActivity::class.java)
+
+        val registry = entryPoint().activeTmuxClients()
+
+        // 1. A live tmux session is held (the App wires observeActiveSessions() in
+        // Application.onCreate, so this drives the same start/stop signal as a real
+        // attached session).
+        sessionLifecycleRegistration = registry.registerLifecycleHooks(
+            hostId = SESSION_HOST_ID,
+            hooks = ActiveTmuxClients.LifecycleHooks(onBackground = {}, onForeground = {}),
+        )
+        val sessionClient = ConnectedTmuxClient()
+        sessionClientRegistration = registry.register(
+            hostId = SESSION_HOST_ID,
+            hostName = "hetzner",
+            hostname = "hetzner.example",
+            port = 22,
+            username = "alexey",
+            keyPath = "/tmp/key",
+            client = sessionClient,
+        )
+
+        // 2. An active port-forward on the SAME host style (hetzner) with two
+        // tunnels → ForwardingService posts "Port forwarding running" AND App.kt's
+        // production collector calls setPortForwardActive(true) — the real pin.
+        registeredHostId = FORWARD_HOST_ID
+        controller().registerActiveHost(hostId = FORWARD_HOST_ID, hostName = "hetzner")
+        controller().updateTunnelCount(FORWARD_HOST_ID, 2)
+        val forwarding = waitForForwardingNotification()
+        assertNotNull(
+            "the ForwardingService 'Port forwarding running' notification must post " +
+                "when a forward goes active; active titles=" + activeTitles(),
+            forwarding,
+        )
+
+        // 3. Background the process (ProcessLifecycleOwner ON_STOP) → the session
+        // FGS is re-evaluated. On BASE it posts the SECOND "Port forwarding active"
+        // notification (the reported double). On the FIX it is suppressed while
+        // pinned.
+        scenario!!.moveToState(androidx.lifecycle.Lifecycle.State.CREATED)
+
+        // AC1 (LOAD-BEARING): across a settle window the forwarding notification is
+        // present AND no SECOND app FGS (session-channel) notification ever appears
+        // — exactly ONE app foreground notification for the forward. On BASE the
+        // session FGS posts "Port forwarding active" on the session channel within
+        // ~1-2s of backgrounding, so this fails RED.
+        val settleDeadline = System.currentTimeMillis() + PINNED_SETTLE_MS
+        while (System.currentTimeMillis() < settleDeadline) {
+            assertNull(
+                "while a session is pinned for a forward the session FGS must be " +
+                    "SUPPRESSED — only ForwardingService's notification may show. A " +
+                    "session-channel notification here is the #1202 second (stacked) " +
+                    "notification whose Stop is a no-op. active titles=" + activeTitles(),
+                sessionChannelNotification(),
+            )
+            assertNotNull(
+                "the ForwardingService notification must stay present while pinned; " +
+                    "active titles=" + activeTitles(),
+                forwardingNotification(),
+            )
+            Thread.sleep(POLL_INTERVAL_MS)
+        }
+        assertEquals(
+            "exactly ONE PocketShell foreground notification must exist for the forward " +
+                "while pinned (the #1198 dedup) — NOT the old running+active pair. " +
+                "active titles=" + activeTitles(),
+            1,
+            appForegroundNotificationCount(),
+        )
+
+        // 4. AC2: tap the Stop action on the (single) forwarding notification and
+        // assert the forward is ACTUALLY torn down.
+        val stopAction = requireNotNull(
+            forwardingNotification()!!.notification.actions?.firstOrNull {
+                it.title?.toString() == "Stop"
+            },
+        ) { "the forwarding notification must carry a 'Stop' action" }
+        assertTrue(
+            "before Stop, the forward host must be active",
+            controller().activeHostIdsSnapshot().contains(FORWARD_HOST_ID),
+        )
+        stopAction.actionIntent.send()
+
+        // Tunnels torn down: active host count → 0 (stopAllForwarding).
+        val stopDeadline = System.currentTimeMillis() + STOP_TEARDOWN_TIMEOUT_MS
+        while (
+            controller().activeHostIdsSnapshot().isNotEmpty() &&
+            System.currentTimeMillis() < stopDeadline
+        ) {
+            Thread.sleep(POLL_INTERVAL_MS)
+        }
+        assertTrue(
+            "tapping Stop must tear down the forward (stopAllForwarding) — active hosts " +
+                "must be empty, not " + controller().activeHostIdsSnapshot(),
+            controller().activeHostIdsSnapshot().isEmpty(),
+        )
+        registeredHostId = null
+
+        // The forwarding notification clears.
+        val clearDeadline = System.currentTimeMillis() + STOP_TEARDOWN_TIMEOUT_MS
+        while (forwardingNotification() != null && System.currentTimeMillis() < clearDeadline) {
+            Thread.sleep(POLL_INTERVAL_MS)
+        }
+        assertNull(
+            "the forwarding notification must clear after Stop tears down the tunnels; " +
+                "active titles=" + activeTitles(),
+            forwardingNotification(),
+        )
+
+        // The forward is NOT re-established (stays down over a settle window).
+        val stableDeadline = System.currentTimeMillis() + REESTABLISH_SETTLE_MS
+        while (System.currentTimeMillis() < stableDeadline) {
+            assertTrue(
+                "the forward must NOT re-establish after Stop; active hosts=" +
+                    controller().activeHostIdsSnapshot(),
+                controller().activeHostIdsSnapshot().isEmpty(),
+            )
+            Thread.sleep(POLL_INTERVAL_MS)
+        }
+    }
+
     private fun forwardingNotification() =
         notificationManager.activeNotifications.firstOrNull {
             it.notification.extras
                 .getCharSequence("android.title")
                 ?.toString()
                 ?.contains("Port forwarding running") == true
+        }
+
+    /**
+     * The SECOND (stacked) notification from the session FGS. Identified by the
+     * session channel id — robust to its title, which was "Port forwarding active"
+     * on base (#1159 Part 3) and would be "Session connected" for a plain hold.
+     */
+    private fun sessionChannelNotification() =
+        notificationManager.activeNotifications.firstOrNull {
+            it.notification.channelId == SESSION_CHANNEL_ID
+        }
+
+    /** Count of THIS app's foreground-service notifications (both FGS channels). */
+    private fun appForegroundNotificationCount(): Int =
+        notificationManager.activeNotifications.count {
+            it.notification.channelId == FORWARDING_CHANNEL_ID ||
+                it.notification.channelId == SESSION_CHANNEL_ID
+        }
+
+    private fun waitForForwardingNotification(): android.service.notification.StatusBarNotification? {
+        val deadline = System.currentTimeMillis() + POST_APPEARS_TIMEOUT_MS
+        var posted = forwardingNotification()
+        while (posted == null && System.currentTimeMillis() < deadline) {
+            Thread.sleep(POLL_INTERVAL_MS)
+            posted = forwardingNotification()
+        }
+        return posted
+    }
+
+    private fun activeTitles(): List<CharSequence?> =
+        notificationManager.activeNotifications.map {
+            it.notification.extras.getCharSequence("android.title")
         }
 
     // True once the notification reflects the controller's settled host +
@@ -357,9 +622,56 @@ class ForwardingNotificationE2eTest {
         }.also { pfd.close() }
     }
 
+    /** In-process live [TmuxClient] double so the session FGS drives exactly as a
+     * live attached session (mirrors SessionConnectionServiceE2eTest). */
+    private class ConnectedTmuxClient : TmuxClient {
+        private val disconnectedState = MutableStateFlow(false)
+        private val disconnectEventState = MutableStateFlow<TmuxDisconnectEvent?>(null)
+
+        override val events: Flow<ControlEvent> = emptyFlow()
+        override val disconnected: StateFlow<Boolean> = disconnectedState.asStateFlow()
+        override val disconnectEvent: StateFlow<TmuxDisconnectEvent?> = disconnectEventState.asStateFlow()
+        override val outputBacklogOverflows: Flow<TmuxOutputBacklogOverflow> = emptyFlow()
+
+        override suspend fun connect() = Unit
+
+        override suspend fun sendCommand(cmd: String): CommandResponse =
+            CommandResponse(number = 0L, output = emptyList(), isError = false)
+
+        override fun outputFor(paneId: String): Flow<ControlEvent.Output> = emptyFlow()
+
+        override fun close() {
+            disconnectedState.value = true
+        }
+
+        override suspend fun setWindowSizeLatest(sessionId: String): CommandResponse =
+            CommandResponse(number = 0L, output = emptyList(), isError = false)
+
+        override suspend fun refreshClientSize(cols: Int, rows: Int): CommandResponse =
+            CommandResponse(number = 0L, output = emptyList(), isError = false)
+
+        override suspend fun detachCleanly(timeoutMs: Long) {
+            disconnectedState.value = true
+        }
+    }
+
     private companion object {
         const val POLL_INTERVAL_MS: Long = 100L
         const val GRANT_PROPAGATION_TIMEOUT_MS: Long = 5_000L
         const val POST_APPEARS_TIMEOUT_MS: Long = 10_000L
+
+        // Issue #1202 harness.
+        const val SESSION_HOST_ID: Long = 1_202_001L
+        const val FORWARD_HOST_ID: Long = 1_202_777L
+        const val SESSION_CHANNEL_ID: String = "pocketshell_session_status_v1"
+        const val FORWARDING_CHANNEL_ID: String = "pocketshell_forwarding_status_v6"
+        // Long enough that a backgrounded session hold stays up (base path) and a
+        // foreground return in @After is comfortably within grace.
+        const val LONG_GRACE_MS: Long = 120_000L
+        // Window over which the session FGS must stay absent while pinned. The base
+        // session FGS posts within ~1-2s of backgrounding, so this reliably catches it.
+        const val PINNED_SETTLE_MS: Long = 6_000L
+        const val STOP_TEARDOWN_TIMEOUT_MS: Long = 10_000L
+        const val REESTABLISH_SETTLE_MS: Long = 2_000L
     }
 }

--- a/app/src/main/java/com/pocketshell/app/sessions/service/SessionConnectionService.kt
+++ b/app/src/main/java/com/pocketshell/app/sessions/service/SessionConnectionService.kt
@@ -225,21 +225,23 @@ class SessionConnectionService : Service() {
         // notification ONCE and never schedules a per-second update / wakeup. A
         // contentTextOverride (the initial "Connecting session") never counts down.
         //
-        // Issue #1159 (Part 3): a port-forward pins the connection always-on — there is no
-        // teardown to count down to, so the snapshot carries a null deadline and the
-        // notification is worded for the forward ("Port forwarding active") instead.
+        // Issue #1202 + #1198 (hard-cut, D22): this session FGS is SUPPRESSED while a
+        // port-forward is active (see [SessionServiceController.setPortForwardActive]) — the
+        // ForwardingService FGS is the single owner of the port-forward notification. So this
+        // notification NEVER renders the port-forward wording anymore; the #1159 Part 3
+        // "Port forwarding active" branch is deleted. This FGS only ever shows the plain
+        // "Session connected" hold with its bounded-grace count-down.
         val countdownDeadline =
-            if (contentTextOverride == null && !snapshot.portForwardActive) {
+            if (contentTextOverride == null) {
                 snapshot.disconnectAtWallClockMillis
             } else {
                 null
             }
 
-        val title = if (snapshot.portForwardActive) "Port forwarding active" else "Session connected"
+        val title = "Session connected"
 
         val detail = contentTextOverride
             ?: when {
-                snapshot.portForwardActive -> "Keeping $hostLabel connected for port forwarding"
                 countdownDeadline != null -> "Holding $hostLabel — disconnecting in"
                 else -> "Keeping $hostLabel connected in the background"
             }

--- a/app/src/main/java/com/pocketshell/app/sessions/service/SessionServiceController.kt
+++ b/app/src/main/java/com/pocketshell/app/sessions/service/SessionServiceController.kt
@@ -41,10 +41,13 @@ import kotlinx.coroutines.launch
  *    [onAppForegrounded]/[onAppBackgrounded]; the service only starts on background and
  *    stops on foreground. Starting/stopping the service never touches the connection itself
  *    (the service owns only Android process-survival mechanics).
- *  - **Part 3**: while a port-forward is active ([setPortForwardActive]) the notification
- *    reads "Port forwarding active" and shows NO count-down — the connection is pinned
- *    always-on (the App-level grace teardown is suppressed), so there is no disconnect
- *    deadline to count down to.
+ *  - **Part 3 / issues #1202 + #1198 (hard-cut, D22)**: while a port-forward is active
+ *    ([setPortForwardActive]) the session FGS is SUPPRESSED. The
+ *    [com.pocketshell.app.portfwd.service.ForwardingService] FGS is the SINGLE owner of the
+ *    port-forward notification (its Stop actually tears down the tunnels); running the session
+ *    FGS in parallel posted a second notification whose Stop only ended the session hold and
+ *    left the tunnels running (the #1202 bug). The ForwardingService FGS already keeps the
+ *    process — and the pinned connection — alive, so nothing is lost by not holding here.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 @Singleton
@@ -115,17 +118,26 @@ class SessionServiceController @Inject constructor(
                     // Issue #1159 (Part 1): hold the FGS ONLY while backgrounded. In the
                     // foreground the Activity holds the connection — no service, no tray
                     // notification (and no Stop-action footgun).
-                    val shouldHold = rawSnapshot.isHoldingConnection && !foreground
+                    //
+                    // Issue #1202 + #1198 (hard-cut, D22): while a port-forward is active the
+                    // ForwardingService FGS is the SINGLE owner of the port-forward
+                    // notification — its Stop actually tears down the tunnels
+                    // ([com.pocketshell.app.portfwd.ForwardingController.stopAllForwarding]).
+                    // The session FGS must NOT run in parallel: it would post a SECOND
+                    // notification (the #1198 double-notification) whose Stop only ended the
+                    // session hold and left the tunnels running (the #1202 reported bug). The
+                    // ForwardingService FGS already keeps the process (and the pinned
+                    // connection) alive, so suppressing the session hold here loses nothing
+                    // while collapsing to exactly one notification with a working Stop.
+                    val shouldHold = rawSnapshot.isHoldingConnection && !foreground && !pfActive
                     val snapshot = if (holdStoppedByUser || !shouldHold) {
                         SessionConnectionSnapshot.Empty
                     } else {
-                        rawSnapshot.copy(
-                            portForwardActive = pfActive,
-                            // Part 3: a port-forward pins the connection always-on (no
-                            // teardown) → no count-down deadline. Otherwise the bounded
-                            // grace count-down.
-                            disconnectAtWallClockMillis = if (pfActive) null else deadline,
-                        )
+                        // pfActive is guaranteed false here (it gates shouldHold above), so the
+                        // held session notification always shows the normal bounded-grace
+                        // count-down — never the port-forward wording (that is now owned solely
+                        // by ForwardingService).
+                        rawSnapshot.copy(disconnectAtWallClockMillis = deadline)
                     }
                     val wasHolding = _snapshot.value.isHoldingConnection
                     _snapshot.value = snapshot
@@ -160,10 +172,15 @@ class SessionServiceController @Inject constructor(
     }
 
     /**
-     * Issue #1159 (Part 3): mark whether a port-forward is currently active. When true the
-     * notification reads "Port forwarding active" with no count-down (the connection is
-     * pinned always-on); when it drops back to false the normal bounded-grace count-down
-     * applies again on the next background.
+     * Mark whether a port-forward is currently active.
+     *
+     * Issue #1202 + #1198 (hard-cut, D22): while a port-forward is active the session FGS is
+     * SUPPRESSED — the [com.pocketshell.app.portfwd.service.ForwardingService] FGS is the
+     * SINGLE owner of the port-forward notification, and its Stop actually tears down the
+     * tunnels. Running the session FGS in parallel posted a second "Port forwarding active"
+     * notification whose Stop only ended the session hold and left the tunnels running (the
+     * reported bug). When the last forward drops back to false the normal bounded-grace
+     * count-down hold applies again while still backgrounded.
      */
     fun setPortForwardActive(active: Boolean) {
         portForwardActive.value = active

--- a/app/src/test/java/com/pocketshell/app/portfwd/ForwardingControllerTest.kt
+++ b/app/src/test/java/com/pocketshell/app/portfwd/ForwardingControllerTest.kt
@@ -114,6 +114,41 @@ class ForwardingControllerTest {
     }
 
     @Test
+    fun `ForwardingService Stop action tears down every tunnel via stopAllForwarding`() {
+        // Issue #1202: the single-owner ForwardingService notification's Stop must ACTUALLY
+        // stop forwarding. Deliver its ACTION_STOP and confirm the controller tears down EVERY
+        // active host (stopAllForwarding), not merely hides a notification. This is the working
+        // Stop the reported bug lacked — the session FGS's "Port forwarding active" Stop only
+        // ended the session hold and left the tunnels running.
+        val controller = ForwardingController(context)
+        controller.registerActiveHost(hostId = 1, hostName = "hetzner")
+        controller.registerActiveHost(hostId = 2, hostName = "beta")
+        assertEquals(2, controller.flowOfActiveHostCount().value)
+        drainStartedServices()
+
+        // buildService(...).get() returns the service WITHOUT running onCreate (no Hilt); we
+        // wire the controller manually, and confine the (unused here) observe dispatcher to a
+        // test scheduler so nothing leaks past the test (issue #994).
+        val service = Robolectric.buildService(ForwardingService::class.java).get()
+        service.controller = controller
+        service.observeDispatcher = StandardTestDispatcher(TestCoroutineScheduler())
+        service.onStartCommand(
+            Intent(context, ForwardingService::class.java).setAction(ForwardingService.ACTION_STOP),
+            0,
+            0,
+        )
+
+        assertEquals(
+            "ForwardingService Stop must tear down every active host (stopAllForwarding), " +
+                "not just hide the notification (#1202)",
+            0,
+            controller.flowOfActiveHostCount().value,
+        )
+        assertEquals(0, controller.flowOfTotalTunnelCount().value)
+        service.onDestroy()
+    }
+
+    @Test
     fun `unregisterActiveHost keeps service running while other hosts remain`() {
         val controller = ForwardingController(context)
 

--- a/app/src/test/java/com/pocketshell/app/sessions/service/SessionConnectionServiceTest.kt
+++ b/app/src/test/java/com/pocketshell/app/sessions/service/SessionConnectionServiceTest.kt
@@ -83,54 +83,31 @@ class SessionConnectionServiceTest {
     }
 
     @Test
-    fun `port-forward active notification reads Port forwarding active with no count-down`() {
-        // Issue #1159 (Part 3): a port-forward pins the connection always-on — the snapshot
-        // carries portForwardActive=true and a null deadline, and the notification is worded
-        // for the forward with NO count-down chronometer (there is no teardown to count to).
+    fun `port-forward wording is never shown by the session FGS (single owner is ForwardingService)`() {
+        // Issue #1202 + #1198 (hard-cut, D22): the session FGS is SUPPRESSED while a
+        // port-forward is active — the ForwardingService FGS is the single owner of the
+        // port-forward notification, so this notification NEVER shows the port-forward wording.
+        // Even if a stale portForwardActive flag leaked into the snapshot, the title stays the
+        // plain "Session connected" hold (the #1159 Part 3 "Port forwarding active" branch is
+        // deleted). A live count-down still renders from the deadline.
+        val deadline = System.currentTimeMillis() + 90_000L
         val notification = buildServiceNotification(
             SessionConnectionSnapshot(
                 liveSessionCount = 1,
                 primaryHostName = "alpha",
-                disconnectAtWallClockMillis = null,
+                disconnectAtWallClockMillis = deadline,
                 portForwardActive = true,
             ),
         )
 
         assertEquals(
-            "Port forwarding active",
+            "Session connected",
             notification.extras.getCharSequence("android.title")?.toString(),
         )
-        val body = notification.extras.getCharSequence("android.text")?.toString().orEmpty()
         assertTrue(
-            "body must be worded for the forward, not a count-down: '$body'",
-            body.contains("port forwarding"),
-        )
-        assertFalse(
-            "a port-forward-pinned hold must NOT show a count-down chronometer",
+            "with a deadline the held session notification still counts down (the forward " +
+                "wording is owned by ForwardingService, not this FGS)",
             notification.extras.getBoolean(Notification.EXTRA_SHOW_CHRONOMETER),
-        )
-    }
-
-    @Test
-    fun `port-forward active suppresses the count-down even when a deadline is present`() {
-        // Defensive: even if a stale deadline leaks into the snapshot, port-forward-active
-        // must win and suppress the chronometer (the connection is pinned, not counting down).
-        val notification = buildServiceNotification(
-            SessionConnectionSnapshot(
-                liveSessionCount = 1,
-                primaryHostName = "alpha",
-                disconnectAtWallClockMillis = System.currentTimeMillis() + 90_000L,
-                portForwardActive = true,
-            ),
-        )
-
-        assertFalse(
-            "port-forward-active must suppress the count-down chronometer",
-            notification.extras.getBoolean(Notification.EXTRA_SHOW_CHRONOMETER),
-        )
-        assertEquals(
-            "Port forwarding active",
-            notification.extras.getCharSequence("android.title")?.toString(),
         )
     }
 

--- a/app/src/test/java/com/pocketshell/app/sessions/service/SessionServiceControllerTest.kt
+++ b/app/src/test/java/com/pocketshell/app/sessions/service/SessionServiceControllerTest.kt
@@ -110,46 +110,101 @@ class SessionServiceControllerTest {
     }
 
     @Test
-    fun `port-forward active flags the snapshot with no count-down`() = runTest {
+    fun `port-forward active stops the session FGS so ForwardingService owns the single notification`() = runTest {
+        // Issue #1202 + #1198 (reported on-device, v0.4.23): a hetzner session is held in the
+        // background — the session FGS is up and its notification (reworded "Port forwarding
+        // active", #1159) is on screen. A port-forward then goes active on the SAME host, so
+        // the ForwardingService FGS posts its OWN "Port forwarding running" notification too:
+        // TWO stacked notifications. Worse, the maintainer taps Stop on the session's "Port
+        // forwarding active" notification (the one deliberately worded to represent the
+        // forward) and it only ends the session hold — the tunnels keep running.
+        //
+        // The fix collapses to ONE notification whose Stop actually stops forwarding: the
+        // ForwardingService FGS is the SINGLE owner (its Stop calls
+        // ForwardingController.stopAllForwarding), and the session FGS is SUPPRESSED while a
+        // port-forward is active. The ForwardingService FGS already keeps the process (and the
+        // pinned connection) alive, so nothing is lost by stopping the session FGS here.
         val activeClients = ActiveTmuxClients()
         val controller = controller(activeClients, testScheduler)
 
         controller.observeActiveSessions()
         runCurrent()
-        registerLive(activeClients, "alpha")
-        runCurrent()
-        controller.setPortForwardActive(true)
+        registerLive(activeClients, "hetzner")
         controller.onAppBackgrounded(disconnectAtWallClockMillis = 5_000L)
         runCurrent()
+        // The session FGS is up and holding — its notification is on screen.
+        assertEquals(SessionConnectionService.ACTION_START, shadow.nextStartedService?.action)
+        drainStartedServices()
+        assertTrue(controller.flowOfSnapshot().value.isHoldingConnection)
 
-        val snapshot = controller.flowOfSnapshot().value
-        assertTrue("a port-forward-pinned session must still hold", snapshot.isHoldingConnection)
-        assertTrue("port-forward-active must flag the snapshot", snapshot.portForwardActive)
-        assertNull(
-            "a port-forward pins the connection always-on — NO count-down deadline (#1159 Part 3)",
-            snapshot.disconnectAtWallClockMillis,
+        // A port-forward goes active on the pinned host.
+        controller.setPortForwardActive(true)
+        runCurrent()
+
+        val stopped = shadow.nextStartedService
+        assertNotNull(
+            "port-forward active must STOP the session FGS so its second, broken-Stop " +
+                "notification disappears — ForwardingService is the single owner (#1202/#1198)",
+            stopped,
+        )
+        assertEquals(SessionConnectionService::class.java.name, stopped?.component?.className)
+        assertEquals(SessionConnectionService.ACTION_STOP, stopped?.action)
+        assertFalse(
+            "the session FGS must not keep holding a second port-forward notification",
+            controller.flowOfSnapshot().value.isHoldingConnection,
         )
     }
 
     @Test
-    fun `dropping the port-forward restores the bounded count-down while still backgrounded`() = runTest {
+    fun `standalone forward with no live session never starts the session FGS`() = runTest {
+        // Class coverage (G2): a pure port-forward with NO interactive tmux session. The
+        // session FGS must never start (no live client to hold), so ForwardingService is
+        // trivially the single owner even before/without the suppression.
         val activeClients = ActiveTmuxClients()
         val controller = controller(activeClients, testScheduler)
 
         controller.observeActiveSessions()
         runCurrent()
-        registerLive(activeClients, "alpha")
         controller.setPortForwardActive(true)
         controller.onAppBackgrounded(disconnectAtWallClockMillis = 5_000L)
         runCurrent()
-        assertTrue(controller.flowOfSnapshot().value.portForwardActive)
-        assertNull(controller.flowOfSnapshot().value.disconnectAtWallClockMillis)
+
+        assertNull(
+            "a standalone forward (no live tmux session) must not start the session FGS",
+            shadow.nextStartedService,
+        )
+        assertFalse(controller.flowOfSnapshot().value.isHoldingConnection)
+    }
+
+    @Test
+    fun `dropping the forward while still backgrounded restarts the session FGS with the count-down`() = runTest {
+        // Class coverage (G2): the transition back. While the forward pins the connection the
+        // session FGS is suppressed; when the last forward stops (activeHostCount 0 →
+        // setPortForwardActive(false)) and the app is still backgrounded with a live session,
+        // the session FGS restarts with the normal bounded-grace count-down restored.
+        val activeClients = ActiveTmuxClients()
+        val controller = controller(activeClients, testScheduler)
+
+        controller.observeActiveSessions()
+        runCurrent()
+        registerLive(activeClients, "hetzner")
+        controller.setPortForwardActive(true)
+        controller.onAppBackgrounded(disconnectAtWallClockMillis = 5_000L)
+        runCurrent()
+        drainStartedServices()
+        assertFalse(
+            "while the forward pins the connection, the session FGS is suppressed",
+            controller.flowOfSnapshot().value.isHoldingConnection,
+        )
 
         controller.setPortForwardActive(false)
         runCurrent()
 
+        val restarted = shadow.nextStartedService
+        assertNotNull("dropping the forward while backgrounded must restart the session FGS", restarted)
+        assertEquals(SessionConnectionService.ACTION_START, restarted?.action)
         val snapshot = controller.flowOfSnapshot().value
-        assertFalse("dropping the forward must clear the flag", snapshot.portForwardActive)
+        assertTrue("the live session must hold again once the forward is gone", snapshot.isHoldingConnection)
         assertEquals(
             "dropping the forward restores the bounded count-down deadline",
             5_000L,

--- a/scripts/check-ci-journey-harness.sh
+++ b/scripts/check-ci-journey-harness.sh
@@ -91,7 +91,6 @@ KNOWN_UNWIRED_ANDROID_E2E_DOCKER_CLASSES=(
   "com.pocketshell.app.hosts.HostEditFromKebabE2eTest"
   "com.pocketshell.app.notifications.UpdateAvailableNotificationE2eTest"
   "com.pocketshell.app.portfwd.ForwardingIndicatorE2eTest"
-  "com.pocketshell.app.portfwd.ForwardingNotificationE2eTest"
   "com.pocketshell.app.portfwd.ForwardingResumeOnLaunchE2eTest"
   "com.pocketshell.app.portfwd.PortForwardPanelLifecycleE2eTest"
   "com.pocketshell.app.projects.AgentLaunchCommandDockerTest"

--- a/scripts/check-test-validity.sh
+++ b/scripts/check-test-validity.sh
@@ -230,7 +230,6 @@ J1_UNWIRED_ANDROID_E2E_DOCKER_BASELINE=(
   "com.pocketshell.app.hosts.HostEditFromKebabE2eTest"
   "com.pocketshell.app.notifications.UpdateAvailableNotificationE2eTest"
   "com.pocketshell.app.portfwd.ForwardingIndicatorE2eTest"
-  "com.pocketshell.app.portfwd.ForwardingNotificationE2eTest"
   "com.pocketshell.app.portfwd.ForwardingResumeOnLaunchE2eTest"
   "com.pocketshell.app.portfwd.PortForwardPanelLifecycleE2eTest"
   "com.pocketshell.app.projects.AgentLaunchCommandDockerTest"

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -1027,6 +1027,24 @@ JOURNEY_CLASSES=(
   # recorded no loss_hold/ride_through and force-redialled the loss + proven-alive
   # restore); GREEN with #1058. Same agents:2222 fixture; runs on CI.
   "com.pocketshell.app.portfwd.ForwardingNetworkRideThroughE2eTest"
+  # ADDED (#1202 — D31/D32 durable-fix gate, on-device regression): the port-forward
+  # "Stop" no-op + double-notification bug. The maintainer reported (v0.4.23) that
+  # while a session is pinned for a forward, TWO tray notifications stack ("Port
+  # forwarding running" + "Port forwarding active") and Stop on the "active" one only
+  # ends the session hold — a no-op for the tunnels. The #1202/#1198 fix (hard-cut D22)
+  # SUPPRESSES the session FGS while a forward is active so ForwardingService is the
+  # SOLE notification owner, and its Stop actually tears the tunnels down.
+  # `sessionPinnedForForward_hasExactlyOneForwardNotification_andStopTearsDownTunnels`
+  # reproduces the exact reported state on the REAL path (App.kt mirrors the
+  # active-host count into SessionServiceController.setPortForwardActive, exactly as
+  # production) and HARD-asserts the REAL tray: exactly ONE app foreground
+  # notification while pinned (RED on base — the session-channel second notification
+  # posts), then fires the Stop action's PendingIntent and asserts the forward is
+  # actually torn down (active host count → 0) + the notification gone. It does NOT
+  # self-skip on CI (the screenshot proof in the sibling test method does; this one
+  # is pure activeNotifications + Stop). NO Docker fixture / SSH / port — in-process
+  # ActiveTmuxClients + ForwardingController doubles — so no tests.yml service change.
+  "com.pocketshell.app.portfwd.ForwardingNotificationE2eTest#sessionPinnedForForward_hasExactlyOneForwardNotification_andStopTearsDownTunnels"
   # ADDED (epic #792 Slice D, #822/V7a + #823 — D31 durable-fix gate): the
   # PROACTIVE silent mid-session drop detection + auto-recovery journey. The
   # maintainer's headline #822 bug: SSH silently drops on stable Wi-Fi while the


### PR DESCRIPTION
Closes #1202. Closes #1198.

Root cause: two FGS each posted a notification for one forward. The reworded "Port forwarding active" notification's Stop only ended the session hold (`stopHoldingFromNotification`) and left tunnels running. Fix (hard-cut, D22): `ForwardingService` is the single owner — `shouldHold` gated on `!pfActive` suppresses the session FGS while a forward is active; the #1159 rewording is deleted. `ForwardingService` Stop already routes to `stopAllForwarding`.

Verification: reviewer reproduced red→green on-device (API-35 emulator) — base shows the exact double `[Port forwarding active, Port forwarding running]`, fix collapses to one + Stop tears down tunnels via the real tray PendingIntent. Reproduction driven by production `App.kt` collector, not the test (F2/G10). New test runs unskipped on the API-34 CI journey job. Orchestrator gate: compile + touched JVM suites green.