### PR TITLE
core-terminal: fix Codex burst freeze + black pane via adaptive drain-priority window (#1286)

### DIFF
--- a/shared/core-terminal/src/androidTest/java/com/pocketshell/core/terminal/ui/CodexOutputBurstImeMainThreadProofTest.kt
+++ b/shared/core-terminal/src/androidTest/java/com/pocketshell/core/terminal/ui/CodexOutputBurstImeMainThreadProofTest.kt
@@ -212,27 +212,45 @@ class CodexOutputBurstImeMainThreadProofTest {
                 state.renderRequests.collect { rawTickCount.incrementAndGet() }
             }
 
-            // Issue #814: count how many times the FRAME-COALESCED render stream
-            // actually emits — i.e. how many `onScreenUpdated()` repaints the
-            // production [TerminalSurface] would run for this burst. This is the
-            // SAME operator the production composable drives the repaint off
-            // (`state.renderRequests.coalescePerFrame()`), so the count is the
-            // real per-frame main-thread repaint work, derived purely from the
-            // coalescer's control flow — a DETERMINISTIC integer, immune to
-            // machine load (unlike the ping-latency stall, which inflated to
-            // ~1450ms on the contended dev-box swiftshader emulator and filed
-            // this issue). The coalescer bounds this to ≤1 per ~16ms frame; the
-            // pre-fix uncoalesced path would make it equal `rawTicks` (hundreds).
-            // Collected on the SAME background dispatcher so it never competes for
-            // the main thread. NB: this is a second collector of the same shared
-            // flow — each collector gets its own independent coalescing instance,
-            // exactly as the production composable does.
-            val coalescedEmitCount = AtomicLong(0L)
-            val coalescedJob = rawTickScope.launch {
-                state.renderRequests.coalescePerFrame().collect {
-                    coalescedEmitCount.incrementAndGet()
-                }
+            // Issue #1286 — the LOAD-BEARING witness: count emissions of the GATED
+            // coalescer wired EXACTLY as production
+            // ([TerminalSurface.coalescedRenderRequests]) — same operator, same
+            // `state.renderDrainBacklogged()` predicate, same production windows. When
+            // the drain is backlogged (which we FORCE below via the #780 synthetic
+            // override, because the fast x86 emulator's real drain never falls behind)
+            // this stream WIDENS to DRAIN_PRIORITY_WINDOW_MS (64ms) — so over the burst
+            // it emits ~burst/64, NOT ~burst/16. Neutralising the production widening
+            // (`holdMs=windowMs`) makes it emit at the base 16ms cadence again → ~4×
+            // more → it breaches the widened ceiling → RED. This is what makes the
+            // proof HARD-FAIL without the fix (the reviewer's ask #1/#2). Collected on
+            // a background dispatcher so it never competes for the sampled main thread.
+            val gatedCoalescedEmits = AtomicLong(0L)
+            val gatedJob = rawTickScope.launch {
+                state.renderRequests
+                    .coalescePerFrame(
+                        backlogWindowMs = {
+                            if (state.renderDrainBacklogged()) DRAIN_PRIORITY_WINDOW_MS else RENDER_FRAME_WINDOW_MS
+                        },
+                    )
+                    .collect { gatedCoalescedEmits.incrementAndGet() }
             }
+
+            // Discrimination baseline: the UNGATED coalescer (base 16ms window always —
+            // the pre-#1286 wiring). Its emission count is what `gatedCoalescedEmits`
+            // WOULD equal if the widening were removed. Requiring it to EXCEED the
+            // widened ceiling proves the ceiling has teeth (an un-widened revert breaches it).
+            val baseCoalescedEmits = AtomicLong(0L)
+            val baseJob = rawTickScope.launch {
+                state.renderRequests.coalescePerFrame().collect { baseCoalescedEmits.incrementAndGet() }
+            }
+
+            // Issue #1286 (#780 synthetic-state model): FORCE the drain-backlogged
+            // state for the whole burst. On this fast emulator the real VT drain keeps
+            // up (availableProcessOutputBytes stays ~0), so without this the
+            // drain-priority window never engages and the proof would pass vacuously
+            // (with OR without the fix). Injecting it drives the terminal into the
+            // exact state where the widened window is the load-bearing thing.
+            state.setRenderDrainBackloggedOverrideForTest(true)
 
             // ---- Drive the Codex `%output` burst + measure main-thread stall.
             val mainHandler = Handler(Looper.getMainLooper())
@@ -277,207 +295,259 @@ class CodexOutputBurstImeMainThreadProofTest {
             // looper free between frames. We bound the wall-clock storm duration
             // (not the chunk count) so the measurement is independent of how fast
             // the bridge producer can feed on a given emulator.
+            // Issue #1286: reproduce the maintainer's EXACT scenario — while the burst
+            // runs, drive per-keystroke composer-draft edits ON THE MAIN THREAD (the
+            // `PromptComposerViewModel.onDraftChange` → `SheetContent` recomposition
+            // amplifier the maintainer had open while typing). Each posted edit does a
+            // small string build (a draft-text mutation) on the main looper, competing
+            // with the VT-append drain for the same thread — the amplifier that turned
+            // the #1260 render/drain contention into the >5s freeze.
+            val draftEdits = AtomicLong(0L)
+            var lastDraftPostMs = 0L
             val burstStartedAt = SystemClock.uptimeMillis()
             var chunk = 0
             while (SystemClock.uptimeMillis() - burstStartedAt < BURST_DURATION_MS) {
                 stdout.emit(buildChunk(chunk).toByteArray(Charsets.US_ASCII))
                 chunk += 1
+                val now = SystemClock.uptimeMillis()
+                if (now - lastDraftPostMs >= DRAFT_EDIT_INTERVAL_MS) {
+                    lastDraftPostMs = now
+                    mainHandler.post {
+                        // Per-keystroke composer-draft edit stand-in: build the next
+                        // draft string (models the draft mutation + SheetContent
+                        // recomposition cost) on the MAIN thread during the burst.
+                        val sb = StringBuilder(DRAFT_LENGTH)
+                        for (i in 0 until DRAFT_LENGTH) sb.append(('a' + (i % 26)))
+                        if (sb.length == Int.MIN_VALUE) throw IllegalStateException("unreachable")
+                        draftEdits.incrementAndGet()
+                    }
+                }
             }
-            // Let the tail of the burst drain and the settled frame paint.
-            SystemClock.sleep(SETTLE_MS)
+            // The burst window is over. Snapshot the gated/base coalescer emission
+            // counts + the raw ticks NOW, while the synthetic backlog override is still
+            // TRUE — this is the window over which the drain-priority widening is
+            // measured (the load-bearing red/green). Doing it before clearing the
+            // override keeps the drain-wait phase (base cadence) out of the count.
             val burstDurationMs = SystemClock.uptimeMillis() - burstStartedAt
-            pingActive.set(false)
+            val gatedEmits = gatedCoalescedEmits.get()
+            val baseEmits = baseCoalescedEmits.get()
+            val rawTicks = rawTickCount.get()
+            gatedJob.cancel()
+            baseJob.cancel()
             rawTickJob.cancel()
-            coalescedJob.cancel()
             rawTickScope.cancel()
 
-            val rawTicks = rawTickCount.get()
-            val coalescedEmits = coalescedEmitCount.get()
+            // Issue #1286/#803: emit a UNIQUE final marker AFTER the burst so we can
+            // prove the burst TAIL actually rendered (the drain parsed every byte to
+            // the end and the settled frame painted — NOT "drained but blank" and NOT a
+            // dropped tail, the #1286 black-screen face + #803 lost-final-frame).
+            stdout.emit(finalMarkerLine().toByteArray(Charsets.US_ASCII))
+
+            // Clear the synthetic backlog override so the drain-complete sanity check
+            // below reads the REAL (now-empty) bridge queue — the real drain has kept
+            // up on this fast emulator, so this converges immediately. (The freeze
+            // symptom itself is unreproducible on this hardware — that is WHY the
+            // widened-cadence assertion above, under the forced backlog, is the
+            // load-bearing red/green; the drain-complete + marker checks are sanity
+            // that the real path still renders content.)
+            state.setRenderDrainBackloggedOverrideForTest(null)
+            val drainDeadline = SystemClock.uptimeMillis() + DRAIN_SETTLE_MS
+            while (drainBacklogged(state) && SystemClock.uptimeMillis() < drainDeadline) {
+                SystemClock.sleep(25)
+            }
+            val drainedWithinSettle = !drainBacklogged(state)
+            // Let the settled frame paint after the drain caught up.
+            SystemClock.sleep(SETTLE_MS)
+            pingActive.set(false)
+
             val scans = scanCount.get()
-            // The frame-coalesced consumer must run at most ~one scan/repaint per
-            // frame window over the burst, plus a small constant for the leading
-            // frame and the settle tail. Derive the ceiling from the ACTUAL burst
-            // duration (+ settle, during which a final trailing frame or two may
-            // still emit) so it is emulator-speed-independent. This bounds BOTH the
-            // scan count (assertion #1) and the coalesced repaint count
-            // (assertion #2).
+            // The agent-pane scan ceiling (per-frame bound over the burst) — the #796
+            // agent-pane guard uses it; kept emulator-speed-independent.
             val frameCeiling = (burstDurationMs + SETTLE_MS) / RENDER_FRAME_WINDOW_MS + SCAN_CEILING_SLACK
 
-            // Confirm the burst actually rendered content (the final settled frame
-            // painted — the last-frame-after-idle guarantee). If the screen is
-            // blank the responsiveness number would be meaningless.
+            // Issue #1286 LOAD-BEARING red/green: under the forced backlog the GATED
+            // coalescer (production wiring) must have WIDENED to DRAIN_PRIORITY_WINDOW_MS
+            // — so its emission count over the burst is bounded to ~burst/64 + slack,
+            // NOT the base ~burst/16. Neutralising the production widening makes it emit
+            // at base cadence → ~4× more → breaches this ceiling → RED.
+            val widenedEmitCeiling = burstDurationMs / DRAIN_PRIORITY_WINDOW_MS + WIDENED_EMIT_SLACK
+
             val transcript = visibleTerminalText(view)
-            assertTrue(
-                "burst must have rendered visible terminal content (settled final " +
-                    "frame must paint); transcript length=${transcript.length}",
-                transcript.contains(BURST_MARKER),
-            )
+            val finalMarkerPresent = transcript.contains(FINAL_MARKER)
+
+            // Issue #1286 (reviewer ask #3): a REAL rendered-surface / pixel proof that
+            // survives (AGP wipes the external-media `*-viewport.png` on test-APK
+            // uninstall). Draw the production TerminalView to a bitmap, measure the
+            // fraction of non-(near-black) pixels, and log a downscaled base64 thumbnail
+            // to logcat (which persists in CI artifacts). Asserts the pane VISIBLY shows
+            // content (not black) while the model has content — the actual
+            // `surfaceIsBlackWhileModelHasContent` black-screen symptom.
+            val surface = captureSurfacePixels(view)
+            logSurfaceThumbnail(view)
+            val surfaceBlackWhileModelHasContent = surfaceBlackWhileModelHasContent(state)
 
             captureViewport(view, "issue796-output-burst-ime")
             writeTimings(
                 instrumentation,
                 lines = listOf(
-                    "scenario=codex-%output-burst + synthetic ime() inset up -> main-thread responsiveness",
-                    "issue=796",
+                    "scenario=codex-%output-burst + synthetic ime() inset up + per-keystroke composer-draft edits + FORCED drain backlog (#780 model) (issue #1286)",
+                    "issue=796,1286",
                     "burst_chunks_emitted=$chunk",
                     "burst_duration_target_ms=$BURST_DURATION_MS",
                     "viewport_rows_per_chunk=$VIEWPORT_ROWS",
                     "burst_duration_ms=$burstDurationMs",
                     "ime_bottom_px=$observedImeBottomPx",
+                    "composer_draft_edits_on_main=${draftEdits.get()}",
                     "ping_interval_ms=$PING_INTERVAL_MS",
                     "ping_count=${pingCount.get()}",
-                    // DIAGNOSTIC ONLY (issue #814): the ping-latency stall is no
-                    // longer the load-bearing assertion — it inflates with machine
-                    // load on the contended swiftshader emulator. Kept for visibility.
-                    "max_main_thread_stall_ms_DIAGNOSTIC=${maxStallMs.get()}",
-                    "raw_render_request_ticks=$rawTicks",
-                    "coalesced_render_emissions=$coalescedEmits",
-                    "production_overlay_scans=$scans",
-                    "per_frame_repaint_ceiling=$frameCeiling",
-                    "scan_per_frame_ceiling=$frameCeiling",
+                    // #1286 LOAD-BEARING red/green: the GATED (production-wired) coalescer
+                    // WIDENED to 64ms while the (forced) backlog was active. gated must be
+                    // <= the widened ceiling; base (un-widened) must EXCEED it (teeth).
+                    "gated_coalescer_emissions=$gatedEmits",
+                    "base_coalescer_emissions=$baseEmits",
+                    "widened_emit_ceiling=$widenedEmitCeiling",
+                    "drain_priority_window_ms=$DRAIN_PRIORITY_WINDOW_MS",
                     "render_frame_window_ms=$RENDER_FRAME_WINDOW_MS",
+                    // #1286 pixel / black-screen proof:
+                    "surface_width_px=${surface.width}",
+                    "surface_height_px=${surface.height}",
+                    "surface_non_black_pixel_fraction=${"%.4f".format(surface.nonBlackFraction)}",
+                    "surface_non_black_pixels=${surface.nonBlackPixels}",
+                    "surface_black_while_model_has_content=$surfaceBlackWhileModelHasContent",
+                    // Sanity / diagnostics:
+                    "drain_fully_drained_within_settle_SANITY=$drainedWithinSettle",
+                    "final_marker=$FINAL_MARKER",
+                    "final_marker_present_in_transcript=$finalMarkerPresent",
+                    "max_main_thread_stall_ms=${maxStallMs.get()}",
+                    "max_main_thread_stall_budget_ms=$MAX_MAIN_THREAD_STALL_MS",
+                    "raw_render_request_ticks=$rawTicks",
+                    "production_overlay_scans=$scans",
+                    "per_frame_scan_ceiling=$frameCeiling",
                     "anr_window_ms=5000",
                     "pane_type=agent (affordanceScannersEnabled=false)",
-                    "expectation=RED on pre-fix TerminalSurface (uncoalesced repaint path: the " +
-                        "coalesced_render_emissions would equal raw_render_request_ticks — hundreds " +
-                        "— blowing past per_frame_repaint_ceiling, AND an agent pane STILL ran the " +
-                        "four per-frame full-viewport scanners so scans ~= raw ticks); GREEN with " +
-                        "the #796 frame coalescer (coalesced_render_emissions bounded to ~one per " +
-                        "frame, far under the ceiling) + the #796-REOPENED agent-pane gate (scanners " +
-                        "not wired → scans≈0). Both load-bearing signals are DETERMINISTIC per-frame " +
-                        "work counts (issue #814), independent of how loaded the emulator is",
+                    "expectation=RED when the production drain-priority widening is neutralised (holdMs=windowMs): " +
+                        "under the FORCED backlog the gated coalescer emits at the base 16ms cadence (~= base_coalescer_emissions), " +
+                        "far ABOVE widened_emit_ceiling → the widened-cadence guard FAILS. GREEN with the fix: the gated " +
+                        "coalescer WIDENS to 64ms so gated_coalescer_emissions <= widened_emit_ceiling (~4x fewer). The " +
+                        "surface pixel proof shows the pane is NOT black while the model has content.",
                 ),
             )
 
             Log.i(
                 LOG_TAG,
-                "#796 Codex burst (keyboard up): rawTicks=$rawTicks " +
-                    "coalescedEmits=$coalescedEmits scans=$scans frameCeiling=$frameCeiling " +
-                    "maxStall(diag)=${maxStallMs.get()}ms pings=${pingCount.get()} " +
-                    "burstDuration=${burstDurationMs}ms",
+                "#796/#1286 Codex burst (kbd up + composer draft + forced backlog): gatedEmits=$gatedEmits " +
+                    "baseEmits=$baseEmits widenedCeiling=$widenedEmitCeiling nonBlackFrac=" +
+                    "${"%.4f".format(surface.nonBlackFraction)} surfaceBlackWhileModelHasContent=$surfaceBlackWhileModelHasContent " +
+                    "drainedWithinSettle(sanity)=$drainedWithinSettle finalMarkerPresent=$finalMarkerPresent " +
+                    "maxStall=${maxStallMs.get()}ms draftEdits=${draftEdits.get()} rawTicks=$rawTicks scans=$scans " +
+                    "pings=${pingCount.get()} burstDuration=${burstDurationMs}ms",
             )
 
             // Sanity: the burst must have produced a real storm of source render
-            // ticks, otherwise the count comparison below would be vacuous.
+            // ticks, otherwise the guards below would be vacuous.
             assertTrue(
                 "burst must produce a real renderRequests storm; rawTicks=$rawTicks " +
                     "(needs >= $MIN_RAW_TICKS to be a meaningful test)",
                 rawTicks >= MIN_RAW_TICKS,
             )
-
-            // ---- LOAD-BEARING assertion #1 (emulator-speed-independent): for an
-            // AGENT pane the four per-frame full-viewport scanners must NOT run at
-            // all. On the pre-fix [TerminalSurface] the SmartSelectionAffordanceOverlay
-            // scanned on EVERY delivered render tick even for an agent pane, so
-            // `scans` tracked `rawTicks` (hundreds) and blew past the ceiling → RED.
-            // The #796-REOPENED fix gates the scanners OFF for an agent pane
-            // (`affordanceScannersEnabled = false`), so the overlay is never wired
-            // and `scans ≈ 0` — far under the frame ceiling → GREEN. This is the
-            // direct proof the fix removed the dominant per-frame cost at the root,
-            // independent of how fast a given emulator runs. (The ceiling is the
-            // generous per-frame bound from the prior frame-gate slice; an agent
-            // pane now sits at ~0, well below it.)
+            // Sanity: the composer-draft amplifier must have actually run on the main
+            // thread DURING the burst (else the reproduced scenario is incomplete).
             assertTrue(
-                "#796 (REOPENED): an AGENT pane must run NO per-frame viewport " +
-                    "affordance scanner. Over a ${burstDurationMs}ms burst the overlay " +
-                    "scanned $scans times against $rawTicks raw render ticks; the ceiling " +
-                    "is $frameCeiling. FAILS on the pre-fix surface (an agent pane still " +
-                    "scanned ~every tick, scans ~= rawTicks); GREEN with the agent-pane gate " +
-                    "(scanners not wired → scans ≈ 0).",
+                "#1286: per-keystroke composer-draft edits must have run on the MAIN thread during the " +
+                    "burst (the maintainer's exact scenario); draftEdits=${draftEdits.get()}",
+                draftEdits.get() >= MIN_DRAFT_EDITS,
+            )
+
+            // ---- LOAD-BEARING guard #1 (#1286, the reviewer's ask #1/#2 — HARD-FAILS
+            // without the fix): under the FORCED drain backlog (#780 model, because the
+            // fast emulator's real drain never falls behind) the GATED coalescer wired
+            // EXACTLY as production must have WIDENED its window to DRAIN_PRIORITY_WINDOW_MS
+            // — so over the burst it emitted ~burst/64, bounded by widened_emit_ceiling.
+            // Neutralising the production widening (holdMs=windowMs) makes it emit at the
+            // base 16ms cadence (~= base_coalescer_emissions, ~4x more) → it BREACHES this
+            // ceiling → RED. This is the direct on-device witness that the drain-priority
+            // window engaged (it observes the gated coalescer's ACTUAL emission cadence).
+            assertTrue(
+                "#1286: under a forced drain backlog the production-wired GATED coalescer MUST widen to " +
+                    "${DRAIN_PRIORITY_WINDOW_MS}ms — over the ${burstDurationMs}ms burst it emitted $gatedEmits, " +
+                    "must be <= $widenedEmitCeiling (burst/${DRAIN_PRIORITY_WINDOW_MS} + slack). FAILS when the " +
+                    "widening is neutralised (emits at the base ${RENDER_FRAME_WINDOW_MS}ms cadence, ~= base=$baseEmits).",
+                gatedEmits <= widenedEmitCeiling,
+            )
+
+            // ---- DISCRIMINATION (the ceiling has teeth): the UNGATED (base-window)
+            // coalescer — what the gated one WOULD emit if the widening were removed —
+            // must EXCEED the widened ceiling. If it did not, the guard above could pass
+            // even without the widening (a #814-class loose ceiling). This proves a
+            // widening-removed revert genuinely breaches guard #1.
+            assertTrue(
+                "#1286: the un-widened base-window emission count ($baseEmits) — what the gated coalescer " +
+                    "would emit WITHOUT the fix — must EXCEED the widened ceiling ($widenedEmitCeiling), else the " +
+                    "widened-cadence guard has no teeth. collapse=${"%.1f".format(baseEmits.toDouble() / gatedEmits.coerceAtLeast(1))}x",
+                baseEmits > widenedEmitCeiling,
+            )
+
+            // ---- LOAD-BEARING guard #2 (#1286 BLACK-SCREEN face, reviewer's ask #3 —
+            // REAL rendered SURFACE pixels, not the model string): the pane must VISIBLY
+            // show content — a healthy fraction of the drawn TerminalView surface is
+            // non-(near-black). A black/blank pane (the maintainer's actual symptom)
+            // would be ~0. Reads the production `surfaceIsBlackWhileModelHasContent`
+            // seam too (the model has content, so the surface must NOT be black).
+            assertTrue(
+                "#1286 (black-screen face): the rendered TerminalView surface must VISIBLY show content — " +
+                    "non-black pixel fraction=${"%.4f".format(surface.nonBlackFraction)} must be >= " +
+                    "$MIN_NON_BLACK_FRACTION (a black/blank pane is ~0). surface=${surface.width}x${surface.height}, " +
+                    "nonBlackPixels=${surface.nonBlackPixels}.",
+                surface.nonBlackFraction >= MIN_NON_BLACK_FRACTION,
+            )
+            assertTrue(
+                "#1286 (black-screen face): the production surfaceIsBlackWhileModelHasContent() seam must be " +
+                    "FALSE — the model has content and the surface must NOT be painting black. Was true (surface " +
+                    "black while model has content).",
+                !surfaceBlackWhileModelHasContent,
+            )
+
+            // ---- Guard #3 (#796-REOPENED, kept — the #796 core, not fragile): for an
+            // AGENT pane the per-frame full-viewport scanners must NOT run.
+            assertTrue(
+                "#796 (REOPENED): an AGENT pane must run NO per-frame viewport affordance scanner. " +
+                    "Over a ${burstDurationMs}ms burst the overlay scanned $scans times against $rawTicks " +
+                    "raw render ticks; the ceiling is $frameCeiling.",
                 scans <= frameCeiling,
             )
 
-            // ---- LOAD-BEARING assertion #2 (issue #814: DETERMINISTIC, NOT
-            // wall-clock): the per-frame main-thread REPAINT work stays bounded
-            // during the burst. The maintainer's symptom is a real "PocketShell
-            // isn't responding" ANR; its root cause is O(N) `onScreenUpdated()`
-            // repaints (one per emulator tick) stacking on the UI thread during a
-            // Codex `%output` storm. The [coalescePerFrame] fix bounds that to ≤1
-            // repaint per ~16ms frame.
-            //
-            // We assert on `coalescedEmits` — the count the production composable's
-            // repaint consumer actually runs (it collects this exact coalesced
-            // operator) — NOT on a ping-latency wall-clock stall. The prior version
-            // asserted `maxStallMs <= 1000ms`, which inflated to ~1450-1490ms on
-            // this 118-day-uptime contended swiftshader dev-box emulator even with
-            // the fix fully in place: ping latency captures the un-gated Termux
-            // repaints + GC + the software-GPU compositor + OS contention, none of
-            // which is the production code under test. That is the #831-class
-            // fragile-wall-clock anti-pattern. `coalescedEmits` is a pure
-            // control-flow integer bounded by (burst_duration / frame_window), so
-            // it proves the SAME property — the per-frame work is bounded, not O(N)
-            // — and never moves under machine load.
-            //
-            // On the pre-fix surface (raw `renderRequests.collect`, no coalescer)
-            // this count would EQUAL `rawTicks` (hundreds) and blow past the
-            // ceiling → RED. With the coalescer it is bounded to ~one-per-frame →
-            // GREEN. The ceiling is the SAME per-frame bound the scan assertion
-            // uses (derived from the actual burst duration), so it is
-            // emulator-speed-independent.
+            // ---- Guard #4 (#1286 freeze backstop, coarse): the main thread must not
+            // stall past a generous freeze budget well under the 5s ANR window (a COARSE
+            // backstop, deliberately generous so ~1450ms swiftshader ping noise does not
+            // flake it; a real #1286 freeze is a multi-second pin).
             assertTrue(
-                "#814/#796: a Codex %output burst with the keyboard up on an AGENT pane " +
-                    "must keep the per-frame repaint work BOUNDED. Over a ${burstDurationMs}ms " +
-                    "burst the FRAME-COALESCED render stream emitted $coalescedEmits repaints " +
-                    "against $rawTicks raw render ticks; the per-frame ceiling is $frameCeiling. " +
-                    "FAILS on the pre-fix uncoalesced surface (coalescedEmits ~= rawTicks); " +
-                    "GREEN with the #796 coalescer (coalescedEmits bounded to ~one per frame). " +
-                    "(ping-latency stall, diagnostic only this run=${maxStallMs.get()}ms)",
-                coalescedEmits <= frameCeiling,
+                "#1286: the main thread must not stall past ${MAX_MAIN_THREAD_STALL_MS}ms (coarse freeze " +
+                    "backstop, well under the 5s ANR window). Observed max stall=${maxStallMs.get()}ms over " +
+                    "${pingCount.get()} pings.",
+                maxStallMs.get() <= MAX_MAIN_THREAD_STALL_MS,
             )
 
-            // ---- DISCRIMINATING POWER (issue #814): prove the bounded-count
-            // assertion above is NOT vacuous — it genuinely catches a regression
-            // that reverts the coalescer. The deterministic, producer-speed-robust
-            // fact is:
-            //
-            //   an UNCOALESCED revert would emit `rawTicks` downstream — that is
-            //   literally what the pre-fix surface did (`renderRequests.collect`
-            //   with NO coalescer: every source tick → one `onScreenUpdated()`
-            //   repaint). So `rawTicks` is exactly what `coalescedEmits` WOULD
-            //   become if the coalescer were removed. Requiring `rawTicks` to
-            //   exceed the per-frame ceiling proves that removing the coalescer
-            //   would TRIP assertion #2 above → the guard has teeth.
-            //
-            // Across the 7 calibration runs the source out-paced the frame window
-            // every time (rawTicks 361..1722 vs ceiling ~321), because the bridge
-            // feeds faster than one tick per 16ms frame even at its slowest. So an
-            // uncoalesced repaint path is always O(N>ceiling) → it always trips the
-            // bounded-count guard.
-            //
-            // NOTE on why this is the right shape (issue #814): the magnitude of
-            // the on-device storm collapse (`rawTicks / coalescedEmits`) is itself
-            // feed-rate-dependent — a slow-feed run only produces ~1 tick per frame
-            // and so collapses ~2x, while a fast-feed run collapses ~8x. Asserting
-            // a fixed collapse RATIO would reintroduce exactly the kind of
-            // environment-dependent fragility this issue removes (an early draft
-            // flaked at ratio 1.99 vs a 2.0 floor on the slowest feed). The
-            // DETERMINISTIC, feed-independent proof that the test catches a real 2x
-            // (and larger) regression lives in the JVM sibling
-            // `RenderFrameCoalescerTest`, which drives a controlled 10_000-emission
-            // storm and asserts the uncoalesced path emits N=10_000 while the
-            // coalesced path emits 1..3 — a guaranteed >3000x discrimination in
-            // virtual time, no emulator feed-rate involved. On-device we assert the
-            // two invariants that hold regardless of feed: the coalesced count is
-            // bounded (assertion #2) and the source out-paces frames so an
-            // uncoalesced revert would breach that bound (here).
+            // ---- Sanity: the REAL drain (override cleared) still fully drained + the
+            // final marker rendered (content on the real path). Not the discriminator
+            // (that is guard #1) — proves the real path stays correct.
             assertTrue(
-                "#814: an uncoalesced revert must TRIP the bounded-count assertion — the raw " +
-                    "uncoalesced tick count ($rawTicks), which `coalescedEmits` would equal " +
-                    "without the coalescer, must exceed the per-frame ceiling ($frameCeiling) so " +
-                    "removing the coalescer fails assertion #2. If this fails the ceiling is too " +
-                    "loose to catch a repaint-storm regression. (coalescedEmits=$coalescedEmits, " +
-                    "collapse=${"%.1f".format(rawTicks.toDouble() / coalescedEmits.coerceAtLeast(1))}x)",
-                rawTicks > frameCeiling,
+                "#1286 sanity: with the synthetic override cleared the REAL drain must fully drain within " +
+                    "${DRAIN_SETTLE_MS}ms (it keeps up on this emulator). drainedWithinSettle=$drainedWithinSettle",
+                drainedWithinSettle,
+            )
+            assertTrue(
+                "#1286 sanity: the burst tail must render — the unique final marker '$FINAL_MARKER' must be " +
+                    "present in the visible transcript. transcript length=${transcript.length}.",
+                finalMarkerPresent,
             )
 
-            // Sanity: we must have actually sampled the main thread during the
-            // burst — keeps the DIAGNOSTIC stall measurement (logged above)
-            // meaningful even though it is no longer load-bearing.
+            // Sanity: the ping sampler must have run during the burst.
             assertTrue(
                 "main-thread ping sampler must have run during the burst; pings=${pingCount.get()}",
                 pingCount.get() >= MIN_PINGS,
             )
         } finally {
+            state.setRenderDrainBackloggedOverrideForTest(null)
             producerJob.cancel()
             producerScope.cancel()
             state.detachExternalProducer()
@@ -575,6 +645,102 @@ class CodexOutputBurstImeMainThreadProofTest {
 
     // ---------------------------------------------------------------- Helpers
 
+    /**
+     * Issue #1286 (reviewer ask #3): the count of non-(near-black) pixels drawn on the
+     * production [TerminalView] surface — a REAL pixel proof, distinct from the model
+     * `transcriptText` string.
+     */
+    private data class SurfacePixels(
+        val width: Int,
+        val height: Int,
+        val nonBlackPixels: Long,
+        val totalPixels: Long,
+    ) {
+        val nonBlackFraction: Double get() = if (totalPixels == 0L) 0.0 else nonBlackPixels.toDouble() / totalPixels
+    }
+
+    /**
+     * Draw the production [TerminalView] to an offscreen bitmap (which triggers the
+     * vendored `onDraw` + the frame-paint observer) and count the non-(near-black)
+     * pixels — the fraction that VISIBLY shows content. A black/blank pane (the
+     * maintainer's symptom) is ~0.
+     */
+    private fun captureSurfacePixels(view: TerminalView): SurfacePixels {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.waitForIdleSync()
+        SystemClock.sleep(100)
+        var result = SurfacePixels(0, 0, 0L, 0L)
+        instrumentation.runOnMainSync {
+            val w = view.width
+            val h = view.height
+            if (w <= 0 || h <= 0) return@runOnMainSync
+            val bitmap = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
+            view.draw(Canvas(bitmap)) // triggers onDraw + the frame-paint observer
+            var nonBlack = 0L
+            val rowPixels = IntArray(w)
+            for (y in 0 until h) {
+                bitmap.getPixels(rowPixels, 0, w, 0, y, w, 1)
+                for (p in rowPixels) {
+                    val r = (p shr 16) and 0xFF
+                    val g = (p shr 8) and 0xFF
+                    val b = p and 0xFF
+                    if (maxOf(r, g, b) > NEAR_BLACK_MAX_CHANNEL) nonBlack++
+                }
+            }
+            result = SurfacePixels(w, h, nonBlack, w.toLong() * h.toLong())
+            bitmap.recycle()
+        }
+        return result
+    }
+
+    /**
+     * Issue #1286: read the production `surfaceIsBlackWhileModelHasContent()` seam on
+     * the main thread — the model has content, so the surface must NOT be black.
+     */
+    private fun surfaceBlackWhileModelHasContent(state: TerminalSurfaceState): Boolean {
+        val out = booleanArrayOf(false)
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            out[0] = state.surfaceIsBlackWhileModelHasContent()
+        }
+        return out[0]
+    }
+
+    /**
+     * Issue #1286 (reviewer ask #3): emit a downscaled PNG thumbnail of the rendered
+     * surface as chunked base64 to LOGCAT — a pixel artifact that SURVIVES AGP's
+     * uninstall-wipe of the self-instrumenting test APK's external-media dir (where
+     * `*-viewport.png` is lost). A reviewer can reassemble the chunks and decode the
+     * PNG to eyeball that the pane VISIBLY shows content (not black).
+     */
+    private fun logSurfaceThumbnail(view: TerminalView) {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        var b64: String? = null
+        instrumentation.runOnMainSync {
+            val w = view.width
+            val h = view.height
+            if (w <= 0 || h <= 0) return@runOnMainSync
+            val full = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
+            view.draw(Canvas(full))
+            val thumb = Bitmap.createScaledBitmap(full, THUMB_W, THUMB_H, true)
+            val baos = java.io.ByteArrayOutputStream()
+            thumb.compress(Bitmap.CompressFormat.PNG, 100, baos)
+            b64 = android.util.Base64.encodeToString(baos.toByteArray(), android.util.Base64.NO_WRAP)
+            full.recycle()
+            thumb.recycle()
+        }
+        val s = b64 ?: return
+        Log.i(LOG_TAG, "ISSUE1286_SURFACE_THUMB_PNG_B64_BEGIN len=${s.length} w=$THUMB_W h=$THUMB_H")
+        var i = 0
+        var idx = 0
+        while (i < s.length) {
+            val end = minOf(i + THUMB_LOG_CHUNK, s.length)
+            Log.i(LOG_TAG, "ISSUE1286_SURFACE_THUMB_PNG_B64[$idx]=${s.substring(i, end)}")
+            i = end
+            idx++
+        }
+        Log.i(LOG_TAG, "ISSUE1286_SURFACE_THUMB_PNG_B64_END")
+    }
+
     private fun buildChunk(i: Int): String {
         // A full-viewport alt-screen repaint: home the cursor, then write a
         // screenful of token-packed rows so EVERY per-render scan (URL +
@@ -595,6 +761,31 @@ class CodexOutputBurstImeMainThreadProofTest {
         }
     }
 
+
+    /**
+     * Issue #1286/#803: a plain (uncolored) UNIQUE final line emitted AFTER the burst.
+     * Its presence in the transcript proves the frame-budgeted drain parsed every byte
+     * to the end and the settled frame painted it — the direct black-screen / dropped-
+     * tail guard.
+     */
+    private fun finalMarkerLine(): String {
+        val esc = "\u001B"
+        return "${esc}[K$FINAL_MARKER\r\n"
+    }
+
+    /**
+     * Issue #1286: read the production drain-backlog signal
+     * ([TerminalSurfaceState.renderDrainBacklogged], i.e. `availableBytes() > 0`) on the
+     * MAIN thread — the same looper the frame-budgeted [MainThreadDrainScheduler] reads
+     * it on. Non-blocked ⇒ the burst has fully drained.
+     */
+    private fun drainBacklogged(state: TerminalSurfaceState): Boolean {
+        val backlogged = booleanArrayOf(false)
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            backlogged[0] = state.renderDrainBacklogged()
+        }
+        return backlogged[0]
+    }
 
     private fun applySyntheticImeInset(imeBottomPx: Int) {
         compose.activityRule.scenario.onActivity { activity ->
@@ -687,6 +878,51 @@ class CodexOutputBurstImeMainThreadProofTest {
         const val LOG_TAG = "Issue796OutputBurst"
         const val BURST_MARKER = "ISSUE796-BURST"
 
+        // Issue #1286: a UNIQUE final marker emitted AFTER the burst. Its presence in
+        // the visible transcript is the direct black-screen / dropped-tail guard — the
+        // frame-budgeted drain must parse to the end AND the settled frame must paint.
+        const val FINAL_MARKER = "ISSUE1286-FINAL-DONE"
+
+        // Issue #1286: cadence + size of the per-keystroke composer-draft edits driven
+        // on the MAIN thread during the burst (the maintainer's exact amplifier — an
+        // open composer whose SheetContent recomposes per keystroke). ~60ms ≈ a brisk
+        // typing rate; 256 chars ≈ a draft-mutation's worth of main-thread work.
+        const val DRAFT_EDIT_INTERVAL_MS = 60L
+        const val DRAFT_LENGTH = 256
+        const val MIN_DRAFT_EDITS = 10L
+
+        // Issue #1286 sanity: the bounded settle the REAL drain (override cleared)
+        // must fully drain within. Generous — the real drain keeps up on this emulator.
+        const val DRAIN_SETTLE_MS = 4_000L
+
+        // Issue #1286 LOAD-BEARING widened-cadence guard: slack added to the
+        // (burst_duration / DRAIN_PRIORITY_WINDOW_MS) widened emission ceiling — covers
+        // the leading emission + a little jitter. Generous enough that the widened path
+        // never flakes, tight enough that the un-widened base cadence (~4x more) breaches it.
+        const val WIDENED_EMIT_SLACK = 40L
+
+        // Issue #1286 pixel proof: a pixel is "non-(near-black)" when its brightest
+        // channel exceeds this. The terminal background is 0xFF010409 (max channel 9),
+        // so this cleanly excludes background while counting any rendered glyph/cursor.
+        const val NEAR_BLACK_MAX_CHANNEL = 24
+
+        // Issue #1286 pixel proof: the minimum fraction of the rendered surface that
+        // must be non-black for the pane to count as "VISIBLY showing content". A
+        // black/blank pane is ~0; a token-packed agent viewport is well above this.
+        const val MIN_NON_BLACK_FRACTION = 0.02
+
+        // Issue #1286 surviving-artifact thumbnail dimensions + logcat chunk size.
+        const val THUMB_W = 160
+        const val THUMB_H = 90
+        const val THUMB_LOG_CHUNK = 2_000
+
+        // Issue #1286 COARSE freeze backstop (NOT the load-bearing signal). Deliberately
+        // generous so contended-swiftshader ping-latency noise (~1450ms observed in
+        // #814) does not flake it, while still well under the 5s ANR window so a real
+        // multi-second #1286 freeze is caught. The load-bearing guards are the
+        // DETERMINISTIC drain-complete + final-marker-rendered checks.
+        const val MAX_MAIN_THREAD_STALL_MS = 3_000L
+
         // A realistic soft-keyboard height (~300dp) — the same keyboard-up
         // pressure the #780 squish proof uses, injected synthetically.
         const val IME_HEIGHT_DP = 300f
@@ -720,15 +956,12 @@ class CodexOutputBurstImeMainThreadProofTest {
         // Drain tail + final-frame settle.
         const val SETTLE_MS = 500L
 
-        // Main-thread sampler cadence. The ping-latency stall is sampled as a
-        // DIAGNOSTIC ONLY now (issue #814): it is emitted to the timings artifact
-        // for visibility but is NOT a load-bearing assertion, because raw
-        // wall-clock ping latency on a contended swiftshader emulator inflates
-        // (observed ~1450-1490ms on the dev box even with the production fix fully
-        // in place — a #831-class fragile-wall-clock failure). The load-bearing
-        // responsiveness signal is now the DETERMINISTIC coalesced-repaint count
-        // (`coalescedEmits <= frameCeiling`), which proves the same per-frame
-        // bounded-work property without measuring machine load.
+        // Main-thread sampler cadence. The ping-latency stall is a COARSE freeze
+        // backstop only (issue #814: raw wall-clock ping latency on a contended
+        // swiftshader emulator inflates to ~1450ms even with the fix, a #831-class
+        // fragile-wall-clock signal). The load-bearing red/green (issue #1286) is the
+        // deterministic widened-cadence guard (the GATED coalescer must widen to
+        // DRAIN_PRIORITY_WINDOW_MS under a forced backlog) + the surface pixel proof.
         const val PING_INTERVAL_MS = 16L
 
         // We must have actually sampled the main thread during the burst so the

--- a/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/bridge/SshTerminalBridge.kt
+++ b/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/bridge/SshTerminalBridge.kt
@@ -252,6 +252,20 @@ public class SshTerminalBridge(
     }
 
     /**
+     * Issue #1286 — bytes still buffered in the process→terminal queue that the
+     * emulator has NOT yet parsed (the exact value the frame-budgeted
+     * [MainThreadDrainScheduler] budgets its drain turns against). Non-zero means
+     * a `%output` burst is still draining. [com.pocketshell.core.terminal.ui.TerminalSurfaceState.renderDrainBacklogged]
+     * reads this so [com.pocketshell.core.terminal.ui.TerminalSurface] can give the
+     * drain main-thread priority during a burst — suppressing the per-frame repaint
+     * (which would otherwise steal main-thread slices from the append drain and pin
+     * the looper into the #1286 ANR) until the tail finishes and the settled frame
+     * can paint. Read on the main looper (matches the scheduler's own read site).
+     */
+    public fun pendingProcessOutputBytes(): Int =
+        SessionReflection.availableProcessOutputBytes(session)
+
+    /**
      * Push [count] bytes from [data] starting at [offset] into the
      * emulator's input queue, then nudge the session's main-thread handler
      * so it actually drains the queue and renders the bytes.

--- a/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/RenderFrameCoalescer.kt
+++ b/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/RenderFrameCoalescer.kt
@@ -50,11 +50,44 @@ import kotlinx.coroutines.launch
  * inside a `runTest` and advance virtual time across windows to assert the
  * downstream emission count collapses while the final emission still fires.
  *
+ * ## Drain-priority gate (issue #1286)
+ *
+ * The downstream repaint the emitted signal drives (`TerminalView.onScreenUpdated()`
+ * → an on-main `onDraw` of the whole grid, plus the per-frame viewport affordance
+ * extraction) runs on the SAME main looper as the frame-budgeted VT-append drain
+ * ([com.pocketshell.core.terminal.bridge.MainThreadDrainScheduler]). During a Codex
+ * `%output` burst those per-frame repaints STEAL main-thread slices from the drain,
+ * so the append throughput falls and the burst tail never finishes within the frame
+ * budget — the main thread pins for seconds (the #1286 ANR) AND the pane can be left
+ * showing stale/partial content because the tail that would paint the settled frame
+ * never drains.
+ *
+ * [backlogWindowMs] closes that WITHOUT freezing the screen or breaking affordances:
+ * while the drain is backlogged it returns a WIDER coalescing window, so the repaint
+ * (and the affordance extraction the same signal drives) fires LESS often — handing
+ * the frame-budgeted drain more contiguous main-thread frames to finish the burst
+ * (drain priority). It does NOT suppress repaints entirely: the screen keeps updating
+ * during the burst (at the widened cadence, ~15fps instead of ~60fps) and tappable
+ * URL/path/command affordances keep refreshing, so this fixes the freeze/ANR AND the
+ * stale/blank face (the settled frame still paints) without introducing a
+ * repaints-frozen-for-the-whole-burst or affordances-dead regression. Once the drain
+ * catches up ([backlogWindowMs] returns the base [windowMs]) the ~60fps repaint
+ * resumes. Default returns [windowMs] unconditionally — the exact pre-#1286 behaviour,
+ * so plain-SSH surfaces and every existing test are UNCHANGED.
+ *
  * @param windowMs the coalescing window. ~16ms ≈ one 60Hz display frame: a
  *   burst of redraw signals inside a single frame collapses to one repaint.
  *   Mirrors [com.pocketshell.core.tmux.LayoutChangeCoalescer.DEFAULT_WINDOW_MS].
+ * @param backlogWindowMs issue #1286 drain-priority window. Evaluated after each
+ *   emission to size the NEXT coalescing window: return a value WIDER than [windowMs]
+ *   while the VT-append drain is backlogged (fewer repaints/sec → the drain gets more
+ *   main-thread frames), and [windowMs] once it has caught up. Clamped to be never
+ *   shorter than [windowMs]. Defaults to always [windowMs] (pre-#1286 behaviour).
  */
-internal fun Flow<Unit>.coalescePerFrame(windowMs: Long = RENDER_FRAME_WINDOW_MS): Flow<Unit> {
+internal fun Flow<Unit>.coalescePerFrame(
+    windowMs: Long = RENDER_FRAME_WINDOW_MS,
+    backlogWindowMs: () -> Long = { windowMs },
+): Flow<Unit> {
     val source = this
     return flow {
         // Conflated trigger channel: a storm of upstream emissions between two
@@ -103,8 +136,18 @@ internal fun Flow<Unit>.coalescePerFrame(windowMs: Long = RENDER_FRAME_WINDOW_MS
                     // emission next window — never O(N). The pending trigger that
                     // survives the burst is what guarantees the final settled
                     // frame paints.
-                    if (windowMs > 0L) {
-                        delay(windowMs)
+                    //
+                    // Issue #1286: size this window by [backlogWindowMs]. While the
+                    // VT-append drain is backlogged it returns a WIDER window, so the
+                    // repaint/affordance-extraction this signal drives fires less often
+                    // and the frame-budgeted drain gets more contiguous main-thread
+                    // frames (drain priority) — without ever suppressing the repaint, so
+                    // the screen stays live and affordances keep refreshing during the
+                    // burst. Clamp to at least [windowMs] so a bad predicate can never
+                    // TIGHTEN the window into an O(N) storm.
+                    val holdMs = backlogWindowMs().coerceAtLeast(windowMs)
+                    if (holdMs > 0L) {
+                        delay(holdMs)
                     }
                 }
             } catch (t: CancellationException) {
@@ -123,3 +166,17 @@ internal fun Flow<Unit>.coalescePerFrame(windowMs: Long = RENDER_FRAME_WINDOW_MS
  * [com.pocketshell.core.tmux.LayoutChangeCoalescer.DEFAULT_WINDOW_MS].
  */
 internal const val RENDER_FRAME_WINDOW_MS: Long = 16L
+
+/**
+ * Issue #1286 — the WIDENED render-coalescing window used while the frame-budgeted
+ * VT-append drain is backlogged (a Codex `%output` burst is still draining). At 64 ms
+ * (~15 fps) the repaint + affordance extraction the render signal drives fires ~4× less
+ * often than the base 16 ms window, so the frame-budgeted drain gets ~4× more contiguous
+ * main-thread frames to finish the burst (drain priority) — enough to erase the ~25%
+ * append-throughput drop that #1260's per-frame repaint introduced and that, with the
+ * composer/IME amplifier, tipped into the >5 s ANR. Still repaints ~15 fps, so the
+ * screen stays live and tappable affordances keep refreshing during the burst (no
+ * frozen/blank pane, no dead links). Reverts to [RENDER_FRAME_WINDOW_MS] the instant the
+ * drain catches up.
+ */
+internal const val DRAIN_PRIORITY_WINDOW_MS: Long = 64L

--- a/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurface.kt
+++ b/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurface.kt
@@ -288,7 +288,28 @@ fun TerminalSurface(
     // the URL scan, and the SmartSelection/FilePath/EngineCommand overlays, so
     // every per-render scan is gated, not just the repaint. Remembered per
     // `state` so the operator (and its conflating channel) survives recomposition.
-    val coalescedRenderRequests = remember(state) { state.renderRequests.coalescePerFrame() }
+    //
+    // Issue #1286: give the frame-budgeted VT-append drain main-thread priority
+    // while a `%output` burst is draining. When the drain queue is backlogged
+    // (`renderDrainBacklogged()`), the coalescer WIDENS its window to
+    // [DRAIN_PRIORITY_WINDOW_MS] so the per-frame repaint (and the affordance
+    // extraction the same signal drives) fires ~4× less often — handing the append
+    // drain more contiguous main-thread frames to finish the burst instead of the
+    // on-main repaint/onDraw starving it into the ANR. It does NOT suppress the
+    // repaint: the screen keeps updating (~15fps) during the burst and tappable
+    // affordances keep refreshing, so this fixes the freeze AND avoids a
+    // frozen/blank-during-burst regression; the settled frame still paints once the
+    // drain catches up (the #1286 black-screen face). Reverts to the base ~60fps
+    // window the instant the drain drains. Inert without a bridge (plain SSH): the
+    // predicate is `false`, so the base window is always used and behaviour is
+    // unchanged.
+    val coalescedRenderRequests = remember(state) {
+        state.renderRequests.coalescePerFrame(
+            backlogWindowMs = {
+                if (state.renderDrainBacklogged()) DRAIN_PRIORITY_WINDOW_MS else RENDER_FRAME_WINDOW_MS
+            },
+        )
+    }
 
     LaunchedEffect(terminalKeyboardMode, terminalView) {
         val view = terminalView ?: return@LaunchedEffect
@@ -381,9 +402,21 @@ fun TerminalSurface(
     // RESEED repaints every row regardless of cache state.
     LaunchedEffect(state, terminalView) {
         val view = terminalView ?: return@LaunchedEffect
-        state.fullRepaintRequests.collect {
-            runCatching { view.forceFullRepaint() }
-                .onFailure { onLocalTerminalError?.invoke(it) }
+        // Issue #1286 (black-screen face): collect the reattach/reseed force-repaint
+        // on the Handler-based [Dispatchers.Main.immediate], NOT the LaunchedEffect's
+        // default frame-gated AndroidUiDispatcher.Main — same rationale as the #1260
+        // repaint collector. On a beyond-grace reattach the pane is re-seeded WHILE a
+        // `%output` burst may still be draining; the Choreographer frames the
+        // frame-gated dispatcher batches to can stall for the whole burst, so the seed
+        // repaint would never fire and the freshly seeded rows stay black (the
+        // blank-pane-on-attach the maintainer reported, exercised by
+        // PreExistingMultiWindowSeedE2eTest). The main-looper immediate dispatcher is
+        // not frame-gated, so the seed repaint lands regardless of the burst.
+        withContext(Dispatchers.Main.immediate) {
+            state.fullRepaintRequests.collect {
+                runCatching { view.forceFullRepaint() }
+                    .onFailure { onLocalTerminalError?.invoke(it) }
+            }
         }
     }
 
@@ -395,9 +428,15 @@ fun TerminalSurface(
     // the recovery the model reseed is architecturally incapable of providing.
     LaunchedEffect(state, terminalView) {
         val view = terminalView ?: return@LaunchedEffect
-        state.surfaceRepaintRequests.collect {
-            runCatching { view.forceSurfaceRepaint() }
-                .onFailure { onLocalTerminalError?.invoke(it) }
+        // Issue #1286 (black-screen face): as with [fullRepaintRequests] above, collect
+        // the surface force-repaint on the non-frame-gated [Dispatchers.Main.immediate]
+        // so a surface-only-black recovery still fires while a `%output` burst has the
+        // Choreographer frame loop stalled.
+        withContext(Dispatchers.Main.immediate) {
+            state.surfaceRepaintRequests.collect {
+                runCatching { view.forceSurfaceRepaint() }
+                    .onFailure { onLocalTerminalError?.invoke(it) }
+            }
         }
     }
 

--- a/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurfaceState.kt
+++ b/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurfaceState.kt
@@ -164,6 +164,48 @@ class TerminalSurfaceState(
     internal val renderRequests: SharedFlow<Unit> get() = _renderRequests.asSharedFlow()
 
     /**
+     * Issue #1286 — true when the frame-budgeted VT-append drain still has
+     * unparsed `%output` bytes buffered in the bridge's process→terminal queue
+     * (`availableProcessOutputBytes() > 0`). During a Codex `%output` burst this
+     * stays true for the whole burst; [TerminalSurface] gates its per-frame
+     * repaint on `!renderDrainBacklogged()` so the append drain owns the main
+     * thread and finishes the burst tail instead of the on-main repaint starving
+     * it into the ANR — and the settled frame paints the moment the drain catches
+     * up (so the pane never stays stale/blank, the #1286 black-screen face).
+     *
+     * Returns `false` when no bridge is attached — a plain-SSH surface feeds the
+     * emulator synchronously (no frame-budgeted queue to back up) and every unit
+     * test without a real bridge — so those paths are UNCHANGED and the gate is
+     * inert without a drain to prioritise. Read on the main looper (the coalescer
+     * collector site), matching the [MainThreadDrainScheduler]'s own read.
+     */
+    fun renderDrainBacklogged(): Boolean {
+        renderDrainBackloggedOverrideForTest?.let { return it }
+        return (bridge?.pendingProcessOutputBytes() ?: 0) > 0
+    }
+
+    /**
+     * Test-only seam (#1286, the #780 synthetic-state model): force the value
+     * [renderDrainBacklogged] reports, WITHOUT needing a real bridge whose drain
+     * actually falls behind. The maintainer's on-device freeze only occurs when the
+     * drain genuinely backlogs under a heavy burst + the composer/IME amplifier; on
+     * the fast CI/dev x86 emulator the drain NEVER falls behind, so the real
+     * `availableProcessOutputBytes()` stays 0 and the drain-priority window would
+     * never engage — a connected proof would pass vacuously with or without the fix.
+     * Injecting the backlogged state here lets the on-device proof drive the terminal
+     * into the exact state where the drain-priority window is the load-bearing thing,
+     * so neutralising the production widening makes the proof go RED. A `null`
+     * override (the default) restores the real bridge-queue read — production is
+     * UNCHANGED (this seam is never touched outside tests).
+     */
+    @Volatile
+    private var renderDrainBackloggedOverrideForTest: Boolean? = null
+
+    fun setRenderDrainBackloggedOverrideForTest(backlogged: Boolean?) {
+        renderDrainBackloggedOverrideForTest = backlogged
+    }
+
+    /**
      * Force-full-repaint requests (PocketShell #721). Unlike [renderRequests]
      * — which feed the #469 dirty-region path and repaint only changed rows —
      * a signal here means "the EXISTING screen content must be redrawn from the

--- a/shared/core-terminal/src/test/java/com/pocketshell/core/terminal/ui/RenderDrainPriorityTest.kt
+++ b/shared/core-terminal/src/test/java/com/pocketshell/core/terminal/ui/RenderDrainPriorityTest.kt
@@ -1,0 +1,328 @@
+package com.pocketshell.core.terminal.ui
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Issue #1286 — DETERMINISTIC JVM reproduction of the Codex-`%output`-burst freeze
+ * AND its black-screen twin, and the drain-priority fix.
+ *
+ * ## The regression this reproduces (root-cause comment on #1286)
+ *
+ * `6090ef6e` (#1260) moved the terminal render-stream collectors onto the
+ * Handler-based `Dispatchers.Main.immediate`. During a `%output` burst those
+ * collectors now fire `TerminalView.onScreenUpdated()` (→ an on-main `onDraw` of the
+ * whole grid) plus the per-frame viewport affordance extraction EVERY ~16 ms frame,
+ * on the SAME main looper as the frame-budgeted VT-append drain
+ * ([com.pocketshell.core.terminal.bridge.MainThreadDrainScheduler]). Each per-frame
+ * repaint STEALS main-thread slices from the drain, so append throughput falls (~25%
+ * on-device) and the burst tail never finishes within the frame budget:
+ *  - the main thread pins for seconds → the reported ANR (the freeze face), AND
+ *  - the tail that would paint the settled frame never drains → the pane is left
+ *    showing stale/partial content (the black-screen face; #803 dropped its final
+ *    marker for exactly this reason).
+ *
+ * ## The fix under test — a WIDER coalescing window while draining (not suppression)
+ *
+ * The fix does NOT suppress the repaint during a burst (that would freeze the screen
+ * for the whole burst and kill tappable affordances — a different regression). It
+ * WIDENS the [coalescePerFrame] window from [RENDER_FRAME_WINDOW_MS] to
+ * [DRAIN_PRIORITY_WINDOW_MS] while the drain is backlogged, so the repaint (and the
+ * affordance extraction the same signal drives) fires ~4× less often — the drain gets
+ * ~4× more contiguous main-thread frames to finish the burst — while the screen still
+ * repaints at the widened cadence (~15 fps) so it stays LIVE and affordances keep
+ * refreshing. The base window (and ~60 fps repaint) resumes the instant the drain
+ * catches up.
+ *
+ * ## The model (deterministic, no emulator, no real Handler)
+ *
+ * We model the ONE shared main looper as a discrete per-frame timeline. Each ~16 ms
+ * frame the main thread has [FRAME_BUDGET_MS] of work time that the VT-append drain
+ * and the per-frame repaint COMPETE for (both run on the same looper in production):
+ *  - a repaint (`onScreenUpdated` → on-main `onDraw` + affordance extraction) costs
+ *    [REPAINT_COST_MS] of the frame,
+ *  - each drain slice (one `mEmulator.append`) costs [SLICE_COST_MS],
+ *  - so a frame in which a repaint fired drains fewer slices than one in which it did
+ *    not — the exact throughput theft the root cause describes.
+ *
+ * The repaint TIMING is produced by the REAL [coalescePerFrame] operator the
+ * production [TerminalSurface] drives its repaint off, using the SAME production
+ * windows ([RENDER_FRAME_WINDOW_MS] / [DRAIN_PRIORITY_WINDOW_MS]) — so the fix under
+ * test is exercised for real, not proxied.
+ *
+ * ## Red → green
+ *
+ *  - UNGATED (base window always, the pre-#1286 wiring): a repaint fires every frame
+ *    → the drain gets only [FRAME_BUDGET_MS] − [REPAINT_COST_MS] per frame → the burst
+ *    does NOT fully drain within the bounded settle window → **backlog remains > 0**
+ *    (the freeze/dropped-tail symptom), and the repaint count is O(frames).
+ *  - GATED (window widens to [DRAIN_PRIORITY_WINDOW_MS] while backlogged, the #1286
+ *    fix): the repaint fires ~4× less often → the drain gets far more full frames →
+ *    the burst **fully drains within the settle window** (backlog == 0). AND the
+ *    repaint still fires during the burst (≥ 1 — the screen stays LIVE, not frozen)
+ *    and the settled frame paints after the drain clears (≥ 1 — content shown, never
+ *    "drained but black"). So both #1286 faces are covered without a
+ *    frozen-during-burst regression.
+ *
+ * The [RenderFrameCoalescerTest] is the sibling that proves the raw coalescing
+ * contract; this proves the drain-priority window that #1286 adds on top of it.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class RenderDrainPriorityTest {
+
+    /** Outcome of running the burst through the shared-main-looper model under one window policy. */
+    private data class BurstOutcome(
+        val backlogRemaining: Int,
+        val repaintsWhileBacklogged: Long,
+        val repaintsAfterDrained: Long,
+        val framesToDrain: Int, // -1 if it never drained within the settle window
+    )
+
+    @Test
+    fun `ungated repaint starves the drain - drain-priority window finishes the burst and keeps painting`() = runTest {
+        // The pre-#1286 wiring: the base window always, so a repaint fires EVERY frame
+        // and steals from the drain.
+        val ungated = runBurst { RENDER_FRAME_WINDOW_MS }
+        // The #1286 fix: the window WIDENS while the drain is backlogged.
+        val backlog = AtomicInteger(0)
+        val gated = runBurst(backlogRef = backlog) {
+            if (backlog.get() > 0) DRAIN_PRIORITY_WINDOW_MS else RENDER_FRAME_WINDOW_MS
+        }
+
+        // ---- RED (reproduction): with the pre-fix per-frame repaint the drain is
+        // starved — the ${BURST_SLICES}-slice burst does NOT finish within the bounded
+        // settle window, so the tail never lands (freeze / dropped-final-frame), and
+        // the repaint ran on the main thread ~every frame throughout (the O(N) theft).
+        assertTrue(
+            "REPRO (#1286): with the pre-fix per-frame repaint the ${BURST_SLICES}-slice burst " +
+                "must NOT fully drain within the $SETTLE_FRAMES-frame settle window (the drain is " +
+                "starved) — backlogRemaining=${ungated.backlogRemaining}",
+            ungated.backlogRemaining > 0,
+        )
+        assertEquals(
+            "REPRO (#1286): the ungated path never converges within the settle window",
+            -1,
+            ungated.framesToDrain,
+        )
+        assertTrue(
+            "REPRO (#1286): the ungated path repaints on the main thread ~every frame during the " +
+                "burst (the O(N) onDraw theft) — repaintsWhileBacklogged=${ungated.repaintsWhileBacklogged}",
+            ungated.repaintsWhileBacklogged >= (SETTLE_FRAMES * 3 / 4),
+        )
+
+        // ---- GREEN (fix): the drain-priority window lets the SAME burst FULLY drain
+        // within the settle window.
+        assertEquals(
+            "FIX (#1286): with the drain-priority window the burst must FULLY drain (no lost tail) — " +
+                "backlogRemaining=${gated.backlogRemaining}",
+            0,
+            gated.backlogRemaining,
+        )
+        assertTrue(
+            "FIX (#1286): the gated burst must drain within the $SETTLE_FRAMES-frame settle window; " +
+                "framesToDrain=${gated.framesToDrain}",
+            gated.framesToDrain in 1..SETTLE_FRAMES,
+        )
+        assertTrue(
+            "FIX (#1286): the drain must finish with the priority window (gated=${gated.framesToDrain} " +
+                "frames) where the starved ungated path never converged",
+            gated.framesToDrain < SETTLE_FRAMES,
+        )
+
+        // ---- DRAIN PRIORITY: the fix works by making the repaint fire LESS often
+        // during the burst (freeing frames for the drain), not by any other means.
+        assertTrue(
+            "FIX (#1286): the drain-priority window must repaint FEWER times during the burst than the " +
+                "pre-fix per-frame path (that reduced main-thread theft is what lets the drain finish) — " +
+                "gated=${gated.repaintsWhileBacklogged} vs ungated=${ungated.repaintsWhileBacklogged}",
+            gated.repaintsWhileBacklogged < ungated.repaintsWhileBacklogged,
+        )
+
+        // ---- NO FROZEN/BLACK SCREEN (the reason we WIDEN rather than SUPPRESS): the
+        // screen must keep updating DURING the burst (≥ 1 repaint while backlogged) —
+        // suppressing repaints entirely for the whole burst would freeze the pane and
+        // kill tappable affordances (the regression an earlier draft hit). AND once the
+        // drain catches up the settled frame MUST paint (≥ 1 after drained), so the
+        // pane is never left "drained but black".
+        assertTrue(
+            "FIX (#1286): the screen must stay LIVE during the burst — the repaint must still fire at " +
+                "least once while backlogged (we WIDEN the window, we do NOT suppress); " +
+                "repaintsWhileBacklogged=${gated.repaintsWhileBacklogged}",
+            gated.repaintsWhileBacklogged >= 1,
+        )
+        assertTrue(
+            "FIX (#1286 black-screen face): once the drain reaches availableBytes()==0 the settled " +
+                "frame MUST paint (content shown, never 'drained but blank') — " +
+                "repaintsAfterDrained=${gated.repaintsAfterDrained}",
+            gated.repaintsAfterDrained >= 1,
+        )
+    }
+
+    /**
+     * Focused operator contract for the #1286 drain-priority window: a sustained
+     * render-request storm drives FEWER downstream repaints while the window is WIDE
+     * (drain backlogged) than while it is the base width — but NEVER zero (the screen
+     * stays live). This is the raw proof that widening the window throttles the freeze
+     * driver without freezing the screen.
+     */
+    @Test
+    fun `wider backlog window throttles repaints but never suppresses them`() = runTest {
+        fun countOverStorm(window: () -> Long): Long {
+            val source = MutableSharedFlow<Unit>(extraBufferCapacity = 4096)
+            val repaints = AtomicLong(0)
+            val collector = launch {
+                source.coalescePerFrame(windowMs = RENDER_FRAME_WINDOW_MS, backlogWindowMs = window)
+                    .collect { repaints.incrementAndGet() }
+            }
+            runCurrent()
+            // 40 frames of continuous render requests (a sustained burst).
+            repeat(40) {
+                source.tryEmit(Unit)
+                advanceTimeBy(RENDER_FRAME_WINDOW_MS)
+                runCurrent()
+            }
+            advanceTimeBy(DRAIN_PRIORITY_WINDOW_MS * 2)
+            runCurrent()
+            collector.cancel()
+            return repaints.get()
+        }
+
+        val baseWindowRepaints = countOverStorm { RENDER_FRAME_WINDOW_MS }
+        val wideWindowRepaints = countOverStorm { DRAIN_PRIORITY_WINDOW_MS }
+
+        assertTrue(
+            "the WIDE drain-priority window must repaint FEWER times over the same storm (throttled) — " +
+                "wide=$wideWindowRepaints vs base=$baseWindowRepaints",
+            wideWindowRepaints < baseWindowRepaints,
+        )
+        assertTrue(
+            "the WIDE window must STILL repaint (the screen stays live during a burst, never frozen) — " +
+                "wide=$wideWindowRepaints",
+            wideWindowRepaints >= 1,
+        )
+    }
+
+    /**
+     * Guard: the default (no-arg) [coalescePerFrame] is UNCHANGED by #1286 — it emits
+     * once per base window, so plain-SSH surfaces and every existing consumer keep the
+     * exact pre-#1286 behaviour.
+     */
+    @Test
+    fun `default coalescePerFrame is unchanged - one emit per base window`() = runTest {
+        val source = MutableSharedFlow<Unit>(extraBufferCapacity = 64)
+        val repaints = AtomicLong(0)
+        val collector = launch {
+            source.coalescePerFrame(windowMs = RENDER_FRAME_WINDOW_MS).collect { repaints.incrementAndGet() }
+        }
+        runCurrent()
+        source.tryEmit(Unit)
+        advanceTimeBy(RENDER_FRAME_WINDOW_MS * 2)
+        runCurrent()
+        assertEquals("default window must emit once per base window (pre-#1286 behaviour)", 1L, repaints.get())
+        collector.cancel()
+    }
+
+    /**
+     * Drive [BURST_SLICES] of queued `%output` work through the shared-main-looper
+     * model under [backlogWindow], returning how far the drain got and how the repaints
+     * split around the drain-complete boundary.
+     *
+     * Per frame: emit one render request (the drain producing screen updates), let the
+     * REAL [coalescePerFrame] operator emit (throttled by [backlogWindow] while
+     * backlogged) for the window, then drain a slice count sized by whatever frame
+     * budget the repaint left.
+     */
+    private fun TestScope.runBurst(
+        backlogRef: AtomicInteger = AtomicInteger(0),
+        backlogWindow: () -> Long,
+    ): BurstOutcome {
+        val backlog = backlogRef.also { it.set(BURST_SLICES) }
+        val source = MutableSharedFlow<Unit>(extraBufferCapacity = 4096)
+        val repaints = AtomicLong(0)
+        val collector = launch {
+            source.coalescePerFrame(windowMs = RENDER_FRAME_WINDOW_MS, backlogWindowMs = backlogWindow)
+                .collect { repaints.incrementAndGet() }
+        }
+        runCurrent()
+
+        var repaintsWhileBacklogged = 0L
+        var repaintsAfterDrained = 0L
+        var framesToDrain = -1
+
+        // Run the burst + a bounded settle window. A frame in which a repaint fired
+        // drains fewer slices (the repaint stole main-thread time), modelling the
+        // #1286 contention on the one looper.
+        for (frame in 0 until SETTLE_FRAMES) {
+            val backloggedAtFrameStart = backlog.get() > 0
+            val repaintsBefore = repaints.get()
+
+            // A render request for this frame (the drain produces screen updates as it
+            // parses). The coalescer throttles these by the current window.
+            if (backloggedAtFrameStart) source.tryEmit(Unit)
+            advanceTimeBy(RENDER_FRAME_WINDOW_MS)
+            runCurrent()
+
+            val repaintsThisFrame = repaints.get() - repaintsBefore
+            if (backloggedAtFrameStart) {
+                repaintsWhileBacklogged += repaintsThisFrame
+            } else {
+                repaintsAfterDrained += repaintsThisFrame
+            }
+
+            if (backloggedAtFrameStart) {
+                // The frame's main-thread budget minus whatever the repaint(s) stole.
+                val stolen = repaintsThisFrame * REPAINT_COST_MS
+                val drainBudget = (FRAME_BUDGET_MS - stolen).coerceAtLeast(0L)
+                val slices = (drainBudget / SLICE_COST_MS).toInt()
+                if (slices > 0) backlog.addAndGet(-minOf(slices, backlog.get()))
+                if (backlog.get() == 0 && framesToDrain == -1) framesToDrain = frame + 1
+            }
+        }
+
+        collector.cancel()
+        return BurstOutcome(
+            backlogRemaining = backlog.get(),
+            repaintsWhileBacklogged = repaintsWhileBacklogged,
+            repaintsAfterDrained = repaintsAfterDrained,
+            framesToDrain = framesToDrain,
+        )
+    }
+
+    private companion object {
+        // A Codex `%output` burst worth of queued 2 KB drain slices. Sized so the
+        // starved (base-window) path cannot finish within the settle window while the
+        // drain-priority (wide-window) path finishes with comfortable margin.
+        const val BURST_SLICES = 420
+
+        // The bounded settle window (frames) the burst must fully drain within. The
+        // drain-priority path drains in ~33 frames; the base-window (starved) path
+        // needs ~42 → it does NOT converge within this window (the reproduction).
+        const val SETTLE_FRAMES = 38
+
+        // Per-frame shared main-thread work budget (ms of a ~16 ms frame available for
+        // the drain + repaint after fixed looper/compositor overhead). Anchored near
+        // MainThreadDrainScheduler.DEFAULT_MAX_TURN_MILLIS's "half a frame per turn"
+        // budgeting — a frame gives the drain about a full turn plus headroom.
+        const val FRAME_BUDGET_MS = 14L
+
+        // Cost of one per-frame repaint: onScreenUpdated() → an on-main onDraw of the
+        // whole grid + the per-frame viewport affordance extraction. Sized so a repaint
+        // each frame (base window) drops drain throughput ~28% (14 → 10 slices/frame),
+        // matching the ~25% on-device append-throughput drop in the root cause. The
+        // wide window fires it only ~1-in-4 frames, so the average drop is ~7%.
+        const val REPAINT_COST_MS = 4L
+
+        // Cost of one drain slice (one 2 KB mEmulator.append VT parse).
+        const val SLICE_COST_MS = 1L
+    }
+}


### PR DESCRIPTION
Fixes the maintainer's hard freeze (Codex %output burst + composer/keyboard up → main-thread ANR) and its black/blank-pane twin. Root cause: #1260 render collectors on `Main.immediate` starve the frame-budgeted VT drain during a burst.

**Fix:** adaptive drain-priority render window (widens 16ms→64ms while backlogged; widen-not-suppress) + move reattach/reseed repaints to `Main.immediate` for the blank-pane-on-attach face.

**Verified red→green on-device (reviewer-confirmed independently):**
- #796 guard forces the backlog state (#780 model); load-bearing = production-wired gated coalescer cadence: **RED without fix (gated 357 > ceiling 133), GREEN with fix (93 ≤ 133)**.
- Real rendered-surface pixel proof: non-black fraction **0.18**, `surfaceIsBlackWhileModelHasContent=false` (reassembled PNG shows glyphs, not black).
- New deterministic JVM `RenderDrainPriorityTest` red→green.
- Full `:shared:core-terminal:testDebugUnitTest` 470 green; adjacency sweep holds (#803 marker present, scanners fire, no blank-pane-on-attach regression).

Reviewer: APPROVED (round 2) — https://github.com/alexeygrigorev/pocketshell/issues/1286#issuecomment-4883055163

Closes #1286