### PR TITLE
sessions: cold-restore stale-session prompt (recreate + go-home) delivered app-wide (#1155)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/ColdRestoreGoneSessionNoResurrectE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/ColdRestoreGoneSessionNoResurrectE2eTest.kt
@@ -17,7 +17,9 @@ import com.pocketshell.app.MainActivity
 import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
 import com.pocketshell.app.hosts.SshKeyStorage
 import com.pocketshell.app.projects.FOLDER_LIST_LOADING_TAG
+import com.pocketshell.app.projects.STALE_SESSION_CONFIRM_TAG
 import com.pocketshell.app.projects.STALE_SESSION_DIALOG_TAG
+import com.pocketshell.app.projects.STALE_SESSION_GO_HOME_TAG
 import com.pocketshell.app.testaccess.TestAccessEntryPoint
 import com.pocketshell.app.tmux.StaleSession
 import com.pocketshell.app.tmux.TMUX_SESSION_SCREEN_TAG
@@ -396,6 +398,89 @@ class ColdRestoreGoneSessionNoResurrectE2eTest {
     } }
 
     /**
+     * Issue #1155 REOPEN (2026-07-03) — the maintainer's exact dogfood path. Open
+     * a session, kill it on the computer, then 1–2 hours later just OPEN
+     * PocketShell so it COLD-RESTORES straight onto that previous session. Part B
+     * only wired the recovery dialog into the folder tree, which is never opened on
+     * this path, so the prompt was silently lost and an empty session was created.
+     *
+     * This is the delivery reproduction: it drives the SAME attach → background →
+     * kill-externally → recreate/cold-restore journey as
+     * [coldRestoreToKilledSessionDoesNotRecreateAndLandsOnList], but asserts the
+     * user actually SEES the app-level "This session no longer exists — create in
+     * this folder, or go home?" recovery DIALOG (with the "Go to home" action), and
+     * that the session was NOT resurrected server-side. On base (tree-only owner)
+     * the dialog never appears on cold restore — this fails; with the app-level
+     * [com.pocketshell.app.tmux.StaleSessionPromptController] it appears.
+     */
+    @Test
+    fun coldRestoreToGoneSessionShowsRecreateDialogWithGoHome() { runBlocking {
+        val key = fixtureKey
+
+        // ---- Attach to the seeded session via the normal journey.
+        waitForHostRowPresent(hostRowTag)
+        compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick()
+        waitForText(SEEDED_SESSION, timeoutMs = 20_000)
+        compose.onNodeWithText(SEEDED_SESSION).performClick()
+        compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertExists()
+
+        // ---- Background -> persist last session, then kill it on the server.
+        compose.activityRule.scenario.moveToState(Lifecycle.State.CREATED)
+        delay(LIFECYCLE_DRAIN_MS)
+        killRemoteSession(key)
+        assertTrue("session must be gone on the server after kill", !sessionAlive(key))
+
+        // ---- Cold-restore into the gone session (savedInstanceState != null).
+        compose.activityRule.scenario.recreate()
+        compose.activityRule.scenario.moveToState(Lifecycle.State.RESUMED)
+
+        // ---- The app-level recovery DIALOG must appear (with the go-home action).
+        compose.waitUntil(timeoutMillis = RESTORE_TIMEOUT_MS) {
+            runCatching {
+                compose.onAllNodesWithTag(STALE_SESSION_DIALOG_TAG, useUnmergedTree = true)
+                    .fetchSemanticsNodes()
+                    .isNotEmpty()
+            }.getOrDefault(false)
+        }
+        val dialogShown = compose
+            .onAllNodesWithTag(STALE_SESSION_DIALOG_TAG, useUnmergedTree = true)
+            .fetchSemanticsNodes()
+            .isNotEmpty()
+        val goHomeShown = compose
+            .onAllNodesWithTag(STALE_SESSION_GO_HOME_TAG, useUnmergedTree = true)
+            .fetchSemanticsNodes()
+            .isNotEmpty()
+        val resurrected = sessionAlive(key)
+        writeText(
+            "cold-restore-recreate-dialog.txt",
+            buildString {
+                appendLine("restored_session=$SEEDED_SESSION")
+                appendLine("recreate_dialog_shown=$dialogShown")
+                appendLine("go_home_action_shown=$goHomeShown")
+                appendLine("session_resurrected_server_side=$resurrected")
+                appendLine("expected_recreate_dialog_shown=true")
+                appendLine("expected_go_home_action_shown=true")
+                appendLine("expected_session_resurrected=false")
+            },
+        )
+        assertTrue(
+            "REGRESSION (#1155 reopen): a cold restore onto a gone session must show " +
+                "the recovery dialog, not silently create an empty session",
+            dialogShown,
+        )
+        assertTrue(
+            "the cold-restore recovery dialog must offer a 'Go to home' action " +
+                "(there is no tree behind it on this path)",
+            goHomeShown,
+        )
+        assertTrue(
+            "a cold restore onto a gone session must NOT resurrect it server-side",
+            !resurrected,
+        )
+        Unit
+    } }
+
+    /**
      * Issue #1155 (Part B) blocker 3 — the maintainer's PRIMARY gesture. A NORMAL
      * TAP of a persisted session row whose tmux session was killed externally must
      * reach the "This session no longer exists — create a new session in this
@@ -463,6 +548,355 @@ class ColdRestoreGoneSessionNoResurrectE2eTest {
             "tapping a gone session must NOT resurrect it server-side (no silent " +
                 "`new-session -A`)",
             !resurrected,
+        )
+        Unit
+    } }
+
+    /**
+     * Issue #1155 REOPEN (2026-07-03) blocker 1 — the "Go to home" recovery ACTION.
+     * The sibling `coldRestoreToGoneSessionShowsRecreateDialogWithGoHome` only
+     * asserts the go-home BUTTON is present; nothing tapped it or proved it
+     * navigates. This drives the tap and asserts the app actually lands on the host
+     * list (`popToHostList()`).
+     *
+     * It uses the OpenExisting tap path deliberately: after the gone preflight the
+     * navigator `back()`s to the FOLDER TREE (not the host list), so the dialog
+     * sits over the folder tree and the host row is NOT yet visible. Tapping "Go to
+     * home" must then `popToHostList()` — the host row appears. If `popToHostList()`
+     * is dropped from the dialog's dismiss handler the app stays on the folder tree
+     * and the host row never appears → this test fails (red→green on the action).
+     */
+    @Test
+    fun goHomeTapOnStaleDialogReturnsToHostList() { runBlocking {
+        val key = fixtureKey
+
+        // ---- (1) host -> folder list; the seeded session row is present.
+        waitForHostRowPresent(hostRowTag)
+        compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick()
+        waitForText(SEEDED_SESSION, timeoutMs = 20_000)
+
+        // ---- (2) Kill the session server-side (external removal).
+        killRemoteSession(key)
+        assertTrue("session must be gone server-side after kill", !sessionAlive(key))
+
+        // ---- (3) TAP the still-shown persisted row -> OpenExisting preflight
+        // confirms gone -> back() to the folder tree + stale broadcast -> dialog.
+        compose.onNodeWithText(SEEDED_SESSION).performClick()
+        compose.waitUntil(timeoutMillis = RESTORE_TIMEOUT_MS) {
+            runCatching {
+                compose.onAllNodesWithTag(STALE_SESSION_DIALOG_TAG, useUnmergedTree = true)
+                    .fetchSemanticsNodes()
+                    .isNotEmpty()
+            }.getOrDefault(false)
+        }
+
+        // Sanity: the dialog sits over the FOLDER TREE, so the host row is NOT
+        // visible yet. This is what makes the go-home nav load-bearing — the app is
+        // not already on the host list.
+        val onHostListBeforeGoHome = onHostList(hostRowTag)
+
+        // ---- (4) TAP "Go to home" -> popToHostList().
+        compose.onNodeWithTag(STALE_SESSION_GO_HOME_TAG, useUnmergedTree = true).performClick()
+
+        // ---- The app must land on the host list, and the dialog is gone.
+        compose.waitUntil(timeoutMillis = RESTORE_TIMEOUT_MS) {
+            onHostList(hostRowTag) &&
+                compose.onAllNodesWithTag(STALE_SESSION_DIALOG_TAG, useUnmergedTree = true)
+                    .fetchSemanticsNodes()
+                    .isEmpty()
+        }
+        val landedOnHostList = onHostList(hostRowTag)
+        val dialogGone = compose
+            .onAllNodesWithTag(STALE_SESSION_DIALOG_TAG, useUnmergedTree = true)
+            .fetchSemanticsNodes()
+            .isEmpty()
+        writeText(
+            "go-home-tap-nav.txt",
+            buildString {
+                appendLine("on_host_list_before_go_home=$onHostListBeforeGoHome")
+                appendLine("landed_on_host_list_after_go_home=$landedOnHostList")
+                appendLine("dialog_dismissed=$dialogGone")
+                appendLine("expected_on_host_list_before_go_home=false")
+                appendLine("expected_landed_on_host_list_after_go_home=true")
+                appendLine("expected_dialog_dismissed=true")
+            },
+        )
+        assertTrue(
+            "precondition: the dialog must sit over the folder tree (NOT the host " +
+                "list) so the go-home navigation is actually exercised",
+            !onHostListBeforeGoHome,
+        )
+        assertTrue(
+            "REGRESSION (#1155 reopen): tapping 'Go to home' on the stale-session " +
+                "dialog must popToHostList() — the host list should be shown",
+            landedOnHostList,
+        )
+        assertTrue("the stale-session dialog must be dismissed after 'Go to home'", dialogGone)
+        Unit
+    } }
+
+    /**
+     * Issue #1155 REOPEN (2026-07-03) blocker 2 — the "Create session" recovery
+     * ACTION. The sibling `openExistingTapOfGoneSessionShowsRecreateDialog` only
+     * asserts the dialog appears; nothing tapped "Create session" or proved a fresh
+     * session is created in the gone session's folder. This drives the tap and
+     * asserts:
+     *
+     *  - a fresh tmux session with the gone session's name is created server-side
+     *    (it was killed; after the tap `tmux has-session` succeeds again), and
+     *  - it is created in the STALE session's FOLDER — the recreated session's
+     *    `pane_current_path` equals the exact `folderPath` the app broadcast on the
+     *    production [SessionLifecycleSignals] stale signal (resolved to the host
+     *    home dir when that folder is null/blank), proving the `-c <folder>` routing
+     *    of `startDirectory = stalePrompt.folderPath`.
+     *
+     * It uses the OpenExisting tap path deliberately: after the gone preflight the
+     * navigator `back()`s to the FOLDER TREE, so the recovery dialog sits over the
+     * tree (not the session screen). Tapping "Create session" must then navigate to
+     * a FRESH session and create it in the folder. If the recreate lambda is broken
+     * (e.g. it drops to the list instead of navigating, or fails to pass the
+     * folder), no session is created / it lands in the wrong dir → this test fails
+     * (red→green on the action).
+     */
+    @Test
+    fun createSessionTapOnStaleDialogRecreatesInStaleFolder() { runBlocking {
+        val key = fixtureKey
+
+        // Subscribe to the production stale-session signal to capture the EXACT
+        // folder the app will recreate into (the `-c <folder>` under test).
+        val ctx = InstrumentationRegistry.getInstrumentation().targetContext
+        val entryPoint = EntryPointAccessors
+            .fromApplication(ctx, TestAccessEntryPoint::class.java)
+        val staleEvents = java.util.Collections.synchronizedList(mutableListOf<StaleSession>())
+        val collectorScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        collectorScope.launch {
+            entryPoint.sessionLifecycleSignals().staleSessions.collect { staleEvents.add(it) }
+        }
+        delay(LIFECYCLE_DRAIN_MS)
+
+        // ---- (1) host -> folder list; the seeded session row is present.
+        waitForHostRowPresent(hostRowTag)
+        compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick()
+        waitForText(SEEDED_SESSION, timeoutMs = 20_000)
+
+        // ---- (2) Kill the session server-side (external removal).
+        killRemoteSession(key)
+        assertTrue("session must be gone server-side after kill", !sessionAlive(key))
+
+        // ---- (3) TAP the still-shown persisted row -> OpenExisting preflight
+        // confirms gone -> back() to the folder tree + stale broadcast -> dialog.
+        compose.onNodeWithText(SEEDED_SESSION).performClick()
+        compose.waitUntil(timeoutMillis = RESTORE_TIMEOUT_MS) {
+            runCatching {
+                compose.onAllNodesWithTag(STALE_SESSION_DIALOG_TAG, useUnmergedTree = true)
+                    .fetchSemanticsNodes()
+                    .isNotEmpty()
+            }.getOrDefault(false)
+        }
+        assertTrue("session must still be gone before Create is tapped", !sessionAlive(key))
+
+        // The exact folder the production code will recreate into (== the
+        // StaleSessionPromptController prompt's folderPath).
+        val staleFolder = synchronized(staleEvents) {
+            staleEvents.firstOrNull { it.sessionName == SEEDED_SESSION }?.folderPath
+        }
+        collectorScope.coroutineContext[kotlinx.coroutines.Job]?.cancel()
+
+        // ---- TAP "Create session" -> recreate a fresh session in the SAME folder.
+        compose.onNodeWithTag(STALE_SESSION_CONFIRM_TAG, useUnmergedTree = true).performClick()
+
+        // The recreate lambda must NAVIGATE to a fresh session screen (base != null,
+        // so it takes the navigate branch, not the go-home fallback). If the session
+        // screen never appears the recreate lambda didn't fire at all.
+        compose.waitUntil(timeoutMillis = CREATE_TIMEOUT_MS) {
+            runCatching {
+                compose.onAllNodesWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true)
+                    .fetchSemanticsNodes()
+                    .isNotEmpty()
+            }.getOrDefault(false)
+        }
+        val sessionScreenShown = compose
+            .onAllNodesWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true)
+            .fetchSemanticsNodes()
+            .isNotEmpty()
+
+        // ---- The recreate must create a fresh session server-side. Poll until the
+        // new session exists (the UserTap connect runs `new-session -A -c <folder>`);
+        // a fresh SSH connect + attach + create can take a while on a cold emulator.
+        var recreated = false
+        val deadline = SystemClock.elapsedRealtime() + CREATE_TIMEOUT_MS
+        while (SystemClock.elapsedRealtime() < deadline) {
+            if (sessionAlive(key)) { recreated = true; break }
+            delay(500)
+        }
+
+        // ---- Folder routing: the recreated session's working directory must equal
+        // the stale folder the app broadcast (null/blank -> host home dir).
+        val expectedPath = canonicalRemotePath(resolveExpectedFolder(key, staleFolder))
+        val recreatedPath = if (recreated) canonicalRemotePath(sessionCurrentPath(key)) else null
+        writeText(
+            "create-session-tap-recreate.txt",
+            buildString {
+                appendLine("stale_session=$SEEDED_SESSION")
+                appendLine("broadcast_folder_path=$staleFolder")
+                appendLine("session_screen_shown_after_create_tap=$sessionScreenShown")
+                appendLine("session_recreated_after_create_tap=$recreated")
+                appendLine("expected_recreated_folder=$expectedPath")
+                appendLine("actual_recreated_folder=$recreatedPath")
+                appendLine("expected_session_screen_shown=true")
+                appendLine("expected_session_recreated=true")
+            },
+        )
+        assertTrue(
+            "tapping 'Create session' must NAVIGATE to a fresh session screen " +
+                "(the recreate branch fired, not the go-home fallback)",
+            sessionScreenShown,
+        )
+        assertTrue(
+            "REGRESSION (#1155 reopen): tapping 'Create session' must recreate the " +
+                "gone session `$SEEDED_SESSION` server-side; has-session still fails",
+            recreated,
+        )
+        assertEquals(
+            "the recreated session must be created in the STALE session's folder " +
+                "(-c <folder> routing of startDirectory = stalePrompt.folderPath)",
+            expectedPath,
+            recreatedPath,
+        )
+        Unit
+    } }
+
+    /**
+     * Issue #1155 REOPEN (2026-07-03) blocker 2 on the COLD-RESTORE path — the
+     * maintainer's exact dogfood gesture for "Create session".
+     *
+     * The sibling [createSessionTapOnStaleDialogRecreatesInStaleFolder] proves the
+     * "Create session" action on the in-tree OpenExisting path; this drives the SAME
+     * recovery through the real cold-restore journey (attach → background → kill
+     * externally → recreate/cold-restore → recovery dialog → tap "Create session")
+     * and asserts the recovery actually recovers: a FRESH session with the gone name
+     * is created server-side IN the stale folder (its `pane_current_path` equals the
+     * broadcast `folderPath`) and the session screen is shown, not a blank.
+     *
+     * The recovery routes through the gateway create-in-folder path
+     * ([StaleSessionPromptController.createSessionInFolder] →
+     * `tmux create-detached` / `new-session -A -c <folder>`), so the create is
+     * deterministic regardless of the navigate outcome — it does NOT depend on the
+     * connect path's `new-session -A`, which the cold-restore `ColdRestore` trigger
+     * refuses to run (the #666 no-resurrect guard). That guard is precisely why a
+     * plain `navigate` back to the (dead) cold-restore destination — which the
+     * screen re-classifies as `ColdRestore` whenever the recovery destination equals
+     * `restoredTmuxDestination` (a persisted session with no `tmuxSessionId`) — was a
+     * silent NO-OP; the gateway create sidesteps it.
+     */
+    @Test
+    fun createSessionTapOnStaleDialogRecreatesInStaleFolderOnColdRestore() { runBlocking {
+        val key = fixtureKey
+        val ctx = InstrumentationRegistry.getInstrumentation().targetContext
+        val entryPoint = EntryPointAccessors
+            .fromApplication(ctx, TestAccessEntryPoint::class.java)
+
+        // Capture the EXACT folder the app will recreate into (== the broadcast
+        // stale folderPath == the restored startDirectory) so the `-c <folder>`
+        // routing can be asserted.
+        val staleEvents = java.util.Collections.synchronizedList(mutableListOf<StaleSession>())
+        val collectorScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        collectorScope.launch {
+            entryPoint.sessionLifecycleSignals().staleSessions.collect { staleEvents.add(it) }
+        }
+        delay(LIFECYCLE_DRAIN_MS)
+
+        // ---- (1) Attach to the seeded session via the normal journey.
+        waitForHostRowPresent(hostRowTag)
+        compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick()
+        waitForText(SEEDED_SESSION, timeoutMs = 20_000)
+        compose.onNodeWithText(SEEDED_SESSION).performClick()
+        compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertExists()
+
+        // ---- (2) Background -> onStop persists the last session (#177).
+        compose.activityRule.scenario.moveToState(Lifecycle.State.CREATED)
+        delay(LIFECYCLE_DRAIN_MS)
+
+        // ---- (3) Kill the session on the server. It is now GONE.
+        killRemoteSession(key)
+        assertTrue("session must be gone on the server after kill", !sessionAlive(key))
+
+        // ---- (4) Cold-restore into the gone session (savedInstanceState != null).
+        compose.activityRule.scenario.recreate()
+        compose.activityRule.scenario.moveToState(Lifecycle.State.RESUMED)
+
+        // ---- (5) The app-level recovery dialog must appear.
+        compose.waitUntil(timeoutMillis = RESTORE_TIMEOUT_MS) {
+            runCatching {
+                compose.onAllNodesWithTag(STALE_SESSION_DIALOG_TAG, useUnmergedTree = true)
+                    .fetchSemanticsNodes()
+                    .isNotEmpty()
+            }.getOrDefault(false)
+        }
+        assertTrue("session must still be gone before Create is tapped", !sessionAlive(key))
+
+        val staleFolder = synchronized(staleEvents) {
+            staleEvents.firstOrNull { it.sessionName == SEEDED_SESSION }?.folderPath
+        }
+        collectorScope.coroutineContext[kotlinx.coroutines.Job]?.cancel()
+
+        // ---- (6) TAP "Create session" -> recreate a fresh session in the SAME folder.
+        compose.onNodeWithTag(STALE_SESSION_CONFIRM_TAG, useUnmergedTree = true).performClick()
+
+        // The recovery must NAVIGATE to a fresh session screen (attaches to the
+        // just-created session). If it re-enters the dead ColdRestore destination,
+        // the screen never attaches and no session is created.
+        compose.waitUntil(timeoutMillis = CREATE_TIMEOUT_MS) {
+            runCatching {
+                compose.onAllNodesWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true)
+                    .fetchSemanticsNodes()
+                    .isNotEmpty()
+            }.getOrDefault(false)
+        }
+        val sessionScreenShown = compose
+            .onAllNodesWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true)
+            .fetchSemanticsNodes()
+            .isNotEmpty()
+
+        // ---- (7) The recreate must create a fresh session server-side.
+        var recreated = false
+        val deadline = SystemClock.elapsedRealtime() + CREATE_TIMEOUT_MS
+        while (SystemClock.elapsedRealtime() < deadline) {
+            if (sessionAlive(key)) { recreated = true; break }
+            delay(500)
+        }
+
+        // ---- Folder routing: the recreated session's cwd must equal the stale folder.
+        val expectedPath = canonicalRemotePath(resolveExpectedFolder(key, staleFolder))
+        val recreatedPath = if (recreated) canonicalRemotePath(sessionCurrentPath(key)) else null
+        writeText(
+            "cold-restore-create-session-tap-recreate.txt",
+            buildString {
+                appendLine("stale_session=$SEEDED_SESSION")
+                appendLine("broadcast_folder_path=$staleFolder")
+                appendLine("session_screen_shown_after_create_tap=$sessionScreenShown")
+                appendLine("session_recreated_after_create_tap=$recreated")
+                appendLine("expected_recreated_folder=$expectedPath")
+                appendLine("actual_recreated_folder=$recreatedPath")
+                appendLine("expected_session_screen_shown=true")
+                appendLine("expected_session_recreated=true")
+            },
+        )
+        assertTrue(
+            "tapping 'Create session' on the COLD-RESTORE stale dialog must NAVIGATE " +
+                "to a fresh session screen (the recreate fired, not a ColdRestore no-op)",
+            sessionScreenShown,
+        )
+        assertTrue(
+            "REGRESSION (#1155 reopen): tapping 'Create session' on cold restore must " +
+                "recreate the gone session `$SEEDED_SESSION` server-side; has-session still fails",
+            recreated,
+        )
+        assertEquals(
+            "the cold-restore recreate must create in the STALE session's folder " +
+                "(-c <folder> routing of the broadcast folderPath)",
+            expectedPath,
+            recreatedPath,
         )
         Unit
     } }
