### PR TITLE
Move submit ack capture to exec lane

### DIFF
--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -14901,7 +14901,7 @@ public class TmuxSessionViewModel @Inject constructor(
         needle: String,
     ): Boolean {
         val response = runCatching {
-            client.sendBestEffortCommand("capture-pane -p -t $paneId")
+            client.capturePaneTextViaExec(paneId)
         }.getOrNull() ?: return false
         if (response.isError) return false
         val visible = response.output.joinToString(separator = "")

--- a/app/src/test/java/com/pocketshell/app/tmux/FakeTmuxClient.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/FakeTmuxClient.kt
@@ -186,6 +186,8 @@ internal class FakeTmuxClient(
 
     var suspendForeverOnCommandPrefix: String? = null
 
+    var suspendForeverOnBestEffortCommandPrefix: String? = null
+
     var sendCommandDelayMs: Long = 0L
 
     /**
@@ -196,6 +198,10 @@ internal class FakeTmuxClient(
      * `FALLBACK_FLOOR + injectedRtt` before pressing Enter.
      */
     var captureCommandDelayMs: Long = 0L
+
+    val capturePaneTextViaExecCalls: MutableList<String> = mutableListOf()
+
+    var suspendForeverOnCapturePaneTextViaExec: Boolean = false
 
     var sendCommandGatePrefix: String? = null
 
@@ -318,6 +324,14 @@ internal class FakeTmuxClient(
     override suspend fun sendBestEffortCommand(cmd: String): CommandResponse =
         handleCommand(cmd, bestEffort = true)
 
+    override suspend fun capturePaneTextViaExec(paneId: String, timeoutMs: Long?): CommandResponse {
+        capturePaneTextViaExecCalls += paneId
+        if (suspendForeverOnCapturePaneTextViaExec) {
+            CompletableDeferred<Unit>().await()
+        }
+        return handleCommand("capture-pane -p -t $paneId", bestEffort = false)
+    }
+
     private suspend fun handleCommand(cmd: String, bestEffort: Boolean): CommandResponse {
         sentCommands += cmd
         onCommandSent?.invoke(cmd)
@@ -356,6 +370,11 @@ internal class FakeTmuxClient(
             }
         }
         if (bestEffort) {
+            suspendForeverOnBestEffortCommandPrefix?.let { prefix ->
+                if (cmd.startsWith(prefix)) {
+                    CompletableDeferred<Unit>().await()
+                }
+            }
             failBestEffortOnCommandPrefix?.let { prefix ->
                 if (cmd.startsWith(prefix)) {
                     throw bestEffortException

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
@@ -11865,6 +11865,45 @@ class TmuxSessionViewModelTest {
         )
     }
 
+    @Test
+    fun sendToAgentPaneAckCaptureBypassesWedgedBestEffortControlLane() = runTest(scheduler) {
+        val vm = newVm()
+        val client = FakeTmuxClient()
+        vm.setAgentSubmitMonotonicClockForTest { scheduler.currentTime }
+        vm.attachClientForTest(client)
+        vm.startAgentConversationForTest("%0", newClaudeDetection())
+        vm.setAgentSubmitEnterDelayForTest(0)
+        vm.setAgentSubmitAckTimeoutForTest(1_000L)
+        client.suspendForeverOnBestEffortCommandPrefix = "capture-pane"
+        client.capturePaneResponses.addLast(
+            CommandResponse(number = 0L, output = listOf("> fast ack prompt"), isError = false),
+        )
+
+        var enterSentAtMs = -1L
+        client.onCommandSent = { cmd ->
+            if (cmd == "send-keys -t %0 Enter" && enterSentAtMs < 0L) {
+                enterSentAtMs = scheduler.currentTime
+            }
+        }
+
+        val send = async { vm.sendToAgentPaneResult("%0", "fast ack prompt") }
+        advanceUntilIdle()
+
+        assertTrue("agent submit should succeed", send.await().isSuccess)
+        assertEquals(listOf("%0"), client.capturePaneTextViaExecCalls)
+        assertTrue(
+            "submit ack capture must not wait for the wedged best-effort control lane",
+            enterSentAtMs in 0 until 1_000L,
+        )
+        assertEquals(
+            listOf(
+                "send-keys -l -t %0 -- 'fast ack prompt'",
+                "send-keys -t %0 Enter",
+            ),
+            client.sentCommands.filter { it.startsWith("send-keys") },
+        )
+    }
+
     /**
      * Issue #869: when the agent's input rendering can never be recognised (the
      * payload never shows up in `capture-pane`), Send must NOT hang — it falls
@@ -11924,7 +11963,7 @@ class TmuxSessionViewModelTest {
         vm.startAgentConversationForTest("%0", newClaudeDetection())
         vm.setAgentSubmitEnterDelayForTest(0)
         vm.setAgentSubmitAckTimeoutForTest(80L)
-        client.suspendForeverOnCommandPrefix = "capture-pane"
+        client.suspendForeverOnCapturePaneTextViaExec = true
 
         val send = async { vm.sendToAgentPaneResult("%0", "blocked capture prompt") }
 
@@ -11940,7 +11979,7 @@ class TmuxSessionViewModelTest {
         assertEquals(
             "a stuck ack capture should be tried once, then cancelled by the wall-clock timeout",
             1,
-            client.sentCommands.count { it.startsWith("capture-pane") },
+            client.capturePaneTextViaExecCalls.size,
         )
         assertEquals(
             listOf(

--- a/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxClient.kt
+++ b/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxClient.kt
@@ -173,6 +173,18 @@ public interface TmuxClient : AutoCloseable {
     }
 
     /**
+     * Capture the pane's visible text on the independent exec lane. This is for
+     * acknowledgement probes that only need `capture-pane -p`, not cursor or
+     * scrollback state. The default keeps test doubles compatible by falling
+     * back to the existing best-effort control-mode path.
+     */
+    public suspend fun capturePaneTextViaExec(
+        paneId: String,
+        timeoutMs: Long? = null,
+    ): CommandResponse =
+        sendBestEffortCommand("capture-pane -p -t $paneId")
+
+    /**
      * Issue #692: send several tmux control-mode commands as ONE chained
      * `cmd1 ; cmd2 ; …` request and drain ALL of their `%begin` / (`%end` |
      * `%error`) response blocks under a SINGLE single-flight acquisition,
@@ -1291,6 +1303,42 @@ internal class RealTmuxClient(
             capture = CommandResponse(number = -1L, output = outputLines, isError = isError),
             cursorReply = cursorReply,
         )
+    }
+
+    override suspend fun capturePaneTextViaExec(
+        paneId: String,
+        timeoutMs: Long?,
+    ): CommandResponse {
+        if (closed) throw TmuxClientException("client is closed")
+        if (!connected) throw TmuxClientException("client is not connected")
+        val effectiveTimeoutMs = timeoutMs?.coerceIn(1L, commandTimeoutMs) ?: commandTimeoutMs
+        val quotedPane = "'${escapeSingleQuoted(paneId)}'"
+        val command = "tmux capture-pane -p -t $quotedPane"
+        val execResult =
+            try {
+                withTimeoutOrNull(effectiveTimeoutMs) {
+                    session.exec(command)
+                }
+            } catch (t: Throwable) {
+                throw TmuxClientException(
+                    "tmux text capture exec failed for pane $paneId: ${t.message}",
+                    t,
+                )
+            }
+        if (execResult == null) {
+            throw TmuxClientException(
+                "tmux capture-pane (exec text lane) timed out after ${effectiveTimeoutMs}ms",
+            )
+        }
+        val lines = splitCaptureLines(execResult.stdout)
+        val isError = execResult.exitCode != 0
+        val output =
+            if (isError && lines.isEmpty()) {
+                execResult.stderr.trim().let { if (it.isEmpty()) emptyList() else it.split("\n") }
+            } else {
+                lines
+            }
+        return CommandResponse(number = -1L, output = output, isError = isError)
     }
 
     /**

--- a/shared/core-tmux/src/test/java/com/pocketshell/core/tmux/TmuxClientTest.kt
+++ b/shared/core-tmux/src/test/java/com/pocketshell/core/tmux/TmuxClientTest.kt
@@ -846,6 +846,36 @@ class TmuxClientTest {
     }
 
     @Test
+    fun `capturePaneTextViaExec runs plain visible capture on the exec lane`() = runBlocking {
+        // Submit-ack probes only need visible text. They must not use the shared
+        // `-CC` best-effort capture lane, because a busy agent can wedge that
+        // mutex while Send is waiting to press Enter.
+        val shell = FakeShell()
+        val session = FakeSession(
+            shell,
+            execHandler = {
+                ExecResult(stdout = "first\nsecond\n", stderr = "", exitCode = 0)
+            },
+        )
+        val client = RealTmuxClient(session, scope)
+        try {
+            client.connect()
+            val response = withTimeout(ASYNC_AWAIT_TIMEOUT_MS) {
+                client.capturePaneTextViaExec("%3", timeoutMs = 2_500L)
+            }
+
+            assertFalse(response.isError)
+            assertEquals(listOf("first", "second"), response.output)
+            assertEquals(
+                "tmux capture-pane -p -t '%3'",
+                session.execCommands.single { it.contains("capture-pane") },
+            )
+        } finally {
+            client.close()
+        }
+    }
+
+    @Test
     fun `captureWithCursor exec lane times out on a wedged transport within the short ceiling`() = runBlocking {
         // Issue #926/#1297: a genuinely wedged/half-open transport (the exec never
         // returns) must surface a TmuxClientException within the SHORT seed


### PR DESCRIPTION
## Summary
- add a plain-text tmux capture API that runs `capture-pane -p` on the SSH exec lane in the real client
- switch submit-ack polling to that exec-lane capture instead of shared best-effort control mode
- add regressions for wedged best-effort capture bypass and bounded exec capture hangs

## Validation
- git diff --check
- scripts/check-connection-vm-ratchet.sh
- ./gradlew :shared:core-tmux:testDebugUnitTest --tests 'com.pocketshell.core.tmux.TmuxClientTest.capturePaneTextViaExec runs plain visible capture on the exec lane'\n- ./gradlew :app:testDebugUnitTest --tests 'com.pocketshell.app.tmux.TmuxSessionViewModelTest.sendToAgentPaneAckCaptureBypassesWedgedBestEffortControlLane' --tests 'com.pocketshell.app.tmux.TmuxSessionViewModelTest.sendToAgentPaneAckTimeoutBoundsStuckCaptureCommand'\n- ./gradlew :app:testDebugUnitTest --tests 'com.pocketshell.app.tmux.TmuxSessionViewModelTest.sendToAgentPane*Ack*' --tests 'com.pocketshell.app.tmux.TmuxSessionViewModelTest.codexAgentSubmitHonoursMinimumFloorThenAckGatesEnter'\n- ./gradlew :shared:core-tmux:testDebugUnitTest --tests 'com.pocketshell.core.tmux.TmuxClientTest.*capture*Exec*' --tests 'com.pocketshell.core.tmux.TmuxClientTest.*captureWithCursor*'