### PR TITLE
hosts: guide first-host connection test

### DIFF
--- a/app/src/main/java/com/pocketshell/app/MainActivity.kt
+++ b/app/src/main/java/com/pocketshell/app/MainActivity.kt
@@ -48,6 +48,7 @@ import com.pocketshell.app.crash.CrashReporter
 import com.pocketshell.app.crash.CrashReportsScreen
 import com.pocketshell.app.diagnostics.DiagnosticEvents
 import com.pocketshell.app.hosts.AddEditHostScreen
+import com.pocketshell.app.hosts.FirstHostTestConnectScreen
 import com.pocketshell.app.hosts.HostListScreen
 import com.pocketshell.app.hosts.HostListViewModel
 import com.pocketshell.app.hosts.QrScannerScreen
@@ -1019,6 +1020,7 @@ private fun AppNavigator(
     when (val dest = activeDestination) {
         AppDestination.HostList -> HostListScreen(
             onAddHost = { navigate(AppDestination.AddHost) },
+            onAddFirstHost = { navigate(AppDestination.AddFirstHost) },
             onEditHost = { id -> navigate(AppDestination.EditHost(id)) },
             onOpenSettings = { navigate(AppDestination.Settings) },
             // Issue #116 (usage-panel Fix B): wire the cross-host usage
@@ -1085,6 +1087,40 @@ private fun AppNavigator(
             hostId = null,
             onDone = ::back,
             onScanQr = { navigate(AppDestination.Scan) },
+        )
+
+        AppDestination.AddFirstHost -> AddEditHostScreen(
+            hostId = null,
+            onDone = ::back,
+            onScanQr = { navigate(AppDestination.Scan) },
+            firstRunGuided = true,
+            onFirstRunHostSaved = { hostId -> replace(AppDestination.FirstHostTestConnect(hostId)) },
+        )
+
+        is AppDestination.FirstHostTestConnect -> FirstHostTestConnectScreen(
+            hostId = dest.hostId,
+            onBack = ::back,
+            onEditHost = { id -> replace(AppDestination.EditFirstHost(id)) },
+            onOpenHost = { host, keyPath, passphrase ->
+                navigate(
+                    AppDestination.FolderList(
+                        hostId = host.id,
+                        hostName = host.name,
+                        hostname = host.hostname,
+                        port = host.port,
+                        username = host.username,
+                        keyPath = keyPath,
+                        passphrase = passphrase,
+                    ),
+                )
+            },
+        )
+
+        is AppDestination.EditFirstHost -> AddEditHostScreen(
+            hostId = dest.hostId,
+            onDone = { replace(AppDestination.FirstHostTestConnect(dest.hostId)) },
+            firstRunGuided = true,
+            onFirstRunHostSaved = { hostId -> replace(AppDestination.FirstHostTestConnect(hostId)) },
         )
 
         is AppDestination.EditHost -> AddEditHostScreen(
@@ -2163,6 +2199,9 @@ internal fun importPayloadFromIntent(intent: Intent?): String? {
 internal fun AppDestination.timingName(): String = when (this) {
     AppDestination.HostList -> "HostList"
     AppDestination.AddHost -> "AddHost"
+    AppDestination.AddFirstHost -> "AddFirstHost"
+    is AppDestination.FirstHostTestConnect -> "FirstHostTestConnect(hostId=$hostId)"
+    is AppDestination.EditFirstHost -> "EditFirstHost(hostId=$hostId)"
     is AppDestination.EditHost -> "EditHost"
     AppDestination.Scan -> "Scan"
     AppDestination.CrashReports -> "CrashReports"
@@ -2185,6 +2224,9 @@ internal fun AppDestination.timingName(): String = when (this) {
 internal fun AppDestination.diagnosticRouteName(): String = when (this) {
     AppDestination.HostList -> "HostList"
     AppDestination.AddHost -> "AddHost"
+    AppDestination.AddFirstHost -> "AddFirstHost"
+    is AppDestination.FirstHostTestConnect -> "FirstHostTestConnect"
+    is AppDestination.EditFirstHost -> "EditFirstHost"
     is AppDestination.EditHost -> "EditHost"
     AppDestination.Scan -> "Scan"
     AppDestination.CrashReports -> "CrashReports"
@@ -2207,6 +2249,15 @@ internal fun AppDestination.diagnosticRouteName(): String = when (this) {
 internal fun AppDestination.crashReportContext(): CrashReportContext = when (this) {
     AppDestination.HostList -> CrashReportContext(screen = "Hosts")
     AppDestination.AddHost -> CrashReportContext(screen = "Add host")
+    AppDestination.AddFirstHost -> CrashReportContext(screen = "Add first host")
+    is AppDestination.FirstHostTestConnect -> CrashReportContext(
+        screen = "First host test connection",
+        action = "hostId=$hostId",
+    )
+    is AppDestination.EditFirstHost -> CrashReportContext(
+        screen = "Edit first host",
+        action = "hostId=$hostId",
+    )
     is AppDestination.EditHost -> CrashReportContext(
         screen = "Edit host",
         action = "hostId=$hostId",

--- a/app/src/main/java/com/pocketshell/app/hosts/AddEditHostScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/hosts/AddEditHostScreen.kt
@@ -48,6 +48,8 @@ import com.pocketshell.uikit.components.PocketShellButton
 import com.pocketshell.uikit.components.ScreenHeader
 import com.pocketshell.uikit.theme.PocketShellColors
 import com.pocketshell.uikit.theme.PocketShellDensity
+import com.pocketshell.uikit.theme.PocketShellShapes
+import com.pocketshell.uikit.theme.PocketShellSpacing
 import com.pocketshell.uikit.theme.PocketShellType
 
 /**
@@ -71,6 +73,7 @@ const val ADD_HOST_KEY_SEARCH_EMPTY_TAG = "add-host-key-search-empty"
 const val ADD_HOST_DETAILS_TAB_TAG = "add-host-tab-details"
 const val ADD_HOST_MANAGE_KEYS_TAB_TAG = "add-host-tab-manage-keys"
 const val ADD_HOST_SCAN_QR_TAG = "add-host-scan-qr"
+const val FIRST_HOST_WIZARD_STEPS_TAG = "first-host-wizard:steps"
 
 /**
  * Default placeholder shown in the optional "Usage command" field
@@ -116,6 +119,8 @@ fun AddEditHostScreen(
     hostId: Long?,
     onDone: () -> Unit,
     onScanQr: (() -> Unit)? = null,
+    firstRunGuided: Boolean = false,
+    onFirstRunHostSaved: (Long) -> Unit = {},
     modifier: Modifier = Modifier,
     viewModel: AddEditHostViewModel = hiltViewModel(),
     keyManagementViewModel: SshKeysViewModel = hiltViewModel(),
@@ -129,7 +134,14 @@ fun AddEditHostScreen(
         if (hostId != null) viewModel.loadHost(hostId)
     }
     LaunchedEffect(state.saved) {
-        if (state.saved) onDone()
+        if (state.saved) {
+            val savedHostId = state.savedHostId
+            if (firstRunGuided && savedHostId != null) {
+                onFirstRunHostSaved(savedHostId)
+            } else {
+                onDone()
+            }
+        }
     }
 
     // Per-field focus requesters drive the "move focus to the first
@@ -196,7 +208,12 @@ fun AddEditHostScreen(
     ) {
         Column(modifier = Modifier.fillMaxSize()) {
             FormHeader(
-                title = if (hostId == null) "Add host" else "Edit host",
+                title = when {
+                    firstRunGuided && hostId == null -> "Add first host"
+                    firstRunGuided -> "Edit first host"
+                    hostId == null -> "Add host"
+                    else -> "Edit host"
+                },
                 onScanQr = onScanQr.takeIf { hostId == null },
                 onBack = {
                     if (selectedTab == AddEditHostTab.ManageKeys) {
@@ -208,6 +225,10 @@ fun AddEditHostScreen(
                     }
                 },
             )
+
+            if (firstRunGuided) {
+                FirstHostWizardSteps(activeStep = FirstHostWizardStep.Host)
+            }
 
             AddEditHostTabs(
                 selectedTab = selectedTab,
@@ -333,6 +354,48 @@ fun AddEditHostScreen(
                     )
                 }
             }
+        }
+    }
+}
+
+internal enum class FirstHostWizardStep {
+    Key,
+    Host,
+    Test,
+}
+
+@Composable
+internal fun FirstHostWizardSteps(
+    activeStep: FirstHostWizardStep,
+    modifier: Modifier = Modifier,
+) {
+    val steps = listOf(
+        FirstHostWizardStep.Key to "Key",
+        FirstHostWizardStep.Host to "Host",
+        FirstHostWizardStep.Test to "Test",
+    )
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(PocketShellColors.Surface)
+            .padding(horizontal = PocketShellSpacing.lg, vertical = PocketShellSpacing.sm)
+            .testTag(FIRST_HOST_WIZARD_STEPS_TAG),
+        horizontalArrangement = Arrangement.spacedBy(PocketShellSpacing.sm),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        steps.forEachIndexed { index, (step, label) ->
+            val selected = step == activeStep
+            Text(
+                text = "${index + 1}. $label",
+                color = if (selected) PocketShellColors.OnAccent else PocketShellColors.TextSecondary,
+                style = MaterialTheme.typography.labelSmall,
+                modifier = Modifier
+                    .background(
+                        color = if (selected) PocketShellColors.Accent else PocketShellColors.SurfaceElev,
+                        shape = PocketShellShapes.small,
+                    )
+                    .padding(horizontal = PocketShellSpacing.sm, vertical = PocketShellSpacing.xs),
+            )
         }
     }
 }

--- a/app/src/main/java/com/pocketshell/app/hosts/AddEditHostViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/hosts/AddEditHostViewModel.kt
@@ -97,6 +97,7 @@ data class HostFormState(
     val firstInvalidField: HostFormField? = null,
     val error: String? = null,
     val saved: Boolean = false,
+    val savedHostId: Long? = null,
 )
 
 /**
@@ -167,6 +168,8 @@ class AddEditHostViewModel @Inject constructor(
                 fieldErrors = HostFormErrors(),
                 firstInvalidField = null,
                 error = null,
+                saved = false,
+                savedHostId = null,
             )
             _state.value = loaded
             // Capture the loaded form as the dirty-state baseline so a
@@ -259,13 +262,15 @@ class AddEditHostViewModel @Inject constructor(
                     usageCommandOverride = usageOverride,
                 )
             }
-            if (editingId != null) {
+            val savedId = if (editingId != null) {
                 hostDao.update(host)
+                editingId
             } else {
                 hostDao.insert(host)
             }
             _state.value = _state.value.copy(
                 saved = true,
+                savedHostId = savedId,
                 fieldErrors = HostFormErrors(),
                 firstInvalidField = null,
                 error = null,

--- a/app/src/main/java/com/pocketshell/app/hosts/FirstHostTestConnectScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/hosts/FirstHostTestConnectScreen.kt
@@ -1,0 +1,303 @@
+package com.pocketshell.app.hosts
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.pocketshell.core.ssh.KnownHostsPolicy
+import com.pocketshell.core.ssh.SshConnection
+import com.pocketshell.core.ssh.SshKey
+import com.pocketshell.core.storage.dao.HostDao
+import com.pocketshell.core.storage.dao.SshKeyDao
+import com.pocketshell.core.storage.entity.HostEntity
+import com.pocketshell.core.storage.entity.SshKeyEntity
+import com.pocketshell.uikit.components.ButtonVariant
+import com.pocketshell.uikit.components.LoadingIndicator
+import com.pocketshell.uikit.components.PocketShellButton
+import com.pocketshell.uikit.components.ScreenHeader
+import com.pocketshell.uikit.components.SpinnerSize
+import com.pocketshell.uikit.theme.PocketShellColors
+import com.pocketshell.uikit.theme.PocketShellSpacing
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.io.File
+import javax.inject.Inject
+
+const val FIRST_HOST_TEST_CONNECT_SCREEN_TAG = "first-host-test-connect:screen"
+const val FIRST_HOST_TEST_CONNECT_RETRY_TAG = "first-host-test-connect:retry"
+const val FIRST_HOST_TEST_CONNECT_EDIT_TAG = "first-host-test-connect:edit"
+const val FIRST_HOST_TEST_CONNECT_OPEN_TAG = "first-host-test-connect:open"
+
+private const val FIRST_HOST_TEST_CONNECT_TIMEOUT_MS = 10_000
+
+@Composable
+fun FirstHostTestConnectScreen(
+    hostId: Long,
+    onBack: () -> Unit,
+    onEditHost: (Long) -> Unit,
+    onOpenHost: (HostEntity, keyPath: String, passphrase: CharArray?) -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: FirstHostTestConnectViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsState()
+    LaunchedEffect(hostId) {
+        viewModel.start(hostId)
+    }
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(PocketShellColors.Background)
+            .testTag(FIRST_HOST_TEST_CONNECT_SCREEN_TAG),
+    ) {
+        ScreenHeader(
+            title = "Test connection",
+            leading = {
+                Box(
+                    modifier = Modifier
+                        .size(40.dp)
+                        .clickable(role = Role.Button, onClick = onBack),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = "‹",
+                        color = PocketShellColors.TextSecondary,
+                        style = MaterialTheme.typography.headlineSmall,
+                    )
+                }
+            },
+        )
+        FirstHostWizardSteps(activeStep = FirstHostWizardStep.Test)
+
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(PocketShellSpacing.lg),
+            verticalArrangement = Arrangement.spacedBy(PocketShellSpacing.md),
+        ) {
+            Text(
+                text = state.host?.name ?: "First host",
+                color = PocketShellColors.Text,
+                style = MaterialTheme.typography.titleMedium,
+            )
+            when (val status = state.status) {
+                FirstHostTestStatus.Idle,
+                FirstHostTestStatus.Testing,
+                -> TestingConnection()
+
+                FirstHostTestStatus.Success -> {
+                    Text(
+                        text = "Connection works.",
+                        color = PocketShellColors.Green,
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                    PocketShellButton(
+                        text = "Open host",
+                        onClick = {
+                            val host = state.host ?: return@PocketShellButton
+                            val key = state.key ?: return@PocketShellButton
+                            onOpenHost(host, key.privateKeyPath, null)
+                        },
+                        variant = ButtonVariant.Primary,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .testTag(FIRST_HOST_TEST_CONNECT_OPEN_TAG),
+                    )
+                }
+
+                FirstHostTestStatus.NeedsPassphrase -> {
+                    Text(
+                        text = "This SSH key needs a passphrase. Open the host from the hosts list to unlock it.",
+                        color = PocketShellColors.TextSecondary,
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                    PocketShellButton(
+                        text = "Open from hosts",
+                        onClick = onBack,
+                        variant = ButtonVariant.Primary,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .testTag(FIRST_HOST_TEST_CONNECT_OPEN_TAG),
+                    )
+                }
+
+                is FirstHostTestStatus.Failed -> {
+                    Text(
+                        text = status.message,
+                        color = PocketShellColors.Red,
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(PocketShellSpacing.md),
+                    ) {
+                        PocketShellButton(
+                            text = "Retry",
+                            onClick = { viewModel.start(hostId, force = true) },
+                            variant = ButtonVariant.Primary,
+                            modifier = Modifier
+                                .weight(1f)
+                                .testTag(FIRST_HOST_TEST_CONNECT_RETRY_TAG),
+                        )
+                        PocketShellButton(
+                            text = "Edit",
+                            onClick = { onEditHost(hostId) },
+                            variant = ButtonVariant.Secondary,
+                            modifier = Modifier
+                                .weight(1f)
+                                .testTag(FIRST_HOST_TEST_CONNECT_EDIT_TAG),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TestingConnection() {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(PocketShellSpacing.md),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        LoadingIndicator.Spinner(size = SpinnerSize.Small)
+        Text(
+            text = "Testing SSH connection...",
+            color = PocketShellColors.TextSecondary,
+            style = MaterialTheme.typography.bodyMedium,
+        )
+    }
+}
+
+data class FirstHostTestConnectState(
+    val host: HostEntity? = null,
+    val key: SshKeyEntity? = null,
+    val status: FirstHostTestStatus = FirstHostTestStatus.Idle,
+)
+
+sealed interface FirstHostTestStatus {
+    data object Idle : FirstHostTestStatus
+    data object Testing : FirstHostTestStatus
+    data object Success : FirstHostTestStatus
+    data object NeedsPassphrase : FirstHostTestStatus
+    data class Failed(val message: String) : FirstHostTestStatus
+}
+
+@HiltViewModel
+class FirstHostTestConnectViewModel @Inject constructor(
+    private val hostDao: HostDao,
+    private val sshKeyDao: SshKeyDao,
+    private val tester: FirstHostConnectionTester,
+) : ViewModel() {
+    private val _state = MutableStateFlow(FirstHostTestConnectState())
+    val state: StateFlow<FirstHostTestConnectState> = _state.asStateFlow()
+
+    private var testingHostId: Long? = null
+
+    fun start(hostId: Long, force: Boolean = false) {
+        val current = _state.value
+        if (!force &&
+            testingHostId == hostId &&
+            current.status in setOf(FirstHostTestStatus.Testing, FirstHostTestStatus.Success)
+        ) {
+            return
+        }
+        testingHostId = hostId
+        _state.value = current.copy(status = FirstHostTestStatus.Testing)
+        viewModelScope.launch {
+            val host = hostDao.getById(hostId)
+            if (host == null) {
+                _state.value = FirstHostTestConnectState(
+                    status = FirstHostTestStatus.Failed("Host was not saved. Go back and add it again."),
+                )
+                return@launch
+            }
+            val key = sshKeyDao.getById(host.keyId)
+            if (key == null) {
+                _state.value = FirstHostTestConnectState(
+                    host = host,
+                    status = FirstHostTestStatus.Failed("SSH key is missing. Edit the host and choose a key."),
+                )
+                return@launch
+            }
+
+            _state.value = FirstHostTestConnectState(
+                host = host,
+                key = key,
+                status = FirstHostTestStatus.Testing,
+            )
+            if (key.hasPassphrase) {
+                _state.value = FirstHostTestConnectState(
+                    host = host,
+                    key = key,
+                    status = FirstHostTestStatus.NeedsPassphrase,
+                )
+                return@launch
+            }
+            val result = tester.test(host, key)
+            _state.value = if (result.isSuccess) {
+                FirstHostTestConnectState(host = host, key = key, status = FirstHostTestStatus.Success)
+            } else {
+                FirstHostTestConnectState(
+                    host = host,
+                    key = key,
+                    status = FirstHostTestStatus.Failed(
+                        friendlyConnectFailure(result.exceptionOrNull()),
+                    ),
+                )
+            }
+        }
+    }
+}
+
+open class FirstHostConnectionTester @Inject constructor() {
+    open suspend fun test(host: HostEntity, key: SshKeyEntity): Result<Unit> {
+        val file = File(key.privateKeyPath)
+        val exists = withContext(Dispatchers.IO) { file.exists() }
+        if (!exists) {
+            return Result.failure(IllegalStateException("SSH key file is missing"))
+        }
+        val session = SshConnection.connect(
+            host = host.hostname,
+            port = host.port,
+            user = host.username,
+            key = SshKey.Path(file),
+            passphrase = null,
+            knownHosts = KnownHostsPolicy.AcceptAll,
+            timeoutMs = FIRST_HOST_TEST_CONNECT_TIMEOUT_MS,
+        ).getOrElse { return Result.failure(it) }
+        session.close()
+        return Result.success(Unit)
+    }
+}
+
+internal fun friendlyConnectFailure(error: Throwable?): String {
+    val detail = error?.message?.takeIf { it.isNotBlank() }
+    val base = "Could not connect. Check the hostname, port, username, and SSH key, then retry."
+    return if (detail == null) base else "$base\n\n$detail"
+}

--- a/app/src/main/java/com/pocketshell/app/hosts/HostListScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/hosts/HostListScreen.kt
@@ -124,6 +124,7 @@ import kotlin.math.sin
 @Composable
 fun HostListScreen(
     onAddHost: () -> Unit,
+    onAddFirstHost: () -> Unit = onAddHost,
     onEditHost: (Long) -> Unit,
     onOpenSettings: () -> Unit = {},
     /**
@@ -586,7 +587,7 @@ fun HostListScreen(
 
                 if (hosts.isEmpty()) {
                     item(key = "hosts:empty") {
-                        EmptyHostList(onAddHost = onAddHost)
+                        EmptyHostList(onAddHost = onAddFirstHost)
                     }
                 } else {
                     items(hosts, key = { "host:" + it.id }) { host ->

--- a/app/src/main/java/com/pocketshell/app/nav/AppDestination.kt
+++ b/app/src/main/java/com/pocketshell/app/nav/AppDestination.kt
@@ -27,6 +27,18 @@ sealed interface AppDestination {
     /** Add a new host. `hostId` is null. */
     data object AddHost : AppDestination
 
+    /**
+     * Guided first-run add-host flow. Reached from the empty-state primary
+     * action only; the ordinary add-host FAB keeps routing to [AddHost].
+     */
+    data object AddFirstHost : AppDestination
+
+    /** Test the freshly-created first host before dropping the user on the list. */
+    data class FirstHostTestConnect(val hostId: Long) : AppDestination
+
+    /** Edit a first-run host, then return to the guided connection test. */
+    data class EditFirstHost(val hostId: Long) : AppDestination
+
     /** Edit the host identified by [hostId]. */
     data class EditHost(val hostId: Long) : AppDestination
 

--- a/app/src/test/java/com/pocketshell/app/hosts/AddEditHostViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/hosts/AddEditHostViewModelTest.kt
@@ -80,6 +80,7 @@ class AddEditHostViewModelTest {
         // The UnconfinedTestDispatcher runs the viewModelScope launch
         // synchronously, so the state has already settled.
         assertTrue(vm.state.value.saved)
+        assertNotNull(vm.state.value.savedHostId)
         assertNull(vm.state.value.error)
         assertTrue(vm.state.value.fieldErrors.isClean())
 
@@ -91,6 +92,30 @@ class AddEditHostViewModelTest {
         assertEquals(2222, hosts[0].port)
         assertEquals("alexey", hosts[0].username)
         assertEquals(keyId, hosts[0].keyId)
+    }
+
+    @Test
+    fun loadHost_clearsPriorSavedSignal() = runTest {
+        val keyId = db.sshKeyDao().insert(
+            SshKeyEntity(name = "k", privateKeyPath = "/tmp/k"),
+        )
+        val vm = AddEditHostViewModel(db.hostDao(), db.sshKeyDao())
+        vm.updateState {
+            it.copy(
+                name = "prod",
+                hostname = "example.com",
+                username = "alexey",
+                selectedKeyId = keyId,
+            )
+        }
+        vm.save()
+        assertTrue(vm.state.value.saved)
+        assertNotNull(vm.state.value.savedHostId)
+
+        vm.loadHost(requireNotNull(vm.state.value.savedHostId))
+
+        assertFalse(vm.state.value.saved)
+        assertNull(vm.state.value.savedHostId)
     }
 
     @Test

--- a/app/src/test/java/com/pocketshell/app/hosts/FirstHostTestConnectViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/hosts/FirstHostTestConnectViewModelTest.kt
@@ -1,0 +1,181 @@
+package com.pocketshell.app.hosts
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.pocketshell.core.storage.AppDatabase
+import com.pocketshell.core.storage.entity.HostEntity
+import com.pocketshell.core.storage.entity.SshKeyEntity
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class FirstHostTestConnectViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private lateinit var db: AppDatabase
+
+    @Before
+    fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            AppDatabase::class.java,
+        )
+            .setQueryExecutor(Runnable::run)
+            .setTransactionExecutor(Runnable::run)
+            .allowMainThreadQueries()
+            .build()
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun start_reportsSuccess_whenTesterConnects() = runTest {
+        val keyId = db.sshKeyDao().insert(SshKeyEntity(name = "lab", privateKeyPath = "/tmp/lab"))
+        val hostId = db.hostDao().insert(
+            HostEntity(
+                name = "Lab",
+                hostname = "127.0.0.1",
+                port = 2222,
+                username = "test",
+                keyId = keyId,
+            ),
+        )
+        val tester = RecordingTester(Result.success(Unit))
+        val vm = FirstHostTestConnectViewModel(db.hostDao(), db.sshKeyDao(), tester)
+
+        vm.start(hostId)
+
+        val state = vm.state.value
+        assertEquals(FirstHostTestStatus.Success, state.status)
+        assertEquals("Lab", state.host?.name)
+        assertEquals("lab", state.key?.name)
+        assertEquals(1, tester.calls)
+    }
+
+    @Test
+    fun start_reportsActionableFailure_whenTesterFails() = runTest {
+        val keyId = db.sshKeyDao().insert(SshKeyEntity(name = "lab", privateKeyPath = "/tmp/lab"))
+        val hostId = db.hostDao().insert(
+            HostEntity(
+                name = "Lab",
+                hostname = "127.0.0.1",
+                port = 1,
+                username = "test",
+                keyId = keyId,
+            ),
+        )
+        val tester = RecordingTester(Result.failure(IllegalStateException("Connection refused")))
+        val vm = FirstHostTestConnectViewModel(db.hostDao(), db.sshKeyDao(), tester)
+
+        vm.start(hostId)
+
+        val failed = vm.state.value.status as FirstHostTestStatus.Failed
+        assertTrue(failed.message.contains("Check the hostname, port, username, and SSH key"))
+        assertTrue(failed.message.contains("Connection refused"))
+    }
+
+    @Test
+    fun start_retestsSameHost_afterPriorFailure() = runTest {
+        val keyId = db.sshKeyDao().insert(SshKeyEntity(name = "lab", privateKeyPath = "/tmp/lab"))
+        val hostId = db.hostDao().insert(
+            HostEntity(
+                name = "Lab",
+                hostname = "127.0.0.1",
+                port = 1,
+                username = "test",
+                keyId = keyId,
+            ),
+        )
+        val tester = QueueTester(
+            listOf(
+                Result.failure(IllegalStateException("Connection refused")),
+                Result.success(Unit),
+            ),
+        )
+        val vm = FirstHostTestConnectViewModel(db.hostDao(), db.sshKeyDao(), tester)
+
+        vm.start(hostId)
+        assertTrue(vm.state.value.status is FirstHostTestStatus.Failed)
+
+        vm.start(hostId)
+
+        assertEquals(FirstHostTestStatus.Success, vm.state.value.status)
+        assertEquals(2, tester.calls)
+    }
+
+    @Test
+    fun start_reportsNeedsPassphrase_withoutCallingTester_whenKeyIsEncrypted() = runTest {
+        val keyId = db.sshKeyDao().insert(
+            SshKeyEntity(name = "lab", privateKeyPath = "/tmp/lab", hasPassphrase = true),
+        )
+        val hostId = db.hostDao().insert(
+            HostEntity(
+                name = "Lab",
+                hostname = "127.0.0.1",
+                port = 2222,
+                username = "test",
+                keyId = keyId,
+            ),
+        )
+        val tester = RecordingTester(Result.success(Unit))
+        val vm = FirstHostTestConnectViewModel(db.hostDao(), db.sshKeyDao(), tester)
+
+        vm.start(hostId)
+
+        assertEquals(FirstHostTestStatus.NeedsPassphrase, vm.state.value.status)
+        assertEquals("Lab", vm.state.value.host?.name)
+        assertEquals("lab", vm.state.value.key?.name)
+        assertEquals(0, tester.calls)
+    }
+
+    @Test
+    fun start_reportsMissingHost_withoutCallingTester() = runTest {
+        val tester = RecordingTester(Result.success(Unit))
+        val vm = FirstHostTestConnectViewModel(db.hostDao(), db.sshKeyDao(), tester)
+
+        vm.start(999L)
+
+        val failed = vm.state.value.status as FirstHostTestStatus.Failed
+        assertEquals("Host was not saved. Go back and add it again.", failed.message)
+        assertEquals(0, tester.calls)
+    }
+
+    private class RecordingTester(
+        private val result: Result<Unit>,
+    ) : FirstHostConnectionTester() {
+        var calls: Int = 0
+            private set
+
+        override suspend fun test(host: HostEntity, key: SshKeyEntity): Result<Unit> {
+            calls++
+            return result
+        }
+    }
+
+    private class QueueTester(
+        results: List<Result<Unit>>,
+    ) : FirstHostConnectionTester() {
+        private val remaining = ArrayDeque(results)
+        var calls: Int = 0
+            private set
+
+        override suspend fun test(host: HostEntity, key: SshKeyEntity): Result<Unit> {
+            calls++
+            return remaining.removeFirst()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- route the first-host empty-state action into a guided add-host flow
- continue saved first hosts to a connection-test screen with retry/edit/success paths
- keep normal add/edit host behavior on the existing FAB and host edit route

Refs #1243

## Verification
- ./gradlew :app:testDebugUnitTest --tests 'com.pocketshell.app.hosts.AddEditHostViewModelTest' --tests 'com.pocketshell.app.hosts.FirstHostTestConnectViewModelTest' :app:compileDebugKotlin :app:compileDebugAndroidTestKotlin\n- git diff --check origin/main..HEAD\n\n## Notes\n- This is still a partial #1243 slice: it does not yet fold bootstrap/notification setup into the guided route or add the Docker end-to-end journey.