### PR TITLE
bootstrap: fold hooks install into host bootstrap + surface notification readiness (#1236)

### DIFF
--- a/.github/workflows/nightly-extensive.yml
+++ b/.github/workflows/nightly-extensive.yml
@@ -220,6 +220,7 @@ jobs:
           docker compose -f tests/docker/docker-compose.yml up -d --build --no-deps \
             agents flaky-agent tmux network-fault-proxy packet-loss-proxy \
             bootstrap-ready bootstrap-uv-install bootstrap-uv-upgrade \
+            bootstrap-notifications \
             agents-old-cli agents-daemon
 
       - name: Wait for fixture containers to report healthy
@@ -238,6 +239,9 @@ jobs:
           cat /tmp/bootstrap-uv-install-health.log
           wait_for_container_healthy tests/docker/docker-compose.yml bootstrap-uv-upgrade /tmp/bootstrap-uv-upgrade-health.log 60
           cat /tmp/bootstrap-uv-upgrade-health.log
+          # Issue #1236 (D26): the silent-host notifications fixture (2241).
+          wait_for_container_healthy tests/docker/docker-compose.yml bootstrap-notifications /tmp/bootstrap-notifications-health.log 60
+          cat /tmp/bootstrap-notifications-health.log
           # Old-CLI (2238, #849) + daemon (2239, #839) fixtures: the phase-1
           # FolderList*DockerTest journeys target these by host port and fail
           # hard when the port is unforwarded, so wait on them before handing off
@@ -353,6 +357,7 @@ jobs:
           docker compose -f tests/docker/docker-compose.yml logs --no-color bootstrap-ready > artifacts/docker/bootstrap-ready.log 2>/dev/null || true
           docker compose -f tests/docker/docker-compose.yml logs --no-color bootstrap-uv-install > artifacts/docker/bootstrap-uv-install.log 2>/dev/null || true
           docker compose -f tests/docker/docker-compose.yml logs --no-color bootstrap-uv-upgrade > artifacts/docker/bootstrap-uv-upgrade.log 2>/dev/null || true
+          docker compose -f tests/docker/docker-compose.yml logs --no-color bootstrap-notifications > artifacts/docker/bootstrap-notifications.log 2>/dev/null || true
           docker compose -f tests/docker/docker-compose.yml logs --no-color agents-old-cli > artifacts/docker/agents-old-cli.log 2>/dev/null || true
           docker compose -f tests/docker/docker-compose.yml logs --no-color agents-daemon > artifacts/docker/agents-daemon.log 2>/dev/null || true
           docker inspect pocketshell-test-agents > artifacts/docker/agents-inspect.json 2>/dev/null || true

--- a/app/src/androidTest/java/com/pocketshell/app/bootstrap/HostBootstrapScenarioSuiteTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/bootstrap/HostBootstrapScenarioSuiteTest.kt
@@ -291,6 +291,53 @@ class HostBootstrapScenarioSuiteTest {
         }
     } }
 
+    @Test
+    fun notifications() { scenario("notifications") {
+        // Issue #1236 (D26): the CLI + tmux are ready, but the agent stop/idle
+        // notification hooks are OFF — a SILENT host under D21 (server-side push
+        // is the only "agent needs input" path). Bootstrap must surface the
+        // silent host and offer a one-tap enable that folds in a NON-DESTRUCTIVE
+        // `pocketshell hooks install`.
+        launchSeededHost()
+        tapSeededHost()
+
+        // Precondition: the pre-existing foreign Claude Stop hook is present and
+        // our hook is NOT yet installed (silent host).
+        assertRemote("fixture must start with a pre-existing foreign hook and NO pocketshell hook") {
+            "/bin/sh -lc 'grep -q my-preexisting-stop-hook ~/.claude/settings.json && " +
+                "! grep -q claude_stop.py ~/.claude/settings.json'"
+        }
+
+        // A ready host with notifications off is diverted to the setup sheet
+        // instead of navigating past it — the silent host is VISIBLE.
+        waitForBootstrapSheet()
+        compose.onNodeWithText("Host setup needed").assertExists()
+        compose.onNodeWithTag(HOST_BOOTSTRAP_ROW_TAG_PREFIX + HOST_BOOTSTRAP_NOTIFICATIONS_ROW_TITLE)
+            .assertExists()
+        compose.onNodeWithTag(HOST_BOOTSTRAP_ENABLE_NOTIFICATIONS_TAG).assertExists()
+        capture("02-notifications-off")
+
+        // Tap "Enable": runs the server setup path, which folds in the
+        // non-destructive hooks install.
+        compose.onNodeWithTag(HOST_BOOTSTRAP_ENABLE_NOTIFICATIONS_TAG).performClick()
+        compose.waitUntil(timeoutMillis = 20_000) {
+            compose.onAllNodesWithText("Host ready").fetchSemanticsNodes().isNotEmpty()
+        }
+        compose.onNodeWithText("Host ready").assertExists()
+        compose.onNodeWithTag(HOST_BOOTSTRAP_NOTIFICATIONS_STATUS_TAG).assertExists()
+        compose.onNodeWithText("Notifications: on", substring = true).assertExists()
+        capture("03-notifications-on")
+
+        // AC3 (G2 class-coverage): the hook files are present AND the install
+        // MERGED non-destructively — BOTH our hook AND the pre-existing foreign
+        // hook survive in ~/.claude/settings.json.
+        assertRemote("hooks install must merge non-destructively into the existing Claude config") {
+            "/bin/sh -lc 'grep -q claude_stop.py ~/.claude/settings.json && " +
+                "grep -q my-preexisting-stop-hook ~/.claude/settings.json && " +
+                "test -f ~/.cache/pocketshell/hooks/.installed'"
+        }
+    } }
+
     private fun scenario(name: String, block: ScenarioContext.() -> Unit) = runBlocking {
         assumeScenariosEnabled()
         val definition = requireNotNull(SCENARIOS[name]) { "unknown bootstrap scenario: $name" }
@@ -651,7 +698,31 @@ class HostBootstrapScenarioSuiteTest {
                         "printf 'active enabled\\n' > $STATE_FILE"
                 },
             ),
+            // Issue #1236 (D26): CLI + tmux ready, but the agent stop/idle
+            // notification hooks are OFF (a silent host). A pre-existing foreign
+            // Claude hook is seeded so the bootstrap install can be asserted to
+            // MERGE non-destructively.
+            "notifications" to ScenarioDefinition(
+                label = "notifications",
+                port = 2241,
+                resetCommand = { targetAppVersion ->
+                    "mkdir -p ~/.claude ~/.cache/pocketshell/hooks; " +
+                        "printf '%s' " +
+                        shellQuote(PREEXISTING_CLAUDE_SETTINGS) +
+                        " > ~/.claude/settings.json; " +
+                        "rm -f ~/.cache/pocketshell/hooks/.installed; " +
+                        "touch ~/.pocketshell-fixture-hooks-enabled; " +
+                        versionReset(targetAppVersion) +
+                        "printf 'active enabled\\n' > $STATE_FILE"
+                },
+            ),
         )
+
+        // A user's PRE-EXISTING Claude config with a foreign Stop hook. The
+        // D26 `hooks install` merge must preserve this entry (non-destructive).
+        const val PREEXISTING_CLAUDE_SETTINGS: String =
+            "{\"model\":\"sonnet\",\"hooks\":{\"Stop\":[{\"hooks\":" +
+                "[{\"type\":\"command\",\"command\":\"my-preexisting-stop-hook\"}]}]}}"
     }
 }
 

