### PR TITLE
ci: scope nightly-fault release gate to the fault phase, de-gate #822 expected-fails (#1201)

### DIFF
--- a/.github/workflows/nightly-extensive.yml
+++ b/.github/workflows/nightly-extensive.yml
@@ -65,6 +65,18 @@ jobs:
           fetch-depth: 0
           ref: main
 
+      # Issue #1201: validate the release-gate fault-verdict decision logic on
+      # every nightly/dispatch (cheap, no network). The helper self-test proves
+      # the verdict is computed from the network-fault + bootstrap phases ONLY
+      # (journey suite + #822 expected-fail lane excluded); the guard self-test
+      # proves the release-gate guard GREENs on a fault-verdict-green run (even
+      # with an unrelated red shard) and REDs on a fault-verdict-red run.
+      - name: "Self-test the fault-verdict logic (issue #1201)"
+        run: |
+          chmod +x scripts/lib/nightly-fault-verdict.sh scripts/check-nightly-fault-run.sh
+          scripts/lib/nightly-fault-verdict.sh --self-test
+          scripts/check-nightly-fault-run.sh --self-test
+
       - name: Decide whether to run the extensive suite
         id: decide
         env:
@@ -382,6 +394,98 @@ jobs:
           path: artifacts/docker/
           if-no-files-found: ignore
 
+      # Issue #1201: the authoritative machine-readable fault-injection safety
+      # verdict is written ONLY by the shard that runs the aux fault phases
+      # (network-fault + bootstrap), i.e. shard 0. Upload it under a stable,
+      # dedicated name so the separate `Fault-injection safety verdict` job can
+      # download and evaluate it, independent of the whole flaky extensive shard.
+      - name: Upload fault-injection safety verdict (shard 0 only)
+        if: always() && matrix.shard == 0
+        uses: actions/upload-artifact@v7
+        with:
+          name: nightly-extensive-fault-verdict
+          path: artifacts/nightly-extensive/fault-verdict.txt
+          if-no-files-found: ignore
+
       - name: Stop Docker fixtures
         if: always()
         run: docker compose -f tests/docker/docker-compose.yml down --volumes --remove-orphans
+
+  # ---------------------------------------------------------------------------
+  # Fault-injection safety verdict (issue #1201) — the RELEASE-GATING signal.
+  #
+  # The extensive shard job is `continue-on-error` and mixes the flaky journey
+  # suite + the #822 expected-fail lane with the actual fault suite, so its job
+  # conclusion is essentially never `success` and can't gate a release. This
+  # cheap job instead reads the machine-readable verdict the suite wrote from the
+  # network-fault + bootstrap phases ONLY, and turns it into a clean job
+  # conclusion. `scripts/check-nightly-fault-run.sh` reads THIS job's conclusion
+  # (JOB_NEEDLE="Fault-injection safety verdict"), NOT the mixed extensive job.
+  #
+  # It is intentionally NOT `continue-on-error`: a red fault phase (or a shard-0
+  # crash that produced no verdict — genuine nightly-infra breakage, the #1056
+  # escape-hatch case) leaves this job red so the release gate blocks.
+  # ---------------------------------------------------------------------------
+  fault-verdict:
+    name: Fault-injection safety verdict (release gate)
+    needs: [guard, extensive]
+    # `extensive` is continue-on-error, so it counts as success for `needs`; run
+    # whenever the guard decided to run the suite (and even if a shard cancelled,
+    # so we still evaluate any verdict shard 0 produced).
+    if: always() && needs.guard.outputs.should_run == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Download fault-injection verdict (shard 0)
+        uses: actions/download-artifact@v5
+        continue-on-error: true
+        with:
+          name: nightly-extensive-fault-verdict
+          path: fault-verdict
+
+      - name: Evaluate fault-injection safety verdict
+        run: |
+          set -uo pipefail
+          file="fault-verdict/fault-verdict.txt"
+
+          if [[ ! -f "$file" ]]; then
+            {
+              echo "# Fault-injection safety verdict"
+              echo
+              echo "**BLOCK** — no verdict artifact was produced."
+              echo
+              echo "Shard 0 did not write \`fault-verdict.txt\` (the fault phase did"
+              echo "not complete — most likely genuine nightly-infra breakage such as"
+              echo "an emulator boot / Docker-fixture failure). There is NO fault"
+              echo "signal to release on. Investigate the shard-0 logs; if it is"
+              echo "genuine infra breakage, re-run the nightly, or use the #1056"
+              echo "escape hatch (NIGHTLY_FAULT_GATE_DISABLED=1) for a deliberately"
+              echo "infra-waived release."
+            } | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+          echo "Verdict artifact contents:"
+          cat "$file"
+          echo
+
+          verdict="$(grep -E '^fault_verdict=' "$file" | head -1 | cut -d= -f2)"
+          nf="$(grep -E '^network_fault_status=' "$file" | head -1 | cut -d= -f2)"
+          bootstrap="$(grep -E '^bootstrap_status=' "$file" | head -1 | cut -d= -f2)"
+          expectedfail="$(grep -E '^expected_fail_status=' "$file" | head -1 | cut -d= -f2)"
+
+          {
+            echo "# Fault-injection safety verdict"
+            echo
+            echo "- network-fault (GATING): \`$nf\`"
+            echo "- bootstrap (GATING): \`$bootstrap\`"
+            echo "- #822 expected-fail lane (NON-GATING, tracked only): \`$expectedfail\`"
+            echo "- **fault_verdict: \`$verdict\`**"
+          } | tee -a "$GITHUB_STEP_SUMMARY"
+
+          if [[ "$verdict" == "PASS" ]]; then
+            echo "PASS: the fault-injection safety journeys (network-fault + bootstrap) passed on this HEAD."
+            exit 0
+          fi
+          echo "BLOCK: fault_verdict=$verdict — a fault-injection safety phase failed on this HEAD."
+          exit 1

