### PR TITLE
Split tmux session auxiliary modals

### DIFF
--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionAuxiliaryModals.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionAuxiliaryModals.kt
@@ -1,0 +1,157 @@
+package com.pocketshell.app.tmux
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import com.pocketshell.app.projects.ClaudeProfile
+import com.pocketshell.app.projects.CodexProfile
+import com.pocketshell.app.projects.FolderListViewModel
+import com.pocketshell.app.projects.SessionKindPickerSheet
+import com.pocketshell.app.projects.SessionTypeChoice
+import com.pocketshell.app.projects.SessionTypePickerSheet
+import com.pocketshell.app.sessions.DEFAULT_TMUX_START_DIRECTORY
+import com.pocketshell.core.terminal.selection.LocalhostUrl
+import com.pocketshell.uikit.model.SessionAgentKind
+import com.pocketshell.uikit.theme.PocketShellColors
+import com.pocketshell.uikit.theme.PocketShellSpacing
+
+@Composable
+internal fun TmuxSessionAuxiliaryModals(
+    showNewSessionSheet: Boolean,
+    currentPaneCwd: String?,
+    suggestStartDirectories: (suspend (String) -> List<String>)?,
+    claudeProfiles: List<ClaudeProfile>,
+    codexProfiles: List<CodexProfile>,
+    deriveDefaultName: (startDirectory: String) -> String,
+    onDismissNewSessionSheet: () -> Unit,
+    onCreateNewSession: (SessionTypeChoice) -> Unit,
+    showKindPicker: Boolean,
+    sessionName: String,
+    currentSessionRecordedKind: SessionAgentKind?,
+    currentSessionRecordedProfile: String?,
+    onDismissKindPicker: () -> Unit,
+    onPickKind: (SessionAgentKind) -> Unit,
+    showOpenFileDialog: Boolean,
+    openFilePath: String,
+    onOpenFilePathChange: (String) -> Unit,
+    onDismissOpenFileDialog: () -> Unit,
+    onOpenFileConfirmed: (path: String, paneCwd: String?) -> Unit,
+    pendingLocalhostForward: LocalhostUrl?,
+    localhostTargetHost: String,
+    onDismissLocalhostForward: () -> Unit,
+    onConfirmLocalhostForward: (LocalhostUrl) -> Unit,
+) {
+    val paneCwd = currentPaneCwd?.takeIf { it.isNotBlank() }
+    val newSessionFolderPath = paneCwd ?: DEFAULT_TMUX_START_DIRECTORY
+
+    // Issue #898: the in-session "+ New session" rich sheet. This remains the
+    // same shared picker used by the host/session-list screen; this wrapper
+    // only hosts the modal, while the route owns create/navigation decisions.
+    if (showNewSessionSheet) {
+        SessionTypePickerSheet(
+            folderPath = newSessionFolderPath,
+            folderLabel = FolderListViewModel.defaultLabelForPath(newSessionFolderPath),
+            onDismiss = onDismissNewSessionSheet,
+            suggestStartDirectories = suggestStartDirectories,
+            claudeProfiles = claudeProfiles,
+            codexProfiles = codexProfiles,
+            deriveDefaultName = deriveDefaultName,
+            onCreate = onCreateNewSession,
+        )
+    }
+
+    // Epic #821 Slice 1: the session-kind classify / change picker.
+    if (showKindPicker) {
+        SessionKindPickerSheet(
+            sessionName = sessionName,
+            onDismiss = onDismissKindPicker,
+            onPick = onPickKind,
+            isUnknown = currentSessionRecordedKind == null,
+            currentKind = currentSessionRecordedKind,
+            suggestedKind = null,
+            currentProfile = currentSessionRecordedProfile,
+        )
+    }
+
+    // Issue #497: in-app file viewer path-entry dialog. The active pane cwd is
+    // threaded through so relative paths resolve server-side in the viewer.
+    if (showOpenFileDialog) {
+        AlertDialog(
+            onDismissRequest = onDismissOpenFileDialog,
+            title = { Text("Open file") },
+            text = {
+                Column {
+                    Text(
+                        text = if (paneCwd != null) {
+                            "Enter a path. Relative paths resolve against $paneCwd."
+                        } else {
+                            "Enter an absolute path, or a path relative to your home directory."
+                        },
+                        color = PocketShellColors.TextSecondary,
+                        style = MaterialTheme.typography.labelSmall,
+                    )
+                    OutlinedTextField(
+                        value = openFilePath,
+                        onValueChange = onOpenFilePathChange,
+                        singleLine = true,
+                        placeholder = { Text("e.g. out/report.png") },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = PocketShellSpacing.sm)
+                            .testTag(TMUX_OPEN_FILE_DIALOG_FIELD_TAG),
+                    )
+                }
+            },
+            confirmButton = {
+                TextButton(
+                    enabled = openFilePath.isNotBlank(),
+                    onClick = {
+                        val path = openFilePath.trim()
+                        onDismissOpenFileDialog()
+                        if (path.isNotEmpty()) onOpenFileConfirmed(path, paneCwd)
+                    },
+                    modifier = Modifier.testTag(TMUX_OPEN_FILE_DIALOG_CONFIRM_TAG),
+                ) {
+                    Text("Open")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = onDismissOpenFileDialog) { Text("Cancel") }
+            },
+        )
+    }
+
+    // Issue #488: confirm dialog for a tapped server-local URL whose remote
+    // port is not yet forwarded.
+    pendingLocalhostForward?.let { pending ->
+        AlertDialog(
+            onDismissRequest = onDismissLocalhostForward,
+            title = { Text("Forward port ${pending.remotePort}?") },
+            text = {
+                Text(
+                    "${pending.remotePort} is a port on $localhostTargetHost, " +
+                        "not reachable directly from this phone. Forward it " +
+                        "to open it here.",
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = { onConfirmLocalhostForward(pending) }) {
+                    Text("Forward")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = onDismissLocalhostForward) {
+                    Text("Cancel")
+                }
+            },
+        )
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
@@ -127,8 +127,6 @@ import com.pocketshell.app.composer.PromptComposerViewModel
 import com.pocketshell.app.diagnostics.DiagnosticEvents
 import com.pocketshell.app.diagnostics.ReconnectCauseTrail
 import com.pocketshell.app.layout.rememberTmuxImeLayoutState
-import com.pocketshell.app.projects.FolderListViewModel
-import com.pocketshell.app.projects.SessionTypePickerSheet
 import com.pocketshell.app.projects.conventionalRemoteHome
 import com.pocketshell.app.projects.defaultSessionBaseName
 import com.pocketshell.app.projects.derivedSessionName
@@ -153,7 +151,6 @@ import com.pocketshell.app.session.SessionTab
 import com.pocketshell.app.session.conversationLinkAction
 import com.pocketshell.app.session.conversationSyncStatusLabel
 import com.pocketshell.app.session.cwdForDetectedFilePath
-import com.pocketshell.app.sessions.DEFAULT_TMUX_START_DIRECTORY
 import com.pocketshell.app.sessions.HostTmuxSessionPickerRequest
 import com.pocketshell.app.sessions.HostTmuxSessionPickerState
 import com.pocketshell.app.sessions.HostTmuxSessionPickerViewModel
@@ -2573,159 +2570,75 @@ public fun TmuxSessionScreen(
             )
         }
 
