### PR TITLE
composer: hold launcher + swipe-up to open WITH recording (#585 entry gesture)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/voice/ComposerLauncherHoldSwipeUpJourneyTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/voice/ComposerLauncherHoldSwipeUpJourneyTest.kt
@@ -1,0 +1,249 @@
+package com.pocketshell.app.voice
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import androidx.lifecycle.SavedStateHandle
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.composer.COMPOSER_CANCEL_RECORDING_TAG
+import com.pocketshell.app.composer.COMPOSER_MIC_TAG
+import com.pocketshell.app.composer.COMPOSER_RECORDING_LOCKED_TAG
+import com.pocketshell.app.composer.COMPOSER_STOP_SEND_TAG
+import com.pocketshell.app.composer.COMPOSER_TO_FIELD_TAG
+import com.pocketshell.app.composer.PromptComposerSheet
+import com.pocketshell.app.composer.PromptComposerViewModel
+import com.pocketshell.app.composer.PromptComposerViewModel.ApiKeyVault
+import com.pocketshell.app.composer.PromptComposerViewModel.MicCapture
+import com.pocketshell.app.composer.PromptComposerViewModel.RecordingState
+import com.pocketshell.app.composer.PromptComposerViewModel.VoiceSettingsSnapshot
+import com.pocketshell.app.di.WhisperClientFactory
+import com.pocketshell.app.proof.WalkthroughScreenshotArtifacts
+import com.pocketshell.core.voice.SpeechAudioGuard
+import com.pocketshell.core.voice.WhisperClient
+import com.pocketshell.uikit.theme.PocketShellTheme
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Issue #585 (REOPENED — the TRUE desired behavior). The maintainer's vision is
+ * an ENTRY gesture on the composer LAUNCHER button (NOT the mic inside the
+ * already-open sheet, which prior attempts kept building): hold the launcher and
+ * swipe UP → the Prompt Composer opens AND recording begins immediately, locked
+ * hands-free, in ONE gesture. A plain tap on the launcher still opens the
+ * composer with NO recording.
+ *
+ * This drives the REAL production wiring: the real [ConversationComposerLauncherRow]
+ * launcher (tag [SESSION_COMPOSER_LAUNCHER_TAG]) with the same `onDictateTap` /
+ * `onDictateHoldSwipeUp` split TmuxSessionScreen uses, opening the real
+ * [PromptComposerSheet] inside its [androidx.compose.material3.ModalBottomSheet]
+ * with a real [PromptComposerViewModel] and `autoStartRecording` threaded exactly
+ * as production threads it. The launcher's hold+swipe-up detector therefore
+ * competes with the same ancestor gesture arbitration it does on device.
+ *
+ * RED on base: without the launcher entry gesture + the sheet's
+ * `autoStartRecording` auto-start, the hold+swipe-up on the launcher opens the
+ * composer with NO recording (recording stays Idle), so
+ * [holdLauncherThenSwipeUpOpensComposerWithLockedRecording] fails its
+ * Recording+locked assertion. GREEN with the fix.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@RunWith(AndroidJUnit4::class)
+class ComposerLauncherHoldSwipeUpJourneyTest {
+
+    @get:Rule
+    val compose = createAndroidComposeRule<ComponentActivity>()
+
+    @Before
+    fun grantRecordAudio() {
+        val targetPackage = InstrumentationRegistry.getInstrumentation()
+            .targetContext.packageName
+        InstrumentationRegistry.getInstrumentation().uiAutomation.executeShellCommand(
+            "pm grant $targetPackage android.permission.RECORD_AUDIO",
+        ).close()
+    }
+
+    private class FakeMicCapture : MicCapture {
+        var startCount = 0
+        var stopCount = 0
+        private var running = false
+
+        override fun start() {
+            startCount++
+            running = true
+        }
+
+        override fun stop(): ByteArray {
+            stopCount++
+            running = false
+            return SpeechAudioGuard.speechWavForTesting()
+        }
+
+        override fun currentAmplitude(): Float = if (running) 0.65f else 0f
+    }
+
+    private class FakeVault : ApiKeyVault {
+        private var key: CharArray? = "sk-test".toCharArray()
+        override fun save(key: CharArray) { this.key = key.copyOf() }
+        override fun load(): CharArray? = key?.copyOf()
+        override fun clear() { key = null }
+    }
+
+    private class FakeVoiceSettings : VoiceSettingsSnapshot {
+        override fun silenceWindowMs(): Long = 600_000L
+        override fun whisperLanguageHint(): String? = null
+    }
+
+    private fun newViewModel(mic: MicCapture): PromptComposerViewModel {
+        val whisper = object : WhisperClient {
+            override suspend fun transcribe(audio: ByteArray, language: String?): Result<String> =
+                Result.success("launcher dictation")
+        }
+        return PromptComposerViewModel(
+            audioRecorder = mic,
+            whisperClientFactory = WhisperClientFactory { whisper },
+            apiKeyStorage = FakeVault(),
+            voiceSettings = FakeVoiceSettings(),
+            savedStateHandle = SavedStateHandle(),
+        )
+    }
+
+    /**
+     * Renders the production launcher + composer wired exactly as TmuxSessionScreen
+     * wires them: a plain launcher tap opens the composer with `autoStartRecording
+     * = false`; the launcher's hold+swipe-up entry gesture opens it with
+     * `autoStartRecording = true`.
+     */
+    // Held outside setContent so a callback-driven flip survives recomposition
+    // (a non-remembered in-composition mutableStateOf would reset to false).
+    private val showComposer = mutableStateOf(false)
+    private val autoRecord = mutableStateOf(false)
+
+    private fun renderLauncherAndComposer(viewModel: PromptComposerViewModel) {
+        compose.setContent {
+            PocketShellTheme {
+                // Pin the launcher to the BOTTOM (as TmuxSessionScreen does) so the
+                // hold+swipe-up has the whole screen above it to pull into — a
+                // top-anchored launcher would run out of screen before the swipe
+                // threshold and never register the pull.
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.BottomCenter,
+                ) {
+                    ConversationComposerLauncherRow(
+                        onDictateTap = {
+                            autoRecord.value = false
+                            showComposer.value = true
+                        },
+                        onDictateHoldSwipeUp = {
+                            autoRecord.value = true
+                            showComposer.value = true
+                        },
+                        inputEnabled = true,
+                    )
+                }
+                if (showComposer.value) {
+                    PromptComposerSheet(
+                        onDismiss = { showComposer.value = false },
+                        onSend = { _ -> true },
+                        viewModel = viewModel,
+                        autoStartRecording = autoRecord.value,
+                    )
+                }
+            }
+        }
+        compose.waitUntil(timeoutMillis = 10_000) {
+            compose.onAllNodesWithTag(SESSION_COMPOSER_LAUNCHER_TAG)
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+        compose.waitForIdle()
+    }
+
+    @Test
+    fun holdLauncherThenSwipeUpOpensComposerWithLockedRecording() {
+        val mic = FakeMicCapture()
+        val viewModel = newViewModel(mic)
+        renderLauncherAndComposer(viewModel)
+
+        // Hold the launcher and pull up in one continuous gesture.
+        compose.onNodeWithTag(SESSION_COMPOSER_LAUNCHER_TAG, useUnmergedTree = true)
+            .performTouchInput {
+                down(center)
+                advanceEventTime(80L)
+                repeat(8) {
+                    moveBy(Offset(0f, -28f))
+                    advanceEventTime(16L)
+                }
+                up()
+            }
+
+        // The composer must OPEN from the swipe AND recording must go live +
+        // locked hands-free from the SAME gesture. (Once recording starts, the
+        // Idle mic disc COMPOSER_MIC_TAG is replaced by the recording controls, so
+        // recording state — driven only from INSIDE the composed sheet — is itself
+        // the proof the composer opened.)
+        compose.waitUntil(timeoutMillis = 5_000) {
+            viewModel.uiState.value.recording == RecordingState.Recording &&
+                viewModel.uiState.value.recordingLocked
+        }
+        compose.waitForIdle()
+
+        assertEquals("Launcher swipe-up entry must start exactly one capture", 1, mic.startCount)
+        assertEquals("Finger-up after the entry swipe must not stop capture", 0, mic.stopCount)
+        assertEquals(RecordingState.Recording, viewModel.uiState.value.recording)
+        assertTrue("Recording must be locked hands-free", viewModel.uiState.value.recordingLocked)
+        // The live locked recording UI + its stop/cancel/send controls are present
+        // (proves the composer is open in the recording state, not just that the
+        // ViewModel flipped).
+        compose.onNodeWithTag(COMPOSER_RECORDING_LOCKED_TAG).assertIsDisplayed()
+        compose.onNodeWithTag(COMPOSER_CANCEL_RECORDING_TAG).assertIsDisplayed()
+        compose.onNodeWithTag(COMPOSER_TO_FIELD_TAG).assertIsDisplayed()
+        compose.onNodeWithTag(COMPOSER_STOP_SEND_TAG).assertIsDisplayed()
+        WalkthroughScreenshotArtifacts.capture("issue-585-launcher-swipe-open-recording")
+
+        // Stop/cancel still works from the launcher-opened locked recording.
+        compose.onNodeWithTag(COMPOSER_CANCEL_RECORDING_TAG).performClick()
+        compose.waitUntil(timeoutMillis = 5_000) {
+            viewModel.uiState.value.recording == RecordingState.Idle &&
+                !viewModel.uiState.value.recordingLocked
+        }
+        assertEquals("Discard should stop the locked capture once", 1, mic.stopCount)
+    }
+
+    @Test
+    fun plainTapOnLauncherOpensComposerWithoutRecording() {
+        val mic = FakeMicCapture()
+        val viewModel = newViewModel(mic)
+        renderLauncherAndComposer(viewModel)
+
+        // A plain tap must open the composer with NO recording (unchanged).
+        compose.onNodeWithTag(SESSION_COMPOSER_LAUNCHER_TAG).performClick()
+        compose.waitUntil(timeoutMillis = 5_000) {
+            compose.onAllNodesWithTag(COMPOSER_MIC_TAG).fetchSemanticsNodes().isNotEmpty()
+        }
+        compose.waitForIdle()
+
+        // Composer is open, but recording never started.
+        compose.onNodeWithTag(COMPOSER_MIC_TAG).assertIsDisplayed()
+        assertEquals("Plain tap must NOT start recording", 0, mic.startCount)
+        assertEquals(RecordingState.Idle, viewModel.uiState.value.recording)
+        assertFalse(viewModel.uiState.value.recordingLocked)
+        compose.onNodeWithTag(COMPOSER_RECORDING_LOCKED_TAG).assertDoesNotExist()
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerSheet.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerSheet.kt
@@ -233,6 +233,13 @@ public fun PromptComposerSheet(
     // Issue #900: UI/API plumbing for manual outbound retry. Tests may override
     // this seam, while production defaults to the owning VM.
     onRetryOutboundItem: ((String) -> Unit)? = null,
+    // Issue #585: open the composer WITH recording already started + locked
+    // hands-free. Set true only when the session launcher's hold+swipe-up ENTRY
+    // gesture opened this sheet; a plain-tap open leaves it false (no recording).
+    // The effect below fires ONCE per sheet open (a remembered latch guards it),
+    // starts recording through the same permission/API-key gate as the mic tap,
+    // and immediately locks it so releasing the finger keeps capturing.
+    autoStartRecording: Boolean = false,
 ) {
     val state by viewModel.uiState.collectAsState()
     val pendingItems by viewModel.pendingItems.collectAsState()
@@ -347,6 +354,57 @@ public fun PromptComposerSheet(
     // context) leaves the draft un-scoped.
     LaunchedEffect(composerTargetKey) {
         viewModel.onComposerTargetChanged(composerTargetKey)
+    }
+
+    // Issue #585: the session launcher's hold+swipe-up ENTRY gesture opens this
+    // sheet WITH recording already started + locked hands-free — one gesture, not
+    // "open then tap the mic". [autoStartRecording] carries that intent from the
+    // launcher; a plain-tap open leaves it false. This effect fires ONCE per sheet
+    // open (a remembered latch guards it against recomposition) and only starts
+    // from a clean Idle composer so it never interrupts an in-flight capture.
+    //
+    // Recording start runs through the SAME permission + API-key gate as the mic
+    // tap. On the common path (mic already granted, key present) it starts and
+    // locks synchronously; if the mic permission must be requested first, the
+    // grant callback ([permissionLauncher]) starts the capture and the lock-latch
+    // effect below locks it the moment capture goes live.
+    var autoStartRecordingConsumed by remember { mutableStateOf(false) }
+    var autoLockPending by remember { mutableStateOf(false) }
+    LaunchedEffect(autoStartRecording) {
+        if (!autoStartRecording || autoStartRecordingConsumed) return@LaunchedEffect
+        autoStartRecordingConsumed = true
+        if (viewModel.uiState.value.recording !=
+            PromptComposerViewModel.RecordingState.Idle
+        ) {
+            return@LaunchedEffect
+        }
+        val granted = ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.RECORD_AUDIO,
+        ) == PackageManager.PERMISSION_GRANTED
+        if (!granted) {
+            // The grant callback fires onMicTap(); the latch effect then locks it.
+            autoLockPending = true
+            permissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
+            return@LaunchedEffect
+        }
+        if (viewModel.needsOpenAiKeyForMicTap()) {
+            // Surface the key dialog; the user adds the key, then records manually.
+            showApiKeyDialog = true
+            return@LaunchedEffect
+        }
+        viewModel.onMicTap()
+        viewModel.lockRecording()
+    }
+    // Issue #585: when auto-start had to wait on the permission dialog, lock the
+    // recording as soon as the grant-driven capture actually goes live.
+    LaunchedEffect(state.recording, autoLockPending) {
+        if (autoLockPending &&
+            state.recording == PromptComposerViewModel.RecordingState.Recording
+        ) {
+            viewModel.lockRecording()
+            autoLockPending = false
+        }
     }
 
     // Issue #511 / #509: dismissing the composer (× button, scrim tap,

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
@@ -781,6 +781,12 @@ public fun TmuxSessionScreen(
     // into a tmux pane (see #123 — the primary user route was completely
     // dark for voice input).
     var showMicSheet by remember { mutableStateOf(false) }
+    // Issue #585: when the composer is opened via the launcher's hold+swipe-up
+    // ENTRY gesture, it must open WITH recording already started + locked
+    // hands-free. A plain launcher tap opens the composer with NO recording. This
+    // flag carries that intent into the sheet; it is reset every time the sheet
+    // closes so the next plain-tap open never inherits a stale auto-record.
+    var micSheetAutoStartRecording by remember { mutableStateOf(false) }
     var showSnippetPicker by remember { mutableStateOf(false) }
     // Issue #1207: when a TUI-only slash-command (/model, /config, a picker) is
     // sent from the Conversation composer, the picker opens in the covered
@@ -816,6 +822,10 @@ public fun TmuxSessionScreen(
     LaunchedEffect(initialComposerAttachments) {
         if (initialComposerAttachments.isNotEmpty()) {
             initialComposerAttachments.forEach { promptComposerViewModel.seedAttachment(it) }
+            // Issue #585: a share/attach intent opens the composer to edit + Send,
+            // never to auto-record — keep the flag false so no stale swipe-open
+            // intent bleeds into this entry.
+            micSheetAutoStartRecording = false
             showMicSheet = true
             onInitialComposerAttachmentsConsumed()
         }
@@ -829,6 +839,9 @@ public fun TmuxSessionScreen(
     LaunchedEffect(initialComposerPrompt) {
         if (initialComposerPrompt.isNotBlank()) {
             promptComposerViewModel.seedDraftPrompt(initialComposerPrompt)
+            // Issue #585: a routed review-prompt opens the composer to edit + Send,
+            // not to auto-record.
+            micSheetAutoStartRecording = false
             showMicSheet = true
             onInitialComposerPromptConsumed()
         }
@@ -1027,6 +1040,7 @@ public fun TmuxSessionScreen(
             }
             if (sent) {
                 showMicSheet = false
+                micSheetAutoStartRecording = false
             }
             sent
         }
@@ -1034,7 +1048,10 @@ public fun TmuxSessionScreen(
     PromptComposerSendDispatcher(
         viewModel = promptComposerViewModel,
         onSend = composerSendHandler,
-        onDelivered = { showMicSheet = false },
+        onDelivered = {
+            showMicSheet = false
+            micSheetAutoStartRecording = false
+        },
     )
 
     // Issue #167: intercept system-back so the user returns to the host
@@ -1066,7 +1083,10 @@ public fun TmuxSessionScreen(
             showSessionDrawer = false
             sessionPickerViewModel.dismiss()
         },
-        onDismissMicSheet = { showMicSheet = false },
+        onDismissMicSheet = {
+            showMicSheet = false
+            micSheetAutoStartRecording = false
+        },
         onDismissSnippetPicker = { showSnippetPicker = false },
         onDismissCardFeedSheet = { showCardFeedSheet = false },
         onBack = onBack,
@@ -2387,7 +2407,18 @@ public fun TmuxSessionScreen(
                     // Issue #810: the composer launcher is UNCONDITIONAL — it only
                     // opens the Prompt Composer sheet (no pane needed), so it is
                     // never gated on `surfacePane`.
-                    onDictateTap = { showMicSheet = true },
+                    onDictateTap = {
+                        // Plain tap: open the composer with NO recording (unchanged).
+                        micSheetAutoStartRecording = false
+                        showMicSheet = true
+                    },
+                    // Issue #585: hold the launcher + swipe UP → open the composer
+                    // AND start recording immediately (locked hands-free), one
+                    // gesture. The sheet consumes `autoStartRecording` on open.
+                    onDictateHoldSwipeUp = {
+                        micSheetAutoStartRecording = true
+                        showMicSheet = true
+                    },
                     onEnterTap = pane?.let { p -> { viewModel.onKeyBarKey(p.paneId, "Enter") } },
                     // Issue #131: surface the show-keyboard chip on the tmux
                     // route too. The helper looks up the TerminalView of the
@@ -2836,7 +2867,15 @@ public fun TmuxSessionScreen(
             // the exact target identity so a "Not sent" draft authored here never
             // bleeds into another session on a switch or same-name recreation.
             composerTargetKey = targetSessionId.value,
-            onDismiss = { showMicSheet = false },
+            // Issue #585: when the launcher's hold+swipe-up entry gesture opened
+            // this sheet, start recording immediately (locked hands-free) as the
+            // sheet appears. A plain-tap open leaves this false = no recording.
+            autoStartRecording = micSheetAutoStartRecording,
+            onDismiss = {
+                showMicSheet = false
+                // Reset so the next plain-tap open never inherits auto-record.
+                micSheetAutoStartRecording = false
+            },
             // Issue #745: surface the live connection state in the composer so a
             // send while the SSH/tmux link is degraded shows a connection-lost
             // indicator immediately rather than leaving the user waiting blind.
@@ -7142,6 +7181,9 @@ internal fun TmuxSessionBottomControlsCallSite(
     isAgentPane: Boolean,
     onChipTap: (String) -> Unit,
     onDictateTap: (() -> Unit)?,
+    // Issue #585: hold-the-launcher-and-swipe-up entry gesture — open the Prompt
+    // Composer WITH recording already active + locked hands-free.
+    onDictateHoldSwipeUp: (() -> Unit)? = null,
     onEnterTap: (() -> Unit)?,
     onShowKeyboardTap: (() -> Unit)?,
     onAddSnippetTap: (() -> Unit)?,
@@ -7165,6 +7207,7 @@ internal fun TmuxSessionBottomControlsCallSite(
         isAgentPane = isAgentPane,
         onChipTap = onChipTap,
         onDictateTap = onDictateTap,
+        onDictateHoldSwipeUp = onDictateHoldSwipeUp,
         onEnterTap = onEnterTap,
         onShowKeyboardTap = onShowKeyboardTap,
         onAddSnippetTap = onAddSnippetTap,
@@ -7182,6 +7225,9 @@ internal fun TmuxTerminalBottomControls(
     isAgentPane: Boolean,
     onChipTap: (String) -> Unit,
     onDictateTap: (() -> Unit)?,
+    // Issue #585: hold-the-launcher-and-swipe-up entry gesture — open the Prompt
+    // Composer WITH recording already active + locked hands-free.
+    onDictateHoldSwipeUp: (() -> Unit)? = null,
     onEnterTap: (() -> Unit)?,
     onShowKeyboardTap: (() -> Unit)?,
     onAddSnippetTap: (() -> Unit)?,
@@ -7256,6 +7302,7 @@ internal fun TmuxTerminalBottomControls(
                 if (onDictateTap != null) {
                     ConversationComposerLauncherRow(
                         onDictateTap = onDictateTap,
+                        onDictateHoldSwipeUp = onDictateHoldSwipeUp,
                         inputEnabled = sessionLive,
                         modifier = modifier,
                     )
@@ -7272,6 +7319,7 @@ internal fun TmuxTerminalBottomControls(
                     chips = if (isAgentPane) AgentExitChips else DefaultSessionChips,
                     onChipTap = onChipTap,
                     onDictateTap = onDictateTap,
+                    onDictateHoldSwipeUp = onDictateHoldSwipeUp,
                     onEnterTap = onEnterTap,
                     onShowKeyboardTap = onShowKeyboardTap,
                     onAddSnippetTap = onAddSnippetTap,

--- a/app/src/main/java/com/pocketshell/app/voice/VoiceSessionSurface.kt
+++ b/app/src/main/java/com/pocketshell/app/voice/VoiceSessionSurface.kt
@@ -3,6 +3,8 @@ package com.pocketshell.app.voice
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -20,18 +22,28 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.PathBuilder
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.changedToUpIgnoreConsumed
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.positionChanged
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.onClick
+import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import kotlin.math.abs
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.runtime.getValue
@@ -565,6 +577,10 @@ internal fun BottomChipControls(
     chips: List<String>,
     onChipTap: (String) -> Unit,
     onDictateTap: (() -> Unit)?,
+    // Issue #585: hold-the-launcher-and-swipe-up entry gesture — open the Prompt
+    // Composer WITH recording already active + locked. Null leaves the launcher
+    // tap-only (open-only), the pre-#585 behaviour.
+    onDictateHoldSwipeUp: (() -> Unit)? = null,
     onEnterTap: (() -> Unit)? = null,
     onShowKeyboardTap: (() -> Unit)? = null,
     onAddSnippetTap: (() -> Unit)? = null,
@@ -707,6 +723,7 @@ internal fun BottomChipControls(
                         ComposerLauncherButton(
                             enabled = inputEnabled,
                             onClick = onDictateTap,
+                            onHoldSwipeUp = onDictateHoldSwipeUp,
                         )
                     }
                 }
@@ -738,6 +755,10 @@ internal fun ConversationComposerLauncherRow(
     onDictateTap: () -> Unit,
     inputEnabled: Boolean,
     modifier: Modifier = Modifier,
+    // Issue #585: hold-the-launcher-and-swipe-up entry gesture — open the Prompt
+    // Composer WITH recording already active + locked. Null leaves the launcher
+    // tap-only (open-only).
+    onDictateHoldSwipeUp: (() -> Unit)? = null,
 ) {
     Box(
         modifier = modifier
@@ -753,6 +774,7 @@ internal fun ConversationComposerLauncherRow(
         ComposerLauncherButton(
             enabled = inputEnabled,
             onClick = onDictateTap,
+            onHoldSwipeUp = onDictateHoldSwipeUp,
         )
     }
 }
@@ -762,16 +784,67 @@ private fun ComposerLauncherButton(
     enabled: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    // Issue #585: the Telegram-style ENTRY gesture. Hold the launcher and swipe
+    // UP past [LAUNCHER_HOLD_SWIPE_UP_THRESHOLD_DP] to open the Prompt Composer
+    // WITH recording already started + locked hands-free — one gesture, no
+    // separate tap-to-open then tap-to-record. A plain TAP (and a hold WITHOUT a
+    // swipe) still routes to [onClick] = open-only, so the launcher's normal
+    // behaviour is untouched. Null (the default) leaves the launcher tap-only for
+    // callers/previews that don't wire the entry gesture.
+    onHoldSwipeUp: (() -> Unit)? = null,
 ) {
     val containerColor = if (enabled) PocketShellColors.SurfaceElev else PocketShellColors.Surface
     val borderColor = if (enabled) PocketShellColors.AccentDim else PocketShellColors.BorderSoft
     val glyphColor = if (enabled) PocketShellColors.Accent else PocketShellColors.TextMuted
     val shape = PocketShellShapes.small
 
+    val swipeThresholdPx = with(LocalDensity.current) {
+        LAUNCHER_HOLD_SWIPE_UP_THRESHOLD_DP.dp.toPx()
+    }
+    val currentOnClick by rememberUpdatedState(onClick)
+    val currentOnHoldSwipeUp by rememberUpdatedState(onHoldSwipeUp)
+
+    // Issue #585: the launcher's tap and hold+swipe-up ENTRY gesture are detected
+    // in ONE pointer handler that OWNS the pointer (consumes the down + moves),
+    // the same reliable delivery pattern as the composer's proven mic swipe-lock —
+    // a non-owning detector was silently losing the drag once the pointer left the
+    // small 44dp button. A release WITHOUT crossing the up-threshold (a plain tap
+    // OR a hold-without-swipe) opens the composer only; an upward pull past the
+    // threshold opens it WITH recording. When no swipe handler is wired the plain
+    // `clickable` is used instead, so unrelated launcher call sites are untouched.
+    val useEntryGesture = onHoldSwipeUp != null
+
     Box(
         modifier = modifier
             .size(PocketShellDensity.tapTargetMin)
-            .clickable(enabled = enabled, role = Role.Button, onClick = onClick)
+            .then(
+                if (useEntryGesture) {
+                    Modifier
+                        .composerLauncherTapOrHoldSwipeUpGesture(
+                            thresholdPx = swipeThresholdPx,
+                            enabled = { enabled },
+                            onTap = { currentOnClick() },
+                            onHoldSwipeUp = { currentOnHoldSwipeUp?.invoke() },
+                        )
+                        // Keep the control accessible: TalkBack "double-tap to
+                        // activate" and test `performClick()` route through this
+                        // OnClick action (open-only), which the pointer handler's
+                        // consume-the-down otherwise hides from `clickable`.
+                        .semantics(mergeDescendants = true) {
+                            role = Role.Button
+                            onClick(label = SESSION_COMPOSER_LAUNCHER_CONTENT_DESCRIPTION) {
+                                if (enabled) {
+                                    onClick()
+                                    true
+                                } else {
+                                    false
+                                }
+                            }
+                        }
+                } else {
+                    Modifier.clickable(enabled = enabled, role = Role.Button, onClick = onClick)
+                },
+            )
             .semantics { contentDescription = SESSION_COMPOSER_LAUNCHER_CONTENT_DESCRIPTION }
             .testTag(SESSION_COMPOSER_LAUNCHER_TAG),
         contentAlignment = Alignment.Center,
@@ -789,6 +862,77 @@ private fun ComposerLauncherButton(
                 tint = glyphColor,
                 modifier = Modifier.size(PocketShellDensity.treeIndent),
             )
+        }
+    }
+}
+
+/**
+ * Issue #585: the upward-swipe distance (from the launcher press-down point) that
+ * commits the "open the composer WITH recording" entry gesture. Deliberately well
+ * ABOVE the ~viewConfiguration touch-slop a plain tap can wander, so a normal tap
+ * (or a hold-without-swipe) never accidentally opens with recording — it stays an
+ * open-only tap. Small enough that a deliberate hold-and-pull-up commits promptly.
+ */
+internal const val LAUNCHER_HOLD_SWIPE_UP_THRESHOLD_DP: Int = 40
+
+/**
+ * Issue #585: true when a pointer drag from the launcher's press-down point is a
+ * deliberate UPWARD swipe past [thresholdPx] — i.e. it has travelled at least
+ * [thresholdPx] up (negative Y) and is more vertical than horizontal, so a
+ * sideways scroll on the bottom control row is never misread as the entry
+ * gesture. Pure so it is unit-testable without a pointer harness.
+ */
+internal fun launcherSwipeCrossedUpThreshold(
+    dragX: Float,
+    dragY: Float,
+    thresholdPx: Float,
+): Boolean = dragY <= -thresholdPx && abs(dragY) >= abs(dragX)
+
+/**
+ * Issue #585: the launcher's combined TAP + hold-and-pull-up ENTRY gesture in one
+ * pointer handler. It OWNS the pointer from the down (consumes the down + every
+ * move) in the Initial pass so it beats the tap detector AND any ancestor drag,
+ * and — critically — so the drag keeps being delivered after the pointer leaves
+ * the small 44dp launcher (a non-owning Initial-pass detector silently lost the
+ * pull on device). An upward drag past [thresholdPx] fires [onHoldSwipeUp] once
+ * (open the composer WITH recording). A release WITHOUT crossing the threshold —
+ * a plain tap OR a hold-without-swipe — fires [onTap] (open-only, #585: the safe,
+ * least-surprising hold-without-swipe behaviour). Accessibility "activate" is
+ * served by the sibling `semantics { onClick }` on the launcher, not this handler.
+ */
+internal fun Modifier.composerLauncherTapOrHoldSwipeUpGesture(
+    thresholdPx: Float,
+    enabled: () -> Boolean,
+    onTap: () -> Unit,
+    onHoldSwipeUp: () -> Unit,
+): Modifier = pointerInput(thresholdPx) {
+    awaitEachGesture {
+        val down = awaitFirstDown(
+            requireUnconsumed = false,
+            pass = PointerEventPass.Initial,
+        )
+        if (!enabled()) return@awaitEachGesture
+        down.consume()
+        var swipeFired = false
+        while (true) {
+            val event = awaitPointerEvent(PointerEventPass.Initial)
+            val change = event.changes.firstOrNull { it.id == down.id } ?: break
+            val drag = change.position - down.position
+            if (!swipeFired && launcherSwipeCrossedUpThreshold(drag.x, drag.y, thresholdPx)) {
+                swipeFired = true
+                onHoldSwipeUp()
+            }
+            if (change.positionChanged()) {
+                change.consume()
+            }
+            if (change.changedToUpIgnoreConsumed()) {
+                // Release without an upward pull past the threshold = a plain tap
+                // (or a hold-without-swipe) → open the composer only.
+                if (!swipeFired) {
+                    onTap()
+                }
+                break
+            }
         }
     }
 }

--- a/app/src/test/java/com/pocketshell/app/voice/ComposerLauncherHoldSwipeUpGestureTest.kt
+++ b/app/src/test/java/com/pocketshell/app/voice/ComposerLauncherHoldSwipeUpGestureTest.kt
@@ -1,0 +1,70 @@
+package com.pocketshell.app.voice
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #585 (REOPENED — launcher ENTRY gesture): unit coverage for the pure
+ * decision that commits the launcher's hold-and-pull-up "open the composer WITH
+ * recording" gesture, [launcherSwipeCrossedUpThreshold]. This is the logic that
+ * separates a deliberate upward pull (→ open-with-recording) from a plain tap /
+ * small wiggle (→ open-only) and from a sideways scroll on the bottom control
+ * row (→ never the entry gesture). The full on-device gesture journey lives in
+ * the androidTest [ComposerLauncherHoldSwipeUpJourneyTest]; this pins the
+ * decision boundary fast in the JVM lane.
+ */
+class ComposerLauncherHoldSwipeUpGestureTest {
+
+    // A representative 40dp threshold in px (density 2.75 ~= Pixel-class mdpi*2.75).
+    private val thresholdPx = 110f
+
+    @Test
+    fun upwardPullPastThresholdCommitsEntryGesture() {
+        // A clear hold-and-pull-up well past the threshold fires.
+        assertTrue(launcherSwipeCrossedUpThreshold(dragX = 0f, dragY = -thresholdPx - 40f, thresholdPx = thresholdPx))
+    }
+
+    @Test
+    fun upwardPullExactlyAtThresholdCommits() {
+        assertTrue(launcherSwipeCrossedUpThreshold(dragX = 0f, dragY = -thresholdPx, thresholdPx = thresholdPx))
+    }
+
+    @Test
+    fun smallUpwardWiggleBelowThresholdDoesNotCommit() {
+        // A tap or a tiny jitter (well under the threshold) must NOT open-with-
+        // recording — it stays a plain open-only tap.
+        assertFalse(launcherSwipeCrossedUpThreshold(dragX = 3f, dragY = -18f, thresholdPx = thresholdPx))
+    }
+
+    @Test
+    fun downwardDragDoesNotCommit() {
+        assertFalse(launcherSwipeCrossedUpThreshold(dragX = 0f, dragY = thresholdPx + 40f, thresholdPx = thresholdPx))
+    }
+
+    @Test
+    fun sidewaysScrollDoesNotCommit() {
+        // A horizontal scroll across the bottom control row (mostly-horizontal
+        // travel) is never the vertical entry gesture, even if it drifts up a bit
+        // past the threshold — guards the #568/#584/#801 bottom key-row controls.
+        assertFalse(
+            launcherSwipeCrossedUpThreshold(
+                dragX = -300f,
+                dragY = -(thresholdPx + 20f),
+                thresholdPx = thresholdPx,
+            ),
+        )
+    }
+
+    @Test
+    fun steeplyDiagonalUpwardPullCommits() {
+        // More vertical than horizontal + past the threshold = a real upward pull.
+        assertTrue(
+            launcherSwipeCrossedUpThreshold(
+                dragX = 40f,
+                dragY = -(thresholdPx + 60f),
+                thresholdPx = thresholdPx,
+            ),
+        )
+    }
+}

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -370,6 +370,17 @@ JOURNEY_CLASSES=(
   # drag detector. This was repeatedly emulator-green but device-broken, so the
   # focused journey is gate-wired per D31/G9; it uses no Docker fixture.
   "com.pocketshell.app.composer.PromptComposerMicSwipeLockJourneyTest"
+  # ADDED (#585 REOPENED — the TRUE desired behavior): the ENTRY gesture on the
+  # composer LAUNCHER button, not the mic inside the already-open sheet. Hold the
+  # launcher (SESSION_COMPOSER_LAUNCHER_TAG) + swipe UP → the Prompt Composer opens
+  # AND recording begins immediately, locked hands-free, in one gesture; a plain
+  # tap still opens the composer with NO recording. Drives the real
+  # ConversationComposerLauncherRow launcher + real PromptComposerSheet
+  # (autoStartRecording) inside its ModalBottomSheet so the launcher gesture
+  # competes with the same ancestor arbitration it does on device. RED on base (a
+  # launcher hold+swipe opens with NO recording); GREEN with the fix. This is the
+  # 7th reopen of #585 — gate-wired per D31/G9. No Docker fixture (fakes only).
+  "com.pocketshell.app.voice.ComposerLauncherHoldSwipeUpJourneyTest"
   # ADDED (#832 — durable per-session composer draft store): a draft authored in
   # session A and lost on a FAILED attachment-send (despite the "Your draft was
   # kept" banner) must survive. The ComposerDraftStore persists the per-session


### PR DESCRIPTION
Closes #585 (maintainer reopen — built the WRONG control every prior time; this is the LAUNCHER entry gesture, not the mic-lock). Hold the composer launcher + swipe up → composer opens AND recording starts immediately, locked hands-free. Plain tap = open-only (no regression).

Reviewer drove the on-device gesture journey red→green (neutralize `onMicTap()`/`lockRecording()` → the swipe test times out at `recording==Recording && recordingLocked`; restore → 2/2 pass), confirmed plain-tap no-regression, gesture-conflict handling (40dp threshold, consume-the-down), and gate-wiring. **Stays `needs-human-confirmation`**: the fake-mic journey proves gesture→open→recording-live+locked mechanics; the final swipe→speak→transcribe→feels-right is the maintainer's dogfood. Disjoint from sibling #750 (loading region). Orchestrator gate green.