### PR TITLE
core-tmux: overflow-reseed parked-frame discard scoped to the authoritative drain (#1305)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -10732,8 +10732,14 @@ public class TmuxSessionViewModel @Inject constructor(
                     // are all PRE-capture (already reflected server-side in the
                     // snapshot), so DROP them before the resume so they cannot
                     // double-apply on top of the fresh grid.
+                    // Issue #1305: use the AUTHORITATIVE post-capture drain so it
+                    // also discards the frame parked in the drain loop's local at
+                    // the pause boundary (not reachable by the channel drain). The
+                    // pre-capture drain in step 2 must NOT arm that discard, so on
+                    // a capture FAILURE (no reseed → this branch is skipped) the
+                    // parked frame still REPLAYS on resume (the #1297 guarantee).
                     drainedFrames +=
-                        runCatching { client.drainPaneOutputBacklog(paneId) }.getOrDefault(0)
+                        runCatching { client.drainPaneOutputBacklogAfterCapture(paneId) }.getOrDefault(0)
                 }
                 // 5. If no snapshot ever landed (all retries near-blank/errored),
                 //    still OPEN the gate so buffered live output is flushed rather

--- a/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxClient.kt
+++ b/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxClient.kt
@@ -256,6 +256,26 @@ public interface TmuxClient : AutoCloseable {
     public fun drainPaneOutputBacklog(paneId: String): Int
 
     /**
+     * Issue #1305: the AUTHORITATIVE post-capture variant of
+     * [drainPaneOutputBacklog], called by the overflow-reseed swap ONLY after a
+     * successful `capture-pane` snapshot (step 4 of
+     * [TmuxSessionViewModel.launchPaneOverflowReseed]).
+     *
+     * Besides emptying the queued channel like [drainPaneOutputBacklog], it also
+     * marks the single frame the pane's drain loop may have RECEIVED into its
+     * local and PARKED at the pause boundary as stale, so that frame is DROPPED on
+     * [resumeOutputDelivery] instead of double-applying on top of the fresh
+     * snapshot. The pre-capture drain (step 2) intentionally does NOT arm this:
+     * on a capture FAILURE step 2 is the only drain that runs, and the parked
+     * frame must still REPLAY on resume (the #1297 held-frame guarantee).
+     *
+     * Defaults to plain [drainPaneOutputBacklog] for [TmuxClient] doubles that do
+     * not model the pause-boundary park.
+     */
+    public fun drainPaneOutputBacklogAfterCapture(paneId: String): Int =
+        drainPaneOutputBacklog(paneId)
+
+    /**
      * Issue #1297: freeze `%output` delivery for [paneId] so frames landing while
      * the sole collector is momentarily detached are HELD in the bounded backlog
      * channel instead of being emitted into a zero-subscriber `replay = 0`
@@ -1802,8 +1822,19 @@ internal class RealTmuxClient(
     // Issue #1205: empty the pane's queued delivery backlog so a post-overflow
     // `capture-pane` reseed is not clobbered by stale burst frames replaying on
     // top of it. Best-effort: only touches the live channel, never the reader.
+    // Issue #1305: this pre-capture drain does NOT arm discard of a frame parked
+    // at the pause boundary — on a capture FAILURE it is the only drain that runs
+    // and the parked frame must still REPLAY on resume (the #1297 guarantee).
     override fun drainPaneOutputBacklog(paneId: String): Int =
-        paneOutputPipes[paneId]?.drainBacklog() ?: 0
+        paneOutputPipes[paneId]?.drainBacklog(armStaleParkedFrameDiscard = false) ?: 0
+
+    // Issue #1305: the AUTHORITATIVE post-capture drain. Runs only after a
+    // successful `capture-pane` reseed, so besides emptying the channel it also
+    // arms discard of the frame parked in the drain loop's local at the pause
+    // boundary — that frame is PRE-capture (already reflected in the fresh
+    // snapshot), so emitting it on resume would double-apply on top of the grid.
+    override fun drainPaneOutputBacklogAfterCapture(paneId: String): Int =
+        paneOutputPipes[paneId]?.drainBacklog(armStaleParkedFrameDiscard = true) ?: 0
 
     override fun pauseOutputDelivery(paneId: String) {
         paneOutputPipes[paneId]?.pauseDelivery()
@@ -2825,6 +2856,16 @@ internal class RealTmuxClient(
         // into a zero-subscriber flow. Driven by [pauseDelivery]/[resumeDelivery]
         // across the overflow-reseed producer swap.
         private val paused: MutableStateFlow<Boolean>,
+        // Issue #1305: `true` while the drain loop holds a frame RECEIVED into its
+        // local but not yet emitted (it parked at the pause boundary). The frame
+        // is no longer in [channel], so [drainBacklog] cannot reach it — this flag
+        // lets a drain-during-pause mark it stale so it is dropped, not
+        // double-applied on top of the authoritative capture snapshot.
+        private val holdingFrameAtPause: AtomicBoolean = AtomicBoolean(false),
+        // Issue #1305: armed by [drainBacklog] when it runs while a frame is parked
+        // at the pause boundary; consumed by the drain loop on resume to DISCARD
+        // that pre-capture frame instead of emitting it.
+        private val discardParkedFrame: AtomicBoolean = AtomicBoolean(false),
         private val droppedEvents: AtomicInteger = AtomicInteger(0),
         private val overflowDiagnosticEmitted: AtomicBoolean = AtomicBoolean(false),
     ) {
@@ -2875,7 +2916,19 @@ internal class RealTmuxClient(
          * The pipe's drain job keeps running; only the queued-but-undelivered
          * burst frames are dropped so a post-overflow reseed is authoritative.
          */
-        fun drainBacklog(): Int {
+        fun drainBacklog(armStaleParkedFrameDiscard: Boolean): Int {
+            // Issue #1305: a frame the drain loop received into its local and
+            // PARKED at the pause boundary is NOT in [channel] — the channel drain
+            // below cannot reach it. Only the AUTHORITATIVE post-capture drain
+            // ([armStaleParkedFrameDiscard] = true) may mark it for discard so it is
+            // dropped on resume instead of double-applying on top of the fresh
+            // capture snapshot. The pre-capture drain (step 2 of the overflow-reseed
+            // swap) passes false: on a capture FAILURE it is the ONLY drain that
+            // runs, and the parked frame must still REPLAY on resume (the #1297
+            // held-frame guarantee), not be silently dropped.
+            if (armStaleParkedFrameDiscard && holdingFrameAtPause.get()) {
+                discardParkedFrame.set(true)
+            }
             var drained = 0
             while (channel.tryReceive().isSuccess) {
                 drained++
@@ -2898,6 +2951,10 @@ internal class RealTmuxClient(
                 )
                 val channel = Channel<ControlEvent.Output>(OUTPUT_BACKLOG_EVENTS)
                 val paused = MutableStateFlow(false)
+                // Issue #1305: coordinate the frame parked in the drain loop's
+                // local at the pause boundary with a concurrent [drainBacklog].
+                val holdingFrameAtPause = AtomicBoolean(false)
+                val discardParkedFrame = AtomicBoolean(false)
                 val job = scope.launch {
                     // Issue #1204: replay any output buffered before this pipe
                     // was registered, IN ORDER, ahead of the live channel. The
@@ -2963,7 +3020,26 @@ internal class RealTmuxClient(
                         // when the pause lands is held, not emitted into a paused
                         // (subscriber-detached) flow.
                         if (paused.value) {
+                            // Issue #1305: this frame was received into `event`
+                            // BEFORE the pause released — it is now parked in a
+                            // local, out of [channel] and beyond [drainBacklog]'s
+                            // reach. Expose it and arm discard detection for THIS
+                            // park so an overflow drain that runs while we're parked
+                            // can flag the frame stale. Re-arm to false at the start
+                            // of every park so a stale flag from a prior park (or a
+                            // drain that ran with nothing parked) never discards a
+                            // legitimate post-snapshot frame.
+                            discardParkedFrame.set(false)
+                            holdingFrameAtPause.set(true)
                             paused.first { !it }
+                            holdingFrameAtPause.set(false)
+                            if (discardParkedFrame.compareAndSet(true, false)) {
+                                // A drain ran while this frame was parked: the
+                                // authoritative capture snapshot already reflects
+                                // it, so emitting now would double-apply on top of
+                                // the fresh grid. Drop it and continue.
+                                continue
+                            }
                         }
                         flow.emit(event)
                     }
@@ -2975,6 +3051,8 @@ internal class RealTmuxClient(
                     onOverflow = onOverflow,
                     diagnosticFields = diagnosticFields,
                     paused = paused,
+                    holdingFrameAtPause = holdingFrameAtPause,
+                    discardParkedFrame = discardParkedFrame,
                 )
             }
         }

--- a/shared/core-tmux/src/test/java/com/pocketshell/core/tmux/TmuxClientTest.kt
+++ b/shared/core-tmux/src/test/java/com/pocketshell/core/tmux/TmuxClientTest.kt
@@ -1198,6 +1198,135 @@ class TmuxClientTest {
     }
 
     @Test
+    fun `capture SUCCESS drains the frame parked at the pause boundary, not double-applied after the snapshot`() =
+        runBlocking {
+            // Issue #1305 (red→green, SUCCESS path): the overflow-reseed swap pauses
+            // %output, drains the pane backlog (step 2, PRE-capture), takes an
+            // authoritative capture snapshot, drains AGAIN (step 4, POST-capture),
+            // then resumes. Both drains empty the pipe CHANNEL — but NOT the single
+            // frame already received into the drain loop's local and PARKED at the
+            // pause boundary (`if (paused.value) { paused.first { !it } }`). On the
+            // #1297 base that parked frame survives BOTH drains and is emitted on
+            // resume, AFTER the snapshot that already reflects it — a double-apply on
+            // top of the fresh grid. With the fix the AUTHORITATIVE step-4 drain
+            // (`drainPaneOutputBacklogAfterCapture`) marks the parked frame stale so
+            // it is dropped on resume; only genuinely post-snapshot deltas reach the
+            // collector.
+            val shell = FakeShell()
+            val session = FakeSession(shell)
+            val client = RealTmuxClient(session, scope)
+            val received = Collections.synchronizedList(mutableListOf<String>())
+            try {
+                client.connect()
+                // Live collector so the pane pipe's drain loop is hot (blocked in
+                // receiveCatching on the empty channel, ready to receive + park).
+                val collector = scope.launch {
+                    client.outputFor("%305").collect {
+                        received.add(String(it.data, StandardCharsets.US_ASCII))
+                    }
+                }
+                delay(200)
+
+                // 1. Pause BEFORE feeding: the next frame the loop receives lands
+                //    in its local and PARKS at the pause boundary (it is NOT left
+                //    queued in the channel).
+                client.pauseOutputDelivery("%305")
+                shell.feed("%output %305 parked-pre-capture\n")
+                // Let the reader parse the frame and the hot loop receive it into
+                // its local + suspend on `paused.first { !it }`.
+                delay(300)
+
+                // 2. Step-2 PRE-capture drain (plain — must NOT arm discard). The
+                //    parked frame is in the loop's LOCAL, not the channel.
+                val drainedPreCapture = client.drainPaneOutputBacklog("%305")
+
+                // 3. Step-4 POST-capture AUTHORITATIVE drain — a successful reseed
+                //    ran, so this arms discard of the parked pre-capture frame.
+                val drainedPostCapture = client.drainPaneOutputBacklogAfterCapture("%305")
+
+                // 4. Resume (snapshot is authoritative). The parked, pre-capture
+                //    frame must NOT reach the collector.
+                client.resumeOutputDelivery("%305")
+                delay(150)
+
+                // 5. A genuinely post-snapshot live delta — this MUST be delivered.
+                shell.feed("%output %305 post-snapshot-delta\n")
+                delay(300)
+
+                collector.cancelAndJoin()
+
+                assertEquals(
+                    "on a SUCCESSFUL reseed the frame parked at the pause boundary " +
+                        "must be dropped by the authoritative post-capture drain (not " +
+                        "double-applied on top of the snapshot); only the post-snapshot " +
+                        "delta survives. drainedPreCapture=" + drainedPreCapture +
+                        " drainedPostCapture=" + drainedPostCapture,
+                    listOf("post-snapshot-delta"),
+                    received.toList(),
+                )
+            } finally {
+                client.close()
+            }
+        }
+
+    @Test
+    fun `capture FAILURE replays the frame parked at the pause boundary, not dropped (issue 1297 guarantee)`() =
+        runBlocking {
+            // Issue #1305 (red→green, FAILURE path — the reviewer's G2 gap): on a
+            // capture FAILURE the overflow-reseed swap runs ONLY the step-2
+            // PRE-capture drain (`drainPaneOutputBacklog`); the step-4 authoritative
+            // drain is guarded by `if (reseeded)` and is SKIPPED. The #1297
+            // held-frame guarantee is that on that failed path the held frames
+            // (including the one parked in the drain loop's local at the pause
+            // boundary) are REPLAYED to the fresh producer on resume, not lost.
+            //
+            // The reviewer flagged that arming discard on ANY drain (the prior fix)
+            // would DROP the parked frame on this failed path too, reintroducing the
+            // #1297 lost-frame break. This test guards that: with the pre-capture
+            // drain NOT arming discard, the parked frame must survive to resume.
+            val shell = FakeShell()
+            val session = FakeSession(shell)
+            val client = RealTmuxClient(session, scope)
+            val received = Collections.synchronizedList(mutableListOf<String>())
+            try {
+                client.connect()
+                val collector = scope.launch {
+                    client.outputFor("%305").collect {
+                        received.add(String(it.data, StandardCharsets.US_ASCII))
+                    }
+                }
+                delay(200)
+
+                // 1. Pause, feed → the frame parks in the drain loop's local.
+                client.pauseOutputDelivery("%305")
+                shell.feed("%output %305 parked-pre-capture\n")
+                delay(300)
+
+                // 2. Step-2 PRE-capture drain — the ONLY drain on the FAILURE path
+                //    (no reseed → step 4 is skipped). It must NOT arm discard.
+                val drainedPreCapture = client.drainPaneOutputBacklog("%305")
+
+                // 3. Resume — capture failed, so the held/parked frame must REPLAY
+                //    to the fresh producer (the #1297 guarantee), not be dropped.
+                client.resumeOutputDelivery("%305")
+                delay(300)
+
+                collector.cancelAndJoin()
+
+                assertEquals(
+                    "on a FAILED reseed (only the pre-capture drain ran, step 4 " +
+                        "skipped) the frame parked at the pause boundary must be " +
+                        "REPLAYED on resume — not silently dropped — preserving the " +
+                        "#1297 held-frame guarantee. drainedPreCapture=" + drainedPreCapture,
+                    listOf("parked-pre-capture"),
+                    received.toList(),
+                )
+            } finally {
+                client.close()
+            }
+        }
+
+    @Test
     fun `sendChainedCommands writes one chained line and drains both blocks in order`() = runBlocking {
         // Issue #692: the folder-list discovery probe fetches list-sessions +
         // list-panes in ONE control-mode round-trip. tmux -CC answers a


### PR DESCRIPTION
Closes #1305. #1297 follow-up: fixes the parked-pre-capture-frame double-apply, with the discard armed ONLY on the post-capture authoritative drain so the capture-FAILED path still replays (#1297 preserved). Reviewer APPROVED after a caught regression + fix: both success-path (drop-once) and failed-path (replay) red→greens driven by the reviewer; core-tmux suite 182 tests 0-fail.