### PR TITLE
hosts: one-tap Resume-last-session + deep-linkable Active-Sessions widget (#1239)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/hosts/HostResumeLastSessionE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/hosts/HostResumeLastSessionE2eTest.kt
@@ -1,0 +1,235 @@
+package com.pocketshell.app.hosts
+
+import android.graphics.Bitmap
+import android.os.SystemClock
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.room.Room
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.MainActivity
+import com.pocketshell.app.proof.PreGrantPermissionsRule
+import com.pocketshell.app.session.LastSessionStore
+import com.pocketshell.core.storage.AppDatabase
+import com.pocketshell.core.storage.entity.HostEntity
+import com.pocketshell.core.storage.entity.SshKeyEntity
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+import java.io.FileOutputStream
+
+/**
+ * Issue #1239 — connected end-to-end proof for the host-card one-tap
+ * "Resume last session" affordance (AC1: "Host card exposes one-tap resume of
+ * the last-attached session"; AC4: card-affordance evidence).
+ *
+ * The journey seeds a persisted `last_session` snapshot for host A (the same
+ * store `MainActivity.onStop` writes), plus two saved hosts A and B. It launches
+ * the real [MainActivity] (full Hilt ViewModel graph — no stubbing of the
+ * production wiring), lands on the host list, and asserts:
+ *
+ *  1. The Resume row (`host:resume:<A.id>`) is DISPLAYED under host A — the card
+ *     surfaces the one-tap resume affordance for the matching host.
+ *  2. NO Resume row exists for host B (`host:resume:<B.id>`) — the affordance is
+ *     scoped to the host the snapshot belongs to, so the other card falls back
+ *     to normal navigation (AC1: no dead end / no spurious affordance).
+ *  3. Tapping Resume LEAVES the host list (the `host-list:content` list is gone),
+ *     i.e. it deep-links straight into the live session screen rather than the
+ *     folder tree.
+ *
+ * No Docker / SSH fixture is required: the session screen renders optimistically
+ * on navigation, so "left the host list" is observable regardless of whether the
+ * background SSH handshake completes. The seeded host carries Ready bootstrap
+ * columns + a fresh `lastBootstrapAt` so the cold-launch reprobe is a no-op and
+ * never races this UI-only assertion.
+ *
+ * This test does NOT self-skip on CI (no `assumeTrue` / `assumeFalse(isRunningOnCi())`)
+ * so it durably guards the affordance per-push once wired into
+ * `scripts/ci-journey-suite.sh` (G3/G9).
+ */
+@RunWith(AndroidJUnit4::class)
+class HostResumeLastSessionE2eTest {
+
+    @get:Rule
+    val compose = createEmptyComposeRule()
+
+    // Grant runtime permissions before the activity launches so the system
+    // permission dialog never steals focus from the Compose hierarchy.
+    @get:Rule
+    val grantPermissions = PreGrantPermissionsRule()
+
+    private var launchedActivity: ActivityScenario<MainActivity>? = null
+
+    @After
+    fun tearDown() {
+        launchedActivity?.close()
+        launchedActivity = null
+        cleanupAppDatabase()
+        clearLastSession()
+    }
+
+    @Test
+    fun resumeRow_showsForMatchingHost_absentForOthers_andTapDeepLinksIntoSession() {
+        cleanupAppDatabase()
+        clearLastSession()
+
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
+        val nonce = System.nanoTime() % 100_000L
+        val hostAName = "resume-A-$nonce"
+        val hostBName = "resume-B-$nonce"
+
+        val (hostAId, hostBId) = seedTwoHosts(hostAName, hostBName)
+
+        // Seed the persisted last-session snapshot for host A — the exact store
+        // MainActivity.onStop writes. Fresh `savedAtMillis` so it is inside the
+        // 24h recency cap `LastSessionStore.peek` enforces.
+        LastSessionStore(appContext).save(
+            LastSessionStore.LastSession(
+                hostId = hostAId,
+                hostName = hostAName,
+                hostname = "10.0.2.2",
+                port = 2222,
+                username = "testuser",
+                keyPath = "/data/local/tmp/no-such-key-$nonce",
+                sessionName = "resume-session-$nonce",
+                startDirectory = null,
+                composerDraft = "",
+                savedAtMillis = System.currentTimeMillis(),
+            ),
+        )
+
+        launchedActivity = ActivityScenario.launch(MainActivity::class.java)
+
+        // Wait for the host list to render both cards.
+        compose.waitUntil(timeoutMillis = 15_000) {
+            compose.onAllNodesWithText(hostAName).fetchSemanticsNodes().isNotEmpty()
+        }
+
+        val resumeATag = HOST_RESUME_ROW_TAG_PREFIX + hostAId
+        val resumeBTag = HOST_RESUME_ROW_TAG_PREFIX + hostBId
+
+        // The Resume affordance is armed by the ViewModel's off-main peek; wait
+        // for it to publish before asserting.
+        compose.waitUntil(timeoutMillis = 10_000) {
+            compose.onAllNodesWithTag(resumeATag, useUnmergedTree = true)
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+        capture("01-resume-affordance-visible")
+
+        // AC1: the matching host card exposes the one-tap resume affordance.
+        compose.onNodeWithTag(resumeATag, useUnmergedTree = true).assertIsDisplayed()
+
+        // AC1: the OTHER host has no resume row (affordance is snapshot-scoped).
+        check(
+            compose.onAllNodesWithTag(resumeBTag, useUnmergedTree = true)
+                .fetchSemanticsNodes().isEmpty(),
+        ) {
+            "host B must not render a Resume row — the affordance is scoped to " +
+                "the host the persisted snapshot belongs to"
+        }
+
+        // AC1: tapping Resume deep-links into the session — the host list is
+        // gone (we navigated away, not stayed on the tree).
+        compose.onNodeWithTag(resumeATag, useUnmergedTree = true).performClick()
+
+        compose.waitUntil(timeoutMillis = 15_000) {
+            compose.onAllNodesWithTag(HOST_LIST_CONTENT_TAG, useUnmergedTree = true)
+                .fetchSemanticsNodes().isEmpty()
+        }
+        capture("02-after-resume-tap-left-host-list")
+
+        check(
+            compose.onAllNodesWithTag(HOST_LIST_CONTENT_TAG, useUnmergedTree = true)
+                .fetchSemanticsNodes().isEmpty(),
+        ) {
+            "tapping Resume must leave the host list and open the session screen"
+        }
+    }
+
+    private fun seedTwoHosts(hostAName: String, hostBName: String): Pair<Long, Long> {
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
+        val db = Room.databaseBuilder(appContext, AppDatabase::class.java, DATABASE_NAME)
+            .fallbackToDestructiveMigration(dropAllTables = true)
+            .build()
+        return try {
+            runBlocking {
+                val keyId = db.sshKeyDao().insert(
+                    SshKeyEntity(
+                        name = "resume-test-key",
+                        privateKeyPath = "/data/local/tmp/no-such-key",
+                    ),
+                )
+                val aId = db.hostDao().insert(readyHost(hostAName, keyId))
+                val bId = db.hostDao().insert(readyHost(hostBName, keyId))
+                aId to bId
+            }
+        } finally {
+            db.close()
+        }
+    }
+
+    private fun readyHost(name: String, keyId: Long): HostEntity =
+        HostEntity(
+            name = name,
+            hostname = "10.0.2.2",
+            port = 2222,
+            username = "testuser",
+            keyId = keyId,
+            // Ready bootstrap columns + fresh freshness stamps so the
+            // cold-launch reprobe is a no-op (never opens an SSH session).
+            tmuxInstalled = true,
+            pocketshellInstalled = true,
+            lastBootstrapAt = System.currentTimeMillis(),
+            pocketshellLastDetectedAt = System.currentTimeMillis(),
+        )
+
+    private fun cleanupAppDatabase() {
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
+        val db = Room.databaseBuilder(appContext, AppDatabase::class.java, DATABASE_NAME)
+            .fallbackToDestructiveMigration(dropAllTables = true)
+            .build()
+        try {
+            runBlocking { db.clearAllTables() }
+        } finally {
+            db.close()
+        }
+    }
+
+    private fun clearLastSession() {
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
+        LastSessionStore(appContext).clear()
+    }
+
+    private fun capture(name: String): File {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.waitForIdleSync()
+        SystemClock.sleep(300)
+        val bitmap = instrumentation.uiAutomation.takeScreenshot()
+        val mediaRoot = com.pocketshell.app.test.testArtifactsRoot(instrumentation.targetContext)
+        val directory = File(mediaRoot, "additional_test_output/host-resume-last-session")
+        check(directory.exists() || directory.mkdirs()) {
+            "Could not create host-resume artifact directory: ${directory.absolutePath}"
+        }
+        val file = File(directory, "$name.png")
+        FileOutputStream(file).use { output ->
+            check(bitmap.compress(Bitmap.CompressFormat.PNG, 100, output)) {
+                "Could not write host-resume screenshot: ${file.absolutePath}"
+            }
+        }
+        bitmap.recycle()
+        println("HOST_RESUME_SCREENSHOT ${file.absolutePath}")
+        return file
+    }
+
+    private companion object {
+        const val DATABASE_NAME: String = "pocketshell.db"
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/MainActivity.kt
+++ b/app/src/main/java/com/pocketshell/app/MainActivity.kt
@@ -1047,6 +1047,13 @@ private fun AppNavigator(
                     ),
                 )
             },
+            // Issue #1239: one-tap "Resume last session" on the host card jumps
+            // straight into the most recently-attached session (the folder /
+            // session tree walk is skipped). The destination is already built
+            // by the ViewModel from the persisted LastSessionStore snapshot; we
+            // just route to it. A gone/stale session is handled by the session
+            // screen's existing recreate path (no dead end).
+            onResumeSession = { destination -> navigate(destination) },
             onOpenPortForwardPanel = { host, keyPath, passphrase ->
                 navigate(AppDestination.PortForwardPanel(hostId = host.id, keyPath = keyPath, passphrase = passphrase))
             },

--- a/app/src/main/java/com/pocketshell/app/hosts/HostListScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/hosts/HostListScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -53,6 +54,7 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.fragment.app.FragmentActivity
 import com.pocketshell.app.bootstrap.HostBootstrapSheet
+import com.pocketshell.app.nav.AppDestination
 import com.pocketshell.app.portfwd.ForwardingGlyph
 import com.pocketshell.app.release.ReleaseInfo
 import com.pocketshell.app.release.launchUpdateDownload
@@ -128,6 +130,15 @@ fun HostListScreen(
      * navigation in MainActivity.
      */
     onOpenFolderList: (HostEntity, keyPath: String, passphrase: CharArray?) -> Unit = { _, _, _ -> },
+    /**
+     * Issue #1239: one-tap "Resume last session" — jump straight into the most
+     * recently-attached session (from [com.pocketshell.app.session.LastSessionStore])
+     * without walking the host → folder → session tree. The affordance only
+     * renders on the host card whose id matches the persisted snapshot; the
+     * caller routes the supplied [AppDestination.TmuxSession] to the live
+     * session screen.
+     */
+    onResumeSession: (AppDestination.TmuxSession) -> Unit = {},
     onOpenPortForwardPanel: (HostEntity, keyPath: String, passphrase: CharArray?) -> Unit = { _, _, _ -> },
     /**
      * Issue #206: per-host watched-folders config screen. The kebab path
@@ -201,6 +212,10 @@ fun HostListScreen(
     // the SAME cached scheduler snapshots the warning banners use (no new
     // fetch). Null while there's no usable reading — the pill is then hidden.
     val usageGlancePill by viewModel.usageGlancePill.collectAsState()
+    // Issue #1239: the most-recently-attached session, surfaced as a one-tap
+    // "Resume" affordance on its host's card. Refreshed on every appearance
+    // below so returning from a session re-arms it for what was last open.
+    val resumableSession by viewModel.resumableSession.collectAsState()
     val context = LocalContext.current
     val activity = context as? FragmentActivity
 
@@ -335,6 +350,15 @@ fun HostListScreen(
     // config changes.
     LaunchedEffect(Unit) {
         viewModel.reprobeUnknownHostsOnce()
+    }
+    // Issue #1239: re-read the persisted last-session snapshot every time the
+    // host list appears. `LastSessionStore` is written on `MainActivity.onStop`,
+    // so a fresh peek here means the Resume affordance reflects whatever session
+    // the user most recently backgrounded — no dead affordance for a session
+    // they already walked away from (it returns null once the snapshot is
+    // cleared / killed / stale).
+    LaunchedEffect(Unit) {
+        viewModel.refreshResumableSession()
     }
 
     // Fire navigation once the ViewModel marks the pending route ready.
@@ -699,6 +723,26 @@ fun HostListScreen(
                             // render here was dropped — it read as a cryptic
                             // floating row under the card. Usage stays one tap
                             // away via the kebab → "Usage" item.
+
+                            // Issue #1239: one-tap "Resume last session". Only
+                            // the host card whose id matches the persisted
+                            // last-session snapshot renders it; tapping jumps
+                            // straight into that live session (bypassing the
+                            // host → folder → session tree walk). When the
+                            // snapshot is absent / stale / killed the affordance
+                            // is simply not shown and the plain card tap routes
+                            // to the folder list (AC1: no dead end).
+                            resumableSession
+                                ?.takeIf { it.hostId == host.id }
+                                ?.let { resume ->
+                                    ResumeLastSessionRow(
+                                        sessionName = resume.sessionName,
+                                        onClick = { onResumeSession(resume.destination) },
+                                        modifier = Modifier.testTag(
+                                            HOST_RESUME_ROW_TAG_PREFIX + host.id,
+                                        ),
+                                    )
+                                }
                         }
                     }
                 }
@@ -836,6 +880,87 @@ private val HostListFabContentClearance = 104.dp
 
 internal const val HOST_LIST_CONTENT_TAG = "host-list:content"
 internal const val HOST_ROW_TAG_PREFIX = "host:row:"
+
+/**
+ * Issue #1239: stable test-tag prefix for the one-tap "Resume last session" row
+ * that renders under the host card whose id matches the persisted last-session
+ * snapshot. The full tag is `host:resume:<hostId>`. Instrumentation asserts the
+ * row is present exactly for the matching host, absent for the others, and that
+ * tapping it navigates into the correct live session.
+ */
+internal const val HOST_RESUME_ROW_TAG_PREFIX = "host:resume:"
+
+/**
+ * Issue #1239: one-tap "Resume last session" affordance shown beneath the host
+ * card whose id matches the persisted [com.pocketshell.app.session.LastSessionStore]
+ * snapshot. It reads as a subtle accent-tinted action row — an accent play glyph,
+ * a bright "Resume" label, and the muted monospace session name so the user knows
+ * exactly which session they'll jump back into. The whole row is one tap target
+ * held at the a11y touch floor; tapping routes straight into the live session,
+ * skipping the host → folder → session tree walk.
+ */
+@Composable
+private fun ResumeLastSessionRow(
+    sessionName: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .defaultMinSize(minHeight = PocketShellDensity.tapTargetMin)
+            .background(color = PocketShellColors.AccentSoft, shape = PocketShellShapes.medium)
+            .border(
+                width = 1.dp,
+                color = PocketShellColors.Accent.copy(alpha = 0.4f),
+                shape = PocketShellShapes.medium,
+            )
+            .clickable(role = Role.Button, onClick = onClick)
+            .semantics { contentDescription = "Resume last session $sessionName" }
+            .padding(
+                horizontal = PocketShellDensity.rowPadH,
+                vertical = PocketShellDensity.rowPadV,
+            ),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        ResumeGlyph()
+        Spacer(modifier = Modifier.width(PocketShellSpacing.sm))
+        Text(
+            text = "Resume",
+            color = PocketShellColors.Accent,
+            style = PocketShellType.bodyDense,
+            fontWeight = FontWeight.SemiBold,
+        )
+        Spacer(modifier = Modifier.width(PocketShellSpacing.sm))
+        Text(
+            text = sessionName,
+            color = PocketShellColors.TextSecondary,
+            style = PocketShellType.bodyMono,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f),
+        )
+    }
+}
+
+/**
+ * Small accent "play" triangle drawn inline (no drawable / material-icon
+ * dependency, matching the other hand-rolled glyphs on this screen) for the
+ * [ResumeLastSessionRow].
+ */
+@Composable
+private fun ResumeGlyph() {
+    val color = PocketShellColors.Accent
+    Canvas(modifier = Modifier.size(12.dp)) {
+        val path = androidx.compose.ui.graphics.Path().apply {
+            moveTo(size.width * 0.15f, 0f)
+            lineTo(size.width * 0.15f, size.height)
+            lineTo(size.width * 0.95f, size.height / 2f)
+            close()
+        }
+        drawPath(path, color)
+    }
+}
 
 /**
  * Issue #418: stable test tag for the single compact "notices" block

--- a/app/src/main/java/com/pocketshell/app/hosts/HostListViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/hosts/HostListViewModel.kt
@@ -15,8 +15,10 @@ import com.pocketshell.app.bootstrap.ToolStatus
 import com.pocketshell.app.bootstrap.cliUpdateFailureMessage
 import com.pocketshell.app.bootstrap.cliUpdateNoChangeMessage
 import com.pocketshell.app.bootstrap.compareSemver
+import com.pocketshell.app.nav.AppDestination
 import com.pocketshell.app.notifications.DefaultUpdateNotifier
 import com.pocketshell.app.notifications.UpdateNotifier
+import com.pocketshell.app.session.LastSessionStore
 import com.pocketshell.app.release.ReleaseCheckResult
 import com.pocketshell.app.release.ReleaseChecker
 import com.pocketshell.app.release.ReleaseInfo
@@ -142,6 +144,13 @@ class HostListViewModel internal constructor(
         },
     ),
     private val sessionOpener: HostSessionOpener = HostSessionOpener { _, _, _ -> null },
+    // Issue #1239: the persisted "last active session" snapshot backs the
+    // host-card one-tap "Resume last session" affordance. Defaulted to a
+    // store over the application context so the Robolectric tests can
+    // construct the ViewModel without Hilt; production injects the shared
+    // @Singleton store (same one MainActivity's onStop writes) via the
+    // @Inject constructor below.
+    private val lastSessionStore: LastSessionStore = LastSessionStore(applicationContext),
     // Issue #502: posts a local "new version available" notification when
     // the foreground [releaseChecker] detects a strictly-newer release.
     // De-dupes per version so the user isn't re-notified on every cold
@@ -161,6 +170,7 @@ class HostListViewModel internal constructor(
         activeClients: ActiveTmuxClients,
         settingsRepository: SettingsRepository,
         sshLeaseManager: SshLeaseManager,
+        lastSessionStore: LastSessionStore,
     ) : this(
         applicationContext = applicationContext,
         hostDao = hostDao,
@@ -172,6 +182,7 @@ class HostListViewModel internal constructor(
         settingsRepository = settingsRepository,
         sshLeaseManager = sshLeaseManager,
         sessionOpener = LeaseBackedHostSessionOpener(sshLeaseManager),
+        lastSessionStore = lastSessionStore,
     )
 
     /** Live list of saved hosts, sorted by name (DAO query). */
@@ -266,6 +277,41 @@ class HostListViewModel internal constructor(
         )
     }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000L), null)
