### PR TITLE
Split composer attachment tiles

### DIFF
--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerAttachments.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerAttachments.kt
@@ -1,0 +1,295 @@
+package com.pocketshell.app.composer
+
+import android.content.ContentResolver
+import android.net.Uri
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.pocketshell.app.fileviewer.BoundedImageDecoder
+import com.pocketshell.uikit.theme.PocketShellColors
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.util.Locale
+
+/**
+ * Issue #566: compact ChatGPT/Claude-style staged attachment tiles. Each
+ * attachment is a fixed square: image selections get a thumbnail when the
+ * local preview Uri is still readable; all other files get a typed file tile.
+ * The full file name stays in accessibility text while the visible label is
+ * constrained to the tile width, so long names cannot stretch the composer.
+ */
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+internal fun AttachmentTileGrid(
+    attachments: List<PromptComposerViewModel.StagedAttachment>,
+    onRemove: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    FlowRow(
+        modifier = modifier
+            .fillMaxWidth()
+            .testTag(COMPOSER_ATTACHMENT_CHIPS_TAG),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        attachments.forEach { attachment ->
+            AttachmentTile(
+                attachment = attachment,
+                onRemove = onRemove,
+            )
+        }
+    }
+}
+
+@Composable
+private fun AttachmentTile(
+    attachment: PromptComposerViewModel.StagedAttachment,
+    onRemove: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val shape = RoundedCornerShape(8.dp)
+    val isImage = attachment.isImageAttachment()
+    val context = LocalContext.current
+    val thumbnail by produceState<ImageBitmap?>(
+        initialValue = null,
+        key1 = attachment.previewUri,
+        key2 = attachment.mimeType,
+    ) {
+        val uri = attachment.previewUri
+        value = if (isImage && uri != null) {
+            withContext(Dispatchers.IO) {
+                decodeAttachmentThumbnail(context.contentResolver, uri)
+            }
+        } else {
+            null
+        }
+    }
+
+    Box(
+        modifier = modifier
+            .size(ATTACHMENT_TILE_SIZE)
+            .clip(shape)
+            .background(
+                color = PocketShellColors.SurfaceElev,
+                shape = shape,
+            )
+            .border(
+                width = 1.dp,
+                color = PocketShellColors.BorderSoft,
+                shape = shape,
+            )
+            .semantics {
+                contentDescription = "Attachment ${attachment.displayName}"
+            }
+            .testTag(composerAttachmentChipTestTag(attachment.remotePath)),
+    ) {
+        if (thumbnail != null) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .testTag(composerAttachmentThumbnailTestTag(attachment.remotePath)),
+            ) {
+                Image(
+                    bitmap = thumbnail!!,
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.fillMaxSize(),
+                )
+            }
+        } else {
+            AttachmentTypeTile(
+                attachment = attachment,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .testTag(composerAttachmentTypeTileTestTag(attachment.remotePath)),
+            )
+        }
+
+        AttachmentTileLabel(
+            label = attachment.displayName,
+            imageBacked = thumbnail != null,
+            modifier = Modifier
+                .align(Alignment.BottomStart)
+                .fillMaxWidth(),
+        )
+
+        Box(
+            modifier = Modifier
+                .align(Alignment.TopEnd)
+                .size(ATTACHMENT_TILE_REMOVE_TOUCH_SIZE)
+                .clickable(role = Role.Button) { onRemove(attachment.remotePath) }
+                .semantics { contentDescription = "Remove ${attachment.displayName}" }
+                .testTag(composerAttachmentRemoveTestTag(attachment.remotePath)),
+            contentAlignment = Alignment.Center,
+        ) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(2.dp)
+                    .size(ATTACHMENT_TILE_REMOVE_SIZE)
+                    .background(
+                        color = PocketShellColors.Surface,
+                        shape = ATTACHMENT_TILE_REMOVE_SHAPE,
+                    )
+                    .border(
+                        width = 1.dp,
+                        color = PocketShellColors.BorderSoft,
+                        shape = ATTACHMENT_TILE_REMOVE_SHAPE,
+                    ),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = "×",
+                    color = PocketShellColors.Text,
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.SemiBold,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun AttachmentTypeTile(
+    attachment: PromptComposerViewModel.StagedAttachment,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier.padding(start = 6.dp, end = 6.dp, top = 8.dp, bottom = 18.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = attachment.fileExtensionLabel(),
+            color = PocketShellColors.Accent,
+            fontSize = 13.sp,
+            fontWeight = FontWeight.Bold,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}
+
+@Composable
+private fun AttachmentTileLabel(
+    label: String,
+    imageBacked: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val background = if (imageBacked) {
+        PocketShellColors.TermBg.copy(alpha = 0.72f)
+    } else {
+        Color.Transparent
+    }
+    Box(
+        modifier = modifier
+            .background(background)
+            .padding(start = 5.dp, end = 5.dp, bottom = 4.dp, top = 2.dp),
+    ) {
+        Text(
+            text = label,
+            color = if (imageBacked) PocketShellColors.TermText else PocketShellColors.TextSecondary,
+            fontSize = ATTACHMENT_TILE_LABEL_FONT_SIZE,
+            fontWeight = FontWeight.Medium,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}
+
+private fun decodeAttachmentThumbnail(
+    resolver: ContentResolver,
+    uri: Uri,
+): ImageBitmap? {
+    return runCatching {
+        BoundedImageDecoder.decodeStream(
+            openInputStream = {
+                if (uri.scheme == "file") {
+                    uri.path?.let { File(it).inputStream() }
+                } else {
+                    resolver.openInputStream(uri)
+                }
+            },
+            maxPixels = ATTACHMENT_THUMBNAIL_MAX_PIXELS,
+        )?.asImageBitmap()
+    }.getOrNull()
+}
+
+private fun PromptComposerViewModel.StagedAttachment.isImageAttachment(): Boolean {
+    if (mimeType?.startsWith("image/") == true) return true
+    return displayName.substringAfterLast('.', missingDelimiterValue = "")
+        .lowercase(Locale.ROOT) in IMAGE_ATTACHMENT_EXTENSIONS
+}
+
+private fun PromptComposerViewModel.StagedAttachment.fileExtensionLabel(): String {
+    val extension = displayName.substringAfterLast('.', missingDelimiterValue = "")
+        .takeIf { it.isNotBlank() }
+        ?.uppercase(Locale.ROOT)
+        ?.take(5)
+    return extension ?: "FILE"
+}
+
+private val IMAGE_ATTACHMENT_EXTENSIONS = setOf("png", "jpg", "jpeg", "gif", "webp", "bmp", "heic", "heif")
+private const val ATTACHMENT_THUMBNAIL_MAX_PIXELS = 192 * 192
+private val ATTACHMENT_TILE_SIZE = 64.dp
+private val ATTACHMENT_TILE_REMOVE_TOUCH_SIZE = 48.dp
+private val ATTACHMENT_TILE_REMOVE_SIZE = 22.dp
+// Genuine sub-ladder component geometry: this tiny overlay button is half of
+// the 22dp visual remove control, not a container radius rung.
+private val ATTACHMENT_TILE_REMOVE_RADIUS = 11.dp
+private val ATTACHMENT_TILE_REMOVE_SHAPE = RoundedCornerShape(ATTACHMENT_TILE_REMOVE_RADIUS)
+// The tile caption fits inside a 64dp square; the normal 11sp label rung clips
+// common attachment names, so the local micro-label size stays named here.
+private val ATTACHMENT_TILE_LABEL_FONT_SIZE = 9.sp
+
+/**
+ * Historic tag for the staged-attachment tile grid (FlowRow) at the bottom of
+ * the composer. Present only while at least one attachment is staged.
+ */
+internal const val COMPOSER_ATTACHMENT_CHIPS_TAG = "prompt-composer-attachment-chips"
+
+/** Historic per-tile tag, keyed by the attachment's remote path. */
+internal fun composerAttachmentChipTestTag(remotePath: String): String =
+    "prompt-composer-attachment-chip:$remotePath"
+
+/** Historic per-tile remove button tag, keyed by remote path. */
+internal fun composerAttachmentRemoveTestTag(remotePath: String): String =
+    "prompt-composer-attachment-remove:$remotePath"
+
+/** Per-image tile thumbnail tag, keyed by remote path. */
+internal fun composerAttachmentThumbnailTestTag(remotePath: String): String =
+    "prompt-composer-attachment-thumbnail:$remotePath"
+
+/** Per non-image typed tile tag, keyed by remote path. */
+internal fun composerAttachmentTypeTileTestTag(remotePath: String): String =
+    "prompt-composer-attachment-type-tile:$remotePath"

--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerSheet.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerSheet.kt
@@ -12,7 +12,6 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -20,11 +19,9 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
@@ -65,7 +62,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
@@ -75,10 +71,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.ImageBitmap
-import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
@@ -108,7 +101,6 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
-import com.pocketshell.app.fileviewer.BoundedImageDecoder
 import com.pocketshell.app.session.InlineDictationViewModel
 import com.pocketshell.app.session.UndeliveredTranscriptBanner
 import com.pocketshell.app.snippets.SnippetKind
@@ -123,10 +115,7 @@ import com.pocketshell.uikit.theme.LocalPocketShellSemantic
 import com.pocketshell.uikit.theme.PocketShellColors
 import com.pocketshell.uikit.theme.PocketShellTheme
 import com.pocketshell.uikit.theme.PocketShellType
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
-import java.util.Locale
 
 /**
  * The Phase 1 prompt composer (issue #15). Visual target:
@@ -2113,228 +2102,6 @@ private fun MicTriggerButton(
     }
 }
 
-/**
- * Issue #566: compact ChatGPT/Claude-style staged attachment tiles. Each
- * attachment is a fixed square: image selections get a thumbnail when the
- * local preview Uri is still readable; all other files get a typed file tile.
- * The full file name stays in accessibility text while the visible label is
- * constrained to the tile width, so long names cannot stretch the composer.
- */
-@OptIn(androidx.compose.foundation.layout.ExperimentalLayoutApi::class)
-@Composable
-internal fun AttachmentTileGrid(
-    attachments: List<PromptComposerViewModel.StagedAttachment>,
-    onRemove: (String) -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    FlowRow(
-        modifier = modifier
-            .fillMaxWidth()
-            .testTag(COMPOSER_ATTACHMENT_CHIPS_TAG),
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp),
-    ) {
-        attachments.forEach { attachment ->
-            AttachmentTile(
-                attachment = attachment,
-                onRemove = onRemove,
-            )
-        }
-    }
-}
-
-@Composable
-private fun AttachmentTile(
-    attachment: PromptComposerViewModel.StagedAttachment,
-    onRemove: (String) -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    val shape = RoundedCornerShape(8.dp)
-    val isImage = attachment.isImageAttachment()
-    val context = LocalContext.current
-    val thumbnail by produceState<ImageBitmap?>(
-        initialValue = null,
-        key1 = attachment.previewUri,
-        key2 = attachment.mimeType,
-    ) {
-        val uri = attachment.previewUri
-        value = if (isImage && uri != null) {
-            withContext(Dispatchers.IO) {
-                decodeAttachmentThumbnail(context.contentResolver, uri)
-            }
-        } else {
-            null
-        }
-    }
-
-    Box(
-        modifier = modifier
-            .size(ATTACHMENT_TILE_SIZE)
-            .clip(shape)
-            .background(
-                color = PocketShellColors.SurfaceElev,
-                shape = shape,
-            )
-            .border(
-                width = 1.dp,
-                color = PocketShellColors.BorderSoft,
-                shape = shape,
-            )
-            .semantics {
-                contentDescription = "Attachment ${attachment.displayName}"
-            }
-            .testTag(composerAttachmentChipTestTag(attachment.remotePath)),
-    ) {
-        if (thumbnail != null) {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .testTag(composerAttachmentThumbnailTestTag(attachment.remotePath)),
-            ) {
-                Image(
-                    bitmap = thumbnail!!,
-                    contentDescription = null,
-                    contentScale = ContentScale.Crop,
-                    modifier = Modifier.fillMaxSize(),
-                )
-            }
-        } else {
-            AttachmentTypeTile(
-                attachment = attachment,
-                modifier = Modifier
-                    .fillMaxSize()
-                    .testTag(composerAttachmentTypeTileTestTag(attachment.remotePath)),
-            )
-        }
-
-        AttachmentTileLabel(
-            label = attachment.displayName,
-            imageBacked = thumbnail != null,
-            modifier = Modifier
-                .align(Alignment.BottomStart)
-                .fillMaxWidth(),
-        )
-
-        Box(
-            modifier = Modifier
-                .align(Alignment.TopEnd)
-                .size(ATTACHMENT_TILE_REMOVE_TOUCH_SIZE)
-                .clickable(role = Role.Button) { onRemove(attachment.remotePath) }
-                .semantics { contentDescription = "Remove ${attachment.displayName}" }
-                .testTag(composerAttachmentRemoveTestTag(attachment.remotePath)),
-            contentAlignment = Alignment.Center,
-        ) {
-            Box(
-                modifier = Modifier
-                    .align(Alignment.TopEnd)
-                    .padding(2.dp)
-                    .size(ATTACHMENT_TILE_REMOVE_SIZE)
-                    .background(
-                        color = PocketShellColors.Surface,
-                        shape = RoundedCornerShape(11.dp),
-                    )
-                    .border(
-                        width = 1.dp,
-                        color = PocketShellColors.BorderSoft,
-                        shape = RoundedCornerShape(11.dp),
-                    ),
-                contentAlignment = Alignment.Center,
-            ) {
-                Text(
-                    text = "×",
-                    color = PocketShellColors.Text,
-                    fontSize = 16.sp,
-                    fontWeight = FontWeight.SemiBold,
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun AttachmentTypeTile(
-    attachment: PromptComposerViewModel.StagedAttachment,
-    modifier: Modifier = Modifier,
-) {
-    Box(
-        modifier = modifier.padding(start = 6.dp, end = 6.dp, top = 8.dp, bottom = 18.dp),
-        contentAlignment = Alignment.Center,
-    ) {
-        Text(
-            text = attachment.fileExtensionLabel(),
-            color = PocketShellColors.Accent,
-            fontSize = 13.sp,
-            fontWeight = FontWeight.Bold,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-        )
-    }
-}
-
-@Composable
-private fun AttachmentTileLabel(
-    label: String,
-    imageBacked: Boolean,
-    modifier: Modifier = Modifier,
-) {
-    val background = if (imageBacked) {
-        PocketShellColors.TermBg.copy(alpha = 0.72f)
-    } else {
-        Color.Transparent
-    }
-    Box(
-        modifier = modifier
-            .background(background)
-            .padding(start = 5.dp, end = 5.dp, bottom = 4.dp, top = 2.dp),
-    ) {
-        Text(
-            text = label,
-            color = if (imageBacked) PocketShellColors.TermText else PocketShellColors.TextSecondary,
-            fontSize = 9.sp,
-            fontWeight = FontWeight.Medium,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-        )
-    }
-}
-
-private fun decodeAttachmentThumbnail(
-    resolver: android.content.ContentResolver,
-    uri: Uri,
-): ImageBitmap? {
-    return runCatching {
-        BoundedImageDecoder.decodeStream(
-            openInputStream = {
-                if (uri.scheme == "file") {
-                    uri.path?.let { java.io.File(it).inputStream() }
-                } else {
-                    resolver.openInputStream(uri)
-                }
-            },
-            maxPixels = ATTACHMENT_THUMBNAIL_MAX_PIXELS,
-        )?.asImageBitmap()
-    }.getOrNull()
-}
-
-private fun PromptComposerViewModel.StagedAttachment.isImageAttachment(): Boolean {
-    if (mimeType?.startsWith("image/") == true) return true
-    return displayName.substringAfterLast('.', missingDelimiterValue = "")
-        .lowercase(Locale.ROOT) in IMAGE_ATTACHMENT_EXTENSIONS
-}
-
-private fun PromptComposerViewModel.StagedAttachment.fileExtensionLabel(): String {
-    val extension = displayName.substringAfterLast('.', missingDelimiterValue = "")
-        .takeIf { it.isNotBlank() }
-        ?.uppercase(Locale.ROOT)
-        ?.take(5)
-    return extension ?: "FILE"
-}
-
-private val IMAGE_ATTACHMENT_EXTENSIONS = setOf("png", "jpg", "jpeg", "gif", "webp", "bmp", "heic", "heif")
-private const val ATTACHMENT_THUMBNAIL_MAX_PIXELS = 192 * 192
-internal val ATTACHMENT_TILE_SIZE = 64.dp
-internal val ATTACHMENT_TILE_REMOVE_TOUCH_SIZE = 48.dp
-private val ATTACHMENT_TILE_REMOVE_SIZE = 22.dp
 // Issue #701: the secondary tool icons sit inside a grouped SurfaceElev pill,
 // so each individual hit target shrinks slightly (40dp) to keep the group neat
 // and the glyph trims to 20dp — still a comfortable touch target, but the
@@ -2737,28 +2504,6 @@ internal const val COMPOSER_SNIPPETS_TAG = "prompt-composer-snippets"
 // agent → empty catalog).
 internal const val COMPOSER_SLASH_TAG = "prompt-composer-slash"
 internal const val COMPOSER_ATTACHMENT_PROGRESS_TAG = "prompt-composer-attachment-progress"
-
-/**
- * Historic tag for the staged-attachment tile grid (FlowRow) at the bottom of
- * the composer. Present only while at least one attachment is staged.
- */
-internal const val COMPOSER_ATTACHMENT_CHIPS_TAG = "prompt-composer-attachment-chips"
-
-/** Historic per-tile tag, keyed by the attachment's remote path. */
-internal fun composerAttachmentChipTestTag(remotePath: String): String =
-    "prompt-composer-attachment-chip:$remotePath"
-
-/** Historic per-tile `×` remove button tag, keyed by remote path. */
-internal fun composerAttachmentRemoveTestTag(remotePath: String): String =
-    "prompt-composer-attachment-remove:$remotePath"
-
-/** Per-image tile thumbnail tag, keyed by remote path. */
-internal fun composerAttachmentThumbnailTestTag(remotePath: String): String =
-    "prompt-composer-attachment-thumbnail:$remotePath"
-
-/** Per non-image typed tile tag, keyed by remote path. */
-internal fun composerAttachmentTypeTileTestTag(remotePath: String): String =
-    "prompt-composer-attachment-type-tile:$remotePath"
 
 /** Issue #453: mockup placeholder text for the empty composer input. */
 internal const val COMPOSER_PLACEHOLDER = "Compose prompt…"

--- a/scripts/design-token-baseline.txt
+++ b/scripts/design-token-baseline.txt
@@ -4,7 +4,7 @@
 # lower numbers are better — re-baseline after migrating a screen.
 app/src/main/java/com/pocketshell/app/composer/MarkdownText.kt 4
 app/src/main/java/com/pocketshell/app/composer/PromptComposerQueueBanners.kt 2
-app/src/main/java/com/pocketshell/app/composer/PromptComposerSheet.kt 23
+app/src/main/java/com/pocketshell/app/composer/PromptComposerSheet.kt 20
 app/src/main/java/com/pocketshell/app/conversation/ConversationMessageTurn.kt 1
 app/src/main/java/com/pocketshell/app/conversation/ConversationTextSection.kt 3
 app/src/main/java/com/pocketshell/app/crash/CrashReportsScreen.kt 2

--- a/scripts/file-size-hygiene-baseline.txt
+++ b/scripts/file-size-hygiene-baseline.txt
@@ -5,7 +5,7 @@
 # Ratchet rule: baselined files may shrink or disappear, but may not grow.
 # New non-exempt tracked files above threshold_bytes fail the guard.
 # Exemptions: vendor/generated/worktree dirs and shared/core-terminal.
-142988 app/src/main/java/com/pocketshell/app/composer/PromptComposerSheet.kt
+134030 app/src/main/java/com/pocketshell/app/composer/PromptComposerSheet.kt
 207337 app/src/main/java/com/pocketshell/app/composer/PromptComposerViewModel.kt
 139372 app/src/main/java/com/pocketshell/app/projects/FolderListScreen.kt
 180197 app/src/main/java/com/pocketshell/app/projects/FolderListViewModel.kt


### PR DESCRIPTION
## Summary
- move staged attachment tile/thumbnail rendering into PromptComposerAttachments
- keep attachment tile tags internal for existing UI tests
- ratchet PromptComposerSheet file-size and design-token baselines after the split

## Tests
- ./gradlew :app:compileDebugKotlin :app:testDebugUnitTest --tests 'com.pocketshell.app.composer.PromptComposerViewModelTest' --tests 'com.pocketshell.app.composer.PromptComposerFailedSendAttachmentResendTest'
- ./gradlew :app:compileDebugKotlin :app:testDebugUnitTest --tests 'com.pocketshell.app.composer.PromptComposerSheetSourceGuardTest' --tests 'com.pocketshell.app.composer.PromptComposerFailedSendAttachmentResendTest'
- ./scripts/check-file-size-hygiene.sh
- ./scripts/check-component-drift.sh
- ./scripts/check-design-tokens.sh
- git diff --check