### PR TITLE
tmux: add agent quick replies

### DIFF
--- a/app/src/main/java/com/pocketshell/app/tmux/AgentQuickReply.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/AgentQuickReply.kt
@@ -1,0 +1,80 @@
+package com.pocketshell.app.tmux
+
+internal data class AgentQuickReply(
+    val label: String,
+    val payload: String,
+)
+
+internal fun agentQuickRepliesForVisibleText(visibleText: String): List<AgentQuickReply> {
+    val tail = visibleText
+        .lineSequence()
+        .map { it.trimEnd() }
+        .filter { it.isNotBlank() }
+        .toList()
+        .takeLast(AGENT_QUICK_REPLY_TAIL_LINES)
+        .joinToString("\n")
+        .trim()
+    if (tail.isBlank()) return emptyList()
+
+    numberedReplies(tail).takeIf { it.isNotEmpty() }?.let { return it }
+    if (YesNoCueRegex.containsMatchIn(tail) && ApprovalPromptCueRegex.containsMatchIn(tail)) {
+        return listOf(
+            AgentQuickReply(label = "Yes", payload = "y"),
+            AgentQuickReply(label = "No", payload = "n"),
+        )
+    }
+    if (EnterCueRegex.containsMatchIn(tail)) {
+        return listOf(AgentQuickReply(label = "Enter", payload = "\r"))
+    }
+    return emptyList()
+}
+
+private fun numberedReplies(text: String): List<AgentQuickReply> {
+    val matches = NumberedOptionRegex.findAll(text).toList()
+    if (matches.size < 2) return emptyList()
+
+    val promptCue = NumberedPromptCueRegex.containsMatchIn(text)
+    val replies = matches
+        .take(AGENT_QUICK_REPLY_MAX_OPTIONS)
+        .mapNotNull { match ->
+            val digit = match.groupValues[1]
+            val option = match.groupValues[2].trim()
+            val label = numberedOptionLabel(option, digit)
+            if (label == digit && !promptCue) return@mapNotNull null
+            AgentQuickReply(label = label, payload = digit)
+        }
+    return replies.takeIf { it.size >= 2 }.orEmpty()
+}
+
+private fun numberedOptionLabel(option: String, fallback: String): String {
+    val lower = option.lowercase()
+    return when {
+        lower.startsWith("yes") || lower.startsWith("approve") || lower.startsWith("allow") -> "Yes"
+        lower.startsWith("no") || lower.startsWith("deny") || lower.startsWith("reject") -> "No"
+        lower.startsWith("continue") || lower.startsWith("proceed") -> "Continue"
+        else -> fallback
+    }
+}
+
+private val YesNoCueRegex = Regex(
+    pattern = """(?i)(\(\s*y\s*/\s*n\s*\)|\[\s*y\s*/\s*n\s*]|yes\s*/\s*no|y\s*/\s*n)""",
+)
+
+private val ApprovalPromptCueRegex = Regex(
+    pattern = """(?i)\b(proceed|approve|approval|allow|permission|execute|apply|accept|confirm|continue|do you want)\b""",
+)
+
+private val EnterCueRegex = Regex(
+    pattern = """(?i)\b(press|hit|tap)?\s*(enter|return)\s+(to\s+)?(continue|proceed|submit)\b""",
+)
+
+private val NumberedOptionRegex = Regex(
+    pattern = """(?im)(?:^|\s)([1-9])\s*[\.)]\s*([^\n\r]{1,40})""",
+)
+
+private val NumberedPromptCueRegex = Regex(
+    pattern = """(?i)\b(choose|select|option|permission|approve|approval|proceed|continue|allow|deny|execute|apply|accept|confirm)\b""",
+)
+
+private const val AGENT_QUICK_REPLY_TAIL_LINES = 6
+private const val AGENT_QUICK_REPLY_MAX_OPTIONS = 5

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
@@ -213,6 +213,7 @@ import com.pocketshell.uikit.theme.PocketShellDensity
 import com.pocketshell.uikit.theme.PocketShellShapes
 import com.pocketshell.uikit.theme.PocketShellSpacing
 import com.pocketshell.uikit.theme.PocketShellType
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import kotlin.math.abs
 
