### PR TITLE
git: in-app unified diff view for commits over the warm session (#1242)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/git/GitHistoryDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/git/GitHistoryDockerTest.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -318,6 +319,148 @@ class GitHistoryDockerTest {
         }
         composeRule.onNodeWithTag(GIT_ISSUES_HINT_TAG).assertExists()
         WalkthroughScreenshotArtifacts.capture("issue649-configure-gh-hint")
+    } }
+
+    @Test
+    fun tappingCommitShowsUnifiedDiffOverWarmSession(): Unit { runBlocking {
+        // Issue #1242: tap a commit → its unified diff is fetched via `git show`
+        // over the SAME warm lease the log rode (D21, no new connection) and
+        // renders in-app with +/- gutters.
+        val suffix = System.currentTimeMillis().toString().takeLast(6)
+        val root = "/tmp/issue1242-$suffix"
+        val repo = "$root/proj"
+        seededRoot = root
+
+        var shortHash = ""
+        withTimeout(30_000) {
+            connect()?.use { session ->
+                val script = listOf(
+                    "mkdir -p '$repo'",
+                    "cd '$repo'",
+                    "git init -q",
+                    "git config user.email tester@example.com",
+                    "git config user.name 'PocketShell Tester'",
+                    "printf 'one\\ntwo\\n' > a.txt",
+                    "git add a.txt",
+                    "git commit -q -m 'Seed a.txt'",
+                    "printf 'one\\nCHANGED\\nthree\\n' > a.txt",
+                    "git add a.txt",
+                    "git commit -q -m 'Change a.txt'",
+                    "echo ok",
+                ).joinToString(" && ")
+                val exit = session.exec(script)
+                assertEquals("seed exit (stderr=${exit.stderr})", 0, exit.exitCode)
+                shortHash = session.exec("git -C '$repo' rev-parse --short HEAD").stdout.trim()
+            } ?: error("could not connect to seed diff repo")
+        }
+        assertTrue("seed must yield a short hash", shortHash.isNotBlank())
+
+        // Issue #699: still ONE warm lease for the log AND the git show.
+        val dialCount = AtomicInteger(0)
+        composeRule.setContent {
+            GitHistoryScreen(
+                hostId = 1242L,
+                hostName = "proj",
+                hostname = DEFAULT_HOST,
+                port = DEFAULT_PORT,
+                username = DEFAULT_USER,
+                keyPath = keyFile.absolutePath,
+                passphrase = null,
+                dir = repo,
+                onBack = {},
+                viewModel = newGitHistoryViewModel(dialCount),
+            )
+        }
+
+        composeRule.waitUntil(timeoutMillis = 30_000) {
+            composeRule.onAllNodesWithTagExists(GIT_HISTORY_TAB_TAG)
+        }
+        composeRule.onNodeWithTag(GIT_HISTORY_TAB_TAG).performClick()
+        composeRule.waitUntil(timeoutMillis = 30_000) {
+            composeRule.onAllNodesWithTagExists(GIT_HISTORY_ROW_TAG_PREFIX + shortHash)
+        }
+        composeRule.onNodeWithTag(GIT_HISTORY_ROW_TAG_PREFIX + shortHash).performClick()
+
+        // The diff renders: content view + the added/removed lines from the commit.
+        composeRule.waitUntil(timeoutMillis = 30_000) {
+            composeRule.onAllNodesWithTagExists(GIT_DIFF_CONTENT_TAG)
+        }
+        composeRule.waitUntil(timeoutMillis = 30_000) {
+            composeRule.onAllNodesWithTextExists("CHANGED")
+        }
+        composeRule.onNodeWithTag(GIT_DIFF_CONTENT_TAG).assertExists()
+        // Only one real SSH handshake for the whole log + show journey (#699/D21).
+        assertEquals(
+            "git show should reuse ONE warm lease, not dial per action (#699/D21)",
+            1,
+            dialCount.get(),
+        )
+        WalkthroughScreenshotArtifacts.capture("issue1242-git-diff")
+    } }
+
+    @Test
+    fun largeCommitDiffIsTruncatedWithMarker(): Unit { runBlocking {
+        // Issue #1242 (AC2): a diff larger than the server-side byte cap must
+        // come back windowed with a visible truncation marker — never an
+        // unbounded read.
+        val suffix = System.currentTimeMillis().toString().takeLast(6)
+        val root = "/tmp/issue1242-big-$suffix"
+        val repo = "$root/proj"
+        seededRoot = root
+
+        var shortHash = ""
+        withTimeout(40_000) {
+            connect()?.use { session ->
+                // seq 1..60000 is ~400 KiB of added lines — well over the 256 KiB
+                // DEFAULT_DIFF_BYTE_CAP, so the diff is byte-capped + truncated.
+                val script = listOf(
+                    "mkdir -p '$repo'",
+                    "cd '$repo'",
+                    "git init -q",
+                    "git config user.email tester@example.com",
+                    "git config user.name 'PocketShell Tester'",
+                    "seq 1 60000 > big.txt",
+                    "git add big.txt",
+                    "git commit -q -m 'Add big.txt'",
+                    "echo ok",
+                ).joinToString(" && ")
+                val exit = session.exec(script)
+                assertEquals("seed exit (stderr=${exit.stderr})", 0, exit.exitCode)
+                shortHash = session.exec("git -C '$repo' rev-parse --short HEAD").stdout.trim()
+            } ?: error("could not connect to seed big-diff repo")
+        }
+        assertTrue(shortHash.isNotBlank())
+
+        composeRule.setContent {
+            GitHistoryScreen(
+                hostId = 12420L,
+                hostName = "proj",
+                hostname = DEFAULT_HOST,
+                port = DEFAULT_PORT,
+                username = DEFAULT_USER,
+                keyPath = keyFile.absolutePath,
+                passphrase = null,
+                dir = repo,
+                onBack = {},
+                viewModel = newGitHistoryViewModel(),
+            )
+        }
+
+        composeRule.waitUntil(timeoutMillis = 30_000) {
+            composeRule.onAllNodesWithTagExists(GIT_HISTORY_TAB_TAG)
+        }
+        composeRule.onNodeWithTag(GIT_HISTORY_TAB_TAG).performClick()
+        composeRule.waitUntil(timeoutMillis = 30_000) {
+            composeRule.onAllNodesWithTagExists(GIT_HISTORY_ROW_TAG_PREFIX + shortHash)
+        }
+        composeRule.onNodeWithTag(GIT_HISTORY_ROW_TAG_PREFIX + shortHash).performClick()
+
+        // The truncation marker appears (the read was bounded, not unbounded).
+        composeRule.waitUntil(timeoutMillis = 30_000) {
+            composeRule.onAllNodesWithTagExists(GIT_DIFF_TRUNCATED_TAG)
+        }
+        composeRule.onNodeWithTag(GIT_DIFF_TRUNCATED_TAG).assertExists()
+        WalkthroughScreenshotArtifacts.capture("issue1242-git-diff-truncated")
     } }
 
     @Test

