### PR TITLE
conversation: render Codex transcripts against a stale host CLI (version-skew fallback) (#1467)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/session/AgentConversationRepository.kt
+++ b/app/src/main/java/com/pocketshell/app/session/AgentConversationRepository.kt
@@ -1658,32 +1658,51 @@ public class AgentConversationRepository internal constructor(
         // same exec is what lets the cold-open path drop the standalone
         // `lineCount` round-trip without losing the tail-start position.
         val sentinel = "@@PS_CODEX_WINDOW@@"
-        // Issue #1267: byte-bound the Codex cold-open read the same way #1225
-        // bounded the Claude flat-JSONL tail. The Codex read goes through
-        // `pocketshell agent-log`, so the clamp lives there (`--max-line-bytes`):
-        // a multi-MB rollout line (inline base64 image / huge tool_result) is
-        // replaced server-side by a compact truncation marker, so its bytes never
-        // cross SSH into the phone's heap. The marker is rendered as a visible
-        // note by [parseTranscriptTailLines] below.
-        val output = session.exec(
+        // Issue #1267: byte-bound the Codex read the same way #1225 bounded the
+        // Claude flat-JSONL tail — the clamp lives in `pocketshell agent-log`
+        // (`--max-line-bytes`). Issue #1467: retry ONCE without the clamp when the
+        // clamped read yields no envelope, so an OLDER host CLI that rejects
+        // `--max-line-bytes` (→ empty stdout behind `2>/dev/null || true`) does
+        // not silently blank the paged Codex window (see [readCodexAgentLogEnvelope]).
+        fun windowCommand(clampBytes: Int?): String =
             "wc -l < ${shellQuote(detection.sourcePath)} 2>/dev/null || printf 0; " +
                 "printf '%s\\n' $sentinel; " +
-                "pocketshell agent-log --engine codex --session ${shellQuote(sessionId)} " +
-                "--json --tail $boundedMaxLines --max-line-bytes $MAX_TRANSCRIPT_LINE_BYTES 2>/dev/null || true",
-        ).stdout
-        val splitLines = output.split("\n")
-        val sentinelIndex = splitLines.indexOf(sentinel)
-        val sourceLineCount = if (sentinelIndex >= 0) {
-            splitLines.take(sentinelIndex).joinToString("").trim().toLongOrNull() ?: 0L
-        } else {
-            0L
+                codexAgentLogCommand(sessionId, boundedMaxLines, clampBytes)
+
+        fun splitWindow(output: String): Pair<Long, String> {
+            val splitLines = output.split("\n")
+            val sentinelIndex = splitLines.indexOf(sentinel)
+            val sourceLineCount = if (sentinelIndex >= 0) {
+                splitLines.take(sentinelIndex).joinToString("").trim().toLongOrNull() ?: 0L
+            } else {
+                0L
+            }
+            val envelopeOutput = if (sentinelIndex >= 0) {
+                splitLines.drop(sentinelIndex + 1).joinToString("\n")
+            } else {
+                output
+            }
+            return sourceLineCount to envelopeOutput
         }
-        val envelopeOutput = if (sentinelIndex >= 0) {
-            splitLines.drop(sentinelIndex + 1).joinToString("\n")
-        } else {
-            output
+
+        var (sourceLineCount, envelopeOutput) = splitWindow(session.exec(windowCommand(MAX_TRANSCRIPT_LINE_BYTES)).stdout)
+        var envelope = agentLogEnvelopeOrNull(envelopeOutput)
+        if (envelope == null) {
+            val (plainCount, plainEnvelopeOutput) = splitWindow(session.exec(windowCommand(clampBytes = null)).stdout)
+            sourceLineCount = plainCount
+            envelopeOutput = plainEnvelopeOutput
+            envelope = agentLogEnvelopeOrNull(plainEnvelopeOutput)
         }
-        val lines = parseAgentLogEnvelopeLines(envelopeOutput)
+        if (envelope == null) {
+            if (envelopeOutput.isNotBlank()) {
+                diagnostic(
+                    "agent-log output had non-blank lines but no JSON envelope carrying " +
+                        "`lines` (preamble/format drift) — returning no messages",
+                )
+            }
+            return CodexWindow(emptyList(), 0, sourceLineCount)
+        }
+        val lines = agentLogEnvelopeLines(envelope)
         // Issue #1267: route the envelope lines through the truncation-aware
         // parser so an over-cap line (clamped to a marker by `--max-line-bytes`)
         // becomes a VISIBLE SystemNote instead of a line the CodexParser silently
@@ -2044,16 +2063,54 @@ public class AgentConversationRepository internal constructor(
         val boundedMaxLines = (maxLines * JSONL_RAW_LINES_PER_EVENT)
             .coerceAtLeast(maxLines)
             .coerceAtLeast(1)
-        // Issue #1267: byte-bound the Codex cold-open read via the tool-side
-        // `--max-line-bytes` clamp (the Codex counterpart of #1225's Claude
-        // flat-JSONL clamp), then render any resulting truncation marker as a
-        // visible note through [parseTranscriptTailLines].
-        val output = session.exec(
-            "pocketshell agent-log --engine codex --session ${shellQuote(sessionId)} " +
-                "--json --tail $boundedMaxLines --max-line-bytes $MAX_TRANSCRIPT_LINE_BYTES 2>/dev/null || true",
+        val envelope = readCodexAgentLogEnvelope(session, sessionId, boundedMaxLines) ?: return emptyList()
+        // Issue #1267: route the envelope lines through the truncation-aware
+        // parser so an over-cap line (clamped to a marker by `--max-line-bytes`)
+        // becomes a VISIBLE SystemNote instead of a line the CodexParser silently
+        // drops.
+        return parseTranscriptTailLines(
+            CodexParser(),
+            AgentKind.Codex,
+            agentLogEnvelopeLines(envelope).asSequence(),
+        )
+    }
+
+    /**
+     * Issue #1467: read the Codex agent-log JSON envelope, byte-clamped by
+     * default (#1267). If the CLAMPED read yields NO envelope, retry ONCE
+     * WITHOUT the `--max-line-bytes` clamp.
+     *
+     * The clamped-then-plain retry closes a silent version-skew blank: a host
+     * `pocketshell` CLI OLDER than #1267 does not know `--max-line-bytes`,
+     * rejects it as an unknown option, and exits non-zero — but behind
+     * `2>/dev/null || true` that leaves EMPTY stdout, indistinguishable from
+     * "no messages" so the entire Codex conversation view rendered blank (the
+     * v0.4.25 release-gate symptom against the stale Docker fixture CLI, and a
+     * real risk on any host whose installed CLI lags the app). The clamp is a
+     * large-line safeguard, not a correctness requirement, so dropping it on the
+     * fallback is acceptable; a CURRENT CLI parses the clamped read and never
+     * reaches the fallback.
+     */
+    private suspend fun readCodexAgentLogEnvelope(
+        session: SshSession,
+        sessionId: String,
+        boundedMaxLines: Int,
+    ): JSONObject? {
+        val clampedOutput = session.exec(
+            codexAgentLogCommand(sessionId, boundedMaxLines, MAX_TRANSCRIPT_LINE_BYTES),
         ).stdout
-        val lines = parseAgentLogEnvelopeLines(output)
-        return parseTranscriptTailLines(CodexParser(), AgentKind.Codex, lines.asSequence())
+        agentLogEnvelopeOrNull(clampedOutput)?.let { return it }
+        val plainOutput = session.exec(
+            codexAgentLogCommand(sessionId, boundedMaxLines, clampBytes = null),
+        ).stdout
+        val envelope = agentLogEnvelopeOrNull(plainOutput)
+        if (envelope == null && (clampedOutput.isNotBlank() || plainOutput.isNotBlank())) {
+            diagnostic(
+                "agent-log output had non-blank lines but no JSON envelope carrying " +
+                    "`lines` (preamble/format drift) — returning no messages",
+            )
+        }
+        return envelope
     }
 
     /**
@@ -2071,11 +2128,7 @@ public class AgentConversationRepository internal constructor(
      * than a silent empty view.
      */
     internal fun parseAgentLogEnvelopeLines(output: String): List<String> {
-        val envelope = output.lineSequence()
-            .filter { it.isNotBlank() }
-            .firstNotNullOfOrNull { line ->
-                runCatching { JSONObject(line) }.getOrNull()?.takeIf { it.has("lines") }
-            }
+        val envelope = agentLogEnvelopeOrNull(output)
         if (envelope == null) {
             if (output.isNotBlank()) {
                 diagnostic(
@@ -2085,12 +2138,46 @@ public class AgentConversationRepository internal constructor(
             }
             return emptyList()
         }
+        return agentLogEnvelopeLines(envelope)
+    }
+
+    /**
+     * Scan [output] for the FIRST line that parses as a JSON object carrying a
+     * `lines` array (the `pocketshell agent-log --json` envelope), skipping any
+     * non-JSON / non-envelope preamble (#1227). Returns `null` when no envelope
+     * is present — the signal the caller uses to distinguish "no envelope in the
+     * output at all" (a failed / version-skewed CLI read, #1467) from a valid
+     * envelope that simply carries zero `lines` ("no messages yet").
+     */
+    internal fun agentLogEnvelopeOrNull(output: String): JSONObject? =
+        output.lineSequence()
+            .filter { it.isNotBlank() }
+            .firstNotNullOfOrNull { line ->
+                runCatching { JSONObject(line) }.getOrNull()?.takeIf { it.has("lines") }
+            }
+
+    /** Extract the non-blank raw JSONL strings from a resolved agent-log envelope. */
+    private fun agentLogEnvelopeLines(envelope: JSONObject): List<String> {
         val lines = envelope.optJSONArray("lines") ?: return emptyList()
         return buildList {
             for (index in 0 until lines.length()) {
                 lines.optString(index).takeIf { it.isNotBlank() }?.let(::add)
             }
         }
+    }
+
+    /**
+     * Build the `pocketshell agent-log --engine codex` invocation. When
+     * [clampBytes] is non-null the read is byte-bounded server-side via
+     * `--max-line-bytes` (#1267), degrading any multi-MB rollout line to a
+     * compact truncation marker so its bytes never cross SSH into the phone's
+     * heap. When null the flag is omitted — the pre-#1267 command shape an
+     * OLDER host CLI understands (the #1467 version-skew fallback).
+     */
+    private fun codexAgentLogCommand(sessionId: String, boundedMaxLines: Int, clampBytes: Int?): String {
+        val clamp = clampBytes?.let { " --max-line-bytes $it" }.orEmpty()
+        return "pocketshell agent-log --engine codex --session ${shellQuote(sessionId)} " +
+            "--json --tail $boundedMaxLines$clamp 2>/dev/null || true"
     }
 
     private fun parserFor(agent: AgentKind): ConversationParser? = when (agent) {

--- a/app/src/test/java/com/pocketshell/app/session/AgentConversationRepositoryTest.kt
+++ b/app/src/test/java/com/pocketshell/app/session/AgentConversationRepositoryTest.kt
@@ -66,6 +66,173 @@ class AgentConversationRepositoryTest {
         assertFalse(session.execCommands.single().contains("tail -n"))
     }
 
+    // ----------------------------------------------------------------
+    // Issue #1467: a payload-wrapped Codex JSONL transcript (the exact
+    // `tests/docker/agent-fixtures/codex-session.jsonl` shape the
+    // EmulatorDockerSshSmokeTest seeds, timestamps and all) must parse to
+    // non-empty conversation events. The v0.4.25 release gate caught
+    // `readInitialEvents(... Codex ...)` returning [] for this form, so a
+    // Codex session whose transcript is payload-wrapped rendered an EMPTY
+    // conversation view. Reproduce it at the JVM level so the per-push Unit
+    // gate catches this class WITHOUT the emulator (#1458 blind spot).
+    // ----------------------------------------------------------------
+    @Test
+    fun codexReadInitialEventsParsesTheExactDockerPayloadWrappedFixture() = runTest {
+        // Byte-identical to tests/docker/agent-fixtures/codex-session.jsonl.
+        val codexLines = listOf(
+            """{"type":"session_meta","timestamp":"2026-05-22T10:00:59Z","payload":{"id":"pocketshell-codex","cwd":"/workspace/pocketshell"}}""",
+            """{"type":"event_msg","timestamp":"2026-05-22T10:01:00Z","payload":{"type":"user_message","message":"add a smoke test"}}""",
+            """{"type":"response_item","timestamp":"2026-05-22T10:01:01Z","payload":{"type":"function_call","call_id":"codex-call-1","name":"shell","arguments":"./gradlew test"}}""",
+            """{"type":"response_item","timestamp":"2026-05-22T10:01:02Z","payload":{"type":"function_call_output","call_id":"codex-call-1","output":"BUILD SUCCESSFUL"}}""",
+            """{"type":"response_item","timestamp":"2026-05-22T10:01:03Z","payload":{"type":"message","id":"codex-message-1","role":"assistant","content":[{"type":"output_text","text":"The deterministic Codex fixture is ready."}]}}""",
+        )
+        val session = FakeSshSession(
+            agentLogOutput = JSONObject(
+                mapOf(
+                    "count" to codexLines.size,
+                    "engine" to "codex",
+                    "lines" to JSONArray(codexLines),
+                    "path" to "/home/testuser/.codex/sessions/2026/05/22/pocketshell-codex.jsonl",
+                    "session" to "pocketshell-codex",
+                ),
+            ).toString(),
+        )
+
+        val events = AgentConversationRepository().readInitialEvents(
+            session = session,
+            detection = AgentDetection(
+                agent = AgentKind.Codex,
+                sourcePath = "/home/testuser/.codex/sessions/2026/05/22/pocketshell-codex.jsonl",
+                sessionId = "pocketshell-codex",
+                confidence = AgentDetection.Confidence.ProcessConfirmed,
+            ),
+            maxLines = 20,
+        )
+
+        assertTrue(
+            "expected the payload-wrapped Codex fixture to parse into non-empty events, got $events",
+            events.isNotEmpty(),
+        )
+        assertTrue(
+            "expected the assistant message text, got ${events.map { it }}",
+            events.any {
+                it is ConversationEvent.Message &&
+                    it.text.contains("deterministic Codex fixture")
+            },
+        )
+        // The user prompt + the assistant reply both surface, in order.
+        assertEquals(
+            listOf(
+                ConversationRole.User to "add a smoke test",
+                ConversationRole.Assistant to "The deterministic Codex fixture is ready.",
+            ),
+            events.filterIsInstance<ConversationEvent.Message>().map { it.role to it.text },
+        )
+        // The function-call + its output render too.
+        assertTrue(events.any { it is ConversationEvent.ToolCall && it.name == "shell" })
+        assertTrue(events.any { it is ConversationEvent.ToolResult && it.output.contains("BUILD SUCCESSFUL") })
+    }
+
+    // ----------------------------------------------------------------
+    // Issue #1467 (ROOT CAUSE / red->green): #1267 added `--max-line-bytes`
+    // to the Codex agent-log read, but a host CLI OLDER than #1267 rejects
+    // that unknown option and (behind `2>/dev/null || true`) returns EMPTY
+    // stdout — so `readInitialEvents` parsed [] and the whole Codex
+    // conversation view blanked. This is the exact failure the v0.4.25
+    // release gate caught end-to-end against the stale Docker fixture CLI.
+    // The repository must retry the read WITHOUT the clamp flag so a
+    // version-skewed host still renders its conversation.
+    // Without the fallback this test is RED (events == []).
+    // ----------------------------------------------------------------
+    @Test
+    fun codexReadInitialEventsFallsBackWhenHostCliRejectsMaxLineBytes() = runTest {
+        val codexLines = listOf(
+            """{"type":"session_meta","timestamp":"2026-05-22T10:00:59Z","payload":{"id":"pocketshell-codex","cwd":"/workspace/pocketshell"}}""",
+            """{"type":"event_msg","timestamp":"2026-05-22T10:01:00Z","payload":{"type":"user_message","message":"add a smoke test"}}""",
+            """{"type":"response_item","timestamp":"2026-05-22T10:01:03Z","payload":{"type":"message","id":"codex-message-1","role":"assistant","content":[{"type":"output_text","text":"The deterministic Codex fixture is ready."}]}}""",
+        )
+        val session = FakeSshSession(
+            agentLogOutput = JSONObject(
+                mapOf(
+                    "count" to codexLines.size,
+                    "engine" to "codex",
+                    "lines" to JSONArray(codexLines),
+                    "path" to "/home/testuser/.codex/sessions/2026/05/22/pocketshell-codex.jsonl",
+                    "session" to "pocketshell-codex",
+                ),
+            ).toString(),
+            agentLogRejectsMaxLineBytes = true,
+        )
+
+        val events = AgentConversationRepository().readInitialEvents(
+            session = session,
+            detection = AgentDetection(
+                agent = AgentKind.Codex,
+                sourcePath = "/home/testuser/.codex/sessions/2026/05/22/pocketshell-codex.jsonl",
+                sessionId = "pocketshell-codex",
+                confidence = AgentDetection.Confidence.ProcessConfirmed,
+            ),
+            maxLines = 20,
+        )
+
+        assertTrue(
+            "expected the version-skew fallback to still parse the Codex conversation, got $events",
+            events.any {
+                it is ConversationEvent.Message &&
+                    it.text.contains("deterministic Codex fixture")
+            },
+        )
+        // The fallback: the clamped read (rejected → empty) THEN a retry
+        // without `--max-line-bytes` (the pre-#1267 shape the stale CLI parses).
+        val agentLogCommands = session.execCommands.filter { it.contains("pocketshell agent-log") }
+        assertEquals(2, agentLogCommands.size)
+        assertTrue(agentLogCommands.first().contains("--max-line-bytes"))
+        assertFalse(agentLogCommands.last().contains("--max-line-bytes"))
+    }
+
+    @Test
+    fun codexReadEventsWindowFallsBackWhenHostCliRejectsMaxLineBytes() = runTest {
+        // Class coverage (G2): the PAGED window read (readEventsWindow) shares
+        // the same `--max-line-bytes` agent-log invocation and the same
+        // version-skew blank; the fallback must protect it too.
+        val codexLines = listOf(
+            """{"type":"event_msg","timestamp":"2026-05-22T10:01:00Z","payload":{"type":"user_message","message":"add a smoke test"}}""",
+            """{"type":"response_item","timestamp":"2026-05-22T10:01:03Z","payload":{"type":"message","id":"codex-message-1","role":"assistant","content":[{"type":"output_text","text":"The deterministic Codex fixture is ready."}]}}""",
+        )
+        val session = FakeSshSession(
+            wcOutput = "2\n",
+            agentLogOutput = JSONObject(
+                mapOf(
+                    "count" to codexLines.size,
+                    "engine" to "codex",
+                    "lines" to JSONArray(codexLines),
+                    "path" to "/home/testuser/.codex/sessions/2026/05/22/pocketshell-codex.jsonl",
+                    "session" to "pocketshell-codex",
+                ),
+            ).toString(),
+            agentLogRejectsMaxLineBytes = true,
+        )
+
+        val window = AgentConversationRepository().readEventsWindow(
+            session = session,
+            detection = AgentDetection(
+                agent = AgentKind.Codex,
+                sourcePath = "/home/testuser/.codex/sessions/2026/05/22/pocketshell-codex.jsonl",
+                sessionId = "pocketshell-codex",
+                confidence = AgentDetection.Confidence.ProcessConfirmed,
+            ),
+            maxMessages = 20,
+        )
+
+        assertTrue(
+            "expected the paged window fallback to still parse the Codex conversation, got ${window.events}",
+            window.events.any {
+                it is ConversationEvent.Message &&
+                    it.text.contains("deterministic Codex fixture")
+            },
+        )
+    }
+
     @Test
     fun tailEventsFromLineReturnsNullWhenSshTailStartThrowsDisconnected() = runTest {
         val session = FakeSshSession(
@@ -2193,6 +2360,12 @@ class AgentConversationRepositoryTest {
         private val tailLines: List<String> = emptyList(),
         private val tailFailure: Throwable? = null,
         private val agentLogOutput: String = "",
+        // Issue #1467: simulate a host `pocketshell` CLI OLDER than #1267 that
+        // does not know `--max-line-bytes` — it rejects the unknown option and
+        // exits non-zero, which behind the repository's `2>/dev/null || true`
+        // surfaces as EMPTY stdout. The repository must retry the read WITHOUT
+        // the clamp flag rather than silently blanking the Codex conversation.
+        private val agentLogRejectsMaxLineBytes: Boolean = false,
         private val jsonlTailOutput: String = "",
         private val recordedKindOutput: String = "",
         private val recordedSourceGenerationOutput: String = "",
@@ -2269,9 +2442,9 @@ class AgentConversationRepositoryTest {
                 // raw-file line count (the follow cursor) without a separate
                 // lineCount exec.
                 command.contains("@@PS_CODEX_WINDOW@@") ->
-                    "${wcOutput.trim()}\n@@PS_CODEX_WINDOW@@\n${applyAgentLogEnvelopeClamp(command, agentLogOutput)}"
+                    "${wcOutput.trim()}\n@@PS_CODEX_WINDOW@@\n${agentLogEnvelopeFor(command)}"
                 command.contains("wc -l < ") -> wcOutput
-                command.contains("pocketshell agent-log") -> applyAgentLogEnvelopeClamp(command, agentLogOutput)
+                command.contains("pocketshell agent-log") -> agentLogEnvelopeFor(command)
                 command.trimStart().startsWith("tail -n") -> applyLineClamp(command, jsonlTailOutput)
                 command.contains("sqlite3 -readonly") -> {
                     sqliteFailure?.let { throw it }
@@ -2313,6 +2486,16 @@ class AgentConversationRepositoryTest {
         // `--max-line-bytes` (base code), the envelope is returned unchanged and a
         // multi-MB line balloons the read exactly as on-device — a genuine
         // red->green. A blank/unparseable envelope is passed through untouched.
+        // Issue #1467: an OLD host CLI rejects `--max-line-bytes` and, behind
+        // `2>/dev/null || true`, returns empty stdout. Otherwise the envelope is
+        // emitted (with the server-side clamp applied when the flag is present).
+        private fun agentLogEnvelopeFor(command: String): String =
+            if (agentLogRejectsMaxLineBytes && command.contains("--max-line-bytes")) {
+                ""
+            } else {
+                applyAgentLogEnvelopeClamp(command, agentLogOutput)
+            }
+
         private fun applyAgentLogEnvelopeClamp(command: String, envelope: String): String {
             val cap = Regex("--max-line-bytes (\\d+)").find(command)
                 ?.groupValues?.get(1)?.toIntOrNull() ?: return envelope


### PR DESCRIPTION
**v0.4.25 release blocker + real Codex dogfood bug.** #1267 added `--max-line-bytes` to the Codex `agent-log` read but a stale host CLI rejects the unknown flag → empty stdout → `[]` → blank Codex conversation. Fix: clamped read, then **retry once without the flag** when it yields no envelope (current CLI keeps the clamp; stale CLI still renders). The client-side 8 MiB `EXEC_STREAM_MAX_BYTES` cap still prevents OOM on a giant line.

Reviewer APPROVED: root cause confirmed (`git show 167a3233`), G1 reviewer-run RED→GREEN on the two new JVM tests (wired into per-push `Unit tests`, closing the #1458 blind spot), OOM explicitly ruled out (independent 8 MiB cap), class-covered, connected `EmulatorDockerSshSmokeTest` green. 2 files. Closes #1467