### PR TITLE
core-usage: per-record resilient exit-0 parse (#1223)

### DIFF
--- a/app/src/test/java/com/pocketshell/app/usage/UsageRemoteSourceTest.kt
+++ b/app/src/test/java/com/pocketshell/app/usage/UsageRemoteSourceTest.kt
@@ -136,6 +136,76 @@ class UsageRemoteSourceTest {
         assertTrue(record.lastError?.contains("HTTP Error 401", ignoreCase = true) == false)
     }
 
+    // -- issue #1223: exit-0 per-record resilience (#847 version-skew class) --
+
+    @Test
+    fun fetchUsage_exit0PartialDrift_stillRendersHealthyProvider() = runTest {
+        // An old/mismatched host CLI emits provider A fine but provider B
+        // drifted (short_term is not an object). Before #1223 the whole usage
+        // panel showed Failed/blank; the healthy provider must now render.
+        val session = FakeSshSession(
+            mapOf(
+                defaultFetchCommand to ExecResult(
+                    stdout = """{"provider":"codex","status":"ok","short_term":{"percent_remaining":77.0},"long_term":null,"block_reason":null,"error":null,"details":{}}""" +
+                        "\n" +
+                        """{"status":"ok","short_term":"drifted","long_term":null,"block_reason":null,"error":null,"details":{}}""",
+                    stderr = "",
+                    exitCode = 0,
+                ),
+            ),
+        )
+
+        val result = source.fetchUsage(session)
+
+        assertTrue(result is UsageFetchResult.Success)
+        val record = (result as UsageFetchResult.Success).records.single()
+        assertEquals("codex", record.provider)
+        assertEquals(UsageStatus.Ok, record.status)
+    }
+
+    @Test
+    fun fetchUsage_exit0NonJsonPreamble_stillRendersAllProviders() = runTest {
+        // A wrapper prepends a non-JSON MOTD/deprecation line before the valid
+        // NDJSON. All valid providers must still render.
+        val session = FakeSshSession(
+            mapOf(
+                defaultFetchCommand to ExecResult(
+                    stdout = "WARNING: pocketshell 0.3.1 is deprecated\n" +
+                        """{"provider":"codex","status":"ok","short_term":{"percent_remaining":50.0},"long_term":null,"block_reason":null,"error":null,"details":{}}""" +
+                        "\n" +
+                        """{"provider":"claude","status":"ok","short_term":{"percent_remaining":41.0},"long_term":null,"block_reason":null,"error":null,"details":{}}""",
+                    stderr = "",
+                    exitCode = 0,
+                ),
+            ),
+        )
+
+        val result = source.fetchUsage(session)
+
+        assertTrue(result is UsageFetchResult.Success)
+        val records = (result as UsageFetchResult.Success).records
+        assertEquals(listOf("codex", "claude"), records.map { it.provider })
+    }
+
+    @Test
+    fun fetchUsage_exit0AllRecordsUnparseable_reportsFailure() = runTest {
+        // Zero parseable records must still surface a visible failure — never a
+        // silent empty-success.
+        val session = FakeSshSession(
+            mapOf(
+                defaultFetchCommand to ExecResult(
+                    stdout = "this is not json at all\nalso not json {broken",
+                    stderr = "",
+                    exitCode = 0,
+                ),
+            ),
+        )
+
+        val result = source.fetchUsage(session)
+
+        assertTrue("zero-parse must not be a silent Success", result is UsageFetchResult.Failed)
+    }
+
     @Test
     fun fetchUsage_nonzeroNonJsonStillReportsFailure() = runTest {
         val session = FakeSshSession(

--- a/shared/core-usage/src/main/java/com/pocketshell/core/usage/PocketshellUsageJsonParser.kt
+++ b/shared/core-usage/src/main/java/com/pocketshell/core/usage/PocketshellUsageJsonParser.kt
@@ -41,6 +41,18 @@ public class PocketshellUsageJsonParser(
         if (trimmed.isEmpty()) return emptyList()
 
         val records = mutableListOf<UsageProviderRecord>()
+        // Per-record resilience (issue #1223): an old/mismatched host CLI (or a
+        // custom `usageCommandOverride` wrapper) can emit one healthy provider
+        // record plus one drifted/malformed record, or prepend a non-JSON
+        // MOTD/deprecation line. We parse record-by-record, SKIP a record that
+        // fails (accumulating a per-record diagnostic), and return the ones that
+        // parsed. Only when ZERO records parse from non-empty input do we
+        // surface a whole-panel failure — this mirrors the graceful degradation
+        // the exit != 0 path (`parseProviderErrorStdout`) already has, and is the
+        // same version-skew class behind the v0.4.10 connect break (#847): one
+        // drifted line must not break the whole surface.
+        val diagnostics = mutableListOf<String>()
+        var candidateCount = 0
         // `pocketshell usage --json` is newline-delimited JSON (NDJSON): one
         // record per line. We also accept records that span multiple lines by
         // accumulating until braces balance — this keeps the parser
@@ -71,22 +83,44 @@ public class PocketshellUsageJsonParser(
                 val record = buffer.toString().trim()
                 buffer.setLength(0)
                 if (record.isEmpty()) continue
-                val obj = try {
-                    JSONObject(record)
-                } catch (e: JSONException) {
-                    throw UsageParseException("invalid usage JSON near line ${index + 1}: ${e.message}", e)
-                }
-                records += parseRecord(obj)
+                candidateCount += 1
+                parseCandidate(record, index + 1)
+                    .onSuccess { records += it }
+                    .onFailure { diagnostics += (it.message ?: "invalid usage record near line ${index + 1}") }
             } else if (buffer.isNotEmpty()) {
                 // Multi-line record: keep the newline so the next iteration
                 // separates tokens correctly.
                 buffer.append('\n')
             }
         }
-        if (depth != 0 || inString) {
-            throw UsageParseException("invalid usage JSON: unterminated record")
+        if (buffer.isNotEmpty() && (depth != 0 || inString)) {
+            // A trailing, never-closed record. Count it as one more failed
+            // candidate rather than hard-failing the whole panel — the same
+            // skip-or-total-failure rule below decides the outcome.
+            candidateCount += 1
+            diagnostics += "invalid usage JSON: unterminated record"
+        }
+
+        if (records.isEmpty() && candidateCount > 0) {
+            // Non-empty input, nothing parsed: surface a visible failure (never
+            // a silent empty-success). The message aggregates every per-record
+            // diagnostic so the cause is still reportable.
+            throw UsageParseException(
+                "invalid usage JSON: no usable records (" +
+                    diagnostics.joinToString("; ").ifBlank { "all records unparseable" } +
+                    ")",
+            )
         }
         return records
+    }
+
+    private fun parseCandidate(record: String, lineNumber: Int): Result<UsageProviderRecord> = runCatching {
+        val obj = try {
+            JSONObject(record)
+        } catch (e: JSONException) {
+            throw UsageParseException("invalid usage JSON near line $lineNumber: ${e.message}", e)
+        }
+        parseRecord(obj)
     }
 
     private fun parseRecord(obj: JSONObject): UsageProviderRecord {

--- a/shared/core-usage/src/test/java/com/pocketshell/core/usage/PocketshellUsageJsonParserTest.kt
+++ b/shared/core-usage/src/test/java/com/pocketshell/core/usage/PocketshellUsageJsonParserTest.kt
@@ -511,4 +511,78 @@ class PocketshellUsageJsonParserTest {
             )
         }
     }
+
+    // -- issue #1223: per-record resilience on the exit-0 success path --------
+    //
+    // An old/mismatched host CLI (or a custom usageCommandOverride wrapper) can
+    // emit one healthy provider record plus one drifted/malformed record, or
+    // prepend a non-JSON MOTD/deprecation line. Before #1223 the FIRST bad
+    // record threw and discarded ALL providers. Parse must now skip the bad
+    // record and return the ones that parsed; only zero parsed records is a
+    // whole-panel failure (mirrors the exit != 0 graceful path #847 class).
+
+    @Test
+    fun parse_skipsDriftedRecordAndKeepsHealthyProvider() {
+        // Healthy record is FIRST so we prove an already-parsed provider is not
+        // discarded when a LATER record drifts (missing `provider`).
+        val records = parser.parse(
+            """
+            {"provider":"codex","status":"ok","short_term":{"percent_remaining":77.0},"long_term":null,"block_reason":null,"error":null,"details":{}}
+            {"status":"ok","short_term":"not-an-object","long_term":null,"block_reason":null,"error":null,"details":{}}
+            """.trimIndent(),
+        )
+
+        assertEquals(1, records.size)
+        assertEquals("codex", records.single().provider)
+        assertEquals(UsageStatus.Ok, records.single().status)
+    }
+
+    @Test
+    fun parse_skipsNonJsonPreambleLineAndRendersAllValidProviders() {
+        // A wrapper/MOTD prints a non-JSON preamble line before the NDJSON. All
+        // valid provider records after it must still render.
+        val records = parser.parse(
+            """
+            WARNING: pocketshell 0.3.1 is deprecated, upgrade with: uv tool upgrade pocketshell
+            {"provider":"codex","status":"ok","short_term":{"percent_remaining":50.0},"long_term":null,"block_reason":null,"error":null,"details":{}}
+            {"provider":"claude","status":"ok","short_term":{"percent_remaining":41.0},"long_term":null,"block_reason":null,"error":null,"details":{}}
+            """.trimIndent(),
+        )
+
+        assertEquals(2, records.size)
+        assertEquals("codex", records[0].provider)
+        assertEquals("claude", records[1].provider)
+    }
+
+    @Test
+    fun parse_throwsWhenZeroRecordsParse() {
+        // Non-empty input where NOTHING parses must still surface a visible
+        // failure (no silent empty-success). The message aggregates the
+        // per-record diagnostics.
+        val error = assertThrows(UsageParseException::class.java) {
+            parser.parse(
+                """
+                this is not json
+                also not json {broken
+                """.trimIndent(),
+            )
+        }
+        assertNotNull(error.message)
+        assertTrue(error.message!!.contains("invalid usage JSON"))
+    }
+
+    @Test
+    fun parse_skipsMalformedJsonRecordAmongValidOnes() {
+        // A record with broken JSON syntax sandwiched between two valid ones is
+        // skipped; the two valid providers still render.
+        val records = parser.parse(
+            """
+            {"provider":"codex","status":"ok","short_term":{"percent_remaining":77.0},"long_term":null,"block_reason":null,"error":null,"details":{}}
+            {"provider":"claude","status":"ok","short_term":{"percent_remaining":not-a-number}}
+            {"provider":"copilot","status":"ok","short_term":{"percent_remaining":90.0},"long_term":null,"block_reason":null,"error":null,"details":{}}
+            """.trimIndent(),
+        )
+
+        assertEquals(listOf("codex", "copilot"), records.map { it.provider })
+    }
 }


### PR DESCRIPTION
Closes #1223. Reviewer APPROVED with reviewer-driven red→green (https://github.com/alexeygrigorev/pocketshell/issues/1223#issuecomment-4878274170). Pure JVM/parser change; new regression tests wired into the Unit gate. Local gate green: `git diff --check` clean, focused core-usage + UsageRemoteSource tests pass.