### PR TITLE
terminal: unify in-progress loaders — one indicator on beyond-grace reconnect (#750)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxConnectingStatesScreenshotTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxConnectingStatesScreenshotTest.kt
@@ -191,6 +191,88 @@ class TmuxConnectingStatesScreenshotTest {
     }
 
     @Test
+    fun captureBeyondGraceReconnectSingleIndicator_reopenRepro() {
+        // Issue #750 (4th occurrence — the maintainer's exact reopen state,
+        // 2026-07-03). A BEYOND-GRACE reconnect re-dials through the controller's
+        // `Connecting` state, which projects to [ConnectionStatus.Connecting] — so
+        // the REAL screen renders the top [ConnectingProgressOverlay] ("Connecting
+        // to host… / Still working, this may be slow…") WHILE the id-keyed
+        // [RevealStateMachine] holds the terminal (`effectiveHidesTerminal == true`)
+        // and the surface paints the centered "Attaching…" hold. Pre-fix the
+        // [ConnectingProgressOverlay] was ungated on `status is Connecting`, so BOTH
+        // rendered = TWO loaders (the reopened symptom).
+        //
+        // This mounts the REAL production [TmuxTopConnectingBanner] (the actual
+        // single render site for both top banners, driven by the real
+        // [primaryLoadingSurface] gate) ABOVE the REAL [SwitchingLoadingPlaceholder]
+        // centered hold — the exact production composition. It is a genuine WIRING
+        // guard: revert the gate and the top overlay renders again, pushing the
+        // indeterminate-indicator count to 2 (RED).
+        val connecting =
+            TmuxSessionViewModel.ConnectionStatus.Connecting(
+                host = "135.181.114.209",
+                port = 22,
+                user = "alexey",
+            )
+        compose.setContent {
+            PocketShellTheme {
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(PocketShellColors.Background)
+                        .padding(top = 24.dp)
+                        .testTag(SCREENSHOT_ROOT_TAG),
+                ) {
+                    ConsolidatedTopChrome(
+                        sessionName = "git-pocketshell",
+                        onBack = {},
+                        onMore = {},
+                    )
+                    // The REAL top-banner render site. With `effectiveHidesTerminal =
+                    // true` (the reconnect re-dial reality) the gate suppresses BOTH
+                    // banners → this renders NOTHING.
+                    TmuxTopConnectingBanner(
+                        status = connecting,
+                        effectiveHidesTerminal = true,
+                        sessionName = "git-pocketshell",
+                        onCancelConnect = {},
+                        onRetryNow = {},
+                    )
+                    // The REAL centered "Attaching…" hold — the SOLE loader that
+                    // must remain.
+                    Box(
+                        modifier = Modifier
+                            .weight(1f)
+                            .fillMaxWidth(),
+                    ) {
+                        SwitchingLoadingPlaceholder()
+                    }
+                }
+            }
+        }
+        compose.onNodeWithText("Attaching…").assertExists()
+        // The top "Connecting to host…" banner (and its slow-hint line) MUST be
+        // absent while the terminal is held — the fix.
+        compose
+            .onAllNodesWithTag(TMUX_CONNECTING_PROGRESS_TAG, useUnmergedTree = true)
+            .assertCountEquals(0)
+        compose
+            .onAllNodesWithTag(TMUX_CONNECTING_SLOW_HINT_TAG, useUnmergedTree = true)
+            .assertCountEquals(0)
+        // The centered "Attaching…" hold is present exactly once.
+        compose
+            .onAllNodesWithTag(TMUX_SWITCHING_LOADING_TAG, useUnmergedTree = true)
+            .assertCountEquals(1)
+        compose.waitForIdle()
+        // EXACTLY ONE animated indicator: the centered "Attaching…" spinner. Pre-fix
+        // the ungated top overlay's linear bar added a second → count 2 (the RED
+        // reproduction of the maintainer's beyond-grace reconnect symptom).
+        assertIndeterminateIndicatorCount(1)
+        SystemClock.sleep(300)
+        captureFullDevice(File(artifactDir(), "tmux-beyond-grace-reconnect-single-indicator.png"))
+    }
+
+    @Test
     fun captureSteadyReconnectingSurfaceSingleIndicator() {
         // STEADY reconnecting state (`effectiveHidesTerminal == false`): the REAL
         // production composition mounts the [ReconnectingProgressRow] band (text +

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
@@ -1733,63 +1733,19 @@ public fun TmuxSessionScreen(
                 }
             }
 