--- a/app/src/androidTest/java/com/pocketshell/app/bootstrap/HostNotificationsReadinessTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/bootstrap/HostNotificationsReadinessTest.kt
@@ -1,0 +1,114 @@
+package com.pocketshell.app.bootstrap
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.pocketshell.uikit.theme.PocketShellColors
+import com.pocketshell.uikit.theme.PocketShellTheme
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Issue #1236 (D26) — per-host notification readiness + the "enable
+ * notifications" upgrade affordance on the [HostBootstrapSheet].
+ *
+ * Under D21 the app never background-polls, so a server-side stop/idle hook →
+ * FCM is the ONLY path to an "agent needs input" push. A host with the CLI but
+ * no hooks is a SILENT host — and before #1236 that was invisible. This drives
+ * the REAL sheet on the emulator and proves:
+ *
+ *  - A ready host whose hooks are OFF ([HooksStatus.NotInstalled]) shows an
+ *    actionable "Agent notifications · Off · Enable" row, and tapping Enable
+ *    fires the enable-notifications path (which folds in the non-destructive
+ *    `pocketshell hooks install`).
+ *  - The success sheet surfaces the readiness line: "Notifications: off" when
+ *    hooks are not installed, "Notifications: on" when they are.
+ *
+ * Direct-Compose (no `ActivityScenario.launch`) so it does not depend on the
+ * full host-connect journey; the live Docker bootstrap journey (bootstrap a
+ * fixture host → non-destructive hook merge) is exercised separately by
+ * [HostBootstrapScenarioSuiteTest.notifications].
+ */
+class HostNotificationsReadinessTest {
+
+    @get:Rule
+    val compose = createComposeRule()
+
+    private fun readyButNotificationsOffReport(): HostBootstrapReport = HostBootstrapReport(
+        tools = mapOf(
+            BootstrapTool.Pocketshell to ToolStatus.Installed("/usr/local/bin/pocketshell"),
+        ),
+        installer = PythonToolInstaller.Uv,
+        installerPath = "/usr/local/bin/uv",
+        daemon = PocketshellDaemonStatus.Running(enabled = true),
+        hooks = HooksStatus.NotInstalled,
+    )
+
+    @OptIn(ExperimentalMaterial3Api::class)
+    @Test
+    fun promptSheet_showsEnableNotifications_forSilentHost_andTapFiresEnable() {
+        val report = readyButNotificationsOffReport()
+        // A compatible CLI with hooks definitively off is the actionable state.
+        assertEquals(true, report.notificationsActionable)
+
+        var enableClicks = 0
+        var installAllClicks = 0
+        compose.setContent {
+            PocketShellTheme {
+                Box(modifier = Modifier.fillMaxSize().background(PocketShellColors.Background)) {
+                    HostBootstrapSheet(
+                        state = HostBootstrapSheetState.Prompt(needsTmux = false, report = report),
+                        hostName = "hetzner",
+                        onInstall = { installAllClicks++ },
+                        onInstallTool = {},
+                        onEnableNotifications = { enableClicks++ },
+                        onSkip = {},
+                        onDismiss = {},
+                    )
+                }
+            }
+        }
+        compose.waitForIdle()
+
+        // The silent host is VISIBLE: an actionable notifications row + Enable.
+        compose.onNodeWithTag(HOST_BOOTSTRAP_ROW_TAG_PREFIX + HOST_BOOTSTRAP_NOTIFICATIONS_ROW_TITLE)
+            .assertExists()
+        compose.onNodeWithTag(HOST_BOOTSTRAP_ENABLE_NOTIFICATIONS_TAG).assertExists()
+
+        // Tapping Enable runs the enable-notifications path (NOT install-all).
+        compose.onNodeWithTag(HOST_BOOTSTRAP_ENABLE_NOTIFICATIONS_TAG).performClick()
+        compose.waitForIdle()
+        assertEquals("Enable must fire onEnableNotifications", 1, enableClicks)
+        assertEquals("Enable must not be the install-all path", 0, installAllClicks)
+    }
+
+    @OptIn(ExperimentalMaterial3Api::class)
+    @Test
+    fun successSheet_showsNotificationsOff_whenHooksNotInstalled() {
+        compose.setContent {
+            PocketShellTheme {
+                Box(modifier = Modifier.fillMaxSize().background(PocketShellColors.Background)) {
+                    HostBootstrapSheet(
+                        state = HostBootstrapSheetState.Success(notificationsReady = false),
+                        hostName = "hetzner",
+                        onInstall = {},
+                        onInstallTool = {},
+                        onSkip = {},
+                        onDismiss = {},
+                    )
+                }
+            }
+        }
+        compose.waitForIdle()
+
+        compose.onNodeWithTag(HOST_BOOTSTRAP_NOTIFICATIONS_STATUS_TAG).assertExists()
+        compose.onNodeWithText("Notifications: off", substring = true).assertExists()
+    }
+}

--- a/app/src/androidTest/java/com/pocketshell/app/bootstrap/HostReadyPrimaryActionTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/bootstrap/HostReadyPrimaryActionTest.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.test.captureToImage
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.platform.app.InstrumentationRegistry
 import com.pocketshell.uikit.theme.PocketShellColors
