### PR TITLE
test: isolate ForwardingNetworkRideThroughE2eTest from real network callbacks (#1356)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/portfwd/ForwardingNetworkRideThroughE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/portfwd/ForwardingNetworkRideThroughE2eTest.kt
@@ -92,6 +92,10 @@ class ForwardingNetworkRideThroughE2eTest {
 
     @After
     fun teardown() {
+        // Issue #1356: re-enable real network callbacks for any sibling test
+        // sharing this singleton observer in the same instrumentation process
+        // (mirrors BareNetworkLossRestoreReconnectE2eTest#tearDown, #1098 item 5).
+        runCatching { observer().ignoreRealNetworkCallbacksForTest = false }
         runCatching { controller().forceTransportProvenAliveForTest = null }
         runCatching { controller().stopAllForwarding() }
         diagnostics?.close()
@@ -159,6 +163,16 @@ class ForwardingNetworkRideThroughE2eTest {
         diagnostics = sink
 
         val observer = observer()
+        // Issue #1356: isolate the synthetic loss/restore/handoff sequence from the
+        // AVD's own real ConnectivityManager callbacks, which feed the SAME detector
+        // and would otherwise re-validate AVD Wi-Fi inside the 2s watchNoRedial window
+        // — read as a spurious RESTORE and recorded as a `network_redial`, failing
+        // arm (a)/(b) non-deterministically. Production always processes real
+        // callbacks; this only quiets them for the deterministic injection, exactly
+        // like BareNetworkLossRestoreReconnectE2eTest (#1098 item 5). The synthetic
+        // emitSyntheticSnapshotForTest path bypasses this seam, so every drive below
+        // still reaches the controller.
+        observer.ignoreRealNetworkCallbacksForTest = true
         // Seed a known validated baseline so the subsequent loss reliably emits a
         // NetworkLost (the detector's loss arm is idempotent if already lost).
         observer.emitSyntheticSnapshotForTest(


### PR DESCRIPTION
Closes #1356 — v0.4.25 emulator-gate flake (test-only, zero production change).

The test omitted the `ignoreRealNetworkCallbacksForTest` seam its sibling uses, so a real emulator `ConnectivityManager` callback could bleed into the 2s `watchNoRedial` window and be read as a spurious RESTORE → `network_redial` (non-deterministic — passed attempt-1, failed retry). The production `ForwardingController` logic is correct (the analysis confirmed `network_loss_hold` fired); only the test lacked isolation.

**Fix:** set `observer().ignoreRealNetworkCallbacksForTest = true` before the synthetic drive + reset in `@After`, mirroring `BareNetworkLossRestoreReconnectE2eTest`. Every network event is driven via `emitSyntheticSnapshotForTest` (bypasses the seam via `updateFromSnapshot`), so no arm depends on a real callback.

**Verification (reviewer APPROVED):** single-file test change; `:app:compileDebugAndroidTestKotlin` BUILD SUCCESSFUL; correctness by-construction (real callbacks suppressed, synthetic drive preserved — proven on the sibling). On-device green deferred to CI's emulator lane. Analysis: #1047 comment (2026-07-08).