-            // Issue #165: replace the bare one-line "connecting" status
-            // with a visible progress overlay (linear indeterminate bar
-            // + host string) so a 2-5s SSH handshake doesn't feel like
-            // the app is frozen. After 5s a "Still working, this may
-            // be slow" subline appears; after 15s a Cancel affordance
-            // tears down the in-flight [connectJob] (#151's
-            // join-on-cancel machinery makes the teardown deterministic).
-            (status as? ConnectionStatus.Connecting)?.let {
-                ConnectingProgressOverlay(
-                    user = it.user,
-                    host = it.host,
-                    port = it.port,
-                    sessionLabel = "tmux $sessionName",
-                    onCancel = { viewModel.cancelConnect() },
-                )
-            }
-            // Issue #750: a same-host session switch ([Switching]) no longer
-            // renders a thin under-header progress line here. During a switch the
-            // terminal surface is always replaced by a centered placeholder —
-            // either the "Attaching…" [SwitchingLoadingPlaceholder]
-            // (switchHidesTerminal) or the "waiting for tmux panes…"
-            // [EmptyPanesPlaceholder] (warm open, panes emptied) — and each of
-            // those now shows the canonical centered spinner (#757). Keeping the
-            // top bar produced the maintainer's reported "two loading indicators"
-            // on the reattach screen, so the centered spinner is the SOLE attach
-            // affordance and the top line is removed. Input stays gated because
-            // [Switching] is not [Connected].
-            //
-            // Issue #750 (post-#766 regression): the SAME two-loaders symptom came
-            // back on the RECONNECT/REATTACH screen. The #766 connection migration
-            // made the controller the authoritative status source: a recoverable
-            // drop projects [ConnectionStatus.Reconnecting] (this top
-            // [ReconnectingProgressRow] bar) WHILE the id-keyed [RevealStateMachine]
-            // maps the controller's `Reattaching`/`Reconnecting` to
-            // [RevealState.Seeding] → [effectiveHidesTerminal] is true → the
-            // centered "Attaching…" [SwitchingLoadingPlaceholder] is already up in
-            // the surface Box below. Two indicators at once. Gate the top bar on
-            // `!effectiveHidesTerminal` so it is suppressed exactly while the
-            // centered hold is showing — the centered "Attaching…" is then the SOLE
-            // reattach affordance, matching the [Switching] fix above. The top bar
-            // is NOT the sole indicator for any other state: it ONLY renders for
-            // [ConnectionStatus.Reconnecting], and every reconnect/reattach keeps
-            // the terminal held (the reveal machine never reveals Live for a
-            // Reattaching/Reconnecting controller state — see RevealStateMachine
-            // §"loading" mapping), so suppressing it here never leaves a reconnect
-            // with zero indicators. (Reconnect speed/behaviour is untouched — this
-            // is presentation-only.)
-            if (shouldShowReconnectingProgressRow(status, effectiveHidesTerminal)) {
-                (status as ConnectionStatus.Reconnecting).let {
-                    ReconnectingProgressRow(
-                        status = it,
-                        sessionLabel = "tmux $sessionName",
-                        onRetryNow = { viewModel.reconnect() },
-                        onCancel = { viewModel.cancelConnect() },
-                    )
-                }
-            }
+            // Issue #750 (4th occurrence): the top under-header connecting /
+            // reconnecting banner region. Both banners are routed through the
+            // single [primaryLoadingSurface] reducer so neither can ever stack on
+            // top of the centered "Attaching…" hold painted by the surface Box
+            // below (the maintainer's recurring "two loaders at once" symptom). See
+            // [TmuxTopConnectingBanner] for the per-banner rationale.
+            TmuxTopConnectingBanner(
+                status = status,
+                effectiveHidesTerminal = effectiveHidesTerminal,
+                sessionName = sessionName,
+                onCancelConnect = { viewModel.cancelConnect() },
+                onRetryNow = { viewModel.reconnect() },
+            )
             // Issue #145: render a user-facing error band (status text +
             // Reconnect affordance) when the SSH transport drops
             // mid-session. The view model's `client.disconnected`