--- a/app/src/androidTest/java/com/pocketshell/app/git/GitHistoryScaffoldTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/git/GitHistoryScaffoldTest.kt
@@ -34,9 +34,13 @@ class GitHistoryScaffoldTest {
         onRetry: () -> Unit = {},
         onOpenGitHub: (String) -> Unit = {},
         createState: CreateIssueUiState = CreateIssueUiState.Idle,
+        diffState: GitDiffUiState = GitDiffUiState.Hidden,
         onSubmitNewIssue: (String, String) -> Unit = { _, _ -> },
         onDismissCreateIssue: () -> Unit = {},
         onOpenIssueUrl: (String) -> Unit = {},
+        onCommitSelected: (String, String) -> Unit = { _, _ -> },
+        onDismissDiff: () -> Unit = {},
+        onOpenCommitOnGitHub: (String) -> Unit = {},
     ) {
         compose.setContent {
             PocketShellTheme {
@@ -46,10 +50,14 @@ class GitHistoryScaffoldTest {
                     onBack = {},
                     onRetry = onRetry,
                     createState = createState,
+                    diffState = diffState,
                     onOpenGitHub = onOpenGitHub,
                     onSubmitNewIssue = onSubmitNewIssue,
                     onDismissCreateIssue = onDismissCreateIssue,
                     onOpenIssueUrl = onOpenIssueUrl,
+                    onCommitSelected = onCommitSelected,
+                    onDismissDiff = onDismissDiff,
+                    onOpenCommitOnGitHub = onOpenCommitOnGitHub,
                 )
             }
         }
@@ -373,6 +381,149 @@ class GitHistoryScaffoldTest {
         compose.onNodeWithTag(GIT_CREATE_ISSUE_ERROR_TAG).assertIsDisplayed()
         // The form is still present so the user can fix and retry.
         compose.onNodeWithTag(GIT_CREATE_ISSUE_TITLE_TAG).assertIsDisplayed()
+    }
+
+    // ---- unified diff viewer (issue #1242) ---------------------------------
+
+    private fun sampleDiff(
+        ref: String = "a1b2c3d",
+        truncated: Boolean = false,
+        longLine: Boolean = false,
+    ) = GitCommitDiff(
+        ref = ref,
+        lines = listOf(
+            DiffLine("", "commit ${ref}0000", DiffLineKind.CommitMeta),
+            DiffLine("", "diff --git a/Foo.kt b/Foo.kt", DiffLineKind.FileHeader),
+            DiffLine("", "@@ -1,3 +1,4 @@", DiffLineKind.HunkHeader),
+            DiffLine(" ", "fun foo() {", DiffLineKind.Context),
+            DiffLine("-", "    val old = 1", DiffLineKind.Removed),
+            DiffLine(
+                "+",
+                if (longLine) "    val new = ${"x".repeat(400)}" else "    val new = 2",
+                DiffLineKind.Added,
+            ),
+            DiffLine(" ", "}", DiffLineKind.Context),
+        ),
+        truncated = truncated,
+    )
+
+    @Test
+    fun tappingCommitInvokesOnCommitSelected() {
+        var selected: Pair<String, String>? = null
+        setState(
+            GitHistoryUiState.Ready(
+                dir = "/home/u/git/proj",
+                commits = listOf(commit("a1b2c3d", "Add timeline view")),
+                truncated = false,
+                overview = overview(),
+            ),
+            onCommitSelected = { hash, subject -> selected = hash to subject },
+        )
+        compose.onNodeWithTag(GIT_HISTORY_TAB_TAG).performClick()
+        compose.onNodeWithTag(GIT_HISTORY_ROW_TAG_PREFIX + "a1b2c3d").performClick()
+        assertEquals("a1b2c3d" to "Add timeline view", selected)
+    }
+
+    @Test
+    fun diffReadyRendersGuttersAndContent() {
+        setState(
+            configuredReady(),
+            diffState = GitDiffUiState.Ready("Add timeline view", sampleDiff()),
+        )
+        compose.assertNodeFullyWithinRoot(GIT_DIFF_VIEW_TAG)
+        compose.assertNodeFullyWithinRoot(GIT_DIFF_CONTENT_TAG)
+        // The added/removed code and the subject header are visible.
+        compose.onNodeWithText("Add timeline view").assertIsDisplayed()
+        compose.onNodeWithText("    val new = 2").assertIsDisplayed()
+        compose.onNodeWithText("    val old = 1").assertIsDisplayed()
+    }
+
+    @Test
+    fun diffLongLineRendersWithoutWrapping() {
+        // A very long added line must render (single-line, horizontally
+        // scrollable) — the full-device scroll proof is the emulator screenshot.
+        setState(
+            configuredReady(),
+            diffState = GitDiffUiState.Ready("Long line", sampleDiff(longLine = true)),
+        )
+        compose.assertNodeFullyWithinRoot(GIT_DIFF_CONTENT_TAG)
+        compose.onNodeWithTag(GIT_DIFF_LINE_TAG_PREFIX + "5").assertExists()
+    }
+
+    @Test
+    fun diffTruncatedShowsMarker() {
+        setState(
+            configuredReady(),
+            diffState = GitDiffUiState.Ready("Big commit", sampleDiff(truncated = true)),
+        )
+        compose.assertNodeFullyWithinRoot(GIT_DIFF_TRUNCATED_TAG)
+    }
+
+    @Test
+    fun diffNotTruncatedHidesMarker() {
+        setState(
+            configuredReady(),
+            diffState = GitDiffUiState.Ready("Small commit", sampleDiff(truncated = false)),
+        )
+        compose.onNodeWithTag(GIT_DIFF_TRUNCATED_TAG).assertDoesNotExist()
+    }
+
+    @Test
+    fun diffLoadingShowsSpinner() {
+        setState(
+            configuredReady(),
+            diffState = GitDiffUiState.Loading("a1b2c3d", "Add timeline view"),
+        )
+        compose.assertNodeFullyWithinRoot(GIT_DIFF_LOADING_TAG)
+    }
+
+    @Test
+    fun diffFailedShowsError() {
+        setState(
+            configuredReady(),
+            diffState = GitDiffUiState.Failed("a1b2c3d", "gone", "Unknown commit: a1b2c3d"),
+        )
+        compose.assertNodeFullyWithinRoot(GIT_DIFF_ERROR_TAG)
+        compose.onNodeWithText("Unknown commit: a1b2c3d").assertIsDisplayed()
+    }
+
+    @Test
+    fun diffBackDismisses() {
+        var dismissed = 0
+        setState(
+            configuredReady(),
+            diffState = GitDiffUiState.Ready("Add timeline view", sampleDiff()),
+            onDismissDiff = { dismissed++ },
+        )
+        compose.onNodeWithTag(GIT_DIFF_BACK_TAG).performClick()
+        assertEquals(1, dismissed)
+    }
+
+    @Test
+    fun diffOpenOnGitHubFiresCommitUrlWhenRepoIsGitHub() {
+        var opened: String? = null
+        setState(
+            GitHistoryUiState.Ready(
+                dir = "/home/u/git/proj",
+                commits = listOf(commit("a1b2c3d", "Add timeline view")),
+                truncated = false,
+                overview = overview(),
+                gitHubUrl = "https://github.com/owner/repo",
+            ),
+            diffState = GitDiffUiState.Ready("Add timeline view", sampleDiff(ref = "a1b2c3d")),
+            onOpenCommitOnGitHub = { opened = it },
+        )
+        compose.onNodeWithTag(GIT_DIFF_OPEN_ON_GITHUB_TAG).performClick()
+        assertEquals("https://github.com/owner/repo/commit/a1b2c3d", opened)
+    }
+
+    @Test
+    fun diffOpenOnGitHubHiddenWhenRepoNotGitHub() {
+        setState(
+            configuredReady(),
+            diffState = GitDiffUiState.Ready("Add timeline view", sampleDiff()),
+        )
+        compose.onNodeWithTag(GIT_DIFF_OPEN_ON_GITHUB_TAG).assertDoesNotExist()
     }
 
     @Test

--- a/app/src/main/java/com/pocketshell/app/git/GitCommitDiff.kt
+++ b/app/src/main/java/com/pocketshell/app/git/GitCommitDiff.kt
@@ -1,0 +1,61 @@
+package com.pocketshell.app.git
+
+/**
+ * A parsed unified diff for a single commit (or working-tree change) — issue
+ * #1242. Read-only: reviewing a change from the phone without leaving the app.
+ *
+ * The raw `git show --no-color <ref>` output is classified line-by-line into
+ * [DiffLine]s so the UI can render `+`/`-` gutters and syntax-neutral coloring
+ * over the shared monospace renderer. Large diffs are bounded — see
+ * [GitHistoryGateway.commitDiff] (server-side byte cap) and the render line cap —
+ * so a huge commit never triggers an unbounded read or an unbounded list. When a
+ * bound trips, [truncated] is set so the UI shows a visible truncation marker.
+ */
+data class GitCommitDiff(
+    /** The commit ref this diff was fetched for (short hash from the log row). */
+    val ref: String,
+    /** Classified diff lines, newest cap first, in file order. */
+    val lines: List<DiffLine>,
+    /**
+     * True when the output was cut off by the server-side byte cap or the render
+     * line cap — the UI appends a truncation marker so the user knows there is
+     * more that isn't shown (and can fall back to "Open on GitHub").
+     */
+    val truncated: Boolean,
+)
+
+/**
+ * One rendered line of a unified diff. [gutter] is the `+`/`-`/space sign shown
+ * in a fixed-width column; [content] is the code (with the leading diff prefix
+ * already stripped for add/remove/context lines). [kind] drives the color.
+ */
+data class DiffLine(
+    val gutter: String,
+    val content: String,
+    val kind: DiffLineKind,
+)
+
+/**
+ * Syntax-neutral classification of a diff line — enough to color the `+`/`-`
+ * gutters and set apart hunk headers, file headers, and the commit metadata
+ * that `git show` prints above the patch.
+ */
+enum class DiffLineKind {
+    /** Commit metadata git show prints first: `commit …`, `Author:`, `Date:`, subject. */
+    CommitMeta,
+
+    /** Per-file header lines: `diff --git`, `index`, `--- a/…`, `+++ b/…`, mode/rename/binary. */
+    FileHeader,
+
+    /** A `@@ -a,b +c,d @@` hunk header. */
+    HunkHeader,
+
+    /** An added line (`+…`). */
+    Added,
+
+    /** A removed line (`-…`). */
+    Removed,
+
+    /** An unchanged context line. */
+    Context,
+}

--- a/app/src/main/java/com/pocketshell/app/git/GitHistoryGateway.kt
+++ b/app/src/main/java/com/pocketshell/app/git/GitHistoryGateway.kt
@@ -67,6 +67,69 @@ class GitHistoryGateway(private val session: SshSession) {
     }
 
     /**
+     * Fetch the unified diff for a single commit [ref] in [dir] over the warm
+     * session — issue #1242.
+     *
+     * Runs `git -C <dir> show --no-color <ref>` and, crucially, pipes it through
+     * `head -c <cap+1>` so the number of bytes pulled over SSH is HARD-bounded on
+     * the server side — a giant commit can never trigger an unbounded read (the
+     * transcript byte-cap lesson). We ask for one byte past the cap so the
+     * over-cap case is detectable: if the returned payload exceeds [maxBytes] the
+     * diff was truncated, and [parseDiff] marks it so the UI shows a visible
+     * marker. The render list is additionally capped at [maxLines] lines.
+     *
+     * [ref] is single-quoted for shell safety even though it originates from our
+     * own parsed log; a stray value can never break out of its argument. Returns
+     * a [NotAGitRepoException] failure when [dir] isn't a working tree (mirroring
+     * [recentCommits]) and a [GitCommandException] when the ref doesn't resolve
+     * to a commit or the show otherwise fails.
+     */
+    suspend fun commitDiff(
+        dir: String,
+        ref: String,
+        maxBytes: Int = DEFAULT_DIFF_BYTE_CAP,
+        maxLines: Int = DEFAULT_DIFF_MAX_LINES,
+    ): Result<GitCommitDiff> {
+        val quoted = quoteSingle(dir)
+        val probe = runCatching {
+            session.exec("git -C $quoted rev-parse --is-inside-work-tree 2>/dev/null")
+        }.getOrElse { return Result.failure(it) }
+        if (probe.exitCode != 0 || probe.stdout.trim() != "true") {
+            return Result.failure(NotAGitRepoException(dir))
+        }
+
+        // Verify the ref resolves to a commit BEFORE the (byte-capped) show, so a
+        // bad ref gives a precise error instead of an empty/garbled payload.
+        val refQuoted = quoteSingle(ref)
+        val verify = runCatching {
+            session.exec("git -C $quoted rev-parse --verify --quiet $refQuoted^{commit} 2>/dev/null")
+        }.getOrElse { return Result.failure(it) }
+        if (verify.exitCode != 0 || verify.stdout.isBlank()) {
+            return Result.failure(GitCommandException("Unknown commit: $ref"))
+        }
+
+        val cap = maxBytes.coerceAtLeast(1)
+        // 2>/dev/null keeps git's stderr out of the parsed patch; the pipe to
+        // `head -c` bounds the transferred bytes at cap+1 so over-cap is
+        // detectable without ever pulling the whole diff.
+        val showCmd =
+            "git -C $quoted show --no-color $refQuoted 2>/dev/null | head -c ${cap + 1}"
+        val result = runCatching { session.exec(showCmd) }
+            .getOrElse { return Result.failure(it) }
+        // The pipeline exit is head's, which is 0 even when git failed; an empty
+        // payload for a ref that resolved above means the show produced nothing.
+        if (result.stdout.isEmpty()) {
+            return Result.failure(
+                GitCommandException(
+                    result.stderr.trim().ifBlank { "git show produced no output for $ref" },
+                ),
+            )
+        }
+        val byteCapExceeded = result.stdout.toByteArray(Charsets.UTF_8).size > cap
+        return Result.success(parseDiff(ref, result.stdout, byteCapExceeded, maxLines))
+    }
+
+    /**
      * Fetch the read-only repository overview for [dir] — issue #647: branches,
      * linked worktrees, and a working-tree status summary (current branch,
      * ahead/behind vs upstream, dirty/clean, last commit).
@@ -258,6 +321,23 @@ class GitHistoryGateway(private val session: SshSession) {
     companion object {
         const val DEFAULT_LIMIT: Int = 100
 
+        /**
+         * Server-side byte cap on a single `git show` (issue #1242). Bounds the
+         * bytes pulled over SSH so a giant commit can't trigger an unbounded
+         * read; 256 KiB comfortably covers a normal review diff while staying
+         * cheap. The show is piped through `head -c cap+1` so over-cap is
+         * detectable.
+         */
+        const val DEFAULT_DIFF_BYTE_CAP: Int = 256 * 1024
+
+        /**
+         * Render cap on the number of diff lines the UI list holds (issue
+         * #1242). A second bound below the byte cap so even a byte-small diff of
+         * very short lines can't produce an unbounded list; when tripped the
+         * diff is marked truncated.
+         */
+        const val DEFAULT_DIFF_MAX_LINES: Int = 2_000
+
         /** Default issue listing cap — keeps a giant project's list manageable. */
         const val DEFAULT_ISSUE_LIMIT: Int = 50
 
@@ -304,6 +384,91 @@ class GitHistoryGateway(private val session: SshSession) {
                     )
                 }
                 .toList()
