### PR TITLE
terminal: diagnostic pixel-black fingerprint, no heal (#1443)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/tmux/StaleRenderSparseWakeBaselines.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/StaleRenderSparseWakeBaselines.kt
@@ -1,5 +1,9 @@
 package com.pocketshell.app.tmux
 
+import android.os.SystemClock
+import com.pocketshell.app.diagnostics.DiagnosticEvents
+import com.pocketshell.core.terminal.ui.TerminalSurfaceState
+
 /**
  * Tracks sparse renders that the authoritative watchdog capture has already
  * proven healthy, so later `%output` bursts do not shortcut a backed-off wait
@@ -16,8 +20,20 @@ internal class StaleRenderSparseWakeBaselines {
         renderedCharsByPane.remove(pane.paneId)
     }
 
-    fun rememberIfHealthySparse(pane: TmuxPaneState) {
+    suspend fun rememberIfHealthySparse(pane: TmuxPaneState) {
         val state = pane.terminalState
+        // Issue #1443: the pixel-truth suspicion probe. This method is invoked from
+        // the stale-render watchdog's `HealOutcome.Healthy` tick — exactly the
+        // MODEL-reports-content-present window where a GENUINE pixel/GPU-layer black
+        // hides: every model-derived detector reads healthy (the model DID paint the
+        // frame), so `surfaceIsBlackWhileModelHasContent()` is false and none of the
+        // black-frame classes fire, yet the composited surface can be black. Sampling
+        // the actual surface pixels here (rate-bounded, off the render path — the
+        // probe internally caps itself to one PixelCopy per cycle) is the only way to
+        // SEE it. DIAGNOSTICS ONLY: on a positive pixel-black we fingerprint the
+        // occurrence and nothing else — NO heal/reseed/reattach is triggered (a 13th
+        // heal mechanism is the D28 patches-on-patches condition #1353 exists to end).
+        maybeFingerprintPixelBlack(pane, state)
         if (
             state.surfaceIsBlackWhileModelHasContent() ||
             state.visibleScreenIsBlankOrPartiallyBlank() ||
@@ -38,5 +54,27 @@ internal class StaleRenderSparseWakeBaselines {
         val healthySparseChars = renderedCharsByPane[pane.paneId] ?: return true
         val currentChars = state.renderedNonBlankCharCount()
         return currentChars <= 0 || currentChars.toLong() * 4L < healthySparseChars.toLong() * 3L
+    }
+
+    /**
+     * Issue #1443 — run the DIAGNOSTIC pixel-truth probe and, when it confirms a
+     * (near-)uniformly black surface over a content-bearing model, emit the distinct
+     * [BLACK_FRAME_CLASS_PIXEL_BLACK_MODEL_HAS_CONTENT] class into the SAME exportable
+     * `black_frame_observed` JSONL ring (#1175 conventions) the other classes use, so
+     * the occurrence stops being invisible to diagnostics. Rides this watchdog tick —
+     * no new poll/timer — and the probe rate-bounds the actual PixelCopy. Emits nothing
+     * (and never heals) when the probe finds content/no-evidence/rate-limited.
+     */
+    private suspend fun maybeFingerprintPixelBlack(pane: TmuxPaneState, state: TerminalSurfaceState) {
+        if (state.probePixelBlackWhileModelHasContent(SystemClock.elapsedRealtime())) {
+            DiagnosticEvents.record(
+                "terminal",
+                BLACK_FRAME_OBSERVED_EVENT,
+                "class" to BLACK_FRAME_CLASS_PIXEL_BLACK_MODEL_HAS_CONTENT,
+                "paneId" to pane.paneId,
+                "windowId" to pane.windowId,
+                "renderedChars" to state.renderedNonBlankCharCount(),
+            )
+        }
     }
 }

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionSupport.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionSupport.kt
@@ -209,6 +209,24 @@ internal const val BLACK_FRAME_CLASS_PARTIAL_BLANK: String = "partial_blank"
 internal const val BLACK_FRAME_CLASS_SURFACE_BLACK_MODEL_INTACT: String = "surface_black_model_intact"
 
 /**
+ * Issue #1443 — the pixel-truth class. Distinct from [BLACK_FRAME_CLASS_SURFACE_BLACK_MODEL_INTACT]:
+ * that #1192 class is still MODEL-derived (the paint-confirmation seam reports
+ * `paintedEmulatorContent` from `hasNonBlankVisibleRow()`, an emulator-model check with NO
+ * pixel readback — the explicit #1296 non-goal). A GENUINE pixel/GPU-layer black — the
+ * composited surface is black while the model still carries the frame (a lost HWUI hardware
+ * layer, a RenderNode that stopped compositing, a Compose layer that dropped the child View's
+ * buffer) — reads HEALTHY on every model-derived detector, so it is un-detected, un-healed,
+ * AND un-fingerprinted (spike #874, the last code-confirmed blind spot). This class is
+ * emitted ONLY when a bounded, rate-limited `PixelCopy` sample
+ * ([TerminalSurfaceState.probePixelBlackWhileModelHasContent], off the render path) confirms
+ * the surface pixels are (near-)uniformly black while the model carries content. DIAGNOSTICS
+ * ONLY (maintainer decision 2026-07-10): it wires NO heal — if it fires in the wild the heal
+ * decision is deferred to #1353 with the captured data; if it never fires it exonerates
+ * pixel-black. Kept a SEPARATE class so the two are attributable and never conflated.
+ */
+internal const val BLACK_FRAME_CLASS_PIXEL_BLACK_MODEL_HAS_CONTENT: String = "pixel_black_model_has_content"
+
+/**
  * Issue #1294 — a watchdog heal tick whose authoritative `capture-pane` could NOT confirm the
  * render (a [HealOutcome.Unverified] outcome: timeout / error / empty-on-live-transport /
  * mutex-starved). Carries an `unverifiedStreak` field (the run of consecutive such ticks) so a

--- a/app/src/test/java/com/pocketshell/app/tmux/PixelBlackModelHasContentDiagnosticTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/PixelBlackModelHasContentDiagnosticTest.kt
@@ -1,0 +1,140 @@
+package com.pocketshell.app.tmux
+
+import android.os.Looper
+import com.pocketshell.app.diagnostics.installRecordingDiagnosticSink
+import com.pocketshell.core.terminal.ui.TerminalSurfaceState
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import java.io.OutputStream
+
+/**
+ * Issue #1443 — the DIAGNOSTIC pixel-truth fingerprint on the WATCHDOG SUSPICION
+ * PATH (the app-side wiring of the pixel probe added to
+ * [TerminalSurfaceState.probePixelBlackWhileModelHasContent]).
+ *
+ * [StaleRenderSparseWakeBaselines.rememberIfHealthySparse] is invoked from the
+ * stale-render watchdog's `HealOutcome.Healthy` tick — exactly the
+ * MODEL-reports-content-present window where a genuine pixel/GPU-layer black hides
+ * (every model-derived detector reads healthy). This proves that on that path:
+ *
+ *  - GREEN: when the surface pixels are (near-)uniformly black over a content-bearing
+ *    model, the distinct `pixel_black_model_has_content` class is emitted into the
+ *    SAME exportable `black_frame_observed` JSONL ring the other classes use — so the
+ *    occurrence is no longer invisible.
+ *  - RED (no false positive): when the surface pixels carry content, NOTHING is
+ *    emitted — the fingerprint is load-bearing on the pixel sample, not always-firing.
+ *
+ * DIAGNOSTICS ONLY: this asserts an emitted diagnostic event; NO heal/reseed/repaint
+ * is requested off the signal (the surface-repaint request count stays 0).
+ *
+ * The real GPU-layer black cannot be produced in the CI JVM, so the pixel sample is
+ * injected synthetically (the #780 model); the real PixelCopy wiring
+ * ([com.termux.view.TerminalView.sampleSurfaceNearUniformBlack]) is exercised
+ * on-device.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class PixelBlackModelHasContentDiagnosticTest {
+
+    private class NoopOutputStream : OutputStream() {
+        override fun write(b: Int) = Unit
+        override fun write(b: ByteArray, off: Int, len: Int) = Unit
+    }
+
+    private fun withContentBearingPane(
+        block: suspend (TerminalSurfaceState) -> Unit,
+    ) = runBlocking {
+        val state = TerminalSurfaceState()
+        val producerScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val producerJob = state.attachExternalProducer(
+            scope = producerScope,
+            stdout = MutableSharedFlow(extraBufferCapacity = 1),
+            remoteStdin = NoopOutputStream(),
+            suppressQueryResponses = true,
+        )
+        try {
+            state.appendRemoteOutput(
+                "[2J[HISSUE1443-WATCHDOG-PATH-PIXEL-BLACK\r\n".toByteArray(Charsets.US_ASCII),
+            )
+            shadowOf(Looper.getMainLooper()).idle()
+            // Model has content AND the last surface paint was CONTENT → the
+            // model-derived detector reads HEALTHY (the exact blind-spot state).
+            state.recordSurfaceFramePaintedForTest(paintedEmulatorContent = true, atMs = 1L)
+            assertTrue(state.renderedNonBlankCharCount() > 0)
+            block(state)
+        } finally {
+            producerJob.cancel()
+            producerScope.cancel()
+            state.detachExternalProducer()
+        }
+    }
+
+    private fun paneWith(state: TerminalSurfaceState): TmuxPaneState =
+        TmuxPaneState(
+            paneId = "%1",
+            windowId = "@0",
+            sessionId = "\$0",
+            title = "",
+            terminalState = state,
+        )
+
+    @Test
+    fun watchdogHealthyTick_pixelBlackSurface_fingerprintsNewClass() =
+        withContentBearingPane { state ->
+            state.setSurfacePixelSampler { true } // synthetic: surface pixels are black
+            val diagnostics = installRecordingDiagnosticSink()
+            try {
+                val baselines = StaleRenderSparseWakeBaselines()
+
+                baselines.rememberIfHealthySparse(paneWith(state))
+
+                val event = diagnostics.eventsNamed(BLACK_FRAME_OBSERVED_EVENT).single {
+                    it.fields["class"] == BLACK_FRAME_CLASS_PIXEL_BLACK_MODEL_HAS_CONTENT
+                }
+                assertEquals("terminal", event.category)
+                assertEquals("%1", event.fields["paneId"])
+                assertEquals("@0", event.fields["windowId"])
+
+                // DIAGNOSTICS ONLY: the signal must NOT have triggered any heal.
+                assertEquals(
+                    "#1443: the pixel-black fingerprint must wire NO heal — surface repaint count stays 0",
+                    0,
+                    state.surfaceRepaintRequestCountForTest(),
+                )
+            } finally {
+                diagnostics.close()
+            }
+        }
+
+    @Test
+    fun watchdogHealthyTick_pixelSurfaceHasContent_emitsNothing() =
+        withContentBearingPane { state ->
+            state.setSurfacePixelSampler { false } // synthetic: surface pixels carry content
+            val diagnostics = installRecordingDiagnosticSink()
+            try {
+                val baselines = StaleRenderSparseWakeBaselines()
+
+                baselines.rememberIfHealthySparse(paneWith(state))
+
+                assertTrue(
+                    "#1443: a content-bearing surface must emit NO pixel-black class (no false positive)",
+                    diagnostics.eventsNamed(BLACK_FRAME_OBSERVED_EVENT).none {
+                        it.fields["class"] == BLACK_FRAME_CLASS_PIXEL_BLACK_MODEL_HAS_CONTENT
+                    },
+                )
+            } finally {
+                diagnostics.close()
+            }
+        }
+}

--- a/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurface.kt
+++ b/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurface.kt
@@ -363,7 +363,22 @@ fun TerminalSurface(
                 { policy -> view.prepareForRawTerminalInput(policy.toTerminalViewPolicy()) }
             },
         )
-        onDispose { state.setSmartTextStagingBridge(null) }
+        // Issue #1443: bind the DIAGNOSTIC pixel-truth sampler to the live View's
+        // bounded PixelCopy. The tmux watchdog's suspicion tick calls
+        // state.probePixelBlackWhileModelHasContent() (rate-bounded, off the render
+        // path) which invokes this to detect a genuine pixel/GPU-layer black the
+        // MODEL-derived detectors cannot see. Diagnostics only — no heal is wired.
+        state.setSurfacePixelSampler(
+            if (view == null) {
+                null
+            } else {
+                TerminalSurfaceState.SurfacePixelSampler { view.sampleSurfaceNearUniformBlack() }
+            },
+        )
+        onDispose {
+            state.setSmartTextStagingBridge(null)
+            state.setSurfacePixelSampler(null)
+        }
     }
 
     LaunchedEffect(state, terminalView, coalescedRenderRequests) {

--- a/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurfaceState.kt
+++ b/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurfaceState.kt
@@ -851,6 +851,146 @@ class TerminalSurfaceState(
     fun recordSurfaceFramePaintedForTest(paintedEmulatorContent: Boolean, atMs: Long) =
         onSurfaceFramePainted(paintedEmulatorContent, atMs)
 
+    // -------------------------------------------------------------------------
+    // Issue #1443 — PIXEL-TRUTH surface-black probe (the last code-confirmed
+    // black-screen blind spot).
+    //
+    // Every surface-black signal above ([surfaceIsBlackWhileModelHasContent], fed
+    // by the #1192 paint-confirmation seam) is derived from the emulator MODEL:
+    // `TerminalView.onDraw` reports `paintedEmulatorContent = getWidth() > 0 &&
+    // getHeight() > 0 && hasNonBlankVisibleRow()` — a MODEL check with NO pixel
+    // readback (the explicit #1296 non-goal). So a GENUINE pixel/GPU-layer black —
+    // the composited surface is black while the model still carries the frame (a
+    // lost HWUI hardware layer, a RenderNode that stopped compositing, a Compose
+    // layer that dropped the child View's buffer) — is INVISIBLE: `onDraw` runs,
+    // the model has content, so a CONTENT paint is recorded,
+    // [surfaceIsBlackWhileModelHasContent] returns false, the model-vs-tmux oracle
+    // reads healthy, and NONE of the black-frame classes fire. It is un-detected,
+    // un-healed, AND un-fingerprinted.
+    //
+    // This is a DIAGNOSTIC-ONLY probe (maintainer decision 2026-07-10, #1443):
+    //  - Fingerprint, do NOT heal. It records an OBSERVATION so the occurrence
+    //    stops being invisible; it wires NO new heal/recovery/reattach trigger (a
+    //    13th mechanism is exactly the D28 patches-on-patches condition the #1353
+    //    consolidation epic exists to end). If it ever fires in the wild, the HEAL
+    //    decision is deferred to #1353 with that data.
+    //  - Off the render path, rate-bounded. [probePixelBlackWhileModelHasContent]
+    //    is invoked ONLY from the app's stale-render watchdog suspicion tick when
+    //    the MODEL reports content-present — NEVER from `onDraw`/the per-frame
+    //    render loop — and it internally rate-limits the actual pixel sample to at
+    //    most one per [PIXEL_PROBE_MIN_INTERVAL_MS]. That is why it does NOT
+    //    reinstate the per-frame PixelCopy cost #1296 rejected.
+    // -------------------------------------------------------------------------
+
+    /**
+     * Issue #1443 — the surface PIXEL sampler seam. Production ([TerminalSurface])
+     * binds this to a bounded `PixelCopy` sample of the live
+     * [com.termux.view.TerminalView]'s window surface (see
+     * [com.termux.view.TerminalView.sampleSurfaceNearUniformBlack]); a unit test
+     * injects a synthetic sample (the #780 model — the CI JVM cannot run a real GPU
+     * `PixelCopy`). [sampleNearUniformBlack] returns `true` when the sampled surface
+     * pixels are (near-)uniformly the background colour, `false` when they carry
+     * visible content, and `null` when the surface could not be sampled (no bound
+     * view, 0-size, PixelCopy error/timeout) — a `null` is "no evidence" and is
+     * never fingerprinted.
+     */
+    fun interface SurfacePixelSampler {
+        fun sampleNearUniformBlack(): Boolean?
+    }
+
+    @Volatile
+    private var pixelSampler: SurfacePixelSampler? = null
+
+    /**
+     * Issue #1443 — install/replace the surface pixel sampler. [TerminalSurface]
+     * binds the production `PixelCopy`-backed sampler while a [TerminalView] is
+     * attached and clears it (`null`) on dispose (the probe then no-ops). Tests
+     * inject a synthetic sampler.
+     */
+    fun setSurfacePixelSampler(sampler: SurfacePixelSampler?) {
+        pixelSampler = sampler
+    }
+
+    @Volatile
+    private var lastPixelProbeAtMs: Long = 0L
+
+    @Volatile
+    private var pixelBlackModelHasContentObservedCount: Int = 0
+
+    /**
+     * Issue #1443 — the pixel-truth probe. DIAGNOSTICS ONLY: returns `true` (and
+     * increments [pixelBlackModelHasContentObservedCountForTest]) exactly when a
+     * suspicion-triggered pixel sample proves the surface is (near-)uniformly black
+     * WHILE the model carries content — the one black-screen class the model-derived
+     * detectors are blind to by construction. It wires NO heal; the caller only
+     * fingerprints the observation.
+     *
+     * Invoked ONLY from the app's stale-render watchdog suspicion path (never from
+     * `onDraw`/the render loop), and internally RATE-BOUNDED to at most one real
+     * pixel sample per [PIXEL_PROBE_MIN_INTERVAL_MS] so it can never become a
+     * hot-path cost even if the caller ticks faster.
+     *
+     * `suspend` + off-main by construction: the watchdog runs on the ViewModel's
+     * `Dispatchers.Main.immediate` scope, and the underlying `PixelCopy` readback
+     * blocks its calling thread on an async callback (`latch.await`). Running that
+     * on the UI thread would stall the render path for up to the PixelCopy timeout —
+     * WORST case exactly during a wedged/black surface, making the freeze worse. So
+     * the sample is dispatched to [pixelProbeDispatcher] ([Dispatchers.IO]); the UI
+     * thread is never blocked. A diagnostic must never destabilise rendering (#1443).
+     *
+     * Returns `false` (no observation) when: the model carries no content (nothing
+     * could be lost — the probe requires content-present, so it is never vacuously
+     * true); the rate-limit window has not yet elapsed; no sampler is bound; the
+     * sample could not be taken (`null`); or the sampled pixels carry visible
+     * content (the healthy case — proving the probe is not just always-firing).
+     *
+     * @param nowMs a monotonic `elapsedRealtime()` stamp supplied by the caller
+     *   (parameterised so a JVM test can drive the rate-limit deterministically —
+     *   the #780 synthetic model).
+     */
+    suspend fun probePixelBlackWhileModelHasContent(nowMs: Long): Boolean {
+        // Content-present gate: a black surface over a model with NO content is not
+        // this class (it is the ordinary blank pane the model detectors already see).
+        if (renderedNonBlankCharCount() <= 0) return false
+        // Rate bound: at most one real pixel sample per window, so a fast-ticking
+        // caller can never turn this into a hot-path PixelCopy cost (#1296/#1164).
+        // Checked BEFORE dispatch so a rate-limited tick spawns no off-main work.
+        if (lastPixelProbeAtMs != 0L && nowMs - lastPixelProbeAtMs < PIXEL_PROBE_MIN_INTERVAL_MS) {
+            return false
+        }
+        lastPixelProbeAtMs = nowMs
+        val sampler = pixelSampler ?: return false
+        // The PixelCopy readback blocks its thread on the async result — NEVER run it
+        // on the caller's (UI) thread; move it to the IO dispatcher (#1443).
+        val nearUniformBlack = withContext(pixelProbeDispatcher) {
+            sampler.sampleNearUniformBlack()
+        } ?: return false
+        if (!nearUniformBlack) return false
+        pixelBlackModelHasContentObservedCount += 1
+        return true
+    }
+
+    @Volatile
+    private var pixelProbeDispatcher: CoroutineDispatcher = Dispatchers.IO
+
+    /**
+     * Test-only (#1443): override the dispatcher the pixel sample runs on so a JVM
+     * test can assert the sample is dispatched OFF the caller/UI thread. Production
+     * always uses [Dispatchers.IO].
+     */
+    fun setPixelProbeDispatcherForTest(dispatcher: CoroutineDispatcher) {
+        pixelProbeDispatcher = dispatcher
+    }
+
+    /**
+     * Test-only (#1443): how many pixel-black-while-model-has-content observations
+     * have fired. `public` (not `internal`) so the app-module tmux tests — a
+     * different Gradle module — can assert the fingerprint, mirroring
+     * [surfaceRepaintRequestCountForTest].
+     */
+    public fun pixelBlackModelHasContentObservedCountForTest(): Int =
+        pixelBlackModelHasContentObservedCount
+
     /**
      * Issue #989 — the NON-DESTRUCTIVE-swap guard for the manual Redraw / attach
      * reseed. The seed path repaints `capture-pane` into the live buffer with a
@@ -1383,6 +1523,18 @@ class TerminalSurfaceState(
          * pass, but a user who pauses for half a second sees fresh matches.
          */
         private const val MATCH_DEBOUNCE_MS = 250L
