### PR TITLE
cards (host): fire FCM notification for push note + every push verb (#859 Slice 2, #1446)

### DIFF
--- a/tools/pocketshell/src/pocketshell/cards.py
+++ b/tools/pocketshell/src/pocketshell/cards.py
@@ -572,6 +572,29 @@ def _require_session(explicit: Optional[str]) -> str:
     return session
 
 
+def _notify_card_pushed_best_effort(
+    session: str, card: dict[str, Any], *, card_paths: CardPaths
+) -> None:
+    """Fire a best-effort FCM push for a freshly upserted card (#859 Slice D/2).
+
+    The single notification path shared by EVERY card-creating ``push`` verb
+    (``checklist``, ``note``, and any future card type). Centralising it here is
+    the durable class fix for #1446: a new ``push <cardtype>`` verb that upserts
+    a card just calls this one helper, so it can't silently forget to notify the
+    phone the way ``push note`` originally did.
+
+    Fail-soft — the push deps are imported lazily so a host without them still
+    pushes the card, and any failure is swallowed so a card write never wedges
+    the CLI. De-dup + configuration guards live in :func:`notify_card_pushed`.
+    """
+    try:
+        from pocketshell.agent_card_push import notify_card_pushed
+
+        notify_card_pushed(session, card, card_paths=card_paths)
+    except Exception:
+        pass
+
+
 def register_push_card_commands(push_group: click.Group) -> None:
     """Register the typed-card verbs onto the existing ``push`` click group.
 
@@ -635,14 +658,8 @@ def register_push_card_commands(push_group: click.Group) -> None:
         card_paths = resolve_paths()
         path = upsert_card(target, card, paths=card_paths)
         # Slice D (#859): fire a best-effort FCM push so the phone surfaces a
-        # heads-up notification opening this session's card feed. Fail-soft —
-        # imported lazily so a host without the push deps still pushes the card.
-        try:
-            from pocketshell.agent_card_push import notify_card_pushed
-
-            notify_card_pushed(target, card, card_paths=card_paths)
-        except Exception:
-            pass
+        # heads-up notification opening this session's card feed.
+        _notify_card_pushed_best_effort(target, card, card_paths=card_paths)
         click.echo(
             f"checklist {card_id!r} ({len(parsed)} items) -> session {target!r} ({path})"
         )
@@ -652,6 +669,8 @@ def register_push_card_commands(push_group: click.Group) -> None:
     @click.option("--session", "session", default=None, help="Override the auto-detected tmux session.")
     def push_get(as_json: bool, session: Optional[str]) -> None:
         """Return the session's cards (human/YAML by default, --json for the app)."""
+        # No notify (#1446 audit): read-only query, upserts no card. The app is
+        # the caller here; there is nothing new to surface.
         target = _require_session(session)
         cards = read_cards(target, paths=resolve_paths())
         if as_json:
@@ -677,6 +696,7 @@ def register_push_card_commands(push_group: click.Group) -> None:
     @click.option("--session", "session", default=None, help="Override the auto-detected tmux session.")
     def push_status(card_id: Optional[str], as_json: bool, session: Optional[str]) -> None:
         """Report interaction state — which checklist items the human has ticked."""
+        # No notify (#1446 audit): read-only query, upserts no card.
         target = _require_session(session)
         cards = read_cards(target, paths=resolve_paths())
         if card_id is not None:
@@ -712,6 +732,9 @@ def register_push_card_commands(push_group: click.Group) -> None:
     @click.option("--session", "session", default=None, help="Override the auto-detected tmux session.")
     def push_check(card_id: str, item_id: str, done: bool, session: Optional[str]) -> None:
         """Set a checklist item's checked state (this is what the app's tick calls)."""
+        # No notify (#1446 audit): this is the APP writing back the human's tick,
+        # not an agent pushing a new card. Notifying would push the phone about
+        # its own action (and could loop). It mutates state, never upserts a card.
         target = _require_session(session)
         try:
             card = apply_interaction(
@@ -771,7 +794,13 @@ def register_push_card_commands(push_group: click.Group) -> None:
             title=title,
             build_kwargs={"text": body_text},
         )
-        path = upsert_card(target, card, paths=resolve_paths())
+        card_paths = resolve_paths()
+        path = upsert_card(target, card, paths=card_paths)
+        # #1446: a pushed note is a card the human must see, just like a
+        # checklist — fire the same best-effort FCM push so the phone surfaces a
+        # heads-up notification opening this session's card feed. (Slice D/#859
+        # shipped this only on `checklist`; `push note` was silently omitted.)
+        _notify_card_pushed_best_effort(target, card, card_paths=card_paths)
         click.echo(f"note {card_id!r} -> session {target!r} ({path})")
 
     @push_group.command("read")
@@ -780,6 +809,8 @@ def register_push_card_commands(push_group: click.Group) -> None:
     @click.option("--session", "session", default=None, help="Override the auto-detected tmux session.")
     def push_read(card_id: str, read: bool, session: Optional[str]) -> None:
         """Set a note's read state (this is what the app's "mark read" calls)."""
+        # No notify (#1446 audit): this is the APP writing back "human read it",
+        # not an agent pushing a new card. Same rationale as `push check`.
         target = _require_session(session)
         try:
             card = apply_interaction(

--- a/tools/pocketshell/tests/test_cards_push_notify.py
+++ b/tools/pocketshell/tests/test_cards_push_notify.py
@@ -1,0 +1,152 @@
+"""Regression tests: EVERY card-creating `push <type>` verb fires the FCM push.
+
+Issue #1446 (#859 Slice 2). `push checklist` fired ``notify_card_pushed`` but
+`push note` did NOT — so an agent that pushed a *note* produced no heads-up
+notification and the maintainer only saw it by opening the session. These tests
+are the durable class fix:
+
+- ``test_push_note_fires_notification`` reproduces the exact reported gap
+  (RED on base: not called; GREEN after the fix) and asserts the payload the
+  app's deep-link (``AgentCardPushPayload``) consumes is producible from the
+  pushed card.
+- ``test_every_card_push_verb_fires_notification_once`` is parametrized across
+  EVERY card-creating verb and asserts each notifies exactly once (no
+  double-notify). The companion coverage guard asserts the parametrize map
+  covers the whole card-type ``REGISTRY``, so a future new card type whose push
+  verb forgets the notify call is caught here rather than on the maintainer's
+  phone.
+
+The read/query/interaction verbs (``get``, ``status``, ``check``, ``read``) do
+NOT notify by design — see the ``#1446 audit`` comments on each in
+``pocketshell.cards`` — so they are intentionally excluded here.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from click.testing import CliRunner
+
+from pocketshell import agent_card_push as push_mod
+from pocketshell import cards as cards_mod
+from pocketshell.cli import cli
+
+
+def _env(tmp_path: Path) -> dict[str, str]:
+    """CLI env pointing the card store at tmp_path with a deterministic session."""
+    return {
+        "POCKETSHELL_CARDS_DIR": str(tmp_path / "pocketshell" / "cards"),
+        "TMUX": "/tmp/fake-tmux,1,0",
+    }
+
+
+@pytest.fixture
+def notify_spy(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    """Spy replacing ``agent_card_push.notify_card_pushed``.
+
+    The push verbs import it lazily (``from pocketshell.agent_card_push import
+    notify_card_pushed``), so patching the module attribute intercepts the call
+    at invocation time. Records each call so we can assert count + arguments.
+    """
+    calls: list[dict[str, Any]] = []
+
+    def _spy(session: str, card: dict[str, Any], *, card_paths: Any, **kwargs: Any) -> None:
+        calls.append({"session": session, "card": card, "card_paths": card_paths})
+        return None
+
+    monkeypatch.setattr(push_mod, "notify_card_pushed", _spy)
+    return calls
+
+
+# --- the reported gap: `push note` must notify (RED on base, GREEN with fix) ---
+
+
+def test_push_note_fires_notification(
+    tmp_path: Path, notify_spy: list[dict[str, Any]]
+) -> None:
+    """`push note` fires notify_card_pushed exactly once with the note card.
+
+    RED on base (the omitted call) — GREEN after the fix. Also proves the pushed
+    card maps to the app's ``agent_card`` deep-link payload shape.
+    """
+    runner = CliRunner()
+    env = _env(tmp_path)
+
+    res = runner.invoke(
+        cli,
+        ["push", "note", "--title", "Heads up", "--text", "deploy done", "--session", "demo"],
+        env=env,
+    )
+    assert res.exit_code == 0, res.output
+
+    # Fired exactly once — no double-notify.
+    assert len(notify_spy) == 1, f"push note must notify exactly once, got {len(notify_spy)}"
+
+    call = notify_spy[0]
+    assert call["session"] == "demo"
+    card = call["card"]
+    assert card["type"] == "note"
+    assert card["id"] == cards_mod.DEFAULT_NOTE_ID
+    assert card["body"]["text"] == "deploy done"
+
+    # The payload the app deep-link consumes (AgentCardPushPayload contract) is
+    # producible from the pushed card via the SAME mapping the checklist path
+    # uses — no invented shape.
+    data = push_mod.card_to_data(call["session"], card, host="devbox")
+    assert data["type"] == push_mod.AGENT_CARD_PUSH_TYPE
+    assert data["session"] == "demo"
+    assert data["host"] == "devbox"
+    assert data["card_type"] == "note"
+    assert data["card_id"] == cards_mod.DEFAULT_NOTE_ID
+    assert data["title"] == "Heads up"
+    assert data["card_key"]  # de-dup identity present
+
+
+# --- class coverage: EVERY card-creating verb notifies exactly once -----------
+
+# Minimal invocation for each card-CREATING push verb, keyed by card type name.
+# A newly registered card type MUST add its verb here (the coverage guard below
+# asserts this map covers the whole REGISTRY), which forces the author to wire
+# up + prove the notify call for the new type.
+_CARD_PUSH_INVOCATIONS: dict[str, list[str]] = {
+    "checklist": ["push", "checklist", "--item", "alpha", "--session", "demo"],
+    "note": ["push", "note", "--text", "hello", "--session", "demo"],
+}
+
+
+def test_card_push_invocation_map_covers_every_registered_type() -> None:
+    """Future-proofing: the notify class-coverage map must cover every card type.
+
+    If someone registers a new card type but omits its push verb here, this
+    fails — a deliberate tripwire so the new verb's notify wiring is proven by
+    ``test_every_card_push_verb_fires_notification_once`` rather than silently
+    shipping un-notified (the exact #1446 gap).
+    """
+    assert set(_CARD_PUSH_INVOCATIONS) == set(cards_mod.REGISTRY), (
+        "card-type REGISTRY and the notify coverage map diverged: "
+        f"registry={sorted(cards_mod.REGISTRY)} map={sorted(_CARD_PUSH_INVOCATIONS)}. "
+        "A new card type's `push <type>` verb must be added here (and must notify)."
+    )
+
+
+@pytest.mark.parametrize("card_type,argv", sorted(_CARD_PUSH_INVOCATIONS.items()))
+def test_every_card_push_verb_fires_notification_once(
+    tmp_path: Path,
+    notify_spy: list[dict[str, Any]],
+    card_type: str,
+    argv: list[str],
+) -> None:
+    """Each card-creating push verb fires notify_card_pushed exactly once."""
+    runner = CliRunner()
+    env = _env(tmp_path)
+
+    res = runner.invoke(cli, argv, env=env)
+    assert res.exit_code == 0, res.output
+
+    assert len(notify_spy) == 1, (
+        f"`{' '.join(argv[:2])}` must notify exactly once, got {len(notify_spy)}"
+    )
+    assert notify_spy[0]["card"]["type"] == card_type
+    assert isinstance(notify_spy[0]["card_paths"], cards_mod.CardPaths)


### PR DESCRIPTION
Sibling-consistency fix from the #859 decomposition: `push note` never fired `notify_card_pushed` (only `push checklist` did), so a pushed note gave no phone notification.

## Fix (host-side Python only)
Shared `_notify_card_pushed_best_effort` helper; every card-creating push verb routes through it. `push note` now notifies with the same `AgentCardPushPayload` shape the app deep-link consumes. Non-notifying verbs (get/status/check/read) documented.

## Verification
Reproduce-first red→green (neutralized `push note` notify → `must notify exactly once, got 0`; fix → green). Parametrized class coverage across all push verbs + a tripwire test asserting the coverage map == card `REGISTRY` (verified to bite: dropping a verb fails the suite). Full suite 723 passed, 0 skipped. Reviewer drove red→green independently and APPROVED. (Local box has no PyPI so a fresh uv env can't resolve pinned deps — the CI `Python utility tests (pocketshell)` job is authoritative and runs the new file.)

Closes #1446