### PR TITLE
usage: absolute reset time + cancel-on-clear for quota notification (#1441)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/usage/UsageThresholdNotificationE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/usage/UsageThresholdNotificationE2eTest.kt
@@ -258,7 +258,6 @@ class UsageThresholdNotificationE2eTest {
         context = context,
         settingsRepository = SettingsRepository(context),
         stateStore = store,
-        now = { Instant.parse("2026-06-08T10:00:00Z") },
         zoneId = { ZoneId.of("UTC") },
         // default poster -> UsageNotifications.show(context, event) -> real post
     )
@@ -290,7 +289,6 @@ class UsageThresholdNotificationE2eTest {
             state = UsageThresholdState.Exceeded,
             warnPercent = SettingsRepository(context)
                 .settings.value.usageWarnThresholdPercent.toDouble(),
-            now = Instant.parse("2026-06-08T10:00:00Z"),
             zoneId = ZoneId.of("UTC"),
             hostName = "agent-box",
             hostId = HOST_ID,

--- a/app/src/main/java/com/pocketshell/app/usage/UsageNotifications.kt
+++ b/app/src/main/java/com/pocketshell/app/usage/UsageNotifications.kt
@@ -15,7 +15,6 @@ import com.pocketshell.app.R
 import com.pocketshell.app.settings.SettingsRepository
 import com.pocketshell.core.usage.UsageProviderRecord
 import com.pocketshell.core.usage.UsageThresholdState
-import java.time.Instant
 import java.time.ZoneId
 
 public interface UsageNotifier {
@@ -30,10 +29,12 @@ public class DefaultUsageNotifier(
     context: Context,
     private val settingsRepository: SettingsRepository,
     private val stateStore: UsageNotificationStateStore,
-    private val now: () -> Instant = { Instant.now() },
     private val zoneId: () -> ZoneId = { ZoneId.systemDefault() },
     private val poster: (UsageNotificationEvent) -> Unit = { event ->
         UsageNotifications.show(context.applicationContext, event)
+    },
+    private val canceller: (Int) -> Unit = { id ->
+        UsageNotifications.cancel(context.applicationContext, id)
     },
 ) : UsageNotifier {
 
@@ -58,7 +59,6 @@ public class DefaultUsageNotifier(
                             record = record,
                             state = state,
                             warnPercent = warnPercent,
-                            now = now(),
                             zoneId = zoneId(),
                             hostName = snapshot.hostName,
                             hostId = snapshot.hostId,
@@ -67,6 +67,26 @@ public class DefaultUsageNotifier(
                     )
                 }
             }
+        }
+        // Issue #1441: a fire-and-forget usage warning was never cancelled, so
+        // when the quota reset (or usage dropped below threshold) the stale
+        // "quota exceeded · resets …" notification lingered in the tray with a
+        // now-false reset time. Any previously-notified crossing that is no
+        // longer in `current` has cleared — cancel its tray notification so it
+        // is dismissed, not left lying. Pruning it from the persisted set below
+        // also re-arms the crossing for a future genuine breach.
+        //
+        // A severity change on the SAME host+provider (e.g. Approaching ->
+        // Exceeded) re-uses the SAME notificationId, and the new crossing has
+        // already been re-posted above, so guard against cancelling that
+        // freshly-posted notification: only cancel ids that no current crossing
+        // still owns.
+        val activeIds = current.mapTo(mutableSetOf()) {
+            usageNotificationId(it.hostId, it.provider)
+        }
+        (alreadyNotified - current).forEach { cleared ->
+            val id = usageNotificationId(cleared.hostId, cleared.provider)
+            if (id !in activeIds) canceller(id)
         }
         stateStore.setNotifiedKeys(current)
     }
@@ -83,7 +103,6 @@ internal fun usageNotificationEvent(
     record: UsageProviderRecord,
     state: UsageThresholdState,
     warnPercent: Double,
-    now: Instant = Instant.now(),
     zoneId: ZoneId = ZoneId.systemDefault(),
     hostName: String? = null,
     hostId: Long? = null,
@@ -100,9 +119,13 @@ internal fun usageNotificationEvent(
         UsageThresholdState.Ok ->
             "${record.displayName} usage"
     }
-    val resetText = record.mostConstrainedWindow?.resetAt?.let { reset ->
-        "resets ${formatResetRelative(now, reset, zoneId)}"
-    }
+    // Issue #1441: show an ABSOLUTE reset time, not a relative "resets in Xh Ym"
+    // computed once against `now`. A notification is fire-and-forget — a value
+    // baked in at post time must stay correct as wall-clock time passes, and a
+    // relative countdown drifts wrong (reads "resets in 2h" long after the reset
+    // already happened). The absolute local time never goes stale.
+    val resetText = formatResetAbsolute(record.mostConstrainedWindow?.resetAt, zoneId)
+        ?.let { "resets $it" }
     val hostText = hostName?.trim()?.takeIf { it.isNotEmpty() }
     val stateText = when (state) {
         UsageThresholdState.Approaching -> "Approaching limit"
@@ -115,10 +138,20 @@ internal fun usageNotificationEvent(
     return UsageNotificationEvent(
         title = title,
         text = body,
-        notificationId = 27_000 + "${record.provider.lowercase()}:${hostId ?: 0L}".hashCode().and(0x0fff),
+        notificationId = usageNotificationId(hostId ?: 0L, record.provider),
         key = key,
     )
 }
+
+/**
+ * Stable tray notification id for a host+provider usage warning. Derived only
+ * from host id + provider so the same slot is reused as severity climbs (the
+ * re-post replaces the prior card) and so a cleared crossing can be cancelled
+ * from its persisted [UsageNotificationKey] alone (issue #1441). The provider
+ * is lowercased to match [usageNotificationKey], which stores it lowercased.
+ */
+internal fun usageNotificationId(hostId: Long, provider: String): Int =
+    27_000 + "${provider.lowercase()}:$hostId".hashCode().and(0x0fff)
 
 private fun usageNotificationKey(
     hostId: Long,
@@ -172,6 +205,18 @@ internal object UsageNotifications {
 
         appContext.getSystemService(NotificationManager::class.java)
             .notify(event.notificationId, notification)
+    }
+
+    /**
+     * Dismiss a previously-posted usage warning (issue #1441). Called when a
+     * notified crossing clears (quota reset / usage dropped below threshold) so
+     * a fire-and-forget warning with a now-stale reset time does not linger in
+     * the tray.
+     */
+    fun cancel(context: Context, notificationId: Int) {
+        context.applicationContext
+            .getSystemService(NotificationManager::class.java)
+            ?.cancel(notificationId)
     }
 
     private fun usagePendingIntent(context: Context): PendingIntent {

--- a/app/src/test/java/com/pocketshell/app/usage/UsageNotificationsTest.kt
+++ b/app/src/test/java/com/pocketshell/app/usage/UsageNotificationsTest.kt
@@ -15,6 +15,7 @@ import java.time.Instant
 import java.time.ZoneId
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -68,12 +69,11 @@ class UsageNotificationsTest {
             ),
             state = UsageThresholdState.Approaching,
             warnPercent = 80.0,
-            now = Instant.parse("2026-06-08T10:00:00Z"),
             zoneId = ZoneId.of("UTC"),
         )
 
         assertEquals("Codex usage: 86% used", event.title)
-        assertEquals("Approaching limit · resets in 2h · Tap to open Usage.", event.text)
+        assertEquals("Approaching limit · resets Jun 8, 12:00 · Tap to open Usage.", event.text)
         assertFalse(event.title.contains("blocked", ignoreCase = true))
         assertFalse(event.text.contains("blocked", ignoreCase = true))
     }
@@ -126,7 +126,6 @@ class UsageNotificationsTest {
             context = context,
             settingsRepository = SettingsRepository(context),
             stateStore = FakeStateStore(),
-            now = { Instant.parse("2026-06-08T10:00:00Z") },
             zoneId = { ZoneId.of("UTC") },
             poster = { events += it },
         )
@@ -180,7 +179,6 @@ class UsageNotificationsTest {
             context = context,
             settingsRepository = SettingsRepository(context),
             stateStore = FakeStateStore(),
-            now = { Instant.parse("2026-06-08T10:00:00Z") },
             zoneId = { ZoneId.of("UTC") },
             poster = { events += it },
         )
@@ -202,7 +200,6 @@ class UsageNotificationsTest {
             context = context,
             settingsRepository = SettingsRepository(context),
             stateStore = FakeStateStore(),
-            now = { Instant.parse("2026-06-08T10:00:00Z") },
             zoneId = { ZoneId.of("UTC") },
             poster = { events += it },
         )
@@ -238,10 +235,147 @@ class UsageNotificationsTest {
         )
         assertEquals(
             listOf(
-                "agent-box · Approaching limit · resets in 5h · Tap to open Usage.",
+                "agent-box · Approaching limit · resets Jun 8, 15:00 · Tap to open Usage.",
             ),
             events.map { it.text },
         )
+    }
+
+    @Test
+    fun notificationUsesAbsoluteResetTimeNotDriftingRelative() {
+        // Issue #1441 (drift): the fire-and-forget notification must bake an
+        // ABSOLUTE reset time, not a "resets in Xh Ym" relative countdown that
+        // goes stale as wall-clock time passes (reads "resets in 2h" hours after
+        // the reset already happened).
+        val event = usageNotificationEvent(
+            record = UsageProviderRecord(
+                provider = "codex",
+                status = UsageStatus.Ok,
+                rawStatus = "ok",
+                windows = listOf(
+                    UsageWindow(
+                        "7d",
+                        86.0,
+                        100.0,
+                        "percent",
+                        Instant.parse("2026-06-08T12:00:00Z"),
+                    ),
+                ),
+            ),
+            state = UsageThresholdState.Approaching,
+            warnPercent = 80.0,
+            zoneId = ZoneId.of("UTC"),
+        )
+
+        assertFalse(
+            "reset line must not bake a drifting relative time: ${event.text}",
+            event.text.contains("resets in"),
+        )
+        assertTrue(
+            "reset line must show an absolute (non-drifting) time: ${event.text}",
+            event.text.contains("resets Jun 8, 12:00"),
+        )
+    }
+
+    @Test
+    fun resetClearsCrossingCancelsStaleNotificationAndReArmsLedger() {
+        // Issue #1441 (stale lingering): a warning is posted, then the quota
+        // RESETS (record no longer warrants a warning). The stale tray
+        // notification must be cancelled — not left with a now-false "resets …"
+        // line — and the persisted ledger entry cleared so a later breach
+        // re-notifies. On base (no cancel path) the notification lingers.
+        val store = FakeStateStore()
+        val cancelled = mutableListOf<Int>()
+        val events = mutableListOf<UsageNotificationEvent>()
+
+        // T0: breach -> posts, records the crossing.
+        notifier(store, cancelled) { events += it }
+            .onSnapshotsChanged(mapOf(1L to exceededSnapshot()))
+        assertEquals(1, events.size)
+        val postedId = events.single().notificationId
+        assertEquals(setOf(events.single().key), store.notifiedKeys())
+
+        // T0+: quota reset -> provider back below threshold (no warning).
+        notifier(store, cancelled) { events += it }
+            .onSnapshotsChanged(mapOf(1L to snapshot(percent = 12.0)))
+
+        // The stale notification is cancelled and the ledger re-armed.
+        assertEquals(listOf(postedId), cancelled)
+        assertEquals(emptySet<UsageNotificationKey>(), store.notifiedKeys())
+
+        // A later genuine breach re-notifies (ledger really cleared).
+        val reNotify = mutableListOf<UsageNotificationEvent>()
+        notifier(store, cancelled) { reNotify += it }
+            .onSnapshotsChanged(mapOf(1L to exceededSnapshot()))
+        assertEquals(listOf("Codex weekly quota exceeded"), reNotify.map { it.title })
+    }
+
+    @Test
+    fun crossingIntoHigherSeverityRePostsAndDoesNotCancelFreshNotification() {
+        // Class coverage: Approaching -> Exceeded on the SAME host+provider
+        // re-posts the new severity and reuses the SAME notificationId. The
+        // cleared Approaching key must NOT cancel the freshly-posted Exceeded
+        // notification (same slot).
+        val store = FakeStateStore()
+        val cancelled = mutableListOf<Int>()
+        val events = mutableListOf<UsageNotificationEvent>()
+
+        notifier(store, cancelled) { events += it }
+            .onSnapshotsChanged(mapOf(1L to snapshot(percent = 80.0)))
+        notifier(store, cancelled) { events += it }
+            .onSnapshotsChanged(mapOf(1L to exceededSnapshot()))
+
+        assertEquals(
+            listOf("Codex usage: 80% used", "Codex weekly quota exceeded"),
+            events.map { it.title },
+        )
+        // Same slot reused; the re-post replaces it, nothing is cancelled.
+        assertEquals(events[0].notificationId, events[1].notificationId)
+        assertEquals(emptyList<Int>(), cancelled)
+    }
+
+    @Test
+    fun stillInSameWarningDoesNotRePostOrCancel() {
+        // Class coverage: an unchanged same-severity crossing across ticks must
+        // neither re-post (existing de-dupe) nor cancel the live notification.
+        val store = FakeStateStore()
+        val cancelled = mutableListOf<Int>()
+        val events = mutableListOf<UsageNotificationEvent>()
+
+        repeat(3) {
+            notifier(store, cancelled) { events += it }
+                .onSnapshotsChanged(mapOf(1L to exceededSnapshot()))
+        }
+
+        assertEquals(listOf("Codex weekly quota exceeded"), events.map { it.title })
+        assertEquals(emptyList<Int>(), cancelled)
+    }
+
+    @Test
+    fun clearingCrossingWithUnknownResetTimeStillCancels() {
+        // Class coverage (missing-data): a provider with NO reset_at still posts
+        // a warning (body omits the reset line), and clearing it must still
+        // cancel the stale notification — the cancel path must not depend on a
+        // reset time being present.
+        val store = FakeStateStore()
+        val cancelled = mutableListOf<Int>()
+        val events = mutableListOf<UsageNotificationEvent>()
+
+        // exceededSnapshot() has a null reset_at window.
+        notifier(store, cancelled) { events += it }
+            .onSnapshotsChanged(mapOf(1L to exceededSnapshot()))
+        assertEquals(1, events.size)
+        assertFalse(
+            "no reset line when reset_at is unknown: ${events.single().text}",
+            events.single().text.contains("resets"),
+        )
+        val postedId = events.single().notificationId
+
+        notifier(store, cancelled) { events += it }
+            .onSnapshotsChanged(mapOf(1L to snapshot(percent = 5.0)))
+
+        assertEquals(listOf(postedId), cancelled)
+        assertEquals(emptySet<UsageNotificationKey>(), store.notifiedKeys())
     }
 
     @Test
@@ -348,14 +482,15 @@ class UsageNotificationsTest {
 
     private fun notifier(
         store: UsageNotificationStateStore,
+        cancelled: MutableList<Int> = mutableListOf(),
         poster: (UsageNotificationEvent) -> Unit,
     ): DefaultUsageNotifier = DefaultUsageNotifier(
         context = context,
         settingsRepository = SettingsRepository(context),
         stateStore = store,
-        now = { Instant.parse("2026-06-08T10:00:00Z") },
         zoneId = { ZoneId.of("UTC") },
         poster = poster,
+        canceller = { cancelled += it },
     )
 
     private fun exceededSnapshot(): UsageSnapshot.Records = UsageSnapshot.Records(


### PR DESCRIPTION
Sibling of #1440 (same fire-and-forget notification-staleness class), surfaced by the #1440 sibling-surface audit.

## Bug
The quota-warning notification baked a computed-once `resets in Xh Ym` relative time that drifts wrong as time passes, and was never cancelled when the crossing cleared — so a stale "quota exceeded · resets in 2h" lingered with a false time after the quota reset.

## Fix
- Absolute (non-drifting) reset time via `formatResetAbsolute`; dropped the dead `now` param (D22 hard-cut).
- Added `UsageNotifications.cancel` + cancel-on-clear pass that dismisses a cleared crossing and re-arms the ledger, guarded so an Approaching→Exceeded upgrade isn't dismissed.

## Verification
Reproduce-first red→green on both defects; class coverage (reset-clears / crossed-severity / no-duplicate / missing-reset-time). Reviewer drove red→green + a mutation test proving the cancel guard is non-vacuous. 16 tests, 0 skipped. JVM/Robolectric authoritative (no pixel dimension).

Closes #1441