### PR TITLE
composer: 'Resend all' button — re-send every queued/unsent prompt at once (#1308)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/composer/ComposerResendAllImeProofTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/composer/ComposerResendAllImeProofTest.kt
@@ -1,0 +1,198 @@
+package com.pocketshell.app.composer
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.dp
+import androidx.core.graphics.Insets
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.proof.signals.assertNodeFullyAboveImeOrKeyboard
+import com.pocketshell.uikit.theme.PocketShellColors
+import com.pocketshell.uikit.theme.PocketShellTheme
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Issue #1308 — the batch "Resend all" button must stay REACHABLE above the soft
+ * keyboard, not occluded, when the maintainer opens the composer with a queued
+ * backlog and the keyboard is up. This is the composer/bottom-chrome
+ * keyboard-up-occlusion failure class (process.md "Visual / composer / keyboard
+ * / layout regressions", #641/#567/#615) applied to the NEW control.
+ *
+ * It reuses the #780 CI-DETERMINISTIC synthetic-inset model: compose the
+ * PRODUCTION [SheetContent] with the outbound queue expanded and >= 2 Failed
+ * rows (so the "Resend all" button renders), host it in a fixed-height container,
+ * dispatch a SYNTHETIC `Type.ime()` inset (no real soft keyboard, so it is
+ * identical on the dev-box AVD and CI swiftshader), HARD-assert the inset applied
+ * (no `assumeTrue` skip — F3), then assert the button is fully above the keyboard
+ * top via [assertNodeFullyAboveImeOrKeyboard] (viewport containment, not a bare
+ * `assertIsDisplayed()` which a below-the-keyboard control still passes).
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@RunWith(AndroidJUnit4::class)
+class ComposerResendAllImeProofTest {
+
+    @get:Rule
+    val compose = createAndroidComposeRule<ComponentActivity>()
+
+    private val observedImeBottomPx = mutableStateOf(0)
+    private val observedNavBottomPx = mutableStateOf(0)
+    private val observedStatusTopPx = mutableStateOf(0)
+
+    private fun failedRow(id: String, text: String, createdAtMs: Long) = OutboundItem(
+        id = id,
+        sessionKey = "1/a",
+        cleanText = text,
+        state = OutboundState.Failed,
+        lastError = "connection lost",
+        createdAtMs = createdAtMs,
+    )
+
+    @Test
+    fun resendAllButtonStaysAboveKeyboardWhenImeUp() {
+        compose.activityRule.scenario.onActivity { activity ->
+            WindowCompat.setDecorFitsSystemWindows(activity.window, false)
+        }
+
+        compose.setContent {
+            PocketShellTheme {
+                val density = LocalDensity.current
+                observedImeBottomPx.value = WindowInsets.ime.getBottom(density)
+                observedNavBottomPx.value = WindowInsets.navigationBars.getBottom(density)
+                observedStatusTopPx.value = WindowInsets.statusBars.getTop(density)
+
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(PocketShellColors.Background),
+                    contentAlignment = Alignment.TopCenter,
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .width(CONTAINER_WIDTH_DP.dp)
+                            .height(CONTAINER_HEIGHT_DP.dp)
+                            .testTag(CONTAINER_TAG),
+                        contentAlignment = Alignment.TopCenter,
+                    ) {
+                        SheetContent(
+                            state = PromptComposerViewModel.UiState(),
+                            onClose = {},
+                            onDraftChange = {},
+                            onMicTap = {},
+                            onSend = {},
+                            outboundQueueItems = listOf(
+                                failedRow("f-1", "first prompt", 1L),
+                                failedRow("f-2", "second prompt", 2L),
+                            ),
+                            outboundQueueExpanded = true,
+                        )
+                    }
+                }
+            }
+        }
+        compose.waitForIdle()
+
+        applySyntheticInsets(
+            imeBottomPx = (IME_HEIGHT_DP * displayDensity()).toInt(),
+            navBarBottomPx = (NAV_BAR_DP * displayDensity()).toInt(),
+            statusBarTopPx = (STATUS_BAR_DP * displayDensity()).toInt(),
+        )
+        compose.waitForIdle()
+
+        val density = displayDensity()
+        val imeBottomPx = observedImeBottomPx.value
+        val navBottomPx = observedNavBottomPx.value
+        val expectedImePx = (IME_HEIGHT_DP * density).toInt()
+        // HARD-assert the synthetic IME actually reached Compose — otherwise we
+        // would validate a keyboard-DOWN layout and pass vacuously (#780/F3).
+        assertTrue(
+            "Synthetic ime() inset did not reach Compose; cannot validate the " +
+                "issue #1308 keyboard-up reachability of Resend all. " +
+                "observedImeBottomPx=$imeBottomPx (expected ~$expectedImePx).",
+            imeBottomPx > 0,
+        )
+
+        val containerBottom = compose.onNodeWithTag(CONTAINER_TAG, useUnmergedTree = true)
+            .fetchSemanticsNode()
+            .boundsInRoot
+            .bottom
+        val keyboardIntrusionPx = (imeBottomPx - navBottomPx).coerceAtLeast(0)
+        val keyboardTopPx = containerBottom - keyboardIntrusionPx
+
+        // Containment: the button's bottom edge must sit at or above the keyboard
+        // top (and within the window horizontally + at the top). A control shoved
+        // under the keyboard still passes assertIsDisplayed(); this fails it.
+        compose.assertNodeFullyAboveImeOrKeyboard(
+            tag = COMPOSER_OUTBOUND_QUEUE_RESEND_ALL_TAG,
+            keyboardTopPx = keyboardTopPx,
+            slopDp = SLOP_DP,
+        )
+    }
+
+    private fun applySyntheticInsets(
+        imeBottomPx: Int,
+        navBarBottomPx: Int,
+        statusBarTopPx: Int,
+    ) {
+        compose.activityRule.scenario.onActivity { activity ->
+            val decor = activity.window.decorView
+            val insets = WindowInsetsCompat.Builder()
+                .setInsets(WindowInsetsCompat.Type.ime(), Insets.of(0, 0, 0, imeBottomPx))
+                .setInsets(
+                    WindowInsetsCompat.Type.navigationBars(),
+                    Insets.of(0, 0, 0, navBarBottomPx),
+                )
+                .setInsets(
+                    WindowInsetsCompat.Type.statusBars(),
+                    Insets.of(0, statusBarTopPx, 0, 0),
+                )
+                .setInsets(
+                    WindowInsetsCompat.Type.systemBars(),
+                    Insets.of(0, statusBarTopPx, 0, navBarBottomPx),
+                )
+                .build()
+            ViewCompat.dispatchApplyWindowInsets(decor, insets)
+        }
+    }
+
+    private fun displayDensity(): Float =
+        InstrumentationRegistry.getInstrumentation()
+            .targetContext.resources.displayMetrics.density
+
+    private companion object {
+        const val CONTAINER_TAG = "issue1308-resend-all-host"
+
+        // Roomy fixed host so a short draft + the expanded 2-row banner (with the
+        // Resend all button) fit above the synthetic keyboard without scrolling;
+        // the layout math is then deterministic on every AVD (#780 model).
+        const val CONTAINER_HEIGHT_DP = 740f
+        const val CONTAINER_WIDTH_DP = 392f
+
+        const val IME_HEIGHT_DP = 300f
+        const val NAV_BAR_DP = 24f
+        const val STATUS_BAR_DP = 28f
+
+        const val SLOP_DP = 4f
+    }
+}

