### PR TITLE
voice: durable undelivered-transcript store + bounded channel (#1272 data-loss slice)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/di/VoiceModule.kt
+++ b/app/src/main/java/com/pocketshell/app/di/VoiceModule.kt
@@ -15,6 +15,8 @@ import com.pocketshell.app.voice.AndroidSpeechRecognitionProvider
 import com.pocketshell.app.voice.ConnectivityObserver
 import com.pocketshell.app.voice.PendingTranscriptionItem
 import com.pocketshell.app.voice.PendingTranscriptionStore
+import com.pocketshell.app.voice.SharedPrefsUndeliveredTranscriptStore
+import com.pocketshell.app.voice.UndeliveredTranscriptStore
 import com.pocketshell.core.storage.dao.AiApiCallLogDao
 import com.pocketshell.core.storage.entity.AiApiCallEntry
 import com.pocketshell.core.voice.AiCostRecord
@@ -179,6 +181,19 @@ object VoiceModule {
         store: PendingTranscriptionStore,
     ): PromptComposerViewModel.PendingTranscriptionQueue =
         PendingTranscriptionStoreAdapter(store)
+
+    /**
+     * Issue #1272: bind the [UndeliveredTranscriptStore] seam onto the durable
+     * SharedPreferences-backed [SharedPrefsUndeliveredTranscriptStore]. Singleton
+     * so a transcript persisted while one session screen is torn down (permanent
+     * pane death) is visible to the next session screen's inline-dictation
+     * ViewModel and survives a process restart.
+     */
+    @Provides
+    @Singleton
+    fun provideUndeliveredTranscriptStore(
+        store: SharedPrefsUndeliveredTranscriptStore,
+    ): UndeliveredTranscriptStore = store
 
     /**
      * Issue #180: bind [PromptComposerViewModel.ConnectivityProbe] onto

--- a/app/src/main/java/com/pocketshell/app/session/InlineDictation.kt
+++ b/app/src/main/java/com/pocketshell/app/session/InlineDictation.kt
@@ -56,6 +56,8 @@ import com.pocketshell.uikit.components.SpinnerSize
 import com.pocketshell.uikit.model.KeyBinding
 import com.pocketshell.uikit.model.KeyModifierState
 import com.pocketshell.uikit.theme.PocketShellColors
+import com.pocketshell.uikit.theme.PocketShellShapes
+import com.pocketshell.uikit.theme.PocketShellType
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -1228,11 +1230,11 @@ private fun UndeliveredTranscriptBanner(
             .testTag(UNDELIVERED_TRANSCRIPT_BANNER_TAG)
             .background(
                 color = PocketShellColors.SurfaceElev,
-                shape = RoundedCornerShape(8.dp),
+                shape = PocketShellShapes.small,
             )
             .border(
                 border = BorderStroke(1.dp, PocketShellColors.AccentDim),
-                shape = RoundedCornerShape(8.dp),
+                shape = PocketShellShapes.small,
             )
             .padding(8.dp),
         verticalArrangement = Arrangement.spacedBy(6.dp),
@@ -1252,7 +1254,7 @@ private fun UndeliveredTranscriptBanner(
                 Text(
                     text = item.text,
                     color = PocketShellColors.Text,
-                    fontSize = 12.sp,
+                    style = PocketShellType.bodyDense,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                     modifier = Modifier.weight(1f),
@@ -1284,14 +1286,14 @@ private fun UndeliveredTranscriptAction(
     Text(
         text = label,
         color = accent,
-        fontSize = 12.sp,
+        style = PocketShellType.bodyDense,
         fontWeight = FontWeight.SemiBold,
         modifier = Modifier
             .testTag(testTag)
-            .background(color = PocketShellColors.Surface, shape = RoundedCornerShape(6.dp))
+            .background(color = PocketShellColors.Surface, shape = PocketShellShapes.small)
             .border(
                 border = BorderStroke(1.dp, PocketShellColors.Border),
-                shape = RoundedCornerShape(6.dp),
+                shape = PocketShellShapes.small,
             )
             .clickable(role = Role.Button, onClick = onClick)
             .padding(horizontal = 10.dp, vertical = 4.dp),

--- a/app/src/main/java/com/pocketshell/app/session/InlineDictation.kt
+++ b/app/src/main/java/com/pocketshell/app/session/InlineDictation.kt
@@ -43,6 +43,9 @@ import com.pocketshell.app.diagnostics.DiagnosticEvents
 import com.pocketshell.app.di.WhisperClientFactory
 import com.pocketshell.app.settings.VoiceTranscriptionProvider
 import com.pocketshell.app.voice.DictateDotIcon
+import com.pocketshell.app.voice.InMemoryUndeliveredTranscriptStore
+import com.pocketshell.app.voice.UndeliveredTranscript
+import com.pocketshell.app.voice.UndeliveredTranscriptStore
 import com.pocketshell.core.storage.entity.PendingTranscriptionEntity
 import com.pocketshell.core.voice.AudioRecorderException
 import com.pocketshell.core.voice.SpeechAudioGuard
@@ -57,6 +60,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -159,6 +163,13 @@ public class InlineDictationViewModel @Inject constructor(
         UnavailableSpeechRecognitionProvider,
     internal val pendingTranscriptionStore: PromptComposerViewModel.PendingTranscriptionQueue =
         DisabledPendingTranscriptionQueue,
+    // Issue #1272: durable holding pen for a successful transcript whose text
+    // could not be delivered to a pane (permanent pane death / channel
+    // overflow). The default in-memory store keeps the persist/expose behavior
+    // testable without wiring; production binds the SharedPreferences-backed
+    // singleton via `VoiceModule`.
+    internal val undeliveredTranscriptStore: UndeliveredTranscriptStore =
+        InMemoryUndeliveredTranscriptStore(),
 ) : ViewModel() {
 
     private val _uiState: MutableStateFlow<UiState> = MutableStateFlow(UiState())
@@ -179,11 +190,27 @@ public class InlineDictationViewModel @Inject constructor(
     // subscribed, and hands each buffered value to exactly one collector
     // exactly once when the screen re-subscribes on re-key. That gives us the
     // "delivered on re-key, never dropped, never duplicated" contract:
-    //  - UNLIMITED + `trySend` so emission never suspends or fails.
+    //  - `trySend` so emission never suspends or fails.
     //  - `receiveAsFlow()` distributes each element to a single collector and
     //    resumes across consecutive collections (the LaunchedEffect re-key),
     //    so nothing is replayed to a fresh collector (no double-write).
-    private val deliveryChannel: Channel<String> = Channel(capacity = Channel.UNLIMITED)
+    //
+    // Issue #1272 hardens two gaps the #1226 reviewer flagged:
+    //  1. BOUNDED, not UNLIMITED. Rapid repeated dictation against a
+    //     permanently-dead pane could grow an UNLIMITED channel without bound.
+    //     A [DELIVERY_CHANNEL_CAPACITY]-deep buffer with `DROP_OLDEST` caps it;
+    //     an overflowed (dropped-oldest) transcript is NOT lost — it is routed
+    //     to [onUndeliveredElement] and persisted for retry.
+    //  2. PERMANENT-DEAD-PANE DRAIN. If the session never returns, no collector
+    //     ever subscribes, so the buffered transcript would be delivered to no
+    //     one. [onCleared] cancels this channel; cancellation hands every still-
+    //     buffered element to [onUndeliveredElement], persisting it instead of
+    //     silently dropping it.
+    private val deliveryChannel: Channel<String> = Channel(
+        capacity = DELIVERY_CHANNEL_CAPACITY,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+        onUndeliveredElement = { undelivered -> undeliveredTranscriptStore.persist(undelivered) },
+    )
 
     /**
      * Stream of successfully transcribed text. The session screen collects
@@ -201,6 +228,17 @@ public class InlineDictationViewModel @Inject constructor(
      * being dropped into the collector gap.
      */
     public val transcriptions: Flow<String> = deliveryChannel.receiveAsFlow()
+
+    /**
+     * Issue #1272: the queue of successfully-transcribed commands whose text
+     * could NOT be delivered to a pane (the session was gone by the time the
+     * transcript resolved, so no collector ever received it). Backed by the
+     * durable [undeliveredTranscriptStore] so the queue survives process death.
+     * A surface renders these as a visible "couldn't deliver — retry" list;
+     * [retryUndelivered] re-delivers a row and [dismissUndelivered] discards it.
+     */
+    public val undeliveredTranscripts: StateFlow<List<UndeliveredTranscript>> =
+        undeliveredTranscriptStore.items
 
     private var recordingJob: Job? = null
     private var transcribeJob: Job? = null
@@ -817,6 +855,35 @@ public class InlineDictationViewModel @Inject constructor(
     }
 
     /**
+     * Issue #1272: re-attempt delivery of a persisted undelivered transcript.
+     * Re-injects the text into the delivery channel — if a pane is now live the
+     * screen's collector writes it to the terminal, and if the pane is still
+     * gone the value re-buffers and re-persists on the next teardown, so the
+     * transcript is never lost. The persisted row is removed here so the retry
+     * item clears from the visible queue; the delivery path is the single
+     * source of truth for the actual terminal write.
+     */
+    public fun retryUndelivered(id: String) {
+        val item = undeliveredTranscriptStore.snapshot().firstOrNull { it.id == id } ?: return
+        undeliveredTranscriptStore.remove(id)
+        deliveryChannel.trySend(item.text)
+        DiagnosticEvents.record(
+            "action",
+            "inline_undelivered_transcript_retry",
+            "transcriptBytes" to item.text.toByteArray(Charsets.UTF_8).size,
+        )
+    }
+
+    /**
+     * Issue #1272: discard a persisted undelivered transcript the user no
+     * longer wants to recover.
+     */
+    public fun dismissUndelivered(id: String) {
+        undeliveredTranscriptStore.remove(id)
+        DiagnosticEvents.record("action", "inline_undelivered_transcript_dismiss")
+    }
+
+    /**
      * Called by the screen when the runtime `RECORD_AUDIO` prompt comes
      * back denied. Mirrors [PromptComposerViewModel.surfacePermissionDenied].
      */
@@ -844,6 +911,15 @@ public class InlineDictationViewModel @Inject constructor(
     override fun onCleared() {
         recordingJob?.cancel()
         transcribeJob?.cancel()
+        // Issue #1272: the ViewModel is being destroyed — the session screen is
+        // gone, so no collector will ever subscribe again (permanent pane
+        // death). Cancel the delivery channel: cancellation hands every still-
+        // buffered transcript to `onUndeliveredElement`, which persists it to
+        // the durable store so it surfaces as a retryable item instead of being
+        // silently dropped. (A transcript already handed to a live collector was
+        // removed from the buffer, so this never double-persists a delivered
+        // one.)
+        deliveryChannel.cancel()
         if (_uiState.value.recording == RecordingState.Recording) {
             if (activeProvider == VoiceTranscriptionProvider.AndroidSpeech) {
                 cancelAndroidSpeechRecognition()
@@ -960,6 +1036,19 @@ public class InlineDictationViewModel @Inject constructor(
     )
 
     public companion object {
+        /**
+         * Issue #1272: bound on the buffered-transcript delivery channel. The
+         * channel buffers transcripts across the transient collector gap (a
+         * pane flipping to `null` / re-keying during a reconnect, #1226); a
+         * handful is plenty for that. Beyond this depth (rapid dictation into a
+         * permanently-dead pane) the channel drops the OLDEST buffered element
+         * to `onUndeliveredElement`, which persists it to the durable store —
+         * so overflow means "moved to the retry queue", never "silently lost".
+         * Bounding replaces the old `Channel.UNLIMITED` so the buffer can never
+         * grow without limit.
+         */
+        public const val DELIVERY_CHANNEL_CAPACITY: Int = 32
+
         /** Same threshold as [PromptComposerViewModel.SILENCE_AMPLITUDE_THRESHOLD]. */
         public const val SILENCE_AMPLITUDE_THRESHOLD: Float = 0.04f
 
@@ -1056,6 +1145,14 @@ public fun KeyBarWithMic(
     // swallow [onKey] / [onMicTap] and render the mic slot in its muted
     // (non-interactive) form so the user sees that input is unavailable.
     inputEnabled: Boolean = true,
+    // Issue #1272: successfully-transcribed commands that could not be
+    // delivered to a pane (the session was gone by the time Whisper resolved).
+    // Surfaced as a visible "couldn't deliver — retry" list so the transcript
+    // is recoverable rather than silently lost. Empty by default so existing
+    // call sites are unaffected.
+    undeliveredTranscripts: List<UndeliveredTranscript> = emptyList(),
+    onRetryUndelivered: (String) -> Unit = {},
+    onDismissUndelivered: (String) -> Unit = {},
 ) {
     androidx.compose.foundation.layout.Column(
         modifier = modifier
@@ -1065,6 +1162,13 @@ public fun KeyBarWithMic(
             .padding(horizontal = 8.dp, vertical = 8.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
+        if (undeliveredTranscripts.isNotEmpty()) {
+            UndeliveredTranscriptBanner(
+                items = undeliveredTranscripts,
+                onRetry = onRetryUndelivered,
+                onDismiss = onDismissUndelivered,
+            )
+        }
         InlineDictationModeSelector(
             selectedMode = dictationMode,
             onModeSelected = onDictationModeSelected,
@@ -1103,6 +1207,95 @@ public fun KeyBarWithMic(
             )
         }
     }
+}
+
+/**
+ * Issue #1272: the "couldn't deliver — retry" list. Each row shows the
+ * undelivered transcript text with a Retry (re-deliver) and Dismiss (discard)
+ * affordance so the user recovers a command that was transcribed successfully
+ * but never reached a pane. Rendered at the top of [KeyBarWithMic] whenever the
+ * durable [UndeliveredTranscriptStore] has entries.
+ */
+@Composable
+private fun UndeliveredTranscriptBanner(
+    items: List<UndeliveredTranscript>,
+    onRetry: (String) -> Unit,
+    onDismiss: (String) -> Unit,
+) {
+    androidx.compose.foundation.layout.Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag(UNDELIVERED_TRANSCRIPT_BANNER_TAG)
+            .background(
+                color = PocketShellColors.SurfaceElev,
+                shape = RoundedCornerShape(8.dp),
+            )
+            .border(
+                border = BorderStroke(1.dp, PocketShellColors.AccentDim),
+                shape = RoundedCornerShape(8.dp),
+            )
+            .padding(8.dp),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        Text(
+            text = "Couldn't deliver — retry",
+            color = PocketShellColors.Accent,
+            fontSize = 11.sp,
+            fontWeight = FontWeight.SemiBold,
+        )
+        items.forEach { item ->
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
+                Text(
+                    text = item.text,
+                    color = PocketShellColors.Text,
+                    fontSize = 12.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f),
+                )
+                UndeliveredTranscriptAction(
+                    label = "Retry",
+                    accent = PocketShellColors.Accent,
+                    testTag = "$UNDELIVERED_TRANSCRIPT_RETRY_TAG-${item.id}",
+                    onClick = { onRetry(item.id) },
+                )
+                UndeliveredTranscriptAction(
+                    label = "Dismiss",
+                    accent = PocketShellColors.TextSecondary,
+                    testTag = "$UNDELIVERED_TRANSCRIPT_DISMISS_TAG-${item.id}",
+                    onClick = { onDismiss(item.id) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun UndeliveredTranscriptAction(
+    label: String,
+    accent: Color,
+    testTag: String,
+    onClick: () -> Unit,
+) {
+    Text(
+        text = label,
+        color = accent,
+        fontSize = 12.sp,
+        fontWeight = FontWeight.SemiBold,
+        modifier = Modifier
+            .testTag(testTag)
+            .background(color = PocketShellColors.Surface, shape = RoundedCornerShape(6.dp))
+            .border(
+                border = BorderStroke(1.dp, PocketShellColors.Border),
+                shape = RoundedCornerShape(6.dp),
+            )
+            .clickable(role = Role.Button, onClick = onClick)
+            .padding(horizontal = 10.dp, vertical = 4.dp),
+    )
 }
 
 @Composable
@@ -1362,3 +1555,8 @@ internal const val INLINE_DICTATION_MIC_SLOT_TAG: String = "inline-dictation-mic
 internal const val INLINE_DICTATION_WAVEFORM_TAG: String = "inline-dictation-waveform"
 internal const val INLINE_DICTATION_TRANSCRIBING_TAG: String = "inline-dictation-transcribing"
 internal const val INLINE_DICTATION_STATUS_TAG: String = "inline-dictation-status"
+
+// Issue #1272: the undelivered-transcript retry banner + its per-row actions.
+internal const val UNDELIVERED_TRANSCRIPT_BANNER_TAG: String = "undelivered-transcript-banner"
+internal const val UNDELIVERED_TRANSCRIPT_RETRY_TAG: String = "undelivered-transcript-retry"
+internal const val UNDELIVERED_TRANSCRIPT_DISMISS_TAG: String = "undelivered-transcript-dismiss"

--- a/app/src/main/java/com/pocketshell/app/voice/UndeliveredTranscriptStore.kt
+++ b/app/src/main/java/com/pocketshell/app/voice/UndeliveredTranscriptStore.kt
@@ -1,0 +1,248 @@
+package com.pocketshell.app.voice
+
+import android.content.Context
+import android.content.SharedPreferences
+import com.pocketshell.app.prefs.ResilientPrefs
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import org.json.JSONArray
+import org.json.JSONObject
+import java.util.UUID
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Durable holding pen for a *successfully transcribed* voice command whose
+ * text could NOT be delivered to a terminal pane — issue #1272.
+ *
+ * ## Why this exists (the residual silent-data-loss tail from #1226)
+ *
+ * Issue #1226 made [com.pocketshell.app.session.InlineDictationViewModel]'s
+ * transcript hand-off a buffering `Channel`, so a transcript produced during a
+ * brief drop/reconnect (the focused pane momentarily flips to `null` /
+ * re-keys) is buffered and delivered once the pane re-subscribes. That fixed
+ * the *transient* gap. It did NOT fix the *permanent* gap: if the session never
+ * returns (the user navigates away, the session is fully gone), **no collector
+ * ever subscribes**, so the buffered transcript is delivered to no one and is
+ * silently lost with no retry affordance. The #1226 reviewer flagged this as
+ * the residual tail.
+ *
+ * This store closes it. When the delivery channel confirms a transcript is
+ * undeliverable — the ViewModel is cleared with the transcript still buffered
+ * (permanent pane death), OR the bounded channel overflows — the text is
+ * [persist]ed here. The store survives process death (SharedPreferences),
+ * exposes the queue as [items] so a surface can render a visible "couldn't
+ * deliver — retry" affordance, and lets the user [remove] an item once
+ * re-delivered or dismissed.
+ *
+ * Unlike the audio-backed [PendingTranscriptionStore] (which persists the raw
+ * WAV so a *failed* Whisper call can be *re-transcribed*), this store persists
+ * the already-resolved *text* — the transcription succeeded, only the terminal
+ * hand-off failed, so recovery is a re-delivery, not a re-transcription.
+ */
+interface UndeliveredTranscriptStore {
+    /** The current queue of undelivered transcripts, newest first. */
+    val items: StateFlow<List<UndeliveredTranscript>>
+
+    /**
+     * Persist [text] as an undelivered transcript. Returns the stored item, or
+     * `null` if [text] is blank (nothing worth surfacing). Safe to call from a
+     * non-suspending / arbitrary-thread context (the delivery channel's
+     * `onUndeliveredElement` callback and ViewModel teardown both call it).
+     */
+    fun persist(text: String): UndeliveredTranscript?
+
+    /** Drop the item with [id] (re-delivered or user-dismissed). Idempotent. */
+    fun remove(id: String)
+
+    /** Point-in-time snapshot of the queue, newest first. */
+    fun snapshot(): List<UndeliveredTranscript>
+}
+
+/**
+ * One undelivered transcript. [text] is the resolved Whisper/speech output that
+ * was never written to a pane; [id] is a stable UUID used for [remove].
+ */
+data class UndeliveredTranscript(
+    val id: String,
+    val text: String,
+    val createdAtMs: Long,
+)
+
+/**
+ * Process-lifetime, non-durable [UndeliveredTranscriptStore]. Used as the
+ * ViewModel's default (so unit tests exercise the persist/expose behavior
+ * without wiring the SharedPreferences implementation) and anywhere durability
+ * is not required. Thread-safe.
+ */
+class InMemoryUndeliveredTranscriptStore(
+    internal var clock: () -> Long = { System.currentTimeMillis() },
+    internal var idGenerator: () -> String = { UUID.randomUUID().toString() },
+) : UndeliveredTranscriptStore {
+
+    private val lock = Any()
+    private val rows = LinkedHashMap<String, UndeliveredTranscript>()
+    private val _items = MutableStateFlow<List<UndeliveredTranscript>>(emptyList())
+    override val items: StateFlow<List<UndeliveredTranscript>> = _items.asStateFlow()
+
+    override fun persist(text: String): UndeliveredTranscript? {
+        val trimmed = text.trim()
+        if (trimmed.isEmpty()) return null
+        synchronized(lock) {
+            val item = UndeliveredTranscript(
+                id = idGenerator(),
+                text = trimmed,
+                createdAtMs = clock(),
+            )
+            rows[item.id] = item
+            trimToCap(rows)
+            publish()
+            return item
+        }
+    }
+
+    override fun remove(id: String) {
+        synchronized(lock) {
+            if (rows.remove(id) != null) publish()
+        }
+    }
+
+    override fun snapshot(): List<UndeliveredTranscript> = synchronized(lock) { newestFirst(rows) }
+
+    private fun publish() {
+        _items.value = newestFirst(rows)
+    }
+}
+
+/**
+ * SharedPreferences-backed, durable [UndeliveredTranscriptStore]. The whole
+ * queue is serialized as a single JSON array under one prefs key so a persist /
+ * remove is one small read-modify-write. Opened through [ResilientPrefs] (issue
+ * #1292) so a corrupt prefs file can't crash the app — it is cleared and
+ * re-opened fresh instead.
+ *
+ * `@Singleton` so every activity-scoped inline-dictation ViewModel over the app
+ * lifetime observes and mutates the same queue: a transcript persisted while
+ * one session screen is torn down is visible to the next session screen's
+ * ViewModel, and a process restart reloads the queue from disk.
+ */
+@Singleton
+class SharedPrefsUndeliveredTranscriptStore @Inject constructor(
+    @ApplicationContext context: Context,
+) : UndeliveredTranscriptStore {
+
+    private val prefs: SharedPreferences = ResilientPrefs.open(context, PREFS_NAME)
+    private val lock = Any()
+    private val rows = LinkedHashMap<String, UndeliveredTranscript>()
+    private val _items = MutableStateFlow<List<UndeliveredTranscript>>(emptyList())
+    override val items: StateFlow<List<UndeliveredTranscript>> = _items.asStateFlow()
+
+    // Test seams — production wires wall-clock + random UUIDs; tests substitute
+    // deterministic generators. Mutable fields (not constructor params) so the
+    // Hilt graph doesn't have to bind function types.
+    internal var clock: () -> Long = { System.currentTimeMillis() }
+    internal var idGenerator: () -> String = { UUID.randomUUID().toString() }
+
+    init {
+        synchronized(lock) {
+            rows.putAll(readFromDisk().associateBy { it.id })
+            publish()
+        }
+    }
+
+    override fun persist(text: String): UndeliveredTranscript? {
+        val trimmed = text.trim()
+        if (trimmed.isEmpty()) return null
+        synchronized(lock) {
+            val item = UndeliveredTranscript(
+                id = idGenerator(),
+                text = trimmed,
+                createdAtMs = clock(),
+            )
+            rows[item.id] = item
+            trimToCap(rows)
+            writeToDisk()
+            publish()
+            return item
+        }
+    }
+
+    override fun remove(id: String) {
+        synchronized(lock) {
+            if (rows.remove(id) != null) {
+                writeToDisk()
+                publish()
+            }
+        }
+    }
+
+    override fun snapshot(): List<UndeliveredTranscript> = synchronized(lock) { newestFirst(rows) }
+
+    private fun publish() {
+        _items.value = newestFirst(rows)
+    }
+
+    private fun readFromDisk(): List<UndeliveredTranscript> {
+        val raw = runCatching { prefs.getString(KEY_QUEUE, null) }.getOrNull() ?: return emptyList()
+        return runCatching {
+            val arr = JSONArray(raw)
+            (0 until arr.length()).mapNotNull { i ->
+                val obj = arr.optJSONObject(i) ?: return@mapNotNull null
+                val id = obj.optString(FIELD_ID, "")
+                val text = obj.optString(FIELD_TEXT, "")
+                if (id.isEmpty() || text.isEmpty()) return@mapNotNull null
+                UndeliveredTranscript(
+                    id = id,
+                    text = text,
+                    createdAtMs = obj.optLong(FIELD_CREATED_AT, 0L),
+                )
+            }
+        }.getOrDefault(emptyList())
+    }
+
+    private fun writeToDisk() {
+        val arr = JSONArray()
+        // Persist insertion order (oldest first); readFromDisk / newestFirst
+        // re-establish the ordering invariants on load and on publish.
+        rows.values.forEach { item ->
+            arr.put(
+                JSONObject()
+                    .put(FIELD_ID, item.id)
+                    .put(FIELD_TEXT, item.text)
+                    .put(FIELD_CREATED_AT, item.createdAtMs),
+            )
+        }
+        runCatching { prefs.edit().putString(KEY_QUEUE, arr.toString()).apply() }
+    }
+
+    companion object {
+        const val PREFS_NAME: String = "undelivered_transcripts"
+        private const val KEY_QUEUE: String = "queue"
+        private const val FIELD_ID: String = "id"
+        private const val FIELD_TEXT: String = "text"
+        private const val FIELD_CREATED_AT: String = "createdAt"
+    }
+}
+
+/**
+ * Hard cap on the number of persisted undelivered transcripts. Voice
+ * transcripts are low-volume, but a permanently-dead pane hit with rapid
+ * repeated dictation could otherwise grow the queue without bound (the second
+ * #1272 gap, mirrored on the persistence side of the bounded delivery channel).
+ * When the cap is exceeded the OLDEST rows are dropped.
+ */
+internal const val MAX_UNDELIVERED_TRANSCRIPTS: Int = 50
+
+/** Trim [rows] (insertion-ordered, oldest first) down to [MAX_UNDELIVERED_TRANSCRIPTS]. */
+private fun trimToCap(rows: LinkedHashMap<String, UndeliveredTranscript>) {
+    while (rows.size > MAX_UNDELIVERED_TRANSCRIPTS) {
+        val oldest = rows.keys.iterator().next()
+        rows.remove(oldest)
+    }
+}
+
+/** Newest-first view of an insertion-ordered (oldest-first) map. */
+private fun newestFirst(rows: LinkedHashMap<String, UndeliveredTranscript>): List<UndeliveredTranscript> =
+    rows.values.toList().asReversed()

--- a/app/src/test/java/com/pocketshell/app/session/InlineDictationViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/session/InlineDictationViewModelTest.kt
@@ -2,6 +2,7 @@ package com.pocketshell.app.session
 
 import com.pocketshell.app.composer.PromptComposerViewModel
 import com.pocketshell.app.diagnostics.installRecordingDiagnosticSink
+import com.pocketshell.app.voice.InMemoryUndeliveredTranscriptStore
 import com.pocketshell.app.voice.PendingTranscriptionItem
 import com.pocketshell.app.di.WhisperClientFactory
 import com.pocketshell.app.session.InlineDictationViewModel.DictationMode
@@ -256,6 +257,8 @@ class InlineDictationViewModelTest {
             FakeSpeechRecognitionProvider(available = false),
         pendingQueue: PromptComposerViewModel.PendingTranscriptionQueue =
             com.pocketshell.app.composer.DisabledPendingTranscriptionQueue,
+        undeliveredStore: com.pocketshell.app.voice.UndeliveredTranscriptStore =
+            com.pocketshell.app.voice.InMemoryUndeliveredTranscriptStore(),
     ): InlineDictationViewModel {
         val factory = WhisperClientFactory { whisper }
         val vm = InlineDictationViewModel(
@@ -265,6 +268,7 @@ class InlineDictationViewModelTest {
             voiceSettings = voiceSettings,
             speechRecognitionProvider = speechRecognitionProvider,
             pendingTranscriptionStore = pendingQueue,
+            undeliveredTranscriptStore = undeliveredStore,
         )
         if (samplerDispatcher != null) vm.samplerDispatcher = samplerDispatcher
         vm.clock = clock
@@ -1613,5 +1617,211 @@ class InlineDictationViewModelTest {
 
         assertEquals(listOf("%7" to "make deploy"), delivered)
         collectorJob?.cancel()
+    }
+
+    // -- Issue #1272: permanent-dead-pane persistence + bounded channel --------
+
+    @Test
+    fun permanentDeadPaneTranscriptIsPersistedAndSurfacedOnClear() = runTest {
+        // The residual #1226 tail: a transcript resolves while there is NO pane,
+        // and the session never returns (the user navigated away). No collector
+        // ever subscribes, so the buffered transcript would be delivered to no
+        // one and silently lost. On ViewModel teardown (permanent pane death)
+        // the delivery channel is cancelled, which persists the still-buffered
+        // transcript to the durable store and surfaces it as a retryable item.
+        //
+        // RED on base: `onCleared` did not cancel the channel and there was no
+        // store, so the buffered transcript vanished with the ViewModel ->
+        // `store.snapshot()` empty, `undeliveredTranscripts.value` empty.
+        // GREEN with the fix: the transcript is persisted + surfaced.
+        val store = InMemoryUndeliveredTranscriptStore()
+        val vm = newVm(
+            mic = FakeMicCapture(audio = SpeechAudioGuard.speechWavForTesting()),
+            whisper = fakeWhisperClient { Result.success("git push origin main") },
+            samplerDispatcher = StandardTestDispatcher(testScheduler),
+            undeliveredStore = store,
+        )
+
+        // Dictate to completion with NO collector ever subscribing (pane gone).
+        vm.onMicTap()
+        runCurrent()
+        vm.onMicTap()
+        advanceUntilIdle()
+
+        // Nothing persisted yet — the transcript is buffered, still deliverable
+        // if the pane were to return within this ViewModel's lifetime.
+        assertTrue(
+            "transcript must stay buffered (not persisted) while the ViewModel is alive",
+            store.snapshot().isEmpty(),
+        )
+
+        // The session is permanently gone: the ViewModel is cleared.
+        vm.clearForTest()
+        advanceUntilIdle()
+
+        val persisted = store.snapshot()
+        assertEquals(
+            "the undeliverable transcript must be persisted on permanent pane death",
+            1,
+            persisted.size,
+        )
+        assertEquals("git push origin main", persisted.first().text)
+        assertEquals(
+            "the persisted transcript is surfaced via undeliveredTranscripts",
+            listOf("git push origin main"),
+            vm.undeliveredTranscripts.value.map { it.text },
+        )
+    }
+
+    @Test
+    fun deliveredTranscriptIsNotPersistedOnClear() = runTest {
+        // Guard against a false positive: a transcript that WAS delivered to a
+        // live collector must not be re-persisted on teardown (receiveAsFlow
+        // removed it from the buffer, so channel-cancel has nothing to drain).
+        val store = InMemoryUndeliveredTranscriptStore()
+        val vm = newVm(
+            mic = FakeMicCapture(audio = SpeechAudioGuard.speechWavForTesting()),
+            whisper = fakeWhisperClient { Result.success("ls -la") },
+            samplerDispatcher = StandardTestDispatcher(testScheduler),
+            undeliveredStore = store,
+        )
+
+        val delivered = mutableListOf<String>()
+        val collector = launch { vm.transcriptions.collect { delivered += it } }
+        runCurrent()
+
+        vm.onMicTap()
+        runCurrent()
+        vm.onMicTap()
+        advanceUntilIdle()
+
+        assertEquals(listOf("ls -la"), delivered)
+
+        collector.cancel()
+        vm.clearForTest()
+        advanceUntilIdle()
+
+        assertTrue(
+            "a delivered transcript must NOT be persisted as undelivered, got ${store.snapshot()}",
+            store.snapshot().isEmpty(),
+        )
+    }
+
+    @Test
+    fun deliveryChannelIsBoundedAndOverflowPersistsInsteadOfGrowingUnbounded() = runTest {
+        // Second #1272 gap: the old `Channel.UNLIMITED` grew without bound under
+        // rapid repeated dictation into a permanently-dead pane. The channel is
+        // now bounded to DELIVERY_CHANNEL_CAPACITY with DROP_OLDEST, and a
+        // dropped-oldest element is routed to the store rather than lost.
+        //
+        // RED on base: an UNLIMITED channel buffers every send, so before any
+        // teardown the store is EMPTY no matter how many transcripts pile up.
+        // GREEN with the fix: sending capacity + N transcripts with no collector
+        // overflows the oldest N straight into the store.
+        val store = InMemoryUndeliveredTranscriptStore()
+        val overflow = 3
+        val total = InlineDictationViewModel.DELIVERY_CHANNEL_CAPACITY + overflow
+        var index = 0
+        val vm = newVm(
+            mic = FakeMicCapture(audio = SpeechAudioGuard.speechWavForTesting()),
+            whisper = fakeWhisperClient { Result.success("cmd-${index++}") },
+            samplerDispatcher = StandardTestDispatcher(testScheduler),
+            undeliveredStore = store,
+        )
+
+        // Fire `total` full dictation cycles with NO collector — the channel
+        // fills to capacity and then drops-oldest to the store.
+        repeat(total) {
+            vm.onMicTap()
+            runCurrent()
+            vm.onMicTap()
+            advanceUntilIdle()
+        }
+
+        val persisted = store.snapshot()
+        assertEquals(
+            "exactly the overflow (oldest) transcripts should be persisted; the " +
+                "channel must be bounded, not unbounded",
+            overflow,
+            persisted.size,
+        )
+        // DROP_OLDEST persists the FIRST-sent transcripts (cmd-0..cmd-2).
+        assertEquals(
+            setOf("cmd-0", "cmd-1", "cmd-2"),
+            persisted.map { it.text }.toSet(),
+        )
+    }
+
+    @Test
+    fun retryUndeliveredReDeliversToLivePaneAndClearsQueue() = runTest {
+        // Recovery loop across ViewModel instances (the real journey): session A
+        // dies with an undelivered transcript persisted; a new session screen B
+        // reads the durable store, the user taps Retry, and the transcript is
+        // re-delivered into B's live pane and removed from the queue.
+        val store = InMemoryUndeliveredTranscriptStore()
+
+        // Session A: dictate with no pane, then permanent death -> persisted.
+        val vmA = newVm(
+            mic = FakeMicCapture(audio = SpeechAudioGuard.speechWavForTesting()),
+            whisper = fakeWhisperClient { Result.success("deploy now") },
+            samplerDispatcher = StandardTestDispatcher(testScheduler),
+            undeliveredStore = store,
+        )
+        vmA.onMicTap()
+        runCurrent()
+        vmA.onMicTap()
+        advanceUntilIdle()
+        vmA.clearForTest()
+        advanceUntilIdle()
+        assertEquals(1, store.snapshot().size)
+        val id = store.snapshot().first().id
+
+        // Session B: shares the same durable store, has a live collector.
+        val vmB = newVm(
+            mic = FakeMicCapture(),
+            undeliveredStore = store,
+        )
+        val delivered = mutableListOf<String>()
+        val collector = launch { vmB.transcriptions.collect { delivered += it } }
+        runCurrent()
+
+        assertEquals(
+            "B surfaces the persisted item before retry",
+            listOf("deploy now"),
+            vmB.undeliveredTranscripts.value.map { it.text },
+        )
+
+        vmB.retryUndelivered(id)
+        advanceUntilIdle()
+
+        assertEquals(
+            "retry re-delivers the transcript into B's live pane",
+            listOf("deploy now"),
+            delivered,
+        )
+        assertTrue(
+            "the retried item is removed from the queue",
+            store.snapshot().isEmpty(),
+        )
+        collector.cancel()
+    }
+
+    @Test
+    fun dismissUndeliveredDiscardsWithoutRedelivery() = runTest {
+        val store = InMemoryUndeliveredTranscriptStore()
+        store.persist("obsolete command")
+        val vm = newVm(mic = FakeMicCapture(), undeliveredStore = store)
+
+        val delivered = mutableListOf<String>()
+        val collector = launch { vm.transcriptions.collect { delivered += it } }
+        runCurrent()
+
+        val id = store.snapshot().first().id
+        vm.dismissUndelivered(id)
+        advanceUntilIdle()
+
+        assertTrue("dismiss removes the item", store.snapshot().isEmpty())
+        assertTrue("dismiss must not re-deliver", delivered.isEmpty())
+        collector.cancel()
     }
 }

--- a/app/src/test/java/com/pocketshell/app/voice/UndeliveredTranscriptStoreTest.kt
+++ b/app/src/test/java/com/pocketshell/app/voice/UndeliveredTranscriptStoreTest.kt
@@ -1,0 +1,195 @@
+package com.pocketshell.app.voice
+
+import android.content.Context
+import android.content.ContextWrapper
+import android.content.SharedPreferences
+import androidx.test.core.app.ApplicationProvider
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Unit tests for [SharedPrefsUndeliveredTranscriptStore] and
+ * [InMemoryUndeliveredTranscriptStore] — the durable holding pen for a
+ * successfully-transcribed voice command whose text could not be delivered to a
+ * pane (issue #1272).
+ *
+ * Covers the two #1272 gaps at the store layer:
+ *  - **Durability**: a persisted transcript survives a process "restart" (a
+ *    fresh store instance reads it back from disk) so it is genuinely
+ *    recoverable, not silently lost.
+ *  - **Bounding**: the queue is capped at [MAX_UNDELIVERED_TRANSCRIPTS]; rapid
+ *    repeated persistence drops the oldest instead of growing without bound.
+ *  - **Resilience**: a corrupt prefs file is opened through [ResilientPrefs] so
+ *    the store never crashes the app (the #1292 hardening the brief calls for).
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class UndeliveredTranscriptStoreTest {
+
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        clearPrefs()
+    }
+
+    @After
+    fun tearDown() {
+        clearPrefs()
+    }
+
+    // -- Durability -----------------------------------------------------------
+
+    @Test
+    fun persistedTranscriptSurvivesProcessRestart() {
+        val store = SharedPrefsUndeliveredTranscriptStore(context)
+        store.persist("git push origin main")
+        store.persist("make deploy")
+
+        // A fresh instance models a process restart reading from the same
+        // SharedPreferences file.
+        val relaunched = SharedPrefsUndeliveredTranscriptStore(context)
+        val restored = relaunched.snapshot().map { it.text }
+        assertEquals(
+            "both undelivered transcripts must survive a restart",
+            setOf("git push origin main", "make deploy"),
+            restored.toSet(),
+        )
+        assertEquals(
+            "the store surfaces the restored items via its items flow",
+            restored.toSet(),
+            relaunched.items.value.map { it.text }.toSet(),
+        )
+    }
+
+    @Test
+    fun removePersistsAcrossRestart() {
+        val store = SharedPrefsUndeliveredTranscriptStore(context)
+        val a = store.persist("cmd-a")!!
+        store.persist("cmd-b")
+        store.remove(a.id)
+
+        val relaunched = SharedPrefsUndeliveredTranscriptStore(context)
+        assertEquals(
+            listOf("cmd-b"),
+            relaunched.snapshot().map { it.text },
+        )
+    }
+
+    @Test
+    fun blankTranscriptIsNotPersisted() {
+        val store = SharedPrefsUndeliveredTranscriptStore(context)
+        assertNull(store.persist("   "))
+        assertNull(store.persist(""))
+        assertTrue(store.snapshot().isEmpty())
+    }
+
+    @Test
+    fun itemsAreSurfacedNewestFirst() {
+        val store = SharedPrefsUndeliveredTranscriptStore(context)
+        store.persist("first")
+        store.persist("second")
+        store.persist("third")
+        assertEquals(
+            listOf("third", "second", "first"),
+            store.snapshot().map { it.text },
+        )
+    }
+
+    // -- Bounding (second #1272 gap) ------------------------------------------
+
+    @Test
+    fun queueIsBoundedAndDropsOldestBeyondCap() {
+        val store = SharedPrefsUndeliveredTranscriptStore(context)
+        val overflow = 5
+        repeat(MAX_UNDELIVERED_TRANSCRIPTS + overflow) { store.persist("cmd-$it") }
+
+        val snapshot = store.snapshot()
+        assertEquals(
+            "the queue must be capped, not grow unbounded",
+            MAX_UNDELIVERED_TRANSCRIPTS,
+            snapshot.size,
+        )
+        // The OLDEST `overflow` entries (cmd-0 .. cmd-4) are dropped.
+        val texts = snapshot.map { it.text }.toSet()
+        repeat(overflow) { assertFalse("cmd-$it (oldest) must be dropped", "cmd-$it" in texts) }
+        assertTrue("the newest entry must be retained", "cmd-${MAX_UNDELIVERED_TRANSCRIPTS + overflow - 1}" in texts)
+    }
+
+    // -- Resilience (ResilientPrefs, #1292) -----------------------------------
+
+    @Test
+    fun corruptPrefsFileDoesNotCrashTheStore() {
+        val corruptContext = CorruptContext(context)
+
+        // Constructing the store opens the prefs file; a corrupt open must be
+        // caught + recovered (ResilientPrefs) rather than propagating.
+        val store = SharedPrefsUndeliveredTranscriptStore(corruptContext)
+        assertTrue(
+            "the corrupt open must have been attempted (guard against a vacuous pass)",
+            corruptContext.throwingOpenAttempts.get() >= 1,
+        )
+
+        // The recovered store is usable: a persist round-trips.
+        val item = store.persist("recovered command")
+        assertEquals("recovered command", item?.text)
+        assertEquals(listOf("recovered command"), store.snapshot().map { it.text })
+    }
+
+    // -- In-memory variant ----------------------------------------------------
+
+    @Test
+    fun inMemoryStorePersistExposeRemove() {
+        val store = InMemoryUndeliveredTranscriptStore()
+        val a = store.persist("alpha")!!
+        store.persist("beta")
+        assertEquals(listOf("beta", "alpha"), store.items.value.map { it.text })
+        store.remove(a.id)
+        assertEquals(listOf("beta"), store.items.value.map { it.text })
+        assertNull(store.persist("  "))
+    }
+
+    private fun clearPrefs() {
+        context.getSharedPreferences(SharedPrefsUndeliveredTranscriptStore.PREFS_NAME, Context.MODE_PRIVATE)
+            .edit().clear().commit()
+    }
+
+    /**
+     * A [ContextWrapper] that throws on the first
+     * `getSharedPreferences(undelivered_transcripts, ...)` — mirroring a corrupt
+     * XML parse — until the file is deleted, at which point [ResilientPrefs]'s
+     * recovery re-opens cleanly.
+     */
+    private class CorruptContext(base: Context) : ContextWrapper(base) {
+        @Volatile
+        private var corrupt = true
+        val throwingOpenAttempts = AtomicInteger(0)
+
+        override fun getApplicationContext(): Context = this
+
+        override fun getSharedPreferences(name: String?, mode: Int): SharedPreferences {
+            if (name == SharedPrefsUndeliveredTranscriptStore.PREFS_NAME && corrupt) {
+                throwingOpenAttempts.incrementAndGet()
+                throw RuntimeException("simulated corrupt undelivered_transcripts.xml")
+            }
+            return super.getSharedPreferences(name, mode)
+        }
+
+        override fun deleteSharedPreferences(name: String?): Boolean {
+            if (name == SharedPrefsUndeliveredTranscriptStore.PREFS_NAME) {
+                corrupt = false
+            }
+            return super.deleteSharedPreferences(name)
+        }
+    }
+}


### PR DESCRIPTION
Part of #1272 (does NOT close it). Fixes the silent transcript-drop: onCleared drains buffered transcripts into a ResilientPrefs-backed UndeliveredTranscriptStore; channel bounded (cap 32, DROP_OLDEST, overflow→persist). Reviewer APPROVED the data-loss slice (reviewer-driven red→green on both gaps, assembleDebug validates the Hilt binding, corrupt-store recovery test). The visible retry banner wiring into live chrome is the remaining #1272 work (composer now unfrozen) — issue stays open.