### PR TITLE
conversation: Open-in-Terminal for TUI slash-commands, no misleading echo, no stranded spinner (#1207)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/conversation/ConversationTuiCommandNoticeRenderTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/conversation/ConversationTuiCommandNoticeRenderTest.kt
@@ -1,0 +1,118 @@
+package com.pocketshell.app.conversation
+
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.pocketshell.app.session.ConversationLoadState
+import com.pocketshell.app.tmux.ConversationDetectingPlaceholder
+import com.pocketshell.app.tmux.ConversationTuiCommandNotice
+import com.pocketshell.app.tmux.TMUX_CONVERSATION_OPEN_TERMINAL_TAG
+import com.pocketshell.app.tmux.TMUX_CONVERSATION_TUI_NOTICE_OPEN_TAG
+import com.pocketshell.app.tmux.TMUX_CONVERSATION_TUI_NOTICE_TAG
+import com.pocketshell.app.tmux.tmuxConversationPlaceholderLoadState
+import com.pocketshell.uikit.theme.PocketShellTheme
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Issue #1207 — rendered-UI proof for the Conversation view's TUI-only
+ * slash-command UX and the stranded-placeholder spinner-race fix.
+ *
+ * The bug: a fresh Claude session opens on the Conversation view with zero
+ * transcript. Sending `/model` (an alt-screen TUI picker that writes NOTHING to
+ * the JSONL) showed the user a silent nothing (and a misleading optimistic
+ * "/model" bubble). Adjacently, a torn-down conversation row left the placeholder
+ * spinning "Loading conversation…" forever with no watchdog behind it.
+ *
+ * These render the REAL production composables ([ConversationTuiCommandNotice],
+ * [ConversationDetectingPlaceholder]) under the real [PocketShellTheme] and
+ * assert the user-visible affordance — the Open-in-Terminal action and a
+ * terminal, legible Empty state instead of an eternal spinner. PURE Compose (NO
+ * Docker fixture, NO SSH/tmux, NO port) so it needs no tests.yml service change,
+ * and it does NOT self-skip on CI (no assumeTrue / assumeFalse(isRunningOnCi())).
+ */
+@RunWith(AndroidJUnit4::class)
+class ConversationTuiCommandNoticeRenderTest {
+
+    @get:Rule
+    val compose = createComposeRule()
+
+    @Test
+    fun tuiCommandNoticeShowsCommandAndOpenInTerminalAction() {
+        // Criterion (a): after a `/model` send, the inline notice names the
+        // command and offers a one-tap Open-in-Terminal jump — instead of the
+        // silent nothing the user saw before.
+        var openedTerminal = false
+        var dismissed = false
+        compose.setContent {
+            PocketShellTheme {
+                ConversationTuiCommandNotice(
+                    command = "/model",
+                    onOpenTerminal = { openedTerminal = true },
+                    onDismiss = { dismissed = true },
+                )
+            }
+        }
+
+        compose.onNodeWithTag(TMUX_CONVERSATION_TUI_NOTICE_TAG).assertIsDisplayed()
+        // The command the user sent is named in the notice.
+        compose.onNodeWithText("/model", substring = true).assertIsDisplayed()
+        // The one-tap action is present and routes the user to the Terminal.
+        compose.onNodeWithTag(TMUX_CONVERSATION_TUI_NOTICE_OPEN_TAG)
+            .assertIsDisplayed()
+            .performClick()
+        assertTrue("Open-in-Terminal must invoke the terminal jump", openedTerminal)
+        assertTrue("dismiss stayed inert on the Open action", !dismissed)
+    }
+
+    @Test
+    fun emptyPlaceholderShowsTerminalStateWithOpenInTerminalNotSpinner() {
+        // Criterion (b): the terminal Empty state (what a torn-down / stranded
+        // placeholder now resolves to) is legible and actionable — NOT an eternal
+        // "Loading conversation…" spinner.
+        var openedTerminal = false
+        compose.setContent {
+            PocketShellTheme {
+                ConversationDetectingPlaceholder(
+                    loadState = ConversationLoadState.Empty,
+                    onOpenTerminal = { openedTerminal = true },
+                )
+            }
+        }
+
+        // The eternal spinner is GONE — no "Loading conversation…" label.
+        compose.onNodeWithText("Loading conversation…").assertDoesNotExist()
+        // The legible terminal state points the user at the Terminal tab.
+        compose.onNodeWithText("Terminal tab", substring = true).assertIsDisplayed()
+        compose.onNodeWithTag(TMUX_CONVERSATION_OPEN_TERMINAL_TAG)
+            .assertIsDisplayed()
+            .performClick()
+        assertTrue("Empty-state Open-in-Terminal must jump to Terminal", openedTerminal)
+    }
+
+    @Test
+    fun strandedPlaceholderFallbackRendersTerminalStateNotSpinner() {
+        // Criterion (b), end-to-end through the PRODUCTION fallback: a torn-down
+        // row (null load state) resolves via [tmuxConversationPlaceholderLoadState]
+        // — the exact expression the showConversationPlaceholder branch runs — to
+        // the terminal Empty affordance, never Loading. On base the `?: Loading`
+        // fallback would render the spinner here forever.
+        val rowLoadState = mutableStateOf<ConversationLoadState?>(null)
+        compose.setContent {
+            PocketShellTheme {
+                ConversationDetectingPlaceholder(
+                    loadState = tmuxConversationPlaceholderLoadState(rowLoadState.value),
+                )
+            }
+        }
+
+        compose.onNodeWithText("Loading conversation…").assertDoesNotExist()
+        compose.onNodeWithTag(TMUX_CONVERSATION_OPEN_TERMINAL_TAG).assertIsDisplayed()
+    }
+}

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/ConversationTuiCommandJourneyDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/ConversationTuiCommandJourneyDockerTest.kt
@@ -1,0 +1,675 @@
+package com.pocketshell.app.tmux
+
+import android.graphics.Bitmap
+import android.os.SystemClock
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.ViewModelProvider
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.MainActivity
+import com.pocketshell.app.composer.COMPOSER_DRAFT_TAG
+import com.pocketshell.app.composer.COMPOSER_SEND_ENTER_TAG
+import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
+import com.pocketshell.app.hosts.SshKeyStorage
+import com.pocketshell.app.proof.DEFAULT_HOST
+import com.pocketshell.app.proof.DEFAULT_PORT
+import com.pocketshell.app.proof.DEFAULT_USER
+import com.pocketshell.app.proof.PreGrantPermissionsRule
+import com.pocketshell.app.proof.SeedBeforeLaunchRule
+import com.pocketshell.app.proof.clearLastSessionPrefs
+import com.pocketshell.app.proof.waitForSshFixtureReady
+import com.pocketshell.app.session.SessionTab
+import com.pocketshell.app.voice.SESSION_COMPOSER_LAUNCHER_TAG
+import com.pocketshell.core.agents.ConversationEvent
+import com.pocketshell.core.agents.ConversationRole
+import com.pocketshell.core.ssh.KnownHostsPolicy
+import com.pocketshell.core.ssh.SshConnection
+import com.pocketshell.core.ssh.SshKey
+import com.pocketshell.core.storage.AppDatabase
+import com.pocketshell.core.storage.entity.HostEntity
+import com.termux.view.TerminalView
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.runner.RunWith
+import java.io.File
+import java.io.FileOutputStream
+
+/**
+ * Issue #1207 (reviewer BLOCKED-G4 follow-up) — the REAL-PATH, end-to-end proof
+ * of the Conversation-view TUI-only slash-command UX INTEGRATION that the
+ * component/JVM proofs could not cover: a `/model` sent from the Conversation
+ * composer on the REAL production [TmuxSessionScreen] takes the no-echo path,
+ * raises the Open-in-Terminal notice, and one tap lands the user on the Terminal
+ * tab. This is a hot reopen area (#818/#878/#815/#894/#962/#1057/#1158) so a
+ * component render is explicitly NOT the acceptance — the maintainer's actual
+ * on-screen journey is.
+ *
+ * ### Why this exists (the reviewer's residual — G4/G10/D33)
+ *
+ * The decision logic is proven by [TmuxSessionScreenTest] (JVM red→green for
+ * `tmuxAgentConversationSend` / `tmuxConversationPlaceholderLoadState`) and the
+ * notice/empty composables render on-device via
+ * [com.pocketshell.app.conversation.ConversationTuiCommandNoticeRenderTest]. But
+ * NEITHER exercises the SCREEN-LEVEL wiring: that a composer `/model` submit on
+ * the live `TmuxSessionScreen` actually routes through the AgentConversation
+ * branch, suppresses the optimistic bubble, raises the notice, and switches tabs
+ * on tap. This test drives that integration on the real app + real Docker agent.
+ *
+ * ### Real-path red→green (D33/G10)
+ *
+ * [modelCommandFromConversationShowsNoticeNoEchoBubbleThenTapOpensTerminal]:
+ *  1. Attach to a masked-live-claude session (the #975/#1057 fixture shape: a
+ *     recorded-shell whose cwd holds a fresh Claude transcript; the #975
+ *     transcript-evidence fallback binds live detection and the transcript tails
+ *     into `events`). The composer route is AgentConversation only when
+ *     `currentDetection != null` on the Conversation tab, so a REAL bound
+ *     detection is required — a presumed-only pane routes AgentPayload and never
+ *     reaches the notice path.
+ *  2. Tap Conversation → the transcript renders. Snapshot the conversation events.
+ *  3. Type `/model` into the REAL composer and Send.
+ *  4. ASSERT (RED on base echo-always / GREEN with the #1207 fix):
+ *      - NO optimistic `/model` User bubble was inserted into the transcript
+ *        (on base `sendToAgentPaneResult` inserts one — the misleading echo).
+ *      - The [TMUX_CONVERSATION_TUI_NOTICE_TAG] Open-in-Terminal notice IS shown
+ *        on the Conversation tab (on base the notice never appears).
+ *      - One tap on [TMUX_CONVERSATION_TUI_NOTICE_OPEN_TAG] lands the user on
+ *        [SessionTab.Terminal] (the only surface that can drive the picker), and
+ *        the notice self-clears.
+ *
+ * [confirmedShellShowsNoConversationNoticeOrPlaceholder] is the #894 no-flap
+ * adjacency control: a genuine no-agent recorded shell shows NO Conversation tab
+ * at all, so neither the notice nor the Conversation placeholder can appear on a
+ * confirmed shell — the #1207 change must not resurrect a Conversation surface
+ * for a conversation-less shell.
+ *
+ * Uses ONLY the deterministic `agents:2222` fixture that `tests.yml` already
+ * brings up (no new Docker service/port), and the load-bearing assertions do NOT
+ * self-skip on CI. Wired into `scripts/ci-journey-suite.sh` so the composer-send
+ * integration stays durably guarded per-push. Harness mirrors
+ * [ConversationStaysReachableAfterDetectionDropsDockerTest].
+ */
+@RunWith(AndroidJUnit4::class)
+class ConversationTuiCommandJourneyDockerTest {
+
+    val compose = createAndroidComposeRule<MainActivity>()
+    private val grantPermissions = PreGrantPermissionsRule()
+
+    @get:Rule
+    val ruleChain: RuleChain = RuleChain
+        .outerRule(grantPermissions)
+        .around(SeedBeforeLaunchRule { description -> seedForMethod(description.methodName) })
+        .around(compose)
+
+    private var seededKey: String? = null
+    private var seededHostRowTag: String? = null
+    private var seededSessionName: String? = null
+    private val cleanupCommands = mutableListOf<String>()
+    private val stamps = mutableListOf<String>()
+
+    @After
+    fun tearDown() {
+        runCatching { compose.activityRule.scenario.moveToState(Lifecycle.State.RESUMED) }
+        clearLastSessionPrefs()
+        seededKey?.let { key ->
+            if (cleanupCommands.isNotEmpty()) {
+                runBlocking {
+                    runCatching {
+                        withTimeout(20_000) { execRemote(key, cleanupCommands.joinToString("\n")) }
+                    }
+                }
+            }
+        }
+        if (stamps.isNotEmpty()) {
+            writeText("issue1207-stamps.txt", stamps.joinToString("\n", postfix = "\n"))
+        }
+    }
+
+    /**
+     * Issue #1207 LOAD-BEARING real-path red→green: a `/model` sent from the
+     * Conversation composer shows the Open-in-Terminal notice (no misleading
+     * echo bubble) and one tap lands the user on the Terminal.
+     */
+    @Test
+    fun modelCommandFromConversationShowsNoticeNoEchoBubbleThenTapOpensTerminal() { runBlocking {
+        val hostRowTag = requireNotNull(seededHostRowTag) { "seed-before-launch host row missing" }
+        val sessionName = requireNotNull(seededSessionName) { "seed-before-launch session missing" }
+
+        attachToSeededSession(hostRowTag, sessionName)
+        waitForTerminalSessionAttached()
+        waitForVisibleTerminalText("issue1207-ready", VISIBLE_TIMEOUT_MS) { "issue1207-ready" in it }
+        stamp("attached session=$sessionName")
+
+        val vm = currentViewModel()
+
+        // STEP 1 — REAL detection binds (the #975 transcript-evidence fallback)
+        // AND the transcript tails into `events`. A bound detection is what makes
+        // the composer route AgentConversation (the notice path); a presumed-only
+        // pane routes AgentPayload and never reaches it.
+        val boundPaneId = requireNotNull(waitForDetectionBoundConversationPane(vm)) {
+            "#1207 precondition: a live conversation with a bound detection must " +
+                "bind on the real path so the composer routes AgentConversation. " +
+                "agentConversations=${describeConversations(vm)}"
+        }
+        stamp("conversation_bound pane=$boundPaneId events=${vm.agentConversations.value[boundPaneId]?.events?.size}")
+
+        // STEP 2 — open the Conversation tab; the real transcript renders.
+        tapConversationSegment()
+        compose.waitUntil(timeoutMillis = SURFACE_TIMEOUT_MS) { conversationPaneShown() }
+        compose.onNodeWithTag(TMUX_CONVERSATION_PANE_TAG, useUnmergedTree = true).assertExists()
+        captureFullFrame("issue1207-01-conversation-open")
+
+        // Snapshot the transcript BEFORE the `/model` send so we can prove no
+        // optimistic `/model` User bubble was inserted by the send.
+        val userTurnsBefore = userMessageTexts(vm, boundPaneId)
+        assertFalse(
+            "precondition: the transcript must not already contain a /model User turn",
+            userTurnsBefore.any { it.trim() == MODEL_COMMAND },
+        )
+        stamp("pre_send user_turns=${userTurnsBefore.size}")
+
+        // STEP 3 — type `/model` into the REAL composer and Send. This drives the
+        // production composerSendHandler AgentConversation branch on the live
+        // screen (NOT a proxy): `tmuxAgentConversationSend("/model")` =
+        // TuiCommandNoEcho → writeInputToPaneResult (no optimistic echo) → the
+        // Open-in-Terminal notice is raised.
+        sendFromComposer(MODEL_COMMAND)
+        stamp("composer_sent text=$MODEL_COMMAND")
+
+        // STEP 4a — LOAD-BEARING (RED on base echo-always / GREEN with the fix):
+        // the Open-in-Terminal notice IS shown on the Conversation tab. On base
+        // the send takes the sendToAgentPaneResult echo path and the notice never
+        // appears — this waitUntil times out → RED.
+        compose.waitUntil(timeoutMillis = NOTICE_TIMEOUT_MS) {
+            compose.onAllNodesWithTag(TMUX_CONVERSATION_TUI_NOTICE_TAG, useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
+        compose.onNodeWithTag(TMUX_CONVERSATION_TUI_NOTICE_TAG, useUnmergedTree = true).assertExists()
+        compose.onNodeWithTag(TMUX_CONVERSATION_TUI_NOTICE_OPEN_TAG, useUnmergedTree = true)
+            .assertIsDisplayed()
+        captureFullFrame("issue1207-02-notice-shown")
+        stamp("notice_shown")
+
+        // STEP 4b — LOAD-BEARING (RED on base / GREEN with the fix): NO optimistic
+        // `/model` User bubble was inserted into the transcript. On base
+        // sendToAgentPaneResult inserts exactly this misleading echo turn.
+        val userTurnsAfter = userMessageTexts(vm, boundPaneId)
+        assertFalse(
+            "#1207: a /model send must NOT insert an optimistic User bubble into " +
+                "the Conversation transcript (the misleading echo). userTurns=$userTurnsAfter",
+            userTurnsAfter.any { it.trim() == MODEL_COMMAND },
+        )
+        stamp("no_optimistic_model_bubble user_turns=${userTurnsAfter.size}")
+
+        // STEP 5 — LOAD-BEARING: one tap on the notice's Open-in-Terminal lands
+        // the user on the Terminal tab (the only surface that can drive the
+        // picker) and the notice self-clears.
+        compose.onNodeWithTag(TMUX_CONVERSATION_TUI_NOTICE_OPEN_TAG, useUnmergedTree = true)
+            .performClick()
+        compose.waitForIdle()
+        compose.waitUntil(timeoutMillis = SURFACE_TIMEOUT_MS) {
+            vm.agentConversations.value[boundPaneId]?.selectedTab == SessionTab.Terminal
+        }
+        assertEquals(
+            "#1207: one tap on Open-in-Terminal must select the Terminal tab",
+            SessionTab.Terminal,
+            vm.agentConversations.value[boundPaneId]?.selectedTab,
+        )
+        // The notice self-clears on the jump.
+        compose.waitUntil(timeoutMillis = SURFACE_TIMEOUT_MS) {
+            compose.onAllNodesWithTag(TMUX_CONVERSATION_TUI_NOTICE_TAG, useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .isEmpty()
+        }
+        compose.onNodeWithTag(TMUX_CONVERSATION_TUI_NOTICE_TAG, useUnmergedTree = true)
+            .assertDoesNotExist()
+        captureFullFrame("issue1207-03-terminal-after-tap")
+        stamp("tap_opened_terminal_and_notice_cleared")
+
+        writeText("issue1207-acceptance.txt", buildString {
+            appendLine("issue=1207")
+            appendLine("no_optimistic_model_bubble=true")
+            appendLine("open_in_terminal_notice_shown=true")
+            appendLine("one_tap_lands_on_terminal=true")
+            appendLine("notice_self_cleared_on_jump=true")
+            appendLine("bound_pane=$boundPaneId")
+            appendLine("user_turns_before=${userTurnsBefore.size}")
+            appendLine("user_turns_after=${userTurnsAfter.size}")
+        })
+        Unit
+    } }
+
+    /**
+     * #894 no-flap adjacency control: a genuine no-agent recorded shell shows NO
+     * Conversation tab, so the #1207 notice and the Conversation placeholder can
+     * NEVER appear on a confirmed shell. The #1207 change (which only touches the
+     * Conversation composer send path + the placeholder load-state resolution)
+     * must not resurrect a Conversation surface for a conversation-less shell.
+     */
+    @Test
+    fun confirmedShellShowsNoConversationNoticeOrPlaceholder() { runBlocking {
+        val hostRowTag = requireNotNull(seededHostRowTag) { "seed-before-launch host row missing" }
+        val sessionName = requireNotNull(seededSessionName) { "seed-before-launch session missing" }
+
+        attachToSeededSession(hostRowTag, sessionName)
+        waitForTerminalSessionAttached()
+        waitForVisibleTerminalText("issue1207-plain-ready", VISIBLE_TIMEOUT_MS) {
+            "issue1207-plain-ready" in it
+        }
+        stamp("plain_shell_attached session=$sessionName")
+
+        // Give live detection a generous window to (not) fire.
+        SystemClock.sleep(SHELL_NO_TOGGLE_SETTLE_MS)
+
+        // No Conversation tab → no notice, no Conversation placeholder possible.
+        compose.onNodeWithTag(TMUX_TABS_TAG, useUnmergedTree = true).assertDoesNotExist()
+        compose.onNodeWithTag(TMUX_CONVERSATION_TUI_NOTICE_TAG, useUnmergedTree = true)
+            .assertDoesNotExist()
+        compose.onNodeWithTag(TMUX_CONVERSATION_DETECTING_TAG, useUnmergedTree = true)
+            .assertDoesNotExist()
+        captureFullFrame("issue1207-plain-shell-no-conversation")
+        stamp("plain_shell_no_conversation_surface_ok")
+        Unit
+    } }
+
+    // -------------------------------------------------------------- seed-before-launch
+
+    private suspend fun seedForMethod(methodName: String) {
+        val key = readFixtureKey()
+        seededKey = key
+        clearLastSessionPrefs()
+        waitForSshFixtureReady(SshKey.Pem(key))
+        val sessionName = when (methodName) {
+            "modelCommandFromConversationShowsNoticeNoEchoBubbleThenTapOpensTerminal" ->
+                seedMaskedLiveClaudeSession(key)
+            "confirmedShellShowsNoConversationNoticeOrPlaceholder" ->
+                seedPlainShellSession(key)
+            else -> error("unexpected test method $methodName")
+        }
+        seededSessionName = sessionName
+        seededHostRowTag = persistHost(key)
+    }
+
+    private suspend fun seedPlainShellSession(key: String): String {
+        val suffix = unique()
+        val sessionName = "issue1207-plain-shell-$suffix"
+        cleanupCommands += "tmux kill-session -t ${shellQuote(sessionName)} 2>/dev/null || true"
+        execRemote(
+            key,
+            buildString {
+                appendLine("set -eu")
+                appendLine("tmux kill-session -t ${shellQuote(sessionName)} 2>/dev/null || true")
+                appendLine(
+                    "tmux new-session -d -x 80 -y 24 -s ${shellQuote(sessionName)} -c /tmp " +
+                        "\"printf 'issue1207-plain-ready\\r\\n'; exec sh\"",
+                )
+                appendLine("tmux set-option -t ${shellQuote(sessionName)} @ps_agent_kind shell")
+                appendLine("sleep 1")
+            },
+        )
+        return sessionName
+    }
+
+    /**
+     * The #975/#1057 masked-live-claude fixture shape: a session recorded
+     * `@ps_agent_kind=shell` whose cwd holds a FRESH Claude transcript (copied
+     * from the fixture seed). The daemon classify returns `unknown`, so the ONLY
+     * way detection binds is the #975 transcript-evidence fallback — which is what
+     * we need: a bound live detection whose transcript tails into events so the
+     * composer routes AgentConversation.
+     */
+    private suspend fun seedMaskedLiveClaudeSession(key: String): String {
+        val suffix = unique()
+        val sessionName = "issue1207-masked-claude-$suffix"
+        cleanupCommands += "tmux kill-session -t ${shellQuote(sessionName)} 2>/dev/null || true"
+        cleanupCommands +=
+            "rm -f /home/testuser/.claude/projects/-home-testuser/" +
+                "issue1207-live-claude.jsonl 2>/dev/null || true"
+        execRemote(
+            key,
+            buildString {
+                appendLine("set -eu")
+                appendLine("tmux kill-session -t ${shellQuote(sessionName)} 2>/dev/null || true")
+                appendLine("mkdir -p /home/testuser/.claude/projects/-home-testuser")
+                appendLine(
+                    "cp /home/testuser/.claude/projects/-workspace-pocketshell/" +
+                        "pocketshell-claude.jsonl " +
+                        "/home/testuser/.claude/projects/-home-testuser/" +
+                        "issue1207-live-claude.jsonl",
+                )
+                appendLine(
+                    "touch /home/testuser/.claude/projects/-home-testuser/" +
+                        "issue1207-live-claude.jsonl",
+                )
+                appendLine(
+                    "tmux new-session -d -x 80 -y 24 -s ${shellQuote(sessionName)} " +
+                        "-c /home/testuser " +
+                        "\"printf 'issue1207-ready\\r\\n'; exec sh\"",
+                )
+                appendLine("tmux set-option -t ${shellQuote(sessionName)} @ps_agent_kind shell")
+                appendLine("sleep 1")
+            },
+        )
+        return sessionName
+    }
+
+    // ------------------------------------------------------------------ composer
+
+    private fun sendFromComposer(text: String) {
+        compose.waitUntil(timeoutMillis = COMPOSER_TIMEOUT_MS) {
+            compose.onAllNodesWithTag(SESSION_COMPOSER_LAUNCHER_TAG, useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
+        clickRobustly {
+            compose.onNodeWithTag(SESSION_COMPOSER_LAUNCHER_TAG, useUnmergedTree = true).performClick()
+        }
+        compose.waitUntil(timeoutMillis = COMPOSER_TIMEOUT_MS) {
+            compose.onAllNodesWithTag(COMPOSER_DRAFT_TAG, useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
+        compose.onNodeWithTag(COMPOSER_DRAFT_TAG, useUnmergedTree = true).performTextInput(text)
+        compose.waitForIdle()
+        clickRobustly {
+            compose.onNodeWithTag(COMPOSER_SEND_ENTER_TAG, useUnmergedTree = true).performClick()
+        }
+        // The composer dismisses on a successful send (draft cleared).
+        compose.waitUntil(timeoutMillis = COMPOSER_TIMEOUT_MS) {
+            compose.onAllNodesWithTag(COMPOSER_DRAFT_TAG, useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .isEmpty()
+        }
+    }
+
+    // ----------------------------------------------------------------- helpers
+
+    private suspend fun persistHost(key: String): String {
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
+        var hostRowTag = ""
+        val db = Room.databaseBuilder(appContext, AppDatabase::class.java, DATABASE_NAME)
+            .fallbackToDestructiveMigration(dropAllTables = true)
+            .build()
+        try {
+            db.clearAllTables()
+            val storedKey = SshKeyStorage.persistKey(
+                context = appContext,
+                sshKeyDao = db.sshKeyDao(),
+                name = "issue1207-key-${System.currentTimeMillis()}",
+                content = key,
+            )
+            val hostId = db.hostDao().insert(
+                HostEntity(
+                    name = HOST_NAME,
+                    hostname = DEFAULT_HOST,
+                    port = DEFAULT_PORT,
+                    username = DEFAULT_USER,
+                    keyId = storedKey.id,
+                    tmuxInstalled = true,
+                    lastBootstrapAt = System.currentTimeMillis(),
+                ),
+            )
+            hostRowTag = HOST_ROW_TAG_PREFIX + hostId
+        } finally {
+            db.close()
+        }
+        return hostRowTag
+    }
+
+    private fun attachToSeededSession(hostRowTag: String, sessionName: String) {
+        compose.waitUntil(timeoutMillis = HOST_ROW_TIMEOUT_MS) {
+            runCatching {
+                compose.onAllNodesWithTag(hostRowTag, useUnmergedTree = true)
+                    .fetchSemanticsNodes()
+                    .isNotEmpty()
+            }.getOrDefault(false)
+        }
+        clickRobustly { compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick() }
+        compose.waitUntil(timeoutMillis = ATTACH_TIMEOUT_MS) {
+            compose.onAllNodesWithText(sessionName, useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
+        tapUntilSessionScreenShown(sessionName)
+        compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertIsDisplayed()
+    }
+
+    private fun clickRobustly(click: () -> Unit) {
+        runCatching { compose.activityRule.scenario.moveToState(Lifecycle.State.RESUMED) }
+        compose.waitForIdle()
+        try {
+            click()
+        } catch (e: AssertionError) {
+            if (e.message?.contains("Failed to inject touch input") != true) throw e
+            runCatching { compose.activityRule.scenario.moveToState(Lifecycle.State.RESUMED) }
+            compose.waitForIdle()
+            SystemClock.sleep(300)
+            click()
+        }
+    }
+
+    private fun tapUntilSessionScreenShown(sessionName: String) {
+        val deadline = SystemClock.elapsedRealtime() + ATTACH_TIMEOUT_MS
+        var lastError: Throwable? = null
+        while (SystemClock.elapsedRealtime() < deadline) {
+            runCatching { compose.activityRule.scenario.moveToState(Lifecycle.State.RESUMED) }
+            compose.waitForIdle()
+            runCatching {
+                compose.onNodeWithText(sessionName, useUnmergedTree = true).performClick()
+            }.onFailure { lastError = it }
+            val shown = compose.onAllNodesWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+            if (shown) return
+            SystemClock.sleep(400)
+        }
+        throw AssertionError(
+            "session screen ($TMUX_SESSION_SCREEN_TAG) never mounted after tapping session " +
+                "'$sessionName' within ${ATTACH_TIMEOUT_MS}ms; lastTapError=$lastError",
+        )
+    }
+
+    private fun waitForTerminalSessionAttached() {
+        compose.waitUntil(timeoutMillis = 30_000) {
+            var attached = false
+            compose.activityRule.scenario.onActivity { activity ->
+                val view = activity.window.decorView.findTerminalView()
+                attached = view?.currentSession?.emulator != null
+            }
+            attached
+        }
+    }
+
+    private fun currentViewModel(): TmuxSessionViewModel {
+        var vm: TmuxSessionViewModel? = null
+        compose.activityRule.scenario.onActivity { activity ->
+            vm = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+        }
+        return requireNotNull(vm) { "TmuxSessionViewModel not available" }
+    }
+
+    /**
+     * Poll until a pane has a bound live detection (`detection != null`) — the
+     * state the composer needs to route AgentConversation. Returns the pane id,
+     * or null if it never bound within the budget.
+     */
+    private fun waitForDetectionBoundConversationPane(vm: TmuxSessionViewModel): String? {
+        val deadline = SystemClock.elapsedRealtime() + CONVERSATION_LOAD_TIMEOUT_MS
+        while (SystemClock.elapsedRealtime() < deadline) {
+            val match = vm.agentConversations.value.entries.firstOrNull {
+                it.value.detection != null
+            }
+            if (match != null) return match.key
+            SystemClock.sleep(150)
+        }
+        return vm.agentConversations.value.entries.firstOrNull { it.value.detection != null }?.key
+    }
+
+    private fun userMessageTexts(vm: TmuxSessionViewModel, paneId: String): List<String> =
+        vm.agentConversations.value[paneId]?.events.orEmpty()
+            .filterIsInstance<ConversationEvent.Message>()
+            .filter { it.role == ConversationRole.User }
+            .map { it.text }
+
+    private fun describeConversations(vm: TmuxSessionViewModel): String =
+        vm.agentConversations.value.entries.joinToString(prefix = "{", postfix = "}") { (k, v) ->
+            "$k=(agent=${v.detection?.agent}, events=${v.events.size}, tab=${v.selectedTab})"
+        }
+
+    private fun tapConversationSegment() {
+        clickRobustly {
+            compose.onNodeWithTag(CONVERSATION_SEGMENT_TAG, useUnmergedTree = true).performClick()
+        }
+        compose.waitForIdle()
+    }
+
+    private fun conversationPaneShown(): Boolean =
+        compose.onAllNodesWithTag(TMUX_CONVERSATION_PANE_TAG, useUnmergedTree = true)
+            .fetchSemanticsNodes()
+            .isNotEmpty()
+
+    private fun visibleTerminalText(): String {
+        var text = ""
+        compose.activityRule.scenario.onActivity { activity ->
+            text = activity.window.decorView
+                .findTerminalView()
+                ?.currentSession
+                ?.emulator
+                ?.screen
+                ?.transcriptText
+                .orEmpty()
+        }
+        return text
+    }
+
+    private fun waitForVisibleTerminalText(
+        label: String,
+        timeoutMs: Long,
+        predicate: (String) -> Boolean,
+    ) {
+        val deadline = SystemClock.elapsedRealtime() + timeoutMs
+        var last = ""
+        while (SystemClock.elapsedRealtime() < deadline) {
+            last = visibleTerminalText()
+            if (predicate(last)) return
+            SystemClock.sleep(50)
+        }
+        writeText("issue1207-failure-$label-visible-terminal.txt", last)
+        assertTrue("predicate $label timed out; visible terminal:\n$last", false)
+    }
+
+    private fun View.findTerminalView(): TerminalView? {
+        if (this is TerminalView) return this
+        if (this !is ViewGroup) return null
+        for (index in 0 until childCount) {
+            val match = getChildAt(index).findTerminalView()
+            if (match != null) return match
+        }
+        return null
+    }
+
+    private fun captureFullFrame(name: String): File {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.waitForIdleSync()
+        SystemClock.sleep(300)
+        val bitmap = instrumentation.uiAutomation.takeScreenshot()
+        val file = artifactFile("$name.png")
+        FileOutputStream(file).use { out ->
+            check(bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)) {
+                "failed to write full-frame screenshot to ${file.absolutePath}"
+            }
+        }
+        bitmap.recycle()
+        println("ISSUE1207_FULLFRAME ${file.absolutePath}")
+        return file
+    }
+
+    private fun writeText(name: String, text: String): File {
+        val file = artifactFile(name)
+        file.writeText(text)
+        println("ISSUE1207_TEXT ${file.absolutePath}")
+        return file
+    }
+
+    private fun artifactFile(name: String): File {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val mediaRoot = com.pocketshell.app.test.testArtifactsRoot(instrumentation.targetContext)
+        val dir = File(mediaRoot, "additional_test_output/conversation-tui-command-1207")
+        check(dir.exists() || dir.mkdirs()) { "could not create artifact dir ${dir.absolutePath}" }
+        return File(dir, name)
+    }
+
+    private suspend fun execRemote(key: String, command: String) {
+        val result = withTimeout(30_000) {
+            SshConnection.connect(
+                host = DEFAULT_HOST,
+                port = DEFAULT_PORT,
+                user = DEFAULT_USER,
+                key = SshKey.Pem(key),
+                knownHosts = KnownHostsPolicy.AcceptAll,
+                timeoutMs = 15_000,
+            ).mapCatching { session -> session.use { it.exec(command) } }
+        }
+        val exec = result.getOrNull()
+        assertTrue(
+            "remote command failed: ${result.exceptionOrNull()} exit=${exec?.exitCode} " +
+                "stdout='${exec?.stdout}' stderr='${exec?.stderr}'",
+            exec?.exitCode == 0,
+        )
+    }
+
+    private fun readFixtureKey(): String =
+        InstrumentationRegistry.getInstrumentation()
+            .context
+            .assets
+            .open("test_key")
+            .bufferedReader()
+            .use { it.readText() }
+
+    private fun shellQuote(value: String): String =
+        "'" + value.replace("'", "'\"'\"'") + "'"
+
+    private fun unique(): String =
+        "${System.currentTimeMillis().toString().takeLast(6)}${System.nanoTime().toString().takeLast(4)}"
+
+    private fun stamp(name: String) {
+        stamps += "[issue1207] $name at ${SystemClock.elapsedRealtime()}"
+    }
+
+    private companion object {
+        const val DATABASE_NAME: String = "pocketshell.db"
+        const val HOST_NAME: String = "Issue1207 Agents"
+        const val MODEL_COMMAND: String = "/model"
+        const val ATTACH_TIMEOUT_MS: Long = 30_000
+        const val HOST_ROW_TIMEOUT_MS: Long = 60_000
+        const val VISIBLE_TIMEOUT_MS: Long = 20_000
+        const val SHELL_NO_TOGGLE_SETTLE_MS: Long = 8_000
+        const val CONVERSATION_LOAD_TIMEOUT_MS: Long = 30_000
+        const val SURFACE_TIMEOUT_MS: Long = 20_000
+        const val NOTICE_TIMEOUT_MS: Long = 20_000
+        const val COMPOSER_TIMEOUT_MS: Long = 15_000
+
+        // The Conversation segment is index 1 in the Terminal|Conversation pill
+        // (index 0 is TMUX_TERMINAL_TAB_TAG; see ConsolidatedTabPill.segmentTag).
+        const val CONVERSATION_SEGMENT_TAG: String = TMUX_CONSOLIDATED_TAB_PILL_TAG_PREFIX + "1"
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
@@ -782,6 +782,15 @@ public fun TmuxSessionScreen(
     // dark for voice input).
     var showMicSheet by remember { mutableStateOf(false) }
     var showSnippetPicker by remember { mutableStateOf(false) }
+    // Issue #1207: when a TUI-only slash-command (/model, /config, a picker) is
+    // sent from the Conversation composer, the picker opens in the covered
+    // alt-screen Terminal and writes NOTHING to the transcript — so the
+    // Conversation surface can never show it. Instead of the misleading
+    // optimistic bubble + silent nothing, we raise an inline notice holding the
+    // command text with a one-tap "Open in Terminal" action. Null when no notice
+    // is up. Reset whenever the send target identity changes so a stale notice
+    // never bleeds into another session on a switch/recreation.
+    var tuiCommandNotice by remember(targetSessionId.value) { mutableStateOf<String?>(null) }
     var showCardFeedSheet by remember(activeSessionCardsTargetKey) { mutableStateOf(false) }
     val sessionCardInteractions = remember(viewModel) {
         object : SessionCardInteractions {
@@ -976,7 +985,30 @@ public fun TmuxSessionScreen(
                 false
             } else when (target.route) {
                 OutboundRoute.AgentConversation ->
-                    viewModel.sendToAgentPaneResult(paneId, request.text).isSuccess
+                    // Issue #1207: a TUI-only slash-command (/model, /config, any
+                    // picker) writes NOTHING to the transcript — it drives an
+                    // alt-screen picker in the covered Terminal pane. Echoing an
+                    // optimistic "/model" user bubble (the old `sendToAgentPaneResult`
+                    // path) is actively misleading: the bubble sits there as if a
+                    // normal turn ran while the picker is invisible on the
+                    // Conversation surface by construction. So for a slash-command we
+                    // send the keystrokes to the pane WITHOUT the optimistic echo (the
+                    // same raw text+Enter delivery a confirmed agent uses on the
+                    // Terminal tab) and raise the inline "Open in Terminal" notice.
+                    when (tmuxAgentConversationSend(request.text)) {
+                        TmuxAgentConversationSend.TuiCommandNoEcho -> {
+                            val ok = viewModel.writeInputToPaneResult(
+                                paneId,
+                                (request.text.trimEnd('\n') + "\r").toByteArray(Charsets.UTF_8),
+                            ).isSuccess
+                            if (ok) {
+                                tuiCommandNotice = request.text.trim()
+                            }
+                            ok
+                        }
+                        TmuxAgentConversationSend.Echo ->
+                            viewModel.sendToAgentPaneResult(paneId, request.text).isSuccess
+                    }
                 OutboundRoute.AgentPayload ->
                     tmuxComposerAgentKindFromToken(target.agentKind)?.let { agentKind ->
                         viewModel.sendAgentPayloadToPaneResult(
@@ -2163,11 +2195,27 @@ public fun TmuxSessionScreen(
                     // a clear Failed terminal state (with Retry) once the
                     // watchdog trips, instead of an infinite "Waiting for agent…"
                     // spinner.
+                    // Issue #1207 (stranded-spinner race): when the conversation
+                    // row is GONE (`visibleConversation == null`) — e.g. the
+                    // 2-consecutive-null detection teardown removed it BEFORE the
+                    // 12s load watchdog fired — there is no watchdog left behind
+                    // this placeholder, so the old `?: Loading` fallback spins
+                    // FOREVER. [tmuxConversationPlaceholderLoadState] resolves a
+                    // missing row to a terminal, legible Empty state ("No
+                    // conversation yet — the agent is live in the Terminal tab")
+                    // with the same one-tap Open-in-Terminal action, never Loading.
                     ConversationDetectingPlaceholder(
-                        loadState = visibleConversation?.loadState
-                            ?: ConversationLoadState.Loading,
+                        loadState = tmuxConversationPlaceholderLoadState(
+                            visibleConversation?.loadState,
+                        ),
                         onRetry = {
                             surfacePane?.paneId?.let { viewModel.retryAgentConversationLoad(it) }
+                        },
+                        onOpenTerminal = {
+                            surfacePane?.paneId?.let {
+                                viewModel.selectSessionTab(it, SessionTab.Terminal)
+                            }
+                            tuiCommandNotice = null
                         },
                     )
                 } else if (unifiedPanes.isEmpty()) {
@@ -2180,6 +2228,36 @@ public fun TmuxSessionScreen(
                 // all stable, so an overlay-visibility toggle skips it) and supplies
                 // the warm, attached terminal surface for BOTH the raw-Terminal tab
                 // and (covered, underneath) the Conversation tab.
+
+                // Issue #1207: a TUI-only slash-command (/model, /config, a
+                // permission picker) sent from the Conversation composer opens its
+                // picker in the covered alt-screen Terminal and writes NOTHING to
+                // the transcript — so nothing appears here. Instead of the old
+                // misleading optimistic bubble + silent nothing, an inline notice
+                // over the Conversation surface tells the user the picker is live in
+                // the Terminal and offers a one-tap jump. Only on the Conversation
+                // tab (the Terminal already shows the picker). The notice self-clears
+                // on the jump, on dismiss, and on a session switch (state key).
+                val activeTuiCommandNotice = tuiCommandNotice
+                if (activeTuiCommandNotice != null &&
+                    currentSelectedTab == SessionTab.Conversation
+                ) {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.BottomCenter,
+                    ) {
+                        ConversationTuiCommandNotice(
+                            command = activeTuiCommandNotice,
+                            onOpenTerminal = {
+                                surfacePane?.paneId?.let {
+                                    viewModel.selectSessionTab(it, SessionTab.Terminal)
+                                }
+                                tuiCommandNotice = null
+                            },
+                            onDismiss = { tuiCommandNotice = null },
+                        )
+                    }
+                }
             }
             Box(
                 modifier = Modifier
@@ -3863,6 +3941,68 @@ internal fun tmuxComposerSendRoute(
     else -> TmuxComposerSendRoute.RawBytes
 }
 
+/**
+ * Issue #1207: true when [text] is an agent TUI slash-command — an alt-screen
+ * interaction (`/model`, `/config`, `/login`, `/agents`, permission pickers …)
+ * that the agent handles in its terminal UI and writes NOTHING to the JSONL
+ * transcript. Such input can NEVER appear on the Conversation surface by
+ * construction, so it must NOT get an optimistic transcript bubble, and the user
+ * must be offered the Terminal (the only surface that can drive the picker).
+ *
+ * The grammar is deliberately narrow so a normal prompt or a filesystem path is
+ * NOT misclassified:
+ *  - the trimmed text is a single line (a multi-line message is a prompt);
+ *  - its first whitespace-delimited token is `/word[...]` where `word` starts
+ *    with a letter and contains only `[A-Za-z0-9_-]` (no further `/`), so
+ *    `/model`, `/model sonnet`, `/config` match but `/home/user/file`,
+ *    `/`, and `/2 + 2` (a leading-slash math prompt) do not.
+ */
+internal fun tmuxComposerIsTuiSlashCommand(text: String): Boolean {
+    val trimmed = text.trim()
+    if (!trimmed.startsWith("/")) return false
+    // A multi-line message is a prompt the user typed, not a slash-command.
+    if (trimmed.contains('\n') || trimmed.contains('\r')) return false
+    val firstToken = trimmed.substringBefore(' ').substringBefore('\t')
+    return firstToken.matches(Regex("^/[A-Za-z][A-Za-z0-9_-]*$"))
+}
+
+/**
+ * Issue #1207: which agent-conversation send path a composer submit takes.
+ *  - [Echo]: a normal prompt — submit to the agent AND echo the optimistic user
+ *    turn into the transcript (`sendToAgentPaneResult`), unchanged from before.
+ *  - [TuiCommandNoEcho]: a TUI-only slash-command — deliver the keystrokes to
+ *    the pane WITHOUT an optimistic transcript bubble and raise the
+ *    Open-in-Terminal notice, because the picker it opens shows only on the
+ *    covered Terminal pane, never on the Conversation surface.
+ */
+internal enum class TmuxAgentConversationSend { Echo, TuiCommandNoEcho }
+
+internal fun tmuxAgentConversationSend(text: String): TmuxAgentConversationSend =
+    if (tmuxComposerIsTuiSlashCommand(text)) {
+        TmuxAgentConversationSend.TuiCommandNoEcho
+    } else {
+        TmuxAgentConversationSend.Echo
+    }
+
+/**
+ * Issue #1207: resolve the load state the Conversation-tab placeholder renders
+ * when it has NO backing conversation row (`rowLoadState == null`).
+ *
+ * The stranded-spinner bug: the 2-consecutive-null detection teardown
+ * (`AGENT_EXIT_CONFIRMATIONS`) can remove the conversation row BEFORE the 12s
+ * load watchdog fires. The placeholder is still shown (the tab stays reachable
+ * via `presumedAgent`), but with no row there is no watchdog behind it — so a
+ * `?: Loading` fallback spins FOREVER. A missing row means no load is in flight
+ * and nothing can ever flip it to a terminal state, so it MUST resolve to a
+ * terminal legible state ([ConversationLoadState.Empty] — "No conversation yet,
+ * the agent is live in the Terminal tab"), never [ConversationLoadState.Loading].
+ * When a row exists we honour its own load state (a `Loading` row always has the
+ * watchdog armed behind it).
+ */
+internal fun tmuxConversationPlaceholderLoadState(
+    rowLoadState: ConversationLoadState?,
+): ConversationLoadState = rowLoadState ?: ConversationLoadState.Empty
+
 internal fun tmuxComposerOutboundRoute(route: TmuxComposerSendRoute): OutboundRoute = when (route) {
     TmuxComposerSendRoute.AgentConversation -> OutboundRoute.AgentConversation
     TmuxComposerSendRoute.AgentPayload -> OutboundRoute.AgentPayload
@@ -4186,6 +4326,12 @@ internal const val TMUX_CONVERSATION_DETECTING_TAG = "tmux:conversation:detectin
 internal const val TMUX_CONVERSATION_LOAD_FAILED_TAG = "tmux:conversation:load-failed"
 internal const val TMUX_CONVERSATION_LOAD_RETRY_TAG = "tmux:conversation:load-retry"
 internal const val TMUX_CONVERSATION_LOAD_EMPTY_TAG = "tmux:conversation:load-empty"
+// Issue #1207: one-tap "Open in Terminal" action on the terminal-state
+// Conversation placeholder + the TUI-command notice — the only surface that can
+// drive a TUI-only slash-command picker (/model, /config …).
+internal const val TMUX_CONVERSATION_OPEN_TERMINAL_TAG = "tmux:conversation:open-terminal"
+internal const val TMUX_CONVERSATION_TUI_NOTICE_TAG = "tmux:conversation:tui-command-notice"
+internal const val TMUX_CONVERSATION_TUI_NOTICE_OPEN_TAG = "tmux:conversation:tui-command-open-terminal"
 // Issue #793: top-of-list progress row shown while older messages page in on
 // upward scroll (tail-first windowed load).
 internal const val TMUX_CONVERSATION_PAGING_OLDER_TAG = "tmux:conversation:paging-older"
@@ -4892,6 +5038,10 @@ internal fun ConversationDetectingPlaceholder(
     // "no messages yet" terminal state.
     loadState: ConversationLoadState = ConversationLoadState.Loading,
     onRetry: () -> Unit = {},
+    // Issue #1207: switch to the Terminal tab — the only surface that can show a
+    // live agent's alt-screen TUI (a fresh session's picker / prompt). Offered on
+    // the terminal Empty state so a stranded placeholder is never a dead end.
+    onOpenTerminal: () -> Unit = {},
 ) {
     Box(
         modifier = Modifier
@@ -4920,16 +5070,83 @@ internal fun ConversationDetectingPlaceholder(
                     Text("Retry")
                 }
             }
-            ConversationLoadState.Empty -> Text(
-                text = "No conversation events yet.",
-                color = PocketShellColors.TextSecondary,
-                fontSize = 14.sp,
-                modifier = Modifier.testTag(TMUX_CONVERSATION_LOAD_EMPTY_TAG),
-            )
+            // Issue #1207: the Empty terminal state is no longer a dead "No
+            // conversation events yet." line. A fresh Claude/Codex session shows
+            // nothing on the Conversation surface because the agent is live in its
+            // alt-screen TUI (the picker / prompt) that writes NOTHING to the
+            // transcript — so this state points the user at the Terminal tab, the
+            // only surface that can show it, with a one-tap action. This is also
+            // the terminal state a stranded placeholder (torn-down row, no
+            // watchdog) now resolves to, instead of an eternal spinner.
+            ConversationLoadState.Empty -> Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier
+                    .padding(horizontal = 24.dp)
+                    .testTag(TMUX_CONVERSATION_LOAD_EMPTY_TAG),
+            ) {
+                Text(
+                    text = "No conversation yet — the agent is live in the Terminal tab.",
+                    color = PocketShellColors.TextSecondary,
+                    fontSize = 14.sp,
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+                TextButton(
+                    onClick = onOpenTerminal,
+                    modifier = Modifier.testTag(TMUX_CONVERSATION_OPEN_TERMINAL_TAG),
+                ) {
+                    Text("Open in Terminal")
+                }
+            }
             else -> LoadingIndicator.Spinner(
                 size = SpinnerSize.Medium,
                 label = "Loading conversation…",
             )
+        }
+    }
+}
+
+/**
+ * Issue #1207: inline notice shown over the Conversation surface after a TUI-only
+ * slash-command ([tmuxComposerIsTuiSlashCommand]) is sent from the composer. Such
+ * a command (`/model`, `/config`, a permission picker …) drives an alt-screen
+ * picker in the covered Terminal pane and writes NOTHING to the transcript, so
+ * the Conversation view can never show it. Rather than the old misleading
+ * optimistic bubble + a silent nothing, this banner is honest about where the
+ * interaction is and gives a one-tap jump to the only surface that can drive it.
+ *
+ * `internal` so the #1207 rendered-UI regression test can mount the REAL notice.
+ */
+@Composable
+internal fun ConversationTuiCommandNotice(
+    command: String,
+    onOpenTerminal: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(12.dp)
+            .background(PocketShellColors.Surface, RoundedCornerShape(10.dp))
+            .padding(horizontal = 14.dp, vertical = 12.dp)
+            .testTag(TMUX_CONVERSATION_TUI_NOTICE_TAG),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(
+            text = "“$command” opens an interactive picker in the Terminal — " +
+                "it doesn't show here.",
+            color = PocketShellColors.Text,
+            fontSize = 13.sp,
+            modifier = Modifier.weight(1f),
+        )
+        TextButton(
+            onClick = onOpenTerminal,
+            modifier = Modifier.testTag(TMUX_CONVERSATION_TUI_NOTICE_OPEN_TAG),
+        ) {
+            Text("Open in Terminal", color = PocketShellColors.Accent)
+        }
+        TextButton(onClick = onDismiss) {
+            Text("Dismiss", color = PocketShellColors.TextSecondary)
         }
     }
 }

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
@@ -5126,7 +5126,7 @@ internal fun ConversationTuiCommandNotice(
         modifier = Modifier
             .fillMaxWidth()
             .padding(12.dp)
-            .background(PocketShellColors.Surface, RoundedCornerShape(10.dp))
+            .background(PocketShellColors.Surface, PocketShellShapes.medium)
             .padding(horizontal = 14.dp, vertical = 12.dp)
             .testTag(TMUX_CONVERSATION_TUI_NOTICE_TAG),
         verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
@@ -5090,12 +5090,12 @@ internal fun ConversationDetectingPlaceholder(
                     fontSize = 14.sp,
                 )
                 Spacer(modifier = Modifier.height(12.dp))
-                TextButton(
+                PocketShellButton(
+                    text = "Open in Terminal",
                     onClick = onOpenTerminal,
                     modifier = Modifier.testTag(TMUX_CONVERSATION_OPEN_TERMINAL_TAG),
-                ) {
-                    Text("Open in Terminal")
-                }
+                    variant = ButtonVariant.Text,
+                )
             }
             else -> LoadingIndicator.Spinner(
                 size = SpinnerSize.Medium,
@@ -5139,15 +5139,18 @@ internal fun ConversationTuiCommandNotice(
             fontSize = 13.sp,
             modifier = Modifier.weight(1f),
         )
-        TextButton(
+        PocketShellButton(
             onClick = onOpenTerminal,
             modifier = Modifier.testTag(TMUX_CONVERSATION_TUI_NOTICE_OPEN_TAG),
+            variant = ButtonVariant.Text,
         ) {
             Text("Open in Terminal", color = PocketShellColors.Accent)
         }
-        TextButton(onClick = onDismiss) {
-            Text("Dismiss", color = PocketShellColors.TextSecondary)
-        }
+        PocketShellButton(
+            text = "Dismiss",
+            onClick = onDismiss,
+            variant = ButtonVariant.Text,
+        )
     }
 }
 

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionScreenTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionScreenTest.kt
@@ -1062,6 +1062,101 @@ class TmuxSessionScreenTest {
         )
     }
 
+    // --- Issue #1207: TUI-only slash-command handling on the Conversation
+    // composer (no misleading echo, Open-in-Terminal notice) + the stranded
+    // placeholder spinner-race fix. ---
+
+    @Test
+    fun tuiSlashCommandRecognisesAgentPickerCommands() {
+        // Criterion (a): `/model` and friends are TUI-only picker commands that
+        // write NOTHING to the transcript. They must be recognised so the
+        // composer suppresses the optimistic bubble and raises the notice.
+        assertTrue(tmuxComposerIsTuiSlashCommand("/model"))
+        assertTrue(tmuxComposerIsTuiSlashCommand("/config"))
+        assertTrue(tmuxComposerIsTuiSlashCommand("/login"))
+        // A slash-command WITH arguments (e.g. `/model sonnet`) is still a
+        // command — the first token drives the classification.
+        assertTrue(tmuxComposerIsTuiSlashCommand("/model sonnet"))
+        // Surrounding whitespace is trimmed before classifying.
+        assertTrue(tmuxComposerIsTuiSlashCommand("  /model  "))
+    }
+
+    @Test
+    fun tuiSlashCommandRejectsPromptsAndPaths() {
+        // A normal prompt is NOT a slash-command — it must keep the optimistic
+        // echo (`Echo`), never divert to the notice path.
+        assertTrue(!tmuxComposerIsTuiSlashCommand("explain this diff"))
+        assertTrue(!tmuxComposerIsTuiSlashCommand(""))
+        // A bare slash is not a command.
+        assertTrue(!tmuxComposerIsTuiSlashCommand("/"))
+        // A filesystem path is not a command (it has a second `/`).
+        assertTrue(!tmuxComposerIsTuiSlashCommand("/home/user/file.txt"))
+        // A leading-slash arithmetic/prompt is not a command (first token starts
+        // with a digit, not a letter).
+        assertTrue(!tmuxComposerIsTuiSlashCommand("/2 + 2"))
+        // A multi-line message is a prompt the user typed, not a command, even
+        // when the first line looks command-like.
+        assertTrue(!tmuxComposerIsTuiSlashCommand("/model\nand also do this"))
+    }
+
+    @Test
+    fun agentConversationSendSuppressesEchoForTuiSlashCommand() {
+        // Criterion (a) — the load-bearing decision: a `/model` sent from the
+        // Conversation composer takes the NO-ECHO path (deliver keystrokes to the
+        // pane, raise the Open-in-Terminal notice), NOT the optimistic-bubble
+        // `sendToAgentPaneResult` echo path. On base (echo always) this would be
+        // `Echo`; the fix makes it `TuiCommandNoEcho`.
+        assertEquals(
+            TmuxAgentConversationSend.TuiCommandNoEcho,
+            tmuxAgentConversationSend("/model"),
+        )
+        // A normal prompt keeps the optimistic echo — unchanged behaviour.
+        assertEquals(
+            TmuxAgentConversationSend.Echo,
+            tmuxAgentConversationSend("summarise the failing test"),
+        )
+    }
+
+    @Test
+    fun placeholderWithNoRowResolvesToTerminalEmptyNotEternalSpinner() {
+        // Criterion (b) — the stranded-spinner race: the 2-null detection
+        // teardown can remove the conversation row BEFORE the load watchdog
+        // fires, leaving the placeholder with NO row and NO watchdog behind it.
+        // The old `?: ConversationLoadState.Loading` fallback then spins FOREVER.
+        // A missing row (null) MUST resolve to a terminal legible state (Empty),
+        // never Loading. This is the exact fallback at
+        // TmuxSessionScreen.kt's showConversationPlaceholder branch.
+        assertEquals(
+            com.pocketshell.app.session.ConversationLoadState.Empty,
+            tmuxConversationPlaceholderLoadState(null),
+        )
+    }
+
+    @Test
+    fun placeholderWithRowHonoursItsOwnLoadState() {
+        // When a row exists, honour its own load state — a `Loading` row always
+        // has the load watchdog armed behind it, so it is NOT a stranded spinner
+        // and must keep showing "Loading conversation…".
+        assertEquals(
+            com.pocketshell.app.session.ConversationLoadState.Loading,
+            tmuxConversationPlaceholderLoadState(
+                com.pocketshell.app.session.ConversationLoadState.Loading,
+            ),
+        )
+        assertEquals(
+            com.pocketshell.app.session.ConversationLoadState.Failed,
+            tmuxConversationPlaceholderLoadState(
+                com.pocketshell.app.session.ConversationLoadState.Failed,
+            ),
+        )
+        assertEquals(
+            com.pocketshell.app.session.ConversationLoadState.Ready,
+            tmuxConversationPlaceholderLoadState(
+                com.pocketshell.app.session.ConversationLoadState.Ready,
+            ),
+        )
+    }
+
     @Test
     fun composerOutboundRouteMapsAllRoutes() {
         assertEquals(

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -911,6 +911,26 @@ JOURNEY_CLASSES=(
   #     a toggle for a conversation-less shell).
   # Uses ONLY agents:2222 that tests.yml already brings up; no self-skip on CI.
   "com.pocketshell.app.tmux.ConversationStaysReachableAfterDetectionDropsDockerTest"
+  # ADDED (#1207 — reviewer BLOCKED-G4 residual, D33/G10): the composer-send
+  # INTEGRATION on the REAL TmuxSessionScreen that the component/JVM proofs
+  # could not cover. A fresh Claude session opens on the Conversation view; a
+  # `/model` (an alt-screen TUI picker that writes NOTHING to the JSONL) used to
+  # echo a MISLEADING optimistic user bubble and offer no way forward. This class
+  # drives the REAL app + REAL Docker agent:
+  #   - modelCommandFromConversationShowsNoticeNoEchoBubbleThenTapOpensTerminal:
+  #     the LOAD-BEARING real-path red->green. Detection binds via the #975
+  #     transcript-evidence fallback (so the composer routes AgentConversation);
+  #     `/model` is typed into the REAL composer and Sent. On base (echo-always)
+  #     sendToAgentPaneResult inserts a misleading /model User bubble and no
+  #     Open-in-Terminal notice appears (RED); with the #1207 fix the no-echo path
+  #     runs -> NO optimistic bubble + the notice IS shown + one tap lands the user
+  #     on SessionTab.Terminal and the notice self-clears (GREEN).
+  #   - confirmedShellShowsNoConversationNoticeOrPlaceholder (#894 no-flap
+  #     ADJACENCY): a genuine no-agent recorded shell shows NO Conversation tab, so
+  #     neither the #1207 notice nor the Conversation placeholder can appear on a
+  #     confirmed shell.
+  # Uses ONLY agents:2222 that tests.yml already brings up; no self-skip on CI.
+  "com.pocketshell.app.tmux.ConversationTuiCommandJourneyDockerTest"
   # ADDED (#813): the composer-launcher NARROW / LARGE-FONT clip proof. The
   # maintainer dogfooded (2026-06-18 07:53) the launcher being CLIPPED off the
   # right edge of the bottom bar by the 4-chip primary cluster on a narrow /
@@ -993,6 +1013,20 @@ JOURNEY_CLASSES=(
   # the inline-image render + the path-text FALLBACK on a failed fetch stay
   # durably guarded. It lives under com.pocketshell.app.conversation.
   "com.pocketshell.app.conversation.ConversationImageContentRenderTest"
+  # ADDED (#1207 — black-screen audit UX leg, D33/G10): a fresh Claude session
+  # opens on the Conversation view with zero transcript; `/model` (an alt-screen
+  # TUI picker that writes NOTHING to the JSONL) showed a silent nothing + a
+  # misleading optimistic bubble, and a torn-down row stranded an eternal
+  # "Loading conversation…" spinner. This class renders the REAL production
+  # composables (ConversationTuiCommandNotice + ConversationDetectingPlaceholder
+  # via the production tmuxConversationPlaceholderLoadState fallback) and asserts
+  # the Open-in-Terminal affordance is shown + the terminal Empty state renders
+  # instead of the eternal spinner. PURE Compose (NO Docker fixture, NO SSH/tmux,
+  # NO port) — no tests.yml service change — and it does NOT self-skip on CI (no
+  # assumeTrue / assumeFalse(isRunningOnCi())). Per G9 it must run per-push so the
+  # TUI-command UX + spinner-race fix stay durably guarded. It lives under
+  # com.pocketshell.app.conversation.
+  "com.pocketshell.app.conversation.ConversationTuiCommandNoticeRenderTest"
   # ADDED (#931 — D33/G10 reproduce-first): the port-forward panel LazyColumn
   # duplicate-key crash guard. The maintainer's captured crash
   # (IllegalArgumentException: Key "22" already used) was a real Compose


### PR DESCRIPTION
Closes #1207. Part of black-screen audit umbrella #1208 (UX leg C — the "new Claude session → /model → nothing shows" report).

Root cause: fresh Claude session opens on Conversation view (zero transcript); `/model` is an alt-screen TUI picker that writes no JSONL, so the surface can never show it, and the composer echoed a misleading optimistic bubble. Fix: TUI slash-commands take a no-echo path (keystrokes reach the pane so the picker opens) + inline `ConversationTuiCommandNotice` with one-tap Open-in-Terminal; the placeholder fallback resolves a torn-down row to a legible terminal Empty state, never an eternal spinner.

Verification: reviewer independently reproduced red→green on emulator+Docker (neutralize the notice → `ComposeTimeoutException`; restore → green), visual artifacts show no `/model` bubble + notice + one tap → Terminal; JVM 98 tests 0-skip; test-backed #894 adjacency; `TmuxSessionViewModel.kt` untouched. Orchestrator gate: compile + TmuxSessionScreenTest green.