### PR TITLE
terminal: unify divergent render-heal pre-gate predicates (#1353 R1)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/IdleClaudeFragmentsOverBlackRecoveryJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/IdleClaudeFragmentsOverBlackRecoveryJourneyE2eTest.kt
@@ -327,7 +327,7 @@ class IdleClaudeFragmentsOverBlackRecoveryJourneyE2eTest {
         compose.activityRule.scenario.onActivity { activity ->
             hit = viewModel(activity).panes.value.firstOrNull()
                 ?.terminalState
-                ?.visibleRenderMayHaveLostFrame() ?: false
+                ?.renderLooksSuspect() ?: false
         }
         return hit
     }

--- a/app/src/androidTest/java/com/pocketshell/app/proof/MostlyEmptyModelHealsAtRevealJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/MostlyEmptyModelHealsAtRevealJourneyE2eTest.kt
@@ -51,7 +51,7 @@ import java.io.FileOutputStream
  * ## The production bug (reveal-time leg of the #1208 fragments-over-black)
  *
  * The reveal/resize/switch nets gate an authoritative `capture-pane` diff on the CHEAP LOCAL
- * pre-check [com.pocketshell.core.terminal.ui.TerminalSurfaceState.visibleRenderMayHaveLostFrame].
+ * pre-check [com.pocketshell.core.terminal.ui.TerminalSurfaceState.renderLooksSuspect].
  * Before #1214 that pre-check only flagged a live-fraction in `(0.5, 0.75]` or a ≤3-line
  * partial-blank. So a mostly-empty pane with >3 scattered live lines but a live-fraction BELOW 0.5
  * read "healthy" at the reveal gate and the no-op-resize heal → it REVEALED UNHEALED
@@ -251,7 +251,7 @@ class MostlyEmptyModelHealsAtRevealJourneyE2eTest {
         compose.activityRule.scenario.onActivity { activity ->
             hit = viewModel(activity).panes.value.firstOrNull()
                 ?.terminalState
-                ?.visibleRenderMayHaveLostFrame() ?: false
+                ?.renderLooksSuspect() ?: false
         }
         return hit
     }

--- a/app/src/androidTest/java/com/pocketshell/app/proof/SendWithAttachmentStaysVisibleE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/SendWithAttachmentStaysVisibleE2eTest.kt
@@ -73,8 +73,9 @@ import java.io.File
  * The heal's real contract is "the visible render is repainted to the SAME content tmux holds"
  * ([TerminalSurfaceState.visibleRenderLostFrameVsCapture] false), NOT "the live rows exceed some
  * fraction of the viewport". A correctly-restored agent frame can legitimately be a small fraction
- * of a tall (e.g. 56-row) emulator viewport — the cheap send-heal pre-check
- * [TerminalSurfaceState.visibleScreenLooksSparseForSendHeal] (a 0.5 live-fraction cost-gate) reads
+ * of a tall (e.g. 56-row) emulator viewport — the unified local suspect pre-gate
+ * [TerminalSurfaceState.renderLooksSuspect] (the single 0.75 live-fraction cost-gate every launcher
+ * shares, epic #1353 R1) reads
  * such a frame "sparse", which is HARMLESS: the authoritative `capture-pane` diff is the load-bearing
  * guard and refuses to re-heal a frame that already matches tmux (proven at the JVM level by
  * `shortPromptDoesNotThrashHeal`). So the final acceptance compares visible-vs-capture, not a
@@ -301,7 +302,7 @@ class SendWithAttachmentStaysVisibleE2eTest {
             hit = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
                 .panes.value.firstOrNull()
                 ?.terminalState
-                ?.visibleScreenLooksSparseForSendHeal() ?: false
+                ?.renderLooksSuspect() ?: false
         }
         return hit
     }

--- a/app/src/main/java/com/pocketshell/app/tmux/StaleRenderSparseWakeBaselines.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/StaleRenderSparseWakeBaselines.kt
@@ -37,7 +37,7 @@ internal class StaleRenderSparseWakeBaselines {
         if (
             state.surfaceIsBlackWhileModelHasContent() ||
             state.visibleScreenIsBlankOrPartiallyBlank() ||
-            !state.visibleRenderMayHaveLostFrame()
+            !state.renderLooksSuspect()
         ) {
             remove(pane)
             return
@@ -49,7 +49,7 @@ internal class StaleRenderSparseWakeBaselines {
     fun renderLooksSuspect(pane: TmuxPaneState): Boolean {
         val state = pane.terminalState
         if (state.surfaceIsBlackWhileModelHasContent()) return true
-        if (!state.visibleRenderMayHaveLostFrame()) return false
+        if (!state.renderLooksSuspect()) return false
         if (state.visibleScreenIsBlankOrPartiallyBlank()) return true
         val healthySparseChars = renderedCharsByPane[pane.paneId] ?: return true
         val currentChars = state.renderedNonBlankCharCount()

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -10939,7 +10939,7 @@ public class TmuxSessionViewModel @Inject constructor(
                 // pane); [healActivePaneIfStaleRender] then confirms against tmux's authoritative
                 // capture with [TerminalSurfaceState.visibleRenderLostFrameVsCapture] and heals
                 // ONLY if the frame is truly lost — bounded to ONE capture, no reveal thrash.
-                if (activePane.terminalState.visibleRenderMayHaveLostFrame()) {
+                if (activePane.terminalState.renderLooksSuspect()) {
                     healActivePaneIfStaleRender(client, activePane, refreshGuard)
                 }
                 return true
@@ -11395,7 +11395,7 @@ public class TmuxSessionViewModel @Inject constructor(
      * while a confidently-dense HEALTHY streaming pane's output is ignored so it reaps
      * the back-off (the #1164 steady-heat lever).
      *
-     * It reuses [TerminalSurfaceState.visibleRenderMayHaveLostFrame] — the SAME cheap
+     * It reuses [TerminalSurfaceState.renderLooksSuspect] — the SAME cheap
      * local pre-check the switch-reveal / no-op-resize heals (#1176/#1214) already run
      * to decide whether an authoritative `capture-pane` diff is worthwhile — so this
      * wake gate covers the whole fragments-over-black class (fully blank, ≤3-line
@@ -11830,7 +11830,7 @@ public class TmuxSessionViewModel @Inject constructor(
         // the target class is the idle non-repainting pane with NO concurrent deltas —
         // free there; a busy suspect pane briefly buffers then flushes in order).
         val quiesceLiveDeltas =
-            surfaceBlack || pane.terminalState.visibleRenderMayHaveLostFrame()
+            surfaceBlack || pane.terminalState.renderLooksSuspect()
         if (quiesceLiveDeltas) pane.terminalState.closeSeedGate()
         try {
         val combined = runCatching {
@@ -11853,7 +11853,7 @@ public class TmuxSessionViewModel @Inject constructor(
             //
             // The scoring turns on whether the LOCAL render currently looks LOST (black /
             // partial-black / mostly-empty / surface-black — the same cheap local pre-check
-            // [visibleRenderMayHaveLostFrame] the suspect-wake gate uses):
+            // [renderLooksSuspect] the suspect-wake gate uses):
             //  - render LOOKS LOST → this is the #1294 UNVERIFIED case: we NEEDED this capture
             //    to heal a suspect pane and could not get it. The watchdog MUST keep the hot
             //    cadence (never throttle) so a black pane whose heal captures are wedged by a
@@ -11862,7 +11862,7 @@ public class TmuxSessionViewModel @Inject constructor(
             //  - render looks HEALTHY → a momentarily-empty/failed capture over a confidently-
             //    dense render is a non-urgent no-op; scoring it HEALTHY preserves the #1219 /
             //    #1164 battery back-off (criterion 3 — do not regress the steady-heat lever).
-            val renderLooksLost = surfaceBlack || pane.terminalState.visibleRenderMayHaveLostFrame()
+            val renderLooksLost = surfaceBlack || pane.terminalState.renderLooksSuspect()
             // Issue #1175: fingerprint the observed frame when it is degenerate so an export
             // sees WHICH class of black it was — no new round-trip, it rides this same (failed)
             // capture tick. A surface-only-black whose capture failed is the #1192 class
@@ -14099,7 +14099,7 @@ public class TmuxSessionViewModel @Inject constructor(
      *     redraw is still caught and a re-overpaint after an early heal is re-healed.
      *
      * A DENSE, normally-painted response is a no-op: each tick pays only the cheap LOCAL
-     * [TerminalSurfaceState.visibleScreenLooksSparseForSendHeal] pre-check and pays for the
+     * [TerminalSurfaceState.renderLooksSuspect] pre-check and pays for the
      * authoritative `capture-pane` diff ONLY when the render looks sparse enough to possibly be
      * a lost frame. The heal is guarded by a [RuntimeRefreshGuard] keyed to the current
      * generation + target + client so a late heal can never paint a switched-away session, and
@@ -14129,7 +14129,7 @@ public class TmuxSessionViewModel @Inject constructor(
                 // Cheap LOCAL pre-check: skip the capture round-trip on a dense, normally-painted
                 // response (its live rows sit above the sparse ceiling). Only a fully-blank /
                 // partial-black / >3-line half-black render pays for the authoritative diff.
-                if (!activePane.terminalState.visibleScreenLooksSparseForSendHeal()) return@repeat
+                if (!activePane.terminalState.renderLooksSuspect()) return@repeat
                 Log.i(
                     ISSUE_145_RECONNECT_TAG,
                     "tmux-send-overpaint-active-pane-heal-check pane=${activePane.paneId} " +
@@ -15953,11 +15953,11 @@ public class TmuxSessionViewModel @Inject constructor(
         // Issue #1176 (GAP C): a keyboard/resize toggle can leave the idle agent's redraw as a
         // >3-line half-black BAND (the GAP-A dead-zone) that reads NON-blank and NON-partial-black
         // locally — the pre-#1176 gate SKIPPED it and left the band until the ~4s watchdog. Widen
-        // the local capture-gate to [visibleRenderMayHaveLostFrame] (a superset of blank/partial
+        // the local capture-gate to [renderLooksSuspect] (a superset of blank/partial
         // that also catches the band), then route the non-blank band through the unified
         // capture-diff oracle so a correct-but-sparse pane never flickers.
-        val mayHaveLostFrame = activePane.terminalState.visibleRenderMayHaveLostFrame()
-        if (!mayHaveLostFrame) return
+        val suspect = activePane.terminalState.renderLooksSuspect()
+        if (!suspect) return
         val attachGeneration = connectGeneration
         Log.i(
             ISSUE_145_RECONNECT_TAG,

--- a/app/src/test/java/com/pocketshell/app/tmux/DeadZoneBandRevealResizeHealTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/DeadZoneBandRevealResizeHealTest.kt
@@ -46,7 +46,7 @@ import java.io.InputStream
  * A render with >50% of the visible rows live (clears the old 0.50 LINE ceiling) AND >25% of
  * tmux's chars (clears the old 0.25 CHAR ceiling) reads NON-blank AND NON-partial-black locally,
  * so the pre-#1176 gates (`blank || partialBlank`) SKIPPED it. Both gates now widen their local
- * cost-gate to [TerminalSurfaceState.visibleRenderMayHaveLostFrame] and confirm against tmux's
+ * cost-gate to [TerminalSurfaceState.renderLooksSuspect] and confirm against tmux's
  * authoritative capture before healing.
  *
  * ## RED → GREEN (D33/G1/G10) — driving the REAL production entry points
@@ -202,7 +202,7 @@ class DeadZoneBandRevealResizeHealTest {
         assertFalse(
             "precondition: a dense pane is confidently full → the local capture-gate is FALSE, " +
                 "so no capture is paid",
-            pane.terminalState.visibleRenderMayHaveLostFrame(),
+            pane.terminalState.renderLooksSuspect(),
         )
 
         client.capturePaneResponses.addLast(
@@ -235,7 +235,7 @@ class DeadZoneBandRevealResizeHealTest {
         advanceUntilIdle()
 
         overpaintDensePane(pane)
-        assertFalse(pane.terminalState.visibleRenderMayHaveLostFrame())
+        assertFalse(pane.terminalState.renderLooksSuspect())
 
         client.capturePaneResponses.addLast(
             CommandResponse(number = 99L, output = FULL_FRAME, isError = false),
@@ -410,7 +410,7 @@ class DeadZoneBandRevealResizeHealTest {
         )
         assertTrue(
             "#1214: the widened local capture-gate flags the mostly-empty model (worth a capture-diff)",
-            s.visibleRenderMayHaveLostFrame(),
+            s.renderLooksSuspect(),
         )
         assertTrue(
             "the unified oracle judges the mostly-empty model LOST vs tmux's full frame",
@@ -422,13 +422,12 @@ class DeadZoneBandRevealResizeHealTest {
         val s = pane.terminalState
         assertFalse("dead-zone band is NOT fully blank", s.visibleScreenIsBlank())
         assertFalse("dead-zone band is NOT ≤3-line partial-black", s.visibleScreenIsPartiallyBlank())
-        assertFalse(
-            "dead-zone band cleared the old 0.5 LINE ceiling (> 50% rows live)",
-            s.visibleScreenLooksSparseForSendHeal(),
-        )
+        // Epic #1353 R1: the >50%-live band that the OLD send-only 0.5 ceiling read NON-sparse (and
+        // so diverged from the reveal 0.75 gate — the #1153 desync) is now flagged by the SINGLE
+        // unified [renderLooksSuspect] authority every launcher shares.
         assertTrue(
-            "the #1176 local capture-gate catches the band (worth a capture-diff)",
-            s.visibleRenderMayHaveLostFrame(),
+            "the unified local suspect authority (0.75) catches the band (worth a capture-diff)",
+            s.renderLooksSuspect(),
         )
         assertTrue(
             "the unified oracle judges the dead-zone band LOST vs tmux's full frame",

--- a/app/src/test/java/com/pocketshell/app/tmux/HealCaptureUnverifiedWatchdogTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/HealCaptureUnverifiedWatchdogTest.kt
@@ -108,7 +108,7 @@ class HealCaptureUnverifiedWatchdogTest {
         advanceUntilIdle()
         assertTrue(
             "precondition: the pane looks LOST/suspect (black) so a failed capture is UNVERIFIED",
-            pane.terminalState.visibleRenderMayHaveLostFrame(),
+            pane.terminalState.renderLooksSuspect(),
         )
 
         // Every heal capture-pane now FAILS (throws) — models a Claude burst holding the shared

--- a/app/src/test/java/com/pocketshell/app/tmux/PartialBlackPaneHealTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/PartialBlackPaneHealTest.kt
@@ -294,7 +294,7 @@ class PartialBlackPaneHealTest {
 
         // A normal multi-line agent response: a DENSE viewport (well over half the 40 rows
         // live) -> neither blank, nor partial-black, nor sparse-half-black
-        // ([TerminalSurfaceState.visibleScreenLooksSparseForSendHeal] false) -> the post-send
+        // ([TerminalSurfaceState.renderLooksSuspect] false) -> the post-send
         // heal must correctly no-op and never pay for a `capture-pane` diff (#1153).
         val fullFrame = buildString {
             append(CLEAR_ONLY)
@@ -482,7 +482,7 @@ class PartialBlackPaneHealTest {
         )
         assertFalse(
             "after the heal the pane is no longer sparse/half-black",
-            pane.terminalState.visibleScreenLooksSparseForSendHeal(),
+            pane.terminalState.renderLooksSuspect(),
         )
     }
 
@@ -523,7 +523,7 @@ class PartialBlackPaneHealTest {
                 "the pane must heal too (same bracketed-paste + submit branch as with-attachment)",
             client.healCaptureCount() > healCapturesBefore,
         )
-        assertFalse(pane.terminalState.visibleScreenLooksSparseForSendHeal())
+        assertFalse(pane.terminalState.renderLooksSuspect())
     }
 
     // -------------------------------------------------------------------------
@@ -564,7 +564,7 @@ class PartialBlackPaneHealTest {
                 "a multi-line paste that half-blacks the pane must now trigger the heal too",
             client.healCaptureCount() > healCapturesBefore,
         )
-        assertFalse(pane.terminalState.visibleScreenLooksSparseForSendHeal())
+        assertFalse(pane.terminalState.renderLooksSuspect())
     }
 
     // -------------------------------------------------------------------------
@@ -817,7 +817,7 @@ class PartialBlackPaneHealTest {
         add(RECOVERED_FRAME)
         // Issue #1153: a DENSE recovered frame (well over half the 40-row viewport) so that
         // after the heal the restored pane reads NON-sparse
-        // ([TerminalSurfaceState.visibleScreenLooksSparseForSendHeal] false) and the bounded
+        // ([TerminalSurfaceState.renderLooksSuspect] false) and the bounded
         // send-heal poll stops paying for further `capture-pane` diffs — mirroring production,
         // where tmux's authoritative frame fills the viewport.
         repeat(27) { add("recovered context row $it") }

--- a/app/src/test/java/com/pocketshell/app/tmux/ReconcileReseedRaceTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/ReconcileReseedRaceTest.kt
@@ -139,7 +139,7 @@ class ReconcileReseedRaceTest {
         advanceUntilIdle()
         assertTrue(
             "precondition: the render must look SUSPECT so the reconciler quiesces + heals it",
-            pane.terminalState.visibleRenderMayHaveLostFrame(),
+            pane.terminalState.renderLooksSuspect(),
         )
         assertFalse(
             "precondition: the newer delta marker must NOT already be on the visible screen",
@@ -212,7 +212,7 @@ class ReconcileReseedRaceTest {
         advanceUntilIdle()
         assertFalse(
             "precondition: the pane is confidently HEALTHY (not suspect)",
-            pane.terminalState.visibleRenderMayHaveLostFrame(),
+            pane.terminalState.renderLooksSuspect(),
         )
 
         // The heal capture confirms the render (matches the dense frame) → HEALTHY, no apply.
@@ -311,7 +311,7 @@ class ReconcileReseedRaceTest {
         advanceUntilIdle()
         assertTrue(
             "precondition: the render must look SUSPECT so the reconciler quiesces + heals it",
-            pane.terminalState.visibleRenderMayHaveLostFrame(),
+            pane.terminalState.renderLooksSuspect(),
         )
         assertTrue(
             "precondition: the seed gate starts OPEN before the heal",
@@ -427,7 +427,7 @@ class ReconcileReseedRaceTest {
         )
         assertTrue(
             "precondition: the mid-session render lost the frame (fragments-over-black)",
-            pane.terminalState.visibleRenderMayHaveLostFrame(),
+            pane.terminalState.renderLooksSuspect(),
         )
         assertFalse(
             "precondition: tmux's authoritative frame is NOT yet on the visible screen",

--- a/app/src/test/java/com/pocketshell/app/tmux/StaleRenderWatchdogGatingTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/StaleRenderWatchdogGatingTest.kt
@@ -238,7 +238,7 @@ class StaleRenderWatchdogGatingTest {
         assertFalse(
             "precondition: the idle pane is confidently DENSE (not suspect), so an empty " +
                 "capture scores HEALTHY and the pane backs off",
-            pane.terminalState.visibleRenderMayHaveLostFrame(),
+            pane.terminalState.renderLooksSuspect(),
         )
 
         vm.setStaleRenderWatchdogAutoArmEnabledForTest(false)
@@ -288,7 +288,7 @@ class StaleRenderWatchdogGatingTest {
         advanceUntilIdle()
         assertFalse(
             "precondition: the idle pane is confidently DENSE (not suspect), so it cools",
-            pane.terminalState.visibleRenderMayHaveLostFrame(),
+            pane.terminalState.renderLooksSuspect(),
         )
 
         vm.setStaleRenderWatchdogAutoArmEnabledForTest(false)
@@ -347,7 +347,7 @@ class StaleRenderWatchdogGatingTest {
         assertFalse(
             "precondition: a dense pane must NOT read as a possible lost frame " +
                 "(else the wake gate would keep it hot)",
-            pane.terminalState.visibleRenderMayHaveLostFrame(),
+            pane.terminalState.renderLooksSuspect(),
         )
 
         vm.setStaleRenderWatchdogMaxTicksForTest(1000)
@@ -432,14 +432,14 @@ class StaleRenderWatchdogGatingTest {
         // clear then a handful of scattered live lines (the #966/#1214 class) — while
         // tmux still holds the authoritative rich frame. On device this redraw arrives
         // AS %output, which must WAKE the backed-off watchdog because the render is now
-        // locally suspect ([visibleRenderMayHaveLostFrame]).
+        // locally suspect ([renderLooksSuspect]).
         pane.terminalState.appendRemoteOutput(
             fragmentsOverBlackFrame().toByteArray(Charsets.US_ASCII),
         )
         assertTrue(
             "precondition: a fragments-over-black render must read as a possible lost " +
                 "frame so the wake gate honors it",
-            pane.terminalState.visibleRenderMayHaveLostFrame(),
+            pane.terminalState.renderLooksSuspect(),
         )
         client.capturePaneResponses.addLast(
             CommandResponse(number = 90L, output = richFrameLines(), isError = false),
@@ -520,7 +520,7 @@ class StaleRenderWatchdogGatingTest {
     // -------------------------------------------------------------------------
     // (5d) A SPARSE-BUT-HEALTHY streaming pane's %output also does NOT cut a
     //      BACKED-OFF wait short. This is the issue #1164 false-positive audit:
-    //      [visibleRenderMayHaveLostFrame] deliberately pre-flags >3-line sparse
+    //      [renderLooksSuspect] deliberately pre-flags >3-line sparse
     //      panes for reveal/resize, but the steady watchdog must not treat a pane
     //      that the authoritative capture just confirmed HEALTHY as genuinely
     //      suspect and keep it in the 4s hot path.
@@ -544,9 +544,9 @@ class StaleRenderWatchdogGatingTest {
         advanceUntilIdle()
         assertTrue(
             "precondition: this pane is locally sparse enough to be pre-flagged by " +
-                "visibleRenderMayHaveLostFrame(), so a pure local wake gate would " +
+                "renderLooksSuspect(), so a pure local wake gate would " +
                 "mistake it for suspect",
-            pane.terminalState.visibleRenderMayHaveLostFrame(),
+            pane.terminalState.renderLooksSuspect(),
         )
         assertFalse(
             "precondition: the authoritative capture matches the sparse render, so " +
@@ -781,7 +781,7 @@ class StaleRenderWatchdogGatingTest {
     /**
      * A DENSE, confidently-healthy viewport (32 of the 80x40 pty's rows live) — a
      * normally-painted streaming agent pane. Its live fraction (0.8) sits ABOVE the
-     * [visibleRenderMayHaveLostFrame] ceiling, so the #1219 wake gate reads it HEALTHY
+     * [renderLooksSuspect] ceiling, so the #1219 wake gate reads it HEALTHY
      * and lets the watchdog back off.
      */
     private fun denseHealthyFrame(): String = buildString {
@@ -792,7 +792,7 @@ class StaleRenderWatchdogGatingTest {
     /**
      * A FRAGMENTS-OVER-BLACK viewport (#966/#1214): a CSI 2J clear then a handful of
      * scattered live lines (>3 so it exercises the VISIBLE-only line-fraction leg of
-     * [visibleRenderMayHaveLostFrame], the class the ≤3-line partial-black misses) over
+     * [renderLooksSuspect], the class the ≤3-line partial-black misses) over
      * an otherwise-black 40-row grid. Reads as a possible lost frame so the #1219 wake
      * gate honors its %output and heals it within the hot bound. Modelled on the
      * maintainer's #966 alt-screen pane — no dense scrollback masks the visible sparsity.

--- a/app/src/test/java/com/pocketshell/app/tmux/VoiceSendSameGridRevealHealTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/VoiceSendSameGridRevealHealTest.kt
@@ -390,7 +390,7 @@ class VoiceSendSameGridRevealHealTest {
         )
         // Issue #1214: a GENUINELY DENSE pane — enough live lines to fill the visible grid well
         // above the 0.75 live-fraction ceiling, so the #1214-widened reveal/resize pre-check
-        // ([TerminalSurfaceState.visibleRenderMayHaveLostFrame]) reads it confidently-full and
+        // ([TerminalSurfaceState.renderLooksSuspect]) reads it confidently-full and
         // skips the capture. A merely-sparse "painted" frame (a handful of lines on a tall grid)
         // now legitimately pays ONE authoritative capture under #1214 — the point of THIS test is
         // the #285 "a healthy DENSE pane must not spam tmux" no-op, which a dense frame models.

--- a/scripts/file-size-hygiene-baseline.txt
+++ b/scripts/file-size-hygiene-baseline.txt
@@ -8,7 +8,7 @@
 177524 app/src/main/java/com/pocketshell/app/composer/PromptComposerViewModel.kt
 147448 app/src/main/java/com/pocketshell/app/projects/FolderListViewModel.kt
 149516 app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
-907779 app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+907650 app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
 148633 app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
 1146350 docs/mockups/feedback/folder-tree-target-20260604.png
 182790 docs/screenshots/readme-settings.png

--- a/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurfaceState.kt
+++ b/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurfaceState.kt
@@ -1183,36 +1183,49 @@ class TerminalSurfaceState(
     }
 
     /**
-     * Issue #1176 (GAP C) — the CHEAP, LOCAL-ONLY capture-gate the switch-reveal
-     * ([com.pocketshell.app.tmux.TmuxSessionViewModel.awaitActivePaneSeededOrLoading]) and the
-     * no-op-resize heal ([com.pocketshell.app.tmux.TmuxSessionViewModel.maybeHealActivePaneOnNoOpResize])
-     * run to decide whether paying for an authoritative `capture-pane` diff (the unified
-     * [visibleRenderLostFrameVsCapture] oracle) is worthwhile before revealing / after a keyboard
-     * toggle. It is TRUE when the rendered viewport is NOT confidently dense — POSSIBLY a lost
-     * frame: fully blank, the ≤3-line partial-black, OR any >3-line pane whose live share of the
-     * visible rows is at most [MAY_HAVE_LOST_FRAME_MAX_LIVE_FRACTION].
+     * The SINGLE local "is this pane suspect?" authority (epic #1353 slice R1). It is the ONE cheap,
+     * LOCAL-ONLY pre-gate EVERY render-heal launcher runs to decide whether paying for an
+     * authoritative `capture-pane` diff (the unified [visibleRenderLostFrameVsCapture] oracle) is
+     * worthwhile: the post-send overpaint heal
+     * ([com.pocketshell.app.tmux.TmuxSessionViewModel.scheduleSendOverpaintHeal]), the switch-reveal
+     * gate ([com.pocketshell.app.tmux.TmuxSessionViewModel.awaitActivePaneSeededOrLoading]), the
+     * no-op-resize heal ([com.pocketshell.app.tmux.TmuxSessionViewModel.maybeHealActivePaneOnNoOpResize]),
+     * the stale-render watchdog wake gate, and the M2 reconcile chokepoint
+     * ([com.pocketshell.app.tmux.TmuxSessionViewModel.healActivePaneIfStaleRender]).
      *
-     * It fires for the SAME two states the pre-#1176 gates already captured for — fully blank OR
-     * the ≤3-line partial-black — PLUS every pane below the confidently-dense ceiling:
-     *  - the #1176 dead-zone BAND (a >3-line black band with MORE than half the visible rows live,
-     *    so the pre-#1176 gates read it "painted"), AND
-     *  - the #1214 mostly-empty MODEL (>3 scattered live lines but a live-fraction BELOW 0.5 — the
-     *    reveal-time leg of the photographed fragments-over-black).
+     * ## Why one authority (#1153 root cause)
      *
-     * The #1214 change DROPPED the old 0.5 lower bound: a mostly-empty model with >3 live lines
-     * used to read "healthy" here and reveal UNHEALED (only the ≤16s-later steady watchdog could
-     * catch it). Paying ONE authoritative capture at reveal/resize is the deliberate cost — the
-     * unified oracle self-guards a genuinely-sparse-but-correct short prompt (Gate 2: capture must
-     * carry materially MORE than the render) and the #807 near-empty alt-screen void (Gate 1:
-     * capture must carry a real frame), so a FALSE pre-flag costs one wasted capture, NEVER a wrong
-     * heal or clear-to-black. It does NOT confirm a lost frame — only the `capture-pane` diff can,
-     * since a sparse-but-correct pane looks identical locally — so a confidently-full pane (live
-     * rows ABOVE the ceiling) skips the capture entirely, and every flagged pane is confirmed
-     * against tmux by the unified oracle before any heal fires. The steady-state watchdog's
-     * foreground/screen/back-off gates (#1166) are untouched — this widening is the reveal/resize
-     * LOCAL pre-check only.
+     * Before R1 this was THREE divergent local pre-gates that did NOT move together:
+     * `visibleScreenLooksSparseForSendHeal` (a 0.5 send-only ceiling), `renderLooksSuspect`
+     * (a 0.75 reveal/resize ceiling, with a spurious `liveLines > 3` floor), and the blank/partial
+     * family. A pane could be judged "suspect, heal it" under one launcher and "healthy, skip" under
+     * another for the SAME state — so a fix landed in one layer (#1163) was silently invalidated when
+     * the oracle changed underneath it (#1300). #1153 broke on exactly that divergence: a >3-line,
+     * >50%-live half-black band was healed on reveal (0.75) but SKIPPED after a send (0.5). Collapsing
+     * to one predicate means a change to the oracle can never desync one launcher relative to another
+     * again — there is ONE "is this pane bad?" authority, and the oracle
+     * ([visibleRenderLostFrameVsCapture]) is the SOLE confirm-and-heal decision it gates.
+     *
+     * ## Semantics — a strict SUPERSET cost-gate (never narrower than any old launcher)
+     *
+     * TRUE when the rendered viewport is NOT confidently dense — POSSIBLY a lost frame:
+     *  - fully blank OR the ≤3-line partial-black ([visibleScreenIsBlankOrPartiallyBlank]);
+     *  - a viewport with NO live visible lines over a non-blank transcript; OR
+     *  - any pane whose live share of the visible rows is at most [RENDER_SUSPECT_MAX_LIVE_FRACTION].
+     *
+     * The 0.75 ceiling is the WIDER of the two old thresholds and the `liveLines > 3` floor is
+     * DROPPED, so this flags a strict SUPERSET of every state the old send (0.5), reveal (0.75), and
+     * blank gates flagged — NO launcher loses heal coverage, and dropping the floor also closes a
+     * latent reveal gap (a ≤3-line, >0.25-fraction band the floor used to exclude). It does NOT
+     * confirm a lost frame — only the `capture-pane` diff can, since a sparse-but-correct pane looks
+     * identical locally — so a confidently-full pane (live rows ABOVE the ceiling) skips the capture
+     * entirely, and every flagged pane is confirmed against tmux by [visibleRenderLostFrameVsCapture]
+     * before any heal fires. The oracle self-guards a genuinely-sparse-but-correct short prompt
+     * (Gate 2: capture must carry materially MORE than the render) and the #807 near-empty alt-screen
+     * void (Gate 1: capture must carry a real frame), so a FALSE pre-flag costs one wasted capture,
+     * NEVER a wrong heal or clear-to-black. Returns false when no emulator is attached.
      */
-    fun visibleRenderMayHaveLostFrame(): Boolean {
+    fun renderLooksSuspect(): Boolean {
         if (visibleScreenIsBlankOrPartiallyBlank()) return true
         val emulator = bridge?.emulator ?: _session?.emulator ?: return false
         val visibleRows = try {
@@ -1223,15 +1236,13 @@ class TerminalSurfaceState(
         if (visibleRows <= 0) return false
         val liveLines = renderedVisibleNonBlankLineCount()
         if (liveLines <= 0) return true
-        val liveFraction = liveLines.toDouble() / visibleRows.toDouble()
-        // Flag every >3-line pane that is NOT confidently dense — its live share sits at or below
-        // the [MAY_HAVE_LOST_FRAME_MAX_LIVE_FRACTION] ceiling. This covers BOTH the #1176 dead-zone
-        // band (0.5..0.75) AND the #1214 mostly-empty model (>3 live lines below 0.5). A ≤3-line
-        // pane is already handled by [visibleScreenIsBlankOrPartiallyBlank] above; a confidently-
-        // full pane (fraction above the ceiling) skips the capture. Every flagged pane is confirmed
-        // against tmux's authoritative capture by [visibleRenderLostFrameVsCapture] before any heal.
-        return liveLines > PARTIAL_BLANK_MAX_LIVE_LINES &&
-            liveFraction <= MAY_HAVE_LOST_FRAME_MAX_LIVE_FRACTION
+        // Flag every pane that is NOT confidently dense — its live share sits at or below the
+        // [RENDER_SUSPECT_MAX_LIVE_FRACTION] ceiling. This covers the #1176 dead-zone band, the
+        // #1214 mostly-empty model, AND the >0.5..0.75 band the old send-only 0.5 ceiling skipped.
+        // A confidently-full pane (fraction above the ceiling) skips the capture. Every flagged pane
+        // is confirmed against tmux's authoritative capture by [visibleRenderLostFrameVsCapture]
+        // before any heal.
+        return liveLines.toDouble() / visibleRows.toDouble() <= RENDER_SUSPECT_MAX_LIVE_FRACTION
     }
 
     /**
@@ -1239,7 +1250,7 @@ class TerminalSurfaceState(
      * currently VISIBLE viewport (scrollback excluded), the sibling of [renderedNonBlankCharCount]
      * measured in LINES. Used to judge the live-line FRACTION of the visible grid — how large the
      * black BAND left by a half-repainted send overpaint is — for [visibleRenderLostFrameVsCapture]
-     * case (c) and the cheap send-heal pre-check [visibleScreenLooksSparseForSendHeal].
+     * case (c) and the unified local suspect pre-gate [renderLooksSuspect].
      *
      * Returns 0 when no emulator is attached or the visible screen is blank.
      */
@@ -1252,34 +1263,6 @@ class TerminalSurfaceState(
         }
         if (text.isBlank()) return 0
         return text.split('\n').count { it.isNotBlank() }
-    }
-
-    /**
-     * Issue #1153 — a CHEAP, LOCAL-ONLY pre-check the post-send overpaint heal
-     * ([com.pocketshell.app.tmux.TmuxSessionViewModel.scheduleSendOverpaintHeal]) runs each
-     * settle tick to decide whether paying for an authoritative `capture-pane` diff is
-     * worthwhile. It is TRUE when the rendered viewport is sparse enough to POSSIBLY be a
-     * half-repainted send overpaint: fully blank, the ≤3-line partial-black
-     * ([visibleScreenIsBlankOrPartiallyBlank]), OR a >3-line half-black band whose live share
-     * of the visible rows is at most [LOST_FRAME_MAX_LIVE_FRACTION].
-     *
-     * It does NOT confirm a lost frame — only the `capture-pane` diff ([visibleRenderLostFrameVsCapture])
-     * can, since a legitimately-sparse-but-correct pane looks identical locally. This gate exists
-     * only to keep a DENSE, normally-painted agent response (its live rows sit above the ceiling)
-     * from paying for a capture round-trip on every send.
-     */
-    fun visibleScreenLooksSparseForSendHeal(): Boolean {
-        if (visibleScreenIsBlankOrPartiallyBlank()) return true
-        val emulator = bridge?.emulator ?: _session?.emulator ?: return false
-        val visibleRows = try {
-            emulator.screen.visibleScreenRows
-        } catch (_: Throwable) {
-            return false
-        }
-        if (visibleRows <= 0) return false
-        val liveLines = renderedVisibleNonBlankLineCount()
-        if (liveLines <= 0) return false
-        return liveLines.toDouble() / visibleRows.toDouble() <= LOST_FRAME_MAX_LIVE_FRACTION
     }
 
     /**
@@ -1675,42 +1658,24 @@ class TerminalSurfaceState(
         private const val LINE_HASH_MIN_LOST_FRACTION = 0.25
 
         /**
-         * Issue #1153: the upper bound on the rendered live-line FRACTION of the visible rows for
-         * the cheap send-heal pre-check [visibleScreenLooksSparseForSendHeal]. The maintainer's
-         * composer Send (with-attachment, so multi-line → bracketed-paste + submit) left the
-         * alt-screen agent pane "partly redrew but still too black": a surviving input box + a few
-         * conversation lines + status (MORE than the ≤3 live lines
-         * [PARTIAL_BLANK_MAX_LIVE_LINES] caps at) over a large black BAND. Half-or-more of the
-         * visible rows black is "materially black"; a DENSE, normally-painted response paints
-         * well over half its rows and sits ABOVE this ceiling, so it never heals. It is HIGHER
-         * than [PARTIAL_BLANK_MAX_LIVE_FRACTION] (0.25) precisely to catch the >3-line band the
-         * narrow partial-black heuristic misses; the authoritative capture-diff gate
-         * ([visibleRenderLostFrameVsCapture]) still guards against healing a sparse-but-correct
-         * pane where the render already reproduces tmux's content lines.
+         * Epic #1353 slice R1 — the SINGLE live-line FRACTION ceiling of the one unified local
+         * suspect pre-gate [renderLooksSuspect] that EVERY render-heal launcher (send-overpaint,
+         * switch-reveal, no-op-resize, stale-render watchdog wake, M2 reconcile) shares. It replaces
+         * the two divergent thresholds that caused the #1153 desync: the send-only 0.5
+         * (`LOST_FRAME_MAX_LIVE_FRACTION`) and the reveal/resize 0.75
+         * (`MAY_HAVE_LOST_FRAME_MAX_LIVE_FRACTION`).
          *
-         * NOTE: this is now ONLY the send-heal LOCAL cost-gate. The authoritative capture-vs-render
-         * decision moved to the [visibleRenderLostFrameVsCapture] per-line-hash content diff (#1300);
-         * this 0.5 line-fraction no longer bounds that oracle.
+         * At 0.75 — the WIDER of the two old ceilings — a confidently-full pane (live rows above the
+         * ceiling) skips the authoritative `capture-pane` diff while ANY pane that could be a
+         * dead-zone black band, a mostly-empty model, or a half-repainted send overpaint (live rows
+         * at or below it) is confirmed against tmux by [visibleRenderLostFrameVsCapture] before any
+         * heal. Picking the wider ceiling (and dropping the old `liveLines > 3` floor in
+         * [renderLooksSuspect]) makes the unified gate a strict SUPERSET of all three old pre-gates,
+         * so NO launcher loses heal coverage. The oracle's Gate 1/Gate 2 self-guard a
+         * genuinely-sparse-but-correct pane, so a false pre-flag costs one wasted capture, never a
+         * wrong heal.
          */
-        private const val LOST_FRAME_MAX_LIVE_FRACTION = 0.5
-
-        /**
-         * Issue #1176 (GAP C) — the live-line FRACTION ceiling of the LOCAL capture-gate
-         * [visibleRenderMayHaveLostFrame] used by the switch-reveal and no-op-resize heals. At 0.75
-         * a confidently-full pane (live rows above the ceiling) skips the authoritative
-         * `capture-pane` diff while ANY pane that could be a dead-zone black band (live rows below
-         * it) is confirmed against tmux by [visibleRenderLostFrameVsCapture] before any heal. It
-         * is deliberately HIGHER than the send-heal cost-gate's [LOST_FRAME_MAX_LIVE_FRACTION]
-         * (0.5) so the reveal/resize gates never MISS the #1176 dead-zone band the way the narrow
-         * pre-check did.
-         *
-         * Issue #1214: the pre-#1176 0.5 LOWER bound (`MAY_HAVE_LOST_FRAME_MIN_LIVE_FRACTION`) was
-         * DELETED here — a mostly-empty model (>3 live lines, live-fraction BELOW 0.5) used to read
-         * "healthy" and reveal UNHEALED, so the local gate now opens for EVERY >3-line pane at or
-         * below this ceiling. The unified oracle's Gate 1/Gate 2 self-guard a genuinely-sparse-but-
-         * correct pane, so a false pre-flag costs one wasted capture, never a wrong heal.
-         */
-        private const val MAY_HAVE_LOST_FRAME_MAX_LIVE_FRACTION = 0.75
+        private const val RENDER_SUSPECT_MAX_LIVE_FRACTION = 0.75
     }
 }
 

--- a/shared/core-terminal/src/test/java/com/pocketshell/core/terminal/ui/RenderHealPreGateUnificationTest.kt
+++ b/shared/core-terminal/src/test/java/com/pocketshell/core/terminal/ui/RenderHealPreGateUnificationTest.kt
@@ -1,0 +1,178 @@
+package com.pocketshell.core.terminal.ui
+
+import android.os.Looper
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import java.io.OutputStream
+
+/**
+ * Epic #1353 slice R1 — the render-heal "is this pane bad?" pre-gate UNIFICATION.
+ *
+ * ## The bug class (#1153 desync)
+ *
+ * The render-heal stack used to run THREE divergent local pre-gates that did not move together —
+ * a send-only 0.5 line-fraction ceiling (`visibleScreenLooksSparseForSendHeal`), a reveal/resize
+ * 0.75 ceiling with a `liveLines > 3` floor (`visibleRenderMayHaveLostFrame`), and the blank/
+ * partial family. For the SAME pane state a launcher could judge "suspect → heal" while another
+ * judged "healthy → skip", so a fix in one layer was silently invalidated when the oracle changed
+ * underneath it. #1153 broke on exactly this: a >3-line, >50%-live half-black band was healed on a
+ * switch-reveal (0.75) but SKIPPED after a send (0.5) — the same pane, two answers.
+ *
+ * R1 collapses the divergent local cost-gates into the ONE
+ * [TerminalSurfaceState.renderLooksSuspect] authority every launcher shares, defined as a strict
+ * SUPERSET of all three old gates (0.75 ceiling, no `liveLines > 3` floor). So no launcher loses
+ * heal coverage and, crucially, no two launchers can disagree about "consult the oracle" for a
+ * given pane — a change to the oracle can never desync one launcher relative to another again.
+ *
+ * ## RED → GREEN (D33/G1/G10)
+ *
+ * [unifiedSuspectAuthorityFlagsBandTheOldSendOnlyCeilingSkipped] composes the exact #1153 pane: a
+ * >3-line, ~58%-live half-black band. With the unified 0.75 authority the ONE predicate flags it
+ * (GREEN). Captured RED: temporarily narrowing [RENDER_SUSPECT_MAX_LIVE_FRACTION] back to the old
+ * send-only 0.5 (the pre-R1 divergence) makes `renderLooksSuspect()` return FALSE for this band and
+ * this assertion fails — the desync reproduced. Widening back to 0.75 is GREEN.
+ *
+ * ## Class coverage (D32-G2)
+ *
+ * [unifiedAuthorityIsSupersetAcrossTheWholeSuspectRange] parametrizes the whole not-confidently-
+ * dense spectrum (fully blank, ≤3-line partial-black, the >0.5..0.75 band the old send ceiling
+ * skipped, the <0.5 mostly-empty model, up to the 0.75 boundary) and asserts the single authority
+ * flags EVERY member — while a confidently-dense pane (live share above 0.75) is NOT flagged (no
+ * over-flag). The geometry is the real visible render, not a proxy.
+ */
+@RunWith(RobolectricTestRunner::class)
+class RenderHealPreGateUnificationTest {
+
+    private class NoopOutputStream : OutputStream() {
+        override fun write(b: Int) = Unit
+        override fun write(b: ByteArray, off: Int, len: Int) = Unit
+    }
+
+    private fun withAttachedSurface(block: (TerminalSurfaceState) -> Unit) = runBlocking {
+        val state = TerminalSurfaceState()
+        val producerScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val producerJob = state.attachExternalProducer(
+            scope = producerScope,
+            stdout = MutableSharedFlow(extraBufferCapacity = 1),
+            remoteStdin = NoopOutputStream(),
+            suppressQueryResponses = true,
+        )
+        try {
+            block(state)
+        } finally {
+            producerJob.cancel()
+            producerScope.cancel()
+            state.detachExternalProducer()
+        }
+    }
+
+    /** ESC (U+001B), so the test feeds real control sequences (a literal `[2J` is just text). */
+    private val esc = ""
+
+    /** A single non-wrapping content line: 20 non-blank chars, well under the 80-col grid. */
+    private val contentLine = "abcdefghij klmnopqrst"
+
+    /** Paint [liveRows] non-wrapping content lines on a cleared screen — a contiguous black band above. */
+    private fun paintBand(state: TerminalSurfaceState, liveRows: Int) {
+        val frame = buildString {
+            append("$esc[2J$esc[H")
+            repeat(liveRows) { append("$contentLine\r\n") }
+        }
+        state.appendRemoteOutput(frame.toByteArray(Charsets.US_ASCII))
+        shadowOf(Looper.getMainLooper()).idle()
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // RED → GREEN: the exact #1153 pane where send (0.5) and reveal (0.75) diverged.
+    // -----------------------------------------------------------------------------------------
+
+    @Test
+    fun unifiedSuspectAuthorityFlagsBandTheOldSendOnlyCeilingSkipped() = withAttachedSurface { state ->
+        // 14 of 24 rows live (~42% black): live-fraction 0.58, which is > 0.5 (so the OLD send-only
+        // 0.5 ceiling read it NON-suspect and skipped the capture) yet ≤ 0.75.
+        paintBand(state, liveRows = 14)
+
+        assertFalse(
+            "precondition: a >3-line half-black band is NOT fully blank",
+            state.visibleScreenIsBlank(),
+        )
+        assertFalse(
+            "precondition: it has MORE than 3 live lines, so it is NOT the ≤3-line partial-black",
+            state.visibleScreenIsPartiallyBlank(),
+        )
+
+        // GREEN: the ONE unified authority flags the band — so the send launcher and the reveal
+        // launcher now AGREE (both consult the oracle for this state). RED when the ceiling is
+        // narrowed to the old send-only 0.5: 0.58 > 0.5 → returns false → this assertion fails,
+        // reproducing the #1153 send/reveal desync.
+        assertTrue(
+            "R1 (#1153): the single renderLooksSuspect() authority must flag a >3-line, ~58%-live " +
+                "half-black band — the pane the old send-only 0.5 ceiling skipped while the reveal " +
+                "0.75 gate caught it (the desync). One authority: send and reveal agree.",
+            state.renderLooksSuspect(),
+        )
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // Class coverage: the single authority is a strict SUPERSET across the whole suspect range,
+    // and does NOT over-flag a confidently-dense pane.
+    // -----------------------------------------------------------------------------------------
+
+    @Test
+    fun unifiedAuthorityIsSupersetAcrossTheWholeSuspectRange() {
+        // liveRows-of-24 → live-fraction. Every member at or below the 0.75 ceiling must be flagged
+        // by the ONE authority (blank, ≤3-line partial-black, the <0.5 mostly-empty model, the
+        // >0.5..0.75 dead-zone band the old send 0.5 ceiling skipped, and the exact 0.75 boundary).
+        val suspectLiveRows = listOf(
+            0,  // fully blank            → 0.00
+            2,  // ≤3-line partial-black  → 0.08
+            6,  // mostly-empty model     → 0.25
+            10, // <0.5 band              → 0.42
+            13, // >0.5 dead-zone band    → 0.54 (old send 0.5 ceiling skipped it)
+            14, // >0.5 dead-zone band    → 0.58 (the #1153 pane)
+            17, // >0.5 dead-zone band    → 0.71 (old send 0.5 ceiling skipped it)
+            18, // exact 0.75 boundary    → 0.75
+        )
+        for (liveRows in suspectLiveRows) {
+            withAttachedSurface { state ->
+                paintBand(state, liveRows)
+                val liveFraction = liveRows / 24.0
+                assertTrue(
+                    "R1 class coverage: a pane with $liveRows/24 live rows (fraction $liveFraction " +
+                        "≤ 0.75) must be flagged suspect by the ONE unified authority",
+                    state.renderLooksSuspect(),
+                )
+            }
+        }
+
+        // Over-flag guard: a confidently-dense pane (live share ABOVE 0.75) is NOT suspect — the
+        // single authority does not widen into a normally-painted frame (both old gates agreed here).
+        for (liveRows in listOf(20, 22, 24)) { // 0.83, 0.92, 1.00
+            withAttachedSurface { state ->
+                paintBand(state, liveRows)
+                assertFalse(
+                    "over-flag guard: a confidently-dense pane ($liveRows/24 live, > 0.75) must NOT " +
+                        "be flagged suspect by the unified authority",
+                    state.renderLooksSuspect(),
+                )
+            }
+        }
+    }
+
+    @Test
+    fun noEmulatorAttachedIsNotSuspect() {
+        // A brand-new state with no attached producer/emulator has nothing rendered to judge — the
+        // authority must be conservative (false), never spuriously suspect.
+        assertFalse(TerminalSurfaceState().renderLooksSuspect())
+    }
+}

--- a/shared/core-terminal/src/test/java/com/pocketshell/core/terminal/ui/TerminalSurfaceStateDeadZoneHealTest.kt
+++ b/shared/core-terminal/src/test/java/com/pocketshell/core/terminal/ui/TerminalSurfaceStateDeadZoneHealTest.kt
@@ -28,9 +28,11 @@ import java.io.OutputStream
  * ## RED → GREEN (D33/G1/G10)
  *
  * [deadZoneBandClearsBothOldCeilingsYetIsHealedByUnifiedOracle] composes a >3-line half-black
- * band whose live share of the rows is > 0.50 (clears the old LINE ceiling —
- * `visibleScreenLooksSparseForSendHeal` is FALSE). The oracle judges it LOST (GREEN). The
- * geometry is visible-render-vs-capture-pane, not a proxy.
+ * band whose live share of the rows is > 0.50. Epic #1353 R1 collapsed the divergent local
+ * pre-gates into the single [TerminalSurfaceState.renderLooksSuspect] authority (0.75 ceiling), so
+ * this band — which the OLD send-only 0.5 ceiling skipped while the reveal 0.75 gate caught it (the
+ * #1153 desync) — is now flagged suspect by the ONE predicate every launcher shares. The oracle
+ * then judges it LOST (GREEN). The geometry is visible-render-vs-capture-pane, not a proxy.
  *
  * ## Class coverage (D32-G2)
  *
@@ -109,12 +111,13 @@ class TerminalSurfaceStateDeadZoneHealTest {
             "precondition: it has MORE than 3 live lines, so it is NOT the ≤3-line partial-black",
             state.visibleScreenIsPartiallyBlank(),
         )
-        // The old LINE ceiling (50%) judged it healthy: live share of the rows > 0.50, so the
-        // 0.5-live-fraction send-heal pre-check reads NON-sparse.
-        assertFalse(
-            "RED premise: > 50% of the visible rows are live → the old 50%-line ceiling judged " +
-                "the band HEALTHY (cleared the LINE ceiling)",
-            state.visibleScreenLooksSparseForSendHeal(),
+        // Epic #1353 R1: the single unified suspect authority (0.75 ceiling) FLAGS this >50%-live
+        // band — where the old send-only 0.5 ceiling read it NON-sparse and diverged from the
+        // reveal 0.75 gate (the #1153 desync). One authority: send and reveal now agree.
+        assertTrue(
+            "R1: the unified renderLooksSuspect() authority flags a >3-line, >50%-rows-live band " +
+                "(0.58 live-fraction ≤ 0.75) — the old send-only 0.5 ceiling missed it",
+            state.renderLooksSuspect(),
         )
 
         // GREEN: the unified char-coverage oracle judges the band LOST (on base this returns
@@ -159,12 +162,14 @@ class TerminalSurfaceStateDeadZoneHealTest {
                     state.visibleRenderLostFrameVsCapture(capture),
                 )
                 if (liveFraction > 0.5) {
-                    // The DEAD-ZONE members: confirm they cleared the old 50%-line send-heal
-                    // ceiling (so they were genuinely un-healed on the pre-#1176 line ceiling),
-                    // closing the dead-zone as a class not a point.
-                    assertFalse(
-                        "band $blackPercent%: cleared the old 50%-line ceiling",
-                        state.visibleScreenLooksSparseForSendHeal(),
+                    // The DEAD-ZONE members (>0.5 live, so the OLD send-only 0.5 ceiling read them
+                    // NON-sparse and diverged from the reveal 0.75 gate). Epic #1353 R1: the single
+                    // unified [renderLooksSuspect] authority (0.75) now flags them, closing the
+                    // dead-zone AND the send/reveal desync as a class, not a point.
+                    assertTrue(
+                        "band $blackPercent%: the unified suspect authority (0.75) flags the whole " +
+                            "dead-zone the old send-only 0.5 ceiling skipped",
+                        state.renderLooksSuspect(),
                     )
                 }
             }

--- a/shared/core-terminal/src/test/java/com/pocketshell/core/terminal/ui/TerminalSurfaceStateMostlyEmptyRevealTest.kt
+++ b/shared/core-terminal/src/test/java/com/pocketshell/core/terminal/ui/TerminalSurfaceStateMostlyEmptyRevealTest.kt
@@ -17,7 +17,7 @@ import java.io.OutputStream
 
 /**
  * Issue #1214 — the reveal/resize/switch LOCAL pre-check
- * [TerminalSurfaceState.visibleRenderMayHaveLostFrame] was BLIND to a mostly-empty model.
+ * [TerminalSurfaceState.renderLooksSuspect] was BLIND to a mostly-empty model.
  *
  * The authoritative steady-watchdog oracle [TerminalSurfaceState.visibleRenderLostFrameVsCapture]
  * is a char-count-fraction test that HEALS a mostly-empty-model-vs-full-tmux pane. But the cheap
@@ -33,7 +33,7 @@ import java.io.OutputStream
  *
  * [mostlyEmptyModelIsFlaggedSoTheRevealGatePaysTheAuthoritativeCapture] composes a >3-live-line
  * pane whose live-fraction is BELOW 0.5 (the mostly-empty model), against a full-tmux capture the
- * authoritative oracle WOULD heal. On base [visibleRenderMayHaveLostFrame] returns FALSE (reads
+ * authoritative oracle WOULD heal. On base [renderLooksSuspect] returns FALSE (reads
  * "healthy" — RED: the reveal gate skips the capture and reveals unhealed). With the fix it
  * returns TRUE (GREEN: the reveal gate pays ONE authoritative diff and heals AT reveal). The test
  * also asserts the authoritative oracle itself judges the pane LOST — proving the pre-check was
@@ -136,9 +136,9 @@ class TerminalSurfaceStateMostlyEmptyRevealTest {
             // base this returns FALSE (reads healthy, reveals unhealed) — the red→green
             // discriminator.
             assertTrue(
-                "GREEN (#1214): visibleRenderMayHaveLostFrame() must flag a >3-live-line pane with " +
+                "GREEN (#1214): renderLooksSuspect() must flag a >3-live-line pane with " +
                     "live-fraction < 0.5 so the reveal/resize gate pays the authoritative capture",
-                state.visibleRenderMayHaveLostFrame(),
+                state.renderLooksSuspect(),
             )
         }
 
@@ -166,7 +166,7 @@ class TerminalSurfaceStateMostlyEmptyRevealTest {
                 assertTrue(
                     "#1214 class coverage: a $liveRows-of-24 mostly-empty model must be flagged so " +
                         "the reveal/resize gate pays the authoritative capture",
-                    state.visibleRenderMayHaveLostFrame(),
+                    state.renderLooksSuspect(),
                 )
                 // And the authoritative oracle confirms the heal — the reveal is not paying for
                 // nothing across the class.
@@ -193,7 +193,7 @@ class TerminalSurfaceStateMostlyEmptyRevealTest {
 
         assertTrue(
             "the pre-check may pre-flag the sparse pane (one wasted capture is acceptable)",
-            state.visibleRenderMayHaveLostFrame(),
+            state.renderLooksSuspect(),
         )
         assertFalse(
             "Gate 2 self-guard: a sparse-but-correct prompt where capture ≈ render must NOT heal " +
@@ -230,7 +230,7 @@ class TerminalSurfaceStateMostlyEmptyRevealTest {
         assertFalse(
             "battery guard: a confidently-dense pane (live-fraction 0.92 > 0.75) must NOT be " +
                 "flagged — no per-reveal capture cost on a healthy pane",
-            state.visibleRenderMayHaveLostFrame(),
+            state.renderLooksSuspect(),
         )
     }
 }


### PR DESCRIPTION
Slice **R1** of the render-heal consolidation (#1353). Unifies the 3 divergent 'is this pane bad?' pre-gates onto one `renderLooksSuspect()` authority (D22 hard-cut), retiring the #1153 render-clobber/desync class. The unified gate is a **strict superset** of the old send(0.5)/reveal(0.75+floor)/blank gates — reviewer-confirmed per launcher, so every launcher heals *more*, not fewer (no new black-screen risk); oracle M1 unchanged. Reviewer **APPROVED**: G1 RED→GREEN + all 5 emulator heal journeys confirmed to heal; VM net-shrank, guards pass. **Part of #1353** (R2–R6 remain). Refs #1153.