### PR TITLE
hotkeys: arrows at top + progressive disclosure (#1332)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/tmux/ShiftTabHotkeyContainmentTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/ShiftTabHotkeyContainmentTest.kt
@@ -7,9 +7,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performClick
 import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.pocketshell.uikit.components.TERMINAL_HOTKEYS_PANEL_EXPAND_TAG
 import com.pocketshell.uikit.components.TerminalHotkeysPanel
 import com.pocketshell.uikit.theme.PocketShellTheme
 import org.junit.Rule
@@ -31,8 +34,10 @@ import org.junit.runner.RunWith
  * at a tight small-phone width where a re-crowded KEYS row would push it off the
  * right edge (the #755-class symptom).
  *
- * This composes the PRODUCTION key set ([TmuxHotkeyPanelSections], which now
- * carries ⇧Tab in the KEYS section) — not a convenient subset — and asserts
+ * This composes the PRODUCTION key set ([TmuxHotkeyPanelSections], which as of
+ * #1332 carries ⇧Tab in the EXTENDED `MORE KEYS` section behind the "Show more
+ * keys" expander — so the test expands the panel first) — not a convenient
+ * subset — and asserts
  * viewport **containment** of the ⇧Tab node against the window root (the check
  * `assertIsDisplayed()` is NOT: a key shoved off the right edge of a 4-column row
  * still reports "displayed"). CI-deterministic: fixed width, no real IME, no
@@ -65,6 +70,11 @@ class ShiftTabHotkeyContainmentTest {
                 }
             }
         }
+        compose.waitForIdle()
+
+        // Issue #1332: ⇧Tab now lives in the EXTENDED set behind the "Show more
+        // keys" expander, so reveal it before asserting containment.
+        compose.onNodeWithTag(TERMINAL_HOTKEYS_PANEL_EXPAND_TAG).performClick()
         compose.waitForIdle()
 
         // (1) The new back-tab key is actually rendered in the production panel.

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TerminalHotkeysPanelNoTruncationTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TerminalHotkeysPanelNoTruncationTest.kt
@@ -8,9 +8,12 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.SemanticsConfiguration
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
 import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.pocketshell.uikit.components.HotkeyLabelTruncatedKey
+import com.pocketshell.uikit.components.TERMINAL_HOTKEYS_PANEL_EXPAND_TAG
 import com.pocketshell.uikit.components.TerminalHotkeysPanel
 import com.pocketshell.uikit.theme.PocketShellTheme
 import org.junit.Rule
@@ -84,6 +87,12 @@ class TerminalHotkeysPanelNoTruncationTest {
                 }
             }
         }
+        compose.waitForIdle()
+
+        // Issue #1332: the extended sections (CTRL COMBOS / letters / doubled
+        // chords / ⇧Tab / sticky Ctrl) sit behind the "Show more keys" expander,
+        // so expand the panel to render EVERY key before the truncation sweep.
+        compose.onNodeWithTag(TERMINAL_HOTKEYS_PANEL_EXPAND_TAG).performClick()
         compose.waitForIdle()
 
         // Walk every label in the production key set. For each key:

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TerminalHotkeysPanelScreenshotHarness.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TerminalHotkeysPanelScreenshotHarness.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.test.captureToImage
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import androidx.compose.ui.unit.dp
 import androidx.core.graphics.Insets
 import androidx.core.view.ViewCompat
@@ -26,6 +27,7 @@ import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.uikit.components.TERMINAL_HOTKEYS_PANEL_EXPAND_TAG
 import com.pocketshell.uikit.components.TerminalHotkeysPanel
 import com.pocketshell.uikit.theme.PocketShellColors
 import com.pocketshell.uikit.theme.PocketShellTheme
@@ -88,6 +90,9 @@ class TerminalHotkeysPanelScreenshotHarness {
                 }
             }
         }
+        compose.waitForIdle()
+        // Issue #1332: reveal the extended sections so the full grid is captured.
+        compose.onNodeWithTag(TERMINAL_HOTKEYS_PANEL_EXPAND_TAG).performClick()
         compose.waitForIdle()
         // Sanity: the redesigned panel really rendered its keys before capture.
         compose.onNodeWithText("^B").assertExists()

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxKeyboardPanLayoutTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxKeyboardPanLayoutTest.kt
@@ -16,8 +16,10 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.pocketshell.uikit.components.TERMINAL_HOTKEYS_PANEL_EXPAND_TAG
 import com.pocketshell.uikit.components.TerminalHotkeysPanel
 import com.pocketshell.uikit.theme.PocketShellColors
 import com.pocketshell.uikit.theme.PocketShellTheme
@@ -144,6 +146,11 @@ class TmuxKeyboardPanLayoutTest {
                 )
             }
         }
+        compose.waitForIdle()
+        // Issue #1332: `^B` is in the EXTENDED CTRL COMBOS grid behind the "Show
+        // more keys" expander, so reveal it before measuring the key height.
+        compose.onNodeWithTag(TERMINAL_HOTKEYS_PANEL_EXPAND_TAG).performClick()
+        compose.waitForIdle()
 
         val keyHeight = compose
             .onNodeWithText("^B")

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxSessionVoiceSurfaceUiTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxSessionVoiceSurfaceUiTest.kt
@@ -41,6 +41,7 @@ import com.pocketshell.app.voice.SESSION_ENTER_CHIP_TAG
 import com.pocketshell.app.voice.SHOW_KEYBOARD_CHIP_TAG
 import com.pocketshell.app.voice.SnippetsChipIcon
 import com.pocketshell.app.proof.signals.assertNodeFullyWithinRoot
+import com.pocketshell.uikit.components.TERMINAL_HOTKEYS_PANEL_EXPAND_TAG
 import com.pocketshell.uikit.components.TERMINAL_HOTKEYS_PANEL_TAG
 import com.pocketshell.uikit.components.TerminalHotkeysPanel
 import com.pocketshell.uikit.theme.PocketShellTheme
