### PR TITLE
terminal: fold parallel reseed sink into the single heal chokepoint (#1353 R2)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionSupport.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionSupport.kt
@@ -97,7 +97,7 @@ internal const val BLANK_PANE_RESEED_DELAY_MS: Long = 350L
 internal const val REVEAL_LIVE_SENTINEL_FRAME: String = "reveal-live"
 
 /**
- * Issue #693/#662: how many times [seedPaneFromCapture] re-issues a
+ * Issue #693/#662: how many times [healActivePaneIfStaleRender] re-issues a
  * `capture-pane` when it comes back empty/error/null on a flaky link before
  * giving up for this pass. A transiently-empty capture on a degraded-but-
  * connected channel is the root of the green-dot-but-black-pane symptom; a few
@@ -109,7 +109,7 @@ internal const val SEED_CAPTURE_EMPTY_RETRY_ATTEMPTS: Int = 4
 
 /**
  * Issue #693/#662: backoff between empty-capture re-tries inside
- * [seedPaneFromCapture]. Short so a flaky-link empty capture re-tries promptly
+ * [healActivePaneIfStaleRender]. Short so a flaky-link empty capture re-tries promptly
  * without stalling a genuinely-empty pane's reveal.
  */
 internal const val SEED_CAPTURE_EMPTY_RETRY_DELAY_MS: Long = 120L

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -394,7 +394,7 @@ public class TmuxSessionViewModel @Inject constructor(
 
     /**
      * Issue #926: the SHORT ceiling (ms) applied to each attach/switch/reattach
-     * SEED `capture-pane` round-trip ([seedPaneFromCaptureOnce] →
+     * SEED `capture-pane` round-trip ([captureAndApplyPaneSnapshot] →
      * [TmuxClient.captureWithCursor]). Far below the full per-command
      * `commandTimeoutMs` (10 s) so a wedged-but-alive control channel makes the
      * seed surface a best-effort failure FAST and fall through to the blank
@@ -1772,7 +1772,7 @@ public class TmuxSessionViewModel @Inject constructor(
     }
 
     /**
-     * Issue #640: pane IDs already seeded (via [seedPaneFromCapture]) during
+     * Issue #640: pane IDs already seeded (via [healActivePaneIfStaleRender]) during
      * the current attach. The cold-open reveal uses this to skip the redundant
      * second full reseed for panes the preload pass already painted, so a fresh
      * connect pays exactly one capture per visible pane and only *reused*
@@ -1783,7 +1783,7 @@ public class TmuxSessionViewModel @Inject constructor(
 
     /**
      * Issue #830: pane IDs whose attach-time seed `capture-pane` round-trip is
-     * currently IN FLIGHT (marked the instant [seedPaneFromCapture] starts, before
+     * currently IN FLIGHT (marked the instant [healActivePaneIfStaleRender] starts, before
      * the wire exchange, and cleared when it returns). [panesSeededThisAttach] only
      * becomes true AFTER the snapshot has been appended — too late to dedup a
      * CONCURRENT reseed net (the pager-settle [reseedVisiblePaneIfBlank] launches a
@@ -2216,7 +2216,7 @@ public class TmuxSessionViewModel @Inject constructor(
     private val paneLastOutputAtMs: MutableMap<String, Long> = ConcurrentHashMap()
     // Issue #1175: the wall-clock (elapsedRealtime) of the last time a `capture-pane`
     // seed successfully LANDED into this pane's emulator (stamped in
-    // [seedPaneFromCaptureOnce] at the same point [panesSeededThisAttach] records the
+    // [captureAndApplyPaneSnapshot] at the same point [panesSeededThisAttach] records the
     // seed). An ABSENT entry means "no seed has ever landed for this pane" — the
     // discriminator between the `never_seeded` and `capture_empty` black-frame classes —
     // and its age (now - stamp) is the `msSinceLastSeed` fingerprint field on the
@@ -3710,7 +3710,7 @@ public class TmuxSessionViewModel @Inject constructor(
      *
      * We force ONE unconditional full-viewport reseed over the WARM `-CC` client, REUSING the
      * exact #553/#721/#892 reseed chokepoint ([reseedActivePaneForReattach] →
-     * [seedPaneFromCapture] → `_fullRepaintRequests` full clear+repaint) that manual Redraw
+     * [healActivePaneIfStaleRender] → `_fullRepaintRequests` full clear+repaint) that manual Redraw
      * and the within-grace reattach already use. `skipWhenFreshlySeeded = false` FORCES the
      * recapture even though the pane is still in [panesSeededThisAttach] from the original
      * attach (the live client never re-attached) — otherwise the model-intact "already seeded,
@@ -3919,7 +3919,7 @@ public class TmuxSessionViewModel @Inject constructor(
      * dogfood screenshot: ~100% black with only a lone stray cursor cell). This forces
      * a FULL-viewport reseed of the active pane over the WARM session — it REUSES the
      * exact #553/#879 full-reseed machinery ([reseedActivePaneForReattach] →
-     * [seedPaneFromCapture] → [TerminalSurfaceState.appendRemoteOutput], which fires the
+     * [healActivePaneIfStaleRender] → [TerminalSurfaceState.appendRemoteOutput], which fires the
      * #721 `_fullRepaintRequests` full clear+repaint) and the other-pane blank net.
      *
      * D21/D28 contract (a warm-session reseed ONLY — NO reconnect, detach, or new lease):
@@ -4008,7 +4008,7 @@ public class TmuxSessionViewModel @Inject constructor(
      * visible pane from a fresh `capture-pane` and feeds the full grid back into the
      * emulator — so a PARTIALLY-blank pane (one live line present, the static content
      * above it gone) is restored to the FULL prior viewport, not left "only a timer,
-     * rest blank" (#553). [seedPaneFromCapture] → [TerminalSurfaceState.appendRemoteOutput]
+     * rest blank" (#553). [healActivePaneIfStaleRender] → [TerminalSurfaceState.appendRemoteOutput]
      * repaints the whole grid (a full clear+restore), so the live line is preserved
      * within the restored frame, not duplicated.
      *
@@ -4065,15 +4065,16 @@ public class TmuxSessionViewModel @Inject constructor(
             // foreground-return. In `-CC` control mode the tmux server holds the pane's
             // full grid independent of whether the app re-emits, so `capture-pane` returns
             // the current content directly; the retained non-destructive swap
-            // ([captureWouldClearVisibleContent] in [seedPaneFromCaptureOnce]) keeps the
+            // ([captureWouldClearVisibleContent] in [captureAndApplyPaneSnapshot]) keeps the
             // last good frame if a capture is momentarily near-blank, so the reseed either
             // lands fresh authoritative content or keeps the prior frame — never black,
             // never a stray keystroke. This single chokepoint feeds manual Redraw, the
             // within-grace reattach, the no-op-resize heal, and the reflow completion.
-            seedPaneFromCapture(
+            healActivePaneIfStaleRender(
                 client,
                 activePane,
                 refreshGuard,
+                force = true,
                 recordMilestone = false,
             )
         }
@@ -8239,7 +8240,7 @@ public class TmuxSessionViewModel @Inject constructor(
                 // Issue #693/#662: this is a fresh attach for the reused panes —
                 // their old per-attach seed flags no longer apply, so clear them
                 // and let [reseedAllVisiblePanes] re-capture every visible pane
-                // with the new control client. [seedPaneFromCapture] now keeps
+                // with the new control client. [healActivePaneIfStaleRender] now keeps
                 // the last rendered frame on an empty capture (never repaints
                 // black) and retries, so a degraded reconnect can't strand a
                 // black pane.
@@ -10055,7 +10056,7 @@ public class TmuxSessionViewModel @Inject constructor(
      * watchdog and heal oracle both early-return on, so nothing self-heals and
      * the user must tap "Recreate terminal". This routes both overflow classes
      * through the existing [reseedActivePaneForReattach]-family machinery
-     * ([drainPaneOutputBacklog] → [seedPaneFromCapture] →
+     * ([drainPaneOutputBacklog] → [healActivePaneIfStaleRender] →
      * [attachTerminalProducerForPane]) with a bounded retry budget
      * ([OVERFLOW_RECOVERY_MAX_ATTEMPTS] within [OVERFLOW_RECOVERY_WINDOW_MS]) so
      * a still-saturated channel can't loop into a reseed storm — after the
@@ -10251,7 +10252,9 @@ public class TmuxSessionViewModel @Inject constructor(
                 //    buffered live deltas flush in order after the snapshot. The
                 //    non-destructive swap keeps the last good frame if the capture
                 //    is momentarily near-blank.
-                reseeded = seedPaneFromCapture(client, pane, guard, recordMilestone = false)
+                reseeded = healActivePaneIfStaleRender(
+                    client, pane, guard, force = true, recordMilestone = false,
+                ) == HealOutcome.Healed
                 if (reseeded) {
                     // Issue #1297: the snapshot is authoritative — the held frames
                     // are all PRE-capture (already reflected server-side in the
@@ -10769,7 +10772,11 @@ public class TmuxSessionViewModel @Inject constructor(
         try {
             if (refreshGuard != null && !isCurrentRuntime(refreshGuard)) {
                 activePane.terminalState.openSeedGateWithoutSeed()
-            } else if (!seedPaneFromCapture(client, activePane, refreshGuard, recordMilestone = true)) {
+            } else if (
+                healActivePaneIfStaleRender(
+                    client, activePane, refreshGuard, force = true, recordMilestone = true,
+                ) != HealOutcome.Healed
+            ) {
                 // Issue #468: a failed/empty active-pane capture must still open
                 // the seed gate so buffered live %output flushes in order.
                 activePane.terminalState.openSeedGateWithoutSeed()
@@ -10795,7 +10802,9 @@ public class TmuxSessionViewModel @Inject constructor(
                     continue
                 }
                 val seeded = try {
-                    seedPaneFromCapture(client, pane, refreshGuard, recordMilestone = false)
+                    healActivePaneIfStaleRender(
+                        client, pane, refreshGuard, force = true, recordMilestone = false,
+                    ) == HealOutcome.Healed
                 } catch (t: Throwable) {
                     if (t is CancellationException) {
                         pane.terminalState.openSeedGateWithoutSeed()
@@ -10847,12 +10856,12 @@ public class TmuxSessionViewModel @Inject constructor(
             // [panesSeededThisAttach] this attach, so they get their authoritative
             // post-attach repaint here.
             if (pane.paneId in panesSeededThisAttach) continue
-            // [seedPaneFromCapture] feeds the snapshot through
+            // The forced reseed feeds the snapshot through
             // [TerminalSurfaceState.appendRemoteOutput], which is safe to call
             // on an already-open gate (it is a feed + an open no-op), so a pane
             // that was already seeded as "new" simply gets its current frame
             // re-painted in place.
-            seedPaneFromCapture(client, pane, refreshGuard, recordMilestone = false)
+            healActivePaneIfStaleRender(client, pane, refreshGuard, force = true, recordMilestone = false)
         }
     }
 
@@ -10895,7 +10904,7 @@ public class TmuxSessionViewModel @Inject constructor(
                 "tmux-blank-pane-reseed pane=${pane.paneId} window=${pane.windowId} " +
                     "session=${activeTarget?.sessionName} status=${_connectionStatus.value}",
             )
-            seedPaneFromCapture(client, pane, refreshGuard, recordMilestone = false)
+            healActivePaneIfStaleRender(client, pane, refreshGuard, force = true, recordMilestone = false)
         }
     }
 
@@ -10949,7 +10958,7 @@ public class TmuxSessionViewModel @Inject constructor(
             // gone). That reads "not blank", so the pre-#941 gate passed it and the
             // partial-black pane was revealed as Connected and never reseeded (the
             // maintainer's "switched and it was black" symptom). Heal it here too —
-            // `seedPaneFromCapture` does a full clear+repaint, so it restores the
+            // the forced reseed does a full clear+repaint, so it restores the
             // FULL viewport from tmux's authoritative grid.
             //
             // Over-heal guard: a partial-black read is a HEURISTIC and a real
@@ -10967,10 +10976,11 @@ public class TmuxSessionViewModel @Inject constructor(
                     "tmux-reveal-gate-active-pane-partial-blank pane=${activePane.paneId} " +
                         "session=${activeTarget?.sessionName} -> one heal capture then reveal",
                 )
-                seedPaneFromCapture(
+                healActivePaneIfStaleRender(
                     client = client,
                     pane = activePane,
                     refreshGuard = refreshGuard,
+                    force = true,
                     recordMilestone = false,
                     maxAttempts = 1,
                 )
@@ -10986,10 +10996,11 @@ public class TmuxSessionViewModel @Inject constructor(
                 "tmux-reveal-gate-active-pane-blank pane=${activePane.paneId} " +
                     "attempt=$attempt session=${activeTarget?.sessionName}",
             )
-            seedPaneFromCapture(
+            healActivePaneIfStaleRender(
                 client = client,
                 pane = activePane,
                 refreshGuard = refreshGuard,
+                force = true,
                 recordMilestone = false,
                 maxAttempts = 1,
             )
@@ -11569,82 +11580,7 @@ public class TmuxSessionViewModel @Inject constructor(
                 "tmux-blank-pane-reseed-on-switch pane=$paneId window=${pane.windowId} " +
                     "session=${activeTarget?.sessionName}",
             )
-            seedPaneFromCapture(client, pane, refreshGuard = null, recordMilestone = false)
-        }
-    }
-
-    /**
-     * Capture a single pane's current content with `capture-pane -p -e` and
-     * feed it (with the restored cursor) into the pane's emulator, restoring
-     * the visible screen + colors after a tmux reattach. Returns true when a
-     * snapshot was actually applied. Shared by the new-pane preload
-     * ([preloadVisibleContentForNewPanes]) and the all-visible-pane reseed
-     * ([reseedAllVisiblePanes]).
-     */
-    /**
-     * Issue #693/#662: seed a pane from `capture-pane`, RETRYING when the
-     * capture comes back empty/error/null on a flaky link.
-     *
-     * The black-screen-while-connected bug: [seedPaneFromCaptureOnce] used to
-     * be the only seed call, and it treats an empty/error/null capture as a
-     * SILENT no-op (`return false` — no repaint, no keep-last, NO retry). On a
-     * degraded-but-connected channel the attach-time capture can transiently
-     * return empty; the idle full-screen agent/pager then emits no `%output`,
-     * so the pane's emulator stays unpainted and the surface renders the
-     * near-black background while status is `Connected` — the maintainer's
-     * green-dot-but-black-pane screenshots (and the partial/orphaned-cell
-     * variant, which is the SAME unseeded grid showing only a few live deltas).
-     *
-     * Retrying a transiently-empty capture (bounded, short backoff) lands the
-     * frame the next time the link recovers. A persistently-empty capture means
-     * tmux genuinely has nothing for that pane (a truly blank shell) — those
-     * retries are cheap and stop after the bound. The caller keeps the last
-     * rendered frame on a still-empty result (we never clear the emulator on a
-     * failed capture), so a momentary drop never repaints black.
-     */
-    private suspend fun seedPaneFromCapture(
-        client: TmuxClient,
-        pane: TmuxPaneState,
-        refreshGuard: RuntimeRefreshGuard?,
-        recordMilestone: Boolean,
-        maxAttempts: Int = SEED_CAPTURE_EMPTY_RETRY_ATTEMPTS,
-    ): Boolean {
-        // Issue #830: publish "a seed for this pane is in flight" BEFORE the first
-        // round-trip so a concurrent reseed net (the pager-settle
-        // [reseedVisiblePaneIfBlank]) dedups against the in-flight seed instead of
-        // racing it into a second redundant `capture-pane`. Cleared in the finally
-        // so the genuine #662 black-window heal still fires once no seed is pending.
-        panesSeedInFlightThisAttach.add(pane.paneId)
-        try {
-            // Issue #1151: reseed purely from tmux's authoritative server-side grid
-            // via `capture-pane` — we NEVER inject a keystroke into the pane to nudge
-            // a repaint. #989's `send-keys C-l` did exactly that and the 0x0C byte
-            // reached the agent CLI as input (Claude/GLM's "Ctrl+L is disabled…"
-            // banner on every switch / foreground-return). In `-CC` control mode the
-            // tmux server tracks the pane's full grid regardless of whether the app
-            // re-emits, so `capture-pane` returns the current content directly; the
-            // non-destructive swap in [seedPaneFromCaptureOnce]
-            // ([captureWouldClearVisibleContent]) keeps the last good frame across the
-            // retry loop below if a capture is momentarily near-blank — so the reseed
-            // lands fresh authoritative content or keeps the prior frame, never black,
-            // and never sends the app a control byte.
-            var attempt = 0
-            while (true) {
-                if (refreshGuard != null && !isCurrentRuntime(refreshGuard)) return false
-                if (client.disconnected.value) return false
-                if (seedPaneFromCaptureOnce(client, pane, refreshGuard, recordMilestone)) {
-                    return true
-                }
-                attempt += 1
-                if (attempt >= maxAttempts) return false
-                // Short backoff so a flaky-link empty capture is re-tried after the
-                // channel has a moment to recover, without stalling a genuinely
-                // empty pane's reveal for long. The guard re-check at the top of the
-                // loop aborts immediately if the runtime was superseded mid-wait.
-                delay(SEED_CAPTURE_EMPTY_RETRY_DELAY_MS)
-            }
-        } finally {
-            panesSeedInFlightThisAttach.remove(pane.paneId)
+            healActivePaneIfStaleRender(client, pane, refreshGuard = null, force = true, recordMilestone = false)
         }
     }
 
@@ -11779,9 +11715,56 @@ public class TmuxSessionViewModel @Inject constructor(
         client: TmuxClient,
         pane: TmuxPaneState,
         refreshGuard: RuntimeRefreshGuard?,
+        // Issue #1353 R2 — the single reseed authority's UNCONDITIONAL (force) mode,
+        // folded in from the deleted parallel `seedPaneFromCapture` sink (M4). A caller
+        // that needs a GUARANTEED reseed (cold-open attach seed, blank-pane heal, reveal
+        // handoff, reattach) passes `force = true`: the capture→[appendRemoteOutput] fires
+        // WITHOUT consulting the #1300 divergence oracle. A non-forced call stays
+        // oracle-gated (the M2 stale-render heal below). ONE capture→append authority.
+        force: Boolean = false,
+        // Force-mode only: warm-switch capture milestone (the cold-open active-pane seed).
+        recordMilestone: Boolean = false,
+        // Force-mode only: bound on the empty/near-blank capture retry loop (#693/#662).
+        // Ignored on the oracle-gated (non-force) path, which pays exactly one capture.
+        maxAttempts: Int = SEED_CAPTURE_EMPTY_RETRY_ATTEMPTS,
     ): HealOutcome {
         if (refreshGuard != null && !isCurrentRuntime(refreshGuard)) return HealOutcome.Unverified
         if (client.disconnected.value) return HealOutcome.Unverified
+        // Issue #1353 R2 — the UNCONDITIONAL reseed (seed mode). Folded in from the old
+        // `seedPaneFromCapture`: capture tmux's authoritative grid and apply it WITHOUT the
+        // oracle gate, RETRYING a transiently empty/near-blank capture on a flaky link
+        // (bounded); the non-destructive swap in [captureAndApplyPaneSnapshot] keeps the last
+        // good frame so a momentary drop never repaints black. Returns [HealOutcome.Healed]
+        // when a snapshot landed, [HealOutcome.Unverified] otherwise (so a force caller reads
+        // `== HealOutcome.Healed` exactly where it previously read the seed's Boolean `true`).
+        if (force) {
+            // Issue #830: publish "a seed for this pane is in flight" BEFORE the first
+            // round-trip so a concurrent reseed net (the pager-settle
+            // [reseedVisiblePaneIfBlank]) dedups against the in-flight seed instead of
+            // racing it into a second redundant `capture-pane`. Cleared in the finally.
+            panesSeedInFlightThisAttach.add(pane.paneId)
+            try {
+                var attempt = 0
+                while (true) {
+                    if (refreshGuard != null && !isCurrentRuntime(refreshGuard)) {
+                        return HealOutcome.Unverified
+                    }
+                    if (client.disconnected.value) return HealOutcome.Unverified
+                    if (captureAndApplyPaneSnapshot(client, pane, refreshGuard, recordMilestone)) {
+                        return HealOutcome.Healed
+                    }
+                    attempt += 1
+                    if (attempt >= maxAttempts) return HealOutcome.Unverified
+                    // Short backoff so a flaky-link empty capture is re-tried after the
+                    // channel has a moment to recover, without stalling a genuinely empty
+                    // pane's reveal for long. The guard re-check at the top aborts
+                    // immediately if the runtime was superseded mid-wait.
+                    delay(SEED_CAPTURE_EMPTY_RETRY_DELAY_MS)
+                }
+            } finally {
+                panesSeedInFlightThisAttach.remove(pane.paneId)
+            }
+        }
         // NOTE: this heal does NOT pre-skip a blank/partial-blank pane. The
         // divergence oracle ([visibleScreenDivergesFromCapture]) is the single
         // decision: it only fires when tmux's grid HAS substantial content while
@@ -11973,7 +11956,17 @@ public class TmuxSessionViewModel @Inject constructor(
         }
     }
 
-    private suspend fun seedPaneFromCaptureOnce(
+    /**
+     * Issue #1353 R2 — the ONE capture→[appendRemoteOutput] apply. A single
+     * single-flight `capture-pane`+cursor round-trip that applies tmux's authoritative
+     * grid to the pane, with the #989 NON-DESTRUCTIVE swap ([captureWouldClearVisibleContent]):
+     * a momentarily near-blank capture is REFUSED (the last good frame is kept, never
+     * cleared to black) so the caller's retry loop re-captures. Returns true when a
+     * snapshot was actually applied. Called ONLY from the force branch of
+     * [healActivePaneIfStaleRender] (the unified reseed chokepoint) — there is no other
+     * seed entry point after the R2 fold.
+     */
+    private suspend fun captureAndApplyPaneSnapshot(
         client: TmuxClient,
         pane: TmuxPaneState,
         refreshGuard: RuntimeRefreshGuard?,
@@ -15903,7 +15896,7 @@ public class TmuxSessionViewModel @Inject constructor(
             //    pane is FULLY populated but wrapped at the stale width — NOT blank,
             //    so [reseedBlankVisiblePanes] `continue`s past it and the garble
             //    persists until a manual tmux refresh. tmux's grid is authoritative
-            //    post-reflow, and [seedPaneFromCapture] -> [toTerminalViewportBytes]
+            //    post-reflow, and [healActivePaneIfStaleRender] -> [toTerminalViewportBytes]
             //    prepends `ESC[H ESC[2J` (full clear+repaint), so an unconditional
             //    active-pane re-capture authoritatively wipes the stale mis-wrapped
             //    rows and re-fits them to the new grid — no manual refresh needed.
@@ -15936,7 +15929,7 @@ public class TmuxSessionViewModel @Inject constructor(
      * short-circuits with no `refresh-client -C` — yet the IME transition lost
      * the idle full-screen agent's redraw and left the active pane BLACK. tmux's
      * server grid still holds the content, so re-capture the active pane from a
-     * fresh `capture-pane` (which [seedPaneFromCapture] -> [toTerminalViewportBytes]
+     * fresh `capture-pane` (which [healActivePaneIfStaleRender] -> [toTerminalViewportBytes]
      * replays as a full clear+repaint) — but ONLY when the pane is actually
      * blank/suspect, so a routine keyboard toggle on an already-painted pane stays
      * a no-op (no capture). Keyed to the target session id via the runtime guard,

--- a/app/src/test/java/com/pocketshell/app/tmux/FakeTmuxClient.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/FakeTmuxClient.kt
@@ -257,7 +257,7 @@ internal class FakeTmuxClient(
 
     /**
      * Issue #926: the thread name on which the most recent SEED round-trip
-     * actually ran. The seed IO ([TmuxSessionViewModel.seedPaneFromCaptureOnce]
+     * actually ran. The seed IO ([TmuxSessionViewModel.captureAndApplyPaneSnapshot]
      * → [captureWithCursor]) and the attach/switch `list-panes`
      * ([handleCommand]) must run OFF the Main (UI) thread; a test pins Main and
      * the seed-IO dispatcher to two DISTINCT single-thread dispatchers and

--- a/app/src/test/java/com/pocketshell/app/tmux/SingleReseedPathFoldTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/SingleReseedPathFoldTest.kt
@@ -1,0 +1,435 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.app.sessions.ActiveTmuxClients
+import com.pocketshell.core.agents.AgentKind
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.SshLeaseConnector
+import com.pocketshell.core.ssh.SshLeaseManager
+import com.pocketshell.core.ssh.SshLeaseTarget
+import com.pocketshell.core.ssh.SshPortForward
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshShell
+import com.pocketshell.core.terminal.bridge.SshTerminalBridge
+import com.pocketshell.core.terminal.ui.TerminalSurfaceState
+import com.pocketshell.core.tmux.CommandResponse
+import com.pocketshell.core.tmux.TmuxClientFactory
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+import java.io.InputStream
+
+/**
+ * Issue #1353 slice R2 — DURABLE REGRESSION GUARD that the terminal render-heal stack
+ * has ONE reseed path: the unified [TmuxSessionViewModel.healActivePaneIfStaleRender]
+ * chokepoint with an UNCONDITIONAL (force) mode, and NO parallel oracle-bypassing sink.
+ *
+ * ## The fold
+ *
+ * Before R2 there were TWO capture→[TerminalSurfaceState.appendRemoteOutput] paths with
+ * different acceptance semantics: the oracle-gated M2 chokepoint
+ * ([TmuxSessionViewModel.healActivePaneIfStaleRender], which only reseeds when the #1300
+ * divergence oracle [TerminalSurfaceState.visibleRenderLostFrameVsCapture] scores the
+ * render "frame lost"), and the parallel M4 sink `seedPaneFromCapture` /
+ * `seedPaneFromCaptureOnce`, which every blank-watchdog / reveal / reattach caller used
+ * to reseed UNCONDITIONALLY (it never consulted the oracle). R2 folds M4 into M2 as a
+ * `force` mode and DELETES the parallel sink — one capture→append authority.
+ *
+ * ## What each test proves (the two semantics the fold must preserve)
+ *
+ *  - [forcedReattachReseedAppliesCaptureEvenWhenOracleWouldNotHeal] (+ the agent-pane
+ *    class-coverage sibling): the LOAD-BEARING assertion — a FORCED reseed still fires
+ *    the capture→append for the reattach / reveal / blank case M4 uniquely served, EVEN
+ *    when the oracle would score the render HEALTHY (not lost). This is the case that a
+ *    wrong fold — one that gated the forced path behind the oracle — would silently
+ *    drop, reintroducing the black/blank-pane class. The GREEN assertion is that tmux's
+ *    marker line lands in the render.
+ *  - [oracleGatedHealLeavesTheSameNonLostCaptureUnapplied]: the CONTROL — the SAME dense
+ *    pane + SAME slightly-richer capture, driven through the NON-forced (oracle-gated)
+ *    path, returns [HealOutcome.Healthy] and does NOT reseed (no over-heal / reveal
+ *    thrash on a confidently-dense pane). Together with the forced test this is the
+ *    discriminator: identical capture, oracle-gated → no reseed, forced → reseed.
+ *  - [blankWatchdogForceReseedAppliesThroughUnifiedChokepoint]: class coverage that the
+ *    blank-watchdog FORCE caller ([TmuxSessionViewModel.reseedBlankVisiblePanes]) reseeds
+ *    a truly-blank pane through the unified chokepoint after the fold.
+ *
+ * ## Red -> green (a WRONG fold, not the pre-R2 base — this slice is a refactor)
+ *
+ * On a variant where the forced path is (incorrectly) gated behind the oracle, the
+ * forced-reseed tests go RED: the marker never lands because the oracle scores the
+ * near-identical capture "not lost" and declines. With the correct force path they are
+ * GREEN. Captured in the issue #1353 R2 status comment.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class SingleReseedPathFoldTest {
+
+    private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val createdVms = mutableListOf<TmuxSessionViewModel>()
+
+    @After
+    fun tearDown() {
+        factoryScope.cancel()
+    }
+
+    // -------------------------------------------------------------------------
+    // (1) FORCED reseed (the reattach/switch/foreground/blank chokepoint) must apply
+    //     tmux's capture EVEN when the oracle would score the render HEALTHY — the case
+    //     the deleted M4 sink uniquely served. LOAD-BEARING GREEN. SHELL pane.
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun forcedReattachReseedAppliesCaptureEvenWhenOracleWouldNotHeal() = runVmTest {
+        val client = FakeTmuxClient().withDenseInitialFrame("work", "%1")
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == "%1" }
+
+        // Precondition: the pane is densely rendered (NOT blank, NOT partial-black) — the
+        // exact state the oracle scores HEALTHY, so any reseed here is UNCONDITIONAL, not
+        // oracle-driven.
+        assertFalse(pane.terminalState.visibleScreenIsBlank())
+        assertFalse(pane.terminalState.visibleScreenIsPartiallyBlank())
+        assertTrue(
+            "precondition: the dense pane already renders tmux's base frame",
+            renderedTranscriptFor(pane).contains(BASE_MARKER),
+        )
+
+        // tmux's grid returns the SAME dense frame plus ONE extra marker line — the render
+        // is missing only that 1 line, WELL under the oracle's lost-line threshold, so the
+        // oracle would read the render HEALTHY (verified by the control test below).
+        client.capturePaneResponses.addLast(
+            CommandResponse(number = 99L, output = forcedCaptureFrame(), isError = false),
+        )
+        val capturesBefore = client.healCaptureCount()
+
+        // THE REAL FORCED PATH: the attach/switch/foreground/no-op-resize/reconnect reseed
+        // chokepoint (skipWhenFreshlySeeded=false → it always forces the active-pane reseed).
+        vm.reseedActivePaneForReattachForTest(vm.currentRuntimeGuardForTest())
+        advanceUntilIdle()
+
+        assertTrue(
+            "R2: the forced reseed must issue a capture-pane",
+            client.healCaptureCount() > capturesBefore,
+        )
+        assertTrue(
+            "R2 LOAD-BEARING: the FORCED reseed must APPLY tmux's capture even though the " +
+                "oracle would score this render healthy — the marker line only tmux holds " +
+                "must land in the render. A fold that gated force behind the oracle would " +
+                "drop this reseed (RED).",
+            renderedTranscriptFor(pane).contains(FORCED_MARKER),
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // (2) CONTROL: the SAME dense pane + SAME slightly-richer capture, driven through the
+    //     NON-forced (oracle-gated) heal, returns Healthy and does NOT reseed. This proves
+    //     the capture the forced test applied is one the oracle scores "not lost".
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun oracleGatedHealLeavesTheSameNonLostCaptureUnapplied() = runVmTest {
+        val client = FakeTmuxClient().withDenseInitialFrame("work", "%1")
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == "%1" }
+        assertFalse(pane.terminalState.visibleScreenIsBlank())
+
+        client.capturePaneResponses.addLast(
+            CommandResponse(number = 99L, output = forcedCaptureFrame(), isError = false),
+        )
+
+        // THE NON-FORCED (oracle-gated) chokepoint over the active pane.
+        val outcome = vm.healActivePaneIfStaleRenderForTest()
+        advanceUntilIdle()
+
+        assertEquals(
+            "R2: the oracle-gated path must GATE — a dense pane whose render is missing only " +
+                "1 of tmux's lines is HEALTHY (not lost), so NO reseed (no over-heal / reveal " +
+                "thrash). This is what makes the forced test's apply UNCONDITIONAL, not oracle-driven.",
+            HealOutcome.Healthy,
+            outcome,
+        )
+        assertFalse(
+            "R2: the oracle-gated heal must NOT apply the near-identical capture — the marker " +
+                "only tmux holds must NOT land when the render is scored healthy",
+            renderedTranscriptFor(pane).contains(FORCED_MARKER),
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // (3) Class coverage: the SAME forced-reseed-bypasses-oracle guarantee on an AGENT
+    //     pane (shell + agent).
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun forcedReattachReseedAppliesCaptureEvenWhenOracleWouldNotHealAgentPane() = runVmTest {
+        val client = FakeTmuxClient().withDenseInitialFrame("work", "%2", title = "codex")
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == "%2" }
+        assertFalse(pane.terminalState.visibleScreenIsBlank())
+        assertFalse(pane.terminalState.visibleScreenIsPartiallyBlank())
+
+        client.capturePaneResponses.addLast(
+            CommandResponse(number = 99L, output = forcedCaptureFrame(), isError = false),
+        )
+        val capturesBefore = client.healCaptureCount()
+
+        vm.reseedActivePaneForReattachForTest(vm.currentRuntimeGuardForTest())
+        advanceUntilIdle()
+
+        assertTrue(client.healCaptureCount() > capturesBefore)
+        assertTrue(
+            "R2 (agent pane): the forced reseed must apply tmux's capture unconditionally",
+            renderedTranscriptFor(pane).contains(FORCED_MARKER),
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // (4) Class coverage: the blank-watchdog FORCE caller
+    //     ([TmuxSessionViewModel.reseedBlankVisiblePanes]) reseeds a truly-blank pane
+    //     through the unified chokepoint after the fold.
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun blankWatchdogForceReseedAppliesThroughUnifiedChokepoint() = runVmTest {
+        // A minimal one-line initial frame so a clear-only overpaint fully blanks the pane
+        // (a dense frame would leave rows in scrollback and read non-blank).
+        val client = FakeTmuxClient().withMinimalInitialFrame("work", "%3")
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == "%3" }
+
+        // Wipe the pane FULLY black (a clear-only overpaint) — the blank-watchdog's target.
+        pane.terminalState.appendRemoteOutput(CLEAR_ONLY.toByteArray(Charsets.US_ASCII))
+        advanceUntilIdle()
+        assertTrue(
+            "precondition: the pane is fully blank (the blank watchdog's state)",
+            pane.terminalState.visibleScreenIsBlank(),
+        )
+
+        client.capturePaneResponses.addLast(
+            CommandResponse(number = 99L, output = forcedCaptureFrame(), isError = false),
+        )
+        val capturesBefore = client.healCaptureCount()
+
+        // THE REAL BLANK-WATCHDOG FORCE PATH.
+        vm.reseedBlankVisiblePanesForTest(vm.currentRuntimeGuardForTest())
+        advanceUntilIdle()
+
+        assertTrue(
+            "R2: the blank-watchdog force reseed must issue a capture through the unified chokepoint",
+            client.healCaptureCount() > capturesBefore,
+        )
+        assertTrue(
+            "R2: the blank pane is restored from tmux's authoritative grid",
+            renderedTranscriptFor(pane).contains(FORCED_MARKER),
+        )
+        assertFalse(
+            "R2: the blank pane is no longer blank after the force reseed",
+            pane.terminalState.visibleScreenIsBlank(),
+        )
+    }
+
+    // ------------------------------------------------------------------ Harness
+
+    private fun runVmTest(body: suspend TestScope.() -> Unit) = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        LivenessProbeTestOverride.setAutoStartEnabledForTest(false)
+        try {
+            body()
+        } finally {
+            for (vm in createdVms) {
+                runCatching { vm.setProcessForegroundForClearedForTest(false) }
+                runCatching { vm.clearForTest() }
+            }
+            advanceUntilIdle()
+            createdVms.clear()
+            LivenessProbeTestOverride.clear()
+            Dispatchers.resetMain()
+        }
+    }
+
+    private fun TestScope.newVm(
+        registry: ActiveTmuxClients,
+        sshLeaseManager: SshLeaseManager,
+    ): TmuxSessionViewModel = TmuxSessionViewModel(
+        tmuxClientFactory = TmuxClientFactory(factoryScope),
+        activeTmuxClients = registry,
+        runtimeCache = TmuxSessionRuntimeCache(),
+        sshLeaseManager = sshLeaseManager,
+        sessionLifecycleSignals = null,
+    ).also {
+        it.setSeedIoDispatcherForTest(StandardTestDispatcher(testScheduler))
+        createdVms.add(it)
+    }
+
+    private fun TestScope.connectVm(client: FakeTmuxClient): TmuxSessionViewModel {
+        val live = AlwaysConnectedSession(id = "live")
+        val connector = SingleSessionConnector(live)
+        val leaseManager =
+            testLeaseManager(connector = connector, scope = this, idleTtlMillis = 60_000L)
+        val registry = ActiveTmuxClients()
+        val vm = newVm(registry = registry, sshLeaseManager = leaseManager)
+        runCurrent()
+        // Isolate the reseed under test: silence the auto-armed blank + stale-render
+        // watchdogs so the only capture-pane traffic is the reseed each test drives.
+        vm.setConnectedBlankWatchdogAutoArmEnabledForTest(false)
+        vm.setStaleRenderWatchdogAutoArmEnabledForTest(false)
+        vm.setTmuxClientFactoryForTest { _, _, _ -> client }
+        vm.connect(
+            hostId = 1L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            passphrase = null,
+            sessionName = "work",
+        )
+        advanceUntilIdle()
+        // Apply a phone grid so the emulator has real row geometry (the oracle / blank
+        // fraction is measured against the emulator's mRows).
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+        return vm
+    }
+
+    private fun FakeTmuxClient.healCaptureCount(): Int =
+        sentCommands.count { it.startsWith("capture-pane") && it.contains(" -e") }
+
+    private fun FakeTmuxClient.withDenseInitialFrame(
+        sessionName: String,
+        paneId: String,
+        title: String = sessionName,
+    ): FakeTmuxClient = apply {
+        responses.addLast(
+            CommandResponse(
+                number = 1L,
+                output = listOf("$paneId\t@0\t\$0\t$sessionName\t$title\t0"),
+                isError = false,
+            ),
+        )
+        // The attach seed paints the dense base frame.
+        capturePaneResponses.addLast(
+            CommandResponse(number = 2L, output = baseFrame(), isError = false),
+        )
+        cursorQueryResponses.addLast(
+            CommandResponse(number = 3L, output = listOf("0,0"), isError = false),
+        )
+    }
+
+    private fun FakeTmuxClient.withMinimalInitialFrame(
+        sessionName: String,
+        paneId: String,
+        title: String = sessionName,
+    ): FakeTmuxClient = apply {
+        responses.addLast(
+            CommandResponse(
+                number = 1L,
+                output = listOf("$paneId\t@0\t\$0\t$sessionName\t$title\t0"),
+                isError = false,
+            ),
+        )
+        capturePaneResponses.addLast(
+            CommandResponse(number = 2L, output = listOf("$sessionName ready"), isError = false),
+        )
+        cursorQueryResponses.addLast(
+            CommandResponse(number = 3L, output = listOf("0,0"), isError = false),
+        )
+    }
+
+    private fun renderedTranscriptFor(pane: TmuxPaneState): String {
+        val state = pane.terminalState
+        val bridgeField = TerminalSurfaceState::class.java.getDeclaredField("bridge").apply {
+            isAccessible = true
+        }
+        val bridge = bridgeField.get(state) as? SshTerminalBridge ?: return ""
+        return bridge.emulator.screen.transcriptText
+    }
+
+    private class SingleSessionConnector(
+        private val session: SshSession,
+    ) : SshLeaseConnector {
+        override suspend fun connect(target: SshLeaseTarget): Result<SshSession> =
+            Result.success(session)
+    }
+
+    private class AlwaysConnectedSession(
+        val id: String,
+    ) : SshSession {
+        @Volatile
+        var closed: Boolean = false
+
+        override val isConnected: Boolean get() = !closed
+
+        override suspend fun exec(command: String): ExecResult =
+            ExecResult(stdout = "", stderr = "", exitCode = 0)
+
+        override fun tail(path: String, onLine: (String) -> Unit): Job =
+            Job().apply { complete() }
+
+        override fun tail(path: String, fromLineExclusive: Long, onLine: (String) -> Unit): Job =
+            Job().apply { complete() }
+
+        override fun openLocalPortForward(
+            remoteHost: String,
+            remotePort: Int,
+            localPort: Int,
+        ): SshPortForward = error("not used")
+
+        override fun startShell(): SshShell = error("not used")
+
+        override suspend fun uploadFile(file: File, remotePath: String): String = error("not used")
+
+        override suspend fun uploadStream(
+            input: InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String = error("not used")
+
+        override fun close() {
+            closed = true
+        }
+    }
+
+    private companion object {
+        const val BASE_MARKER: String = "R2FOLD-BASE-ROW"
+        const val FORCED_MARKER: String = "R2FOLD-FORCED-RESEED-MARKER"
+
+        // ESC[2J ESC[H — clear screen + cursor home.
+        val CLEAR_ONLY: String = "[2J[H"
+
+        // A DENSE 34-line base frame (well over the 0.75 suspect ceiling on a 40-row
+        // viewport), so the pane renders confidently-full and the oracle scores it healthy.
+        fun baseFrame(): List<String> = buildList {
+            repeat(34) { add("$BASE_MARKER $it real rendered content padding here to fill the row") }
+        }
+
+        // tmux's grid returns the SAME 34 base lines PLUS one extra marker line: the render
+        // is missing only 1 of the 35 capture lines, well under the oracle's
+        // max(3, ceil(0.25*35)=9) lost-line threshold → the oracle scores it "not lost"
+        // (verified by [oracleGatedHealLeavesTheSameNonLostCaptureUnapplied]).
+        fun forcedCaptureFrame(): List<String> = buildList {
+            addAll(baseFrame())
+            add("$FORCED_MARKER only tmux's authoritative grid holds this line")
+        }
+    }
+}

--- a/scripts/connection-vm-ratchet-baseline.txt
+++ b/scripts/connection-vm-ratchet-baseline.txt
@@ -6,4 +6,4 @@
 io_count 17
 runblocking_count 13
 connection_decision_variants 0
-vm_line_count 17629
+vm_line_count 17622

--- a/scripts/file-size-hygiene-baseline.txt
+++ b/scripts/file-size-hygiene-baseline.txt
@@ -8,7 +8,7 @@
 177524 app/src/main/java/com/pocketshell/app/composer/PromptComposerViewModel.kt
 147448 app/src/main/java/com/pocketshell/app/projects/FolderListViewModel.kt
 149516 app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
-907650 app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+907594 app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
 148633 app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
 1146350 docs/mockups/feedback/folder-tree-target-20260604.png
 182790 docs/screenshots/readme-settings.png


### PR DESCRIPTION
Slice **R2** of the terminal render-heal consolidation EPIC #1353 (follows R1's pre-gate unification, shipped in v0.4.26).

Folds the parallel, oracle-**bypassing** reseed sink (M4 `seedPaneFromCapture`/`seedPaneFromCaptureOnce`) into the single oracle-gated chokepoint `healActivePaneIfStaleRender` (M2) via a new `force` mode:
- `force=true` → reseeds unconditionally (the blank / reveal-handoff / reattach / surface-recovery cases M4 uniquely served).
- `force=false` → stays oracle-gated (M2 behavior; no over-heal on dense panes).
- The parallel sink is **DELETED** (hard-cut, D22); `seedPaneFromCaptureOnce` → `captureAndApplyPaneSnapshot`; all **9 former M4 callers** routed through the chokepoint with `force=true`.
- M8 full-repaint + M9 seed-gate quiesce preserved; the M1 oracle and R1 `renderLooksSuspect()` pre-gate **untouched**. VM **net shrink** (17629→17622).

### Review — APPROVED
https://github.com/alexeygrigorev/pocketshell/issues/1353#issuecomment-4944925889
- Reviewer-run RED→GREEN (G1/G3/G6): neutralizing the `force` branch fails exactly the forced-reattach tests (FORCED_MARKER never lands — oracle scores the dense render healthy); restored → all 4 pass. Green assertion is the behavior, not a proxy.
- All 5 correctness questions verified: forced reseed fires for every M4-unique case; oracle path still gates; 9 callers routed (5 pre-existing M2 sites correctly left non-force); hard-cut complete; M8/M9 + oracle/R1 preserved.
- Emulator heal journeys (G4): 7/8 green incl. every direct force-caller journey; the 1 failure proven pre-existing (red on base cfac9f32 too — a local-AVD `Issue1206` view-attach flake, not introduced here).
- Hygiene: VM ratchet net shrink, file-size downward re-bake, `git diff --check` clean.

Rebased onto current `main` (058092e9, incl. #1482); no conflict with #1482's `TmuxSessionSupport.kt` const removals; post-rebase focused test green (4/4).

Refs #1353 (one slice of the ongoing EPIC — does not close it).