@@ -4106,6 +4062,86 @@ internal fun reconnectKebabEnabled(
         status !is ConnectionStatus.Reconnecting
 
 /**
+ * Issue #750 (4th occurrence — the beyond-grace RECONNECT path): the single
+ * authoritative primary loading surface for the tmux session screen.
+ *
+ * The maintainer's recurring symptom is TWO loading surfaces at once on a
+ * connect/reconnect. The screen has THREE mutually-exclusive primary loading
+ * surfaces, and this reducer makes "two of them at once" TYPE-UNREPRESENTABLE —
+ * it returns EXACTLY ONE (or [None]):
+ *
+ *  - [CenteredAttaching] — the centered "Attaching…" [SwitchingLoadingPlaceholder]
+ *    hold, painted by the surface whenever the id-keyed [RevealStateMachine] holds
+ *    the terminal ([effectiveHidesTerminal] == true). This is the CANONICAL loader
+ *    per #750's original decision and WINS over any top banner: every in-progress
+ *    connect/switch/reattach/reconnect holds the terminal in [RevealState.Seeding],
+ *    so the centered hold is the sole loader for all of them.
+ *  - [ConnectingBanner] — the top [ConnectingProgressOverlay] ("Connecting to
+ *    host…", + slow hint + Cancel). It renders ONLY when the terminal is NOT held
+ *    (the rare live-frame-kept Connecting edge, e.g. the #178 dead-session-mid-
+ *    switch fallback), so it can never stack on top of the centered hold.
+ *  - [ReconnectingBand] — the top [ReconnectingProgressRow] (text + Retry now /
+ *    Cancel). Same rule: only when the terminal is NOT held.
+ *
+ * The 4th recurrence (2026-07-03): a beyond-grace reconnect re-dials through the
+ * controller's `Connecting` state, which projects to [ConnectionStatus.Connecting]
+ * (the top [ConnectingProgressOverlay] banner). The previous #750 fix gated only
+ * the [ReconnectingProgressRow] band on `!effectiveHidesTerminal` — it never gated
+ * the [ConnectingProgressOverlay], so on the reconnect re-dial BOTH the top
+ * "Connecting to host…" banner AND the centered "Attaching…" hold rendered at
+ * once. Routing BOTH banners through this reducer closes that gap: when the
+ * terminal is held (which it always is on a reconnect re-dial), the reducer
+ * returns [CenteredAttaching] and BOTH banners are suppressed.
+ */
+internal enum class PrimaryLoadingSurface {
+    /** No primary loading surface (Connected / Idle / Failed steady states). */
+    None,
+
+    /** The centered "Attaching…" [SwitchingLoadingPlaceholder] hold. */
+    CenteredAttaching,
+
+    /** The top [ConnectingProgressOverlay] "Connecting to host…" banner. */
+    ConnectingBanner,
+
+    /** The top [ReconnectingProgressRow] "Reconnecting to host…" band. */
+    ReconnectingBand,
+}
+
+/**
+ * Issue #750: the SINGLE source of truth for which primary loading surface is
+ * shown, so the screen can never paint two at once. See [PrimaryLoadingSurface].
+ */
+internal fun primaryLoadingSurface(
+    status: ConnectionStatus,
+    effectiveHidesTerminal: Boolean,
+): PrimaryLoadingSurface = when {
+    // The terminal is held → the surface paints the centered "Attaching…" hold,
+    // which is the canonical SOLE loader. Both top banners are suppressed so the
+    // maintainer never sees the top connecting banner AND the centered spinner at
+    // once (the 4th-recurrence beyond-grace reconnect symptom).
+    effectiveHidesTerminal -> PrimaryLoadingSurface.CenteredAttaching
+    status is ConnectionStatus.Connecting -> PrimaryLoadingSurface.ConnectingBanner
+    status is ConnectionStatus.Reconnecting -> PrimaryLoadingSurface.ReconnectingBand
+    else -> PrimaryLoadingSurface.None
+}
+
+/**
+ * Issue #750: the single-indicator gate for the top under-header
+ * [ConnectingProgressOverlay] "Connecting to host…" banner. Derived from
+ * [primaryLoadingSurface] so it can never coexist with the centered "Attaching…"
+ * hold — the exact 4th-recurrence beyond-grace-reconnect stacking (a reconnect
+ * re-dials through `Connecting`, projecting this banner, WHILE the reveal machine
+ * holds the terminal and paints the centered spinner). The banner renders ONLY in
+ * the live-frame-kept Connecting edge (terminal NOT held), so it is never the sole
+ * indicator stripped from a state that needs it.
+ */
+internal fun shouldShowConnectingProgressOverlay(
+    status: ConnectionStatus,
+    effectiveHidesTerminal: Boolean,
+): Boolean =
+    primaryLoadingSurface(status, effectiveHidesTerminal) == PrimaryLoadingSurface.ConnectingBanner
+
+/**
  * Issue #750: the single-indicator gate for the top under-header
  * [ReconnectingProgressRow] progress line.
  *
@@ -4116,19 +4152,20 @@ internal fun reconnectKebabEnabled(
  * terminal in [RevealState.Seeding] ([effectiveHidesTerminal] == true) and
  * paints the centered spinner — the two-loaders regression.
  *
- * This pure predicate makes the invariant a unit-testable wiring guard rather
- * than a comment: the top bar renders ONLY for a [ConnectionStatus.Reconnecting]
- * status AND only when the terminal is NOT held (so the centered spinner is not
- * up). Every real reconnect/reattach holds the terminal, so in practice the
- * centered spinner is the sole reattach affordance — but the predicate keeps the
- * top bar as a (currently unreached) fallback for any future reconnect that does
- * keep a live frame painted, so suppressing it can never leave a reconnect with
- * zero indicators.
+ * Derived from [primaryLoadingSurface] (single source of truth): the top bar
+ * renders ONLY for a [ConnectionStatus.Reconnecting] status AND only when the
+ * terminal is NOT held (so the centered spinner is not up). Every real
+ * reconnect/reattach holds the terminal, so in practice the centered spinner is
+ * the sole reattach affordance — but the reducer keeps the top bar as a
+ * (currently unreached) fallback for any future reconnect that does keep a live
+ * frame painted, so suppressing it can never leave a reconnect with zero
+ * indicators.
  */
 internal fun shouldShowReconnectingProgressRow(
     status: ConnectionStatus,
     effectiveHidesTerminal: Boolean,
-): Boolean = status is ConnectionStatus.Reconnecting && !effectiveHidesTerminal
+): Boolean =
+    primaryLoadingSurface(status, effectiveHidesTerminal) == PrimaryLoadingSurface.ReconnectingBand
 
 /**
  * Issue #463: the short leaf label for the header project crumb, derived
@@ -4763,6 +4800,74 @@ private fun StatusLine(text: String) {
 }
 
 /**
+ * Issue #750 (4th occurrence): the top under-header connecting / reconnecting
+ * banner region — the SINGLE render site for both top loading banners.
+ *
+ * Both the cold-dial [ConnectingProgressOverlay] ("Connecting to host…") and the
+ * recovery [ReconnectingProgressRow] band are gated through [primaryLoadingSurface]
+ * (via [shouldShowConnectingProgressOverlay] / [shouldShowReconnectingProgressRow]),
+ * so NEITHER can render while the terminal is held ([effectiveHidesTerminal] ==
+ * true) — that is exactly when the surface Box paints the centered "Attaching…"
+ * hold. This makes the maintainer's recurring "top connecting banner AND centered
+ * spinner at once" symptom structurally impossible: while the terminal is held the
+ * reducer resolves to [PrimaryLoadingSurface.CenteredAttaching] and this whole
+ * region renders nothing.
+ *
+ * The two banners are mutually exclusive by status ([ConnectionStatus.Connecting]
+ * vs [ConnectionStatus.Reconnecting]), so at most one ever renders here — and only
+ * in the (currently unreached) live-frame-kept edge where the terminal is NOT held.
+ *
+ * Extracting this as a composable (rather than inlining the two `if` blocks in the
+ * screen body) makes it a genuine WIRING guard: the #750 regression test drives
+ * this exact composable in the beyond-grace state and hard-asserts a single loader,
+ * so a future re-introduction of an ungated banner is caught in CI.
+ */
+@Composable
+internal fun TmuxTopConnectingBanner(
+    status: ConnectionStatus,
+    effectiveHidesTerminal: Boolean,
+    sessionName: String,
+    onCancelConnect: () -> Unit,
+    onRetryNow: () -> Unit,
+) {
+    // Issue #165: the cold-dial progress overlay (linear bar + host string + slow
+    // hint + Cancel). Gated on [shouldShowConnectingProgressOverlay] so it never
+    // stacks on top of the centered "Attaching…" hold on a reconnect re-dial (the
+    // 4th-recurrence beyond-grace symptom: a reconnect re-dials through the
+    // controller's `Connecting`, projecting this banner, while the terminal is
+    // held). It renders ONLY in the live-frame-kept Connecting edge.
+    if (shouldShowConnectingProgressOverlay(status, effectiveHidesTerminal)) {
+        (status as ConnectionStatus.Connecting).let {
+            ConnectingProgressOverlay(
+                user = it.user,
+                host = it.host,
+                port = it.port,
+                sessionLabel = "tmux $sessionName",
+                onCancel = onCancelConnect,
+            )
+        }
+    }
+    // Issue #750: the recovery band. A same-host session switch ([Switching]) and
+    // every reconnect/reattach hold the terminal and paint the centered
+    // "Attaching…" [SwitchingLoadingPlaceholder] (the SOLE attach affordance), so
+    // the band is suppressed while held ([shouldShowReconnectingProgressRow]). It
+    // renders ONLY for a [ConnectionStatus.Reconnecting] status that keeps a live
+    // frame painted (terminal NOT held) — the fallback so a reconnect is never left
+    // with zero indicators. (Reconnect speed/behaviour is untouched — this is
+    // presentation-only.)
+    if (shouldShowReconnectingProgressRow(status, effectiveHidesTerminal)) {
+        (status as ConnectionStatus.Reconnecting).let {
+            ReconnectingProgressRow(
+                status = it,
+                sessionLabel = "tmux $sessionName",
+                onRetryNow = onRetryNow,
+                onCancel = onCancelConnect,
+            )
+        }
+    }
+}
+
+/**
  * Issue #165: progress overlay rendered above the terminal viewport
  * while the screen is in [ConnectionStatus.Connecting].
  *
@@ -5182,7 +5287,7 @@ private fun EmptyPanesPlaceholder() {
  * reveals the real terminal the instant the new session's panes are seeded.
  */
 @Composable