@@ -603,6 +604,12 @@ class TmuxSessionVoiceSurfaceUiTest {
         // sticky `Ctrl` MODIFIER for the general `Ctrl+<letter>` escape hatch; the
         // direct combos below are unchanged and this test does not assert against
         // the modifier.)
+        //
+        // Issue #1332: Esc / ^C / ^D are now in the COMMON (always-shown) set, so
+        // they are tapped while collapsed (a single node each). ^B (tmux prefix)
+        // lives in the EXTENDED CTRL COMBOS grid behind the "Show more keys"
+        // expander, so it is tapped after revealing the extended set. The taps
+        // still route through `onKey` unchanged — order/disclosure only.
         val taps = mutableListOf<String>()
         compose.setContent {
             PocketShellTheme {
@@ -615,11 +622,15 @@ class TmuxSessionVoiceSurfaceUiTest {
         }
 
         compose.onNodeWithText("Esc").assertIsDisplayed().assertHasClickAction().performClick()
-        compose.onNodeWithText("^B").assertIsDisplayed().assertHasClickAction().performClick()
         compose.onNodeWithText("^C").assertIsDisplayed().assertHasClickAction().performClick()
         compose.onNodeWithText("^D").assertIsDisplayed().assertHasClickAction().performClick()
 
-        assertEquals(listOf("Esc", "^B", "^C", "^D"), taps)
+        // Reveal the extended set, then tap the restored ^B (tmux prefix).
+        compose.onNodeWithTag(TERMINAL_HOTKEYS_PANEL_EXPAND_TAG).performClick()
+        compose.waitForIdle()
+        compose.onNodeWithText("^B").assertIsDisplayed().assertHasClickAction().performClick()
+
+        assertEquals(listOf("Esc", "^C", "^D", "^B"), taps)
     }
 
     @Test

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
@@ -7801,10 +7801,14 @@ internal fun tmuxTerminalKeyboardChromeMode(
  * Issue #784: the dedicated terminal-hotkeys panel key set.
  *
  * This replaces the cramped, `…`-overflowing in-composer key bar (#458/#755,
- * hard-cut per D22). The panel shows EVERY key at once in a tidy multi-row grid
- * — no `…` expander, no horizontal scroll, no lone `Ctrl` modifier, no
- * duplicate `/`. Each label is audited so the visible glyph equals the byte
- * sent ([TmuxSessionViewModel.onKeyBarKey]):
+ * hard-cut per D22). Issue #1332 adds progressive disclosure: the panel opens
+ * COMPACT showing only the COMMON set (ARROWS first — the most-used keys — then
+ * `Esc`/`Tab`/`Enter`/`^C`/`^D`), with a "Show more keys" expander revealing the
+ * EXTENDED set (the full `CTRL COMBOS` grid, `⇧Tab`, doubled interrupt/EOF, the
+ * `Ctrl` sticky modifier, and the a–z `LETTERS` grid). No horizontal scroll, no
+ * lone `Ctrl` modifier, no duplicate `/`. Each label is audited so the visible
+ * glyph equals the byte sent ([TmuxSessionViewModel.onKeyBarKey]) — #1332 only
+ * reordered and split the catalog; no routing/byte changed:
  *
  *  - Keys section: `Esc` (0x1B), `Tab`, `Enter` (#527).
  *  - Ctrl combos section: the useful chords as DIRECT buttons (no modifier to
@@ -7842,25 +7846,43 @@ internal const val TmuxHotkeyInterruptX2Label: String = "^C×2"
 internal const val TmuxHotkeyEofX2Label: String = "^D×2"
 
 internal val TmuxHotkeyPanelSections: List<com.pocketshell.uikit.components.HotkeySection> = listOf(
+    // Issue #1332: ARROWS is now the FIRST/top section (was last). Arrows are the
+    // most-used navigation keys, so they sit at the very top, immediately
+    // reachable. Part of the COMMON set (always shown, `extended = false`).
     com.pocketshell.uikit.components.HotkeySection(
-        title = "KEYS",
+        title = "ARROWS",
+        keys = listOf(
+            KeyBinding(label = "←", kind = KeyKind.Arrow),
+            KeyBinding(label = "↑", kind = KeyKind.Arrow),
+            KeyBinding(label = "↓", kind = KeyKind.Arrow),
+            KeyBinding(label = "→", kind = KeyKind.Arrow),
+        ),
+        columns = 4,
+    ),
+    // Issue #1332: the everyday essentials, shown by default alongside the
+    // arrows — `Esc`, `Tab`, `Enter`, and the single `^C` / `^D` (interrupt /
+    // EOF). One compact row of five. `^C` / `^D` also remain in the full CTRL
+    // COMBOS grid behind the expander; surfacing them here is intentional (the
+    // most-reached-for control keys). Every label still routes through
+    // [TmuxSessionViewModel.onKeyBarKey] exactly as before — order/disclosure
+    // only, no byte change.
+    com.pocketshell.uikit.components.HotkeySection(
+        title = "COMMON",
         keys = listOf(
             KeyBinding(label = "Esc", kind = KeyKind.Regular),
             KeyBinding(label = "Tab", kind = KeyKind.Regular),
-            // Issue #893: ⇧Tab (back-tab / Shift+Tab) sends tmux's `BTab` named
-            // key (ESC [ Z) so the maintainer can cycle Claude Code's
-            // permission/plan mode from the phone. 4 columns keep every label
-            // fully readable (Esc / Tab / ⇧Tab / Enter).
-            KeyBinding(label = "⇧Tab", kind = KeyKind.Regular),
             KeyBinding(label = TmuxHotkeyEnterLabel, kind = KeyKind.Regular),
+            KeyBinding(label = "^C", kind = KeyKind.Regular),
+            KeyBinding(label = "^D", kind = KeyKind.Regular),
         ),
-        columns = 4,
+        columns = 5,
     ),
     // Issue #1091: the curated one-tap control combos — the existing 8 plus the
     // control keys nano (and many TUIs) need that were missing: `^G` Help, `^J`
     // Justify, `^K` Cut, `^O` Write Out, `^T` Execute, `^U` cut-to-start, `^W`
     // Where-Is, `^X` Exit, `^\` Replace. Ordered by control byte so the grid
     // reads predictably. Each routes to its byte via [onKeyBarKey].
+    // Issue #1332: EXTENDED — behind the "Show more keys" expander.
     com.pocketshell.uikit.components.HotkeySection(
         title = "CTRL COMBOS",
         keys = listOf(
@@ -7883,10 +7905,24 @@ internal val TmuxHotkeyPanelSections: List<com.pocketshell.uikit.components.Hotk
             KeyBinding(label = "^\\", kind = KeyKind.Regular),
         ),
         columns = 4,
+        extended = true,
+    ),
+    // Issue #893: ⇧Tab (back-tab / Shift+Tab) sends tmux's `BTab` named key
+    // (ESC [ Z) so the maintainer can cycle Claude Code's permission/plan mode
+    // from the phone. Issue #1332: EXTENDED — it moved out of the common KEYS
+    // row into the expander (the common set is arrows + Esc/Tab/Enter/^C/^D).
+    com.pocketshell.uikit.components.HotkeySection(
+        title = "MORE KEYS",
+        keys = listOf(
+            KeyBinding(label = "⇧Tab", kind = KeyKind.Regular),
+        ),
+        columns = 4,
+        extended = true,
     ),
     // Issue #787: interrupt / EOF doubled chords (re-homed from the deleted
     // palette). Distinct from the single `^C`/`^D` above — these send the byte
     // TWICE so they actually stop the running agent / exit the REPL.
+    // Issue #1332: EXTENDED — behind the "Show more keys" expander.
     com.pocketshell.uikit.components.HotkeySection(
         title = "INTERRUPT / EOF",
         keys = listOf(
@@ -7894,33 +7930,27 @@ internal val TmuxHotkeyPanelSections: List<com.pocketshell.uikit.components.Hotk
             KeyBinding(label = TmuxHotkeyEofX2Label, kind = KeyKind.Regular),
         ),
         columns = 2,
+        extended = true,
     ),
     // Issue #1091: the general `Ctrl + <any letter>` escape hatch. Tap `Ctrl`
     // (a sticky modifier — single tap = one-shot, double tap = locked, accent
     // when active) then a letter to send that letter's control byte. With
     // `Ctrl` off a letter types literally. Covers every `Ctrl+<a–z>` combo, not
     // just the curated subset above — so no TUI key is ever unreachable.
+    // Issue #1332: EXTENDED — behind the "Show more keys" expander.
     com.pocketshell.uikit.components.HotkeySection(
         title = "CTRL + LETTER",
         keys = listOf(
             KeyBinding(label = TmuxHotkeyCtrlModifierLabel, kind = KeyKind.Modifier),
         ),
         columns = 4,
+        extended = true,
     ),
     com.pocketshell.uikit.components.HotkeySection(
         title = "LETTERS",
         keys = ('a'..'z').map { KeyBinding(label = it.toString(), kind = KeyKind.Regular) },
         columns = 7,
-    ),
-    com.pocketshell.uikit.components.HotkeySection(
-        title = "ARROWS",
-        keys = listOf(
-            KeyBinding(label = "←", kind = KeyKind.Arrow),
-            KeyBinding(label = "↑", kind = KeyKind.Arrow),
-            KeyBinding(label = "↓", kind = KeyKind.Arrow),
-            KeyBinding(label = "→", kind = KeyKind.Arrow),
-        ),
-        columns = 4,
+        extended = true,
     ),
 )
 

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxHotkeyPanelSectionsTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxHotkeyPanelSectionsTest.kt
@@ -1,0 +1,127 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.uikit.model.KeyKind
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1332 — the production terminal-hotkeys catalog ([TmuxHotkeyPanelSections])
+ * must satisfy the progressive-disclosure contract:
+ *  - ARROWS is the FIRST/top section and part of the COMMON (always-shown) set.
+ *  - The COMMON set (sections with `extended = false`) is exactly the arrows plus
+ *    the everyday `Esc`/`Tab`/`Enter`/`^C`/`^D`.
+ *  - Everything else (full CTRL combos, `⇧Tab`, doubled interrupt/EOF, the `Ctrl`
+ *    sticky modifier, and the a–z letters) is EXTENDED (`extended = true`), behind
+ *    the "Show more keys" expander.
+ *  - No key from the pre-#1332 catalog was dropped — every label is still routed
+ *    (order/disclosure only, no key made unreachable).
+ *
+ * This is a pure JVM data-model assertion on the production catalog (no Compose
+ * runtime); the panel's disclosure rendering + routing is proven separately by
+ * the ui-kit `TerminalHotkeysPanelProgressiveDisclosureTest`.
+ */
+class TmuxHotkeyPanelSectionsTest {
+
+    private val sections = TmuxHotkeyPanelSections
+    private val common = sections.filterNot { it.extended }
+    private val extended = sections.filter { it.extended }
+
+    private val arrows = listOf("←", "↑", "↓", "→")
+
+    @Test
+    fun arrowsIsTheFirstSectionAndAllArrowsAreArrowKind() {
+        val first = sections.first()
+        assertEquals(
+            "Issue #1332: ARROWS must be the FIRST/top section of the hotkeys panel",
+            "ARROWS",
+            first.title,
+        )
+        assertEquals(
+            "Issue #1332: the first section must be exactly the four arrows",
+            arrows,
+            first.keys.map { it.label },
+        )
+        assertTrue(
+            "Issue #1332: the arrow section is part of the common (always-shown) set",
+            !first.extended,
+        )
+        assertTrue(
+            "Issue #1332: every arrow key must be KeyKind.Arrow",
+            first.keys.all { it.kind == KeyKind.Arrow },
+        )
+    }
+
+    @Test
+    fun commonSetIsExactlyArrowsPlusEverydayEssentials() {
+        val commonLabels = common.flatMap { it.keys.map { k -> k.label } }
+        assertEquals(
+            "Issue #1332: the COMMON (default-shown) set must be exactly arrows + " +
+                "Esc/Tab/Enter/^C/^D — nothing more, nothing less",
+            arrows + listOf("Esc", "Tab", TmuxHotkeyEnterLabel, "^C", "^D"),
+            commonLabels,
+        )
+        // The common set is compact — a couple of rows (2 sections).
+        assertEquals(
+            "Issue #1332: the common set should be two compact sections (arrows + essentials)",
+            2,
+            common.size,
+        )
+    }
+
+    @Test
+    fun extendedSetHoldsTheFullGridsBehindTheExpander() {
+        val extendedLabels = extended.flatMap { it.keys.map { k -> k.label } }
+
+        // Full CTRL COMBOS grid.
+        val ctrlCombos = listOf(
+            "^A", "^B", "^C", "^D", "^E", "^G", "^J", "^K", "^L", "^O",
+            "^R", "^T", "^U", "^W", "^X", "^Z", "^\\",
+        )
+        assertTrue(
+            "Issue #1332: the full CTRL COMBOS grid must live in the extended set",
+            extendedLabels.containsAll(ctrlCombos),
+        )
+        // ⇧Tab, doubled interrupt/EOF, sticky Ctrl, and a–z letters.
+        assertTrue(
+            "Issue #1332: ⇧Tab must be extended (moved out of the common row)",
+            extendedLabels.contains("⇧Tab"),
+        )
+        assertTrue(
+            "Issue #1332: doubled interrupt/EOF chords must be extended",
+            extendedLabels.containsAll(listOf(TmuxHotkeyInterruptX2Label, TmuxHotkeyEofX2Label)),
+        )
+        assertTrue(
+            "Issue #1332: the a–z LETTERS grid must be extended",
+            extendedLabels.containsAll(('a'..'z').map { it.toString() }),
+        )
+        // The sticky Ctrl modifier is extended and is a Modifier key.
+        val ctrl = extended.flatMap { it.keys }.single { it.label == TmuxHotkeyCtrlModifierLabel }
+        assertEquals(
+            "Issue #1332: the sticky Ctrl modifier must keep KeyKind.Modifier",
+            KeyKind.Modifier,
+            ctrl.kind,
+        )
+    }
+
+    @Test
+    fun noKeyFromThePreDisclosureCatalogWasDropped() {
+        val allLabels = sections.flatMap { it.keys.map { k -> k.label } }.toSet()
+        // The complete set of keys that existed before #1332 (arrows + KEYS +
+        // CTRL COMBOS + INTERRUPT/EOF + CTRL modifier + a–z). Every one must still
+        // be reachable somewhere in the catalog — #1332 only reordered/split.
+        val required = buildSet {
+            addAll(arrows)
+            addAll(listOf("Esc", "Tab", "⇧Tab", TmuxHotkeyEnterLabel))
+            addAll(listOf("^A", "^B", "^C", "^D", "^E", "^G", "^J", "^K", "^L", "^O", "^R", "^T", "^U", "^W", "^X", "^Z", "^\\"))
+            addAll(listOf(TmuxHotkeyInterruptX2Label, TmuxHotkeyEofX2Label))
+            add(TmuxHotkeyCtrlModifierLabel)
+            addAll(('a'..'z').map { it.toString() })
+        }
+        val missing = required - allLabels
+        assertTrue(
+            "Issue #1332: no key may become unreachable — missing from catalog: $missing",
+            missing.isEmpty(),
+        )
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
@@ -7775,35 +7775,41 @@ class TmuxSessionViewModelTest {
         // #1091 FILLED the missing nano/TUI control keys into CTRL COMBOS
         // (`^G ^J ^K ^O ^T ^U ^W ^X ^\`) and DELIBERATELY restored a sticky
         // `Ctrl` modifier plus the a–z LETTERS grid so `Ctrl+<any letter>` is
-        // reachable. Verify the curated set is exactly what we expect and has
-        // no duplicate labels.
+        // reachable. Issue #1332 reordered ARROWS to the TOP and introduced
+        // progressive disclosure: a compact COMMON set (arrows + Esc/Tab/Enter/
+        // ^C/^D) shown by default, everything else EXTENDED behind the expander.
+        // Verify the curated set is exactly what we expect in the new order.
         val labels = TmuxHotkeyPanelSections.flatMap { it.keys }.map { it.label }
         assertEquals(
             listOf(
-                // KEYS — Issue #893: ⇧Tab (back-tab / Shift+Tab) sits between
-                // Tab and Enter.
-                "Esc", "Tab", "⇧Tab", "Enter",
+                // ARROWS — Issue #1332: now the FIRST/top section.
+                "←", "↑", "↓", "→",
+                // COMMON — Issue #1332: the everyday essentials shown by default.
+                "Esc", "Tab", "Enter", "^C", "^D",
                 // CTRL COMBOS — Issue #1091 ordered by control byte; the
-                // previously-missing nano/TUI keys are filled in.
+                // previously-missing nano/TUI keys are filled in. Now EXTENDED.
                 "^A", "^B", "^C", "^D", "^E", "^G", "^J", "^K", "^L", "^O",
                 "^R", "^T", "^U", "^W", "^X", "^Z", "^\\",
-                // INTERRUPT / EOF — Issue #787 doubled chords.
+                // MORE KEYS — Issue #893 ⇧Tab (back-tab), Issue #1332 EXTENDED.
+                "⇧Tab",
+                // INTERRUPT / EOF — Issue #787 doubled chords. Now EXTENDED.
                 TmuxHotkeyInterruptX2Label, TmuxHotkeyEofX2Label,
-                // CTRL + LETTER — Issue #1091 sticky modifier.
+                // CTRL + LETTER — Issue #1091 sticky modifier. Now EXTENDED.
                 TmuxHotkeyCtrlModifierLabel,
-                // LETTERS — Issue #1091 a–z grid for Ctrl composition.
+                // LETTERS — Issue #1091 a–z grid for Ctrl composition. Now EXTENDED.
                 "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m",
                 "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z",
-                // ARROWS.
-                "←", "↑", "↓", "→",
             ),
             labels,
         )
-        // Issue #893: the back-tab key is present in the KEYS section.
+        // Issue #893: the back-tab key is present (now in the EXTENDED MORE KEYS).
         assertTrue(labels.contains("⇧Tab"))
-        // No duplicates (the maintainer's "/ appears twice" / "Esc duplicated"
-        // complaints) — still holds with the filled keys + LETTERS grid added.
-        assertEquals(labels.size, labels.toSet().size)
+        // Issue #1332: the ONLY intentional duplicates are `^C` / `^D` — surfaced
+        // both in the common essentials row AND kept in the full CTRL COMBOS grid
+        // (the most-reached-for control keys). No OTHER label repeats (the
+        // maintainer's "/ appears twice" / "Esc duplicated" complaints still hold).
+        val duplicated = labels.groupingBy { it }.eachCount().filterValues { it > 1 }.keys
+        assertEquals(setOf("^C", "^D"), duplicated)
         // Issue #1091: the sticky `Ctrl` modifier is now INTENTIONALLY present
         // (it is the general `Ctrl+<letter>` escape hatch), and it is a
         // Modifier-kind key, not a lone Regular button.
@@ -7829,8 +7835,9 @@ class TmuxSessionViewModelTest {
         assertTrue(labels.contains(TmuxHotkeyEofX2Label))
         assertTrue(labels.contains("^C"))
         assertTrue(labels.contains("^D"))
-        // The arrow section uses the clean glyphs, marked as Arrow kind.
-        val arrows = TmuxHotkeyPanelSections.last().keys
+        // Issue #1332: the arrow section is now the FIRST section (was last), still
+        // using the clean glyphs, marked as Arrow kind.
+        val arrows = TmuxHotkeyPanelSections.first().keys
         assertEquals(listOf("←", "↑", "↓", "→"), arrows.map { it.label })
         assertTrue(arrows.all { it.kind == KeyKind.Arrow })
     }

--- a/shared/ui-kit/src/main/java/com/pocketshell/uikit/components/TerminalHotkeysPanel.kt
+++ b/shared/ui-kit/src/main/java/com/pocketshell/uikit/components/TerminalHotkeysPanel.kt
@@ -1,5 +1,6 @@
 package com.pocketshell.uikit.components
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -8,9 +9,11 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -22,6 +25,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.Role
@@ -72,10 +76,26 @@ data class HotkeySection(
      * trailing slots empty (keys stay full-size, never stretched).
      */
     val columns: Int,
+    /**
+     * Issue #1332 — progressive disclosure. `false` (default) => this section is
+     * part of the COMMON set, always shown. `true` => this section lives behind
+     * the "Show more keys" expander and is only rendered when the panel is
+     * expanded. The catalog puts the everyday keys (arrows + Esc/Tab/Enter/^C/^D)
+     * in the common set and the full CTRL-combos / letters / doubled-chord grids
+     * behind the expander so the panel opens compact.
+     */
+    val extended: Boolean = false,
 )
 
 const val TERMINAL_HOTKEYS_PANEL_TAG: String = "terminal:hotkeys-panel"
 const val TERMINAL_HOTKEYS_PANEL_CLOSE_TAG: String = "terminal:hotkeys-panel-close"
+
+/**
+ * Issue #1332: test tag on the "Show more / Show fewer keys" expander row that
+ * toggles the extended sections. Only rendered when the panel actually has
+ * [HotkeySection.extended] sections to reveal.
+ */
+const val TERMINAL_HOTKEYS_PANEL_EXPAND_TAG: String = "terminal:hotkeys-panel-expand"
 
 /**
  * Test-only semantics flag (issue #755): `true` on a key slot whose label
@@ -100,6 +120,16 @@ val HotkeyModifierActiveKey: SemanticsPropertyKey<Boolean> =
     SemanticsPropertyKey("HotkeyModifierActive")
 var SemanticsPropertyReceiver.hotkeyModifierActive: Boolean by HotkeyModifierActiveKey
 
+/**
+ * Issue #1332: test-readable flag on the expander row — `true` when the panel is
+ * expanded (extended sections shown), `false` when collapsed (common set only).
+ * A JVM Compose test reads it to assert the progressive-disclosure state without
+ * relying on layout timing. Render-only; no behaviour.
+ */
+val HotkeyPanelExpandedKey: SemanticsPropertyKey<Boolean> =
+    SemanticsPropertyKey("HotkeyPanelExpanded")
+var SemanticsPropertyReceiver.hotkeyPanelExpanded: Boolean by HotkeyPanelExpandedKey
+
 @Composable
 fun TerminalHotkeysPanel(
     sections: List<HotkeySection>,
@@ -112,7 +142,22 @@ fun TerminalHotkeysPanel(
     // the [KeyBar] modifier visual. The single shared state is enough because
     // the panel has exactly one modifier (`Ctrl`).
     modifierState: KeyModifierState = KeyModifierState.Off,
+    // Issue #1332: seed the collapsed/expanded state. Defaults to `false` so the
+    // panel opens COLLAPSED every time it is shown (no persistence — the sheet
+    // re-enters composition on each open, resetting the remembered state). It is
+    // overridable ONLY so the JVM render harness can snapshot the expanded state
+    // (a captured render cannot tap the expander); production callers never pass
+    // it.
+    initiallyExpanded: Boolean = false,
 ) {
+    // Issue #1332: progressive disclosure. The COMMON sections (arrows first,
+    // then the everyday keys) are always shown; the EXTENDED sections (the full
+    // CTRL combos / letters / doubled chords) hide behind the expander so the
+    // panel opens compact.
+    val commonSections = sections.filterNot { it.extended }
+    val extendedSections = sections.filter { it.extended }
+    var expanded by remember { mutableStateOf(initiallyExpanded) }
+
     Column(
         modifier = modifier
             .fillMaxWidth()
@@ -135,7 +180,7 @@ fun TerminalHotkeysPanel(
             modifier = Modifier.padding(top = 6.dp),
         )
 
-        sections.forEach { section ->
+        commonSections.forEach { section ->
             HotkeySectionGrid(
                 section = section,
                 onKey = onKey,
@@ -143,6 +188,75 @@ fun TerminalHotkeysPanel(
                 modifierState = modifierState,
             )
         }
+
+        if (extendedSections.isNotEmpty()) {
+            HotkeyExpandToggle(
+                expanded = expanded,
+                enabled = enabled,
+                onToggle = { expanded = !expanded },
+            )
+            // Smooth reveal/collapse: the extended block fades + expands in and
+            // shrinks + fades out. When collapsed the extended sections are NOT
+            // composed at all, so their keys genuinely aren't in the tree.
+            AnimatedVisibility(visible = expanded) {
+                Column(verticalArrangement = Arrangement.spacedBy(14.dp)) {
+                    extendedSections.forEach { section ->
+                        HotkeySectionGrid(
+                            section = section,
+                            onKey = onKey,
+                            enabled = enabled,
+                            modifierState = modifierState,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Issue #1332: the "Show more keys" / "Show fewer keys" expander that toggles the
+ * extended sections. A full-width, bordered, accent-labelled row with a chevron
+ * that flips with the state. Publishes [hotkeyPanelExpanded] for tests.
+ */
+@Composable
+private fun HotkeyExpandToggle(
+    expanded: Boolean,
+    enabled: Boolean,
+    onToggle: () -> Unit,
+) {
+    val label = if (expanded) "Show fewer keys" else "Show more keys"
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .border(
+                border = BorderStroke(1.dp, PocketShellColors.Border),
+                shape = RoundedCornerShape(8.dp),
+            )
+            .let { if (enabled) it.clickable(role = Role.Button, onClick = onToggle) else it }
+            .testTag(TERMINAL_HOTKEYS_PANEL_EXPAND_TAG)
+            .semantics(mergeDescendants = true) {
+                hotkeyPanelExpanded = expanded
+                contentDescription = label
+            }
+            .padding(vertical = 10.dp),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = label,
+            color = if (enabled) PocketShellColors.Accent else PocketShellColors.TextMuted,
+            fontSize = 13.sp,
+            fontWeight = FontWeight.Medium,
+        )
+        Spacer(modifier = Modifier.width(6.dp))
+        Text(
+            text = if (expanded) "▴" else "▾",
+            color = if (enabled) PocketShellColors.Accent else PocketShellColors.TextMuted,
+            fontSize = 13.sp,
+            fontWeight = FontWeight.Medium,
+        )
     }
 }
 

--- a/shared/ui-kit/src/test/java/com/pocketshell/uikit/components/TerminalHotkeysPanelProgressiveDisclosureTest.kt
+++ b/shared/ui-kit/src/test/java/com/pocketshell/uikit/components/TerminalHotkeysPanelProgressiveDisclosureTest.kt
@@ -1,0 +1,291 @@
+package com.pocketshell.uikit.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.width
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.unit.dp
+import com.pocketshell.uikit.model.KeyBinding
+import com.pocketshell.uikit.model.KeyKind
+import com.pocketshell.uikit.theme.PocketShellTheme
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * Issue #1332 — the terminal hotkeys panel opens COMPACT (progressive
+ * disclosure): ARROWS at the TOP, then the everyday `Esc`/`Tab`/`Enter`/`^C`/`^D`
+ * row, and a "Show more keys" expander. The full CTRL-combos / letters / doubled
+ * chords / sticky-Ctrl grids live behind the expander.
+ *
+ * This JVM Robolectric Compose test (Unit gate, no emulator) is the load-bearing
+ * proof for every acceptance criterion:
+ *  - ARROWS render as the FIRST/top section (positional check on y-bounds).
+ *  - Collapsed shows ONLY the common set; the extended-only keys are genuinely
+ *    absent from the tree (`AnimatedVisibility` does not compose hidden content).
+ *  - Tapping the expander reveals the full extended set; tapping again collapses.
+ *  - Every key still routes through `onKey` — common keys while collapsed AND
+ *    extended keys once expanded — so no key becomes unreachable.
+ *
+ * It composes a production-SHAPED catalog (arrows-first, common/extended split);
+ * the real `TmuxHotkeyPanelSections` catalog is asserted to match this contract
+ * by the app-module `TmuxHotkeyPanelSectionsTest`.
+ */
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(qualifiers = "w412dp-h915dp-night-xxhdpi")
+class TerminalHotkeysPanelProgressiveDisclosureTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    // Extended-ONLY labels (not present in the common set), used to assert the
+    // collapsed panel hides them and the expander reveals them.
+    private val extendedOnlyLabels = listOf(
+        "^A", "^B", "^E", "^G", "^J", "^K", "^L", "^O", "^R", "^T",
+        "^U", "^W", "^X", "^Z", "^\\", // full CTRL COMBOS (minus ^C/^D which are common)
+        "⇧Tab", // MORE KEYS
+        "^C×2", "^D×2", // INTERRUPT / EOF
+        "Ctrl", // CTRL + LETTER sticky modifier
+        "a", "m", "z", // representative LETTERS
+    )
+
+    private val commonLabels = listOf("←", "↑", "↓", "→", "Esc", "Tab", "Enter", "^C", "^D")
+
+    private fun sections(): List<HotkeySection> = listOf(
+        HotkeySection(
+            title = "ARROWS",
+            keys = listOf(
+                KeyBinding("←", KeyKind.Arrow),
+                KeyBinding("↑", KeyKind.Arrow),
+                KeyBinding("↓", KeyKind.Arrow),
+                KeyBinding("→", KeyKind.Arrow),
+            ),
+            columns = 4,
+        ),
+        HotkeySection(
+            title = "COMMON",
+            keys = listOf(
+                KeyBinding("Esc", KeyKind.Regular),
+                KeyBinding("Tab", KeyKind.Regular),
+                KeyBinding("Enter", KeyKind.Regular),
+                KeyBinding("^C", KeyKind.Regular),
+                KeyBinding("^D", KeyKind.Regular),
+            ),
+            columns = 5,
+        ),
+        HotkeySection(
+            title = "CTRL COMBOS",
+            keys = listOf(
+                "^A", "^B", "^C", "^D", "^E", "^G", "^J", "^K", "^L", "^O",
+                "^R", "^T", "^U", "^W", "^X", "^Z", "^\\",
+            ).map { KeyBinding(it, KeyKind.Regular) },
+            columns = 4,
+            extended = true,
+        ),
+        HotkeySection(
+            title = "MORE KEYS",
+            keys = listOf(KeyBinding("⇧Tab", KeyKind.Regular)),
+            columns = 4,
+            extended = true,
+        ),
+        HotkeySection(
+            title = "INTERRUPT / EOF",
+            keys = listOf(
+                KeyBinding("^C×2", KeyKind.Regular),
+                KeyBinding("^D×2", KeyKind.Regular),
+            ),
+            columns = 2,
+            extended = true,
+        ),
+        HotkeySection(
+            title = "CTRL + LETTER",
+            keys = listOf(KeyBinding("Ctrl", KeyKind.Modifier)),
+            columns = 4,
+            extended = true,
+        ),
+        HotkeySection(
+            title = "LETTERS",
+            keys = ('a'..'z').map { KeyBinding(it.toString(), KeyKind.Regular) },
+            columns = 7,
+            extended = true,
+        ),
+    )
+
+    private fun setPanel(onKey: (KeyBinding) -> Unit = {}) {
+        composeRule.setContent {
+            PocketShellTheme {
+                // A realistic small-phone width so the arrows/common rows lay out
+                // as they would on-device.
+                Box(modifier = Modifier.width(360.dp).fillMaxHeight().testTag(HOST_TAG)) {
+                    TerminalHotkeysPanel(
+                        sections = sections(),
+                        onKey = onKey,
+                        onClose = {},
+                    )
+                }
+            }
+        }
+        composeRule.waitForIdle()
+    }
+
+    private fun expandedFlagNodes() =
+        composeRule.onAllNodes(SemanticsMatcher.expectValue(HotkeyPanelExpandedKey, true))
+
+    private fun collapsedFlagNodes() =
+        composeRule.onAllNodes(SemanticsMatcher.expectValue(HotkeyPanelExpandedKey, false))
+
+    @Test
+    fun arrowsRenderAsFirstTopSectionAboveCommonAndExpander() {
+        setPanel()
+        val arrowTop = composeRule.onNodeWithText("←").fetchSemanticsNode().boundsInRoot.top
+        val escTop = composeRule.onNodeWithText("Esc").fetchSemanticsNode().boundsInRoot.top
+        val expanderTop = composeRule.onNodeWithTag(TERMINAL_HOTKEYS_PANEL_EXPAND_TAG)
+            .fetchSemanticsNode().boundsInRoot.top
+
+        assertTrue(
+            "Issue #1332: ARROWS must be the FIRST section — the arrow row must " +
+                "sit above the COMMON (Esc) row. arrowTop=$arrowTop escTop=$escTop",
+            arrowTop < escTop,
+        )
+        assertTrue(
+            "Issue #1332: the common keys must sit above the 'Show more keys' " +
+                "expander. escTop=$escTop expanderTop=$expanderTop",
+            escTop < expanderTop,
+        )
+    }
+
+    @Test
+    fun collapsedShowsOnlyCommonSetExtendedKeysHidden() {
+        setPanel()
+
+        // The expander reports collapsed state.
+        collapsedFlagNodes().assertCountEquals(1)
+        composeRule.onNodeWithText("Show more keys").assertIsDisplayed()
+
+        // Every common key is present and fully within the panel root.
+        for (label in commonLabels) {
+            val nodes = composeRule.onAllNodesWithText(label).fetchSemanticsNodes()
+            assertTrue("Issue #1332: common key '$label' must be shown by default", nodes.isNotEmpty())
+        }
+        assertNodeFullyWithinRoot("←")
+        assertNodeFullyWithinRoot("Esc")
+
+        // Every EXTENDED-only key is genuinely absent (not composed) while collapsed.
+        for (label in extendedOnlyLabels) {
+            composeRule.onAllNodesWithText(label).assertCountEquals(0)
+        }
+    }
+
+    @Test
+    fun expandingRevealsFullExtendedSetThenCollapseHidesItAgain() {
+        setPanel()
+
+        composeRule.onNodeWithTag(TERMINAL_HOTKEYS_PANEL_EXPAND_TAG).performClick()
+        composeRule.waitForIdle()
+
+        // Now expanded: flag flips, label flips, and every extended key is present.
+        expandedFlagNodes().assertCountEquals(1)
+        composeRule.onNodeWithText("Show fewer keys").assertIsDisplayed()
+        for (label in extendedOnlyLabels) {
+            val nodes = composeRule.onAllNodesWithText(label).fetchSemanticsNodes()
+            assertTrue("Issue #1332: extended key '$label' must appear once expanded", nodes.isNotEmpty())
+        }
+        // Common keys stay visible after expanding (arrows still first).
+        for (label in commonLabels) {
+            assertTrue(
+                "Issue #1332: common key '$label' must remain shown when expanded",
+                composeRule.onAllNodesWithText(label).fetchSemanticsNodes().isNotEmpty(),
+            )
+        }
+
+        // Collapse again: extended keys disappear.
+        composeRule.onNodeWithTag(TERMINAL_HOTKEYS_PANEL_EXPAND_TAG).performClick()
+        composeRule.waitForIdle()
+        collapsedFlagNodes().assertCountEquals(1)
+        for (label in extendedOnlyLabels) {
+            composeRule.onAllNodesWithText(label).assertCountEquals(0)
+        }
+    }
+
+    @Test
+    fun commonKeysRouteThroughOnKeyWhileCollapsed() {
+        val taps = mutableListOf<String>()
+        setPanel { taps += it.label }
+
+        composeRule.onNodeWithText("←").performClick()
+        composeRule.onNodeWithText("Esc").performClick()
+        composeRule.onNodeWithText("^C").performClick() // collapsed => exactly one ^C (the common one)
+        composeRule.onNodeWithText("^D").performClick()
+
+        assertEquals(
+            "Issue #1332: common keys must still route through onKey unchanged",
+            listOf("←", "Esc", "^C", "^D"),
+            taps,
+        )
+    }
+
+    @Test
+    fun extendedKeysRouteThroughOnKeyOnceExpanded() {
+        val taps = mutableListOf<String>()
+        setPanel { taps += it.label }
+
+        composeRule.onNodeWithTag(TERMINAL_HOTKEYS_PANEL_EXPAND_TAG).performClick()
+        composeRule.waitForIdle()
+
+        // Scroll each key into view before clicking — the panel body scrolls, so
+        // the lower extended sections (LETTERS) sit below the fold on a phone.
+        composeRule.onNodeWithText("^A").performScrollTo().performClick()
+        composeRule.onNodeWithText("⇧Tab").performScrollTo().performClick()
+        composeRule.onNodeWithText("^C×2").performScrollTo().performClick()
+        composeRule.onNodeWithText("Ctrl").performScrollTo().performClick()
+        composeRule.onNodeWithText("z").performScrollTo().performClick()
+
+        assertEquals(
+            "Issue #1332: extended keys must route through onKey unchanged once revealed",
+            listOf("^A", "⇧Tab", "^C×2", "Ctrl", "z"),
+            taps,
+        )
+    }
+
+    /**
+     * Viewport containment (F2/F3): the node with [label] must sit fully within
+     * the window root — the property `assertIsDisplayed()` does NOT verify (a key
+     * pushed off an edge still reports "displayed").
+     */
+    private fun assertNodeFullyWithinRoot(label: String) {
+        val density = composeRule.density.density
+        val slopPx = 2f * density
+        val bounds = composeRule.onNodeWithText(label).fetchSemanticsNode().boundsInRoot
+        val root = composeRule.onRoot().fetchSemanticsNode().boundsInRoot
+        val within = bounds.left >= root.left - slopPx &&
+            bounds.top >= root.top - slopPx &&
+            bounds.right <= root.right + slopPx &&
+            bounds.bottom <= root.bottom + slopPx
+        assertTrue(
+            "Issue #1332: '$label' must be fully within the panel root — " +
+                "nodeBounds=$bounds rootBounds=$root",
+            within,
+        )
+    }
+
+    private companion object {
+        const val HOST_TAG = "issue1332:hotkeys-panel-host"
+    }
+}

--- a/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenders.kt
+++ b/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenders.kt
@@ -144,26 +144,62 @@ class DesignRenders {
                 // Issue #1091: render the sticky `Ctrl` modifier ARMED so the
                 // accent treatment on the `Ctrl` key is visually checked.
                 modifierState = com.pocketshell.uikit.model.KeyModifierState.OneShot,
+                // Issue #1332: default-collapsed render shows the compact COMMON
+                // set only (ARROWS first, then Esc/Tab/Enter/^C/^D) + the "Show
+                // more keys" expander.
+                initiallyExpanded = true,
             )
         }
     }
 
     /**
-     * Issue #1091: the post-#1091 hotkeys panel — `CTRL COMBOS` filled with the
-     * nano keys (`^G`/`^J`/`^K`/`^O`/`^T`/`^U`/`^W`/`^X`/`^\`), the sticky
-     * `Ctrl` modifier, and the a–z LETTERS grid for `Ctrl+<any letter>`.
+     * Issue #1332: the DEFAULT (collapsed) hotkeys panel — the compact COMMON
+     * set the maintainer sees on open: ARROWS at the TOP, then the everyday
+     * `Esc`/`Tab`/`Enter`/`^C`/`^D` row, and the "Show more keys" expander. The
+     * full CTRL/letters grids are hidden until expanded.
+     */
+    @Test
+    fun terminalHotkeysPanelCollapsed() = render("terminal-hotkeys-panel-collapsed") {
+        Surface(color = PocketShellColors.Surface) {
+            com.pocketshell.uikit.components.TerminalHotkeysPanel(
+                sections = sampleHotkeySections(),
+                onKey = {},
+                onClose = {},
+                initiallyExpanded = false,
+            )
+        }
+    }
+
+    /**
+     * Issue #1091 + #1332: the EXPANDED hotkeys panel — `CTRL COMBOS` filled with
+     * the nano keys (`^G`/`^J`/`^K`/`^O`/`^T`/`^U`/`^W`/`^X`/`^\`), the sticky
+     * `Ctrl` modifier, and the a–z LETTERS grid — all revealed behind the
+     * expander, with ARROWS still pinned at the top.
      */
     private fun sampleHotkeySections(): List<com.pocketshell.uikit.components.HotkeySection> =
         listOf(
+            // Issue #1332: ARROWS first (common, always shown).
             com.pocketshell.uikit.components.HotkeySection(
-                title = "KEYS",
+                title = "ARROWS",
+                keys = listOf(
+                    KeyBinding("←", KeyKind.Arrow),
+                    KeyBinding("↑", KeyKind.Arrow),
+                    KeyBinding("↓", KeyKind.Arrow),
+                    KeyBinding("→", KeyKind.Arrow),
+                ),
+                columns = 4,
+            ),
+            // Issue #1332: the compact COMMON essentials row (always shown).
+            com.pocketshell.uikit.components.HotkeySection(
+                title = "COMMON",
                 keys = listOf(
                     KeyBinding("Esc", KeyKind.Regular),
                     KeyBinding("Tab", KeyKind.Regular),
-                    KeyBinding("⇧Tab", KeyKind.Regular),
                     KeyBinding("Enter", KeyKind.Regular),
+                    KeyBinding("^C", KeyKind.Regular),
+                    KeyBinding("^D", KeyKind.Regular),
                 ),
-                columns = 4,
+                columns = 5,
             ),
             com.pocketshell.uikit.components.HotkeySection(
                 title = "CTRL COMBOS",
@@ -187,6 +223,13 @@ class DesignRenders {
                     KeyBinding("^\\", KeyKind.Regular),
                 ),
                 columns = 4,
+                extended = true,
+            ),
+            com.pocketshell.uikit.components.HotkeySection(
+                title = "MORE KEYS",
+                keys = listOf(KeyBinding("⇧Tab", KeyKind.Regular)),
+                columns = 4,
+                extended = true,
             ),
             com.pocketshell.uikit.components.HotkeySection(
                 title = "INTERRUPT / EOF",
@@ -195,26 +238,19 @@ class DesignRenders {
                     KeyBinding("^D×2", KeyKind.Regular),
                 ),
                 columns = 2,
+                extended = true,
             ),
             com.pocketshell.uikit.components.HotkeySection(
                 title = "CTRL + LETTER",
                 keys = listOf(KeyBinding("Ctrl", KeyKind.Modifier)),
                 columns = 4,
+                extended = true,
             ),
             com.pocketshell.uikit.components.HotkeySection(
                 title = "LETTERS",
                 keys = ('a'..'z').map { KeyBinding(it.toString(), KeyKind.Regular) },
                 columns = 7,
-            ),
-            com.pocketshell.uikit.components.HotkeySection(
-                title = "ARROWS",
-                keys = listOf(
-                    KeyBinding("←", KeyKind.Arrow),
-                    KeyBinding("↑", KeyKind.Arrow),
-                    KeyBinding("↓", KeyKind.Arrow),
-                    KeyBinding("→", KeyKind.Arrow),
-                ),
-                columns = 4,
+                extended = true,
             ),
         )
 


### PR DESCRIPTION
Closes #1332. Maintainer dogfood request: arrows (← ↑ ↓ →) at the TOP of the hotkeys panel + progressive disclosure (COMMON set default, EXTENDED behind a 'Show more keys' expander). Order/disclosure only — no routing/byte change, every key still reachable. Reviewer APPROVED with on-device proof: 8 emulator tests green, keyboard-up screenshots attached (arrows top, expander works, launcher above keyboard, nothing clipped), reviewer-run red→green, key-set preserved.