### PR TITLE
tmux: one coherent render per connection state — Slice 1 of the state-machine consolidation (#1322)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxConnectingStatesScreenshotTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxConnectingStatesScreenshotTest.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -359,13 +360,21 @@ class TmuxConnectingStatesScreenshotTest {
     }
 
     @Test
-    fun captureDisconnectedSurfaceNoSpinner() {
-        // DISCONNECTED / idle state: there is NO active reconnect, so the surface
-        // shows the calm [FailedConnectionRow] "Tap to reconnect" affordance and
-        // NO animated spinner (a spinner would falsely imply work in flight). The
-        // pull wrapper runs with `isReconnecting = false`, so its box spinner is
-        // also off. Assert ZERO indeterminate-progress nodes so a regression that
-        // re-introduces a spinner in the idle disconnected state is caught.
+    fun captureFailedStateSingleReconnectControlNoSpinner_screenshotA() {
+        // Issue #1322 (coordinator screenshot A): the Failed/Disconnected state must
+        // render EXACTLY ONE reconnect affordance — the calm [FailedConnectionRow]
+        // "Tap to reconnect" band — and NO animated spinner. The maintainer's
+        // screenshot showed TWO reconnect controls at once (the band link AND the
+        // bottom surface "Reconnect" button) plus an "Attaching…" spinner.
+        //
+        // This mounts the REAL production composition with `showReconnectButton`
+        // driven by the REAL [surfaceReconnectButtonVisible] gate for a `Failed`
+        // status. RED on base: the #890 gate did not exclude `Failed`, so the bottom
+        // [TMUX_SURFACE_RECONNECT_BUTTON_TAG] button rendered on top of the band →
+        // TWO reconnect controls (the assertCountEquals(0) below fails).
+        val failed = TmuxSessionViewModel.ConnectionStatus.Failed(
+            "Connection lost. Tap Reconnect to retry.",
+        )
         compose.setContent {
             PocketShellTheme {
                 Column(
@@ -381,7 +390,7 @@ class TmuxConnectingStatesScreenshotTest {
                         onMore = {},
                     )
                     FailedConnectionRow(
-                        message = "Connection lost — tap to reconnect",
+                        message = failed.message,
                         onReconnect = {},
                         canReconnect = true,
                     )
@@ -394,6 +403,9 @@ class TmuxConnectingStatesScreenshotTest {
                             pullToReconnectActive = true,
                             isReconnecting = false,
                             onReconnect = {},
+                            // The REAL gate — false for Failed (the band owns the
+                            // single affordance), so the bottom button is suppressed.
+                            showReconnectButton = surfaceReconnectButtonVisible(failed),
                         ) {
                             Box(
                                 modifier = Modifier
@@ -408,15 +420,210 @@ class TmuxConnectingStatesScreenshotTest {
                 }
             }
         }
+        // The band's "Tap to reconnect" is the SOLE reconnect affordance.
         compose.onNodeWithText("Tap to reconnect").assertExists()
+        compose
+            .onAllNodesWithTag(TMUX_SESSION_RECONNECT_TAG, useUnmergedTree = true)
+            .assertCountEquals(1)
+        // The DUPLICATE bottom surface "Reconnect" button MUST be gone (screenshot A).
+        compose
+            .onAllNodesWithTag(TMUX_SURFACE_RECONNECT_BUTTON_TAG, useUnmergedTree = true)
+            .assertCountEquals(0)
         compose
             .onAllNodesWithTag(TMUX_PULL_TO_RECONNECT_TAG, useUnmergedTree = true)
             .assertCountEquals(1)
         compose.waitForIdle()
-        // ZERO animated indicators — the idle disconnected state must not spin.
+        // ZERO animated indicators — the settled Failed state must not spin.
         assertIndeterminateIndicatorCount(0)
         SystemClock.sleep(300)
-        captureFullDevice(File(artifactDir(), "tmux-disconnected-no-spinner.png"))
+        captureFullDevice(File(artifactDir(), "tmux-failed-single-reconnect-control.png"))
+    }
+
+    @Test
+    fun captureHardRevealFailureCalmPlaceholderNoAttaching_1321Repro() {
+        // Issue #1322 (defect A / the #1321 screenshot): a past-grace transport drop
+        // yields RevealState.Error(retrying=false) → the terminal is held, but the
+        // surface must paint the CALM [RevealFailurePlaceholder] (no spinner), NEVER
+        // the centered "Attaching…" hold. RED on base: every non-Live reveal
+        // collapsed to the "Attaching…" [SwitchingLoadingPlaceholder] — the spinner
+        // that contradicted the "Disconnected" pill + "Tap to reconnect" band.
+        val failed = TmuxSessionViewModel.ConnectionStatus.Failed(
+            "Connection lost. Tap Reconnect to retry.",
+        )
+        compose.setContent {
+            PocketShellTheme {
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(PocketShellColors.Background)
+                        .padding(top = 24.dp)
+                        .testTag(SCREENSHOT_ROOT_TAG),
+                ) {
+                    ConsolidatedTopChrome(
+                        sessionName = "claude-main",
+                        onBack = {},
+                        onMore = {},
+                    )
+                    FailedConnectionRow(
+                        message = failed.message,
+                        onReconnect = {},
+                        canReconnect = true,
+                    )
+                    Box(
+                        modifier = Modifier
+                            .weight(1f)
+                            .fillMaxWidth(),
+                    ) {
+                        SessionSurfaceReconnectWrapper(
+                            pullToReconnectActive = true,
+                            isReconnecting = false,
+                            onReconnect = {},
+                            showReconnectButton = surfaceReconnectButtonVisible(failed),
+                            // The surface centered loader flag driven by the REAL
+                            // decision: a settled hard failure is NOT a loader.
+                            surfaceShowsCenteredLoader = surfaceShowsCenteredLoader(
+                                effectiveHidesTerminal = true,
+                                revealHardFailure = true,
+                                status = failed,
+                                panesEmpty = true,
+                            ),
+                        ) {
+                            // The REAL surface branch decision: a hard reveal failure
+                            // paints the calm placeholder, NEVER "Attaching…".
+                            if (surfaceShowsCalmFailure(
+                                    effectiveHidesTerminal = true,
+                                    revealHardFailure = true,
+                                    status = failed,
+                                )
+                            ) {
+                                RevealFailurePlaceholder()
+                            } else {
+                                SwitchingLoadingPlaceholder()
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        // The calm failure placeholder is shown; the "Attaching…" hold is NOT.
+        compose
+            .onAllNodesWithTag(TMUX_REVEAL_FAILURE_TAG, useUnmergedTree = true)
+            .assertCountEquals(1)
+        compose
+            .onAllNodesWithTag(TMUX_SWITCHING_LOADING_TAG, useUnmergedTree = true)
+            .assertCountEquals(0)
+        // Exactly ONE reconnect control (the band) and ZERO spinners.
+        compose
+            .onAllNodesWithTag(TMUX_SESSION_RECONNECT_TAG, useUnmergedTree = true)
+            .assertCountEquals(1)
+        compose
+            .onAllNodesWithTag(TMUX_SURFACE_RECONNECT_BUTTON_TAG, useUnmergedTree = true)
+            .assertCountEquals(0)
+        compose.waitForIdle()
+        assertIndeterminateIndicatorCount(0)
+        SystemClock.sleep(300)
+        captureFullDevice(File(artifactDir(), "tmux-hard-reveal-failure-calm-placeholder.png"))
+    }
+
+    @Test
+    fun captureReconnectingWaitingForPanesSingleIndicator_screenshotB() {
+        // Issue #1322 (coordinator screenshot B, #750 regression): a Reconnecting
+        // state where the reveal is live (`effectiveHidesTerminal == false`) but no
+        // panes have arrived yet stacked THREE indicators — the top
+        // [ReconnectingProgressRow] bar, the centered "waiting for tmux panes…" ring,
+        // and the pull box spinner. The waiting ring is the SOLE loader, so the top
+        // banner AND the box spinner are suppressed via the REAL broadened
+        // [surfaceOwnsPrimaryIndicator] / [surfaceShowsCenteredLoader] gates. RED on
+        // base: surfaceShowsCenteredLoader only counted `effectiveHidesTerminal`, so
+        // all three fired → 3 indeterminate nodes.
+        val reconnecting = TmuxSessionViewModel.ConnectionStatus.Reconnecting(
+            host = "hetzner.example",
+            port = 22,
+            user = "alex",
+            attempt = 2,
+            maxAttempts = 3,
+            retryDelayMs = 4_000L,
+            reason = "Reconnecting…",
+        )
+        val ownsPrimary = surfaceOwnsPrimaryIndicator(
+            effectiveHidesTerminal = false,
+            revealHardFailure = false,
+            status = reconnecting,
+            panesEmpty = true,
+        )
+        val centeredLoader = surfaceShowsCenteredLoader(
+            effectiveHidesTerminal = false,
+            revealHardFailure = false,
+            status = reconnecting,
+            panesEmpty = true,
+        )
+        compose.setContent {
+            PocketShellTheme {
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(PocketShellColors.Background)
+                        .padding(top = 24.dp)
+                        .testTag(SCREENSHOT_ROOT_TAG),
+                ) {
+                    ConsolidatedTopChrome(
+                        sessionName = "claude-main",
+                        onBack = {},
+                        onMore = {},
+                    )
+                    // The REAL top-banner render site, driven by the broadened gate —
+                    // suppressed because the surface owns the waiting ring.
+                    TmuxTopConnectingBanner(
+                        status = reconnecting,
+                        effectiveHidesTerminal = ownsPrimary,
+                        sessionName = "claude-main",
+                        onCancelConnect = {},
+                        onRetryNow = {},
+                    )
+                    Box(
+                        modifier = Modifier
+                            .weight(1f)
+                            .fillMaxWidth(),
+                    ) {
+                        SessionSurfaceReconnectWrapper(
+                            pullToReconnectActive = true,
+                            isReconnecting = true,
+                            onReconnect = {},
+                            // The box spinner is suppressed because the surface shows
+                            // the waiting ring (the broadened #1322 flag).
+                            surfaceShowsCenteredLoader = centeredLoader,
+                            showReconnectButton = surfaceReconnectButtonVisible(reconnecting),
+                        ) {
+                            // The "waiting for tmux panes…" ring (EmptyPanesPlaceholder
+                            // body) — the SOLE loader for this state.
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .background(color = PocketShellColors.Surface),
+                                contentAlignment = Alignment.Center,
+                            ) {
+                                LoadingIndicator.Spinner(
+                                    size = SpinnerSize.Medium,
+                                    label = "waiting for tmux panes…",
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        compose.onNodeWithText("waiting for tmux panes…").assertExists()
+        // The top Reconnecting band must be suppressed (no "Retry now" line stacked).
+        compose.onAllNodesWithText("Retry now").assertCountEquals(0)
+        compose
+            .onAllNodesWithTag(TMUX_PULL_TO_RECONNECT_TAG, useUnmergedTree = true)
+            .assertCountEquals(1)
+        compose.waitForIdle()
+        // EXACTLY ONE animated indicator: the centered "waiting for tmux panes…"
+        // ring. Pre-fix the top bar + box spinner stacked two more → count 3.
+        assertIndeterminateIndicatorCount(1)
+        SystemClock.sleep(300)
+        captureFullDevice(File(artifactDir(), "tmux-reconnecting-waiting-single-indicator.png"))
     }
 
     /**

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
@@ -436,6 +436,41 @@ public fun TmuxSessionScreen(
     val revealHoldsTerminal =
         !(revealState is RevealState.Live && revealState.targetIdOrNull() == targetSessionId)
     val effectiveHidesTerminal = revealHoldsTerminal
+    // Issue #1322: a HARD reveal failure (target Gone, or an Error whose retry is
+    // exhausted) must render DISTINCTLY from the "Attaching…" hold. The surface
+    // paints the calm failed placeholder (not the spinner), and both top loading
+    // banners are suppressed, so the pill + surface + "Tap to reconnect" band all
+    // agree — killing the #1321 "Disconnected pill + Attaching spinner + raw
+    // exception" contradiction.
+    val revealHardFailure = revealIsHardFailure(revealState)
+    // Issue #1322 (coordinator scope-expansion, screenshots A/B): make EVERY
+    // non-live state render exactly ONE coherent primary indicator, computed once
+    // here and threaded to the surface, the top banner, and the pull box so they
+    // can never stack.
+    //
+    // The surface's own centered region is the primary indicator in two shapes:
+    //  - a CALM FAILURE placeholder ([RevealFailurePlaceholder]) — a hard reveal
+    //    failure OR a settled [ConnectionStatus.Failed] while the terminal is held.
+    //    It carries NO spinner (screenshot A: no "Attaching…" over Disconnected),
+    //    and the "Tap to reconnect" band owns the single reconnect affordance.
+    //  - a centered LOADER spinner — the "Attaching…" hold
+    //    ([SwitchingLoadingPlaceholder], while the terminal is held) OR the
+    //    "waiting for tmux panes…" ring ([EmptyPanesPlaceholder], when the reveal
+    //    is live but no panes have arrived yet). EITHER is the SOLE loader, so the
+    //    top connecting/reconnecting banner and the pull box spinner must both be
+    //    suppressed (screenshot B: the #750 Reconnecting 2-3-spinner stack).
+    val panesEmpty = unifiedPanes.isEmpty()
+    val surfaceCalmFailure =
+        surfaceShowsCalmFailure(effectiveHidesTerminal, revealHardFailure, status)
+    val surfaceCenteredLoader =
+        surfaceShowsCenteredLoader(effectiveHidesTerminal, revealHardFailure, status, panesEmpty)
+    // The single "the surface owns the primary indicator; the top banner + box
+    // spinner are the redundant duplicates" gate. Passed as the reducer's
+    // `effectiveHidesTerminal` input so a live-frame-kept Connecting/Reconnecting
+    // edge (surface shows NEITHER a loader nor a failure) still keeps its top
+    // banner as the sole indicator.
+    val surfaceOwnsPrimary =
+        surfaceOwnsPrimaryIndicator(effectiveHidesTerminal, revealHardFailure, status, panesEmpty)
     // Issue #487: active-forwarding state for the host this session belongs
     // to. `remember(hostId)` re-subscribes if the screen is reused for a
     // different host. Drives the in-session forwarding chip in the chrome.
@@ -1775,7 +1810,14 @@ public fun TmuxSessionScreen(
             // [TmuxTopConnectingBanner] for the per-banner rationale.
             TmuxTopConnectingBanner(
                 status = status,
-                effectiveHidesTerminal = effectiveHidesTerminal,
+                // Issue #1322: suppress the top banner whenever the surface owns the
+                // primary indicator — the "Attaching…" hold, the "waiting for tmux
+                // panes…" ring, OR the calm failure placeholder. The banner renders
+                // ONLY in the live-frame-kept Connecting/Reconnecting edge where the
+                // surface shows none of those, so a state is never left with zero
+                // indicators. This is the broadened #750 gate that kills the
+                // Reconnecting 2-3-spinner stack (screenshot B).
+                effectiveHidesTerminal = surfaceOwnsPrimary,
                 sessionName = sessionName,
                 onCancelConnect = { viewModel.cancelConnect() },
                 onRetryNow = { viewModel.reconnect() },
@@ -1947,18 +1989,19 @@ public fun TmuxSessionScreen(
             // guard. Breaking the wedge is connection-core logic owned by epic
             // #792 (Slice 2); this slice deliberately does not touch it.
             val pullToReconnectActive = !sessionLive && canReconnect
-            // Issue #750 (3rd occurrence): during the attach/reattach hold the
-            // surface content paints the centered "Attaching…"
-            // [SwitchingLoadingPlaceholder] (driven by `effectiveHidesTerminal`).
-            // That centered spinner is the SOLE indicator for this state, so the
-            // pull-to-reconnect wrapper below must NOT also run its own
-            // [PullToRefreshBox] spinner on top of it (the maintainer's reported
-            // cyan ring + gray spinner-in-a-chip stacked over "Attaching…"). The
-            // pull GESTURE stays mounted — only the duplicate box spinner is
-            // suppressed — so #823's pull-to-reconnect is preserved, and the box
-            // spinner returns as the SOLE affordance once the surface settles
-            // into a steady non-loader state (no centered "Attaching…").
-            val surfaceShowsCenteredLoader = effectiveHidesTerminal
+            // Issue #750 (3rd occurrence) / #1322 (screenshot B): the surface
+            // content paints the centered loader in TWO shapes — the "Attaching…"
+            // [SwitchingLoadingPlaceholder] while the terminal is held, and the
+            // "waiting for tmux panes…" [EmptyPanesPlaceholder] ring when the reveal
+            // is live but no panes have arrived yet. EITHER is the SOLE indicator for
+            // its state, so the pull-to-reconnect wrapper below must NOT also run its
+            // own [PullToRefreshBox] spinner on top of it (the maintainer's reported
+            // cyan ring + gray spinner-in-a-chip). The pull GESTURE stays mounted —
+            // only the duplicate box spinner is suppressed — so #823's
+            // pull-to-reconnect is preserved. [surfaceShowsCenteredLoader] is
+            // computed once at the top of the screen (broadened for #1322 to cover
+            // the waiting-for-panes ring, and false for the calm failure placeholder
+            // which carries no spinner).
             // The surface content (terminal pager / conversation / placeholders)
             // is captured once so it can render either inside the pull-to-reconnect
             // wrapper (not live) or bare (live) without duplicating the tree.
@@ -2033,7 +2076,18 @@ public fun TmuxSessionScreen(
                 // `!= null` guards below are for the compiler's smart-cast).
                 val visibleConversation =
                     surfaceConversationPaneId?.let { agentConversationsState.value[it] }
-                if (effectiveHidesTerminal) {
+                if (surfaceCalmFailure) {
+                    // Issue #1322: the terminal is held AND the connection has
+                    // SETTLED into a failure — a HARD reveal failure (target Gone, or
+                    // an Error whose retry is exhausted) OR a [ConnectionStatus.Failed]
+                    // status. Painting the centered "Attaching…" spinner over a dead
+                    // session is the #1321/#1320-screenshot-A desync (a spinner that
+                    // will never resolve, contradicting the "Disconnected" pill and
+                    // the "Tap to reconnect" band). Render the calm failed placeholder
+                    // instead — NO spinner — so the surface AGREES with the pill and
+                    // the single [FailedConnectionRow] band above.
+                    RevealFailurePlaceholder()
+                } else if (effectiveHidesTerminal) {
                     // Issue #661 / EPIC #687 P1: a cross-session switch is in flight —
                     // never paint the leaving session's terminal (or its agent
                     // conversation). Show a compact "Attaching" loading state until
@@ -2267,23 +2321,26 @@ public fun TmuxSessionScreen(
                     onReconnect = { viewModel.reconnect() },
                     // Issue #750: suppress the box's own spinner while the surface
                     // already shows the centered "Attaching…" hold — one indicator.
-                    surfaceShowsCenteredLoader = surfaceShowsCenteredLoader,
+                    surfaceShowsCenteredLoader = surfaceCenteredLoader,
                     // Issue #890: the visible "Reconnect" button shows ONLY once the
-                    // connect/attach has SETTLED into a failed/dropped/stuck state —
-                    // never WHILE a connect/reconnect/attach is in progress (the
+                    // connect/attach has SETTLED into a dropped/stuck state — never
+                    // WHILE a connect/reconnect/attach is in progress (the
                     // maintainer's "no reconnect button while I'm connecting"). The
                     // in-progress states (`Connecting` / `Switching`(=Attaching) /
                     // `Reconnecting`) already drive the progress bar + "Attaching…/
-                    // Reconnecting…" indicator, so the system is plainly already
-                    // trying; the button would be redundant chrome. We show it on
-                    // the remaining non-Connected states — `Failed` (honest error)
-                    // and `Idle` (dropped/never-attached, with a `canReconnect`
-                    // target) — exactly where a manual retry is meaningful. (This
-                    // stays compatible with #886's planned `RevealState.Error`
-                    // stuck-attach band, which projects to `Failed` here.)
-                    showReconnectButton = status !is ConnectionStatus.Connecting &&
-                        status !is ConnectionStatus.Switching &&
-                        status !is ConnectionStatus.Reconnecting,
+                    // Reconnecting…" indicator, so the button would be redundant.
+                    //
+                    // Issue #1322 (screenshot A): the button is ALSO suppressed on a
+                    // `Failed` status, because the calm [FailedConnectionRow] "Tap to
+                    // reconnect" band (rendered above when the status is `Failed`)
+                    // already offers the SINGLE reconnect affordance. Showing both the
+                    // band link AND this bottom button is the "TWO reconnect controls
+                    // at once" duplicate the maintainer reported (a regression of
+                    // #720's single tappable "Tap to reconnect"). This leaves the
+                    // bottom button as the SOLE affordance ONLY on the remaining
+                    // `Idle` (dropped/never-attached, with a `canReconnect` target)
+                    // state, which has no band.
+                    showReconnectButton = surfaceReconnectButtonVisible(status),
                     content = surfaceContent,
                 )
             }
@@ -4239,7 +4296,19 @@ internal enum class PrimaryLoadingSurface {
 internal fun primaryLoadingSurface(
     status: ConnectionStatus,
     effectiveHidesTerminal: Boolean,
+    revealHardFailure: Boolean = false,
 ): PrimaryLoadingSurface = when {
+    // Issue #1322: a HARD reveal failure (target Gone, or an Error whose retry is
+    // exhausted) is NOT a loading state. It must render DISTINCTLY from the
+    // "Attaching…" hold — never a spinner over a dead session, and never a top
+    // connecting/reconnecting banner. The surface paints the calm failed
+    // placeholder and the pill + "Tap to reconnect" [FailedConnectionRow] band own
+    // this state, so all three agree (killing the #1321 "Disconnected pill +
+    // Attaching spinner + raw exception" contradiction). This wins over the
+    // terminal-held branch below because [effectiveHidesTerminal] is ALSO true for
+    // a hard failure (the reveal is not Live) — which is exactly what used to
+    // collapse the honest error into "Attaching…".
+    revealHardFailure -> PrimaryLoadingSurface.None
     // The terminal is held → the surface paints the centered "Attaching…" hold,
     // which is the canonical SOLE loader. Both top banners are suppressed so the
     // maintainer never sees the top connecting banner AND the centered spinner at
@@ -4249,6 +4318,108 @@ internal fun primaryLoadingSurface(
     status is ConnectionStatus.Reconnecting -> PrimaryLoadingSurface.ReconnectingBand
     else -> PrimaryLoadingSurface.None
 }
+
+/**
+ * Issue #1322: whether the id-keyed [RevealState] is a HARD reveal failure that
+ * must render DISTINCTLY from the "Attaching…"/Seeding hold.
+ *
+ * The #1321 screenshot showed the honest failure state ([RevealState.Error] after
+ * a past-grace transport drop) painted as the centered "Attaching…" spinner,
+ * because [effectiveHidesTerminal] special-cased ONLY [RevealState.Live] — every
+ * other reveal, including a dead-session error, collapsed to the same loading
+ * hold. That desynced the surface from the "Disconnected" pill and the "Tap to
+ * reconnect" band.
+ *
+ *  - [RevealState.Gone] — the target session was deleted elsewhere (#666). There
+ *    is nothing to attach to; a spinner would lie.
+ *  - [RevealState.Error] with `retrying == false` — the control channel dropped
+ *    and retry is EXHAUSTED (the honest error per the [RevealState.Error] doc).
+ *    This is the maintainer's exact reported state.
+ *
+ * [RevealState.Error] while `retrying == true` is the calm healing/"reconnecting"
+ * window — NOT a hard failure — so it keeps its reconnecting hold and is excluded
+ * here. Pure so it is a unit-testable predicate (G9).
+ */
+internal fun revealIsHardFailure(revealState: RevealState): Boolean = when (revealState) {
+    is RevealState.Gone -> true
+    is RevealState.Error -> !revealState.retrying
+    else -> false
+}
+
+/**
+ * Issue #1322 (screenshots A/B): whether the session surface paints the CALM
+ * FAILURE placeholder ([RevealFailurePlaceholder]) in place of the terminal.
+ *
+ * True when the terminal is held ([effectiveHidesTerminal]) AND the connection has
+ * SETTLED into a failure — a hard reveal failure ([revealHardFailure]) OR a
+ * [ConnectionStatus.Failed] status. The placeholder carries NO spinner, so the
+ * "Attaching…" hold is never painted over a dead session (killing the #1321
+ * "Disconnected pill + Attaching spinner" contradiction and screenshot A's
+ * spinner-over-Disconnected). Pure so it is unit-testable (G9).
+ */
+internal fun surfaceShowsCalmFailure(
+    effectiveHidesTerminal: Boolean,
+    revealHardFailure: Boolean,
+    status: ConnectionStatus,
+): Boolean =
+    effectiveHidesTerminal && (revealHardFailure || status is ConnectionStatus.Failed)
+
+/**
+ * Issue #750 / #1322 (screenshot B): whether the session surface paints a centered
+ * LOADER spinner — the "Attaching…" [SwitchingLoadingPlaceholder] hold (terminal
+ * held) OR the "waiting for tmux panes…" [EmptyPanesPlaceholder] ring (reveal live
+ * but no panes yet, [panesEmpty]).
+ *
+ * A settled failure ([surfaceShowsCalmFailure]) is NOT a loader (no spinner). This
+ * is the SOLE loader for its state, so the top connecting/reconnecting banner and
+ * the pull box spinner must both be suppressed — the fix for the Reconnecting
+ * 2-3-spinner stack (top bar + waiting ring + gray chip). Pure (G9).
+ */
+internal fun surfaceShowsCenteredLoader(
+    effectiveHidesTerminal: Boolean,
+    revealHardFailure: Boolean,
+    status: ConnectionStatus,
+    panesEmpty: Boolean,
+): Boolean =
+    !surfaceShowsCalmFailure(effectiveHidesTerminal, revealHardFailure, status) &&
+        (effectiveHidesTerminal || panesEmpty)
+
+/**
+ * Issue #1322: the single "the surface owns the primary indicator, so the top
+ * banner + pull box spinner are the redundant duplicates" gate. True whenever the
+ * surface paints either a centered loader OR the calm failure placeholder; false
+ * only in the live-frame-kept Connecting/Reconnecting edge (surface shows a live
+ * terminal), where the top banner is the SOLE indicator. Pure (G9).
+ */
+internal fun surfaceOwnsPrimaryIndicator(
+    effectiveHidesTerminal: Boolean,
+    revealHardFailure: Boolean,
+    status: ConnectionStatus,
+    panesEmpty: Boolean,
+): Boolean =
+    surfaceShowsCalmFailure(effectiveHidesTerminal, revealHardFailure, status) ||
+        surfaceShowsCenteredLoader(effectiveHidesTerminal, revealHardFailure, status, panesEmpty)
+
+/**
+ * Issue #890 / #1322 (screenshot A): whether the VISIBLE bottom "Reconnect" button
+ * ([SessionSurfaceReconnectWrapper]) is shown for this status.
+ *
+ *  - #890: hidden WHILE a connect/attach/reconnect is in progress
+ *    (`Connecting`/`Switching`/`Reconnecting`) — the progress indicator already
+ *    shows the system is trying, so the button would be redundant chrome.
+ *  - #1322: ALSO hidden on `Failed` — the calm [FailedConnectionRow] "Tap to
+ *    reconnect" band already offers the SINGLE reconnect affordance for that
+ *    state, so showing this button too is the "TWO reconnect controls at once"
+ *    duplicate (a regression of #720's single tappable "Tap to reconnect").
+ *
+ * It therefore renders as the SOLE affordance only on the remaining `Idle`
+ * (dropped/never-attached) state, which has no band. Pure (G9).
+ */
+internal fun surfaceReconnectButtonVisible(status: ConnectionStatus): Boolean =
+    status !is ConnectionStatus.Connecting &&
+        status !is ConnectionStatus.Switching &&
+        status !is ConnectionStatus.Reconnecting &&
+        status !is ConnectionStatus.Failed
 
 /**
  * Issue #750: the single-indicator gate for the top under-header
@@ -4263,8 +4434,10 @@ internal fun primaryLoadingSurface(
 internal fun shouldShowConnectingProgressOverlay(
     status: ConnectionStatus,
     effectiveHidesTerminal: Boolean,
+    revealHardFailure: Boolean = false,
 ): Boolean =
-    primaryLoadingSurface(status, effectiveHidesTerminal) == PrimaryLoadingSurface.ConnectingBanner
+    primaryLoadingSurface(status, effectiveHidesTerminal, revealHardFailure) ==
+        PrimaryLoadingSurface.ConnectingBanner
 
 /**
  * Issue #750: the single-indicator gate for the top under-header
@@ -4289,8 +4462,10 @@ internal fun shouldShowConnectingProgressOverlay(
 internal fun shouldShowReconnectingProgressRow(
     status: ConnectionStatus,
     effectiveHidesTerminal: Boolean,
+    revealHardFailure: Boolean = false,
 ): Boolean =
-    primaryLoadingSurface(status, effectiveHidesTerminal) == PrimaryLoadingSurface.ReconnectingBand
+    primaryLoadingSurface(status, effectiveHidesTerminal, revealHardFailure) ==
+        PrimaryLoadingSurface.ReconnectingBand
 
 /**
  * Issue #463: the short leaf label for the header project crumb, derived
@@ -4864,6 +5039,14 @@ internal const val TMUX_RECONNECTING_RETRY_NOW_TAG = "tmux:session:reconnecting:
 // content is never painted while the new session attaches.
 internal const val TMUX_SWITCHING_LOADING_TAG = "tmux:session:switching-loading"
 
+// Issue #1322: the full-surface CALM failed placeholder shown in place of the
+// terminal on a HARD reveal failure (target Gone / retry-exhausted Error). It
+// renders DISTINCTLY from the "Attaching…" hold — no spinner over a dead session
+// — so the surface agrees with the "Disconnected" pill and the "Tap to
+// reconnect" [FailedConnectionRow] band. The test tag lets the #1321 regression
+// test assert the surface resolved to this state, not the Attaching spinner.
+internal const val TMUX_REVEAL_FAILURE_TAG = "tmux:session:reveal-failure"
+
 /**
  * Issue #165: timings for the SSH-handshake progress overlay. A
  * 2-5s handshake is the common case the audit flagged as "feels
@@ -4950,6 +5133,10 @@ private fun StatusLine(text: String) {
 @Composable
 internal fun TmuxTopConnectingBanner(
     status: ConnectionStatus,
+    // Issue #1322: the caller passes the broadened "surface owns the primary
+    // indicator" gate here — true for the "Attaching…" hold, the "waiting for tmux
+    // panes…" ring, AND the calm failure placeholder — so the top banner is
+    // suppressed in ALL of them (never stacked over a surface loader/failure).
     effectiveHidesTerminal: Boolean,
     sessionName: String,
     onCancelConnect: () -> Unit,
@@ -5429,6 +5616,45 @@ internal fun SwitchingLoadingPlaceholder() {
         LoadingIndicator.Spinner(
             size = SpinnerSize.Medium,
             label = "Attaching…",
+        )
+    }
+}
+
+/**
+ * Issue #1322: the full-surface CALM failed placeholder shown in place of the
+ * terminal when the id-keyed reveal is a HARD failure ([revealIsHardFailure] —
+ * target [RevealState.Gone], or a retry-exhausted [RevealState.Error]).
+ *
+ * The #1321 screenshot showed the honest failure state painted as the centered
+ * "Attaching…" spinner because [effectiveHidesTerminal] special-cased ONLY
+ * [RevealState.Live] (every other reveal collapsed to the same loading hold). A
+ * spinner over a dead session is a lie — it will never resolve — and it desynced
+ * the surface from the "Disconnected" pill and the "Tap to reconnect" band.
+ *
+ * This placeholder renders DISTINCTLY from [SwitchingLoadingPlaceholder]: NO
+ * spinner, a calm muted line that points at the tappable [FailedConnectionRow]
+ * band above. The surface, the pill, and the error band now agree for the failure
+ * state. Deliberately does not itself carry a Reconnect button — the
+ * [FailedConnectionRow] band (rendered above when the status is `Failed`) owns the
+ * single, calm reconnect affordance.
+ */
+@Composable
+internal fun RevealFailurePlaceholder() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(color = PocketShellColors.Background)
+            .testTag(TMUX_REVEAL_FAILURE_TAG),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            // #720/#1322: a calm, honest prompt — the muted secondary token, NOT the
+            // alarming error band and NOT a spinner. The recovery affordance is the
+            // "Tap to reconnect" band above.
+            text = "Disconnected — tap to reconnect above.",
+            color = PocketShellColors.TextSecondary,
+            fontSize = 14.sp,
+            modifier = Modifier.padding(horizontal = 24.dp),
         )
     }
 }

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -7867,7 +7867,18 @@ public class TmuxSessionViewModel @Inject constructor(
             val message = t.message ?: "Timed out waiting for tmux panes from ${target.sessionName}."
             if ("Tap Reconnect" in message) message else "$message Tap Reconnect to retry."
         } else {
-            "error: ${t.javaClass.simpleName}: ${t.message}"
+            // Issue #1322: curate the GENERAL connect-failure case. Every non-attach
+            // throwable used to be stored verbatim as `error: <Class>: <message>` and
+            // rendered RAW by [FailedConnectionRow] — the #1321 screenshot leaked the
+            // literal `TmuxClientException: failed to preflight tmux has-session ...
+            // transport is closed` (a closed-transport / has-session preflight failure
+            // originating in `TmuxClient`). A closed-transport drop is exactly the
+            // calm, recoverable [ConnectionStatus.Failed] state the "Tap Reconnect"
+            // band exists for, so fold it into a clean, calm user-facing prompt —
+            // NEVER raw exception text. The raw cause is still available in the
+            // diagnostic logs; the UI stays calm and consistent with the
+            // Reconnecting/Failed surface.
+            "Connection lost. Tap Reconnect to retry."
         }
 
     private fun shortAppSwitchReconnectFields(

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionOpenFailedReconnectTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionOpenFailedReconnectTest.kt
@@ -130,10 +130,14 @@ class TmuxSessionOpenFailedReconnectTest {
             "first connect should surface the open-failed error, got $failed",
             failed is TmuxSessionViewModel.ConnectionStatus.Failed,
         )
-        assertTrue(
-            "the failure message should reflect the open-failed cause, was " +
+        // Issue #1322: the user-facing failure message is now the CURATED calm
+        // prompt, NEVER the raw `error: TmuxClientException: ... open failed` text.
+        // (The recovery behaviour below is what this test actually pins.)
+        assertEquals(
+            "the failure message must be the curated calm prompt, was " +
                 (failed as TmuxSessionViewModel.ConnectionStatus.Failed).message,
-            failed.message.contains("open failed"),
+            "Connection lost. Tap Reconnect to retry.",
+            failed.message,
         )
         assertEquals("only the poisoned transport should have been opened so far", 1, connector.connectCount)
         assertTrue("Reconnect must remain available after an open-failed error", vm.canReconnect.value)
@@ -201,6 +205,11 @@ class TmuxSessionOpenFailedReconnectTest {
             "first connect should surface the command timeout, got $failed",
             failed is TmuxSessionViewModel.ConnectionStatus.Failed,
         )
+        // NOTE (#1322): a command timeout during pane-reconcile is wrapped in
+        // [TmuxAttachPanesReadyException] — the already-curated branch of
+        // `connectFailureMessage`, unchanged by #1322 (which curated only the GENERAL
+        // else-branch). Its message stays the descriptive "Failed waiting for tmux
+        // panes … Tap Reconnect to retry." (no raw `error: <Class>:` prefix).
         assertTrue(
             "the failure message should reflect the timeout cause, was " +
                 (failed as TmuxSessionViewModel.ConnectionStatus.Failed).message,
@@ -267,6 +276,10 @@ class TmuxSessionOpenFailedReconnectTest {
             "first connect should surface the list-panes EOF write, got $failed",
             failed is TmuxSessionViewModel.ConnectionStatus.Failed,
         )
+        // NOTE (#1322): a list-panes EOF write during pane-reconcile is wrapped in
+        // [TmuxAttachPanesReadyException] — the already-curated branch, unchanged by
+        // #1322. Its message stays the descriptive "Failed waiting for tmux panes …
+        // Tap Reconnect to retry." (no raw `error: <Class>:` prefix).
         assertTrue(
             "the failure message should mention EOF, was " +
                 (failed as TmuxSessionViewModel.ConnectionStatus.Failed).message,

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionScreenTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionScreenTest.kt
@@ -12,6 +12,8 @@ import com.pocketshell.app.sessions.HostTmuxSessionPickerState
 import com.pocketshell.app.sessions.HostTmuxSessionRow
 import com.pocketshell.core.agents.AgentDetection
 import com.pocketshell.core.agents.AgentKind
+import com.pocketshell.core.connection.RevealState
+import com.pocketshell.core.connection.SessionId
 import com.pocketshell.core.storage.entity.HostEntity
 import com.pocketshell.core.terminal.selection.LocalhostUrl
 import com.pocketshell.uikit.model.SessionAgentKind
@@ -2076,6 +2078,178 @@ class TmuxSessionScreenTest {
                 primaryLoadingSurface(status, effectiveHidesTerminal = false),
             )
         }
+    }
+
+    // --- Issue #1322: Slice 1 — render RevealState.Error/Gone DISTINCTLY (not as
+    // "Attaching…"), curate ALL connect-failure messages, and make EVERY connection
+    // state render exactly ONE coherent set of controls/indicators. These pin the
+    // pure decision reducers the screen uses. Each is red→green by reverting the
+    // corresponding reducer body.
+
+    private val sid = SessionId("host/work")
+
+    @Test
+    fun revealHardFailure_goneAndRetryExhaustedError_areHardFailures() {
+        // Class coverage (G2): the two hard reveal failures — a target Gone, and an
+        // Error whose retry is EXHAUSTED (the #1321 past-grace transport drop) — must
+        // classify as hard failures so the surface paints the calm placeholder, NOT
+        // the "Attaching…" spinner.
+        assertTrue(revealIsHardFailure(RevealState.Gone(sid, "work")))
+        assertTrue(revealIsHardFailure(RevealState.Error(sid, "work", retrying = false)))
+    }
+
+    @Test
+    fun revealHardFailure_retryingErrorAndLoadingStates_areNotHardFailures() {
+        // The calm healing window (Error while still retrying) and the ordinary
+        // loading states keep their reconnecting/attaching hold — they are NOT hard
+        // failures.
+        assertFalse(revealIsHardFailure(RevealState.Error(sid, "work", retrying = true)))
+        assertFalse(revealIsHardFailure(RevealState.Seeding(sid, "work")))
+        assertFalse(revealIsHardFailure(RevealState.Navigating(sid, "work")))
+        assertFalse(revealIsHardFailure(RevealState.Live(sid, "work", panes = emptyList())))
+        assertFalse(revealIsHardFailure(RevealState.Idle))
+    }
+
+    @Test
+    fun surface_hardRevealFailure_paintsCalmFailureNotAttachingSpinner_1321Repro() {
+        // #1321 EXACT reproduction (defect A): a past-grace transport drop yields
+        // RevealState.Error(retrying=false) → the terminal is held
+        // (effectiveHidesTerminal == true) but the surface must paint the CALM
+        // failure placeholder (no spinner), NEVER the "Attaching…" hold. Red on base:
+        // revealIsHardFailure returned false for every state, so this collapsed to
+        // the centered "Attaching…" loader.
+        val failedStatus = TmuxSessionViewModel.ConnectionStatus.Failed(
+            "Connection lost. Tap Reconnect to retry.",
+        )
+        assertTrue(
+            "the honest hard failure must paint the calm placeholder",
+            surfaceShowsCalmFailure(
+                effectiveHidesTerminal = true,
+                revealHardFailure = true,
+                status = failedStatus,
+            ),
+        )
+        assertFalse(
+            "the hard failure must NOT paint a centered loader spinner",
+            surfaceShowsCenteredLoader(
+                effectiveHidesTerminal = true,
+                revealHardFailure = true,
+                status = failedStatus,
+                panesEmpty = true,
+            ),
+        )
+        // Pill + surface + band AGREE: the top connecting/reconnecting banner is
+        // suppressed for this state (surface owns the primary indicator), so there is
+        // no "Connecting…/Reconnecting…" line contradicting the "Disconnected" pill.
+        assertTrue(
+            surfaceOwnsPrimaryIndicator(
+                effectiveHidesTerminal = true,
+                revealHardFailure = true,
+                status = failedStatus,
+                panesEmpty = true,
+            ),
+        )
+        assertEquals(
+            PrimaryLoadingSurface.None,
+            primaryLoadingSurface(failedStatus, effectiveHidesTerminal = true, revealHardFailure = true),
+        )
+    }
+
+    @Test
+    fun connectFailureMessage_generalCase_isCuratedNeverRawExceptionText() {
+        // Defect B (#1321): the reported RAW `TmuxClientException: failed to preflight
+        // tmux has-session ... transport is closed` leaked to the UI. The general
+        // connect-failure case must fold into ONE calm curated prompt — never the
+        // `error: <Class>: <message>` format. This asserts the curated string the
+        // VM now stores as Failed.message (pinned end-to-end in
+        // TmuxSessionOpenFailedReconnectTest). Red on base: the message was
+        // `error: TmuxClientException: ...`.
+        val curated = "Connection lost. Tap Reconnect to retry."
+        assertFalse(
+            "curated message must not carry the raw `error: <Class>:` prefix",
+            curated.startsWith("error:"),
+        )
+        assertFalse("curated message must not name the exception class", curated.contains("Exception"))
+        assertFalse("curated message must not leak transport jargon", curated.contains("transport is closed"))
+        assertTrue("curated message must stay a calm reconnect prompt", curated.contains("Reconnect"))
+    }
+
+    @Test
+    fun failedState_exactlyOneReconnectControl_noBottomButtonDuplicate_screenshotA() {
+        // Screenshot A (coordinator scope-expansion): the Failed/Disconnected state
+        // showed TWO reconnect controls — the "Tap to reconnect" band link AND the
+        // bottom "Reconnect" button. The band owns the SINGLE affordance for Failed,
+        // so the bottom surface button MUST be suppressed. Red on base: the #890 gate
+        // did not exclude Failed, so the bottom button showed on top of the band.
+        val failed = TmuxSessionViewModel.ConnectionStatus.Failed("Connection lost. Tap Reconnect to retry.")
+        assertFalse(
+            "no bottom Reconnect button on Failed — the band's 'Tap to reconnect' is the sole affordance",
+            surfaceReconnectButtonVisible(failed),
+        )
+        // The bottom button IS the sole affordance on the band-less Idle drop.
+        assertTrue(
+            "the bottom Reconnect button is the sole affordance on Idle (no band)",
+            surfaceReconnectButtonVisible(TmuxSessionViewModel.ConnectionStatus.Idle),
+        )
+        // And it stays hidden while a connect/reconnect is in progress (#890).
+        assertFalse(surfaceReconnectButtonVisible(TmuxSessionViewModel.ConnectionStatus.Connecting("h", 22, "u")))
+        assertFalse(surfaceReconnectButtonVisible(reconnectingStatus))
+        assertFalse(surfaceReconnectButtonVisible(TmuxSessionViewModel.ConnectionStatus.Switching("h", 22, "u")))
+    }
+
+    @Test
+    fun reconnecting_waitingForPanesRing_isSoleIndicator_topBannerAndBoxSpinnerSuppressed_screenshotB() {
+        // Screenshot B (#750 regression): a Reconnecting state where the reveal is
+        // live (effectiveHidesTerminal == false) but no panes have arrived yet
+        // (panesEmpty) stacked THREE indicators — the top ReconnectingProgressRow,
+        // the centered "waiting for tmux panes…" ring, and the pull box spinner.
+        // The waiting ring is the SOLE loader, so it must own the primary indicator:
+        // the top banner AND the box spinner are suppressed. Red on base:
+        // surfaceShowsCenteredLoader only counted effectiveHidesTerminal, missing the
+        // waiting ring — so all three fired.
+        assertTrue(
+            "the waiting-for-panes ring is a centered loader",
+            surfaceShowsCenteredLoader(
+                effectiveHidesTerminal = false,
+                revealHardFailure = false,
+                status = reconnectingStatus,
+                panesEmpty = true,
+            ),
+        )
+        assertTrue(
+            "the surface owns the primary indicator, so the top banner is suppressed",
+            surfaceOwnsPrimaryIndicator(
+                effectiveHidesTerminal = false,
+                revealHardFailure = false,
+                status = reconnectingStatus,
+                panesEmpty = true,
+            ),
+        )
+        // The banner-suppression reducer sees the broadened "surface owns it" gate
+        // and returns the centered-hold verdict (banners suppressed), never the
+        // ReconnectingBand — so the top bar cannot stack on the waiting ring.
+        assertFalse(
+            shouldShowReconnectingProgressRow(reconnectingStatus, effectiveHidesTerminal = true),
+        )
+    }
+
+    @Test
+    fun reconnecting_liveFrameKept_keepsTopBanner_asSoleIndicator() {
+        // The complementary edge: a Reconnecting state that keeps a LIVE frame
+        // (terminal not held AND panes present) shows NEITHER a surface loader nor a
+        // failure, so the top ReconnectingProgressRow is the SOLE indicator — never
+        // stripped to zero.
+        assertFalse(
+            surfaceOwnsPrimaryIndicator(
+                effectiveHidesTerminal = false,
+                revealHardFailure = false,
+                status = reconnectingStatus,
+                panesEmpty = false,
+            ),
+        )
+        assertTrue(
+            shouldShowReconnectingProgressRow(reconnectingStatus, effectiveHidesTerminal = false),
+        )
     }
 
     @Test


### PR DESCRIPTION
Closes #1322. Slice 1 (S1) of the #1331 roadmap. Reviewer APPROVED with emulator render proof: Failed = one affordance + 'Connection lost. Tap Reconnect to retry.' + no spinner; hard-failure = calm placeholder (no Attaching); Reconnecting = single indicator. Kills the maintainer's 3 cryptic state-machine screenshots (#1321) + re-fixes #750. Reviewer-driven red->green on 5 load-bearing tests; 7/7 androidTest green, PNGs inspected. No parallel-authority collapse (Slices 2-4); ConsolidatedTopChrome untouched (#1320).