### PR TITLE
sessions: gate dashboard list-sessions poll to foreground-only (#1164)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/hosts/HostListScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/hosts/HostListScreen.kt
@@ -364,6 +364,14 @@ fun HostListScreen(
     LaunchedEffect(Unit) {
         viewModel.refreshResumableSession()
     }
+    // Issue #1164 (battery/heat): gate the cross-host `list-sessions` poll
+    // on the whole-process foreground state so it stops firing SSH
+    // round-trips while the app is backgrounded / the screen is off. The
+    // ViewModel parks each per-host poller on ProcessLifecycleOwner's
+    // STARTED state and resumes with a prompt refresh on return.
+    LaunchedEffect(Unit) {
+        sessionsViewModel.observeProcessLifecycle()
+    }
 
     // Fire navigation once the ViewModel marks the pending route ready.
     // The ViewModel handles the cache-hit fast path (immediate ready)

--- a/app/src/main/java/com/pocketshell/app/sessions/SessionsDashboardViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/sessions/SessionsDashboardViewModel.kt
@@ -2,6 +2,10 @@ package com.pocketshell.app.sessions
 
 import android.content.Context
 import android.util.Log
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.pocketshell.app.systemsurfaces.ActiveSessionsWidgetProvider
@@ -24,6 +28,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
 
@@ -72,6 +77,25 @@ import javax.inject.Inject
  * navigation away and back. Per-host poller [Job]s are cancelled and
  * restarted as the registry's snapshot changes, and all of them tear
  * down when [onCleared] cancels `viewModelScope`.
+ *
+ * ## Foreground-gated polling (battery — issue #1164)
+ *
+ * The `list-sessions` poll only exists to keep the visible dashboard's
+ * relative timestamps + agent chips fresh, so it must not run while the
+ * app is backgrounded / the screen is off — a backgrounded dashboard
+ * nobody is looking at that keeps firing an SSH `list-sessions` round-trip
+ * per host every 10s is pure battery/heat waste (the audit's "clearest
+ * small win", #1164). Each per-host [pollLoop] parks on [processStarted]
+ * (`first { it }`) at the top of every iteration: while the whole process
+ * is below [Lifecycle.State.STARTED] (the user has backgrounded the app,
+ * `ON_STOP`) no poll fires; on `ON_START` the loop resumes with an
+ * immediate fetch so the dashboard is never stale on return.
+ *
+ * [processStarted] is driven by [ProcessLifecycleOwner] via
+ * [observeProcessLifecycle], which the host landing screen calls once on
+ * composition. The mechanism mirrors
+ * [com.pocketshell.app.usage.UsageScheduler] — the dashboard's sibling
+ * periodic poll, already foreground-gated for the same D21 reason.
  *
  * ## Testability
  *
@@ -140,6 +164,38 @@ class SessionsDashboardViewModel @Inject constructor(
     private val perHostSnapshots: MutableMap<Long, List<SessionSummary>> = mutableMapOf()
     private var registryJob: Job? = null
 
+    /**
+     * Whole-process foreground signal (issue #1164). `true` while the
+     * process is at least [Lifecycle.State.STARTED] — an Activity is
+     * visible to the user. Each [pollLoop] parks on this flag so no
+     * `list-sessions` round-trip fires while the app is backgrounded /
+     * the screen is off.
+     *
+     * Defaults to `true` so a view model that is never attached to a
+     * lifecycle (the unit-test seams that construct it directly) polls
+     * exactly as before. Production wiring calls [observeProcessLifecycle]
+     * from the host landing screen, which seeds the flag from the owner's
+     * current state and flips it on every `ON_START` / `ON_STOP`.
+     */
+    private val _processStarted = MutableStateFlow(true)
+    val processStarted: StateFlow<Boolean> = _processStarted.asStateFlow()
+
+    /**
+     * The attached process lifecycle + its observer. Kept as fields so
+     * [onCleared] can detach cleanly and a second [observeProcessLifecycle]
+     * with the same owner is a no-op (a different owner detaches the
+     * previous one first — the [com.pocketshell.app.usage.UsageScheduler]
+     * / [com.pocketshell.app.portfwd.PortForwardPanelViewModel] pattern).
+     */
+    private var attachedLifecycle: Lifecycle? = null
+    private val lifecycleObserver = LifecycleEventObserver { _: LifecycleOwner, event ->
+        when (event) {
+            Lifecycle.Event.ON_START -> _processStarted.value = true
+            Lifecycle.Event.ON_STOP -> _processStarted.value = false
+            else -> Unit
+        }
+    }
+
     init {
         // One supervising coroutine watches the registry. When the
         // snapshot of clients changes we diff against [pollerJobs] and
@@ -203,6 +259,17 @@ class SessionsDashboardViewModel @Inject constructor(
         // possible after register; subsequent polls back off to the
         // configured cadence.
         while (currentCoroutineContext().isActive) {
+            // Issue #1164 (battery/heat): gate every poll on the
+            // whole-process foreground state. While the app is
+            // backgrounded / screen off (`ON_STOP` -> processStarted
+            // false) `first { it }` parks the loop, so no `list-sessions`
+            // SSH round-trip fires — the dashboard nobody is looking at
+            // stops draining battery. On `ON_START` the flag flips true,
+            // the loop resumes here and immediately fetches, so the list
+            // is never stale on return. When no lifecycle is attached
+            // (unit-test seams) the flag defaults true and this returns
+            // instantly — unchanged behaviour.
+            processStarted.first { it }
             val rows = runCatching { fetchSessions(entry) }.getOrNull()
             if (rows != null) {
                 perHostSnapshots[entry.hostId] = rows
@@ -272,7 +339,49 @@ class SessionsDashboardViewModel @Inject constructor(
         }
     }
 
+    /**
+     * Attach the whole-process lifecycle so the `list-sessions` poll is
+     * gated on foreground state (issue #1164). Called once from the host
+     * landing screen's composition. Seeds [processStarted] from the
+     * owner's current state so a screen that mounts while already visible
+     * doesn't have to wait for the next `ON_START`, then flips it on every
+     * subsequent `ON_START` / `ON_STOP`.
+     *
+     * Idempotent: a second call with the same owner is a no-op; a
+     * different owner detaches the previous one first so tests can
+     * re-attach to a fresh `LifecycleRegistry`. Mirrors
+     * [com.pocketshell.app.usage.UsageScheduler.observeProcessLifecycle]
+     * and [com.pocketshell.app.portfwd.PortForwardPanelViewModel.observeProcessLifecycle].
+     */
+    fun observeProcessLifecycle(owner: LifecycleOwner = ProcessLifecycleOwner.get()) {
+        val lifecycle = owner.lifecycle
+        if (attachedLifecycle === lifecycle) return
+        attachedLifecycle?.removeObserver(lifecycleObserver)
+        attachedLifecycle = lifecycle
+        // `Lifecycle.addObserver` + reading `currentState` require the
+        // main thread; hop there explicitly so a call from any dispatcher
+        // is safe. The observer then runs on whatever thread the lifecycle
+        // dispatches on (always Main in production).
+        viewModelScope.launch {
+            withContext(Dispatchers.Main) {
+                _processStarted.value =
+                    lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)
+                lifecycle.addObserver(lifecycleObserver)
+            }
+        }
+    }
+
+    /**
+     * Visible-for-testing seam: flip the foreground flag without a real
+     * lifecycle owner. Production wiring uses [observeProcessLifecycle].
+     */
+    internal fun setProcessStartedForTest(started: Boolean) {
+        _processStarted.value = started
+    }
+
     override fun onCleared() {
+        attachedLifecycle?.removeObserver(lifecycleObserver)
+        attachedLifecycle = null
         stopPolling()
         super.onCleared()
     }

--- a/app/src/test/java/com/pocketshell/app/sessions/SessionsDashboardViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/sessions/SessionsDashboardViewModelTest.kt
@@ -1,5 +1,8 @@
 package com.pocketshell.app.sessions
 
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
 import com.pocketshell.app.hosts.MainDispatcherRule
 import com.pocketshell.app.tmux.FakeTmuxClient
 import com.pocketshell.core.storage.entity.HostEntity
@@ -1003,6 +1006,128 @@ class SessionsDashboardViewModelTest {
         assertNotNull(vm.createError.value)
         vm.clearCreateError()
         assertNull(vm.createError.value)
+    }
+
+    /**
+     * Issue #1164 (battery/heat) — load-bearing battery property, driven
+     * through the REAL [SessionsDashboardViewModel.observeProcessLifecycle]
+     * path: while the whole process is backgrounded (`ON_STOP`) the
+     * `list-sessions` poll MUST stop firing SSH round-trips, and it MUST
+     * resume promptly on `ON_START`.
+     *
+     * Reproduces the pre-fix gap: without the foreground gate, the poller
+     * keeps issuing `list-sessions` on cadence forever while the app is
+     * backgrounded / screen off — the audit's "clearest small win". The
+     * red case (fix reverted) fails the "no polls while backgrounded"
+     * assertEquals below; the fix parks the loop so it holds.
+     */
+    @Test
+    fun pollParksWhenBackgroundedAndResumesPromptlyOnForeground() = runTest {
+        val registry = newRegistry()
+        val vm = newVm(registry = registry, pollMs = 50L)
+
+        // FakeTmuxClient with no queued responses returns an empty success
+        // per poll, so every poll still records a `list-sessions` command.
+        val client = FakeTmuxClient()
+        val owner = ManualLifecycleOwner().also { it.moveTo(Lifecycle.State.STARTED) }
+        vm.observeProcessLifecycle(owner)
+        runCurrent()
+
+        register(registry, host(1L, "h"), "/k", client)
+        runCurrent()
+
+        fun listSessionsPolls() = client.sentCommands.count { it.startsWith("list-sessions") }
+
+        // Foreground: the immediate first poll fired and the cadence keeps ticking.
+        val afterRegister = listSessionsPolls()
+        assertTrue("foreground poll must fire on register", afterRegister >= 1)
+        advanceTimeBy(50L * 3)
+        runCurrent()
+        val foregroundPolls = listSessionsPolls()
+        assertTrue(
+            "foreground poll must keep ticking on cadence (was $afterRegister, now $foregroundPolls)",
+            foregroundPolls > afterRegister,
+        )
+
+        // Background (ON_STOP): the poller parks.
+        owner.moveTo(Lifecycle.State.CREATED) // dispatches ON_STOP
+        runCurrent()
+        // Flush any in-flight cadence delay so the loop reaches its park point.
+        advanceTimeBy(50L)
+        runCurrent()
+        val atBackground = listSessionsPolls()
+
+        // Advance well past many cadences while backgrounded — the
+        // load-bearing battery assertion: ZERO further polls.
+        advanceTimeBy(50L * 20)
+        runCurrent()
+        assertEquals(
+            "backgrounded dashboard must issue NO further list-sessions polls (battery #1164)",
+            atBackground,
+            listSessionsPolls(),
+        )
+
+        // Foreground again (ON_START): poll resumes with a prompt refresh.
+        owner.moveTo(Lifecycle.State.STARTED) // dispatches ON_START
+        runCurrent()
+        assertTrue(
+            "returning to foreground must promptly resume the poll (was $atBackground)",
+            listSessionsPolls() > atBackground,
+        )
+        vm.stopForTest()
+    }
+
+    /**
+     * Issue #1164 — focused proof of the poll gate itself, isolated from
+     * the lifecycle plumbing via [SessionsDashboardViewModel.setProcessStartedForTest].
+     * A backgrounded process (flag false) must never issue a
+     * `list-sessions`, even across many cadences; flipping to foreground
+     * fires the parked poll immediately.
+     */
+    @Test
+    fun pollIsSuppressedWhileProcessBackgroundedAndFiresOnForeground() = runTest {
+        val registry = newRegistry()
+        val vm = newVm(registry = registry, pollMs = 50L)
+        // Enter the backgrounded state BEFORE the host registers.
+        vm.setProcessStartedForTest(false)
+        val client = FakeTmuxClient()
+        register(registry, host(1L, "h"), "/k", client)
+        runCurrent()
+        advanceTimeBy(50L * 10)
+        runCurrent()
+        assertEquals(
+            "no list-sessions may fire while the process is backgrounded",
+            0,
+            client.sentCommands.count { it.startsWith("list-sessions") },
+        )
+
+        // Flip to foreground — the parked poller fires promptly.
+        vm.setProcessStartedForTest(true)
+        runCurrent()
+        assertTrue(
+            "the poll must fire promptly once the process is foreground",
+            client.sentCommands.any { it.startsWith("list-sessions") },
+        )
+        vm.stopForTest()
+    }
+
+    /**
+     * Manual [LifecycleOwner] backed by [LifecycleRegistry.createUnsafe] so
+     * the registry does NOT enforce the main thread — this test class runs
+     * without Robolectric (no real main looper), and `createUnsafe` lets
+     * `addObserver` / `currentState =` dispatch synchronously on the test
+     * thread. Tests drive transitions via [moveTo]; the dashboard's
+     * lifecycle observer then fires deterministically.
+     */
+    private class ManualLifecycleOwner : LifecycleOwner {
+        private val registry = LifecycleRegistry.createUnsafe(this).apply {
+            currentState = Lifecycle.State.INITIALIZED
+        }
+        override val lifecycle: Lifecycle = registry
+
+        fun moveTo(state: Lifecycle.State) {
+            registry.currentState = state
+        }
     }
 
     /**


### PR DESCRIPTION
Battery win from the #1164 audit: the per-host `list-sessions` dashboard poll (10s) was ungated — polling every host while backgrounded/screen-off. Gate it on `ProcessLifecycleOwner` (same mechanism `UsageScheduler` already uses): parks the poll on ON_STOP, resumes with an immediate fetch on ON_START (no stale data). Reviewer APPROVED — red→green proven (un-gated poll reschedules forever = the drain; gated it parks); 31 unit tests green, scope-clean (3 files, no FGS/wakelock/#1467/S6 areas touched). Closes #1164