### PR TITLE
terminal: heal a mostly-empty model at reveal/resize/switch (#1214)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/MostlyEmptyModelHealsAtRevealJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/MostlyEmptyModelHealsAtRevealJourneyE2eTest.kt
@@ -1,0 +1,608 @@
+package com.pocketshell.app.proof
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.os.SystemClock
+import android.util.Log
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.ViewModelProvider
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.MainActivity
+import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
+import com.pocketshell.app.hosts.SshKeyStorage
+import com.pocketshell.app.tmux.TMUX_CONNECTING_PROGRESS_TAG
+import com.pocketshell.app.tmux.TMUX_SESSION_ERROR_TAG
+import com.pocketshell.app.tmux.TMUX_SESSION_RECONNECT_TAG
+import com.pocketshell.app.tmux.TMUX_SESSION_SCREEN_TAG
+import com.pocketshell.app.tmux.TMUX_SWITCHING_LOADING_TAG
+import com.pocketshell.app.tmux.TmuxSessionViewModel
+import com.pocketshell.core.ssh.KnownHostsPolicy
+import com.pocketshell.core.ssh.SshConnection
+import com.pocketshell.core.ssh.SshKey
+import com.pocketshell.core.storage.AppDatabase
+import com.pocketshell.core.storage.entity.HostEntity
+import com.termux.view.TerminalView
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.runner.RunWith
+import java.io.File
+import java.io.FileOutputStream
+
+/**
+ * Issue #1214 — DEVICE-TRUTH journey: a MOSTLY-EMPTY model (fragments-over-black with MORE than 3
+ * live lines) must heal AT REVEAL, not ~4s later at the steady watchdog.
+ *
+ * ## The production bug (reveal-time leg of the #1208 fragments-over-black)
+ *
+ * The reveal/resize/switch nets gate an authoritative `capture-pane` diff on the CHEAP LOCAL
+ * pre-check [com.pocketshell.core.terminal.ui.TerminalSurfaceState.visibleRenderMayHaveLostFrame].
+ * Before #1214 that pre-check only flagged a live-fraction in `(0.5, 0.75]` or a ≤3-line
+ * partial-blank. So a mostly-empty pane with >3 scattered live lines but a live-fraction BELOW 0.5
+ * read "healthy" at the reveal gate and the no-op-resize heal → it REVEALED UNHEALED
+ * (fragments-over-black) and only the ≤16s-later steady watchdog could catch it. #1214 drops the
+ * 0.5 lower bound so the reveal/resize nets pay ONE authoritative diff for the mostly-empty model.
+ *
+ * ## How this reproduces the bug deterministically on agents:2222 (no toxiproxy)
+ *
+ * Seed a FULL multi-row banner as an idle full-screen pane, attach, then model the reveal-time
+ * fragments-over-black straight into the SAME emulator the app renders: a `CSI 2J` + `CSI H`
+ * (erase + home) wipes the banner, then FIVE scattered live lines are painted. Five live lines is
+ * MORE than the ≤3-line partial-black cap AND well below the 0.5 live-fraction floor — the exact
+ * #1214 gap the pre-#1214 pre-check read "healthy". The REMOTE tmux grid is untouched, so
+ * `capture-pane` still holds the FULL banner. Then drive the EXACT same-dimension (no-op) resize
+ * heal production branch (a keyboard/composer dismissal). On base the widened-only-to-the-dead-zone
+ * pre-check SKIPS the sub-0.5 mostly-empty pane → the banner stays gone within the SHORT heal
+ * window → RED. With #1214 the pre-check flags it → the no-op-resize heal confirms against tmux and
+ * re-captures the full viewport AT reveal → GREEN. Uses ONLY the deterministic `agents` fixture
+ * (host port 2222), feeds the emulator locally (no toxiproxy, no
+ * `Assume.assumeFalse(isRunningOnCi())`), so it RUNS on the per-PR CI emulator-journey job once
+ * wired into `scripts/ci-journey-suite.sh`.
+ *
+ * ## Contract (DEVICE TRUTH — asserts the user's pixels)
+ *
+ *  1. Before the reveal, the active pane shows the full banner (baseline).
+ *  2. The mostly-empty model is REAL on screen: the banner is gone, >3 fragment lines survive, the
+ *     pane reads NON-blank AND NON-partial-black (the origin/main reveal-gate skip precondition),
+ *     and the widened #1214 pre-check flags it.
+ *  3. After the (same-dimension) resize heal the active pane is RE-SEEDED to the full prior
+ *     content: the banner is restored PROMPTLY. On base the sub-0.5 mostly-empty pane is skipped,
+ *     so the banner is never restored within the short window → RED.
+ *  4. NO Reconnecting/Disconnected/Connecting/Attaching surface appears (the heal is a calm
+ *     in-place re-capture, not a reconnect).
+ */
+@RunWith(AndroidJUnit4::class)
+class MostlyEmptyModelHealsAtRevealJourneyE2eTest {
+
+    val compose = createAndroidComposeRule<MainActivity>()
+    private val grantPermissions = PreGrantPermissionsRule()
+
+    @get:Rule
+    val ruleChain: RuleChain = RuleChain
+        .outerRule(grantPermissions)
+        .around(SeedBeforeLaunchRule { seedBeforeLaunch() })
+        .around(compose)
+
+    private var seededKey: String? = null
+    private var seededHostRowTag: String? = null
+    private val timings = mutableListOf<String>()
+
+    @After
+    fun tearDown() {
+        runCatching { compose.activityRule.scenario.moveToState(Lifecycle.State.RESUMED) }
+        seededKey?.let { key -> runCatching { runBlocking { cleanupRemoteTmuxSession(key) } } }
+    }
+
+    @Test
+    fun mostlyEmptyModelHealsAtRevealNotAtTheWatchdog() { runBlocking {
+        val hostRowTag = requireNotNull(seededHostRowTag) { "seed-before-launch host row missing" }
+        attachSeededTmuxSession(hostRowTag)
+
+        // (1) Baseline: the full multi-row banner is on screen and the channel is Connected.
+        waitForVisibleTerminal("initial attach banner") { bannerRowCount(it) >= MIN_RESTORED_BANNER_ROWS }
+        waitForConnected("initial attach")
+        captureViewport("issue1214-01-attached")
+
+        val cycleStart = SystemClock.elapsedRealtime()
+
+        // (2) Model the reveal-time fragments-over-black: erase the display + home, then paint
+        // FIVE scattered live lines — straight into the SAME emulator the app renders. Five live
+        // lines is MORE than the ≤3-line partial-black cap AND far below the 0.5 live-fraction
+        // floor: the exact #1214 gap the pre-#1214 pre-check read "healthy". The banner above is
+        // WIPED; the REMOTE tmux grid still holds the full banner, so only the #1214-widened
+        // reveal/resize heal restores it.
+        injectMostlyEmptyModel()
+        val fragmentView = waitForVisibleTerminal("mostly-empty fragments-over-black") {
+            it.contains(FRAGMENT_MARKER) && bannerRowCount(it) < MIN_RESTORED_BANNER_ROWS
+        }
+        assertTrue(
+            "mostly-empty precondition must keep the >3 fragment lines ('$FRAGMENT_MARKER') so the " +
+                "pane reads NON-partial-black; visible:\n$fragmentView",
+            fragmentView.contains(FRAGMENT_MARKER),
+        )
+        assertTrue(
+            "mostly-empty precondition must have WIPED the full banner; visible:\n$fragmentView",
+            bannerRowCount(fragmentView) < MIN_RESTORED_BANNER_ROWS,
+        )
+        // The exact origin/main reveal-gate skip precondition + the #1214 pre-check now catching it.
+        assertFalse(
+            "RED premise (#1214): the >3-line mostly-empty model reads NON-blank AND " +
+                "NON-partial-black, so the pre-#1214 blank/partial reveal net SKIPPED it",
+            activePaneBlankOrPartiallyBlank(),
+        )
+        assertTrue(
+            "GREEN premise (#1214): the widened local capture-gate must flag the mostly-empty model " +
+                "so the reveal/resize heal pays the authoritative capture",
+            activePaneMayHaveLostFrame(),
+        )
+        captureViewport("issue1214-02-mostly-empty")
+        recordTiming("mostly_empty_injected_ms", SystemClock.elapsedRealtime() - cycleStart)
+
+        // ----- DISCRIMINATOR: the transport is GUARANTEED LIVE (render bug, not a drop). -----
+        assertTrue(
+            "the transport must stay Connected with a mostly-empty render, observed=${currentConnectionStatus()}",
+            currentConnectionStatus() is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+
+        // (3) Drive the EXACT same-dimension (no-op) resize heal production branch a
+        // composer/keyboard dismissal takes. On base the sub-0.5 mostly-empty pane is skipped; with
+        // #1214 the heal confirms against tmux and re-captures the full viewport AT reveal.
+        var triggered = false
+        compose.activityRule.scenario.onActivity { activity ->
+            triggered = viewModel(activity).triggerSameDimensionResizeHealForTest()
+        }
+        assertTrue("expected the same-dimension resize heal seam to find a live runtime", triggered)
+        recordTiming("resize_heal_triggered_ms", SystemClock.elapsedRealtime() - cycleStart)
+
+        // DEVICE-TRUTH assertion (3): the active pane is RE-SEEDED to the full banner within a
+        // SHORT window (a single `capture-pane`). Kept well below the idle passive-disconnect
+        // timeout so a later transport reattach cannot mask a missing reveal-time heal on base.
+        waitForVisibleTerminal(
+            "post-heal full-viewport restore",
+            timeoutMillis = HEAL_RESTORE_TIMEOUT_MS,
+        ) { bannerRowCount(it) >= MIN_RESTORED_BANNER_ROWS }
+        val visibleAfter = visibleTerminalText()
+        assertTrue(
+            "the reveal-time heal must PROMPTLY restore the active pane's full banner " +
+                "(>= $MIN_RESTORED_BANNER_ROWS rows) — the pane must NOT stay fragments-over-black; " +
+                "visible terminal was:\n$visibleAfter",
+            bannerRowCount(visibleAfter) >= MIN_RESTORED_BANNER_ROWS,
+        )
+        recordTiming("banner_restored_ms", SystemClock.elapsedRealtime() - cycleStart)
+        captureViewport("issue1214-03-full-viewport-restored")
+
+        // DEVICE-TRUTH assertion (4): NO reconnect surface across the heal + a short settle.
+        watchNoVisibleReconnect("mostly-empty reveal heal settle", OVERLAY_WATCH_MS)
+
+        assertTrue(
+            "tmux session screen must still be up after the reveal-time heal",
+            compose.onAllNodesWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .isNotEmpty(),
+        )
+        assertTrue(
+            "session must stay Connected after the heal (render fix, no reconnect), " +
+                "observed=${currentConnectionStatus()}",
+            currentConnectionStatus() is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+
+        writeSummary()
+        writeTimings()
+        Unit
+    } }
+
+    // ---------------------------------------------------------------- Helpers
+
+    /**
+     * Model the reveal-time fragments-over-black straight into the SAME emulator the app renders: a
+     * `CSI 2J` (erase entire display) + `CSI H` (home) wipes the banner, then FIVE scattered live
+     * lines are painted (each separated by a blank row — genuine fragments-over-black). Five live
+     * lines is MORE than the ≤3-line partial-black cap AND far below the 0.5 live-fraction floor —
+     * the #1214 gap. Local to the emulator; the remote tmux grid keeps the full banner.
+     */
+    private fun injectMostlyEmptyModel() {
+        val esc = ""
+        val frame = buildString {
+            append("$esc[2J$esc[H")
+            repeat(5) { i ->
+                append("$FRAGMENT_MARKER fragment $i over black\r\n\r\n")
+            }
+        }.toByteArray(Charsets.UTF_8)
+        var fed = false
+        compose.activityRule.scenario.onActivity { activity ->
+            val view = activity.window.decorView.findTerminalView() ?: return@onActivity
+            val emulator = view.mEmulator ?: return@onActivity
+            emulator.append(frame, frame.size)
+            view.invalidate()
+            fed = true
+        }
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        assertTrue("expected to inject the mostly-empty frame to the active pane emulator", fed)
+        Log.i(LOG_TAG, "injected mostly-empty model (2J + home + 5 scattered live lines)")
+    }
+
+    private fun activePaneBlankOrPartiallyBlank(): Boolean {
+        var hit = false
+        compose.activityRule.scenario.onActivity { activity ->
+            hit = viewModel(activity).panes.value.firstOrNull()
+                ?.terminalState
+                ?.visibleScreenIsBlankOrPartiallyBlank() ?: false
+        }
+        return hit
+    }
+
+    private fun activePaneMayHaveLostFrame(): Boolean {
+        var hit = false
+        compose.activityRule.scenario.onActivity { activity ->
+            hit = viewModel(activity).panes.value.firstOrNull()
+                ?.terminalState
+                ?.visibleRenderMayHaveLostFrame() ?: false
+        }
+        return hit
+    }
+
+    private fun attachSeededTmuxSession(hostRowTag: String) {
+        compose.waitUntil(timeoutMillis = TerminalTestTimeouts.screenRenderPresenceTimeoutMs()) {
+            runCatching {
+                compose.onAllNodesWithTag(hostRowTag, useUnmergedTree = true)
+                    .fetchSemanticsNodes()
+                    .isNotEmpty()
+            }.getOrDefault(false)
+        }
+        compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick()
+        compose.waitUntil(timeoutMillis = TerminalTestTimeouts.screenRenderPresenceTimeoutMs()) {
+            runCatching {
+                compose.onAllNodesWithText(SESSION_NAME, useUnmergedTree = true)
+                    .fetchSemanticsNodes()
+                    .isNotEmpty()
+            }.getOrDefault(false)
+        }
+        compose.onNodeWithText(SESSION_NAME, useUnmergedTree = true).performClick()
+        compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertExists()
+        waitForTerminalViewAttached()
+    }
+
+    private fun waitForTerminalViewAttached() {
+        compose.waitUntil(timeoutMillis = 30_000) {
+            var attached = false
+            compose.activityRule.scenario.onActivity { activity ->
+                val view = activity.window.decorView.findTerminalView()
+                attached = view?.currentSession != null && view.mEmulator != null
+            }
+            attached
+        }
+    }
+
+    private fun waitForConnected(label: String) {
+        compose.waitUntil(timeoutMillis = CONNECTED_TIMEOUT_MS) {
+            currentConnectionStatus() is TmuxSessionViewModel.ConnectionStatus.Connected
+        }
+        assertTrue(
+            "expected Connected after $label, observed=${currentConnectionStatus()}",
+            currentConnectionStatus() is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+    }
+
+    private fun viewModel(activity: MainActivity): TmuxSessionViewModel =
+        ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+
+    private fun currentConnectionStatus(): TmuxSessionViewModel.ConnectionStatus {
+        var status: TmuxSessionViewModel.ConnectionStatus =
+            TmuxSessionViewModel.ConnectionStatus.Idle
+        compose.activityRule.scenario.onActivity { activity ->
+            status = viewModel(activity).connectionStatus.value
+        }
+        return status
+    }
+
+    private fun waitForVisibleTerminal(
+        label: String,
+        timeoutMillis: Long = TerminalTestTimeouts.terminalVisibilityTimeoutMs(),
+        predicate: (String) -> Boolean,
+    ): String {
+        var last = ""
+        val satisfied = runCatching {
+            compose.waitUntil(timeoutMillis = timeoutMillis) {
+                last = visibleTerminalText()
+                predicate(last)
+            }
+            true
+        }.getOrDefault(false)
+        if (!satisfied) writeText("failure-$label-visible-terminal.txt", last)
+        assertTrue("expected visible terminal for $label; got:\n$last", predicate(last))
+        return last
+    }
+
+    private fun visibleTerminalText(): String {
+        var text = ""
+        compose.activityRule.scenario.onActivity { activity ->
+            text = activity.window.decorView
+                .findTerminalView()
+                ?.currentSession
+                ?.emulator
+                ?.screen
+                ?.transcriptText
+                .orEmpty()
+        }
+        return text
+    }
+
+    private fun bannerRowCount(text: String): Int =
+        Regex("$BANNER_MARKER row (\\d{2})").findAll(text).map { it.groupValues[1] }.toSet().size
+
+    private fun assertNoVisibleReconnect(label: String) {
+        assertEquals(
+            "expected no Connecting overlay for $label",
+            0,
+            compose.onAllNodesWithTag(TMUX_CONNECTING_PROGRESS_TAG, useUnmergedTree = true)
+                .fetchSemanticsNodes().size,
+        )
+        assertEquals(
+            "expected no disconnect band for $label",
+            0,
+            compose.onAllNodesWithTag(TMUX_SESSION_ERROR_TAG, useUnmergedTree = true)
+                .fetchSemanticsNodes().size,
+        )
+        assertEquals(
+            "expected no Tap Reconnect button for $label",
+            0,
+            compose.onAllNodesWithTag(TMUX_SESSION_RECONNECT_TAG, useUnmergedTree = true)
+                .fetchSemanticsNodes().size,
+        )
+        assertEquals(
+            "expected no 'Attaching…' switching-loading overlay for $label",
+            0,
+            compose.onAllNodesWithTag(TMUX_SWITCHING_LOADING_TAG, useUnmergedTree = true)
+                .fetchSemanticsNodes().size,
+        )
+        listOf("Connecting", "Reconnecting", "Disconnected", "Tap Reconnect", "Attaching").forEach { text ->
+            assertEquals(
+                "expected no visible '$text' text for $label",
+                0,
+                compose.onAllNodesWithText(text, substring = true, useUnmergedTree = true)
+                    .fetchSemanticsNodes().size,
+            )
+        }
+    }
+
+    private fun watchNoVisibleReconnect(label: String, durationMs: Long) {
+        val deadline = SystemClock.elapsedRealtime() + durationMs
+        while (SystemClock.elapsedRealtime() < deadline) {
+            assertNoVisibleReconnect(label)
+            SystemClock.sleep(100)
+        }
+        recordTiming("${label.replace(' ', '_')}_no_reconnect_ms", durationMs)
+    }
+
+    private fun readFixtureKey(): String =
+        InstrumentationRegistry.getInstrumentation()
+            .context
+            .assets
+            .open("test_key")
+            .bufferedReader()
+            .use { it.readText() }
+
+    private suspend fun seedBeforeLaunch() {
+        val key = readFixtureKey()
+        seededKey = key
+        try {
+            waitForSshFixtureReady(SshKey.Pem(key))
+            seedTmuxSession(key)
+            seededHostRowTag = seedDockerHost(key)
+        } catch (t: Throwable) {
+            runCatching { cleanupRemoteTmuxSession(key) }
+            throw t
+        }
+    }
+
+    private suspend fun seedDockerHost(key: String): String {
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
+        val db = Room.databaseBuilder(appContext, AppDatabase::class.java, DATABASE_NAME)
+            .fallbackToDestructiveMigration(dropAllTables = true)
+            .build()
+        return try {
+            db.clearAllTables()
+            val storedKey = SshKeyStorage.persistKey(
+                context = appContext,
+                sshKeyDao = db.sshKeyDao(),
+                name = "issue1214-key-${System.currentTimeMillis()}",
+                content = key,
+            )
+            val hostId = db.hostDao().insert(
+                HostEntity(
+                    name = "Issue1214 Mostly-Empty Reveal Heal",
+                    hostname = DEFAULT_HOST,
+                    port = DEFAULT_PORT,
+                    username = DEFAULT_USER,
+                    keyId = storedKey.id,
+                    tmuxInstalled = true,
+                    lastBootstrapAt = System.currentTimeMillis(),
+                ),
+            )
+            HOST_ROW_TAG_PREFIX + hostId
+        } finally {
+            db.close()
+        }
+    }
+
+    private suspend fun seedTmuxSession(key: String) {
+        // A FULL multi-row banner running as an idle full-screen pane that emits no further
+        // output — so tmux's `capture-pane` holds materially MORE than the injected 5-line
+        // mostly-empty render (Gate 2), and the restore is visibly the full banner.
+        val bannerLines = (1..40).joinToString("") {
+            "$BANNER_MARKER row %02d filler abcdefghijklmnopqrstuvwxyz\\n".format(it)
+        }
+        val payload = buildString {
+            append("printf '$bannerLines'; ")
+            append("while true; do sleep 3600; done")
+        }
+        val script = buildString {
+            appendLine("set -eu")
+            appendLine("tmux kill-session -t ${shellQuote(SESSION_NAME)} 2>/dev/null || true")
+            appendLine("tmux new-session -d -s ${shellQuote(SESSION_NAME)} ${shellQuote(payload)}")
+            appendLine("sleep 2")
+            appendLine("tmux list-sessions")
+        }
+        val result = SshConnection.connect(
+            host = DEFAULT_HOST,
+            port = DEFAULT_PORT,
+            user = DEFAULT_USER,
+            key = SshKey.Pem(key),
+            knownHosts = KnownHostsPolicy.AcceptAll,
+            timeoutMs = 15_000,
+        ).mapCatching { session -> session.use { it.exec(script) } }
+        val exec = result.getOrNull()
+        assertTrue(
+            "expected tmux seeding to succeed; exception=${result.exceptionOrNull()} stderr='${exec?.stderr}'",
+            exec?.exitCode == 0,
+        )
+        Log.i(LOG_TAG, "seeded session: ${exec?.stdout?.trim()}")
+    }
+
+    private suspend fun cleanupRemoteTmuxSession(key: String) {
+        runCatching {
+            SshConnection.connect(
+                host = DEFAULT_HOST,
+                port = DEFAULT_PORT,
+                user = DEFAULT_USER,
+                key = SshKey.Pem(key),
+                knownHosts = KnownHostsPolicy.AcceptAll,
+                timeoutMs = 15_000,
+            ).mapCatching { session ->
+                session.use {
+                    it.exec("tmux kill-session -t ${shellQuote(SESSION_NAME)} 2>/dev/null || true")
+                }
+            }
+        }
+    }
+
+    private fun captureViewport(name: String) {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.waitForIdleSync()
+        SystemClock.sleep(150)
+
+        var bitmap: Bitmap? = null
+        compose.activityRule.scenario.onActivity { activity ->
+            val view = activity.window.decorView.findTerminalView() ?: return@onActivity
+            if (view.width <= 0 || view.height <= 0) return@onActivity
+            val b = Bitmap.createBitmap(view.width, view.height, Bitmap.Config.ARGB_8888)
+            view.draw(Canvas(b))
+            bitmap = b
+        }
+        bitmap?.let { writeBitmap("$name-viewport", it) }
+        writeText("$name-visible-terminal.txt", visibleTerminalText())
+        bitmap?.recycle()
+    }
+
+    private fun writeBitmap(name: String, bitmap: Bitmap): File {
+        val file = artifactFile("$name.png")
+        FileOutputStream(file).use { out ->
+            check(bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)) {
+                "failed to write bitmap to ${file.absolutePath}"
+            }
+        }
+        println("ISSUE1214_VIEWPORT ${file.absolutePath}")
+        return file
+    }
+
+    private fun writeText(name: String, text: String): File {
+        val file = artifactFile(name)
+        file.writeText(text)
+        println("ISSUE1214_TEXT ${file.absolutePath}")
+        return file
+    }
+
+    private fun writeTimings(): File =
+        writeText("timings.txt", timings.joinToString(separator = "\n", postfix = "\n"))
+
+    private fun writeSummary(): File =
+        writeText(
+            "summary.txt",
+            buildString {
+                appendLine("test=MostlyEmptyModelHealsAtRevealJourneyE2eTest")
+                appendLine("issue=1214")
+                appendLine("fixture=tests/docker agents ($DEFAULT_HOST:$DEFAULT_PORT)")
+                appendLine("running_on_ci=${TerminalTestTimeouts.isRunningOnCi()}")
+                appendLine("session=$SESSION_NAME")
+                appendLine("banner_marker=$BANNER_MARKER")
+                appendLine("fragment_marker=$FRAGMENT_MARKER")
+                appendLine(
+                    "scenario=attach a full 40-row banner, inject a mostly-empty model (2J + home + " +
+                        "5 scattered live lines, >3 lines and <0.5 live-fraction) on the LIVE " +
+                        "emulator, assert the transport stays Connected, then drive the " +
+                        "same-dimension (no-op) resize heal",
+                )
+                appendLine(
+                    "expectation=the full banner is re-seeded AT reveal (not ~4s later), no " +
+                        "Reconnecting/Disconnected/Attaching surface",
+                )
+                appendLine("timings:")
+                timings.forEach { appendLine("  $it") }
+            },
+        )
+
+    private fun artifactFile(name: String): File {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val mediaRoot = com.pocketshell.app.test.testArtifactsRoot(instrumentation.targetContext)
+        val dir = File(mediaRoot, "additional_test_output/$DEVICE_DIR_NAME")
+        check(dir.exists() || dir.mkdirs()) {
+            "could not create artifact directory ${dir.absolutePath}"
+        }
+        return File(dir, name)
+    }
+
+    private fun recordTiming(name: String, value: Long) {
+        val line = "$name=$value"
+        timings += line
+        println("ISSUE1214_TIMING $line")
+    }
+
+    private fun View.findTerminalView(): TerminalView? {
+        if (this is TerminalView) return this
+        if (this !is ViewGroup) return null
+        for (index in 0 until childCount) {
+            val match = getChildAt(index).findTerminalView()
+            if (match != null) return match
+        }
+        return null
+    }
+
+    private fun shellQuote(value: String): String =
+        "'" + value.replace("'", "'\"'\"'") + "'"
+
+    private companion object {
+        const val DATABASE_NAME: String = "pocketshell.db"
+        const val LOG_TAG: String = "Issue1214MostlyEmptyReveal"
+        const val DEVICE_DIR_NAME: String = "issue1214-mostly-empty-reveal-heal"
+        const val SESSION_NAME: String = "issue1214-mostly-empty-proof"
+        const val BANNER_MARKER: String = "ISSUE1214-BANNER"
+        const val FRAGMENT_MARKER: String = "ISSUE1214-FRAG"
+
+        const val OVERLAY_WATCH_MS: Long = 2_500L
+        const val MIN_RESTORED_BANNER_ROWS: Int = 20
+
+        // SHORT restore window: the reveal-time heal re-captures the pane within a single
+        // `capture-pane` round-trip. Kept well below the idle passive-disconnect timeout so a
+        // later transport reattach cannot mask a missing reveal-time heal on base.
+        val HEAL_RESTORE_TIMEOUT_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 10_000L else 6_000L
+
+        val CONNECTED_TIMEOUT_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 30_000L else 15_000L
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/DeadZoneBandRevealResizeHealTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/DeadZoneBandRevealResizeHealTest.kt
@@ -252,6 +252,86 @@ class DeadZoneBandRevealResizeHealTest {
         )
     }
 
+    // -------------------------------------------------------------------------------------------
+    // (6) #1214 — SWITCH-reveal heals a MOSTLY-EMPTY model (>3 scattered lines, live-fraction < 0.5).
+    // -------------------------------------------------------------------------------------------
+
+    @Test
+    fun switchRevealHealsMostlyEmptyModel() = runVmTest {
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%6")
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == "%6" }
+
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+
+        overpaintMostlyEmptyModel(pane)
+        assertMostlyEmptyPreconditions(pane)
+
+        client.capturePaneResponses.addLast(
+            CommandResponse(number = 99L, output = FULL_FRAME, isError = false),
+        )
+        val healCapturesBefore = client.healCaptureCount()
+
+        // THE REAL ENTRY POINT: the switch-reveal gate over the active pane.
+        val revealed = vm.awaitActivePaneSeededOrLoadingForTest(client)
+        advanceUntilIdle()
+
+        assertEquals(
+            "REGRESSION (#1214): the switch-reveal gate must confirm a mostly-empty model against " +
+                "tmux and heal it with EXACTLY ONE `capture-pane -p -e` (#973 one-capture bound). " +
+                "On base the pre-check read the >3-scattered-line, <0.5-fraction pane 'healthy' and " +
+                "revealed it UNHEALED (fragments-over-black), only maybe healed ~4s later at the " +
+                "steady watchdog.",
+            healCapturesBefore + 1,
+            client.healCaptureCount(),
+        )
+        assertTrue("the gate still reveals (does not spin)", revealed)
+        assertTrue(
+            "the heal restored the FULL frame from tmux's authoritative grid AT reveal",
+            renderedTranscriptFor(pane).contains(FULL_FRAME_MARKER),
+        )
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // (7) #1214 — NO-OP resize heals a MOSTLY-EMPTY model (keyboard/IME toggle).
+    // -------------------------------------------------------------------------------------------
+
+    @Test
+    fun noOpResizeHealsMostlyEmptyModel() = runVmTest {
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%7", title = "codex")
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == "%7" }
+
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+
+        overpaintMostlyEmptyModel(pane)
+        assertMostlyEmptyPreconditions(pane)
+
+        client.capturePaneResponses.addLast(
+            CommandResponse(number = 99L, output = FULL_FRAME, isError = false),
+        )
+        val healCapturesBefore = client.healCaptureCount()
+
+        // THE REAL ENTRY POINT: a same-dimension (no-op) resize, e.g. a keyboard dismissal.
+        assertTrue(vm.triggerSameDimensionResizeHealForTest())
+        advanceUntilIdle()
+
+        assertEquals(
+            "REGRESSION (#1214): a no-op resize (keyboard toggle) must confirm a mostly-empty model " +
+                "against tmux and heal it with EXACTLY ONE capture. On base the pre-check skipped the " +
+                ">3-scattered-line, <0.5-fraction pane and left it black-with-fragments until the ~4s " +
+                "watchdog.",
+            healCapturesBefore + 1,
+            client.healCaptureCount(),
+        )
+        assertTrue(
+            "the heal restored the FULL frame",
+            renderedTranscriptFor(pane).contains(FULL_FRAME_MARKER),
+        )
+    }
+
     // ------------------------------------------------------------------ Fixtures + assertions
 
     /** ESC (U+001B). */
@@ -294,6 +374,48 @@ class DeadZoneBandRevealResizeHealTest {
             }
         }
         pane.terminalState.appendRemoteOutput(frame.toByteArray(Charsets.US_ASCII))
+    }
+
+    /**
+     * Issue #1214 — drive the active pane into a MOSTLY-EMPTY model: paint ~0.2 of the visible
+     * rows (but at least 4 lines, so it is ABOVE the ≤3-line partial-black cap) with non-wrapping
+     * content on the alt screen. Live-fraction well BELOW 0.5 yet MORE than 3 live lines — the
+     * exact gap the pre-#1214 pre-check read "healthy" and revealed unhealed (fragments-over-black),
+     * while tmux (the dense [FULL_FRAME] capture) still holds the full frame.
+     */
+    private fun overpaintMostlyEmptyModel(pane: TmuxPaneState) {
+        val visibleRows = visibleRowsOf(pane)
+        // >3 live lines (above the ≤3-line partial-black cap) AND strictly below the 0.5 floor
+        // (capped so a small grid can't cross 0.5).
+        val minLiveRows = 4
+        val liveRows = (visibleRows * 0.2).toInt()
+            .coerceAtLeast(minLiveRows)
+            .coerceAtMost((visibleRows * 0.45).toInt().coerceAtLeast(minLiveRows))
+        val frame = buildString {
+            append("$esc[?1049h$esc[2J$esc[H")
+            for (row in 0 until liveRows) {
+                append("$FULL_FRAME_MARKER scattered fragment line $row\r\n")
+            }
+        }
+        pane.terminalState.appendRemoteOutput(frame.toByteArray(Charsets.US_ASCII))
+    }
+
+    private fun assertMostlyEmptyPreconditions(pane: TmuxPaneState) {
+        val s = pane.terminalState
+        assertFalse("mostly-empty model is NOT fully blank", s.visibleScreenIsBlank())
+        assertFalse(
+            "mostly-empty model has >3 live lines, so it is NOT the ≤3-line partial-black (the ONLY " +
+                "sub-0.5 case the base pre-check flagged)",
+            s.visibleScreenIsPartiallyBlank(),
+        )
+        assertTrue(
+            "#1214: the widened local capture-gate flags the mostly-empty model (worth a capture-diff)",
+            s.visibleRenderMayHaveLostFrame(),
+        )
+        assertTrue(
+            "the unified oracle judges the mostly-empty model LOST vs tmux's full frame",
+            s.visibleRenderLostFrameVsCapture(FULL_FRAME.joinToString("\n")),
+        )
     }
 
     private fun assertDeadZonePreconditions(pane: TmuxPaneState) {

--- a/app/src/test/java/com/pocketshell/app/tmux/VoiceSendSameGridRevealHealTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/VoiceSendSameGridRevealHealTest.kt
@@ -388,7 +388,13 @@ class VoiceSendSameGridRevealHealTest {
                 isError = false,
             ),
         )
-        val fullFrame = (1..6).map { "$sessionName painted line $it" }
+        // Issue #1214: a GENUINELY DENSE pane — enough live lines to fill the visible grid well
+        // above the 0.75 live-fraction ceiling, so the #1214-widened reveal/resize pre-check
+        // ([TerminalSurfaceState.visibleRenderMayHaveLostFrame]) reads it confidently-full and
+        // skips the capture. A merely-sparse "painted" frame (a handful of lines on a tall grid)
+        // now legitimately pays ONE authoritative capture under #1214 — the point of THIS test is
+        // the #285 "a healthy DENSE pane must not spam tmux" no-op, which a dense frame models.
+        val fullFrame = (1..60).map { "$sessionName painted line $it" }
         repeat(4) {
             capturePaneResponses.addLast(
                 CommandResponse(number = 2L, output = fullFrame, isError = false),

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -560,6 +560,20 @@ JOURNEY_CLASSES=(
   # UNCONDITIONAL `reseedActivePaneForReattach`, not blank-only). Uses ONLY the
   # deterministic agents:2222 fixture (no toxiproxy) and does NOT self-skip on CI.
   "$FQCN_PREFIX.VoiceSendActivePaneStaysVisibleE2eTest"
+  # ADDED (#1214 — mostly-empty-model reveal-time leg of the #1208 fragments-over-black audit): the
+  # reveal/resize/switch nets gate an authoritative `capture-pane` diff on the cheap LOCAL pre-check
+  # `visibleRenderMayHaveLostFrame`, which before #1214 only flagged a live-fraction in (0.5, 0.75]
+  # or a ≤3-line partial-blank. A mostly-empty pane with >3 scattered live lines but live-fraction
+  # BELOW 0.5 read "healthy" at reveal → it REVEALED UNHEALED (fragments-over-black), only maybe
+  # caught ~4s later by the steady watchdog. This journey seeds a FULL 40-row banner, attaches,
+  # injects a mostly-empty model (local `CSI 2J`+`CSI H` + 5 scattered live lines — >3 lines and
+  # <0.5 fraction; the REMOTE tmux grid keeps the full banner → transport GUARANTEED LIVE), then
+  # drives the EXACT same-dimension (no-op) resize heal branch. RED on base (the sub-0.5 pane is
+  # skipped → banner never restored in the SHORT window); GREEN with #1214 (the widened pre-check
+  # flags it → the reveal-time heal re-captures the full banner AT reveal, not ~4s later). Uses ONLY
+  # the deterministic agents:2222 fixture (state injected LOCALLY, no toxiproxy) and does NOT
+  # self-skip on CI.
+  "$FQCN_PREFIX.MostlyEmptyModelHealsAtRevealJourneyE2eTest"
   # ADDED (#1153 — send-with-attachment half-black, v0.4.21 dogfood): a composer Send WITH AN
   # ATTACHMENT is ALWAYS multi-line (it appends an "Attached files:" block), so it takes the
   # bracketed-paste + submit branch and the alt-screen agent clear+redraws its WHOLE viewport; the

--- a/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurfaceState.kt
+++ b/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurfaceState.kt
@@ -967,20 +967,29 @@ class TerminalSurfaceState(
      * no-op-resize heal ([com.pocketshell.app.tmux.TmuxSessionViewModel.maybeHealActivePaneOnNoOpResize])
      * run to decide whether paying for an authoritative `capture-pane` diff (the unified
      * [visibleRenderLostFrameVsCapture] oracle) is worthwhile before revealing / after a keyboard
-     * toggle. It is TRUE when the rendered viewport is sparse/banded enough to POSSIBLY be a lost
-     * frame: fully blank, the ≤3-line partial-black, OR a black BAND whose live share of the
+     * toggle. It is TRUE when the rendered viewport is NOT confidently dense — POSSIBLY a lost
+     * frame: fully blank, the ≤3-line partial-black, OR any >3-line pane whose live share of the
      * visible rows is at most [MAY_HAVE_LOST_FRAME_MAX_LIVE_FRACTION].
      *
      * It fires for the SAME two states the pre-#1176 gates already captured for — fully blank OR
-     * the ≤3-line partial-black — PLUS the exact GAP the dead-zone left: a >3-line black BAND with
-     * MORE than half the visible rows live (so the pre-#1176 gates read it "painted") but still up
-     * to [MAY_HAVE_LOST_FRAME_MAX_LIVE_FRACTION] of them — the band between the old 50%-line ceiling
-     * and a confidently-dense pane. A genuinely-sparse-but-correct SMALL pane (≤ half the rows live
-     * — a short prompt) is deliberately NOT flagged: the pre-#1176 no-op-resize contract pays
-     * nothing for it, and the steady-state watchdog remains its net. It does NOT confirm a lost
-     * frame — only the `capture-pane` diff can, since a sparse-but-correct pane looks identical
-     * locally — so a confidently-full pane (live rows ABOVE the ceiling) skips the capture entirely,
-     * and every flagged pane is confirmed against tmux by the unified oracle before any heal fires.
+     * the ≤3-line partial-black — PLUS every pane below the confidently-dense ceiling:
+     *  - the #1176 dead-zone BAND (a >3-line black band with MORE than half the visible rows live,
+     *    so the pre-#1176 gates read it "painted"), AND
+     *  - the #1214 mostly-empty MODEL (>3 scattered live lines but a live-fraction BELOW 0.5 — the
+     *    reveal-time leg of the photographed fragments-over-black).
+     *
+     * The #1214 change DROPPED the old 0.5 lower bound: a mostly-empty model with >3 live lines
+     * used to read "healthy" here and reveal UNHEALED (only the ≤16s-later steady watchdog could
+     * catch it). Paying ONE authoritative capture at reveal/resize is the deliberate cost — the
+     * unified oracle self-guards a genuinely-sparse-but-correct short prompt (Gate 2: capture must
+     * carry materially MORE than the render) and the #807 near-empty alt-screen void (Gate 1:
+     * capture must carry a real frame), so a FALSE pre-flag costs one wasted capture, NEVER a wrong
+     * heal or clear-to-black. It does NOT confirm a lost frame — only the `capture-pane` diff can,
+     * since a sparse-but-correct pane looks identical locally — so a confidently-full pane (live
+     * rows ABOVE the ceiling) skips the capture entirely, and every flagged pane is confirmed
+     * against tmux by the unified oracle before any heal fires. The steady-state watchdog's
+     * foreground/screen/back-off gates (#1166) are untouched — this widening is the reveal/resize
+     * LOCAL pre-check only.
      */
     fun visibleRenderMayHaveLostFrame(): Boolean {
         if (visibleScreenIsBlankOrPartiallyBlank()) return true
@@ -994,11 +1003,13 @@ class TerminalSurfaceState(
         val liveLines = renderedVisibleNonBlankLineCount()
         if (liveLines <= 0) return true
         val liveFraction = liveLines.toDouble() / visibleRows.toDouble()
-        // The #1176 dead-zone the pre-#1176 gates MISSED: MORE than half the rows live yet not
-        // confidently dense. Below the lower bound the pane is genuinely sparse (the pre-#1176
-        // no-op contract skips it — the "cheap no-op" for a short correct prompt); above the upper
-        // bound it is confidently full.
-        return liveFraction > MAY_HAVE_LOST_FRAME_MIN_LIVE_FRACTION &&
+        // Flag every >3-line pane that is NOT confidently dense — its live share sits at or below
+        // the [MAY_HAVE_LOST_FRAME_MAX_LIVE_FRACTION] ceiling. This covers BOTH the #1176 dead-zone
+        // band (0.5..0.75) AND the #1214 mostly-empty model (>3 live lines below 0.5). A ≤3-line
+        // pane is already handled by [visibleScreenIsBlankOrPartiallyBlank] above; a confidently-
+        // full pane (fraction above the ceiling) skips the capture. Every flagged pane is confirmed
+        // against tmux's authoritative capture by [visibleRenderLostFrameVsCapture] before any heal.
+        return liveLines > PARTIAL_BLANK_MAX_LIVE_LINES &&
             liveFraction <= MAY_HAVE_LOST_FRAME_MAX_LIVE_FRACTION
     }
 
@@ -1405,20 +1416,14 @@ class TerminalSurfaceState(
          * is deliberately HIGHER than the send-heal cost-gate's [LOST_FRAME_MAX_LIVE_FRACTION]
          * (0.5) so the reveal/resize gates never MISS the #1176 dead-zone band the way the narrow
          * pre-check did.
+         *
+         * Issue #1214: the pre-#1176 0.5 LOWER bound (`MAY_HAVE_LOST_FRAME_MIN_LIVE_FRACTION`) was
+         * DELETED here — a mostly-empty model (>3 live lines, live-fraction BELOW 0.5) used to read
+         * "healthy" and reveal UNHEALED, so the local gate now opens for EVERY >3-line pane at or
+         * below this ceiling. The unified oracle's Gate 1/Gate 2 self-guard a genuinely-sparse-but-
+         * correct pane, so a false pre-flag costs one wasted capture, never a wrong heal.
          */
         private const val MAY_HAVE_LOST_FRAME_MAX_LIVE_FRACTION = 0.75
-
-        /**
-         * Issue #1176 (GAP C) — the LOWER bound of the [visibleRenderMayHaveLostFrame] band
-         * trigger. A >3-line pane with at most this live-fraction is genuinely SPARSE (a short
-         * correct prompt), NOT the dead-zone band the pre-#1176 no-op-resize gate missed — flagging
-         * it would break the "cheap no-op" contract (capturing a correct small pane on routine
-         * layout churn). The dead-zone is specifically the band with MORE than half the rows live
-         * (spike #874: >50% rows + >25% chars), so the local capture-gate only opens ABOVE this
-         * 0.5 boundary; the genuinely-sparse pane's net stays the steady-state watchdog + the
-         * send-heal path (whose own cost-gate is [LOST_FRAME_MAX_LIVE_FRACTION] = 0.5).
-         */
-        private const val MAY_HAVE_LOST_FRAME_MIN_LIVE_FRACTION = 0.5
     }
 }
 

--- a/shared/core-terminal/src/test/java/com/pocketshell/core/terminal/ui/TerminalSurfaceStateMostlyEmptyRevealTest.kt
+++ b/shared/core-terminal/src/test/java/com/pocketshell/core/terminal/ui/TerminalSurfaceStateMostlyEmptyRevealTest.kt
@@ -1,0 +1,236 @@
+package com.pocketshell.core.terminal.ui
+
+import android.os.Looper
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import java.io.OutputStream
+
+/**
+ * Issue #1214 — the reveal/resize/switch LOCAL pre-check
+ * [TerminalSurfaceState.visibleRenderMayHaveLostFrame] was BLIND to a mostly-empty model.
+ *
+ * The authoritative steady-watchdog oracle [TerminalSurfaceState.visibleRenderLostFrameVsCapture]
+ * is a char-count-fraction test that HEALS a mostly-empty-model-vs-full-tmux pane. But the cheap
+ * LOCAL pre-check that gates the reveal gate
+ * ([com.pocketshell.app.tmux.TmuxSessionViewModel.awaitActivePaneSeededOrLoading]) and the no-op
+ * resize heal ([com.pocketshell.app.tmux.TmuxSessionViewModel.maybeHealActivePaneOnNoOpResize])
+ * only flagged a live-fraction in `(0.5, 0.75]` or a ≤3-line partial-blank. So a mostly-empty
+ * pane with MORE than 3 scattered live lines but a live-fraction BELOW 0.5 read "healthy" at the
+ * reveal gate, revealed UNHEALED (fragments-over-black), and only the ≤16s-later steady watchdog
+ * could catch it. This is the reveal-time leg of the photographed fragments-over-black (#1208).
+ *
+ * ## RED → GREEN (D33/G1/G10)
+ *
+ * [mostlyEmptyModelIsFlaggedSoTheRevealGatePaysTheAuthoritativeCapture] composes a >3-live-line
+ * pane whose live-fraction is BELOW 0.5 (the mostly-empty model), against a full-tmux capture the
+ * authoritative oracle WOULD heal. On base [visibleRenderMayHaveLostFrame] returns FALSE (reads
+ * "healthy" — RED: the reveal gate skips the capture and reveals unhealed). With the fix it
+ * returns TRUE (GREEN: the reveal gate pays ONE authoritative diff and heals AT reveal). The test
+ * also asserts the authoritative oracle itself judges the pane LOST — proving the pre-check was
+ * the ONLY thing blocking the reveal-time heal.
+ *
+ * ## Class coverage (D32-G2)
+ *
+ * [mostlyEmptyModelIsFlaggedAcrossTheSparseSpectrum] parametrizes 4..11 live lines of 24 (all
+ * below the 0.5 floor, all above the 3-line partial-blank cap) so the whole mostly-empty class is
+ * flagged, not the single reported instance. [sparseButCorrectPaneNoOpsViaGate2] and
+ * [nearEmptyAltScreenVoidNoOpsViaGate1] pin the two self-guards: a genuinely-sparse-but-correct
+ * short prompt (capture ≈ render, Gate 2) and the #807 near-empty alt-screen void (capture < 40
+ * chars, Gate 1) may now be pre-flagged (one wasted capture) but the authoritative oracle STILL
+ * refuses to heal — so a false pre-flag never causes a wrong heal or reseed-thrash.
+ * [confidentlyDensePaneStillSkipsTheCapture] confirms a dense pane still short-circuits the
+ * capture (no per-reveal cost on a healthy pane, the #1166 battery guard for the local gate).
+ */
+@RunWith(RobolectricTestRunner::class)
+class TerminalSurfaceStateMostlyEmptyRevealTest {
+
+    private class NoopOutputStream : OutputStream() {
+        override fun write(b: Int) = Unit
+        override fun write(b: ByteArray, off: Int, len: Int) = Unit
+    }
+
+    private fun withAttachedSurface(block: (TerminalSurfaceState) -> Unit) = runBlocking {
+        val state = TerminalSurfaceState()
+        val producerScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val producerJob = state.attachExternalProducer(
+            scope = producerScope,
+            stdout = MutableSharedFlow(extraBufferCapacity = 1),
+            remoteStdin = NoopOutputStream(),
+            suppressQueryResponses = true,
+        )
+        try {
+            block(state)
+        } finally {
+            producerJob.cancel()
+            producerScope.cancel()
+            state.detachExternalProducer()
+        }
+    }
+
+    /** ESC (U+001B), so the test feeds real control sequences (a literal `[2J` is just text). */
+    private val esc = ""
+
+    /** A single non-wrapping content line: 20 non-blank chars, well under the 80-col grid. */
+    private val contentLine = "abcdefghij klmnopqrst"
+
+    /**
+     * tmux's authoritative capture: a full 24-row viewport of [contentLine] (the emulator's
+     * visible-row count is 24). A render that painted only a few of those rows lost the frame tmux
+     * still holds — the mostly-empty-model-vs-full-tmux case #1214 is about.
+     */
+    private fun fullCapture(): String = buildString { repeat(24) { append("$contentLine\n") } }
+
+    /** Paint [liveRows] non-wrapping content lines on a cleared screen — a mostly-empty model. */
+    private fun paintLines(state: TerminalSurfaceState, liveRows: Int) {
+        val frame = buildString {
+            append("$esc[2J$esc[H")
+            repeat(liveRows) { append("$contentLine\r\n") }
+        }
+        state.appendRemoteOutput(frame.toByteArray(Charsets.US_ASCII))
+        shadowOf(Looper.getMainLooper()).idle()
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // RED → GREEN: the mostly-empty model the pre-check judged "healthy" at reveal.
+    // -----------------------------------------------------------------------------------------
+
+    @Test
+    fun mostlyEmptyModelIsFlaggedSoTheRevealGatePaysTheAuthoritativeCapture() =
+        withAttachedSurface { state ->
+            // 6 of 24 rows live: live-fraction 0.25 (BELOW the 0.5 floor) AND more than 3 live
+            // lines (so it escapes the ≤3-line partial-black net). This is the mostly-empty model.
+            paintLines(state, liveRows = 6)
+            val capture = fullCapture()
+
+            assertFalse(
+                "precondition: a 6-live-line model is NOT fully blank",
+                state.visibleScreenIsBlank(),
+            )
+            assertFalse(
+                "precondition: it has MORE than 3 live lines, so it is NOT the ≤3-line partial-black " +
+                    "(the ONLY sub-0.5 case the base pre-check flagged)",
+                state.visibleScreenIsPartiallyBlank(),
+            )
+
+            // The authoritative oracle WOULD heal this pane (tmux holds a full frame, the render
+            // reproduces only ~25% of it) — so the ONLY thing standing between the reveal and a
+            // healed pane is the cheap local pre-check.
+            assertTrue(
+                "premise: the authoritative count-diff oracle judges this mostly-empty model LOST — " +
+                    "the reveal-time heal is available IF the pre-check opens the capture",
+                state.visibleRenderLostFrameVsCapture(capture),
+            )
+
+            // GREEN (#1214): the pre-check must flag the mostly-empty model so the reveal gate and
+            // the no-op-resize heal pay ONE authoritative diff instead of reading "healthy". On
+            // base this returns FALSE (reads healthy, reveals unhealed) — the red→green
+            // discriminator.
+            assertTrue(
+                "GREEN (#1214): visibleRenderMayHaveLostFrame() must flag a >3-live-line pane with " +
+                    "live-fraction < 0.5 so the reveal/resize gate pays the authoritative capture",
+                state.visibleRenderMayHaveLostFrame(),
+            )
+        }
+
+    // -----------------------------------------------------------------------------------------
+    // Class coverage (G2): the WHOLE mostly-empty spectrum (>3 lines, < 0.5 fraction) is flagged.
+    // -----------------------------------------------------------------------------------------
+
+    @Test
+    fun mostlyEmptyModelIsFlaggedAcrossTheSparseSpectrum() {
+        val capture = fullCapture()
+        // 4..11 live rows of 24: all ABOVE the 3-line partial-black cap and all BELOW the 0.5
+        // live-fraction floor (11/24 = 0.458). The whole mostly-empty class must be flagged.
+        for (liveRows in 4..11) {
+            withAttachedSurface { state ->
+                paintLines(state, liveRows)
+                val liveFraction = liveRows / 24.0
+                assertTrue(
+                    "precondition: $liveRows live rows is below the 0.5 floor (fraction $liveFraction)",
+                    liveFraction < 0.5,
+                )
+                assertFalse(
+                    "precondition: $liveRows live rows escapes the ≤3-line partial-black net",
+                    state.visibleScreenIsPartiallyBlank(),
+                )
+                assertTrue(
+                    "#1214 class coverage: a $liveRows-of-24 mostly-empty model must be flagged so " +
+                        "the reveal/resize gate pays the authoritative capture",
+                    state.visibleRenderMayHaveLostFrame(),
+                )
+                // And the authoritative oracle confirms the heal — the reveal is not paying for
+                // nothing across the class.
+                assertTrue(
+                    "#1214 class coverage: the authoritative oracle heals the $liveRows-of-24 pane",
+                    state.visibleRenderLostFrameVsCapture(capture),
+                )
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // Self-guards (G2): a false pre-flag costs ONE wasted capture, never a wrong heal / thrash.
+    // -----------------------------------------------------------------------------------------
+
+    @Test
+    fun sparseButCorrectPaneNoOpsViaGate2() = withAttachedSurface { state ->
+        // A genuinely-sparse-but-correct SHORT prompt: 5 live lines, and tmux's capture is the
+        // SAME 5 lines (render ≈ capture). The pre-check may now flag it (one wasted capture),
+        // but the authoritative oracle's Gate 2 (capture must carry materially MORE than the
+        // render) refuses the heal → NO reseed-thrash.
+        paintLines(state, liveRows = 5)
+        val sparseCorrectCapture = buildString { repeat(5) { append("$contentLine\n") } }
+
+        assertTrue(
+            "the pre-check may pre-flag the sparse pane (one wasted capture is acceptable)",
+            state.visibleRenderMayHaveLostFrame(),
+        )
+        assertFalse(
+            "Gate 2 self-guard: a sparse-but-correct prompt where capture ≈ render must NOT heal " +
+                "(no reseed-thrash on a legitimately-short pane)",
+            state.visibleRenderLostFrameVsCapture(sparseCorrectCapture),
+        )
+    }
+
+    @Test
+    fun nearEmptyAltScreenVoidNoOpsViaGate1() = withAttachedSurface { state ->
+        // The #807 by-design near-empty alt-screen void: a few live render lines but tmux's
+        // capture carries < 40 non-blank chars (Gate 1: no real frame to restore). The pre-check
+        // may pre-flag the render, but the oracle's Gate 1 refuses to heal a genuinely-empty pane
+        // to itself.
+        paintLines(state, liveRows = 5)
+        val nearEmptyCapture = "ab\n" // < STALE_RENDER_MIN_CAPTURE_CHARS (40) non-blank chars
+
+        assertFalse(
+            "#807 Gate 1 self-guard: a near-empty tmux capture (< 40 chars) must NOT heal — the " +
+                "genuinely-empty alt-screen void is left alone",
+            state.visibleRenderLostFrameVsCapture(nearEmptyCapture),
+        )
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // #1166 battery guard for the LOCAL gate: a confidently-dense pane still skips the capture.
+    // -----------------------------------------------------------------------------------------
+
+    @Test
+    fun confidentlyDensePaneStillSkipsTheCapture() = withAttachedSurface { state ->
+        // 22 of 24 rows live (~8% black): live-fraction 0.92, well ABOVE the 0.75 ceiling. A
+        // confidently-full pane must NOT pay for a capture on every reveal/resize.
+        paintLines(state, liveRows = 22)
+        assertFalse(
+            "battery guard: a confidently-dense pane (live-fraction 0.92 > 0.75) must NOT be " +
+                "flagged — no per-reveal capture cost on a healthy pane",
+            state.visibleRenderMayHaveLostFrame(),
+        )
+    }
+}


### PR DESCRIPTION
Closes #1214. FINAL leg of the #1208 black-screen audit (the reveal-time fragments-over-black).

The reveal/resize/switch heal nets gated on `visibleRenderMayHaveLostFrame()`, which only flagged a `(0.5, 0.75]` live-fraction or ≤3-line partial-blank — so a mostly-empty pane (>3 scattered live lines, fraction <0.5) revealed unhealed. Drop the 0.5 floor so every >3-line pane ≤0.75 pays ONE authoritative `capture-pane` diff; Gate 1/Gate 2 + #989 self-guard a sparse-but-correct pane to a no-op.

Reviewer: reproduced red→green (predicate + real VM reveal/resize entry points, exactly +1 capture); ran the connected journey on emulator+Docker — viewport artifacts show 40-row → 5 fragments-over-black → 40-row restored, healed **44ms after reveal** (at reveal, not ~4s later). Over-heal risk verdict: acceptable (bounded one-capture-per-reveal, never a wrong heal, #1166 watchdog untouched). #973/#807/#989 guards preserved; scope clean (no VM change). Orchestrator gate green.