### PR TITLE
core-tmux: bound never-closed %begin block + cap LF buffer (#1231)

### DIFF
--- a/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxClient.kt
+++ b/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxClient.kt
@@ -1875,6 +1875,28 @@ internal class RealTmuxClient(
                         buffer.reset()
                     } else {
                         buffer.write(b.toInt())
+                        if (buffer.size() >= MAX_LINE_BUFFER_BYTES) {
+                            // Issue #1231 T2: an LF-starved stream (a binary MOTD
+                            // that lands before the `-CC` handshake, a degraded
+                            // non-control-mode byte stream, or a wedged server that
+                            // stops emitting LFs) would otherwise grow this buffer
+                            // one byte at a time with no ceiling until the process
+                            // OOMs — silently, with no diagnostic. Cap the
+                            // in-progress line: flush what we have as a (truncated)
+                            // line and reset, so framing stays bounded and the
+                            // overflow is observable. A truncated non-`%`-line just
+                            // parses to null downstream and is skipped.
+                            TmuxClientDiagnostics.record(
+                                "tmux_client_line_overflow",
+                                buildMap {
+                                    put("session", sessionName)
+                                    put("bytes", buffer.size())
+                                    put("maxBytes", MAX_LINE_BUFFER_BYTES)
+                                },
+                            )
+                            emit(takeLine(buffer))
+                            buffer.reset()
+                        }
                     }
                     i++
                 }
