### PR TITLE
test: fix has-session fixture modeling so version-mismatch hint is reached (#759)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/projects/AgentLaunchVersionMismatchHintE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/AgentLaunchVersionMismatchHintE2eTest.kt
@@ -76,6 +76,16 @@ class AgentLaunchVersionMismatchHintE2eTest {
         )
         // The raw Click jargon must NOT leak to the user.
         assertFalse("raw Click error must not leak: $hint", hint.contains("No such command"))
+        // Regression (chronic emulator red): the #976 launch-collision guard
+        // (`tmux has-session`) runs BEFORE the version pre-flight. For a
+        // fresh-name launch the session is ABSENT, so the guard must NOT fire
+        // and must NOT short-circuit the version hint with its "already open"
+        // collision message. This is exactly the failure that kept this E2E red
+        // for days (the fake reported a never-created session as already open).
+        assertFalse(
+            "launch-collision guard must not short-circuit the version pre-flight: $hint",
+            hint.contains("already open"),
+        )
         // The doomed agent line must NOT be typed into the pane.
         assertFalse(
             "must not send-keys a launch that will fail: ${session.execCommands}",

--- a/app/src/androidTest/java/com/pocketshell/app/proof/FakeOldHostSshSession.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/FakeOldHostSshSession.kt
@@ -65,6 +65,13 @@ class FakeOldHostSshSession(
     private val connectRpcMode: OldHostConnectRpcMode = OldHostConnectRpcMode.UNKNOWN_COMMAND,
     private val hangDelayMs: Long = DEFAULT_HANG_DELAY_MS,
     private val slowDelayMs: Long = DEFAULT_SLOW_DELAY_MS,
+    /**
+     * Session names this host reports as already open (`tmux has-session`
+     * exits 0). Empty by default — a not-yet-created launch target is absent,
+     * so the #976 launch-collision guard does NOT fire and the launch reaches
+     * the #759 version pre-flight. Populate it to model a real name collision.
+     */
+    private val openSessions: Set<String> = emptySet(),
 ) : SshSession {
 
     /** Every command the session was asked to `exec`, in order. */
@@ -107,6 +114,27 @@ class FakeOldHostSshSession(
                 OldHostConnectRpcMode.UNKNOWN_COMMAND ->
                     return unknownCommandResult(connectRpcName)
             }
+        }
+
+        // Issue #759 (chronic emulator red): the launch path's #976
+        // routing-safety guard probes `tmux has-session -t '<name>'` BEFORE the
+        // version pre-flight and REFUSES the launch (with the "already open"
+        // collision message) when the target session already exists. This fake
+        // never actually creates a session, so a not-yet-created target is
+        // ABSENT — it MUST report the tmux "can't find session" non-zero exit,
+        // exactly like a real host launching an agent into a fresh directory.
+        // The old catch-all returned exit 0 here, which the collision guard read
+        // as a FALSE "already open" and short-circuited the version-mismatch
+        // pre-flight this old-host seam exists to exercise — the root cause of
+        // the chronic-red `AgentLaunchVersionMismatchHintE2eTest`. A session
+        // named in [openSessions] does exist (for future collision proofs).
+        if (command.contains("tmux has-session")) {
+            val exists = openSessions.any { command.contains("-t '$it'") || command.contains("-t $it") }
+            return ExecResult(
+                stdout = "",
+                stderr = if (exists) "" else "can't find session",
+                exitCode = if (exists) 0 else 1,
+            )
         }
 
         return when {

--- a/app/src/test/java/com/pocketshell/app/projects/FolderListGatewayFallbackTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/FolderListGatewayFallbackTest.kt
@@ -342,6 +342,77 @@ class FolderListGatewayFallbackTest {
     }
 
     @Test
+    fun freshNameAgentLaunchOnOutdatedHostReachesVersionHintNotCollisionGuard() = runTest {
+        // Regression lock for the chronic-red #759 emulator journey. The #976
+        // launch-collision guard probes `tmux has-session` and REFUSES the
+        // launch when the target already exists — and it runs BEFORE the #759
+        // version pre-flight. For a FRESH target name the session is ABSENT
+        // (has-session exits non-zero), so the guard must NOT fire and the
+        // launch MUST reach the version-mismatch pre-flight and surface the
+        // update hint — NOT the "already open" collision message.
+        //
+        // The on-device fake (FakeOldHostSshSession) had regressed to answer
+        // has-session with exit 0 (a never-created session reported as already
+        // open), which short-circuited the version hint and kept
+        // AgentLaunchVersionMismatchHintE2eTest red for days. This per-push JVM
+        // test locks the coexistence so the ordering can't silently rot again.
+        val session = CreateSessionFake(
+            results = listOf(
+                // Fresh name → has-session reports the session absent.
+                CreateSessionFake.Rule(
+                    match = "has-session",
+                    result = ExecResult(stdout = "", stderr = "can't find session", exitCode = 1),
+                ),
+                CreateSessionFake.Rule(match = "create-detached", result = ok()),
+                CreateSessionFake.Rule(
+                    match = "pocketshell agent --help",
+                    result = ExecResult(
+                        stdout = "",
+                        stderr = "Error: No such command 'agent'. " +
+                            "(Did you mean one of: 'agent-log', 'usage'?)",
+                        exitCode = 2,
+                    ),
+                ),
+                CreateSessionFake.Rule(
+                    match = "pocketshell --version",
+                    result = ExecResult(stdout = "pocketshell, version 0.3.33", stderr = "", exitCode = 0),
+                ),
+                CreateSessionFake.Rule(match = "send-keys", result = ok()),
+            ),
+        )
+        val gateway = SshFolderListGateway()
+
+        val ex = runCatching {
+            gateway.createSessionOnSession(
+                session = session,
+                sessionName = SESSION_NAME,
+                cwd = CWD,
+                startCommand = "pocketshell agent claude --dir '/home/me/proj dir'",
+            )
+        }.exceptionOrNull()
+
+        assertTrue("expected a surfaced RuntimeException, got $ex", ex is RuntimeException)
+        val message = ex?.message.orEmpty()
+        // Reached the version pre-flight: the hint names the installed version.
+        assertTrue("must reach the version hint (installed version): $message", message.contains("0.3.33"))
+        // The collision guard must NOT have short-circuited the launch.
+        assertFalse(
+            "collision guard must not short-circuit the version pre-flight: $message",
+            message.contains("already open"),
+        )
+        // The pre-flight probe genuinely ran (this is what caught the mismatch).
+        assertTrue(
+            "must have pre-flighted `pocketshell agent --help`: ${session.execCommands}",
+            session.execCommands.any { it.contains("pocketshell agent --help") },
+        )
+        // A doomed launch must never leak keystrokes.
+        assertFalse(
+            "must not send-keys a launch that will fail",
+            session.execCommands.any { it.contains("send-keys") },
+        )
+    }
+
+    @Test
     fun outdatedHostHintStaysGenericWhenVersionProbeFails() = runTest {
         // The `--help` probe shows the mismatch but the version probe itself
         // errors out: the hint still fires, just with generic "too old"


### PR DESCRIPTION
Closes #759 — REOPENED v0.4.25 release-blocker (test-only; no production change).

Chronic emulator-gate red on `AgentLaunchVersionMismatchHintE2eTest`. Root cause: `FakeOldHostSshSession.exec` returned exit 0 for `tmux has-session -t 'issue759-outdated'`, so the #976 launch-collision guard (runs BEFORE the #759 version pre-flight in `FolderListGateway.createSessionOnSession`) false-tripped on a never-created session and threw the collision message before the version-hint path ran. The JVM fake defaulted absent commands to exit 1, which is why JVM stayed green while on-device went red — the two fakes disagreed on `has-session`. On a real outdated host launching into a fresh name, `has-session` exits non-zero, so the product path is correct.

**Fix (test-only):** fake now models `has-session` as non-zero for an absent session (matches real tmux); E2E also hard-asserts the collision message doesn't leak; new per-push Unit lock `freshNameAgentLaunchOnOutdatedHostReachesVersionHintNotCollisionGuard` (D31, non-vacuous).

**Verification (reviewer APPROVED, red→green driven on emulator-5554):** GREEN with fix (1 test, BUILD SUCCESSFUL); RED reproduced on base (exact chronic assertion). Reviewer confirmed the fixture-was-wrong from the real path (G6). https://github.com/alexeygrigorev/pocketshell/issues/759#issuecomment-4912484992