--- a/scripts/check-nightly-fault-run.sh
+++ b/scripts/check-nightly-fault-run.sh
@@ -6,14 +6,24 @@ set -euo pipefail
 # The #848 test-reliability audit found the safety suites run in NO blocking
 # gate: the toxiproxy network-fault proofs + the bootstrap setup-scenario matrix
 # live ONLY in the nightly "Nightly Extensive Tests" workflow
-# (.github/workflows/nightly-extensive.yml), and that workflow's extensive job
-# is `continue-on-error: true` — so a RED fault run reports the WORKFLOW as
-# `success` while the fault tests actually FAILED. On top of that the run can be
-# `cancelled` (the latest scheduled run at the time of writing was) or STALE
-# (it tested an older `headSha` than the commit being released). In every one of
-# those cases the release gate previously sailed past with zero fault signal.
+# (.github/workflows/nightly-extensive.yml).
 #
-# This guard makes the release gate FAIL when the latest nightly fault/bootstrap
+# ISSUE #1201 — WHAT THIS GUARD NOW READS:
+# The extensive shard job mixes the ACTUAL fault suite (network-fault +
+# bootstrap) with the flaky full journey/E2E suite AND the #822 Slice C/D
+# expected-fail lane (TDD specs for unbuilt features, designed RED). Reading the
+# whole extensive-job conclusion meant the job was essentially never `success`,
+# so every recent release had to WAIVE this gate (NIGHTLY_FAULT_GATE_DISABLED=1)
+# — a permanently-waived gate protects nothing. The suite now emits a
+# machine-readable fault verdict from the network-fault + bootstrap phases ONLY,
+# and the workflow exposes it as a dedicated, NON-continue-on-error
+# `Fault-injection safety verdict` job. This guard reads THAT job's conclusion,
+# so it GREENs when the fault phases passed even though an unrelated journey /
+# expected-fail test is red, and REDs only when a fault phase itself failed (or
+# no verdict was produced — genuine nightly-infra breakage, the #1056 escape
+# hatch case).
+#
+# This guard makes the release gate FAIL when the latest nightly fault-verdict
 # run is red / cancelled / stale / missing. It is wired as an early required
 # step in scripts/release-emulator-validation.sh.
 #
@@ -21,42 +31,46 @@ set -euo pipefail
 # network/`gh` dependency:
 #
 #   1. evaluate_nightly_fault_run — PURE decision function. Given the run's
-#      status, the extensive-JOB conclusion, the run headSha, the release HEAD,
-#      and whether headSha is an ancestor-or-equal of the release HEAD, it prints
-#      a PASS/BLOCK verdict + reason and returns 0 (pass) / 1 (block). No git, no
-#      gh, no I/O. The release HEAD ancestry is computed by the caller.
+#      status, the fault-verdict-JOB conclusion, the run headSha, the release
+#      HEAD, and whether headSha is an ancestor-or-equal of the release HEAD, it
+#      prints a PASS/BLOCK verdict + reason and returns 0 (pass) / 1 (block). No
+#      git, no gh, no I/O. The release HEAD ancestry is computed by the caller.
 #
 #   2. The `gh`/git fetch layer (main path) — queries the latest nightly run that
-#      ACTUALLY RAN the extensive job (skips guard-skipped runs), extracts the
-#      extensive job conclusion (NOT the masked workflow conclusion), resolves
-#      ancestry against the release HEAD, then calls the pure function.
+#      ACTUALLY RAN the fault-verdict job (skips guard-skipped runs), extracts
+#      that job's conclusion, resolves ancestry against the release HEAD, then
+#      calls the pure function.
 #
 # Self-test: `scripts/check-nightly-fault-run.sh --self-test` exercises the pure
 # decision function across the red / cancelled / stale / missing / pass matrix
-# with NO network — this is the dry-run rejection proof the issue asks for.
+# with NO network, PLUS a fixture-driven end-to-end dry run proving the guard
+# GREENs on a fault-verdict-green run and REDs on a fault-verdict-red run — this
+# is the dry-run rejection proof the issue asks for.
 #
 # Override env (for dry-runs / CI without `gh` creds):
 #   NIGHTLY_FAULT_RUN_FIXTURE   path to a JSON file shaped like one element of
 #                               `gh run list --json ...` PLUS a `jobConclusion`
-#                               field (the extensive-job conclusion). When set,
-#                               the script reads this instead of calling `gh`.
+#                               field (the fault-verdict-job conclusion). When
+#                               set, the script reads this instead of calling `gh`.
 #   NIGHTLY_FAULT_RELEASE_HEAD  override the release HEAD SHA (default: HEAD).
 #   NIGHTLY_FAULT_WORKFLOW      workflow file (default: nightly-extensive.yml).
-#   NIGHTLY_FAULT_JOB_NEEDLE    substring identifying the extensive job
-#                               (default: "Extensive").
+#   NIGHTLY_FAULT_JOB_NEEDLE    substring identifying the fault-verdict job
+#                               (default: "Fault-injection safety verdict").
 #   NIGHTLY_FAULT_GATE_DISABLED=1  skip the guard entirely (escape hatch; the
 #                               release gate prints a loud SKIPPED note).
 
 WORKFLOW="${NIGHTLY_FAULT_WORKFLOW:-nightly-extensive.yml}"
-JOB_NEEDLE="${NIGHTLY_FAULT_JOB_NEEDLE:-Extensive}"
+JOB_NEEDLE="${NIGHTLY_FAULT_JOB_NEEDLE:-Fault-injection safety verdict}"
 
 # ---------------------------------------------------------------------------
 # Layer 1: PURE decision function (no git, no gh, no I/O).
 #
 # Args:
 #   $1 run_status        the run's `status` (e.g. completed / in_progress)
