### PR TITLE
test(composer): fix stale cancel-recording selectors after #1245 + strengthen to containment (#1463)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerCancelRecordingTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerCancelRecordingTest.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.pocketshell.app.proof.signals.assertNodeFullyWithinRoot
 import com.pocketshell.uikit.theme.PocketShellTheme
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -130,7 +131,14 @@ class PromptComposerCancelRecordingTest {
 
         // Idle: no Cancel; the mic trigger + (disabled) Send are shown.
         compose.onNodeWithTag(COMPOSER_CANCEL_RECORDING_TAG).assertDoesNotExist()
-        compose.onNodeWithContentDescription("Start dictation. Swipe up to lock recording")
+        // Issue #1245 (#357aeaa6) removed the hands-free recording Lock — both the
+        // pill and the swipe-up-to-lock gesture — so the mic disc's content
+        // description was shortened from "Start dictation. Swipe up to lock
+        // recording" to just "Start dictation". This assertion tracks the CURRENT
+        // description; asserting the removed swipe-up copy made this whole test
+        // fail with a misleading "component is not displayed" (a not-found node)
+        // and blocked the v0.4.25 release gate (#1463).
+        compose.onNodeWithContentDescription("Start dictation")
             .assertIsDisplayed()
 
         // Recording: explicit Discard is visible inside the recording panel,
@@ -144,7 +152,13 @@ class PromptComposerCancelRecordingTest {
                 liveTranscript = "android partial words",
             )
         }
-        compose.onNodeWithTag(COMPOSER_CANCEL_RECORDING_TAG).assertIsDisplayed()
+        // Issue #1463 / #657 F2-F3: assert viewport CONTAINMENT, not a bare
+        // assertIsDisplayed(). "displayed" is satisfied by layout participation, so
+        // a Discard pushed off the right edge of the balanced [Discard · Insert ·
+        // Send] action row (e.g. a future width regression at font scale) would
+        // still report "displayed" while the user cannot reach it. Containment
+        // catches that — the exact off-screen/clipped class this issue feared.
+        compose.assertNodeFullyWithinRoot(COMPOSER_CANCEL_RECORDING_TAG)
         compose.onNodeWithContentDescription("Discard recording without transcribing").assertIsDisplayed()
         val discardBounds = compose.onNodeWithTag(COMPOSER_CANCEL_RECORDING_TAG)
             .getUnclippedBoundsInRoot()
@@ -152,6 +166,10 @@ class PromptComposerCancelRecordingTest {
             "Discard recording touch target must be at least 48dp tall",
             discardBounds.bottom - discardBounds.top >= 48.dp,
         )
+        // The sibling recording controls (Insert / Send / timer / live transcript)
+        // stay intact and reachable alongside Discard.
+        compose.assertNodeFullyWithinRoot(COMPOSER_TO_FIELD_TAG)
+        compose.assertNodeFullyWithinRoot(COMPOSER_STOP_SEND_TAG)
         compose.onNodeWithTag(COMPOSER_TO_FIELD_TAG).assertIsDisplayed()
         compose.onNodeWithTag(COMPOSER_STOP_SEND_TAG).assertIsDisplayed()
         compose.onNodeWithTag(COMPOSER_TIMER_TAG).assertIsDisplayed()


### PR DESCRIPTION
v0.4.25 release-gate blocker. The gate-failing assertion was a **stale test selector**, not a product bug: #1245 (`357aeaa6`) removed the recording lock and shortened the mic description to `Start dictation`; the idle assertion still hunted the old `Start dictation. Swipe up to lock recording` → not-found → 'component is not displayed'. Production is correct (Discard fully within bounds). Fix corrects the selector and **strengthens** the Recording-state Discard check to `assertNodeFullyWithinRoot` containment (#657 F2/F3). Test-only; reviewer APPROVED (resolved the on-call misattribution; base line 134 = idle mic, discard is line 147 never reached). Emulator re-verification is the release gate r3. Closes #1463