### PR TITLE
Throttle tmux output hot-path logs

### DIFF
--- a/scripts/file-size-hygiene-baseline.txt
+++ b/scripts/file-size-hygiene-baseline.txt
@@ -16,6 +16,6 @@
 1146350 docs/mockups/feedback/folder-tree-target-20260604.png
 182790 docs/screenshots/readme-settings.png
 194363 scripts/ci-journey-suite.sh
-160299 shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxClient.kt
+160115 shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxClient.kt
 188725 shared/core-tmux/src/test/java/com/pocketshell/core/tmux/TmuxClientTest.kt
 189411 shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenders.kt

--- a/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxClient.kt
+++ b/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxClient.kt
@@ -39,6 +39,9 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
 
+internal fun shouldLogTmuxDropCount(count: Int): Boolean =
+    count > 0 && (count and (count - 1)) == 0
+
 /**
  * High-level client wrapping a `tmux -CC` control channel running inside an
  * [SshSession].
@@ -2240,27 +2243,20 @@ internal class RealTmuxClient(
                 // Response framing markers are internal to correlation and are
                 // deliberately not exposed to UI collectors.
                 if (event is ControlEvent.Output) {
-                    // Issue #105 diagnostics. We log BEFORE and AFTER the
-                    // emit so a reviewer reading logcat can tell apart:
-                    //   * tmux never produced %output for the external
-                    //     write (no `tmux-output-received` line appears),
-                    //   * the reader saw bytes but the bus emit suspended
-                    //     longer than expected (gap between `received`
-                    //     and `bus-emit`),
-                    //   * downstream (parser + Compose invalidation) is
-                    //     slow (the test's emulator-side checks fire long
-                    //     after `bus-emit`).
-                    // The byte count is enough to correlate with the
-                    // external write without leaking the payload itself.
-                    Log.i(
-                        ISSUE_105_DIAG_TAG,
-                        "tmux-output-received pane=${event.paneId} bytes=${event.data.size}",
-                    )
+                    val debugOutputLogging = Log.isLoggable(ISSUE_105_DIAG_TAG, Log.DEBUG)
+                    if (debugOutputLogging) {
+                        Log.i(
+                            ISSUE_105_DIAG_TAG,
+                            "tmux-output-received pane=${event.paneId} bytes=${event.data.size}",
+                        )
+                    }
                     emitOutput(event)
-                    Log.i(
-                        ISSUE_105_DIAG_TAG,
-                        "tmux-output-bus-emit pane=${event.paneId} bytes=${event.data.size}",
-                    )
+                    if (debugOutputLogging) {
+                        Log.i(
+                            ISSUE_105_DIAG_TAG,
+                            "tmux-output-delivered pane=${event.paneId} bytes=${event.data.size}",
+                        )
+                    }
                 } else {
                     emitPublicEvent(event)
                 }
@@ -2541,12 +2537,14 @@ internal class RealTmuxClient(
                 ),
             )
         }
-        Log.w(
-            ISSUE_105_DIAG_TAG,
-            "tmux-preregistration-output-drop pane=$paneId bytes=$evictedBytes " +
-                "droppedEvents=$droppedForPane totalDroppedEvents=$total " +
-                "maxEvents=$PRE_REGISTRATION_MAX_EVENTS maxBytes=$PRE_REGISTRATION_MAX_BYTES",
-        )
+        if (shouldLogTmuxDropCount(droppedForPane)) {
+            Log.w(
+                ISSUE_105_DIAG_TAG,
+                "tmux-preregistration-output-drop pane=$paneId bytes=$evictedBytes " +
+                    "droppedEvents=$droppedForPane totalDroppedEvents=$total " +
+                    "maxEvents=$PRE_REGISTRATION_MAX_EVENTS maxBytes=$PRE_REGISTRATION_MAX_BYTES",
+            )
+        }
     }
 
     private fun emitPublicEvent(event: ControlEvent) {
@@ -2566,11 +2564,13 @@ internal class RealTmuxClient(
                     ),
                 )
             }
-            Log.w(
-                ISSUE_105_DIAG_TAG,
-                "tmux-eventbus-drop event=${event.javaClass.simpleName} " +
-                    "droppedEvents=$dropped capacity=$EVENT_BUFFER",
-            )
+            if (shouldLogTmuxDropCount(dropped)) {
+                Log.w(
+                    ISSUE_105_DIAG_TAG,
+                    "tmux-eventbus-drop event=${event.javaClass.simpleName} " +
+                        "droppedEvents=$dropped capacity=$EVENT_BUFFER",
+                )
+            }
         }
     }
 
@@ -2943,13 +2943,15 @@ internal class RealTmuxClient(
                         ),
                     )
                 }
-                Log.w(
-                    ISSUE_105_DIAG_TAG,
-                    "tmux-output-backlog-overflow pane=${event.paneId} " +
-                        "bytes=${event.data.size} droppedEvents=$dropped " +
-                        "capacity=$OUTPUT_BACKLOG_EVENTS",
-                    result.exceptionOrNull(),
-                )
+                if (shouldLogTmuxDropCount(dropped)) {
+                    Log.w(
+                        ISSUE_105_DIAG_TAG,
+                        "tmux-output-backlog-overflow pane=${event.paneId} " +
+                            "bytes=${event.data.size} droppedEvents=$dropped " +
+                            "capacity=$OUTPUT_BACKLOG_EVENTS",
+                        result.exceptionOrNull(),
+                    )
+                }
             }
         }
 

--- a/shared/core-tmux/src/test/java/com/pocketshell/core/tmux/TmuxDropLogSamplingTest.kt
+++ b/shared/core-tmux/src/test/java/com/pocketshell/core/tmux/TmuxDropLogSamplingTest.kt
@@ -1,0 +1,22 @@
+package com.pocketshell.core.tmux
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TmuxDropLogSamplingTest {
+
+    @Test
+    fun dropLogSamplingKeepsFirstDropAndPowersOfTwo() {
+        listOf(1, 2, 4, 8, 16, 32, 64, 128).forEach { count ->
+            assertTrue("expected count $count to be logged", shouldLogTmuxDropCount(count))
+        }
+    }
+
+    @Test
+    fun dropLogSamplingSkipsZeroNegativeAndNonPowersOfTwo() {
+        listOf(-4, -1, 0, 3, 5, 6, 7, 9, 10, 12, 63, 127).forEach { count ->
+            assertFalse("expected count $count to be skipped", shouldLogTmuxDropCount(count))
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- gate per-output tmux reader diagnostics behind debug loggability
- sample repeated overflow/drop warnings at powers of two instead of logging every dropped frame
- add unit coverage for the drop-log sampling predicate and lower the oversized-file baseline for TmuxClient.kt

## Verification
- ./gradlew :shared:core-tmux:testDebugUnitTest --tests 'com.pocketshell.core.tmux.TmuxDropLogSamplingTest' --tests 'com.pocketshell.core.tmux.TmuxClientTest.codex scale output flood cannot starve command response parsing' --tests 'com.pocketshell.core.tmux.TmuxClientTest.unbounded pane output flood emits overflow without disconnecting reader' --tests 'com.pocketshell.core.tmux.TmuxClientTest.trailing window-close survives an output flood behind a stalled collector' --tests 'com.pocketshell.core.tmux.TmuxClientTest.pre-registration buffer overflow evicts oldest and records drop diagnostic'
- ./gradlew :shared:core-tmux:testDebugUnitTest
- ./gradlew :shared:core-tmux:testReleaseUnitTest
- scripts/check-file-size-hygiene.sh
- scripts/check-connection-vm-ratchet.sh