-#   $2 job_conclusion    the EXTENSIVE-job conclusion (success/failure/cancelled
-#                        /timed_out/skipped/"" when the job did not exist)
+#   $2 job_conclusion    the FAULT-VERDICT-job conclusion (success/failure
+#                        /cancelled/timed_out/skipped/"" when the job did not
+#                        exist). This is the network-fault + bootstrap verdict
+#                        ONLY — never the flaky journey suite / #822 lane.
 #   $3 run_head_sha      the run's headSha ("" if no run found)
 #   $4 release_head_sha  the commit being released
 #   $5 head_is_ancestor  "yes" if the run COVERS the release HEAD — i.e.
@@ -94,24 +108,25 @@ evaluate_nightly_fault_run() {
     return 1
   fi
 
-  # The extensive job is `continue-on-error` in the workflow, so the WORKFLOW
-  # conclusion is `success` even when the fault tests failed. The load-bearing
-  # signal is the JOB conclusion. Anything other than `success` is a block.
+  # The load-bearing signal is the dedicated `Fault-injection safety verdict`
+  # JOB conclusion (issue #1201) — the network-fault + bootstrap verdict, with
+  # the flaky journey suite and the #822 expected-fail lane excluded. Anything
+  # other than `success` is a block.
   case "$job_conclusion" in
     success)
-      echo "PASS: nightly fault/bootstrap run is green (extensive job conclusion=success) and covers the release HEAD ($release_head_sha)."
+      echo "PASS: nightly fault-injection safety verdict is green (fault-verdict job conclusion=success) and covers the release HEAD ($release_head_sha). The network-fault + bootstrap safety journeys passed on this line."
       return 0
       ;;
     cancelled)
-      echo "BLOCK: latest nightly fault run was CANCELLED (extensive job conclusion=cancelled) — the fault/bootstrap suite did not complete, so it proves nothing. Re-run 'Nightly Extensive Tests' on the release commit."
+      echo "BLOCK: latest nightly fault-verdict job was CANCELLED (conclusion=cancelled) — the fault/bootstrap suite did not complete, so it proves nothing. Re-run 'Nightly Extensive Tests' on the release commit."
       return 1
       ;;
     "")
-      echo "BLOCK: latest nightly run did not run the extensive fault/bootstrap job (no job matching '$JOB_NEEDLE' — it was guard-skipped or never started). There is no fault signal. Force-run 'Nightly Extensive Tests' on the release commit."
+      echo "BLOCK: latest nightly run did not run the fault-verdict job (no job matching '$JOB_NEEDLE' — it was guard-skipped or never started). There is no fault signal. Force-run 'Nightly Extensive Tests' on the release commit."
       return 1
       ;;
     *)
-      echo "BLOCK: latest nightly fault run is RED (extensive job conclusion='$job_conclusion'). The safety suite (toxiproxy network-fault + bootstrap matrix) failed on the release line — fix the failure or re-run before releasing."
+      echo "BLOCK: latest nightly fault-injection safety verdict is RED (fault-verdict job conclusion='$job_conclusion'). The safety suite (toxiproxy network-fault + bootstrap matrix) failed on the release line — fix the failure or re-run before releasing."
       return 1
       ;;
   esac