@@ -622,6 +1056,37 @@ class ColdRestoreGoneSessionNoResurrectE2eTest {
         return exec?.stdout?.contains("ALIVE") == true
     }
 
+    /** The working directory (`pane_current_path`) of the seeded session, or "". */
+    private suspend fun sessionCurrentPath(key: String): String {
+        val exec = runScript(
+            key,
+            "tmux display-message -p -t ${shellQuote(SEEDED_SESSION)} '#{pane_current_path}' 2>/dev/null",
+        )
+        return exec?.stdout?.trim().orEmpty()
+    }
+
+    /**
+     * The directory a recreate with [staleFolder] must land in: the folder itself
+     * when the app broadcast one, else the host home dir (a null/blank folderPath
+     * recreates with no `-c`, so `new-session -A` lands in `$HOME`).
+     */
+    private suspend fun resolveExpectedFolder(key: String, staleFolder: String?): String {
+        val folder = staleFolder?.trim().orEmpty()
+        if (folder.isNotEmpty() && folder != "~") return folder
+        val home = runScript(key, "printf %s \"\$HOME\"")?.stdout?.trim().orEmpty()
+        return home.ifEmpty { folder }
+    }
+
+    /**
+     * Resolve a remote path to its canonical form so the recreate assertion is not
+     * defeated by a symlinked home (`/home/x` vs `/root` vs a `realpath`ed cwd).
+     */
+    private suspend fun canonicalRemotePath(path: String): String {
+        if (path.isBlank()) return path
+        val exec = runScript(key = fixtureKey, script = "cd ${shellQuote(path)} 2>/dev/null && pwd -P || printf %s ${shellQuote(path)}")
+        return exec?.stdout?.trim()?.ifBlank { path } ?: path
+    }
+
     private suspend fun runScript(key: String, script: String) =
         SshConnection.connect(
             host = DEFAULT_HOST,
@@ -705,5 +1170,10 @@ class ColdRestoreGoneSessionNoResurrectE2eTest {
 
         const val LIFECYCLE_DRAIN_MS: Long = 750L
         const val RESTORE_TIMEOUT_MS: Long = 20_000L
+
+        // A fresh SSH connect + tmux attach + `new-session -A -c <folder>` after the
+        // recreate tap is slower than a restore probe (a brand-new connection, not a
+        // warm reattach), so the create-session recreate gets a longer window.
+        const val CREATE_TIMEOUT_MS: Long = 60_000L
     }
 }

