### PR TITLE
cleanup: remove 13 verified-dead symbols from the #684 audit (#1438)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/cards/SessionChecklistUi.kt
+++ b/app/src/main/java/com/pocketshell/app/cards/SessionChecklistUi.kt
@@ -39,7 +39,6 @@ import com.pocketshell.uikit.theme.PocketShellSpacing
 import com.pocketshell.uikit.theme.PocketShellType
 
 internal const val SESSION_CHECKLIST_CHIP_TAG: String = "session:checklist-chip"
-internal const val SESSION_CHECKLIST_SHEET_TAG: String = "session:checklist:sheet"
 internal const val SESSION_CHECKLIST_CARD_TAG_PREFIX: String = "session:checklist:card:"
 internal const val SESSION_CHECKLIST_ITEM_TAG_PREFIX: String = "session:checklist:item:"
 internal const val SESSION_CHECKLIST_CLOSE_TAG: String = "session:checklist:close"
@@ -197,37 +196,6 @@ internal fun SessionCardFeedContent(
                 Spacer(modifier = Modifier.height(PocketShellSpacing.sm))
             }
         }
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Checklist-only sheet — kept for the current single-checklist wiring, but now
-// renders through the registry's [ChecklistCardRenderer] so there is no
-// checklist-specific row layout duplicated outside the renderer (hard-cut D22).
-// ---------------------------------------------------------------------------
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-internal fun ChecklistCardsSheet(
-    cards: List<SessionCardsRemoteSource.ChecklistCard>,
-    onToggle: (cardId: String, itemId: String, checked: Boolean) -> Unit,
-    onDismiss: () -> Unit,
-    modifier: Modifier = Modifier,
-    sheetState: SheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
-) {
-    ModalBottomSheet(
-        onDismissRequest = onDismiss,
-        sheetState = sheetState,
-        containerColor = PocketShellColors.Surface,
-        contentColor = PocketShellColors.Text,
-        modifier = modifier,
-    ) {
-        ChecklistCardsContent(
-            cards = cards,
-            onToggle = onToggle,
-            onClose = onDismiss,
-            modifier = Modifier.testTag(SESSION_CHECKLIST_SHEET_TAG),
-        )
     }
 }
 

--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerSheet.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerSheet.kt
@@ -2135,17 +2135,6 @@ internal const val SEND_ENTER_TOOLTIP_LABEL: String =
     "Send the draft and submit it with Enter"
 
 /**
- * Issue #153 fix 3: stable test tag for the long-press tooltip popup
- * surface. The tag derives from the tooltip copy so the OutlineSend and
- * Primary Send tooltips get distinct tags without an extra parameter
- * threaded through. Connected tests can long-press the button and
- * assert the popup surfaced with the expected copy.
- */
-internal fun composerSendTooltipTestTag(label: String): String =
-    "prompt-composer-send-tooltip:" + label.hashCode().toString(16)
-
-
-/**
  * Issue #174: test tag for the recording discard control. It only appears in
  * `Recording`, where it stops the mic and drops the buffer before Whisper.
  */

--- a/app/src/main/java/com/pocketshell/app/conversation/ConversationMessageTurn.kt
+++ b/app/src/main/java/com/pocketshell/app/conversation/ConversationMessageTurn.kt
@@ -238,21 +238,6 @@ private fun MessageBody(
     }
 }
 
-/**
- * A streaming cursor indicator for use at the end of a streaming message.
- */
-@Composable
-internal fun StreamingCursor(
-    modifier: Modifier = Modifier,
-) {
-    Text(
-        text = "▌",
-        color = PocketShellColors.Purple,
-        fontSize = 14.sp,
-        modifier = modifier,
-    )
-}
-
 internal val LocalConversationFontSizeSp: ProvidableCompositionLocal<Float> =
     staticCompositionLocalOf { PocketShellType.bodyDense.fontSize.value }
 

