### PR TITLE
tmux: avoid hot wakes for healthy sparse panes

### DIFF
--- a/app/src/main/java/com/pocketshell/app/tmux/StaleRenderSparseWakeBaselines.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/StaleRenderSparseWakeBaselines.kt
@@ -1,0 +1,42 @@
+package com.pocketshell.app.tmux
+
+/**
+ * Tracks sparse renders that the authoritative watchdog capture has already
+ * proven healthy, so later `%output` bursts do not shortcut a backed-off wait
+ * unless the local render gets materially worse.
+ */
+internal class StaleRenderSparseWakeBaselines {
+    private val renderedCharsByPane = mutableMapOf<String, Int>()
+
+    fun clear() {
+        renderedCharsByPane.clear()
+    }
+
+    fun remove(pane: TmuxPaneState) {
+        renderedCharsByPane.remove(pane.paneId)
+    }
+
+    fun rememberIfHealthySparse(pane: TmuxPaneState) {
+        val state = pane.terminalState
+        if (
+            state.surfaceIsBlackWhileModelHasContent() ||
+            state.visibleScreenIsBlankOrPartiallyBlank() ||
+            !state.visibleRenderMayHaveLostFrame()
+        ) {
+            remove(pane)
+            return
+        }
+        val renderedChars = state.renderedNonBlankCharCount()
+        if (renderedChars > 0) renderedCharsByPane[pane.paneId] = renderedChars else remove(pane)
+    }
+
+    fun renderLooksSuspect(pane: TmuxPaneState): Boolean {
+        val state = pane.terminalState
+        if (state.surfaceIsBlackWhileModelHasContent()) return true
+        if (!state.visibleRenderMayHaveLostFrame()) return false
+        if (state.visibleScreenIsBlankOrPartiallyBlank()) return true
+        val healthySparseChars = renderedCharsByPane[pane.paneId] ?: return true
+        val currentChars = state.renderedNonBlankCharCount()
+        return currentChars <= 0 || currentChars.toLong() * 4L < healthySparseChars.toLong() * 3L
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -1857,6 +1857,8 @@ public class TmuxSessionViewModel @Inject constructor(
     // trySend never suspends.
     private val staleRenderWatchdogWake = Channel<Unit>(Channel.CONFLATED)
 
+    private val staleRenderSparseWakeBaselines = StaleRenderSparseWakeBaselines()
+
     /**
      * Issue #1166 test seam: fire the stale-render watchdog wake directly, so a
      * JVM test can assert that a backed-off watchdog snaps to the hot cadence on a
@@ -11731,6 +11733,7 @@ public class TmuxSessionViewModel @Inject constructor(
         // A stale loop otherwise only self-terminates on its NEXT tick via
         // isCurrentRuntime (up to one full tick of double/triple captures per switch).
         staleRenderWatchdogJob?.cancel()
+        staleRenderSparseWakeBaselines.clear()
         staleRenderWatchdogJob = bridgeScope.launch {
             var tick = 0
             // Issue #1166: consecutive stable ticks drive the back-off interval.
@@ -11758,6 +11761,7 @@ public class TmuxSessionViewModel @Inject constructor(
                     // the back-off so the resume tick captures at the hot cadence.
                     stableTicks = 0
                     unverifiedStreak = 0
+                    staleRenderSparseWakeBaselines.clear()
                     tick += 1
                     continue
                 }
@@ -11767,6 +11771,7 @@ public class TmuxSessionViewModel @Inject constructor(
                 if (!shouldRunStaleRenderWatchdogCapture()) {
                     stableTicks = 0
                     unverifiedStreak = 0
+                    staleRenderSparseWakeBaselines.clear()
                     tick += 1
                     continue
                 }
@@ -11818,14 +11823,17 @@ public class TmuxSessionViewModel @Inject constructor(
                         HealOutcome.Healthy -> {
                             stableTicks += 1
                             unverifiedStreak = 0
+                            staleRenderSparseWakeBaselines.rememberIfHealthySparse(activePane)
                         }
                         HealOutcome.Healed -> {
                             stableTicks = 0
                             unverifiedStreak = 0
+                            staleRenderSparseWakeBaselines.remove(activePane)
                         }
                         HealOutcome.Unverified -> {
                             stableTicks = 0
                             unverifiedStreak += 1
+                            staleRenderSparseWakeBaselines.remove(activePane)
                             recordHealCaptureUnverified(activePane, unverifiedStreak)
                         }
                     }
@@ -11902,10 +11910,7 @@ public class TmuxSessionViewModel @Inject constructor(
      * the real capture-diff oracle a little sooner (a no-op heal), never a wrong heal.
      */
     private fun activeVisiblePaneRenderLooksSuspect(): Boolean {
-        val pane = activeVisiblePane() ?: return false
-        val state = pane.terminalState
-        return state.visibleRenderMayHaveLostFrame() ||
-            state.surfaceIsBlackWhileModelHasContent()
+        return activeVisiblePane()?.let(staleRenderSparseWakeBaselines::renderLooksSuspect) == true
     }
 
     /**

--- a/app/src/test/java/com/pocketshell/app/tmux/StaleRenderWatchdogGatingTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/StaleRenderWatchdogGatingTest.kt
@@ -68,6 +68,9 @@ import java.io.InputStream
  *  - [healthyStreamingOutputDoesNotCutBackedOffWaitShort]: the #1219 wake gate — a
  *    dense healthy pane's %output is IGNORED (no capture cuts the backed-off wait
  *    short), the direct counterpart of the black case below.
+ *  - [healthySparseStreamingOutputDoesNotCutBackedOffWaitShort]: issue #1164 follow-up —
+ *    a legitimately sparse-but-authoritatively-healthy streaming pane also ignores
+ *    %output wakes, so the broad local sparse predicate does not falsely pin it to 4s.
  *  - [fragmentsOverBlackStreamingPaneStillHealsWithinHotBound]: the LOAD-BEARING
  *    black-recovery guard — a fragments-over-black (#966/#1138/#1214) redraw on a
  *    STREAMING pane during a backed-off window STILL heals within ≤4s (its render is
@@ -515,6 +518,82 @@ class StaleRenderWatchdogGatingTest {
     }
 
     // -------------------------------------------------------------------------
+    // (5d) A SPARSE-BUT-HEALTHY streaming pane's %output also does NOT cut a
+    //      BACKED-OFF wait short. This is the issue #1164 false-positive audit:
+    //      [visibleRenderMayHaveLostFrame] deliberately pre-flags >3-line sparse
+    //      panes for reveal/resize, but the steady watchdog must not treat a pane
+    //      that the authoritative capture just confirmed HEALTHY as genuinely
+    //      suspect and keep it in the 4s hot path.
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun healthySparseStreamingOutputDoesNotCutBackedOffWaitShort() = runVmTest {
+        val sparseLines = sparseHealthyLines()
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%1").apply {
+            defaultCaptureResponse =
+                CommandResponse(number = 80L, output = sparseLines, isError = false)
+        }
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == "%1" }
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+
+        pane.terminalState.appendRemoteOutput(
+            sparseHealthyFrame(sparseLines).toByteArray(Charsets.US_ASCII),
+        )
+        advanceUntilIdle()
+        assertTrue(
+            "precondition: this pane is locally sparse enough to be pre-flagged by " +
+                "visibleRenderMayHaveLostFrame(), so a pure local wake gate would " +
+                "mistake it for suspect",
+            pane.terminalState.visibleRenderMayHaveLostFrame(),
+        )
+        assertFalse(
+            "precondition: the authoritative capture matches the sparse render, so " +
+                "this is a HEALTHY sparse pane, not fragments-over-black",
+            pane.terminalState.visibleRenderLostFrameVsCapture(sparseLines.joinToString("\n")),
+        )
+
+        vm.setStaleRenderWatchdogMaxTicksForTest(1000)
+        vm.setProcessForegroundForClearedForTest(true)
+        vm.setScreenInteractiveForTest(true)
+        val guard = requireNotNull(vm.currentRuntimeGuardForTest())
+        vm.armActivePaneStaleRenderWatchdogForTest(guard)
+        runCurrent()
+
+        // Matching captures at t=4s and t=12s confirm HEALTHY twice, putting the
+        // loop inside the 16s backed-off wait.
+        val before = client.captureCount()
+        advanceTimeBy(13 * 1000L)
+        runCurrent()
+        assertEquals("backed off to 2 healthy captures by t=13s", 2, client.captureCount() - before)
+
+        // Fresh sparse streaming output lands ~1s into the 16s wait. Because the
+        // pane was just authoritatively confirmed healthy and has not become
+        // locally worse, the wake must NOT shortcut the wait back to the 4s path.
+        val beforeWake = client.captureCount()
+        vm.recordPaneOutputActivityForTest("%1")
+        advanceTimeBy(2 * 1000L)
+        runCurrent()
+        assertEquals(
+            "REGRESSION (#1164): a HEALTHY but sparse streaming pane must NOT falsely " +
+                "look suspect to the wake gate and cut a backed-off wait short. No " +
+                "capture may land 2s into the 16s window; true suspect/UNVERIFIED " +
+                "recovery is covered by the black-pane tests. Captured " +
+                "${client.captureCount() - beforeWake}.",
+            0,
+            client.captureCount() - beforeWake,
+        )
+
+        advanceTimeBy(16 * 1000L)
+        runCurrent()
+        assertTrue(
+            "the backed-off tick still fires after the full interval",
+            client.captureCount() > beforeWake,
+        )
+    }
+
+    // -------------------------------------------------------------------------
     // (5b) A PARTIAL-BLACK REDRAW during a BACKED-OFF window HEALS within the hot
     //      bound (issue #1166 heal-latency fix, the #1138 no-black-screen bar). A
     //      redraw on device arrives AS %output, so it wakes the backed-off watchdog
@@ -725,6 +804,14 @@ class StaleRenderWatchdogGatingTest {
         append("scattered fragment B\r\n")
         append("scattered fragment C\r\n")
         append("3\r\n")
+    }
+
+    private fun sparseHealthyLines(): List<String> =
+        List(5) { "healthy sparse status row $it" }
+
+    private fun sparseHealthyFrame(lines: List<String>): String = buildString {
+        append(CLEAR_ONLY)
+        for (line in lines) append(line).append("\r\n")
     }
 
     private fun runVmTest(body: suspend TestScope.() -> Unit) = runTest {


### PR DESCRIPTION
## Summary
- remember a confirmed-healthy sparse render baseline after authoritative watchdog capture
- avoid cutting backed-off waits short for sparse panes that remain locally no worse
- preserve hot recovery for black, partial-black, divergent, and unverified capture paths

Refs #1164

## Verification
- ./gradlew :app:testDebugUnitTest --tests 'com.pocketshell.app.tmux.StaleRenderWatchdogGatingTest' --tests 'com.pocketshell.app.tmux.HealCaptureUnverifiedWatchdogTest'\n- git diff --check origin/main..HEAD