### PR TITLE
core-tmux: wedge-proof heal-capture lane (dedicated exec channel) + overflow-reseed collector-gap fix (#1297)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -10618,6 +10618,17 @@ public class TmuxSessionViewModel @Inject constructor(
             var reseeded = false
             var drainedFrames = 0
             var reattached = false
+            // Issue #1297: FREEZE %output delivery across the whole producer swap.
+            // The teardown (step 1) tears the sole pane collector down and step 3
+            // reattaches a fresh one; every %output emitted in that gap used to be
+            // emitted into the zero-subscriber (replay = 0) pipe and vanish, so
+            // recovery leaned SOLELY on the step-4 capture (the same SPOF this
+            // issue closes). With delivery paused the frames are HELD in the
+            // bounded backlog: on a successful capture the snapshot is
+            // authoritative and the (pre-capture, now-stale) held frames are
+            // dropped so they can't double-apply; on a FAILED capture they are
+            // replayed to the fresh producer on resume instead of being lost.
+            runCatching { client.pauseOutputDelivery(paneId) }
             try {
                 val pane = paneRows[paneId] ?: return@launch
                 // 1. Detach the current (dropped / feed-failed) producer + its
@@ -10640,8 +10651,9 @@ public class TmuxSessionViewModel @Inject constructor(
                 if (!isCurrentRuntime(guard) || client.disconnected.value) return@launch
                 // 3. Reattach a FRESH producer (new bridge + emulator, seed gate
                 //    CLOSED via awaitSeed) BEFORE reseeding: the seed must land on
-                //    the SAME bridge the live producer feeds. Live %output arriving
-                //    now buffers in order behind the closed gate — the #468 design.
+                //    the SAME bridge the live producer feeds. Delivery is still
+                //    PAUSED here, so the fresh collector receives nothing yet —
+                //    the held frames wait for the capture outcome (step 4/5).
                 attachTerminalProducerForPane(
                     paneId = paneId,
                     state = pane.terminalState,
@@ -10654,15 +10666,30 @@ public class TmuxSessionViewModel @Inject constructor(
                 //    non-destructive swap keeps the last good frame if the capture
                 //    is momentarily near-blank.
                 reseeded = seedPaneFromCapture(client, pane, guard, recordMilestone = false)
+                if (reseeded) {
+                    // Issue #1297: the snapshot is authoritative — the held frames
+                    // are all PRE-capture (already reflected server-side in the
+                    // snapshot), so DROP them before the resume so they cannot
+                    // double-apply on top of the fresh grid.
+                    drainedFrames +=
+                        runCatching { client.drainPaneOutputBacklog(paneId) }.getOrDefault(0)
+                }
                 // 5. If no snapshot ever landed (all retries near-blank/errored),
                 //    still OPEN the gate so buffered live output is flushed rather
                 //    than swallowed — the same fallback the cold-open seed uses
                 //    ([seedPrewarmedPane]/preload). Otherwise the reattached
-                //    producer would be gated forever.
+                //    producer would be gated forever. On resume (finally) the held
+                //    frames then replay to the fresh producer through this open
+                //    gate — the #1297 belt so recovery isn't solely the capture.
                 if (!reseeded && isCurrentRuntime(guard)) {
                     runCatching { pane.terminalState.openSeedGateWithoutSeed() }
                 }
             } finally {
+                // Issue #1297: THAW delivery last. On success the backlog was just
+                // drained (nothing stale replays); on failure the held frames now
+                // replay to the fresh producer through the opened gate. Always
+                // resume so a pane is never left frozen, even on an early return.
+                runCatching { client.resumeOutputDelivery(paneId) }
                 paneOverflowRecoveryInFlight.remove(paneId)
                 DiagnosticEvents.record(
                     "connection",

--- a/app/src/test/java/com/pocketshell/app/tmux/FakeTmuxClient.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/FakeTmuxClient.kt
@@ -408,6 +408,24 @@ internal class FakeTmuxClient(
         return 0
     }
 
+    /**
+     * Issue #1297: records the panes whose `%output` delivery the overflow-reseed
+     * swap froze/thawed, so a test can assert the swap paused delivery before the
+     * producer teardown and resumed it afterwards (so a collector gap holds frames
+     * instead of dropping them, and recovery doesn't depend solely on the
+     * capture).
+     */
+    val outputDeliveryPauseCalls: MutableList<String> = mutableListOf()
+    val outputDeliveryResumeCalls: MutableList<String> = mutableListOf()
+
+    override fun pauseOutputDelivery(paneId: String) {
+        outputDeliveryPauseCalls += paneId
+    }
+
+    override fun resumeOutputDelivery(paneId: String) {
+        outputDeliveryResumeCalls += paneId
+    }
+
     override fun outputFor(paneId: String): Flow<ControlEvent.Output> =
         if (decoupleOutputForFromEvents) {
             emittedPaneOutputs.filter { it.paneId == paneId }

--- a/app/src/test/java/com/pocketshell/app/tmux/PaneOutputOverflowRecoveryTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/PaneOutputOverflowRecoveryTest.kt
@@ -232,6 +232,27 @@ class PaneOutputOverflowRecoveryTest {
             System.identityHashCode(client),
             vm.paneProducerClientIdentityForTest("%1"),
         )
+        // Issue #1297: the swap must FREEZE %output delivery across the producer
+        // teardown/reattach so frames in the gap are held (not dropped into the
+        // zero-subscriber pipe), and THAW it afterwards so live output resumes.
+        assertTrue(
+            "the overflow reseed must pause %output delivery across the swap (#1297)",
+            client.outputDeliveryPauseCalls.contains("%1"),
+        )
+        assertTrue(
+            "the overflow reseed must resume %output delivery after the swap (#1297)",
+            client.outputDeliveryResumeCalls.contains("%1"),
+        )
+        // On a SUCCESSFUL reseed the snapshot is authoritative, so the held
+        // pre-capture frames are dropped: the pane's backlog is drained TWICE —
+        // once before the swap (step 2) and once after the successful capture
+        // (step 4) — so they can't double-apply on top of the fresh grid (#1297).
+        assertEquals(
+            "a successful overflow reseed must drain the pane backlog twice " +
+                "(pre-swap + post-successful-capture) so held frames can't double-apply",
+            2,
+            client.drainedPaneBacklogs.count { it == "%1" },
+        )
     }
 
     // -----------------------------------------------------------------------

--- a/shared/core-tmux/src/integrationTest/java/com/pocketshell/core/tmux/TmuxClientIntegrationTest.kt
+++ b/shared/core-tmux/src/integrationTest/java/com/pocketshell/core/tmux/TmuxClientIntegrationTest.kt
@@ -419,4 +419,147 @@ class TmuxClientIntegrationTest {
             scope.cancel()
         }
     }
+
+    @Test
+    fun `captureWithCursor exec lane captures real pane content and cursor`() = runBlocking {
+        // Issue #1297: the heal/seed capture now runs on a DEDICATED exec channel
+        // (SshSession.exec), not the -CC control shell. Prove the exec lane
+        // captures a real tmux pane's content and cursor against a real server —
+        // the connection-core contract the unit tests (fake exec) can't verify.
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        try {
+            connectSession().use { session ->
+                val client: TmuxClient = TmuxClientFactory(scope).create(
+                    session,
+                    sessionName = "it-${System.nanoTime()}",
+                )
+                client.use {
+                    it.connect()
+                    delay(500)
+                    val paneId = withTimeout(10_000) {
+                        it.sendCommand("display-message -p \"#{pane_id}\"")
+                    }.output.firstOrNull()?.trim().orEmpty()
+                    assertTrue("pane id must resolve; got '$paneId'", paneId.startsWith("%"))
+
+                    val marker = "PS_HEAL_CAPTURE_${System.nanoTime()}"
+                    // Print the marker into the pane and wait until tmux has it on
+                    // the server-side grid (observed via %output) before capturing.
+                    val buffer = java.lang.StringBuilder()
+                    val collector = scope.launch {
+                        it.outputFor(paneId).collect { evt ->
+                            synchronized(buffer) { buffer.append(String(evt.data, Charsets.UTF_8)) }
+                        }
+                    }
+                    delay(200)
+                    withTimeout(10_000) {
+                        it.sendCommand("send-keys -t $paneId 'echo $marker' Enter")
+                    }
+                    val deadline = System.currentTimeMillis() + 10_000
+                    while (System.currentTimeMillis() < deadline &&
+                        !synchronized(buffer) { buffer.toString() }.contains(marker)
+                    ) {
+                        delay(50)
+                    }
+                    collector.cancel()
+
+                    // Capture on the exec lane with the production short ceiling.
+                    val combined = withTimeout(10_000) {
+                        it.captureWithCursor(paneId, scrollbackLines = 200, timeoutMs = 2_500L)
+                    }
+                    assertFalse(
+                        "exec-lane capture must not be an error; got ${combined.capture.output}",
+                        combined.capture.isError,
+                    )
+                    val captureText = combined.capture.output.joinToString("\n")
+                    assertTrue(
+                        "exec-lane capture must contain the marker echoed into the pane; got:\n$captureText",
+                        captureText.contains(marker),
+                    )
+                    assertNotNull(
+                        "exec-lane capture must return a cursor reply",
+                        combined.cursorReply,
+                    )
+                    assertTrue(
+                        "cursor reply must be `x,y`; got '${combined.cursorReply}'",
+                        Regex("""\d+,\d+""").matches(combined.cursorReply!!.trim()),
+                    )
+                }
+            }
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `captureWithCursor exec lane succeeds while the -CC channel streams a burst`() = runBlocking {
+        // Issue #1297 (G10 real-path, no emulator): the "capture behind a busy
+        // agent" symptom (#470/#835) — a heal capture whose reply is head-of-line
+        // blocked behind a flood of %output on the -CC reader. With the capture on
+        // an INDEPENDENT exec channel it returns while the burst streams on the
+        // -CC channel. Reproduces the busy-agent burst fixture at the Docker level.
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        try {
+            connectSession().use { session ->
+                val client: TmuxClient = TmuxClientFactory(scope).create(
+                    session,
+                    sessionName = "it-${System.nanoTime()}",
+                )
+                client.use {
+                    it.connect()
+                    delay(500)
+                    val paneId = withTimeout(10_000) {
+                        it.sendCommand("display-message -p \"#{pane_id}\"")
+                    }.output.firstOrNull()?.trim().orEmpty()
+                    assertTrue("pane id must resolve; got '$paneId'", paneId.startsWith("%"))
+
+                    // Keep the -CC reader busy: subscribe and drive a large output
+                    // burst into the pane so %output frames flood the control
+                    // channel while we capture.
+                    val burstBytes = java.util.concurrent.atomic.AtomicLong(0)
+                    val collector = scope.launch {
+                        it.outputFor(paneId).collect { evt -> burstBytes.addAndGet(evt.data.size.toLong()) }
+                    }
+                    delay(200)
+                    // `seq` on alpine floods tens of thousands of lines through the
+                    // pane; the shell echoes each through %output on the -CC reader.
+                    withTimeout(10_000) {
+                        it.sendCommand("send-keys -t $paneId 'seq 1 200000' Enter")
+                    }
+                    // Wait until the burst is actively streaming on the -CC channel.
+                    val burstDeadline = System.currentTimeMillis() + 10_000
+                    while (System.currentTimeMillis() < burstDeadline && burstBytes.get() < 50_000L) {
+                        delay(20)
+                    }
+                    assertTrue(
+                        "the -CC channel must actually be streaming a burst; sawBytes=${burstBytes.get()}",
+                        burstBytes.get() >= 50_000L,
+                    )
+
+                    // Capture on the exec lane WHILE the burst streams. It must
+                    // return (not time out) within the short ceiling.
+                    val startedAt = System.currentTimeMillis()
+                    val combined = withTimeout(10_000) {
+                        it.captureWithCursor(paneId, scrollbackLines = 200, timeoutMs = 2_500L)
+                    }
+                    val elapsed = System.currentTimeMillis() - startedAt
+                    collector.cancel()
+                    assertFalse(
+                        "exec-lane capture must succeed during a -CC burst; got ${combined.capture.output}",
+                        combined.capture.isError,
+                    )
+                    assertTrue(
+                        "exec-lane capture must return content during a -CC burst",
+                        combined.capture.output.isNotEmpty(),
+                    )
+                    assertTrue(
+                        "exec-lane capture must return within the short ceiling during a burst " +
+                            "(elapsed ${elapsed}ms)",
+                        elapsed < 5_000L,
+                    )
+                }
+            }
+        } finally {
+            scope.cancel()
+        }
+    }
 }

--- a/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxClient.kt
+++ b/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxClient.kt
@@ -1,6 +1,7 @@
 package com.pocketshell.core.tmux
 
 import android.util.Log
+import com.pocketshell.core.ssh.ExecResult
 import com.pocketshell.core.ssh.SshSession
 import com.pocketshell.core.ssh.SshShell
 import com.pocketshell.core.tmux.protocol.ControlEvent
@@ -128,27 +129,24 @@ public interface TmuxClient : AutoCloseable {
         sendCommand(cmd)
 
     /**
-     * Issue #640: capture a pane's content AND its cursor in a SINGLE wire
-     * round-trip.
+     * Issue #640 / #1297: capture a pane's content AND its cursor
+     * (`#{cursor_x},#{cursor_y}`, see #259) so the seed path can repaint a
+     * freshly-attached — or stale/black — pane correctly.
      *
-     * The seed path needs both the `capture-pane` snapshot and the pane's true
-     * cursor (`#{cursor_x},#{cursor_y}`, see #259) to repaint a freshly-attached
-     * pane correctly. In `tmux -CC` control mode a `cmd1 ; cmd2` request is
-     * answered with TWO separate `%begin`/`%end` blocks — chaining does NOT
-     * collapse them — so a naive single `sendCommand` would only see the first
-     * block and the cursor reply would arrive as an uncorrelated second block.
-     *
-     * Implementations therefore send the chained command and drain BOTH
-     * response blocks under one single-flight acquisition, returning the capture
-     * block plus the raw cursor reply line. This collapses the previous two
-     * serial seed round-trips into one wire exchange while keeping the cursor
-     * restore intact. Best-effort: a missing/failed cursor block degrades to a
-     * null [CaptureWithCursor.cursorReply] (seed without explicit cursor
-     * restore) rather than failing the capture.
+     * Issue #1297 (heal-capture SPOF): the real client runs this on a DEDICATED
+     * `exec` channel (the `SshSession.exec` lane the `tmux has-session` preflight
+     * already uses), NOT the shared per-host `-CC` control-mode `sendMutex`. A
+     * busy Claude agent saturating the `-CC` channel used to wedge every
+     * recovery-net capture (stale-render heal, reveal/switch reseed, overflow
+     * reseed) behind that one mutex, so the 2.5s seed ceiling fired exactly when
+     * a pane was black (#470/#835). The exec lane reads its own channel's stdout
+     * independently of the `-CC` reader, so a heal capture succeeds while a burst
+     * saturates the control channel. Both `capture-pane` and `display-message`
+     * run in one exec, split on a sentinel line; a missing/failed cursor degrades
+     * to a null [CaptureWithCursor.cursorReply] rather than failing the capture.
      *
      * The default implementation falls back to two separate best-effort
-     * commands for [TmuxClient] doubles that do not model control-mode block
-     * correlation.
+     * `-CC` commands for [TmuxClient] doubles that do not model an exec lane.
      */
     public suspend fun captureWithCursor(
         paneId: String,
@@ -220,6 +218,34 @@ public interface TmuxClient : AutoCloseable {
      * correct. No-op (returns 0) when the pane has no registered pipe.
      */
     public fun drainPaneOutputBacklog(paneId: String): Int
+
+    /**
+     * Issue #1297: freeze `%output` delivery for [paneId] so frames landing while
+     * the sole collector is momentarily detached are HELD in the bounded backlog
+     * channel instead of being emitted into a zero-subscriber `replay = 0`
+     * SharedFlow (where they vanish).
+     *
+     * The overflow-reseed producer swap
+     * ([TmuxSessionViewModel.launchPaneOverflowReseed]) tears the sole pane
+     * collector down and reattaches a FRESH one; every `%output` emitted in that
+     * teardown/reattach gap used to be lost, leaving recovery to depend SOLELY on
+     * the step-4 `capture-pane` (the same SPOF this issue closes). With the pause
+     * held across the swap, the held frames are replayed to the fresh collector
+     * on [resumeOutputDelivery] when the capture fails, and dropped
+     * ([drainPaneOutputBacklog]) when the authoritative capture succeeds.
+     *
+     * No-op when the pane has no registered pipe. The default implementation is a
+     * no-op for [TmuxClient] doubles that do not model per-pane delivery.
+     */
+    public fun pauseOutputDelivery(paneId: String) {}
+
+    /**
+     * Issue #1297: thaw `%output` delivery for [paneId] previously frozen by
+     * [pauseOutputDelivery]. Any frames held in the bounded backlog channel drain
+     * to the (re)attached collector in arrival order. No-op when the pane has no
+     * registered pipe or delivery was never paused.
+     */
+    public fun resumeOutputDelivery(paneId: String) {}
 
     /**
      * Issue #173: observable signal that the control channel has
@@ -1084,12 +1110,27 @@ internal class RealTmuxClient(
     }
 
     /**
-     * Issue #640: capture a pane + its cursor in a single single-flight wire
-     * exchange. tmux `-CC` answers `capture-pane ; display-message` with two
-     * separate `%begin`/`%end` blocks, so we register TWO pending commands
-     * (capture, then cursor) under one [sendMutex] acquisition, write the
-     * chained line once, and drain both blocks in FIFO order. This collapses
-     * the two serial seed round-trips into one while keeping the cursor restore.
+     * Issue #1297: capture a pane + its cursor on a DEDICATED `exec` channel, NOT
+     * the shared per-host `-CC` control-mode [sendMutex].
+     *
+     * The heal-capture SPOF (audit finding 4, #1208): every recovery net —
+     * stale-render heal, reveal/switch reseed, overflow reseed — funnelled every
+     * `capture-pane` through the ONE `sendMutex`. A busy Claude agent saturating
+     * the `-CC` channel wedged that mutex, so a heal capture timed out at the
+     * 2.5s ceiling exactly when a pane was black (#470/#835). This runs
+     * `capture-pane` + `display-message` in a SINGLE [SshSession.exec] — the same
+     * independent-channel lane the `tmux has-session` preflight already uses
+     * (#666) — whose stdout is read OUTSIDE the transport dispatcher (see
+     * `RealSshSession.exec` phase 2), so a heal capture completes while a burst
+     * saturates the `-CC` reader. The two tmux sub-commands are joined with a
+     * sentinel line so the single stdout splits cleanly into cursor + capture; a
+     * missing/failed cursor degrades to a null [CaptureWithCursor.cursorReply].
+     *
+     * Failure signalling (§4 req 5): a wedged/half-open transport surfaces as a
+     * thrown [TmuxClientException] (timeout) — distinct from a capture that
+     * returned on a live transport but was empty (a non-error [CommandResponse]
+     * with an empty [CommandResponse.output]), so the caller can distinguish
+     * "timed out → stay hot" from "empty → never-seeded".
      */
     override suspend fun captureWithCursor(
         paneId: String,
@@ -1098,148 +1139,103 @@ internal class RealTmuxClient(
     ): CaptureWithCursor {
         if (closed) throw TmuxClientException("client is closed")
         if (!connected) throw TmuxClientException("client is not connected")
-        // Issue #926: bound the attach/switch/reattach SEED capture by the
-        // caller's short ceiling (≈2-3 s) instead of the full per-command
-        // `commandTimeoutMs` (10 s). On a wedged-but-alive `-CC` channel the seed
-        // then surfaces a best-effort failure fast and the caller falls through
-        // to the blank watchdog on the still-live transport, rather than parking
-        // the (now off-Main, but still time-bounded) seed for the full 10 s. A
-        // null caller-supplied timeout (every non-seed caller) keeps the full
-        // ceiling. Clamp to `commandTimeoutMs` so a caller can only SHORTEN, never
-        // lengthen, the bound.
+        // Issue #926/#1297: bound the heal/seed capture by the caller's short
+        // ceiling (≈2.5s) instead of the full per-command `commandTimeoutMs`
+        // (10s). Clamp so a caller can only SHORTEN, never lengthen, the bound; a
+        // null (non-seed) caller keeps the full ceiling.
         val effectiveTimeoutMs = timeoutMs?.coerceIn(1L, commandTimeoutMs) ?: commandTimeoutMs
-        val chained =
-            "capture-pane -p -e -S -$scrollbackLines -t $paneId ; " +
-                "display-message -p -t $paneId '#{cursor_x},#{cursor_y}'"
-        // Issue #886: bound the single-flight ACQUIRE itself (mirrors
-        // #702/#692 in sendChainedCommands). `sendMutex.withLock { … }` had no
-        // deadline on the *acquire* — only the body inside it was gated. The
-        // attach seed reaches here on the shared per-host `-CC` client and
-        // serializes against the in-session terminal's own control traffic; if a
-        // current holder is wedged (e.g. another command stalled behind a busy
-        // agent channel during an attach) the seed parks on the acquire forever
-        // and "Attaching…" never resolves (#886). `Mutex.lock()` is a cancellable
-        // suspension point, so bound ONLY the acquire with `withTimeoutOrNull` and
-        // surface a best-effort failure (the caller falls back to opening the seed
-        // gate without a snapshot, exactly as for a capture timeout).
-        val acquired = withTimeoutOrNull(effectiveTimeoutMs) {
-            sendMutex.lock()
-            true
+        val quotedPane = "'${escapeSingleQuoted(paneId)}'"
+        // One exec, three shell commands: cursor FIRST, then a sentinel line,
+        // then the (multi-line) capture LAST. Splitting on the FIRST sentinel
+        // occurrence means capture content that happens to contain the sentinel
+        // token cannot corrupt the split (it lands after the split point).
+        val command = buildString {
+            append("tmux display-message -p -t ")
+            append(quotedPane)
+            append(" '#{cursor_x},#{cursor_y}'; printf '%s\\n' '")
+            append(HEAL_CAPTURE_SPLIT_MARKER)
+            append("'; tmux capture-pane -p -e -S -")
+            append(scrollbackLines)
+            append(" -t ")
+            append(quotedPane)
         }
-        if (acquired != true) {
+        val execResult =
+            try {
+                // The exec lane is independent of the busy `-CC` channel, so this
+                // returns fast under a burst. The ceiling is the safety bound for
+                // a genuinely wedged/half-open transport (both channels dead);
+                // cancelling the exec closes its own channel (RealSshSession.exec
+                // cancellation handler), never the `-CC` shell.
+                withTimeoutOrNull(effectiveTimeoutMs) {
+                    session.exec(command)
+                }
+            } catch (t: Throwable) {
+                throw TmuxClientException(
+                    "tmux heal capture exec failed for pane $paneId: ${t.message}",
+                    t,
+                )
+            }
+        if (execResult == null) {
             Log.w(
                 ISSUE_244_DIAG_TAG,
-                "tmux captureWithCursor acquire wedged >${effectiveTimeoutMs}ms; " +
-                    "surfacing a best-effort failure so the seed gate opens. " +
-                    "paneId=$paneId",
+                "tmux captureWithCursor exec timed out >${effectiveTimeoutMs}ms " +
+                    "(heal lane); surfacing a best-effort failure. paneId=$paneId",
             )
             throw TmuxClientException(
-                "tmux capture-pane (combined) acquire wedged after ${effectiveTimeoutMs}ms",
+                "tmux capture-pane (exec heal lane) timed out after ${effectiveTimeoutMs}ms",
             )
         }
-        return try {
-            if (closed) throw TmuxClientException("client is closed")
-            if (!connected) throw TmuxClientException("client is not connected")
-            val sh = shell ?: throw TmuxClientException("client has no active shell")
-
-            // Register both expected response blocks BEFORE writing so neither
-            // can be lost if it arrives before the write returns. Order matters:
-            // tmux answers the chained commands in submission order, so the
-            // capture block correlates to [capturePending] and the cursor block
-            // to [cursorPending].
-            val capturePending = PendingCommand(deferred = CompletableDeferred())
-            val cursorPending = PendingCommand(deferred = CompletableDeferred())
-            synchronized(responseCorrelationLock) {
-                pendingQueue.offer(capturePending)
-                pendingQueue.offer(cursorPending)
-            }
-
-            val writeResult = CompletableDeferred<Unit>()
-            val writeCompleted = AtomicBoolean(false)
-            val writeJob = clientScope.launch {
-                try {
-                    writeLine(sh, chained)
-                    writeCompleted.set(true)
-                    writeResult.complete(Unit)
-                } catch (t: Throwable) {
-                    writeResult.completeExceptionally(t)
-                }
-            }
-
-            try {
-                val capture = commandTimeoutGate.run(effectiveTimeoutMs) { checkpoint ->
-                    writeResult.await()
-                    checkpoint.writeCompleted()
-                    capturePending.deferred.await()
-                } ?: run {
-                    // Capture itself timed out: tear down both pending entries
-                    // and surface a best-effort failure (the caller falls back
-                    // to opening the seed gate without a snapshot).
-                    cleanupCaptureWithCursorPending(
-                        capturePending = capturePending,
-                        cursorPending = cursorPending,
-                        commandWasWritten = writeCompleted.get(),
-                    )
-                    writeJob.cancel()
-                    throw TmuxClientException(
-                        "tmux capture-pane (combined) timed out after ${effectiveTimeoutMs}ms",
-                    )
-                }
-                // The cursor block is best-effort: a slow/absent reply degrades
-                // to no explicit cursor restore rather than failing the seed.
-                val cursorReply = commandTimeoutGate.run(effectiveTimeoutMs) { checkpoint ->
-                    checkpoint.writeCompleted()
-                    cursorPending.deferred.await()
-                }
-                    ?.takeUnless { it.isError }
-                    ?.output
-                    ?.firstOrNull()
-                if (cursorReply == null) {
-                    // Stop waiting on the cursor block: discard a not-yet-begun
-                    // late block or drain an already-open one so it cannot
-                    // mis-correlate with the NEXT command on the wire.
-                    synchronized(responseCorrelationLock) {
-                        abandonPendingResponse(cursorPending, commandWasWritten = true)
-                    }
-                }
-                CaptureWithCursor(capture = capture, cursorReply = cursorReply)
-            } catch (t: Throwable) {
-                cleanupCaptureWithCursorPending(
-                    capturePending = capturePending,
-                    cursorPending = cursorPending,
-                    commandWasWritten = writeCompleted.get(),
-                )
-                writeJob.cancel()
-                if (!writeCompleted.get()) {
-                    close()
-                    throw TmuxClientException(
-                        "failed to write tmux combined capture command: ${t.message}",
-                        t,
-                    )
-                }
-                throw t
-            }
-        } finally {
-            sendMutex.unlock()
-        }
+        return parseHealCaptureResult(execResult)
     }
 
     /**
-     * Issue #640: remove both pending entries for a combined capture exchange,
-     * accounting for blocks tmux has already begun, plus every not-yet-begun
-     * block still owed by a written chained line, so late replies cannot bind
-     * to a later command.
+     * Issue #1297: split a heal-capture [ExecResult] into the raw cursor reply
+     * and the `capture-pane` lines around the [HEAL_CAPTURE_SPLIT_MARKER]
+     * sentinel line. A non-zero exit (pane/session gone) surfaces as an error
+     * [CommandResponse] carrying the stderr; a live-but-blank pane surfaces as a
+     * non-error response so the caller distinguishes error from empty.
      */
-    private fun cleanupCaptureWithCursorPending(
-        capturePending: PendingCommand,
-        cursorPending: PendingCommand,
-        commandWasWritten: Boolean,
-    ) {
-        synchronized(responseCorrelationLock) {
-            for (pending in listOf(capturePending, cursorPending)) {
-                abandonPendingResponse(pending, commandWasWritten = commandWasWritten)
-            }
+    private fun parseHealCaptureResult(result: ExecResult): CaptureWithCursor {
+        val stdout = result.stdout
+        val markerIdx = stdout.indexOf(HEAL_CAPTURE_SPLIT_MARKER)
+        val cursorRaw: String
+        val captureRaw: String
+        if (markerIdx >= 0) {
+            cursorRaw = stdout.substring(0, markerIdx)
+            // Drop the newline that terminates the sentinel line so the capture
+            // starts on its own first line.
+            captureRaw = stdout.substring(markerIdx + HEAL_CAPTURE_SPLIT_MARKER.length)
+                .removePrefix("\n")
+        } else {
+            // Sentinel missing (unexpected shell state): no reliable split. Treat
+            // the whole stdout as capture and degrade to a null cursor.
+            cursorRaw = ""
+            captureRaw = stdout
         }
+        val cursorReply = cursorRaw.trim().ifEmpty { null }
+        val captureLines = splitCaptureLines(captureRaw)
+        val isError = result.exitCode != 0
+        val outputLines =
+            if (isError && captureLines.isEmpty()) {
+                result.stderr.trim().let { if (it.isEmpty()) emptyList() else it.split("\n") }
+            } else {
+                captureLines
+            }
+        return CaptureWithCursor(
+            capture = CommandResponse(number = -1L, output = outputLines, isError = isError),
+            cursorReply = cursorReply,
+        )
+    }
+
+    /**
+     * Split the `capture-pane` payload into lines, dropping the single trailing
+     * empty line the terminal newline produces so the output matches the
+     * per-line list the old `-CC` block drain returned.
+     */
+    private fun splitCaptureLines(capture: String): List<String> {
+        if (capture.isEmpty()) return emptyList()
+        val lines = capture.split("\n")
+        return if (lines.isNotEmpty() && lines.last().isEmpty()) lines.dropLast(1) else lines
     }
 
     /**
@@ -1404,8 +1400,8 @@ internal class RealTmuxClient(
     /**
      * Issue #692: remove every still-pending entry for a chained exchange,
      * accounting for blocks tmux has already begun, plus every not-yet-begun
-     * block still owed by a written chained line. Mirrors
-     * [cleanupCaptureWithCursorPending] for N blocks.
+     * block still owed by a written chained line. The N-block generalisation of
+     * the old combined-capture pending cleanup.
      */
     private fun cleanupChainedPending(
         pendings: List<PendingCommand>,
@@ -1688,6 +1684,14 @@ internal class RealTmuxClient(
     // top of it. Best-effort: only touches the live channel, never the reader.
     override fun drainPaneOutputBacklog(paneId: String): Int =
         paneOutputPipes[paneId]?.drainBacklog() ?: 0
+
+    override fun pauseOutputDelivery(paneId: String) {
+        paneOutputPipes[paneId]?.pauseDelivery()
+    }
+
+    override fun resumeOutputDelivery(paneId: String) {
+        paneOutputPipes[paneId]?.resumeDelivery()
+    }
 
     override suspend fun setWindowSizeLatest(sessionId: String): CommandResponse =
         sendCommandInternal(
@@ -2605,6 +2609,15 @@ internal class RealTmuxClient(
         private const val ISSUE_105_DIAG_TAG = "issue105-diag"
         private const val ISSUE_244_DIAG_TAG = "issue244-diag"
 
+        /**
+         * Issue #1297: sentinel line printed between the cursor reply and the
+         * `capture-pane` payload in the single heal-capture `exec` so the one
+         * stdout splits cleanly into cursor + capture. Distinctive enough that a
+         * collision with real capture content is implausible, and the split takes
+         * the FIRST occurrence so even a colliding capture body cannot corrupt it.
+         */
+        private const val HEAL_CAPTURE_SPLIT_MARKER = "__PS_HEAL_CAPTURE_SPLIT_9c3f__"
+
         /** LF (`0x0A`) — the line delimiter in the control-mode stream. */
         private const val LF_BYTE: Byte = 0x0A
 
@@ -2687,9 +2700,24 @@ internal class RealTmuxClient(
         private val job: Job,
         private val onOverflow: (TmuxOutputBacklogOverflow) -> Unit,
         private val diagnosticFields: () -> Map<String, Any?>,
+        // Issue #1297: when `true` the drain job stops emitting to [flow] and
+        // frames accumulate in the bounded [channel] instead of being dropped
+        // into a zero-subscriber flow. Driven by [pauseDelivery]/[resumeDelivery]
+        // across the overflow-reseed producer swap.
+        private val paused: MutableStateFlow<Boolean>,
         private val droppedEvents: AtomicInteger = AtomicInteger(0),
         private val overflowDiagnosticEmitted: AtomicBoolean = AtomicBoolean(false),
     ) {
+        /** Issue #1297: freeze delivery so a collector gap holds, not drops. */
+        fun pauseDelivery() {
+            paused.value = true
+        }
+
+        /** Issue #1297: thaw delivery; held frames drain to the collector. */
+        fun resumeDelivery() {
+            paused.value = false
+        }
+
         fun send(event: ControlEvent.Output) {
             val result = channel.trySend(event)
             if (result.isFailure) {
@@ -2749,6 +2777,7 @@ internal class RealTmuxClient(
                     extraBufferCapacity = EVENT_BUFFER,
                 )
                 val channel = Channel<ControlEvent.Output>(OUTPUT_BACKLOG_EVENTS)
+                val paused = MutableStateFlow(false)
                 val job = scope.launch {
                     // Issue #1204: replay any output buffered before this pipe
                     // was registered, IN ORDER, ahead of the live channel. The
@@ -2797,7 +2826,25 @@ internal class RealTmuxClient(
                         }
                         replay = null // release the (bounded) replay list either way
                     }
-                    for (event in channel) {
+                    while (true) {
+                        val event = channel.receiveCatching().getOrNull() ?: break
+                        // Issue #1297: HOLD delivery while paused. The overflow-
+                        // reseed producer swap tears the sole collector down and
+                        // reattaches a fresh one; without this gate every %output
+                        // emitted in that window used to be emitted into the
+                        // zero-subscriber (replay = 0) flow and vanish, leaving
+                        // recovery to depend SOLELY on the step-4 capture (#1297's
+                        // SPOF). The just-received frame is HELD in `event` (never
+                        // dropped) and every later frame stays queued in the bounded
+                        // [channel] (its own OUTPUT_BACKLOG_EVENTS overflow bound
+                        // still applies); on resume the held frame emits first, then
+                        // the queued frames drain — arrival order preserved. Checked
+                        // AFTER the receive so a frame parked in [receiveCatching]
+                        // when the pause lands is held, not emitted into a paused
+                        // (subscriber-detached) flow.
+                        if (paused.value) {
+                            paused.first { !it }
+                        }
                         flow.emit(event)
                     }
                 }
@@ -2807,6 +2854,7 @@ internal class RealTmuxClient(
                     job = job,
                     onOverflow = onOverflow,
                     diagnosticFields = diagnosticFields,
+                    paused = paused,
                 )
             }
         }

--- a/shared/core-tmux/src/test/java/com/pocketshell/core/tmux/TmuxClientTest.kt
+++ b/shared/core-tmux/src/test/java/com/pocketshell/core/tmux/TmuxClientTest.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.selects.select
@@ -705,85 +706,91 @@ class TmuxClientTest {
         }
     }
 
+    /**
+     * Issue #1297: an [SshSession.exec] handler that simulates the remote shell
+     * running the single heal-capture exec (`tmux display-message … ; printf
+     * '%s\n' '<MARKER>' ; tmux capture-pane …`). It extracts the sentinel token
+     * straight from the command (so the test never hard-codes the production
+     * marker constant) and assembles the combined stdout the shell would produce:
+     * `<cursor>\n<MARKER>\n<capture lines…>`.
+     */
+    private fun healExecHandler(
+        cursor: String?,
+        captureLines: List<String>,
+        exitCode: Int = 0,
+        stderr: String = "",
+        delayMs: Long = 0L,
+    ): suspend (String) -> ExecResult = { command ->
+        if (delayMs > 0L) delay(delayMs)
+        val marker = command.substringAfter("printf '%s\\n' '").substringBefore("'")
+        val stdout = buildString {
+            if (cursor != null) {
+                append(cursor)
+                append('\n')
+            }
+            append(marker)
+            append('\n')
+            for (line in captureLines) {
+                append(line)
+                append('\n')
+            }
+        }
+        ExecResult(stdout = stdout, stderr = stderr, exitCode = exitCode)
+    }
+
     @Test
-    fun `captureWithCursor sends one chained command and drains both response blocks`() = runBlocking {
-        // Issue #640: the seed needs capture + cursor in ONE wire round-trip.
-        // tmux -CC answers a `capture-pane ; display-message` request with TWO
-        // separate begin/end blocks, so captureWithCursor must write ONE chained
-        // line and correlate both blocks under one single-flight acquisition.
+    fun `captureWithCursor runs on the exec lane and returns capture and cursor`() = runBlocking {
+        // Issue #1297: the heal/seed capture runs on a DEDICATED exec channel
+        // (not the -CC control shell). One exec carries display-message +
+        // capture-pane, split on a sentinel line, and the parsed result exposes
+        // the pane lines and the cursor.
         val shell = FakeShell()
-        val session = FakeSession(shell)
+        val session = FakeSession(
+            shell,
+            execHandler = healExecHandler(cursor = "4,2", captureLines = listOf("line-one", "line-two")),
+        )
         val client = RealTmuxClient(session, scope)
         try {
             client.connect()
-            withTimeout(2_000) {
-                while (shell.stdinBytes().isEmpty()) { yield(); delay(10) }
-            }
-            shell.resetStdin()
-
-            val result = scope.async {
+            val combined = withTimeout(ASYNC_AWAIT_TIMEOUT_MS) {
                 client.captureWithCursor("%3", scrollbackLines = 200)
             }
-            withTimeout(2_000) {
-                while (shell.stdinBytes().isEmpty()) { yield(); delay(10) }
-            }
-            // Exactly ONE chained line on the wire (one round-trip), carrying
-            // both the capture and the cursor query.
-            assertEquals(
-                "capture-pane -p -e -S -200 -t %3 ; " +
-                    "display-message -p -t %3 '#{cursor_x},#{cursor_y}'\n",
-                shell.stdinAsString(),
-            )
-
-            // tmux answers with two sequential blocks: capture, then cursor.
-            shell.feed(
-                "%begin 1700000000 10 0\n" +
-                    "line-one\n" +
-                    "line-two\n" +
-                    "%end 1700000000 10 0\n" +
-                    "%begin 1700000000 11 0\n" +
-                    "4,2\n" +
-                    "%end 1700000000 11 0\n",
-            )
-
-            val combined = withTimeout(ASYNC_AWAIT_TIMEOUT_MS) { result.await() }
             assertFalse(combined.capture.isError)
             assertEquals(listOf("line-one", "line-two"), combined.capture.output)
             assertEquals("4,2", combined.cursorReply)
+
+            // Proof it ran on an exec channel — NOT the -CC control shell. Nothing
+            // was written to the -CC stdin for the capture, and the exec command
+            // carries both pane-targeted tmux sub-commands.
+            val execCmd = session.execCommands.single { it.contains("capture-pane") }
+            assertTrue(
+                "exec must carry the pane-targeted capture-pane",
+                execCmd.contains("tmux capture-pane -p -e -S -200 -t '%3'"),
+            )
+            assertTrue(
+                "exec must carry the pane-targeted cursor query",
+                execCmd.contains("tmux display-message -p -t '%3' '#{cursor_x},#{cursor_y}'"),
+            )
         } finally {
             client.close()
         }
     }
 
     @Test
-    fun `captureWithCursor degrades to null cursor when only the capture block returns`() = runBlocking {
-        // Issue #640/#259: a missing/failed cursor block must NOT fail the
+    fun `captureWithCursor degrades to null cursor when display-message yields nothing`() = runBlocking {
+        // Issue #640/#259/#1297: a missing/empty cursor reply must NOT fail the
         // capture — the seed degrades to no explicit cursor restore.
         val shell = FakeShell()
-        val session = FakeSession(shell)
-        val client = RealTmuxClient(session, scope, commandTimeoutMs = 300L)
+        val session = FakeSession(
+            shell,
+            execHandler = healExecHandler(cursor = null, captureLines = listOf("only-capture")),
+        )
+        val client = RealTmuxClient(session, scope)
         try {
             client.connect()
-            withTimeout(2_000) {
-                while (shell.stdinBytes().isEmpty()) { yield(); delay(10) }
-            }
-            shell.resetStdin()
-
-            val result = scope.async {
+            val combined = withTimeout(ASYNC_AWAIT_TIMEOUT_MS) {
                 client.captureWithCursor("%3", scrollbackLines = 200)
             }
-            withTimeout(2_000) {
-                while (shell.stdinBytes().isEmpty()) { yield(); delay(10) }
-            }
-
-            // Only the capture block returns; the cursor block never arrives.
-            shell.feed(
-                "%begin 1700000000 10 0\n" +
-                    "only-capture\n" +
-                    "%end 1700000000 10 0\n",
-            )
-
-            val combined = withTimeout(ASYNC_AWAIT_TIMEOUT_MS) { result.await() }
             assertFalse(combined.capture.isError)
             assertEquals(listOf("only-capture"), combined.capture.output)
             assertNull(combined.cursorReply)
@@ -793,68 +800,84 @@ class TmuxClientTest {
     }
 
     @Test
-    fun `captureWithCursor with a short seed timeout fires BELOW the full command ceiling on a wedged channel`() =
-        runBlocking {
-            // Issue #926: the attach/switch/reattach seed passes a SHORT ceiling
-            // (timeoutMs ≈ 2.5 s in production) so a wedged-but-alive `-CC`
-            // channel makes the seed fall through to the blank watchdog FAST,
-            // instead of parking the full per-command `commandTimeoutMs` (10 s in
-            // production) — the #895 freeze. Here the full ceiling is a generous
-            // 30 s and the seed ceiling is 250 ms; the wedged capture (no response
-            // ever fed) must surface a best-effort failure within the SHORT bound,
-            // proving the seed timeout is honoured and clamps below the command
-            // ceiling.
-            val shell = FakeShell()
-            val session = FakeSession(shell)
-            val client = RealTmuxClient(session, scope, commandTimeoutMs = 30_000L)
-            try {
-                client.connect()
-                withTimeout(2_000) {
-                    while (shell.stdinBytes().isEmpty()) { yield(); delay(10) }
-                }
-                shell.resetStdin()
-
-                // No response is ever fed, so the capture block never completes;
-                // the seed ceiling (250 ms) — NOT the 30 s command ceiling — must
-                // fire. Bounding the await at 5 s proves it fired well below 30 s.
-                val startedAtMs = System.currentTimeMillis()
-                val thrown = runCatching {
-                    withTimeout(5_000) {
-                        client.captureWithCursor("%3", scrollbackLines = 200, timeoutMs = 250L)
-                    }
-                }.exceptionOrNull()
-                val elapsedMs = System.currentTimeMillis() - startedAtMs
-
-                assertTrue(
-                    "the wedged seed must surface a TmuxClientException from the short " +
-                        "ceiling, not hang to the 30 s command ceiling (was $thrown)",
-                    thrown is TmuxClientException,
-                )
-                assertTrue(
-                    "the seed must time out within ~the short ceiling, NEVER the full " +
-                        "command ceiling (elapsed ${elapsedMs}ms)",
-                    elapsedMs < 5_000L,
-                )
-            } finally {
-                client.close()
+    fun `captureWithCursor surfaces an error response when the pane is gone`() = runBlocking {
+        // Issue #1297 (§4 req 5 — distinct failure signal): a non-zero exec exit
+        // (pane/session gone) must surface as an ERROR CommandResponse, not a
+        // thrown timeout — so the caller distinguishes "gone" from "wedged".
+        val shell = FakeShell()
+        val session = FakeSession(
+            shell,
+            execHandler = healExecHandler(
+                cursor = null,
+                captureLines = emptyList(),
+                exitCode = 1,
+                stderr = "can't find pane: %9",
+            ),
+        )
+        val client = RealTmuxClient(session, scope)
+        try {
+            client.connect()
+            val combined = withTimeout(ASYNC_AWAIT_TIMEOUT_MS) {
+                client.captureWithCursor("%9", scrollbackLines = 200)
             }
+            assertTrue("a gone pane must surface as an error response", combined.capture.isError)
+            assertEquals(listOf("can't find pane: %9"), combined.capture.output)
+        } finally {
+            client.close()
         }
+    }
 
     @Test
-    fun `captureWithCursor timeout before begin quarantines all late batch blocks`() = runBlocking {
-        // A combined capture writes TWO tmux commands in one line. If the line
-        // has reached tmux but neither reply block has begun before the timeout,
-        // both late blocks must be reserved as stale; otherwise the first late
-        // capture block can bind to the next unrelated command.
+    fun `captureWithCursor exec lane times out on a wedged transport within the short ceiling`() = runBlocking {
+        // Issue #926/#1297: a genuinely wedged/half-open transport (the exec never
+        // returns) must surface a TmuxClientException within the SHORT seed
+        // ceiling, never the full 30 s command ceiling — so a heal capture on a
+        // dead link falls through fast instead of parking.
         val shell = FakeShell()
-        val session = FakeSession(shell)
-        val timeoutGate = DeterministicCommandTimeoutGate()
-        val client = RealTmuxClient(
-            session,
-            scope,
-            commandTimeoutMs = 100L,
-            commandTimeoutGate = timeoutGate,
+        val neverReturns = CompletableDeferred<ExecResult>()
+        val session = FakeSession(shell, execHandler = { neverReturns.await() })
+        val client = RealTmuxClient(session, scope, commandTimeoutMs = 30_000L)
+        try {
+            client.connect()
+            val startedAtMs = System.currentTimeMillis()
+            val thrown = runCatching {
+                withTimeout(5_000) {
+                    client.captureWithCursor("%3", scrollbackLines = 200, timeoutMs = 250L)
+                }
+            }.exceptionOrNull()
+            val elapsedMs = System.currentTimeMillis() - startedAtMs
+            assertTrue(
+                "a wedged exec must surface a TmuxClientException from the short " +
+                    "ceiling, not hang to the 30 s command ceiling (was $thrown)",
+                thrown is TmuxClientException,
+            )
+            assertTrue(
+                "the heal capture must time out within ~the short ceiling (elapsed ${elapsedMs}ms)",
+                elapsedMs < 5_000L,
+            )
+            neverReturns.cancel()
+        } finally {
+            client.close()
+        }
+    }
+
+    @Test
+    fun `heal capture completes on the exec lane while the -CC sendMutex is wedged`() = runBlocking {
+        // Issue #1297 (acceptance criterion 1, red→green): a busy Claude agent
+        // wedges the ONE per-host sendMutex, so a heal capture behind it used to
+        // time out at the 2.5 s ceiling exactly when a pane was black
+        // (#470/#835). On BASE (mutex-based captureWithCursor) this test fails —
+        // the capture can't acquire the wedged mutex within 2.5 s and throws.
+        // With the fix the capture runs on a DEDICATED exec channel and returns
+        // fast, independent of the wedged -CC mutex.
+        val shell = FakeShell()
+        val session = FakeSession(
+            shell,
+            execHandler = healExecHandler(cursor = "1,1", captureLines = listOf("healed")),
         )
+        // A large command ceiling so the wedging command holds the mutex for the
+        // whole test.
+        val client = RealTmuxClient(session, scope, commandTimeoutMs = 30_000L)
         try {
             client.connect()
             withTimeout(2_000) {
@@ -862,46 +885,115 @@ class TmuxClientTest {
             }
             shell.resetStdin()
 
-            val timedOut = scope.async {
-                runCatching { client.captureWithCursor("%3", scrollbackLines = 200) }
-            }
+            // WEDGE the sendMutex: a sendCommand that is written but never
+            // answered holds the mutex for its whole 30 s ceiling (the "capture
+            // behind a busy agent" symptom).
+            val wedger = scope.async { runCatching { client.sendCommand("list-clients") } }
             withTimeout(2_000) {
-                while (!shell.stdinAsString().contains("capture-pane")) { yield(); delay(10) }
+                while (!shell.stdinAsString().contains("list-clients")) { yield(); delay(10) }
             }
-            timeoutGate.fireNextTimeout()
+
+            val startedAtMs = System.currentTimeMillis()
+            val combined = withTimeout(5_000) {
+                client.captureWithCursor("%3", scrollbackLines = 200, timeoutMs = 2_500L)
+            }
+            val elapsedMs = System.currentTimeMillis() - startedAtMs
+
+            assertEquals(listOf("healed"), combined.capture.output)
+            assertEquals("1,1", combined.cursorReply)
             assertTrue(
-                "combined capture must time out before any reply block begins",
-                withTimeout(ASYNC_AWAIT_TIMEOUT_MS) { timedOut.await() }.isFailure,
+                "the heal capture must complete well under the 2.5 s mutex-acquire " +
+                    "ceiling (elapsed ${elapsedMs}ms) — proving it did NOT wait on the " +
+                    "wedged sendMutex",
+                elapsedMs < 2_000L,
             )
-            shell.resetStdin()
+            wedger.cancel()
+        } finally {
+            client.close()
+        }
+    }
 
-            val next = scope.async { client.sendCommand("list-sessions") }
-            withTimeout(2_000) {
-                while (shell.stdinAsString() != "list-sessions\n") { yield(); delay(10) }
+    @Test
+    fun `pauseOutputDelivery holds output across a collector gap so a fresh collector recovers them`() =
+        runBlocking {
+            // Issue #1297 (acceptance criterion 2, red→green): the overflow-reseed
+            // producer swap tears the sole pane collector down and reattaches a
+            // fresh one. On BASE the %output emitted in that gap is emitted into
+            // the zero-subscriber (replay = 0) flow and lost, so a re-subscribing
+            // collector recovers NOTHING. With the fix, pausing delivery across
+            // the swap HOLDS the frames in the bounded backlog and they replay to
+            // the fresh collector in order on resume.
+            val shell = FakeShell()
+            val session = FakeSession(shell)
+            val client = RealTmuxClient(session, scope)
+            try {
+                client.connect()
+                // Attach the sole collector so the pane pipe exists and is live.
+                val firstCollector = scope.launch { client.outputFor("%7").collect { } }
+                delay(150)
+                // Freeze delivery, THEN detach the sole collector (mirrors the
+                // overflow reseed order: pause before the producer teardown).
+                client.pauseOutputDelivery("%7")
+                firstCollector.cancelAndJoin()
+
+                // Emit N frames into the collector gap.
+                shell.feed(
+                    "%output %7 gap-one\n" +
+                        "%output %7 gap-two\n" +
+                        "%output %7 gap-three\n",
+                )
+                // Let the reader parse them into the (paused) backlog.
+                delay(250)
+
+                // Re-subscribe a fresh collector, then thaw — held frames drain in
+                // arrival order to the fresh collector.
+                val recovered = scope.async { client.outputFor("%7").take(3).toList() }
+                delay(100)
+                client.resumeOutputDelivery("%7")
+
+                val frames = withTimeout(ASYNC_AWAIT_TIMEOUT_MS) { recovered.await() }
+                assertEquals(
+                    "every %output emitted during the collector gap must replay in order",
+                    listOf("gap-one", "gap-two", "gap-three"),
+                    frames.map { String(it.data, StandardCharsets.US_ASCII) },
+                )
+            } finally {
+                client.close()
             }
+        }
 
+    @Test
+    fun `output emitted during an unpaused collector gap is dropped`() = runBlocking {
+        // Issue #1297: documents the SPOF the pause closes. WITHOUT the delivery
+        // pause, %output emitted while the sole collector is detached vanishes
+        // into the zero-subscriber flow — a re-subscribing collector recovers
+        // none of it. This is the base behaviour the overflow-reseed swap relied
+        // on the capture to paper over; `pauseOutputDelivery` is the opt-in fix.
+        val shell = FakeShell()
+        val session = FakeSession(shell)
+        val client = RealTmuxClient(session, scope)
+        try {
+            client.connect()
+            val firstCollector = scope.launch { client.outputFor("%8").collect { } }
+            delay(150)
+            // Detach WITHOUT pausing.
+            firstCollector.cancelAndJoin()
             shell.feed(
-                "%begin 1700000000 10 0\n" +
-                    "late-capture\n" +
-                    "%end 1700000000 10 0\n" +
-                    "%begin 1700000000 11 0\n" +
-                    "9,4\n" +
-                    "%end 1700000000 11 0\n",
+                "%output %8 lost-one\n" +
+                    "%output %8 lost-two\n",
             )
-            repeat(10) { yield(); delay(10) }
-            shell.feed(
-                "%begin 1700000000 12 0\n" +
-                    "next-session\n" +
-                    "%end 1700000000 12 0\n",
-            )
-
-            val response = withTimeout(ASYNC_AWAIT_TIMEOUT_MS) { next.await() }
+            delay(250)
+            // Re-subscribe and prove the gap frames are gone: a fresh sentinel is
+            // the only thing delivered.
+            val recovered = scope.async { client.outputFor("%8").take(1).toList() }
+            delay(100)
+            shell.feed("%output %8 after-resubscribe\n")
+            val frames = withTimeout(ASYNC_AWAIT_TIMEOUT_MS) { recovered.await() }
             assertEquals(
-                "late combined-capture blocks must not bind to the next command",
-                12L,
-                response.number,
+                "unpaused gap frames are dropped; only post-resubscribe output survives",
+                listOf("after-resubscribe"),
+                frames.map { String(it.data, StandardCharsets.US_ASCII) },
             )
-            assertEquals(listOf("next-session"), response.output)
         } finally {
             client.close()
         }


### PR DESCRIPTION
Removes the heal-capture single-point-of-failure from the #1208 recovery-layer cluster. Every recovery net funneled through one `capture-pane` behind the shared `-CC` `sendMutex` that a Claude burst wedges; heal captures timed out exactly when a pane was black.

**Fix:** `captureWithCursor` runs on a dedicated `SshSession.exec` channel (the lane the `has-session` preflight uses), so captures return while the `-CC` reader is saturated. Overflow-reseed collector gap closed with a `PaneOutputPipe` pause/resume delivery hold (resume in `finally`) so a reseed no longer depends solely on the capture.

- **Connection-core (D28): clean localized addition, `-CC` control path untouched.** Reviewer independently ran both mandatory integration suites: `:shared:core-tmux:integrationTest` 7/7 (incl. real-tmux + `-CC`-burst), `:shared:core-ssh:integrationTest` green 6m49s (incl. exec close/stale-contract, the #1144→#1149 gate).
- Independent red→green on both load-bearing tests; exec-lane staleness/leak/lifecycle risks all cleared (capture never staler than applied deltas; channel closed per-call; dead-transport race degrades to seed-gate fallback, not a #1288 crash).
- Rebased onto #1294; `:shared:core-tmux:testDebugUnitTest` + flagged app fixtures (`PartialBlackPaneHealTest`, `PaneOutputOverflowRecoveryTest`, `HealCaptureUnverifiedWatchdogTest`) green post-rebase.

Closes #1297