### PR TITLE
tmux: bound Codex submit ack waits

### DIFF
--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerViewModel.kt
@@ -274,6 +274,7 @@ public class PromptComposerViewModel @Inject constructor(
     private var outboundAttachmentUploader: (suspend (List<LocalAttachmentSidecarRef>) -> Result<List<String>>)? =
         null
     private var outboundSidecarDispatchInFlight: Boolean = false
+    internal var outboundQueueDispatcher: CoroutineDispatcher = Dispatchers.IO
 
     /**
      * Issue #971: the [SendRequest] for the prompt currently in flight, captured
@@ -935,7 +936,7 @@ public class PromptComposerViewModel @Inject constructor(
         )
         inFlightSendRequest = handoffRequest
         if (sendTarget.sessionKey.isNotBlank() && hasLocalAttachmentsForSidecars(attachments)) {
-            viewModelScope.launch {
+            viewModelScope.launch(outboundQueueDispatcher) {
                 try {
                     enqueueAndDispatchSidecarBackedSend(
                         cleanDraft = draft,
@@ -1693,8 +1694,9 @@ public class PromptComposerViewModel @Inject constructor(
     public fun retryNextOutboundItem(excludingIds: Set<String> = emptySet()): String? {
         if (_uiState.value.sendInFlight) return null
         val target = composerTarget?.takeIf { it.isNotBlank() } ?: return null
-        val next = outboundQueueStore.itemsFor(target)
+        val next = _outboundQueueItems.value
             .firstOrNull { item ->
+                item.sessionKey == target &&
                 item.id !in excludingIds &&
                     (item.state == OutboundState.Queued || item.state == OutboundState.Failed)
             }
@@ -1757,11 +1759,11 @@ public class PromptComposerViewModel @Inject constructor(
 
     private fun dispatchOutboundItem(id: String): Boolean {
         if (_uiState.value.sendInFlight) return false
+        if (outboundSidecarDispatchInFlight) return false
         val sidecarStore = outboundAttachmentSidecarStore
         if (sidecarStore != null) {
-            if (outboundSidecarDispatchInFlight) return false
             outboundSidecarDispatchInFlight = true
-            viewModelScope.launch {
+            viewModelScope.launch(outboundQueueDispatcher) {
                 try {
                     val sidecars = sidecarStore.refsFor(id)
                     if (sidecars.isNotEmpty()) {
@@ -1786,7 +1788,22 @@ public class PromptComposerViewModel @Inject constructor(
             }
             return true
         }
-        return claimAndEmitOutboundItem(id)
+        outboundSidecarDispatchInFlight = true
+        viewModelScope.launch(outboundQueueDispatcher) {
+            try {
+                claimAndEmitOutboundItem(id)
+            } catch (cancelled: CancellationException) {
+                clearStrandedSendInFlight()
+                throw cancelled
+            } catch (t: Throwable) {
+                clearStrandedSendInFlight(
+                    error = "Send failed: reconnect, then send again or discard the draft.",
+                )
+            } finally {
+                outboundSidecarDispatchInFlight = false
+            }
+        }
+        return true
     }
 
     private suspend fun dispatchPreparedOutboundItem(id: String): Boolean {

--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerViewModel.kt
@@ -926,6 +926,14 @@ public class PromptComposerViewModel @Inject constructor(
         // emission with no live collector) can never leave the composer stuck on
         // "Sending…" forever.
         armSendWatchdog()
+        val handoffRequest = SendRequest(
+            text = text,
+            withEnter = withEnter,
+            cleanDraft = draft,
+            attachments = attachments,
+            sendTarget = sendTarget,
+        )
+        inFlightSendRequest = handoffRequest
         if (sendTarget.sessionKey.isNotBlank() && hasLocalAttachmentsForSidecars(attachments)) {
             viewModelScope.launch {
                 try {
@@ -1080,6 +1088,14 @@ public class PromptComposerViewModel @Inject constructor(
         if (queuedItem.id != itemId) {
             outboundAttachmentSidecarStore?.removeOutboundItem(itemId)
         }
+        inFlightSendRequest = SendRequest(
+            text = appendAttachmentPaths(cleanDraft, attachments.map { it.remotePath }),
+            withEnter = withEnter,
+            cleanDraft = cleanDraft,
+            attachments = attachments,
+            sendTarget = sendTarget,
+            outboundQueueItemId = queuedItem.id,
+        )
         refreshOutboundQueueItemsFor(sessionKey)
         dispatchPreparedOutboundItem(queuedItem.id)
     }
@@ -1174,7 +1190,12 @@ public class PromptComposerViewModel @Inject constructor(
         request: SendRequest,
         message: String = "Not sent. Reconnect, then send again or discard the draft.",
     ) {
-        if (request.text.isEmpty()) return
+        if (request.text.isEmpty()) {
+            disarmSendWatchdog()
+            inFlightSendRequest = null
+            _uiState.update { it.copy(sendInFlight = false, attachmentUpload = AttachmentUploadState.Idle) }
+            return
+        }
         // Issue #891: the send resolved (to failure) — disarm the overall-send
         // watchdog so the retryable failed state we are about to set is not
         // immediately re-stamped by a late watchdog firing.
@@ -1274,6 +1295,18 @@ public class PromptComposerViewModel @Inject constructor(
         inFlightSendRequest = null
         val id = request.outboundQueueItemId
         val requeued = id?.let { outboundQueueStore.requeueForRetry(it) }
+            ?: request.sendTarget.sessionKey.takeIf { it.isNotBlank() }?.let { sessionKey ->
+                val candidates = outboundQueueStore.itemsFor(sessionKey)
+                    .filter { it.state != OutboundState.Delivered }
+                candidates
+                    .firstOrNull {
+                        it.cleanText == request.cleanDraft &&
+                            it.state != OutboundState.Delivered
+                    }
+                    ?: candidates.firstOrNull()
+            }?.let {
+                outboundQueueStore.requeueForRetry(it.id)
+            }
         if (requeued == null) {
             // No durable row to keep queued — fall back to the composer-restore
             // path so the typed prompt is not silently lost.
@@ -1482,6 +1515,7 @@ public class PromptComposerViewModel @Inject constructor(
         // back to the composer-restore path inside markOutboundSendDeferred with
         // the watchdog-specific copy so the typed prompt is not lost and the user
         // sees that the send timed out.
+        requeueStaleOutboundInFlight(staleAfterMs = 0L)
         markOutboundSendDeferred(request, noRowFallbackMessage = SEND_TIMEOUT_MESSAGE)
     }
 
@@ -1791,6 +1825,9 @@ public class PromptComposerViewModel @Inject constructor(
         } catch (timeout: TimeoutCancellationException) {
             Result.failure(timeout)
         } catch (cancelled: CancellationException) {
+            outboundQueueStore.requeueForRetry(id)
+            refreshOutboundQueueItemsFor(uploading.sessionKey)
+            clearStrandedSendInFlight()
             throw cancelled
         } catch (t: Throwable) {
             Result.failure(t)
@@ -3138,6 +3175,7 @@ public class PromptComposerViewModel @Inject constructor(
      */
     public fun onForegroundResume() {
         viewModelScope.launch {
+            requeueStaleOutboundInFlight()
             if (!connectivity.refresh()) return@launch
             val snapshot = runCatching { pendingTranscriptionStore.snapshot() }
                 .getOrElse { return@launch }

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
@@ -923,10 +923,26 @@ public fun TmuxSessionScreen(
     val paletteAgent: AgentKind? = liveAgentForPane
         ?: currentPaneId?.let { stickyAgentForPane[it] }
     val surfaceTerminalState = surfacePane?.terminalState
-    val visibleTerminalText by remember(currentPaneId, surfaceTerminalState) {
-        surfaceTerminalState?.flowOfVisibleScreenText ?: flowOf("")
+    val quickReplyInputEligible = sessionLive &&
+        surfaceTerminalState != null &&
+        currentSelectedTab != SessionTab.Conversation &&
+        tmuxSessionHasPositiveAgentEvidence(
+            hasLiveDetection = currentDetection != null,
+            hasStickyAgent = paletteAgent != null,
+            recordedAgentKind = tmuxSessionRecordedAgentKind(currentSessionRecordedKind),
+        )
+    val visibleTerminalText by remember(currentPaneId, surfaceTerminalState, quickReplyInputEligible) {
+        if (quickReplyInputEligible) {
+            surfaceTerminalState?.flowOfVisibleScreenText ?: flowOf("")
+        } else {
+            flowOf("")
+        }
     }.collectAsState(
-        initial = surfaceTerminalState?.visibleScreenTextSnapshot().orEmpty(),
+        initial = if (quickReplyInputEligible) {
+            surfaceTerminalState?.visibleScreenTextSnapshot().orEmpty()
+        } else {
+            ""
+        },
     )
     val agentQuickReplies = remember(visibleTerminalText) {
         agentQuickRepliesForVisibleText(visibleTerminalText)
@@ -2372,15 +2388,9 @@ public fun TmuxSessionScreen(
 
             run {
                 val pane = surfacePane
-                val quickReplyInputEnabled = sessionLive &&
-                    pane != null &&
+                val quickReplyInputEnabled = quickReplyInputEligible &&
                     !showMicSheet &&
-                    !showConversation &&
-                    tmuxSessionHasPositiveAgentEvidence(
-                        hasLiveDetection = currentDetection != null,
-                        hasStickyAgent = paletteAgent != null,
-                        recordedAgentKind = tmuxSessionRecordedAgentKind(currentSessionRecordedKind),
-                    )
+                    !showConversation
                 if (quickReplyInputEnabled && agentQuickReplies.isNotEmpty()) {
                     AgentQuickReplyRow(
                         replies = agentQuickReplies,

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -14796,63 +14796,62 @@ public class TmuxSessionViewModel @Inject constructor(
         // capture confirms instantly (preserves the #526 tunable minimum).
         if (minFloorMs > 0L) delay(minFloorMs)
 
-        // Bound the ack poll by iteration count rather than a wall clock so the
-        // loop is deterministic under virtual time AND cannot spin forever (a
-        // `SystemClock` reading is a no-op 0 under the unit-test default-values
-        // runtime, which would make an elapsed-based bound never trip — #869
-        // OOM). Each capture is itself a round-trip, so this stays RTT-adaptive.
         val ackTimeoutMs = agentSubmitAckTimeoutMsOverrideForTest ?: AGENT_SUBMIT_ACK_TIMEOUT_MS
-        val maxPolls = (ackTimeoutMs / AGENT_SUBMIT_ACK_POLL_INTERVAL_MS)
-            .toInt()
-            .coerceAtLeast(1)
         var poll = 0
         // The longest single `capture-pane` round-trip seen so far — the RTT
         // addend for the hardened fallback floor (#869).
         var maxCaptureRttMs = 0L
-        while (true) {
-            if (client.disconnected.value) return
-            val captureStartMs = agentSubmitNowMs()
-            val visible = agentPaneShowsPayload(client, paneId, ackNeedle)
-            maxCaptureRttMs = maxOf(maxCaptureRttMs, agentSubmitNowMs() - captureStartMs)
-            if (visible) {
-                // The paste is visible in the pane — the agent has ingested it.
-                // Press Enter now (caller does the send-keys Enter).
-                DiagnosticEvents.record(
-                    "action",
-                    "agent_submit_ack",
-                    "pane" to paneId,
-                    "result" to "ack_observed",
-                    "polls" to poll,
-                )
-                return
+        var disconnectedDuringAck = false
+        val ackObserved = withTimeoutOrNull(ackTimeoutMs.coerceAtLeast(1L)) {
+            while (true) {
+                if (client.disconnected.value) {
+                    disconnectedDuringAck = true
+                    return@withTimeoutOrNull false
+                }
+                val captureStartMs = agentSubmitNowMs()
+                val visible = agentPaneShowsPayload(client, paneId, ackNeedle)
+                maxCaptureRttMs = maxOf(maxCaptureRttMs, agentSubmitNowMs() - captureStartMs)
+                if (visible) {
+                    // The paste is visible in the pane — the agent has ingested it.
+                    // Press Enter now (caller does the send-keys Enter).
+                    DiagnosticEvents.record(
+                        "action",
+                        "agent_submit_ack",
+                        "pane" to paneId,
+                        "result" to "ack_observed",
+                        "polls" to poll,
+                    )
+                    return@withTimeoutOrNull true
+                }
+                poll += 1
+                delay(AGENT_SUBMIT_ACK_POLL_INTERVAL_MS)
             }
-            poll += 1
-            if (poll >= maxPolls) {
-                // Hardened needle-miss fallback (#869): we could not confirm
-                // ingestion. Do NOT degrade to the short floor that caused the
-                // missed-submit. Hold the Enter until an ADEQUATE working floor
-                // has elapsed since the gate started:
-                //   max(minFloor, FALLBACK_FLOOR + maxCaptureRtt).
-                val fallbackFloorMs = maxOf(
-                    minFloorMs,
-                    com.pocketshell.app.settings.AppSettings.AGENT_SUBMIT_ACK_FALLBACK_FLOOR_MS +
-                        maxCaptureRttMs,
-                )
-                val elapsedMs = agentSubmitNowMs() - gateStartMs
-                val remainingMs = fallbackFloorMs - elapsedMs
-                if (remainingMs > 0L) delay(remainingMs)
-                DiagnosticEvents.record(
-                    "action",
-                    "agent_submit_ack",
-                    "pane" to paneId,
-                    "result" to "fallback_floor",
-                    "polls" to poll,
-                    "fallbackFloorMs" to fallbackFloorMs,
-                )
-                return
-            }
-            delay(AGENT_SUBMIT_ACK_POLL_INTERVAL_MS)
-        }
+        } == true
+        if (disconnectedDuringAck) return
+        if (ackObserved) return
+
+        // Codex input-freeze follow-up: the ack timeout must bound the WHOLE
+        // capture loop, not just the number of polls. A single stuck
+        // `capture-pane` on the busy control lane used to park this coroutine past
+        // the advertised timeout, making Codex sends appear frozen. On timeout,
+        // keep the #869 fallback floor, then let the caller send Enter rather than
+        // blocking user input indefinitely.
+        val fallbackFloorMs = maxOf(
+            minFloorMs,
+            com.pocketshell.app.settings.AppSettings.AGENT_SUBMIT_ACK_FALLBACK_FLOOR_MS +
+                maxCaptureRttMs,
+        )
+        val elapsedMs = agentSubmitNowMs() - gateStartMs
+        val remainingMs = fallbackFloorMs - elapsedMs
+        if (remainingMs > 0L) delay(remainingMs)
+        DiagnosticEvents.record(
+            "action",
+            "agent_submit_ack",
+            "pane" to paneId,
+            "result" to "fallback_floor",
+            "polls" to poll,
+            "fallbackFloorMs" to fallbackFloorMs,
+        )
     }
 
     /**

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -18403,7 +18403,7 @@ public class TmuxSessionViewModel @Inject constructor(
 
         override fun write(buffer: ByteArray, offset: Int, length: Int) {
             if (length <= 0) return
-            queue.write(buffer, offset, length)
+            try { queue.write(buffer, offset, length) } catch (_: IOException) { }
         }
 
         override fun close() {

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -14218,13 +14218,13 @@ public class TmuxSessionViewModel @Inject constructor(
 
     public suspend fun uploadQueuedAttachmentSidecars(
         sidecars: List<LocalAttachmentSidecarRef>,
-    ): Result<List<String>> {
+    ): Result<List<String>> = withContext(seedIoDispatcher) {
         DiagnosticEvents.record("action", "tmux_outbound_sidecar_upload_start", "count" to sidecars.size)
-        if (sidecars.isEmpty()) return Result.success(emptyList())
+        if (sidecars.isEmpty()) return@withContext Result.success(emptyList())
         val session = awaitLiveSessionForAttachment()
-            ?: return Result.failure(IllegalStateException("No live SSH session for attachment upload."))
+            ?: return@withContext Result.failure(IllegalStateException("No live SSH session for attachment upload."))
         if (!session.isConnected) {
-            return Result.failure(SshException("SSH session is not connected"))
+            return@withContext Result.failure(SshException("SSH session is not connected"))
         }
         val target = activeTarget
         val scopeKey = when (target) {
@@ -14235,11 +14235,11 @@ public class TmuxSessionViewModel @Inject constructor(
         val remoteDir = "${PromptAttachmentStager.REMOTE_DIRECTORY}/$safeScope"
         val displayDir = "~/$remoteDir"
         val timestamp = ShareUploader.formatTimestamp(sidecars.minOf { it.createdAtMs })
-        return try {
+        try {
             val mkdir = session.exec("mkdir -p \"\$HOME/$remoteDir\"")
             if (mkdir.exitCode != 0) {
                 val detail = mkdir.stderr.ifBlank { mkdir.stdout }.trim()
-                return Result.failure(
+                return@withContext Result.failure(
                     SshException("Could not create attachment directory: ${detail.ifBlank { "mkdir failed" }}"),
                 )
             }

--- a/app/src/test/java/com/pocketshell/app/composer/PromptComposerViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/PromptComposerViewModelTest.kt
@@ -231,7 +231,10 @@ class PromptComposerViewModelTest {
             outboundAttachmentSidecarStore = outboundAttachmentSidecarStore,
             savedStateHandle = savedStateHandle,
         )
-        if (samplerDispatcher != null) vm.samplerDispatcher = samplerDispatcher
+        if (samplerDispatcher != null) {
+            vm.samplerDispatcher = samplerDispatcher
+            vm.outboundQueueDispatcher = samplerDispatcher
+        }
         vm.clock = clock
         // Issue #882: track for teardown so a test that leaves recording active
         // doesn't leak the #880 ticker loop into `runTest`'s final
@@ -4151,6 +4154,34 @@ class PromptComposerViewModelTest {
         assertEquals(OutboundState.InFlight, queue.item(item.id)!!.state)
         assertEquals(2, queue.item(item.id)!!.attemptCount)
         assertEquals(listOf(item.id), vm.outboundQueueItems.value.map { it.id })
+    }
+
+    @Test
+    fun retryNextOutboundItemSchedulesQueueClaimOffCallerThread() = runTest {
+        val queue = InMemoryOutboundQueueStore()
+        val item = queue.enqueue(
+            sessionKey = "1/session-a",
+            cleanText = "saved prompt",
+            createdAtMs = 1L,
+            paneId = "%1",
+        )
+        val vm = newVm(
+            samplerDispatcher = StandardTestDispatcher(testScheduler),
+            outboundQueueStore = queue,
+        )
+        val sent = collectSendRequests(vm)
+        vm.onComposerTargetChanged("1/session-a")
+
+        val retried = vm.retryNextOutboundItem()
+
+        assertEquals(item.id, retried)
+        assertTrue(sent.isEmpty())
+        assertEquals(OutboundState.Queued, queue.item(item.id)!!.state)
+
+        advanceUntilIdle()
+
+        assertEquals(item.id, sent.single().outboundQueueItemId)
+        assertEquals(OutboundState.InFlight, queue.item(item.id)!!.state)
     }
 
     @Test

--- a/app/src/test/java/com/pocketshell/app/composer/PromptComposerViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/PromptComposerViewModelTest.kt
@@ -4351,6 +4351,42 @@ class PromptComposerViewModelTest {
     }
 
     @Test
+    fun foregroundResumeRequeuesStaleUploadingOutboundRows() = runTest {
+        val queue = InMemoryOutboundQueueStore()
+        val now = 500_000L
+        val staleUpload = OutboundItem(
+            id = "stale-upload",
+            sessionKey = "1/session-a",
+            cleanText = "recover upload",
+            state = OutboundState.Uploading,
+            createdAtMs = 1L,
+            lastAttemptAtMs = now - PromptComposerViewModel.OUTBOUND_IN_FLIGHT_STALE_MS - 1L,
+            attachments = listOf(DurableAttachmentRef("/tmp/local.png", "local.png", "image/png")),
+        )
+        val freshUpload = staleUpload.copy(
+            id = "fresh-upload",
+            cleanText = "leave upload",
+            createdAtMs = 2L,
+            lastAttemptAtMs = now - PromptComposerViewModel.OUTBOUND_IN_FLIGHT_STALE_MS + 1L,
+        )
+        queue.enqueueExisting(staleUpload)
+        queue.enqueueExisting(freshUpload)
+        val vm = newVm(
+            samplerDispatcher = StandardTestDispatcher(testScheduler),
+            outboundQueueStore = queue,
+            clock = { now },
+        )
+        vm.onComposerTargetChanged("1/session-a")
+
+        vm.onForegroundResume()
+        runCurrent()
+
+        assertEquals(OutboundState.Queued, queue.item(staleUpload.id)!!.state)
+        assertEquals(OutboundState.Uploading, queue.item(freshUpload.id)!!.state)
+        assertEquals(listOf(staleUpload.id, freshUpload.id), vm.outboundQueueItems.value.map { it.id })
+    }
+
+    @Test
     fun requestSendWhileRecordingPreservesOriginalSendTargetSnapshot() = runTest {
         // Issue #900: a Send tap during Recording first stops the recorder and
         // transcribes. The eventual request must keep the target captured from

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
@@ -11897,6 +11897,49 @@ class TmuxSessionViewModelTest {
     }
 
     /**
+     * Codex input-freeze follow-up: a Codex/agent output storm can wedge the
+     * `capture-pane` command the submit ack gate uses to confirm the paste
+     * landed. The ack timeout must bound the WHOLE capture loop, including a
+     * single stuck capture command, so typing never parks forever before the
+     * submit Enter.
+     */
+    @Test
+    fun sendToAgentPaneAckTimeoutBoundsStuckCaptureCommand() = runTest(scheduler) {
+        val vm = newVm()
+        val client = FakeTmuxClient()
+        vm.setAgentSubmitMonotonicClockForTest { scheduler.currentTime }
+        vm.attachClientForTest(client)
+        vm.startAgentConversationForTest("%0", newClaudeDetection())
+        vm.setAgentSubmitEnterDelayForTest(0)
+        vm.setAgentSubmitAckTimeoutForTest(80L)
+        client.suspendForeverOnCommandPrefix = "capture-pane"
+
+        val send = async { vm.sendToAgentPaneResult("%0", "blocked capture prompt") }
+
+        advanceTimeBy(79L)
+        runCurrent()
+        assertFalse(
+            "the submit Enter must not fire before the ack timeout elapses",
+            client.sentCommands.contains("send-keys -t %0 Enter"),
+        )
+
+        advanceUntilIdle()
+        assertTrue("stuck capture must fall back instead of hanging Send", send.await().isSuccess)
+        assertEquals(
+            "a stuck ack capture should be tried once, then cancelled by the wall-clock timeout",
+            1,
+            client.sentCommands.count { it.startsWith("capture-pane") },
+        )
+        assertEquals(
+            listOf(
+                "send-keys -l -t %0 -- 'blocked capture prompt'",
+                "send-keys -t %0 Enter",
+            ),
+            client.sentCommands.filter { it.startsWith("send-keys") },
+        )
+    }
+
+    /**
      * Issue #869 (reviewer BLOCKED-G4 follow-up): the needle-miss FALLBACK must
      * NOT degrade to the pre-#869 short floor — that short delay IS the
      * maintainer's missed-submit symptom. When the ack is never observed (an

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
@@ -7348,7 +7348,7 @@ class TmuxSessionViewModelTest {
     }
 
     @Test
-    fun tmuxInputEnqueueRejectsWhenPendingByteBudgetIsFull() = runTest(scheduler) {
+    fun tmuxInputStreamDropsOverflowAndAcceptsLaterBytes() = runTest(scheduler) {
         val vm = newVm()
         val client = FakeTmuxClient().apply {
             sendCommandGatePrefix = "send-keys -l -t %0"
@@ -7363,14 +7363,26 @@ class TmuxSessionViewModelTest {
         }
         runCurrent()
 
-        val thrown = runCatching { sink.write("overflow".toByteArray(Charsets.US_ASCII)) }
-            .exceptionOrNull()
+        val overflow = runCatching { sink.write("overflow".toByteArray(Charsets.US_ASCII)) }
         assertTrue(
-            "enqueue must fail fast instead of blocking when the pending-byte budget is full",
-            thrown is IOException,
+            "the bridge-facing input stream must drop overflow instead of killing the input drainer",
+            overflow.isSuccess,
         )
         client.sendCommandGate?.complete(Unit)
         advanceUntilIdle()
+
+        sink.write("after".toByteArray(Charsets.US_ASCII))
+        advanceUntilIdle()
+
+        val literalSends = client.sentCommands.filter { it.startsWith("send-keys -l -t %0") }
+        assertTrue(
+            "later input must still reach tmux after a transient full-queue drop",
+            literalSends.any { it.contains("'after'") },
+        )
+        assertTrue(
+            "overflow bytes should be dropped rather than replayed after the backlog drains",
+            literalSends.none { it.contains("overflow") },
+        )
     }
 
     @Test


### PR DESCRIPTION
## Summary
- bound Codex submit ack waiting so a stuck capture-pane cannot delay Enter indefinitely
- gate quick-reply visible-text collection to panes where quick replies can actually render
- keep the terminal input drainer alive under tmux input backpressure by dropping overflow instead of letting the bridge-facing stream kill the drainer
- run queued attachment uploads on the VM's existing IO dispatcher seam so SSH/file upload work cannot pin Main
- dispatch saved queued prompts from the rendered queue snapshot and claim/upload them on the queue dispatcher, so reopening a session with 1 unsent prompt cannot synchronously block the UI thread
- requeue stale Uploading attachments outbound rows on composer foreground/open so a saved queued prompt can become sendable again
- preserve/recover queued sidecar send state when watchdog/cancellation paths fire before a normal send request is emitted

## Validation
- scripts/check-connection-vm-ratchet.sh
- git diff --check
- ./gradlew :app:testDebugUnitTest --tests 'com.pocketshell.app.composer.PromptComposerViewModelTest.retryNextOutboundItemSchedulesQueueClaimOffCallerThread' --tests 'com.pocketshell.app.composer.PromptComposerViewModelTest.retryNextOutboundItemClaimsOldestCurrentTargetAndHonorsLiveWindowExclusions' --tests 'com.pocketshell.app.composer.PromptComposerViewModelTest.retryNextOutboundItemUploadsPersistedSidecarsBeforeClaimingQueuedRow' --tests 'com.pocketshell.app.composer.PromptComposerViewModelTest.foregroundResumeRequeuesStaleUploadingOutboundRows' --tests 'com.pocketshell.app.composer.PromptComposerViewModelTest.attachmentUploadTimeoutDoesNotWedgeSubsequentPlainSend' --tests 'com.pocketshell.app.tmux.TmuxSessionViewModelTest.tmuxInputStreamDropsOverflowAndAcceptsLaterBytes' --tests 'com.pocketshell.app.tmux.TmuxSessionViewModelTest.sendToAgentPaneAckTimeoutBoundsStuckCaptureCommand'