### PR TITLE
test: assert visible input box (not scrollback) after Submit + JVM class-cover (#1350)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/AgentSubmitAckJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/AgentSubmitAckJourneyE2eTest.kt
@@ -280,28 +280,55 @@ class AgentSubmitAckJourneyE2eTest {
 
     /**
      * After a submit, the fake-agent clears its input box (`> ` with no buffer),
-     * so the typed prompt must NO LONGER appear in the input region — it left the
-     * input rather than sitting unsent. The `FAKE-AGENT SUBMITTED: <prompt>`
-     * marker (emitted ONLY on Enter) legitimately contains the prompt, so we strip
-     * that marker line out of the visible text and assert the prompt's tail does
-     * not appear in the REMAINDER (the live input box). If Send had left the
-     * prompt unsent, the input box would still show `> <prompt>` here (and there'd
-     * be no SUBMITTED marker, which the caller already asserted appears).
+     * so the CURRENT input box must be empty — the typed prompt left the input
+     * rather than sitting unsent. This asserts against the AUTHORITATIVE remote
+     * `capture-pane -p` (the VISIBLE pane only), NOT the app-side `transcriptText`.
+     *
+     * Issue #1350 (the long-prompt false-fail this fixes): `transcriptText`
+     * includes the pane's SCROLLBACK. On the phone-sized grid, a long/wrapping
+     * prompt's earlier typing renders overflow the short pane and scroll into
+     * history, so the prompt's tail lingers in SCROLLBACK even after the current
+     * input box is cleared. The prior transcript-based check filtered out only the
+     * single `FAKE-AGENT SUBMITTED:` marker line, so those historical input-box
+     * fragments survived and false-failed the LONG prompt only
+     * (`remainder='…pipelinetodayFAKE-AGENT-READY'`) — while the real input box was
+     * empty (proven: `capture-pane -p` shows `>` after the submit). Short prompts
+     * fit the visible pane, never scroll into scrollback, and always passed.
+     *
+     * `capture-pane -p` returns the VISIBLE pane only, so it tests the REAL
+     * property ("the prompt left the input box NOW") and cannot be polluted by
+     * scrollback — yet it STILL fails if the submit genuinely left the prompt
+     * unsent in the input line (the input box line would read `> <prompt>`). This
+     * is the SAME authoritative input-box check the mid-flow
+     * [waitForSidecarCaptureEmptyInput] already relies on. Polled because the
+     * fake-agent renders asynchronously after the submit Enter.
      */
     private fun assertInputBoxEmptyAfterSubmit(label: String, prompt: String) {
+        val key = requireNotNull(seededKey)
         val promptTailStripped = prompt.filterNot { it.isWhitespace() }.takeLast(16)
-        // Remove every SUBMITTED-marker line (whitespace-stripped) from the
-        // whitespace-stripped visible text, then check the input box remainder.
-        val remainderStripped = visibleTerminalText()
-            .lines()
-            .filterNot { it.filterNot { c -> c.isWhitespace() }.contains(FAKE_AGENT_SUBMITTED.filterNot { c -> c.isWhitespace() }) }
-            .joinToString("")
-            .filterNot { it.isWhitespace() }
+        val deadline = SystemClock.elapsedRealtime() + INPUT_CLEARED_AFTER_SUBMIT_TIMEOUT_MS
+        var inputLine = ""
+        var lastCapture = ""
+        while (SystemClock.elapsedRealtime() < deadline) {
+            lastCapture = runBlocking { sidecarCapturePane(key) }
+            // The input box is the last `> `-prefixed VISIBLE line; it is empty
+            // when it trims to just `>` (the fake-agent cleared the buffer on
+            // submit). A wrapped SUBMITTED marker's continuation rows are plain
+            // prompt text (no leading `>`), so they never masquerade as the input
+            // box here.
+            inputLine = lastCapture.lines()
+                .lastOrNull { it.trimStart().startsWith(">") }
+                ?.trim()
+                .orEmpty()
+            if (inputLine == ">") return
+            SystemClock.sleep(150)
+        }
         assertTrue(
-            "$label: input box must be EMPTY after submit (prompt left the input, " +
-                "not unsent); the prompt tail '$promptTailStripped' still appears " +
-                "in the input box. remainder='${remainderStripped.takeLast(80)}'",
-            !remainderStripped.contains(promptTailStripped),
+            "$label: the agent input box must be EMPTY after submit (the prompt left " +
+                "the input — really sent, not left unsent). The VISIBLE input box line " +
+                "is '$inputLine' (prompt tail '$promptTailStripped'). capture-pane -p:\n" +
+                lastCapture,
+            inputLine == ">",
         )
     }
 
@@ -554,6 +581,12 @@ class AgentSubmitAckJourneyE2eTest {
         const val SESSION_NAME: String = "issue869-fake-agent"
         const val FAKE_AGENT_READY: String = "FAKE-AGENT-READY"
         const val FAKE_AGENT_SUBMITTED: String = "FAKE-AGENT SUBMITTED: "
+
+        // Issue #1350: how long to poll the authoritative `capture-pane -p` for the
+        // input box to clear after the submit Enter (the fake-agent renders the
+        // cleared box asynchronously). Mirrors the 8s bound the mid-flow
+        // [waitForSidecarCaptureEmptyInput] already uses.
+        const val INPUT_CLEARED_AFTER_SUBMIT_TIMEOUT_MS: Long = 8_000L
 
         val HOST_ROW_TIMEOUT_MS: Long =
             if (TerminalTestTimeouts.isRunningOnCi()) 60_000L else 20_000L

--- a/app/src/test/java/com/pocketshell/app/composer/PromptComposerViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/PromptComposerViewModelTest.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
@@ -623,6 +624,91 @@ class PromptComposerViewModelTest {
             PromptComposerViewModel.AttachmentUploadState.Idle,
             vm.uiState.value.attachmentUpload,
         )
+    }
+
+    // -- Issue #1350: Send clears the draft for EVERY prompt shape --------
+    //
+    // Class-coverage guard for the maintainer's dogfood annoyance ("the next
+    // dictation/typing appends to stale text"). `clearComposerForHandoff`
+    // (issue #971 single-representation hand-off) empties the editable draft the
+    // instant a Send is dispatched, and it is length/shape-INDEPENDENT. These
+    // pin that invariant across the whole class — short, long/wrapping,
+    // multi-line, and attachment-bearing — so a future change can't
+    // reintroduce a stale draft for one shape (e.g. a wrapped long prompt).
+
+    @Test
+    fun sendClearsDraftForShortPrompt() = runTest {
+        assertSendClearsDraft("deploy the staging build now")
+    }
+
+    @Test
+    fun sendClearsDraftForLongWrappingPrompt() = runTest {
+        assertSendClearsDraft(
+            "please carefully refactor the authentication middleware module so that " +
+                "every single inbound request is fully validated against the brand new " +
+                "rotating session token format and structured audit logging schema before " +
+                "it is ever allowed to reach the request handler layer or any downstream " +
+                "service in the pipeline today",
+        )
+    }
+
+    @Test
+    fun sendClearsDraftForMultiLinePrompt() = runTest {
+        assertSendClearsDraft(
+            "first line of the plan\nsecond line continues it\nthird and final line",
+        )
+    }
+
+    @Test
+    fun sendClearsDraftForAttachmentBearingPrompt() = runTest {
+        val vm = newVm()
+        val sends = mutableListOf<PromptComposerViewModel.SendRequest>()
+        val job = launch { vm.sendRequests.collect { sends += it } }
+        vm.onDraftChange("review these carefully and report anything suspicious you find")
+        vm.attachFiles(count = 2) {
+            Result.success(
+                listOf(
+                    "~/.pocketshell/attachments/host-1/20260601-120000-01-report.txt",
+                    "~/.pocketshell/attachments/host-1/20260601-120000-02-data.csv",
+                ),
+            )
+        }
+        advanceUntilIdle()
+        assertEquals(2, vm.uiState.value.attachments.size)
+
+        vm.requestSend(withEnter = true)
+        advanceUntilIdle()
+
+        // Both the draft text AND the staged attachment tiles clear on hand-off.
+        assertEquals("", vm.uiState.value.draft)
+        assertTrue(vm.uiState.value.attachments.isEmpty())
+        assertTrue(vm.uiState.value.sendInFlight)
+        // The composed prompt that actually went out still carried the clean text
+        // (the paths are folded into the outgoing text at send time, #544).
+        assertEquals(1, sends.size)
+        assertTrue(sends.single().text.contains("review these"))
+        job.cancelAndJoin()
+    }
+
+    private suspend fun TestScope.assertSendClearsDraft(prompt: String) {
+        val vm = newVm()
+        val sends = mutableListOf<PromptComposerViewModel.SendRequest>()
+        val job = launch { vm.sendRequests.collect { sends += it } }
+        vm.onDraftChange(prompt)
+        assertEquals(prompt, vm.uiState.value.draft)
+
+        vm.requestSend(withEnter = true)
+        advanceUntilIdle()
+
+        // The editor is emptied the instant the send is handed off to the queue
+        // (issue #971 single-representation), regardless of prompt length/shape —
+        // so the next dictation/typing starts from a clean field.
+        assertEquals("", vm.uiState.value.draft)
+        assertTrue(vm.uiState.value.sendInFlight)
+        // The exact prompt still travelled out in the SendRequest (nothing lost).
+        assertEquals(1, sends.size)
+        assertEquals(prompt, sends.single().text)
+        job.cancelAndJoin()
     }
 
     @Test


### PR DESCRIPTION
Closes #1350 — v0.4.25 release-blocker (reopened-class; test-only, no product change).

`AgentSubmitAckJourneyE2eTest` was chronically red due to an **over-broad assertion**, not a composer defect: `assertInputBoxEmptyAfterSubmit` read `transcriptText` (includes pane SCROLLBACK). On the phone grid the long prompt's earlier input-box renders scroll into history, so the tail lingered in scrollback even after the visible box cleared — short prompts fit the pane so never false-failed. Confirmed at source (`TerminalBuffer.getTranscriptText` folds scrollback; `capture-pane -p` is visible-only).

**Fix (test-only):** (1) the E2E now asserts the CURRENT VISIBLE input box via `capture-pane -p` (scrollback-immune; requires exactly `>`, gated by the submit marker — still fails a genuine unsent prompt); (2) 4 new JVM `PromptComposerViewModelTest` cases proving `clearComposerForHandoff` clears the draft on Send for short/long/multi-line/attachment.

**Verification (reviewer APPROVED, non-masking confirmed):** product clear is genuine + unchanged — `cp`-neutralizing the product `draft=""` fails all 4 JVM tests (red→green); new E2E assertion still load-bearing (can't false-pass); `:app:testDebugUnitTest` 187/0 (4 new run); only 2 test files changed, no production diff. On-device green deferred to CI's emulator lane (tag-gate). Reviewer: https://github.com/alexeygrigorev/pocketshell/issues/1350#issuecomment-4913087079