### PR TITLE
core-tmux: attach list-panes reconcile on a dedicated exec lane + bounded reveal escape (#1316)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -4765,7 +4765,13 @@ public class TmuxSessionViewModel @Inject constructor(
         target: ConnectionTarget,
         client: TmuxClient,
     ): PrewarmedPaneRuntime {
-        val response = client.sendCommand(buildListPanesCommand(target))
+        // Issue #1316: the prewarm enumeration rides the same dedicated exec lane
+        // as the attach reconcile, so a busy sibling session's `-CC` burst cannot
+        // head-of-line-block a prewarm behind the shared control channel.
+        val response = client.listPanesViaExec(
+            buildListPanesCommand(target),
+            timeoutMs = RECONCILE_LIST_PANES_EXEC_TIMEOUT_MS,
+        )
         if (response.isError) {
             throw TmuxAttachPanesReadyException(
                 "tmux list-panes failed during prewarm: " +
@@ -9947,7 +9953,19 @@ public class TmuxSessionViewModel @Inject constructor(
         val listPanesStartedAtMs = SystemClock.elapsedRealtime()
         val response = try {
             withContext(seedIoDispatcher) {
-                client.sendCommand(buildListPanesCommand(target))
+                // Issue #1316: run the reconcile `list-panes` on the DEDICATED exec
+                // lane (mirror of #1297's capture-pane move), NOT the shared per-host
+                // `-CC` control channel. A new-session attach's reconcile used to
+                // head-of-line-block behind a busy sibling session's `-CC` `%output`
+                // burst on the ONE shared transport reader — the v0.4.24 "Attaching…"
+                // wedge. The bounded [RECONCILE_LIST_PANES_EXEC_TIMEOUT_MS] ceiling is
+                // the escape: a genuinely wedged/half-open transport surfaces a
+                // `Failed` fast (→ retryable "Tap Reconnect"), never a tens-of-seconds
+                // input-gated freeze.
+                client.listPanesViaExec(
+                    buildListPanesCommand(target),
+                    timeoutMs = RECONCILE_LIST_PANES_EXEC_TIMEOUT_MS,
+                )
             }
         } catch (t: Throwable) {
             if (t is CancellationException) throw t
@@ -19599,8 +19617,25 @@ internal const val AGENT_SUBMIT_ACK_NEEDLE_TAIL_CHARS: Int = 24
  * mid-word) still matches the original prompt's tail.
  */
 private val WHITESPACE_RUN_REGEX = Regex("\\s+")
-internal const val ATTACH_PANES_READY_TIMEOUT_MS: Long = 30_000L
+// Issue #1316: the OUTER attach-reveal ceiling. Was 30 s — the maintainer's
+// "it took forever to attach / wouldn't let me touch" felt-freeze while the
+// `list-panes` reconcile head-of-line-blocked behind a busy sibling's `-CC`
+// burst. With the reconcile now on the dedicated exec lane it returns in ms, so
+// this bound only ever fires on a genuinely stuck attach; a much shorter
+// ceiling turns that into a fast user-visible "Tap Reconnect to retry" escape
+// (→ evict lease → fresh-transport runConnect) instead of a tens-of-seconds
+// input-gated overlay. The reconcile itself is separately bounded by
+// [RECONCILE_LIST_PANES_EXEC_TIMEOUT_MS].
+internal const val ATTACH_PANES_READY_TIMEOUT_MS: Long = 12_000L
 internal const val ATTACH_PANES_READY_RETRY_MS: Long = 100L
+
+// Issue #1316: per-reconcile exec ceiling for the attach/switch/refresh
+// `list-panes` on the dedicated exec lane. Healthy reconciles return in
+// milliseconds; this is the safety bound so a genuinely wedged/half-open
+// transport surfaces a `Failed` fast (→ retryable attach error) rather than
+// parking the reveal. Well under the outer [ATTACH_PANES_READY_TIMEOUT_MS] so
+// the reconcile-level escape fires first.
+internal const val RECONCILE_LIST_PANES_EXEC_TIMEOUT_MS: Long = 6_000L
 
 /**
  * Issue #552 / #685 (Bug A): a passive tmux reader EOF during a brief foreground

--- a/shared/core-tmux/src/integrationTest/java/com/pocketshell/core/tmux/TmuxClientIntegrationTest.kt
+++ b/shared/core-tmux/src/integrationTest/java/com/pocketshell/core/tmux/TmuxClientIntegrationTest.kt
@@ -631,4 +631,79 @@ class TmuxClientIntegrationTest {
             scope.cancel()
         }
     }
+
+    @Test
+    fun `listPanesViaExec succeeds while the -CC channel streams a burst`() = runBlocking {
+        // Issue #1316 (G10 real-path, no emulator): the attach RECONCILE wedge —
+        // a new session's `list-panes` reply head-of-line blocked behind a flood
+        // of %output on the -CC reader (the maintainer's v0.4.24 day-0 "Attaching…"
+        // freeze). With the reconcile on an INDEPENDENT exec channel it returns
+        // while the burst streams on the -CC channel. Reproduces the busy-agent
+        // burst at the Docker level; on BASE (a -CC `list-panes`) the reply stalls
+        // behind the burst.
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        try {
+            connectSession().use { session ->
+                val sessionName = "it-${System.nanoTime()}"
+                val client: TmuxClient = TmuxClientFactory(scope).create(
+                    session,
+                    sessionName = sessionName,
+                )
+                client.use {
+                    it.connect()
+                    delay(500)
+                    val paneId = withTimeout(10_000) {
+                        it.sendCommand("display-message -p \"#{pane_id}\"")
+                    }.output.firstOrNull()?.trim().orEmpty()
+                    assertTrue("pane id must resolve; got '$paneId'", paneId.startsWith("%"))
+
+                    // Keep the -CC reader busy: subscribe and drive a large output
+                    // burst into the pane so %output frames flood the control
+                    // channel while we reconcile.
+                    val burstBytes = java.util.concurrent.atomic.AtomicLong(0)
+                    val collector = scope.launch {
+                        it.outputFor(paneId).collect { evt -> burstBytes.addAndGet(evt.data.size.toLong()) }
+                    }
+                    delay(200)
+                    withTimeout(10_000) {
+                        it.sendCommand("send-keys -t $paneId 'seq 1 200000' Enter")
+                    }
+                    val burstDeadline = System.currentTimeMillis() + 10_000
+                    while (System.currentTimeMillis() < burstDeadline && burstBytes.get() < 50_000L) {
+                        delay(20)
+                    }
+                    assertTrue(
+                        "the -CC channel must actually be streaming a burst; sawBytes=${burstBytes.get()}",
+                        burstBytes.get() >= 50_000L,
+                    )
+
+                    // Reconcile on the exec lane WHILE the burst streams. It must
+                    // return (not time out) within the short ceiling, with the pane.
+                    val listPanesCommand =
+                        "list-panes -s -t '$sessionName' -F '#{pane_id}'"
+                    val startedAt = System.currentTimeMillis()
+                    val response = withTimeout(10_000) {
+                        it.listPanesViaExec(listPanesCommand, timeoutMs = 6_000L)
+                    }
+                    val elapsed = System.currentTimeMillis() - startedAt
+                    collector.cancel()
+                    assertFalse(
+                        "exec-lane reconcile must succeed during a -CC burst; got ${response.output}",
+                        response.isError,
+                    )
+                    assertTrue(
+                        "exec-lane reconcile must list the pane during a -CC burst; got ${response.output}",
+                        response.output.any { row -> row.trim() == paneId },
+                    )
+                    assertTrue(
+                        "exec-lane reconcile must return within the short ceiling during a burst " +
+                            "(elapsed ${elapsed}ms)",
+                        elapsed < 5_000L,
+                    )
+                }
+            }
+        } finally {
+            scope.cancel()
+        }
+    }
 }

--- a/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxClient.kt
+++ b/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxClient.kt
@@ -195,6 +195,42 @@ public interface TmuxClient : AutoCloseable {
         commands.map { sendCommand(it) }
 
     /**
+     * Issue #1316: enumerate a session's panes on a DEDICATED `exec` channel, NOT
+     * the shared per-host `-CC` control-mode [sendMutex].
+     *
+     * The attach RECONCILE — the `tmux list-panes` round-trip in
+     * `TmuxSessionViewModel.awaitPanesReadyForAttach` — is the FIRST thing a
+     * fast-switch attach blocks on, and it used to ride the shared `-CC` control
+     * channel. When a NEW session B attaches while a busy Claude session A still
+     * drains its `-CC` `%output` burst, A head-of-line-blocks B's `list-panes`
+     * reply on the ONE shared sshj transport reader, so B's reconcile times out
+     * and retries for up to `ATTACH_PANES_READY_TIMEOUT_MS` behind the
+     * input-gated "Attaching…" overlay — the maintainer's day-0 v0.4.24 wedge.
+     * This is the SAME transport SPOF #1297 closed for `capture-pane`; here it is
+     * closed for the attach's own `list-panes`.
+     *
+     * The real client runs the enumeration on the independent [SshSession.exec]
+     * lane (the `tmux has-session` preflight / #1297 capture lane), whose stdout
+     * is read OUTSIDE the transport dispatcher, so a new attach's reconcile
+     * returns while a sibling session saturates the `-CC` reader.
+     *
+     * [listPanesCommand] is the tmux command WITHOUT the leading `tmux` — the
+     * same `list-panes -s -t '<session>' -F '…'` string the `-CC` path used, so
+     * the `#{…}` format parity (and the caller's row parse) is preserved
+     * unchanged. [timeoutMs] bounds the exec round-trip so a wedged/half-open
+     * transport surfaces a [TmuxClientException] fast instead of parking the
+     * attach — the bounded escape that stops the reveal gating input
+     * indefinitely.
+     *
+     * The default implementation falls back to a `-CC` [sendCommand] for
+     * [TmuxClient] doubles that do not model an exec lane.
+     */
+    public suspend fun listPanesViaExec(
+        listPanesCommand: String,
+        timeoutMs: Long? = null,
+    ): CommandResponse = sendCommand(listPanesCommand)
+
+    /**
      * Subscribe to `%output` events for a single pane.
      *
      * Multiple callers may subscribe to the same pane — the underlying
@@ -1246,6 +1282,80 @@ internal class RealTmuxClient(
         if (capture.isEmpty()) return emptyList()
         val lines = capture.split("\n")
         return if (lines.isNotEmpty() && lines.last().isEmpty()) lines.dropLast(1) else lines
+    }
+
+    /**
+     * Issue #1316: run the attach RECONCILE `list-panes` on a DEDICATED
+     * [SshSession.exec] channel — the same independent lane the `tmux
+     * has-session` preflight (#666) and the #1297 heal capture already use — NOT
+     * the shared per-host `-CC` control-mode [sendMutex].
+     *
+     * The attach `awaitPanesReadyForAttach` reconcile was the FIRST call a
+     * fast-switch attach blocked on, and it rode the `-CC` channel. When a new
+     * session attaches while a busy sibling session drains its `-CC` `%output`
+     * burst, the sibling head-of-line-blocks the new attach's `list-panes` reply
+     * on the ONE shared sshj transport reader, so the reconcile timed out /
+     * retried behind the input-gated "Attaching…" overlay for up to 30 s (the
+     * maintainer's v0.4.24 day-0 wedge). The exec lane reads its own channel's
+     * stdout OUTSIDE the transport dispatcher, so this returns fast while a burst
+     * saturates `-CC`. [listPanesCommand] is the `-CC`-form command (no leading
+     * `tmux`); [timeoutMs] bounds the round-trip so a genuinely wedged/half-open
+     * transport surfaces a [TmuxClientException] fast instead of parking the
+     * attach.
+     */
+    override suspend fun listPanesViaExec(
+        listPanesCommand: String,
+        timeoutMs: Long?,
+    ): CommandResponse {
+        if (closed) throw TmuxClientException("client is closed")
+        if (!connected) throw TmuxClientException("client is not connected")
+        val effectiveTimeoutMs = timeoutMs?.coerceIn(1L, commandTimeoutMs) ?: commandTimeoutMs
+        val command = "tmux $listPanesCommand"
+        val execResult =
+            try {
+                // Independent of the busy `-CC` channel, so this returns fast under
+                // a burst. The ceiling is the safety bound for a genuinely
+                // wedged/half-open transport; cancelling the exec closes its OWN
+                // channel (RealSshSession.exec cancellation handler), never `-CC`.
+                withTimeoutOrNull(effectiveTimeoutMs) {
+                    session.exec(command)
+                }
+            } catch (t: Throwable) {
+                throw TmuxClientException(
+                    "tmux list-panes exec (attach reconcile lane) failed: ${t.message}",
+                    t,
+                )
+            }
+        if (execResult == null) {
+            Log.w(
+                ISSUE_244_DIAG_TAG,
+                "tmux listPanesViaExec exec timed out >${effectiveTimeoutMs}ms " +
+                    "(attach reconcile lane); surfacing a best-effort failure.",
+            )
+            throw TmuxClientException(
+                "tmux list-panes (exec attach reconcile lane) timed out after ${effectiveTimeoutMs}ms",
+            )
+        }
+        return parseListPanesExecResult(execResult)
+    }
+
+    /**
+     * Issue #1316: turn a `list-panes` [ExecResult] into the per-row
+     * [CommandResponse] the `-CC` `sendCommand` path returned, so the caller's
+     * `parsePaneRow` parse is unchanged. A non-zero exit (session/server gone)
+     * surfaces as an error response carrying the stderr — matching the `-CC`
+     * error contract — so the attach reconcile still fails honestly.
+     */
+    private fun parseListPanesExecResult(result: ExecResult): CommandResponse {
+        val isError = result.exitCode != 0
+        val lines = splitCaptureLines(result.stdout)
+        val output =
+            if (isError && lines.isEmpty()) {
+                result.stderr.trim().let { if (it.isEmpty()) emptyList() else it.split("\n") }
+            } else {
+                lines
+            }
+        return CommandResponse(number = -1L, output = output, isError = isError)
     }
 
     /**

--- a/shared/core-tmux/src/test/java/com/pocketshell/core/tmux/TmuxClientTest.kt
+++ b/shared/core-tmux/src/test/java/com/pocketshell/core/tmux/TmuxClientTest.kt
@@ -931,6 +931,186 @@ class TmuxClientTest {
         }
     }
 
+    /**
+     * Issue #1316: an [SshSession.exec] handler that simulates the remote shell
+     * running the attach reconcile `tmux list-panes …`, returning the given pane
+     * rows on stdout (one per line, the shape the `-CC` `%begin/%end` drain
+     * produced). Optional [delayMs] models a slow exec; a non-zero [exitCode] +
+     * [stderr] models a gone session.
+     */
+    private fun listPanesExecHandler(
+        rows: List<String>,
+        exitCode: Int = 0,
+        stderr: String = "",
+        delayMs: Long = 0L,
+    ): suspend (String) -> ExecResult = { _ ->
+        if (delayMs > 0L) delay(delayMs)
+        val stdout = if (rows.isEmpty()) "" else rows.joinToString(separator = "\n") + "\n"
+        ExecResult(stdout = stdout, stderr = stderr, exitCode = exitCode)
+    }
+
+    @Test
+    fun `listPanesViaExec runs on the exec lane and returns the pane rows`() = runBlocking {
+        // Issue #1316: the attach reconcile `list-panes` moves off the shared
+        // `-CC` control channel onto a DEDICATED exec channel (the #1297/#666
+        // lane). The exec runs `tmux list-panes …` and the rows come back as the
+        // per-row CommandResponse the caller's parse expects.
+        val rows = listOf("%0|PS|@0|PS|0|PS|\$1", "%1|PS|@0|PS|0|PS|\$1")
+        val shell = FakeShell()
+        val session = FakeSession(shell, execHandler = listPanesExecHandler(rows))
+        val client = RealTmuxClient(session, scope)
+        try {
+            client.connect()
+            val command = "list-panes -s -t 'sess' -F '#{pane_id}|PS|#{window_id}'"
+            val response = withTimeout(ASYNC_AWAIT_TIMEOUT_MS) {
+                client.listPanesViaExec(command)
+            }
+            assertFalse(response.isError)
+            assertEquals(rows, response.output)
+
+            // Proof it ran on an exec channel — NOT the -CC control shell. Nothing
+            // was written to -CC stdin for the reconcile, and the exec carries the
+            // tmux-prefixed list-panes command verbatim.
+            val execCmd = session.execCommands.single { it.contains("list-panes") }
+            assertEquals("tmux $command", execCmd)
+        } finally {
+            client.close()
+        }
+    }
+
+    @Test
+    fun `listPanesViaExec surfaces an error response when the session is gone`() = runBlocking {
+        // Issue #1316 (error parity with the -CC path): a non-zero exec exit
+        // (session/server gone) must surface as an ERROR CommandResponse carrying
+        // the stderr, so the attach reconcile still fails honestly (→ retryable
+        // attach error) rather than silently reporting zero panes.
+        val shell = FakeShell()
+        val session = FakeSession(
+            shell,
+            execHandler = listPanesExecHandler(
+                rows = emptyList(),
+                exitCode = 1,
+                stderr = "can't find session: sess",
+            ),
+        )
+        val client = RealTmuxClient(session, scope)
+        try {
+            client.connect()
+            val response = withTimeout(ASYNC_AWAIT_TIMEOUT_MS) {
+                client.listPanesViaExec("list-panes -s -t 'sess' -F '#{pane_id}'")
+            }
+            assertTrue("a gone session must surface as an error response", response.isError)
+            assertEquals(listOf("can't find session: sess"), response.output)
+        } finally {
+            client.close()
+        }
+    }
+
+    @Test
+    fun `listPanesViaExec bounds itself and throws within the short ceiling on a wedged exec`() =
+        runBlocking {
+            // Issue #1316 (bounded escape): a genuinely wedged/half-open transport
+            // (the exec never returns) must surface a TmuxClientException within the
+            // caller's SHORT ceiling, NOT hang to the full command ceiling — so the
+            // attach reconcile can never gate input indefinitely. It fails fast → a
+            // `Failed` reconcile → a retryable "Tap Reconnect" attach error.
+            val shell = FakeShell()
+            val neverReturns = CompletableDeferred<ExecResult>()
+            val session = FakeSession(shell, execHandler = { neverReturns.await() })
+            val client = RealTmuxClient(session, scope, commandTimeoutMs = 30_000L)
+            try {
+                client.connect()
+                val startedAtMs = System.currentTimeMillis()
+                val thrown = runCatching {
+                    withTimeout(5_000) {
+                        client.listPanesViaExec(
+                            "list-panes -s -t 'sess' -F '#{pane_id}'",
+                            timeoutMs = 250L,
+                        )
+                    }
+                }.exceptionOrNull()
+                val elapsedMs = System.currentTimeMillis() - startedAtMs
+                assertTrue(
+                    "a wedged exec must surface a TmuxClientException from the short " +
+                        "ceiling, not hang to the 30 s command ceiling (was $thrown)",
+                    thrown is TmuxClientException,
+                )
+                assertTrue(
+                    "the reconcile must time out within ~the short ceiling (elapsed ${elapsedMs}ms)",
+                    elapsedMs < 5_000L,
+                )
+                neverReturns.cancel()
+            } finally {
+                client.close()
+            }
+        }
+
+    @Test
+    fun `list-panes reconcile completes on the exec lane while the -CC channel is wedged by a burst`() =
+        runBlocking {
+            // Issue #1316 (acceptance criterion 1+4, red→green): the maintainer's
+            // v0.4.24 day-0 wedge. A busy Claude/agent session saturates the ONE
+            // shared `-CC` control channel; a NEW session's attach reconcile
+            // `list-panes` used to head-of-line-block behind that burst on the
+            // single transport reader and retry behind the "Attaching…" overlay for
+            // up to 30 s.
+            //
+            // We reproduce the head-of-line block SYNTHETICALLY (#780 model): a
+            // `sendCommand` that is written but NEVER answered holds the -CC
+            // `sendMutex` for its whole 30 s ceiling — the "reconcile behind a busy
+            // agent" symptom. On BASE (the default `listPanesViaExec` = `-CC`
+            // `sendCommand`) the reconcile can't get onto the wedged control channel
+            // within budget and blocks/times out → RED. With the fix it runs on a
+            // DEDICATED exec channel and returns fast, independent of the wedged
+            // -CC mutex → GREEN.
+            //
+            // This SAME code path (`reconcilePanes` → `listPanesViaExec`) serves
+            // BOTH reported scenarios — new-session-from-kebab attach AND
+            // enter-existing-Claude attach — so the class is covered here.
+            val rows = listOf("%7|PS|@0|PS|0|PS|\$1")
+            val shell = FakeShell()
+            val session = FakeSession(shell, execHandler = listPanesExecHandler(rows))
+            // A large command ceiling so the wedging command holds the mutex for the
+            // whole test.
+            val client = RealTmuxClient(session, scope, commandTimeoutMs = 30_000L)
+            try {
+                client.connect()
+                withTimeout(2_000) {
+                    while (shell.stdinBytes().isEmpty()) { yield(); delay(10) }
+                }
+                shell.resetStdin()
+
+                // WEDGE the -CC sendMutex: a sendCommand written but never answered
+                // holds the mutex for its whole 30 s ceiling (the busy-agent burst
+                // saturating the shared control channel).
+                val wedger = scope.async { runCatching { client.sendCommand("list-clients") } }
+                withTimeout(2_000) {
+                    while (!shell.stdinAsString().contains("list-clients")) { yield(); delay(10) }
+                }
+
+                val startedAtMs = System.currentTimeMillis()
+                val response = withTimeout(5_000) {
+                    client.listPanesViaExec(
+                        "list-panes -s -t 'sess' -F '#{pane_id}|PS|#{window_id}'",
+                        timeoutMs = 6_000L,
+                    )
+                }
+                val elapsedMs = System.currentTimeMillis() - startedAtMs
+
+                assertFalse("the reconcile must succeed during a -CC burst", response.isError)
+                assertEquals(rows, response.output)
+                assertTrue(
+                    "the reconcile must complete well under the -CC mutex ceiling " +
+                        "(elapsed ${elapsedMs}ms) — proving it did NOT wait on the wedged " +
+                        "-CC sendMutex",
+                    elapsedMs < 2_000L,
+                )
+                wedger.cancel()
+            } finally {
+                client.close()
+            }
+        }
+
     @Test
     fun `pauseOutputDelivery holds output across a collector gap so a fresh collector recovers them`() =
         runBlocking {


### PR DESCRIPTION
## Summary
Fixes the v0.4.24 dogfood **attach/reveal wedge** on entering/creating a Claude/agent session (#1316). The attach reconcile `tmux list-panes` rode the shared per-host `-CC` control channel; a busy sibling session's `%output` burst head-of-line-blocks a new session's `list-panes` reply on the single transport reader, so the new attach wedges up to 30s behind the input-gated "Attaching…" overlay until a full back-out frees the transport.

## Change (scoped stop-the-bleeding, D28 SPOF-removal left as maintainer-owned)
- **Exec lane:** `TmuxClient.listPanesViaExec()` runs `list-panes` on the independent `SshSession.exec` channel (mirrors #1297's `capture-pane` move); `reconcilePanes()` + `buildPrewarmedPaneRuntime()` migrated. Hard-cut, no `-CC` reconcile path remains (D22). Format/error parity preserved.
- **Bounded escape:** 6s per-reconcile exec timeout → fast `Failed`/"Tap Reconnect"; `ATTACH_PANES_READY_TIMEOUT_MS` 30s→12s.

## Reproduce-first (G10/D33)
Synthetic core-tmux JVM test — **red on base** (`TimeoutCancellationException` on the wedged `-CC` mutex), **green** on the exec lane. Docker `TmuxClientIntegrationTest` exercises a real `-CC` burst. Reviewer independently drove red→green + ran the Docker integration suite + D31 adjacency sweep (reconnect/grace/#666/#1297 green). See #1316 comments.

## Follow-ups (non-blocking, flagged)
- Emulator confirmation of the 30s→12s bound + overlay ungating (batched emulator CI).
- Scenario 1's possible Main-thread render-cost half stays open (needs an ANR trace) — out of scope here.
- D28 transport SPOF-removal rework — maintainer-owned decision.

Closes #1316