--- a/app/src/main/java/com/pocketshell/app/MainActivity.kt
+++ b/app/src/main/java/com/pocketshell/app/MainActivity.kt
@@ -30,8 +30,10 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.core.view.WindowCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.fragment.app.FragmentActivity
@@ -60,6 +62,9 @@ import com.pocketshell.app.nav.AppDestination
 import com.pocketshell.app.portfwd.PortForwardPanelScreen
 import com.pocketshell.app.projects.FolderListScreen
 import com.pocketshell.app.projects.RepoBrowserScreen
+import com.pocketshell.app.projects.STALE_SESSION_CONFIRM_TAG
+import com.pocketshell.app.projects.STALE_SESSION_DIALOG_TAG
+import com.pocketshell.app.projects.STALE_SESSION_GO_HOME_TAG
 import com.pocketshell.app.projects.WatchedFoldersScreen
 import com.pocketshell.app.projects.WatchedFoldersViewModel
 import com.pocketshell.app.session.InlineDictationViewModel
@@ -85,6 +90,7 @@ import com.pocketshell.app.usage.UsageViewModel
 import com.pocketshell.core.storage.dao.HostDao
 import com.pocketshell.core.storage.dao.SshKeyDao
 import com.pocketshell.core.storage.entity.HostEntity
+import com.pocketshell.uikit.components.ConfirmDialog
 import com.pocketshell.uikit.theme.PocketShellTheme
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Dispatchers
@@ -190,6 +196,20 @@ class MainActivity : FragmentActivity() {
      */
     @Inject
     lateinit var sessionLifecycleSignals: SessionLifecycleSignals
+
+    /**
+     * Issue #1155 / #666: the APP-LEVEL owner of the "This session no longer
+     * exists — create in this folder, or go home?" recovery prompt. Injected here
+     * (so it is alive and subscribed to [SessionLifecycleSignals] from `onCreate`,
+     * long before any cold-restore connect emits) and observed inside
+     * [AppNavigator] to render a single app-level dialog. This surfaces the
+     * recovery prompt on the COLD-RESTORE path — the maintainer's dogfood scenario
+     * — where the folder tree was never opened, in addition to the in-tree
+     * OpenExisting tap.
+     */
+    @Inject
+    lateinit var staleSessionPromptController:
+        com.pocketshell.app.tmux.StaleSessionPromptController
 
     @Inject
     lateinit var startDirectoryAutocomplete: StartDirectoryAutocompleteRemoteSource
@@ -488,6 +508,10 @@ class MainActivity : FragmentActivity() {
                         // when a restored session is found gone, so the next
                         // foreground does not retry-and-resurrect it.
                         onClearLastSession = { lastSessionStore.clear() },
+                        // Issue #1155 / #666: the app-level recovery-prompt owner,
+                        // observed to render the single "create in this folder, or
+                        // go home?" dialog — including on the cold-restore path.
+                        staleSessionPromptController = staleSessionPromptController,
                     )
                 }
             }
