### PR TITLE
connection: add inert network-loss vocabulary

### DIFF
--- a/app/src/main/java/com/pocketshell/app/tmux/connection/ConnectionEffectDriver.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/connection/ConnectionEffectDriver.kt
@@ -508,6 +508,7 @@ class ConnectionEffectDriver(
                 is ConnectionState.Attaching -> "Attaching"
                 is ConnectionState.Live -> "Live"
                 is ConnectionState.Backgrounded -> "Backgrounded"
+                is ConnectionState.NetworkLossSuspended -> "NetworkLossSuspended"
                 is ConnectionState.Reattaching -> "Reattaching"
                 is ConnectionState.Reconnecting -> "Reconnecting(${state.attempt})"
                 is ConnectionState.Gone -> "Gone"

--- a/app/src/main/java/com/pocketshell/app/tmux/connection/ConnectionManager.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/connection/ConnectionManager.kt
@@ -265,6 +265,7 @@ class ConnectionManager(
             // Backgrounded keeps the prior live surface in the inline VM; project to Connected
             // for comparison parity.
             is ConnectionState.Backgrounded -> "Connected"
+            is ConnectionState.NetworkLossSuspended -> "Connected"
             is ConnectionState.Reattaching -> "Reconnecting"
             is ConnectionState.Reconnecting -> "Reconnecting"
             is ConnectionState.Gone -> "Failed"

--- a/app/src/main/java/com/pocketshell/app/tmux/connection/ConnectionStatusProjection.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/connection/ConnectionStatusProjection.kt
@@ -132,7 +132,9 @@ internal object ConnectionStatusProjection {
             // anyway — so we follow the inline state to keep the backgrounded surface
             // byte-identical. The controller's grace deadline still governs the next
             // foreground reattach-vs-reconnect decision.
-            is ConnectionState.Backgrounded -> inlineStatus
+            is ConnectionState.Backgrounded,
+            is ConnectionState.NetworkLossSuspended,
+            -> inlineStatus
             // APPROVED #685 divergence #1 (silent recovery): a recoverable drop leaves
             // the controller Reattaching/Reconnecting → a CALM Reconnecting band, NOT
             // the scary Failed. The display payload (attempt/reason) is the inline

--- a/shared/core-connection/src/main/java/com/pocketshell/core/connection/ConnectionController.kt
+++ b/shared/core-connection/src/main/java/com/pocketshell/core/connection/ConnectionController.kt
@@ -151,6 +151,8 @@ class ConnectionController(
             is ConnectionEvent.TransportDropped -> onTransportDropped(current, event)
             ConnectionEvent.TransportLive -> onTransportLive(current)
             is ConnectionEvent.NetworkChanged -> onNetworkChanged(current, event)
+            ConnectionEvent.NetworkLost -> current
+            ConnectionEvent.NetworkRestored -> current
             is ConnectionEvent.TargetGone -> onTargetGone(current, event)
             is ConnectionEvent.SeedLanded -> onSeedLanded(current, event)
         }
@@ -368,6 +370,7 @@ fun ConnectionState.targetIdOrNull(): SessionId? = when (this) {
     is ConnectionState.Attaching -> targetId
     is ConnectionState.Live -> targetId
     is ConnectionState.Backgrounded -> targetId
+    is ConnectionState.NetworkLossSuspended -> targetId
     is ConnectionState.Reattaching -> targetId
     is ConnectionState.Reconnecting -> targetId
     is ConnectionState.Gone -> targetId
@@ -381,11 +384,48 @@ fun ConnectionState.hostOrNull(): HostKey? = when (this) {
     is ConnectionState.Attaching -> host
     is ConnectionState.Live -> host
     is ConnectionState.Backgrounded -> host
+    is ConnectionState.NetworkLossSuspended -> host
     is ConnectionState.Reattaching -> host
     is ConnectionState.Reconnecting -> host
     is ConnectionState.Gone -> host
     is ConnectionState.Unreachable -> host
 }
+
+/**
+ * Pure foundation reducer for the future S4 network-loss path.
+ *
+ * This is intentionally NOT called by [ConnectionController.submit] in this prep
+ * slice. It defines the contract that VM/app wiring will later fold in:
+ * live loss holds without redial; restore rides through when the transport is
+ * proven alive, otherwise it enters the silent reconnect ladder.
+ */
+fun reduceNetworkLossRestore(
+    current: ConnectionState,
+    event: ConnectionEvent,
+    liveness: LivenessPort,
+    nowMs: Long,
+): ConnectionState =
+    when (event) {
+        ConnectionEvent.NetworkLost ->
+            if (current is ConnectionState.Live) {
+                ConnectionState.NetworkLossSuspended(current.host, current.targetId, sinceMs = nowMs)
+            } else {
+                current
+            }
+
+        ConnectionEvent.NetworkRestored ->
+            if (current is ConnectionState.NetworkLossSuspended) {
+                if (liveness.transportProvenAliveRecently()) {
+                    ConnectionState.Live(current.host, current.targetId)
+                } else {
+                    ConnectionState.Reconnecting(current.host, current.targetId, attempt = 1)
+                }
+            } else {
+                current
+            }
+
+        else -> current
+    }
 
 /**
  * Debug-only dispatcher-confinement guard for [ConnectionController]

--- a/shared/core-connection/src/main/java/com/pocketshell/core/connection/ConnectionModel.kt
+++ b/shared/core-connection/src/main/java/com/pocketshell/core/connection/ConnectionModel.kt
@@ -114,6 +114,25 @@ sealed interface ConnectionEvent {
      */
     data class NetworkChanged(val validatedHandoff: Boolean) : ConnectionEvent
 
+    /**
+     * Device network connectivity was lost entirely. This is distinct from
+     * [NetworkChanged]: there is no validated replacement network to redial onto,
+     * so Slice S4 holds the existing lease/content in [ConnectionState.NetworkLossSuspended].
+     *
+     * In this prep slice the event is vocabulary only: [ConnectionController.submit]
+     * treats it as a no-op until VM/app wiring migrates the network reducer.
+     */
+    data object NetworkLost : ConnectionEvent
+
+    /**
+     * Device network connectivity was restored after [NetworkLost]. Slice S4 will
+     * decide between ride-through and silent reconnect with an injected [LivenessPort].
+     *
+     * In this prep slice the event is vocabulary only: [ConnectionController.submit]
+     * treats it as a no-op until VM/app wiring migrates the network reducer.
+     */
+    data object NetworkRestored : ConnectionEvent
+
     /** Target session was deleted elsewhere (#666). Must NOT resurrect it. */
     data class TargetGone(val targetId: SessionId) : ConnectionEvent
 
@@ -150,6 +169,20 @@ sealed interface ConnectionState {
      * deadline is a stored value compared on the next [ConnectionEvent.Foreground].
      */
     data class Backgrounded(
+        val host: HostKey,
+        val targetId: SessionId,
+        val sinceMs: Long,
+    ) : ConnectionState
+
+    /**
+     * The device network is down while a session was live. Hold the lease/content
+     * without redialing or surfacing an honest error; probes/effects can suspend
+     * until [ConnectionEvent.NetworkRestored] resolves the state.
+     *
+     * This state is inert in this prep slice: [ConnectionController.submit] never
+     * transitions into it. The pure network-loss reducer owns the future contract.
+     */
+    data class NetworkLossSuspended(
         val host: HostKey,
         val targetId: SessionId,
         val sinceMs: Long,

--- a/shared/core-connection/src/main/java/com/pocketshell/core/connection/Ports.kt
+++ b/shared/core-connection/src/main/java/com/pocketshell/core/connection/Ports.kt
@@ -42,6 +42,15 @@ interface TransportPort {
 }
 
 /**
+ * Synchronous transport-liveness signal for resolving network restore without
+ * over-eager redial. It mirrors the existing liveness probe IO shape, but stays
+ * controller-facing and pure for JVM reducer tests.
+ */
+fun interface LivenessPort {
+    fun transportProvenAliveRecently(): Boolean
+}
+
+/**
  * Wraps `TmuxClient`. The controller observes the transport-drop oracle; the VM
  * adapter owns the control-mode IO.
  */

--- a/shared/core-connection/src/main/java/com/pocketshell/core/connection/RevealStateMachine.kt
+++ b/shared/core-connection/src/main/java/com/pocketshell/core/connection/RevealStateMachine.kt
@@ -127,6 +127,8 @@ class RevealStateMachine {
      *    (honest error only when exhausted).
      *  - [ConnectionState.Backgrounded] -> keep the current state (no reveal change
      *    while backgrounded; the next foreground re-drives this).
+     *  - [ConnectionState.NetworkLossSuspended] -> keep the current state (calm
+     *    network hold; the restored edge re-drives this).
      *  - [ConnectionState.Idle] -> ignored (a [navigate] drives the target, not Idle).
      */
     fun onConnectionState(connectionState: ConnectionState) {
@@ -142,6 +144,7 @@ class RevealStateMachine {
         val next = when (connectionState) {
             is ConnectionState.Idle,
             is ConnectionState.Backgrounded,
+            is ConnectionState.NetworkLossSuspended,
             -> _state.value // no reveal change
 
             is ConnectionState.Connecting,

--- a/shared/core-connection/src/test/java/com/pocketshell/core/connection/ConnectionControllerNetworkLossRestoreTest.kt
+++ b/shared/core-connection/src/test/java/com/pocketshell/core/connection/ConnectionControllerNetworkLossRestoreTest.kt
@@ -1,0 +1,210 @@
+package com.pocketshell.core.connection
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ConnectionControllerNetworkLossRestoreTest {
+
+    private val host = HostKey("alice@host:22")
+    private val target = SessionId("A")
+    private val other = SessionId("B")
+    private val nowMs = 12_345L
+
+    @Test
+    fun `NetworkLost on Live suspends - holds lease and does not redial`() {
+        val liveness = FakeLivenessPort()
+
+        val next = reduceNetworkLossRestore(
+            ConnectionState.Live(host, target),
+            ConnectionEvent.NetworkLost,
+            liveness,
+            nowMs,
+        )
+
+        assertEquals(ConnectionState.NetworkLossSuspended(host, target, sinceMs = nowMs), next)
+        assertEquals("loss should not query liveness", 0, liveness.queryCount)
+    }
+
+    @Test
+    fun `NetworkLost stamps sinceMs from injected clock value`() {
+        val next = reduceNetworkLossRestore(
+            ConnectionState.Live(host, target),
+            ConnectionEvent.NetworkLost,
+            FakeLivenessPort(),
+            nowMs = 77L,
+        )
+
+        assertEquals(ConnectionState.NetworkLossSuspended(host, target, sinceMs = 77L), next)
+    }
+
+    @Test
+    fun `NetworkLost outside Live is a no-op for every existing state class`() {
+        val states = listOf(
+            ConnectionState.Idle,
+            ConnectionState.Connecting(host, target),
+            ConnectionState.Attaching(host, target),
+            ConnectionState.Backgrounded(host, target, sinceMs = 1L),
+            ConnectionState.NetworkLossSuspended(host, target, sinceMs = 2L),
+            ConnectionState.Reattaching(host, target),
+            ConnectionState.Reconnecting(host, target, attempt = 2),
+            ConnectionState.Gone(host, target),
+            ConnectionState.Unreachable(host, target),
+        )
+        val liveness = FakeLivenessPort()
+
+        states.forEach { state ->
+            assertEquals(state, reduceNetworkLossRestore(state, ConnectionEvent.NetworkLost, liveness, nowMs))
+        }
+        assertEquals("loss no-ops should not query liveness", 0, liveness.queryCount)
+    }
+
+    @Test
+    fun `NetworkRestored with transport proven alive rides through to Live - no redial`() {
+        val liveness = FakeLivenessPort(provenAlive = true)
+
+        val next = reduceNetworkLossRestore(
+            ConnectionState.NetworkLossSuspended(host, target, sinceMs = 1L),
+            ConnectionEvent.NetworkRestored,
+            liveness,
+            nowMs,
+        )
+
+        assertEquals(ConnectionState.Live(host, target), next)
+        assertEquals(1, liveness.queryCount)
+    }
+
+    @Test
+    fun `NetworkRestored with dead transport redials via the silent Reconnecting ladder`() {
+        val liveness = FakeLivenessPort(provenAlive = false)
+
+        val next = reduceNetworkLossRestore(
+            ConnectionState.NetworkLossSuspended(host, target, sinceMs = 1L),
+            ConnectionEvent.NetworkRestored,
+            liveness,
+            nowMs,
+        )
+
+        assertEquals(ConnectionState.Reconnecting(host, target, attempt = 1), next)
+        assertEquals(1, liveness.queryCount)
+    }
+
+    @Test
+    fun `NetworkRestored outside suspended state is a no-op and does not query liveness`() {
+        val states = listOf(
+            ConnectionState.Idle,
+            ConnectionState.Connecting(host, target),
+            ConnectionState.Attaching(host, target),
+            ConnectionState.Live(host, target),
+            ConnectionState.Backgrounded(host, target, sinceMs = 1L),
+            ConnectionState.Reattaching(host, target),
+            ConnectionState.Reconnecting(host, target, attempt = 2),
+            ConnectionState.Gone(host, target),
+            ConnectionState.Unreachable(host, target),
+        )
+        val liveness = FakeLivenessPort(provenAlive = true)
+
+        states.forEach { state ->
+            assertEquals(state, reduceNetworkLossRestore(state, ConnectionEvent.NetworkRestored, liveness, nowMs))
+        }
+        assertEquals(0, liveness.queryCount)
+    }
+
+    @Test
+    fun `foreign event is a no-op and does not query liveness`() {
+        val state = ConnectionState.NetworkLossSuspended(host, target, sinceMs = 1L)
+        val liveness = FakeLivenessPort(provenAlive = true)
+
+        val next = reduceNetworkLossRestore(
+            state,
+            ConnectionEvent.SeedLanded(target, "%0"),
+            liveness,
+            nowMs,
+        )
+
+        assertEquals(state, next)
+        assertEquals(0, liveness.queryCount)
+    }
+
+    @Test
+    fun `new vocabulary carries target and host through helper accessors`() {
+        val state = ConnectionState.NetworkLossSuspended(host, target, sinceMs = nowMs)
+
+        assertEquals(target, state.targetIdOrNull())
+        assertEquals(host, state.hostOrNull())
+    }
+
+    @Test
+    fun `submit treats NetworkLost and NetworkRestored as inert vocabulary while Live`() {
+        val transport = FakeTransportPort()
+        val controller = controller(transport).bringLive(transport)
+        assertEquals(ConnectionState.Live(host, target), controller.state.value)
+        val reveal = controller.revealGate.value
+
+        controller.submit(ConnectionEvent.NetworkLost)
+        assertEquals(ConnectionState.Live(host, target), controller.state.value)
+        assertEquals(reveal, controller.revealGate.value)
+
+        controller.submit(ConnectionEvent.NetworkRestored)
+        assertEquals(ConnectionState.Live(host, target), controller.state.value)
+        assertEquals(reveal, controller.revealGate.value)
+    }
+
+    @Test
+    fun `submit treats NetworkLost and NetworkRestored as inert vocabulary while Backgrounded`() {
+        val transport = FakeTransportPort()
+        val controller = controller(transport).bringLive(transport)
+        controller.submit(ConnectionEvent.Background)
+        val backgrounded = controller.state.value
+        val reveal = controller.revealGate.value
+
+        controller.submit(ConnectionEvent.NetworkLost)
+        assertEquals(backgrounded, controller.state.value)
+        assertEquals(reveal, controller.revealGate.value)
+
+        controller.submit(ConnectionEvent.NetworkRestored)
+        assertEquals(backgrounded, controller.state.value)
+        assertEquals(reveal, controller.revealGate.value)
+    }
+
+    @Test
+    fun `NetworkLossSuspended reveal projection keeps current reveal state`() {
+        val machine = RevealStateMachine()
+        machine.navigate(target, "A")
+        machine.onConnectionState(ConnectionState.Attaching(host, target))
+        machine.onSeed(Seed(target, "%0", "content"))
+        assertEquals(
+            RevealState.Live(target, "A", listOf(Seed(target, "%0", "content"))),
+            machine.state.value,
+        )
+
+        machine.onConnectionState(ConnectionState.NetworkLossSuspended(host, target, sinceMs = nowMs))
+
+        assertEquals(
+            RevealState.Live(target, "A", listOf(Seed(target, "%0", "content"))),
+            machine.state.value,
+        )
+    }
+
+    @Test
+    fun `NetworkLossSuspended reveal projection still drops foreign target states`() {
+        val machine = RevealStateMachine()
+        machine.navigate(target, "A")
+
+        machine.onConnectionState(ConnectionState.NetworkLossSuspended(host, other, sinceMs = nowMs))
+
+        assertEquals(RevealState.Navigating(target, "A"), machine.state.value)
+    }
+
+    private fun controller(
+        transport: FakeTransportPort = FakeTransportPort(),
+    ) = ConnectionController(FakeClock(), transport)
+
+    private fun ConnectionController.bringLive(transport: FakeTransportPort): ConnectionController {
+        transport.setWarm(host, false)
+        submit(ConnectionEvent.Enter(host, target))
+        transport.setWarm(host, true)
+        submit(ConnectionEvent.TransportLive)
+        submit(ConnectionEvent.SeedLanded(target, "%0"))
+        return this
+    }
+}

--- a/shared/core-connection/src/test/java/com/pocketshell/core/connection/Fakes.kt
+++ b/shared/core-connection/src/test/java/com/pocketshell/core/connection/Fakes.kt
@@ -30,3 +30,17 @@ class FakeTransportPort : TransportPort {
 
     override fun isWarm(host: HostKey): Boolean = host in warmHosts
 }
+
+class FakeLivenessPort(private var provenAlive: Boolean = false) : LivenessPort {
+    var queryCount: Int = 0
+        private set
+
+    fun setProvenAlive(value: Boolean) {
+        provenAlive = value
+    }
+
+    override fun transportProvenAliveRecently(): Boolean {
+        queryCount++
+        return provenAlive
+    }
+}


### PR DESCRIPTION
## Summary
- add inert core-connection vocabulary for NetworkLost, NetworkRestored, NetworkLossSuspended, and LivenessPort
- keep ConnectionController.submit behavior unchanged by treating the new events as no-ops
- add pure reducer and reveal-state coverage for the future S4 network-loss migration
- add tiny app exhaustive mappings without wiring the new reducer into the VM/app path

Refs #1327

## Verification
- ./gradlew --rerun-tasks :shared:core-connection:testDebugUnitTest :shared:core-connection:testReleaseUnitTest :app:compileDebugKotlin
- git diff --check origin/main..HEAD

## Notes
- This is the inert core prep slice only. It does not migrate `reduceNetworkChanged` or touch `TmuxSessionViewModel`.