### PR TITLE
voice: wire undelivered-transcript retry banner into the live composer (#1272)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerUndeliveredRetryHiltWiringTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerUndeliveredRetryHiltWiringTest.kt
@@ -1,0 +1,214 @@
+package com.pocketshell.app.composer
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.isRoot
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.lifecycle.ViewModelProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.pocketshell.app.session.InlineDictationViewModel
+import com.pocketshell.app.session.UNDELIVERED_TRANSCRIPT_BANNER_TAG
+import com.pocketshell.app.session.UNDELIVERED_TRANSCRIPT_RETRY_TAG
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * Issue #1272 — the PRODUCTION-WIRING proof (the #1341 reviewer's blocking gap).
+ *
+ * The sibling [PromptComposerUndeliveredRetryTest] cases all BYPASS the guard in
+ * `rememberComposerUndeliveredBinding`:
+ *  - tests 1–2 call `SheetContent(...)` directly with the list injected;
+ *  - test 3 forces the surface via the `inlineDictationViewModel` OVERRIDE seam.
+ *
+ * So `rememberComposerUndeliveredBinding`'s REAL branch —
+ * `storeOwner is GeneratedComponentManagerHolder -> hiltViewModel(storeOwner)` —
+ * never executes there. Those prove "SheetContent renders a banner when handed a
+ * list", NOT that in the real composer the guard resolves the activity-scoped
+ * [InlineDictationViewModel] that `TmuxSessionScreen` collects.
+ *
+ * This test closes that gap. It launches the REAL `@AndroidEntryPoint`
+ * [ComposerHiltHostActivity], which mounts the PRODUCTION [PromptComposerSheet]
+ * with NO seam (`inlineDictationViewModel` left null). Because the host is a
+ * `GeneratedComponentManagerHolder`, the guard takes its REAL Hilt branch and
+ * resolves [InlineDictationViewModel] from the live app graph — the exact path
+ * the session screen uses.
+ *
+ * The test then reaches the SAME activity-scoped VM instance via
+ * `ViewModelProvider(activity)` (the composer's `hiltViewModel()` and
+ * `ViewModelProvider(activity)` share the activity's ViewModelStore + the Hilt
+ * factory, so it is literally the same object the composer resolved), drives a
+ * durable undelivered transcript into that VM's own store, and asserts:
+ *
+ *  1. The composer surfaces the persisted transcript as a VISIBLE retry row —
+ *     asserted with viewport CONTAINMENT (`assertNodeFullyWithinRoot`, not a bare
+ *     `assertIsDisplayed`, per #657/F1). This is what PROVES the guard resolved
+ *     the SAME VM the test drove: if the guard had taken the inert `null` branch
+ *     (the base/broken state), the composer would read an empty list and the
+ *     banner tag would not exist.
+ *  2. Tapping Retry re-injects the transcript into that VM's live delivery
+ *     channel; a live collector on `vm.transcriptions` receives it (re-delivered
+ *     to a live pane) and the row clears.
+ *
+ * There is no soft-IME dependency (pure Compose geometry), so there is NO
+ * `assumeTrue` / `assumeFalse(isRunningOnCi())` on the load-bearing assertions —
+ * they HARD-fail on every device, CI included.
+ *
+ * ## Driving the transcript
+ *
+ * The undelivered queue is the durable holding pen the whole #1272 feature is
+ * about: `vm.undeliveredTranscripts` is exactly `vm.undeliveredTranscriptStore.items`.
+ * Persisting into that store is precisely what the VM's own `onCleared` /
+ * channel-overflow paths do to enqueue an undeliverable transcript (see
+ * [InlineDictationViewModel.onCleared]). We drive it directly here rather than
+ * re-run the permanent-dead-pane FSM because the Hilt-resolved production VM owns
+ * a REAL microphone / Whisper client that cannot be driven to record in a test —
+ * and the dead-pane FSM itself is already proven red→green by the JVM
+ * `InlineDictationViewModelTest` and the sibling connected test. What is UNPROVEN
+ * without this test, and what this test exists to prove, is the GUARD RESOLUTION:
+ * that the live composer binds the production activity-scoped VM.
+ */
+@RunWith(AndroidJUnit4::class)
+class PromptComposerUndeliveredRetryHiltWiringTest {
+
+    @get:Rule
+    val compose = createAndroidComposeRule<ComposerHiltHostActivity>()
+
+    /**
+     * The SAME activity-scoped [InlineDictationViewModel] the composer's
+     * `hiltViewModel()` guard resolved: `ViewModelProvider(activity)` reads the
+     * activity's ViewModelStore through its Hilt default factory, under the
+     * default key (the canonical class name) — identical to `hiltViewModel()`.
+     */
+    private fun activityScopedInlineVm(): InlineDictationViewModel {
+        lateinit var vm: InlineDictationViewModel
+        compose.runOnUiThread {
+            vm = ViewModelProvider(compose.activity)[InlineDictationViewModel::class.java]
+        }
+        return vm
+    }
+
+    private fun liveCollector(
+        vm: InlineDictationViewModel,
+        sink: CopyOnWriteArrayList<String>,
+    ): Job {
+        var job: Job? = null
+        val scope = CoroutineScope(Dispatchers.Main)
+        compose.runOnUiThread {
+            job = scope.launch { vm.transcriptions.collect { sink.add(it) } }
+        }
+        compose.waitForIdle()
+        return job!!
+    }
+
+    private var vmUnderTest: InlineDictationViewModel? = null
+
+    @After
+    fun drainDurableStore() {
+        // The production VM binds the DURABLE SharedPreferences store; clear any
+        // residue so a failed run can't leak an item into a sibling test/run.
+        vmUnderTest?.let { vm ->
+            vm.undeliveredTranscriptStore.snapshot().forEach { vm.undeliveredTranscriptStore.remove(it.id) }
+        }
+    }
+
+    @Test
+    fun liveComposerResolvesActivityScopedVmViaGuardAndSurfacesRetryRowThatReDelivers() {
+        val vm = activityScopedInlineVm().also { vmUnderTest = it }
+        // Start from a clean durable store (residue from a prior aborted run).
+        vm.undeliveredTranscriptStore.snapshot().forEach { vm.undeliveredTranscriptStore.remove(it.id) }
+        compose.waitForIdle()
+
+        val delivered = CopyOnWriteArrayList<String>()
+        val collector = liveCollector(vm, delivered)
+
+        // Enqueue an undeliverable transcript into the PRODUCTION VM's own durable
+        // store — the same enqueue the VM's onCleared / channel-overflow paths do.
+        val text = "git push origin main"
+        val item = vm.undeliveredTranscriptStore.persist(text)!!
+        val id = item.id
+
+        // The LIVE composer must now surface it. If the guard had taken the inert
+        // `null` branch (the base/broken state), the composer would read an empty
+        // list and this banner tag would never appear — so a rendered, CONTAINED
+        // row proves the guard resolved the SAME activity-scoped VM we drove.
+        compose.waitUntil(TIMEOUT_MS) {
+            compose.onAllNodesWithTag(UNDELIVERED_TRANSCRIPT_BANNER_TAG)
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+        compose.onNodeWithTag(UNDELIVERED_TRANSCRIPT_BANNER_TAG).assertIsDisplayed()
+        assertNodeFullyWithinSheetWindow(UNDELIVERED_TRANSCRIPT_BANNER_TAG)
+        compose.onNodeWithText("Couldn't deliver — retry").assertIsDisplayed()
+        compose.onNodeWithText(text).assertIsDisplayed()
+        assertNodeFullyWithinSheetWindow("$UNDELIVERED_TRANSCRIPT_RETRY_TAG-$id")
+
+        // Retry must re-inject into the VM's live delivery channel and clear the row.
+        compose.onNodeWithTag("$UNDELIVERED_TRANSCRIPT_RETRY_TAG-$id").performClick()
+        compose.waitUntil(TIMEOUT_MS) { delivered.isNotEmpty() }
+        assertEquals(
+            "Retry from the live composer must re-deliver the transcript into the " +
+                "activity-scoped VM's live delivery channel (proves the composer bound " +
+                "the SAME production VM the session screen collects)",
+            listOf(text),
+            delivered.toList(),
+        )
+        compose.waitUntil(TIMEOUT_MS) { vm.undeliveredTranscriptStore.snapshot().isEmpty() }
+        compose.onNodeWithTag(UNDELIVERED_TRANSCRIPT_BANNER_TAG).assertDoesNotExist()
+        assertTrue(
+            "the durable store must be empty after a successful re-delivery",
+            vm.undeliveredTranscriptStore.snapshot().isEmpty(),
+        )
+
+        collector.cancel()
+    }
+
+    /**
+     * Viewport CONTAINMENT for the retry surface — the #657/F1 property ("the user
+     * can actually SEE + tap it", not merely `assertIsDisplayed`, which is
+     * satisfied by layout participation even off-screen).
+     *
+     * The shared [com.pocketshell.app.proof.signals.assertNodeFullyWithinRoot]
+     * helper compares against `onRoot()`, but the full production
+     * [PromptComposerSheet] opens a `ModalBottomSheet` — a SECOND full-screen
+     * window root — so `onRoot()` is ambiguous here (fails "expected exactly 1
+     * root, found 2"). This asserts the node's `boundsInRoot` sits within the
+     * on-screen WINDOW rect (the union of the full-screen roots) instead, so a row
+     * pushed off any window edge / clipped fails exactly as the shared helper
+     * would in a single-root scene. NOT a bare `assertIsDisplayed`.
+     */
+    private fun assertNodeFullyWithinSheetWindow(tag: String) {
+        val slopPx = 2f * compose.density.density
+        val bounds = compose.onNodeWithTag(tag, useUnmergedTree = true)
+            .fetchSemanticsNode().boundsInRoot
+        val roots = compose.onAllNodes(isRoot()).fetchSemanticsNodes().map { it.boundsInRoot }
+        check(roots.isNotEmpty()) { "no window roots found" }
+        val left = roots.minOf { it.left }
+        val top = roots.minOf { it.top }
+        val right = roots.maxOf { it.right }
+        val bottom = roots.maxOf { it.bottom }
+        assertTrue(
+            "Node '$tag' is not fully within the on-screen window (off-screen / " +
+                "clipped): nodeBounds=$bounds window=[l=$left,t=$top,r=$right,b=$bottom] " +
+                "slopPx=$slopPx",
+            bounds.left >= left - slopPx &&
+                bounds.top >= top - slopPx &&
+                bounds.right <= right + slopPx &&
+                bounds.bottom <= bottom + slopPx,
+        )
+    }
+
+    private companion object {
+        const val TIMEOUT_MS = 5_000L
+    }
+}

--- a/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerUndeliveredRetryTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerUndeliveredRetryTest.kt
@@ -1,0 +1,421 @@
+package com.pocketshell.app.composer
+
+import android.graphics.Bitmap
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Text
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asAndroidBitmap
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.di.WhisperClientFactory
+import com.pocketshell.app.proof.signals.assertNodeFullyWithinRoot
+import com.pocketshell.app.session.InlineDictationViewModel
+import com.pocketshell.app.session.UNDELIVERED_TRANSCRIPT_BANNER_TAG
+import com.pocketshell.app.session.UNDELIVERED_TRANSCRIPT_DISMISS_TAG
+import com.pocketshell.app.session.UNDELIVERED_TRANSCRIPT_RETRY_TAG
+import com.pocketshell.app.test.testArtifactsRoot
+import com.pocketshell.app.voice.InMemoryUndeliveredTranscriptStore
+import com.pocketshell.core.voice.SpeechAudioGuard
+import com.pocketshell.core.voice.WhisperClient
+import com.pocketshell.uikit.theme.PocketShellColors
+import com.pocketshell.uikit.theme.PocketShellTheme
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+import java.io.FileOutputStream
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * Issue #1272: the durable "couldn't deliver — retry" surface, wired into the
+ * LIVE prompt composer chrome.
+ *
+ * The data-loss slice (#1341) landed a durable [InMemoryUndeliveredTranscriptStore] /
+ * SharedPreferences store + a bounded delivery channel + the VM API
+ * ([InlineDictationViewModel.undeliveredTranscripts] / `retryUndelivered` /
+ * `dismissUndelivered`), and a JVM `InlineDictationViewModelTest` proved the
+ * permanent-dead-pane persist + cross-instance re-delivery LOGIC red→green. But
+ * that logic had NO user-visible surface: the retry banner was rendered only
+ * inside `KeyBarWithMic`, which has no production call site. The #1341 reviewer
+ * blocked closure on exactly this gap.
+ *
+ * This is the missing UI proof. It exercises the REAL production composer body
+ * ([SheetContent]) AND the full [PromptComposerSheet] (no `*StandIn` / `*Proxy`,
+ * per #657/F2) bound to a real shared [InlineDictationViewModel], and asserts the
+ * FULL loop end-to-end:
+ *
+ *  1. A transcript becomes undeliverable via the REAL permanent-dead-pane path —
+ *     dictated with NO collector ever subscribing, then the session ViewModel is
+ *     cleared (navigated-away / permanent pane death). The delivery channel
+ *     drains the still-buffered transcript into the durable store.
+ *  2. A fresh session ViewModel B shares that durable store; the composer surfaces
+ *     the persisted transcript as a VISIBLE "Couldn't deliver — retry" row —
+ *     asserted with viewport CONTAINMENT (`assertNodeFullyWithinRoot`, not a bare
+ *     `assertIsDisplayed`), the F1/F3 "actually on-screen, not clipped" property.
+ *  3. Tapping Retry re-injects the transcript into B's live delivery channel; a
+ *     live collector receives it (re-delivered to a live pane) and the row clears.
+ *  4. Tapping Dismiss on a still-dead surface (no live pane) discards the item
+ *     without re-delivery — the navigated-away / give-up path.
+ *  5. The FULL production [PromptComposerSheet] (its `ModalBottomSheet` window +
+ *     the `hiltViewModel`-sourced binding, exercised via the `inlineDictationViewModel`
+ *     override seam) surfaces the same row, proving the production wiring is
+ *     reachable — the exact half the #1341 reviewer blocked on.
+ *
+ * RED on base (before the composer wiring): [SheetContent] / [PromptComposerSheet]
+ * rendered no undelivered banner at all — [UNDELIVERED_TRANSCRIPT_BANNER_TAG] does
+ * not exist in the tree, so `assertDoesNotExist()` would pass but the containment /
+ * displayed assertions FAIL and the item is unreachable by the user. GREEN with
+ * the wiring: the row is visible, contained, and retryable.
+ *
+ * The assertions are pure Compose UI (no soft-IME dependency), so there is NO
+ * `assumeTrue` / `assumeFalse(isRunningOnCi())` on the load-bearing assertions —
+ * they HARD-fail on every device, CI included.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@RunWith(AndroidJUnit4::class)
+class PromptComposerUndeliveredRetryTest {
+
+    @get:Rule
+    val compose = createAndroidComposeRule<ComponentActivity>()
+
+    // --- Test doubles: the composer's own ViewModel (not under test here) -----
+
+    private class ComposerMic : PromptComposerViewModel.MicCapture {
+        override fun start() {}
+        override fun stop(): ByteArray = ByteArray(0)
+        override fun currentAmplitude(): Float = 0f
+    }
+
+    private class ComposerVault : PromptComposerViewModel.ApiKeyVault {
+        private var key: CharArray? = "sk-test".toCharArray()
+        override fun save(key: CharArray) { this.key = key.copyOf() }
+        override fun load(): CharArray? = key?.copyOf()
+        override fun clear() { key = null }
+    }
+
+    private class ComposerVoiceSettings : PromptComposerViewModel.VoiceSettingsSnapshot {
+        override fun silenceWindowMs(): Long = PromptComposerViewModel.SILENCE_WINDOW_MS
+        override fun whisperLanguageHint(): String? = null
+    }
+
+    private fun newComposerVm(): PromptComposerViewModel = PromptComposerViewModel(
+        audioRecorder = ComposerMic(),
+        whisperClientFactory = WhisperClientFactory {
+            object : WhisperClient {
+                override suspend fun transcribe(audio: ByteArray, language: String?): Result<String> =
+                    Result.success("")
+            }
+        },
+        apiKeyStorage = ComposerVault(),
+        voiceSettings = ComposerVoiceSettings(),
+    )
+
+    // --- Test doubles: the shared inline-dictation ViewModel (under test) -----
+
+    /**
+     * Emits a real speech-energy WAV on stop so [SpeechAudioGuard.hasSpeechEnergy]
+     * passes and the FSM reaches the transcribe + delivery-channel send step.
+     */
+    private class InlineMic : PromptComposerViewModel.MicCapture {
+        private var running = false
+        override fun start() { running = true }
+        override fun stop(): ByteArray {
+            running = false
+            return SpeechAudioGuard.speechWavForTesting()
+        }
+        override fun currentAmplitude(): Float = if (running) 0.5f else 0f
+    }
+
+    private class InlineVault : PromptComposerViewModel.ApiKeyVault {
+        private var key: CharArray? = "sk-test".toCharArray()
+        override fun save(key: CharArray) { this.key = key.copyOf() }
+        override fun load(): CharArray? = key?.copyOf()
+        override fun clear() { key = null }
+    }
+
+    private class InlineVoiceSettings : PromptComposerViewModel.VoiceSettingsSnapshot {
+        override fun silenceWindowMs(): Long = InlineDictationViewModel.SILENCE_WINDOW_MS
+        override fun whisperLanguageHint(): String? = null
+        // transcriptionProvider() defaults to OpenAiWhisper -> the Whisper FSM path.
+    }
+
+    private fun newInlineVm(
+        store: InMemoryUndeliveredTranscriptStore,
+        transcript: () -> Result<String> = { Result.success("") },
+    ): InlineDictationViewModel = InlineDictationViewModel(
+        audioRecorder = InlineMic(),
+        whisperClientFactory = WhisperClientFactory {
+            object : WhisperClient {
+                override suspend fun transcribe(audio: ByteArray, language: String?): Result<String> =
+                    transcript()
+            }
+        },
+        apiKeyStorage = InlineVault(),
+        voiceSettings = InlineVoiceSettings(),
+        undeliveredTranscriptStore = store,
+    )
+
+    /**
+     * Drives a real InlineDictationViewModel through the REAL permanent-dead-pane
+     * path: dictate to completion with NO collector ever subscribing, then clear
+     * the ViewModel (the session is permanently gone). The still-buffered
+     * transcript drains into [store]. Returns the persisted item id.
+     */
+    private fun persistViaPermanentDeadPane(
+        store: InMemoryUndeliveredTranscriptStore,
+        text: String,
+    ): String {
+        val deadVm = newInlineVm(store) { Result.success(text) }
+        // Start recording (Idle -> Recording), then stop (Recording -> Transcribing
+        // -> Idle) so Whisper resolves and the transcript is sent into the delivery
+        // channel. No collector is ever subscribed, so it stays buffered.
+        compose.runOnUiThread { deadVm.onMicTap() }
+        compose.waitUntil(TIMEOUT_MS) {
+            deadVm.uiState.value.recording == InlineDictationViewModel.RecordingState.Recording
+        }
+        compose.runOnUiThread { deadVm.onMicTap() }
+        compose.waitUntil(TIMEOUT_MS) {
+            deadVm.uiState.value.recording == InlineDictationViewModel.RecordingState.Idle
+        }
+        // Nothing persisted while the ViewModel is alive — the transcript is still
+        // deliverable if a pane were to return within this VM's lifetime.
+        assertTrue(
+            "transcript must stay buffered (not persisted) while the session VM is alive",
+            store.snapshot().isEmpty(),
+        )
+        // Permanent pane death: the session screen is gone for good.
+        compose.runOnUiThread { deadVm.clearForTest() }
+        compose.waitUntil(TIMEOUT_MS) { store.snapshot().isNotEmpty() }
+        return store.snapshot().first().id
+    }
+
+    /** Composes the REAL production composer BODY bound to [vm] (single window root
+     *  -> viewport-containment assertions are valid). */
+    private fun setSheetContent(vm: InlineDictationViewModel) {
+        compose.setContent {
+            PocketShellTheme {
+                val items by vm.undeliveredTranscripts.collectAsState()
+                SheetContent(
+                    state = PromptComposerViewModel.UiState(),
+                    onClose = {},
+                    onDraftChange = {},
+                    onMicTap = {},
+                    onSend = {},
+                    undeliveredTranscripts = items,
+                    onRetryUndelivered = vm::retryUndelivered,
+                    onDismissUndelivered = vm::dismissUndelivered,
+                )
+            }
+        }
+        compose.waitForIdle()
+    }
+
+    /** Composes the FULL production [PromptComposerSheet] (its `ModalBottomSheet`
+     *  window + the real `inlineDictationViewModel` binding). */
+    private fun setFullComposerSheet(vm: InlineDictationViewModel) {
+        val composerVm = newComposerVm()
+        compose.setContent {
+            PocketShellTheme {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(PocketShellColors.Background),
+                    contentAlignment = Alignment.TopCenter,
+                ) {
+                    Text(
+                        text = "alex@pocketshell:~$ claude\n> ready",
+                        color = PocketShellColors.Text,
+                    )
+                    PromptComposerSheet(
+                        onDismiss = {},
+                        onSend = { _ -> true },
+                        viewModel = composerVm,
+                        // Issue #1272: production resolves this shared VM via
+                        // hiltViewModel(); the test injects it directly so the real
+                        // composer wiring renders the durable retry surface without
+                        // a Hilt graph.
+                        inlineDictationViewModel = vm,
+                    )
+                }
+            }
+        }
+        compose.waitForIdle()
+    }
+
+    private fun liveCollector(vm: InlineDictationViewModel, sink: CopyOnWriteArrayList<String>): Job {
+        var job: Job? = null
+        val scope = CoroutineScope(Dispatchers.Main)
+        compose.runOnUiThread {
+            job = scope.launch { vm.transcriptions.collect { sink.add(it) } }
+        }
+        compose.waitForIdle()
+        return job!!
+    }
+
+    @Test
+    fun permanentDeadPaneTranscriptIsVisibleContainedInComposerAndRetryReDelivers() {
+        val store = InMemoryUndeliveredTranscriptStore()
+        val text = "git push origin main"
+
+        // (1) REAL permanent-dead-pane persist: session A dies with the transcript
+        // still buffered — the navigated-away / subscriber-torn-down path.
+        val id = persistViaPermanentDeadPane(store, text)
+
+        // (2) Session B shares the durable store and has a live delivery collector.
+        val vmB = newInlineVm(store)
+        val delivered = CopyOnWriteArrayList<String>()
+        val collector = liveCollector(vmB, delivered)
+        setSheetContent(vmB)
+
+        // The composer must SURFACE the persisted transcript as a VISIBLE retry row.
+        // Containment (assertNodeFullyWithinRoot) is the load-bearing assertion —
+        // 'displayed' passes even off-screen; this proves the user can actually see
+        // it. On base (no composer wiring) the banner tag does not exist -> fails.
+        compose.onNodeWithTag(UNDELIVERED_TRANSCRIPT_BANNER_TAG).assertIsDisplayed()
+        compose.assertNodeFullyWithinRoot(UNDELIVERED_TRANSCRIPT_BANNER_TAG)
+        compose.onNodeWithText("Couldn't deliver — retry").assertIsDisplayed()
+        compose.onNodeWithText(text).assertIsDisplayed()
+        compose.assertNodeFullyWithinRoot("$UNDELIVERED_TRANSCRIPT_RETRY_TAG-$id")
+
+        captureFullDevice("issue-1272-undelivered-retry-row-visible.png")
+
+        // (3) Retry re-delivers into B's live pane and clears the row.
+        compose.onNodeWithTag("$UNDELIVERED_TRANSCRIPT_RETRY_TAG-$id").performClick()
+        compose.waitUntil(TIMEOUT_MS) { delivered.isNotEmpty() }
+        assertEquals(
+            "Retry must re-deliver the persisted transcript into the live delivery channel",
+            listOf(text),
+            delivered.toList(),
+        )
+        compose.waitUntil(TIMEOUT_MS) { store.snapshot().isEmpty() }
+        compose.onNodeWithTag(UNDELIVERED_TRANSCRIPT_BANNER_TAG).assertDoesNotExist()
+
+        collector.cancel()
+    }
+
+    @Test
+    fun undeliveredRetryRowDismissDiscardsWithoutReDelivery() {
+        val store = InMemoryUndeliveredTranscriptStore()
+        val text = "deploy staging"
+
+        // Permanent-dead-pane persist; the surface then stays dead (no live pane):
+        // the navigated-away path where the user gives up and dismisses the command.
+        val id = persistViaPermanentDeadPane(store, text)
+
+        val vmB = newInlineVm(store)
+        val delivered = CopyOnWriteArrayList<String>()
+        val collector = liveCollector(vmB, delivered)
+        setSheetContent(vmB)
+
+        compose.onNodeWithTag(UNDELIVERED_TRANSCRIPT_BANNER_TAG).assertIsDisplayed()
+        compose.assertNodeFullyWithinRoot("$UNDELIVERED_TRANSCRIPT_DISMISS_TAG-$id")
+
+        compose.onNodeWithTag("$UNDELIVERED_TRANSCRIPT_DISMISS_TAG-$id").performClick()
+        compose.waitUntil(TIMEOUT_MS) { store.snapshot().isEmpty() }
+        compose.onNodeWithTag(UNDELIVERED_TRANSCRIPT_BANNER_TAG).assertDoesNotExist()
+        assertTrue("Dismiss must NOT re-deliver the transcript", delivered.isEmpty())
+
+        collector.cancel()
+    }
+
+    @Test
+    fun fullComposerSheetSurfacesUndeliveredRetryRowFromSharedViewModelAndReDelivers() {
+        // Proves the PRODUCTION wiring path the #1341 reviewer blocked on: the full
+        // PromptComposerSheet (ModalBottomSheet window) resolves the shared
+        // InlineDictationViewModel binding (rememberComposerUndeliveredBinding ->
+        // SheetContent) and surfaces the retry row so the user can actually see +
+        // tap it. Multiple window roots (the sheet's dialog) make onRoot()-based
+        // containment ambiguous here, so this asserts displayed + re-delivery; the
+        // containment guarantee is owned by the single-root SheetContent test above.
+        val store = InMemoryUndeliveredTranscriptStore()
+        val text = "make deploy"
+        persistViaPermanentDeadPane(store, text)
+
+        val vmB = newInlineVm(store)
+        val delivered = CopyOnWriteArrayList<String>()
+        val collector = liveCollector(vmB, delivered)
+        val id = store.snapshot().first().id
+        setFullComposerSheet(vmB)
+
+        compose.onNodeWithText("Couldn't deliver — retry", useUnmergedTree = true).assertIsDisplayed()
+        compose.onNodeWithText(text, useUnmergedTree = true).assertIsDisplayed()
+
+        captureFullDevice("issue-1272-live-composer-sheet-retry-row.png")
+
+        compose.onNodeWithTag("$UNDELIVERED_TRANSCRIPT_RETRY_TAG-$id", useUnmergedTree = true).performClick()
+        compose.waitUntil(TIMEOUT_MS) { delivered.isNotEmpty() }
+        assertEquals(
+            "Retry from the live composer sheet must re-deliver the transcript",
+            listOf(text),
+            delivered.toList(),
+        )
+        compose.waitUntil(TIMEOUT_MS) { store.snapshot().isEmpty() }
+        compose.onNodeWithText("Couldn't deliver — retry", useUnmergedTree = true).assertDoesNotExist()
+
+        collector.cancel()
+    }
+
+    /**
+     * Issue #1272 (round-2 finding 2): capture the retry-row surface through the
+     * ComposeTestRule's OWN capture path ([captureToImage]) — NOT
+     * `instrumentation.uiAutomation.takeScreenshot()`.
+     *
+     * `takeScreenshot()` obtains a full-device `UiAutomation`; the no-arg
+     * `getUiAutomation()` connects with different flags than the instance the
+     * instrumentation / ComposeTestRule already registered, which throws
+     * `UiAutomation already registered` and crashed the run (round-1 was 3/3
+     * FAILED on run 1: `UiAutomation already registered` / process crash / `No
+     * compose hierarchies found`, 3/3 PASSED on run 2). That self-inflicted
+     * collision is also the likely culprit wedging the shared AVD for sibling
+     * agents. [captureToImage] reuses the already-owned automation, so it can
+     * never re-register — and it captures exactly the banner under test, which is
+     * the authoritative evidence anyway.
+     */
+    private fun captureFullDevice(name: String) {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val mediaRoot = testArtifactsRoot(instrumentation.targetContext)
+        val dir = File(mediaRoot, "additional_test_output/issue-1272-undelivered")
+        check(dir.exists() || dir.mkdirs()) {
+            "Could not create issue-1272 screenshot directory: ${dir.absolutePath}"
+        }
+        val file = File(dir, name)
+        compose.waitForIdle()
+        val bitmap = compose
+            .onNodeWithTag(UNDELIVERED_TRANSCRIPT_BANNER_TAG, useUnmergedTree = true)
+            .captureToImage()
+            .asAndroidBitmap()
+        try {
+            FileOutputStream(file).use { output ->
+                check(bitmap.compress(Bitmap.CompressFormat.PNG, 100, output)) {
+                    "Could not write issue-1272 screenshot: ${file.absolutePath}"
+                }
+            }
+            println("ISSUE1272_SCREENSHOT ${file.absolutePath}")
+        } finally {
+            bitmap.recycle()
+        }
+    }
+
+    private companion object {
+        const val TIMEOUT_MS = 5_000L
+    }
+}

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,5 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <application android:usesCleartextTraffic="true" />
+    <application android:usesCleartextTraffic="true">
+        <!--
+          Issue #1272: a debug-only @AndroidEntryPoint host that mounts the
+          PRODUCTION PromptComposerSheet with no test seams, so
+          PromptComposerUndeliveredRetryHiltWiringTest can exercise the REAL
+          `storeOwner is GeneratedComponentManagerHolder -> hiltViewModel()`
+          guard branch that resolves the activity-scoped InlineDictationViewModel
+          (the exact production link the #1341 reviewer blocked closure on).
+          Debug source set only, so it never ships in a release build.
+        -->
+        <activity
+            android:name="com.pocketshell.app.composer.ComposerHiltHostActivity"
+            android:exported="false"
+            android:theme="@style/Theme.PocketShell" />
+    </application>
 </manifest>

--- a/app/src/debug/java/com/pocketshell/app/composer/ComposerHiltHostActivity.kt
+++ b/app/src/debug/java/com/pocketshell/app/composer/ComposerHiltHostActivity.kt
@@ -1,0 +1,88 @@
+package com.pocketshell.app.composer
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Text
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import com.pocketshell.uikit.theme.PocketShellColors
+import com.pocketshell.uikit.theme.PocketShellTheme
+import dagger.hilt.android.AndroidEntryPoint
+
+/**
+ * Issue #1272 — a REAL `@AndroidEntryPoint` host that mounts the PRODUCTION
+ * [PromptComposerSheet] with ZERO test seams, so the connected regression test
+ * exercises the exact composer wiring that ships.
+ *
+ * ## Why this activity has to exist (the #1341 reviewer's blocking gap)
+ *
+ * The composer resolves the activity-scoped [com.pocketshell.app.session.InlineDictationViewModel]
+ * that owns the durable undelivered-transcript queue via a guard in
+ * `rememberComposerUndeliveredBinding`:
+ *
+ * ```kotlin
+ * val vm = override
+ *     ?: if (storeOwner is GeneratedComponentManagerHolder) hiltViewModel(storeOwner)
+ *     else null
+ * ```
+ *
+ * The other `PromptComposerUndeliveredRetryTest` cases mount the sheet under a
+ * plain (non-Hilt) `ComponentActivity`, so the `storeOwner` is NOT a
+ * `GeneratedComponentManagerHolder` and the guard takes the inert `null` branch
+ * (test 3 forces the surface via the `inlineDictationViewModel` OVERRIDE seam).
+ * That proves "SheetContent renders a banner when handed a list", but NEVER
+ * executes the REAL `storeOwner is GeneratedComponentManagerHolder ->
+ * hiltViewModel(storeOwner)` branch — the exact production link the #1341
+ * reviewer blocked closure on.
+ *
+ * This activity IS `@AndroidEntryPoint`, so its `ViewModelStoreOwner` (the
+ * activity, exposed as `LocalViewModelStoreOwner.current` inside the composer)
+ * IS a `GeneratedComponentManagerHolder` and the guard takes the REAL Hilt
+ * branch. It mounts [PromptComposerSheet] with NO override — every ViewModel
+ * (`PromptComposerViewModel` AND the guarded `InlineDictationViewModel`) is
+ * resolved from the live app Hilt graph exactly as production does. The test
+ * then reaches the SAME activity-scoped `InlineDictationViewModel` instance via
+ * `ViewModelProvider(activity)` and drives the durable queue, proving the guard
+ * resolves the production VM.
+ *
+ * Debug-source-set only (Hilt processes `src/main` + the debug build type, which
+ * is what `androidTest` runs against). It never ships in a release build.
+ */
+@AndroidEntryPoint
+class ComposerHiltHostActivity : ComponentActivity() {
+
+    @OptIn(ExperimentalMaterial3Api::class)
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            PocketShellTheme {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(PocketShellColors.Background),
+                    contentAlignment = Alignment.TopCenter,
+                ) {
+                    // A minimal terminal backdrop so the composer sheet renders
+                    // over content, matching the real session screen framing.
+                    Text(
+                        text = "alex@pocketshell:~$ claude\n> ready",
+                        color = PocketShellColors.Text,
+                    )
+                    // PRODUCTION wiring, no seams: `viewModel` and the guarded
+                    // `inlineDictationViewModel` (left null) both resolve from
+                    // the live Hilt graph via hiltViewModel(). This is the exact
+                    // path TmuxSessionScreen mounts.
+                    PromptComposerSheet(
+                        onDismiss = {},
+                        onSend = { _ -> true },
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerSheet.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerSheet.kt
@@ -108,12 +108,17 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
 import com.pocketshell.app.fileviewer.BoundedImageDecoder
+import com.pocketshell.app.session.InlineDictationViewModel
+import com.pocketshell.app.session.UndeliveredTranscriptBanner
 import com.pocketshell.app.snippets.SnippetKind
 import com.pocketshell.app.snippets.SnippetPickerSheet
 import com.pocketshell.app.agentcommands.AgentCommand
 import com.pocketshell.app.voice.DictateDotIcon
 import com.pocketshell.app.voice.PendingTranscriptionItem
+import com.pocketshell.app.voice.UndeliveredTranscript
+import dagger.hilt.internal.GeneratedComponentManagerHolder
 import com.pocketshell.core.agents.AgentKind
 import com.pocketshell.core.storage.entity.PendingTranscriptionEntity
 import com.pocketshell.uikit.components.DisclosureIcon
@@ -233,8 +238,21 @@ public fun PromptComposerSheet(
     // (timer + waveform) until Discard / Insert / Send — issue #1245 removed the
     // separate hands-free "lock" concept.
     autoStartRecording: Boolean = false,
+    // Issue #1272: override seam for the activity-scoped inline-dictation
+    // ViewModel that owns the durable undelivered-transcript queue + delivery
+    // channel. Production leaves it null — the sheet resolves the SAME
+    // activity-scoped instance TmuxSessionScreen uses via `hiltViewModel()` (so a
+    // Retry re-injects into the live delivery channel the session screen
+    // collects). Tests pass a real instance directly so the retry surface renders
+    // without a Hilt graph.
+    inlineDictationViewModel: InlineDictationViewModel? = null,
 ) {
     val state by viewModel.uiState.collectAsState()
+    // Issue #1272: surface the durable "couldn't deliver — retry" queue in the
+    // composer's own bottom chrome so a voice command that was transcribed but
+    // never reached a pane (permanent pane death / channel overflow) is
+    // recoverable by the user instead of silently lost.
+    val undelivered = rememberComposerUndeliveredBinding(inlineDictationViewModel)
     val pendingItems by viewModel.pendingItems.collectAsState()
     val outboundQueueItems by viewModel.outboundQueueItems.collectAsState()
     val context = LocalContext.current
@@ -501,6 +519,10 @@ public fun PromptComposerSheet(
             onRetryOutboundItem = onRetryOutboundItem ?: viewModel::retryOutboundItem,
             onResendAllOutbound = onResendAllOutbound ?: { viewModel.resendAllQueued(); Unit },
             agentKind = agentKind,
+            // Issue #1272: the durable undelivered-transcript retry surface.
+            undeliveredTranscripts = undelivered.transcripts,
+            onRetryUndelivered = undelivered.onRetry,
+            onDismissUndelivered = undelivered.onDismiss,
         )
     }
 
@@ -564,6 +586,62 @@ public fun PromptComposerSheet(
  * a window decor view), so the previews target this composable directly.
  */
 @OptIn(ExperimentalComposeUiApi::class)
+/**
+ * Issue #1272: the composer's live binding to the durable undelivered-transcript
+ * queue — the list to render plus the Retry / Dismiss callbacks.
+ */
+private data class ComposerUndeliveredBinding(
+    val transcripts: List<UndeliveredTranscript>,
+    val onRetry: (String) -> Unit,
+    val onDismiss: (String) -> Unit,
+)
+
+/**
+ * Issue #1272: resolve the ACTIVITY-scoped [InlineDictationViewModel] that owns
+ * the durable undelivered-transcript queue and the delivery channel the session
+ * screen collects.
+ *
+ * The composer sheet is composed inside the SAME activity-scoped
+ * `ViewModelStoreOwner` as `TmuxSessionScreen`, so `hiltViewModel()` here returns
+ * the SAME instance the session screen's `transcriptions` collector reads — a
+ * Retry re-injects into that live channel and reaches the focused pane (or
+ * re-persists if the pane is still gone). That is why the retry lives on the
+ * shared inline-dictation VM, not a private composer copy.
+ *
+ * Guarded: composer render / connected tests mount [PromptComposerSheet] under a
+ * plain (non-Hilt) `ComponentActivity` that has no `InlineDictationViewModel`
+ * factory. Only a Hilt `@AndroidEntryPoint` activity (a
+ * [GeneratedComponentManagerHolder]) can resolve the VM, so a non-Hilt owner
+ * degrades to an inert empty surface instead of crashing. Tests that WANT the
+ * surface pass [override] directly.
+ */
+@Composable
+private fun rememberComposerUndeliveredBinding(
+    override: InlineDictationViewModel?,
+): ComposerUndeliveredBinding {
+    val storeOwner = LocalViewModelStoreOwner.current
+    val vm: InlineDictationViewModel? = override
+        ?: if (storeOwner is GeneratedComponentManagerHolder) {
+            hiltViewModel<InlineDictationViewModel>(storeOwner)
+        } else {
+            null
+        }
+    return if (vm != null) {
+        val transcripts by vm.undeliveredTranscripts.collectAsState()
+        ComposerUndeliveredBinding(
+            transcripts = transcripts,
+            onRetry = vm::retryUndelivered,
+            onDismiss = vm::dismissUndelivered,
+        )
+    } else {
+        ComposerUndeliveredBinding(
+            transcripts = emptyList(),
+            onRetry = {},
+            onDismiss = {},
+        )
+    }
+}
+
 @Composable
 internal fun SheetContent(
     state: PromptComposerViewModel.UiState,
@@ -615,6 +693,14 @@ internal fun SheetContent(
     // `AgentCommandCatalog` the `/`-autocomplete dropdown filters. Null on a
     // shell pane / preview, where the dropdown is never shown.
     agentKind: AgentKind? = null,
+    // Issue #1272: the durable "couldn't deliver — retry" queue for voice
+    // commands that were transcribed successfully but never reached a pane
+    // (permanent pane death / channel overflow). Rendered in the sticky bottom
+    // chrome so it stays visible above the soft keyboard. Empty default keeps
+    // previews / legacy tests that don't wire it source-compatible.
+    undeliveredTranscripts: List<UndeliveredTranscript> = emptyList(),
+    onRetryUndelivered: (String) -> Unit = {},
+    onDismissUndelivered: (String) -> Unit = {},
 ) {
     val isTranscribing = state.recording == PromptComposerViewModel.RecordingState.Transcribing
     val attachmentUploading =
@@ -1159,6 +1245,26 @@ internal fun SheetContent(
                 )
                 Spacer(modifier = Modifier.height(8.dp))
             }
+        }
+
+        // Issue #1272: the durable "couldn't deliver — retry" surface. A voice
+        // command that was transcribed successfully but never reached a pane
+        // (the session was permanently gone by the time Whisper resolved, or the
+        // bounded delivery channel overflowed) is persisted and surfaced HERE, in
+        // the composer's sticky bottom chrome — OUTSIDE the scrollable upper
+        // region so it stays visible directly above the Send row even with the
+        // soft keyboard up. Tapping Retry re-injects the text into the shared
+        // inline-dictation delivery channel (re-delivered to the focused pane, or
+        // re-persisted if the pane is still gone); Dismiss discards it. Before
+        // this wiring the retry item had no user-visible surface at all, so the
+        // maintainer's dictate-then-vanish symptom had no recovery affordance.
+        if (undeliveredTranscripts.isNotEmpty()) {
+            UndeliveredTranscriptBanner(
+                items = undeliveredTranscripts,
+                onRetry = onRetryUndelivered,
+                onDismiss = onDismissUndelivered,
+                modifier = Modifier.padding(bottom = 8.dp),
+            )
         }
 
         // Issue #745: connection-lost indicator. Sits OUTSIDE the scrollable

--- a/app/src/main/java/com/pocketshell/app/session/InlineDictation.kt
+++ b/app/src/main/java/com/pocketshell/app/session/InlineDictation.kt
@@ -1217,15 +1217,21 @@ public fun KeyBarWithMic(
  * affordance so the user recovers a command that was transcribed successfully
  * but never reached a pane. Rendered at the top of [KeyBarWithMic] whenever the
  * durable [UndeliveredTranscriptStore] has entries.
+ *
+ * `internal` (not `private`) so the LIVE prompt composer chrome
+ * ([com.pocketshell.app.composer.PromptComposerSheet]) reuses the SAME banner —
+ * same design-system tokens, same test tags — rather than re-styling a second
+ * copy off the token ladder.
  */
 @Composable
-private fun UndeliveredTranscriptBanner(
+internal fun UndeliveredTranscriptBanner(
     items: List<UndeliveredTranscript>,
     onRetry: (String) -> Unit,
     onDismiss: (String) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     androidx.compose.foundation.layout.Column(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .testTag(UNDELIVERED_TRANSCRIPT_BANNER_TAG)
             .background(

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -348,6 +348,30 @@ JOURNEY_CLASSES=(
   # retry callbacks in the same per-push androidTest lane as the send-feedback
   # composer proofs. Pure Compose, no Docker fixture.
   "com.pocketshell.app.composer.PromptComposerOutboundQueueTest"
+  # ADDED (#1272): the durable "couldn't deliver — retry" surface wired into the
+  # LIVE composer chrome. A voice command transcribed successfully but never
+  # delivered to a pane (permanent pane death / channel overflow) was silently
+  # lost — the #1341 data-loss slice made it durable but had NO user-visible
+  # retry surface (the #1341 reviewer blocked closure on exactly that). This
+  # drives the REAL production PromptComposerSheet (no *StandIn/*Proxy) through a
+  # real permanent-dead-pane persist, asserts the retry row is VISIBLE with
+  # viewport CONTAINMENT (assertNodeFullyWithinRoot, not bare assertIsDisplayed),
+  # and proves Retry re-delivers into a live pane + Dismiss discards. Pure Compose,
+  # no Docker fixture, no assumeTrue self-skip. Carries its FQ name directly.
+  "com.pocketshell.app.composer.PromptComposerUndeliveredRetryTest"
+  # ADDED (#1272 round-2, finding 1): the PRODUCTION-WIRING proof. The class
+  # above bypasses the composer's hiltViewModel() guard (SheetContent called
+  # directly / the inlineDictationViewModel override seam), so it never runs the
+  # REAL `storeOwner is GeneratedComponentManagerHolder -> hiltViewModel()`
+  # branch that resolves the activity-scoped InlineDictationViewModel the session
+  # screen collects (the exact link #1341 blocked on). This class launches the
+  # real @AndroidEntryPoint ComposerHiltHostActivity (debug source set), mounts
+  # the PRODUCTION PromptComposerSheet with NO seam, drives an undelivered
+  # transcript into the SAME activity-scoped VM (via ViewModelProvider(activity)),
+  # and asserts the retry row renders with viewport CONTAINMENT + Retry
+  # re-delivers — proving the guard's real Hilt branch binds the production VM.
+  # Pure Compose, no Docker fixture, no assumeTrue self-skip.
+  "com.pocketshell.app.composer.PromptComposerUndeliveredRetryHiltWiringTest"
   # ADDED (#1308): batch "Resend all" for the queued backlog. The presence/absence
   # + callback + within-root containment of the new button live in
   # PromptComposerOutboundQueueTest above; this class is its keyboard-UP occlusion


### PR DESCRIPTION
Closes #1272

Completes the #1272 data-loss issue: the durable `UndeliveredTranscriptStore` + bounded channel shipped in #1341, and this slice makes the retry affordance USER-REACHABLE. Mounts `UndeliveredTranscriptBanner` into the production `PromptComposerSheet` chrome via a `GeneratedComponentManagerHolder`-guarded `hiltViewModel()` that resolves the activity-scoped `InlineDictationViewModel` — an undeliverable transcript (permanent-dead-pane / channel overflow) now surfaces as a tappable "Couldn't deliver — retry" row, and Retry re-delivers.

**Verification (reviewer APPROVED, re-review after CHANGES REQUESTED):**
- **Real Hilt guard path** (prior gap): new `PromptComposerUndeliveredRetryHiltWiringTest` mounts the production sheet under the live Hilt graph via a debug-only `@AndroidEntryPoint` host — NO override seam, NO `SheetContent` shortcut — reviewer drove red→green (guard inert → banner never appears; restored → passes), `boundsInRoot` containment assertion.
- **UiAutomation-collision flake** (prior gap, also the shared-AVD wedge cause): `captureFullDevice()` rewritten to `captureToImage()` (no second UiAutomation) — 3× consecutive clean runs.
- Debug-only host confirmed `src/debug/`-only (never ships release); no connection-core edits. Reviewer: https://github.com/alexeygrigorev/pocketshell/issues/1272#issuecomment-4912557882