### PR TITLE
prefs: corrupt-tolerant cold-start reads — LastSessionStore + DeferredPrefs class coverage (#1292)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/prefs/DeferredPrefs.kt
+++ b/app/src/main/java/com/pocketshell/app/prefs/DeferredPrefs.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.runBlocking
 
 /**
  * Issue #1125 / #1087 (freeze cause F6, class sweep): open a
- * [SharedPreferences] file OFF the Main thread.
+ * [SharedPreferences] file OFF the Main thread, resiliently (issue #1292).
  *
  * `Context.getSharedPreferences(...)` does a synchronous first-touch disk read.
  * Opening it eagerly in a store's field initializer blocks whatever thread
@@ -24,12 +24,26 @@ import kotlinx.coroutines.runBlocking
  * lands, but the block is real on every screen open).
  *
  * This helper kicks the open + first-touch off onto [ioDispatcher] (an eager
- * [async]) at construction time and exposes the prefs via [get], which
- * warms-or-awaits. The build is started immediately, so by the time a consumer
- * actually reads (a draft load, a toggle read, a dedup check) the cache is
- * typically already warm; the worst case blocks the caller waiting for the IO
- * build, but the disk read itself never runs on the constructing/Main thread.
- * Hard-cut (D22): there is no synchronous on-Main open fallback.
+ * [async]) at construction time and exposes the prefs via [get]. The build is
+ * started immediately, so by the time a consumer actually reads (a draft load, a
+ * toggle read, a dedup check) the cache is typically already warm, and the disk
+ * read is virtually never on the constructing/Main thread. Hard-cut (D22): there
+ * is no legacy on-Main open branch.
+ *
+ * ## Resilient open + no runBlocking on Main (issue #1292)
+ *
+ * The file-backed constructor opens through [ResilientPrefs.open], which
+ * tolerates a corrupt/unreadable prefs file (best-effort delete + re-open fresh)
+ * instead of letting the open THROW — a corrupt file previously latched in the
+ * warm-up `Deferred` and rethrew on **Main** at the first [get], crash-looping
+ * the app/screen (the #1291 class; `app_settings` was fixed in #1229/#1248).
+ *
+ * [get] no longer `runBlocking`-awaits the off-main coroutine on a cache miss:
+ * that parked Main on the whole contended IO-dispatcher queue drain during cold
+ * start (the #1249 lesson), not merely on the small-file read. Instead the cold
+ * path opens SYNCHRONOUSLY via the same resilient [opener] — a single bounded
+ * small-file read that also caches — so no `runBlocking` runs on the Main /
+ * cold-start path.
  *
  * This is the reusable extraction of the inlined pattern that already lives in
  * [com.pocketshell.app.release.UpdateCheckStore],
@@ -40,17 +54,17 @@ internal class DeferredPrefs(
     ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) {
     /**
-     * Open the named prefs file off-main. The opener captures [context]'s
-     * application context so it does not retain an Activity/screen Context.
+     * Open the named prefs file off-main, resiliently (#1292). The opener
+     * captures [context]'s application context so it does not retain an
+     * Activity/screen Context, and routes through [ResilientPrefs.open] so a
+     * corrupt prefs file self-heals instead of crashing.
      */
     constructor(
         context: Context,
         prefsName: String,
         ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
     ) : this(
-        opener = {
-            context.applicationContext.getSharedPreferences(prefsName, Context.MODE_PRIVATE)
-        },
+        opener = { ResilientPrefs.open(context, prefsName) },
         ioDispatcher = ioDispatcher,
     )
 
@@ -71,8 +85,15 @@ internal class DeferredPrefs(
         opener().also { cachedPrefs = it }
     }
 
-    /** The opened prefs — warm if the off-main build finished, else await it. */
-    fun get(): SharedPreferences = cachedPrefs ?: runBlocking { deferred.await() }
+    /**
+     * The opened prefs. Warm case: the eager off-main build already published
+     * [cachedPrefs] — a plain volatile read, zero on-Main disk work. Cold /
+     * contended case: open SYNCHRONOUSLY via the resilient [opener] (which caches
+     * as a side effect) rather than `runBlocking`-awaiting the off-main coroutine
+     * — that await parked Main on the whole contended IO-queue drain during cold
+     * start (#1249), and this path must never `runBlocking` on Main (#1292).
+     */
+    fun get(): SharedPreferences = cachedPrefs ?: opener().also { cachedPrefs = it }
 
     /**
      * Test-only: block until the off-main open completes and return the name of

--- a/app/src/main/java/com/pocketshell/app/prefs/ResilientPrefs.kt
+++ b/app/src/main/java/com/pocketshell/app/prefs/ResilientPrefs.kt
@@ -1,0 +1,67 @@
+package com.pocketshell.app.prefs
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.util.Log
+
+/**
+ * The ONE resilient [SharedPreferences] open used by every cold-start / Main-path
+ * prefs store — the class-coverage hardening for issue #1292 (the #1291 crash
+ * class).
+ *
+ * ## The crash class (#1291)
+ * `Context.getSharedPreferences(name, ...)` does a synchronous first-touch open +
+ * XML parse. A power loss / disk-full event can truncate or mangle
+ * `shared_prefs/<name>.xml`, and a corrupt file makes that open THROW. Every
+ * store on the cold-start / Main path warmed the open in an eager off-main
+ * `async` and then, on the first read, `runBlocking`-awaited (or synchronously
+ * opened) it on **Main** — so a corrupt file rethrew on Main and crash-looped
+ * the app at launch (`app_settings` was fixed in #1229/#1248; `last_session` and
+ * the 7 [DeferredPrefs]-backed screen stores shared the identical unguarded
+ * pattern — #1292).
+ *
+ * ## The #1248 shape (hard-cut recovery, D22)
+ * [open] mirrors `SettingsRepository.buildSnapshotResiliently`:
+ *  1. `runCatching` the open.
+ *  2. On failure: best-effort `deleteSharedPreferences(name)` so a fresh empty
+ *     file is created and the recovery is DURABLE across relaunch (no "clear app
+ *     data" needed), then re-open a writable handle on the cleared file so
+ *     subsequent writes still persist.
+ *  3. Return that handle (a fresh empty prefs) instead of propagating.
+ *
+ * There is no compat branch and no fallback to the old unguarded path (D22 hard
+ * cut). Callers open synchronously via [open] on the cold path rather than
+ * `runBlocking`-awaiting an off-main coroutine — a single bounded small-file read
+ * that never parks Main on the contended IO-dispatcher queue (the #1249 lesson).
+ */
+internal object ResilientPrefs {
+
+    private const val TAG = "PsResilientPrefs"
+
+    /**
+     * Open [prefsName] under [context]'s application context, tolerating a
+     * corrupt/unreadable prefs file: on an open/parse failure the file is
+     * best-effort deleted and re-opened fresh so launch/screen-open survives and
+     * the recovery is durable. Never propagates the open failure.
+     */
+    fun open(context: Context, prefsName: String): SharedPreferences {
+        val appContext = context.applicationContext
+        return runCatching {
+            appContext.getSharedPreferences(prefsName, Context.MODE_PRIVATE)
+        }.getOrElse { error ->
+            Log.e(
+                TAG,
+                "$prefsName prefs open/parse failed — corrupt prefs file; " +
+                    "clearing it and re-opening fresh so launch survives",
+                error,
+            )
+            // Best-effort clear the corrupt file so a fresh empty one is created
+            // and the recovery is durable across relaunch. Then re-open on the
+            // cleared file so writes still persist. The re-open of a just-deleted
+            // prefs file creates a brand-new empty XML — the reliable recovery
+            // path the #1291 fixture exercises.
+            runCatching { appContext.deleteSharedPreferences(prefsName) }
+            appContext.getSharedPreferences(prefsName, Context.MODE_PRIVATE)
+        }
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/session/LastSessionStore.kt
+++ b/app/src/main/java/com/pocketshell/app/session/LastSessionStore.kt
@@ -5,14 +5,10 @@ import android.content.SharedPreferences
 import android.util.Log
 import androidx.annotation.VisibleForTesting
 import com.pocketshell.app.nav.AppDestination
+import com.pocketshell.app.prefs.DeferredPrefs
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.async
-import kotlinx.coroutines.runBlocking
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -60,12 +56,26 @@ import javax.inject.Singleton
  *
  * The fix mirrors F5's [com.pocketshell.app.systemsurfaces.SystemSurfaceStateStore]:
  * the constructor never reads the prefs file on the calling thread. It only
- * *kicks off* the build on [ioDispatcher] (an eager [async]) and returns
+ * *kicks off* the build on [ioDispatcher] (an eager `async`) and returns
  * immediately, so `<init>` never blocks the constructing (Main) thread. The
- * first read warms-or-awaits that background result; on a fresh cold launch
+ * first read warms-or-opens that background result; on a fresh cold launch
  * [read] is never called (only on the process-death resume path), so the
  * background build is virtually always warm before any read. Hard-cut (D22):
- * there is no synchronous on-Main fallback.
+ * there is no legacy on-Main open branch.
+ *
+ * ## Resilient open + no runBlocking on Main (issue #1292)
+ *
+ * The prefs open routes through [com.pocketshell.app.prefs.DeferredPrefs], which
+ * opens via [com.pocketshell.app.prefs.ResilientPrefs] — the ONE shared resilient
+ * helper (best-effort delete + re-open on a corrupt file). A corrupt
+ * `last_session.xml` previously made `getSharedPreferences(...)` THROW inside the
+ * warm-up coroutine; `MainActivity.onCreate`'s process-death-resume
+ * `lastSessionStore.read()` then rethrew it on **Main**, crash-looping launch
+ * exactly like the #1291 `app_settings` outage (fixed for that one file in
+ * #1229/#1248). Routing through [DeferredPrefs] closes this door of the same
+ * class, and its [DeferredPrefs.get] opens synchronously on the cold path rather
+ * than `runBlocking`-awaiting the off-main coroutine (#1249) — so [read] never
+ * `runBlocking`s on Main.
  */
 @Singleton
 class LastSessionStore @VisibleForTesting internal constructor(
@@ -76,32 +86,13 @@ class LastSessionStore @VisibleForTesting internal constructor(
     @Inject
     constructor(@ApplicationContext context: Context) : this(context, Dispatchers.IO)
 
-    private val appContext: Context = context.applicationContext
-
-    // Once the background build completes, the result is cached here so reads
-    // never re-enter runBlocking. @Volatile: written on [ioDispatcher], read
-    // from any consumer thread.
-    @Volatile
-    private var cachedPrefs: SharedPreferences? = null
-
-    // Test seam (#1087): records the name of the thread the prefs-file build
-    // actually ran on, so the regression test can hard-assert it is NOT the
-    // constructing/Main thread. Written on [ioDispatcher].
-    @Volatile
-    private var prefsBuildThreadName: String? = null
-
-    // Eager async: the build STARTS at construction but on a background thread.
-    // `async` (DEFAULT start) dispatches immediately and returns without
-    // blocking the caller.
-    private val warmUpScope = CoroutineScope(SupervisorJob() + ioDispatcher)
-    private val prefsDeferred: Deferred<SharedPreferences> = warmUpScope.async {
-        prefsBuildThreadName = currentPhysicalThreadName()
-        appContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-            .also { cachedPrefs = it }
-    }
+    // The ONE shared resilient prefs helper (#1292): eager off-main open through
+    // [com.pocketshell.app.prefs.ResilientPrefs] (corrupt-tolerant, self-healing),
+    // and a cold-path synchronous open that never `runBlocking`s on Main (#1249).
+    private val deferredPrefs = DeferredPrefs(context, PREFS_NAME, ioDispatcher)
 
     private val prefs: SharedPreferences
-        get() = cachedPrefs ?: runBlocking { prefsDeferred.await() }
+        get() = deferredPrefs.get()
 
     /**
      * Test-only: block until the off-main build completes and return the name
@@ -109,19 +100,8 @@ class LastSessionStore @VisibleForTesting internal constructor(
      * construction did NOT happen on the constructing/Main thread (#1087).
      */
     @VisibleForTesting
-    internal fun awaitPrefsBuildThreadNameForTest(): String {
-        runBlocking { prefsDeferred.await() }
-        return prefsBuildThreadName
-            ?: error("prefs build thread was not recorded")
-    }
-
-    // The build runs inside a coroutine, whose framework decorates the thread
-    // name with a " @coroutine#N" suffix. Strip it so the recorded value is the
-    // PHYSICAL thread name — otherwise an on-Main build (e.g. the un-fixed base)
-    // would still differ from the captured constructing name by the suffix alone,
-    // giving a false off-main pass (#1087 G6: keep the assertion load-bearing).
-    private fun currentPhysicalThreadName(): String =
-        Thread.currentThread().name.substringBefore(" @coroutine")
+    internal fun awaitPrefsBuildThreadNameForTest(): String =
+        deferredPrefs.awaitBuildThreadNameForTest()
 
     /**
      * Issue #834: identity of the most recently killed session, remembered in

--- a/app/src/test/java/com/pocketshell/app/prefs/DeferredPrefsCorruptPrefsTest.kt
+++ b/app/src/test/java/com/pocketshell/app/prefs/DeferredPrefsCorruptPrefsTest.kt
@@ -1,0 +1,142 @@
+package com.pocketshell.app.prefs
+
+import android.content.Context
+import android.content.ContextWrapper
+import android.content.SharedPreferences
+import androidx.test.core.app.ApplicationProvider
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Reproduce-first, CLASS-COVERING regression proof for issue #1292 (#1291 /
+ * D31 / D32-G2 / G10): the 7 screen-scoped stores that route their prefs open
+ * through [DeferredPrefs] (composer draft + outbound queue + attachment sidecar,
+ * port-forward panel, file viewer, FCM token, push dedup) all share the same
+ * unguarded-open crash class as `app_settings` (#1229) and `last_session`
+ * (#1292): a corrupt prefs file makes `getSharedPreferences(...)` THROW, the
+ * exception latches in the warm-up `Deferred`, and the first `get()` on the
+ * **Main** thread (at screen-open) `runBlocking`-rethrows it — crashing the
+ * screen.
+ *
+ * Rather than re-fixture all 7 stores, this exercises the SHARED node they all
+ * funnel through — [DeferredPrefs] — so a fix there covers the whole class (G2).
+ *
+ * ## The fixture that reproduces it (the non-happy state)
+ * [CorruptScreenPrefsContext] throws on `getSharedPreferences(PREFS_NAME, ...)`
+ * exactly as a corrupt XML parse would, until the file is DELETED. A happy
+ * fixture can never enter the failing state, so it would prove nothing.
+ *
+ * RED on base: `DeferredPrefs.get()` rethrows the latched exception → RED.
+ * GREEN with fix: the shared resilient helper catches the corrupt open,
+ * best-effort deletes the file, re-opens a fresh handle, and `get()` returns a
+ * usable prefs instance without throwing → GREEN.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class DeferredPrefsCorruptPrefsTest {
+
+    private lateinit var realContext: Context
+
+    @Before
+    fun setUp() {
+        realContext = ApplicationProvider.getApplicationContext()
+        clearPrefs()
+    }
+
+    @After
+    fun tearDown() {
+        clearPrefs()
+    }
+
+    /**
+     * LOAD-BEARING (#1292 acceptance 2): a corrupt file in a [DeferredPrefs]-
+     * backed screen store no longer crashes on Main at screen-open. On base
+     * `get()` rethrows the latched corrupt-open exception (RED); with the shared
+     * resilient helper it returns a usable prefs handle (GREEN).
+     */
+    @Test
+    fun corrupt_screen_store_prefs_does_not_crash_on_get() {
+        val corruptContext = CorruptScreenPrefsContext(realContext)
+
+        val deferred = DeferredPrefs(corruptContext, PREFS_NAME)
+        val prefs = deferred.get()
+
+        // A usable handle came back (no crash) and reads a default cleanly.
+        assertNull("recovered prefs must read a missing key as its default", prefs.getString("k", null))
+        assertTrue(
+            "the corrupt-prefs open must have been attempted at least once",
+            corruptContext.throwingOpenAttempts.get() >= 1,
+        )
+    }
+
+    /**
+     * #1292 acceptance 2 (durable + writable recovery): after the corrupt open
+     * recovers (best-effort delete + re-open), the returned handle is writable
+     * and a fresh [DeferredPrefs] on the SAME cleared app data reads the value
+     * back — proving the recovery is durable across screen re-open, not a
+     * one-shot in-memory patch.
+     */
+    @Test
+    fun recovery_is_durable_and_writable() {
+        val corruptContext = CorruptScreenPrefsContext(realContext)
+
+        val recovered = DeferredPrefs(corruptContext, PREFS_NAME).get()
+        assertTrue(
+            "the fix must best-effort delete the corrupt prefs file so recovery " +
+                "is durable across screen re-open",
+            corruptContext.wasDeleted,
+        )
+        recovered.edit().putString("k", "v").commit()
+
+        val reopened = DeferredPrefs(corruptContext, PREFS_NAME).get()
+        assertEquals("v", reopened.getString("k", null))
+    }
+
+    private fun clearPrefs() {
+        realContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit().clear().commit()
+    }
+
+    private class CorruptScreenPrefsContext(base: Context) : ContextWrapper(base) {
+        @Volatile
+        private var corrupt = true
+
+        @Volatile
+        var wasDeleted = false
+            private set
+
+        val throwingOpenAttempts = AtomicInteger(0)
+
+        override fun getApplicationContext(): Context = this
+
+        override fun getSharedPreferences(name: String?, mode: Int): SharedPreferences {
+            if (name == PREFS_NAME && corrupt) {
+                throwingOpenAttempts.incrementAndGet()
+                throw RuntimeException(
+                    "simulated corrupt $PREFS_NAME.xml: unexpected end of document",
+                )
+            }
+            return super.getSharedPreferences(name, mode)
+        }
+
+        override fun deleteSharedPreferences(name: String?): Boolean {
+            if (name == PREFS_NAME) {
+                corrupt = false
+                wasDeleted = true
+            }
+            return super.deleteSharedPreferences(name)
+        }
+    }
+
+    private companion object {
+        const val PREFS_NAME = "file_viewer_prefs"
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/prefs/ResilientPrefsTest.kt
+++ b/app/src/test/java/com/pocketshell/app/prefs/ResilientPrefsTest.kt
@@ -1,0 +1,110 @@
+package com.pocketshell.app.prefs
+
+import android.content.Context
+import android.content.ContextWrapper
+import android.content.SharedPreferences
+import androidx.test.core.app.ApplicationProvider
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Unit proof for the ONE shared resilient prefs helper (issue #1292). This is
+ * the node every cold-start / Main-path store funnels its open through, so its
+ * corrupt-tolerance is the class-covering guarantee for the #1291 crash class.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class ResilientPrefsTest {
+
+    private lateinit var realContext: Context
+
+    @Before
+    fun setUp() {
+        realContext = ApplicationProvider.getApplicationContext()
+        clearPrefs()
+    }
+
+    @After
+    fun tearDown() {
+        clearPrefs()
+    }
+
+    /** Happy path: a healthy prefs file opens and reads its persisted value. */
+    @Test
+    fun healthy_open_reads_persisted_value() {
+        realContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit().putString("k", "persisted").commit()
+
+        val prefs = ResilientPrefs.open(realContext, PREFS_NAME)
+
+        assertEquals("persisted", prefs.getString("k", null))
+    }
+
+    /**
+     * LOAD-BEARING: a corrupt open does NOT propagate — the helper best-effort
+     * deletes the file, re-opens a fresh writable handle, and returns it.
+     */
+    @Test
+    fun corrupt_open_self_heals_and_returns_writable_handle() {
+        val corruptContext = CorruptContext(realContext)
+
+        val prefs = ResilientPrefs.open(corruptContext, PREFS_NAME)
+
+        assertTrue(
+            "the corrupt open must have been attempted",
+            corruptContext.throwingOpenAttempts.get() >= 1,
+        )
+        assertTrue(
+            "the fix must best-effort delete the corrupt prefs file",
+            corruptContext.wasDeleted,
+        )
+        // The returned handle is usable + writable.
+        prefs.edit().putString("k", "fresh").commit()
+        assertEquals("fresh", prefs.getString("k", null))
+    }
+
+    private fun clearPrefs() {
+        realContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit().clear().commit()
+    }
+
+    private class CorruptContext(base: Context) : ContextWrapper(base) {
+        @Volatile
+        private var corrupt = true
+
+        @Volatile
+        var wasDeleted = false
+            private set
+
+        val throwingOpenAttempts = AtomicInteger(0)
+
+        override fun getApplicationContext(): Context = this
+
+        override fun getSharedPreferences(name: String?, mode: Int): SharedPreferences {
+            if (name == PREFS_NAME && corrupt) {
+                throwingOpenAttempts.incrementAndGet()
+                throw RuntimeException("simulated corrupt $PREFS_NAME.xml")
+            }
+            return super.getSharedPreferences(name, mode)
+        }
+
+        override fun deleteSharedPreferences(name: String?): Boolean {
+            if (name == PREFS_NAME) {
+                corrupt = false
+                wasDeleted = true
+            }
+            return super.deleteSharedPreferences(name)
+        }
+    }
+
+    private companion object {
+        const val PREFS_NAME = "resilient_prefs_probe"
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/session/LastSessionStoreCorruptPrefsTest.kt
+++ b/app/src/test/java/com/pocketshell/app/session/LastSessionStoreCorruptPrefsTest.kt
@@ -1,0 +1,187 @@
+package com.pocketshell.app.session
+
+import android.content.Context
+import android.content.ContextWrapper
+import android.content.SharedPreferences
+import androidx.test.core.app.ApplicationProvider
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Reproduce-first regression proof for issue #1292 (class coverage of #1291 /
+ * D31 / D32-G2 / G10): a corrupt / unreadable `last_session` prefs file must NOT
+ * crash-loop the app at launch on the process-death resume path.
+ *
+ * ## The bug (the #1291 class, second door)
+ * v0.4.23 fixed the `app_settings` open (#1229/#1248), but [LastSessionStore]
+ * shipped the same unguarded pattern: its off-main warm-up opened the prefs file
+ * with `getSharedPreferences("last_session", ...)` — a synchronous first-touch
+ * open + XML parse — with **no** guard around the open (individual key reads are
+ * `safeXxx`-wrapped; the file open was not). `MainActivity.onCreate` reads the
+ * persisted snapshot on the **Main** thread on the process-death resume path
+ * (`lastSessionStore.read()`), whose `prefs` getter `runBlocking`-awaited the
+ * warm-up `Deferred`. A power loss / disk-full event that mangles
+ * `shared_prefs/last_session.xml` makes the open THROW; the exception latched in
+ * the `Deferred` and rethrew on **Main** at `read()` — the identical total
+ * cold-start outage as #1291, unrecoverable without clearing app data.
+ *
+ * ## The fixture that reproduces it (the non-happy state)
+ * [CorruptLastSessionContext] throws on `getSharedPreferences("last_session",
+ * ...)` exactly as a corrupt XML parse would, until the file is DELETED — a
+ * happy fixture (a normal writable prefs file) can never enter the failing
+ * state, so it would prove nothing (the v0.4.10/#847 lesson).
+ *
+ * RED on base: `store.read()` rethrows the latched exception on the reading
+ * (Main-equivalent) thread → the test throws → RED.
+ * GREEN with fix: the shared resilient helper catches the corrupt open,
+ * best-effort deletes the file, re-opens a fresh handle, and `read()` returns
+ * null (nothing to restore) without throwing → GREEN.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class LastSessionStoreCorruptPrefsTest {
+
+    private lateinit var realContext: Context
+
+    @Before
+    fun setUp() {
+        realContext = ApplicationProvider.getApplicationContext()
+        clearPrefs()
+    }
+
+    @After
+    fun tearDown() {
+        clearPrefs()
+    }
+
+    /**
+     * LOAD-BEARING (#1292 acceptance 1): a corrupt/throwing `last_session`
+     * source degrades to "nothing to restore" at launch instead of crashing the
+     * process-death resume read. On base the unguarded open latches in the
+     * warm-up Deferred and `read()` rethrows on the reading thread (RED); with
+     * the shared resilient helper it returns null (GREEN).
+     */
+    @Test
+    fun corrupt_last_session_prefs_does_not_crash_process_death_resume_read() {
+        val corruptContext = CorruptLastSessionContext(realContext)
+
+        // Constructing the store kicks off the off-main warm-up; `read()` is
+        // exactly what `MainActivity.onCreate` does on the process-death resume
+        // path — the crash site.
+        val store = LastSessionStore(corruptContext)
+        val restored = store.read()
+
+        assertNull("corrupt last_session must degrade to no restore, not crash", restored)
+        // The corrupt open was actually exercised (guards against a vacuous pass
+        // where the fixture never threw — G3).
+        assertTrue(
+            "the corrupt-prefs open must have been attempted at least once",
+            corruptContext.throwingOpenAttempts.get() >= 1,
+        )
+    }
+
+    /**
+     * #1292 acceptance 1 (durable self-recovery): after the first launch's
+     * warm-up recovers (best-effort deleting the corrupt file), a SECOND
+     * instance — a "relaunch" on the SAME app data, without the user clearing
+     * data — opens cleanly, and a save→fresh-read round-trips. The fix's
+     * `deleteSharedPreferences` clears the corrupt marker so the relaunch's open
+     * succeeds and writes persist.
+     */
+    @Test
+    fun recovery_is_durable_relaunch_after_corruption_round_trips() {
+        val corruptContext = CorruptLastSessionContext(realContext)
+
+        // First launch: recovers + best-effort clears the corrupt file.
+        LastSessionStore(corruptContext).read()
+        assertTrue(
+            "first launch must have attempted the corrupt open",
+            corruptContext.throwingOpenAttempts.get() >= 1,
+        )
+        assertTrue(
+            "the fix must best-effort delete the corrupt prefs file so the " +
+                "recovery is durable across relaunch",
+            corruptContext.wasDeleted,
+        )
+
+        // Second launch on the SAME (now cleared) app data: a save persists and
+        // a fresh instance reads it back (proves the fix re-seeded a usable,
+        // writable prefs handle from the cleared file).
+        val session = LastSessionStore.LastSession(
+            hostId = 7L,
+            hostName = "prod-box",
+            hostname = "10.0.0.9",
+            port = 2022,
+            username = "alex",
+            keyPath = "/data/keys/id_ed25519",
+            sessionName = "claude-main",
+            startDirectory = "/srv/app",
+            tmuxSessionId = "\$3",
+            sessionCreated = 1_700_000_000L,
+            composerDraft = "deploy please",
+            savedAtMillis = 1_000L,
+        )
+        LastSessionStore(corruptContext).save(session)
+        val restored = LastSessionStore(corruptContext).read(
+            nowMillis = 1_500L,
+            maxAgeMillis = Long.MAX_VALUE,
+        )
+        assertEquals(session, restored)
+    }
+
+    private fun clearPrefs() {
+        realContext.getSharedPreferences("last_session", Context.MODE_PRIVATE)
+            .edit().clear().commit()
+    }
+
+    /**
+     * A [ContextWrapper] that simulates a corrupt `last_session` XML: it throws
+     * on `getSharedPreferences("last_session", ...)` — mirroring the open/parse
+     * failure — until the file is deleted, at which point (the durable recovery)
+     * it opens cleanly against the real backing context. `getApplicationContext()`
+     * returns `this` so the store's `context.applicationContext` is the throwing
+     * wrapper.
+     */
+    private class CorruptLastSessionContext(base: Context) : ContextWrapper(base) {
+        @Volatile
+        private var corrupt = true
+
+        @Volatile
+        var wasDeleted = false
+            private set
+
+        val throwingOpenAttempts = AtomicInteger(0)
+
+        override fun getApplicationContext(): Context = this
+
+        override fun getSharedPreferences(name: String?, mode: Int): SharedPreferences {
+            if (name == PREFS_NAME && corrupt) {
+                throwingOpenAttempts.incrementAndGet()
+                throw RuntimeException(
+                    "simulated corrupt $PREFS_NAME.xml: unexpected end of document",
+                )
+            }
+            return super.getSharedPreferences(name, mode)
+        }
+
+        override fun deleteSharedPreferences(name: String?): Boolean {
+            if (name == PREFS_NAME) {
+                corrupt = false
+                wasDeleted = true
+            }
+            return super.deleteSharedPreferences(name)
+        }
+    }
+
+    private companion object {
+        const val PREFS_NAME = "last_session"
+    }
+}


### PR DESCRIPTION
Closes #1292. Class-coverage hardening for the #1291 app-won't-open cold-start crash class. Routes LastSessionStore + the DeferredPrefs family through one shared `ResilientPrefs` helper (#1248 shape). Reviewer APPROVED with reviewer-driven red→green, class coverage (both launch path + DeferredPrefs family), D22 hard-cut, adjacency sweep clean. JVM unit tests in the required `Unit tests` gate.