### PR TITLE
terminal: wrap-tolerant send-heal oracle — reflowed-but-restored frame scores healthy (#1153)

### DIFF
--- a/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurfaceState.kt
+++ b/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurfaceState.kt
@@ -952,6 +952,22 @@ class TerminalSurfaceState(
      * half-black band (#1153), and a mostly-empty model (#1214) all reproduce only a small fraction
      * of tmux's content lines, so one line-diff catches them all.
      *
+     * ## Wrap / width tolerance (the #1153 reopen this closes)
+     *
+     * The per-line hash must compare LOGICAL lines, not PHYSICAL grid rows, or a correctly-restored
+     * frame scores falsely "lost" whenever a frame line is wider than the pane. `capture-pane`
+     * (without `-J`) emits a wrapped logical line as TWO physical rows, and a reseed writes each
+     * captured row via cursor addressing (so the render holds two full-width rows too), while a live
+     * soft-wrapped render folds them back — three different physical layouts of the SAME content. The
+     * #1300 physical-row hash mismatched them (every wrapped frame line counted as ≥2 lost rows), so
+     * the send-with-attachment E2E stayed chronically RED on CI even though the heal fully restored
+     * the frame (#1153). Both sides are therefore de-wrapped to width-independent LOGICAL lines first:
+     * the render via [TerminalBuffer.getVisibleScreenTextFullyJoined] (joins soft-wrapped AND
+     * full-width rows), the capture via [dewrapCaptureToLogicalLines] (joins each physical row that
+     * fills the pane width with the next). A genuinely lost / black frame is still lost — it is
+     * MISSING logical lines, which no amount of re-wrapping conjures back — so real black-frame
+     * detection is intact; only reflow is forgiven.
+     *
      * ## Position-free by design
      *
      * `getVisibleScreenText()` trims leading/trailing blank rows and joins wrapped rows, so a
@@ -984,19 +1000,29 @@ class TerminalSurfaceState(
             return false
         }
         if (visibleRows <= 0) return false
+        // The pane width the render (and, in production, the capture) is laid out at — used to
+        // de-wrap each side's physical rows back to width-independent LOGICAL lines (#1153).
+        val columns = try {
+            emulator.mColumns
+        } catch (_: Throwable) {
+            return false
+        }
         // tmux's authoritative visible content lines (the visible tail, scrollback excluded), each
         // ANSI-stripped, trimmed, and non-blank. Reuse THIS same capture text — no extra round-trip.
         // #1300: the capture is `capture-pane -e`, so each line carries raw SGR/colour escapes; strip
         // them FIRST ([stripAnsiEscapes]) so a coloured capture line (`ESC[32m…ESC[0m`) collapses to
         // the plain content the render holds — otherwise no coloured line ever hash-matches and every
-        // coloured pane scores divergent (reseed-thrash, #1164/#1219). Normalize with a full trim()
-        // (not just trimEnd) because `getVisibleScreenText()` trims the WHOLE rendered string,
-        // dropping a leading space on the render's first content line that the raw capture still
-        // carries — trimming both sides keeps those otherwise-identical lines matching. A bg-colour-
-        // only row (`ESC[44m   ESC[0m`) strips to spaces → trim → empty, matching its blank render.
-        val captureContentLines = captureText
-            .split('\n')
-            .map { stripAnsiEscapes(it).trim() }
+        // coloured pane scores divergent (reseed-thrash, #1164/#1219). #1153: de-wrap the capture's
+        // PHYSICAL rows into LOGICAL lines FIRST (join each row that fills the pane width with the
+        // next) so a frame line wider than the pane — which `capture-pane` (no `-J`) emits as two
+        // physical rows — compares equal to the render's single de-wrapped logical line, whatever
+        // width either side wrapped at. Normalize with a full trim() (not just trimEnd) because the
+        // render side trims the WHOLE string, dropping a leading space on the first content line the
+        // raw capture still carries — trimming both sides keeps those otherwise-identical lines
+        // matching. A bg-colour-only row (`ESC[44m   ESC[0m`) strips to spaces → trim → empty,
+        // matching its blank render.
+        val captureContentLines = dewrapCaptureToLogicalLines(captureText.split('\n'), columns)
+            .map { it.trim() }
             .filter { it.isNotEmpty() }
             .takeLast(visibleRows)
         if (captureContentLines.isEmpty()) return false
@@ -1008,9 +1034,12 @@ class TerminalSurfaceState(
         // multiset, not a set, so a black BAND over a uniform-content frame (many identical rows) is
         // seen as lost: the render reproduces only `liveRows` copies while tmux holds all of them.
         // The whole diff is two String.split + line hashes over ≤ visibleRows lines: well under 1 ms
-        // on-device, no allocation storm, and it runs only AFTER the capture already returned.
+        // on-device, no allocation storm, and it runs only AFTER the capture already returned. #1153:
+        // read the FULLY-joined visible text (soft-wrapped AND full-width rows folded to logical
+        // lines) so a reseeded / soft-wrapped render of a wide frame line compares equal to the
+        // de-wrapped capture, whatever physical layout either wrapped at.
         val renderedText = try {
-            emulator.screen.visibleScreenText
+            emulator.screen.visibleScreenTextFullyJoined
         } catch (_: Throwable) {
             return false
         }
@@ -1398,6 +1427,39 @@ class TerminalSurfaceState(
          */
         private fun stripAnsiEscapes(line: String): String =
             if (line.indexOf('\u001B') < 0) line else AnsiEscapeRegex.replace(line, "")
+
+        /**
+         * Issue #1153: de-wrap `capture-pane` PHYSICAL rows into width-independent LOGICAL lines so
+         * the [visibleRenderLostFrameVsCapture] per-line hash forgives WRAPPING/reflow while still
+         * catching a genuinely lost frame. `capture-pane` without `-J` emits a logical line wider
+         * than the pane as consecutive physical rows; a row whose last PRINTING cell reaches the
+         * pane's right edge ([columns]) is a hard wrap whose logical line continues on the next row,
+         * so it is joined (no boundary) with the following row — mirroring how the render's own
+         * full-width rows fold in [TerminalBuffer.getVisibleScreenTextFullyJoined]. Each row is
+         * ANSI-stripped first (a `-e` capture carries SGR escapes); trailing whitespace is ignored
+         * for the fill test so a partially-filled coloured row (bg colour to the edge) is NOT
+         * mistaken for a wrap. A row shorter than the pane width ends its logical line. This never
+         * conjures missing content back — a black band is missing whole logical lines regardless of
+         * how the surviving rows wrap — so it forgives reflow only, not lost frames.
+         */
+        private fun dewrapCaptureToLogicalLines(rawLines: List<String>, columns: Int): List<String> {
+            if (columns <= 0) return rawLines.map { stripAnsiEscapes(it) }
+            val logical = ArrayList<String>(rawLines.size)
+            val pending = StringBuilder()
+            for (raw in rawLines) {
+                val stripped = stripAnsiEscapes(raw)
+                pending.append(stripped)
+                // A physical row whose last PRINTING cell reaches the right edge is a hard wrap: the
+                // logical line continues on the next row. Otherwise the logical line ends here.
+                val fillsWidth = stripped.trimEnd().length >= columns
+                if (!fillsWidth) {
+                    logical.add(pending.toString())
+                    pending.setLength(0)
+                }
+            }
+            if (pending.isNotEmpty()) logical.add(pending.toString())
+            return logical
+        }
 
         /**
          * Issue #553 (J2): upper bound on live (non-blank) lines for

--- a/shared/core-terminal/src/main/java/com/termux/terminal/TerminalBuffer.java
+++ b/shared/core-terminal/src/main/java/com/termux/terminal/TerminalBuffer.java
@@ -56,6 +56,24 @@ public final class TerminalBuffer {
     }
 
     /**
+     * Issue #1153: the text of ONLY the currently VISIBLE screen rows (like
+     * {@link #getVisibleScreenText()}), but with wrapped AND full-width rows joined
+     * into their LOGICAL lines ({@code joinFullLines=true}). {@code getVisibleScreenText()}
+     * folds only soft-wrapped rows ({@code joinBackLines}); a pane reseeded from a
+     * {@code capture-pane} snapshot writes each captured PHYSICAL row via cursor
+     * addressing, so a frame line wider than the pane lands as two full-width rows with
+     * NO soft-wrap flag — which {@code getVisibleScreenText()} would keep split while an
+     * independent {@code capture-pane -p} snapshot (or a live soft-wrapped render) folds
+     * them differently. Joining full-width rows here collapses BOTH shapes to the same
+     * width-independent logical lines, so the {@code visibleRenderLostFrameVsCapture}
+     * per-line-hash oracle scores a correctly-restored-but-reflowed frame as HEALTHY
+     * instead of falsely "lost". Reads the visible viewport only, scrollback excluded.
+     */
+    public String getVisibleScreenTextFullyJoined() {
+        return getSelectedText(0, 0, mColumns, mScreenRows, true, true).trim();
+    }
+
+    /**
      * Issue #966/#967: the number of VISIBLE screen rows (the viewport height in
      * cells), so the stale-render oracle can compare the rendered visible grid
      * against the matching visible-tail of tmux's `capture-pane` text — an

--- a/shared/core-terminal/src/test/java/com/pocketshell/core/terminal/ui/TerminalSurfaceStateAgentPartialBlackTest.kt
+++ b/shared/core-terminal/src/test/java/com/pocketshell/core/terminal/ui/TerminalSurfaceStateAgentPartialBlackTest.kt
@@ -76,6 +76,12 @@ class TerminalSurfaceStateAgentPartialBlackTest {
     /** ESC, so the test feeds real control sequences. */
     private val esc = ""
 
+    /** The default emulator pane width (SshTerminalBridge.INITIAL_COLUMNS) the JVM harness runs at. */
+    private val WRAP_COLUMNS = 80
+
+    /** A wide frame line length so each line WRAPS at [WRAP_COLUMNS] (80 + a 20-char continuation). */
+    private val WIDE_LINE_LEN = 100
+
     /**
      * The full alt-screen agent frame tmux's grid holds while "Working": a header, a couple
      * of conversation lines, a large BLANK conversation area (padding — the sparse part), an
@@ -260,6 +266,83 @@ class TerminalSurfaceStateAgentPartialBlackTest {
             "#807: when tmux's alt-screen is ALSO near-empty (agent's own clear) the union " +
                 "must NOT heal — there is no lost frame to restore",
             state.visibleRenderLostFrameVsCapture(voidCapture),
+        )
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Issue #1153 REOPEN — the STRICT cross-capture oracle at a WRAPPING width (the coverage gap
+    // that let #1153 come back). The prior #1153 JVM tests all run at a fixed NON-wrapping width
+    // (short lines) and read the render through the cheap local pre-gate — they never exercise the
+    // per-line-hash oracle against an independently-captured `capture-pane` snapshot when a frame
+    // line is WIDER than the pane. On the CI emulator (~62 cols) the send-with-attachment frame row
+    // (~68 chars) wraps: the render folds the soft-wrap back to a logical line while `capture-pane
+    // -p` (no `-J`) emits it as two PHYSICAL rows, so the #1300 physical-row hash counted every
+    // wrapped-but-fully-restored frame line as ≥2 "lost" rows and the E2E stayed chronically RED
+    // even though the heal restored the frame. These pin the wrap-tolerant contract.
+
+    /** A wide LOGICAL frame line (100 chars, NO spaces) that wraps at the 80-col pane width. */
+    private fun wideFrameLine(row: Int): String {
+        val head = "WRAP-frame-row-$row-"
+        return head + ".".repeat(WIDE_LINE_LEN - head.length)
+    }
+
+    /**
+     * Mirror `tmux capture-pane -p` (no `-J`): emit each wide logical line as the PHYSICAL grid rows
+     * tmux splits it into at the pane width — the exact shape that mismatched the folded render.
+     */
+    private fun captureAsPhysicalRows(logical: List<String>, columns: Int): String =
+        logical.joinToString("\n") { line -> line.chunked(columns).joinToString("\n") } + "\n"
+
+    /**
+     * Issue #1153 (reopen) RED→GREEN at a WRAPPING width: a fully-restored frame that merely
+     * REFLOWED — the render folds each wide line's soft-wrap into a logical line, while tmux's
+     * `capture-pane -p` holds it as two physical rows — must score HEALTHY. On base (the #1300
+     * physical-row hash) this scored "lost" (each wrapped line = ≥2 missing rows), which is the
+     * chronic CI RED. The load-bearing assertion is the STRICT oracle itself, not the local pre-gate.
+     */
+    @Test
+    fun reflowedFullFrameScoresHealthyAtWrappingWidth() = withAttachedSurface { state ->
+        val logical = (0 until 10).map { wideFrameLine(it) }
+        // Render: feed the wide frame with hard newlines → each line soft-wraps at col 80, so the
+        // render holds physical rows the model folds back to logical lines.
+        val render = buildString {
+            append("$esc[2J$esc[H")
+            for (line in logical) append("$line\r\n")
+        }
+        state.appendRemoteOutput(render.toByteArray(Charsets.US_ASCII))
+        shadowOf(Looper.getMainLooper()).idle()
+        // tmux's authoritative capture of the SAME content, but as `capture-pane -p` PHYSICAL rows.
+        val capture = captureAsPhysicalRows(logical, WRAP_COLUMNS)
+        assertFalse(
+            "GREEN (#1153 reopen): a correctly-restored frame that merely REFLOWED (render folds " +
+                "soft-wrap, capture-pane emits physical rows) must score HEALTHY via the strict " +
+                "cross-capture oracle — not falsely lost the way the #1300 physical-row hash did",
+            state.visibleRenderLostFrameVsCapture(capture),
+        )
+    }
+
+    /**
+     * Issue #1153 (reopen) non-masking guard: at the SAME wrapping width, a GENUINELY lost/black
+     * render (only a couple of short survivors over black) must STILL score LOST. Proves the
+     * wrap-tolerance forgives REFLOW only — it never conjures missing content back (G6: the fix
+     * did not weaken real black-frame detection into always-healthy).
+     */
+    @Test
+    fun genuinelyLostFrameStillScoresLostAtWrappingWidth() = withAttachedSurface { state ->
+        val render = buildString {
+            append("$esc[2J$esc[H")
+            append("only-one-surviving-live-line\r\n")
+            append("and-one-more-survivor\r\n")
+        }
+        state.appendRemoteOutput(render.toByteArray(Charsets.US_ASCII))
+        shadowOf(Looper.getMainLooper()).idle()
+        // tmux holds the FULL wide frame (10 wide logical lines → 20 physical capture rows).
+        val logical = (0 until 10).map { wideFrameLine(it) }
+        val capture = captureAsPhysicalRows(logical, WRAP_COLUMNS)
+        assertTrue(
+            "non-masking (#1153 reopen): a genuinely lost/black render must STILL score LOST at a " +
+                "wrapping width — the wrap-tolerance forgives reflow, never missing content",
+            state.visibleRenderLostFrameVsCapture(capture),
         )
     }
 


### PR DESCRIPTION
Closes #1153 — v0.4.25 release-blocker (render-core, targeted; NOT the render-heal rewrite — that's parked as #1353).

**Root cause:** `SendWithAttachmentStaysVisibleE2eTest`'s load-bearing assertion is the strict #1300 `visibleRenderLostFrameVsCapture` per-line-hash oracle. On CI the marker/row-restore wait passes (content IS restored); only the oracle fails, because the ~68-char frame row WRAPS at the CI pane width — the render's `visibleScreenText` folds soft-wraps to a logical line while the independent `capture-pane -p` emits physical rows, so wrapped-but-restored lines scored 'lost'. The old #1163 oracle (char-count) was wrap-tolerant; #1300 swapped in the format-sensitive one underneath the heal. The JVM test was green vacuously (fixed 80×40, no wrapping) — the coverage gap that let it recur.

**Fix:** `visibleRenderLostFrameVsCapture` now de-wraps BOTH sides to width-independent logical lines (`getVisibleScreenTextFullyJoined` / `dewrapCaptureToLogicalLines` at `emulator.mColumns`) before hashing. Wrapping/reflow forgiven; black-frame gates (#807 Gate 1, anti-thrash Gate 2) intact. No production VM change, no 6th heal layer.

**Verification (reviewer APPROVED, drove red→green):** new `reflowedFullFrameScoresHealthyAtWrappingWidth` RED on the physical-row oracle → GREEN with the fix, at a WRAPPING width through the real `TerminalSurfaceState`; non-masking `genuinelyLostFrameStillScoresLostAtWrappingWidth` stays LOST; full `:shared:core-terminal:testDebugUnitTest` 474/0. On-device `SendWithAttachmentStaysVisibleE2eTest` green deferred to CI's emulator lane (tag-gate). Reviewer: https://github.com/alexeygrigorev/pocketshell/issues/1153#issuecomment-4912840037