### PR TITLE
sessions: cold-restore stale-session prompt (recreate + go-home) delivered app-wide (#1155)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/ColdRestoreGoneSessionNoResurrectE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/ColdRestoreGoneSessionNoResurrectE2eTest.kt
@@ -16,7 +16,10 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.pocketshell.app.MainActivity
 import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
 import com.pocketshell.app.hosts.SshKeyStorage
+import com.pocketshell.app.projects.FOLDER_LIST_LOADING_TAG
+import com.pocketshell.app.projects.STALE_SESSION_DIALOG_TAG
 import com.pocketshell.app.testaccess.TestAccessEntryPoint
+import com.pocketshell.app.tmux.StaleSession
 import com.pocketshell.app.tmux.TMUX_SESSION_SCREEN_TAG
 import com.pocketshell.core.ssh.KnownHostsPolicy
 import com.pocketshell.core.ssh.SshConnection
@@ -24,7 +27,11 @@ import com.pocketshell.core.ssh.SshKey
 import com.pocketshell.core.storage.AppDatabase
 import com.pocketshell.core.storage.entity.HostEntity
 import dagger.hilt.android.EntryPointAccessors
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -315,6 +322,222 @@ class ColdRestoreGoneSessionNoResurrectE2eTest {
             "the deleted session's screen (Conversation/Terminal) must NOT be " +
                 "showing on resume after a delete",
             !sessionScreenStillUp,
+        )
+        Unit
+    } }
+
+    /**
+     * Issue #1155 (Part B) on-device emitter proof. When the persisted last
+     * session is confirmed GENUINELY GONE on the real cold-restore attach path
+     * (the exact journey the #666 test drives: attach → background → kill
+     * externally → recreate/cold-restore), the app must broadcast a
+     * [StaleSession] on the production singleton [SessionLifecycleSignals] so the
+     * folder tree can raise the "create a new session in this folder?" recovery
+     * prompt instead of leaving the user on a blank list. This is the
+     * genuinely-gone branch only — a transient reconnect never reaches this path
+     * (covered red/green in the JVM `TmuxSessionWarmOpenTest`). Same Docker
+     * `agents` fixture + same lifecycle path as the sibling tests, so the signal
+     * is proven on the real gone-session journey, not a proxy.
+     */
+    @Test
+    fun coldRestoreToGoneSessionBroadcastsStaleSignalForRecreatePrompt() { runBlocking {
+        val key = fixtureKey
+
+        // Subscribe to the production stale-session signal BEFORE the restore so
+        // the no-replay broadcast at attach-fail time is observed.
+        val ctx = InstrumentationRegistry.getInstrumentation().targetContext
+        val entryPoint = EntryPointAccessors
+            .fromApplication(ctx, TestAccessEntryPoint::class.java)
+        val staleEvents = java.util.Collections.synchronizedList(mutableListOf<StaleSession>())
+        val collectorScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        collectorScope.launch {
+            entryPoint.sessionLifecycleSignals().staleSessions.collect { staleEvents.add(it) }
+        }
+        delay(LIFECYCLE_DRAIN_MS)
+
+        // ---- Attach to the seeded session via the normal journey.
+        waitForHostRowPresent(hostRowTag)
+        compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick()
+        waitForText(SEEDED_SESSION, timeoutMs = 20_000)
+        compose.onNodeWithText(SEEDED_SESSION).performClick()
+        compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertExists()
+
+        // ---- Background -> persist last session, then kill it on the server.
+        compose.activityRule.scenario.moveToState(Lifecycle.State.CREATED)
+        delay(LIFECYCLE_DRAIN_MS)
+        killRemoteSession(key)
+        assertTrue("session must be gone on the server after kill", !sessionAlive(key))
+
+        // ---- Cold-restore into the gone session.
+        compose.activityRule.scenario.recreate()
+        compose.activityRule.scenario.moveToState(Lifecycle.State.RESUMED)
+
+        // The genuinely-gone attach must broadcast a StaleSession naming the gone
+        // session, so the folder tree can offer the recreate prompt.
+        compose.waitUntil(timeoutMillis = RESTORE_TIMEOUT_MS) {
+            staleEvents.any { it.sessionName == SEEDED_SESSION }
+        }
+        val fired = synchronized(staleEvents) { staleEvents.toList() }
+        writeText(
+            "stale-session-signal.txt",
+            buildString {
+                appendLine("expected_stale_session=$SEEDED_SESSION")
+                appendLine("stale_events=${fired.map { it.sessionName }}")
+                appendLine("stale_folders=${fired.map { it.folderPath }}")
+            },
+        )
+        collectorScope.coroutineContext[kotlinx.coroutines.Job]?.cancel()
+        assertTrue(
+            "a genuinely-gone cold-restore must broadcast a StaleSession for the " +
+                "folder tree's recreate prompt; saw ${fired.map { it.sessionName }}",
+            fired.any { it.sessionName == SEEDED_SESSION },
+        )
+        Unit
+    } }
+
+    /**
+     * Issue #1155 (Part B) blocker 3 — the maintainer's PRIMARY gesture. A NORMAL
+     * TAP of a persisted session row whose tmux session was killed externally must
+     * reach the "This session no longer exists — create a new session in this
+     * folder?" recreate DIALOG, NOT silently recreate a fresh shell via
+     * `new-session -A` (the reported "it was there but as a shell, not the agent").
+     *
+     * Journey on the deterministic Docker `agents` fixture:
+     *  1. host row -> folder list (the seeded session row is shown).
+     *  2. Kill that tmux session server-side (external removal — the RARE case the
+     *     persistent tree can't know about).
+     *  3. TAP the still-shown (advisory-cached) session row -> the OpenExisting
+     *     connect preflights `tmux has-session`, sees it gone, drops back to the
+     *     folder tree AND broadcasts the stale-session signal.
+     *  4. The folder tree (bound on the backstack) raises the recreate dialog.
+     *
+     * Acceptance: the `STALE_SESSION_DIALOG_TAG` recreate dialog is shown after the
+     * tap, and the session was NOT resurrected server-side.
+     */
+    @Test
+    fun openExistingTapOfGoneSessionShowsRecreateDialog() { runBlocking {
+        val key = fixtureKey
+
+        // ---- (1) host -> folder list; the seeded session row is present.
+        waitForHostRowPresent(hostRowTag)
+        compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick()
+        waitForText(SEEDED_SESSION, timeoutMs = 20_000)
+
+        // ---- (2) Kill the session server-side (external removal).
+        killRemoteSession(key)
+        assertTrue("session must be gone server-side after kill", !sessionAlive(key))
+
+        // ---- (3) TAP the still-shown persisted row -> OpenExisting -> preflight
+        // confirms gone -> drop back + stale-session broadcast.
+        compose.onNodeWithText(SEEDED_SESSION).performClick()
+
+        // ---- (4) The folder tree raises the recreate dialog.
+        compose.waitUntil(timeoutMillis = RESTORE_TIMEOUT_MS) {
+            runCatching {
+                compose.onAllNodesWithTag(STALE_SESSION_DIALOG_TAG, useUnmergedTree = true)
+                    .fetchSemanticsNodes()
+                    .isNotEmpty()
+            }.getOrDefault(false)
+        }
+        val dialogShown = compose
+            .onAllNodesWithTag(STALE_SESSION_DIALOG_TAG, useUnmergedTree = true)
+            .fetchSemanticsNodes()
+            .isNotEmpty()
+        val resurrected = sessionAlive(key)
+        writeText(
+            "open-existing-tap-recreate-dialog.txt",
+            buildString {
+                appendLine("tapped_session=$SEEDED_SESSION")
+                appendLine("recreate_dialog_shown=$dialogShown")
+                appendLine("session_resurrected_server_side=$resurrected")
+                appendLine("expected_recreate_dialog_shown=true")
+                appendLine("expected_session_resurrected=false")
+            },
+        )
+        assertTrue(
+            "REGRESSION (#1155 blocker 3): tapping a gone persisted session must " +
+                "show the recreate dialog, not silently recreate a shell",
+            dialogShown,
+        )
+        assertTrue(
+            "tapping a gone session must NOT resurrect it server-side (no silent " +
+                "`new-session -A`)",
+            !resurrected,
+        )
+        Unit
+    } }
+
+    /**
+     * Issue #1155 (Part A) blocker 4 — the cold deep-link-back INSTANT render. The
+     * maintainer's recurring #867/#1109 symptom is the "Loading workspace tree"
+     * flash when returning to the folder tree. With the process-start warm
+     * ([com.pocketshell.app.App.onCreate] → `TreeClientCache.warmAll`), a cold
+     * process that deep-links back into the tree must paint the persisted tree
+     * (the seeded session row) with NO Loading panel.
+     *
+     * Journey:
+     *  1. host -> folder list (the tree reconciles + persists to the client cache).
+     *  2. Deep-link into the session, then `recreate()` the activity (COLD process:
+     *     App.onCreate re-warms the client cache from disk).
+     *  3. Back out to the folder tree.
+     *
+     * Acceptance: the persisted session row is shown and the `FOLDER_LIST_LOADING_TAG`
+     * Loading panel is NOT present when it appears (no rebuild flash). The reviewer
+     * additionally confirms the no-flash visually on the emulator.
+     */
+    @Test
+    fun coldDeepLinkBackToFolderTreeRendersPersistedTreeNoLoadingFlash() { runBlocking {
+        // ---- (1) host -> folder list; let the tree settle + persist to the cache.
+        waitForHostRowPresent(hostRowTag)
+        compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick()
+        waitForText(SEEDED_SESSION, timeoutMs = 20_000)
+        delay(LIFECYCLE_DRAIN_MS)
+
+        // ---- (2) Deep-link into the session, then COLD-recreate the process.
+        compose.onNodeWithText(SEEDED_SESSION).performClick()
+        compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertExists()
+        compose.activityRule.scenario.moveToState(Lifecycle.State.CREATED)
+        delay(LIFECYCLE_DRAIN_MS)
+        compose.activityRule.scenario.recreate()
+        compose.activityRule.scenario.moveToState(Lifecycle.State.RESUMED)
+
+        // ---- (3) Back out to the folder tree (the cold-restored session screen or
+        // wherever the restore landed) and assert the persisted tree paints.
+        compose.waitUntil(timeoutMillis = RESTORE_TIMEOUT_MS) {
+            runCatching {
+                compose.onAllNodesWithText(SEEDED_SESSION, useUnmergedTree = true)
+                    .fetchSemanticsNodes()
+                    .isNotEmpty()
+            }.getOrDefault(false)
+        }
+        // When the persisted row is present, the full-screen Loading panel must NOT
+        // be — i.e. the tree rendered from the warmed cache, not a rebuild flash.
+        val loadingShown = compose
+            .onAllNodesWithTag(FOLDER_LIST_LOADING_TAG, useUnmergedTree = true)
+            .fetchSemanticsNodes()
+            .isNotEmpty()
+        val rowShown = compose
+            .onAllNodesWithText(SEEDED_SESSION, useUnmergedTree = true)
+            .fetchSemanticsNodes()
+            .isNotEmpty()
+        writeText(
+            "cold-deep-link-back-instant-render.txt",
+            buildString {
+                appendLine("persisted_row_shown=$rowShown")
+                appendLine("loading_panel_shown_with_row=$loadingShown")
+                appendLine("expected_persisted_row_shown=true")
+                appendLine("expected_loading_panel_shown_with_row=false")
+            },
+        )
+        assertTrue(
+            "the cold deep-link-back must paint the persisted session row from the " +
+                "warmed client cache",
+            rowShown,
+        )
+        assertTrue(
+            "REGRESSION (#1155 Part A): the folder tree showed the full-screen " +
+                "Loading panel alongside the persisted row (rebuild flash)",
+            !loadingShown,
         )
         Unit
     } }

