### PR TITLE
Move quick replies off session root

### DIFF
--- a/app/src/main/java/com/pocketshell/app/tmux/AgentQuickReply.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/AgentQuickReply.kt
@@ -1,9 +1,27 @@
 package com.pocketshell.app.tmux
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
+
 internal data class AgentQuickReply(
     val label: String,
     val payload: String,
 )
+
+internal fun agentQuickRepliesForVisibleTextFlow(
+    visibleText: Flow<String>,
+    enabled: Boolean,
+): Flow<List<AgentQuickReply>> {
+    if (!enabled) return flowOf(emptyList())
+    return visibleText
+        .map { agentQuickRepliesForVisibleText(it) }
+        .distinctUntilChanged()
+        .flowOn(Dispatchers.Default)
+}
 
 internal fun agentQuickRepliesForVisibleText(visibleText: String): List<AgentQuickReply> {
     val tail = visibleText

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
@@ -194,6 +194,7 @@ import androidx.compose.foundation.layout.width
 import com.pocketshell.core.storage.entity.HostEntity
 import com.pocketshell.core.terminal.ui.TerminalKeyboardMode
 import com.pocketshell.core.terminal.ui.TerminalSurface
+import com.pocketshell.core.terminal.ui.TerminalSurfaceState
 import com.pocketshell.core.terminal.ui.showTerminalSoftKeyboard
 import com.pocketshell.uikit.components.Badge
 import com.pocketshell.uikit.components.BadgeRole
@@ -213,7 +214,6 @@ import com.pocketshell.uikit.theme.PocketShellDensity
 import com.pocketshell.uikit.theme.PocketShellShapes
 import com.pocketshell.uikit.theme.PocketShellSpacing
 import com.pocketshell.uikit.theme.PocketShellType
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import kotlin.math.abs
 
@@ -931,23 +931,6 @@ public fun TmuxSessionScreen(
             hasStickyAgent = paletteAgent != null,
             recordedAgentKind = tmuxSessionRecordedAgentKind(currentSessionRecordedKind),
         )
-    val visibleTerminalText by remember(currentPaneId, surfaceTerminalState, quickReplyInputEligible) {
-        if (quickReplyInputEligible) {
-            surfaceTerminalState?.flowOfVisibleScreenText ?: flowOf("")
-        } else {
-            flowOf("")
-        }
-    }.collectAsState(
-        initial = if (quickReplyInputEligible) {
-            surfaceTerminalState?.visibleScreenTextSnapshot().orEmpty()
-        } else {
-            ""
-        },
-    )
-    val agentQuickReplies = remember(visibleTerminalText) {
-        agentQuickRepliesForVisibleText(visibleTerminalText)
-    }
-
     // Issue #770: the set of engine slash-commands the terminal should make
     // tappable for the visible pane. Sourced verbatim from [AgentCommandCatalog]
     // for the detected/sticky engine — so only commands that actually exist for
@@ -2386,22 +2369,17 @@ public fun TmuxSessionScreen(
                 onCancelChoice = viewModel::cancelAssistantChoice,
             )
 
-            run {
-                val pane = surfacePane
-                val quickReplyInputEnabled = quickReplyInputEligible &&
-                    !showMicSheet &&
-                    !showConversation
-                if (quickReplyInputEnabled && agentQuickReplies.isNotEmpty()) {
-                    AgentQuickReplyRow(
-                        replies = agentQuickReplies,
-                        onReply = { reply ->
-                            viewModel.writeInputToPane(
-                                pane.paneId,
-                                reply.payload.toByteArray(Charsets.UTF_8),
-                            )
-                        },
-                    )
-                }
+            surfacePane?.let { pane ->
+                AgentQuickReplyBand(
+                    terminalState = pane.terminalState,
+                    enabled = quickReplyInputEligible && !showMicSheet && !showConversation,
+                    onReply = { reply ->
+                        viewModel.writeInputToPane(
+                            pane.paneId,
+                            reply.payload.toByteArray(Charsets.UTF_8),
+                        )
+                    },
+                )
             }
 
             // Issue #810 (hard-cut, D22) — the prompt composer affordance is
@@ -3104,6 +3082,24 @@ internal fun detectedPortForwardNavigation(remotePort: Int): PortForwardNavigati
  * not an overlay, so it reserves its own height above the composer/bottom
  * controls and never covers terminal content or the input controls.
  */
+@Composable
+private fun AgentQuickReplyBand(
+    terminalState: TerminalSurfaceState,
+    enabled: Boolean,
+    onReply: (AgentQuickReply) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val replies by remember(terminalState, enabled) {
+        agentQuickRepliesForVisibleTextFlow(
+            visibleText = terminalState.flowOfVisibleScreenText,
+            enabled = enabled,
+        )
+    }.collectAsState(initial = emptyList())
+    if (replies.isNotEmpty()) {
+        AgentQuickReplyRow(replies = replies, onReply = onReply, modifier = modifier)
+    }
+}
+
 @Composable
 internal fun AgentQuickReplyRow(
     replies: List<AgentQuickReply>,

--- a/app/src/test/java/com/pocketshell/app/tmux/AgentQuickReplyTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/AgentQuickReplyTest.kt
@@ -1,5 +1,8 @@
 package com.pocketshell.app.tmux
 
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -80,5 +83,35 @@ class AgentQuickReplyTest {
         val replies = agentQuickRepliesForVisibleText("Use yes/no examples in the docs.")
 
         assertTrue(replies.isEmpty())
+    }
+
+    @Test
+    fun visibleTextFlowParsesRepliesAndSuppressesDuplicateRows() = runTest {
+        val emissions = agentQuickRepliesForVisibleTextFlow(
+            visibleText = flowOf(
+                "Proceed with this command? (y/n)",
+                "Proceed with this command? (y/n)",
+                "Done. Press Enter to continue",
+            ),
+            enabled = true,
+        ).toList()
+
+        assertEquals(
+            listOf(
+                listOf(AgentQuickReply("Yes", "y"), AgentQuickReply("No", "n")),
+                listOf(AgentQuickReply("Enter", "\r")),
+            ),
+            emissions,
+        )
+    }
+
+    @Test
+    fun disabledVisibleTextFlowNeverParsesReplies() = runTest {
+        val emissions = agentQuickRepliesForVisibleTextFlow(
+            visibleText = flowOf("Proceed with this command? (y/n)"),
+            enabled = false,
+        ).toList()
+
+        assertEquals(listOf(emptyList<AgentQuickReply>()), emissions)
     }
 }

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionScreenQuickReplySourceGuardTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionScreenQuickReplySourceGuardTest.kt
@@ -1,0 +1,50 @@
+package com.pocketshell.app.tmux
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * Quick-reply detection follows terminal output during busy agent sessions. The
+ * large session root must not collect visible terminal text directly; that work
+ * belongs in the small quick-reply leaf with off-main parsing.
+ */
+class TmuxSessionScreenQuickReplySourceGuardTest {
+
+    @Test
+    fun rootSessionBodyDoesNotCollectVisibleScreenTextForQuickReplies() {
+        val src = locate("TmuxSessionScreen.kt")
+        val quickReplyEligibility = src.substringBetween(
+            start = "val quickReplyInputEligible =",
+            end = "// Issue #770",
+        )
+
+        assertFalse(
+            "TmuxSessionScreen root must not collect terminal visible text; " +
+                "keep quick-reply collection in AgentQuickReplyBand.",
+            quickReplyEligibility.contains("collectAsState") ||
+                quickReplyEligibility.contains("flowOfVisibleScreenText") ||
+                quickReplyEligibility.contains("visibleScreenTextSnapshot"),
+        )
+        assertTrue(src.contains("private fun AgentQuickReplyBand("))
+    }
+
+    private fun String.substringBetween(start: String, end: String): String {
+        val startIndex = indexOf(start)
+        check(startIndex >= 0) { "$start not found" }
+        val endIndex = indexOf(end, startIndex)
+        check(endIndex >= 0) { "$end not found after $start" }
+        return substring(startIndex, endIndex)
+    }
+
+    private fun locate(relative: String): String {
+        val candidates = listOf(
+            File("app/src/main/java/com/pocketshell/app/tmux/$relative"),
+            File("src/main/java/com/pocketshell/app/tmux/$relative"),
+        )
+        val file = candidates.firstOrNull { it.isFile }
+            ?: error("Could not locate $relative from ${File(".").absolutePath}")
+        return file.readText()
+    }
+}


### PR DESCRIPTION
## Summary
- move quick-reply visible-text collection out of the large TmuxSessionScreen root and into a small leaf band
- derive quick replies with a flow helper that parses/dedupes upstream on Dispatchers.Default
- add flow coverage and a source guard to prevent root visible-text collection from regressing

## Validation
- git diff --check
- scripts/check-connection-vm-ratchet.sh
- ./gradlew :app:testDebugUnitTest --tests 'com.pocketshell.app.tmux.AgentQuickReplyTest' --tests 'com.pocketshell.app.tmux.TmuxSessionScreenQuickReplySourceGuardTest'
- ./gradlew :app:compileDebugAndroidTestKotlin

## Follow-up risks found by agents
- submit ack capture-pane still uses shared tmux control lane
- capture seed/heal post-capture string/byte prep still can run on Main
- queued sidecar uploads are not tracked by reconnect teardown upload job
- Conversation tab render model still does O(window) pairing/filtering on Main