### PR TITLE
tmux: restore #145 'Disconnected from' disconnect-band wording after S3 fuse (#1344)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
@@ -1823,7 +1823,15 @@ public fun TmuxSessionScreen(
             // elements grep-able from connected disconnect+reconnect tests.
             (surfaceState as? SessionSurfaceState.Failed)?.let { failed ->
                 FailedConnectionRow(
-                    message = failureReasonSentence(failed.reason),
+                    // Issue #1344: host-qualify the generic disconnect so the band reads
+                    // the unified #145 "Disconnected from <user>@<host>:<port>." wording
+                    // (the maintainer's clear disconnected indicator) — restored after the
+                    // S3 fuse dropped it. The endpoint comes from this screen's target
+                    // coordinates, matching the VM's historical message exactly.
+                    message = failureReasonSentence(
+                        failed.reason,
+                        endpoint = disconnectEndpointLabel(user = user, host = host, port = port),
+                    ),
                     onReconnect = { viewModel.reconnect() },
                     canReconnect = canReconnect,
                 )
@@ -7380,16 +7388,47 @@ internal fun SessionSurfaceState.toUiStatus(): com.pocketshell.uikit.model.Conne
  * (it stays in the diagnostic logs); every failure surfaces as a recoverable "Tap
  * Reconnect" prompt, in the calm #720/#1322 tone. This is the ONLY place a failure
  * reason becomes display text.
+ *
+ * Issue #1344 (v0.4.25 regression): the generic connection-lost / socket-death /
+ * ladder-exhaust case ([FailureReason.Unreachable]) renders the UNIFIED #145
+ * "Disconnected from <user>@<host>:<port>. Tap Reconnect to retry." wording — the
+ * clear, actionable disconnected indicator the maintainer relies on. The S3 fuse
+ * dropped that phrase to a bare "Connection lost." here; this restores it while
+ * keeping the fused [SessionSurfaceState] the single source (D22 hard-cut — no
+ * legacy dual-read of the old `ConnectionStatus.Failed.message`). [endpoint] is the
+ * `<user>@<host>:<port>` label built at the call site from the screen's target
+ * coordinates (see [disconnectEndpointLabel]); when it is unknown (blank host in a
+ * standalone render) the phrase degrades to a host-less "Disconnected. …" but the
+ * #145 "Disconnected from"/"Disconnected" marker is always present. The config-level
+ * reasons (auth/host/key) and the [FailureReason.ServerRestarted] / [FailureReason.SessionEnded]
+ * cases keep their DISTINCT curated wording — the coherent #1322 Error/Gone
+ * distinction is preserved, only the generic Unreachable disconnect is host-qualified.
  */
-internal fun failureReasonSentence(reason: FailureReason): String =
+internal fun failureReasonSentence(reason: FailureReason, endpoint: String? = null): String =
     when (reason) {
         FailureReason.AuthFailed -> "Authentication failed — check your key. Tap Reconnect to retry."
         FailureReason.HostUnresolved -> "Host could not be resolved. Tap Reconnect to retry."
         FailureReason.ServerRestarted -> "The tmux server restarted — all sessions ended. Tap Reconnect."
         FailureReason.SessionEnded -> "This session ended. Tap Reconnect."
         FailureReason.KeyMissing -> "Private key file not found. Tap Reconnect to retry."
-        is FailureReason.Unreachable -> "Connection lost. Tap Reconnect to retry."
+        is FailureReason.Unreachable ->
+            if (endpoint.isNullOrBlank()) {
+                "Disconnected. Tap Reconnect to retry."
+            } else {
+                "Disconnected from $endpoint. Tap Reconnect to retry."
+            }
     }
+
+/**
+ * Issue #1344: build the `<user>@<host>:<port>` endpoint label for the unified #145
+ * disconnect band wording ([failureReasonSentence]) from the session screen's target
+ * coordinates. Returns null when the host is unknown/blank (a standalone render with
+ * no target) so the band degrades to the host-less "Disconnected." rather than an
+ * empty "Disconnected from ." — matching the historical VM-composed
+ * "Disconnected from ${target.user}@${target.host}:${target.port}" wording exactly.
+ */
+internal fun disconnectEndpointLabel(user: String, host: String, port: Int): String? =
+    if (host.isBlank()) null else "$user@$host:$port"
 
 internal fun recordTmuxReconnectUiStateRendered(
     status: ConnectionStatus,

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionScreenTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionScreenTest.kt
@@ -2122,22 +2122,121 @@ class TmuxSessionScreenTest {
         // AC-3: the failed state carries a TYPED FailureReason (no raw string field),
         // and the screen maps it to ONE calm curated sentence — never raw exception
         // text. Class coverage over every reason.
+        // Issue #1344: the generic Unreachable disconnect renders the unified #145
+        // host-qualified "Disconnected from <user>@<host>:<port>." wording; the config
+        // reasons keep their DISTINCT curated sentences (#1322 Error/Gone distinction).
+        val endpoint = "testuser@dev.box:22"
         val cases = mapOf(
             FailureReason.AuthFailed to "Authentication failed — check your key. Tap Reconnect to retry.",
             FailureReason.HostUnresolved to "Host could not be resolved. Tap Reconnect to retry.",
             FailureReason.ServerRestarted to "The tmux server restarted — all sessions ended. Tap Reconnect.",
             FailureReason.SessionEnded to "This session ended. Tap Reconnect.",
             FailureReason.KeyMissing to "Private key file not found. Tap Reconnect to retry.",
-            FailureReason.Unreachable(retryable = true) to "Connection lost. Tap Reconnect to retry.",
+            FailureReason.Unreachable(retryable = true) to "Disconnected from $endpoint. Tap Reconnect to retry.",
+            FailureReason.Unreachable(retryable = false) to "Disconnected from $endpoint. Tap Reconnect to retry.",
         )
         cases.forEach { (reason, expected) ->
             val state = SessionSurfaceState.Failed(sid, "work", reason)
-            assertEquals("curated sentence for $reason", expected, failureReasonSentence(state.reason))
-            val sentence = failureReasonSentence(state.reason)
+            assertEquals("curated sentence for $reason", expected, failureReasonSentence(state.reason, endpoint))
+            val sentence = failureReasonSentence(state.reason, endpoint)
             assertFalse("no raw error: prefix", sentence.startsWith("error:"))
             assertFalse("no exception class name", sentence.contains("Exception"))
             assertTrue("stays a calm reconnect prompt", sentence.contains("Reconnect"))
         }
+    }
+
+    // ─── Issue #1344 (v0.4.25 regression, release-blocker) ──────────────────────
+    // The S1+S3 connection-state-machine consolidation fused the disconnect band to
+    // render from the typed [FailureReason] via [failureReasonSentence]; the generic
+    // [FailureReason.Unreachable] arm regressed to a bare "Connection lost." that no
+    // longer contained the unified #145 "Disconnected from <user>@<host>:<port>."
+    // wording. `BackgroundResumeSocketDeathE2eTest` (which asserts the band contains
+    // "Disconnected from") went RED on the v0.4.25 train. These JVM class-cover tests
+    // pin the mapping so it cannot silently regress again (D31/D33, wired into the
+    // `Unit tests` gate).
+
+    @Test
+    fun failureReasonSentence_unreachable_containsUnified145DisconnectedFromWording() {
+        // The load-bearing #1344 assertion: the disconnect/socket-death class
+        // ([FailureReason.Unreachable], BOTH retryable values — the reveal-driven
+        // exhaustion path and the phase-driven Failed hold) renders the unified #145
+        // "Disconnected from <user>@<host>:<port>." band the socket-death journey
+        // greps for. This FAILS on the pre-fix "Connection lost." mapping.
+        val endpoint = disconnectEndpointLabel(user = "testuser", host = "dev.box", port = 2222)
+        assertEquals("testuser@dev.box:2222", endpoint)
+        for (retryable in listOf(true, false)) {
+            val sentence = failureReasonSentence(FailureReason.Unreachable(retryable), endpoint)
+            assertTrue(
+                "Unreachable(retryable=$retryable) band must contain the #145 `Disconnected from` " +
+                    "wording (was `$sentence`)",
+                sentence.contains("Disconnected from"),
+            )
+            assertTrue(
+                "Unreachable(retryable=$retryable) band must name the endpoint (was `$sentence`)",
+                sentence.contains("testuser@dev.box:2222"),
+            )
+            assertTrue("stays a calm reconnect prompt", sentence.contains("Tap Reconnect"))
+        }
+    }
+
+    @Test
+    fun failureReasonSentence_unreachable_withoutEndpoint_stillShowsDisconnectedMarker() {
+        // A standalone render with no known host (blank host → null endpoint) must NOT
+        // print an empty "Disconnected from ." — it degrades to a host-less
+        // "Disconnected." that still carries the clear disconnected indicator.
+        assertNull(disconnectEndpointLabel(user = "u", host = "", port = 22))
+        for (retryable in listOf(true, false)) {
+            val sentence = failureReasonSentence(FailureReason.Unreachable(retryable), endpoint = null)
+            assertTrue("host-less band still says Disconnected (was `$sentence`)", sentence.contains("Disconnected"))
+            assertFalse("no dangling `Disconnected from .` (was `$sentence`)", sentence.contains("Disconnected from ."))
+            assertTrue("stays a calm reconnect prompt", sentence.contains("Tap Reconnect"))
+        }
+    }
+
+    @Test
+    fun failureReasonSentence_configReasons_keepDistinctWording_notDisconnectedFrom() {
+        // Adjacency guard (#1322 Error/Gone distinction preserved): the config-level
+        // reasons must NOT be swept into the generic "Disconnected from" wording — each
+        // keeps its own actionable sentence so the user knows WHAT to fix.
+        val endpoint = "u@h:22"
+        val distinct = mapOf(
+            FailureReason.AuthFailed to "Authentication failed",
+            FailureReason.HostUnresolved to "Host could not be resolved",
+            FailureReason.ServerRestarted to "tmux server restarted",
+            FailureReason.SessionEnded to "This session ended",
+            FailureReason.KeyMissing to "Private key file not found",
+        )
+        distinct.forEach { (reason, marker) ->
+            val sentence = failureReasonSentence(reason, endpoint)
+            assertTrue("$reason keeps its distinct wording (was `$sentence`)", sentence.contains(marker))
+            assertFalse("$reason must NOT read as a generic disconnect (was `$sentence`)", sentence.contains("Disconnected from"))
+        }
+    }
+
+    @Test
+    fun failedSurface_fromRevealError_rendersDisconnectedFromBand() {
+        // End-to-end of the mapping the socket-death journey exercises: a reveal-driven
+        // honest error ([RevealState.Error] retrying=false, Unreachable) fuses to
+        // [SessionSurfaceState.Failed] and the band (endpoint from the screen's target)
+        // reads the unified #145 wording. Drives the SAME fusion + sentence helpers the
+        // production screen wires, in the reported exhaustion state.
+        val target = SessionId("2222/claude-main")
+        val fused = sessionSurfaceState(
+            reveal = RevealState.Error(
+                target,
+                "claude-main",
+                retrying = false,
+                reason = FailureReason.Unreachable(retryable = false),
+            ),
+            phase = ConnectionPhase.Failed,
+            targetId = target,
+        )
+        assertTrue("fusion must settle to Failed", fused is SessionSurfaceState.Failed)
+        val band = failureReasonSentence(
+            (fused as SessionSurfaceState.Failed).reason,
+            endpoint = disconnectEndpointLabel(user = "testuser", host = "dev.box", port = 2222),
+        )
+        assertTrue("socket-death band must contain #145 `Disconnected from` (was `$band`)", band.contains("Disconnected from testuser@dev.box:2222"))
     }
 
     @Test


### PR DESCRIPTION
Closes #1344 — v0.4.25 release-blocker (connection-core regression).

The S1+S3 consolidation (#1342/#1326) regressed the disconnect band: it now reads `failureReasonSentence(FailureReason.Unreachable)` which mapped to a bare `Connection lost.`, dropping the unified #145 `Disconnected from <endpoint>` wording. `BackgroundResumeSocketDeathE2eTest` went RED both cold boots at `8e628cc9` (GREEN at pre-train `158949dc`).

Fix restores the wording via `disconnectEndpointLabel(user,host,port)`; fused `SessionSurfaceState` stays the single source (D22, no legacy dual-read); #1322 Error/Gone distinction preserved.

**Verification (reviewer-driven, APPROVED):** JVM class-cover red→green — 4 targeted tests FAIL on the pre-fix mapping, 115 PASS with the fix; wired into the `Unit tests` gate; class coverage over `Unreachable(true/false)` + host-less degrade + #1322 adjacency.

**⚠️ Release-tag gate:** the on-device `BackgroundResumeSocketDeathE2eTest` must go GREEN in CI's batched emulator lane before the v0.4.25 tag (local AVD was wedged; deferred to CI per reviewer). Reviewer: https://github.com/alexeygrigorev/pocketshell/issues/1344#issuecomment-4912244811