### PR TITLE
conversation: byte-bound Codex/OpenCode cold-open + keep truncation marker visible (#1267)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/conversation/ConversationTimelineSupport.kt
+++ b/app/src/main/java/com/pocketshell/app/conversation/ConversationTimelineSupport.kt
@@ -4,6 +4,41 @@ import com.pocketshell.core.agents.CodexParser
 import com.pocketshell.core.agents.ConversationEvent
 import com.pocketshell.core.agents.ConversationTextFormatting
 
+/**
+ * Issue #1225/#1267: the [ConversationEvent.SystemNote.tag] used for the
+ * over-cap transcript-line truncation marker. Unlike ordinary system notes,
+ * this marker is an ALWAYS-VISIBLE truncation affordance: it MUST survive the
+ * `showSystemNotes = false` filter, because a truncated giant line is a
+ * *dropped user message* the user needs to know about regardless of the
+ * system-notes preference (the exact silently-dropped-again failure #1225 set
+ * out to avoid). Kept in lockstep with the tag emitted by
+ * `AgentConversationRepository.parseTranscriptTailLines` /
+ * `parseOpenCodeRowsWithTruncation`.
+ */
+internal const val TRUNCATED_LINE_SYSTEM_NOTE_TAG: String = "truncated"
+
+/**
+ * Issue #176/#1267: the events the conversation timeline actually renders,
+ * given the `showSystemNotes` preference. Internal-protocol-noise rows are
+ * always dropped; when [showSystemNotes] is false, ordinary
+ * [ConversationEvent.SystemNote] rows are hidden too — EXCEPT the truncation
+ * marker ([TRUNCATED_LINE_SYSTEM_NOTE_TAG]), which stays visible so a
+ * byte-clamped giant line never becomes a silently dropped message.
+ *
+ * Pure + side-effect free so it is unit-tested directly (the composable just
+ * `remember`s the result).
+ */
+internal fun conversationTimelineVisibleEvents(
+    events: List<ConversationEvent>,
+    showSystemNotes: Boolean,
+): List<ConversationEvent> {
+    val timelineEvents = events.filterNot { it.isHiddenConversationTimelineRow() }
+    if (showSystemNotes) return timelineEvents
+    return timelineEvents.filterNot {
+        it is ConversationEvent.SystemNote && it.tag != TRUNCATED_LINE_SYSTEM_NOTE_TAG
+    }
+}
+
 internal fun ConversationEvent.isHiddenConversationTimelineRow(): Boolean = when (this) {
     is ConversationEvent.SystemNote ->
         // turn_duration was always hidden; #704 req #1 also hides rows whose

--- a/app/src/main/java/com/pocketshell/app/session/AgentConversationRepository.kt
+++ b/app/src/main/java/com/pocketshell/app/session/AgentConversationRepository.kt
@@ -1,6 +1,7 @@
 package com.pocketshell.app.session
 
 import android.util.Log
+import com.pocketshell.app.conversation.TRUNCATED_LINE_SYSTEM_NOTE_TAG
 import com.pocketshell.core.agents.AgentDetection
 import com.pocketshell.core.agents.AgentDetector
 import com.pocketshell.core.agents.AgentKind
@@ -406,7 +407,7 @@ internal fun parseTranscriptTailLines(
             out += ConversationEvent.SystemNote(
                 id = "ps-truncated-line-$truncationOrdinal",
                 agent = agent,
-                tag = "truncated",
+                tag = TRUNCATED_LINE_SYSTEM_NOTE_TAG,
                 content = truncationPlaceholderText(truncatedBytes),
             )
             truncationOrdinal++
@@ -1488,7 +1489,7 @@ public class AgentConversationRepository internal constructor(
     ): List<ConversationEvent> {
         if (detection.isOpenCodeSqlite()) {
             val output = exportOpenCodeSqliteRows(session, detection, maxMessages = maxLines)
-            return OpenCodeReader().parseSqliteJsonRows(output)
+            return parseOpenCodeRowsWithTruncation(output)
         }
         if (detection.agent == AgentKind.Codex) {
             return readCodexInitialEvents(session, detection, maxLines)
@@ -1540,7 +1541,7 @@ public class AgentConversationRepository internal constructor(
         val budget = maxMessages.coerceAtLeast(1)
         if (detection.isOpenCodeSqlite()) {
             val output = exportOpenCodeSqliteRows(session, detection, maxMessages = budget)
-            val events = OpenCodeReader().parseSqliteJsonRows(output)
+            val events = parseOpenCodeRowsWithTruncation(output)
             // The SQL LIMIT is on the `message` table; distinct message ids in
             // the window approximate "rows read". If we filled the limit there
             // are (very likely) older messages we did not pull.
@@ -1633,11 +1634,18 @@ public class AgentConversationRepository internal constructor(
         // same exec is what lets the cold-open path drop the standalone
         // `lineCount` round-trip without losing the tail-start position.
         val sentinel = "@@PS_CODEX_WINDOW@@"
+        // Issue #1267: byte-bound the Codex cold-open read the same way #1225
+        // bounded the Claude flat-JSONL tail. The Codex read goes through
+        // `pocketshell agent-log`, so the clamp lives there (`--max-line-bytes`):
+        // a multi-MB rollout line (inline base64 image / huge tool_result) is
+        // replaced server-side by a compact truncation marker, so its bytes never
+        // cross SSH into the phone's heap. The marker is rendered as a visible
+        // note by [parseTranscriptTailLines] below.
         val output = session.exec(
             "wc -l < ${shellQuote(detection.sourcePath)} 2>/dev/null || printf 0; " +
                 "printf '%s\\n' $sentinel; " +
                 "pocketshell agent-log --engine codex --session ${shellQuote(sessionId)} " +
-                "--json --tail $boundedMaxLines 2>/dev/null || true",
+                "--json --tail $boundedMaxLines --max-line-bytes $MAX_TRANSCRIPT_LINE_BYTES 2>/dev/null || true",
         ).stdout
         val splitLines = output.split("\n")
         val sentinelIndex = splitLines.indexOf(sentinel)
@@ -1652,8 +1660,11 @@ public class AgentConversationRepository internal constructor(
             output
         }
         val lines = parseAgentLogEnvelopeLines(envelopeOutput)
-        val parser = CodexParser()
-        val events = lines.asSequence().flatMap { parser.parseLine(it) }.toList()
+        // Issue #1267: route the envelope lines through the truncation-aware
+        // parser so an over-cap line (clamped to a marker by `--max-line-bytes`)
+        // becomes a VISIBLE SystemNote instead of a line the CodexParser silently
+        // fails to parse and drops.
+        val events = parseTranscriptTailLines(CodexParser(), AgentKind.Codex, lines.asSequence())
         return CodexWindow(events = events, rawLineCount = lines.size, sourceLineCount = sourceLineCount)
     }
 
@@ -1948,8 +1959,54 @@ public class AgentConversationRepository internal constructor(
             LEFT JOIN part p ON p.message_id = m.id
             ORDER BY m.time_created, m.id, p.time_created, p.id;
         """.trimIndent().replace("\n", " ")
-        return session.exec("sqlite3 -readonly ${shellQuote(dbPath)} ${shellQuote(query)} 2>/dev/null || true")
+        // Issue #1267: byte-bound the OpenCode read. `json_object(...)` emits one
+        // JSON object per row on its own line (newlines inside values are escaped
+        // as `\n`), so the SAME per-line `awk` byte clamp #1225 used for the
+        // Claude flat-JSONL tail is the format-appropriate bound here: a row whose
+        // `part_data`/`message_data` is a multi-MB tool result / inline image is
+        // replaced server-side by a compact truncation marker, so its bytes never
+        // cross SSH into the phone's heap. The cold-open reads render that marker
+        // as a visible note via [parseOpenCodeRowsWithTruncation].
+        return session.exec(
+            "sqlite3 -readonly ${shellQuote(dbPath)} ${shellQuote(query)} 2>/dev/null | " +
+                "${transcriptLineClampPipe()} 2>/dev/null || true",
+        )
             .stdout
+    }
+
+    /**
+     * Issue #1267: parse an OpenCode SQLite export whose rows may include a
+     * per-line truncation marker emitted by [transcriptLineClampPipe] (an
+     * over-cap row byte-clamped server-side). Each marker line becomes a VISIBLE
+     * [ConversationEvent.SystemNote] (never silently dropped — the oversized JSON
+     * is gone, so feeding the fragment to [OpenCodeReader] would just vanish the
+     * message), and the remaining rows are parsed normally. Ids are ordinal-stable
+     * within a read so re-reads reconcile the same placeholder. The fast path
+     * (no marker present) is byte-identical to the previous direct
+     * [OpenCodeReader.parseSqliteJsonRows] call.
+     */
+    private fun parseOpenCodeRowsWithTruncation(output: String): List<ConversationEvent> {
+        if (!output.contains(LINE_TRUNCATION_SENTINEL)) {
+            return OpenCodeReader().parseSqliteJsonRows(output)
+        }
+        val keptRows = ArrayList<String>()
+        val truncationNotes = ArrayList<ConversationEvent>()
+        var truncationOrdinal = 0
+        for (line in output.lineSequence()) {
+            val truncatedBytes = truncatedLineByteCountOrNull(line)
+            if (truncatedBytes != null) {
+                truncationNotes += ConversationEvent.SystemNote(
+                    id = "ps-truncated-line-$truncationOrdinal",
+                    agent = AgentKind.OpenCode,
+                    tag = TRUNCATED_LINE_SYSTEM_NOTE_TAG,
+                    content = truncationPlaceholderText(truncatedBytes),
+                )
+                truncationOrdinal++
+            } else {
+                keptRows += line
+            }
+        }
+        return OpenCodeReader().parseSqliteJsonRows(keptRows.joinToString("\n")) + truncationNotes
     }
 
     private suspend fun readCodexInitialEvents(
@@ -1963,13 +2020,16 @@ public class AgentConversationRepository internal constructor(
         val boundedMaxLines = (maxLines * JSONL_RAW_LINES_PER_EVENT)
             .coerceAtLeast(maxLines)
             .coerceAtLeast(1)
+        // Issue #1267: byte-bound the Codex cold-open read via the tool-side
+        // `--max-line-bytes` clamp (the Codex counterpart of #1225's Claude
+        // flat-JSONL clamp), then render any resulting truncation marker as a
+        // visible note through [parseTranscriptTailLines].
         val output = session.exec(
             "pocketshell agent-log --engine codex --session ${shellQuote(sessionId)} " +
-                "--json --tail $boundedMaxLines 2>/dev/null || true",
+                "--json --tail $boundedMaxLines --max-line-bytes $MAX_TRANSCRIPT_LINE_BYTES 2>/dev/null || true",
         ).stdout
         val lines = parseAgentLogEnvelopeLines(output)
-        val parser = CodexParser()
-        return lines.asSequence().flatMap { parser.parseLine(it) }.toList()
+        return parseTranscriptTailLines(CodexParser(), AgentKind.Codex, lines.asSequence())
     }
 
     /**

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
@@ -114,6 +114,7 @@ import com.pocketshell.app.conversation.ConversationMessageTurn
 import com.pocketshell.app.conversation.ConversationTextSection
 import com.pocketshell.app.conversation.ConversationToolArgsSection
 import com.pocketshell.app.conversation.ConversationToolCardExpansion
+import com.pocketshell.app.conversation.conversationTimelineVisibleEvents
 import com.pocketshell.app.conversation.filterConversationRows
 import com.pocketshell.app.conversation.isHiddenConversationTimelineRow
 import com.pocketshell.app.conversation.runningToolCallIds
@@ -5643,9 +5644,11 @@ internal fun TmuxConversationPane(
     // [filterConversationRows] call STAYS (it also does tool-result pairing +
     // the searched-tool-call expansion merge) but is fed an empty query, so it
     // never filters out rows — every event is shown.
+    // Issue #176/#1267: honour the system-notes preference, but the byte-clamp
+    // truncation marker (#1225) stays visible even when notes are off — see
+    // [conversationTimelineVisibleEvents].
     val visibleEvents = remember(events, showSystemNotes) {
-        val timelineEvents = events.filterNot { it.isHiddenConversationTimelineRow() }
-        if (showSystemNotes) timelineEvents else timelineEvents.filterNot { it is ConversationEvent.SystemNote }
+        conversationTimelineVisibleEvents(events, showSystemNotes)
     }
     val toolResultPairing = remember(visibleEvents) { visibleEvents.toolResultPairing() }
     val filteredConversation = remember(visibleEvents, toolResultPairing) {

--- a/app/src/test/java/com/pocketshell/app/conversation/ConversationTimelineFilterTest.kt
+++ b/app/src/test/java/com/pocketshell/app/conversation/ConversationTimelineFilterTest.kt
@@ -1,0 +1,108 @@
+package com.pocketshell.app.conversation
+
+import com.pocketshell.core.agents.AgentKind
+import com.pocketshell.core.agents.ConversationEvent
+import com.pocketshell.core.agents.ConversationRole
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1267 (Part 2): the byte-clamp truncation marker (#1225) is rendered as
+ * a [ConversationEvent.SystemNote]. With `showSystemNotes = false` the whole
+ * system-notes class is filtered out — so a truncated giant line silently
+ * vanishes AGAIN, the exact failure #1225 set out to avoid. The marker must
+ * survive the filter regardless of the setting.
+ */
+class ConversationTimelineFilterTest {
+    private fun message(id: String, text: String): ConversationEvent.Message =
+        ConversationEvent.Message(
+            id = id,
+            agent = AgentKind.ClaudeCode,
+            role = ConversationRole.Assistant,
+            text = text,
+        )
+
+    private fun systemNote(id: String, tag: String, content: String): ConversationEvent.SystemNote =
+        ConversationEvent.SystemNote(
+            id = id,
+            agent = AgentKind.ClaudeCode,
+            tag = tag,
+            content = content,
+        )
+
+    private fun truncationMarker(id: String = "ps-truncated-line-0"): ConversationEvent.SystemNote =
+        systemNote(
+            id = id,
+            tag = TRUNCATED_LINE_SYSTEM_NOTE_TAG,
+            content = "[A 5242880-byte transcript line was too large to load and was truncated.]",
+        )
+
+    @Test
+    fun truncationMarkerSurvivesTheSystemNotesFilterWhenNotesAreOff() {
+        val events = listOf(
+            message("u1", "here is a screenshot"),
+            truncationMarker(),
+            systemNote("sn1", "system-reminder", "an ordinary system note"),
+            message("a1", "got it"),
+        )
+
+        val visible = conversationTimelineVisibleEvents(events, showSystemNotes = false)
+
+        // The truncation marker STAYS (RED without the tag-exemption: it was
+        // filtered out with all other system notes).
+        assertTrue(
+            "the truncation marker must survive the system-notes filter; got $visible",
+            visible.any { it is ConversationEvent.SystemNote && it.tag == TRUNCATED_LINE_SYSTEM_NOTE_TAG },
+        )
+        // The ordinary system note is still hidden (the setting is honoured for
+        // everything except the always-visible truncation affordance).
+        assertFalse(
+            "an ordinary system note must still be hidden when notes are off; got $visible",
+            visible.any { it is ConversationEvent.SystemNote && it.tag == "system-reminder" },
+        )
+        // Both real messages survive.
+        assertEquals(
+            listOf("here is a screenshot", "got it"),
+            visible.filterIsInstance<ConversationEvent.Message>().map { it.text },
+        )
+    }
+
+    @Test
+    fun systemNotesVisibleKeepsEveryNoteIncludingTheMarker() {
+        val events = listOf(
+            message("u1", "hi"),
+            truncationMarker(),
+            systemNote("sn1", "system-reminder", "an ordinary system note"),
+        )
+
+        val visible = conversationTimelineVisibleEvents(events, showSystemNotes = true)
+
+        assertTrue(
+            "with notes on, the ordinary note is shown",
+            visible.any { it is ConversationEvent.SystemNote && it.tag == "system-reminder" },
+        )
+        assertTrue(
+            "with notes on, the truncation marker is shown",
+            visible.any { it is ConversationEvent.SystemNote && it.tag == TRUNCATED_LINE_SYSTEM_NOTE_TAG },
+        )
+    }
+
+    @Test
+    fun internalProtocolNoiseRowsAreDroppedEvenWithNotesOn() {
+        // The truncation exemption must not resurrect the internal-protocol-noise
+        // hiding that isHiddenConversationTimelineRow already enforces.
+        val events = listOf(
+            message("u1", "hi"),
+            systemNote("turn", "turn_duration", "42ms"),
+        )
+
+        val visible = conversationTimelineVisibleEvents(events, showSystemNotes = true)
+
+        assertFalse(
+            "turn_duration noise is always hidden; got $visible",
+            visible.any { it is ConversationEvent.SystemNote && it.tag == "turn_duration" },
+        )
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/session/AgentConversationRepositoryTest.kt
+++ b/app/src/test/java/com/pocketshell/app/session/AgentConversationRepositoryTest.kt
@@ -2921,6 +2921,225 @@ class AgentConversationRepositoryTest {
         assertEquals(listOf("first", "second"), messages)
     }
 
+    // ===================================================================
+    // Issue #1267: extend the #1225 byte-bound to the Codex AND OpenCode
+    // cold-open reads (a G2 class-coverage gap — they use different read
+    // mechanisms than the Claude flat-JSONL tail). A multi-MB single line
+    // (huge tool_result / inline image) must degrade to a VISIBLE marker,
+    // per agent kind, instead of ballooning the read or vanishing.
+    // ===================================================================
+
+    @Test
+    fun codexReadInitialEventsByteClampsAMultiMegabyteLineToAVisibleTruncationMarker() = runTest {
+        // The Codex read goes through `pocketshell agent-log`, so the clamp is the
+        // tool-side `--max-line-bytes` flag; the giant envelope line is degraded
+        // server-side to a marker. FakeSshSession emulates that server clamp.
+        val hugeText = "A".repeat(5 * 1024 * 1024) // ~5 MB, >> MAX_TRANSCRIPT_LINE_BYTES
+        val codexLines = listOf(
+            """{"type":"event_msg","payload":{"type":"user_message","message":"look at this"}}""",
+            """{"type":"response_item","payload":{"type":"message","id":"m2","role":"assistant","content":[{"type":"output_text","text":"$hugeText"}]}}""",
+            """{"type":"response_item","payload":{"type":"message","id":"m3","role":"assistant","content":[{"type":"output_text","text":"seen"}]}}""",
+        )
+        val session = FakeSshSession(
+            agentLogOutput = JSONObject(
+                mapOf(
+                    "count" to codexLines.size,
+                    "engine" to "codex",
+                    "lines" to JSONArray(codexLines),
+                    "path" to "/home/testuser/.codex/sessions/2026/05/22/pocketshell-codex.jsonl",
+                    "session" to "pocketshell-codex",
+                ),
+            ).toString(),
+        )
+
+        val events = AgentConversationRepository().readInitialEvents(
+            session = session,
+            detection = AgentDetection(
+                agent = AgentKind.Codex,
+                sourcePath = "/home/testuser/.codex/sessions/2026/05/22/pocketshell-codex.jsonl",
+                sessionId = "pocketshell-codex",
+                confidence = AgentDetection.Confidence.ProcessConfirmed,
+            ),
+            maxLines = 20,
+        )
+
+        // RED on base: the Codex read passes no byte cap to the tool.
+        val command = session.execCommands.single { it.contains("pocketshell agent-log --engine codex") }
+        assertTrue(
+            "the Codex cold-open must byte-clamp server-side via --max-line-bytes; got: $command",
+            command.contains("--max-line-bytes $MAX_TRANSCRIPT_LINE_BYTES"),
+        )
+        val maxEventBytes = events.maxOfOrNull { estimatedEventBytes(it) } ?: 0L
+        assertTrue(
+            "no Codex cold-open event may exceed the per-line byte cap; largest was $maxEventBytes bytes",
+            maxEventBytes <= MAX_TRANSCRIPT_LINE_BYTES.toLong(),
+        )
+        assertNotNull(
+            "the oversized Codex line must degrade to a visible truncation note",
+            events.filterIsInstance<ConversationEvent.SystemNote>().singleOrNull { it.tag == "truncated" },
+        )
+        val messages = events.filterIsInstance<ConversationEvent.Message>().map { it.text }
+        assertTrue("normal Codex turns survive; got $messages", messages.contains("look at this"))
+        assertTrue("normal Codex turns survive; got $messages", messages.contains("seen"))
+    }
+
+    @Test
+    fun codexReadEventsWindowByteClampsAMultiMegabyteLineToAVisibleTruncationMarker() = runTest {
+        // Class coverage: the windowed Codex cold-open (readEventsWindow) folds
+        // the agent-log call into its exec and must byte-clamp it too.
+        val hugeText = "B".repeat(4 * 1024 * 1024)
+        val codexLines = listOf(
+            """{"type":"event_msg","payload":{"type":"user_message","message":"dump it"}}""",
+            """{"type":"response_item","payload":{"type":"message","id":"m2","role":"assistant","content":[{"type":"output_text","text":"$hugeText"}]}}""",
+            """{"type":"response_item","payload":{"type":"message","id":"m3","role":"assistant","content":[{"type":"output_text","text":"done"}]}}""",
+        )
+        val session = FakeSshSession(
+            wcOutput = "3\n",
+            agentLogOutput = JSONObject(
+                mapOf(
+                    "count" to codexLines.size,
+                    "engine" to "codex",
+                    "lines" to JSONArray(codexLines),
+                    "path" to "/home/testuser/.codex/sessions/2026/05/22/pocketshell-codex.jsonl",
+                    "session" to "pocketshell-codex",
+                ),
+            ).toString(),
+        )
+
+        val window = AgentConversationRepository().readEventsWindow(
+            session = session,
+            detection = AgentDetection(
+                agent = AgentKind.Codex,
+                sourcePath = "/home/testuser/.codex/sessions/2026/05/22/pocketshell-codex.jsonl",
+                sessionId = "pocketshell-codex",
+                confidence = AgentDetection.Confidence.ProcessConfirmed,
+            ),
+            maxMessages = FIRST_PAINT_MESSAGE_BUDGET,
+        )
+
+        val command = session.execCommands.single { it.contains("pocketshell agent-log --engine codex") }
+        assertTrue(
+            "the windowed Codex read must byte-clamp via --max-line-bytes; got: $command",
+            command.contains("--max-line-bytes $MAX_TRANSCRIPT_LINE_BYTES"),
+        )
+        val maxEventBytes = window.events.maxOfOrNull { estimatedEventBytes(it) } ?: 0L
+        assertTrue(
+            "no windowed Codex event may exceed the per-line byte cap; largest was $maxEventBytes bytes",
+            maxEventBytes <= MAX_TRANSCRIPT_LINE_BYTES.toLong(),
+        )
+        assertNotNull(
+            "the oversized Codex line must degrade to a visible truncation note",
+            window.events.filterIsInstance<ConversationEvent.SystemNote>().singleOrNull { it.tag == "truncated" },
+        )
+        val messages = window.events.filterIsInstance<ConversationEvent.Message>().map { it.text }
+        assertTrue("normal Codex turns survive; got $messages", messages.contains("dump it"))
+        assertTrue("normal Codex turns survive; got $messages", messages.contains("done"))
+    }
+
+    @Test
+    fun openCodeReadInitialEventsByteClampsAMultiMegabyteRowToAVisibleTruncationMarker() = runTest {
+        // The OpenCode read is a `sqlite3` export, one JSON object per line, so
+        // the SAME per-line `awk` byte clamp #1225 used for Claude is the
+        // format-appropriate bound. A row whose `part_data` is a multi-MB tool
+        // result must degrade to a visible marker, not balloon the read.
+        val hugePart = "D".repeat(4 * 1024 * 1024)
+        val session = FakeSshSession(
+            sqliteOutput = openCodeRows(
+                listOf(
+                    openCodeRow(1, "hello"),
+                    openCodeRow(2, hugePart),
+                    openCodeRow(3, "bye"),
+                ),
+            ),
+        )
+
+        val events = AgentConversationRepository().readInitialEvents(session, openCodeDetection())
+
+        // RED on base: the OpenCode sqlite export is not piped through the clamp.
+        val command = session.execCommands.single { it.contains("sqlite3 -readonly") }
+        assertTrue(
+            "the OpenCode cold-open must byte-clamp each row server-side; got: $command",
+            command.contains(LINE_TRUNCATION_SENTINEL) && command.contains("awk"),
+        )
+        val maxEventBytes = events.maxOfOrNull { estimatedEventBytes(it) } ?: 0L
+        assertTrue(
+            "no OpenCode cold-open event may exceed the per-line byte cap; largest was $maxEventBytes bytes",
+            maxEventBytes <= MAX_TRANSCRIPT_LINE_BYTES.toLong(),
+        )
+        val note = events.filterIsInstance<ConversationEvent.SystemNote>().singleOrNull { it.tag == "truncated" }
+        assertNotNull("the oversized OpenCode row must degrade to a visible truncation note", note)
+        assertEquals(AgentKind.OpenCode, note!!.agent)
+        val messages = events.filterIsInstance<ConversationEvent.Message>().map { it.text }
+        assertTrue("normal OpenCode messages survive; got $messages", messages.contains("hello"))
+        assertTrue("normal OpenCode messages survive; got $messages", messages.contains("bye"))
+    }
+
+    @Test
+    fun openCodeReadEventsWindowByteClampsAMultiMegabyteRowToAVisibleTruncationMarker() = runTest {
+        // Class coverage: the windowed OpenCode cold-open (readEventsWindow) must
+        // byte-clamp too.
+        val hugePart = "E".repeat(4 * 1024 * 1024)
+        val session = FakeSshSession(
+            sqliteOutput = openCodeRows(
+                listOf(
+                    openCodeRow(1, "first"),
+                    openCodeRow(2, hugePart),
+                    openCodeRow(3, "third"),
+                ),
+            ),
+        )
+
+        val window = AgentConversationRepository().readEventsWindow(
+            session = session,
+            detection = openCodeDetection(),
+            maxMessages = FIRST_PAINT_MESSAGE_BUDGET,
+        )
+
+        val command = session.execCommands.single { it.contains("sqlite3 -readonly") }
+        assertTrue(
+            "the windowed OpenCode read must byte-clamp each row server-side; got: $command",
+            command.contains(LINE_TRUNCATION_SENTINEL) && command.contains("awk"),
+        )
+        val maxEventBytes = window.events.maxOfOrNull { estimatedEventBytes(it) } ?: 0L
+        assertTrue(
+            "no windowed OpenCode event may exceed the per-line byte cap; largest was $maxEventBytes bytes",
+            maxEventBytes <= MAX_TRANSCRIPT_LINE_BYTES.toLong(),
+        )
+        assertNotNull(
+            "the oversized OpenCode row must degrade to a visible truncation note",
+            window.events.filterIsInstance<ConversationEvent.SystemNote>().singleOrNull { it.tag == "truncated" },
+        )
+        val messages = window.events.filterIsInstance<ConversationEvent.Message>().map { it.text }
+        assertTrue("normal OpenCode messages survive; got $messages", messages.contains("first"))
+        assertTrue("normal OpenCode messages survive; got $messages", messages.contains("third"))
+    }
+
+    @Test
+    fun openCodeReadInitialEventsLeavesANormalTranscriptUnchangedByTheByteClamp() = runTest {
+        // Counter-pin: a normal OpenCode transcript (every row well under the cap)
+        // is byte-clamped harmlessly — same messages, NO spurious marker.
+        val session = FakeSshSession(
+            sqliteOutput = openCodeRows(
+                listOf(
+                    openCodeRow(1, "run the tests"),
+                    openCodeRow(2, "all green"),
+                ),
+            ),
+        )
+
+        val events = AgentConversationRepository().readInitialEvents(session, openCodeDetection())
+
+        assertTrue(
+            "a normal OpenCode transcript must not produce any truncation marker",
+            events.none { it is ConversationEvent.SystemNote && it.tag == "truncated" },
+        )
+        val messages = events.filterIsInstance<ConversationEvent.Message>().map { it.text }
+        assertEquals(listOf("run the tests", "all green"), messages)
+        assertTrue(
+            session.execCommands.single { it.contains("sqlite3 -readonly") }.contains(LINE_TRUNCATION_SENTINEL),
+        )
+    }
+
     private fun estimatedEventBytes(event: ConversationEvent): Long = when (event) {
         is ConversationEvent.Message ->
             event.text.toByteArray(Charsets.UTF_8).size.toLong() +
@@ -3104,13 +3323,17 @@ class AgentConversationRepositoryTest {
                 // raw-file line count (the follow cursor) without a separate
                 // lineCount exec.
                 command.contains("@@PS_CODEX_WINDOW@@") ->
-                    "${wcOutput.trim()}\n@@PS_CODEX_WINDOW@@\n$agentLogOutput"
+                    "${wcOutput.trim()}\n@@PS_CODEX_WINDOW@@\n${applyAgentLogEnvelopeClamp(command, agentLogOutput)}"
                 command.contains("wc -l < ") -> wcOutput
-                command.contains("pocketshell agent-log") -> agentLogOutput
+                command.contains("pocketshell agent-log") -> applyAgentLogEnvelopeClamp(command, agentLogOutput)
                 command.trimStart().startsWith("tail -n") -> applyLineClamp(command, jsonlTailOutput)
                 command.contains("sqlite3 -readonly") -> {
                     sqliteFailure?.let { throw it }
-                    sqliteOutputs.removeFirstOrNull() ?: sqliteOutput
+                    // Issue #1267: the OpenCode read now pipes the sqlite output
+                    // through the same server-side per-line byte clamp; emulate it
+                    // so an over-cap row degrades to the sentinel exactly as on the
+                    // real host (identity for normal small rows).
+                    applyLineClamp(command, sqliteOutputs.removeFirstOrNull() ?: sqliteOutput)
                 }
                 else -> ""
             }
@@ -3133,6 +3356,30 @@ class AgentConversationRepositoryTest {
                 val bytes = line.toByteArray(Charsets.UTF_8).size
                 if (bytes > cap) "@@PS_LINE_TRUNCATED@@$bytes" else line
             }
+        }
+
+        // Issue #1267: faithfully emulate the SERVER-SIDE `pocketshell agent-log
+        // --max-line-bytes N` clamp (agent_log.py `_clamp_line_bytes`). The Codex
+        // read goes through the tool, not the `awk` pipe, so the byte clamp lives
+        // in the tool: each element of the envelope's `lines` array whose UTF-8
+        // byte length exceeds N is replaced by `@@PS_LINE_TRUNCATED@@<bytes>`
+        // before the envelope is serialised. When the command does NOT carry
+        // `--max-line-bytes` (base code), the envelope is returned unchanged and a
+        // multi-MB line balloons the read exactly as on-device — a genuine
+        // red->green. A blank/unparseable envelope is passed through untouched.
+        private fun applyAgentLogEnvelopeClamp(command: String, envelope: String): String {
+            val cap = Regex("--max-line-bytes (\\d+)").find(command)
+                ?.groupValues?.get(1)?.toIntOrNull() ?: return envelope
+            val json = runCatching { JSONObject(envelope) }.getOrNull() ?: return envelope
+            val lines = json.optJSONArray("lines") ?: return envelope
+            val clamped = JSONArray()
+            for (index in 0 until lines.length()) {
+                val line = lines.optString(index)
+                val bytes = line.toByteArray(Charsets.UTF_8).size
+                clamped.put(if (bytes > cap) "@@PS_LINE_TRUNCATED@@$bytes" else line)
+            }
+            json.put("lines", clamped)
+            return json.toString()
         }
 
         private fun emulatedFoldedClaudePath(command: String): String {

--- a/tools/pocketshell/src/pocketshell/agent_log.py
+++ b/tools/pocketshell/src/pocketshell/agent_log.py
@@ -66,6 +66,16 @@ import click
 #          daemon consumer can tell "session id is wrong" apart from
 #          "binary is missing".
 _EXIT_LOG_NOT_FOUND = 66
+# Issue #1225/#1267: sentinel emitted in place of a transcript line that
+# exceeded ``--max-line-bytes``, immediately followed by the line's original
+# UTF-8 byte length. MUST stay byte-identical to ``LINE_TRUNCATION_SENTINEL``
+# in the Kotlin ``AgentConversationRepository`` so the app recognises it and
+# renders a VISIBLE truncation marker instead of feeding the (now absent)
+# oversized JSON to the parser. This is the Codex/OpenCode counterpart of the
+# ``awk`` per-line byte clamp #1225 applied to the Claude flat-JSONL tail: one
+# multi-megabyte rollout line (an inline base64 image, a huge ``tool_result``)
+# is degraded server-side so its bytes never cross SSH into the phone's heap.
+_LINE_TRUNCATION_SENTINEL = "@@PS_LINE_TRUNCATED@@"
 _DEFAULT_HANDOFF_MAX_TURNS = 30
 _DEFAULT_HANDOFF_MAX_CHARS = 20_000
 _HANDOFF_PROMPT = (
@@ -283,6 +293,28 @@ def _tail(lines: Iterable[str], n: Optional[int]) -> List[str]:
     if n is None or n <= 0 or n >= len(materialised):
         return list(materialised)
     return materialised[-n:]
+
+
+def _clamp_line_bytes(lines: List[str], max_line_bytes: Optional[int]) -> List[str]:
+    """Byte-bound each line, server-side, before it is emitted.
+
+    Any line whose UTF-8 byte length exceeds ``max_line_bytes`` is replaced by
+    ``<_LINE_TRUNCATION_SENTINEL><byte-length>`` so a single multi-megabyte
+    rollout line (an inline base64 image, a huge ``tool_result``) never crosses
+    SSH into the phone's heap — the Codex/OpenCode counterpart of the Claude
+    ``awk`` clamp (#1225/#1267). ``None`` or a non-positive cap disables the
+    clamp (the whole-file default); normal lines pass through verbatim.
+    """
+    if not max_line_bytes or max_line_bytes <= 0:
+        return lines
+    clamped: List[str] = []
+    for line in lines:
+        byte_length = len(line.encode("utf-8"))
+        if byte_length > max_line_bytes:
+            clamped.append(f"{_LINE_TRUNCATION_SENTINEL}{byte_length}")
+        else:
+            clamped.append(line)
+    return clamped
 
 
 def _parse_json_line(line: str) -> Optional[dict[str, Any]]:
@@ -631,6 +663,18 @@ def _emit_json(
     is_flag=True,
     help="Emit a JSON envelope (`{engine, session, path, count, lines}`) instead of raw JSONL.",
 )
+@click.option(
+    "--max-line-bytes",
+    "max_line_bytes",
+    type=click.IntRange(min=0),
+    default=None,
+    help=(
+        "Replace any single log line longer than N bytes with a compact "
+        "truncation marker, server-side, so one multi-megabyte line (a pasted "
+        "image / huge tool result) cannot balloon the read into the client's "
+        "heap. Default: no clamp (emit lines verbatim)."
+    ),
+)
 @click.pass_context
 def agent_log_command(
     ctx: click.Context,
@@ -639,13 +683,16 @@ def agent_log_command(
     cwd: Optional[str],
     tail_count: Optional[int],
     json_output: bool,
+    max_line_bytes: Optional[int],
 ) -> None:
     """Print an agent JSONL conversation log.
 
     Reads the canonical per-engine path for the given session and emits
     the JSONL content either as raw lines (default) or wrapped in a JSON
     envelope (``--json``). ``--tail N`` bounds the output to the last N
-    events.
+    events. ``--max-line-bytes N`` degrades any single line longer than N
+    bytes to a compact truncation marker so one pathological line cannot
+    balloon the read (#1225/#1267).
 
     Exit codes:
 
@@ -679,7 +726,7 @@ def agent_log_command(
         )
         ctx.exit(_EXIT_LOG_NOT_FOUND)
 
-    lines = _tail(_read_lines(path), tail_count)
+    lines = _clamp_line_bytes(_tail(_read_lines(path), tail_count), max_line_bytes)
     if json_output:
         _emit_json(engine_normalised, session, path, lines)
     else:

--- a/tools/pocketshell/tests/test_agent_log.py
+++ b/tools/pocketshell/tests/test_agent_log.py
@@ -375,6 +375,112 @@ def test_json_envelope_with_tail(fake_home: Path) -> None:
     assert envelope["lines"] == [json.dumps(e, sort_keys=True) for e in events[-2:]]
 
 
+# ----- --max-line-bytes clamp (#1225/#1267) --------------------------
+
+
+def test_max_line_bytes_degrades_an_oversized_line_to_a_marker(fake_home: Path) -> None:
+    """A single multi-megabyte rollout line is replaced by
+    `@@PS_LINE_TRUNCATED@@<bytes>` server-side; normal lines pass through.
+
+    This is the Codex/OpenCode counterpart of the Claude `awk` byte clamp
+    (#1225): the oversized bytes never cross SSH into the phone's heap. The
+    Kotlin `AgentConversationRepository` recognises the marker and renders a
+    visible truncation note.
+    """
+    session = "clamp-session"
+    huge = "A" * (5 * 1024 * 1024)  # ~5 MB, far above a 256 KiB cap
+    events = [
+        {"type": "user", "message": "look at this"},
+        {"type": "assistant", "message": huge},
+        {"type": "assistant", "message": "seen"},
+    ]
+    log_path = (
+        fake_home / ".codex" / "sessions" / "2026" / "07" / "03" / f"{session}.jsonl"
+    )
+    _write_jsonl(log_path, events)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        agent_log_command,
+        [
+            "--engine",
+            "codex",
+            "--session",
+            session,
+            "--json",
+            "--max-line-bytes",
+            str(256 * 1024),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    envelope = json.loads(result.output)
+    lines = envelope["lines"]
+    assert len(lines) == 3
+    # The oversized line is a marker naming its original byte length; no envelope
+    # line exceeds the cap now.
+    marker = lines[1]
+    assert marker.startswith("@@PS_LINE_TRUNCATED@@")
+    original_bytes = len(json.dumps(events[1], sort_keys=True).encode("utf-8"))
+    assert marker == f"@@PS_LINE_TRUNCATED@@{original_bytes}"
+    assert all(len(line.encode("utf-8")) <= 256 * 1024 for line in lines)
+    # The normal turns around the pathological line are untouched.
+    assert lines[0] == json.dumps(events[0], sort_keys=True)
+    assert lines[2] == json.dumps(events[2], sort_keys=True)
+
+
+def test_max_line_bytes_leaves_a_normal_transcript_unchanged(fake_home: Path) -> None:
+    """Counter-pin: every line under the cap passes through verbatim, no marker."""
+    session = "clamp-normal"
+    events = _sample_events("c", count=4)
+    log_path = (
+        fake_home / ".codex" / "sessions" / "2026" / "07" / "03" / f"{session}.jsonl"
+    )
+    _write_jsonl(log_path, events)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        agent_log_command,
+        [
+            "--engine",
+            "codex",
+            "--session",
+            session,
+            "--json",
+            "--max-line-bytes",
+            str(256 * 1024),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    envelope = json.loads(result.output)
+    assert envelope["lines"] == [json.dumps(e, sort_keys=True) for e in events]
+    assert not any("@@PS_LINE_TRUNCATED@@" in line for line in envelope["lines"])
+
+
+def test_no_max_line_bytes_keeps_the_oversized_line_verbatim(fake_home: Path) -> None:
+    """Without the flag (the whole-file default) an oversized line is NOT clamped
+    — proving the clamp is what the flag opts into (the red state on base)."""
+    session = "clamp-off"
+    huge = "Z" * (300 * 1024)
+    events = [{"type": "assistant", "message": huge}]
+    log_path = (
+        fake_home / ".codex" / "sessions" / "2026" / "07" / "03" / f"{session}.jsonl"
+    )
+    _write_jsonl(log_path, events)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        agent_log_command,
+        ["--engine", "codex", "--session", session, "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    envelope = json.loads(result.output)
+    assert envelope["lines"] == [json.dumps(events[0], sort_keys=True)]
+    assert "@@PS_LINE_TRUNCATED@@" not in result.output
+
+
 # ----- handoff export ------------------------------------------------
 
 


### PR DESCRIPTION
Closes #1267 — two follow-ups from #1225.

## What
- **Codex/OpenCode byte-bound (G2 gap):** #1225 clamped only the Claude flat-JSONL tail. Codex now passes `--max-line-bytes` to `agent_log.py` (server-side per-line clamp to a sentinel); OpenCode pipes an awk per-line clamp after its sqlite export. All three agent kinds are now OOM-protected against a multi-MB single line.
- **Marker survives `showSystemNotes=false`:** the over-cap truncation marker renders through `conversationTimelineVisibleEvents(...)`, which keeps it even with system notes off (previously filtered → silent re-drop, the exact #1225 failure).

## Verification (reviewer-driven, all 3 kinds)
- G10 red→green per kind with REAL giant-line fixtures (5MB Codex / 4MB OpenCode): each load-bearing test fails on base, passes with fix. 91 Kotlin + 3 Python tests, 0 failures.
- Marker-survives-filter test asserts visibility with `showSystemNotes=false`.
- Sentinel `@@PS_LINE_TRUNCATED@@` byte-identical across Python and Kotlin; Claude #1225 path untouched + green.

Non-blocking follow-up noted: OpenCode marker appended at feed end vs interleaved (AC still met).

Reviewer APPROVED: https://github.com/alexeygrigorev/pocketshell/issues/1267#issuecomment-4879978509