-        // Issue #898: the in-session "+ New session" rich sheet — the SAME
-        // SessionTypePickerSheet the host/session-list screen uses (Session type
-        // Shell/Agent, Agent CLI claude/codex/opencode, Skip permissions,
-        // Profile). The stripped-down name+folder dialog is gone (hard-cut D22 —
-        // one New-session UI). The Start folder defaults to the current
-        // session's pane cwd (preserving the one good behaviour of the old
-        // dialog); Create routes through viewModel.createSession — the SAME
-        // verified gateway path the host screen uses — so the created session
-        // honours type/CLI/skip-perms/profile identically, then navigates to the
-        // new session via onOpenTmuxSession (which attaches to the now-existing
-        // session).
-        if (showNewSessionSheet) {
-            val folderPath = currentPane?.cwd?.takeIf { it.isNotBlank() }
-                ?: DEFAULT_TMUX_START_DIRECTORY
-            SessionTypePickerSheet(
-                folderPath = folderPath,
-                folderLabel = FolderListViewModel.defaultLabelForPath(folderPath),
-                onDismiss = { showNewSessionSheet = false },
-                suggestStartDirectories = suggestStartDirectories,
-                claudeProfiles = newSessionClaudeProfiles,
-                codexProfiles = newSessionCodexProfiles,
-                // Issue #1184: prefill the editable "Session name" field with
-                // the directory-derived default for the chosen start folder.
-                deriveDefaultName = { dir ->
-                    defaultSessionBaseName(dir, conventionalRemoteHome(user))
-                },
-                onCreate = { choice ->
-                    showNewSessionSheet = false
-                    // Issue #898 (Finding 1): pass the host's already-known
-                    // session names into the deriver so a second "New session"
-                    // in the SAME folder gets a deterministic `-2`/`-3` suffix
-                    // instead of colliding with the existing same-named session
-                    // (the gateway/tmux has no server-side de-dupe, so a
-                    // duplicate name fails the create). This mirrors the host
-                    // screen, which passes `knownSessionNames(state)`.
-                    //
-                    // Issue #976: the de-dupe ONLY works when this list is
-                    // populated. If the picker is NOT `Ready` (a #974 connection
-                    // drop / still-loading list flips it to Loading/ConnectError),
-                    // the list collapses to ∅, the `-2`/`-3` suffix is skipped,
-                    // the derived name COLLIDES with the live same-folder session,
-                    // and the launch send-keys would type into that existing pane.
-                    // So do NOT proceed with a possibly-colliding name when the
-                    // list is unknown — block with a clear message and let the
-                    // user retry once the list is `Ready`. (The gateway's
-                    // has-session guard is the server-side safety net; this avoids
-                    // even attempting the collision-prone create.)
-                    val readyPicker =
-                        sessionPickerState as? HostTmuxSessionPickerState.Ready
-                    if (readyPicker == null) {
-                        Toast.makeText(
-                            context,
-                            "Session list isn't loaded yet — reconnect or wait " +
-                                "for it to finish, then start the new session again.",
-                            Toast.LENGTH_LONG,
-                        ).show()
-                    } else {
-                        val knownNames = readyPicker.rows.map { it.name }.toSet()
-                        val newName = derivedSessionName(
-                            choice = choice,
-                            homeDirectory = conventionalRemoteHome(user),
-                            existingNames = knownNames,
-                        )
-                        viewModel.createSession(
-                            name = newName,
-                            cwd = choice.startDirectory,
-                            startCommand = choice.startCommand(
-                                newSessionClaudeProfiles,
-                                newSessionCodexProfiles,
-                            ),
-                            chosenKind = choice.sessionAgentKind,
-                            onResolved = { resolved ->
-                                onOpenTmuxSession(resolved, choice.startDirectory)
-                            },
-                        )
-                    }
-                },
-            )
-        }
-
-        // Epic #821 Slice 1: the session-kind classify / change picker. Opens
-        // in the "unknown" prompt mode for a foreign session (no recorded
-        // kind), otherwise the "change kind" mode pre-selected on the current
-        // recorded kind. On Save it writes the durable host-side
-        // `@ps_agent_kind` via ManualKindWriter and re-reads it.
-        if (showKindPicker) {
-            com.pocketshell.app.projects.SessionKindPickerSheet(
-                sessionName = sessionName,
-                onDismiss = { showKindPicker = false },
-                onPick = { kind ->
-                    viewModel.setCurrentSessionKind(kind)
-                    showKindPicker = false
-                },
-                isUnknown = currentSessionRecordedKind == null,
-                currentKind = currentSessionRecordedKind,
-                // Option B today: no guess. A follow-up (Option A) passes a
-                // cgroup-based suggestion here with zero other change.
-                suggestedKind = null,
-                // Issue #858: the recorded non-default profile/provider, so a
-                // z.ai Claude reads differently from a default Claude here.
-                currentProfile = currentSessionRecordedProfile,
-            )
-        }
-
-        // Issue #497: in-app file viewer path-entry dialog. The active
-        // pane's cwd is threaded through so a relative path the agent
-        // referenced resolves server-side in the viewer.
-        if (showOpenFileDialog) {
-            val paneCwd = currentPane?.cwd?.takeIf { it.isNotBlank() }
-            AlertDialog(
-                onDismissRequest = { showOpenFileDialog = false },
-                title = { Text("Open file") },
-                text = {
-                    Column {
-                        Text(
-                            text = if (paneCwd != null) {
-                                "Enter a path. Relative paths resolve against $paneCwd."
-                            } else {
-                                "Enter an absolute path, or a path relative to your home directory."
-                            },
-                            color = PocketShellColors.TextSecondary,
-                            fontSize = 12.sp,
-                        )
-                        OutlinedTextField(
-                            value = openFilePath,
-                            onValueChange = { openFilePath = it },
-                            singleLine = true,
-                            placeholder = { Text("e.g. out/report.png") },
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(top = 8.dp)
-                                .testTag(TMUX_OPEN_FILE_DIALOG_FIELD_TAG),
-                        )
-                    }
-                },
-                confirmButton = {
-                    TextButton(
-                        enabled = openFilePath.isNotBlank(),
-                        onClick = {
-                            val path = openFilePath.trim()
-                            showOpenFileDialog = false
-                            if (path.isNotEmpty()) onOpenFile(path, paneCwd)
+        TmuxSessionAuxiliaryModals(
+            showNewSessionSheet = showNewSessionSheet,
+            currentPaneCwd = currentPane?.cwd,
+            suggestStartDirectories = suggestStartDirectories,
+            claudeProfiles = newSessionClaudeProfiles,
+            codexProfiles = newSessionCodexProfiles,
+            // Issue #1184: prefill the editable "Session name" field with the
+            // directory-derived default for the chosen start folder.
+            deriveDefaultName = { dir ->
+                defaultSessionBaseName(dir, conventionalRemoteHome(user))
+            },
+            onDismissNewSessionSheet = { showNewSessionSheet = false },
+            onCreateNewSession = { choice ->
+                showNewSessionSheet = false
+                // Issue #898/#976: do not create with an unknown session list;
+                // without known names the derived name can collide with the
+                // current same-folder session and route launch keys wrongly.
+                val readyPicker = sessionPickerState as? HostTmuxSessionPickerState.Ready
+                if (readyPicker == null) {
+                    Toast.makeText(
+                        context,
+                        "Session list isn't loaded yet — reconnect or wait " +
+                            "for it to finish, then start the new session again.",
+                        Toast.LENGTH_LONG,
+                    ).show()
+                } else {
+                    val knownNames = readyPicker.rows.map { it.name }.toSet()
+                    val newName = derivedSessionName(
+                        choice = choice,
+                        homeDirectory = conventionalRemoteHome(user),
+                        existingNames = knownNames,
+                    )
+                    viewModel.createSession(
+                        name = newName,
+                        cwd = choice.startDirectory,
+                        startCommand = choice.startCommand(
+                            newSessionClaudeProfiles,
+                            newSessionCodexProfiles,
+                        ),
+                        chosenKind = choice.sessionAgentKind,
+                        onResolved = { resolved ->
+                            onOpenTmuxSession(resolved, choice.startDirectory)
                         },
-                        modifier = Modifier.testTag(TMUX_OPEN_FILE_DIALOG_CONFIRM_TAG),
-                    ) {
-                        Text("Open")
-                    }
-                },
-                dismissButton = {
-                    TextButton(onClick = { showOpenFileDialog = false }) { Text("Cancel") }
-                },
-            )
-        }
+                    )
+                }
+            },
+            showKindPicker = showKindPicker,
+            sessionName = sessionName,
+            currentSessionRecordedKind = currentSessionRecordedKind,
+            currentSessionRecordedProfile = currentSessionRecordedProfile,
+            onDismissKindPicker = { showKindPicker = false },
+            onPickKind = { kind ->
+                viewModel.setCurrentSessionKind(kind)
+                showKindPicker = false
+            },
+            showOpenFileDialog = showOpenFileDialog,
+            openFilePath = openFilePath,
+            onOpenFilePathChange = { openFilePath = it },
+            onDismissOpenFileDialog = { showOpenFileDialog = false },
+            onOpenFileConfirmed = onOpenFile,
+            pendingLocalhostForward = pendingLocalhostForward,
+            localhostTargetHost = hostName.ifBlank { host },
+            onDismissLocalhostForward = { pendingLocalhostForward = null },
+            onConfirmLocalhostForward = { pending ->
+                val target = acceptedLocalhostForwardNavigation(pending)
+                pendingLocalhostForward = null
+                onOpenPortForwardingWithPort(target.remotePort, target.autoOpenLocalhostUrl)
+            },
+        )
 
         SessionSwitcherOverlay(
             visible = showSessionSwitcher,
@@ -2810,42 +2723,6 @@ public fun TmuxSessionScreen(
                 }
             },
             onDismiss = { viewModel.dismissDetectedPort() },
-        )
-    }
-
-    // Issue #488: confirm dialog for a tapped server-local URL whose remote
-    // port is not yet forwarded. Confirming routes through the existing
-    // port-forward flow (#447/#448 prefill) which opens the panel and sets up
-    // the tunnel, then opens the working local URL once the actual local port
-    // is known.
-    pendingLocalhostForward?.let { pending ->
-        val targetHost = hostName.ifBlank { host }
-        AlertDialog(
-            onDismissRequest = { pendingLocalhostForward = null },
-            title = { Text("Forward port ${pending.remotePort}?") },
-            text = {
-                Text(
-                    "${pending.remotePort} is a port on $targetHost, " +
-                        "not reachable directly from this phone. Forward it " +
-                        "to open it here.",
-                )
-            },
-            confirmButton = {
-                TextButton(
-                    onClick = {
-                        val target = acceptedLocalhostForwardNavigation(pending)
-                        pendingLocalhostForward = null
-                        onOpenPortForwardingWithPort(target.remotePort, target.autoOpenLocalhostUrl)
-                    },
-                ) {
-                    Text("Forward")
-                }
-            },
-            dismissButton = {
-                TextButton(onClick = { pendingLocalhostForward = null }) {
-                    Text("Cancel")
-                }
-            },
         )
     }
 

