### PR TITLE
test: de-flake transportSilentReattach heal test (pin producer dispatcher) (#1250)

### DIFF
--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
@@ -3385,6 +3385,25 @@ class TmuxSessionViewModelTest {
         vm.setProcessForegroundForClearedForTest(true)
         vm.setScreenInteractiveForTest(true)
         vm.setStaleRenderWatchdogMaxTicksForTest(1000)
+        // Issue #1250 (CI-flake fix): pin the TerminalSurfaceState external-producer
+        // dispatcher to the SHARED virtual-clock scheduler. The default factory builds
+        // `TerminalSurfaceState()` on the production `Dispatchers.IO` (a real off-Main
+        // thread — correct for the on-device feed). But this fresh-transport reattach
+        // REBINDS each pane's producer several times (initial attach → reattach
+        // rebindVisiblePaneProducersToClient → each connected-blank-watchdog reseed),
+        // and every rebind CANCELS the prior producer whose `finally` runs
+        // `detachCompletedExternalProducer` (nulling `bridge`/`_session`) via a
+        // `Dispatchers.Main.immediate` hop OFF that real IO thread. Under `runTest`'s
+        // virtual clock that real-thread hop lands at a non-deterministic point, so the
+        // pane's emulator was sometimes DETACHED (isAttached=false) at assertion time —
+        // and `visibleScreenIsBlank()` returns false with NO emulator, spuriously
+        // failing the "seed stayed empty -> black" precondition (~70% in isolation).
+        // Confining the producer to the shared scheduler makes attach/detach step
+        // deterministically under `advanceTimeBy`/`runCurrent` (same pin as the sibling
+        // heal tests, e.g. PartialBlackPaneHealTest / ReseedBlankWatchdogCharacterizationTest).
+        vm.setTerminalSurfaceStateFactoryForTest {
+            TerminalSurfaceState(StandardTestDispatcher(scheduler))
+        }
         val deadClient = FakeTmuxClient()
         val replacementClient =
             FakeTmuxClient().withSinglePaneRowButEmptyCapture("work", "%1")


### PR DESCRIPTION
Closes #1250. Test-only CI de-flake (the ~70%-isolation flake found during the #1168 review). The test never pinned the `TerminalSurfaceState` producer dispatcher, so a real-IO-thread `Dispatchers.Main.immediate` detach hop landed non-deterministically under `runTest`'s virtual clock → the pane read detached → `visibleScreenIsBlank()` flaked. Pin to `StandardTestDispatcher(scheduler)` (matches 6 sibling heal tests).

Reviewer: red→green reproduced (base RED under load, fixed 20/20 serial + 3/3 under load), confirmed it's genuinely test-timing NOT a masked production race (production guarded by the `completedBridge` check, dispatcher untouched), assertion byte-identical. Sibling `passiveSilentReattach...` needs the same pin → filed #1258.