@@ -820,6 +844,12 @@ private fun AppNavigator(
     // session is found gone on the server, so the next foreground does not
     // retry-and-resurrect it. Wired by the activity to [LastSessionStore.clear].
     onClearLastSession: () -> Unit = {},
+    // Issue #1155 / #666: the app-level "This session no longer exists" recovery
+    // prompt owner. Observed here to render ONE app-level dialog (create in this
+    // folder OR go home) so the prompt also surfaces on the cold-restore path,
+    // where the folder tree was never opened. Null in previews/tests that do not
+    // exercise the recovery dialog.
+    staleSessionPromptController: com.pocketshell.app.tmux.StaleSessionPromptController? = null,
 ) {
     // Issue #129: the activity scrapes the import payload out of a
     // `pocketshell://import?...` deep link before composition starts
@@ -851,6 +881,19 @@ private fun AppNavigator(
             "current" to current.timingName(),
             "requestedDestination" to requestedDestination.timingName(),
         )
+    }
+
+    // Issue #1155 / #666: remember the LAST tmux-session destination the app
+    // connected to — it carries every SSH connection field needed to recreate a
+    // fresh session in the gone session's folder from the app-level recovery
+    // dialog. Seeded with the cold-restore target so "Create session" works even
+    // when the app process-restored straight onto the (now gone) session and the
+    // folder tree was never opened. Updated as the user opens other sessions.
+    var lastTmuxDestination: AppDestination.TmuxSession? by remember {
+        mutableStateOf(restoredTmuxDestination)
+    }
+    LaunchedEffect(current) {
+        (current as? AppDestination.TmuxSession)?.let { lastTmuxDestination = it }
     }
 
     // Issue #177: report the current top destination up to the activity
@@ -1684,6 +1727,107 @@ private fun AppNavigator(
         )
     }
     }
+
+    // Issue #1155 / #666: the SINGLE app-level "This session no longer exists"
+    // recovery dialog. The connection core refuses to resurrect a gone session
+    // (the #666 `tmux has-session` preflight in TmuxSessionViewModel) and
+    // broadcasts a StaleSession; this controller — subscribed process-wide from
+    // onCreate — holds the latest one, so the dialog appears REGARDLESS of which
+    // screen the app is on, including the cold-restore path where the folder tree
+    // was never opened (the maintainer's dogfood scenario). Two recoveries, per
+    // the reopen: recreate a fresh session in the SAME folder, or go to the host
+    // list ("go home"). A stale broadcast only ever fires for a genuinely-gone
+    // session (never a transient reconnect blip), so this never appears spuriously.
+    val recoveryScope = rememberCoroutineScope()
+    val stalePrompt = staleSessionPromptController?.prompt?.collectAsState()?.value
+    if (stalePrompt != null) {
+        val base = lastTmuxDestination?.takeIf { it.hostId == stalePrompt.hostId }
+        ConfirmDialog(
+            title = "This session no longer exists",
+            message = "The session “${stalePrompt.sessionName}” is gone on the host. " +
+                "Create a new session in “${staleSessionFolderLabel(stalePrompt.folderPath)}”, " +
+                "or go to the home screen?",
+            confirmLabel = "Create session",
+            dismissLabel = "Go to home",
+            destructive = false,
+            onConfirm = {
+                staleSessionPromptController.clear()
+                if (base != null) {
+                    // Issue #1155 REOPEN (2026-07-03): recreate a FRESH session in
+                    // the gone session's folder through the REAL create-in-folder
+                    // gateway path (`tmux create-detached` / `new-session -A -c`),
+                    // then attach to the now-existing session. We do NOT just
+                    // re-navigate to `base.copy(...)`: on the cold-restore path that
+                    // destination equals `restoredTmuxDestination`, so the screen
+                    // classifies it as [TmuxConnectTrigger.ColdRestore] whose
+                    // `has-session` preflight REFUSES to create the gone session (the
+                    // #666 no-resurrect guard) — making the recreate a silent no-op.
+                    // Creating server-side first makes the recovery deterministic on
+                    // BOTH the cold-restore and the in-tree OpenExisting path.
+                    recoveryScope.launch {
+                        val resolvedName = staleSessionPromptController
+                            .createSessionInFolder(
+                                hostId = stalePrompt.hostId,
+                                keyPath = base.keyPath,
+                                passphrase = base.passphrase,
+                                sessionName = stalePrompt.sessionName,
+                                folderPath = stalePrompt.folderPath,
+                            )
+                            .getOrElse {
+                                // Create exec failed (host briefly unreachable): fall
+                                // back to the session name we intended so the attach
+                                // path can still `new-session -A` it, and never leave
+                                // the user stuck on the dialog-less blank.
+                                stalePrompt.sessionName
+                            }
+                        // Attach to the freshly-created session. `openExisting = true`
+                        // makes this destination DISTINCT from the cold-restore
+                        // destination (which is `openExisting = false`), so it is
+                        // never re-classified as ColdRestore; its OpenExisting
+                        // preflight now finds the session ALIVE (we just created it)
+                        // and attaches instead of dropping back to the list.
+                        navigate(
+                            base.copy(
+                                sessionName = resolvedName,
+                                startDirectory = stalePrompt.folderPath,
+                                initialWindowIndex = null,
+                                tmuxSessionId = null,
+                                sessionCreated = null,
+                                openExisting = true,
+                            ),
+                        )
+                    }
+                } else {
+                    // No connection details to rebuild from — recover to the list.
+                    popToHostList()
+                }
+            },
+            onDismiss = {
+                // "Go to home" (and scrim/back): drop to the host list.
+                staleSessionPromptController.clear()
+                popToHostList()
+            },
+            modifier = Modifier.testTag(STALE_SESSION_DIALOG_TAG),
+            confirmTestTag = STALE_SESSION_CONFIRM_TAG,
+            dismissTestTag = STALE_SESSION_GO_HOME_TAG,
+        )
+    }
+}
+
+/**
+ * Issue #1155: the short folder label shown in the recovery dialog for a gone
+ * session's working directory. Mirrors `FolderListViewModel.defaultLabelForPath`
+ * for the app-level dialog: the trailing path segment, or "home" for a null /
+ * blank / `~` folder so the message always reads sensibly.
+ */
+internal fun staleSessionFolderLabel(folderPath: String?): String {
+    val clean = folderPath?.trim().orEmpty()
+    if (clean.isEmpty()) return "home"
+    val stripped = clean.trimEnd('/')
+    if (stripped.isEmpty()) return "/"
+    if (stripped == "~" || stripped == "\$HOME") return "home"
+    val tail = stripped.substringAfterLast('/')
+    return tail.ifBlank { stripped }
 }
 
 /**

--- a/app/src/main/java/com/pocketshell/app/projects/FolderListScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListScreen.kt
@@ -236,10 +236,11 @@ fun FolderListScreen(
     }
     val state by viewModel.state.collectAsState()
     val actionStatus by viewModel.actionStatus.collectAsState()
-    // Issue #1155 (Part B): a persisted session the user tried to open was
-    // confirmed genuinely gone on attach — surface the "create a new session in
-    // this folder?" recovery prompt (not a blank list).
-    val staleSessionPrompt by viewModel.staleSessionPrompt.collectAsState()
+    // Issue #1155: the "this session no longer exists" recovery prompt is now
+    // owned app-level by `MainActivity` (via `StaleSessionPromptController`) so
+    // it surfaces on the cold-restore path too, not only an in-tree tap. The
+    // folder tree still drops the confirmed-gone row from its list for accuracy
+    // (FolderListViewModel.onStaleSession), it just no longer raises the dialog.
     // Issue #885: passive host-CLI-version mismatch, detected from the regular
     // `pocketshell tree` payload on every host open — surfaced as a dismissible
     // update prompt (NOT a slow blocking on-open `--version` wait).
@@ -628,22 +629,6 @@ fun FolderListScreen(
         )
     }
 
-    // Issue #1155 (Part B): a persisted session the user opened was confirmed
-    // genuinely gone on attach — offer to recreate it in the SAME folder in one
-    // tap instead of leaving the user on a blank list.
-    staleSessionPrompt?.let { prompt ->
-        StaleSessionRecreateDialog(
-            prompt = prompt,
-            onDismiss = { viewModel.dismissStaleSessionPrompt() },
-            onConfirm = {
-                viewModel.confirmRecreateStaleSession(
-                    onResolved = { resolved ->
-                        onSessionCreated(resolved, prompt.folderPath ?: "~")
-                    },
-                )
-            },
-        )
-    }
 }
 
 private data class PickerTarget(
@@ -3004,33 +2989,6 @@ private fun StopSessionDialog(
     )
 }
 
-/**
- * Issue #1155 (Part B): the "this session no longer exists — create a new
- * session in this folder?" recovery dialog. Shown when a persisted session the
- * user opened was confirmed genuinely gone on attach. Confirming recreates a
- * session in the SAME folder ([FolderListViewModel.confirmRecreateStaleSession]);
- * dismissing leaves the (accurate) tree list in place. NOT destructive — it is a
- * one-tap recovery, so the confirm is the primary action.
- */
-@Composable
-private fun StaleSessionRecreateDialog(
-    prompt: StaleSessionRecreatePrompt,
-    onDismiss: () -> Unit,
-    onConfirm: () -> Unit,
-) {
-    ConfirmDialog(
-        title = "This session no longer exists",
-        message = "The session “${prompt.sessionName}” is gone on the host. " +
-            "Create a new session in “${prompt.folderLabel}”?",
-        confirmLabel = "Create session",
-        onConfirm = onConfirm,
-        onDismiss = onDismiss,
-        destructive = false,
-        modifier = Modifier.testTag(STALE_SESSION_DIALOG_TAG),
-        confirmTestTag = STALE_SESSION_CONFIRM_TAG,
-        dismissTestTag = STALE_SESSION_CANCEL_TAG,
-    )
-}
 
 private val FolderListBottomContentPadding = 12.dp
 
