### PR TITLE
connection: one fused SessionSurfaceState — contradictions type-unrepresentable (S3, #1326)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/BackgroundGraceReconnectE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/BackgroundGraceReconnectE2eTest.kt
@@ -675,7 +675,7 @@ class BackgroundGraceReconnectE2eTest {
         )
         // Issue #754: the "Attaching…" SwitchingLoadingPlaceholder overlay is the
         // EXACT surface the maintainer reported on a within-grace return. The old
-        // inline foreground probe→connect raised `_switchHidesTerminal` (this tag) on
+        // inline foreground probe→connect raised the reveal-machine hold (this tag) on
         // any confirmed-dead probe verdict even inside grace — the D21 violation #754
         // deletes. A within-grace foreground must NEVER paint it.
         assertEquals(

--- a/app/src/androidTest/java/com/pocketshell/app/proof/WithinGraceResumeRideThroughE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/WithinGraceResumeRideThroughE2eTest.kt
@@ -34,7 +34,7 @@ import org.junit.runner.RunWith
  * the #754 driver-owned RESEED-ONLY path.
  *
  * #754 hard-cut DELETED the inline `probeCurrentRuntimeOnForegroundIfNeeded →
- * connect(LifecycleReattach)` path that raised `_switchHidesTerminal` (the
+ * connect(LifecycleReattach)` path that raised the reveal-machine hold (the
  * "Attaching…" overlay) on a confirmed-dead probe verdict even inside grace. The
  * within-grace foreground is now a driver/controller-owned reseed-only effect: it
  * re-promotes Live + heals blank panes over the still-warm `-CC` lease — NO
@@ -193,7 +193,7 @@ class WithinGraceResumeRideThroughE2eTest : NetworkFaultProofBase() {
      *
      * On the OLD inline path this is exactly when `probeCurrentRuntimeOnForegroundIfNeeded`
      * saw a dead channel inside grace and fired `connect(LifecycleReattach)` →
-     * `_switchHidesTerminal=true` → the "Attaching…" (`TMUX_SWITCHING_LOADING_TAG`)
+     * the reveal-machine hold (RevealState.Seeding) → the "Attaching…" (`TMUX_SWITCHING_LOADING_TAG`)
      * overlay — the D21 violation. The #754 hard-cut DELETED that inline probe path, so a
      * confirmed-dead within-grace foreground NEVER paints "Attaching…" and NEVER runs the
      * inline probe.

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxConnectingProgressOverlayTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxConnectingProgressOverlayTest.kt
@@ -177,15 +177,12 @@ class TmuxConnectingProgressOverlayTest {
         compose.setContent {
             PocketShellTheme {
                 ReconnectingProgressRow(
-                    status = TmuxSessionViewModel.ConnectionStatus.Reconnecting(
-                        host = "10.0.2.2",
-                        port = 22,
-                        user = "alex",
-                        attempt = 2,
-                        maxAttempts = 4,
-                        retryDelayMs = 60_000,
-                        reason = "Network changed; reconnecting.",
-                    ),
+                    user = "alex",
+                    host = "10.0.2.2",
+                    port = 22,
+                    attempt = 2,
+                    maxAttempts = 4,
+                    retryDelayMs = 60_000,
                     sessionLabel = "tmux work",
                     onRetryNow = { retryCalls += 1 },
                     onCancel = { cancelCalls += 1 },
@@ -233,7 +230,12 @@ class TmuxConnectingProgressOverlayTest {
                 when (val current = status.value) {
                     is TmuxSessionViewModel.ConnectionStatus.Reconnecting -> {
                         ReconnectingProgressRow(
-                            status = current,
+                            user = current.user,
+                            host = current.host,
+                            port = current.port,
+                            attempt = current.attempt,
+                            maxAttempts = current.maxAttempts,
+                            retryDelayMs = current.retryDelayMs,
                             sessionLabel = "tmux work",
                             onRetryNow = {},
                             onCancel = {

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxConnectingStatesScreenshotTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxConnectingStatesScreenshotTest.kt
@@ -23,6 +23,14 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.core.connection.FailureReason
+import com.pocketshell.core.connection.RevealState
+import com.pocketshell.core.connection.SessionId
+import com.pocketshell.core.connection.SessionSurfaceState
+import com.pocketshell.core.connection.sessionSurfaceState
+import com.pocketshell.core.connection.showsCalmFailure
+import com.pocketshell.core.connection.showsCenteredLoader
+import com.pocketshell.core.connection.surfaceOwnsPrimary
 import com.pocketshell.uikit.components.LoadingIndicator
 import com.pocketshell.uikit.components.SpinnerSize
 import com.pocketshell.uikit.theme.PocketShellColors
@@ -71,6 +79,15 @@ class TmuxConnectingStatesScreenshotTest {
 
     @get:Rule
     val compose = createAndroidComposeRule<ComponentActivity>()
+
+    // Issue #1326 (S3): build the fused view state the screen renders, exactly as
+    // the screen wires it, so these screenshot proofs drive the SAME single state.
+    private val sid = SessionId("host/work")
+
+    private fun surfaceOf(
+        reveal: RevealState,
+        status: TmuxSessionViewModel.ConnectionStatus,
+    ): SessionSurfaceState = sessionSurfaceState(reveal, connectionPhaseOf(status), sid)
 
     @Test
     fun captureWaitingForPanesConnectingState() {
@@ -233,8 +250,8 @@ class TmuxConnectingStatesScreenshotTest {
                     // true` (the reconnect re-dial reality) the gate suppresses BOTH
                     // banners → this renders NOTHING.
                     TmuxTopConnectingBanner(
-                        status = connecting,
-                        effectiveHidesTerminal = true,
+                        surfaceState = surfaceOf(RevealState.Seeding(sid, "git-pocketshell"), connecting),
+                        surfaceOwnsPrimary = true,
                         sessionName = "git-pocketshell",
                         onCancelConnect = {},
                         onRetryNow = {},
@@ -309,7 +326,12 @@ class TmuxConnectingStatesScreenshotTest {
                     // The REAL under-header reconnect band — text + Retry now /
                     // Cancel, no linear bar after the #750 class-wide fix.
                     ReconnectingProgressRow(
-                        status = reconnecting,
+                        user = reconnecting.user,
+                        host = reconnecting.host,
+                        port = reconnecting.port,
+                        attempt = reconnecting.attempt,
+                        maxAttempts = reconnecting.maxAttempts,
+                        retryDelayMs = reconnecting.retryDelayMs,
                         sessionLabel = "tmux claude-main",
                         onRetryNow = {},
                         onCancel = {},
@@ -405,7 +427,9 @@ class TmuxConnectingStatesScreenshotTest {
                             onReconnect = {},
                             // The REAL gate — false for Failed (the band owns the
                             // single affordance), so the bottom button is suppressed.
-                            showReconnectButton = surfaceReconnectButtonVisible(failed),
+                            showReconnectButton = surfaceReconnectButtonVisible(
+                                surfaceOf(RevealState.Error(sid, "claude-main", retrying = false, reason = FailureReason.Unreachable(true)), failed),
+                            ),
                         ) {
                             Box(
                                 modifier = Modifier
@@ -450,6 +474,12 @@ class TmuxConnectingStatesScreenshotTest {
         val failed = TmuxSessionViewModel.ConnectionStatus.Failed(
             "Connection lost. Tap Reconnect to retry.",
         )
+        // The #1321 exact state: a past-grace transport drop → RevealState.Error
+        // (retry exhausted) fused with the Failed phase → SessionSurfaceState.Failed.
+        val hardFailureState = surfaceOf(
+            RevealState.Error(sid, "claude-main", retrying = false, reason = FailureReason.Unreachable(true)),
+            failed,
+        )
         compose.setContent {
             PocketShellTheme {
                 Column(
@@ -465,7 +495,7 @@ class TmuxConnectingStatesScreenshotTest {
                         onMore = {},
                     )
                     FailedConnectionRow(
-                        message = failed.message,
+                        message = failureReasonSentence((hardFailureState as SessionSurfaceState.Failed).reason),
                         onReconnect = {},
                         canReconnect = true,
                     )
@@ -478,24 +508,14 @@ class TmuxConnectingStatesScreenshotTest {
                             pullToReconnectActive = true,
                             isReconnecting = false,
                             onReconnect = {},
-                            showReconnectButton = surfaceReconnectButtonVisible(failed),
+                            showReconnectButton = surfaceReconnectButtonVisible(hardFailureState),
                             // The surface centered loader flag driven by the REAL
                             // decision: a settled hard failure is NOT a loader.
-                            surfaceShowsCenteredLoader = surfaceShowsCenteredLoader(
-                                effectiveHidesTerminal = true,
-                                revealHardFailure = true,
-                                status = failed,
-                                panesEmpty = true,
-                            ),
+                            surfaceShowsCenteredLoader = hardFailureState.showsCenteredLoader(panesEmpty = true),
                         ) {
                             // The REAL surface branch decision: a hard reveal failure
                             // paints the calm placeholder, NEVER "Attaching…".
-                            if (surfaceShowsCalmFailure(
-                                    effectiveHidesTerminal = true,
-                                    revealHardFailure = true,
-                                    status = failed,
-                                )
-                            ) {
+                            if (hardFailureState.showsCalmFailure) {
                                 RevealFailurePlaceholder()
                             } else {
                                 SwitchingLoadingPlaceholder()
@@ -545,18 +565,11 @@ class TmuxConnectingStatesScreenshotTest {
             retryDelayMs = 4_000L,
             reason = "Reconnecting…",
         )
-        val ownsPrimary = surfaceOwnsPrimaryIndicator(
-            effectiveHidesTerminal = false,
-            revealHardFailure = false,
-            status = reconnecting,
-            panesEmpty = true,
-        )
-        val centeredLoader = surfaceShowsCenteredLoader(
-            effectiveHidesTerminal = false,
-            revealHardFailure = false,
-            status = reconnecting,
-            panesEmpty = true,
-        )
+        // Reveal LIVE (terminal not held) but no panes yet → the "waiting for tmux
+        // panes…" ring is the SOLE loader; the top banner + box spinner are suppressed.
+        val waitingState = surfaceOf(RevealState.Live(sid, "claude-main", panes = emptyList()), reconnecting)
+        val ownsPrimary = waitingState.surfaceOwnsPrimary(panesEmpty = true)
+        val centeredLoader = waitingState.showsCenteredLoader(panesEmpty = true)
         compose.setContent {
             PocketShellTheme {
                 Column(
@@ -574,8 +587,8 @@ class TmuxConnectingStatesScreenshotTest {
                     // The REAL top-banner render site, driven by the broadened gate —
                     // suppressed because the surface owns the waiting ring.
                     TmuxTopConnectingBanner(
-                        status = reconnecting,
-                        effectiveHidesTerminal = ownsPrimary,
+                        surfaceState = waitingState,
+                        surfaceOwnsPrimary = ownsPrimary,
                         sessionName = "claude-main",
                         onCancelConnect = {},
                         onRetryNow = {},
@@ -592,7 +605,7 @@ class TmuxConnectingStatesScreenshotTest {
                             // The box spinner is suppressed because the surface shows
                             // the waiting ring (the broadened #1322 flag).
                             surfaceShowsCenteredLoader = centeredLoader,
-                            showReconnectButton = surfaceReconnectButtonVisible(reconnecting),
+                            showReconnectButton = surfaceReconnectButtonVisible(waitingState),
                         ) {
                             // The "waiting for tmux panes…" ring (EmptyPanesPlaceholder
                             // body) — the SOLE loader for this state.

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
@@ -140,7 +140,15 @@ import com.pocketshell.app.session.ConversationLinkAction
 import com.pocketshell.app.session.ConversationSyncStatusRow
 import com.pocketshell.app.session.InlineDictationViewModel
 import com.pocketshell.app.settings.SettingsViewModel
+import com.pocketshell.core.connection.ConnectionPhase
+import com.pocketshell.core.connection.FailureReason
 import com.pocketshell.core.connection.RevealState
+import com.pocketshell.core.connection.SessionSurfaceState
+import com.pocketshell.core.connection.sessionSurfaceState
+import com.pocketshell.core.connection.showsCalmFailure
+import com.pocketshell.core.connection.showsCenteredLoader
+import com.pocketshell.core.connection.surfaceOwnsPrimary
+import com.pocketshell.core.connection.terminalHeld
 import com.pocketshell.core.connection.targetIdOrNull
 import com.pocketshell.app.session.SessionTab
 import com.pocketshell.app.session.conversationLinkAction
@@ -431,46 +439,34 @@ public fun TmuxSessionScreen(
             sessionName = sessionName,
         )
     }
-    // Hold the terminal (loading placeholder) until the reveal machine confirms
-    // RevealState.Live FOR THIS target — never paint the previous session's frame.
-    val revealHoldsTerminal =
-        !(revealState is RevealState.Live && revealState.targetIdOrNull() == targetSessionId)
-    val effectiveHidesTerminal = revealHoldsTerminal
-    // Issue #1322: a HARD reveal failure (target Gone, or an Error whose retry is
-    // exhausted) must render DISTINCTLY from the "Attaching…" hold. The surface
-    // paints the calm failed placeholder (not the spinner), and both top loading
-    // banners are suppressed, so the pill + surface + "Tap to reconnect" band all
-    // agree — killing the #1321 "Disconnected pill + Attaching spinner + raw
-    // exception" contradiction.
-    val revealHardFailure = revealIsHardFailure(revealState)
-    // Issue #1322 (coordinator scope-expansion, screenshots A/B): make EVERY
-    // non-live state render exactly ONE coherent primary indicator, computed once
-    // here and threaded to the surface, the top banner, and the pull box so they
-    // can never stack.
-    //
-    // The surface's own centered region is the primary indicator in two shapes:
-    //  - a CALM FAILURE placeholder ([RevealFailurePlaceholder]) — a hard reveal
-    //    failure OR a settled [ConnectionStatus.Failed] while the terminal is held.
-    //    It carries NO spinner (screenshot A: no "Attaching…" over Disconnected),
-    //    and the "Tap to reconnect" band owns the single reconnect affordance.
-    //  - a centered LOADER spinner — the "Attaching…" hold
-    //    ([SwitchingLoadingPlaceholder], while the terminal is held) OR the
-    //    "waiting for tmux panes…" ring ([EmptyPanesPlaceholder], when the reveal
-    //    is live but no panes have arrived yet). EITHER is the SOLE loader, so the
-    //    top connecting/reconnecting banner and the pull box spinner must both be
-    //    suppressed (screenshot B: the #750 Reconnecting 2-3-spinner stack).
+    // Issue #1326 (S3): the SINGLE fused view state. The header pill, the surface
+    // and the under-header band all derive from THIS one state via `when(state)`,
+    // so a contradictory (pill, surface, band) triple ("Disconnected" pill +
+    // "Attaching…" spinner + raw exception — #641/#750/#1185/#1321) is no longer
+    // type-representable. The id-keyed [RevealStateMachine] is the SURFACE authority
+    // (hold / hard-failure / within-grace live-frame hold); [connectionPhaseOf]
+    // projects the connection status into the PILL / progress payload. This is the
+    // only place [revealState] and [status] are read for these three regions — every
+    // region below reads [surfaceState].
+    val surfaceState = remember(revealState, status, targetSessionId) {
+        sessionSurfaceState(revealState, connectionPhaseOf(status), targetSessionId)
+    }
+    // Derived surface signals — all pure reads of the ONE state (they SUPERSEDE the
+    // deleted independent revealHoldsTerminal / effectiveHidesTerminal /
+    // revealHardFailure signals, #1326 AC-6).
+    val terminalHeld = surfaceState.terminalHeld
     val panesEmpty = unifiedPanes.isEmpty()
-    val surfaceCalmFailure =
-        surfaceShowsCalmFailure(effectiveHidesTerminal, revealHardFailure, status)
-    val surfaceCenteredLoader =
-        surfaceShowsCenteredLoader(effectiveHidesTerminal, revealHardFailure, status, panesEmpty)
+    // A CALM FAILURE placeholder ([RevealFailurePlaceholder]) — Gone/Failed — carries
+    // NO spinner (no "Attaching…" over Disconnected); the "Tap to reconnect" band
+    // owns the single reconnect affordance.
+    val surfaceCalmFailure = surfaceState.showsCalmFailure
+    // A centered LOADER spinner — the "Attaching…" hold OR the "waiting for tmux
+    // panes…" ring (reveal live but no panes yet). EITHER is the SOLE loader, so the
+    // top connecting/reconnecting banner + the pull box spinner are both suppressed.
+    val surfaceCenteredLoader = surfaceState.showsCenteredLoader(panesEmpty)
     // The single "the surface owns the primary indicator; the top banner + box
-    // spinner are the redundant duplicates" gate. Passed as the reducer's
-    // `effectiveHidesTerminal` input so a live-frame-kept Connecting/Reconnecting
-    // edge (surface shows NEITHER a loader nor a failure) still keeps its top
-    // banner as the sole indicator.
-    val surfaceOwnsPrimary =
-        surfaceOwnsPrimaryIndicator(effectiveHidesTerminal, revealHardFailure, status, panesEmpty)
+    // spinner are the redundant duplicates" gate (#750/#1322).
+    val surfaceOwnsPrimary = surfaceState.surfaceOwnsPrimary(panesEmpty)
     // Issue #487: active-forwarding state for the host this session belongs
     // to. `remember(hostId)` re-subscribes if the screen is reused for a
     // different host. Drives the in-session forwarding chip in the chrome.
@@ -714,7 +710,7 @@ public fun TmuxSessionScreen(
     // + detection actually work. See [tmuxSessionSurfacePane].
     val surfacePane = tmuxSessionSurfacePane(
         visibleUnifiedPane = currentUnifiedPane,
-        switchHidesTerminal = effectiveHidesTerminal,
+        switchHidesTerminal = terminalHeld,
     )
     // Issue #626: derive session name for the unified pane, used to detect
     // cross-session swipes.
@@ -778,18 +774,18 @@ public fun TmuxSessionScreen(
     // later slice).
     val projectLabel = remember(
         projectPath,
-        effectiveHidesTerminal,
+        terminalHeld,
         sessionName,
         currentUnifiedPaneSessionName,
     ) {
         // EPIC #687 P1: under NEW the crumb keys off the reveal-driven
-        // [effectiveHidesTerminal] (held until the target's pane is revealed); under
+        // [terminalHeld] (held until the target's pane is revealed); under
         // OLD it keys off the inline `switchHidesTerminal`. Either way the crumb is
         // suppressed while the target's own pane is not yet visible, so the header
         // shows the SINGLE target identity throughout a switch.
         keyedProjectCrumbLabel(
             projectPath = projectPath,
-            switchHidesTerminal = effectiveHidesTerminal,
+            switchHidesTerminal = terminalHeld,
             targetSessionName = sessionName,
             visiblePaneSessionName = currentUnifiedPaneSessionName,
         )
@@ -1459,7 +1455,7 @@ public fun TmuxSessionScreen(
                     navTargetSession = sessionName,
                     settledPaneIsActiveSession = settledPaneIsActive,
                     pagerAlignedToNavTarget = aligned,
-                    switchHidesTerminal = effectiveHidesTerminal,
+                    switchHidesTerminal = terminalHeld,
                 )
             if (switchTo != null || shouldPromoteStalledCachedPane) {
                 viewModel.onUnifiedPageSettled(page)
@@ -1582,7 +1578,7 @@ public fun TmuxSessionScreen(
             },
             // Issue #993: only actionable when there IS a target to reconnect to AND a
             // connect/reconnect is not already in flight — see [reconnectKebabEnabled].
-            reconnectEnabled = reconnectKebabEnabled(canReconnect, status),
+            reconnectEnabled = reconnectKebabEnabled(canReconnect, surfaceState),
         )
     }
 
@@ -1731,7 +1727,7 @@ public fun TmuxSessionScreen(
                                 // switch is hiding the terminal so the header
                                 // shows the target session name (a neutral label),
                                 // never the old agent's display name.
-                                agentName = if (effectiveHidesTerminal) {
+                                agentName = if (terminalHeld) {
                                     null
                                 } else {
                                     currentDetection?.agent?.displayName
@@ -1766,7 +1762,7 @@ public fun TmuxSessionScreen(
                                         onReplace = onReplaceTmuxSession,
                                     )
                                 },
-                                connectionStatus = status.toUiStatus(),
+                                connectionStatus = surfaceState.toUiStatus(),
                                 modifier = Modifier.testTag(TMUX_FULL_BREADCRUMB_TAG),
                             )
                             // Issue #782: PocketShell no longer manages tmux
@@ -1795,7 +1791,7 @@ public fun TmuxSessionScreen(
                             onBack = onBack,
                             onMore = { moreExpanded = true },
                             moreMenu = { AnchoredTmuxMoreMenu() },
-                            connectionStatus = status.toUiStatus(),
+                            connectionStatus = surfaceState.toUiStatus(),
                             modifier = Modifier.testTag(TMUX_COMPACT_BREADCRUMB_TAG),
                         )
                     }
@@ -1809,32 +1805,25 @@ public fun TmuxSessionScreen(
             // below (the maintainer's recurring "two loaders at once" symptom). See
             // [TmuxTopConnectingBanner] for the per-banner rationale.
             TmuxTopConnectingBanner(
-                status = status,
-                // Issue #1322: suppress the top banner whenever the surface owns the
-                // primary indicator — the "Attaching…" hold, the "waiting for tmux
-                // panes…" ring, OR the calm failure placeholder. The banner renders
-                // ONLY in the live-frame-kept Connecting/Reconnecting edge where the
-                // surface shows none of those, so a state is never left with zero
-                // indicators. This is the broadened #750 gate that kills the
-                // Reconnecting 2-3-spinner stack (screenshot B).
-                effectiveHidesTerminal = surfaceOwnsPrimary,
+                surfaceState = surfaceState,
+                // Issue #1322/#1326: suppress the top banner whenever the surface
+                // owns the primary indicator — the "Attaching…" hold, the "waiting
+                // for tmux panes…" ring, OR the calm failure placeholder — so a state
+                // is never left with two loaders. Derived from the ONE state.
+                surfaceOwnsPrimary = surfaceOwnsPrimary,
                 sessionName = sessionName,
                 onCancelConnect = { viewModel.cancelConnect() },
                 onRetryNow = { viewModel.reconnect() },
             )
-            // Issue #145: render a user-facing error band (status text +
-            // Reconnect affordance) when the SSH transport drops
-            // mid-session. The view model's `client.disconnected`
-            // observer (added in #173, rephrased in #145) flips status
-            // to Failed when the underlying [TmuxClient.readerLoop]
-            // exits; this band surfaces the failure and gives the user
-            // a single-tap retry that re-runs the same connect() path.
-            // The test tags [TMUX_SESSION_ERROR_TAG] and
-            // [TMUX_SESSION_RECONNECT_TAG] make the elements grep-able
-            // from connected disconnect+reconnect tests.
-            (status as? ConnectionStatus.Failed)?.let { failed ->
+            // Issue #145/#1326: render a user-facing error band when the session has
+            // SETTLED into an honest failure ([SessionSurfaceState.Failed]). The band
+            // reads the TYPED [FailureReason] and maps it to ONE calm curated
+            // sentence — never a raw exception string. The test tags
+            // [TMUX_SESSION_ERROR_TAG] and [TMUX_SESSION_RECONNECT_TAG] make the
+            // elements grep-able from connected disconnect+reconnect tests.
+            (surfaceState as? SessionSurfaceState.Failed)?.let { failed ->
                 FailedConnectionRow(
-                    message = failed.message,
+                    message = failureReasonSentence(failed.reason),
                     onReconnect = { viewModel.reconnect() },
                     canReconnect = canReconnect,
                 )
@@ -2027,11 +2016,11 @@ public fun TmuxSessionScreen(
                 // pager's inputs are still all stable, so an overlay-visibility
                 // toggle still skips it).
                 //
-                // `effectiveHidesTerminal` still takes precedence and paints ONLY
+                // `terminalHeld` still takes precedence and paints ONLY
                 // the switch placeholder: during a cross-session switch not a single
                 // frame of the leaving session's terminal (or conversation) may leak
                 // (#661 / EPIC #687 P1).
-                val keepTerminalMounted = !effectiveHidesTerminal &&
+                val keepTerminalMounted = !terminalHeld &&
                     !deferTerminalAttachForSwap &&
                     unifiedPanes.isNotEmpty()
                 if (keepTerminalMounted) {
@@ -2087,7 +2076,7 @@ public fun TmuxSessionScreen(
                     // instead — NO spinner — so the surface AGREES with the pill and
                     // the single [FailedConnectionRow] band above.
                     RevealFailurePlaceholder()
-                } else if (effectiveHidesTerminal) {
+                } else if (terminalHeld) {
                     // Issue #661 / EPIC #687 P1: a cross-session switch is in flight —
                     // never paint the leaving session's terminal (or its agent
                     // conversation). Show a compact "Attaching" loading state until
@@ -2340,7 +2329,7 @@ public fun TmuxSessionScreen(
                     // bottom button as the SOLE affordance ONLY on the remaining
                     // `Idle` (dropped/never-attached, with a `canReconnect` target)
                     // state, which has no band.
-                    showReconnectButton = surfaceReconnectButtonVisible(status),
+                    showReconnectButton = surfaceReconnectButtonVisible(surfaceState),
                     content = surfaceContent,
                 )
             }
@@ -4236,12 +4225,12 @@ internal class OutboundQueueAutoFlushController {
  */
 internal fun reconnectKebabEnabled(
     canReconnect: Boolean,
-    status: ConnectionStatus,
+    surfaceState: SessionSurfaceState,
 ): Boolean =
     canReconnect &&
-        status !is ConnectionStatus.Connecting &&
-        status !is ConnectionStatus.Switching &&
-        status !is ConnectionStatus.Reconnecting
+        surfaceState !is SessionSurfaceState.Connecting &&
+        surfaceState !is SessionSurfaceState.Attaching &&
+        surfaceState !is SessionSurfaceState.Reconnecting
 
 /**
  * Issue #750 (4th occurrence — the beyond-grace RECONNECT path): the single
@@ -4254,7 +4243,7 @@ internal fun reconnectKebabEnabled(
  *
  *  - [CenteredAttaching] — the centered "Attaching…" [SwitchingLoadingPlaceholder]
  *    hold, painted by the surface whenever the id-keyed [RevealStateMachine] holds
- *    the terminal ([effectiveHidesTerminal] == true). This is the CANONICAL loader
+ *    the terminal (the reveal hold == true). This is the CANONICAL loader
  *    per #750's original decision and WINS over any top banner: every in-progress
  *    connect/switch/reattach/reconnect holds the terminal in [RevealState.Seeding],
  *    so the centered hold is the sole loader for all of them.
@@ -4268,7 +4257,7 @@ internal fun reconnectKebabEnabled(
  * The 4th recurrence (2026-07-03): a beyond-grace reconnect re-dials through the
  * controller's `Connecting` state, which projects to [ConnectionStatus.Connecting]
  * (the top [ConnectingProgressOverlay] banner). The previous #750 fix gated only
- * the [ReconnectingProgressRow] band on `!effectiveHidesTerminal` — it never gated
+ * the [ReconnectingProgressRow] band on `!terminalHeld` — it never gated
  * the [ConnectingProgressOverlay], so on the reconnect re-dial BOTH the top
  * "Connecting to host…" banner AND the centered "Attaching…" hold rendered at
  * once. Routing BOTH banners through this reducer closes that gap: when the
@@ -4294,111 +4283,25 @@ internal enum class PrimaryLoadingSurface {
  * shown, so the screen can never paint two at once. See [PrimaryLoadingSurface].
  */
 internal fun primaryLoadingSurface(
-    status: ConnectionStatus,
-    effectiveHidesTerminal: Boolean,
-    revealHardFailure: Boolean = false,
+    surfaceState: SessionSurfaceState,
+    panesEmpty: Boolean = false,
 ): PrimaryLoadingSurface = when {
-    // Issue #1322: a HARD reveal failure (target Gone, or an Error whose retry is
-    // exhausted) is NOT a loading state. It must render DISTINCTLY from the
-    // "Attaching…" hold — never a spinner over a dead session, and never a top
-    // connecting/reconnecting banner. The surface paints the calm failed
-    // placeholder and the pill + "Tap to reconnect" [FailedConnectionRow] band own
-    // this state, so all three agree (killing the #1321 "Disconnected pill +
-    // Attaching spinner + raw exception" contradiction). This wins over the
-    // terminal-held branch below because [effectiveHidesTerminal] is ALSO true for
-    // a hard failure (the reveal is not Live) — which is exactly what used to
-    // collapse the honest error into "Attaching…".
-    revealHardFailure -> PrimaryLoadingSurface.None
-    // The terminal is held → the surface paints the centered "Attaching…" hold,
-    // which is the canonical SOLE loader. Both top banners are suppressed so the
-    // maintainer never sees the top connecting banner AND the centered spinner at
-    // once (the 4th-recurrence beyond-grace reconnect symptom).
-    effectiveHidesTerminal -> PrimaryLoadingSurface.CenteredAttaching
-    status is ConnectionStatus.Connecting -> PrimaryLoadingSurface.ConnectingBanner
-    status is ConnectionStatus.Reconnecting -> PrimaryLoadingSurface.ReconnectingBand
+    // Issue #1326: a settled failure ([Gone]/[Failed]) is NOT a loading state —
+    // the calm failed placeholder + "Disconnected" pill + "Tap to reconnect" band
+    // own it, so NO spinner and NO top banner (killing the #1321 contradiction).
+    surfaceState.showsCalmFailure -> PrimaryLoadingSurface.None
+    // Any HELD state → the surface paints the centered "Attaching…" hold, the
+    // canonical SOLE loader; the top banners are suppressed so the maintainer never
+    // sees a top banner AND the centered spinner at once (the #750 stack). The
+    // reveal machine is the surface authority, so every in-progress connect / switch
+    // / reconnect holds the terminal — the top ConnectingBanner/ReconnectingBand are
+    // the (now unreachable) live-frame fallback, never returned here.
+    surfaceState.terminalHeld -> PrimaryLoadingSurface.CenteredAttaching
+    // Live but the active pane has no content yet — the "waiting for tmux panes…"
+    // ring is the sole loader.
+    panesEmpty -> PrimaryLoadingSurface.CenteredAttaching
     else -> PrimaryLoadingSurface.None
 }
-
-/**
- * Issue #1322: whether the id-keyed [RevealState] is a HARD reveal failure that
- * must render DISTINCTLY from the "Attaching…"/Seeding hold.
- *
- * The #1321 screenshot showed the honest failure state ([RevealState.Error] after
- * a past-grace transport drop) painted as the centered "Attaching…" spinner,
- * because [effectiveHidesTerminal] special-cased ONLY [RevealState.Live] — every
- * other reveal, including a dead-session error, collapsed to the same loading
- * hold. That desynced the surface from the "Disconnected" pill and the "Tap to
- * reconnect" band.
- *
- *  - [RevealState.Gone] — the target session was deleted elsewhere (#666). There
- *    is nothing to attach to; a spinner would lie.
- *  - [RevealState.Error] with `retrying == false` — the control channel dropped
- *    and retry is EXHAUSTED (the honest error per the [RevealState.Error] doc).
- *    This is the maintainer's exact reported state.
- *
- * [RevealState.Error] while `retrying == true` is the calm healing/"reconnecting"
- * window — NOT a hard failure — so it keeps its reconnecting hold and is excluded
- * here. Pure so it is a unit-testable predicate (G9).
- */
-internal fun revealIsHardFailure(revealState: RevealState): Boolean = when (revealState) {
-    is RevealState.Gone -> true
-    is RevealState.Error -> !revealState.retrying
-    else -> false
-}
-
-/**
- * Issue #1322 (screenshots A/B): whether the session surface paints the CALM
- * FAILURE placeholder ([RevealFailurePlaceholder]) in place of the terminal.
- *
- * True when the terminal is held ([effectiveHidesTerminal]) AND the connection has
- * SETTLED into a failure — a hard reveal failure ([revealHardFailure]) OR a
- * [ConnectionStatus.Failed] status. The placeholder carries NO spinner, so the
- * "Attaching…" hold is never painted over a dead session (killing the #1321
- * "Disconnected pill + Attaching spinner" contradiction and screenshot A's
- * spinner-over-Disconnected). Pure so it is unit-testable (G9).
- */
-internal fun surfaceShowsCalmFailure(
-    effectiveHidesTerminal: Boolean,
-    revealHardFailure: Boolean,
-    status: ConnectionStatus,
-): Boolean =
-    effectiveHidesTerminal && (revealHardFailure || status is ConnectionStatus.Failed)
-
-/**
- * Issue #750 / #1322 (screenshot B): whether the session surface paints a centered
- * LOADER spinner — the "Attaching…" [SwitchingLoadingPlaceholder] hold (terminal
- * held) OR the "waiting for tmux panes…" [EmptyPanesPlaceholder] ring (reveal live
- * but no panes yet, [panesEmpty]).
- *
- * A settled failure ([surfaceShowsCalmFailure]) is NOT a loader (no spinner). This
- * is the SOLE loader for its state, so the top connecting/reconnecting banner and
- * the pull box spinner must both be suppressed — the fix for the Reconnecting
- * 2-3-spinner stack (top bar + waiting ring + gray chip). Pure (G9).
- */
-internal fun surfaceShowsCenteredLoader(
-    effectiveHidesTerminal: Boolean,
-    revealHardFailure: Boolean,
-    status: ConnectionStatus,
-    panesEmpty: Boolean,
-): Boolean =
-    !surfaceShowsCalmFailure(effectiveHidesTerminal, revealHardFailure, status) &&
-        (effectiveHidesTerminal || panesEmpty)
-
-/**
- * Issue #1322: the single "the surface owns the primary indicator, so the top
- * banner + pull box spinner are the redundant duplicates" gate. True whenever the
- * surface paints either a centered loader OR the calm failure placeholder; false
- * only in the live-frame-kept Connecting/Reconnecting edge (surface shows a live
- * terminal), where the top banner is the SOLE indicator. Pure (G9).
- */
-internal fun surfaceOwnsPrimaryIndicator(
-    effectiveHidesTerminal: Boolean,
-    revealHardFailure: Boolean,
-    status: ConnectionStatus,
-    panesEmpty: Boolean,
-): Boolean =
-    surfaceShowsCalmFailure(effectiveHidesTerminal, revealHardFailure, status) ||
-        surfaceShowsCenteredLoader(effectiveHidesTerminal, revealHardFailure, status, panesEmpty)
 
 /**
  * Issue #890 / #1322 (screenshot A): whether the VISIBLE bottom "Reconnect" button
@@ -4415,57 +4318,40 @@ internal fun surfaceOwnsPrimaryIndicator(
  * It therefore renders as the SOLE affordance only on the remaining `Idle`
  * (dropped/never-attached) state, which has no band. Pure (G9).
  */
-internal fun surfaceReconnectButtonVisible(status: ConnectionStatus): Boolean =
-    status !is ConnectionStatus.Connecting &&
-        status !is ConnectionStatus.Switching &&
-        status !is ConnectionStatus.Reconnecting &&
-        status !is ConnectionStatus.Failed
+internal fun surfaceReconnectButtonVisible(surfaceState: SessionSurfaceState): Boolean =
+    surfaceState !is SessionSurfaceState.Connecting &&
+        surfaceState !is SessionSurfaceState.Attaching &&
+        surfaceState !is SessionSurfaceState.Reconnecting &&
+        surfaceState !is SessionSurfaceState.Failed &&
+        surfaceState !is SessionSurfaceState.Gone
 
 /**
- * Issue #750: the single-indicator gate for the top under-header
- * [ConnectingProgressOverlay] "Connecting to host…" banner. Derived from
- * [primaryLoadingSurface] so it can never coexist with the centered "Attaching…"
- * hold — the exact 4th-recurrence beyond-grace-reconnect stacking (a reconnect
- * re-dials through `Connecting`, projecting this banner, WHILE the reveal machine
- * holds the terminal and paints the centered spinner). The banner renders ONLY in
- * the live-frame-kept Connecting edge (terminal NOT held), so it is never the sole
- * indicator stripped from a state that needs it.
+ * Issue #750/#1326: the single-indicator gate for the top under-header
+ * [ConnectingProgressOverlay] "Connecting to host…" banner. Derived from the ONE
+ * [SessionSurfaceState] so it can never coexist with the centered "Attaching…"
+ * hold. The reveal machine is the surface authority, so every in-progress connect
+ * holds the terminal and the CENTERED hold is the sole loader — this top banner is
+ * the (now unreachable) live-frame fallback and is never shown, but the gate is
+ * kept so a future live-frame connect edge cannot be left with zero indicators.
  */
 internal fun shouldShowConnectingProgressOverlay(
-    status: ConnectionStatus,
-    effectiveHidesTerminal: Boolean,
-    revealHardFailure: Boolean = false,
+    surfaceState: SessionSurfaceState,
+    surfaceOwnsPrimary: Boolean,
 ): Boolean =
-    primaryLoadingSurface(status, effectiveHidesTerminal, revealHardFailure) ==
-        PrimaryLoadingSurface.ConnectingBanner
+    !surfaceOwnsPrimary && surfaceState is SessionSurfaceState.Connecting
 
 /**
- * Issue #750: the single-indicator gate for the top under-header
- * [ReconnectingProgressRow] progress line.
- *
- * The reconnect/reattach screen must show EXACTLY ONE loading indicator — the
- * centered "Attaching…" [SwitchingLoadingPlaceholder]. After the #766
- * connection migration the controller projects [ConnectionStatus.Reconnecting]
- * (this top bar) at the SAME time the id-keyed [RevealStateMachine] holds the
- * terminal in [RevealState.Seeding] ([effectiveHidesTerminal] == true) and
- * paints the centered spinner — the two-loaders regression.
- *
- * Derived from [primaryLoadingSurface] (single source of truth): the top bar
- * renders ONLY for a [ConnectionStatus.Reconnecting] status AND only when the
- * terminal is NOT held (so the centered spinner is not up). Every real
- * reconnect/reattach holds the terminal, so in practice the centered spinner is
- * the sole reattach affordance — but the reducer keeps the top bar as a
- * (currently unreached) fallback for any future reconnect that does keep a live
- * frame painted, so suppressing it can never leave a reconnect with zero
- * indicators.
+ * Issue #750/#1326: the single-indicator gate for the top under-header
+ * [ReconnectingProgressRow] progress line. Same rule as
+ * [shouldShowConnectingProgressOverlay] — derived from the ONE state; the centered
+ * "Attaching…" hold is the sole reattach affordance for every real reconnect (the
+ * terminal is held), so this top bar is the unreachable live-frame fallback.
  */
 internal fun shouldShowReconnectingProgressRow(
-    status: ConnectionStatus,
-    effectiveHidesTerminal: Boolean,
-    revealHardFailure: Boolean = false,
+    surfaceState: SessionSurfaceState,
+    surfaceOwnsPrimary: Boolean,
 ): Boolean =
-    primaryLoadingSurface(status, effectiveHidesTerminal, revealHardFailure) ==
-        PrimaryLoadingSurface.ReconnectingBand
+    !surfaceOwnsPrimary && surfaceState is SessionSurfaceState.Reconnecting
 
 /**
  * Issue #463: the short leaf label for the header project crumb, derived
@@ -4847,7 +4733,7 @@ internal const val TMUX_SURFACE_RECONNECT_BUTTON_TAG = "tmux:session:surface-rec
  *
  * Issue #750 (3rd occurrence): the surface content ITSELF renders a centered
  * loading indicator during the attach/reattach hold (the "Attaching…"
- * [SwitchingLoadingPlaceholder], driven by `effectiveHidesTerminal`). When that
+ * [SwitchingLoadingPlaceholder], driven by the reveal hold). When that
  * overlay is up, the [PullToRefreshBox]'s own circular indicator would stack a
  * SECOND spinner on top of it (the maintainer's reported cyan ring + gray
  * spinner-in-a-chip). [surfaceShowsCenteredLoader] tells the wrapper the surface
@@ -5114,7 +5000,7 @@ private fun StatusLine(text: String) {
  * Both the cold-dial [ConnectingProgressOverlay] ("Connecting to host…") and the
  * recovery [ReconnectingProgressRow] band are gated through [primaryLoadingSurface]
  * (via [shouldShowConnectingProgressOverlay] / [shouldShowReconnectingProgressRow]),
- * so NEITHER can render while the terminal is held ([effectiveHidesTerminal] ==
+ * so NEITHER can render while the terminal is held (the reveal hold ==
  * true) — that is exactly when the surface Box paints the centered "Attaching…"
  * hold. This makes the maintainer's recurring "top connecting banner AND centered
  * spinner at once" symptom structurally impossible: while the terminal is held the
@@ -5132,24 +5018,23 @@ private fun StatusLine(text: String) {
  */
 @Composable
 internal fun TmuxTopConnectingBanner(
-    status: ConnectionStatus,
-    // Issue #1322: the caller passes the broadened "surface owns the primary
+    surfaceState: SessionSurfaceState,
+    // Issue #1322/#1326: the caller passes the broadened "surface owns the primary
     // indicator" gate here — true for the "Attaching…" hold, the "waiting for tmux
     // panes…" ring, AND the calm failure placeholder — so the top banner is
     // suppressed in ALL of them (never stacked over a surface loader/failure).
-    effectiveHidesTerminal: Boolean,
+    surfaceOwnsPrimary: Boolean,
     sessionName: String,
     onCancelConnect: () -> Unit,
     onRetryNow: () -> Unit,
 ) {
-    // Issue #165: the cold-dial progress overlay (linear bar + host string + slow
-    // hint + Cancel). Gated on [shouldShowConnectingProgressOverlay] so it never
-    // stacks on top of the centered "Attaching…" hold on a reconnect re-dial (the
-    // 4th-recurrence beyond-grace symptom: a reconnect re-dials through the
-    // controller's `Connecting`, projecting this banner, while the terminal is
-    // held). It renders ONLY in the live-frame-kept Connecting edge.
-    if (shouldShowConnectingProgressOverlay(status, effectiveHidesTerminal)) {
-        (status as ConnectionStatus.Connecting).let {
+    // Issue #165/#1326: the cold-dial progress overlay (linear bar + host string +
+    // slow hint + Cancel). Gated on [shouldShowConnectingProgressOverlay] (a pure
+    // read of the ONE state) so it never stacks on top of the centered "Attaching…"
+    // hold. The reveal machine holds the terminal for every real connect, so this
+    // renders ONLY in the (now unreachable) live-frame-kept Connecting edge.
+    if (shouldShowConnectingProgressOverlay(surfaceState, surfaceOwnsPrimary)) {
+        (surfaceState as SessionSurfaceState.Connecting).let {
             ConnectingProgressOverlay(
                 user = it.user,
                 host = it.host,
@@ -5159,18 +5044,21 @@ internal fun TmuxTopConnectingBanner(
             )
         }
     }
-    // Issue #750: the recovery band. A same-host session switch ([Switching]) and
-    // every reconnect/reattach hold the terminal and paint the centered
-    // "Attaching…" [SwitchingLoadingPlaceholder] (the SOLE attach affordance), so
-    // the band is suppressed while held ([shouldShowReconnectingProgressRow]). It
-    // renders ONLY for a [ConnectionStatus.Reconnecting] status that keeps a live
-    // frame painted (terminal NOT held) — the fallback so a reconnect is never left
-    // with zero indicators. (Reconnect speed/behaviour is untouched — this is
-    // presentation-only.)
-    if (shouldShowReconnectingProgressRow(status, effectiveHidesTerminal)) {
-        (status as ConnectionStatus.Reconnecting).let {
+    // Issue #750/#1326: the recovery band. Every reconnect/reattach holds the
+    // terminal and paints the centered "Attaching…" [SwitchingLoadingPlaceholder]
+    // (the SOLE attach affordance), so the band is suppressed while held. It renders
+    // ONLY for a [SessionSurfaceState.Reconnecting] that keeps a live frame painted
+    // (surface owns nothing) — the fallback so a reconnect is never left with zero
+    // indicators. (Reconnect behaviour is untouched — this is presentation-only.)
+    if (shouldShowReconnectingProgressRow(surfaceState, surfaceOwnsPrimary)) {
+        (surfaceState as SessionSurfaceState.Reconnecting).let {
             ReconnectingProgressRow(
-                status = it,
+                user = it.user,
+                host = it.host,
+                port = it.port,
+                attempt = it.attempt,
+                maxAttempts = it.maxAttempts,
+                retryDelayMs = it.retryDelayMs,
                 sessionLabel = "tmux $sessionName",
                 onRetryNow = onRetryNow,
                 onCancel = onCancelConnect,
@@ -5299,10 +5187,10 @@ internal fun ConnectingProgressOverlay(
  *
  * The reconnect SURFACE already owns the canonical animated indicator for every
  * non-Connected reconnect state:
- *  - while the terminal is HELD (`effectiveHidesTerminal == true`) the centered
+ *  - while the terminal is HELD (the terminal is held) the centered
  *    "Attaching…" [SwitchingLoadingPlaceholder] spinner is shown, and this band
  *    is suppressed entirely by [shouldShowReconnectingProgressRow];
- *  - in the STEADY reconnect state (`effectiveHidesTerminal == false`) the
+ *  - in the STEADY reconnect state (the terminal is shown) the
  *    [SessionSurfaceReconnectWrapper]'s [PullToRefreshBox] circular spinner is
  *    shown (`isRefreshing = isReconnecting`).
  *
@@ -5314,7 +5202,12 @@ internal fun ConnectingProgressOverlay(
  */
 @Composable
 internal fun ReconnectingProgressRow(
-    status: ConnectionStatus.Reconnecting,
+    user: String,
+    host: String,
+    port: Int,
+    attempt: Int,
+    maxAttempts: Int,
+    retryDelayMs: Long,
     sessionLabel: String,
     onRetryNow: () -> Unit,
     onCancel: () -> Unit,
@@ -5331,8 +5224,8 @@ internal fun ReconnectingProgressRow(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
-                text = "Reconnecting to ${status.user}@${status.host}:${status.port} " +
-                    "($sessionLabel, ${status.attempt}/${status.maxAttempts})…",
+                text = "Reconnecting to $user@$host:$port " +
+                    "($sessionLabel, $attempt/$maxAttempts)…",
                 color = PocketShellColors.Text,
                 style = PocketShellType.bodyDense,
                 modifier = Modifier.weight(1f),
@@ -5350,10 +5243,10 @@ internal fun ReconnectingProgressRow(
                 Text("Cancel")
             }
         }
-        if (status.retryDelayMs > 0) {
+        if (retryDelayMs > 0) {
             Spacer(modifier = Modifier.height(2.dp))
             Text(
-                text = "Retrying in ${status.retryDelayMs / 1_000}s",
+                text = "Retrying in ${retryDelayMs / 1_000}s",
                 color = PocketShellColors.TextSecondary,
                 style = PocketShellType.labelMono,
                 modifier = Modifier.testTag(TMUX_CONNECTING_SLOW_HINT_TAG),
@@ -5621,22 +5514,22 @@ internal fun SwitchingLoadingPlaceholder() {
 }
 
 /**
- * Issue #1322: the full-surface CALM failed placeholder shown in place of the
- * terminal when the id-keyed reveal is a HARD failure ([revealIsHardFailure] —
- * target [RevealState.Gone], or a retry-exhausted [RevealState.Error]).
+ * Issue #1322/#1326: the full-surface CALM failed placeholder shown in place of the
+ * terminal when the fused [SessionSurfaceState] is a settled failure
+ * ([SessionSurfaceState.Gone] or [SessionSurfaceState.Failed]).
  *
  * The #1321 screenshot showed the honest failure state painted as the centered
- * "Attaching…" spinner because [effectiveHidesTerminal] special-cased ONLY
- * [RevealState.Live] (every other reveal collapsed to the same loading hold). A
- * spinner over a dead session is a lie — it will never resolve — and it desynced
- * the surface from the "Disconnected" pill and the "Tap to reconnect" band.
+ * "Attaching…" spinner because the surface hold special-cased ONLY the live reveal
+ * (every other reveal collapsed to the same loading hold). A spinner over a dead
+ * session is a lie — it will never resolve — and it desynced the surface from the
+ * "Disconnected" pill and the "Tap to reconnect" band.
  *
  * This placeholder renders DISTINCTLY from [SwitchingLoadingPlaceholder]: NO
  * spinner, a calm muted line that points at the tappable [FailedConnectionRow]
  * band above. The surface, the pill, and the error band now agree for the failure
- * state. Deliberately does not itself carry a Reconnect button — the
- * [FailedConnectionRow] band (rendered above when the status is `Failed`) owns the
- * single, calm reconnect affordance.
+ * state — all derived from the ONE [SessionSurfaceState]. Deliberately does not
+ * itself carry a Reconnect button — the [FailedConnectionRow] band owns the single,
+ * calm reconnect affordance.
  */
 @Composable
 internal fun RevealFailurePlaceholder() {
@@ -7435,25 +7328,67 @@ private fun ConnectionStatusPill(
 }
 
 /**
- * Issues #177 / #249: map the tmux view-model connection state onto the
- * design-system [com.pocketshell.uikit.model.ConnectionStatus] used by the
- * breadcrumb dot + pill. `Failed` maps to `Error` (red, "Disconnected");
- * `Connecting` maps to `Connecting` (amber pulse, "Reconnecting").
+ * Issue #1326 (S3): project the tmux view-model [ConnectionStatus] into the neutral
+ * [ConnectionPhase] the [sessionSurfaceState] fusion consumes for its pill/progress
+ * payload. This is the SINGLE point where [ConnectionStatus] is read for the three
+ * screen regions — every region reads the fused [SessionSurfaceState] instead.
  */
-internal fun ConnectionStatus.toUiStatus(): com.pocketshell.uikit.model.ConnectionStatus =
+internal fun connectionPhaseOf(status: ConnectionStatus): ConnectionPhase =
+    when (status) {
+        is ConnectionStatus.Idle -> ConnectionPhase.Idle
+        is ConnectionStatus.Connecting -> ConnectionPhase.Connecting(status.host, status.port, status.user)
+        is ConnectionStatus.Switching -> ConnectionPhase.Warm(status.host, status.port, status.user)
+        is ConnectionStatus.Connected -> ConnectionPhase.Live(status.host, status.port, status.user)
+        is ConnectionStatus.Reconnecting -> ConnectionPhase.Reconnecting(
+            host = status.host,
+            port = status.port,
+            user = status.user,
+            attempt = status.attempt,
+            maxAttempts = status.maxAttempts,
+            retryDelayMs = status.retryDelayMs,
+        )
+        is ConnectionStatus.Failed -> ConnectionPhase.Failed
+    }
+
+/**
+ * Issues #177 / #249 / #1326: map the fused [SessionSurfaceState] onto the
+ * design-system [com.pocketshell.uikit.model.ConnectionStatus] used by the
+ * breadcrumb dot + pill. Derived from the ONE state so the pill can NEVER disagree
+ * with the surface/band: [SessionSurfaceState.Failed]/[SessionSurfaceState.Gone] →
+ * `Error` (red, "Disconnected"), [SessionSurfaceState.Reconnecting]/
+ * [SessionSurfaceState.Connecting] → `Connecting` (amber, "Reconnecting"),
+ * [SessionSurfaceState.Attaching] (warm switch / live-unseeded) → `Connected`
+ * (green, no pill flash), [SessionSurfaceState.Live] → `Connected`.
+ */
+internal fun SessionSurfaceState.toUiStatus(): com.pocketshell.uikit.model.ConnectionStatus =
     when (this) {
-        is ConnectionStatus.Connected -> com.pocketshell.uikit.model.ConnectionStatus.Connected
-        // Issue #437 (slice A): a same-host session switch keeps the
-        // terminal frame on screen and only swaps the active `-CC` control
-        // client behind the scenes. Map it to `Connected` so the
-        // breadcrumb dot stays green (no alarming amber "Reconnecting"
-        // flash) — the session is up; we are just changing which session
-        // is rendered.
-        is ConnectionStatus.Switching -> com.pocketshell.uikit.model.ConnectionStatus.Connected
-        is ConnectionStatus.Connecting -> com.pocketshell.uikit.model.ConnectionStatus.Connecting
-        is ConnectionStatus.Reconnecting -> com.pocketshell.uikit.model.ConnectionStatus.Connecting
-        is ConnectionStatus.Failed -> com.pocketshell.uikit.model.ConnectionStatus.Error
-        ConnectionStatus.Idle -> com.pocketshell.uikit.model.ConnectionStatus.Idle
+        is SessionSurfaceState.Live -> com.pocketshell.uikit.model.ConnectionStatus.Connected
+        // A warm same-host switch (or a Live lifecycle whose pane has not seeded yet)
+        // keeps the dot GREEN — the session is up; we are only revealing its pane.
+        is SessionSurfaceState.Attaching -> com.pocketshell.uikit.model.ConnectionStatus.Connected
+        is SessionSurfaceState.Connecting -> com.pocketshell.uikit.model.ConnectionStatus.Connecting
+        is SessionSurfaceState.Reconnecting -> com.pocketshell.uikit.model.ConnectionStatus.Connecting
+        is SessionSurfaceState.Failed -> com.pocketshell.uikit.model.ConnectionStatus.Error
+        is SessionSurfaceState.Gone -> com.pocketshell.uikit.model.ConnectionStatus.Error
+        is SessionSurfaceState.Navigating -> com.pocketshell.uikit.model.ConnectionStatus.Idle
+        is SessionSurfaceState.Idle -> com.pocketshell.uikit.model.ConnectionStatus.Idle
+    }
+
+/**
+ * Issue #1326 (S3): map the TYPED [FailureReason] to ONE calm, curated user-facing
+ * sentence for the [FailedConnectionRow] band. The raw exception is NEVER shown
+ * (it stays in the diagnostic logs); every failure surfaces as a recoverable "Tap
+ * Reconnect" prompt, in the calm #720/#1322 tone. This is the ONLY place a failure
+ * reason becomes display text.
+ */
+internal fun failureReasonSentence(reason: FailureReason): String =
+    when (reason) {
+        FailureReason.AuthFailed -> "Authentication failed — check your key. Tap Reconnect to retry."
+        FailureReason.HostUnresolved -> "Host could not be resolved. Tap Reconnect to retry."
+        FailureReason.ServerRestarted -> "The tmux server restarted — all sessions ended. Tap Reconnect."
+        FailureReason.SessionEnded -> "This session ended. Tap Reconnect."
+        FailureReason.KeyMissing -> "Private key file not found. Tap Reconnect to retry."
+        is FailureReason.Unreachable -> "Connection lost. Tap Reconnect to retry."
     }
 
 internal fun recordTmuxReconnectUiStateRendered(

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -80,7 +80,10 @@ import com.pocketshell.app.tmux.connection.hostKeyFor
 import com.pocketshell.core.connection.ConnectionController
 import com.pocketshell.core.connection.ConnectionEvent as CoreConnectionEvent
 import com.pocketshell.core.connection.ConnectionState as CoreConnectionState
+import com.pocketshell.core.connection.FailureReason
 import com.pocketshell.core.connection.HostKey
+import com.pocketshell.core.connection.classifyFailure
+import com.pocketshell.core.connection.retryable
 import com.pocketshell.core.connection.LivenessProbe
 import com.pocketshell.core.connection.RevealState
 import com.pocketshell.core.connection.RevealStateMachine
@@ -1584,7 +1587,7 @@ public class TmuxSessionViewModel @Inject constructor(
     /**
      * EPIC #687 P1: promote the reveal to [RevealState.Live] for the CURRENT target
      * at the inline "active pane revealed" moments — the points where the inline
-     * path clears `_switchHidesTerminal` because the target's own pane is shown.
+     * path clears the reveal-machine hold because the target's own pane is shown.
      * This covers the WARM-CACHE switch (and the fast-switch/cold reveal) where no
      * fresh `capture-pane` re-fires for an already-cached pane, so [offerRevealSeed]
      * alone would never land a seed and the NEW-path reveal gate would stay held
@@ -1791,29 +1794,13 @@ public class TmuxSessionViewModel @Inject constructor(
         projectStatusFromController()
     }
 
-    /**
-     * Issue #661: while a CROSS-session switch to a NOT-yet-cached target is in
-     * flight, the screen must NEVER paint the leaving session's terminal frame —
-     * not even for one Compose frame. #634 kept the previous frame painted to
-     * avoid a "Connecting" blank, but the maintainer's refined preference is the
-     * opposite for a cross-session switch: hide the terminal surface entirely
-     * (show a compact "Attaching" loading indicator) and reveal ONLY once the
-     * NEW session's panes are seeded from `capture-pane`.
-     *
-     * This flag is set SYNCHRONOUSLY (before any coroutine runs) at the start of
-     * a cross-session fast-switch and cleared the instant the new session's
-     * panes are revealed (status flips to [ConnectionStatus.Connected]). It is
-     * NOT set on the runtime-cache-hit path: that path activates the TARGET
-     * session's own cached frame instantly, which is correct content (the target,
-     * never the leaving session), so there is nothing to hide.
-     *
-     * Keep-frame remains in force for a within-session reattach / warm reopen of
-     * the SAME session — only the cross-session case blanks.
-     */
-    private val _switchHidesTerminal: MutableStateFlow<Boolean> =
-        MutableStateFlow(false)
-    public val switchHidesTerminal: StateFlow<Boolean> =
-        _switchHidesTerminal.asStateFlow()
+    // Issue #1326 (S3): the legacy switch-hides-terminal "hide the terminal
+    // during a cross-session switch" flag is DELETED (D22 hard-cut). It was a
+    // SECOND, unsynchronised source for the surface-hold decision alongside the
+    // id-keyed [RevealStateMachine] — no production render read it (the screen
+    // holds the terminal off [revealState] alone), so it was a dead write that
+    // could only DIVERGE from the reveal machine. The single hold authority is now
+    // the reveal machine -> [SessionSurfaceState].
 
     private var attachPanesReadyTimeoutMs: Long = ATTACH_PANES_READY_TIMEOUT_MS
     private var activeAttachMilestone: AttachMilestone? = null
@@ -2955,7 +2942,7 @@ public class TmuxSessionViewModel @Inject constructor(
         // SYNCHRONOUSLY (the screen shows a compact "Attaching" loading state
         // instead) and reveal only once the new session's panes are seeded. This
         // reverses #634's keep-frame for the cross-session case (see
-        // [_switchHidesTerminal]). The runtime-cache-hit path returned earlier
+        // the reveal-machine hold). The runtime-cache-hit path returned earlier
         // above and is unaffected — it activates the target's own cached frame,
         // which is correct content, not the leaving session.
         //
@@ -2966,9 +2953,9 @@ public class TmuxSessionViewModel @Inject constructor(
         // we are removing. The cached runtime still captures the leaving panes
         // via [deactivateCurrentRuntimeToCache]'s `paneRows` fallback (the
         // per-pane row map is untouched here), so blanking [_panes] now loses no
-        // warm-cache content.
+        // warm-cache content. (The terminal is held by the reveal machine, not a
+        // separate flag — #1326.)
         if (willFastSwitch) {
-            _switchHidesTerminal.value = true
             _panes.value = emptyList()
             rebuildUnifiedPanes()
         }
@@ -3050,7 +3037,7 @@ public class TmuxSessionViewModel @Inject constructor(
                     // second" flash the maintainer reported. We now blank the
                     // rendered panes (the producer teardown inside
                     // [deactivateCurrentRuntimeToCache] already clears them)
-                    // and rely on [_switchHidesTerminal] (set synchronously
+                    // and rely on the reveal-machine hold (set synchronously
                     // above) to show a compact "Attaching" loading state until
                     // [runFastSessionSwitch]'s reconcile seeds and reveals the
                     // NEW session's panes. Input stays gated for the whole
@@ -3781,7 +3768,7 @@ public class TmuxSessionViewModel @Inject constructor(
         // lease is intact: we re-capture the active pane and let the existing
         // SeedLanded feedback promote the controller back to Live. We DO NOT run the
         // old inline `probeCurrentRuntimeOnForegroundIfNeeded → connect(LifecycleReattach)`
-        // path, which raised `_switchHidesTerminal` (the "Attaching…" overlay) on any
+        // path, which raised the reveal-machine hold (the "Attaching…" overlay) on any
         // confirmed-dead probe verdict even inside grace — the D21 violation #754 fixes.
         // The within-grace gate (`resumedWithinGrace && warm lease`) is exactly the
         // controller's `onForeground` predicate (`now < deadline && transport.isWarm`),
@@ -3795,7 +3782,7 @@ public class TmuxSessionViewModel @Inject constructor(
             // grace-elapsed teardown, NOT here, so the #738 driver detach never fires).
             // Run the RESEED-ONLY effect directly: it re-promotes Live (a no-op
             // TransportLive on an already-Live controller) and heals blank panes over
-            // the warm client. NO connect(), NO `_switchHidesTerminal` "Attaching…"
+            // the warm client. NO connect(), NO the reveal-machine hold "Attaching…"
             // overlay — the D21 within-grace contract. The driver's
             // `foregroundReattachEffect` seam invokes this SAME body on the controller's
             // Backgrounded→Reattaching edge (the classification model, unit-tested in
@@ -3890,7 +3877,7 @@ public class TmuxSessionViewModel @Inject constructor(
      * drops a late seed for a switched-away/superseded runtime.
      *
      * D21/D28 contract: NO reconnect, NO new lease, NO `connectGeneration` bump, NO
-     * `_switchHidesTerminal` "Attaching…" overlay, and NO new polling/timer (#1164) — a single
+     * the reveal-machine hold "Attaching…" overlay, and NO new polling/timer (#1164) — a single
      * reseed on this one no-op branch, at most one `capture-pane` per pinned foreground return.
      * A no-op when nothing is attached / the client is gone (the beyond-grace non-pinned resume
      * that DID tear down never reaches here — it always has an arm to dispatch above).
@@ -4022,7 +4009,7 @@ public class TmuxSessionViewModel @Inject constructor(
      * to Live (the channel is live) and run the existing blank-pane safety-net reseed
      * over the SAME live client so a pane that came back blank under a brief link blip
      * still heals — without a handshake. Crucially this NEVER calls `connect()` and
-     * NEVER raises `_switchHidesTerminal`, so the user sees no "Attaching…" overlay and
+     * NEVER raises the reveal-machine hold, so the user sees no "Attaching…" overlay and
      * no reconnect — the D21 within-grace contract.
      *
      * This is also the body the [ConnectionEffectDriver]'s `foregroundReattachEffect`
@@ -4099,7 +4086,7 @@ public class TmuxSessionViewModel @Inject constructor(
      *    or touches the reconnect/grace state machine. It runs entirely over the
      *    already-live `clientRef` (`-CC` control channel) against the current runtime
      *    guard, exactly like the within-grace foreground reseed does.
-     *  - It does NOT raise `_switchHidesTerminal` (no "Attaching…" overlay) and does NOT
+     *  - It does NOT raise the reveal-machine hold (no "Attaching…" overlay) and does NOT
      *    change [_connectionStatus] — the status stays the calm `Connected`.
      *
      * It differs from [reseedVisiblePaneIfBlank] (the #662 switch heal) in that it is
@@ -6102,11 +6089,6 @@ public class TmuxSessionViewModel @Inject constructor(
         installLifecycleHooks(target.hostId)
         bindProjectRootsForHost(target.hostId)
         refreshReconnectAvailability()
-        // Issue #661: the cache-hit path activates the TARGET session's own
-        // cached frame (already published above), so there is never a leaving
-        // frame to hide here; clear the gate defensively in case a prior
-        // in-flight fast switch had set it.
-        _switchHidesTerminal.value = false
         // EPIC #687 P1: the warm cache-hit reveals the target's own pane WITHOUT a
         // fresh capture, so promote the reveal machine to Live for the target here
         // (otherwise the NEW-path reveal gate would stay held and the surface would
@@ -6485,17 +6467,10 @@ public class TmuxSessionViewModel @Inject constructor(
             )
             // Issue #693/#661: NEVER reveal a black active pane on this cold/slow
             // path either (it is also the dead-lease fast-switch escalation
-            // target). Gate the reveal on a non-empty active-pane seed; only
-            // clear [_switchHidesTerminal] (the loading overlay) once the active
-            // pane is non-blank, otherwise keep the calm "Attaching…" overlay and
-            // hand off to [armConnectedBlankWatchdog].
+            // target). Gate the reveal on a non-empty active-pane seed, otherwise
+            // keep the calm "Attaching…" hold and hand off to
+            // [armConnectedBlankWatchdog].
             val activePaneSeeded = awaitActivePaneSeededOrLoading(blankReseedGuard)
-            // Issue #661: clear any cross-session "hide terminal" gate at the
-            // reveal so a fast switch that fell through to this slow/cold path
-            // (e.g. a dead-lease escalation) still reveals the new session's
-            // seeded panes rather than staying on the loading placeholder — but
-            // only when the active pane actually has content (#693).
-            _switchHidesTerminal.value = !activePaneSeeded
             // EPIC #687 P1: when the active pane is seeded non-blank, the inline path
             // reveals the target's surface — promote the reveal machine to Live for
             // the target so the NEW-path reveal gate releases in lockstep.
@@ -7019,23 +6994,13 @@ public class TmuxSessionViewModel @Inject constructor(
             // reveal gates on the active pane's single capture — a degraded
             // switch could otherwise reveal a BLACK active pane with a green dot
             // and no reconnecting band. Gate the reveal on a non-empty active-
-            // pane seed (bounded retries); only clear [_switchHidesTerminal]
-            // (the loading overlay) once the active pane is non-blank.
+            // pane seed (bounded retries).
             val fastSwitchRevealGuard = RuntimeRefreshGuard(
                 generation = connectGeneration,
                 target = target,
                 client = client,
             )
             val activePaneSeeded = awaitActivePaneSeededOrLoading(fastSwitchRevealGuard)
-            // Issue #661: the NEW session's panes are seeded (reconciled in
-            // [awaitPanesReadyForAttach]); reveal the terminal surface in the
-            // SAME state mutation that flips to Connected so the first painted
-            // frame is the new session's content — never a transient blank or
-            // (worse) the leaving session's frame. When the active pane could
-            // NOT be seeded non-blank within the gate's bound, keep the loading
-            // overlay raised and hand off to [armConnectedBlankWatchdog] so the
-            // user sees a calm "Attaching…" rather than a black Connected pane.
-            _switchHidesTerminal.value = !activePaneSeeded
             // EPIC #687 P1: the fast-switch reveal shows the target's seeded pane —
             // promote the reveal machine to Live for the target so the NEW-path reveal
             // gate releases in the same mutation (never holds on a warm switch).
@@ -7493,9 +7458,6 @@ public class TmuxSessionViewModel @Inject constructor(
         connectingTarget =
             if (preserveReconnectTarget || staleChannelSymptom || coalescedCancel) target else null
         refreshReconnectAvailability()
-        // Issue #661: a failed switch must drop the cross-session "hide terminal"
-        // gate so the Failed band is shown (not the loading placeholder).
-        _switchHidesTerminal.value = false
         setConnectionState(ConnectionState.Unreachable(message))
         // Issue #1185 (two-holder safety net): drive the reveal machine DIRECTLY
         // to a terminal error for THIS exact target instead of relying solely on
@@ -7506,7 +7468,7 @@ public class TmuxSessionViewModel @Inject constructor(
         // honest error in lockstep, closing the #1185 contradictory Disconnected +
         // live-spinner surface. Drop-by-id inside the machine makes this a no-op if
         // the user has since navigated to another session.
-        driveRevealTerminalError(target)
+        driveRevealTerminalError(target, cause)
     }
 
     /**
@@ -7592,8 +7554,11 @@ public class TmuxSessionViewModel @Inject constructor(
      * the machine makes this a no-op when the user has navigated to another
      * session.
      */
-    private fun driveRevealTerminalError(target: ConnectionTarget) {
-        revealStateMachine.onTerminalError(controllerSessionId(target))
+    private fun driveRevealTerminalError(target: ConnectionTarget, cause: Throwable?) {
+        // Issue #1326 (S3): carry the TYPED failure reason (the single
+        // [classifyFailure] classifier) to the reveal machine so the honest error
+        // surface renders a curated sentence, never a raw exception string.
+        revealStateMachine.onTerminalError(controllerSessionId(target), classifyFailure(cause))
         _revealState.value = revealStateMachine.state.value
     }
 
@@ -7639,6 +7604,22 @@ public class TmuxSessionViewModel @Inject constructor(
             current = current.cause
         }
         return false
+    }
+
+    /**
+     * Issue #1326 (characterization test seam): drive the id-keyed reveal machine to
+     * a HELD (Seeding) surface for the active target — the loading-hold state a
+     * connected-but-blank pane hands off into. Replaces the deleted
+     * `setSwitchHidesTerminalForTest` seam now that the reveal machine (not a
+     * separate flag) is the single surface-hold authority.
+     */
+    @androidx.annotation.VisibleForTesting
+    internal fun setRevealHoldForTest() {
+        val target = activeTarget ?: connectingTarget ?: return
+        revealStateMachine.onConnectionState(
+            CoreConnectionState.Attaching(controllerHostKey(target), controllerSessionId(target)),
+        )
+        _revealState.value = revealStateMachine.state.value
     }
 
     /**
@@ -7819,48 +7800,29 @@ public class TmuxSessionViewModel @Inject constructor(
      * (a host briefly unreachable while rebooting, Wi-Fi handover, etc.), so
      * they stay on the retry-with-backoff path.
      */
-    private fun isNonRetryableConnectFailure(cause: Throwable?): Boolean {
-        var current: Throwable? = cause
-        val seen = HashSet<Throwable>()
-        while (current != null && seen.add(current)) {
-            val simpleName = current.javaClass.simpleName
-            if (simpleName in NON_RETRYABLE_FAILURE_CLASS_NAMES) return true
-            // The key-not-found case is surfaced as a plain IOException with a
-            // descriptive message (see [SshConnection]); a literal type match
-            // would be too broad (IOException also covers transient socket
-            // tear-downs), so we narrow it on the message text.
-            val message = current.message
-            if (message != null && message.contains(MISSING_KEY_MESSAGE_FRAGMENT, ignoreCase = true)) {
-                return true
-            }
-            current = current.cause
-        }
-        return false
-    }
+    // Issue #1326 (S3): the `Throwable → non-retryable?` and `Throwable → reason`
+    // string tables moved to the SINGLE `:shared:core-connection` classifier
+    // ([classifyFailure] + [FailureReason.retryable]). These are thin adapters over
+    // it so the auto-reconnect ladder + the [ConnectionStatus.Failed] band keep their
+    // exact behaviour while there is ONE source of truth for the reason.
+    private fun isNonRetryableConnectFailure(cause: Throwable?): Boolean =
+        !classifyFailure(cause).retryable
 
     /**
-     * Issue #440: a short, user-facing reason for a non-retryable connect
-     * failure, used in the [ConnectionStatus.Failed] message that replaces
-     * the backoff loop. Keeps the band actionable ("authentication failed —
-     * check your key") instead of leaking the raw exception type.
+     * Issue #440/#1326: a short, user-facing reason for a non-retryable connect
+     * failure, used in the [ConnectionStatus.Failed] message that replaces the
+     * backoff loop. Derived from the typed [classifyFailure] reason so the wording
+     * has one source.
      */
-    private fun nonRetryableReason(cause: Throwable?): String {
-        var current: Throwable? = cause
-        val seen = HashSet<Throwable>()
-        while (current != null && seen.add(current)) {
-            when (current.javaClass.simpleName) {
-                "UserAuthException" -> return "authentication failed"
-                "UnknownHostException" -> return "host could not be resolved"
-                // Issue #998: server-death — all sessions ended, recreate one.
-                "TmuxServerDeadException" -> return "the tmux server restarted — all sessions ended"
-            }
-            if (current.message?.contains(MISSING_KEY_MESSAGE_FRAGMENT, ignoreCase = true) == true) {
-                return "private key file not found"
-            }
-            current = current.cause
+    private fun nonRetryableReason(cause: Throwable?): String =
+        when (val reason = classifyFailure(cause)) {
+            FailureReason.AuthFailed -> "authentication failed"
+            FailureReason.HostUnresolved -> "host could not be resolved"
+            FailureReason.ServerRestarted -> "the tmux server restarted — all sessions ended"
+            FailureReason.SessionEnded -> "this session ended"
+            FailureReason.KeyMissing -> "private key file not found"
+            is FailureReason.Unreachable -> "connection cannot be retried"
         }
-        return "connection cannot be retried"
-    }
 
     private fun connectFailureMessage(t: Throwable, target: ConnectionTarget): String =
         if (t is TmuxAttachPanesReadyException) {
@@ -9625,10 +9587,9 @@ public class TmuxSessionViewModel @Inject constructor(
         refreshReconnectAvailability()
         // Issue #437 (slice A) / #661: mirror production — a same-host fast
         // switch enters [Switching] (inline indicator), NOT the blanking
-        // full-screen [Connecting] overlay; and per #661 it HIDES the terminal
-        // surface ([_switchHidesTerminal]) so the leaving frame is never painted
-        // until the new session's panes are seeded.
-        _switchHidesTerminal.value = true
+        // full-screen [Connecting] overlay; per #661 the reveal machine holds the
+        // terminal surface so the leaving frame is never painted until the new
+        // session's panes are seeded.
         setConnectionState(ConnectionState.Attaching(host, port, user))
         recordWarmSwitchMilestone(
             attempt = attempt,
@@ -9640,9 +9601,9 @@ public class TmuxSessionViewModel @Inject constructor(
         )
         // Mirror production's ordering: deactivate the previous tmux/UI runtime
         // into the warm cache before binding the new one. Issue #661: do NOT
-        // re-publish the leaving frame — blank the rendered panes and rely on
-        // [_switchHidesTerminal] to show the loading state until the new
-        // session's panes reconcile and reveal.
+        // re-publish the leaving frame — blank the rendered panes and rely on the
+        // reveal machine's hold to show the loading state until the new session's
+        // panes reconcile and reveal.
         closeCachedRuntimesAsync(deactivateCurrentRuntimeToCache())
         _panes.value = emptyList()
         rebuildUnifiedPanes()
@@ -9691,8 +9652,8 @@ public class TmuxSessionViewModel @Inject constructor(
         bindProjectRootsForHost(hostId)
         connectingTarget = null
         refreshReconnectAvailability()
-        // Issue #661: reveal the new session's surface at the Connected flip.
-        _switchHidesTerminal.value = false
+        // Issue #661: reveal the new session's surface at the Connected flip
+        // (the reveal machine promotes to Live via the seed/promote path).
         setConnectionState(ConnectionState.Live(host, port, user))
         recordWarmSwitchMilestone(
             attempt = attempt,
@@ -11202,17 +11163,6 @@ public class TmuxSessionViewModel @Inject constructor(
         )
     }
 
-    /**
-     * Issue #722 (characterization test seam): set the loading-overlay flag
-     * [_switchHidesTerminal] so a test can recreate the exact post-reveal state
-     * the blank watchdog is handed off into (overlay raised over a blank pane).
-     * Touches only the overlay flag — NOT the connection-status machinery.
-     */
-    @androidx.annotation.VisibleForTesting
-    internal fun setSwitchHidesTerminalForTest(hidden: Boolean) {
-        _switchHidesTerminal.value = hidden
-    }
-
     private suspend fun preloadVisibleContentForNewPanes(
         newPanes: List<TmuxPaneState>,
         refreshGuard: RuntimeRefreshGuard? = null,
@@ -11573,7 +11523,11 @@ public class TmuxSessionViewModel @Inject constructor(
                     // pane (a real one-line prompt that landed after reveal reads
                     // partial-black), reseed-thrashing it on every arming — so the
                     // watchdog keeps its narrow fully-blank contract.
-                    if (_switchHidesTerminal.value) _switchHidesTerminal.value = false
+                    // Issue #1326: the frame recovered — promote the reveal machine
+                    // to Live for the active target so the surface reveals (this
+                    // replaces the deleted switch-hides-terminal clear; the reveal
+                    // machine is now the single hold authority).
+                    promoteRevealLiveForActiveTarget()
                     // Issue #973: the pane that was blank AT reveal has now
                     // produced a frame, so hand off the #966 lifetime net here —
                     // the reveal sites skip arming the stale-render watchdog while
@@ -11590,7 +11544,8 @@ public class TmuxSessionViewModel @Inject constructor(
                 )
                 reseedBlankVisiblePanes(refreshGuard)
                 if (!activePane.terminalState.visibleScreenIsBlank()) {
-                    if (_switchHidesTerminal.value) _switchHidesTerminal.value = false
+                    // Issue #1326: reveal via the single reveal-machine authority.
+                    promoteRevealLiveForActiveTarget()
                     // Issue #973: frame landed after a reseed — hand off the #966
                     // stale-render lifetime net (see the early-exit case above).
                     armActivePaneStaleRenderWatchdog(refreshGuard)
@@ -11994,11 +11949,12 @@ public class TmuxSessionViewModel @Inject constructor(
             "maxTicks" to connectedBlankWatchdogMaxTicks,
             "tickMs" to CONNECTED_BLANK_WATCHDOG_TICK_MS,
         )
-        // Preserve the target so Reconnect has something to re-dial, then drop
-        // the loading overlay and drive the honest-error reveal surface.
+        // Preserve the target so Reconnect has something to re-dial, then drive
+        // the honest-error surface via [ConnectionState.Unreachable] (the reveal
+        // machine + [SessionSurfaceState] resolve the held surface to the calm
+        // failure placeholder — no separate loading-overlay flag; #1326).
         connectingTarget = target
         refreshReconnectAvailability()
-        _switchHidesTerminal.value = false
         val where = target?.let { " ${it.user}@${it.host}:${it.port}" } ?: ""
         setConnectionState(
             ConnectionState.Unreachable(
@@ -19958,39 +19914,6 @@ private const val STALE_LEASE_AUTO_RECOVER_MAX: Int = 2
  * surfaces instead of an unbounded re-dial loop.
  */
 private const val COALESCED_CANCEL_REDIAL_MAX: Int = 2
-
-/**
- * Issue #440: simple class names of connect-failure causes that retrying
- * cannot fix — authentication rejection and DNS resolution failure. Matched
- * against the cause chain of a failed connect attempt (see
- * [TmuxSessionViewModel.isNonRetryableConnectFailure]). When one of these is
- * the failure, auto-reconnect stops immediately and surfaces the manual
- * Reconnect affordance rather than exhausting the backoff schedule.
- *
- * `UserAuthException` is sshj's authentication failure; `UnknownHostException`
- * is `java.net`'s DNS / unresolved-host signal. Both are config-level
- * problems the user must fix, not transient blips.
- */
-private val NON_RETRYABLE_FAILURE_CLASS_NAMES: Set<String> = setOf(
-    "UserAuthException",
-    "UnknownHostException",
-    // Issue #998: a dead tmux server will not come back by retrying the same
-    // attach — every retry would re-detect `no server running` (or worse, on a
-    // host whose tmux DID come back up, silently `new-session -A` a fresh empty
-    // server). So the auto-reconnect ladder must STOP on server-death rather
-    // than burn its 4 rungs; the user lands on the list (failServerDied already
-    // emitted `sessionEnded`) and recreates a session explicitly.
-    "TmuxServerDeadException",
-)
-
-/**
- * Issue #440: substring that identifies the "private key file not found"
- * IOException raised by [com.pocketshell.core.ssh.SshConnection]. A missing
- * key is a non-retryable config error; matching on the message keeps the
- * generic IOException type (which also covers transient socket drops) on the
- * retryable path.
- */
-private const val MISSING_KEY_MESSAGE_FRAGMENT: String = "Private key file not found"
 
 /**
  * Issue #423: a terminal surface that fails this many times within

--- a/app/src/test/java/com/pocketshell/app/tmux/ReseedBlankWatchdogCharacterizationTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/ReseedBlankWatchdogCharacterizationTest.kt
@@ -67,7 +67,7 @@ import java.io.InputStream
  *      ([TmuxSessionViewModel.currentRuntimeGuardForTest],
  *      [TmuxSessionViewModel.reseedBlankVisiblePanesForTest],
  *      [TmuxSessionViewModel.armConnectedBlankWatchdogForTest],
- *      [TmuxSessionViewModel.setSwitchHidesTerminalForTest]). These build a
+ *      [TmuxSessionViewModel.setRevealHoldForTest]). These build a
  *      [TmuxSessionViewModel.RuntimeRefreshGuard] pinned to the live runtime
  *      exactly the way the production reveal call sites do, so the cluster runs
  *      against a known runtime without driving the whole connect coroutine
@@ -82,6 +82,13 @@ import java.io.InputStream
 @RunWith(RobolectricTestRunner::class)
 @Config(manifest = Config.NONE, sdk = [33])
 class ReseedBlankWatchdogCharacterizationTest {
+
+    // Issue #1326 (S3): the loading "Attaching…" hold is now owned by the id-keyed
+    // reveal machine ([RevealState.Seeding]) — the deleted `_switchHidesTerminal`
+    // flag is gone. "the loading overlay is raised" ⟺ the reveal is a held Seeding
+    // surface. (Live = terminal shown; Error = the calm honest-failure surface.)
+    private fun TmuxSessionViewModel.loadingHoldRaisedForTest(): Boolean =
+        revealState.value is com.pocketshell.core.connection.RevealState.Seeding
 
     private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
@@ -392,7 +399,7 @@ class ReseedBlankWatchdogCharacterizationTest {
     fun connectedBlankWatchdogReseedsBlankActivePaneAndClearsLoadingOverlay() = runVmTest {
         // The watchdog's reason for existing: a Connected pane that is BLACK gets
         // re-seeded on a timer until a real frame lands, at which point the
-        // loading overlay (switchHidesTerminal) is dropped.
+        // loading hold (RevealState.Seeding) is dropped.
         val client = FakeTmuxClient().withSinglePaneRowButEmptyCapture("work", "%1")
         val vm = connectVm(client)
         val pane = vm.panes.value.single { it.paneId == "%1" }
@@ -402,7 +409,7 @@ class ReseedBlankWatchdogCharacterizationTest {
         )
         assertTrue(
             "an empty-seed reveal keeps the loading overlay raised (never black-reveal)",
-            vm.switchHidesTerminal.value,
+            vm.loadingHoldRaisedForTest(),
         )
         assertTrue(pane.terminalState.visibleScreenIsBlank())
 
@@ -438,7 +445,7 @@ class ReseedBlankWatchdogCharacterizationTest {
         )
         assertFalse(
             "once a real frame lands the watchdog drops the loading overlay",
-            vm.switchHidesTerminal.value,
+            vm.loadingHoldRaisedForTest(),
         )
         assertTrue(
             renderedTranscriptFor(pane).contains("ISSUE722-WATCHDOG-RECOVER"),
@@ -458,7 +465,7 @@ class ReseedBlankWatchdogCharacterizationTest {
             pane.terminalState.visibleScreenIsBlank(),
         )
         // Recreate the handed-off state: overlay raised over a (now) painted pane.
-        vm.setSwitchHidesTerminalForTest(true)
+        vm.setRevealHoldForTest()
 
         val capturesBefore = client.captureCount()
         val guard = requireNotNull(vm.currentRuntimeGuardForTest())
@@ -468,7 +475,7 @@ class ReseedBlankWatchdogCharacterizationTest {
 
         assertFalse(
             "a non-blank active pane makes the watchdog drop the overlay",
-            vm.switchHidesTerminal.value,
+            vm.loadingHoldRaisedForTest(),
         )
         assertEquals(
             "the watchdog must NOT reseed when the pane already shows content",
@@ -486,7 +493,7 @@ class ReseedBlankWatchdogCharacterizationTest {
         val vm = connectVm(client)
         val pane = vm.panes.value.single { it.paneId == "%1" }
         assertTrue(pane.terminalState.visibleScreenIsBlank())
-        assertTrue(vm.switchHidesTerminal.value)
+        assertTrue(vm.loadingHoldRaisedForTest())
 
         // Isolate the WATCHDOG's disconnect guard from the VM's reconnect ladder:
         //   - grace=0 makes the silent-reattach grace a no-op (it would otherwise
@@ -524,9 +531,14 @@ class ReseedBlankWatchdogCharacterizationTest {
             capturesBefore,
             client.captureCount(),
         )
+        // Issue #1326: the watchdog bails WITHOUT revealing the terminal — the
+        // dead client never produced content, so the reveal stays a non-Live surface
+        // (a loading hold or, once grace=0 exhausts, the honest-failure surface). The
+        // load-bearing point is that the watchdog did NOT paint content on a dead
+        // client (no reseed above, terminal still not Live).
         assertTrue(
-            "the watchdog leaves the overlay raised when it bails on a dead client",
-            vm.switchHidesTerminal.value,
+            "the watchdog must not reveal the terminal when it bails on a dead client",
+            vm.revealState.value !is com.pocketshell.core.connection.RevealState.Live,
         )
     }
 
@@ -539,7 +551,7 @@ class ReseedBlankWatchdogCharacterizationTest {
         val vm = connectVm(client)
         val pane = vm.panes.value.single { it.paneId == "%1" }
         assertTrue(pane.terminalState.visibleScreenIsBlank())
-        assertTrue(vm.switchHidesTerminal.value)
+        assertTrue(vm.loadingHoldRaisedForTest())
         // No further capture responses queued -> every capture is the default
         // empty reply, so the pane stays blank for the whole watchdog run.
 
@@ -585,7 +597,7 @@ class ReseedBlankWatchdogCharacterizationTest {
         // (every capture-pane comes back empty — the wedged-seed stand-in for the
         // capture stuck behind a streaming agent channel). Before #886 the
         // connect()-auto-armed watchdog fell off the end SILENTLY, leaving
-        // switchHidesTerminal raised forever (the infinite "Attaching…" spinner).
+        // the loading hold raised forever (the infinite "Attaching…" spinner).
         // Now it must surface a retryable error + the #823 Reconnect affordance.
         val client = FakeTmuxClient().withSinglePaneRowButEmptyCapture("work", "%1")
         val vm = connectVmExhaustingWatchdog(client)
@@ -602,7 +614,7 @@ class ReseedBlankWatchdogCharacterizationTest {
         assertFalse(
             "the loading overlay must be dropped on watchdog exhaustion — never an " +
                 "infinite Attaching spinner (#886)",
-            vm.switchHidesTerminal.value,
+            vm.loadingHoldRaisedForTest(),
         )
         // The reveal projects to the honest-error surface (RevealState.Error,
         // not retrying) so the screen shows a clear message, not a spinner.
@@ -650,7 +662,7 @@ class ReseedBlankWatchdogCharacterizationTest {
 
         assertFalse(
             "the healed pane drops the overlay (revealed Live)",
-            vm.switchHidesTerminal.value,
+            vm.loadingHoldRaisedForTest(),
         )
         assertTrue(
             "a healed reveal must NOT surface a Failed error",
@@ -777,9 +789,9 @@ class ReseedBlankWatchdogCharacterizationTest {
         )
         // The reveal gate kept the loading overlay rather than revealing black.
         assertTrue(
-            "the reveal must KEEP the loading overlay (switchHidesTerminal=true) " +
+            "the reveal must KEEP the loading hold (RevealState.Seeding) " +
                 "for a blank active pane, never reveal a black Connected pane",
-            vm.switchHidesTerminal.value,
+            vm.loadingHoldRaisedForTest(),
         )
         assertTrue(
             vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected,
@@ -801,7 +813,7 @@ class ReseedBlankWatchdogCharacterizationTest {
         )
         assertFalse(
             "after recovery the watchdog drops the loading overlay",
-            vm.switchHidesTerminal.value,
+            vm.loadingHoldRaisedForTest(),
         )
         assertTrue(
             renderedTranscriptFor(pane).contains("ISSUE722-721-HEALED"),

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionScreenTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionScreenTest.kt
@@ -12,8 +12,16 @@ import com.pocketshell.app.sessions.HostTmuxSessionPickerState
 import com.pocketshell.app.sessions.HostTmuxSessionRow
 import com.pocketshell.core.agents.AgentDetection
 import com.pocketshell.core.agents.AgentKind
+import com.pocketshell.core.connection.ConnectionPhase
+import com.pocketshell.core.connection.FailureReason
 import com.pocketshell.core.connection.RevealState
 import com.pocketshell.core.connection.SessionId
+import com.pocketshell.core.connection.SessionSurfaceState
+import com.pocketshell.core.connection.sessionSurfaceState
+import com.pocketshell.core.connection.showsCalmFailure
+import com.pocketshell.core.connection.showsCenteredLoader
+import com.pocketshell.core.connection.surfaceOwnsPrimary
+import com.pocketshell.core.connection.terminalHeld
 import com.pocketshell.core.storage.entity.HostEntity
 import com.pocketshell.core.terminal.selection.LocalhostUrl
 import com.pocketshell.uikit.model.SessionAgentKind
@@ -1340,31 +1348,59 @@ class TmuxSessionScreenTest {
 
     // ─── Issues #177 / #249: breadcrumb status mapping ──────────────────
 
+    // Issue #1326 (S3): the pill now derives from the SINGLE fused
+    // [SessionSurfaceState], so it can NEVER disagree with the surface/band.
     @Test
-    fun toUiStatusMapsConnectedToConnected() {
+    fun toUiStatusMapsLiveToConnected() {
         assertEquals(
             com.pocketshell.uikit.model.ConnectionStatus.Connected,
-            TmuxSessionViewModel.ConnectionStatus.Connected("h", 22, "u").toUiStatus(),
+            SessionSurfaceState.Live(SessionId("t"), "s", emptyList()).toUiStatus(),
+        )
+    }
+
+    @Test
+    fun toUiStatusMapsAttachingToConnected() {
+        // A warm switch / live-unseeded hold keeps the dot GREEN — the session is up.
+        assertEquals(
+            com.pocketshell.uikit.model.ConnectionStatus.Connected,
+            SessionSurfaceState.Attaching(SessionId("t"), "s", "h", 22, "u").toUiStatus(),
         )
     }
 
     @Test
     fun toUiStatusMapsConnectingToConnecting() {
-        // Connecting drives the amber pulse + "Reconnecting" pill while a
-        // background-detach reattach handshake (#177) is in flight.
         assertEquals(
             com.pocketshell.uikit.model.ConnectionStatus.Connecting,
-            TmuxSessionViewModel.ConnectionStatus.Connecting("h", 22, "u").toUiStatus(),
+            SessionSurfaceState.Connecting(SessionId("t"), "s", "h", 22, "u").toUiStatus(),
+        )
+    }
+
+    @Test
+    fun toUiStatusMapsReconnectingToConnecting() {
+        assertEquals(
+            com.pocketshell.uikit.model.ConnectionStatus.Connecting,
+            SessionSurfaceState.Reconnecting(SessionId("t"), "s", "h", 22, "u", 2, 3, 0L).toUiStatus(),
         )
     }
 
     @Test
     fun toUiStatusMapsFailedToError() {
-        // Failed is the dropped-socket state #249 rides on; it must read
-        // as a red "Disconnected" indicator, not a steady-state dot.
+        // Failed must read as a red "Disconnected" indicator, not a steady-state dot.
         assertEquals(
             com.pocketshell.uikit.model.ConnectionStatus.Error,
-            TmuxSessionViewModel.ConnectionStatus.Failed("Disconnected from ...").toUiStatus(),
+            SessionSurfaceState.Failed(
+                SessionId("t"),
+                "s",
+                FailureReason.Unreachable(retryable = true),
+            ).toUiStatus(),
+        )
+    }
+
+    @Test
+    fun toUiStatusMapsGoneToError() {
+        assertEquals(
+            com.pocketshell.uikit.model.ConnectionStatus.Error,
+            SessionSurfaceState.Gone(SessionId("t"), "s").toUiStatus(),
         )
     }
 
@@ -1372,7 +1408,7 @@ class TmuxSessionScreenTest {
     fun toUiStatusMapsIdleToIdle() {
         assertEquals(
             com.pocketshell.uikit.model.ConnectionStatus.Idle,
-            TmuxSessionViewModel.ConnectionStatus.Idle.toUiStatus(),
+            SessionSurfaceState.Idle.toUiStatus(),
         )
     }
 
@@ -1902,7 +1938,11 @@ class TmuxSessionScreenTest {
         assertEquals(30, imeKeyboardPanOffsetPx(imeBottomPx = 30, navBarBottomPx = 48))
     }
 
-    // --- Issue #750: single-indicator gate on the top ReconnectingProgressRow. ---
+    // ─── Issue #1326 (S3): ONE fused view state drives pill + surface + band. ───
+    // These pin the [sessionSurfaceState] fusion + the derived surface/pill/band
+    // helpers so a contradictory (pill, surface, band) triple is UNREPRESENTABLE.
+
+    private val sid = SessionId("host/work")
 
     private val reconnectingStatus = TmuxSessionViewModel.ConnectionStatus.Reconnecting(
         host = "alpha.example",
@@ -1913,343 +1953,216 @@ class TmuxSessionScreenTest {
         retryDelayMs = 0L,
         reason = "Reconnecting…",
     )
-
-    @Test
-    fun topReconnectBarSuppressedWhileTerminalHeldDuringReattach() {
-        // Regression for the post-#766 two-loaders symptom: a recoverable drop
-        // projects Reconnecting (the top bar) WHILE the reveal machine holds the
-        // terminal in Seeding (effectiveHidesTerminal == true) and paints the
-        // centered "Attaching…" spinner. The top bar MUST be suppressed so only the
-        // centered indicator shows.
-        assertEquals(
-            false,
-            shouldShowReconnectingProgressRow(
-                status = reconnectingStatus,
-                effectiveHidesTerminal = true,
-            ),
-        )
-    }
-
-    @Test
-    fun topReconnectBarShownWhenReconnectingWithTerminalNotHeld() {
-        // The top bar is the fallback indicator for a (currently unreached)
-        // reconnect that keeps a live frame painted (terminal NOT held): it then
-        // renders so a reconnect is never left with zero indicators.
-        assertTrue(
-            shouldShowReconnectingProgressRow(
-                status = reconnectingStatus,
-                effectiveHidesTerminal = false,
-            ),
-        )
-    }
-
-    @Test
-    fun topReconnectBarNeverShownForNonReconnectingStatus() {
-        // The top bar renders ONLY for Reconnecting — so it is never the sole
-        // indicator for any other state. Connecting has its own top overlay (gated
-        // the same way); Connected/Switching/Failed/Idle drive their own affordances.
-        val nonReconnecting = listOf(
-            TmuxSessionViewModel.ConnectionStatus.Idle,
-            TmuxSessionViewModel.ConnectionStatus.Connecting("h", 22, "u"),
-            TmuxSessionViewModel.ConnectionStatus.Switching("h", 22, "u"),
-            TmuxSessionViewModel.ConnectionStatus.Connected("h", 22, "u"),
-            TmuxSessionViewModel.ConnectionStatus.Failed("boom"),
-        )
-        nonReconnecting.forEach { status ->
-            assertEquals(
-                "no top progress bar for $status",
-                false,
-                shouldShowReconnectingProgressRow(status, effectiveHidesTerminal = false),
-            )
-            assertEquals(
-                "no top progress bar for $status (terminal held)",
-                false,
-                shouldShowReconnectingProgressRow(status, effectiveHidesTerminal = true),
-            )
-        }
-    }
-
-    // --- Issue #750 (4th occurrence): the beyond-grace RECONNECT two-loaders bug.
-    // The maintainer sees the top "Connecting to host…" [ConnectingProgressOverlay]
-    // banner AND the centered "Attaching…" hold at the SAME time on a beyond-grace
-    // reconnect. Root cause: a reconnect re-dials through the controller's
-    // `Connecting` state → status projects to [ConnectionStatus.Connecting] (the top
-    // banner) WHILE the reveal machine holds the terminal (effectiveHidesTerminal ==
-    // true) and paints the centered spinner. The previous #750 fix gated only the
-    // Reconnecting band, never the Connecting overlay. These tests pin the reducer +
-    // BOTH gate predicates so exactly ONE primary loading surface resolves per state.
-
     private val connectingStatus =
         TmuxSessionViewModel.ConnectionStatus.Connecting("beta.example", 22, "alex")
 
+    /** Build the fused view state the screen renders, exactly as the screen wires it. */
+    private fun fuse(
+        reveal: RevealState,
+        status: TmuxSessionViewModel.ConnectionStatus,
+        target: SessionId? = sid,
+    ): SessionSurfaceState = sessionSurfaceState(reveal, connectionPhaseOf(status), target)
+
     @Test
-    fun connectingOverlaySuppressedWhileTerminalHeld_beyondGraceReconnectRepro() {
-        // REPRODUCTION of the maintainer's exact reopen state: a beyond-grace
-        // reconnect projects Connecting (the top overlay) WHILE the terminal is held
-        // (the centered "Attaching…" hold is up). Pre-fix the overlay was ungated on
-        // `status is Connecting`, so it stacked on top of the centered hold — TWO
-        // loaders. The reducer must resolve to the SINGLE centered hold and suppress
-        // the top banner.
-        assertEquals(
-            PrimaryLoadingSurface.CenteredAttaching,
-            primaryLoadingSurface(connectingStatus, effectiveHidesTerminal = true),
+    fun fusion_failedState_pillDisconnected_surfaceCalmFailure_noSpinner_1321Repro() {
+        // #1321 EXACT reproduction: a settled honest failure must render as ONE
+        // coherent screen — calm failure surface + "Disconnected" pill + NO spinner
+        // + NO top banner. Red on base (pre-S3): the pill read `status`, the surface
+        // read `revealState`, and the band read a raw string, so "Disconnected" pill
+        // + "Attaching…" spinner + raw exception could all show at once.
+        val state = fuse(
+            RevealState.Error(sid, "work", retrying = false, reason = FailureReason.Unreachable(true)),
+            TmuxSessionViewModel.ConnectionStatus.Failed("Connection lost."),
         )
+        assertTrue("settled failure → Failed view state", state is SessionSurfaceState.Failed)
+        // Surface: calm placeholder, NO centered loader.
+        assertTrue("surface paints calm failure", state.showsCalmFailure)
+        assertFalse("no centered loader over a dead session", state.showsCenteredLoader(panesEmpty = true))
+        assertEquals("no top loading banner", PrimaryLoadingSurface.None, primaryLoadingSurface(state, panesEmpty = true))
+        // Pill: Disconnected (red Error), never a green/amber that contradicts the surface.
         assertEquals(
-            "top Connecting overlay must be suppressed while the terminal is held",
-            false,
-            shouldShowConnectingProgressOverlay(connectingStatus, effectiveHidesTerminal = true),
+            com.pocketshell.uikit.model.ConnectionStatus.Error,
+            state.toUiStatus(),
         )
+        // Band owns the single reconnect affordance → the bottom button is suppressed.
+        assertFalse("no bottom reconnect button on Failed (band owns it)", surfaceReconnectButtonVisible(state))
     }
 
     @Test
-    fun connectingOverlayShownOnlyWhenTerminalNotHeld() {
-        // The top overlay is the fallback loader for a (currently unreached)
-        // Connecting that keeps a live frame painted (terminal NOT held), so it is
-        // never the sole indicator stripped from a state that needs it.
-        assertEquals(
-            PrimaryLoadingSurface.ConnectingBanner,
-            primaryLoadingSurface(connectingStatus, effectiveHidesTerminal = false),
-        )
-        assertTrue(
-            shouldShowConnectingProgressOverlay(connectingStatus, effectiveHidesTerminal = false),
-        )
+    fun fusion_reconnecting_holdSurface_matchingReconnectingPill_singleCenteredLoader() {
+        // AC-2: Reconnecting renders the hold (centered "Attaching…") + a MATCHING
+        // "Reconnecting" pill — never two loaders, never a pill that disagrees.
+        val state = fuse(RevealState.Seeding(sid, "work"), reconnectingStatus)
+        assertTrue("held → Reconnecting view state", state is SessionSurfaceState.Reconnecting)
+        assertTrue("terminal held", state.terminalHeld)
+        assertTrue("single centered loader", state.showsCenteredLoader(panesEmpty = false))
+        assertEquals("the SOLE loader is the centered hold", PrimaryLoadingSurface.CenteredAttaching, primaryLoadingSurface(state))
+        // Pill matches the surface: amber "Reconnecting".
+        assertEquals(com.pocketshell.uikit.model.ConnectionStatus.Connecting, state.toUiStatus())
+        // Both top banners suppressed while the surface owns the primary indicator.
+        val ownsPrimary = state.surfaceOwnsPrimary(panesEmpty = false)
+        assertFalse(shouldShowReconnectingProgressRow(state, ownsPrimary))
+        assertFalse(shouldShowConnectingProgressOverlay(state, ownsPrimary))
     }
 
     @Test
-    fun exactlyOnePrimaryLoadingSurfacePerInProgressState_classCoverage() {
-        // Class coverage (D31/G2): every in-progress connection state resolves to
-        // EXACTLY ONE primary loading surface — never a top banner AND the centered
-        // "Attaching…" at once. Each in-progress state ALWAYS holds the terminal
-        // (RevealState.Seeding), so each resolves to the SINGLE centered hold; the
-        // top banners are suppressed. This is the invariant the maintainer's symptom
-        // keeps regressing on, pinned for all four states plus the never-held edges.
-
-        // Beyond-grace reconnect re-dials through the controller's Connecting →
-        // status Connecting; within-grace/steady recovery → status Reconnecting;
-        // a same-host switch → status Switching; a cold connect → status Connecting.
-        val inProgressHeldStates = listOf(
-            "cold Connecting" to connectingStatus,
-            "beyond-grace reconnect (re-dial → Connecting)" to connectingStatus,
-            "Switching / Attaching" to
-                TmuxSessionViewModel.ConnectionStatus.Switching("h", 22, "u"),
-            "Reattaching / Reconnecting" to reconnectingStatus,
+    fun fusion_everyInProgressHold_resolvesToSingleCenteredLoader_classCoverage() {
+        // Class coverage (D31/G2): every in-progress hold resolves to EXACTLY ONE
+        // primary loading surface — the centered "Attaching…" — and BOTH top banners
+        // are suppressed. This is the two-loaders invariant the maintainer's symptom
+        // keeps regressing on, pinned across cold connect / warm switch / reconnect.
+        val holds = listOf(
+            "cold Connecting" to fuse(RevealState.Seeding(sid, "work"), connectingStatus),
+            "warm Switching" to
+                fuse(RevealState.Seeding(sid, "work"), TmuxSessionViewModel.ConnectionStatus.Switching("h", 22, "u")),
+            "beyond-grace Reconnecting" to fuse(RevealState.Seeding(sid, "work"), reconnectingStatus),
+            "Navigating (pre-connect)" to fuse(RevealState.Navigating(sid, "work"), TmuxSessionViewModel.ConnectionStatus.Idle),
         )
-        inProgressHeldStates.forEach { (label, status) ->
-            // Terminal held (the real in-progress reality): the SOLE loader is the
-            // centered "Attaching…"; BOTH top banners are suppressed.
+        holds.forEach { (label, state) ->
+            assertTrue("$label: terminal held", state.terminalHeld)
             assertEquals(
-                "$label must resolve to the single centered hold while the terminal is held",
+                "$label: the SOLE loader is the centered hold",
                 PrimaryLoadingSurface.CenteredAttaching,
-                primaryLoadingSurface(status, effectiveHidesTerminal = true),
+                primaryLoadingSurface(state),
             )
-            assertEquals(
-                "$label: top Connecting overlay suppressed while held",
-                false,
-                shouldShowConnectingProgressOverlay(status, effectiveHidesTerminal = true),
-            )
-            assertEquals(
-                "$label: top Reconnecting band suppressed while held",
-                false,
-                shouldShowReconnectingProgressRow(status, effectiveHidesTerminal = true),
-            )
-            // Never both banners at once regardless of hold state.
-            listOf(true, false).forEach { held ->
-                assertFalse(
-                    "$label (held=$held): the two top banners must be mutually exclusive",
-                    shouldShowConnectingProgressOverlay(status, held) &&
-                        shouldShowReconnectingProgressRow(status, held),
-                )
+            val ownsPrimary = state.surfaceOwnsPrimary(panesEmpty = false)
+            assertFalse("$label: top Connecting overlay suppressed", shouldShowConnectingProgressOverlay(state, ownsPrimary))
+            assertFalse("$label: top Reconnecting band suppressed", shouldShowReconnectingProgressRow(state, ownsPrimary))
+            // No settled failure surface for an in-progress hold.
+            assertFalse("$label: not a calm failure", state.showsCalmFailure)
+        }
+    }
+
+    @Test
+    fun fusion_liveReveal_dominates_regardlessOfPhase_withinGraceSuppression() {
+        // AC-4 (#685/#1098): a LIVE reveal is the surface authority — even if the
+        // connection phase is still Reconnecting (a within-grace silent heal), the
+        // fused state stays Live: terminal shown, GREEN pill, NO overlay/band. The
+        // load-bearing green is the SUPPRESSION (G6). Red if a phase read leaked
+        // through and flipped the surface/pill during the heal.
+        listOf(
+            reconnectingStatus,
+            connectingStatus,
+            TmuxSessionViewModel.ConnectionStatus.Connected("h", 22, "u"),
+        ).forEach { phaseStatus ->
+            val state = fuse(RevealState.Live(sid, "work", panes = emptyList()), phaseStatus)
+            assertTrue("live reveal dominates phase=$phaseStatus", state is SessionSurfaceState.Live)
+            assertFalse("terminal shown (no hold)", state.terminalHeld)
+            assertEquals("green Connected pill", com.pocketshell.uikit.model.ConnectionStatus.Connected, state.toUiStatus())
+            assertEquals("no loading surface over a live frame", PrimaryLoadingSurface.None, primaryLoadingSurface(state, panesEmpty = false))
+        }
+    }
+
+    @Test
+    fun fusion_goneTarget_calmFailure_disconnectedPill() {
+        // A target deleted elsewhere (#666) → calm failure surface + "Disconnected"
+        // pill + no spinner, all in agreement.
+        val state = fuse(RevealState.Gone(sid, "work"), TmuxSessionViewModel.ConnectionStatus.Failed("gone"))
+        assertTrue(state is SessionSurfaceState.Gone)
+        assertTrue(state.showsCalmFailure)
+        assertEquals(PrimaryLoadingSurface.None, primaryLoadingSurface(state))
+        assertEquals(com.pocketshell.uikit.model.ConnectionStatus.Error, state.toUiStatus())
+    }
+
+    @Test
+    fun fusion_contradictoryCombination_isUnrepresentable() {
+        // The keystone invariant: NO fused state can present a spinner AND a settled
+        // failure at once, and NO state can show a top banner while the surface owns
+        // the primary indicator. Enumerate every reveal×phase pair and assert the
+        // (loader, calm-failure) pair is never both-true and the banners never stack.
+        val reveals = listOf(
+            RevealState.Idle,
+            RevealState.Navigating(sid, "work"),
+            RevealState.Seeding(sid, "work"),
+            RevealState.Live(sid, "work", panes = emptyList()),
+            RevealState.Gone(sid, "work"),
+            RevealState.Error(sid, "work", retrying = false, reason = FailureReason.AuthFailed),
+        )
+        val phases = listOf(
+            ConnectionPhase.Idle,
+            ConnectionPhase.Connecting("h", 22, "u"),
+            ConnectionPhase.Warm("h", 22, "u"),
+            ConnectionPhase.Live("h", 22, "u"),
+            ConnectionPhase.Reconnecting("h", 22, "u", 1, 3, 0L),
+            ConnectionPhase.Failed,
+        )
+        reveals.forEach { reveal ->
+            phases.forEach { phase ->
+                val state = sessionSurfaceState(reveal, phase, sid)
+                listOf(true, false).forEach { panesEmpty ->
+                    // A calm failure and a centered loader can NEVER both paint.
+                    assertFalse(
+                        "reveal=$reveal phase=$phase panesEmpty=$panesEmpty: loader+failure both true",
+                        state.showsCalmFailure && state.showsCenteredLoader(panesEmpty),
+                    )
+                    val ownsPrimary = state.surfaceOwnsPrimary(panesEmpty)
+                    // The two top banners are mutually exclusive AND suppressed while
+                    // the surface owns the primary indicator.
+                    assertFalse(
+                        "reveal=$reveal phase=$phase: both top banners at once",
+                        shouldShowConnectingProgressOverlay(state, ownsPrimary) &&
+                            shouldShowReconnectingProgressRow(state, ownsPrimary),
+                    )
+                    // Pill agrees with the surface: a calm-failure surface ALWAYS reads
+                    // Error; a live surface NEVER reads Error.
+                    if (state.showsCalmFailure) {
+                        assertEquals(
+                            "failure surface must read Disconnected pill",
+                            com.pocketshell.uikit.model.ConnectionStatus.Error,
+                            state.toUiStatus(),
+                        )
+                    }
+                }
             }
         }
     }
 
     @Test
-    fun steadyStatesHaveNoPrimaryLoadingSurface() {
-        // Connected / Idle / Failed with a live (not-held) frame have no primary
-        // loading surface — no spinner falsely implying in-flight work.
-        listOf(
-            TmuxSessionViewModel.ConnectionStatus.Connected("h", 22, "u"),
-            TmuxSessionViewModel.ConnectionStatus.Idle,
-            TmuxSessionViewModel.ConnectionStatus.Failed("boom"),
-        ).forEach { status ->
-            assertEquals(
-                "no loading surface for steady $status",
-                PrimaryLoadingSurface.None,
-                primaryLoadingSurface(status, effectiveHidesTerminal = false),
-            )
+    fun fusion_failedState_carriesTypedReason_notRawString_curatedSentence() {
+        // AC-3: the failed state carries a TYPED FailureReason (no raw string field),
+        // and the screen maps it to ONE calm curated sentence — never raw exception
+        // text. Class coverage over every reason.
+        val cases = mapOf(
+            FailureReason.AuthFailed to "Authentication failed — check your key. Tap Reconnect to retry.",
+            FailureReason.HostUnresolved to "Host could not be resolved. Tap Reconnect to retry.",
+            FailureReason.ServerRestarted to "The tmux server restarted — all sessions ended. Tap Reconnect.",
+            FailureReason.SessionEnded to "This session ended. Tap Reconnect.",
+            FailureReason.KeyMissing to "Private key file not found. Tap Reconnect to retry.",
+            FailureReason.Unreachable(retryable = true) to "Connection lost. Tap Reconnect to retry.",
+        )
+        cases.forEach { (reason, expected) ->
+            val state = SessionSurfaceState.Failed(sid, "work", reason)
+            assertEquals("curated sentence for $reason", expected, failureReasonSentence(state.reason))
+            val sentence = failureReasonSentence(state.reason)
+            assertFalse("no raw error: prefix", sentence.startsWith("error:"))
+            assertFalse("no exception class name", sentence.contains("Exception"))
+            assertTrue("stays a calm reconnect prompt", sentence.contains("Reconnect"))
         }
     }
 
-    // --- Issue #1322: Slice 1 — render RevealState.Error/Gone DISTINCTLY (not as
-    // "Attaching…"), curate ALL connect-failure messages, and make EVERY connection
-    // state render exactly ONE coherent set of controls/indicators. These pin the
-    // pure decision reducers the screen uses. Each is red→green by reverting the
-    // corresponding reducer body.
-
-    private val sid = SessionId("host/work")
-
     @Test
-    fun revealHardFailure_goneAndRetryExhaustedError_areHardFailures() {
-        // Class coverage (G2): the two hard reveal failures — a target Gone, and an
-        // Error whose retry is EXHAUSTED (the #1321 past-grace transport drop) — must
-        // classify as hard failures so the surface paints the calm placeholder, NOT
-        // the "Attaching…" spinner.
-        assertTrue(revealIsHardFailure(RevealState.Gone(sid, "work")))
-        assertTrue(revealIsHardFailure(RevealState.Error(sid, "work", retrying = false)))
-    }
-
-    @Test
-    fun revealHardFailure_retryingErrorAndLoadingStates_areNotHardFailures() {
-        // The calm healing window (Error while still retrying) and the ordinary
-        // loading states keep their reconnecting/attaching hold — they are NOT hard
-        // failures.
-        assertFalse(revealIsHardFailure(RevealState.Error(sid, "work", retrying = true)))
-        assertFalse(revealIsHardFailure(RevealState.Seeding(sid, "work")))
-        assertFalse(revealIsHardFailure(RevealState.Navigating(sid, "work")))
-        assertFalse(revealIsHardFailure(RevealState.Live(sid, "work", panes = emptyList())))
-        assertFalse(revealIsHardFailure(RevealState.Idle))
-    }
-
-    @Test
-    fun surface_hardRevealFailure_paintsCalmFailureNotAttachingSpinner_1321Repro() {
-        // #1321 EXACT reproduction (defect A): a past-grace transport drop yields
-        // RevealState.Error(retrying=false) → the terminal is held
-        // (effectiveHidesTerminal == true) but the surface must paint the CALM
-        // failure placeholder (no spinner), NEVER the "Attaching…" hold. Red on base:
-        // revealIsHardFailure returned false for every state, so this collapsed to
-        // the centered "Attaching…" loader.
-        val failedStatus = TmuxSessionViewModel.ConnectionStatus.Failed(
-            "Connection lost. Tap Reconnect to retry.",
-        )
-        assertTrue(
-            "the honest hard failure must paint the calm placeholder",
-            surfaceShowsCalmFailure(
-                effectiveHidesTerminal = true,
-                revealHardFailure = true,
-                status = failedStatus,
-            ),
-        )
-        assertFalse(
-            "the hard failure must NOT paint a centered loader spinner",
-            surfaceShowsCenteredLoader(
-                effectiveHidesTerminal = true,
-                revealHardFailure = true,
-                status = failedStatus,
-                panesEmpty = true,
-            ),
-        )
-        // Pill + surface + band AGREE: the top connecting/reconnecting banner is
-        // suppressed for this state (surface owns the primary indicator), so there is
-        // no "Connecting…/Reconnecting…" line contradicting the "Disconnected" pill.
-        assertTrue(
-            surfaceOwnsPrimaryIndicator(
-                effectiveHidesTerminal = true,
-                revealHardFailure = true,
-                status = failedStatus,
-                panesEmpty = true,
-            ),
-        )
-        assertEquals(
-            PrimaryLoadingSurface.None,
-            primaryLoadingSurface(failedStatus, effectiveHidesTerminal = true, revealHardFailure = true),
-        )
+    fun surfaceReconnectButton_visibleOnlyOnIdleDrop_notWhileFailedOrInProgress() {
+        // The bottom Reconnect button is the sole affordance ONLY on a band-less Idle
+        // drop — hidden on Failed/Gone (the band owns it) and while connecting.
+        assertTrue(surfaceReconnectButtonVisible(SessionSurfaceState.Idle))
+        assertTrue(surfaceReconnectButtonVisible(SessionSurfaceState.Live(sid, "work", emptyList())))
+        assertFalse(surfaceReconnectButtonVisible(SessionSurfaceState.Failed(sid, "work", FailureReason.Unreachable(true))))
+        assertFalse(surfaceReconnectButtonVisible(SessionSurfaceState.Gone(sid, "work")))
+        assertFalse(surfaceReconnectButtonVisible(SessionSurfaceState.Connecting(sid, "work", "h", 22, "u")))
+        assertFalse(surfaceReconnectButtonVisible(SessionSurfaceState.Attaching(sid, "work", "h", 22, "u")))
+        assertFalse(surfaceReconnectButtonVisible(SessionSurfaceState.Reconnecting(sid, "work", "h", 22, "u", 1, 3, 0L)))
     }
 
     @Test
     fun connectFailureMessage_generalCase_isCuratedNeverRawExceptionText() {
-        // Defect B (#1321): the reported RAW `TmuxClientException: failed to preflight
-        // tmux has-session ... transport is closed` leaked to the UI. The general
-        // connect-failure case must fold into ONE calm curated prompt — never the
-        // `error: <Class>: <message>` format. This asserts the curated string the
-        // VM now stores as Failed.message (pinned end-to-end in
-        // TmuxSessionOpenFailedReconnectTest). Red on base: the message was
-        // `error: TmuxClientException: ...`.
-        val curated = "Connection lost. Tap Reconnect to retry."
-        assertFalse(
-            "curated message must not carry the raw `error: <Class>:` prefix",
-            curated.startsWith("error:"),
-        )
-        assertFalse("curated message must not name the exception class", curated.contains("Exception"))
-        assertFalse("curated message must not leak transport jargon", curated.contains("transport is closed"))
-        assertTrue("curated message must stay a calm reconnect prompt", curated.contains("Reconnect"))
-    }
-
-    @Test
-    fun failedState_exactlyOneReconnectControl_noBottomButtonDuplicate_screenshotA() {
-        // Screenshot A (coordinator scope-expansion): the Failed/Disconnected state
-        // showed TWO reconnect controls — the "Tap to reconnect" band link AND the
-        // bottom "Reconnect" button. The band owns the SINGLE affordance for Failed,
-        // so the bottom surface button MUST be suppressed. Red on base: the #890 gate
-        // did not exclude Failed, so the bottom button showed on top of the band.
-        val failed = TmuxSessionViewModel.ConnectionStatus.Failed("Connection lost. Tap Reconnect to retry.")
-        assertFalse(
-            "no bottom Reconnect button on Failed — the band's 'Tap to reconnect' is the sole affordance",
-            surfaceReconnectButtonVisible(failed),
-        )
-        // The bottom button IS the sole affordance on the band-less Idle drop.
-        assertTrue(
-            "the bottom Reconnect button is the sole affordance on Idle (no band)",
-            surfaceReconnectButtonVisible(TmuxSessionViewModel.ConnectionStatus.Idle),
-        )
-        // And it stays hidden while a connect/reconnect is in progress (#890).
-        assertFalse(surfaceReconnectButtonVisible(TmuxSessionViewModel.ConnectionStatus.Connecting("h", 22, "u")))
-        assertFalse(surfaceReconnectButtonVisible(reconnectingStatus))
-        assertFalse(surfaceReconnectButtonVisible(TmuxSessionViewModel.ConnectionStatus.Switching("h", 22, "u")))
-    }
-
-    @Test
-    fun reconnecting_waitingForPanesRing_isSoleIndicator_topBannerAndBoxSpinnerSuppressed_screenshotB() {
-        // Screenshot B (#750 regression): a Reconnecting state where the reveal is
-        // live (effectiveHidesTerminal == false) but no panes have arrived yet
-        // (panesEmpty) stacked THREE indicators — the top ReconnectingProgressRow,
-        // the centered "waiting for tmux panes…" ring, and the pull box spinner.
-        // The waiting ring is the SOLE loader, so it must own the primary indicator:
-        // the top banner AND the box spinner are suppressed. Red on base:
-        // surfaceShowsCenteredLoader only counted effectiveHidesTerminal, missing the
-        // waiting ring — so all three fired.
-        assertTrue(
-            "the waiting-for-panes ring is a centered loader",
-            surfaceShowsCenteredLoader(
-                effectiveHidesTerminal = false,
-                revealHardFailure = false,
-                status = reconnectingStatus,
-                panesEmpty = true,
-            ),
-        )
-        assertTrue(
-            "the surface owns the primary indicator, so the top banner is suppressed",
-            surfaceOwnsPrimaryIndicator(
-                effectiveHidesTerminal = false,
-                revealHardFailure = false,
-                status = reconnectingStatus,
-                panesEmpty = true,
-            ),
-        )
-        // The banner-suppression reducer sees the broadened "surface owns it" gate
-        // and returns the centered-hold verdict (banners suppressed), never the
-        // ReconnectingBand — so the top bar cannot stack on the waiting ring.
-        assertFalse(
-            shouldShowReconnectingProgressRow(reconnectingStatus, effectiveHidesTerminal = true),
-        )
-    }
-
-    @Test
-    fun reconnecting_liveFrameKept_keepsTopBanner_asSoleIndicator() {
-        // The complementary edge: a Reconnecting state that keeps a LIVE frame
-        // (terminal not held AND panes present) shows NEITHER a surface loader nor a
-        // failure, so the top ReconnectingProgressRow is the SOLE indicator — never
-        // stripped to zero.
-        assertFalse(
-            surfaceOwnsPrimaryIndicator(
-                effectiveHidesTerminal = false,
-                revealHardFailure = false,
-                status = reconnectingStatus,
-                panesEmpty = false,
-            ),
-        )
-        assertTrue(
-            shouldShowReconnectingProgressRow(reconnectingStatus, effectiveHidesTerminal = false),
-        )
+        // Defect B (#1321): the reported RAW `TmuxClientException: ... transport is
+        // closed` leaked to the UI. The general (closed-transport) case classifies to
+        // a retryable Unreachable → the calm curated prompt, never `error: <Class>:`.
+        val curated = failureReasonSentence(FailureReason.Unreachable(retryable = true))
+        assertFalse("no raw `error:` prefix", curated.startsWith("error:"))
+        assertFalse("no exception class name", curated.contains("Exception"))
+        assertFalse("no transport jargon", curated.contains("transport is closed"))
+        assertTrue("stays a calm reconnect prompt", curated.contains("Reconnect"))
     }
 
     @Test
@@ -2325,14 +2238,14 @@ class TmuxSessionScreenTest {
             "Failed-with-target must enable Reconnect (the dropped-session escape hatch)",
             reconnectKebabEnabled(
                 canReconnect = true,
-                status = TmuxSessionViewModel.ConnectionStatus.Failed("Disconnected"),
+                surfaceState = SessionSurfaceState.Failed(sid, "work", FailureReason.Unreachable(true)),
             ),
         )
         assertTrue(
-            "a (possibly stale) Connected with a target still enables a manual reconnect",
+            "a (possibly stale) Live session with a target still enables a manual reconnect",
             reconnectKebabEnabled(
                 canReconnect = true,
-                status = TmuxSessionViewModel.ConnectionStatus.Connected("h", 22, "u"),
+                surfaceState = SessionSurfaceState.Live(sid, "work", emptyList()),
             ),
         )
     }
@@ -2342,14 +2255,14 @@ class TmuxSessionScreenTest {
         // No target to reconnect to (VM never opened / initial-connect race) — the item
         // must be disabled so a tap is never a silent no-op (AC4).
         listOf(
-            TmuxSessionViewModel.ConnectionStatus.Idle,
-            TmuxSessionViewModel.ConnectionStatus.Failed("boom"),
-            TmuxSessionViewModel.ConnectionStatus.Connected("h", 22, "u"),
-        ).forEach { status ->
+            SessionSurfaceState.Idle,
+            SessionSurfaceState.Failed(sid, "work", FailureReason.Unreachable(true)),
+            SessionSurfaceState.Live(sid, "work", emptyList()),
+        ).forEach { state ->
             assertEquals(
-                "no target → Reconnect disabled for $status",
+                "no target → Reconnect disabled for $state",
                 false,
-                reconnectKebabEnabled(canReconnect = false, status = status),
+                reconnectKebabEnabled(canReconnect = false, surfaceState = state),
             )
         }
     }
@@ -2374,7 +2287,7 @@ class TmuxSessionScreenTest {
             "the kebab Reconnect must be enabled while dropped-with-target (the escape hatch)",
             reconnectKebabEnabled(
                 canReconnect = true,
-                status = TmuxSessionViewModel.ConnectionStatus.Failed("Disconnected"),
+                surfaceState = SessionSurfaceState.Failed(sid, "work", FailureReason.Unreachable(true)),
             ),
         )
         // While dropped, the queue does NOT flush (the message stays queued).
@@ -2408,14 +2321,14 @@ class TmuxSessionScreenTest {
         // redundant re-dial that yanks an already-recovering session, so the item is
         // disabled even with a target present (AC: "sensible state mid-reconnect").
         listOf(
-            TmuxSessionViewModel.ConnectionStatus.Connecting("h", 22, "u"),
-            TmuxSessionViewModel.ConnectionStatus.Switching("h", 22, "u"),
-            reconnectingStatus,
-        ).forEach { status ->
+            SessionSurfaceState.Connecting(sid, "work", "h", 22, "u"),
+            SessionSurfaceState.Attaching(sid, "work", "h", 22, "u"),
+            SessionSurfaceState.Reconnecting(sid, "work", "h", 22, "u", 1, 3, 0L),
+        ).forEach { state ->
             assertEquals(
-                "in-flight → Reconnect disabled for $status",
+                "in-flight → Reconnect disabled for $state",
                 false,
-                reconnectKebabEnabled(canReconnect = true, status = status),
+                reconnectKebabEnabled(canReconnect = true, surfaceState = state),
             )
         }
     }

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
@@ -21,6 +21,9 @@ import com.pocketshell.app.session.SessionTab
 import com.pocketshell.app.sessions.ActiveTmuxClients
 import com.pocketshell.core.agents.AgentDetection
 import com.pocketshell.core.agents.AgentKind
+import com.pocketshell.core.connection.RevealState
+import com.pocketshell.core.connection.SessionId
+import com.pocketshell.core.connection.sessionSurfaceState
 import com.pocketshell.core.agents.ConversationEvent
 import com.pocketshell.core.agents.ConversationRole
 import com.pocketshell.core.agents.MessageSendState
@@ -6806,15 +6809,23 @@ class TmuxSessionViewModelTest {
                     "observed=$emittedConnectionStatuses",
                 connectionFailureStatuses.isEmpty(),
             )
+            // Issue #1326 (S3): the pill now derives from the fused
+            // [SessionSurfaceState]. Map each emitted status through the SAME fusion
+            // the screen uses (a held reveal takes the status's pill flavor) to prove
+            // the breadcrumb never flips to Reconnecting/Disconnected on overflow.
+            val pillSid = SessionId("codex/overflow")
+            fun TmuxSessionViewModel.ConnectionStatus.toPillUi() =
+                sessionSurfaceState(RevealState.Seeding(pillSid, "s"), connectionPhaseOf(this), pillSid)
+                    .toUiStatus()
             val disconnectUiStatuses = emittedConnectionStatuses
-                .map { it.toUiStatus() }
+                .map { it.toPillUi() }
                 .filter { uiStatus ->
                     uiStatus == com.pocketshell.uikit.model.ConnectionStatus.Connecting ||
                         uiStatus == com.pocketshell.uikit.model.ConnectionStatus.Error
                 }
             assertTrue(
                 "Codex-like output overflow must not map to the breadcrumb Reconnecting/Disconnected UI; " +
-                    "observed=${emittedConnectionStatuses.map { it.toUiStatus() }}",
+                    "observed=${emittedConnectionStatuses.map { it.toPillUi() }}",
                 disconnectUiStatuses.isEmpty(),
             )
             assertTrue(
@@ -15410,16 +15421,16 @@ class TmuxSessionViewModelTest {
             "same-host switch must never show the blanking Connecting overlay",
             midStatus is TmuxSessionViewModel.ConnectionStatus.Connecting,
         )
-        // Issue #661: a CROSS-session switch must NOT paint the previous
+        // Issue #661/#1326: a CROSS-session switch must NOT paint the previous
         // session's frame — not even one frame. #634's keep-frame is reversed
-        // for the cross-session case: the surface is HIDDEN
-        // ([switchHidesTerminal] = true) and the rendered panes are blanked,
-        // so the screen shows the "Attaching" loading state instead of the
-        // leaving session's content.
+        // for the cross-session case: the id-keyed reveal machine HOLDS the surface
+        // (revealState is not Live) and the rendered panes are blanked, so the
+        // screen shows the "Attaching" loading state instead of the leaving
+        // session's content.
         assertTrue(
-            "cross-session switch must hide the terminal surface (loading state) " +
+            "cross-session switch must hold the terminal surface (loading state) " +
                 "so the previous session's frame is never painted",
-            vm.switchHidesTerminal.value,
+            vm.revealState.value !is RevealState.Live,
         )
         assertEquals(
             "previous session's frame must NOT stay painted during a cross-session " +
@@ -15446,9 +15457,9 @@ class TmuxSessionViewModelTest {
         // Issue #661: the terminal surface is revealed only AFTER the new
         // session's panes are seeded — and it is the NEW session's content.
         assertFalse(
-            "the terminal surface must be revealed (switchHidesTerminal=false) " +
+            "the terminal surface must be revealed (revealState Live) " +
                 "once the new session's panes are seeded",
-            vm.switchHidesTerminal.value,
+            vm.revealState.value !is RevealState.Live,
         )
         assertEquals(
             "viewport must swap to the new session's panes after attach",
@@ -15808,8 +15819,8 @@ class TmuxSessionViewModelTest {
         // Issue #661 (reverses #437 slice A / #634 keep-frame for the
         // cross-session case): a same-host fast switch to a DIFFERENT session
         // must NEVER paint the leaving session's frame — not even one frame.
-        // The previous frame is BLANKED and the terminal surface is HIDDEN
-        // ([switchHidesTerminal] = true, the screen shows the "Attaching"
+        // The previous frame is BLANKED and the reveal machine HOLDS the terminal
+        // surface (revealState not Live, the screen shows the "Attaching"
         // loading state) until the new session's panes reconcile and reveal.
         // This is the maintainer's refined preference (hard-cut, per D22):
         // we no longer keep the previous frame painted on a cross-session

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionWarmOpenTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionWarmOpenTest.kt
@@ -1,6 +1,7 @@
 package com.pocketshell.app.tmux
 
 import com.pocketshell.app.sessions.ActiveTmuxClients
+import com.pocketshell.core.connection.RevealState
 import com.pocketshell.core.ssh.ExecResult
 import com.pocketshell.core.ssh.KnownHostsPolicy
 import com.pocketshell.core.ssh.SshKey
@@ -1263,14 +1264,14 @@ class TmuxSessionWarmOpenTest {
      * path (session A live → connect to B on the same warm host) and asserts the
      * no-flash invariant on the EXACT state the screen renders:
      *
-     *   1. [switchHidesTerminal] is raised (true) while the switch is in flight —
+     *   1. the reveal machine HOLDS the surface (revealState not Live) while the switch is in flight —
      *      the screen renders the loading placeholder, never the terminal.
-     *   2. It is NEVER the case that [switchHidesTerminal] is true while the
+     *   2. It is NEVER the case that the surface is held while the
      *      LEAVING session's pane (`%1`) is still in the rendered [panes] — i.e.
      *      the previous session's frame is blanked the instant the switch begins
      *      and is never re-published (the #634 keep-frame is removed for the
      *      cross-session case).
-     *   3. The terminal is revealed ([switchHidesTerminal] back to false) only
+     *   3. The terminal is revealed (revealState becomes Live) only
      *      AFTER the NEW session's panes are seeded, and the final rendered pane
      *      is the new session's pane (`%2`), never the previous one.
      */
@@ -1308,7 +1309,7 @@ class TmuxSessionWarmOpenTest {
         )
         assertFalse(
             "no switch is in flight before the cross-session switch begins",
-            vm.switchHidesTerminal.value,
+            vm.revealState.value !is RevealState.Live,
         )
 
         // ---- Record the EXACT (hidesTerminal, rendered-pane-ids) state stream
@@ -1318,7 +1319,8 @@ class TmuxSessionWarmOpenTest {
         val renderStates = java.util.Collections.synchronizedList(mutableListOf<RenderState>())
         val hidesSeen = java.util.Collections.synchronizedList(mutableListOf<Boolean>())
         val stateCollector = launch {
-            vm.switchHidesTerminal.collect { hides ->
+            vm.revealState.collect { reveal ->
+                val hides = reveal !is RevealState.Live
                 hidesSeen.add(hides)
                 renderStates.add(RenderState(hides, vm.panes.value.map { it.paneId }))
             }
@@ -1326,7 +1328,7 @@ class TmuxSessionWarmOpenTest {
         val panesCollector = launch {
             vm.panes.collect { panes ->
                 renderStates.add(
-                    RenderState(vm.switchHidesTerminal.value, panes.map { it.paneId }),
+                    RenderState(vm.revealState.value !is RevealState.Live, panes.map { it.paneId }),
                 )
             }
         }
@@ -1350,7 +1352,7 @@ class TmuxSessionWarmOpenTest {
 
         // (1) The switch hid the terminal surface while it was in flight.
         assertTrue(
-            "a cross-session switch must raise switchHidesTerminal so the screen " +
+            "a cross-session switch must hold the surface so the screen " +
                 "shows the loading state instead of the leaving frame; hides seen: $hidesSeen",
             hidesSeen.contains(true),
         )
@@ -1369,9 +1371,9 @@ class TmuxSessionWarmOpenTest {
 
         // (3) The terminal is revealed only with the NEW session's content.
         assertFalse(
-            "the switch must reveal the terminal (switchHidesTerminal=false) once " +
-                "the new session's panes are seeded, got hidden=${vm.switchHidesTerminal.value}",
-            vm.switchHidesTerminal.value,
+            "the switch must reveal the terminal (revealState Live) once " +
+                "the new session's panes are seeded, got held=${vm.revealState.value !is RevealState.Live}",
+            vm.revealState.value !is RevealState.Live,
         )
         assertTrue(
             "the switch must reach Connected, got ${vm.connectionStatus.value}",
@@ -1440,7 +1442,7 @@ class TmuxSessionWarmOpenTest {
         // pane's emulator never paints. #661's O(1) reveal gates on the active
         // pane's single capture — without this guard it would flip to Connected
         // with a BLACK active pane and no reconnecting band. Here the reveal must
-        // KEEP the loading overlay (switchHidesTerminal=true) and RETRY the seed
+        // KEEP the loading hold (revealState not Live) and RETRY the seed
         // rather than reveal a black Connected pane.
         val live = AlwaysConnectedSession(id = "live")
         val connector = SingleSessionConnector(live)
@@ -1479,13 +1481,13 @@ class TmuxSessionWarmOpenTest {
         )
 
         // (1) The reveal must NOT show a black Connected pane: the loading
-        // overlay (switchHidesTerminal) stays raised so the user sees the calm
+        // hold (revealState not Live) stays raised so the user sees the calm
         // "Attaching…" state, never a black pane behind a green dot.
         assertTrue(
             "a Connected session with an empty/blank active pane must KEEP the " +
-                "loading overlay (switchHidesTerminal=true), never reveal a black " +
-                "Connected pane; got switchHidesTerminal=${vm.switchHidesTerminal.value}",
-            vm.switchHidesTerminal.value,
+                "loading hold (revealState not Live), never reveal a black " +
+                "Connected pane; got held=${vm.revealState.value !is RevealState.Live}",
+            vm.revealState.value !is RevealState.Live,
         )
 
         // (2) The reveal gate must retry at its own bound without multiplying
@@ -1505,7 +1507,7 @@ class TmuxSessionWarmOpenTest {
         // Issue #693: the recovery side of the never-reveal-black gate. The
         // active pane's first capture is empty (flaky link) but a retry within
         // the gate's bound succeeds — the gate must then reveal the REAL content
-        // (switchHidesTerminal cleared), not stay stuck on the loading overlay.
+        // (revealState Live), not stay stuck on the loading overlay.
         val live = AlwaysConnectedSession(id = "live")
         val connector = SingleSessionConnector(live)
         val leaseManager =
@@ -1554,7 +1556,7 @@ class TmuxSessionWarmOpenTest {
         assertFalse(
             "the active pane recovered content within the gate's retry bound, so " +
                 "the loading overlay must be cleared",
-            vm.switchHidesTerminal.value,
+            vm.revealState.value !is RevealState.Live,
         )
         assertTrue(
             "the recovered content must be on the pane's grid",

--- a/shared/core-connection/src/main/java/com/pocketshell/core/connection/FailureReason.kt
+++ b/shared/core-connection/src/main/java/com/pocketshell/core/connection/FailureReason.kt
@@ -1,0 +1,129 @@
+package com.pocketshell.core.connection
+
+/**
+ * Slice S3 (epic #1331, issue #1326): the TYPED reason a session connect/attach
+ * ended in the honest failure surface. This is the single failure payload the
+ * view state ([SessionSurfaceState.Failed]) carries — it replaces the raw
+ * `"error: ${class}: ${message}"` string the #1321 screenshot leaked. The screen
+ * maps a [FailureReason] to ONE calm, curated sentence at render time; the raw
+ * exception never reaches the UI (it stays in the diagnostic logs).
+ *
+ * Producing the reason is [classifyFailure]'s job — the SINGLE `Throwable →
+ * FailureReason` classifier that supersedes the VM's `nonRetryableReason` /
+ * `isNonRetryableConnectFailure` string table. Keeping the reason a closed type
+ * (not a free string) is what makes the pill / surface / band derive one coherent
+ * failure screen instead of three independently-worded ones.
+ */
+sealed interface FailureReason {
+    /** sshj `UserAuthException` — the key/credentials were rejected. */
+    data object AuthFailed : FailureReason
+
+    /** `java.net.UnknownHostException` — DNS could not resolve the host. */
+    data object HostUnresolved : FailureReason
+
+    /** The tmux server died — all sessions ended (`TmuxServerDeadException`). */
+    data object ServerRestarted : FailureReason
+
+    /** The target tmux session no longer exists on the host (killed elsewhere). */
+    data object SessionEnded : FailureReason
+
+    /** The configured private key file was not found. */
+    data object KeyMissing : FailureReason
+
+    /**
+     * A generic "could not reach / lost the connection" failure. [retryable] is
+     * true for a transient transport drop (a closed-transport / preflight failure,
+     * a socket tear-down) that another dial can plausibly fix; false when the
+     * auto-reconnect ladder has genuinely EXHAUSTED and only a manual retry remains.
+     */
+    data class Unreachable(val retryable: Boolean) : FailureReason
+}
+
+/**
+ * Whether AUTO-retry can plausibly recover from this reason. Only a transient
+ * [FailureReason.Unreachable] with `retryable == true` is auto-retryable; every
+ * config-level reason (auth, host, key) and the exhausted/dead cases are not (the
+ * user must act — fix the key, recreate the session, tap Reconnect). This mirrors
+ * the old `isNonRetryableConnectFailure` boolean, now derived from the typed reason.
+ */
+val FailureReason.retryable: Boolean
+    get() = when (this) {
+        is FailureReason.Unreachable -> retryable
+        FailureReason.AuthFailed,
+        FailureReason.HostUnresolved,
+        FailureReason.ServerRestarted,
+        FailureReason.SessionEnded,
+        FailureReason.KeyMissing,
+        -> false
+    }
+
+/**
+ * Simple class names of connect-failure causes that retrying cannot fix. Ported
+ * verbatim from `TmuxSessionViewModel.NON_RETRYABLE_FAILURE_CLASS_NAMES` (#440,
+ * #998) — matched against the cause chain by [classifyFailure]. Matched on the
+ * simple name so this module need not depend on sshj / core-tmux exception types.
+ */
+private val NON_RETRYABLE_FAILURE_CLASS_NAMES: Set<String> = setOf(
+    "UserAuthException",
+    "UnknownHostException",
+    "TmuxServerDeadException",
+)
+
+/** Substring identifying the "private key file not found" IOException (#440). */
+private const val MISSING_KEY_MESSAGE_FRAGMENT: String = "Private key file not found"
+
+/**
+ * Substrings identifying a "the target tmux session is gone" failure surfaced as
+ * a generic exception message (the host still answers, but `has-session` reports
+ * the session no longer exists). Kept narrow so a transient socket tear-down is
+ * NOT misread as a permanent SessionEnded.
+ */
+private val SESSION_ENDED_MESSAGE_FRAGMENTS: List<String> = listOf(
+    "no such session",
+    "session not found",
+    "can't find session",
+    "session ended",
+)
+
+/**
+ * The SINGLE `Throwable → FailureReason` classifier (issue #1326, S3). Walks the
+ * cause chain (guarding against cycles) and maps the first recognised cause to a
+ * typed reason:
+ *
+ *  - `UserAuthException` → [FailureReason.AuthFailed]
+ *  - `UnknownHostException` → [FailureReason.HostUnresolved]
+ *  - `TmuxServerDeadException` → [FailureReason.ServerRestarted]
+ *  - a "private key file not found" message → [FailureReason.KeyMissing]
+ *  - a "session gone" message → [FailureReason.SessionEnded]
+ *  - any other non-retryable class → [FailureReason.Unreachable]`(retryable = false)`
+ *  - anything else (incl. a null cause, and the closed-transport / has-session
+ *    preflight case the #1321 screenshot leaked) → [FailureReason.Unreachable]`(retryable = true)`
+ *
+ * The default is the CALM, retryable case — a closed-transport drop is exactly the
+ * recoverable "Tap Reconnect" state, never a scary raw exception.
+ */
+fun classifyFailure(cause: Throwable?): FailureReason {
+    var current: Throwable? = cause
+    val seen = HashSet<Throwable>()
+    while (current != null && seen.add(current)) {
+        when (current.javaClass.simpleName) {
+            "UserAuthException" -> return FailureReason.AuthFailed
+            "UnknownHostException" -> return FailureReason.HostUnresolved
+            "TmuxServerDeadException" -> return FailureReason.ServerRestarted
+        }
+        val message = current.message
+        if (message != null) {
+            if (message.contains(MISSING_KEY_MESSAGE_FRAGMENT, ignoreCase = true)) {
+                return FailureReason.KeyMissing
+            }
+            if (SESSION_ENDED_MESSAGE_FRAGMENTS.any { message.contains(it, ignoreCase = true) }) {
+                return FailureReason.SessionEnded
+            }
+        }
+        if (current.javaClass.simpleName in NON_RETRYABLE_FAILURE_CLASS_NAMES) {
+            return FailureReason.Unreachable(retryable = false)
+        }
+        current = current.cause
+    }
+    return FailureReason.Unreachable(retryable = true)
+}

--- a/shared/core-connection/src/main/java/com/pocketshell/core/connection/RevealStateMachine.kt
+++ b/shared/core-connection/src/main/java/com/pocketshell/core/connection/RevealStateMachine.kt
@@ -174,7 +174,16 @@ class RevealStateMachine {
                 RevealState.Gone(target, targetName)
 
             is ConnectionState.Unreachable ->
-                RevealState.Error(target, targetName, retrying = false)
+                // The controller-driven exhaust ladder carries no cause here (core
+                // [ConnectionState.Unreachable] is opaque host/id), so the reason is
+                // the generic non-retryable Unreachable. A cause-typed reason arrives
+                // through [onTerminalError] instead (#1185 direct-drive path).
+                RevealState.Error(
+                    target,
+                    targetName,
+                    retrying = false,
+                    reason = FailureReason.Unreachable(retryable = false),
+                )
         }
         if (next != _state.value) {
             _state.value = next
@@ -235,13 +244,16 @@ class RevealStateMachine {
      * now moves BOTH holders to an honest error in lockstep — never a red pill
      * over a live "Attaching…" spinner.
      */
-    fun onTerminalError(targetId: SessionId) {
+    fun onTerminalError(
+        targetId: SessionId,
+        reason: FailureReason = FailureReason.Unreachable(retryable = false),
+    ) {
         val target = currentTargetId ?: return
         if (targetId != target) {
             return
         }
         val targetName = _state.value.targetNameOrNull() ?: return
-        val next = RevealState.Error(target, targetName, retrying = false)
+        val next = RevealState.Error(target, targetName, retrying = false, reason = reason)
         if (next != _state.value) {
             _state.value = next
         }
@@ -311,6 +323,12 @@ sealed interface RevealState {
         val targetId: SessionId,
         val targetName: String,
         val retrying: Boolean,
+        /**
+         * Issue #1326 (S3): the TYPED failure reason the view state carries — never
+         * a raw exception string. Only meaningful for the settled honest error
+         * ([retrying] == false); the calm heal window ([retrying] == true) ignores it.
+         */
+        val reason: FailureReason = FailureReason.Unreachable(retryable = false),
     ) : RevealState
 }
 

--- a/shared/core-connection/src/main/java/com/pocketshell/core/connection/SessionSurfaceState.kt
+++ b/shared/core-connection/src/main/java/com/pocketshell/core/connection/SessionSurfaceState.kt
@@ -1,0 +1,267 @@
+package com.pocketshell.core.connection
+
+/**
+ * Slice S3 (epic #1331, issue #1326): the SINGLE view-facing session state. The
+ * session screen renders THREE regions — the header status pill, the surface
+ * (terminal / loader / calm-failure placeholder), and the under-header band — and
+ * before S3 each read a DIFFERENT source (`revealState`, `displayConnectionStatus`,
+ * the legacy `_switchHidesTerminal` flag), so contradictory screens ("Disconnected"
+ * pill + "Attaching…" spinner + a raw exception) were *representable* and recurred
+ * (#641, #750×4, #1185, #1321).
+ *
+ * [SessionSurfaceState] fuses the id-keyed [RevealState] (the SURFACE authority —
+ * it owns the drop-by-id rule, the hard-failure and the within-grace live-frame
+ * hold) with the [ConnectionPhase] projected from the connection status (the PILL /
+ * progress payload — host/port/user, reconnect attempt) into ONE coherent state.
+ * The pill, the surface and the band all derive from a single `when (state)`, so a
+ * contradictory (pill, surface, band) triple is no longer type-representable.
+ *
+ * This is the VIEW-axis consolidation only (S3). It deliberately does NOT collapse
+ * the parallel projection authority (that is S7 / #766) — the inline machine keeps
+ * feeding the [ConnectionPhase]; S3 just makes the RENDER read one state.
+ */
+sealed interface SessionSurfaceState {
+    /** Before the first navigation — no target, empty surface. */
+    data object Idle : SessionSurfaceState
+
+    /** Nav arrived; nothing connecting yet. Surface = loader, pill = "Connecting". */
+    data class Navigating(val targetId: SessionId, val targetName: String) : SessionSurfaceState
+
+    /** A cold first-connect is in flight. Surface = centered loader, pill = "Reconnecting"/amber. */
+    data class Connecting(
+        val targetId: SessionId,
+        val targetName: String,
+        val host: String,
+        val port: Int,
+        val user: String,
+    ) : SessionSurfaceState
+
+    /**
+     * A warm same-host switch / a Live lifecycle whose active pane is not yet
+     * seeded — the terminal is held behind the centered "Attaching…" loader while
+     * the pill stays green (the session is up; we are only revealing its pane).
+     */
+    data class Attaching(
+        val targetId: SessionId,
+        val targetName: String,
+        val host: String,
+        val port: Int,
+        val user: String,
+    ) : SessionSurfaceState
+
+    /** A beyond-grace reconnect is in flight. Surface = centered hold, pill = "Reconnecting". */
+    data class Reconnecting(
+        val targetId: SessionId,
+        val targetName: String,
+        val host: String,
+        val port: Int,
+        val user: String,
+        val attempt: Int,
+        val maxAttempts: Int,
+        val retryDelayMs: Long,
+    ) : SessionSurfaceState
+
+    /** The active pane is seeded for this target — the terminal is shown, pill hidden. */
+    data class Live(
+        val targetId: SessionId,
+        val targetName: String,
+        val panes: List<Seed>,
+        val agentName: String? = null,
+    ) : SessionSurfaceState
+
+    /** The target session was deleted elsewhere (#666). Calm failure surface + "Disconnected" pill. */
+    data class Gone(val targetId: SessionId, val targetName: String) : SessionSurfaceState
+
+    /**
+     * A settled honest failure. Carries the TYPED [FailureReason] — never a raw
+     * exception string (#1326 AC-3). Renders the calm failure placeholder (NO
+     * spinner), the "Disconnected" pill and the single "Tap to reconnect" band, all
+     * in agreement.
+     */
+    data class Failed(
+        val targetId: SessionId,
+        val targetName: String,
+        val reason: FailureReason,
+    ) : SessionSurfaceState
+}
+
+/**
+ * The connection-projection payload [sessionSurfaceState] needs, decoupled from the
+ * app's `TmuxSessionViewModel.ConnectionStatus` (which lives in the app module and
+ * carries the same host/port/user + reconnect payload). The screen maps its
+ * `ConnectionStatus` to a [ConnectionPhase] at the single fusion point.
+ */
+sealed interface ConnectionPhase {
+    data object Idle : ConnectionPhase
+    data class Connecting(val host: String, val port: Int, val user: String) : ConnectionPhase
+
+    /** A warm same-host switch (`ConnectionStatus.Switching`). */
+    data class Warm(val host: String, val port: Int, val user: String) : ConnectionPhase
+
+    /** The transport is live (`ConnectionStatus.Connected`). */
+    data class Live(val host: String, val port: Int, val user: String) : ConnectionPhase
+
+    data class Reconnecting(
+        val host: String,
+        val port: Int,
+        val user: String,
+        val attempt: Int,
+        val maxAttempts: Int,
+        val retryDelayMs: Long,
+    ) : ConnectionPhase
+
+    /** A settled `ConnectionStatus.Failed`. The typed reason flows via [RevealState.Error]. */
+    data object Failed : ConnectionPhase
+}
+
+/**
+ * Fuse the id-keyed [reveal] surface state with the [phase] pill/progress payload
+ * into the SINGLE [SessionSurfaceState] the screen renders every region from.
+ *
+ * The reveal machine is the SURFACE authority: a [RevealState.Live]/[Gone]/[Error]
+ * dominates (terminal / gone card / calm failure), and its within-grace live-frame
+ * hold (#685/#1098) makes the surface stay [SessionSurfaceState.Live] with NO
+ * overlay — the load-bearing suppression. Only the *loading* reveal states
+ * ([Navigating]/[Seeding], and the never-emitted [Error]`(retrying = true)`) defer
+ * to [phase] for their flavor (cold Connecting vs warm Attaching vs Reconnecting),
+ * so the pill matches the surface hold.
+ *
+ * [targetId] guards the defensive case where the reveal machine holds a
+ * [RevealState.Live] for a target the screen is no longer keyed to (a superseded
+ * frame): it is treated as a hold, never painted as this screen's live terminal.
+ */
+fun sessionSurfaceState(
+    reveal: RevealState,
+    phase: ConnectionPhase,
+    targetId: SessionId?,
+): SessionSurfaceState = when (reveal) {
+    is RevealState.Idle -> holdFromPhase(targetId = null, targetName = null, phase = phase)
+
+    is RevealState.Navigating -> holdFromPhase(reveal.targetId, reveal.targetName, phase)
+
+    is RevealState.Seeding -> holdFromPhase(reveal.targetId, reveal.targetName, phase)
+
+    is RevealState.Live ->
+        if (targetId == null || reveal.targetId == targetId) {
+            SessionSurfaceState.Live(reveal.targetId, reveal.targetName, reveal.panes, reveal.agentName)
+        } else {
+            // Superseded live frame for another target — never paint it here; hold.
+            holdFromPhase(reveal.targetId, reveal.targetName, phase, allowFailed = false)
+        }
+
+    is RevealState.Gone -> SessionSurfaceState.Gone(reveal.targetId, reveal.targetName)
+
+    is RevealState.Error ->
+        if (reveal.retrying) {
+            // The calm healing/"reconnecting" window (never emitted today) — a HOLD,
+            // never the settled failure surface.
+            holdFromPhase(reveal.targetId, reveal.targetName, phase, allowFailed = false)
+        } else {
+            SessionSurfaceState.Failed(reveal.targetId, reveal.targetName, reveal.reason)
+        }
+}
+
+/**
+ * Build the coherent HOLD (loading / settled-failure) surface state for a reveal
+ * that is not yet Live, choosing the flavor from the [phase] pill payload so the
+ * pill matches the surface. A settled [ConnectionPhase.Failed] while the terminal
+ * is held resolves to the calm [SessionSurfaceState.Failed] (a generic retryable
+ * reason — the typed reason for a *reveal-driven* failure flows through
+ * [RevealState.Error] instead). [allowFailed] is false when the caller already
+ * knows the reveal is not a failure (a held Live for another target, or the calm
+ * heal window).
+ */
+private fun holdFromPhase(
+    targetId: SessionId?,
+    targetName: String?,
+    phase: ConnectionPhase,
+    allowFailed: Boolean = true,
+): SessionSurfaceState {
+    if (targetId == null || targetName == null) {
+        // No target yet (pre-navigation) — nothing to hold.
+        return SessionSurfaceState.Idle
+    }
+    return when (phase) {
+        is ConnectionPhase.Idle -> SessionSurfaceState.Navigating(targetId, targetName)
+        is ConnectionPhase.Connecting ->
+            SessionSurfaceState.Connecting(targetId, targetName, phase.host, phase.port, phase.user)
+        is ConnectionPhase.Warm ->
+            SessionSurfaceState.Attaching(targetId, targetName, phase.host, phase.port, phase.user)
+        is ConnectionPhase.Live ->
+            // Live lifecycle but the active pane has not seeded yet (never-reveal-black):
+            // hold behind the loader with a green (Connected) pill.
+            SessionSurfaceState.Attaching(targetId, targetName, phase.host, phase.port, phase.user)
+        is ConnectionPhase.Reconnecting ->
+            SessionSurfaceState.Reconnecting(
+                targetId, targetName, phase.host, phase.port, phase.user,
+                phase.attempt, phase.maxAttempts, phase.retryDelayMs,
+            )
+        is ConnectionPhase.Failed ->
+            if (allowFailed) {
+                SessionSurfaceState.Failed(targetId, targetName, FailureReason.Unreachable(retryable = true))
+            } else {
+                SessionSurfaceState.Navigating(targetId, targetName)
+            }
+    }
+}
+
+/** The target id of a non-idle [SessionSurfaceState], or null for [SessionSurfaceState.Idle]. */
+fun SessionSurfaceState.targetIdOrNull(): SessionId? = when (this) {
+    is SessionSurfaceState.Idle -> null
+    is SessionSurfaceState.Navigating -> targetId
+    is SessionSurfaceState.Connecting -> targetId
+    is SessionSurfaceState.Attaching -> targetId
+    is SessionSurfaceState.Reconnecting -> targetId
+    is SessionSurfaceState.Live -> targetId
+    is SessionSurfaceState.Gone -> targetId
+    is SessionSurfaceState.Failed -> targetId
+}
+
+/** The header name of a non-idle [SessionSurfaceState], or null for [SessionSurfaceState.Idle]. */
+fun SessionSurfaceState.targetNameOrNull(): String? = when (this) {
+    is SessionSurfaceState.Idle -> null
+    is SessionSurfaceState.Navigating -> targetName
+    is SessionSurfaceState.Connecting -> targetName
+    is SessionSurfaceState.Attaching -> targetName
+    is SessionSurfaceState.Reconnecting -> targetName
+    is SessionSurfaceState.Live -> targetName
+    is SessionSurfaceState.Gone -> targetName
+    is SessionSurfaceState.Failed -> targetName
+}
+
+/**
+ * True while the terminal is HELD behind a loader / failure placeholder — i.e. the
+ * surface is anything but the live terminal. Supersedes the deleted
+ * `effectiveHidesTerminal` / `revealHoldsTerminal` screen signal (#1326 AC-6):
+ * derived from the ONE state, never from `revealState`/`_switchHidesTerminal`.
+ */
+val SessionSurfaceState.terminalHeld: Boolean
+    get() = this !is SessionSurfaceState.Live
+
+/**
+ * True when the surface paints the CALM failure placeholder ([Gone]/[Failed]) — a
+ * settled failure that must render distinctly from the "Attaching…" hold: NO
+ * spinner, agreeing with the "Disconnected" pill and the "Tap to reconnect" band
+ * (the #1321/#1322 contradiction killer). Supersedes the old
+ * `surfaceShowsCalmFailure(held, hardFailure, status)` — now a pure read of the one
+ * state (the `status is Failed` arm is folded into [SessionSurfaceState.Failed]).
+ */
+val SessionSurfaceState.showsCalmFailure: Boolean
+    get() = this is SessionSurfaceState.Gone || this is SessionSurfaceState.Failed
+
+/**
+ * True when the surface paints a centered LOADER spinner — the "Attaching…" hold
+ * (terminal held) OR the "waiting for tmux panes…" ring (reveal live but no panes
+ * yet, [panesEmpty]). A settled failure ([showsCalmFailure]) is never a loader.
+ */
+fun SessionSurfaceState.showsCenteredLoader(panesEmpty: Boolean): Boolean =
+    !showsCalmFailure && (terminalHeld || panesEmpty)
+
+/**
+ * True whenever the surface owns the primary indicator (a loader OR the calm
+ * failure placeholder), so the top connecting/reconnecting banner and the pull-box
+ * spinner are the redundant duplicates and must be suppressed (the #750 single-
+ * indicator gate). False only in the live-frame steady state.
+ */
+fun SessionSurfaceState.surfaceOwnsPrimary(panesEmpty: Boolean): Boolean =
+    showsCalmFailure || showsCenteredLoader(panesEmpty)

--- a/shared/core-connection/src/test/java/com/pocketshell/core/connection/FailureReasonTest.kt
+++ b/shared/core-connection/src/test/java/com/pocketshell/core/connection/FailureReasonTest.kt
@@ -1,0 +1,88 @@
+package com.pocketshell.core.connection
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.IOException
+import java.net.UnknownHostException
+
+/**
+ * Issue #1326 (S3): the SINGLE `Throwable -> FailureReason` classifier. These pin
+ * the typed reason contract that supersedes the VM's `nonRetryableReason` string
+ * table — class-covering (auth / host / server / key / session / the closed-
+ * transport default) so the whole failure CLASS is typed, not just one instance.
+ */
+class FailureReasonTest {
+
+    // Exceptions whose SIMPLE NAME the classifier matches (it matches on the name so
+    // core-connection need not depend on sshj / core-tmux types).
+    private class UserAuthException(message: String) : Exception(message)
+    private class TmuxServerDeadException(message: String) : Exception(message)
+
+    @Test
+    fun classifiesAuthFailure() {
+        assertEquals(FailureReason.AuthFailed, classifyFailure(UserAuthException("auth")))
+    }
+
+    @Test
+    fun classifiesUnknownHost() {
+        assertEquals(FailureReason.HostUnresolved, classifyFailure(UnknownHostException("nope")))
+    }
+
+    @Test
+    fun classifiesServerDeath() {
+        assertEquals(FailureReason.ServerRestarted, classifyFailure(TmuxServerDeadException("no server running")))
+    }
+
+    @Test
+    fun classifiesMissingKeyFromMessageFragment() {
+        // The key-not-found case is a plain IOException identified by message text.
+        assertEquals(
+            FailureReason.KeyMissing,
+            classifyFailure(IOException("Private key file not found: /keys/id_ed25519")),
+        )
+    }
+
+    @Test
+    fun classifiesSessionEndedFromMessageFragment() {
+        assertEquals(FailureReason.SessionEnded, classifyFailure(IOException("can't find session: work")))
+        assertEquals(FailureReason.SessionEnded, classifyFailure(IOException("no such session")))
+    }
+
+    @Test
+    fun closedTransportPreflightDefaultsToRetryableUnreachable_1321Repro() {
+        // The #1321 leak: a `TmuxClientException: failed to preflight tmux has-session
+        // ... transport is closed`. It has none of the non-retryable signatures, so it
+        // classifies to the CALM, retryable Unreachable — the "Tap Reconnect" state,
+        // never a scary raw exception surfaced to the UI.
+        val closedTransport = IOException("failed to preflight tmux has-session -t work: transport is closed")
+        val reason = classifyFailure(closedTransport)
+        assertEquals(FailureReason.Unreachable(retryable = true), reason)
+        assertTrue("a closed-transport drop is auto-retryable", reason.retryable)
+    }
+
+    @Test
+    fun nullCauseIsRetryableUnreachable() {
+        assertEquals(FailureReason.Unreachable(retryable = true), classifyFailure(null))
+    }
+
+    @Test
+    fun walksTheCauseChain() {
+        val nested = RuntimeException("wrapper", UserAuthException("deep auth reject"))
+        assertEquals(FailureReason.AuthFailed, classifyFailure(nested))
+    }
+
+    @Test
+    fun retryableFlag_configLevelReasonsAreNotAutoRetryable() {
+        // Class coverage: every config-level reason is non-retryable (user must act);
+        // only a transient Unreachable is auto-retryable.
+        assertFalse(FailureReason.AuthFailed.retryable)
+        assertFalse(FailureReason.HostUnresolved.retryable)
+        assertFalse(FailureReason.ServerRestarted.retryable)
+        assertFalse(FailureReason.SessionEnded.retryable)
+        assertFalse(FailureReason.KeyMissing.retryable)
+        assertFalse(FailureReason.Unreachable(retryable = false).retryable)
+        assertTrue(FailureReason.Unreachable(retryable = true).retryable)
+    }
+}

--- a/shared/core-connection/src/test/java/com/pocketshell/core/connection/SessionSurfaceStateTest.kt
+++ b/shared/core-connection/src/test/java/com/pocketshell/core/connection/SessionSurfaceStateTest.kt
@@ -1,0 +1,130 @@
+package com.pocketshell.core.connection
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1326 (S3): the [sessionSurfaceState] fusion is the KEYSTONE that makes a
+ * contradictory (pill, surface, band) triple type-UNREPRESENTABLE. These pin the
+ * fusion + the derived surface signals at the core level (the app screen renders
+ * strictly from these).
+ */
+class SessionSurfaceStateTest {
+
+    private val sid = SessionId("host/work")
+    private val other = SessionId("host/other")
+
+    private fun connecting() = ConnectionPhase.Connecting("h", 22, "u")
+    private fun reconnecting() = ConnectionPhase.Reconnecting("h", 22, "u", 2, 3, 0L)
+
+    @Test
+    fun errorReveal_fusesToFailed_carryingTypedReason() {
+        val state = sessionSurfaceState(
+            RevealState.Error(sid, "work", retrying = false, reason = FailureReason.AuthFailed),
+            reconnecting(),
+            sid,
+        )
+        assertTrue(state is SessionSurfaceState.Failed)
+        assertEquals(FailureReason.AuthFailed, (state as SessionSurfaceState.Failed).reason)
+        // A settled failure is a calm-failure surface, never a loader.
+        assertTrue(state.showsCalmFailure)
+        assertFalse(state.showsCenteredLoader(panesEmpty = true))
+        assertTrue(state.terminalHeld)
+    }
+
+    @Test
+    fun goneReveal_fusesToGone_calmFailure() {
+        val state = sessionSurfaceState(RevealState.Gone(sid, "work"), ConnectionPhase.Failed, sid)
+        assertTrue(state is SessionSurfaceState.Gone)
+        assertTrue(state.showsCalmFailure)
+        assertFalse(state.showsCenteredLoader(panesEmpty = false))
+    }
+
+    @Test
+    fun liveReveal_dominatesPhase_withinGraceSuppression() {
+        // #685/#1098: a Live reveal is the surface authority — even if the phase is
+        // still Reconnecting (within-grace silent heal), the surface stays Live with
+        // NO loader. The load-bearing green is the SUPPRESSION.
+        listOf(connecting(), reconnecting(), ConnectionPhase.Live("h", 22, "u")).forEach { phase ->
+            val state = sessionSurfaceState(RevealState.Live(sid, "work", emptyList()), phase, sid)
+            assertTrue("live dominates $phase", state is SessionSurfaceState.Live)
+            assertFalse(state.terminalHeld)
+            assertFalse("no loader over a live frame", state.showsCenteredLoader(panesEmpty = false))
+            assertFalse(state.showsCalmFailure)
+        }
+    }
+
+    @Test
+    fun seedingHold_takesFlavorFromPhase() {
+        assertTrue(
+            sessionSurfaceState(RevealState.Seeding(sid, "work"), connecting(), sid)
+                is SessionSurfaceState.Connecting,
+        )
+        assertTrue(
+            sessionSurfaceState(RevealState.Seeding(sid, "work"), reconnecting(), sid)
+                is SessionSurfaceState.Reconnecting,
+        )
+        assertTrue(
+            sessionSurfaceState(RevealState.Seeding(sid, "work"), ConnectionPhase.Warm("h", 22, "u"), sid)
+                is SessionSurfaceState.Attaching,
+        )
+        // A held reveal + a settled Failed phase resolves to the calm failure surface.
+        assertTrue(
+            sessionSurfaceState(RevealState.Seeding(sid, "work"), ConnectionPhase.Failed, sid)
+                is SessionSurfaceState.Failed,
+        )
+    }
+
+    @Test
+    fun liveForAnotherTarget_isNeverPaintedAsThisScreensLive() {
+        // Defensive: a Live reveal for a DIFFERENT target than the screen is keyed to
+        // is a superseded frame — held, never painted as this screen's live terminal.
+        val state = sessionSurfaceState(
+            RevealState.Live(other, "other", emptyList()),
+            connecting(),
+            targetId = sid,
+        )
+        assertFalse(state is SessionSurfaceState.Live)
+        assertTrue(state.terminalHeld)
+    }
+
+    @Test
+    fun everyRevealTimesPhase_contradictionUnrepresentable() {
+        // The keystone invariant across every reveal x phase pair: a centered loader
+        // and a calm failure can NEVER both paint.
+        val reveals = listOf(
+            RevealState.Idle,
+            RevealState.Navigating(sid, "work"),
+            RevealState.Seeding(sid, "work"),
+            RevealState.Live(sid, "work", emptyList()),
+            RevealState.Gone(sid, "work"),
+            RevealState.Error(sid, "work", retrying = false, reason = FailureReason.KeyMissing),
+        )
+        val phases = listOf(
+            ConnectionPhase.Idle,
+            connecting(),
+            ConnectionPhase.Warm("h", 22, "u"),
+            ConnectionPhase.Live("h", 22, "u"),
+            reconnecting(),
+            ConnectionPhase.Failed,
+        )
+        reveals.forEach { reveal ->
+            phases.forEach { phase ->
+                val state = sessionSurfaceState(reveal, phase, sid)
+                listOf(true, false).forEach { panesEmpty ->
+                    assertFalse(
+                        "reveal=$reveal phase=$phase panesEmpty=$panesEmpty: loader AND failure",
+                        state.showsCalmFailure && state.showsCenteredLoader(panesEmpty),
+                    )
+                    // surfaceOwnsPrimary is exactly the OR of the two surface indicators.
+                    assertEquals(
+                        state.showsCalmFailure || state.showsCenteredLoader(panesEmpty),
+                        state.surfaceOwnsPrimary(panesEmpty),
+                    )
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #1326. Roadmap keystone S3 (#1331). Pill+surface+band render from ONE SessionSurfaceState → the maintainer's recurring cryptic-state combos (#1321) become type-unrepresentable. Typed FailureReason + single classifyFailure (no raw error text). Deletes independent gate signals + _switchHidesTerminal; VM 20119→20042 (ratchet OK). S7 parallel-authority collapse NOT done here.

Reviewer APPROVED with full D28 rigor: reviewer-driven red→green (fusion-unrepresentable + classifier), **emulator+Docker #638 journeys 8/8 green** — within-grace SUPPRESSION proven from authoritative logs (`SUPPRESSED (single-grace-owner)`), A→B→C→A correct non-stale, beyond-grace clean; adjacency sweep clean.