### PR TITLE
sessions: phase-aware FGS notification — kill negative countdown + stale 'connected' during reconnect (#1440)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/sessions/service/SessionConnectionService.kt
+++ b/app/src/main/java/com/pocketshell/app/sessions/service/SessionConnectionService.kt
@@ -190,6 +190,7 @@ class SessionConnectionService : Service() {
     internal fun buildNotification(
         snapshot: SessionConnectionSnapshot,
         contentTextOverride: String? = null,
+        nowMillis: Long = System.currentTimeMillis(),
     ): Notification {
         val contentIntent = PendingIntent.getActivity(
             this,
@@ -225,24 +226,38 @@ class SessionConnectionService : Service() {
         // notification ONCE and never schedules a per-second update / wakeup. A
         // contentTextOverride (the initial "Connecting session") never counts down.
         //
+        // Issue #1440: the count-down chronometer is used ONLY while the deadline is STRICTLY in
+        // the FUTURE (Phase.HOLDING_GRACE). Once grace has elapsed the system chronometer would
+        // otherwise count PAST ZERO into a NEGATIVE timer (the reported −06:51), and the frozen
+        // "Session connected / disconnecting in" copy would misrepresent a connection that has
+        // actually moved on to reconnecting. So a past/elapsed deadline (or the controller's
+        // explicit reconnecting flag) resolves to Phase.RECONNECTING: reconnecting copy, NO
+        // count-down. [SessionServiceController] re-posts at the deadline so this flip happens
+        // at the right moment instead of the notification drifting negative.
+        //
         // Issue #1202 + #1198 (hard-cut, D22): this session FGS is SUPPRESSED while a
         // port-forward is active (see [SessionServiceController.setPortForwardActive]) — the
         // ForwardingService FGS is the single owner of the port-forward notification. So this
         // notification NEVER renders the port-forward wording anymore; the #1159 Part 3
-        // "Port forwarding active" branch is deleted. This FGS only ever shows the plain
-        // "Session connected" hold with its bounded-grace count-down.
+        // "Port forwarding active" branch is deleted.
+        val phase = if (contentTextOverride == null) snapshot.phaseAt(nowMillis) else null
+
         val countdownDeadline =
-            if (contentTextOverride == null) {
+            if (phase == SessionConnectionSnapshot.Phase.HOLDING_GRACE) {
                 snapshot.disconnectAtWallClockMillis
             } else {
                 null
             }
 
-        val title = "Session connected"
+        val title = when (phase) {
+            SessionConnectionSnapshot.Phase.RECONNECTING -> "Reconnecting…"
+            else -> "Session connected"
+        }
 
         val detail = contentTextOverride
-            ?: when {
-                countdownDeadline != null -> "Holding $hostLabel — disconnecting in"
+            ?: when (phase) {
+                SessionConnectionSnapshot.Phase.HOLDING_GRACE -> "Holding $hostLabel — disconnecting in"
+                SessionConnectionSnapshot.Phase.RECONNECTING -> "Reconnecting to $hostLabel…"
                 else -> "Keeping $hostLabel connected in the background"
             }
 

--- a/app/src/main/java/com/pocketshell/app/sessions/service/SessionConnectionSnapshot.kt
+++ b/app/src/main/java/com/pocketshell/app/sessions/service/SessionConnectionSnapshot.kt
@@ -21,9 +21,49 @@ data class SessionConnectionSnapshot(
      * a count-down.
      */
     val portForwardActive: Boolean = false,
+    /**
+     * Issue #1440: the bounded grace window has elapsed and the connection is no longer a
+     * live in-grace hold — the app has moved on to reconnecting. Set by
+     * [SessionServiceController] when the deadline it scheduled on background fires while the
+     * session is still held. The foreground-service notification then reads as RECONNECTING
+     * (no "disconnecting in", no count-down) instead of freezing on the grace-hold copy with a
+     * count-down that would drift PAST ZERO into a negative timer (the reported −06:51 defect).
+     */
+    val reconnecting: Boolean = false,
 ) {
     val isHoldingConnection: Boolean
         get() = liveSessionCount > 0
+
+    /**
+     * Issue #1440: the lifecycle phase the notification must faithfully render, resolved
+     * against wall clock [nowMillis].
+     *
+     * A grace [disconnectAtWallClockMillis] is a LIVE count-down only while it is STRICTLY in
+     * the future. Once it is at/in the past the grace window is over — rendering it as a
+     * count-down chronometer would count PAST ZERO into a negative timer (the reported −06:51),
+     * so a past deadline resolves to [Phase.RECONNECTING], never a count-down. The explicit
+     * [reconnecting] flag forces the same phase even before the wall clock crosses the deadline
+     * (the controller's scheduled flip), so the display never depends on a single racy `now`
+     * comparison.
+     */
+    fun phaseAt(nowMillis: Long): Phase = when {
+        reconnecting -> Phase.RECONNECTING
+        disconnectAtWallClockMillis == null -> Phase.CONNECTED
+        disconnectAtWallClockMillis > nowMillis -> Phase.HOLDING_GRACE
+        else -> Phase.RECONNECTING
+    }
+
+    /** Issue #1440: the lifecycle phase the foreground-service notification renders. */
+    enum class Phase {
+        /** Live session held with no bounded-grace count-down (e.g. no deadline yet). */
+        CONNECTED,
+
+        /** Backgrounded within the bounded grace window — a live count-down to disconnect. */
+        HOLDING_GRACE,
+
+        /** Grace elapsed / connection dropped — the app is reconnecting. No count-down. */
+        RECONNECTING,
+    }
 
     companion object {
         val Empty = SessionConnectionSnapshot(
@@ -31,10 +71,15 @@ data class SessionConnectionSnapshot(
             primaryHostName = "",
             disconnectAtWallClockMillis = null,
             portForwardActive = false,
+            reconnecting = false,
         )
 
         fun fromEntries(entries: Collection<ActiveTmuxClients.Entry>): SessionConnectionSnapshot {
             val liveEntries = entries.filter { entry -> !entry.client.disconnected.value }
+            // Issue #1440: fromEntries NEVER stamps a bounded-grace deadline — the deadline is
+            // owned by [SessionServiceController] (set on background, cleared on foreground) and
+            // merged in there. A raw entry snapshot therefore never carries a PAST deadline that
+            // would keep the count-down branch selected once grace has elapsed.
             return SessionConnectionSnapshot(
                 liveSessionCount = liveEntries.size,
                 primaryHostName = liveEntries.firstOrNull()?.hostName.orEmpty(),

--- a/app/src/main/java/com/pocketshell/app/sessions/service/SessionServiceController.kt
+++ b/app/src/main/java/com/pocketshell/app/sessions/service/SessionServiceController.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -58,8 +59,17 @@ class SessionServiceController @Inject constructor(
     @VisibleForTesting
     internal var scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
 
+    /**
+     * Issue #1440: wall clock used to compute the scheduled grace-expiry re-post delay. Injected
+     * in tests so a virtual-time [kotlinx.coroutines.test.TestCoroutineScheduler] and the delay
+     * math agree (a real [System.currentTimeMillis] vs a virtual `delay` would never line up).
+     */
+    @VisibleForTesting
+    internal var nowMillis: () -> Long = { System.currentTimeMillis() }
+
     private val _snapshot = MutableStateFlow(SessionConnectionSnapshot.Empty)
     private var observeJob: Job? = null
+    private var deadlineFlipJob: Job? = null
     private var holdStoppedByUser: Boolean = false
 
     /**
@@ -78,6 +88,12 @@ class SessionServiceController @Inject constructor(
     // into every emitted snapshot so a client-liveness update never drops the count-down
     // mid-window. Null while a port-forward pins the connection (#1159 Part 3 — no teardown).
     private val graceDisconnectAtWallClockMillis = MutableStateFlow<Long?>(null)
+
+    // Issue #1440: flips true when the scheduled deadline fires while the session is still held —
+    // the bounded grace window has elapsed but a live client is still registered (reconnecting /
+    // hung), so the notification must re-post as RECONNECTING (no count-down) instead of freezing
+    // on the grace-hold copy with a count-down that drifts past zero into a negative timer.
+    private val graceExpired = MutableStateFlow(false)
 
     fun flowOfSnapshot(): StateFlow<SessionConnectionSnapshot> = _snapshot.asStateFlow()
 
@@ -107,11 +123,12 @@ class SessionServiceController @Inject constructor(
                 appForegrounded,
                 portForwardActive,
                 graceDisconnectAtWallClockMillis,
-            ) { rawSnapshot, foreground, pfActive, deadline ->
-                EffectiveInputs(rawSnapshot, foreground, pfActive, deadline)
+                graceExpired,
+            ) { rawSnapshot, foreground, pfActive, deadline, expired ->
+                EffectiveInputs(rawSnapshot, foreground, pfActive, deadline, expired)
             }
                 .distinctUntilChanged()
-                .collect { (rawSnapshot, foreground, pfActive, deadline) ->
+                .collect { (rawSnapshot, foreground, pfActive, deadline, expired) ->
                     if (!rawSnapshot.isHoldingConnection) {
                         holdStoppedByUser = false
                     }
@@ -137,7 +154,15 @@ class SessionServiceController @Inject constructor(
                         // held session notification always shows the normal bounded-grace
                         // count-down — never the port-forward wording (that is now owned solely
                         // by ForwardingService).
-                        rawSnapshot.copy(disconnectAtWallClockMillis = deadline)
+                        //
+                        // Issue #1440: [expired] flips true when the scheduled deadline fires while
+                        // the session is still held, so the notification re-posts as RECONNECTING
+                        // (no count-down) instead of freezing on the grace-hold copy with a
+                        // negative-drifting timer.
+                        rawSnapshot.copy(
+                            disconnectAtWallClockMillis = deadline,
+                            reconnecting = expired,
+                        )
                     }
                     val wasHolding = _snapshot.value.isHoldingConnection
                     _snapshot.value = snapshot
@@ -159,7 +184,10 @@ class SessionServiceController @Inject constructor(
      */
     fun onAppBackgrounded(disconnectAtWallClockMillis: Long) {
         graceDisconnectAtWallClockMillis.value = disconnectAtWallClockMillis
+        // Issue #1440: a fresh grace window — clear any prior expiry and (re)schedule the flip.
+        graceExpired.value = false
         appForegrounded.value = false
+        scheduleDeadlineFlip(disconnectAtWallClockMillis)
     }
 
     /**
@@ -167,8 +195,31 @@ class SessionServiceController @Inject constructor(
      * connection, so the FGS + its tray notification are stopped and the count-down cleared.
      */
     fun onAppForegrounded() {
+        cancelDeadlineFlip()
         graceDisconnectAtWallClockMillis.value = null
         appForegrounded.value = true
+    }
+
+    /**
+     * Issue #1440: schedule the re-post at the grace deadline. The system count-down chronometer
+     * is fire-and-forget (issue #1123 posts it once), so nothing re-posts when the deadline
+     * passes — the timer drifts past zero into a negative value and the copy stays frozen. This
+     * arms a wakeup at the deadline that flips [graceExpired] true, forcing a fresh emission the
+     * FGS re-posts as RECONNECTING (no count-down) at the right moment.
+     */
+    private fun scheduleDeadlineFlip(disconnectAtWallClockMillis: Long) {
+        deadlineFlipJob?.cancel()
+        deadlineFlipJob = scope.launch {
+            val wait = (disconnectAtWallClockMillis - nowMillis()).coerceAtLeast(0L)
+            delay(wait)
+            graceExpired.value = true
+        }
+    }
+
+    private fun cancelDeadlineFlip() {
+        deadlineFlipJob?.cancel()
+        deadlineFlipJob = null
+        graceExpired.value = false
     }
 
     /**
@@ -198,6 +249,7 @@ class SessionServiceController @Inject constructor(
         if (holdStoppedByUser) return
         if (!currentSnapshot().isHoldingConnection) return
         holdStoppedByUser = true
+        cancelDeadlineFlip()
         graceDisconnectAtWallClockMillis.value = null
         _snapshot.value = SessionConnectionSnapshot.Empty
         if (requestServiceStop) {
@@ -210,5 +262,6 @@ class SessionServiceController @Inject constructor(
         val foreground: Boolean,
         val portForwardActive: Boolean,
         val disconnectDeadline: Long?,
+        val graceExpired: Boolean,
     )
 }

--- a/app/src/test/java/com/pocketshell/app/sessions/service/SessionConnectionServiceTest.kt
+++ b/app/src/test/java/com/pocketshell/app/sessions/service/SessionConnectionServiceTest.kt
@@ -71,6 +71,128 @@ class SessionConnectionServiceTest {
     }
 
     @Test
+    fun `grace-expired past deadline shows reconnecting copy and NO count-down (issue 1440)`() {
+        // Issue #1440 — the reported frame: the maintainer returned to the app while it was
+        // RECONNECTING (expected), but the FGS notification was frozen on the grace-hold copy
+        // with a system count-down chronometer that had drifted PAST ZERO into a NEGATIVE timer
+        // (−06:51), still titled "Session connected" / "disconnecting in". Reproduce it: a
+        // holding snapshot whose bounded-grace deadline is now ~6:51 in the PAST.
+        val deadline = 1_000_000L
+        val now = deadline + (6 * 60_000L + 51_000L) // 06:51 past the deadline — the −06:51 frame
+        val notification = buildServiceNotification(
+            SessionConnectionSnapshot(
+                liveSessionCount = 1,
+                primaryHostName = "alpha",
+                disconnectAtWallClockMillis = deadline,
+            ),
+            nowMillis = now,
+        )
+
+        // No count-down chronometer at all — the system must not render a negative timer.
+        assertFalse(
+            "an elapsed grace deadline must NOT render a count-down chronometer (it would go " +
+                "negative — the reported −06:51)",
+            notification.extras.getBoolean(Notification.EXTRA_SHOW_CHRONOMETER),
+        )
+        assertFalse(
+            notification.extras.getBoolean(Notification.EXTRA_CHRONOMETER_COUNT_DOWN),
+        )
+        // Copy tracks the lifecycle phase: reconnecting, not the frozen grace-hold.
+        assertEquals(
+            "Reconnecting…",
+            notification.extras.getCharSequence("android.title")?.toString(),
+        )
+        val body = notification.extras.getCharSequence("android.text")?.toString().orEmpty()
+        assertFalse(
+            "an elapsed deadline must NOT keep the frozen 'disconnecting in' grace-hold copy: '$body'",
+            body.contains("disconnecting in"),
+        )
+        assertTrue(
+            "reconnecting body must read as reconnecting: '$body'",
+            body.contains("Reconnecting to alpha"),
+        )
+    }
+
+    @Test
+    fun `explicit reconnecting flag shows reconnecting copy even before the deadline elapses (issue 1440)`() {
+        // Class coverage (G2): the controller flips the reconnecting flag at the scheduled
+        // deadline. Even if the wall-clock `when` anchor were still nominally in the future, the
+        // explicit flag forces RECONNECTING — the display never depends on a single racy `now`.
+        val deadline = 5_000_000L
+        val now = deadline - 30_000L // still 30s before the anchor
+        val notification = buildServiceNotification(
+            SessionConnectionSnapshot(
+                liveSessionCount = 1,
+                primaryHostName = "alpha",
+                disconnectAtWallClockMillis = deadline,
+                reconnecting = true,
+            ),
+            nowMillis = now,
+        )
+
+        assertFalse(
+            "reconnecting must never render a count-down chronometer",
+            notification.extras.getBoolean(Notification.EXTRA_SHOW_CHRONOMETER),
+        )
+        assertEquals(
+            "Reconnecting…",
+            notification.extras.getCharSequence("android.title")?.toString(),
+        )
+        val body = notification.extras.getCharSequence("android.text")?.toString().orEmpty()
+        assertFalse("no grace-hold copy while reconnecting: '$body'", body.contains("disconnecting in"))
+    }
+
+    @Test
+    fun `holding within grace with a future deadline still shows the live count-down (no 1123 regression)`() {
+        // Regression guard for #1123: a STRICTLY FUTURE deadline is a live count-down.
+        val deadline = 2_000_000L
+        val now = deadline - 90_000L // 90s before the deadline — comfortably in grace
+        val notification = buildServiceNotification(
+            SessionConnectionSnapshot(
+                liveSessionCount = 1,
+                primaryHostName = "alpha",
+                disconnectAtWallClockMillis = deadline,
+            ),
+            nowMillis = now,
+        )
+
+        assertTrue(
+            "an in-grace future deadline must still render the count-down chronometer",
+            notification.extras.getBoolean(Notification.EXTRA_SHOW_CHRONOMETER),
+        )
+        assertTrue(notification.extras.getBoolean(Notification.EXTRA_CHRONOMETER_COUNT_DOWN))
+        assertEquals(deadline, notification.`when`)
+        assertEquals(
+            "Session connected",
+            notification.extras.getCharSequence("android.title")?.toString(),
+        )
+        val body = notification.extras.getCharSequence("android.text")?.toString().orEmpty()
+        assertTrue("in-grace body counts down: '$body'", body.contains("disconnecting in"))
+    }
+
+    @Test
+    fun `connected with no deadline shows the plain background hold and NO count-down (issue 1440 phase)`() {
+        // Class coverage (G2): the null-deadline / missing-data phase.
+        val notification = buildServiceNotification(
+            SessionConnectionSnapshot(liveSessionCount = 1, primaryHostName = "alpha"),
+            nowMillis = 5_000_000L,
+        )
+
+        assertFalse(
+            notification.extras.getBoolean(Notification.EXTRA_SHOW_CHRONOMETER),
+        )
+        assertEquals(
+            "Session connected",
+            notification.extras.getCharSequence("android.title")?.toString(),
+        )
+        val body = notification.extras.getCharSequence("android.text")?.toString().orEmpty()
+        assertTrue(
+            "no-deadline body reads as a plain background hold: '$body'",
+            body.contains("Keeping alpha connected in the background"),
+        )
+    }
+
+    @Test
     fun `foreground notification has no count-down chronometer`() {
         val notification = buildServiceNotification(
             SessionConnectionSnapshot(liveSessionCount = 1, primaryHostName = "alpha"),
@@ -167,8 +289,11 @@ class SessionConnectionServiceTest {
         )
     }
 
-    private fun buildServiceNotification(snapshot: SessionConnectionSnapshot): Notification {
+    private fun buildServiceNotification(
+        snapshot: SessionConnectionSnapshot,
+        nowMillis: Long = System.currentTimeMillis(),
+    ): Notification {
         val service = Robolectric.buildService(SessionConnectionService::class.java).get()
-        return service.buildNotification(snapshot)
+        return service.buildNotification(snapshot, nowMillis = nowMillis)
     }
 }

--- a/app/src/test/java/com/pocketshell/app/sessions/service/SessionServiceControllerTest.kt
+++ b/app/src/test/java/com/pocketshell/app/sessions/service/SessionServiceControllerTest.kt
@@ -213,6 +213,74 @@ class SessionServiceControllerTest {
     }
 
     @Test
+    fun `deadline elapsing while still backgrounded flips the snapshot to reconnecting (issue 1440)`() = runTest {
+        // Issue #1440 (scope 3 + 4): the system count-down chronometer is fire-and-forget (#1123
+        // posts it once). When the grace deadline passes while a live client is STILL registered
+        // (reconnecting / hung), nothing re-posts — so the timer drifts past zero into a negative
+        // value and the copy stays frozen on the grace-hold. The controller must arm a wakeup at
+        // the deadline that re-emits a RECONNECTING snapshot (no live count-down deadline).
+        val activeClients = ActiveTmuxClients()
+        val controller = controller(activeClients, testScheduler)
+
+        controller.observeActiveSessions()
+        runCurrent()
+        registerLive(activeClients, "alpha")
+        val deadline = 5_000L
+        controller.onAppBackgrounded(disconnectAtWallClockMillis = deadline)
+        runCurrent()
+
+        // Within grace: a live count-down, NOT reconnecting.
+        val holding = controller.flowOfSnapshot().value
+        assertTrue(holding.isHoldingConnection)
+        assertFalse("within grace the snapshot must not be reconnecting", holding.reconnecting)
+        assertEquals(
+            SessionConnectionSnapshot.Phase.HOLDING_GRACE,
+            holding.phaseAt(testScheduler.currentTime),
+        )
+
+        // The deadline elapses while the session is still held → re-post as reconnecting.
+        testScheduler.advanceTimeBy(deadline + 1)
+        runCurrent()
+
+        val expired = controller.flowOfSnapshot().value
+        assertTrue("the session is still held while reconnecting", expired.isHoldingConnection)
+        assertTrue(
+            "an elapsed grace deadline with a live client must flip the snapshot to reconnecting",
+            expired.reconnecting,
+        )
+        assertEquals(
+            SessionConnectionSnapshot.Phase.RECONNECTING,
+            expired.phaseAt(testScheduler.currentTime),
+        )
+    }
+
+    @Test
+    fun `returning to the foreground before the deadline cancels the reconnecting flip (issue 1440)`() = runTest {
+        // Class coverage (G2): if the app returns to the foreground within grace, the scheduled
+        // deadline flip must be cancelled — the FGS stops (Activity holds the connection) and no
+        // stale reconnecting notification is ever posted.
+        val activeClients = ActiveTmuxClients()
+        val controller = controller(activeClients, testScheduler)
+
+        controller.observeActiveSessions()
+        runCurrent()
+        registerLive(activeClients, "alpha")
+        controller.onAppBackgrounded(disconnectAtWallClockMillis = 5_000L)
+        runCurrent()
+        drainStartedServices()
+
+        controller.onAppForegrounded()
+        runCurrent()
+        // Advance well past the original deadline — the cancelled flip must not fire.
+        testScheduler.advanceTimeBy(10_000L)
+        runCurrent()
+
+        val snapshot = controller.flowOfSnapshot().value
+        assertFalse("foreground handoff stops the hold", snapshot.isHoldingConnection)
+        assertFalse("a cancelled deadline flip must not leave a reconnecting snapshot", snapshot.reconnecting)
+    }
+
+    @Test
     fun `disconnecting the last live tmux client stops the backgrounded service`() = runTest {
         val activeClients = ActiveTmuxClients()
         val client = FakeTmuxClient()
@@ -347,6 +415,9 @@ class SessionServiceControllerTest {
     ): SessionServiceController {
         return SessionServiceController(context, activeClients).apply {
             scope = CoroutineScope(SupervisorJob() + StandardTestDispatcher(scheduler))
+            // Issue #1440: tie the deadline-flip clock to the virtual scheduler so the scheduled
+            // `delay(deadline - now)` and the deadline value agree under virtual time.
+            nowMillis = { scheduler.currentTime }
         }
     }
 


### PR DESCRIPTION
Fixes the maintainer-reported session foreground-service notification bug (2026-07-10): a negative count-down (`−06:51`) plus frozen "Session connected / disconnecting in" copy while the app was actually reconnecting.

## Root cause
Notification posted once with a system count-down chronometer on the grace deadline, never re-posted or phase-guarded — so past the deadline the chronometer ran negative and the copy stayed stale.

## Fix (3 layers)
- `SessionConnectionSnapshot.phaseAt(now)` — past/elapsed deadline resolves to `RECONNECTING`; count-down only while strictly future.
- `SessionConnectionService` — chronometer only for `HOLDING_GRACE`; `RECONNECTING` shows "Reconnecting…", no chronometer, no "disconnecting in".
- `SessionServiceController` — deadline wakeup flips snapshot to reconnecting + re-posts; cancelled on foreground/Stop.

## Verification
Reproduce-first red→green on the exact reported frame (asserts `EXTRA_SHOW_CHRONOMETER=false` on the built `Notification`); per-phase class coverage (connected / holding-grace-future / grace-expired / reconnecting / null-deadline); future-deadline count-down preserved (no #1123 regression). 22 tests, 0 skipped. Reviewer drove red→green independently and APPROVED.

Closes #1440