### PR TITLE
conversation: scope #819 dedup to the synthetic echo shape (#1234 item 5)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/session/AgentConversationRepository.kt
+++ b/app/src/main/java/com/pocketshell/app/session/AgentConversationRepository.kt
@@ -182,12 +182,22 @@ internal fun reconcileAgentEvents(
             if (previous != null &&
                 previous.role == event.role &&
                 previous.text == event.text &&
-                previous.agent == event.agent
+                previous.agent == event.agent &&
+                // Issue #1234 (item 5): the collapse must fire ONLY for the
+                // #819 echo+record SHAPE — exactly one side lacks a stable id
+                // (the streaming echo's `line.hashCode()` fallback; a real
+                // `response_item`/UUID record always has one). Two ADJACENT
+                // authoritative records with distinct stable ids are a
+                // genuinely repeated turn — a real back-to-back "ok"/"Done." —
+                // and must both survive. Without this guard the old
+                // any-identical-adjacent-pair collapse silently merged those
+                // real repeats down to one.
+                (previous.lacksStableId() != event.lacksStableId())
             ) {
                 // Consecutive duplicate of the same turn (the Codex echo +
-                // record pair). Keep the one already inserted; skip this one.
-                // The previous entry stays "last" so a third identical write
-                // (rare) also collapses.
+                // record pair — one synthetic id, one real). Keep the one
+                // already inserted; skip this one. The previous entry stays
+                // "last" so a third identical write (rare) also collapses.
                 continue
             }
         }
@@ -283,6 +293,23 @@ private fun List<ConversationEvent>.takeLastPreservingMessages(
 
 private fun ConversationEvent.Message.isOptimistic(): Boolean =
     id.startsWith(OPTIMISTIC_USER_MESSAGE_ID_PREFIX)
+
+/**
+ * Issue #1234 (item 5): a message id that is a bare signed-decimal integer is
+ * the parser's `line.hashCode().toString()` fallback (`CodexParser`/
+ * `ClaudeCodeParser` mint it ONLY when a transcript line carried no stable
+ * `id`/`call_id`). That is the fingerprint of the streaming-echo half of a #819
+ * echo+record pair — the transient `event_msg`/`agent_message` line has no id,
+ * while its authoritative `response_item`/`message` (or Claude UUID) record
+ * always does. A real transcript id is never a bare integer, so this cleanly
+ * separates "streaming echo, no stable id" from a genuine authoritative record;
+ * the adjacency collapse fires only for the mixed (one-synthetic, one-stable)
+ * echo shape, never for two real records that happen to repeat the same text.
+ */
+private val SYNTHETIC_HASHCODE_ID_PATTERN: Regex = Regex("^-?\\d+$")
+
+private fun ConversationEvent.Message.lacksStableId(): Boolean =
+    SYNTHETIC_HASHCODE_ID_PATTERN.matches(id)
 
 /**
  * Issue #494: return a copy of this feed where the optimistic user turn

--- a/app/src/test/java/com/pocketshell/app/session/AgentConversationRepositoryTest.kt
+++ b/app/src/test/java/com/pocketshell/app/session/AgentConversationRepositoryTest.kt
@@ -348,6 +348,84 @@ class AgentConversationRepositoryTest {
         )
     }
 
+    @Test
+    fun reconcileKeepsGenuinelyRepeatedAdjacentAssistantTurnsWithDistinctStableIds() {
+        // Issue #1234 (item 5): the #819 echo-collapse over-reached. Its
+        // adjacency check collapsed ANY two adjacent Messages with the same
+        // role+text+agent, so a genuinely repeated SHORT turn the agent really
+        // emitted twice back-to-back (a real "Done." / "ok") silently showed
+        // once. The collapse must fire ONLY for the echo SHAPE — one side is
+        // the streaming echo with a synthetic `line.hashCode()` id, the other
+        // is the authoritative record with a stable id. Two ADJACENT records
+        // that BOTH carry a distinct STABLE id are a real repeat and must both
+        // survive.
+        //
+        // Before the fix this reconciles to a SINGLE "Done." (RED); after the
+        // fix both survive (GREEN).
+        val first = ConversationEvent.Message(
+            id = "codex-real-done-1",
+            agent = AgentKind.Codex,
+            role = ConversationRole.Assistant,
+            text = "Done.",
+        )
+        val second = ConversationEvent.Message(
+            id = "codex-real-done-2",
+            agent = AgentKind.Codex,
+            role = ConversationRole.Assistant,
+            text = "Done.",
+        )
+
+        val reconciled = reconcileAgentEvents(listOf(first, second))
+
+        val dones = reconciled.filterIsInstance<ConversationEvent.Message>()
+            .filter { it.role == ConversationRole.Assistant && it.text == "Done." }
+        assertEquals(
+            "two ADJACENT authoritative assistant records with the same text " +
+                "but DISTINCT stable ids are a genuine repeat, not an echo — " +
+                "both must survive (#1234 item 5)",
+            2,
+            dones.size,
+        )
+        assertTrue(dones.any { it.id == "codex-real-done-1" })
+        assertTrue(dones.any { it.id == "codex-real-done-2" })
+    }
+
+    @Test
+    fun reconcileKeepsGenuinelyRepeatedAdjacentUserTurnsWithDistinctStableIds() {
+        // Issue #1234 (item 5), class coverage for the USER role: a user who
+        // really sends "ok" twice in a row produces two authoritative user
+        // records with DISTINCT stable ids and no intervening turn. Neither is
+        // an `optimistic:` echo, so the #819 adjacency collapse (pre-fix) would
+        // merge them into one — the same over-reach as the assistant case. With
+        // the echo-shape guard both stable-id records survive.
+        val first = ConversationEvent.Message(
+            id = "codex-real-ok-1",
+            agent = AgentKind.Codex,
+            role = ConversationRole.User,
+            text = "ok",
+        )
+        val second = ConversationEvent.Message(
+            id = "codex-real-ok-2",
+            agent = AgentKind.Codex,
+            role = ConversationRole.User,
+            text = "ok",
+        )
+
+        val reconciled = reconcileAgentEvents(listOf(first, second))
+
+        val oks = reconciled.filterIsInstance<ConversationEvent.Message>()
+            .filter { it.role == ConversationRole.User && it.text == "ok" }
+        assertEquals(
+            "two ADJACENT authoritative user records with the same text but " +
+                "DISTINCT stable ids are a genuine repeat and must both survive " +
+                "(#1234 item 5)",
+            2,
+            oks.size,
+        )
+        assertTrue(oks.any { it.id == "codex-real-ok-1" })
+        assertTrue(oks.any { it.id == "codex-real-ok-2" })
+    }
+
     // ----------------------------------------------------------------
     // Issue #576: the conversation-tail performance hole.
     //


### PR DESCRIPTION
Part of #1234 (item 5 — the only remaining item; 1/2/4/6 already merged via #1273, item 3 → #1271). The #819 duplicate-turn collapse was too aggressive and silently hid real repeated short turns ('ok'/'Done.'). Now scoped to the echo shape (synthetic hashcode id vs stable id). Reviewer APPROVED: reviewer-driven red→green, both roles covered, #819 collapse preserved, D31 adjacency clean (93 tests 0-fail).