### PR TITLE
ci: guard against synthetic-masks-reality test seams (#1430)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,14 +64,19 @@ jobs:
       # (a small baseline allowlists the catalogued-but-not-yet-rewritten cases,
       # and an inline `// JUSTIFIED:` comment opts a legitimate non-IME guard
       # out), so it adds protection without reddening CI for tests it is not its
-      # job to fix. Cheap (< 1 s grep), runs BEFORE the Gradle test step. This is
-      # the machine backstop for the process.md "Regression-proof validity rules"
-      # (F2/F3) so the rule does not rely solely on reviewer memory. Additive —
-      # it does not touch the existing Unit/Python/Integration/emulator jobs.
-      - name: Test-validity guard (issue #657)
+      # job to fix. Runs BEFORE the Gradle test step. This is the machine backstop
+      # for the process.md "Regression-proof validity rules" (F2/F3) so the rule
+      # does not rely solely on reviewer memory. Additive — it does not touch the
+      # existing Unit/Python/Integration/emulator jobs. The guard now also carries
+      # the #1430 SEAM1 detector (unvetted connected-test state-injection seams —
+      # the #1158 forceActivePaneAltBufferForTest cheat class), and its self-test
+      # (below) plants a synthetic cheat + a vetted counterpart to prove SEAM1
+      # (and the other detectors) still fire red / stay green each push.
+      - name: Test-validity guard (issue #657/#848/#1048/#1154/#1430)
         run: |
-          chmod +x scripts/check-test-validity.sh
+          chmod +x scripts/check-test-validity.sh scripts/check-test-validity-selftest.sh
           scripts/check-test-validity.sh
+          scripts/check-test-validity-selftest.sh
 
       # Issue #848: per-push journey harness guard. Proof journeys listed by
       # scripts/ci-journey-suite.sh that launch MainActivity should use the

--- a/scripts/check-test-validity-selftest.sh
+++ b/scripts/check-test-validity-selftest.sh
@@ -64,11 +64,41 @@ section_of() {
     capture && /^  - / { print }
   '
 }
+# PERFORMANCE (#1430): the guard scans the whole ~900-file test tree (~13 s), and
+# this self-test asserts it ~30 times. Naively re-running the guard per assertion
+# was ~7 min — too heavy for the per-push Unit job. But the guard's NORMAL
+# (non-report) mode prints the SAME section bullets AND carries the guard-mode
+# exit code, so ONE run per distinct fixture state serves both assert_report and
+# assert_exit. We memoize that run, keyed on a cheap signature of the fixture
+# dirs + the (possibly-overridden) registry, and re-run only when a fixture /
+# registry file changed. This drops the self-test to ~1 run per fixture state.
+_CACHE_SIG=""
+_CACHE_OUT=""
+_CACHE_RC=""
+_fixture_signature() {
+  {
+    find "$TEST_FIX_DIR" "$ANDROID_FIX_DIR" "$SRC_FIX_DIR" "$TIMING_FIX_DIR" \
+      -type f -printf '%p|%s|%T@\n' 2>/dev/null | sort
+    printf 'REG:%s\n' "${VETTED_SEAM_REGISTRY:-<default>}"
+    [[ -n "${VETTED_SEAM_REGISTRY:-}" && -f "${VETTED_SEAM_REGISTRY}" ]] \
+      && printf 'REGSIG:%s\n' "$(cksum "$VETTED_SEAM_REGISTRY")"
+  } | cksum
+}
+ensure_guard_cache() {
+  local sig
+  sig="$(_fixture_signature)"
+  if [[ "$sig" != "$_CACHE_SIG" ]]; then
+    _CACHE_SIG="$sig"
+    _CACHE_OUT="$("$GUARD" 2>&1)"
+    _CACHE_RC=$?
+  fi
+}
+
 assert_report() {
   local mode="$1" needle="$2" section="$3" desc="$4"
-  local out sect
-  out="$("$GUARD" --report 2>&1)"
-  sect="$(section_of "$section" "$out")"
+  local sect
+  ensure_guard_cache
+  sect="$(section_of "$section" "$_CACHE_OUT")"
   if [[ "$mode" == "present" ]]; then
     if printf '%s' "$sect" | grep -Fq "$needle"; then note_pass "$desc"; else note_fail "$desc (expected '$needle' under '$section')"; fi
   else
@@ -76,11 +106,11 @@ assert_report() {
   fi
 }
 
-# Assert the guard's guard-mode exit code.
+# Assert the guard's guard-mode exit code (served from the same memoized run).
 assert_exit() {
   local want="$1" desc="$2"
-  "$GUARD" >/dev/null 2>&1
-  local got=$?
+  ensure_guard_cache
+  local got="$_CACHE_RC"
   if [[ "$got" -eq "$want" ]]; then note_pass "$desc (exit $got)"; else note_fail "$desc (want exit $want, got $got)"; fi
 }
 
@@ -400,6 +430,111 @@ assert_exit 1 "TIMING1 bare sleep-before-assert hard-fails the guard"
 # Remove the BAD TIMING1 so the final clean-state assertion (exit 0 with only
 # advisory/justified findings) holds.
 rm -f "$TIMING_FIX_DIR/Timing1BadSleepBeforeAssertTest.kt"
+
+# --------------------------------------------------------------------------
+# SEAM1 — connected test driving an assertion from an UNVETTED production
+# state-injection seam (#1430). Reconstructs the deleted #1158
+# forceActivePaneAltBufferForTest cheat: a production `force*ForTest` seam that
+# injects a state the real path never reaches, called by a connected test whose
+# load-bearing assert then reads it back — green while the feature is broken.
+# --------------------------------------------------------------------------
+echo
+echo "[SEAM1] connected test driving an assertion from an unvetted state-injection seam"
+
+# Plant a PRODUCTION state-injection seam (the alt-buffer cheat shape) under
+# src/main so the guard resolves the call to a real production seam (a
+# test-double helper of the same name must be IGNORED — proven separately below).
+cat > "$SRC_FIX_DIR/Seam1ProdSeam.kt" <<'KT'
+package com.pocketshell.app.validityselftest
+class Seam1ProdSeam {
+    // A production state-injection seam of the #1158 alt-buffer shape: it forces
+    // a runtime flag the real seed path never sets on its own.
+    fun forceActivePaneAltBufferForTest(active: Boolean) { /* injects unreachable state */ }
+}
+KT
+
+# BAD: a connected test that forces the unreachable state, then asserts on it —
+# the exact #1158 cheat. The seam is production-defined but NOT registry-vetted.
+cat > "$ANDROID_FIX_DIR/Seam1BadAltBufferCheatTest.kt" <<'KT'
+package com.pocketshell.app.validityselftest
+class Seam1BadAltBufferCheatTest {
+    fun conversationTabAppearsForLiveAgent() {
+        vm.forceActivePaneAltBufferForTest(true)   // injects a production-unreachable state
+        assertTrue(showsConversationTab())          // load-bearing — green while broken
+    }
+    private val vm = Seam1ProdSeam()
+    private fun showsConversationTab() = true
+    private fun assertTrue(b: Boolean) {}
+}
+KT
+
+# GOOD-1 (vetted): forceTreeStaleForTest IS a real production seam AND is listed
+# in scripts/vetted-test-state-setters.txt with a real-path-reachability reason.
+cat > "$ANDROID_FIX_DIR/Seam1GoodVettedTest.kt" <<'KT'
+package com.pocketshell.app.validityselftest
+class Seam1GoodVettedTest {
+    fun treeGoesStale() {
+        vm.forceTreeStaleForTest()   // registry-vetted: wraps the exact production markReconcileDue call
+    }
+    private val vm = FakeVm()
+    class FakeVm { fun forceTreeStaleForTest() {} }
+}
+KT
+
+# GOOD-2 (justified): the same unvetted production seam but opted out inline.
+cat > "$ANDROID_FIX_DIR/Seam1GoodJustifiedTest.kt" <<'KT'
+package com.pocketshell.app.validityselftest
+class Seam1GoodJustifiedTest {
+    fun oneOff() {
+        vm.forceActivePaneAltBufferForTest(true) // SEAM_JUSTIFIED: selftest one-off; injected state is reachable here
+    }
+    private val vm = Seam1ProdSeam()
+}
+KT
+
+# GOOD-3 (non-production helper): a `force*ForTest` of the same SHAPE but defined
+# locally in the test (NOT a production seam) must be IGNORED — the cheat class is
+# specifically a production seam.
+cat > "$ANDROID_FIX_DIR/Seam1GoodLocalHelperTest.kt" <<'KT'
+package com.pocketshell.app.validityselftest
+class Seam1GoodLocalHelperTest {
+    fun usesLocalHelper() {
+        forceLocalOnlyHelperForTest(true)  // a test-double helper, never a production seam
+    }
+    private fun forceLocalOnlyHelperForTest(active: Boolean) {}
+}
+KT
+
+assert_report present "Seam1BadAltBufferCheatTest.kt" "SEAM1 — NEW" "SEAM1 fires on an unvetted production state-injection seam (reconstructs the #1158 alt-buffer cheat)"
+assert_report absent  "Seam1GoodVettedTest.kt" "SEAM1 — NEW" "SEAM1 spares a registry-vetted seam (forceTreeStaleForTest)"
+assert_report absent  "Seam1GoodJustifiedTest.kt" "SEAM1 — NEW" "SEAM1 spares a // SEAM_JUSTIFIED: opt-out"
+assert_report absent  "Seam1GoodLocalHelperTest.kt" "SEAM1 — NEW" "SEAM1 ignores a non-production test-double helper of the same shape"
+assert_exit 1 "SEAM1 unvetted production state-injection seam hard-fails the guard"
+
+# Remove the BAD SEAM1 caller so the registry-error and clean-state checks below
+# are not confounded by its hard-fail.
+rm -f "$ANDROID_FIX_DIR/Seam1BadAltBufferCheatTest.kt"
+
+# --------------------------------------------------------------------------
+# SEAM1 registry hygiene — a registry line with no `# justification` is a hard
+# error (registry additions must carry a written real-path-reachability reason).
+# Point the guard at a TEMP registry (real registry + one un-justified line) so
+# the real 3 vetted seams stay covered (no spurious SEAM1 — NEW) and only the bad
+# line trips the error.
+# --------------------------------------------------------------------------
+echo
+echo "[SEAM1] registry line without a written justification is a hard error"
+
+TMP_REG="$(mktemp)"
+cat "scripts/vetted-test-state-setters.txt" > "$TMP_REG"
+printf '\nselftestSeamWithoutReasonForTest\n' >> "$TMP_REG"   # no `# justification` -> error
+export VETTED_SEAM_REGISTRY="$TMP_REG"
+
+assert_report present "has no '# justification'" "SEAM1 — REGISTRY error" "SEAM1 flags a registry line with no written justification"
+assert_exit 1 "SEAM1 un-justified registry line hard-fails the guard"
+
+unset VETTED_SEAM_REGISTRY
+rm -f "$TMP_REG"
 
 # --------------------------------------------------------------------------
 # Clean state: only corrective/advisory fixtures remain -> guard must PASS.

--- a/scripts/check-test-validity.sh
+++ b/scripts/check-test-validity.sh
@@ -74,6 +74,34 @@
 #       are baselined, and stale J1 baseline entries hard-fail so the baseline
 #       only shrinks as classes are promoted or removed.
 #
+#   --- #1430 addition (the synthetic-masks-reality state-injection cheat class) ---
+#
+#   SEAM1 (HARD-FAIL on a NEW occurrence) — a connected / journey test
+#       (app/src/androidTest, shared/*/src/androidTest) that drives an assertion
+#       from a PRODUCTION-defined `*ForTest` STATE-INJECTION seam whose injected
+#       state the real path may NEVER reach, and that seam is NOT vetted in
+#       scripts/vetted-test-state-setters.txt. The #1158
+#       `forceActivePaneAltBufferForTest` cheat forced an alt-buffer flag the real
+#       tmux -CC seed path never sets, so the connected test was green while the
+#       Conversation tab stayed broken on the maintainer's fleet — a 5x recurrence
+#       a plain grep could not catch because the discriminator is semantic
+#       (*can the real path produce this state at all?*). The #848 audit's fix
+#       (option b) is a VETTED-SEAM REGISTRY: the detector matches the narrow,
+#       highest-signal state-INJECTION shape a connected test calls — force*ForTest,
+#       *Override*ForTest, set*ActiveForTest — resolves it to its production
+#       `fun ...ForTest(` definition in src/main (so test-double helpers are
+#       ignored), and HARD-FAILS when that seam is neither registry-listed nor
+#       carries an inline `// SEAM_JUSTIFIED:` opt-out. Registering a seam requires
+#       writing a one-line real-path-reachability justification — the exact
+#       judgement that was skipped for alt-buffer. Config/dispatcher/timeout knob
+#       setters, exact-production-call wrappers (clearAgentDetectionForPaneForTest),
+#       lifecycle gates (setProcessStartedForTest) and read-only accessors are NOT
+#       injection-shape, so they are deliberately out of scope (precision over
+#       recall — a noisy guard gets disabled). Self-test:
+#       scripts/check-test-validity-selftest.sh plants a synthetic unregistered
+#       force*ForTest cheat (reconstructing the deleted #1158 shape) and asserts
+#       SEAM1 flags it, plus a registered counterpart it does not flag.
+#
 #   --- #1048 addition (the runTest virtual-clock-vs-real-dispatcher flake class) ---
 #
 #   TIMING1 (ADVISORY warning, with ONE narrow HARD-FAIL) — scoped to the
@@ -107,8 +135,15 @@
 # intended direction of travel; a stale baseline entry is pruned + noted.
 #
 # Usage:
-#   scripts/check-test-validity.sh            # guard mode (CI): exit 1 on a NEW A5/C1/J1/TIMING1 hard-fail smell
+#   scripts/check-test-validity.sh            # guard mode (CI): exit 1 on a NEW A5/C1/J1/TIMING1/SEAM1 hard-fail smell
 #   scripts/check-test-validity.sh --report   # report ALL findings incl. baseline; never fails
+#   scripts/check-test-validity.sh --self-test # run the synthetic red->green proof (delegates to check-test-validity-selftest.sh)
+#
+# REVIEWER FAST-CHECK: run this (and scripts/check-test-validity-selftest.sh)
+# locally before approving any test change — it is the machine sibling of
+# process.md's "Regression-proof validity rules" (F2/F3) and catches the
+# synthetic-masks-reality state-injection cheat class (SEAM1, #1430) that a code
+# read can miss.
 #
 # This is intentionally a grep-guard, not a custom lint rule, for affordability
 # (it runs in the cheap Unit job in .github/workflows/tests.yml before the
@@ -135,6 +170,15 @@ done < <(find shared -maxdepth 3 -type d -path 'shared/*/src/test' 2>/dev/null |
 RPC_SOURCE_ROOT="app/src/main/java/com/pocketshell/app"
 ANDROID_TEST_ROOT="app/src/androidTest/java"
 CI_JOURNEY_SUITE="scripts/ci-journey-suite.sh"
+# #1430: the vetted state-injection seam registry (SEAM1). Overridable via the
+# VETTED_SEAM_REGISTRY env var so the self-test can point at a temp registry.
+VETTED_SEAM_REGISTRY="${VETTED_SEAM_REGISTRY:-scripts/vetted-test-state-setters.txt}"
+# Production source roots where a `fun ...ForTest(` DEFINITION makes a seam a
+# genuine production seam (vs a test-double helper of the same name).
+PROD_SRC_ROOTS=(app/src/main)
+while IFS= read -r d; do
+  [[ -d "$d" ]] && PROD_SRC_ROOTS+=("$d")
+done < <(find shared -maxdepth 3 -type d -path 'shared/*/src/main' 2>/dev/null | sort)
 
 # Collect all test .kt files once.
 collect_test_files() {
@@ -162,6 +206,14 @@ collect_android_test_files() {
     | while IFS= read -r d; do find "$d" -type f -name '*.kt'; done
 }
 mapfile -t ANDROID_TEST_FILES < <(collect_android_test_files)
+
+# --self-test delegates to the sibling driver (which plants synthetic red/green
+# fixtures for every detector — including the #1430 SEAM1 cheat — and asserts the
+# guard flags the bad ones / spares the good ones). Kept as a separate script for
+# affordability, but exposed here so `check-test-validity.sh --self-test` works.
+if [[ "${1:-}" == "--self-test" ]]; then
+  exec "$REPO_ROOT/scripts/check-test-validity-selftest.sh"
+fi
 
 REPORT_MODE=0
 if [[ "${1:-}" == "--report" ]]; then
@@ -861,6 +913,127 @@ scan_timing1() {
 }
 
 # --------------------------------------------------------------------------
+# SEAM1 scan (#1430) — a connected / journey test (androidTest) that drives an
+# assertion from a PRODUCTION-defined state-INJECTION seam not vetted in the
+# registry. See the header block for the full rationale (the #1158 alt-buffer
+# cheat class). Deliberately conservative (precision over recall):
+#
+#   (1) the CALL must be the state-injection SHAPE — force*ForTest,
+#       *Override*ForTest, or set*ActiveForTest — the narrow, highest-signal shape
+#       the alt-buffer cheat took (forceActivePaneAltBufferForTest). Plain config
+#       setters, exact-production-call wrappers, lifecycle gates and read
+#       accessors are out of scope.
+#   (2) the seam must be PRODUCTION-defined (`fun <name>ForTest(` under
+#       app/src/main or shared/*/src/main), so a test-double helper of the same
+#       name is ignored — the cheat class is specifically a production seam.
+#   (3) VETTED — the seam name is listed in scripts/vetted-test-state-setters.txt
+#       (each with a written real-path-reachability justification), OR the call
+#       carries an inline `// SEAM_JUSTIFIED:` opt-out (on the call line or the
+#       line directly above). Otherwise it is a NEW hard-fail.
+# --------------------------------------------------------------------------
+declare -a SEAM1_NEW=()
+declare -a SEAM1_VETTED=()          # call-site records that resolved to a vetted seam
+declare -a SEAM1_REGISTRY_NAMES=()  # the bare seam names parsed from the registry
+declare -a SEAM1_JUSTIFIED=()
+declare -a SEAM1_REGISTRY_ERRORS=()
+declare -a SEAM1_STALE_REGISTRY=()
+declare -A SEAM1_VETTED_SEEN=()
+declare -A PROD_SEAM_DEFINED=()
+
+# The state-injection call shape (the alt-buffer cheat's shape).
+SEAM1_INJECTION_SHAPE='(force[A-Za-z]*ForTest|[a-z][A-Za-z]*Override[A-Za-z]*ForTest|set[A-Za-z]*ActiveForTest)'
+
+# Build the set of production-defined `*ForTest` seam names once.
+build_prod_seam_set() {
+  local r name
+  for r in "${PROD_SRC_ROOTS[@]}"; do
+    [[ -d "$r" ]] || continue
+    while IFS= read -r name; do
+      [[ -n "$name" ]] && PROD_SEAM_DEFINED["$name"]=1
+    done < <(grep -rhoE 'fun[[:space:]]+[A-Za-z_]+ForTest[[:space:]]*\(' "$r" 2>/dev/null \
+             | sed -E 's/fun[[:space:]]+//; s/[[:space:]]*\($//')
+  done
+}
+
+# Parse the registry: each data line is `<seamName>  # <justification>`. A data
+# line with no `#`-justification is a hard error (registry additions must carry a
+# written reason). Blank / `#`-leading lines are ignored (header).
+parse_vetted_seam_registry() {
+  if [[ ! -f "$VETTED_SEAM_REGISTRY" ]]; then
+    SEAM1_REGISTRY_ERRORS+=("missing $VETTED_SEAM_REGISTRY")
+    return
+  fi
+  local line seam reason lineno=0
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    lineno=$((lineno + 1))
+    # Strip leading whitespace.
+    line="${line#"${line%%[![:space:]]*}"}"
+    [[ -z "$line" ]] && continue
+    [[ "$line" == \#* ]] && continue
+    # Split on the first '#'.
+    seam="${line%%#*}"
+    reason="${line#*#}"
+    # Trim the seam token to its first word.
+    seam="${seam%%[[:space:]]*}"
+    # Trim the reason.
+    reason="${reason#"${reason%%[![:space:]]*}"}"
+    if [[ -z "$seam" ]]; then
+      continue
+    fi
+    if [[ "$line" != *"#"* || -z "$reason" ]]; then
+      SEAM1_REGISTRY_ERRORS+=("$VETTED_SEAM_REGISTRY:$lineno: '$seam' has no '# justification' (registry additions must carry a written reason)")
+      continue
+    fi
+    if [[ -z "${SEAM1_VETTED_SEEN[$seam]:-}" ]]; then
+      SEAM1_VETTED_SEEN[$seam]=1
+      SEAM1_REGISTRY_NAMES+=("$seam")
+    fi
+  done < "$VETTED_SEAM_REGISTRY"
+}
+
+scan_seam1() {
+  build_prod_seam_set
+  parse_vetted_seam_registry
+
+  local file lineno text prev seam
+  for file in "${ANDROID_TEST_FILES[@]}"; do
+    [[ -z "$file" ]] && continue
+    grep -Eq "$SEAM1_INJECTION_SHAPE[[:space:]]*\(" "$file" || continue
+    while IFS= read -r lineno; do
+      [[ -z "$lineno" ]] && continue
+      text="$(sed -n "${lineno}p" "$file")"
+      is_code_line "$text" || continue
+      # Every injection-shape seam name called on this line.
+      while IFS= read -r seam; do
+        [[ -z "$seam" ]] && continue
+        # (2) only PRODUCTION-defined seams are the cheat class.
+        [[ -n "${PROD_SEAM_DEFINED[$seam]:-}" ]] || continue
+        # Inline opt-out on the call line or the line directly above.
+        prev="$(sed -n "$((lineno - 1))p" "$file")"
+        if printf '%s\n%s' "$prev" "$text" | grep -q 'SEAM_JUSTIFIED:'; then
+          SEAM1_JUSTIFIED+=("$file:$lineno ($seam)")
+          continue
+        fi
+        if [[ -n "${SEAM1_VETTED_SEEN[$seam]:-}" ]]; then
+          SEAM1_VETTED+=("$file:$lineno ($seam)")
+        else
+          SEAM1_NEW+=("$file:$lineno ($seam)")
+        fi
+      done < <(grep -oE "$SEAM1_INJECTION_SHAPE[[:space:]]*\(" <<< "$text" | sed -E 's/[[:space:]]*\($//' | sort -u)
+    done < <(grep -nE "$SEAM1_INJECTION_SHAPE[[:space:]]*\(" "$file" | cut -d: -f1)
+  done
+
+  # Registry hygiene: a vetted seam that is no longer production-defined anywhere
+  # is stale (renamed / removed) — advisory NOTE so the registry only lists live
+  # seams (mirrors the *_BASELINE stale check).
+  local v
+  for v in "${SEAM1_REGISTRY_NAMES[@]:-}"; do
+    [[ -z "$v" ]] && continue
+    [[ -n "${PROD_SEAM_DEFINED[$v]:-}" ]] || SEAM1_STALE_REGISTRY+=("$v -> not defined in any src/main")
+  done
+}
+
+# --------------------------------------------------------------------------
 # V1 scan (#1154) — non-void @Test (and @Before/@After lifecycle) methods in
 # androidTest. A Kotlin EXPRESSION body — `@Test fun x() = runBlocking { … }` —
 # returns the block's last expression. When that is non-Unit (e.g. the block
@@ -890,41 +1063,52 @@ V1_JUNIT_ANNOT='@(Test|Before|After|BeforeClass|AfterClass)([[:space:](]|$)'
 # excluded by `[^)]*`), so this does not false-positive on `fun f(a: Int = 5) { }`.
 V1_FUN_EXPR='^[[:space:]]*(override[[:space:]]+|public[[:space:]]+|internal[[:space:]]+|private[[:space:]]+)*fun[[:space:]]+[A-Za-z0-9_]+[[:space:]]*\([^)]*\)[[:space:]]*(:[[:space:]]*[^={]+)?='
 
+# V1_FUN_MODIFIER — a leading-modifier `fun` declaration head. Kept as a separate
+# constant so the in-memory scan and the (behaviour-identical) grep form agree.
+V1_FUN_MODIFIER='^[[:space:]]*(override[[:space:]]+|public[[:space:]]+|internal[[:space:]]+|private[[:space:]]+)*fun[[:space:]]'
+
 scan_void1() {
+  # PERFORMANCE (#1430): the original walked each androidTest file with per-line
+  # `sed -n Np file` (a whole-file read per line) inside a forward-walk loop —
+  # tens of thousands of subprocess spawns across the androidTest tree, ~18 s. This
+  # reads each candidate file ONCE into an array and classifies lines with bash's
+  # builtin `[[ =~ ]]` using the SAME ERE constants (V1_JUNIT_ANNOT / V1_FUN_EXPR /
+  # V1_FUN_MODIFIER), so behaviour is identical while dropping the cost to ~1 s.
   local file
   for file in "${ANDROID_TEST_FILES[@]}"; do
     [[ -z "$file" ]] && continue
     # Cheap pre-filter: only files that even have a lifecycle annotation.
     grep -Eq "$V1_JUNIT_ANNOT" "$file" || continue
-    local total lineno
-    total="$(wc -l < "$file")"
-    while IFS= read -r lineno; do
-      [[ -z "$lineno" ]] && continue
+    local -a lines=()
+    mapfile -t lines < "$file"
+    local total="${#lines[@]}"
+    local i annline j text stripped
+    for ((i = 0; i < total; i++)); do
+      annline="${lines[i]}"
+      [[ "$annline" =~ $V1_JUNIT_ANNOT ]] || continue
       # Same-line form: `@Test fun x() = …` on the annotation line itself.
-      local annline
-      annline="$(sed -n "${lineno}p" "$file")"
-      if printf '%s' "$annline" | grep -Eq "$V1_FUN_EXPR"; then
-        V1_NEW+=("$file:$lineno")
+      if [[ "$annline" =~ $V1_FUN_EXPR ]]; then
+        V1_NEW+=("$file:$((i + 1))")
         continue
       fi
       # Otherwise walk forward to the next `fun` declaration, skipping further
       # annotations, blank lines, and comment lines.
-      local j="$((lineno + 1))" text
-      while [[ "$j" -le "$total" ]]; do
-        text="$(sed -n "${j}p" "$file")"
-        case "$(printf '%s' "$text" | sed -e 's/^[[:space:]]*//')" in
+      j=$((i + 1))
+      while (( j < total )); do
+        text="${lines[j]}"
+        stripped="${text#"${text%%[![:space:]]*}"}"
+        case "$stripped" in
           '@'*|''|'//'*|'/*'*|'*'*) j=$((j + 1)); continue ;;
         esac
         break
       done
-      [[ "$j" -gt "$total" ]] && continue
-      text="$(sed -n "${j}p" "$file")"
+      (( j >= total )) && continue
+      text="${lines[j]}"
       # Only flag when this is actually a `fun` declaration (an expression body).
-      if printf '%s' "$text" | grep -Eq '^[[:space:]]*(override[[:space:]]+|public[[:space:]]+|internal[[:space:]]+|private[[:space:]]+)*fun[[:space:]]' \
-         && printf '%s' "$text" | grep -Eq "$V1_FUN_EXPR"; then
-        V1_NEW+=("$file:$j")
+      if [[ "$text" =~ $V1_FUN_MODIFIER ]] && [[ "$text" =~ $V1_FUN_EXPR ]]; then
+        V1_NEW+=("$file:$((j + 1))")
       fi
-    done < <(grep -nE "$V1_JUNIT_ANNOT" "$file" | cut -d: -f1)
+    done
   done
 }
 
@@ -943,6 +1127,7 @@ scan_fake1
 scan_await1
 scan_j1
 scan_timing1
+scan_seam1
 scan_void1
 
 echo "=============================================================="
@@ -951,6 +1136,7 @@ echo " Scanned test roots:"
 for r in "${TEST_ROOTS[@]}"; do echo "   - $r/**/*.kt"; done
 echo " Connect-path RPC sources: $RPC_SOURCE_ROOT/**/*RemoteSource.kt (+ FolderListViewModel.kt)"
 echo " CI journey suite: $CI_JOURNEY_SUITE (${#J1_WIRED_ANDROID_TEST_CLASSES[@]} androidTest class entr(y/ies) parsed)"
+echo " Vetted state-injection seam registry: $VETTED_SEAM_REGISTRY (${#SEAM1_REGISTRY_NAMES[@]} seam(s) vetted)"
 echo "=============================================================="
 
 print_list() {
@@ -993,6 +1179,11 @@ print_list "TIMING1 — NEW bare Thread.sleep(N) before a load-bearing assert, n
 print_list "TIMING1 — NEW runTest over a real dispatcher/thread without a pinned seam or bounded pump [advisory]" "${TIMING1_FINDINGS[@]:-}"
 print_list "TIMING1 — KNOWN baseline (real-dispatcher/thread runTest catalogued; seam adoption is per-test follow-up) [advisory]" "${TIMING1_KNOWN[@]:-}"
 print_list "TIMING1 — JUSTIFIED (opted out via // JUSTIFIED:) [advisory]" "${TIMING1_JUSTIFIED[@]:-}"
+print_list "SEAM1 — NEW connected-test assertion driven by an UNVETTED production state-injection seam (force*/Override*/set*Active*ForTest not in the registry) [HARD FAIL]" "${SEAM1_NEW[@]:-}"
+print_list "SEAM1 — VETTED connected-test state-injection seam call (registry-listed) [advisory]" "${SEAM1_VETTED[@]:-}"
+print_list "SEAM1 — JUSTIFIED (opted out via // SEAM_JUSTIFIED:) [advisory]" "${SEAM1_JUSTIFIED[@]:-}"
+print_list "SEAM1 — REGISTRY error (a registry line has no '# justification') [HARD FAIL]" "${SEAM1_REGISTRY_ERRORS[@]:-}"
+print_list "SEAM1 — STALE registry entry (seam no longer defined in any src/main) [advisory NOTE]" "${SEAM1_STALE_REGISTRY[@]:-}"
 print_list "V1 — NEW non-void expression-body @Test/@Before/@After in androidTest (JUnit InvalidTestClassError -> class never runs) [HARD FAIL]" "${V1_NEW[@]:-}"
 
 if [[ "${#STALE_BASELINE[@]}" -gt 0 ]]; then
@@ -1026,9 +1217,15 @@ echo " V1     androidTest @Test/@Before/@After must use a VOID BLOCK body, not a
 echo "        expression body. Change  fun x() = runBlocking { … }  to"
 echo "        fun x() { runBlocking { … } }  (the block body is always Unit; the"
 echo "        expression-body value that made the method non-void is discarded)."
+echo " SEAM1  a connected test must not drive an assertion from a state-injection"
+echo "        seam (force*/Override*/set*Active*ForTest) whose injected state the"
+echo "        real path may never reach, unless the seam is vetted with a written"
+echo "        real-path-reachability reason in $VETTED_SEAM_REGISTRY"
+echo "        (or the call carries an inline // SEAM_JUSTIFIED: opt-out). This is"
+echo "        the #1158 forceActivePaneAltBufferForTest cheat class (#1430/#848)."
 echo "--------------------------------------------------------------"
 
-# Collect the HARD-FAIL categories (A5 + C1 + J1 + TIMING1).
+# Collect the HARD-FAIL categories (A5 + C1 + J1 + TIMING1 + SEAM1 + V1).
 real_hard_fail=()
 for x in \
   "${A5_NEW[@]:-}" \
@@ -1037,6 +1234,8 @@ for x in \
   "${J1_STALE_BASELINE[@]:-}" \
   "${J1_PARSER_FAILURE[@]:-}" \
   "${TIMING1_NEW_HARD[@]:-}" \
+  "${SEAM1_NEW[@]:-}" \
+  "${SEAM1_REGISTRY_ERRORS[@]:-}" \
   "${V1_NEW[@]:-}"; do
   [[ -n "$x" ]] && real_hard_fail+=("$x")
 done
@@ -1049,12 +1248,12 @@ fi
 
 if [[ "${#real_hard_fail[@]}" -gt 0 ]]; then
   echo
-  echo "::error title=Test-validity guard (issue #657/#848/#1048/#1154)::A NEW load-bearing self-skip, ungated androidTest journey, fixed-sleep-before-assert, or non-void androidTest @Test method was found. An androidTest @Test/@Before/@After must use a VOID BLOCK body (fun x() { … }), never an expression body (fun x() = …) — a non-Unit expression body makes the method non-void and JUnit rejects the ENTIRE class at load (InvalidTestClassError), so it never runs (#1154). An IME/keyboard/geometry test must not gate its assertion behind assumeTrue(...) (convert to the synthetic-inset model, #780), a connect/journey test must not gate behind assumeFalse(isRunningOnCi()) outside a genuine opt-in fault/Docker fixture (inject the state and HARD-assert, or add an inline // JUSTIFIED: comment naming the opt-in fixture), a new androidTest *E2eTest/*DockerTest class must be wired into scripts/ci-journey-suite.sh or carry a local // CI_JOURNEY_SUITE_JUSTIFIED: reason, and a connection/terminal runTest test must not use a bare Thread.sleep(N) as the only sync before a load-bearing assert (use a StandardTestDispatcher seam or a bounded advanceUntilIdle()+idleFor() deadline pump per #1048). Remove stale J1 baselines when a class is promoted or deleted."
+  echo "::error title=Test-validity guard (issue #657/#848/#1048/#1154/#1430)::A NEW load-bearing self-skip, ungated androidTest journey, fixed-sleep-before-assert, unvetted connected-test state-injection seam (a force*/Override*/set*Active*ForTest seam driving an assertion that is not vetted in scripts/vetted-test-state-setters.txt with a real-path-reachability reason — the #1158 alt-buffer cheat class), or non-void androidTest @Test method was found. An androidTest @Test/@Before/@After must use a VOID BLOCK body (fun x() { … }), never an expression body (fun x() = …) — a non-Unit expression body makes the method non-void and JUnit rejects the ENTIRE class at load (InvalidTestClassError), so it never runs (#1154). An IME/keyboard/geometry test must not gate its assertion behind assumeTrue(...) (convert to the synthetic-inset model, #780), a connect/journey test must not gate behind assumeFalse(isRunningOnCi()) outside a genuine opt-in fault/Docker fixture (inject the state and HARD-assert, or add an inline // JUSTIFIED: comment naming the opt-in fixture), a new androidTest *E2eTest/*DockerTest class must be wired into scripts/ci-journey-suite.sh or carry a local // CI_JOURNEY_SUITE_JUSTIFIED: reason, and a connection/terminal runTest test must not use a bare Thread.sleep(N) as the only sync before a load-bearing assert (use a StandardTestDispatcher seam or a bounded advanceUntilIdle()+idleFor() deadline pump per #1048). Remove stale J1 baselines when a class is promoted or deleted."
   echo
-  echo "FAIL: ${#real_hard_fail[@]} unjustified hard-fail occurrence(s) (A5 + C1 + J1 + TIMING1 + V1)."
+  echo "FAIL: ${#real_hard_fail[@]} unjustified hard-fail occurrence(s) (A5 + C1 + J1 + TIMING1 + SEAM1 + V1)."
   exit 1
 fi
 
 echo
-echo "PASS: no new unjustified load-bearing self-skips, ungated androidTest journeys, fixed-sleep-before-assert flakes, or non-void androidTest @Test methods (A5 + C1 + J1 + TIMING1 + V1)."
+echo "PASS: no new unjustified load-bearing self-skips, ungated androidTest journeys, fixed-sleep-before-assert flakes, unvetted state-injection seams, or non-void androidTest @Test methods (A5 + C1 + J1 + TIMING1 + SEAM1 + V1)."
 exit 0

--- a/scripts/vetted-test-state-setters.txt
+++ b/scripts/vetted-test-state-setters.txt
@@ -1,0 +1,43 @@
+# Vetted connected-test STATE-INJECTION seams (issue #1430, child of #848).
+#
+# WHY THIS FILE EXISTS
+# --------------------
+# A connected / journey test (app/src/androidTest, shared/*/src/androidTest) can
+# be GREEN while the real production path is BROKEN when its load-bearing
+# assertion is driven from a `*ForTest` STATE-INJECTION seam that injects a state
+# production can NEVER reach on its own. The #1158 `forceActivePaneAltBufferForTest`
+# cheat (now deleted) did exactly that — it forced an alt-buffer flag the real
+# tmux -CC seed path never sets — and hid a 5x-recurring Conversation-tab bug for
+# weeks. `scripts/check-test-validity.sh` could not grep for it because the
+# discriminator is SEMANTIC: *can the real path produce this state at all?*
+#
+# This registry is the answer the audit (#848 comment 4929654015, option (b))
+# recommended: an EXPLICIT allowlist of the state-injection seams whose injected
+# state the real path GENUINELY reaches (the #780 model — the injection only makes
+# a real-but-nondeterministic on-device state deterministic on the fast x86 AVD).
+# The SEAM1 detector in check-test-validity.sh HARD-FAILS a connected test that
+# calls a production-defined state-injection seam (force*ForTest / *Override*ForTest
+# / set*ActiveForTest) that is NOT listed here and has no inline
+# `// SEAM_JUSTIFIED:` opt-out. That forces the reviewer to write down, for every
+# NEW synthetic connected proof, WHY the real path reaches the injected state —
+# the exact judgement that was skipped for alt-buffer.
+#
+# FORMAT (enforced): one entry per line
+#     <seamName>  # <one-line real-path-reachability justification>
+# The justification after `#` is REQUIRED — a bare seam name with no reason is a
+# hard error (registry additions must be deliberate and vetted). Lines that are
+# blank or start with `#` are ignored (this header).
+#
+# SCOPE NOTE: the SEAM1 detector only consults the state-INJECTION shape
+# (force*ForTest / *Override*ForTest / set*ActiveForTest) — the narrow, highest-
+# signal shape the alt-buffer cheat took. Plain config/dispatcher/timeout knob
+# setters (setExecDispatcherForTest, setSendTimeoutForTest, ...),
+# exact-production-call wrappers (clearAgentDetectionForPaneForTest,
+# applyRecordedShellVerdictForTest), lifecycle gates (setProcessStartedForTest),
+# user-setting pins (setDefaultAgentSessionViewForTest) and read-only accessors
+# are NOT injection-shape and are not gated by SEAM1, so they do not need an entry
+# here (the #848 audit cleared them as legitimate #780-model seams).
+
+forceTreeStaleForTest  # FolderListViewModel: wraps the EXACT production call tree.markReconcileDueForTest(); the real path marks the tree due for reconcile on its real timer/change, so this only makes that reachable transition deterministic.
+forceAttachingStateForTest  # TmuxSessionViewModel: sets ConnectionState.Attaching, the EXACT state a same-host fast switch (runFastSessionSwitch/fastSwitchSessionForTest) holds before the Live flip; the real path reaches Attaching on every same-host switch.
+setRenderDrainBackloggedOverrideForTest  # TerminalSurfaceState: the seam's own doc confirms the maintainer's on-device freeze DOES drive the drain-backlogged state under a heavy Codex burst + IME amplifier; only the fast CI/dev x86 AVD never backlogs, so the override makes that real on-device state deterministic (textbook #780).


### PR DESCRIPTION
Child of #848. Prevents the next #1158-class cheat — a connected test that passes GREEN while the real path is broken because its load-bearing assertion is driven by a `*ForTest` state-injection seam production can't reach.

## What
- `scripts/check-test-validity.sh` — new **SEAM1** detector: hard-fail a connected/androidTest driving an assertion from a production-defined state-INJECTION seam (`force*ForTest` / `*Override*ForTest` / `set*ActiveForTest` — the deleted #1158 `forceActivePaneAltBufferForTest` shape) unless registry-vetted or `// SEAM_JUSTIFIED:`-opted-out. Precision-first (config/timeout knobs, exact-production-call wrappers, lifecycle gates, read accessors are out of scope). Also refactors the V1 `scan_void1` hotspot (behavior-identical, 28s→13s).
- `scripts/vetted-test-state-setters.txt` (NEW) — vetted-seam registry; each entry needs a written real-path-reachability justification (a line without one is a hard error).
- `scripts/check-test-validity-selftest.sh` — SEAM1 red→green self-test (reconstructs the #1158 cheat synthetically).
- `.github/workflows/tests.yml` — wires the self-test into the Unit job.

## Verification (reviewer APPROVED)
- Reviewer independently drove G1 red→green: planted a `force*ForTest` seam + unvetted caller → guard hard-fails exit 1; `// SEAM_JUSTIFIED:` clears it. Bundled `--self-test` 30/0.
- 0 false positives on the real tree; the 3 vetted seams inject genuinely production-reachable states.
- V1 optimization byte-identical output.
- Combination check: guard passes against the post-#1432 shrunk `ci-journey-suite.sh` (J1 parses the preserved FQCN literals).

Closes #1430