+        }
+
+        /**
+         * Parse raw `git show --no-color` output into classified [DiffLine]s —
+         * issue #1242. Pure — unit-tested without a live session.
+         *
+         * Splits on newlines, classifies each line for the `+`/`-` gutter and
+         * syntax-neutral color, and enforces the render [maxLines] cap. The
+         * result is marked [GitCommitDiff.truncated] when either the server-side
+         * byte cap was exceeded ([byteCapExceeded]) or the line count hit
+         * [maxLines], so the UI shows a visible truncation marker.
+         */
+        internal fun parseDiff(
+            ref: String,
+            raw: String,
+            byteCapExceeded: Boolean,
+            maxLines: Int = DEFAULT_DIFF_MAX_LINES,
+        ): GitCommitDiff {
+            val cap = maxLines.coerceAtLeast(1)
+            // Drop a single trailing empty element from a final newline, but keep
+            // interior blank lines (a blank context line is meaningful).
+            val rawLines = raw.split('\n').let {
+                if (it.isNotEmpty() && it.last().isEmpty()) it.dropLast(1) else it
+            }
+            val overLineCap = rawLines.size > cap
+            // `git show` prints the commit message body indented with spaces
+            // BEFORE the first `diff --git`; those look like context lines, so we
+            // only treat `+`/`-`/space as add/remove/context once we're inside the
+            // patch (a `diff --git` has been seen). Track that state as we go.
+            var inPatch = false
+            val lines = rawLines.asSequence()
+                .take(cap)
+                .map { line ->
+                    if (line.startsWith("diff --git") || line.startsWith("@@")) inPatch = true
+                    classifyDiffLine(line, inPatch)
+                }
+                .toList()
+            return GitCommitDiff(
+                ref = ref,
+                lines = lines,
+                truncated = byteCapExceeded || overLineCap,
+            )
+        }
+
+        /**
+         * Classify a single raw diff line into a [DiffLine] with a `+`/`-`/space
+         * gutter and a [DiffLineKind]. Pure — unit-tested. [inPatch] is true once
+         * the first `diff --git` has been seen; before that (the commit-message
+         * header git show prints) an indented or `+`/`-` line is metadata, NOT a
+         * diff line. The leading diff prefix is moved into the gutter for
+         * add/remove/context lines so [DiffLine.content] is the bare code;
+         * header/metadata lines keep an empty gutter and their full text.
+         */
+        internal fun classifyDiffLine(line: String, inPatch: Boolean): DiffLine = when {
+            line.startsWith("@@") ->
+                DiffLine(gutter = "", content = line, kind = DiffLineKind.HunkHeader)
+            line.startsWith("diff --git") ||
+                line.startsWith("index ") ||
+                line.startsWith("--- ") ||
+                line.startsWith("+++ ") ||
+                line.startsWith("new file") ||
+                line.startsWith("deleted file") ||
+                line.startsWith("old mode") ||
+                line.startsWith("new mode") ||
+                line.startsWith("similarity index") ||
+                line.startsWith("dissimilarity index") ||
+                line.startsWith("rename ") ||
+                line.startsWith("copy ") ||
+                line.startsWith("Binary files") ->
+                DiffLine(gutter = "", content = line, kind = DiffLineKind.FileHeader)
+            // Everything before the first `diff --git` (commit hash, Author/Date,
+            // the indented subject/body, blank separators) is commit metadata.
+            !inPatch ->
+                DiffLine(gutter = "", content = line, kind = DiffLineKind.CommitMeta)
+            // A real added/removed line — but NOT the `+++`/`---` file headers,
+            // which are matched above.
+            line.startsWith("+") ->
+                DiffLine(gutter = "+", content = line.substring(1), kind = DiffLineKind.Added)
+            line.startsWith("-") ->
+                DiffLine(gutter = "-", content = line.substring(1), kind = DiffLineKind.Removed)
+            line.startsWith(" ") ->
+                DiffLine(gutter = " ", content = line.substring(1), kind = DiffLineKind.Context)
+            // The `\ No newline at end of file` marker inside a hunk — neutral.
+            else ->
+                DiffLine(gutter = "", content = line, kind = DiffLineKind.CommitMeta)
         }
 
         /**

--- a/app/src/main/java/com/pocketshell/app/git/GitHistoryScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/git/GitHistoryScreen.kt
@@ -4,7 +4,9 @@ import android.content.Intent
 import android.net.Uri
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -42,6 +44,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.Role
@@ -88,6 +91,16 @@ const val GIT_WORKTREE_ROW_TAG_PREFIX = "gitWorktreeRow:"
 
 // "Open on GitHub" action (issue #648) — only shown when origin is a GitHub repo.
 const val GIT_OPEN_ON_GITHUB_TAG = "gitOpenOnGitHub"
+
+// In-app unified diff viewer (issue #1242).
+const val GIT_DIFF_VIEW_TAG = "gitDiffView"
+const val GIT_DIFF_BACK_TAG = "gitDiffBack"
+const val GIT_DIFF_LOADING_TAG = "gitDiffLoading"
+const val GIT_DIFF_ERROR_TAG = "gitDiffError"
+const val GIT_DIFF_CONTENT_TAG = "gitDiffContent"
+const val GIT_DIFF_TRUNCATED_TAG = "gitDiffTruncated"
+const val GIT_DIFF_OPEN_ON_GITHUB_TAG = "gitDiffOpenOnGitHub"
+const val GIT_DIFF_LINE_TAG_PREFIX = "gitDiffLine:"
 
 // Issues tab (issue #649): the repo's GitHub issues via `gh issue list`.
 const val GIT_ISSUES_TAB_TAG = "gitTabIssues"
@@ -145,6 +158,7 @@ fun GitHistoryScreen(
     }
     val state by viewModel.state.collectAsState()
     val createState by viewModel.createState.collectAsState()
+    val diffState by viewModel.diffState.collectAsState()
     val context = LocalContext.current
     val openUrl: (String) -> Unit = { url ->
         runCatching {
@@ -155,12 +169,16 @@ fun GitHistoryScreen(
         hostName = hostName,
         state = state,
         createState = createState,
+        diffState = diffState,
         onBack = onBack,
         onRetry = viewModel::retry,
         onOpenGitHub = openUrl,
         onSubmitNewIssue = viewModel::createIssue,
         onDismissCreateIssue = viewModel::dismissCreateIssue,
         onOpenIssueUrl = openUrl,
+        onCommitSelected = viewModel::loadDiff,
+        onDismissDiff = viewModel::dismissDiff,
+        onOpenCommitOnGitHub = openUrl,
         modifier = modifier,
     )
 }
@@ -177,13 +195,18 @@ internal fun GitHistoryScaffold(
     onBack: () -> Unit,
     onRetry: () -> Unit,
     createState: CreateIssueUiState = CreateIssueUiState.Idle,
+    diffState: GitDiffUiState = GitDiffUiState.Hidden,
     onOpenGitHub: (String) -> Unit = {},
     onSubmitNewIssue: (String, String) -> Unit = { _, _ -> },
     onDismissCreateIssue: () -> Unit = {},
     onOpenIssueUrl: (String) -> Unit = {},
+    onCommitSelected: (String, String) -> Unit = { _, _ -> },
+    onDismissDiff: () -> Unit = {},
+    onOpenCommitOnGitHub: (String) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     var showCreateSheet by rememberSaveable { mutableStateOf(false) }
+    val gitHubUrl = (state as? GitHistoryUiState.Ready)?.gitHubUrl
     Box(
         modifier = modifier
             .fillMaxSize()
@@ -205,6 +228,7 @@ internal fun GitHistoryScaffold(
                         onDismissCreateIssue()
                         showCreateSheet = true
                     },
+                    onCommitSelected = onCommitSelected,
                 )
                 is GitHistoryUiState.NotARepo -> NotARepoPanel(state.dir)
                 is GitHistoryUiState.Failed -> ErrorPanel(
@@ -213,6 +237,21 @@ internal fun GitHistoryScaffold(
                     onRetry = onRetry,
                 )
             }
+        }
+
+        // In-app unified diff viewer (#1242): an opaque overlay over the whole
+        // screen while a commit's diff is open, so the escape-hatch "Open on
+        // GitHub" list row underneath stays reachable when the viewer is closed.
+        if (diffState !is GitDiffUiState.Hidden) {
+            val commitGitHubUrl = gitHubUrl?.let { base ->
+                diffRefOf(diffState)?.let { ref -> "${base.trimEnd('/')}/commit/$ref" }
+            }
+            GitDiffView(
+                diffState = diffState,
+                gitHubCommitUrl = commitGitHubUrl,
+                onBack = onDismissDiff,
+                onOpenOnGitHub = onOpenCommitOnGitHub,
+            )
         }
     }
 
@@ -244,6 +283,7 @@ private fun ReadyPanel(
     state: GitHistoryUiState.Ready,
     onOpenGitHub: (String) -> Unit,
     onNewIssue: () -> Unit,
+    onCommitSelected: (String, String) -> Unit,
 ) {
     // Default to Overview so the at-a-glance "what's happening" view (status,
     // branches, worktrees) is what the user lands on; History is one tap away.
@@ -271,7 +311,7 @@ private fun ReadyPanel(
         )
         when (tab) {
             GitTab.Overview -> OverviewPanel(state, onOpenGitHub)
-            GitTab.History -> HistoryPanel(state)
+            GitTab.History -> HistoryPanel(state, onCommitSelected = onCommitSelected)
             GitTab.Issues -> IssuesPanel(state, onNewIssue = onNewIssue)
         }
     }
@@ -327,7 +367,10 @@ private fun GitHistoryHeader(
 }
 
 @Composable
-private fun HistoryPanel(state: GitHistoryUiState.Ready) {
+private fun HistoryPanel(
+    state: GitHistoryUiState.Ready,
+    onCommitSelected: (String, String) -> Unit,
+) {
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
         contentPadding = PaddingValues(vertical = PocketShellSpacing.sm),
@@ -346,10 +389,13 @@ private fun HistoryPanel(state: GitHistoryUiState.Ready) {
             }
         }
         itemsIndexed(state.commits, key = { index, c -> "$index:${c.shortHash}" }) { _, commit ->
+            val subject = commit.subject.ifBlank { "(no subject)" }
+            // Tapping a commit opens its unified diff in-app (#1242).
             ListRow(
-                title = commit.subject.ifBlank { "(no subject)" },
+                title = subject,
                 subtitle = "${commit.author} · ${commit.relativeTime}",
                 leading = { GlyphCell(commit.shortHash) },
+                onClick = { onCommitSelected(commit.shortHash, subject) },
                 modifier = Modifier.testTag(GIT_HISTORY_ROW_TAG_PREFIX + commit.shortHash),
             )
         }
@@ -698,6 +744,215 @@ private fun ErrorPanel(
                 }
             }
         }
+    }
+}
+
+// ---- unified diff viewer (issue #1242) ------------------------------------
+
+/** The commit ref a non-hidden [GitDiffUiState] is about, for the commit URL. */
+private fun diffRefOf(state: GitDiffUiState): String? = when (state) {
+    is GitDiffUiState.Loading -> state.ref
+    is GitDiffUiState.Ready -> state.diff.ref
+    is GitDiffUiState.Failed -> state.ref
+    GitDiffUiState.Hidden -> null
+}
+
+/** The commit subject a non-hidden [GitDiffUiState] carries, for the header. */
+private fun diffSubjectOf(state: GitDiffUiState): String = when (state) {
+    is GitDiffUiState.Loading -> state.subject
+    is GitDiffUiState.Ready -> state.subject
+    is GitDiffUiState.Failed -> state.subject
+    GitDiffUiState.Hidden -> ""
+}
+
+/**
+ * The in-app unified diff viewer (issue #1242). A full-screen opaque overlay
+ * that renders a commit's `git show` output over the shared monospace renderer
+ * with `+`/`-` gutters and syntax-neutral coloring. Long lines DON'T wrap — each
+ * row's code scrolls horizontally under a single shared scroll state so the
+ * whole diff pans together and a long line is never wrap-mangled on the narrow
+ * Pixel-7 width. A visible truncation marker appears when the diff was bounded.
+ * "Open on GitHub" stays available as the escape hatch when the commit's GitHub
+ * URL is known.
+ */
+@Composable
+private fun GitDiffView(
+    diffState: GitDiffUiState,
+    gitHubCommitUrl: String?,
+    onBack: () -> Unit,
+    onOpenOnGitHub: (String) -> Unit,
+) {
+    val ref = diffRefOf(diffState).orEmpty()
+    val subject = diffSubjectOf(diffState)
+    // One shared horizontal scroll state so every code line pans together.
+    val hScroll = rememberScrollState()
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(PocketShellColors.Background)
+            .testTag(GIT_DIFF_VIEW_TAG),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(PocketShellColors.Background)
+                .border(width = 1.dp, color = PocketShellColors.BorderSoft)
+                .padding(end = PocketShellDensity.rowPadH),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(PocketShellDensity.tapTargetMin)
+                    .clickable(role = Role.Button, onClick = onBack)
+                    .testTag(GIT_DIFF_BACK_TAG),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = "‹",
+                    color = PocketShellColors.TextSecondary,
+                    style = MaterialTheme.typography.headlineSmall,
+                )
+            }
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = ref,
+                    color = PocketShellColors.Accent,
+                    style = PocketShellType.labelMono,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                )
+                Text(
+                    text = subject,
+                    color = PocketShellColors.Text,
+                    style = PocketShellType.bodyDense,
+                    maxLines = 2,
+                )
+            }
+            if (gitHubCommitUrl != null) {
+                PocketShellButton(
+                    text = "GitHub",
+                    onClick = { onOpenOnGitHub(gitHubCommitUrl) },
+                    variant = ButtonVariant.Text,
+                    modifier = Modifier.testTag(GIT_DIFF_OPEN_ON_GITHUB_TAG),
+                )
+            }
+        }
+
+        when (diffState) {
+            GitDiffUiState.Hidden -> Unit
+            is GitDiffUiState.Loading -> Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .testTag(GIT_DIFF_LOADING_TAG),
+                contentAlignment = Alignment.Center,
+            ) {
+                LoadingIndicator.Spinner(size = SpinnerSize.Small)
+            }
+            is GitDiffUiState.Failed -> Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(PocketShellDensity.rowPadH)
+                    .testTag(GIT_DIFF_ERROR_TAG),
+            ) {
+                Text(
+                    text = "Couldn't load diff",
+                    color = PocketShellColors.Red,
+                    style = PocketShellType.bodyDense,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Text(
+                    text = diffState.message,
+                    color = PocketShellColors.TextSecondary,
+                    style = PocketShellType.bodyMono,
+                )
+            }
+            is GitDiffUiState.Ready -> Column(modifier = Modifier.fillMaxSize()) {
+                // Truncation notice as a FIXED banner at the top of the body (not
+                // a trailing lazy item, which would be off-screen at the bottom of
+                // a huge diff and never seen), so the user always knows the diff
+                // was bounded and can fall back to "Open on GitHub".
+                if (diffState.diff.truncated) {
+                    Text(
+                        text = "Diff truncated — showing the first part. Open on GitHub for the rest.",
+                        color = PocketShellColors.TextSecondary,
+                        style = PocketShellType.bodyDense,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .background(PocketShellColors.SurfaceElev)
+                            .padding(
+                                horizontal = PocketShellDensity.rowPadH,
+                                vertical = PocketShellSpacing.sm,
+                            )
+                            .testTag(GIT_DIFF_TRUNCATED_TAG),
+                    )
+                }
+                LazyColumn(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .testTag(GIT_DIFF_CONTENT_TAG),
+                    contentPadding = PaddingValues(vertical = PocketShellSpacing.sm),
+                ) {
+                    itemsIndexed(
+                        diffState.diff.lines,
+                        key = { index, _ -> "diffline:$index" },
+                    ) { index, line ->
+                        DiffLineRow(line = line, index = index, hScroll = hScroll)
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * One rendered diff line (#1242): a fixed-width `+`/`-` gutter followed by the
+ * code, which scrolls horizontally under the shared [hScroll] state so a long
+ * line pans instead of wrapping. The row background is tinted by the line kind
+ * across the FULL width (the tint sits outside the scroll region).
+ */
+@Composable
+private fun DiffLineRow(line: DiffLine, index: Int, hScroll: ScrollState) {
+    val fg = when (line.kind) {
+        DiffLineKind.Added -> PocketShellColors.Green
+        DiffLineKind.Removed -> PocketShellColors.Red
+        DiffLineKind.HunkHeader -> PocketShellColors.Accent
+        DiffLineKind.FileHeader -> PocketShellColors.TextSecondary
+        DiffLineKind.CommitMeta -> PocketShellColors.TextSecondary
+        DiffLineKind.Context -> PocketShellColors.Text
+    }
+    val bg = when (line.kind) {
+        DiffLineKind.Added -> Color(0x1A22C55E)
+        DiffLineKind.Removed -> Color(0x1AEF4444)
+        DiffLineKind.HunkHeader -> PocketShellColors.AccentSoft
+        else -> Color.Transparent
+    }
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(bg)
+            .testTag(GIT_DIFF_LINE_TAG_PREFIX + index),
+    ) {
+        Text(
+            text = line.gutter,
+            color = fg,
+            style = PocketShellType.bodyMono,
+            fontWeight = FontWeight.SemiBold,
+            maxLines = 1,
+            modifier = Modifier
+                .width(16.dp)
+                .padding(start = PocketShellSpacing.sm),
+        )
+        Text(
+            text = line.content,
+            color = fg,
+            style = PocketShellType.bodyMono,
+            softWrap = false,
+            maxLines = 1,
+            modifier = Modifier
+                .weight(1f)
+                .horizontalScroll(hScroll)
+                .padding(end = PocketShellSpacing.sm),
+        )
     }
 }
 

--- a/app/src/main/java/com/pocketshell/app/git/GitHistoryViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/git/GitHistoryViewModel.kt
@@ -82,6 +82,24 @@ sealed interface GitHistoryUiState {
 }
 
 /**
+ * State of the in-app unified diff viewer (#1242), separate from the main screen
+ * load so opening/closing a commit's diff doesn't disturb the list/overview.
+ */
+sealed interface GitDiffUiState {
+    /** No diff open — the commit list is shown. */
+    data object Hidden : GitDiffUiState
+
+    /** Fetching the diff for [ref] via `git show` over the warm session. */
+    data class Loading(val ref: String, val subject: String) : GitDiffUiState
+
+    /** The diff loaded. [diff] carries the classified lines + truncation flag. */
+    data class Ready(val subject: String, val diff: GitCommitDiff) : GitDiffUiState
+
+    /** The diff couldn't be read (bad ref, transport drop). */
+    data class Failed(val ref: String, val subject: String, val message: String) : GitDiffUiState
+}
+
+/**
  * State of the "New issue" create form (#650), separate from the screen's main
  * load state so opening/submitting the sheet doesn't disturb the list/overview.
  */
@@ -118,10 +136,12 @@ class GitHistoryViewModel @Inject constructor(
         ioDispatcher: CoroutineDispatcher,
         bestEffortProbeTimeoutMs: Long = BEST_EFFORT_PROBE_TIMEOUT_MS,
         createIssueTimeoutMs: Long = CREATE_ISSUE_TIMEOUT_MS,
+        diffTimeoutMs: Long = DIFF_TIMEOUT_MS,
     ) : this(sshLeaseManager) {
         this.ioDispatcher = ioDispatcher
         this.bestEffortProbeTimeoutMs = bestEffortProbeTimeoutMs
         this.createIssueTimeoutMs = createIssueTimeoutMs
+        this.diffTimeoutMs = diffTimeoutMs
     }
 
     private val _state = MutableStateFlow<GitHistoryUiState>(
@@ -133,7 +153,12 @@ class GitHistoryViewModel @Inject constructor(
     private val _createState = MutableStateFlow<CreateIssueUiState>(CreateIssueUiState.Idle)
     val createState: StateFlow<CreateIssueUiState> = _createState.asStateFlow()
 
+    /** Unified diff viewer state (#1242), independent of the main screen state. */
+    private val _diffState = MutableStateFlow<GitDiffUiState>(GitDiffUiState.Hidden)
+    val diffState: StateFlow<GitDiffUiState> = _diffState.asStateFlow()
+
     private var request: Request? = null
+    private var diffJob: Job? = null
     // Issue #699: the screen borrows ONE warm lease from the app-wide
     // @Singleton SshLeaseManager (keyed identically to the live session
     // screens, so it shares the same transport per host) and reuses
@@ -144,6 +169,7 @@ class GitHistoryViewModel @Inject constructor(
     private var ioDispatcher: CoroutineDispatcher = Dispatchers.IO
     private var bestEffortProbeTimeoutMs: Long = BEST_EFFORT_PROBE_TIMEOUT_MS
     private var createIssueTimeoutMs: Long = CREATE_ISSUE_TIMEOUT_MS
+    private var diffTimeoutMs: Long = DIFF_TIMEOUT_MS
 
     /**
      * Issue #1085 (F2): the application-scoped coroutine the warm-lease
@@ -238,6 +264,58 @@ class GitHistoryViewModel @Inject constructor(
     fun dismissCreateIssue() {
         createJob?.cancel()
         _createState.value = CreateIssueUiState.Idle
+    }
+
+    /**
+     * Open the in-app unified diff for commit [ref] (#1242) — fetched via
+     * `git show` over the SAME warm session the log rode (D21, no new
+     * connection). [subject] is carried so the diff header can show it while the
+     * body loads. Any in-flight diff load is cancelled first.
+     *
+     * The read is byte-capped server-side by [GitHistoryGateway.commitDiff] and
+     * time-bounded here, so a giant commit can neither hang the screen nor pull
+     * an unbounded payload. Failures surface on [diffState] as
+     * [GitDiffUiState.Failed] rather than a blank viewer.
+     */
+    fun loadDiff(ref: String, subject: String) {
+        val req = request ?: return
+        diffJob?.cancel()
+        _diffState.value = GitDiffUiState.Loading(ref = ref, subject = subject)
+        diffJob = viewModelScope.launch {
+            val outcome = withContext(ioDispatcher) {
+                val live = ensureSession(req)
+                    ?: return@withContext GitDiffUiState.Failed(
+                        ref = ref,
+                        subject = subject,
+                        message = "Couldn't reach ${req.username}@${req.hostname}.",
+                    )
+                val gateway = GitHistoryGateway(live)
+                val result = boundedGatewayResult(
+                    timeoutMs = diffTimeoutMs,
+                    timeoutMessage = "git show timed out",
+                ) {
+                    gateway.commitDiff(req.dir, ref)
+                }
+                result.fold(
+                    onSuccess = { diff -> GitDiffUiState.Ready(subject = subject, diff = diff) },
+                    onFailure = { error ->
+                        if (error is CancellationException) throw error
+                        GitDiffUiState.Failed(
+                            ref = ref,
+                            subject = subject,
+                            message = error.message ?: error.javaClass.simpleName,
+                        )
+                    },
+                )
+            }
+            _diffState.value = outcome
+        }
+    }
+
+    /** Close the diff viewer, returning to the commit list (#1242). */
+    fun dismissDiff() {
+        diffJob?.cancel()
+        _diffState.value = GitDiffUiState.Hidden
     }
 
     private fun load() {
@@ -385,6 +463,7 @@ class GitHistoryViewModel @Inject constructor(
     override fun onCleared() {
         loadJob?.cancel()
         createJob?.cancel()
+        diffJob?.cancel()
         // Issue #1085 (F2): refcount-- the warm transport OFF the Main thread.
         // This screen's VM is `hiltViewModel()` nav-scoped, so `onCleared` fires
         // on an ordinary foreground back/navigate-away ON the Main thread. The
@@ -487,6 +566,9 @@ class GitHistoryViewModel @Inject constructor(
 
         /** Bound the user-triggered gh create call independently of the screen load. */
         private const val CREATE_ISSUE_TIMEOUT_MS: Long = 15_000L
+
+        /** Bound the user-triggered `git show` diff read (#1242) independently. */
+        private const val DIFF_TIMEOUT_MS: Long = 20_000L
 
         /** Cap the history so a giant repo doesn't blow up the listing. */
         const val COMMIT_LIMIT: Int = GitHistoryGateway.DEFAULT_LIMIT

--- a/app/src/test/java/com/pocketshell/app/git/GitCommitDiffParseTest.kt
+++ b/app/src/test/java/com/pocketshell/app/git/GitCommitDiffParseTest.kt
@@ -1,0 +1,143 @@
+package com.pocketshell.app.git
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure unit tests over the `git show` diff parser — issue #1242.
+ *
+ * The gateway pipes `git show --no-color <ref>` through `head -c cap+1` and hands
+ * the raw output to [GitHistoryGateway.parseDiff]. These pin the line
+ * classification (the `+`/`-` gutter + syntax-neutral kind) and — the
+ * load-bearing safety property — the truncation/windowing boundary that keeps a
+ * giant commit from producing an unbounded list.
+ */
+class GitCommitDiffParseTest {
+
+    private val sampleDiff = buildString {
+        appendLine("commit a1b2c3d4e5f6")
+        appendLine("Author: Ada Lovelace <ada@example.com>")
+        appendLine("Date:   Mon Jul 6 10:00:00 2026 +0000")
+        appendLine()
+        appendLine("    Add timeline view")
+        appendLine()
+        appendLine("diff --git a/app/Foo.kt b/app/Foo.kt")
+        appendLine("index 1111111..2222222 100644")
+        appendLine("--- a/app/Foo.kt")
+        appendLine("+++ b/app/Foo.kt")
+        appendLine("@@ -1,3 +1,4 @@")
+        appendLine(" fun foo() {")
+        appendLine("-    val old = 1")
+        appendLine("+    val new = 2")
+        appendLine("+    val added = 3")
+        appendLine(" }")
+    }
+
+    @Test
+    fun `classifies commit metadata file headers hunk headers and add remove context`() {
+        val diff = GitHistoryGateway.parseDiff("a1b2c3d", sampleDiff, byteCapExceeded = false)
+
+        // Commit header block.
+        assertEquals(DiffLineKind.CommitMeta, lineByContent(diff, "commit a1b2c3d4e5f6").kind)
+        assertEquals(
+            DiffLineKind.CommitMeta,
+            lineByContent(diff, "Author: Ada Lovelace <ada@example.com>").kind,
+        )
+        // File header block.
+        assertEquals(
+            DiffLineKind.FileHeader,
+            lineByContent(diff, "diff --git a/app/Foo.kt b/app/Foo.kt").kind,
+        )
+        assertEquals(DiffLineKind.FileHeader, lineByContent(diff, "--- a/app/Foo.kt").kind)
+        assertEquals(DiffLineKind.FileHeader, lineByContent(diff, "+++ b/app/Foo.kt").kind)
+        // Hunk header.
+        assertEquals(DiffLineKind.HunkHeader, lineByContent(diff, "@@ -1,3 +1,4 @@").kind)
+    }
+
+    @Test
+    fun `plus and minus lines get a gutter and stripped content but the file headers do not`() {
+        val diff = GitHistoryGateway.parseDiff("a1b2c3d", sampleDiff, byteCapExceeded = false)
+
+        val added = diff.lines.first { it.kind == DiffLineKind.Added && it.content.contains("new") }
+        assertEquals("+", added.gutter)
+        assertEquals("    val new = 2", added.content)
+
+        val removed = diff.lines.first { it.kind == DiffLineKind.Removed }
+        assertEquals("-", removed.gutter)
+        assertEquals("    val old = 1", removed.content)
+
+        val context = diff.lines.first { it.kind == DiffLineKind.Context }
+        assertEquals(" ", context.gutter)
+        assertEquals("fun foo() {", context.content)
+
+        // The `+++`/`---` file headers must NOT be misclassified as add/remove.
+        assertTrue(
+            diff.lines.none { it.kind == DiffLineKind.Added && it.content.startsWith("+ b/") },
+        )
+        assertFalse(diff.truncated)
+    }
+
+    @Test
+    fun `not truncated when under both caps`() {
+        val diff = GitHistoryGateway.parseDiff("a1b2c3d", sampleDiff, byteCapExceeded = false)
+        assertFalse(diff.truncated)
+    }
+
+    @Test
+    fun `byte-cap-exceeded flag propagates to truncated`() {
+        val diff = GitHistoryGateway.parseDiff("a1b2c3d", sampleDiff, byteCapExceeded = true)
+        assertTrue(diff.truncated)
+    }
+
+    @Test
+    fun `line cap windows the list and marks truncated at the boundary`() {
+        // 10 lines of content but a cap of 4 → exactly 4 kept, truncated=true.
+        val raw = (1..10).joinToString("\n") { "+line $it" }
+        val diff = GitHistoryGateway.parseDiff("a1b2c3d", raw, byteCapExceeded = false, maxLines = 4)
+        assertEquals(4, diff.lines.size)
+        assertTrue("more lines than the cap must mark truncated", diff.truncated)
+    }
+
+    @Test
+    fun `exactly at the line cap is not truncated`() {
+        val raw = (1..4).joinToString("\n") { "+line $it" }
+        val diff = GitHistoryGateway.parseDiff("a1b2c3d", raw, byteCapExceeded = false, maxLines = 4)
+        assertEquals(4, diff.lines.size)
+        assertFalse("exactly at the cap is complete, not truncated", diff.truncated)
+    }
+
+    @Test
+    fun `trailing newline does not create a spurious empty line`() {
+        val diff = GitHistoryGateway.parseDiff("a1b2c3d", "+one\n+two\n", byteCapExceeded = false)
+        assertEquals(2, diff.lines.size)
+    }
+
+    @Test
+    fun `interior blank context line is preserved`() {
+        // A blank context line in unified diff is a single space; keep it. Inside
+        // a hunk (after @@) so it classifies as context, not commit metadata.
+        val diff = GitHistoryGateway.parseDiff(
+            "a1b2c3d",
+            "@@ -1,3 +1,3 @@\n a\n \n b",
+            byteCapExceeded = false,
+        )
+        assertEquals(4, diff.lines.size)
+        assertEquals(DiffLineKind.Context, diff.lines[2].kind)
+    }
+
+    @Test
+    fun `no newline at end of file marker is neutral metadata not a removal`() {
+        val diff = GitHistoryGateway.parseDiff(
+            "a1b2c3d",
+            "@@ -1 +1 @@\n-old\n+new\n\\ No newline at end of file",
+            byteCapExceeded = false,
+        )
+        val marker = lineByContent(diff, "\\ No newline at end of file")
+        assertEquals(DiffLineKind.CommitMeta, marker.kind)
+    }
+
+    private fun lineByContent(diff: GitCommitDiff, content: String): DiffLine =
+        diff.lines.first { it.content == content }
+}

--- a/app/src/test/java/com/pocketshell/app/git/GitHistoryDiffViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/git/GitHistoryDiffViewModelTest.kt
@@ -1,0 +1,150 @@
+package com.pocketshell.app.git
+
+import com.pocketshell.app.hosts.MainDispatcherRule
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.SshLeaseConnector
+import com.pocketshell.core.ssh.SshLeaseManager
+import com.pocketshell.core.ssh.SshPortForward
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshShell
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import java.io.File
+import java.io.InputStream
+
+/**
+ * Drives the in-app diff viewer state wiring on [GitHistoryViewModel] — issue
+ * #1242. Tapping a commit runs `git show` over the SAME warm lease the log rode
+ * (no new connection) and surfaces the parsed diff on `diffState`; a bad ref
+ * surfaces a failure; dismiss returns to the list.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class GitHistoryDiffViewModelTest {
+
+    private val scheduler = TestCoroutineScheduler()
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule(StandardTestDispatcher(scheduler))
+
+    private val request = GitHistoryViewModel.Request(
+        hostId = 1L,
+        hostname = "lab.local",
+        port = 22,
+        username = "alexey",
+        keyPath = "/tmp/key",
+        passphrase = null,
+        dir = "/repo",
+    )
+
+    @Test
+    fun `loadDiff fetches and exposes the parsed diff over the warm lease`() = runTest(scheduler) {
+        val dials = intArrayOf(0)
+        val vm = viewModelOver(dials) { cmd ->
+            when {
+                "rev-parse --is-inside-work-tree" in cmd -> ExecResult("true\n", "", 0)
+                "rev-parse --verify" in cmd -> ExecResult("a1b2c3d\n", "", 0)
+                "show" in cmd -> ExecResult("@@ -1 +1 @@\n-old\n+new\n", "", 0)
+                // log / status / gh probes during start(): degrade harmlessly.
+                else -> ExecResult("", "", 0)
+            }
+        }
+        vm.start(request)
+        advanceUntilIdle()
+
+        vm.loadDiff("a1b2c3d", "Add timeline view")
+        advanceUntilIdle()
+
+        val state = vm.diffState.value
+        assertTrue("expected Ready but was $state", state is GitDiffUiState.Ready)
+        val ready = state as GitDiffUiState.Ready
+        assertEquals("Add timeline view", ready.subject)
+        assertEquals("a1b2c3d", ready.diff.ref)
+        assertTrue(ready.diff.lines.any { it.kind == DiffLineKind.Added })
+        assertTrue(ready.diff.lines.any { it.kind == DiffLineKind.Removed })
+        // D21 / #699: the whole screen + diff rode ONE warm transport.
+        assertEquals("git diff must reuse the warm lease, not dial again", 1, dials[0])
+    }
+
+    @Test
+    fun `loadDiff on an unknown ref surfaces a failure`() = runTest(scheduler) {
+        val vm = viewModelOver(intArrayOf(0)) { cmd ->
+            when {
+                "rev-parse --is-inside-work-tree" in cmd -> ExecResult("true\n", "", 0)
+                "rev-parse --verify" in cmd -> ExecResult("", "", 1)
+                else -> ExecResult("", "", 0)
+            }
+        }
+        vm.start(request)
+        advanceUntilIdle()
+
+        vm.loadDiff("deadbee", "gone")
+        advanceUntilIdle()
+
+        assertTrue(vm.diffState.value is GitDiffUiState.Failed)
+    }
+
+    @Test
+    fun `dismissDiff returns to the hidden list state`() = runTest(scheduler) {
+        val vm = viewModelOver(intArrayOf(0)) { cmd ->
+            when {
+                "rev-parse --is-inside-work-tree" in cmd -> ExecResult("true\n", "", 0)
+                "rev-parse --verify" in cmd -> ExecResult("sha\n", "", 0)
+                "show" in cmd -> ExecResult("+x\n", "", 0)
+                else -> ExecResult("", "", 0)
+            }
+        }
+        vm.start(request)
+        advanceUntilIdle()
+        vm.loadDiff("abc", "s")
+        advanceUntilIdle()
+        assertTrue(vm.diffState.value is GitDiffUiState.Ready)
+
+        vm.dismissDiff()
+        advanceUntilIdle()
+        assertEquals(GitDiffUiState.Hidden, vm.diffState.value)
+    }
+
+    private fun viewModelOver(
+        dials: IntArray,
+        onExec: (String) -> ExecResult,
+    ): GitHistoryViewModel {
+        val session = scripted(onExec)
+        val manager = SshLeaseManager(
+            connector = SshLeaseConnector { dials[0]++; Result.success(session) },
+            connectTimeoutContext = StandardTestDispatcher(scheduler),
+            nowMillis = { scheduler.currentTime },
+        )
+        return GitHistoryViewModel(
+            sshLeaseManager = manager,
+            ioDispatcher = StandardTestDispatcher(scheduler),
+        )
+    }
+
+    private fun scripted(onExec: (String) -> ExecResult): SshSession = object : SshSession {
+        override val isConnected: Boolean = true
+        override suspend fun exec(command: String): ExecResult = onExec(command)
+        override fun tail(path: String, onLine: (String) -> Unit): Job = error("unused")
+        override fun openLocalPortForward(
+            remoteHost: String,
+            remotePort: Int,
+            localPort: Int,
+        ): SshPortForward = error("unused")
+        override fun startShell(): SshShell = error("unused")
+        override suspend fun uploadFile(file: File, remotePath: String): String = error("unused")
+        override suspend fun uploadStream(
+            input: InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String = error("unused")
+        override fun close() = Unit
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/git/GitHistoryGatewayDiffTest.kt
+++ b/app/src/test/java/com/pocketshell/app/git/GitHistoryGatewayDiffTest.kt
@@ -1,0 +1,133 @@
+package com.pocketshell.app.git
+
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshShell
+import com.pocketshell.core.ssh.SshPortForward
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+import java.io.InputStream
+
+/**
+ * Drives [GitHistoryGateway.commitDiff] over a scripted [SshSession] — issue
+ * #1242. Pins the real command path (probe → ref-verify → byte-capped show) and
+ * the load-bearing safety property: the server-side `head -c cap+1` byte cap
+ * turns an over-cap diff into a truncated result rather than an unbounded read.
+ */
+class GitHistoryGatewayDiffTest {
+
+    @Test
+    fun `fetches and parses a commit diff over the session`() = runBlocking {
+        val session = scripted { cmd ->
+            when {
+                "rev-parse --is-inside-work-tree" in cmd -> ExecResult("true\n", "", 0)
+                "rev-parse --verify" in cmd -> ExecResult("a1b2c3d4\n", "", 0)
+                "git -C" in cmd && "show" in cmd -> ExecResult(
+                    "@@ -1 +1 @@\n-old\n+new\n",
+                    "",
+                    0,
+                )
+                else -> ExecResult("", "", 0)
+            }
+        }
+        val diff = GitHistoryGateway(session).commitDiff("/repo", "a1b2c3d").getOrThrow()
+        assertEquals("a1b2c3d", diff.ref)
+        assertEquals(DiffLineKind.HunkHeader, diff.lines[0].kind)
+        assertEquals(DiffLineKind.Removed, diff.lines[1].kind)
+        assertEquals(DiffLineKind.Added, diff.lines[2].kind)
+        assertFalse(diff.truncated)
+    }
+
+    @Test
+    fun `pipes the show through a bounded head -c cap+1`() = runBlocking {
+        var showCmd: String? = null
+        val session = scripted { cmd ->
+            when {
+                "rev-parse --is-inside-work-tree" in cmd -> ExecResult("true\n", "", 0)
+                "rev-parse --verify" in cmd -> ExecResult("sha\n", "", 0)
+                "show" in cmd -> { showCmd = cmd; ExecResult("+x\n", "", 0) }
+                else -> ExecResult("", "", 0)
+            }
+        }
+        GitHistoryGateway(session).commitDiff("/repo", "abc", maxBytes = 1024).getOrThrow()
+        assertTrue("show must be byte-capped via head -c", showCmd!!.contains("head -c 1025"))
+        assertTrue("stderr must be dropped so it never pollutes the patch", showCmd!!.contains("2>/dev/null"))
+    }
+
+    @Test
+    fun `over-cap output is marked truncated`() = runBlocking {
+        // maxBytes = 8 → the gateway asks for 9 bytes; a 9-byte payload means the
+        // real diff was longer, so it must come back truncated.
+        val nineBytes = "+123456789" // 10 chars > 8 cap
+        val session = scripted { cmd ->
+            when {
+                "rev-parse --is-inside-work-tree" in cmd -> ExecResult("true\n", "", 0)
+                "rev-parse --verify" in cmd -> ExecResult("sha\n", "", 0)
+                "show" in cmd -> ExecResult(nineBytes, "", 0)
+                else -> ExecResult("", "", 0)
+            }
+        }
+        val diff = GitHistoryGateway(session).commitDiff("/repo", "abc", maxBytes = 8).getOrThrow()
+        assertTrue("payload over the byte cap must be truncated", diff.truncated)
+    }
+
+    @Test
+    fun `under-cap output is not truncated`() = runBlocking {
+        val session = scripted { cmd ->
+            when {
+                "rev-parse --is-inside-work-tree" in cmd -> ExecResult("true\n", "", 0)
+                "rev-parse --verify" in cmd -> ExecResult("sha\n", "", 0)
+                "show" in cmd -> ExecResult("+x\n", "", 0)
+                else -> ExecResult("", "", 0)
+            }
+        }
+        val diff = GitHistoryGateway(session).commitDiff("/repo", "abc", maxBytes = 1024).getOrThrow()
+        assertFalse(diff.truncated)
+    }
+
+    @Test
+    fun `unknown ref fails cleanly`() = runBlocking {
+        val session = scripted { cmd ->
+            when {
+                "rev-parse --is-inside-work-tree" in cmd -> ExecResult("true\n", "", 0)
+                "rev-parse --verify" in cmd -> ExecResult("", "", 1)
+                else -> ExecResult("", "", 0)
+            }
+        }
+        val result = GitHistoryGateway(session).commitDiff("/repo", "nope")
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is GitCommandException)
+    }
+
+    @Test
+    fun `non-repo dir fails with NotAGitRepoException`() = runBlocking {
+        val session = scripted { ExecResult("", "", 128) }
+        val result = GitHistoryGateway(session).commitDiff("/tmp/plain", "abc")
+        assertTrue(result.exceptionOrNull() is NotAGitRepoException)
+    }
+
+    private fun scripted(onExec: (String) -> ExecResult): SshSession = object : SshSession {
+        override val isConnected: Boolean = true
+        override suspend fun exec(command: String): ExecResult = onExec(command)
+        override fun tail(path: String, onLine: (String) -> Unit): Job = error("unused")
+        override fun openLocalPortForward(
+            remoteHost: String,
+            remotePort: Int,
+            localPort: Int,
+        ): SshPortForward = error("unused")
+        override fun startShell(): SshShell = error("unused")
+        override suspend fun uploadFile(file: File, remotePath: String): String = error("unused")
+        override suspend fun uploadStream(
+            input: InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String = error("unused")
+        override fun close() = Unit
+    }
+}


### PR DESCRIPTION
Closes #1242

Unified `git show` diff in-app (monospace, +/- gutters, syntax-neutral coloring) over the ONE warm SSH lease the history log already rode (D21 — no new connection). Large diffs byte-capped server-side + windowed with a fixed truncation banner. "Open on GitHub" retained.

**Verification (reviewer APPROVED, full red→green driven):** JVM 18/0 (caught+fixed a real commit-body-indent parser misclassification, red→green); on-device emulator + Docker `agents:2222` — both Docker tests pass incl. `dialCount==1` D21 proof + the truncation-banner case; `GitHistoryScaffoldTest` 30/30; screenshots inspected (gutters/coloring/truncation banner correct). CI-compat: agents:2222 only. Reviewer: https://github.com/alexeygrigorev/pocketshell/issues/1242#issuecomment-4912276849