### PR TITLE
proof: locate reconnect affordance by tag

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/NetworkFaultProofBase.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/NetworkFaultProofBase.kt
@@ -281,9 +281,15 @@ abstract class NetworkFaultProofBase {
                 .isNotEmpty()
         }
         recordTiming("${label}_disconnect_visible_ms", SystemClock.elapsedRealtime() - start)
-        compose.onAllNodesWithText("Reconnect", useUnmergedTree = true).fetchSemanticsNodes().let {
-            assertTrue("expected Reconnect button for $label; found ${it.size}", it.isNotEmpty())
-        }
+        val reconnectActions = compose.onAllNodesWithTag(
+            TMUX_SESSION_RECONNECT_TAG,
+            useUnmergedTree = true,
+        )
+            .fetchSemanticsNodes()
+        assertTrue(
+            "expected reconnect affordance for $label; found ${reconnectActions.size}",
+            reconnectActions.isNotEmpty(),
+        )
     }
 
     protected fun tapReconnectAndWait(label: String) {


### PR DESCRIPTION
## Summary
- update the network-fault disconnect-band helper to assert the stable reconnect test tag
- stop depending on stale exact button copy while keeping the same reconnect affordance requirement

Refs #1293

## Verification
- ./gradlew :app:compileDebugAndroidTestKotlin
- ./gradlew :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.pocketshellNetworkFaultProofs=true -Pandroid.testInstrumentationRunnerArguments.class=com.pocketshell.app.proof.RideThroughInterruptionE2eTest#sustainedLinkCutReconnectsCleanlyWithoutHang
- git diff --check