### PR TITLE
terminal: single off-main affordance scan for shell panes (#1233)

### DIFF
--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -2525,6 +2525,51 @@ else
   fi
 fi
 
+# --------------------------------------------------------------------------
+# Issue #1233 shell-pane single-snapshot affordance-scan proof (core-terminal
+# androidTest). A shell / non-agent pane used to run FOUR independent per-frame
+# on-main full-viewport affordance scanners (URL + SmartSelection + FilePath +
+# EngineCommand), each re-extracting the whole viewport AND running its regex on
+# Main every frame — a milder cousin of the #796 ANR on a high-throughput
+# streaming pane with the keyboard up. The fix consolidates them into ONE
+# ShellPaneAffordanceOverlay that extracts the viewport ONCE per coalesced frame
+# and runs the enabled passes OFF-main (the #871 single-snapshot split applied to
+# all four shell scanners). This proof asserts BOTH (a) URL / file-path /
+# engine-command affordances stay tappable on a real shell pane (behavior
+# UNCHANGED), and (b) the LOAD-BEARING property — the scan runs OFF the main
+# thread and dispatches ONE debounced single-snapshot scan per frame, NOT four
+# on-main scans per tick. Because #1233 is adjacent to the #796/#803/#866/#871
+# terminal-ANR class it runs alongside those proofs in this per-push gate. Uses
+# NO Docker fixture (in-process Compose UI test).
+CORE_TERMINAL_SHELL_SNAPSHOT_CLASS="com.pocketshell.core.terminal.ui.ShellPaneAffordanceSingleSnapshotProofTest"
+SHELL_SNAPSHOT_STATUS="PASS"
+
+run_core_terminal_shell_snapshot() {
+  run_ct_class "$CORE_TERMINAL_SHELL_SNAPSHOT_CLASS"
+}
+
+if budget_exhausted; then
+  STEP_TIMEOUT_HIT=1
+  SHELL_SNAPSHOT_STATUS="SKIPPED"
+  echo "JOURNEY_STEP_TIMEOUT: skipping #1233 shell-pane single-snapshot proof — suite budget exhausted (issue #835 / #470 stall)"
+else
+  echo "=========================================================="
+  echo ">>> CORE-TERMINAL #1233 SHELL-PANE SINGLE-SNAPSHOT PROOF: $CORE_TERMINAL_SHELL_SNAPSHOT_CLASS (attempt 1)"
+  echo "=========================================================="
+  shell_snapshot_start=$SECONDS
+  if run_core_terminal_shell_snapshot; then
+    echo "SHELL_SNAPSHOT_PASS: passed on attempt 1 (elapsed $((SECONDS - shell_snapshot_start))s)"
+  else
+    echo ">>> SHELL-PANE SINGLE-SNAPSHOT PROOF FAILED attempt 1 — retrying once (CI-AVD infra flake / sibling-install)"
+    if run_core_terminal_shell_snapshot; then
+      echo "SHELL_SNAPSHOT_FLAKE_RECOVERED: passed on retry (attempt 2)"
+    else
+      echo "SHELL_SNAPSHOT_FAILED: #1233 proof failed twice"
+      SHELL_SNAPSHOT_STATUS="FAIL"
+    fi
+  fi
+fi
+
 SUITE_ELAPSED=$((SECONDS - SUITE_START))
 
 # The job is red iff at least one class failed BOTH attempts, OR the #803
@@ -2538,14 +2583,14 @@ if [[ "${#FAILED_CLASSES[@]}" -eq 0 && "$STEP_TIMEOUT_HIT" -eq 0 \
       && "$APPEND_BURST_STATUS" == "PASS" && "$OUTPUT_BURST_IME_STATUS" == "PASS" \
       && "$MULTICHUNK_SEED_STATUS" == "PASS" && "$AGENT_LINK_AFFORDANCE_STATUS" == "PASS" \
       && "$REATTACH_REPAINT_STATUS" == "PASS" && "$OVERLAY_UNBOUNDED_STATUS" == "PASS" \
-      && "$SURFACE_REPAINT_STATUS" == "PASS" ]]; then
+      && "$SURFACE_REPAINT_STATUS" == "PASS" && "$SHELL_SNAPSHOT_STATUS" == "PASS" ]]; then
   JOURNEY_EXIT=0
   journey_status="PASS"
 elif [[ "$STEP_TIMEOUT_HIT" -eq 1 && "${#FAILED_CLASSES[@]}" -eq 0 \
         && "$APPEND_BURST_STATUS" != "FAIL" && "$OUTPUT_BURST_IME_STATUS" != "FAIL" \
         && "$MULTICHUNK_SEED_STATUS" != "FAIL" && "$AGENT_LINK_AFFORDANCE_STATUS" != "FAIL" \
         && "$REATTACH_REPAINT_STATUS" != "FAIL" && "$OVERLAY_UNBOUNDED_STATUS" != "FAIL" \
-        && "$SURFACE_REPAINT_STATUS" != "FAIL" ]]; then
+        && "$SURFACE_REPAINT_STATUS" != "FAIL" && "$SHELL_SNAPSHOT_STATUS" != "FAIL" ]]; then
   # Only the budget timeout fired (no class failed BOTH attempts on its own
   # merits): a pure #470-stall time-budget casualty.
   JOURNEY_EXIT=1
@@ -2597,6 +2642,9 @@ echo "=========================================================="
   echo
   echo "Core-terminal #1203 surface-only-black recovery proof (\`shared:core-terminal\`): **$SURFACE_REPAINT_STATUS**"
   echo "- \`$CORE_TERMINAL_SURFACE_REPAINT_CLASS\`"
+  echo
+  echo "Core-terminal #1233 shell-pane single-snapshot affordance-scan proof (\`shared:core-terminal\`): **$SHELL_SNAPSHOT_STATUS**"
+  echo "- \`$CORE_TERMINAL_SHELL_SNAPSHOT_CLASS\`"
   if [[ "${#RECOVERED_CLASSES[@]}" -gt 0 ]]; then
     echo
     echo "Recovered on retry (CI-AVD flake — \`JOURNEY_FLAKE_RECOVERED\`):"

