### PR TITLE
composer: de-flake attachment-wedge test via injectable sidecar-store IO dispatcher (#1461)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/composer/OutboundAttachmentSidecarStore.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/OutboundAttachmentSidecarStore.kt
@@ -9,6 +9,7 @@ import com.pocketshell.app.prefs.DeferredPrefs
 import com.pocketshell.app.share.FilenameSanitiser
 import com.pocketshell.app.share.ShareUploader
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
@@ -42,29 +43,40 @@ class OutboundAttachmentSidecarStore @Inject constructor(
     internal var idGenerator: () -> String = { UUID.randomUUID().toString() }
     internal var clock: () -> Long = { System.currentTimeMillis() }
 
+    // Issue #1461: the IO dispatcher these blocking file/prefs methods hop onto,
+    // injectable so a `runTest` unit test can confine the hop to its
+    // `testScheduler`. Without this seam the `withContext(Dispatchers.IO)` below
+    // resumes its caller — a `viewModelScope.launch {}` on the test's unconfined
+    // Main — from a REAL IO worker thread, and that background→unconfined-Main
+    // resume calls `UnconfinedTestDispatcher.dispatch`, which throws
+    // ("can only be used by the yield function"), a coroutines-test thread-race
+    // that flaked `PromptComposerAttachmentWedgeTest`. Defaults to
+    // `Dispatchers.IO`, so production behaviour is unchanged.
+    internal var ioDispatcher: CoroutineDispatcher = Dispatchers.IO
+
     suspend fun stage(
         outboundItemId: String,
         uris: List<Uri>,
         attachmentIndices: List<Int> = emptyList(),
-    ): List<LocalAttachmentSidecarRef> = withContext(Dispatchers.IO) {
+    ): List<LocalAttachmentSidecarRef> = withContext(ioDispatcher) {
         if (outboundItemId.isBlank() || uris.isEmpty()) return@withContext emptyList()
         uris.mapIndexedNotNull { index, uri ->
             stageOne(outboundItemId, uri, attachmentIndices.getOrNull(index))
         }
     }
 
-    suspend fun refsFor(outboundItemId: String): List<LocalAttachmentSidecarRef> = withContext(Dispatchers.IO) {
+    suspend fun refsFor(outboundItemId: String): List<LocalAttachmentSidecarRef> = withContext(ioDispatcher) {
         refsForBlocking(outboundItemId)
     }
 
-    suspend fun removeOutboundItem(outboundItemId: String) = withContext(Dispatchers.IO) {
+    suspend fun removeOutboundItem(outboundItemId: String) = withContext(ioDispatcher) {
         refsForBlocking(outboundItemId).forEach { ref -> runCatching { File(ref.localPath).delete() } }
         val remaining = allRefsBlocking().filterNot { it.outboundItemId == outboundItemId }
         persistAll(remaining)
         runCatching { File(rootDir(), outboundItemId).deleteRecursively() }
     }
 
-    suspend fun remove(refId: String) = withContext(Dispatchers.IO) {
+    suspend fun remove(refId: String) = withContext(ioDispatcher) {
         val refs = allRefsBlocking()
         refs.firstOrNull { it.id == refId }?.let { ref ->
             runCatching { File(ref.localPath).delete() }
@@ -72,7 +84,7 @@ class OutboundAttachmentSidecarStore @Inject constructor(
         persistAll(refs.filterNot { it.id == refId })
     }
 
-    suspend fun reconcile() = withContext(Dispatchers.IO) {
+    suspend fun reconcile() = withContext(ioDispatcher) {
         val liveRefs = allRefsBlocking().filter { File(it.localPath).exists() }
         persistAll(liveRefs)
         val livePaths = liveRefs.mapTo(mutableSetOf()) { File(it.localPath).absolutePath }

--- a/app/src/test/java/com/pocketshell/app/composer/PromptComposerAttachmentWedgeTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/PromptComposerAttachmentWedgeTest.kt
@@ -114,6 +114,7 @@ class PromptComposerAttachmentWedgeTest {
     }
 
     private fun newSidecarStore(
+        ioDispatcher: TestDispatcher,
         context: Context = ApplicationProvider.getApplicationContext(),
     ): OutboundAttachmentSidecarStore {
         context.getSharedPreferences(OutboundAttachmentSidecarStore.PREFS_NAME, Context.MODE_PRIVATE)
@@ -125,6 +126,12 @@ class PromptComposerAttachmentWedgeTest {
         return OutboundAttachmentSidecarStore(context).also { store ->
             store.idGenerator = { "sidecar-${++nextId}" }
             store.clock = { nextId.toLong() }
+            // Issue #1461: confine the store's file/prefs IO hop to the same
+            // `testScheduler` the VM's sampler/outbound-queue dispatchers use, so
+            // no coroutine on the send path resumes on a real IO worker and then
+            // dispatches back onto the unconfined test-Main — the thread-race that
+            // flaked the `_shellPane` variant.
+            store.ioDispatcher = ioDispatcher
         }
     }
 
@@ -222,9 +229,10 @@ class PromptComposerAttachmentWedgeTest {
     @Test
     fun attachmentDropMidUploadDoesNotWedgeSubsequentPlainSend_shellPane() = runTest {
         val queue = InMemoryOutboundQueueStore()
-        val sidecars = newSidecarStore()
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val sidecars = newSidecarStore(ioDispatcher = dispatcher)
         val vm = newVm(
-            samplerDispatcher = StandardTestDispatcher(testScheduler),
+            samplerDispatcher = dispatcher,
             outboundQueueStore = queue,
             outboundAttachmentSidecarStore = sidecars,
         )
@@ -244,9 +252,10 @@ class PromptComposerAttachmentWedgeTest {
     @Test
     fun attachmentDropMidUploadDoesNotWedgeSubsequentPlainSend_agentPane() = runTest {
         val queue = InMemoryOutboundQueueStore()
-        val sidecars = newSidecarStore()
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val sidecars = newSidecarStore(ioDispatcher = dispatcher)
         val vm = newVm(
-            samplerDispatcher = StandardTestDispatcher(testScheduler),
+            samplerDispatcher = dispatcher,
             outboundQueueStore = queue,
             outboundAttachmentSidecarStore = sidecars,
         )
@@ -268,9 +277,10 @@ class PromptComposerAttachmentWedgeTest {
     @Test
     fun attachmentUploadTimeoutDoesNotWedgeSubsequentPlainSend() = runTest {
         val queue = InMemoryOutboundQueueStore()
-        val sidecars = newSidecarStore()
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val sidecars = newSidecarStore(ioDispatcher = dispatcher)
         val vm = newVm(
-            samplerDispatcher = StandardTestDispatcher(testScheduler),
+            samplerDispatcher = dispatcher,
             outboundQueueStore = queue,
             outboundAttachmentSidecarStore = sidecars,
         )
@@ -293,9 +303,10 @@ class PromptComposerAttachmentWedgeTest {
         val queue = object : InMemoryOutboundQueueStore() {
             override fun claim(id: String): OutboundItem? = null
         }
-        val sidecars = newSidecarStore()
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val sidecars = newSidecarStore(ioDispatcher = dispatcher)
         val vm = newVm(
-            samplerDispatcher = StandardTestDispatcher(testScheduler),
+            samplerDispatcher = dispatcher,
             outboundQueueStore = queue,
             outboundAttachmentSidecarStore = sidecars,
         )
@@ -317,9 +328,10 @@ class PromptComposerAttachmentWedgeTest {
         val queue = object : InMemoryOutboundQueueStore() {
             override fun markUploading(id: String, lastAttemptAtMs: Long): OutboundItem? = null
         }
-        val sidecars = newSidecarStore()
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val sidecars = newSidecarStore(ioDispatcher = dispatcher)
         val vm = newVm(
-            samplerDispatcher = StandardTestDispatcher(testScheduler),
+            samplerDispatcher = dispatcher,
             outboundQueueStore = queue,
             outboundAttachmentSidecarStore = sidecars,
         )
@@ -339,9 +351,10 @@ class PromptComposerAttachmentWedgeTest {
     @Test
     fun successfulAttachmentSendThenPlainSendBothReachSession() = runTest {
         val queue = InMemoryOutboundQueueStore()
-        val sidecars = newSidecarStore()
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val sidecars = newSidecarStore(ioDispatcher = dispatcher)
         val vm = newVm(
-            samplerDispatcher = StandardTestDispatcher(testScheduler),
+            samplerDispatcher = dispatcher,
             outboundQueueStore = queue,
             outboundAttachmentSidecarStore = sidecars,
         )


### PR DESCRIPTION
Fixes the confirmed-flaky `PromptComposerAttachmentWedgeTest._shellPane` that turned the **v0.4.25 release gate** red at the JVM `:app:testReleaseUnitTest` stage.

## Root cause
`OutboundAttachmentSidecarStore` hardcoded `withContext(Dispatchers.IO)` in its 5 suspend methods. Invoked from a bare `viewModelScope.launch { store.removeOutboundItem(id) }` on `runTest`'s unconfined test-Main, the IO hop resumed the caller from a real `LimitedDispatcher` worker; that background→unconfined-Main resume calls `UnconfinedTestDispatcher.dispatch`, which throws (`can only be used by the yield function`) — a coroutines-test thread-race (~1-in-3).

## Fix
Injectable `ioDispatcher` seam on the store (defaults to `Dispatchers.IO` → **production behaviour unchanged**), confined to the test's `StandardTestDispatcher(testScheduler)` in the test.

## Evidence (D33/G5)
- Implementer: RED reproduced at run 19/40; **120/120 green** with the fix.
- Reviewer (independent): RED reproduced at run 55; **110/110 green**; `:app:testReleaseUnitTest` BUILD SUCCESSFUL; APPROVED.
- 2 files (composer store + composer test); no `TmuxSessionViewModel.kt`/VM touched; file-size hygiene OK.

Closes #1461