### PR TITLE
conversation: restore tab for an agent run inside a shell-recorded session (#1158)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/tmux/ConversationToggleVisibleForLiveAgentInShellRecordedSessionDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/ConversationToggleVisibleForLiveAgentInShellRecordedSessionDockerTest.kt
@@ -355,6 +355,105 @@ class ConversationToggleVisibleForLiveAgentInShellRecordedSessionDockerTest {
         Unit
     } }
 
+    /**
+     * Issue #1158 (REOPENED — maintainer's EXACT dogfood path, 2026-07-01) — an
+     * agent launched DIRECTLY inside an existing shell tmux session (NOT via the
+     * `pocketshell agent` wrapper). Result on-device: the Conversation tab is NEVER
+     * shown — the user is stranded on the raw (often black) Terminal for the whole
+     * session. Root cause: the session recorded `@ps_agent_kind=shell` (so
+     * `recordedAgentKind == false`), the confirmed-shell verdict is never cleared,
+     * and live detection never binds for the node-wrapped-Claude / Codex-`/proc` /
+     * Z.AI fleet — so every prior tab signal is false and the toggle is gone for the
+     * session's life.
+     *
+     * The durable fix is the detection-INDEPENDENT alt-buffer positive signal: a
+     * full-screen agent TUI holds the ALTERNATE screen buffer, which the tmux
+     * ViewModel latches STICKY and OR's into `showsConversationTab`.
+     *
+     * ### #780 synthetic-state model (no self-skip — hard-fail)
+     *
+     * The tmux `-CC` control path does not reliably mirror a REMOTE pane's alternate
+     * screen buffer into the CLIENT emulator (the capture-pane seed replays the
+     * screen TEXT onto the main buffer, and an idle full-screen agent emits no fresh
+     * `%output` carrying the `?1049h` toggle), so a connected journey cannot enter
+     * the on-device alt-buffer state on its own. Per D33/#780 the failing state is
+     * injected SYNTHETICALLY on the REAL connected pane
+     * ([TmuxSessionViewModel.forceActivePaneAltBufferForTest]) — the ONLY synthetic
+     * part; the recorded-shell verdict, the detection-never-binds state, the real
+     * production tab gate and the real chrome rendering are all live. It HARD-fails
+     * (no `assumeTrue`) so CI carries real protection.
+     *
+     * RED on base: with no `|| altBufferAgent` term the toggle stays absent even
+     * with the alt-buffer injected (the maintainer's symptom). GREEN with the fix:
+     * the latch shows the toggle, and it STAYS after the buffer leaves alt-mode
+     * (sticky).
+     */
+    @Test
+    fun conversationToggleAppearsForAltBufferAgentDirectlyLaunchedInShellSession() { runBlocking {
+        val hostRowTag = requireNotNull(seededHostRowTag) { "seed-before-launch host row missing" }
+        val sessionName = requireNotNull(seededSessionName) { "seed-before-launch session missing" }
+
+        attachToSeededSession(hostRowTag, sessionName)
+        waitForTerminalSessionAttached()
+        waitForVisibleTerminalText("issue962-plain-ready", VISIBLE_TIMEOUT_MS) {
+            "issue962-plain-ready" in it
+        }
+        stamp("altbuf_shell_attached session=$sessionName")
+
+        // Settle so the recorded `@ps_agent_kind=shell` verdict applies and live
+        // detection has a generous window to (not) fire — the exact base state where
+        // the toggle is absent for the maintainer.
+        val vm = currentViewModel()
+        val verdictObserved = waitForConfirmedShellVerdict(vm)
+        stamp("altbuf_confirmed_shell_verdict_observed=$verdictObserved")
+        SystemClock.sleep(SHELL_NO_TOGGLE_SETTLE_MS)
+        val detectionBound = vm.agentConversations.value.values.any { it.detection != null }
+        stamp("altbuf_detection_bound=$detectionBound")
+
+        // Precondition (the maintainer's symptom, base state): NO Conversation toggle
+        // — the recorded shell + no detection leaves only the "Terminal" pill.
+        compose.onNodeWithTag(TMUX_TABS_TAG, useUnmergedTree = true).assertDoesNotExist()
+        captureFullFrame("issue1158-altbuf-before-no-toggle")
+        stamp("altbuf_no_toggle_before_ok")
+
+        // The agent goes full-screen: the pane's emulator switches to the ALTERNATE
+        // screen buffer. Injected synthetically on the REAL connected pane (#780) —
+        // the on-device signal a full-screen Claude/Codex TUI produces.
+        compose.activityRule.scenario.onActivity { vm.forceActivePaneAltBufferForTest(true) }
+        compose.waitUntil(timeoutMillis = MASKED_TOGGLE_TIMEOUT_MS) {
+            vm.altBufferAgentPaneIds.value.isNotEmpty()
+        }
+        stamp("altbuf_latched=${vm.altBufferAgentPaneIds.value.isNotEmpty()}")
+
+        // DURABLE UI (load-bearing): the Terminal/Conversation toggle now appears,
+        // driven purely by the alt-buffer signal (detection is still null). RED on
+        // base (no `|| altBufferAgent`), GREEN with the fix.
+        compose.waitUntil(timeoutMillis = MASKED_TOGGLE_TIMEOUT_MS) {
+            compose.onAllNodesWithTag(TMUX_TABS_TAG, useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
+        compose.onNodeWithTag(TMUX_TABS_TAG, useUnmergedTree = true).assertExists()
+        compose.waitUntil(timeoutMillis = MASKED_TOGGLE_TIMEOUT_MS) {
+            compose.onAllNodesWithText("Conversation", useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
+        compose.onNodeWithText("Conversation", useUnmergedTree = true).assertExists()
+        captureFullFrame("issue1158-altbuf-toggle-appears")
+        stamp("altbuf_toggle_appears_ok")
+
+        // STICKY: the agent leaves the alt-buffer (exits its full-screen view /
+        // detection stays null). The toggle MUST remain for the session's life.
+        compose.activityRule.scenario.onActivity { vm.forceActivePaneAltBufferForTest(false) }
+        SystemClock.sleep(SHELL_NO_TOGGLE_SETTLE_MS)
+        compose.onNodeWithTag(TMUX_TABS_TAG, useUnmergedTree = true).assertExists()
+        compose.onNodeWithText("Conversation", useUnmergedTree = true).assertExists()
+        captureFullFrame("issue1158-altbuf-toggle-sticky")
+        stamp("altbuf_toggle_sticky_ok")
+        Unit
+    } }
+
     // -------------------------------------------------------------- seed-before-launch
 
     /**
@@ -375,6 +474,8 @@ class ConversationToggleVisibleForLiveAgentInShellRecordedSessionDockerTest {
                 seedPlainShellSession(key)
             "conversationTogglePresentForRecordedCodexAgentWhenSourceBindingFails" ->
                 seedRecordedCodexNoTranscriptSession(key)
+            "conversationToggleAppearsForAltBufferAgentDirectlyLaunchedInShellSession" ->
+                seedPlainShellSession(key)
             else -> error("unexpected test method $methodName")
         }
         seededSessionName = sessionName

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
@@ -68,6 +68,7 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.State
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -1596,22 +1597,24 @@ public fun TmuxSessionScreen(
             // flush but the resulting [TmuxSessionTabState] is structurally equal,
             // so the body is not invalidated.
             // Issue #1158: the active session's RECORDED agent kind
-            // (`@ps_agent_kind`, collected above at [currentSessionRecordedKind])
-            // projected to a stable boolean so it can force the Conversation tab
-            // present for a recorded agent even when live detection /
-            // transcript-source binding never bound. Independent of the
-            // per-pane `presumedAgent` gate so a recorded Codex / Z.AI-Claude
-            // session shows the toggle regardless of the fragile binding.
-            val recordedAgentKind = tmuxSessionRecordedAgentKind(currentSessionRecordedKind)
-            val tabState by remember(surfaceConversationPaneId, presumedAgent, recordedAgentKind) {
-                derivedStateOf {
-                    tmuxSessionTabState(
-                        surfaceConversationPaneId?.let { agentConversationsState.value[it] },
-                        presumedAgent,
-                        recordedAgentKind,
-                    )
-                }
-            }
+            // (`@ps_agent_kind`) AND the sticky alt-buffer agent signal are both
+            // folded into [rememberTmuxSessionTabState], an extracted @Composable,
+            // so the `recordedAgentKind` projection, the `altBufferAgentPaneIds`
+            // collectAsState, the `altBufferAgent` derivation and the
+            // `derivedStateOf` remember all live in THAT small method's register
+            // frame instead of this enormous body. That is the R2 fix: the extra
+            // locals had inflated [TmuxSessionScreen]'s method past ART's dex
+            // verifier register limit (`v273` VerifyError) and crashed the session
+            // screen at class load. Same recomposition semantics as the previous
+            // inline block — the returned [State] is read via `by` here so the
+            // derived-state read stays attributed to this caller's restart scope.
+            val tabState by rememberTmuxSessionTabState(
+                viewModel = viewModel,
+                surfaceConversationPaneId = surfaceConversationPaneId,
+                presumedAgent = presumedAgent,
+                currentSessionRecordedKind = currentSessionRecordedKind,
+                agentConversationsState = agentConversationsState,
+            )
             val onTabSelected: (Int) -> Unit = { index ->
                 if (index == 1) {
                     // Issue #778: honour a Conversation tap whenever the tab is
@@ -3759,6 +3762,64 @@ internal fun tmuxSessionShouldPromoteSettledCachedPane(
 }
 
 /**
+ * Issue #1158 (R2 ART VerifyError fix): the session's Terminal/Conversation
+ * [TmuxSessionTabState], derived in its OWN @Composable so the alt-buffer wiring
+ * does not inflate the enormous [TmuxSessionScreen] method past ART's dex
+ * verifier register limit.
+ *
+ * The reviewer found that adding the `altBufferAgentPaneIds` collectAsState, the
+ * `altBufferAgent` local and the extra `remember(...)` key directly into the
+ * mega-composable body tipped its method past the ART verifier's register
+ * ceiling (`VerifyError ... copy1 v273<-...`), so the session screen — the app's
+ * MAIN screen — crashed at class load on-device (invisible to the JVM verifier).
+ * Extracting the derivation here moves ALL of that register pressure
+ * (`recordedAgentKind` projection, `altBufferAgentPaneIds` collectAsState,
+ * `altBufferAgent` derivation, the `derivedStateOf` remember) into this small
+ * method's own frame, letting [TmuxSessionScreen] verify again.
+ *
+ * Behaviour is IDENTICAL to the previous inline block: it returns a
+ * [State]<[TmuxSessionTabState]> which the caller reads via `by`, so the
+ * derived-state read stays attributed to the caller's restart scope and the tab
+ * chrome still stays OFF the 60ms agent-streaming flush (#1085). The alt-buffer
+ * signal is a detection-INDEPENDENT positive agent signal (see
+ * [TmuxSessionViewModel.altBufferAgentPaneIds]); a plain shell on the main buffer
+ * never latches it, preserving the #894/#815 no-flap invariant.
+ */
+@Composable
+private fun rememberTmuxSessionTabState(
+    viewModel: TmuxSessionViewModel,
+    surfaceConversationPaneId: String?,
+    presumedAgent: Boolean,
+    currentSessionRecordedKind: SessionAgentKind?,
+    agentConversationsState: State<Map<String, AgentConversationUiState>>,
+): State<TmuxSessionTabState> {
+    val recordedAgentKind = tmuxSessionRecordedAgentKind(currentSessionRecordedKind)
+    // Issue #1158: the STICKY set of pane ids whose emulator has been seen on the
+    // ALTERNATE screen buffer — the detection-independent positive agent signal
+    // that keeps the Conversation tab reachable for an agent launched directly
+    // inside a shell-recorded session (where `@ps_agent_kind=shell`, the
+    // confirmed-shell verdict is never cleared, and live detection never binds).
+    val altBufferAgentPaneIds by viewModel.altBufferAgentPaneIds.collectAsState()
+    val altBufferAgent = surfaceConversationPaneId != null &&
+        surfaceConversationPaneId in altBufferAgentPaneIds
+    return remember(
+        surfaceConversationPaneId,
+        presumedAgent,
+        recordedAgentKind,
+        altBufferAgent,
+    ) {
+        derivedStateOf {
+            tmuxSessionTabState(
+                surfaceConversationPaneId?.let { agentConversationsState.value[it] },
+                presumedAgent,
+                recordedAgentKind,
+                altBufferAgent,
+            )
+        }
+    }
+}
+
+/**
  * Issue #1158 (recurrence of #962/#1057): whether the tree has RECORDED this
  * session as a known agent kind (Claude / Codex / OpenCode), independent of
  * whether live agent-detection or conversation-source binding has succeeded.
@@ -3797,6 +3858,7 @@ internal fun tmuxSessionTabState(
     currentAgentConversation: AgentConversationUiState?,
     presumedAgent: Boolean = false,
     recordedAgentKind: Boolean = false,
+    altBufferAgent: Boolean = false,
 ): TmuxSessionTabState {
     // The Conversation tab exists for a live-detected agent OR a presumed
     // agent (#716). Issue #778: the active index now follows the user's
@@ -3846,9 +3908,22 @@ internal fun tmuxSessionTabState(
     // the user reaches the existing Placeholder/Failed surface
     // ([tmuxSessionConversationSurface]) — the whole tab is NEVER collapsed on a
     // source-binding hiccup.
+    //
+    // Issue #1158 (REOPENED — the maintainer still can't reach conversations when
+    // an agent is launched DIRECTLY inside an existing shell session, so nothing
+    // ever recorded `@ps_agent_kind` and live detection never binds for the
+    // node-wrapped-Claude / Codex-`/proc` / Z.AI fleet). [altBufferAgent] is a
+    // detection-INDEPENDENT positive agent signal: the visible pane's emulator is
+    // on the ALTERNATE screen buffer, which a full-screen agent TUI holds for its
+    // whole run while a plain shell at a prompt does not. It is fed STICKY from the
+    // VM ([TmuxSessionViewModel.altBufferAgentPaneIds]) — once a pane/session has
+    // been seen on the alt-buffer the tab stays for the session's life even if the
+    // buffer later leaves alt-mode or detection drops. Because it is a POSITIVE
+    // signal, a genuine plain interactive shell (main buffer) still shows NO
+    // Conversation tab, preserving the #894/#815 no-flap invariant.
     val showsConversationTab =
         hasLiveDetection || presumedAgent || hasConversationContent ||
-            userOpenedConversation || recordedAgentKind
+            userOpenedConversation || recordedAgentKind || altBufferAgent
     return TmuxSessionTabState(
         labels = if (showsConversationTab) listOf("Terminal", "Conversation") else listOf("Terminal"),
         selectedIndex = if (showsConversationTab && userOpenedConversation) 1 else 0,

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -2195,6 +2195,43 @@ public class TmuxSessionViewModel @Inject constructor(
         _confirmedShellPaneIds.asStateFlow()
 
     /**
+     * Issue #1158 (REOPENED chain #962→#975→#1057→#1158): the STICKY set of tmux
+     * session ids whose visible pane has been observed on the ALTERNATE screen
+     * buffer — the maintainer's real "agent launched directly inside an existing
+     * shell" case. That session records `@ps_agent_kind=shell`, so the
+     * confirmed-shell verdict is never cleared (live detection never binds for
+     * node-wrapped Claude / Codex `/proc` / Z.AI transcript-path fleets), and
+     * every other tab signal is false — the Conversation tab was gone for the
+     * session's whole life. A full-screen agent TUI holds the alternate buffer for
+     * its run, which [TerminalSurfaceState.isAlternateBufferActive] reports
+     * detection-INDEPENDENTLY.
+     *
+     * STICKY (latch): a session is only ever ADDED here, never removed within a
+     * runtime — once the tab has been shown it stays for the session's life even
+     * if the buffer later leaves alt-mode or detection drops, so a failed/again-
+     * null detection can't collapse the tab back to Terminal-only. Cleared only
+     * with the other per-runtime caches on park/restore/clear so a different
+     * session never inherits a stale latch.
+     *
+     * POSITIVE signal: a genuine plain shell at a prompt (main buffer) never
+     * enters this set, so the #894/#815 no-flap invariant holds.
+     */
+    private val altBufferAgentSessionIds: MutableSet<String> =
+        ConcurrentHashMap.newKeySet()
+
+    /**
+     * Issue #1158: the per-pane projection of [altBufferAgentSessionIds] over the
+     * current pane rows, consumed by the screen to force the Conversation tab
+     * present on the visible pane. Mirrors [confirmedShellPaneIds]'s shape:
+     * republished whenever the pane set changes or a new alt-buffer sighting
+     * latches a session.
+     */
+    private val _altBufferAgentPaneIds: MutableStateFlow<Set<String>> =
+        MutableStateFlow(emptySet())
+    public val altBufferAgentPaneIds: StateFlow<Set<String>> =
+        _altBufferAgentPaneIds.asStateFlow()
+
+    /**
      * Issue #858: the active session's recorded NON-default profile label
      * (e.g. `"Claude (Z.AI)"`), read fresh from the host-side
      * `@ps_agent_profile` tmux user option alongside the kind. `null` for a
@@ -5854,6 +5891,10 @@ public class TmuxSessionViewModel @Inject constructor(
         // different session never inherits a stale shell verdict.
         confirmedShellSessionIds.clear()
         _confirmedShellPaneIds.value = emptySet()
+        // Issue #1158: drop the sticky alt-buffer agent latch with the other
+        // per-runtime caches so a different session never inherits a stale verdict.
+        altBufferAgentSessionIds.clear()
+        _altBufferAgentPaneIds.value = emptySet()
         clearAgentConversations()
         // Issue #448: drop any pending forward overlay when this runtime
         // is parked to the cache — it belongs to the view we're leaving.
@@ -5992,6 +6033,10 @@ public class TmuxSessionViewModel @Inject constructor(
         // the `@ps_agent_kind` on the restored connection and re-derives it.
         confirmedShellSessionIds.clear()
         _confirmedShellPaneIds.value = emptySet()
+        // Issue #1158: drop the sticky alt-buffer agent latch with the other
+        // per-runtime caches so a different session never inherits a stale verdict.
+        altBufferAgentSessionIds.clear()
+        _altBufferAgentPaneIds.value = emptySet()
         paneAgentInputs.putAll(runtime.paneAgentInputs)
         replaceAgentConversations(runtime.agentConversations)
         remoteColumns = runtime.remoteColumns
@@ -10163,6 +10208,10 @@ public class TmuxSessionViewModel @Inject constructor(
         // a pane added/removed by this reconcile picks up (or drops) its
         // session's durable shell verdict for the screen + seed gate.
         refreshConfirmedShellPaneIds()
+        // Issue #1158: republish the sticky alt-buffer agent signal so a pane
+        // added by this reconcile for an already-latched session keeps the
+        // Conversation tab (the latch is per-session; the pane id can rotate).
+        refreshAltBufferAgentPaneIds()
         rebuildUnifiedPanes()
         return newRows
     }
@@ -11553,6 +11602,12 @@ public class TmuxSessionViewModel @Inject constructor(
                     tick += 1
                     continue
                 }
+                // Issue #1158: latch the visible pane's alt-buffer agent signal on
+                // the tick we already pay for (cheap local emulator read, no SSH
+                // round-trip, no new timer). Sticky — this is how the Conversation
+                // tab appears for an agent launched directly in a shell-recorded
+                // session where detection never binds.
+                noteActivePaneAltBufferState()
                 val activePane = activeVisiblePane()
                 if (activePane != null) {
                     val healed = runCatching {
@@ -12553,6 +12608,71 @@ public class TmuxSessionViewModel @Inject constructor(
         if (_confirmedShellPaneIds.value != next) {
             _confirmedShellPaneIds.value = next
         }
+    }
+
+    /**
+     * Issue #1158: read the VISIBLE pane's alternate-screen-buffer state and, when
+     * active, LATCH its session into [altBufferAgentSessionIds] (sticky — never
+     * removed within the runtime). Cheap: a single local emulator read, no SSH
+     * round-trip — safe to call on the existing stale-render watchdog tick (no new
+     * timer, respects #1164/#1166). Republishes the per-pane projection only when a
+     * NEW session is latched, so steady-state ticks allocate nothing.
+     *
+     * A no-op for a plain shell on the main buffer (the #894/#815 no-flap
+     * invariant): nothing is latched, so the Conversation tab stays hidden.
+     */
+    private fun noteActivePaneAltBufferState() {
+        val pane = activeVisiblePane() ?: return
+        if (!pane.terminalState.isAlternateBufferActive()) return
+        val sessionId = pane.sessionId.trim()
+        if (sessionId.isEmpty()) return
+        if (altBufferAgentSessionIds.add(sessionId)) {
+            refreshAltBufferAgentPaneIds()
+        }
+    }
+
+    /**
+     * Issue #1158: recompute [altBufferAgentPaneIds] from the current pane rows and
+     * the sticky [altBufferAgentSessionIds] latch. Called after a new alt-buffer
+     * sighting and on pane reconcile so a pane added to a latched session picks up
+     * (and never drops) the signal.
+     */
+    private fun refreshAltBufferAgentPaneIds() {
+        val next = paneRows.values
+            .filter { altBufferAgentSessionIds.contains(it.sessionId.trim()) }
+            .map { it.paneId }
+            .toSet()
+        if (_altBufferAgentPaneIds.value != next) {
+            _altBufferAgentPaneIds.value = next
+        }
+    }
+
+    /**
+     * Issue #1158 test seam: drive the alt-buffer poll directly (the production
+     * caller is the stale-render watchdog tick, which a JVM unit test would have to
+     * stand up a whole runtime to reach) so a test can prove the sticky latch +
+     * per-pane projection deterministically against a synthetic alt-buffer state.
+     */
+    @androidx.annotation.VisibleForTesting
+    internal fun noteActivePaneAltBufferStateForTest() {
+        noteActivePaneAltBufferState()
+    }
+
+    /**
+     * Issue #1158 connected-test seam (#780 synthetic-state model): force the REAL
+     * active pane's emulator alt-buffer verdict, then run the production latch poll.
+     * The tmux `-CC` control path does not reliably mirror a REMOTE pane's alternate
+     * screen buffer into the CLIENT emulator (the capture-pane seed replays the
+     * screen TEXT onto the main buffer, and an idle full-screen agent emits no fresh
+     * `%output` carrying the `?1049h` toggle), so a connected journey cannot enter
+     * the on-device alt-buffer state on its own. This injects that failing state
+     * synthetically on the REAL connected pane + real production tab gate, exactly
+     * as the maintainer's full-screen agent TUI would — with NO self-skip.
+     */
+    @androidx.annotation.VisibleForTesting
+    internal fun forceActivePaneAltBufferForTest(active: Boolean) {
+        activeVisiblePane()?.terminalState?.setAlternateBufferActiveForTest(active)
+        noteActivePaneAltBufferState()
     }
 
     /**
@@ -17335,6 +17455,10 @@ public class TmuxSessionViewModel @Inject constructor(
         // different session never inherits a stale shell verdict.
         confirmedShellSessionIds.clear()
         _confirmedShellPaneIds.value = emptySet()
+        // Issue #1158: drop the sticky alt-buffer agent latch with the other
+        // per-runtime caches so a different session never inherits a stale verdict.
+        altBufferAgentSessionIds.clear()
+        _altBufferAgentPaneIds.value = emptySet()
         _agentConversations.value = emptyMap()
         // Issue #959 (#780 synthetic-injection seam): when the test forces the
         // pane-runtime-survives-teardown race, KEEP paneRows + their producers +
@@ -17491,6 +17615,10 @@ public class TmuxSessionViewModel @Inject constructor(
         // different session never inherits a stale shell verdict.
         confirmedShellSessionIds.clear()
         _confirmedShellPaneIds.value = emptySet()
+        // Issue #1158: drop the sticky alt-buffer agent latch with the other
+        // per-runtime caches so a different session never inherits a stale verdict.
+        altBufferAgentSessionIds.clear()
+        _altBufferAgentPaneIds.value = emptySet()
         paneInputJobs.clear()
         paneInputQueues.clear()
         _agentConversations.value = emptyMap()

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionScreenTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionScreenTest.kt
@@ -745,6 +745,108 @@ class TmuxSessionScreenTest {
         assertTrue(!state.showsConversationTab)
     }
 
+    // ─── Issue #1158 (REOPENED chain #962→#975→#1057→#1158): the maintainer's ──
+    // REAL path — an agent launched DIRECTLY inside an existing shell session, so
+    // nothing recorded `@ps_agent_kind` (it stays `shell`), the confirmed-shell
+    // verdict is never cleared, and live detection never binds for the
+    // node-wrapped-Claude / Codex-`/proc` / Z.AI fleet. Every prior signal is
+    // false → the tab was gone for the session's whole life. The detection-
+    // INDEPENDENT alt-buffer signal ([altBufferAgent]) restores it: a full-screen
+    // agent TUI holds the alternate screen buffer for its run, which a plain shell
+    // at a prompt does not.
+    //
+    // RED→GREEN: on base — remove the `|| altBufferAgent` OR-term from
+    // `tmuxSessionTabState.showsConversationTab` — each alt-buffer case below FAILS
+    // (single "Terminal" pill, no toggle), exactly the maintainer's #1158 symptom.
+    // With the fix the term is present and they GREEN, while the plain-shell
+    // main-buffer no-flap control (#894/#815) stays GREEN either way. The alt-buffer
+    // signal is kind-AGNOSTIC (it reads the emulator, not `@ps_agent_kind`), so ONE
+    // case covers node-wrapped Claude, Codex, glm/Z.AI AND the missing-data
+    // kind=null fleet — they are indistinguishable at this gate; the parametrized
+    // sibling below locks that independence. ──────────────────────────────────────
+
+    @Test
+    fun tmuxSessionTabStateShowsConversationForAltBufferAgentOnShellRecordedSession() {
+        // The maintainer's EXACT reported path: `@ps_agent_kind=shell`
+        // (recordedAgentKind == false), confirmed-shell surface
+        // (presumedAgent == false), NO live detection, NO transcript content — yet
+        // the visible pane is on the ALTERNATE screen buffer (a full-screen agent
+        // TUI is running). The tab MUST be present. RED on base.
+        val state = tmuxSessionTabState(
+            currentAgentConversation = null,
+            presumedAgent = false,
+            recordedAgentKind = false,
+            altBufferAgent = true,
+        )
+
+        assertEquals(listOf("Terminal", "Conversation"), state.labels)
+        assertEquals(0, state.selectedIndex)
+        assertTrue(state.showsConversationTab)
+    }
+
+    @Test
+    fun tmuxSessionTabStateShowsConversationForAltBufferAgentOnForeignNullKindSession() {
+        // The missing-data (kind = null) fleet: a foreign session the app didn't
+        // launch, so there is no recorded kind AND no bindable transcript — but its
+        // visible pane is on the alt-buffer. The tab MUST be present. RED on base.
+        val state = tmuxSessionTabState(
+            currentAgentConversation = AgentConversationUiState(
+                detection = null,
+                selectedTab = SessionTab.Terminal,
+            ),
+            presumedAgent = false,
+            recordedAgentKind = tmuxSessionRecordedAgentKind(null),
+            altBufferAgent = true,
+        )
+
+        assertTrue(state.showsConversationTab)
+        assertEquals(listOf("Terminal", "Conversation"), state.labels)
+    }
+
+    @Test
+    fun tmuxSessionTabStateAltBufferSignalIsIndependentOfRecordedKindAcrossFleet() {
+        // Class coverage (G2): the alt-buffer signal alone shows the tab regardless
+        // of what (if anything) the tree recorded — node-wrapped Claude, Codex,
+        // glm/Z.AI AND the null/unknown foreign case — all reach the tab through the
+        // SAME kind-agnostic emulator read, with NO detection, NO content, NOT
+        // presumed-agent.
+        for (recordedKind in listOf(
+            SessionAgentKind.Shell, // agent launched inside a shell-recorded session
+            SessionAgentKind.Unknown,
+            null, // foreign session
+        )) {
+            val state = tmuxSessionTabState(
+                currentAgentConversation = null,
+                presumedAgent = false,
+                recordedAgentKind = tmuxSessionRecordedAgentKind(recordedKind),
+                altBufferAgent = true,
+            )
+            assertTrue(
+                "alt-buffer must force the tab for recordedKind=$recordedKind",
+                state.showsConversationTab,
+            )
+        }
+    }
+
+    @Test
+    fun tmuxSessionTabStateHidesConversationForPlainShellMainBufferNoFlapControl() {
+        // #894/#815 no-flap invariant: a plain interactive shell at a prompt — main
+        // buffer (altBufferAgent == false), confirmed-shell (presumedAgent ==
+        // false), no detection, no content, recorded shell — must show NO
+        // Conversation tab and must not flap. GREEN on base AND with the fix (the
+        // alt-buffer signal is POSITIVE-only).
+        val state = tmuxSessionTabState(
+            currentAgentConversation = null,
+            presumedAgent = false,
+            recordedAgentKind = tmuxSessionRecordedAgentKind(SessionAgentKind.Shell),
+            altBufferAgent = false,
+        )
+
+        assertEquals(listOf("Terminal"), state.labels)
+        assertEquals(0, state.selectedIndex)
+        assertTrue(!state.showsConversationTab)
+    }
+
     @Test
     fun tmuxSessionRecordedAgentKindClassifiesEveryKind() {
         // The recorded-agent signal is true ONLY for the agent kinds and never

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
@@ -9956,6 +9956,114 @@ class TmuxSessionViewModelTest {
         )
     }
 
+    // ─── Issue #1158 (REOPENED chain #962→#975→#1057→#1158) — the STICKY ────────
+    // alt-buffer agent latch. The maintainer launches `claude`/`codex` DIRECTLY
+    // inside a shell-recorded session, so `@ps_agent_kind` stays `shell`, the
+    // confirmed-shell verdict is never cleared, and live detection never binds for
+    // the node-wrapped-Claude / Codex-`/proc` / Z.AI fleet. The detection-
+    // INDEPENDENT alt-buffer signal restores the Conversation tab and, once shown,
+    // must STAY for the session's life (a later detection drop / buffer flip must
+    // not collapse it). ─────────────────────────────────────────────────────────
+
+    @Test
+    fun altBufferAgentLatchesShellRecordedSessionAndIsStickyAcrossBufferFlip() = runTest(scheduler) {
+        // A single held surface state so the test can drive the active pane's
+        // alt-buffer verdict synthetically (the #780 model — CI has no real curses
+        // agent). The factory returns the SAME instance the (single) pane uses.
+        val surface = TerminalSurfaceState()
+        val vm = newVm()
+        vm.setTerminalSurfaceStateFactoryForTest { surface }
+        vm.connectWithPaneForTest(paneId = "%0", windowId = "@0")
+        runCurrent()
+        // The maintainer's exact state: the session is a CONFIRMED shell
+        // (`@ps_agent_kind=shell`) — nothing else will ever show the tab.
+        vm.applyRecordedShellVerdictForTest(sessionId = "$0", isShell = true)
+        runCurrent()
+        assertTrue(
+            "precondition: the session is a confirmed shell",
+            "%0" in vm.confirmedShellPaneIds.value,
+        )
+        assertTrue(
+            "precondition: no alt-buffer sighting yet → tab still hidden (RED on base)",
+            "%0" !in vm.altBufferAgentPaneIds.value,
+        )
+
+        // The agent (claude/codex/glm — kind-agnostic) goes full-screen: the pane's
+        // emulator switches to the ALTERNATE screen buffer. The watchdog tick reads
+        // it (driven here directly) and LATCHES the session.
+        surface.setAlternateBufferActiveForTest(true)
+        vm.noteActivePaneAltBufferStateForTest()
+        runCurrent()
+        assertTrue(
+            "#1158: the alt-buffer sighting latches the session → Conversation tab shown",
+            "%0" in vm.altBufferAgentPaneIds.value,
+        )
+
+        // STICKY: the agent leaves the alt-buffer (exits a full-screen view / drops
+        // detection). The tab MUST stay for the rest of the session.
+        surface.setAlternateBufferActiveForTest(false)
+        vm.noteActivePaneAltBufferStateForTest()
+        runCurrent()
+        assertTrue(
+            "#1158 sticky: a later buffer flip / detection drop must NOT collapse the tab",
+            "%0" in vm.altBufferAgentPaneIds.value,
+        )
+    }
+
+    @Test
+    fun altBufferAgentSurvivesReattachPaneIdRotation() = runTest(scheduler) {
+        // Sticky across the real reattach path: tmux re-attach assigns a NEW pane
+        // id under the SAME session ($0). The latch is per-SESSION, so the new pane
+        // id inherits the Conversation tab without needing a fresh alt-buffer
+        // sighting — the maintainer's long-lived sessions keep the tab across
+        // reconnects.
+        val surface = TerminalSurfaceState()
+        val vm = newVm()
+        vm.setTerminalSurfaceStateFactoryForTest { surface }
+        vm.connectWithPaneForTest(paneId = "%0", windowId = "@0")
+        runCurrent()
+        surface.setAlternateBufferActiveForTest(true)
+        vm.noteActivePaneAltBufferStateForTest()
+        runCurrent()
+        assertTrue("precondition: latched on the original pane id", "%0" in vm.altBufferAgentPaneIds.value)
+
+        // Reattach: same session $0, new pane id %7. No fresh alt-buffer read.
+        surface.setAlternateBufferActiveForTest(false)
+        vm.applyParsedPanesForTest(
+            listOf(
+                TmuxSessionViewModel.ParsedPane("%7", "@0", "$0", "work", paneIndex = 0, sessionName = "work"),
+            ),
+        )
+        runCurrent()
+        assertTrue(
+            "#1158 sticky: the new pane id under the latched session keeps the tab",
+            "%7" in vm.altBufferAgentPaneIds.value,
+        )
+        assertTrue("old pane id is gone", "%0" !in vm.altBufferAgentPaneIds.value)
+    }
+
+    @Test
+    fun plainShellOnMainBufferNeverLatchesNoFlap() = runTest(scheduler) {
+        // #894/#815 no-flap adjacency: a plain interactive shell sitting at a prompt
+        // is on the MAIN buffer, so the alt-buffer poll never latches it → NO
+        // Conversation tab. The alt-buffer signal is POSITIVE-only.
+        val surface = TerminalSurfaceState()
+        val vm = newVm()
+        vm.setTerminalSurfaceStateFactoryForTest { surface }
+        vm.connectWithPaneForTest(paneId = "%0", windowId = "@0")
+        vm.applyRecordedShellVerdictForTest(sessionId = "$0", isShell = true)
+        runCurrent()
+        // Main buffer (the emulator override defaults to null → the real read, and a
+        // stub emulator with no alt-screen reports false; assert false explicitly).
+        surface.setAlternateBufferActiveForTest(false)
+        vm.noteActivePaneAltBufferStateForTest()
+        runCurrent()
+        assertTrue(
+            "#894 no-flap: a main-buffer shell never latches → tab stays hidden",
+            "%0" !in vm.altBufferAgentPaneIds.value,
+        )
+    }
+
     @Test
     fun notShellVerdictDoesNotClobberLiveRowNoYank() = runTest(scheduler) {
         // #815 no-yank invariant (class coverage): the #874 re-seed must NOT

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -943,6 +943,19 @@ JOURNEY_CLASSES=(
   #     second kind in the class (Codex), covering the recurrence #962/#975 missed by
   #     only proving vanilla Claude. (Fast JVM sibling: TmuxSessionScreenTest
   #     .tmuxSessionTabStateShowsConversationForRecorded{Claude,Codex,ZaiClaude,OpenCode}*.)
+  #   - conversationToggleAppearsForAltBufferAgentDirectlyLaunchedInShellSession
+  #     (#1158 REOPENED — the maintainer's EXACT dogfood path): an agent launched
+  #     DIRECTLY inside an existing shell tmux session (NOT the `pocketshell agent`
+  #     wrapper), so `@ps_agent_kind` stays `shell`, the confirmed-shell verdict is
+  #     never cleared, and live detection never binds — every prior signal false, the
+  #     toggle GONE for the session's life. The detection-INDEPENDENT alt-buffer
+  #     signal (a full-screen agent TUI holds the alternate screen buffer) restores
+  #     it, STICKY. The pane's alt-buffer state is injected synthetically on the REAL
+  #     connected pane (#780 model — tmux -CC cannot mirror a remote alt-buffer into
+  #     the client emulator), hard-failing (no assumeTrue). RED on base (no
+  #     `|| altBufferAgent`): the toggle stays absent even with the alt-buffer set.
+  #     (Fast JVM siblings: TmuxSessionScreenTest.tmuxSessionTabStateShowsConversation
+  #     ForAltBufferAgent* + TmuxSessionViewModelTest.altBufferAgent*.)
   # It uses ONLY agents:2222 (DEFAULT_HOST/DEFAULT_PORT -> 10.0.2.2:2222) that
   # tests.yml already brings up, and does NOT self-skip on CI (no assumeTrue /
   # assumeFalse(isRunningOnCi())). Lives under com.pocketshell.app.tmux.

--- a/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurfaceState.kt
+++ b/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurfaceState.kt
@@ -693,6 +693,49 @@ class TerminalSurfaceState(
         }
     }
 
+    /**
+     * Issue #1158 — true when the attached emulator is currently on the ALTERNATE
+     * screen buffer (the `smcup`/`?1049h` full-screen mode). A full-screen agent
+     * TUI (Claude Code / Codex / OpenCode and other curses apps) switches the
+     * terminal to the alternate buffer for its whole run; a plain scrolling shell
+     * sitting at a prompt stays on the MAIN buffer. The tmux ViewModel reads this
+     * as a detection-INDEPENDENT positive agent signal so the Conversation tab
+     * appears for an agent launched directly inside a shell-recorded session —
+     * where the `@ps_agent_kind` record says `shell`, the confirmed-shell verdict
+     * is never cleared (live detection can't bind for node-wrapped Claude / Codex
+     * `/proc` / Z.AI transcript-path fleets), and every other tab signal is false.
+     *
+     * A POSITIVE signal only: a genuine plain shell on the main buffer reads false,
+     * so the #894/#815 no-flap invariant holds (a fresh shell at a prompt never
+     * flashes the Conversation tab). Returns false when no emulator is attached yet,
+     * and treats a mid-resize throw as "unknown" (false) so a transient never
+     * spuriously latches the tab.
+     */
+    fun isAlternateBufferActive(): Boolean {
+        alternateBufferOverrideForTest?.let { return it }
+        val emulator = bridge?.emulator ?: _session?.emulator ?: return false
+        return try {
+            emulator.isAlternateBufferActive
+        } catch (_: Throwable) {
+            false
+        }
+    }
+
+    /**
+     * Test-only seam (#1158): force the alternate-buffer verdict reported by
+     * [isAlternateBufferActive] WITHOUT standing up a real emulator on the JVM.
+     * A `null` override (the default) restores the real emulator read. Lets a JVM
+     * unit test drive a pane onto/off the alt-buffer synthetically (the #780
+     * synthetic-state model — CI has no real curses agent) so the sticky-latch
+     * behaviour is deterministically reproducible.
+     */
+    @Volatile
+    private var alternateBufferOverrideForTest: Boolean? = null
+
+    fun setAlternateBufferActiveForTest(active: Boolean?) {
+        alternateBufferOverrideForTest = active
+    }
+
     // -------------------------------------------------------------------------
     // Issue #1192 — SURFACE-paint confirmation seam (distinct from the MODEL grid).
     //


### PR DESCRIPTION
Closes #1158 — RECURRENCE of #962/#1057/#1161, D31/D32 durable-fix gate applied.

## Root cause
The maintainer's long-lived sessions are recorded `@ps_agent_kind=shell` (he runs claude/codex/glm INSIDE a shell), forcing `showsConversationTab` false on both the presumed-agent and recorded-kind terms; live detection also fails for the node-wrapped fleet → tab collapses permanently. #1161 only ORed *recorded* Claude/Codex/OpenCode into the gate — hard-false for a `Shell` record, so it never fixed agent-run-inside-a-shell. That was the reopen.

## Fix (detection-independent)
A full-screen agent TUI holds the terminal's **alternate screen buffer** (`TerminalSurfaceState.isAlternateBufferActive()`), latched **sticky** per-session (`altBufferAgentPaneIds`), OR'd into the tab gate — kind-agnostic, independent of the fragile live-detection path. Extracted into `rememberTmuxSessionTabState` to avoid an ART VerifyError.

## Verification (reviewer-driven, durable-fix gate)
- **G1/G10 red→green:** neutralizing the `|| altBufferAgent` term reproduces the maintainer's EXACT symptom `[Terminal]` only (no Conversation); restored → `[Terminal, Conversation]`. No-flap control (#894) stays green.
- **G2 class coverage:** recorded kind {Shell, Unknown, null} × any agent kind, parametrized.
- **G4 on-device journey:** connected `conversationToggleAppearsForAltBufferAgentDirectlyLaunchedInShellSession` green on emulator+Docker; authoritative before/after/sticky screenshots show the `Terminal | Conversation` toggle appear; stamps confirm the real `confirmed_shell=true, detection_bound=false` failing state. VerifyError gone (real APK).
- Adjacency sweep clean (no flap, no auto-yank, no wrong-source #819/#1228 regression).

## Maintainer-visible trade-off (not a blocker)
The alt-buffer signal over-shows the tab for non-agent full-screen programs (vim/less/htop) → a harmless loading placeholder. Accepted (positive-only + sticky) to reliably restore the tab; flagged for your UX call.

Reviewer APPROVED: https://github.com/alexeygrigorev/pocketshell/issues/1158#issuecomment-4880129420