@@ -3097,11 +3055,14 @@ const val RENAME_SESSION_FIELD_TAG: String = "folder-list:rename-session:field"
 const val RENAME_SESSION_CONFIRM_TAG: String = "folder-list:rename-session:confirm"
 const val RENAME_SESSION_CANCEL_TAG: String = "folder-list:rename-session:cancel"
 
-// Issue #1155 (Part B) — "this session no longer exists, create a new one in
-// this folder?" recovery prompt.
+// Issue #1155 — "this session no longer exists, create a new one in this
+// folder, or go home?" recovery prompt. Owned app-level by `MainActivity`
+// (via `StaleSessionPromptController`) so it also surfaces on the cold-restore
+// path where the folder tree was never opened. Tags kept in this package so the
+// existing connected E2E imports resolve unchanged.
 const val STALE_SESSION_DIALOG_TAG: String = "folder-list:stale-session:dialog"
 const val STALE_SESSION_CONFIRM_TAG: String = "folder-list:stale-session:confirm"
-const val STALE_SESSION_CANCEL_TAG: String = "folder-list:stale-session:cancel"
+const val STALE_SESSION_GO_HOME_TAG: String = "folder-list:stale-session:go-home"
 
 fun folderRowTestTag(path: String): String = "folder-list:row:$path"
 fun folderHeaderClickTestTag(path: String): String = "folder-list:header-click:$path"

