### PR TITLE
Split tmux session identity key

### DIFF
--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionIdentity.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionIdentity.kt
@@ -19,3 +19,30 @@ internal fun tmuxTargetSessionId(
     sessionCreated: Long?,
 ): SessionId =
     SessionId(durableTmuxSessionKey(hostId, tmuxSessionId, sessionCreated) ?: "$hostId/$sessionName")
+
+internal fun sessionCardsTargetKey(
+    hostId: Long,
+    host: String,
+    port: Int,
+    user: String,
+    keyPath: String,
+    sessionName: String,
+): String = buildString {
+    append(hostId)
+    append('|')
+    append(port)
+    append('|')
+    appendKeyPart(host)
+    append('|')
+    appendKeyPart(user)
+    append('|')
+    appendKeyPart(keyPath)
+    append('|')
+    appendKeyPart(sessionName.trim())
+}
+
+private fun StringBuilder.appendKeyPart(value: String) {
+    append(value.length)
+    append(':')
+    append(value)
+}

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -172,33 +172,6 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
 import javax.inject.Inject
 
-internal fun sessionCardsTargetKey(
-    hostId: Long,
-    host: String,
-    port: Int,
-    user: String,
-    keyPath: String,
-    sessionName: String,
-): String = buildString {
-    append(hostId)
-    append('|')
-    append(port)
-    append('|')
-    appendKeyPart(host)
-    append('|')
-    appendKeyPart(user)
-    append('|')
-    appendKeyPart(keyPath)
-    append('|')
-    appendKeyPart(sessionName.trim())
-}
-
-private fun StringBuilder.appendKeyPart(value: String) {
-    append(value.length)
-    append(':')
-    append(value)
-}
-
 /**
  * Holds the live `tmux -CC` control channel for a single SSH host /
  * session-name pair, and surfaces the resulting list of panes as

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionIdentityTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionIdentityTest.kt
@@ -1,0 +1,51 @@
+package com.pocketshell.app.tmux
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class TmuxSessionIdentityTest {
+    @Test
+    fun sessionCardsTargetKeyTrimsSessionName() {
+        assertEquals(
+            sessionCardsTargetKey(
+                hostId = 42L,
+                host = "example.test",
+                port = 22,
+                user = "alexey",
+                keyPath = "/keys/id",
+                sessionName = " work ",
+            ),
+            sessionCardsTargetKey(
+                hostId = 42L,
+                host = "example.test",
+                port = 22,
+                user = "alexey",
+                keyPath = "/keys/id",
+                sessionName = "work",
+            ),
+        )
+    }
+
+    @Test
+    fun sessionCardsTargetKeyLengthPrefixesPartsToAvoidSeparatorCollisions() {
+        val left = sessionCardsTargetKey(
+            hostId = 1L,
+            host = "a|b",
+            port = 22,
+            user = "c",
+            keyPath = "d",
+            sessionName = "e",
+        )
+        val right = sessionCardsTargetKey(
+            hostId = 1L,
+            host = "a",
+            port = 22,
+            user = "b|c",
+            keyPath = "d",
+            sessionName = "e",
+        )
+
+        assertNotEquals(left, right)
+    }
+}

--- a/scripts/connection-vm-ratchet-baseline.txt
+++ b/scripts/connection-vm-ratchet-baseline.txt
@@ -6,4 +6,4 @@
 io_count 17
 runblocking_count 13
 connection_decision_variants 0
-vm_line_count 19426
+vm_line_count 19399

--- a/scripts/file-size-hygiene-baseline.txt
+++ b/scripts/file-size-hygiene-baseline.txt
@@ -10,7 +10,7 @@
 139372 app/src/main/java/com/pocketshell/app/projects/FolderListScreen.kt
 180197 app/src/main/java/com/pocketshell/app/projects/FolderListViewModel.kt
 226939 app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
-994135 app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+993607 app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
 290559 app/src/test/java/com/pocketshell/app/composer/PromptComposerViewModelTest.kt
 167942 app/src/test/java/com/pocketshell/app/session/AgentConversationRepositoryTest.kt
 797307 app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt


### PR DESCRIPTION
## Summary
- move session card target key formatting into TmuxSessionIdentity
- add focused coverage for trimming and length-prefixed collision avoidance
- update size ratchet baselines after shrinking TmuxSessionViewModel

## Tests
- ./gradlew :app:compileDebugKotlin
- ./gradlew :app:testDebugUnitTest --tests com.pocketshell.app.tmux.TmuxSessionIdentityTest --tests com.pocketshell.app.tmux.TmuxSessionViewModelTest
- ./scripts/check-connection-vm-ratchet.sh
- ./scripts/check-file-size-hygiene.sh