### PR TITLE
core-ssh: lease liveness ignores stale isConnected during async close (#1222)

### DIFF
--- a/shared/core-ssh/src/integrationTest/java/com/pocketshell/core/ssh/SshIntegrationTest.kt
+++ b/shared/core-ssh/src/integrationTest/java/com/pocketshell/core/ssh/SshIntegrationTest.kt
@@ -322,6 +322,128 @@ class SshIntegrationTest {
         )
     }
 
+    // --- #1222: close-initiated is the authoritative "going away" signal the ---
+    // lease pool routes its liveness through (real SSH transport) --------------
+
+    @Test
+    fun closeInitiatedIsSynchronousAndAuthoritativeOnRealSession() = runBlocking(Dispatchers.IO) {
+        // The whole #1222 fix hinges on RealSshSession.isCloseInitiated being
+        // (a) false while the session is alive and (b) true the INSTANT close()
+        // is reached — synchronously, for the entire ~2 s async-drain window
+        // during which isConnected still lies true (#1144). If that real
+        // contract were wrong the lease-pool routing would be inert, so this is
+        // the load-bearing real-path proof, not a proxy.
+        val session = SshConnection.connect(
+            host = container!!.host,
+            port = sshPort,
+            user = "testuser",
+            key = SshKey.Path(privateKeyFile),
+            passphrase = null,
+            knownHosts = KnownHostsPolicy.AcceptAll,
+        ).getOrThrow()
+
+        assertTrue("a live session must be connected", session.isConnected)
+        assertFalse(
+            "a live session must NOT report close-initiated",
+            session.isCloseInitiated,
+        )
+
+        // close() launches the async teardown off-caller and returns immediately,
+        // but flips the close-initiated guard SYNCHRONOUSLY first.
+        session.close()
+        assertTrue(
+            "close() must flip isCloseInitiated synchronously, before the async " +
+                "SSH_MSG_DISCONNECT drains (the window where isConnected still lies true)",
+            session.isCloseInitiated,
+        )
+
+        // After the teardown drains, isConnected finally flips false too; the
+        // close-initiated signal is sticky.
+        session.awaitClosed()
+        assertFalse("the drained transport must report disconnected", session.isConnected)
+        assertTrue("close-initiated is sticky after the drain", session.isCloseInitiated)
+    }
+
+    @Test
+    fun leaseReleaseAfterCloseInitiatedReDialsFreshInsteadOfReusingTheCorpse() =
+        runBlocking(Dispatchers.IO) {
+            // End-to-end on the REAL transport + REAL lease pool: a session whose
+            // close() has been initiated (the keepalive-dead teardown calls close()
+            // out-of-band) must NOT be kept warm or reused. The pool's read-only
+            // probe must exclude it and a re-acquire must dial a FRESH handshake.
+            val connector = CountingLeaseConnector()
+            val manager = SshLeaseManager(
+                connector = connector,
+                idleTtlMillis = 60_000L,
+            )
+            val target = SshLeaseTarget(
+                leaseKey = SshLeaseKey(
+                    host = container!!.host,
+                    port = sshPort,
+                    user = "testuser",
+                    credentialId = privateKeyFile.absolutePath,
+                ),
+                key = SshKey.Path(privateKeyFile),
+                knownHosts = KnownHostsPolicy.AcceptAll,
+            )
+
+            try {
+                val lease = manager.acquire(target).getOrThrow()
+                val poisoned = lease.session
+                assertTrue("first acquire is a live connection", poisoned.isConnected)
+                assertEquals("exactly one handshake so far", 1, connector.connectCount)
+
+                // The keepalive-dead teardown calls close() on the session directly
+                // (out-of-band). close is now INITIATED.
+                poisoned.close()
+                assertTrue("close is initiated on the pooled session", poisoned.isCloseInitiated)
+
+                // The pool must no longer treat it as a live lease — even though the
+                // async disconnect may still be draining (isConnected transiently
+                // true). Routed through isCloseInitiated, this is deterministic.
+                assertFalse(
+                    "a close-initiated transport must NOT be reported as a live lease",
+                    manager.hasLiveLease(target.leaseKey),
+                )
+                assertFalse(
+                    "a close-initiated transport must NOT be reported as live-or-connecting",
+                    manager.hasLiveOrConnectingLease(target.leaseKey),
+                )
+
+                // The reconnect releases the poisoned lease inside the close window;
+                // a follow-up acquire (folder probe / reconnect ensureLease) must get
+                // a FRESH transport, not the corpse.
+                lease.release()
+                val refreshed = manager.acquire(target).getOrThrow()
+                assertTrue("the re-acquire dialled a brand-new connection", refreshed.isNewConnection)
+                assertTrue("the fresh transport is connected", refreshed.session.isConnected)
+                assertFalse("the fresh transport is NOT close-initiated", refreshed.session.isCloseInitiated)
+                assertEquals("a second, fresh handshake was performed", 2, connector.connectCount)
+
+                refreshed.release()
+            } finally {
+                manager.close()
+            }
+        }
+
+    /**
+     * Issue #1222: a real [SshLeaseConnector] that dials the container via
+     * [DefaultSshLeaseConnector] and counts how many handshakes the pool actually
+     * performed, so the end-to-end test can prove a close-initiated corpse is
+     * re-dialled fresh rather than reused.
+     */
+    private class CountingLeaseConnector : SshLeaseConnector {
+        private val delegate = DefaultSshLeaseConnector()
+        @Volatile
+        var connectCount: Int = 0
+            private set
+
+        override suspend fun connect(target: SshLeaseTarget): Result<SshSession> {
+            connectCount += 1
+            return delegate.connect(target)
+        }
+    }
+
     @Test
     fun listDirectoryReturnsEntriesFoldersFirst() = runTest {
         // Issue #528: SFTP file explorer listing. Build a known tree under the

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshSession.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshSession.kt
@@ -368,6 +368,19 @@ internal class RealSshSession(
         get() = !dispatcher.isClosed && client.isConnected && client.isAuthenticated
 
     /**
+     * Issue #1222 — the authoritative "close has begun" signal the lease pool
+     * routes its liveness through. Reads the SAME one-shot [closeStarted] guard
+     * [close] flips synchronously (via `compareAndSet(false, true)`) BEFORE it
+     * launches the async `SSH_MSG_DISCONNECT` teardown, so it is `true` the
+     * instant close is initiated — the entire ~2 s async-drain window during
+     * which [isConnected] still lies `true`. This is what lets
+     * [SshLeaseManager] evict a keepalive-dead / mid-drain transport instead of
+     * trusting the transiently-stale [isConnected] and parking the corpse warm.
+     */
+    override val isCloseInitiated: Boolean
+        get() = closeStarted.get()
+
+    /**
      * Issue #964 — the transport-liveness oracle the app-level `LivenessProbe`
      * defers to. True while the keepalive ([TransportKeepAlive]) has seen INBOUND
      * activity (its reply bumps [lastInboundActivityNanos]) within its

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshLeaseManager.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshLeaseManager.kt
@@ -115,6 +115,24 @@ public class SshLeaseManager(
         require(connectTimeoutMillis > 0) { "connectTimeoutMillis must be > 0" }
     }
 
+    /**
+     * Issue #1222 — the SINGLE liveness predicate the whole pool trusts. A
+     * session counts as live for pooling ONLY while it is BOTH transport-connected
+     * AND has not had its async [SshSession.close] initiated.
+     *
+     * The #1144 async `close()` leaves [SshSession.isConnected] == `true` for up to
+     * ~2 s while the `SSH_MSG_DISCONNECT` drains. Trusting [isConnected] alone kept
+     * a keepalive-dead / mid-drain transport as a warm-idle lease for up to 60 s,
+     * lost the `keepalive_dead` attribution (it surfaced `Idle`, not
+     * `Closed(KeepaliveDead)`), and handed the dying transport to a concurrent
+     * same-host acquire (→ `TransportClosedException` → spurious failed attach).
+     * [SshSession.isCloseInitiated] is the authoritative "going away" signal, so
+     * routing reuse / [hasLiveLease] / [hasLiveOrConnectingLease] / [release]
+     * through THIS one predicate closes the whole class in a single place (no dual
+     * path, hard-cut D22).
+     */
+    private fun SshSession.isLiveForLease(): Boolean = isConnected && !isCloseInitiated
+
     public suspend fun acquire(target: SshLeaseTarget): Result<SshLease> {
         val key = target.leaseKey
 
@@ -123,7 +141,7 @@ public class SshLeaseManager(
         // owner of a fresh connect.
         val decision = mutex.withLock {
             if (closed) return Result.failure(SshLeaseManagerClosedException())
-            val existing = entries[key]?.takeIf { it.session.isConnected }
+            val existing = entries[key]?.takeIf { it.session.isLiveForLease() }
             if (existing != null) {
                 existing.closeJob?.cancel()
                 existing.closeJob = null
@@ -186,7 +204,7 @@ public class SshLeaseManager(
         val reused = mutex.withLock {
             if (closed) return Result.failure(SshLeaseManagerClosedException())
             val entry = shared
-                .takeIf { entries[key] === it && it.session.isConnected }
+                .takeIf { entries[key] === it && it.session.isLiveForLease() }
                 ?: return@withLock null
             entry.closeJob?.cancel()
             entry.closeJob = null
@@ -245,7 +263,7 @@ public class SshLeaseManager(
                         return@withLock Result.failure(SshLeaseManagerClosedException())
                     }
                     val raced = entries[key]
-                    if (raced != null && raced.session.isConnected) {
+                    if (raced != null && raced.session.isLiveForLease()) {
                         // A live entry appeared for this key while we were dialing
                         // (e.g. a different code path acquired directly). Drop our
                         // redundant transport and reuse the live one; awaiters reuse
@@ -399,7 +417,7 @@ public class SshLeaseManager(
         key: SshLeaseKey,
         closeReason: SshLeaseCloseReason = SshLeaseCloseReason.Disconnected,
     ) {
-        if (entries[key]?.session?.isConnected == true) return
+        if (entries[key]?.session?.isLiveForLease() == true) return
         if (inFlightConnects.containsKey(key)) return
         if (lastPublishedState[key] != SshLeaseConnectionState.Connecting) return
         emitStateLocked(
@@ -429,7 +447,7 @@ public class SshLeaseManager(
     public suspend fun hasLiveLease(key: SshLeaseKey): Boolean =
         mutex.withLock {
             if (closed) return@withLock false
-            entries[key]?.session?.isConnected == true
+            entries[key]?.session?.isLiveForLease() == true
         }
 
     /**
@@ -450,7 +468,7 @@ public class SshLeaseManager(
     public suspend fun hasLiveOrConnectingLease(key: SshLeaseKey): Boolean =
         mutex.withLock {
             if (closed) return@withLock false
-            if (entries[key]?.session?.isConnected == true) return@withLock true
+            if (entries[key]?.session?.isLiveForLease() == true) return@withLock true
             inFlightConnects.containsKey(key)
         }
 
@@ -584,7 +602,13 @@ public class SshLeaseManager(
                 if (entry.refCount <= 0) return@withContext null
                 entry.refCount -= 1
                 if (entry.refCount > 0) return@withContext null
-                if (!entry.session.isConnected || !processStarted || idleTtlMillis == 0L || maxIdleLeases == 0) {
+                // Issue #1222: a session whose async close() has been INITIATED is
+                // NOT live (isLiveForLease()==false even while isConnected still
+                // transiently lies true during the ~2 s disconnect drain), so it
+                // takes the removal branch instead of being parked warm/idle. This
+                // is what stops a keepalive-dead / mid-drain transport from being
+                // retained for up to 60 s and handed to a concurrent acquirer.
+                if (!entry.session.isLiveForLease() || !processStarted || idleTtlMillis == 0L || maxIdleLeases == 0) {
                     entries.remove(key)
                     emitStateLocked(
                         key = key,
@@ -596,9 +620,18 @@ public class SshLeaseManager(
                             // resolving the #964 attribution ambiguity. Read the
                             // session's own cause so the lease layer never
                             // reaches up into the app (no layering violation).
+                            // Issue #1222: checked FIRST so a keepalive-dead
+                            // session released INSIDE the async-close window (when
+                            // isConnected still lies true) is still stamped
+                            // `keepalive_dead` on the transport EDGE, not lost as
+                            // an anonymous `Idle`.
                             entry.session.closeCause == SshSessionCloseCause.KeepaliveDead ->
                                 SshLeaseCloseReason.KeepaliveDead
-                            !entry.session.isConnected -> SshLeaseCloseReason.Disconnected
+                            // Issue #1222: a close-initiated OR already-disconnected
+                            // transport is an anonymous `Disconnected` (a plain
+                            // teardown reached mid-drain), distinct from an idle-TTL
+                            // expiry — the transport is gone, not merely unused.
+                            !entry.session.isLiveForLease() -> SshLeaseCloseReason.Disconnected
                             !processStarted -> SshLeaseCloseReason.ProcessStopped
                             else -> SshLeaseCloseReason.IdleExpired
                         },

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshSession.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshSession.kt
@@ -23,6 +23,30 @@ public interface SshSession : AutoCloseable {
     public val isConnected: Boolean
 
     /**
+     * Issue #1222 — the authoritative "this session is going away" signal.
+     *
+     * True the instant [close] has been INITIATED, and stays true forever after.
+     * Distinct from ![isConnected]: the #1144 async [close] launches the bounded
+     * `SSH_MSG_DISCONNECT` teardown off the caller and returns immediately, so
+     * [isConnected] keeps reporting `true` for up to ~2 s (longer on a wedged
+     * socket) while the disconnect drains. During that window the transport is
+     * already doomed — no new channel should be opened on it, and it must NOT be
+     * kept as a warm/idle lease or handed to a concurrent acquirer.
+     *
+     * The [SshLeaseManager] treats a session as live for pooling ONLY while it is
+     * BOTH [isConnected] AND NOT close-initiated, so a keepalive-dead teardown (or
+     * any close reached mid-drain) evicts the lease and emits the real close cause
+     * instead of parking the corpse warm for 60 s (the #1222 bug). Backed by
+     * [RealSshSession]'s existing one-shot `closeStarted` guard.
+     *
+     * Has a default body returning `false` so the many bespoke per-test
+     * [SshSession] fakes need not override it; only [RealSshSession] answers off
+     * its real close-initiated flag.
+     */
+    public val isCloseInitiated: Boolean
+        get() = false
+
+    /**
      * Why this session's transport went down (issue #969 — reconnect
      * observability). [SshSessionCloseCause.KeepaliveDead] when the always-on
      * transport keepalive (#945) declared the peer dead and closed the

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/SshLeaseManagerTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/SshLeaseManagerTest.kt
@@ -965,6 +965,148 @@ class SshLeaseManagerTest {
         )
     }
 
+    // --- #1222: lease liveness must NOT trust the transiently-stale isConnected --
+    // during the #1144 async close() window ------------------------------------
+    //
+    // The #1144 async close() flips RealSshSession.closeStarted SYNCHRONOUSLY but
+    // launches the SSH_MSG_DISCONNECT teardown off-caller, so isConnected keeps
+    // reporting true for up to ~2 s while the disconnect drains. The
+    // keepalive-dead scenario: flaky Wi-Fi -> half-open transport -> keepalive
+    // watchdog fires onKeepAliveDead -> async close() -> -CC EOF -> reconnect
+    // releases the poisoned lease INSIDE the close window. These three tests pin
+    // each documented failure, modelling the window with FakeSshSession's
+    // asyncCloseWindow flag (isConnected stays true while isCloseInitiated is
+    // true) — the state a healthy local transport cannot deterministically hold
+    // open (D33 synthetic-injection model).
+
+    @Test
+    fun `AC1 - release during the async-close window removes the entry instead of parking it warm`() = runTest {
+        val session = FakeSshSession()
+        val manager = leaseManager(QueueLeaseConnector(session), idleTtlMillis = 60_000)
+        val events = mutableListOf<SshLeaseStateEvent>()
+        val collectJob = backgroundScope.launch { manager.stateEvents.toList(events) }
+        runCurrent()
+
+        val lease = manager.acquire(TARGET).getOrThrow()
+        runCurrent()
+
+        // The keepalive watchdog declared the peer dead and called close() on the
+        // session out-of-band: close is INITIATED but the transport still lies
+        // isConnected==true for the whole async-drain window.
+        session.asyncCloseWindow = true
+        session.close()
+        assertTrue("precondition: the modelled window keeps isConnected true", session.isConnected)
+        assertTrue("precondition: close is initiated", session.isCloseInitiated)
+
+        // The reconnect path releases the poisoned lease inside that window.
+        lease.release()
+        runCurrent()
+        collectJob.cancel()
+
+        // FIX: a close-initiated session is NEVER kept warm/idle — it is removed
+        // and a Closed edge is emitted. RED on base: release() trusts isConnected,
+        // keeps it warm, and emits Idle (the corpse sits for up to 60 s).
+        assertTrue(
+            "a close-initiated transport must be removed with a Closed edge, not parked warm",
+            events.any {
+                it.key == TARGET.leaseKey && it.state == SshLeaseConnectionState.Closed
+            },
+        )
+        assertFalse(
+            "a close-initiated transport must NOT be announced Idle (kept warm)",
+            events.any {
+                it.key == TARGET.leaseKey && it.state == SshLeaseConnectionState.Idle
+            },
+        )
+        assertFalse(
+            "the pool must not retain a close-initiated session as a live lease",
+            manager.hasLiveLease(TARGET.leaseKey),
+        )
+    }
+
+    @Test
+    fun `AC2 - keepalive-dead attribution reaches the edge even when released inside the close window`() = runTest {
+        val session = FakeSshSession()
+        val manager = leaseManager(QueueLeaseConnector(session), idleTtlMillis = 60_000)
+        val events = mutableListOf<SshLeaseStateEvent>()
+        val collectJob = backgroundScope.launch { manager.stateEvents.toList(events) }
+        runCurrent()
+
+        val lease = manager.acquire(TARGET).getOrThrow()
+        runCurrent()
+
+        // The keepalive watchdog (#945) NAMES the cause BEFORE close(), then the
+        // async close() begins — but isConnected still lies true (the window).
+        session.sessionCloseCause = SshSessionCloseCause.KeepaliveDead
+        session.asyncCloseWindow = true
+        session.close()
+        assertTrue("precondition: still isConnected during the async drain", session.isConnected)
+
+        lease.release()
+        runCurrent()
+        collectJob.cancel()
+
+        // FIX: the transport EDGE carries keepalive_dead. RED on base: isConnected
+        // is still true so release() parks the corpse warm (Idle) and the
+        // keepalive_dead attribution never reaches the reconnect trail (#964).
+        assertTrue(
+            "keepalive_dead must reach the Closed edge even inside the async-close window",
+            events.any {
+                it.key == TARGET.leaseKey &&
+                    it.state == SshLeaseConnectionState.Closed &&
+                    it.closeReason == SshLeaseCloseReason.KeepaliveDead
+            },
+        )
+        assertFalse(
+            "a keepalive-dead close-window release must NOT surface as an anonymous Idle",
+            events.any {
+                it.key == TARGET.leaseKey && it.state == SshLeaseConnectionState.Idle
+            },
+        )
+    }
+
+    @Test
+    fun `AC3 - a concurrent same-host acquire during the close window dials FRESH, not the corpse`() = runTest {
+        val poisoned = FakeSshSession()
+        val fresh = FakeSshSession()
+        val connector = QueueLeaseConnector(poisoned, fresh)
+        val manager = leaseManager(connector, idleTtlMillis = 60_000)
+
+        val lease1 = manager.acquire(TARGET).getOrThrow()
+        assertSame("first acquire dials the poisoned transport", poisoned, lease1.session)
+        assertEquals("one handshake so far", 1, connector.connectCount)
+
+        // The keepalive-dead async close begins; isConnected still lies true.
+        poisoned.asyncCloseWindow = true
+        poisoned.close()
+        assertTrue("precondition: poisoned transport still lies isConnected", poisoned.isConnected)
+
+        // The read-only pool probes must exclude a close-initiated session so the
+        // attach flow shows a genuine cold Connecting overlay, not a warm attach.
+        assertFalse(
+            "hasLiveLease must exclude a close-initiated transport",
+            manager.hasLiveLease(TARGET.leaseKey),
+        )
+        assertFalse(
+            "hasLiveOrConnectingLease must exclude a close-initiated transport",
+            manager.hasLiveOrConnectingLease(TARGET.leaseKey),
+        )
+
+        // A concurrent same-host acquire (folder probe / agent-kind exec / the
+        // reconnect's own ensureLease) during the window.
+        val concurrent = manager.acquire(TARGET).getOrThrow()
+
+        // FIX: it dials a FRESH transport. RED on base: the reuse path trusts
+        // isConnected, hands back the dying corpse, connectCount stays 1, and the
+        // caller gets a TransportClosedException -> spurious failed attach.
+        assertSame("the concurrent acquire must get a FRESH transport", fresh, concurrent.session)
+        assertNotSame("the concurrent acquire must NOT be handed the corpse", poisoned, concurrent.session)
+        assertTrue("the fresh transport is a new connection", concurrent.isNewConnection)
+        assertEquals("a second, fresh handshake was performed", 2, connector.connectCount)
+
+        concurrent.release()
+    }
+
     @Test
     fun `release from replaced disconnected lease does not mutate active replacement`() = runTest {
         val first = FakeSshSession()
@@ -1141,8 +1283,23 @@ class SshLeaseManagerTest {
         // lease manager's close-reason attribution can be exercised.
         var sessionCloseCause: SshSessionCloseCause = SshSessionCloseCause.Unknown
 
+        // Issue #1222: model the #1144 async close() window. The real
+        // RealSshSession.close() flips its `closeStarted` guard SYNCHRONOUSLY but
+        // launches the SSH_MSG_DISCONNECT teardown off-caller, so `isConnected`
+        // keeps lying `true` for up to ~2 s while the disconnect drains. When
+        // [asyncCloseWindow] is true, [close] models exactly that: it flips
+        // [closeInitiated] but leaves [connected] untouched so [isConnected] stays
+        // true — the precise state where trusting `isConnected` alone kept the
+        // corpse warm. Default false so every pre-existing test keeps its
+        // synchronous close() (which sets [closed] and drops [isConnected]).
+        var asyncCloseWindow: Boolean = false
+        var closeInitiated: Boolean = false
+
         override val isConnected: Boolean
             get() = connected && !closed
+
+        override val isCloseInitiated: Boolean
+            get() = closeInitiated
 
         override val closeCause: SshSessionCloseCause
             get() = sessionCloseCause
@@ -1178,7 +1335,12 @@ class SshLeaseManagerTest {
 
         override fun close() {
             closeCount += 1
-            closed = true
+            // Issue #1222: close is initiated the instant close() is reached,
+            // exactly like RealSshSession's synchronous `closeStarted` flip.
+            closeInitiated = true
+            // In the async-close window the transport keeps reporting connected
+            // until its (modelled) disconnect drains — see [asyncCloseWindow].
+            if (!asyncCloseWindow) closed = true
         }
     }
 


### PR DESCRIPTION
Closes #1222 — D28 connection core, #1149-class async-close contract change.

## What
#1144's async `close()` leaves `SshSession.isConnected == true` for up to ~2s during the disconnect drain; every lease-pool predicate trusted it, so a keepalive-dead transport was kept warm, emitted `Idle` (losing `keepalive_dead` attribution), and could be handed to a concurrent same-host acquirer → spurious failed attach. Fix: authoritative `isCloseInitiated` (off the synchronous `closeStarted` guard) + single `isLiveForLease() = isConnected && !isCloseInitiated` routed through reuse / coalesced-await / owned-connect race / `hasLiveLease` / `hasLiveOrConnectingLease` / `release()`.

## Verification (reviewer-driven, #1149 rule)
- G1 red→green: neutralizing `isLiveForLease()` fails AC1/AC2/AC3; restored → green.
- **`:shared:core-ssh:integrationTest` (Docker real SSH) green** (6m54s, full suite + 2 new real-path tests) — the mandatory contract-change gate.
- Adversarial: `closeStarted` flips synchronously as the FIRST statement of `RealSshSession.close()` (line 1751) — no late-flip window (proven on the real transport).
- G6: AC2 load-bearing on the emitted `Closed(KeepaliveDead)` edge. 227 unit tests green; no dual authority (consumer edge unchanged, D22 hard-cut).

Reviewer APPROVED: https://github.com/alexeygrigorev/pocketshell/issues/1222#issuecomment-4879883428