### PR TITLE
gate: de-front-gate #1302 journey + swiftshader-robust burst poll (#1314)

### DIFF
--- a/scripts/pre-release-confidence-gate.sh
+++ b/scripts/pre-release-confidence-gate.sh
@@ -163,6 +163,10 @@ EMULATOR_SERIAL="unknown"
 APP_WALKTHROUGH_INSTALL_STATUS="not_run"
 FINAL_INSTALL_STATUS="not_run"
 ISSUE_261_STALE_DB_STATUS="not_run"
+# Issue #1314: step 12 (core-terminal burst proof) runs non-fatally so a slow-AVD
+# timing red no longer front-gates the #1302 journey; its captured result is
+# folded into the final verdict after the downstream stages run.
+CONNECTED_TERMINAL_INPUT_STATUS="not_run"
 ISSUE_261_STALE_DB_LOGCAT="$RUN_DIR/issue-261-stale-db-launch-logcat.log"
 STEP_NAMES=()
 STEP_STATUSES=()
@@ -248,6 +252,7 @@ write_summary() {
     printf 'Docker compose file: %s\n' "$COMPOSE_FILE"
     printf 'Docker profile/service: agents\n'
     printf 'Docker SSH target: 127.0.0.1:2222\n'
+    printf 'Connected core-terminal burst proof (step 12, non-fatal — issue #1314): %s\n' "$CONNECTED_TERMINAL_INPUT_STATUS"
     printf 'Focused app cold-reset APK install status: %s\n' "$APP_WALKTHROUGH_INSTALL_STATUS"
     printf 'Final data-preserving update install status: %s\n' "$FINAL_INSTALL_STATUS"
     printf 'Issue #261 cold-reset stale DB launch status: %s\n' "$ISSUE_261_STALE_DB_STATUS"
@@ -1366,7 +1371,24 @@ run_bash_step "emulator-readiness" \
   "$(emulator_readiness_script)"
 update_emulator_serial
 
-run_bash_step "connected-terminal-input" "$(core_terminal_connected_input_script)"
+# Issue #1314: the heavy core-terminal burst proof (step 12) is a slow-AVD,
+# throughput-sensitive check that historically FRONT-GATED — via the `set -e`
+# abort on this bare step — the release-critical stages that follow it: the
+# #1302 black-screen recovery journey, the EmulatorDockerSshSmokeTest
+# walkthroughs, and the visual-audit. A single timing red here left every one of
+# them `not_run`, so no release gate could ever produce clean journey evidence.
+# Run it NON-FATALLY: capture the result, keep going so the downstream product-
+# validation phases still run and produce their evidence, and fold the result
+# back into the final gate verdict below (a real red still FAILS the gate — just
+# not before the journey stages ran). This is the de-front-gate half of #1314;
+# the deterministic half is the poll-to-deadline final-marker wait in
+# CodexAppendBurstMainThreadProofTest.
+if run_bash_step "connected-terminal-input" "$(core_terminal_connected_input_script)"; then
+  CONNECTED_TERMINAL_INPUT_STATUS="passed"
+else
+  CONNECTED_TERMINAL_INPUT_STATUS="failed"
+  printf 'WARN: connected-terminal-input (step 12) FAILED; continuing to the downstream #1302 journey + walkthroughs + visual-audit so their evidence is still produced. The gate will still FAIL at the end (issue #1314).\n' >&2
+fi
 
 run_step "build-app-test-apks" \
   "$ROOT_DIR/scripts/cgroup-run.sh" --unit "pocketshell-pre-release-$(pocketshell_unit_token "$RUN_ID")-build-app-test-apks" -- \
@@ -1409,6 +1431,16 @@ run_step "build-debug-apk" \
 [[ -f "$APK_PATH" ]] || fail "APK artifact was not created at $APK_PATH"
 
 run_step "update-install-debug-apk" "$ROOT_DIR/scripts/install-update-apk.sh" "$APK_PATH"
+
+# Issue #1314: fold the deferred step-12 (connected-terminal-input) result into
+# the final verdict. If it failed, the gate FAILS here — AFTER the downstream
+# #1302 journey + walkthroughs + visual-audit produced their evidence — so a
+# real core-terminal red is never lost, but a step-12 red never again masks the
+# release-critical journey stages by aborting before them.
+if [[ "$CONNECTED_TERMINAL_INPUT_STATUS" == "failed" ]]; then
+  FAILING_STEP="connected-terminal-input"
+  fail "connected-terminal-input (step 12) failed; the downstream #1302 journey + walkthroughs + visual-audit were still run for evidence (issue #1314). See the connected-terminal-input step log."
+fi
 
 GATE_RESULT="PASS"
 GATE_RESULT_MESSAGE="PASS: pre-release confidence gate completed"

--- a/shared/core-terminal/src/androidTest/java/com/pocketshell/core/terminal/ui/CodexAppendBurstMainThreadProofTest.kt
+++ b/shared/core-terminal/src/androidTest/java/com/pocketshell/core/terminal/ui/CodexAppendBurstMainThreadProofTest.kt
@@ -163,14 +163,32 @@ class CodexAppendBurstMainThreadProofTest {
             // (final-state correctness / no-loss).
             stdout.emit(finalMarkerLine(lastChunk).toByteArray(Charsets.US_ASCII))
 
-            // Let the tail of the burst drain across its budgeted frames and the
-            // settled final frame paint.
-            SystemClock.sleep(SETTLE_MS)
+            // Issue #1314: poll for the FINAL marker to a swiftshader-aware
+            // deadline instead of a single fixed settle sleep. The frame-budgeted
+            // drain paces a bounded-but-multi-MB FIFO backlog across frames, so on
+            // the slow software-GL CI AVD the tail of the burst can take well past
+            // a fixed 1.5s to reach the last byte — "late, not lost" (the drain
+            // reposts until availableBytes()==0; it never drops or reorders). A
+            // poll turns that "late" into a PASS while still hard-failing if the
+            // marker genuinely never arrives. Ping sampling stays active across the
+            // whole drain, so the #803 main-thread-stall measurement below still
+            // covers the settle (the drain must stay responsive the entire time).
+            val finalMarkerText = finalMarker(lastChunk)
+            var finalMarkerPresent = false
+            val markerDeadline = SystemClock.uptimeMillis() + FINAL_MARKER_TIMEOUT_MS
+            while (SystemClock.uptimeMillis() < markerDeadline) {
+                if (visibleTerminalText(view).contains(finalMarkerText)) {
+                    finalMarkerPresent = true
+                    break
+                }
+                SystemClock.sleep(MARKER_POLL_INTERVAL_MS)
+            }
             val burstDurationMs = SystemClock.uptimeMillis() - burstStartedAt
             pingActive.set(false)
 
             captureViewport(view, "issue803-append-burst")
             val transcript = visibleTerminalText(view)
+            finalMarkerPresent = finalMarkerPresent || transcript.contains(finalMarkerText)
 
             writeTimings(
                 instrumentation,
@@ -187,8 +205,9 @@ class CodexAppendBurstMainThreadProofTest {
                     "max_main_thread_stall_ms=${maxStallMs.get()}",
                     "max_main_thread_stall_budget_ms=$MAX_MAIN_THREAD_STALL_MS",
                     "anr_window_ms=5000",
-                    "final_marker=${finalMarker(lastChunk)}",
-                    "final_marker_present=${transcript.contains(finalMarker(lastChunk))}",
+                    "final_marker=$finalMarkerText",
+                    "final_marker_present=$finalMarkerPresent",
+                    "final_marker_timeout_ms=$FINAL_MARKER_TIMEOUT_MS",
                     "expectation=RED on pre-fix unbounded MSG_NEW_INPUT re-post (append pins main " +
                         "for seconds, max stall blows past budget); GREEN with the #803 " +
                         "frame-budgeted MainThreadDrainScheduler (stall bounded, final state correct)",
@@ -200,7 +219,7 @@ class CodexAppendBurstMainThreadProofTest {
                 "#803 dense-colored-diff append burst: chunks=$chunk sgrSpans=$sgrSpansEmitted " +
                     "maxStall=${maxStallMs.get()}ms pings=${pingCount.get()} " +
                     "burstDuration=${burstDurationMs}ms finalMarkerPresent=" +
-                    "${transcript.contains(finalMarker(lastChunk))}",
+                    "$finalMarkerPresent",
             )
 
             // Sanity: the burst must have emitted a real storm of SGR spans,
@@ -225,9 +244,10 @@ class CodexAppendBurstMainThreadProofTest {
             assertTrue(
                 "#803: the FINAL diff state must render — the frame-budgeted drain must " +
                     "parse every byte in order to the end (no lost/garbled/reordered output). " +
-                    "Final marker '${finalMarker(lastChunk)}' missing from transcript " +
-                    "(length=${transcript.length}).",
-                transcript.contains(finalMarker(lastChunk)),
+                    "Final marker '$finalMarkerText' missing from transcript " +
+                    "(length=${transcript.length}) after polling ${FINAL_MARKER_TIMEOUT_MS}ms " +
+                    "(issue #1314 swiftshader-aware deadline).",
+                finalMarkerPresent,
             )
 
             // ---- LOAD-BEARING assertion: the dense colored-diff append burst must
@@ -389,9 +409,15 @@ class CodexAppendBurstMainThreadProofTest {
         // at most one per-frame parse budget per turn and stays bounded.
         const val BURST_DURATION_MS = 3_500L
 
-        // Drain tail (across budgeted frames) + final-frame settle. Generous so
-        // the whole queue + the final marker drain even under the paced budget.
-        const val SETTLE_MS = 1_500L
+        // Issue #1314: the tail of a multi-MB burst drains across many budgeted
+        // frames, and on the slow software-GL CI AVD that can run well past the
+        // old fixed 1.5s settle. Poll the transcript for the FINAL marker to this
+        // generous swiftshader-aware deadline instead — succeed as soon as the
+        // marker lands, hard-fail only if it never arrives. This removes the
+        // throughput-dependent flake WITHOUT weakening the main-thread-stall
+        // load-bearing assertion (which still samples across the whole drain).
+        const val FINAL_MARKER_TIMEOUT_MS = 20_000L
+        const val MARKER_POLL_INTERVAL_MS = 100L
 
         const val PING_INTERVAL_MS = 16L
 


### PR DESCRIPTION
Closes #1314.

Confirmed **infra/timing, not a render bug** (researcher spike): the frame-budget drain provably can't drop the final frame, and the load-bearing #803 main-thread-stall assertion passes — the marker was late-not-lost under the fixed 1.5s settle on the slow swiftshader CI AVD.

- **Fix 1** `CodexAppendBurstMainThreadProofTest.kt`: fixed-1.5s-sleep + one-shot check → bounded 20s poll for the final marker. #803 stall assertion byte-for-byte unchanged, now samples the whole drain. Non-vacuous (hard-fails on deadline).
- **Fix 2** `pre-release-confidence-gate.sh`: step 12 non-fatal — downstream #1302 journey + walkthroughs + visual-audit now run even when it reds; a genuine red still fails the gate (exit 1) after the journey evidence exists.

Unblocks automated on-gate black-screen confirmation for every future cut.

Local gate: `bash -n`, `git diff --check`, `check-test-validity.sh`, `check-ci-journey-harness.sh`, `:shared:core-terminal:compileDebugAndroidTestKotlin` all green. Reviewer verified Fix 2 by control-flow simulation (step12-red→downstream-ran→exit 1; happy→exit 0; downstream-fail→exit 1). AC1 swiftshader-green defers to the next gate run (fast box can't repro the timing red).