--- a/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerOutboundQueueTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerOutboundQueueTest.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.pocketshell.app.proof.signals.assertNodeFullyWithinRoot
 import com.pocketshell.uikit.theme.PocketShellTheme
 import org.junit.Assert.assertEquals
 import org.junit.Rule
@@ -155,5 +156,105 @@ class PromptComposerOutboundQueueTest {
         compose.onNodeWithText("Uploading attachments").assertIsDisplayed()
         compose.onNodeWithTag(composerOutboundQueueDeleteTestTag(uploading.id)).assertDoesNotExist()
         compose.onNodeWithTag(composerOutboundQueueRetryTestTag(uploading.id)).assertDoesNotExist()
+    }
+
+    // ---------------------------------------------------------------------
+    // Issue #1308: batch "Resend all"
+    // ---------------------------------------------------------------------
+
+    private fun failedItem(id: String, text: String, createdAtMs: Long) = OutboundItem(
+        id = id,
+        sessionKey = "1/a",
+        cleanText = text,
+        state = OutboundState.Failed,
+        lastError = "connection lost",
+        createdAtMs = createdAtMs,
+    )
+
+    @Test
+    fun resendAllButtonIsAbsentForASingleResendableRow() {
+        // AC3: one unsent prompt already has its own tap-to-retry, so a batch
+        // "Resend all" would be the #971/#987 double-affordance confusion — absent.
+        compose.setContent {
+            PocketShellTheme {
+                SheetContent(
+                    state = PromptComposerViewModel.UiState(),
+                    onClose = {},
+                    onDraftChange = {},
+                    onMicTap = {},
+                    onSend = {},
+                    outboundQueueItems = listOf(failedItem("only-1", "just one", 1L)),
+                    outboundQueueExpanded = true,
+                )
+            }
+        }
+
+        compose.onNodeWithTag(composerOutboundQueueRetryTestTag("only-1")).assertIsDisplayed()
+        compose.onNodeWithTag(COMPOSER_OUTBOUND_QUEUE_RESEND_ALL_TAG).assertDoesNotExist()
+    }
+
+    @Test
+    fun resendAllButtonIsAbsentWhenOnlyOneRowIsResendableAmongActiveRows() {
+        // Two rows, but one is InFlight (not resendable) — only ONE is resendable,
+        // so the batch button stays hidden (the resendable-count gate, not raw size).
+        val failed = failedItem("failed-x", "retry me", 1L)
+        val inFlight = OutboundItem(
+            id = "in-flight-x",
+            sessionKey = "1/a",
+            cleanText = "on the wire",
+            state = OutboundState.InFlight,
+            createdAtMs = 2L,
+        )
+        compose.setContent {
+            PocketShellTheme {
+                SheetContent(
+                    state = PromptComposerViewModel.UiState(),
+                    onClose = {},
+                    onDraftChange = {},
+                    onMicTap = {},
+                    onSend = {},
+                    outboundQueueItems = listOf(failed, inFlight),
+                    outboundQueueExpanded = true,
+                )
+            }
+        }
+
+        compose.onNodeWithTag(COMPOSER_OUTBOUND_QUEUE_RESEND_ALL_TAG).assertDoesNotExist()
+    }
+
+    @Test
+    fun resendAllButtonIsVisibleContainedAndInvokesCallbackForTwoResendableRows() {
+        // AC1: with >= 2 unsent prompts a "Resend all" button appears; tapping it
+        // fires the batch re-arm exactly once. Containment (assertNodeFullyWithinRoot,
+        // not a bare assertIsDisplayed) guards the F1/F3 "actually on-screen, not
+        // clipped off an edge" property for this new bottom-chrome control.
+        val first = failedItem("f-1", "first prompt", 1L)
+        val second = failedItem("f-2", "second prompt", 2L)
+        var resendAllCount = 0
+
+        compose.setContent {
+            PocketShellTheme {
+                SheetContent(
+                    state = PromptComposerViewModel.UiState(),
+                    onClose = {},
+                    onDraftChange = {},
+                    onMicTap = {},
+                    onSend = {},
+                    outboundQueueItems = listOf(first, second),
+                    outboundQueueExpanded = true,
+                    onResendAllOutbound = { resendAllCount++ },
+                )
+            }
+        }
+
+        compose.onNodeWithTag(COMPOSER_OUTBOUND_QUEUE_RESEND_ALL_TAG).assertIsDisplayed()
+        compose.onNodeWithText("Resend all (2)").assertIsDisplayed()
+        compose.assertNodeFullyWithinRoot(COMPOSER_OUTBOUND_QUEUE_RESEND_ALL_TAG)
+        // Per-row retry stays intact alongside the batch action.
+        compose.onNodeWithTag(composerOutboundQueueRetryTestTag(first.id)).assertIsDisplayed()
+
+        compose.onNodeWithTag(COMPOSER_OUTBOUND_QUEUE_RESEND_ALL_TAG).performClick()
+        compose.waitForIdle()
+        assertEquals(1, resendAllCount)
     }
 }

