### PR TITLE
core-terminal/tmux: three-state heal watchdog — capture failure never counts as healthy (#1294)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/AgentAltScreenPartialBlackHealJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/AgentAltScreenPartialBlackHealJourneyE2eTest.kt
@@ -22,6 +22,7 @@ import com.pocketshell.app.hosts.SshKeyStorage
 import com.pocketshell.app.tmux.TMUX_SESSION_ERROR_TAG
 import com.pocketshell.app.tmux.TMUX_SESSION_RECONNECT_TAG
 import com.pocketshell.app.tmux.TMUX_SESSION_SCREEN_TAG
+import com.pocketshell.app.tmux.HealOutcome
 import com.pocketshell.app.tmux.TmuxSessionViewModel
 import com.pocketshell.core.ssh.KnownHostsPolicy
 import com.pocketshell.core.ssh.SshConnection
@@ -208,7 +209,9 @@ class AgentAltScreenPartialBlackHealJourneyE2eTest {
     // ---------------------------------------------------------------- Heal driver
 
     private fun driveStaleRenderHeal(): Boolean {
-        var result = false
+        // Issue #1294: the oracle now returns a three-state [HealOutcome]; "the heal fired"
+        // is the HEALED outcome (a real divergence found + repaired).
+        var result: HealOutcome = HealOutcome.Unverified
         val latch = java.util.concurrent.CountDownLatch(1)
         compose.activityRule.scenario.onActivity { activity ->
             val vm = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
@@ -217,7 +220,7 @@ class AgentAltScreenPartialBlackHealJourneyE2eTest {
         }
         latch.await(RESTORE_TIMEOUT_MS, java.util.concurrent.TimeUnit.MILLISECONDS)
         InstrumentationRegistry.getInstrumentation().waitForIdleSync()
-        return result
+        return result == HealOutcome.Healed
     }
 
     private fun activePanePartiallyBlank(): Boolean {

--- a/app/src/androidTest/java/com/pocketshell/app/proof/StaleRenderHealOnLiveTransportJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/StaleRenderHealOnLiveTransportJourneyE2eTest.kt
@@ -26,6 +26,7 @@ import com.pocketshell.app.tmux.TMUX_SESSION_ERROR_TAG
 import com.pocketshell.app.tmux.TMUX_SESSION_RECONNECT_TAG
 import com.pocketshell.app.tmux.TMUX_SESSION_SCREEN_TAG
 import com.pocketshell.app.tmux.TMUX_SWITCHING_LOADING_TAG
+import com.pocketshell.app.tmux.HealOutcome
 import com.pocketshell.app.tmux.TmuxSessionViewModel
 import com.pocketshell.core.ssh.KnownHostsPolicy
 import com.pocketshell.core.ssh.SshConnection
@@ -262,7 +263,9 @@ class StaleRenderHealOnLiveTransportJourneyE2eTest {
      * healActivePaneIfStaleRenderForTest]. Returns whether the heal fired.
      */
     private fun driveStaleRenderHeal(): Boolean {
-        var result = false
+        // Issue #1294: the oracle now returns a three-state [HealOutcome]; "the heal fired"
+        // is the HEALED outcome (a real divergence found + repaired).
+        var result: HealOutcome = HealOutcome.Unverified
         val latch = java.util.concurrent.CountDownLatch(1)
         launchedActivity?.onActivity { activity ->
             val vm = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
@@ -273,7 +276,7 @@ class StaleRenderHealOnLiveTransportJourneyE2eTest {
         }
         latch.await(RESTORE_TIMEOUT_MS, java.util.concurrent.TimeUnit.MILLISECONDS)
         InstrumentationRegistry.getInstrumentation().waitForIdleSync()
-        return result
+        return result == HealOutcome.Healed
     }
 
     private fun activePaneBlankOrPartiallyBlank(): Boolean {

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -11574,6 +11574,11 @@ public class TmuxSessionViewModel @Inject constructor(
             var tick = 0
             // Issue #1166: consecutive stable ticks drive the back-off interval.
             var stableTicks = 0
+            // Issue #1294: consecutive UNVERIFIED heal ticks (capture timeout/error/empty/
+            // mutex-starved). Recorded into the exportable diagnostics so a shared log can
+            // tell a genuinely-idle backed-off pane from a pane whose heal captures are
+            // WEDGED while it is black. Reset on any confirming (HEALTHY/HEALED) tick.
+            var unverifiedStreak = 0
             while (tick < staleRenderWatchdogMaxTicks) {
                 // Issue #1166: wait out the (possibly backed-off) interval, but a
                 // fresh active-pane %output wake cuts a backed-off wait short so a
@@ -11591,6 +11596,7 @@ public class TmuxSessionViewModel @Inject constructor(
                     // watchdog alive but skip the heal until Connected resumes. Reset
                     // the back-off so the resume tick captures at the hot cadence.
                     stableTicks = 0
+                    unverifiedStreak = 0
                     tick += 1
                     continue
                 }
@@ -11599,6 +11605,7 @@ public class TmuxSessionViewModel @Inject constructor(
                 // reset the back-off so the first tick after resume captures hot.
                 if (!shouldRunStaleRenderWatchdogCapture()) {
                     stableTicks = 0
+                    unverifiedStreak = 0
                     tick += 1
                     continue
                 }
@@ -11610,22 +11617,43 @@ public class TmuxSessionViewModel @Inject constructor(
                 noteActivePaneAltBufferState()
                 val activePane = activeVisiblePane()
                 if (activePane != null) {
-                    val healed = runCatching {
+                    val outcome = runCatching {
                         healActivePaneIfStaleRender(client, activePane, refreshGuard)
-                    }.getOrDefault(false)
-                    // Issue #1219 (steady-heat fix): back off UNLESS the authoritative
-                    // heal oracle just found (and repaired) a divergence. Only a real
-                    // divergence — a black / partial-black / stale render vs tmux's grid
-                    // — snaps the cadence back to hot; a CONFIRMED-HEALTHY tick backs off
-                    // (4s -> 8s -> 16s) even when the pane is actively streaming %output.
+                    }.getOrDefault(HealOutcome.Unverified)
+                    // Issue #1294 (three-state scoring — the load-bearing fix): score the
+                    // tick by WHICH of the three oracle outcomes it was, never conflating a
+                    // capture FAILURE with a confirmed-healthy tick.
                     //
-                    // Before #1219 ANY new %output (or an output wake) reset the back-off,
-                    // so a continuously-streaming-but-correct agent pane never left the hot
-                    // 4s cadence and paid a capture-pane round-trip every 4s forever (the
-                    // #1164 "runs warm" lever). A streaming-but-BLACK pane still heals fast:
-                    // its render is locally suspect, so its %output wakes the backed-off
-                    // wait ([awaitStaleRenderWatchdogTick]) and this tick heals it hot.
-                    stableTicks = if (healed) 0 else stableTicks + 1
+                    //  - HEALTHY: the authoritative capture CONFIRMED the render matches tmux.
+                    //    This — and ONLY this — earns the #1219 steady-heat back-off (4s -> 8s
+                    //    -> 16s), even while the pane streams %output (the #1164 "runs warm"
+                    //    lever). Before #1294 a capture FAILURE was scored identically here, so
+                    //    consecutive failures throttled the watchdog to 16s exactly while the
+                    //    pane was black and a Claude burst had the -CC capture mutex wedged.
+                    //  - HEALED: the oracle found + repaired a real divergence (black / partial-
+                    //    black / stale render vs tmux's grid). Snap the cadence back to hot so a
+                    //    just-blacked pane is re-checked at 4s (#1138/#1153 heal preservation).
+                    //  - UNVERIFIED: the capture could NOT confirm health (timeout / error /
+                    //    empty-on-live-transport / mutex-starved). Keep the HOT cadence — never
+                    //    throttle — so a black pane whose heal captures are wedged keeps retrying
+                    //    at 4s until the mutex frees and the heal lands, instead of backing off
+                    //    to 16s while the user stares at a black pane. Record the streak into the
+                    //    exportable diagnostics (#1175) so an export tells "blind" from "idle".
+                    when (outcome) {
+                        HealOutcome.Healthy -> {
+                            stableTicks += 1
+                            unverifiedStreak = 0
+                        }
+                        HealOutcome.Healed -> {
+                            stableTicks = 0
+                            unverifiedStreak = 0
+                        }
+                        HealOutcome.Unverified -> {
+                            stableTicks = 0
+                            unverifiedStreak += 1
+                            recordHealCaptureUnverified(activePane, unverifiedStreak)
+                        }
+                    }
                 }
                 tick += 1
             }
@@ -11759,10 +11787,10 @@ public class TmuxSessionViewModel @Inject constructor(
      * without waiting on the watchdog cadence.
      */
     @androidx.annotation.VisibleForTesting
-    internal suspend fun healActivePaneIfStaleRenderForTest(): Boolean {
-        val client = clientRef ?: return false
-        val activePane = activeVisiblePane() ?: return false
-        val target = activeTarget ?: return false
+    internal suspend fun healActivePaneIfStaleRenderForTest(): HealOutcome {
+        val client = clientRef ?: return HealOutcome.Unverified
+        val activePane = activeVisiblePane() ?: return HealOutcome.Unverified
+        val target = activeTarget ?: return HealOutcome.Unverified
         val guard = RuntimeRefreshGuard(
             generation = connectGeneration,
             target = target,
@@ -11988,14 +12016,19 @@ public class TmuxSessionViewModel @Inject constructor(
         pane: TmuxPaneState,
         blackClass: String,
         captureText: String?,
+        // Issue #1294: present only on the [BLACK_FRAME_CLASS_HEAL_CAPTURE_UNVERIFIED]
+        // class — the count of consecutive UNVERIFIED heal ticks (capture timeout / error /
+        // empty / mutex-starved) the watchdog has seen without a confirming capture. It lets
+        // a shared-log export distinguish a genuinely-healthy pane that BACKED OFF (watchdog
+        // throttled, unverifiedStreak absent) from a pane whose heal captures are WEDGED
+        // (watchdog BLIND, unverifiedStreak climbing) — the exact #1294 mechanism.
+        unverifiedStreak: Int? = null,
     ) {
         val nowMs = SystemClock.elapsedRealtime()
         val lastSeedAtMs = paneLastSeedAtMs[pane.paneId]
         val lastOutputAtMs = paneLastOutputAtMs[pane.paneId]
         val state = pane.terminalState
-        DiagnosticEvents.record(
-            "terminal",
-            BLACK_FRAME_OBSERVED_EVENT,
+        val fields = mutableListOf<Pair<String, Any?>>(
             "class" to blackClass,
             "paneId" to pane.paneId,
             "windowId" to pane.windowId,
@@ -12003,7 +12036,8 @@ public class TmuxSessionViewModel @Inject constructor(
             "renderedChars" to state.renderedNonBlankCharCount(),
             // Byte count of the authoritative capture this observation was judged
             // against; 0 when the capture was empty/errored (the capture_empty /
-            // never_seeded classes) or unavailable at the site (the reveal gate).
+            // never_seeded / heal_capture_unverified classes) or unavailable at the
+            // site (the reveal gate).
             "captureBytes" to (captureText?.length ?: 0),
             "visibleRows" to state.visibleRowCount(),
             // -1 means the field is unavailable (never seeded / never streamed output).
@@ -12014,15 +12048,38 @@ public class TmuxSessionViewModel @Inject constructor(
             "screenOn" to isScreenInteractive(),
             "partialBlank" to state.visibleScreenIsPartiallyBlank(),
         )
+        if (unverifiedStreak != null) {
+            fields += "unverifiedStreak" to unverifiedStreak
+        }
+        DiagnosticEvents.record("terminal", BLACK_FRAME_OBSERVED_EVENT, *fields.toTypedArray())
+    }
+
+    /**
+     * Issue #1294: record a watchdog tick whose authoritative `capture-pane` could NOT
+     * confirm the render's health (a [HealOutcome.Unverified] outcome — capture timeout,
+     * error response, empty-on-live-transport, or mutex-starved by a concurrent burst).
+     * Rides the existing exportable `black_frame_observed` ring (#1175 conventions) under a
+     * dedicated class + an `unverifiedStreak` field, so an export can tell an idle healthy
+     * pane that legitimately backed off from a pane whose heal captures are WEDGED while it
+     * is black (the #1294 "watchdog blind, not throttled" distinction). Emitted from the
+     * watchdog tick that already paid the capture — no new poll/timer/round-trip.
+     */
+    private fun recordHealCaptureUnverified(pane: TmuxPaneState, unverifiedStreak: Int) {
+        recordBlackFrameObserved(
+            pane,
+            BLACK_FRAME_CLASS_HEAL_CAPTURE_UNVERIFIED,
+            captureText = null,
+            unverifiedStreak = unverifiedStreak,
+        )
     }
 
     private suspend fun healActivePaneIfStaleRender(
         client: TmuxClient,
         pane: TmuxPaneState,
         refreshGuard: RuntimeRefreshGuard?,
-    ): Boolean {
-        if (refreshGuard != null && !isCurrentRuntime(refreshGuard)) return false
-        if (client.disconnected.value) return false
+    ): HealOutcome {
+        if (refreshGuard != null && !isCurrentRuntime(refreshGuard)) return HealOutcome.Unverified
+        if (client.disconnected.value) return HealOutcome.Unverified
         // NOTE: this heal does NOT pre-skip a blank/partial-blank pane. The
         // divergence oracle ([visibleScreenDivergesFromCapture]) is the single
         // decision: it only fires when tmux's grid HAS substantial content while
@@ -12031,6 +12088,29 @@ public class TmuxSessionViewModel @Inject constructor(
         // a few scattered fragments (#966), or a post-burst clear. The heal is
         // idempotent (a full clear+repaint of tmux's authoritative grid), so even
         // if the blank watchdog also fires it just re-paints identical content.
+        //
+        // Issue #1294: the SURFACE-BLACK detector/heal runs FIRST — BEFORE and
+        // INDEPENDENT of the `capture-pane` round-trip below. A surface-only black (the
+        // MODEL grid is intact but the on-screen SURFACE is confirmed black, spike #874
+        // GAP-1) recovers with a PURE surface repaint that needs NO tmux content — so a
+        // wedged / timed-out capture must never gate it. Before #1294 this #1203 auto-heal
+        // sat INSIDE the capture-success branch, behind the empty/errored early-return, so
+        // a Claude burst that starved the shared capture mutex (the exact window a pane
+        // goes black) blocked the one recovery that never needed a capture at all. The
+        // repaint fires here on the surface-black signal; its exportable FINGERPRINT is
+        // recorded below where the authoritative captureBytes is known (or, when the
+        // capture then fails, in the capture-failed branch with captureBytes unknown).
+        val surfaceBlack = pane.terminalState.surfaceIsBlackWhileModelHasContent()
+        if (surfaceBlack) {
+            Log.i(
+                ISSUE_145_RECONNECT_TAG,
+                "tmux-surface-black-model-intact-heal pane=${pane.paneId} " +
+                    "window=${pane.windowId} session=${activeTarget?.sessionName} " +
+                    "status=${_connectionStatus.value} " +
+                    "rendered=${pane.terminalState.renderedNonBlankCharCount()}",
+            )
+            pane.terminalState.requestSurfaceRepaint()
+        }
         val combined = runCatching {
             withContext(seedIoDispatcher) {
                 client.captureWithCursor(
@@ -12040,17 +12120,36 @@ public class TmuxSessionViewModel @Inject constructor(
                 )
             }
         }.getOrNull()
-        if (refreshGuard != null && !isCurrentRuntime(refreshGuard)) return false
+        if (refreshGuard != null && !isCurrentRuntime(refreshGuard)) return HealOutcome.Unverified
         val captureResponse = combined?.capture
         if (captureResponse == null || captureResponse.isError || captureResponse.output.isEmpty()) {
-            // Issue #1175: capture-pane came back empty/errored on a LIVE transport.
-            // Fingerprint it ONLY when the render is actually degenerate (a healthy
-            // pane whose capture momentarily failed is NOT a black screen — stay
-            // silent so healthy ticks never record). A never-seeded pane (no seed has
-            // ever landed) is the distinct `never_seeded` class; otherwise this is the
-            // server-side `capture_empty` class. Rides the heal's existing capture — no
-            // new round-trip, no new poll.
-            if (pane.terminalState.renderedNonBlankCharCount() == 0 ||
+            // Issue #1294: the `capture-pane` round-trip could NOT confirm the render against
+            // tmux's grid — it timed out, errored, or came back EMPTY on a live transport (or
+            // was starved out by a concurrent burst holding the shared capture mutex). The
+            // surface repaint above already fired if the surface was black, so a
+            // surface-only-black recovers even on this path.
+            //
+            // The scoring turns on whether the LOCAL render currently looks LOST (black /
+            // partial-black / mostly-empty / surface-black — the same cheap local pre-check
+            // [visibleRenderMayHaveLostFrame] the suspect-wake gate uses):
+            //  - render LOOKS LOST → this is the #1294 UNVERIFIED case: we NEEDED this capture
+            //    to heal a suspect pane and could not get it. The watchdog MUST keep the hot
+            //    cadence (never throttle) so a black pane whose heal captures are wedged by a
+            //    Claude burst keeps retrying at 4s until the mutex frees — instead of scoring
+            //    the failure as a healthy tick and backing off to 16s (the exact bug).
+            //  - render looks HEALTHY → a momentarily-empty/failed capture over a confidently-
+            //    dense render is a non-urgent no-op; scoring it HEALTHY preserves the #1219 /
+            //    #1164 battery back-off (criterion 3 — do not regress the steady-heat lever).
+            val renderLooksLost = surfaceBlack || pane.terminalState.visibleRenderMayHaveLostFrame()
+            // Issue #1175: fingerprint the observed frame when it is degenerate so an export
+            // sees WHICH class of black it was — no new round-trip, it rides this same (failed)
+            // capture tick. A surface-only-black whose capture failed is the #1192 class
+            // (captureBytes unknown → 0); an empty capture over a degenerate render is the
+            // server-side `capture_empty`, or `never_seeded` when no seed ever landed. A healthy
+            // pane whose capture momentarily blipped stays silent here.
+            if (surfaceBlack) {
+                recordBlackFrameObserved(pane, BLACK_FRAME_CLASS_SURFACE_BLACK_MODEL_INTACT, captureText = null)
+            } else if (pane.terminalState.renderedNonBlankCharCount() == 0 ||
                 pane.terminalState.visibleScreenIsBlankOrPartiallyBlank()
             ) {
                 val blackClass = if (paneLastSeedAtMs[pane.paneId] == null) {
@@ -12060,7 +12159,7 @@ public class TmuxSessionViewModel @Inject constructor(
                 }
                 recordBlackFrameObserved(pane, blackClass, captureText = null)
             }
-            return false
+            return if (renderLooksLost) HealOutcome.Unverified else HealOutcome.Healthy
         }
         val captureText = captureResponse.output.joinToString(separator = "\n")
         // The discriminating check: tmux carries a real frame but the local render
@@ -12076,37 +12175,23 @@ public class TmuxSessionViewModel @Inject constructor(
         // guarded), restoring the FULL viewport from tmux's authoritative capture.
         if (!pane.terminalState.visibleRenderLostFrameVsCapture(captureText)) {
             // Issue #1192: the MODEL grid did NOT lose tmux's frame — the heal oracle,
-            // comparing model-vs-tmux, calls this pane HEALTHY and returns without
-            // touching the grid. But the on-screen SURFACE can still be black while the
-            // model is intact (a surface-only black never diverges from tmux by
-            // construction, spike #874 GAP-1), so it emits NONE of the five #1175
-            // classes above. Fingerprint that ONE otherwise-invisible class here — the
-            // exact site the oracle short-circuits — ONLY when the paint-confirmation
-            // seam says the surface is CONFIRMED black while the model holds content.
-            // Rides this same already-paid capture tick: NO new poll/timer (#1164).
-            if (pane.terminalState.surfaceIsBlackWhileModelHasContent()) {
+            // comparing model-vs-tmux, calls this pane HEALTHY. The authoritative capture
+            // CONFIRMED the render, so this is [HealOutcome.Healthy] — the ONLY outcome that
+            // earns the #1219 back-off. But the on-screen SURFACE can still be black while
+            // the model is intact (a surface-only black never diverges from tmux by
+            // construction, spike #874 GAP-1), so it emits NONE of the five #1175 classes.
+            // The #1203 surface repaint already fired above (issue #1294 moved it out from
+            // behind the capture); fingerprint that ONE otherwise-invisible class here where
+            // the authoritative captureBytes is known. Rides this same already-paid capture
+            // tick: NO new poll/timer (#1164).
+            if (surfaceBlack) {
                 recordBlackFrameObserved(
                     pane,
                     BLACK_FRAME_CLASS_SURFACE_BLACK_MODEL_INTACT,
                     captureText,
                 )
-                // Issue #1203: the AUTO-HEAL recovery for this class. A model reseed
-                // restores nothing here (the model already matches tmux — the oracle is
-                // blind to this class by construction), so the recovery is a SURFACE
-                // force-repaint: re-bind the View's emulator + full-clip invalidate so
-                // the surface repaints what the model already holds. This is the
-                // self-heal without user action — the maintainer no longer has to tap
-                // Redraw for a surface-only-black.
-                Log.i(
-                    ISSUE_145_RECONNECT_TAG,
-                    "tmux-surface-black-model-intact-heal pane=${pane.paneId} " +
-                        "window=${pane.windowId} session=${activeTarget?.sessionName} " +
-                        "status=${_connectionStatus.value} " +
-                        "rendered=${pane.terminalState.renderedNonBlankCharCount()}",
-                )
-                pane.terminalState.requestSurfaceRepaint()
             }
-            return false
+            return HealOutcome.Healthy
         }
         // Issue #1175: the render LOST tmux's frame (capture carries materially more
         // than the render). Fingerprint the observed black frame BEFORE the heal
@@ -12146,9 +12231,12 @@ public class TmuxSessionViewModel @Inject constructor(
         } catch (cause: Throwable) {
             if (cause is CancellationException) throw cause
             reportTerminalSurfaceFailure(pane.paneId, cause)
-            return false
+            // Issue #1294: the divergence was real but the surface write failed — the heal
+            // did not complete, so this is UNVERIFIED (keep the hot cadence to retry), not a
+            // confirmed-healthy back-off.
+            return HealOutcome.Unverified
         }
-        return true
+        return HealOutcome.Healed
     }
 
     private suspend fun seedPaneFromCaptureOnce(
@@ -14379,7 +14467,7 @@ public class TmuxSessionViewModel @Inject constructor(
                 // re-seed ONLY when the render is materially less than the authoritative frame.
                 val healed = runCatching {
                     healActivePaneIfStaleRender(client, activePane, guard)
-                }.getOrDefault(false)
+                }.getOrDefault(HealOutcome.Unverified) == HealOutcome.Healed
                 if (healed) {
                     Log.i(
                         ISSUE_145_RECONNECT_TAG,
@@ -18990,6 +19078,30 @@ internal const val ACTIVE_PANE_REVEAL_SEED_ATTEMPTS: Int = 5
  */
 internal const val BLACK_FRAME_OBSERVED_EVENT: String = "black_frame_observed"
 
+/**
+ * Issue #1294 — the three-state result of the stale-render heal oracle
+ * ([TmuxSessionViewModel.healActivePaneIfStaleRender]). It replaces the old boolean that
+ * conflated a capture FAILURE with a confirmed-healthy tick, which let the watchdog score
+ * consecutive capture failures identically to consecutive healthy ticks and back off to 16s
+ * exactly while the pane was black and the shared `-CC` capture mutex was wedged by a Claude
+ * burst. Only [Healthy] earns the #1219 back-off; [Unverified] keeps the hot cadence.
+ */
+internal enum class HealOutcome {
+    /** A real divergence was found and the model grid was re-seeded from tmux. Resets back-off. */
+    Healed,
+
+    /** The authoritative `capture-pane` CONFIRMED the render matches tmux. The ONLY outcome that backs off. */
+    Healthy,
+
+    /**
+     * The `capture-pane` round-trip could NOT confirm the render's health: it timed out,
+     * errored, came back empty on a live transport, or was starved out by a concurrent burst
+     * holding the shared capture mutex. Keeps the HOT cadence — never throttles — so a black
+     * pane whose heal captures are wedged keeps retrying at 4s instead of backing off to 16s.
+     */
+    Unverified,
+}
+
 /** Server-side black: capture-pane also empty/errored while the render is degenerate. */
 internal const val BLACK_FRAME_CLASS_CAPTURE_EMPTY: String = "capture_empty"
 
@@ -19015,6 +19127,16 @@ internal const val BLACK_FRAME_CLASS_PARTIAL_BLANK: String = "partial_blank"
  * self-heals every known surface-blank trigger; this is the safety-net for an UNKNOWN one).
  */
 internal const val BLACK_FRAME_CLASS_SURFACE_BLACK_MODEL_INTACT: String = "surface_black_model_intact"
+
+/**
+ * Issue #1294 — a watchdog heal tick whose authoritative `capture-pane` could NOT confirm the
+ * render (a [HealOutcome.Unverified] outcome: timeout / error / empty-on-live-transport /
+ * mutex-starved). Carries an `unverifiedStreak` field (the run of consecutive such ticks) so a
+ * shared-log export distinguishes a genuinely-idle pane that BACKED OFF (watchdog throttled)
+ * from a pane whose heal captures are WEDGED while it is black (watchdog BLIND) — the exact
+ * #1294 mechanism. Rides the watchdog tick that already paid the capture; no new poll.
+ */
+internal const val BLACK_FRAME_CLASS_HEAL_CAPTURE_UNVERIFIED: String = "heal_capture_unverified"
 
 /**
  * Issue #693/#661: backoff between active-pane reveal-gate seed retries.

--- a/app/src/test/java/com/pocketshell/app/tmux/BlackFrameObservedDiagnosticTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/BlackFrameObservedDiagnosticTest.kt
@@ -115,7 +115,11 @@ class BlackFrameObservedDiagnosticTest {
             val healed = vm.healActivePaneIfStaleRenderForTest()
             advanceUntilIdle()
 
-            assertFalse("an empty capture cannot heal", healed)
+            assertEquals(
+                "an empty capture cannot heal — it is UNVERIFIED (issue #1294)",
+                HealOutcome.Unverified,
+                healed,
+            )
             val event = sink.singleBlackFrameEvent()
             assertEquals("capture_empty", event.fields["class"])
             assertEquals("%1", event.fields["paneId"])
@@ -154,7 +158,7 @@ class BlackFrameObservedDiagnosticTest {
         val healed = vm.healActivePaneIfStaleRenderForTest()
         advanceUntilIdle()
 
-        assertFalse(healed)
+        assertEquals(HealOutcome.Unverified, healed)
         val event = sink.singleBlackFrameEvent()
         assertEquals("never_seeded", event.fields["class"])
         assertEquals(0, event.fields["captureBytes"])
@@ -188,7 +192,7 @@ class BlackFrameObservedDiagnosticTest {
         val healed = vm.healActivePaneIfStaleRenderForTest()
         advanceUntilIdle()
 
-        assertTrue("the render lost the frame → the heal fires", healed)
+        assertEquals("the render lost the frame → the heal fires", HealOutcome.Healed, healed)
         val event = sink.singleBlackFrameEvent()
         assertEquals("lost_after_paint", event.fields["class"])
         assertEquals(0, event.fields["renderedChars"])
@@ -226,7 +230,7 @@ class BlackFrameObservedDiagnosticTest {
         val healed = vm.healActivePaneIfStaleRenderForTest()
         advanceUntilIdle()
 
-        assertTrue(healed)
+        assertEquals(HealOutcome.Healed, healed)
         val event = sink.singleBlackFrameEvent()
         assertEquals("partial_blank", event.fields["class"])
         assertTrue("partial-black keeps SOME rendered content", (event.fields["renderedChars"] as Int) > 0)

--- a/app/src/test/java/com/pocketshell/app/tmux/FakeTmuxClient.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/FakeTmuxClient.kt
@@ -147,6 +147,19 @@ internal class FakeTmuxClient(
     val capturePaneResponses: ArrayDeque<CommandResponse> = ArrayDeque()
 
     /**
+     * Issue #1294: sticky fallback for `capture-pane` when [capturePaneResponses] is empty.
+     * The default when this is `null` is an EMPTY success response — which the #1294 heal
+     * oracle now scores UNVERIFIED (an empty capture cannot CONFIRM the render). A test that
+     * needs a REPEATED confirmed-healthy tick (a matching frame on every backoff tick, not a
+     * one-shot from the FIFO) sets this to the frame that MATCHES the render, so the oracle
+     * reads HEALTHY and the watchdog backs off (the #1219 battery lever), without polluting
+     * the scrollback with a dense frame (which would defeat ≤3-line partial-black detection).
+     * Explicitly-queued [capturePaneResponses] still take precedence (checked first).
+     */
+    @Volatile
+    var defaultCaptureResponse: CommandResponse? = null
+
+    /**
      * Issue #259: replies to the `display-message -p ... '#{cursor_x},#{cursor_y}'`
      * cursor query the seed path issues after a `capture-pane`. Defaults to a
      * single `0,0` reply (cursor home) so tests that do not care about the seed
@@ -350,11 +363,13 @@ internal class FakeTmuxClient(
             }
         }
         if (cmd.startsWith("capture-pane")) {
-            return capturePaneResponses.removeFirstOrNull() ?: CommandResponse(
-                number = 0L,
-                output = emptyList(),
-                isError = false,
-            )
+            return capturePaneResponses.removeFirstOrNull()
+                ?: defaultCaptureResponse
+                ?: CommandResponse(
+                    number = 0L,
+                    output = emptyList(),
+                    isError = false,
+                )
         }
         // Issue #259: the seed path issues `display-message -p ... cursor_x,cursor_y`
         // right after `capture-pane`. Serve it from a dedicated queue so it

--- a/app/src/test/java/com/pocketshell/app/tmux/HealCaptureUnverifiedWatchdogTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/HealCaptureUnverifiedWatchdogTest.kt
@@ -1,0 +1,459 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.app.diagnostics.RecordedDiagnosticEvent
+import com.pocketshell.app.diagnostics.installRecordingDiagnosticSink
+import com.pocketshell.app.sessions.ActiveTmuxClients
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.SshLeaseConnector
+import com.pocketshell.core.ssh.SshLeaseManager
+import com.pocketshell.core.ssh.SshLeaseTarget
+import com.pocketshell.core.ssh.SshPortForward
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshShell
+import com.pocketshell.core.tmux.CommandResponse
+import com.pocketshell.core.tmux.TmuxClientException
+import com.pocketshell.core.tmux.TmuxClientFactory
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+import java.io.InputStream
+
+/**
+ * Issue #1294 — the stale-render heal watchdog scored a capture FAILURE identically to a
+ * confirmed-healthy tick and backed off to 16s exactly while the pane was black and the
+ * shared `-CC` capture mutex was wedged by a Claude burst; and the #1203 surface-black
+ * auto-heal sat behind the capture-success early-return, so a capture failure blocked the one
+ * recovery that needs no capture at all.
+ *
+ * ## Mechanism (the two conflations the fix removes)
+ *
+ * Before #1294 [TmuxSessionViewModel.healActivePaneIfStaleRender] returned a BOOLEAN that
+ * conflated "capture timed out / errored / came back empty" with "render confirmed healthy",
+ * and the watchdog did `stableTicks = if (healed) 0 else stableTicks + 1` — so consecutive
+ * capture FAILURES throttled the watchdog identically to consecutive confirmed-healthy ticks
+ * (interval `4s << min(stableTicks, 2)`, capped 16s). The fix makes the oracle return a
+ * three-state [HealOutcome] (HEALED / HEALTHY / UNVERIFIED); only HEALTHY earns the #1219
+ * back-off, UNVERIFIED keeps the hot cadence, and the surface repaint runs BEFORE the capture.
+ *
+ * ## Red → green (captured this run)
+ *
+ *  - [captureFailuresKeepHotCadenceAndDoNotClimbTo16s] — the LOAD-BEARING watchdog guard: a
+ *    black pane whose heal captures FAIL every tick keeps the hot 4s cadence (~15 captures /
+ *    60s), NOT the backed-off 16s (~5). RED on the pre-fix scoring (Unverified conflated with
+ *    healthy → backs off); GREEN with the fix.
+ *  - [surfaceOnlyBlackFiresSurfaceRepaintEvenWhenCaptureTimesOut] — the surface-heal-not-gated
+ *    guard: a surface-only-black (model intact, surface confirmed black) fires
+ *    `requestSurfaceRepaint()` even when the heal capture TIMES OUT. RED on base (repaint sat
+ *    behind the capture-success branch → never fired) = 0; GREEN = 1.
+ *  - [unverifiedStreakIsRecordedInBlackFrameDiagnostics] — criterion 4: each UNVERIFIED tick
+ *    fingerprints a `heal_capture_unverified` event with a climbing `unverifiedStreak`, so an
+ *    export distinguishes "watchdog blind" from "watchdog throttled".
+ *  - Class coverage (G2 / criterion 6): [captureTimeoutIsUnverified], [captureErrorIsUnverified],
+ *    and [emptyCaptureOnLiveTransportIsUnverified] each drive one member of the UNVERIFIED class
+ *    through the real oracle and assert the [HealOutcome.Unverified] verdict.
+ *
+ * Criterion 3 (confirmed-healthy still backs off 4s→8s→16s) and criterion 5 (a successful model
+ * heal resets the back-off) are covered by [StaleRenderWatchdogGatingTest.stableForegroundPaneBacksOff]
+ * and [StaleRenderWatchdogGatingTest.divergingTickSnapsCadenceBackToHot] respectively, now
+ * modelled against confirmed-healthy (matching-capture) ticks.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class HealCaptureUnverifiedWatchdogTest {
+
+    private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val createdVms = mutableListOf<TmuxSessionViewModel>()
+
+    @After
+    fun tearDown() {
+        factoryScope.cancel()
+    }
+
+    // -------------------------------------------------------------------------
+    // Criterion 1 (LOAD-BEARING) — a black pane whose heal captures FAIL every tick keeps the
+    // hot 4s cadence and does NOT climb to 16s. RED on the pre-fix scoring; GREEN with the fix.
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun captureFailuresKeepHotCadenceAndDoNotClimbTo16s() = runVmTest { _ ->
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%1")
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == "%1" }
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+
+        // The pane goes BLACK on a LIVE transport (a render bug, not a drop) — a CSI 2J
+        // overpaint wipes the visible viewport.
+        pane.terminalState.appendRemoteOutput(CLEAR_ONLY.toByteArray(Charsets.US_ASCII))
+        advanceUntilIdle()
+        assertTrue(
+            "precondition: the pane looks LOST/suspect (black) so a failed capture is UNVERIFIED",
+            pane.terminalState.visibleRenderMayHaveLostFrame(),
+        )
+
+        // Every heal capture-pane now FAILS (throws) — models a Claude burst holding the shared
+        // -CC capture mutex so the bounded seed capture times out each watchdog tick.
+        client.failBestEffortOnCommandPrefix = "capture-pane"
+
+        vm.setStaleRenderWatchdogMaxTicksForTest(1000)
+        vm.setPaneLastOutputAtMsForTest("%1", 0L)
+        vm.setProcessForegroundForClearedForTest(true)
+        vm.setScreenInteractiveForTest(true)
+        val guard = requireNotNull(vm.currentRuntimeGuardForTest())
+        vm.armActivePaneStaleRenderWatchdogForTest(guard)
+        runCurrent()
+
+        val before = client.captureCount()
+        // 60s window with NO %output (pure poll — no suspect-wake shortcuts), so timing is set
+        // ENTIRELY by the backoff scoring. advanceTimeBy (NOT advanceUntilIdle, which drains
+        // the bounded loop to maxTicks).
+        advanceTimeBy(61 * 1000L)
+        runCurrent()
+        val captures = client.captureCount() - before
+
+        // With the #1294 fix every UNVERIFIED (failed) capture keeps the HOT 4s cadence, so a
+        // 60s window pays ~15 captures (t=4,8,...,60). On base the failure was scored as a
+        // healthy tick and the watchdog backed off 4s->8s->16s (t=4,12,28,44,60 = ~5) —
+        // throttling recovery exactly while the pane was black. Assert the cadence stayed hot.
+        assertTrue(
+            "REGRESSION (#1294): consecutive heal-capture FAILURES on a black pane must keep " +
+                "the hot 4s cadence (watchdog stays BLIND-but-fast), NOT back off to 16s. A 60s " +
+                "window pays ~15 hot captures; the backed-off bug pays ~5. Observed $captures.",
+            captures >= 12,
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // Criterion 2 (LOAD-BEARING) — a surface-only-black fires requestSurfaceRepaint() even when
+    // the heal capture TIMES OUT. On base the repaint sat behind the capture-success branch, so
+    // a capture failure blocked the one recovery that needs no capture at all.
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun surfaceOnlyBlackFiresSurfaceRepaintEvenWhenCaptureTimesOut() = runVmTest { _ ->
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%1")
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == "%1" }
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+
+        // MODEL intact (dense frame) + SURFACE confirmed black = the #1192 surface-only-black
+        // class, un-catchable by the model-vs-tmux oracle by construction.
+        renderDenseFrame(pane)
+        assertTrue(pane.terminalState.renderedNonBlankCharCount() > 0)
+        pane.terminalState.recordSurfaceFramePaintedForTest(paintedEmulatorContent = false, atMs = 5L)
+        assertTrue(pane.terminalState.surfaceIsBlackWhileModelHasContent())
+
+        // The heal's capture-pane TIMES OUT (throws) — the Claude-burst / wedged-mutex window.
+        client.failBestEffortOnCommandPrefix = "capture-pane"
+
+        val repaintsBefore = pane.terminalState.surfaceRepaintRequestCountForTest()
+        val outcome = vm.healActivePaneIfStaleRenderForTest()
+        advanceUntilIdle()
+
+        assertEquals(
+            "REGRESSION (#1294): a surface-only-black must fire requestSurfaceRepaint() even " +
+                "when the heal capture TIMES OUT — the surface heal must run BEFORE / independent " +
+                "of the capture round-trip, not gated behind capture success (base = 0).",
+            repaintsBefore + 1,
+            pane.terminalState.surfaceRepaintRequestCountForTest(),
+        )
+        assertEquals(
+            "a capture that could not confirm the render is UNVERIFIED",
+            HealOutcome.Unverified,
+            outcome,
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // Criterion 4 — each UNVERIFIED watchdog tick fingerprints a `heal_capture_unverified`
+    // event with a climbing `unverifiedStreak`, so a shared-log export tells "watchdog blind"
+    // (streak climbing) from "watchdog throttled" (a healthy backed-off pane).
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun unverifiedStreakIsRecordedInBlackFrameDiagnostics() = runVmTest { sink ->
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%1")
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == "%1" }
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+
+        pane.terminalState.appendRemoteOutput(CLEAR_ONLY.toByteArray(Charsets.US_ASCII))
+        advanceUntilIdle()
+        client.failBestEffortOnCommandPrefix = "capture-pane"
+
+        vm.setStaleRenderWatchdogMaxTicksForTest(1000)
+        vm.setPaneLastOutputAtMsForTest("%1", 0L)
+        vm.setProcessForegroundForClearedForTest(true)
+        vm.setScreenInteractiveForTest(true)
+        val guard = requireNotNull(vm.currentRuntimeGuardForTest())
+        vm.armActivePaneStaleRenderWatchdogForTest(guard)
+        runCurrent()
+
+        // Three hot (4s) ticks → three UNVERIFIED heal passes (t=4, t=8, t=12).
+        advanceTimeBy(13 * 1000L)
+        runCurrent()
+
+        val unverified = sink.eventsNamed("black_frame_observed")
+            .filter { it.fields["class"] == "heal_capture_unverified" }
+        assertTrue(
+            "REGRESSION (#1294): each UNVERIFIED watchdog tick must fingerprint a " +
+                "heal_capture_unverified event so an export distinguishes 'watchdog blind' from " +
+                "'watchdog throttled'. Found ${unverified.size}: " +
+                unverified.map { it.fields["unverifiedStreak"] },
+            unverified.size >= 3,
+        )
+        val streaks = unverified.map { it.fields["unverifiedStreak"] as Int }
+        assertEquals("the UNVERIFIED streak climbs monotonically (watchdog BLIND, not a blip)", 1, streaks[0])
+        assertEquals(2, streaks[1])
+        assertEquals(3, streaks[2])
+    }
+
+    // -------------------------------------------------------------------------
+    // Class coverage (G2 / criterion 6) — the UNVERIFIED class covers a capture TIMEOUT, an
+    // ERROR response, AND an empty-capture-on-live-transport; each is driven through the real
+    // oracle on a black pane and asserted UNVERIFIED.
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun captureTimeoutIsUnverified() = runVmTest { _ ->
+        val vm = blackPaneVm("%1") { client ->
+            // The bounded seed capture times out on a wedged-but-alive channel → throws.
+            client.failBestEffortOnCommandPrefix = "capture-pane"
+            client.bestEffortException = TmuxClientException("tmux command timed out")
+        }
+        val outcome = vm.healActivePaneIfStaleRenderForTest()
+        advanceUntilIdle()
+        assertEquals(
+            "a heal-capture TIMEOUT on a black pane is UNVERIFIED (keep hot)",
+            HealOutcome.Unverified,
+            outcome,
+        )
+    }
+
+    @Test
+    fun captureErrorIsUnverified() = runVmTest { _ ->
+        val vm = blackPaneVm("%1") { client ->
+            // tmux returned an ERROR block for capture-pane.
+            client.capturePaneResponses.addLast(
+                CommandResponse(number = 90L, output = listOf("capture-pane: no such pane"), isError = true),
+            )
+        }
+        val outcome = vm.healActivePaneIfStaleRenderForTest()
+        advanceUntilIdle()
+        assertEquals(
+            "a heal-capture ERROR response on a black pane is UNVERIFIED (keep hot)",
+            HealOutcome.Unverified,
+            outcome,
+        )
+    }
+
+    @Test
+    fun emptyCaptureOnLiveTransportIsUnverified() = runVmTest { _ ->
+        val vm = blackPaneVm("%1") { client ->
+            // Empty capture on a LIVE transport (the queue is empty → default empty success).
+            client.capturePaneResponses.clear()
+            client.defaultCaptureResponse = null
+        }
+        assertTrue("precondition: the transport is still connected", !vm.clientDisconnectedForTest())
+        val outcome = vm.healActivePaneIfStaleRenderForTest()
+        advanceUntilIdle()
+        assertEquals(
+            "an EMPTY capture on a live transport over a black pane is UNVERIFIED (keep hot)",
+            HealOutcome.Unverified,
+            outcome,
+        )
+    }
+
+    // ------------------------------------------------------------------ Harness
+
+    /**
+     * A connected VM whose active pane %<id> is rendered BLACK (a CSI 2J overpaint) on a live
+     * transport, with [configureFailure] applied to stage the desired UNVERIFIED capture mode.
+     */
+    private fun TestScope.blackPaneVm(
+        paneId: String,
+        configureFailure: (FakeTmuxClient) -> Unit,
+    ): TmuxSessionViewModel {
+        val client = FakeTmuxClient().withSinglePaneRow("work", paneId)
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == paneId }
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+        pane.terminalState.appendRemoteOutput(CLEAR_ONLY.toByteArray(Charsets.US_ASCII))
+        advanceUntilIdle()
+        configureFailure(client)
+        return vm
+    }
+
+    /** Dense, correctly-painted viewport that MATCHES tmux (model intact / oracle healthy). */
+    private fun renderDenseFrame(pane: TmuxPaneState) {
+        pane.terminalState.appendRemoteOutput(
+            buildString {
+                append(CLEAR_ONLY)
+                repeat(28) { append("ISSUE1294 dense context row $it with real tmux content\r\n") }
+            }.toByteArray(Charsets.US_ASCII),
+        )
+    }
+
+    private fun FakeTmuxClient.captureCount(): Int =
+        sentCommands.count { it.startsWith("capture-pane") }
+
+    private fun runVmTest(body: suspend TestScope.(RecordingSink) -> Unit) = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        LivenessProbeTestOverride.setAutoStartEnabledForTest(false)
+        val sink = installRecordingDiagnosticSink()
+        try {
+            body(RecordingSink(sink))
+        } finally {
+            sink.close()
+            for (vm in createdVms) {
+                runCatching { vm.setProcessForegroundForClearedForTest(false) }
+                runCatching { vm.clearForTest() }
+            }
+            advanceUntilIdle()
+            createdVms.clear()
+            LivenessProbeTestOverride.clear()
+            Dispatchers.resetMain()
+        }
+    }
+
+    private class RecordingSink(
+        private val delegate: com.pocketshell.app.diagnostics.RecordingDiagnosticEventSink,
+    ) {
+        fun eventsNamed(name: String): List<RecordedDiagnosticEvent> = delegate.eventsNamed(name)
+    }
+
+    private fun TestScope.newVm(
+        registry: ActiveTmuxClients,
+        sshLeaseManager: SshLeaseManager,
+    ): TmuxSessionViewModel = TmuxSessionViewModel(
+        tmuxClientFactory = TmuxClientFactory(factoryScope),
+        activeTmuxClients = registry,
+        runtimeCache = TmuxSessionRuntimeCache(),
+        sshLeaseManager = sshLeaseManager,
+        sessionLifecycleSignals = null,
+    ).also {
+        it.setSeedIoDispatcherForTest(StandardTestDispatcher(testScheduler))
+        // Drive the watchdog / heal seams explicitly; keep connect() from auto-arming its own
+        // loop so capture counts + timings stay deterministic.
+        it.setStaleRenderWatchdogAutoArmEnabledForTest(false)
+        it.setConnectedBlankWatchdogAutoArmEnabledForTest(false)
+        createdVms.add(it)
+    }
+
+    private fun TestScope.connectVm(client: FakeTmuxClient): TmuxSessionViewModel {
+        val live = AlwaysConnectedSession(id = "live")
+        val connector = SingleSessionConnector(live)
+        val leaseManager =
+            testLeaseManager(connector = connector, scope = this, idleTtlMillis = 60_000L)
+        val registry = ActiveTmuxClients()
+        val vm = newVm(registry = registry, sshLeaseManager = leaseManager)
+        runCurrent()
+        vm.setTmuxClientFactoryForTest { _, _, _ -> client }
+        vm.connect(
+            hostId = 1L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            passphrase = null,
+            sessionName = "work",
+        )
+        advanceUntilIdle()
+        return vm
+    }
+
+    private fun FakeTmuxClient.withSinglePaneRow(
+        sessionName: String,
+        paneId: String,
+        title: String = sessionName,
+    ): FakeTmuxClient = apply {
+        responses.addLast(
+            CommandResponse(
+                number = 1L,
+                output = listOf("$paneId\t@0\t\$0\t$sessionName\t$title\t0"),
+                isError = false,
+            ),
+        )
+        capturePaneResponses.addLast(
+            CommandResponse(number = 2L, output = listOf("$sessionName ready"), isError = false),
+        )
+        cursorQueryResponses.addLast(
+            CommandResponse(number = 3L, output = listOf("0,0"), isError = false),
+        )
+    }
+
+    private class SingleSessionConnector(
+        private val session: SshSession,
+    ) : SshLeaseConnector {
+        override suspend fun connect(target: SshLeaseTarget): Result<SshSession> =
+            Result.success(session)
+    }
+
+    private class AlwaysConnectedSession(
+        val id: String,
+    ) : SshSession {
+        @Volatile
+        var closed: Boolean = false
+
+        override val isConnected: Boolean get() = !closed
+
+        override suspend fun exec(command: String): ExecResult =
+            ExecResult(stdout = "", stderr = "", exitCode = 0)
+
+        override fun tail(path: String, onLine: (String) -> Unit): Job =
+            Job().apply { complete() }
+
+        override fun tail(path: String, fromLineExclusive: Long, onLine: (String) -> Unit): Job =
+            Job().apply { complete() }
+
+        override fun openLocalPortForward(
+            remoteHost: String,
+            remotePort: Int,
+            localPort: Int,
+        ): SshPortForward = error("not used")
+
+        override fun startShell(): SshShell = error("not used")
+
+        override suspend fun uploadFile(file: File, remotePath: String): String = error("not used")
+
+        override suspend fun uploadStream(
+            input: InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String = error("not used")
+
+        override fun close() {
+            closed = true
+        }
+    }
+
+    private companion object {
+        // ESC[2J ESC[H — a full clear + home, the overpaint that wipes a viewport to black.
+        const val CLEAR_ONLY: String = "[2J[H"
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/PartialBlackPaneHealTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/PartialBlackPaneHealTest.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -372,9 +373,10 @@ class PartialBlackPaneHealTest {
         val healed = vm.healActivePaneIfStaleRenderForTest()
         advanceUntilIdle()
 
-        assertTrue(
+        assertEquals(
             "REGRESSION (#1138): the steady-state watchdog must heal a partial-black " +
                 "alt-screen agent pane. On base the divergence-only predicate skipped it.",
+            HealOutcome.Healed,
             healed,
         )
         assertTrue(
@@ -418,9 +420,11 @@ class PartialBlackPaneHealTest {
         val healed = vm.healActivePaneIfStaleRenderForTest()
         advanceUntilIdle()
 
-        assertFalse(
+        assertEquals(
             "OVER-HEAL GUARD (#1138/#807): when tmux's alt-screen capture is ALSO near-empty " +
-                "there is no lost frame to restore — the watchdog must NOT heal",
+                "there is no lost frame to restore — the watchdog reads the pane HEALTHY and " +
+                "must NOT heal",
+            HealOutcome.Healthy,
             healed,
         )
         assertTrue(

--- a/app/src/test/java/com/pocketshell/app/tmux/StaleRenderWatchdogGatingTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/StaleRenderWatchdogGatingTest.kt
@@ -204,13 +204,31 @@ class StaleRenderWatchdogGatingTest {
     @Test
     fun stableForegroundPaneBacksOff() = runVmTest {
         val client = FakeTmuxClient().withSinglePaneRow("work", "%1")
-        val vm = armIdleWatchdog(client, paneId = "%1")
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == "%1" }
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
 
+        // Issue #1294: model a CONFIRMED-healthy idle pane — a DENSE, fully-rendered viewport
+        // (not the 1-line "work ready" partial-blank, which now reads SUSPECT and correctly
+        // stays hot). Each watchdog tick's empty capture over a confidently-dense render scores
+        // HEALTHY (a non-urgent no-op), so the #1219/#1164 battery back-off (4s->8s->16s) holds.
+        pane.terminalState.appendRemoteOutput(denseHealthyFrame().toByteArray(Charsets.US_ASCII))
+        advanceUntilIdle()
+        assertFalse(
+            "precondition: the idle pane is confidently DENSE (not suspect), so an empty " +
+                "capture scores HEALTHY and the pane backs off",
+            pane.terminalState.visibleRenderMayHaveLostFrame(),
+        )
+
+        vm.setStaleRenderWatchdogAutoArmEnabledForTest(false)
+        vm.setStaleRenderWatchdogMaxTicksForTest(1000)
         vm.setProcessForegroundForClearedForTest(true)
         vm.setScreenInteractiveForTest(true)
-        // No streamed output -> the pane is fully idle/stable (empty capture queue
-        // -> healActivePaneIfStaleRender no-ops, healed=false every tick).
         vm.setPaneLastOutputAtMsForTest("%1", 0L)
+        val guard = requireNotNull(vm.currentRuntimeGuardForTest())
+        vm.armActivePaneStaleRenderWatchdogForTest(guard)
+        runCurrent()
 
         val before = client.captureCount()
         // Captures land at t=4s (#1, stableTicks->1), t=12s (#2, ->2), t=28s (#3, cap).
@@ -220,9 +238,9 @@ class StaleRenderWatchdogGatingTest {
 
         val captures = client.captureCount() - before
         assertEquals(
-            "REGRESSION (#1166): a STABLE foreground pane must back off (4s->8s->16s). " +
-                "Over 20s it should capture 2 times (t=4s, t=12s), NOT the 5 a flat 4s " +
-                "cadence would pay. Observed $captures.",
+            "REGRESSION (#1166/#1294): a STABLE (confirmed-healthy) foreground pane must back " +
+                "off (4s->8s->16s). Over 20s it should capture 2 times (t=4s, t=12s), NOT the 5 " +
+                "a flat 4s cadence would pay. Observed $captures.",
             2,
             captures,
         )
@@ -318,8 +336,16 @@ class StaleRenderWatchdogGatingTest {
         vm.resizeRemotePty(80, 40)
         advanceUntilIdle()
 
+        // Issue #1294: the pane STREAMS a DENSE, confidently-healthy frame first — the "S" in
+        // "STREAMING pane". Each backoff-phase tick's empty capture over this dense render
+        // scores HEALTHY (a non-urgent no-op), so the pane backs off (a partial-blank pane
+        // would now correctly stay hot). The fragments-over-black redraw below then makes it
+        // suspect.
+        pane.terminalState.appendRemoteOutput(denseHealthyFrame().toByteArray(Charsets.US_ASCII))
+        advanceUntilIdle()
+
         // Let the watchdog back off to the widest (16s) interval — captures at t=4s,
-        // t=12s (empty capture => healed=false).
+        // t=12s (empty capture over a confidently-dense render => HEALTHY no-op).
         vm.setStaleRenderWatchdogMaxTicksForTest(1000)
         vm.setProcessForegroundForClearedForTest(true)
         vm.setScreenInteractiveForTest(true)
@@ -438,6 +464,15 @@ class StaleRenderWatchdogGatingTest {
         vm.resizeRemotePty(80, 40)
         advanceUntilIdle()
 
+        // Issue #1294: the backoff phase must be CONFIRMED-healthy so the pane backs off. The
+        // render is the connect seed ("work ready"); return a MATCHING capture on every backoff
+        // tick so the oracle reads HEALTHY (empty captures would now score UNVERIFIED and keep
+        // the pane hot). A sticky default (not a dense frame) is used deliberately: a dense
+        // frame would pollute the scrollback and defeat the ≤3-line partial-black detection the
+        // redraw below relies on.
+        client.defaultCaptureResponse =
+            CommandResponse(number = 80L, output = listOf("work ready"), isError = false)
+
         vm.setStaleRenderWatchdogMaxTicksForTest(1000)
         vm.setPaneLastOutputAtMsForTest("%1", 0L)
         vm.setProcessForegroundForClearedForTest(true)
@@ -493,6 +528,14 @@ class StaleRenderWatchdogGatingTest {
         val pane = vm.panes.value.single { it.paneId == "%1" }
         vm.resizeRemotePty(80, 40)
         advanceUntilIdle()
+
+        // Issue #1294: the backoff phase must be CONFIRMED-healthy so the pane backs off. Return
+        // a MATCHING capture ("work ready", the connect-seed render) on every backoff tick so the
+        // oracle reads HEALTHY (empty captures would now score UNVERIFIED and keep it hot). A
+        // sticky default (not a dense frame) is used so the scrollback stays clean for the
+        // ≤3-line partial-black drive below.
+        client.defaultCaptureResponse =
+            CommandResponse(number = 80L, output = listOf("work ready"), isError = false)
 
         vm.setStaleRenderWatchdogMaxTicksForTest(1000)
         vm.setPaneLastOutputAtMsForTest("%1", 0L)

--- a/app/src/test/java/com/pocketshell/app/tmux/SurfaceBlackModelIntactDiagnosticTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/SurfaceBlackModelIntactDiagnosticTest.kt
@@ -126,9 +126,10 @@ class SurfaceBlackModelIntactDiagnosticTest {
         val healed = vm.healActivePaneIfStaleRenderForTest()
         advanceUntilIdle()
 
-        assertFalse(
-            "a model-healthy pane is not MODEL-reseeded (no capture-pane swap) — the recovery is " +
-                "a surface repaint, not a model heal",
+        assertEquals(
+            "a model-healthy pane is not MODEL-reseeded (no capture-pane swap) — it is HEALTHY; " +
+                "the recovery is a surface repaint, not a model heal",
+            HealOutcome.Healthy,
             healed,
         )
         // Issue #1203: the auto-heal now RECOVERS this class with a SURFACE force-repaint
@@ -284,7 +285,7 @@ class SurfaceBlackModelIntactDiagnosticTest {
         val healed = vm.healActivePaneIfStaleRenderForTest()
         advanceUntilIdle()
 
-        assertFalse("no model reseed for an oracle-healthy agent pane", healed)
+        assertEquals("no model reseed for an oracle-healthy agent pane", HealOutcome.Healthy, healed)
         assertTrue(
             "the auto-heal must request a surface force-repaint for a surface-only-black " +
                 "agent/alt-screen pane too (class coverage, not just shell panes)",
@@ -490,7 +491,7 @@ class SurfaceBlackModelIntactDiagnosticTest {
         val healed = vm.healActivePaneIfStaleRenderForTest()
         advanceUntilIdle()
 
-        assertTrue("the render lost the frame → the heal fires", healed)
+        assertEquals("the render lost the frame → the heal fires", HealOutcome.Healed, healed)
         val event = sink.singleBlackFrameEvent()
         assertEquals(
             "the lost_after_paint class is unchanged — the surface branch never runs when " +


### PR DESCRIPTION
The centerpiece of the black-screen recovery-layer cluster (#1208 audit, 2026-07-06).

**Defect:** the stale-render heal watchdog scored a `capture-pane` FAILURE identically to a confirmed-healthy tick, so consecutive failures backed it off 4s→8s→16s exactly when a Claude burst wedged the capture mutex and the pane was black. Separately, the #1203 surface-black auto-heal sat behind capture success, so a wedged capture blocked a heal that needs no capture at all.

**Fix:** three-state `HealOutcome` (HEALED / HEALTHY / UNVERIFIED). Only HEALTHY backs off (#1219 battery preserved); HEALED resets; UNVERIFIED keeps the hot 4s cadence (gated on `renderLooksLost` so healthy panes still cool) and emits `heal_capture_unverified` with a climbing `unverifiedStreak` — making the previously-invisible 'throttled while black' state observable in the diagnostics export. Surface-black heal moved before/independent of capture.

- Reproduce-first red→green, proven by implementer and independently re-driven by reviewer (both on #1294; reviewer neutralized the fix, saw the 3 load-bearing tests fail on base, restored, green).
- `:app:testDebugUnitTest` green + `compileDebugAndroidTestKotlin` green in the integration gate; `check-test-validity.sh` PASS. #1250 de-flake test 3×/3× green in isolation.
- New `HealCaptureUnverifiedWatchdogTest`; G2 class coverage (timeout/error/empty/mutex-starved).

Closes #1294