### PR TITLE
core-tmux: don't resurrect a host-killed session on grace reattach (#666)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/LifecycleReattachGoneSessionNoResurrectE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/LifecycleReattachGoneSessionNoResurrectE2eTest.kt
@@ -1,0 +1,412 @@
+package com.pocketshell.app.proof
+
+import android.content.Context
+import android.os.SystemClock
+import android.util.Log
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.lifecycle.Lifecycle
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.BackgroundGraceTestOverride
+import com.pocketshell.app.MainActivity
+import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
+import com.pocketshell.app.hosts.SshKeyStorage
+import com.pocketshell.app.projects.FOLDER_LIST_SCREEN_TAG
+import com.pocketshell.app.tmux.TMUX_SESSION_SCREEN_TAG
+import com.pocketshell.core.ssh.KnownHostsPolicy
+import com.pocketshell.core.ssh.SshConnection
+import com.pocketshell.core.ssh.SshKey
+import com.pocketshell.core.storage.AppDatabase
+import com.pocketshell.core.storage.entity.HostEntity
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+
+/**
+ * Issue #666 REOPEN (2026-07-06) — a tmux session the user killed on the host
+ * must NOT be resurrected when the app REATTACHES to it (the lifecycle /
+ * reconnect path), with the tmux SERVER still alive.
+ *
+ * The maintainer's exact dogfood journey (reported again on v0.4.23): "the bug
+ * where it creates a session when I removed it from the computer is still here."
+ * You are in a session, you leave the app briefly (to screenshot/annotate), the
+ * session is removed on the computer, you come back — and the app RECREATES the
+ * killed session server-side.
+ *
+ * The prior #666 fix guarded the process-death COLD-RESTORE path
+ * ([ColdRestoreGoneSessionNoResurrectE2eTest]) but the RECONNECT/REATTACH path
+ * still leaked: on a `LifecycleReattach` / `AutoReconnect` / `Reconnect`
+ * (`probeServerLiveness=true`, `createIfMissing=true`) the `has-session`
+ * preflight saw the SERVER alive but the ONE target session gone and FELL
+ * THROUGH to `tmux -CC new-session -A` (attach-OR-create) → resurrection. The
+ * fix: a gone session on a LIVE server throws [TmuxSessionNotFoundException] on
+ * EVERY reattach path (not just cold restore), so the app drops to the list.
+ *
+ * This reproduces the reopened symptom on the REAL connected path (G10/D33)
+ * using the deterministic Docker `agents` fixture:
+ *
+ *  1. Seed TWO sessions — the target (`claude-main`) and a KEEPALIVE
+ *     (`shell-2`). The keepalive is load-bearing: it keeps the tmux SERVER
+ *     alive after the target is killed, so the journey exercises the
+ *     server-alive-session-gone branch (the #666 case) and NOT the dead-server
+ *     branch (the #998 case, already covered). A happy fixture that killed the
+ *     only session would kill the server too and mask this exact leak (G10).
+ *  2. Attach to `claude-main` through the normal journey.
+ *  3. Kill ONLY `claude-main` over a sidecar SSH connection; `shell-2` (and the
+ *     server) stay alive. `claude-main` is now gone on a LIVE server.
+ *  4. Background past the grace window, then foreground — the maintainer's "I
+ *     left the app and came back" journey. The foreground fires a
+ *     `LifecycleReattach` reconnect, which runs the server-liveness preflight,
+ *     sees the target session gone (server alive), and drops to the list
+ *     instead of the silent `new-session -A` resurrection.
+ *
+ * Acceptance:
+ *  - `claude-main` is NOT resurrected: a `tmux has-session` probe taken AFTER
+ *    the reattach still fails (on base the reattach recreated it here).
+ *  - The tmux SERVER stayed alive throughout (the keepalive `shell-2` is still
+ *    there) — proving this is the server-alive-session-gone branch.
+ *  - The app drops to the session list instead of a resurrected, empty session
+ *    screen.
+ */
+@RunWith(AndroidJUnit4::class)
+class LifecycleReattachGoneSessionNoResurrectE2eTest {
+
+    val compose = createAndroidComposeRule<MainActivity>()
+
+    @get:Rule
+    val ruleChain: org.junit.rules.RuleChain = org.junit.rules.RuleChain
+        .outerRule(PreGrantPermissionsRule())
+        .around(SeedBeforeLaunchRule { seedBeforeLaunch() })
+        .around(compose)
+
+    private lateinit var fixtureKey: String
+    private lateinit var hostRowTag: String
+    private val timings = mutableListOf<String>()
+
+    @After
+    fun tearDown() {
+        runCatching { compose.activityRule.scenario.moveToState(Lifecycle.State.RESUMED) }
+        BackgroundGraceTestOverride.setForTest(null)
+        clearBackgroundGraceSetting()
+        clearLastSessionPrefs()
+        runBlocking {
+            if (::fixtureKey.isInitialized) {
+                // Reset the fixture's tmux server for the next test.
+                runCatching { runScript(fixtureKey, "tmux kill-server 2>/dev/null || true") }
+            }
+        }
+    }
+
+    private suspend fun seedBeforeLaunch() {
+        clearLastSessionPrefs()
+        clearBackgroundGraceSetting()
+        BackgroundGraceTestOverride.setForTest(null)
+        val key = readFixtureKey()
+        fixtureKey = key
+        waitForSshFixtureReady(SshKey.Pem(key))
+        // Seed the target AND a keepalive so the server survives the target kill.
+        seedTmuxSessions(key)
+        assertTrue("seeded target session must be alive", sessionAlive(key, TARGET_SESSION))
+        assertTrue("seeded keepalive session must be alive", sessionAlive(key, KEEPALIVE_SESSION))
+        hostRowTag = seedDockerHost(key)
+    }
+
+    @Test
+    fun lifecycleReattachToKilledSessionOnLiveServerDropsToListAndNeverResurrects() { runBlocking {
+        val key = fixtureKey
+
+        // ---- (1) Attach to the target session via the normal journey.
+        waitForHostRowPresent(hostRowTag)
+        compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick()
+        waitForText(TARGET_SESSION, timeoutMs = 20_000)
+        compose.onNodeWithText(TARGET_SESSION).performClick()
+        compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertExists()
+        // Let the attach fully settle (panes seeded, Connected revealed).
+        delay(LIFECYCLE_DRAIN_MS)
+
+        // ---- (2) Kill ONLY the target session. The server + keepalive stay
+        // alive, so this is the server-alive-session-gone branch (the #666 case).
+        val killAt = SystemClock.elapsedRealtime()
+        killRemoteSession(key, TARGET_SESSION)
+        recordTiming("kill_session_ms", SystemClock.elapsedRealtime() - killAt)
+        assertTrue(
+            "the target session must be gone on the server after kill-session",
+            !sessionAlive(key, TARGET_SESSION),
+        )
+        assertTrue(
+            "the keepalive session must still be alive (server stays up)",
+            sessionAlive(key, KEEPALIVE_SESSION),
+        )
+        recordTiming("target_alive_after_kill", if (sessionAlive(key, TARGET_SESSION)) 1L else 0L)
+        recordTiming("keepalive_alive_after_kill", if (sessionAlive(key, KEEPALIVE_SESSION)) 1L else 0L)
+
+        // ---- (3) Background past the grace window, then foreground — the
+        // maintainer's "I left the app and came back" journey. Foreground fires a
+        // LifecycleReattach reconnect, which runs the server-liveness preflight,
+        // sees the target session gone (server alive), and routes to
+        // failSessionEnded (drop to the list) — NOT `new-session -A`.
+        val reattachAt = SystemClock.elapsedRealtime()
+        BackgroundGraceTestOverride.setForTest(POST_GRACE_MS)
+        compose.activityRule.scenario.moveToState(Lifecycle.State.CREATED)
+        // Wait out the grace window so the app detaches the live client.
+        delay(POST_GRACE_MS + LIFECYCLE_DRAIN_MS)
+        compose.activityRule.scenario.moveToState(Lifecycle.State.RESUMED)
+
+        // The reattach runs the preflight against the gone session and drops out
+        // of the (now-dead) session into the session list. Give it time.
+        compose.waitUntil(timeoutMillis = RECONNECT_TIMEOUT_MS) {
+            droppedToSessionList()
+        }
+        recordTiming("reattach_to_list_ms", SystemClock.elapsedRealtime() - reattachAt)
+
+        // ---- Acceptance A: the killed session was NOT resurrected server-side.
+        // The bug's symptom is `new-session -A` reviving the killed session. A
+        // has-session probe taken now must still fail.
+        val stillGone = !sessionAlive(key, TARGET_SESSION)
+        val keepaliveAlive = sessionAlive(key, KEEPALIVE_SESSION)
+        recordTiming("target_recreated_after_reattach", if (stillGone) 0L else 1L)
+        recordTiming("keepalive_alive_after_reattach", if (keepaliveAlive) 1L else 0L)
+        writeText(
+            "has-session-probe.txt",
+            buildString {
+                appendLine("target_session=$TARGET_SESSION")
+                appendLine("keepalive_session=$KEEPALIVE_SESSION")
+                appendLine("target_alive_after_reattach=${!stillGone}")
+                appendLine("expected_target_alive_after_reattach=false")
+                appendLine("keepalive_alive_after_reattach=$keepaliveAlive")
+                appendLine("expected_keepalive_alive_after_reattach=true")
+            },
+        )
+        assertTrue(
+            "REGRESSION (#666 reopen): the killed session `$TARGET_SESSION` was " +
+                "RECREATED on lifecycle reattach (tmux has-session succeeded) — a " +
+                "reattach must not resurrect a session gone on a live server",
+            stillGone,
+        )
+        // The server stayed alive throughout (keepalive present) — this proves the
+        // journey exercised the server-alive-session-gone branch, not server death.
+        assertTrue(
+            "the keepalive session must still be alive — the server must have stayed " +
+                "up so this is the #666 (session-gone) branch, not the #998 (server-dead) branch",
+            keepaliveAlive,
+        )
+
+        // ---- Acceptance B: the app dropped OUT of the (would-be-resurrected)
+        // session into the session list, not a resurrected blank session screen.
+        assertTrue(
+            "expected to land on the session list after a gone-session reattach; " +
+                "the FolderList session-list screen should be visible",
+            droppedToSessionList(),
+        )
+        val sessionScreenStillUp = compose
+            .onAllNodesWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true)
+            .fetchSemanticsNodes()
+            .isNotEmpty()
+        assertFalse(
+            "the resurrected session screen must NOT be showing after a gone-session reattach",
+            sessionScreenStillUp,
+        )
+
+        writeTimings()
+        Unit
+    } }
+
+    // ---------------------------------------------------------------- Helpers
+
+    /**
+     * True once the app has dropped OUT of the (would-be-resurrected) session
+     * onto the session list: the FolderList session-list screen is present AND
+     * the tmux session screen is gone. On the base (silent-resurrection) bug the
+     * session screen stays up (a resurrected pane) and this never holds.
+     */
+    private fun droppedToSessionList(): Boolean {
+        val onSessionList = compose
+            .onAllNodesWithTag(FOLDER_LIST_SCREEN_TAG, useUnmergedTree = true)
+            .fetchSemanticsNodes()
+            .isNotEmpty()
+        val sessionScreenGone = compose
+            .onAllNodesWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true)
+            .fetchSemanticsNodes()
+            .isEmpty()
+        return onSessionList && sessionScreenGone
+    }
+
+    private fun readFixtureKey(): String =
+        InstrumentationRegistry.getInstrumentation()
+            .context
+            .assets
+            .open("test_key")
+            .bufferedReader()
+            .use { it.readText() }
+
+    private fun clearBackgroundGraceSetting() {
+        val ctx = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
+        ctx.getSharedPreferences("app_settings", Context.MODE_PRIVATE)
+            .edit()
+            .remove("background_grace_millis")
+            .commit()
+    }
+
+    private suspend fun seedDockerHost(key: String): String {
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
+        val db = Room.databaseBuilder(appContext, AppDatabase::class.java, DATABASE_NAME)
+            .fallbackToDestructiveMigration(dropAllTables = true)
+            .build()
+        return try {
+            db.clearAllTables()
+            val storedKey = SshKeyStorage.persistKey(
+                context = appContext,
+                sshKeyDao = db.sshKeyDao(),
+                name = "issue666reopen-key-${System.currentTimeMillis()}",
+                content = key,
+            )
+            val hostId = db.hostDao().insert(
+                HostEntity(
+                    name = "Issue666 ReattachGone",
+                    hostname = DEFAULT_HOST,
+                    port = DEFAULT_PORT,
+                    username = DEFAULT_USER,
+                    keyId = storedKey.id,
+                    tmuxInstalled = true,
+                    lastBootstrapAt = System.currentTimeMillis(),
+                ),
+            )
+            HOST_ROW_TAG_PREFIX + hostId
+        } finally {
+            db.close()
+        }
+    }
+
+    private suspend fun seedTmuxSessions(key: String) {
+        val script = buildString {
+            appendLine("set -eu")
+            appendLine("tmux kill-server 2>/dev/null || true")
+            appendLine("sleep 1")
+            appendLine(
+                "tmux new-session -d -s ${shellQuote(TARGET_SESSION)} " +
+                    "${shellQuote("printf 'ISSUE666-TARGET\\n'; exec sleep 600")}",
+            )
+            appendLine(
+                "tmux new-session -d -s ${shellQuote(KEEPALIVE_SESSION)} " +
+                    "${shellQuote("printf 'ISSUE666-KEEPALIVE\\n'; exec sleep 600")}",
+            )
+            appendLine("sleep 1")
+            appendLine("tmux has-session -t ${shellQuote(TARGET_SESSION)}")
+        }
+        val exec = runScript(key, script)
+        assertTrue(
+            "expected tmux seeding to succeed; stderr='${exec?.stderr}'",
+            exec?.exitCode == 0,
+        )
+        Log.i(LOG_TAG, "seeded sessions: ${exec?.stdout?.trim()}")
+    }
+
+    private suspend fun killRemoteSession(key: String, session: String) {
+        runScript(
+            key,
+            "tmux kill-session -t ${shellQuote(session)} 2>/dev/null || true",
+        )
+    }
+
+    /** True iff the named tmux session currently exists on the server. */
+    private suspend fun sessionAlive(key: String, session: String): Boolean {
+        val exec = runScript(
+            key,
+            "tmux has-session -t ${shellQuote(session)} 2>/dev/null && echo ALIVE || echo GONE",
+        )
+        return exec?.stdout?.contains("ALIVE") == true
+    }
+
+    private suspend fun runScript(key: String, script: String) =
+        SshConnection.connect(
+            host = DEFAULT_HOST,
+            port = DEFAULT_PORT,
+            user = DEFAULT_USER,
+            key = SshKey.Pem(key),
+            knownHosts = KnownHostsPolicy.AcceptAll,
+            timeoutMs = 15_000,
+        ).mapCatching { session -> session.use { it.exec(script) } }.getOrNull()
+
+    private fun waitForText(text: String, timeoutMs: Long) {
+        compose.waitUntil(timeoutMillis = timeoutMs) {
+            runCatching {
+                compose.onAllNodesWithText(text, useUnmergedTree = true)
+                    .fetchSemanticsNodes()
+                    .isNotEmpty()
+            }.getOrDefault(false)
+        }
+    }
+
+    private fun waitForHostRowPresent(hostRowTag: String) {
+        compose.waitUntil(timeoutMillis = TerminalTestTimeouts.screenRenderPresenceTimeoutMs()) {
+            runCatching {
+                compose.onAllNodesWithTag(hostRowTag, useUnmergedTree = true)
+                    .fetchSemanticsNodes()
+                    .isNotEmpty()
+            }.getOrDefault(false)
+        }
+    }
+
+    private fun writeText(name: String, text: String): File {
+        val file = artifactFile(name)
+        file.writeText(text)
+        println("ISSUE666REOPEN_TEXT ${file.absolutePath}")
+        return file
+    }
+
+    private fun writeTimings(): File {
+        val file = artifactFile("timings.txt")
+        file.writeText(timings.joinToString(separator = "\n", postfix = "\n"))
+        println("ISSUE666REOPEN_TIMINGS ${file.absolutePath}")
+        return file
+    }
+
+    private fun artifactFile(name: String): File {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val mediaRoot = com.pocketshell.app.test.testArtifactsRoot(instrumentation.targetContext)
+        val dir = File(mediaRoot, "additional_test_output/$DEVICE_DIR_NAME")
+        check(dir.exists() || dir.mkdirs()) {
+            "could not create artifact directory ${dir.absolutePath}"
+        }
+        return File(dir, name)
+    }
+
+    private fun recordTiming(name: String, value: Long) {
+        val line = "$name=$value"
+        timings += line
+        println("ISSUE666REOPEN_TIMING $line")
+    }
+
+    private fun shellQuote(value: String): String =
+        "'" + value.replace("'", "'\"'\"'") + "'"
+
+    private companion object {
+        const val DATABASE_NAME: String = "pocketshell.db"
+        const val LOG_TAG: String = "Issue666ReattachGone"
+        const val DEVICE_DIR_NAME: String = "issue666-reopen-lifecycle-reattach-gone-session"
+
+        // Picker entry names shipped by the deterministic `agents` fixture so the
+        // normal attach journey reaches them; `tmux` itself is the real binary,
+        // so has-session / kill-session are authoritative.
+        const val TARGET_SESSION: String = "claude-main"
+        const val KEEPALIVE_SESSION: String = "shell-2"
+
+        const val LIFECYCLE_DRAIN_MS: Long = 1_500L
+        // Short grace so the post-grace detach + foreground reattach cycle runs
+        // without the user-facing 30s minimum.
+        const val POST_GRACE_MS: Long = 1_200L
+        const val RECONNECT_TIMEOUT_MS: Long = 30_000L
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionWarmOpenTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionWarmOpenTest.kt
@@ -1004,6 +1004,144 @@ class TmuxSessionWarmOpenTest {
     }
 
     @Test
+    fun reconnectToGoneSessionOnLiveServerDropsToListAndNeverResurrects() = runVmTest {
+        // Issue #666 REOPEN (2026-07-06): the maintainer killed a session on the
+        // host, backgrounded, came back — and the app RECREATED the killed session.
+        // The leak was NOT cold-restore (that path was already guarded) but the
+        // RECONNECT/REATTACH path: `probeServerLiveness=true` runs the has-session
+        // probe, sees the SERVER alive but the ONE target session gone, and on base
+        // FELL THROUGH to `new-session -A` (attach-OR-create) → resurrection.
+        //
+        // This drives the REAL [RealTmuxClient] reattach preflight (no factory
+        // override) with a LIVE server + a GONE session (`can't find session:
+        // work`, exit 1). The fix must throw [TmuxSessionNotFoundException] and
+        // drop to the list — identically to cold-restore — never recreate. On base
+        // the fall-through would call startShell() (the reconnect ladder), so
+        // `sessionEnded` never fires: red. With the fix it fires: green.
+        val gone = AlwaysConnectedSession(
+            id = "gone",
+            hasSessionExitCode = 1,
+            hasSessionStderr = "can't find session: work",
+        )
+        assertGoneSessionReattachDropsToList(gone, TmuxConnectTrigger.Reconnect)
+    }
+
+    @Test
+    fun lifecycleReattachToGoneSessionOnLiveServerDropsToListAndNeverResurrects() = runVmTest {
+        // Issue #666 REOPEN — the maintainer's EXACT dogfood gesture: in a session,
+        // leave the app (to screenshot/annotate), the session is removed on the
+        // computer, come back to the FOREGROUND within the grace window. Foreground
+        // fires `connect(LifecycleReattach)` (a reconnect trigger,
+        // `probeServerLiveness=true`). Same leaking preflight fall-through as the
+        // Reconnect case above — this pins the LifecycleReattach member of the class
+        // so the reopened symptom cannot come back through the lifecycle path.
+        val gone = AlwaysConnectedSession(
+            id = "gone",
+            hasSessionExitCode = 1,
+            hasSessionStderr = "can't find session: work",
+        )
+        assertGoneSessionReattachDropsToList(gone, TmuxConnectTrigger.LifecycleReattach)
+    }
+
+    /**
+     * Issue #666 REOPEN shared driver: a reattach ([trigger] is a reconnect
+     * trigger) to a session that is GONE on a LIVE server must drop to the list
+     * (one-shot `sessionEnded`, terminal `Failed`), never resurrect via
+     * `new-session -A`, and never fall into the auto-reconnect ladder. Uses the
+     * REAL [RealTmuxClient] preflight through the ViewModel so the client fix is
+     * exercised end-to-end at the VM boundary.
+     */
+    private fun TestScope.assertGoneSessionReattachDropsToList(
+        gone: AlwaysConnectedSession,
+        trigger: TmuxConnectTrigger,
+    ) {
+        val connector = SingleSessionConnector(gone)
+        val leaseManager =
+            testLeaseManager(connector = connector, scope = this, idleTtlMillis = 60_000L)
+        val registry = ActiveTmuxClients()
+        val vm = TestNewVm(registry = registry, sshLeaseManager = leaseManager)
+
+        // No factory override: the REAL RealTmuxClient preflight runs. If a client
+        // were spawned past the preflight it would call startShell() (which this
+        // session errors on), so reaching Connected is impossible without the
+        // silent-resurrection fall-through.
+        val sessionEndedEvents = mutableListOf<String>()
+        var endedSubscribed = false
+        val endedCollector = launch {
+            vm.sessionEnded
+                .onSubscription { endedSubscribed = true }
+                .collect { sessionEndedEvents.add(it) }
+        }
+        // DETERMINISM (issue #998 flake): subscribe the no-replay `sessionEnded`
+        // collector BEFORE connect so the drop-to-list `tryEmit` is observed.
+        testScheduler.runCurrent()
+        assertTrue(
+            "the sessionEnded collector must be subscribed before connect (determinism barrier)",
+            endedSubscribed,
+        )
+
+        vm.connect(
+            hostId = 1L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            passphrase = null,
+            sessionName = "work",
+            trigger = trigger,
+        )
+        pumpUntil(reason = "gone-session reattach drop-to-list (sessionEnded fired)") {
+            sessionEndedEvents.isNotEmpty()
+        }
+        endedCollector.cancel()
+
+        // The reattach requested the server-liveness probe...
+        assertTrue(
+            "a ${trigger.logValue} reattach must request the server-liveness probe",
+            vm.lastProbeServerLivenessForTest(),
+        )
+        // ...and it is create-if-missing (proving the fix guards even the
+        // create-if-missing reattach path, not just attach-only cold-restore)...
+        assertTrue(
+            "a ${trigger.logValue} reattach stays create-if-missing (guard must not depend on it)",
+            vm.lastCreateIfMissingForTest(),
+        )
+        // ...the preflight ran the has-session probe...
+        assertTrue(
+            "reattach must probe `tmux has-session`; saw: ${gone.execCommands}",
+            gone.execCommands.any { it.startsWith("tmux has-session -t 'work'") },
+        )
+        // ...we dropped to the list (one-shot sessionEnded fired, naming the gone
+        // session) instead of resurrecting it...
+        assertEquals(
+            "a gone-session reattach must drop to the list via sessionEnded",
+            listOf("work"),
+            sessionEndedEvents,
+        )
+        // ...the surface is the terminal "session ended" Failed state...
+        assertTrue(
+            "gone-session reattach must surface Failed (session ended), got ${vm.connectionStatus.value}",
+            vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Failed,
+        )
+        // ...NOT resurrected into Connected...
+        assertFalse(
+            "gone-session reattach must NOT resurrect into Connected",
+            vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+        // ...and NOT dropped into the auto-reconnect ladder (the resurrection loop).
+        assertFalse(
+            "gone-session reattach must NOT auto-reconnect (the silent-resurrection loop)",
+            vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Reconnecting,
+        )
+        // No pane was ever painted — nothing got resurrected.
+        assertTrue(
+            "no pane must be painted for a gone-session reattach, got ${vm.panes.value.map { it.paneId }}",
+            vm.panes.value.isEmpty(),
+        )
+    }
+
+    @Test
     fun explicitNewSessionNeverRequestsServerLivenessProbe() = runVmTest {
         // The boundary that keeps the #998 probe off the create path: the
         // explicit user "new session" intent (UserTap) must NOT request the

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -133,6 +133,18 @@ JOURNEY_CLASSES=(
   # self-skip on CI.
   "$FQCN_PREFIX.BackThenOpenSecondSessionReusesWarmLeaseE2eTest"
   "$FQCN_PREFIX.ColdRestoreGoneSessionNoResurrectE2eTest"
+  # Issue #666 REOPEN (2026-07-06): a session killed on the host must NOT be
+  # RESURRECTED when the app REATTACHES to it (lifecycle/reconnect path) with the
+  # tmux SERVER still alive. The prior fix only guarded the process-death
+  # cold-restore path; the reattach path still fell through to `new-session -A`
+  # (attach-OR-create) and recreated the killed session — the maintainer's exact
+  # dogfood report. This journey seeds a KEEPALIVE session so the server survives
+  # the target kill (the server-alive-session-gone branch, distinct from #998's
+  # dead-server), attaches, kills only the target, backgrounds past grace, and
+  # foregrounds (a LifecycleReattach reconnect). It asserts the target is NOT
+  # recreated, the server stayed alive (keepalive present), and the app drops to
+  # the session list. Runs on agents:2222; does NOT self-skip on CI.
+  "$FQCN_PREFIX.LifecycleReattachGoneSessionNoResurrectE2eTest"
   # Issue #998: a remote tmux SERVER death (host reboot / OOM / `kill-server`)
   # must NOT be silently resurrected via `new-session -A` into a blank
   # "Connected" session. This journey attaches, `tmux kill-server`s the whole

--- a/shared/core-tmux/src/integrationTest/java/com/pocketshell/core/tmux/TmuxClientIntegrationTest.kt
+++ b/shared/core-tmux/src/integrationTest/java/com/pocketshell/core/tmux/TmuxClientIntegrationTest.kt
@@ -302,6 +302,75 @@ class TmuxClientIntegrationTest {
     }
 
     @Test
+    fun `reattach to a session killed on a live server refuses to recreate it`() = runBlocking {
+        // Issue #666 REOPEN (2026-07-06) — the real-tmux proof. A session killed
+        // on the host must NOT be resurrected when the app REATTACHES to it
+        // (probeServerLiveness=true, createIfMissing=true) with the tmux SERVER
+        // still alive. On base the `has-session` preflight saw the server alive
+        // but the target gone and FELL THROUGH to `new-session -A`, recreating it.
+        //
+        // A KEEPALIVE session keeps the real tmux server alive after the target is
+        // killed, so this exercises the server-alive-session-gone branch (the #666
+        // case) and NOT the dead-server branch (#998). The fix must throw
+        // [TmuxSessionNotFoundException] (not [TmuxServerDeadException]) and never
+        // create the gone session.
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        try {
+            connectSession().use { session ->
+                val stamp = System.nanoTime()
+                val keepalive = "keepalive-$stamp"
+                val target = "gone-$stamp"
+                // Keep the server alive; ensure the target does NOT exist.
+                session.exec("tmux new-session -d -s '$keepalive' 'sleep 600'")
+                session.exec("tmux kill-session -t '$target' >/dev/null 2>&1 || true")
+                assertEquals(
+                    "keepalive must be alive so the server stays up",
+                    0,
+                    session.exec("tmux has-session -t '$keepalive'").exitCode,
+                )
+                assertFalse(
+                    "target must be gone before the reattach",
+                    session.exec("tmux has-session -t '$target'").exitCode == 0,
+                )
+
+                val client: TmuxClient = TmuxClientFactory(scope).create(
+                    session,
+                    sessionName = target,
+                    createIfMissing = true,
+                    probeServerLiveness = true,
+                )
+                val thrown = client.use { runCatching { it.connect() }.exceptionOrNull() }
+
+                // A gone SESSION on a LIVE server is session-ended, NOT server-death.
+                assertTrue(
+                    "expected TmuxSessionNotFoundException for a gone reattach, got $thrown",
+                    thrown is TmuxSessionNotFoundException,
+                )
+                assertFalse(
+                    "a gone session on a live server must NOT be classified server-death",
+                    thrown is TmuxServerDeadException,
+                )
+                // The killed session must NOT have been recreated by the reattach.
+                assertFalse(
+                    "REGRESSION (#666 reopen): the reattach RECREATED the killed session " +
+                        "`$target` on a live server (`new-session -A`) — it must refuse",
+                    session.exec("tmux has-session -t '$target'").exitCode == 0,
+                )
+                // The server stayed alive (keepalive present) — the #666 branch.
+                assertEquals(
+                    "the keepalive must still be alive (server stayed up — the #666 branch)",
+                    0,
+                    session.exec("tmux has-session -t '$keepalive'").exitCode,
+                )
+                session.exec("tmux kill-session -t '$keepalive' >/dev/null 2>&1 || true")
+                Unit
+            }
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
     fun `sendCommand error response surfaces with isError true`() = runBlocking {
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
         try {

--- a/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxClient.kt
+++ b/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxClient.kt
@@ -1028,20 +1028,30 @@ internal class RealTmuxClient(
                     )
                     throw TmuxServerDeadException()
                 }
-                // Server alive but the target session is gone. On the explicit
-                // reattach path (`createIfMissing && probeServerLiveness`) a
-                // single missing session is the #666 not-the-#998 case: the
-                // server is up, so `new-session -A` recreating that one session
-                // is the correct reconnect behaviour — fall through and attach.
-                // Only the attach-only cold-restore path (`!createIfMissing`)
-                // must refuse to recreate a gone session.
-                if (!createIfMissing) {
-                    Log.i(
-                        ISSUE_105_DIAG_TAG,
-                        "tmux-has-session-gone session=$resolvedSessionName exit=${probe.exitCode}",
-                    )
-                    throw TmuxSessionNotFoundException(resolvedSessionName)
-                }
+                // Server alive but the TARGET session is gone. Issue #666 REOPEN
+                // (2026-07-06): a session that no longer exists at reattach time
+                // ENDED — a reattach must NEVER recreate it. Previously ONLY the
+                // attach-only cold-restore path (`!createIfMissing`) refused to
+                // recreate here; the reattach path (`createIfMissing &&
+                // probeServerLiveness`: LifecycleReattach / AutoReconnect /
+                // Reconnect / NetworkReconnect) FELL THROUGH to `new-session -A`
+                // (attach-OR-create) and silently resurrected the killed session —
+                // the exact dogfood bug ("I removed it on the computer, but the app
+                // created it again"). We hard-cut that branch (D22): whenever the
+                // preflight ran (`!createIfMissing || probeServerLiveness`) and the
+                // specific session is gone on a LIVE server, throw
+                // [TmuxSessionNotFoundException] so the caller drops to the list —
+                // identically for cold-restore AND every reattach. The only path
+                // that legitimately create-if-missing is the explicit user "new
+                // session" intent (`createIfMissing && !probeServerLiveness`), which
+                // never enters this preflight at all.
+                Log.i(
+                    ISSUE_105_DIAG_TAG,
+                    "tmux-has-session-gone session=$resolvedSessionName exit=${probe.exitCode} " +
+                        "createIfMissing=$createIfMissing probeServerLiveness=$probeServerLiveness " +
+                        "— refusing to recreate, dropping to list",
+                )
+                throw TmuxSessionNotFoundException(resolvedSessionName)
             }
         }
         // Open the SSH shell and launch the reader. We do not synchronously

--- a/shared/core-tmux/src/test/java/com/pocketshell/core/tmux/TmuxClientTest.kt
+++ b/shared/core-tmux/src/test/java/com/pocketshell/core/tmux/TmuxClientTest.kt
@@ -321,11 +321,21 @@ class TmuxClientTest {
     }
 
     @Test
-    fun `reattach preflight to an ALIVE server with a gone session still reattaches (recreates that one session)`() = runBlocking {
-        // Server alive (`can't find session: work`, exit 1) on the reattach path
-        // is the #666 case, NOT #998: the server is up, so `new-session -A`
-        // recreating that one session is the correct reconnect behaviour. We must
-        // NOT throw server-death here, and we MUST attach.
+    fun `reattach preflight to an ALIVE server with a gone session REFUSES to recreate`() = runBlocking {
+        // Issue #666 REOPEN (2026-07-06): the maintainer killed a session on the
+        // host, backgrounded briefly, came back — and the app RECREATED the killed
+        // session. Root cause: the reattach path (`createIfMissing=true` +
+        // `probeServerLiveness=true`, used by LifecycleReattach / AutoReconnect /
+        // Reconnect / NetworkReconnect) ran the `has-session` preflight, saw the
+        // server alive but the ONE target session gone, and FELL THROUGH to
+        // `tmux -CC new-session -A` — attach-OR-create — which resurrected it.
+        //
+        // A session that no longer exists at reattach time ENDED; a reattach must
+        // NEVER recreate it. Server alive (`can't find session: work`, exit 1) with
+        // the specific session gone is the #666 case (NOT the #998 dead-SERVER
+        // case): it must throw [TmuxSessionNotFoundException] so the ViewModel
+        // drops to the list, exactly like the attach-only cold-restore path. It
+        // must NOT open a shell and must NOT write any `new-session` line.
         val shell = FakeShell()
         val session = FakeSession(
             shell,
@@ -341,18 +351,26 @@ class TmuxClientTest {
             probeServerLiveness = true,
         )
         try {
-            client.connect()
-            withTimeout(2_000) {
-                while (shell.stdinBytes().isEmpty()) { yield(); delay(10) }
-            }
+            val thrown = runCatching { client.connect() }.exceptionOrNull()
+            // A gone session on the reattach path is session-ended, NOT server-death.
+            assertTrue(
+                "expected TmuxSessionNotFoundException for a gone session on reattach, got $thrown",
+                thrown is TmuxSessionNotFoundException,
+            )
+            assertFalse(
+                "a gone SESSION (server alive) must NOT be classified server-death",
+                thrown is TmuxServerDeadException,
+            )
+            // The preflight ran exactly the has-session probe...
             assertEquals(
                 listOf("tmux has-session -t 'work'"),
                 session.execCommands.toList(),
             )
-            // A live server still attaches with the normal control-mode spawn.
-            assertEquals(
-                "tmux -CC new-session -A -s 'work'\n",
-                shell.stdinAsString(),
+            // ...and we NEVER wrote a `new-session` line, so the killed session
+            // could not be resurrected via `new-session -A` on the reattach path.
+            assertTrue(
+                "no creating command may be written for a gone reattach, got `${shell.stdinAsString()}`",
+                shell.stdinBytes().isEmpty(),
             )
         } finally {
             client.close()


### PR DESCRIPTION
Closes #666 (REOPENED — D31 durable-fix).

## Symptom (maintainer, dogfooding v0.4.23)
A tmux session killed on the host was **recreated/resurrected** by the app on the background→foreground 'screenshot, come back' gesture.

## Root cause
`connect(LifecycleReattach)` (grace-window reattach, `createIfMissing=true`) ran the `has-session` preflight, saw the **server alive but that session killed**, and fell through to `tmux -CC new-session -A` → recreated it. The prior #666 fix only guarded the process-death cold-restore path.

## Fix (D22 hard-cut — deletes a branch, not a patch)
Remove the `if(!createIfMissing)` special-case in `TmuxClient.kt`. Now every reattach trigger throws `TmuxSessionNotFoundException` when the session is gone on a live server, and `runConnect`'s catch drops to the list. **Live-session grace reattach is byte-identical to base** (the throw is scoped to the session-gone branch).

## Verification (reproduce-first, red→green — reviewer independently confirmed all four this run)
- Client unit `TmuxClientTest`, app VM `TmuxSessionWarmOpenTest` (Reconnect + LifecycleReattach), real-tmux Docker `TmuxClientIntegrationTest` (keepalive fixture = server-alive non-happy G10 state), on-device E2E `LifecycleReattachGoneSessionNoResurrectE2eTest` (wired into `scripts/ci-journey-suite.sh`) — `target_recreated_after_reattach=0`, `keepalive_alive_after_reattach=1`.
- Class coverage (G2): cold-restore + all reattach triggers + server-death (#998).
- Adjacency sweep (D31/#638): `BackgroundGraceReconnect` (live-session reattach) + `MultiSessionSwitch` A→B→C→A green with the fix.
- Local pre-push: `git diff --check` clean; `:shared:core-tmux:testDebugUnitTest` + `:app:testDebugUnitTest` BUILD SUCCESSFUL.

Reviewer verdict: APPROVED (issue #666).