--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerSheet.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerSheet.kt
@@ -233,6 +233,10 @@ public fun PromptComposerSheet(
     // Issue #900: UI/API plumbing for manual outbound retry. Tests may override
     // this seam, while production defaults to the owning VM.
     onRetryOutboundItem: ((String) -> Unit)? = null,
+    // Issue #1308: batch "Resend all" for the expanded unsent-prompts surface.
+    // Tests may override this seam; production defaults to the owning VM's
+    // resendAllQueued, which re-arms every resendable row to Queued in FIFO order.
+    onResendAllOutbound: (() -> Unit)? = null,
     // Issue #585: open the composer WITH recording already started + locked
     // hands-free. Set true only when the session launcher's hold+swipe-up ENTRY
     // gesture opened this sheet; a plain-tap open leaves it false (no recording).
@@ -519,6 +523,7 @@ public fun PromptComposerSheet(
             onToggleOutboundQueue = { outboundQueueExpanded = !outboundQueueExpanded },
             onDeleteOutboundItem = viewModel::discardOutboundItem,
             onRetryOutboundItem = onRetryOutboundItem ?: viewModel::retryOutboundItem,
+            onResendAllOutbound = onResendAllOutbound ?: { viewModel.resendAllQueued(); Unit },
             agentKind = agentKind,
         )
     }