--- a/app/src/main/java/com/pocketshell/app/App.kt
+++ b/app/src/main/java/com/pocketshell/app/App.kt
@@ -106,6 +106,19 @@ class App : Application() {
     lateinit var settingsRepository: SettingsRepository
 
     /**
+     * Issue #1155 (Part A): the per-host persisted folder-tree cache. Warmed into
+     * its in-memory PARSED snapshot at process startup (off Main) so the FIRST
+     * host the user opens after a cold launch — including the maintainer's common
+     * deep-link-to-a-session-then-back-to-the-tree path, where a per-VM warm would
+     * lose the race with `bind` — paints the persisted tree INSTANTLY via
+     * [com.pocketshell.app.projects.TreeClientCache.peek] instead of flashing the
+     * "Loading workspace tree" spinner. This runs many frames ahead of any
+     * navigation, so the parse normally completes well before the first `bind`.
+     */
+    @Inject
+    lateinit var treeClientCache: com.pocketshell.app.projects.TreeClientCache
+
+    /**
      * Issue #698: fires the GitHub-Releases update check on process
      * foreground resume (and host-open, from MainActivity), throttled, so
      * the maintainer — who deep-links straight into a host and almost
@@ -346,6 +359,19 @@ class App : Application() {
         DiagnosticEvents.record("app", "created")
         CrashReporter.install(this)
         StartupTiming.mark("app-crash-reporter-installed")
+
+        // Issue #1155 (Part A): warm the persisted folder-tree cache into memory
+        // OFF Main at process startup, so the FIRST host opened after a cold launch
+        // paints the persisted tree instantly (no "Loading workspace tree" spinner
+        // flash) rather than losing the warm-vs-`bind` race a per-VM warm hits on
+        // the maintainer's deep-link-then-back-to-the-tree path. Best-effort; a
+        // missing/corrupt cache just stays a cold miss (the brief Loading + off-Main
+        // read, exactly as before). Off Main so StrictMode's disk-read tripwire and
+        // the #965 ANR budget are untouched.
+        sshLifecycleScope.launch {
+            runCatching { treeClientCache.warmAll() }
+        }
+        StartupTiming.mark("tree-cache-warmed")
         // No-background-work hook-up (issue #161 / D21). Attach the
         // ProcessLifecycleOwner observer before starting the loop so
         // the loop's `processStarted.first { it }` gate sees the

--- a/app/src/main/java/com/pocketshell/app/MainActivity.kt
+++ b/app/src/main/java/com/pocketshell/app/MainActivity.kt
@@ -1200,6 +1200,10 @@ private fun AppNavigator(
                         startDirectory = startDirectory,
                         tmuxSessionId = tmuxSessionId,
                         sessionCreated = sessionCreated,
+                        // Issue #1155 (Part B): a tap of a PERSISTED session row →
+                        // OpenExisting so a genuine cold open preflights and, when
+                        // gone, shows the recreate prompt (not a silent shell).
+                        openExisting = true,
                     ),
                 )
             },
@@ -1218,6 +1222,9 @@ private fun AppNavigator(
                         initialWindowIndex = windowIndex,
                         tmuxSessionId = tmuxSessionId,
                         sessionCreated = sessionCreated,
+                        // Issue #1155 (Part B): opening a window of a persisted
+                        // session is also an OpenExisting tap.
+                        openExisting = true,
                     ),
                 )
             },
@@ -1665,10 +1672,14 @@ private fun AppNavigator(
                     typedPrefix = prefix,
                 )
             },
-            connectTrigger = if (dest == restoredTmuxDestination) {
-                TmuxConnectTrigger.ColdRestore
-            } else {
-                TmuxConnectTrigger.UserTap
+            connectTrigger = when {
+                dest == restoredTmuxDestination -> TmuxConnectTrigger.ColdRestore
+                // Issue #1155 (Part B): a NORMAL tap of a persisted session row
+                // preflights `tmux has-session` and, when the session is confirmed
+                // gone, shows the "create a new session in this folder?" prompt
+                // instead of silently recreating a fresh shell via `new-session -A`.
+                dest.openExisting -> TmuxConnectTrigger.OpenExisting
+                else -> TmuxConnectTrigger.UserTap
             },
         )
     }

--- a/app/src/main/java/com/pocketshell/app/nav/AppDestination.kt
+++ b/app/src/main/java/com/pocketshell/app/nav/AppDestination.kt
@@ -167,6 +167,13 @@ sealed interface AppDestination {
         val initialWindowIndex: Int? = null,
         val tmuxSessionId: String? = null,
         val sessionCreated: Long? = null,
+        // Issue #1155 (Part B): true when this destination came from a NORMAL tap
+        // of a PERSISTED session row in the folder tree (vs a create-new-session
+        // navigate, which leaves this false). Drives the [OpenExisting] connect
+        // trigger so a genuine cold open preflights `tmux has-session` and, when
+        // the session is confirmed gone, shows the "create a new session in this
+        // folder?" recreate prompt instead of silently recreating a fresh shell.
+        val openExisting: Boolean = false,
     ) : AppDestination
 
     /**

--- a/app/src/main/java/com/pocketshell/app/projects/FolderListScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListScreen.kt
@@ -236,6 +236,10 @@ fun FolderListScreen(
     }
     val state by viewModel.state.collectAsState()
     val actionStatus by viewModel.actionStatus.collectAsState()
+    // Issue #1155 (Part B): a persisted session the user tried to open was
+    // confirmed genuinely gone on attach — surface the "create a new session in
+    // this folder?" recovery prompt (not a blank list).
+    val staleSessionPrompt by viewModel.staleSessionPrompt.collectAsState()
     // Issue #885: passive host-CLI-version mismatch, detected from the regular
     // `pocketshell tree` payload on every host open — surfaced as a dismissible
     // update prompt (NOT a slow blocking on-open `--version` wait).
@@ -615,6 +619,23 @@ fun FolderListScreen(
             onConfirm = { newName ->
                 renameSessionTarget = null
                 viewModel.renameSession(sessionName, newName)
+            },
+        )
+    }
+
+    // Issue #1155 (Part B): a persisted session the user opened was confirmed
+    // genuinely gone on attach — offer to recreate it in the SAME folder in one
+    // tap instead of leaving the user on a blank list.
+    staleSessionPrompt?.let { prompt ->
+        StaleSessionRecreateDialog(
+            prompt = prompt,
+            onDismiss = { viewModel.dismissStaleSessionPrompt() },
+            onConfirm = {
+                viewModel.confirmRecreateStaleSession(
+                    onResolved = { resolved ->
+                        onSessionCreated(resolved, prompt.folderPath ?: "~")
+                    },
+                )
             },
         )
     }
@@ -2966,6 +2987,34 @@ private fun StopSessionDialog(
     )
 }
 
+/**
+ * Issue #1155 (Part B): the "this session no longer exists — create a new
+ * session in this folder?" recovery dialog. Shown when a persisted session the
+ * user opened was confirmed genuinely gone on attach. Confirming recreates a
+ * session in the SAME folder ([FolderListViewModel.confirmRecreateStaleSession]);
+ * dismissing leaves the (accurate) tree list in place. NOT destructive — it is a
+ * one-tap recovery, so the confirm is the primary action.
+ */
+@Composable
+private fun StaleSessionRecreateDialog(
+    prompt: StaleSessionRecreatePrompt,
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit,
+) {
+    ConfirmDialog(
+        title = "This session no longer exists",
+        message = "The session “${prompt.sessionName}” is gone on the host. " +
+            "Create a new session in “${prompt.folderLabel}”?",
+        confirmLabel = "Create session",
+        onConfirm = onConfirm,
+        onDismiss = onDismiss,
+        destructive = false,
+        modifier = Modifier.testTag(STALE_SESSION_DIALOG_TAG),
+        confirmTestTag = STALE_SESSION_CONFIRM_TAG,
+        dismissTestTag = STALE_SESSION_CANCEL_TAG,
+    )
+}
+
 private val FolderListBottomContentPadding = 12.dp
 
 // Test tags exposed for the unit / connected E2E suite.
@@ -3030,6 +3079,12 @@ const val RENAME_SESSION_DIALOG_TAG: String = "folder-list:rename-session:dialog
 const val RENAME_SESSION_FIELD_TAG: String = "folder-list:rename-session:field"
 const val RENAME_SESSION_CONFIRM_TAG: String = "folder-list:rename-session:confirm"
 const val RENAME_SESSION_CANCEL_TAG: String = "folder-list:rename-session:cancel"
+
+// Issue #1155 (Part B) — "this session no longer exists, create a new one in
+// this folder?" recovery prompt.
+const val STALE_SESSION_DIALOG_TAG: String = "folder-list:stale-session:dialog"
+const val STALE_SESSION_CONFIRM_TAG: String = "folder-list:stale-session:confirm"
+const val STALE_SESSION_CANCEL_TAG: String = "folder-list:stale-session:cancel"
 
 fun folderRowTestTag(path: String): String = "folder-list:row:$path"
 fun folderHeaderClickTestTag(path: String): String = "folder-list:header-click:$path"

--- a/app/src/main/java/com/pocketshell/app/projects/FolderListViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListViewModel.kt
@@ -227,6 +227,26 @@ sealed interface FolderListUiState {
 }
 
 /**
+ * Issue #1155 (Part B): a live "This session no longer exists — create a new
+ * session in this folder?" recovery prompt, raised when a persisted session the
+ * user tried to open was confirmed GENUINELY GONE on attach (absent tmux
+ * session, not a transient reconnect). Confirming reuses the SAME folder's
+ * create-session path so the user recovers in one tap; dismissing clears it.
+ *
+ * @property sessionName the gone session's name (also its `tmux new-session -A`
+ *   name for the same folder, so recreating with it reproduces the same slot).
+ * @property folderPath the gone session's working directory — the folder the
+ *   recreate happens in. `null` when the gone session carried no known start
+ *   directory (the recreate then falls back to the host home directory).
+ * @property folderLabel a short human label for the folder, for the prompt copy.
+ */
+data class StaleSessionRecreatePrompt(
+    val sessionName: String,
+    val folderPath: String?,
+    val folderLabel: String,
+)
+
+/**
  * Host-detail action feedback surface (#656).
  *
  * For a routine **success** there is deliberately no final status state at all
@@ -514,6 +534,20 @@ class FolderListViewModel internal constructor(
     private val _actionStatus: MutableStateFlow<FolderActionStatus> =
         MutableStateFlow(FolderActionStatus.Idle)
     val actionStatus: StateFlow<FolderActionStatus> = _actionStatus.asStateFlow()
+
+    /**
+     * Issue #1155 (Part B): non-null when a persisted session the user tried to
+     * open was confirmed GENUINELY GONE on attach (an absent tmux session, not a
+     * transient reconnect blip — see [SessionLifecycleSignals.emitStaleSession]).
+     * The FolderList surfaces it as a "This session no longer exists — create a
+     * new session in this folder?" prompt; confirming reuses the SAME folder's
+     * create-session path ([confirmRecreateStaleSession]), dismissing clears it
+     * ([dismissStaleSessionPrompt]). `null` while there is nothing to recover.
+     */
+    private val _staleSessionPrompt: MutableStateFlow<StaleSessionRecreatePrompt?> =
+        MutableStateFlow(null)
+    val staleSessionPrompt: StateFlow<StaleSessionRecreatePrompt?> =
+        _staleSessionPrompt.asStateFlow()
 
     /**
      * Issue #885: passive host-CLI-version mismatch, detected from the
@@ -969,6 +1003,17 @@ class FolderListViewModel internal constructor(
                     onWindowClosed(closed)
                 }
             }
+            // Issue #1155 (Part B): a persisted session the user tried to open was
+            // confirmed GENUINELY GONE on attach (absent tmux session, not a
+            // transient reconnect). Raise the "create a new session in this folder?"
+            // recreate prompt so the user recovers in one tap instead of landing on
+            // a blank list. Filtered by bound host so a gone session on host A never
+            // prompts on host B's tree.
+            viewModelScope.launch {
+                signals.staleSessions.collect { stale ->
+                    onStaleSession(stale)
+                }
+            }
         }
         // EPIC #679 requirement #2: reconcile INFREQUENTLY, not on a constant
         // poll. The tree is held across opens, so a foreground/resume only
@@ -980,18 +1025,19 @@ class FolderListViewModel internal constructor(
                 if (started) maybeReconcileOnResume()
             }
         }
-        // Issue #1109: pre-warm the per-host PARSED client-cache snapshots into
-        // memory OFF Main, so by the time the user navigates in and [bind] runs its
-        // SYNCHRONOUS seed, [TreeClientCache.peek] hits without a Main-thread file
-        // read + JSON parse (the #965 ANR cause). This runs at VM construction — one
-        // composition + LaunchedEffect ahead of `bind` — so the warm normally wins
-        // the race and the cold connect paints instantly; if it loses, `bind` falls
-        // back to the brief Loading + the off-Main read (never a Main-thread read).
-        treeClientCache?.let { cache ->
-            viewModelScope.launch(ioDispatcher) {
-                runCatching { cache.warmAll() }
-            }
-        }
+        // Issue #1155 (Part A): the client-cache PARSED snapshots are warmed into
+        // memory ONCE at process startup by [com.pocketshell.app.App.onCreate]
+        // (`TreeClientCache.warmAll`, off Main, MANY frames ahead of any
+        // navigation) — the SINGLE warm path. The old per-VM warm launched here at
+        // construction lost the race with `bind` on the maintainer's
+        // deep-link-into-a-session-then-back path (VM built + bound in the same
+        // instant), which is exactly the recurring #867/#1109 Loading flash. It was
+        // ALSO the flaky-test culprit: launched on the default `Dispatchers.IO`
+        // (captured before a test can rebind `ioDispatcher`), it raced the
+        // synchronous `bind` peek on a real background thread. Removed here (D22
+        // hard-cut — one warm path): the startup warm makes `peek` hit for every
+        // persisted host, and a genuine cold MISS still falls back to the brief
+        // Loading + the OFF-Main read in [bind] (never a Main-thread read).
         if (attachLifecycle) attachProcessLifecycle()
     }
 
@@ -1048,6 +1094,58 @@ class FolderListViewModel internal constructor(
             emitReady()
         }
         if (probeJob != null) refresh()
+    }
+
+    /**
+     * Issue #1155 (Part B): handle a persisted-but-GENUINELY-GONE session
+     * broadcast from the per-session screen ([SessionLifecycleSignals.staleSessions]).
+     * The attach confirmed the tmux session is absent (`TmuxSessionNotFoundException`)
+     * — NOT a transient reconnect (those never emit this) — so instead of leaving
+     * the user on a blank list we raise the "create a new session in this folder?"
+     * recreate prompt for the SAME folder. Also drops the dead row from the held
+     * tree (it is confirmed gone), matching [onSessionKilled]. Ignores other hosts.
+     */
+    @androidx.annotation.VisibleForTesting
+    internal fun onStaleSession(stale: com.pocketshell.app.tmux.StaleSession) {
+        val params = bound ?: return
+        if (params.hostId != stale.hostId) return
+        // The session is confirmed gone — drop its row from the maintained tree so
+        // the list the prompt sits over is already accurate.
+        if (tree.removeSession(stale.sessionName)) {
+            emitReady()
+        }
+        _staleSessionPrompt.value = StaleSessionRecreatePrompt(
+            sessionName = stale.sessionName,
+            folderPath = stale.folderPath,
+            folderLabel = stale.folderPath
+                ?.let { defaultLabelForPath(canonicalisePath(it)) }
+                ?: "home",
+        )
+    }
+
+    /**
+     * Issue #1155 (Part B): confirm the recreate prompt — create a fresh session
+     * in the gone session's SAME folder (reusing the standard [createSession]
+     * create-in-folder path, `tmux new-session -A` semantics) and route to it via
+     * [onResolved]. A no-op when there is no active prompt. The gone session's name
+     * is reused (it maps to that folder), and a null folder falls back to the host
+     * home directory (`~`), so the user always recovers — never a blank/error.
+     */
+    fun confirmRecreateStaleSession(onResolved: (sessionName: String) -> Unit) {
+        val prompt = _staleSessionPrompt.value ?: return
+        _staleSessionPrompt.value = null
+        createSession(
+            sessionName = prompt.sessionName,
+            cwd = prompt.folderPath ?: "~",
+            startCommand = null,
+            chosenKind = null,
+            onResolved = onResolved,
+        )
+    }
+
+    /** Issue #1155 (Part B): dismiss the stale-session recreate prompt. */
+    fun dismissStaleSessionPrompt() {
+        _staleSessionPrompt.value = null
     }
 
     /**

--- a/app/src/main/java/com/pocketshell/app/tmux/SessionLifecycleSignals.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/SessionLifecycleSignals.kt
@@ -51,6 +51,30 @@ data class ClosedWindow(
 )
 
 /**
+ * Issue #1155 (Part B): a persisted session the user tried to open turned out
+ * to be GENUINELY GONE on the host — the attach failed because the tmux session
+ * is absent ([com.pocketshell.core.tmux.TmuxSessionNotFoundException]), NOT a
+ * transient reconnect blip (those go through the reconnect ladder and never
+ * emit this). The maintainer's persistent tree is usually accurate (sessions
+ * are created/removed through the app), so this is the RARE case (external
+ * removal / a sync we skipped). Rather than dropping to a blank list the folder
+ * tree offers "This session no longer exists — create a new session in this
+ * folder?" so the user recovers in one tap.
+ *
+ * @property hostId the host the gone session belonged to (the tree filters on it).
+ * @property sessionName the tmux session name that was confirmed absent.
+ * @property folderPath the session's working directory (its folder) so the
+ *   recreate reuses the SAME folder's create-session path. `null` when the gone
+ *   session carried no known start directory (the prompt then falls back to the
+ *   home directory create path, never a blank/error).
+ */
+data class StaleSession(
+    val hostId: Long,
+    val sessionName: String,
+    val folderPath: String?,
+)
+
+/**
  * Process-scoped fan-out of tmux-session lifecycle signals — issue #464.
  *
  * Today it carries exactly one event: a confirmed session kill. The kill
@@ -95,6 +119,27 @@ class SessionLifecycleSignals @Inject constructor(
      */
     val closedWindows: SharedFlow<ClosedWindow> = _closedWindows.asSharedFlow()
 
+    // Issue #1155 (Part B): a persisted session confirmed GENUINELY GONE on
+    // attach (absent tmux session, not a transient reconnect). No replay — the
+    // same safe convention as [killedSessions]: the folder tree is ALIVE and
+    // bound to the host while the user is in the session screen (its `bound` +
+    // collector survive `stopPolling`), so it catches the emit at attach-fail
+    // time and shows the prompt on the `back()` that follows. A no-replay buffer
+    // avoids a stale recreate prompt resurrecting on a much later same-host
+    // re-bind.
+    private val _staleSessions = MutableSharedFlow<StaleSession>(
+        replay = 0,
+        extraBufferCapacity = 4,
+    )
+
+    /**
+     * Issue #1155 (Part B): hot stream of persisted-but-genuinely-gone sessions.
+     * The folder tree ([com.pocketshell.app.projects.FolderListViewModel]) filters
+     * on the bound host and raises the "create a new session in this folder?"
+     * recreate prompt.
+     */
+    val staleSessions: SharedFlow<StaleSession> = _staleSessions.asSharedFlow()
+
     /** Broadcast a confirmed kill of [sessionName] on [hostId]. */
     fun emitKilled(hostId: Long, sessionName: String) {
         val trimmed = sessionName.trim()
@@ -115,5 +160,29 @@ class SessionLifecycleSignals @Inject constructor(
         val trimmed = windowId.trim()
         if (trimmed.isEmpty()) return
         _closedWindows.tryEmit(ClosedWindow(hostId = hostId, windowId = trimmed))
+    }
+
+    /**
+     * Issue #1155 (Part B): broadcast that the persisted session [sessionName] on
+     * [hostId] was confirmed GENUINELY GONE on attach (an absent tmux session —
+     * `TmuxSessionNotFoundException` — NOT a transient reconnect blip). [folderPath]
+     * is the session's working directory so the tree can offer "create a new session
+     * in this folder?". Also forgets the dead session's per-host memory/runtime like
+     * [emitKilled], since it is confirmed gone.
+     */
+    fun emitStaleSession(hostId: Long, sessionName: String, folderPath: String?) {
+        val trimmed = sessionName.trim()
+        if (trimmed.isEmpty()) return
+        agentSessionMemory?.forgetSession(hostId = hostId, sessionName = trimmed)
+        runtimeCache?.removeSession(hostId = hostId, sessionName = trimmed)?.forEach { runtime ->
+            cleanupScope.launch { runtime.closeCachedRuntime() }
+        }
+        _staleSessions.tryEmit(
+            StaleSession(
+                hostId = hostId,
+                sessionName = trimmed,
+                folderPath = folderPath?.trim()?.takeIf { it.isNotEmpty() },
+            ),
+        )
     }
 }

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -2513,10 +2513,10 @@ public class TmuxSessionViewModel @Inject constructor(
         tmuxSessionId: String? = null,
         sessionCreated: Long? = null,
         trigger: TmuxConnectTrigger = TmuxConnectTrigger.UserTap,
-        // Issue #666: internal guard so the ColdRestore preflight (below) can
+        // Issue #666 / #1155: internal guard so the existence preflight (below) can
         // re-enter [connect] once it has confirmed the session is still alive
         // without preflighting a second time. Never set by external callers.
-        skipColdRestorePreflight: Boolean = false,
+        skipExistencePreflight: Boolean = false,
     ) {
         // Issue #666: a foreground cold-restore must NOT resurrect a session
         // killed elsewhere while the app was backgrounded. Before we attach —
@@ -2524,11 +2524,13 @@ public class TmuxSessionViewModel @Inject constructor(
         // whose `-CC` channel would EOF and trigger an auto-reconnect that
         // recreates the session via `new-session -A` — probe `tmux has-session`
         // over the pooled transport. If the session is gone, drop to the list
-        // instead of attaching anything. We only do this for ColdRestore (the
-        // genuine resume-from-persisted-last-session path); every other trigger
-        // is unchanged.
-        if (trigger == TmuxConnectTrigger.ColdRestore && !skipColdRestorePreflight) {
-            preflightColdRestore(
+        // (and broadcast the stale-session recreate prompt, #1155) instead of
+        // attaching anything. ColdRestore always preflights (the genuine
+        // resume-from-persisted-last-session path); [OpenExisting] preflights too,
+        // but only for a genuine COLD open (handled below, after the warm-path
+        // determination).
+        if (trigger == TmuxConnectTrigger.ColdRestore && !skipExistencePreflight) {
+            preflightSessionExistence(
                 hostId = hostId,
                 hostName = hostName,
                 host = host,
@@ -2540,6 +2542,7 @@ public class TmuxSessionViewModel @Inject constructor(
                 startDirectory = startDirectory,
                 tmuxSessionId = tmuxSessionId,
                 sessionCreated = sessionCreated,
+                originalTrigger = TmuxConnectTrigger.ColdRestore,
             )
             return
         }
@@ -2594,6 +2597,37 @@ public class TmuxSessionViewModel @Inject constructor(
             isSameHost(previousActiveTarget, target) &&
             previousActiveTarget.sessionName != target.sessionName
         val effectiveTrigger = if (willFastSwitch) TmuxConnectTrigger.FastSwitch else trigger
+        // Issue #1155 (Part B): a NORMAL tap of a persisted session row
+        // ([OpenExisting]) that is a genuine COLD open — NOT a fast-switch and with
+        // NO warm cached runtime (either would already prove the session is alive)
+        // — preflights `tmux has-session` before attaching. If the session is
+        // CONFIRMED GONE, [preflightSessionExistence] routes to [failSessionEnded]
+        // → the "create a new session in this folder?" recreate prompt instead of
+        // silently resurrecting a fresh shell via `new-session -A`. A warm/fast open
+        // skips the probe (no added latency to the maintainer's instant switch), and
+        // any AMBIGUOUS probe (no lease / exec error) FAILS OPEN to the normal
+        // attach — so a transient reconnect blip never triggers the prompt.
+        if (trigger == TmuxConnectTrigger.OpenExisting &&
+            !skipExistencePreflight &&
+            !willFastSwitch &&
+            !runtimeCache.contains(target.toRuntimeKey())
+        ) {
+            preflightSessionExistence(
+                hostId = target.hostId,
+                hostName = target.hostName,
+                host = target.host,
+                port = target.port,
+                user = target.user,
+                keyPath = target.keyPath,
+                passphrase = target.passphrase,
+                sessionName = target.sessionName,
+                startDirectory = target.startDirectory,
+                tmuxSessionId = target.tmuxSessionId,
+                sessionCreated = target.sessionCreated,
+                originalTrigger = TmuxConnectTrigger.OpenExisting,
+            )
+            return
+        }
         val generation = nextConnectGeneration()
         latestConnectIntent = ConnectIntent(
             target = target,
@@ -6262,6 +6296,17 @@ public class TmuxSessionViewModel @Inject constructor(
         setConnectionState(
             ConnectionState.Unreachable("Session “${target.sessionName}” has ended."),
         )
+        // Issue #1155 (Part B): this is the GENUINELY-GONE path — the attach failed
+        // with a [TmuxSessionNotFoundException] (an absent tmux session), NOT a
+        // transient reconnect blip (those go through [failConnectAttempt] and the
+        // reconnect ladder, which never reach here). Broadcast the gone session +
+        // its folder so the folder tree offers "create a new session in this
+        // folder?" instead of a blank drop-to-list.
+        sessionLifecycleSignals?.emitStaleSession(
+            hostId = target.hostId,
+            sessionName = target.sessionName,
+            folderPath = target.startDirectory,
+        )
         _sessionEnded.tryEmit(target.sessionName)
     }
 
@@ -6321,30 +6366,34 @@ public class TmuxSessionViewModel @Inject constructor(
     }
 
     /**
-     * Issue #666: cold-restore liveness gate. Runs as the [connectJob] for a
-     * [TmuxConnectTrigger.ColdRestore] connect and probes `tmux has-session`
-     * over the pooled SSH transport BEFORE any attach or warm/cached-runtime
-     * activation.
+     * Issue #666 / #1155: session-existence liveness gate. Runs as the
+     * [connectJob] for a [TmuxConnectTrigger.ColdRestore] resume OR a genuine
+     * COLD [TmuxConnectTrigger.OpenExisting] tree-row tap, and probes `tmux
+     * has-session` over the pooled SSH transport BEFORE any attach or
+     * warm/cached-runtime activation.
      *
      * Why up front, not just in [runConnect]: the resurrection the maintainer
-     * hit happens when the restore activates a STALE warm/cached runtime whose
+     * hit happens when the attach activates a STALE warm/cached runtime whose
      * `-CC` channel then EOFs (the session was killed), which kicks the
      * auto-reconnect path — and that path re-attaches with `new-session -A`,
-     * recreating the session. Probing here, before we touch any cached runtime,
-     * catches the gone session regardless of which attach path would follow.
+     * recreating the session (as a bare shell). Probing here, before we touch
+     * any cached runtime, catches the gone session regardless of which attach
+     * path would follow.
      *
      * - Session GONE (`has-session` exits non-zero): surface "that session
-     *   ended" and drop to the list via [failSessionEnded] — never attach,
-     *   never recreate.
+     *   ended" and drop to the list via [failSessionEnded] — which also
+     *   broadcasts the #1155 stale-session recreate prompt — never attach,
+     *   never silently recreate.
      * - Session ALIVE (`has-session` exits 0): re-enter [connect] with
-     *   `skipColdRestorePreflight = true` so the normal (warm/cached or cold)
-     *   ColdRestore attach proceeds unchanged — no #634/#177 regression.
+     *   `originalTrigger` + `skipExistencePreflight = true` so the normal
+     *   (warm/cached or cold) attach proceeds unchanged — no #634/#177
+     *   regression, and a normal OpenExisting tap attaches as before.
      * - Probe could not run (no lease / exec error): fail OPEN — fall through
      *   to the normal attach so a transient transport hiccup never masquerades
-     *   as "session ended". The attach-only [runConnect] preflight is the
-     *   second line of defence there.
+     *   as "session ended" (no spurious recreate prompt). The attach-only
+     *   [runConnect] preflight is the second line of defence there.
      */
-    private fun preflightColdRestore(
+    private fun preflightSessionExistence(
         hostId: Long,
         hostName: String,
         host: String,
@@ -6356,6 +6405,12 @@ public class TmuxSessionViewModel @Inject constructor(
         startDirectory: String?,
         tmuxSessionId: String?,
         sessionCreated: Long?,
+        // Issue #1155: the trigger to RE-ENTER connect with once the session is
+        // confirmed alive (ColdRestore for the resume path, OpenExisting for a
+        // normal tree-row tap). The GONE branch is identical for both:
+        // [failSessionEnded] drops to the list AND broadcasts the stale-session
+        // recreate prompt.
+        originalTrigger: TmuxConnectTrigger,
     ) {
         val target = ConnectionTarget(
             hostId = hostId,
@@ -6403,17 +6458,17 @@ public class TmuxSessionViewModel @Inject constructor(
                     startDirectory = startDirectory,
                     tmuxSessionId = tmuxSessionId,
                     sessionCreated = sessionCreated,
-                    trigger = TmuxConnectTrigger.ColdRestore,
-                    skipColdRestorePreflight = true,
+                    trigger = originalTrigger,
+                    skipExistencePreflight = true,
                 )
             }
             if (lease == null) {
                 // No transport to probe with — fail open and let the normal
-                // ColdRestore attach (and its attach-only runConnect preflight)
-                // handle it.
+                // attach (and its attach-only runConnect preflight) handle it.
                 Log.i(
                     ISSUE_145_RECONNECT_TAG,
-                    "tmux-cold-restore-preflight-no-lease session=$sessionName — failing open to normal attach",
+                    "tmux-existence-preflight-no-lease session=$sessionName " +
+                        "trigger=${originalTrigger.logValue} — failing open to normal attach",
                 )
                 proceed()
                 return@launch
@@ -6428,20 +6483,24 @@ public class TmuxSessionViewModel @Inject constructor(
             val result = probe.getOrNull()
             when {
                 result == null -> {
-                    // The probe exec itself failed (transport hiccup). Fail open.
+                    // The probe exec itself failed (transport hiccup) — a TRANSIENT
+                    // condition, not a confirmed-gone. Fail open (attach as normal;
+                    // no recreate prompt).
                     Log.i(
                         ISSUE_145_RECONNECT_TAG,
-                        "tmux-cold-restore-preflight-probe-error session=$sessionName " +
+                        "tmux-existence-preflight-probe-error session=$sessionName " +
+                            "trigger=${originalTrigger.logValue} " +
                             "cause=${probe.exceptionOrNull()?.javaClass?.simpleName} — failing open",
                     )
                     proceed()
                 }
                 result.exitCode != 0 -> {
-                    // Session is GONE — do NOT attach or recreate it.
+                    // Session is CONFIRMED GONE — do NOT attach or recreate it.
                     Log.i(
                         ISSUE_145_RECONNECT_TAG,
-                        "tmux-cold-restore-session-gone session=$sessionName exit=${result.exitCode} " +
-                            "— dropping to list, not recreating",
+                        "tmux-existence-session-gone session=$sessionName " +
+                            "trigger=${originalTrigger.logValue} exit=${result.exitCode} " +
+                            "— dropping to list + stale-session recreate prompt, not recreating",
                     )
                     failSessionEnded(
                         target = target,
@@ -6451,7 +6510,8 @@ public class TmuxSessionViewModel @Inject constructor(
                     )
                 }
                 else -> {
-                    // Session is alive — proceed with the normal restore attach.
+                    // Session is alive — proceed with the normal attach for the
+                    // original trigger (ColdRestore resume or OpenExisting tap).
                     proceed()
                 }
             }
@@ -18595,6 +18655,13 @@ internal const val CONVERSATION_LOAD_TIMEOUT_MS: Long = 12_000L
 
 public enum class TmuxConnectTrigger(public val logValue: String) {
     UserTap("user-tap"),
+    // Issue #1155 (Part B): a NORMAL tap of a PERSISTED session row in the folder
+    // tree. Distinct from [UserTap] (which also covers create-new) so a genuine
+    // cold open of an existing-but-maybe-gone session preflights `tmux has-session`
+    // and, when the session is CONFIRMED GONE, drops to the tree with the "create a
+    // new session in this folder?" prompt instead of silently resurrecting it as a
+    // fresh shell via `new-session -A`.
+    OpenExisting("open-existing"),
     LifecycleReattach("lifecycle-reattach"),
     ColdRestore("cold-restore"),
     FastSwitch("fast-switch"),
@@ -18611,6 +18678,7 @@ private val TmuxConnectTrigger.isReconnectTrigger: Boolean
         TmuxConnectTrigger.LifecycleReattach,
         -> true
         TmuxConnectTrigger.UserTap,
+        TmuxConnectTrigger.OpenExisting,
         TmuxConnectTrigger.ColdRestore,
         TmuxConnectTrigger.FastSwitch,
         -> false

--- a/app/src/test/java/com/pocketshell/app/AppTreeCacheWarmWiringTest.kt
+++ b/app/src/test/java/com/pocketshell/app/AppTreeCacheWarmWiringTest.kt
@@ -1,0 +1,122 @@
+package com.pocketshell.app
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * Issue #1155 (Part A) — durable wiring guard for the process-start folder-tree
+ * cache warm (D31/G1/G9, non-waivable — this is a REOPEN of #867 / #1109).
+ *
+ * The Part-A production fix is the `App.onCreate` cache warm:
+ *
+ * ```
+ * sshLifecycleScope.launch {
+ *     runCatching { treeClientCache.warmAll() }
+ * }
+ * ```
+ *
+ * That single line is the SOLE warm path (the old racy per-VM warm was removed
+ * in blocker 1). It is what makes the FIRST host opened after a genuinely cold
+ * PROCESS start paint the persisted tree instantly instead of flashing "Loading
+ * workspace tree". The exact regression that reopened #867 / #1109 twice is
+ * "the startup warm got removed" — so the durable gate is: deleting that warm
+ * call from `App.onCreate` must turn a test RED.
+ *
+ * Why a source-structure guard (not a Robolectric `App.onCreate()` run):
+ *   - `App` is `@HiltAndroidApp` and `treeClientCache` is an injected
+ *     `lateinit var`. `App.onCreate()` runs `super.onCreate()` (Hilt field
+ *     injection) plus StrictMode/CrashReporter/scheduler wiring; a plain-JVM
+ *     unit test cannot drive that full `onCreate` without the androidTest Hilt
+ *     rule. This mirrors the accepted precedent `AppStrictModeArmOrderTest`,
+ *     which guards the SAME class of "a load-bearing line moved / was removed
+ *     from `App.onCreate`" regression at the source/structure level so it runs
+ *     for free in the Unit job and fails deterministically on the regression.
+ *   - The property under test IS the wiring itself: the warm call present, in
+ *     `App.onCreate`, dispatched off Main via `sshLifecycleScope.launch`, and
+ *     placed AFTER `super.onCreate()` (so Hilt has populated the `lateinit`
+ *     `treeClientCache` — a warm before injection would crash on the lateinit).
+ *     This is not a proxy for the behaviour; the presence-of-wiring is the exact
+ *     thing #867 / #1109 lost.
+ *
+ * RED→GREEN: reverting `App.kt` line 372 (`runCatching { treeClientCache.warmAll() }`)
+ * removes `treeClientCache.warmAll()` from the source, so `warmAllIdx` becomes
+ * -1 and every assertion below fails. Restoring it makes them pass.
+ */
+class AppTreeCacheWarmWiringTest {
+
+    // Code only — comment lines are stripped so a prose mention of
+    // `treeClientCache.warmAll()` in this file's sibling comments (or App.kt's
+    // own explanatory comment) can never be matched as the call site.
+    private val source: String = locate("App.kt")
+        .lineSequence()
+        .filterNot { it.trimStart().startsWith("//") }
+        .joinToString("\n")
+
+    @Test
+    fun onCreateWarmsTreeClientCacheAtProcessStart() {
+        val warmAllIdx = source.indexOf(WARM_ALL_CALL)
+        assertTrue(
+            "App.onCreate must warm the persisted folder-tree cache at process start via " +
+                "`$WARM_ALL_CALL` (issue #1155 Part A; the SOLE warm path). Its removal is the " +
+                "exact regression that reopened #867 / #1109 — a cold-launch \"Loading workspace " +
+                "tree\" flash returns without it. warmAllIdx=$warmAllIdx",
+            warmAllIdx >= 0,
+        )
+    }
+
+    @Test
+    fun warmRunsAfterSuperOnCreateSoInjectedCacheIsAvailable() {
+        // `treeClientCache` is an injected `lateinit var`; Hilt populates it in
+        // `super.onCreate()`. The warm MUST run after `super.onCreate()` or it
+        // would touch the uninitialised lateinit. This ordering guard fails if
+        // the warm line is deleted (warmAllIdx == -1) AND if a future edit hoists
+        // it above injection.
+        val superIdx = source.indexOf(SUPER_ON_CREATE_CALL)
+        assertTrue("App.onCreate must call $SUPER_ON_CREATE_CALL", superIdx >= 0)
+        val warmAllIdx = source.indexOf(WARM_ALL_CALL)
+        assertTrue(
+            "The tree-cache warm must run AFTER super.onCreate() (Hilt injects the lateinit " +
+                "treeClientCache there). warmAllIdx=$warmAllIdx superIdx=$superIdx",
+            warmAllIdx in (superIdx + 1) until source.length,
+        )
+    }
+
+    @Test
+    fun warmIsDispatchedOffMainOnTheSshLifecycleScope() {
+        // The warm reads the persisted tree from disk, so it must be dispatched
+        // OFF Main (StrictMode disk-read tripwire + the #965 ANR budget). Assert
+        // the warm call sits inside an `sshLifecycleScope.launch { ... }` block:
+        // the nearest `sshLifecycleScope.launch` before the warm must be closer
+        // than any prior `super.onCreate()`, and there is a launch opening before
+        // the warm. Deleting the warm makes warmAllIdx == -1 and fails here too.
+        val warmAllIdx = source.indexOf(WARM_ALL_CALL)
+        assertTrue(
+            "App.onCreate must warm via `$WARM_ALL_CALL`. warmAllIdx=$warmAllIdx",
+            warmAllIdx >= 0,
+        )
+        val launchIdx = source.lastIndexOf(SSH_SCOPE_LAUNCH, warmAllIdx)
+        assertTrue(
+            "The tree-cache warm must be dispatched off Main via `$SSH_SCOPE_LAUNCH { ... }` " +
+                "so the disk read does not run on the Main thread (StrictMode / #965 ANR budget). " +
+                "launchIdx=$launchIdx warmAllIdx=$warmAllIdx",
+            launchIdx in 0 until warmAllIdx,
+        )
+    }
+
+    private fun locate(name: String): String {
+        val candidates = listOf(
+            File("app/src/main/java/com/pocketshell/app/$name"),
+            File("src/main/java/com/pocketshell/app/$name"),
+        )
+        val file = candidates.firstOrNull { it.isFile }
+            ?: error("Could not locate $name from ${File(".").absolutePath}")
+        return file.readText()
+    }
+
+    private companion object {
+        const val WARM_ALL_CALL = "treeClientCache.warmAll()"
+        const val SUPER_ON_CREATE_CALL = "super.onCreate()"
+        const val SSH_SCOPE_LAUNCH = "sshLifecycleScope.launch"
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelClientCacheTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelClientCacheTest.kt
@@ -1,5 +1,7 @@
 package com.pocketshell.app.projects
 
+import android.content.Context
+import android.content.ContextWrapper
 import androidx.lifecycle.ViewModelStore
 import androidx.test.core.app.ApplicationProvider
 import com.pocketshell.app.hosts.MainDispatcherRule
@@ -30,11 +32,13 @@ import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
+import java.io.File
 
 /**
  * Issue #867: session-tree stale-while-revalidate — render the last-known tree
@@ -60,9 +64,24 @@ class FolderListViewModelClientCacheTest {
     private val viewModelStore = ViewModelStore()
     private var nextViewModelKey: Int = 0
 
+    // Issue #1155 (blocker 1): a PER-TEST isolated on-disk cache directory so the
+    // client-cache tests never share `filesDir`/`tree-cache` state across methods.
+    // The prior suite read + wrote one shared `ApplicationProvider` filesDir, which
+    // (together with the now-removed per-VM real-`Dispatchers.IO` warm) let one
+    // test's on-disk snapshot + a racing warm flip a sibling's cold-miss assertion.
+    // Every `newCache()` in a test targets this dir; `@After` wipes it.
+    private lateinit var testCacheFilesDir: File
+
+    @Before
+    fun setUpIsolatedCacheDir() {
+        testCacheFilesDir =
+            java.nio.file.Files.createTempDirectory("tree-client-cache-test").toFile()
+    }
+
     @After
     fun tearDown() {
         viewModelStore.clear()
+        testCacheFilesDir.deleteRecursively()
     }
 
     // ---- RED reproduction: with NO cache, cold start flashes Loading ---------
@@ -225,6 +244,104 @@ class FolderListViewModelClientCacheTest {
         assertEquals(
             listOf("gamma"),
             (ready as FolderListUiState.Ready).flatSessions.map { it.sessionName },
+        )
+    }
+
+    // ---- Issue #1155 (Part A): the PROCESS-START warm makes cold connect instant ----
+    //
+    // The maintainer's recurring #867/#1109 symptom: a cold process (the parsed
+    // map is empty; the tree file is on disk from the previous run) where they
+    // deep-link into a session and then go BACK to the tree. The VM is constructed
+    // and `bind` runs in the SAME instant, so a per-VM warm (removed in this
+    // change) loses the race and [TreeClientCache.peek] MISSES → the "Loading
+    // workspace tree" spinner flashes. The fix warms the parsed snapshot ONCE at
+    // process startup ([com.pocketshell.app.App.onCreate] → [TreeClientCache.warmAll],
+    // MANY frames ahead of any navigation) — the SINGLE warm path — so `peek` HITS
+    // synchronously inside `bind` and the FIRST painted frame is the persisted
+    // Ready tree.
+    //
+    // These two tests pivot on that process-start warm: the ONLY difference is
+    // whether [TreeClientCache.warmAll] (exactly what App.onCreate calls) ran
+    // before `bind`. With the per-VM warm GONE, warmAll is the load-bearing
+    // mechanism, and both assertions are deterministic (no real-`Dispatchers.IO`
+    // warm racing the synchronous peek). Reverting the App.onCreate warm turns
+    // every first cold open into the RED case below — which the CI-wired on-device
+    // `ColdRestoreGoneSessionNoResurrectE2eTest` deep-link-back journey catches.
+
+    /**
+     * Issue #1155 (Part A) RED — the "App.onCreate warm reverted / not yet run"
+     * state. A cold-memory cache (file on disk, parsed map cold) with NO
+     * process-start warm: `bind` MISSES [TreeClientCache.peek], so the FIRST frame
+     * is the "Loading workspace tree" flash (then the OFF-Main read paints the held
+     * tree — never a Main-thread read). Deterministic now that the per-VM
+     * real-`Dispatchers.IO` warm is removed.
+     */
+    @Test
+    fun coldStartWithoutProcessStartWarm_flashesLoadingThenPaintsOffMain_RED() = runTest {
+        newCache().write(
+            HOST.name,
+            TreeClientCache.CachedTree(nodes = listOf(node("alpha", 0, folderPath("alpha")))),
+        )
+        val coldCache = newCache() // fresh process: file on disk, parsed map cold.
+        // NB: no `coldCache.warmAll()` — this is the App.onCreate-warm-absent case.
+        val gateway = StubGateway(listOf(sessionRow("alpha")))
+        val vm = newViewModel(gateway, coldCache)
+
+        bind(vm)
+        assertTrue(
+            "without the process-start warm the cold `bind` MISSES peek and flashes " +
+                "Loading — got ${vm.state.value}",
+            vm.state.value is FolderListUiState.Loading,
+        )
+        // The off-Main fallback still paints the held tree (no Main-thread read).
+        runCurrent()
+        val painted = vm.state.value
+        assertTrue(
+            "the OFF-Main cold-miss read must still paint the held tree — got $painted",
+            painted is FolderListUiState.Ready,
+        )
+        assertEquals(
+            listOf("alpha"),
+            (painted as FolderListUiState.Ready).flatSessions.map { it.sessionName },
+        )
+    }
+
+    /**
+     * Issue #1155 (Part A) GREEN — the fix. The process-start warm
+     * ([TreeClientCache.warmAll], exactly what [com.pocketshell.app.App.onCreate]
+     * runs off Main, many frames ahead of navigation) parses the on-disk snapshot
+     * into the process-wide in-memory map BEFORE the user navigates in. So the SAME
+     * cold-memory cache, once warmed, makes the first `bind` [peek] HIT — the FIRST
+     * state read (before any coroutine runs) is already the persisted Ready tree,
+     * NO Loading spinner flash. Load-bearing proof that the startup warm (the ONLY
+     * warm path now the per-VM warm is removed) kills the disruptive loading on the
+     * maintainer's deep-link-then-back path.
+     */
+    @Test
+    fun coldStartAfterProcessStartWarm_rendersInstantlyNoLoadingFlash_GREEN() = runTest {
+        newCache().write(
+            HOST.name,
+            TreeClientCache.CachedTree(nodes = listOf(node("alpha", 0, folderPath("alpha")))),
+        )
+        val coldCache = newCache() // fresh process: file on disk, parsed map cold.
+        // The App.onCreate process-start warm (issue #1155 Part A): parse the
+        // on-disk snapshot into memory BEFORE navigation. This one call is the
+        // WHOLE difference from the RED test above.
+        coldCache.warmAll()
+
+        val gateway = StubGateway(listOf(sessionRow("alpha")))
+        val vm = newViewModel(gateway, coldCache)
+
+        bind(vm)
+        val first = vm.state.value
+        assertTrue(
+            "after the process-start warm the cold connect must render the persisted tree " +
+                "INSTANTLY (Ready, no Loading flash) — got $first",
+            first is FolderListUiState.Ready,
+        )
+        assertEquals(
+            listOf("alpha"),
+            (first as FolderListUiState.Ready).flatSessions.map { it.sessionName },
         )
     }
 
@@ -553,7 +670,17 @@ class FolderListViewModelClientCacheTest {
         )
 
     private fun newCache(): TreeClientCache =
-        TreeClientCache(ApplicationProvider.getApplicationContext())
+        TreeClientCache(isolatedCacheContext())
+
+    /**
+     * A [Context] whose `filesDir` is this test's own temp dir, so the
+     * [TreeClientCache] writes/reads under an isolated `tree-cache/` folder and no
+     * on-disk snapshot leaks across test methods (blocker 1 hermeticity).
+     */
+    private fun isolatedCacheContext(): Context =
+        object : ContextWrapper(ApplicationProvider.getApplicationContext()) {
+            override fun getFilesDir(): File = testCacheFilesDir
+        }
 
     private fun TestScope.newViewModel(
         gateway: FolderListGateway,

--- a/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelStaleSessionTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelStaleSessionTest.kt
@@ -1,0 +1,367 @@
+package com.pocketshell.app.projects
+
+import androidx.lifecycle.ViewModelStore
+import androidx.test.core.app.ApplicationProvider
+import com.pocketshell.app.hosts.MainDispatcherRule
+import com.pocketshell.app.portfwd.ForwardingController
+import com.pocketshell.app.tmux.SessionLifecycleSignals
+import com.pocketshell.core.ssh.SshLeaseConnector
+import com.pocketshell.core.ssh.SshLeaseManager
+import com.pocketshell.core.storage.dao.HostDao
+import com.pocketshell.core.storage.dao.ProjectRootDao
+import com.pocketshell.core.storage.entity.HostEntity
+import com.pocketshell.core.storage.entity.ProjectRootEntity
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Issue #1155 (Part B): the folder tree's "This session no longer exists —
+ * create a new session in this folder?" recovery prompt.
+ *
+ * When a persisted session the user tried to open is confirmed GENUINELY GONE on
+ * attach ([SessionLifecycleSignals.staleSessions], emitted only from the
+ * `TmuxSessionNotFoundException` path — NOT a transient reconnect), the tree
+ * raises a [StaleSessionRecreatePrompt] instead of leaving the user on a blank
+ * list. Confirming reuses the SAME folder's create-session path; dismissing
+ * clears it. The genuinely-gone-vs-transient distinction itself is proven on the
+ * emitter side in `TmuxSessionWarmOpenTest`
+ * (`goneSessionBroadcastsStaleSignal…` / `liveSessionDoesNotBroadcastStale…`).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class FolderListViewModelStaleSessionTest {
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val viewModelStore = ViewModelStore()
+    private var nextViewModelKey: Int = 0
+
+    @After
+    fun tearDown() {
+        viewModelStore.clear()
+    }
+
+    private val goneFolder = "/home/alexey/git/pocketshell"
+
+    // ---- a genuinely-gone session raises the recreate prompt (bound host) -----
+
+    @Test
+    fun staleSessionRaisesRecreatePromptForBoundHost() = runTest {
+        val signals = SessionLifecycleSignals()
+        val gateway = StubGateway(listOf(sessionRow("git-pocketshell"), sessionRow("beta")))
+        val vm = newViewModel(gateway = gateway, signals = signals)
+        try {
+            bind(vm)
+            runCurrent()
+            // The user navigated onward to the (now gone) session -> tree paused.
+            vm.stopPolling()
+            runCurrent()
+            assertNull("no prompt before the gone-session signal", vm.staleSessionPrompt.value)
+
+            // The session was confirmed genuinely gone on attach.
+            signals.emitStaleSession(HOST.id, "git-pocketshell", goneFolder)
+            runCurrent()
+
+            val prompt = vm.staleSessionPrompt.value
+            assertTrue("a genuinely-gone session must raise the recreate prompt", prompt != null)
+            assertEquals("git-pocketshell", prompt!!.sessionName)
+            assertEquals(goneFolder, prompt.folderPath)
+            // The confirmed-gone row is also dropped from the tree so the list the
+            // prompt sits over is accurate.
+            assertTrue(
+                "the confirmed-gone session drops from the tree",
+                "git-pocketshell" !in readySessionNames(vm),
+            )
+        } finally {
+            vm.stopPolling()
+        }
+    }
+
+    // ---- host filter: a gone session on ANOTHER host must not prompt ----------
+
+    @Test
+    fun staleSessionForOtherHostDoesNotPrompt() = runTest {
+        val signals = SessionLifecycleSignals()
+        val gateway = StubGateway(listOf(sessionRow("git-pocketshell")))
+        val vm = newViewModel(gateway = gateway, signals = signals)
+        try {
+            bind(vm)
+            runCurrent()
+
+            signals.emitStaleSession(HOST.id + 1, "git-pocketshell", goneFolder)
+            runCurrent()
+
+            assertNull(
+                "a gone session on another host must not raise this host's prompt",
+                vm.staleSessionPrompt.value,
+            )
+        } finally {
+            vm.stopPolling()
+        }
+    }
+
+    // ---- confirm recreates in the SAME folder and routes to the new session ---
+
+    @Test
+    fun confirmRecreatesSessionInSameFolderAndRoutes() = runTest {
+        val signals = SessionLifecycleSignals()
+        val gateway = StubGateway(listOf(sessionRow("beta")))
+        val vm = newViewModel(gateway = gateway, signals = signals)
+        try {
+            bind(vm)
+            runCurrent()
+            signals.emitStaleSession(HOST.id, "git-pocketshell", goneFolder)
+            runCurrent()
+            assertTrue(vm.staleSessionPrompt.value != null)
+
+            val routed = mutableListOf<String>()
+            vm.confirmRecreateStaleSession(onResolved = { routed.add(it) })
+            runCurrent()
+
+            assertEquals(
+                "confirm must recreate the session in the SAME folder",
+                listOf("git-pocketshell" to goneFolder),
+                gateway.createdSessions,
+            )
+            assertEquals("confirm routes to the recreated session", listOf("git-pocketshell"), routed)
+            assertNull("confirm clears the prompt", vm.staleSessionPrompt.value)
+        } finally {
+            vm.stopPolling()
+        }
+    }
+
+    // ---- dismiss clears the prompt (no create) --------------------------------
+
+    @Test
+    fun dismissClearsPromptWithoutCreating() = runTest {
+        val signals = SessionLifecycleSignals()
+        val gateway = StubGateway(listOf(sessionRow("beta")))
+        val vm = newViewModel(gateway = gateway, signals = signals)
+        try {
+            bind(vm)
+            runCurrent()
+            signals.emitStaleSession(HOST.id, "git-pocketshell", goneFolder)
+            runCurrent()
+            assertTrue(vm.staleSessionPrompt.value != null)
+
+            vm.dismissStaleSessionPrompt()
+            runCurrent()
+
+            assertNull("dismiss clears the prompt", vm.staleSessionPrompt.value)
+            assertTrue("dismiss must NOT create a session", gateway.createdSessions.isEmpty())
+        } finally {
+            vm.stopPolling()
+        }
+    }
+
+    // ---- missing-data: a gone session with no known folder falls back to ~ -----
+
+    @Test
+    fun staleSessionWithNullFolderFallsBackToHomeOnRecreate() = runTest {
+        val signals = SessionLifecycleSignals()
+        val gateway = StubGateway(listOf(sessionRow("beta")))
+        val vm = newViewModel(gateway = gateway, signals = signals)
+        try {
+            bind(vm)
+            runCurrent()
+            // The gone session carried no start directory (missing-data case).
+            signals.emitStaleSession(HOST.id, "orphan", folderPath = null)
+            runCurrent()
+
+            val prompt = vm.staleSessionPrompt.value
+            assertTrue("a null-folder gone session must STILL prompt (never blank/error)", prompt != null)
+            assertNull(prompt!!.folderPath)
+
+            vm.confirmRecreateStaleSession(onResolved = {})
+            runCurrent()
+            assertEquals(
+                "a null-folder recreate falls back to the host home directory",
+                listOf("orphan" to "~"),
+                gateway.createdSessions,
+            )
+        } finally {
+            vm.stopPolling()
+        }
+    }
+
+    // ---- class coverage: app-created removal (via the app) drops the row and --
+    // ---- does NOT prompt (the tree stays accurate) — only a gone-on-open does -
+
+    @Test
+    fun appCreatedRemovalDropsRowWithoutRecreatePrompt() = runTest {
+        val signals = SessionLifecycleSignals()
+        val gateway = StubGateway(listOf(sessionRow("git-pocketshell"), sessionRow("beta")))
+        val vm = newViewModel(gateway = gateway, signals = signals)
+        try {
+            bind(vm)
+            runCurrent()
+            vm.stopPolling()
+            runCurrent()
+
+            // The COMMON case: the user removed the session THROUGH the app — the
+            // tree drops the row immediately and there is nothing to recover, so
+            // NO recreate prompt (that is only for opening a persisted-but-gone
+            // session — the external-removal / missed-sync case).
+            signals.emitKilled(HOST.id, "git-pocketshell")
+            runCurrent()
+
+            assertTrue("app-created removal drops the row", "git-pocketshell" !in readySessionNames(vm))
+            assertNull("app-created removal must NOT raise the recreate prompt", vm.staleSessionPrompt.value)
+        } finally {
+            vm.stopPolling()
+        }
+    }
+
+    // --- helpers ---------------------------------------------------------------
+
+    private fun bind(vm: FolderListViewModel) {
+        vm.bind(
+            hostId = HOST.id,
+            hostName = HOST.name,
+            hostname = HOST.hostname,
+            port = HOST.port,
+            username = HOST.username,
+            keyPath = KEY_PATH,
+            passphrase = null,
+        )
+    }
+
+    private fun readySessionNames(vm: FolderListViewModel): Set<String> {
+        val state = vm.state.value as FolderListUiState.Ready
+        return state.flatSessions.map { it.sessionName }.toSet()
+    }
+
+    private fun sessionRow(name: String): FolderSessionRow =
+        FolderSessionRow(
+            sessionName = name,
+            lastActivity = 1_000L,
+            attached = false,
+            cwd = "/home/alexey/git/$name",
+        )
+
+    private fun TestScope.newViewModel(
+        gateway: FolderListGateway,
+        signals: SessionLifecycleSignals,
+    ): FolderListViewModel {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        Dispatchers.setMain(dispatcher)
+        return FolderListViewModel(
+            gateway = gateway,
+            hostDao = FakeHostDao(HOST),
+            projectRootDao = FakeProjectRootDao(),
+            sshLeaseManager = SshLeaseManager(
+                connector = SshLeaseConnector {
+                    Result.failure(IllegalStateException("prewarm disabled for stale-session test"))
+                },
+                scope = this,
+                idleTtlMillis = 0L,
+                connectTimeoutContext = dispatcher,
+                nowMillis = { testScheduler.currentTime },
+            ),
+            forwardingController = ForwardingController(ApplicationProvider.getApplicationContext()),
+            sessionLifecycleSignals = signals,
+            attachLifecycle = false,
+        ).also {
+            it.ioDispatcher = dispatcher
+            it.treeDispatcher = dispatcher
+            it.setProcessStartedForTest(true)
+            viewModelStore.put("FolderListViewModel-${nextViewModelKey++}", it)
+        }
+    }
+
+    private class StubGateway(
+        @Volatile var rows: List<FolderSessionRow>,
+    ) : FolderListGateway {
+        val createdSessions: MutableList<Pair<String, String>> = mutableListOf()
+
+        override suspend fun listSessionsWithFolder(
+            host: HostEntity,
+            keyPath: String,
+            passphrase: CharArray?,
+            watchedRoots: List<ProjectRootEntity>,
+        ): FolderListResult = FolderListResult.Sessions(rows = rows)
+
+        override suspend fun createSession(
+            host: HostEntity,
+            keyPath: String,
+            passphrase: CharArray?,
+            sessionName: String,
+            cwd: String,
+            startCommand: String?,
+        ): Result<String> {
+            createdSessions.add(sessionName to cwd)
+            return Result.success(sessionName)
+        }
+
+        override suspend fun createEmptyProject(
+            host: HostEntity,
+            keyPath: String,
+            passphrase: CharArray?,
+            parentPath: String,
+            folderName: String,
+        ): Result<String> = error("not used")
+
+        override suspend fun importFile(
+            host: HostEntity,
+            keyPath: String,
+            passphrase: CharArray?,
+            folderPath: String,
+            payload: FolderImportPayload,
+        ): Result<String> = error("not used")
+
+        override suspend fun killSession(
+            host: HostEntity,
+            keyPath: String,
+            passphrase: CharArray?,
+            sessionName: String,
+        ): Result<Unit> = error("not used")
+    }
+
+    private class FakeHostDao(private val host: HostEntity) : HostDao {
+        override fun getAll(): Flow<List<HostEntity>> = flowOf(listOf(host))
+        override suspend fun getById(id: Long): HostEntity? = host.takeIf { it.id == id }
+        override fun getEnabled(): Flow<List<HostEntity>> = flowOf(listOf(host))
+        override suspend fun insert(host: HostEntity): Long = error("not used")
+        override suspend fun update(host: HostEntity) = error("not used")
+        override suspend fun delete(host: HostEntity) = error("not used")
+        override suspend fun deleteById(id: Long) = error("not used")
+    }
+
+    private class FakeProjectRootDao : ProjectRootDao {
+        private val roots = MutableStateFlow<List<ProjectRootEntity>>(emptyList())
+        override fun getByHostId(hostId: Long): Flow<List<ProjectRootEntity>> = roots
+        override suspend fun insert(root: ProjectRootEntity): Long = error("not used")
+        override suspend fun update(root: ProjectRootEntity) = error("not used")
+        override suspend fun delete(root: ProjectRootEntity) = error("not used")
+    }
+
+    private companion object {
+        const val KEY_PATH: String = "/tmp/pocketshell-test-key"
+        val HOST: HostEntity = HostEntity(
+            id = 42L,
+            name = "docker",
+            hostname = "10.0.2.2",
+            port = 2222,
+            username = "testuser",
+            keyId = 7L,
+        )
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionWarmOpenTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionWarmOpenTest.kt
@@ -85,12 +85,15 @@ class TmuxSessionWarmOpenTest {
         registry: ActiveTmuxClients,
         sshLeaseManager: SshLeaseManager,
         settingsRepository: com.pocketshell.app.settings.SettingsRepository? = null,
+        // Issue #1155 (Part B): pass a real signals instance so the gone-session
+        // (`failSessionEnded`) path's `emitStaleSession` broadcast can be asserted.
+        sessionLifecycleSignals: SessionLifecycleSignals? = null,
     ): TmuxSessionViewModel = TmuxSessionViewModel(
         tmuxClientFactory = TmuxClientFactory(factoryScope),
         activeTmuxClients = registry,
         runtimeCache = TmuxSessionRuntimeCache(),
         sshLeaseManager = sshLeaseManager,
-        sessionLifecycleSignals = null,
+        sessionLifecycleSignals = sessionLifecycleSignals,
         settingsRepository = settingsRepository,
     ).also {
         // Issue #886: these warm-open / switch / never-reveal-black tests assert
@@ -488,6 +491,292 @@ class TmuxSessionWarmOpenTest {
         assertFalse(
             "gone session must not be auto-reconnected",
             vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Reconnecting,
+        )
+    }
+
+    // ---- Issue #1155 (Part B): genuinely-gone emits the stale-session signal ----
+
+    @Test
+    fun goneSessionBroadcastsStaleSignalWithFolderForRecreatePrompt() = runVmTest {
+        // Part B emitter proof: a cold-restore to a GENUINELY-GONE session (the
+        // `has-session` preflight fails) must broadcast a StaleSession carrying the
+        // gone name AND its folder, so the folder tree can offer "create a new
+        // session in this folder?". This is the ONLY path that emits it — a
+        // transient reconnect (which never reaches `failSessionEnded`) does not.
+        val fresh = AlwaysConnectedSession(id = "fresh", hasSessionExitCode = 1)
+        val connector = SingleSessionConnector(fresh)
+        val leaseManager =
+            testLeaseManager(connector = connector, scope = this, idleTtlMillis = 60_000L)
+        val registry = ActiveTmuxClients()
+        val signals = SessionLifecycleSignals()
+        val vm = TestNewVm(
+            registry = registry,
+            sshLeaseManager = leaseManager,
+            sessionLifecycleSignals = signals,
+        )
+        vm.setTmuxClientFactoryForTest { _, _, _ -> FakeTmuxClient() }
+
+        val staleEvents = mutableListOf<StaleSession>()
+        var staleSubscribed = false
+        val staleCollector = launch {
+            signals.staleSessions
+                .onSubscription { staleSubscribed = true }
+                .collect { staleEvents.add(it) }
+        }
+        testScheduler.runCurrent()
+        assertTrue("stale collector must subscribe before connect", staleSubscribed)
+
+        vm.connect(
+            hostId = 7L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            passphrase = null,
+            sessionName = "work",
+            startDirectory = "/home/alex/git/pocketshell",
+            trigger = TmuxConnectTrigger.ColdRestore,
+        )
+        pumpUntil(reason = "gone-session stale broadcast") { staleEvents.isNotEmpty() }
+        staleCollector.cancel()
+
+        assertEquals(
+            "genuinely-gone must broadcast exactly one StaleSession for the folder tree",
+            listOf(StaleSession(hostId = 7L, sessionName = "work", folderPath = "/home/alex/git/pocketshell")),
+            staleEvents,
+        )
+    }
+
+    @Test
+    fun liveSessionDoesNotBroadcastStaleSignal() = runVmTest {
+        // Part B guard (the "only when genuinely gone" criterion): a session that
+        // is STILL there attaches normally and must NOT broadcast a StaleSession —
+        // so a live attach / a recovered reconnect never raises a spurious recreate
+        // prompt. This is the class-coverage sibling of the gone case above.
+        val fresh = AlwaysConnectedSession(id = "fresh")
+        val connector = SingleSessionConnector(fresh)
+        val leaseManager =
+            testLeaseManager(connector = connector, scope = this, idleTtlMillis = 60_000L)
+        val registry = ActiveTmuxClients()
+        val signals = SessionLifecycleSignals()
+        val vm = TestNewVm(
+            registry = registry,
+            sshLeaseManager = leaseManager,
+            sessionLifecycleSignals = signals,
+        )
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%1")
+        vm.setTmuxClientFactoryForTest { _, _, _ -> client }
+
+        val staleEvents = mutableListOf<StaleSession>()
+        var staleSubscribed = false
+        val staleCollector = launch {
+            signals.staleSessions
+                .onSubscription { staleSubscribed = true }
+                .collect { staleEvents.add(it) }
+        }
+        testScheduler.runCurrent()
+        assertTrue("stale collector must subscribe before connect", staleSubscribed)
+
+        vm.connect(
+            hostId = 7L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            passphrase = null,
+            sessionName = "work",
+            startDirectory = "/home/alex/git/pocketshell",
+            trigger = TmuxConnectTrigger.ColdRestore,
+        )
+        advanceUntilIdle()
+        staleCollector.cancel()
+
+        assertTrue(
+            "a live session must NOT broadcast a stale-session recreate signal, got $staleEvents",
+            staleEvents.isEmpty(),
+        )
+        assertTrue(
+            "a live cold-restore must reach Connected, got ${vm.connectionStatus.value}",
+            vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+    }
+
+    // ---- Issue #1155 (Part B): the NORMAL tap of a persisted session row --------
+    // ---- (OpenExisting) reaches the recreate prompt when the session is gone ----
+    //
+    // Class coverage per the reviewer's blocker 3: confirmed-gone -> prompt;
+    // exists -> attach; transient -> neither. The maintainer's exact reported
+    // symptom ("I refreshed the tree and it was there but not as an agent session,
+    // just shell") was a TAP silently recreating a gone session via `new-session
+    // -A`. The tap now preflights `tmux has-session` and, when confirmed gone,
+    // routes to `failSessionEnded` -> the stale-session recreate prompt instead.
+
+    @Test
+    fun openExistingTapOfGoneSessionReachesRecreatePrompt() = runVmTest {
+        // CONFIRMED-GONE -> PROMPT. A normal tree-row tap (OpenExisting) of a
+        // persisted session that is genuinely gone (has-session exits non-zero)
+        // must broadcast a StaleSession for the folder tree's recreate prompt —
+        // NOT silently `new-session -A` a fresh shell.
+        val fresh = AlwaysConnectedSession(id = "fresh", hasSessionExitCode = 1)
+        val connector = SingleSessionConnector(fresh)
+        val leaseManager =
+            testLeaseManager(connector = connector, scope = this, idleTtlMillis = 60_000L)
+        val registry = ActiveTmuxClients()
+        val signals = SessionLifecycleSignals()
+        val vm = TestNewVm(
+            registry = registry,
+            sshLeaseManager = leaseManager,
+            sessionLifecycleSignals = signals,
+        )
+        vm.setTmuxClientFactoryForTest { _, _, _ -> FakeTmuxClient() }
+
+        val staleEvents = mutableListOf<StaleSession>()
+        var staleSubscribed = false
+        val staleCollector = launch {
+            signals.staleSessions
+                .onSubscription { staleSubscribed = true }
+                .collect { staleEvents.add(it) }
+        }
+        testScheduler.runCurrent()
+        assertTrue("stale collector must subscribe before connect", staleSubscribed)
+
+        vm.connect(
+            hostId = 7L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            passphrase = null,
+            sessionName = "work",
+            startDirectory = "/home/alex/git/pocketshell",
+            trigger = TmuxConnectTrigger.OpenExisting,
+        )
+        pumpUntil(reason = "open-existing gone-session stale broadcast") { staleEvents.isNotEmpty() }
+        staleCollector.cancel()
+
+        assertTrue(
+            "the OpenExisting tap must probe `tmux has-session`; saw: ${fresh.execCommands}",
+            fresh.execCommands.any { it.startsWith("tmux has-session -t 'work'") },
+        )
+        assertEquals(
+            "a confirmed-gone tap must broadcast exactly one StaleSession for the recreate prompt",
+            listOf(StaleSession(hostId = 7L, sessionName = "work", folderPath = "/home/alex/git/pocketshell")),
+            staleEvents,
+        )
+    }
+
+    @Test
+    fun openExistingTapOfLiveSessionAttachesNoPrompt() = runVmTest {
+        // EXISTS -> ATTACH. A tap of a session that is STILL there attaches
+        // normally (the preflight passes) and must NOT broadcast a StaleSession.
+        val fresh = AlwaysConnectedSession(id = "fresh", hasSessionExitCode = 0)
+        val connector = SingleSessionConnector(fresh)
+        val leaseManager =
+            testLeaseManager(connector = connector, scope = this, idleTtlMillis = 60_000L)
+        val registry = ActiveTmuxClients()
+        val signals = SessionLifecycleSignals()
+        val vm = TestNewVm(
+            registry = registry,
+            sshLeaseManager = leaseManager,
+            sessionLifecycleSignals = signals,
+        )
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%1")
+        vm.setTmuxClientFactoryForTest { _, _, _ -> client }
+
+        val staleEvents = mutableListOf<StaleSession>()
+        var staleSubscribed = false
+        val staleCollector = launch {
+            signals.staleSessions
+                .onSubscription { staleSubscribed = true }
+                .collect { staleEvents.add(it) }
+        }
+        testScheduler.runCurrent()
+        assertTrue("stale collector must subscribe before connect", staleSubscribed)
+
+        vm.connect(
+            hostId = 7L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            passphrase = null,
+            sessionName = "work",
+            startDirectory = "/home/alex/git/pocketshell",
+            trigger = TmuxConnectTrigger.OpenExisting,
+        )
+        advanceUntilIdle()
+        staleCollector.cancel()
+
+        assertTrue(
+            "a live tap must NOT broadcast a stale-session recreate signal, got $staleEvents",
+            staleEvents.isEmpty(),
+        )
+        assertTrue(
+            "a live OpenExisting tap must reach Connected, got ${vm.connectionStatus.value}",
+            vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+    }
+
+    @Test
+    fun openExistingTapWithTransientProbeErrorAttachesNoPrompt() = runVmTest {
+        // TRANSIENT -> NEITHER. When the has-session probe itself ERRORS (a
+        // transport hiccup, not a confirmed non-zero exit), the preflight FAILS
+        // OPEN: it attaches as normal (createIfMissing) and must NOT raise the
+        // recreate prompt — a reconnect blip is not "session gone".
+        val fresh = AlwaysConnectedSession(id = "fresh", hasSessionThrows = true)
+        val connector = SingleSessionConnector(fresh)
+        val leaseManager =
+            testLeaseManager(connector = connector, scope = this, idleTtlMillis = 60_000L)
+        val registry = ActiveTmuxClients()
+        val signals = SessionLifecycleSignals()
+        val vm = TestNewVm(
+            registry = registry,
+            sshLeaseManager = leaseManager,
+            sessionLifecycleSignals = signals,
+        )
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%1")
+        vm.setTmuxClientFactoryForTest { _, _, _ -> client }
+
+        val staleEvents = mutableListOf<StaleSession>()
+        var staleSubscribed = false
+        val staleCollector = launch {
+            signals.staleSessions
+                .onSubscription { staleSubscribed = true }
+                .collect { staleEvents.add(it) }
+        }
+        testScheduler.runCurrent()
+        assertTrue("stale collector must subscribe before connect", staleSubscribed)
+
+        vm.connect(
+            hostId = 7L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            passphrase = null,
+            sessionName = "work",
+            startDirectory = "/home/alex/git/pocketshell",
+            trigger = TmuxConnectTrigger.OpenExisting,
+        )
+        advanceUntilIdle()
+        staleCollector.cancel()
+
+        assertTrue(
+            "a transient probe error must NOT broadcast a stale-session signal, got $staleEvents",
+            staleEvents.isEmpty(),
+        )
+        assertTrue(
+            "a transient probe error must fail OPEN to attach-or-create (createIfMissing=true)",
+            vm.lastCreateIfMissingForTest(),
+        )
+        assertTrue(
+            "a fail-open OpenExisting tap must reach Connected, got ${vm.connectionStatus.value}",
+            vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected,
         )
     }
 
@@ -1198,6 +1487,11 @@ class TmuxSessionWarmOpenTest {
         // (with a non-zero exit) to drive the REAL [RealTmuxClient] reattach
         // preflight into [TmuxServerDeadException].
         private val hasSessionStderr: String = "",
+        // Issue #1155 (Part B): make the `tmux has-session` existence probe THROW
+        // (a transport hiccup) so the OpenExisting/ColdRestore preflight takes its
+        // fail-OPEN branch — a transient error must NOT be treated as confirmed-gone
+        // and must NOT raise a recreate prompt.
+        private val hasSessionThrows: Boolean = false,
     ) : SshSession {
         @Volatile
         var closed: Boolean = false
@@ -1210,6 +1504,9 @@ class TmuxSessionWarmOpenTest {
         override suspend fun exec(command: String): ExecResult {
             execCommands.add(command)
             if (command.startsWith("tmux has-session")) {
+                if (hasSessionThrows) {
+                    throw java.io.IOException("has-session probe transport hiccup (transient)")
+                }
                 return ExecResult(
                     stdout = "",
                     stderr = hasSessionStderr,


### PR DESCRIPTION
Closes #1155 (maintainer reopen). Closes #666. Cold-restore into a session killed on the host silently created an empty session. The #1155 Part-B prompt existed but was delivered only through the folder tree's VM (dead on cold-restore). Fix: a process-wide `StaleSessionPromptController` (subscribed from `MainActivity`) shows one app-level dialog — **Create session** (routes through the real create-in-folder gateway, id-independent so it always creates) + **Go to home** (popToHostList). Tree-only machinery removed (single owner, no double dialog).

Reviewer verified on-device (4/4 connected E2E): dialog shows on cold-restore, go-home → HostList, create → fresh session in the stale folder (both cold-restore + OpenExisting paths), no resurrection. 11 JVM tests. D33 adjudication: the null-id 'create no-op' edge is covered by construction (onConfirm is id-independent), genuinely unconstructable otherwise. Handler-level, D28-safe. Orchestrator gate green.