### PR TITLE
release: v0.4.26 — Codex-freeze send-lane fix

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,8 +65,8 @@ android {
         applicationId = "com.pocketshell.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 72
-        versionName = "0.4.25"
+        versionCode = 73
+        versionName = "0.4.26"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/tools/pocketshell/pyproject.toml
+++ b/tools/pocketshell/pyproject.toml
@@ -8,7 +8,7 @@ name = "pocketshell"
 # scripts/check-pypi-version.sh enforces this; .github/workflows/build.yml
 # runs that check before publishing to PyPI. See
 # tools/pocketshell/README.md ("Release flow") for the bump procedure.
-version = "0.4.25"
+version = "0.4.26"
 description = "Unified server-side Python utility for the PocketShell Android client."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Version bump **0.4.25 → 0.4.26** (versionCode 72 → 73) to release the send-side Codex-freeze fixes that landed after v0.4.25.

### What this release delivers (delta v0.4.25..main)
- **#1460** tmux: interactive `send-keys` off the shared `-CC` channel onto a dedicated exec lane (`sendKeysViaExec`) — the residual Codex-freeze Mechanism #6 (typing+Send HOL-blocked behind a live `%output` burst). RED→GREEN JVM (`TmuxClientExecLaneTest`) + Docker (`TmuxClientIntegrationTest` 11/11, <5s during a ≥50KB burst).
- **#1475** share: `ShareViewModel.sendTextToAttachedPane` onto the same exec lane (same wedge class).
- **#1353 R1** terminal: unify the divergent render-heal pre-gate predicates (kills the #1153 desync class; superset-verified, no black-screen regression).
- **#1329 S6** connection: controller decides open/switch + attach/seed IO off Main.
- **#1164** sessions: gate dashboard list-sessions poll to foreground-only.
- **#684 / #1449** code-health: ~1570 LOC dead/IDE-only code removed.
- **#1458** ci: classify emulator console-storm as INFRA-ABORT (not a genuine failure).

### Gate
- Merge after required `Unit tests` + `Python utility tests` are green.
- Tag `v0.4.26` cut from stable `main` only after the emulator release-validation gate passes on the bumped commit.

Refs #1459 (Codex-freeze family — this delivers the send-lane lanes to the maintainer).