### PR TITLE
test: de-flake TmuxSessionViewModelTest CME (#1289)

### DIFF
--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
@@ -18542,7 +18542,16 @@ class TmuxSessionViewModelTest {
         @Volatile
         var closed: Boolean = false
 
-        val execCommands = mutableListOf<String>()
+        // Issue #1289: exec() appends to this list from a real Dispatchers.IO
+        // thread (the recorded-kind read runs off-Main), while test-thread
+        // `awaitCondition` predicates walk it via Kotlin `.count { }` / `.any { }`
+        // (an iterator walk). A plain ArrayList throws ConcurrentModificationException
+        // on that concurrent iterate+append — the flake that red-blocked the
+        // pre-release confidence gate under `--no-parallel --max-workers=2`. A
+        // CopyOnWriteArrayList iterates over a stable snapshot and copies on append,
+        // so no predicate read can ever race the exec() append. Class-covering: this
+        // makes EVERY execCommands read across the suite race-safe, not just one test.
+        val execCommands: MutableList<String> = java.util.concurrent.CopyOnWriteArrayList()
         private var cardGetIndex: Int = 0
 
         // Issue #793: let a paging test reprogram the window the fake returns.


### PR DESCRIPTION
De-flakes `TmuxSessionViewModelTest.cacheRestoreThenScreenRefreshDoesNotDoubleSeed`, which intermittently red-blocked the pre-release confidence gate with a `ConcurrentModificationException`.

Root cause: `FakeSshSession.execCommands` (plain `ArrayList`) is appended from `Dispatchers.IO` in `exec()` while the test thread's `awaitCondition` predicate iterates it — CME under the gate's `--no-parallel --max-workers=2 --no-build-cache` schedule. Fix: back it with `java.util.concurrent.CopyOnWriteArrayList` (stable-snapshot iteration, copy-on-write append). Test-only, class-covering (every `execCommands` reader is now race-safe), assertion semantics preserved.

Reviewer: APPROVED — red→green 5/5 (ArrayList) vs 0/5 (COW), green 5× under gate flags, 376 tests 0 failures. https://github.com/alexeygrigorev/pocketshell/issues/1289#issuecomment-4883182708

Closes #1289