### PR TITLE
portfwd: guard ForwardingService.startForeground against FGS start-not-allowed crash (#1232)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/portfwd/service/ForwardingService.kt
+++ b/app/src/main/java/com/pocketshell/app/portfwd/service/ForwardingService.kt
@@ -245,7 +245,18 @@ class ForwardingService : Service() {
                 // a STARTED foreground service that doesn't call
                 // startForeground() fast enough crashes the process
                 // with ForegroundServiceDidNotStartInTimeException.
-                promoteToForegroundIfNeeded(initialNotification())
+                //
+                // Issue #1232: mirror SessionConnectionService — a start that
+                // lands on a background-restricted edge throws
+                // ForegroundServiceStartNotAllowedException (Android 12+; 14+
+                // adds specialUse throw conditions). promoteToForegroundIfNeeded
+                // now contains that throw and returns false rather than
+                // promote-or-die; on failure we stop the service cleanly instead
+                // of crashing the process.
+                if (!promoteToForegroundIfNeeded(initialNotification())) {
+                    stopForwarding()
+                    return START_NOT_STICKY
+                }
                 if (observeJob == null || observeJob?.isActive != true) {
                     startObserving()
                 }
@@ -340,27 +351,50 @@ class ForwardingService : Service() {
         stopSelf()
     }
 
-    private fun promoteToForegroundIfNeeded(notification: Notification) {
-        if (hasStartedForeground) return
-        // On Android 14+ (API 34) the service type must be supplied
-        // explicitly to `startForeground()`. We declare the type in
-        // the manifest as `specialUse` because PocketShell's
-        // foreground-service usage is not "data sync" or "media
-        // playback" — it's keeping a user-initiated SSH transport
-        // alive while the app is backgrounded. `specialUse` is the
-        // catch-all category for use cases not covered by the other
-        // pre-defined types and requires the `propertyName` attribute
-        // in the manifest, which we supply.
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-            startForeground(
-                NOTIFICATION_ID,
-                notification,
-                ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE,
-            )
-        } else {
-            startForeground(NOTIFICATION_ID, notification)
+    /**
+     * Promote the process to foreground state, containing a
+     * background-restricted-start failure instead of crashing.
+     *
+     * Issue #1232: previously this called `startForeground` unguarded, so a
+     * start that landed on a background-restricted edge (a network-restore-driven
+     * rebuild, or an enable landing exactly on the app→background transition)
+     * threw `ForegroundServiceStartNotAllowedException` (Android 12+; Android 14+
+     * adds specialUse throw conditions) and crashed the process. The sibling
+     * [com.pocketshell.app.sessions.service.SessionConnectionService.promoteToForegroundIfNeeded]
+     * already wrapped the identical call precisely because it can start on the
+     * background path; this mirrors that guard. On failure the caller stops the
+     * service cleanly (promote-or-stop, not promote-or-die).
+     *
+     * @return true if the service is now in the foreground (either it just
+     *   promoted or it was already foreground); false if promotion was rejected.
+     */
+    private fun promoteToForegroundIfNeeded(notification: Notification): Boolean {
+        if (hasStartedForeground) return true
+        return runCatching {
+            // On Android 14+ (API 34) the service type must be supplied
+            // explicitly to `startForeground()`. We declare the type in
+            // the manifest as `specialUse` because PocketShell's
+            // foreground-service usage is not "data sync" or "media
+            // playback" — it's keeping a user-initiated SSH transport
+            // alive while the app is backgrounded. `specialUse` is the
+            // catch-all category for use cases not covered by the other
+            // pre-defined types and requires the `propertyName` attribute
+            // in the manifest, which we supply.
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                startForeground(
+                    NOTIFICATION_ID,
+                    notification,
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE,
+                )
+            } else {
+                startForeground(NOTIFICATION_ID, notification)
+            }
+            hasStartedForeground = true
+            true
+        }.getOrElse {
+            Log.w(TAG, "forwarding foreground service promotion failed", it)
+            false
         }
-        hasStartedForeground = true
     }
 
     private fun updateNotification(

--- a/app/src/test/java/com/pocketshell/app/portfwd/service/ForwardingServiceForegroundStartGuardTest.kt
+++ b/app/src/test/java/com/pocketshell/app/portfwd/service/ForwardingServiceForegroundStartGuardTest.kt
@@ -1,0 +1,171 @@
+package com.pocketshell.app.portfwd.service
+
+import android.app.ForegroundServiceStartNotAllowedException
+import android.app.Notification
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import androidx.test.core.app.ApplicationProvider
+import com.pocketshell.app.portfwd.ForwardingController
+import kotlinx.coroutines.Dispatchers
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.Implementation
+import org.robolectric.annotation.Implements
+import org.robolectric.shadows.ShadowService
+
+/**
+ * Issue #1232 regression — `ForwardingService` must CONTAIN a
+ * background-restricted foreground-start failure instead of crashing the
+ * process, exactly as the sibling
+ * [com.pocketshell.app.sessions.service.SessionConnectionService] already does.
+ *
+ * ## The bug (reproduce-first, D33/G10)
+ *
+ * `promoteToForegroundIfNeeded` called `startForeground(...)` with no
+ * `runCatching`. On Android 12+ (API 31) `startForeground` from a
+ * background-restricted state throws
+ * [ForegroundServiceStartNotAllowedException]; Android 14+ adds further
+ * specialUse throw conditions. A forwarding start that reaches `onStartCommand`
+ * on such an edge (a network-restore-driven rebuild, or an enable landing
+ * exactly on the app→background transition) therefore propagated an uncaught
+ * throw out of `onStartCommand` → process crash.
+ *
+ * The sibling `SessionConnectionService.promoteToForegroundIfNeeded` wraps the
+ * identical call in `runCatching` and returns `false` on failure, and its
+ * `onStartCommand` stops the service cleanly when promotion is refused. This
+ * test drives the SAME failing edge against `ForwardingService` and asserts the
+ * mirrored guard: no throw escapes, and the service stops itself.
+ *
+ * ## Injecting the failing state (the #780 model)
+ *
+ * A plain Robolectric AVD cannot enter the real FGS-start-not-allowed state, so
+ * the background-restricted throw is injected synthetically with a scoped
+ * [ThrowingForegroundShadow] that makes `startForeground` throw the exact
+ * platform exception — and it is applied ONLY to the throw test via a
+ * method-level `@Config`, so the "normal promotion" test still exercises the
+ * real ShadowService success path.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class ForwardingServiceForegroundStartGuardTest {
+
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+    }
+
+    /**
+     * Robolectric shadow that reproduces the background-restricted foreground
+     * start: every `startForeground` overload throws the exact platform
+     * exception the OS raises when an FGS start is disallowed. Applied only to
+     * the throw test (method-level `@Config`) so it does not affect the
+     * normal-promotion test.
+     */
+    @Implements(Service::class)
+    class ThrowingForegroundShadow : ShadowService() {
+        @Implementation
+        override fun startForeground(id: Int, notification: Notification) {
+            throw ForegroundServiceStartNotAllowedException(
+                "test-injected: FGS start not allowed from a background-restricted state",
+            )
+        }
+
+        @Implementation
+        override fun startForeground(id: Int, notification: Notification, foregroundServiceType: Int) {
+            throw ForegroundServiceStartNotAllowedException(
+                "test-injected: FGS start not allowed from a background-restricted state",
+            )
+        }
+    }
+
+    @Test
+    @Config(shadows = [ThrowingForegroundShadow::class])
+    fun `background-restricted startForeground throw is contained and the service stops itself`() {
+        val service = buildStartedService()
+
+        // RED on base (unguarded startForeground): this onStartCommand call would
+        // propagate ForegroundServiceStartNotAllowedException and crash. GREEN with
+        // the fix: the throw is contained, no exception escapes.
+        val result = try {
+            service.onStartCommand(startIntent(), 0, 1)
+        } catch (t: Throwable) {
+            throw AssertionError(
+                "onStartCommand must CONTAIN the background-restricted foreground-start " +
+                    "failure (issue #1232), but it propagated: $t",
+                t,
+            )
+        }
+
+        // The service must degrade cleanly: promote-or-stop, not promote-or-die.
+        assertEquals(
+            "a refused foreground promotion must not leave a STICKY service that will be " +
+                "restarted straight back into the same failing start",
+            Service.START_NOT_STICKY,
+            result,
+        )
+        assertTrue(
+            "the service must stop ITSELF when foreground promotion is refused",
+            shadowOf(service).isStoppedBySelf,
+        )
+    }
+
+    @Test
+    fun `normal foreground promotion is unchanged`() {
+        val service = buildStartedService()
+
+        val result = service.onStartCommand(startIntent(), 0, 1)
+
+        assertEquals(
+            "a successful foreground promotion keeps the service sticky",
+            Service.START_STICKY,
+            result,
+        )
+        assertFalse(
+            "a successfully promoted service must NOT stop itself",
+            shadowOf(service).isStoppedBySelf,
+        )
+
+        service.onDestroy()
+    }
+
+    private fun buildStartedService(): ForwardingService {
+        val controller = ForwardingController(context)
+        // Seed one active host so the observe loop keeps the service alive on the
+        // happy path (0 active hosts is a legitimate self-teardown, unrelated to
+        // the promotion-refusal path under test). Reflection avoids the
+        // registerActiveHost() side effect that auto-starts a second service —
+        // same seam the #994 dispatcher-leak test uses.
+        seedActiveHostCount(controller, 1)
+        val service = Robolectric.buildService(ForwardingService::class.java).get()
+        service.controller = controller
+        // Confine the observe loop to a direct dispatcher so nothing leaks (#994);
+        // the happy path launches it, the guarded path returns before it.
+        service.observeDispatcher = Dispatchers.Unconfined
+        service.createNotificationChannel()
+        return service
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun seedActiveHostCount(controller: ForwardingController, count: Int) {
+        val field = ForwardingController::class.java.getDeclaredField("activeHostCount")
+        field.isAccessible = true
+        val flow = field.get(controller) as kotlinx.coroutines.flow.MutableStateFlow<Int>
+        flow.value = count
+    }
+
+    private fun startIntent(): Intent =
+        Intent(context, ForwardingService::class.java).apply {
+            action = ForwardingService.ACTION_START
+        }
+}


### PR DESCRIPTION
Closes #1232. Post-audit hardening. `ForwardingService.promoteToForegroundIfNeeded` called `startForeground` unguarded (the sibling `SessionConnectionService` already guards it) → a background-edge start threw `ForegroundServiceStartNotAllowedException` and crashed. Fix mirrors the sibling verbatim: `runCatching` the promote; on refusal `stopForwarding()` + `START_NOT_STICKY`.

Reviewer reproduced red→green (revert → the exception propagates out of `onStartCommand`; restore → green, happy path unaffected), confirmed sibling parity + clean degrade (no orphan wakelock). Orchestrator gate green.