+
+    /**
+     * Issue #1239: the single most-recently-attached session, surfaced as a
+     * one-tap "Resume last session" affordance on its host's card. Null when
+     * there is no fresh snapshot (cold install, the session was killed / the
+     * user walked away, or the snapshot aged past the 24h recency cap in
+     * [LastSessionStore]) — the affordance is then absent and the user falls
+     * back to the normal host-tap → folder-list navigation (AC1: no dead end).
+     *
+     * Because [LastSessionStore] is written on `MainActivity.onStop`, this is
+     * refreshed by [refreshResumableSession] every time the host list appears
+     * (the screen calls it from a `LaunchedEffect`), so returning from a session
+     * immediately re-arms the affordance for whatever the user last had open.
+     */
+    private val _resumableSession = MutableStateFlow<ResumableSession?>(null)
+    val resumableSession: StateFlow<ResumableSession?> = _resumableSession.asStateFlow()
+
+    /**
+     * Issue #1239: re-read the persisted last-session snapshot off-main and
+     * publish it (or null) to [resumableSession]. Called from the host-list
+     * screen's `LaunchedEffect` on every appearance so the Resume affordance
+     * tracks the latest backgrounded session. Uses [LastSessionStore.peek]
+     * (non-logging) since this is a UI-arming peek, not a process-death restore.
+     */
+    fun refreshResumableSession(): Job =
+        viewModelScope.launch {
+            val session = withContext(Dispatchers.IO) { lastSessionStore.peek() }
+            _resumableSession.value = session?.let {
+                ResumableSession(
+                    hostId = it.hostId,
+                    sessionName = it.sessionName,
+                    destination = with(lastSessionStore) { it.toDestination() },
+                )
+            }
+        }
 
     // Issue #483 introduced a per-host usage summary chip (`usageSummaries`)
     // rendered under each host card; issue #506 dropped that chip because it
