### PR TITLE
Harden composer and terminal freeze paths

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerOutboundQueueTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerOutboundQueueTest.kt
@@ -117,6 +117,50 @@ class PromptComposerOutboundQueueTest {
     }
 
     @Test
+    fun outboundQueueCollapsedRetryInvokesOldestQueuedOrFailedRow() {
+        val failed = OutboundItem(
+            id = "failed-collapsed",
+            sessionKey = "1/a",
+            cleanText = "send after reconnect",
+            state = OutboundState.Failed,
+            lastError = "connection lost",
+            createdAtMs = 1L,
+        )
+        val queued = OutboundItem(
+            id = "queued-collapsed",
+            sessionKey = "1/a",
+            cleanText = "queued behind it",
+            state = OutboundState.Queued,
+            createdAtMs = 2L,
+        )
+        val retriedIds = mutableListOf<String>()
+
+        compose.setContent {
+            PocketShellTheme {
+                SheetContent(
+                    state = PromptComposerViewModel.UiState(),
+                    onClose = {},
+                    onDraftChange = {},
+                    onMicTap = {},
+                    onSend = {},
+                    outboundQueueItems = listOf(failed, queued),
+                    outboundQueueExpanded = false,
+                    onRetryOutboundItem = { retriedIds += it },
+                )
+            }
+        }
+
+        compose.onNodeWithTag(COMPOSER_OUTBOUND_QUEUE_BANNER_TAG).assertIsDisplayed()
+        compose.onNodeWithTag(composerOutboundQueueItemRowTestTag(failed.id)).assertDoesNotExist()
+        compose.onNodeWithTag(composerOutboundQueueRetryTestTag(failed.id)).assertIsDisplayed()
+        compose.onNodeWithTag(composerOutboundQueueRetryTestTag(queued.id)).assertDoesNotExist()
+
+        compose.onNodeWithTag(composerOutboundQueueRetryTestTag(failed.id)).performClick()
+        compose.waitForIdle()
+        assertEquals(listOf(failed.id), retriedIds)
+    }
+
+    @Test
     fun outboundQueueActiveRowsStayVisibleWithoutRetryOrDeleteControls() {
         val inFlight = OutboundItem(
             id = "in-flight-1",

--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerSheet.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerSheet.kt
@@ -2634,6 +2634,7 @@ private fun OutboundQueueBanner(
     onRetry: (String) -> Unit,
     onResendAll: () -> Unit,
 ) {
+    val collapsedRetryItem = if (expanded) null else retryableOutboundQueueItem(items)
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -2671,6 +2672,18 @@ private fun OutboundQueueBanner(
                     overflow = TextOverflow.Ellipsis,
                 )
             }
+            if (collapsedRetryItem != null) {
+                Spacer(modifier = Modifier.width(8.dp))
+                PendingActionButton(
+                    label = "Retry",
+                    primary = true,
+                    onClick = { onRetry(collapsedRetryItem.id) },
+                    modifier = Modifier.testTag(
+                        composerOutboundQueueRetryTestTag(collapsedRetryItem.id),
+                    ),
+                )
+            }
+            Spacer(modifier = Modifier.width(8.dp))
             DisclosureIcon(
                 expanded = expanded,
                 tint = PocketShellColors.TextSecondary,

--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerViewModel.kt
@@ -39,8 +39,13 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import javax.inject.Inject
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
 import java.util.UUID
 
 /**
@@ -275,6 +280,11 @@ public class PromptComposerViewModel @Inject constructor(
         null
     private var outboundSidecarDispatchInFlight: Boolean = false
     internal var outboundQueueDispatcher: CoroutineDispatcher = Dispatchers.IO
+    private val draftStoreWriteMutex = Mutex()
+    private val draftStoreWriteGenerations: ConcurrentHashMap<String, AtomicLong> =
+        ConcurrentHashMap()
+    private val draftStoreOverrides: ConcurrentHashMap<String, String> =
+        ConcurrentHashMap()
 
     /**
      * Issue #971: the [SendRequest] for the prompt currently in flight, captured
@@ -453,8 +463,64 @@ public class PromptComposerViewModel @Inject constructor(
         // a single owner-stamped slot the #746 switch discards). Keyed by the
         // session that owns this draft; nothing to persist when no target is
         // wired yet (proof-of-life / pre-target restore).
-        composerTarget?.let { composerDraftStore.save(it, newText) }
+        saveComposerDraft(composerTarget, newText)
         _uiState.update { it.copy(draft = newText, error = null) }
+    }
+
+    private fun loadComposerDraft(sessionKey: String): String? {
+        val override = draftStoreOverrides[sessionKey]
+        if (override != null || draftStoreOverrides.containsKey(sessionKey)) {
+            return override?.takeIf { it.isNotEmpty() }
+        }
+        return composerDraftStore.load(sessionKey)
+    }
+
+    private fun saveComposerDraft(sessionKey: String?, draft: String) {
+        val key = sessionKey?.takeIf { it.isNotBlank() } ?: return
+        draftStoreOverrides[key] = draft
+        val generation = nextDraftStoreWriteGeneration(key)
+        if (composerDraftStore is SharedPrefsComposerDraftStore) {
+            viewModelScope.launch(outboundQueueDispatcher) {
+                writeLatestComposerDraft(key, generation) {
+                    composerDraftStore.save(key, draft)
+                }
+            }
+        } else {
+            composerDraftStore.save(key, draft)
+        }
+    }
+
+    private fun clearComposerDraft(sessionKey: String?) {
+        val key = sessionKey?.takeIf { it.isNotBlank() } ?: return
+        draftStoreOverrides[key] = ""
+        val generation = nextDraftStoreWriteGeneration(key)
+        if (composerDraftStore is SharedPrefsComposerDraftStore) {
+            viewModelScope.launch(outboundQueueDispatcher) {
+                writeLatestComposerDraft(key, generation) {
+                    composerDraftStore.clear(key)
+                }
+            }
+        } else {
+            composerDraftStore.clear(key)
+        }
+    }
+
+    private fun nextDraftStoreWriteGeneration(sessionKey: String): Long =
+        draftStoreWriteGenerations
+            .computeIfAbsent(sessionKey) { AtomicLong() }
+            .incrementAndGet()
+
+    private suspend fun writeLatestComposerDraft(
+        sessionKey: String,
+        generation: Long,
+        write: () -> Unit,
+    ) {
+        draftStoreWriteMutex.withLock {
+            val latest = draftStoreWriteGenerations[sessionKey]?.get()
+            if (latest == generation) {
+                write()
+            }
+        }
     }
 
     /**
@@ -972,14 +1038,16 @@ public class PromptComposerViewModel @Inject constructor(
                         withEnter = withEnter,
                         sendTarget = sendTarget,
                     )
-                    emitPreparedSendRequest(
-                        text = text,
-                        withEnter = withEnter,
-                        cleanDraft = draft,
-                        attachments = attachments,
-                        sendTarget = sendTarget,
-                        outboundQueueItemId = outboundItem?.id,
-                    )
+                    withContext(Dispatchers.Main.immediate) {
+                        emitPreparedSendRequest(
+                            text = text,
+                            withEnter = withEnter,
+                            cleanDraft = draft,
+                            attachments = attachments,
+                            sendTarget = sendTarget,
+                            outboundQueueItemId = outboundItem?.id,
+                        )
+                    }
                 } catch (cancelled: CancellationException) {
                     clearStrandedSendInFlight()
                     throw cancelled
@@ -1051,7 +1119,7 @@ public class PromptComposerViewModel @Inject constructor(
         savedStateHandle[KEY_DRAFT] = ""
         savedStateHandle[KEY_DRAFT_OWNER] = null
         composerTarget?.let { target ->
-            composerDraftStore.clear(target)
+            clearComposerDraft(target)
             composerDraftStore.clearAttachments(target)
         }
         _uiState.update { current ->
@@ -1182,7 +1250,7 @@ public class PromptComposerViewModel @Inject constructor(
         markOutboundSendDelivered(request)
         val deliveryTarget = request?.sendTarget?.sessionKey?.takeIf { it.isNotBlank() } ?: composerTarget
         if (deliveryTarget != null && deliveryTarget != composerTarget) {
-            composerDraftStore.clear(deliveryTarget)
+            clearComposerDraft(deliveryTarget)
             composerDraftStore.clearAttachments(deliveryTarget)
             _uiState.update {
                 it.copy(
@@ -1252,7 +1320,7 @@ public class PromptComposerViewModel @Inject constructor(
         val restoredAttachments = request.attachments
         val restoreTarget = request.sendTarget.sessionKey.takeIf { it.isNotBlank() } ?: composerTarget
         if (restoreTarget != null && restoreTarget != composerTarget) {
-            composerDraftStore.save(restoreTarget, restoredDraft)
+            saveComposerDraft(restoreTarget, restoredDraft)
             composerDraftStore.saveAttachments(restoreTarget, restoredAttachments.toDurableRefs())
             _uiState.update { current ->
                 current.copy(
@@ -1275,7 +1343,7 @@ public class PromptComposerViewModel @Inject constructor(
         // draft was kept" promise becomes recoverable, not just true for an
         // instant — and now covers the attachment, not just the text).
         restoreTarget?.let { target ->
-            composerDraftStore.save(target, restoredDraft)
+            saveComposerDraft(target, restoredDraft)
             composerDraftStore.saveAttachments(target, restoredAttachments.toDurableRefs())
         }
         _uiState.update { current ->
@@ -1586,7 +1654,7 @@ public class PromptComposerViewModel @Inject constructor(
         // otherwise the next switch back would reload what the user just
         // discarded.
         composerTarget?.let {
-            composerDraftStore.clear(it)
+            clearComposerDraft(it)
             composerDraftStore.clearAttachments(it)
         }
         _uiState.update { current ->
@@ -1640,7 +1708,7 @@ public class PromptComposerViewModel @Inject constructor(
         // under the new owner, then keep it on screen (do not reload).
         if (hasDraft && draftOwner == null) {
             savedStateHandle[KEY_DRAFT_OWNER] = targetKey
-            composerDraftStore.save(targetKey, _uiState.value.draft)
+            saveComposerDraft(targetKey, _uiState.value.draft)
             // Issue #872: the orphan draft may carry staged attachment tiles
             // (e.g. a restored failed send); adopt those under the new owner too
             // so they are recoverable on a later switch.
@@ -1656,7 +1724,7 @@ public class PromptComposerViewModel @Inject constructor(
         // this covers any gap, e.g. a draft set without going through
         // [onDraftChange], and the staged-tile state #872 makes durable.)
         if (hasDraft && draftOwner != null && draftOwner != targetKey) {
-            composerDraftStore.save(draftOwner, _uiState.value.draft)
+            saveComposerDraft(draftOwner, _uiState.value.draft)
             composerDraftStore.saveAttachments(
                 draftOwner,
                 _uiState.value.attachments.toDurableRefs(),
@@ -1667,7 +1735,7 @@ public class PromptComposerViewModel @Inject constructor(
         // Load the incoming session's durable draft + attachments (empty when
         // none) so the in-memory state shows ONLY this session's draft/tiles —
         // no bleed, but also no loss of the other session's draft (#832/#872).
-        val incoming = composerDraftStore.load(targetKey).orEmpty()
+        val incoming = loadComposerDraft(targetKey).orEmpty()
         val incomingAttachments = composerDraftStore.loadAttachments(targetKey)
             .toStagedAttachments()
         if (incoming == _uiState.value.draft &&

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -16123,7 +16123,7 @@ public class TmuxSessionViewModel @Inject constructor(
                 }
             }
         }
-        return TmuxPaneInputStream(queue)
+        return TmuxPaneInputStream(paneId, queue)
     }
 
     private suspend fun sendDequeuedInputBatch(
@@ -18394,21 +18394,23 @@ public class TmuxSessionViewModel @Inject constructor(
         data class NamedKey(val name: String) : TmuxInputToken
     }
 
-    private class TmuxPaneInputStream(
-        private val queue: TmuxPaneInputQueue,
-    ) : OutputStream() {
-        override fun write(b: Int) {
-            write(byteArrayOf(b.toByte()))
-        }
+    private class TmuxPaneInputStream(private val paneId: String, private val queue: TmuxPaneInputQueue) :
+        OutputStream() {
+        override fun write(b: Int) = write(byteArrayOf(b.toByte()))
 
         override fun write(buffer: ByteArray, offset: Int, length: Int) {
             if (length <= 0) return
-            try { queue.write(buffer, offset, length) } catch (_: IOException) { }
+            try {
+                queue.write(buffer, offset, length)
+            } catch (overflow: TmuxPaneInputQueueOverflowException) {
+                DiagnosticEvents.record(
+                    "connection", "pane_input_write_dropped", "pane" to paneId,
+                    "bytes" to length, "reason" to "queue_full", "message" to overflow.message,
+                )
+            }
         }
 
-        override fun close() {
-            queue.close()
-        }
+        override fun close() = queue.close()
     }
 
     /**
@@ -18890,14 +18892,15 @@ internal class TmuxPaneInputQueue(
     private var maxObservedBatchChunks: Int = 0
     private var sentBatchCount: Long = 0L
     private var maxObservedSendLatencyNs: Long = 0L
+    private var closed: Boolean = false
 
     fun write(buffer: ByteArray, offset: Int, length: Int) {
-        if (length > maxPendingBytes) {
-            throw IOException("tmux pane input queue write exceeds pending byte budget")
+        if (offset < 0 || length < 0 || length > buffer.size - offset) {
+            throw IndexOutOfBoundsException("offset=$offset length=$length size=${buffer.size}")
         }
         var written = 0
         while (written < length) {
-            val chunkLength = minOf(maxPendingBytes, TMUX_INPUT_CHUNK_BYTES, length - written)
+            val chunkLength = minOf(TMUX_INPUT_CHUNK_BYTES, length - written)
             val copy = buffer.copyOfRange(offset + written, offset + written + chunkLength)
             enqueue(copy)
             written += chunkLength
@@ -18981,15 +18984,14 @@ internal class TmuxPaneInputQueue(
         )
     }
 
-    fun close() {
-        signal.close()
-    }
+    fun close() { synchronized(lock) { closed = true }; signal.close() }
 
     private fun enqueue(bytes: ByteArray) {
         val segment = TmuxPaneInputSegment(bytes, System.nanoTime())
         synchronized(lock) {
+            if (closed) throw IOException("tmux pane input queue is closed")
             if (pendingBytes + bytes.size > maxPendingBytes) {
-                throw IOException("tmux pane input queue pending byte budget exceeded")
+                throw TmuxPaneInputQueueOverflowException("tmux pane input queue pending byte budget exceeded")
             }
             pendingBytes += bytes.size
             totalEnqueuedBytes += bytes.size.toLong()
@@ -19015,11 +19017,10 @@ internal class TmuxPaneInputQueue(
         }
     }
 
-    private fun signalIfPending() {
-        val hasPending = synchronized(lock) { pending.isNotEmpty() }
-        if (hasPending) signal.trySend(Unit)
-    }
+    private fun signalIfPending() { if (synchronized(lock) { pending.isNotEmpty() }) signal.trySend(Unit) }
 }
+
+private class TmuxPaneInputQueueOverflowException(message: String) : IOException(message)
 
 /**
  * Issue #243: true when [bytes] contains only complete terminal emulator

--- a/app/src/test/java/com/pocketshell/app/composer/PromptComposerSheetQueueHelperTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/PromptComposerSheetQueueHelperTest.kt
@@ -28,6 +28,17 @@ class PromptComposerSheetQueueHelperTest {
         )
     }
 
+    @Test
+    fun retryableOutboundQueueItemTreatsRecoveredUploadingRowAsRetryableAfterRequeue() {
+        val recoveredUpload = item("recovered-upload", OutboundState.Queued, createdAtMs = 1L)
+        val freshUpload = item("fresh-upload", OutboundState.Uploading, createdAtMs = 2L)
+
+        assertEquals(
+            recoveredUpload,
+            retryableOutboundQueueItem(listOf(recoveredUpload, freshUpload)),
+        )
+    }
+
     private fun item(id: String, state: OutboundState, createdAtMs: Long): OutboundItem =
         OutboundItem(
             id = id,

--- a/app/src/test/java/com/pocketshell/app/composer/PromptComposerViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/PromptComposerViewModelTest.kt
@@ -5307,6 +5307,54 @@ class PromptComposerViewModelTest {
     }
 
     @Test
+    fun sharedPrefsDraftWritesAreScheduledOffCallerThreadButVisibleToSessionSwitches() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val store = SharedPrefsComposerDraftStore(ApplicationProvider.getApplicationContext())
+        val target = "test/off-main-${System.nanoTime()}"
+        val vm = newVm(
+            samplerDispatcher = dispatcher,
+            composerDraftStore = store,
+        )
+        vm.onComposerTargetChanged(target)
+
+        vm.onDraftChange("first")
+        vm.onDraftChange("second")
+
+        assertEquals("second", vm.uiState.value.draft)
+        assertNull(store.load(target))
+
+        vm.onComposerTargetChanged("$target/other")
+        vm.onComposerTargetChanged(target)
+
+        assertEquals("second", vm.uiState.value.draft)
+        assertNull(store.load(target))
+
+        advanceUntilIdle()
+
+        assertEquals("second", store.load(target))
+    }
+
+    @Test
+    fun clearDraftWinsOverPendingSharedPrefsDraftSave() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val store = SharedPrefsComposerDraftStore(ApplicationProvider.getApplicationContext())
+        val target = "test/clear-wins-${System.nanoTime()}"
+        val vm = newVm(
+            samplerDispatcher = dispatcher,
+            composerDraftStore = store,
+        )
+        vm.onComposerTargetChanged(target)
+
+        vm.onDraftChange("stale draft")
+        vm.discardDraft()
+
+        assertEquals("", vm.uiState.value.draft)
+        advanceUntilIdle()
+
+        assertNull(store.load(target))
+    }
+
+    @Test
     fun discardClearsTheDurableSlotSoSwitchBackIsEmpty() = runTest {
         // Issue #832: Discard is the explicit "throw it away" control — it must
         // drop the durable slot too, otherwise a switch back resurrects the

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
@@ -12312,6 +12312,73 @@ class TmuxSessionViewModelTest {
     }
 
     @Test
+    fun tmuxInputStreamLargeSingleWriteEnqueuesBoundedPrefixInsteadOfDroppingWholePaste() = runTest(scheduler) {
+        val vm = newVm()
+        val client = FakeTmuxClient().apply {
+            sendCommandGatePrefix = "send-keys -l -t %0"
+            sendCommandGate = CompletableDeferred()
+        }
+        vm.attachClientForTest(client)
+        val sink = vm.tmuxInputSinkForTest("%0")
+        val capacity = vm.tmuxInputCapacityBytesForTest()
+        val payload = ByteArray(capacity + TMUX_INPUT_CHUNK_BYTES) { index ->
+            if (index < capacity) 'a'.code.toByte() else 'z'.code.toByte()
+        }
+
+        val write = runCatching { sink.write(payload) }
+        assertTrue(
+            "a single paste larger than the queue capacity must not be rejected before any bytes are enqueued",
+            write.isSuccess,
+        )
+        val beforeDrain = vm.tmuxInputMetricsForTest("%0")
+            ?: error("input metrics should be recorded")
+        assertEquals(
+            "the bounded queue should retain the prefix it can send instead of dropping the whole paste",
+            capacity.toLong(),
+            beforeDrain.totalEnqueuedBytes,
+        )
+
+        runCurrent()
+        client.sendCommandGate?.complete(Unit)
+        advanceUntilIdle()
+
+        val sentText = client.sentCommands
+            .filter { it.startsWith("send-keys -l -t %0 -- '") }
+            .joinToString(separator = "") { command ->
+                command.substringAfter("-- '").removeSuffix("'")
+            }
+        assertEquals(
+            "only the bounded prefix should be sent after the overflow tail is dropped",
+            capacity,
+            sentText.length,
+        )
+        assertTrue("the retained prefix should reach tmux", sentText.all { it == 'a' })
+        assertFalse("overflow tail bytes must not be replayed later", sentText.any { it == 'z' })
+    }
+
+    @Test
+    fun tmuxInputStreamWriteAfterCloseThrowsInsteadOfSilentlyDroppingBytes() = runTest(scheduler) {
+        val vm = newVm()
+        val client = FakeTmuxClient()
+        vm.attachClientForTest(client)
+        val sink = vm.tmuxInputSinkForTest("%0")
+
+        sink.close()
+        val write = runCatching { sink.write("after-close".toByteArray(Charsets.US_ASCII)) }
+
+        assertTrue(
+            "writes after close must be observable failures, not silent successful drops",
+            write.isFailure,
+        )
+        assertTrue(
+            "closed queue writes should fail with IOException",
+            write.exceptionOrNull() is IOException,
+        )
+        advanceUntilIdle()
+        assertTrue(client.sentCommands.none { it.startsWith("send-keys") })
+    }
+
+    @Test
     fun sendToAgentPaneLongSingleLineUsesBoundedBracketedChunksThenEnter() = runTest(scheduler) {
         val vm = newVm()
         val client = FakeTmuxClient()


### PR DESCRIPTION
## Summary
- move SharedPrefs-backed composer draft writes off the typing path while keeping session switches immediately consistent
- expose a collapsed Retry action for the oldest queued/failed outbound prompt
- chunk large terminal input writes into the bounded pane queue and make closed writes observable failures

## Validation
- git diff --check
- scripts/check-connection-vm-ratchet.sh
- ./gradlew :app:testDebugUnitTest --tests 'com.pocketshell.app.composer.PromptComposerViewModelTest.sharedPrefsDraftWritesAreScheduledOffCallerThreadButVisibleToSessionSwitches' --tests 'com.pocketshell.app.composer.PromptComposerViewModelTest.clearDraftWinsOverPendingSharedPrefsDraftSave' --tests 'com.pocketshell.app.composer.PromptComposerViewModelTest.requestSendInIdleSchedulesOutboundEnqueueOffCallerThread' --tests 'com.pocketshell.app.composer.PromptComposerViewModelTest.requestSendEnqueuesOutboundItemAndCarriesQueueId' --tests 'com.pocketshell.app.composer.PromptComposerSheetQueueHelperTest' --tests 'com.pocketshell.app.tmux.TmuxSessionViewModelTest.tmuxInputStreamLargeSingleWriteEnqueuesBoundedPrefixInsteadOfDroppingWholePaste' --tests 'com.pocketshell.app.tmux.TmuxSessionViewModelTest.tmuxInputStreamWriteAfterCloseThrowsInsteadOfSilentlyDroppingBytes'
- ./gradlew :app:compileDebugAndroidTestKotlin