+
+        /**
+         * Issue #1443 — minimum spacing between real surface PIXEL samples in
+         * [probePixelBlackWhileModelHasContent]. The probe is already invoked only
+         * from the app stale-render watchdog's per-tick suspicion path (4s–30s
+         * cadence), so at the normal cadence one sample lands per watchdog cycle;
+         * this bound is a hard defensive ceiling so even a pathologically fast
+         * caller cannot turn the bounded `PixelCopy` into a hot-path cost (the
+         * #1296-rejected per-frame readback, #1164 battery). 2s < the 4s hot
+         * watchdog tick, so a legitimate per-cycle probe is never suppressed.
+         */
+        private const val PIXEL_PROBE_MIN_INTERVAL_MS = 2_000L
 
         /**
          * Issue #1300: the heal capture is issued with `capture-pane -e` (`TmuxClient.kt`),

--- a/shared/core-terminal/src/main/java/com/termux/view/TerminalView.java
+++ b/shared/core-terminal/src/main/java/com/termux/view/TerminalView.java
@@ -6,10 +6,15 @@ import android.app.Activity;
 import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
+import android.content.ContextWrapper;
+import android.graphics.Bitmap;
 import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Rect;
 import android.graphics.Typeface;
 import android.os.Build;
 import android.os.Handler;
+import android.os.HandlerThread;
 import android.os.Looper;
 import android.os.SystemClock;
 import android.text.Editable;
@@ -23,9 +28,11 @@ import android.view.KeyCharacterMap;
 import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MotionEvent;
+import android.view.PixelCopy;
 import android.view.View;
 import android.view.ViewConfiguration;
 import android.view.ViewTreeObserver;
+import android.view.Window;
 import android.view.accessibility.AccessibilityManager;
 import android.view.autofill.AutofillManager;
 import android.view.autofill.AutofillValue;
@@ -42,6 +49,9 @@ import com.termux.terminal.KeyHandler;
 import com.termux.terminal.TerminalEmulator;
 import com.termux.terminal.TerminalSession;
 import com.termux.view.textselection.TextSelectionCursorController;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 /** View displaying and interacting with a {@link TerminalSession}. */
 public final class TerminalView extends View {
@@ -240,6 +250,174 @@ public final class TerminalView extends View {
         }
         invalidate();
     }
