### PR TITLE
Split tmux control byte helpers

### DIFF
--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxControlBytes.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxControlBytes.kt
@@ -1,0 +1,55 @@
+package com.pocketshell.app.tmux
+
+internal const val CtrlAByte: Int = 0x01
+internal const val CtrlBByteValue: Int = 0x02
+internal const val CtrlCByte: Int = 0x03
+internal const val CtrlDByte: Int = 0x04
+internal const val CtrlEByte: Int = 0x05
+internal const val CtrlLByte: Int = 0x0C
+internal const val CtrlRByte: Int = 0x12
+internal const val CtrlZByte: Int = 0x1A
+internal const val CtrlOByte: Int = 0x0F
+internal const val CtrlXByte: Int = 0x18
+
+// Issue #1091: the control keys nano (and many TUIs) need that were missing
+// from the hotkey set - `^G` Help, `^J` Justify/newline, `^K` Cut, `^T`
+// Execute, `^U` cut-to-start, `^W` Where-Is, `^\` Replace. Each is
+// `(uppercase letter - 0x40)`; `^\` is 0x1C.
+internal const val CtrlGByte: Int = 0x07
+internal const val CtrlJByte: Int = 0x0A
+internal const val CtrlKByte: Int = 0x0B
+internal const val CtrlTByte: Int = 0x14
+internal const val CtrlUByte: Int = 0x15
+internal const val CtrlWByte: Int = 0x17
+internal const val CtrlBackslashByte: Int = 0x1C
+
+/**
+ * Issue #1091: control byte for a single printable [c] composed with the
+ * sticky `Ctrl` modifier. Letters map to `0x01..0x1A` (`Ctrl+A`..`Ctrl+Z`);
+ * the caret-range symbols map to `0x1B..0x1F` and `Ctrl+@`/`Ctrl+Space` to
+ * `0x00`. Returns null for a char that has no control encoding. Mirrors the
+ * canonical xterm/VT control-char table so the byte the terminal receives is
+ * exactly what a hardware `Ctrl` chord would produce.
+ */
+internal fun controlByteForChar(c: Char): Int? {
+    val upper = c.uppercaseChar()
+    return when (upper) {
+        in 'A'..'Z' -> upper.code - 0x40
+        '@', ' ' -> 0x00
+        '[' -> 0x1B
+        '\\' -> 0x1C
+        ']' -> 0x1D
+        '^' -> 0x1E
+        '_' -> 0x1F
+        else -> null
+    }
+}
+
+/**
+ * Issue #1091: the single-character key label (the panel's LETTERS section)
+ * that the sticky `Ctrl` modifier composes with, or null when [label] is not a
+ * single control-composable char (e.g. multi-char `Esc`/`^X`, or an arrow
+ * glyph).
+ */
+internal fun singleControlComposableChar(label: String): Char? =
+    label.singleOrNull()?.takeIf { controlByteForChar(it) != null }

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -18921,58 +18921,6 @@ internal const val SEND_OVERPAINT_HEAL_SETTLE_MS: Long = 350L
 internal const val SEND_OVERPAINT_HEAL_MAX_TICKS: Int = 4
 
 private const val MaxAgentEvents: Int = 500
-internal const val CtrlAByte: Int = 0x01
-internal const val CtrlBByteValue: Int = 0x02
-internal const val CtrlCByte: Int = 0x03
-internal const val CtrlDByte: Int = 0x04
-internal const val CtrlEByte: Int = 0x05
-internal const val CtrlLByte: Int = 0x0C
-internal const val CtrlRByte: Int = 0x12
-internal const val CtrlZByte: Int = 0x1A
-internal const val CtrlOByte: Int = 0x0F
-internal const val CtrlXByte: Int = 0x18
-// Issue #1091: the control keys nano (and many TUIs) need that were missing
-// from the hotkey set — `^G` Help, `^J` Justify/newline, `^K` Cut, `^T`
-// Execute, `^U` cut-to-start, `^W` Where-Is, `^\` Replace. Each is
-// `(uppercase letter - 0x40)`; `^\` is 0x1C.
-internal const val CtrlGByte: Int = 0x07
-internal const val CtrlJByte: Int = 0x0A
-internal const val CtrlKByte: Int = 0x0B
-internal const val CtrlTByte: Int = 0x14
-internal const val CtrlUByte: Int = 0x15
-internal const val CtrlWByte: Int = 0x17
-internal const val CtrlBackslashByte: Int = 0x1C
-
-/**
- * Issue #1091: control byte for a single printable [c] composed with the
- * sticky `Ctrl` modifier. Letters map to `0x01..0x1A` (`Ctrl+A`..`Ctrl+Z`);
- * the caret-range symbols map to `0x1B..0x1F` and `Ctrl+@`/`Ctrl+Space` to
- * `0x00`. Returns null for a char that has no control encoding. Mirrors the
- * canonical xterm/VT control-char table so the byte the terminal receives is
- * exactly what a hardware `Ctrl` chord would produce.
- */
-internal fun controlByteForChar(c: Char): Int? {
-    val upper = c.uppercaseChar()
-    return when (upper) {
-        in 'A'..'Z' -> upper.code - 0x40
-        '@', ' ' -> 0x00
-        '[' -> 0x1B
-        '\\' -> 0x1C
-        ']' -> 0x1D
-        '^' -> 0x1E
-        '_' -> 0x1F
-        else -> null
-    }
-}
-
-/**
- * Issue #1091: the single-character key label (the panel's LETTERS section)
- * that the sticky `Ctrl` modifier composes with, or null when [label] is not a
- * single control-composable char (e.g. multi-char `Esc`/`^X`, or an arrow
- * glyph).
- */
-internal fun singleControlComposableChar(label: String): Char? =
-    label.singleOrNull()?.takeIf { controlByteForChar(it) != null }
 
 /**
  * Issue #215: ceiling on the synchronous `detach-client` round-trip the

--- a/scripts/connection-vm-ratchet-baseline.txt
+++ b/scripts/connection-vm-ratchet-baseline.txt
@@ -6,4 +6,4 @@
 io_count 17
 runblocking_count 13
 connection_decision_variants 0
-vm_line_count 19478
+vm_line_count 19426

--- a/scripts/file-size-hygiene-baseline.txt
+++ b/scripts/file-size-hygiene-baseline.txt
@@ -10,7 +10,7 @@
 139372 app/src/main/java/com/pocketshell/app/projects/FolderListScreen.kt
 180197 app/src/main/java/com/pocketshell/app/projects/FolderListViewModel.kt
 303487 app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
-996247 app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+994135 app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
 290559 app/src/test/java/com/pocketshell/app/composer/PromptComposerViewModelTest.kt
 167942 app/src/test/java/com/pocketshell/app/session/AgentConversationRepositoryTest.kt
 797307 app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt


### PR DESCRIPTION
## Summary
- move tmux control-byte constants and sticky-Ctrl helpers into TmuxControlBytes.kt
- reduce TmuxSessionViewModel.kt to 19,426 lines and update size ratchets

## Tests
- ./gradlew :app:compileDebugKotlin
- ./gradlew :app:testDebugUnitTest --tests com.pocketshell.app.tmux.TmuxSessionHotkeyTest --tests com.pocketshell.app.tmux.TmuxSessionViewModelTest
- ./scripts/check-connection-vm-ratchet.sh
- ./scripts/check-file-size-hygiene.sh
- git diff --check
- git diff --cached --check

Note: an initial parallel Gradle run corrupted local KSP incremental caches; after stopping Gradle and clearing app/build/kspCaches/debug plus app/build/generated/ksp/debug, the serial compile and tests passed.