### PR TITLE
hosts: QR share export handles multi-chunk payloads (no crash) (#1230)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/hosts/HostListScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/hosts/HostListScreen.kt
@@ -755,7 +755,13 @@ fun HostListScreen(
                         Intent.createChooser(
                             Intent(Intent.ACTION_SEND)
                                 .setType("text/plain")
-                                .putExtra(Intent.EXTRA_TEXT, share.payload),
+                                // Issue #1230: a payload may split into several
+                                // QR envelope parts; share every one (newline
+                                // separated) so a text import can reassemble.
+                                .putExtra(
+                                    Intent.EXTRA_TEXT,
+                                    share.payloads.joinToString("\n"),
+                                ),
                             "Share host",
                         ),
                     )
@@ -1465,7 +1471,14 @@ private fun HostShareDialog(
     onDismiss: () -> Unit,
     onShare: () -> Unit,
 ) {
-    val qr = remember(share.payload) { HostQrCode.encode(share.payload, sizePx = 640) }
+    // Issue #1230: a large payload (long name/hostname/username, long key
+    // name) splits into several QR envelope parts. Page through them so the
+    // in-app scanner can reassemble; a single-part payload shows just its QR.
+    val total = share.payloads.size
+    var index by remember(share) { mutableStateOf(0) }
+    val safeIndex = index.coerceIn(0, (total - 1).coerceAtLeast(0))
+    val current = share.payloads[safeIndex]
+    val qr = remember(current) { HostQrCode.encode(current, sizePx = 640) }
     AlertDialog(
         onDismissRequest = onDismiss,
         title = { Text("Share ${share.hostName}", color = PocketShellColors.Text) },
@@ -1476,6 +1489,37 @@ private fun HostShareDialog(
                     contentDescription = "Host share QR code",
                     modifier = Modifier.size(220.dp),
                 )
+                if (total > 1) {
+                    Spacer(modifier = Modifier.height(PocketShellSpacing.sm))
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.Center,
+                    ) {
+                        PocketShellButton(
+                            text = "Prev",
+                            onClick = { if (safeIndex > 0) index = safeIndex - 1 },
+                            variant = ButtonVariant.Text,
+                            compact = true,
+                        )
+                        Text(
+                            text = "QR ${safeIndex + 1} of $total",
+                            color = PocketShellColors.Text,
+                            style = PocketShellTypography.labelSmall,
+                        )
+                        PocketShellButton(
+                            text = "Next",
+                            onClick = { if (safeIndex < total - 1) index = safeIndex + 1 },
+                            variant = ButtonVariant.Text,
+                            compact = true,
+                        )
+                    }
+                    Spacer(modifier = Modifier.height(PocketShellSpacing.sm))
+                    Text(
+                        text = "This host is large, so it splits across $total codes. Scan all of them with the in-app QR scanner to combine.",
+                        color = PocketShellColors.TextSecondary,
+                        style = PocketShellTypography.labelSmall,
+                    )
+                }
                 Spacer(modifier = Modifier.height(PocketShellSpacing.md))
                 Text(
                     text = "Private keys and passphrases are never included. Import requires a local key with the same name.",

--- a/app/src/main/java/com/pocketshell/app/hosts/HostListViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/hosts/HostListViewModel.kt
@@ -745,10 +745,14 @@ class HostListViewModel internal constructor(
                     auth = SshImportAuth.KeyReference(name = key.name),
                 ),
             )
-            val payload = QrChunkCodec.encode(importPayload).single()
+            // Issue #1230: encode returns one-or-more envelope chunks. Do NOT
+            // `.single()` — that throws (and crashes viewModelScope) the moment
+            // the payload needs more than one QR. Keep every part; the share
+            // dialog renders the multi-QR sequence and the scanner reassembles.
+            val payloads = QrChunkCodec.encode(importPayload)
             _sharePayload.value = HostSharePayload(
                 hostName = host.name,
-                payload = payload,
+                payloads = payloads,
             )
             _shareMessage.value = null
         }
@@ -1665,7 +1669,17 @@ class HostListViewModel internal constructor(
 
     data class HostSharePayload(
         val hostName: String,
-        val payload: String,
+        /**
+         * The one-or-more QR envelope strings the payload split into
+         * (issue #1230). [QrChunkCodec.encode] is explicitly multi-part
+         * (1500-byte chunks) — a host with long name/hostname/username or a
+         * long key name pushes the payload past one chunk. Rendering (and
+         * text-sharing) must iterate ALL parts; the old export did
+         * `encode(...).single()`, which threw and crashed the app for any
+         * multi-chunk payload. `part=1/N` order is preserved so the in-app
+         * scanner ([QrChunkAssembler]) can reassemble them.
+         */
+        val payloads: List<String>,
     )
 
     /**

--- a/app/src/test/java/com/pocketshell/app/hosts/HostListViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/hosts/HostListViewModelTest.kt
@@ -1713,13 +1713,91 @@ class HostListViewModelTest {
 
         val share = viewModel.sharePayload.value
         assertNotNull(share)
-        assertTrue(QrChunkCodec.isEnvelope(share!!.payload))
-        val part = QrChunkCodec.decodePart(share.payload).getOrThrow()
+        // A normal-sized host fits in a single QR envelope part (AC2).
+        assertEquals(1, share!!.payloads.size)
+        val envelope = share.payloads.single()
+        assertTrue(QrChunkCodec.isEnvelope(envelope))
+        val part = QrChunkCodec.decodePart(envelope).getOrThrow()
         assertEquals(1, part.total)
         val decoded = SshImportPayloadCodec.decode(
             String(part.chunk, Charsets.UTF_8),
         ).getOrThrow()
         assertEquals("shared", decoded.name)
+        assertEquals("shared.example.com", decoded.host)
+        assertEquals(2222, decoded.port)
+        assertEquals("ubuntu", decoded.username)
+        assertEquals(SshImportAuth.KeyReference("shared-key"), decoded.auth)
+    }
+
+    /**
+     * Issue #1230 regression (reproduce-first, D33/G10). The export used to do
+     * `QrChunkCodec.encode(importPayload).single()`; `.single()` throws
+     * `IllegalArgumentException` on a >1-element list, and the uncaught throw
+     * inside the bare `viewModelScope.launch` crashed the app for ANY payload
+     * that split into more than one QR chunk (a host with a long
+     * name/hostname/username or a long key name).
+     *
+     * The fixture below has a name long enough to push the SSH-import JSON well
+     * past [QrChunkCodec.ChunkSize] (1500 bytes), so `encode` returns multiple
+     * parts — the exact crash trigger.
+     *
+     * RED (revert the fix — restore `.single()` in `createSharePayload`): the
+     * coroutine throws before assigning `_sharePayload`, so `share` is null and
+     * `assertNotNull` fails (and the uncaught crash surfaces via `runTest`).
+     * GREEN (with the fix): every part is produced and reassembles through the
+     * live scanner's [QrChunkAssembler] back into the original import payload.
+     */
+    @Test
+    fun createSharePayload_producesAllParts_forOversizedPayload_andRoundTrips() = runTest {
+        val keyId = db.sshKeyDao().insert(
+            SshKeyEntity(name = "shared-key", privateKeyPath = "/tmp/shared-key"),
+        )
+        // ~4 KiB name → SSH-import JSON far exceeds the 1500-byte chunk size, so
+        // the QR envelope MUST split into multiple parts.
+        val longName = "long-host-".repeat(400)
+        val host = HostEntity(
+            name = longName,
+            hostname = "shared.example.com",
+            port = 2222,
+            username = "ubuntu",
+            keyId = keyId,
+        )
+        val viewModel = newViewModel(
+            applicationContext = context,
+            hostDao = db.hostDao(),
+            sshKeyDao = db.sshKeyDao(),
+            releaseChecker = FakeReleaseChecker(result = null),
+            bootstrapper = HostBootstrapper(),
+            usageScheduler = newUsageScheduler(),
+            activeClients = ActiveTmuxClients(),
+            settingsRepository = newSettingsRepository(),
+        )
+
+        viewModel.createSharePayload(host)
+
+        val share = viewModel.sharePayload.value
+        assertNotNull("multi-chunk share must not crash (issue #1230)", share)
+        // The crash trigger: the payload genuinely splits into >1 part.
+        assertTrue(
+            "oversized payload should produce more than one QR part",
+            share!!.payloads.size > 1,
+        )
+        // Every part is a well-formed envelope sharing one id, parts 1..N, and
+        // the whole set reassembles the way the in-app scanner combines them.
+        val assembler = QrChunkAssembler()
+        var assembled: String? = null
+        share.payloads.forEach { envelope ->
+            assertTrue(QrChunkCodec.isEnvelope(envelope))
+            val part = QrChunkCodec.decodePart(envelope).getOrThrow()
+            assertEquals(share.payloads.size, part.total)
+            when (val outcome = assembler.accept(part)) {
+                is QrChunkAssembler.Outcome.Complete -> assembled = outcome.payload
+                else -> Unit
+            }
+        }
+        assertNotNull("all parts should reassemble into the payload", assembled)
+        val decoded = SshImportPayloadCodec.decode(assembled!!).getOrThrow()
+        assertEquals(longName, decoded.name)
         assertEquals("shared.example.com", decoded.host)
         assertEquals(2222, decoded.port)
         assertEquals("ubuntu", decoded.username)


### PR DESCRIPTION
Closes #1230. Post-audit hardening. `createSharePayload` called `.single()` on the multi-part `QrChunkCodec.encode(...)` → any host with a long name/key crashed the app. Fix: keep all parts (`payloads: List`), page the share dialog through the multi-QR sequence (X of N), "Share text" newline-joins all; single-part unchanged.

Reviewer reproduced red→green (revert `.single()` → oversized ~4KiB fixture crashes with `IllegalArgumentException`, `_sharePayload` stays null) and verified the parts reassemble through the real `QrChunkAssembler` (no data-corruption regression). Residual: on-device pager render (emulators busy) — behavior fully JVM-proven. Orchestrator gate green.