+
+    /**
+     * Issue #1443 — DIAGNOSTIC pixel-truth sample of the on-screen surface, for the
+     * one black-screen class the MODEL-derived detectors are blind to.
+     *
+     * <p>Every other surface-black signal (the #1192 paint-confirmation seam →
+     * {@link com.pocketshell.core.terminal.ui.TerminalSurfaceState#surfaceIsBlackWhileModelHasContent})
+     * is derived from the emulator MODEL: {@link #onDraw} reports
+     * {@code paintedEmulatorContent} from {@code hasNonBlankVisibleRow()}, a MODEL
+     * check with NO pixel readback (the explicit #1296 non-goal). A GENUINE
+     * pixel/GPU-layer black — the composited surface is black while the model still
+     * carries the frame (a lost HWUI hardware layer, a RenderNode that stopped
+     * compositing, a Compose layer that dropped this View's buffer) — is invisible
+     * to all of them. This bounded {@link PixelCopy} of the actual window surface is
+     * the only way to see it.
+     *
+     * <p><b>This is called ONLY on a suspicion trigger</b> — the app's stale-render
+     * watchdog tick when the MODEL reports content-present, via
+     * {@link com.pocketshell.core.terminal.ui.TerminalSurfaceState#probePixelBlackWhileModelHasContent}
+     * (itself rate-bounded). It is NEVER called from {@link #onDraw} / the per-frame
+     * render loop, so it does NOT reinstate the per-frame PixelCopy cost #1296
+     * rejected. It samples the whole view region SCALED into a small fixed
+     * {@value #PIXEL_SAMPLE_DIM}×{@value #PIXEL_SAMPLE_DIM} bitmap, so the readback
+     * cost is O({@value #PIXEL_SAMPLE_DIM}²) regardless of the view size.
+     *
+     * <p><b>Diagnostics only</b>: this NEVER heals/reseeds/reattaches anything and
+     * NEVER throws into a caller — any failure returns {@code null} ("no evidence").
+     *
+     * @return {@code Boolean.TRUE} when the sampled surface pixels are
+     *   (near-)uniformly the default background colour (a dead/black surface),
+     *   {@code Boolean.FALSE} when they carry visible content (a healthy surface),
+     *   and {@code null} when the surface could not be sampled (no host window,
+     *   0-size, PixelCopy error/timeout) — never fingerprinted by the caller.
+     */
+    @Nullable
+    public Boolean sampleSurfaceNearUniformBlack() {
+        try {
+            final int width = getWidth();
+            final int height = getHeight();
+            if (width <= 0 || height <= 0) return null;
+            final Window window = findHostWindow();
+            if (window == null || window.peekDecorView() == null) return null;
+
+            final int[] loc = new int[2];
+            getLocationInWindow(loc);
+            final Rect src = new Rect(loc[0], loc[1], loc[0] + width, loc[1] + height);
+
+            // PixelCopy scales srcRect INTO the destination bitmap, so a fixed small
+            // dest bounds the whole readback to O(dim^2) pixels regardless of the
+            // view's on-screen size — never a per-pixel full-surface scan (#1296/#1164).
+            final Bitmap dest =
+                Bitmap.createBitmap(PIXEL_SAMPLE_DIM, PIXEL_SAMPLE_DIM, Bitmap.Config.ARGB_8888);
+            try {
+                final CountDownLatch latch = new CountDownLatch(1);
+                final int[] status = {PixelCopy.ERROR_UNKNOWN};
+                // Reuse ONE process-wide handler thread for every probe (rate-limited to
+                // ≤1 per watchdog cycle) instead of spinning a HandlerThread up per call.
+                PixelCopy.request(window, src, dest, copyResult -> {
+                    status[0] = copyResult;
+                    latch.countDown();
+                }, pixelProbeHandler());
+                if (!latch.await(PIXEL_SAMPLE_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+                    return null;
+                }
+                if (status[0] != PixelCopy.SUCCESS) {
+                    return null;
+                }
+                return Boolean.valueOf(isBitmapNearUniformBackground(dest));
+            } finally {
+                // Always recycle — including the timeout / error / exception paths — so a
+                // probe failure never leaks the sample bitmap.
+                dest.recycle();
+            }
+        } catch (Throwable t) {
+            // A diagnostic probe must NEVER destabilise the terminal: any failure
+            // (no window, permission, driver refusal, interruption) is "no evidence".
+            return null;
+        }
+    }
+
+    /** Issue #1443 — one shared, lazily-started handler thread for all pixel probes. */
+    private static volatile Handler sPixelProbeHandler;
+
+    private static Handler pixelProbeHandler() {
+        Handler handler = sPixelProbeHandler;
+        if (handler == null) {
+            synchronized (TerminalView.class) {
+                handler = sPixelProbeHandler;
+                if (handler == null) {
+                    final HandlerThread thread = new HandlerThread("ps-pixel-probe");
+                    thread.start();
+                    handler = new Handler(thread.getLooper());
+                    sPixelProbeHandler = handler;
+                }
+            }
+        }
+        return handler;
+    }
+
+    /**
+     * Issue #1443 — walk the View's context chain to the hosting {@link Activity}'s
+     * {@link Window}, needed by {@link PixelCopy#request} (a plain HWUI View has no
+     * Surface of its own; the composited pixels live on the window surface). Returns
+     * {@code null} when the View is not hosted by an Activity window.
+     */
+    @Nullable
+    private Window findHostWindow() {
+        Context ctx = getContext();
+        while (ctx instanceof ContextWrapper) {
+            if (ctx instanceof Activity) {
+                return ((Activity) ctx).getWindow();
+            }
+            ctx = ((ContextWrapper) ctx).getBaseContext();
+        }
+        return null;
+    }
+
+    /**
+     * Issue #1443 — true when (near-)all sampled pixels are within
+     * {@value #PIXEL_BG_CHANNEL_TOLERANCE} per channel of the default background
+     * colour, i.e. the surface is (near-)uniformly the background (a dead/black
+     * surface) rather than carrying rendered glyphs.
+     *
+     * <p>The threshold ({@value #PIXEL_BG_UNIFORM_PERMILLE}‰) is deliberately very
+     * high: a genuine GPU-layer black is 100% background, while even a sparse but
+     * HEALTHY terminal frame lights up several of the {@value #PIXEL_SAMPLE_DIM}²
+     * sampled cells with glyph coverage. It is a conservative first cut for on-device
+     * tuning — a false positive here only emits a diagnostic event (never a heal), and
+     * the model-content gate in the caller already excludes the ordinary blank pane.
+     */
+    private boolean isBitmapNearUniformBackground(Bitmap bmp) {
+        final int bg = mDefaultBackgroundColor;
+        final int bgR = Color.red(bg);
+        final int bgG = Color.green(bg);
+        final int bgB = Color.blue(bg);
+        final int w = bmp.getWidth();
+        final int h = bmp.getHeight();
+        final int total = w * h;
+        if (total <= 0) return false;
+        int backgroundPixels = 0;
+        for (int y = 0; y < h; y++) {
+            for (int x = 0; x < w; x++) {
+                final int p = bmp.getPixel(x, y);
+                if (Math.abs(Color.red(p) - bgR) <= PIXEL_BG_CHANNEL_TOLERANCE
+                        && Math.abs(Color.green(p) - bgG) <= PIXEL_BG_CHANNEL_TOLERANCE
+                        && Math.abs(Color.blue(p) - bgB) <= PIXEL_BG_CHANNEL_TOLERANCE) {
+                    backgroundPixels++;
+                }
+            }
+        }
+        return (long) backgroundPixels * 1000L >= (long) total * PIXEL_BG_UNIFORM_PERMILLE;
+    }
+
+    /** Issue #1443 — the fixed downscaled dimension the surface is PixelCopy'd into. */
+    private static final int PIXEL_SAMPLE_DIM = 16;
+
+    /** Issue #1443 — max wait for the single-shot async PixelCopy callback. */
+    private static final long PIXEL_SAMPLE_TIMEOUT_MS = 250L;
+
+    /** Issue #1443 — per-channel tolerance for "this pixel equals the background". */
+    private static final int PIXEL_BG_CHANNEL_TOLERANCE = 16;
+
+    /**
+     * Issue #1443 — the ‰ of sampled pixels that must match the background for the
+     * surface to count as (near-)uniformly black. 990‰ (99%) targets a genuine
+     * full-black surface while leaving headroom for antialiasing fringe.
+     */
+    private static final int PIXEL_BG_UNIFORM_PERMILLE = 990;
 
     float mScaleFactor = 1.f;
     final GestureAndScaleRecognizer mGestureRecognizer;

--- a/shared/core-terminal/src/test/java/com/pocketshell/core/terminal/ui/TerminalSurfaceStatePixelBlackProbeTest.kt
+++ b/shared/core-terminal/src/test/java/com/pocketshell/core/terminal/ui/TerminalSurfaceStatePixelBlackProbeTest.kt
@@ -1,0 +1,269 @@
+package com.pocketshell.core.terminal.ui
+
+import android.os.Looper
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import java.io.OutputStream
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Issue #1443 — the pixel-truth surface-black probe, the LAST code-confirmed
+ * black-screen blind spot.
+ *
+ * ## The blind spot this pins
+ *
+ * Every surface-black signal in the app is derived from the emulator MODEL:
+ * `TerminalView.onDraw` reports `paintedEmulatorContent` from
+ * `hasNonBlankVisibleRow()` (a MODEL check, NO pixel readback — the explicit #1296
+ * non-goal), which drives [TerminalSurfaceState.surfaceIsBlackWhileModelHasContent].
+ * So a GENUINE pixel/GPU-layer black — the composited surface is black while the
+ * model still carries the frame (a lost HWUI hardware layer, a RenderNode that
+ * stopped compositing, a Compose layer that dropped the child View's buffer) — is
+ * INVISIBLE: `onDraw` runs, the model has content, so a CONTENT paint is recorded,
+ * `surfaceIsBlackWhileModelHasContent()` returns false, and nothing fingerprints it.
+ *
+ * ## Red → green, in one run (the #780 synthetic model)
+ *
+ * A real GPU-layer black cannot be produced in the CI JVM (no real surface /
+ * PixelCopy), so — like the #1192/#1296 tests — this drives the exact blind-spot
+ * STATE synthetically: the model carries content AND the surface's most-recent
+ * frame was a CONTENT paint (so the model-derived detector reads HEALTHY), while an
+ * injected pixel sampler reports the surface pixels are (near-)uniformly black.
+ *
+ *  - RED (the blind spot): in that exact state
+ *    [TerminalSurfaceState.surfaceIsBlackWhileModelHasContent] returns `false` — the
+ *    model-derived detector is blind to it BY CONSTRUCTION, so on base nothing sees
+ *    or records the pixel-black.
+ *  - GREEN (the probe): [TerminalSurfaceState.probePixelBlackWhileModelHasContent]
+ *    samples the actual pixels and FIRES (returns true, increments the observation
+ *    count) on the SAME state — the occurrence is now attributable.
+ *
+ * The load-bearing assertion is the probe firing; reverting the probe's
+ * `pixelBlackModelHasContentObservedCount += 1; return true` to `return false`
+ * turns [pixelBlackWhileModelHasContent_modelDetectorBlind_pixelProbeFires] RED.
+ *
+ * DIAGNOSTICS ONLY: the probe wires NO heal — this file asserts detection +
+ * fingerprint firing, no reseed/repaint is requested.
+ */
+@RunWith(RobolectricTestRunner::class)
+class TerminalSurfaceStatePixelBlackProbeTest {
+
+    private class NoopOutputStream : OutputStream() {
+        override fun write(b: Int) = Unit
+        override fun write(b: ByteArray, off: Int, len: Int) = Unit
+    }
+
+    /**
+     * Drive the state to the exact blind-spot precondition: attach a producer, seed
+     * the model with visible content, and record a CONTENT surface paint so the
+     * MODEL-derived detector reads HEALTHY (the surface-only-black class the #1192
+     * detector CAN see is explicitly excluded here — this is the pixel-only class).
+     */
+    private fun withContentBearingState(
+        recordContentPaint: Boolean = true,
+        block: suspend (TerminalSurfaceState) -> Unit,
+    ) = runBlocking {
+        val state = TerminalSurfaceState()
+        val producerScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val producerJob = state.attachExternalProducer(
+            scope = producerScope,
+            stdout = MutableSharedFlow(extraBufferCapacity = 1),
+            remoteStdin = NoopOutputStream(),
+            suppressQueryResponses = true,
+        )
+        try {
+            state.appendRemoteOutput(
+                "[2J[HISSUE1443-PIXEL-BLACK-MODEL-HAS-CONTENT\r\n".toByteArray(Charsets.US_ASCII),
+            )
+            shadowOf(Looper.getMainLooper()).idle()
+            assertTrue(
+                "precondition: the MODEL grid must hold content — otherwise the probe's " +
+                    "content-present gate makes it vacuously false and proves nothing",
+                state.renderedNonBlankCharCount() > 0,
+            )
+            if (recordContentPaint) {
+                // The most-recent painted frame was a CONTENT paint → the model-derived
+                // detector reads HEALTHY. This is the blind spot: the surface can still
+                // be black at the pixel/GPU layer while this says all is well.
+                state.recordSurfaceFramePaintedForTest(paintedEmulatorContent = true, atMs = 1L)
+                assertFalse(
+                    "RED (the blind spot): the MODEL-derived surface-black detector is FALSE " +
+                        "in the exact pixel-black state — it cannot see a pixel/GPU-layer black",
+                    state.surfaceIsBlackWhileModelHasContent(),
+                )
+            }
+            block(state)
+        } finally {
+            producerJob.cancel()
+            producerScope.cancel()
+            state.detachExternalProducer()
+        }
+    }
+
+    /**
+     * Criterion 1 (red→green) — model content + model detector blind, but the pixel
+     * sampler reports (near-)uniform black → the probe FIRES and records the
+     * observation. This is the load-bearing green assertion.
+     */
+    @Test
+    fun pixelBlackWhileModelHasContent_modelDetectorBlind_pixelProbeFires() =
+        withContentBearingState { state ->
+            state.setSurfacePixelSampler { true } // synthetic: surface pixels are black
+
+            assertEquals(0, state.pixelBlackModelHasContentObservedCountForTest())
+            assertTrue(
+                "#1443 GREEN: the pixel probe must FIRE when the surface is pixel-black while " +
+                    "the model carries content — the class the model detectors are blind to",
+                state.probePixelBlackWhileModelHasContent(nowMs = 10_000L),
+            )
+            assertEquals(
+                "the pixel-black observation must be fingerprinted exactly once",
+                1,
+                state.pixelBlackModelHasContentObservedCountForTest(),
+            )
+        }
+
+    /**
+     * Criterion 2 (no false positive) — the SAME content-bearing state, but the pixel
+     * sampler reports the surface carries visible content → the probe does NOT fire.
+     * Proves the probe is load-bearing on the pixel sample, not just always-firing.
+     */
+    @Test
+    fun pixelSampleHasContent_probeDoesNotFire() =
+        withContentBearingState { state ->
+            state.setSurfacePixelSampler { false } // synthetic: surface pixels carry content
+
+            assertFalse(
+                "#1443: a content-bearing pixel sample must NOT fire the probe (no false positive)",
+                state.probePixelBlackWhileModelHasContent(nowMs = 10_000L),
+            )
+            assertEquals(0, state.pixelBlackModelHasContentObservedCountForTest())
+        }
+
+    /**
+     * No sampler bound (the plain-SSH / pre-attach window) → the probe no-ops. It must
+     * never fingerprint without positive pixel evidence.
+     */
+    @Test
+    fun noSamplerBound_probeDoesNotFire() =
+        withContentBearingState { state ->
+            assertFalse(state.probePixelBlackWhileModelHasContent(nowMs = 10_000L))
+            assertEquals(0, state.pixelBlackModelHasContentObservedCountForTest())
+        }
+
+    /**
+     * The surface could not be sampled (no host window / 0-size / PixelCopy error) →
+     * the production sampler returns `null` ("no evidence") → the probe does NOT fire.
+     */
+    @Test
+    fun sampleUnavailable_null_probeDoesNotFire() =
+        withContentBearingState { state ->
+            state.setSurfacePixelSampler { null }
+
+            assertFalse(
+                "#1443: a null pixel sample is 'no evidence' and must never be fingerprinted",
+                state.probePixelBlackWhileModelHasContent(nowMs = 10_000L),
+            )
+            assertEquals(0, state.pixelBlackModelHasContentObservedCountForTest())
+        }
+
+    /**
+     * Content-present gate (never vacuous) — a black pixel sample over a model with NO
+     * content is the ordinary blank pane the model detectors already handle, NOT this
+     * class. The probe requires model content-present, so it does NOT fire here.
+     */
+    @Test
+    fun modelHasNoContent_probeDoesNotFire_evenWhenPixelsBlack() = runBlocking {
+        val state = TerminalSurfaceState()
+        state.setSurfacePixelSampler { true } // pixels black...
+        assertEquals(
+            "precondition: no model content",
+            0,
+            state.renderedNonBlankCharCount(),
+        )
+        assertFalse(
+            "#1443: with NO model content the probe must not fire — it is never vacuously true",
+            state.probePixelBlackWhileModelHasContent(nowMs = 10_000L),
+        )
+        assertEquals(0, state.pixelBlackModelHasContentObservedCountForTest())
+    }
+
+    /**
+     * BLOCKING soundness (reviewer round 2) — the `PixelCopy` readback blocks its
+     * thread on an async callback (`latch.await`), and the production probe is invoked
+     * from the watchdog's `Dispatchers.Main.immediate` scope. Running the blocking
+     * sample on the UI thread would stall the render path for up to the PixelCopy
+     * timeout — worst case exactly during a wedged/black surface, making the freeze
+     * worse. The probe MUST dispatch the sample OFF the caller thread. This captures
+     * the thread the sampler runs on and asserts it is neither the probe's caller
+     * thread NOR the main looper thread.
+     *
+     * RED (remove the `withContext(pixelProbeDispatcher)`): the sampler runs on the
+     * caller thread → `assertNotSame(callerThread, …)` fails. GREEN (dispatched to
+     * IO): the sample runs on an IO-pool thread.
+     */
+    @Test
+    fun pixelSample_dispatchedOffCallerThread_andNotOnMain() =
+        withContentBearingState { state ->
+            val callerThread = Thread.currentThread()
+            val sampledOn = AtomicReference<Thread?>()
+            state.setSurfacePixelSampler {
+                sampledOn.set(Thread.currentThread())
+                true
+            }
+
+            assertTrue(state.probePixelBlackWhileModelHasContent(nowMs = 20_000L))
+
+            val sampledThread = sampledOn.get()
+            assertNotNull("the sampler must have run", sampledThread)
+            assertNotSame(
+                "#1443: the blocking PixelCopy sample must NOT run on the probe's caller (UI) thread",
+                callerThread,
+                sampledThread,
+            )
+            assertNotSame(
+                "#1443: the sample must never run on the main looper thread",
+                Looper.getMainLooper().thread,
+                sampledThread,
+            )
+        }
+
+    /**
+     * Criterion (off render path / bounded) — even a hot caller cannot turn the
+     * PixelCopy into a per-frame cost: the probe rate-limits itself to at most one
+     * real sample per window. Two calls inside the window fingerprint ONCE; a call
+     * past the window fingerprints again.
+     */
+    @Test
+    fun probeIsRateBounded_atMostOneSamplePerWindow() =
+        withContentBearingState { state ->
+            state.setSurfacePixelSampler { true }
+
+            assertTrue(state.probePixelBlackWhileModelHasContent(nowMs = 1_000L))
+            assertEquals(1, state.pixelBlackModelHasContentObservedCountForTest())
+
+            // Within the min-interval window: suppressed, no second sample/fingerprint.
+            assertFalse(
+                "#1443: a call inside the rate-limit window must be suppressed (bounded cost)",
+                state.probePixelBlackWhileModelHasContent(nowMs = 1_500L),
+            )
+            assertEquals(1, state.pixelBlackModelHasContentObservedCountForTest())
+
+            // Past the window: a fresh sample is allowed and fires again.
+            assertTrue(state.probePixelBlackWhileModelHasContent(nowMs = 9_000L))
+            assertEquals(2, state.pixelBlackModelHasContentObservedCountForTest())
+        }
+}


### PR DESCRIPTION
The last code-confirmed black-screen blind spot (from the #874 enumeration): the surface-black detector is model-only (no PixelCopy, #1296), so a genuine pixel/GPU-layer black is invisible — unhealed AND unfingerprinted.

**Maintainer-approved as DIAGNOSTIC-ONLY** (heal decision deferred to #1353 — no 13th heal trigger, per D28):
- Bounded, rate-limited `PixelCopy` probe on the watchdog suspicion tick only (never `onDraw`); emits a distinct `pixel_black_model_has_content` class; **no heal wired** off it.
- Probe is `suspend` + `withContext(Dispatchers.IO)` so the blocking readback never stalls the UI thread (round-2 fix); rate-limit/content gates stay synchronous. Does NOT touch `TmuxSessionViewModel` (no S5 collision).

## Verification
Synthetic reproduce-first red→green (fires on pixel-black-while-model-has-content; no false positive on content) + a not-on-main assertion (removing `withContext` fails it). core-terminal 7/7, app 2/2, `check-test-validity.sh` PASS, emission-only preserved (`surfaceRepaintRequestCountForTest()==0`). Reviewer drove red→green both rounds and APPROVED. Synthetic seam is the accepted proof (real GPU-black can't be forced under swiftshader).

If it fires in the wild → heal decision to #1353 with data; if it never fires after dogfood → exonerates pixel-black, close clean.

Closes #1443