-private fun SwitchingLoadingPlaceholder() {
+internal fun SwitchingLoadingPlaceholder() {
     Box(
         modifier = Modifier
             .fillMaxSize()

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionScreenTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionScreenTest.kt
@@ -16,6 +16,7 @@ import com.pocketshell.core.storage.entity.HostEntity
 import com.pocketshell.core.terminal.selection.LocalhostUrl
 import com.pocketshell.uikit.model.SessionAgentKind
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -1841,8 +1842,8 @@ class TmuxSessionScreenTest {
     @Test
     fun topReconnectBarNeverShownForNonReconnectingStatus() {
         // The top bar renders ONLY for Reconnecting — so it is never the sole
-        // indicator for any other state. Connecting has its own full-screen
-        // overlay; Connected/Switching/Failed/Idle drive their own affordances.
+        // indicator for any other state. Connecting has its own top overlay (gated
+        // the same way); Connected/Switching/Failed/Idle drive their own affordances.
         val nonReconnecting = listOf(
             TmuxSessionViewModel.ConnectionStatus.Idle,
             TmuxSessionViewModel.ConnectionStatus.Connecting("h", 22, "u"),
@@ -1860,6 +1861,117 @@ class TmuxSessionScreenTest {
                 "no top progress bar for $status (terminal held)",
                 false,
                 shouldShowReconnectingProgressRow(status, effectiveHidesTerminal = true),
+            )
+        }
+    }
+
+    // --- Issue #750 (4th occurrence): the beyond-grace RECONNECT two-loaders bug.
+    // The maintainer sees the top "Connecting to host…" [ConnectingProgressOverlay]
+    // banner AND the centered "Attaching…" hold at the SAME time on a beyond-grace
+    // reconnect. Root cause: a reconnect re-dials through the controller's
+    // `Connecting` state → status projects to [ConnectionStatus.Connecting] (the top
+    // banner) WHILE the reveal machine holds the terminal (effectiveHidesTerminal ==
+    // true) and paints the centered spinner. The previous #750 fix gated only the
+    // Reconnecting band, never the Connecting overlay. These tests pin the reducer +
+    // BOTH gate predicates so exactly ONE primary loading surface resolves per state.
+
+    private val connectingStatus =
+        TmuxSessionViewModel.ConnectionStatus.Connecting("beta.example", 22, "alex")
+
+    @Test
+    fun connectingOverlaySuppressedWhileTerminalHeld_beyondGraceReconnectRepro() {
+        // REPRODUCTION of the maintainer's exact reopen state: a beyond-grace
+        // reconnect projects Connecting (the top overlay) WHILE the terminal is held
+        // (the centered "Attaching…" hold is up). Pre-fix the overlay was ungated on
+        // `status is Connecting`, so it stacked on top of the centered hold — TWO
+        // loaders. The reducer must resolve to the SINGLE centered hold and suppress
+        // the top banner.
+        assertEquals(
+            PrimaryLoadingSurface.CenteredAttaching,
+            primaryLoadingSurface(connectingStatus, effectiveHidesTerminal = true),
+        )
+        assertEquals(
+            "top Connecting overlay must be suppressed while the terminal is held",
+            false,
+            shouldShowConnectingProgressOverlay(connectingStatus, effectiveHidesTerminal = true),
+        )
+    }
+
+    @Test
+    fun connectingOverlayShownOnlyWhenTerminalNotHeld() {
+        // The top overlay is the fallback loader for a (currently unreached)
+        // Connecting that keeps a live frame painted (terminal NOT held), so it is
+        // never the sole indicator stripped from a state that needs it.
+        assertEquals(
+            PrimaryLoadingSurface.ConnectingBanner,
+            primaryLoadingSurface(connectingStatus, effectiveHidesTerminal = false),
+        )
+        assertTrue(
+            shouldShowConnectingProgressOverlay(connectingStatus, effectiveHidesTerminal = false),
+        )
+    }
+
+    @Test
+    fun exactlyOnePrimaryLoadingSurfacePerInProgressState_classCoverage() {
+        // Class coverage (D31/G2): every in-progress connection state resolves to
+        // EXACTLY ONE primary loading surface — never a top banner AND the centered
+        // "Attaching…" at once. Each in-progress state ALWAYS holds the terminal
+        // (RevealState.Seeding), so each resolves to the SINGLE centered hold; the
+        // top banners are suppressed. This is the invariant the maintainer's symptom
+        // keeps regressing on, pinned for all four states plus the never-held edges.
+
+        // Beyond-grace reconnect re-dials through the controller's Connecting →
+        // status Connecting; within-grace/steady recovery → status Reconnecting;
+        // a same-host switch → status Switching; a cold connect → status Connecting.
+        val inProgressHeldStates = listOf(
+            "cold Connecting" to connectingStatus,
+            "beyond-grace reconnect (re-dial → Connecting)" to connectingStatus,
+            "Switching / Attaching" to
+                TmuxSessionViewModel.ConnectionStatus.Switching("h", 22, "u"),
+            "Reattaching / Reconnecting" to reconnectingStatus,
+        )
+        inProgressHeldStates.forEach { (label, status) ->
+            // Terminal held (the real in-progress reality): the SOLE loader is the
+            // centered "Attaching…"; BOTH top banners are suppressed.
+            assertEquals(
+                "$label must resolve to the single centered hold while the terminal is held",
+                PrimaryLoadingSurface.CenteredAttaching,
+                primaryLoadingSurface(status, effectiveHidesTerminal = true),
+            )
+            assertEquals(
+                "$label: top Connecting overlay suppressed while held",
+                false,
+                shouldShowConnectingProgressOverlay(status, effectiveHidesTerminal = true),
+            )
+            assertEquals(
+                "$label: top Reconnecting band suppressed while held",
+                false,
+                shouldShowReconnectingProgressRow(status, effectiveHidesTerminal = true),
+            )
+            // Never both banners at once regardless of hold state.
+            listOf(true, false).forEach { held ->
+                assertFalse(
+                    "$label (held=$held): the two top banners must be mutually exclusive",
+                    shouldShowConnectingProgressOverlay(status, held) &&
+                        shouldShowReconnectingProgressRow(status, held),
+                )
+            }
+        }
+    }
+
+    @Test
+    fun steadyStatesHaveNoPrimaryLoadingSurface() {
+        // Connected / Idle / Failed with a live (not-held) frame have no primary
+        // loading surface — no spinner falsely implying in-flight work.
+        listOf(
+            TmuxSessionViewModel.ConnectionStatus.Connected("h", 22, "u"),
+            TmuxSessionViewModel.ConnectionStatus.Idle,
+            TmuxSessionViewModel.ConnectionStatus.Failed("boom"),
+        ).forEach { status ->
+            assertEquals(
+                "no loading surface for steady $status",
+                PrimaryLoadingSurface.None,
+                primaryLoadingSurface(status, effectiveHidesTerminal = false),
             )
         }
     }


### PR DESCRIPTION
Closes #750 (maintainer dogfood reopen, 4th occurrence — screenshot on the issue). The prior fix gated only the reconnecting row, never the `ConnectingProgressOverlay` banner, so beyond-grace reconnect (re-dials through `Connecting` while the terminal is held) stacked banner + centered 'Attaching…'. Fix routes both top banners through a single `primaryLoadingSurface(status, effectiveHidesTerminal)` reducer → 'two loaders' is type-unrepresentable; the centered hold is the sole loader across all in-progress states.

Reviewer: red→green reproduced (neutralize the gate → beyond-grace repro + class-coverage fail; restore → 102 green), all 4 states pin to one loader, reducer verified type-exclusive, on-device `captureBeyondGraceReconnectSingleIndicator_reopenRepro` hard-asserts zero banner nodes + exactly one indicator (5/5 on emulator). Presentation-only, disjoint from sibling #585. Orchestrator gate green.