@@ -921,6 +922,15 @@ public fun TmuxSessionScreen(
     // agent pane in the current attach.
     val paletteAgent: AgentKind? = liveAgentForPane
         ?: currentPaneId?.let { stickyAgentForPane[it] }
+    val surfaceTerminalState = surfacePane?.terminalState
+    val visibleTerminalText by remember(currentPaneId, surfaceTerminalState) {
+        surfaceTerminalState?.flowOfVisibleScreenText ?: flowOf("")
+    }.collectAsState(
+        initial = surfaceTerminalState?.visibleScreenTextSnapshot().orEmpty(),
+    )
+    val agentQuickReplies = remember(visibleTerminalText) {
+        agentQuickRepliesForVisibleText(visibleTerminalText)
+    }
 
     // Issue #770: the set of engine slash-commands the terminal should make
     // tappable for the visible pane. Sourced verbatim from [AgentCommandCatalog]
@@ -2360,6 +2370,30 @@ public fun TmuxSessionScreen(
                 onCancelChoice = viewModel::cancelAssistantChoice,
             )
 
+            run {
+                val pane = surfacePane
+                val quickReplyInputEnabled = sessionLive &&
+                    pane != null &&
+                    !showMicSheet &&
+                    !showConversation &&
+                    tmuxSessionHasPositiveAgentEvidence(
+                        hasLiveDetection = currentDetection != null,
+                        hasStickyAgent = paletteAgent != null,
+                        recordedAgentKind = tmuxSessionRecordedAgentKind(currentSessionRecordedKind),
+                    )
+                if (quickReplyInputEnabled && agentQuickReplies.isNotEmpty()) {
+                    AgentQuickReplyRow(
+                        replies = agentQuickReplies,
+                        onReply = { reply ->
+                            viewModel.writeInputToPane(
+                                pane.paneId,
+                                reply.payload.toByteArray(Charsets.UTF_8),
+                            )
+                        },
+                    )
+                }
+            }
+
             // Issue #810 (hard-cut, D22) — the prompt composer affordance is
             // ALWAYS present on every live session, structurally independent of
             // agent-detection state, pane-cache state (`surfacePane == null` /
@@ -3056,6 +3090,40 @@ internal fun detectedPortForwardNavigation(remotePort: Int): PortForwardNavigati
     )
 
 /**
+ * Issue #1235: one-tap agent approval replies. This is a regular bottom band,
+ * not an overlay, so it reserves its own height above the composer/bottom
+ * controls and never covers terminal content or the input controls.
+ */
+@Composable
+internal fun AgentQuickReplyRow(
+    replies: List<AgentQuickReply>,
+    onReply: (AgentQuickReply) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (replies.isEmpty()) return
+    val scrollState = rememberScrollState()
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(color = PocketShellColors.Surface)
+            .border(width = 1.dp, color = PocketShellColors.Border)
+            .horizontalScroll(scrollState)
+            .padding(horizontal = PocketShellSpacing.sm, vertical = PocketShellSpacing.xs)
+            .testTag(TMUX_AGENT_QUICK_REPLY_ROW_TAG),
+        horizontalArrangement = Arrangement.spacedBy(PocketShellSpacing.sm),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        replies.forEachIndexed { index, reply ->
+            CommandChip(
+                label = reply.label,
+                onClick = { onReply(reply) },
+                modifier = Modifier.testTag(TMUX_AGENT_QUICK_REPLY_CHIP_TAG_PREFIX + index),
+            )
+        }
+    }
+}
+
+/**
  * Issue #448 (epic #432 slice C): the non-blocking "forward this newly
  * detected port?" overlay. Rendered as a bottom banner that floats over
  * the terminal — it deliberately does not cover the terminal viewport or
@@ -3664,6 +3732,19 @@ internal fun tmuxSessionIsAgentPane(
     hasLiveDetection: Boolean,
     presumedAgent: Boolean,
 ): Boolean = hasLiveDetection || presumedAgent
+
+/**
+ * Issue #1235: quick-reply chips must require positive agent evidence. The
+ * broader [tmuxSessionIsAgentPane] predicate intentionally includes the
+ * optimistic presumed-agent default, which is useful for keeping agent chrome
+ * reachable during detection but too broad for injecting reply chips over an
+ * unknown shell.
+ */
+internal fun tmuxSessionHasPositiveAgentEvidence(
+    hasLiveDetection: Boolean,
+    hasStickyAgent: Boolean,
+    recordedAgentKind: Boolean,
+): Boolean = hasLiveDetection || hasStickyAgent || recordedAgentKind
 
 /**
  * Issue #805 (regression of #744/#716): whether the bottom-bar chrome wears its
@@ -4914,6 +4995,8 @@ internal const val TMUX_CHANGE_KIND_BUTTON_TAG = "tmux:session:change-kind-butto
 internal const val TMUX_DETECTED_PORT_OVERLAY_TAG = "tmux:session:detected-port-overlay"
 internal const val TMUX_DETECTED_PORT_FORWARD_TAG = "tmux:session:detected-port-forward"
 internal const val TMUX_DETECTED_PORT_DISMISS_TAG = "tmux:session:detected-port-dismiss"
+internal const val TMUX_AGENT_QUICK_REPLY_ROW_TAG = "tmux:agent-quick-replies"
+internal const val TMUX_AGENT_QUICK_REPLY_CHIP_TAG_PREFIX = "tmux:agent-quick-reply:"
 /**
  * Issue #165: stable test tags for the SSH-handshake progress overlay
  * rendered while [TmuxSessionViewModel.ConnectionStatus] is Connecting.

--- a/app/src/test/java/com/pocketshell/app/tmux/AgentQuickReplyTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/AgentQuickReplyTest.kt
@@ -1,0 +1,84 @@
+package com.pocketshell.app.tmux
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AgentQuickReplyTest {
+    @Test
+    fun yNPromptOffersYesAndNoLiteralKeys() {
+        val replies = agentQuickRepliesForVisibleText("Proceed with this command? (y/n)")
+
+        assertEquals(
+            listOf(
+                AgentQuickReply("Yes", "y"),
+                AgentQuickReply("No", "n"),
+            ),
+            replies,
+        )
+    }
+
+    @Test
+    fun numberedYesNoPromptSendsChoiceDigits() {
+        val replies = agentQuickRepliesForVisibleText(
+            """
+            Approve tool call?
+            1. Yes
+            2. No
+            """.trimIndent(),
+        )
+
+        assertEquals(
+            listOf(
+                AgentQuickReply("Yes", "1"),
+                AgentQuickReply("No", "2"),
+            ),
+            replies,
+        )
+    }
+
+    @Test
+    fun enterPromptOffersEnterKey() {
+        val replies = agentQuickRepliesForVisibleText("Done. Press Enter to continue")
+
+        assertEquals(listOf(AgentQuickReply("Enter", "\r")), replies)
+    }
+
+    @Test
+    fun ordinaryNumberedOutputDoesNotOfferReplies() {
+        val replies = agentQuickRepliesForVisibleText(
+            """
+            Recent tasks:
+            1. Refactor parser
+            2. Update docs
+            3. Run tests
+            """.trimIndent(),
+        )
+
+        assertTrue(replies.isEmpty())
+    }
+
+    @Test
+    fun stalePromptOutsideVisibleTailIsIgnored() {
+        val replies = agentQuickRepliesForVisibleText(
+            """
+            Proceed with command? (y/n)
+            running step 1
+            running step 2
+            running step 3
+            running step 4
+            running step 5
+            running step 6
+            """.trimIndent(),
+        )
+
+        assertTrue(replies.isEmpty())
+    }
+
+    @Test
+    fun yesNoProseWithoutApprovalCueIsIgnored() {
+        val replies = agentQuickRepliesForVisibleText("Use yes/no examples in the docs.")
+
+        assertTrue(replies.isEmpty())
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionScreenTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionScreenTest.kt
@@ -993,6 +993,38 @@ class TmuxSessionScreenTest {
         assertTrue(!tmuxSessionIsAgentPane(hasLiveDetection = false, presumedAgent = false))
     }
 
+    @Test
+    fun quickReplyGateRequiresPositiveAgentEvidence() {
+        assertTrue(
+            tmuxSessionHasPositiveAgentEvidence(
+                hasLiveDetection = true,
+                hasStickyAgent = false,
+                recordedAgentKind = false,
+            ),
+        )
+        assertTrue(
+            tmuxSessionHasPositiveAgentEvidence(
+                hasLiveDetection = false,
+                hasStickyAgent = true,
+                recordedAgentKind = false,
+            ),
+        )
+        assertTrue(
+            tmuxSessionHasPositiveAgentEvidence(
+                hasLiveDetection = false,
+                hasStickyAgent = false,
+                recordedAgentKind = true,
+            ),
+        )
+        assertTrue(
+            !tmuxSessionHasPositiveAgentEvidence(
+                hasLiveDetection = false,
+                hasStickyAgent = false,
+                recordedAgentKind = false,
+            ),
+        )
+    }
+
     // ─── Issue #805 (regression of #744/#716): the bottom-bar chrome follows ──
     // the Conversation TAB (detecting OR loaded), not the detection-gated ──────
     // transcript — so the composer launcher is never pushed off-screen by the ──

--- a/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurfaceState.kt
+++ b/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurfaceState.kt
@@ -585,6 +585,20 @@ class TerminalSurfaceState(
         .distinctUntilChanged()
 
     /**
+     * Debounced visible-screen text snapshots for lightweight UI affordances
+     * that need to react to terminal prompts without adding a new SSH/tmux read.
+     *
+     * This uses the same output-driven tick as [flowOfMatches]: no collector means
+     * no work, and active collectors coalesce bursty `%output` before reading the
+     * emulator grid.
+     */
+    @OptIn(kotlinx.coroutines.FlowPreview::class)
+    val flowOfVisibleScreenText: Flow<String> = bufferTick
+        .debounce(MATCH_DEBOUNCE_MS)
+        .map { visibleScreenTextSnapshot() }
+        .distinctUntilChanged()
+
+    /**
      * Replace the active [TerminalMatcher]. The next [flowOfMatches] emission
      * uses the new matcher; in-flight emissions complete with the matcher
      * that was active when the debounce window closed (a benign race that
@@ -1190,6 +1204,19 @@ class TerminalSurfaceState(
             return emptyList()
         }
         return matcher.matches(text)
+    }
+
+    /**
+     * Current visible viewport text, defensively empty when no emulator is
+     * attached or the vendored screen throws during a resize.
+     */
+    fun visibleScreenTextSnapshot(): String {
+        val emulator = bridge?.emulator ?: _session?.emulator ?: return ""
+        return try {
+            emulator.screen.visibleScreenText
+        } catch (_: Throwable) {
+            ""
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary

Refs #1235.

Adds a compact quick-reply row for live tmux agent terminal panes when the visible terminal text looks like an approval/input prompt. The row sits as a normal band above the composer/bottom controls and sends literal keystrokes to the visible pane.

## Details

- Adds an output-driven visible-screen text flow on TerminalSurfaceState, reusing the existing debounced terminal tick so this adds no SSH/tmux polling.
- Detects conservative prompt shapes: y/n approval prompts, numbered Yes/No-style choices, and Enter-to-continue prompts.
- Gates the row on positive agent evidence, not the optimistic presumed-agent default, so unknown shell panes do not sprout reply chips.
- Adds stable tmux test tags for the row and per-chip controls.

## Validation

- scripts/check-component-drift.sh
- ./gradlew :app:testDebugUnitTest --tests 'com.pocketshell.app.tmux.AgentQuickReplyTest' --tests 'com.pocketshell.app.tmux.TmuxSessionScreenTest' :app:compileDebugKotlin