### PR TITLE
test: de-flake passiveSilentReattach heal test (producer-dispatcher pin) (#1258)

### DIFF
--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
@@ -3308,6 +3308,26 @@ class TmuxSessionViewModelTest {
         vm.setProcessForegroundForClearedForTest(true)
         vm.setScreenInteractiveForTest(true)
         vm.setStaleRenderWatchdogMaxTicksForTest(1000)
+        // Issue #1258 (CI-flake fix, sibling of #1250/#1259): pin the
+        // TerminalSurfaceState external-producer dispatcher to the SHARED
+        // virtual-clock scheduler. The default factory builds
+        // `TerminalSurfaceState()` on the production `Dispatchers.IO` (a real
+        // off-Main thread — correct on-device). But this warm silent reattach
+        // REBINDS each pane's producer several times (initial attach → reattach
+        // rebindVisiblePaneProducersToClient → each connected-blank-watchdog
+        // reseed), and every rebind CANCELS the prior producer whose `finally`
+        // runs `detachCompletedExternalProducer` (nulling `bridge`/`_session`)
+        // via a `Dispatchers.Main.immediate` hop OFF that real IO thread. Under
+        // `runTest`'s virtual clock that real-thread hop lands at a
+        // non-deterministic point, so the pane's emulator was sometimes DETACHED
+        // (isAttached=false) at assertion time — and `visibleScreenIsBlank()`
+        // returns false with NO emulator, spuriously failing the "seed stayed
+        // empty -> black" precondition under load. Confining the producer to the
+        // shared scheduler makes attach/detach step deterministically under
+        // `advanceTimeBy`/`runCurrent` (same pin as the sibling heal tests).
+        vm.setTerminalSurfaceStateFactoryForTest {
+            TerminalSurfaceState(StandardTestDispatcher(scheduler))
+        }
         val session = FakeSshSession()
         val deadClient = FakeTmuxClient()
         val replacementClient =


### PR DESCRIPTION
Closes #1258. Reviewer APPROVED — 20-insertion test-only determinism pin, byte-identical assertion, reviewer-run 20/20 green + 2/8 fail on neutralized base under load (pin proven load-bearing), check-test-validity clean (https://github.com/alexeygrigorev/pocketshell/issues/1258#issuecomment-4878637246). Same pattern as the merged #1259.