### PR TITLE
voice: buffer inline dictation transcript across pane re-key (#1226)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/session/InlineDictation.kt
+++ b/app/src/main/java/com/pocketshell/app/session/InlineDictation.kt
@@ -57,13 +57,13 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -166,10 +166,24 @@ public class InlineDictationViewModel @Inject constructor(
     /** Current dictation state — drives the mic slot's visual treatment. */
     public val uiState: StateFlow<UiState> = _uiState.asStateFlow()
 
-    // Replay = 0 because every transcription is a one-shot event that must
-    // be written to the terminal exactly once. Re-collecting (e.g. on
-    // recomposition) must not re-write old bytes.
-    private val _transcriptions: MutableSharedFlow<String> = MutableSharedFlow(replay = 0)
+    // Issue #1226: a durable delivery Channel — NOT a `replay = 0`
+    // MutableSharedFlow. A replay-0 SharedFlow drops any emit that lands
+    // while there is no active collector, so a transcript produced during the
+    // 1-3s Whisper round-trip was silently lost whenever the screen's
+    // collector was momentarily torn down — e.g. the focused pane flips to
+    // `null` or re-keys during a brief reconnect (common on mobile). The FSM
+    // was already back at Idle with `error == null`, so the user believed
+    // they had sent a command that never arrived.
+    //
+    // A Channel buffers emitted transcripts even when no collector is
+    // subscribed, and hands each buffered value to exactly one collector
+    // exactly once when the screen re-subscribes on re-key. That gives us the
+    // "delivered on re-key, never dropped, never duplicated" contract:
+    //  - UNLIMITED + `trySend` so emission never suspends or fails.
+    //  - `receiveAsFlow()` distributes each element to a single collector and
+    //    resumes across consecutive collections (the LaunchedEffect re-key),
+    //    so nothing is replayed to a fresh collector (no double-write).
+    private val deliveryChannel: Channel<String> = Channel(capacity = Channel.UNLIMITED)
 
     /**
      * Stream of successfully transcribed text. The session screen collects
@@ -180,8 +194,13 @@ public class InlineDictationViewModel @Inject constructor(
      * transcribed text becomes terminal stdin directly" — the user is
      * dictating a command name or fragment, not a complete line they want
      * submitted.
+     *
+     * Issue #1226: backed by [deliveryChannel] so a transcript emitted while
+     * the collector is torn down (pane null / re-keying during a reconnect)
+     * is buffered and delivered when the collector re-subscribes, rather than
+     * being dropped into the collector gap.
      */
-    public val transcriptions: SharedFlow<String> = _transcriptions.asSharedFlow()
+    public val transcriptions: Flow<String> = deliveryChannel.receiveAsFlow()
 
     private var recordingJob: Job? = null
     private var transcribeJob: Job? = null
@@ -638,7 +657,10 @@ public class InlineDictationViewModel @Inject constructor(
                         "pendingQueued" to (pendingId != null),
                         "mode" to _uiState.value.mode.name,
                     )
-                    _transcriptions.emit(trimmed)
+                    // Issue #1226: buffered send — survives a torn-down /
+                    // re-keying collector so the transcript is not lost in the
+                    // reconnect gap.
+                    deliveryChannel.trySend(trimmed)
                 },
                 onFailure = { t ->
                     val msg = when (t) {
@@ -728,9 +750,11 @@ public class InlineDictationViewModel @Inject constructor(
             "transcriptBytes" to text.toByteArray(Charsets.UTF_8).size,
             "mode" to _uiState.value.mode.name,
         )
-        transcribeJob = viewModelScope.launch {
-            _transcriptions.emit(text)
-        }
+        // Issue #1226: buffered send (see [deliveryChannel]) — no coroutine
+        // needed since `trySend` never suspends, and it survives a torn-down /
+        // re-keying collector so the Android-speech transcript is not dropped
+        // in a reconnect gap.
+        deliveryChannel.trySend(text)
     }
 
     private fun failAndroidSpeechRecognition(message: String) {

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
@@ -1158,8 +1158,18 @@ public fun TmuxSessionScreen(
     // user is looking at once promotion makes it active — not a no-op.
     val focusedPaneId = surfacePane?.paneId
     LaunchedEffect(inlineDictationViewModel, dictationMode, focusedPaneId) {
+        // Issue #1226: do NOT drain the durable delivery channel while there
+        // is no pane to receive the text. The old code collected the flow even
+        // when `focusedPaneId` was null and then `return@collect`-discarded the
+        // value — so a transcript that resolved during a brief drop/reconnect
+        // (pane flipped to null mid Whisper round-trip) was pulled out of the
+        // channel and thrown away, silently losing the user's command. By
+        // returning early here we leave the transcript buffered in the
+        // ViewModel's channel; when the session re-attaches and the pane
+        // re-keys to a live id, this effect re-runs and delivers the buffered
+        // transcript into the pane the user is now looking at.
+        val paneId = focusedPaneId ?: return@LaunchedEffect
         inlineDictationViewModel.transcriptions.collect { text ->
-            val paneId = focusedPaneId ?: return@collect
             when (dictationMode) {
                 InlineDictationViewModel.DictationMode.Prompt -> {
                     if (text.isNotEmpty()) {

--- a/app/src/test/java/com/pocketshell/app/session/InlineDictationViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/session/InlineDictationViewModelTest.kt
@@ -15,6 +15,7 @@ import com.pocketshell.core.voice.WhisperClient
 import com.pocketshell.core.voice.WhisperException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.take
@@ -1443,5 +1444,174 @@ class InlineDictationViewModelTest {
         } finally {
             // Nothing to release; the abandoned worker honours interrupt.
         }
+    }
+
+    // -- Issue #1226: durable delivery across a torn-down / re-keying collector
+
+    @Test
+    fun transcriptEmittedWhileNoCollectorSubscribedSurvivesTheReKey() = runTest {
+        // Reproduces the silent data-loss class (issue #1226). The user
+        // dictates a command and taps stop; during the 1-3s Whisper round-trip
+        // the session briefly drops/reconnects, so the screen's transcript
+        // collector is torn down (focusedPaneId flips to null / re-keys) and no
+        // collector is subscribed at emit time. On the old `replay = 0`
+        // MutableSharedFlow the emit lands in the collector gap and is silently
+        // dropped — the FSM is already back at Idle with error == null, so the
+        // user believes they sent a command that never arrived.
+        //
+        // RED on base: with the SharedFlow, a late subscriber never sees the
+        // dropped value -> `received` stays empty -> the assert fails.
+        // GREEN with the fix: the Channel buffers the transcript and hands it
+        // to the collector when it re-subscribes on re-key.
+        val audio = SpeechAudioGuard.speechWavForTesting()
+        val vm = newVm(
+            mic = FakeMicCapture(audio = audio),
+            whisper = fakeWhisperClient { Result.success("deploy prod") },
+            samplerDispatcher = StandardTestDispatcher(testScheduler),
+        )
+
+        // No collector subscribed — the screen's collector is torn down during
+        // the reconnect gap while the Whisper round-trip resolves.
+        vm.onMicTap()
+        runCurrent()
+        vm.onMicTap()
+        advanceUntilIdle()
+
+        // Exactly the "user thinks it sent" state: Idle, no error surfaced.
+        assertEquals(RecordingState.Idle, vm.uiState.value.recording)
+        assertNull(vm.uiState.value.error)
+
+        // The pane re-keys to a live id and the screen re-subscribes.
+        val received = mutableListOf<String>()
+        val collector = launch { received += vm.transcriptions.first() }
+        advanceUntilIdle()
+
+        assertEquals(
+            "transcript emitted during the collector gap must survive the re-key, not be dropped",
+            listOf("deploy prod"),
+            received,
+        )
+        collector.cancel()
+    }
+
+    @Test
+    fun transcriptDeliveredExactlyOnceWhileCollectorStaysAlive() = runTest {
+        // Subscriber-alive path — the pane survives, the transcript is
+        // delivered once and never duplicated (AC: no duplicate delivery when
+        // the pane survives).
+        val vm = newVm(
+            mic = FakeMicCapture(audio = SpeechAudioGuard.speechWavForTesting()),
+            whisper = fakeWhisperClient { Result.success("git status") },
+            samplerDispatcher = StandardTestDispatcher(testScheduler),
+        )
+
+        val received = mutableListOf<String>()
+        val collector = launch { vm.transcriptions.collect { received += it } }
+        runCurrent()
+
+        vm.onMicTap()
+        runCurrent()
+        vm.onMicTap()
+        advanceUntilIdle()
+
+        assertEquals(listOf("git status"), received)
+
+        // Let the collector keep running: a durable channel must not
+        // re-deliver an already-consumed value.
+        advanceUntilIdle()
+        assertEquals(listOf("git status"), received)
+        collector.cancel()
+    }
+
+    @Test
+    fun reKeyAfterSuccessfulDeliveryDoesNotRedeliverTranscript() = runTest {
+        // Guards AC3 against the Channel change: a collector that re-subscribes
+        // AFTER a value was already delivered must NOT see it again (a
+        // `replay = 1` fix would have re-fired the command into the terminal).
+        val vm = newVm(
+            mic = FakeMicCapture(audio = SpeechAudioGuard.speechWavForTesting()),
+            whisper = fakeWhisperClient { Result.success("git status") },
+            samplerDispatcher = StandardTestDispatcher(testScheduler),
+        )
+
+        val firstReceived = mutableListOf<String>()
+        val first = launch { vm.transcriptions.collect { firstReceived += it } }
+        runCurrent()
+
+        vm.onMicTap()
+        runCurrent()
+        vm.onMicTap()
+        advanceUntilIdle()
+
+        assertEquals(listOf("git status"), firstReceived)
+        first.cancel() // pane re-keys AFTER successful delivery
+
+        val secondReceived = mutableListOf<String>()
+        val second = launch { vm.transcriptions.collect { secondReceived += it } }
+        advanceUntilIdle()
+
+        assertTrue(
+            "re-key after delivery must not replay the transcript, got $secondReceived",
+            secondReceived.isEmpty(),
+        )
+        second.cancel()
+    }
+
+    @Test
+    fun screenCollectorPatternDeliversTranscriptAfterPaneReKeyDuringReconnect() = runTest {
+        // Faithful model of TmuxSessionScreen's inline-dictation collector and
+        // the #1226 fix: while focusedPaneId is null (session dropped mid
+        // Whisper round-trip) the LaunchedEffect must NOT drain the delivery
+        // channel; when the pane re-keys to a live id the effect re-runs and
+        // delivers the buffered transcript into the pane the user is now
+        // looking at.
+        //
+        // RED on base: the old code drained the SharedFlow even with a null
+        // pane and `return@collect`-discarded the value (and the SharedFlow
+        // dropped it anyway with no subscriber) -> `delivered` stays empty.
+        // GREEN with the fix: pane-null skips the collect entirely, the Channel
+        // buffers, and the re-keyed collector delivers.
+        val vm = newVm(
+            mic = FakeMicCapture(audio = SpeechAudioGuard.speechWavForTesting()),
+            whisper = fakeWhisperClient { Result.success("make deploy") },
+            samplerDispatcher = StandardTestDispatcher(testScheduler),
+        )
+
+        val delivered = mutableListOf<Pair<String, String>>() // paneId to text
+        var focusedPaneId: String? = null
+        var collectorJob: Job? = null
+
+        // Mirrors LaunchedEffect(inlineDictationViewModel, dictationMode,
+        // focusedPaneId): re-bind the collector on every focusedPaneId change,
+        // and skip collecting entirely when there is no pane (the #1226 guard).
+        fun rebindCollector() {
+            collectorJob?.cancel()
+            val paneId = focusedPaneId ?: return
+            collectorJob = launch {
+                vm.transcriptions.collect { text -> delivered += paneId to text }
+            }
+        }
+
+        rebindCollector() // pane null: effect returns early, nothing draining
+        runCurrent()
+
+        // Dictation completes while focusedPaneId is null (the reconnect gap).
+        vm.onMicTap()
+        runCurrent()
+        vm.onMicTap()
+        advanceUntilIdle()
+
+        assertTrue(
+            "no delivery may happen while there is no pane to receive it, got $delivered",
+            delivered.isEmpty(),
+        )
+
+        // Reconnect completes; the pane re-keys to a live id -> effect re-runs.
+        focusedPaneId = "%7"
+        rebindCollector()
+        advanceUntilIdle()
+
+        assertEquals(listOf("%7" to "make deploy"), delivered)
+        collectorJob?.cancel()
     }
 }


### PR DESCRIPTION
Closes #1226

## What
Inline dictation `_transcriptions` was a `MutableSharedFlow(replay=0)` — an emit landing while no collector was subscribed (pane null / re-keyed during a 1-3s Whisper round-trip on a mobile reconnect) was silently dropped, FSM already back at Idle with no error. Now a `Channel(UNLIMITED)` exposed via `receiveAsFlow()` buffers the emit and delivers it exactly once on re-key. The screen collector's `focusedPaneId ?: return@LaunchedEffect` guard sits BEFORE `transcriptions.collect{}`, so no collector consumes-and-discards during the null window.

## Verification (reviewer-driven red→green)
- Reverted only production `InlineDictation.kt` to base → 2 reproduction tests fail with AssertionError; restored → green.
- F2 both paths (subscriber-alive + torn-down/re-key) covered; AC3 exactly-once verified (no double-deliver on re-key).
- `check-test-validity.sh` PASS.

## Known non-blocking follow-ups (to be filed)
Permanent-dead-pane (session never returns) still drops silently — only the delivered-on-re-key OR-branch is implemented, not a PendingTranscriptionStore retry affordance; `Channel(UNLIMITED)` is unbounded.

Reviewer APPROVED: https://github.com/alexeygrigorev/pocketshell/issues/1226#issuecomment-4879558452