### PR TITLE
usage: surface real dependency error, not 'pocketshell not installed' (#1220)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/usage/UsageRemoteSource.kt
+++ b/app/src/main/java/com/pocketshell/app/usage/UsageRemoteSource.kt
@@ -4,6 +4,7 @@ import com.pocketshell.app.pocketshell.PocketshellCommand
 import com.pocketshell.core.ssh.SshException
 import com.pocketshell.core.ssh.SshSession
 import com.pocketshell.core.usage.PocketshellUsageJsonParser
+import com.pocketshell.core.usage.UsageParseException
 import com.pocketshell.core.usage.UsageProviderRecord
 import kotlinx.coroutines.CancellationException
 import org.json.JSONArray
@@ -166,7 +167,18 @@ public class UsageRemoteSource @Inject constructor(
                 val reason = result.stderr.ifBlank { result.stdout }.ifBlank { "usage command exited ${result.exitCode}" }
                 return UsageFetchResult.Failed(reason)
             }
-            UsageFetchResult.Success(parser.parse(result.stdout))
+            // exit 0: pocketshell resolved and ran (binary present). Parse its
+            // usage JSON — but when parsing yields NO records because pocketshell
+            // printed its OWN dependency error (e.g. `quse` missing) as plain
+            // text on stdout (issue #1220), surface pocketshell's real message +
+            // install hint. Do NOT leak the JSON parser internals, and NEVER map
+            // this to ToolMissing — "pocketshell not installed" is exit-127 only.
+            val records = try {
+                parser.parse(result.stdout)
+            } catch (e: UsageParseException) {
+                return UsageFetchResult.Failed(pocketshellUsageErrorReason(result.stdout, e))
+            }
+            UsageFetchResult.Success(records)
         } catch (e: CancellationException) {
             throw e
         } catch (t: Throwable) {
@@ -190,6 +202,35 @@ public class UsageRemoteSource @Inject constructor(
          * the PATH-robust [PocketshellCommand.wrap] of [DEFAULT_USAGE_ARGS].
          */
         public const val defaultUsageCommand: String = "pocketshell usage --json"
+
+        /**
+         * Upper bound on the surfaced pocketshell-error reason (issue #1220) so
+         * an unexpectedly large non-JSON stdout can't produce a runaway panel
+         * message. The failure panel already caps to a few lines visually; this
+         * keeps the model value bounded too.
+         */
+        private const val POCKETSHELL_ERROR_REASON_MAX_CHARS: Int = 500
+    }
+
+    /**
+     * Build the user-facing failure reason for an exit-0 usage read whose
+     * stdout did not parse into any usage record (issue #1220).
+     *
+     * pocketshell resolved and ran (exit 0 ⇒ the binary is present), so this is
+     * NOT "pocketshell not installed". The most common cause is pocketshell
+     * emitting its OWN dependency error — e.g. "`quse` is not installed on this
+     * host. Install it via `uv tool install quse` ..." — as plain text. Prefer
+     * that message (dropping pocketshell's own "pocketshell: " prefix so it
+     * reads as the dependency error, not as pocketshell itself being absent) so
+     * the panel shows the real problem + install hint. Fall back to the parse
+     * diagnostic only when stdout is blank.
+     */
+    private fun pocketshellUsageErrorReason(stdout: String, parseError: UsageParseException): String {
+        val message = stdout.trim().takeIf { it.isNotEmpty() }
+            ?.removePrefix("pocketshell:")?.trim()
+            ?.takeIf { it.isNotEmpty() }
+            ?: return parseError.message ?: "usage command produced no usable data"
+        return message.take(POCKETSHELL_ERROR_REASON_MAX_CHARS)
     }
 
     private fun parseProviderErrorStdout(stdout: String): List<UsageProviderRecord>? {

--- a/app/src/test/java/com/pocketshell/app/usage/UsageRemoteSourceTest.kt
+++ b/app/src/test/java/com/pocketshell/app/usage/UsageRemoteSourceTest.kt
@@ -206,6 +206,33 @@ class UsageRemoteSourceTest {
         assertTrue("zero-parse must not be a silent Success", result is UsageFetchResult.Failed)
     }
 
+    // -- issue #1220: pocketshell present but `quse` backend missing ---------
+
+    @Test
+    fun fetchUsage_exit0QuseMissingText_surfacesPocketshellOwnError_notParserInternals() = runTest {
+        // Issue #1220 (reproduce-first): pocketshell IS installed and runs
+        // (exit 0), but `pocketshell usage --json` prints pocketshell's OWN
+        // dependency error — `quse` missing — as PLAIN TEXT on stdout instead
+        // of usage JSON. The panel must surface pocketshell's real message +
+        // install hint. It must NOT be classified as ToolMissing ("pocketshell
+        // not installed"), and it must NOT leak the JSON parser internals.
+        val quseMissing =
+            "pocketshell: `quse` is not installed on this host. " +
+                "Install it via `uv tool install quse` or `pipx install quse` and re-run."
+        val session = FakeSshSession(
+            mapOf(defaultFetchCommand to ExecResult(quseMissing, "", 0)),
+        )
+
+        val result = source.fetchUsage(session)
+
+        assertTrue("quse-missing must NOT read as pocketshell missing", result !is UsageFetchResult.ToolMissing)
+        assertTrue("zero-parse pocketshell error must be a visible Failed, got $result", result is UsageFetchResult.Failed)
+        val reason = (result as UsageFetchResult.Failed).reason
+        assertTrue("must surface pocketshell's own quse dependency error, got: $reason", reason.contains("quse"))
+        assertTrue("must keep pocketshell's install hint, got: $reason", reason.contains("Install", ignoreCase = true))
+        assertTrue("must not leak the JSON parser internals, got: $reason", !reason.contains("invalid usage JSON", ignoreCase = true))
+    }
+
     @Test
     fun fetchUsage_nonzeroNonJsonStillReportsFailure() = runTest {
         val session = FakeSshSession(

--- a/app/src/test/java/com/pocketshell/app/usage/UsageViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/usage/UsageViewModelTest.kt
@@ -754,6 +754,97 @@ class UsageViewModelTest {
     }
 
     @Test
+    fun sshHostUsageFetcher_pocketshellPresentButQuseMissing_surfacesQuseError_notToolMissing() = runTest {
+        // Issue #1220 (reproduce-first, real path): pocketshell IS installed
+        // (the PATH-robust wrapped `pocketshell usage --json` resolves and runs,
+        // exit 0), but pocketshell prints its OWN dependency error — `quse`
+        // missing — as PLAIN TEXT on stdout at exit 0. The detail panel must
+        // surface that real dependency error, NOT conflate it with "pocketshell
+        // not installed" (ToolMissing is exit-127 only).
+        val keyFile = Files.createTempFile("pocketshell-quse", ".key").toFile()
+        keyFile.deleteOnExit()
+        val keyId = db.sshKeyDao().insert(
+            SshKeyEntity(name = "k", privateKeyPath = keyFile.absolutePath),
+        )
+        val host = HostEntity(
+            name = "hetzner",
+            hostname = "quse.example",
+            username = "u",
+            keyId = keyId,
+        )
+        val wrappedUsage = com.pocketshell.app.pocketshell.PocketshellCommand.wrap(
+            UsageRemoteSource.DEFAULT_USAGE_ARGS,
+        )
+        val quseMissing =
+            "pocketshell: `quse` is not installed on this host. " +
+                "Install it via `uv tool install quse` or `pipx install quse` and re-run."
+        val session = FakeSshSession(
+            canned = mapOf(wrappedUsage to ExecResult(stdout = quseMissing, stderr = "", exitCode = 0)),
+        )
+        val fetcher = SshHostUsageFetcher(
+            sshKeyDao = db.sshKeyDao(),
+            remoteSource = UsageRemoteSource(),
+            sshLeaseManager = leaseManagerFor(CountingLeaseConnector(session), this),
+        )
+
+        val result = fetcher.fetch(host)
+
+        assertTrue(
+            "quse-missing must NOT be classified as pocketshell missing, got $result",
+            result is HostUsageFetch.Failed,
+        )
+        val reason = (result as HostUsageFetch.Failed).reason
+        assertTrue("must surface pocketshell's own quse dependency error, got: $reason", reason.contains("quse"))
+        assertTrue("must keep pocketshell's install hint, got: $reason", reason.contains("Install", ignoreCase = true))
+        assertFalse("must not leak the JSON parser internals, got: $reason", reason.contains("invalid usage JSON", ignoreCase = true))
+    }
+
+    @Test
+    fun refresh_quseMissingHostRendersDependencyError_absentHostRendersNotInstalled() = runTest {
+        // Issue #1220: the two states must render DIFFERENTLY on the panel:
+        //  - pocketshell present but `pocketshell usage` errors (quse missing) →
+        //    a failed panel carrying pocketshell's own message, NOT the
+        //    "pocketshell not installed" empty state.
+        //  - pocketshell genuinely absent (exit 127 → ToolMissing) → the
+        //    "pocketshell not installed" empty state (correct only here).
+        val keyId = db.sshKeyDao().insert(
+            SshKeyEntity(name = "k", privateKeyPath = "/dev/null/missing"),
+        )
+        val quseHostId = db.hostDao().insert(
+            HostEntity(name = "hetzner", hostname = "quse.example", username = "u", keyId = keyId),
+        )
+        val absentHostId = db.hostDao().insert(
+            HostEntity(name = "bare", hostname = "absent.example", username = "u", keyId = keyId),
+        )
+        val quseMessage =
+            "`quse` is not installed on this host. " +
+                "Install it via `uv tool install quse` or `pipx install quse` and re-run."
+        val fetcher = FakeFetcher(
+            scripts = mapOf(
+                "quse.example" to HostUsageFetch.Failed(quseMessage),
+                "absent.example" to HostUsageFetch.ToolMissing,
+            ),
+        )
+
+        val viewModel = testViewModel(fetcher, testScheduler)
+        advanceUntilIdle()
+
+        val state = viewModel.state.value
+        // quse host → the failed panel with the real dependency error.
+        assertEquals(listOf(quseHostId), state.failedHosts.map { it.hostId })
+        assertTrue(
+            "quse dependency error must be surfaced, got: ${state.failedHosts.single().reason}",
+            state.failedHosts.single().reason.contains("quse"),
+        )
+        assertFalse(
+            "quse-missing host must NOT be listed as pocketshell-not-installed",
+            state.missingToolHosts.any { it.hostId == quseHostId },
+        )
+        // absent host → the "pocketshell not installed" empty state, correct here.
+        assertEquals(listOf(absentHostId), state.missingToolHosts.map { it.hostId })
+    }
+
+    @Test
     fun sshHostUsageFetcher_nonJsonUsageFailureIsReturnedForUi() = runTest {
         val keyFile = Files.createTempFile("pocketshell-usage-failed", ".key").toFile()
         keyFile.deleteOnExit()

--- a/docs/server-setup.md
+++ b/docs/server-setup.md
@@ -89,5 +89,6 @@ package are bumped in lockstep on each release tag).
 |---|---|---|
 | "pocketshell not installed" / "server-side usage tracking unavailable" | `~/.local/bin` not on non-interactive SSH PATH | Step 2 (PATH above the `.bashrc` guard) |
 | `pocketshell: command not found` over `ssh host 'pocketshell ...'` | not installed, or PATH | Step 1 + Step 2 |
+| Usage panel shows a `quse`-not-installed / dependency error (NOT "pocketshell not installed") | pocketshell IS installed but its usage backend `quse` is missing (e.g. a dangling `~/.local/bin/quse` symlink); `pocketshell usage --json` prints pocketshell's own error at exit 0 | Install/repair `quse` (`uv tool install quse` or `pipx install quse`) — issue #1220. The app now surfaces pocketshell's own message rather than mislabelling it "pocketshell not installed". |
 | One provider shows an error, others OK | that provider's helper (e.g. `goz`) missing | install that helper, or ignore |
 | Worked before, broke after dotfile edit | PATH line moved below the guard | Step 2 |


### PR DESCRIPTION
Closes #1220

## What
`pocketshell usage --json` can exit 0 with pocketshell's own non-JSON dependency error (e.g. `quse` missing). The exit-0 parse branch now catches `UsageParseException` and returns `Failed(pocketshellUsageErrorReason(...))` — surfacing pocketshell's own message + install hint. `pocketshell not installed` is now exit-127-only. Both the detail-panel `failedHosts` and summary `UsageSnapshot.Failed` surfaces route identically, so one classification fix covers both.

## Verification
- Reviewer-run red→green (G1/G10): neutralized the fix → two real-path classification tests fail with the leaked-internals reason; restored → green.
- G3 counts: UsageRemoteSourceTest 18/0/0, UsageViewModelTest 22/0/0, UsageSchedulerTest 10/0/0.
- G2: no `quse` string-match — generic exit-0 non-JSON handling, second non-quse fixture present.
- Hard-cut (D22), no fallback branch.

Reviewer APPROVED: https://github.com/alexeygrigorev/pocketshell/issues/1220#issuecomment-4879535029