### PR TITLE
connection (S6): controller decides open/switch + attach/seed IO off Main (#1329)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -1321,6 +1321,9 @@ public class TmuxSessionViewModel @Inject constructor(
      * Switching window still surfaces an escapable band (no swallow gate).
      */
     internal fun forceAttachingStateForTest(host: String, port: Int, user: String) {
+        // S6 (#1329): drive Attaching via the same-host Switch intent (retired Attaching arm).
+        val (ctrlHost, ctrlTarget) = controllerHostAndTarget()
+        if (ctrlHost != null && ctrlTarget != null) connectionManager.switchTo(ctrlHost, ctrlTarget)
         setConnectionState(ConnectionState.Attaching(host, port, user))
     }
 
@@ -1618,33 +1621,24 @@ public class TmuxSessionViewModel @Inject constructor(
     }
 
     /**
-     * EPIC #687 slice 1c-iii / EPIC #792 Slice A: drive the controller's INTENT
-     * directly from the inline transition. Previously this built an inline state NAME
-     * string and mirrored it through `observeInlineTransition` (a string round-trip the
-     * facade re-derived events from). Now it calls the [connectionManager]'s TYPED intent
-     * entrypoints directly — the controller drives the intent state machine. This is NET-NEUTRAL with
-     * the deleted string mirror: each inline state maps to the SAME controller event it
-     * mirrored before (`Connecting`→Enter, warm `Attaching`→Switch/Enter, `Live`/
-     * `Backgrounded`→reveal-Live, `Reattaching`/`Reconnecting`→drop-escalation,
-     * `Gone`→TargetGone, `Unreachable`→exhaust-ladder, `Idle`→no-op).
-     * Never mutates VM state, never reads the controller state back.
+     * EPIC #687 slice 1c-iii / EPIC #792 Slice A: drive the controller's INTENT.
+     *
+     * Roadmap slice **S6 (#1329)**: the OPEN / SWITCH / REVEAL arms are RETIRED — open/switch
+     * SUBMIT `Enter`/`Switch` at the flow edges so the controller DECIDES the transition, and
+     * the reveal edge submits `revealLive` at each `setConnectionState(Live)` (D28: controller
+     * is authority, not a mirror). This drives ONLY the remaining reconnect/gone/unreachable arms.
      */
     private fun driveControllerIntent(state: ConnectionState) {
         val (host, target) = controllerHostAndTarget()
         when (state) {
-            is ConnectionState.Idle -> Unit // controller stays Idle; nothing to drive.
-            is ConnectionState.Connecting ->
-                if (host != null && target != null) connectionManager.enter(host, target)
-            is ConnectionState.Attaching ->
-                if (host != null && target != null) connectionManager.switchTo(host, target)
-            // Backgrounded keeps the prior live surface in the inline VM — same as Live
-            // (the deleted mirror mapped both to the "Live" reveal branch).
+            // S6 (#1329): open/switch/reveal are controller-decided at the flow edges;
+            // these inline states are display-payload carriers only now.
+            is ConnectionState.Idle,
+            is ConnectionState.Connecting,
+            is ConnectionState.Attaching,
             is ConnectionState.Live,
             is ConnectionState.Backgrounded,
-            ->
-                if (host != null && target != null) connectionManager.revealLive(host, target)
-            // Reattaching and Reconnecting both mirrored to the "Reconnecting"
-            // drop-escalation branch.
+            -> Unit
             is ConnectionState.Reattaching,
             is ConnectionState.Reconnecting,
             ->
@@ -1655,6 +1649,22 @@ public class TmuxSessionViewModel @Inject constructor(
                 if (target != null) connectionManager.markGone(target)
             is ConnectionState.Unreachable -> connectionManager.escalateUnreachable()
         }
+    }
+
+    /** S6 (#1329): OPEN intent — controller decides warm→Attaching / cold→Connecting. */
+    private fun submitControllerOpen(target: ConnectionTarget) {
+        connectionManager.enter(controllerHostKey(target), controllerSessionId(target))
+    }
+
+    /** S6 (#1329): same-host fast SWITCH intent (→ Attaching, no re-handshake). */
+    private fun submitControllerSwitch(target: ConnectionTarget) {
+        connectionManager.switchTo(controllerHostKey(target), controllerSessionId(target))
+    }
+
+    /** S6 (#1329): REVEAL intent at each `setConnectionState(Live)` edge (retired `Live` arm). */
+    private fun revealControllerLive() {
+        val (host, target) = controllerHostAndTarget()
+        if (host != null && target != null) connectionManager.revealLive(host, target)
     }
 
     /**
@@ -2614,6 +2624,9 @@ public class TmuxSessionViewModel @Inject constructor(
         // connection path the screen can never paint `(old session's panes, new
         // target id)`, the wrong-session-on-switch race (#686/#658).
         navigateRevealTo(target)
+
+        // S6 (#1329): submit the open/switch event — the controller decides the transition.
+        if (willFastSwitch) submitControllerSwitch(target) else submitControllerOpen(target)
 
         // Issue #145: deterministic reconnect-loop signal. Every accepted
         // connect attempt increments a process-wide counter and emits a
@@ -5449,6 +5462,7 @@ public class TmuxSessionViewModel @Inject constructor(
         )
         // Clear the loss-hold "reconnecting" band: the surviving transport is alive,
         // so flip back to Live (the -CC client was never torn down).
+        revealControllerLive()
         setConnectionState(
             ConnectionState.Live(
                 target.host,
@@ -5981,6 +5995,7 @@ public class TmuxSessionViewModel @Inject constructor(
         // (otherwise the NEW-path reveal gate would stay held and the surface would
         // never mount on a switch back to a cached session).
         promoteRevealLiveForActiveTarget()
+        revealControllerLive()
         setConnectionState(
             ConnectionState.Live(
                 target.host,
@@ -6362,6 +6377,7 @@ public class TmuxSessionViewModel @Inject constructor(
             // reveals the target's surface — promote the reveal machine to Live for
             // the target so the NEW-path reveal gate releases in lockstep.
             if (activePaneSeeded) promoteRevealLiveForActiveTarget()
+            revealControllerLive()
             setConnectionState(
                 ConnectionState.Live(
                     target.host,
@@ -6679,6 +6695,7 @@ public class TmuxSessionViewModel @Inject constructor(
         autoReconnectJob = null
         connectingTarget = target
         refreshReconnectAvailability()
+        submitControllerOpen(target)
         setConnectionState(ConnectionState.Connecting(host, port, user))
         connectJob = viewModelScope.launch {
             val leaseTarget = target.toSshLeaseTarget()
@@ -6816,6 +6833,7 @@ public class TmuxSessionViewModel @Inject constructor(
                     runCatching { lease.release() }
                 }
                 sessionRef = null
+                submitControllerOpen(target)
                 setConnectionState(
                     ConnectionState.Connecting(
                         target.host,
@@ -6901,6 +6919,7 @@ public class TmuxSessionViewModel @Inject constructor(
             // promote the reveal machine to Live for the target so the NEW-path reveal
             // gate releases in the same mutation (never holds on a warm switch).
             if (activePaneSeeded) promoteRevealLiveForActiveTarget()
+            revealControllerLive()
             setConnectionState(
                 ConnectionState.Live(
                     target.host,
@@ -6995,6 +7014,7 @@ public class TmuxSessionViewModel @Inject constructor(
                 refreshReconnectAvailability()
                 // Escalate from the keep-frame [Switching] to the full-screen
                 // [Connecting] overlay: we are now doing a real fresh handshake.
+                submitControllerOpen(target)
                 setConnectionState(
                     ConnectionState.Connecting(
                         target.host,
@@ -8266,6 +8286,7 @@ public class TmuxSessionViewModel @Inject constructor(
             activeTarget = target
             connectingTarget = null
             refreshReconnectAvailability()
+            revealControllerLive()
             setConnectionState(
                 ConnectionState.Live(
                     target.host,
@@ -8510,6 +8531,7 @@ public class TmuxSessionViewModel @Inject constructor(
             activeTarget = target
             connectingTarget = null
             refreshReconnectAvailability()
+            revealControllerLive()
             setConnectionState(
                 ConnectionState.Live(
                     target.host,
@@ -9004,6 +9026,9 @@ public class TmuxSessionViewModel @Inject constructor(
         setConnectionState(ConnectionState.Live("test", 0, "test"))
     }
 
+    /** S6 (#1329): the AUTHORITATIVE controller state — a test asserts it DECIDED the transition. */
+    internal fun connectionControllerStateForTest(): CoreConnectionState = connectionManager.state
+
     internal fun attachSessionForAgentRetryForTest(session: SshSession) {
         sessionRef = session
         activeTarget = ConnectionTarget(
@@ -9078,6 +9103,7 @@ public class TmuxSessionViewModel @Inject constructor(
         activeTarget = target
         refreshReconnectAvailability()
         bindProjectRootsForHost(hostId)
+        revealControllerLive()
         setConnectionState(ConnectionState.Live(host, port, user))
         maybeRefreshControlClientSize()
     }
@@ -9154,6 +9180,7 @@ public class TmuxSessionViewModel @Inject constructor(
         )
         connectingTarget = target
         refreshReconnectAvailability()
+        submitControllerSwitch(target)
         // Issue #437 (slice A) / #661: mirror production — a same-host fast
         // switch enters [Switching] (inline indicator), NOT the blanking
         // full-screen [Connecting] overlay; per #661 the reveal machine holds the
@@ -9223,6 +9250,7 @@ public class TmuxSessionViewModel @Inject constructor(
         refreshReconnectAvailability()
         // Issue #661: reveal the new session's surface at the Connected flip
         // (the reveal machine promotes to Live via the seed/promote path).
+        revealControllerLive()
         setConnectionState(ConnectionState.Live(host, port, user))
         recordWarmSwitchMilestone(
             attempt = attempt,
@@ -9302,6 +9330,7 @@ public class TmuxSessionViewModel @Inject constructor(
         connectingTarget = target
         activeTarget = target
         refreshReconnectAvailability()
+        submitControllerOpen(target)
         setConnectionState(ConnectionState.Connecting(host, port, user))
         recordWarmSwitchMilestone(
             attempt = attempt,
@@ -9343,6 +9372,7 @@ public class TmuxSessionViewModel @Inject constructor(
             reseedAllVisiblePanes()
             connectingTarget = null
             refreshReconnectAvailability()
+            revealControllerLive()
             setConnectionState(ConnectionState.Live(host, port, user))
             markSuccessfulAttachForNetworkCoalescing(target, trigger)
             recordWarmSwitchMilestone(

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue1329ControllerDecidesOpenSwitchTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue1329ControllerDecidesOpenSwitchTest.kt
@@ -1,0 +1,207 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.app.sessions.ActiveTmuxClients
+import com.pocketshell.core.connection.ConnectionState as CoreConnectionState
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.SshPortForward
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshShell
+import com.pocketshell.core.tmux.CommandResponse
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+import java.io.InputStream
+
+/**
+ * Roadmap slice **S6 (#1329)** — the OPEN / SWITCH / REVEAL transitions are now DECIDED by the
+ * [com.pocketshell.core.connection.ConnectionController] from the events the VM SUBMITS at the
+ * flow edges (`Enter` / `Switch` / `revealLive`), NOT dictated by the retired inline
+ * `driveControllerIntent` open/switch/reveal arms. These tests read the AUTHORITATIVE controller
+ * state via [TmuxSessionViewModel.connectionControllerStateForTest] and assert it reflects the
+ * controller's own decision.
+ *
+ * RED on base (arms present but the submit-at-edge wiring absent) is not the shape here — the
+ * arms were the *only* driver before this slice, so these assertions pin that the NEW edge
+ * submissions keep the controller authoritative after the arms are deleted (the retirement is
+ * behaviour-preserving, D28: the controller is the single authority).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class Issue1329ControllerDecidesOpenSwitchTest : TmuxSessionViewModelTestBase() {
+
+    /**
+     * Criterion 1: a genuine open/attach REVEAL drives the controller to Live via the reveal
+     * edge (`revealControllerLive`), not the retired `Live → revealLive` dictation arm.
+     */
+    @Test
+    fun revealEdgeDrivesControllerLiveOnOpen() = runTest(scheduler) {
+        val vm = newVm()
+        vm.replaceClientForTest(
+            hostId = 1L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            sessionName = "work",
+            client = FakeTmuxClient(),
+        )
+        runCurrent()
+
+        assertTrue(
+            "the reveal edge must drive the controller to Live (was " +
+                "${vm.connectionControllerStateForTest()})",
+            vm.connectionControllerStateForTest() is CoreConnectionState.Live,
+        )
+        assertTrue(
+            "the displayed status projects Connected from the controller Live",
+            vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+    }
+
+    /**
+     * Criterion 1: the same-host fast-SWITCH WINDOW is the controller's Attaching state, reached
+     * from the submitted [com.pocketshell.core.connection.ConnectionEvent.Switch] (the retired
+     * `Attaching → switchTo` arm). The projected status is Switching, never a swallowed Connected.
+     */
+    @Test
+    fun switchWindowIsControllerDecidedAttaching() = runTest(scheduler) {
+        val vm = newVm()
+        vm.replaceClientForTest(
+            hostId = 1L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            sessionName = "work",
+            client = FakeTmuxClient(),
+        )
+        runCurrent()
+        assertTrue(vm.connectionControllerStateForTest() is CoreConnectionState.Live)
+
+        // The switch window a same-host fast switch holds before the Live flip.
+        vm.forceAttachingStateForTest("alpha.example", 22, "alex")
+        runCurrent()
+
+        assertTrue(
+            "the switch window must be the controller's Attaching state (Switch-decided), was " +
+                "${vm.connectionControllerStateForTest()}",
+            vm.connectionControllerStateForTest() is CoreConnectionState.Attaching,
+        )
+        assertTrue(
+            "the switch window projects Switching from the controller Attaching",
+            vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Switching,
+        )
+    }
+
+    /**
+     * Criterion 1 (end-to-end switch): a same-host fast switch re-targets the controller onto the
+     * NEW session (a distinct [com.pocketshell.core.connection.SessionId]) and the reveal edge
+     * flips it back to Live — all controller-decided from the submitted Switch + revealLive,
+     * with the inline dictation arms deleted.
+     */
+    @Test
+    fun fastSwitchRetargetsControllerAndRevealsLive() = runTest(scheduler) {
+        val registry = ActiveTmuxClients()
+        val vm = newVm(registry = registry)
+        val session = FakeSshSession()
+        vm.replaceClientForTest(
+            hostId = 1L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            sessionName = "work",
+            client = FakeTmuxClient().withSinglePane("work", "%1"),
+            session = session,
+        )
+        runCurrent()
+        val liveBeforeSwitch = vm.connectionControllerStateForTest()
+        assertTrue(liveBeforeSwitch is CoreConnectionState.Live)
+        val workTargetId = (liveBeforeSwitch as CoreConnectionState.Live).targetId
+
+        vm.fastSwitchSessionForTest(
+            hostId = 1L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            sessionName = "other",
+            client = FakeTmuxClient().withSinglePane("other", "%2"),
+            session = session,
+        )
+        advanceUntilIdle()
+
+        val afterSwitch = vm.connectionControllerStateForTest()
+        assertTrue(
+            "the fast switch must reveal the controller Live on the new session, was $afterSwitch",
+            afterSwitch is CoreConnectionState.Live,
+        )
+        assertNotEquals(
+            "the controller must be re-targeted onto the switched-to session (Switch-decided)",
+            workTargetId,
+            (afterSwitch as CoreConnectionState.Live).targetId,
+        )
+        assertTrue(
+            vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+    }
+
+    private fun FakeTmuxClient.withSinglePane(sessionName: String, paneId: String): FakeTmuxClient =
+        apply {
+            responses.addLast(
+                CommandResponse(
+                    number = 1L,
+                    output = listOf("$paneId\t@0\t\$0\t$sessionName\t$sessionName\t0"),
+                    isError = false,
+                ),
+            )
+            capturePaneResponses.addLast(
+                CommandResponse(number = 2L, output = listOf("$sessionName ready"), isError = false),
+            )
+            cursorQueryResponses.addLast(
+                CommandResponse(number = 3L, output = listOf("0,0"), isError = false),
+            )
+        }
+
+    private class FakeSshSession : SshSession {
+        @Volatile
+        private var closed: Boolean = false
+
+        override val isConnected: Boolean get() = !closed
+
+        override suspend fun exec(command: String): ExecResult =
+            ExecResult(stdout = "", stderr = "", exitCode = 0)
+
+        override fun tail(path: String, onLine: (String) -> Unit): Job = Job()
+
+        override fun openLocalPortForward(
+            remoteHost: String,
+            remotePort: Int,
+            localPort: Int,
+        ): SshPortForward = throw NotImplementedError("not needed")
+
+        override fun startShell(): SshShell = throw NotImplementedError("not needed")
+
+        override suspend fun uploadFile(file: File, remotePath: String): String = remotePath
+
+        override suspend fun uploadStream(
+            input: InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String = remotePath
+
+        override fun close() {
+            closed = true
+        }
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue926SeedIoOffMainTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue926SeedIoOffMainTest.kt
@@ -138,6 +138,54 @@ class Issue926SeedIoOffMainTest {
         return vm
     }
 
+    /**
+     * Roadmap slice S6 (#1329), criterion 4: the SAME-HOST FAST SWITCH must not block Main with
+     * its attach/seed IO. This is the switch-specific sibling of
+     * [seedCaptureAndListPanesRunOffMainWithTheShortCeiling]: connect to `work`, then fast-switch
+     * to `other` on the same warm SSH lease, and assert the SWITCH client's `list-panes` reconcile
+     * and `capture-pane` seed both ran OFF the Main (UI) thread — the #895 switch-while-black
+     * freeze was attach/seed IO parking Main during exactly this window.
+     */
+    @Test
+    fun fastSwitchReconcileAndSeedRunOffMain() {
+        val workClient = FakeTmuxClient().withSinglePaneRowButEmptyCapture("work", "%1")
+        val switchClient = FakeTmuxClient().withSinglePaneRowButEmptyCapture("other", "%2")
+        val vm = connectVm(workClient)
+
+        // Route the fast-switch attach to a DISTINCT client so its recorded execution threads
+        // are attributable to the switch, not the initial attach.
+        vm.setTmuxClientFactoryForTest { _, sessionName, _ ->
+            if (sessionName == "other") switchClient else workClient
+        }
+
+        runBlocking(mainDispatcher) {
+            vm.connect(
+                hostId = 1L,
+                hostName = "alpha",
+                host = "alpha.example",
+                port = 22,
+                user = "alex",
+                keyPath = "/keys/a",
+                passphrase = null,
+                sessionName = "other",
+            )
+        }
+        waitUntil("switched to other") {
+            vm.panes.value.any { it.paneId == "%2" }
+        }
+
+        assertNotNull("the fast switch must run a list-panes round-trip", switchClient.lastListPanesThreadName)
+        assertRanOffMain(
+            "the SAME-HOST FAST SWITCH `list-panes` IO",
+            switchClient.lastListPanesThreadName,
+        )
+        assertNotNull("the fast switch must run a seed capture round-trip", switchClient.lastCaptureThreadName)
+        assertRanOffMain(
+            "the SAME-HOST FAST SWITCH seed `capture-pane` IO",
+            switchClient.lastCaptureThreadName,
+        )
+    }
+
     @Test
     fun seedCaptureAndListPanesRunOffMainWithTheShortCeiling() {
         // A single-pane session whose attach-time capture came back EMPTY, so the

--- a/scripts/connection-vm-ratchet-baseline.txt
+++ b/scripts/connection-vm-ratchet-baseline.txt
@@ -6,4 +6,4 @@
 io_count 17
 runblocking_count 13
 connection_decision_variants 0
-vm_line_count 17671
+vm_line_count 17629

--- a/scripts/file-size-hygiene-baseline.txt
+++ b/scripts/file-size-hygiene-baseline.txt
@@ -8,7 +8,7 @@
 177524 app/src/main/java/com/pocketshell/app/composer/PromptComposerViewModel.kt
 147448 app/src/main/java/com/pocketshell/app/projects/FolderListViewModel.kt
 149516 app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
-907910 app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+907894 app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
 148633 app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
 1146350 docs/mockups/feedback/folder-tree-target-20260604.png
 182790 docs/screenshots/readme-settings.png


### PR DESCRIPTION
Connection-roadmap (#1331) slice **S6**. Migrates the last inline transitions (OPEN/SWITCH) to `ConnectionController.submit(Enter/Switch)` — the controller is now the authority, the `driveControllerIntent` open/switch/reveal dictation arms are deleted — and routes attach/seed reconcile IO off the Main thread, **fixing the #895 switch-while-black-band freeze**. VM god-object shrinks 17671→17629 lines (ratchet re-baked downward).

**Reviewer APPROVED** (code + JVM + hygiene) AND the mandatory #638 emulator+Docker journeys are GREEN: #895 1/1 (escapable band, no freeze), A→B→C→A 4/4 (non-stale session + reseed + IO-off-Main proven via main-thread probe), DeepLink 1/1, Grace 3/3. Unblocks the #1460 send-lane freeze, S7, render-heal R1, and the rest of the TmuxSessionViewModel cluster. Closes #1329.