@@ -630,6 +635,7 @@ internal fun SheetContent(
     onToggleOutboundQueue: () -> Unit = {},
     onDeleteOutboundItem: (String) -> Unit = {},
     onRetryOutboundItem: (String) -> Unit = {},
+    onResendAllOutbound: () -> Unit = {},
     // Issue #767: detected engine for the focused pane — selects the
     // `AgentCommandCatalog` the `/`-autocomplete dropdown filters. Null on a
     // shell pane / preview, where the dropdown is never shown.
@@ -1175,6 +1181,7 @@ internal fun SheetContent(
                     onToggle = onToggleOutboundQueue,
                     onDelete = onDeleteOutboundItem,
                     onRetry = onRetryOutboundItem,
+                    onResendAll = onResendAllOutbound,
                 )
                 Spacer(modifier = Modifier.height(8.dp))
             }
@@ -2738,6 +2745,7 @@ private fun OutboundQueueBanner(
     onToggle: () -> Unit,
     onDelete: (String) -> Unit,
     onRetry: (String) -> Unit,
+    onResendAll: () -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -2790,6 +2798,45 @@ private fun OutboundQueueBanner(
                     .height(1.dp)
                     .background(PocketShellColors.BorderSoft),
             )
+            // Issue #1308: batch "Resend all" — re-arm EVERY resendable row
+            // (Queued/Failed) at once, in FIFO order, instead of tapping each
+            // row's Retry. Shown ONLY when at least TWO rows are actually
+            // resendable: a single resendable row already has its own tap-to-retry,
+            // so a batch affordance there would be the #971/#987 double-affordance
+            // confusion. Rows still delivering (InFlight/Uploading) are not counted.
+            val resendableCount = items.count {
+                it.state == OutboundState.Queued || it.state == OutboundState.Failed
+            }
+            if (resendableCount >= 2) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 12.dp, vertical = 8.dp)
+                        .clip(RoundedCornerShape(6.dp))
+                        .background(PocketShellColors.Accent, RoundedCornerShape(6.dp))
+                        .clickable(
+                            role = androidx.compose.ui.semantics.Role.Button,
+                            onClick = onResendAll,
+                        )
+                        .padding(vertical = 10.dp)
+                        .testTag(COMPOSER_OUTBOUND_QUEUE_RESEND_ALL_TAG),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = "Resend all ($resendableCount)",
+                        color = PocketShellColors.OnAccent,
+                        fontSize = 13.sp,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                }
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 12.dp)
+                        .height(1.dp)
+                        .background(PocketShellColors.BorderSoft),
+                )
+            }
             items.forEach { item ->
                 OutboundQueueRow(
                     item = item,
@@ -3557,6 +3604,9 @@ internal const val COMPOSER_PENDING_TOGGLE_TAG = "prompt-composer-pending-toggle
 internal const val COMPOSER_PENDING_SAVED_BANNER_TAG = "prompt-composer-pending-saved"
 internal const val COMPOSER_OUTBOUND_QUEUE_BANNER_TAG = "prompt-composer-outbound-queue"
 internal const val COMPOSER_OUTBOUND_QUEUE_TOGGLE_TAG = "prompt-composer-outbound-queue-toggle"
+// Issue #1308: batch "Resend all" button, shown in the expanded queue banner
+// only when >= 2 rows are resendable.
+internal const val COMPOSER_OUTBOUND_QUEUE_RESEND_ALL_TAG = "prompt-composer-outbound-queue-resend-all"
 
 /**
  * Issue #688: status text shown on a pending row while its retry round-trip

--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerSheet.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerSheet.kt
@@ -1885,6 +1885,16 @@ private fun DiscardRecordingButton(
 private val ComposerActionPillRadius = 22.dp
 private val ComposerActionPillShape = RoundedCornerShape(ComposerActionPillRadius)
 
+// Genuine sub-ladder "micro role" geometry: the outbound-queue action buttons
+// (the per-row Resend affordance and the #1308 "Resend all" banner) use a
+// 6dp radius (design-system.md "Radius, Elevation, And Borders" — "Micro role
+// badges | 3-6dp"), smaller than the named ladder rungs (8/14/20/28dp). 6dp
+// matches the sibling per-row queue button; named here (vs an inline literal)
+// so it stays one intentional token rather than off-ladder drift. See
+// docs/design-system.md.
+private val ComposerQueueButtonRadius = 6.dp
+private val ComposerQueueButtonShape = RoundedCornerShape(ComposerQueueButtonRadius)
+
 // Issue #1152: one baseline HEIGHT for EVERY recording-row pill (Discard / Lock /
 // Insert / Send) so the row reads as a single deliberate control ladder instead
 // of the old 40/44/48dp mix (audit D4). 48dp is the design-system tapTargetMin,
@@ -2812,8 +2822,8 @@ private fun OutboundQueueBanner(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(horizontal = 12.dp, vertical = 8.dp)
-                        .clip(RoundedCornerShape(6.dp))
-                        .background(PocketShellColors.Accent, RoundedCornerShape(6.dp))
+                        .clip(ComposerQueueButtonShape)
+                        .background(PocketShellColors.Accent, ComposerQueueButtonShape)
                         .clickable(
                             role = androidx.compose.ui.semantics.Role.Button,
                             onClick = onResendAll,

--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerViewModel.kt
@@ -1695,6 +1695,43 @@ public class PromptComposerViewModel @Inject constructor(
     }
 
     /**
+     * Issue #1308: re-arm EVERY resendable outbound row for the current composer
+     * target back to [OutboundState.Queued] in ONE action — the batch equivalent
+     * of tapping each row's Retry. After a drop/black-screen leaves several sends
+     * `Failed`/queued, this lets the user re-send the whole backlog with a single
+     * tap instead of one row at a time.
+     *
+     * Order + no-duplicate contract (reusing the existing store primitives):
+     *  - Iterates [OutboundQueueStore.itemsFor], which is sorted oldest-first by
+     *    [OutboundItem.createdAtMs], so the re-arm preserves original FIFO
+     *    (oldest-composed-first) order.
+     *  - Re-arms only the resendable states (`Queued`/`Failed`) via
+     *    [OutboundQueueStore.requeueForRetry] — the SAME per-item primitive the
+     *    single-row Retry uses — so no second deliverable row is ever minted.
+     *  - Leaves `InFlight` rows untouched: they are actively being delivered, and
+     *    re-arming one to `Queued` is exactly the double-send this must not cause.
+     *  - Leaves `Uploading` rows untouched: their attachment upload is in
+     *    progress. A `Delivered` row is already pruned and never resurrected.
+     *
+     * This does NOT itself force a send. Re-arming the rows to `Queued` and
+     * refreshing the snapshot lets the SAME auto-send drain the screen already
+     * runs ([retryNextOutboundItem] on every queue-snapshot change while the
+     * session is live) deliver them one at a time in FIFO order — immediately
+     * when the session is live, or on reconnect if currently disconnected (the
+     * #900/#971 auto-send-on-reconnect path, unchanged).
+     *
+     * Returns the re-armed ids oldest-first, for observability/testing.
+     */
+    public fun resendAllQueued(): List<String> {
+        val target = composerTarget?.takeIf { it.isNotBlank() } ?: return emptyList()
+        val rearmedIds = outboundQueueStore.itemsFor(target)
+            .filter { it.state == OutboundState.Queued || it.state == OutboundState.Failed }
+            .mapNotNull { outboundQueueStore.requeueForRetry(it.id)?.id }
+        if (rearmedIds.isNotEmpty()) refreshOutboundQueueItemsFor(target)
+        return rearmedIds
+    }
+
+    /**
      * Issue #900: process-death / lost-callback recovery. If a row was left
      * [OutboundState.InFlight] longer than the send watchdog window, move it
      * back to [OutboundState.Queued] so the next foreground/reconnect flush can

--- a/app/src/test/java/com/pocketshell/app/composer/PromptComposerViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/PromptComposerViewModelTest.kt
@@ -4147,6 +4147,107 @@ class PromptComposerViewModelTest {
     }
 
     @Test
+    fun resendAllQueuedRearmsFailedAndQueuedRowsToQueuedInFifoOrderWithoutMintingDuplicates() = runTest {
+        // Issue #1308: the batch "Resend all" — with several unsent prompts queued
+        // after a drop, one action re-arms EVERY resendable (Queued/Failed) row to
+        // Queued in original FIFO order, reusing requeueForRetry, WITHOUT minting a
+        // second deliverable row and WITHOUT disturbing a row still on the wire
+        // (InFlight/Uploading), which would be the AC2 double-send.
+        val queue = InMemoryOutboundQueueStore()
+        val failed1 = queue.enqueue(sessionKey = "1/a", cleanText = "oldest failed", createdAtMs = 1L)
+            .let { queue.markFailed(it.id, lastError = "connection lost", lastAttemptAtMs = 10L)!! }
+        val queued2 = queue.enqueue(sessionKey = "1/a", cleanText = "middle queued", createdAtMs = 2L)
+        val failed3 = queue.enqueue(sessionKey = "1/a", cleanText = "newest failed", createdAtMs = 3L)
+            .let { queue.markFailed(it.id, lastError = "connection lost", lastAttemptAtMs = 10L)!! }
+        val inFlight = queue.enqueue(sessionKey = "1/a", cleanText = "on the wire", createdAtMs = 4L)
+            .let { queue.markInFlight(it.id)!! }
+        val uploading = queue.enqueue(sessionKey = "1/a", cleanText = "uploading now", createdAtMs = 5L)
+            .let { queue.markUploading(it.id)!! }
+        val vm = newVm(
+            samplerDispatcher = StandardTestDispatcher(testScheduler),
+            outboundQueueStore = queue,
+        )
+        vm.onComposerTargetChanged("1/a")
+        val rowCountBefore = queue.itemsFor("1/a").size
+
+        val rearmed = vm.resendAllQueued()
+
+        // FIFO: oldest-composed-first, only the resendable (Queued/Failed) rows.
+        assertEquals(listOf(failed1.id, queued2.id, failed3.id), rearmed)
+        // Every resendable row is now clean Queued (error cleared) — no sibling minted.
+        assertEquals(OutboundState.Queued, queue.item(failed1.id)!!.state)
+        assertNull(queue.item(failed1.id)!!.lastError)
+        assertEquals(OutboundState.Queued, queue.item(queued2.id)!!.state)
+        assertEquals(OutboundState.Queued, queue.item(failed3.id)!!.state)
+        // AC2: rows still on the wire are untouched (re-arming them is the double-send).
+        assertEquals(OutboundState.InFlight, queue.item(inFlight.id)!!.state)
+        assertEquals(OutboundState.Uploading, queue.item(uploading.id)!!.state)
+        // No duplicate rows minted — same five ids, same order.
+        assertEquals(rowCountBefore, queue.itemsFor("1/a").size)
+        assertEquals(
+            listOf(failed1.id, queued2.id, failed3.id, inFlight.id, uploading.id),
+            vm.outboundQueueItems.value.map { it.id },
+        )
+        // AC4: a re-armed row stays individually retryable (still exact-claimable).
+        assertEquals(OutboundState.InFlight, queue.claim(failed1.id)!!.state)
+    }
+
+    @Test
+    fun resendAllQueuedThenAutoDrainDeliversFifoAndCountDecrementsToZero() = runTest {
+        // Issue #1308 (AC1 + AC4): after Resend all re-arms the backlog to Queued,
+        // the SAME auto-send drain (retryNextOutboundItem, one-at-a-time) delivers
+        // them oldest-first and the visible unsent count decrements to zero.
+        val queue = InMemoryOutboundQueueStore()
+        val first = queue.enqueue(sessionKey = "1/a", cleanText = "first", createdAtMs = 1L)
+            .let { queue.markFailed(it.id, lastError = "lost", lastAttemptAtMs = 10L)!! }
+        val second = queue.enqueue(sessionKey = "1/a", cleanText = "second", createdAtMs = 2L)
+            .let { queue.markFailed(it.id, lastError = "lost", lastAttemptAtMs = 10L)!! }
+        val vm = newVm(
+            samplerDispatcher = StandardTestDispatcher(testScheduler),
+            outboundQueueStore = queue,
+        )
+        val sent = collectSendRequests(vm)
+        vm.onComposerTargetChanged("1/a")
+
+        assertEquals(listOf(first.id, second.id), vm.resendAllQueued())
+
+        // Drain #1 claims the OLDEST re-armed row (FIFO), delivery prunes it.
+        // `runCurrent()` (not advanceUntilIdle) runs the collector WITHOUT advancing
+        // virtual time to the send watchdog's timeout, so delivery is deterministic.
+        assertEquals(first.id, vm.retryNextOutboundItem())
+        runCurrent()
+        assertEquals(first.id, sent.single().outboundQueueItemId)
+        vm.markSendDelivered(sent.single())
+        assertNull(queue.item(first.id))
+        assertEquals(listOf(second.id), vm.outboundQueueItems.value.map { it.id })
+
+        // Drain #2 delivers the last row — the unsent count reaches zero.
+        assertEquals(second.id, vm.retryNextOutboundItem())
+        runCurrent()
+        assertEquals(second.id, sent.last().outboundQueueItemId)
+        vm.markSendDelivered(sent.last())
+        assertNull(queue.item(second.id))
+        assertTrue(vm.outboundQueueItems.value.isEmpty())
+    }
+
+    @Test
+    fun resendAllQueuedWithNoResendableRowsIsANoOp() = runTest {
+        // Guard: a single in-flight row (nothing resendable) yields no re-arm and
+        // no snapshot churn — the button gate (>= 2 resendable) has a VM twin here.
+        val queue = InMemoryOutboundQueueStore()
+        val inFlight = queue.enqueue(sessionKey = "1/a", cleanText = "on the wire", createdAtMs = 1L)
+            .let { queue.markInFlight(it.id)!! }
+        val vm = newVm(
+            samplerDispatcher = StandardTestDispatcher(testScheduler),
+            outboundQueueStore = queue,
+        )
+        vm.onComposerTargetChanged("1/a")
+
+        assertTrue(vm.resendAllQueued().isEmpty())
+        assertEquals(OutboundState.InFlight, queue.item(inFlight.id)!!.state)
+    }
+
+    @Test
     fun requeueStaleOutboundInFlightUsesWatchdogCutoffBeforeRetryNext() = runTest {
         val queue = InMemoryOutboundQueueStore()
         val now = 500_000L

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -336,6 +336,16 @@ JOURNEY_CLASSES=(
   # retry callbacks in the same per-push androidTest lane as the send-feedback
   # composer proofs. Pure Compose, no Docker fixture.
   "com.pocketshell.app.composer.PromptComposerOutboundQueueTest"
+  # ADDED (#1308): batch "Resend all" for the queued backlog. The presence/absence
+  # + callback + within-root containment of the new button live in
+  # PromptComposerOutboundQueueTest above; this class is its keyboard-UP occlusion
+  # sibling — it composes the production SheetContent with the queue expanded and
+  # >= 2 Failed rows under a SYNTHETIC ime() inset (the #780 model — deterministic
+  # on CI swiftshader, no real keyboard, HARD-asserts the inset applied, no
+  # assumeTrue skip) and asserts the Resend all button stays ABOVE the keyboard via
+  # the #657/F1 assertNodeFullyAboveImeOrKeyboard containment helper. Pure Compose,
+  # no Docker fixture. Carries its fully-qualified name directly.
+  "com.pocketshell.app.composer.ComposerResendAllImeProofTest"
   # PROMOTED (#746): the composer "Not sent" DISCARD + draft session-scoping
   # journey. The maintainer's dogfood report: a "Not sent" draft authored in one
   # session had no Discard control (only Send + the close ×, which PRESERVES the


### PR DESCRIPTION
Maintainer request: with multiple prompts queued unsent (a drop/black-screen leaves several `Failed`/`Queued` rows), retry was one-row-at-a-time. Adds a single **Resend all (N)** button.

- `PromptComposerViewModel.resendAllQueued()` re-arms every `Queued`/`Failed` row for the active session to `Queued` in FIFO order via the existing `requeueForRetry` primitive; `InFlight`/`Uploading`/`Delivered` untouched → no double-send, no duplicate rows. Relies on the existing auto-send drain to flush in order.
- Button shown only when ≥2 resendable rows (per-row tap-to-retry preserved; the #971/#987 double-affordance is guarded).
- **Reviewer ran keyboard-up emulator acceptance** (7 connected tests on the real AVD, 0 failed, incl. the `ComposerResendAllImeProofTest` synthetic-IME geometric containment proof — the button is fully above the IME and tappable). VM behavior red→green driven independently; `check-test-validity` PASS; every AC wired into `ci-journey-suite.sh`.
- File-disjoint from the black-screen v0.4.24 cluster (composer/queue only).

Closes #1308