### PR TITLE
release: v0.4.25 — connection consolidation (S1+S3) + dogfood fixes

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,8 +65,8 @@ android {
         applicationId = "com.pocketshell.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 71
-        versionName = "0.4.24"
+        versionCode = 72
+        versionName = "0.4.25"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/tools/pocketshell/pyproject.toml
+++ b/tools/pocketshell/pyproject.toml
@@ -8,7 +8,7 @@ name = "pocketshell"
 # scripts/check-pypi-version.sh enforces this; .github/workflows/build.yml
 # runs that check before publishing to PyPI. See
 # tools/pocketshell/README.md ("Release flow") for the bump procedure.
-version = "0.4.24"
+version = "0.4.25"
 description = "Unified server-side Python utility for the PocketShell Android client."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Version bump to 0.4.25 (code 72, tool 0.4.25). Bundles the merged session fixes: conversation toggle (#1320), cold-start class (#1292), state-machine S1 (#1322) + keystone S3 (#1326), attach-freeze (#1316), composer (#1245), hotkeys (#1332), resume-session (#1239), voice data-loss (#1272), API-35 CI (#1197), ratchet/dead-weight. Usage-panel #1318 → v0.4.26.