### PR TITLE
hosts: route first-host success through setup

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/hosts/FirstHostTestConnectScreenTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/hosts/FirstHostTestConnectScreenTest.kt
@@ -1,0 +1,100 @@
+package com.pocketshell.app.hosts
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.pocketshell.app.bootstrap.HOST_BOOTSTRAP_SHEET_TAG
+import com.pocketshell.app.bootstrap.HostBootstrapSheetState
+import com.pocketshell.core.storage.entity.HostEntity
+import com.pocketshell.core.storage.entity.SshKeyEntity
+import com.pocketshell.uikit.theme.PocketShellTheme
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Issue #1243: after the guided first-host SSH test succeeds, the primary
+ * action must enter the existing host bootstrap/setup flow instead of skipping
+ * straight to the folder list.
+ */
+class FirstHostTestConnectScreenTest {
+
+    @get:Rule
+    val compose = createComposeRule()
+
+    @Test
+    fun successActionStartsSetup_andSetupStepIsActive() {
+        val host = HostEntity(
+            id = 42L,
+            name = "Lab",
+            hostname = "127.0.0.1",
+            username = "test",
+            keyId = 7L,
+        )
+        val key = SshKeyEntity(id = 7L, name = "lab", privateKeyPath = "/tmp/lab")
+        var setupHost: HostEntity? = null
+        var setupKeyPath: String? = null
+
+        compose.setContent {
+            PocketShellTheme {
+                FirstHostTestConnectContent(
+                    state = FirstHostTestConnectState(
+                        host = host,
+                        key = key,
+                        status = FirstHostTestStatus.Success,
+                    ),
+                    hostId = host.id,
+                    onBack = {},
+                    onEditHost = {},
+                    onRetry = {},
+                    onStartSetup = { h, path ->
+                        setupHost = h
+                        setupKeyPath = path
+                    },
+                    bootstrapState = null,
+                    bootstrapHostName = "",
+                    onInstall = {},
+                    onInstallTool = {},
+                    onEnableNotifications = {},
+                    onDismissSetup = {},
+                )
+            }
+        }
+
+        compose.onNodeWithText("4. Setup", useUnmergedTree = true).assertIsDisplayed()
+        compose.onNodeWithText("Finish setup", useUnmergedTree = true).assertIsDisplayed()
+        compose.onNodeWithTag(FIRST_HOST_TEST_CONNECT_OPEN_TAG, useUnmergedTree = true)
+            .performClick()
+
+        compose.runOnIdle {
+            assertEquals(host, setupHost)
+            assertEquals("/tmp/lab", setupKeyPath)
+        }
+    }
+
+    @Test
+    fun setupStateRendersExistingBootstrapSheet() {
+        compose.setContent {
+            PocketShellTheme {
+                FirstHostTestConnectContent(
+                    state = FirstHostTestConnectState(status = FirstHostTestStatus.Success),
+                    hostId = 42L,
+                    onBack = {},
+                    onEditHost = {},
+                    onRetry = {},
+                    onStartSetup = { _, _ -> },
+                    bootstrapState = HostBootstrapSheetState.Prompt(needsTmux = true),
+                    bootstrapHostName = "Lab",
+                    onInstall = {},
+                    onInstallTool = {},
+                    onEnableNotifications = {},
+                    onDismissSetup = {},
+                )
+            }
+        }
+
+        compose.onNodeWithTag(HOST_BOOTSTRAP_SHEET_TAG).assertIsDisplayed()
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/hosts/AddEditHostScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/hosts/AddEditHostScreen.kt
@@ -362,6 +362,7 @@ internal enum class FirstHostWizardStep {
     Key,
     Host,
     Test,
+    Setup,
 }
 
 @Composable
@@ -373,6 +374,7 @@ internal fun FirstHostWizardSteps(
         FirstHostWizardStep.Key to "Key",
         FirstHostWizardStep.Host to "Host",
         FirstHostWizardStep.Test to "Test",
+        FirstHostWizardStep.Setup to "Setup",
     )
     Row(
         modifier = modifier

--- a/app/src/main/java/com/pocketshell/app/hosts/FirstHostTestConnectScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/hosts/FirstHostTestConnectScreen.kt
@@ -10,12 +10,14 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
@@ -24,6 +26,9 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.pocketshell.app.bootstrap.BootstrapTool
+import com.pocketshell.app.bootstrap.HostBootstrapSheet
+import com.pocketshell.app.bootstrap.HostBootstrapSheetState
 import com.pocketshell.core.ssh.KnownHostsPolicy
 import com.pocketshell.core.ssh.SshConnection
 import com.pocketshell.core.ssh.SshKey
@@ -63,12 +68,58 @@ fun FirstHostTestConnectScreen(
     onOpenHost: (HostEntity, keyPath: String, passphrase: CharArray?) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: FirstHostTestConnectViewModel = hiltViewModel(),
+    bootstrapViewModel: HostListViewModel = hiltViewModel(),
 ) {
     val state by viewModel.state.collectAsState()
+    val bootstrapState by bootstrapViewModel.bootstrapState.collectAsState()
+    val bootstrapHostName by bootstrapViewModel.bootstrapHostName.collectAsState()
+    val pendingNavigation by bootstrapViewModel.pendingNavigation.collectAsState()
+    val currentOnOpenHost by rememberUpdatedState(onOpenHost)
     LaunchedEffect(hostId) {
         viewModel.start(hostId)
     }
+    LaunchedEffect(pendingNavigation) {
+        val pending = pendingNavigation
+        if (pending != null && pending.ready) {
+            currentOnOpenHost(pending.host, pending.keyPath, pending.passphrase)
+            bootstrapViewModel.consumePendingNavigation()
+        }
+    }
 
+    FirstHostTestConnectContent(
+        state = state,
+        hostId = hostId,
+        onBack = onBack,
+        onEditHost = onEditHost,
+        onRetry = { viewModel.start(hostId, force = true) },
+        onStartSetup = { host, keyPath -> bootstrapViewModel.bootstrapHost(host, keyPath, null) },
+        bootstrapState = bootstrapState,
+        bootstrapHostName = bootstrapHostName,
+        onInstall = { bootstrapViewModel.installTmuxOnPendingHost() },
+        onInstallTool = { tool -> bootstrapViewModel.installBootstrapTool(tool) },
+        onEnableNotifications = { bootstrapViewModel.installTmuxOnPendingHost() },
+        onDismissSetup = { bootstrapViewModel.dismissBootstrapAndOpen() },
+        modifier = modifier,
+    )
+}
+
+@Composable
+@OptIn(ExperimentalMaterial3Api::class)
+internal fun FirstHostTestConnectContent(
+    state: FirstHostTestConnectState,
+    hostId: Long,
+    onBack: () -> Unit,
+    onEditHost: (Long) -> Unit,
+    onRetry: () -> Unit,
+    onStartSetup: (HostEntity, keyPath: String) -> Unit,
+    bootstrapState: HostBootstrapSheetState?,
+    bootstrapHostName: String,
+    onInstall: () -> Unit,
+    onInstallTool: (BootstrapTool) -> Unit,
+    onEnableNotifications: () -> Unit,
+    onDismissSetup: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
     Column(
         modifier = modifier
             .fillMaxSize()
@@ -92,7 +143,13 @@ fun FirstHostTestConnectScreen(
                 }
             },
         )
-        FirstHostWizardSteps(activeStep = FirstHostWizardStep.Test)
+        FirstHostWizardSteps(
+            activeStep = if (state.status == FirstHostTestStatus.Success) {
+                FirstHostWizardStep.Setup
+            } else {
+                FirstHostWizardStep.Test
+            },
+        )
 
         Column(
             modifier = Modifier
@@ -117,11 +174,11 @@ fun FirstHostTestConnectScreen(
                         style = MaterialTheme.typography.bodyMedium,
                     )
                     PocketShellButton(
-                        text = "Open host",
+                        text = "Finish setup",
                         onClick = {
                             val host = state.host ?: return@PocketShellButton
                             val key = state.key ?: return@PocketShellButton
-                            onOpenHost(host, key.privateKeyPath, null)
+                            onStartSetup(host, key.privateKeyPath)
                         },
                         variant = ButtonVariant.Primary,
                         modifier = Modifier
@@ -158,7 +215,7 @@ fun FirstHostTestConnectScreen(
                     ) {
                         PocketShellButton(
                             text = "Retry",
-                            onClick = { viewModel.start(hostId, force = true) },
+                            onClick = onRetry,
                             variant = ButtonVariant.Primary,
                             modifier = Modifier
                                 .weight(1f)
@@ -176,6 +233,18 @@ fun FirstHostTestConnectScreen(
                 }
             }
         }
+    }
+
+    bootstrapState?.let { setupState ->
+        HostBootstrapSheet(
+            state = setupState,
+            hostName = bootstrapHostName,
+            onInstall = onInstall,
+            onInstallTool = onInstallTool,
+            onEnableNotifications = onEnableNotifications,
+            onSkip = onDismissSetup,
+            onDismiss = onDismissSetup,
+        )
     }
 }
 


### PR DESCRIPTION
Refs #1243

## Summary
- route the guided first-host test-success CTA through the existing `HostListViewModel.bootstrapHost(...)` setup flow instead of navigating directly to folders
- render the existing `HostBootstrapSheet` from the first-host test screen and consume `pendingNavigation` the same way the host-list tap path does
- add a fourth `Setup` wizard step so the flow is visibly key -> host -> test -> setup
- add direct Compose coverage for the success CTA and bootstrap sheet rendering

## Validation
- `./gradlew :app:testDebugUnitTest --tests 'com.pocketshell.app.hosts.FirstHostTestConnectViewModelTest' :app:compileDebugKotlin :app:compileDebugAndroidTestKotlin`
- `scripts/check-component-drift.sh`
- `git diff --check`

Existing warnings only: deprecated `ClickableText`, the pre-existing `TmuxSessionScreen.kt` always-true condition, and existing test warning/deprecation messages.

Remaining #1243 scope: Docker happy-path journey plus bad-key/bad-port failure-path coverage.
