### PR TITLE
hardening: ReleaseChecker/ShareActivity/PcmCapturePump + Room exportSchema (#1234 items 1,2,4)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/release/ReleaseChecker.kt
+++ b/app/src/main/java/com/pocketshell/app/release/ReleaseChecker.kt
@@ -114,27 +114,40 @@ open class ReleaseChecker(
                     setRequestProperty("User-Agent", USER_AGENT)
                 }
 
-                val code = conn.responseCode
-                if (code != 200) {
-                    // GitHub returns 403 with a rate-limit body for
-                    // unauthenticated bursts — the single most likely cause
-                    // of "the banner never showed at cold launch". Naming the
-                    // code makes that diagnosable.
-                    val reason = "GitHub returned HTTP $code"
-                    Log.w(TAG, "release check failed: $reason (current=$currentVersion)")
-                    return@withContext ReleaseCheckResult.Failed(reason)
-                }
-
-                val body = conn.inputStream.bufferedReader().readText()
-                when (val outcome = parseReleaseOutcome(body, currentVersion)) {
-                    is ParsedReleaseOutcome.UpdateAvailable ->
-                        ReleaseCheckResult.UpdateAvailable(outcome.info)
-                    ParsedReleaseOutcome.UpToDate ->
-                        ReleaseCheckResult.UpToDate
-                    is ParsedReleaseOutcome.Failed -> {
-                        Log.w(TAG, "release check failed: ${outcome.reason} (current=$currentVersion)")
-                        ReleaseCheckResult.Failed(outcome.reason)
+                // A single `disconnect()` in the finally releases the socket no
+                // matter which branch runs (or throws). Without it the keep-alive
+                // socket leaks — repeated cold-launch polls pile up half-open
+                // connections. The input/error streams are additionally closed
+                // (via `use`) so the body is drained; on a non-200 (the common
+                // GitHub 403 rate-limit) an unread + unclosed `errorStream`
+                // otherwise leaks the connection back-pressure too.
+                try {
+                    val code = conn.responseCode
+                    if (code != 200) {
+                        // GitHub returns 403 with a rate-limit body for
+                        // unauthenticated bursts — the single most likely cause
+                        // of "the banner never showed at cold launch". Naming the
+                        // code makes that diagnosable. Drain + close the error
+                        // stream so the socket is reusable rather than leaked.
+                        conn.errorStream?.use { runCatching { it.readBytes() } }
+                        val reason = "GitHub returned HTTP $code"
+                        Log.w(TAG, "release check failed: $reason (current=$currentVersion)")
+                        ReleaseCheckResult.Failed(reason)
+                    } else {
+                        val body = conn.inputStream.bufferedReader().use { it.readText() }
+                        when (val outcome = parseReleaseOutcome(body, currentVersion)) {
+                            is ParsedReleaseOutcome.UpdateAvailable ->
+                                ReleaseCheckResult.UpdateAvailable(outcome.info)
+                            ParsedReleaseOutcome.UpToDate ->
+                                ReleaseCheckResult.UpToDate
+                            is ParsedReleaseOutcome.Failed -> {
+                                Log.w(TAG, "release check failed: ${outcome.reason} (current=$currentVersion)")
+                                ReleaseCheckResult.Failed(outcome.reason)
+                            }
+                        }
                     }
+                } finally {
+                    conn.disconnect()
                 }
             } catch (e: Exception) {
                 val reason = "${e.javaClass.simpleName}: ${e.message ?: "no message"}"

--- a/app/src/main/java/com/pocketshell/app/share/ShareActivity.kt
+++ b/app/src/main/java/com/pocketshell/app/share/ShareActivity.kt
@@ -3,6 +3,7 @@ package com.pocketshell.app.share
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import android.util.Log
 import android.widget.Toast
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
@@ -44,7 +45,13 @@ class ShareActivity : FragmentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val staged = decodeShareIntent(intent)
+        // This activity is EXPORTED (it is a system share target), so `intent`
+        // is fully untrusted: a malformed `EXTRA_STREAM` can throw
+        // BadParcelableException / ClassCastException while Android unmarshals
+        // the parcelled extras (the pre-33 untyped getters are the classic
+        // offender). Never let that crash the share surface — decode defensively
+        // and finish gracefully on anything unroutable.
+        val staged = runCatching { decodeShareIntent(intent) }.getOrDefault(emptyList())
         if (staged.isEmpty()) {
             Toast.makeText(this, "Nothing to share", Toast.LENGTH_SHORT).show()
             finish()
@@ -165,6 +172,19 @@ private const val SHARE_URI_METADATA_TOTAL_TIMEOUT_MS = 2_000L
  */
 internal fun decodeShareIntent(intent: Intent?): List<ShareableItem> {
     if (intent == null) return emptyList()
+    // The share intent comes from an EXPORTED activity, so its parcelled extras
+    // are untrusted input. Reading a malformed `EXTRA_STREAM` can throw
+    // BadParcelableException / ClassCastException as Android unmarshals it
+    // (notably via the pre-33 untyped `getParcelableExtra` getters). Treat any
+    // such failure as "nothing routable" rather than crashing the share surface.
+    return runCatching { decodeShareIntentExtras(intent) }
+        .getOrElse { error ->
+            Log.w("ShareActivity", "failed to decode share intent extras", error)
+            emptyList()
+        }
+}
+
+private fun decodeShareIntentExtras(intent: Intent): List<ShareableItem> {
     val mime = intent.type
     return when (intent.action) {
         Intent.ACTION_SEND -> {

--- a/app/src/test/java/com/pocketshell/app/release/ReleaseCheckerNetworkTest.kt
+++ b/app/src/test/java/com/pocketshell/app/release/ReleaseCheckerNetworkTest.kt
@@ -1,0 +1,120 @@
+package com.pocketshell.app.release
+
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.net.InetAddress
+import java.net.ServerSocket
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.thread
+
+/**
+ * Exercises the real [ReleaseChecker.checkForUpdate] network path against a
+ * tiny in-process HTTP server, covering the resource-hygiene fix (item 1 of the
+ * 2026-07-03 hardening batch): the `HttpURLConnection` must always
+ * `disconnect()`, the input reader must be closed, and on a non-200 (the common
+ * GitHub 403 rate-limit) the `errorStream` must be drained + closed rather than
+ * leaked. These run the exact production branches (403 + 200) end to end;
+ * Robolectric supplies the Android runtime so `android.util.Log` resolves.
+ *
+ * A hand-rolled `ServerSocket` is used rather than `com.sun.net.httpserver`
+ * (which is not on the Android unit-test classpath). Each response sets
+ * `Connection: close`, so every poll opens a fresh connection — a leak of the
+ * prior connection or its error stream would surface as a hang/failure here.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class ReleaseCheckerNetworkTest {
+
+    private lateinit var server: ServerSocket
+    private val requestCount = AtomicInteger(0)
+
+    @After
+    fun tearDown() {
+        server.close()
+    }
+
+    private fun startServer(status: Int, statusText: String, body: String) {
+        server = ServerSocket(0, 50, InetAddress.getByName("127.0.0.1"))
+        thread(isDaemon = true) {
+            val bytes = body.toByteArray()
+            while (!server.isClosed) {
+                try {
+                    server.accept().use { socket ->
+                        requestCount.incrementAndGet()
+                        // Drain the request head (request line + headers).
+                        val reader = socket.getInputStream().bufferedReader()
+                        while (true) {
+                            val line = reader.readLine() ?: break
+                            if (line.isEmpty()) break
+                        }
+                        val header = buildString {
+                            append("HTTP/1.0 ").append(status).append(' ').append(statusText).append("\r\n")
+                            append("Content-Type: application/json\r\n")
+                            append("Content-Length: ").append(bytes.size).append("\r\n")
+                            append("Connection: close\r\n\r\n")
+                        }
+                        socket.getOutputStream().apply {
+                            write(header.toByteArray())
+                            write(bytes)
+                            flush()
+                        }
+                    }
+                } catch (_: Exception) {
+                    break
+                }
+            }
+        }
+    }
+
+    private fun url(): String = "http://127.0.0.1:${server.localPort}/"
+
+    @Test
+    fun rateLimit403DrainsErrorStreamAndKeepsPollingCleanly() = runBlocking {
+        // GitHub's real 403 carries a rate-limit JSON body that the client must
+        // consume; leaving it unread + the connection undisconnected is the leak
+        // this fix closes.
+        startServer(403, "Forbidden", """{"message":"API rate limit exceeded for 1.2.3.4"}""")
+        val checker = ReleaseChecker(latestReleaseUrl = url())
+
+        // Poll several times. Every call must drive the error-stream drain +
+        // disconnect and return a clean Failed.
+        repeat(10) {
+            val result = checker.checkForUpdate("0.1.0")
+            assertTrue("expected a Failed result on 403", result is ReleaseCheckResult.Failed)
+            assertEquals(
+                "GitHub returned HTTP 403",
+                (result as ReleaseCheckResult.Failed).reason,
+            )
+        }
+        assertEquals("every poll must reach the server", 10, requestCount.get())
+    }
+
+    @Test
+    fun success200ParsesUpdateAndClosesConnection() = runBlocking {
+        val body = """
+            {
+              "tag_name": "v9.9.9",
+              "html_url": "https://example.com/releases/v9.9.9",
+              "assets": [
+                {"name":"pocketshell-9.9.9-debug.apk","browser_download_url":"https://example.com/a.apk"}
+              ]
+            }
+        """.trimIndent()
+        startServer(200, "OK", body)
+        val checker = ReleaseChecker(latestReleaseUrl = url())
+
+        val result = checker.checkForUpdate("0.1.0")
+
+        assertTrue("expected an UpdateAvailable result", result is ReleaseCheckResult.UpdateAvailable)
+        assertEquals("v9.9.9", (result as ReleaseCheckResult.UpdateAvailable).info.tagName)
+        // A second poll must still succeed — the connection from the first was
+        // closed cleanly, not leaked.
+        assertTrue(checker.checkForUpdate("0.1.0") is ReleaseCheckResult.UpdateAvailable)
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/share/ShareIntentDecodeTest.kt
+++ b/app/src/test/java/com/pocketshell/app/share/ShareIntentDecodeTest.kt
@@ -189,4 +189,49 @@ class ShareIntentDecodeTest {
         val intent = Intent(Intent.ACTION_VIEW).apply { type = "image/*" }
         assertTrue(decodeShareIntent(intent).isEmpty())
     }
+
+    /**
+     * The share activity is EXPORTED, so a malicious/broken sender can put a
+     * non-`Uri` Parcelable under `EXTRA_STREAM`. On pre-33 the untyped
+     * `getParcelableExtra` casts the stored value to `Uri`, throwing a
+     * `ClassCastException` mid-`onCreate`. `decodeShareIntent` must swallow that
+     * and return an empty list (the activity then finishes gracefully) instead
+     * of crashing. Run under SDK 28 to exercise the untyped getter path.
+     *
+     * Without the `runCatching` guard in `decodeShareIntent` this test throws
+     * (CCE) instead of asserting — the red→green pin for the fix.
+     */
+    @Test
+    @Config(sdk = [28])
+    fun malformedStreamExtraDecodesToEmptyInsteadOfCrashing() {
+        val intent = Intent(Intent.ACTION_SEND).apply {
+            type = "image/png"
+            // A Bundle is a valid Parcelable but NOT a Uri — the exact "wrong
+            // type in EXTRA_STREAM" shape that CCEs the pre-33 untyped getter.
+            putExtra(Intent.EXTRA_STREAM, android.os.Bundle())
+        }
+
+        val items = decodeShareIntent(intent)
+
+        assertTrue("a malformed EXTRA_STREAM must decode to nothing, not crash", items.isEmpty())
+    }
+
+    /**
+     * Class coverage: the `ACTION_SEND_MULTIPLE` list path unmarshals + casts
+     * each element too, so a wrong-type element there must also degrade to empty
+     * rather than crash the exported activity.
+     */
+    @Test
+    @Config(sdk = [28])
+    fun malformedStreamListDecodesToEmptyInsteadOfCrashing() {
+        val bogus = arrayListOf<android.os.Parcelable>(android.os.Bundle())
+        val intent = Intent(Intent.ACTION_SEND_MULTIPLE).apply {
+            type = "image/*"
+            putParcelableArrayListExtra(Intent.EXTRA_STREAM, bogus)
+        }
+
+        val items = decodeShareIntent(intent)
+
+        assertTrue("a malformed EXTRA_STREAM list must decode to nothing, not crash", items.isEmpty())
+    }
 }

--- a/shared/core-storage/build.gradle.kts
+++ b/shared/core-storage/build.gradle.kts
@@ -22,6 +22,15 @@ android {
         jvmTarget = "17"
     }
 
+    // Room `exportSchema = true` writes the versioned schema JSON here so every
+    // shipped schema has a durable, checked-in artifact and a future migration
+    // gap is caught at build time rather than on-device.
+    sourceSets {
+        getByName("androidTest") {
+            assets.srcDir("$projectDir/schemas")
+        }
+    }
+
     testOptions {
         // Room requires an Android Context to build a database. Robolectric
         // gives the host JVM a real Android runtime without booting an
@@ -37,6 +46,11 @@ android {
             }
         }
     }
+}
+
+ksp {
+    // Destination for the Room `exportSchema = true` JSON artifacts.
+    arg("room.schemaLocation", "$projectDir/schemas")
 }
 
 dependencies {

--- a/shared/core-storage/schemas/com.pocketshell.core.storage.AppDatabase/16.json
+++ b/shared/core-storage/schemas/com.pocketshell.core.storage.AppDatabase/16.json
@@ -1,0 +1,839 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 16,
+    "identityHash": "afc67c7758ec9cfe23ecb21326abe06d",
+    "entities": [
+      {
+        "tableName": "hosts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `hostname` TEXT NOT NULL, `port` INTEGER NOT NULL, `username` TEXT NOT NULL, `keyId` INTEGER NOT NULL, `maxAutoPort` INTEGER NOT NULL, `skipPortsBelow` INTEGER NOT NULL, `scanIntervalSec` INTEGER NOT NULL, `enabled` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `lastConnectedAt` INTEGER, `tmuxInstalled` INTEGER, `lastBootstrapAt` INTEGER, `pocketshellInstalled` INTEGER, `pocketshellLastDetectedAt` INTEGER, `pocketshellCliVersion` TEXT, `pocketshellExpectedCliVersion` TEXT, `pocketshellVersionCompatible` INTEGER, `pocketshellDaemonRunning` INTEGER, `pocketshellDaemonEnabled` INTEGER, `usageCommandOverride` TEXT, FOREIGN KEY(`keyId`) REFERENCES `ssh_keys`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hostname",
+            "columnName": "hostname",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "port",
+            "columnName": "port",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "keyId",
+            "columnName": "keyId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxAutoPort",
+            "columnName": "maxAutoPort",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "skipPortsBelow",
+            "columnName": "skipPortsBelow",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scanIntervalSec",
+            "columnName": "scanIntervalSec",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastConnectedAt",
+            "columnName": "lastConnectedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "tmuxInstalled",
+            "columnName": "tmuxInstalled",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastBootstrapAt",
+            "columnName": "lastBootstrapAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pocketshellInstalled",
+            "columnName": "pocketshellInstalled",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pocketshellLastDetectedAt",
+            "columnName": "pocketshellLastDetectedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pocketshellCliVersion",
+            "columnName": "pocketshellCliVersion",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pocketshellExpectedCliVersion",
+            "columnName": "pocketshellExpectedCliVersion",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pocketshellVersionCompatible",
+            "columnName": "pocketshellVersionCompatible",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pocketshellDaemonRunning",
+            "columnName": "pocketshellDaemonRunning",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pocketshellDaemonEnabled",
+            "columnName": "pocketshellDaemonEnabled",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "usageCommandOverride",
+            "columnName": "usageCommandOverride",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_hosts_keyId",
+            "unique": false,
+            "columnNames": [
+              "keyId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_hosts_keyId` ON `${TABLE_NAME}` (`keyId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "ssh_keys",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "keyId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "ssh_keys",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `privateKeyPath` TEXT NOT NULL, `fingerprint` TEXT NOT NULL, `hasPassphrase` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "privateKeyPath",
+            "columnName": "privateKeyPath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fingerprint",
+            "columnName": "fingerprint",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasPassphrase",
+            "columnName": "hasPassphrase",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "port_remappings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `hostId` INTEGER NOT NULL, `remotePort` INTEGER NOT NULL, `localPort` INTEGER NOT NULL, FOREIGN KEY(`hostId`) REFERENCES `hosts`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hostId",
+            "columnName": "hostId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remotePort",
+            "columnName": "remotePort",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localPort",
+            "columnName": "localPort",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_port_remappings_hostId",
+            "unique": false,
+            "columnNames": [
+              "hostId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_port_remappings_hostId` ON `${TABLE_NAME}` (`hostId`)"
+          },
+          {
+            "name": "index_port_remappings_hostId_remotePort",
+            "unique": true,
+            "columnNames": [
+              "hostId",
+              "remotePort"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_port_remappings_hostId_remotePort` ON `${TABLE_NAME}` (`hostId`, `remotePort`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "hosts",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "hostId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "port_usage",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`hostId` INTEGER NOT NULL, `remotePort` INTEGER NOT NULL, `clickCount` INTEGER NOT NULL, `totalBytes` INTEGER NOT NULL, `lastUsedAt` INTEGER NOT NULL, PRIMARY KEY(`hostId`, `remotePort`), FOREIGN KEY(`hostId`) REFERENCES `hosts`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "hostId",
+            "columnName": "hostId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remotePort",
+            "columnName": "remotePort",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "clickCount",
+            "columnName": "clickCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalBytes",
+            "columnName": "totalBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUsedAt",
+            "columnName": "lastUsedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "hostId",
+            "remotePort"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_port_usage_hostId",
+            "unique": false,
+            "columnNames": [
+              "hostId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_port_usage_hostId` ON `${TABLE_NAME}` (`hostId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "hosts",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "hostId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "project_roots",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `hostId` INTEGER NOT NULL, `label` TEXT NOT NULL, `path` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, FOREIGN KEY(`hostId`) REFERENCES `hosts`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hostId",
+            "columnName": "hostId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_project_roots_hostId",
+            "unique": false,
+            "columnNames": [
+              "hostId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_project_roots_hostId` ON `${TABLE_NAME}` (`hostId`)"
+          },
+          {
+            "name": "index_project_roots_hostId_path",
+            "unique": true,
+            "columnNames": [
+              "hostId",
+              "path"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_project_roots_hostId_path` ON `${TABLE_NAME}` (`hostId`, `path`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "hosts",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "hostId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `hostId` INTEGER NOT NULL, `name` TEXT NOT NULL, `lastSeenAt` INTEGER NOT NULL, `tags` TEXT, FOREIGN KEY(`hostId`) REFERENCES `hosts`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hostId",
+            "columnName": "hostId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSeenAt",
+            "columnName": "lastSeenAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sessions_hostId",
+            "unique": false,
+            "columnNames": [
+              "hostId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sessions_hostId` ON `${TABLE_NAME}` (`hostId`)"
+          },
+          {
+            "name": "index_sessions_hostId_name",
+            "unique": true,
+            "columnNames": [
+              "hostId",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_sessions_hostId_name` ON `${TABLE_NAME}` (`hostId`, `name`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "hosts",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "hostId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "snippets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `hostId` INTEGER NOT NULL, `label` TEXT, `body` TEXT NOT NULL, `kind` TEXT NOT NULL, FOREIGN KEY(`hostId`) REFERENCES `hosts`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hostId",
+            "columnName": "hostId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "body",
+            "columnName": "body",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_snippets_hostId",
+            "unique": false,
+            "columnNames": [
+              "hostId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_snippets_hostId` ON `${TABLE_NAME}` (`hostId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "hosts",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "hostId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "agent_sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `paneRef` TEXT NOT NULL, `agent` TEXT NOT NULL, `jsonlPath` TEXT, `detectedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "paneRef",
+            "columnName": "paneRef",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "agent",
+            "columnName": "agent",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "jsonlPath",
+            "columnName": "jsonlPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "detectedAt",
+            "columnName": "detectedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_agent_sessions_paneRef",
+            "unique": true,
+            "columnNames": [
+              "paneRef"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_agent_sessions_paneRef` ON `${TABLE_NAME}` (`paneRef`)"
+          }
+        ]
+      },
+      {
+        "tableName": "ai_api_call_log",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `timestampMillis` INTEGER NOT NULL, `provider` TEXT NOT NULL, `feature` TEXT NOT NULL, `inputUnits` INTEGER NOT NULL, `outputUnits` INTEGER NOT NULL, `unitCostUsdMillicents` INTEGER NOT NULL, `computedCostUsdMillicents` INTEGER NOT NULL, `metadataJson` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestampMillis",
+            "columnName": "timestampMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "feature",
+            "columnName": "feature",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inputUnits",
+            "columnName": "inputUnits",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "outputUnits",
+            "columnName": "outputUnits",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unitCostUsdMillicents",
+            "columnName": "unitCostUsdMillicents",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "computedCostUsdMillicents",
+            "columnName": "computedCostUsdMillicents",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataJson",
+            "columnName": "metadataJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_ai_api_call_log_timestampMillis",
+            "unique": false,
+            "columnNames": [
+              "timestampMillis"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_ai_api_call_log_timestampMillis` ON `${TABLE_NAME}` (`timestampMillis`)"
+          },
+          {
+            "name": "index_ai_api_call_log_provider_feature",
+            "unique": false,
+            "columnNames": [
+              "provider",
+              "feature"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_ai_api_call_log_provider_feature` ON `${TABLE_NAME}` (`provider`, `feature`)"
+          }
+        ]
+      },
+      {
+        "tableName": "pending_transcriptions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `audioPath` TEXT NOT NULL, `recordingTimestampMs` INTEGER NOT NULL, `destinationContext` TEXT NOT NULL, `retryCount` INTEGER NOT NULL, `lastErrorMessage` TEXT, `audioByteSize` INTEGER NOT NULL, `createdAtMs` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "audioPath",
+            "columnName": "audioPath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recordingTimestampMs",
+            "columnName": "recordingTimestampMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "destinationContext",
+            "columnName": "destinationContext",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "retryCount",
+            "columnName": "retryCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastErrorMessage",
+            "columnName": "lastErrorMessage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioByteSize",
+            "columnName": "audioByteSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAtMs",
+            "columnName": "createdAtMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_pending_transcriptions_recordingTimestampMs",
+            "unique": false,
+            "columnNames": [
+              "recordingTimestampMs"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_pending_transcriptions_recordingTimestampMs` ON `${TABLE_NAME}` (`recordingTimestampMs`)"
+          }
+        ]
+      },
+      {
+        "tableName": "command_templates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `hostId` INTEGER NOT NULL, `label` TEXT NOT NULL, `commands` TEXT NOT NULL, FOREIGN KEY(`hostId`) REFERENCES `hosts`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hostId",
+            "columnName": "hostId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "commands",
+            "columnName": "commands",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_command_templates_hostId",
+            "unique": false,
+            "columnNames": [
+              "hostId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_command_templates_hostId` ON `${TABLE_NAME}` (`hostId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "hosts",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "hostId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'afc67c7758ec9cfe23ecb21326abe06d')"
+    ]
+  }
+}

--- a/shared/core-storage/src/main/java/com/pocketshell/core/storage/AppDatabase.kt
+++ b/shared/core-storage/src/main/java/com/pocketshell/core/storage/AppDatabase.kt
@@ -49,9 +49,12 @@ val APP_DATABASE_UNSUPPORTED_STALE_SCHEMA_VERSIONS: IntArray = intArrayOf(1)
  * daemon running/enabled result so the host setup cache cannot route on CLI
  * readiness alone.
  *
- * `exportSchema = false` is historical. Issue #386 starts the preservation
- * path with checked-in migration code; a follow-up should enable exported
- * schemas so every future migration has a generated schema artifact too.
+ * `exportSchema = true` (Room writes the versioned schema JSON to the
+ * `room.schemaLocation` dir configured in this module's `build.gradle.kts`).
+ * The exported artifact is the durable record of each shipped schema, so a
+ * future migration gap (a `version` bump with no matching `MIGRATION_*`) is
+ * caught by a schema diff / migration test at build time instead of on the
+ * maintainer's device.
  */
 @Database(
     entities = [
@@ -68,7 +71,7 @@ val APP_DATABASE_UNSUPPORTED_STALE_SCHEMA_VERSIONS: IntArray = intArrayOf(1)
         CommandTemplateEntity::class,
     ],
     version = APP_DATABASE_SCHEMA_VERSION,
-    exportSchema = false,
+    exportSchema = true,
 )
 abstract class AppDatabase : RoomDatabase() {
     abstract fun hostDao(): HostDao

--- a/shared/core-voice/src/main/java/com/pocketshell/core/voice/PcmCapturePump.kt
+++ b/shared/core-voice/src/main/java/com/pocketshell/core/voice/PcmCapturePump.kt
@@ -61,6 +61,19 @@ internal class PcmCapturePump(
     // only cost of waiting is start latency; we never want to fail a
     // recording just because thread scheduling was slow.
     private val readyTimeoutMs: Long = READY_TIMEOUT_MS,
+    // Hard ceiling on how many PCM bytes a single capture may accumulate. Once
+    // the buffer reaches this, the reader loop self-stops and [captureCapReached]
+    // flips true so the caller can surface a "recording stopped (max length)"
+    // notice. Bounds memory (a forgotten/stuck capture otherwise grows ~19 MB per
+    // 10 min at 16 kHz mono 16-bit) and keeps the utterance inside the 60 s
+    // Whisper transcription timeout. Default derived for the AudioRecorder format
+    // (16 kHz mono 16-bit = 32000 B/s); a test can shrink it to exercise the cap.
+    private val maxCaptureBytes: Int = DEFAULT_MAX_CAPTURE_BYTES,
+    // Backoff applied when [PcmSource.read] returns 0 (no data available). A live
+    // AudioRecord can legitimately return 0 while the mic underruns; looping on
+    // it with no pause pins a CPU core (the busy-spin). A short sleep yields the
+    // core without meaningfully delaying real frames. Test-tunable.
+    private val idleReadBackoffMs: Long = IDLE_READ_BACKOFF_MS,
     // Test-only seam (issue #683): a hook the reader thread runs as its very
     // first action, BEFORE the `while (capturing)` guard. Production passes the
     // default no-op so behaviour is unchanged; the unit test injects a barrier
@@ -80,6 +93,12 @@ internal class PcmCapturePump(
 
     @Volatile
     private var captureError: AudioRecorderException? = null
+
+    // Set true when the capture self-stopped because it reached [maxCaptureBytes]
+    // (as opposed to the caller stopping it or a platform error). Lets the caller
+    // surface a "recording stopped at max length" notice to the user.
+    @Volatile
+    private var capReached: Boolean = false
 
     private var captureThread: Thread? = null
 
@@ -118,11 +137,33 @@ internal class PcmCapturePump(
                 }
                 val read = source.read(frame, 0, frame.size)
                 if (read > 0) {
-                    buffer.write(frame, 0, read)
-                    lastAmplitude = peakAmplitude(frame, read)
+                    // Never accumulate past the cap: clamp this frame's write to
+                    // the remaining budget, then self-stop. Bounds memory and
+                    // keeps the utterance within the Whisper timeout.
+                    val remaining = maxCaptureBytes - buffer.size()
+                    val writable = read.coerceAtMost(remaining)
+                    if (writable > 0) {
+                        buffer.write(frame, 0, writable)
+                        lastAmplitude = peakAmplitude(frame, writable)
+                    }
+                    if (buffer.size() >= maxCaptureBytes) {
+                        capReached = true
+                        capturing = false
+                    }
                 } else if (read < 0) {
                     captureError = mapAudioReadErrorCode(read)
                     capturing = false
+                } else {
+                    // read == 0: no data available right now. Yield the core
+                    // instead of hot-spinning until the next frame or a stop.
+                    if (idleReadBackoffMs > 0) {
+                        try {
+                            Thread.sleep(idleReadBackoffMs)
+                        } catch (_: InterruptedException) {
+                            Thread.currentThread().interrupt()
+                            capturing = false
+                        }
+                    }
                 }
             }
         }
@@ -172,6 +213,13 @@ internal class PcmCapturePump(
     fun currentAmplitude(): Float = lastAmplitude
 
     /**
+     * True when the last capture self-stopped because it hit [maxCaptureBytes]
+     * rather than being stopped by the caller. The caller uses this to tell the
+     * user the recording was cut at the maximum length.
+     */
+    fun captureCapReached(): Boolean = capReached
+
+    /**
      * Pull whatever the source already has buffered, without blocking. The
      * real `AudioRecord` keeps a small ring buffer the HAL fills; the inline
      * loop abandoned it on stop. We read in [DRAIN_FRAME_BUDGET] bounded
@@ -181,10 +229,13 @@ internal class PcmCapturePump(
         val frame = ByteArray(frameBytes)
         var passes = 0
         while (passes < DRAIN_FRAME_BUDGET) {
+            val remaining = maxCaptureBytes - buffer.size()
+            if (remaining <= 0) break
             val read = source.readNonBlocking(frame, 0, frame.size)
             if (read <= 0) break
-            buffer.write(frame, 0, read)
-            lastAmplitude = peakAmplitude(frame, read)
+            val writable = read.coerceAtMost(remaining)
+            buffer.write(frame, 0, writable)
+            lastAmplitude = peakAmplitude(frame, writable)
             passes++
         }
     }
@@ -206,6 +257,17 @@ internal class PcmCapturePump(
 
     companion object {
         const val READY_TIMEOUT_MS: Long = 500L
+
+        // Default capture ceiling. AudioRecorder records 16 kHz mono 16-bit =
+        // 32000 B/s, so 60 s ≈ 1.92 MB. This bounds memory (vs ~19 MB for a
+        // forgotten 10-min capture) AND keeps a single utterance within the 60 s
+        // Whisper transcription timeout. When the cap trips the capture stops and
+        // [captureCapReached] flips so the user can be told why.
+        const val DEFAULT_MAX_CAPTURE_BYTES: Int = 32_000 * 60
+
+        // Sleep applied on a zero-length read so an underrunning/idle mic can't
+        // hot-spin the reader thread.
+        const val IDLE_READ_BACKOFF_MS: Long = 5L
 
         // Cap the post-stop drain. At 16 kHz mono 16-bit a typical frame is
         // tens of ms; a handful of passes covers the AudioRecord ring buffer

--- a/shared/core-voice/src/test/java/com/pocketshell/core/voice/PcmCapturePumpTest.kt
+++ b/shared/core-voice/src/test/java/com/pocketshell/core/voice/PcmCapturePumpTest.kt
@@ -352,6 +352,97 @@ class PcmCapturePumpTest {
         )
     }
 
+    /**
+     * A source that never runs dry — every blocking read delivers a full frame.
+     * Models a mic that keeps streaming forever (a stuck/forgotten recording),
+     * which is exactly the runaway the byte cap must bound. The drain has nothing
+     * to add.
+     */
+    private class InfiniteSource(private val frameBytes: Int) : PcmSource {
+        val totalReads = AtomicInteger(0)
+        override fun read(buffer: ByteArray, offsetBytes: Int, sizeBytes: Int): Int {
+            totalReads.incrementAndGet()
+            loudFrame(frameBytes).copyInto(buffer, destinationOffset = offsetBytes)
+            return sizeBytes
+        }
+
+        override fun readNonBlocking(buffer: ByteArray, offsetBytes: Int, sizeBytes: Int): Int = 0
+    }
+
+    @Test
+    fun captureSelfStopsAtByteCapOnAMultipleOfFrameSize() {
+        // A never-ending mic stream must not accumulate without bound. With a cap
+        // of exactly 4 frames the reader loop self-stops after 4 frames instead of
+        // growing forever (~19 MB per 10 min on-device), and flags that it capped.
+        val cap = frameBytes * 4
+        val source = InfiniteSource(frameBytes)
+        val pump = PcmCapturePump(source = source, frameBytes = frameBytes, maxCaptureBytes = cap)
+
+        pump.start()
+        // The loop self-stops WITHOUT any external stop() once the cap trips.
+        val cappedInTime = awaitTrue(2_000) { pump.captureCapReached() }
+        assertTrue("capture must self-stop when the byte cap is reached", cappedInTime)
+
+        val pcm = pump.stop()
+        assertEquals("capture must not exceed the byte cap", cap, pcm.size)
+        assertTrue("cap-reached flag must be set for the user notice", pump.captureCapReached())
+    }
+
+    @Test
+    fun captureCapClampsToExactByteBudgetNotAWholeFrame() {
+        // The cap is byte-exact, not frame-rounded: a cap that lands mid-frame
+        // clamps the final write so the buffer is never even one frame over.
+        val cap = frameBytes * 3 + 100
+        val source = InfiniteSource(frameBytes)
+        val pump = PcmCapturePump(source = source, frameBytes = frameBytes, maxCaptureBytes = cap)
+
+        pump.start()
+        assertTrue(awaitTrue(2_000) { pump.captureCapReached() })
+        val pcm = pump.stop()
+
+        assertEquals("cap must clamp to the exact byte budget", cap, pcm.size)
+    }
+
+    /**
+     * A source whose blocking read always reports "no data available right now"
+     * (return 0) — the underrunning-mic case. Without a backoff the reader loop
+     * hot-spins on this; the test counts reads to prove the loop yields.
+     */
+    private class ZeroReadSource : PcmSource {
+        val totalReads = AtomicInteger(0)
+        override fun read(buffer: ByteArray, offsetBytes: Int, sizeBytes: Int): Int {
+            totalReads.incrementAndGet()
+            return 0
+        }
+
+        override fun readNonBlocking(buffer: ByteArray, offsetBytes: Int, sizeBytes: Int): Int = 0
+    }
+
+    @Test
+    fun zeroLengthReadsBackOffInsteadOfBusySpinning() {
+        // read == 0 must not pin a CPU core. With a 10 ms backoff, a ~120 ms
+        // window can only fit ~12 reads; a hot-spin (no backoff) would rack up
+        // many thousands. Asserting a low bound pins the yield: remove the
+        // backoff and this goes red.
+        val source = ZeroReadSource()
+        val pump = PcmCapturePump(
+            source = source,
+            frameBytes = frameBytes,
+            idleReadBackoffMs = 10L,
+        )
+
+        pump.start()
+        Thread.sleep(120)
+        pump.stop()
+
+        val reads = source.totalReads.get()
+        assertTrue("reader must actually poll at least once", reads > 0)
+        assertTrue(
+            "zero-length reads must back off, not hot-spin (saw $reads reads in ~120ms)",
+            reads < 500,
+        )
+    }
+
     @Test
     fun stopWithoutStartReturnsEmpty() {
         val source = FakeSource(frameBytes = frameBytes, bufferedFrames = 0)
@@ -378,6 +469,16 @@ class PcmCapturePumpTest {
             assertTrue(e.message?.contains("ERROR_DEAD_OBJECT") == true)
         }
     }
+}
+
+/** Poll [condition] until it is true or [timeoutMs] elapses. */
+private fun awaitTrue(timeoutMs: Long, condition: () -> Boolean): Boolean {
+    val deadline = System.currentTimeMillis() + timeoutMs
+    while (System.currentTimeMillis() < deadline) {
+        if (condition()) return true
+        Thread.sleep(2)
+    }
+    return condition()
 }
 
 /** One frame of non-silent 16-bit PCM (constant 0x4000 samples). */


### PR DESCRIPTION
Part of #1234 (items 1, 2, 4 + the exportSchema CI guard). Item 3 (destructive Room allowlist) split to #1271 (maintainer sign-off); items 5/6 deferred to their lanes.

## What
- **Item 1** `ReleaseChecker.kt`: try/finally `disconnect()`, streams closed via `use`, non-200 `errorStream` drained+closed (the common 403 rate-limit leak).
- **Item 2** `ShareActivity.kt`: `runCatching` guard around the untrusted `EXTRA_STREAM` unparcel on the exported activity → graceful finish instead of `ClassCastException`/`BadParcelableException`.
- **Item 4** `PcmCapturePump.kt`: byte/duration cap with self-stop + `captureCapReached()`, read==0 backoff kills the busy-spin.
- **exportSchema** `= true` + schemaLocation → generates `schemas/**/16.json` so future migration gaps fail CI (independent of the deferred allowlist).

## Verification
- Reviewer-driven G1 red→green on item 2 (neutralized guard → malformed-intent tests fail with CCE; restored → green).
- Counts (0 skipped/0 fail): ShareIntentDecodeTest 13, ReleaseCheckerNetworkTest 2, ReleaseCheckerTest 19, PcmCapturePumpTest 9, AppDatabaseTest 19. `check-test-validity.sh` PASS.
- Item 3 reverted to `intArrayOf(1)` baseline; AppDatabaseTest zero-diff.

Reviewer APPROVED: https://github.com/alexeygrigorev/pocketshell/issues/1234#issuecomment-4879636983