--- a/scripts/component-drift-baseline.txt
+++ b/scripts/component-drift-baseline.txt
@@ -18,7 +18,8 @@ app/src/main/java/com/pocketshell/app/projects/WatchedFoldersScreen.kt 1
 app/src/main/java/com/pocketshell/app/settings/SettingsScreen.kt 3
 app/src/main/java/com/pocketshell/app/share/HostPickerScreen.kt 2
 app/src/main/java/com/pocketshell/app/snippets/SnippetPickerSheet.kt 1
-app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt 20
+app/src/main/java/com/pocketshell/app/tmux/TmuxSessionAuxiliaryModals.kt 6
+app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt 14
 shared/ui-kit/src/main/java/com/pocketshell/uikit/components/ConfirmDialog.kt 1
 shared/ui-kit/src/main/java/com/pocketshell/uikit/components/FormDialog.kt 1
 shared/ui-kit/src/main/java/com/pocketshell/uikit/components/HostCard.kt 2

--- a/scripts/file-size-hygiene-baseline.txt
+++ b/scripts/file-size-hygiene-baseline.txt
@@ -9,7 +9,7 @@
 207337 app/src/main/java/com/pocketshell/app/composer/PromptComposerViewModel.kt
 139372 app/src/main/java/com/pocketshell/app/projects/FolderListScreen.kt
 190951 app/src/main/java/com/pocketshell/app/projects/FolderListViewModel.kt
-371674 app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
+365249 app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
 1020647 app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
 290559 app/src/test/java/com/pocketshell/app/composer/PromptComposerViewModelTest.kt
 167942 app/src/test/java/com/pocketshell/app/session/AgentConversationRepositoryTest.kt


### PR DESCRIPTION
## Summary
- extract the in-session new-session sheet, session-kind picker, open-file dialog, and localhost-forward dialog into `TmuxSessionAuxiliaryModals`
- keep session creation, navigation, and view-model mutations in `TmuxSessionScreen` callbacks
- update the file-size hygiene baseline for the smaller `TmuxSessionScreen.kt`

## Validation
- `./gradlew :app:compileDebugKotlin`
- `./gradlew :app:testDebugUnitTest --tests 'com.pocketshell.app.tmux.TmuxSessionScreenTest' --tests 'com.pocketshell.app.tmux.TmuxSessionScreenQuickReplySourceGuardTest'`\n- `scripts/check-file-size-hygiene.sh`\n- `scripts/check-design-tokens.sh`\n- `git diff --check`