### PR TITLE
tmux: guarantee Terminal/Conversation toggle width — fix the 5x-recurring clipped-toggle (#1320)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxChromeConversationTogglePresentTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxChromeConversationTogglePresentTest.kt
@@ -1,0 +1,297 @@
+package com.pocketshell.app.tmux
+
+import android.graphics.Bitmap
+import android.os.SystemClock
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.proof.signals.assertNodeFullyWithinRoot
+import com.pocketshell.app.sessions.HostTmuxSessionPickerViewModel
+import com.pocketshell.app.sessions.HostTmuxSessionRow
+import com.pocketshell.uikit.components.SegmentedToggle
+import com.pocketshell.uikit.model.ConnectionStatus
+import com.pocketshell.uikit.theme.PocketShellColors
+import com.pocketshell.uikit.theme.PocketShellTheme
+import java.io.File
+import java.io.FileOutputStream
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Issue #1320 regression proof — the 5×-recurring "Conversation toggle missing"
+ * dogfood blocker (#962 → #975 → #1057 → #1158). The REAL root cause is a LAYOUT
+ * clip, NOT the agent-detection gate: in [ConsolidatedTopChrome] the
+ * Terminal/Conversation toggle used to live inside a `weight(1f, fill = false)`
+ * trailing slot that competed with the title's own `weight(1f)`. Two `weight(1f)`
+ * slots split the remaining row width 50/50, so a long agent/session title
+ * starved the toggle's slot below its intrinsic width and its "Conversation"
+ * segment was width-constrained and ellipsised away — the user saw only
+ * "Terminal" and had no way to switch to the conversation view. Detection had
+ * already fired (the header showed the agent name), which is exactly why adding
+ * yet another detection OR-term never fixed it.
+ *
+ * The load-bearing property this proves (red→green): the **Conversation
+ * segment** must render at its FULL intrinsic width — it must NOT be squeezed
+ * narrower than the same segment rendered unconstrained. The segment bug is
+ * width-STARVATION (the constrained toggle ellipsises the "Conversation" label),
+ * NOT an off-the-edge overflow, so a bare `assertIsDisplayed()` — and even a
+ * whole-toggle containment check — passes on base (the squeezed toggle still
+ * lies within the row). The decisive check compares the production segment's
+ * rendered width against a reference intrinsic render of the identical
+ * [SegmentedToggle]; on base the production segment is starved (< intrinsic) and
+ * the assertion FAILS, with the fix (toggle pulled OUT of the weighted slot and
+ * reserved at intrinsic width) it renders full and PASSES. It is density-
+ * independent (no hard-coded pixel threshold) and does NOT self-skip on CI.
+ *
+ * Class coverage (D31/D32 G2): long title, long title + status pill present,
+ * long project crumb, and the narrowest supported width with everything
+ * competing. F1/F2 (#657): composes the PRODUCTION [ConsolidatedTopChrome] in
+ * the reported state, captures a full-device screenshot for visual proof, and
+ * asserts the segment is displayed + tappable (reachability, not just presence).
+ *
+ * Pure Compose-rule UI test — NO Docker fixture, NO SSH/tmux, NO toxiproxy, NO
+ * 2222/2226 port — so it needs no tests.yml service change and is wired into
+ * `scripts/ci-journey-suite.sh` so the class regression cannot silently return.
+ */
+@RunWith(AndroidJUnit4::class)
+class TmuxChromeConversationTogglePresentTest {
+
+    @get:Rule
+    val compose = createAndroidComposeRule<ComponentActivity>()
+
+    /** The Conversation segment tag inside [ConsolidatedTabPill] (index 1). */
+    private val conversationSegmentTag = TMUX_CONSOLIDATED_TAB_PILL_TAG_PREFIX + 1
+
+    /** A very long agent/model title — the maintainer's reported widening source. */
+    private val longAgentName =
+        "pocketshell Claude Code sonnet-4.5 extended-thinking session"
+
+    @Test
+    fun conversationSegmentRendersFullWidth_longAgentName() {
+        assertConversationSegmentNotStarved(
+            artifactName = "conv-toggle-long-agent",
+            phoneWidth = 360.dp,
+            agentName = longAgentName,
+            connectionStatus = ConnectionStatus.Connected,
+            projectLabel = null,
+            projectSwitcher = HostTmuxSessionPickerViewModel.ProjectSwitcherState(),
+        )
+    }
+
+    @Test
+    fun conversationSegmentRendersFullWidth_longAgentNameWithStatusPill() {
+        // Class coverage: a non-live connection surfaces the "Disconnected" pill
+        // in the yielding region — the widest the leading cluster ever gets. The
+        // toggle must still win its full width over the pill.
+        assertConversationSegmentNotStarved(
+            artifactName = "conv-toggle-long-agent-status-pill",
+            phoneWidth = 360.dp,
+            agentName = longAgentName,
+            connectionStatus = ConnectionStatus.Error,
+            projectLabel = null,
+            projectSwitcher = HostTmuxSessionPickerViewModel.ProjectSwitcherState(),
+        )
+    }
+
+    @Test
+    fun conversationSegmentRendersFullWidth_longProjectCrumb() {
+        // Class coverage: a long project crumb competes for the leading width.
+        val switcher = HostTmuxSessionPickerViewModel.ProjectSwitcherState(
+            currentSessionName = "pocketshell-android-client",
+            projectPath = "/home/alexey/projects/pocketshell-android-client",
+            siblings = listOf(
+                HostTmuxSessionRow(name = "pocketshell-android-client"),
+                HostTmuxSessionRow(name = "pocketshell-android-client-worker"),
+            ),
+        )
+        assertConversationSegmentNotStarved(
+            artifactName = "conv-toggle-long-crumb",
+            phoneWidth = 360.dp,
+            agentName = longAgentName,
+            connectionStatus = ConnectionStatus.Connected,
+            projectLabel = "pocketshell-android-client",
+            projectSwitcher = switcher,
+        )
+    }
+
+    @Test
+    fun conversationSegmentRendersFullWidth_narrowestSupportedWidth() {
+        // Class coverage: the narrowest realistic phone content width, long title
+        // AND status pill AND crumb all competing. The toggle still never yields.
+        val switcher = HostTmuxSessionPickerViewModel.ProjectSwitcherState(
+            currentSessionName = "app",
+            projectPath = "/home/alexey/projects/app",
+            siblings = listOf(
+                HostTmuxSessionRow(name = "app"),
+                HostTmuxSessionRow(name = "app-worker"),
+            ),
+        )
+        assertConversationSegmentNotStarved(
+            artifactName = "conv-toggle-narrowest",
+            phoneWidth = 320.dp,
+            agentName = longAgentName,
+            connectionStatus = ConnectionStatus.Error,
+            projectLabel = "long-project-folder-name",
+            projectSwitcher = switcher,
+        )
+    }
+
+    /**
+     * Renders BOTH a reference intrinsic [SegmentedToggle] (unconstrained) and
+     * the production [ConsolidatedTopChrome] constrained to [phoneWidth] with a
+     * long title, then asserts the production Conversation segment is at least as
+     * wide as the reference (within slop) — i.e. NOT starved/ellipsised. Also
+     * captures a full-device screenshot and asserts the segment is displayed +
+     * tappable.
+     */
+    private fun assertConversationSegmentNotStarved(
+        artifactName: String,
+        phoneWidth: Dp,
+        agentName: String,
+        connectionStatus: ConnectionStatus,
+        projectLabel: String?,
+        projectSwitcher: HostTmuxSessionPickerViewModel.ProjectSwitcherState,
+    ) {
+        compose.setContent {
+            PocketShellTheme {
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(PocketShellColors.Background)
+                        .padding(top = 24.dp)
+                        .testTag(ROOT_TAG),
+                ) {
+                    // Reference: the same two-label toggle rendered UNCONSTRAINED
+                    // (wrap content) so its Conversation segment measures at full
+                    // intrinsic width — the width the production segment MUST
+                    // match. Comparing against it keeps the check density-
+                    // independent (no hard-coded pixel threshold).
+                    Box {
+                        SegmentedToggle(
+                            labels = listOf("Terminal", "Conversation"),
+                            selectedIndex = 1,
+                            onSelected = {},
+                            segmentTag = { index ->
+                                if (index == 1) REFERENCE_CONVERSATION_TAG else null
+                            },
+                        )
+                    }
+                    // Production chrome constrained to a realistic phone width so
+                    // the (base) weight-split squeeze is deterministic on any AVD.
+                    Box(modifier = Modifier.width(phoneWidth)) {
+                        ConsolidatedTopChrome(
+                            sessionName = "app",
+                            agentName = agentName,
+                            onBack = {},
+                            onMore = {},
+                            tabLabels = listOf("Terminal", "Conversation"),
+                            selectedTabIndex = 1,
+                            projectLabel = projectLabel,
+                            projectSwitcher = projectSwitcher,
+                            connectionStatus = connectionStatus,
+                        )
+                    }
+                    TerminalBandFiller()
+                }
+            }
+        }
+
+        compose.onNodeWithTag(ROOT_TAG).assertExists()
+        compose.waitForIdle()
+
+        captureFullDevice(File(artifactDir(), "$artifactName.png"))
+
+        val intrinsicConversationWidth = nodeWidthPx(REFERENCE_CONVERSATION_TAG)
+        val renderedConversationWidth = nodeWidthPx(conversationSegmentTag)
+        val slopPx = compose.density.density * SLOP_DP
+
+        if (renderedConversationWidth < intrinsicConversationWidth - slopPx) {
+            throw AssertionError(
+                "Issue #1320: the Conversation segment is STARVED — it rendered " +
+                    "at ${renderedConversationWidth}px but its full intrinsic " +
+                    "width is ${intrinsicConversationWidth}px (slop=${slopPx}px). " +
+                    "The Terminal/Conversation toggle is being squeezed by the " +
+                    "long title in ConsolidatedTopChrome, so the 'Conversation' " +
+                    "label is clipped/ellipsised and the user cannot switch to " +
+                    "the conversation view. phoneWidth=$phoneWidth " +
+                    "agentName='$agentName' status=$connectionStatus " +
+                    "projectLabel=$projectLabel.",
+            )
+        }
+
+        // Belt-and-suspenders: the whole toggle must also lie within the root
+        // (never pushed off the edge), and the Conversation segment must be
+        // displayed + tappable — reachability, not just width.
+        compose.assertNodeFullyWithinRoot(TMUX_TABS_TAG)
+        compose.onNodeWithTag(conversationSegmentTag, useUnmergedTree = true)
+            .assertIsDisplayed()
+            .assertHasClickAction()
+    }
+
+    private fun nodeWidthPx(tag: String): Float =
+        compose.onNodeWithTag(tag, useUnmergedTree = true)
+            .fetchSemanticsNode()
+            .boundsInRoot
+            .width
+
+    @androidx.compose.runtime.Composable
+    private fun TerminalBandFiller() {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(80.dp)
+                .background(PocketShellColors.TermBg)
+                .padding(12.dp),
+        )
+    }
+
+    private fun artifactDir(): File {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val mediaRoot = com.pocketshell.app.test.testArtifactsRoot(instrumentation.targetContext)
+        val dir = File(mediaRoot, "additional_test_output/tmux-conversation-toggle-present")
+        check(dir.exists() || dir.mkdirs()) {
+            "Could not create conversation-toggle screenshot dir: ${dir.absolutePath}"
+        }
+        return dir
+    }
+
+    private fun captureFullDevice(file: File) {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.waitForIdleSync()
+        SystemClock.sleep(200)
+        val bitmap: Bitmap = instrumentation.uiAutomation.takeScreenshot() ?: return
+        try {
+            FileOutputStream(file).use { output ->
+                check(bitmap.compress(Bitmap.CompressFormat.PNG, 100, output)) {
+                    "Could not write conversation-toggle screenshot: ${file.absolutePath}"
+                }
+            }
+            println("TMUX_CONVERSATION_TOGGLE_SCREENSHOT ${file.absolutePath}")
+        } finally {
+            bitmap.recycle()
+        }
+    }
+
+    private companion object {
+        const val ROOT_TAG = "tmux:conv-toggle-present-root"
+        const val REFERENCE_CONVERSATION_TAG = "test:reference-conversation-segment"
+        const val SLOP_DP = 1f
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
@@ -6757,86 +6757,92 @@ internal fun ConsolidatedTopChrome(
         )
         Spacer(modifier = Modifier.width(8.dp))
 
-        // Issue #463: the tappable project/folder crumb. Opens a dropdown of
-        // this project's sibling sessions; selecting one warm-switches to it.
-        // Hidden entirely when we don't know the project; the chevron is
-        // hidden when there's nothing to switch to (single-session project).
-        if (projectLabel != null) {
-            ProjectSwitcherCrumb(
-                projectLabel = projectLabel,
-                switcher = projectSwitcher,
-                onOpen = onProjectSwitcherOpen,
-                onSwitchToSibling = onSwitchToSibling,
+        // Issue #1320: the LEADING yielding region — the ONLY part of the
+        // header that gives up width under pressure. It holds the project
+        // crumb, the title, and the connection-status pill, all wrapped in a
+        // single `weight(1f)` slot. Everything to its right (the
+        // Terminal/Conversation toggle and the kebab) is a NON-weighted sibling
+        // measured at its full intrinsic width FIRST, so the toggle can never be
+        // squeezed/clipped — it is a primary control and must always be fully
+        // visible + tappable.
+        //
+        // Why this shape (the 5×-recurrence root cause #962/#975/#1057/#1158):
+        // the toggle used to live INSIDE a `weight(1f, fill = false)` trailing
+        // slot that competed with the title's own `weight(1f)`. Two `weight(1f)`
+        // slots split the remaining width, so a long agent/session title (e.g.
+        // "pocketshell Claude Code") starved the toggle's slot and its
+        // "Conversation" segment ellipsised away — leaving only "Terminal" and
+        // no way to switch to the conversation view. Pulling the toggle OUT of
+        // the weighted slot and reserving it at intrinsic width fixes the clip
+        // at the layout level (not by adding another detection OR-term — the
+        // detection gate was never the cause of this report).
+        //
+        // Within this region the yield order is: the title (its own
+        // `weight(1f)` + ellipsis) shrinks FIRST; the crumb (capped ≤120dp,
+        // ellipsis) and the connection-status pill only clip under extreme
+        // pressure — both are acceptable to shrink, the toggle is not.
+        Row(
+            modifier = Modifier.weight(1f),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            // Issue #463: the tappable project/folder crumb. Opens a dropdown
+            // of this project's sibling sessions; selecting one warm-switches
+            // to it. Hidden entirely when we don't know the project; the
+            // chevron is hidden when there's nothing to switch to.
+            if (projectLabel != null) {
+                ProjectSwitcherCrumb(
+                    projectLabel = projectLabel,
+                    switcher = projectSwitcher,
+                    onOpen = onProjectSwitcherOpen,
+                    onSwitchToSibling = onSwitchToSibling,
+                )
+                Spacer(modifier = Modifier.width(6.dp))
+            }
+
+            // Issue #481: the title — the agent/model name when a conversation
+            // is detected (`claude-3-5-sonnet` in the mockup), otherwise the
+            // tmux session name. It takes the inner `weight(1f)` slot so it is
+            // the FIRST element to yield/ellipsise (issue #1320), keeping the
+            // crumb, pill, toggle, and kebab intact. The 8dp end padding keeps
+            // the name from butting straight against the pill/toggle.
+            val sessionLabelModifier = Modifier
+                .weight(1f)
+                .padding(end = 8.dp)
+                .testTag(TMUX_CONSOLIDATED_SESSION_LABEL_TAG)
+            Text(
+                text = agentName ?: sessionName,
+                color = PocketShellColors.Text,
+                fontSize = 15.sp,
+                fontWeight = FontWeight.SemiBold,
+                maxLines = 1,
+                overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+                modifier = sessionLabelModifier,
             )
-            Spacer(modifier = Modifier.width(6.dp))
+
+            // Issues #177 / #249: the compact "Reconnecting"/"Disconnected"
+            // pill. It sits at the right edge of the yielding region (adjacent
+            // to the toggle) so, under extreme width pressure, it clips AFTER
+            // the title but BEFORE the toggle (#1320 — the toggle never yields).
+            ConnectionStatusPill(connectionStatus)
         }
 
-        // Issue #481: the title — the agent/model name when a conversation
-        // is detected (`claude-3-5-sonnet` in the mockup), otherwise the
-        // tmux session name.
-        //
-        // Issue #637: the title takes the full weighted slot (`weight(1f)`,
-        // fill = true) so it consumes ALL remaining width and pushes the
-        // trailing control cluster flush against the right edge. This is what
-        // gives the kebab a CONSISTENT right-anchored position in both
-        // states — the previous `fill = false` left the title hugging its
-        // own text, so the kebab floated in the middle of the row next to a
-        // short name instead of sitting at the edge ("⋮ position looks off").
-        // Because the title is the only element that yields width, a long
-        // host/session name ellipsises inside this slot WITHOUT squeezing the
-        // toggle or pushing the kebab off screen. The 8dp end padding
-        // guarantees the name never butts straight against the trailing
-        // controls.
-        val sessionLabelModifier = Modifier
-            .weight(1f)
-            .padding(end = 8.dp)
-            .testTag(TMUX_CONSOLIDATED_SESSION_LABEL_TAG)
-        Text(
-            text = agentName ?: sessionName,
-            color = PocketShellColors.Text,
-            fontSize = 15.sp,
-            fontWeight = FontWeight.SemiBold,
-            maxLines = 1,
-            overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
-            modifier = sessionLabelModifier,
-        )
-
-        // Issue #637 / #747: the trailing controls. The SHRINKABLE middle group
-        // (connection-status pill + Terminal/Conversation toggle) sits in its
-        // OWN weighted slot — `weight(1f, fill = false)` — so it yields width
-        // before anything else, while the kebab is a FIXED 48dp sibling of the
-        // outer row that is laid out AFTER the weighted slots and so can never
-        // be displaced.
-        //
-        // Why this matters (#747): previously the whole trailing cluster was a
-        // single non-shrinking [Row]. When that cluster was wide (forwarding
-        // active -> agent present -> the wide "Terminal Conversation" toggle, a
-        // non-live "Disconnected"/"Reconnecting" pill, and a project crumb all
-        // competing for width), the cluster overflowed the 56dp row and Compose
-        // shoved its LAST child — the kebab — past the right edge. The
-        // maintainer saw the kebab "can't be selected" because it was
-        // off-screen. Putting the kebab outside the weighted slot reserves its
-        // 48dp unconditionally; the toggle's segment labels ellipsise (they are
-        // `maxLines = 1`) instead of pushing the kebab off-screen.
-        Row(
-            modifier = Modifier
-                .weight(1f, fill = false)
-                .padding(end = 4.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            ConnectionStatusPill(connectionStatus)
-
-            if (tabLabels.size > 1) {
-                TabsRowWithPulse(pulseVisible = pulseConversationTab) {
-                    ConsolidatedTabPill(
-                        labels = tabLabels,
-                        selectedIndex = selectedTabIndex,
-                        onSelected = onTabSelected,
-                        modifier = Modifier.testTag(TMUX_TABS_TAG),
-                    )
-                }
+        // Issue #1320: the Terminal/Conversation toggle — a PRIMARY control that
+        // must have GUARANTEED width. It is a NON-weighted sibling of the outer
+        // row rendered at its full intrinsic width, so it is measured before the
+        // weighted leading region gets the remainder and can never be
+        // clipped/ellipsised no matter how long the title is. The kebab stays a
+        // fixed 48dp sibling laid out after it (#747), so both survive.
+        if (tabLabels.size > 1) {
+            Spacer(modifier = Modifier.width(8.dp))
+            TabsRowWithPulse(pulseVisible = pulseConversationTab) {
+                ConsolidatedTabPill(
+                    labels = tabLabels,
+                    selectedIndex = selectedTabIndex,
+                    onSelected = onTabSelected,
+                    modifier = Modifier.testTag(TMUX_TABS_TAG),
+                )
             }
+            Spacer(modifier = Modifier.width(4.dp))
         }
 
         // The kebab — fixed 48dp, OUTSIDE every weighted slot, so it is always

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -1057,6 +1057,25 @@ JOURNEY_CLASSES=(
   # self-skip on CI (no assumeTrue / assumeFalse(isRunningOnCi()) on the
   # load-bearing assertion). It lives under com.pocketshell.app.tmux.
   "com.pocketshell.app.tmux.TmuxComposerLauncherNarrowFontClipProofTest"
+  # ADDED (#1320): the Terminal/Conversation TOGGLE-CLIP regression guard — the
+  # REAL (layout) cause behind the 5×-recurring "Conversation tab missing"
+  # (#962/#975/#1057/#1158). The toggle used to live in a `weight(1f, fill=false)`
+  # slot that split width 50/50 with the title's own `weight(1f)`, so a long
+  # agent title starved the toggle and its "Conversation" segment ellipsised away
+  # (detection had already fired — the header showed the agent name — so the prior
+  # detection-gate fixes never addressed this). This proof renders the PRODUCTION
+  # ConsolidatedTopChrome at a narrow phone width with a long title (+ status pill
+  # + long crumb + narrowest-width variants) and HARD-asserts the Conversation
+  # segment renders at its FULL intrinsic width (compared to a reference
+  # unconstrained SegmentedToggle — density-independent, no pixel threshold), not
+  # a bare assertIsDisplayed (a squeezed/ellipsised segment still reports
+  # displayed). RED on base (segment starved ~119px vs ~291px intrinsic); GREEN
+  # after the toggle is pulled OUT of the weighted slot and reserved at intrinsic
+  # width. Pure Compose-rule UI test — NO Docker fixture, NO SSH/tmux, NO
+  # toxiproxy, NO 2222/2226 port — so it needs no tests.yml service change, and it
+  # does NOT self-skip on CI (no assumeTrue / assumeFalse(isRunningOnCi())). It
+  # lives under com.pocketshell.app.tmux, so it carries its FQCN directly.
+  "com.pocketshell.app.tmux.TmuxChromeConversationTogglePresentTest"
   # ADDED (#859 Slice B): the typed-card RENDERER REGISTRY proof. The session
   # feed is now a generic typed-card list dispatched through
   # SessionCardRenderers (no `when (type)` in the feed). This connected Compose


### PR DESCRIPTION
Closes #1320. The real (layout) cause behind the 5x 'Conversation tab missing' recurrence (#962/#975/#1057/#1158) + reopened #1158.

The toggle was in a yielding weighted slot; a long agent title clipped the 'Conversation' segment. Now the toggle gets guaranteed intrinsic width; only the title ellipsises. **Layout-only — no detection-gate change (D22).**

Reviewer APPROVED with the maintainer's mandatory gate satisfied: full-device Pixel-class emulator screenshots of the long-title chrome showing the full Terminal | Conversation toggle attached to the issue, base-red reproduces the exact clip, reviewer-run red->green on emulator, tap-to-switch confirmed on the live-agent Docker journey. New `TmuxChromeConversationTogglePresentTest` wired into the iterated journey gate.