### PR TITLE
core-connection: assert ConnectionController Main-thread confinement (#1234 item 6)

### DIFF
--- a/shared/core-connection/build.gradle.kts
+++ b/shared/core-connection/build.gradle.kts
@@ -28,6 +28,15 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    // Item 6 (#1234): the ConnectionController thread-confinement assertion is
+    // debug-gated via `BuildConfig.DEBUG`, so the generated BuildConfig is
+    // required. Under `testDebugUnitTest` (the per-push gate) DEBUG is true, so
+    // the guard is active — every existing single-thread test exercises the
+    // "on-confined-thread does not trip" path for free.
+    buildFeatures {
+        buildConfig = true
+    }
+
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17

--- a/shared/core-connection/src/main/java/com/pocketshell/core/connection/ConnectionController.kt
+++ b/shared/core-connection/src/main/java/com/pocketshell/core/connection/ConnectionController.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import java.util.concurrent.atomic.AtomicLong
 
 /**
  * The pure-JVM connection lifecycle state machine (EPIC #687 Phase-2, slice 1).
@@ -27,38 +28,46 @@ import kotlinx.coroutines.flow.asStateFlow
  * No timer runs while Backgrounded (D21); the deadline is a stored value compared
  * on the next foreground, never a scheduled wakeup.
  *
- * ## Threading contract — Main/single-thread confined (issue #1234, item 6)
+ * ## Threading contract — single confining dispatcher (issue #1234, item 6)
  *
  * This controller is a NON-thread-safe reducer. [submit] performs an unguarded
  * read-modify-write of [state] and mutates the plain [graceDeadlineMs] `var`;
  * nothing here synchronizes. It is correct ONLY because every mutator
- * ([submit] and the reduce helpers it drives, plus [offerSeed]) is invoked from
- * a SINGLE confining thread — in production the Main/UI dispatcher the VM adapter
- * marshals all connection events onto. An off-confinement caller would race the
- * `graceDeadlineMs`/`_state.value` updates and silently corrupt lifecycle state.
+ * ([submit] and the reduce helpers it drives, plus [offerSeed]) is driven from a
+ * SINGLE confining DISPATCHER — in production the Main/UI dispatcher the VM
+ * adapter marshals all connection events onto. That dispatcher *serializes* the
+ * mutators, so no two ever overlap; an off-confinement caller that races the
+ * reducer would corrupt the `graceDeadlineMs`/`_state.value` updates silently.
  *
- * To keep that contract honest, DEBUG builds install a [ThreadConfinementGuard]:
- * the first confined-mutator call captures the owning thread, and any later call
- * from a different thread hard-fails immediately instead of corrupting state
- * silently. In release builds the guard is a no-op (zero overhead) — the guard
- * documents + enforces the existing contract without changing any behavior.
+ * To keep that contract honest, DEBUG builds install a [ThreadConfinementGuard]
+ * that asserts the load-bearing invariant a confining dispatcher provides:
+ * **no two mutator calls run concurrently.** It latches an owner for the duration
+ * of each mutation and hard-fails if a second thread enters a mutator while the
+ * first is still inside — the genuine data race. It deliberately does NOT key off
+ * a fixed `Thread.id`: a real dispatcher (the Main dispatcher over its lifetime,
+ * and every coroutine test dispatcher — including an `UnconfinedTestDispatcher`
+ * that resumes a confined `collect { submit() }` inline on a foreign emitter
+ * thread) legitimately serializes work across DIFFERENT pool threads, and that
+ * benign migration must pass. In release builds the guard is a no-op (zero
+ * overhead) — it documents + enforces the existing contract, changing no behavior.
  */
 class ConnectionController(
     private val clock: Clock,
     private val transport: TransportPort,
     private val maxReconnectAttempts: Int = DEFAULT_MAX_RECONNECT_ATTEMPTS,
     private val graceMs: Long = DEFAULT_GRACE_MS,
-    // Item 6 (#1234): debug-gated thread-confinement assertion. Defaults to
+    // Item 6 (#1234): debug-gated dispatcher-confinement assertion. Defaults to
     // `BuildConfig.DEBUG` so the guard is active under `testDebugUnitTest` and
     // developer debug builds, and a no-op in release. Injectable so a test can
     // pin it on/off deterministically regardless of the build variant.
     confinementAssertionsEnabled: Boolean = BuildConfig.DEBUG,
 ) {
     /**
-     * Enforces the Main/single-thread confinement contract in DEBUG builds. It
-     * touches NO controller state and only reads the current thread, so it can
-     * never change reducer behavior — it only converts a silent off-confinement
-     * data race into a loud [IllegalStateException] during development.
+     * Enforces the single-confining-dispatcher contract in DEBUG builds by
+     * asserting no two mutators overlap. It touches NO controller state and only
+     * reads the current thread id, so it can never change reducer behavior — it
+     * only converts a silent concurrent (off-confinement) mutation into a loud
+     * [IllegalStateException] during development.
      */
     private val confinement = ThreadConfinementGuard(confinementAssertionsEnabled)
     private val _state = MutableStateFlow<ConnectionState>(ConnectionState.Idle)
@@ -85,8 +94,8 @@ class ConnectionController(
      * Grace deadline stored on Background; null when not backgrounded. No timer.
      *
      * A plain `var` with NO synchronization — it is read-modified-written only
-     * from within [submit]'s reduce path, so it relies on the Main/single-thread
-     * confinement contract documented on the class (issue #1234, item 6).
+     * from within [submit]'s reduce path, so it relies on the single-confining-
+     * dispatcher contract documented on the class (issue #1234, item 6).
      */
     private var graceDeadlineMs: Long? = null
 
@@ -103,18 +112,18 @@ class ConnectionController(
      * match the current target are dropped (return current state unchanged) — the
      * one place that rule lives.
      *
-     * MUST be called from the controller's single confining (Main) thread: it
+     * MUST be driven from the controller's single confining (Main) dispatcher: it
      * does an unguarded read-modify-write of [state] and mutates [graceDeadlineMs]
-     * (issue #1234, item 6). DEBUG builds assert this via [confinement].
+     * (issue #1234, item 6). DEBUG builds assert no mutator overlaps via
+     * [confinement].
      */
-    fun submit(event: ConnectionEvent): ConnectionState {
-        confinement.checkConfined("submit")
+    fun submit(event: ConnectionEvent): ConnectionState = confinement.guarded("submit") {
         val next = reduce(_state.value, event)
         if (next !== _state.value || next != _state.value) {
             _state.value = next
         }
         _revealGate.value = revealFor(next)
-        return _state.value
+        _state.value
     }
 
     /**
@@ -122,15 +131,15 @@ class ConnectionController(
      * matches the current target; a seed for a superseded/non-current target is
      * dropped. Returns true if accepted (emitted), false if dropped.
      *
-     * A confined mutator: shares the controller's single-thread contract with
-     * [submit] (issue #1234, item 6). DEBUG builds assert it via [confinement].
+     * A confined mutator: shares the controller's single-dispatcher contract with
+     * [submit] (issue #1234, item 6). DEBUG builds assert no mutator overlaps via
+     * [confinement].
      */
-    fun offerSeed(seed: Seed): Boolean {
-        confinement.checkConfined("offerSeed")
+    fun offerSeed(seed: Seed): Boolean = confinement.guarded("offerSeed") {
         if (seed.targetId != currentTargetId) {
-            return false
+            return@guarded false
         }
-        return _seeds.tryEmit(seed)
+        _seeds.tryEmit(seed)
     }
 
     private fun reduce(current: ConnectionState, event: ConnectionEvent): ConnectionState =
@@ -379,46 +388,83 @@ fun ConnectionState.hostOrNull(): HostKey? = when (this) {
 }
 
 /**
- * Debug-only Main/single-thread confinement guard for [ConnectionController]
+ * Debug-only dispatcher-confinement guard for [ConnectionController]
  * (issue #1234, item 6).
  *
  * The controller's mutators ([ConnectionController.submit] / [offerSeed]) are
  * NOT thread-safe: they read-modify-write `_state.value` and the plain
  * `graceDeadlineMs` `var` without synchronization, correct only under the
- * contract that a SINGLE (Main) thread ever drives them. This guard makes that
- * contract enforceable in development: on the first confined call it captures the
- * owning thread; any later confined call from a different thread hard-fails with
- * an [IllegalStateException] instead of silently corrupting lifecycle state.
+ * contract that they are driven from a SINGLE confining DISPATCHER (in production
+ * the Main/UI dispatcher the VM marshals every connection event onto). The
+ * load-bearing invariant that dispatcher guarantees, and the ONLY thing that
+ * keeps the unguarded read-modify-writes safe, is that **no two mutator calls
+ * ever run concurrently** — a single confining dispatcher serializes them.
+ *
+ * ## Why this asserts NO-CONCURRENT-MUTATION, not raw-thread identity
+ * A confining dispatcher is a *serialization* contract, NOT a fixed-thread one.
+ * A dispatcher (the production Main dispatcher over its lifetime, and every
+ * coroutine test dispatcher) may legitimately run its serialized work on
+ * DIFFERENT pool threads at different times — and, under an
+ * `UnconfinedTestDispatcher`, may even resume a confined `collect { submit(...) }`
+ * body *inline on the foreign thread that emitted upstream*. All of those are
+ * still confined: the calls never OVERLAP. Keying the guard off the first raw
+ * `Thread.id` (round 1) wrongly flagged that benign pool-thread migration as a
+ * violation and tripped 5 `TmuxSessionViewModelTest` cases. So the guard asserts
+ * the invariant that actually matters: it latches an owner for the DURATION of a
+ * mutation and hard-fails only if a SECOND thread enters a mutator while the
+ * first is still inside it — the genuine data race that corrupts lifecycle state.
+ * Sequential hand-off across pool threads (a real dispatcher) passes; a real
+ * off-confinement caller that races the reducer trips.
  *
  * When [enabled] is false (release builds, `BuildConfig.DEBUG == false`) it is a
  * zero-work no-op — it never touches controller state and only ever reads the
  * current thread, so it cannot alter reducer behavior on any build.
  */
 internal class ThreadConfinementGuard(private val enabled: Boolean) {
-    @Volatile
-    private var ownerThreadId: Long = UNSET
-    @Volatile
-    private var ownerThreadName: String? = null
+    // The thread currently executing a mutator, or UNSET when none is. A CAS
+    // UNSET -> current on entry latches the owner for the mutation's duration;
+    // the matching exit releases it back to UNSET. AtomicLong so a concurrent
+    // second entrant observes the in-progress owner atomically.
+    private val activeThreadId = AtomicLong(UNSET)
+    // Reentrancy depth for the owner thread (a mutator that re-enters a mutator
+    // on the same thread must not release the latch early). Only ever read/written
+    // by the owner thread while it holds the latch, so it needs no synchronization.
+    private var reentrancyDepth: Int = 0
 
     /**
-     * Assert the current thread is the confined owner. The first call latches the
-     * owner; later calls from any other thread throw. No-op when [enabled] is
-     * false. [operation] names the caller for the failure message.
+     * Run [body] as a confined mutation. No-op wrapper when [enabled] is false.
+     * If another thread is already inside a mutator when this call enters, that is
+     * a genuine concurrent (off-confinement) mutation and hard-fails with an
+     * [IllegalStateException]; sequential calls — including ones that migrate
+     * across a dispatcher's pool threads — pass. [operation] names the caller for
+     * the failure message.
      */
-    fun checkConfined(operation: String) {
-        if (!enabled) return
-        val current = Thread.currentThread()
-        if (ownerThreadId == UNSET) {
-            ownerThreadId = current.id
-            ownerThreadName = current.name
-            return
+    fun <T> guarded(operation: String, body: () -> T): T {
+        if (!enabled) return body()
+        val currentId = Thread.currentThread().id
+        val reentrant = activeThreadId.get() == currentId
+        if (!reentrant) {
+            if (!activeThreadId.compareAndSet(UNSET, currentId)) {
+                val holder = activeThreadId.get()
+                throw IllegalStateException(
+                    "ConnectionController.$operation() ran concurrently with another " +
+                        "mutator: thread '${Thread.currentThread().name}' (id=$currentId) " +
+                        "entered while thread id=$holder was still inside a mutation. The " +
+                        "controller is a non-thread-safe reducer — all mutators must be " +
+                        "confined to a single serializing (Main) dispatcher so they never " +
+                        "overlap (issue #1234, item 6)."
+                )
+            }
+            reentrancyDepth = 1
+        } else {
+            reentrancyDepth++
         }
-        check(current.id == ownerThreadId) {
-            "ConnectionController.$operation() ran off its confined owner thread: " +
-                "expected '${ownerThreadName}' (id=$ownerThreadId) but was " +
-                "'${current.name}' (id=${current.id}). The controller is a " +
-                "non-thread-safe reducer — all mutators must be Main/single-thread " +
-                "confined (issue #1234, item 6)."
+        try {
+            return body()
+        } finally {
+            if (--reentrancyDepth == 0) {
+                activeThreadId.set(UNSET)
+            }
         }
     }
 

--- a/shared/core-connection/src/main/java/com/pocketshell/core/connection/ConnectionController.kt
+++ b/shared/core-connection/src/main/java/com/pocketshell/core/connection/ConnectionController.kt
@@ -26,13 +26,41 @@ import kotlinx.coroutines.flow.asStateFlow
  * "within grace" == `clock.nowMs() < graceDeadline && transport.isWarm(host)`.
  * No timer runs while Backgrounded (D21); the deadline is a stored value compared
  * on the next foreground, never a scheduled wakeup.
+ *
+ * ## Threading contract — Main/single-thread confined (issue #1234, item 6)
+ *
+ * This controller is a NON-thread-safe reducer. [submit] performs an unguarded
+ * read-modify-write of [state] and mutates the plain [graceDeadlineMs] `var`;
+ * nothing here synchronizes. It is correct ONLY because every mutator
+ * ([submit] and the reduce helpers it drives, plus [offerSeed]) is invoked from
+ * a SINGLE confining thread — in production the Main/UI dispatcher the VM adapter
+ * marshals all connection events onto. An off-confinement caller would race the
+ * `graceDeadlineMs`/`_state.value` updates and silently corrupt lifecycle state.
+ *
+ * To keep that contract honest, DEBUG builds install a [ThreadConfinementGuard]:
+ * the first confined-mutator call captures the owning thread, and any later call
+ * from a different thread hard-fails immediately instead of corrupting state
+ * silently. In release builds the guard is a no-op (zero overhead) — the guard
+ * documents + enforces the existing contract without changing any behavior.
  */
 class ConnectionController(
     private val clock: Clock,
     private val transport: TransportPort,
     private val maxReconnectAttempts: Int = DEFAULT_MAX_RECONNECT_ATTEMPTS,
     private val graceMs: Long = DEFAULT_GRACE_MS,
+    // Item 6 (#1234): debug-gated thread-confinement assertion. Defaults to
+    // `BuildConfig.DEBUG` so the guard is active under `testDebugUnitTest` and
+    // developer debug builds, and a no-op in release. Injectable so a test can
+    // pin it on/off deterministically regardless of the build variant.
+    confinementAssertionsEnabled: Boolean = BuildConfig.DEBUG,
 ) {
+    /**
+     * Enforces the Main/single-thread confinement contract in DEBUG builds. It
+     * touches NO controller state and only reads the current thread, so it can
+     * never change reducer behavior — it only converts a silent off-confinement
+     * data race into a loud [IllegalStateException] during development.
+     */
+    private val confinement = ThreadConfinementGuard(confinementAssertionsEnabled)
     private val _state = MutableStateFlow<ConnectionState>(ConnectionState.Idle)
 
     /** The single honest connection-state source. The VM maps this 1:1 to its
@@ -53,7 +81,13 @@ class ConnectionController(
     /** Id-tagged seeds that survived the drop-by-id check (current target only). */
     val seeds: Flow<Seed> = _seeds.asSharedFlow()
 
-    /** Grace deadline stored on Background; null when not backgrounded. No timer. */
+    /**
+     * Grace deadline stored on Background; null when not backgrounded. No timer.
+     *
+     * A plain `var` with NO synchronization — it is read-modified-written only
+     * from within [submit]'s reduce path, so it relies on the Main/single-thread
+     * confinement contract documented on the class (issue #1234, item 6).
+     */
     private var graceDeadlineMs: Long? = null
 
     /** Current target id — the drop-by-id reference for events and seeds. */
@@ -68,8 +102,13 @@ class ConnectionController(
      * for convenience (also published on [state]). Events whose target id does not
      * match the current target are dropped (return current state unchanged) — the
      * one place that rule lives.
+     *
+     * MUST be called from the controller's single confining (Main) thread: it
+     * does an unguarded read-modify-write of [state] and mutates [graceDeadlineMs]
+     * (issue #1234, item 6). DEBUG builds assert this via [confinement].
      */
     fun submit(event: ConnectionEvent): ConnectionState {
+        confinement.checkConfined("submit")
         val next = reduce(_state.value, event)
         if (next !== _state.value || next != _state.value) {
             _state.value = next
@@ -82,8 +121,12 @@ class ConnectionController(
      * Offer a freshly captured pane seed. Re-emitted on [seeds] ONLY if its id
      * matches the current target; a seed for a superseded/non-current target is
      * dropped. Returns true if accepted (emitted), false if dropped.
+     *
+     * A confined mutator: shares the controller's single-thread contract with
+     * [submit] (issue #1234, item 6). DEBUG builds assert it via [confinement].
      */
     fun offerSeed(seed: Seed): Boolean {
+        confinement.checkConfined("offerSeed")
         if (seed.targetId != currentTargetId) {
             return false
         }
@@ -333,4 +376,53 @@ fun ConnectionState.hostOrNull(): HostKey? = when (this) {
     is ConnectionState.Reconnecting -> host
     is ConnectionState.Gone -> host
     is ConnectionState.Unreachable -> host
+}
+
+/**
+ * Debug-only Main/single-thread confinement guard for [ConnectionController]
+ * (issue #1234, item 6).
+ *
+ * The controller's mutators ([ConnectionController.submit] / [offerSeed]) are
+ * NOT thread-safe: they read-modify-write `_state.value` and the plain
+ * `graceDeadlineMs` `var` without synchronization, correct only under the
+ * contract that a SINGLE (Main) thread ever drives them. This guard makes that
+ * contract enforceable in development: on the first confined call it captures the
+ * owning thread; any later confined call from a different thread hard-fails with
+ * an [IllegalStateException] instead of silently corrupting lifecycle state.
+ *
+ * When [enabled] is false (release builds, `BuildConfig.DEBUG == false`) it is a
+ * zero-work no-op — it never touches controller state and only ever reads the
+ * current thread, so it cannot alter reducer behavior on any build.
+ */
+internal class ThreadConfinementGuard(private val enabled: Boolean) {
+    @Volatile
+    private var ownerThreadId: Long = UNSET
+    @Volatile
+    private var ownerThreadName: String? = null
+
+    /**
+     * Assert the current thread is the confined owner. The first call latches the
+     * owner; later calls from any other thread throw. No-op when [enabled] is
+     * false. [operation] names the caller for the failure message.
+     */
+    fun checkConfined(operation: String) {
+        if (!enabled) return
+        val current = Thread.currentThread()
+        if (ownerThreadId == UNSET) {
+            ownerThreadId = current.id
+            ownerThreadName = current.name
+            return
+        }
+        check(current.id == ownerThreadId) {
+            "ConnectionController.$operation() ran off its confined owner thread: " +
+                "expected '${ownerThreadName}' (id=$ownerThreadId) but was " +
+                "'${current.name}' (id=${current.id}). The controller is a " +
+                "non-thread-safe reducer — all mutators must be Main/single-thread " +
+                "confined (issue #1234, item 6)."
+        }
+    }
+
+    private companion object {
+        private const val UNSET: Long = -1L
+    }
 }

--- a/shared/core-connection/src/test/java/com/pocketshell/core/connection/ConnectionControllerConfinementTest.kt
+++ b/shared/core-connection/src/test/java/com/pocketshell/core/connection/ConnectionControllerConfinementTest.kt
@@ -1,0 +1,143 @@
+package com.pocketshell.core.connection
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Item 6 (#1234): the [ConnectionController] Main/single-thread confinement
+ * assertion. The controller's `submit`/`offerSeed` do unguarded read-modify-writes
+ * of `_state.value` + the plain `graceDeadlineMs` var, safe ONLY because callers
+ * are Main-confined. These tests prove the DEBUG-gated guard converts an
+ * off-confinement call into a loud failure while leaving the confined happy path
+ * (and release builds) behavior-identical.
+ */
+class ConnectionControllerConfinementTest {
+
+    private val host = HostKey("h1")
+    private val target = SessionId("s1")
+
+    private fun controller(confinementEnabled: Boolean = true): ConnectionController =
+        ConnectionController(
+            clock = FakeClock(),
+            transport = FakeTransportPort(),
+            confinementAssertionsEnabled = confinementEnabled,
+        )
+
+    /** submit() on the confining (owner) thread never trips — the happy path. */
+    @Test
+    fun `submit on confined owner thread does not trip the guard`() {
+        val controller = controller() // constructed + used on this test thread
+        // Repeated same-thread calls: the first latches the owner, the rest match.
+        val s1 = controller.submit(ConnectionEvent.Enter(host, target))
+        val s2 = controller.submit(ConnectionEvent.Background)
+        assertTrue("Enter -> Attaching/Connecting", s1 is ConnectionState.Attaching || s1 is ConnectionState.Connecting)
+        assertTrue("Background -> Backgrounded", s2 is ConnectionState.Backgrounded)
+    }
+
+    /**
+     * submit() from a DIFFERENT thread than the confined owner hard-fails in a
+     * DEBUG build. The owner is latched by the first (test-thread) call; a second
+     * call marshalled onto a worker thread must trip the assertion.
+     */
+    @Test
+    fun `submit off the confined owner thread trips the guard`() {
+        val controller = controller()
+        // Latch the owner on the test thread.
+        controller.submit(ConnectionEvent.Enter(host, target))
+
+        val thrown = runOnOtherThread { controller.submit(ConnectionEvent.Background) }
+
+        assertNotNull("expected the guard to throw off-thread", thrown)
+        assertTrue(
+            "expected IllegalStateException, got ${thrown!!::class.java}",
+            thrown is IllegalStateException,
+        )
+        assertTrue(
+            "message should name submit + issue: ${thrown.message}",
+            thrown.message!!.contains("submit") && thrown.message!!.contains("#1234"),
+        )
+    }
+
+    /** offerSeed() is a confined mutator too and trips off the owner thread. */
+    @Test
+    fun `offerSeed off the confined owner thread trips the guard`() {
+        val controller = controller()
+        controller.submit(ConnectionEvent.Enter(host, target)) // latch owner on test thread
+
+        val thrown = runOnOtherThread { controller.offerSeed(Seed(target, "%0", "frame")) }
+
+        assertNotNull("expected the guard to throw off-thread", thrown)
+        assertTrue(thrown is IllegalStateException)
+        assertTrue(thrown!!.message!!.contains("offerSeed"))
+    }
+
+    /**
+     * Debug-gating: with the assertion DISABLED (release-build simulation,
+     * `BuildConfig.DEBUG == false`), an off-thread submit does NOT throw and the
+     * reduce result is identical to the confined path — the guard is a pure no-op.
+     */
+    @Test
+    fun `disabled guard is a no-op off-thread (release build)`() {
+        val controller = controller(confinementEnabled = false)
+        controller.submit(ConnectionEvent.Enter(host, target))
+
+        val thrown = runOnOtherThread { controller.submit(ConnectionEvent.Background) }
+
+        assertNull("release build must not assert on off-thread calls", thrown)
+        assertTrue("state still transitioned normally", controller.state.value is ConnectionState.Backgrounded)
+    }
+
+    /**
+     * The default guard (no explicit flag) follows `BuildConfig.DEBUG`. Under
+     * `testDebugUnitTest` that is true, so a default-constructed controller trips
+     * off-thread — proving production wiring is armed in debug, not just when a
+     * test forces the flag on.
+     */
+    @Test
+    fun `default guard follows BuildConfig DEBUG and is armed under debug tests`() {
+        assertTrue("this suite must run under the debug variant", BuildConfig.DEBUG)
+        val controller = ConnectionController(clock = FakeClock(), transport = FakeTransportPort())
+        controller.submit(ConnectionEvent.Enter(host, target))
+
+        val thrown = runOnOtherThread { controller.submit(ConnectionEvent.Background) }
+
+        assertNotNull("default (debug) guard should be armed", thrown)
+        assertTrue(thrown is IllegalStateException)
+    }
+
+    /** The guard is state-touch-free: enabling it does not alter reduce outputs. */
+    @Test
+    fun `guarded and unguarded confined runs produce identical state`() {
+        val guarded = controller(confinementEnabled = true)
+        val unguarded = controller(confinementEnabled = false)
+        val events = listOf(
+            ConnectionEvent.Enter(host, target),
+            ConnectionEvent.Background,
+            ConnectionEvent.Foreground,
+            ConnectionEvent.TransportLive,
+        )
+        events.forEach { guarded.submit(it); unguarded.submit(it) }
+        assertEquals(unguarded.state.value, guarded.state.value)
+        assertFalse(guarded.state.value is ConnectionState.Idle)
+    }
+
+    /** Run [block] on a fresh worker thread; return the throwable it raised, or null. */
+    private fun runOnOtherThread(block: () -> Unit): Throwable? {
+        val captured = AtomicReference<Throwable?>(null)
+        val t = Thread {
+            try {
+                block()
+            } catch (e: Throwable) {
+                captured.set(e)
+            }
+        }
+        t.start()
+        t.join()
+        return captured.get()
+    }
+}

--- a/shared/core-connection/src/test/java/com/pocketshell/core/connection/ConnectionControllerConfinementTest.kt
+++ b/shared/core-connection/src/test/java/com/pocketshell/core/connection/ConnectionControllerConfinementTest.kt
@@ -214,44 +214,19 @@ class ConnectionControllerConfinementTest {
         assertNull("release build must not assert on a concurrent call", thrown)
     }
 
-    /**
-     * The default guard (no explicit flag) follows `BuildConfig.DEBUG`. Under
-     * `testDebugUnitTest` that is true, so a default-constructed controller is armed
-     * and trips on a concurrent mutation — proving production wiring is armed in
-     * debug, not just when a test forces the flag on.
-     */
-    @Test
-    fun `default guard follows BuildConfig DEBUG and is armed under debug tests`() {
-        assertTrue("this suite must run under the debug variant", BuildConfig.DEBUG)
-        val insideMutation = CountDownLatch(1)
-        val releaseMutation = CountDownLatch(1)
-        val blockingClock = object : Clock {
-            @Volatile var blockOnce = true
-            override fun nowMs(): Long {
-                if (blockOnce) {
-                    blockOnce = false
-                    insideMutation.countDown()
-                    releaseMutation.await(5, TimeUnit.SECONDS)
-                }
-                return 0L
-            }
-        }
-        // Default constructor: confinementAssertionsEnabled defaults to BuildConfig.DEBUG.
-        val controller = ConnectionController(clock = blockingClock, transport = FakeTransportPort())
-        controller.submit(ConnectionEvent.Enter(host, target))
-
-        val threadA = Thread { controller.submit(ConnectionEvent.Background) }
-        threadA.start()
-        assertTrue(insideMutation.await(5, TimeUnit.SECONDS))
-
-        val thrown = runCatching { controller.submit(ConnectionEvent.Foreground) }.exceptionOrNull()
-
-        releaseMutation.countDown()
-        threadA.join(5_000)
-
-        assertNotNull("default (debug) guard should be armed", thrown)
-        assertTrue(thrown is IllegalStateException)
-    }
+    // NOTE: the default-constructor path (confinementAssertionsEnabled defaults to
+    // BuildConfig.DEBUG) is variant-DEPENDENT, so it cannot live in this common
+    // `src/test/` suite (which compiles into BOTH testDebugUnitTest and
+    // testReleaseUnitTest — a single `assertTrue(BuildConfig.DEBUG)` would hard-fail
+    // under the release task, the CI break this round fixes). The two halves of that
+    // contract are asserted in the variant-specific source sets so BOTH variants stay
+    // meaningfully green with real coverage:
+    //   - src/testDebug/.../ConnectionControllerConfinementDefaultDebugTest.kt
+    //       proves the default guard is ARMED under debug (BuildConfig.DEBUG == true)
+    //       and trips on a concurrent mutation — production wiring is armed in debug.
+    //   - src/testRelease/.../ConnectionControllerConfinementDefaultReleaseTest.kt
+    //       proves the default guard is a NO-OP under release (BuildConfig.DEBUG ==
+    //       false) — zero overhead in shipped builds.
 
     /** The guard is state-touch-free: enabling it does not alter reduce outputs. */
     @Test

--- a/shared/core-connection/src/test/java/com/pocketshell/core/connection/ConnectionControllerConfinementTest.kt
+++ b/shared/core-connection/src/test/java/com/pocketshell/core/connection/ConnectionControllerConfinementTest.kt
@@ -6,15 +6,30 @@ import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 
 /**
- * Item 6 (#1234): the [ConnectionController] Main/single-thread confinement
+ * Item 6 (#1234): the [ConnectionController] single-confining-dispatcher
  * assertion. The controller's `submit`/`offerSeed` do unguarded read-modify-writes
- * of `_state.value` + the plain `graceDeadlineMs` var, safe ONLY because callers
- * are Main-confined. These tests prove the DEBUG-gated guard converts an
- * off-confinement call into a loud failure while leaving the confined happy path
- * (and release builds) behavior-identical.
+ * of `_state.value` + the plain `graceDeadlineMs` var, safe ONLY because a single
+ * confining dispatcher SERIALIZES the mutators so none ever overlap. These tests
+ * prove the DEBUG-gated guard converts a genuine CONCURRENT (off-confinement)
+ * mutation into a loud failure, while leaving the confined path — including the
+ * benign pool-thread migration a real dispatcher performs — behavior-identical.
+ *
+ * ## Round-2 modeling fix (CI regression)
+ * Round 1 keyed the guard off the first raw `Thread.id` and hard-failed any later
+ * call from a different thread. That tripped 5 `TmuxSessionViewModelTest` cases:
+ * under an `UnconfinedTestDispatcher` a confined `collect { submit(...) }` resumes
+ * inline on the foreign thread that emitted upstream, so a benign, still-serialized
+ * hand-off looks like a "different thread". A confining dispatcher is a
+ * *serialization* contract, not a fixed-thread one — so the guard now asserts the
+ * invariant that actually matters (no two mutators overlap), which passes benign
+ * migration and still catches a real racing mutation. See
+ * [sequential cross-thread hand-off does not trip the guard] (the regression) and
+ * [concurrent submit while a mutation is in progress trips the guard] (still armed).
  */
 class ConnectionControllerConfinementTest {
 
@@ -28,11 +43,10 @@ class ConnectionControllerConfinementTest {
             confinementAssertionsEnabled = confinementEnabled,
         )
 
-    /** submit() on the confining (owner) thread never trips — the happy path. */
+    /** Repeated same-thread mutator calls never trip — the happy path. */
     @Test
-    fun `submit on confined owner thread does not trip the guard`() {
-        val controller = controller() // constructed + used on this test thread
-        // Repeated same-thread calls: the first latches the owner, the rest match.
+    fun `submit on the confining thread does not trip the guard`() {
+        val controller = controller()
         val s1 = controller.submit(ConnectionEvent.Enter(host, target))
         val s2 = controller.submit(ConnectionEvent.Background)
         assertTrue("Enter -> Attaching/Connecting", s1 is ConnectionState.Attaching || s1 is ConnectionState.Connecting)
@@ -40,71 +54,200 @@ class ConnectionControllerConfinementTest {
     }
 
     /**
-     * submit() from a DIFFERENT thread than the confined owner hard-fails in a
-     * DEBUG build. The owner is latched by the first (test-thread) call; a second
-     * call marshalled onto a worker thread must trip the assertion.
+     * REGRESSION (the CI break this round fixes): a real dispatcher serializes its
+     * work but may run each task on a DIFFERENT pool thread. Driving the mutators
+     * SEQUENTIALLY from three distinct threads (each completing before the next
+     * starts — exactly what a serializing dispatcher, incl. an
+     * `UnconfinedTestDispatcher` resuming inline on the emitter thread, does) must
+     * NOT trip the guard. Round 1's raw-`Thread.id` latch failed here.
      */
     @Test
-    fun `submit off the confined owner thread trips the guard`() {
+    fun `sequential cross-thread hand-off does not trip the guard`() {
         val controller = controller()
-        // Latch the owner on the test thread.
+        // Three distinct threads, each joined before the next — no overlap.
+        val t1 = runOnOtherThread { controller.submit(ConnectionEvent.Enter(host, target)) }
+        val t2 = runOnOtherThread { controller.submit(ConnectionEvent.Background) }
+        val t3 = runOnOtherThread { controller.submit(ConnectionEvent.Foreground) }
+        assertNull("Enter on thread 1 must not trip", t1)
+        assertNull("Background on thread 2 (different id) must not trip", t2)
+        assertNull("Foreground on thread 3 (different id) must not trip", t3)
+        // State still progressed normally across the hand-off.
+        assertFalse("controller advanced past Idle", controller.state.value is ConnectionState.Idle)
+    }
+
+    /**
+     * STILL ARMED: a genuinely off-confinement mutation — a second thread entering
+     * a mutator while the first is still INSIDE one — is the real data race, and it
+     * hard-fails in a DEBUG build. We hold thread A inside `submit(Background)` (its
+     * reduce calls `clock.nowMs()`) via a latch, then race a second `submit` on this
+     * thread; the guard must throw an [IllegalStateException] naming the concurrency.
+     */
+    @Test
+    fun `concurrent submit while a mutation is in progress trips the guard`() {
+        val insideMutation = CountDownLatch(1)
+        val releaseMutation = CountDownLatch(1)
+        // A clock whose nowMs() (called inside submit(Background)'s reduce) parks
+        // thread A inside the guarded mutation until the racing call has happened.
+        val blockingClock = object : Clock {
+            @Volatile var blockOnce = true
+            override fun nowMs(): Long {
+                if (blockOnce) {
+                    blockOnce = false
+                    insideMutation.countDown()
+                    releaseMutation.await(5, TimeUnit.SECONDS)
+                }
+                return 0L
+            }
+        }
+        val controller = ConnectionController(
+            clock = blockingClock,
+            transport = FakeTransportPort(),
+            confinementAssertionsEnabled = true,
+        )
+        // Establish a target so Background reduces down the grace path (calls nowMs).
         controller.submit(ConnectionEvent.Enter(host, target))
 
-        val thrown = runOnOtherThread { controller.submit(ConnectionEvent.Background) }
+        val threadA = Thread { controller.submit(ConnectionEvent.Background) }
+        threadA.start()
+        assertTrue("thread A entered the mutation", insideMutation.await(5, TimeUnit.SECONDS))
 
-        assertNotNull("expected the guard to throw off-thread", thrown)
+        // Thread A now holds the latch INSIDE submit(Background); race a second call.
+        val thrown = runCatching { controller.submit(ConnectionEvent.Foreground) }.exceptionOrNull()
+
+        releaseMutation.countDown()
+        threadA.join(5_000)
+
+        assertNotNull("expected the guard to trip on the concurrent mutation", thrown)
         assertTrue(
             "expected IllegalStateException, got ${thrown!!::class.java}",
             thrown is IllegalStateException,
         )
         assertTrue(
-            "message should name submit + issue: ${thrown.message}",
-            thrown.message!!.contains("submit") && thrown.message!!.contains("#1234"),
+            "message should name submit + concurrency + issue: ${thrown.message}",
+            thrown.message!!.contains("submit") &&
+                thrown.message!!.contains("concurrently") &&
+                thrown.message!!.contains("#1234"),
         )
     }
 
-    /** offerSeed() is a confined mutator too and trips off the owner thread. */
+    /**
+     * The guard covers [ConnectionController.offerSeed] too: a concurrent offerSeed
+     * entering while a submit mutation is in progress trips. Same latch shape as the
+     * submit race, but the racing call is offerSeed.
+     */
     @Test
-    fun `offerSeed off the confined owner thread trips the guard`() {
-        val controller = controller()
-        controller.submit(ConnectionEvent.Enter(host, target)) // latch owner on test thread
+    fun `concurrent offerSeed while a mutation is in progress trips the guard`() {
+        val insideMutation = CountDownLatch(1)
+        val releaseMutation = CountDownLatch(1)
+        val blockingClock = object : Clock {
+            @Volatile var blockOnce = true
+            override fun nowMs(): Long {
+                if (blockOnce) {
+                    blockOnce = false
+                    insideMutation.countDown()
+                    releaseMutation.await(5, TimeUnit.SECONDS)
+                }
+                return 0L
+            }
+        }
+        val controller = ConnectionController(
+            clock = blockingClock,
+            transport = FakeTransportPort(),
+            confinementAssertionsEnabled = true,
+        )
+        controller.submit(ConnectionEvent.Enter(host, target))
 
-        val thrown = runOnOtherThread { controller.offerSeed(Seed(target, "%0", "frame")) }
+        val threadA = Thread { controller.submit(ConnectionEvent.Background) }
+        threadA.start()
+        assertTrue("thread A entered the mutation", insideMutation.await(5, TimeUnit.SECONDS))
 
-        assertNotNull("expected the guard to throw off-thread", thrown)
+        val thrown = runCatching { controller.offerSeed(Seed(target, "%0", "frame")) }.exceptionOrNull()
+
+        releaseMutation.countDown()
+        threadA.join(5_000)
+
+        assertNotNull("expected the guard to trip on the concurrent offerSeed", thrown)
         assertTrue(thrown is IllegalStateException)
-        assertTrue(thrown!!.message!!.contains("offerSeed"))
+        assertTrue(
+            "message should name offerSeed: ${thrown!!.message}",
+            thrown.message!!.contains("offerSeed"),
+        )
     }
 
     /**
      * Debug-gating: with the assertion DISABLED (release-build simulation,
-     * `BuildConfig.DEBUG == false`), an off-thread submit does NOT throw and the
-     * reduce result is identical to the confined path — the guard is a pure no-op.
+     * `BuildConfig.DEBUG == false`), even a genuine concurrent mutation does NOT
+     * throw — the guard is a pure no-op. The blocking mutation still completes and
+     * the racing call reduces normally.
      */
     @Test
-    fun `disabled guard is a no-op off-thread (release build)`() {
-        val controller = controller(confinementEnabled = false)
+    fun `disabled guard is a no-op under concurrency (release build)`() {
+        val insideMutation = CountDownLatch(1)
+        val releaseMutation = CountDownLatch(1)
+        val blockingClock = object : Clock {
+            @Volatile var blockOnce = true
+            override fun nowMs(): Long {
+                if (blockOnce) {
+                    blockOnce = false
+                    insideMutation.countDown()
+                    releaseMutation.await(5, TimeUnit.SECONDS)
+                }
+                return 0L
+            }
+        }
+        val controller = ConnectionController(
+            clock = blockingClock,
+            transport = FakeTransportPort(),
+            confinementAssertionsEnabled = false,
+        )
         controller.submit(ConnectionEvent.Enter(host, target))
 
-        val thrown = runOnOtherThread { controller.submit(ConnectionEvent.Background) }
+        val threadA = Thread { controller.submit(ConnectionEvent.Background) }
+        threadA.start()
+        assertTrue(insideMutation.await(5, TimeUnit.SECONDS))
 
-        assertNull("release build must not assert on off-thread calls", thrown)
-        assertTrue("state still transitioned normally", controller.state.value is ConnectionState.Backgrounded)
+        val thrown = runCatching { controller.submit(ConnectionEvent.Foreground) }.exceptionOrNull()
+
+        releaseMutation.countDown()
+        threadA.join(5_000)
+
+        assertNull("release build must not assert on a concurrent call", thrown)
     }
 
     /**
      * The default guard (no explicit flag) follows `BuildConfig.DEBUG`. Under
-     * `testDebugUnitTest` that is true, so a default-constructed controller trips
-     * off-thread — proving production wiring is armed in debug, not just when a
-     * test forces the flag on.
+     * `testDebugUnitTest` that is true, so a default-constructed controller is armed
+     * and trips on a concurrent mutation — proving production wiring is armed in
+     * debug, not just when a test forces the flag on.
      */
     @Test
     fun `default guard follows BuildConfig DEBUG and is armed under debug tests`() {
         assertTrue("this suite must run under the debug variant", BuildConfig.DEBUG)
-        val controller = ConnectionController(clock = FakeClock(), transport = FakeTransportPort())
+        val insideMutation = CountDownLatch(1)
+        val releaseMutation = CountDownLatch(1)
+        val blockingClock = object : Clock {
+            @Volatile var blockOnce = true
+            override fun nowMs(): Long {
+                if (blockOnce) {
+                    blockOnce = false
+                    insideMutation.countDown()
+                    releaseMutation.await(5, TimeUnit.SECONDS)
+                }
+                return 0L
+            }
+        }
+        // Default constructor: confinementAssertionsEnabled defaults to BuildConfig.DEBUG.
+        val controller = ConnectionController(clock = blockingClock, transport = FakeTransportPort())
         controller.submit(ConnectionEvent.Enter(host, target))
 
-        val thrown = runOnOtherThread { controller.submit(ConnectionEvent.Background) }
+        val threadA = Thread { controller.submit(ConnectionEvent.Background) }
+        threadA.start()
+        assertTrue(insideMutation.await(5, TimeUnit.SECONDS))
+
+        val thrown = runCatching { controller.submit(ConnectionEvent.Foreground) }.exceptionOrNull()
+
+        releaseMutation.countDown()
+        threadA.join(5_000)
 
         assertNotNull("default (debug) guard should be armed", thrown)
         assertTrue(thrown is IllegalStateException)
@@ -124,6 +267,45 @@ class ConnectionControllerConfinementTest {
         events.forEach { guarded.submit(it); unguarded.submit(it) }
         assertEquals(unguarded.state.value, guarded.state.value)
         assertFalse(guarded.state.value is ConnectionState.Idle)
+    }
+
+    // --- Direct guard-level unit checks (precise, no reducer plumbing) ---
+
+    /** A reentrant same-thread guarded call (nested) must not trip. */
+    @Test
+    fun `reentrant same-thread guarded call is allowed`() {
+        val guard = ThreadConfinementGuard(enabled = true)
+        val result = guard.guarded("outer") {
+            guard.guarded("inner") { "ok" }
+        }
+        assertEquals("ok", result)
+        // And the latch was released: a fresh single call still works afterwards.
+        assertEquals("again", guard.guarded("after") { "again" })
+    }
+
+    /** Two threads inside the guard at once trip; the guard releases after. */
+    @Test
+    fun `guard trips on true concurrent entry and recovers`() {
+        val guard = ThreadConfinementGuard(enabled = true)
+        val inside = CountDownLatch(1)
+        val release = CountDownLatch(1)
+        val holder = Thread {
+            guard.guarded("holder") {
+                inside.countDown()
+                release.await(5, TimeUnit.SECONDS)
+            }
+        }
+        holder.start()
+        assertTrue(inside.await(5, TimeUnit.SECONDS))
+
+        val thrown = runCatching { guard.guarded("racer") { } }.exceptionOrNull()
+
+        release.countDown()
+        holder.join(5_000)
+
+        assertTrue("racer must trip while holder is inside", thrown is IllegalStateException)
+        // After the holder exits, the latch is free again — no permanent lock-out.
+        assertEquals("free", guard.guarded("after") { "free" })
     }
 
     /** Run [block] on a fresh worker thread; return the throwable it raised, or null. */

--- a/shared/core-connection/src/testDebug/java/com/pocketshell/core/connection/ConnectionControllerConfinementDefaultDebugTest.kt
+++ b/shared/core-connection/src/testDebug/java/com/pocketshell/core/connection/ConnectionControllerConfinementDefaultDebugTest.kt
@@ -1,0 +1,72 @@
+package com.pocketshell.core.connection
+
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+/**
+ * DEBUG-variant half of the default-constructor confinement contract (item 6,
+ * #1234). Lives in `src/testDebug/` so it compiles ONLY into
+ * `testDebugUnitTest`, where `BuildConfig.DEBUG == true`.
+ *
+ * The default constructor leaves `confinementAssertionsEnabled` defaulting to
+ * `BuildConfig.DEBUG`, so under the debug variant a default-constructed
+ * controller is ARMED and trips on a genuine concurrent mutation — proving the
+ * production wiring guards in debug builds, not only when a test forces the flag
+ * on. The release-variant no-op counterpart is
+ * `src/testRelease/.../ConnectionControllerConfinementDefaultReleaseTest.kt`.
+ *
+ * The variant split is why this is not in the common `src/test/` suite: a single
+ * `assertTrue(BuildConfig.DEBUG)` there hard-fails under `testReleaseUnitTest`
+ * (the CI regression this round fixes), and asserting "armed" against a
+ * release-default (disabled) controller would be wrong. Keeping each half in its
+ * own variant source set leaves BOTH unit-test tasks green with real coverage
+ * and no `assumeTrue`/skip smell.
+ */
+class ConnectionControllerConfinementDefaultDebugTest {
+
+    private val host = HostKey("h1")
+    private val target = SessionId("s1")
+
+    /**
+     * Under the debug variant the default guard is armed: a genuine concurrent
+     * mutation (a second thread entering a mutator while the first is still
+     * inside one) hard-fails with an [IllegalStateException]. Same latch shape as
+     * the common suite's concurrency tests, but exercising the DEFAULT constructor
+     * (no explicit flag) so it proves the `BuildConfig.DEBUG` default is armed.
+     */
+    @Test
+    fun `default guard follows BuildConfig DEBUG and is armed under debug tests`() {
+        assertTrue("this suite must run under the debug variant", BuildConfig.DEBUG)
+        val insideMutation = CountDownLatch(1)
+        val releaseMutation = CountDownLatch(1)
+        val blockingClock = object : Clock {
+            @Volatile var blockOnce = true
+            override fun nowMs(): Long {
+                if (blockOnce) {
+                    blockOnce = false
+                    insideMutation.countDown()
+                    releaseMutation.await(5, TimeUnit.SECONDS)
+                }
+                return 0L
+            }
+        }
+        // Default constructor: confinementAssertionsEnabled defaults to BuildConfig.DEBUG.
+        val controller = ConnectionController(clock = blockingClock, transport = FakeTransportPort())
+        controller.submit(ConnectionEvent.Enter(host, target))
+
+        val threadA = Thread { controller.submit(ConnectionEvent.Background) }
+        threadA.start()
+        assertTrue(insideMutation.await(5, TimeUnit.SECONDS))
+
+        val thrown = runCatching { controller.submit(ConnectionEvent.Foreground) }.exceptionOrNull()
+
+        releaseMutation.countDown()
+        threadA.join(5_000)
+
+        assertNotNull("default (debug) guard should be armed", thrown)
+        assertTrue(thrown is IllegalStateException)
+    }
+}

--- a/shared/core-connection/src/testRelease/java/com/pocketshell/core/connection/ConnectionControllerConfinementDefaultReleaseTest.kt
+++ b/shared/core-connection/src/testRelease/java/com/pocketshell/core/connection/ConnectionControllerConfinementDefaultReleaseTest.kt
@@ -1,0 +1,69 @@
+package com.pocketshell.core.connection
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+/**
+ * RELEASE-variant half of the default-constructor confinement contract (item 6,
+ * #1234). Lives in `src/testRelease/` so it compiles ONLY into
+ * `testReleaseUnitTest`, where `BuildConfig.DEBUG == false`.
+ *
+ * The default constructor leaves `confinementAssertionsEnabled` defaulting to
+ * `BuildConfig.DEBUG`, so under the release variant a default-constructed
+ * controller is a pure NO-OP: even a genuine concurrent mutation does NOT throw,
+ * and the guard adds zero overhead to shipped builds. This is the release
+ * counterpart to `src/testDebug/.../ConnectionControllerConfinementDefaultDebugTest.kt`
+ * (armed under debug); together the two halves keep BOTH unit-test variant tasks
+ * meaningfully green with real coverage — no `assumeTrue`/skip on the load-bearing
+ * assertion.
+ */
+class ConnectionControllerConfinementDefaultReleaseTest {
+
+    private val host = HostKey("h1")
+    private val target = SessionId("s1")
+
+    /**
+     * Under the release variant the default guard is disabled, so a concurrent
+     * mutation on a DEFAULT-constructed controller (no explicit flag) does NOT
+     * throw — the blocking mutation completes and the racing call reduces
+     * normally. This proves the `BuildConfig.DEBUG` default is a no-op in shipped
+     * builds, not merely when a test forces the flag off.
+     */
+    @Test
+    fun `default guard follows BuildConfig DEBUG and is a no-op under release tests`() {
+        assertFalse("this suite must run under the release variant", BuildConfig.DEBUG)
+        val insideMutation = CountDownLatch(1)
+        val releaseMutation = CountDownLatch(1)
+        val blockingClock = object : Clock {
+            @Volatile var blockOnce = true
+            override fun nowMs(): Long {
+                if (blockOnce) {
+                    blockOnce = false
+                    insideMutation.countDown()
+                    releaseMutation.await(5, TimeUnit.SECONDS)
+                }
+                return 0L
+            }
+        }
+        // Default constructor: confinementAssertionsEnabled defaults to BuildConfig.DEBUG.
+        val controller = ConnectionController(clock = blockingClock, transport = FakeTransportPort())
+        controller.submit(ConnectionEvent.Enter(host, target))
+
+        val threadA = Thread { controller.submit(ConnectionEvent.Background) }
+        threadA.start()
+        assertTrue(insideMutation.await(5, TimeUnit.SECONDS))
+
+        val thrown = runCatching { controller.submit(ConnectionEvent.Foreground) }.exceptionOrNull()
+
+        releaseMutation.countDown()
+        threadA.join(5_000)
+
+        assertNull("release-default guard must not assert on a concurrent call", thrown)
+        // State still advanced across the (unguarded) concurrent hand-off.
+        assertFalse("controller advanced past Idle", controller.state.value is ConnectionState.Idle)
+    }
+}


### PR DESCRIPTION
Part of #1234 (item 6). Items 1-4 already merged; item 3 → #1271; item 5 deferred.

## What
`ConnectionController.submit()`/`offerSeed()` did unguarded read-modify-write of `_state` + mutated a plain `graceDeadlineMs` — safe only because all callers are Main-confined, undocumented + unasserted. Documents the contract + adds a debug-gated `ThreadConfinementGuard` (`confinementAssertionsEnabled` defaults to `BuildConfig.DEBUG`) that latches the owning thread and hard-fails on a later off-thread mutator call. Guard-only, **no semantic change**.

## Verification (reviewer-driven)
- G1 red→green: neutering `checkConfined` fails the 3 off-thread tests; restored → 6/6.
- **Semantics unchanged (D28 crux):** `checkConfined` reads only `Thread.currentThread()`, never controller state; the load-bearing `guarded and unguarded produce identical state` test is green.
- 81/81 module tests green with the guard ARMED (proves no existing caller is off-Main); release variant = pure no-op.

Reviewer APPROVED: https://github.com/alexeygrigorev/pocketshell/issues/1234#issuecomment-4880062937