@@ -67,7 +68,7 @@ class HostReadyPrimaryActionTest {
                         .background(PocketShellColors.Background),
                 ) {
                     HostBootstrapSheet(
-                        state = HostBootstrapSheetState.Success,
+                        state = HostBootstrapSheetState.Success(notificationsReady = true),
                         hostName = "hetzner",
                         onInstall = {},
                         onInstallTool = {},
@@ -85,6 +86,10 @@ class HostReadyPrimaryActionTest {
         compose.onNodeWithTag(HOST_BOOTSTRAP_CONTINUE_TAG).assertExists()
         // Issue #885: the "Open Usage" CTA must NOT exist on the success sheet.
         compose.onNodeWithTag("host-bootstrap-open-usage").assertDoesNotExist()
+        // Issue #1236: the success sheet surfaces per-host notification
+        // readiness so a silent host is visible. notificationsReady = true here.
+        compose.onNodeWithTag(HOST_BOOTSTRAP_NOTIFICATIONS_STATUS_TAG).assertExists()
+        compose.onNodeWithText("Notifications: on", substring = true).assertExists()
 
         capture("issue-885-host-ready.png")
 

--- a/app/src/main/java/com/pocketshell/app/bootstrap/HostBootstrapSheet.kt
+++ b/app/src/main/java/com/pocketshell/app/bootstrap/HostBootstrapSheet.kt
@@ -66,7 +66,15 @@ public sealed interface HostBootstrapSheetState {
         val report: HostBootstrapReport? = null,
     ) : HostBootstrapSheetState
     public data object Installing : HostBootstrapSheetState
-    public data object Success : HostBootstrapSheetState
+
+    /**
+     * Install/update succeeded. [notificationsReady] (issue #1236) drives the
+     * per-host "notifications: on/off" line so a silent host is visible on the
+     * bootstrap result.
+     */
+    public data class Success(
+        val notificationsReady: Boolean = false,
+    ) : HostBootstrapSheetState
     public data class Failed(val message: String) : HostBootstrapSheetState
 }
 
@@ -77,6 +85,12 @@ public const val HOST_BOOTSTRAP_CONTINUE_TAG: String = "host-bootstrap-continue"
 public const val HOST_BOOTSTRAP_CLOSE_TAG: String = "host-bootstrap-close"
 public const val HOST_BOOTSTRAP_INSTALLING_TAG: String = "host-bootstrap-installing"
 public const val HOST_BOOTSTRAP_ROW_TAG_PREFIX: String = "host-bootstrap-row-"
+
+// Issue #1236: per-host notification readiness surface + the "enable
+// notifications" affordance (D26 stop/idle hooks).
+public const val HOST_BOOTSTRAP_NOTIFICATIONS_STATUS_TAG: String = "host-bootstrap-notifications-status"
+public const val HOST_BOOTSTRAP_ENABLE_NOTIFICATIONS_TAG: String = "host-bootstrap-enable-notifications"
+public const val HOST_BOOTSTRAP_NOTIFICATIONS_ROW_TITLE: String = "Agent notifications"
 
 /**
  * Compose modal that surfaces on host connect when `tmux` is missing.
@@ -109,6 +123,10 @@ public fun HostBootstrapSheet(
     onSkip: () -> Unit,
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier,
+    // Issue #1236: enable the D26 stop/idle notification hooks. Defaults to the
+    // full install path so a caller that only wires `onInstall` still enables
+    // notifications.
+    onEnableNotifications: () -> Unit = onInstall,
     sheetState: SheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
 ) {
     ModalBottomSheet(
@@ -125,13 +143,15 @@ public fun HostBootstrapSheet(
                 state = state,
                 onInstall = onInstall,
                 onInstallTool = onInstallTool,
+                onEnableNotifications = onEnableNotifications,
                 onSkip = onSkip,
             )
 
             HostBootstrapSheetState.Installing -> InstallingContent(hostName = hostName)
 
-            HostBootstrapSheetState.Success -> SuccessContent(
+            is HostBootstrapSheetState.Success -> SuccessContent(
                 hostName = hostName,
+                notificationsReady = state.notificationsReady,
                 onContinue = onDismiss,
             )
 
@@ -150,6 +170,7 @@ private fun PromptContent(
     state: HostBootstrapSheetState.Prompt,
     onInstall: () -> Unit,
     onInstallTool: (BootstrapTool) -> Unit,
+    onEnableNotifications: () -> Unit,
     onSkip: () -> Unit,
 ) {
     SheetColumn {
@@ -160,6 +181,7 @@ private fun PromptContent(
         SetupActions(
             state = state,
             onInstallTool = onInstallTool,
+            onEnableNotifications = onEnableNotifications,
         )
         Spacer(modifier = Modifier.height(PocketShellSpacing.lg + PocketShellSpacing.xs))
         if (state.hasActionableSetup()) {
@@ -202,15 +224,18 @@ private fun PromptContent(
 private fun SetupActions(
     state: HostBootstrapSheetState.Prompt,
     onInstallTool: (BootstrapTool) -> Unit,
+    onEnableNotifications: () -> Unit,
 ) {
     val report = state.report ?: return
     val missingTools = report.missingTools
     if (!report.hasBootstrapSheetRows()) return
 
+    val notificationsActionable = report.notificationsActionable
     Spacer(modifier = Modifier.height(PocketShellSpacing.lg))
     SectionHeader(
         label = "Setup actions",
-        count = missingTools.size + report.versionMismatchedTools.size,
+        count = missingTools.size + report.versionMismatchedTools.size +
+            (if (notificationsActionable) 1 else 0),
     )
     Column(verticalArrangement = Arrangement.spacedBy(PocketShellSpacing.sm)) {
         missingTools.forEach { tool ->
@@ -236,6 +261,20 @@ private fun SetupActions(
                 onClick = { onInstallTool(BootstrapTool.Pocketshell) },
             )
         }
+        // Issue #1236 (D26): the "agent needs input" notification hooks. A host
+        // with the CLI but no hooks is a SILENT host under D21 (server-side
+        // push is the only path), so surface it as an actionable row with a
+        // one-tap "Enable" that runs the non-destructive `hooks install`.
+        if (notificationsActionable) {
+            SetupActionRow(
+                title = HOST_BOOTSTRAP_NOTIFICATIONS_ROW_TITLE,
+                detail = "Off — install the stop/idle hooks so \"agent needs input\" pushes work.",
+                statusLabel = "Off",
+                actionLabel = "Enable",
+                actionTestTag = HOST_BOOTSTRAP_ENABLE_NOTIFICATIONS_TAG,
+                onClick = onEnableNotifications,
+            )
+        }
         // Mosh row intentionally not rendered. Spike #159 returned NO-GO
         // for Mosh + tmux -CC, so surfacing a permanent "unsupported" row
         // would only draw attention to a feature we do not ship. The
@@ -246,12 +285,14 @@ private fun SetupActions(
 
 internal fun HostBootstrapReport.hasBootstrapSheetRows(): Boolean =
     missingTools.isNotEmpty() ||
-        versionMismatchedTools.isNotEmpty()
+        versionMismatchedTools.isNotEmpty() ||
+        notificationsActionable
 
 internal fun HostBootstrapSheetState.Prompt.hasActionableSetup(): Boolean =
     needsTmux ||
         report?.missingTools?.isNotEmpty() == true ||
-        report?.versionMismatchedTools?.isNotEmpty() == true
+        report?.versionMismatchedTools?.isNotEmpty() == true ||
+        report?.notificationsActionable == true
 
 internal fun HostBootstrapReport.needsPocketshellDaemonSetup(): Boolean {
     val daemonStatus = daemon
@@ -272,6 +313,7 @@ private fun SetupActionRow(
     statusLabel: String,
     actionLabel: String,
     onClick: () -> Unit,
+    actionTestTag: String? = null,
 ) {
     ListRow(
         title = title,
@@ -289,16 +331,21 @@ private fun SetupActionRow(
                 text = actionLabel,
                 onClick = onClick,
                 variant = ButtonVariant.Secondary,
+                modifier = if (actionTestTag != null) Modifier.testTag(actionTestTag) else Modifier,
             )
         },
     )
 }
 
 @Composable
-private fun SetupInfoRow(title: String, detail: String) {
+private fun SetupInfoRow(
+    title: String,
+    detail: String,
+    testTag: String = HOST_BOOTSTRAP_ROW_TAG_PREFIX + title,
+) {
     Column(
         modifier = Modifier
-            .testTag(HOST_BOOTSTRAP_ROW_TAG_PREFIX + title)
+            .testTag(testTag)
             .fillMaxWidth()
             .background(PocketShellColors.SurfaceElev, PocketShellShapes.small)
             .border(1.dp, PocketShellColors.Border, PocketShellShapes.small)
@@ -351,12 +398,22 @@ private fun InstallingContent(hostName: String) {
 @Composable
 private fun SuccessContent(
     hostName: String,
+    notificationsReady: Boolean,
     onContinue: () -> Unit,
 ) {
     SheetColumn {
         SheetHeader(
             title = "Host ready",
             subtitle = hostBootstrapSuccessSubtitle(hostName),
+        )
+        Spacer(modifier = Modifier.height(PocketShellSpacing.md))
+        // Issue #1236: per-host notification readiness. A silent host (hooks
+        // not installed) is visible here instead of the user only finding out
+        // when an agent finishes unheard.
+        SetupInfoRow(
+            title = HOST_BOOTSTRAP_NOTIFICATIONS_ROW_TITLE,
+            detail = hostBootstrapNotificationsStatusText(notificationsReady),
+            testTag = HOST_BOOTSTRAP_NOTIFICATIONS_STATUS_TAG,
         )
         Spacer(modifier = Modifier.height(PocketShellSpacing.lg + PocketShellSpacing.xs))
         // Issue #885 (hard cut, D22): after a successful install/update the
@@ -379,6 +436,18 @@ private fun SuccessContent(
 
 internal fun hostBootstrapSuccessSubtitle(hostName: String): String =
     "$hostName · tmux and the pocketshell CLI are ready."
+
+/**
+ * Issue #1236: the per-host notification-readiness line. "On" means the D26
+ * stop/idle hooks are installed so "agent needs input" pushes will fire; "Off"
+ * makes a silent host visible (and points at the re-check upgrade path).
+ */
+internal fun hostBootstrapNotificationsStatusText(notificationsReady: Boolean): String =
+    if (notificationsReady) {
+        "Notifications: on — this host will push when an agent needs input."
+    } else {
+        "Notifications: off — re-check setup to enable \"agent needs input\" pushes."
+    }
 
 @Composable
 private fun FailedContent(hostName: String, message: String, onClose: () -> Unit) {

--- a/app/src/main/java/com/pocketshell/app/bootstrap/HostBootstrapper.kt
+++ b/app/src/main/java/com/pocketshell/app/bootstrap/HostBootstrapper.kt
@@ -117,6 +117,33 @@ public sealed interface ToolStatus {
 }
 
 /**
+ * Whether the agent stop/idle notification hooks (D26, `pocketshell hooks
+ * install`) are present on the host.
+ *
+ * Under D21 the app never background-polls, so a server-side stop/idle hook
+ * feeding FCM is the ONLY path to an "agent needs input" push. A host with
+ * the `pocketshell` CLI but no hooks is therefore a **silent host** — the
+ * user never hears that an agent finished. Issue #1236 folds the hook
+ * install into host bootstrap and surfaces this state so a silent host is
+ * visible.
+ *
+ * - [Installed] — every engine reported by `pocketshell hooks status --json`
+ *   has our stop/idle hook installed. Notifications are ready.
+ * - [NotInstalled] — the CLI is present and `hooks status` ran, but at least
+ *   one engine is missing our hook. This is the actionable "enable
+ *   notifications" state.
+ * - [Unknown] — we could not determine the state: the CLI is absent, the
+ *   `hooks` subcommand failed, or the transport errored. Treated as "don't
+ *   pester" (mirrors [TmuxStatus.Unknown]) — we never nudge on Unknown
+ *   because we cannot prove notifications are actually off.
+ */
+public sealed interface HooksStatus {
+    public data object Installed : HooksStatus
+    public data object NotInstalled : HooksStatus
+    public data class Unknown(val reason: String) : HooksStatus
+}
+
+/**
  * Compare two dotted-numeric versions (`MAJOR.MINOR.PATCH`, any number of
  * components) numerically. Returns a negative number when [a] < [b], zero
  * when equal, a positive number when [a] > [b], or `null` when either side
@@ -188,6 +215,10 @@ public data class HostBootstrapReport(
     val installerPath: String? = null,
     val daemon: PocketshellDaemonStatus,
     val mosh: MoshStatus = MoshStatus.Unsupported(MOSH_UNSUPPORTED_REASON),
+    // Issue #1236 (D26): agent stop/idle notification hooks on the host.
+    // Defaults to Unknown so a report constructed before a hooks probe
+    // (or on a host without the CLI) never falsely claims notifications on.
+    val hooks: HooksStatus = HooksStatus.Unknown("hooks not probed"),
 ) {
     public val missingTools: List<BootstrapTool>
         get() = BootstrapTool.entries.filter { tools[it] is ToolStatus.Missing }
@@ -217,6 +248,36 @@ public data class HostBootstrapReport(
 
     public val isReady: Boolean
         get() = isRequiredReady
+
+    /**
+     * Issue #1236: the `pocketshell` CLI is present AND app-compatible
+     * (a plain [ToolStatus.Installed], NOT [ToolStatus.AppUpdateRequired]).
+     * Hooks can only be installed / read through the CLI, so this gates
+     * every notifications affordance. AppUpdateRequired hosts are handled by
+     * the soft "update the app" banner path and are intentionally excluded
+     * so they never get diverted into a setup sheet.
+     */
+    public val pocketshellCompatible: Boolean
+        get() = tools[BootstrapTool.Pocketshell] is ToolStatus.Installed
+
+    /**
+     * Issue #1236: notifications are ready when the D26 stop/idle hooks are
+     * installed on the host. This is the "notifications: on" signal surfaced
+     * per-host so a silent host is visible.
+     */
+    public val notificationsReady: Boolean
+        get() = hooks is HooksStatus.Installed
+
+    /**
+     * Issue #1236: the host has a compatible CLI but the hooks are
+     * *definitively* not installed — the actionable "enable notifications"
+     * state. We deliberately do NOT treat [HooksStatus.Unknown] as
+     * actionable: if we cannot prove notifications are off (old CLI without
+     * the `hooks` subcommand, transport error) we never pester the user,
+     * mirroring the [TmuxStatus.Unknown] policy.
+     */
+    public val notificationsActionable: Boolean
+        get() = pocketshellCompatible && hooks is HooksStatus.NotInstalled
 }
 
 /**
@@ -296,12 +357,14 @@ public class HostBootstrapper @javax.inject.Inject constructor() {
         } else {
             PocketshellDaemonStatus.Missing
         }
+        val hooks = probeHooks(session, tools[BootstrapTool.Pocketshell], bootstrapPath)
         return HostBootstrapReport(
             tools = tools,
             installer = installer?.installer,
             installerPath = installer?.path,
             daemon = daemon,
             mosh = MoshStatus.Unsupported(MOSH_UNSUPPORTED_REASON),
+            hooks = hooks,
         )
     }
 
@@ -356,7 +419,88 @@ public class HostBootstrapper @javax.inject.Inject constructor() {
                 reason = "Required host tools are still missing after setup: $missing.",
             )
         }
+
+        // Issue #1236 (D26): once the required tools are present, fold in the
+        // agent stop/idle notification hooks in the SAME one-tap flow so a
+        // freshly-bootstrapped host is not silently non-notifying. The install
+        // is a NON-DESTRUCTIVE merge (the CLI preserves the user's existing
+        // Claude/Codex/OpenCode config). Best-effort: a hooks-install failure
+        // must NOT fail the whole setup — tmux + the CLI are already usable, so
+        // the readiness probe (via checkServerSetup) reflects whether
+        // notifications ended up on, and the sheet still offers "enable
+        // notifications" rather than reporting a hard install failure.
+        val pocketshellPath = (afterTools.tools[BootstrapTool.Pocketshell] as? ToolStatus.Installed)?.path
+        if (pocketshellPath != null && afterTools.hooks !is HooksStatus.Installed) {
+            installHooks(session, pocketshellPath, bootstrapPath)
+        }
         return InstallResult.Success
+    }
+
+    /**
+     * Issue #1236: probe whether the D26 stop/idle notification hooks are
+     * installed. Only runs against a compatible ([ToolStatus.Installed])
+     * `pocketshell` — hooks live behind the CLI, so without it (or on an
+     * AppUpdateRequired host handled by the app-update banner) the state is
+     * [HooksStatus.Unknown].
+     */
+    private suspend fun probeHooks(
+        session: SshSession,
+        pocketshellStatus: ToolStatus?,
+        bootstrapPath: String?,
+    ): HooksStatus {
+        val path = (pocketshellStatus as? ToolStatus.Installed)?.path
+            ?: return HooksStatus.Unknown("pocketshell CLI not installed")
+        return checkHooks(session, path, bootstrapPath)
+    }
+
+    /**
+     * Run `pocketshell hooks status --json` and classify the result. The CLI
+     * emits `{"engines": [{"engine": "...", "installed": true|false}, ...]}`;
+     * we treat "every engine installed" as [HooksStatus.Installed], any engine
+     * missing as [HooksStatus.NotInstalled], and any failure/unparseable output
+     * as [HooksStatus.Unknown].
+     */
+    internal suspend fun checkHooks(
+        session: SshSession,
+        pocketshellPath: String,
+        bootstrapPath: String?,
+    ): HooksStatus = try {
+        val result = session.exec(
+            pathAwareCommand("${shellQuote(pocketshellPath)} hooks status --json", bootstrapPath),
+        )
+        if (result.exitCode != 0) {
+            HooksStatus.Unknown(
+                "hooks status failed: ${result.stderr.ifBlank { "exit ${result.exitCode}" }}",
+            )
+        } else {
+            parseHooksStatus(result.stdout)
+        }
+    } catch (e: SshException) {
+        HooksStatus.Unknown(e.message ?: e.javaClass.simpleName)
+    } catch (t: Throwable) {
+        HooksStatus.Unknown("${t.javaClass.simpleName}: ${t.message ?: "unknown error"}")
+    }
+
+    /**
+     * Install the D26 stop/idle hooks for every engine. The server-side
+     * `pocketshell hooks install` merges NON-DESTRUCTIVELY into each engine's
+     * existing config (see `tools/pocketshell/src/pocketshell/hooks.py` and
+     * D26). Returns [InstallResult.Success] on exit 0, else Failed/Error so
+     * callers can surface the reason.
+     */
+    public suspend fun installHooks(
+        session: SshSession,
+        pocketshellPath: String,
+        bootstrapPath: String? = null,
+    ): InstallResult = runInstall(
+        session,
+        pathAwareCommand("${shellQuote(pocketshellPath)} hooks install --engine all", bootstrapPath),
+    )
+
+    internal fun parseHooksStatus(output: String): HooksStatus {
+        val states = HOOKS_INSTALLED_PATTERN.findAll(output).map { it.groupValues[1] }.toList()
+        if (states.isEmpty()) return HooksStatus.Unknown("hooks status returned no engine state")
+        return if (states.all { it == "true" }) HooksStatus.Installed else HooksStatus.NotInstalled
     }
 
     private suspend fun freshenReport(
@@ -379,12 +523,14 @@ public class HostBootstrapper @javax.inject.Inject constructor() {
             } else {
                 PocketshellDaemonStatus.Missing
             }
+            val hooks = probeHooks(session, tools[BootstrapTool.Pocketshell], bootstrapPath)
             return HostBootstrapReport(
                 tools = tools,
                 installer = installer?.installer,
                 installerPath = installer?.path,
                 daemon = daemon,
                 mosh = MoshStatus.Unsupported(MOSH_UNSUPPORTED_REASON),
+                hooks = hooks,
             )
         }
         return report
@@ -892,6 +1038,12 @@ public class HostBootstrapper @javax.inject.Inject constructor() {
 
     public companion object {
         private val VERSION_PATTERN: Regex = Regex("""\b(\d+(?:\.\d+){1,3}(?:[-+][0-9A-Za-z.-]+)?)\b""")
+
+        // Issue #1236: extract every `"installed": true|false` from
+        // `pocketshell hooks status --json`. A tolerant regex avoids pulling
+        // in a JSON library for a shape the CLI fully controls.
+        private val HOOKS_INSTALLED_PATTERN: Regex =
+            Regex("\"installed\"\\s*:\\s*(true|false)")
         private const val PATH_BEGIN: String = "__POCKETSHELL_PATH_BEGIN__"
         private const val PATH_END: String = "__POCKETSHELL_PATH_END__"
         private val COMMON_TOOL_DIRS: List<String> = listOf(

--- a/app/src/main/java/com/pocketshell/app/hosts/HostListScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/hosts/HostListScreen.kt
@@ -778,6 +778,10 @@ fun HostListScreen(
                 hostName = bootstrapHostName,
                 onInstall = { viewModel.installTmuxOnPendingHost() },
                 onInstallTool = { tool -> viewModel.installBootstrapTool(tool) },
+                // Issue #1236: "Enable notifications" runs the same server
+                // setup path, which folds in the non-destructive D26 hooks
+                // install once the CLI is present.
+                onEnableNotifications = { viewModel.installTmuxOnPendingHost() },
                 onSkip = { viewModel.dismissBootstrapAndOpen() },
                 onDismiss = { viewModel.dismissBootstrapAndOpen() },
             )

--- a/app/src/main/java/com/pocketshell/app/hosts/HostListViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/hosts/HostListViewModel.kt
@@ -1169,7 +1169,16 @@ class HostListViewModel internal constructor(
                 // note is surfaced as a small dismissible banner on the host
                 // list (see [pocketshellAppUpdateWarning]), NOT a takeover
                 // sheet. No installer, no "setup needed" framing, no loop.
-                if (report.isReady) {
+                //
+                // Issue #1236: a host with the CLI but no D26 notification
+                // hooks is a SILENT host (server-side push is the only "agent
+                // needs input" path under D21). When that is *definitively*
+                // the case (notificationsActionable — a compatible CLI whose
+                // `hooks status` proved hooks off), surface the one-tap
+                // "enable notifications" upgrade instead of navigating past it.
+                // Unknown hooks state (old CLI without the subcommand) is never
+                // actionable, so those hosts navigate unchanged.
+                if (report.isReady && !report.notificationsActionable) {
                     maybeRaiseAppUpdateWarning(host, report)
                     closeBootstrapSession()
                     setHostOpenPhase(host.id, HostOpenPhase.OpeningFolders)
@@ -1346,7 +1355,9 @@ class HostListViewModel internal constructor(
                     // sheet.
                     maybeRaiseAppUpdateWarning(host, finalReport)
                     _bootstrapState.value = if (finalReport.isReady) {
-                        HostBootstrapSheetState.Success
+                        HostBootstrapSheetState.Success(
+                            notificationsReady = finalReport.notificationsReady,
+                        )
                     } else {
                         HostBootstrapSheetState.Prompt(
                             needsTmux = false,
@@ -1503,8 +1514,8 @@ class HostListViewModel internal constructor(
             // via the banner, never the sheet.
             maybeRaiseAppUpdateWarning(it, report)
         }
-        _bootstrapState.value = if (!needsTmux && report.isRequiredReady) {
-            HostBootstrapSheetState.Success
+        _bootstrapState.value = if (!needsTmux && report.isRequiredReady && !report.notificationsActionable) {
+            HostBootstrapSheetState.Success(notificationsReady = report.notificationsReady)
         } else {
             HostBootstrapSheetState.Prompt(needsTmux = needsTmux, report = report)
         }

--- a/app/src/test/java/com/pocketshell/app/bootstrap/HostBootstrapperTest.kt
+++ b/app/src/test/java/com/pocketshell/app/bootstrap/HostBootstrapperTest.kt
@@ -268,6 +268,193 @@ class HostBootstrapperTest {
         assertTrue(session.recorded.none { it.contains("mosh", ignoreCase = true) })
     }
 
+    // ---------------------------------------------------------------------
+    // Issue #1236 (D26): agent stop/idle notification hooks folded into
+    // bootstrap. checkServerSetup probes `pocketshell hooks status --json`;
+    // installServerSetup runs `pocketshell hooks install --engine all` once
+    // the tools are ready.
+    // ---------------------------------------------------------------------
+
+    private fun hooksStatusJson(
+        claude: Boolean = true,
+        codex: Boolean = true,
+        opencode: Boolean = true,
+    ): String =
+        """
+        {"bus_path":"/home/u/.cache/pocketshell/hooks/events.jsonl","engines":[
+          {"engine":"claude","installed":$claude},
+          {"engine":"codex","installed":$codex},
+          {"engine":"opencode","installed":$opencode}
+        ]}
+        """.trimIndent()
+
+    private fun readyToolsWithHooks(hooksStatus: ExecResult): Map<String, ExecResult> = mapOf(
+        pathAware("command -v 'pocketshell'") to ExecResult("/home/u/.local/bin/pocketshell\n", "", 0),
+        pathAware("command -v 'uv'") to ExecResult("/home/u/.local/bin/uv\n", "", 0),
+        pathAware("command -v 'systemctl'") to ExecResult("/usr/bin/systemctl\n", "", 0),
+        systemdAware("systemctl --user is-active pocketshell-jobs.service") to ExecResult("active\n", "", 0),
+        systemdAware("systemctl --user is-enabled pocketshell-jobs.service") to ExecResult("enabled\n", "", 0),
+        pathAware("'/home/u/.local/bin/pocketshell' hooks status --json") to hooksStatus,
+    )
+
+    @Test
+    fun checkServerSetup_reportsNotificationsReady_whenAllHookEnginesInstalled() = runTest {
+        val session = FakeSshSession(
+            readyToolsWithHooks(ExecResult(hooksStatusJson(), "", 0)),
+        )
+
+        val report = bootstrapper.checkServerSetup(session)
+
+        assertEquals(HooksStatus.Installed, report.hooks)
+        assertTrue(report.notificationsReady)
+        assertTrue(!report.notificationsActionable)
+        assertTrue(
+            "checkServerSetup must probe `pocketshell hooks status --json`",
+            session.recorded.any { it.contains("hooks status --json") },
+        )
+    }
+
+    @Test
+    fun checkServerSetup_reportsNotificationsActionable_whenAnEngineMissesTheHook() = runTest {
+        val session = FakeSshSession(
+            readyToolsWithHooks(ExecResult(hooksStatusJson(claude = false), "", 0)),
+        )
+
+        val report = bootstrapper.checkServerSetup(session)
+
+        assertEquals(HooksStatus.NotInstalled, report.hooks)
+        assertTrue(!report.notificationsReady)
+        // CLI is compatible + hooks definitively off → the actionable "enable
+        // notifications" state (a silent host under D21).
+        assertTrue(report.notificationsActionable)
+    }
+
+    @Test
+    fun checkServerSetup_reportsHooksUnknown_neverActionable_whenHooksStatusFails() = runTest {
+        // An OLD CLI without the `hooks` subcommand exits non-zero. We must NOT
+        // pester the user on Unknown (mirrors TmuxStatus.Unknown).
+        val session = FakeSshSession(
+            readyToolsWithHooks(ExecResult("", "no such command 'hooks'", 2)),
+        )
+
+        val report = bootstrapper.checkServerSetup(session)
+
+        assertTrue(report.hooks is HooksStatus.Unknown)
+        assertTrue(!report.notificationsReady)
+        assertTrue(!report.notificationsActionable)
+    }
+
+    @Test
+    fun checkServerSetup_reportsHooksUnknown_whenPocketshellMissing() = runTest {
+        // No CLI → cannot probe hooks. Unknown, never actionable.
+        val session = FakeSshSession(
+            mapOf(
+                pathAware("command -v 'pocketshell'") to ExecResult("", "", 1),
+                pathAware("command -v 'uv'") to ExecResult("/home/u/.local/bin/uv\n", "", 0),
+                pathAware("command -v 'systemctl'") to ExecResult("/usr/bin/systemctl\n", "", 0),
+            ),
+        )
+
+        val report = bootstrapper.checkServerSetup(session)
+
+        assertTrue(report.hooks is HooksStatus.Unknown)
+        assertTrue(!report.notificationsActionable)
+        assertTrue(
+            "no hooks probe should run without a pocketshell CLI",
+            session.recorded.none { it.contains("hooks status") },
+        )
+    }
+
+    @Test
+    fun installServerSetup_installsHooks_afterToolsReady() = runTest {
+        // Tools already present but hooks off → installServerSetup must fold in
+        // `hooks install --engine all` and report Success with notifications on.
+        var installed = false
+        val session = FakeSshSession(
+            dynamic = { command ->
+                when {
+                    command == pathAware("'/home/u/.local/bin/pocketshell' hooks install --engine all") -> {
+                        installed = true
+                        ExecResult("claude: installed\ncodex: installed\nopencode: installed\n", "", 0)
+                    }
+                    command == pathAware("'/home/u/.local/bin/pocketshell' hooks status --json") ->
+                        ExecResult(hooksStatusJson(claude = installed, codex = installed, opencode = installed), "", 0)
+                    command == pathAware("command -v 'pocketshell'") -> ExecResult("/home/u/.local/bin/pocketshell\n", "", 0)
+                    command == pathAware("command -v 'uv'") -> ExecResult("/home/u/.local/bin/uv\n", "", 0)
+                    command == pathAware("command -v 'systemctl'") -> ExecResult("/usr/bin/systemctl\n", "", 0)
+                    command == systemdAware("systemctl --user is-active pocketshell-jobs.service") -> ExecResult("active\n", "", 0)
+                    command == systemdAware("systemctl --user is-enabled pocketshell-jobs.service") -> ExecResult("enabled\n", "", 0)
+                    else -> null
+                }
+            },
+        )
+
+        val result = bootstrapper.installServerSetup(session)
+
+        assertEquals(InstallResult.Success, result)
+        assertTrue(
+            "installServerSetup must run `pocketshell hooks install --engine all`",
+            session.recorded.any { it.contains("hooks install --engine all") },
+        )
+    }
+
+    @Test
+    fun installServerSetup_stillSucceeds_whenHooksInstallFails() = runTest {
+        // Best-effort: a hooks-install failure must NOT fail the whole setup —
+        // tmux + CLI are already usable. The readiness surface will just show
+        // notifications off.
+        val session = FakeSshSession(
+            dynamic = { command ->
+                when {
+                    command == pathAware("'/home/u/.local/bin/pocketshell' hooks install --engine all") ->
+                        ExecResult("", "permission denied", 1)
+                    command == pathAware("'/home/u/.local/bin/pocketshell' hooks status --json") ->
+                        ExecResult(hooksStatusJson(claude = false), "", 0)
+                    command == pathAware("command -v 'pocketshell'") -> ExecResult("/home/u/.local/bin/pocketshell\n", "", 0)
+                    command == pathAware("command -v 'uv'") -> ExecResult("/home/u/.local/bin/uv\n", "", 0)
+                    command == pathAware("command -v 'systemctl'") -> ExecResult("/usr/bin/systemctl\n", "", 0)
+                    command == systemdAware("systemctl --user is-active pocketshell-jobs.service") -> ExecResult("active\n", "", 0)
+                    command == systemdAware("systemctl --user is-enabled pocketshell-jobs.service") -> ExecResult("enabled\n", "", 0)
+                    else -> null
+                }
+            },
+        )
+
+        val result = bootstrapper.installServerSetup(session)
+
+        assertEquals(InstallResult.Success, result)
+        assertTrue(session.recorded.any { it.contains("hooks install --engine all") })
+    }
+
+    @Test
+    fun installHooks_runsInstallForAllEngines() = runTest {
+        val session = FakeSshSession(
+            mapOf(
+                pathAware("'/home/u/.local/bin/pocketshell' hooks install --engine all")
+                    to ExecResult("claude: installed\n", "", 0),
+            ),
+        )
+
+        val result = bootstrapper.installHooks(session, "/home/u/.local/bin/pocketshell", DEFAULT_BOOTSTRAP_PATH)
+
+        assertEquals(InstallResult.Success, result)
+        assertTrue(session.recorded.any { it.contains("hooks install --engine all") })
+    }
+
+    @Test
+    fun parseHooksStatus_classifiesInstalledNotInstalledAndUnknown() {
+        assertEquals(HooksStatus.Installed, bootstrapper.parseHooksStatus(hooksStatusJson()))
+        assertEquals(HooksStatus.NotInstalled, bootstrapper.parseHooksStatus(hooksStatusJson(codex = false)))
+        assertTrue(bootstrapper.parseHooksStatus("not json at all") is HooksStatus.Unknown)
+        assertTrue(bootstrapper.parseHooksStatus("") is HooksStatus.Unknown)
+    }
+
+    @Test
+    fun notificationsStatusText_reflectsReadiness() {
+        assertTrue(hostBootstrapNotificationsStatusText(true).startsWith("Notifications: on"))
+        assertTrue(hostBootstrapNotificationsStatusText(false).startsWith("Notifications: off"))
+    }
+
     @Test
     fun checkServerSetup_usesUserLocalPathForToolDetection() = runTest {
         val session = FakeSshSession(

--- a/app/src/test/java/com/pocketshell/app/hosts/HostListViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/hosts/HostListViewModelTest.kt
@@ -1009,6 +1009,78 @@ class HostListViewModelTest {
     }
 
     @Test
+    fun bootstrapHost_divertsToSetupSheet_whenReadyButNotificationsOff() = runTest {
+        // Issue #1236 (D26): a host with the CLI + tmux ready but the agent
+        // stop/idle notification hooks OFF is a SILENT host under D21. Instead
+        // of navigating past it, bootstrap must surface the one-tap "enable
+        // notifications" upgrade (the AC4 upgrade path). notificationsActionable
+        // is true only when the CLI is compatible AND hooks are DEFINITIVELY
+        // off, so this must NOT navigate.
+        val keyId = db.sshKeyDao().insert(SshKeyEntity(name = "k", privateKeyPath = "/tmp/k"))
+        val hostId = db.hostDao().insert(
+            HostEntity(name = "silent-host", hostname = "h.example", username = "u", keyId = keyId),
+        )
+        val host = db.hostDao().getById(hostId)!!
+        val viewModel = newViewModel(
+            sessionOpener = HostSessionOpener { _, _, _ ->
+                FakeBootstrapSession(hooksInstalled = false)
+            },
+        )
+
+        viewModel.bootstrapHost(host, keyPath = "/tmp/k").join()
+
+        val state = viewModel.bootstrapState.value
+        assertTrue(
+            "ready-but-silent host must show the setup sheet, got $state",
+            state is HostBootstrapSheetState.Prompt,
+        )
+        val prompt = state as HostBootstrapSheetState.Prompt
+        assertEquals(true, prompt.report?.notificationsActionable)
+        assertEquals(false, viewModel.pendingNavigation.value!!.ready)
+    }
+
+    @Test
+    fun bootstrapHost_navigates_whenReadyAndHooksUnknown() = runTest {
+        // A CLI without the `hooks` subcommand (old CLI) reads as Unknown. We
+        // must NEVER pester on Unknown — the host navigates normally.
+        val keyId = db.sshKeyDao().insert(SshKeyEntity(name = "k", privateKeyPath = "/tmp/k"))
+        val hostId = db.hostDao().insert(
+            HostEntity(name = "unknown-hooks", hostname = "h.example", username = "u", keyId = keyId),
+        )
+        val host = db.hostDao().getById(hostId)!!
+        val viewModel = newViewModel(
+            sessionOpener = HostSessionOpener { _, _, _ ->
+                FakeBootstrapSession(hooksInstalled = null)
+            },
+        )
+
+        viewModel.bootstrapHost(host, keyPath = "/tmp/k").join()
+
+        assertEquals(true, viewModel.pendingNavigation.value!!.ready)
+        assertNull(viewModel.bootstrapState.value)
+    }
+
+    @Test
+    fun bootstrapHost_navigates_whenReadyAndNotificationsOn() = runTest {
+        // Hooks installed → notifications on → navigate normally, no nudge.
+        val keyId = db.sshKeyDao().insert(SshKeyEntity(name = "k", privateKeyPath = "/tmp/k"))
+        val hostId = db.hostDao().insert(
+            HostEntity(name = "notifying-host", hostname = "h.example", username = "u", keyId = keyId),
+        )
+        val host = db.hostDao().getById(hostId)!!
+        val viewModel = newViewModel(
+            sessionOpener = HostSessionOpener { _, _, _ ->
+                FakeBootstrapSession(hooksInstalled = true)
+            },
+        )
+
+        viewModel.bootstrapHost(host, keyPath = "/tmp/k").join()
+
+        assertEquals(true, viewModel.pendingNavigation.value!!.ready)
+        assertNull(viewModel.bootstrapState.value)
+    }
+
+    @Test
     fun installBootstrapTool_surfacesNoChangeMessage_whenUpgradeExitsZeroButVersionUnchanged() = runTest {
         // Issue #779: the user taps "Update" on the outdated-CLI row. The
         // host's `uv tool install --upgrade …` exits 0 but installs nothing
@@ -2599,6 +2671,10 @@ class HostListViewModelTest {
         // no-op upgrade (the exclude-newer-style "Nothing to upgrade" dead
         // end). Lets a test drive the "update ran but did nothing" branch.
         private val upgradeIsNoOp: Boolean = false,
+        // Issue #1236: model the D26 notification hooks state. `null` = the CLI
+        // does not support the `hooks` subcommand (exit non-zero → the app
+        // reads HooksStatus.Unknown); `true`/`false` = a real `hooks status`.
+        private val hooksInstalled: Boolean? = null,
     ) : SshSession {
         val recorded = mutableListOf<String>()
         var closeCount: Int = 0
@@ -2631,6 +2707,24 @@ class HostListViewModelTest {
                 // `pocketshell`.
                 upgradeIsNoOp && command.contains("tool install") && command.contains("--upgrade") ->
                     ExecResult("Nothing to upgrade\n", "", 0)
+                // Issue #1236: model `pocketshell hooks status/install`. Match
+                // BEFORE the generic `command -v pocketshell` / `--version`
+                // rules since the hooks command line also mentions pocketshell.
+                command.contains("hooks status --json") ->
+                    if (hooksInstalled == null) {
+                        ExecResult("", "no such command 'hooks'", 2)
+                    } else {
+                        ExecResult(
+                            "{\"engines\":[" +
+                                "{\"engine\":\"claude\",\"installed\":$hooksInstalled}," +
+                                "{\"engine\":\"codex\",\"installed\":$hooksInstalled}," +
+                                "{\"engine\":\"opencode\",\"installed\":$hooksInstalled}]}",
+                            "",
+                            0,
+                        )
+                    }
+                command.contains("hooks install --engine all") ->
+                    ExecResult("claude: installed\n", "", 0)
                 command.contains("command -v") && command.contains("pocketshell") ->
                     ExecResult("/home/u/.local/bin/pocketshell\n", "", 0)
                 command.contains("pocketshell") && command.contains("--version") ->

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -1512,6 +1512,18 @@ JOURNEY_CLASSES=(
   # its fully-qualified name directly (not under the proof prefix).
   "com.pocketshell.app.bootstrap.HostReadyPrimaryActionTest"
 
+  # ADDED (#1236, D26 / D32 G9): per-host notification readiness + the "enable
+  # notifications" upgrade affordance on the REAL HostBootstrapSheet. A host
+  # with the CLI but no D26 stop/idle hooks is a SILENT host under D21 (server
+  # push is the only "agent needs input" path); this HARD-asserts the actionable
+  # "Agent notifications · Off · Enable" row fires the enable path and that the
+  # success sheet surfaces "Notifications: on/off". PURE Compose
+  # (createComposeRule, no Docker / SSH / tmux / port — runs on the already-booted
+  # AVD), no self-skip. Carries its fully-qualified name directly. The live
+  # Docker non-destructive-merge journey is HostBootstrapScenarioSuiteTest
+  # #notifications (nightly-extensive bootstrap matrix).
+  "com.pocketshell.app.bootstrap.HostNotificationsReadinessTest"
+
   # ===========================================================================
   # Issue #933 (#928 D9 — detection net). Kept in its OWN block to minimize
   # merge friction with the sibling #931 edits to this file.

--- a/scripts/nightly-extensive-suite.sh
+++ b/scripts/nightly-extensive-suite.sh
@@ -156,6 +156,11 @@ BOOTSTRAP_METHODS=(
   "ready"
   "uvInstall"
   "appUpdateRequired"
+  # Issue #1236 (D26): the silent-host notifications journey — CLI + tmux ready
+  # but the agent stop/idle hooks off; asserts the one-tap enable folds in a
+  # NON-DESTRUCTIVE `pocketshell hooks install` (pre-existing foreign hook
+  # survives). Needs the bootstrap-notifications:2241 fixture (brought up below).
+  "notifications"
 )
 BOOTSTRAP_CLASS_ARG="$(printf "%s\n" "${BOOTSTRAP_METHODS[@]}" \
   | sed "s|^|$BOOTSTRAP_TEST_CLASS#|" | paste -sd, -)"

--- a/tests/docker/Dockerfile.bootstrap
+++ b/tests/docker/Dockerfile.bootstrap
@@ -5,7 +5,7 @@ ARG INSTALL_FISH=false
 ARG LOGIN_SHELL=/bin/sh
 ENV POCKETSHELL_BOOTSTRAP_SCENARIO=${SCENARIO}
 
-RUN packages="openssh-server openssh-client tmux procps" \
+RUN packages="openssh-server openssh-client tmux procps python3" \
     && if [ "$INSTALL_FISH" = "true" ]; then packages="$packages fish"; fi \
     && apk add --no-cache $packages \
     && ssh-keygen -A \

--- a/tests/docker/bootstrap-bin/pocketshell
+++ b/tests/docker/bootstrap-bin/pocketshell
@@ -32,5 +32,77 @@ if [ "${1:-}" = "jobs" ] && [ "${2:-}" = "list" ]; then
   exit 0
 fi
 
-printf 'pocketshell bootstrap fixture supports --version, jobs daemon, and jobs list\n' >&2
+# Issue #1236 (D26): agent stop/idle notification hooks. Gated behind a marker
+# file so ONLY the dedicated "notifications" scenario reports a real hooks
+# state; every other bootstrap scenario keeps the old behaviour (`hooks` exits
+# 64 → the app reads HooksStatus.Unknown → navigates unchanged, no nudge).
+hooks_enable_marker="${HOME}/.pocketshell-fixture-hooks-enabled"
+hooks_installed_marker="${HOME}/.cache/pocketshell/hooks/.installed"
+claude_settings="${HOME}/.claude/settings.json"
+our_hook_cmd="python3 ${HOME}/.cache/pocketshell/hooks/claude_stop.py"
+
+if [ "${1:-}" = "hooks" ]; then
+  if [ ! -f "$hooks_enable_marker" ]; then
+    printf 'pocketshell bootstrap fixture: hooks not supported in this scenario\n' >&2
+    exit 64
+  fi
+
+  if [ "${2:-}" = "install" ]; then
+    mkdir -p "${HOME}/.cache/pocketshell/hooks" "${HOME}/.claude"
+    : > "${HOME}/.cache/pocketshell/hooks/claude_stop.py"
+    # NON-DESTRUCTIVE merge into ~/.claude/settings.json (D26): add our
+    # Stop/SubagentStop/Notification command group only when absent, preserving
+    # every other key and any pre-existing hook the user already has.
+    python3 - "$claude_settings" "$our_hook_cmd" <<'PY'
+import json, sys
+path, cmd = sys.argv[1], sys.argv[2]
+try:
+    with open(path) as f:
+        data = json.load(f)
+    if not isinstance(data, dict):
+        data = {}
+except Exception:
+    data = {}
+hooks = data.setdefault("hooks", {})
+group = {"hooks": [{"type": "command", "command": cmd}]}
+for event in ("Stop", "SubagentStop", "Notification"):
+    lst = hooks.setdefault(event, [])
+    if not any(
+        any(h.get("command") == cmd for h in g.get("hooks", []) if isinstance(h, dict))
+        for g in lst if isinstance(g, dict)
+    ):
+        lst.append(group)
+with open(path, "w") as f:
+    json.dump(data, f, indent=2)
+PY
+    mkdir -p "$(dirname "$hooks_installed_marker")"
+    : > "$hooks_installed_marker"
+    printf 'claude: installed\ncodex: installed\nopencode: installed\n'
+    exit 0
+  fi
+
+  if [ "${2:-}" = "status" ]; then
+    if [ -f "$hooks_installed_marker" ]; then
+      installed=true
+    else
+      installed=false
+    fi
+    # Match `pocketshell hooks status --json` shape (see hooks.py).
+    printf '{\n'
+    printf '  "bus_path": "%s/.cache/pocketshell/hooks/events.jsonl",\n' "$HOME"
+    printf '  "engines": [\n'
+    printf '    {"engine": "claude", "installed": %s},\n' "$installed"
+    printf '    {"engine": "codex", "installed": %s},\n' "$installed"
+    printf '    {"engine": "opencode", "installed": %s}\n' "$installed"
+    printf '  ],\n'
+    printf '  "recent_events": []\n'
+    printf '}\n'
+    exit 0
+  fi
+
+  printf 'pocketshell bootstrap fixture hooks supports install and status\n' >&2
+  exit 64
+fi
+
+printf 'pocketshell bootstrap fixture supports --version, jobs daemon, jobs list, and hooks\n' >&2
 exit 64

--- a/tests/docker/bootstrap-entrypoint.sh
+++ b/tests/docker/bootstrap-entrypoint.sh
@@ -61,6 +61,35 @@ case "$scenario" in
     install_tool systemctl /usr/local/bin
     write_daemon_state active enabled
     ;;
+  notifications)
+    # Issue #1236 (D26): a host with the CLI + tmux ready but the agent
+    # stop/idle notification hooks NOT installed — a SILENT host. Enable the
+    # fixture's real `hooks` support (marker) and seed a PRE-EXISTING foreign
+    # Claude hook so the bootstrap install can be asserted to MERGE
+    # non-destructively (the pre-existing hook must survive).
+    for tool in pocketshell systemctl; do
+      install_tool "$tool" /usr/local/bin
+    done
+    write_daemon_state active enabled
+    install -d -o testuser -g testuser /home/testuser/.claude
+    cat > /home/testuser/.claude/settings.json <<'JSON'
+{
+  "model": "sonnet",
+  "hooks": {
+    "Stop": [
+      { "hooks": [ { "type": "command", "command": "my-preexisting-stop-hook" } ] }
+    ]
+  }
+}
+JSON
+    chown testuser:testuser /home/testuser/.claude/settings.json
+    # Enable the fixture's real hooks behaviour for THIS scenario only.
+    touch /home/testuser/.pocketshell-fixture-hooks-enabled
+    chown testuser:testuser /home/testuser/.pocketshell-fixture-hooks-enabled
+    # Ensure hooks start UNINSTALLED so the app surfaces the "enable
+    # notifications" nudge before the install.
+    rm -rf /home/testuser/.cache/pocketshell/hooks/.installed
+    ;;
   *)
     printf 'unknown PocketShell bootstrap scenario: %s\n' "$scenario" >&2
     exit 64

--- a/tests/docker/docker-compose.yml
+++ b/tests/docker/docker-compose.yml
@@ -239,6 +239,23 @@ services:
       - "2235:22"
     healthcheck: *ssh-healthcheck
 
+  # Issue #1236 (D26): a host with tmux + the pocketshell CLI ready but the
+  # agent stop/idle notification hooks NOT installed — a SILENT host under D21.
+  # Seeds a pre-existing foreign Claude hook so the bootstrap `hooks install`
+  # can be asserted to MERGE non-destructively. Bound on host port 2241
+  # (distinct from the other bootstrap variants 2230-2236, old-cli 2238,
+  # daemon 2239, real-agent 2240).
+  bootstrap-notifications:
+    build:
+      context: .
+      dockerfile: Dockerfile.bootstrap
+      args:
+        SCENARIO: notifications
+    image: pocketshell-test:bootstrap-notifications
+    ports:
+      - "2241:22"
+    healthcheck: *ssh-healthcheck
+
   # Issue #145: deterministic mid-session disconnect fixture. Every
   # accepted interactive SSH session (TmuxClient shell channel) is
   # wrapped in a ForceCommand watcher that kills the SSH child after


### PR DESCRIPTION
Closes #1236

Installs the agent stop/idle notification hooks (D26) in the SAME one-tap step as the pocketshell CLI install (best-effort, never fails setup), and surfaces per-host "Notifications: on/off" + an "Enable" affordance so a silently non-notifying host is visible (D21 — server-side push is the only path). `Unknown` (old CLI without the subcommand) is never actionable, so existing bootstrap fixtures are unaffected.

**Verification (reviewer APPROVED):** JVM `HostBootstrapperTest` 67/0 + `HostListViewModelTest` 66/0 (10 new cases run, G3); reviewer-driven G1 red→green on the divert logic; **Docker non-destructive merge over real SSH** (`bootstrap-notifications:2241`): a pre-existing FOREIGN Claude Stop hook SURVIVED, ours installed, readiness flipped false→true, idempotent re-run (G2 class case). CI-compat: fixture-dependent journey runs in nightly-extensive (which brings up `bootstrap-notifications`); per-push adds only pure-Compose tests — no post-merge red-CI risk. On-device readiness screenshot deferred to nightly. Reviewer: https://github.com/alexeygrigorev/pocketshell/issues/1236#issuecomment-4912254565