### PR TITLE
composer: move hands-free lock inline with the waveform row (#1245)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerMicSwipeLockJourneyTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerMicSwipeLockJourneyTest.kt
@@ -231,6 +231,67 @@ class PromptComposerMicSwipeLockJourneyTest {
         compose.onNodeWithTag(COMPOSER_MIC_TAG).assertIsDisplayed()
     }
 
+    /**
+     * Issue #1245: the hands-free lock affordance was mystery-meat sitting in the
+     * bottom Send/Discard cluster. It must now live INLINE on the recording/
+     * waveform row (attached to the recording it controls), NOT down in the
+     * bottom cluster next to Insert/Send.
+     *
+     * This asserts the geometry that encodes "moved up": the lock toggle
+     * ([COMPOSER_LOCK_RECORDING_TAG]) sits on the recording surface row — vertically
+     * aligned with the elapsed timer + waveform — and ENTIRELY ABOVE the bottom
+     * stop-action cluster (Insert / Send). On the unfixed layout the lock pill lived
+     * next to Discard in the bottom cluster (its top roughly level with the
+     * Insert/Send rows, far below the timer), so this test is RED on base and GREEN
+     * with the inline toggle. The tap-to-lock path itself is covered by
+     * [tapLockControlLocksRecordingHandsFree].
+     */
+    @Test
+    fun lockControlSitsOnWaveformRowAboveBottomCluster() {
+        val mic = FakeMicCapture()
+        val viewModel = newViewModel(mic)
+        renderComposer(viewModel)
+
+        compose.onNodeWithTag(COMPOSER_MIC_TAG).performClick()
+        compose.waitUntil(timeoutMillis = 5_000) {
+            viewModel.uiState.value.recording == RecordingState.Recording
+        }
+        compose.waitForIdle()
+
+        assertFalse(viewModel.uiState.value.recordingLocked)
+
+        val lock = compose.onNodeWithTag(COMPOSER_LOCK_RECORDING_TAG, useUnmergedTree = true)
+            .fetchSemanticsNode().boundsInRoot
+        val timer = compose.onNodeWithTag(COMPOSER_TIMER_TAG, useUnmergedTree = true)
+            .fetchSemanticsNode().boundsInRoot
+        val waveform = compose.onNodeWithTag(COMPOSER_WAVEFORM_TAG, useUnmergedTree = true)
+            .fetchSemanticsNode().boundsInRoot
+        val insert = compose.onNodeWithTag(COMPOSER_TO_FIELD_TAG, useUnmergedTree = true)
+            .fetchSemanticsNode().boundsInRoot
+        val send = compose.onNodeWithTag(COMPOSER_STOP_SEND_TAG, useUnmergedTree = true)
+            .fetchSemanticsNode().boundsInRoot
+
+        // Vertically overlaps the timer/waveform (same row) — the lock is attached
+        // to the active recording, not floating below it.
+        val overlapsTimerRow =
+            lock.top < timer.bottom && lock.bottom > timer.top &&
+                lock.top < waveform.bottom && lock.bottom > waveform.top
+        assertTrue(
+            "Inline lock toggle is NOT on the recording/waveform row (#1245). " +
+                "lock=$lock timer=$timer waveform=$waveform",
+            overlapsTimerRow,
+        )
+
+        // Entirely ABOVE the bottom stop-action cluster (Insert / Send) — i.e. it
+        // is no longer a bottom-cluster pill.
+        assertTrue(
+            "Inline lock toggle is NOT above the bottom Insert/Send cluster (#1245). " +
+                "lock.bottom=${lock.bottom} insert.top=${insert.top} send.top=${send.top}",
+            lock.bottom <= insert.top && lock.bottom <= send.top,
+        )
+        WalkthroughScreenshotArtifacts.capture("issue-1245-lock-inline-on-waveform-row")
+    }
+
     @Test
     fun plainTapStartsRecordingWithoutLocking() {
         val mic = FakeMicCapture()

--- a/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerRecordingRowFitProofTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerRecordingRowFitProofTest.kt
@@ -45,8 +45,11 @@ import org.junit.runner.RunWith
  *
  * The maintainer's directive is FIT EVERYTHING — never hide a control to make
  * room. The fix relays the recording states into a TWO-ROW layout (secondary row:
- * tools + Discard + Lock; primary row: Insert + Send) so EVERY control fits with
- * the editing tools still mounted.
+ * tools + Discard; primary row: Insert + Send) so EVERY control fits with the
+ * editing tools still mounted. (Issue #1245 later moved the hands-free Lock UP to
+ * the recording/waveform row as an inline toggle, so it is no longer a
+ * bottom-cluster pill; this test guards that the inline toggle also stays within
+ * the band.)
  *
  * ## What this proves (red → green, class-covering)
  *
@@ -54,7 +57,7 @@ import org.junit.runner.RunWith
  * NOT-LOCKED and LOCKED — pinned to a FIXED phone-width band, keyboard-UP (the
  * #780 synthetic-inset model), at font scale 1.0 AND 1.3 (the widest-content
  * case, since this is a width-overflow bug). It then asserts, for every
- * recording-row pill (Discard / Lock / Insert / Send) AND the editing-tools
+ * recording-row pill (Discard / Insert / Send) AND the editing-tools
  * group:
  *  1. the pill is fully within the band horizontally (no edge spill), AND
  *  2. the pill is NOT CRUSHED — its width stays at/above a not-a-sliver floor.
@@ -207,9 +210,13 @@ class PromptComposerRecordingRowFitProofTest {
         // is 70–102dp; base crushes the trailing `Send` to ~33dp, so a 56dp floor
         // cleanly separates crushed (red) from intact (green). The editing-tools
         // group is a fixed 3×40dp icon pill, so it uses the icon-width floor.
+        // Issue #1245: the hands-free Lock is no longer a bottom-cluster pill — it
+        // moved UP to the recording/waveform row as an inline toggle, so it is not
+        // part of this bottom-row fit check (its placement is proven by
+        // PromptComposerMicSwipeLockJourneyTest). The bottom row must still FIT
+        // Discard · Insert · Send with the tools group mounted (the #1152 guard).
         val pills = buildList {
             add(Triple("Discard", COMPOSER_CANCEL_RECORDING_TAG, LABELLED_PILL_MIN_DP))
-            if (!locked) add(Triple("Lock", COMPOSER_LOCK_RECORDING_TAG, LABELLED_PILL_MIN_DP))
             add(Triple("Insert", COMPOSER_TO_FIELD_TAG, LABELLED_PILL_MIN_DP))
             add(Triple("Send", COMPOSER_STOP_SEND_TAG, LABELLED_PILL_MIN_DP))
             // The editing tools group stays mounted during recording (the "fit
@@ -256,6 +263,20 @@ class PromptComposerRecordingRowFitProofTest {
             )
             // Additive brief-named guard: never off the WHOLE screen either.
             compose.assertNodeFullyWithinRoot(tag)
+        }
+
+        // Issue #1245: the inline hands-free lock toggle now rides the recording/
+        // waveform row (when not locked). Guard that it, too, stays fully within
+        // the band (never spills off the right edge into the waveform's neighbour
+        // area) at both font scales.
+        if (!locked) {
+            val lock = bounds(COMPOSER_LOCK_RECORDING_TAG)
+            assertTrue(
+                "Inline lock toggle spills off the band. lock=[${lock.left}..${lock.right}] " +
+                    "band=[${band.left}..${band.right}] font=$fontScale",
+                lock.right <= band.right + slopPx && lock.left >= band.left - slopPx,
+            )
+            compose.assertNodeFullyWithinRoot(COMPOSER_LOCK_RECORDING_TAG)
         }
     }
 

--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerSheet.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerSheet.kt
@@ -982,6 +982,9 @@ internal fun SheetContent(
                         // newest words always stay visible.
                         liveTranscript = state.liveTranscript,
                         locked = state.recordingLocked,
+                        // Issue #1245: the inline lock toggle on the waveform row
+                        // taps the SAME lock action the bottom-cluster button used to.
+                        onLockRecording = onLockRecording,
                     )
                 }
 
