### PR TITLE
settings: remove cold-start runBlocking stall (#1249)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/settings/SettingsRepository.kt
+++ b/app/src/main/java/com/pocketshell/app/settings/SettingsRepository.kt
@@ -62,16 +62,37 @@ import javax.inject.Singleton
  *   eager [async] kicked off from the constructor. Because construction itself
  *   happens during `App.onCreate`, that async IS the splash/startup-window
  *   PRELOAD — it warms while the activity inflates, before `setContent`. A
- *   [StartupTiming] mark fires when it completes for cold-launch observability.
+ *   [StartupTiming] mark fires when it completes for cold-launch observability;
+ *   its result is stashed in [warmSnapshot] for a zero-cost seed.
  * - [settings] is created LAZILY (a getter over the lazy [_settings]); its
- *   initial value is the warm snapshot. The very first value the composition
- *   observes is therefore the persisted snapshot — never a default — so there
- *   is no flash. The first read blocks only on the await, which by first
- *   composition is already complete (warmed during the splash window), so it
- *   does not block launch.
+ *   initial value is the persisted snapshot — never a default — so there is no
+ *   flash.
  *
- * Hard-cut (D22): there is no synchronous on-Main read path. Reads/writes route
- * through [prefs], which warms-or-awaits the off-main build.
+ * ## Non-blocking cold-start seed (issue #1249)
+ *
+ * The earlier #1088 design seeded [_settings] with `runBlocking {
+ * snapshotDeferred.await() }` at first composition. That re-coupled Main to the
+ * IO dispatcher: if the eager preload had not finished (cold start floods
+ * [Dispatchers.IO] with every store's warm-up + Room reads), the first
+ * composition PARKED Main on the whole IO-queue drain, not merely on the
+ * small-file read — a launch stall. [seedSnapshot] removes that await:
+ *
+ * - Warm/common case: the eager preload has already completed by first
+ *   composition (it warms during the splash window), so [warmSnapshot] is set
+ *   and the seed is a plain volatile read — zero on-Main disk work.
+ * - Cold/contended case: [warmSnapshot] is still null, so the seed reads the
+ *   persisted snapshot SYNCHRONOUSLY on the current thread via
+ *   [buildSnapshotResiliently]. That is a single bounded small-file read that
+ *   reuses the SharedPreferences load already kicked off at construction — it
+ *   never parks Main on the contended IO dispatcher queue.
+ *
+ * Either way the first observed value is the PERSISTED snapshot (no #1088
+ * flash — the seed reads the real persisted file, never a default-then-update),
+ * and the launch path no longer blocks on the off-main coroutine.
+ *
+ * Hard-cut (D22): there is no `runBlocking`-await on the launch path. Reads and
+ * writes route through [prefs] / [seedSnapshot], which open the prefs file
+ * synchronously (bounded) rather than awaiting the off-main coroutine.
  */
 @Singleton
 class SettingsRepository @VisibleForTesting internal constructor(
@@ -100,6 +121,16 @@ class SettingsRepository @VisibleForTesting internal constructor(
     @Volatile
     private var snapshotBuildThreadName: String? = null
 
+    /**
+     * The warm result of the eager off-main preload ([snapshotDeferred]). `null`
+     * until that preload completes; set to the persisted snapshot when it does.
+     * [seedSnapshot] reads this for a zero-cost seed when the preload has already
+     * finished (the common warm case) — it must NOT `await()` the deferred, which
+     * is what would park Main on the contended IO queue (#1249).
+     */
+    @Volatile
+    private var warmSnapshot: AppSettings? = null
+
     private val warmUpScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     /**
@@ -109,12 +140,14 @@ class SettingsRepository @VisibleForTesting internal constructor(
      */
     private val snapshotDeferred: Deferred<AppSettings> = warmUpScope.async {
         // Test-only: hold the build in-flight until the gate opens. No-op in
-        // production (gate == null). Placed BEFORE the snapshot is built so the
-        // deferred cannot complete — and `_settings`' blocking-await cannot
-        // return — while a test is reading the first value.
+        // production (gate == null). Placed BEFORE the snapshot is built so a
+        // test can hold the OFF-MAIN preload provably in-flight while it reads
+        // the first `settings.value` — the seed then takes the synchronous
+        // cold-path (#1249) rather than this gated preload.
         warmUpGate?.await()
         snapshotBuildThreadName = currentPhysicalThreadName()
         val snapshot = buildSnapshotResiliently()
+        warmSnapshot = snapshot
         StartupTiming.markOnce("settings-snapshot-preloaded")
         snapshot
     }
@@ -167,22 +200,45 @@ class SettingsRepository @VisibleForTesting internal constructor(
         }
 
     private val prefs: SharedPreferences
-        get() = cachedPrefs ?: runBlocking {
-            snapshotDeferred.await()
-            cachedPrefs ?: error("settings prefs not cached after off-main build")
+        get() = cachedPrefs ?: run {
+            // Do NOT await the off-main coroutine (that is the #1249 park). Open
+            // the prefs file synchronously — bounded, reuses the already-started
+            // SharedPreferences load — which sets [cachedPrefs] as a side effect.
+            buildSnapshotResiliently()
+            cachedPrefs ?: error("settings prefs not cached after synchronous open")
         }
 
     private val _settings: MutableStateFlow<AppSettings> by lazy {
-        MutableStateFlow(runBlocking { snapshotDeferred.await() })
+        MutableStateFlow(seedSnapshot())
     }
 
     /**
+     * Seed the first observed [settings] value WITHOUT parking on the off-main
+     * preload's IO coroutine (#1249).
+     *
+     * - If the eager preload already completed ([warmSnapshot] set — the common
+     *   warm case, warmed during the splash window before first composition),
+     *   reuse its result at zero on-Main cost.
+     * - Otherwise read the persisted snapshot SYNCHRONOUSLY on the current
+     *   thread via [buildSnapshotResiliently]. That is a single bounded
+     *   small-file read that reuses the SharedPreferences load already kicked
+     *   off at construction, rather than blocking Main on the cold-start-
+     *   contended [Dispatchers.IO] queue.
+     *
+     * Either way the first value is the PERSISTED snapshot (no #1088 flash — the
+     * seed reads the real persisted file, never a default-then-update). It does
+     * not record [snapshotBuildThreadName]; that remains the off-main preload's
+     * to set, so the #1088 off-main assertion stays load-bearing.
+     */
+    private fun seedSnapshot(): AppSettings =
+        warmSnapshot ?: buildSnapshotResiliently()
+
+    /**
      * Hot, always-current snapshot of [AppSettings]. A getter (not an eager
-     * `val`) so the backing [_settings] — and its blocking await on the warm
-     * snapshot — is initialised at first read (first composition), NOT at
-     * construction/injection. By first composition the preload is warm, so the
-     * initial value is the persisted snapshot (no default flash) and the read
-     * does not block launch.
+     * `val`) so the backing [_settings] — and its [seedSnapshot] read — is
+     * initialised at first read (first composition), NOT at
+     * construction/injection. The seed is the persisted snapshot (no default
+     * flash) and, per #1249, does NOT block launch on the off-main coroutine.
      */
     val settings: StateFlow<AppSettings>
         get() = _settings.asStateFlow()

--- a/app/src/test/java/com/pocketshell/app/settings/SettingsRepositoryOffMainTest.kt
+++ b/app/src/test/java/com/pocketshell/app/settings/SettingsRepositoryOffMainTest.kt
@@ -6,6 +6,7 @@ import com.pocketshell.core.terminal.ui.TerminalKeyboardMode
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -80,7 +81,7 @@ class SettingsRepositoryOffMainTest {
      * No default→persisted flash (the reason #1088 was deferred from #1087):
      * after a non-default value is persisted, a FRESH instance's FIRST observed
      * [SettingsRepository.settings] value is the persisted snapshot, never the
-     * default. The lazy StateFlow's initial value is the warm preload, so the
+     * default. The lazy StateFlow's initial value is the seeded snapshot, so the
      * composition never sees a default first.
      *
      * DETERMINISTIC, not timing-dependent (#1088 reviewer round 2 — the
@@ -92,13 +93,14 @@ class SettingsRepositoryOffMainTest {
      * sensitivity the reviewer demonstrated.
      *
      * This version uses the [SettingsRepository] warm-up GATE seam to hold the
-     * snapshot build provably IN-FLIGHT at the moment `settings.value` is first
+     * OFF-MAIN preload provably IN-FLIGHT at the moment `settings.value` is first
      * read, on a worker thread. The two implementations then diverge
      * DETERMINISTICALLY, independent of CPU scheduling:
      *
-     *  - Shipped (blocking-await `_settings by lazy { … runBlocking { await() } }`):
-     *    the first read BLOCKS until the gate opens — so the very first value it
-     *    can ever observe is the persisted snapshot. GREEN.
+     *  - Shipped (#1249 non-blocking seed): with the preload gated, the first
+     *    read takes the SYNCHRONOUS cold-path — it opens the prefs file directly
+     *    and returns the PERSISTED snapshot without awaiting the gated preload.
+     *    GREEN.
      *  - Racy (seed a default StateFlow, then update from the async): the first
      *    read returns the DEFAULT immediately, BEFORE the gated async can update
      *    — the visible flash. The captured first value is the default. RED.
@@ -136,34 +138,92 @@ class SettingsRepositoryOffMainTest {
         val readReturned = CountDownLatch(1)
         val reader = thread(name = "settings-first-read") {
             readEntered.countDown()
-            // Shipped: this BLOCKS in `runBlocking { await() }` until the gate
-            // opens. Racy seed-default: this returns the default immediately.
+            // Shipped (#1249): the gated preload forces the SYNCHRONOUS cold
+            // seed, which reads the persisted snapshot directly. Racy
+            // seed-default: this returns the default immediately.
             firstObserved.set(repo.settings.value)
             readReturned.countDown()
         }
 
         // The reader thread is running and about to read.
         readEntered.await()
-        // Give the read itself a generous window to execute WHILE the gate is
-        // still closed. The racy variant captures the default within this
-        // window (the read does not block); the shipped variant cannot return
-        // here at all (it is blocked on the gated await), which is the whole
-        // point — so a timeout here is expected and correct for the fix.
+        // Give the read a generous window to execute WHILE the gate is still
+        // closed. The racy variant captures the default within this window; the
+        // shipped variant reads the persisted snapshot synchronously (it never
+        // parks on the gated preload — #1249). Both return here without opening
+        // the gate.
         readReturned.await(2, TimeUnit.SECONDS)
 
-        // Open the gate so the off-main build can complete and the shipped
-        // reader can unblock with the persisted snapshot.
+        // Open the gate so the off-main build can complete and drain its scope.
         gate.countDown()
         reader.join(TimeUnit.SECONDS.toMillis(5))
 
         val observed = firstObserved.get()
-            ?: error("settings.value read never completed even after the gate opened")
+            ?: error("settings.value read never completed")
         // LOAD-BEARING: the FIRST value the composition can observe is the
         // PERSISTED snapshot, never a default. The seed-default variant captured
-        // the default above → RED here; the shipped blocking-await returns the
+        // the default above → RED here; the shipped synchronous seed returns the
         // persisted snapshot → GREEN.
         assertEquals(PERSISTED_FONT_SP, observed.terminalFontSizeSp, 0f)
         assertEquals(PERSISTED_KEYBOARD_MODE, observed.terminalKeyboardMode)
+    }
+
+    /**
+     * LOAD-BEARING (#1249): the cold-start first read of [settings] must NOT
+     * block on the off-main preload. This is the perf half of #1229 — the old
+     * #1088 design seeded `_settings` with `runBlocking { snapshotDeferred.await()
+     * }`, which parked the reading thread until the preload finished. On a
+     * contended cold start (every store warming on [kotlinx.coroutines.Dispatchers.IO]
+     * at once) that stalled launch.
+     *
+     * Reproduce-first (D33 / G10): the off-main preload is GATED and the gate is
+     * NEVER opened, so the preload can never complete. The first `settings.value`
+     * read is then required to RETURN — with the persisted snapshot — WITHOUT the
+     * gate opening.
+     *
+     *  - Pre-fix (`runBlocking { snapshotDeferred.await() }`): the read blocks on
+     *    the gated preload forever → `done.await(timeout)` returns false → the
+     *    `assertTrue` fails → RED.
+     *  - Fixed (#1249 synchronous seed): the read opens the prefs file directly,
+     *    returns the persisted snapshot, never parks on the preload → GREEN.
+     *
+     * This single test proves BOTH #1249 properties at once: cold start no longer
+     * blocks on the prefs read (the no-block assertion) AND the seed is still the
+     * persisted snapshot, not a default (the no-#1088-flash assertion).
+     */
+    @Test
+    fun cold_start_first_read_does_not_block_on_gated_offmain_preload() {
+        // Persist a genuinely NON-default value via a fully-warmed instance.
+        assertNotEquals(AppSettings.DEFAULT_TERMINAL_FONT_SP, PERSISTED_FONT_SP)
+        SettingsRepository(context).setTerminalFontSizeSp(PERSISTED_FONT_SP)
+
+        // Fresh instance = a "process restart" with its off-main preload GATED —
+        // and the gate is NEVER opened, simulating a preload that has not yet
+        // completed by first composition (the contended cold start).
+        val gate = CountDownLatch(1)
+        val repo = SettingsRepository(context, gate)
+
+        val firstObserved = AtomicReference<AppSettings?>(null)
+        val done = CountDownLatch(1)
+        thread(name = "cold-start-first-read") {
+            firstObserved.set(repo.settings.value)
+            done.countDown()
+        }
+
+        // The read MUST return without the gate ever opening (#1249). Pre-fix
+        // this blocks on the gated await → times out → RED.
+        val returned = done.await(3, TimeUnit.SECONDS)
+        assertTrue(
+            "cold-start first settings read must NOT block on the off-main " +
+                "preload (#1249) — it blocked past the timeout with the gate still closed",
+            returned,
+        )
+
+        // And the value it returned is the PERSISTED snapshot (no #1088 flash),
+        // read synchronously without the preload completing.
+        val observed = firstObserved.get()
+            ?: error("settings.value read never completed")
+        assertEquals(PERSISTED_FONT_SP, observed.terminalFontSizeSp, 0f)
     }
 
     /** Defaults read correctly after the off-main build (clean install). */


### PR DESCRIPTION
Closes #1249 (perf half of #1229). Reviewer APPROVED with reviewer-run red→green + explicit no-flash ordering & concurrency reasoning (https://github.com/alexeygrigorev/pocketshell/issues/1249#issuecomment-4878318918). #1088 no-theme-flash and #1229 corrupt-prefs tests stay green. Local gate: diff --check clean, forced settings suite green.