### PR TITLE
usage: glanceable usage pill on the landing app bar (#1241)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/usage/UsageGlancePillE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/usage/UsageGlancePillE2eTest.kt
@@ -1,0 +1,137 @@
+package com.pocketshell.app.usage
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.pocketshell.app.hosts.HostsAppBar
+import com.pocketshell.app.hosts.SETTINGS_BUTTON_TAG
+import com.pocketshell.app.portfwd.ForwardingIndicatorState
+import com.pocketshell.app.proof.signals.assertNodeFullyWithinRoot
+import com.pocketshell.uikit.model.PillKind
+import com.pocketshell.uikit.theme.PocketShellColors
+import com.pocketshell.uikit.theme.PocketShellTheme
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Issue #1241: on-device Compose proof for the landing app-bar usage glance
+ * pill. Composes the PRODUCTION [HostsAppBar] (the real landing app bar) inside
+ * the real [PocketShellTheme] — not a proxy — and pins the acceptance criteria
+ * that need a rendered composition:
+ *
+ *  - AC1: the most-constraining percent renders; HIDDEN when there is no data.
+ *  - AC2: tapping the pill routes to Usage (invokes `onOpenUsage`).
+ *  - AC3: the pill does NOT crowd the app bar — it and the Settings gear are
+ *    both fully contained within the window root (the #418 declutter guard).
+ *  - AC4: a stale reading renders honestly ("cached from HH:mm").
+ *
+ * Pure Compose-rule UI test (like `EnvScreenE2eTest`): no Docker fixture, no
+ * SSH/tmux, no toxiproxy, deterministic on the CI swiftshader AVD, and it does
+ * NOT self-skip on CI. Wired into `scripts/ci-journey-suite.sh` so it gates at
+ * per-push/batched time (G9). The pure state-derivation coverage
+ * (most-constraining pick, hidden-when-no-data, kind, stale flag) lives in the
+ * per-push Unit gate: `UsageGlancePillStateTest`.
+ */
+@RunWith(AndroidJUnit4::class)
+class UsageGlancePillE2eTest {
+
+    @get:Rule
+    val compose = createAndroidComposeRule<ComponentActivity>()
+
+    private fun appBar(
+        pill: UsageGlancePillState?,
+        onOpenUsage: (() -> Unit)? = {},
+        forwarding: ForwardingIndicatorState = ForwardingIndicatorState(
+            activeHostCount = 1,
+            totalTunnelCount = 2,
+        ),
+    ) {
+        compose.setContent {
+            PocketShellTheme {
+                Column(modifier = Modifier.fillMaxSize().background(PocketShellColors.Background)) {
+                    HostsAppBar(
+                        hostCount = 5,
+                        activeSessionCount = 4,
+                        forwardingIndicator = forwarding,
+                        usageGlancePill = pill,
+                        onOpenUsage = onOpenUsage,
+                    )
+                }
+            }
+        }
+    }
+
+    // AC1: shows the most-constraining percent from cache.
+    @Test
+    fun showsMostConstrainingPercent() {
+        appBar(pill = UsageGlancePillState(percent = 72, kind = PillKind.Warn, stale = false, capturedClock = "14:05"))
+        compose.onNodeWithTag(USAGE_GLANCE_PILL_TAG).assertIsDisplayed()
+        compose.onNodeWithText("72%").assertIsDisplayed()
+        compose.onNodeWithContentDescription("Usage 72%").assertIsDisplayed()
+    }
+
+    // AC1: hidden when there is no data.
+    @Test
+    fun hiddenWhenNoData() {
+        appBar(pill = null)
+        compose.onNodeWithTag(USAGE_GLANCE_PILL_TAG).assertDoesNotExist()
+        // The Settings gear must still be present — the app bar is intact.
+        compose.onNodeWithTag(SETTINGS_BUTTON_TAG).assertIsDisplayed()
+    }
+
+    // AC1: hidden when the Usage route is not wired (no destination to tap into).
+    @Test
+    fun hiddenWhenNoUsageRoute() {
+        appBar(
+            pill = UsageGlancePillState(percent = 50, kind = PillKind.Ok, stale = false, capturedClock = "14:05"),
+            onOpenUsage = null,
+        )
+        compose.onNodeWithTag(USAGE_GLANCE_PILL_TAG).assertDoesNotExist()
+    }
+
+    // AC2: tap navigates to UsageScreen (invokes onOpenUsage).
+    @Test
+    fun tapInvokesUsageRoute() {
+        var tapped = false
+        appBar(
+            pill = UsageGlancePillState(percent = 88, kind = PillKind.Warn, stale = false, capturedClock = "14:05"),
+            onOpenUsage = { tapped = true },
+        )
+        compose.onNodeWithTag(USAGE_GLANCE_PILL_TAG).assertHasClickAction()
+        compose.onNodeWithTag(USAGE_GLANCE_PILL_TAG).performClick()
+        compose.waitForIdle()
+        assertTrue("tapping the usage pill must route to Usage", tapped)
+    }
+
+    // AC3: does not crowd the app bar — pill AND settings gear both fully within
+    // the window root, even alongside the forwarding indicator (the #418 guard).
+    @Test
+    fun pillAndSettingsAreBothFullyContained() {
+        appBar(pill = UsageGlancePillState(percent = 100, kind = PillKind.Blocked, stale = true, capturedClock = "13:40"))
+        compose.assertNodeFullyWithinRoot(USAGE_GLANCE_PILL_TAG)
+        compose.assertNodeFullyWithinRoot(SETTINGS_BUTTON_TAG)
+    }
+
+    // AC4: stale data is visually honest ("cached from HH:mm").
+    @Test
+    fun staleReadingRendersHonestly() {
+        appBar(pill = UsageGlancePillState(percent = 63, kind = PillKind.Ok, stale = true, capturedClock = "13:40"))
+        compose.onNodeWithTag(USAGE_GLANCE_PILL_TAG).assertIsDisplayed()
+        // The muted capture clock is rendered inline …
+        compose.onNodeWithText("13:40").assertIsDisplayed()
+        // … and the honest provenance is in the accessibility description.
+        compose.onNodeWithContentDescription("Usage 63%, cached from 13:40").assertIsDisplayed()
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/hosts/HostListScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/hosts/HostListScreen.kt
@@ -197,6 +197,10 @@ fun HostListScreen(
     val usageWarningProviders by viewModel.usageWarningProviders.collectAsState()
     val dismissedBanners by viewModel.dismissedBanners.collectAsState()
     val forwardingIndicator by forwardingIndicatorViewModel.state.collectAsState()
+    // Issue #1241: the glanceable most-constraining usage percent, read from
+    // the SAME cached scheduler snapshots the warning banners use (no new
+    // fetch). Null while there's no usable reading — the pill is then hidden.
+    val usageGlancePill by viewModel.usageGlancePill.collectAsState()
     val context = LocalContext.current
     val activity = context as? FragmentActivity
 
@@ -364,6 +368,11 @@ fun HostListScreen(
                 onSettingsClick = onOpenSettings,
                 forwardingIndicator = forwardingIndicator,
                 onForwardingIndicatorClick = onOpenPortForwarding,
+                // Issue #1241: the glance pill only lights up when there's a
+                // cached reading AND a Usage route is wired (mirrors the
+                // banner / kebab gate).
+                usageGlancePill = usageGlancePill,
+                onOpenUsage = onOpenUsage,
             )
 
             // The landing body is one scrolling hosts-first list. Live
@@ -983,19 +992,32 @@ internal fun UpdateBanner(info: ReleaseInfo, onUpdate: () -> Unit) {
  * from the caller's live state.
  */
 @Composable
-private fun HostsAppBar(
+internal fun HostsAppBar(
     hostCount: Int,
     activeSessionCount: Int,
     onSettingsClick: () -> Unit = {},
     forwardingIndicator: com.pocketshell.app.portfwd.ForwardingIndicatorState =
         com.pocketshell.app.portfwd.ForwardingIndicatorState(),
     onForwardingIndicatorClick: () -> Unit = {},
+    // Issue #1241: the glanceable usage pill. Null (or a null route) hides it.
+    usageGlancePill: com.pocketshell.app.usage.UsageGlancePillState? = null,
+    onOpenUsage: (() -> Unit)? = null,
 ) {
     ScreenHeader(
         title = "Hosts",
         subtitle = hostsHeaderSubtitle(hostCount, activeSessionCount),
         modifier = Modifier.border(width = 1.dp, color = PocketShellColors.BorderSoft),
         trailing = {
+            // Issue #1241: the most-constraining usage percent, tapping into
+            // UsageScreen. Leftmost of the trailing affordances so the number
+            // is the first thing scanned; the shared trailing Row's inter-item
+            // spacing keeps it clear of the forwarding pill + Settings gear.
+            if (usageGlancePill != null && onOpenUsage != null) {
+                com.pocketshell.app.usage.UsageGlancePill(
+                    state = usageGlancePill,
+                    onClick = onOpenUsage,
+                )
+            }
             // Issue #446: the global "ports forwarding" indicator only appears
             // while ≥1 host is actively auto-forwarding. Tapping it opens the
             // port-forward panel entry (same chooser as the QS tile +

--- a/app/src/main/java/com/pocketshell/app/hosts/HostListViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/hosts/HostListViewModel.kt
@@ -247,6 +247,26 @@ class HostListViewModel internal constructor(
     }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000L), emptyMap())
 
+    /**
+     * Issue #1241: the landing app-bar glance pill. The most-constraining
+     * provider percent across every cached host, or null when there is no
+     * usable reading yet (the pill is then hidden). Reads the SAME cached
+     * [UsageScheduler.snapshots] the warning banners + per-card badges consult
+     * — NO new fetch cadence (D21-compliant). The warn-threshold gate is read
+     * from settings so the pill's severity tint stays in sync with the other
+     * in-app usage surfaces.
+     */
+    val usageGlancePill: StateFlow<com.pocketshell.app.usage.UsageGlancePillState?> = combine(
+        usageScheduler.snapshots,
+        settingsRepository.settings,
+    ) { snapshots, settings ->
+        com.pocketshell.app.usage.usageGlancePillState(
+            snapshots = snapshots,
+            warnPercent = settings.usageWarnThresholdPercent.toDouble(),
+        )
+    }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000L), null)
+
     // Issue #483 introduced a per-host usage summary chip (`usageSummaries`)
     // rendered under each host card; issue #506 dropped that chip because it
     // read as a cryptic floating row. Usage is reachable per-host via the

--- a/app/src/main/java/com/pocketshell/app/usage/UsageGlancePill.kt
+++ b/app/src/main/java/com/pocketshell/app/usage/UsageGlancePill.kt
@@ -1,0 +1,210 @@
+package com.pocketshell.app.usage
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.pocketshell.core.usage.UsageThresholdState
+import com.pocketshell.uikit.model.PillKind
+import com.pocketshell.uikit.theme.PocketShellColors
+import com.pocketshell.uikit.theme.PocketShellShapes
+import com.pocketshell.uikit.theme.PocketShellSpacing
+import com.pocketshell.uikit.theme.PocketShellType
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneId
+import kotlin.math.roundToInt
+
+/**
+ * Issue #1241: the glanceable usage pill on the landing app bar.
+ *
+ * The routine, NON-warning question — "how much have I burned this week" —
+ * was reachable only via Settings → Diagnostics or the in-session kebab (2–3
+ * taps). The per-provider warning banners (#214) only surface when a provider
+ * crosses the warn threshold, so a healthy 40% Claude never showed anywhere on
+ * the landing surface. This small most-constraining-percent pill sits next to
+ * the port-forward indicator + Settings gear and taps straight into
+ * [UsageScreen], so the number is always one glance / one tap away.
+ *
+ * It reads the SAME cached [UsageScheduler.snapshots] the host-list warning
+ * banners + per-card badges already consult — NO new fetch cadence, no extra
+ * polling (D21-compliant). When the scheduler has no usable reading yet the
+ * pill is hidden entirely (see [usageGlancePillState] returning null).
+ */
+public data class UsageGlancePillState(
+    /** Most-constraining provider percent across every cached host, rounded. */
+    val percent: Int,
+    /**
+     * Severity tint for the leading dot, derived from the winning provider's
+     * threshold state so a blocked provider reads red at a glance without the
+     * user opening the panel.
+     */
+    val kind: PillKind,
+    /**
+     * True when the freshest cached reading behind this percent is older than
+     * [USAGE_GLANCE_STALE_AFTER]. Rendered honestly (muted + "cached from
+     * HH:mm") so the number is never silently presented as live.
+     */
+    val stale: Boolean,
+    /** Local "HH:mm" capture clock, shown only while [stale]. */
+    val capturedClock: String,
+) {
+    val label: String get() = "$percent%"
+
+    /**
+     * Accessibility / test-visible description. Mirrors the visual: a fresh
+     * pill is just "Usage N%"; a stale pill spells out the honest "cached from
+     * HH:mm" provenance so TalkBack users get the same signal the muted clock
+     * gives sighted users.
+     */
+    val contentDescription: String
+        get() = if (stale) {
+            "Usage $percent%, cached from $capturedClock"
+        } else {
+            "Usage $percent%"
+        }
+}
+
+/**
+ * How old the freshest cached reading may be before the glance pill flips to
+ * its honest "stale / cached from HH:mm" treatment. The scheduler polls active
+ * hosts on a 60s / 5m cadence (#117), so 10 minutes is comfortably past a
+ * healthy refresh yet short enough that a genuinely stalled reading reads as
+ * cached rather than live.
+ */
+public val USAGE_GLANCE_STALE_AFTER: Duration = Duration.ofMinutes(10)
+
+/**
+ * Stable test tag for the app-bar usage pill (#1241).
+ */
+public const val USAGE_GLANCE_PILL_TAG: String = "hosts:appbar:usage-pill"
+
+/**
+ * Derive the glance-pill state from the cached scheduler [snapshots].
+ *
+ * Picks the single MOST-CONSTRAINING window across every host + provider (the
+ * highest percent) so the pill answers "how close am I to the nearest limit"
+ * with one number. A hard-blocked provider that reports no windows still
+ * surfaces as 100% (mirroring [dashboardRows]) so a block is never invisible.
+ *
+ * Returns null — i.e. the pill is HIDDEN — when there is no usable reading yet:
+ * no [UsageSnapshot.Records], or only records without a thresholdable window.
+ * This is the "hidden/neutral when no data" contract (AC1).
+ */
+internal fun usageGlancePillState(
+    snapshots: Map<Long, UsageSnapshot>,
+    warnPercent: Double,
+    now: Instant = Instant.now(),
+    staleAfter: Duration = USAGE_GLANCE_STALE_AFTER,
+    zoneId: ZoneId = ZoneId.systemDefault(),
+): UsageGlancePillState? {
+    val worst = snapshots.values
+        .filterIsInstance<UsageSnapshot.Records>()
+        .flatMap { snap -> snap.records.map { snap to it } }
+        .mapNotNull { (snap, record) ->
+            val state = record.thresholdState(warnPercent = warnPercent)
+            val percent = record.mostConstrainedWindow?.percent
+                ?: if (state == UsageThresholdState.Exceeded) 100.0 else return@mapNotNull null
+            GlanceCandidate(percent = percent, state = state, fetchedAt = snap.fetchedAt)
+        }
+        .maxByOrNull { it.percent }
+        ?: return null
+
+    val kind = when (worst.state) {
+        UsageThresholdState.Exceeded, UsageThresholdState.Critical -> PillKind.Blocked
+        UsageThresholdState.Approaching -> PillKind.Warn
+        UsageThresholdState.Ok -> PillKind.Ok
+    }
+    val stale = Duration.between(worst.fetchedAt, now) > staleAfter
+    return UsageGlancePillState(
+        percent = worst.percent.roundToInt(),
+        kind = kind,
+        stale = stale,
+        capturedClock = formatCapturedClock(worst.fetchedAt, zoneId),
+    )
+}
+
+private data class GlanceCandidate(
+    val percent: Double,
+    val state: UsageThresholdState,
+    val fetchedAt: Instant,
+)
+
+/**
+ * The app-bar usage pill. Styled to match the sibling [ForwardingIndicatorPill]
+ * chrome (32dp rounded [PocketShellColors.SurfaceElev] surface + 1dp
+ * [PocketShellColors.BorderSoft] hairline) so it reads as one of the small
+ * app-bar affordances, NOT a heavy card — the #418 declutter constraint. The
+ * enclosing [ScreenHeader] trailing row spaces it from the Settings gear, so it
+ * never crowds.
+ */
+@Composable
+internal fun UsageGlancePill(
+    state: UsageGlancePillState,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val contentAlpha = if (state.stale) STALE_CONTENT_ALPHA else 1f
+    Row(
+        modifier = modifier
+            .height(32.dp)
+            .background(color = PocketShellColors.SurfaceElev, shape = PocketShellShapes.large)
+            .border(
+                width = 1.dp,
+                color = PocketShellColors.BorderSoft,
+                shape = PocketShellShapes.large,
+            )
+            .clickable(role = Role.Button, onClick = onClick)
+            .semantics { this.contentDescription = state.contentDescription }
+            .testTag(USAGE_GLANCE_PILL_TAG)
+            .padding(horizontal = PocketShellSpacing.md),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        // Small severity dot — the kind tint reads even before the number does.
+        Canvas(modifier = Modifier.size(8.dp)) {
+            drawCircle(color = usageGlanceKindColor(state.kind).copy(alpha = contentAlpha))
+        }
+        Spacer(modifier = Modifier.width(6.dp))
+        androidx.compose.material3.Text(
+            text = state.label,
+            color = PocketShellColors.Text.copy(alpha = contentAlpha),
+            style = PocketShellType.bodyDense,
+            fontWeight = FontWeight.SemiBold,
+        )
+        if (state.stale) {
+            // Honest provenance for a cached reading, consistent with the Usage
+            // screen's "showing cached from HH:mm" pattern.
+            Spacer(modifier = Modifier.width(6.dp))
+            androidx.compose.material3.Text(
+                text = state.capturedClock,
+                color = PocketShellColors.TextMuted,
+                style = PocketShellType.bodyDense,
+            )
+        }
+    }
+}
+
+private const val STALE_CONTENT_ALPHA = 0.6f
+
+internal fun usageGlanceKindColor(kind: PillKind): Color = when (kind) {
+    PillKind.Ok -> PocketShellColors.Green
+    PillKind.Warn -> PocketShellColors.Amber
+    PillKind.Blocked -> PocketShellColors.Red
+    PillKind.Error -> PocketShellColors.TextMuted
+}

--- a/app/src/test/java/com/pocketshell/app/usage/UsageGlancePillStateTest.kt
+++ b/app/src/test/java/com/pocketshell/app/usage/UsageGlancePillStateTest.kt
@@ -1,0 +1,175 @@
+package com.pocketshell.app.usage
+
+import com.pocketshell.core.usage.UsageProviderRecord
+import com.pocketshell.core.usage.UsageStatus
+import com.pocketshell.core.usage.UsageWindow
+import com.pocketshell.uikit.model.PillKind
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneId
+
+/**
+ * Issue #1241: unit coverage for the landing app-bar usage glance pill's
+ * state derivation ([usageGlancePillState]). These pin the acceptance criteria
+ * that are pure logic — the most-constraining percent from cache, the
+ * hidden-when-no-data contract, the severity tint, and the honest-when-stale
+ * flag — in the per-push Unit gate (they run under `./gradlew test`). The
+ * on-device render / tap / non-crowding proof lives in
+ * `app/src/androidTest/.../UsageGlancePillE2eTest`.
+ */
+class UsageGlancePillStateTest {
+
+    private val zone = ZoneId.of("UTC")
+    private val now = Instant.parse("2026-07-04T14:10:00Z")
+
+    private fun window(percent: Double): UsageWindow =
+        UsageWindow(name = "5h", used = percent, limit = 100.0, unit = "percent", resetAt = null)
+
+    private fun record(
+        provider: String,
+        percent: Double,
+        status: UsageStatus = UsageStatus.Ok,
+        windows: List<UsageWindow> = listOf(window(percent)),
+    ): UsageProviderRecord =
+        UsageProviderRecord(
+            provider = provider,
+            status = status,
+            windows = windows,
+            rawStatus = status.name.lowercase(),
+        )
+
+    private fun snapshot(
+        hostId: Long,
+        records: List<UsageProviderRecord>,
+        fetchedAt: Instant = now,
+    ): UsageSnapshot =
+        UsageSnapshot.Records(
+            hostId = hostId,
+            hostName = "host-$hostId",
+            records = records,
+            fetchedAt = fetchedAt,
+            command = UsageRemoteSource.defaultUsageCommand,
+        )
+
+    // AC1: hidden/neutral when no data.
+    @Test
+    fun `no snapshots yields null so the pill is hidden`() {
+        assertNull(usageGlancePillState(emptyMap(), warnPercent = 80.0, now = now, zoneId = zone))
+    }
+
+    @Test
+    fun `tool-missing and failed snapshots alone yield null`() {
+        val snapshots = mapOf(
+            1L to UsageSnapshot.ToolMissing(hostId = 1L, hostName = "a", fetchedAt = now),
+            2L to UsageSnapshot.Failed(hostId = 2L, hostName = "b", reason = "boom", fetchedAt = now),
+        )
+        assertNull(usageGlancePillState(snapshots, warnPercent = 80.0, now = now, zoneId = zone))
+    }
+
+    @Test
+    fun `records with no thresholdable window yield null`() {
+        // status=Ok with no windows has no percent to show → hidden.
+        val snapshots = mapOf(
+            1L to snapshot(1L, listOf(record("claude", 0.0, status = UsageStatus.Unsupported, windows = emptyList()))),
+        )
+        assertNull(usageGlancePillState(snapshots, warnPercent = 80.0, now = now, zoneId = zone))
+    }
+
+    // AC1: most-constraining provider percent from cache — across providers AND hosts.
+    @Test
+    fun `picks the highest percent across every provider and host`() {
+        val snapshots = mapOf(
+            1L to snapshot(1L, listOf(record("claude", 40.0), record("codex", 72.0))),
+            2L to snapshot(2L, listOf(record("opencode", 55.0))),
+        )
+        val state = usageGlancePillState(snapshots, warnPercent = 80.0, now = now, zoneId = zone)!!
+        assertEquals(72, state.percent)
+        assertEquals("72%", state.label)
+    }
+
+    @Test
+    fun `percent is rounded to nearest integer`() {
+        val snapshots = mapOf(1L to snapshot(1L, listOf(record("claude", 82.6))))
+        val state = usageGlancePillState(snapshots, warnPercent = 80.0, now = now, zoneId = zone)!!
+        assertEquals(83, state.percent)
+    }
+
+    @Test
+    fun `hard-blocked provider with no windows still surfaces as 100 percent`() {
+        val snapshots = mapOf(
+            1L to snapshot(
+                1L,
+                listOf(record("codex", 0.0, status = UsageStatus.Blocked, windows = emptyList())),
+            ),
+        )
+        val state = usageGlancePillState(snapshots, warnPercent = 80.0, now = now, zoneId = zone)!!
+        assertEquals(100, state.percent)
+        assertEquals(PillKind.Blocked, state.kind)
+    }
+
+    // AC1: severity tint mirrors the warn-threshold state.
+    @Test
+    fun `kind reflects threshold state at the configured warn percent`() {
+        // 40% healthy → Ok (green).
+        assertEquals(
+            PillKind.Ok,
+            usageGlancePillState(mapOf(1L to snapshot(1L, listOf(record("claude", 40.0)))), 80.0, now, zoneId = zone)!!.kind,
+        )
+        // 84% at warn=80 → Approaching → Warn (amber).
+        assertEquals(
+            PillKind.Warn,
+            usageGlancePillState(mapOf(1L to snapshot(1L, listOf(record("claude", 84.0)))), 80.0, now, zoneId = zone)!!.kind,
+        )
+        // 97% → Critical → Blocked (red); 100% → Exceeded → Blocked (red).
+        assertEquals(
+            PillKind.Blocked,
+            usageGlancePillState(mapOf(1L to snapshot(1L, listOf(record("claude", 97.0)))), 80.0, now, zoneId = zone)!!.kind,
+        )
+    }
+
+    @Test
+    fun `warn threshold gate is respected — 84 percent is Ok when warn is 90`() {
+        val snapshots = mapOf(1L to snapshot(1L, listOf(record("claude", 84.0))))
+        assertEquals(
+            PillKind.Ok,
+            usageGlancePillState(snapshots, warnPercent = 90.0, now = now, zoneId = zone)!!.kind,
+        )
+    }
+
+    // AC4: stale data is visually honest.
+    @Test
+    fun `fresh reading is not stale and has no cached-from description`() {
+        val snapshots = mapOf(1L to snapshot(1L, listOf(record("claude", 60.0)), fetchedAt = now.minus(Duration.ofMinutes(2))))
+        val state = usageGlancePillState(snapshots, warnPercent = 80.0, now = now, zoneId = zone)!!
+        assertFalse(state.stale)
+        assertEquals("Usage 60%", state.contentDescription)
+    }
+
+    @Test
+    fun `reading older than the stale window is flagged stale with an HHmm clock`() {
+        val captured = Instant.parse("2026-07-04T13:55:00Z") // 15 min before now → stale
+        val snapshots = mapOf(1L to snapshot(1L, listOf(record("claude", 60.0)), fetchedAt = captured))
+        val state = usageGlancePillState(snapshots, warnPercent = 80.0, now = now, zoneId = zone)!!
+        assertTrue(state.stale)
+        assertEquals("13:55", state.capturedClock)
+        assertEquals("Usage 60%, cached from 13:55", state.contentDescription)
+    }
+
+    @Test
+    fun `staleness follows the winning provider's own snapshot age`() {
+        // The most-constraining provider (72%) is fresh; an older lower host must
+        // not make the shown percent look stale.
+        val snapshots = mapOf(
+            1L to snapshot(1L, listOf(record("codex", 72.0)), fetchedAt = now.minus(Duration.ofMinutes(1))),
+            2L to snapshot(2L, listOf(record("claude", 30.0)), fetchedAt = now.minus(Duration.ofHours(3))),
+        )
+        val state = usageGlancePillState(snapshots, warnPercent = 80.0, now = now, zoneId = zone)!!
+        assertEquals(72, state.percent)
+        assertFalse(state.stale)
+    }
+}

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -1580,6 +1580,23 @@ JOURNEY_CLASSES=(
   # fixture tests.yml already brings up (no toxiproxy / new port), and does NOT
   # self-skip on CI. Lives under com.pocketshell.app.tmux, so it carries its FQCN.
   "com.pocketshell.app.tmux.TmuxResizeSessionE2eTest#cachedSizeReplayRestoresFullWindowAndAgentPaneIsNotCut"
+  # ADDED (#1241): the landing app-bar usage GLANCE PILL on-device proof. The
+  # routine non-warning "how much have I burned this week" question was 2-3 taps
+  # deep (Settings->Diagnostics / in-session kebab); this small most-constraining-
+  # percent pill surfaces it on the landing app bar next to Settings and taps into
+  # UsageScreen. This connected UI test composes the PRODUCTION HostsAppBar in the
+  # real PocketShellTheme and asserts: the percent renders, the pill is HIDDEN with
+  # no data / no route, tapping routes to Usage, a stale reading renders honestly
+  # ("cached from HH:mm"), and the pill + Settings gear are BOTH fully within the
+  # window root (the #418 declutter / no-crowd guard — assertNodeFullyWithinRoot,
+  # not a bare assertIsDisplayed). Pure Compose-rule UI test (like EnvScreenE2eTest):
+  # no Docker fixture / SSH / tmux / toxiproxy / port, so it needs NO tests.yml
+  # service change, is deterministic on the CI swiftshader AVD, and does NOT
+  # self-skip on CI. The pure state-derivation backstop (most-constraining pick,
+  # hidden-when-no-data, kind, stale flag) is the per-push Unit-job
+  # UsageGlancePillStateTest. It lives under com.pocketshell.app.usage, so it
+  # carries its FQCN directly.
+  "com.pocketshell.app.usage.UsageGlancePillE2eTest"
 )
 
 # ---------------------------------------------------------------------------

--- a/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenders.kt
+++ b/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenders.kt
@@ -722,6 +722,40 @@ class DesignRenders {
     }
 
     /**
+     * Issue #1241: the landing app-bar with the new glanceable usage pill next
+     * to the forwarding indicator + Settings gear. The real pill lives in the
+     * app module ([com.pocketshell.app.usage.UsageGlancePill]); this fixture
+     * mirrors it with the SAME ui-kit chrome (32dp rounded SurfaceElev surface,
+     * 1dp BorderSoft hairline, kind-tinted dot + percent) the app pill composes,
+     * so the fast JVM check shows it reads as one small app-bar affordance — NOT
+     * a heavy card — and does NOT crowd the header (the #418 declutter guard).
+     * Fresh (Warn 72%) on top, stale (Ok 63% · "cached from 13:40") below to
+     * check the honest muted treatment. The emulator screenshot is the acceptance.
+     */
+    @Test
+    fun usageGlancePill() = render("usage-glance-pill") {
+        Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+            ScreenHeader(
+                title = "Hosts",
+                subtitle = "5 hosts · 4 active",
+                trailing = {
+                    UsageGlancePillFacsimile(percent = "72%", dot = PillKind.Warn)
+                    AppBarPillFacsimile { Text("2", color = PocketShellColors.Text, style = PocketShellType.bodyDense, fontWeight = FontWeight.SemiBold) }
+                    AppBarGearFacsimile()
+                },
+            )
+            ScreenHeader(
+                title = "Hosts",
+                subtitle = "5 hosts · 4 active",
+                trailing = {
+                    UsageGlancePillFacsimile(percent = "63%", dot = PillKind.Ok, staleClock = "13:40")
+                    AppBarGearFacsimile()
+                },
+            )
+        }
+    }
+
+    /**
      * Issue #603: the host-detail workspace tree with the redesigned
      * inactive / empty watched-root callout.
      *
@@ -4102,6 +4136,71 @@ class DesignRenders {
                 color = PocketShellColors.Text,
                 style = PocketShellType.bodyDense,
             )
+        }
+    }
+
+    /**
+     * Issue #1241: ui-kit facsimile of the app-module app-bar usage glance pill
+     * ([com.pocketshell.app.usage.UsageGlancePill]) for the fast JVM render.
+     * Mirrors the app pill's chrome so the design read is faithful; the emulator
+     * screenshot is the acceptance.
+     */
+    @Composable
+    private fun UsageGlancePillFacsimile(percent: String, dot: PillKind, staleClock: String? = null) {
+        val alpha = if (staleClock != null) 0.6f else 1f
+        val dotColor = when (dot) {
+            PillKind.Ok -> PocketShellColors.Green
+            PillKind.Warn -> PocketShellColors.Amber
+            PillKind.Blocked -> PocketShellColors.Red
+            PillKind.Error -> PocketShellColors.TextMuted
+        }
+        Row(
+            modifier = Modifier
+                .height(32.dp)
+                .background(color = PocketShellColors.SurfaceElev, shape = PocketShellShapes.large)
+                .border(width = 1.dp, color = PocketShellColors.BorderSoft, shape = PocketShellShapes.large)
+                .padding(horizontal = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Box(modifier = Modifier.size(8.dp).clip(CircleShape).background(dotColor.copy(alpha = alpha)))
+            Spacer(modifier = Modifier.width(6.dp))
+            Text(
+                text = percent,
+                color = PocketShellColors.Text.copy(alpha = alpha),
+                style = PocketShellType.bodyDense,
+                fontWeight = FontWeight.SemiBold,
+            )
+            if (staleClock != null) {
+                Spacer(modifier = Modifier.width(6.dp))
+                Text(text = staleClock, color = PocketShellColors.TextMuted, style = PocketShellType.bodyDense)
+            }
+        }
+    }
+
+    @Composable
+    private fun AppBarPillFacsimile(content: @Composable RowScope.() -> Unit) {
+        Row(
+            modifier = Modifier
+                .height(32.dp)
+                .background(color = PocketShellColors.SurfaceElev, shape = PocketShellShapes.large)
+                .border(width = 1.dp, color = PocketShellColors.BorderSoft, shape = PocketShellShapes.large)
+                .padding(horizontal = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            content = content,
+        )
+    }
+
+    @Composable
+    private fun AppBarGearFacsimile() {
+        Box(
+            modifier = Modifier
+                .size(40.dp)
+                .clip(CircleShape)
+                .background(color = PocketShellColors.SurfaceElev)
+                .border(width = 1.dp, color = PocketShellColors.BorderSoft, shape = CircleShape),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text("⚙", color = PocketShellColors.TextSecondary)
         }
     }
 


### PR DESCRIPTION
Closes #1241 — Size S UX.

## What
The routine non-warning question ('how much have I burned this week') was 2-3 taps deep. Adds a most-constraining-percent pill to the Hosts app bar that reads the EXISTING cached `UsageScheduler.snapshots` (no new fetch cadence — D21), shows the highest window percent across cached hosts/providers tinted by threshold, flags stale >10min, hides when no data / no Usage route, and taps into `UsageScreen`.

## Verification (reviewer-run on emulator)
- `UsageGlancePillE2eTest` 6/6 on a real emulator composing the production `HostsAppBar`; the #418 no-crowd guard is a genuine `assertNodeFullyWithinRoot` `boundsInRoot` containment on both the pill and the Settings gear (load-bearing green — G6).
- 11 JVM derivation tests (0 skipped); render inspected (fresh amber 72% / stale muted 'HH:mm'); D21 no-new-fetch confirmed; hidden-state correct.

Reviewer APPROVED: https://github.com/alexeygrigorev/pocketshell/issues/1241#issuecomment-4879984914