### PR TITLE
test: fix API-35-ungated FGS journeys to match current #1159/#1202 behavior (#1345)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/BoundedGraceSessionHoldJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/BoundedGraceSessionHoldJourneyE2eTest.kt
@@ -42,6 +42,7 @@ import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -139,7 +140,11 @@ class BoundedGraceSessionHoldJourneyE2eTest {
         waitForVisibleTerminal("initial attach") { it.contains(READY_MARKER) }
         waitForConnected("initial attach")
         waitForClientCountAtLeast(1, "initial attach")
-        waitForSessionNotification("initial attach")
+        // Issue #1159 Part 1: the session FGS runs ONLY while backgrounded — in the
+        // FOREGROUND the Activity itself holds the connection, so NO "Session connected"
+        // notification (and no Stop-action footgun) is posted at attach. The real FGS
+        // notification coverage is asserted below in PHASE 1, once backgrounded.
+        awaitNoSessionNotification("initial attach (foreground)")
         recordTiming("attach_ms", SystemClock.elapsedRealtime() - attachStart)
         captureViewport("issue1123-01-attached")
 
@@ -166,7 +171,10 @@ class BoundedGraceSessionHoldJourneyE2eTest {
         watchNoVisibleReconnect("within-grace settle", WATCH_NO_RECONNECT_MS)
         waitForVisibleTerminal("within-grace marker") { it.contains(READY_MARKER) }
         waitForClientCountAtLeast(1, "within-grace after foreground")
-        assertSessionNotificationOngoing("within-grace after foreground")
+        // Issue #1159 Part 1: returning to the FOREGROUND stops the FGS — the Activity holds
+        // the connection again, so the "Session connected" notification must CLEAR (no lingering
+        // tray control whose Stop could kill the live foreground connection).
+        awaitNoSessionNotification("within-grace after foreground")
         captureViewport("issue1123-02-within-grace")
 
         val tmuxConnectBeforeBeyondGrace = TMUX_CONNECT_ATTEMPTS.get()
@@ -469,10 +477,22 @@ class BoundedGraceSessionHoldJourneyE2eTest {
         }
     }
 
-    private fun waitForSessionNotification(label: String) {
-        val posted = pollForSessionNotification(timeoutMs = NOTIFICATION_TIMEOUT_MS)
-        assertNotNull("session foreground notification must be posted for $label", posted)
-        assertSessionNotificationOngoing(label)
+    /**
+     * Issue #1159 Part 1: the session FGS + its "Session connected" notification exist ONLY
+     * while the app is BACKGROUNDED. This asserts the notification is ABSENT in a foreground
+     * state (initial attach, and after a within-grace foreground return), polling briefly so
+     * an async foreground-stop has time to clear a previously-posted notification.
+     */
+    private fun awaitNoSessionNotification(label: String) {
+        val deadline = SystemClock.elapsedRealtime() + NOTIFICATION_TIMEOUT_MS
+        while (sessionNotification() != null && SystemClock.elapsedRealtime() < deadline) {
+            SystemClock.sleep(100)
+        }
+        assertNull(
+            "no session foreground notification must be posted in the foreground for $label " +
+                "(#1159 Part 1: the Activity holds the connection; the FGS runs only backgrounded)",
+            sessionNotification(),
+        )
     }
 
     private fun assertSessionNotificationOngoing(label: String) {
@@ -535,16 +555,6 @@ class BoundedGraceSessionHoldJourneyE2eTest {
             null,
             sessionNotification(),
         )
-    }
-
-    private fun pollForSessionNotification(timeoutMs: Long): android.service.notification.StatusBarNotification? {
-        val deadline = SystemClock.elapsedRealtime() + timeoutMs
-        var posted = sessionNotification()
-        while (posted == null && SystemClock.elapsedRealtime() < deadline) {
-            SystemClock.sleep(100)
-            posted = sessionNotification()
-        }
-        return posted
     }
 
     private fun sessionNotification() =

--- a/app/src/androidTest/java/com/pocketshell/app/proof/NotificationTapLivePinnedForegroundReseedJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/NotificationTapLivePinnedForegroundReseedJourneyE2eTest.kt
@@ -40,6 +40,7 @@ import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -84,8 +85,10 @@ import java.io.FileOutputStream
  *    viewport goes (near-)black — exactly the maintainer's screenshot. The REMOTE tmux grid is
  *    never touched, so a fresh `capture-pane` still holds the full banner.
  *  - Background PAST a short injected grace (the pin holds — assert `background_grace_held_by_
- *    port_forward` fired and NO `terminal_background_teardown`), then deliver the REAL session
- *    notification `contentIntent` (`SINGLE_TOP|CLEAR_TOP`, no extra) and foreground.
+ *    port_forward` fired and NO `terminal_background_teardown`). While pinned the SESSION FGS is
+ *    SUPPRESSED (#1159 Part 3 / #1202: the ForwardingService FGS is the single tray owner), so we
+ *    assert the "Session connected" notification is absent and the "Port forwarding running"
+ *    notification is the posted tray control, then foreground back onto the terminal.
  *
  * ## Why the LOAD-BEARING assertion is the capture-pane round-trip (recompose-immune)
  *
@@ -227,18 +230,33 @@ class NotificationTapLivePinnedForegroundReseedJourneyE2eTest {
             0,
             diagnostics!!.eventsNamed("terminal_background_teardown").size,
         )
-        // The FGS session notification is held while backgrounded+pinned — the tappable target.
-        val notification = pollForSessionNotification(NOTIFICATION_TIMEOUT_MS)
-        assertNotNull("$namePrefix session foreground notification must be posted while pinned", notification)
+        // Issue #1159 Part 3 / #1202 (hard-cut, D22): while a port-forward PINS the connection
+        // the SESSION FGS is SUPPRESSED — the ForwardingService FGS is the SINGLE owner of the
+        // tray notification (its Stop actually tears down the tunnels). So the "Session connected"
+        // notification must be ABSENT while pinned, and the "Port forwarding running" notification
+        // is the real tappable target that foregrounds the app (its contentIntent opens MainActivity).
+        assertNull(
+            "$namePrefix the session FGS notification must be SUPPRESSED while a port-forward pins " +
+                "the connection (#1159 Part 3 / #1202); the ForwardingService FGS owns the tray",
+            sessionNotification(),
+        )
+        val notification = pollForNotification("Port forwarding running", NOTIFICATION_TIMEOUT_MS)
+        assertNotNull(
+            "$namePrefix the ForwardingService notification (the tappable target while pinned) " +
+                "must be posted",
+            notification,
+        )
 
         // ============================================================
-        // Deliver the REAL notification contentIntent, then foreground.
+        // Foreground the app back onto the live terminal, then resume.
         // ============================================================
         val capturesBeforeResume = capturePaneCount(activePaneId)
-        // Fire the actual `SINGLE_TOP|CLEAR_TOP` no-extra content intent (the real tap path →
-        // onNewIntent) if present; the ProcessLifecycle ON_START below is what drives
-        // onAppForegrounded(false) either way.
-        runCatching { notification?.notification?.contentIntent?.send() }
+        // The maintainer's #1181 return path is back onto the TERMINAL (recents / app-switch)
+        // of the still-live pinned connection. We do NOT fire the pinned "Port forwarding
+        // running" notification's contentIntent — it carries EXTRA_OPEN_PORT_FORWARDING and
+        // routes to the port-forward chooser, not the terminal. The ProcessLifecycle ON_START
+        // driven by moveToState(RESUMED) is what fires onAppForegrounded(false) — the exact
+        // live-no-pending foreground-resume branch that must reseed the black pane.
         compose.activityRule.scenario.moveToState(Lifecycle.State.RESUMED)
         waitForDiagnostic("background_grace_foreground", "$namePrefix foreground") {
             it.fields["withinGrace"] == false
@@ -589,19 +607,24 @@ class NotificationTapLivePinnedForegroundReseedJourneyE2eTest {
         error("timed out waiting for diagnostic '$name' during $label; events=${diagnostics!!.events}")
     }
 
-    private fun pollForSessionNotification(timeoutMs: Long): android.service.notification.StatusBarNotification? {
+    private fun pollForNotification(
+        title: String,
+        timeoutMs: Long,
+    ): android.service.notification.StatusBarNotification? {
         val deadline = SystemClock.elapsedRealtime() + timeoutMs
-        var posted = sessionNotification()
+        var posted = notificationWithTitle(title)
         while (posted == null && SystemClock.elapsedRealtime() < deadline) {
             SystemClock.sleep(100)
-            posted = sessionNotification()
+            posted = notificationWithTitle(title)
         }
         return posted
     }
 
-    private fun sessionNotification() =
+    private fun sessionNotification() = notificationWithTitle("Session connected")
+
+    private fun notificationWithTitle(title: String) =
         notificationManager.activeNotifications.firstOrNull {
-            it.notification.extras.getCharSequence("android.title")?.toString() == "Session connected"
+            it.notification.extras.getCharSequence("android.title")?.toString() == title
         }
 
     private fun readFixtureKey(): String =


### PR DESCRIPTION
Closes #1345 — v0.4.25 release-blocker (test-only; NOT a device bug).

The #1217 API-35 bump un-gated two FGS-notification journeys that were SDK-gated dead on API 34, so they ran for the first time and hit **stale** assertions from before #1159/#1202. Reviewer independently confirmed from `SessionServiceController:132` (`shouldHold = ... && !foreground && !pfActive`) that `startForeground` is never called in the failing states — session FGS only holds while backgrounded, and is suppressed when a port-forward pins the tray. So the old positive assertions were stale-by-design, **not** a masked Android-15 product bug.

**Fix:** test-only — replace stale positive assertions with correct absence/ownership assertions; the load-bearing backgrounded FGS-posts (test 1) + capture-pane black-reseed (test 2) coverage is preserved and now *reachable* (non-masking, D33/G6 — a real API-35 backgrounded-FGS regression would still fail). Reviewer APPROVED: https://github.com/alexeygrigorev/pocketshell/issues/1345#issuecomment-4912436409

**Tag gate:** the two journeys going GREEN on CI's batched API-35 emulator lane is required before the v0.4.25 tag.