### PR TITLE
usage: pin quse + strict unified schema, delete downstream defensive code (#1318)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/usage/Usage1318StrictSchemaRenderE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/usage/Usage1318StrictSchemaRenderE2eTest.kt
@@ -1,0 +1,300 @@
+package com.pocketshell.app.usage
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.SshPortForward
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshShell
+import com.pocketshell.uikit.theme.PocketShellColors
+import com.pocketshell.uikit.theme.PocketShellTheme
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+import java.io.InputStream
+import java.time.Instant
+
+/**
+ * Issue #1318 — on-device (connected) render acceptance for the quse-v0.0.9
+ * strict-schema usage pipeline. This is the G4/D33 proof that the BLOCKED
+ * reviewer round asked for: not "the parser returns the right list" (that is
+ * the JVM `PocketshellUsageJsonParserTest`), but "the real Compose usage panel
+ * VISIBLY renders provider cards for the authoritative quse-0.0.9 data, and
+ * fails LOUD — never a silent wrong render — on the un-flattened blob the
+ * maintainer's device actually received on v0.4.24."
+ *
+ * ## The reported symptom (maintainer dogfood, v0.4.24)
+ *
+ * `0 providers · 0 hosts`, `hetzner: Refresh usage failed`, and a raw JSON dump
+ * where the provider cards should be. Root cause: quse changed its `--json`
+ * schema to a provider-keyed object, but the whole pipeline expected per-line
+ * NDJSON — so the app received the un-flattened blob and could not turn it into
+ * cards.
+ *
+ * ## Why this drives the REAL path (F2, not a proxy)
+ *
+ * Both @Test cases feed a canned [SshSession] into the PRODUCTION
+ * [UsageRemoteSource.fetchUsage] (which runs the PRODUCTION
+ * `PocketshellUsageJsonParser`), map its result into the PRODUCTION
+ * [UsageScreenState] exactly as [UsageViewModel.loadUsageState] does
+ * (Records → [UsageHostSnapshot]; Failed → [UsageFailedHost]), and compose the
+ * PRODUCTION [UsageScreen] in the real [PocketShellTheme]. Nothing about the
+ * #1318 subject (fetch → strict parse → panel render) is stubbed; only the SSH
+ * transport is canned, which is not what #1318 changed. There is no
+ * `*StandIn` / `*Proxy` for the panel under test.
+ *
+ * ## Red → green
+ *
+ * The same-input base-vs-fix red→green for the schema change lives in the JVM
+ * `PocketshellUsageJsonParserTest` (the OLD parser derived zai's long window as
+ * `long_term` via `canonicalWindowName`; the NEW parser reads it straight from
+ * `window: "weekly"`). This test is the on-device manifestation of that: the
+ * green case HARD-asserts the panel renders the **"Weekly limit"** card (zai)
+ * and **"Monthly limit"** card (copilot) — labels the OLD parser could not
+ * produce for these providers — plus `4 providers · 1 hosts` and NO
+ * `Refresh usage failed`. The companion case reproduces the exact v0.4.24
+ * broken panel through the real render path so a regression to silent-wrong /
+ * non-loud handling of an un-flattened blob is caught.
+ *
+ * Pure Compose-rule UI test (like [UsageGlancePillE2eTest]): no Docker fixture,
+ * no SSH/tmux/toxiproxy, deterministic on the CI swiftshader AVD, and it does
+ * NOT self-skip on CI. Wired into `scripts/ci-journey-suite.sh` so it gates at
+ * per-push/batched time (G9).
+ */
+@RunWith(AndroidJUnit4::class)
+class Usage1318StrictSchemaRenderE2eTest {
+
+    @get:Rule
+    val compose = createAndroidComposeRule<ComponentActivity>()
+
+    // A fixed "now" so the per-window reset foot is deterministic; the label
+    // assertions below do not depend on it.
+    private val now: Instant = Instant.parse("2026-07-07T20:00:00Z")
+
+    /**
+     * GREEN acceptance: the authoritative quse-0.0.9 output, flattened by
+     * `pocketshell usage --json` into per-provider NDJSON, renders all four
+     * provider cards with the unified window labels straight from quse's
+     * `window` field.
+     */
+    @Test
+    fun flattenedQuseV009Ndjson_rendersAllFourProviderCardsWithUnifiedWindows() {
+        val state = renderStateFor(stdout = FLATTENED_QUSE_V009_NDJSON, exitCode = 0)
+
+        // The real fetch → strict parse produced 4 provider records on 1 host.
+        assertTrue(
+            "expected the real UsageRemoteSource to parse 4 provider records, " +
+                "got ${state.providerCount} on ${state.hostCount} host(s)",
+            state.providerCount == 4 && state.hostCount == 1,
+        )
+        assertTrue(
+            "expected no failed host on the authoritative flattened NDJSON, " +
+                "got ${state.failedHosts}",
+            state.failedHosts.isEmpty(),
+        )
+
+        setUsageScreen(state)
+
+        // All four provider cards render (display names). This is the symptom
+        // gone: cards, not `0 providers` / a raw dump.
+        compose.waitUntil(timeoutMillis = 10_000) {
+            compose.onAllNodesWithText("Claude Code", useUnmergedTree = true)
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+        compose.onNodeWithText("Claude Code", useUnmergedTree = true).assertExists()
+        compose.onNodeWithText("Codex", useUnmergedTree = true).assertExists()
+        compose.onNodeWithText("GitHub Copilot", useUnmergedTree = true).assertExists()
+        compose.onNodeWithText("Zai", useUnmergedTree = true).assertExists()
+
+        // Load-bearing new-schema labels: these come STRAIGHT from quse's
+        // `window` field. The OLD parser rendered zai's long window as
+        // "Long term" (canonicalWindowName), never "Weekly limit"; and only
+        // knew "monthly" for copilot's long window. Their presence is the
+        // on-device manifestation of the Part-B parser fix.
+        compose.onNodeWithText("Weekly limit", useUnmergedTree = true).assertExists()
+        compose.onNodeWithText("Monthly limit", useUnmergedTree = true).assertExists()
+        // The concrete short/long spans quse emits for claude/codex/zai.
+        compose.onAllNodesWithText("5h window", useUnmergedTree = true).fetchSemanticsNodes()
+            .isNotEmpty().let { assertTrue("expected a 5h window label", it) }
+        compose.onAllNodesWithText("7d window", useUnmergedTree = true).fetchSemanticsNodes()
+            .isNotEmpty().let { assertTrue("expected a 7d window label", it) }
+
+        // The screen-level meta row reads the populated provider/host counts —
+        // NOT the reported `0 providers · 0 hosts`.
+        compose.onNodeWithText("4 providers · 1 hosts", useUnmergedTree = true).assertExists()
+
+        // The reported failure band must be ABSENT (no "Refresh usage failed").
+        assertTrue(
+            "the populated panel must not show the failure band",
+            compose.onAllNodesWithText("Refresh usage failed", useUnmergedTree = true)
+                .fetchSemanticsNodes().isEmpty(),
+        )
+    }
+
+    /**
+     * Reproduce the exact v0.4.24 broken panel through the real render path:
+     * the un-flattened quse-0.0.9 provider-keyed object (what a broken pipeline
+     * delivered to the device) must produce a LOUD, visible failure — the
+     * reported `0 providers · 0 hosts` + `Refresh usage failed` — never a silent
+     * wrong render and never a provider card. This guards the D22 hard-cut
+     * fail-loud intent: the ONLY input that yields cards is the flattened NDJSON.
+     */
+    @Test
+    fun rawUnflattenedQuseV009Object_failsLoudReproducingReportedSymptom() {
+        val state = renderStateFor(stdout = RAW_QUSE_V009_PROVIDER_KEYED, exitCode = 0)
+
+        // The strict parser throws on the un-flattened blob, so the real
+        // UsageRemoteSource classifies the host as Failed — the reported state.
+        assertTrue(
+            "expected the un-flattened blob to fail loud (0 providers, host failed), " +
+                "got providerCount=${state.providerCount} failed=${state.failedHosts.size}",
+            state.providerCount == 0 && state.failedHosts.size == 1,
+        )
+
+        setUsageScreen(state)
+
+        compose.waitUntil(timeoutMillis = 10_000) {
+            compose.onAllNodesWithText("hetzner: Refresh usage failed", useUnmergedTree = true)
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+        // The exact reported symptom text.
+        compose.onNodeWithText("hetzner: Refresh usage failed", useUnmergedTree = true).assertExists()
+        compose.onNodeWithText("0 providers · 0 hosts", useUnmergedTree = true).assertExists()
+
+        // And crucially NOT a silently-rendered provider card: the un-flattened
+        // blob must never masquerade as usable data.
+        assertTrue(
+            "an un-flattened blob must NOT render a provider card",
+            compose.onAllNodesWithText("Weekly limit", useUnmergedTree = true)
+                .fetchSemanticsNodes().isEmpty() &&
+                compose.onAllNodesWithText("Claude Code", useUnmergedTree = true)
+                    .fetchSemanticsNodes().isEmpty(),
+        )
+    }
+
+    /**
+     * Drive the PRODUCTION [UsageRemoteSource.fetchUsage] (real strict parser)
+     * with a canned session, then map its result into [UsageScreenState] exactly
+     * as [UsageViewModel.loadUsageState] does. Only the SSH transport is stubbed.
+     */
+    private fun renderStateFor(stdout: String, exitCode: Int): UsageScreenState = runBlocking {
+        val source = UsageRemoteSource()
+        val session = CannedUsageSshSession(stdout = stdout, exitCode = exitCode)
+        when (val result = source.fetchUsage(session)) {
+            is UsageFetchResult.Success -> UsageScreenState(
+                hosts = listOf(
+                    UsageHostSnapshot(
+                        hostId = 1L,
+                        hostName = "hetzner",
+                        records = result.records,
+                        lastSyncedAt = now,
+                    ),
+                ),
+            )
+            is UsageFetchResult.Failed -> UsageScreenState(
+                failedHosts = listOf(
+                    UsageFailedHost(hostId = 1L, hostName = "hetzner", reason = result.reason),
+                ),
+            )
+            UsageFetchResult.ToolMissing -> UsageScreenState(
+                missingToolHosts = listOf(
+                    UsageMissingToolHost(hostId = 1L, hostName = "hetzner"),
+                ),
+            )
+        }
+    }
+
+    private fun setUsageScreen(state: UsageScreenState) {
+        compose.setContent {
+            PocketShellTheme {
+                Column(modifier = Modifier.fillMaxSize().background(PocketShellColors.Background)) {
+                    UsageScreen(
+                        state = state,
+                        onBack = {},
+                        onRefresh = {},
+                        now = now,
+                    )
+                }
+            }
+        }
+    }
+
+    /**
+     * Minimal canned [SshSession]: every `exec` returns the configured
+     * stdout/exit so the real [UsageRemoteSource] runs its production parse path
+     * against deterministic bytes. Non-usage methods are unused by this flow.
+     */
+    private class CannedUsageSshSession(
+        private val stdout: String,
+        private val exitCode: Int,
+    ) : SshSession {
+        override val isConnected: Boolean = true
+        override suspend fun exec(command: String): ExecResult =
+            ExecResult(stdout = stdout, stderr = "", exitCode = exitCode)
+
+        override fun tail(path: String, onLine: (String) -> Unit): Job = error("not used")
+        override fun openLocalPortForward(remoteHost: String, remotePort: Int, localPort: Int): SshPortForward =
+            error("not used")
+        override fun startShell(): SshShell = error("not used")
+        override suspend fun uploadFile(file: File, remotePath: String): String = error("not used")
+        override suspend fun uploadStream(
+            input: InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String = error("not used")
+        override fun close() = Unit
+    }
+
+    private companion object {
+        /**
+         * The authoritative per-provider NDJSON `pocketshell usage --json`
+         * emits — the exact output of `normalize_usage_stdout` applied to the
+         * `tools/pocketshell/tests/data/quse-0.0.9-usage.json` fixture (verified
+         * this run by running the flatten on that fixture). Four providers:
+         * claude (5h/7d), codex (5h/7d), copilot (—/monthly), zai (5h/weekly).
+         */
+        val FLATTENED_QUSE_V009_NDJSON: String = listOf(
+            """{"details":{"limit_reached":false,"windows":{"five_hour":{"reset_at":"2026-07-07T23:19:59Z","used_percent":9.0},"seven_day":{"reset_at":"2026-07-09T14:59:59Z","used_percent":70.0}}},"error":null,"long_term":{"percent_remaining":30.0,"reset_at":"2026-07-09T14:59:59Z","window":"7d"},"provider":"claude","short_term":{"percent_remaining":91.0,"reset_at":"2026-07-07T23:19:59Z","window":"5h"},"status":"ok"}""",
+            """{"details":{"limit_reached":true,"windows":{"primary_window":{"reset_at":"2026-07-07T23:57:08Z","used_percent":0.0},"secondary_window":{"reset_at":"2026-07-11T06:23:55Z","used_percent":98.0}}},"error":null,"long_term":{"percent_remaining":2.0,"reset_at":"2026-07-11T06:23:55Z","window":"7d"},"provider":"codex","short_term":{"percent_remaining":100.0,"reset_at":"2026-07-07T23:57:08Z","window":"5h"},"status":"ok"}""",
+            """{"details":{"limit_reached":false,"premium_percent_remaining":97.1},"error":null,"long_term":{"percent_remaining":97.1,"reset_at":"2026-08-01T00:00:00Z","window":"monthly"},"provider":"copilot","short_term":{"percent_remaining":100.0,"reset_at":null,"window":null},"status":"ok"}""",
+            """{"details":{"limit_reached":false,"max_used_percent":44.0},"error":null,"long_term":{"percent_remaining":56.0,"reset_at":"2026-07-11T14:04:58Z","window":"weekly"},"provider":"zai","short_term":{"percent_remaining":58.0,"reset_at":null,"window":"5h"},"status":"ok"}""",
+        ).joinToString("\n")
+
+        /**
+         * The RAW, un-flattened quse-0.0.9 `--json` document — a provider-keyed
+         * object with NO top-level `provider` key. This is what the maintainer's
+         * device received on v0.4.24 (the flatten was broken), and the strict
+         * parser must reject it loudly. Pretty-printed to match quse's real
+         * multi-line dump; the trimmed 2-provider excerpt is sufficient to
+         * reproduce the fail-loud symptom (the parser throws on the leading `{`).
+         */
+        val RAW_QUSE_V009_PROVIDER_KEYED: String = """
+            {
+              "claude": {
+                "error": null,
+                "long_term": {"percent_remaining": 30.0, "reset_at": "2026-07-09T14:59:59Z", "window": "7d"},
+                "short_term": {"percent_remaining": 91.0, "reset_at": "2026-07-07T23:19:59Z", "window": "5h"},
+                "status": "ok"
+              },
+              "codex": {
+                "error": null,
+                "long_term": {"percent_remaining": 2.0, "reset_at": "2026-07-11T06:23:55Z", "window": "7d"},
+                "short_term": {"percent_remaining": 100.0, "reset_at": "2026-07-07T23:57:08Z", "window": "5h"},
+                "status": "ok"
+              }
+            }
+        """.trimIndent()
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/usage/UsageRemoteSourceTest.kt
+++ b/app/src/test/java/com/pocketshell/app/usage/UsageRemoteSourceTest.kt
@@ -136,13 +136,19 @@ class UsageRemoteSourceTest {
         assertTrue(record.lastError?.contains("HTTP Error 401", ignoreCase = true) == false)
     }
 
-    // -- issue #1223: exit-0 per-record resilience (#847 version-skew class) --
+    // -- issue #1318: exit-0 STRICT schema — any drift fails the whole panel --
+    //
+    // Hard-cut reversal of #1223's per-record skip-resilience: quse v0.0.9 is
+    // the single source of truth for the schema, so `pocketshell usage --json`
+    // emits exactly the expected per-provider NDJSON. A drifted/malformed
+    // record is a schema violation now, and the app fails LOUDLY (whole-panel
+    // Failed) instead of silently skipping the bad record.
 
     @Test
-    fun fetchUsage_exit0PartialDrift_stillRendersHealthyProvider() = runTest {
-        // An old/mismatched host CLI emits provider A fine but provider B
-        // drifted (short_term is not an object). Before #1223 the whole usage
-        // panel showed Failed/blank; the healthy provider must now render.
+    fun fetchUsage_exit0PartialDrift_failsLoudNoSilentSkip() = runTest {
+        // Provider A is fine but provider B drifted (short_term is not an
+        // object). #1318: the whole panel must surface a visible failure, NOT
+        // silently render only the healthy provider.
         val session = FakeSshSession(
             mapOf(
                 defaultFetchCommand to ExecResult(
@@ -157,16 +163,13 @@ class UsageRemoteSourceTest {
 
         val result = source.fetchUsage(session)
 
-        assertTrue(result is UsageFetchResult.Success)
-        val record = (result as UsageFetchResult.Success).records.single()
-        assertEquals("codex", record.provider)
-        assertEquals(UsageStatus.Ok, record.status)
+        assertTrue("a drifted record must fail loud, not skip", result is UsageFetchResult.Failed)
     }
 
     @Test
-    fun fetchUsage_exit0NonJsonPreamble_stillRendersAllProviders() = runTest {
-        // A wrapper prepends a non-JSON MOTD/deprecation line before the valid
-        // NDJSON. All valid providers must still render.
+    fun fetchUsage_exit0NonJsonPreamble_failsLoud() = runTest {
+        // A non-JSON MOTD/deprecation preamble line is a schema violation now:
+        // the panel fails loudly instead of skipping the line.
         val session = FakeSshSession(
             mapOf(
                 defaultFetchCommand to ExecResult(
@@ -182,9 +185,7 @@ class UsageRemoteSourceTest {
 
         val result = source.fetchUsage(session)
 
-        assertTrue(result is UsageFetchResult.Success)
-        val records = (result as UsageFetchResult.Success).records
-        assertEquals(listOf("codex", "claude"), records.map { it.provider })
+        assertTrue("a non-JSON preamble must fail loud", result is UsageFetchResult.Failed)
     }
 
     @Test

--- a/app/src/test/java/com/pocketshell/app/usage/UsageViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/usage/UsageViewModelTest.kt
@@ -508,10 +508,7 @@ class UsageViewModelTest {
             ),
         )
         val records = PocketshellUsageJsonParser().parse(
-            """{"provider":"codex","status":"exhausted",
-              "short_term":null,"long_term":null,
-              "block_reason":"Codex quota exhausted",
-              "error":null,"details":{}}""".trimIndent(),
+            """{"provider":"codex","status":"exhausted","short_term":null,"long_term":null,"block_reason":"Codex quota exhausted","error":null,"details":{}}""",
         )
         val fetcher = FakeFetcher(
             scripts = mapOf("codex.example" to HostUsageFetch.Records(records, Instant.now())),

--- a/docs/server-setup.md
+++ b/docs/server-setup.md
@@ -89,6 +89,6 @@ package are bumped in lockstep on each release tag).
 |---|---|---|
 | "pocketshell not installed" / "server-side usage tracking unavailable" | `~/.local/bin` not on non-interactive SSH PATH | Step 2 (PATH above the `.bashrc` guard) |
 | `pocketshell: command not found` over `ssh host 'pocketshell ...'` | not installed, or PATH | Step 1 + Step 2 |
-| Usage panel shows a `quse`-not-installed / dependency error (NOT "pocketshell not installed") | pocketshell IS installed but its usage backend `quse` is missing (e.g. a dangling `~/.local/bin/quse` symlink); `pocketshell usage --json` prints pocketshell's own error at exit 0 | Install/repair `quse` (`uv tool install quse` or `pipx install quse`) — issue #1220. The app now surfaces pocketshell's own message rather than mislabelling it "pocketshell not installed". |
+| Usage panel shows a "bundled `quse` missing" packaging error (NOT "pocketshell not installed") | `quse` is now a PINNED dependency shipped WITH `pocketshell` (issue #1318) and resolved next to the interpreter, never from PATH. This error means the install is broken (e.g. a partial/corrupt install) | Reinstall pocketshell (`uv tool install --force pocketshell` — that reinstalls the pinned `quse` too). Do NOT install a separate host `quse`; a host-level `quse` on PATH is intentionally ignored so a host upgrade cannot break the schema. |
 | One provider shows an error, others OK | that provider's helper (e.g. `goz`) missing | install that helper, or ignore |
 | Worked before, broke after dotfile edit | PATH line moved below the guard | Step 2 |

--- a/docs/usage-panel.md
+++ b/docs/usage-panel.md
@@ -55,16 +55,17 @@ NAME each record carries drives the label:
 | `monthly` | `Monthly limit` |
 | anything else (`short_term` / `long_term` / unknown) | humanized (`Short term` / `Long term`, #522) |
 
-The two main coding-agent providers — **Codex and Claude Code** — both use the
-same 5h + 7d windows, so both render the identical concrete `5h window` /
-`7d window` labels. Codex derives the span from its detail-window
-`limit_window_seconds`; Claude Code's quota is the same fixed 5h/7d so the
-span is seeded canonically (server-side in `pocketshell usage`, and as a
-parser fallback so older hosts still render it). **Monthly-cadence providers
-keep their real cadence**: GitHub Copilot's long-term quota renders
-`Monthly limit`, NOT a 7d window. Providers whose span is genuinely unknown
-fall back to the humanized `Short term` / `Long term` label so nothing is
-mislabeled.
+The window NAME comes STRAIGHT from quse's `window` field — quse v0.0.9 is the
+single source of truth for the span (issue #1318). The two main coding-agent
+providers — **Codex and Claude Code** — both use the same 5h + 7d windows, so
+quse emits `5h` / `7d` for both and they render the identical concrete
+`5h window` / `7d window` labels. **Monthly-cadence providers keep their real
+cadence**: GitHub Copilot's long-term quota carries `monthly` and renders
+`Monthly limit`, NOT a 7d window. When quse carries no span (`window: null`,
+e.g. Copilot's short-term bucket), the parser falls back to the generic key
+name so the label humanizes to `Short term` / `Long term`. There is no
+downstream re-derivation of the span from `details` — the app IGNORES
+`details` entirely.
 
 ## Surfaces
 
@@ -151,28 +152,40 @@ schema.
 
 ## Expected JSON Schema
 
-`pocketshell usage --json` emits newline-delimited JSON (NDJSON) — one object per line per provider:
+`quse` (the pinned usage backend bundled with `pocketshell`, issue #1318) is
+the single source of truth for the unified schema. Its `--json` output is a
+**provider-keyed object**; `pocketshell usage --json` FLATTENS it into
+newline-delimited JSON (NDJSON) — one record per line per provider, injecting
+the provider name from the key and passing quse's unified fields through
+unchanged. No downstream re-derivation of windows / resets / percentages
+(hard-cut, D22). `quse`'s raw output:
 
 ```json
 {
-  "provider": "codex",
-  "status": "ok",
-  "short_term": {"percent_remaining": 77.0, "reset_at": "2026-05-24T15:53:01Z", "window": null},
-  "long_term":  {"percent_remaining": 88.0, "reset_at": "2026-05-30T20:33:54Z", "window": null},
-  "block_reason": null,
-  "error": null,
-  "details": {"limit_reached": false, "windows": {"primary_window": {...}, "secondary_window": {...}}}
-}
-{
-  "provider": "claude",
-  "status": "ok",
-  "short_term": {"percent_remaining": 41.0, "reset_at": "2026-05-24T14:30:00Z"},
-  "long_term":  {"percent_remaining": 85.0, "reset_at": "2026-05-28T14:59:59Z"},
-  "block_reason": null,
-  "error": null,
-  "details": {...}
+  "codex": {
+    "status": "ok",
+    "short_term": {"percent_remaining": 100.0, "reset_at": "2026-07-07T23:57:08Z", "window": "5h"},
+    "long_term":  {"percent_remaining": 2.0,   "reset_at": "2026-07-11T06:23:55Z", "window": "7d"},
+    "error": null,
+    "details": { ... extra/human-CLI only; the app IGNORES it ... }
+  },
+  "claude": { "status": "ok", "short_term": {...}, "long_term": {...}, "error": null, "details": {...} }
 }
 ```
+
+which `pocketshell usage --json` flattens to one record per line:
+
+```json
+{"provider":"codex","status":"ok","short_term":{"percent_remaining":100.0,"reset_at":"2026-07-07T23:57:08Z","window":"5h"},"long_term":{"percent_remaining":2.0,"reset_at":"2026-07-11T06:23:55Z","window":"7d"},"error":null,"details":{...}}
+{"provider":"claude","status":"ok","short_term":{...},"long_term":{...},"error":null,"details":{...}}
+```
+
+The app reads `provider`, `status`, `short_term` / `long_term`
+`{percent_remaining, reset_at, window}`, and `error` directly, and expects
+this exact schema — a mismatch fails the whole panel loudly (no per-record
+skip-resilience). `reset_at` is canonical ISO-8601 UTC; the window label comes
+straight from `short_term.window` / `long_term.window`. The app **ignores**
+`details`.
 
 The supported providers are `codex`, `claude`, `copilot`, and `zai`.
 `gemini` is accepted but reports `status: "unsupported"` because Gemini

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -1684,6 +1684,23 @@ JOURNEY_CLASSES=(
   # UsageGlancePillStateTest. It lives under com.pocketshell.app.usage, so it
   # carries its FQCN directly.
   "com.pocketshell.app.usage.UsageGlancePillE2eTest"
+  # ADDED (#1318): on-device render acceptance for the quse-v0.0.9 strict-schema
+  # usage pipeline — the G4/D33 proof the BLOCKED reviewer round asked for. Drives
+  # the PRODUCTION UsageRemoteSource.fetchUsage (real strict PocketshellUsageJsonParser)
+  # with the authoritative quse-0.0.9 FLATTENED per-provider NDJSON, maps to the real
+  # UsageScreenState, and composes the PRODUCTION UsageScreen. HARD-asserts all four
+  # provider cards render with the unified window labels straight from quse's `window`
+  # field ("Weekly limit"/zai + "Monthly limit"/copilot — labels the OLD parser could
+  # not produce), "4 providers · 1 hosts", and NO "Refresh usage failed" band. A
+  # companion @Test reproduces the exact v0.4.24 broken panel through the SAME real
+  # render path: the un-flattened provider-keyed blob must fail LOUD ("0 providers ·
+  # 0 hosts" + "Refresh usage failed"), never a silent wrong render. Pure Compose-rule
+  # UI test (like UsageGlancePillE2eTest): no Docker fixture / SSH / tmux / toxiproxy /
+  # port, so it needs NO tests.yml service change, is deterministic on the CI
+  # swiftshader AVD, and does NOT self-skip on CI. The same-input base-vs-fix red→green
+  # for the schema change is the per-push Unit-job PocketshellUsageJsonParserTest. It
+  # lives under com.pocketshell.app.usage, so it carries its FQCN directly.
+  "com.pocketshell.app.usage.Usage1318StrictSchemaRenderE2eTest"
 )
 
 # ---------------------------------------------------------------------------

--- a/shared/core-usage/src/main/java/com/pocketshell/core/usage/PocketshellUsageJsonParser.kt
+++ b/shared/core-usage/src/main/java/com/pocketshell/core/usage/PocketshellUsageJsonParser.kt
@@ -3,171 +3,84 @@ package com.pocketshell.core.usage
 import org.json.JSONException
 import org.json.JSONObject
 import java.time.Instant
-import kotlin.math.ceil
 
 /**
- * Parser for the normalized JSON produced by `pocketshell usage --json`.
+ * Parser for the per-provider NDJSON produced by `pocketshell usage --json`.
  *
- * `pocketshell usage --json` emits one JSON object per line (newline-delimited
- * JSON, also known as NDJSON). Each record has a fixed shape:
+ * `pocketshell usage` flattens quse's provider-keyed `--json` document into
+ * newline-delimited JSON — ONE object per line per provider. quse v0.0.9 is
+ * the single source of truth for the unified schema (issue #1318, D22
+ * hard-cut): the app reads quse's exact fields and does NOT re-derive windows
+ * / resets / percentages. Each record has this fixed shape:
  *
  * ```json
  * {
- *   "provider": "codex",
+ *   "provider": "claude",
  *   "status": "ok",
- *   "short_term": {"percent_remaining": 77.0, "reset_at": "...", "window": null},
- *   "long_term":  {"percent_remaining": 88.0, "reset_at": "...", "window": null},
+ *   "short_term": {"percent_remaining": 91.0, "reset_at": "2026-07-07T23:19:59Z", "window": "5h"},
+ *   "long_term":  {"percent_remaining": 30.0, "reset_at": "2026-07-09T14:59:59Z", "window": "7d"},
  *   "block_reason": null,
  *   "error": null,
- *   "details": { ... }
+ *   "details": { ... IGNORED by the app ... }
  * }
  * ```
  *
- * Either `short_term` or `long_term` (or both) may be present. `status`
- * values include `ok`, `unsupported`, `error`, and `limited` / `blocked`
- * for providers that have hit a quota wall. When `status == "error"` the
- * `error` field carries a free-form string.
+ * Either `short_term` or `long_term` (or both) may be present / null. The
+ * window label comes straight from `short_term.window` / `long_term.window`
+ * (e.g. `5h`, `7d`, `weekly`, `monthly`, or `null` → the generic key name).
+ * `status` values include `ok`, `unsupported`, `error`, and `limited` /
+ * `blocked`. When `status == "error"` the `error` field carries a free-form
+ * string. The app IGNORES `details` entirely — windows come from the unified
+ * top-level fields.
+ *
+ * STRICT / fail-loud (issue #1318): the parser expects quse's exact schema.
+ * Any malformed record — non-JSON line, missing `provider`, a `short_term` /
+ * `long_term` that is not an object — throws [UsageParseException], which the
+ * caller surfaces as a whole-panel error. There is no per-record
+ * skip-resilience, no `details.windows` alias fallback, and no re-derivation:
+ * a schema mismatch fails visibly instead of silently rendering a broken
+ * panel. Genuine RUNTIME states (SSH failure, quse-missing / exit != 0
+ * provider-error, empty `--cached`) are handled by the caller, not here.
  *
  * Parsing stays app-credential-free: the app only consumes JSON already
  * fetched by a server-side command.
  */
-public class PocketshellUsageJsonParser(
-    private val now: () -> Instant = { Instant.now() },
-) {
+public class PocketshellUsageJsonParser {
 
     @Throws(UsageParseException::class)
     public fun parse(input: String): List<UsageProviderRecord> {
         val trimmed = input.trim()
         if (trimmed.isEmpty()) return emptyList()
 
+        // `pocketshell usage --json` is newline-delimited JSON: exactly one
+        // provider record per line. We parse each non-blank line strictly and
+        // THROW on the first malformed line (fail-loud, issue #1318). No
+        // per-record skip-resilience, no multi-line accumulation — pocketshell
+        // emits compact single-line records, and any drift is a hard error.
         val records = mutableListOf<UsageProviderRecord>()
-        // Per-record resilience (issue #1223): an old/mismatched host CLI (or a
-        // custom `usageCommandOverride` wrapper) can emit one healthy provider
-        // record plus one drifted/malformed record, or prepend a non-JSON
-        // MOTD/deprecation line. We parse record-by-record, SKIP a record that
-        // fails (accumulating a per-record diagnostic), and return the ones that
-        // parsed. Only when ZERO records parse from non-empty input do we
-        // surface a whole-panel failure — this mirrors the graceful degradation
-        // the exit != 0 path (`parseProviderErrorStdout`) already has, and is the
-        // same version-skew class behind the v0.4.10 connect break (#847): one
-        // drifted line must not break the whole surface.
-        val diagnostics = mutableListOf<String>()
-        var candidateCount = 0
-        // `pocketshell usage --json` is newline-delimited JSON (NDJSON): one
-        // record per line. We also accept records that span multiple lines by
-        // accumulating until braces balance — this keeps the parser
-        // tolerant of pretty-printed output from custom wrapper scripts
-        // (per-host `usageCommandOverride`) without losing the
-        // per-record error reporting the line index gives us.
-        val buffer = StringBuilder()
-        var depth = 0
-        var inString = false
-        var escape = false
         for ((index, rawLine) in trimmed.lines().withIndex()) {
-            val line = rawLine
-            if (buffer.isEmpty() && line.isBlank()) continue
-            for (ch in line) {
-                buffer.append(ch)
-                if (escape) {
-                    escape = false
-                    continue
-                }
-                when (ch) {
-                    '\\' -> if (inString) escape = true
-                    '"' -> inString = !inString
-                    '{' -> if (!inString) depth += 1
-                    '}' -> if (!inString) depth -= 1
-                }
+            val line = rawLine.trim()
+            if (line.isEmpty()) continue
+            val obj = try {
+                JSONObject(line)
+            } catch (e: JSONException) {
+                throw UsageParseException(
+                    "invalid usage JSON near line ${index + 1}: ${e.message}",
+                    e,
+                )
             }
-            if (buffer.isNotEmpty() && depth == 0 && !inString) {
-                val record = buffer.toString().trim()
-                buffer.setLength(0)
-                if (record.isEmpty()) continue
-                candidateCount += 1
-                parseCandidate(record, index + 1)
-                    .onSuccess { records += it }
-                    .onFailure { diagnostics += (it.message ?: "invalid usage record near line ${index + 1}") }
-            } else if (buffer.isNotEmpty()) {
-                // Multi-line record: keep the newline so the next iteration
-                // separates tokens correctly.
-                buffer.append('\n')
-            }
-        }
-        if (buffer.isNotEmpty() && (depth != 0 || inString)) {
-            // A trailing, never-closed record. Count it as one more failed
-            // candidate rather than hard-failing the whole panel — the same
-            // skip-or-total-failure rule below decides the outcome.
-            candidateCount += 1
-            diagnostics += "invalid usage JSON: unterminated record"
-        }
-
-        if (records.isEmpty() && candidateCount > 0) {
-            // Non-empty input, nothing parsed: surface a visible failure (never
-            // a silent empty-success). The message aggregates every per-record
-            // diagnostic so the cause is still reportable.
-            throw UsageParseException(
-                "invalid usage JSON: no usable records (" +
-                    diagnostics.joinToString("; ").ifBlank { "all records unparseable" } +
-                    ")",
-            )
+            records += parseRecord(obj)
         }
         return records
-    }
-
-    private fun parseCandidate(record: String, lineNumber: Int): Result<UsageProviderRecord> = runCatching {
-        val obj = try {
-            JSONObject(record)
-        } catch (e: JSONException) {
-            throw UsageParseException("invalid usage JSON near line $lineNumber: ${e.message}", e)
-        }
-        parseRecord(obj)
     }
 
     private fun parseRecord(obj: JSONObject): UsageProviderRecord {
         val provider = obj.requiredString("provider")
         val rawStatus = obj.optString("status", "unknown").ifBlank { "unknown" }
-        val detailWindows = obj.optJSONObject("details")?.optJSONObject("windows")
 
         val windows = mutableListOf<UsageWindow>()
-        val codexCompatible = provider.isCodexCompatibleProvider()
-        parseWindow(
-            record = obj,
-            jsonKey = "short_term",
-            // Issue #800: Claude Code's short window is the same concrete 5h
-            // span Codex uses, so seed the span as the fallback window name
-            // when the record carries no explicit `window`. This makes the
-            // data-driven `windowLabel` mapping render "5h window" for Claude
-            // exactly like Codex, without any provider check in the UI layer.
-            // Codex itself still derives "5h"/"7d" from its detail-window
-            // `limit_window_seconds`; this fallback only fills providers whose
-            // span is genuinely fixed (Claude 5h/7d, Copilot monthly).
-            windowName = canonicalWindowName(provider, isShortTerm = true),
-            provider = provider,
-            detailWindow = detailWindows?.firstObject(
-                when {
-                    codexCompatible -> listOf("primary_window", "primary", "short_term", "five_hour", "5h")
-                    provider.equals("claude", ignoreCase = true) -> listOf("five_hour", "short_term", "5h")
-                    else -> emptyList()
-                },
-            ),
-            preferDetailPercent = codexCompatible,
-            preferDetailWindowMetadata = codexCompatible,
-        )?.let { windows += it }
-        parseWindow(
-            record = obj,
-            jsonKey = "long_term",
-            windowName = canonicalWindowName(provider, isShortTerm = false),
-            provider = provider,
-            detailWindow = detailWindows?.firstObject(
-                when {
-                    codexCompatible -> listOf("secondary_window", "secondary", "long_term", "seven_day", "7d")
-                    provider.equals("claude", ignoreCase = true) -> listOf("seven_day", "long_term", "7d")
-                    else -> emptyList()
-                },
-            ),
-            preferDetailPercent = codexCompatible,
-            preferDetailWindowMetadata = codexCompatible,
-        )?.let { windows += it }
+        parseWindow(record = obj, jsonKey = "short_term", provider = provider)?.let { windows += it }
+        parseWindow(record = obj, jsonKey = "long_term", provider = provider)?.let { windows += it }
 
         return UsageProviderRecord(
             provider = provider,
@@ -180,61 +93,46 @@ public class PocketshellUsageJsonParser(
     }
 
     /**
-     * Convert a usage window object into a [UsageWindow]. The
-     * `pocketshell usage --json` payload reports `percent_remaining`,
-     * while the PocketShell model uses
-     * `used` / `limit` in `percent` units; convert `percent_remaining = R`
-     * to `used = 100 - R, limit = 100, unit = "percent"`.
+     * Convert a usage window object into a [UsageWindow]. quse reports
+     * `percent_remaining`; the PocketShell model uses `used` / `limit` in
+     * `percent` units, so `percent_remaining = R` maps to
+     * `used = 100 - R, limit = 100, unit = "percent"`.
      *
-     * Returns `null` when the field is missing or null on the record
-     * (some providers only expose one of short/long term).
+     * The window NAME comes straight from quse's `window` field (`5h`, `7d`,
+     * `weekly`, `monthly`, …); when quse carries no span (`window: null`) the
+     * generic key name (`short_term` / `long_term`) is used so the UI's
+     * `windowLabel` humanizes it. The reset time comes straight from the
+     * `reset_at` field (canonical ISO-8601 UTC).
+     *
+     * Returns `null` when the field is absent / null on the record, or when
+     * the window carries no `percent_remaining` (some providers expose only
+     * one of short/long term). THROWS when the field is present but is not an
+     * object, or when `percent_remaining` / `reset_at` are malformed
+     * (fail-loud, issue #1318).
      */
     private fun parseWindow(
         record: JSONObject,
         jsonKey: String,
-        windowName: String,
         provider: String,
-        detailWindow: JSONObject? = null,
-        preferDetailPercent: Boolean = false,
-        preferDetailWindowMetadata: Boolean = false,
     ): UsageWindow? {
-        val obj = if (!record.has(jsonKey) || record.isNull(jsonKey)) {
-            null
-        } else {
-            record.opt(jsonKey) as? JSONObject
+        if (!record.has(jsonKey) || record.isNull(jsonKey)) return null
+        val obj = record.opt(jsonKey) as? JSONObject
             ?: throw UsageParseException("'$jsonKey' for $provider is not an object")
-        }
-        val detailPercentRemaining = detailWindow?.percentRemainingFromUsedPercent()
-        val percentRemaining = when {
-            preferDetailPercent && detailPercentRemaining != null -> detailPercentRemaining
-            obj != null && obj.has("percent_remaining") && !obj.isNull("percent_remaining") ->
-                obj.requiredNumber("percent_remaining", provider, jsonKey)
-            detailPercentRemaining != null -> detailPercentRemaining
-            else -> null
-        }
-        if (percentRemaining == null) {
-            // Per-provider window may exist but carry no value (e.g.
-            // copilot short_term is hardcoded but other providers may
-            // omit it). Treat as absent.
+
+        if (!obj.has("percent_remaining") || obj.isNull("percent_remaining")) {
+            // The window object exists but carries no value (e.g. a provider
+            // that only populates one range, or an error record with null
+            // percent). Treat as absent — no renderable window.
             return null
         }
+        val percentRemaining = obj.requiredNumber("percent_remaining", provider, jsonKey)
         val used = (100.0 - percentRemaining).coerceIn(0.0, 100.0)
-        val detailWindowLabel = detailWindow?.windowLabelFromLimitSeconds()
-        val topLevelWindowLabel = obj?.optionalString("window")
         return UsageWindow(
-            name = if (preferDetailWindowMetadata) {
-                detailWindowLabel ?: topLevelWindowLabel ?: windowName
-            } else {
-                topLevelWindowLabel ?: detailWindowLabel ?: windowName
-            },
+            name = obj.optionalString("window") ?: jsonKey,
             used = used,
             limit = 100.0,
             unit = "percent",
-            resetAt = if (preferDetailWindowMetadata) {
-                detailWindow?.optionalResetInstant(now) ?: obj?.optionalResetInstant(now)
-            } else {
-                obj?.optionalResetInstant(now) ?: detailWindow?.optionalResetInstant(now)
-            },
+            resetAt = obj.optionalResetInstant(),
         )
     }
 
@@ -262,46 +160,18 @@ public class PocketshellUsageJsonParser(
     }
 }
 
-private val CODEX_COMPATIBLE_PROVIDERS = setOf(
-    "codex",
-    "openai",
-    "openai-codex",
-    "openai_codex",
-    "chatgpt",
-)
-
 private const val CLAUDE_USAGE_AUTH_SETUP_MESSAGE =
     "Claude login needed on this host. " +
         "Open Claude Code on the host and sign in, then refresh usage."
 
-private fun String.isCodexCompatibleProvider(): Boolean =
-    lowercase().replace(' ', '_') in CODEX_COMPATIBLE_PROVIDERS
-
 /**
- * Issue #800: the fallback window name to use when a provider's record does
- * not carry an explicit `window` span. This is the data-driven hook the UI's
- * `windowLabel` mapping consumes, so providers with a genuinely fixed cadence
- * render the concrete label without any provider check in the Compose layer:
- *
- * - **Claude Code** — both windows are the same 5h / 7d spans as Codex, so
- *   surface them as "5h" / "7d" (renders "5h window" / "7d window").
- * - **GitHub Copilot** — the long-term quota is a monthly cycle, so surface
- *   "monthly" (renders "Monthly limit"), NOT 7d. Its short-term window is the
- *   fixed 100% bucket with no clean span, so it keeps the generic name.
- * - **Everything else** (Codex, Z.AI, unknown spans) keeps the generic
- *   `short_term` / `long_term` name. Codex still upgrades to "5h"/"7d" from its
- *   detail-window `limit_window_seconds`; the generic name only shows when no
- *   span is known, preserving the #522 humanizer fallback.
+ * Rewrite a provider `error` string into an actionable, human message. This is
+ * genuine error-message UX (a legit runtime state, kept per issue #1318), NOT
+ * schema re-derivation: it translates a couple of known auth failures into
+ * "here is what to do" text so the panel shows "sign in on the host" instead
+ * of a bare "HTTP Error 401". Idempotent — the rewritten messages do not
+ * re-match these patterns.
  */
-private fun canonicalWindowName(provider: String, isShortTerm: Boolean): String {
-    val normalized = provider.lowercase().replace(' ', '_')
-    return when {
-        normalized == "claude" -> if (isShortTerm) "5h" else "7d"
-        normalized == "copilot" && !isShortTerm -> "monthly"
-        else -> if (isShortTerm) "short_term" else "long_term"
-    }
-}
-
 private fun actionableProviderError(provider: String, error: String?): String? {
     val text = error?.trim()?.takeIf { it.isNotEmpty() } ?: return null
     val lower = text.lowercase()
@@ -349,13 +219,6 @@ private fun JSONObject.optionalString(name: String): String? {
     return optString(name).trim().ifBlank { null }
 }
 
-private fun JSONObject.firstObject(names: List<String>): JSONObject? {
-    names.forEach { name ->
-        optJSONObject(name)?.let { return it }
-    }
-    return null
-}
-
 private fun JSONObject.requiredNumber(name: String, provider: String, windowKey: String): Double {
     if (!has(name) || isNull(name)) {
         throw UsageParseException("missing '$name' for $provider $windowKey")
@@ -368,95 +231,28 @@ private fun JSONObject.requiredNumber(name: String, provider: String, windowKey:
     } ?: throw UsageParseException("invalid '$name' for $provider $windowKey")
 }
 
-private fun JSONObject.optionalInstant(name: String): Instant? {
-    if (!has(name) || isNull(name)) return null
-    val value = opt(name)
+/**
+ * Read quse's canonical `reset_at` (ISO-8601 UTC, e.g. `2026-07-07T23:19:59Z`).
+ * quse owns the timestamp format (issue #1318): the app parses that one field
+ * directly — no `resets_at` / `next_reset_at` / `reset_after_seconds` alias
+ * fallbacks. A malformed value THROWS (fail-loud). A numeric epoch-seconds
+ * value is still accepted as a convenience, but a bare non-ISO string is a
+ * hard error.
+ */
+private fun JSONObject.optionalResetInstant(): Instant? {
+    if (!has("reset_at") || isNull("reset_at")) return null
+    val value = opt("reset_at")
     if (value is Number) {
         return try {
             Instant.ofEpochSecond(value.toLong())
         } catch (e: Exception) {
-            throw UsageParseException("invalid '$name': $value", e)
+            throw UsageParseException("invalid 'reset_at': $value", e)
         }
     }
     val raw = value?.toString()?.trim()?.ifBlank { return null } ?: return null
-    raw.toLongOrNull()?.let { epochSeconds ->
-        return try {
-            Instant.ofEpochSecond(epochSeconds)
-        } catch (e: Exception) {
-            throw UsageParseException("invalid '$name': $raw", e)
-        }
-    }
     return try {
         Instant.parse(raw)
     } catch (e: Exception) {
-        throw UsageParseException("invalid '$name': $raw", e)
+        throw UsageParseException("invalid 'reset_at': $raw", e)
     }
-}
-
-private fun JSONObject.optionalResetInstant(now: () -> Instant): Instant? =
-    optionalInstant("reset_at")
-        ?: optionalInstant("resets_at")
-        ?: optionalInstant("resetAt")
-        ?: optionalInstant("resetsAt")
-        ?: optionalInstant("next_reset_at")
-        ?: optionalInstant("nextResetAt")
-        ?: optionalDurationSeconds("reset_after_seconds")?.let { seconds ->
-            try {
-                now().plusSeconds(seconds)
-            } catch (e: Exception) {
-                throw UsageParseException("invalid 'reset_after_seconds': $seconds", e)
-            }
-        }
-        ?: optionalDurationSeconds("reset_after")?.let { seconds ->
-            try {
-                now().plusSeconds(seconds)
-            } catch (e: Exception) {
-                throw UsageParseException("invalid 'reset_after': $seconds", e)
-            }
-        }
-
-private fun JSONObject.optionalDurationSeconds(name: String): Long? {
-    if (!has(name) || isNull(name)) return null
-    val value = opt(name)
-    val seconds = when (value) {
-        is Number -> value.toDouble()
-        is String -> value.trim().toDoubleOrNull()
-        else -> null
-    } ?: throw UsageParseException("invalid '$name': $value")
-    if (!seconds.isFinite() || seconds < 0.0) {
-        throw UsageParseException("invalid '$name': $value")
-    }
-    return ceil(seconds).toLong()
-}
-
-private fun JSONObject.percentRemainingFromUsedPercent(): Double? {
-    if (!has("used_percent") || isNull("used_percent")) return null
-    val value = opt("used_percent")
-    val used = when (value) {
-        is Number -> value.toDouble()
-        is String -> value.trim().toDoubleOrNull()
-        else -> null
-    } ?: return null
-    return (100.0 - used).coerceIn(0.0, 100.0)
-}
-
-private fun JSONObject.windowLabelFromLimitSeconds(): String? {
-    if (!has("limit_window_seconds") || isNull("limit_window_seconds")) return null
-    val seconds = when (val value = opt("limit_window_seconds")) {
-        is Number -> value.toLong()
-        is String -> value.trim().toLongOrNull()
-        else -> null
-    } ?: return null
-    if (seconds <= 0L) return null
-    val units = listOf(
-        24L * 60L * 60L to "d",
-        60L * 60L to "h",
-        60L to "m",
-    )
-    for ((unitSeconds, suffix) in units) {
-        if (seconds >= unitSeconds && seconds % unitSeconds == 0L) {
-            return "${seconds / unitSeconds}$suffix"
-        }
-    }
-    return "${seconds}s"
 }

--- a/shared/core-usage/src/test/java/com/pocketshell/core/usage/PocketshellUsageJsonParserTest.kt
+++ b/shared/core-usage/src/test/java/com/pocketshell/core/usage/PocketshellUsageJsonParserTest.kt
@@ -8,387 +8,81 @@ import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
+/**
+ * Strict-schema parser tests (issue #1318). `pocketshell usage --json` emits
+ * per-provider NDJSON flattened from quse v0.0.9's provider-keyed document;
+ * quse owns the unified schema, so each record carries `status`,
+ * `short_term`/`long_term` `{percent_remaining, reset_at, window}`, and
+ * `error` directly. The window label comes STRAIGHT from `*.window`. The
+ * parser is fail-loud: any schema drift throws (no details-window aliasing, no
+ * per-record skip-resilience). The app ignores `details`.
+ */
 class PocketshellUsageJsonParserTest {
 
     private val parser = PocketshellUsageJsonParser()
 
+    /** The four provider records as `pocketshell usage --json` emits them,
+     * flattened from the real quse-0.0.9 output (window + ISO reset_at). */
+    private val fourProviderNdjson = listOf(
+        """{"provider":"claude","status":"ok","short_term":{"percent_remaining":91.0,"reset_at":"2026-07-07T23:19:59Z","window":"5h"},"long_term":{"percent_remaining":30.0,"reset_at":"2026-07-09T14:59:59Z","window":"7d"},"error":null,"details":{"anything":true}}""",
+        """{"provider":"codex","status":"ok","short_term":{"percent_remaining":100.0,"reset_at":"2026-07-07T23:57:08Z","window":"5h"},"long_term":{"percent_remaining":2.0,"reset_at":"2026-07-11T06:23:55Z","window":"7d"},"error":null,"details":{}}""",
+        """{"provider":"copilot","status":"ok","short_term":{"percent_remaining":100.0,"reset_at":null,"window":null},"long_term":{"percent_remaining":97.1,"reset_at":"2026-08-01T00:00:00Z","window":"monthly"},"error":null,"details":{}}""",
+        """{"provider":"zai","status":"ok","short_term":{"percent_remaining":58.0,"reset_at":null,"window":"5h"},"long_term":{"percent_remaining":56.0,"reset_at":"2026-07-11T14:04:58Z","window":"weekly"},"error":null,"details":{}}""",
+    ).joinToString("\n")
+
     @Test
-    fun parse_codexHappyPath() {
-        val records = parser.parse(
-            """
-            {"provider":"codex","status":"ok",
-             "short_term":{"percent_remaining":77.0,"reset_at":"2026-05-24T15:53:01Z","window":null},
-             "long_term":{"percent_remaining":88.0,"reset_at":"2026-05-30T20:33:54Z","window":null},
-             "block_reason":null,"error":null,"details":{}}
-            """.trimIndent(),
-        )
+    fun parse_allFourProviders_renderWithWindowsLabelsAndResets() {
+        val records = parser.parse(fourProviderNdjson)
+        assertEquals(listOf("claude", "codex", "copilot", "zai"), records.map { it.provider })
+        records.forEach { assertEquals(UsageStatus.Ok, it.status) }
 
-        assertEquals(1, records.size)
-        val record = records.single()
-        assertEquals("codex", record.provider)
-        assertEquals(UsageStatus.Ok, record.status)
-        assertEquals("ok", record.rawStatus)
-        assertNull(record.blockReason)
-        assertNull(record.lastError)
+        val claude = records[0]
+        assertEquals(2, claude.windows.size)
+        assertEquals("5h", claude.windows[0].name)
+        assertEquals(9.0, claude.windows[0].percent, 0.001) // 100 - 91
+        assertEquals(Instant.parse("2026-07-07T23:19:59Z"), claude.windows[0].resetAt)
+        assertEquals("7d", claude.windows[1].name)
+        assertEquals(70.0, claude.windows[1].percent, 0.001) // 100 - 30
+        assertEquals(Instant.parse("2026-07-09T14:59:59Z"), claude.windows[1].resetAt)
 
-        assertEquals(2, record.windows.size)
+        val codex = records[1]
+        assertEquals("5h", codex.windows[0].name)
+        assertEquals("7d", codex.windows[1].name)
+        assertEquals(98.0, codex.windows[1].percent, 0.001) // 100 - 2
+
+        val copilot = records[2]
+        // short_term window is null -> generic key name; long_term is monthly.
+        assertEquals("short_term", copilot.windows[0].name)
+        assertNull(copilot.windows[0].resetAt)
+        assertEquals("monthly", copilot.windows[1].name)
+        assertTrue("copilot long-term must not be framed 7d", copilot.windows[1].name != "7d")
+        assertEquals(Instant.parse("2026-08-01T00:00:00Z"), copilot.windows[1].resetAt)
+
+        val zai = records[3]
+        assertEquals("5h", zai.windows[0].name)
+        assertEquals("weekly", zai.windows[1].name)
+        assertEquals(Instant.parse("2026-07-11T14:04:58Z"), zai.windows[1].resetAt)
+    }
+
+    @Test
+    fun parse_windowLabelComesStraightFromWindowField() {
+        val record = parser.parse(
+            """{"provider":"codex","status":"ok","short_term":{"percent_remaining":77.0,"reset_at":"2026-05-24T15:53:01Z","window":"5h"},"long_term":{"percent_remaining":88.0,"reset_at":"2026-05-30T20:33:54Z","window":"7d"},"error":null,"details":{}}""",
+        ).single()
+
         val shortTerm = record.windows[0]
-        assertEquals("short_term", shortTerm.name)
+        assertEquals("5h", shortTerm.name)
         assertEquals(23.0, shortTerm.used, 0.001)
         assertEquals(100.0, shortTerm.limit, 0.001)
         assertEquals("percent", shortTerm.unit)
-        assertEquals(23.0, shortTerm.percent, 0.001)
         assertEquals(Instant.parse("2026-05-24T15:53:01Z"), shortTerm.resetAt)
-
-        val longTerm = record.windows[1]
-        assertEquals("long_term", longTerm.name)
-        assertEquals(12.0, longTerm.used, 0.001)
-        assertEquals(12.0, longTerm.percent, 0.001)
-        assertEquals(Instant.parse("2026-05-30T20:33:54Z"), longTerm.resetAt)
-    }
-
-    @Test
-    fun parse_codexFallsBackToDetailWindowsAndEpochResets() {
-        val records = parser.parse(
-            """
-            {"provider":"codex","status":"ok",
-             "short_term":{"percent_remaining":100.0,"reset_at":null},
-             "long_term":{"percent_remaining":69.0,"reset_at":null},
-             "block_reason":null,"error":null,
-             "details":{"limit_reached":false,"windows":{
-               "primary_window":{
-                 "used_percent":12,
-                 "limit_window_seconds":18000,
-                 "reset_at":1780828285
-               },
-               "secondary_window":{
-                 "used_percent":31,
-                 "limit_window_seconds":604800,
-                 "reset_at":1781137638
-               }
-             }}}
-            """.trimIndent(),
-        )
-
-        val record = records.single()
-        assertEquals(2, record.windows.size)
-        assertEquals("5h", record.windows[0].name)
-        assertEquals(12.0, record.windows[0].percent, 0.001)
-        assertEquals(Instant.parse("2026-06-07T10:31:25Z"), record.windows[0].resetAt)
         assertEquals("7d", record.windows[1].name)
-        assertEquals(31.0, record.windows[1].percent, 0.001)
-        assertEquals(Instant.parse("2026-06-11T00:27:18Z"), record.windows[1].resetAt)
     }
 
     @Test
-    fun parse_codexFallsBackToDetailResetAfterSeconds() {
-        val parser = PocketshellUsageJsonParser(
-            now = { Instant.parse("2026-06-08T10:00:00Z") },
-        )
-        val records = parser.parse(
-            """
-            {"provider":"codex","status":"ok",
-             "short_term":{"percent_remaining":100.0,"reset_at":null},
-             "long_term":{"percent_remaining":69.0,"reset_at":null},
-             "block_reason":null,"error":null,
-             "details":{"windows":{
-               "primary_window":{
-                 "used_percent":12,
-                 "limit_window_seconds":18000,
-                 "reset_after_seconds":7200
-               },
-               "secondary_window":{
-                 "used_percent":31,
-                 "limit_window_seconds":604800,
-                 "reset_after_seconds":"604800"
-               }
-             }}}
-            """.trimIndent(),
-        )
-
-        val record = records.single()
-        assertEquals("5h", record.windows[0].name)
-        assertEquals(12.0, record.windows[0].percent, 0.001)
-        assertEquals(Instant.parse("2026-06-08T12:00:00Z"), record.windows[0].resetAt)
-        assertEquals("7d", record.windows[1].name)
-        assertEquals(31.0, record.windows[1].percent, 0.001)
-        assertEquals(Instant.parse("2026-06-15T10:00:00Z"), record.windows[1].resetAt)
-    }
-
-    @Test
-    fun parse_codexReadsResetFromDetailAliasesWhenTopLevelResetMissing() {
-        val parser = PocketshellUsageJsonParser(
-            now = { Instant.parse("2026-06-08T10:00:00Z") },
-        )
-        val records = parser.parse(
-            """
-            {"provider":"codex","status":"ok",
-             "short_term":{"percent_remaining":100.0,"reset_at":null},
-             "long_term":{"percent_remaining":100.0,"reset_at":null},
-             "block_reason":null,"error":null,
-             "details":{"windows":{
-               "primary":{
-                 "used_percent":65,
-                 "limit_window_seconds":18000,
-                 "next_reset_at":"2026-06-08T15:00:00Z"
-               },
-               "secondary":{
-                 "used_percent":20,
-                 "limit_window_seconds":604800,
-                 "reset_after":7200
-               }
-             }}}
-            """.trimIndent(),
-        )
-
-        val record = records.single()
-        assertEquals("5h", record.windows[0].name)
-        assertEquals(65.0, record.windows[0].percent, 0.001)
-        assertEquals(Instant.parse("2026-06-08T15:00:00Z"), record.windows[0].resetAt)
-        assertEquals("7d", record.windows[1].name)
-        assertEquals(20.0, record.windows[1].percent, 0.001)
-        assertEquals(Instant.parse("2026-06-08T12:00:00Z"), record.windows[1].resetAt)
-    }
-
-    @Test
-    fun parse_topLevelResetAfterSecondsWhenResetAtMissing() {
-        val parser = PocketshellUsageJsonParser(
-            now = { Instant.parse("2026-06-08T10:00:00Z") },
-        )
+    fun parse_nullWindow_fallsBackToGenericKeyName() {
         val record = parser.parse(
-            """{"provider":"codex","status":"ok",
-              "short_term":{"percent_remaining":35.0,"reset_at":null,"reset_after_seconds":3600,"window":"5h"},
-              "long_term":null,
-              "block_reason":null,"error":null,"details":{}}""".trimIndent(),
-        ).single()
-
-        assertEquals(65.0, record.windows.single().percent, 0.001)
-        assertEquals(Instant.parse("2026-06-08T11:00:00Z"), record.windows.single().resetAt)
-    }
-
-    @Test
-    fun parse_codexPrefersDetailWindowPeriodAndResetWhenTopLevelIsGeneric() {
-        val records = parser.parse(
-            """
-            {"provider":"codex","status":"ok",
-             "short_term":{"percent_remaining":100.0,"reset_at":"2026-06-07T00:00:00Z","window":"primary_window"},
-             "long_term":{"percent_remaining":69.0,"reset_at":"2026-06-10T00:00:00Z","window":"secondary_window"},
-             "block_reason":null,"error":null,
-             "details":{"windows":{
-               "primary_window":{
-                 "used_percent":12,
-                 "limit_window_seconds":18000,
-                 "reset_at":1780828285
-               },
-               "secondary_window":{
-                 "used_percent":31,
-                 "limit_window_seconds":604800,
-                 "reset_at":1781137638
-               }
-             }}}
-            """.trimIndent(),
-        )
-
-        val record = records.single()
-        assertEquals("5h", record.windows[0].name)
-        assertEquals(Instant.parse("2026-06-07T10:31:25Z"), record.windows[0].resetAt)
-        assertEquals("7d", record.windows[1].name)
-        assertEquals(Instant.parse("2026-06-11T00:27:18Z"), record.windows[1].resetAt)
-    }
-
-    @Test
-    fun parse_openAiCompatibleFallsBackToDetailWindowsAndPeriodLabels() {
-        val records = parser.parse(
-            """
-            {"provider":"openai","status":"ok",
-             "short_term":{"percent_remaining":100.0,"reset_at":null},
-             "long_term":{"percent_remaining":35.0,"reset_at":null},
-             "block_reason":null,"error":null,
-             "details":{"windows":{
-               "primary_window":{
-                 "used_percent":22,
-                 "limit_window_seconds":"18000",
-                 "reset_at":"2026-06-08T02:19:59Z"
-               },
-               "secondary_window":{
-                 "used_percent":65,
-                 "limit_window_seconds":604800,
-                 "reset_at":1781137637
-               }
-             }}}
-            """.trimIndent(),
-        )
-
-        val record = records.single()
-        assertEquals("openai", record.provider)
-        assertEquals(2, record.windows.size)
-        assertEquals("5h", record.windows[0].name)
-        assertEquals(22.0, record.windows[0].percent, 0.001)
-        assertEquals(Instant.parse("2026-06-08T02:19:59Z"), record.windows[0].resetAt)
-        assertEquals("7d", record.windows[1].name)
-        assertEquals(65.0, record.windows[1].percent, 0.001)
-        assertEquals(Instant.parse("2026-06-11T00:27:17Z"), record.windows[1].resetAt)
-    }
-
-    @Test
-    fun parse_claudeHappyPath() {
-        val records = parser.parse(
-            """{"provider":"claude","status":"ok",
-              "short_term":{"percent_remaining":41.0,"reset_at":"2026-05-24T14:30:00Z"},
-              "long_term":{"percent_remaining":85.0,"reset_at":"2026-05-28T14:59:59Z"},
-              "block_reason":null,"error":null,"details":{}}""".trimIndent(),
-        )
-
-        val record = records.single()
-        assertEquals("claude", record.provider)
-        assertEquals(UsageStatus.Ok, record.status)
-        assertEquals("Claude Code", record.displayName)
-        assertEquals(2, record.windows.size)
-        assertEquals(59.0, record.windows[0].percent, 0.001)
-        assertEquals(15.0, record.windows[1].percent, 0.001)
-    }
-
-    @Test
-    fun parse_copilotHappyPath_acceptsNullResetOnShortTerm() {
-        val records = parser.parse(
-            """{"provider":"copilot","status":"ok",
-              "short_term":{"percent_remaining":100.0,"reset_at":null},
-              "long_term":{"percent_remaining":96.6,"reset_at":"2026-06-01T00:00:00Z"},
-              "block_reason":null,"error":null,"details":{}}""".trimIndent(),
-        )
-
-        val record = records.single()
-        assertEquals("copilot", record.provider)
-        assertEquals(UsageStatus.Ok, record.status)
-        assertEquals("GitHub Copilot", record.displayName)
-        assertEquals(2, record.windows.size)
-        assertEquals(0.0, record.windows[0].percent, 0.001)
-        assertNull(record.windows[0].resetAt)
-        assertEquals(3.4, record.windows[1].percent, 0.001)
-    }
-
-    @Test
-    fun parse_zaiHappyPath() {
-        val records = parser.parse(
-            """{"provider":"zai","status":"ok",
-              "short_term":{"percent_remaining":100.0,"reset_at":"2026-05-27T10:31:58Z"},
-              "long_term":{"percent_remaining":100.0,"reset_at":null},
-              "block_reason":null,"error":null,"details":{}}""".trimIndent(),
-        )
-
-        val record = records.single()
-        assertEquals("zai", record.provider)
-        assertEquals(UsageStatus.Ok, record.status)
-        assertEquals(2, record.windows.size)
-        record.windows.forEach { assertEquals(0.0, it.percent, 0.001) }
-    }
-
-    @Test
-    fun parse_unsupportedStatus_forGemini() {
-        val records = parser.parse(
-            """{"provider":"gemini","status":"unsupported",
-              "short_term":null,"long_term":null,
-              "block_reason":null,
-              "error":"gemini does not expose a usage endpoint","details":{}}""".trimIndent(),
-        )
-
-        val record = records.single()
-        assertEquals("gemini", record.provider)
-        assertEquals(UsageStatus.Unsupported, record.status)
-        assertTrue("expected windows to be empty when both ranges are null", record.windows.isEmpty())
-        assertEquals("gemini does not expose a usage endpoint", record.lastError)
-    }
-
-    @Test
-    fun parse_errorStatus_surfacesErrorField() {
-        val records = parser.parse(
-            """{"provider":"codex","status":"error",
-              "short_term":null,"long_term":null,
-              "block_reason":null,
-              "error":"login required: run codex login","details":{}}""".trimIndent(),
-        )
-
-        val record = records.single()
-        assertEquals(UsageStatus.Error, record.status)
-        assertEquals("login required: run codex login", record.lastError)
-        assertTrue(record.windows.isEmpty())
-    }
-
-    @Test
-    fun parse_claudeUnauthorizedMapsToUsageDataUnavailable() {
-        val record = parser.parse(
-            """{"provider":"claude","status":"error",
-              "short_term":{"percent_remaining":null,"reset_at":null},
-              "long_term":{"percent_remaining":null,"reset_at":null},
-              "block_reason":null,
-              "error":"HTTP Error 401: Unauthorized","details":{}}""".trimIndent(),
-        ).single()
-
-        assertEquals(UsageStatus.Error, record.status)
-        assertEquals(
-            "Claude login needed on this host. " +
-                "Open Claude Code on the host and sign in, then refresh usage.",
-            record.lastError,
-        )
-        assertTrue(record.lastError?.contains("claude " + "/login") == false)
-        assertTrue(record.lastError?.contains("authentication " + "failed", ignoreCase = true) == false)
-        assertTrue(record.lastError?.contains("HTTP Error 401", ignoreCase = true) == false)
-    }
-
-    @Test
-    fun parse_claudeWindowsCarryConcrete5hAnd7dSpans() {
-        // #800: Claude Code's short/long windows are the same 5h/7d spans as
-        // Codex. The record carries the generic short_term/long_term keys with
-        // no explicit `window`, so the parser seeds the canonical span name so
-        // the UI's windowLabel renders "5h window" / "7d window" — data-driven,
-        // no provider check in the Compose layer.
-        val record = parser.parse(
-            """{"provider":"claude","status":"ok",
-              "short_term":{"percent_remaining":59.0,"reset_at":"2026-05-24T14:30:00Z","window":null},
-              "long_term":{"percent_remaining":15.0,"reset_at":"2026-05-28T14:59:59Z","window":null},
-              "block_reason":null,"error":null,"details":{}}""".trimIndent(),
-        ).single()
-
-        assertEquals("claude", record.provider)
-        assertEquals(2, record.windows.size)
-        assertEquals("5h", record.windows[0].name)
-        assertEquals(41.0, record.windows[0].percent, 0.001)
-        assertEquals("7d", record.windows[1].name)
-        assertEquals(85.0, record.windows[1].percent, 0.001)
-    }
-
-    @Test
-    fun parse_copilotLongTermIsMonthlyNot7d() {
-        // #800: Copilot's long-term quota is a monthly cycle. It must keep its
-        // real cadence label, NOT be framed as a 7d window. The short-term
-        // window stays generic (fixed 100% bucket with no clean span).
-        val record = parser.parse(
-            """{"provider":"copilot","status":"ok",
-              "short_term":{"percent_remaining":100.0,"reset_at":null},
-              "long_term":{"percent_remaining":96.6,"reset_at":"2026-07-01T00:00:00Z"},
-              "block_reason":null,"error":null,"details":{}}""".trimIndent(),
-        ).single()
-
-        assertEquals("copilot", record.provider)
-        assertEquals(2, record.windows.size)
-        assertEquals("short_term", record.windows[0].name)
-        assertEquals("monthly", record.windows[1].name)
-        assertTrue(
-            "copilot long-term must not be framed as a 7d window",
-            record.windows[1].name != "7d",
-        )
-    }
-
-    @Test
-    fun parse_zaiKeepsGenericWindowNames() {
-        // #800 regression guard: providers with unknown spans must NOT get
-        // forced into 5h/7d — they keep the generic names so windowLabel
-        // humanizes them (Short term / Long term), preserving #522.
-        val record = parser.parse(
-            """{"provider":"zai","status":"ok",
-              "short_term":{"percent_remaining":100.0,"reset_at":"2026-05-27T10:31:58Z"},
-              "long_term":{"percent_remaining":100.0,"reset_at":null},
-              "block_reason":null,"error":null,"details":{}}""".trimIndent(),
+            """{"provider":"zai","status":"ok","short_term":{"percent_remaining":100.0,"reset_at":null,"window":null},"long_term":{"percent_remaining":100.0,"reset_at":null,"window":null},"error":null,"details":{}}""",
         ).single()
 
         assertEquals("short_term", record.windows[0].name)
@@ -396,15 +90,41 @@ class PocketshellUsageJsonParserTest {
     }
 
     @Test
-    fun parse_claudeStaleAuthTelemetryMessageMapsToUsageDataUnavailable() {
-        val staleError = "Claude Code authentication " + "failed on this host. Run `claude " +
-            "/login` in the host shell, then refresh usage."
+    fun parse_displayNames() {
+        val records = parser.parse(fourProviderNdjson)
+        assertEquals("Claude Code", records[0].displayName)
+        assertEquals("Codex", records[1].displayName)
+        assertEquals("GitHub Copilot", records[2].displayName)
+    }
+
+    // -- genuine runtime states (kept) ---------------------------------------
+
+    @Test
+    fun parse_unsupportedStatus_forGemini() {
         val record = parser.parse(
-            """{"provider":"claude","status":"error",
-              "short_term":{"percent_remaining":null,"reset_at":null},
-              "long_term":{"percent_remaining":null,"reset_at":null},
-              "block_reason":null,
-              "error":${org.json.JSONObject.quote(staleError)},"details":{}}""".trimIndent(),
+            """{"provider":"gemini","status":"unsupported","short_term":null,"long_term":null,"error":"gemini does not expose a usage endpoint","details":{}}""",
+        ).single()
+
+        assertEquals(UsageStatus.Unsupported, record.status)
+        assertTrue(record.windows.isEmpty())
+        assertEquals("gemini does not expose a usage endpoint", record.lastError)
+    }
+
+    @Test
+    fun parse_errorStatus_surfacesErrorField() {
+        val record = parser.parse(
+            """{"provider":"codex","status":"error","short_term":null,"long_term":null,"error":"login required: run codex login","details":{}}""",
+        ).single()
+
+        assertEquals(UsageStatus.Error, record.status)
+        assertEquals("login required: run codex login", record.lastError)
+        assertTrue(record.windows.isEmpty())
+    }
+
+    @Test
+    fun parse_claudeUnauthorizedMapsToActionableError() {
+        val record = parser.parse(
+            """{"provider":"claude","status":"error","short_term":{"percent_remaining":null,"reset_at":null},"long_term":{"percent_remaining":null,"reset_at":null},"error":"HTTP Error 401: Unauthorized","details":{}}""",
         ).single()
 
         assertEquals(UsageStatus.Error, record.status)
@@ -413,58 +133,45 @@ class PocketshellUsageJsonParserTest {
                 "Open Claude Code on the host and sign in, then refresh usage.",
             record.lastError,
         )
-        assertTrue(record.lastError?.contains("claude " + "/login") == false)
-        assertTrue(record.lastError?.contains("authentication " + "failed", ignoreCase = true) == false)
-        assertTrue(record.lastError?.contains("provider " + "blocked", ignoreCase = true) == false)
+        assertTrue(record.lastError?.contains("HTTP Error 401", ignoreCase = true) == false)
+        // percent_remaining null on both windows -> no renderable windows.
+        assertTrue(record.windows.isEmpty())
     }
 
     @Test
-    fun parse_codexExhaustedStatus_mapsToBlockedExceededRecord() {
-        val records = parser.parse(
-            """{"provider":"codex","status":"quota-exhausted",
-              "short_term":null,"long_term":null,
-              "block_reason":"Codex quota exhausted",
-              "error":null,"details":{"message":"quota exhausted"}}""".trimIndent(),
-        )
+    fun parse_blockedStatus_mapsToBlockedExceededRecord() {
+        val record = parser.parse(
+            """{"provider":"codex","status":"quota-exhausted","short_term":null,"long_term":null,"block_reason":"Codex quota exhausted","error":null,"details":{"message":"quota exhausted"}}""",
+        ).single()
 
-        val record = records.single()
-        assertEquals("codex", record.provider)
         assertEquals(UsageStatus.Blocked, record.status)
         assertEquals("quota-exhausted", record.rawStatus)
         assertEquals("Codex quota exhausted", record.blockReason)
-        assertTrue(record.windows.isEmpty())
         assertTrue(record.isBlocked)
         assertEquals(UsageThresholdState.Exceeded, record.thresholdState())
     }
 
     @Test
-    fun parse_acceptsMultipleNdjsonLines() {
+    fun parse_multipleNdjsonLines() {
         val records = parser.parse(
             """
-            {"provider":"codex","status":"ok","short_term":{"percent_remaining":50.0},"long_term":null,"block_reason":null,"error":null,"details":{}}
+            {"provider":"codex","status":"ok","short_term":{"percent_remaining":50.0},"long_term":null,"error":null,"details":{}}
             {"provider":"claude","status":"limited","short_term":{"percent_remaining":0.0},"long_term":null,"block_reason":"weekly limit reached","error":null,"details":{}}
             """.trimIndent(),
         )
-
         assertEquals(2, records.size)
-        assertEquals("codex", records[0].provider)
         assertEquals(UsageStatus.Ok, records[0].status)
-        assertEquals("claude", records[1].provider)
         assertEquals(UsageStatus.Blocked, records[1].status)
         assertEquals("weekly limit reached", records[1].blockReason)
-        assertTrue(records[1].isBlocked)
     }
 
     @Test
     fun parse_skipsBlankLines() {
         val records = parser.parse(
-            """
-
-            {"provider":"codex","status":"ok","short_term":{"percent_remaining":77.0},"long_term":null,"block_reason":null,"error":null,"details":{}}
-
-            """.trimIndent(),
+            "\n\n" +
+                """{"provider":"codex","status":"ok","short_term":{"percent_remaining":77.0},"long_term":null,"error":null,"details":{}}""" +
+                "\n\n",
         )
-
         assertEquals(1, records.size)
     }
 
@@ -477,12 +184,13 @@ class PocketshellUsageJsonParserTest {
     @Test
     fun parse_preservesUnknownStatus() {
         val record = parser.parse(
-            """{"provider":"x","status":"maintenance","short_term":null,"long_term":null,"block_reason":null,"error":null,"details":{}}""",
+            """{"provider":"x","status":"maintenance","short_term":null,"long_term":null,"error":null,"details":{}}""",
         ).single()
-
         assertEquals(UsageStatus.Unknown, record.status)
         assertEquals("maintenance", record.rawStatus)
     }
+
+    // -- fail-loud on schema mismatch (issue #1318: no skip-resilience) ------
 
     @Test
     fun parse_rejectsMalformedJson() {
@@ -497,7 +205,7 @@ class PocketshellUsageJsonParserTest {
     fun parse_rejectsNonObjectWindowField() {
         val error = assertThrows(UsageParseException::class.java) {
             parser.parse(
-                """{"provider":"x","status":"ok","short_term":"not an object","long_term":null,"block_reason":null,"error":null,"details":{}}""",
+                """{"provider":"x","status":"ok","short_term":"not an object","long_term":null,"error":null,"details":{}}""",
             )
         }
         assertTrue(error.message!!.contains("short_term"))
@@ -507,82 +215,49 @@ class PocketshellUsageJsonParserTest {
     fun parse_rejectsMissingProvider() {
         assertThrows(UsageParseException::class.java) {
             parser.parse(
-                """{"status":"ok","short_term":null,"long_term":null,"block_reason":null,"error":null,"details":{}}""",
+                """{"status":"ok","short_term":null,"long_term":null,"error":null,"details":{}}""",
             )
         }
     }
 
-    // -- issue #1223: per-record resilience on the exit-0 success path --------
-    //
-    // An old/mismatched host CLI (or a custom usageCommandOverride wrapper) can
-    // emit one healthy provider record plus one drifted/malformed record, or
-    // prepend a non-JSON MOTD/deprecation line. Before #1223 the FIRST bad
-    // record threw and discarded ALL providers. Parse must now skip the bad
-    // record and return the ones that parsed; only zero parsed records is a
-    // whole-panel failure (mirrors the exit != 0 graceful path #847 class).
-
     @Test
-    fun parse_skipsDriftedRecordAndKeepsHealthyProvider() {
-        // Healthy record is FIRST so we prove an already-parsed provider is not
-        // discarded when a LATER record drifts (missing `provider`).
-        val records = parser.parse(
-            """
-            {"provider":"codex","status":"ok","short_term":{"percent_remaining":77.0},"long_term":null,"block_reason":null,"error":null,"details":{}}
-            {"status":"ok","short_term":"not-an-object","long_term":null,"block_reason":null,"error":null,"details":{}}
-            """.trimIndent(),
-        )
-
-        assertEquals(1, records.size)
-        assertEquals("codex", records.single().provider)
-        assertEquals(UsageStatus.Ok, records.single().status)
-    }
-
-    @Test
-    fun parse_skipsNonJsonPreambleLineAndRendersAllValidProviders() {
-        // A wrapper/MOTD prints a non-JSON preamble line before the NDJSON. All
-        // valid provider records after it must still render.
-        val records = parser.parse(
-            """
-            WARNING: pocketshell 0.3.1 is deprecated, upgrade with: uv tool upgrade pocketshell
-            {"provider":"codex","status":"ok","short_term":{"percent_remaining":50.0},"long_term":null,"block_reason":null,"error":null,"details":{}}
-            {"provider":"claude","status":"ok","short_term":{"percent_remaining":41.0},"long_term":null,"block_reason":null,"error":null,"details":{}}
-            """.trimIndent(),
-        )
-
-        assertEquals(2, records.size)
-        assertEquals("codex", records[0].provider)
-        assertEquals("claude", records[1].provider)
-    }
-
-    @Test
-    fun parse_throwsWhenZeroRecordsParse() {
-        // Non-empty input where NOTHING parses must still surface a visible
-        // failure (no silent empty-success). The message aggregates the
-        // per-record diagnostics.
+    fun parse_throwsOnOneBadLineAmongValid_noSkipResilience() {
+        // Issue #1318 hard-cut: a drifted/malformed record among healthy ones
+        // must FAIL THE WHOLE PANEL (fail-loud), NOT be silently skipped. This
+        // is the deleted #1223 skip-resilience — the app now expects quse's
+        // exact schema and throws on any drift.
         val error = assertThrows(UsageParseException::class.java) {
             parser.parse(
                 """
-                this is not json
-                also not json {broken
+                {"provider":"codex","status":"ok","short_term":{"percent_remaining":77.0},"long_term":null,"error":null,"details":{}}
+                {"status":"ok","short_term":"not-an-object","long_term":null,"error":null,"details":{}}
                 """.trimIndent(),
             )
         }
         assertNotNull(error.message)
-        assertTrue(error.message!!.contains("invalid usage JSON"))
     }
 
     @Test
-    fun parse_skipsMalformedJsonRecordAmongValidOnes() {
-        // A record with broken JSON syntax sandwiched between two valid ones is
-        // skipped; the two valid providers still render.
-        val records = parser.parse(
-            """
-            {"provider":"codex","status":"ok","short_term":{"percent_remaining":77.0},"long_term":null,"block_reason":null,"error":null,"details":{}}
-            {"provider":"claude","status":"ok","short_term":{"percent_remaining":not-a-number}}
-            {"provider":"copilot","status":"ok","short_term":{"percent_remaining":90.0},"long_term":null,"block_reason":null,"error":null,"details":{}}
-            """.trimIndent(),
-        )
+    fun parse_throwsOnNonJsonPreambleLine_noSkipResilience() {
+        // A non-JSON MOTD/deprecation preamble line is a schema violation now:
+        // the parser throws instead of quietly skipping it.
+        assertThrows(UsageParseException::class.java) {
+            parser.parse(
+                """
+                WARNING: pocketshell 0.3.1 is deprecated
+                {"provider":"codex","status":"ok","short_term":{"percent_remaining":50.0},"long_term":null,"error":null,"details":{}}
+                """.trimIndent(),
+            )
+        }
+    }
 
-        assertEquals(listOf("codex", "copilot"), records.map { it.provider })
+    @Test
+    fun parse_rejectsMalformedResetAt() {
+        val error = assertThrows(UsageParseException::class.java) {
+            parser.parse(
+                """{"provider":"codex","status":"ok","short_term":{"percent_remaining":50.0,"reset_at":"not-a-date"},"long_term":null,"error":null,"details":{}}""",
+            )
+        }
+        assertTrue(error.message!!.contains("reset_at"))
     }
 }

--- a/tools/pocketshell/pyproject.toml
+++ b/tools/pocketshell/pyproject.toml
@@ -27,12 +27,19 @@ classifiers = [
     "Topic :: Software Development",
     "Topic :: System :: Monitoring",
 ]
-# `pocketshell usage` delegates to the existing `quse` CLI via subprocess
-# (see `pocketshell/usage.py`) so this utility does not need `quse`
-# published on PyPI; the provider-detection implementation may be folded
-# in directly later. Pin lower-bound only.
+# `pocketshell usage` delegates to the `quse` CLI, which is now a PINNED
+# hard dependency (issue #1318): quse owns the unified usage schema, so we
+# ship a known-good quse WITH pocketshell and invoke that pinned console-
+# script (next to `sys.executable`, never PATH — see `pocketshell/usage.py`
+# `_resolve_quse_binary`). A host-level quse upgrade must not reach us.
 dependencies = [
     "click>=8.2.0",
+    # Usage backend + single source of truth for the unified provider schema
+    # (issue #1318). Pinned exactly: `pocketshell usage --json` expects quse
+    # 0.0.9's provider-keyed `--json` document (per provider: status +
+    # short_term/long_term {percent_remaining, reset_at, window} + error) and
+    # fails loudly on any schema drift, so the version is frozen, not a range.
+    "quse==0.0.9",
     # FCM HTTP v1 push delivery (#690): service-account OAuth2 bearer minting
     # for `pocketshell push` / the `usage --capture` reset-push send. Imported
     # lazily and fail-soft — a host without it (or without a Firebase

--- a/tools/pocketshell/src/pocketshell/daemon.py
+++ b/tools/pocketshell/src/pocketshell/daemon.py
@@ -358,11 +358,11 @@ def _usage_fetch_handler(params: Mapping[str, Any]) -> dict[str, Any]:
        }
 
     Returning stdout in the envelope preserves the CLI/daemon contract.
-    The stdout is normalized by :mod:`pocketshell.usage` before it is cached,
-    because ``quse --json`` can expose provider quirks that are not the
-    PocketShell app-facing schema. ``quse --json`` emits **NDJSON** (one
-    provider per line, not a single document), so normalization keeps that
-    line-oriented wire format.
+    ``quse --json`` emits a **provider-keyed JSON object**; the daemon
+    FLATTENS it into per-provider NDJSON via
+    :func:`pocketshell.usage.normalize_usage_stdout` before caching, so the
+    cached envelope stdout is already the app-facing NDJSON wire format (the
+    CLI proxies it verbatim, without re-flattening).
     """
     # Lazy import to avoid a circular module load at startup: the
     # daemon module is imported from ``cli.py`` which also imports
@@ -378,17 +378,13 @@ def _usage_fetch_handler(params: Mapping[str, Any]) -> dict[str, Any]:
 
     quse_path = _usage._resolve_quse_binary()
     if quse_path is None:
-        # Mirror the CLI's exit-127 behaviour. The daemon does NOT
-        # cache this; a `quse` install during the daemon's lifetime
-        # should be picked up on the next call.
+        # quse is bundled WITH pocketshell (issue #1318): a missing pinned
+        # copy is a packaging-integrity error, not a "install quse" nag. The
+        # daemon does NOT cache this failure.
         return {
             "stdout": "",
-            "stderr": (
-                "pocketshell: `quse` is not installed on this host. "
-                "Install it via `uv tool install quse` or `pipx install quse` "
-                "and re-run.\n"
-            ),
-            "returncode": 127,
+            "stderr": _usage._QUSE_MISSING_MESSAGE + "\n",
+            "returncode": _usage._QUSE_MISSING_EXIT_CODE,
             "provider": provider,
         }
 
@@ -402,8 +398,16 @@ def _usage_fetch_handler(params: Mapping[str, Any]) -> dict[str, Any]:
         capture_output=True,
         text=True,
     )
+    # Only a successful (exit 0) quse run is flattened into per-provider
+    # NDJSON. A failed fetch is proxied raw (it is not a valid provider-keyed
+    # document, and the daemon does not cache failures anyway).
+    stdout = (
+        _usage.normalize_usage_stdout(completed.stdout)
+        if completed.returncode == 0
+        else completed.stdout
+    )
     return {
-        "stdout": _usage.normalize_usage_stdout(completed.stdout),
+        "stdout": stdout,
         "stderr": completed.stderr,
         "returncode": completed.returncode,
         "provider": provider,

--- a/tools/pocketshell/src/pocketshell/usage.py
+++ b/tools/pocketshell/src/pocketshell/usage.py
@@ -1,17 +1,33 @@
 """`pocketshell usage` subcommand.
 
-Implementation delegates to the existing `quse` CLI via `subprocess.run`
-and normalizes JSON records into PocketShell's app-facing schema. Human
-output is proxied verbatim.
+Implementation delegates to the **pinned** `quse` CLI via `subprocess.run`
+and FLATTENS its provider-keyed `--json` document into the per-provider
+NDJSON the Android app consumes. Human output is proxied verbatim.
 
-Daemon mode (issue #219, first PR scope)
-----------------------------------------
+quse is the single source of truth for the unified schema (issue #1318,
+D22 hard-cut): pocketshell does NOT re-derive windows / resets / percentages
+downstream. It parses quse's provider-keyed object, injects the `provider`
+name from each key, and passes quse's unified fields through unchanged. A
+schema mismatch (non-JSON / non-object payload) raises loudly rather than
+silently emptying the panel.
+
+quse is a hard dependency of pocketshell (see `pyproject.toml`), so its
+console-script ships in the SAME bin directory as the running interpreter.
+`_resolve_quse_binary` resolves that pinned copy next to `sys.executable`
+and NEVER falls back to PATH — a host-level `quse` upgrade must not shadow
+the pinned copy, and a missing pinned copy is a packaging-integrity error
+(fail loud), not a user "install quse" nag.
+
+Daemon mode (issue #219)
+------------------------
 
 When the IPC daemon is running, ``pocketshell usage --json`` sends a
 ``usage.fetch`` JSON-RPC request to ``$XDG_RUNTIME_DIR/pocketshell/daemon.sock``
-instead of forking ``quse`` itself. The daemon caches the result for
-30 s, so a polled usage row in the Android app returns the second-and-
-later calls in microseconds.
+instead of forking ``quse`` itself. The daemon caches the ALREADY-FLATTENED
+NDJSON for 30 s, so a polled usage row in the Android app returns the
+second-and-later calls in microseconds. The daemon performs the flatten
+before caching; the CLI proxies the daemon's NDJSON verbatim (it is NOT
+re-flattened — that would fail, NDJSON is not a provider-keyed object).
 
 The fall-through is intentional and matches the spike's Q6 parity rule:
 
@@ -19,91 +35,84 @@ The fall-through is intentional and matches the spike's Q6 parity rule:
   daemon is up (debugging / belt-and-braces).
 - ``--no-cache`` is honoured by the daemon (cache miss + populate)
   but is intentionally a no-op on the subprocess path: there is no
-  cache to bypass when every call is a fresh subprocess. This keeps
-  the CLI surface uniform without paying for client-side caching that
-  duplicates the daemon's logic.
+  cache to bypass when every call is a fresh subprocess.
 - The probe is best-effort: any error talking to the daemon
   (``ECONNREFUSED``, stale socket, version-skew RPC error, slow
   reply) falls through silently to the subprocess path. The daemon
   never blocks correctness.
-
-Why subprocess instead of `import quse`:
-
-- `quse` is currently not published to PyPI; declaring it as a normal
-  `pyproject.toml` dependency would break `uv tool install
-  pocketshell` for any user (including the maintainer's dev box).
-- Subprocess delegation keeps `pocketshell` decoupled from `quse`'s
-  internal module layout, so updates to `quse` don't break the wrapper.
-- The PATH-discovery story for `quse` is solved by the Android bootstrap
-  wrapper, which derives PATH from the user's shell rc before probing
-  tools. Delegating to whatever `quse` is on PATH keeps this wrapper
-  decoupled from that bootstrap plumbing.
-
-Later PRs will fold the provider-detection logic in directly so
-`pocketshell` is the canonical implementation and the subprocess
-hop disappears, but that is explicit non-scope here per the brief on
-issue [#170](https://github.com/alexeygrigorev/pocketshell/issues/170).
 """
 
 from __future__ import annotations
 
-import shutil
 import subprocess
 import sys
-from datetime import datetime, timezone
 import json
 from pathlib import Path
 from typing import Any, Optional, Sequence
-import urllib.error
-import urllib.request
 
 import click
 
-_CODEX_USAGE_URL = "https://chatgpt.com/backend-api/wham/usage"
-_CODEX_AUTH_PATH = Path.home() / ".codex" / "auth.json"
-_CODEX_COMPATIBLE_PROVIDERS = {
-    "codex",
-    "openai",
-    "openai-codex",
-    "openai_codex",
-    "chatgpt",
-}
 _CLAUDE_USAGE_AUTH_SETUP_MESSAGE = (
     "Claude usage authentication needs setup on this host. "
     "Open Claude Code on the host and complete sign-in, then refresh usage."
 )
 
+# quse is bundled WITH pocketshell as a pinned dependency (issue #1318). A
+# missing pinned quse is therefore a packaging-integrity error, NOT a user
+# "install quse" nag: the fix is reinstalling pocketshell, not installing a
+# separate host tool. Exit non-zero (but NOT 127 — 127 is reserved for
+# "pocketshell itself not found" on the app side) with a clear message.
+_QUSE_MISSING_MESSAGE = (
+    "pocketshell: the bundled `quse` usage backend is missing from this "
+    "pocketshell install. Reinstall pocketshell (e.g. "
+    "`uv tool install --force pocketshell`) to restore it."
+)
+_QUSE_MISSING_EXIT_CODE = 1
+
 
 def _resolve_quse_binary() -> Optional[str]:
-    """Locate the `quse` CLI on PATH, or return ``None`` if absent.
+    """Resolve the PINNED `quse` console-script shipped with pocketshell.
 
-    Pulled out as a function so the unit suite can monkeypatch it.
-    `shutil.which` returns the same path the user would see from
-    `command -v quse`, which is the probe the Android app already runs.
+    quse is a hard dependency (pyproject ``dependencies``), so its
+    console-script lands in the SAME ``bin`` directory as the ``pocketshell``
+    interpreter (the venv / ``uv tool`` install dir). We resolve it there —
+    next to ``sys.executable`` — and NEVER fall back to ``PATH``: a
+    host-level ``quse`` on PATH must not shadow the pinned copy (a host
+    upgrade must not reach us), and a missing pinned copy is a
+    packaging-integrity error, not a "please install quse" nag. Returns the
+    absolute path, or ``None`` when the pinned copy is absent. Pulled out so
+    the unit suite can monkeypatch it.
+
+    Console-scripts live next to the UNRESOLVED ``sys.executable``: in a venv
+    (or a ``uv tool`` install) ``bin/python`` is a symlink to the underlying
+    interpreter, so ``Path(sys.executable).resolve()`` points at the shared
+    interpreter dir where ``quse`` is NOT installed. We therefore check the
+    interpreter's own ``bin`` dir first, and only fall through to the
+    resolved dir for layouts where the two coincide. Both candidates are
+    anchored to ``sys.executable`` — this is NOT a PATH search.
     """
-    return shutil.which("quse")
+    exe_dir = Path(sys.executable).parent
+    candidates = [exe_dir]
+    resolved_dir = Path(sys.executable).resolve().parent
+    if resolved_dir != exe_dir:
+        candidates.append(resolved_dir)
+    for bin_dir in candidates:
+        candidate = bin_dir / "quse"
+        if candidate.exists():
+            return str(candidate)
+    return None
 
 
 def _run_quse(args: Sequence[str]) -> int:
-    """Invoke `quse` with [args]; proxy stdout/stderr and exit code.
+    """Invoke the pinned `quse` with [args]; proxy stdout/stderr and exit.
 
-    Using `subprocess.run(..., check=False)` and forwarding the captured
-    output rather than `os.execvp` keeps the call testable (the test
-    suite can monkeypatch `subprocess.run`) and lets us decorate the
-    failure mode with a friendly hint when `quse` is missing.
+    Used for the human-readable (non-JSON) path where output stays
+    byte-identical to `quse`.
     """
     quse_path = _resolve_quse_binary()
     if quse_path is None:
-        # Same wording the bootstrap sheet uses so the user sees a
-        # consistent message whether they hit the bin via `pocketshell
-        # usage` or the app's poll loop.
-        click.echo(
-            "pocketshell: `quse` is not installed on this host. "
-            "Install it via `uv tool install quse` or `pipx install quse` "
-            "and re-run.",
-            err=True,
-        )
-        return 127
+        click.echo(_QUSE_MISSING_MESSAGE, err=True)
+        return _QUSE_MISSING_EXIT_CODE
 
     completed = subprocess.run(
         [quse_path, *args],
@@ -119,166 +128,15 @@ def _run_quse(args: Sequence[str]) -> int:
     return completed.returncode
 
 
-def _normalize_reset_at(value: Any) -> Optional[str]:
-    """Return an ISO-8601 UTC reset timestamp, accepting provider quirks.
-
-    OpenAI's Codex usage endpoint currently returns ``reset_at`` as Unix epoch
-    seconds. Older ``quse`` releases attempted ISO parsing only, which turned a
-    valid reset into ``null`` and left the app rendering ``resets —``.
-    """
-    if value is None:
-        return None
-    parsed: datetime
-    if isinstance(value, (int, float)) and not isinstance(value, bool):
-        try:
-            parsed = datetime.fromtimestamp(float(value), tz=timezone.utc)
-        except (OverflowError, OSError, ValueError):
-            return None
-    else:
-        text = str(value).strip()
-        if not text:
-            return None
-        try:
-            if text.isdigit():
-                parsed = datetime.fromtimestamp(float(text), tz=timezone.utc)
-            else:
-                parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
-        except (OverflowError, OSError, ValueError):
-            try:
-                parsed = datetime.strptime(text, "%Y-%m-%d")
-            except ValueError:
-                return None
-            parsed = parsed.replace(tzinfo=timezone.utc)
-    if parsed.tzinfo is None:
-        parsed = parsed.replace(tzinfo=timezone.utc)
-    return parsed.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-
-
-def _percent_remaining_from_used(value: Any) -> Optional[float]:
-    try:
-        used = float(value)
-    except (TypeError, ValueError):
-        return None
-    return round(max(0.0, min(100.0, 100.0 - used)), 2)
-
-
-def _reset_after_seconds_to_iso(
-    value: Any,
-    *,
-    now: Optional[datetime] = None,
-) -> Optional[str]:
-    if value is None:
-        return None
-    try:
-        seconds = float(value)
-    except (TypeError, ValueError):
-        return None
-    if seconds < 0:
-        return None
-    base = now or datetime.now(timezone.utc)
-    if base.tzinfo is None:
-        base = base.replace(tzinfo=timezone.utc)
-    reset_at = base.astimezone(timezone.utc).timestamp() + seconds
-    try:
-        parsed = datetime.fromtimestamp(reset_at, tz=timezone.utc)
-    except (OverflowError, OSError, ValueError):
-        return None
-    return parsed.strftime("%Y-%m-%dT%H:%M:%SZ")
-
-
-def _window_label_from_seconds(value: Any) -> Optional[str]:
-    try:
-        seconds = int(float(value))
-    except (TypeError, ValueError, OverflowError):
-        return None
-    if seconds <= 0:
-        return None
-    units = (
-        (24 * 60 * 60, "d"),
-        (60 * 60, "h"),
-        (60, "m"),
-    )
-    for unit_seconds, suffix in units:
-        if seconds >= unit_seconds and seconds % unit_seconds == 0:
-            return f"{seconds // unit_seconds}{suffix}"
-    return f"{seconds}s"
-
-
-def _window_label_from_detail(detail: dict[str, Any]) -> Optional[str]:
-    label = _window_label_from_seconds(detail.get("limit_window_seconds"))
-    if label is not None:
-        return label
-    try:
-        minutes = float(detail.get("window_minutes"))
-    except (TypeError, ValueError):
-        return None
-    return _window_label_from_seconds(minutes * 60)
-
-
-def _window_from_detail(
-    detail: Any,
-    *,
-    now: Optional[datetime] = None,
-) -> Optional[dict[str, Any]]:
-    if not isinstance(detail, dict):
-        return None
-    percent_remaining = _percent_remaining_from_used(detail.get("used_percent"))
-    reset_at = _normalize_reset_at(detail.get("reset_at")) or _reset_after_seconds_to_iso(
-        detail.get("reset_after_seconds"),
-        now=now,
-    )
-    window = _window_label_from_detail(detail)
-    if percent_remaining is None and reset_at is None and window is None:
-        return None
-    return {
-        "percent_remaining": percent_remaining,
-        "reset_at": reset_at,
-        "window": window,
-    }
-
-
-def _merge_window(
-    current: Any,
-    detail: Any,
-    *,
-    prefer_detail_percent: bool = False,
-    default_window: Optional[str] = None,
-    now: Optional[datetime] = None,
-) -> Any:
-    if not isinstance(current, dict):
-        if not isinstance(detail, dict):
-            return current
-        current = {"percent_remaining": None, "reset_at": None}
-    else:
-        current = dict(current)
-
-    detail_window = _window_from_detail(detail, now=now)
-    if detail_window is not None:
-        if prefer_detail_percent or current.get("percent_remaining") is None:
-            current["percent_remaining"] = detail_window.get("percent_remaining")
-        if current.get("reset_at") is None:
-            current["reset_at"] = detail_window.get("reset_at")
-        if current.get("window") is None and detail_window.get("window") is not None:
-            current["window"] = detail_window.get("window")
-
-    # Issue #800: providers with a genuinely fixed cadence (Claude Code 5h/7d,
-    # Copilot monthly) carry no `limit_window_seconds`, so the span never lands
-    # in `window`. Seed the canonical span here so the app renders the concrete
-    # label ("5h window" / "7d window" / "Monthly limit") rather than the
-    # generic "Short term" / "Long term". Only fills when nothing else set it.
-    if default_window is not None and current.get("window") is None:
-        current["window"] = default_window
-
-    reset_after_seconds = current.get("reset_after_seconds")
-    current["reset_at"] = _normalize_reset_at(current.get("reset_at")) or _reset_after_seconds_to_iso(
-        reset_after_seconds,
-        now=now,
-    )
-    current.pop("reset_after_seconds", None)
-    return current
-
-
 def _actionable_error(provider: str, error: Any) -> Optional[str]:
+    """Rewrite a provider `error` string into an actionable, human message.
+
+    This is genuine error-message UX, NOT schema re-derivation: quse owns the
+    schema and reports the raw upstream error; pocketshell only translates a
+    couple of known auth failures into a "here is what to do" message so the
+    app surfaces "sign in on the host" instead of a bare "HTTP Error 401".
+    Idempotent — the rewritten messages do not re-match these patterns.
+    """
     if error is None:
         return None
     text = str(error).strip()
@@ -306,190 +164,48 @@ def _actionable_error(provider: str, error: Any) -> Optional[str]:
     return text
 
 
-def _read_codex_bearer_token(auth_path: Path = _CODEX_AUTH_PATH) -> Optional[str]:
-    try:
-        data = json.loads(auth_path.read_text(encoding="utf-8"))
-    except (FileNotFoundError, json.JSONDecodeError, OSError):
-        return None
-    token = data.get("tokens", {}).get("access_token")
-    return token if isinstance(token, str) and token.strip() else None
+def normalize_usage_stdout(stdout: str) -> str:
+    """Flatten quse's provider-keyed `--json` object into per-provider NDJSON.
 
+    quse v0.0.9 emits ONE JSON object keyed by provider name; each value is
+    the unified per-provider record (``status`` / ``short_term`` /
+    ``long_term`` / ``error`` / ``details``). This is a THIN flatten — one
+    NDJSON line per provider — that injects the provider name (from the
+    object key) as a top-level ``provider`` field and passes quse's unified
+    fields through unchanged. quse is the single source of truth for the
+    schema (D22): pocketshell does NOT re-derive windows / resets /
+    percentages here.
 
-def _fetch_codex_detail_windows() -> Optional[dict[str, dict[str, Any]]]:
-    token = _read_codex_bearer_token()
-    if token is None:
-        return None
-    req = urllib.request.Request(
-        _CODEX_USAGE_URL,
-        headers={
-            "Authorization": f"Bearer {token}",
-            "Accept": "application/json",
-        },
-        method="GET",
-    )
-    try:
-        with urllib.request.urlopen(req, timeout=10.0) as resp:
-            payload = json.loads(resp.read().decode("utf-8"))
-    except (urllib.error.URLError, urllib.error.HTTPError, json.JSONDecodeError, OSError):
-        return None
-    rate_limit = payload.get("rate_limit")
-    if not isinstance(rate_limit, dict):
-        return None
-    windows: dict[str, dict[str, Any]] = {}
-    for name in ("primary_window", "secondary_window"):
-        value = rate_limit.get(name)
-        if isinstance(value, dict):
-            windows[name] = value
-    return windows or None
-
-
-def _codex_needs_source_patch(record: dict[str, Any], detail_windows: dict[str, Any]) -> bool:
-    has_window_shape = any(
-        isinstance(record.get(key), dict) for key in ("short_term", "long_term")
-    ) or bool(detail_windows)
-    if not has_window_shape:
-        return False
-    for top_level_key, detail_key in (
-        ("short_term", "primary_window"),
-        ("long_term", "secondary_window"),
-    ):
-        top_level = record.get(top_level_key)
-        detail = detail_windows.get(detail_key)
-        top_level_reset = None
-        if isinstance(top_level, dict):
-            top_level_reset = top_level.get("reset_at")
-            if top_level_reset is None:
-                top_level_reset = top_level.get("reset_after_seconds")
-        detail_reset = None
-        if isinstance(detail, dict):
-            detail_reset = detail.get("reset_at")
-            if detail_reset is None:
-                detail_reset = detail.get("reset_after_seconds")
-        if top_level_reset is None and detail_reset is None:
-            return True
-    return False
-
-
-def _is_codex_compatible_provider(provider: str) -> bool:
-    return provider.replace(" ", "_").lower() in _CODEX_COMPATIBLE_PROVIDERS
-
-
-def normalize_usage_record(
-    record: dict[str, Any],
-    *,
-    now: Optional[datetime] = None,
-) -> dict[str, Any]:
-    """Normalize a provider record emitted by ``quse --json``.
-
-    PocketShell owns the app-facing schema even when it delegates provider
-    probing to ``quse``. Keep this post-processing focused on schema repairs
-    that older ``quse`` releases cannot express correctly.
+    Strict / fail-loud: non-JSON stdout, a non-object top-level payload, or a
+    non-object provider value all raise ``ValueError`` so a schema mismatch
+    fails visibly instead of silently emptying the usage panel. Handles both
+    the multi-provider and single-provider (``{"<p>": {...}}``) shapes — both
+    are provider-keyed objects. Empty/blank stdout passes through untouched
+    (the caller decides what an empty read means).
     """
-    normalized = dict(record)
-    provider = str(normalized.get("provider", "")).lower()
-    details = normalized.get("details")
-    detail_windows = details.get("windows") if isinstance(details, dict) else None
-    if not isinstance(detail_windows, dict):
-        detail_windows = {}
-
-    if _is_codex_compatible_provider(provider):
-        # Codex's ChatGPT usage response exposes the real primary/secondary
-        # windows under details. Older quse versions hard-code short_term to
-        # 100% and lose epoch reset timestamps, which regressed issue #501.
-        if _codex_needs_source_patch(normalized, detail_windows):
-            fetched_windows = _fetch_codex_detail_windows()
-            if fetched_windows is not None:
-                detail_windows = {**detail_windows, **fetched_windows}
-                details_obj = dict(details) if isinstance(details, dict) else {}
-                details_obj["windows"] = detail_windows
-                normalized["details"] = details_obj
-        short_term = _merge_window(
-            normalized.get("short_term"),
-            detail_windows.get("primary_window"),
-            prefer_detail_percent=True,
-            now=now,
-        )
-        if short_term is not None:
-            normalized["short_term"] = short_term
-        long_term = _merge_window(
-            normalized.get("long_term"),
-            detail_windows.get("secondary_window"),
-            prefer_detail_percent=True,
-            now=now,
-        )
-        if long_term is not None:
-            normalized["long_term"] = long_term
-    elif provider == "claude":
-        # Issue #800: Claude Code's windows are the same concrete 5h / 7d spans
-        # as Codex; seed them so the app frames them as "5h window" / "7d window"
-        # rather than the generic "Short term" / "Long term".
-        short_term = _merge_window(
-            normalized.get("short_term"),
-            detail_windows.get("five_hour"),
-            default_window="5h",
-            now=now,
-        )
-        if short_term is not None:
-            normalized["short_term"] = short_term
-        long_term = _merge_window(
-            normalized.get("long_term"),
-            detail_windows.get("seven_day"),
-            default_window="7d",
-            now=now,
-        )
-        if long_term is not None:
-            normalized["long_term"] = long_term
-    elif provider == "copilot":
-        # Issue #800: Copilot's long-term quota is a monthly cycle — label it
-        # with its real cadence, NOT a 7d window. The short-term window is the
-        # fixed 100% bucket with no clean span, so leave it generic.
-        if isinstance(normalized.get("short_term"), dict):
-            normalized["short_term"] = _merge_window(normalized.get("short_term"), None, now=now)
-        long_term = _merge_window(
-            normalized.get("long_term"),
-            None,
-            default_window="monthly",
-            now=now,
-        )
-        if long_term is not None:
-            normalized["long_term"] = long_term
-    else:
-        if isinstance(normalized.get("short_term"), dict):
-            normalized["short_term"] = _merge_window(normalized.get("short_term"), None, now=now)
-        if isinstance(normalized.get("long_term"), dict):
-            normalized["long_term"] = _merge_window(normalized.get("long_term"), None, now=now)
-
-    actionable = _actionable_error(provider, normalized.get("error"))
-    if actionable != normalized.get("error"):
-        normalized["error"] = actionable
-    return normalized
-
-
-def normalize_usage_stdout(
-    stdout: str,
-    *,
-    now: Optional[datetime] = None,
-) -> str:
-    """Normalize NDJSON stdout from ``quse --json`` for app consumption."""
     if not stdout.strip():
         return stdout
+    try:
+        parsed = json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"quse --json did not emit valid JSON: {exc}") from exc
+    if not isinstance(parsed, dict):
+        raise ValueError(
+            "quse --json must be a provider-keyed JSON object, got "
+            f"{type(parsed).__name__}"
+        )
     lines: list[str] = []
-    changed = False
-    for raw_line in stdout.splitlines():
-        if not raw_line.strip():
-            lines.append(raw_line)
-            continue
-        try:
-            parsed = json.loads(raw_line)
-        except json.JSONDecodeError:
-            return stdout
-        if not isinstance(parsed, dict):
-            return stdout
-        normalized = normalize_usage_record(parsed, now=now)
-        changed = changed or normalized != parsed
-        lines.append(json.dumps(normalized, sort_keys=True))
-    suffix = "\n" if stdout.endswith("\n") else ""
-    return "\n".join(lines) + suffix if changed else stdout
+    for provider, record in parsed.items():
+        if not isinstance(record, dict):
+            raise ValueError(
+                f"quse --json provider '{provider}' is not a JSON object "
+                f"(got {type(record).__name__})"
+            )
+        flattened: dict[str, Any] = {"provider": provider, **record}
+        if flattened.get("error") is not None:
+            flattened["error"] = _actionable_error(provider, flattened["error"])
+        lines.append(json.dumps(flattened, sort_keys=True))
+    return "\n".join(lines) + "\n"
 
 
 def _try_daemon_usage_fetch(
@@ -502,7 +218,9 @@ def _try_daemon_usage_fetch(
     Returns the JSON-RPC ``result`` envelope (a dict with
     ``stdout``/``stderr``/``returncode`` keys) on success, or ``None``
     when the daemon is unreachable / errors out and the caller should
-    fall through to the one-shot subprocess path.
+    fall through to the one-shot subprocess path. The envelope's ``stdout``
+    is ALREADY-FLATTENED per-provider NDJSON (the daemon flattens before
+    caching), so callers proxy it verbatim — they must NOT re-flatten it.
 
     Lazy import keeps the cold-cache CLI start fast for users who
     never hit the daemon path.
@@ -544,7 +262,7 @@ def _try_daemon_usage_fetch(
     "--json",
     "json_output",
     is_flag=True,
-    help="Emit machine-readable JSON output identical to `quse --json`.",
+    help="Emit machine-readable per-provider NDJSON (flattened from `quse --json`).",
 )
 @click.option(
     "--no-daemon",
@@ -611,9 +329,10 @@ def usage_command(
     By default the command probes the IPC daemon's Unix socket
     (``$XDG_RUNTIME_DIR/pocketshell/daemon.sock``) and dispatches a
     ``usage.fetch`` JSON-RPC call when the daemon is live. Otherwise
-    it falls through to ``quse [provider] [--json]`` as a one-shot
-    subprocess. JSON output is normalized into PocketShell's schema so
-    the app is not pinned to provider-specific `quse` quirks.
+    it falls through to the pinned ``quse [provider] [--json]`` as a one-shot
+    subprocess. JSON output is FLATTENED from quse's provider-keyed document
+    into per-provider NDJSON — quse owns the schema, pocketshell just reshapes
+    it into the one-record-per-line wire format the app reads.
 
     ``--capture`` and ``--cached`` implement the stale-while-revalidate
     cache (#689): a scheduled ``--capture`` writes the latest reading +
@@ -640,16 +359,18 @@ def usage_command(
             ctx.exit(exit_code)
         return
 
-    # JSON output is the format the daemon caches against (NDJSON
-    # straight from `quse --json`). Human-readable output is rare and
-    # not on the Android hot path, so it does not get the daemon
-    # speed-up — falling through to subprocess is simpler than
-    # teaching the daemon to render two formats.
+    # JSON output is the format the daemon caches against (per-provider NDJSON
+    # already flattened by the daemon). Human-readable output is rare and not
+    # on the Android hot path, so it does not get the daemon speed-up —
+    # falling through to subprocess is simpler than teaching the daemon to
+    # render two formats.
     if json_output and not no_daemon:
         envelope = _try_daemon_usage_fetch(provider, no_cache=no_cache)
         if envelope is not None:
+            # The daemon already flattened quse's document into NDJSON before
+            # caching; proxy it verbatim (re-flattening NDJSON would raise).
             if envelope.get("stdout"):
-                sys.stdout.write(normalize_usage_stdout(str(envelope["stdout"])))
+                sys.stdout.write(str(envelope["stdout"]))
             if envelope.get("stderr"):
                 sys.stderr.write(envelope["stderr"])
             exit_code = int(envelope.get("returncode", 0))
@@ -680,34 +401,31 @@ def _fetch_usage_ndjson(
 ) -> tuple[Optional[str], str, int]:
     """Fetch live usage NDJSON for the cache capture.
 
-    Returns ``(stdout, stderr, returncode)`` where ``stdout`` is the
-    normalized NDJSON (or ``None`` when ``quse`` is missing). Mirrors the
-    command's own daemon-then-subprocess fall-through so a scheduled
-    ``--capture`` benefits from the daemon cache when one is live.
+    Returns ``(stdout, stderr, returncode)`` where ``stdout`` is the flattened
+    per-provider NDJSON (or ``None`` when the pinned ``quse`` is missing).
+    Mirrors the command's own daemon-then-subprocess fall-through so a
+    scheduled ``--capture`` benefits from the daemon cache when one is live.
     """
     if not no_daemon:
         envelope = _try_daemon_usage_fetch(provider, no_cache=False)
         if envelope is not None:
-            stdout = normalize_usage_stdout(str(envelope.get("stdout") or ""))
+            # Daemon envelope stdout is already-flattened NDJSON — use as-is.
+            stdout = str(envelope.get("stdout") or "")
             stderr = str(envelope.get("stderr") or "")
             return stdout, stderr, int(envelope.get("returncode", 0))
 
     quse_path = _resolve_quse_binary()
     if quse_path is None:
-        return (
-            None,
-            (
-                "pocketshell: `quse` is not installed on this host. "
-                "Install it via `uv tool install quse` or `pipx install quse` "
-                "and re-run.\n"
-            ),
-            127,
-        )
+        return (None, _QUSE_MISSING_MESSAGE + "\n", _QUSE_MISSING_EXIT_CODE)
     args: list[str] = [quse_path]
     if provider:
         args.append(provider)
     args.append("--json")
     completed = subprocess.run(args, check=False, capture_output=True, text=True)
+    if completed.returncode != 0:
+        # A failed live fetch is not flattened/cached — return quse's raw
+        # stdout so the caller can decide (it will not be persisted).
+        return completed.stdout, completed.stderr, completed.returncode
     return normalize_usage_stdout(completed.stdout), completed.stderr, completed.returncode
 
 
@@ -768,16 +486,17 @@ def _emit_reset_events() -> int:
 
 
 def _run_quse_json(args: Sequence[str]) -> int:
-    """Invoke ``quse`` and normalize JSON stdout before proxying it."""
+    """Invoke the pinned `quse --json` and flatten its output before proxying.
+
+    quse emits a provider-keyed JSON object; ``normalize_usage_stdout``
+    flattens it into per-provider NDJSON for the app. On a non-zero exit the
+    raw quse stdout/stderr is proxied verbatim (a failed fetch is not
+    flattened) so the app's exit!=0 provider-error path sees the real output.
+    """
     quse_path = _resolve_quse_binary()
     if quse_path is None:
-        click.echo(
-            "pocketshell: `quse` is not installed on this host. "
-            "Install it via `uv tool install quse` or `pipx install quse` "
-            "and re-run.",
-            err=True,
-        )
-        return 127
+        click.echo(_QUSE_MISSING_MESSAGE, err=True)
+        return _QUSE_MISSING_EXIT_CODE
 
     completed = subprocess.run(
         [quse_path, *args],
@@ -785,6 +504,12 @@ def _run_quse_json(args: Sequence[str]) -> int:
         capture_output=True,
         text=True,
     )
+    if completed.returncode != 0:
+        if completed.stdout:
+            sys.stdout.write(completed.stdout)
+        if completed.stderr:
+            sys.stderr.write(completed.stderr)
+        return completed.returncode
     if completed.stdout:
         sys.stdout.write(normalize_usage_stdout(completed.stdout))
     if completed.stderr:

--- a/tools/pocketshell/tests/data/quse-0.0.9-usage.json
+++ b/tools/pocketshell/tests/data/quse-0.0.9-usage.json
@@ -1,0 +1,132 @@
+{
+  "claude": {
+    "details": {
+      "limit_reached": false,
+      "subscription": null,
+      "windows": {
+        "five_hour": {
+          "reset_at": "2026-07-07T23:19:59Z",
+          "used_percent": 9.0
+        },
+        "seven_day": {
+          "reset_at": "2026-07-09T14:59:59Z",
+          "used_percent": 70.0
+        }
+      }
+    },
+    "error": null,
+    "long_term": {
+      "percent_remaining": 30.0,
+      "reset_at": "2026-07-09T14:59:59Z",
+      "window": "7d"
+    },
+    "short_term": {
+      "percent_remaining": 91.0,
+      "reset_at": "2026-07-07T23:19:59Z",
+      "window": "5h"
+    },
+    "status": "ok"
+  },
+  "codex": {
+    "details": {
+      "limit_reached": true,
+      "reset_credits": [
+        {
+          "expires_at": "2026-07-26T23:52:15Z",
+          "status": "available",
+          "title": "Full reset (Weekly + 5 hr)"
+        },
+        {
+          "expires_at": "2026-07-31T19:09:12Z",
+          "status": "available",
+          "title": "Full reset (Weekly + 5 hr)"
+        }
+      ],
+      "reset_credits_available": 2,
+      "reset_credits_error": null,
+      "windows": {
+        "primary_window": {
+          "reset_at": "2026-07-07T23:57:08Z",
+          "used_percent": 0.0
+        },
+        "secondary_window": {
+          "reset_at": "2026-07-11T06:23:55Z",
+          "used_percent": 98.0
+        }
+      }
+    },
+    "error": null,
+    "long_term": {
+      "percent_remaining": 2.0,
+      "reset_at": "2026-07-11T06:23:55Z",
+      "window": "7d"
+    },
+    "short_term": {
+      "percent_remaining": 100.0,
+      "reset_at": "2026-07-07T23:57:08Z",
+      "window": "5h"
+    },
+    "status": "ok"
+  },
+  "copilot": {
+    "details": {
+      "limit_reached": false,
+      "premium_entitlement": 1500,
+      "premium_percent_remaining": 97.1,
+      "premium_remaining": 1457
+    },
+    "error": null,
+    "long_term": {
+      "percent_remaining": 97.1,
+      "reset_at": "2026-08-01T00:00:00Z",
+      "window": "monthly"
+    },
+    "short_term": {
+      "percent_remaining": 100.0,
+      "reset_at": null,
+      "window": null
+    },
+    "status": "ok"
+  },
+  "zai": {
+    "details": {
+      "limit_reached": false,
+      "max_used_percent": 44.0,
+      "windows": {
+        "five_hour": {
+          "limit": null,
+          "remaining": null,
+          "reset_at": null,
+          "used_percent": 42.0,
+          "window_hours": 5
+        },
+        "monthly_web_search": {
+          "limit": 4000,
+          "remaining": 3962,
+          "reset_at": "2026-07-27T14:04:58Z",
+          "used_percent": 1.0,
+          "window_hours": 5
+        },
+        "weekly": {
+          "limit": null,
+          "remaining": null,
+          "reset_at": "2026-07-11T14:04:58Z",
+          "used_percent": 44.0,
+          "window_hours": null
+        }
+      }
+    },
+    "error": null,
+    "long_term": {
+      "percent_remaining": 56.0,
+      "reset_at": "2026-07-11T14:04:58Z",
+      "window": "weekly"
+    },
+    "short_term": {
+      "percent_remaining": 58.0,
+      "reset_at": null,
+      "window": "5h"
+    },
+    "status": "ok"
+  }
+}

--- a/tools/pocketshell/tests/test_daemon.py
+++ b/tools/pocketshell/tests/test_daemon.py
@@ -17,6 +17,7 @@ socket on the host running the test suite.
 
 from __future__ import annotations
 
+import json
 import os
 import signal
 import socket
@@ -60,24 +61,61 @@ def sandbox_socket(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
             pass
 
 
+# Issue #1318: `pocketshell usage` now resolves the PINNED `quse` next to its
+# own interpreter (`sys.executable`), NOT off PATH. To point a spawned daemon
+# at a FAKE quse, the daemon must run under an interpreter whose sibling `bin`
+# dir contains the fake `quse`. `_fake_python_bin` builds such a dir (a
+# `python` symlink to the real interpreter) and `_spawn_daemon(python_exe=...)`
+# runs the daemon through it, injecting PYTHONPATH so `pocketshell` (and its
+# deps) stay importable under the shadow interpreter.
+_SRC_DIR = str(Path(__file__).resolve().parent.parent / "src")
+_SITE_PACKAGES = next(
+    (p for p in reversed(sys.path) if p.endswith("site-packages")),
+    "",
+)
+
+
+def _fake_python_bin(bin_dir: Path) -> Path:
+    """Create ``bin_dir/python`` as a symlink to the real interpreter.
+
+    Returns the symlink path, suitable as ``_spawn_daemon(python_exe=...)`` so
+    a fake ``quse`` written into ``bin_dir`` is the one the daemon resolves.
+    """
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    python_link = bin_dir / "python"
+    if not python_link.exists():
+        python_link.symlink_to(sys.executable)
+    return python_link
+
+
 def _spawn_daemon(
     socket_path: Path,
     *,
     idle_timeout: float = 120.0,
     extra_env: dict[str, str] | None = None,
+    python_exe: Path | None = None,
 ) -> subprocess.Popen:
     """Spawn a real daemon process via ``python -m pocketshell daemon _serve``.
 
     Returns the running Popen handle. The caller is responsible for
-    terminating the process at the end of the test.
+    terminating the process at the end of the test. Pass ``python_exe`` (from
+    :func:`_fake_python_bin`) to run the daemon under a shadow interpreter
+    whose sibling ``bin`` dir holds a fake ``quse`` (issue #1318).
     """
     env = dict(os.environ)
     env["POCKETSHELL_DAEMON_SOCKET"] = str(socket_path)
     env["POCKETSHELL_DAEMON_IDLE_SECS"] = str(idle_timeout)
+    interpreter = str(python_exe) if python_exe is not None else sys.executable
+    if python_exe is not None:
+        # The shadow interpreter does not inherit the venv's site-packages, so
+        # put the editable src + installed deps on PYTHONPATH explicitly.
+        existing = env.get("PYTHONPATH", "")
+        parts = [p for p in (_SRC_DIR, _SITE_PACKAGES, existing) if p]
+        env["PYTHONPATH"] = os.pathsep.join(parts)
     if extra_env:
         env.update(extra_env)
     proc = subprocess.Popen(
-        [sys.executable, "-m", "pocketshell", "daemon", "_serve"],
+        [interpreter, "-m", "pocketshell", "daemon", "_serve"],
         stdin=subprocess.DEVNULL,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -243,14 +281,15 @@ def test_usage_fetch_round_trip(
     sandbox_socket: Path,
     tmp_path: Path,
 ) -> None:
-    """Daemon's ``usage.fetch`` invokes the fake quse and returns its stdout."""
+    """Daemon's ``usage.fetch`` invokes the pinned quse and flattens its
+    provider-keyed output into per-provider NDJSON (issue #1318)."""
     fake_bin = tmp_path / "bin"
-    fake_bin.mkdir()
-    payload = '{"provider":"codex","status":"ok"}\n'
+    python_exe = _fake_python_bin(fake_bin)
+    # quse-0.0.9 emits a provider-keyed object; the daemon flattens it.
+    payload = '{"codex": {"status": "ok", "short_term": {"percent_remaining": 77.0, "reset_at": null, "window": "5h"}}}\n'
     _write_fake_quse(fake_bin, payload=payload)
 
-    env = {"PATH": f"{fake_bin}:{os.environ.get('PATH', '')}"}
-    proc = _spawn_daemon(sandbox_socket, extra_env=env)
+    proc = _spawn_daemon(sandbox_socket, python_exe=python_exe)
     try:
         result = daemon_mod.call(
             "usage.fetch",
@@ -259,8 +298,11 @@ def test_usage_fetch_round_trip(
             timeout=10.0,
         )
         assert isinstance(result, dict)
-        assert result["stdout"] == payload
         assert result["returncode"] == 0
+        # stdout is FLATTENED NDJSON: one record, provider injected from key.
+        record = json.loads(result["stdout"].strip())
+        assert record["provider"] == "codex"
+        assert record["short_term"]["window"] == "5h"
     finally:
         _terminate(proc)
 
@@ -276,12 +318,14 @@ def test_two_concurrent_clients_cache_hit_is_faster(
     daemon's in-memory dict and should land well under 50 ms.
     """
     fake_bin = tmp_path / "bin"
-    fake_bin.mkdir()
-    payload = '{"provider":"codex","status":"ok"}\n'
+    python_exe = _fake_python_bin(fake_bin)
+    payload = '{"codex": {"status": "ok"}}\n'
+    # The daemon flattens the provider-keyed payload into NDJSON before
+    # caching; the cold and warm responses both carry this flattened form.
+    flattened = '{"provider": "codex", "status": "ok"}\n'
     _write_fake_quse(fake_bin, payload=payload, sleep_secs=0.3)
 
-    env = {"PATH": f"{fake_bin}:{os.environ.get('PATH', '')}"}
-    proc = _spawn_daemon(sandbox_socket, extra_env=env)
+    proc = _spawn_daemon(sandbox_socket, python_exe=python_exe)
     try:
         # Cold call — runs the (slow) fake quse.
         cold_start = time.monotonic()
@@ -298,7 +342,7 @@ def test_two_concurrent_clients_cache_hit_is_faster(
             socket_obj.close()
         cold_elapsed = time.monotonic() - cold_start
 
-        assert cold_response["result"]["stdout"] == payload
+        assert cold_response["result"]["stdout"] == flattened
         assert cold_response.get("cached") is False
         # The fake quse sleeps 300 ms; allow generous slack but assert
         # the call did take real time.
@@ -319,7 +363,7 @@ def test_two_concurrent_clients_cache_hit_is_faster(
             socket_obj2.close()
         warm_elapsed = time.monotonic() - warm_start
 
-        assert warm_response["result"]["stdout"] == payload
+        assert warm_response["result"]["stdout"] == flattened
         assert warm_response.get("cached") is True
         # 100 ms ceiling for an in-memory cache hit is very generous
         # — typically lands well under 10 ms — but tolerates a busy CI.
@@ -338,30 +382,30 @@ def test_no_cache_param_bypasses_cache(
 ) -> None:
     """``no_cache=True`` forces the daemon to re-run the upstream call."""
     fake_bin = tmp_path / "bin"
-    fake_bin.mkdir()
+    python_exe = _fake_python_bin(fake_bin)
     counter_file = tmp_path / "counter"
     counter_file.write_text("0")
-    # Each invocation increments the counter and echoes the new value.
+    # Each invocation increments the counter and emits a provider-keyed doc
+    # whose per-provider `call` field carries the new counter value.
     script = fake_bin / "quse"
     script.write_text(
         "#!/bin/sh\n"
         f"n=$(cat {counter_file})\n"
         "n=$((n+1))\n"
         f'echo "$n" > {counter_file}\n'
-        'printf \'{"provider":"x","call":%s}\\n\' "$n"\n'
+        'printf \'{"x": {"status": "ok", "call": %s}}\\n\' "$n"\n'
     )
     script.chmod(0o755)
 
-    env = {"PATH": f"{fake_bin}:{os.environ.get('PATH', '')}"}
-    proc = _spawn_daemon(sandbox_socket, extra_env=env)
+    proc = _spawn_daemon(sandbox_socket, python_exe=python_exe)
     try:
         # First call populates the cache.
         first = daemon_mod.call("usage.fetch", socket_path=sandbox_socket)
-        assert first["stdout"].strip() == '{"provider":"x","call":1}'
+        assert json.loads(first["stdout"].strip())["call"] == 1
 
         # Second without no_cache must hit the cache and not increment.
         cached = daemon_mod.call("usage.fetch", socket_path=sandbox_socket)
-        assert cached["stdout"].strip() == '{"provider":"x","call":1}'
+        assert json.loads(cached["stdout"].strip())["call"] == 1
 
         # Third with no_cache must re-run upstream — counter increments.
         fresh = daemon_mod.call(
@@ -369,7 +413,7 @@ def test_no_cache_param_bypasses_cache(
             params={"no_cache": True},
             socket_path=sandbox_socket,
         )
-        assert fresh["stdout"].strip() == '{"provider":"x","call":2}'
+        assert json.loads(fresh["stdout"].strip())["call"] == 2
     finally:
         _terminate(proc)
 
@@ -463,17 +507,18 @@ def test_no_daemon_flag_skips_daemon_probe(
     """
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
-    daemon_payload = '{"from":"daemon"}\n'
-    subprocess_payload = '{"from":"subprocess"}\n'
+    # Provider names encode the source so the flattened NDJSON reveals which
+    # path answered (issue #1318: provider-keyed payloads).
+    daemon_payload = '{"fromdaemon": {"status": "ok"}}\n'
+    subprocess_payload = '{"fromsubprocess": {"status": "ok"}}\n'
     _write_fake_quse(fake_bin, payload=subprocess_payload)
 
     # Spin up a daemon that returns a different payload so we can
     # distinguish "daemon answered" vs "subprocess answered".
     daemon_bin = tmp_path / "daemon_bin"
-    daemon_bin.mkdir()
+    daemon_python = _fake_python_bin(daemon_bin)
     _write_fake_quse(daemon_bin, payload=daemon_payload)
-    daemon_env = {"PATH": f"{daemon_bin}:{os.environ.get('PATH', '')}"}
-    proc = _spawn_daemon(sandbox_socket, extra_env=daemon_env)
+    proc = _spawn_daemon(sandbox_socket, python_exe=daemon_python)
     try:
         # Confirm the daemon is up and would answer the call.
         assert daemon_mod.is_daemon_running(sandbox_socket)
@@ -492,8 +537,8 @@ def test_no_daemon_flag_skips_daemon_probe(
         )
         assert result.exit_code == 0, result.output
         # Must be the subprocess payload, NOT the daemon payload.
-        assert "subprocess" in result.output
-        assert "daemon" not in result.output
+        assert "fromsubprocess" in result.output
+        assert "fromdaemon" not in result.output
     finally:
         _terminate(proc)
 
@@ -506,15 +551,14 @@ def test_usage_uses_daemon_by_default(
     """Without ``--no-daemon`` the CLI must dispatch via the daemon."""
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
-    daemon_payload = '{"from":"daemon"}\n'
-    subprocess_payload = '{"from":"subprocess"}\n'
+    daemon_payload = '{"fromdaemon": {"status": "ok"}}\n'
+    subprocess_payload = '{"fromsubprocess": {"status": "ok"}}\n'
     _write_fake_quse(fake_bin, payload=subprocess_payload)
 
     daemon_bin = tmp_path / "daemon_bin"
-    daemon_bin.mkdir()
+    daemon_python = _fake_python_bin(daemon_bin)
     _write_fake_quse(daemon_bin, payload=daemon_payload)
-    daemon_env = {"PATH": f"{daemon_bin}:{os.environ.get('PATH', '')}"}
-    proc = _spawn_daemon(sandbox_socket, extra_env=daemon_env)
+    proc = _spawn_daemon(sandbox_socket, python_exe=daemon_python)
     try:
         monkeypatch.setattr(
             "pocketshell.usage._resolve_quse_binary",
@@ -528,8 +572,8 @@ def test_usage_uses_daemon_by_default(
         )
         assert result.exit_code == 0, result.output
         # Daemon path should have produced the daemon_payload.
-        assert "daemon" in result.output
-        assert "subprocess" not in result.output
+        assert "fromdaemon" in result.output
+        assert "fromsubprocess" not in result.output
     finally:
         _terminate(proc)
 
@@ -542,7 +586,7 @@ def test_usage_falls_through_when_daemon_absent(
     """No daemon socket on disk => CLI must use the subprocess path."""
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
-    payload = '{"from":"subprocess"}\n'
+    payload = '{"fromsubprocess": {"status": "ok"}}\n'
     _write_fake_quse(fake_bin, payload=payload)
     monkeypatch.setattr(
         "pocketshell.usage._resolve_quse_binary",
@@ -556,7 +600,7 @@ def test_usage_falls_through_when_daemon_absent(
     runner = CliRunner()
     result = runner.invoke(usage_command, ["--json"], catch_exceptions=False)
     assert result.exit_code == 0, result.output
-    assert "subprocess" in result.output
+    assert "fromsubprocess" in result.output
 
 
 # ---------------------------------------------------------------------------
@@ -949,7 +993,7 @@ def test_failed_usage_fetch_is_not_cached(
 ) -> None:
     """A non-zero return from ``quse`` must not pin a bad result in cache."""
     fake_bin = tmp_path / "bin"
-    fake_bin.mkdir()
+    python_exe = _fake_python_bin(fake_bin)
     counter_file = tmp_path / "counter"
     counter_file.write_text("0")
     script = fake_bin / "quse"
@@ -962,8 +1006,7 @@ def test_failed_usage_fetch_is_not_cached(
         "exit 2\n"
     )
     script.chmod(0o755)
-    env = {"PATH": f"{fake_bin}:{os.environ.get('PATH', '')}"}
-    proc = _spawn_daemon(sandbox_socket, extra_env=env)
+    proc = _spawn_daemon(sandbox_socket, python_exe=python_exe)
     try:
         first = daemon_mod.call("usage.fetch", socket_path=sandbox_socket)
         assert first["returncode"] == 2

--- a/tools/pocketshell/tests/test_usage.py
+++ b/tools/pocketshell/tests/test_usage.py
@@ -1,26 +1,24 @@
-"""Unit tests for `pocketshell usage`.
+"""Unit tests for `pocketshell usage` (issue #1318).
 
-The first PR exercises:
- - `pocketshell --help` lists the `usage` subcommand.
- - `pocketshell usage --help` shows the click usage line.
- - `pocketshell usage --json` forwards through to `quse --json` and
-   normalizes provider quirks into PocketShell's schema.
- - `pocketshell usage <provider>` forwards the positional arg.
- - Missing `quse` produces a friendly stderr message + exit 127.
- - stdout/stderr/exit-code from the subprocess are proxied verbatim.
+quse v0.0.9 is the single source of truth for the unified usage schema. Its
+``--json`` output is a provider-keyed object; ``pocketshell usage --json``
+FLATTENS it into per-provider NDJSON (one record per line, ``provider``
+injected from the key, quse's unified fields passed through unchanged). There
+is no downstream re-derivation of windows / resets / percentages — pocketshell
+expects quse's exact schema and fails loudly on a mismatch (D22 hard-cut).
 
-The tests stub `pocketshell.usage._resolve_quse_binary` and
-`subprocess.run` so they never invoke a real `quse` binary; the contract
-under test is "pocketshell delegates correctly to whatever quse exists
-on the host and repairs known schema mismatches", not "the provider
-check works".
+The tests stub ``pocketshell.usage._resolve_quse_binary`` and
+``subprocess.run`` so they never invoke a real ``quse`` binary; the contract
+under test is "pocketshell resolves the PINNED quse and flattens its schema
+correctly", not "the provider check works".
 """
 
 from __future__ import annotations
 
 import json
 import subprocess
-from datetime import datetime, timezone
+import sys
+from pathlib import Path
 from typing import Sequence
 from unittest.mock import patch
 
@@ -29,10 +27,15 @@ from click.testing import CliRunner
 from pocketshell.cli import cli, main
 from pocketshell.usage import (
     _CLAUDE_USAGE_AUTH_SETUP_MESSAGE,
+    _QUSE_MISSING_EXIT_CODE,
     _actionable_error,
-    normalize_usage_record,
+    _resolve_quse_binary,
+    normalize_usage_stdout,
     usage_command,
 )
+
+_PYPROJECT = Path(__file__).resolve().parent.parent / "pyproject.toml"
+_FIXTURE = Path(__file__).resolve().parent / "data" / "quse-0.0.9-usage.json"
 
 
 def _fake_completed(
@@ -48,23 +51,218 @@ def _fake_completed(
     )
 
 
-def _fake_json_payload() -> str:
-    return json.dumps(
+def _quse_keyed_json() -> str:
+    """The real quse-0.0.9 provider-keyed --json document (4 providers)."""
+    return _FIXTURE.read_text()
+
+
+# ---------------------------------------------------------------------------
+# quse is a PINNED dependency, resolved next to sys.executable, never PATH
+# ---------------------------------------------------------------------------
+
+
+def test_pyproject_pins_quse_exactly() -> None:
+    # AC: pocketshell pins quse==0.0.9 as a hard dependency (frozen contract).
+    text = _PYPROJECT.read_text()
+    assert '"quse==0.0.9"' in text, "pyproject must pin quse==0.0.9 in dependencies"
+
+
+def test_resolve_quse_binary_uses_pinned_env_next_to_interpreter(tmp_path: Path) -> None:
+    # AC: `pocketshell usage` invokes the PINNED quse (next to sys.executable),
+    # not PATH. A quse living next to the interpreter is resolved.
+    bin_dir = tmp_path / "venv" / "bin"
+    bin_dir.mkdir(parents=True)
+    (bin_dir / "python").write_text("#!/bin/sh\n")
+    pinned = bin_dir / "quse"
+    pinned.write_text("#!/bin/sh\n")
+    pinned.chmod(0o755)
+
+    with patch.object(sys, "executable", str(bin_dir / "python")):
+        resolved = _resolve_quse_binary()
+
+    assert resolved == str(pinned)
+
+
+def test_resolve_quse_binary_does_not_fall_back_to_path(tmp_path: Path) -> None:
+    # AC: NO PATH fallback. A quse on PATH but NOT next to the interpreter must
+    # NOT be resolved — absence next to sys.executable => None (fail loud).
+    interp_dir = tmp_path / "venv" / "bin"
+    interp_dir.mkdir(parents=True)
+    (interp_dir / "python").write_text("#!/bin/sh\n")
+    # A decoy quse on PATH in a different dir.
+    path_dir = tmp_path / "elsewhere"
+    path_dir.mkdir()
+    decoy = path_dir / "quse"
+    decoy.write_text("#!/bin/sh\n")
+    decoy.chmod(0o755)
+
+    with patch.object(sys, "executable", str(interp_dir / "python")), patch.dict(
+        "os.environ", {"PATH": str(path_dir)}
+    ):
+        resolved = _resolve_quse_binary()
+
+    assert resolved is None, "a PATH-only quse must not shadow the pinned copy"
+
+
+# ---------------------------------------------------------------------------
+# normalize_usage_stdout: thin flatten of quse's provider-keyed object
+# ---------------------------------------------------------------------------
+
+
+def test_flatten_emits_per_provider_ndjson_with_window_and_iso_reset() -> None:
+    # AC: `pocketshell usage --json` fed quse-0.0.9 keyed JSON emits strict
+    # per-provider NDJSON (provider + unified fields + window + ISO reset_at).
+    out = normalize_usage_stdout(_quse_keyed_json())
+    lines = [json.loads(ln) for ln in out.splitlines()]
+    by_provider = {r["provider"]: r for r in lines}
+
+    assert set(by_provider) == {"claude", "codex", "copilot", "zai"}
+
+    claude = by_provider["claude"]
+    assert claude["short_term"]["window"] == "5h"
+    assert claude["short_term"]["reset_at"] == "2026-07-07T23:19:59Z"
+    assert claude["short_term"]["percent_remaining"] == 91.0
+    assert claude["long_term"]["window"] == "7d"
+    assert claude["long_term"]["reset_at"] == "2026-07-09T14:59:59Z"
+
+    codex = by_provider["codex"]
+    assert codex["short_term"]["window"] == "5h"
+    assert codex["long_term"]["window"] == "7d"
+
+    copilot = by_provider["copilot"]
+    assert copilot["long_term"]["window"] == "monthly"
+    # quse passes null short-term window/reset through unchanged.
+    assert copilot["short_term"]["window"] is None
+    assert copilot["short_term"]["reset_at"] is None
+
+    zai = by_provider["zai"]
+    assert zai["short_term"]["window"] == "5h"
+    assert zai["long_term"]["window"] == "weekly"
+
+    # Every line carries an injected `provider` field.
+    assert all("provider" in json.loads(ln) for ln in out.splitlines())
+
+
+def test_flatten_handles_single_provider_shape() -> None:
+    keyed = json.dumps(
+        {
+            "codex": {
+                "status": "ok",
+                "short_term": {"percent_remaining": 77.0, "reset_at": None, "window": "5h"},
+                "long_term": {"percent_remaining": 88.0, "reset_at": None, "window": "7d"},
+                "error": None,
+                "details": {},
+            }
+        }
+    )
+    out = normalize_usage_stdout(keyed)
+    lines = out.splitlines()
+    assert len(lines) == 1
+    record = json.loads(lines[0])
+    assert record["provider"] == "codex"
+    assert record["short_term"]["window"] == "5h"
+
+
+def test_flatten_passes_unified_fields_through_unchanged() -> None:
+    keyed = json.dumps(
         {
             "claude": {
-                "plan": "Pro",
-                "session_used_percent": 12.5,
-                "session_window_resets_at": "2026-05-27T15:00:00Z",
-            },
-            "codex": {
-                "plan": "Plus",
-                "session_used_percent": 4.0,
-                "session_window_resets_at": "2026-05-27T16:00:00Z",
-            },
-        },
-        indent=2,
-        sort_keys=True,
+                "status": "ok",
+                "short_term": {"percent_remaining": 59.0, "reset_at": "2026-05-24T14:30:00Z", "window": "5h"},
+                "long_term": {"percent_remaining": 15.0, "reset_at": "2026-05-28T14:59:59Z", "window": "7d"},
+                "error": None,
+                "details": {"anything": "the app ignores this"},
+            }
+        }
     )
+    record = json.loads(normalize_usage_stdout(keyed).splitlines()[0])
+    # Quota math + spans are passed through verbatim (no re-derivation).
+    assert record["short_term"] == {
+        "percent_remaining": 59.0,
+        "reset_at": "2026-05-24T14:30:00Z",
+        "window": "5h",
+    }
+    assert record["long_term"] == {
+        "percent_remaining": 15.0,
+        "reset_at": "2026-05-28T14:59:59Z",
+        "window": "7d",
+    }
+
+
+def test_flatten_raises_on_non_json() -> None:
+    try:
+        normalize_usage_stdout("this is not json")
+    except ValueError as exc:
+        assert "valid JSON" in str(exc)
+    else:  # pragma: no cover - fail-loud contract
+        raise AssertionError("expected ValueError on non-JSON stdout")
+
+
+def test_flatten_raises_on_non_object_top_level() -> None:
+    try:
+        normalize_usage_stdout('[{"provider": "codex"}]')
+    except ValueError as exc:
+        assert "provider-keyed JSON object" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("expected ValueError on a non-object top-level payload")
+
+
+def test_flatten_raises_on_non_object_provider_value() -> None:
+    try:
+        normalize_usage_stdout('{"codex": "not-an-object"}')
+    except ValueError as exc:
+        assert "codex" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("expected ValueError on a non-object provider value")
+
+
+def test_flatten_blank_passes_through() -> None:
+    assert normalize_usage_stdout("") == ""
+    assert normalize_usage_stdout("   \n") == "   \n"
+
+
+# ---------------------------------------------------------------------------
+# _actionable_error: genuine error-message UX (kept), applied in the flatten
+# ---------------------------------------------------------------------------
+
+
+def test_flatten_maps_claude_401_to_actionable_error() -> None:
+    keyed = json.dumps(
+        {
+            "claude": {
+                "status": "error",
+                "short_term": None,
+                "long_term": None,
+                "error": "HTTP Error 401: Unauthorized",
+                "details": {},
+            }
+        }
+    )
+    record = json.loads(normalize_usage_stdout(keyed).splitlines()[0])
+    assert record["error"] == _CLAUDE_USAGE_AUTH_SETUP_MESSAGE
+    assert "HTTP Error 401" not in record["error"]
+
+
+def test_actionable_error_is_idempotent() -> None:
+    # The rewritten friendly message must not re-match the auth patterns.
+    once = _actionable_error("claude", "HTTP Error 401: Unauthorized")
+    twice = _actionable_error("claude", once)
+    assert once == _CLAUDE_USAGE_AUTH_SETUP_MESSAGE
+    assert twice == _CLAUDE_USAGE_AUTH_SETUP_MESSAGE
+
+
+def test_claude_stale_auth_telemetry_error_is_usage_unavailable() -> None:
+    stale_error = (
+        "Claude Code authentication "
+        + "failed on this host. Run `claude "
+        + "/login` in the host shell."
+    )
+    assert _actionable_error("claude", stale_error) == _CLAUDE_USAGE_AUTH_SETUP_MESSAGE
+
+
+# ---------------------------------------------------------------------------
+# CLI wiring: forwards to the pinned quse and flattens JSON output
+# ---------------------------------------------------------------------------
 
 
 def test_top_level_help_lists_usage_subcommand() -> None:
@@ -85,352 +283,19 @@ def test_usage_help_does_not_call_quse() -> None:
     run.assert_not_called()
 
 
-def test_usage_json_forwards_to_quse_and_proxies_stdout() -> None:
-    payload = _fake_json_payload()
+def test_usage_json_flattens_quse_keyed_object() -> None:
     runner = CliRunner()
     with patch("pocketshell.usage._resolve_quse_binary", return_value="/fake/quse"), patch(
         "pocketshell.usage.subprocess.run",
-        return_value=_fake_completed(stdout=payload),
-    ) as run:
-        result = runner.invoke(usage_command, ["--json"])
+        return_value=_fake_completed(stdout=_quse_keyed_json()),
+    ) as run, patch("pocketshell.usage._try_daemon_usage_fetch", return_value=None):
+        result = runner.invoke(usage_command, ["--json", "--no-daemon"])
     assert result.exit_code == 0, result.output
-    # Non-provider-shaped JSON is left untouched.
-    assert result.output == payload
-    # Args forwarded to the quse subprocess must include `--json`.
-    call_args = run.call_args
-    invoked: Sequence[str] = call_args.args[0]
+    providers = [json.loads(ln)["provider"] for ln in result.output.splitlines()]
+    assert providers == ["claude", "codex", "copilot", "zai"]
+    # Args forwarded to the pinned quse subprocess must include `--json`.
+    invoked: Sequence[str] = run.call_args.args[0]
     assert invoked == ["/fake/quse", "--json"]
-
-
-def test_usage_json_normalizes_codex_detail_windows_and_epoch_resets() -> None:
-    raw = "\n".join(
-        [
-            json.dumps(
-                {
-                    "provider": "codex",
-                    "status": "ok",
-                    "short_term": {"percent_remaining": 100.0, "reset_at": None},
-                    "long_term": {"percent_remaining": 69.0, "reset_at": None},
-                    "block_reason": None,
-                    "error": None,
-                    "details": {
-                        "limit_reached": False,
-                        "windows": {
-                            "primary_window": {
-                                "used_percent": 12,
-                                "limit_window_seconds": 18000,
-                                "reset_at": 1780828285,
-                            },
-                            "secondary_window": {
-                                "used_percent": 31,
-                                "limit_window_seconds": 604800,
-                                "reset_at": 1781137638,
-                            },
-                        },
-                    },
-                },
-            ),
-            json.dumps(
-                {
-                    "provider": "claude",
-                    "status": "error",
-                    "short_term": {"percent_remaining": None, "reset_at": None},
-                    "long_term": {"percent_remaining": None, "reset_at": None},
-                    "block_reason": None,
-                    "error": "HTTP Error 401: Unauthorized",
-                    "details": {},
-                },
-            ),
-        ],
-    )
-    runner = CliRunner()
-    with patch("pocketshell.usage._resolve_quse_binary", return_value="/fake/quse"), patch(
-        "pocketshell.usage.subprocess.run",
-        return_value=_fake_completed(stdout=raw + "\n"),
-    ):
-        result = runner.invoke(usage_command, ["--json"])
-
-    assert result.exit_code == 0, result.output
-    lines = [json.loads(line) for line in result.output.splitlines()]
-    codex = lines[0]
-    assert codex["short_term"] == {
-        "percent_remaining": 88.0,
-        "reset_at": "2026-06-07T10:31:25Z",
-        "window": "5h",
-    }
-    assert codex["long_term"] == {
-        "percent_remaining": 69.0,
-        "reset_at": "2026-06-11T00:27:18Z",
-        "window": "7d",
-    }
-    assert lines[1]["error"] == _CLAUDE_USAGE_AUTH_SETUP_MESSAGE
-    assert "claude " + "/login" not in lines[1]["error"]
-    assert "authentication " + "failed" not in lines[1]["error"].lower()
-    assert "HTTP Error 401" not in lines[1]["error"]
-
-
-def test_normalize_claude_seeds_concrete_5h_and_7d_window_spans() -> None:
-    # #800: Claude Code's windows are the same concrete 5h/7d spans as Codex.
-    # quse emits them with no `window` span, so normalize seeds the canonical
-    # span so the app frames them as "5h window" / "7d window".
-    record = {
-        "provider": "claude",
-        "status": "ok",
-        "short_term": {"percent_remaining": 59.0, "reset_at": "2026-05-24T14:30:00Z"},
-        "long_term": {"percent_remaining": 15.0, "reset_at": "2026-05-28T14:59:59Z"},
-        "block_reason": None,
-        "error": None,
-        "details": {},
-    }
-
-    normalized = normalize_usage_record(record)
-
-    assert normalized["short_term"]["window"] == "5h"
-    assert normalized["long_term"]["window"] == "7d"
-    # The quota math is untouched.
-    assert normalized["short_term"]["percent_remaining"] == 59.0
-    assert normalized["long_term"]["percent_remaining"] == 15.0
-
-
-def test_normalize_copilot_long_term_is_monthly_not_7d() -> None:
-    # #800: Copilot's long-term quota is a monthly cycle — keep its real
-    # cadence, NOT a 7d window. Its short-term window stays generic.
-    record = {
-        "provider": "copilot",
-        "status": "ok",
-        "short_term": {"percent_remaining": 100.0, "reset_at": None},
-        "long_term": {"percent_remaining": 96.6, "reset_at": "2026-07-01T00:00:00Z"},
-        "block_reason": None,
-        "error": None,
-        "details": {},
-    }
-
-    normalized = normalize_usage_record(record)
-
-    assert normalized["long_term"]["window"] == "monthly"
-    assert normalized["long_term"]["window"] != "7d"
-    # Short-term keeps no forced span (renders the generic humanized label).
-    assert normalized["short_term"].get("window") is None
-
-
-def test_normalize_zai_keeps_generic_window_spans() -> None:
-    # #800 regression guard: providers with unknown spans must NOT be forced
-    # into 5h/7d/monthly — leave `window` unset so the app humanizes them.
-    record = {
-        "provider": "zai",
-        "status": "ok",
-        "short_term": {"percent_remaining": 100.0, "reset_at": "2026-05-27T10:31:58Z"},
-        "long_term": {"percent_remaining": 100.0, "reset_at": None},
-        "block_reason": None,
-        "error": None,
-        "details": {},
-    }
-
-    normalized = normalize_usage_record(record)
-
-    assert normalized["short_term"].get("window") is None
-    assert normalized["long_term"].get("window") is None
-
-
-def test_normalize_claude_keeps_detail_window_span_when_present() -> None:
-    # When quse DOES carry a concrete span via limit_window_seconds, the
-    # detail span wins over the default seed (still 5h/7d for Claude here).
-    record = {
-        "provider": "claude",
-        "status": "ok",
-        "short_term": {"percent_remaining": None, "reset_at": None},
-        "long_term": {"percent_remaining": None, "reset_at": None},
-        "block_reason": None,
-        "error": None,
-        "details": {
-            "windows": {
-                "five_hour": {"used_percent": 40, "limit_window_seconds": 18000},
-                "seven_day": {"used_percent": 10, "limit_window_seconds": 604800},
-            },
-        },
-    }
-
-    normalized = normalize_usage_record(record)
-
-    assert normalized["short_term"]["window"] == "5h"
-    assert normalized["long_term"]["window"] == "7d"
-    assert normalized["short_term"]["percent_remaining"] == 60.0
-    assert normalized["long_term"]["percent_remaining"] == 90.0
-
-
-def test_claude_stale_auth_telemetry_error_is_usage_unavailable() -> None:
-    stale_error = (
-        "Claude Code authentication "
-        + "failed on this host. Run `claude "
-        + "/login` in the host shell."
-    )
-
-    assert _actionable_error("claude", stale_error) == _CLAUDE_USAGE_AUTH_SETUP_MESSAGE
-
-
-def test_usage_json_patches_codex_resets_from_source_when_quse_dropped_them() -> None:
-    raw = json.dumps(
-        {
-            "provider": "codex",
-            "status": "ok",
-            "short_term": {"percent_remaining": 100.0, "reset_at": None},
-            "long_term": {"percent_remaining": 69.0, "reset_at": None},
-            "block_reason": None,
-            "error": None,
-            "details": {
-                "limit_reached": False,
-                "windows": {
-                    "primary_window": {"used_percent": 13, "reset_at": None},
-                    "secondary_window": {"used_percent": 31, "reset_at": None},
-                },
-            },
-        },
-    )
-    runner = CliRunner()
-    with patch("pocketshell.usage._resolve_quse_binary", return_value="/fake/quse"), patch(
-        "pocketshell.usage.subprocess.run",
-        return_value=_fake_completed(stdout=raw + "\n"),
-    ), patch(
-        "pocketshell.usage._fetch_codex_detail_windows",
-        return_value={
-            "primary_window": {
-                "used_percent": 13,
-                "limit_window_seconds": 18000,
-                "reset_at": 1780828285,
-            },
-            "secondary_window": {
-                "used_percent": 31,
-                "limit_window_seconds": 604800,
-                "reset_at": 1781137638,
-            },
-        },
-    ):
-        result = runner.invoke(usage_command, ["--json"])
-
-    assert result.exit_code == 0, result.output
-    codex = json.loads(result.output)
-    assert codex["short_term"] == {
-        "percent_remaining": 87.0,
-        "reset_at": "2026-06-07T10:31:25Z",
-        "window": "5h",
-    }
-    assert codex["long_term"] == {
-        "percent_remaining": 69.0,
-        "reset_at": "2026-06-11T00:27:18Z",
-        "window": "7d",
-    }
-
-
-def test_usage_json_normalizes_openai_compatible_detail_windows() -> None:
-    raw = json.dumps(
-        {
-            "provider": "openai",
-            "status": "ok",
-            "short_term": {"percent_remaining": 100.0, "reset_at": None},
-            "long_term": {"percent_remaining": 35.0, "reset_at": None},
-            "block_reason": None,
-            "error": None,
-            "details": {
-                "windows": {
-                    "primary_window": {
-                        "used_percent": 22,
-                        "limit_window_seconds": 18000,
-                        "reset_at": "2026-06-08T02:19:59Z",
-                    },
-                    "secondary_window": {
-                        "used_percent": 65,
-                        "limit_window_seconds": 604800,
-                        "reset_at": "2026-06-11T00:27:17Z",
-                    },
-                },
-            },
-        },
-    )
-    runner = CliRunner()
-    with patch("pocketshell.usage._resolve_quse_binary", return_value="/fake/quse"), patch(
-        "pocketshell.usage.subprocess.run",
-        return_value=_fake_completed(stdout=raw + "\n"),
-    ):
-        result = runner.invoke(usage_command, ["--json"])
-
-    assert result.exit_code == 0, result.output
-    record = json.loads(result.output)
-    assert record["short_term"] == {
-        "percent_remaining": 78.0,
-        "reset_at": "2026-06-08T02:19:59Z",
-        "window": "5h",
-    }
-    assert record["long_term"] == {
-        "percent_remaining": 35.0,
-        "reset_at": "2026-06-11T00:27:17Z",
-        "window": "7d",
-    }
-
-
-def test_normalize_usage_record_preserves_codex_reset_after_seconds() -> None:
-    record = normalize_usage_record(
-        {
-            "provider": "codex",
-            "status": "ok",
-            "short_term": {"percent_remaining": 35.0, "reset_at": None},
-            "long_term": {"percent_remaining": 69.0, "reset_at": None},
-            "block_reason": None,
-            "error": None,
-            "details": {
-                "windows": {
-                    "primary_window": {
-                        "used_percent": 65,
-                        "window_minutes": 300,
-                        "reset_after_seconds": 3600,
-                    },
-                    "secondary_window": {
-                        "used_percent": 31,
-                        "limit_window_seconds": 604800,
-                        "reset_after_seconds": "604800",
-                    },
-                },
-            },
-        },
-        now=datetime(2026, 6, 8, 10, 0, tzinfo=timezone.utc),
-    )
-
-    assert record["short_term"] == {
-        "percent_remaining": 35.0,
-        "reset_at": "2026-06-08T11:00:00Z",
-        "window": "5h",
-    }
-    assert record["long_term"] == {
-        "percent_remaining": 69.0,
-        "reset_at": "2026-06-15T10:00:00Z",
-        "window": "7d",
-    }
-
-
-def test_normalize_usage_record_converts_top_level_reset_after_seconds() -> None:
-    with patch("pocketshell.usage._fetch_codex_detail_windows", return_value=None):
-        record = normalize_usage_record(
-            {
-                "provider": "codex",
-                "status": "ok",
-                "short_term": {
-                    "percent_remaining": 35.0,
-                    "reset_at": None,
-                    "reset_after_seconds": 3600,
-                    "window": "5h",
-                },
-                "long_term": None,
-                "block_reason": None,
-                "error": None,
-                "details": {},
-            },
-            now=datetime(2026, 6, 8, 10, 0, tzinfo=timezone.utc),
-        )
-
-    assert record["short_term"] == {
-        "percent_remaining": 35.0,
-        "reset_at": "2026-06-08T11:00:00Z",
-        "window": "5h",
-    }
 
 
 def test_usage_forwards_provider_argument() -> None:
@@ -448,30 +313,30 @@ def test_usage_forwards_provider_argument() -> None:
 
 def test_usage_forwards_provider_and_json_flag_together() -> None:
     runner = CliRunner()
+    single = json.dumps({"claude": {"status": "ok", "short_term": None, "long_term": None, "error": None}})
     with patch("pocketshell.usage._resolve_quse_binary", return_value="/fake/quse"), patch(
         "pocketshell.usage.subprocess.run",
-        return_value=_fake_completed(stdout="{\n  \"claude\": {}\n}\n"),
-    ) as run:
-        result = runner.invoke(usage_command, ["claude", "--json"])
+        return_value=_fake_completed(stdout=single),
+    ) as run, patch("pocketshell.usage._try_daemon_usage_fetch", return_value=None):
+        result = runner.invoke(usage_command, ["claude", "--json", "--no-daemon"])
     assert result.exit_code == 0, result.output
     invoked: Sequence[str] = run.call_args.args[0]
     assert invoked == ["/fake/quse", "claude", "--json"]
+    assert json.loads(result.output.splitlines()[0])["provider"] == "claude"
 
 
-def test_usage_returns_127_when_quse_missing() -> None:
+def test_usage_fails_loud_when_pinned_quse_missing() -> None:
+    # AC: quse missing => packaging-integrity error, fail loud (NOT a PATH nag,
+    # NOT exit 127 which the app reserves for "pocketshell not found").
     runner = CliRunner()
     with patch("pocketshell.usage._resolve_quse_binary", return_value=None), patch(
         "pocketshell.usage.subprocess.run"
-    ) as run:
-        result = runner.invoke(usage_command, ["--json"], catch_exceptions=False)
-    # 127 is the POSIX exit code for "command not found" and matches the
-    # signal `UsageRemoteSource.fetchUsage` already special-cases on the
-    # Kotlin side.
-    assert result.exit_code == 127, result.output
-    # The friendly message lands on stderr; CliRunner mixes stdout+stderr
-    # by default but `mix_stderr=False` is removed in click>=8.2, so just
-    # check that the install hint was emitted somewhere.
+    ) as run, patch("pocketshell.usage._try_daemon_usage_fetch", return_value=None):
+        result = runner.invoke(usage_command, ["--json", "--no-daemon"], catch_exceptions=False)
+    assert result.exit_code == _QUSE_MISSING_EXIT_CODE
+    assert result.exit_code != 127
     assert "quse" in result.output.lower()
+    assert "reinstall pocketshell" in result.output.lower()
     run.assert_not_called()
 
 
@@ -483,21 +348,15 @@ def test_usage_proxies_nonzero_exit_from_quse() -> None:
     ):
         result = runner.invoke(usage_command, ["wat"])
     assert result.exit_code == 2
-    # stderr from the subprocess must reach the user (otherwise debugging
-    # a failing provider would be opaque).
     assert "unknown provider" in result.output
 
 
 def test_main_returns_int_on_success() -> None:
-    """`main` is the canonical entrypoint for the console-script and
-    `python -m pocketshell`. It must translate Click's exit-code object
-    into a plain int and never raise SystemExit through to the caller.
-    """
     with patch("pocketshell.usage._resolve_quse_binary", return_value="/fake/quse"), patch(
         "pocketshell.usage.subprocess.run",
-        return_value=_fake_completed(stdout=_fake_json_payload()),
-    ):
-        exit_code = main(["usage", "--json"])
+        return_value=_fake_completed(stdout=_quse_keyed_json()),
+    ), patch("pocketshell.usage._try_daemon_usage_fetch", return_value=None):
+        exit_code = main(["usage", "--json", "--no-daemon"])
     assert isinstance(exit_code, int)
     assert exit_code == 0
 

--- a/tools/pocketshell/tests/test_usage_capture.py
+++ b/tools/pocketshell/tests/test_usage_capture.py
@@ -31,11 +31,35 @@ from pocketshell.usage_capture import (
 )
 
 
+# The flattened per-provider NDJSON `write_capture` consumes (pocketshell's
+# own output format — one provider record per line).
 _NDJSON = (
     '{"provider": "codex", "status": "ok", '
     '"short_term": {"percent_remaining": 77.0, "reset_at": "2026-06-11T15:00:00Z"}}\n'
     '{"provider": "claude", "status": "ok", '
     '"short_term": {"percent_remaining": 41.0, "reset_at": "2026-06-11T14:00:00Z"}}\n'
+)
+
+# quse v0.0.9's provider-keyed `--json` document — what `subprocess.run`
+# returns when the CLI capture path shells out to the pinned quse. The
+# `usage --capture` flow FLATTENS this into the NDJSON above before caching.
+_QUSE_KEYED = json.dumps(
+    {
+        "codex": {
+            "status": "ok",
+            "short_term": {"percent_remaining": 77.0, "reset_at": "2026-06-11T15:00:00Z", "window": "5h"},
+            "long_term": {"percent_remaining": 88.0, "reset_at": "2026-06-18T15:00:00Z", "window": "7d"},
+            "error": None,
+            "details": {},
+        },
+        "claude": {
+            "status": "ok",
+            "short_term": {"percent_remaining": 41.0, "reset_at": "2026-06-11T14:00:00Z", "window": "5h"},
+            "long_term": {"percent_remaining": 85.0, "reset_at": "2026-06-18T14:00:00Z", "window": "7d"},
+            "error": None,
+            "details": {},
+        },
+    }
 )
 
 
@@ -152,7 +176,7 @@ def _fake_completed(stdout: str = "", stderr: str = "", returncode: int = 0):
 def test_cli_capture_writes_cache_and_history(tmp_path: Path) -> None:
     env = {"XDG_STATE_HOME": str(tmp_path / "state")}
     with patch("pocketshell.usage._resolve_quse_binary", return_value="/usr/bin/quse"), patch(
-        "pocketshell.usage.subprocess.run", return_value=_fake_completed(stdout=_NDJSON)
+        "pocketshell.usage.subprocess.run", return_value=_fake_completed(stdout=_QUSE_KEYED)
     ), patch("pocketshell.usage._try_daemon_usage_fetch", return_value=None):
         result = CliRunner().invoke(cli, ["usage", "--capture", "--no-daemon"], env=env)
 


### PR DESCRIPTION
Closes #1318

Consumes quse v0.0.9 as a pinned dependency of `pocketshell-cli` (resolved next to `sys.executable`, no PATH), flattens quse's provider-keyed `--json` to per-provider NDJSON, and makes the Android parser strict/fail-loud on schema drift. Deletes the whole downstream re-derivation layer (D22 hard-cut — no `canonicalWindowName` fallback, no `normalize_usage_record`).

**Verification (reviewer-driven red→green, APPROVED):**
- Part A python: 713 passed against pinned quse==0.0.9; defensive layer grep-proven gone.
- Part B parser JVM: 18/0/0; base-vs-fix red→green driven by the reviewer.
- On-device: `Usage1318StrictSchemaRenderE2eTest` on emulator — RED reproduces the v0.4.24 symptom (`hetzner: Refresh usage failed` + `0 providers · 0 hosts`) on the real `UsageScreen`, GREEN renders all 4 provider cards. Wired into `ci-journey-suite.sh` (per-push gate).

Reviewer: https://github.com/alexeygrigorev/pocketshell/issues/1318#issuecomment-4912104795