### PR TITLE
tmux: send interactive keys via the exec lane, not shared -CC (#1460 — last Codex-freeze mechanism)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxInputCommands.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxInputCommands.kt
@@ -4,6 +4,40 @@ import com.pocketshell.core.terminal.input.BracketedPaste
 import com.pocketshell.core.tmux.CommandResponse
 import com.pocketshell.core.tmux.TmuxClient
 
+/**
+ * Issue #1460: type a literal UTF-8 string into [paneId] via `send-keys -l` on
+ * the interactive send EXEC lane (not the shared `-CC` channel), so it does not
+ * head-of-line-block behind a live agent `%output` burst.
+ */
+internal suspend fun sendLiteralTextKeys(
+    client: TmuxClient,
+    paneId: String,
+    text: String,
+): CommandResponse =
+    client.sendKeysViaExec("send-keys -l -t $paneId -- '${escapeSingleQuoted(text)}'")
+
+/**
+ * Issue #1460: send a tmux named key (`Enter`, `Tab`, `BSpace`, `Up`, a
+ * `C-<letter>` modifier, …) to [paneId] on the interactive send exec lane.
+ */
+internal suspend fun sendNamedKeyToPane(
+    client: TmuxClient,
+    paneId: String,
+    key: String,
+): CommandResponse =
+    client.sendKeysViaExec("send-keys -t $paneId $key")
+
+/**
+ * Issue #1460: exit copy-mode in [paneId] (`send-keys -X … cancel`) on the
+ * interactive send exec lane so a pane in copy-mode can accept input without
+ * wedging behind a burst.
+ */
+internal suspend fun sendCancelCopyMode(
+    client: TmuxClient,
+    paneId: String,
+): CommandResponse =
+    client.sendKeysViaExec("send-keys -X -t $paneId cancel")
+
 internal suspend fun sendRawInputBytes(
     client: TmuxClient,
     paneId: String,
@@ -11,7 +45,10 @@ internal suspend fun sendRawInputBytes(
 ) {
     val hex = BracketedPaste.hex(bytes)
     if (hex.isEmpty()) return
-    client.sendCommand("send-keys -H -t $paneId $hex")
+    // Issue #1460: the `-H` raw-byte injection rides the interactive send exec
+    // lane, not the shared `-CC` channel, so it does not head-of-line-block
+    // behind a live agent `%output` burst.
+    client.sendKeysViaExec("send-keys -H -t $paneId $hex")
 }
 
 /**
@@ -36,7 +73,11 @@ internal suspend fun sendBracketedPaste(
 ) {
     if (bytes.isEmpty()) return
     for (hex in BracketedPaste.hexChunks(bytes, TMUX_PASTE_BODY_CHUNK_BYTES)) {
-        client.sendCommand("send-keys -H -t $paneId $hex")
+        // Issue #1460: each bracketed-paste body chunk rides the interactive send
+        // exec lane (awaited sequentially, so ordering is preserved) instead of
+        // the shared `-CC` channel — a multi-chunk paste to a live agent mid-burst
+        // no longer wedges behind the burst's `%output` on the one sshj reader.
+        client.sendKeysViaExec("send-keys -H -t $paneId $hex")
             .throwIfTmuxError("paste chunk into pane $paneId")
     }
 }

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -14056,11 +14056,11 @@ public class TmuxSessionViewModel @Inject constructor(
             if (payloadBytes.size > TMUX_PASTE_BODY_CHUNK_BYTES || BracketedPaste.containsLineBreak(payloadBytes)) {
                 sendBracketedPaste(client, paneId, payloadBytes)
             } else if (payload.isNotEmpty()) {
-                client.sendCommand("send-keys -l -t $paneId -- '${escapeSingleQuoted(payload)}'")
+                sendLiteralTextKeys(client, paneId, payload)
                     .throwIfTmuxError("type agent input into pane $paneId")
             }
             awaitAgentPasteIngestedBeforeSubmit(client, paneId, payload, agent)
-            client.sendCommand("send-keys -t $paneId Enter")
+            sendNamedKeyToPane(client, paneId, "Enter")
                 .throwIfTmuxError("submit pasted agent input")
             // Issue #941 (black-screen B1): the maintainer's "I sent a message and
             // everything became black" symptom. After the submit Enter, a full-screen
@@ -15652,11 +15652,11 @@ public class TmuxSessionViewModel @Inject constructor(
             when (token) {
                 is TmuxInputToken.Literal -> {
                     if (token.text.isNotEmpty()) {
-                        client.sendCommand("send-keys -l -t $paneId -- '${escapeSingleQuoted(token.text)}'")
+                        sendLiteralTextKeys(client, paneId, token.text)
                     }
                 }
                 is TmuxInputToken.NamedKey -> {
-                    client.sendCommand("send-keys -t $paneId ${token.name}")
+                    sendNamedKeyToPane(client, paneId, token.name)
                 }
             }
         }
@@ -15664,7 +15664,7 @@ public class TmuxSessionViewModel @Inject constructor(
 
     private suspend fun ensurePaneAcceptsInput(client: TmuxClient, paneId: String) {
         if (paneRows[paneId]?.inCopyMode != true) return
-        client.sendCommand("send-keys -X -t $paneId cancel")
+        sendCancelCopyMode(client, paneId)
             .throwIfTmuxError("exit copy-mode for pane $paneId")
         markPaneCopyMode(paneId, false)
     }
@@ -15692,7 +15692,7 @@ public class TmuxSessionViewModel @Inject constructor(
         bridgeScope.launch {
             runCatching {
                 ensurePaneAcceptsInput(client, paneId)
-                client.sendCommand("send-keys -t $paneId $key")
+                sendNamedKeyToPane(client, paneId, key)
             }
         }
     }

--- a/scripts/file-size-hygiene-baseline.txt
+++ b/scripts/file-size-hygiene-baseline.txt
@@ -8,7 +8,7 @@
 177524 app/src/main/java/com/pocketshell/app/composer/PromptComposerViewModel.kt
 147448 app/src/main/java/com/pocketshell/app/projects/FolderListViewModel.kt
 149516 app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
-907894 app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+907779 app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
 148633 app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
 1146350 docs/mockups/feedback/folder-tree-target-20260604.png
 182790 docs/screenshots/readme-settings.png

--- a/shared/core-tmux/src/integrationTest/java/com/pocketshell/core/tmux/TmuxClientIntegrationTest.kt
+++ b/shared/core-tmux/src/integrationTest/java/com/pocketshell/core/tmux/TmuxClientIntegrationTest.kt
@@ -706,4 +706,111 @@ class TmuxClientIntegrationTest {
             scope.cancel()
         }
     }
+
+    @Test
+    fun `sendKeysViaExec delivers keys to a real pane and returns fast during a -CC burst`() = runBlocking {
+        // Issue #1460 (G10 real-path, no emulator): the residual SEND-side wedge
+        // #1459 found after #1316 fixed the attach side — typing a message and
+        // hitting Send to a live agent mid-`%output`-burst head-of-line-blocked
+        // the send's `%begin`/`%end` reply on the ONE sshj reader (the
+        // maintainer's "app froze, had to restart"). The fix moves the
+        // interactive `send-keys` off `-CC` onto the exec lane.
+        //
+        // Two real-tmux assertions:
+        //   Phase A — FUNCTIONAL: `sendKeysViaExec` (a fresh `tmux send-keys`
+        //     exec client) actually injects keys into the pane; the echoed
+        //     marker appears in an authoritative `capture-pane`.
+        //   Phase B — LIVENESS: during a `-CC` %output burst the exec-lane send
+        //     returns fast + non-error (it does not wait on the busy `-CC`
+        //     reader). Note: the DETERMINISTIC red→green discriminator for the
+        //     head-of-line wedge is the JVM `TmuxClientExecLaneTest` (a held
+        //     `-CC` sendMutex) — a fast Docker host flushes a bounded burst's
+        //     `%begin`/`%end` between frames faster than the phone's
+        //     throughput-bound reader, so this Phase B is real-path GREEN
+        //     confirmation, not the RED discriminator (same as the #1316
+        //     precedent above).
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        try {
+            connectSession().use { session ->
+                val sessionName = "it-${System.nanoTime()}"
+                val client: TmuxClient = TmuxClientFactory(scope).create(
+                    session,
+                    sessionName = sessionName,
+                )
+                client.use {
+                    it.connect()
+                    delay(500)
+                    val paneId = withTimeout(10_000) {
+                        it.sendCommand("display-message -p \"#{pane_id}\"")
+                    }.output.firstOrNull()?.trim().orEmpty()
+                    assertTrue("pane id must resolve; got '$paneId'", paneId.startsWith("%"))
+
+                    // Phase A — FUNCTIONAL: inject `echo <marker>` + Enter via the
+                    // exec lane into an idle pane and confirm the echoed marker
+                    // appears. Proves a fresh `tmux send-keys` exec client really
+                    // delivers keys to the pane (the whole point of the send move).
+                    val marker = "PS1460MARK${System.nanoTime()}"
+                    withTimeout(10_000) {
+                        it.sendKeysViaExec("send-keys -l -t $paneId -- 'echo $marker'", timeoutMs = 5_000L)
+                    }
+                    withTimeout(10_000) {
+                        it.sendKeysViaExec("send-keys -t $paneId Enter", timeoutMs = 5_000L)
+                    }
+                    val delivered = withTimeout(15_000) {
+                        var seen = false
+                        val deadline = System.currentTimeMillis() + 12_000
+                        while (System.currentTimeMillis() < deadline && !seen) {
+                            val capture = it.capturePaneTextViaExec(paneId, timeoutMs = 4_000L)
+                            // The echoed line (command result) must appear, not just
+                            // the typed command — assert the marker shows at least
+                            // twice (typed + echoed) OR on its own output line.
+                            if (capture.output.count { line -> line.contains(marker) } >= 2) seen = true
+                            if (!seen) delay(200)
+                        }
+                        seen
+                    }
+                    assertTrue(
+                        "the exec-lane send-keys must actually deliver '$marker' to the real pane",
+                        delivered,
+                    )
+
+                    // Phase B — LIVENESS: drive a `-CC` %output burst and confirm
+                    // the exec-lane send returns fast + non-error during it.
+                    val burstBytes = java.util.concurrent.atomic.AtomicLong(0)
+                    val collector = scope.launch {
+                        it.outputFor(paneId).collect { evt -> burstBytes.addAndGet(evt.data.size.toLong()) }
+                    }
+                    delay(200)
+                    withTimeout(10_000) {
+                        it.sendCommand("send-keys -t $paneId 'seq 1 400000' Enter")
+                    }
+                    val burstDeadline = System.currentTimeMillis() + 10_000
+                    while (System.currentTimeMillis() < burstDeadline && burstBytes.get() < 50_000L) {
+                        delay(20)
+                    }
+                    assertTrue(
+                        "the -CC channel must actually be streaming a burst; sawBytes=${burstBytes.get()}",
+                        burstBytes.get() >= 50_000L,
+                    )
+                    val startedAt = System.currentTimeMillis()
+                    val sendResponse = withTimeout(10_000) {
+                        it.sendKeysViaExec("send-keys -H -t $paneId 20", timeoutMs = 6_000L)
+                    }
+                    val elapsed = System.currentTimeMillis() - startedAt
+                    collector.cancel()
+                    assertFalse(
+                        "exec-lane send must succeed during a -CC burst; got ${sendResponse.output}",
+                        sendResponse.isError,
+                    )
+                    assertTrue(
+                        "exec-lane send must return within the short ceiling during a burst " +
+                            "(elapsed ${elapsed}ms)",
+                        elapsed < 5_000L,
+                    )
+                }
+            }
+        } finally {
+            scope.cancel()
+        }
+    }
 }

--- a/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxClient.kt
+++ b/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxClient.kt
@@ -244,6 +244,42 @@ public interface TmuxClient : AutoCloseable {
     ): CommandResponse = sendCommand(listPanesCommand)
 
     /**
+     * Issue #1460: run an interactive INPUT-INJECTION tmux command (`send-keys`
+     * in all its flavours — `-l` literal, named-key, `-H` hex bracketed-paste
+     * body, `-X … cancel` copy-mode exit) on a DEDICATED [SshSession.exec]
+     * channel — the SAME independent lane [listPanesViaExec] (#1316) and
+     * [captureWithCursor] (#1297) use — NOT the shared per-host `-CC`
+     * control-mode channel that [sendCommand] awaits `%begin`/`%end` on.
+     *
+     * The send path was the residual [sendCommand] SPOF the #1459 Codex-freeze
+     * audit found after #1316 fixed the attach side. When the user types a
+     * message and hits Send to a live agent mid-`%output`-burst, the send's
+     * `%begin`/`%end` reply was HEAD-OF-LINE-BLOCKED behind the burst on the ONE
+     * sshj transport reader (`sendCommand` awaits its reply on that reader), so
+     * the UI action wedged — the maintainer's "app froze, had to restart". The
+     * exec lane reads its OWN channel's stdout OUTSIDE the transport dispatcher,
+     * so `send-keys` returns while a burst saturates `-CC`.
+     *
+     * [sendKeysCommand] is the `-CC`-form command WITHOUT the leading `tmux`
+     * (e.g. `send-keys -l -t '%0' -- 'hi'`), so the caller's command string is
+     * preserved unchanged. Interactive input is ordered by awaiting each call
+     * sequentially, exactly as the `-CC` path did — `send-keys` is synchronous
+     * server-side, so a completed exec has queued its keys before the next runs.
+     * [timeoutMs] bounds the round-trip so a genuinely wedged/half-open
+     * transport surfaces a [TmuxClientException] fast (and the composer keeps
+     * the unsent draft) instead of parking the send. `send-keys` prints nothing
+     * on success (empty [CommandResponse.output], non-error); a non-zero exit
+     * (pane/session gone) surfaces as an error response carrying stderr.
+     *
+     * The default implementation falls back to a `-CC` [sendCommand] for
+     * [TmuxClient] doubles that do not model an exec lane.
+     */
+    public suspend fun sendKeysViaExec(
+        sendKeysCommand: String,
+        timeoutMs: Long? = null,
+    ): CommandResponse = sendCommand(sendKeysCommand)
+
+    /**
      * Subscribe to `%output` events for a single pane.
      *
      * Multiple callers may subscribe to the same pane — the underlying
@@ -1309,6 +1345,59 @@ internal class RealTmuxClient(
             )
         }
         return parseListPanesExecResult(execResult)
+    }
+
+    /**
+     * Issue #1460: run an interactive `send-keys` input-injection command on the
+     * DEDICATED [SshSession.exec] channel — the same independent lane
+     * [listPanesViaExec] (#1316) / [captureWithCursor] (#1297) use — NOT the
+     * shared per-host `-CC` control-mode [sendMutex].
+     *
+     * The send path was the residual `sendCommand` SPOF (#1459 audit): a Send to
+     * a live agent mid-`%output`-burst head-of-line-blocked its `%begin`/`%end`
+     * reply behind the burst on the ONE sshj transport reader, wedging the UI
+     * action (the maintainer's "app froze, had to restart"). The exec lane reads
+     * its OWN channel's stdout OUTSIDE the transport dispatcher, so `send-keys`
+     * returns while a burst saturates `-CC`. [sendKeysCommand] is the `-CC`-form
+     * command (no leading `tmux`); [timeoutMs] bounds the round-trip so a
+     * genuinely wedged/half-open transport surfaces a [TmuxClientException] fast
+     * instead of parking the send (cancelling the exec closes its OWN channel,
+     * never `-CC`).
+     */
+    override suspend fun sendKeysViaExec(
+        sendKeysCommand: String,
+        timeoutMs: Long?,
+    ): CommandResponse {
+        if (closed) throw TmuxClientException("client is closed")
+        if (!connected) throw TmuxClientException("client is not connected")
+        val effectiveTimeoutMs = timeoutMs?.coerceIn(1L, commandTimeoutMs) ?: commandTimeoutMs
+        val command = "tmux $sendKeysCommand"
+        val execResult =
+            try {
+                // Independent of the busy `-CC` channel, so this returns fast under
+                // a burst. The ceiling is the safety bound for a genuinely
+                // wedged/half-open transport; cancelling the exec closes its OWN
+                // channel (RealSshSession.exec cancellation handler), never `-CC`.
+                withTimeoutOrNull(effectiveTimeoutMs) {
+                    session.exec(command)
+                }
+            } catch (t: Throwable) {
+                throw TmuxClientException(
+                    "tmux send-keys exec (interactive send lane) failed: ${t.message}",
+                    t,
+                )
+            }
+        if (execResult == null) {
+            Log.w(
+                ISSUE_244_DIAG_TAG,
+                "tmux sendKeysViaExec exec timed out >${effectiveTimeoutMs}ms " +
+                    "(interactive send lane); surfacing a best-effort failure.",
+            )
+            throw TmuxClientException(
+                "tmux send-keys (exec interactive send lane) timed out after ${effectiveTimeoutMs}ms",
+            )
+        }
+        return parseSendKeysExecResult(execResult)
     }
 
     /**

--- a/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxExecResultParsers.kt
+++ b/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxExecResultParsers.kt
@@ -70,6 +70,19 @@ internal fun parseListPanesExecResult(result: ExecResult): CommandResponse {
 }
 
 /**
+ * Issue #1460: turn a `send-keys` (or other input-injection) [ExecResult] from
+ * the interactive send exec lane into a [CommandResponse]. `send-keys` prints
+ * nothing on success, so a zero exit yields an empty, non-error response (the
+ * caller's `throwIfTmuxError` treats it as success); a non-zero exit
+ * (pane/session gone) surfaces as an error response carrying the stderr, so a
+ * failed send still fails honestly and the composer keeps the unsent draft. The
+ * parse rule is identical to [parseListPanesExecResult] (empty-stdout success /
+ * stderr-on-error), so it delegates.
+ */
+internal fun parseSendKeysExecResult(result: ExecResult): CommandResponse =
+    parseListPanesExecResult(result)
+
+/**
  * Split the `capture-pane` payload into lines, dropping the single trailing
  * empty line the terminal newline produces so the output matches the per-line
  * list the old `-CC` block drain returned.

--- a/shared/core-tmux/src/test/java/com/pocketshell/core/tmux/TmuxClientExecLaneTest.kt
+++ b/shared/core-tmux/src/test/java/com/pocketshell/core/tmux/TmuxClientExecLaneTest.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.coroutines.yield
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -368,6 +369,261 @@ class TmuxClientExecLaneTest {
                 client.close()
             }
         }
+
+    // ---------------------------------------------------------------------
+    // Issue #1460: the send-lane wedge — the residual `sendCommand` SPOF the
+    // #1459 Codex-freeze audit found after #1316 fixed the attach side. Typing
+    // a message and hitting Send to a live agent mid-`%output`-burst
+    // head-of-line-blocked the send's `%begin`/`%end` reply behind the burst on
+    // the ONE sshj reader (the maintainer's "app froze, had to restart"). The
+    // fix moves the interactive `send-keys` round-trips onto the exec lane.
+    // ---------------------------------------------------------------------
+
+    @Test
+    fun `RED — send-keys on the shared -CC sendCommand wedges behind a held control channel`() =
+        runBlocking {
+            // Issue #1460 (reproduce-first): this is the BUG. When the shared
+            // per-host `-CC` sendMutex is held by an in-flight command whose
+            // reply is head-of-line-blocked behind a live agent's `%output`
+            // burst, a `send-keys` issued through `sendCommand` (the OLD send
+            // path) cannot acquire the mutex and wedges — exactly the composer
+            // Send freeze. Documents WHY the send lane moved off `-CC`; the
+            // sibling GREEN tests below prove `sendKeysViaExec` does NOT wedge.
+            val shell = FakeShell()
+            val session = FakeSession(shell, execHandler = sendKeysExecHandler())
+            val client = RealTmuxClient(session, scope, commandTimeoutMs = 30_000L)
+            try {
+                client.connect()
+                withTimeout(2_000) {
+                    while (shell.stdinBytes().isEmpty()) { yield(); delay(10) }
+                }
+                shell.resetStdin()
+
+                // Wedge `-CC`: this command never gets a `%begin`/`%end` reply
+                // (the FakeShell never answers), modelling a reply stuck behind
+                // a sustained `%output` burst on the single sshj reader. It holds
+                // the sendMutex.
+                val wedger = scope.async { runCatching { client.sendCommand("list-clients") } }
+                withTimeout(2_000) {
+                    while (!shell.stdinAsString().contains("list-clients")) { yield(); delay(10) }
+                }
+
+                // The OLD send path (`sendCommand("send-keys …")`) must NOT
+                // complete within a generous budget — it is wedged behind the
+                // held mutex. This is the reproduced freeze.
+                val completed = withTimeoutOrNull(1_500) {
+                    client.sendCommand("send-keys -l -t %0 -- 'hello'")
+                }
+                assertNull(
+                    "BUG REPRO: send-keys on the shared -CC sendCommand must wedge " +
+                        "behind the held control channel (it returned $completed)",
+                    completed,
+                )
+                wedger.cancel()
+            } finally {
+                client.close()
+            }
+        }
+
+    @Test
+    fun `GREEN — literal send-keys completes on the exec lane while the -CC channel is wedged`() =
+        runBlocking {
+            // Issue #1460: the FIX. The same held `-CC` mutex no longer blocks a
+            // literal `send-keys -l` — it rides the dedicated exec channel and
+            // returns fast. Same wedge as the RED test above; the only change is
+            // `sendCommand` → `sendKeysViaExec`.
+            assertSendKeysViaExecCompletesDuringCcWedge(
+                sendKeysCommand = "send-keys -l -t %0 -- 'hello'",
+                expectExecContains = "tmux send-keys -l -t %0 -- 'hello'",
+            )
+        }
+
+    @Test
+    fun `GREEN — named-key Enter send-keys completes on the exec lane while the -CC channel is wedged`() =
+        runBlocking {
+            // Issue #1460 class coverage: the submit Enter (composer Send's final
+            // round-trip) is the round-trip most likely to be issued mid-burst.
+            assertSendKeysViaExecCompletesDuringCcWedge(
+                sendKeysCommand = "send-keys -t %0 Enter",
+                expectExecContains = "tmux send-keys -t %0 Enter",
+            )
+        }
+
+    @Test
+    fun `GREEN — hex bracketed-paste send-keys -H completes on the exec lane while the -CC channel is wedged`() =
+        runBlocking {
+            // Issue #1460 class coverage: multi-line paste + raw-byte injection
+            // (write-stdin) both funnel through `send-keys -H`. It must not wedge
+            // behind a burst either.
+            assertSendKeysViaExecCompletesDuringCcWedge(
+                sendKeysCommand = "send-keys -H -t %0 1b 5b 32 30 30 7e",
+                expectExecContains = "tmux send-keys -H -t %0 1b 5b 32 30 30 7e",
+            )
+        }
+
+    @Test
+    fun `GREEN — copy-mode cancel send-keys -X completes on the exec lane while the -CC channel is wedged`() =
+        runBlocking {
+            // Issue #1460 class coverage: `ensurePaneAcceptsInput` fires a
+            // `send-keys -X … cancel` before input when a pane is in copy-mode.
+            // It is on the send lane too, so it must not wedge behind a burst.
+            assertSendKeysViaExecCompletesDuringCcWedge(
+                sendKeysCommand = "send-keys -X -t %0 cancel",
+                expectExecContains = "tmux send-keys -X -t %0 cancel",
+            )
+        }
+
+    @Test
+    fun `sendKeysViaExec surfaces an error response when the pane is gone`() = runBlocking {
+        // Issue #1460: a non-zero exec exit (pane/session gone) must surface as
+        // an ERROR CommandResponse carrying stderr — so a failed send still
+        // fails honestly (the composer keeps the unsent draft), not a silent
+        // success.
+        val shell = FakeShell()
+        val session = FakeSession(
+            shell,
+            execHandler = sendKeysExecHandler(
+                exitCode = 1,
+                stderr = "can't find pane: %9",
+            ),
+        )
+        val client = RealTmuxClient(session, scope)
+        try {
+            client.connect()
+            val response = withTimeout(ASYNC_AWAIT_TIMEOUT_MS) {
+                client.sendKeysViaExec("send-keys -l -t %9 -- 'hi'")
+            }
+            assertTrue("a gone pane must surface as an error response", response.isError)
+            assertEquals(listOf("can't find pane: %9"), response.output)
+        } finally {
+            client.close()
+        }
+    }
+
+    @Test
+    fun `sendKeysViaExec succeeds with an empty non-error response on a normal send`() = runBlocking {
+        // Issue #1460: `send-keys` prints nothing on success, so a zero exit must
+        // yield an empty, non-error response (the caller's `throwIfTmuxError`
+        // treats it as success).
+        val shell = FakeShell()
+        val session = FakeSession(shell, execHandler = sendKeysExecHandler())
+        val client = RealTmuxClient(session, scope)
+        try {
+            client.connect()
+            val response = withTimeout(ASYNC_AWAIT_TIMEOUT_MS) {
+                client.sendKeysViaExec("send-keys -l -t %0 -- 'hi'")
+            }
+            assertFalse("a normal send must not be an error", response.isError)
+            assertTrue("send-keys prints nothing on success", response.output.isEmpty())
+            assertEquals(
+                "tmux send-keys -l -t %0 -- 'hi'",
+                session.execCommands.single { it.contains("send-keys") },
+            )
+        } finally {
+            client.close()
+        }
+    }
+
+    @Test
+    fun `sendKeysViaExec bounds itself and throws within the short ceiling on a wedged exec`() =
+        runBlocking {
+            // Issue #1460: a genuinely wedged/half-open transport (the exec never
+            // returns) must surface a TmuxClientException within the caller's
+            // SHORT ceiling, not hang to the full command ceiling — so a send
+            // against a dead link fails fast and the composer keeps the draft.
+            val shell = FakeShell()
+            val neverReturns = CompletableDeferred<ExecResult>()
+            val session = FakeSession(shell, execHandler = { neverReturns.await() })
+            val client = RealTmuxClient(session, scope, commandTimeoutMs = 30_000L)
+            try {
+                client.connect()
+                val startedAtMs = System.currentTimeMillis()
+                val thrown = runCatching {
+                    withTimeout(5_000) {
+                        client.sendKeysViaExec("send-keys -l -t %0 -- 'hi'", timeoutMs = 250L)
+                    }
+                }.exceptionOrNull()
+                val elapsedMs = System.currentTimeMillis() - startedAtMs
+                assertTrue(
+                    "a wedged send-keys exec must surface a TmuxClientException from " +
+                        "the short ceiling, not hang to the command ceiling (was $thrown)",
+                    thrown is TmuxClientException,
+                )
+                assertTrue(
+                    "the send must time out within ~the short ceiling (elapsed ${elapsedMs}ms)",
+                    elapsedMs < 5_000L,
+                )
+                neverReturns.cancel()
+            } finally {
+                client.close()
+            }
+        }
+
+    /**
+     * Issue #1460 shared driver: connect, wedge the shared `-CC` control channel
+     * with a never-answered command (modelling a reply stuck behind a live agent
+     * `%output` burst on the one sshj reader), then assert [sendKeysCommand] rides
+     * the dedicated exec channel and returns WELL under the `-CC` mutex ceiling —
+     * proving it did not wait on the wedged sendMutex. Verifies the exec carried
+     * the exact command via [expectExecContains].
+     */
+    private suspend fun assertSendKeysViaExecCompletesDuringCcWedge(
+        sendKeysCommand: String,
+        expectExecContains: String,
+    ) {
+        val shell = FakeShell()
+        val session = FakeSession(shell, execHandler = sendKeysExecHandler())
+        val client = RealTmuxClient(session, scope, commandTimeoutMs = 30_000L)
+        try {
+            client.connect()
+            withTimeout(2_000) {
+                while (shell.stdinBytes().isEmpty()) { yield(); delay(10) }
+            }
+            shell.resetStdin()
+
+            val wedger = scope.async { runCatching { client.sendCommand("list-clients") } }
+            withTimeout(2_000) {
+                while (!shell.stdinAsString().contains("list-clients")) { yield(); delay(10) }
+            }
+
+            val startedAtMs = System.currentTimeMillis()
+            val response = withTimeout(5_000) {
+                client.sendKeysViaExec(sendKeysCommand)
+            }
+            val elapsedMs = System.currentTimeMillis() - startedAtMs
+
+            assertFalse("the send must succeed during a -CC burst", response.isError)
+            assertTrue(
+                "the send must complete well under the -CC mutex ceiling " +
+                    "(elapsed ${elapsedMs}ms) proving it did not wait on the wedged " +
+                    "-CC sendMutex",
+                elapsedMs < 2_000L,
+            )
+            assertEquals(
+                "the send-keys must ride the exec lane verbatim",
+                expectExecContains,
+                session.execCommands.single { it.contains("send-keys") },
+            )
+            // And the send-keys never reached the wedged -CC stdin.
+            assertFalse(
+                "the send-keys must NOT be written to the wedged -CC shell",
+                shell.stdinAsString().contains("send-keys"),
+            )
+            wedger.cancel()
+        } finally {
+            client.close()
+        }
+    }
+
+    private fun sendKeysExecHandler(
+        exitCode: Int = 0,
+        stderr: String = "",
+        delayMs: Long = 0L,
+    ): suspend (String) -> ExecResult = { _ ->
+        if (delayMs > 0L) delay(delayMs)
+        // `send-keys` prints nothing on success.
+        ExecResult(stdout = "", stderr = stderr, exitCode = exitCode)
+    }
 
     private fun healExecHandler(
         cursor: String?,


### PR DESCRIPTION
**Closes the last known Codex-freeze mechanism** (#1459 family). Interactive `send-keys` rode `sendCommand` on the shared `-CC` channel (awaits `%begin/%end` on the one sshj reader) → typing+Send to a live agent mid-burst head-of-line-blocked behind the burst and wedged the app. New `TmuxClient.sendKeysViaExec` runs send-keys on an independent `exec` channel (send-side sibling of #1316). All send variants routed (literal/Enter/hex-write-stdin/paste/copy-mode-cancel).

Reviewer **APPROVED** with real-path proof: G1 RED→GREEN on 8 `TmuxClientExecLaneTest` + the **Docker `:shared:core-tmux:integrationTest` 11/11** including 'keys delivered to a real pane + send returns <5s during a ≥50KB real `-CC` burst' (G4 real-path, not a proxy). Class-covered, hygiene guards pass (VM ratchet OK, file-size lowered). ShareViewModel sibling → #1475. Closes #1460