### PR TITLE
tmux: gate Conversation tab on server-truth alt-buffer (#1158)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/tmux/ConversationToggleVisibleForLiveAgentInShellRecordedSessionDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/ConversationToggleVisibleForLiveAgentInShellRecordedSessionDockerTest.kt
@@ -368,25 +368,28 @@ class ConversationToggleVisibleForLiveAgentInShellRecordedSessionDockerTest {
      *
      * The durable fix is the detection-INDEPENDENT alt-buffer positive signal: a
      * full-screen agent TUI holds the ALTERNATE screen buffer, which the tmux
-     * ViewModel latches STICKY and OR's into `showsConversationTab`.
+     * ViewModel latches STICKY (from the tmux SERVER-TRUTH `#{alternate_on}` flag on
+     * the `list-panes` reconcile) and OR's into `showsConversationTab`.
      *
-     * ### #780 synthetic-state model (no self-skip — hard-fail)
+     * ### REAL server-truth path (no synthetic injection — the #847/G10 lesson)
      *
-     * The tmux `-CC` control path does not reliably mirror a REMOTE pane's alternate
-     * screen buffer into the CLIENT emulator (the capture-pane seed replays the
-     * screen TEXT onto the main buffer, and an idle full-screen agent emits no fresh
-     * `%output` carrying the `?1049h` toggle), so a connected journey cannot enter
-     * the on-device alt-buffer state on its own. Per D33/#780 the failing state is
-     * injected SYNTHETICALLY on the REAL connected pane
-     * ([TmuxSessionViewModel.forceActivePaneAltBufferForTest]) — the ONLY synthetic
-     * part; the recorded-shell verdict, the detection-never-binds state, the real
-     * production tab gate and the real chrome rendering are all live. It HARD-fails
-     * (no `assumeTrue`) so CI carries real protection.
+     * The prior round of this test CHEATED: it forced the CLIENT emulator's
+     * alt-buffer verdict (`forceActivePaneAltBufferForTest`) — a signal that is
+     * INERT on the real `-CC` path (the capture-pane seed replays the alt-screen
+     * TEXT onto the client's MAIN buffer, and an idle agent emits no fresh
+     * `?1049h`), so the test was green while the maintainer's device stayed broken.
+     * That synthetic-masks-reality gap is exactly what let #1158 survive five fixes.
      *
-     * RED on base: with no `|| altBufferAgent` term the toggle stays absent even
-     * with the alt-buffer injected (the maintainer's symptom). GREEN with the fix:
-     * the latch shows the toggle, and it STAYS after the buffer leaves alt-mode
-     * (sticky).
+     * This round enters the REAL failing state: the seeded pane runs a genuine
+     * full-screen program that holds the alternate screen buffer server-side
+     * (`seedAltBufferShellSession` emits `?1049h` then idles), so the tmux SERVER
+     * reports `#{alternate_on}=1` — the app's reconcile reads it on attach and
+     * latches the session. NOTHING is injected on the client; the client emulator
+     * is on the main buffer the whole time (proving the fix does NOT rely on it).
+     *
+     * RED on base: base has no `#{alternate_on}` read + latch, so even though the
+     * pane is REALLY on the alt buffer the toggle stays absent (the maintainer's
+     * exact symptom). GREEN with the fix: the server-truth latch shows the toggle.
      */
     @Test
     fun conversationToggleAppearsForAltBufferAgentDirectlyLaunchedInShellSession() { runBlocking {
@@ -395,8 +398,8 @@ class ConversationToggleVisibleForLiveAgentInShellRecordedSessionDockerTest {
 
         attachToSeededSession(hostRowTag, sessionName)
         waitForTerminalSessionAttached()
-        waitForVisibleTerminalText("issue962-plain-ready", VISIBLE_TIMEOUT_MS) {
-            "issue962-plain-ready" in it
+        waitForVisibleTerminalText("issue1158-altbuf-ready", VISIBLE_TIMEOUT_MS) {
+            "issue1158-altbuf-ready" in it
         }
         stamp("altbuf_shell_attached session=$sessionName")
 
@@ -406,28 +409,39 @@ class ConversationToggleVisibleForLiveAgentInShellRecordedSessionDockerTest {
         val vm = currentViewModel()
         val verdictObserved = waitForConfirmedShellVerdict(vm)
         stamp("altbuf_confirmed_shell_verdict_observed=$verdictObserved")
-        SystemClock.sleep(SHELL_NO_TOGGLE_SETTLE_MS)
         val detectionBound = vm.agentConversations.value.values.any { it.detection != null }
         stamp("altbuf_detection_bound=$detectionBound")
 
-        // Precondition (the maintainer's symptom, base state): NO Conversation toggle
-        // — the recorded shell + no detection leaves only the "Terminal" pill.
-        compose.onNodeWithTag(TMUX_TABS_TAG, useUnmergedTree = true).assertDoesNotExist()
-        captureFullFrame("issue1158-altbuf-before-no-toggle")
-        stamp("altbuf_no_toggle_before_ok")
+        // The CLIENT emulator is NOT on the alt buffer (the -CC seed replayed the
+        // alt-screen TEXT onto the client's MAIN buffer). Record it as evidence the
+        // toggle below is driven purely by SERVER truth, not the client emulator.
+        var clientAltBuffer = false
+        compose.activityRule.scenario.onActivity { activity ->
+            clientAltBuffer = activity.window.decorView
+                .findTerminalView()
+                ?.currentSession
+                ?.emulator
+                ?.isAlternateBufferActive == true
+        }
+        stamp("altbuf_client_emulator_alt_active=$clientAltBuffer")
 
-        // The agent goes full-screen: the pane's emulator switches to the ALTERNATE
-        // screen buffer. Injected synthetically on the REAL connected pane (#780) —
-        // the on-device signal a full-screen Claude/Codex TUI produces.
-        compose.activityRule.scenario.onActivity { vm.forceActivePaneAltBufferForTest(true) }
+        // LOAD-BEARING server-truth latch: the reconcile's `list-panes` read the
+        // real `#{alternate_on}=1` for the pane and latched the session. On base
+        // (no `#{alternate_on}` read + latch) this never becomes non-empty → RED.
         compose.waitUntil(timeoutMillis = MASKED_TOGGLE_TIMEOUT_MS) {
             vm.altBufferAgentPaneIds.value.isNotEmpty()
         }
+        assertTrue(
+            "#1158 (real path): the server-truth `#{alternate_on}` latch must fire " +
+                "for the genuinely-alt-buffer pane. altBufferAgentPaneIds=" +
+                "${vm.altBufferAgentPaneIds.value}",
+            vm.altBufferAgentPaneIds.value.isNotEmpty(),
+        )
         stamp("altbuf_latched=${vm.altBufferAgentPaneIds.value.isNotEmpty()}")
 
         // DURABLE UI (load-bearing): the Terminal/Conversation toggle now appears,
-        // driven purely by the alt-buffer signal (detection is still null). RED on
-        // base (no `|| altBufferAgent`), GREEN with the fix.
+        // driven purely by the server-truth alt-buffer signal (detection is still
+        // null, client emulator on main buffer). RED on base, GREEN with the fix.
         compose.waitUntil(timeoutMillis = MASKED_TOGGLE_TIMEOUT_MS) {
             compose.onAllNodesWithTag(TMUX_TABS_TAG, useUnmergedTree = true)
                 .fetchSemanticsNodes()
@@ -443,9 +457,9 @@ class ConversationToggleVisibleForLiveAgentInShellRecordedSessionDockerTest {
         captureFullFrame("issue1158-altbuf-toggle-appears")
         stamp("altbuf_toggle_appears_ok")
 
-        // STICKY: the agent leaves the alt-buffer (exits its full-screen view /
-        // detection stays null). The toggle MUST remain for the session's life.
-        compose.activityRule.scenario.onActivity { vm.forceActivePaneAltBufferForTest(false) }
+        // STICKY: the tab must remain for the session's life. Settle a generous
+        // window (any later reconcile that reports `#{alternate_on}=0` must NOT
+        // collapse it) and re-assert.
         SystemClock.sleep(SHELL_NO_TOGGLE_SETTLE_MS)
         compose.onNodeWithTag(TMUX_TABS_TAG, useUnmergedTree = true).assertExists()
         compose.onNodeWithText("Conversation", useUnmergedTree = true).assertExists()
@@ -475,7 +489,7 @@ class ConversationToggleVisibleForLiveAgentInShellRecordedSessionDockerTest {
             "conversationTogglePresentForRecordedCodexAgentWhenSourceBindingFails" ->
                 seedRecordedCodexNoTranscriptSession(key)
             "conversationToggleAppearsForAltBufferAgentDirectlyLaunchedInShellSession" ->
-                seedPlainShellSession(key)
+                seedAltBufferShellSession(key)
             else -> error("unexpected test method $methodName")
         }
         seededSessionName = sessionName
@@ -494,6 +508,47 @@ class ConversationToggleVisibleForLiveAgentInShellRecordedSessionDockerTest {
                 appendLine(
                     "tmux new-session -d -x 80 -y 24 -s ${shellQuote(sessionName)} -c /tmp " +
                         "\"printf 'issue962-plain-ready\\r\\n'; exec sh\"",
+                )
+                appendLine("tmux set-option -t ${shellQuote(sessionName)} @ps_agent_kind shell")
+                appendLine("sleep 1")
+            },
+        )
+        return sessionName
+    }
+
+    /**
+     * Issue #1158 (REOPENED — the maintainer's EXACT dogfood path): a session
+     * recorded `@ps_agent_kind=shell` whose pane runs a GENUINE full-screen program
+     * holding the ALTERNATE screen buffer (it emits DEC-1049 `?1049h`, exactly what
+     * a full-screen agent TUI — Claude Code / Codex / glm-Z.AI — does for its whole
+     * run), then idles. This puts the tmux SERVER pane on `#{alternate_on}=1`
+     * REALLY — no synthetic client-emulator injection — so the reconcile's
+     * `list-panes` reads the server-truth flag on attach and latches the session.
+     *
+     * This is the real-path reproduction the five prior fixes never had: the
+     * client emulator NEVER sees the alt buffer here (the `-CC` capture-pane seed
+     * replays the alt-screen TEXT onto the client's MAIN buffer, and the pane emits
+     * no fresh `?1049h` after attach because it idles), so on base (no
+     * `#{alternate_on}` read + latch) NO toggle appears — the maintainer's symptom.
+     */
+    private suspend fun seedAltBufferShellSession(key: String): String {
+        val suffix = unique()
+        val sessionName = "issue1158-altbuf-shell-$suffix"
+        cleanupCommands += "tmux kill-session -t ${shellQuote(sessionName)} 2>/dev/null || true"
+        execRemote(
+            key,
+            buildString {
+                appendLine("set -eu")
+                appendLine("tmux kill-session -t ${shellQuote(sessionName)} 2>/dev/null || true")
+                // The pane program enters the ALTERNATE screen buffer (?1049h) —
+                // what a full-screen agent TUI does — prints a ready marker there,
+                // then idles (emits no further output, so the client emulator never
+                // sees the alt-buffer toggle). The tmux SERVER holds the pane on
+                // `#{alternate_on}=1` for the whole run.
+                appendLine(
+                    "tmux new-session -d -x 80 -y 24 -s ${shellQuote(sessionName)} -c /tmp " +
+                        "\"printf '\\033[?1049h'; printf 'issue1158-altbuf-ready\\r\\n'; " +
+                        "exec sh -c 'while true; do sleep 30; done'\"",
                 )
                 appendLine("tmux set-option -t ${shellQuote(sessionName)} @ps_agent_kind shell")
                 appendLine("sleep 1")

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxAltBufferAgentLatch.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxAltBufferAgentLatch.kt
@@ -1,0 +1,83 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.app.tmux.TmuxSessionViewModel.ParsedPane
+import kotlinx.coroutines.flow.MutableStateFlow
+
+/**
+ * Issue #1158 (REOPENED chain #962→#975→#1057→#1158): the SERVER-TRUTH
+ * alternate-buffer agent latch, extracted verbatim out of
+ * [TmuxSessionViewModel] to keep that file under the oversized-file hygiene
+ * baseline (PR #1431). Pure behaviour-preserving move — the logic is identical
+ * to the in-VM version the #1158 fix shipped; only the two functions' location
+ * (and the `this.`-member references, now explicit parameters) changed. The VM
+ * keeps thin private wrappers that forward its own state into these.
+ *
+ * A full-screen agent TUI holds the alternate screen buffer for its run, which
+ * the tmux SERVER reports via `#{alternate_on}` on every `list-panes`
+ * reconcile. Reading that SERVER truth — NOT the CLIENT emulator's
+ * `isAlternateBufferActive`, which stays false because the `-CC` capture-pane
+ * seed replays screen TEXT onto the client's MAIN buffer and an idle agent
+ * emits no fresh `?1049h` — is what makes the Conversation tab appear on the
+ * real path for an agent launched directly inside a `@ps_agent_kind=shell`
+ * session where live detection never binds.
+ */
+internal object TmuxAltBufferAgentLatch {
+
+    /**
+     * Issue #1158 (recurrence of #962/#1057): LATCH every session whose
+     * reconciled pane list reports the SERVER-TRUTH alternate-screen flag
+     * ([ParsedPane.alternateOn], from `#{alternate_on}`) into
+     * [altBufferAgentSessionIds] (sticky — never removed within the runtime).
+     * Called from [TmuxSessionViewModel]'s reconcile on every reconcile
+     * (attach / switch / layout-change), so an idle full-screen agent that
+     * emits no fresh output is still caught: the tmux SERVER always knows the
+     * pane holds the alternate buffer even though the CLIENT emulator can't see
+     * it (the `-CC` capture-pane seed replays screen TEXT onto the client's
+     * MAIN buffer). This is the fix for the maintainer's fleet — an agent
+     * launched directly inside a `@ps_agent_kind=shell` session where live
+     * detection never binds.
+     *
+     * A no-op for a plain shell on the main buffer (the #894/#815 no-flap
+     * invariant): `alternate_on` is 0, nothing is latched, the tab stays hidden.
+     *
+     * Republishes the per-pane projection only when a NEW session is latched,
+     * so a steady-state reconcile allocates nothing.
+     */
+    fun latchAltBufferAgentsFromParsed(
+        parsed: List<ParsedPane>,
+        altBufferAgentSessionIds: MutableSet<String>,
+        paneRows: Map<String, TmuxPaneState>,
+        altBufferAgentPaneIds: MutableStateFlow<Set<String>>,
+    ) {
+        var added = false
+        for (pane in parsed) {
+            if (!pane.alternateOn) continue
+            val sessionId = pane.sessionId.trim()
+            if (sessionId.isEmpty()) continue
+            if (altBufferAgentSessionIds.add(sessionId)) added = true
+        }
+        if (added) {
+            refreshAltBufferAgentPaneIds(altBufferAgentSessionIds, paneRows, altBufferAgentPaneIds)
+        }
+    }
+
+    /**
+     * Issue #1158: recompute [altBufferAgentPaneIds] from the current pane rows
+     * and the sticky [altBufferAgentSessionIds] latch. Called after a new
+     * alt-buffer sighting and on pane reconcile so a pane added to a latched
+     * session picks up (and never drops) the signal.
+     */
+    fun refreshAltBufferAgentPaneIds(
+        altBufferAgentSessionIds: Set<String>,
+        paneRows: Map<String, TmuxPaneState>,
+        altBufferAgentPaneIds: MutableStateFlow<Set<String>>,
+    ) {
+        val next = paneRows.values
+            .filter { altBufferAgentSessionIds.contains(it.sessionId.trim()) }
+            .map { it.paneId }
+            .toSet()
+        if (altBufferAgentPaneIds.value != next) {
+            altBufferAgentPaneIds.value = next
+        }
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxPaneListingCommands.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxPaneListingCommands.kt
@@ -38,9 +38,22 @@ internal fun buildTmuxPaneListingCommand(sessionName: String?): String = buildSt
     append(LIST_PANES_FIELD_SEPARATOR)
     // Epic #821 slice A2: `#{pane_pid}` feeds the foreign-session one-shot
     // kind guess (`pocketshell agents kind` / `agents.kind_for_panes`).
-    // Appended LAST so older tmux that omit it leave every prior field's
-    // index unchanged (the parser tolerates its absence -> panePid 0).
-    append("#{pane_pid}'")
+    append("#{pane_pid}")
+    append(LIST_PANES_FIELD_SEPARATOR)
+    // Issue #1158 (recurrence of #962/#1057): `#{alternate_on}` is the
+    // SERVER-TRUTH alternate-screen-buffer flag (1 while the pane's program
+    // holds the DEC-1049 alternate screen — what a full-screen agent TUI does
+    // for its whole run; 0 for a plain shell at a prompt). It is the durable
+    // detection-INDEPENDENT agent signal for the maintainer's fleet (agent
+    // launched directly inside a `@ps_agent_kind=shell` session, live detection
+    // never binds). It replaces the inert CLIENT-emulator `isAlternateBufferActive`
+    // read: the tmux `-CC` capture-pane seed replays screen TEXT onto the CLIENT's
+    // MAIN buffer and an idle agent emits no fresh `?1049h`, so the client
+    // emulator never sees the alt buffer — but the SERVER always knows, and
+    // `list-panes` reports it truthfully on every reconcile. Appended LAST so
+    // older tmux that omit it leave every prior field's index unchanged (the
+    // parser tolerates its absence -> alternateOn false).
+    append("#{alternate_on}'")
 }
 
 private fun escapePaneListingSingleQuoted(input: String): String =

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxPaneRows.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxPaneRows.kt
@@ -41,10 +41,14 @@ internal fun parsePaneRow(line: String): TmuxSessionViewModel.ParsedPane? {
         // skips this pane rather than fall back to a host-wide scan.
         paneTty = parts.getOrNull(paneIndexIndex + 3).orEmpty(),
         inCopyMode = parseTmuxBoolean(parts.getOrNull(paneIndexIndex + 4)),
-        // Epic #821 slice A2: `#{pane_pid}` is the LAST field. Older tmux
-        // (or unit tests on the legacy format) omit it -> 0, and the
-        // foreign-session kind guess simply skips the pane.
+        // Epic #821 slice A2: `#{pane_pid}` for the foreign-session kind guess.
+        // Older tmux (or unit tests on the legacy format) omit it -> 0.
         panePid = parts.getOrNull(paneIndexIndex + 5)?.trim()?.toLongOrNull() ?: 0L,
+        // Issue #1158: `#{alternate_on}` is the LAST field — the SERVER-TRUTH
+        // alternate-screen flag that drives the detection-independent alt-buffer
+        // agent latch. Older tmux / legacy-format tests omit it -> false (no
+        // latch), preserving the #894 no-flap invariant for a plain shell.
+        alternateOn = parseTmuxBoolean(parts.getOrNull(paneIndexIndex + 6)),
         sessionName = sessionName,
     )
 }

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -12430,50 +12430,19 @@ public class TmuxSessionViewModel @Inject constructor(
     }
 
     /**
-     * Issue #1158 (recurrence of #962/#1057): LATCH every session whose reconciled
-     * pane list reports the SERVER-TRUTH alternate-screen flag
-     * ([ParsedPane.alternateOn], from `#{alternate_on}`) into
-     * [altBufferAgentSessionIds] (sticky — never removed within the runtime).
-     * Called from [applyParsedPanes] on every reconcile (attach / switch /
-     * layout-change), so an idle full-screen agent that emits no fresh output is
-     * still caught: the tmux SERVER always knows the pane holds the alternate
-     * buffer even though the CLIENT emulator can't see it (the `-CC` capture-pane
-     * seed replays screen TEXT onto the client's MAIN buffer). This is the fix for
-     * the maintainer's fleet — an agent launched directly inside a
-     * `@ps_agent_kind=shell` session where live detection never binds.
-     *
-     * A no-op for a plain shell on the main buffer (the #894/#815 no-flap
-     * invariant): `alternate_on` is 0, nothing is latched, the tab stays hidden.
-     *
-     * Republishes the per-pane projection only when a NEW session is latched, so a
-     * steady-state reconcile allocates nothing.
+     * Issue #1158: thin forwarders into [TmuxAltBufferAgentLatch] (extracted for
+     * PR #1431 file-size hygiene). The SERVER-TRUTH `#{alternate_on}` latch and
+     * its per-pane projection live there; the VM just supplies its own state.
      */
-    private fun latchAltBufferAgentsFromParsed(parsed: List<ParsedPane>) {
-        var added = false
-        for (pane in parsed) {
-            if (!pane.alternateOn) continue
-            val sessionId = pane.sessionId.trim()
-            if (sessionId.isEmpty()) continue
-            if (altBufferAgentSessionIds.add(sessionId)) added = true
-        }
-        if (added) refreshAltBufferAgentPaneIds()
-    }
+    private fun latchAltBufferAgentsFromParsed(parsed: List<ParsedPane>) =
+        TmuxAltBufferAgentLatch.latchAltBufferAgentsFromParsed(
+            parsed, altBufferAgentSessionIds, paneRows, _altBufferAgentPaneIds,
+        )
 
-    /**
-     * Issue #1158: recompute [altBufferAgentPaneIds] from the current pane rows and
-     * the sticky [altBufferAgentSessionIds] latch. Called after a new alt-buffer
-     * sighting and on pane reconcile so a pane added to a latched session picks up
-     * (and never drops) the signal.
-     */
-    private fun refreshAltBufferAgentPaneIds() {
-        val next = paneRows.values
-            .filter { altBufferAgentSessionIds.contains(it.sessionId.trim()) }
-            .map { it.paneId }
-            .toSet()
-        if (_altBufferAgentPaneIds.value != next) {
-            _altBufferAgentPaneIds.value = next
-        }
-    }
+    private fun refreshAltBufferAgentPaneIds() =
+        TmuxAltBufferAgentLatch.refreshAltBufferAgentPaneIds(
+            altBufferAgentSessionIds, paneRows, _altBufferAgentPaneIds,
+        )
 
     /**
      * Issue #878: seed the #818 open-time default tab placeholder for a

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -2070,8 +2070,12 @@ public class TmuxSessionViewModel @Inject constructor(
      * node-wrapped Claude / Codex `/proc` / Z.AI transcript-path fleets), and
      * every other tab signal is false — the Conversation tab was gone for the
      * session's whole life. A full-screen agent TUI holds the alternate buffer for
-     * its run, which [TerminalSurfaceState.isAlternateBufferActive] reports
-     * detection-INDEPENDENTLY.
+     * its run, which the tmux SERVER reports via `#{alternate_on}` on every
+     * `list-panes` reconcile ([latchAltBufferAgentsFromParsed]),
+     * detection-INDEPENDENTLY. (The SERVER truth — NOT the CLIENT emulator's
+     * `isAlternateBufferActive`, which stays false because the `-CC` capture-pane
+     * seed replays screen TEXT onto the client's MAIN buffer and an idle agent
+     * emits no fresh `?1049h` — is what makes this fire on the real path.)
      *
      * STICKY (latch): a session is only ever ADDED here, never removed within a
      * runtime — once the tab has been shown it stays for the session's life even
@@ -9782,9 +9786,14 @@ public class TmuxSessionViewModel @Inject constructor(
         // a pane added/removed by this reconcile picks up (or drops) its
         // session's durable shell verdict for the screen + seed gate.
         refreshConfirmedShellPaneIds()
-        // Issue #1158: republish the sticky alt-buffer agent signal so a pane
-        // added by this reconcile for an already-latched session keeps the
-        // Conversation tab (the latch is per-session; the pane id can rotate).
+        // Issue #1158: latch any session whose reconciled pane reports the
+        // SERVER-TRUTH `#{alternate_on}` flag (a full-screen agent TUI holds the
+        // alternate buffer) so the Conversation tab appears for an agent launched
+        // directly inside a `@ps_agent_kind=shell` session — the maintainer's
+        // fleet where live detection never binds. This ALSO republishes the sticky
+        // projection so a pane added by this reconcile for an already-latched
+        // session keeps the tab (the latch is per-session; the pane id can rotate).
+        latchAltBufferAgentsFromParsed(sorted)
         refreshAltBufferAgentPaneIds()
         rebuildUnifiedPanes()
         return newRows
@@ -11259,12 +11268,12 @@ public class TmuxSessionViewModel @Inject constructor(
                     tick += 1
                     continue
                 }
-                // Issue #1158: latch the visible pane's alt-buffer agent signal on
-                // the tick we already pay for (cheap local emulator read, no SSH
-                // round-trip, no new timer). Sticky — this is how the Conversation
-                // tab appears for an agent launched directly in a shell-recorded
-                // session where detection never binds.
-                noteActivePaneAltBufferState()
+                // Issue #1158: the alt-buffer agent latch is driven from the
+                // SERVER-TRUTH `#{alternate_on}` read in the pane reconcile
+                // ([latchAltBufferAgentsFromParsed]), NOT the inert CLIENT emulator
+                // — the `-CC` capture-pane seed replays screen TEXT onto the
+                // client's MAIN buffer, so the client never sees the alt buffer for
+                // an idle agent. No watchdog-tick emulator read is needed here.
                 val activePane = activeVisiblePane()
                 if (activePane != null) {
                     // Issue #1295 (deliverable 1) — the POSITIVE watchdog-liveness heartbeat.
@@ -12421,24 +12430,33 @@ public class TmuxSessionViewModel @Inject constructor(
     }
 
     /**
-     * Issue #1158: read the VISIBLE pane's alternate-screen-buffer state and, when
-     * active, LATCH its session into [altBufferAgentSessionIds] (sticky — never
-     * removed within the runtime). Cheap: a single local emulator read, no SSH
-     * round-trip — safe to call on the existing stale-render watchdog tick (no new
-     * timer, respects #1164/#1166). Republishes the per-pane projection only when a
-     * NEW session is latched, so steady-state ticks allocate nothing.
+     * Issue #1158 (recurrence of #962/#1057): LATCH every session whose reconciled
+     * pane list reports the SERVER-TRUTH alternate-screen flag
+     * ([ParsedPane.alternateOn], from `#{alternate_on}`) into
+     * [altBufferAgentSessionIds] (sticky — never removed within the runtime).
+     * Called from [applyParsedPanes] on every reconcile (attach / switch /
+     * layout-change), so an idle full-screen agent that emits no fresh output is
+     * still caught: the tmux SERVER always knows the pane holds the alternate
+     * buffer even though the CLIENT emulator can't see it (the `-CC` capture-pane
+     * seed replays screen TEXT onto the client's MAIN buffer). This is the fix for
+     * the maintainer's fleet — an agent launched directly inside a
+     * `@ps_agent_kind=shell` session where live detection never binds.
      *
      * A no-op for a plain shell on the main buffer (the #894/#815 no-flap
-     * invariant): nothing is latched, so the Conversation tab stays hidden.
+     * invariant): `alternate_on` is 0, nothing is latched, the tab stays hidden.
+     *
+     * Republishes the per-pane projection only when a NEW session is latched, so a
+     * steady-state reconcile allocates nothing.
      */
-    private fun noteActivePaneAltBufferState() {
-        val pane = activeVisiblePane() ?: return
-        if (!pane.terminalState.isAlternateBufferActive()) return
-        val sessionId = pane.sessionId.trim()
-        if (sessionId.isEmpty()) return
-        if (altBufferAgentSessionIds.add(sessionId)) {
-            refreshAltBufferAgentPaneIds()
+    private fun latchAltBufferAgentsFromParsed(parsed: List<ParsedPane>) {
+        var added = false
+        for (pane in parsed) {
+            if (!pane.alternateOn) continue
+            val sessionId = pane.sessionId.trim()
+            if (sessionId.isEmpty()) continue
+            if (altBufferAgentSessionIds.add(sessionId)) added = true
         }
+        if (added) refreshAltBufferAgentPaneIds()
     }
 
     /**
@@ -12455,34 +12473,6 @@ public class TmuxSessionViewModel @Inject constructor(
         if (_altBufferAgentPaneIds.value != next) {
             _altBufferAgentPaneIds.value = next
         }
-    }
-
-    /**
-     * Issue #1158 test seam: drive the alt-buffer poll directly (the production
-     * caller is the stale-render watchdog tick, which a JVM unit test would have to
-     * stand up a whole runtime to reach) so a test can prove the sticky latch +
-     * per-pane projection deterministically against a synthetic alt-buffer state.
-     */
-    @androidx.annotation.VisibleForTesting
-    internal fun noteActivePaneAltBufferStateForTest() {
-        noteActivePaneAltBufferState()
-    }
-
-    /**
-     * Issue #1158 connected-test seam (#780 synthetic-state model): force the REAL
-     * active pane's emulator alt-buffer verdict, then run the production latch poll.
-     * The tmux `-CC` control path does not reliably mirror a REMOTE pane's alternate
-     * screen buffer into the CLIENT emulator (the capture-pane seed replays the
-     * screen TEXT onto the main buffer, and an idle full-screen agent emits no fresh
-     * `%output` carrying the `?1049h` toggle), so a connected journey cannot enter
-     * the on-device alt-buffer state on its own. This injects that failing state
-     * synthetically on the REAL connected pane + real production tab gate, exactly
-     * as the maintainer's full-screen agent TUI would — with NO self-skip.
-     */
-    @androidx.annotation.VisibleForTesting
-    internal fun forceActivePaneAltBufferForTest(active: Boolean) {
-        activeVisiblePane()?.terminalState?.setAlternateBufferActiveForTest(active)
-        noteActivePaneAltBufferState()
     }
 
     /**
@@ -17471,6 +17461,14 @@ public class TmuxSessionViewModel @Inject constructor(
         // Epic #821 slice A2: copied from `#{pane_pid}` for the foreign-session
         // one-shot kind guess. Defaults 0 for older tmux / tests.
         val panePid: Long = 0L,
+        // Issue #1158: copied from `#{alternate_on}` — the SERVER-TRUTH
+        // alternate-screen-buffer flag. `true` while the pane's program holds the
+        // DEC-1049 alternate screen (a full-screen agent TUI for its whole run),
+        // `false` for a plain shell at a prompt. Drives the detection-independent
+        // alt-buffer agent latch that restores the Conversation tab for an agent
+        // launched directly inside a `@ps_agent_kind=shell` session. Defaults
+        // false for older tmux / tests that omit the field.
+        val alternateOn: Boolean = false,
         val sessionName: String = "",
     )
 

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxPaneAlternateOnParseTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxPaneAlternateOnParseTest.kt
@@ -1,0 +1,97 @@
+package com.pocketshell.app.tmux
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1158 (recurrence of #962/#1057) — the SERVER-TRUTH `#{alternate_on}`
+ * signal that restores the Conversation tab for an agent launched directly inside
+ * a `@ps_agent_kind=shell` session (where live detection never binds and the
+ * client emulator never sees the alt buffer). These tests lock the SOURCE of the
+ * signal: the `list-panes` format string requests `#{alternate_on}`, and
+ * [parsePaneRow] reads it into [TmuxSessionViewModel.ParsedPane.alternateOn]
+ * WITHOUT disturbing any earlier field's index. The latch behaviour that consumes
+ * this field is covered by
+ * `TmuxSessionAgentDetectionStateTest.altBufferAgent*` (red→green).
+ */
+class TmuxPaneAlternateOnParseTest {
+
+    /** Build a `list-panes -F` row in the production `#{...}` field order. */
+    private fun row(
+        paneId: String = "%3",
+        windowId: String = "@1",
+        windowIndex: Int = 2,
+        sessionId: String = "$0",
+        sessionName: String = "work",
+        title: String = "claude",
+        paneIndex: Int = 0,
+        cwd: String = "/home/u/proj",
+        currentCommand: String = "node",
+        paneTty: String = "/dev/pts/5",
+        inMode: String = "0",
+        panePid: Long = 4321L,
+        alternateOn: String = "1",
+    ): String = listOf(
+        paneId, windowId, windowIndex.toString(), sessionId, sessionName, title,
+        paneIndex.toString(), cwd, currentCommand, paneTty, inMode, panePid.toString(),
+        alternateOn,
+    ).joinToString(LIST_PANES_FIELD_SEPARATOR)
+
+    @Test
+    fun listingCommandRequestsAlternateOnAsLastField() {
+        val command = buildTmuxPaneListingCommand("work")
+        assertTrue(
+            "the reconcile must request the SERVER-TRUTH alt-buffer flag",
+            "#{alternate_on}" in command,
+        )
+        // `#{alternate_on}` is the LAST field so an older tmux that omits it leaves
+        // every earlier field's index unchanged (parser tolerates its absence).
+        assertTrue(
+            "alternate_on must be the final requested field",
+            command.trimEnd().endsWith("#{alternate_on}'"),
+        )
+        assertTrue("pane_pid must still precede alternate_on", "#{pane_pid}" in command)
+    }
+
+    @Test
+    fun parsesAlternateOnTrueForFullScreenAgentPane() {
+        val parsed = requireNotNull(parsePaneRow(row(alternateOn = "1")))
+        assertTrue(
+            "#1158: `#{alternate_on}=1` (a full-screen agent TUI) parses to alternateOn=true",
+            parsed.alternateOn,
+        )
+        // The field-index invariant: adding alternate_on last must NOT shift the
+        // earlier fields the foreign-kind guess + detection depend on.
+        assertEquals("%3", parsed.paneId)
+        assertEquals(4321L, parsed.panePid)
+        assertEquals("node", parsed.currentCommand)
+        assertEquals("/dev/pts/5", parsed.paneTty)
+    }
+
+    @Test
+    fun parsesAlternateOnFalseForPlainShellPane() {
+        val parsed = requireNotNull(parsePaneRow(row(alternateOn = "0")))
+        assertFalse(
+            "#894 no-flap: a plain shell at a prompt reads `#{alternate_on}=0`",
+            parsed.alternateOn,
+        )
+    }
+
+    @Test
+    fun missingAlternateOnFieldDefaultsFalseForOlderTmux() {
+        // Missing-data / older-tmux row (the format field absent entirely): the
+        // parser must default alternateOn to false — no spurious latch, no crash.
+        val legacyRow = listOf(
+            "%3", "@1", "2", "$0", "work", "claude", "0", "/home/u/proj", "node",
+            "/dev/pts/5", "0", "4321",
+        ).joinToString(LIST_PANES_FIELD_SEPARATOR)
+        val parsed = requireNotNull(parsePaneRow(legacyRow))
+        assertFalse(
+            "older tmux omitting `#{alternate_on}` must default alternateOn=false",
+            parsed.alternateOn,
+        )
+        assertEquals("pane_pid still parses on the legacy row", 4321L, parsed.panePid)
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionAgentDetectionStateTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionAgentDetectionStateTest.kt
@@ -8,7 +8,6 @@ import com.pocketshell.core.ssh.ExecResult
 import com.pocketshell.core.ssh.SshPortForward
 import com.pocketshell.core.ssh.SshSession
 import com.pocketshell.core.ssh.SshShell
-import com.pocketshell.core.terminal.ui.TerminalSurfaceState
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.test.TestScope
@@ -706,22 +705,52 @@ class TmuxSessionAgentDetectionStateTest : TmuxSessionViewModelTestBase() {
     }
 
     // ─── Issue #1158 (REOPENED chain #962→#975→#1057→#1158) — the STICKY ────────
-    // alt-buffer agent latch. The maintainer launches `claude`/`codex` DIRECTLY
-    // inside a shell-recorded session, so `@ps_agent_kind` stays `shell`, the
-    // confirmed-shell verdict is never cleared, and live detection never binds for
-    // the node-wrapped-Claude / Codex-`/proc` / Z.AI fleet. The detection-
-    // INDEPENDENT alt-buffer signal restores the Conversation tab and, once shown,
-    // must STAY for the session's life (a later detection drop / buffer flip must
-    // not collapse it). ─────────────────────────────────────────────────────────
+    // alt-buffer agent latch, driven from SERVER TRUTH. The maintainer launches
+    // `claude`/`codex`/glm DIRECTLY inside a shell-recorded session, so
+    // `@ps_agent_kind` stays `shell`, the confirmed-shell verdict is never cleared,
+    // and live detection never binds for the node-wrapped-Claude / Codex-`/proc` /
+    // Z.AI fleet. The detection-INDEPENDENT alt-buffer signal restores the
+    // Conversation tab and, once shown, must STAY for the session's life.
+    //
+    // The signal source is the tmux SERVER's `#{alternate_on}` flag read on every
+    // `list-panes` reconcile ([ParsedPane.alternateOn] →
+    // [TmuxSessionViewModel.latchAltBufferAgentsFromParsed]) — NOT the CLIENT
+    // emulator (which is inert on the real `-CC` path: the capture-pane seed
+    // replays screen TEXT onto the client's MAIN buffer and an idle agent emits no
+    // fresh `?1049h`, so `isAlternateBufferActive` stays false forever — the exact
+    // synthetic-masks-reality cheat that hid #1158 for five fixes). Driving the
+    // latch through `applyParsedPanesForTest(alternateOn = true)` exercises the
+    // REAL production reconcile path.
+    //
+    // RED→GREEN (base): remove the `latchAltBufferAgentsFromParsed(sorted)` call in
+    // `applyParsedPanes` (the fix) and every case below FAILS — the server-truth
+    // `alternate_on` is read but never latched, so the tab stays hidden, exactly
+    // the maintainer's #1158 symptom. ───────────────────────────────────────────
+
+    /** Server-truth reconcile: one pane in session `$0` reporting `#{alternate_on}`. */
+    private fun TmuxSessionViewModel.reconcilePaneAltBuffer(
+        paneId: String,
+        alternateOn: Boolean,
+        sessionName: String = "work",
+    ) {
+        applyParsedPanesForTest(
+            listOf(
+                TmuxSessionViewModel.ParsedPane(
+                    paneId,
+                    "@0",
+                    "$0",
+                    "shell",
+                    paneIndex = 0,
+                    alternateOn = alternateOn,
+                    sessionName = sessionName,
+                ),
+            ),
+        )
+    }
 
     @Test
     fun altBufferAgentLatchesShellRecordedSessionAndIsStickyAcrossBufferFlip() = runTest(scheduler) {
-        // A single held surface state so the test can drive the active pane's
-        // alt-buffer verdict synthetically (the #780 model — CI has no real curses
-        // agent). The factory returns the SAME instance the (single) pane uses.
-        val surface = TerminalSurfaceState()
         val vm = newVm()
-        vm.setTerminalSurfaceStateFactoryForTest { surface }
         vm.connectWithPaneForTest(paneId = "%0", windowId = "@0")
         runCurrent()
         // The maintainer's exact state: the session is a CONFIRMED shell
@@ -737,21 +766,20 @@ class TmuxSessionAgentDetectionStateTest : TmuxSessionViewModelTestBase() {
             "%0" !in vm.altBufferAgentPaneIds.value,
         )
 
-        // The agent (claude/codex/glm — kind-agnostic) goes full-screen: the pane's
-        // emulator switches to the ALTERNATE screen buffer. The watchdog tick reads
-        // it (driven here directly) and LATCHES the session.
-        surface.setAlternateBufferActiveForTest(true)
-        vm.noteActivePaneAltBufferStateForTest()
+        // The agent (claude/codex/glm — kind-agnostic) goes full-screen: the tmux
+        // SERVER reports `#{alternate_on}=1` on the next reconcile. This is the real
+        // path — no client-emulator injection — and it LATCHES the session.
+        vm.reconcilePaneAltBuffer(paneId = "%0", alternateOn = true)
         runCurrent()
         assertTrue(
-            "#1158: the alt-buffer sighting latches the session → Conversation tab shown",
+            "#1158: the server-truth alt-buffer read latches the session → Conversation tab shown",
             "%0" in vm.altBufferAgentPaneIds.value,
         )
 
         // STICKY: the agent leaves the alt-buffer (exits a full-screen view / drops
-        // detection). The tab MUST stay for the rest of the session.
-        surface.setAlternateBufferActiveForTest(false)
-        vm.noteActivePaneAltBufferStateForTest()
+        // detection) — a later reconcile reports `#{alternate_on}=0`. The tab MUST
+        // stay for the rest of the session.
+        vm.reconcilePaneAltBuffer(paneId = "%0", alternateOn = false)
         runCurrent()
         assertTrue(
             "#1158 sticky: a later buffer flip / detection drop must NOT collapse the tab",
@@ -766,23 +794,17 @@ class TmuxSessionAgentDetectionStateTest : TmuxSessionViewModelTestBase() {
         // id inherits the Conversation tab without needing a fresh alt-buffer
         // sighting — the maintainer's long-lived sessions keep the tab across
         // reconnects.
-        val surface = TerminalSurfaceState()
         val vm = newVm()
-        vm.setTerminalSurfaceStateFactoryForTest { surface }
         vm.connectWithPaneForTest(paneId = "%0", windowId = "@0")
         runCurrent()
-        surface.setAlternateBufferActiveForTest(true)
-        vm.noteActivePaneAltBufferStateForTest()
+        vm.reconcilePaneAltBuffer(paneId = "%0", alternateOn = true)
         runCurrent()
         assertTrue("precondition: latched on the original pane id", "%0" in vm.altBufferAgentPaneIds.value)
 
-        // Reattach: same session $0, new pane id %7. No fresh alt-buffer read.
-        surface.setAlternateBufferActiveForTest(false)
-        vm.applyParsedPanesForTest(
-            listOf(
-                TmuxSessionViewModel.ParsedPane("%7", "@0", "$0", "work", paneIndex = 0, sessionName = "work"),
-            ),
-        )
+        // Reattach: same session $0, new pane id %7. The reconcile reports
+        // `#{alternate_on}=0` for the new pane (the agent may be idle-on-main by now),
+        // but the per-SESSION latch keeps the tab.
+        vm.reconcilePaneAltBuffer(paneId = "%7", alternateOn = false)
         runCurrent()
         assertTrue(
             "#1158 sticky: the new pane id under the latched session keeps the tab",
@@ -794,18 +816,14 @@ class TmuxSessionAgentDetectionStateTest : TmuxSessionViewModelTestBase() {
     @Test
     fun plainShellOnMainBufferNeverLatchesNoFlap() = runTest(scheduler) {
         // #894/#815 no-flap adjacency: a plain interactive shell sitting at a prompt
-        // is on the MAIN buffer, so the alt-buffer poll never latches it → NO
-        // Conversation tab. The alt-buffer signal is POSITIVE-only.
-        val surface = TerminalSurfaceState()
+        // is on the MAIN buffer, so the tmux SERVER reports `#{alternate_on}=0` on
+        // every reconcile → the latch never fires → NO Conversation tab. The
+        // alt-buffer signal is POSITIVE-only.
         val vm = newVm()
-        vm.setTerminalSurfaceStateFactoryForTest { surface }
         vm.connectWithPaneForTest(paneId = "%0", windowId = "@0")
         vm.applyRecordedShellVerdictForTest(sessionId = "$0", isShell = true)
         runCurrent()
-        // Main buffer (the emulator override defaults to null → the real read, and a
-        // stub emulator with no alt-screen reports false; assert false explicitly).
-        surface.setAlternateBufferActiveForTest(false)
-        vm.noteActivePaneAltBufferStateForTest()
+        vm.reconcilePaneAltBuffer(paneId = "%0", alternateOn = false)
         runCurrent()
         assertTrue(
             "#894 no-flap: a main-buffer shell never latches → tab stays hidden",

--- a/scripts/file-size-hygiene-baseline.txt
+++ b/scripts/file-size-hygiene-baseline.txt
@@ -8,7 +8,7 @@
 177524 app/src/main/java/com/pocketshell/app/composer/PromptComposerViewModel.kt
 147448 app/src/main/java/com/pocketshell/app/projects/FolderListViewModel.kt
 149516 app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
-909020 app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+907910 app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
 148633 app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
 1146350 docs/mockups/feedback/folder-tree-target-20260604.png
 182790 docs/screenshots/readme-settings.png

--- a/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurfaceState.kt
+++ b/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurfaceState.kt
@@ -766,48 +766,15 @@ class TerminalSurfaceState(
         }
     }
 
-    /**
-     * Issue #1158 — true when the attached emulator is currently on the ALTERNATE
-     * screen buffer (the `smcup`/`?1049h` full-screen mode). A full-screen agent
-     * TUI (Claude Code / Codex / OpenCode and other curses apps) switches the
-     * terminal to the alternate buffer for its whole run; a plain scrolling shell
-     * sitting at a prompt stays on the MAIN buffer. The tmux ViewModel reads this
-     * as a detection-INDEPENDENT positive agent signal so the Conversation tab
-     * appears for an agent launched directly inside a shell-recorded session —
-     * where the `@ps_agent_kind` record says `shell`, the confirmed-shell verdict
-     * is never cleared (live detection can't bind for node-wrapped Claude / Codex
-     * `/proc` / Z.AI transcript-path fleets), and every other tab signal is false.
-     *
-     * A POSITIVE signal only: a genuine plain shell on the main buffer reads false,
-     * so the #894/#815 no-flap invariant holds (a fresh shell at a prompt never
-     * flashes the Conversation tab). Returns false when no emulator is attached yet,
-     * and treats a mid-resize throw as "unknown" (false) so a transient never
-     * spuriously latches the tab.
-     */
-    fun isAlternateBufferActive(): Boolean {
-        alternateBufferOverrideForTest?.let { return it }
-        val emulator = bridge?.emulator ?: _session?.emulator ?: return false
-        return try {
-            emulator.isAlternateBufferActive
-        } catch (_: Throwable) {
-            false
-        }
-    }
-
-    /**
-     * Test-only seam (#1158): force the alternate-buffer verdict reported by
-     * [isAlternateBufferActive] WITHOUT standing up a real emulator on the JVM.
-     * A `null` override (the default) restores the real emulator read. Lets a JVM
-     * unit test drive a pane onto/off the alt-buffer synthetically (the #780
-     * synthetic-state model — CI has no real curses agent) so the sticky-latch
-     * behaviour is deterministically reproducible.
-     */
-    @Volatile
-    private var alternateBufferOverrideForTest: Boolean? = null
-
-    fun setAlternateBufferActiveForTest(active: Boolean?) {
-        alternateBufferOverrideForTest = active
-    }
+    // Issue #1158 (recurrence): the CLIENT-emulator alternate-buffer read that
+    // used to feed the alt-buffer agent latch was REMOVED here (hard-cut, D22).
+    // It was inert on the real path — the tmux `-CC` capture-pane seed replays
+    // screen TEXT onto the client's MAIN buffer and an idle agent emits no fresh
+    // `?1049h`, so the client emulator never saw the alt buffer for the
+    // maintainer's fleet. The latch now reads the SERVER-TRUTH `#{alternate_on}`
+    // flag from the `list-panes` reconcile (see
+    // `TmuxSessionViewModel.latchAltBufferAgentsFromParsed`), which is authoritative
+    // regardless of what the client emulator painted.
 
     // -------------------------------------------------------------------------
     // Issue #1192 — SURFACE-paint confirmation seam (distinct from the MODEL grid).


### PR DESCRIPTION
Fixes the 5×-recurrence of the missing Terminal↔Conversation toggle for agent sessions.

## Root cause
The #1283 `altBufferAgent` rescue term was **inert on the real path**: its latch read the client emulator's `isAlternateBufferActive()`, which stays false forever because tmux `-CC` replays alt-screen text onto the client **main** buffer and an idle agent emits no fresh `?1049h`. The connected test only passed via a synthetic `forceActivePaneAltBufferForTest` injection — the synthetic-masks-reality gap (see #848) that hid the recurrence across five prior "fixes" (incl. merged PR #1161).

## Fix (hard-cut, D22)
Latch now reads the tmux **server** `#{alternate_on}` per-pane var on the existing `list-panes` reconcile (no new poll — D21). Deleted the inert client latch, its watchdog-tick call, and the `forceActivePaneAltBufferForTest` / `isAlternateBufferActive()` override seam.

## Verification (D31/D33 durable-fix gate — reviewer APPROVED)
- Reviewer drove **red→green on JVM**: neutralizing only `latchAltBufferAgentsFromParsed(sorted)` flips the alt-buffer latch tests red while the #894 no-flap control stays green.
- Reviewer drove **red→green on the REAL emulator+Docker path**: the connected journey runs green against a genuine server-side `?1049h` alt-buffer with **zero injection**; stamps prove `client_emulator_alt_active=false` (old cheat inert) while `latched=true` (server truth fired); viewport PNG shows the toggle present + sticky for a `@ps_agent_kind=shell` session.
- Class coverage (Claude/Codex/glm recorded-shell), #1057/#894 adjacency, and CI-fixture wiring (`agents:2222`, class active in `ci-journey-suite.sh`) all pass.

## Known trade-off (flagged for maintainer, non-blocking)
The kind-agnostic server-truth signal means a genuine full-screen `vim`/`less`/`htop` in a plain shell now also latches the (sticky) Conversation tab — a placeholder surface, not a broken screen; the #1283-intended trade-off. Does not break the #894 at-a-prompt invariant. Tighten later if it proves annoying.

Closes #1158