@@ -678,6 +724,9 @@ class HostListViewModel internal constructor(
     init {
         checkForUpdates()
         observeCachedAppUpdateWarnings()
+        // Issue #1239: arm the host-card Resume affordance for the first
+        // composition; the screen re-arms it on every appearance thereafter.
+        refreshResumableSession()
     }
 
     /**

--- a/app/src/main/java/com/pocketshell/app/hosts/ResumableSession.kt
+++ b/app/src/main/java/com/pocketshell/app/hosts/ResumableSession.kt
@@ -1,0 +1,24 @@
+package com.pocketshell.app.hosts
+
+import com.pocketshell.app.nav.AppDestination
+
+/**
+ * Issue #1239: the most-recently-attached session surfaced as a one-tap
+ * "Resume last session" affordance on its host's card. Built from the persisted
+ * [com.pocketshell.app.session.LastSessionStore] snapshot by
+ * [HostListViewModel.refreshResumableSession].
+ *
+ * @property hostId the host the snapshot belongs to; the host card whose id
+ *   matches renders the Resume affordance.
+ * @property sessionName the tmux session name, shown on the affordance so the
+ *   user knows exactly what they'll jump back into.
+ * @property destination the pre-built live-session route the tap navigates to.
+ *   Its passphrase is null — the reattach path resolves the key from disk by
+ *   path, identical to a cold attach (same contract as
+ *   [com.pocketshell.app.session.LastSessionStore.toDestination]).
+ */
+data class ResumableSession(
+    val hostId: Long,
+    val sessionName: String,
+    val destination: AppDestination.TmuxSession,
+)

--- a/app/src/main/java/com/pocketshell/app/session/LastSessionStore.kt
+++ b/app/src/main/java/com/pocketshell/app/session/LastSessionStore.kt
@@ -216,7 +216,38 @@ class LastSessionStore @VisibleForTesting internal constructor(
     fun read(
         nowMillis: Long = System.currentTimeMillis(),
         maxAgeMillis: Long = DEFAULT_MAX_AGE_MILLIS,
-    ): LastSession? {
+    ): LastSession? =
+        parse(nowMillis, maxAgeMillis)?.also { session ->
+            Log.i(
+                LAST_SESSION_LOG_TAG,
+                "last-session-restore trigger=cold-restore hostId=${session.hostId} " +
+                    "host=${session.hostname} port=${session.port} user=${session.username} " +
+                    "session=${session.sessionName} startDirectory=${session.startDirectory}",
+            )
+        }
+
+    /**
+     * Issue #1239: a non-logging read of the persisted last-session snapshot,
+     * used by the host-card "Resume last session" affordance and the
+     * Active-Sessions widget deep-link. Same recency + validity rules as
+     * [read] (returns null for a stale, killed, or absent snapshot — so a gone
+     * session simply hides the affordance and the user falls back to normal
+     * navigation, no dead end), but WITHOUT the `trigger=cold-restore` log line:
+     * this is peeked whenever the host list appears / a widget refreshes, not on
+     * an actual process-death restore, so tagging it `cold-restore` would be
+     * misleading log noise.
+     */
+    fun peek(
+        nowMillis: Long = System.currentTimeMillis(),
+        maxAgeMillis: Long = DEFAULT_MAX_AGE_MILLIS,
+    ): LastSession? = parse(nowMillis, maxAgeMillis)
+
+    /**
+     * Shared parse of the persisted snapshot into a [LastSession], applying the
+     * recency cap + field-validity guards. Both [read] (which logs) and [peek]
+     * (which does not) delegate here so the two never drift.
+     */
+    private fun parse(nowMillis: Long, maxAgeMillis: Long): LastSession? {
         val savedAt = prefs.safeLong(KEY_SAVED_AT, 0L) ?: return null
         if (savedAt <= 0L) return null
         if (nowMillis - savedAt > maxAgeMillis) return null
@@ -241,14 +272,7 @@ class LastSessionStore @VisibleForTesting internal constructor(
             sessionCreated = prefs.safeLong(KEY_SESSION_CREATED, 0L)?.takeIf { it > 0L },
             composerDraft = prefs.safeString(KEY_COMPOSER_DRAFT, "") ?: "",
             savedAtMillis = savedAt,
-        ).also { session ->
-            Log.i(
-                LAST_SESSION_LOG_TAG,
-                "last-session-restore trigger=cold-restore hostId=${session.hostId} " +
-                    "host=${session.hostname} port=${session.port} user=${session.username} " +
-                    "session=${session.sessionName} startDirectory=${session.startDirectory}",
-            )
-        }
+        )
     }
 
     private fun SharedPreferences.safeString(key: String, default: String?): String? =
@@ -303,7 +327,7 @@ class LastSessionStore @VisibleForTesting internal constructor(
         if (trimmed.isEmpty()) return
         val killed = SessionIdentity(hostId = hostId, sessionName = trimmed)
         killedTombstone = killed
-        val stored = read(maxAgeMillis = Long.MAX_VALUE)
+        val stored = peek(maxAgeMillis = Long.MAX_VALUE)
         if (stored != null && stored.identity() == killed) {
             Log.i(
                 LAST_SESSION_LOG_TAG,

--- a/app/src/main/java/com/pocketshell/app/systemsurfaces/ActiveSessionsWidgetProvider.kt
+++ b/app/src/main/java/com/pocketshell/app/systemsurfaces/ActiveSessionsWidgetProvider.kt
@@ -10,6 +10,7 @@ import android.util.Log
 import android.widget.RemoteViews
 import com.pocketshell.app.MainActivity
 import com.pocketshell.app.R
+import com.pocketshell.app.session.LastSessionStore
 
 class ActiveSessionsWidgetProvider : AppWidgetProvider() {
 
@@ -52,12 +53,23 @@ class ActiveSessionsWidgetProvider : AppWidgetProvider() {
             context: Context,
             state: SessionWidgetState,
         ): RemoteViews {
-            val intent = Intent(context, MainActivity::class.java)
-                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+            // Issue #1239: the widget tap is the fastest re-entry surface, so it
+            // deep-links straight into the most recently-attached session instead
+            // of dropping the user on the host-list top. The persisted snapshot is
+            // read best-effort; when there is none (cold install / stale / killed)
+            // the extras are omitted and MainActivity opens the host list — the
+            // same non-dead-end fallback the host-card Resume affordance uses.
+            val lastSession = runCatching { LastSessionStore(context).peek() }
+                .onFailure { Log.w(SYSTEM_SURFACES_TAG, "widget last-session read failed", it) }
+                .getOrNull()
+            val intent = widgetLaunchIntent(context, lastSession)
             val pendingIntent = PendingIntent.getActivity(
                 context,
                 0,
                 intent,
+                // FLAG_UPDATE_CURRENT replaces the extras of the existing
+                // PendingIntent, so the deep-link target follows the latest
+                // last-session snapshot rather than latching the first one.
                 PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
             )
             return RemoteViews(context.packageName, R.layout.widget_active_sessions).apply {
@@ -65,6 +77,33 @@ class ActiveSessionsWidgetProvider : AppWidgetProvider() {
                 setTextViewText(R.id.widget_session_label, activeSessionCountText(state.activeSessionCount))
                 setOnClickPendingIntent(R.id.widget_active_sessions_root, pendingIntent)
             }
+        }
+
+        /**
+         * Issue #1239: build the widget-tap launch intent. When a fresh
+         * last-session snapshot exists it carries the `EXTRA_OPEN_SESSION_*`
+         * deep-link extras so [MainActivity] routes straight into that live
+         * tmux session (same extras the share-into-session flow uses, consumed by
+         * `MainActivity.shareSessionDestinationFromIntent`). With no snapshot the
+         * bare intent opens the host list (non-dead-end fallback). Extracted +
+         * `internal` so a JVM unit test can assert the deep-link extras directly.
+         */
+        @JvmStatic
+        internal fun widgetLaunchIntent(
+            context: Context,
+            lastSession: LastSessionStore.LastSession?,
+        ): Intent {
+            val intent = Intent(context, MainActivity::class.java)
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+            if (lastSession == null) return intent
+            return intent
+                .putExtra(MainActivity.EXTRA_OPEN_SESSION_HOST_ID, lastSession.hostId)
+                .putExtra(MainActivity.EXTRA_OPEN_SESSION_HOST_NAME, lastSession.hostName)
+                .putExtra(MainActivity.EXTRA_OPEN_SESSION_HOSTNAME, lastSession.hostname)
+                .putExtra(MainActivity.EXTRA_OPEN_SESSION_PORT, lastSession.port)
+                .putExtra(MainActivity.EXTRA_OPEN_SESSION_USERNAME, lastSession.username)
+                .putExtra(MainActivity.EXTRA_OPEN_SESSION_KEY_PATH, lastSession.keyPath)
+                .putExtra(MainActivity.EXTRA_OPEN_SESSION_NAME, lastSession.sessionName)
         }
     }
 }

--- a/app/src/test/java/com/pocketshell/app/hosts/HostListViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/hosts/HostListViewModelTest.kt
@@ -17,6 +17,7 @@ import com.pocketshell.app.notifications.UpdateNotifier
 import com.pocketshell.app.release.ReleaseCheckResult
 import com.pocketshell.app.release.ReleaseChecker
 import com.pocketshell.app.release.ReleaseInfo
+import com.pocketshell.app.session.LastSessionStore
 import com.pocketshell.app.sessions.ActiveTmuxClients
 import com.pocketshell.app.settings.SettingsRepository
 import com.pocketshell.app.usage.UsageRemoteSource
@@ -345,6 +346,90 @@ class HostListViewModelTest {
             settingsRepository = newSettingsRepository(),
         )
         assertNull(viewModel.keyFor(9_999L))
+    }
+
+    // Issue #1239: the host-card one-tap "Resume last session" affordance is
+    // driven by [HostListViewModel.resumableSession], read from the persisted
+    // [LastSessionStore] snapshot. `newViewModel` uses the default store over the
+    // Robolectric `context`, so seeding that store before construction (or before
+    // an explicit refresh) exercises the exact production path.
+
+    private fun clearLastSession() {
+        context.getSharedPreferences("last_session", Context.MODE_PRIVATE)
+            .edit().clear().commit()
+    }
+
+    private fun seedLastSession(
+        hostId: Long = 42L,
+        sessionName: String = "claude-main",
+        savedAtMillis: Long = System.currentTimeMillis(),
+    ) {
+        LastSessionStore(context).save(
+            LastSessionStore.LastSession(
+                hostId = hostId,
+                hostName = "hetzner",
+                hostname = "10.0.0.9",
+                port = 2222,
+                username = "alex",
+                keyPath = "/data/keys/id_ed25519",
+                sessionName = sessionName,
+                startDirectory = "/home/alex/project",
+                composerDraft = "",
+                savedAtMillis = savedAtMillis,
+            ),
+        )
+    }
+
+    @Test
+    fun resumableSession_isPresent_whenAFreshSnapshotExists() = runTest {
+        clearLastSession()
+        seedLastSession(hostId = 42L, sessionName = "claude-main")
+
+        val viewModel = newViewModel()
+        viewModel.refreshResumableSession().join()
+
+        val resume = viewModel.resumableSession.value
+        assertNotNull(resume)
+        requireNotNull(resume)
+        assertEquals(42L, resume.hostId)
+        assertEquals("claude-main", resume.sessionName)
+        // The one-tap route jumps straight into that live session.
+        assertEquals(42L, resume.destination.hostId)
+        assertEquals("claude-main", resume.destination.sessionName)
+        assertEquals("10.0.0.9", resume.destination.hostname)
+        assertEquals(2222, resume.destination.port)
+        assertEquals("alex", resume.destination.username)
+        assertEquals("/data/keys/id_ed25519", resume.destination.keyPath)
+        // Passphrase is never persisted — reattach resolves the key by path.
+        assertNull(resume.destination.passphrase)
+    }
+
+    @Test
+    fun resumableSession_isNull_whenNoSnapshotExists() = runTest {
+        clearLastSession()
+
+        val viewModel = newViewModel()
+        viewModel.refreshResumableSession().join()
+
+        // No snapshot → no affordance → host tap falls back to normal
+        // folder-list navigation (AC1: no dead end).
+        assertNull(viewModel.resumableSession.value)
+    }
+
+    @Test
+    fun resumableSession_isNull_whenSnapshotIsStale() = runTest {
+        clearLastSession()
+        // Saved ~25h ago — past the 24h recency cap peek() enforces.
+        seedLastSession(
+            hostId = 42L,
+            savedAtMillis = System.currentTimeMillis() -
+                (LastSessionStore.DEFAULT_MAX_AGE_MILLIS + 60_000L),
+        )
+
+        val viewModel = newViewModel()
+        viewModel.refreshResumableSession().join()
+
+        assertNull(viewModel.resumableSession.value)
     }
 
     @Test

--- a/app/src/test/java/com/pocketshell/app/session/LastSessionStoreTest.kt
+++ b/app/src/test/java/com/pocketshell/app/session/LastSessionStoreTest.kt
@@ -488,6 +488,68 @@ class LastSessionStoreTest {
         assertEquals("claude-main", read!!.sessionName)
     }
 
+    // Issue #1239: peek() — the non-logging read backing the host-card Resume
+    // affordance + the widget deep-link. Same recency/validity rules as read().
+
+    @Test
+    fun `peek on cold store returns null`() {
+        val store = LastSessionStore(context)
+        assertNull(store.peek(nowMillis = 5_000L))
+    }
+
+    @Test
+    fun `peek returns the persisted snapshot when fresh`() {
+        val store = LastSessionStore(context)
+        store.save(sample(savedAtMillis = 1_000L))
+
+        val peeked = LastSessionStore(context).peek(nowMillis = 2_000L)
+        assertNotNull(peeked)
+        requireNotNull(peeked)
+        assertEquals(7L, peeked.hostId)
+        assertEquals("claude-main", peeked.sessionName)
+        assertEquals("10.0.0.5", peeked.hostname)
+        assertEquals(2222, peeked.port)
+        assertEquals("me", peeked.username)
+        assertEquals("/data/keys/id_ed25519", peeked.keyPath)
+    }
+
+    @Test
+    fun `peek returns null once the snapshot ages past the recency cap`() {
+        val store = LastSessionStore(context)
+        store.save(sample(savedAtMillis = 1_000L))
+
+        // Just inside the cap → present; just past it → gone (the host-card
+        // affordance is then absent and the user falls back to normal nav).
+        assertNotNull(
+            store.peek(
+                nowMillis = 1_000L + LastSessionStore.DEFAULT_MAX_AGE_MILLIS,
+            ),
+        )
+        assertNull(
+            store.peek(
+                nowMillis = 1_000L + LastSessionStore.DEFAULT_MAX_AGE_MILLIS + 1L,
+            ),
+        )
+    }
+
+    @Test
+    fun `peek returns null after the stored session is cleared`() {
+        val store = LastSessionStore(context)
+        store.save(sample(savedAtMillis = 1_000L))
+        store.clear()
+
+        assertNull(LastSessionStore(context).peek(nowMillis = 2_000L))
+    }
+
+    @Test
+    fun `peek returns null after the stored session is killed`() {
+        val store = LastSessionStore(context)
+        store.save(sample(savedAtMillis = 1_000L))
+        store.onSessionKilled(hostId = 7L, sessionName = "claude-main")
+
+        assertNull(LastSessionStore(context).peek(nowMillis = 2_000L))
+    }
+
     private fun LastSessionStore.LastSession.copyWith(
         sessionName: String,
     ): LastSessionStore.LastSession = copy(sessionName = sessionName)

--- a/app/src/test/java/com/pocketshell/app/systemsurfaces/ActiveSessionsWidgetIntentTest.kt
+++ b/app/src/test/java/com/pocketshell/app/systemsurfaces/ActiveSessionsWidgetIntentTest.kt
@@ -1,0 +1,90 @@
+package com.pocketshell.app.systemsurfaces
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.pocketshell.app.initialDestinationFromIntent
+import com.pocketshell.app.nav.AppDestination
+import com.pocketshell.app.session.LastSessionStore
+import com.pocketshell.app.shareSessionDestinationFromIntent
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Issue #1239 (AC2): the Active-Sessions home-screen widget tap must deep-link
+ * straight into a session surface, not the host-list top.
+ *
+ * The widget builds its launch intent via
+ * [ActiveSessionsWidgetProvider.widgetLaunchIntent]. This suite proves that,
+ * given a persisted last-session snapshot, that intent carries the same
+ * `EXTRA_OPEN_SESSION_*` deep-link extras the production launch path consumes —
+ * so `MainActivity.initialDestinationFromIntent` routes it to
+ * [AppDestination.TmuxSession] (the live session screen) rather than
+ * [AppDestination.HostList]. With no snapshot it degrades to a bare
+ * host-list launch (the non-dead-end fallback).
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class ActiveSessionsWidgetIntentTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private fun sample() = LastSessionStore.LastSession(
+        hostId = 11L,
+        hostName = "hetzner",
+        hostname = "65.108.42.11",
+        port = 2222,
+        username = "alex",
+        keyPath = "/data/keys/id_ed25519",
+        sessionName = "claude-main",
+        startDirectory = "/home/alex/project",
+        composerDraft = "",
+        savedAtMillis = 1_000L,
+    )
+
+    @Test
+    fun widgetIntent_withSnapshot_deepLinksIntoTheSession() {
+        val intent = ActiveSessionsWidgetProvider.widgetLaunchIntent(context, sample())
+
+        // The production launch path resolves it to the live session, not the
+        // host list — the widget tap lands the user directly in their session.
+        val destination = initialDestinationFromIntent(intent)
+        check(destination is AppDestination.TmuxSession) {
+            "widget tap must deep-link into a TmuxSession, was $destination"
+        }
+        assertEquals(11L, destination.hostId)
+        assertEquals("hetzner", destination.hostName)
+        assertEquals("65.108.42.11", destination.hostname)
+        assertEquals(2222, destination.port)
+        assertEquals("alex", destination.username)
+        assertEquals("/data/keys/id_ed25519", destination.keyPath)
+        assertEquals("claude-main", destination.sessionName)
+        // Passphrase is never carried in an intent — reattach resolves the key
+        // from disk by path.
+        assertNull(destination.passphrase)
+    }
+
+    @Test
+    fun widgetIntent_withSnapshot_roundTripsThroughShareSessionParser() {
+        val intent = ActiveSessionsWidgetProvider.widgetLaunchIntent(context, sample())
+
+        val parsed = shareSessionDestinationFromIntent(intent)
+        requireNotNull(parsed) { "widget deep-link extras must parse to a TmuxSession" }
+        assertEquals(11L, parsed.hostId)
+        assertEquals("claude-main", parsed.sessionName)
+        assertEquals("65.108.42.11", parsed.hostname)
+    }
+
+    @Test
+    fun widgetIntent_withNoSnapshot_fallsBackToHostList() {
+        val intent = ActiveSessionsWidgetProvider.widgetLaunchIntent(context, lastSession = null)
+
+        // No deep-link extras → the launch path opens the host list (non-dead-end
+        // fallback), never a broken/partial session route.
+        assertNull(shareSessionDestinationFromIntent(intent))
+        assertEquals(AppDestination.HostList, initialDestinationFromIntent(intent))
+    }
+}

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -1124,6 +1124,18 @@ JOURNEY_CLASSES=(
   # cannot silently regress. It lives under com.pocketshell.app.tmux, so it carries
   # its fully-qualified name directly.
   "com.pocketshell.app.tmux.SessionSurfaceReconnectWrapperTest"
+  # ADDED (#1239): the host-card one-tap "Resume last session" affordance proof.
+  # Seeds a persisted `last_session` snapshot + two saved hosts, launches the
+  # real MainActivity, and HARD-asserts the Resume row is displayed under the
+  # matching host, absent for the other host, and that tapping it LEAVES the host
+  # list (deep-links into the session screen). It needs NO Docker fixture (the
+  # session screen renders optimistically, so "left the host list" is observable
+  # without SSH), NO toxiproxy, NO port — so no tests.yml service change — and it
+  # does NOT self-skip on CI (no assumeTrue / assumeFalse(isRunningOnCi())). Per
+  # G9 (a test per acceptance criterion, wired into a running gate) it must run
+  # per-push so the affordance cannot silently regress. It lives under
+  # com.pocketshell.app.hosts, so it carries its fully-qualified name directly.
+  "com.pocketshell.app.hosts.HostResumeLastSessionE2eTest"
   # ADDED (#868): the previous-session-toggle REMOVED regression guard (AC4).
   # The maintainer's #628 previous-session toggle button was hard-cut from the
   # Conversation bottom composer; this proof composes the production

--- a/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenders.kt
+++ b/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenders.kt
@@ -768,6 +768,38 @@ class DesignRenders {
      * Fresh (Warn 72%) on top, stale (Ok 63% · "cached from 13:40") below to
      * check the honest muted treatment. The emulator screenshot is the acceptance.
      */
+    /**
+     * Issue #1239: the host-card one-tap "Resume last session" affordance. The
+     * real row lives in the app module
+     * ([com.pocketshell.app.hosts.HostListScreen]'s `ResumeLastSessionRow`);
+     * this fixture mirrors it with the SAME chrome (accent play glyph, bright
+     * "Resume" label, muted-mono session name, AccentSoft fill + 40%-accent
+     * hairline on the `medium` card shape) so the fast JVM check shows it reads
+     * as a subtle action row under the matching host card — NOT a heavy second
+     * card — while making the exact session it resumes obvious. The top host has
+     * a resume row (the last-attached session); the second host has none (its
+     * snapshot isn't the current one), matching the snapshot-scoped production
+     * behaviour. The emulator screenshot is the acceptance.
+     */
+    @Test
+    fun hostCardResumeAffordance() = render("host-card-resume-affordance") {
+        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            HostCard(
+                name = "hetzner",
+                subtitle = "alex@65.108.42.11",
+                status = HostStatus.Attached,
+                onClick = {},
+            )
+            ResumeLastSessionRowFacsimile(sessionName = "claude-main")
+        }
+        HostCard(
+            name = "gpu-box",
+            subtitle = "alex@10.0.0.42",
+            status = HostStatus.NoActiveSessions,
+            onClick = {},
+        )
+    }
+
     @Test
     fun usageGlancePill() = render("usage-glance-pill") {
         Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
@@ -4187,6 +4219,48 @@ class DesignRenders {
             contentAlignment = Alignment.Center,
         ) {
             Text("⚙", color = PocketShellColors.TextSecondary)
+        }
+    }
+
+    /**
+     * Issue #1239: JVM facsimile of the app-module `ResumeLastSessionRow` — the
+     * one-tap "Resume last session" affordance under the matching host card. Same
+     * chrome as the production row (accent play glyph, bright "Resume" label,
+     * muted-mono session name, AccentSoft fill + 40%-accent hairline on the
+     * `medium` card shape) so the fast render is a faithful design read; the
+     * emulator screenshot is the acceptance.
+     */
+    @Composable
+    private fun ResumeLastSessionRowFacsimile(sessionName: String) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(48.dp)
+                .background(color = PocketShellColors.AccentSoft, shape = PocketShellShapes.medium)
+                .border(
+                    width = 1.dp,
+                    color = PocketShellColors.Accent.copy(alpha = 0.4f),
+                    shape = PocketShellShapes.medium,
+                )
+                .padding(horizontal = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text("▶", color = PocketShellColors.Accent, style = PocketShellType.bodyDense)
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = "Resume",
+                color = PocketShellColors.Accent,
+                style = PocketShellType.bodyDense,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = sessionName,
+                color = PocketShellColors.TextSecondary,
+                style = PocketShellType.bodyMono,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
         }
     }
 


### PR DESCRIPTION
Closes #1239. Host-card one-tap 'Resume <session>' (reusing LastSessionStore/ResilientPrefs) + Active-Sessions widget deep-links into the live session. No dead-ends (absent/stale → folder-list fallback). Reviewer APPROVED with emulator proof: ran HostResumeLastSessionE2eTest on the emulator (resume row scoped to the right host, tap landed on the correct session screen — screenshots attached), reviewer-driven red→green, 96 unit tests 0-fail.