### PR TITLE
test: structural de-flake — drain the VM's own coroutine roots in @After (#1355)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -4583,6 +4583,72 @@ public class TmuxSessionViewModel @Inject constructor(
         onCleared()
     }
 
+    /**
+     * Issue #1355 test seam — the STRUCTURAL fix for the recurring
+     * `TmuxSessionViewModelTest` coroutine-leak-across-test-boundary flake
+     * (`IllegalStateException` at `TestMainDispatcher.kt:72`,
+     * "Dispatchers.Main is used concurrently with setting it").
+     *
+     * ## Why the prior four point-fixes kept whack-a-moling
+     *
+     * The suite's `@After` drains three INJECTED collaborator scopes to
+     * quiescence before the rule's `resetMain()` — `factoryScope` (#708),
+     * `defaultTeardownScope` (#1085), and `agentTailScope` (#1168) — but it
+     * never drained the VM's OWN coroutine roots. `viewModelScope` is cancelled
+     * only by the framework's `ViewModel.clear()`; the test seam [clearForTest]
+     * calls [onCleared] DIRECTLY, so `viewModelScope` and its child
+     * [bridgeScope] are NOT cancelled by teardown. Any
+     * `viewModelScope`/`bridgeScope` launch that hops to a REAL background
+     * dispatcher (e.g. the IO-dispatcher `withContext{ dao.getById(...) }`
+     * create-session / profiles fetches, or a `NonCancellable`
+     * teardown/detach/lease-release launch routed through
+     * [launchContainedTeardown]) therefore survives `@After` and, on
+     * completion, re-dispatches its continuation onto `Dispatchers.Main` —
+     * touching the test Main dispatcher — during the NEXT test's `setMain`.
+     * That inter-test race is the flake; each prior fix chased ONE leaking
+     * test's dispatcher instead of the shared root.
+     *
+     * ## What these two seams do
+     *
+     * The drain runs test-side (the test owns the shared
+     * `TestCoroutineScheduler`). [cancelOwnScopesForTest] cancels every
+     * `viewModelScope` child (which transitively cancels [bridgeScope]'s
+     * `SupervisorJob`, itself a `viewModelScope` child, and every job under it);
+     * [activeOwnScopeChildCountForTest] reports how many are not yet complete.
+     *
+     * The test's `@After` alternates `cancel → scheduler.runCurrent() →
+     * Thread.sleep(1)` to a bounded deadline: `runCurrent()` (NEVER
+     * `advanceUntilIdle` — the #1110 lesson: advancing the clock trips the #793
+     * re-seed watchdog) drives the cancellation of the virtual-clock children
+     * AND the Main re-dispatch of any child that hopped to a REAL background
+     * dispatcher, while the `Thread.sleep(1)` yields wall-clock time for the
+     * real IO thread to finish before the next drain. It HARD-FAILS if the count
+     * never reaches zero — so a FUTURE leak (a new un-drained VM launch) is a
+     * DETERMINISTIC red instead of an intermittent inter-class Main-set race.
+     *
+     * `viewModelScope`'s children are on the test Main dispatcher, so a plain
+     * a plain blocking `join()` would deadlock (it never pumps the test
+     * scheduler); the `runCurrent` pump is why the drain must be test-side.
+     *
+     * Test-only: production teardown runs through [onCleared] + the framework's
+     * `viewModelScope` cancellation. Never called in production.
+     */
+    @androidx.annotation.VisibleForTesting
+    internal fun cancelOwnScopesForTest() {
+        viewModelScope.coroutineContext[Job]?.children?.forEach { it.cancel() }
+    }
+
+    /**
+     * Issue #1355 test seam — count of this VM's `viewModelScope`/[bridgeScope]
+     * children that are NOT yet complete (a cancelled child still running its
+     * IO-dispatcher `withContext` / `NonCancellable` block reports
+     * `!isCompleted`, so it is counted until the real hop finishes and its Main
+     * re-dispatch has run). The `@After` drain loops until this is zero.
+     */
+    @androidx.annotation.VisibleForTesting
+    internal fun activeOwnScopeChildCountForTest(): Int =
+        viewModelScope.coroutineContext[Job]?.children?.count { !it.isCompleted } ?: 0
+
     internal fun hasPendingReattachForTest(): Boolean = pendingReattach != null
 
     internal fun connectingSessionNameForTest(): String? = connectingTarget?.sessionName

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
@@ -387,6 +387,10 @@ class TmuxSessionViewModelTest {
 
     @After
     fun tearDown() {
+        // Issue #1355: snapshot the VMs BEFORE clearing the list so the
+        // structural own-scope drain below (inside `runBlocking`, before the
+        // rule's `resetMain()`) still has the handles.
+        val vmsToDrain = createdViewModels.toList()
         createdViewModels.asReversed().forEach { vm ->
             runCatching { vm.clearForTest() }
         }
@@ -442,6 +446,50 @@ class TmuxSessionViewModelTest {
             withTimeoutOrNull(SLOW_FEED_DRAIN_TIMEOUT_MS) {
                 agentTailScope.coroutineContext.job.children.forEach { it.join() }
             }
+        }
+        // Issue #1355: the STRUCTURAL fix. The three drains above only cover the
+        // INJECTED collaborator scopes (factory/teardown/agent-tail); they never
+        // drained the VM's OWN coroutine roots. `clearForTest()` calls
+        // `onCleared()` directly, which does NOT cancel `viewModelScope` (only
+        // the framework's `ViewModel.clear()` does that), so any
+        // `viewModelScope`/`bridgeScope` launch that hopped to a REAL background
+        // dispatcher (`withContext(Dispatchers.IO){ dao.getById }`, the
+        // `NonCancellable` teardown/detach launches) survives `@After` and
+        // re-dispatches its continuation onto `Dispatchers.Main` during the NEXT
+        // test's `setMain` — the inter-test leak (TestMainDispatcher:72) the
+        // prior four point-fixes (#708/#1085/#1168/#1289) kept chasing one test
+        // at a time. Draining each VM's OWN scopes here closes the whole CLASS.
+        //
+        // These children run on the test Main dispatcher (the shared virtual
+        // scheduler), so a `runBlocking { join() }` would deadlock (it never
+        // pumps that scheduler — that is why the prior drains work: their scopes
+        // are REAL `Dispatchers.IO`). Instead alternate `cancel → runCurrent →
+        // Thread.sleep(1)` to a bounded deadline: `runCurrent()` (NEVER
+        // `advanceUntilIdle` — advancing the clock trips the #793/#1110 re-seed
+        // watchdog) drives both the cancellations of the virtual-clock children
+        // AND the Main re-dispatch of any child that hopped to a real dispatcher,
+        // while the sleep yields wall-clock time for the real IO thread to
+        // finish before the next drain. Re-cancel each pass so a completion
+        // handler that re-spawns a `bridgeScope` child (the #1168 hand-back
+        // shape) is cancelled too. Runs while the rule's Main is still installed
+        // (before its `resetMain()`), so every real-thread Main touch happens now
+        // against a stable Main. HARD-FAIL if a VM never quiesces: a future real
+        // leak is then a DETERMINISTIC red, not an inter-class flake.
+        val issue1355Deadline = System.currentTimeMillis() + SLOW_FEED_DRAIN_TIMEOUT_MS
+        while (true) {
+            vmsToDrain.forEach { it.cancelOwnScopesForTest() }
+            scheduler.runCurrent()
+            val active = vmsToDrain.sumOf { it.activeOwnScopeChildCountForTest() }
+            if (active == 0) break
+            assertTrue(
+                "Issue #1355: $active TmuxSessionViewModel coroutine(s) did not quiesce within " +
+                    "${SLOW_FEED_DRAIN_TIMEOUT_MS}ms of @After — one would survive into the next " +
+                    "test's Dispatchers.setMain and race it (TestMainDispatcher:72, the " +
+                    "leak-across-test-boundary flake). Root-cause the new un-drained " +
+                    "viewModelScope/bridgeScope launch rather than adding another point-fix.",
+                System.currentTimeMillis() < issue1355Deadline,
+            )
+            Thread.sleep(1)
         }
         defaultTeardownScope.cancel()
     }


### PR DESCRIPTION
Closes #1355 — durable fix for the recurring `TmuxSessionViewModelTest` / `TestMainDispatcher.kt:72` coroutine-leak flake that has forced CI re-runs (point-fixed 4× before: #1289/#1168/#1110/#1001).

**Root cause:** `clearForTest()` calls `onCleared()` directly, but `viewModelScope` is cancelled only by the framework's `ViewModel.clear()` — never `onCleared()`. So the VM's own `viewModelScope`/`bridgeScope` children survived `@After`; any that hopped to a real `Dispatchers.IO` re-dispatched their continuation onto `Dispatchers.Main` during the NEXT test's `setMain`. The `@After` drained only the injected collaborator scopes, never the VM's OWN roots — the structural gap the prior patches missed.

**Fix (test-infra):** two `@VisibleForTesting` seams (`cancelOwnScopesForTest`, `activeOwnScopeChildCountForTest` — zero production callers, no behavior change) + an `@After` drain that cancels the VM's own roots, pumps `scheduler.runCurrent()` (not `advanceUntilIdle`, the #1110 lesson) to quiescence, and HARD-FAILS on any leaked child.

**Verification (reviewer APPROVED):** production inertness confirmed (grep: no prod callers); drain cancels `viewModelScope`/`bridgeScope` roots; backstop proven — a deliberate non-cancellable leak made `@After` hard-fail with the #1355 signature (red→green); 7× (impl) / 4× (reviewer) consecutive `--rerun-tasks` runs all 376/0. Reviewer: https://github.com/alexeygrigorev/pocketshell/issues/1355#issuecomment-4913264682