@@ -2591,6 +2613,16 @@ internal class RealTmuxClient(
 
         /** Initial per-line accumulation buffer. Grows as needed. */
         private const val DEFAULT_LINE_BUFFER_BYTES = 4096
+
+        /**
+         * Hard ceiling on a single in-progress LF-framed line (issue #1231
+         * T2). A legit `-CC` line — even a wide `%output` batch with escape
+         * sequences — is well under this; the cap only trips on an LF-starved
+         * stream, where without it the accumulation buffer grows unbounded to
+         * an OOM. On overflow the buffer is flushed-and-reset so framing stays
+         * bounded and the event is recorded via `tmux_client_line_overflow`.
+         */
+        private const val MAX_LINE_BUFFER_BYTES = 512 * 1024
 
         /** stdout read granularity for the control-mode reader. */
         private const val READ_CHUNK_BYTES = 8192

--- a/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/protocol/ControlEventStream.kt
+++ b/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/protocol/ControlEventStream.kt
@@ -1,5 +1,6 @@
 package com.pocketshell.core.tmux.protocol
 
+import com.pocketshell.core.tmux.TmuxClientDiagnostics
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
@@ -41,7 +42,37 @@ import kotlinx.coroutines.flow.flow
 public class ControlEventStream(
     private val parser: ControlModeParser = ControlModeParser(),
     private val onResponsePayload: (commandNumber: Long, line: String) -> Unit = { _, _ -> },
+    private val maxOpenBlockLines: Int = MAX_OPEN_BLOCK_LINES,
+    private val maxOpenBlockBytes: Long = MAX_OPEN_BLOCK_BYTES,
 ) {
+    public companion object {
+        /**
+         * Ceiling on payload lines accumulated inside a single `%begin` /
+         * (`%end`|`%error`) block before it is abandoned as never-closing
+         * (issue #1231 T4).
+         *
+         * A legit tmux `-CC` response block is tiny: the largest one
+         * PocketShell issues is a `capture-pane -p -e -S -200` seed
+         * (`SEED_SCROLLBACK_LINES = 200`); `list-sessions` / `list-panes` /
+         * `list-windows` are smaller still. This ceiling is three orders of
+         * magnitude above any real response, so it never trips on legitimate
+         * output — it only fires when a truncated / garbled `%end` (one that
+         * fails `parseBeginEnd` and so never matches the open block) latches
+         * `openBlock` forever, silently swallowing EVERY subsequent line —
+         * including real `%output` — as payload. That is a permanent render
+         * freeze invisible to the black-screen / heal apparatus, because bytes
+         * stop reaching the model entirely.
+         */
+        public const val MAX_OPEN_BLOCK_LINES: Int = 50_000
+
+        /**
+         * Byte ceiling companion to [MAX_OPEN_BLOCK_LINES] — bounds an open
+         * block that stays under the line count but accumulates huge lines.
+         * 8 MB is far beyond any legit `-CC` response block yet caps the
+         * pathological never-closing block's transient memory.
+         */
+        public const val MAX_OPEN_BLOCK_BYTES: Long = 8L * 1024 * 1024
+    }
 
     /**
      * Map [lines] into the structured event stream.
@@ -55,6 +86,11 @@ public class ControlEventStream(
         // `%end` / `%error` — holds the command-number from the `%begin`
         // so we can forward payload lines correctly.
         var openBlock: Long? = null
+        // Payload accumulated inside the current open block. Bounds the block
+        // so a never-closing / garbled `%end` cannot latch the stream into a
+        // permanent silent freeze (issue #1231 T4).
+        var openBlockLines = 0
+        var openBlockBytes = 0L
 
         lines.collect { rawLine ->
             // Byte-level DCS strip; the parser re-strips defensively but we
@@ -72,15 +108,56 @@ public class ControlEventStream(
                     parsed is ControlEvent.Error && parsed.number == openBlock
                 if (closing) {
                     openBlock = null
+                    openBlockLines = 0
+                    openBlockBytes = 0L
                     // Emit the closing event so callers can observe success
                     // vs. failure of the command.
                     emit(parsed!!)
-                } else {
-                    // Payload line. Forward it to the response-correlation
-                    // callback as a String — command-response bodies are
-                    // ASCII / UTF-8 text, never partial multi-byte fragments.
-                    onResponsePayload(openBlock!!, String(lineBytes, Charsets.UTF_8))
+                    return@collect
                 }
+
+                // Not a closing marker — this is a payload line. Guard against
+                // a never-closing block FIRST: a truncated / garbled `%end`
+                // (one that fails `parseBeginEnd` so `parsed` is null or a
+                // non-matching number) would otherwise leave `openBlock`
+                // latched forever, routing every subsequent line — including
+                // real `%output` — to `onResponsePayload` and never emitting an
+                // event again. That is a total silent render freeze the
+                // black-screen / heal apparatus cannot see. Once the block
+                // exceeds the ceiling, abandon it, record a diagnostic, and
+                // resume normal event parsing by re-processing THIS line
+                // outside the block so a real event flows immediately.
+                if (openBlockLines >= maxOpenBlockLines || openBlockBytes >= maxOpenBlockBytes) {
+                    val abandonedNumber = openBlock
+                    TmuxClientDiagnostics.record(
+                        "tmux_control_block_abandoned",
+                        buildMap {
+                            put("commandNumber", abandonedNumber)
+                            put("lines", openBlockLines)
+                            put("bytes", openBlockBytes)
+                            put("maxLines", maxOpenBlockLines)
+                            put("maxBytes", maxOpenBlockBytes)
+                        },
+                    )
+                    openBlock = null
+                    openBlockLines = 0
+                    openBlockBytes = 0L
+                    // Re-process this same line as if it arrived outside a
+                    // block. `parsed` is the parse of `lineBytes`, so reuse it.
+                    val event = parsed ?: return@collect
+                    if (event is ControlEvent.Begin) {
+                        openBlock = event.number
+                    }
+                    emit(event)
+                    return@collect
+                }
+
+                // Payload line. Forward it to the response-correlation
+                // callback as a String — command-response bodies are
+                // ASCII / UTF-8 text, never partial multi-byte fragments.
+                onResponsePayload(openBlock!!, String(lineBytes, Charsets.UTF_8))
+                openBlockLines += 1
+                openBlockBytes += lineBytes.size
                 return@collect
             }
 
@@ -88,6 +165,8 @@ public class ControlEventStream(
             val event = parser.parse(lineBytes) ?: return@collect
             if (event is ControlEvent.Begin) {
                 openBlock = event.number
+                openBlockLines = 0
+                openBlockBytes = 0L
             }
             emit(event)
         }

--- a/shared/core-tmux/src/test/java/com/pocketshell/core/tmux/TmuxClientTest.kt
+++ b/shared/core-tmux/src/test/java/com/pocketshell/core/tmux/TmuxClientTest.kt
@@ -1746,6 +1746,78 @@ class TmuxClientTest {
         }
     }
 
+    /**
+     * Issue #1231 T2 — the LF-framing accumulation buffer in the reader loop
+     * must be bounded. An LF-starved stream (a binary MOTD before the `-CC`
+     * handshake, a degraded non-control-mode byte stream, or a wedged server
+     * that stops emitting LFs) grows the per-line `ByteArrayOutputStream` one
+     * byte at a time. Without a ceiling it grows until the process OOMs, with
+     * NO diagnostic. This test feeds ~1.5 MB with no LF and asserts the buffer
+     * is capped-and-reset (so it never grows to the full feed size), the
+     * `tmux_client_line_overflow` diagnostic fires repeatedly, and normal event
+     * framing resumes once an LF finally arrives.
+     *
+     * Red→green: on base (unbounded buffer) no diagnostic is ever recorded, so
+     * the `overflow.isNotEmpty()` assertion is RED.
+     */
+    @Test
+    fun `LF-starved stream caps the framing buffer and records overflow diagnostic`() = runBlocking {
+        // Mirrors the private TmuxClient.MAX_LINE_BUFFER_BYTES ceiling (512 KB).
+        val maxLineBytes = 512 * 1024
+        val diagnostics = Collections.synchronizedList(
+            mutableListOf<Pair<String, Map<String, Any?>>>(),
+        )
+        TmuxClientDiagnostics.install { event, fields -> diagnostics += event to fields }
+        val shell = FakeShell()
+        val session = FakeSession(shell)
+        val client = RealTmuxClient(session, scope)
+        try {
+            client.connect()
+
+            // Subscribe to the recovered pane's output BEFORE feeding so the
+            // post-overflow frame can't be missed in the subscribe race.
+            val recovered = scope.async {
+                client.outputFor("%0").first()
+            }
+            // Give the collector a tick to subscribe to the per-pane flow.
+            delay(200)
+
+            // Exactly 2× the cap of LF-free bytes → two clean flush-and-reset
+            // overflows that leave the buffer empty, so the trailing frame is
+            // framed cleanly. On the unbounded reader this all accumulates in
+            // ONE ever-growing line buffer that never resets (and would OOM in
+            // production); no overflow diagnostic is ever recorded.
+            val starved = "x".repeat(maxLineBytes * 2)
+            // Then a real, LF-terminated %output frame proves framing resumed.
+            shell.feed(starved + "%output %0 recovered\n")
+
+            // Barrier: the post-overflow frame must reach the pane output.
+            val frame = withTimeout(ASYNC_AWAIT_TIMEOUT_MS) { recovered.await() }
+            assertEquals("recovered", String(frame.data, StandardCharsets.US_ASCII))
+
+            val overflow = diagnostics.filter { it.first == "tmux_client_line_overflow" }
+            assertTrue(
+                "expected at least one tmux_client_line_overflow diagnostic; got none " +
+                    "(unbounded buffer would have OOMed instead of flushing)",
+                overflow.isNotEmpty(),
+            )
+            // Two fires over the 2× feed prove the buffer resets each time
+            // rather than growing unbounded to the full 1 MB.
+            assertTrue(
+                "expected the buffer to cap-and-reset repeatedly, got ${overflow.size} overflow(s)",
+                overflow.size >= 2,
+            )
+            // Each overflow flushed at exactly the ceiling — never the full feed.
+            overflow.forEach { (_, fields) ->
+                assertEquals(maxLineBytes, fields["maxBytes"])
+                assertEquals(maxLineBytes, fields["bytes"])
+            }
+        } finally {
+            TmuxClientDiagnostics.install(TmuxClientDiagnosticSink.Noop)
+            client.close()
+        }
+    }
+
     // ── Issue #1212: pre-registration buffer lifecycle hardening ──────────────
 
     /**

--- a/shared/core-tmux/src/test/java/com/pocketshell/core/tmux/protocol/ControlEventStreamTest.kt
+++ b/shared/core-tmux/src/test/java/com/pocketshell/core/tmux/protocol/ControlEventStreamTest.kt
@@ -1,10 +1,13 @@
 package com.pocketshell.core.tmux.protocol
 
+import com.pocketshell.core.tmux.TmuxClientDiagnosticSink
+import com.pocketshell.core.tmux.TmuxClientDiagnostics
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
+import org.junit.After
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -22,6 +25,20 @@ import org.junit.Test
  * byte lines directly.
  */
 class ControlEventStreamTest {
+
+    /** Captures the diagnostics [ControlEventStream] records via the process-local sink. */
+    private val diagnostics = mutableListOf<Pair<String, Map<String, Any?>>>()
+
+    init {
+        TmuxClientDiagnostics.install(
+            TmuxClientDiagnosticSink { event, fields -> diagnostics += event to fields },
+        )
+    }
+
+    @After
+    fun tearDown() {
+        TmuxClientDiagnostics.install(TmuxClientDiagnosticSink.Noop)
+    }
 
     /** Encode a list of fixture lines to the `Flow<ByteArray>` the stream wants. */
     private fun byteLines(lines: List<String>): Flow<ByteArray> =
@@ -345,6 +362,121 @@ class ControlEventStreamTest {
 
         assertArrayEquals(byteArrayOf(0xE2.toByte(), 0x94.toByte(), 0x80.toByte()), combined)
         assertEquals("─", String(combined, Charsets.UTF_8))
+    }
+
+    // --- issue #1231 T4: a never-closing / garbled %end block must not latch
+    //     the stream into a permanent silent freeze ---------------------------
+
+    @Test
+    fun `never-closing block is abandoned so output events resume after the bound`() = runTest {
+        // The maintainer's failure: a %begin opens a response block whose %end
+        // is truncated / garbled (fails parseBeginEnd), so it never matches the
+        // open block. On the unbounded code openBlock stays latched forever and
+        // EVERY subsequent line — including real %output — is swallowed as
+        // payload and never emitted, freezing all pane rendering permanently
+        // and invisibly to the black-screen / heal apparatus.
+        val payload = mutableListOf<String>()
+        val stream = ControlEventStream(
+            onResponsePayload = { _, line -> payload += line },
+            // Tiny bound so the fixture stays small; production ceiling is huge.
+            maxOpenBlockLines = 3,
+        )
+
+        val lines = listOf(
+            "%begin 1 5 0",
+            "%end 1 5",             // garbled %end (2 fields) → payload, block stays open
+            "%output %0 payload-b", // payload (block still open)
+            "%output %0 payload-c", // payload — reaches the 3-line bound
+            "%output %0 after-1",   // 4th inside-block line → abandon, re-parsed as Output
+            "%output %0 after-2",   // now outside the block → Output event
+            "%exit",
+        )
+
+        val events = stream.events(byteLines(lines)).toList()
+
+        // After the bound the block is abandoned and events flow again. On the
+        // unbounded (base) code, only %begin escapes — after-1/after-2/%exit are
+        // all swallowed as payload — so this assertion is RED without the fix.
+        val outputs = events.filterIsInstance<ControlEvent.Output>()
+        assertEquals(
+            "output events must resume after the never-closing block is abandoned",
+            2,
+            outputs.size,
+        )
+        assertTrue("session lifecycle events must resume too", events.any { it is ControlEvent.Exit })
+
+        // A diagnostic makes the stuck block observable and recoverable.
+        assertTrue(
+            "a tmux_control_block_abandoned diagnostic must be recorded",
+            diagnostics.any { it.first == "tmux_control_block_abandoned" },
+        )
+        val diag = diagnostics.first { it.first == "tmux_control_block_abandoned" }.second
+        assertEquals(5L, diag["commandNumber"])
+        assertEquals(3, diag["lines"])
+
+        // The three lines before the bound were still delivered as payload.
+        assertEquals(3, payload.size)
+    }
+
+    @Test
+    fun `open block over the byte ceiling is abandoned`() = runTest {
+        // Same latch class, tripped by bytes rather than line count: a block
+        // that stays under the line count but accumulates a huge payload.
+        val big = "x".repeat(2000)
+        val stream = ControlEventStream(
+            maxOpenBlockLines = 1_000_000,   // effectively unlimited by count
+            maxOpenBlockBytes = 4_000L,      // ~2 payload lines
+        )
+
+        val lines = listOf(
+            "%begin 1 9 0",
+            big,                    // ~2000 bytes payload
+            big,                    // ~4000 bytes → reaches the byte bound
+            "%output %0 resumed",   // over the ceiling → abandon, re-parsed as Output
+            "%exit",
+        )
+
+        val events = stream.events(byteLines(lines)).toList()
+
+        assertTrue(
+            "output must resume once the byte ceiling abandons the block",
+            events.any { it is ControlEvent.Output },
+        )
+        assertTrue(
+            "a tmux_control_block_abandoned diagnostic must be recorded",
+            diagnostics.any { it.first == "tmux_control_block_abandoned" },
+        )
+    }
+
+    @Test
+    fun `a normal large response under the default ceiling never abandons`() = runTest {
+        // Regression guard against false positives: a legit multi-line response
+        // (well under the production ceiling) round-trips as payload with the
+        // block closing cleanly and NO diagnostic recorded. Uses the default
+        // constructor bounds (MAX_OPEN_BLOCK_LINES / _BYTES).
+        val payload = mutableListOf<String>()
+        val stream = ControlEventStream(
+            onResponsePayload = { _, line -> payload += line },
+        )
+
+        val body = (1..500).map { "session $it: 1 windows" }
+        val lines = buildList {
+            add("%begin 1 7 0")
+            addAll(body)
+            add("%end 1 7 0")
+            add("%output %0 after")
+        }
+
+        val events = stream.events(byteLines(lines)).toList()
+
+        assertTrue(events[0] is ControlEvent.Begin)
+        assertTrue("the real %end must close the block", events[1] is ControlEvent.End)
+        assertTrue(events[2] is ControlEvent.Output)
+        assertEquals(500, payload.size)
+        assertTrue(
+            "no diagnostic may fire for a legit response",
+            diagnostics.none { it.first == "tmux_control_block_abandoned" },
+        )
     }
 
     private fun indexOfSubarray(haystack: ByteArray, needle: ByteArray): Int {


### PR DESCRIPTION
Closes #1231. Reviewer APPROVED — tree completeness confirmed after the implementer's re-apply, reviewer-run red→green on all 3 behaviour tests, threshold safety verified (SEED_SCROLLBACK_LINES=200 << 50k/8MB/512KB), full 172-test suite green (https://github.com/alexeygrigorev/pocketshell/issues/1231#issuecomment-4878322110). Local gate: diff --check clean, forced core-tmux suite green.