### PR TITLE
connection: unify onto a single controller-owned reconnect ladder (S5, #1328)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/tmux/ReconnectLadderDiagnostics.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/ReconnectLadderDiagnostics.kt
@@ -1,0 +1,114 @@
+package com.pocketshell.app.tmux
+
+import android.util.Log
+import com.pocketshell.app.diagnostics.DiagnosticEvents
+import com.pocketshell.app.diagnostics.ReconnectCauseTrail
+import com.pocketshell.app.startup.StartupTiming
+
+/**
+ * Issue #1328 (S5): the auto-reconnect ladder's per-rung DIAGNOSTIC emission, split out
+ * of the [TmuxSessionViewModel] god-object (the connection-VM ratchet, issue #1047). These
+ * are PURE logging — [DiagnosticEvents] / [ReconnectCauseTrail] / [StartupTiming] / [Log]
+ * only — behaviour-identical to the inline blocks that lived in `scheduleAutoReconnectBody`,
+ * with the SAME event names, field names, and field ORDER (the maintainer's `PsTmuxReconnect`
+ * trail parses them). The VM keeps the coupled IO body and passes the already-computed
+ * `shortAppSwitchReconnectFields` array + primitives; nothing here touches VM state.
+ */
+
+/** The `reconnect_start` diagnostics for one ladder rung — emitted before the backoff delay. */
+internal fun recordReconnectRungScheduled(
+    target: TmuxSessionViewModel.ConnectionTarget,
+    trigger: TmuxConnectTrigger,
+    attemptNo: Int,
+    maxAttempts: Int,
+    delayMs: Long,
+    generation: Long,
+    reason: String,
+    shortAppSwitchFields: Array<Pair<String, Any?>>,
+) {
+    DiagnosticEvents.record(
+        "connection",
+        "reconnect_start",
+        "attempt" to attemptNo,
+        "maxAttempts" to maxAttempts,
+        "retryDelayMs" to delayMs,
+        "hostId" to target.hostId,
+        "host" to target.host,
+        "port" to target.port,
+        "user" to target.user,
+        "session" to target.sessionName,
+        "trigger" to trigger.logValue,
+        "reason" to reason,
+        "generation" to generation,
+        *shortAppSwitchFields,
+    )
+    ReconnectCauseTrail.record(
+        stage = "reconnect_attempt",
+        outcome = "scheduled",
+        cause = "auto_reconnect_loop",
+        trigger = trigger.logValue,
+        "attempt" to attemptNo,
+        "maxAttempts" to maxAttempts,
+        "retryDelayMs" to delayMs,
+        "hostId" to target.hostId,
+        "generation" to generation,
+    )
+}
+
+/** The `connect_start` / `connect_attempt` diagnostics for one ladder rung — emitted just
+ *  before the fresh dial. [dialAttempt] is the global `TMUX_CONNECT_ATTEMPTS` counter. */
+internal fun recordReconnectRungDialAttempt(
+    target: TmuxSessionViewModel.ConnectionTarget,
+    trigger: TmuxConnectTrigger,
+    dialAttempt: Int,
+    retryAttempt: Int,
+    maxAttempts: Int,
+    generation: Long,
+    clientHash: Int?,
+    previousClientPresent: Boolean,
+    shortAppSwitchFields: Array<Pair<String, Any?>>,
+) {
+    StartupTiming.mark(
+        "tmux-connect-attempt",
+        "attempt" to dialAttempt,
+        "hostId" to target.hostId,
+        "host" to target.host,
+        "port" to target.port,
+        "session" to target.sessionName,
+        "trigger" to trigger.logValue,
+        "requestedTrigger" to trigger.logValue,
+        "generation" to generation,
+    )
+    Log.i(
+        ISSUE_145_RECONNECT_TAG,
+        "tmux-connect-attempt count=$dialAttempt trigger=${trigger.logValue} " +
+            "requestedTrigger=${trigger.logValue} generation=$generation " +
+            targetLogFields(target),
+    )
+    DiagnosticEvents.record(
+        "connection",
+        "connect_start",
+        "attempt" to dialAttempt,
+        "hostId" to target.hostId,
+        "host" to target.host,
+        "port" to target.port,
+        "user" to target.user,
+        "session" to target.sessionName,
+        "trigger" to trigger.logValue,
+        "generation" to generation,
+        "clientHash" to clientHash,
+        *shortAppSwitchFields,
+    )
+    ReconnectCauseTrail.record(
+        stage = "connect_attempt",
+        outcome = "reconnect",
+        cause = "auto_reconnect_loop",
+        trigger = trigger.logValue,
+        "attempt" to dialAttempt,
+        "retryAttempt" to retryAttempt,
+        "maxAttempts" to maxAttempts,
+        "hostId" to target.hostId,
+        "generation" to generation,
+        "previousClientPresent" to previousClientPresent,
+    )
+}

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionFailureClassifiers.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionFailureClassifiers.kt
@@ -6,7 +6,32 @@ internal object TmuxSessionFailureClassifiers {
             isTmuxCommandTimeout(cause) ||
             isTmuxEofWriteFailure(cause) ||
             isTransportDisconnected(cause) ||
-            isControlChannelClosed(cause)
+            isControlChannelClosed(cause) ||
+            isTransportClosed(cause)
+
+    /**
+     * Issue #1328 (S5, #1321 §1b): true when [cause] is the "transport is closed"
+     * shape a beyond-grace reconnect PREFLIGHT (`tmux has-session`) hits when the
+     * reused warm lease's SSH transport was silently torn down while backgrounded.
+     * It is TRANSIENT — the fix (evict the poisoned lease + dial a FRESH transport)
+     * heals the same session, so it must NOT hard-`Failed`/"Tap Reconnect" on the
+     * first preflight (the beyond-grace break the maintainer hit). Matched on
+     * message text (walking the cause chain) so the app module needs no sshj dep.
+     */
+    private fun isTransportClosed(cause: Throwable?): Boolean {
+        var current: Throwable? = cause
+        val seen = HashSet<Throwable>()
+        while (current != null && seen.add(current)) {
+            val message = current.message
+            if (message != null &&
+                message.contains("transport is closed", ignoreCase = true)
+            ) {
+                return true
+            }
+            current = current.cause
+        }
+        return false
+    }
 
     /**
      * Issue #685 (Bug B): true when [cause] is the "control channel closed"

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -1407,6 +1407,10 @@ public class TmuxSessionViewModel @Inject constructor(
      * while the app is BACKGROUNDED.
      */
     private fun shouldSuppressTransportDropsForSingleGraceOwner(): Boolean {
+        // Issue #1328 (S5): while the ladder is in flight the loop is the sole counter
+        // advancer; each rung's `-CC` teardown flips the drop oracle, so the driver's
+        // extra drops would double-advance + exhaust it early — suppress them (not `Up`).
+        if (autoReconnectJob?.isActive == true) return true
         // The app is backgrounded at the PROCESS level (ProcessLifecycle below STARTED).
         // We deliberately do NOT use [appActive] here: within the App-level background
         // grace window the `-CC` connection is held and `onAppBackgrounded()` (which
@@ -6723,14 +6727,23 @@ public class TmuxSessionViewModel @Inject constructor(
             val result = probe.getOrNull()
             when {
                 result == null -> {
-                    // The probe exec itself failed (transport hiccup) — a TRANSIENT
-                    // condition, not a confirmed-gone. Fail open (attach as normal;
-                    // no recreate prompt).
+                    // The probe exec failed (transient hiccup, not confirmed-gone): fail
+                    // open. Issue #1328 (#1321 §1b): a `transport is closed` probe = the
+                    // reused warm lease died silently; evict it first so proceed() dials
+                    // FRESH (else re-attaching that dead lease hard-`Failed` the reconnect).
+                    val probeError = probe.exceptionOrNull()
+                    val closedTransport = isStaleChannelSymptom(probeError)
+                    if (closedTransport) {
+                        withContext(NonCancellable) {
+                            runCatching { sshLeaseManager.disconnect(leaseTarget.leaseKey) }
+                        }
+                    }
                     Log.i(
                         ISSUE_145_RECONNECT_TAG,
                         "tmux-existence-preflight-probe-error session=$sessionName " +
                             "trigger=${originalTrigger.logValue} " +
-                            "cause=${probe.exceptionOrNull()?.javaClass?.simpleName} — failing open",
+                            "cause=${probeError?.javaClass?.simpleName} " +
+                            "closedTransport=$closedTransport — failing open (dial fresh)",
                     )
                     proceed()
                 }
@@ -7341,6 +7354,10 @@ public class TmuxSessionViewModel @Inject constructor(
         connectingTarget =
             if (preserveReconnectTarget || staleChannelSymptom || coalescedCancel) target else null
         refreshReconnectAvailability()
+        // Issue #1328 (S5): while the ladder ([autoReconnectJob]) is active, do NOT
+        // terminalize — the loop + controller own advance-vs-exhaust (the deleted
+        // over-exhaust guard masked this premature "Unreachable on rung 1").
+        if (autoReconnectJob?.isActive == true) return
         setConnectionState(ConnectionState.Unreachable(message))
         // Issue #1185 (two-holder safety net): drive the reveal machine DIRECTLY
         // to a terminal error for THIS exact target instead of relying solely on
@@ -8754,6 +8771,8 @@ public class TmuxSessionViewModel @Inject constructor(
         connectingTarget = null
         refreshReconnectAvailability()
         val delays = autoReconnectDelaysMs.ifEmpty { listOf(0L) }
+        // Issue #1328 (S5): the controller owns the SINGLE ladder; this body only dials.
+        connectionManager.setReconnectLadder(delays)
         recordAutoReconnectDecision(
             decision = "scheduled",
             target = target,
@@ -8768,54 +8787,47 @@ public class TmuxSessionViewModel @Inject constructor(
         // the death cascade; attach the safety-net handler so an unexpected
         // throw mid-ladder degrades to a recorded non-fatal instead of crashing.
         autoReconnectJob = viewModelScope.launch(bridgeExceptionHandler) {
-            for ((index, delayMs) in delays.withIndex()) {
+            // Issue #1328 (S5): enter the ladder + drive off the controller's `Reconnecting`.
+            connectionManager.enterReconnectLadder(
+                controllerHostKey(target),
+                controllerSessionId(target),
+            )
+            while (true) {
+                val recon = connectionManager.state as? CoreConnectionState.Reconnecting ?: break
+                val attemptNo = recon.attempt
+                val maxAttempts = recon.maxAttempts
+                val delayMs = recon.retryDelayMs
                 val generation = nextConnectGeneration()
                 latestConnectIntent = ConnectIntent(
                     target = target,
                     trigger = trigger,
                     generation = generation,
                 )
+                // Carry the reason inline; attempt/max/delay MIRROR the controller.
                 setConnectionState(
                     ConnectionState.Reconnecting(
                         host = target.host,
                         port = target.port,
                         user = target.user,
-                        attempt = index + 1,
-                        maxAttempts = delays.size,
+                        attempt = attemptNo,
+                        maxAttempts = maxAttempts,
                         retryDelayMs = delayMs,
                         reason = reason,
                     ),
                 )
-                DiagnosticEvents.record(
-                    "connection",
-                    "reconnect_start",
-                    "attempt" to (index + 1),
-                    "maxAttempts" to delays.size,
-                    "retryDelayMs" to delayMs,
-                    "hostId" to target.hostId,
-                    "host" to target.host,
-                    "port" to target.port,
-                    "user" to target.user,
-                    "session" to target.sessionName,
-                    "trigger" to trigger.logValue,
-                    "reason" to reason,
-                    "generation" to generation,
-                    *shortAppSwitchReconnectFields(
+                recordReconnectRungScheduled(
+                    target = target,
+                    trigger = trigger,
+                    attemptNo = attemptNo,
+                    maxAttempts = maxAttempts,
+                    delayMs = delayMs,
+                    generation = generation,
+                    reason = reason,
+                    shortAppSwitchFields = shortAppSwitchReconnectFields(
                         trigger = trigger,
                         target = target,
                         sourceCandidate = "auto_reconnect",
                     ),
-                )
-                ReconnectCauseTrail.record(
-                    stage = "reconnect_attempt",
-                    outcome = "scheduled",
-                    cause = "auto_reconnect_loop",
-                    trigger = trigger.logValue,
-                    "attempt" to (index + 1),
-                    "maxAttempts" to delays.size,
-                    "retryDelayMs" to delayMs,
-                    "hostId" to target.hostId,
-                    "generation" to generation,
                 )
                 if (delayMs > 0) delay(delayMs)
                 if (!appActive) {
@@ -8825,58 +8837,26 @@ public class TmuxSessionViewModel @Inject constructor(
                         trigger = trigger,
                         reason = reason,
                         cause = "app_background_after_delay",
-                        "attempt" to (index + 1),
-                        "maxAttempts" to delays.size,
+                        "attempt" to attemptNo,
+                        "maxAttempts" to maxAttempts,
                     )
                     return@launch
                 }
                 val attempt = TMUX_CONNECT_ATTEMPTS.incrementAndGet()
-                StartupTiming.mark(
-                    "tmux-connect-attempt",
-                    "attempt" to attempt,
-                    "hostId" to target.hostId,
-                    "host" to target.host,
-                    "port" to target.port,
-                    "session" to target.sessionName,
-                    "trigger" to trigger.logValue,
-                    "requestedTrigger" to trigger.logValue,
-                    "generation" to generation,
-                )
-                Log.i(
-                    ISSUE_145_RECONNECT_TAG,
-                    "tmux-connect-attempt count=$attempt trigger=${trigger.logValue} " +
-                        "requestedTrigger=${trigger.logValue} generation=$generation " +
-                        targetLogFields(target),
-                )
-                DiagnosticEvents.record(
-                    "connection",
-                    "connect_start",
-                    "attempt" to attempt,
-                    "hostId" to target.hostId,
-                    "host" to target.host,
-                    "port" to target.port,
-                    "user" to target.user,
-                    "session" to target.sessionName,
-                    "trigger" to trigger.logValue,
-                    "generation" to generation,
-                    "clientHash" to clientRef?.let { System.identityHashCode(it) },
-                    *shortAppSwitchReconnectFields(
+                recordReconnectRungDialAttempt(
+                    target = target,
+                    trigger = trigger,
+                    dialAttempt = attempt,
+                    retryAttempt = attemptNo,
+                    maxAttempts = maxAttempts,
+                    generation = generation,
+                    clientHash = clientRef?.let { System.identityHashCode(it) },
+                    previousClientPresent = clientRef != null,
+                    shortAppSwitchFields = shortAppSwitchReconnectFields(
                         trigger = trigger,
                         target = target,
                         sourceCandidate = "auto_reconnect",
                     ),
-                )
-                ReconnectCauseTrail.record(
-                    stage = "connect_attempt",
-                    outcome = "reconnect",
-                    cause = "auto_reconnect_loop",
-                    trigger = trigger.logValue,
-                    "attempt" to attempt,
-                    "retryAttempt" to (index + 1),
-                    "maxAttempts" to delays.size,
-                    "hostId" to target.hostId,
-                    "generation" to generation,
-                    "previousClientPresent" to (clientRef != null),
                 )
                 withContext(NonCancellable) {
                     closeCurrentConnectionAndJoin(preserveConnectingTarget = target)
@@ -8900,10 +8880,12 @@ public class TmuxSessionViewModel @Inject constructor(
                         ISSUE_145_RECONNECT_TAG,
                         "tmux-auto-reconnect-abort reason=non-retryable " +
                             "cause=${failureCause?.javaClass?.simpleName} " +
-                            "attempt=${index + 1} " + targetLogFields(target),
+                            "attempt=$attemptNo " + targetLogFields(target),
                     )
                     connectingTarget = target
                     refreshReconnectAvailability()
+                    // Issue #1328 (S5): honest give-up — the reducer decides Unreachable.
+                    connectionManager.escalateUnreachable()
                     setConnectionState(
                         ConnectionState.Unreachable(
                             "$reason Auto reconnect stopped: ${nonRetryableReason(failureCause)}. " +
@@ -8917,36 +8899,40 @@ public class TmuxSessionViewModel @Inject constructor(
                         reason = reason,
                         cause = "non_retryable_connect_failure",
                         "failureClass" to failureCause?.javaClass?.simpleName,
-                        "attempt" to (index + 1),
-                        "maxAttempts" to delays.size,
+                        "attempt" to attemptNo,
+                        "maxAttempts" to maxAttempts,
                     )
                     autoReconnectJob = null
                     return@launch
                 }
+                // Issue #1328 (S5): a SPECIFIC terminal error from runConnect (session ended
+                // / server restarted) is not a ladder rung — keep it.
+                if (connectionManager.state is CoreConnectionState.Unreachable) break
+                // A retryable rung failed — the reducer advances (or exhausts) the ladder.
+                connectionManager.reconnectRungFailed()
             }
+            // Issue #1328 (S5): on genuine exhaustion (Unreachable, no specific terminal
+            // message set) surface the unified "Disconnected from …" band (#1098).
             connectingTarget = target
             refreshReconnectAvailability()
-            // Issue #1098 item 3 / #145: once the bounded auto-reconnect ladder
-            // genuinely EXHAUSTS against an unreachable host, surface the CLEAR,
-            // unified "Disconnected from <user>@<host>:<port>. Tap Reconnect to retry."
-            // band — never the jargon-y, self-contradictory "Transport EOF …;
-            // reconnecting. Auto reconnect failed after N attempts." The cause is
-            // captured in the diagnostics below; the user sees a calm, honest,
-            // tappable disconnect state instead of a frozen-but-live screen.
-            setConnectionState(
-                ConnectionState.Unreachable(
-                    "Disconnected from ${target.user}@${target.host}:${target.port}. " +
-                        "Tap Reconnect to retry.",
-                ),
-            )
-            recordAutoReconnectDecision(
-                decision = "exhausted",
-                target = target,
-                trigger = trigger,
-                reason = reason,
-                cause = "max_attempts",
-                "maxAttempts" to delays.size,
-            )
+            if (connectionManager.state is CoreConnectionState.Unreachable &&
+                inlineConnectionStatus !is ConnectionStatus.Failed
+            ) {
+                setConnectionState(
+                    ConnectionState.Unreachable(
+                        "Disconnected from ${target.user}@${target.host}:${target.port}. " +
+                            "Tap Reconnect to retry.",
+                    ),
+                )
+                recordAutoReconnectDecision(
+                    decision = "exhausted",
+                    target = target,
+                    trigger = trigger,
+                    reason = reason,
+                    cause = "max_attempts",
+                    "maxAttempts" to delays.size,
+                )
+            }
             autoReconnectJob = null
         }
     }

--- a/app/src/main/java/com/pocketshell/app/tmux/connection/ConnectionManager.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/connection/ConnectionManager.kt
@@ -144,24 +144,74 @@ class ConnectionManager(
      * [observeSeedLanded] / driver-fed `TransportLive` feeds REMAIN (idempotent).
      */
     fun revealLive(host: HostKey, targetId: SessionId) {
+        // Issue #1328 (S5): a reveal is the authoritative "we ARE connected" moment. If a
+        // prior failed attempt for this target left the controller in a TERMINAL state
+        // (Unreachable/Gone), that state ABSORBS TransportLive/SeedLanded — so promoting
+        // would leave the controller wrongly Unreachable while the pane is live on screen
+        // (a stuck-Failed band the deleted projection over-exhaust guard used to mask).
+        // A successful reveal RESURRECTS it: re-Enter resets it onto the live path first.
+        val state = controller.state.value
+        if (state is ConnectionState.Unreachable || state is ConnectionState.Gone) {
+            controller.submit(ConnectionEvent.Enter(host, targetId))
+        }
         ensureTargeting(host, targetId)
         promoteToLive(host, targetId)
     }
 
     /**
-     * INTENT: the drop-escalation / beyond-grace silent reconnect ladder. Models the inline
-     * escalation as a transport drop from a live-ish state so the controller walks the same
-     * reconnect ladder.
+     * INTENT: ENTER the silent-recovery ladder (idempotently). Drives a live-ish
+     * controller into [ConnectionState.Reattaching] so the displayed status becomes the
+     * calm Reconnecting band, but does NOT advance the numbered attempt counter — issue
+     * #1328 (S5) made the [ConnectionController] the SINGLE reconnect counter, so once it
+     * is already Reattaching/Reconnecting this is a NO-OP. Attempt ADVANCEMENT is owned
+     * solely by the reconnect effect via [advanceReconnectLadder]; this entrypoint (the
+     * inline-transition mirror in `driveControllerIntent`) must never double-count.
      */
     fun escalateReconnecting(host: HostKey, targetId: SessionId) {
         ensureTargeting(host, targetId)
+        val state = controller.state.value
+        if (state is ConnectionState.Reattaching || state is ConnectionState.Reconnecting) return
         controller.submit(ConnectionEvent.TransportDropped("reconnect"))
     }
 
-    /** INTENT: the inline honest error. Drives the reconnect ladder past its budget so the
-     *  controller surfaces [ConnectionState.Unreachable]. */
+    /**
+     * Issue #1328 (S5): install the reconnect backoff ladder into the controller — the
+     * SINGLE source of the attempt budget + per-attempt backoff. Called by the VM effect
+     * from its `autoReconnectDelaysMs` before it walks the ladder.
+     */
+    fun setReconnectLadder(delaysMs: List<Long>) {
+        controller.setReconnectLadder(delaysMs)
+    }
+
+    /**
+     * Issue #1328 (S5): the reconnect effect ENTERS the numbered ladder (attempt 1).
+     * Arms the controller's SINGLE churn-surviving counter and moves the tracked target
+     * to [ConnectionState.Reconnecting] attempt 1 via [ConnectionEvent.ReconnectLadderEntered]
+     * — one honest intent, not a stack of synthetic drops.
+     */
+    fun enterReconnectLadder(host: HostKey, targetId: SessionId) {
+        ensureTargeting(host, targetId)
+        controller.submit(ConnectionEvent.ReconnectLadderEntered)
+    }
+
+    /**
+     * Issue #1328 (S5): report that ONE reconnect ladder rung's real dial failed
+     * (retryably). The reducer advances the single churn-surviving counter and re-asserts
+     * [ConnectionState.Reconnecting] at the next attempt — even from the transient
+     * Reattaching/Live/Attaching state the just-failed dial churned to — or, at the ladder
+     * budget, decides exhaustion itself → [ConnectionState.Unreachable]. The VM never
+     * counts a parallel ladder.
+     */
+    fun reconnectRungFailed() {
+        controller.submit(ConnectionEvent.ReconnectFailed)
+    }
+
+    /** INTENT: the honest give-up. The reconnect effect hit a non-retryable failure (or an
+     *  explicit abort) — submit [ConnectionEvent.ReconnectGaveUp] so the reducer surfaces
+     *  [ConnectionState.Unreachable]. NOT the exhaustion path — the reducer decides
+     *  exhaustion itself in [advanceReconnectLadder] (#1328). */
     fun escalateUnreachable() {
-        exhaustToUnreachable()
+        controller.submit(ConnectionEvent.ReconnectGaveUp)
     }
 
     /** INTENT: a target deleted elsewhere. Submits [ConnectionEvent.TargetGone]; the controller
@@ -224,16 +274,6 @@ class ConnectionManager(
         if (controller.state.value.targetIdOrNull() != targetId) return
         controller.submit(ConnectionEvent.TransportLive)
         controller.submit(ConnectionEvent.SeedLanded(targetId, paneId = "inline-reveal"))
-    }
-
-    private fun exhaustToUnreachable() {
-        var guard = 0
-        while (controller.state.value !is ConnectionState.Unreachable && guard < 16) {
-            val before = controller.state.value
-            controller.submit(ConnectionEvent.TransportDropped("unreachable"))
-            if (controller.state.value === before) break
-            guard++
-        }
     }
 
     /**

--- a/app/src/main/java/com/pocketshell/app/tmux/connection/ConnectionStatusProjection.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/connection/ConnectionStatusProjection.kt
@@ -112,10 +112,9 @@ internal object ConnectionStatusProjection {
                 // authoritative "panes are seeded, safe to reveal" gate
                 // (`awaitPanesReadyForAttach`/`awaitActivePaneSeededOrLoading`); follow
                 // it so the full-screen Connecting overlay stays up until those panes
-                // land. This is the OPEN-direction sibling of [terminalOrInlineStatus]'s
-                // "don't show a premature scary Failed while the inline ladder is still
-                // recovering" guard — here: don't show a premature blank Connected while
-                // the inline open is still handshaking. Every normal cold open reaches
+                // land. This is the OPEN-direction sibling of the (now deleted, #1328)
+                // terminal over-exhaust guard — here: don't show a premature blank
+                // Connected while the inline open is still handshaking. Every normal cold open reaches
                 // controller `Live` only via the SeedLanded feed (which lands AT the
                 // inline reveal), so the inline status is already past `Connecting`
                 // there and this guard is a no-op for them.
@@ -137,55 +136,49 @@ internal object ConnectionStatusProjection {
             -> inlineStatus
             // APPROVED #685 divergence #1 (silent recovery): a recoverable drop leaves
             // the controller Reattaching/Reconnecting → a CALM Reconnecting band, NOT
-            // the scary Failed. The display payload (attempt/reason) is the inline
-            // reconnect bookkeeping.
+            // the scary Failed. Issue #1328 (S5): the displayed attempt/maxAttempts/
+            // retryDelayMs come from the controller's SINGLE-counter `Reconnecting`
+            // state (null for the pre-numbered Reattaching heal → calm attempt-1
+            // default); only the human reason string still rides the inline payload.
             is ConnectionState.Reattaching ->
-                reconnectingStatusFor(inlineStatus, hpu)
+                reconnectingStatusFor(controllerRecon = null, inlineStatus, hpu)
             is ConnectionState.Reconnecting ->
-                reconnectingStatusFor(inlineStatus, hpu)
+                reconnectingStatusFor(controllerRecon = controllerState, inlineStatus, hpu)
             is ConnectionState.Gone ->
-                terminalOrInlineStatus(inlineStatus, hpu)
+                ConnectionStatus.Failed(failedMessageFor(inlineStatus))
             is ConnectionState.Unreachable ->
-                // #720: the ONLY honest error. The CAUSE message is preserved (it is
-                // already a curated, user-facing string — never raw
-                // `TransportException`/SSH text); the CALM, tappable "Tap to reconnect"
-                // affordance + the dropped "Open the session again" instruction live in
-                // the screen band ([FailedConnectionRow]). "Failed only after retries
-                // truly exhaust" tracks the INLINE ladder (see [terminalOrInlineStatus]).
-                terminalOrInlineStatus(inlineStatus, hpu)
+                // #720: the ONLY honest error. Issue #1328 (S5): the controller is now the
+                // SINGLE reconnect ladder — its exhaustion IS the authoritative "retries
+                // truly exhausted" signal, so an `Unreachable` controller ALWAYS surfaces
+                // Failed. The old over-exhaust reconcile branch (follow the inline ladder
+                // when the controller "over-exhausted") is DELETED: with one ladder there
+                // is no second counter to over-run. The curated CAUSE message (never raw
+                // `TransportException`/SSH text) rides the inline Failed payload; the calm
+                // tappable "Tap to reconnect" affordance lives in the screen band.
+                ConnectionStatus.Failed(failedMessageFor(inlineStatus))
         }
     }
 
-    /**
-     * Project a controller TERMINAL state (Unreachable/Gone). The brief's approved
-     * #685 change is "Failed/Unreachable only AFTER retries truly exhaust". The
-     * authoritative "retries exhausted" signal is the INLINE reconnect ladder (the
-     * effect machinery 1c-iv-b owns) — the controller's own drop-ladder counter can
-     * over-exhaust because the bridge mirrors each inline reconnect transition as a
-     * drop. So: surface Failed ONLY when the inline state is ALSO terminal
-     * (the inline-projected status is `Failed`). While the inline ladder is still
-     * recovering (the inline status is `Reconnecting`) OR back live, follow the inline
-     * status — a calm Reconnecting band or Connected, never a premature scary Failed.
-     */
-    private fun terminalOrInlineStatus(
-        inlineStatus: ConnectionStatus,
-        hpu: HostPortUser,
-    ): ConnectionStatus =
-        when (inlineStatus) {
-            is ConnectionStatus.Failed ->
-                ConnectionStatus.Failed(inlineStatus.message)
-            is ConnectionStatus.Reconnecting ->
-                reconnectingStatusFor(inlineStatus, hpu)
-            // Inline already recovered (Connected) or is mid-open: the controller
-            // over-exhausted; follow the inline truth, not a premature Failed.
-            else -> inlineStatus
-        }
+    /** The curated failure message for a terminal controller state. It rides the inline
+     *  Failed payload (the VM sets the inline Unreachable/Gone message in lockstep with
+     *  the controller reaching it — one ladder, #1328); a generic calm default backstops
+     *  the transient window before the inline message lands. */
+    private fun failedMessageFor(inlineStatus: ConnectionStatus): String =
+        (inlineStatus as? ConnectionStatus.Failed)?.message
+            ?: "Disconnected. Tap Reconnect to retry."
 
-    /** Build the view [ConnectionStatus.Reconnecting], preserving the inline
-     *  reconnect payload (attempt/maxAttempts/retryDelayMs/reason) when the inline
-     *  status is itself a reconnect; otherwise (the approved recoverable-drop
-     *  divergence, where the inline status is `Failed`/`Connected`) a calm default. */
+    /**
+     * Build the view [ConnectionStatus.Reconnecting]. Issue #1328 (S5): the numbered
+     * ladder payload (attempt/maxAttempts/retryDelayMs) comes from the controller's
+     * SINGLE-counter [controllerRecon] when present (the numbered reconnect ladder);
+     * for the pre-numbered silent heal ([controllerRecon] null → controller Reattaching)
+     * a calm attempt-1 default. The human [ConnectionStatus.Reconnecting.reason] string
+     * still rides the inline payload (it is a VM-classified display string, not a
+     * counter — reading it from the inline path does NOT reintroduce a parallel attempt
+     * counter, which is what S5 forbids).
+     */
     private fun reconnectingStatusFor(
+        controllerRecon: ConnectionState.Reconnecting?,
         inlineStatus: ConnectionStatus,
         hpu: HostPortUser,
     ): ConnectionStatus.Reconnecting {
@@ -194,10 +187,10 @@ internal object ConnectionStatusProjection {
             host = hpu.host,
             port = hpu.port,
             user = hpu.user,
-            attempt = inlineReconnect?.attempt ?: 1,
-            maxAttempts = inlineReconnect?.maxAttempts
+            attempt = controllerRecon?.attempt ?: 1,
+            maxAttempts = controllerRecon?.maxAttempts
                 ?: ConnectionController.DEFAULT_MAX_RECONNECT_ATTEMPTS,
-            retryDelayMs = inlineReconnect?.retryDelayMs ?: 0L,
+            retryDelayMs = controllerRecon?.retryDelayMs ?: 0L,
             reason = inlineReconnect?.reason ?: "Reconnecting…",
         )
     }

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelReconnectTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelReconnectTest.kt
@@ -188,6 +188,83 @@ class TmuxSessionViewModelReconnectTest : TmuxSessionViewModelTestBase() {
     }
 
     @Test
+    fun beyondGraceReconnectPreflightClosedTransportRedialsFreshNotUnreachable() = runTest(scheduler) {
+        // Issue #1328 (S5, #1321 §1b) — the BEHAVIORAL red→green (NOT the classifier
+        // proxy). The maintainer's beyond-grace reconnect hit a `transport is closed`
+        // failure: the reused warm lease's SSH transport was silently torn down while
+        // backgrounded, so the reconnect's first dial fails with "transport is closed".
+        // The BROKEN behavior surfaced a hard Unreachable / "Tap Reconnect" on that first
+        // failure. The FIX: a closed transport is TRANSIENT — evict the poisoned lease and
+        // SILENTLY DIAL A FRESH transport, healing the SAME session.
+        //
+        // The load-bearing GREEN assertion is the FRESH SECOND DIAL + recovery to
+        // Connected (NOT a Failed band), and that the FIRST (poisoned) session was evicted.
+        TMUX_CONNECT_ATTEMPTS.set(0)
+        val registry = ActiveTmuxClients()
+        val closedSession = FakeSshSession()
+        val freshSession = FakeSshSession()
+        val connector = QueueLeaseConnector(closedSession, freshSession)
+        val manager = testLeaseManager(connector = connector, scope = this, idleTtlMillis = 60_000L)
+
+        // First client: connect() succeeds but list-panes throws the exact
+        // `transport is closed` shape #1321 hit (the silently-dead backgrounded lease).
+        val closedClient = FakeTmuxClient().apply {
+            closeAndThrowOnCommandPrefix = "list-panes"
+            closeAndThrowException = TmuxClientException(
+                "failed to preflight tmux has-session -t work: transport is closed",
+            )
+        }
+        val freshClient = FakeTmuxClient().withSinglePane("work", "%1")
+
+        val vm = newVm(registry = registry, sshLeaseManager = manager)
+        vm.setTmuxClientFactoryForTest { session, sessionName, _ ->
+            assertEquals("work", sessionName)
+            if (session === closedSession) closedClient else freshClient
+        }
+        vm.setAutoReconnectDelaysForTest(listOf(0L, 0L))
+        val oldClient = FakeTmuxClient()
+        vm.replaceClientForTest(
+            hostId = 1L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            sessionName = "work",
+            client = oldClient,
+        )
+
+        // Trigger the reconnect (a validated network handoff drives the beyond-grace
+        // proactive reconnect through the SAME single ladder the maintainer's reconnect used).
+        registry.lifecycleHooksSnapshot().single().onNetworkChanged(
+            networkChange(reason = "validated-default-network-changed"),
+        )
+        advanceUntilIdle()
+
+        assertEquals(
+            "a `transport is closed` reconnect must dial TWICE: the closed transport, " +
+                "then a FRESH one — never hard-fail on the first (the #1321 break)",
+            2,
+            connector.connectCount,
+        )
+        assertTrue(
+            "the poisoned (closed-transport) SSH session must be evicted, not reused",
+            closedSession.closed,
+        )
+        assertSame(
+            "the SAME session must recover onto the fresh client",
+            freshClient,
+            registry.clients.value[1L]?.client,
+        )
+        val status = vm.connectionStatus.value
+        assertTrue(
+            "a closed-transport reconnect must SILENTLY heal to Connected, not surface " +
+                "a Failed/Unreachable 'Tap Reconnect' band; got $status",
+            status is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+    }
+
+    @Test
     fun lifecycleReattachEvictsConnectedIdleLeaseBeforeReattaching() = runTest(scheduler) {
         val registry = ActiveTmuxClients()
         val staleSession = FakeSshSession()

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionWarmOpenTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionWarmOpenTest.kt
@@ -782,6 +782,85 @@ class TmuxSessionWarmOpenTest {
     }
 
     @Test
+    fun openExistingPreflightClosedTransportEvictsAndReDialsFreshNotUnreachable() = runVmTest {
+        // Issue #1328 (S5, #1321 §1b) — the BEHAVIORAL red→green for the closed-PREFLIGHT
+        // state (NOT the classifier proxy). The maintainer's beyond-grace break: reusing a
+        // warm lease whose SSH transport was SILENTLY torn down while backgrounded, the
+        // `tmux has-session` PREFLIGHT fails with `transport is closed`. The BROKEN
+        // behavior failed OPEN onto that SAME dead pooled lease and hard-`Failed` the
+        // reconnect. The FIX: a closed-transport preflight is TRANSIENT — EVICT the
+        // poisoned lease and SILENTLY DIAL A FRESH transport, healing the same session.
+        //
+        // Load-bearing GREEN assertions: the poisoned session is EVICTED (closed), a
+        // SECOND FRESH transport is dialed, and the tap reaches Connected — never Failed.
+        val poisoned = AlwaysConnectedSession(
+            id = "poisoned",
+            hasSessionThrows = true,
+            hasSessionThrowMessage = "failed to preflight tmux has-session -t work: transport is closed",
+        )
+        val fresh = AlwaysConnectedSession(id = "fresh", hasSessionExitCode = 0)
+        val connector = QueueSessionConnector(poisoned, fresh)
+        val leaseManager =
+            testLeaseManager(connector = connector, scope = this, idleTtlMillis = 60_000L)
+        val registry = ActiveTmuxClients()
+        val signals = SessionLifecycleSignals()
+        val vm = TestNewVm(
+            registry = registry,
+            sshLeaseManager = leaseManager,
+            sessionLifecycleSignals = signals,
+        )
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%1")
+        vm.setTmuxClientFactoryForTest { _, _, _ -> client }
+
+        val staleEvents = mutableListOf<StaleSession>()
+        var staleSubscribed = false
+        val staleCollector = launch {
+            signals.staleSessions
+                .onSubscription { staleSubscribed = true }
+                .collect { staleEvents.add(it) }
+        }
+        testScheduler.runCurrent()
+        assertTrue("stale collector must subscribe before connect", staleSubscribed)
+
+        vm.connect(
+            hostId = 7L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            passphrase = null,
+            sessionName = "work",
+            startDirectory = "/home/alex/git/pocketshell",
+            trigger = TmuxConnectTrigger.OpenExisting,
+        )
+        pumpUntil(reason = "closed-transport preflight evict + fresh re-dial recovers") {
+            vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected
+        }
+        staleCollector.cancel()
+
+        assertTrue(
+            "a closed-transport preflight is TRANSIENT, never a confirmed-gone recreate prompt; " +
+                "got $staleEvents",
+            staleEvents.isEmpty(),
+        )
+        assertTrue(
+            "the poisoned (closed-transport) lease must be EVICTED, not reused",
+            poisoned.closed,
+        )
+        assertTrue(
+            "the reconnect must dial a SECOND, FRESH transport after evicting the poisoned " +
+                "one (connectCount==${connector.connectCount})",
+            connector.connectCount >= 2,
+        )
+        assertTrue(
+            "a closed-transport preflight must SILENTLY heal to Connected, never a Failed " +
+                "'Tap Reconnect' band; got ${vm.connectionStatus.value}",
+            vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+    }
+
+    @Test
     fun explicitUserTapStillCreatesOrAttaches() = runVmTest {
         // The explicit user "new/open session" intent must keep attach-OR-create
         // (createIfMissing=true) so a brand-new session is created as before.
@@ -1590,6 +1669,21 @@ class TmuxSessionWarmOpenTest {
         }
     }
 
+    /** Serves each dial the NEXT session in order (poisoned-then-fresh), so an evict
+     *  + re-dial reaches a genuinely FRESH transport. Reuses the last once exhausted. */
+    private class QueueSessionConnector(
+        private vararg val sessions: SshSession,
+    ) : SshLeaseConnector {
+        var connectCount: Int = 0
+            private set
+
+        override suspend fun connect(target: SshLeaseTarget): Result<SshSession> {
+            val session = sessions.getOrElse(connectCount) { sessions.last() }
+            connectCount += 1
+            return Result.success(session)
+        }
+    }
+
     /**
      * Issue #620: connector whose `connect` parks until [releaseConnect], so a
      * test can hold a warm handshake "in flight" while a session-open tap lands —
@@ -1632,6 +1726,11 @@ class TmuxSessionWarmOpenTest {
         // fail-OPEN branch — a transient error must NOT be treated as confirmed-gone
         // and must NOT raise a recreate prompt.
         private val hasSessionThrows: Boolean = false,
+        // Issue #1328 (S5, #1321 §1b): the exact message a `tmux has-session`
+        // preflight throws when the reused warm lease's SSH transport was silently
+        // torn down while backgrounded ("transport is closed"). Overrides the generic
+        // hiccup message so the closed-transport eviction path can be reproduced.
+        private val hasSessionThrowMessage: String = "has-session probe transport hiccup (transient)",
     ) : SshSession {
         @Volatile
         var closed: Boolean = false
@@ -1645,7 +1744,7 @@ class TmuxSessionWarmOpenTest {
             execCommands.add(command)
             if (command.startsWith("tmux has-session")) {
                 if (hasSessionThrows) {
-                    throw java.io.IOException("has-session probe transport hiccup (transient)")
+                    throw java.io.IOException(hasSessionThrowMessage)
                 }
                 return ExecResult(
                     stdout = "",

--- a/app/src/test/java/com/pocketshell/app/tmux/connection/ConnectionStatusProjectionTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/connection/ConnectionStatusProjectionTest.kt
@@ -189,15 +189,18 @@ class ConnectionStatusProjectionTest {
     // ---------------------------------------------------------------------------
 
     @Test
-    fun reattachingController_withReconnectingInline_preservesReconnectPayload() {
+    fun reattachingController_takesAttemptFromController_reasonFromInline() {
+        // Issue #1328 (S5): the numbered ladder payload (attempt/max/delay) now comes
+        // from the CONTROLLER. Reattaching is the pre-numbered silent heal → calm
+        // attempt-1 default; only the human reason still rides the inline payload.
         assertEquals(
             ConnectionStatus.Reconnecting(
                 host = HOST,
                 port = PORT,
                 user = USER,
-                attempt = 3,
-                maxAttempts = 7,
-                retryDelayMs = 1_500L,
+                attempt = 1,
+                maxAttempts = ConnectionController.DEFAULT_MAX_RECONNECT_ATTEMPTS,
+                retryDelayMs = 0L,
                 reason = "Network changed",
             ),
             project(ConnectionState.Reattaching(host, sid), inlineReconnecting),
@@ -205,18 +208,28 @@ class ConnectionStatusProjectionTest {
     }
 
     @Test
-    fun reconnectingController_withReconnectingInline_preservesReconnectPayload() {
+    fun reconnectingController_takesAttemptFromController_reasonFromInline() {
+        // Issue #1328 (S5) — G6 wrong-source guard: the DISTINCT controller values
+        // (attempt=2, budget=4, backoff=2000ms) differ on EVERY field from the inline
+        // payload (attempt=3, max=7, delay=1500). A wrong-source read (still reading the
+        // inline attempt/max/delay) would fail loudly here — the displayed numbers MUST
+        // come from the CONTROLLER's single counter; only the reason rides the inline path.
         assertEquals(
             ConnectionStatus.Reconnecting(
                 host = HOST,
                 port = PORT,
                 user = USER,
-                attempt = 3,
-                maxAttempts = 7,
-                retryDelayMs = 1_500L,
+                attempt = 2,
+                maxAttempts = 4,
+                retryDelayMs = 2_000L,
                 reason = "Network changed",
             ),
-            project(ConnectionState.Reconnecting(host, sid, attempt = 3), inlineReconnecting),
+            project(
+                ConnectionState.Reconnecting(
+                    host, sid, attempt = 2, maxAttempts = 4, retryDelayMs = 2_000L,
+                ),
+                inlineReconnecting,
+            ),
         )
     }
 
@@ -281,44 +294,45 @@ class ConnectionStatusProjectionTest {
     }
 
     // ---------------------------------------------------------------------------
-    // terminalOrInlineStatus guard — BOTH ways, for Gone AND Unreachable
+    // Terminal controller states → Failed. Issue #1328 (S5): the OVER-EXHAUST
+    // reconcile guard is DELETED — with one ladder the controller's Unreachable IS
+    // authoritative, so it ALWAYS surfaces Failed (never "follow the inline ladder").
     // ---------------------------------------------------------------------------
 
     @Test
-    fun unreachableController_withFailedInline_surfacesFailed_onlyWhenInlineTrulyExhausted() {
-        // The honest error: surface Failed ONLY when the inline ladder is ALSO terminal
-        // (the inline-projected status is Failed). The curated cause message is
-        // preserved (never raw SSH text).
+    fun unreachableController_withFailedInline_surfacesFailed_withCuratedMessage() {
+        // The honest error carries the curated inline cause message (never raw SSH text).
         assertEquals(
             ConnectionStatus.Failed("Host unreachable"),
             project(ConnectionState.Unreachable(host, sid), inlineFailed),
         )
     }
 
+    /**
+     * Issue #1328 (S5) REPRODUCE-FIRST characterization: the projection over-exhaust
+     * guard divergence. On BASE (the deleted guard) a controller `Unreachable` while the
+     * inline ladder was STILL `Reconnecting` projected to a CALM Reconnecting band —
+     * because the controller's own drop-ladder counter could over-exhaust past the
+     * inline ladder (two counters, one exhaustion decision). This test asserts the
+     * SINGLE-ladder truth: an `Unreachable` controller ALWAYS surfaces `Failed`. It FAILS
+     * on base (returns the calm Reconnecting) and PASSES with the guard deleted — the
+     * deletability of that guard is the acceptance signal that ONE ladder remains.
+     */
     @Test
-    fun unreachableController_withReconnectingInline_staysCalmReconnecting_notPrematureFailed() {
-        // The controller's drop-ladder over-exhausted while the inline ladder is STILL
-        // recovering: follow the inline reconnect, NOT a premature scary Failed.
+    fun unreachableController_withReconnectingInline_surfacesFailed_notCalmReconnecting_singleLadder() {
+        val result = project(ConnectionState.Unreachable(host, sid), inlineReconnecting)
         assertEquals(
-            ConnectionStatus.Reconnecting(
-                host = HOST,
-                port = PORT,
-                user = USER,
-                attempt = 3,
-                maxAttempts = 7,
-                retryDelayMs = 1_500L,
-                reason = "Network changed",
-            ),
-            project(ConnectionState.Unreachable(host, sid), inlineReconnecting),
+            ConnectionStatus.Failed("Disconnected. Tap Reconnect to retry."),
+            result,
         )
     }
 
     @Test
-    fun unreachableController_withConnectedInline_followsInline_controllerOverExhausted() {
-        // Inline already recovered (Connected): the controller over-exhausted; follow
-        // the inline truth, not a premature Failed.
+    fun unreachableController_withConnectedInline_surfacesFailed_singleLadder() {
+        // With one ladder the controller cannot be Unreachable while the inline is live;
+        // if that impossible-under-S5 pair is ever projected, the controller wins → Failed.
         assertEquals(
-            inlineConnected,
+            ConnectionStatus.Failed("Disconnected. Tap Reconnect to retry."),
             project(ConnectionState.Unreachable(host, sid), inlineConnected),
         )
     }
@@ -332,25 +346,17 @@ class ConnectionStatusProjectionTest {
     }
 
     @Test
-    fun goneController_withReconnectingInline_staysCalmReconnecting() {
+    fun goneController_withReconnectingInline_surfacesFailed_singleLadder() {
         assertEquals(
-            ConnectionStatus.Reconnecting(
-                host = HOST,
-                port = PORT,
-                user = USER,
-                attempt = 3,
-                maxAttempts = 7,
-                retryDelayMs = 1_500L,
-                reason = "Network changed",
-            ),
+            ConnectionStatus.Failed("Disconnected. Tap Reconnect to retry."),
             project(ConnectionState.Gone(host, sid), inlineReconnecting),
         )
     }
 
     @Test
-    fun goneController_withConnectedInline_followsInline() {
+    fun goneController_withConnectedInline_surfacesFailed_singleLadder() {
         assertEquals(
-            inlineConnected,
+            ConnectionStatus.Failed("Disconnected. Tap Reconnect to retry."),
             project(ConnectionState.Gone(host, sid), inlineConnected),
         )
     }

--- a/shared/core-connection/src/main/java/com/pocketshell/core/connection/ConnectionController.kt
+++ b/shared/core-connection/src/main/java/com/pocketshell/core/connection/ConnectionController.kt
@@ -99,6 +99,33 @@ class ConnectionController(
      */
     private var graceDeadlineMs: Long? = null
 
+    /**
+     * Issue #1328 (S5): the reconnect backoff ladder — the SINGLE source of the
+     * attempt budget ([effectiveMaxAttempts]) and per-attempt backoff
+     * ([retryDelayForAttempt]). Injected by the VM ([ConnectionManager.setReconnectLadder])
+     * from its `autoReconnectDelaysMs`, so the controller's ladder and the VM effect's
+     * backoff timing are ONE ladder, not two. Empty (the default until the VM sets it,
+     * and in the many controller unit tests) means "flat: [maxReconnectAttempts]
+     * attempts, 0 ms delay" — byte-identical to the pre-S5 counter.
+     *
+     * A plain `var` mutated only from the confining dispatcher (via [setReconnectLadder]),
+     * same single-confining-dispatcher contract as [graceDeadlineMs].
+     */
+    private var reconnectLadderMs: List<Long> = emptyList()
+
+    /**
+     * Issue #1328 (S5): the SINGLE reconnect-attempt counter. It lives HERE, in the
+     * controller, decoupled from the transient [ConnectionState] — because the VM's
+     * re-dial IO walks the state through Connecting/Attaching/Live on every rung
+     * (even one that then fails an attach), which would otherwise reset an in-state
+     * counter. 0 means "no ladder in flight"; a ladder arms it to 1
+     * ([ConnectionEvent.ReconnectLadderEntered] / a heal-failed drop) and each failed
+     * rung ([ConnectionEvent.ReconnectFailed]) advances it until the budget exhausts.
+     * A plain `var` mutated only from the confining dispatcher (same contract as
+     * [graceDeadlineMs]).
+     */
+    private var reconnectAttempt: Int = 0
+
     /** Current target id — the drop-by-id reference for events and seeds. */
     private val currentTargetId: SessionId?
         get() = _state.value.targetIdOrNull()
@@ -142,6 +169,51 @@ class ConnectionController(
         _seeds.tryEmit(seed)
     }
 
+    /**
+     * Issue #1328 (S5): install the reconnect backoff ladder (from the VM's
+     * `autoReconnectDelaysMs`). The ladder size is the attempt budget and each
+     * entry the per-attempt backoff, so the controller's SINGLE counter/exhaustion
+     * decision uses the exact same ladder the VM effect times its dials against.
+     *
+     * A confined mutator (shares the single-dispatcher contract with [submit]).
+     */
+    fun setReconnectLadder(delaysMs: List<Long>) = confinement.guarded("setReconnectLadder") {
+        reconnectLadderMs = delaysMs
+        // If a reconnect is already in flight when the ladder is (re)installed — the
+        // proactive network-handoff / passive-drop paths enter [ConnectionState.Reconnecting]
+        // BEFORE the VM effect installs its `autoReconnectDelaysMs` — re-stamp the current
+        // attempt's maxAttempts/retryDelayMs from the new ladder so the SINGLE displayed
+        // ladder reflects the real backoff, not the stale flat default (issue #1328).
+        val current = _state.value
+        if (current is ConnectionState.Reconnecting) {
+            _state.value = reconnectingAt(current.host, current.targetId, current.attempt)
+        }
+    }
+
+    /** The attempt budget for the current ladder — the ONE exhaustion boundary. */
+    private val effectiveMaxAttempts: Int
+        get() = reconnectLadderMs.size.takeIf { it > 0 } ?: maxReconnectAttempts
+
+    /** Backoff before the 1-based [attempt]'s dial; clamps to the last ladder step. */
+    private fun retryDelayForAttempt(attempt: Int): Long {
+        if (reconnectLadderMs.isEmpty()) return 0L
+        val index = (attempt - 1).coerceIn(0, reconnectLadderMs.lastIndex)
+        return reconnectLadderMs[index]
+    }
+
+    /** Build a [ConnectionState.Reconnecting] for [attempt] from the single ladder,
+     *  syncing the churn-surviving [reconnectAttempt] counter to it. */
+    private fun reconnectingAt(host: HostKey, target: SessionId, attempt: Int): ConnectionState.Reconnecting {
+        reconnectAttempt = attempt
+        return ConnectionState.Reconnecting(
+            host = host,
+            targetId = target,
+            attempt = attempt,
+            maxAttempts = effectiveMaxAttempts,
+            retryDelayMs = retryDelayForAttempt(attempt),
+        )
+    }
+
     private fun reduce(current: ConnectionState, event: ConnectionEvent): ConnectionState =
         when (event) {
             is ConnectionEvent.Enter -> onEnter(current, event)
@@ -155,6 +227,9 @@ class ConnectionController(
             ConnectionEvent.NetworkRestored -> current
             is ConnectionEvent.TargetGone -> onTargetGone(current, event)
             is ConnectionEvent.SeedLanded -> onSeedLanded(current, event)
+            ConnectionEvent.ReconnectLadderEntered -> onReconnectLadderEntered(current)
+            ConnectionEvent.ReconnectFailed -> onReconnectFailed(current)
+            ConnectionEvent.ReconnectGaveUp -> onReconnectGaveUp(current)
         }
 
     /**
@@ -164,8 +239,9 @@ class ConnectionController(
      */
     private fun onEnter(current: ConnectionState, event: ConnectionEvent.Enter): ConnectionState {
         // A genuine open clears any prior grace window — we are foregrounded and
-        // re-targeting.
+        // re-targeting. It also disarms any stale reconnect counter (#1328).
         graceDeadlineMs = null
+        reconnectAttempt = 0
         return if (transport.isWarm(event.host)) {
             ConnectionState.Attaching(event.host, event.targetId)
         } else {
@@ -182,6 +258,7 @@ class ConnectionController(
     private fun onSwitch(current: ConnectionState, event: ConnectionEvent.Switch): ConnectionState {
         val host = current.hostOrNull() ?: return current
         graceDeadlineMs = null
+        reconnectAttempt = 0
         return ConnectionState.Attaching(host, event.targetId)
     }
 
@@ -223,7 +300,7 @@ class ConnectionController(
         return if (withinGrace) {
             ConnectionState.Reattaching(current.host, current.targetId)
         } else {
-            ConnectionState.Reconnecting(current.host, current.targetId, attempt = 1)
+            reconnectingAt(current.host, current.targetId, attempt = 1)
         }
     }
 
@@ -246,17 +323,22 @@ class ConnectionController(
             -> ConnectionState.Reattaching(host, target)
 
             is ConnectionState.Reattaching ->
-                // The silent heal failed once; start the silent reconnect ladder.
-                ConnectionState.Reconnecting(host, target, attempt = 1)
+                // The silent heal failed once; start (or, if a re-dial churn briefly
+                // dropped an in-flight ladder back through Reattaching, RESUME at) the
+                // silent reconnect ladder. Preserving [reconnectAttempt] here keeps the
+                // SINGLE counter churn-safe (#1328).
+                reconnectingAt(host, target, attempt = if (reconnectAttempt > 0) reconnectAttempt else 1)
 
-            is ConnectionState.Reconnecting -> {
-                val nextAttempt = current.attempt + 1
-                if (nextAttempt > maxReconnectAttempts) {
-                    ConnectionState.Unreachable(host, target)
-                } else {
-                    ConnectionState.Reconnecting(host, target, attempt = nextAttempt)
-                }
-            }
+            is ConnectionState.Reconnecting ->
+                // Issue #1328 (S5): a raw transport drop while ALREADY in the numbered
+                // ladder does NOT advance the counter. The reconnect effect's re-dial IO
+                // legitimately closes/evicts the transport on every rung (force-fresh
+                // lease, poisoned-half-open evict), which flips the drop oracle — counting
+                // those incidental churn drops would exhaust the ladder before the rung's
+                // real dial even resolves (fatal on a 1-rung ladder). Advancement is owned
+                // SOLELY by [ConnectionEvent.ReconnectFailed], reported once per real rung
+                // failure by the effect. So hold the current attempt here (idempotent).
+                current
 
             // Backgrounded/Idle/Gone/Unreachable: a drop is irrelevant.
             else -> current
@@ -293,11 +375,85 @@ class ConnectionController(
         if (!event.validatedHandoff) return current
         return when (current) {
             is ConnectionState.Live ->
-                ConnectionState.Reconnecting(current.host, current.targetId, attempt = 1)
+                reconnectingAt(current.host, current.targetId, attempt = 1)
             // Connecting/Attaching/Reattaching/Reconnecting already have a
             // dial/heal in flight; Backgrounded/Idle/Gone/Unreachable have no live
             // channel to proactively replace. Suppress in all of them.
             else -> current
+        }
+    }
+
+    /**
+     * Issue #1328 (S5): the reconnect effect gave up early (a non-retryable failure
+     * or explicit abort). Surface the honest [ConnectionState.Unreachable] from any
+     * live-ish / recovering state. Idempotent on an already-terminal state, and a
+     * no-op with no live channel (Idle/Backgrounded/NetworkLossSuspended). This is
+     * NOT the exhaustion path — the reducer decides exhaustion itself in
+     * [onTransportDropped]; this is the VM's honest "stop retrying" signal.
+     */
+    private fun onReconnectGaveUp(current: ConnectionState): ConnectionState {
+        val host = current.hostOrNull() ?: return current
+        val target = current.targetIdOrNull() ?: return current
+        return when (current) {
+            is ConnectionState.Live,
+            is ConnectionState.Connecting,
+            is ConnectionState.Attaching,
+            is ConnectionState.Reattaching,
+            is ConnectionState.Reconnecting,
+            -> {
+                reconnectAttempt = 0
+                ConnectionState.Unreachable(host, target)
+            }
+            // Idle/Backgrounded/NetworkLossSuspended/Gone/Unreachable: nothing to fail.
+            else -> current
+        }
+    }
+
+    /**
+     * Issue #1328 (S5): the VM effect entered its numbered reconnect ladder. Arm the
+     * SINGLE counter at attempt 1 and move any live-ish / recovering state to
+     * [ConnectionState.Reconnecting] attempt 1. A no-op from Idle/Gone/Unreachable
+     * (there is no channel to reconnect).
+     */
+    private fun onReconnectLadderEntered(current: ConnectionState): ConnectionState {
+        val host = current.hostOrNull() ?: return current
+        val target = current.targetIdOrNull() ?: return current
+        return when (current) {
+            is ConnectionState.Idle,
+            is ConnectionState.Gone,
+            is ConnectionState.Unreachable,
+            -> current
+            else -> reconnectingAt(host, target, attempt = 1)
+        }
+    }
+
+    /**
+     * Issue #1328 (S5): one reconnect rung's real dial failed retryably. Advance the
+     * SINGLE churn-surviving counter and re-assert [ConnectionState.Reconnecting] at
+     * the new attempt — REGARDLESS of the transient state the failed dial churned to
+     * (Reattaching/Live/Attaching/Connecting) — or, once past the ladder budget,
+     * decide exhaustion here → [ConnectionState.Unreachable]. This is the ONLY place
+     * the VM effect advances the ladder; it never counts its own.
+     */
+    private fun onReconnectFailed(current: ConnectionState): ConnectionState {
+        val host = current.hostOrNull() ?: return current
+        val target = current.targetIdOrNull() ?: return current
+        return when (current) {
+            is ConnectionState.Idle,
+            is ConnectionState.Gone,
+            is ConnectionState.Unreachable,
+            is ConnectionState.Backgrounded,
+            is ConnectionState.NetworkLossSuspended,
+            -> current
+            else -> {
+                val nextAttempt = (if (reconnectAttempt > 0) reconnectAttempt else 1) + 1
+                if (nextAttempt > effectiveMaxAttempts) {
+                    reconnectAttempt = 0
+                    ConnectionState.Unreachable(host, target)
+                } else {
+                    reconnectingAt(host, target, attempt = nextAttempt)
+                }
+            }
         }
     }
 

--- a/shared/core-connection/src/main/java/com/pocketshell/core/connection/ConnectionModel.kt
+++ b/shared/core-connection/src/main/java/com/pocketshell/core/connection/ConnectionModel.kt
@@ -138,6 +138,42 @@ sealed interface ConnectionEvent {
 
     /** A capture completed for ([targetId], [paneId]) — feeds the reseed gate. */
     data class SeedLanded(val targetId: SessionId, val paneId: String) : ConnectionEvent
+
+    /**
+     * The VM reconnect effect ENTERED its numbered ladder (attempt 1). The reducer
+     * arms the SINGLE churn-surviving reconnect counter and moves any live-ish /
+     * recovering state to [ConnectionState.Reconnecting] attempt 1 (issue #1328, S5).
+     *
+     * A dedicated intent (not a raw drop) so the effect's re-dial IO — which
+     * transiently walks the controller through Connecting/Attaching/Live before an
+     * attach may still fail — cannot reset the counter: the count lives in the
+     * controller, decoupled from the transient [ConnectionState] the dial churns.
+     */
+    data object ReconnectLadderEntered : ConnectionEvent
+
+    /**
+     * One reconnect ladder RUNG's real dial failed (retryably). The reducer advances
+     * the SINGLE churn-surviving counter and re-asserts [ConnectionState.Reconnecting]
+     * at the new attempt — REGARDLESS of the transient state the just-failed dial left
+     * behind (Reattaching/Live/Attaching) — or, once the counter passes the ladder
+     * budget, decides exhaustion itself → [ConnectionState.Unreachable] (issue #1328).
+     * The VM never counts a parallel ladder; it only reports "this rung failed".
+     */
+    data object ReconnectFailed : ConnectionEvent
+
+    /**
+     * The reconnect effect GAVE UP early — a non-retryable failure (bad auth,
+     * unknown host, missing key) that waiting/retrying cannot fix (#440), or an
+     * explicit abort. The reducer surfaces the honest [ConnectionState.Unreachable]
+     * from any live-ish / recovering state.
+     *
+     * This is DISTINCT from ladder EXHAUSTION: when the reconnect budget runs out,
+     * the reducer decides that itself — a [TransportDropped] that pushes
+     * [ConnectionState.Reconnecting.attempt] past `maxAttempts` transitions to
+     * [ConnectionState.Unreachable] (issue #1328, S5 single-ladder). The VM effect
+     * never counts attempts; it only feeds honest drops and this abort signal.
+     */
+    data object ReconnectGaveUp : ConnectionEvent
 }
 
 /**
@@ -197,11 +233,21 @@ sealed interface ConnectionState {
     /**
      * Beyond grace / heal exhausted: silent auto-reconnect + reseed. Brief
      * loading only, NO manual "Tap Reconnect".
+     *
+     * Issue #1328 (S5): this is the SINGLE reconnect-attempt counter and the SINGLE
+     * exhaustion point. [attempt] is the 1-based attempt number, [maxAttempts] the
+     * ladder budget (from the injected [ConnectionController.setReconnectLadder]),
+     * and [retryDelayMs] the backoff the VM effect waits before this attempt's dial.
+     * The reducer owns every increment and the `attempt > maxAttempts → Unreachable`
+     * decision; the VM never counts a parallel ladder. [maxAttempts]/[retryDelayMs]
+     * default to the flat pre-S5 shape so the many 3-arg test call sites keep working.
      */
     data class Reconnecting(
         val host: HostKey,
         val targetId: SessionId,
         val attempt: Int,
+        val maxAttempts: Int = ConnectionController.DEFAULT_MAX_RECONNECT_ATTEMPTS,
+        val retryDelayMs: Long = 0L,
     ) : ConnectionState
 
     /**

--- a/shared/core-connection/src/test/java/com/pocketshell/core/connection/ConnectionControllerCoverageFirstTest.kt
+++ b/shared/core-connection/src/test/java/com/pocketshell/core/connection/ConnectionControllerCoverageFirstTest.kt
@@ -144,19 +144,19 @@ class ConnectionControllerCoverageFirstTest {
         assertEquals(ConnectionState.Reattaching(host, a), controller.state.value)
 
         controller.submit(ConnectionEvent.TransportDropped("drop 2"))
-        assertEquals(ConnectionState.Reconnecting(host, a, attempt = 1), controller.state.value)
+        assertEquals(ConnectionState.Reconnecting(host, a, attempt = 1, maxAttempts = 3), controller.state.value)
         assertEquals(a, controller.state.value.targetIdOrNull())
 
         controller.submit(ConnectionEvent.SeedLanded(b, "%1"))
         controller.submit(ConnectionEvent.TargetGone(b))
         assertEquals(
             "late events for B must not corrupt or switch the recovery target",
-            ConnectionState.Reconnecting(host, a, attempt = 1),
+            ConnectionState.Reconnecting(host, a, attempt = 1, maxAttempts = 3),
             controller.state.value,
         )
 
-        controller.submit(ConnectionEvent.TransportDropped("drop 3"))
-        assertEquals(ConnectionState.Reconnecting(host, a, attempt = 2), controller.state.value)
+        controller.submit(ConnectionEvent.ReconnectFailed)
+        assertEquals(ConnectionState.Reconnecting(host, a, attempt = 2, maxAttempts = 3), controller.state.value)
         assertEquals(a, controller.state.value.targetIdOrNull())
 
         controller.submit(ConnectionEvent.TransportLive)
@@ -179,14 +179,14 @@ class ConnectionControllerCoverageFirstTest {
 
         // Heal failed -> silent reconnect ladder (attempt 1).
         controller.submit(ConnectionEvent.TransportDropped("drop 2"))
-        assertEquals(ConnectionState.Reconnecting(host, a, attempt = 1), controller.state.value)
+        assertEquals(ConnectionState.Reconnecting(host, a, attempt = 1, maxAttempts = 2), controller.state.value)
 
-        // attempt 2 (still silent — no band).
-        controller.submit(ConnectionEvent.TransportDropped("drop 3"))
-        assertEquals(ConnectionState.Reconnecting(host, a, attempt = 2), controller.state.value)
+        // attempt 2 (still silent — no band). #1328: ReconnectFailed advances the ladder.
+        controller.submit(ConnectionEvent.ReconnectFailed)
+        assertEquals(ConnectionState.Reconnecting(host, a, attempt = 2, maxAttempts = 2), controller.state.value)
 
         // Budget exhausted -> the ONLY honest error band.
-        controller.submit(ConnectionEvent.TransportDropped("drop 4"))
+        controller.submit(ConnectionEvent.ReconnectFailed)
         assertEquals(ConnectionState.Unreachable(host, a), controller.state.value)
     }
 }

--- a/shared/core-connection/src/test/java/com/pocketshell/core/connection/ConnectionControllerReconnectLadderTest.kt
+++ b/shared/core-connection/src/test/java/com/pocketshell/core/connection/ConnectionControllerReconnectLadderTest.kt
@@ -1,0 +1,155 @@
+package com.pocketshell.core.connection
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1328 (S5) — the SINGLE reconnect ladder now lives entirely in the
+ * [ConnectionController] reducer: one attempt counter, one exhaustion point, the
+ * per-attempt backoff read straight off the injected ladder. These pure-JVM
+ * virtual-clock tests pin that:
+ *
+ *  1. An injected ladder sets [ConnectionState.Reconnecting.maxAttempts] to the
+ *     ladder size and [retryDelayMs] to each ladder step (clamped to the last).
+ *  2. Exhaustion is decided ONCE, in the reducer: a [ConnectionEvent.TransportDropped]
+ *     that pushes `attempt` past `maxAttempts` transitions to [ConnectionState.Unreachable].
+ *  3. The honest [ConnectionEvent.ReconnectGaveUp] abort surfaces [Unreachable] from
+ *     any live-ish / recovering state, and is a no-op with no live channel.
+ *
+ * The VM effect (`TmuxSessionViewModel.scheduleAutoReconnectBody`) reads the attempt /
+ * delay off this state and feeds honest drops; it never counts a parallel ladder.
+ */
+class ConnectionControllerReconnectLadderTest {
+
+    private val host = HostKey("alice@host:22")
+    private val a = SessionId("A")
+
+    private fun controller(ladder: List<Long> = emptyList()): Pair<ConnectionController, FakeTransportPort> {
+        val transport = FakeTransportPort()
+        val c = ConnectionController(FakeClock(), transport)
+        if (ladder.isNotEmpty()) c.setReconnectLadder(ladder)
+        return c to transport
+    }
+
+    /** Live -> Reattaching -> Reconnecting(1): enter the numbered ladder. */
+    private fun ConnectionController.bringToReconnecting(transport: FakeTransportPort) {
+        transport.setWarm(host, false)
+        submit(ConnectionEvent.Enter(host, a))
+        transport.setWarm(host, true)
+        submit(ConnectionEvent.TransportLive)
+        submit(ConnectionEvent.SeedLanded(a, "%0")) // Live
+        submit(ConnectionEvent.TransportDropped("d")) // Live -> Reattaching
+        submit(ConnectionEvent.TransportDropped("d")) // Reattaching -> Reconnecting(1)
+    }
+
+    @Test
+    fun `injected ladder drives maxAttempts and per-attempt retry delay`() {
+        val (c, transport) = controller(ladder = listOf(0L, 1_000L, 2_000L, 5_000L))
+        c.bringToReconnecting(transport)
+
+        assertEquals(
+            ConnectionState.Reconnecting(host, a, attempt = 1, maxAttempts = 4, retryDelayMs = 0L),
+            c.state.value,
+        )
+        // Advancement is EXCLUSIVELY ReconnectFailed (one per real rung failure).
+        c.submit(ConnectionEvent.ReconnectFailed)
+        assertEquals(
+            ConnectionState.Reconnecting(host, a, attempt = 2, maxAttempts = 4, retryDelayMs = 1_000L),
+            c.state.value,
+        )
+        c.submit(ConnectionEvent.ReconnectFailed)
+        assertEquals(
+            ConnectionState.Reconnecting(host, a, attempt = 3, maxAttempts = 4, retryDelayMs = 2_000L),
+            c.state.value,
+        )
+        c.submit(ConnectionEvent.ReconnectFailed)
+        assertEquals(
+            ConnectionState.Reconnecting(host, a, attempt = 4, maxAttempts = 4, retryDelayMs = 5_000L),
+            c.state.value,
+        )
+    }
+
+    @Test
+    fun `a raw transport drop while Reconnecting does NOT advance the ladder`() {
+        // Issue #1328: incidental re-dial churn drops must not count — only ReconnectFailed
+        // advances. Otherwise a 1-rung ladder would exhaust before its dial resolves.
+        val (c, transport) = controller(ladder = listOf(0L, 0L, 0L))
+        c.bringToReconnecting(transport)
+        assertEquals(1, (c.state.value as ConnectionState.Reconnecting).attempt)
+        c.submit(ConnectionEvent.TransportDropped("incidental churn"))
+        c.submit(ConnectionEvent.TransportDropped("incidental churn"))
+        assertEquals(
+            "raw drops while already Reconnecting hold the attempt (loop owns advancement)",
+            1,
+            (c.state.value as ConnectionState.Reconnecting).attempt,
+        )
+    }
+
+    @Test
+    fun `exhaustion is decided once in the reducer at the ladder budget`() {
+        val (c, transport) = controller(ladder = listOf(0L, 0L)) // budget 2
+        c.bringToReconnecting(transport)
+
+        assertEquals(1, (c.state.value as ConnectionState.Reconnecting).attempt)
+        c.submit(ConnectionEvent.ReconnectFailed) // -> attempt 2
+        assertEquals(2, (c.state.value as ConnectionState.Reconnecting).attempt)
+        c.submit(ConnectionEvent.ReconnectFailed) // 3 > 2 -> exhausted
+        assertEquals(ConnectionState.Unreachable(host, a), c.state.value)
+    }
+
+    @Test
+    fun `retry delay clamps to the last ladder step past the budget`() {
+        // A 1-step ladder: every attempt reuses the single step's delay.
+        val (c, transport) = controller(ladder = listOf(750L))
+        c.bringToReconnecting(transport)
+        assertEquals(
+            ConnectionState.Reconnecting(host, a, attempt = 1, maxAttempts = 1, retryDelayMs = 750L),
+            c.state.value,
+        )
+        // attempt 2 > budget 1 -> exhausted (no over-run of the ladder).
+        c.submit(ConnectionEvent.ReconnectFailed)
+        assertEquals(ConnectionState.Unreachable(host, a), c.state.value)
+    }
+
+    @Test
+    fun `empty ladder falls back to the flat default budget with zero delay`() {
+        val (c, transport) = controller(ladder = emptyList())
+        c.bringToReconnecting(transport)
+        val recon = c.state.value as ConnectionState.Reconnecting
+        assertEquals(1, recon.attempt)
+        assertEquals(ConnectionController.DEFAULT_MAX_RECONNECT_ATTEMPTS, recon.maxAttempts)
+        assertEquals(0L, recon.retryDelayMs)
+    }
+
+    @Test
+    fun `ReconnectGaveUp surfaces Unreachable from the reconnect ladder before exhaustion`() {
+        val (c, transport) = controller(ladder = listOf(0L, 0L, 0L, 0L))
+        c.bringToReconnecting(transport)
+        assertTrue(c.state.value is ConnectionState.Reconnecting)
+        // A non-retryable failure aborts the ladder early — honest, reducer-owned.
+        c.submit(ConnectionEvent.ReconnectGaveUp)
+        assertEquals(ConnectionState.Unreachable(host, a), c.state.value)
+    }
+
+    @Test
+    fun `ReconnectGaveUp aborts a live channel too`() {
+        val (c, transport) = controller()
+        transport.setWarm(host, false)
+        c.submit(ConnectionEvent.Enter(host, a))
+        transport.setWarm(host, true)
+        c.submit(ConnectionEvent.TransportLive)
+        c.submit(ConnectionEvent.SeedLanded(a, "%0"))
+        assertTrue(c.state.value is ConnectionState.Live)
+        c.submit(ConnectionEvent.ReconnectGaveUp)
+        assertEquals(ConnectionState.Unreachable(host, a), c.state.value)
+    }
+
+    @Test
+    fun `ReconnectGaveUp is a no-op with no live channel`() {
+        val (c, _) = controller()
+        assertTrue(c.state.value is ConnectionState.Idle)
+        c.submit(ConnectionEvent.ReconnectGaveUp)
+        assertEquals(ConnectionState.Idle, c.state.value)
+    }
+}

--- a/shared/core-connection/src/test/java/com/pocketshell/core/connection/ConnectionControllerTest.kt
+++ b/shared/core-connection/src/test/java/com/pocketshell/core/connection/ConnectionControllerTest.kt
@@ -260,13 +260,15 @@ class ConnectionControllerTest {
         assertEquals(ConnectionState.Reattaching(host, a), controller.state.value)
 
         controller.submit(ConnectionEvent.TransportDropped("d2"))
-        assertEquals(ConnectionState.Reconnecting(host, a, attempt = 1), controller.state.value)
+        assertEquals(ConnectionState.Reconnecting(host, a, attempt = 1, maxAttempts = 2), controller.state.value)
 
-        controller.submit(ConnectionEvent.TransportDropped("d3"))
-        assertEquals(ConnectionState.Reconnecting(host, a, attempt = 2), controller.state.value)
+        // Issue #1328 (S5): within the numbered ladder, advancement is the effect's
+        // ReconnectFailed (one per real rung failure) — raw drops no longer escalate.
+        controller.submit(ConnectionEvent.ReconnectFailed)
+        assertEquals(ConnectionState.Reconnecting(host, a, attempt = 2, maxAttempts = 2), controller.state.value)
 
         // Exhausts the budget -> the ONLY honest error.
-        controller.submit(ConnectionEvent.TransportDropped("d4"))
+        controller.submit(ConnectionEvent.ReconnectFailed)
         assertEquals(ConnectionState.Unreachable(host, a), controller.state.value)
     }
 

--- a/shared/core-connection/src/test/java/com/pocketshell/core/connection/FailureReasonTest.kt
+++ b/shared/core-connection/src/test/java/com/pocketshell/core/connection/FailureReasonTest.kt
@@ -51,11 +51,15 @@ class FailureReasonTest {
     }
 
     @Test
-    fun closedTransportPreflightDefaultsToRetryableUnreachable_1321Repro() {
-        // The #1321 leak: a `TmuxClientException: failed to preflight tmux has-session
-        // ... transport is closed`. It has none of the non-retryable signatures, so it
-        // classifies to the CALM, retryable Unreachable — the "Tap Reconnect" state,
-        // never a scary raw exception surfaced to the UI.
+    fun closedTransportClassifiesToRetryableUnreachable() {
+        // CLASSIFICATION ONLY: a `transport is closed` preflight error has none of the
+        // non-retryable signatures, so it classifies to the CALM, retryable Unreachable
+        // (never a scary raw exception). NOTE: this is a pure classifier assertion — the
+        // load-bearing #1321 BEHAVIOR (a beyond-grace reconnect preflight that hits a
+        // closed transport SILENTLY DIALS A FRESH TRANSPORT rather than surfacing
+        // Unreachable) is proven end-to-end by
+        // `TmuxSessionViewModelReconnectTest.beyondGraceReconnectPreflightClosedTransportRedialsFreshNotUnreachable`
+        // (issue #1328 S5), NOT here.
         val closedTransport = IOException("failed to preflight tmux has-session -t work: transport is closed")
         val reason = classifyFailure(closedTransport)
         assertEquals(FailureReason.Unreachable(retryable = true), reason)


### PR DESCRIPTION
Roadmap slice **S5** of the connection state-machine consolidation (#1331), D28. Supersedes PR #1453 (rebased onto current `main` + the file-size hygiene fix).

## Change
Collapses the two parallel reconnect ladders onto `ConnectionController.Reconnecting` as the single counter + exhaustion point; VM `scheduleAutoReconnectBody` becomes a pure effect body (`reconnectRungFailed()`); **deletes** the projection over-exhaust guard; folds in the #1321 §1b closed-preflight fresh-dial fix; fixes two latent bugs the guard masked. The per-rung diagnostic emission is extracted to a sibling `ReconnectLadderDiagnostics.kt` (byte-identical `PsTmuxReconnect` trail) to keep `TmuxSessionViewModel.kt` under its file-size hygiene baseline (#1047 split).

## Verification
Reviewer drove both reproduce-first red→green defects (over-exhaust divergence + #1321 closed-preflight redial — real redial behavior, G6), the full #638 emulator+Docker journeys (SshReconnect, StaleLeaseSwitch/toxiproxy, CleanOutage, BackgroundGrace within-grace-unchanged, ServerDeath no-resurrect), `:shared:core-ssh:integrationTest` 37/0. Focused re-review confirmed the diagnostic extraction is a provable pure move. All three Unit-job hygiene guards pass locally (VM 906780 B < baseline; ratchet G-A/B/C within baseline).

Closes #1328