--- a/app/src/main/java/com/pocketshell/app/projects/FolderListViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListViewModel.kt
@@ -227,26 +227,6 @@ sealed interface FolderListUiState {
 }
 
 /**
- * Issue #1155 (Part B): a live "This session no longer exists — create a new
- * session in this folder?" recovery prompt, raised when a persisted session the
- * user tried to open was confirmed GENUINELY GONE on attach (absent tmux
- * session, not a transient reconnect). Confirming reuses the SAME folder's
- * create-session path so the user recovers in one tap; dismissing clears it.
- *
- * @property sessionName the gone session's name (also its `tmux new-session -A`
- *   name for the same folder, so recreating with it reproduces the same slot).
- * @property folderPath the gone session's working directory — the folder the
- *   recreate happens in. `null` when the gone session carried no known start
- *   directory (the recreate then falls back to the host home directory).
- * @property folderLabel a short human label for the folder, for the prompt copy.
- */
-data class StaleSessionRecreatePrompt(
-    val sessionName: String,
-    val folderPath: String?,
-    val folderLabel: String,
-)
-
-/**
  * Host-detail action feedback surface (#656).
  *
  * For a routine **success** there is deliberately no final status state at all
@@ -534,20 +514,6 @@ class FolderListViewModel internal constructor(
     private val _actionStatus: MutableStateFlow<FolderActionStatus> =
         MutableStateFlow(FolderActionStatus.Idle)
     val actionStatus: StateFlow<FolderActionStatus> = _actionStatus.asStateFlow()
-
-    /**
-     * Issue #1155 (Part B): non-null when a persisted session the user tried to
-     * open was confirmed GENUINELY GONE on attach (an absent tmux session, not a
-     * transient reconnect blip — see [SessionLifecycleSignals.emitStaleSession]).
-     * The FolderList surfaces it as a "This session no longer exists — create a
-     * new session in this folder?" prompt; confirming reuses the SAME folder's
-     * create-session path ([confirmRecreateStaleSession]), dismissing clears it
-     * ([dismissStaleSessionPrompt]). `null` while there is nothing to recover.
-     */
-    private val _staleSessionPrompt: MutableStateFlow<StaleSessionRecreatePrompt?> =
-        MutableStateFlow(null)
-    val staleSessionPrompt: StateFlow<StaleSessionRecreatePrompt?> =
-        _staleSessionPrompt.asStateFlow()
 
     /**
      * Issue #885: passive host-CLI-version mismatch, detected from the
@@ -1097,55 +1063,28 @@ class FolderListViewModel internal constructor(
     }
 
     /**
-     * Issue #1155 (Part B): handle a persisted-but-GENUINELY-GONE session
-     * broadcast from the per-session screen ([SessionLifecycleSignals.staleSessions]).
-     * The attach confirmed the tmux session is absent (`TmuxSessionNotFoundException`)
-     * — NOT a transient reconnect (those never emit this) — so instead of leaving
-     * the user on a blank list we raise the "create a new session in this folder?"
-     * recreate prompt for the SAME folder. Also drops the dead row from the held
-     * tree (it is confirmed gone), matching [onSessionKilled]. Ignores other hosts.
+     * Issue #1155: handle a persisted-but-GENUINELY-GONE session broadcast from
+     * the per-session screen ([SessionLifecycleSignals.staleSessions]). The attach
+     * confirmed the tmux session is absent (`TmuxSessionNotFoundException`) — NOT a
+     * transient reconnect (those never emit this) — so drop the dead row from the
+     * held tree (it is confirmed gone), matching [onSessionKilled], keeping the
+     * list accurate. Ignores other hosts.
+     *
+     * The user-facing "This session no longer exists — create in this folder, or
+     * go home?" recovery PROMPT is no longer raised here: it is owned app-level by
+     * `MainActivity` ([com.pocketshell.app.tmux.StaleSessionPromptController]) so
+     * it also surfaces on the cold-restore path where this view model never
+     * exists (the folder tree was never opened). This collector only keeps the
+     * tree it IS bound to accurate.
      */
     @androidx.annotation.VisibleForTesting
     internal fun onStaleSession(stale: com.pocketshell.app.tmux.StaleSession) {
         val params = bound ?: return
         if (params.hostId != stale.hostId) return
-        // The session is confirmed gone — drop its row from the maintained tree so
-        // the list the prompt sits over is already accurate.
+        // The session is confirmed gone — drop its row from the maintained tree.
         if (tree.removeSession(stale.sessionName)) {
             emitReady()
         }
-        _staleSessionPrompt.value = StaleSessionRecreatePrompt(
-            sessionName = stale.sessionName,
-            folderPath = stale.folderPath,
-            folderLabel = stale.folderPath
-                ?.let { defaultLabelForPath(canonicalisePath(it)) }
-                ?: "home",
-        )
-    }
-
-    /**
-     * Issue #1155 (Part B): confirm the recreate prompt — create a fresh session
-     * in the gone session's SAME folder (reusing the standard [createSession]
-     * create-in-folder path, `tmux new-session -A` semantics) and route to it via
-     * [onResolved]. A no-op when there is no active prompt. The gone session's name
-     * is reused (it maps to that folder), and a null folder falls back to the host
-     * home directory (`~`), so the user always recovers — never a blank/error.
-     */
-    fun confirmRecreateStaleSession(onResolved: (sessionName: String) -> Unit) {
-        val prompt = _staleSessionPrompt.value ?: return
-        _staleSessionPrompt.value = null
-        createSession(
-            sessionName = prompt.sessionName,
-            cwd = prompt.folderPath ?: "~",
-            startCommand = null,
-            chosenKind = null,
-            onResolved = onResolved,
-        )
-    }
-
-    /** Issue #1155 (Part B): dismiss the stale-session recreate prompt. */
-    fun dismissStaleSessionPrompt() {
-        _staleSessionPrompt.value = null
     }
 
     /**

--- a/app/src/main/java/com/pocketshell/app/tmux/StaleSessionPromptController.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/StaleSessionPromptController.kt
@@ -1,0 +1,181 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.app.projects.FolderListGateway
+import com.pocketshell.core.storage.dao.HostDao
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Issue #1155 / #666 — the APP-LEVEL owner of the "This session no longer
+ * exists" recovery prompt.
+ *
+ * ## Why an app-level owner (the reopen, 2026-07-03)
+ *
+ * Part B first wired the recreate prompt into the folder tree
+ * ([com.pocketshell.app.projects.FolderListViewModel]) only. That works for a
+ * NORMAL tap of a persisted session ROW ([TmuxConnectTrigger.OpenExisting]) —
+ * the user came FROM the tree, so its view model is still bound and collecting
+ * the no-replay [SessionLifecycleSignals.staleSessions] broadcast when the
+ * genuinely-gone attach fails.
+ *
+ * But the maintainer's dogfood path is a **cold restore**
+ * ([TmuxConnectTrigger.ColdRestore]): the app process-restores DIRECTLY onto the
+ * last session screen, so the folder tree was NEVER opened and its view model
+ * does not exist — nothing is subscribed to the no-replay stale broadcast, and
+ * the prompt was silently lost (the user just landed on the bare host list). The
+ * connection core already PROBES `tmux has-session` and refuses to resurrect a
+ * gone session (issue #666 preflight in [TmuxSessionViewModel]); the missing
+ * piece was surfacing the recovery prompt to the user on that path.
+ *
+ * This controller is a process-scoped [Singleton] that subscribes to the stale
+ * broadcast ONCE at construction (injected into `MainActivity`, so it is alive
+ * from `onCreate`, long before any cold-restore connect emits) and holds the
+ * latest gone session in a [StateFlow]. `MainActivity` renders a single
+ * app-level "Create a new session in this folder, or go home?" dialog off it, so
+ * the recovery prompt appears regardless of which screen the app restored onto —
+ * cold restore, an OpenExisting tap, whatever. One owner, one dialog (D22
+ * hard-cut): the folder tree no longer raises its own prompt (it still drops the
+ * confirmed-gone row from its list for accuracy).
+ *
+ * The stale broadcast only fires from the genuinely-gone attach-fail path
+ * (`TmuxSessionNotFoundException` → `failSessionEnded` → `emitStaleSession`); a
+ * transient reconnect blip rides the reconnect ladder and NEVER reaches it, so
+ * this prompt never appears on a mere network hiccup.
+ */
+@Singleton
+class StaleSessionPromptController internal constructor(
+    signals: SessionLifecycleSignals,
+    // Issue #1155 REOPEN (2026-07-03): the create-in-folder seam. The "Create
+    // session" recovery action creates a FRESH tmux session in the gone session's
+    // folder over the SAME gateway path the normal "new session in this folder"
+    // action uses (`tmux create-detached` / `new-session -A -c <folder>`), rather
+    // than re-navigating to the dead cold-restore destination — which the screen
+    // classifies as a [TmuxConnectTrigger.ColdRestore] whose `has-session`
+    // preflight then REFUSES to create (the #666 no-resurrect guard), so the
+    // recreate was a silent no-op on the cold-restore path. Routing through the
+    // gateway makes the create deterministic regardless of which screen the app
+    // restored onto. Null on the bare test constructor (which does not exercise
+    // the create).
+    private val gateway: FolderListGateway?,
+    private val hostDao: HostDao?,
+    private val ioDispatcher: CoroutineDispatcher,
+) {
+    /** Production Hilt entry point. */
+    @Inject
+    constructor(
+        signals: SessionLifecycleSignals,
+        gateway: FolderListGateway,
+        hostDao: HostDao,
+    ) : this(signals, gateway, hostDao, Dispatchers.IO)
+
+    /**
+     * Test convenience: the original signal-only constructor, for JVM tests that
+     * assert the prompt subscription/clear wiring without the create seam.
+     */
+    @androidx.annotation.VisibleForTesting
+    internal constructor(signals: SessionLifecycleSignals) :
+        this(signals, gateway = null, hostDao = null, ioDispatcher = Dispatchers.Unconfined)
+
+    // Main.immediate so the StateFlow flip lands on the same thread Compose
+    // reads it from; the subscription is established once at construction.
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+
+    private val _prompt = MutableStateFlow<StaleSession?>(null)
+
+    /**
+     * The most recent genuinely-gone session the user should be prompted to
+     * recreate (or leave via "go home"), or `null` when there is nothing to
+     * recover. `MainActivity` observes this and renders the app-level dialog.
+     */
+    val prompt: StateFlow<StaleSession?> = _prompt.asStateFlow()
+
+    init {
+        scope.launch {
+            signals.staleSessions.collect { _prompt.value = it }
+        }
+    }
+
+    /**
+     * Clear the active prompt — called once the user has resolved it (created a
+     * fresh session in the folder or gone home).
+     */
+    fun clear() {
+        _prompt.value = null
+    }
+
+    /**
+     * Issue #1155 REOPEN (2026-07-03): the "Create session" recovery action.
+     *
+     * Creates a FRESH tmux session named [sessionName] in [folderPath] over the
+     * SAME gateway create path the normal "new session in this folder" action
+     * uses ([FolderListGateway.createSession] → `tmux create-detached` /
+     * `new-session -A -c <folder>`), and returns the resolved session name.
+     *
+     * This is deliberately the GATEWAY path, NOT a re-navigate to the (now dead)
+     * cold-restore destination: on the cold-restore path the recovery navigate
+     * lands on a destination the screen classifies as [TmuxConnectTrigger.ColdRestore]
+     * (`dest == restoredTmuxDestination`), whose `has-session` preflight then
+     * REFUSES to create the gone session (the #666 no-resurrect guard) — so the
+     * recreate was a silent no-op. Creating the session server-side FIRST makes it
+     * deterministic; the caller then attaches to the now-existing session.
+     *
+     * [folderPath] is the gone session's working directory; a null/blank folder
+     * recreates in the host home directory (`~`), so the user always recovers —
+     * never a blank/error. Returns a failure when no create seam is wired (a bare
+     * test controller) or the host row / create exec fails.
+     */
+    suspend fun createSessionInFolder(
+        hostId: Long,
+        keyPath: String,
+        passphrase: CharArray?,
+        sessionName: String,
+        folderPath: String?,
+    ): Result<String> {
+        val gateway = this.gateway
+        val hostDao = this.hostDao
+        if (gateway == null || hostDao == null) {
+            return Result.failure(
+                IllegalStateException("StaleSessionPromptController has no create-session seam wired"),
+            )
+        }
+        val host = withContext(ioDispatcher) { hostDao.getById(hostId) }
+            ?: return Result.failure(IllegalStateException("Host $hostId not found for stale-session recreate"))
+        val cwd = folderPath?.trim()?.takeUnless { it.isEmpty() } ?: DEFAULT_RECREATE_START_DIRECTORY
+        return gateway.createSession(
+            host = host,
+            keyPath = keyPath,
+            passphrase = passphrase,
+            sessionName = sessionName,
+            cwd = cwd,
+            startCommand = null,
+        )
+    }
+
+    /**
+     * Test-only injection of a stale session, bypassing the signal subscription,
+     * for JVM tests that assert `MainActivity`'s dialog wiring off the [prompt]
+     * state without a live [SessionLifecycleSignals].
+     */
+    @androidx.annotation.VisibleForTesting
+    internal fun offerForTest(stale: StaleSession) {
+        _prompt.value = stale
+    }
+
+    private companion object {
+        /**
+         * Fallback create directory for a gone session with no known folder — the
+         * host home (`~`). Mirrors the folder create path's default so a
+         * null/blank-folder recovery still lands in a real directory.
+         */
+        const val DEFAULT_RECREATE_START_DIRECTORY: String = "~"
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelStaleSessionTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelStaleSessionTest.kt
@@ -22,8 +22,6 @@ import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -32,17 +30,19 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 /**
- * Issue #1155 (Part B): the folder tree's "This session no longer exists —
- * create a new session in this folder?" recovery prompt.
+ * Issue #1155: when a persisted session is confirmed GENUINELY GONE on attach
+ * ([SessionLifecycleSignals.staleSessions], emitted only from the
+ * `TmuxSessionNotFoundException` path — NOT a transient reconnect), the bound
+ * folder tree drops the dead row from its list so the list stays accurate.
  *
- * When a persisted session the user tried to open is confirmed GENUINELY GONE on
- * attach ([SessionLifecycleSignals.staleSessions], emitted only from the
- * `TmuxSessionNotFoundException` path — NOT a transient reconnect), the tree
- * raises a [StaleSessionRecreatePrompt] instead of leaving the user on a blank
- * list. Confirming reuses the SAME folder's create-session path; dismissing
- * clears it. The genuinely-gone-vs-transient distinction itself is proven on the
- * emitter side in `TmuxSessionWarmOpenTest`
+ * The USER-FACING "This session no longer exists — create in this folder, or go
+ * home?" recovery PROMPT is owned app-level by
+ * [com.pocketshell.app.tmux.StaleSessionPromptController] (so it also surfaces on
+ * the cold-restore path where this view model never exists), covered by
+ * `StaleSessionPromptControllerTest`; the genuinely-gone-vs-transient distinction
+ * is proven on the emitter side in `TmuxSessionWarmOpenTest`
  * (`goneSessionBroadcastsStaleSignal…` / `liveSessionDoesNotBroadcastStale…`).
+ * This test covers only the tree's row-accuracy behaviour.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)
@@ -61,10 +61,10 @@ class FolderListViewModelStaleSessionTest {
 
     private val goneFolder = "/home/alexey/git/pocketshell"
 
-    // ---- a genuinely-gone session raises the recreate prompt (bound host) -----
+    // ---- a genuinely-gone session drops its row from the bound tree -----------
 
     @Test
-    fun staleSessionRaisesRecreatePromptForBoundHost() = runTest {
+    fun staleSessionDropsDeadRowForBoundHost() = runTest {
         val signals = SessionLifecycleSignals()
         val gateway = StubGateway(listOf(sessionRow("git-pocketshell"), sessionRow("beta")))
         val vm = newViewModel(gateway = gateway, signals = signals)
@@ -74,31 +74,34 @@ class FolderListViewModelStaleSessionTest {
             // The user navigated onward to the (now gone) session -> tree paused.
             vm.stopPolling()
             runCurrent()
-            assertNull("no prompt before the gone-session signal", vm.staleSessionPrompt.value)
+            assertTrue(
+                "the row is present before the gone-session signal",
+                "git-pocketshell" in readySessionNames(vm),
+            )
 
-            // The session was confirmed genuinely gone on attach.
+            // The session was confirmed genuinely gone on attach. The USER-FACING
+            // recovery prompt is owned app-level (StaleSessionPromptController);
+            // the tree just keeps its list accurate by dropping the dead row.
             signals.emitStaleSession(HOST.id, "git-pocketshell", goneFolder)
             runCurrent()
 
-            val prompt = vm.staleSessionPrompt.value
-            assertTrue("a genuinely-gone session must raise the recreate prompt", prompt != null)
-            assertEquals("git-pocketshell", prompt!!.sessionName)
-            assertEquals(goneFolder, prompt.folderPath)
-            // The confirmed-gone row is also dropped from the tree so the list the
-            // prompt sits over is accurate.
             assertTrue(
                 "the confirmed-gone session drops from the tree",
                 "git-pocketshell" !in readySessionNames(vm),
+            )
+            assertTrue(
+                "an unrelated live row is untouched",
+                "beta" in readySessionNames(vm),
             )
         } finally {
             vm.stopPolling()
         }
     }
 
-    // ---- host filter: a gone session on ANOTHER host must not prompt ----------
+    // ---- host filter: a gone session on ANOTHER host must not drop OUR row -----
 
     @Test
-    fun staleSessionForOtherHostDoesNotPrompt() = runTest {
+    fun staleSessionForOtherHostDoesNotDropRow() = runTest {
         val signals = SessionLifecycleSignals()
         val gateway = StubGateway(listOf(sessionRow("git-pocketshell")))
         val vm = newViewModel(gateway = gateway, signals = signals)
@@ -109,104 +112,19 @@ class FolderListViewModelStaleSessionTest {
             signals.emitStaleSession(HOST.id + 1, "git-pocketshell", goneFolder)
             runCurrent()
 
-            assertNull(
-                "a gone session on another host must not raise this host's prompt",
-                vm.staleSessionPrompt.value,
+            assertTrue(
+                "a gone session on another host must not drop this host's row",
+                "git-pocketshell" in readySessionNames(vm),
             )
         } finally {
             vm.stopPolling()
         }
     }
 
-    // ---- confirm recreates in the SAME folder and routes to the new session ---
+    // ---- class coverage: app-created removal (via the app) also drops the row --
 
     @Test
-    fun confirmRecreatesSessionInSameFolderAndRoutes() = runTest {
-        val signals = SessionLifecycleSignals()
-        val gateway = StubGateway(listOf(sessionRow("beta")))
-        val vm = newViewModel(gateway = gateway, signals = signals)
-        try {
-            bind(vm)
-            runCurrent()
-            signals.emitStaleSession(HOST.id, "git-pocketshell", goneFolder)
-            runCurrent()
-            assertTrue(vm.staleSessionPrompt.value != null)
-
-            val routed = mutableListOf<String>()
-            vm.confirmRecreateStaleSession(onResolved = { routed.add(it) })
-            runCurrent()
-
-            assertEquals(
-                "confirm must recreate the session in the SAME folder",
-                listOf("git-pocketshell" to goneFolder),
-                gateway.createdSessions,
-            )
-            assertEquals("confirm routes to the recreated session", listOf("git-pocketshell"), routed)
-            assertNull("confirm clears the prompt", vm.staleSessionPrompt.value)
-        } finally {
-            vm.stopPolling()
-        }
-    }
-
-    // ---- dismiss clears the prompt (no create) --------------------------------
-
-    @Test
-    fun dismissClearsPromptWithoutCreating() = runTest {
-        val signals = SessionLifecycleSignals()
-        val gateway = StubGateway(listOf(sessionRow("beta")))
-        val vm = newViewModel(gateway = gateway, signals = signals)
-        try {
-            bind(vm)
-            runCurrent()
-            signals.emitStaleSession(HOST.id, "git-pocketshell", goneFolder)
-            runCurrent()
-            assertTrue(vm.staleSessionPrompt.value != null)
-
-            vm.dismissStaleSessionPrompt()
-            runCurrent()
-
-            assertNull("dismiss clears the prompt", vm.staleSessionPrompt.value)
-            assertTrue("dismiss must NOT create a session", gateway.createdSessions.isEmpty())
-        } finally {
-            vm.stopPolling()
-        }
-    }
-
-    // ---- missing-data: a gone session with no known folder falls back to ~ -----
-
-    @Test
-    fun staleSessionWithNullFolderFallsBackToHomeOnRecreate() = runTest {
-        val signals = SessionLifecycleSignals()
-        val gateway = StubGateway(listOf(sessionRow("beta")))
-        val vm = newViewModel(gateway = gateway, signals = signals)
-        try {
-            bind(vm)
-            runCurrent()
-            // The gone session carried no start directory (missing-data case).
-            signals.emitStaleSession(HOST.id, "orphan", folderPath = null)
-            runCurrent()
-
-            val prompt = vm.staleSessionPrompt.value
-            assertTrue("a null-folder gone session must STILL prompt (never blank/error)", prompt != null)
-            assertNull(prompt!!.folderPath)
-
-            vm.confirmRecreateStaleSession(onResolved = {})
-            runCurrent()
-            assertEquals(
-                "a null-folder recreate falls back to the host home directory",
-                listOf("orphan" to "~"),
-                gateway.createdSessions,
-            )
-        } finally {
-            vm.stopPolling()
-        }
-    }
-
-    // ---- class coverage: app-created removal (via the app) drops the row and --
-    // ---- does NOT prompt (the tree stays accurate) — only a gone-on-open does -
-
-    @Test
-    fun appCreatedRemovalDropsRowWithoutRecreatePrompt() = runTest {
+    fun appCreatedRemovalDropsRow() = runTest {
         val signals = SessionLifecycleSignals()
         val gateway = StubGateway(listOf(sessionRow("git-pocketshell"), sessionRow("beta")))
         val vm = newViewModel(gateway = gateway, signals = signals)
@@ -217,14 +135,13 @@ class FolderListViewModelStaleSessionTest {
             runCurrent()
 
             // The COMMON case: the user removed the session THROUGH the app — the
-            // tree drops the row immediately and there is nothing to recover, so
-            // NO recreate prompt (that is only for opening a persisted-but-gone
-            // session — the external-removal / missed-sync case).
+            // tree drops the row immediately (external removal is the gone-on-open
+            // case the app-level recovery prompt covers).
             signals.emitKilled(HOST.id, "git-pocketshell")
             runCurrent()
 
             assertTrue("app-created removal drops the row", "git-pocketshell" !in readySessionNames(vm))
-            assertNull("app-created removal must NOT raise the recreate prompt", vm.staleSessionPrompt.value)
+            assertTrue("the sibling row survives", "beta" in readySessionNames(vm))
         } finally {
             vm.stopPolling()
         }

--- a/app/src/test/java/com/pocketshell/app/tmux/StaleSessionPromptControllerTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/StaleSessionPromptControllerTest.kt
@@ -1,0 +1,337 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.app.projects.FolderImportPayload
+import com.pocketshell.app.projects.FolderListGateway
+import com.pocketshell.app.projects.FolderListResult
+import com.pocketshell.core.storage.dao.HostDao
+import com.pocketshell.core.storage.entity.HostEntity
+import com.pocketshell.core.storage.entity.ProjectRootEntity
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Issue #1155 / #666 — the APP-LEVEL stale-session recovery prompt owner.
+ *
+ * ## Reopen (2026-07-03): cold restore silently recreated the gone session
+ *
+ * Part B first wired the recreate prompt into the folder tree
+ * (`FolderListViewModel`) ONLY, whose no-replay subscription to
+ * [SessionLifecycleSignals.staleSessions] is alive only while the tree is on the
+ * back stack. The maintainer's dogfood path is a COLD RESTORE straight onto the
+ * last session screen — the folder tree was never opened, so its view model does
+ * not exist, so nothing was subscribed and the recovery prompt was silently lost
+ * (the connection core still refused to resurrect the gone session; the missing
+ * piece was surfacing the prompt).
+ *
+ * [StaleSessionPromptController] is the fix: a process-scoped singleton that is
+ * subscribed to the stale broadcast from app start (injected into `MainActivity`),
+ * so it catches the genuinely-gone broadcast REGARDLESS of which screen the app
+ * restored onto, and `MainActivity` renders one app-level "create in this folder,
+ * or go home?" dialog off its [StaleSessionPromptController.prompt] state.
+ *
+ * These tests drive the REAL wiring (emit on [SessionLifecycleSignals] → the
+ * controller's subscription surfaces the prompt) with NO folder tree bound — the
+ * cold-restore condition that the base, tree-only owner could not cover.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class StaleSessionPromptControllerTest {
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private val goneFolder = "/home/alex/git/pocketshell"
+
+    /**
+     * The reopen reproduction, at the delivery layer: a genuinely-gone broadcast
+     * fires with NO folder tree bound (the cold-restore condition). The base,
+     * tree-only owner would drop it on the floor; the app-level controller
+     * surfaces it as a prompt — the maintainer's "this session no longer exists"
+     * recovery, instead of the silent recreate.
+     */
+    @Test
+    fun coldRestoreStaleEmitSurfacesPromptWithNoTreeBound() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val signals = SessionLifecycleSignals()
+        val controller = StaleSessionPromptController(signals)
+        runCurrent()
+
+        assertNull("no prompt before the gone-session broadcast", controller.prompt.value)
+
+        // The cold-restore attach confirmed the session is genuinely gone.
+        signals.emitStaleSession(hostId = 7L, sessionName = "work", folderPath = goneFolder)
+        runCurrent()
+
+        val prompt = controller.prompt.value
+        assertNotNull(
+            "a cold-restore gone-session broadcast must surface the app-level recovery prompt",
+            prompt,
+        )
+        assertEquals(7L, prompt!!.hostId)
+        assertEquals("work", prompt.sessionName)
+        assertEquals(goneFolder, prompt.folderPath)
+    }
+
+    /**
+     * Class coverage — the OpenExisting tap path fires the SAME broadcast, so the
+     * one app-level owner covers both the cold-restore and the in-tree tap without
+     * a second dialog.
+     */
+    @Test
+    fun openExistingStaleEmitSurfacesPrompt() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val signals = SessionLifecycleSignals()
+        val controller = StaleSessionPromptController(signals)
+        runCurrent()
+
+        signals.emitStaleSession(hostId = 3L, sessionName = "beta", folderPath = "/srv/beta")
+        runCurrent()
+
+        assertEquals("beta", controller.prompt.value?.sessionName)
+        assertEquals("/srv/beta", controller.prompt.value?.folderPath)
+    }
+
+    /**
+     * Class coverage — the missing-data case: a gone session with NO known folder
+     * still surfaces the prompt (never a blank/dropped recovery). The app-level
+     * dialog falls its label back to "home" and recreates in the host home dir.
+     */
+    @Test
+    fun nullFolderStaleEmitStillSurfacesPrompt() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val signals = SessionLifecycleSignals()
+        val controller = StaleSessionPromptController(signals)
+        runCurrent()
+
+        signals.emitStaleSession(hostId = 9L, sessionName = "orphan", folderPath = null)
+        runCurrent()
+
+        val prompt = controller.prompt.value
+        assertNotNull("a null-folder gone session must STILL surface the prompt", prompt)
+        assertEquals("orphan", prompt!!.sessionName)
+        assertNull(prompt.folderPath)
+    }
+
+    /**
+     * Class coverage — NO spurious prompt. The stale broadcast only ever fires
+     * from the genuinely-gone attach-fail path; a transient reconnect blip never
+     * emits it (proven on the emitter side in `TmuxSessionWarmOpenTest`). With no
+     * broadcast the controller stays clear — the transient-never-prompts guarantee
+     * at the delivery layer.
+     */
+    @Test
+    fun noBroadcastMeansNoPrompt() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val signals = SessionLifecycleSignals()
+        val controller = StaleSessionPromptController(signals)
+        runCurrent()
+
+        // A transient reconnect emits a KILL or nothing on this bus, never a
+        // stale-session; assert the controller does not fabricate a prompt.
+        signals.emitKilled(hostId = 7L, sessionName = "work")
+        runCurrent()
+
+        assertNull("only a genuinely-gone broadcast may surface the prompt", controller.prompt.value)
+    }
+
+    /** The user resolving the prompt (recreate / go home) clears it. */
+    @Test
+    fun clearResetsPrompt() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val signals = SessionLifecycleSignals()
+        val controller = StaleSessionPromptController(signals)
+        runCurrent()
+
+        signals.emitStaleSession(hostId = 7L, sessionName = "work", folderPath = goneFolder)
+        runCurrent()
+        assertNotNull(controller.prompt.value)
+
+        controller.clear()
+        runCurrent()
+        assertNull("clear() must reset the prompt after the user resolves it", controller.prompt.value)
+    }
+
+    // ---------------------------------------------------------------------------
+    // Issue #1155 REOPEN (2026-07-03): the "Create session" recovery ACTION creates
+    // a fresh session in the gone session's folder over the REAL gateway create
+    // path, instead of re-navigating to the dead cold-restore destination (which
+    // the screen classifies as ColdRestore, whose has-session preflight REFUSES to
+    // create — the silent no-op the reopen reports).
+    // ---------------------------------------------------------------------------
+
+    /**
+     * The recreate goes through [FolderListGateway.createSession] with the gone
+     * session's name AND its folder as the `cwd` — the deterministic create the
+     * cold-restore navigate no-op could not do. Returns the resolved session name.
+     */
+    @Test
+    fun createSessionInFolderCreatesInTheStaleFolderViaGateway() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val gateway = RecordingGateway(resolvedName = "work")
+        val controller = StaleSessionPromptController(
+            SessionLifecycleSignals(),
+            gateway = gateway,
+            hostDao = FakeHostDao(host(id = 7L)),
+            ioDispatcher = StandardTestDispatcher(testScheduler),
+        )
+
+        val result = controller.createSessionInFolder(
+            hostId = 7L,
+            keyPath = "/tmp/key",
+            passphrase = null,
+            sessionName = "work",
+            folderPath = goneFolder,
+        )
+
+        assertTrue("gateway create must succeed", result.isSuccess)
+        assertEquals("work", result.getOrNull())
+        assertEquals("the gateway must be asked to create the gone session name", "work", gateway.lastSessionName)
+        assertEquals(
+            "the recreate must target the STALE session's folder (cwd = folderPath)",
+            goneFolder,
+            gateway.lastCwd,
+        )
+        assertNull("a plain recovery create never auto-launches a start command", gateway.lastStartCommand)
+    }
+
+    /**
+     * Class coverage — the missing-data case: a null/blank folder recreates in the
+     * host home directory (`~`), never a blank/error. The `cwd` handed to the
+     * gateway falls back to `~`.
+     */
+    @Test
+    fun createSessionInFolderNullFolderFallsBackToHome() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val gateway = RecordingGateway(resolvedName = "orphan")
+        val controller = StaleSessionPromptController(
+            SessionLifecycleSignals(),
+            gateway = gateway,
+            hostDao = FakeHostDao(host(id = 9L)),
+            ioDispatcher = StandardTestDispatcher(testScheduler),
+        )
+
+        val result = controller.createSessionInFolder(
+            hostId = 9L,
+            keyPath = "/tmp/key",
+            passphrase = null,
+            sessionName = "orphan",
+            folderPath = null,
+        )
+
+        assertTrue(result.isSuccess)
+        assertEquals("a null folder recreates in the host home dir", "~", gateway.lastCwd)
+    }
+
+    /**
+     * A create against an unknown host id fails cleanly (never throws / hangs), so
+     * the caller can recover the user to the list rather than silently doing
+     * nothing.
+     */
+    @Test
+    fun createSessionInFolderFailsWhenHostMissing() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val gateway = RecordingGateway(resolvedName = "x")
+        val controller = StaleSessionPromptController(
+            SessionLifecycleSignals(),
+            gateway = gateway,
+            hostDao = FakeHostDao(host(id = 7L)),
+            ioDispatcher = StandardTestDispatcher(testScheduler),
+        )
+
+        val result = controller.createSessionInFolder(
+            hostId = 999L,
+            keyPath = "/tmp/key",
+            passphrase = null,
+            sessionName = "x",
+            folderPath = goneFolder,
+        )
+
+        assertTrue("an unknown host must surface a failure", result.isFailure)
+        assertFalse("the gateway must not be called for an unknown host", gateway.called)
+    }
+
+    private fun host(id: Long): HostEntity =
+        HostEntity(id = id, name = "h", hostname = "example", username = "u", keyId = 1L)
+
+    private class FakeHostDao(private val host: HostEntity) : HostDao {
+        override fun getAll(): Flow<List<HostEntity>> = flowOf(listOf(host))
+        override suspend fun getById(id: Long): HostEntity? = host.takeIf { it.id == id }
+        override fun getEnabled(): Flow<List<HostEntity>> = flowOf(listOf(host))
+        override suspend fun insert(host: HostEntity): Long = error("not used")
+        override suspend fun update(host: HostEntity) = error("not used")
+        override suspend fun delete(host: HostEntity) = error("not used")
+        override suspend fun deleteById(id: Long) = error("not used")
+    }
+
+    private class RecordingGateway(private val resolvedName: String) : FolderListGateway {
+        var called: Boolean = false
+        var lastSessionName: String? = null
+        var lastCwd: String? = null
+        var lastStartCommand: String? = null
+
+        override suspend fun createSession(
+            host: HostEntity,
+            keyPath: String,
+            passphrase: CharArray?,
+            sessionName: String,
+            cwd: String,
+            startCommand: String?,
+        ): Result<String> {
+            called = true
+            lastSessionName = sessionName
+            lastCwd = cwd
+            lastStartCommand = startCommand
+            return Result.success(resolvedName)
+        }
+
+        override suspend fun listSessionsWithFolder(
+            host: HostEntity,
+            keyPath: String,
+            passphrase: CharArray?,
+            watchedRoots: List<ProjectRootEntity>,
+        ): FolderListResult = error("not used")
+
+        override suspend fun createEmptyProject(
+            host: HostEntity,
+            keyPath: String,
+            passphrase: CharArray?,
+            parentPath: String,
+            folderName: String,
+        ): Result<String> = error("not used")
+
+        override suspend fun importFile(
+            host: HostEntity,
+            keyPath: String,
+            passphrase: CharArray?,
+            folderPath: String,
+            payload: FolderImportPayload,
+        ): Result<String> = error("not used")
+
+        override suspend fun killSession(
+            host: HostEntity,
+            keyPath: String,
+            passphrase: CharArray?,
+            sessionName: String,
+        ): Result<Unit> = error("not used")
+    }
+}


### PR DESCRIPTION
Closes #1155 (maintainer reopen). Closes #666. Cold-restore into a session killed on the host silently created an empty session. The Part-B prompt existed but was delivered only through the folder tree's VM (dead on cold-restore). Fix: a process-wide `StaleSessionPromptController` (subscribed from `MainActivity`) shows one app-level dialog — **Create session** (real create-in-folder gateway, id-independent so it always creates) + **Go to home** (popToHostList). Tree-only machinery removed.

Reviewer verified on-device (4/4 connected E2E): dialog on cold-restore, go-home → HostList, create → fresh session in the stale folder (cold-restore + OpenExisting), no resurrection. 11 JVM tests. D33: the null-id 'create no-op' edge is covered by construction (onConfirm id-independent). Handler-level, D28-safe. Orchestrator gate green.

(Note: supersedes stale PR #1256, which pointed at the already-merged original issue-1155 branch.)