--- a/shared/core-terminal/src/androidTest/java/com/pocketshell/core/terminal/selection/TerminalOverlayUnboundedMeasureCrashTest.kt
+++ b/shared/core-terminal/src/androidTest/java/com/pocketshell/core/terminal/selection/TerminalOverlayUnboundedMeasureCrashTest.kt
@@ -35,10 +35,10 @@ import org.junit.runner.RunWith
  *   at …pager.PagerMeasureKt.measurePager(…)
  * ```
  *
- * i.e. the draw-only terminal affordance overlays
- * ([SmartSelectionAffordanceOverlay], [FilePathOverlay],
- * [AgentPaneAffordanceOverlay], [EngineCommandOverlay]) each laid out at the raw
- * `constraints.maxHeight.coerceAtLeast(0)` — fine under a normal bounded measure,
+ * i.e. the draw-only terminal affordance overlays ([ShellPaneAffordanceOverlay],
+ * [AgentPaneAffordanceOverlay]; before issue #1233 the shell overlay was three
+ * separate scanners — SmartSelection / FilePath / EngineCommand) each laid out at
+ * the raw `constraints.maxHeight.coerceAtLeast(0)` — fine under a normal bounded measure,
  * but the overlay sits inside the terminal pane, which sits inside the
  * `TmuxTerminalPager` ([androidx.compose.foundation.pager.Pager]). The pager /
  * lookahead runs intermittent measure passes with an **unbounded**
@@ -51,12 +51,13 @@ import org.junit.runner.RunWith
  *
  * ## Why this is the load-bearing assertion (F2 / G6 / G10)
  *
- * This composes EACH of the four PRODUCTION overlays (no proxy/stand-in) inside a
+ * This composes EACH production overlay (no proxy/stand-in) inside a
  * [measureUnbounded] harness that hands it EXACTLY the crash constraint —
  * `Constraints(maxWidth = 1070, maxHeight = Infinity)`. On the unfixed overlay
  * this throws the exact `Size(1070 x Int.MAX_VALUE)` crash (the test fails / the
  * activity dies); with the fix every overlay lays out at a FINITE, bounded size.
- * Class coverage (G2): all four overlays, not only the one in the captured trace.
+ * Class coverage (G2): both production overlays (the consolidated shell overlay +
+ * the agent overlay), not only the one in the captured trace.
  */
 @RunWith(AndroidJUnit4::class)
 class TerminalOverlayUnboundedMeasureCrashTest {
@@ -114,24 +115,23 @@ class TerminalOverlayUnboundedMeasureCrashTest {
     }
 
     @Test
-    fun smartSelectionAffordanceOverlay_measuresFiniteUnderUnboundedHeight() {
-        assertOverlayMeasuresFinite("SmartSelectionAffordance") {
-            SmartSelectionAffordanceOverlay(
+    fun shellPaneAffordanceOverlay_measuresFiniteUnderUnboundedHeight() {
+        // Issue #1233: the consolidated shell-pane overlay replaced the three
+        // per-frame scanning overlays (SmartSelection / FilePath / EngineCommand);
+        // it must keep the same unbounded-measure guard. All four passes enabled so
+        // its full draw path is exercised.
+        assertOverlayMeasuresFinite("ShellPaneAffordance") {
+            ShellPaneAffordanceOverlay(
                 view = null,
                 renderRequests = renders,
-                onMatchesChanged = {},
-                modifier = Modifier,
-            )
-        }
-    }
-
-    @Test
-    fun filePathOverlay_measuresFiniteUnderUnboundedHeight() {
-        assertOverlayMeasuresFinite("FilePath") {
-            FilePathOverlay(
-                view = null,
-                renderRequests = renders,
+                matcher = DefaultTerminalMatcher(),
+                knownCommands = setOf("/clear"),
+                scanUrls = true,
+                scanFilePaths = true,
+                onUrlsChanged = {},
                 onFilePathsChanged = {},
+                onMatchesChanged = {},
+                onEngineCommandsChanged = {},
                 modifier = Modifier,
             )
         }
@@ -147,19 +147,6 @@ class TerminalOverlayUnboundedMeasureCrashTest {
                 renderRequests = renders,
                 onFilePathsChanged = {},
                 onUrlsChanged = {},
-                modifier = Modifier,
-            )
-        }
-    }
-
-    @Test
-    fun engineCommandOverlay_measuresFiniteUnderUnboundedHeight() {
-        assertOverlayMeasuresFinite("EngineCommand") {
-            EngineCommandOverlay(
-                view = null,
-                renderRequests = renders,
-                knownCommands = setOf("git", "ls"),
-                onEngineCommandsChanged = {},
                 modifier = Modifier,
             )
         }

--- a/shared/core-terminal/src/androidTest/java/com/pocketshell/core/terminal/ui/ShellPaneAffordanceSingleSnapshotProofTest.kt
+++ b/shared/core-terminal/src/androidTest/java/com/pocketshell/core/terminal/ui/ShellPaneAffordanceSingleSnapshotProofTest.kt
@@ -1,0 +1,481 @@
+package com.pocketshell.core.terminal.ui
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.os.Looper
+import android.os.SystemClock
+import android.view.MotionEvent
+import android.view.View
+import android.view.ViewGroup
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.core.terminal.selection.DefaultTerminalMatcher
+import com.pocketshell.core.terminal.selection.EngineCommandRegion
+import com.pocketshell.core.terminal.selection.FilePathRegion
+import com.pocketshell.core.terminal.selection.ShellPaneAffordanceOverlay
+import com.pocketshell.core.terminal.selection.UrlRegion
+import com.pocketshell.core.terminal.selection.findVisibleEngineCommands
+import com.pocketshell.core.terminal.selection.findVisibleFilePaths
+import com.pocketshell.core.terminal.selection.findVisibleUrls
+import com.termux.view.TerminalView
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+import java.io.FileOutputStream
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Issue #1233 — REGRESSION / behavior-preservation PROOF on the REAL shell-pane
+ * path: a shell / non-agent terminal pane keeps tappable URLs, file paths and
+ * engine commands (behavior UNCHANGED), but its affordance detection now runs
+ * from a SINGLE viewport extraction per coalesced frame, OFF the main thread —
+ * not the four independent per-frame on-main scanners it used before.
+ *
+ * ## What #1233 changed
+ *
+ * A shell pane used to wire FOUR independent per-frame full-viewport scanners
+ * (the URL scan + `SmartSelectionAffordanceOverlay` + `FilePathOverlay` +
+ * `EngineCommandOverlay`). Each re-extracted the entire visible viewport
+ * (`getSelectedText` per row) AND ran its own regex pass, all on the MAIN thread,
+ * every coalesced frame — ~4× redundant per-frame extraction + regex that kept
+ * the main thread busy on a high-throughput streaming shell pane (a milder cousin
+ * of the #796 ANR). The fix consolidates them into ONE
+ * [ShellPaneAffordanceOverlay] that extracts once per frame and runs the enabled
+ * passes off-main (the same single-snapshot + off-main split #871 gave agent
+ * panes).
+ *
+ * ## The two load-bearing checks (deterministic, no SSH / Docker)
+ *
+ * 1. [shellPaneUrlPathAndCommandAreTappableFromSingleSnapshot] composes the
+ *    PRODUCTION [TerminalSurface] as a SHELL pane (default
+ *    `affordanceScannersEnabled = true`) with the full scanner wiring, feeds a
+ *    live `%output` burst carrying a URL + a file path + a `/clear` command, waits
+ *    for the consolidated overlay to publish all three, taps each through the SAME
+ *    production `onTapMaybeUrl` hook and asserts every tap reaches the host —
+ *    proving the URL / path / command affordances are UNCHANGED for a shell pane.
+ * 2. [shellPaneAffordanceScanRunsOffMainSingleSnapshotNotFourPerFrame] drives
+ *    [ShellPaneAffordanceOverlay] directly with an INSTRUMENTED `scanDispatcher`
+ *    and asserts (a) the scan runs OFF the main looper thread, and (b) over a tight
+ *    `%output` burst the number of off-main scan dispatches stays bounded FAR below
+ *    the raw render-tick count — i.e. ONE debounced scan of ONE snapshot per frame,
+ *    NOT four on-main scans per tick. This is the ANR-safety / single-snapshot
+ *    load-bearing assertion.
+ *
+ * Artifact contract (process.md "Terminal Artifact Review"):
+ *  - `issue1233-shell-pane-tappable-viewport.png` + `-visible-terminal.txt`
+ *  - `issue1233-shell-pane-singlesnapshot-timings.txt`
+ */
+@RunWith(AndroidJUnit4::class)
+class ShellPaneAffordanceSingleSnapshotProofTest {
+
+    @get:Rule
+    val compose = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun shellPaneUrlPathAndCommandAreTappableFromSingleSnapshot() { runBlocking {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val state = TerminalSurfaceState()
+        val stdout = MutableSharedFlow<ByteArray>(extraBufferCapacity = 8)
+        val producerScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val producerJob = state.attachExternalProducer(
+            scope = producerScope,
+            stdout = stdout,
+            remoteStdin = null,
+        )
+
+        val filePath = "/home/alexey/src/App.kt"
+        val url = "https://example.com/shell/run-1233"
+        val command = "/clear"
+
+        val tappedPaths = mutableListOf<String>()
+        val tappedUrls = mutableListOf<String>()
+        val tappedCommands = mutableListOf<String>()
+
+        try {
+            compose.setContent {
+                TerminalSurface(
+                    state = state,
+                    modifier = Modifier,
+                    // The maintainer's shell pane: the DEFAULT non-agent pane
+                    // (affordanceScannersEnabled = true) with the full scanner
+                    // wiring the production tmux screen passes.
+                    urlsEnabled = true,
+                    onUrlTap = { tappedUrls.add(it) },
+                    onFilePathTap = { tappedPaths.add(it) },
+                    engineCommands = setOf("/clear", "/compact", "/model"),
+                    onEngineCommandTap = { tappedCommands.add(it) },
+                    matchListener = {},
+                    affordanceScannersEnabled = true,
+                )
+            }
+            compose.waitForIdle()
+            val view = waitForTerminalView()
+            val client = view.mClient as PocketShellTerminalViewClient
+
+            // A shell pane printing a URL, a file path and a slash-command, each
+            // prefixed with prose so we also prove the surrounding words are NOT
+            // linked. Fed as live `%output` (the real shell shape).
+            stdout.emit(
+                "See $url\r\nEdit $filePath\r\nType $command to reset\r\n".toByteArray(Charsets.US_ASCII),
+            )
+
+            // Wait until the consolidated single-snapshot overlay has published all
+            // three affordances onto the live viewport.
+            val paths = AtomicReference<List<FilePathRegion>>(emptyList())
+            val urls = AtomicReference<List<UrlRegion>>(emptyList())
+            val commands = AtomicReference<List<EngineCommandRegion>>(emptyList())
+            withTimeout(8_000) {
+                while (true) {
+                    delay(40)
+                    instrumentation.runOnMainSync {
+                        paths.set(findVisibleFilePaths(view))
+                        urls.set(findVisibleUrls(view))
+                        commands.set(findVisibleEngineCommands(view, setOf("/clear", "/compact", "/model")))
+                    }
+                    if (paths.get().any { it.path == filePath } &&
+                        urls.get().any { it.url == url } &&
+                        commands.get().any { it.command == command }
+                    ) {
+                        break
+                    }
+                }
+            }
+
+            val pathRegion = paths.get().firstOrNull { it.path == filePath }
+            val urlRegion = urls.get().firstOrNull { it.url == url }
+            val cmdRegion = commands.get().firstOrNull { it.command == command }
+            assertNotNull("#1233: shell pane must surface the tappable file path ($filePath)", pathRegion)
+            assertNotNull("#1233: shell pane must surface the tappable URL ($url)", urlRegion)
+            assertNotNull("#1233: shell pane must surface the tappable engine command ($command)", cmdRegion)
+
+            // Tap the centre of each region through the SAME production
+            // `onTapMaybeUrl` hook [TerminalSurface] installs on the view client.
+            suspend fun tapUntilRecorded(x: Float, y: Float, recorded: () -> Boolean) {
+                withTimeout(5_000) {
+                    while (!recorded()) {
+                        compose.waitForIdle()
+                        instrumentation.runOnMainSync {
+                            val now = SystemClock.uptimeMillis()
+                            val tap = MotionEvent.obtain(now, now, MotionEvent.ACTION_UP, x, y, 0)
+                            try {
+                                client.onSingleTapUp(tap)
+                            } finally {
+                                tap.recycle()
+                            }
+                        }
+                        if (recorded()) break
+                        delay(60)
+                    }
+                }
+            }
+            tapUntilRecorded(centreX(urlRegion!!, view), centreY(urlRegion.row, view)) { tappedUrls.contains(url) }
+            tapUntilRecorded(centreX(pathRegion!!, view), centreY(pathRegion.row, view)) { tappedPaths.contains(filePath) }
+            tapUntilRecorded(centreX(cmdRegion!!, view), centreY(cmdRegion.row, view)) { tappedCommands.contains(command) }
+
+            assertTrue("#1233: tapping the URL on a shell pane must reach the host. tappedUrls=$tappedUrls", tappedUrls.contains(url))
+            assertTrue("#1233: tapping the file path on a shell pane must reach the host. tappedPaths=$tappedPaths", tappedPaths.contains(filePath))
+            assertTrue("#1233: tapping the /clear command on a shell pane must reach the host. tappedCommands=$tappedCommands", tappedCommands.contains(command))
+
+            captureViewport(view, "issue1233-shell-pane-tappable")
+        } finally {
+            producerJob.cancel()
+            producerScope.cancel()
+            state.detachExternalProducer()
+        }
+        Unit
+    } }
+
+    /**
+     * Issue #1233 — the LOAD-BEARING single-snapshot / ANR-safety assertion: the
+     * shell-pane affordance scan must run OFF the main thread and dispatch ONE
+     * debounced scan per settled frame, NOT four on-main scans per tick.
+     */
+    @Test
+    fun shellPaneAffordanceScanRunsOffMainSingleSnapshotNotFourPerFrame() { runBlocking {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val state = TerminalSurfaceState()
+        val stdout = MutableSharedFlow<ByteArray>(extraBufferCapacity = 256)
+        val producerScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val producerJob = state.attachExternalProducer(
+            scope = producerScope,
+            stdout = stdout,
+            remoteStdin = null,
+        )
+
+        val mainThread = Looper.getMainLooper().thread
+        val sawMainThreadScan = AtomicBoolean(false)
+        val scanThreadName = AtomicReference("")
+        // Each dispatch is ONE off-main scan of ONE viewport snapshot (the single
+        // `withContext(scanContext)` per frame in collectShellPaneAffordances).
+        val scanDispatchCount = AtomicLong(0L)
+        val executor = Executors.newSingleThreadExecutor { r -> Thread(r, "issue1233-scan") }
+        val scanDispatcher = object : CoroutineDispatcher() {
+            override fun dispatch(context: CoroutineContext, block: Runnable) {
+                runCatching {
+                    executor.execute {
+                        val t = Thread.currentThread()
+                        scanThreadName.set(t.name)
+                        if (t === mainThread) sawMainThreadScan.set(true)
+                        scanDispatchCount.incrementAndGet()
+                        block.run()
+                    }
+                }
+            }
+        }
+
+        // Count the RAW render ticks the burst produces (the per-frame budget the
+        // scan must NOT track). Collected off-main so it never competes for Main.
+        val rawTickCount = AtomicLong(0L)
+        val rawScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val rawJob = rawScope.launch { state.renderRequests.collect { rawTickCount.incrementAndGet() } }
+
+        val view = buildLaidOutView(state)
+
+        try {
+            compose.setContent {
+                ShellPaneAffordanceOverlay(
+                    view = view,
+                    renderRequests = state.renderRequests,
+                    matcher = DefaultTerminalMatcher(),
+                    knownCommands = setOf("/clear", "/compact", "/model"),
+                    scanUrls = true,
+                    scanFilePaths = true,
+                    onUrlsChanged = {},
+                    onFilePathsChanged = {},
+                    onMatchesChanged = {},
+                    onEngineCommandsChanged = {},
+                    scanDispatcher = scanDispatcher,
+                )
+            }
+            compose.waitForIdle()
+
+            val burstStart = SystemClock.uptimeMillis()
+            var chunk = 0
+            while (SystemClock.uptimeMillis() - burstStart < BURST_DURATION_MS) {
+                stdout.emit(buildChunk(chunk).toByteArray(Charsets.US_ASCII))
+                chunk += 1
+            }
+            SystemClock.sleep(SETTLE_MS)
+            instrumentation.waitForIdleSync()
+
+            val dispatches = scanDispatchCount.get()
+            val rawTicks = rawTickCount.get()
+            rawJob.cancel()
+            rawScope.cancel()
+
+            writeTimings(
+                instrumentation,
+                listOf(
+                    "scenario=#1233 shell-pane affordance scan: single-snapshot + off-main + debounced",
+                    "issue=1233",
+                    "burst_chunks=$chunk",
+                    "burst_duration_ms=$BURST_DURATION_MS",
+                    "raw_render_request_ticks=$rawTicks",
+                    "off_main_scan_dispatches=$dispatches",
+                    "scan_thread_name=${scanThreadName.get()}",
+                    "saw_main_thread_scan=${sawMainThreadScan.get()}",
+                    "note=one dispatch = one off-main scan of ONE viewport snapshot per frame " +
+                        "(all four passes share it); pre-#1233 a shell pane ran FOUR on-main scans " +
+                        "per tick, each re-extracting the viewport.",
+                    "expectation=scan runs on a background dispatcher (NOT main); off-main scan " +
+                        "dispatches bounded FAR below raw_render_request_ticks (one debounced " +
+                        "single-snapshot scan per frame, not four per tick).",
+                ),
+            )
+
+            assertTrue(
+                "burst must produce a real renderRequests storm; rawTicks=$rawTicks",
+                rawTicks >= MIN_RAW_TICKS,
+            )
+            assertTrue(
+                "shell-pane overlay must have dispatched at least one off-main scan; " +
+                    "scanThread='${scanThreadName.get()}'",
+                scanThreadName.get().isNotEmpty(),
+            )
+
+            // ---- LOAD-BEARING #1: the scan NEVER ran on the main thread.
+            assertFalse(
+                "#1233: the shell-pane affordance scan must run OFF the main thread. It " +
+                    "executed on thread '${scanThreadName.get()}'; a main-thread scan is the " +
+                    "per-frame cost this issue removed.",
+                sawMainThreadScan.get(),
+            )
+
+            // ---- LOAD-BEARING #2: ONE debounced single-snapshot scan per frame,
+            // bounded FAR below the raw tick count. A per-tick (let alone 4-per-tick
+            // on-main) scan would dispatch ~= rawTicks.
+            assertTrue(
+                "#1233: the shell-pane scan must be a debounced SINGLE-snapshot scan per frame, " +
+                    "NOT four on-main scans per tick. Over the burst it dispatched $dispatches " +
+                    "off-main scans against $rawTicks raw render ticks; a conflated single-snapshot " +
+                    "scan stays far below the raw count.",
+                dispatches <= rawTicks / DEBOUNCE_FACTOR + DEBOUNCE_SLACK,
+            )
+        } finally {
+            executor.shutdownNow()
+            producerJob.cancel()
+            producerScope.cancel()
+            state.detachExternalProducer()
+        }
+        Unit
+    } }
+
+    // ---------------------------------------------------------------- Helpers
+
+    private fun buildChunk(i: Int): String {
+        val esc = ""
+        return buildString {
+            append("$esc[H")
+            for (row in 0 until VIEWPORT_ROWS) {
+                append("$esc[K")
+                append("$BURST_MARKER r$row see https://example.com/shell-$i-$row ")
+                append("/clear edit /home/alexey/src/Burst$i$row.kt done\r\n")
+            }
+        }
+    }
+
+    private fun buildLaidOutView(state: TerminalSurfaceState): TerminalView {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val ref = arrayOfNulls<TerminalView>(1)
+        instrumentation.runOnMainSync {
+            val view = TerminalView(instrumentation.targetContext, null)
+            view.applyPocketShellDefaults(PocketShellTerminalViewClient())
+            view.attachSession(requireNotNull(state.session))
+            val w = View.MeasureSpec.makeMeasureSpec(1080, View.MeasureSpec.EXACTLY)
+            val h = View.MeasureSpec.makeMeasureSpec(1920, View.MeasureSpec.EXACTLY)
+            view.measure(w, h)
+            view.layout(0, 0, view.measuredWidth, view.measuredHeight)
+            ref[0] = view
+        }
+        return requireNotNull(ref[0])
+    }
+
+    private suspend fun waitForTerminalView(): TerminalView {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val ref = arrayOfNulls<TerminalView>(1)
+        withTimeout(5_000) {
+            while (ref[0] == null) {
+                instrumentation.runOnMainSync {
+                    ref[0] = findTerminalView(compose.activity.window.decorView)
+                }
+                if (ref[0] == null) delay(20)
+            }
+        }
+        return requireNotNull(ref[0])
+    }
+
+    private fun findTerminalView(root: View): TerminalView? {
+        if (root is TerminalView) return root
+        if (root is ViewGroup) {
+            for (i in 0 until root.childCount) {
+                val hit = findTerminalView(root.getChildAt(i))
+                if (hit != null) return hit
+            }
+        }
+        return null
+    }
+
+    private fun centreX(region: FilePathRegion, view: TerminalView): Float {
+        val r = requireNotNull(view.mRenderer)
+        return (region.startCol + (region.endColExclusive - region.startCol) / 2f) * r.fontWidth
+    }
+
+    private fun centreX(region: UrlRegion, view: TerminalView): Float {
+        val r = requireNotNull(view.mRenderer)
+        return (region.startCol + (region.endColExclusive - region.startCol) / 2f) * r.fontWidth
+    }
+
+    private fun centreX(region: EngineCommandRegion, view: TerminalView): Float {
+        val r = requireNotNull(view.mRenderer)
+        return (region.startCol + (region.endColExclusive - region.startCol) / 2f) * r.fontWidth
+    }
+
+    private fun centreY(row: Int, view: TerminalView): Float {
+        val r = requireNotNull(view.mRenderer)
+        return r.fontLineSpacingAndAscent + (row - view.topRow + 0.5f) * r.fontLineSpacing
+    }
+
+    private fun visibleTerminalText(view: TerminalView): String {
+        var text = ""
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            text = view.currentSession?.emulator?.screen?.transcriptText.orEmpty()
+        }
+        return text
+    }
+
+    private fun captureViewport(view: TerminalView, name: String) {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.waitForIdleSync()
+        SystemClock.sleep(150)
+        var bitmap: Bitmap? = null
+        instrumentation.runOnMainSync {
+            if (view.width > 0 && view.height > 0) {
+                val b = Bitmap.createBitmap(view.width, view.height, Bitmap.Config.ARGB_8888)
+                view.draw(Canvas(b))
+                bitmap = b
+            }
+        }
+        val ctx = instrumentation.targetContext
+        bitmap?.let { b ->
+            val file = artifactFile(ctx, "$name-viewport.png")
+            FileOutputStream(file).use { out ->
+                check(b.compress(Bitmap.CompressFormat.PNG, 100, out)) {
+                    "failed to write bitmap to ${file.absolutePath}"
+                }
+            }
+            println("ISSUE1233_VIEWPORT ${file.absolutePath}")
+            b.recycle()
+        }
+        artifactFile(ctx, "$name-visible-terminal.txt").writeText(visibleTerminalText(view))
+    }
+
+    private fun writeTimings(
+        instrumentation: android.app.Instrumentation,
+        lines: List<String>,
+    ) {
+        val file = artifactFile(instrumentation.targetContext, "issue1233-shell-pane-singlesnapshot-timings.txt")
+        file.writeText(lines.joinToString("\n") + "\n")
+        println("ISSUE1233_TIMINGS ${file.absolutePath}")
+        for (line in lines) android.util.Log.i(LOG_TAG, "TIMING $line")
+    }
+
+    private fun artifactFile(context: android.content.Context, name: String): File {
+        val dir = File(testArtifactsRoot(context), "terminal-lab").apply { mkdirs() }
+        return File(dir, name)
+    }
+
+    private companion object {
+        const val LOG_TAG = "Issue1233ShellPane"
+        const val BURST_MARKER = "ISSUE1233-BURST"
+        const val VIEWPORT_ROWS = 30
+        const val BURST_DURATION_MS = 4_000L
+        const val SETTLE_MS = 600L
+        const val MIN_RAW_TICKS = 40L
+
+        // A conflated single-snapshot scan services at most ~one per settled frame;
+        // over a burst that fires N raw ticks it should dispatch << N.
+        const val DEBOUNCE_FACTOR = 4L
+        const val DEBOUNCE_SLACK = 20L
+    }
+}

--- a/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/selection/AgentCommandScanner.kt
+++ b/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/selection/AgentCommandScanner.kt
@@ -75,32 +75,44 @@ public fun findVisibleEngineCommands(
     knownCommands: Set<String>,
 ): List<EngineCommandRegion> {
     if (knownCommands.isEmpty()) return emptyList()
-    val emulator = view.mEmulator ?: return emptyList()
-    val screen = emulator.screen ?: return emptyList()
-    val columns = emulator.mColumns
-    val rows = emulator.mRows
-    if (columns <= 0 || rows <= 0) return emptyList()
+    // Issue #1233: share the single cheap main-thread viewport extraction
+    // ([extractVisibleViewportRows]) with the URL / file-path / smart-selection
+    // scanners instead of running an independent `getSelectedText` row loop here.
+    // The engine-command detection is per-row (no soft-wrap reassembly — a
+    // slash-command never wraps), so it iterates the snapshot rows directly.
+    val snapshot = extractVisibleViewportRows(view)
+    return engineCommandRegionsForRows(snapshot.rows, snapshot.columns, knownCommands)
+}
 
-    val topRow = view.topRow
-    val firstRow = topRow
-    val lastRowExclusive = topRow + rows
-
+/**
+ * Pure, Android-`TerminalView`-free engine-command detection over an
+ * already-extracted list of [VisualRow]s (issue #1233). This is the regex half of
+ * [findVisibleEngineCommands], split out so the four shell-pane affordance
+ * scanners can all run against ONE [extractVisibleViewportRows] snapshot per
+ * coalesced frame (and off the main thread), instead of each re-extracting the
+ * full viewport itself.
+ *
+ * Per-row, no soft-wrap reassembly: an engine slash-command (`/clear`) is a short
+ * token that never wraps across a visual-row boundary, so each row is scanned in
+ * isolation — identical output to the inline row loop [findVisibleEngineCommands]
+ * previously performed.
+ */
+internal fun engineCommandRegionsForRows(
+    visualRows: List<VisualRow>,
+    columns: Int,
+    knownCommands: Set<String>,
+): List<EngineCommandRegion> {
+    if (columns <= 0 || knownCommands.isEmpty() || visualRows.isEmpty()) return emptyList()
     val out = mutableListOf<EngineCommandRegion>()
-    for (row in firstRow until lastRowExclusive) {
-        val line: String = try {
-            screen.getSelectedText(0, row, columns, row)
-        } catch (_: Throwable) {
-            // Mid-resize the vendored emulator occasionally throws AIOOBE.
-            continue
-        }
-        for (detected in detectEngineCommandsInLine(line, knownCommands)) {
+    for (visual in visualRows) {
+        for (detected in detectEngineCommandsInLine(visual.text, knownCommands)) {
             val startCol = detected.start
             if (startCol >= columns) continue
             val endCol = detected.endExclusive.coerceAtMost(columns)
             if (endCol <= startCol) continue
             out += EngineCommandRegion(
                 command = detected.command,
-                row = row,
+                row = visual.row,
                 startCol = startCol,
                 endColExclusive = endCol,
             )

--- a/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/selection/FilePathScanner.kt
+++ b/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/selection/FilePathScanner.kt
@@ -94,37 +94,14 @@ public data class DetectedFilePath(
  * Safe to call from the UI thread. One regex pass per visible row.
  */
 public fun findVisibleFilePaths(view: TerminalView): List<FilePathRegion> {
-    val emulator = view.mEmulator ?: return emptyList()
-    val screen = emulator.screen ?: return emptyList()
-    val columns = emulator.mColumns
-    val rows = emulator.mRows
-    if (columns <= 0 || rows <= 0) return emptyList()
-
-    val topRow = view.topRow
-    val firstRow = topRow
-    val lastRowExclusive = topRow + rows
-
-    // Issue #558 bug 2: read every visible row WITH its line-wrap flag so a path
-    // soft-wrapped across rows is reassembled into one logical line before
-    // matching, then re-emitted per visual row sharing the full path string.
-    val visualRows = mutableListOf<VisualRow>()
-    for (row in firstRow until lastRowExclusive) {
-        val line: String = try {
-            screen.getSelectedText(0, row, columns, row)
-        } catch (_: Throwable) {
-            // Mid-resize the vendored emulator occasionally throws AIOOBE.
-            visualRows += VisualRow(row = row, text = "", wrapsToNext = false)
-            continue
-        }
-        val wraps = try {
-            row + 1 < lastRowExclusive && screen.getLineWrap(row)
-        } catch (_: Throwable) {
-            false
-        }
-        visualRows += VisualRow(row = row, text = line, wrapsToNext = wraps)
-    }
-
-    return filePathRegionsForRows(visualRows, columns)
+    // Issue #558 bug 2 / #1233: read every visible row WITH its line-wrap flag via
+    // the shared [extractVisibleViewportRows] primitive so a path soft-wrapped
+    // across rows is reassembled into one logical line before matching (then
+    // re-emitted per visual row sharing the full path string), AND so the four
+    // shell-pane affordance scanners share ONE viewport extraction per coalesced
+    // frame rather than each re-running the row loop.
+    val snapshot = extractVisibleViewportRows(view)
+    return filePathRegionsForRows(snapshot.rows, snapshot.columns)
 }
 
 internal fun filePathRegionsForRows(

--- a/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/selection/SelectionScanner.kt
+++ b/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/selection/SelectionScanner.kt
@@ -31,29 +31,12 @@ fun findVisibleTerminalMatches(
     view: TerminalView,
     matcher: TerminalMatcher = DefaultTerminalMatcher(),
 ): List<TerminalMatchRegion> {
-    val emulator = view.mEmulator ?: return emptyList()
-    val screen = emulator.screen ?: return emptyList()
-    val columns = emulator.mColumns
-    val rows = emulator.mRows
-    if (columns <= 0 || rows <= 0) return emptyList()
-
-    val topRow = view.topRow
-    val visualRows = mutableListOf<VisualRow>()
-    for (row in topRow until topRow + rows) {
-        val line: String = try {
-            screen.getSelectedText(0, row, columns, row)
-        } catch (_: Throwable) {
-            visualRows += VisualRow(row = row, text = "", wrapsToNext = false)
-            continue
-        }
-        val wraps = try {
-            row + 1 < topRow + rows && screen.getLineWrap(row)
-        } catch (_: Throwable) {
-            false
-        }
-        visualRows += VisualRow(row = row, text = line, wrapsToNext = wraps)
-    }
-    return terminalMatchRegionsForRows(visualRows, columns, matcher)
+    // Issue #1233: read the visible viewport via the shared
+    // [extractVisibleViewportRows] primitive so all four shell-pane affordance
+    // scanners share ONE extraction per coalesced frame rather than each running
+    // an independent `getSelectedText` row loop on the main thread.
+    val snapshot = extractVisibleViewportRows(view)
+    return terminalMatchRegionsForRows(snapshot.rows, snapshot.columns, matcher)
 }
 
 internal fun terminalMatchRegionsForRows(

--- a/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/selection/ShellPaneAffordanceOverlay.kt
+++ b/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/selection/ShellPaneAffordanceOverlay.kt
@@ -1,0 +1,290 @@
+package com.pocketshell.core.terminal.selection
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.layout.Layout
+import com.termux.view.TerminalView
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.conflate
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * The four affordance-region snapshots a shell / non-agent terminal pane needs,
+ * all produced from ONE [ViewportRowsSnapshot] per coalesced frame (issue #1233).
+ *
+ * @property urls tappable URL regions (hit-test only; the URL hairline is drawn
+ *   from the matcher's [TerminalMatch.Url] matches, mirroring the pre-#1233 split
+ *   where [findVisibleUrls] fed hit-testing and the smart-selection matcher fed
+ *   the underline).
+ * @property filePaths tappable file-path regions (hit-test + hairline).
+ * @property matches smart-selection matcher regions (hairline + optional
+ *   [SelectionOverlay] tap routing).
+ * @property engineCommands tappable engine-command regions (hit-test + underline).
+ */
+internal data class ShellPaneAffordanceRegions(
+    val urls: List<UrlRegion> = emptyList(),
+    val filePaths: List<FilePathRegion> = emptyList(),
+    val matches: List<TerminalMatchRegion> = emptyList(),
+    val engineCommands: List<EngineCommandRegion> = emptyList(),
+)
+
+/**
+ * Issue #1233: the consolidated shell-pane affordance scan loop, split out of the
+ * [ShellPaneAffordanceOverlay] composable so it is directly unit-testable with an
+ * injected [extractSnapshot] counter and test dispatchers.
+ *
+ * ## What this fixes
+ *
+ * Before #1233 a shell / non-agent pane ran FOUR independent per-frame
+ * full-viewport scanners — the URL scan plus the SmartSelection, FilePath and
+ * EngineCommand overlays — each of which INDEPENDENTLY re-extracted the entire
+ * visible viewport (`getSelectedText` per row) AND ran its own regex pass, all on
+ * the MAIN thread, on every coalesced render frame. On a high-throughput
+ * streaming shell pane with the keyboard up that ~4× redundant per-frame
+ * extraction + regex kept the main thread busy enough to drop input
+ * responsiveness — a milder cousin of the #796 ANR.
+ *
+ * ## How the single-snapshot + off-main split works (mirrors #871's
+ * [AgentPaneAffordanceOverlay])
+ *
+ * Per coalesced frame (debounced with [conflate] so a `%output` burst collapses
+ * to the latest settled snapshot):
+ *  1. **On [mainContext]**: extract the visible viewport ONCE into a thread-safe
+ *     [ViewportRowsSnapshot] via [extractSnapshot] (the live emulator/screen is
+ *     not thread-safe, so this read stays on Main).
+ *  2. **On [scanContext]** (off Main): run the enabled regex passes
+ *     ([urlRegionsForRows] / [filePathRegionsForRows] / [terminalMatchRegionsForRows]
+ *     / [engineCommandRegionsForRows]) against that ONE snapshot.
+ *  3. **On [mainContext]**: publish the four region lists to [onResult].
+ *
+ * A pass is skipped (empty list, no work) when its consumer is disabled: [matcher]
+ * `null`, empty [knownCommands], `scanUrls`/`scanFilePaths` `false`.
+ *
+ * The load-bearing invariant (issue #1233 acceptance): [extractSnapshot] is
+ * invoked AT MOST ONCE per coalesced frame regardless of how many of the four
+ * passes are enabled — verified with a counting fake in
+ * `ShellPaneAffordanceScanCountTest`.
+ */
+internal suspend fun collectShellPaneAffordances(
+    renderRequests: Flow<Unit>,
+    extractSnapshot: () -> ViewportRowsSnapshot,
+    matcher: TerminalMatcher?,
+    knownCommands: Set<String>,
+    scanUrls: Boolean,
+    scanFilePaths: Boolean,
+    mainContext: CoroutineContext,
+    scanContext: CoroutineContext,
+    onResult: (ShellPaneAffordanceRegions) -> Unit,
+) {
+    withContext(mainContext) {
+        // `onStart { emit(Unit) }` runs the initial scan before the first render
+        // signal arrives; `conflate()` drops intermediate emissions while a scan is
+        // in flight so a `%output` burst re-extracts only the freshest settled
+        // viewport (never a backlog of N scans).
+        renderRequests.onStart { emit(Unit) }.conflate().collect {
+            // CHEAP, on Main: ONE viewport extraction shared by all four passes.
+            val snapshot = withContext(mainContext) { extractSnapshot() }
+            // EXPENSIVE, OFF Main: the regex/reassembly passes that used to run
+            // ~4× per frame on the UI thread.
+            val result = withContext(scanContext) {
+                ShellPaneAffordanceRegions(
+                    urls = if (scanUrls) {
+                        runCatching { urlRegionsForRows(snapshot.rows, snapshot.columns) }.getOrDefault(emptyList())
+                    } else {
+                        emptyList()
+                    },
+                    filePaths = if (scanFilePaths) {
+                        runCatching { filePathRegionsForRows(snapshot.rows, snapshot.columns) }.getOrDefault(emptyList())
+                    } else {
+                        emptyList()
+                    },
+                    matches = if (matcher != null) {
+                        runCatching { terminalMatchRegionsForRows(snapshot.rows, snapshot.columns, matcher) }
+                            .getOrDefault(emptyList())
+                    } else {
+                        emptyList()
+                    },
+                    engineCommands = if (knownCommands.isNotEmpty()) {
+                        runCatching { engineCommandRegionsForRows(snapshot.rows, snapshot.columns, knownCommands) }
+                            .getOrDefault(emptyList())
+                    } else {
+                        emptyList()
+                    },
+                )
+            }
+            // Publish back ON Main so the recomposer / host hit-test snapshots
+            // pick it up reliably.
+            withContext(mainContext) { onResult(result) }
+        }
+    }
+}
+
+/**
+ * Issue #1233: tappable URLs, file paths, smart-selection matches AND engine
+ * commands on a shell / non-agent terminal pane, produced from a SINGLE
+ * viewport extraction per coalesced frame, off the main thread — replacing the
+ * four independent per-frame on-main scanners
+ * (the old `SmartSelectionAffordanceOverlay` + `FilePathOverlay` +
+ * `EngineCommandOverlay` + the URL scan) that each re-extracted the full
+ * viewport and ran their regex on Main every frame.
+ *
+ * This is the shell-pane sibling of [AgentPaneAffordanceOverlay] (#871), which
+ * applies the same single-snapshot + off-main split for the two affordances an
+ * agent pane keeps (path + URL). A shell pane keeps all four.
+ *
+ * Each pass is gated independently:
+ *  - [scanUrls] — run [urlRegionsForRows] for the URL hit-test snapshot.
+ *  - [matcher] non-null — run the smart-selection matcher (draws the hairlines,
+ *    including URL underlines, and feeds [SelectionOverlay] tap routing).
+ *  - [scanFilePaths] — run [filePathRegionsForRows].
+ *  - non-empty [knownCommands] — run [engineCommandRegionsForRows].
+ *
+ * The overlay draws the union of the matcher matches, file-path regions and
+ * engine-command regions as affordance hairlines (identical to what the three
+ * deleted overlays drew); URL regions are hit-test only (their underline comes
+ * from the matcher's [TerminalMatch.Url] matches).
+ *
+ * @param scanDispatcher dispatcher the regex passes run on; defaults to
+ *   [Dispatchers.Default]. Injected by tests to observe the dispatch thread.
+ */
+@Composable
+public fun ShellPaneAffordanceOverlay(
+    view: TerminalView?,
+    renderRequests: Flow<Unit>,
+    viewportChangeKey: Any? = Unit,
+    matcher: TerminalMatcher? = null,
+    knownCommands: Set<String> = emptySet(),
+    scanUrls: Boolean = false,
+    scanFilePaths: Boolean = false,
+    onUrlsChanged: (List<UrlRegion>) -> Unit = {},
+    onFilePathsChanged: (List<FilePathRegion>) -> Unit = {},
+    onMatchesChanged: (List<TerminalMatchRegion>) -> Unit = {},
+    onEngineCommandsChanged: (List<EngineCommandRegion>) -> Unit = {},
+    scanDispatcher: CoroutineDispatcher = Dispatchers.Default,
+    modifier: Modifier = Modifier,
+) {
+    var urls by remember { mutableStateOf<List<UrlRegion>>(emptyList()) }
+    var paths by remember { mutableStateOf<List<FilePathRegion>>(emptyList()) }
+    var matches by remember { mutableStateOf<List<TerminalMatchRegion>>(emptyList()) }
+    var commands by remember { mutableStateOf<List<EngineCommandRegion>>(emptyList()) }
+    val latestOnUrls by rememberUpdatedState(onUrlsChanged)
+    val latestOnPaths by rememberUpdatedState(onFilePathsChanged)
+    val latestOnMatches by rememberUpdatedState(onMatchesChanged)
+    val latestOnCommands by rememberUpdatedState(onEngineCommandsChanged)
+
+    LaunchedEffect(
+        view,
+        renderRequests,
+        viewportChangeKey,
+        matcher,
+        knownCommands,
+        scanUrls,
+        scanFilePaths,
+        scanDispatcher,
+    ) {
+        if (view == null) {
+            urls = emptyList()
+            paths = emptyList()
+            matches = emptyList()
+            commands = emptyList()
+            latestOnUrls(emptyList())
+            latestOnPaths(emptyList())
+            latestOnMatches(emptyList())
+            latestOnCommands(emptyList())
+            return@LaunchedEffect
+        }
+        // Issue #1260 (mirrored from [AgentPaneAffordanceOverlay]): pin the collect
+        // + the extract/publish to the Handler-based [Dispatchers.Main.immediate],
+        // NOT the LaunchedEffect's default frame-gated AndroidUiDispatcher.Main —
+        // otherwise the coalescer's `delay` window stalls for a whole `%output`
+        // burst on a non-invalidating surface and the affordance never repopulates.
+        val mainDispatcher = Dispatchers.Main.immediate
+        collectShellPaneAffordances(
+            renderRequests = renderRequests,
+            extractSnapshot = { extractVisibleViewportRows(view) },
+            matcher = matcher,
+            knownCommands = knownCommands,
+            scanUrls = scanUrls,
+            scanFilePaths = scanFilePaths,
+            mainContext = mainDispatcher,
+            scanContext = scanDispatcher,
+        ) { result ->
+            if (result.urls != urls) {
+                urls = result.urls
+                latestOnUrls(result.urls)
+            }
+            if (result.filePaths != paths) {
+                paths = result.filePaths
+                latestOnPaths(result.filePaths)
+            }
+            if (result.matches != matches) {
+                matches = result.matches
+                latestOnMatches(result.matches)
+            }
+            if (result.engineCommands != commands) {
+                commands = result.engineCommands
+                latestOnCommands(result.engineCommands)
+            }
+        }
+    }
+
+    val regions = remember(matches, paths, commands) {
+        buildList {
+            addAll(matches)
+            paths.forEach { region ->
+                add(
+                    TerminalMatchRegion(
+                        match = TerminalMatch.Path(region.path),
+                        row = region.row,
+                        startCol = region.startCol,
+                        endColExclusive = region.endColExclusive,
+                    ),
+                )
+            }
+            commands.forEach { region ->
+                add(
+                    TerminalMatchRegion(
+                        match = TerminalMatch.EngineCommand(region.command),
+                        row = region.row,
+                        startCol = region.startCol,
+                        endColExclusive = region.endColExclusive,
+                    ),
+                )
+            }
+        }
+    }
+
+    Layout(
+        content = {},
+        modifier = modifier.drawBehind {
+            for (segment in smartSelectionAffordanceSegments(view, regions, size.width, size.height)) {
+                drawRect(
+                    color = segment.color,
+                    topLeft = Offset(segment.left, segment.top),
+                    size = Size(
+                        width = segment.right - segment.left,
+                        height = segment.thicknessPx,
+                    ),
+                )
+            }
+        },
+    ) { _, constraints ->
+        // Draw-only overlay sized to the pane, robust to the pager/lookahead's
+        // intermittent UNBOUNDED-height measure pass (v0.4.17 crash) — see
+        // [layoutOverlayBounded].
+        layoutOverlayBounded(constraints)
+    }
+}

--- a/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/selection/SmartSelectionAffordanceOverlay.kt
+++ b/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/selection/SmartSelectionAffordanceOverlay.kt
@@ -25,218 +25,16 @@ import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.withContext
 
 /**
- * Compose overlay that paints lightweight affordances for smart-selection
- * tokens currently visible on the embedded [com.termux.view.TerminalView].
- *
- * The overlay is purely visual. It does not install pointer handlers and it
- * does not change which tokens are tappable; URL taps still route through the
- * vendored View's gesture pipeline, and path/error taps still route through
- * [SelectionOverlay] when the host supplies a smart-selection callback.
- *
- * The treatment deliberately stays close to the terminal renderer: URLs keep
- * the existing 2 px cyan underline, while paths and errors get quieter
- * 1 px hairlines. There are no filled backgrounds, chips, or red error
- * chrome, so dense terminal output remains readable.
- *
- * ## Coordinate math
- *
- * The overlay reads the renderer's `mFontWidth` and `mFontLineSpacing` from
- * the supplied [TerminalView] and converts grid (col, row) ranges to pixel
- * rectangles using the same arithmetic the renderer does:
- *
- *   x_left  = col_start * mFontWidth
- *   x_right = col_end_exclusive * mFontWidth
- *   y_top   = (external_row - mTopRow) * mFontLineSpacing
- *   y_bot   = y_top + mFontLineSpacing
- *
- * `mTopRow` is the view's current scroll offset (0 when stationary,
- * negative when scrolled into history). The overlay only paints rows whose
- * `y_top` and `y_bot` fall inside the canvas height, so URLs that scrolled
- * partially off-screen are clipped naturally.
- *
- * ## Refresh cadence
- *
- * The overlay does not poll continuously. It re-scans the visible viewport
- * for matches every time the supplied [renderRequests] flow emits — the same
- * signal that drives [TerminalView.onScreenUpdated] — and whenever
- * [viewportChangeKey] changes due to scroll or terminal resize. That keeps
- * affordance regions in sync with both rendered text and viewport-only
- * movement without spinning a render-rate animation loop.
- *
- * Why no dependency on `androidx.compose.foundation`: this module stays on
- * `androidx.compose.ui` only (`compose.foundation` is not a declared
- * dependency in `build.gradle.kts`) so the overlay uses [Layout] +
- * [Modifier.drawBehind] instead of `foundation.Canvas`. The visual result is
- * identical — a `DrawScope` either way — but the dependency footprint stays
- * exactly the same as [SelectionOverlay].
- *
- * @param view the embedded [TerminalView]. May be null before the first
- *   layout pass; the overlay composes an inert sized box in that case.
- * @param renderRequests the surface's redraw signal — typically
- *   `state.renderRequests`. Each emission triggers a fresh match scan.
- * @param viewportChangeKey any value that changes when the visible grid
- *   changes without a render request, such as scrollback position or
- *   emulator size. Each key change triggers an immediate fresh URL scan.
- * @param matcher smart-selection matcher used only to derive visible
- *   affordance spans.
- * @param onMatchesChanged invoked with the latest visible match snapshot.
- *   Hosts may reuse the same snapshot for invisible smart-selection
- *   hit-testing; receiving it here does not make this overlay interactive.
- * @param modifier standard Compose modifier; the overlay sizes itself to the
- *   modifier's measured bounds.
- */
-@Composable
-fun SmartSelectionAffordanceOverlay(
-    view: TerminalView?,
-    renderRequests: Flow<Unit>,
-    viewportChangeKey: Any? = Unit,
-    matcher: TerminalMatcher = DefaultTerminalMatcher(),
-    onMatchesChanged: (List<TerminalMatchRegion>) -> Unit = {},
-    modifier: Modifier = Modifier,
-) {
-    var regions by remember { mutableStateOf<List<TerminalMatchRegion>>(emptyList()) }
-    val latestOnMatchesChanged by rememberUpdatedState(onMatchesChanged)
-
-    LaunchedEffect(view, renderRequests, viewportChangeKey, matcher) {
-        if (view == null) {
-            latestOnMatchesChanged(emptyList())
-            return@LaunchedEffect
-        }
-        // Initial scan so the host gets the match list before the first
-        // post-render signal arrives.
-        val initial = findVisibleTerminalMatches(view, matcher)
-        regions = initial
-        latestOnMatchesChanged(initial)
-        // Issue #1260: collect on the Handler-based [Dispatchers.Main.immediate],
-        // NOT the LaunchedEffect's default Compose `AndroidUiDispatcher.Main`.
-        // The coalesced render stream ([RenderFrameCoalescer]) times its window
-        // with `delay`, and AndroidUiDispatcher batches dispatch to Choreographer
-        // frames — during a `%output` burst on a non-invalidating surface those
-        // frames stop, so the scan stalls for the whole burst (the #1260 shell
-        // `scans=0` regression, exposed by #1216's `renderRequests replay = 1`).
-        // The main-thread Handler dispatcher is not frame-gated; the emulator read
-        // still runs on the main thread, so this is thread-safe.
-        withContext(Dispatchers.Main.immediate) {
-            renderRequests.collect {
-                val fresh = findVisibleTerminalMatches(view, matcher)
-                // Only churn the host when the list shape changes; equal lists
-                // are no-ops both visually and for tap routing.
-                if (fresh != regions) {
-                    regions = fresh
-                    latestOnMatchesChanged(fresh)
-                }
-            }
-        }
-    }
-
-    Layout(
-        content = {},
-        modifier = modifier.drawBehind {
-            for (segment in smartSelectionAffordanceSegments(view, regions, size.width, size.height)) {
-                drawRect(
-                    color = segment.color,
-                    topLeft = Offset(segment.left, segment.top),
-                    size = Size(
-                        width = segment.right - segment.left,
-                        height = segment.thicknessPx,
-                    ),
-                )
-            }
-        },
-    ) { _, constraints ->
-        // Inert draw-only box sized to the terminal pane (drawBehind needs
-        // non-zero bounds to paint) — but robust to the pager/lookahead's
-        // intermittent UNBOUNDED-height measure pass (the v0.4.17
-        // `Size(W x Int.MAX_VALUE)` crash). See [layoutOverlayBounded].
-        layoutOverlayBounded(constraints)
-    }
-}
-
-/**
- * Issue #500: paints a quiet path hairline under every tappable file path the
- * [findVisibleFilePaths] scanner reports on the visible viewport, and keeps the
- * host's [FilePathRegion] snapshot in sync for hit-testing. The actual tap
- * routing happens in the View's gesture pipeline via
- * [com.pocketshell.core.terminal.ui.PocketShellTerminalViewClient.onTapMaybeUrl].
- */
-@Composable
-public fun FilePathOverlay(
-    view: TerminalView?,
-    renderRequests: Flow<Unit>,
-    viewportChangeKey: Any? = Unit,
-    onFilePathsChanged: (List<FilePathRegion>) -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    var paths by remember { mutableStateOf<List<FilePathRegion>>(emptyList()) }
-    val latestOnPathsChanged by rememberUpdatedState(onFilePathsChanged)
-
-    LaunchedEffect(view, renderRequests, viewportChangeKey) {
-        if (view == null) {
-            latestOnPathsChanged(emptyList())
-            return@LaunchedEffect
-        }
-        val initial = findVisibleFilePaths(view)
-        paths = initial
-        latestOnPathsChanged(initial)
-        // Issue #1260: collect on the Handler-based [Dispatchers.Main.immediate]
-        // so the coalesced-render window resumes during a burst — see
-        // [SmartSelectionAffordanceOverlay] for the frame-gated-dispatcher detail.
-        withContext(Dispatchers.Main.immediate) {
-            renderRequests.collect {
-                val fresh = findVisibleFilePaths(view)
-                if (fresh != paths) {
-                    paths = fresh
-                    latestOnPathsChanged(fresh)
-                }
-            }
-        }
-    }
-
-    val regions = remember(paths) {
-        paths.map { region ->
-            TerminalMatchRegion(
-                match = TerminalMatch.Path(region.path),
-                row = region.row,
-                startCol = region.startCol,
-                endColExclusive = region.endColExclusive,
-            )
-        }
-    }
-
-    Layout(
-        content = {},
-        modifier = modifier.drawBehind {
-            for (segment in smartSelectionAffordanceSegments(view, regions, size.width, size.height)) {
-                drawRect(
-                    color = segment.color,
-                    topLeft = Offset(segment.left, segment.top),
-                    size = Size(
-                        width = segment.right - segment.left,
-                        height = segment.thicknessPx,
-                    ),
-                )
-            }
-        },
-    ) { _, constraints ->
-        // Issue: a draw-only overlay sized to the pane — but robust to the
-        // pager/lookahead's intermittent UNBOUNDED-height measure pass (the
-        // v0.4.17 `Size(W x Int.MAX_VALUE)` crash). See [layoutOverlayBounded].
-        layoutOverlayBounded(constraints)
-    }
-}
-
-/**
  * Issue #871: tappable file paths AND URLs on an interactive-agent pane
  * (Codex/Claude), WITHOUT the per-frame main-thread regex cost that caused the
  * #803/#866/#796 ANR.
  *
- * ## Why a dedicated overlay instead of re-enabling [FilePathOverlay] + the URL scan
+ * ## Why a dedicated overlay instead of the per-frame on-main scan
  *
- * The #796-REOPENED gate turned ALL four per-frame, full-viewport, **on-main**
- * affordance scanners OFF for an agent pane to kill the ANR. Just flipping that
- * gate back on would reintroduce the exact per-frame main-thread scan storm.
- * This overlay restores the two affordances the maintainer actually wants on an
- * agent pane (file path + URL) by splitting the work:
+ * The #796-REOPENED gate turned ALL per-frame, full-viewport, **on-main**
+ * affordance scanners OFF for an agent pane to kill the ANR. This overlay
+ * restores the two affordances the maintainer actually wants on an agent pane
+ * (file path + URL) by splitting the work:
  *
  * 1. **On the main thread, debounced on viewport-settle** (NOT every frame): read
  *    the visible rows into a thread-safe [ViewportRowsSnapshot] via
@@ -252,7 +50,9 @@ public fun FilePathOverlay(
  *
  * The heavier/less-valuable smart-selection match + engine-command scanners stay
  * OFF for an agent pane (the conversation view, #818, is the richer agent
- * surface); only path + URL are restored here, which is the scope of #871.
+ * surface); only path + URL are restored here, which is the scope of #871. Issue
+ * #1233 applies the SAME single-snapshot + off-main split to the SHELL-pane path
+ * (all four scanners) — see [ShellPaneAffordanceOverlay].
  *
  * @param onFilePathsChanged latest visible file-path snapshot for hit-testing.
  * @param onUrlsChanged latest visible URL snapshot for hit-testing.
@@ -384,97 +184,18 @@ public fun AgentPaneAffordanceOverlay(
 }
 
 /**
- * Issue #770: paints a cyan underline under every tappable engine command the
- * [findVisibleEngineCommands] scanner reports on the visible viewport, and keeps
- * the host's [EngineCommandRegion] snapshot in sync for hit-testing. Like
- * [FilePathOverlay], the actual tap routing happens in the View's gesture
- * pipeline via
- * [com.pocketshell.core.terminal.ui.PocketShellTerminalViewClient.onTapMaybeUrl].
- *
- * [knownCommands] is the set of valid command strings for the pane's detected
- * engine, supplied by the app from `AgentCommandCatalog`; an empty set scans
- * nothing.
- */
-@Composable
-public fun EngineCommandOverlay(
-    view: TerminalView?,
-    renderRequests: Flow<Unit>,
-    knownCommands: Set<String>,
-    viewportChangeKey: Any? = Unit,
-    onEngineCommandsChanged: (List<EngineCommandRegion>) -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    var commands by remember { mutableStateOf<List<EngineCommandRegion>>(emptyList()) }
-    val latestOnCommandsChanged by rememberUpdatedState(onEngineCommandsChanged)
-
-    LaunchedEffect(view, renderRequests, viewportChangeKey, knownCommands) {
-        if (view == null) {
-            latestOnCommandsChanged(emptyList())
-            return@LaunchedEffect
-        }
-        val initial = findVisibleEngineCommands(view, knownCommands)
-        commands = initial
-        latestOnCommandsChanged(initial)
-        // Issue #1260: collect on the Handler-based [Dispatchers.Main.immediate]
-        // so the coalesced-render window resumes during a burst — see
-        // [SmartSelectionAffordanceOverlay] for the frame-gated-dispatcher detail.
-        withContext(Dispatchers.Main.immediate) {
-            renderRequests.collect {
-                val fresh = findVisibleEngineCommands(view, knownCommands)
-                if (fresh != commands) {
-                    commands = fresh
-                    latestOnCommandsChanged(fresh)
-                }
-            }
-        }
-    }
-
-    val regions = remember(commands) {
-        commands.map { region ->
-            TerminalMatchRegion(
-                match = TerminalMatch.EngineCommand(region.command),
-                row = region.row,
-                startCol = region.startCol,
-                endColExclusive = region.endColExclusive,
-            )
-        }
-    }
-
-    Layout(
-        content = {},
-        modifier = modifier.drawBehind {
-            for (segment in smartSelectionAffordanceSegments(view, regions, size.width, size.height)) {
-                drawRect(
-                    color = segment.color,
-                    topLeft = Offset(segment.left, segment.top),
-                    size = Size(
-                        width = segment.right - segment.left,
-                        height = segment.thicknessPx,
-                    ),
-                )
-            }
-        },
-    ) { _, constraints ->
-        // Issue: a draw-only overlay sized to the pane — but robust to the
-        // pager/lookahead's intermittent UNBOUNDED-height measure pass (the
-        // v0.4.17 `Size(W x Int.MAX_VALUE)` crash). See [layoutOverlayBounded].
-        layoutOverlayBounded(constraints)
-    }
-}
-
-/**
  * Lay out a draw-only terminal affordance overlay at the available size — but
  * NEVER at an unbounded dimension.
  *
- * These overlays ([SmartSelectionAffordanceOverlay], [FilePathOverlay],
- * [AgentPaneAffordanceOverlay], [EngineCommandOverlay]) are inert `drawBehind`
- * boxes that just need to fill the terminal pane so their hairlines paint. Each
- * previously called `layout(maxWidth.coerceAtLeast(0), maxHeight.coerceAtLeast(0))`,
- * which is fine under a normal bounded measure — but the overlay sits inside the
- * terminal pane, which is itself inside a [androidx.compose.foundation.pager.Pager]
+ * These overlays ([ShellPaneAffordanceOverlay], [AgentPaneAffordanceOverlay]) are
+ * inert `drawBehind` boxes that just need to fill the terminal pane so their
+ * hairlines paint. Each previously called
+ * `layout(maxWidth.coerceAtLeast(0), maxHeight.coerceAtLeast(0))`, which is fine
+ * under a normal bounded measure — but the overlay sits inside the terminal pane,
+ * which is itself inside a [androidx.compose.foundation.pager.Pager]
  * (`TmuxTerminalPager`). The pager / lookahead runs intermittent measure passes
  * with an **unbounded** (`Constraints.Infinity`, i.e. `Int.MAX_VALUE`) maximum
- * dimension. `coerceAtLeast(0)` leaves that `Int.MAX_VALUE` intact, so
+ * dimension. `coerceAtLeast(0)` left that `Int.MAX_VALUE` intact, so
  * `layout(width, Int.MAX_VALUE)` threw
  * `IllegalStateException: Size(<w> x 2147483647) is out of range. Each dimension
  * must be between 0 and 16777215.` — the v0.4.17 RELEASE-BLOCKING crash that
@@ -488,9 +209,9 @@ public fun EngineCommandOverlay(
  *
  * Issue #966/#967: the helper itself now lives in [layoutTerminalOverlayBounded]
  * (in `TerminalOverlayMeasure.kt`) so EVERY terminal measure site can share the
- * unbounded-safe guard, not just the four affordance overlays here.
+ * unbounded-safe guard, not just the affordance overlays here.
  */
-private fun MeasureScope.layoutOverlayBounded(constraints: Constraints): MeasureResult =
+internal fun MeasureScope.layoutOverlayBounded(constraints: Constraints): MeasureResult =
     layoutTerminalOverlayBounded(constraints)
 
 internal data class SmartSelectionAffordanceSegment(

--- a/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/selection/UrlScanner.kt
+++ b/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/selection/UrlScanner.kt
@@ -102,44 +102,13 @@ public data class UrlRegion(
  * typically <30 rows on a phone.
  */
 public fun findVisibleUrls(view: TerminalView): List<UrlRegion> {
-    val emulator = view.mEmulator ?: return emptyList()
-    val screen = emulator.screen ?: return emptyList()
-    val columns = emulator.mColumns
-    val rows = emulator.mRows
-    if (columns <= 0 || rows <= 0) return emptyList()
-
-    val topRow = view.topRow
-    val firstRow = topRow
-    val lastRowExclusive = topRow + rows
-
-    // Issue #558 bug 2: read every visible row WITH its line-wrap flag so a URL
-    // that the emulator soft-wrapped across rows is reassembled into one logical
-    // line before matching. `getLineWrap(row)` is true when the next row
-    // continues this one.
-    val visualRows = mutableListOf<VisualRow>()
-    for (row in firstRow until lastRowExclusive) {
-        val line: String = try {
-            // (selX1, selY1, selX2, selY2): inclusive-inclusive rectangle.
-            // (0, row, mColumns, row) → the full row, with trailing spaces
-            // preserved (joinBackLines=true is the default but only joins
-            // *back* lines, not pad the right edge with extra spaces).
-            screen.getSelectedText(0, row, columns, row)
-        } catch (_: Throwable) {
-            // Mid-resize the vendored emulator occasionally throws AIOOBE.
-            // Treat as a blank, non-wrapping row rather than failing the whole
-            // overlay pass — the next render request will retry.
-            visualRows += VisualRow(row = row, text = "", wrapsToNext = false)
-            continue
-        }
-        val wraps = try {
-            row + 1 < lastRowExclusive && screen.getLineWrap(row)
-        } catch (_: Throwable) {
-            false
-        }
-        visualRows += VisualRow(row = row, text = line, wrapsToNext = wraps)
-    }
-
-    return urlRegionsForRows(visualRows, columns)
+    // Issue #558 bug 2 / #1233: read every visible row WITH its line-wrap flag —
+    // via the shared [extractVisibleViewportRows] primitive so a URL the emulator
+    // soft-wrapped across rows is reassembled into one logical line before
+    // matching, AND so the four shell-pane affordance scanners share ONE viewport
+    // extraction per coalesced frame rather than each re-running the row loop.
+    val snapshot = extractVisibleViewportRows(view)
+    return urlRegionsForRows(snapshot.rows, snapshot.columns)
 }
 
 /**

--- a/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurface.kt
+++ b/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurface.kt
@@ -26,17 +26,14 @@ import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
 import com.pocketshell.core.terminal.selection.AgentPaneAffordanceOverlay
-import com.pocketshell.core.terminal.selection.EngineCommandOverlay
 import com.pocketshell.core.terminal.selection.EngineCommandRegion
-import com.pocketshell.core.terminal.selection.FilePathOverlay
 import com.pocketshell.core.terminal.selection.FilePathRegion
 import com.pocketshell.core.terminal.selection.SelectionOverlay
-import com.pocketshell.core.terminal.selection.SmartSelectionAffordanceOverlay
+import com.pocketshell.core.terminal.selection.ShellPaneAffordanceOverlay
 import com.pocketshell.core.terminal.selection.safeLayoutDimension
 import com.pocketshell.core.terminal.selection.TerminalMatch
 import com.pocketshell.core.terminal.selection.TerminalMatchRegion
 import com.pocketshell.core.terminal.selection.UrlRegion
-import com.pocketshell.core.terminal.selection.findVisibleUrls
 import com.pocketshell.core.terminal.selection.hitTestEngineCommand
 import com.pocketshell.core.terminal.selection.hitTestFilePath
 import com.pocketshell.core.terminal.selection.hitTestUrl
@@ -481,57 +478,26 @@ fun TerminalSurface(
         !affordanceScannersEnabled &&
             agentPaneLinkAffordancesEnabled &&
             (onFilePathTap != null || effectiveUrlTap != null)
-    // The file-path tap is live when EITHER the shell-pane on-main overlay OR the
-    // agent-pane off-main overlay is feeding `visibleFilePaths`.
+    // The file-path tap is live when EITHER the shell-pane single-snapshot overlay
+    // OR the agent-pane off-main overlay is feeding `visibleFilePaths`.
     val filePathTapActive =
         onFilePathTap != null && (filePathScannerEnabled || agentLinkOverlayEnabled)
+    // Issue #1233: the ONE consolidated shell / non-agent affordance overlay
+    // ([ShellPaneAffordanceOverlay] below) is wired whenever a shell pane has ANY
+    // of the four affordance passes active. It extracts the visible viewport ONCE
+    // per coalesced frame and runs the enabled URL / smart-selection / file-path /
+    // engine-command regex passes off the main thread — replacing the four
+    // independent per-frame on-main scanners that each re-extracted the whole
+    // viewport (~4× redundant extraction + regex on Main every frame).
+    val shellAffordanceOverlayEnabled =
+        affordanceScannersEnabled &&
+            (effectiveUrlTap != null || matchScannerEnabled || filePathScannerEnabled || engineCommandsEnabled)
 
-    LaunchedEffect(state, terminalView, effectiveUrlTap, viewportTick, coalescedRenderRequests, agentLinkOverlayEnabled) {
-        val view = terminalView
-        if (view == null || effectiveUrlTap == null) {
-            visibleUrls = emptyList()
-            return@LaunchedEffect
-        }
-        if (agentLinkOverlayEnabled) {
-            // Issue #871: on an agent pane the URL scan is driven OFF-main by
-            // [AgentPaneAffordanceOverlay] (which publishes into `visibleUrls`),
-            // NOT by this per-frame on-main scan. Skipping it here is what keeps
-            // the #803/#866 per-frame main-thread cost off agent panes while still
-            // making URLs tappable.
-            return@LaunchedEffect
-        }
-        visibleUrls = runCatching { findVisibleUrls(view) }
-            .getOrElse { cause ->
-                onLocalTerminalError?.invoke(cause)
-                emptyList()
-            }
-        // Issue #796: scan the full viewport for URLs at most once per frame, not
-        // once per emulator tick. `findVisibleUrls` reads the live TerminalView
-        // renderer/emulator, so it must run on the UI thread (the view is not
-        // thread-safe); the win here is frame-gating the scan count, which is the
-        // dominant per-tick cost during a burst. Only the diff is published.
-        // Issue #1260: collect on the Handler-based [Dispatchers.Main.immediate]
-        // so the coalescer window resumes during a burst — see the repaint
-        // collector above for the full frame-gated-dispatcher rationale.
-        withContext(Dispatchers.Main.immediate) {
-            coalescedRenderRequests.collect {
-                val fresh = runCatching { findVisibleUrls(view) }
-                    .getOrElse { cause ->
-                        onLocalTerminalError?.invoke(cause)
-                        emptyList()
-                    }
-                if (fresh != visibleUrls) {
-                    visibleUrls = fresh
-                }
-            }
-        }
-    }
-
-    // Issue #500: file-path detection is driven by the FilePathOverlay below
-    // (gated on onFilePathTap != null). The overlay scans the visible viewport
-    // and reports its FilePathRegion snapshot via onFilePathsChanged, which we
-    // capture into `visibleFilePaths` for the tap hit-test. Keeping a single
-    // scan source (the overlay) avoids double-scanning per render tick.
+    // Issue #1233: the URL / smart-selection / file-path / engine-command hit-test
+    // snapshots (`visibleUrls` / `visibleMatchRegions` / `visibleFilePaths` /
+    // `visibleEngineCommands`) are all fed by [ShellPaneAffordanceOverlay] (shell
+    // pane) or [AgentPaneAffordanceOverlay] (agent pane) below, each from a SINGLE
+    // per-frame viewport extraction — no standalone per-frame URL scan here.
 
     // Install the tap-hook on the view client every time `visibleUrls`,
     // `terminalView`, or `effectiveUrlTap` changes. The hook receives a tap
@@ -610,7 +576,7 @@ fun TerminalSurface(
     // so token hairlines are visible above other overlays. URL tap-routing
     // happens inside the View's gesture pipeline via
     // [PocketShellTerminalViewClient.onTapMaybeUrl], not in the overlay —
-    // see [SmartSelectionAffordanceOverlay]'s KDoc for the rationale.
+    // see [ShellPaneAffordanceOverlay]'s KDoc for the rationale.
     Layout(
         modifier = keyAwareModifier,
         content = {
@@ -670,41 +636,44 @@ fun TerminalSurface(
                     onTap = matchListener,
                 )
             }
-            // Issue #796: the smart-selection affordance overlay runs a
-            // full-viewport `findVisibleTerminalMatches` scan per render frame —
-            // one of the four scanners. Only wire it when a scanner consumer is
-            // active AND scanners are enabled (an agent pane wires none). Issue
-            // #871: gate on `affordanceScannersEnabled` too — an agent pane's
-            // `effectiveUrlTap` is now non-null (URLs are tappable there via the
-            // OFF-main overlay), so without this gate the on-main per-frame match
-            // scan would wrongly come back for agent panes (the ANR).
-            if (affordanceScannersEnabled && (matchScannerEnabled || effectiveUrlTap != null)) {
-                SmartSelectionAffordanceOverlay(
+            // Issue #1233: ONE consolidated shell / non-agent affordance overlay
+            // replaces the four independent per-frame on-main scanners (the URL
+            // scan + SmartSelectionAffordanceOverlay + FilePathOverlay +
+            // EngineCommandOverlay). It extracts the visible viewport ONCE per
+            // coalesced frame and runs the (enabled) URL / smart-selection /
+            // file-path / engine-command regex passes OFF the main thread against
+            // that single snapshot, publishing all four hit-test snapshots. It
+            // draws the match + file-path + engine-command hairlines; the URL
+            // underline comes from the matcher's TerminalMatch.Url matches (the URL
+            // pass feeds tap hit-testing only), exactly as the four overlays did.
+            // The matcher pass runs whenever the smart-selection consumer is active
+            // OR URLs are tappable (so the URL underline is still drawn), matching
+            // the deleted SmartSelectionAffordanceOverlay gate.
+            if (shellAffordanceOverlayEnabled) {
+                ShellPaneAffordanceOverlay(
                     view = terminalView,
-                    // Issue #796: gate the per-render match scan to ≤1/frame.
                     renderRequests = coalescedRenderRequests,
                     viewportChangeKey = viewportTick,
-                    matcher = state.currentMatcher(),
-                    onMatchesChanged = { visibleMatchRegions = it },
-                )
-            }
-            // Issue #500: tappable file-path affordance + hit-test snapshot (the
-            // ON-main per-frame scan, shell / non-agent panes only).
-            if (filePathScannerEnabled) {
-                FilePathOverlay(
-                    view = terminalView,
-                    // Issue #796: gate the per-render file-path scan to ≤1/frame.
-                    renderRequests = coalescedRenderRequests,
-                    viewportChangeKey = viewportTick,
+                    matcher = if (matchScannerEnabled || effectiveUrlTap != null) {
+                        state.currentMatcher()
+                    } else {
+                        null
+                    },
+                    knownCommands = if (engineCommandsEnabled) engineCommands else emptySet(),
+                    scanUrls = effectiveUrlTap != null,
+                    scanFilePaths = filePathScannerEnabled,
+                    onUrlsChanged = { visibleUrls = it },
                     onFilePathsChanged = { visibleFilePaths = it },
+                    onMatchesChanged = { visibleMatchRegions = it },
+                    onEngineCommandsChanged = { visibleEngineCommands = it },
                 )
             }
             // Issue #871: an agent pane (Codex/Claude) gets tappable file paths +
             // URLs via the OFF-main, debounced overlay — never the per-frame
-            // on-main scan above. It feeds BOTH `visibleFilePaths` and
-            // `visibleUrls` for the tap hit-test and paints the affordance
-            // hairlines. The match + engine-command scanners stay off for an agent
-            // pane (Conversation, #818, is the richer surface).
+            // on-main scan. It feeds BOTH `visibleFilePaths` and `visibleUrls` for
+            // the tap hit-test and paints the affordance hairlines. The match +
+            // engine-command scanners stay off for an agent pane (Conversation,
+            // #818, is the richer surface).
             if (agentLinkOverlayEnabled) {
                 AgentPaneAffordanceOverlay(
                     view = terminalView,
@@ -712,17 +681,6 @@ fun TerminalSurface(
                     viewportChangeKey = viewportTick,
                     onFilePathsChanged = { visibleFilePaths = it },
                     onUrlsChanged = { visibleUrls = it },
-                )
-            }
-            // Issue #770: tappable engine-command affordance + hit-test snapshot.
-            if (engineCommandsEnabled) {
-                EngineCommandOverlay(
-                    view = terminalView,
-                    // Issue #796: gate the per-render engine-command scan to ≤1/frame.
-                    renderRequests = coalescedRenderRequests,
-                    knownCommands = engineCommands,
-                    viewportChangeKey = viewportTick,
-                    onEngineCommandsChanged = { visibleEngineCommands = it },
                 )
             }
         },

--- a/shared/core-terminal/src/test/java/com/pocketshell/core/terminal/selection/ShellPaneAffordanceScanCountTest.kt
+++ b/shared/core-terminal/src/test/java/com/pocketshell/core/terminal/selection/ShellPaneAffordanceScanCountTest.kt
@@ -1,0 +1,205 @@
+package com.pocketshell.core.terminal.selection
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Issue #1233 — LOAD-BEARING unit proof: a shell / non-agent terminal pane must
+ * extract the visible viewport AT MOST ONCE per coalesced frame for its affordance
+ * scanners, instead of the FOUR independent full-viewport extractions the four
+ * per-frame on-main scanners (URL scan + SmartSelection + FilePath +
+ * EngineCommand overlays) each performed before the fix.
+ *
+ * ## The before/after this pins (RenderFrameCoalescerTest precedent)
+ *
+ * - [preFixShellPaneExtractsViewportFourTimesPerFrame] models the DELETED shell-pane
+ *   wiring: each of the four scanners ran its own `findVisible*` = its own viewport
+ *   extraction, so ONE render frame drove FOUR full-viewport extractions on the
+ *   main thread. This pins the redundant per-frame cost (the milder-#796 root).
+ * - [consolidatedShellScannerExtractsViewportOncePerFrame] drives the PRODUCTION
+ *   [collectShellPaneAffordances] loop (the body of [ShellPaneAffordanceOverlay])
+ *   with a counting extractor and asserts ONE render frame drives exactly ONE
+ *   extraction — while STILL producing all four affordance region lists (URL /
+ *   file-path / smart-selection / engine-command), so detection is unchanged.
+ * - [consolidatedShellScannerExtractsOncePerFrameAcrossManyFrames] extends that to
+ *   N frames -> N extractions (1 per frame), never 4N.
+ *
+ * The counting fake is the injected `extractSnapshot: () -> ViewportRowsSnapshot`
+ * seam — the exact thing #1233's acceptance calls a "fake that counts viewport-text
+ * extractions per frame".
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class ShellPaneAffordanceScanCountTest {
+
+    /**
+     * A realistic one-row viewport carrying all four affordance token kinds so
+     * every pass detects something (proving the single-snapshot path feeds each
+     * scanner, not just that it runs once):
+     *  - a schemed URL, a rooted file path (`.txt`), and an engine command
+     *    (`/clear`) — the URL/path also register as smart-selection matches.
+     */
+    private fun sampleSnapshot(): ViewportRowsSnapshot =
+        ViewportRowsSnapshot(
+            rows = listOf(
+                VisualRow(
+                    row = 0,
+                    text = "open https://example.com/foo see /home/me/out/report.txt run /clear",
+                    wrapsToNext = false,
+                ),
+            ),
+            columns = 80,
+        )
+
+    private val knownCommands = setOf("/clear")
+
+    @Test
+    fun preFixShellPaneExtractsViewportFourTimesPerFrame() {
+        // Model the pre-#1233 shell-pane wiring: the URL scan + SmartSelection +
+        // FilePath + EngineCommand overlays EACH re-extracted the full viewport
+        // themselves (each `findVisible*` = one `extractVisibleViewportRows`) on the
+        // SAME render frame. So ONE frame drove FOUR independent extractions.
+        val extractCount = AtomicInteger(0)
+        val snapshot = sampleSnapshot()
+        val extract: () -> ViewportRowsSnapshot = {
+            extractCount.incrementAndGet()
+            snapshot
+        }
+
+        // The four scanners, exactly as the four deleted overlays ran them — each
+        // from its OWN extraction.
+        val urls = urlRegionsForRows(extract().rows, snapshot.columns)
+        val paths = filePathRegionsForRows(extract().rows, snapshot.columns)
+        val matches = terminalMatchRegionsForRows(extract().rows, snapshot.columns, DefaultTerminalMatcher())
+        val commands = engineCommandRegionsForRows(extract().rows, snapshot.columns, knownCommands)
+
+        assertEquals(
+            "pre-#1233 shell pane: the four independent scanners each re-extract the " +
+                "viewport, so ONE frame drives FOUR full-viewport extractions on Main",
+            4,
+            extractCount.get(),
+        )
+        // Sanity: the sample viewport genuinely carries all four token kinds, so the
+        // green single-snapshot test below is not vacuous.
+        assertTrue("sample must contain a URL", urls.any { it.url == "https://example.com/foo" })
+        assertTrue("sample must contain a file path", paths.any { it.path == "/home/me/out/report.txt" })
+        assertTrue("sample must contain smart-selection matches", matches.isNotEmpty())
+        assertTrue("sample must contain the /clear engine command", commands.any { it.command == "/clear" })
+    }
+
+    @Test
+    fun consolidatedShellScannerExtractsViewportOncePerFrame() = runTest {
+        val extractCount = AtomicInteger(0)
+        val snapshot = sampleSnapshot()
+        val results = mutableListOf<ShellPaneAffordanceRegions>()
+        val frames = MutableSharedFlow<Unit>(extraBufferCapacity = 16)
+        val dispatcher = StandardTestDispatcher(testScheduler)
+
+        val job = launch(dispatcher) {
+            collectShellPaneAffordances(
+                renderRequests = frames,
+                extractSnapshot = {
+                    extractCount.incrementAndGet()
+                    snapshot
+                },
+                matcher = DefaultTerminalMatcher(),
+                knownCommands = knownCommands,
+                scanUrls = true,
+                scanFilePaths = true,
+                mainContext = dispatcher,
+                scanContext = dispatcher,
+                onResult = { results += it },
+            )
+        }
+
+        // The `onStart { emit(Unit) }` initial frame: ONE frame -> ONE extraction.
+        advanceUntilIdle()
+
+        assertEquals(
+            "#1233: ONE coalesced frame must drive exactly ONE viewport extraction " +
+                "for ALL four affordance scanners (was 4 pre-fix)",
+            1,
+            extractCount.get(),
+        )
+        assertEquals("one frame publishes one affordance result", 1, results.size)
+
+        // Behavior UNCHANGED: the single snapshot fed all four passes — every
+        // affordance kind is still detected.
+        val regions = results.single()
+        assertTrue(
+            "URL still detected from the single snapshot",
+            regions.urls.any { it.url == "https://example.com/foo" },
+        )
+        assertTrue(
+            "file path still detected from the single snapshot",
+            regions.filePaths.any { it.path == "/home/me/out/report.txt" },
+        )
+        assertTrue(
+            "smart-selection matches still detected from the single snapshot",
+            regions.matches.isNotEmpty(),
+        )
+        assertTrue(
+            "engine command still detected from the single snapshot",
+            regions.engineCommands.any { it.command == "/clear" },
+        )
+
+        job.cancel()
+    }
+
+    @Test
+    fun consolidatedShellScannerExtractsOncePerFrameAcrossManyFrames() = runTest {
+        val extractCount = AtomicInteger(0)
+        val snapshot = sampleSnapshot()
+        val results = mutableListOf<ShellPaneAffordanceRegions>()
+        val frames = MutableSharedFlow<Unit>(extraBufferCapacity = 64)
+        val dispatcher = StandardTestDispatcher(testScheduler)
+
+        val job = launch(dispatcher) {
+            collectShellPaneAffordances(
+                renderRequests = frames,
+                extractSnapshot = {
+                    extractCount.incrementAndGet()
+                    snapshot
+                },
+                matcher = DefaultTerminalMatcher(),
+                knownCommands = knownCommands,
+                scanUrls = true,
+                scanFilePaths = true,
+                mainContext = dispatcher,
+                scanContext = dispatcher,
+                onResult = { results += it },
+            )
+        }
+        advanceUntilIdle() // initial onStart frame (extraction 1)
+
+        // Emit each render frame with a settle between them so `conflate` does not
+        // collapse them — one distinct frame at a time.
+        val extraFrames = 5
+        repeat(extraFrames) {
+            frames.emit(Unit)
+            advanceUntilIdle()
+        }
+
+        // 1 (initial) + extraFrames distinct frames = one extraction PER frame,
+        // never 4 per frame.
+        assertEquals(
+            "#1233: each coalesced frame drives exactly ONE extraction (N frames -> N " +
+                "extractions), never 4N",
+            1 + extraFrames,
+            extractCount.get(),
+        )
+        assertTrue("each frame published a result", results.size >= 1 + extraFrames)
+
+        job.cancel()
+    }
+}


### PR DESCRIPTION
Closes #1233

## What
Shell/non-agent panes ran **4 independent full-viewport affordance scanners** per coalesced frame (URL + smart-selection + file-path + engine-command), each re-extracting the viewport and running its regex on **Main**. Consolidated into one `ShellPaneAffordanceOverlay` that extracts the viewport **once per frame** and runs the enabled passes **off-main** against that single snapshot (reusing #871's `AgentPaneAffordanceOverlay` machinery). The 3 superseded scanning overlays are gutted (hard-cut, D22).

## Verification (reviewer ran the connected proof itself)
- **G6 detection-unchanged (load-bearing green)**: connected proof composes the production `TerminalSurface` shell pane, detects URL + file path + `/clear`, each tap reaches the host — 2/2 on emulator-5554.
- **G1 count proof**: pre-fix 4 extractions/frame → `collectShellPaneAffordances` = 1 (N frames = N, not 4N); tests=3, 0 skipped.
- **Cost win (this run's logcat)**: `saw_main_thread_scan=false`, 307 off-main dispatches vs 3099 render ticks.
- **Off-main correctness**: snapshot on Main.immediate, regex on Default over immutable copy, published on Main, `conflate()` → latest frame; no stale-snapshot race; agent-pane #871 path byte-unchanged.
- Deleted-scanner safety: no code references remain; 467 core-terminal unit tests green.

Reviewer APPROVED: https://github.com/alexeygrigorev/pocketshell/issues/1233#issuecomment-4879762263