### PR TITLE
release: v0.4.24 — black-screen recovery layer + continuous reconciler

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,8 +65,8 @@ android {
         applicationId = "com.pocketshell.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 70
-        versionName = "0.4.23"
+        versionCode = 71
+        versionName = "0.4.24"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/tools/pocketshell/pyproject.toml
+++ b/tools/pocketshell/pyproject.toml
@@ -8,7 +8,7 @@ name = "pocketshell"
 # scripts/check-pypi-version.sh enforces this; .github/workflows/build.yml
 # runs that check before publishing to PyPI. See
 # tools/pocketshell/README.md ("Release flow") for the bump procedure.
-version = "0.4.23"
+version = "0.4.24"
 description = "Unified server-side Python utility for the PocketShell Android client."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Bumps versionName to 0.4.24 / versionCode 71.

## What ships
The full black-screen **recovery layer + continuous full-frame reconciler** (#1294–#1302) that landed on `main` after v0.4.23 was tagged:
- Continuous full-frame reconciler — heals any lost pane grid within one interval, whatever dropped it (#1301)
- Wedge-proof heal-capture lane (dedicated exec channel) (#1297)
- Per-line-hash divergence oracle — catches fragments-over-black (#1300)
- Three-state heal watchdog; steady watchdog on every attach path + `watchdog_liveness` event (#1294/#1295)
- Red→green black-screen-gone journey wired into CI as the durable backstop (#1302)

## Release note on gating
Maintainer directive: focus the release on the black screen. This wave is strictly additive / safety-positive and independent of the open #1288 connection-core reconnect gate (confirmed NOT a black-screen cause). The pre-tag release-emulator-validation may require the documented emergency bypass if #1288/AVD flake blocks a clean green, same as v0.4.23 — that will be documented on the release issue.

Refs #1208. Does not close #1288 (separate reconnect gate).