### PR TITLE
tmux: retry failed fresh-pane seed + repaint-on-empty + renderRequests replay=1 (#1206)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/Issue1206PrewarmEmptyCaptureSeedRetryJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/Issue1206PrewarmEmptyCaptureSeedRetryJourneyE2eTest.kt
@@ -1,0 +1,712 @@
+package com.pocketshell.app.proof
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.os.SystemClock
+import android.util.Log
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.hasAnyAncestor
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.swipeWithVelocity
+import androidx.lifecycle.Lifecycle
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.MainActivity
+import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
+import com.pocketshell.app.hosts.SshKeyStorage
+import com.pocketshell.app.proof.signals.waitForSessionInPicker
+import com.pocketshell.app.tmux.PrewarmSeedFaultTestOverride
+import com.pocketshell.app.tmux.TMUX_COMPACT_CHROME_BACK_BUTTON_TAG
+import com.pocketshell.app.tmux.TMUX_CONSOLIDATED_SESSION_LABEL_TAG
+import com.pocketshell.app.tmux.TMUX_FULL_BREADCRUMB_TAG
+import com.pocketshell.app.tmux.TMUX_FULL_CHROME_BACK_BUTTON_TAG
+import com.pocketshell.app.tmux.TMUX_SESSION_PAGER_OVERLAY_TAG
+import com.pocketshell.app.tmux.TMUX_SESSION_PAGER_PAGE_TAG_PREFIX
+import com.pocketshell.app.tmux.TMUX_SESSION_SCREEN_TAG
+import com.pocketshell.core.ssh.KnownHostsPolicy
+import com.pocketshell.core.ssh.SshConnection
+import com.pocketshell.core.ssh.SshKey
+import com.pocketshell.core.storage.AppDatabase
+import com.pocketshell.core.storage.entity.HostEntity
+import com.termux.view.TerminalView
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.runner.RunWith
+import java.io.File
+import java.io.FileOutputStream
+
+/**
+ * Issue #1206 (AC4) — DEVICE-TRUTH journey: a fresh pane whose FIRST
+ * `capture-pane` seed comes back EMPTY on a busy shared `-CC` channel still
+ * lands on a PAINTED Terminal grid, not fragments-over-black.
+ *
+ * ## Why this must inject the failing state synthetically (the #780 model)
+ *
+ * The maintainer's report is a fresh Claude session's first alt-screen frame
+ * being unrecoverable because the prewarm seed `capture-pane` came back empty
+ * (or the acquire wedged) on a startup-flooded `-CC` channel — even though the
+ * pane HAS content. The happy real-agent workbench structurally CANNOT enter
+ * that empty/wedged-first-capture state (a healthy fixture always captures
+ * content on the first try), which is exactly why AC4 permits — and this test
+ * uses — a #780 synthetic injection: [PrewarmSeedFaultTestOverride] forces the
+ * FIRST prewarm seed capture (after the real wire round-trip ran) to be TREATED
+ * as empty. Production never arms it (default 0), so this is a pure test hook.
+ *
+ * ## The journey
+ *
+ *  1. Seed exactly two same-host sessions A (attach) and B (the prewarm target),
+ *     each printing a unique marker, killing every other session so the switcher
+ *     lists only A + B (prewarm then targets exactly B's single pane).
+ *  2. Attach to A.
+ *  3. Open the in-session session switcher (swipe-down) — this fires
+ *     `prewarmLikelySwitchTargets`, prewarming B. The armed override forces B's
+ *     FIRST seed capture empty, driving the #1206 retry / deferred-reseed
+ *     recovery against a real pane that HAS content.
+ *  4. HARD-assert the injected fault was actually consumed by the prewarm seed
+ *     path (`PrewarmSeedFaultTestOverride.consumedCount >= 1`) — this is NOT a
+ *     vacuous pass: the #1206 code path provably ran.
+ *  5. Swipe forward to B (only two sessions → deterministically lands on B) and
+ *     HARD-assert B's terminal shows B's marker and is NOT blank — i.e. the
+ *     background retry / deferred reseed painted the full grid over what the
+ *     empty first capture would otherwise have left blank.
+ *
+ * ## Fail-first note (honest)
+ *
+ * The clean red→green for the retry logic is proven at the JVM layer
+ * (`TmuxSessionViewModelTest.prewarmSeedRetries*` — the grid stays blank without
+ * the retry, seeds with it). This connected journey is the on-device GREEN
+ * acceptance G4/G10 require for the black-screen fix: with the empty-first-
+ * capture injected, the user still lands on a painted B grid. (On the emulator,
+ * independent post-reveal blank-heal safety nets could also eventually repaint,
+ * so this test's teeth are the load-bearing "B is painted" assertion PLUS the
+ * hard "the #1206 fault was consumed" assertion, not a device red.)
+ *
+ * Uses ONLY the deterministic `agents` fixture (host port 2222), so it RUNS on
+ * the per-PR CI emulator-journey job — no toxiproxy, no
+ * `Assume.assumeFalse(isRunningOnCi())`, no self-skip.
+ */
+@RunWith(AndroidJUnit4::class)
+class Issue1206PrewarmEmptyCaptureSeedRetryJourneyE2eTest {
+
+    val compose = createAndroidComposeRule<MainActivity>()
+    private val grantPermissions = PreGrantPermissionsRule()
+
+    @get:Rule
+    val ruleChain: RuleChain = RuleChain
+        .outerRule(grantPermissions)
+        .around(SeedBeforeLaunchRule { seedBeforeLaunch() })
+        .around(compose)
+
+    private var seededKey: String? = null
+    private var seededHostRowTag: String? = null
+    private val timings = mutableListOf<String>()
+
+    private val pickerWaitMs: Long =
+        if (TerminalTestTimeouts.isRunningOnCi()) 60_000L else 20_000L
+
+    private val pickerReadyWaitMs: Long =
+        if (TerminalTestTimeouts.isRunningOnCi()) 120_000L else 45_000L
+
+    @After
+    fun tearDown() {
+        // Always disarm the process-global seam so it never leaks into a sibling
+        // test in the same instrumentation process.
+        PrewarmSeedFaultTestOverride.clear()
+        runCatching { compose.activityRule.scenario.moveToState(Lifecycle.State.RESUMED) }
+        seededKey?.let { key ->
+            runBlocking { runCatching { cleanupSeededSessions(key) } }
+        }
+    }
+
+    @Test
+    fun freshPaneWithEmptyFirstCaptureStillLandsOnPaintedGrid() { runBlocking {
+        val hostRowTag = requireNotNull(seededHostRowTag) { "seed-before-launch host row missing" }
+
+        // ---- (1) Attach to A.
+        compose.waitUntil(timeoutMillis = TerminalTestTimeouts.screenRenderPresenceTimeoutMs()) {
+            runCatching {
+                compose.onAllNodesWithTag(hostRowTag, useUnmergedTree = true)
+                    .fetchSemanticsNodes()
+                    .isNotEmpty()
+            }.getOrDefault(false)
+        }
+        compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick()
+        waitForSessionInPicker(
+            rule = compose,
+            sessionName = SESSION_A,
+            timeoutMs = pickerWaitMs,
+            onRepoke = { repokeFolderListFromHostRow(hostRowTag) },
+        )
+        compose.onNodeWithText(SESSION_A, useUnmergedTree = true).performClick()
+        compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertExists()
+        waitForTerminalViewAttached()
+        waitForTerminalContains(SESSION_A_MARKER, "initial attach to A")
+        captureViewport("issue1206-00-attached-$SESSION_A")
+
+        // ---- (2) Open the in-session session switcher (swipe-down). This fires
+        // prewarmLikelySwitchTargets → prewarms B, whose FIRST seed capture the
+        // armed override forces empty (the #1206 target state).
+        openSessionSwitcherViaSwipeDown()
+        waitForPagerReady()
+        // The picker must have enumerated B, otherwise prewarm has no target to
+        // seed (prewarmLikelySwitchTargets filters to non-current rows).
+        waitForSessionInPager(SESSION_B)
+
+        // ---- (3) HARD-assert the injected empty-first-capture fault was actually
+        // consumed by B's prewarm seed path — proves the #1206 code path ran (no
+        // vacuous pass). Re-poke the switcher once if prewarm has not fired yet.
+        val consumed = waitForForcedEmptyConsumed()
+        assertTrue(
+            "the forced empty-first-capture fault must be consumed by the prewarm seed path " +
+                "(the #1206 retry path must have run); consumedCount=" +
+                "${PrewarmSeedFaultTestOverride.consumedCount} seedAttemptCount=" +
+                "${PrewarmSeedFaultTestOverride.seedAttemptCount} (attempt=0 => prewarm never " +
+                "seeded B; attempt>0 => seeded but seam not hit)",
+            consumed,
+        )
+        recordTiming("forced_empty_consumed_count", PrewarmSeedFaultTestOverride.consumedCount.toLong())
+
+        // ---- (4) Switch to B via the pager. Only two sessions exist, so a
+        // forward swipe deterministically lands on B (the prewarmed target).
+        val landed = swipeSessionPagerForwardOnce(captureOpenAs = "issue1206-01-pager-open")
+        assertTrue(
+            "forward session-pager swipe must land on the prewarmed target '$SESSION_B'; " +
+                "landed on '$landed'",
+            landed == SESSION_B,
+        )
+        waitForTerminalViewAttached()
+
+        // ---- (5) LOAD-BEARING: B lands on a PAINTED grid — its marker visible,
+        // NOT blank — despite the empty first prewarm capture. The #1206 retry /
+        // deferred reseed recovered the full grid; without it the prewarmed grid
+        // would stay empty (fragments-over-black).
+        waitForTerminalContains(SESSION_B_MARKER, "B painted after empty-first-capture prewarm")
+        val bText = visibleTerminalText()
+        assertFalse(
+            "B's terminal must NOT be blank after an empty-first-capture prewarm — the #1206 " +
+                "retry/deferred-reseed must paint the full grid (transcript='${bText.take(200)}')",
+            bText.isBlank(),
+        )
+        captureViewport("issue1206-02-$SESSION_B-painted")
+
+        writeSummary(consumedCount = PrewarmSeedFaultTestOverride.consumedCount)
+        writeTimings()
+        Unit
+    } }
+
+    // ---------------------------------------------------------------- Gestures
+
+    /**
+     * Open the session pager with a swipe-DOWN on the top chrome, then wait for
+     * the overlay to appear. Copied from the #237 swipe-switch journey — the
+     * swipe surface wraps only the ~56dp top chrome, so an explicit multi-step
+     * downward drag clears the 72.dp open threshold.
+     */
+    private fun openSessionSwitcherViaSwipeDown() {
+        compose.onNodeWithTag(TMUX_FULL_BREADCRUMB_TAG, useUnmergedTree = true)
+            .performTouchInput {
+                down(Offset(centerX, centerY))
+                repeat(SWIPE_DOWN_STEPS) { moveBy(Offset(0f, SWIPE_DOWN_STEP_PX)) }
+                up()
+            }
+        compose.waitUntil(timeoutMillis = pickerWaitMs) {
+            compose.onAllNodesWithTag(TMUX_SESSION_PAGER_OVERLAY_TAG, useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
+        captureFullFrame("issue1206-switcher-open-fullframe")
+    }
+
+    /** Wait for the session pager to reach `Ready` (remote list-sessions resolved). */
+    private fun waitForPagerReady() {
+        val pickerReady = runCatching {
+            compose.waitUntil(timeoutMillis = pickerReadyWaitMs) {
+                val readyStatusVisible = compose
+                    .onAllNodes(
+                        hasText(READY_CURRENT_STATUS)
+                            .and(hasAnyAncestor(hasTestTag(TMUX_SESSION_PAGER_OVERLAY_TAG))),
+                        useUnmergedTree = true,
+                    ).fetchSemanticsNodes().isNotEmpty()
+                val loadingGone = compose
+                    .onAllNodesWithText(LOADING_PLACEHOLDER_STATUS, useUnmergedTree = true)
+                    .fetchSemanticsNodes().isEmpty()
+                readyStatusVisible && loadingGone
+            }
+            true
+        }.getOrDefault(false)
+        if (!pickerReady) captureFullFrame("issue1206-FAIL-pager-not-ready-fullframe")
+        assertTrue(
+            "session pager never reached Ready within ${pickerReadyWaitMs}ms",
+            pickerReady,
+        )
+    }
+
+    /** Wait until [sessionName]'s card is present in the open session pager. */
+    private fun waitForSessionInPager(sessionName: String) {
+        val present = runCatching {
+            compose.waitUntil(timeoutMillis = pickerReadyWaitMs) {
+                compose.onAllNodes(
+                    hasText(sessionName)
+                        .and(hasAnyAncestor(hasTestTag(TMUX_SESSION_PAGER_OVERLAY_TAG))),
+                    useUnmergedTree = true,
+                ).fetchSemanticsNodes().isNotEmpty()
+            }
+            true
+        }.getOrDefault(false)
+        if (!present) captureFullFrame("issue1206-FAIL-$sessionName-not-in-pager-fullframe")
+        assertTrue(
+            "session '$sessionName' must be enumerated in the switcher pager so prewarm can " +
+                "target it (the picker's remote list-sessions must include it)",
+            present,
+        )
+    }
+
+    /**
+     * Poll until the prewarm seed path has consumed the injected empty-capture
+     * fault (or the budget elapses). The prewarm fires when the switcher opens,
+     * so this must be awaited AFTER [openSessionSwitcherViaSwipeDown]. The
+     * switcher is held OPEN and untouched for the whole window: any interaction
+     * (dismiss/re-open) re-emits the picker state, which cancels an in-flight
+     * `prewarmRuntime` before it can build + seed the target — so we wait quietly
+     * and let a stable prewarm complete.
+     */
+    private fun waitForForcedEmptyConsumed(): Boolean {
+        val deadline = SystemClock.elapsedRealtime() + pickerReadyWaitMs
+        while (SystemClock.elapsedRealtime() < deadline) {
+            if (PrewarmSeedFaultTestOverride.consumedCount >= 1) return true
+            SystemClock.sleep(100)
+        }
+        return PrewarmSeedFaultTestOverride.consumedCount >= 1
+    }
+
+    /**
+     * Swipe the session pager one page forward and return the session the app
+     * lands on (read from the top-chrome session label). Copied from the #237
+     * swipe-switch journey.
+     */
+    private fun swipeSessionPagerForwardOnce(captureOpenAs: String): String {
+        captureFullFrame(captureOpenAs)
+        val previous = readActiveSessionName()
+        val currentPageIndex = onScreenPageIndex()
+        compose.onNodeWithTag(
+            "$TMUX_SESSION_PAGER_PAGE_TAG_PREFIX$currentPageIndex",
+            useUnmergedTree = true,
+        ).performTouchInput {
+            val midY = centerY
+            swipeWithVelocity(
+                start = Offset(right - SWIPE_PAGER_EDGE_INSET_PX, midY),
+                end = Offset(left + SWIPE_PAGER_EDGE_INSET_PX, midY),
+                endVelocity = SWIPE_PAGER_VELOCITY,
+                durationMillis = SWIPE_PAGER_DURATION_MS,
+            )
+        }
+        compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertExists()
+        return waitForActiveSessionChange(previous = previous)
+    }
+
+    private fun onScreenPageIndex(): Int {
+        var bestIndex = 1
+        var bestWidth = 0f
+        for (index in 1..MAX_PAGER_PAGES_PROBE) {
+            val nodes = compose.onAllNodesWithTag(
+                "$TMUX_SESSION_PAGER_PAGE_TAG_PREFIX$index",
+                useUnmergedTree = true,
+            ).fetchSemanticsNodes()
+            val node = nodes.firstOrNull() ?: continue
+            val width = node.boundsInRoot.width
+            if (width > bestWidth) {
+                bestWidth = width
+                bestIndex = index
+            }
+        }
+        return bestIndex
+    }
+
+    private fun readActiveSessionName(): String? {
+        val nodes = compose.onAllNodesWithTag(
+            TMUX_CONSOLIDATED_SESSION_LABEL_TAG,
+            useUnmergedTree = true,
+        ).fetchSemanticsNodes()
+        val node = nodes.firstOrNull() ?: return null
+        return node.config.getOrNull(SemanticsProperties.Text)?.firstOrNull()?.text
+    }
+
+    private fun waitForActiveSessionChange(previous: String?): String {
+        var current: String? = null
+        compose.waitUntil(timeoutMillis = pickerWaitMs) {
+            current = readActiveSessionName()
+            current != null && current != previous
+        }
+        return requireNotNull(current) {
+            "active session label never changed away from '$previous'"
+        }
+    }
+
+    // ---------------------------------------------------------------- Seeding
+
+    private fun readFixtureKey(): String =
+        InstrumentationRegistry.getInstrumentation()
+            .context
+            .assets
+            .open("test_key")
+            .bufferedReader()
+            .use { it.readText() }
+
+    private suspend fun seedBeforeLaunch() {
+        val key = readFixtureKey()
+        seededKey = key
+        try {
+            waitForSshFixtureReady(SshKey.Pem(key))
+            seedTwoSessions(key)
+            seededHostRowTag = seedDockerHost(key)
+            forceFlatHostDetailViewMode()
+            // Arm the #1206 synthetic seam BEFORE launch: the FIRST prewarm seed
+            // capture is treated as empty (a wedged/empty first `capture-pane`).
+            PrewarmSeedFaultTestOverride.setForcedEmptyFirstCaptures(1)
+        } catch (t: Throwable) {
+            PrewarmSeedFaultTestOverride.clear()
+            runCatching { cleanupSeededSessions(key) }
+            throw t
+        }
+    }
+
+    private suspend fun seedDockerHost(key: String): String {
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
+        val db = Room.databaseBuilder(appContext, AppDatabase::class.java, DATABASE_NAME)
+            .fallbackToDestructiveMigration(dropAllTables = true)
+            .build()
+        return try {
+            db.clearAllTables()
+            val storedKey = SshKeyStorage.persistKey(
+                context = appContext,
+                sshKeyDao = db.sshKeyDao(),
+                name = "issue1206-key-${System.currentTimeMillis()}",
+                content = key,
+            )
+            val hostId = db.hostDao().insert(
+                HostEntity(
+                    name = "Issue1206 Prewarm Empty Capture",
+                    hostname = DEFAULT_HOST,
+                    port = DEFAULT_PORT,
+                    username = DEFAULT_USER,
+                    keyId = storedKey.id,
+                    tmuxInstalled = true,
+                    lastBootstrapAt = System.currentTimeMillis(),
+                ),
+            )
+            HOST_ROW_TAG_PREFIX + hostId
+        } finally {
+            db.close()
+        }
+    }
+
+    /**
+     * Seed EXACTLY two same-host sessions (A + B), each printing its own idle
+     * marker, and kill every other session so the switcher lists only A + B —
+     * making the prewarm target exactly B's single pane (so the process-global
+     * forced-empty budget lands on B).
+     */
+    private suspend fun seedTwoSessions(key: String) {
+        val script = buildString {
+            appendLine("set -eu")
+            listOf(SESSION_A, SESSION_B).forEach { name ->
+                appendLine("tmux kill-session -t ${shellQuote(name)} 2>/dev/null || true")
+            }
+            appendLine(
+                "tmux list-sessions -F '#{session_name}' 2>/dev/null | " +
+                    "grep -vx ${shellQuote(SESSION_A)} | grep -vx ${shellQuote(SESSION_B)} | " +
+                    "while IFS= read -r s; do tmux kill-session -t \"\$s\" 2>/dev/null || true; done",
+            )
+            appendLine(
+                "tmux new-session -d -s ${shellQuote(SESSION_A)} " +
+                    shellQuote("printf '$SESSION_A_MARKER\\n'; exec sh"),
+            )
+            appendLine(
+                "tmux new-session -d -s ${shellQuote(SESSION_B)} " +
+                    shellQuote("printf '$SESSION_B_MARKER\\n'; exec sh"),
+            )
+            appendLine("sleep 1")
+            appendLine("tmux list-sessions")
+        }
+        val result = SshConnection.connect(
+            host = DEFAULT_HOST,
+            port = DEFAULT_PORT,
+            user = DEFAULT_USER,
+            key = SshKey.Pem(key),
+            knownHosts = KnownHostsPolicy.AcceptAll,
+            timeoutMs = 15_000,
+        ).mapCatching { session -> session.use { it.exec(script) } }
+        val exec = result.getOrNull()
+        assertTrue(
+            "expected two-session seeding to succeed; " +
+                "exception=${result.exceptionOrNull()} stderr='${exec?.stderr}'",
+            exec?.exitCode == 0,
+        )
+        Log.i(LOG_TAG, "seeded sessions: ${exec?.stdout?.trim()}")
+    }
+
+    private suspend fun cleanupSeededSessions(key: String) {
+        runCatching {
+            SshConnection.connect(
+                host = DEFAULT_HOST,
+                port = DEFAULT_PORT,
+                user = DEFAULT_USER,
+                key = SshKey.Pem(key),
+                knownHosts = KnownHostsPolicy.AcceptAll,
+                timeoutMs = 15_000,
+            ).mapCatching { session ->
+                session.use {
+                    it.exec(
+                        listOf(SESSION_A, SESSION_B).joinToString(separator = "; ") { name ->
+                            "tmux kill-session -t ${shellQuote(name)} 2>/dev/null || true"
+                        },
+                    )
+                }
+            }
+        }
+    }
+
+    private fun forceFlatHostDetailViewMode() {
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
+        appContext
+            .getSharedPreferences("app_settings", android.content.Context.MODE_PRIVATE)
+            .edit()
+            .putString("host_detail_view_mode", "Flat")
+            .commit()
+    }
+
+    private fun repokeFolderListFromHostRow(hostRowTag: String) {
+        runCatching {
+            val backTags = listOf(
+                TMUX_COMPACT_CHROME_BACK_BUTTON_TAG,
+                TMUX_FULL_CHROME_BACK_BUTTON_TAG,
+            )
+            for (tag in backTags) {
+                if (compose.onAllNodesWithTag(tag, useUnmergedTree = true)
+                        .fetchSemanticsNodes()
+                        .isNotEmpty()
+                ) {
+                    compose.onNodeWithTag(tag, useUnmergedTree = true).performClick()
+                    break
+                }
+            }
+            compose.waitUntil(timeoutMillis = TerminalTestTimeouts.screenRenderPresenceTimeoutMs()) {
+                runCatching {
+                    compose.onAllNodesWithTag(hostRowTag, useUnmergedTree = true)
+                        .fetchSemanticsNodes()
+                        .isNotEmpty()
+                }.getOrDefault(false)
+            }
+            compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick()
+        }
+    }
+
+    // ---------------------------------------------------------------- Terminal
+
+    private fun waitForTerminalViewAttached() {
+        compose.waitUntil(timeoutMillis = 30_000) {
+            var attached = false
+            compose.activityRule.scenario.onActivity { activity ->
+                val view = activity.window.decorView.findTerminalView()
+                attached = view?.currentSession != null && view.mEmulator != null
+            }
+            attached
+        }
+    }
+
+    private fun waitForTerminalContains(
+        expected: String,
+        label: String,
+        timeoutMillis: Long = TerminalTestTimeouts.terminalVisibilityTimeoutMs(),
+    ) {
+        var last = ""
+        val satisfied = runCatching {
+            compose.waitUntil(timeoutMillis = timeoutMillis) {
+                last = visibleTerminalText()
+                last.contains(expected)
+            }
+            true
+        }.getOrDefault(false)
+        if (!satisfied) writeText("failure-$label-visible-terminal.txt", last)
+        assertTrue(
+            "expected visible terminal for $label to contain '$expected' within " +
+                "${timeoutMillis}ms; got:\n$last",
+            satisfied,
+        )
+    }
+
+    private fun visibleTerminalText(): String {
+        var text = ""
+        compose.activityRule.scenario.onActivity { activity ->
+            text = activity.window.decorView
+                .findTerminalView()
+                ?.currentSession
+                ?.emulator
+                ?.screen
+                ?.transcriptText
+                .orEmpty()
+        }
+        return text
+    }
+
+    // ---------------------------------------------------------------- Artifacts
+
+    private fun captureViewport(name: String) {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.waitForIdleSync()
+        SystemClock.sleep(150)
+
+        var bitmap: Bitmap? = null
+        compose.activityRule.scenario.onActivity { activity ->
+            val view = activity.window.decorView.findTerminalView() ?: return@onActivity
+            if (view.width <= 0 || view.height <= 0) return@onActivity
+            val b = Bitmap.createBitmap(view.width, view.height, Bitmap.Config.ARGB_8888)
+            view.draw(Canvas(b))
+            bitmap = b
+        }
+        bitmap?.let { writeBitmap("$name-viewport", it) }
+        writeText("$name-visible-terminal.txt", visibleTerminalText())
+        bitmap?.recycle()
+    }
+
+    private fun captureFullFrame(name: String) {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.waitForIdleSync()
+        SystemClock.sleep(150)
+        var bitmap: Bitmap? = null
+        compose.activityRule.scenario.onActivity { activity ->
+            val view = activity.window.decorView
+            if (view.width <= 0 || view.height <= 0) return@onActivity
+            val b = Bitmap.createBitmap(view.width, view.height, Bitmap.Config.ARGB_8888)
+            view.draw(Canvas(b))
+            bitmap = b
+        }
+        bitmap?.let { writeBitmap(name, it) }
+        bitmap?.recycle()
+    }
+
+    private fun writeBitmap(name: String, bitmap: Bitmap): File {
+        val file = artifactFile("$name.png")
+        FileOutputStream(file).use { out ->
+            check(bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)) {
+                "failed to write bitmap to ${file.absolutePath}"
+            }
+        }
+        println("ISSUE1206_VIEWPORT ${file.absolutePath}")
+        return file
+    }
+
+    private fun writeText(name: String, text: String): File {
+        val file = artifactFile(name)
+        file.writeText(text)
+        println("ISSUE1206_TEXT ${file.absolutePath}")
+        return file
+    }
+
+    private fun writeTimings(): File {
+        val file = artifactFile("timings.txt")
+        file.writeText(timings.joinToString(separator = "\n", postfix = "\n"))
+        println("ISSUE1206_TIMINGS ${file.absolutePath}")
+        return file
+    }
+
+    private fun writeSummary(consumedCount: Int): File {
+        val file = artifactFile("summary.txt")
+        file.writeText(
+            buildString {
+                appendLine("test=Issue1206PrewarmEmptyCaptureSeedRetryJourneyE2eTest")
+                appendLine("issue=1206")
+                appendLine("fixture=tests/docker agents ($DEFAULT_HOST:$DEFAULT_PORT)")
+                appendLine("running_on_ci=${TerminalTestTimeouts.isRunningOnCi()}")
+                appendLine("session_a=$SESSION_A (attach)")
+                appendLine("session_b=$SESSION_B (prewarm target)")
+                appendLine("b_marker=$SESSION_B_MARKER")
+                appendLine("forced_empty_first_captures=1")
+                appendLine("forced_empty_consumed_count=$consumedCount")
+                appendLine(
+                    "scenario=prewarm B with an injected empty FIRST capture-pane; the " +
+                        "#1206 retry/deferred-reseed must still paint B's grid",
+                )
+                appendLine(
+                    "expectation=B's terminal shows '$SESSION_B_MARKER' and is NOT blank " +
+                        "after switching to it (painted grid, not fragments-over-black)",
+                )
+                appendLine("timings:")
+                timings.forEach { appendLine("  $it") }
+            },
+        )
+        return file
+    }
+
+    private fun artifactFile(name: String): File {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val mediaRoot = com.pocketshell.app.test.testArtifactsRoot(instrumentation.targetContext)
+        val dir = File(mediaRoot, "additional_test_output/$DEVICE_DIR_NAME")
+        check(dir.exists() || dir.mkdirs()) {
+            "could not create artifact directory ${dir.absolutePath}"
+        }
+        return File(dir, name)
+    }
+
+    private fun recordTiming(name: String, value: Long) {
+        val line = "$name=$value"
+        timings += line
+        println("ISSUE1206_TIMING $line")
+    }
+
+    private fun View.findTerminalView(): TerminalView? {
+        if (this is TerminalView) return this
+        if (this !is ViewGroup) return null
+        for (index in 0 until childCount) {
+            val match = getChildAt(index).findTerminalView()
+            if (match != null) return match
+        }
+        return null
+    }
+
+    private fun shellQuote(value: String): String =
+        "'" + value.replace("'", "'\"'\"'") + "'"
+
+    private companion object {
+        const val DATABASE_NAME: String = "pocketshell.db"
+        const val DEVICE_DIR_NAME: String = "issue1206-prewarm-empty-capture-seed-retry"
+        const val LOG_TAG: String = "Issue1206PrewarmSeed"
+
+        // Host/port/user come from the package-level DEFAULT_HOST/DEFAULT_PORT/
+        // DEFAULT_USER (backed by AgentsFixtureTarget), so a per-lane pool run
+        // points this journey at its own agents container.
+
+        const val SESSION_A: String = "issue1206-session-a"
+        const val SESSION_B: String = "issue1206-session-b"
+        const val SESSION_A_MARKER: String = "A1206-READY"
+        const val SESSION_B_MARKER: String = "B1206-READY"
+
+        const val SWIPE_DOWN_STEPS: Int = 8
+        const val SWIPE_DOWN_STEP_PX: Float = 80f
+        const val SWIPE_PAGER_EDGE_INSET_PX: Float = 20f
+        const val SWIPE_PAGER_VELOCITY: Float = 2_000f
+        const val SWIPE_PAGER_DURATION_MS: Long = 250L
+        const val MAX_PAGER_PAGES_PROBE: Int = 24
+
+        const val LOADING_PLACEHOLDER_STATUS: String = "loading same-host sessions"
+        const val READY_CURRENT_STATUS: String = "current"
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionRuntimeCache.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionRuntimeCache.kt
@@ -279,6 +279,11 @@ internal data class CachedTmuxRuntime(
     val paneProducerJobs: Map<String, Job>,
     val paneInputQueues: Map<String, TmuxPaneInputQueue>,
     val paneInputJobs: Map<String, Job>,
+    // Issue #1206: background seed-recovery jobs (bounded capture retry + one
+    // deferred reseed on first live %output) carried from a prewarmed runtime so
+    // a promoted-but-still-parked recovery job is cancelled on cache eviction /
+    // deactivate (closeCachedRuntime) instead of leaking until whole-VM teardown.
+    val paneSeedRecoveryJobs: Map<String, Job> = emptyMap(),
     val paneAgentJobs: Map<String, Job>,
     val paneAgentInputs: Map<String, Triple<String, String, String>>,
     val agentConversations: Map<String, com.pocketshell.app.session.AgentConversationUiState>,
@@ -308,6 +313,11 @@ internal suspend fun CachedTmuxRuntime.closeCachedRuntime(
     //
     // If a join times out we stop joining and fall through to the non-suspending
     // cleanup (queue close, producer detach, client close) so those still run.
+    // Issue #1206: cancel any parked seed-recovery job FIRST (a promoted
+    // prewarmed pane whose capture stayed empty parks on `outputFor().first()`).
+    // `cancel()` (not `cancelAndJoin`) — the parked flow-collect returns
+    // promptly on cancel and we must never block the bounded teardown on it.
+    paneSeedRecoveryJobs.values.forEach { it.cancel() }
     withTimeoutOrNull(detachTimeoutMs) {
         paneProducerJobs.values.forEach { it.cancelAndJoin() }
         paneInputJobs.values.forEach { it.cancelAndJoin() }

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -432,6 +432,20 @@ public class TmuxSessionViewModel @Inject constructor(
     private val seedCaptureTimeoutMs: Long = SEED_CAPTURE_TIMEOUT_MS
 
     /**
+     * Issue #1206: backoff (ms) between bounded prewarm seed-recovery capture
+     * retries ([schedulePrewarmSeedRecovery]). Defaults to the production value;
+     * a unit test may shorten it via [setPrewarmSeedRetryBackoffForTest] so the
+     * retry window doesn't need real wall-clock delay under a real-thread driver
+     * (the virtual-clock `runTest` driver auto-advances it either way).
+     */
+    private var prewarmSeedRetryBackoffMs: Long = PREWARM_SEED_RETRY_BACKOFF_MS
+
+    @androidx.annotation.VisibleForTesting
+    internal fun setPrewarmSeedRetryBackoffForTest(backoffMs: Long) {
+        prewarmSeedRetryBackoffMs = backoffMs
+    }
+
+    /**
      * Issue #576 (Slice A of #792): the dispatcher the structural reconcile's
      * pane-state APPLY step runs on. The `list-panes`/`capture-pane` IO runs
      * off-main on [reconcileDispatcher], but the resulting `_panes` /
@@ -2479,6 +2493,12 @@ public class TmuxSessionViewModel @Inject constructor(
     // would also stop them, but we want to release the bridge cleanly
     // mid-lifecycle when a single pane closes.
     private val paneProducerJobs: MutableMap<String, Job> = ConcurrentHashMap()
+    // Issue #1206: background seed-recovery jobs for ACTIVE-runtime panes whose
+    // seed capture came back empty/wedged (e.g. the surface-error recovery
+    // reseed in [reseedRecoveredSurface]). The prewarm path tracks its own local
+    // map per [PrewarmedPaneRuntime]; this is the active-runtime registry so the
+    // retry/deferred-reseed is cancellable when the runtime is deactivated.
+    private val paneSeedRecoveryJobs: MutableMap<String, Job> = ConcurrentHashMap()
     private val paneOutputActivityJobs: MutableMap<String, Job> = ConcurrentHashMap()
     // Issue #959: track the EXACT `-CC` client each pane's output producer +
     // input drain are currently bound to. A beyond-grace background→foreground
@@ -4608,6 +4628,11 @@ public class TmuxSessionViewModel @Inject constructor(
                 paneProducerJobs = panes.paneProducerJobs,
                 paneInputQueues = panes.paneInputQueues,
                 paneInputJobs = panes.paneInputJobs,
+                // Issue #1206: carry the prewarm seed-recovery jobs into the
+                // cache entry so a promoted-but-still-parked recovery job is
+                // cancelled on cache eviction / deactivate rather than leaking
+                // until whole-VM `bridgeScope` teardown.
+                paneSeedRecoveryJobs = panes.paneSeedRecoveryJobs,
                 paneAgentJobs = emptyMap(),
                 paneAgentInputs = emptyMap(),
                 agentConversations = emptyMap(),
@@ -4661,6 +4686,10 @@ public class TmuxSessionViewModel @Inject constructor(
         val paneInputQueues = LinkedHashMap<String, TmuxPaneInputQueue>()
         val paneInputJobs = LinkedHashMap<String, Job>()
         val paneProducerJobs = LinkedHashMap<String, Job>()
+        // Issue #1206: background seed-recovery jobs (bounded capture retry +
+        // one deferred reseed on the first live %output) for panes whose FIRST
+        // capture came back empty/error/timeout on a busy shared -CC channel.
+        val paneSeedRecoveryJobs = LinkedHashMap<String, Job>()
         val paneRows = LinkedHashMap<String, TmuxPaneState>()
         try {
             val parsed = response.output
@@ -4704,6 +4733,7 @@ public class TmuxSessionViewModel @Inject constructor(
                             paneProducerJobs = paneProducerJobs,
                             paneInputQueues = paneInputQueues,
                             paneInputJobs = paneInputJobs,
+                            paneSeedRecoveryJobs = paneSeedRecoveryJobs,
                         )
                     },
                 )
@@ -4711,7 +4741,7 @@ public class TmuxSessionViewModel @Inject constructor(
                 // Issue #448 (epic #432 slice C): also tap the prewarmed
                 // pane's shared output flow for new-port detection.
                 startPortDetectionForPane(paneId = pane.paneId, client = client)
-                seedPrewarmedPane(client, row)
+                seedPrewarmedPane(client, row, paneSeedRecoveryJobs)
             }
             return PrewarmedPaneRuntime(
                 panes = paneRows.values.toList(),
@@ -4719,6 +4749,7 @@ public class TmuxSessionViewModel @Inject constructor(
                 paneProducerJobs = paneProducerJobs,
                 paneInputQueues = paneInputQueues,
                 paneInputJobs = paneInputJobs,
+                paneSeedRecoveryJobs = paneSeedRecoveryJobs,
             )
         } catch (t: Throwable) {
             PrewarmedPaneRuntime(
@@ -4727,6 +4758,7 @@ public class TmuxSessionViewModel @Inject constructor(
                 paneProducerJobs = paneProducerJobs,
                 paneInputQueues = paneInputQueues,
                 paneInputJobs = paneInputJobs,
+                paneSeedRecoveryJobs = paneSeedRecoveryJobs,
             ).closePartialPrewarm()
             throw t
         }
@@ -4738,48 +4770,123 @@ public class TmuxSessionViewModel @Inject constructor(
         paneProducerJobs: MutableMap<String, Job>,
         paneInputQueues: MutableMap<String, TmuxPaneInputQueue>,
         paneInputJobs: MutableMap<String, Job>,
+        paneSeedRecoveryJobs: MutableMap<String, Job>,
     ) {
         val existing = paneRows[paneId] ?: return
         if (existing.surfaceError) return
         paneProducerJobs.remove(paneId)?.cancel()
         paneInputJobs.remove(paneId)?.cancel()
         paneInputQueues.remove(paneId)?.close()
+        // Issue #1206: the pane's feed failed — stop any background seed-recovery
+        // retry/deferred-reseed too so it doesn't reseed a dead surface.
+        paneSeedRecoveryJobs.remove(paneId)?.cancel()
         runCatching { existing.terminalState.detachExternalProducer() }
         paneRows[paneId] = existing.copy(surfaceError = true)
     }
 
-    private suspend fun seedPrewarmedPane(client: TmuxClient, pane: TmuxPaneState) {
+    private suspend fun seedPrewarmedPane(
+        client: TmuxClient,
+        pane: TmuxPaneState,
+        paneSeedRecoveryJobs: MutableMap<String, Job> = this.paneSeedRecoveryJobs,
+    ) {
         // Issue #468: the live %output producer is gated behind the seed.
         // appendRemoteOutput opens the gate when a snapshot lands; if the
         // capture fails (or anything throws) we must still open the gate so
         // buffered live output is flushed in order rather than swallowed.
-        var seeded = false
-        try {
-            // Issue #640: single-flight combined capture+cursor exchange (see
-            // [TmuxClient.captureWithCursor]) shared with the cold-open seed
-            // path so both pay one wire round-trip and restore the #259 cursor.
-            // Issue #926: the round-trip runs OFF Main on [seedIoDispatcher] with
-            // the short seed ceiling — the prewarm seed must never park the UI
-            // thread on a wedged channel either.
-            val combined = runCatching {
-                withContext(seedIoDispatcher) {
-                    client.captureWithCursor(
-                        pane.paneId,
-                        scrollbackLines = SEED_SCROLLBACK_LINES,
-                        timeoutMs = seedCaptureTimeoutMs,
-                    )
-                }
-            }.getOrNull() ?: return
-            val capture = combined.capture
-            if (capture.isError || capture.output.isEmpty()) return
-            val cursor = parseTmuxPaneCursor(combined.cursorReply)
-            pane.terminalState.appendRemoteOutput(
-                capture.output.toTerminalViewportBytes(cursor),
-            )
-            seeded = true
-        } finally {
-            if (!seeded) pane.terminalState.openSeedGateWithoutSeed()
+        val seeded = captureAndApplyPrewarmSeed(client, pane)
+        if (!seeded) {
+            // Open the gate immediately (do NOT hold live %output behind a
+            // multi-second retry) and recover in the background.
+            pane.terminalState.openSeedGateWithoutSeed()
+            // Issue #1206: the FIRST capture came back empty/error/timeout on a
+            // busy shared -CC channel (Claude floods at startup and can wedge the
+            // capture acquire). Without recovery the model grid stays empty and
+            // only future incremental %output paints → fragments-over-black. Retry
+            // a bounded number of times with backoff, and failing that re-arm ONE
+            // deferred reseed on the first live %output so the full grid is
+            // recovered the moment the pane produces anything.
+            schedulePrewarmSeedRecovery(client, pane, paneSeedRecoveryJobs)
         }
+    }
+
+    /**
+     * Issue #640/#926: one combined capture+cursor seed attempt for a prewarmed
+     * pane, run OFF Main on [seedIoDispatcher] with the short seed ceiling.
+     * Returns true and applies the snapshot (firing the full-repaint) when the
+     * capture returned content; false on empty/error/timeout/throw so the caller
+     * can open the gate and schedule recovery (#1206).
+     */
+    private suspend fun captureAndApplyPrewarmSeed(
+        client: TmuxClient,
+        pane: TmuxPaneState,
+    ): Boolean {
+        // Issue #1206 (connected AC4 proof, #780 synthetic-injection): a busy
+        // shared `-CC` channel can wedge/empty the FIRST `capture-pane` on a
+        // fresh prewarmed pane even though the pane HAS content — the exact
+        // non-happy state the happy real-agent workbench structurally cannot
+        // enter. This seam lets a connected journey force the first seed attempt
+        // to be TREATED as empty (deterministically, BEFORE the wire round-trip),
+        // driving the retry/deferred-reseed recovery against a real pane.
+        // [onSeedAttempt] is a diagnostic counter (how many times the prewarm
+        // seed path ran). Production never arms the seam (default 0), so this is
+        // a pure test hook.
+        PrewarmSeedFaultTestOverride.onSeedAttempt()
+        if (PrewarmSeedFaultTestOverride.consumeForcedEmpty(pane.paneId)) return false
+        val combined = runCatching {
+            withContext(seedIoDispatcher) {
+                client.captureWithCursor(
+                    pane.paneId,
+                    scrollbackLines = SEED_SCROLLBACK_LINES,
+                    timeoutMs = seedCaptureTimeoutMs,
+                )
+            }
+        }.getOrNull() ?: return false
+        val capture = combined.capture
+        if (capture.isError || capture.output.isEmpty()) return false
+        val cursor = parseTmuxPaneCursor(combined.cursorReply)
+        pane.terminalState.appendRemoteOutput(
+            capture.output.toTerminalViewportBytes(cursor),
+        )
+        return true
+    }
+
+    /**
+     * Issue #1206: background recovery for a prewarmed pane whose first seed
+     * capture came back empty/error/timeout. Runs on [bridgeScope] (never blocks
+     * the prewarm loop; cancelled with the VM), retries the capture a bounded
+     * number of times with backoff, and — if the capture stays wedged/empty for
+     * the whole window — re-arms ONE deferred reseed that fires the moment the
+     * first live %output lands (an idle pane emits nothing, so no wasted
+     * capture; when Claude finally paints a cell, one fresh capture seeds the
+     * full grid over the fragment-only screen).
+     */
+    private fun schedulePrewarmSeedRecovery(
+        client: TmuxClient,
+        pane: TmuxPaneState,
+        paneSeedRecoveryJobs: MutableMap<String, Job>,
+    ) {
+        val paneId = pane.paneId
+        paneSeedRecoveryJobs.remove(paneId)?.cancel()
+        val job = bridgeScope.launch {
+            // Bounded retry with backoff (≈PREWARM_SEED_RETRY_ATTEMPTS attempts
+            // over ≈PREWARM_SEED_RETRY_BACKOFF_MS spacing).
+            repeat(PREWARM_SEED_RETRY_ATTEMPTS) {
+                delay(prewarmSeedRetryBackoffMs)
+                if (captureAndApplyPrewarmSeed(client, pane)) return@launch
+            }
+            // Retry window exhausted while the capture stayed empty/wedged.
+            // Re-arm ONE deferred reseed: wait for the first live %output, then
+            // do a single fresh capture. The wait parks harmlessly for a truly
+            // idle pane (nothing to reseed) and is torn down with bridgeScope.
+            runCatching { client.outputFor(paneId).first() }
+                .onSuccess { captureAndApplyPrewarmSeed(client, pane) }
+        }
+        // The map is a per-runtime cancellation registry only (torn down with the
+        // runtime); a completed entry left behind is harmless (`cancel()` on a
+        // finished job is a no-op). Deliberately NOT self-removed on completion so
+        // a completion handler can't mutate the map while [closePartialPrewarm]
+        // iterates it.
+        paneSeedRecoveryJobs[paneId] = job
     }
 
     /**
@@ -5675,6 +5782,10 @@ public class TmuxSessionViewModel @Inject constructor(
         clientRef = null
         paneRows.clear()
         paneProducerJobs.clear()
+        // Issue #1206: cancel any active-runtime seed-recovery retry/deferred
+        // reseed — the runtime is being parked; a fresh attach/restore re-seeds.
+        paneSeedRecoveryJobs.values.forEach { it.cancel() }
+        paneSeedRecoveryJobs.clear()
         // Issue #959: the parked panes' producers will be re-bound to a (new
         // or same) client on restore via [rebindRestoredRuntimePaneJobsIfNeeded];
         // drop the stale-client bindings so a restore re-binds rather than
@@ -5812,6 +5923,14 @@ public class TmuxSessionViewModel @Inject constructor(
         paneInputQueues.putAll(runtime.paneInputQueues)
         paneInputJobs.clear()
         paneInputJobs.putAll(runtime.paneInputJobs)
+        // Issue #1206: a restored prewarmed runtime may still carry a parked
+        // seed-recovery job (its capture stayed empty). Move it into the
+        // active-runtime registry so it is cancelled on the next
+        // [deactivateCurrentRuntimeToCache] (and the whole-VM teardown) rather
+        // than leaking. Cancel any stale active entry first.
+        paneSeedRecoveryJobs.values.forEach { it.cancel() }
+        paneSeedRecoveryJobs.clear()
+        paneSeedRecoveryJobs.putAll(runtime.paneSeedRecoveryJobs)
         paneSurfaceRecoveryTimestamps.clear()
         paneAgentJobs.clear()
         // Issue #793: drop any pending load watchdogs from the prior runtime so
@@ -17963,9 +18082,15 @@ private data class PrewarmedPaneRuntime(
     val paneProducerJobs: Map<String, Job>,
     val paneInputQueues: Map<String, TmuxPaneInputQueue>,
     val paneInputJobs: Map<String, Job>,
+    // Issue #1206: background seed-recovery jobs (bounded capture retry + one
+    // deferred reseed on first live %output) for empty/wedged-capture panes.
+    val paneSeedRecoveryJobs: Map<String, Job> = emptyMap(),
 )
 
 private suspend fun PrewarmedPaneRuntime.closePartialPrewarm() {
+    // Issue #1206: cancel background seed recovery first so no retry/deferred
+    // reseed touches a pane whose producer we are tearing down.
+    paneSeedRecoveryJobs.values.forEach { it.cancel() }
     paneProducerJobs.values.forEach { it.cancelAndJoin() }
     paneInputJobs.values.forEach { it.cancelAndJoin() }
     paneInputQueues.values.forEach { it.close() }
@@ -18323,6 +18448,25 @@ internal const val SEED_SCROLLBACK_LINES: Int = 200
  * lands the snapshot, short enough that a wedge never reads as a freeze.
  */
 internal const val SEED_CAPTURE_TIMEOUT_MS: Long = 2_500L
+
+/**
+ * Issue #1206: how many times a prewarmed pane whose FIRST seed `capture-pane`
+ * came back empty/error/timeout retries the capture in the background before it
+ * falls back to a deferred reseed on the first live %output. Bounded so a
+ * genuinely-empty (brand-new, nothing-drawn-yet) pane isn't captured forever,
+ * but generous enough to ride out a Claude startup flood wedging the shared
+ * `-CC` capture acquire.
+ */
+internal const val PREWARM_SEED_RETRY_ATTEMPTS: Int = 3
+
+/**
+ * Issue #1206: backoff (ms) between prewarm seed-recovery capture retries. Three
+ * attempts at ≈1.6 s spacing covers the ≈5 s window a startup flood typically
+ * takes to drain enough for the capture acquire to succeed. The retry runs in
+ * the background on `bridgeScope`, so this spacing never blocks the prewarm loop
+ * or the UI thread.
+ */
+internal const val PREWARM_SEED_RETRY_BACKOFF_MS: Long = 1_600L
 
 /**
  * Issue #662: how long the post-reveal black-pane safety net waits before
@@ -18847,6 +18991,79 @@ internal object LivenessProbeTestOverride {
 
     fun failureThreshold(): Int =
         failureThresholdOverride ?: LivenessProbe.DEFAULT_FAILURE_THRESHOLD
+}
+
+/**
+ * Issue #1206: test-only synthetic-injection seam (the #780 model) for the
+ * prewarm seed path. A fresh Claude pane's FIRST `capture-pane` can come back
+ * empty/wedged on a busy shared `-CC` channel even though the pane HAS content
+ * — the exact non-happy state the happy real-agent workbench structurally
+ * cannot enter, which is why AC4 must inject it synthetically to prove the pane
+ * still lands on a PAINTED grid via the retry/deferred-reseed recovery.
+ *
+ * A connected journey arms [setForcedEmptyFirstCaptures] BEFORE launching the
+ * activity; the production seed path calls [consumeForcedEmpty] once per
+ * capture and, while budget remains, TREATS that capture as empty (after the
+ * real wire round-trip). [consumedCount] lets the journey hard-assert the
+ * injected fault was actually hit by the prewarm seed path (no vacuous pass),
+ * and the analogue of [LivenessProbeTestOverride]. Production keeps it at 0.
+ */
+internal object PrewarmSeedFaultTestOverride {
+    @Volatile
+    private var forcedEmptyFirstCaptures: Int = 0
+
+    /** Number of forced-empty captures actually consumed by the seed path. */
+    @Volatile
+    var consumedCount: Int = 0
+        private set
+
+    /**
+     * Diagnostic: how many times the prewarm seed path entered
+     * [captureAndApplyPrewarmSeed]. A connected journey reads this to tell
+     * "prewarm never seeded the target" (0) apart from "prewarm seeded but the
+     * seam wasn't armed / consumed" (>0, consumed 0).
+     */
+    @Volatile
+    var seedAttemptCount: Int = 0
+        private set
+
+    /**
+     * Arm the seam so the next [count] prewarm seed captures are treated as
+     * empty (simulating a wedged/empty first `capture-pane`). Resets the
+     * consumed + attempt counters so a journey can assert the injection landed.
+     */
+    fun setForcedEmptyFirstCaptures(count: Int) {
+        require(count >= 0) { "count must be >= 0" }
+        forcedEmptyFirstCaptures = count
+        consumedCount = 0
+        seedAttemptCount = 0
+    }
+
+    fun clear() {
+        forcedEmptyFirstCaptures = 0
+        consumedCount = 0
+        seedAttemptCount = 0
+    }
+
+    /** Record that the prewarm seed path ran once (diagnostic counter). */
+    @Synchronized
+    fun onSeedAttempt() {
+        seedAttemptCount += 1
+    }
+
+    /**
+     * Consume one unit of forced-empty budget for [paneId]. Returns true (and
+     * decrements the budget) when this capture must be treated as empty. The
+     * [paneId] is accepted for future per-pane targeting and diagnostic logging;
+     * the budget itself is process-global and consumed in call order.
+     */
+    @Synchronized
+    fun consumeForcedEmpty(paneId: String): Boolean {
+        if (forcedEmptyFirstCaptures <= 0) return false
+        forcedEmptyFirstCaptures -= 1
+        consumedCount += 1
+        return true
+    }
 }
 
 /**

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
@@ -14554,6 +14554,289 @@ class TmuxSessionViewModelTest {
         assertFalse("prewarm capture timeout must not mark tmux disconnected", prewarmClient.disconnected.value)
     }
 
+    // ---------------------------------------------------------------------
+    // Issue #1206 — fresh-pane seed: retry an empty/error/wedged first
+    // capture-pane instead of leaving the model grid empty (fragments-over-
+    // black on a fresh Claude session). Reproduce-first (D33/G10): each fixture
+    // makes the FIRST capture come back the non-happy way (empty / error /
+    // wedged-throw) while the pane HAS content the retry can seed — a happy
+    // fixture proves nothing (#847). The prewarmed pane is inspected DIRECTLY
+    // from the cached runtime (no switch/reveal reseed masking the RED), so the
+    // ONLY seeding path under test is the prewarm seed + #1206 retry.
+    //
+    // RED on base (no retry): the pane stays blank — the second (content)
+    // capture response is never consumed. GREEN with the fix: the background
+    // retry consumes it and seeds the full grid.
+    // ---------------------------------------------------------------------
+
+    /** Empty first capture, content on retry (G2 — empty-capture class). */
+    @Test
+    fun prewarmSeedRetriesEmptyFirstCaptureUntilContentSeedsTheGrid() = runTest(scheduler) {
+        val pane = prewarmSeedRetryPane(
+            firstCapture = CommandResponse(number = 2L, output = emptyList(), isError = false),
+        )
+        assertFalse(
+            "empty first capture must NOT leave the fresh pane blank — the #1206 retry " +
+                "must seed the full grid (transcript='${renderedTranscriptFrom(pane.terminalState)}')",
+            pane.terminalState.visibleScreenIsBlank(),
+        )
+        assertTrue(
+            "the retry's captured content must be on the pane grid",
+            renderedTranscriptFrom(pane.terminalState).contains(ISSUE_1206_SEED_MARKER),
+        )
+    }
+
+    /** Error first capture, content on retry (G2 — error-capture class). */
+    @Test
+    fun prewarmSeedRetriesErrorFirstCaptureUntilContentSeedsTheGrid() = runTest(scheduler) {
+        val pane = prewarmSeedRetryPane(
+            firstCapture = CommandResponse(
+                number = 2L,
+                output = listOf("capture-pane: no such pane"),
+                isError = true,
+            ),
+        )
+        assertFalse(
+            "error first capture must NOT leave the fresh pane blank — the #1206 retry must seed it",
+            pane.terminalState.visibleScreenIsBlank(),
+        )
+        assertTrue(
+            renderedTranscriptFrom(pane.terminalState).contains(ISSUE_1206_SEED_MARKER),
+        )
+    }
+
+    /**
+     * Wedged/thrown first capture (the busy -CC acquire timeout), content on
+     * retry (G2 — timeout/wedged-acquire class). Modeled by making the first
+     * `capture-pane` THROW (as `captureWithCursor` does on a wedged acquire),
+     * then succeed.
+     */
+    @Test
+    fun prewarmSeedRetriesWedgedFirstCaptureUntilContentSeedsTheGrid() = runTest(scheduler) {
+        val pane = prewarmSeedRetryPane(
+            firstCapture = null,
+            wedgeFirstCapture = true,
+        )
+        assertFalse(
+            "a wedged/thrown first capture must NOT leave the fresh pane blank — #1206 retry seeds it",
+            pane.terminalState.visibleScreenIsBlank(),
+        )
+        assertTrue(
+            renderedTranscriptFrom(pane.terminalState).contains(ISSUE_1206_SEED_MARKER),
+        )
+    }
+
+    /**
+     * Issue #1206 — deferred reseed on the first live %output. When the capture
+     * stays empty/wedged for the WHOLE bounded retry window, the pane opens its
+     * gate blank; the moment the pane emits its first live %output, ONE fresh
+     * capture reseeds the full grid. RED on base: no retry AND no deferred
+     * reseed, so an idle Claude pane whose non-visible first frame arrives after
+     * the seed window stays fragments-over-black. GREEN: the deferred reseed
+     * seeds the full grid on that first output.
+     */
+    @Test
+    fun prewarmDeferredReseedOnFirstOutputSeedsTheGridAfterExhaustedRetries() = runTest(scheduler) {
+        val runtimeCache = TmuxSessionRuntimeCache(maxEntries = 4)
+        val connector = QueueLeaseConnector(FakeSshSession())
+        val vm = newVm(
+            runtimeCache = runtimeCache,
+            sshLeaseManager = testLeaseManager(connector = connector, scope = this, idleTtlMillis = 0L),
+        )
+        vm.setConnectedBlankWatchdogAutoArmEnabledForTest(false)
+        vm.setPrewarmSeedRetryBackoffForTest(50L)
+        // Every capture across the inline attempt + all retries returns empty.
+        val prewarmClient = FakeTmuxClient().apply {
+            responses.addLast(
+                CommandResponse(
+                    number = 1L,
+                    output = listOf("%4\t@0\t\$0\trecent\trecent\t0"),
+                    isError = false,
+                ),
+            )
+        }
+        vm.setTmuxClientFactoryForTest { _, _, _ -> prewarmClient }
+        vm.replaceClientForTest(
+            hostId = 1L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            sessionName = "work",
+            client = FakeTmuxClient(),
+            session = FakeSshSession(),
+        )
+
+        vm.prewarmLikelySwitchTargets(listOf("recent"))
+        advanceUntilIdle()
+
+        val pane = runtimeCache.cachedRuntimesForHost(1L).single().panes.single { it.paneId == "%4" }
+        // The retry window is exhausted (all captures empty) — pane still blank,
+        // deferred reseed parked on the first live %output.
+        assertTrue(
+            "after an all-empty retry window the pane is blank until it produces output",
+            pane.terminalState.visibleScreenIsBlank(),
+        )
+
+        // The pane produces its first live %output — non-visible bytes (a cursor
+        // home escape) so the OUTPUT itself paints nothing: the deferred reseed
+        // is the only thing that can fill the grid. Queue the content the reseed
+        // capture will pick up, then emit.
+        prewarmClient.capturePaneResponses.addLast(
+            CommandResponse(number = 9L, output = listOf(ISSUE_1206_SEED_MARKER), isError = false),
+        )
+        prewarmClient.tryEmitPaneOutput("%4", "[H".toByteArray(Charsets.US_ASCII))
+        advanceUntilIdle()
+
+        assertFalse(
+            "the first live %output must trigger ONE deferred reseed that fills the grid " +
+                "(transcript='${renderedTranscriptFrom(pane.terminalState)}')",
+            pane.terminalState.visibleScreenIsBlank(),
+        )
+        assertTrue(
+            "the deferred reseed's captured content must be on the pane grid",
+            renderedTranscriptFrom(pane.terminalState).contains(ISSUE_1206_SEED_MARKER),
+        )
+    }
+
+    /**
+     * Drives a prewarm whose FIRST seed capture is [firstCapture] (or throws
+     * when [wedgeFirstCapture]) and whose RETRY capture returns the
+     * [ISSUE_1206_SEED_MARKER] content, then returns the cached prewarmed pane
+     * for the caller to assert on. Shared by the #1206 empty/error/wedged tests.
+     */
+    private fun TestScope.prewarmSeedRetryPane(
+        firstCapture: CommandResponse?,
+        wedgeFirstCapture: Boolean = false,
+    ): TmuxPaneState {
+        val runtimeCache = TmuxSessionRuntimeCache(maxEntries = 4)
+        val connector = QueueLeaseConnector(FakeSshSession())
+        val vm = newVm(
+            runtimeCache = runtimeCache,
+            sshLeaseManager = testLeaseManager(connector = connector, scope = this, idleTtlMillis = 0L),
+        )
+        vm.setConnectedBlankWatchdogAutoArmEnabledForTest(false)
+        vm.setPrewarmSeedRetryBackoffForTest(50L)
+        val prewarmClient = FakeTmuxClient().apply {
+            responses.addLast(
+                CommandResponse(
+                    number = 1L,
+                    output = listOf("%4\t@0\t\$0\trecent\trecent\t0"),
+                    isError = false,
+                ),
+            )
+            if (wedgeFirstCapture) {
+                // The first capture-pane THROWS (a wedged -CC acquire), then the
+                // retry succeeds — throwOnCommandPrefix does NOT consume a queued
+                // capture response, so only the content response is queued.
+                throwOnCommandPrefix = "capture-pane"
+                throwOnCommandException = TmuxClientException("capture-pane acquire wedged")
+                throwOnCommandRemaining = 1
+            } else {
+                capturePaneResponses.addLast(requireNotNull(firstCapture))
+            }
+            // The retry capture returns real content that must seed the grid.
+            capturePaneResponses.addLast(
+                CommandResponse(number = 8L, output = listOf(ISSUE_1206_SEED_MARKER), isError = false),
+            )
+        }
+        vm.setTmuxClientFactoryForTest { _, _, _ -> prewarmClient }
+        vm.replaceClientForTest(
+            hostId = 1L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            sessionName = "work",
+            client = FakeTmuxClient(),
+            session = FakeSshSession(),
+        )
+
+        vm.prewarmLikelySwitchTargets(listOf("recent"))
+        advanceUntilIdle()
+
+        return runtimeCache.cachedRuntimesForHost(1L).single().panes.single { it.paneId == "%4" }
+    }
+
+    /**
+     * Issue #1206 (recovery-job cancellation — the reviewer's #2 residual). A
+     * prewarmed pane whose seed capture stays empty for the WHOLE bounded retry
+     * window PARKS a recovery job on the first-live-%output wait. That job is
+     * promoted with the runtime into the cache entry; it MUST be cancelled when
+     * the cached runtime is evicted/closed (`closeCachedRuntime`) — not leaked
+     * as a parked coroutine until whole-VM `bridgeScope` teardown.
+     *
+     * Load-bearing assertion: after [closeCachedRuntime] the parked recovery job
+     * is CANCELLED (`isCancelled` / not `isActive`). Before the fix the cache
+     * entry did not carry the recovery job and `closeCachedRuntime` had nothing
+     * to cancel, so the job leaked — this test would fail (the job stays active).
+     */
+    @Test
+    fun prewarmSeedRecoveryJobIsCancelledOnCachedRuntimeClose() = runTest(scheduler) {
+        val runtimeCache = TmuxSessionRuntimeCache(maxEntries = 4)
+        val connector = QueueLeaseConnector(FakeSshSession())
+        val vm = newVm(
+            runtimeCache = runtimeCache,
+            sshLeaseManager = testLeaseManager(connector = connector, scope = this, idleTtlMillis = 0L),
+        )
+        vm.setConnectedBlankWatchdogAutoArmEnabledForTest(false)
+        vm.setPrewarmSeedRetryBackoffForTest(50L)
+        // Every capture (inline + all retries) returns empty → the recovery job
+        // exhausts its retries and PARKS on the first-live-%output wait.
+        val prewarmClient = FakeTmuxClient().apply {
+            responses.addLast(
+                CommandResponse(
+                    number = 1L,
+                    output = listOf("%4\t@0\t\$0\trecent\trecent\t0"),
+                    isError = false,
+                ),
+            )
+        }
+        vm.setTmuxClientFactoryForTest { _, _, _ -> prewarmClient }
+        vm.replaceClientForTest(
+            hostId = 1L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            sessionName = "work",
+            client = FakeTmuxClient(),
+            session = FakeSshSession(),
+        )
+
+        vm.prewarmLikelySwitchTargets(listOf("recent"))
+        advanceUntilIdle()
+
+        val runtime = runtimeCache.cachedRuntimesForHost(1L).single()
+        val recoveryJob = runtime.paneSeedRecoveryJobs["%4"]
+        assertNotNull(
+            "an all-empty-capture prewarm must carry its parked seed-recovery job into the " +
+                "cache entry so it is cancellable on eviction",
+            recoveryJob,
+        )
+        assertTrue(
+            "the parked recovery job must be active (waiting on first %output) before teardown",
+            recoveryJob!!.isActive,
+        )
+
+        // Cache eviction / deactivate must cancel the parked recovery job.
+        runtime.closeCachedRuntime()
+        advanceUntilIdle()
+
+        assertTrue(
+            "the parked seed-recovery job MUST be cancelled on cache close — a promoted " +
+                "prewarmed pane's recovery job must not leak until whole-VM teardown",
+            recoveryJob.isCancelled,
+        )
+        assertFalse(
+            "the cancelled recovery job must no longer be active",
+            recoveryJob.isActive,
+        )
+    }
+
     @Test
     fun switchingToPrewarmedTargetUsesCachedRuntimeFirstFramePath() = runTest(scheduler) {
         TmuxSessionLatencyTelemetry.resetForTest()
@@ -17830,6 +18113,11 @@ class TmuxSessionViewModelTest {
     }
 
     private companion object {
+        // Issue #1206: distinctive content the retry / deferred-reseed capture
+        // returns, so the pane transcript can be asserted to CONTAIN it (proving
+        // the reseed — not some incidental output — filled the grid).
+        const val ISSUE_1206_SEED_MARKER = "ISSUE1206-RESEED-CONTENT-fresh-pane-grid"
+
         // Issue #713: the slow-feed / real-async terminal tests below keep
         // `factoryScope` on real `Dispatchers.IO` (#708 judgment call A), so
         // they drain the real bridge feed / final marker via real-wall-clock

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -439,6 +439,21 @@ JOURNEY_CLASSES=(
   # Uses ONLY the deterministic agents:2222 fixture (the black state is injected LOCALLY
   # on the emulator, no toxiproxy) and does NOT self-skip on CI, so it belongs here.
   "$FQCN_PREFIX.RedrawFullViewportReseedJourneyE2eTest"
+  # ADDED (#1206 — fresh Claude pane whose FIRST prewarm capture-pane comes back EMPTY on a
+  # busy shared -CC channel lands fragments-over-black instead of a painted grid). The prewarm
+  # seed is single-shot: seedPrewarmedPane returned on the empty/wedged first capture and only
+  # future incremental %output painted → the initial Claude TUI frame was unrecoverable. This
+  # journey seeds exactly two sessions (A attach + B prewarm target), opens the in-session
+  # switcher to fire prewarmLikelySwitchTargets, and uses a #780 synthetic injection
+  # (PrewarmSeedFaultTestOverride) to force B's FIRST seed capture EMPTY while the pane HAS
+  # content — the exact non-happy state the happy real-agent workbench structurally cannot
+  # enter. It HARD-asserts the fault was consumed by the prewarm seed path (the #1206 code
+  # path ran — no vacuous pass) AND that B lands on a PAINTED grid (its marker visible, not
+  # blank) after switching to it (the retry/deferred-reseed recovered the full grid). The clean
+  # red→green for the retry is at the JVM layer (TmuxSessionViewModelTest.prewarmSeedRetries*);
+  # this is the on-device GREEN acceptance (G4/G10). Deterministic agents:2222 only, no
+  # toxiproxy, no CI self-skip — belongs in this per-push subset.
+  "$FQCN_PREFIX.Issue1206PrewarmEmptyCaptureSeedRetryJourneyE2eTest"
   # ADDED (#1181 — BLACK terminal on tapping the connection notification / background→
   # foreground resume while the FGS keeps the connection ALIVE): a port-forward pin (#1159
   # Part 3) SUPPRESSES the bounded-grace teardown, so the VM never stashes a pendingReattach

--- a/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurfaceState.kt
+++ b/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurfaceState.kt
@@ -143,9 +143,21 @@ class TerminalSurfaceState(
      * not Compose state: remote output can arrive in tight bursts, and each
      * burst should redraw the Android [TerminalView] without recomposing the
      * Compose wrapper.
+     *
+     * `replay = 1` (PocketShell #1206): mirrors the #879 fix on
+     * [_fullRepaintRequests]. On a fresh-pane seed / post-switch reveal the pane
+     * is seeded and its render request fires BEFORE the late-subscribing
+     * [TerminalSurface] binds its collector. With `replay = 0` that request was
+     * silently dropped (`extraBufferCapacity = 1` + `DROP_OLDEST` only buffers
+     * for an ALREADY-subscribed slow collector, never for a not-yet-subscribed
+     * one), and an idle Claude pane emits no follow-up byte to compensate — so
+     * the freshly seeded rows were left unpainted (fragments-over-black). With
+     * `replay = 1` a collector that subscribes after the emit still receives the
+     * most-recent render request and redraws. Harmless in steady state: one
+     * coalesced render on bind, then the #469 dirty path resumes.
      */
     private val _renderRequests = MutableSharedFlow<Unit>(
-        replay = 0,
+        replay = 1,
         extraBufferCapacity = 1,
         onBufferOverflow = BufferOverflow.DROP_OLDEST,
     )
@@ -364,29 +376,39 @@ class TerminalSurfaceState(
      * `capture-pane` snapshot before future `%output` events arrive.
      */
     fun appendRemoteOutput(bytes: ByteArray) {
-        if (bytes.isEmpty()) return
-        val activeBridge = bridge ?: return
-        val clean = if (sanitizeQueryResponses) {
+        val activeBridge = bridge
+        val clean = if (bytes.isNotEmpty() && sanitizeQueryResponses) {
             TerminalQueryResponseSanitizer.sanitize(bytes)
         } else {
             bytes
         }
-        if (clean.isEmpty()) return
-        // Issue #468: apply this seed snapshot, then release any live `%output`
-        // bytes that were buffered behind the seed gate while the
-        // `capture-pane` round-trip was in flight — in their original arrival
-        // order, after the seed. When the gate was never closed (plain SSH
-        // surface, or a re-seed) this is just an ordinary feed plus an
-        // already-open-gate no-op.
-        activeBridge.seedThenOpenGate(clean)
-        _output.tryEmit(clean)
+        if (activeBridge != null && clean.isNotEmpty()) {
+            // Issue #468: apply this seed snapshot, then release any live
+            // `%output` bytes that were buffered behind the seed gate while the
+            // `capture-pane` round-trip was in flight — in their original arrival
+            // order, after the seed. When the gate was never closed (plain SSH
+            // surface, or a re-seed) this is just an ordinary feed plus an
+            // already-open-gate no-op.
+            activeBridge.seedThenOpenGate(clean)
+            _output.tryEmit(clean)
+            bufferTick.value = bufferTick.value + 1
+        }
         // Issue #721: a re-seed applies the captured snapshot to the emulator
         // buffer but does not change which rows the renderer's #469 dirty cache
         // considers stale — so a plain render request would repaint only freshly
         // changed cells and leave the rest of the existing screen black. Signal a
         // FULL repaint so every row is redrawn straight from the buffer.
+        //
+        // Issue #1206: fire the full repaint even when the capture came back
+        // EMPTY (or sanitized to empty). An idle alt-screen pane (Claude at rest)
+        // already holds its frame in the emulator buffer, but with the request
+        // gated behind the empty short-circuit it got neither fresh content NOR a
+        // repaint — so the #469 dirty cache clipped the next draw to changed rows
+        // over a black canvas and the pane stayed black until the agent happened
+        // to touch a cell. Firing here (above the empty short-circuits) repaints
+        // the existing buffer from a clean slate. Combined with the #879/#1206
+        // `replay = 1` flows, a late-subscribing surface still receives it.
         _fullRepaintRequests.tryEmit(Unit)
-        bufferTick.value = bufferTick.value + 1
     }
 
     /**
@@ -398,6 +420,13 @@ class TerminalSurfaceState(
      */
     fun openSeedGateWithoutSeed() {
         bridge?.openGateFlushingPending()
+        // Issue #1206: a fresh/empty-capture seed leaves the emulator holding
+        // whatever the idle alt-screen pane already had (or nothing). Fire a FULL
+        // repaint so an idle pane redraws its existing buffer from a clean slate
+        // instead of staying black behind the #469 dirty cache — the same
+        // idle-pane gap the empty-capture branch in [appendRemoteOutput] closes.
+        // Coalesced + `replay = 1`, so this is at worst one extra redraw on bind.
+        _fullRepaintRequests.tryEmit(Unit)
     }
 
     /**
@@ -429,6 +458,18 @@ class TerminalSurfaceState(
      */
     internal fun emitFullRepaintRequestForTesting(): Boolean =
         _fullRepaintRequests.tryEmit(Unit)
+
+    /**
+     * Test-only seam (PocketShell #1206): fire a plain render request exactly as
+     * a Termux screen-update callback does, WITHOUT a real session. Lets a unit
+     * test reproduce the fresh-pane / post-switch reveal ordering — the render
+     * request fires BEFORE the fresh [TerminalSurface]'s collector subscribes —
+     * and assert that with `replay = 1` a late subscriber still receives the
+     * most-recent request (with `replay = 0` it was silently dropped, leaving the
+     * freshly seeded rows unpainted over black).
+     */
+    internal fun emitRenderRequestForTesting(): Boolean =
+        _renderRequests.tryEmit(Unit)
 
     /**
      * Matcher used by [flowOfMatches] to extract tap-target candidates from

--- a/shared/core-terminal/src/test/java/com/pocketshell/core/terminal/ui/TerminalSurfaceStateRenderRequestLateSubscribeTest.kt
+++ b/shared/core-terminal/src/test/java/com/pocketshell/core/terminal/ui/TerminalSurfaceStateRenderRequestLateSubscribeTest.kt
@@ -1,0 +1,136 @@
+package com.pocketshell.core.terminal.ui
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.yield
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure-JVM render-layer regression for PocketShell #1206 — the late-subscribe
+ * drop of a PLAIN render request on the fresh-pane seed / post-switch reveal
+ * path.
+ *
+ * ## What this guards
+ *
+ * On a fresh-pane seed / post-switch reveal the pane is seeded (or its idle
+ * frame is already in the emulator buffer) and a render request fires BEFORE the
+ * late-subscribing [com.pocketshell.core.terminal.ui.TerminalSurface] binds its
+ * render collector. When [TerminalSurfaceState.renderRequests] was a
+ * `replay = 0` `MutableSharedFlow` (`extraBufferCapacity = 1` +
+ * `DROP_OLDEST` only buffers for an ALREADY-subscribed slow collector, never for
+ * a not-yet-subscribed one), that request `tryEmit` fired while NO collector was
+ * attached, so the late-subscribing [com.termux.view.TerminalView] never
+ * received it. An idle Claude pane emits no follow-up byte to compensate, so the
+ * freshly seeded rows were left unpainted — the #966/#879 fragments-over-black
+ * class recurring on a fresh session (#1206, sibling of the #879 full-repaint
+ * drop this mirrors).
+ *
+ * The fix makes `_renderRequests` `replay = 1`, mirroring the #879
+ * `_fullRepaintRequests` fix, so a collector that subscribes AFTER the render
+ * emit still receives the most-recent request and redraws.
+ *
+ * ## Red→green
+ *
+ * - With `replay = 0` (base/unfixed): [emitFirstThenSubscribe] times out — the
+ *   late collector never observes the request → FAIL.
+ * - With `replay = 1` (fixed): the late collector observes the replayed request
+ *   → PASS.
+ *
+ * Runs on the host JVM via [runBlocking] — no Robolectric, no Compose, no PTY,
+ * deterministic. Wired into the Unit job by living under `src/test`.
+ */
+class TerminalSurfaceStateRenderRequestLateSubscribeTest {
+
+    /**
+     * The #1206 ordering: the seed/reveal fires the render request, and ONLY
+     * AFTERWARDS does the fresh surface's collector subscribe. With `replay = 1`
+     * the late subscriber must still receive the request; with `replay = 0` it
+     * is dropped and this fails by timing out.
+     */
+    @Test
+    fun `late subscriber after the render request still receives it`() = runBlocking {
+        val state = TerminalSurfaceState()
+
+        // 1) A render request fires BEFORE any collector exists — exactly what a
+        //    fresh-pane seed / reveal does while the fresh TerminalSurface has
+        //    not yet bound its render collector.
+        val emitted = state.emitRenderRequestForTesting()
+        assertTrue("the render request must be accepted by the flow", emitted)
+
+        // 2) NOW the fresh TerminalSurface subscribes (post-reveal). This is the
+        //    late subscriber that drops the signal under replay = 0.
+        val received = CompletableDeferred<Unit>()
+        val collectorJob = launch(Dispatchers.Unconfined) {
+            state.renderRequests.collect {
+                if (!received.isCompleted) received.complete(Unit)
+            }
+        }
+        yield()
+
+        // 3) With replay = 1 the late subscriber gets the most-recent request and
+        //    would redraw; with replay = 0 this await times out (the #1206 drop).
+        withTimeout(1_000) { received.await() }
+        collectorJob.cancel()
+    }
+
+    /**
+     * Sanity: a collector already attached at emit time still receives the
+     * request (the steady-state render path), so the replay change does not
+     * regress the always-worked already-subscribed ordering.
+     */
+    @Test
+    fun `subscriber attached before the render request also receives it`() = runBlocking {
+        val state = TerminalSurfaceState()
+
+        val received = CompletableDeferred<Unit>()
+        val collectorJob = launch(Dispatchers.Unconfined) {
+            state.renderRequests.collect {
+                if (!received.isCompleted) received.complete(Unit)
+            }
+        }
+        yield()
+
+        assertTrue(state.emitRenderRequestForTesting())
+
+        withTimeout(1_000) { received.await() }
+        collectorJob.cancel()
+    }
+
+    /**
+     * Documents the RED explicitly: a fresh state that has never had a collector
+     * still holds exactly ONE replayed request for the first late subscriber
+     * (`replay = 1`). If this ever reverts to `replay = 0`, the `withTimeout`
+     * throws and the test fails.
+     */
+    @Test
+    fun `the most recent render request is replayed to the first late subscriber`() = runBlocking {
+        val state = TerminalSurfaceState()
+        // Two emits before any subscriber — coalesced; the latest is replayed.
+        state.emitRenderRequestForTesting()
+        state.emitRenderRequestForTesting()
+
+        val received = CompletableDeferred<Unit>()
+        val collectorJob = launch(Dispatchers.Unconfined) {
+            state.renderRequests.collect {
+                if (!received.isCompleted) received.complete(Unit)
+            }
+        }
+        yield()
+
+        try {
+            withTimeout(1_000) { received.await() }
+        } catch (e: TimeoutCancellationException) {
+            throw AssertionError(
+                "replay = 0 regression (#1206): a render request emitted before the first " +
+                    "subscriber was dropped, so a freshly seeded pane is left unpainted",
+                e,
+            )
+        }
+        collectorJob.cancel()
+    }
+}


### PR DESCRIPTION
Closes #1206. Black-screen audit #1208 (data-path — fresh-Claude-session leg).

A fresh pane whose first `capture-pane` returns empty/wedged on a busy shared -CC channel stayed model-empty → fragments-over-black. Fix: open the gate immediately, bounded background retry (3×/~5s) + one deferred reseed on first live `%output`; fire full-repaint on empty capture; `_renderRequests replay=1` (mirrors #879). Recovery jobs cancelled on teardown/cached-close/deactivate (no leak).

Verification: reviewer reproduced red→green (empty/error/wedged fixtures) + the cancellation red→green; reseed/reveal adjacency (#973/#640) green; scope clean (TmuxClient.kt untouched). AC4 connected journey wired + hard-asserts `consumedCount>=1`+B-painted — its on-device green is owed from the batched emulator-journey run (contention-only local block, not a harness flaw; reopen if CI's single-emulator lane also can't reach the path). Orchestrator gate: compile + seed/replay/cache tests green.