### PR TITLE
tmux: recover pane-output overflow by reseed-and-reattach, not a dead surfaceError latch (#1205)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/diagnostics/ConnectionLogHostMirrorReconnectDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/diagnostics/ConnectionLogHostMirrorReconnectDockerTest.kt
@@ -437,6 +437,7 @@ class ConnectionLogHostMirrorReconnectDockerTest {
             CommandResponse(number = 0L, output = emptyList(), isError = false)
 
         override fun outputFor(paneId: String): Flow<ControlEvent.Output> = emptyFlow()
+        override fun drainPaneOutputBacklog(paneId: String): Int = 0
 
         override fun close() = Unit
 

--- a/app/src/androidTest/java/com/pocketshell/app/portfwd/ForwardingNotificationE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/portfwd/ForwardingNotificationE2eTest.kt
@@ -639,6 +639,7 @@ class ForwardingNotificationE2eTest {
             CommandResponse(number = 0L, output = emptyList(), isError = false)
 
         override fun outputFor(paneId: String): Flow<ControlEvent.Output> = emptyFlow()
+        override fun drainPaneOutputBacklog(paneId: String): Int = 0
 
         override fun close() {
             disconnectedState.value = true

--- a/app/src/androidTest/java/com/pocketshell/app/proof/PaneOutputOverflowRecoveryJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/PaneOutputOverflowRecoveryJourneyE2eTest.kt
@@ -1,0 +1,810 @@
+package com.pocketshell.app.proof
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.os.SystemClock
+import android.util.Log
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.lifecycle.ViewModelProvider
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.BackgroundGraceTestOverride
+import com.pocketshell.app.MainActivity
+import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
+import com.pocketshell.app.hosts.SshKeyStorage
+import com.pocketshell.app.tmux.OVERFLOW_RECOVERY_MAX_ATTEMPTS
+import com.pocketshell.app.tmux.TMUX_SESSION_ERROR_TAG
+import com.pocketshell.app.tmux.TMUX_SESSION_RECONNECT_TAG
+import com.pocketshell.app.tmux.TMUX_SESSION_SCREEN_TAG
+import com.pocketshell.app.tmux.TMUX_TERMINAL_SURFACE_ERROR_TAG
+import com.pocketshell.app.tmux.TMUX_TERMINAL_SURFACE_RECREATE_TAG
+import com.pocketshell.app.tmux.TmuxSessionLatencyTelemetry
+import com.pocketshell.app.tmux.TmuxSessionViewModel
+import com.pocketshell.core.ssh.KnownHostsPolicy
+import com.pocketshell.core.ssh.SshConnection
+import com.pocketshell.core.ssh.SshKey
+import com.pocketshell.core.storage.AppDatabase
+import com.pocketshell.core.storage.entity.HostEntity
+import com.pocketshell.core.terminal.bridge.TerminalSeedGateOverflowException
+import com.termux.view.TerminalView
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+
+/**
+ * Issue #1205 — DEVICE-TRUTH journey for the maintainer's black-screen class where a pane
+ * whose per-pane delivery backlog (or 2 MB seed gate) OVERFLOWS under a sustained high-output
+ * burst latched a permanently-dead `surfaceError` "Recreate terminal" card instead of
+ * self-healing.
+ *
+ * ## The bug (2026-07-03 black-screen audit on #874)
+ *
+ * Per-pane `%output` delivery is a bounded `Channel(4096)` fed by non-blocking `trySend`. Under
+ * a sustained Claude alt-screen redraw burst with a contended main thread the channel overflows
+ * and drops. On the FIRST dropped frame the app cancelled the pane producer, detached the pane,
+ * and latched `surfaceError` — a permanently dead pane the blank/stale watchdog and heal oracle
+ * both early-return on, so nothing self-heals and the user must tap "Recreate terminal". The
+ * 2 MB seed-gate overflow latched the same way. The KDoc on
+ * [com.pocketshell.core.tmux.TmuxClient.outputBacklogOverflows] already prescribes the correct
+ * behavior: this is LOCAL renderer backpressure, NOT a transport disconnect, so recover by
+ * RESEEDING from `capture-pane` — a transient burst costs one reseed, not the pane.
+ *
+ * ## What this journey PROVES on the REAL on-device path (D33 / G4 / G10)
+ *
+ * The JVM/Robolectric proof ([com.pocketshell.app.tmux.PaneOutputOverflowRecoveryTest]) covers
+ * the state-machine logic and the real `trySend`-drop drain. This is the on-device residual the
+ * reviewer flagged BLOCKED: the RENDER correctness of the detach → reattach → reseed ordering on
+ * a real terminal emulator against real Docker tmux. Attach to a real `agents`-fixture tmux
+ * session running a full-viewport banner, then:
+ *
+ *  - **[backlogOverflowSelfHealsWithContentInsteadOfDeadSurfaceErrorCard]** — the maintainer's
+ *    reported LIVE-output backlog class. Wipe the LOCAL emulator to black (the REMOTE tmux grid
+ *    keeps the full banner → transport GUARANTEED LIVE), then trip a REAL backlog overflow through
+ *    the same private handler the `outputBacklogOverflows` collector calls. GREEN: NO dead
+ *    `surfaceError` "Recreate terminal" card, a FRESH `capture-pane` reseed fires (the
+ *    recompose-immune "reseed actually ran" signal), the banner content is RESTORED, the producer
+ *    is REATTACHED to the LIVE client (live %output resumes), and the session stays Connected with
+ *    NO reconnect surface. On base the pane latches `surfaceError` → the card covers the terminal
+ *    (RED).
+ *  - **[seedGateOverflowSelfHealsInsteadOfDeadSurfaceErrorCard]** — the OTHER overflow class
+ *    (the 2 MB seed-gate feed-failure), on-device (G2 class coverage on the real path).
+ *  - **[sustainedUnrecoverableOverflowExhaustsBudgetAndLandsOnRecoveryCard]** — the GIVE-UP
+ *    class: a channel that keeps overflowing after each reseed must NOT loop into a reseed storm.
+ *    After the bounded retry budget ([OVERFLOW_RECOVERY_MAX_ATTEMPTS]) is exhausted the pane DOES
+ *    land on the actionable `surfaceError` card exactly once.
+ *
+ * No `Assume.assumeFalse(isRunningOnCi())` on the load-bearing assertions — the failing state is
+ * injected synthetically (the #780 model: a real 4096-deep channel overflow / 2 MB feed can't be
+ * forced deterministically on the swiftshader emulator), and everything DOWNSTREAM of the trigger
+ * — drain → `capture-pane` reseed → producer reattach → render — runs on the REAL client/transport.
+ * Wired into `scripts/ci-journey-suite.sh` so it RUNS on the per-PR emulator-journey job.
+ */
+@RunWith(AndroidJUnit4::class)
+class PaneOutputOverflowRecoveryJourneyE2eTest {
+
+    // Issue #788/#848: launch-owned `createAndroidComposeRule<MainActivity>()` (NOT
+    // `createEmptyComposeRule()` + a hand-rolled `ActivityScenario.launch`) so the Compose test
+    // clock drives the SAME foreground MainActivity the Termux `TerminalView` interop child is
+    // placed into. The remote banner tmux session + DB host row are seeded BEFORE launch by
+    // [SeedBeforeLaunchRule] in the RuleChain below.
+    val compose = createAndroidComposeRule<MainActivity>()
+
+    @get:Rule
+    val ruleChain: org.junit.rules.RuleChain = org.junit.rules.RuleChain
+        .outerRule(PreGrantPermissionsRule())
+        .around(SeedBeforeLaunchRule { seedBeforeLaunch() })
+        .around(compose)
+
+    private lateinit var fixtureKey: String
+    private lateinit var hostRowTag: String
+
+    private suspend fun seedBeforeLaunch() {
+        BackgroundGraceTestOverride.setForTest(null)
+        TmuxSessionLatencyTelemetry.resetForTest()
+        val key = readFixtureKey()
+        fixtureKey = key
+        waitForSshFixtureReady(SshKey.Pem(key))
+        seedBannerSession(key)
+        hostRowTag = seedDockerHost(key)
+    }
+
+    @After
+    fun tearDown() {
+        BackgroundGraceTestOverride.setForTest(null)
+        if (::fixtureKey.isInitialized) {
+            runCatching { runBlocking { cleanupRemoteTmuxSession(fixtureKey) } }
+        }
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // (1) Live-output backlog overflow — the maintainer's reported class — self-heals with
+    //     content, NOT a dead surfaceError card.
+    // -----------------------------------------------------------------------------------------
+
+    @Test
+    fun backlogOverflowSelfHealsWithContentInsteadOfDeadSurfaceErrorCard() { runBlocking {
+        attachSeededTmuxSession(hostRowTag)
+        waitForVisibleTerminal("initial banner") { it.contains(BANNER_MARKER) }
+        waitForConnected("initial attach")
+        val paneId = firstVisiblePaneId()
+        assertFalse("precondition: pane not errored before overflow", activePaneSurfaceError())
+        capturePaintedRows("issue1205-backlog-00-attached")
+
+        // Wipe the LOCAL emulator to black so the reseed's content-restoration is OBSERVABLE.
+        // The REMOTE tmux grid still holds the banner → the transport is GUARANTEED LIVE, and a
+        // fresh `capture-pane` will restore it. Real ESC (0x1B) fed straight into the emulator.
+        feedFrameToEmulator("[2J[H")
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        capturePaintedRows("issue1205-backlog-01-black")
+
+        val capturesBefore = capturePaneCount(paneId)
+
+        // ===== Trip a REAL live-output backlog overflow (the reported class). =====
+        tripBacklogOverflow(paneId, droppedEvents = 1)
+
+        // ----- GREEN: NO dead surfaceError "Recreate terminal" card. -----
+        assertHealsNoSurfaceErrorCard("backlog overflow")
+
+        // ----- GREEN: a FRESH capture-pane reseed actually ran (recompose-immune signal). -----
+        val capturesAfter = waitForNewCapturePane(
+            "backlog-reseed",
+            paneId,
+            baseline = capturesBefore,
+            timeoutMillis = RESTORE_TIMEOUT_MS,
+        )
+        assertTrue(
+            "REGRESSION (#1205): a backlog overflow must RESEED the pane from tmux's server-side " +
+                "grid (a fresh capture-pane), not latch surfaceError; captures before=$capturesBefore " +
+                "after=$capturesAfter",
+            capturesAfter > capturesBefore,
+        )
+
+        // ----- GREEN: the banner content is RESTORED (self-heal WITH content). -----
+        val visibleAfter = waitForVisibleTerminal(
+            "banner restored",
+            timeoutMillis = RESTORE_TIMEOUT_MS,
+        ) { bannerRowCount(it) >= MIN_RESTORED_BANNER_ROWS }
+        assertTrue(
+            "the reseed must restore the FULL banner content (>= $MIN_RESTORED_BANNER_ROWS rows); " +
+                "found ${bannerRowCount(visibleAfter)}",
+            bannerRowCount(visibleAfter) >= MIN_RESTORED_BANNER_ROWS,
+        )
+        capturePaintedRows("issue1205-backlog-02-healed")
+
+        // ----- GREEN: producer REATTACHED to the LIVE client (live %output resumes). -----
+        assertProducerReattachedToLiveClient(paneId, "backlog overflow")
+
+        // ----- DISCRIMINATOR: still Connected, no reconnect (renderer backpressure, not a drop). -----
+        assertNoVisibleReconnect("post-backlog-heal")
+        assertTrue(
+            "session must stay Connected after the overflow heal (renderer backpressure, no " +
+                "reconnect), observed=${currentConnectionStatus()}",
+            currentConnectionStatus() is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+        assertFalse("the tmux client must NOT be disconnected", clientDisconnected())
+        writeSummary("backlog", "live-output pane delivery backlog Channel(4096) overflow")
+    } }
+
+    // -----------------------------------------------------------------------------------------
+    // (2) Seed-gate 2 MB overflow — the OTHER class (G2), on the real path.
+    // -----------------------------------------------------------------------------------------
+
+    @Test
+    fun seedGateOverflowSelfHealsInsteadOfDeadSurfaceErrorCard() { runBlocking {
+        attachSeededTmuxSession(hostRowTag)
+        waitForVisibleTerminal("initial banner") { it.contains(BANNER_MARKER) }
+        waitForConnected("initial attach")
+        val paneId = firstVisiblePaneId()
+        assertFalse("precondition: pane not errored before overflow", activePaneSurfaceError())
+
+        feedFrameToEmulator("[2J[H")
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        val capturesBefore = capturePaneCount(paneId)
+
+        // ===== Trip a REAL 2 MB seed-gate overflow (the feed-failure class). =====
+        tripSeedGateOverflow(paneId)
+
+        assertHealsNoSurfaceErrorCard("seed-gate overflow")
+        val capturesAfter = waitForNewCapturePane(
+            "seedgate-reseed",
+            paneId,
+            baseline = capturesBefore,
+            timeoutMillis = RESTORE_TIMEOUT_MS,
+        )
+        assertTrue(
+            "REGRESSION (#1205): a seed-gate overflow must RESEED from capture-pane, not latch " +
+                "surfaceError; captures before=$capturesBefore after=$capturesAfter",
+            capturesAfter > capturesBefore,
+        )
+        val visibleAfter = waitForVisibleTerminal(
+            "banner restored",
+            timeoutMillis = RESTORE_TIMEOUT_MS,
+        ) { bannerRowCount(it) >= MIN_RESTORED_BANNER_ROWS }
+        assertTrue(
+            "the seed-gate reseed must restore the FULL banner content; found " +
+                "${bannerRowCount(visibleAfter)}",
+            bannerRowCount(visibleAfter) >= MIN_RESTORED_BANNER_ROWS,
+        )
+        assertProducerReattachedToLiveClient(paneId, "seed-gate overflow")
+        assertNoVisibleReconnect("post-seedgate-heal")
+        assertTrue(
+            "session must stay Connected after the seed-gate heal, observed=${currentConnectionStatus()}",
+            currentConnectionStatus() is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+        writeSummary("seedgate", "2 MB seed-gate live-buffer overflow (feed-failure)")
+    } }
+
+    // -----------------------------------------------------------------------------------------
+    // (3) Bounded-retry EXHAUSTION — a still-saturated channel must NOT reseed-storm; after the
+    //     budget it lands on the actionable surfaceError "Recreate terminal" card.
+    // -----------------------------------------------------------------------------------------
+
+    @Test
+    fun sustainedUnrecoverableOverflowExhaustsBudgetAndLandsOnRecoveryCard() { runBlocking {
+        attachSeededTmuxSession(hostRowTag)
+        waitForVisibleTerminal("initial banner") { it.contains(BANNER_MARKER) }
+        waitForConnected("initial attach")
+        val paneId = firstVisiblePaneId()
+        assertFalse("precondition: pane not errored before overflow", activePaneSurfaceError())
+
+        // The first OVERFLOW_RECOVERY_MAX_ATTEMPTS overflows RESEED within the budget. Wait for each
+        // recovery to FULLY complete — a fresh capture-pane reseed AND the in-flight slot RELEASED
+        // (the deterministic [waitUntilOverflowRecoveryIdle] seam) — before the next trip, so the
+        // next overflow is counted against the budget rather than de-duped as a still-in-flight burst
+        // signal. No local black-wipe here (unlike the self-heal tests): a black TerminalView at the
+        // exhaustion moment would race the latch->card surface swap; the reseed's capture-pane
+        // telemetry fires regardless, so the budget still accumulates deterministically.
+        repeat(OVERFLOW_RECOVERY_MAX_ATTEMPTS) { attempt ->
+            val capturesBefore = capturePaneCount(paneId)
+            tripBacklogOverflow(paneId, droppedEvents = attempt + 1)
+            val capturesAfter = waitForNewCapturePane(
+                "exhaustion-reseed-${attempt + 1}",
+                paneId,
+                baseline = capturesBefore,
+                timeoutMillis = RESTORE_TIMEOUT_MS,
+            )
+            assertTrue(
+                "attempt ${attempt + 1} is WITHIN budget — the pane must reseed (fresh capture), " +
+                    "not latch; captures before=$capturesBefore after=$capturesAfter",
+                capturesAfter > capturesBefore,
+            )
+            waitUntilProducerActive(paneId, "attempt ${attempt + 1} reattach")
+            // Wait deterministically for the recovery's `finally` to release the in-flight slot,
+            // so the next trip is counted against the budget (not de-duped as IN_FLIGHT).
+            waitUntilOverflowRecoveryIdle(paneId, "attempt ${attempt + 1}")
+            assertFalse(
+                "attempt ${attempt + 1} is within budget — the pane must NOT be latched yet",
+                activePaneSurfaceError(),
+            )
+        }
+
+        // The (budget + 1)th overflow, with the channel STILL saturated, exhausts the budget — the
+        // pane now lands on the actionable card exactly once (no infinite reseed loop).
+        tripBacklogOverflow(paneId, droppedEvents = 99)
+
+        // LOAD-BEARING (G6): the `surfaceError` STATE that `latchPaneSurfaceError` sets — the card
+        // (`TerminalSurfaceErrorState`) is a pure render of exactly this flag, gated on nothing else
+        // for the shown pane. On base a FIRST overflow already latches this; with the fix ONLY the
+        // (budget+1)th does, after two silent reseeds. Assert it flips true and STAYS latched (no
+        // reseed storm un-latches it).
+        compose.waitUntil(timeoutMillis = RESTORE_TIMEOUT_MS) { activePaneSurfaceError() }
+        assertTrue(
+            "Issue #1205: after $OVERFLOW_RECOVERY_MAX_ATTEMPTS reseeds a STILL-saturated channel " +
+                "must land on the bounded surfaceError give-up state (no infinite reseed storm)",
+            activePaneSurfaceError(),
+        )
+
+        // And the actionable "Recreate terminal" card renders from that state (the user-visible
+        // give-up affordance). Capture the artifact regardless so a card-render gap is diagnosable.
+        val cardShown = runCatching {
+            compose.waitUntil(timeoutMillis = RESTORE_TIMEOUT_MS) {
+                compose.onAllNodesWithTag(TMUX_TERMINAL_SURFACE_ERROR_TAG, useUnmergedTree = true)
+                    .fetchSemanticsNodes().isNotEmpty()
+            }
+            true
+        }.getOrDefault(false)
+        capturePaintedRows("issue1205-exhaustion-card")
+        assertTrue(
+            "Issue #1205: the bounded-retry exhaustion must render the actionable 'Recreate " +
+                "terminal' card (surfaceError=${activePaneSurfaceError()})",
+            cardShown,
+        )
+        compose.onNodeWithTag(TMUX_TERMINAL_SURFACE_ERROR_TAG, useUnmergedTree = true).assertExists()
+        compose.onNodeWithTag(TMUX_TERMINAL_SURFACE_RECREATE_TAG, useUnmergedTree = true).assertExists()
+        writeSummary("exhaustion", "bounded-retry exhaustion lands on the Recreate-terminal card")
+    } }
+
+    // -------------------------------------------------------------------- Overflow triggers
+
+    /**
+     * Trip a REAL live-output backlog overflow via the SAME private handler the
+     * `outputBacklogOverflows` collector calls ([TmuxSessionViewModel.handleTerminalOutputBacklogOverflow]).
+     * Only the trigger is synthetic (the #780 model); drain → capture-pane reseed → producer
+     * reattach all run on the REAL client/transport.
+     */
+    private fun tripBacklogOverflow(paneId: String, droppedEvents: Int) {
+        compose.activityRule.scenario.onActivity { activity ->
+            ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+                .handleTerminalOutputBacklogOverflowForTest(paneId, droppedEvents)
+        }
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+    }
+
+    /** Trip a REAL 2 MB seed-gate overflow via the same production handler its feed-failure calls. */
+    private fun tripSeedGateOverflow(paneId: String) {
+        compose.activityRule.scenario.onActivity { activity ->
+            ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+                .handleTerminalSeedGateOverflowForTest(
+                    paneId = paneId,
+                    overflow = TerminalSeedGateOverflowException(
+                        pendingBytes = 2_000_000,
+                        incomingBytes = 100_000,
+                        maxBytes = 2_097_152,
+                    ),
+                )
+        }
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+    }
+
+    // -------------------------------------------------------------------- Assertions
+
+    private fun assertHealsNoSurfaceErrorCard(label: String) {
+        // Give the async recovery a beat to run, then assert the dead card never appears. If the
+        // fix regressed, the pane latches surfaceError SYNCHRONOUSLY, so a short settle is enough.
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        SystemClock.sleep(500)
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        assertEquals(
+            "REGRESSION (#1205): $label must NOT latch the dead surfaceError card — it must " +
+                "reseed-and-reattach",
+            0,
+            compose.onAllNodesWithTag(TMUX_TERMINAL_SURFACE_ERROR_TAG, useUnmergedTree = true)
+                .fetchSemanticsNodes().size,
+        )
+        assertEquals(
+            "REGRESSION (#1205): $label must NOT show a 'Recreate terminal' button",
+            0,
+            compose.onAllNodesWithTag(TMUX_TERMINAL_SURFACE_RECREATE_TAG, useUnmergedTree = true)
+                .fetchSemanticsNodes().size,
+        )
+        assertFalse(
+            "REGRESSION (#1205): $label must NOT leave the pane in surfaceError",
+            activePaneSurfaceError(),
+        )
+    }
+
+    private fun assertProducerReattachedToLiveClient(paneId: String, label: String) {
+        waitUntilProducerActive(paneId, label)
+        var producerClient: Int? = null
+        var liveClient: Int? = null
+        compose.activityRule.scenario.onActivity { activity ->
+            val vm = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+            producerClient = vm.paneProducerClientIdentityForTest(paneId)
+            liveClient = vm.currentClientIdentityForTest()
+        }
+        assertTrue(
+            "REGRESSION (#1205): after the $label heal the pane producer must be REATTACHED and " +
+                "bound to the LIVE client (producer=$producerClient live=$liveClient) — live %output " +
+                "resumes with no user action",
+            producerClient != null && producerClient == liveClient,
+        )
+    }
+
+    private fun waitUntilProducerActive(paneId: String, label: String) {
+        compose.waitUntil(timeoutMillis = RESTORE_TIMEOUT_MS) {
+            var active = false
+            compose.activityRule.scenario.onActivity { activity ->
+                active = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+                    .paneProducerActiveForTest(paneId)
+            }
+            active
+        }
+    }
+
+    /** Wait deterministically for an in-flight overflow recovery to fully complete (slot released). */
+    private fun waitUntilOverflowRecoveryIdle(paneId: String, label: String) {
+        compose.waitUntil(timeoutMillis = RESTORE_TIMEOUT_MS) {
+            var inFlight = true
+            compose.activityRule.scenario.onActivity { activity ->
+                inFlight = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+                    .paneOverflowRecoveryInFlightForTest(paneId)
+            }
+            !inFlight
+        }
+    }
+
+    // -------------------------------------------------------------------- VM introspection
+
+    private fun firstVisiblePaneId(): String {
+        var paneId: String? = null
+        compose.activityRule.scenario.onActivity { activity ->
+            paneId = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+                .panes.value.firstOrNull()?.paneId
+        }
+        return checkNotNull(paneId) { "no visible pane after attach" }
+    }
+
+    private fun activePaneSurfaceError(): Boolean {
+        var errored = false
+        compose.activityRule.scenario.onActivity { activity ->
+            errored = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+                .panes.value.firstOrNull()?.surfaceError ?: false
+        }
+        return errored
+    }
+
+    private fun clientDisconnected(): Boolean {
+        var disconnected = false
+        compose.activityRule.scenario.onActivity { activity ->
+            disconnected = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+                .clientDisconnectedForTest()
+        }
+        return disconnected
+    }
+
+    private fun currentConnectionStatus(): TmuxSessionViewModel.ConnectionStatus {
+        var status: TmuxSessionViewModel.ConnectionStatus = TmuxSessionViewModel.ConnectionStatus.Idle
+        compose.activityRule.scenario.onActivity { activity ->
+            status = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+                .connectionStatus.value
+        }
+        return status
+    }
+
+    private fun capturePaneCount(paneId: String): Int =
+        TmuxSessionLatencyTelemetry.snapshot()
+            .count { it.name == "capture_pane" && it.paneId == paneId }
+
+    private fun waitForNewCapturePane(
+        label: String,
+        paneId: String,
+        baseline: Int,
+        timeoutMillis: Long,
+    ): Int {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val deadline = SystemClock.elapsedRealtime() + timeoutMillis
+        var count = baseline
+        while (SystemClock.elapsedRealtime() < deadline) {
+            instrumentation.waitForIdleSync()
+            count = capturePaneCount(paneId)
+            if (count > baseline) return count
+            SystemClock.sleep(100)
+        }
+        writeText(
+            "failure-$label-capture-pane.txt",
+            "baseline=$baseline observed=$count pane=$paneId\n" +
+                "capture_pane spans:\n" +
+                TmuxSessionLatencyTelemetry.snapshot()
+                    .filter { it.name == "capture_pane" }
+                    .joinToString("\n") { it.toArtifactLine() },
+        )
+        return count
+    }
+
+    // -------------------------------------------------------------------- Emulator feed
+
+    private fun feedFrameToEmulator(frame: String) {
+        val bytes = frame.toByteArray(Charsets.UTF_8)
+        var fed = false
+        compose.activityRule.scenario.onActivity { activity ->
+            val view = activity.window.decorView.findTerminalView() ?: return@onActivity
+            val emulator = view.mEmulator ?: return@onActivity
+            emulator.append(bytes, bytes.size)
+            view.invalidate()
+            fed = true
+        }
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        assertTrue("expected to feed the frame to the live emulator", fed)
+    }
+
+    // -------------------------------------------------------------------- Attach / wait
+
+    private fun attachSeededTmuxSession(hostRowTag: String) {
+        compose.waitUntil(timeoutMillis = TerminalTestTimeouts.screenRenderPresenceTimeoutMs()) {
+            runCatching {
+                compose.onAllNodesWithTag(hostRowTag, useUnmergedTree = true)
+                    .fetchSemanticsNodes().isNotEmpty()
+            }.getOrDefault(false)
+        }
+        compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick()
+        compose.waitUntil(timeoutMillis = TerminalTestTimeouts.terminalVisibilityTimeoutMs()) {
+            runCatching {
+                compose.onAllNodesWithText(SESSION_NAME, useUnmergedTree = true)
+                    .fetchSemanticsNodes().isNotEmpty()
+            }.getOrDefault(false)
+        }
+        compose.onNodeWithText(SESSION_NAME, useUnmergedTree = true).performClick()
+        compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertExists()
+        waitForTerminalViewAttached()
+    }
+
+    private fun waitForTerminalViewAttached() {
+        compose.waitUntil(timeoutMillis = 30_000) {
+            var attached = false
+            compose.activityRule.scenario.onActivity { activity ->
+                val view = activity.window.decorView.findTerminalView()
+                attached = view?.currentSession != null && view.mEmulator != null
+            }
+            attached
+        }
+    }
+
+    private fun waitForConnected(label: String) {
+        compose.waitUntil(timeoutMillis = CONNECTED_TIMEOUT_MS) {
+            currentConnectionStatus() is TmuxSessionViewModel.ConnectionStatus.Connected
+        }
+        assertTrue(
+            "expected Connected after $label, observed=${currentConnectionStatus()}",
+            currentConnectionStatus() is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+    }
+
+    private fun waitForVisibleTerminal(
+        label: String,
+        timeoutMillis: Long = TerminalTestTimeouts.terminalVisibilityTimeoutMs(),
+        predicate: (String) -> Boolean,
+    ): String {
+        var last = ""
+        val satisfied = runCatching {
+            compose.waitUntil(timeoutMillis = timeoutMillis) {
+                last = visibleTerminalText()
+                predicate(last)
+            }
+            true
+        }.getOrDefault(false)
+        if (!satisfied) writeText("failure-$label-visible-terminal.txt", last)
+        assertTrue("expected visible terminal for $label; got:\n$last", predicate(last))
+        return last
+    }
+
+    private fun visibleTerminalText(): String {
+        var text = ""
+        compose.activityRule.scenario.onActivity { activity ->
+            text = activity.window.decorView
+                .findTerminalView()?.currentSession?.emulator?.screen?.transcriptText.orEmpty()
+        }
+        return text
+    }
+
+    private fun assertNoVisibleReconnect(label: String) {
+        assertEquals(
+            "expected no disconnect band for $label", 0,
+            compose.onAllNodesWithTag(TMUX_SESSION_ERROR_TAG, useUnmergedTree = true)
+                .fetchSemanticsNodes().size,
+        )
+        assertEquals(
+            "expected no Tap Reconnect button for $label", 0,
+            compose.onAllNodesWithTag(TMUX_SESSION_RECONNECT_TAG, useUnmergedTree = true)
+                .fetchSemanticsNodes().size,
+        )
+        listOf("Reconnecting", "Disconnected", "Tap Reconnect").forEach { text ->
+            assertEquals(
+                "expected no visible '$text' text for $label", 0,
+                compose.onAllNodesWithText(text, substring = true, useUnmergedTree = true)
+                    .fetchSemanticsNodes().size,
+            )
+        }
+    }
+
+    /** Count distinct numbered banner rows (`ISSUE1205-BANNER row NN`) in the visible buffer. */
+    private fun bannerRowCount(text: String): Int =
+        Regex("$BANNER_MARKER row (\\d{2})").findAll(text).map { it.groupValues[1] }.toSet().size
+
+    // -------------------------------------------------------------------- Fixture
+
+    private fun readFixtureKey(): String =
+        InstrumentationRegistry.getInstrumentation()
+            .context.assets.open("test_key").bufferedReader().use { it.readText() }
+
+    private suspend fun seedDockerHost(key: String): String {
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
+        val db = Room.databaseBuilder(appContext, AppDatabase::class.java, DATABASE_NAME)
+            .fallbackToDestructiveMigration(dropAllTables = true)
+            .build()
+        return try {
+            db.clearAllTables()
+            val storedKey = SshKeyStorage.persistKey(
+                context = appContext,
+                sshKeyDao = db.sshKeyDao(),
+                name = "issue1205-key-${System.currentTimeMillis()}",
+                content = key,
+            )
+            val hostId = db.hostDao().insert(
+                HostEntity(
+                    name = "Issue1205 Overflow Recovery",
+                    hostname = DEFAULT_HOST,
+                    port = DEFAULT_PORT,
+                    username = DEFAULT_USER,
+                    keyId = storedKey.id,
+                    tmuxInstalled = true,
+                    lastBootstrapAt = System.currentTimeMillis(),
+                ),
+            )
+            HOST_ROW_TAG_PREFIX + hostId
+        } finally {
+            db.close()
+        }
+    }
+
+    /** Seed a full-viewport banner tmux session so a post-overflow `capture-pane` restores content. */
+    private suspend fun seedBannerSession(key: String) {
+        val bannerLines = (1..40).joinToString("") {
+            "$BANNER_MARKER row %02d filler abcdefghijklmnopqrstuvwxyz\\n".format(it)
+        }
+        val payload = "printf '$bannerLines'; while true; do sleep 3600; done"
+        val script = buildString {
+            appendLine("set -eu")
+            appendLine("tmux kill-session -t ${shellQuote(SESSION_NAME)} 2>/dev/null || true")
+            appendLine("tmux new-session -d -s ${shellQuote(SESSION_NAME)} ${shellQuote(payload)}")
+            appendLine("sleep 2")
+            appendLine("tmux list-sessions")
+        }
+        val result = SshConnection.connect(
+            host = DEFAULT_HOST,
+            port = DEFAULT_PORT,
+            user = DEFAULT_USER,
+            key = SshKey.Pem(key),
+            knownHosts = KnownHostsPolicy.AcceptAll,
+            timeoutMs = 15_000,
+        ).mapCatching { session -> session.use { it.exec(script) } }
+        val exec = result.getOrNull()
+        assertTrue(
+            "expected tmux banner seeding to succeed; exception=${result.exceptionOrNull()} " +
+                "stderr='${exec?.stderr}'",
+            exec?.exitCode == 0,
+        )
+        Log.i(LOG_TAG, "seeded banner session: ${exec?.stdout?.trim()}")
+    }
+
+    private suspend fun cleanupRemoteTmuxSession(key: String) {
+        runCatching {
+            SshConnection.connect(
+                host = DEFAULT_HOST,
+                port = DEFAULT_PORT,
+                user = DEFAULT_USER,
+                key = SshKey.Pem(key),
+                knownHosts = KnownHostsPolicy.AcceptAll,
+                timeoutMs = 15_000,
+            ).mapCatching { session ->
+                session.use { it.exec("tmux kill-session -t ${shellQuote(SESSION_NAME)} 2>/dev/null || true") }
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------- Artifacts
+
+    private fun capturePaintedRows(name: String): Int {
+        val bitmap = renderViewportBitmap() ?: return 0
+        writeBitmap("$name-viewport", bitmap)
+        writeText("$name-visible-terminal.txt", visibleTerminalText())
+        val rows = paintedRowCount(bitmap)
+        bitmap.recycle()
+        return rows
+    }
+
+    private fun renderViewportBitmap(): Bitmap? {
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        var bitmap: Bitmap? = null
+        compose.activityRule.scenario.onActivity { activity ->
+            val view = activity.window.decorView.findTerminalView() ?: return@onActivity
+            if (view.width <= 0 || view.height <= 0) return@onActivity
+            val b = Bitmap.createBitmap(view.width, view.height, Bitmap.Config.ARGB_8888)
+            view.draw(Canvas(b))
+            bitmap = b
+        }
+        return bitmap
+    }
+
+    private fun paintedRowCount(bitmap: Bitmap): Int {
+        var painted = 0
+        var y = 0
+        while (y < bitmap.height) {
+            var x = 0
+            var rowPainted = false
+            while (x < bitmap.width) {
+                val p = bitmap.getPixel(x, y)
+                if (android.graphics.Color.red(p) > 40 ||
+                    android.graphics.Color.green(p) > 40 ||
+                    android.graphics.Color.blue(p) > 40
+                ) {
+                    rowPainted = true
+                    break
+                }
+                x += 4
+            }
+            if (rowPainted) painted++
+            y += 4
+        }
+        return painted
+    }
+
+    private fun writeBitmap(name: String, bitmap: Bitmap): File {
+        val file = artifactFile("$name.png")
+        java.io.FileOutputStream(file).use { out ->
+            check(bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)) {
+                "failed to write bitmap to ${file.absolutePath}"
+            }
+        }
+        println("ISSUE1205_VIEWPORT ${file.absolutePath}")
+        return file
+    }
+
+    private fun writeText(name: String, text: String): File {
+        val file = artifactFile(name)
+        file.writeText(text)
+        println("ISSUE1205_TEXT ${file.absolutePath}")
+        return file
+    }
+
+    private fun writeSummary(scenario: String, overflowClass: String): File =
+        writeText(
+            "issue1205-$scenario-summary.txt",
+            buildString {
+                appendLine("test=PaneOutputOverflowRecoveryJourneyE2eTest#$scenario")
+                appendLine("issue=1205")
+                appendLine("fixture=tests/docker agents ($DEFAULT_HOST:$DEFAULT_PORT), full-viewport banner")
+                appendLine("running_on_ci=${TerminalTestTimeouts.isRunningOnCi()}")
+                appendLine("session=$SESSION_NAME")
+                appendLine("banner_marker=$BANNER_MARKER")
+                appendLine("overflow_class=$overflowClass")
+                appendLine(
+                    "scenario=attach a full-viewport banner, wipe the LOCAL emulator to black " +
+                        "(remote tmux grid keeps the banner -> transport GUARANTEED LIVE), trip a REAL " +
+                        "$overflowClass, then assert the pane SELF-HEALS (fresh capture-pane reseed, " +
+                        "banner content restored, producer reattached to the live client, no dead " +
+                        "surfaceError card, still Connected) — OR, for the exhaustion scenario, that a " +
+                        "sustained un-recoverable overflow lands on the actionable Recreate-terminal card",
+                )
+            },
+        )
+
+    private fun artifactFile(name: String): File {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val mediaRoot = com.pocketshell.app.test.testArtifactsRoot(instrumentation.targetContext)
+        val dir = File(mediaRoot, "additional_test_output/$DEVICE_DIR_NAME")
+        check(dir.exists() || dir.mkdirs()) { "could not create artifact directory ${dir.absolutePath}" }
+        return File(dir, name)
+    }
+
+    private fun View.findTerminalView(): TerminalView? {
+        if (this is TerminalView) return this
+        if (this !is ViewGroup) return null
+        for (index in 0 until childCount) {
+            val match = getChildAt(index).findTerminalView()
+            if (match != null) return match
+        }
+        return null
+    }
+
+    private fun shellQuote(value: String): String =
+        "'" + value.replace("'", "'\"'\"'") + "'"
+
+    private companion object {
+        const val DATABASE_NAME: String = "pocketshell.db"
+        const val LOG_TAG: String = "Issue1205Overflow"
+        const val DEVICE_DIR_NAME: String = "issue1205-overflow-recovery"
+        const val SESSION_NAME: String = "issue1205-overflow-proof"
+        const val BANNER_MARKER: String = "ISSUE1205-BANNER"
+
+        const val MIN_RESTORED_BANNER_ROWS: Int = 20
+
+        val RESTORE_TIMEOUT_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 30_000L else 20_000L
+        val CONNECTED_TIMEOUT_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 30_000L else 15_000L
+    }
+}

--- a/app/src/androidTest/java/com/pocketshell/app/proof/SshReconnectE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/SshReconnectE2eTest.kt
@@ -825,6 +825,7 @@ class SshReconnectE2eTest {
             CommandResponse(number = 0L, output = emptyList(), isError = false)
 
         override fun outputFor(paneId: String): Flow<ControlEvent.Output> = emptyFlow()
+        override fun drainPaneOutputBacklog(paneId: String): Int = 0
 
         override fun close() = Unit
 

--- a/app/src/androidTest/java/com/pocketshell/app/sessions/service/SessionConnectionServiceE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/sessions/service/SessionConnectionServiceE2eTest.kt
@@ -279,6 +279,7 @@ class SessionConnectionServiceE2eTest {
             CommandResponse(number = 0L, output = emptyList(), isError = false)
 
         override fun outputFor(paneId: String): Flow<ControlEvent.Output> = emptyFlow()
+        override fun drainPaneOutputBacklog(paneId: String): Int = 0
 
         override fun close() {
             markDisconnected()

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -1319,6 +1319,27 @@ public class TmuxSessionViewModel @Inject constructor(
         paneProducerClients[paneId]?.let { System.identityHashCode(it) }
 
     /**
+     * Issue #1205 test seam: is [paneId]'s live-output producer currently attached
+     * and active? The overflow-recovery proof uses this to confirm the producer
+     * was REATTACHED after a reseed (live %output resumes), not left dead.
+     */
+    @androidx.annotation.VisibleForTesting
+    internal fun paneProducerActiveForTest(paneId: String): Boolean =
+        paneProducerJobs[paneId]?.isActive == true
+
+    /**
+     * Issue #1205 test seam: is an overflow reseed-and-reattach recovery currently
+     * in flight for [paneId]? The connected exhaustion journey polls this to know
+     * a recovery cycle has fully COMPLETED (the in-flight slot released in its
+     * `finally`) before tripping the next overflow, so each trip is counted against
+     * [OVERFLOW_RECOVERY_MAX_ATTEMPTS] rather than de-duped as a still-in-flight
+     * burst signal — making the budget exhaustion deterministic on-device.
+     */
+    @androidx.annotation.VisibleForTesting
+    internal fun paneOverflowRecoveryInFlightForTest(paneId: String): Boolean =
+        paneId in paneOverflowRecoveryInFlight
+
+    /**
      * Issue #895 (switch-while-black) test seam: force the inline connection
      * state to [ConnectionState.Attaching] so a regression test can drive a
      * passive drop while [inlineConnectionStatus] projects to
@@ -2525,6 +2546,21 @@ public class TmuxSessionViewModel @Inject constructor(
     // The SSH/tmux transport stays untouched the whole time.
     private val paneSurfaceRecoveryTimestamps: MutableMap<String, ArrayDeque<Long>> =
         ConcurrentHashMap()
+
+    // Issue #1205: per-pane sliding window of backlog/seed-gate overflow recovery
+    // attempts (reseed-and-reattach). Bounds a saturated channel to
+    // [OVERFLOW_RECOVERY_MAX_ATTEMPTS] reseeds inside [OVERFLOW_RECOVERY_WINDOW_MS]
+    // before the pane falls to the `surfaceError` card, so a burst that keeps
+    // overflowing after each reseed cannot loop into a reseed storm.
+    private val paneOverflowRecoveryTimestamps: MutableMap<String, ArrayDeque<Long>> =
+        ConcurrentHashMap()
+
+    // Issue #1205: panes with a reseed-and-reattach recovery currently in flight.
+    // A single overflow BURST fires the overflow signal many times (once per
+    // dropped frame); this de-dups the burst to ONE recovery per pane so we don't
+    // launch a reseed per dropped event. Cleared when the recovery job completes.
+    private val paneOverflowRecoveryInFlight: MutableSet<String> =
+        ConcurrentHashMap.newKeySet()
 
     /**
      * Open the SSH transport, spawn `tmux -CC` against [sessionName], and
@@ -5800,6 +5836,8 @@ public class TmuxSessionViewModel @Inject constructor(
         panePortDetectorClients.clear()
         panePortDetectorGenerations.clear()
         paneSurfaceRecoveryTimestamps.clear()
+        paneOverflowRecoveryTimestamps.clear()
+        paneOverflowRecoveryInFlight.clear()
         paneAgentJobs.values.forEach { it.cancel() }
         paneAgentJobs.clear()
         conversationLoadWatchdogJobs.values.forEach { it.cancel() }
@@ -5932,6 +5970,8 @@ public class TmuxSessionViewModel @Inject constructor(
         paneSeedRecoveryJobs.clear()
         paneSeedRecoveryJobs.putAll(runtime.paneSeedRecoveryJobs)
         paneSurfaceRecoveryTimestamps.clear()
+        paneOverflowRecoveryTimestamps.clear()
+        paneOverflowRecoveryInFlight.clear()
         paneAgentJobs.clear()
         // Issue #793: drop any pending load watchdogs from the prior runtime so
         // a restored, already-populated conversation row is not flipped to
@@ -10129,6 +10169,8 @@ public class TmuxSessionViewModel @Inject constructor(
             paneInputJobs.remove(paneId)?.cancel()
             paneInputQueues.remove(paneId)?.close()
             paneSurfaceRecoveryTimestamps.remove(paneId)
+            paneOverflowRecoveryTimestamps.remove(paneId)
+            paneOverflowRecoveryInFlight.remove(paneId)
             paneRows[paneId]?.terminalState?.detachExternalProducer()
             paneRows.remove(paneId)
         }
@@ -10367,13 +10409,74 @@ public class TmuxSessionViewModel @Inject constructor(
         return port
     }
 
+    /**
+     * Issue #1205: the synchronous verdict the overflow handlers get from
+     * [beginPaneOverflowRecovery] and record on the `terminal_output_overflow`
+     * diagnostic, deciding what the handler does next.
+     */
+    private enum class OverflowRecoveryDecision {
+        /** Reseed-and-reattach this pane (within the retry budget). */
+        RESEED,
+
+        /** Budget exhausted — fall to the actionable `surfaceError` card. */
+        EXHAUSTED,
+
+        /** A recovery is already running for this pane — drop the burst signal. */
+        IN_FLIGHT,
+    }
+
+    /**
+     * Issue #1205: a pane's delivery backlog (or the 2 MB seed gate) overflowed
+     * under a sustained high-output burst. The KDoc on
+     * [TmuxClient.outputBacklogOverflows] already prescribes the correct
+     * recovery: this is a LOCAL rendering/ingestion backpressure signal, NOT a
+     * transport disconnect, so the pane must recover by RESEEDING from
+     * `capture-pane` — a transient burst costs one reseed, not the pane.
+     *
+     * Before #1205 the FIRST dropped frame cancelled the producer, detached the
+     * pane, and latched `surfaceError` — a permanently dead pane the blank/stale
+     * watchdog and heal oracle both early-return on, so nothing self-heals and
+     * the user must tap "Recreate terminal". This routes both overflow classes
+     * through the existing [reseedActivePaneForReattach]-family machinery
+     * ([drainPaneOutputBacklog] → [seedPaneFromCapture] →
+     * [attachTerminalProducerForPane]) with a bounded retry budget
+     * ([OVERFLOW_RECOVERY_MAX_ATTEMPTS] within [OVERFLOW_RECOVERY_WINDOW_MS]) so
+     * a still-saturated channel can't loop into a reseed storm — after the
+     * budget the pane lands on the same `surfaceError` card as a LAST resort.
+     */
+    private fun beginPaneOverflowRecovery(paneId: String): OverflowRecoveryDecision {
+        // De-dup a burst: a single overflow fires the signal once per DROPPED
+        // frame. If a recovery is already running for this pane, drop the
+        // duplicate. The running job clears the flag on completion; only then can
+        // a genuinely-new overflow re-trigger and be counted against the budget,
+        // so a still-in-flight recovery can never be pre-empted into the card.
+        if (paneId in paneOverflowRecoveryInFlight) return OverflowRecoveryDecision.IN_FLIGHT
+        val now = SystemClock.elapsedRealtime()
+        val attempts = paneOverflowRecoveryTimestamps.getOrPut(paneId) { ArrayDeque() }
+        val recent = synchronized(attempts) {
+            while (attempts.isNotEmpty() && now - attempts.first() > OVERFLOW_RECOVERY_WINDOW_MS) {
+                attempts.removeFirst()
+            }
+            attempts.size
+        }
+        if (recent >= OVERFLOW_RECOVERY_MAX_ATTEMPTS) return OverflowRecoveryDecision.EXHAUSTED
+        // Reserve the in-flight slot atomically so a concurrent burst signal
+        // (the seed-gate path can fire from a producer-feed thread) can't also
+        // start a second recovery for the same pane.
+        if (!paneOverflowRecoveryInFlight.add(paneId)) return OverflowRecoveryDecision.IN_FLIGHT
+        synchronized(attempts) { attempts.addLast(now) }
+        return OverflowRecoveryDecision.RESEED
+    }
+
     private fun handleTerminalOutputBacklogOverflow(overflow: TmuxOutputBacklogOverflow) {
         val existing = paneRows[overflow.paneId] ?: return
         if (existing.surfaceError) return
+        val decision = beginPaneOverflowRecovery(overflow.paneId)
         Log.w(
             ISSUE_145_RECONNECT_TAG,
             "tmux-terminal-output-backlog-overflow pane=${overflow.paneId} " +
-                "droppedEvents=${overflow.droppedEvents} status=${_connectionStatus.value}",
+                "droppedEvents=${overflow.droppedEvents} status=${_connectionStatus.value} " +
+                "recovery=${decision.name.lowercase()}",
         )
         DiagnosticEvents.record(
             "connection",
@@ -10384,6 +10487,11 @@ public class TmuxSessionViewModel @Inject constructor(
             "source" to "pane_output_backlog",
             "classification" to "local_terminal_renderer_backpressure",
             "reconnect" to false,
+            // Issue #1205: the recovery outcome DECISION on the existing event —
+            // reseed (auto-heal), exhausted (fell to the card), or in_flight
+            // (deduped burst). The async outcome lands on
+            // `terminal_output_overflow_recovery`.
+            "recovery" to decision.name.lowercase(),
             "tmuxDisconnected" to clientRef?.disconnected?.value,
             "hostId" to activeTarget?.hostId,
             "host" to activeTarget?.host,
@@ -10395,20 +10503,7 @@ public class TmuxSessionViewModel @Inject constructor(
             "attempt" to activeAttachMilestone?.attempt,
             "activeTrigger" to activeAttachMilestone?.trigger?.logValue,
         )
-
-        paneProducerJobs.remove(overflow.paneId)?.cancel()
-        paneProducerClients.remove(overflow.paneId) // Issue #959
-        paneOutputActivityJobs.remove(overflow.paneId)?.cancel()
-        panePortDetectorJobs.remove(overflow.paneId)?.cancel()
-        panePortDetectorClients.remove(overflow.paneId)
-        panePortDetectorGenerations.remove(overflow.paneId)
-        runCatching { existing.terminalState.detachExternalProducer() }
-
-        val errored = existing.copy(surfaceError = true)
-        paneRows[overflow.paneId] = errored
-        _panes.update { rows ->
-            rows.map { row -> if (row.paneId == overflow.paneId) errored else row }
-        }
+        dispatchPaneOverflowRecovery(overflow.paneId, source = "pane_output_backlog", decision = decision)
     }
 
     private fun handleTerminalSeedGateOverflow(
@@ -10417,11 +10512,13 @@ public class TmuxSessionViewModel @Inject constructor(
     ) {
         val existing = paneRows[paneId] ?: return
         if (existing.surfaceError) return
+        val decision = beginPaneOverflowRecovery(paneId)
         Log.w(
             ISSUE_145_RECONNECT_TAG,
             "tmux-terminal-seed-gate-overflow pane=$paneId " +
                 "pendingBytes=${overflow.pendingBytes} incomingBytes=${overflow.incomingBytes} " +
-                "maxBytes=${overflow.maxBytes} status=${_connectionStatus.value}",
+                "maxBytes=${overflow.maxBytes} status=${_connectionStatus.value} " +
+                "recovery=${decision.name.lowercase()}",
             overflow,
         )
         DiagnosticEvents.record(
@@ -10435,6 +10532,7 @@ public class TmuxSessionViewModel @Inject constructor(
             "source" to "seed_gate_live_buffer",
             "classification" to "local_terminal_renderer_backpressure",
             "reconnect" to false,
+            "recovery" to decision.name.lowercase(),
             "tmuxDisconnected" to clientRef?.disconnected?.value,
             "hostId" to activeTarget?.hostId,
             "host" to activeTarget?.host,
@@ -10446,7 +10544,124 @@ public class TmuxSessionViewModel @Inject constructor(
             "attempt" to activeAttachMilestone?.attempt,
             "activeTrigger" to activeAttachMilestone?.trigger?.logValue,
         )
+        dispatchPaneOverflowRecovery(paneId, source = "seed_gate_live_buffer", decision = decision)
+    }
 
+    private fun dispatchPaneOverflowRecovery(
+        paneId: String,
+        source: String,
+        decision: OverflowRecoveryDecision,
+    ) {
+        when (decision) {
+            OverflowRecoveryDecision.RESEED -> launchPaneOverflowReseed(paneId, source)
+            OverflowRecoveryDecision.EXHAUSTED ->
+                latchPaneSurfaceError(paneId, source, outcome = "surface_error_retry_exhausted")
+            // A recovery for this pane is already running; the burst signal is a
+            // duplicate — drop it (the in-flight job will finish the reseed).
+            OverflowRecoveryDecision.IN_FLIGHT -> Unit
+        }
+    }
+
+    /**
+     * Issue #1205: reseed-and-reattach the overflowed pane through the existing
+     * chokepoint machinery — drain the stale burst backlog, recapture the
+     * authoritative server-side grid, and reattach a fresh producer — SILENTLY,
+     * with NO user action and WITHOUT touching the SSH/tmux transport (this is
+     * local renderer backpressure, not a disconnect). Mirrors
+     * [rebindVisiblePaneProducersToClient]'s producer teardown+reattach so a
+     * duplicate producer/input drain is never left behind. Releases the in-flight
+     * slot in a `finally` so the retry budget can re-arm.
+     */
+    private fun launchPaneOverflowReseed(paneId: String, source: String) {
+        val client = clientRef
+        val guard = client?.let { currentRuntimeGuardForClient(it) }
+        if (client == null || client.disconnected.value || guard == null) {
+            // Nothing live to reseed from (dropped / reconnecting). Fall to the
+            // actionable card and release the slot so a later live overflow can
+            // recover.
+            paneOverflowRecoveryInFlight.remove(paneId)
+            latchPaneSurfaceError(paneId, source, outcome = "surface_error_no_live_client")
+            return
+        }
+        bridgeScope.launch {
+            var reseeded = false
+            var drainedFrames = 0
+            var reattached = false
+            try {
+                val pane = paneRows[paneId] ?: return@launch
+                // 1. Detach the current (dropped / feed-failed) producer + its
+                //    output-activity, port-detector, and input drains — the same
+                //    teardown [rebindVisiblePaneProducersToClient] does before a
+                //    clean reattach, so nothing is left double-bound.
+                paneProducerJobs.remove(paneId)?.cancel()
+                paneProducerClients.remove(paneId)
+                paneOutputActivityJobs.remove(paneId)?.cancel()
+                panePortDetectorJobs.remove(paneId)?.cancel()
+                panePortDetectorClients.remove(paneId)
+                panePortDetectorGenerations.remove(paneId)
+                paneInputJobs.remove(paneId)?.cancel()
+                paneInputQueues.remove(paneId)?.close()
+                runCatching { pane.terminalState.detachExternalProducer() }
+                // 2. Drain the stale burst frames still queued in the pane's
+                //    channel so they can't replay to the fresh producer and
+                //    double-apply on top of the capture-pane snapshot.
+                drainedFrames = runCatching { client.drainPaneOutputBacklog(paneId) }.getOrDefault(0)
+                if (!isCurrentRuntime(guard) || client.disconnected.value) return@launch
+                // 3. Reattach a FRESH producer (new bridge + emulator, seed gate
+                //    CLOSED via awaitSeed) BEFORE reseeding: the seed must land on
+                //    the SAME bridge the live producer feeds. Live %output arriving
+                //    now buffers in order behind the closed gate — the #468 design.
+                attachTerminalProducerForPane(
+                    paneId = paneId,
+                    state = pane.terminalState,
+                    client = client,
+                )
+                reattached = paneProducerJobs[paneId]?.isActive == true
+                // 4. Reseed from tmux's authoritative server-side grid onto the
+                //    fresh bridge; [appendRemoteOutput] OPENS the seed gate so the
+                //    buffered live deltas flush in order after the snapshot. The
+                //    non-destructive swap keeps the last good frame if the capture
+                //    is momentarily near-blank.
+                reseeded = seedPaneFromCapture(client, pane, guard, recordMilestone = false)
+                // 5. If no snapshot ever landed (all retries near-blank/errored),
+                //    still OPEN the gate so buffered live output is flushed rather
+                //    than swallowed — the same fallback the cold-open seed uses
+                //    ([seedPrewarmedPane]/preload). Otherwise the reattached
+                //    producer would be gated forever.
+                if (!reseeded && isCurrentRuntime(guard)) {
+                    runCatching { pane.terminalState.openSeedGateWithoutSeed() }
+                }
+            } finally {
+                paneOverflowRecoveryInFlight.remove(paneId)
+                DiagnosticEvents.record(
+                    "connection",
+                    "terminal_output_overflow_recovery",
+                    "pane" to paneId,
+                    "source" to source,
+                    "outcome" to when {
+                        reseeded && reattached -> "reseeded_and_reattached"
+                        reattached -> "reattached_gate_opened"
+                        else -> "reseed_declined"
+                    },
+                    "reattached" to reattached,
+                    "drainedFrames" to drainedFrames,
+                    "generation" to connectGeneration,
+                    "status" to _connectionStatus.value.javaClass.simpleName,
+                )
+            }
+        }
+    }
+
+    /**
+     * Issue #1205: the LAST-RESORT actionable-error card — the pre-#1205
+     * latch-first behavior, now reached ONLY after the bounded reseed retry
+     * budget is exhausted (or there is no live client to reseed from). Tears the
+     * pane's producer/input drains down and flips it to `surfaceError` so the
+     * user recovers via "Recreate terminal".
+     */
+    private fun latchPaneSurfaceError(paneId: String, source: String, outcome: String) {
+        val existing = paneRows[paneId] ?: return
+        if (existing.surfaceError) return
         paneProducerJobs.remove(paneId)?.cancel()
         paneProducerClients.remove(paneId) // Issue #959
         paneOutputActivityJobs.remove(paneId)?.cancel()
@@ -10462,6 +10677,60 @@ public class TmuxSessionViewModel @Inject constructor(
         _panes.update { rows ->
             rows.map { row -> if (row.paneId == paneId) errored else row }
         }
+        // Issue #1205: the terminal PAGER renders `unifiedPanes`, NOT `_panes`
+        // directly, so the flipped-to-`surfaceError` row must be republished into
+        // the unified list or the user-visible "Recreate terminal" give-up card
+        // never appears — the pane just sits frozen with no recovery affordance.
+        // (An on-device exhaustion journey caught this; the JVM proof only asserts
+        // the `_panes` state, which the pager does not read.)
+        rebuildUnifiedPanes()
+        DiagnosticEvents.record(
+            "connection",
+            "terminal_output_overflow_recovery",
+            "pane" to paneId,
+            "source" to source,
+            "outcome" to outcome,
+            "generation" to connectGeneration,
+            "status" to _connectionStatus.value.javaClass.simpleName,
+        )
+    }
+
+    // Issue #1205 (test seam): drive the production seed-gate overflow handler
+    // directly. The backlog-overflow class is driven end-to-end through the real
+    // `outputBacklogOverflows` collector by a test emitting an overflow event;
+    // the seed-gate class originates from the terminal bridge's
+    // `onTerminalFeedFailure` callback, which a JVM test cannot raise without a
+    // real 2 MB feed, so this seam calls the SAME private handler the callback
+    // does. No production logic added.
+    internal fun handleTerminalSeedGateOverflowForTest(
+        paneId: String,
+        overflow: TerminalSeedGateOverflowException,
+    ) {
+        handleTerminalSeedGateOverflow(paneId, overflow)
+    }
+
+    // Issue #1205 (connected-journey test seam): trip the LIVE-output backlog
+    // overflow class the maintainer reported. A real 4096-deep `Channel` overflow
+    // needs a sustained burst outrunning the frame-budgeted drain — timing-
+    // dependent and flaky to force deterministically on the emulator (the #780
+    // reason to inject the failing state synthetically). This calls the SAME
+    // private handler the real `outputBacklogOverflows` collector calls
+    // ([handleTerminalOutputBacklogOverflow], wired at the `outputOverflowJob`
+    // collect), so everything downstream — `beginPaneOverflowRecovery`, the
+    // bounded-retry budget, `launchPaneOverflowReseed`'s drain → capture-pane
+    // reseed → producer reattach — runs on the REAL on-device path against the
+    // REAL client/transport. Only the trigger is synthetic. No production logic
+    // added; symmetric with [handleTerminalSeedGateOverflowForTest].
+    internal fun handleTerminalOutputBacklogOverflowForTest(
+        paneId: String,
+        droppedEvents: Int,
+    ) {
+        handleTerminalOutputBacklogOverflow(
+            com.pocketshell.core.tmux.TmuxOutputBacklogOverflow(
+                paneId = paneId,
+                droppedEvents = droppedEvents,
+            ),
+        )
     }
 
     /**
@@ -10603,6 +10872,8 @@ public class TmuxSessionViewModel @Inject constructor(
     public fun recreateTerminalSurface(paneId: String) {
         val existing = paneRows[paneId] ?: return
         paneSurfaceRecoveryTimestamps.remove(paneId)
+        paneOverflowRecoveryTimestamps.remove(paneId)
+        paneOverflowRecoveryInFlight.remove(paneId)
         paneProducerJobs.remove(paneId)?.cancel()
         paneProducerClients.remove(paneId)
         paneOutputActivityJobs.remove(paneId)?.cancel()
@@ -18506,6 +18777,23 @@ internal const val SEED_CAPTURE_EMPTY_RETRY_ATTEMPTS: Int = 4
  * without stalling a genuinely-empty pane's reveal.
  */
 internal const val SEED_CAPTURE_EMPTY_RETRY_DELAY_MS: Long = 120L
+
+/**
+ * Issue #1205: how many times a pane may be auto-recovered from a delivery
+ * backlog / seed-gate overflow (reseed-and-reattach) inside
+ * [OVERFLOW_RECOVERY_WINDOW_MS] before the recovery is abandoned and the pane
+ * falls to the actionable `surfaceError` card as a last resort. Bounds a
+ * saturated channel so a burst that keeps overflowing after each reseed cannot
+ * loop into a reseed storm. Two attempts, then the card.
+ */
+internal const val OVERFLOW_RECOVERY_MAX_ATTEMPTS: Int = 2
+
+/**
+ * Issue #1205: sliding window over which [OVERFLOW_RECOVERY_MAX_ATTEMPTS] is
+ * counted. A single transient burst costs one reseed; only a pane that keeps
+ * overflowing inside this window exhausts the budget and lands on the card.
+ */
+internal const val OVERFLOW_RECOVERY_WINDOW_MS: Long = 60_000L
 
 /**
  * Issue #989: the user-visible message shown when the manual Redraw kebab item is

--- a/app/src/test/java/com/pocketshell/app/sessions/SessionsDashboardViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/sessions/SessionsDashboardViewModelTest.kt
@@ -994,6 +994,7 @@ class SessionsDashboardViewModelTest {
             return CommandResponse(0L, emptyList(), false)
         }
         override fun outputFor(paneId: String) = delegate.outputFor(paneId)
+        override fun drainPaneOutputBacklog(paneId: String) = delegate.drainPaneOutputBacklog(paneId)
         override fun close() = delegate.close()
         // Issue #215: detachCleanly added to the interface; the
         // throwing fake delegates to FakeTmuxClient so the killSession

--- a/app/src/test/java/com/pocketshell/app/tmux/FakeTmuxClient.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/FakeTmuxClient.kt
@@ -380,6 +380,19 @@ internal class FakeTmuxClient(
         )
     }
 
+    /**
+     * Issue #1205: records the panes whose backlog the recovery path asked to
+     * drain, so a test can assert the reseed-and-reattach recovery drained the
+     * stale burst before recapturing. The fake has no bounded channel, so the
+     * count is unused here; it returns 0 like a pane with no queued frames.
+     */
+    val drainedPaneBacklogs: MutableList<String> = mutableListOf()
+
+    override fun drainPaneOutputBacklog(paneId: String): Int {
+        drainedPaneBacklogs += paneId
+        return 0
+    }
+
     override fun outputFor(paneId: String): Flow<ControlEvent.Output> =
         if (decoupleOutputForFromEvents) {
             emittedPaneOutputs.filter { it.paneId == paneId }

--- a/app/src/test/java/com/pocketshell/app/tmux/PaneOutputOverflowRecoveryTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/PaneOutputOverflowRecoveryTest.kt
@@ -1,0 +1,413 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.app.sessions.ActiveTmuxClients
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.SshLeaseConnector
+import com.pocketshell.core.ssh.SshLeaseManager
+import com.pocketshell.core.ssh.SshLeaseTarget
+import com.pocketshell.core.ssh.SshPortForward
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshShell
+import com.pocketshell.core.terminal.bridge.SshTerminalBridge
+import com.pocketshell.core.terminal.bridge.TerminalSeedGateOverflowException
+import com.pocketshell.core.terminal.ui.TerminalSurfaceState
+import com.pocketshell.core.tmux.CommandResponse
+import com.pocketshell.core.tmux.TmuxClientFactory
+import com.pocketshell.core.tmux.TmuxOutputBacklogOverflow
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+import java.io.InputStream
+
+/**
+ * Issue #1205 — REPRODUCE-FIRST (D33/G10) JVM proof that a pane's delivery
+ * backlog overflow (and the 2 MB seed-gate overflow) RESEEDS-AND-REATTACHES the
+ * pane instead of latching it into a permanently-dead `surfaceError` card.
+ *
+ * THE BUG (2026-07-03 black-screen audit on #874): per-pane `%output` delivery
+ * is a bounded `Channel(4096)` fed by non-blocking `trySend`. Under a sustained
+ * Claude alt-screen burst with a contended main thread the channel overflows and
+ * drops. On the FIRST dropped frame the app cancelled the producer, detached the
+ * pane, and latched `surfaceError` — a permanently dead pane the blank/stale
+ * watchdog and heal oracle both early-return on, so nothing self-heals and the
+ * user must tap "Recreate terminal". The seed-gate 2 MB overflow latched the
+ * same way. The KDoc on `TmuxClient.outputBacklogOverflows` already prescribes
+ * the correct behavior: this is LOCAL renderer backpressure, so recover by
+ * RESEEDING from `capture-pane` — a transient burst costs one reseed, not the
+ * pane.
+ *
+ * RED on base (the load-bearing assertion that FAILS without the fix): after an
+ * overflow the pane is latched `surfaceError == true`. With the fix the pane is
+ * reseeded from a fresh `capture-pane`, the producer is reattached, live output
+ * resumes, and `surfaceError` stays false — with NO user action.
+ *
+ * Class coverage (G2): the live-output backlog overflow AND the seed-gate 2 MB
+ * overflow both recover, and the bounded-retry exhaustion path still lands on the
+ * `surfaceError` card (never an infinite reseed loop).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class PaneOutputOverflowRecoveryTest {
+
+    private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val createdVms = mutableListOf<TmuxSessionViewModel>()
+
+    @After
+    fun tearDown() {
+        factoryScope.cancel()
+    }
+
+    private fun runVmTest(body: suspend TestScope.() -> Unit) = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        LivenessProbeTestOverride.setAutoStartEnabledForTest(false)
+        try {
+            body()
+        } finally {
+            for (vm in createdVms) {
+                runCatching { vm.setProcessForegroundForClearedForTest(false) }
+                runCatching { vm.clearForTest() }
+            }
+            advanceUntilIdle()
+            createdVms.clear()
+            LivenessProbeTestOverride.clear()
+            Dispatchers.resetMain()
+        }
+    }
+
+    private fun TestScope.newVm(
+        registry: ActiveTmuxClients,
+        sshLeaseManager: SshLeaseManager,
+    ): TmuxSessionViewModel = TmuxSessionViewModel(
+        tmuxClientFactory = TmuxClientFactory(factoryScope),
+        activeTmuxClients = registry,
+        runtimeCache = TmuxSessionRuntimeCache(),
+        sshLeaseManager = sshLeaseManager,
+        sessionLifecycleSignals = null,
+    ).also {
+        it.setSeedIoDispatcherForTest(StandardTestDispatcher(testScheduler))
+        createdVms.add(it)
+    }
+
+    /**
+     * Connect a single-pane session painted with a content-rich frame, then
+     * silence the connect-armed watchdogs so the only `capture-pane` traffic is
+     * the one the recovery under test issues.
+     */
+    private fun TestScope.connectVmWithRichFrame(client: FakeTmuxClient): TmuxSessionViewModel {
+        val live = AlwaysConnectedSession(id = "live")
+        val connector = SingleSessionConnector(live)
+        val leaseManager = testLeaseManager(connector = connector, scope = this, idleTtlMillis = 60_000L)
+        val registry = ActiveTmuxClients()
+        val vm = newVm(registry = registry, sshLeaseManager = leaseManager)
+        runCurrent()
+        vm.setConnectedBlankWatchdogAutoArmEnabledForTest(false)
+        vm.setStaleRenderWatchdogAutoArmEnabledForTest(false)
+        vm.setTmuxClientFactoryForTest { _, _, _ -> client }
+        vm.connect(
+            hostId = 1L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            passphrase = null,
+            sessionName = "work",
+        )
+        advanceUntilIdle()
+        return vm
+    }
+
+    private val contentRichFrame: List<String> = buildList {
+        add("╭──────────────────────────────────────────────╮")
+        add("│  Claude Code  •  idle                          │")
+        add("├──────────────────────────────────────────────┤")
+        repeat(10) { i -> add("│  context line $i — real rendered content here  │") }
+        add("│  > waiting for your next message…              │")
+        add("╰──────────────────────────────────────────────╯")
+    }
+
+    private fun FakeTmuxClient.withRichInitialFrame(
+        sessionName: String,
+        paneId: String,
+        frame: List<String> = contentRichFrame,
+    ): FakeTmuxClient = apply {
+        responses.addLast(
+            CommandResponse(
+                number = 1L,
+                output = listOf("$paneId\t@0\t\$0\t$sessionName\t$sessionName\t0"),
+                isError = false,
+            ),
+        )
+        capturePaneResponses.addLast(
+            CommandResponse(number = 2L, output = frame, isError = false),
+        )
+        cursorQueryResponses.addLast(
+            CommandResponse(number = 3L, output = listOf("0,0"), isError = false),
+        )
+    }
+
+    /** Queue a content-rich recovery capture tagged so the test can see it landed. */
+    private fun FakeTmuxClient.queueRecoveryCapture(marker: String, number: Long) {
+        capturePaneResponses.addLast(
+            CommandResponse(
+                number = number,
+                output = contentRichFrame.map { it.replace("idle", marker) },
+                isError = false,
+            ),
+        )
+    }
+
+    // -----------------------------------------------------------------------
+    // (1) Live-output backlog overflow — the maintainer's reported class.
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun backlogOverflowReseedsAndReattachesInsteadOfLatchingSurfaceError() = runVmTest {
+        val client = FakeTmuxClient().withRichInitialFrame("work", "%1")
+        val vm = connectVmWithRichFrame(client)
+        val pane = vm.panes.value.single { it.paneId == "%1" }
+        assertFalse("precondition: pane is not errored before the overflow", pane.surfaceError)
+        assertTrue(pane.terminalState.renderedNonBlankCharCount() > 100)
+
+        client.queueRecoveryCapture(marker = "BACKLOG-RECOVERED", number = 9L)
+        val sentBefore = client.sentCommands.size
+
+        // Drive the REAL overflow path: emit an overflow the same way the tmux
+        // client's `trySend`-drop does; it flows through the VM's real
+        // `outputBacklogOverflows` collector into `handleTerminalOutputBacklogOverflow`.
+        client.outputBacklogOverflowEvents.tryEmit(
+            TmuxOutputBacklogOverflow(paneId = "%1", droppedEvents = 1),
+        )
+        advanceUntilIdle()
+
+        // LOAD-BEARING red→green: on base the pane is latched `surfaceError`; the
+        // fix reseeds-and-reattaches it instead, with NO user action.
+        val recovered = vm.panes.value.single { it.paneId == "%1" }
+        assertFalse(
+            "Issue #1205: a backlog overflow must NOT latch the pane into surfaceError " +
+                "— it must reseed-and-reattach",
+            recovered.surfaceError,
+        )
+        // The pane was reseeded from a fresh capture-pane (the recovery chokepoint).
+        val sentDuring = client.sentCommands.drop(sentBefore)
+        assertTrue(
+            "the recovery must reseed the pane from tmux's server-side grid " +
+                "(sent: $sentDuring)",
+            sentDuring.any { it.startsWith("capture-pane") },
+        )
+        assertTrue(
+            "the reseed must restore fresh authoritative content",
+            renderedTranscriptFor(recovered).contains("BACKLOG-RECOVERED"),
+        )
+        // The producer was reattached to the LIVE client — live %output resumes
+        // with no user action. Bound-to-live-client is the deterministic proof the
+        // producer pipeline is restored (the render of a post-recovery emit runs on
+        // the producer's own dispatcher, which the virtual clock can't sync).
+        assertTrue(
+            "the pane producer must be reattached and active after recovery",
+            vm.paneProducerActiveForTest("%1"),
+        )
+        assertEquals(
+            "the reattached producer must be bound to the live client",
+            System.identityHashCode(client),
+            vm.paneProducerClientIdentityForTest("%1"),
+        )
+    }
+
+    // -----------------------------------------------------------------------
+    // (2) Seed-gate 2 MB overflow — the other class (G2).
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun seedGateOverflowReseedsInsteadOfLatchingSurfaceError() = runVmTest {
+        val client = FakeTmuxClient().withRichInitialFrame("work", "%1")
+        val vm = connectVmWithRichFrame(client)
+        val pane = vm.panes.value.single { it.paneId == "%1" }
+        assertFalse(pane.surfaceError)
+
+        client.queueRecoveryCapture(marker = "SEEDGATE-RECOVERED", number = 9L)
+        val sentBefore = client.sentCommands.size
+
+        // The seed-gate overflow originates in the terminal bridge's feed-failure
+        // callback (`onTerminalFeedFailure`), which a JVM test can't raise without
+        // a real 2 MB feed — drive the SAME production handler the callback calls.
+        vm.handleTerminalSeedGateOverflowForTest(
+            paneId = "%1",
+            overflow = TerminalSeedGateOverflowException(
+                pendingBytes = 2_000_000,
+                incomingBytes = 100_000,
+                maxBytes = 2_097_152,
+            ),
+        )
+        advanceUntilIdle()
+
+        val recovered = vm.panes.value.single { it.paneId == "%1" }
+        assertFalse(
+            "Issue #1205: a seed-gate overflow must NOT latch the pane into surfaceError",
+            recovered.surfaceError,
+        )
+        val sentDuring = client.sentCommands.drop(sentBefore)
+        assertTrue(
+            "the seed-gate recovery must reseed from capture-pane (sent: $sentDuring)",
+            sentDuring.any { it.startsWith("capture-pane") },
+        )
+        assertTrue(
+            "the reseed must restore fresh authoritative content",
+            renderedTranscriptFor(recovered).contains("SEEDGATE-RECOVERED"),
+        )
+        assertTrue(
+            "the pane producer must be reattached and active after seed-gate recovery",
+            vm.paneProducerActiveForTest("%1"),
+        )
+    }
+
+    // -----------------------------------------------------------------------
+    // (3) Bounded-retry exhaustion — a still-saturated channel must NOT loop
+    //     into a reseed storm; after the budget it lands on the card (G2).
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun boundedRetryExhaustionLandsOnSurfaceErrorCardNotAnInfiniteLoop() = runVmTest {
+        val client = FakeTmuxClient().withRichInitialFrame("work", "%1")
+        val vm = connectVmWithRichFrame(client)
+        assertFalse(vm.panes.value.single { it.paneId == "%1" }.surfaceError)
+
+        // Attempts 1 and 2 reseed (within the OVERFLOW_RECOVERY_MAX_ATTEMPTS budget).
+        client.queueRecoveryCapture(marker = "RETRY-1", number = 11L)
+        client.queueRecoveryCapture(marker = "RETRY-2", number = 12L)
+
+        repeat(OVERFLOW_RECOVERY_MAX_ATTEMPTS) { attempt ->
+            client.outputBacklogOverflowEvents.tryEmit(
+                TmuxOutputBacklogOverflow(paneId = "%1", droppedEvents = attempt + 1),
+            )
+            advanceUntilIdle()
+            assertFalse(
+                "attempt ${attempt + 1} is within budget — the pane must still recover, not latch",
+                vm.panes.value.single { it.paneId == "%1" }.surfaceError,
+            )
+        }
+
+        // The (budget + 1)th overflow, with the channel STILL saturated, exhausts
+        // the budget — the pane now falls to the actionable card exactly once (no
+        // infinite reseed loop).
+        client.outputBacklogOverflowEvents.tryEmit(
+            TmuxOutputBacklogOverflow(paneId = "%1", droppedEvents = 99),
+        )
+        advanceUntilIdle()
+
+        assertTrue(
+            "Issue #1205: after OVERFLOW_RECOVERY_MAX_ATTEMPTS reseeds a still-saturated " +
+                "channel must land on the surfaceError card, not loop forever",
+            vm.panes.value.single { it.paneId == "%1" }.surfaceError,
+        )
+    }
+
+    // -----------------------------------------------------------------------
+    // (4) De-dup: a BURST of overflow signals (one per dropped frame) must
+    //     trigger exactly ONE reseed, never one reseed per dropped frame.
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun aBurstOfOverflowSignalsTriggersASingleReseedNotOnePerDroppedFrame() = runVmTest {
+        val client = FakeTmuxClient().withRichInitialFrame("work", "%1")
+        val vm = connectVmWithRichFrame(client)
+        client.queueRecoveryCapture(marker = "BURST-RECOVERED", number = 9L)
+        val sentBefore = client.sentCommands.size
+
+        // A single burst fires the overflow signal once per dropped frame.
+        repeat(50) { i ->
+            client.outputBacklogOverflowEvents.tryEmit(
+                TmuxOutputBacklogOverflow(paneId = "%1", droppedEvents = i + 1),
+            )
+        }
+        advanceUntilIdle()
+
+        val capturesDuring = client.sentCommands.drop(sentBefore).count { it.startsWith("capture-pane") }
+        assertEquals(
+            "a burst of 50 overflow signals must de-dup to exactly ONE reseed capture, " +
+                "not 50 (a reseed storm)",
+            1,
+            capturesDuring,
+        )
+        assertFalse(vm.panes.value.single { it.paneId == "%1" }.surfaceError)
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private fun renderedTranscriptFor(pane: TmuxPaneState): String {
+        val state = pane.terminalState
+        val bridgeField = TerminalSurfaceState::class.java.getDeclaredField("bridge").apply {
+            isAccessible = true
+        }
+        val bridge = bridgeField.get(state) as? SshTerminalBridge ?: return ""
+        return bridge.emulator.screen.transcriptText
+    }
+
+    private class SingleSessionConnector(
+        private val session: SshSession,
+    ) : SshLeaseConnector {
+        override suspend fun connect(target: SshLeaseTarget): Result<SshSession> =
+            Result.success(session)
+    }
+
+    private class AlwaysConnectedSession(
+        val id: String,
+    ) : SshSession {
+        @Volatile
+        var closed: Boolean = false
+
+        override val isConnected: Boolean get() = !closed
+
+        override suspend fun exec(command: String): ExecResult =
+            ExecResult(stdout = "", stderr = "", exitCode = 0)
+
+        override fun tail(path: String, onLine: (String) -> Unit): Job =
+            Job().apply { complete() }
+
+        override fun tail(path: String, fromLineExclusive: Long, onLine: (String) -> Unit): Job =
+            Job().apply { complete() }
+
+        override fun openLocalPortForward(
+            remoteHost: String,
+            remotePort: Int,
+            localPort: Int,
+        ): SshPortForward = error("not used")
+
+        override fun startShell(): SshShell = error("not used")
+
+        override suspend fun uploadFile(file: File, remotePath: String): String = error("not used")
+
+        override suspend fun uploadStream(
+            input: InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String = error("not used")
+
+        override fun close() {
+            closed = true
+        }
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
@@ -6757,8 +6757,15 @@ class TmuxSessionViewModelTest {
                 "local output overflow must not flip the tmux disconnected signal",
                 client.disconnectedSignal.value,
             )
-            assertTrue(
-                "overflowed pane should expose local terminal recovery instead of fake reconnect",
+            // Issue #1205: a backlog overflow no longer LATCHES the pane into a
+            // dead surfaceError card — it reseeds-and-reattaches the pane through
+            // the existing chokepoint (a transient burst costs one reseed, not the
+            // pane). The load-bearing invariant this test guards is unchanged: the
+            // overflow stays LOCAL (no reconnect, stable transport). The pane now
+            // self-heals rather than requiring "Recreate terminal".
+            assertFalse(
+                "Issue #1205: local output overflow must reseed-and-reattach the pane, " +
+                    "not latch it into a dead surfaceError card",
                 vm.panes.value.single().surfaceError,
             )
         } finally {
@@ -6894,11 +6901,15 @@ class TmuxSessionViewModelTest {
                 val overflow = diagnostics.eventsNamed("terminal_output_overflow").singleOrNull()
 
                 assertNotNull(
-                    "seed-gate live buffer overflow should become a local pane surface error",
+                    "seed-gate live buffer overflow should record the local backpressure event",
                     overflow,
                 )
-                assertTrue(
-                    "seed-gate live buffer overflow should mark the pane surface as errored",
+                // Issue #1205: the seed-gate overflow reseeds-and-reattaches the
+                // pane (same recovery as the backlog overflow) instead of latching
+                // it into a dead surfaceError card.
+                assertFalse(
+                    "Issue #1205: seed-gate overflow must reseed-and-reattach the pane, " +
+                        "not latch it into a dead surfaceError card",
                     vm.panes.value.single().surfaceError,
                 )
                 val overflowEvent = overflow!!
@@ -11882,7 +11893,15 @@ class TmuxSessionViewModelTest {
             .filter { it.role == ConversationRole.User && it.text == "previous user prompt" }
         assertEquals("Conversation should keep one optimistic user turn", 1, messages.size)
         assertEquals(MessageSendState.Pending, messages.single().sendState)
-        assertTrue("overflowed pane is shown as a surface error", vm.panes.value.single().surfaceError)
+        // Issue #1205: the overflow that fired mid-submit reseeds-and-reattaches
+        // the pane instead of latching it into a dead surfaceError card — and it
+        // must NOT disturb the in-flight Codex send (no reconnect, no duplicate
+        // prompt, one optimistic turn), which the assertions above already prove.
+        assertFalse(
+            "Issue #1205: overflow during a delayed submit must reseed-and-reattach the " +
+                "pane, not latch it into a dead surfaceError card",
+            vm.panes.value.single().surfaceError,
+        )
     }
 
     @Test

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -528,6 +528,24 @@ JOURNEY_CLASSES=(
   # with the union predicate `visibleRenderLostFrameVsCapture`. Uses ONLY the deterministic
   # agents:2222 fixture (state injected LOCALLY, no toxiproxy) and does NOT self-skip on CI.
   "$FQCN_PREFIX.AgentAltScreenPartialBlackHealJourneyE2eTest"
+  # ADDED (#1205 — pane delivery-backlog / seed-gate OVERFLOW must self-heal, not latch a dead
+  # `surfaceError` card): per-pane `%output` delivery is a bounded `Channel(4096)` fed by
+  # non-blocking `trySend`; a sustained Claude alt-screen burst on a contended main thread
+  # overflows and drops. Before #1205 the FIRST dropped frame cancelled the producer, detached
+  # the pane, and latched `surfaceError` — a permanently dead pane the blank/stale watchdog and
+  # heal oracle early-return on, so the user had to tap "Recreate terminal" (the 2 MB seed-gate
+  # overflow latched the same way). This journey attaches a full-viewport banner, wipes the LIVE
+  # emulator to black (the REMOTE tmux grid keeps the banner → transport GUARANTEED LIVE), then
+  # trips a REAL overflow through the SAME private handler the `outputBacklogOverflows` collector
+  # calls (only the trigger is synthetic — the #780 model; a 4096-deep channel overflow can't be
+  # forced deterministically on swiftshader). GREEN: no dead surfaceError card, a FRESH
+  # capture-pane reseed restores the banner, the producer reattaches to the LIVE client, session
+  # stays Connected (renderer backpressure, no reconnect); RED on base (the pane latches
+  # surfaceError). Three tests class-cover backlog + seed-gate self-heal AND the bounded-retry
+  # EXHAUSTION give-up (a still-saturated channel lands on the Recreate-terminal card exactly once
+  # — no reseed storm). Deterministic agents:2222 only (state injected LOCALLY, no toxiproxy) and
+  # does NOT self-skip on CI, so it belongs in this per-push subset.
+  "$FQCN_PREFIX.PaneOutputOverflowRecoveryJourneyE2eTest"
   # ADDED (epic #687 slice 2, #717 — reveal/reflow-heal absorbed from #658): after a
   # voice-send the active pane must NEVER go black. The composer/keyboard dismissal
   # shrinks the IME inset → `resizeRemotePty` → `maybeRefreshControlClientSize`; for an

--- a/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxClient.kt
+++ b/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxClient.kt
@@ -203,6 +203,21 @@ public interface TmuxClient : AutoCloseable {
     public fun outputFor(paneId: String): Flow<ControlEvent.Output>
 
     /**
+     * Issue #1205: discard every `%output` frame currently queued in [paneId]'s
+     * per-pane delivery backlog and return the number of frames dropped.
+     *
+     * After a backlog overflow (a sustained high-output burst outran the local
+     * renderer and [outputBacklogOverflows] fired), the buffered burst frames
+     * still queued in the pane's channel are STALE deltas: the recovery path
+     * repaints the pane from an authoritative `capture-pane` snapshot, and if
+     * those queued deltas were allowed to replay AFTER the snapshot they would
+     * double-apply on top of the already-current grid and corrupt it. Draining
+     * the backlog before the reseed is what makes "one reseed, not a dead pane"
+     * correct. No-op (returns 0) when the pane has no registered pipe.
+     */
+    public fun drainPaneOutputBacklog(paneId: String): Int
+
+    /**
      * Issue #173: observable signal that the control channel has
      * disconnected — either because [close] was called or because the
      * underlying SSH transport's reader loop exited (clean EOF or
@@ -1658,6 +1673,12 @@ internal class RealTmuxClient(
         return pipe.flow.asSharedFlow()
     }
 
+    // Issue #1205: empty the pane's queued delivery backlog so a post-overflow
+    // `capture-pane` reseed is not clobbered by stale burst frames replaying on
+    // top of it. Best-effort: only touches the live channel, never the reader.
+    override fun drainPaneOutputBacklog(paneId: String): Int =
+        paneOutputPipes[paneId]?.drainBacklog() ?: 0
+
     override suspend fun setWindowSizeLatest(sessionId: String): CommandResponse =
         sendCommandInternal(
             "set-window-option -t '${escapeSingleQuoted(sessionId)}' window-size latest",
@@ -2666,6 +2687,20 @@ internal class RealTmuxClient(
         fun close() {
             channel.close()
             job.cancel()
+        }
+
+        /**
+         * Issue #1205: discard every frame currently buffered in the live
+         * channel (best-effort, non-blocking) and return the count drained.
+         * The pipe's drain job keeps running; only the queued-but-undelivered
+         * burst frames are dropped so a post-overflow reseed is authoritative.
+         */
+        fun drainBacklog(): Int {
+            var drained = 0
+            while (channel.tryReceive().isSuccess) {
+                drained++
+            }
+            return drained
         }
 
         companion object {

--- a/shared/core-tmux/src/test/java/com/pocketshell/core/tmux/ProbeLivenessBusyVsDeadTest.kt
+++ b/shared/core-tmux/src/test/java/com/pocketshell/core/tmux/ProbeLivenessBusyVsDeadTest.kt
@@ -62,6 +62,7 @@ class ProbeLivenessBusyVsDeadTest {
             error("not used")
         override val events: Flow<ControlEvent> = emptyFlow()
         override fun outputFor(paneId: String): Flow<ControlEvent.Output> = emptyFlow()
+        override fun drainPaneOutputBacklog(paneId: String): Int = 0
         override val disconnected: StateFlow<Boolean> = disconnectedState
         override val disconnectEvent: StateFlow<TmuxDisconnectEvent?> = MutableStateFlow(null)
         override val outputBacklogOverflows: Flow<TmuxOutputBacklogOverflow> = emptyFlow()

--- a/shared/core-tmux/src/test/java/com/pocketshell/core/tmux/TmuxClientTest.kt
+++ b/shared/core-tmux/src/test/java/com/pocketshell/core/tmux/TmuxClientTest.kt
@@ -2091,6 +2091,80 @@ class TmuxClientTest {
         }
     }
 
+    /**
+     * Issue #1205 — the CORE reproduction of the trySend-drop that used to KILL
+     * the pane. A sustained %output flood past the bounded [OUTPUT_BACKLOG_EVENTS]
+     * channel (with the pane collector parked so the drain job can't keep up)
+     * makes `trySend` drop and fires [TmuxClient.outputBacklogOverflows] — exactly
+     * the signal the app latched `surfaceError` on. The FIX's recovery path drains
+     * the pane's queued backlog before a `capture-pane` reseed so the stale burst
+     * frames can't replay on top of the authoritative snapshot; this proves the
+     * NEW [TmuxClient.drainPaneOutputBacklog] actually empties the saturated
+     * channel (returns > 0 for the overflowed pane) and is a no-op for an
+     * unregistered pane.
+     */
+    @Test
+    fun `drainPaneOutputBacklog empties a saturated pane channel so a reseed is authoritative`() =
+        runBlocking {
+            val shell = FakeShell()
+            val session = FakeSession(shell)
+            val client = RealTmuxClient(session, scope, commandTimeoutMs = 1_000L)
+            val firstOutputBlocked = CompletableDeferred<Unit>()
+            val releasePaneCollector = CompletableDeferred<Unit>()
+            try {
+                client.connect()
+                withTimeout(2_000) {
+                    while (shell.stdinBytes().isEmpty()) { yield(); delay(10) }
+                }
+                shell.resetStdin()
+
+                // Park the pane collector on the first frame: the drain job stalls,
+                // the flow buffer fills, the channel backs up, and the flood below
+                // overflows it (the exact trySend-drop condition).
+                val blockedPaneCollector = scope.async {
+                    client.outputFor("%0").collect {
+                        firstOutputBlocked.complete(Unit)
+                        releasePaneCollector.await()
+                    }
+                }
+                val overflow = scope.async { client.outputBacklogOverflows.first() }
+                delay(100)
+
+                val feedJob = scope.async {
+                    shell.feed(codexScaleControlModeFlood(commandNumber = 1L, outputCount = 5_000))
+                }
+
+                withTimeout(ASYNC_AWAIT_TIMEOUT_MS) { firstOutputBlocked.await() }
+                val overflowEvent = withTimeout(ASYNC_AWAIT_TIMEOUT_MS) { overflow.await() }
+                assertEquals("%0", overflowEvent.paneId)
+                assertTrue("sustained flood must overflow the channel", overflowEvent.droppedEvents > 0)
+                withTimeout(ASYNC_AWAIT_TIMEOUT_MS) { feedJob.await() }
+
+                // LOAD-BEARING: the queued stale frames ARE drainable — the recovery
+                // clears them before the capture-pane reseed so they cannot double
+                // apply on top of the authoritative grid. A saturated channel has
+                // frames to drop.
+                val drained = client.drainPaneOutputBacklog("%0")
+                assertTrue(
+                    "drainPaneOutputBacklog must empty the saturated backlog (drained=$drained)",
+                    drained > 0,
+                )
+                // Draining again is now a no-op (already emptied), and an
+                // unregistered pane returns 0 without throwing.
+                assertEquals(0, client.drainPaneOutputBacklog("%0"))
+                assertEquals(0, client.drainPaneOutputBacklog("%does-not-exist"))
+                assertFalse(
+                    "draining the backlog is a local recovery, never a transport disconnect",
+                    client.disconnected.value,
+                )
+
+                blockedPaneCollector.cancel()
+            } finally {
+                releasePaneCollector.complete(Unit)
+                client.close()
+            }
+        }
+
     @Test
     fun `close fails an in-flight sendCommand with TmuxClientException`() = runBlocking {
         val shell = FakeShell()


### PR DESCRIPTION
Closes #1205. Black-screen audit #1208 (data-path — overflow leg). Last of the core data-path fixes.

Overflow of the per-pane `Channel(4096)` (or the 2 MB seed-gate) latched `surfaceError` on the first drop → permanently dead pane. Now routes both through the existing reseed chokepoint (drain → reattach → capture-pane reseed → gate fallback), bounded 2×/60s + burst de-dup, then the recovery card as last resort. **D28: handler-level, reuses existing primitives, no reconnect/grace/lease rewrite** (reviewer-confirmed).

The on-device journey caught a real bug the JVM proof missed: `latchPaneSurfaceError` set `_panes.surfaceError` but never called `rebuildUnifiedPanes()` (what the pager renders), so the 'Recreate terminal' card never appeared and the pane froze — fixed. Reviewer reproduced on-device red→green (neutralize → card never renders; fix → 3/3 green, banner 0→40 rows restored); D28 handler-level confirmed; `:shared:core-ssh:integrationTest` green; JVM 367/0/0. Rebased onto current main (+ the `drainPaneOutputBacklog` interface stubs); orchestrator gate green.