### PR TITLE
core-ssh: exec-after-close throws canonical stale message under async close (#1284)

### DIFF
--- a/shared/core-ssh/src/integrationTest/java/com/pocketshell/core/ssh/SshIntegrationTest.kt
+++ b/shared/core-ssh/src/integrationTest/java/com/pocketshell/core/ssh/SshIntegrationTest.kt
@@ -935,6 +935,63 @@ class SshIntegrationTest {
         )
     }
 
+    /**
+     * Issue #1284 (regression, DETERMINISTIC) — the #1222 async-close race that
+     * broke the #680 heal-matcher gate on the batched-on-`main` Docker integration
+     * job, reproduced without any host-timing dependence.
+     *
+     * `execOnAClosedSessionThrowsExactStaleChannelMessage` above exercises the same
+     * contract but only fails when the `Dispatchers.IO` transport-drain coroutine is
+     * scheduled AFTER the follow-up `exec` — the loaded-CI ordering. On fast local
+     * hardware the drain wins that race and closes the dispatcher first, so exec
+     * hits `TransportClosedException` (also the canonical text) and the gate can
+     * never be made to fail locally. That masking is exactly how #1222 shipped
+     * green in isolation while red on CI.
+     *
+     * Here we inject the failing state synthetically (the #780 model): connect a
+     * REAL session, then enter the exact #1222 window — close INITIATED
+     * (`closeStarted` = true, so `isCloseInitiated` == true) but the transport NOT
+     * yet drained (`isConnected` still lies `true`: dispatcher open, client
+     * connected). In that window a pre-#1284 `exec` sails past `ensureConnected()`
+     * (which only consulted the lying `isConnected`), opens a channel on the
+     * still-live transport, and RETURNS A REAL RESULT — silently breaking the
+     * cross-module heal matcher (no exception at all, or a transient
+     * "Failed to open exec channel" if the drain lands mid-open), the CI failure.
+     * The #1284 fix makes `ensureConnected()` also consult `isCloseInitiated`, so
+     * exec in this window RELIABLY throws the exact
+     * "SSH session is not connected" text. Runs on any host.
+     */
+    @Test
+    fun execInCloseInitiatedRaceWindowThrowsExactStaleChannelMessage() = runTest {
+        val session = SshConnection.connect(
+            host = container!!.host,
+            port = sshPort,
+            user = "testuser",
+            key = SshKey.Path(privateKeyFile),
+            passphrase = null,
+            knownHosts = KnownHostsPolicy.AcceptAll,
+        ).getOrThrow()
+
+        // Enter the #1222 async-close window deterministically: close initiated but
+        // transport still live (isConnected == true, isCloseInitiated == true).
+        val real = session as RealSshSession
+        real.enterCloseInitiatedRaceWindowForTest()
+        assertTrue("precondition: transport must still be live in the race window", session.isConnected)
+        assertTrue("precondition: close must be initiated in the race window", session.isCloseInitiated)
+
+        val ex = runCatching { session.exec("whoami") }.exceptionOrNull()
+        assertTrue(
+            "exec in the #1222 close-initiated window must throw (not race ahead onto the " +
+                "still-live transport and return a result); got: $ex",
+            ex is SshException,
+        )
+        assertTrue(
+            "exec in the #1222 close-initiated window must produce the exact #680 heal-matcher " +
+                "text \"SSH session is not connected\"; got: ${ex?.message}",
+            ex?.message?.contains("SSH session is not connected", ignoreCase = true) == true,
+        )
+    }
+
     // ---- Issue #654: share-upload auth path against a passphrase key ----
 
     /**

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshSession.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshSession.kt
@@ -263,6 +263,29 @@ internal class RealSshSession(
     internal fun lastOutboundActivityNanosForTest(): Long = lastOutboundActivityNanos
 
     /**
+     * Issue #1284 — deterministically enter the #1222 async-close RACE WINDOW that
+     * broke the #680 heal-matcher gate on CI. Flips the synchronous [closeStarted]
+     * guard exactly as [close] does as its FIRST action, but WITHOUT launching the
+     * async transport drain — so the transport stays live ([isConnected] still lies
+     * `true`: dispatcher open, client connected) while close has been INITIATED.
+     *
+     * This is the exact state a real exec-after-close lands in when the
+     * `Dispatchers.IO` teardown coroutine is scheduled late (the loaded-CI path):
+     * on fast local hardware the drain wins the race and closes the dispatcher
+     * before exec runs, so the natural gate test
+     * (`execOnAClosedSessionThrowsExactStaleChannelMessage`) cannot be made to fail
+     * locally. This seam injects the failing state synthetically (the #780 model)
+     * so `execInCloseInitiatedRaceWindowThrowsExactStaleChannelMessage` reproduces
+     * the regression red→green DETERMINISTICALLY on any host. NOT part of the public
+     * [SshSession] surface. Because it leaves [closeStarted] set, a later [close] on
+     * the same session is a contract no-op; the owning test relies on the shared
+     * Testcontainers container teardown to reclaim the leaked transport.
+     */
+    internal fun enterCloseInitiatedRaceWindowForTest() {
+        closeStarted.set(true)
+    }
+
+    /**
      * Issue #985/#983 — single-flight guard for the keepalive reply wait. Holds
      * the throwaway [awaitKeepAliveReply] `retrieve()` coroutine launched for the
      * most recent ping that has NOT yet completed (the reply has not landed and the
@@ -1950,7 +1973,22 @@ internal class RealSshSession(
     }
 
     private fun ensureConnected() {
-        if (!isConnected) throw SshException("SSH session is not connected")
+        // Issue #1284 — after the #1222 async close(), the transport drain runs on
+        // a Dispatchers.IO coroutine ([closeScope]). Between close() RETURNING
+        // (which synchronously flips [closeStarted] → [isCloseInitiated] == `true`
+        // as its FIRST action) and that coroutine marking the dispatcher closed +
+        // disconnecting the client, [isConnected] still lies `true` (dispatcher
+        // open, client connected — the #1222-documented ~2s window). An exec that
+        // lands in that window (the CI-slow path) must STILL classify the session
+        // as gone: consult the authoritative close-initiated signal so
+        // exec-after-close RELIABLY throws the EXACT "SSH session is not connected"
+        // heal-matcher text (#680 / EPIC #687 Phase-1 gate,
+        // `execOnAClosedSessionThrowsExactStaleChannelMessage`) instead of racing
+        // ahead onto the still-live transport and returning a bogus result or a
+        // transient "Failed to open exec channel" message. [isConnected] /
+        // [SshLeaseManager.isLiveForLease] semantics are intentionally left
+        // unchanged (#1222) — this only tightens the exec/shell/upload pre-check.
+        if (isCloseInitiated || !isConnected) throw SshException("SSH session is not connected")
     }
 
     /**


### PR DESCRIPTION
Closes #1284 — release blocker for v0.4.23; regression from #1222 caught by the #1149 integrationTest rule on batched main.

## What
#1222's async `close()` leaves `isConnected==true` for ~2s during the IO-dispatched drain. `RealSshSession.ensureConnected()` consulted only `isConnected`, so an `exec()` winning the race against the not-yet-run drain opened a channel and returned a REAL result instead of the canonical `"SSH session is not connected"` text the #680 heal matcher substring-matches — silently breaking that contract (EPIC #687 Phase-1 gate `execOnAClosedSessionThrowsExactStaleChannelMessage`). Fix: `ensureConnected()` now `if (isCloseInitiated || !isConnected) throw SshException("SSH session is not connected")`. Additive — #1222 lease-liveness + `isConnected` semantics untouched. All 7 entry points (exec/startShell/openLocalPortForward/uploadFile/uploadStream/listDirectory/downloadFile) route through `ensureConnected()`.

## Verification (reviewer-driven, #1149)
- **≥5× stability:** the 2 gate tests + full suite ran **6/6 green, zero flake**; full `:shared:core-ssh:integrationTest` = 37 tests, 0 failures.
- G1 red→green: neutering `isCloseInitiated ||` fails the new deterministic `execInCloseInitiatedRaceWindowThrowsExactStaleChannelMessage` (uses an internal seam to enter the exact #1222 race window on a live sshd); restored → green.
- Gate un-weakened: `execOnAClosedSessionThrowsExactStaleChannelMessage` still does `close()` → immediate `exec()` (no `awaitClosed()`).

Reviewer APPROVED: https://github.com/alexeygrigorev/pocketshell/issues/1284#issuecomment-4880393549