### PR TITLE
Harden queued prompt send paths

### DIFF
--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerSheet.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerSheet.kt
@@ -323,7 +323,7 @@ public fun PromptComposerSheet(
             val previews = uris.map { uri ->
                 PromptComposerViewModel.AttachmentPreview(
                     uri = uri,
-                    mimeType = runCatching { context.contentResolver.getType(uri) }.getOrNull(),
+                    mimeType = null,
                 )
             }
             viewModel.attachFiles(count = uris.size, previews = previews) {
@@ -705,6 +705,7 @@ internal fun SheetContent(
     val isTranscribing = state.recording == PromptComposerViewModel.RecordingState.Transcribing
     val attachmentUploading =
         state.attachmentUpload as? PromptComposerViewModel.AttachmentUploadState.Uploading
+    val retryableOutboundItem = retryableOutboundQueueItem(outboundQueueItems)
 
     // Issue #169 Part 1: hold the screen on while we are actively
     // capturing audio or waiting for Whisper. Without this, the system's
@@ -821,6 +822,19 @@ internal fun SheetContent(
         focusManager.clearFocus(force = true)
         keyboardController?.hide()
         onSend(true)
+    }
+    val commitSendOrRetryQueued: () -> Unit = {
+        if (draftFieldValue.text.isEmpty() &&
+            state.attachments.isEmpty() &&
+            retryableOutboundItem != null &&
+            !state.sendInFlight
+        ) {
+            focusManager.clearFocus(force = true)
+            keyboardController?.hide()
+            onRetryOutboundItem(retryableOutboundItem.id)
+        } else {
+            commitAndSend()
+        }
     }
     // Issue #682 / #567: bound the composer body to the room ABOVE the keyboard.
     //
@@ -1361,10 +1375,12 @@ internal fun SheetContent(
                     // disable while a send is in flight (#745). [commitAndSend]
                     // flushes the live text before dispatching so the tap delivers.
                     val sendEnabled =
-                        (draftFieldValue.text.isNotEmpty() || state.attachments.isNotEmpty()) &&
+                        (draftFieldValue.text.isNotEmpty() ||
+                            state.attachments.isNotEmpty() ||
+                            retryableOutboundItem != null) &&
                             !state.sendInFlight
                     SendButton(
-                        onClick = commitAndSend,
+                        onClick = commitSendOrRetryQueued,
                         enabled = sendEnabled,
                         sending = state.sendInFlight,
                         modifier = Modifier.testTag(COMPOSER_SEND_ENTER_TAG),
@@ -3081,6 +3097,11 @@ internal fun outboundQueueStateLabel(item: OutboundItem): String = when (item.st
 
 internal fun outboundAttachmentCountLabel(count: Int): String =
     "$count attachment${if (count == 1) "" else "s"}"
+
+internal fun retryableOutboundQueueItem(items: List<OutboundItem>): OutboundItem? =
+    items
+        .filter { it.state == OutboundState.Queued || it.state == OutboundState.Failed }
+        .minByOrNull { it.createdAtMs }
 
 /**
  * Issue #180 helper: humanise an epoch-millis timestamp into "Just now"

--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerViewModel.kt
@@ -961,30 +961,67 @@ public class PromptComposerViewModel @Inject constructor(
             }
             return
         }
-        val outboundItem = enqueueOutboundSend(
+        if (outboundQueueStore !== DisabledOutboundQueueStore &&
+            sendTarget.sessionKey.isNotBlank()
+        ) {
+            viewModelScope.launch(outboundQueueDispatcher) {
+                try {
+                    val outboundItem = enqueueOutboundSend(
+                        cleanDraft = draft,
+                        attachments = attachments,
+                        withEnter = withEnter,
+                        sendTarget = sendTarget,
+                    )
+                    emitPreparedSendRequest(
+                        text = text,
+                        withEnter = withEnter,
+                        cleanDraft = draft,
+                        attachments = attachments,
+                        sendTarget = sendTarget,
+                        outboundQueueItemId = outboundItem?.id,
+                    )
+                } catch (cancelled: CancellationException) {
+                    clearStrandedSendInFlight()
+                    throw cancelled
+                } catch (t: Throwable) {
+                    clearStrandedSendInFlight(
+                        error = "Send failed: reconnect, then send again or discard the draft.",
+                    )
+                }
+            }
+            return
+        }
+        emitPreparedSendRequest(
+            text = text,
+            withEnter = withEnter,
             cleanDraft = draft,
             attachments = attachments,
-            withEnter = withEnter,
             sendTarget = sendTarget,
+            outboundQueueItemId = null,
         )
-        // Issue #254: a `Channel.trySend` buffers the item until a
-        // collector consumes it, so a send dispatched while the sheet's
-        // collector is mid-recreate (dismiss → re-open) is delivered to
-        // the next collector instead of being dropped.
+    }
+
+    private fun emitPreparedSendRequest(
+        text: String,
+        withEnter: Boolean,
+        cleanDraft: String,
+        attachments: List<StagedAttachment>,
+        sendTarget: SendTargetSnapshot,
+        outboundQueueItemId: String?,
+    ) {
+        // Issue #254: a `Channel.trySend` buffers the item until a collector
+        // consumes it, so a send dispatched while the sheet's collector is
+        // mid-recreate (dismiss → re-open) is delivered to the next collector.
         val request = SendRequest(
             text = text,
             withEnter = withEnter,
-            // Issue #872: carry the clean draft + staged tiles so a failed
-            // send restores the original text + the actual attachment tiles,
-            // not the paths-folded-into-text proxy.
-            cleanDraft = draft,
+            cleanDraft = cleanDraft,
             attachments = attachments,
             sendTarget = sendTarget,
-            outboundQueueItemId = outboundItem?.id,
+            outboundQueueItemId = outboundQueueItemId,
         )
-        // Issue #971: remember the in-flight prompt so a wedged/cancelled send
-        // (watchdog / strand-clear / cancellation) restores the EXACT draft +
-        // tiles to the now-cleared composer, not an empty one.
+        // Issue #971: remember the in-flight prompt so wedged/cancelled send
+        // recovery restores the exact draft + tiles to the now-cleared composer.
         inFlightSendRequest = request
         if (_sendRequests.trySend(request).isFailure) {
             // Issue #971/#987: a buffer-full enqueue is a transient dispatch

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
@@ -487,7 +487,6 @@ public fun TmuxSessionScreen(
     // reported. We disable those affordances and surface a visible
     // "Reconnecting" / "Disconnected" pill instead.
     val sessionLive = rawStatus is ConnectionStatus.Connected
-    val outboundQueueItems by promptComposerViewModel.outboundQueueItems.collectAsState()
     val outboundQueueAutoFlushController = remember(targetSessionId.value) {
         OutboundQueueAutoFlushController()
     }
@@ -511,11 +510,12 @@ public fun TmuxSessionScreen(
             promptComposerViewModel.requeueStaleOutboundInFlight()
         }
     }
-    LaunchedEffect(sessionLive, targetSessionId.value, outboundQueueItems) {
-        outboundQueueAutoFlushController.onQueueSnapshotChanged(sessionLive) { excludingIds ->
-            promptComposerViewModel.retryNextOutboundItem(excludingIds = excludingIds)
-        }
-    }
+    TmuxOutboundQueueAutoFlushEffect(
+        sessionLive = sessionLive,
+        targetSessionKey = targetSessionId.value,
+        promptComposerViewModel = promptComposerViewModel,
+        controller = outboundQueueAutoFlushController,
+    )
     val sessionCardsState by viewModel.sessionCards.collectAsState()
     val sessionCards = remember(sessionCardsState, activeSessionCardsTargetKey) {
         if (sessionCardsState.targetKey == activeSessionCardsTargetKey) {
@@ -4277,6 +4277,22 @@ internal fun handleTmuxSessionSelection(
     if (selectedSessionName == currentSessionName) return
     onDismiss()
     onReplace(selectedSessionName)
+}
+
+@Composable
+private fun TmuxOutboundQueueAutoFlushEffect(
+    sessionLive: Boolean,
+    targetSessionKey: String,
+    promptComposerViewModel: PromptComposerViewModel,
+    controller: OutboundQueueAutoFlushController,
+) {
+    LaunchedEffect(sessionLive, targetSessionKey, promptComposerViewModel, controller) {
+        promptComposerViewModel.outboundQueueItems.collect {
+            controller.onQueueSnapshotChanged(sessionLive) { excludingIds ->
+                promptComposerViewModel.retryNextOutboundItem(excludingIds = excludingIds)
+            }
+        }
+    }
 }
 
 /**

--- a/app/src/test/java/com/pocketshell/app/composer/PromptComposerSheetQueueHelperTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/PromptComposerSheetQueueHelperTest.kt
@@ -1,0 +1,39 @@
+package com.pocketshell.app.composer
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class PromptComposerSheetQueueHelperTest {
+
+    @Test
+    fun retryableOutboundQueueItemPicksOldestQueuedOrFailedRow() {
+        val uploading = item("uploading", OutboundState.Uploading, createdAtMs = 1L)
+        val failed = item("failed", OutboundState.Failed, createdAtMs = 2L)
+        val queued = item("queued", OutboundState.Queued, createdAtMs = 3L)
+
+        assertEquals(failed, retryableOutboundQueueItem(listOf(uploading, failed, queued)))
+    }
+
+    @Test
+    fun retryableOutboundQueueItemIgnoresActiveAndDeliveredRows() {
+        assertNull(
+            retryableOutboundQueueItem(
+                listOf(
+                    item("uploading", OutboundState.Uploading, createdAtMs = 1L),
+                    item("in-flight", OutboundState.InFlight, createdAtMs = 2L),
+                    item("delivered", OutboundState.Delivered, createdAtMs = 3L),
+                ),
+            ),
+        )
+    }
+
+    private fun item(id: String, state: OutboundState, createdAtMs: Long): OutboundItem =
+        OutboundItem(
+            id = id,
+            sessionKey = "1/session-a",
+            cleanText = id,
+            state = state,
+            createdAtMs = createdAtMs,
+        )
+}

--- a/app/src/test/java/com/pocketshell/app/composer/PromptComposerSheetSourceGuardTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/PromptComposerSheetSourceGuardTest.kt
@@ -1,0 +1,44 @@
+package com.pocketshell.app.composer
+
+import org.junit.Assert.assertFalse
+import org.junit.Test
+import java.io.File
+
+/**
+ * The document picker callback runs on the UI path. URI metadata probing can
+ * block on remote content providers, so MIME/display-name work must stay in the
+ * existing staging paths that already run on IO dispatchers.
+ */
+class PromptComposerSheetSourceGuardTest {
+
+    @Test
+    fun documentPickerCallbackDoesNotProbeMimeOnMain() {
+        val src = locate("PromptComposerSheet.kt")
+        val callback = src.substringFrom("val attachmentLauncher = rememberLauncherForActivityResult")
+
+        assertFalse(
+            "PromptComposerSheet picker callback must not touch ContentResolver; " +
+                "resolve MIME/display-name/bytes inside attachment staging off Main.",
+            callback.contains("contentResolver") ||
+                callback.contains(".getType(") ||
+                callback.contains(".query(") ||
+                callback.contains(".openInputStream("),
+        )
+    }
+
+    private fun String.substringFrom(marker: String): String {
+        val start = indexOf(marker)
+        check(start >= 0) { "$marker not found" }
+        return substring(start, minOf(start + 900, length))
+    }
+
+    private fun locate(relative: String): String {
+        val candidates = listOf(
+            File("app/src/main/java/com/pocketshell/app/composer/$relative"),
+            File("src/main/java/com/pocketshell/app/composer/$relative"),
+        )
+        val file = candidates.firstOrNull { it.isFile }
+            ?: error("Could not locate $relative from ${File(".").absolutePath}")
+        return file.readText()
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/composer/PromptComposerViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/PromptComposerViewModelTest.kt
@@ -3335,6 +3335,39 @@ class PromptComposerViewModelTest {
         assertEquals(listOf(queueId), vm.outboundQueueItems.value.map { it.id })
     }
 
+    @Test
+    fun requestSendInIdleSchedulesOutboundEnqueueOffCallerThread() = runTest {
+        val queue = InMemoryOutboundQueueStore()
+        val vm = newVm(
+            samplerDispatcher = StandardTestDispatcher(testScheduler),
+            outboundQueueStore = queue,
+        )
+        val sent = collectSendRequests(vm)
+        val target = PromptComposerViewModel.SendTargetSnapshot(
+            sessionKey = "1/session-a",
+            paneId = "%7",
+            route = OutboundRoute.AgentPayload,
+            agentKind = "codex",
+        )
+
+        vm.onComposerTargetChanged("1/session-a")
+        vm.onDraftChange("ship it later")
+        vm.requestSend(withEnter = true, sendTarget = target)
+
+        assertTrue(vm.uiState.value.sendInFlight)
+        assertEquals("", vm.uiState.value.draft)
+        assertTrue(sent.isEmpty())
+        assertTrue(queue.itemsFor("1/session-a").isEmpty())
+
+        advanceUntilIdle()
+
+        val request = sent.single()
+        val queueId = requireNotNull(request.outboundQueueItemId)
+        assertEquals("ship it later", request.cleanDraft)
+        assertEquals(OutboundState.InFlight, queue.item(queueId)!!.state)
+        assertEquals(listOf(queueId), vm.outboundQueueItems.value.map { it.id })
+    }
+
     // -- Issue #971/#987: single-representation + auto-retry on drop -------
     //
     // The maintainer's v0.4.18 dogfood + the #987 refinement: while a send is in


### PR DESCRIPTION
## Summary
- remove picker-time ContentResolver MIME probing from the composer document callback; attachment metadata stays in IO-backed staging paths
- let the primary Send button retry the oldest visible queued/failed prompt when the editor is empty
- move fresh durable outbound enqueue for text sends onto the outbound queue dispatcher before emitting the send request
- move tmux outbound queue auto-flush collection into a leaf side-effect composable so queue snapshots do not invalidate the full session screen

## Validation
- scripts/check-connection-vm-ratchet.sh
- git diff --check
- ./gradlew :app:testDebugUnitTest --tests 'com.pocketshell.app.tmux.TmuxSessionScreenTest.outboundQueueAutoFlushRequeuesOnLiveAndSuppressesSameWindowRetryLoop' --tests 'com.pocketshell.app.tmux.TmuxSessionScreenTest.kebabReconnectThenLiveWindowFlushesQueuedOutboundMessage' --tests 'com.pocketshell.app.composer.PromptComposerSheetSourceGuardTest.documentPickerCallbackDoesNotProbeMimeOnMain' --tests 'com.pocketshell.app.composer.PromptComposerSheetQueueHelperTest.*' --tests 'com.pocketshell.app.composer.PromptComposerViewModelTest.requestSendInIdleSchedulesOutboundEnqueueOffCallerThread' --tests 'com.pocketshell.app.composer.PromptComposerViewModelTest.requestSendEnqueuesOutboundItemAndCarriesQueueId'