--- a/app/src/main/java/com/pocketshell/app/projects/FolderListTreeChrome.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListTreeChrome.kt
@@ -3,14 +3,12 @@ package com.pocketshell.app.projects
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
@@ -28,11 +26,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.pocketshell.uikit.components.ConfirmDialog
@@ -40,7 +34,6 @@ import com.pocketshell.uikit.components.FormDialog
 import com.pocketshell.uikit.model.SessionAgentKind
 import com.pocketshell.uikit.theme.LocalPocketShellSemantic
 import com.pocketshell.uikit.theme.PocketShellColors
-import com.pocketshell.uikit.theme.PocketShellDensity
 import com.pocketshell.uikit.theme.PocketShellSpacing
 import com.pocketshell.uikit.theme.PocketShellType
 
@@ -154,52 +147,6 @@ internal fun TreeChildRow(
 
 /** Round a px value to the nearest whole device pixel (for crisp 1 dp hairlines). */
 private fun snapToPixel(px: Float): Float = kotlin.math.round(px)
-
-// docs/design-system.md: this compact tree chrome keeps sub-ladder glyph geometry
-// that predates the token sweep, but names it so the drift guard can ratchet by file.
-private val CompactTreeAddGlyphSize = 18.sp
-
-@Composable
-internal fun CompactTreeIconButton(
-    label: String,
-    contentDescription: String,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-    testTag: String? = null,
-    accent: Boolean = false,
-    size: Dp = PocketShellDensity.tapTargetMin,
-) {
-    val background = if (accent) {
-        PocketShellColors.AccentSoft
-    } else {
-        PocketShellColors.SurfaceElev.copy(alpha = 0.72f)
-    }
-    val foreground = if (accent) PocketShellColors.Accent else PocketShellColors.TextSecondary
-    val pillSize = (size.value - 4f).coerceAtLeast(24f).dp
-    Box(
-        modifier = modifier
-            .size(size)
-            .semantics { this.contentDescription = contentDescription }
-            .clickable(role = Role.Button, onClick = onClick)
-            .then(if (testTag != null) Modifier.testTag(testTag) else Modifier),
-        contentAlignment = Alignment.Center,
-    ) {
-        Box(
-            modifier = Modifier
-                .size(pillSize)
-                .background(background, CircleShape),
-            contentAlignment = Alignment.Center,
-        ) {
-            Text(
-                text = label,
-                color = foreground,
-                fontSize = if (label == "+") CompactTreeAddGlyphSize else 14.sp,
-                fontWeight = FontWeight.SemiBold,
-                maxLines = 1,
-            )
-        }
-    }
-}
 
 @Composable
 internal fun StatusDot(active: Boolean, modifier: Modifier = Modifier) {
@@ -327,30 +274,6 @@ internal fun sessionWindowEntryTitle(
         ?: window.name?.trim()?.takeIf { it.isNotEmpty() }
     val base = "$sessionName $suffix"
     return if (hint == null) base else "$base $hint"
-}
-
-// docs/design-system.md: the watched pill is a dense row annotation, so its
-// sub-ladder radius and caption size stay named while this screen is migrated.
-private val WatchedPinRadius = 6.dp
-private val WatchedPinFontSize = 10.sp
-
-@Composable
-internal fun WatchedPin() {
-    Box(
-        modifier = Modifier
-            .background(
-                color = PocketShellColors.Purple.copy(alpha = 0.12f),
-                shape = RoundedCornerShape(WatchedPinRadius),
-            )
-            .padding(horizontal = 6.dp, vertical = 2.dp),
-    ) {
-        Text(
-            text = "Watched",
-            color = PocketShellColors.Purple,
-            fontSize = WatchedPinFontSize,
-            fontWeight = FontWeight.SemiBold,
-        )
-    }
 }
 
 internal fun SessionAgentKind.isAgent(): Boolean = when (this) {

--- a/app/src/main/java/com/pocketshell/app/projects/WatchedFoldersViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/WatchedFoldersViewModel.kt
@@ -327,14 +327,6 @@ class WatchedFoldersViewModel @Inject constructor(
             }.getOrThrow()
         }
 
-    /**
-     * Test seam — drive [runDiscover] without going through the
-     * Flow + view-model state machine. Internal so test code in the
-     * same package can call it.
-     */
-    internal suspend fun parseDiscoverForTest(stdout: String): List<DiscoveredFolder> =
-        parseDiscoverOutput(stdout)
-
     data class SshCredentials(
         val hostname: String,
         val port: Int,

--- a/app/src/main/java/com/pocketshell/app/session/AgentConversationRepository.kt
+++ b/app/src/main/java/com/pocketshell/app/session/AgentConversationRepository.kt
@@ -644,9 +644,6 @@ public class AgentConversationRepository internal constructor(
         return RecordedAgentSourceOption(source = value, generationScoped = false)
     }
 
-    internal fun recordedAgentSourceFromOption(raw: String?, generation: String? = null): String? =
-        recordedAgentSourceOptionFromRaw(raw, generation).source
-
     /**
      * Epic #821 slice #3 (#825): map a raw `@ps_agent_kind` option value to an
      * [AgentKind]. The launch wrapper writes the lowercase engine token

--- a/app/src/main/java/com/pocketshell/app/sessions/service/SessionServiceController.kt
+++ b/app/src/main/java/com/pocketshell/app/sessions/service/SessionServiceController.kt
@@ -205,17 +205,6 @@ class SessionServiceController @Inject constructor(
         }
     }
 
-    @VisibleForTesting
-    internal fun stopObservingForTest() {
-        observeJob?.cancel()
-        observeJob = null
-        holdStoppedByUser = false
-        graceDisconnectAtWallClockMillis.value = null
-        appForegrounded.value = true
-        portForwardActive.value = false
-        _snapshot.value = SessionConnectionSnapshot.Empty
-    }
-
     private data class EffectiveInputs(
         val rawSnapshot: SessionConnectionSnapshot,
         val foreground: Boolean,

--- a/app/src/main/java/com/pocketshell/app/tmux/StaleSessionPromptController.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/StaleSessionPromptController.kt
@@ -160,16 +160,6 @@ class StaleSessionPromptController internal constructor(
         )
     }
 
-    /**
-     * Test-only injection of a stale session, bypassing the signal subscription,
-     * for JVM tests that assert `MainActivity`'s dialog wiring off the [prompt]
-     * state without a live [SessionLifecycleSignals].
-     */
-    @androidx.annotation.VisibleForTesting
-    internal fun offerForTest(stale: StaleSession) {
-        _prompt.value = stale
-    }
-
     private companion object {
         /**
          * Fallback create directory for a gone session with no known folder — the

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionRuntimeCache.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionRuntimeCache.kt
@@ -115,13 +115,6 @@ public class TmuxSessionRuntimeCache @Inject constructor() {
 
     internal fun size(): Int = synchronized(this) { runtimes.size }
 
-    internal fun hasLiveRuntime(): Boolean = synchronized(this) {
-        runtimes.values.any { entry ->
-            !entry.runtime.client.disconnected.value &&
-                entry.runtime.session?.isConnected != false
-        }
-    }
-
     internal fun diagnosticSnapshot(): TmuxRuntimeCacheDiagnostics = synchronized(this) {
         val values = runtimes.values.map { it.runtime }
         TmuxRuntimeCacheDiagnostics(

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionSurfacePlaceholders.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionSurfacePlaceholders.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -26,19 +25,6 @@ import com.pocketshell.uikit.components.PocketShellButton
 import com.pocketshell.uikit.components.SpinnerSize
 import com.pocketshell.uikit.theme.PocketShellColors
 import com.pocketshell.uikit.theme.PocketShellShapes
-
-@Composable
-private fun StatusLine(text: String) {
-    Text(
-        text = text,
-        color = PocketShellColors.TextSecondary,
-        style = MaterialTheme.typography.labelSmall,
-        modifier = Modifier
-            .fillMaxWidth()
-            .background(color = PocketShellColors.Surface)
-            .padding(horizontal = 12.dp, vertical = 6.dp),
-    )
-}
 
 /**
  * Issue #778: lightweight Conversation-tab placeholder shown when the user has

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionTopChrome.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionTopChrome.kt
@@ -146,7 +146,7 @@ private fun TabsRowWithPulse(
  *
  * The host segment is intentionally not surfaced - the host name is
  * already visible on the host list, the pre-session status line, and on
- * [StatusLine]/[FailedConnectionRow] when not connected.
+ * [FailedConnectionRow] when not connected.
  */
 @Composable
 internal fun ConsolidatedTopChrome(

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -1737,19 +1737,6 @@ public class TmuxSessionViewModel @Inject constructor(
 
     private val staleRenderSparseWakeBaselines = StaleRenderSparseWakeBaselines()
 
-    /**
-     * Issue #1166 test seam: fire the stale-render watchdog wake directly, so a
-     * JVM test can assert that a backed-off watchdog snaps to the hot cadence on a
-     * fresh `%output` wake WITHOUT standing up the real `-CC` output stream. The
-     * production wake is fired from [recordVisiblePaneOutput] on every active-pane
-     * output chunk (see [recordPaneOutputActivityForTest], which drives that real
-     * path end-to-end).
-     */
-    @androidx.annotation.VisibleForTesting
-    internal fun signalStaleRenderWatchdogWakeForTest() {
-        staleRenderWatchdogWake.trySend(Unit)
-    }
-
     // Issue #1166: a test override for [PowerManager.isInteractive] (screen-on).
     // Null → read the real PowerManager (or default on when no context). A JVM
     // test drives the foreground/screen gate deterministically without an AVD.
@@ -13102,18 +13089,6 @@ public class TmuxSessionViewModel @Inject constructor(
             return true
         }
         return shouldDeferAgentDowngrade(paneId)
-    }
-
-    /**
-     * Issue #819 (A2): true when a REMEMBERED-agent resolving placeholder is
-     * currently up for [paneId] — the #495 reattach seed, now detection-less,
-     * holding "Loading conversation…" while live `detectRecordedSessionForPane`
-     * re-anchors the route-true source. False once a real detection lands (the
-     * flag is cleared) or the row is gone.
-     */
-    private fun isRememberedAgentPlaceholderUp(paneId: String): Boolean {
-        val row = _agentConversations.value[paneId] ?: return false
-        return row.rememberedAgentPlaceholder && row.detection == null
     }
 
     /**


### PR DESCRIPTION
Test-first dead-code removal from the #684 audit (spike: https://github.com/alexeygrigorev/pocketshell/issues/684#issuecomment-4930946059). All 13 symbols verified zero-reference (production + test); the green full compile (incl. androidTest) is the deadness proof.

## Removed (~214 deletions, 12 files)
- **Dead `@Composable` chrome**: `CompactTreeIconButton`, `WatchedPin`, `ChecklistCardsSheet`, `StreamingCursor`, `StatusLine`.
- **Orphaned `…ForTest` seams (4)** + **dead private helpers (4)**: `isRememberedAgentPlaceholderUp`, `hasLiveRuntime`, `recordedAgentSourceFromOption`, `composerSendTooltipTestTag`.
- Cascade: kept `ChecklistCardsContent` (3 live androidTest callers), removed orphaned `SESSION_CHECKLIST_SHEET_TAG`. `StatusLine` orphaned import + KDoc link fixed.

## Verification (reviewer APPROVED)
- Reviewer re-ran `:app:compileDebugKotlin :app:compileDebugAndroidTestKotlin --rerun-tasks` from scratch → BUILD SUCCESSFUL (none of the 13 had a live caller), independently confirmed each symbol zero-reference, verified the cascade/KDoc nuances and the `…ForTest` vs `…ForTesting` trap, and confirmed no #1047/#1321 or #1353 code touched.
- Guards (`check-test-validity.sh`, `check-ci-journey-harness.sh`, `git diff --check`) pass.

Closes #1438