@@ -1314,15 +1317,18 @@ internal fun SheetContent(
                 }
 
                 PromptComposerViewModel.RecordingState.Recording -> {
-                    // Issue #1152: the four recording pills stack as two right-
-                    // aligned rows so they all fit next to the mounted tools group.
-                    //  - [Discard · Lock]: Discard (drop this audio — pulled OUT of
-                    //    the waveform surface into a proper outlined secondary pill
-                    //    so it no longer collides with the bars / reads disabled,
-                    //    audit B/D2/D3) and, until locked, Lock (#585 hands-free).
+                    // Issue #1152 / #1245: the recording stop actions stack as two
+                    // right-aligned rows so they all fit next to the mounted tools
+                    // group without clipping `Send` (the #1152 fit).
+                    //  - [Discard]: drop this audio — an outlined secondary pill,
+                    //    pulled OUT of the waveform surface (audit B/D2/D3).
                     //  - [Insert · Send]: the two "how do you want to end this
                     //    dictation" stop actions. Every pill shares one 48dp
                     //    baseline (audit D4).
+                    // Issue #1245: the hands-free Lock is NO LONGER a pill here — it
+                    // moved UP to the recording/waveform row as an inline toggle
+                    // attached to the recording it controls (hard-cut D22: one
+                    // affordance, not two). Discard stays put (it's clear).
                     Column(
                         horizontalAlignment = Alignment.End,
                         verticalArrangement = Arrangement.spacedBy(8.dp),
@@ -1335,12 +1341,6 @@ internal fun SheetContent(
                                 onClick = onCancelRecording,
                                 modifier = Modifier.testTag(COMPOSER_CANCEL_RECORDING_TAG),
                             )
-                            if (!state.recordingLocked) {
-                                LockRecordingButton(
-                                    onClick = onLockRecording,
-                                    modifier = Modifier.testTag(COMPOSER_LOCK_RECORDING_TAG),
-                                )
-                            }
                         }
                         Row(
                             verticalAlignment = Alignment.CenterVertically,
@@ -1548,6 +1548,13 @@ private fun RecordingSurface(
     elapsedLabel: String,
     liveTranscript: String?,
     locked: Boolean,
+    // Issue #1245: the hands-free lock affordance now lives INLINE on this
+    // recording/waveform row — a compact toggle attached to the active recording
+    // it controls ("lock THIS recording"), not a mystery-meat labelled button
+    // floating in the bottom Send/Discard cluster. Tapping it is the tap-path
+    // equivalent of the swipe-up-to-lock gesture (kept working via #585). Defaults
+    // to a no-op so previews / legacy tests that don't wire it keep compiling.
+    onLockRecording: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -1586,6 +1593,13 @@ private fun RecordingSurface(
                 fontWeight = FontWeight.SemiBold,
                 modifier = Modifier.testTag(COMPOSER_TIMER_TAG),
             )
+            // Issue #1245: the hands-free lock affordance lives inline here, between
+            // the timer and the waveform it controls. Until locked it is a compact
+            // TAPPABLE toggle (accent-bordered circle) whose tap locks the recording
+            // hands-free — the tap-path equivalent of the swipe-up gesture, moved up
+            // out of the mystery-meat bottom cluster (#1245). Once locked it becomes
+            // a static closed-lock indicator (no border, no tap) so the row reads
+            // clean. The two states keep the SAME tags the #585 journey drives.
             if (locked) {
                 Icon(
                     imageVector = Icons.Outlined.Lock,
@@ -1596,10 +1610,34 @@ private fun RecordingSurface(
                         .testTag(COMPOSER_RECORDING_LOCKED_TAG)
                         .semantics { contentDescription = "Recording locked" },
                 )
+            } else {
+                Box(
+                    modifier = Modifier
+                        .size(34.dp)
+                        .clip(RoundedCornerShape(17.dp))
+                        .border(
+                            width = 1.dp,
+                            color = PocketShellColors.Accent,
+                            shape = RoundedCornerShape(17.dp),
+                        )
+                        .clickable(role = Role.Button, onClick = onLockRecording)
+                        .testTag(COMPOSER_LOCK_RECORDING_TAG)
+                        .semantics {
+                            contentDescription = "Lock recording to continue hands-free"
+                        },
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.Lock,
+                        contentDescription = null,
+                        tint = PocketShellColors.Accent,
+                        modifier = Modifier.size(18.dp),
+                    )
+                }
             }
             // Issue #1152: Discard moved OUT of this surface into the bottom action
-            // row (an outlined secondary pill), so the surface is now just
-            // [timer · (lock?) · waveform]. A small end inset keeps the amplitude
+            // row (an outlined secondary pill), so the surface is now
+            // [timer · lock-toggle · waveform]. A small end inset keeps the amplitude
             // bars from kissing the surface edge (audit C/D2).
             Waveform(
                 amplitude = amplitude,
@@ -1618,16 +1656,17 @@ private fun RecordingSurface(
                     },
             )
         }
-        // Issue #585: until the recording is locked, surface a one-line hint so
-        // the user knows the hands-free path exists and how to reach it — "tap
-        // Lock" is the deterministic affordance, "swipe up" the gesture. The
-        // hint disappears the moment the lock indicator appears, so a locked
-        // recording reads clean. The missing feedback was itself a reason the
-        // gesture felt broken ("I don't think it's recording / locking").
+        // Issue #585 / #1245: until the recording is locked, surface a one-line
+        // hint so the user knows the hands-free path exists and how to reach it —
+        // "tap the lock" (the inline toggle on this row, #1245) is the
+        // deterministic affordance, "swipe up" the gesture. The hint disappears
+        // the moment the lock indicator appears, so a locked recording reads
+        // clean. The missing feedback was itself a reason the gesture felt broken
+        // ("I don't think it's recording / locking").
         if (!locked && liveTranscript.isNullOrBlank()) {
             Spacer(modifier = Modifier.height(4.dp))
             Text(
-                text = "Tap Lock or swipe up to keep recording hands-free",
+                text = "Tap the lock or swipe up to keep recording hands-free",
                 color = PocketShellColors.TextMuted,
                 fontSize = 11.sp,
                 modifier = Modifier.testTag(COMPOSER_LOCK_HINT_TAG),
@@ -1889,58 +1928,6 @@ private fun ComposerEditingToolsGroup(
             onClick = onSlashTap,
             enabled = !isTranscribing && !attachmentBusy && agentKind != null,
             modifier = Modifier.testTag(COMPOSER_SLASH_TAG),
-        )
-    }
-}
-
-/**
- * Issue #585: the deterministic hands-free LOCK affordance shown while
- * Recording but not yet locked. A single tap calls [onLockRecording] so the
- * user can release the finger and keep dictating — exactly the maintainer's
- * Telegram-style "swipe up to lock" intent, but via a tap that the
- * ModalBottomSheet drag-to-dismiss can NEVER steal (the velocity-driven
- * arbitration that broke the swipe gesture on real hardware across this
- * issue's reopens). Rendered as a compact accent-bordered pill with the lock
- * glyph so it reads as "lock this recording on". A 48dp min touch target keeps
- * it comfortably tappable next to the Insert/Send pills.
- */
-@Composable
-private fun LockRecordingButton(
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    Row(
-        modifier = modifier
-            // Issue #1152: shared 48dp recording pill baseline so Lock lines up
-            // with Discard / Insert / Send (audit D4).
-            .height(ComposerActionPillHeight)
-            .clip(ComposerActionPillShape)
-            .background(
-                color = PocketShellColors.SurfaceElev,
-                shape = ComposerActionPillShape,
-            )
-            .border(
-                width = 1.dp,
-                color = PocketShellColors.Accent,
-                shape = ComposerActionPillShape,
-            )
-            .clickable(role = Role.Button, onClick = onClick)
-            .semantics { contentDescription = "Lock recording to continue hands-free" }
-            .padding(horizontal = 12.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(6.dp),
-    ) {
-        Icon(
-            imageVector = Icons.Outlined.Lock,
-            contentDescription = null,
-            tint = PocketShellColors.Accent,
-            modifier = Modifier.size(16.dp),
-        )
-        Text(
-            text = "Lock",
-            color = PocketShellColors.Accent,
-            fontSize = 13.sp,
-            fontWeight = FontWeight.SemiBold,
         )
     }
 }

--- a/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenders.kt
+++ b/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenders.kt
@@ -2058,11 +2058,14 @@ class DesignRenders {
      * Issue #1152: static mirror of the redesigned VOICE-RECORDING (not-locked)
      * composer bottom area. The old single row overflowed and clipped `Send` off
      * the right edge (audit D1); the maintainer directive is FIT EVERYTHING — keep
-     * the editing tools mounted, hide nothing. This mirrors the fix:
-     *  - recording surface: [00:14 timer · waveform] (Discard pulled out of it);
+     * the editing tools mounted, hide nothing. This mirrors the fix (with the #1245
+     * inline-lock move):
+     *  - recording surface: [00:14 timer · 🔒 inline lock toggle · waveform]
+     *    (Discard pulled out of it; #1245 moved the hands-free lock UP into it);
      *  - bottom row: the mounted [📎 {} /] tools group anchors the left, then a
-     *    weighted gap, then the four pills stacked as two right-aligned rows —
-     *    [Discard (outlined) · Lock (accent-outlined)] over [Insert · Send].
+     *    weighted gap, then the stop pills stacked as two right-aligned rows —
+     *    [Discard (outlined)] over [Insert · Send]. The old mystery-meat Lock pill
+     *    is gone from this cluster (#1245).
      *
      * Caveat (#555): the real recording row lives in the `app` module's
      * `SheetContent`, which the ui-kit harness can't import, so this mirrors its
@@ -2095,6 +2098,19 @@ class DesignRenders {
                     fontSize = 15.sp,
                     fontWeight = FontWeight.SemiBold,
                 )
+                // Issue #1245: the hands-free lock is now an INLINE toggle on the
+                // recording/waveform row (attached to the recording it controls),
+                // an accent-bordered circle with the lock glyph — no longer a
+                // mystery-meat pill in the bottom Send/Discard cluster.
+                Box(
+                    modifier = Modifier
+                        .size(34.dp)
+                        .clip(RoundedCornerShape(17.dp))
+                        .border(1.dp, PocketShellColors.Accent, RoundedCornerShape(17.dp)),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(text = "🔒", fontSize = 15.sp)
+                }
                 Box(
                     modifier = Modifier
                         .weight(1f)
@@ -2149,7 +2165,9 @@ class DesignRenders {
                     verticalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
                     Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                        // Discard — outlined secondary pill (48dp).
+                        // Discard — outlined secondary pill (48dp). Issue #1245: the
+                        // Lock pill was removed from this cluster (it moved up to the
+                        // waveform row as an inline toggle); Discard stays put.
                         Box(
                             modifier = Modifier
                                 .height(48.dp)
@@ -2162,25 +2180,6 @@ class DesignRenders {
                             Text(
                                 text = "Discard",
                                 color = PocketShellColors.TextSecondary,
-                                fontSize = 13.sp,
-                                fontWeight = FontWeight.SemiBold,
-                            )
-                        }
-                        // Lock — accent-outlined pill (48dp).
-                        Row(
-                            modifier = Modifier
-                                .height(48.dp)
-                                .clip(RoundedCornerShape(22.dp))
-                                .background(PocketShellColors.SurfaceElev, RoundedCornerShape(22.dp))
-                                .border(1.dp, PocketShellColors.Accent, RoundedCornerShape(22.dp))
-                                .padding(horizontal = 12.dp),
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.spacedBy(6.dp),
-                        ) {
-                            Text(text = "🔒", fontSize = 13.sp)
-                            Text(
-                                text = "Lock",
-                                color = PocketShellColors.Accent,
                                 fontSize = 13.sp,
                                 fontWeight = FontWeight.SemiBold,
                             )


### PR DESCRIPTION
Closes #1245

## What (maintainer on-device feedback, v0.4.23)
The standalone '🔒 Lock' button beside Discard/Insert/Send was mystery-meat. Moved the hands-free record-lock UP onto the recording/waveform row as a compact inline toggle (reads as 'lock THIS recording'); deleted the standalone `LockRecordingButton` (hard-cut D22). Discard stays; swipe-to-lock + tap-to-lock preserved.

## Verification (reviewer-run on emulator)
- G1 red→green geometry: neutralizing the change puts the lock back in the bottom cluster (`Rect(...,1941,...)`, below the waveform) → fails; fix overlaps the waveform row → passes.
- On-device screenshot: inline 🔒 on the waveform row, no bottom-cluster Lock, **Send fully visible/not clipped** (#1152).
- 8/8 connected composer tests green (swipe-lock, tap-lock, placement, fit at font 1.0/1.3 locked+unlocked); render matches the feedback image; `LockRecordingButton` fully deleted, no dead refs.

Reviewer APPROVED: https://github.com/alexeygrigorev/pocketshell/issues/1245#issuecomment-4879833963