@@ -143,15 +158,15 @@ self_test() {
   local REL="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
   local OLD="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 
-  # PASS: completed, job success, covers the release HEAD.
+  # PASS: completed, fault-verdict job success, covers the release HEAD.
   assert_verdict "green-and-current" 0 completed success "$REL" "$REL" yes
-  # BLOCK: extensive job failed (workflow would falsely read success).
+  # BLOCK: fault-verdict job failed (a fault phase actually failed).
   assert_verdict "red-job"           1 completed failure "$REL" "$REL" yes
   # BLOCK: run cancelled.
   assert_verdict "cancelled"         1 completed cancelled "$REL" "$REL" yes
   # BLOCK: timed_out.
   assert_verdict "timed-out"         1 completed timed_out "$REL" "$REL" yes
-  # BLOCK: extensive job absent (guard-skipped / never ran).
+  # BLOCK: fault-verdict job absent (guard-skipped / never ran).
   assert_verdict "job-absent"        1 completed "" "$OLD" "$REL" yes
   # BLOCK: no run found at all.
   assert_verdict "no-run"            1 completed success "" "$REL" no
@@ -161,8 +176,48 @@ self_test() {
   assert_verdict "green-but-stale"   1 completed success "$OLD" "$REL" no
 
   echo
+  # -------------------------------------------------------------------------
+  # Issue #1201 — fixture-driven END-TO-END dry run through the real fetch +
+  # decide path (Layer 2 → Layer 1), proving BOTH load-bearing directions:
+  #   * fault-verdict job GREEN (fault phases passed even though the extensive
+  #     shard is red from an unrelated journey / #822 test) -> guard exits 0;
+  #   * fault-verdict job RED (a fault phase itself failed)  -> guard exits 1.
+  # The fixture's `jobConclusion` IS the dedicated fault-verdict job conclusion,
+  # so this exercises exactly what the guard reads on a real run. headSha ==
+  # release head so the ancestry short-circuit avoids any git dependency.
+  # -------------------------------------------------------------------------
+  local self_path="${BASH_SOURCE[0]}"
+  fixture_dry_run() {
+    local label="$1" expect_rc="$2" job_conclusion="$3"
+    local sha="cccccccccccccccccccccccccccccccccccccccc"
+    local tmp; tmp="$(mktemp)"
+    printf '{"status":"completed","jobConclusion":"%s","headSha":"%s","databaseId":424242}\n' \
+      "$job_conclusion" "$sha" > "$tmp"
+    set +e
+    out="$(NIGHTLY_FAULT_RUN_FIXTURE="$tmp" NIGHTLY_FAULT_RELEASE_HEAD="$sha" \
+      bash "$self_path" 2>&1)"
+    rc=$?
+    set -e
+    rm -f "$tmp"
+    if [[ "$rc" != "$expect_rc" ]]; then
+      printf 'FAIL [%s]: expected guard rc=%s got rc=%s\n%s\n' "$label" "$expect_rc" "$rc" "$out"
+      failures=$((failures + 1))
+    else
+      printf 'ok   [%s] guard rc=%s :: %s\n' "$label" "$rc" "$(printf '%s' "$out" | tail -1)"
+    fi
+  }
+
+  echo "--- fixture-driven end-to-end guard dry run (issue #1201) ---"
+  # Fault phases PASSED (verdict job success) while the extensive shard is red
+  # from unrelated journey / #822 flakes -> the guard GREENs (exit 0). This is
+  # the exact case that used to force NIGHTLY_FAULT_GATE_DISABLED=1.
+  fixture_dry_run "fault-verdict-green-shard-red" 0 success
+  # A fault phase itself FAILED (verdict job failure) -> the guard BLOCKS (exit 1).
+  fixture_dry_run "fault-verdict-red"             1 failure
+
+  echo
   if [[ "$failures" -eq 0 ]]; then
-    echo "SELF-TEST PASS: all 8 cases produced the expected verdict."
+    echo "SELF-TEST PASS: all pure-decision + fixture-driven cases produced the expected verdict."
     return 0
   fi
   echo "SELF-TEST FAIL: $failures case(s) wrong."
@@ -173,8 +228,8 @@ self_test() {
 # Layer 2: fetch + resolve, then call the pure function.
 # ---------------------------------------------------------------------------
 
-# Resolve the latest nightly run that ACTUALLY ran the extensive job, plus that
-# job's conclusion. Emits four tab-separated fields on stdout:
+# Resolve the latest nightly run that ACTUALLY ran the fault-verdict job, plus
+# that job's conclusion. Emits four tab-separated fields on stdout:
 #   <run_status>\t<job_conclusion>\t<run_head_sha>\t<databaseId>
 # job_conclusion is "" when no run ran a matching job.
 #
@@ -192,8 +247,8 @@ resolve_latest_fault_run() {
   command -v gh >/dev/null 2>&1 || { echo "gh CLI is required" >&2; return 2; }
   command -v jq >/dev/null 2>&1 || { echo "jq is required" >&2; return 2; }
 
-  # Pull recent runs. Walk newest→oldest and pick the FIRST whose extensive job
-  # exists (i.e. it was not guard-skipped). Guard-skipped runs only have the
+  # Pull recent runs. Walk newest→oldest and pick the FIRST whose fault-verdict
+  # job exists (i.e. it was not guard-skipped). Guard-skipped runs only have the
   # cheap "Guard" job, so the fault suite never ran — those are not a signal.
   local runs
   runs="$(gh run list --workflow="$WORKFLOW" --limit 15 \
@@ -210,7 +265,7 @@ resolve_latest_fault_run() {
     sha="$(jq -r ".[$i].headSha" <<<"$runs")"
     status="$(jq -r ".[$i].status" <<<"$runs")"
 
-    # Inspect this run's jobs; find the extensive job by name needle.
+    # Inspect this run's jobs; find the fault-verdict job by name needle.
     local jobs job_conclusion
     jobs="$(gh run view "$id" --json jobs 2>/dev/null)" || continue
     job_conclusion="$(jq -r --arg needle "$JOB_NEEDLE" \
@@ -221,10 +276,10 @@ resolve_latest_fault_run() {
       printf '%s\t%s\t%s\t%s\n' "$status" "$job_conclusion" "$sha" "$id"
       return 0
     fi
-    # else: extensive job did not run in this run (guard-skipped) → keep looking.
+    # else: fault-verdict job did not run in this run (guard-skipped) → keep looking.
   done
 
-  # No run in the window actually ran the extensive job.
+  # No run in the window actually ran the fault-verdict job.
   printf '%s\t%s\t%s\t%s\n' "completed" "" "" ""
   return 0
 }
@@ -267,7 +322,7 @@ main() {
     fi
   fi
 
-  echo "Nightly fault run: workflow=$WORKFLOW id=${db_id:-none} status=${run_status:-?} extensive-job-conclusion=${job_conclusion:-<none>} headSha=${run_head_sha:-<none>}"
+  echo "Nightly fault run: workflow=$WORKFLOW id=${db_id:-none} status=${run_status:-?} fault-verdict-job-conclusion=${job_conclusion:-<none>} headSha=${run_head_sha:-<none>}"
   echo "Release HEAD=$release_head head_is_ancestor=$head_is_ancestor"
 
   local verdict rc

--- a/scripts/lib/nightly-fault-verdict.sh
+++ b/scripts/lib/nightly-fault-verdict.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# nightly-fault-verdict.sh — the authoritative fault-injection safety verdict
+# helper (issue #1201).
+#
+# WHY THIS EXISTS
+# ---------------
+# The release gate's nightly-fault guard (scripts/check-nightly-fault-run.sh,
+# #851) used to block the release on the WHOLE "Nightly Extensive Tests"
+# extensive-job conclusion. But that shard mixes THREE unrelated things:
+#
+#   1. phase 1 — the full connected journey/E2E suite (chronic emulator /
+#      toxiproxy infra flakes + stale-test debt);
+#   2. phase 2 — the toxiproxy network-fault proofs (the ACTUAL fault suite);
+#   3. phase 3 — the bootstrap setup-scenario matrix (also a release-gating
+#      safety journey);
+#
+#   plus an intentional TDD "expected-fail" lane (#822 Slice C/D unbuilt-feature
+#   journeys, designed RED until the slice lands).
+#
+# Because phase 1's chronic flakes and the #822 expected-fail lane are ALWAYS
+# red, the extensive job conclusion was essentially never `success`, so the
+# release gate had to be waived with NIGHTLY_FAULT_GATE_DISABLED=1 on every
+# recent release — a permanently-waived safety gate protects nothing.
+#
+# This helper computes a verdict that reflects ONLY the fault-injection safety
+# phases (network-fault + bootstrap), EXCLUDING the flaky journey suite AND the
+# non-gating #822 expected-fail lane. `nightly-extensive-suite.sh` writes that
+# verdict to a machine-readable file on the shard that runs those phases; the
+# workflow's dedicated `Fault-injection safety verdict` job reads it and turns it
+# into a job conclusion; and `check-nightly-fault-run.sh` reads THAT job's
+# conclusion (not the mixed extensive-job conclusion).
+#
+# Everything here is PURE (no gradle, no emulator, no network) so it is
+# unit-testable with `scripts/lib/nightly-fault-verdict.sh --self-test`.
+
+# ---------------------------------------------------------------------------
+# compute_fault_verdict <network_fault_status> <bootstrap_status>
+#
+# The two arguments are the PASS/FAIL results of the network-fault (phase 2) and
+# bootstrap (phase 3) phases. The journey phase (phase 1) and the #822
+# expected-fail lane are DELIBERATELY not arguments — they must never influence
+# the fault-injection safety verdict.
+#
+# Prints "PASS" / "FAIL"; returns 0 (pass) / 1 (fail).
+# ---------------------------------------------------------------------------
+compute_fault_verdict() {
+  local network_fault_status="$1"
+  local bootstrap_status="$2"
+
+  if [[ "$network_fault_status" == "PASS" && "$bootstrap_status" == "PASS" ]]; then
+    echo "PASS"
+    return 0
+  fi
+  echo "FAIL"
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# write_fault_verdict_file <path> <nf_status> <nf_exit> <bootstrap_status> \
+#                          <bootstrap_exit> <expectedfail_status> <expectedfail_exit>
+#
+# Writes the machine-readable verdict file the CI `Fault-injection safety
+# verdict` job reads. The expected-fail fields are recorded for TRACKING only
+# and are explicitly NON-GATING (they do not feed `fault_verdict`).
+# ---------------------------------------------------------------------------
+write_fault_verdict_file() {
+  local path="$1"
+  local nf_status="$2"
+  local nf_exit="$3"
+  local bootstrap_status="$4"
+  local bootstrap_exit="$5"
+  local expectedfail_status="$6"
+  local expectedfail_exit="$7"
+
+  local verdict
+  # `compute_fault_verdict` returns non-zero on FAIL; capture the string without
+  # letting a caller's `set -e` abort here (the assignment inherits its status).
+  verdict="$(compute_fault_verdict "$nf_status" "$bootstrap_status")" || true
+
+  {
+    echo "# Fault-injection safety verdict (issue #1201) — machine-readable."
+    echo "# GATING inputs: network-fault (phase 2) + bootstrap (phase 3) ONLY."
+    echo "# The journey/E2E suite (phase 1) and the #822 expected-fail lane"
+    echo "# (phase 2b) are DELIBERATELY excluded and never gate this verdict."
+    echo "fault_phase_ran=yes"
+    echo "network_fault_status=$nf_status"
+    echo "network_fault_exit=$nf_exit"
+    echo "bootstrap_status=$bootstrap_status"
+    echo "bootstrap_exit=$bootstrap_exit"
+    echo "# NON-GATING (tracked only): the #822 Slice C/D expected-fail lane."
+    echo "expected_fail_status=$expectedfail_status"
+    echo "expected_fail_exit=$expectedfail_exit"
+    echo "fault_verdict=$verdict"
+  } > "$path"
+}
+
+# ---------------------------------------------------------------------------
+# Self-test: exercises the pure verdict function across the full matrix with NO
+# gradle/emulator. This is the dry-run proof (issue #1201 acceptance) that the
+# verdict GREENs when the fault phases passed even though the journey suite /
+# expected-fail lane are red, and REDs when a fault phase itself failed.
+# ---------------------------------------------------------------------------
+_fault_verdict_self_test() {
+  local failures=0
+  local out rc tmp
+
+  assert_verdict() {
+    local label="$1" expect="$2" expect_rc="$3" nf="$4" bootstrap="$5"
+    out="$(compute_fault_verdict "$nf" "$bootstrap")" && rc=0 || rc=$?
+    if [[ "$out" != "$expect" || "$rc" != "$expect_rc" ]]; then
+      printf 'FAIL [%s]: expected %s(rc=%s) got %s(rc=%s)\n' \
+        "$label" "$expect" "$expect_rc" "$out" "$rc"
+      failures=$((failures + 1))
+    else
+      printf 'ok   [%s] -> %s (rc=%s)\n' "$label" "$out" "$rc"
+    fi
+  }
+
+  # Both gating phases green -> PASS.
+  assert_verdict "nf+bootstrap green"                 PASS 0 PASS PASS
+  # A gating phase red -> FAIL.
+  assert_verdict "nf red"                             FAIL 1 FAIL PASS
+  assert_verdict "bootstrap red"                      FAIL 1 PASS FAIL
+  assert_verdict "both gating red"                    FAIL 1 FAIL FAIL
+
+  # THE load-bearing #1201 direction, at the FILE level: the journey suite and
+  # the #822 expected-fail lane are red, but the fault phases passed -> the
+  # written verdict is PASS and does NOT reflect the unrelated red.
+  echo
+  echo "--- file-level dry run: fault phases green, journey + expected-fail RED ---"
+  tmp="$(mktemp)"
+  # journey (not an arg here) FAIL + expected-fail FAIL, but nf/bootstrap PASS.
+  write_fault_verdict_file "$tmp" PASS 0 PASS 0 FAIL 1
+  cat "$tmp"
+  if grep -q '^fault_verdict=PASS$' "$tmp"; then
+    echo "ok   [file] fault_verdict=PASS despite expected-fail lane red"
+  else
+    echo "FAIL [file] fault_verdict should be PASS despite expected-fail lane red"
+    failures=$((failures + 1))
+  fi
+  rm -f "$tmp"
+
+  echo
+  echo "--- file-level dry run: a fault phase itself RED -> verdict FAIL ---"
+  tmp="$(mktemp)"
+  write_fault_verdict_file "$tmp" FAIL 1 PASS 0 FAIL 1
+  cat "$tmp"
+  if grep -q '^fault_verdict=FAIL$' "$tmp"; then
+    echo "ok   [file] fault_verdict=FAIL when the network-fault phase failed"
+  else
+    echo "FAIL [file] fault_verdict should be FAIL when the network-fault phase failed"
+    failures=$((failures + 1))
+  fi
+  rm -f "$tmp"
+
+  echo
+  if [[ "$failures" -eq 0 ]]; then
+    echo "FAULT-VERDICT SELF-TEST PASS: all cases produced the expected verdict."
+    return 0
+  fi
+  echo "FAULT-VERDICT SELF-TEST FAIL: $failures case(s) wrong."
+  return 1
+}
+
+# Allow running directly for the self-test; stays a pure library when sourced.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  if [[ "${1:-}" == "--self-test" ]]; then
+    _fault_verdict_self_test
+    exit $?
+  fi
+  echo "usage: source this file, or run with --self-test" >&2
+  exit 2
+fi

--- a/scripts/nightly-extensive-suite.sh
+++ b/scripts/nightly-extensive-suite.sh
@@ -97,18 +97,6 @@ NETWORK_FAULT_CLASSES=(
   # no longer tears itself down. The test now passes GREEN; enrolled here as the
   # standing nightly regression guard.
   "$FQCN_PREFIX.CodexRedrawOverflowReconnectE2eTest"
-  # EPIC #792 Slice D (#822/V7a): the FAITHFUL silent half-open drop proof. A
-  # toxiproxy `timeout=0` blackhole keeps the TCP socket established while
-  # dropping every byte (the authentic half-open Wi-Fi drop sshj's isConnected
-  # lies about for ~60s). On an IDLE channel with NO send, the LivenessProbe must
-  # surface the connection-lost indicator within the bounded probe window, and
-  # after the link returns the SAME session must auto-recover with no switch
-  # dance. This is the AUTHENTIC half-open reproduction; the per-PR
-  # SilentDropSyntheticSeam* sibling runs the same detection/recovery contract on
-  # the deterministic agents:2222 fixture via the probe's synthetic-drop seam (so
-  # D31's per-push gate is met without depending on the toxiproxy family). Reuses
-  # network-fault-proxy:2228 + toxiproxy API:8474 (no new fixture).
-  "$FQCN_PREFIX.SilentMidSessionDropDetectionE2eTest"
   # Issue #1139 (maintainer's #1 freeze / top v0.4.20 release-gate item): the
   # push-notification → resume-an-idle-overnight-session UI freeze. A toxiproxy
   # `timeout=0` blackhole DEAD-HOLDS the `-CC` socket (half-open, no FIN — the
@@ -137,6 +125,30 @@ NETWORK_FAULT_CLASSES=(
   "$FQCN_PREFIX.NatIdleMappingSurvivalE2eTest"
 )
 
+# ---------------------------------------------------------------------------
+# EXPECTED-FAIL lane (issue #1201, de-gated from the fault verdict).
+#
+# The #822 Slice C/D journeys (SilentMidSessionDropDetectionE2eTest) are TDD-style
+# executable specs for UNBUILT connection-manager features — the two tests assert
+# "Expected to FAIL until the LivenessProbe (Slice D) lands" / "until the
+# controller-owned reconnect ladder (Slice C) lands". They are DESIGNED red until
+# those slices land. They are NOT fault-suite regressions, so they must NOT poison
+# the fault-injection safety verdict the release gate reads (that is exactly what
+# forced every recent release to waive the gate with NIGHTLY_FAULT_GATE_DISABLED=1).
+#
+# They still RUN nightly (their tracking value — their artifacts/timings are still
+# uploaded and their status is still shown in the summary), but in their OWN phase
+# (2b) whose exit code is recorded as informational only and is DELIBERATELY
+# excluded from both `overall_status` and the machine-readable fault verdict. When
+# Slice C/D lands and they turn GREEN, promote them back into NETWORK_FAULT_CLASSES.
+#
+# They use the same toxiproxy harness (NetworkFaultProofBase → network-fault-proxy
+# :2228 + toxiproxy API:8474) as the gating proofs, so they run WITH the same
+# pocketshellNetworkFaultProofs=true opt-in flag.
+EXPECTED_FAIL_CLASSES=(
+  "$FQCN_PREFIX.SilentMidSessionDropDetectionE2eTest"
+)
+
 # The bootstrap setup-scenario class (opt-in via pocketshellBootstrapScenarios).
 # Run as a trimmed slice in its own phase; excluded from the journey phase so it
 # does not just self-skip there (the journey phase never passes the opt-in flag).
@@ -155,11 +167,13 @@ BOOTSTRAP_CLASS_ARG="$(printf "%s\n" "${BOOTSTRAP_METHODS[@]}" \
   | sed "s|^|$BOOTSTRAP_TEST_CLASS#|" | paste -sd, -)"
 
 # Classes excluded from the journey/E2E phase: the network-fault proofs (run in
-# their own un-gated phase), the opt-in-only release-gate classes that need
-# extra env/args, and the opt-in bootstrap scenario suite (run in its own phase
-# with the pocketshellBootstrapScenarios flag) — all would otherwise self-skip.
+# their own un-gated phase), the #822 expected-fail lane (run in its own
+# non-gating phase 2b), the opt-in-only release-gate classes that need extra
+# env/args, and the opt-in bootstrap scenario suite (run in its own phase with
+# the pocketshellBootstrapScenarios flag) — all would otherwise self-skip.
 JOURNEY_EXCLUDED_CLASSES=(
   "${NETWORK_FAULT_CLASSES[@]}"
+  "${EXPECTED_FAIL_CLASSES[@]}"
   "$FQCN_PREFIX.LongRunningSessionStabilityTest"
   "$FQCN_PREFIX.LongRunningInstrumentationHeartbeatTest"
   "$FQCN_PREFIX.RealAgentReleaseGateTest"
@@ -173,7 +187,15 @@ join_by() {
 }
 
 NETWORK_FAULT_CLASS_ARG="$(join_by , "${NETWORK_FAULT_CLASSES[@]}")"
+EXPECTED_FAIL_CLASS_ARG="$(join_by , "${EXPECTED_FAIL_CLASSES[@]}")"
 JOURNEY_NOTCLASS_ARG="$(join_by , "${JOURNEY_EXCLUDED_CLASSES[@]}")"
+
+# The machine-readable fault-verdict helper (issue #1201): pure PASS/FAIL from the
+# network-fault + bootstrap phases ONLY (never the journey suite or the
+# expected-fail lane). Written to a file the CI fault-verdict job reads.
+# shellcheck source=scripts/lib/nightly-fault-verdict.sh
+source "$REPO_ROOT/scripts/lib/nightly-fault-verdict.sh"
+FAULT_VERDICT_FILE="$ARTIFACT_DIR/fault-verdict.txt"
 
 # ---------------------------------------------------------------------------
 # Sharding (issue #835 follow-up): the full connected journey/E2E suite is
@@ -230,12 +252,14 @@ echo "phase 1 (journey/E2E) exit code: $JOURNEY_EXIT"
 # Default the aux phases to SKIPPED; only the shard that owns them flips these.
 NETWORK_FAULT_EXIT=0
 BOOTSTRAP_EXIT=0
+EXPECTED_FAIL_EXIT=0
 nf_status="SKIP"
 bootstrap_status="SKIP"
+expectedfail_status="SKIP"
 
 if [[ "$RUN_AUX_PHASES" == "yes" ]]; then
   echo "=========================================================="
-  echo "Nightly Extensive Tests — phase 2: network-fault proofs (un-gated)"
+  echo "Nightly Extensive Tests — phase 2: network-fault proofs (un-gated, GATING)"
   echo "Included classes: $NETWORK_FAULT_CLASS_ARG"
   echo "  (pocketshellNetworkFaultProofs=true, pocketshellCi NOT set)"
   echo "=========================================================="
@@ -251,7 +275,26 @@ if [[ "$RUN_AUX_PHASES" == "yes" ]]; then
   echo "phase 2 (network-fault proofs) exit code: $NETWORK_FAULT_EXIT"
 
   echo "=========================================================="
-  echo "Nightly Extensive Tests — phase 3: bootstrap setup scenarios (opt-in)"
+  echo "Nightly Extensive Tests — phase 2b: #822 expected-fail lane (NON-GATING)"
+  echo "Included classes: $EXPECTED_FAIL_CLASS_ARG"
+  echo "  (pocketshellNetworkFaultProofs=true; result is INFORMATIONAL ONLY —"
+  echo "   these are TDD specs for unbuilt Slice C/D features, designed RED, and"
+  echo "   are DELIBERATELY excluded from the fault verdict — issue #1201)"
+  echo "=========================================================="
+
+  # Issue #1201: the #822 Slice C/D journeys still RUN nightly (their tracking
+  # value) but in their OWN phase whose exit code NEVER feeds `overall_status` or
+  # the machine-readable fault verdict — so an intentional red here can no longer
+  # poison the release-gating fault signal.
+  "$GRADLEW" :app:connectedDebugAndroidTest \
+    -Pandroid.testInstrumentationRunnerArguments.pocketshellNetworkFaultProofs=true \
+    -Pandroid.testInstrumentationRunnerArguments.class="$EXPECTED_FAIL_CLASS_ARG" \
+    --stacktrace
+  EXPECTED_FAIL_EXIT=$?
+  echo "phase 2b (#822 expected-fail lane) exit code: $EXPECTED_FAIL_EXIT (NON-GATING)"
+
+  echo "=========================================================="
+  echo "Nightly Extensive Tests — phase 3: bootstrap setup scenarios (opt-in, GATING)"
   echo "Selected methods: $BOOTSTRAP_CLASS_ARG"
   echo "  (pocketshellBootstrapScenarios=true, pocketshellCi NOT set)"
   echo "=========================================================="
@@ -271,16 +314,40 @@ if [[ "$RUN_AUX_PHASES" == "yes" ]]; then
   [[ "$NETWORK_FAULT_EXIT" -ne 0 ]] && nf_status="FAIL"
   bootstrap_status="PASS"
   [[ "$BOOTSTRAP_EXIT" -ne 0 ]] && bootstrap_status="FAIL"
+  expectedfail_status="PASS"
+  [[ "$EXPECTED_FAIL_EXIT" -ne 0 ]] && expectedfail_status="FAIL"
+
+  # Issue #1201: emit the authoritative, machine-readable fault-injection safety
+  # verdict from the network-fault + bootstrap phases ONLY. The journey suite
+  # (phase 1) and the #822 expected-fail lane (phase 2b) are DELIBERATELY not
+  # inputs, so their chronic/intentional red can no longer flip this verdict. The
+  # CI `Fault-injection safety verdict` job reads this file; the release-gate
+  # guard reads THAT job's conclusion.
+  write_fault_verdict_file \
+    "$FAULT_VERDICT_FILE" \
+    "$nf_status" "$NETWORK_FAULT_EXIT" \
+    "$bootstrap_status" "$BOOTSTRAP_EXIT" \
+    "$expectedfail_status" "$EXPECTED_FAIL_EXIT"
+  fault_verdict="$(grep -E '^fault_verdict=' "$FAULT_VERDICT_FILE" | head -1 | cut -d= -f2)"
+  echo "----------------------------------------------------------"
+  echo "Fault-injection safety verdict (issue #1201) -> $fault_verdict"
+  cat "$FAULT_VERDICT_FILE"
+  echo "----------------------------------------------------------"
 else
   echo "=========================================================="
-  echo "Nightly Extensive Tests — phases 2 & 3 SKIPPED on shard ${SHARD_INDEX:-0}"
-  echo "  (network-fault proofs + bootstrap scenarios run once, on shard 0)"
+  echo "Nightly Extensive Tests — phases 2, 2b & 3 SKIPPED on shard ${SHARD_INDEX:-0}"
+  echo "  (network-fault + expected-fail + bootstrap run once, on shard 0)"
   echo "=========================================================="
 fi
 
 journey_status="PASS"
 [[ "$JOURNEY_EXIT" -ne 0 ]] && journey_status="FAIL"
 
+# `overall_status` is the human/summary verdict for the whole extensive shard. It
+# includes the journey suite and both GATING fault phases, but NOT the #822
+# expected-fail lane (phase 2b) — including an intentionally-red TDD lane would
+# make the shard summary permanently red for a non-reason. Note: `overall_status`
+# is NOT the release-gating signal; the machine-readable fault verdict above is.
 overall_status="PASS"
 if [[ "$JOURNEY_EXIT" -ne 0 || "$NETWORK_FAULT_EXIT" -ne 0 || "$BOOTSTRAP_EXIT" -ne 0 ]]; then
   overall_status="FAIL"
@@ -299,18 +366,37 @@ fi
   echo
   echo "| Phase | Selection | Args | Exit | Result |"
   echo "| --- | --- | --- | --- | --- |"
-  echo "| Journey / E2E | full connected suite minus network-fault + opt-in classes ($shard_label) | \`pocketshellCi=true\` | $JOURNEY_EXIT | **$journey_status** |"
-  echo "| Network-fault proofs | ${#NETWORK_FAULT_CLASSES[@]} NetworkFaultProofBase classes | \`pocketshellNetworkFaultProofs=true\` (no pocketshellCi) | $NETWORK_FAULT_EXIT | **$nf_status** |"
-  echo "| Bootstrap setup scenarios | ${#BOOTSTRAP_METHODS[@]} HostBootstrapScenarioSuiteTest methods (trimmed) | \`pocketshellBootstrapScenarios=true\` | $BOOTSTRAP_EXIT | **$bootstrap_status** |"
+  echo "| Journey / E2E (non-gating) | full connected suite minus network-fault + expected-fail + opt-in classes ($shard_label) | \`pocketshellCi=true\` | $JOURNEY_EXIT | **$journey_status** |"
+  echo "| Network-fault proofs (GATING) | ${#NETWORK_FAULT_CLASSES[@]} NetworkFaultProofBase classes | \`pocketshellNetworkFaultProofs=true\` (no pocketshellCi) | $NETWORK_FAULT_EXIT | **$nf_status** |"
+  echo "| #822 expected-fail lane (NON-GATING) | ${#EXPECTED_FAIL_CLASSES[@]} Slice C/D TDD spec class(es) | \`pocketshellNetworkFaultProofs=true\` | $EXPECTED_FAIL_EXIT | **$expectedfail_status** |"
+  echo "| Bootstrap setup scenarios (GATING) | ${#BOOTSTRAP_METHODS[@]} HostBootstrapScenarioSuiteTest methods (trimmed) | \`pocketshellBootstrapScenarios=true\` | $BOOTSTRAP_EXIT | **$bootstrap_status** |"
   echo
-  echo "**Overall: $overall_status**"
+  echo "**Extensive-shard overall (non-gating summary): $overall_status**"
   echo
-  echo "Network-fault classes exercised:"
+  echo "## Fault-injection safety verdict (issue #1201 — the RELEASE-GATING signal)"
+  echo
+  if [[ "$RUN_AUX_PHASES" == "yes" ]]; then
+    echo "\`fault_verdict\` = network-fault ($nf_status) + bootstrap ($bootstrap_status) ONLY."
+    echo "The journey suite and the #822 expected-fail lane are DELIBERATELY excluded."
+    echo
+    echo '```'
+    cat "$FAULT_VERDICT_FILE"
+    echo '```'
+  else
+    echo "Not computed on this shard (aux phases run once, on shard 0)."
+  fi
+  echo
+  echo "Network-fault classes exercised (GATING):"
   for c in "${NETWORK_FAULT_CLASSES[@]}"; do
     echo "- \`$c\`"
   done
   echo
-  echo "Bootstrap setup scenarios exercised (\`$BOOTSTRAP_TEST_CLASS\`):"
+  echo "#822 expected-fail lane (NON-GATING, tracked only — TDD specs for unbuilt Slice C/D):"
+  for c in "${EXPECTED_FAIL_CLASSES[@]}"; do
+    echo "- \`$c\`"
+  done
+  echo
+  echo "Bootstrap setup scenarios exercised (\`$BOOTSTRAP_TEST_CLASS\`, GATING):"
   for m in "${BOOTSTRAP_METHODS[@]}"; do
     echo "- \`$m\`"
   done


### PR DESCRIPTION
Closes #1201. The D28 connection-core release safety gate was always-red-and-waived (mixed extensive shard = #822 expected-fails + infra flakes), so it protected nothing. Now emits a fault-phase-only verdict (toxiproxy network-fault + bootstrap) via a dedicated non-`continue-on-error` job the guard reads; #822's sole expected-fail test moved to a non-gating lane (still runs+uploads); all 12 real fault classes stay gating.

Reviewer ran both self-tests (rc=0) and verified: false-pass is structurally impossible (PASS only when fault+bootstrap pass; every degenerate path fails safe → BLOCK), false-fail (chronic flake) fixed, gate not blinded. Escape hatch untouched. Orchestrator gate: both `--self-test`s pass both directions.