### PR TITLE
tmux: fix TmuxSessionScreen API-33/35 VerifyError (register-alloc regression from #1344) (#1362)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/TmuxSessionScreenArtVerifyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/TmuxSessionScreenArtVerifyE2eTest.kt
@@ -1,0 +1,92 @@
+package com.pocketshell.app.proof
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.lang.reflect.Modifier
+
+/**
+ * Issue #1362 (v0.4.25 RELEASE BLOCKER) — durable regression proof for the
+ * `TmuxSessionScreen` ART dex-verification failure.
+ *
+ * ## The bug this pins
+ * On the API-33 CI AVD the app threw, on EVERY session-screen open:
+ * ```
+ * java.lang.VerifyError: Verifier rejected class
+ *   com.pocketshell.app.tmux.TmuxSessionScreenKt:
+ *   ... TmuxSessionScreen(...) failed to verify:
+ *   [0x39D8] copy1 v19<-v300 type=Reference: androidx.compose.runtime.MutableState
+ *     at com.pocketshell.app.MainActivityKt.AppNavigator(MainActivity.kt:1574)
+ * ```
+ * The ART bytecode verifier REJECTS the `TmuxSessionScreen` composable because
+ * D8 allocated a `MutableState` reference into a wide (v256+) register and then
+ * emitted a `move-object/16`/`move-object/from16` of it that the verifier's
+ * register-type merge rejects. `AppNavigator` therefore crashed the instant any
+ * journey opened a session screen (all three emulator shards, both cold boots).
+ *
+ * The #1344 band-wording fix (68ac75b7) added the nested
+ * `disconnectEndpointLabel(user, host, port)` -> `failureReasonSentence(...)`
+ * computation INLINE inside the ~2800-line `TmuxSessionScreen` method; that
+ * changed D8's register allocation of the mega-method into the fatal wide-register
+ * MutableState-move shape. The #1362 fix hoists that computation into its own
+ * [com.pocketshell.app.tmux.SessionFailureBand] composable frame (keeping the
+ * #1344 "Disconnected from <endpoint>" wording verbatim), restoring an allocation
+ * that the verifier accepts.
+ *
+ * ## Why THIS test reproduces it (no proxy — process.md F2/G10)
+ * ART verifies a class's method bodies when the class is resolved on-device. This
+ * test forces that resolution+verification of the REAL production class that
+ * declares the crashing composable (`TmuxSessionScreenKt`), exactly the class
+ * `AppNavigator` resolves when it opens a session screen. On the broken build the
+ * class fails verification and the load throws `VerifyError` (RED); with the fix
+ * the class resolves + verifies clean (GREEN). No stand-in, no convenient proxy:
+ * it is the exact production class that crashed on-device.
+ *
+ * Deliberately NOT a MainActivity/Docker journey: the VerifyError fires at class
+ * resolution, BEFORE any SSH/tmux connection, so a full connected journey is not
+ * needed to trigger it — this is the cheapest deterministic reproduction. The
+ * broad emulator gate (every session-opening `*E2eTest`) is the on-device backstop
+ * for the full user path; this dedicated class-verify test is the focused,
+ * fast RED->GREEN pin. Wired into the per-push emulator journey gate via
+ * `scripts/ci-journey-suite.sh`. No `assumeTrue` / `assumeFalse(isRunningOnCi())`
+ * on the load-bearing assertion (process.md F3 / D33).
+ */
+@RunWith(AndroidJUnit4::class)
+class TmuxSessionScreenArtVerifyE2eTest {
+
+    @Test
+    fun tmuxSessionScreenComposableClassResolvesAndVerifiesOnDevice() {
+        val loader = requireNotNull(javaClass.classLoader) {
+            "no classloader available to resolve the production composable class"
+        }
+
+        // Class.forName(initialize = true) resolves AND (on ART) verifies the
+        // class that declares the crashing composable. On the #1362 broken build
+        // this throws java.lang.VerifyError here; with the fix it returns cleanly.
+        val cls = Class.forName(
+            "com.pocketshell.app.tmux.TmuxSessionScreenKt",
+            /* initialize = */ true,
+            loader,
+        )
+
+        // Touch the declared methods so the verifier must resolve the mega-method
+        // whose body was rejected on-device (its parameter/return descriptors are
+        // resolved here). getDeclaredMethods()/getParameterTypes() force the
+        // class's method table to fully resolve rather than staying lazy.
+        val composable = cls.declaredMethods.firstOrNull { method ->
+            method.name == "TmuxSessionScreen" && Modifier.isStatic(method.modifiers)
+        }
+        assertTrue(
+            "TmuxSessionScreenKt.TmuxSessionScreen must be declared and its class " +
+                "must verify on-device (issue #1362 VerifyError regression). If the " +
+                "class failed ART verification this line is never reached — the " +
+                "Class.forName above throws VerifyError first.",
+            composable != null,
+        )
+        // Resolve the parameter descriptors too — a second nudge to make ART touch
+        // the method fully. (No-op on a verified class; on a rejected class the
+        // load already failed above.)
+        composable?.parameterTypes
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
@@ -1821,21 +1821,27 @@ public fun TmuxSessionScreen(
             // sentence — never a raw exception string. The test tags
             // [TMUX_SESSION_ERROR_TAG] and [TMUX_SESSION_RECONNECT_TAG] make the
             // elements grep-able from connected disconnect+reconnect tests.
-            (surfaceState as? SessionSurfaceState.Failed)?.let { failed ->
-                FailedConnectionRow(
-                    // Issue #1344: host-qualify the generic disconnect so the band reads
-                    // the unified #145 "Disconnected from <user>@<host>:<port>." wording
-                    // (the maintainer's clear disconnected indicator) — restored after the
-                    // S3 fuse dropped it. The endpoint comes from this screen's target
-                    // coordinates, matching the VM's historical message exactly.
-                    message = failureReasonSentence(
-                        failed.reason,
-                        endpoint = disconnectEndpointLabel(user = user, host = host, port = port),
-                    ),
-                    onReconnect = { viewModel.reconnect() },
-                    canReconnect = canReconnect,
-                )
-            }
+            //
+            // Issue #1362 (v0.4.25 release blocker): the band is rendered by the
+            // dedicated [SessionFailureBand] sub-composable rather than inline here.
+            // The #1344 endpoint/message computation (the nested
+            // `disconnectEndpointLabel(user, host, port)` -> `failureReasonSentence`
+            // call) used to live inline in THIS mega-composable, which tipped
+            // TmuxSessionScreen's dex register frame into the API-33 ART verifier's
+            // v256+ wide-operand danger zone — a `move-object/16` of a MutableState
+            // from a v256+ register that the verifier rejected (VerifyError, crashing
+            // AppNavigator on every session-screen open). Hoisting the computation into
+            // its own composable frame keeps the #1344 "Disconnected from <endpoint>"
+            // wording verbatim while dropping the mega-method's register pressure. See
+            // [SessionFailureBand].
+            SessionFailureBand(
+                surfaceState = surfaceState,
+                user = user,
+                host = host,
+                port = port,
+                canReconnect = canReconnect,
+                onReconnect = { viewModel.reconnect() },
+            )
             // Per [D6]: render exactly one pane at a time. The
             // HorizontalPager renders only the visible page eagerly by
             // default; sibling panes are pre-loaded into the off-screen
@@ -5330,6 +5336,58 @@ internal fun FailedConnectionRow(
             }
         }
     }
+}
+
+/**
+ * Issue #1362 (v0.4.25 release blocker): the settled-failure band, hoisted out of
+ * the [TmuxSessionScreen] mega-composable into its OWN composable frame.
+ *
+ * This renders exactly what the inline `(surfaceState as? SessionSurfaceState.Failed)`
+ * block used to: the calm [FailedConnectionRow] with the #145/#1344 "Disconnected from
+ * <user>@<host>:<port>." wording (via [disconnectEndpointLabel] + [failureReasonSentence])
+ * and the #1322 Error/Gone-distinct curated text for the config-level reasons. Nothing
+ * about the produced UI changes — same band, same text, same tags.
+ *
+ * WHY it is a separate composable and not inline: the #1344 fix added the nested
+ * `disconnectEndpointLabel(user, host, port)` -> `failureReasonSentence(...)` computation
+ * INSIDE the ~2800-line `TmuxSessionScreen` method. `TmuxSessionScreen` dexes to a method
+ * that already uses >256 registers, so D8 must address some locals with wide (v256+)
+ * operands; the #1344 inline computation shifted D8's register allocation so that a
+ * `MutableState` reference landed in a wide register with a `move-object/from16 v19<-v300`
+ * that the API-33 ART bytecode verifier REJECTS (`VerifyError [0x39D8] copy1 v19<-v300
+ * type=Reference: androidx.compose.runtime.MutableState`), crashing `AppNavigator` the
+ * instant any journey opened a session screen (emulator tag-gate hard-red on all shards).
+ * The register COUNT is not itself the trigger — the pre-#1344 method verified fine at an
+ * even higher count — but the #1344 inline locals produced the fatal wide-register
+ * MutableState move. Giving the computation its own composable frame removes those locals
+ * from the giant method and restores an allocation the verifier accepts.
+ * [com.pocketshell.app.proof.TmuxSessionScreenArtVerifyE2eTest] pins this: it resolves +
+ * verifies this exact production class on an API-33 device and goes RED (VerifyError) on
+ * the broken build, GREEN with this hoist.
+ */
+@Composable
+internal fun SessionFailureBand(
+    surfaceState: SessionSurfaceState,
+    user: String,
+    host: String,
+    port: Int,
+    canReconnect: Boolean,
+    onReconnect: () -> Unit,
+) {
+    val failed = surfaceState as? SessionSurfaceState.Failed ?: return
+    FailedConnectionRow(
+        // Issue #1344: host-qualify the generic disconnect so the band reads the
+        // unified #145 "Disconnected from <user>@<host>:<port>." wording (the
+        // maintainer's clear disconnected indicator) — restored after the S3 fuse
+        // dropped it. The endpoint comes from this screen's target coordinates,
+        // matching the VM's historical message exactly.
+        message = failureReasonSentence(
+            failed.reason,
+            endpoint = disconnectEndpointLabel(user = user, host = host, port = port),
+        ),
+        onReconnect = onReconnect,
+        canReconnect = canReconnect,
+    )
 }
 
 /**

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -114,6 +114,18 @@ FQCN_PREFIX="com.pocketshell.app.proof"
 # CI-AVD wedge. The per-test `timeout_msec` backstop below stays as defense in
 # depth so ANY future wedge fails fast (~5 min) instead of hanging the job.
 JOURNEY_CLASSES=(
+  # Issue #1362 (v0.4.25 RELEASE BLOCKER): the ART dex-verification guard for the
+  # TmuxSessionScreen composable. The #1344 band-wording fix tipped the mega-
+  # composable's D8 register allocation into a wide (v256+) MutableState move-object
+  # that the API-33 ART verifier REJECTS (`VerifyError [0x39D8] copy1 v19<-v300`),
+  # crashing AppNavigator on EVERY session-screen open (all 3 emulator shards hard-
+  # red). This test resolves+verifies the exact production class on-device: RED
+  # (VerifyError) on the broken build, GREEN with the #1362 SessionFailureBand
+  # hoist. Fast + deterministic (no Docker/SSH — the crash is at class resolution,
+  # before any connection), so it belongs at the head of the per-push subset as the
+  # cheapest early-fail for a regression that would otherwise fail every journey
+  # below with the same VerifyError.
+  "$FQCN_PREFIX.TmuxSessionScreenArtVerifyE2eTest"
   "$FQCN_PREFIX.DeepLinkSessionSwitchE2eTest"
   # RE-ADDED (#710): the CI-AVD wedge was the unbounded VM-clear park teardown,
   # now bounded at SYNC_DETACH_TIMEOUT_MS. See the block comment above.


### PR DESCRIPTION
Closes #1362 — HARD v0.4.25 release-blocker (connection-core).

**Defect:** on the API-33 AND API-35 ART verifier, `TmuxSessionScreenKt` is rejected (`VerifyError [0x39D8] copy1 v19<-v300 type=Reference: MutableState`), crashing `AppNavigator` on every session-screen open. The emulator journey subset was hard-red — ~40 session-opening journeys (incl. #1344's `BackgroundResumeSocketDeath`) all died with this VerifyError BEFORE their logic ran; a portfwd journey that never opens the screen passed, proving it screen-specific.

**Root cause (subtle — not register count):** `TmuxSessionScreen` already dexes to >256 registers; #1344's inline `disconnectEndpointLabel` locals shifted D8's allocation so a `MutableState` landed in a wide register reached by a `move-object/from16` the verifier rejects.

**Fix (minimal, D28):** hoist the #1344 band into a new `SessionFailureBand` sub-composable → restores the known-good pre-#1344 register allocation. #1344 wording + #1322 distinctions untouched. (Full decompose of the >256-register mega-composable is filed as D28 epic #1363 for maintainer scheduling — NOT needed here.)

**Verification (reviewer APPROVED, personally drove red→green):** new `TmuxSessionScreenArtVerifyE2eTest` resolves the REAL production class via `Class.forName` (AppNavigator's native path) — RED on broken (exact `0x39D8`/`v19<-v300`), GREEN on fix, on BOTH a fresh API-33 AVD and the actual **API-35** CI image; wired into `ci-journey-suite.sh`. `TmuxSessionScreenTest` 115/0 (wording/distinction cases pass). Merge gate: the CI Emulator journey subset (API-35) green on this commit. Reviewer: https://github.com/alexeygrigorev/pocketshell/issues/1362#issuecomment-4914746854