### PR TITLE
Add quick reply surface pane guard

### DIFF
--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionScreenQuickReplySourceGuardTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionScreenQuickReplySourceGuardTest.kt
@@ -30,6 +30,27 @@ class TmuxSessionScreenQuickReplySourceGuardTest {
         assertTrue(src.contains("private fun AgentQuickReplyBand("))
     }
 
+    @Test
+    fun quickReplyTapRoutesThroughSurfacePaneId() {
+        val src = locate("TmuxSessionScreen.kt")
+        val quickReplyMount = src.substringBetween(
+            start = "AgentQuickReplyBand(\n                    terminalState = pane.terminalState,",
+            end = "// Issue #810",
+        )
+
+        assertTrue(
+            "Quick-reply taps must route to the surface pane, so cached/session-switch " +
+                "surfaces do not send replies to a stale active pane.",
+            quickReplyMount.contains("AgentQuickReplyBand(") &&
+                quickReplyMount.contains("viewModel.writeInputToPane(") &&
+                quickReplyMount.contains("pane.paneId,"),
+        )
+        assertFalse(
+            "The quick-reply callback must not route through currentPane/currentPaneId.",
+            quickReplyMount.contains("currentPane") || quickReplyMount.contains("currentPaneId"),
+        )
+    }
+
     private fun String.substringBetween(start: String, end: String): String {
         val startIndex = indexOf(start)
         check(startIndex >= 0) { "$start not found" }


### PR DESCRIPTION
## Summary
- add a source guard that quick-reply taps route through the visible surface pane id
- keep the existing guard that visible text collection stays inside the quick-reply leaf

## Validation
- `./gradlew :app:testDebugUnitTest --tests 'com.pocketshell.app.tmux.TmuxSessionScreenQuickReplySourceGuardTest'`\n- `git diff --check`