### PR TITLE
release: human update-check failure message + retry transient TLS blips (#1456)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/release/ReleaseChecker.kt
+++ b/app/src/main/java/com/pocketshell/app/release/ReleaseChecker.kt
@@ -2,10 +2,16 @@ package com.pocketshell.app.release
 
 import android.util.Log
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import org.json.JSONObject
 import java.net.HttpURLConnection
+import java.net.SocketException
+import java.net.SocketTimeoutException
 import java.net.URL
+import java.net.UnknownHostException
+import java.security.GeneralSecurityException
+import javax.net.ssl.SSLException
 
 /**
  * Metadata about a GitHub Release that PocketShell can offer the user as
@@ -77,12 +83,19 @@ sealed interface ReleaseCheckResult {
  */
 open class ReleaseChecker(
     private val latestReleaseUrl: String = API_URL,
+    /**
+     * Backoff before the single auto-retry of a transient network/TLS blip
+     * (issue #1456). Injectable so unit tests can drive the retry path with
+     * zero wall-clock cost.
+     */
+    private val retryBackoffMs: Long = RETRY_BACKOFF_MS,
 ) {
     companion object {
         private const val REPO = "alexeygrigorev/pocketshell"
         private const val API_URL = "https://api.github.com/repos/$REPO/releases/latest"
         private const val USER_AGENT = "pocketshell"
         private const val TIMEOUT_MS = 10_000
+        private const val RETRY_BACKOFF_MS = 400L
         private const val TAG = "PsReleaseCheck"
     }
 
@@ -107,54 +120,153 @@ open class ReleaseChecker(
     open suspend fun checkForUpdate(currentVersion: String): ReleaseCheckResult =
         withContext(Dispatchers.IO) {
             try {
-                val conn = (URL(latestReleaseUrl).openConnection() as HttpURLConnection).apply {
-                    connectTimeout = TIMEOUT_MS
-                    readTimeout = TIMEOUT_MS
-                    setRequestProperty("Accept", "application/vnd.github+json")
-                    setRequestProperty("User-Agent", USER_AGENT)
-                }
-
-                // A single `disconnect()` in the finally releases the socket no
-                // matter which branch runs (or throws). Without it the keep-alive
-                // socket leaks — repeated cold-launch polls pile up half-open
-                // connections. The input/error streams are additionally closed
-                // (via `use`) so the body is drained; on a non-200 (the common
-                // GitHub 403 rate-limit) an unread + unclosed `errorStream`
-                // otherwise leaks the connection back-pressure too.
-                try {
-                    val code = conn.responseCode
-                    if (code != 200) {
-                        // GitHub returns 403 with a rate-limit body for
-                        // unauthenticated bursts — the single most likely cause
-                        // of "the banner never showed at cold launch". Naming the
-                        // code makes that diagnosable. Drain + close the error
-                        // stream so the socket is reusable rather than leaked.
-                        conn.errorStream?.use { runCatching { it.readBytes() } }
-                        val reason = "GitHub returned HTTP $code"
-                        Log.w(TAG, "release check failed: $reason (current=$currentVersion)")
-                        ReleaseCheckResult.Failed(reason)
-                    } else {
-                        val body = conn.inputStream.bufferedReader().use { it.readText() }
-                        when (val outcome = parseReleaseOutcome(body, currentVersion)) {
-                            is ParsedReleaseOutcome.UpdateAvailable ->
-                                ReleaseCheckResult.UpdateAvailable(outcome.info)
-                            ParsedReleaseOutcome.UpToDate ->
-                                ReleaseCheckResult.UpToDate
-                            is ParsedReleaseOutcome.Failed -> {
-                                Log.w(TAG, "release check failed: ${outcome.reason} (current=$currentVersion)")
-                                ReleaseCheckResult.Failed(outcome.reason)
-                            }
-                        }
-                    }
-                } finally {
-                    conn.disconnect()
-                }
+                // A returned non-200 (e.g. the GitHub 403 rate-limit) never throws
+                // — it comes back as a [ReleaseCheckResult.Failed] here and is NOT
+                // retried (issue #1456: don't hammer GitHub on a rate-limit).
+                fetchRelease(currentVersion)
             } catch (e: Exception) {
-                val reason = "${e.javaClass.simpleName}: ${e.message ?: "no message"}"
-                Log.w(TAG, "release check failed: $reason (current=$currentVersion)", e)
-                ReleaseCheckResult.Failed(reason)
+                // Issue #1456: the raw exception chain (e.g. the cryptic conscrypt
+                // `SocketException: NoSuchAlgorithmException ... DefaultSSLContextImpl`)
+                // stays in logcat for diagnosis, but the user only ever sees the
+                // classified human category — never a class name or stack.
+                val failure = classifyFailure(e)
+                Log.w(
+                    TAG,
+                    "release check failed: ${e.javaClass.simpleName}: ${e.message ?: "no message"} " +
+                        "-> \"${failure.message}\" (transient=${failure.transient}, current=$currentVersion)",
+                    e,
+                )
+                if (failure.transient) {
+                    // The conscrypt SSLContext-construction failure and other
+                    // transient network/TLS blips commonly succeed on a fresh
+                    // connection. Retry ONCE before surfacing the banner; only a
+                    // both-attempts-failed result nags the user (issue #515's
+                    // visible-failure contract is preserved for a persistent fault).
+                    delay(retryBackoffMs)
+                    try {
+                        fetchRelease(currentVersion)
+                    } catch (retry: Exception) {
+                        val retryFailure = classifyFailure(retry)
+                        Log.w(
+                            TAG,
+                            "release check retry failed: ${retry.javaClass.simpleName}: " +
+                                "${retry.message ?: "no message"} -> \"${retryFailure.message}\" " +
+                                "(current=$currentVersion)",
+                            retry,
+                        )
+                        ReleaseCheckResult.Failed(retryFailure.message)
+                    }
+                } else {
+                    ReleaseCheckResult.Failed(failure.message)
+                }
             }
         }
+
+    /**
+     * One network attempt against the GitHub Releases API. Returns the outcome
+     * for the non-throwing cases (update / up-to-date / non-200 / unparseable
+     * body) and lets a genuine network/TLS exception PROPAGATE so
+     * [checkForUpdate] can classify + retry it (issue #1456).
+     *
+     * `internal open` so unit tests can subclass and inject a throw-then-succeed
+     * sequence to exercise the auto-retry orchestration without real sockets.
+     */
+    internal open fun fetchRelease(currentVersion: String): ReleaseCheckResult {
+        val conn = (URL(latestReleaseUrl).openConnection() as HttpURLConnection).apply {
+            connectTimeout = TIMEOUT_MS
+            readTimeout = TIMEOUT_MS
+            setRequestProperty("Accept", "application/vnd.github+json")
+            setRequestProperty("User-Agent", USER_AGENT)
+        }
+
+        // A single `disconnect()` in the finally releases the socket no
+        // matter which branch runs (or throws). Without it the keep-alive
+        // socket leaks — repeated cold-launch polls pile up half-open
+        // connections. The input/error streams are additionally closed
+        // (via `use`) so the body is drained; on a non-200 (the common
+        // GitHub 403 rate-limit) an unread + unclosed `errorStream`
+        // otherwise leaks the connection back-pressure too.
+        return try {
+            val code = conn.responseCode
+            if (code != 200) {
+                // GitHub returns 403 with a rate-limit body for unauthenticated
+                // bursts — the single most likely cause of "the banner never
+                // showed at cold launch". Drain + close the error stream so the
+                // socket is reusable rather than leaked. The concrete code is
+                // logged; the user sees a human category (issue #1456).
+                conn.errorStream?.use { runCatching { it.readBytes() } }
+                val userReason = if (code == HttpURLConnection.HTTP_FORBIDDEN) {
+                    "rate-limited, try again later"
+                } else {
+                    "server error (HTTP $code)"
+                }
+                Log.w(TAG, "release check failed: GitHub returned HTTP $code (current=$currentVersion)")
+                ReleaseCheckResult.Failed(userReason)
+            } else {
+                val body = conn.inputStream.bufferedReader().use { it.readText() }
+                when (val outcome = parseReleaseOutcome(body, currentVersion)) {
+                    is ParsedReleaseOutcome.UpdateAvailable ->
+                        ReleaseCheckResult.UpdateAvailable(outcome.info)
+                    ParsedReleaseOutcome.UpToDate ->
+                        ReleaseCheckResult.UpToDate
+                    is ParsedReleaseOutcome.Failed -> {
+                        Log.w(TAG, "release check failed: ${outcome.reason} (current=$currentVersion)")
+                        ReleaseCheckResult.Failed(outcome.reason)
+                    }
+                }
+            }
+        } finally {
+            conn.disconnect()
+        }
+    }
+
+    /**
+     * Maps a caught network/TLS exception to a short, human-readable banner
+     * category and whether it is worth an automatic retry (issue #1456). The
+     * user NEVER sees the class name or `message`; the raw exception stays in
+     * logcat. The whole cause chain is inspected because conscrypt surfaces its
+     * default-`SSLContext` construction failure as a plain [SocketException]
+     * *caused by* a `NoSuchAlgorithmException` mentioning `DefaultSSLContextImpl`.
+     */
+    internal fun classifyFailure(e: Throwable): FailureClassification {
+        var cause: Throwable? = e
+        val seen = HashSet<Throwable>()
+        while (cause != null && seen.add(cause)) {
+            when (cause) {
+                // A connect/read timeout — a transient slow-network blip.
+                is SocketTimeoutException ->
+                    return FailureClassification("timed out", transient = true)
+                // DNS/connectivity failure: retrying immediately won't help.
+                is UnknownHostException ->
+                    return FailureClassification("no network connection", transient = false)
+                // TLS handshake / SSLContext construction faults (incl. the
+                // conscrypt NoSuchAlgorithmException, a GeneralSecurityException)
+                // are the classic transient case this fix heals.
+                is SSLException, is GeneralSecurityException ->
+                    return FailureClassification("connection problem", transient = true)
+                // Covers ConnectException / the conscrypt-wrapped SocketException.
+                is SocketException ->
+                    return FailureClassification("connection problem", transient = true)
+            }
+            val message = cause.message ?: ""
+            if (message.contains("DefaultSSLContextImpl") || message.contains("NoSuchAlgorithmException")) {
+                return FailureClassification("connection problem", transient = true)
+            }
+            cause = cause.cause
+        }
+        // Anything unclassified: show a generic connection category and do NOT
+        // retry blindly (avoid hammering on an unknown persistent fault).
+        return FailureClassification("connection problem", transient = false)
+    }
+
+    /**
+     * The user-facing banner category ([message]) plus whether [checkForUpdate]
+     * should auto-retry once before surfacing it ([transient]). Issue #1456.
+     */
+    internal data class FailureClassification(
+        val message: String,
+        val transient: Boolean,
+    )
 
     internal fun parseRelease(body: String, currentVersion: String): ReleaseInfo? =
         (parseReleaseOutcome(body, currentVersion) as? ParsedReleaseOutcome.UpdateAvailable)?.info

--- a/app/src/test/java/com/pocketshell/app/release/ReleaseCheckerFailureClassificationTest.kt
+++ b/app/src/test/java/com/pocketshell/app/release/ReleaseCheckerFailureClassificationTest.kt
@@ -1,0 +1,244 @@
+package com.pocketshell.app.release
+
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowLog
+import java.net.InetAddress
+import java.net.ServerSocket
+import java.net.SocketException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
+import java.security.NoSuchAlgorithmException
+import java.util.concurrent.atomic.AtomicInteger
+import javax.net.ssl.SSLHandshakeException
+
+/**
+ * Issue #1456: the update-check banner used to dump the raw exception chain
+ * (the cryptic conscrypt
+ * `SocketException: NoSuchAlgorithmException ... DefaultSSLContextImpl$TLSv13`),
+ * and a transient TLS/network blip nagged the user with no self-heal. This
+ * suite proves:
+ *
+ *  1. every failure category maps to a short HUMAN banner reason — never the
+ *     raw `simpleName: message` (the maintainer's reported symptom);
+ *  2. the raw exception is still preserved in logcat for diagnosis;
+ *  3. a transient failure that succeeds on the 2nd attempt self-heals (no
+ *     banner), while a both-attempts-failed result still surfaces the human
+ *     banner (issue #515's visible-failure contract);
+ *  4. the GitHub 403 rate-limit path does NOT auto-retry.
+ *
+ * Robolectric supplies the Android runtime so `android.util.Log` resolves and
+ * [ShadowLog] can assert the raw detail is still logged.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class ReleaseCheckerFailureClassificationTest {
+
+    @Before
+    fun setUp() {
+        ShadowLog.clear()
+    }
+
+    /** The exact conscrypt exception the maintainer saw on-device (issue #1456). */
+    private fun conscryptSocketException(): SocketException =
+        SocketException(
+            "java.security.NoSuchAlgorithmException: Error constructing implementation " +
+                "(algorithm: Default, provider: AndroidOpenSSL, " +
+                "class: com.android.org.conscrypt.DefaultSSLContextImpl\$TLSv13)",
+        ).apply {
+            initCause(
+                NoSuchAlgorithmException(
+                    "Error constructing implementation (algorithm: Default, provider: " +
+                        "AndroidOpenSSL, class: com.android.org.conscrypt.DefaultSSLContextImpl\$TLSv13)",
+                ),
+            )
+        }
+
+    // ---------------------------------------------------------------------
+    // Red -> green: the reported conscrypt symptom, on the REAL public surface.
+    // ---------------------------------------------------------------------
+
+    /**
+     * RED on base, GREEN with the fix — WITHOUT any new symbol so the reviewer
+     * can run it against the unmodified `ReleaseChecker`. A connect to a closed
+     * local port throws a `ConnectException` (a [SocketException], same category
+     * as the conscrypt fault). Base builds the banner reason as
+     * `"ConnectException: Connection refused"`; the fix classifies it to the
+     * human "connection problem".
+     */
+    @Test
+    fun realNetworkFailure_surfacesHumanReason_notRawExceptionDump() = runBlocking {
+        val closedPort = ServerSocket(0, 1, InetAddress.getByName("127.0.0.1")).use { it.localPort }
+        // Socket closed above -> the port now refuses connections.
+        val checker = ReleaseChecker(latestReleaseUrl = "http://127.0.0.1:$closedPort/")
+
+        val result = checker.checkForUpdate("0.1.0")
+
+        assertTrue("expected a Failed result", result is ReleaseCheckResult.Failed)
+        val reason = (result as ReleaseCheckResult.Failed).reason
+        assertEquals("connection problem", reason)
+        // The user must NEVER see a class name or raw message.
+        assertFalse("banner leaked an exception class name: $reason", reason.contains("Exception"))
+        assertFalse("banner leaked a raw exception message: $reason", reason.contains("Connection refused"))
+    }
+
+    /**
+     * The exact conscrypt `SocketException(cause=NoSuchAlgorithmException ...
+     * DefaultSSLContextImpl)` injected into the real [ReleaseChecker.checkForUpdate]
+     * path via the [ReleaseChecker.fetchRelease] seam. The banner reason is the
+     * human category, and the raw chain survives in logcat.
+     */
+    @Test
+    fun conscryptException_throughCheckForUpdate_isHuman_andRawStillLogged() = runBlocking {
+        val checker = object : ReleaseChecker(retryBackoffMs = 0) {
+            override fun fetchRelease(currentVersion: String): ReleaseCheckResult =
+                throw conscryptSocketException()
+        }
+
+        val result = checker.checkForUpdate("0.1.0")
+
+        assertTrue(result is ReleaseCheckResult.Failed)
+        val reason = (result as ReleaseCheckResult.Failed).reason
+        assertEquals("connection problem", reason)
+        assertFalse(reason.contains("SocketException"))
+        assertFalse(reason.contains("NoSuchAlgorithmException"))
+        assertFalse(reason.contains("DefaultSSLContextImpl"))
+
+        // Criterion: the full raw detail is NOT lost — it is still logged.
+        val logs = ShadowLog.getLogs().filter { it.tag == "PsReleaseCheck" }
+        assertTrue("expected a diagnostic log entry", logs.isNotEmpty())
+        assertTrue(
+            "raw conscrypt detail must remain in logcat",
+            logs.any { it.msg.contains("DefaultSSLContextImpl") || it.msg.contains("SocketException") },
+        )
+        // The throwable itself is attached to the log for the full stack.
+        assertTrue(
+            "the raw throwable must be attached to a log entry",
+            logs.any { it.throwable != null },
+        )
+    }
+
+    // ---------------------------------------------------------------------
+    // Class coverage (G2): every category -> its human message + transient flag.
+    // ---------------------------------------------------------------------
+
+    private val checker = ReleaseChecker()
+
+    @Test
+    fun classify_conscryptSocketException_isConnectionProblem_transient() {
+        val c = checker.classifyFailure(conscryptSocketException())
+        assertEquals("connection problem", c.message)
+        assertTrue("conscrypt TLS-construction blip must be retried", c.transient)
+    }
+
+    @Test
+    fun classify_rawNoSuchAlgorithm_isConnectionProblem_transient() {
+        val c = checker.classifyFailure(
+            NoSuchAlgorithmException("Error constructing implementation ... DefaultSSLContextImpl"),
+        )
+        assertEquals("connection problem", c.message)
+        assertTrue(c.transient)
+    }
+
+    @Test
+    fun classify_sslException_isConnectionProblem_transient() {
+        val c = checker.classifyFailure(SSLHandshakeException("handshake failed"))
+        assertEquals("connection problem", c.message)
+        assertTrue(c.transient)
+    }
+
+    @Test
+    fun classify_plainSocketException_isConnectionProblem_transient() {
+        val c = checker.classifyFailure(SocketException("Connection reset"))
+        assertEquals("connection problem", c.message)
+        assertTrue(c.transient)
+    }
+
+    @Test
+    fun classify_timeout_isTimedOut_transient() {
+        val c = checker.classifyFailure(SocketTimeoutException("connect timed out"))
+        assertEquals("timed out", c.message)
+        assertTrue(c.transient)
+    }
+
+    @Test
+    fun classify_unknownHost_isNoNetwork_notTransient() {
+        val c = checker.classifyFailure(UnknownHostException("api.github.com"))
+        assertEquals("no network connection", c.message)
+        assertFalse("a DNS/connectivity failure must NOT auto-retry", c.transient)
+    }
+
+    @Test
+    fun classify_unclassifiedException_isConnectionProblem_notTransient() {
+        val c = checker.classifyFailure(IllegalStateException("boom"))
+        assertEquals("connection problem", c.message)
+        assertFalse(c.transient)
+    }
+
+    // ---------------------------------------------------------------------
+    // Auto-retry orchestration (issue #1456 + #515 contract).
+    // ---------------------------------------------------------------------
+
+    @Test
+    fun transientFailure_healsOnSecondAttempt_noBanner() = runBlocking {
+        val calls = AtomicInteger(0)
+        val checker = object : ReleaseChecker(retryBackoffMs = 0) {
+            override fun fetchRelease(currentVersion: String): ReleaseCheckResult {
+                return if (calls.incrementAndGet() == 1) {
+                    throw conscryptSocketException()
+                } else {
+                    ReleaseCheckResult.UpToDate
+                }
+            }
+        }
+
+        val result = checker.checkForUpdate("0.1.0")
+
+        assertEquals("the transient blip must self-heal", ReleaseCheckResult.UpToDate, result)
+        assertEquals("must have retried exactly once", 2, calls.get())
+    }
+
+    @Test
+    fun transientFailure_bothAttemptsFail_surfacesHumanBanner() = runBlocking {
+        val calls = AtomicInteger(0)
+        val checker = object : ReleaseChecker(retryBackoffMs = 0) {
+            override fun fetchRelease(currentVersion: String): ReleaseCheckResult {
+                calls.incrementAndGet()
+                throw conscryptSocketException()
+            }
+        }
+
+        val result = checker.checkForUpdate("0.1.0")
+
+        // Issue #515: a genuine, persistent failure IS still surfaced.
+        assertTrue(result is ReleaseCheckResult.Failed)
+        assertEquals("connection problem", (result as ReleaseCheckResult.Failed).reason)
+        assertEquals("must have made exactly two attempts", 2, calls.get())
+    }
+
+    @Test
+    fun rateLimit403_isNotRetried() = runBlocking {
+        val calls = AtomicInteger(0)
+        val checker = object : ReleaseChecker(retryBackoffMs = 0) {
+            override fun fetchRelease(currentVersion: String): ReleaseCheckResult {
+                calls.incrementAndGet()
+                // A 403 comes back as a returned Failed (not thrown), so the
+                // orchestration must NOT retry it.
+                return ReleaseCheckResult.Failed("rate-limited, try again later")
+            }
+        }
+
+        val result = checker.checkForUpdate("0.1.0")
+
+        assertTrue(result is ReleaseCheckResult.Failed)
+        assertEquals("rate-limited, try again later", (result as ReleaseCheckResult.Failed).reason)
+        assertEquals("403 rate-limit must be a single attempt (no hammering)", 1, calls.get())
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/release/ReleaseCheckerNetworkTest.kt
+++ b/app/src/test/java/com/pocketshell/app/release/ReleaseCheckerNetworkTest.kt
@@ -87,12 +87,32 @@ class ReleaseCheckerNetworkTest {
         repeat(10) {
             val result = checker.checkForUpdate("0.1.0")
             assertTrue("expected a Failed result on 403", result is ReleaseCheckResult.Failed)
+            // Issue #1456: the user sees a human category, never the raw
+            // "GitHub returned HTTP 403". A 403 rate-limit is NOT auto-retried
+            // (see requestCount assertion below), so exactly one request per poll.
             assertEquals(
-                "GitHub returned HTTP 403",
+                "rate-limited, try again later",
                 (result as ReleaseCheckResult.Failed).reason,
             )
         }
-        assertEquals("every poll must reach the server", 10, requestCount.get())
+        // 10 polls -> exactly 10 requests proves the 403 rate-limit path does
+        // NOT auto-retry (issue #1456: don't hammer GitHub).
+        assertEquals("every poll must reach the server exactly once (403 not retried)", 10, requestCount.get())
+    }
+
+    @Test
+    fun serverError500_surfacesHumanReason_andIsNotRetried() = runBlocking {
+        // A non-403 non-200 (e.g. a GitHub 5xx) maps to a human "server error"
+        // banner naming the code, and — like 403 — is a returned Failed, not a
+        // thrown exception, so it is NOT auto-retried (issue #1456).
+        startServer(500, "Internal Server Error", """{"message":"oops"}""")
+        val checker = ReleaseChecker(latestReleaseUrl = url())
+
+        val result = checker.checkForUpdate("0.1.0")
+
+        assertTrue("expected a Failed result on 500", result is ReleaseCheckResult.Failed)
+        assertEquals("server error (HTTP 500)", (result as ReleaseCheckResult.Failed).reason)
+        assertEquals("a non-200 must be a single attempt (not retried)", 1, requestCount.get())
     }
 
     @Test


### PR DESCRIPTION
Fixes the maintainer-reported Hosts-screen banner (2026-07-10) that dumped a raw conscrypt exception chain and didn't retry a transient TLS blip.

## Fix
- `ReleaseChecker.classifyFailure()` walks the whole cause chain (conscrypt surfaces as `SocketException` **caused by** `NoSuchAlgorithmException …DefaultSSLContextImpl$TLSv13`) → short human category. Raw detail stays in logcat; the user never sees a class name / message / stack.
- `checkForUpdate` → one attempt in `fetchRelease()`; a transient exception (SSL/socket/timeout) retries **once** before surfacing anything. A 403 rate-limit (returned `Failed`, not thrown) is never retried. Both-attempts-fail still shows the human banner (#515 preserved).

## Verification
Reviewer independently drove the **exact conscrypt cause-chain** red→green (the maintainer's precise string fails on base → 'connection problem' with the fix), proved retry counts (transient=2, 403=1, 500=1), confirmed no class-name leak + raw still logged. 34 release + 66 HostListViewModel tests green, 0 skipped. Root-cause spike (on #1456) confirmed this is a transient platform flake (no app FD/socket leak) — so retry is the complete fix.

Closes #1456