### PR TITLE
ci: classify emulator console-storm as INFRA-ABORT (#1458 classifier)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -914,6 +914,26 @@ jobs:
           first_timeout="${{ steps.journey_summary.outputs.first_timeout }}"
           first_failure="${{ steps.journey_summary.outputs.first_failure }}"
           summary="artifacts/ci-journey/summary.md"
+          # Issue #1458: count the `Failed to start Emulator console` storm from
+          # the durable journey-console capture (teed by run_bounded). On a
+          # CPU/RAM-starved swiftshader AVD this ddmlib line repeats ~100×/shard
+          # and is the signature of a DEGRADED emulator, NOT a product defect. A
+          # storm makes the whole run's JOURNEY_FAILED verdict untrustworthy, so
+          # it is routed to an INFRA-ABORT (re-run) BELOW — but ONLY where a
+          # genuine test-failure would otherwise be reported. A HEALTHY-console
+          # JOURNEY_FAILED (low/zero count) STAYS a genuine red: masking a real
+          # regression behind "infra" is the #657/#844 flake-masks-real trap, the
+          # exact inverse of what this guard exists to prevent. The #835 timeout
+          # and #771 never-booted branches are intentionally NOT gated by the
+          # storm — their behavior is unchanged.
+          console_log="artifacts/ci-journey/journey-console.log"
+          console_storm_threshold=25
+          console_storm_count=0
+          if [[ -f "$console_log" ]]; then
+            console_storm_count="$(grep -c 'Failed to start Emulator console' "$console_log" 2>/dev/null || true)"
+          fi
+          [[ "$console_storm_count" =~ ^[0-9]+$ ]] || console_storm_count=0
+          echo "console-storm 'Failed to start Emulator console' count: $console_storm_count (INFRA-ABORT threshold: >= $console_storm_threshold)"
           echo "first attempt outcome:  $first"
           echo "retry attempt outcome:  ${retry:-<skipped>}"
           echo "first attempt conclusion:  $first_concl"
@@ -929,6 +949,10 @@ jobs:
             exit 0
           fi
           if [[ "${first_failure:-false}" == "true" ]]; then
+            if (( console_storm_count >= console_storm_threshold )); then
+              echo "::error title=EMULATOR INFRA UNAVAILABLE / degraded — console storm (${console_storm_count}× 'Failed to start Emulator console')::The first cold boot wrote a JOURNEY_FAILED summary, but the emulator console failed to start ${console_storm_count} times (>= ${console_storm_threshold}) — the signature of a CPU/RAM-starved swiftshader AVD (issue #1458). A JOURNEY_FAILED read off a DEGRADED emulator is NOT a trustworthy product verdict, so this is an infra abort (a re-run signal, same class as the never-booted #771 branch), NOT a genuine regression. A real regression on a HEALTHY console shows a low console-storm count and stays red."
+              exit 1
+            fi
             echo "::error title=Emulator journey FAILED — first attempt genuine failure::The first cold boot wrote a JOURNEY_FAILED / Failed BOTH attempts summary, and the retry did not pass cleanly. Refusing to downgrade this run to advisory timeout even if the retry overwrote summary.md with a timeout-only artifact."
             exit 1
           fi
@@ -948,6 +972,16 @@ jobs:
           fi
           # Both attempts failed — classify from the suite's own summary artifact.
           if [[ -f "$summary" ]] && grep -qE 'JOURNEY_FAILED|Failed BOTH attempts' "$summary"; then
+            # Issue #1458: before reading this as a genuine regression, gate on the
+            # console storm. If the emulator was storming (>= threshold), the
+            # JOURNEY_FAILED was produced on a DEGRADED emulator and is an infra
+            # abort (re-run), NOT a product verdict. A HEALTHY-console
+            # JOURNEY_FAILED (count below threshold) falls through to the genuine
+            # test-failure verdict below — a real regression is NEVER swallowed.
+            if (( console_storm_count >= console_storm_threshold )); then
+              echo "::error title=EMULATOR INFRA UNAVAILABLE / degraded — console storm (${console_storm_count}× 'Failed to start Emulator console')::A load-bearing journey class failed on both cold-boot attempts, but the emulator console failed to start ${console_storm_count} times (>= ${console_storm_threshold}) — the signature of a CPU/RAM-starved swiftshader AVD (issue #1458). A both-attempts JOURNEY_FAILED read off a DEGRADED emulator is NOT a trustworthy product verdict; this is an infra abort (a re-run signal, same class as the never-booted #771 branch), NOT a genuine test regression. A real regression on a HEALTHY console shows a low console-storm count and stays red."
+              exit 1
+            fi
             # The emulator booted and the suite ran to a verdict: a journey class
             # failed twice. This is a GENUINE test failure (app-code regression),
             # NOT the #771 emulator-infra abort.

--- a/scripts/ci-journey-budget-functions.sh
+++ b/scripts/ci-journey-budget-functions.sh
@@ -65,16 +65,30 @@ run_bounded() {
   to_pid=$!
 
   exec {rfd}<"$fifo"
+  # Issue #1458: tee every streamed line to a DURABLE capture file so the
+  # workflow "Classify emulator-journey result" step can count the
+  # `Failed to start Emulator console` storm (a CPU/RAM-starved swiftshader
+  # symptom, ~100×/shard) AFTER this emulator step has ended and its stdout is
+  # gone. Live streaming (the `printf` to stdout) is UNCHANGED. The fd is opened
+  # in append mode ONCE per class attempt (cheap) and only when
+  # JOURNEY_CONSOLE_LOG is set + openable, so the budget self-test and any
+  # non-CI caller that leaves it unset behave exactly as before.
+  local cfd=-1
+  if [[ -n "${JOURNEY_CONSOLE_LOG:-}" ]]; then
+    exec {cfd}>>"$JOURNEY_CONSOLE_LOG" || cfd=-1
+  fi
   read_rc=0
   while :; do
     if IFS= read -r -t "$no_output" -u "$rfd" line; then
       printf '%s\n' "$line"
+      (( cfd >= 0 )) && printf '%s\n' "$line" >&"$cfd"
     else
       read_rc=$?
       break
     fi
   done
   exec {rfd}<&-
+  (( cfd >= 0 )) && exec {cfd}>&-
 
   if (( read_rc > 128 )); then
     echo "JOURNEY_NO_OUTPUT_WATCHDOG: no output for ${no_output}s — hard-killing wedged connectedDebugAndroidTest (issue #1056)" >&2

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -87,6 +87,20 @@ ARTIFACT_DIR="$REPO_ROOT/artifacts/ci-journey"
 mkdir -p "$ARTIFACT_DIR"
 SUMMARY="$ARTIFACT_DIR/summary.md"
 
+# Issue #1458: durable capture of the journey run's streamed gradle/ddmlib output.
+# run_bounded appends every streamed line here (while still streaming live) so the
+# workflow "Classify emulator-journey result" step can count the
+# `Failed to start Emulator console` storm — the signature of a CPU/RAM-starved
+# swiftshader AVD (~100×/shard) — AFTER this emulator step has ended and its stdout
+# is gone. A degraded-emulator storm is then classified as an INFRA-ABORT (re-run),
+# never a "genuine test failure" reading, so a starved emulator can no longer make
+# `main`'s emulator-level health unreadable. Truncated once per suite run so the
+# capture reflects THIS attempt only — mirroring how summary.md is overwritten per
+# cold-boot attempt (the classifier reads the last attempt's artifacts).
+JOURNEY_CONSOLE_LOG="$ARTIFACT_DIR/journey-console.log"
+export JOURNEY_CONSOLE_LOG
+: > "$JOURNEY_CONSOLE_LOG"
+
 GRADLEW="$REPO_ROOT/gradlew"
 
 FQCN_PREFIX="com.pocketshell.app.proof"

--- a/scripts/test-ci-journey-budget.sh
+++ b/scripts/test-ci-journey-budget.sh
@@ -170,6 +170,37 @@ pass "(pre) #835 right-sized budget arithmetic pinned (${job_cap_secs}s job - ${
 pass "(pre) first-attempt diagnostics are preserved before emulator retry"
 
 # ---------------------------------------------------------------------------
+# Issue #1458 workflow-parity pins: the real workflow classifier must count the
+# `Failed to start Emulator console` storm from the durable journey-console
+# capture and route a STORMING JOURNEY_FAILED to an INFRA-ABORT. Pin the
+# load-bearing pieces so the classify() mirror above cannot silently drift from
+# the workflow, and so a regression that drops the storm gate trips this test.
+grep -q 'journey-console.log' "$WORKFLOW" \
+  || fail "(pre-1458) tests.yml classifier must read the durable journey-console.log capture"
+grep -q "Failed to start Emulator console" "$WORKFLOW" \
+  || fail "(pre-1458) tests.yml classifier must count the 'Failed to start Emulator console' storm signature"
+grep -q 'console_storm_threshold=25' "$WORKFLOW" \
+  || fail "(pre-1458) tests.yml classifier must use the 25-storm INFRA-ABORT threshold"
+grep -q 'console_storm_count >= console_storm_threshold' "$WORKFLOW" \
+  || fail "(pre-1458) tests.yml classifier must gate the genuine-failure verdict on the storm count"
+grep -q 'EMULATOR INFRA UNAVAILABLE / degraded' "$WORKFLOW" \
+  || fail "(pre-1458) tests.yml storm branch must emit a distinct degraded-emulator INFRA-ABORT title"
+# The suite must define + truncate the console capture and route it through
+# run_bounded's tee.
+grep -q 'JOURNEY_CONSOLE_LOG' "$REAL_SUITE" \
+  || fail "(pre-1458) ci-journey-suite.sh must define the durable JOURNEY_CONSOLE_LOG capture"
+grep -q 'JOURNEY_CONSOLE_LOG' "$SCRIPT_DIR/ci-journey-budget-functions.sh" \
+  || fail "(pre-1458) run_bounded (ci-journey-budget-functions.sh) must tee to JOURNEY_CONSOLE_LOG"
+# The storm gate must be a genuine-failure gate ONLY: the #835 timeout ::error
+# lines must NOT be preceded by a storm re-route (already asserted unchanged by
+# the (pre) timeout-exit walk above; here we assert the storm branch sits inside
+# a JOURNEY_FAILED/first_failure context, not the timeout context).
+storm_gate_count="$(grep -c 'console_storm_count >= console_storm_threshold' "$WORKFLOW" || true)"
+[[ "$storm_gate_count" -eq 2 ]] \
+  || fail "(pre-1458) expected exactly 2 storm gates (first_failure + both-failed JOURNEY_FAILED), found $storm_gate_count"
+pass "(pre-1458) console-storm INFRA-ABORT classifier is wired into the workflow + suite + run_bounded"
+
+# ---------------------------------------------------------------------------
 # Build a sandbox "repo root": a copy of the suite script + a stub gradlew that
 # SLEEPS (modelling a #470-stalling class) + stub scripts the suite shells out
 # to. REPO_ROOT in the suite is derived from BASH_SOURCE, so we run the COPY
@@ -267,6 +298,11 @@ classify() {
   local retry_concl="${5:-failure}"
   local first_timeout="${6:-}"
   local first_failure="${7:-false}"
+  # Issue #1458: the count of `Failed to start Emulator console` storms from the
+  # durable journey-console capture. >= threshold => the emulator was DEGRADED and
+  # any JOURNEY_FAILED read is an INFRA-ABORT (re-run), NOT a product verdict.
+  local console_storm_count="${8:-0}"
+  local console_storm_threshold=25
   if [[ -z "$first_timeout" ]]; then
     first_timeout="false"
     if [[ -f "$s" ]] \
@@ -282,16 +318,27 @@ classify() {
     echo "PASS_RETRY"; return
   fi
   if [[ "$first_failure" == "true" ]]; then
+    # #1458: a first-attempt JOURNEY_FAILED off a STORMING (degraded) emulator is
+    # an infra abort (re-run); a healthy-console one stays a genuine red.
+    if (( console_storm_count >= console_storm_threshold )); then
+      echo "INFRA_CONSOLE_STORM"; return
+    fi
     echo "FIRST_GENUINE_FAILURE"; return
   fi
   if [[ "$first_timeout" == "true" ]]; then
-    # #835 REOPENED: the first-attempt budget timeout is now a HARD RED.
+    # #835 REOPENED: the first-attempt budget timeout is now a HARD RED. NOT gated
+    # by the #1458 storm — #835 behavior is intentionally unchanged.
     echo "FIRST_TIMEOUT_RED"; return
   fi
   if [[ "$first_outcome" == "cancelled" || "$retry_outcome" == "cancelled" || "$first_concl" == "cancelled" || "$retry_concl" == "cancelled" ]]; then
     echo "STEP_CANCELLED"; return
   fi
   if [[ -f "$s" ]] && grep -qE 'JOURNEY_FAILED|Failed BOTH attempts' "$s"; then
+    # #1458: a both-attempts JOURNEY_FAILED off a STORMING (degraded) emulator is
+    # an infra abort (re-run); a healthy-console one stays a genuine red.
+    if (( console_storm_count >= console_storm_threshold )); then
+      echo "INFRA_CONSOLE_STORM"; return
+    fi
     echo "GENUINE_FAILURE"; return
   fi
   if [[ -f "$s" ]] && grep -qE 'JOURNEY_STEP_TIMEOUT|Suite step time budget exhausted' "$s"; then
@@ -359,6 +406,86 @@ overwrite_verdict="$(classify "$retry_timeout_summary" failure failure failure f
 [[ "$overwrite_verdict" == "FIRST_GENUINE_FAILURE" ]] \
   || fail "(h) first genuine failure + retry timeout overwrite routed to '$overwrite_verdict', expected FIRST_GENUINE_FAILURE"
 pass "(h) first genuine failure remains red when retry overwrites summary with timeout-only content"
+
+# ---------------------------------------------------------------------------
+# Issue #1458: console-storm INFRA-ABORT classifier. A CPU/RAM-starved
+# swiftshader AVD storms `Failed to start Emulator console` ~100×/shard and
+# produces a JOURNEY_FAILED summary that is NOT a real regression — it made
+# `main`'s emulator-level health unreadable. The classifier must route a
+# STORMING run's genuine-failure reading to an INFRA-ABORT (re-run), while a
+# HEALTHY-console JOURNEY_FAILED STAYS a genuine red — masking a real regression
+# behind "infra" is the #657/#844 flake-masks-real trap this guard must NOT hit.
+echo "== #1458 console-storm INFRA-ABORT classifier =="
+storm_summary="$SANDBOX/storm-summary.md"
+printf '%s\n' \
+  '# Per-push CI journey suite — summary' \
+  'Failed BOTH attempts (`JOURNEY_FAILED` — job red):' \
+  '- `com.pocketshell.app.proof.Issue1206PrewarmEmptyCaptureSeedRetryJourneyE2eTest`' \
+  > "$storm_summary"
+
+# (p1) STORM: both attempts failed with a JOURNEY_FAILED summary AND the console
+#      stormed (104×, the run-29081790650 forensic count) -> INFRA_CONSOLE_STORM
+#      (re-run), NOT a genuine product verdict.
+storm_verdict="$(classify "$storm_summary" failure failure failure failure false false 104)"
+[[ "$storm_verdict" == "INFRA_CONSOLE_STORM" ]] \
+  || fail "(p1) storming JOURNEY_FAILED routed to '$storm_verdict', expected INFRA_CONSOLE_STORM"
+verdict_is_red "$storm_verdict" \
+  || fail "(p1) INFRA_CONSOLE_STORM must still exit the job non-zero (a re-run signal, like #771)"
+pass "(p1) storming (104×) JOURNEY_FAILED -> INFRA_CONSOLE_STORM re-run signal"
+
+# (p2) THE #1 ACCEPTANCE CRITERION: a HEALTHY console (below threshold) with the
+#      SAME JOURNEY_FAILED summary MUST stay a genuine red — a real regression is
+#      NEVER swallowed behind "infra" (the #657/#844 flake-masks-real inverse).
+healthy_verdict="$(classify "$storm_summary" failure failure failure failure false false 3)"
+[[ "$healthy_verdict" == "GENUINE_FAILURE" ]] \
+  || fail "(p2) healthy-console JOURNEY_FAILED routed to '$healthy_verdict', expected GENUINE_FAILURE (a real regression must NOT be masked)"
+verdict_is_red "$healthy_verdict" \
+  || fail "(p2) healthy-console genuine failure must stay red"
+pass "(p2) healthy-console (3×) JOURNEY_FAILED -> GENUINE_FAILURE (real regression NOT masked)"
+
+# (p3) boundary: exactly 25 storms -> INFRA (>= threshold); 24 -> genuine red.
+[[ "$(classify "$storm_summary" failure failure failure failure false false 25)" == "INFRA_CONSOLE_STORM" ]] \
+  || fail "(p3) 25 storms (== threshold) must route to INFRA_CONSOLE_STORM"
+[[ "$(classify "$storm_summary" failure failure failure failure false false 24)" == "GENUINE_FAILURE" ]] \
+  || fail "(p3) 24 storms (< threshold) must stay GENUINE_FAILURE"
+[[ "$(classify "$storm_summary" failure failure failure failure false false 0)" == "GENUINE_FAILURE" ]] \
+  || fail "(p3) 0 storms (healthy) must stay GENUINE_FAILURE"
+pass "(p3) threshold boundary: >=25 INFRA-abort, <25 genuine red"
+
+# (p4) first-attempt genuine failure: storm -> INFRA (re-run); healthy console ->
+#      FIRST_GENUINE_FAILURE (stays red).
+[[ "$(classify "$storm_summary" failure failure failure failure false true 104)" == "INFRA_CONSOLE_STORM" ]] \
+  || fail "(p4) storming first_failure must route to INFRA_CONSOLE_STORM"
+[[ "$(classify "$storm_summary" failure failure failure failure false true 3)" == "FIRST_GENUINE_FAILURE" ]] \
+  || fail "(p4) healthy-console first_failure must stay FIRST_GENUINE_FAILURE"
+pass "(p4) first_failure: storm -> INFRA re-run, healthy -> genuine red"
+
+# (p5) a storming run that nonetheless PASSED (first or retry success) stays
+#      GREEN — the storm gate never masks a real pass into a re-run.
+[[ "$(classify "$storm_summary" success failure failure failure false false 104)" == "PASS_FIRST" ]] \
+  || fail "(p5) storming first-pass must stay PASS_FIRST (green)"
+[[ "$(classify "$storm_summary" failure success failure failure false false 104)" == "PASS_RETRY" ]] \
+  || fail "(p5) storming retry-pass must stay PASS_RETRY (green)"
+pass "(p5) storm never masks a genuine PASS into a re-run"
+
+# (p6) a storm must NOT preempt the #835 timeout / #771 no-summary branches —
+#      their behavior is intentionally unchanged even with a high storm count.
+storm_timeout_summary="$SANDBOX/storm-timeout-summary.md"
+printf '%s\n' \
+  '# Per-push CI journey suite — summary' \
+  'Suite step time budget exhausted — JOURNEY_STEP_TIMEOUT (issue #835 / #470 stall — job red):' \
+  '- `com.pocketshell.app.TimedOutClass`' \
+  > "$storm_timeout_summary"
+[[ "$(classify "$storm_timeout_summary" failure failure failure failure true false 104)" == "FIRST_TIMEOUT_RED" ]] \
+  || fail "(p6) a storming first-attempt budget timeout must STAY FIRST_TIMEOUT_RED (#835 unchanged)"
+[[ "$(classify "$storm_timeout_summary" failure failure failure failure false false 104)" == "JOURNEY_TIMEOUT_RED" ]] \
+  || fail "(p6) a storming both-failed budget timeout must STAY JOURNEY_TIMEOUT_RED (#835 unchanged)"
+[[ "$(classify "$storm_timeout_summary" failure failure cancelled failure false false 104)" == "STEP_CANCELLED" ]] \
+  || fail "(p6) a storming cancelled attempt must STAY STEP_CANCELLED"
+missing_storm_summary="$SANDBOX/does-not-exist-storm-summary.md"
+[[ "$(classify "$missing_storm_summary" failure failure failure failure false false 104)" == "INFRA_UNAVAILABLE" ]] \
+  || fail "(p6) a storming no-summary run must STAY INFRA_UNAVAILABLE (#771 unchanged)"
+pass "(p6) storm does not preempt the #835 timeout / cancelled / #771 no-summary branches"
 
 # ---------------------------------------------------------------------------
 # Issue #918: if the per-class `timeout` kills a Gradle invocation, the next
@@ -933,6 +1060,60 @@ summary_ct="$SANDBOX/artifacts/ci-journey/summary.md"
 grep -qE 'output-burst-IME ANR proof.*\*\*FAIL\*\*' "$summary_ct" \
   || { cat "$summary_ct"; fail "(m) the hung #796 proof must surface as FAIL in the summary (classifiable red, not a cancel)"; }
 pass "(m) core-terminal proofs are timeout-bounded — a hung proof yields a classifiable summary, never a job-cap cancel"
+
+# ---------------------------------------------------------------------------
+# Issue #1458 (AC1): drive the REAL suite with a gradle stub that emits the
+# `Failed to start Emulator console` storm signature and prove run_bounded TEES
+# it to a DURABLE console log the workflow classifier reads AFTER the emulator
+# step ends — while KEEPING live streaming intact (the tee must not break it).
+echo "== #1458 run_bounded tees journey console output to a durable log =="
+cat > "$SANDBOX/gradlew" <<'STUB'
+#!/usr/bin/env bash
+set -u
+[[ "${1:-}" == "--stop" ]] && exit 0
+# Emit the degraded-swiftshader console-storm signature, then a normal task line,
+# then a passing exit — models a storming-but-"passing" run so the tee capture is
+# what proves the storm is durably recorded (not the summary verdict).
+for i in 1 2 3 4 5; do echo "Failed to start Emulator console for 5554"; done
+echo "> Task :app:connectedDebugAndroidTest done"
+exit 0
+STUB
+chmod +x "$SANDBOX/gradlew"
+
+out_tee="$SANDBOX/run-console-tee.log"
+set +e
+PATH="$STUBBIN:$PATH" \
+  JOURNEY_STEP_BUDGET_SECS=600 \
+  JOURNEY_CLASS_TIMEOUT_SECS=60 \
+  bash "$SANDBOX/scripts/ci-journey-suite.sh" > "$out_tee" 2>&1
+rc_tee=$?
+set -e
+
+# The tee must not break a run: this storming-but-"passing" stub exits 0, so the
+# suite must still exit 0 (the durable capture is a side channel, never a gate).
+[[ "$rc_tee" -eq 0 ]] \
+  || { sed -n '1,40p' "$out_tee"; fail "(q0) the #1458 tee broke a passing run (rc=$rc_tee)"; }
+console_log="$SANDBOX/artifacts/ci-journey/journey-console.log"
+[[ -f "$console_log" ]] \
+  || { sed -n '1,40p' "$out_tee"; fail "(q1) run_bounded did not create the durable console log $console_log"; }
+tee_count="$(grep -c 'Failed to start Emulator console' "$console_log" || true)"
+# Each of the many journey + core-terminal classes invokes the stub (5 storm
+# lines each), so the durable count is comfortably above the 25 INFRA-ABORT
+# threshold — this is exactly what the workflow classifier would count.
+(( tee_count >= 25 )) \
+  || { sed -n '1,20p' "$console_log"; fail "(q1) durable console log captured $tee_count storm lines, expected >= 25 (the classifier could not see the storm)"; }
+pass "(q1) run_bounded tees the storm to a durable log the classifier reads (count=$tee_count)"
+
+# (q2) live streaming is UNCHANGED: the storm lines also reached stdout.
+grep -q 'Failed to start Emulator console' "$out_tee" \
+  || { sed -n '1,40p' "$out_tee"; fail "(q2) storm lines were not streamed live — the #1458 tee broke live streaming"; }
+pass "(q2) live streaming intact — storm lines reach stdout AND the durable log"
+
+# (q3) end-to-end: feed the REAL classify() mirror the durable count from this
+# simulated run alongside a JOURNEY_FAILED summary -> INFRA_CONSOLE_STORM.
+[[ "$(classify "$storm_summary" failure failure failure failure false false "$tee_count")" == "INFRA_CONSOLE_STORM" ]] \
+  || fail "(q3) the durably-captured storm count ($tee_count) did not classify a JOURNEY_FAILED as INFRA_CONSOLE_STORM"
+pass "(q3) durable count from a real suite run drives the classifier to INFRA_CONSOLE_STORM"
 
 echo
 echo "ALL TESTS PASSED"


### PR DESCRIPTION
Makes the emulator-journey gate distinguish a CPU/RAM-starved swiftshader emulator (~100x/shard `Failed to start Emulator console` storm) from a genuine test failure — closing the flake-masks-real blind spot that let the #1467 Codex regression slip through. Tees journey output to a durable log + a classify branch emitting a distinct INFRA-ABORT (re-run) verdict at >=25 console failures, gating ONLY the genuine-failure verdicts. A healthy-console JOURNEY_FAILED still exits RED (reviewer proved both ways — no masking). CI-infra only. **Part of #1458** (option 3); deeper stabilization stays open. Reviewer APPROVED.