### PR TITLE
terminal: per-pane single-flight for the render-heal chokepoint (#1353 R3)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/tmux/RenderHealCoordinator.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/RenderHealCoordinator.kt
@@ -1,0 +1,66 @@
+package com.pocketshell.app.tmux
+
+import java.util.concurrent.ConcurrentHashMap
+import kotlinx.coroutines.sync.Mutex
+
+/**
+ * Issue #1353 slice R3 — the PER-PANE SINGLE-FLIGHT owner for the terminal render-heal
+ * chokepoint ([TmuxSessionViewModel.healActivePaneIfStaleRender]). Extracted to a sibling
+ * of the connection-core god object (D28: prefer extraction over growing the VM).
+ *
+ * ## The race this closes (spike §3 "double-fire / race")
+ *
+ * `healActivePaneIfStaleRender` had NO cross-launcher single-flight. The send-overpaint
+ * heal (L1), the continuous stale-render watchdog (L2), and the reveal/switch heal (L5) all
+ * call it on the SAME active pane with no shared lock, so two heals could enter the
+ * `closeSeedGate()` … `capture-pane` … `appendRemoteOutput`/`openSeedGateWithoutSeed()`
+ * window (the M9 seed gate) CONCURRENTLY. M9 is a **single latch on the bridge**, so an
+ * interleave — heal B closes the gate and parks on its (in-flight) capture while a NEWER
+ * live `%output` delta buffers behind the gate; sibling heal A then reaches its
+ * `openSeedGateWithoutSeed` and OPENS the gate, flushing B's buffered delta to the emulator;
+ * then B's (older) snapshot lands and its `CSI 2J` clear WIPES the just-flushed delta —
+ * re-introduces the exact "capture clobbers newer delta" class M9 was built to prevent. The
+ * `finally` fail-safe in the heal only protects against a *stuck-closed* gate, NOT against a
+ * *premature open* by a sibling launcher crossing into another heal's window.
+ *
+ * ## Semantics: SERIALIZE per pane (queue, never drop) — NOT coalesce
+ *
+ * Each pane id owns its own [Mutex]. A heal takes the pane's mutex for the whole
+ * close→capture→apply→open window, so a second heal for the SAME pane WAITS and then runs
+ * its own full window afterwards. We deliberately QUEUE rather than COALESCE (drop a
+ * concurrent duplicate): a queued heal always performs its own fresh `capture-pane`, so no
+ * heal that could have recovered a pane is ever dropped — the #1-critical guarantee is "never
+ * leave a pane black", and the cost is at most one bounded capture round-trip of added
+ * latency for the queued heal (the capture is bounded by the seed timeout / the force-mode
+ * retry cap, so the lock is always released and there is no deadlock). Different panes hold
+ * DIFFERENT mutexes, so they still heal fully concurrently (this is per-pane, never a global
+ * lock). R4 (event-driven reconciler) may revisit coalescing once the six launchers collapse
+ * into one loop; for R3 the safe, no-drop serialization is the correct minimal guard.
+ *
+ * Thread-safety: [paneMutexes] is a [ConcurrentHashMap] and [paneHealMutex] uses
+ * [ConcurrentHashMap.getOrPut] so two launchers racing to heal a never-before-seen pane still
+ * observe the SAME mutex instance (a lost-update on the map would defeat the whole guard).
+ * Pane ids (`%N`) are small and reused across a session, so the map stays naturally bounded;
+ * [forget]/[reset] are provided for explicit eviction and test teardown.
+ */
+internal class RenderHealCoordinator {
+
+    private val paneMutexes = ConcurrentHashMap<String, Mutex>()
+
+    /**
+     * The single-flight [Mutex] for [paneId], created on first use. Concurrent callers for
+     * the same pane observe the same instance (atomic [ConcurrentHashMap.getOrPut]); callers
+     * for different panes observe distinct instances (heal concurrently).
+     */
+    fun paneHealMutex(paneId: String): Mutex = paneMutexes.getOrPut(paneId) { Mutex() }
+
+    /** Drop the single-flight mutex for a pane that no longer exists. */
+    fun forget(paneId: String) {
+        paneMutexes.remove(paneId)
+    }
+
+    /** Test / teardown seam: forget every per-pane mutex. */
+    fun reset() {
+        paneMutexes.clear()
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -156,6 +156,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.ContinuationInterceptor
 import kotlin.coroutines.coroutineContext
@@ -1796,6 +1797,9 @@ public class TmuxSessionViewModel @Inject constructor(
      */
     private val panesSeedInFlightThisAttach: MutableSet<String> =
         java.util.Collections.newSetFromMap(ConcurrentHashMap())
+
+    /** Issue #1353 R3 — per-pane single-flight owner for the heal chokepoint (spike §3 race). */
+    private val renderHealCoordinator = RenderHealCoordinator()
     private var autoReconnectDelaysMs: List<Long> = DEFAULT_AUTO_RECONNECT_DELAYS_MS
     private var passiveDisconnectGraceMs: Long = PASSIVE_DISCONNECT_GRACE_MS
     private var silentReattachTimeoutMs: Long = PASSIVE_DISCONNECT_SILENT_REATTACH_TIMEOUT_MS
@@ -11715,28 +11719,46 @@ public class TmuxSessionViewModel @Inject constructor(
         client: TmuxClient,
         pane: TmuxPaneState,
         refreshGuard: RuntimeRefreshGuard?,
+        force: Boolean = false,
+        recordMilestone: Boolean = false,
+        maxAttempts: Int = SEED_CAPTURE_EMPTY_RETRY_ATTEMPTS,
+    ): HealOutcome =
+        // Issue #1353 R3 — SINGLE-FLIGHT per pane. Serialize the whole close→capture→apply→open
+        // seed-gate (M9) window so a sibling launcher (L1 send / L2 watchdog / L5 reveal) on the
+        // SAME pane can't cross into it and open the gate early, clobbering a buffered newer
+        // `%output` delta (spike §3 race). Keyed per pane, so different panes heal concurrently.
+        // `withLock` is inline (early returns stay non-local, the mutex ALWAYS unlocks — bounded).
+        renderHealCoordinator.paneHealMutex(pane.paneId).withLock {
+            healActivePaneIfStaleRenderLocked(
+                client, pane, refreshGuard, force, recordMilestone, maxAttempts,
+            )
+        }
+
+    private suspend fun healActivePaneIfStaleRenderLocked(
+        client: TmuxClient,
+        pane: TmuxPaneState,
+        refreshGuard: RuntimeRefreshGuard?,
         // Issue #1353 R2 — the single reseed authority's UNCONDITIONAL (force) mode,
         // folded in from the deleted parallel `seedPaneFromCapture` sink (M4). A caller
         // that needs a GUARANTEED reseed (cold-open attach seed, blank-pane heal, reveal
         // handoff, reattach) passes `force = true`: the capture→[appendRemoteOutput] fires
         // WITHOUT consulting the #1300 divergence oracle. A non-forced call stays
         // oracle-gated (the M2 stale-render heal below). ONE capture→append authority.
-        force: Boolean = false,
+        force: Boolean,
         // Force-mode only: warm-switch capture milestone (the cold-open active-pane seed).
-        recordMilestone: Boolean = false,
+        recordMilestone: Boolean,
         // Force-mode only: bound on the empty/near-blank capture retry loop (#693/#662).
         // Ignored on the oracle-gated (non-force) path, which pays exactly one capture.
-        maxAttempts: Int = SEED_CAPTURE_EMPTY_RETRY_ATTEMPTS,
+        maxAttempts: Int,
     ): HealOutcome {
         if (refreshGuard != null && !isCurrentRuntime(refreshGuard)) return HealOutcome.Unverified
         if (client.disconnected.value) return HealOutcome.Unverified
-        // Issue #1353 R2 — the UNCONDITIONAL reseed (seed mode). Folded in from the old
+        // Issue #1353 R2 — the UNCONDITIONAL reseed (seed mode), folded in from the old
         // `seedPaneFromCapture`: capture tmux's authoritative grid and apply it WITHOUT the
-        // oracle gate, RETRYING a transiently empty/near-blank capture on a flaky link
-        // (bounded); the non-destructive swap in [captureAndApplyPaneSnapshot] keeps the last
-        // good frame so a momentary drop never repaints black. Returns [HealOutcome.Healed]
-        // when a snapshot landed, [HealOutcome.Unverified] otherwise (so a force caller reads
-        // `== HealOutcome.Healed` exactly where it previously read the seed's Boolean `true`).
+        // oracle gate, RETRYING a transiently empty/near-blank capture (bounded); the
+        // non-destructive swap in [captureAndApplyPaneSnapshot] keeps the last good frame so a
+        // momentary drop never repaints black. Returns [HealOutcome.Healed] when a snapshot
+        // landed, [HealOutcome.Unverified] otherwise (a force caller reads `== Healed`).
         if (force) {
             // Issue #830: publish "a seed for this pane is in flight" BEFORE the first
             // round-trip so a concurrent reseed net (the pager-settle
@@ -11765,26 +11787,20 @@ public class TmuxSessionViewModel @Inject constructor(
                 panesSeedInFlightThisAttach.remove(pane.paneId)
             }
         }
-        // NOTE: this heal does NOT pre-skip a blank/partial-blank pane. The
-        // divergence oracle ([visibleScreenDivergesFromCapture]) is the single
-        // decision: it only fires when tmux's grid HAS substantial content while
-        // the rendered VISIBLE viewport shows almost none of it — which is a stale
-        // render regardless of whether the residue is zero glyphs (fully black),
-        // a few scattered fragments (#966), or a post-burst clear. The heal is
-        // idempotent (a full clear+repaint of tmux's authoritative grid), so even
-        // if the blank watchdog also fires it just re-paints identical content.
+        // NOTE: this heal does NOT pre-skip a blank/partial-blank pane. The divergence oracle
+        // ([visibleScreenDivergesFromCapture]) is the single decision: it fires only when
+        // tmux's grid HAS substantial content while the VISIBLE viewport shows almost none of
+        // it — a stale render whether the residue is zero glyphs, scattered fragments (#966), or
+        // a post-burst clear. The heal is idempotent (a full clear+repaint of tmux's grid).
         //
-        // Issue #1294: the SURFACE-BLACK detector/heal runs FIRST — BEFORE and
-        // INDEPENDENT of the `capture-pane` round-trip below. A surface-only black (the
-        // MODEL grid is intact but the on-screen SURFACE is confirmed black, spike #874
-        // GAP-1) recovers with a PURE surface repaint that needs NO tmux content — so a
-        // wedged / timed-out capture must never gate it. Before #1294 this #1203 auto-heal
-        // sat INSIDE the capture-success branch, behind the empty/errored early-return, so
-        // a Claude burst that starved the shared capture mutex (the exact window a pane
-        // goes black) blocked the one recovery that never needed a capture at all. The
-        // repaint fires here on the surface-black signal; its exportable FINGERPRINT is
-        // recorded below where the authoritative captureBytes is known (or, when the
-        // capture then fails, in the capture-failed branch with captureBytes unknown).
+        // Issue #1294: the SURFACE-BLACK detector/heal runs FIRST — BEFORE and INDEPENDENT of
+        // the `capture-pane` round-trip below. A surface-only black (MODEL grid intact but the
+        // on-screen SURFACE confirmed black, spike #874 GAP-1) recovers with a PURE surface
+        // repaint that needs NO tmux content, so a wedged/timed-out capture must never gate it
+        // (before #1294 it sat behind the capture's empty/errored early-return and a
+        // capture-mutex-starving Claude burst blocked the one recovery needing no capture). Its
+        // exportable FINGERPRINT is recorded below where captureBytes is known (or, on capture
+        // failure, in the capture-failed branch).
         val surfaceBlack = pane.terminalState.surfaceIsBlackWhileModelHasContent()
         if (surfaceBlack) {
             Log.i(
@@ -11796,22 +11812,16 @@ public class TmuxSessionViewModel @Inject constructor(
             )
             pane.terminalState.requestSurfaceRepaint()
         }
-        // Issue #1301 (capture-clobbers-newer-delta race): QUIESCE live `%output`
-        // delivery around the reconcile capture+apply — but ONLY for a pane whose render
-        // already looks SUSPECT (black / partial-black / mostly-empty / surface-black),
-        // i.e. one we are about to reseed. Closing the seed gate buffers any NEWER
-        // in-flight delta (in arrival order) instead of letting it paint the emulator and
-        // then be wiped by the (older) snapshot's `CSI 2J` clear; [appendRemoteOutput]'s
-        // `seedThenOpenGate` re-applies the buffered deltas ON TOP of the snapshot
-        // (newest-wins). A HEALTHY (dense, correctly-rendering) pane is NOT quiesced — its
-        // gate stays OPEN so its steady live output never buffers, preserving the
-        // #1219/#1164 steady-heat back-off with zero added stutter. The gate is REOPENED
-        // in the `finally` on EVERY exit (healthy / unverified / healed), flushing any
-        // buffered delta so live output is never swallowed (#468 fail-safe). This is the
-        // #1298 design §5 "quiesce-around-apply" widened to the whole capture+apply window
-        // for a suspect pane (strictly stronger, deterministically testable, and — since
-        // the target class is the idle non-repainting pane with NO concurrent deltas —
-        // free there; a busy suspect pane briefly buffers then flushes in order).
+        // Issue #1301 (capture-clobbers-newer-delta race): QUIESCE live `%output` delivery
+        // around the capture+apply — but ONLY for a pane whose render already looks SUSPECT
+        // (one we are about to reseed). Closing the seed gate buffers any NEWER in-flight delta
+        // (in arrival order); [appendRemoteOutput]'s `seedThenOpenGate` re-applies it ON TOP of
+        // the snapshot (newest-wins) so the snapshot's `CSI 2J` clear can't clobber it. A
+        // HEALTHY pane is NOT quiesced (gate stays open — #1219/#1164 steady-heat back-off
+        // untouched); the `finally` REOPENS the gate on EVERY exit so live output is never
+        // swallowed (#468 fail-safe). Issue #1353 R3 wraps this WHOLE window in the per-pane
+        // single-flight ([renderHealCoordinator]) so a sibling launcher can't cross into it and
+        // open the gate early (the concurrent premature-open clobber — see the coordinator).
         val quiesceLiveDeltas =
             surfaceBlack || pane.terminalState.renderLooksSuspect()
         if (quiesceLiveDeltas) pane.terminalState.closeSeedGate()
@@ -11829,29 +11839,19 @@ public class TmuxSessionViewModel @Inject constructor(
         val captureResponse = combined?.capture
         if (captureResponse == null || captureResponse.isError || captureResponse.output.isEmpty()) {
             // Issue #1294: the `capture-pane` round-trip could NOT confirm the render against
-            // tmux's grid — it timed out, errored, or came back EMPTY on a live transport (or
-            // was starved out by a concurrent burst holding the shared capture mutex). The
-            // surface repaint above already fired if the surface was black, so a
-            // surface-only-black recovers even on this path.
-            //
-            // The scoring turns on whether the LOCAL render currently looks LOST (black /
-            // partial-black / mostly-empty / surface-black — the same cheap local pre-check
-            // [renderLooksSuspect] the suspect-wake gate uses):
-            //  - render LOOKS LOST → this is the #1294 UNVERIFIED case: we NEEDED this capture
-            //    to heal a suspect pane and could not get it. The watchdog MUST keep the hot
-            //    cadence (never throttle) so a black pane whose heal captures are wedged by a
-            //    Claude burst keeps retrying at 4s until the mutex frees — instead of scoring
-            //    the failure as a healthy tick and backing off to 16s (the exact bug).
-            //  - render looks HEALTHY → a momentarily-empty/failed capture over a confidently-
-            //    dense render is a non-urgent no-op; scoring it HEALTHY preserves the #1219 /
-            //    #1164 battery back-off (criterion 3 — do not regress the steady-heat lever).
+            // tmux's grid (timed out / errored / EMPTY on a live transport / starved by a
+            // capture-mutex-holding burst). The surface repaint above already fired if black.
+            // Scoring turns on whether the LOCAL render looks LOST ([renderLooksSuspect]):
+            //  - LOOKS LOST → UNVERIFIED: we needed this capture to heal a suspect pane and
+            //    couldn't; the watchdog keeps the HOT cadence (retry at 4s) instead of scoring
+            //    the failure as healthy and backing off to 16s while the pane is black (the bug).
+            //  - looks HEALTHY → a momentary empty/failed capture over a dense render is a
+            //    no-op; scoring HEALTHY preserves the #1219/#1164 battery back-off.
             val renderLooksLost = surfaceBlack || pane.terminalState.renderLooksSuspect()
-            // Issue #1175: fingerprint the observed frame when it is degenerate so an export
-            // sees WHICH class of black it was — no new round-trip, it rides this same (failed)
-            // capture tick. A surface-only-black whose capture failed is the #1192 class
-            // (captureBytes unknown → 0); an empty capture over a degenerate render is the
-            // server-side `capture_empty`, or `never_seeded` when no seed ever landed. A healthy
-            // pane whose capture momentarily blipped stays silent here.
+            // Issue #1175: fingerprint the observed frame when degenerate so an export sees
+            // WHICH class of black it was (rides this same failed capture — no new round-trip):
+            // surface-only-black → #1192 class; empty capture over a degenerate render →
+            // `capture_empty`, or `never_seeded` if no seed ever landed. Healthy pane: silent.
             if (surfaceBlack) {
                 recordBlackFrameObserved(pane, BLACK_FRAME_CLASS_SURFACE_BLACK_MODEL_INTACT, captureText = null)
             } else if (pane.terminalState.renderedNonBlankCharCount() == 0 ||

--- a/app/src/test/java/com/pocketshell/app/tmux/FakeTmuxClient.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/FakeTmuxClient.kt
@@ -288,6 +288,20 @@ internal class FakeTmuxClient(
     @Volatile
     var captureWithCursorGate: CompletableDeferred<Unit>? = null
 
+    /**
+     * Issue #1353 R3: response reserved for a capture that PARKED on
+     * [captureWithCursorGate] (a slow / in-flight capture). When set, a parked capture
+     * returns THIS (with [gatedCursorReply]) instead of consuming the [capturePaneResponses]
+     * FIFO — so a concurrent single-flight test can hand the SLOW (parked) heal and the FAST
+     * (unparked) heal DISTINCT responses deterministically, independent of coroutine run order
+     * (which flips between the fixed serialized path and the un-serialized base).
+     */
+    @Volatile
+    var gatedCaptureResponse: CommandResponse? = null
+
+    @Volatile
+    var gatedCursorReply: String? = null
+
     override suspend fun captureWithCursor(
         paneId: String,
         scrollbackLines: Int,
@@ -295,7 +309,18 @@ internal class FakeTmuxClient(
     ): com.pocketshell.core.tmux.CaptureWithCursor {
         lastCaptureThreadName = Thread.currentThread().name
         lastCaptureTimeoutMs = timeoutMs
-        captureWithCursorGate?.await()
+        val parkedOnGate = captureWithCursorGate
+        parkedOnGate?.await()
+        if (parkedOnGate != null) {
+            gatedCaptureResponse?.let { reserved ->
+                // Record the capture command so healCaptureCount()-style assertions still see it.
+                sentCommands += "capture-pane -p -e -S -$scrollbackLines -t $paneId"
+                return com.pocketshell.core.tmux.CaptureWithCursor(
+                    capture = reserved,
+                    cursorReply = gatedCursorReply,
+                )
+            }
+        }
         // Reuse the canned-response plumbing in handleCommand so existing
         // capturePaneResponses / cursorQueryResponses fixtures keep working.
         val capture = handleCommand(

--- a/app/src/test/java/com/pocketshell/app/tmux/RenderHealCoordinatorTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/RenderHealCoordinatorTest.kt
@@ -1,0 +1,81 @@
+package com.pocketshell.app.tmux
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1353 slice R3 — the pure ownership contract of the per-pane single-flight owner
+ * ([RenderHealCoordinator]). This is the deterministic sibling of the end-to-end
+ * [RenderHealSingleFlightTest]: it asserts the invariant that makes the guard correct —
+ * SAME pane id → SAME mutex (heals serialize), DIFFERENT pane id → DIFFERENT mutex (heals
+ * run concurrently, never a global lock).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class RenderHealCoordinatorTest {
+
+    @Test
+    fun samePaneReturnsSameMutexDifferentPaneReturnsDifferentMutex() {
+        val coordinator = RenderHealCoordinator()
+
+        assertSame(
+            "the same pane id MUST map to the SAME mutex — otherwise two heals for one pane " +
+                "would take different locks and never serialize (the race would survive)",
+            coordinator.paneHealMutex("%1"),
+            coordinator.paneHealMutex("%1"),
+        )
+        assertNotSame(
+            "different pane ids MUST map to DIFFERENT mutexes — otherwise the guard would be a " +
+                "GLOBAL lock and serialize heals on unrelated panes",
+            coordinator.paneHealMutex("%1"),
+            coordinator.paneHealMutex("%2"),
+        )
+    }
+
+    @Test
+    fun samePaneHealBlocksWhileDifferentPaneHealProceeds() = runTest {
+        val coordinator = RenderHealCoordinator()
+
+        // Hold pane %1's mutex (a heal is "in flight" for %1).
+        coordinator.paneHealMutex("%1").lock()
+
+        // A concurrent heal for the SAME pane must NOT be able to enter (serialized).
+        assertFalse(
+            "REGRESSION (#1353 R3): a second heal for the SAME pane must block while the first " +
+                "holds the pane mutex — this is the single-flight that closes the seed-gate race",
+            coordinator.paneHealMutex("%1").tryLock(),
+        )
+
+        // A concurrent heal for a DIFFERENT pane must proceed immediately (per-pane, not global).
+        var otherPaneRan = false
+        val job = launch {
+            coordinator.paneHealMutex("%2").withLock { otherPaneRan = true }
+        }
+        job.join()
+        assertTrue(
+            "REGRESSION (#1353 R3 per-pane): a heal for a DIFFERENT pane must run while pane " +
+                "%1's heal holds its mutex — the guard is keyed per pane, not a global lock",
+            otherPaneRan,
+        )
+
+        coordinator.paneHealMutex("%1").unlock()
+    }
+
+    @Test
+    fun forgetDropsThePaneMutex() {
+        val coordinator = RenderHealCoordinator()
+        val first = coordinator.paneHealMutex("%1")
+        coordinator.forget("%1")
+        assertNotSame(
+            "after forget(), the pane gets a FRESH mutex (the old one was evicted)",
+            first,
+            coordinator.paneHealMutex("%1"),
+        )
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/RenderHealSingleFlightTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/RenderHealSingleFlightTest.kt
@@ -1,0 +1,467 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.app.sessions.ActiveTmuxClients
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.SshLeaseConnector
+import com.pocketshell.core.ssh.SshLeaseManager
+import com.pocketshell.core.ssh.SshLeaseTarget
+import com.pocketshell.core.ssh.SshPortForward
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshShell
+import com.pocketshell.core.terminal.bridge.SshTerminalBridge
+import com.pocketshell.core.terminal.ui.TerminalSurfaceState
+import com.pocketshell.core.tmux.CommandResponse
+import com.pocketshell.core.tmux.TmuxClientFactory
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+import java.io.InputStream
+
+/**
+ * Issue #1353 slice R3 — REPRODUCE-FIRST (D33 / G1 / G10) proof for the PER-PANE
+ * SINGLE-FLIGHT guard around the render-heal chokepoint
+ * ([TmuxSessionViewModel.healActivePaneIfStaleRender]), on the REAL bridge + real emulator +
+ * the real chokepoint (two concurrent heals through the production VM path, not a proxy).
+ *
+ * ## The race (spike §3 "double-fire / race")
+ *
+ * `healActivePaneIfStaleRender` had NO cross-launcher single-flight: the send-overpaint heal
+ * (L1), the stale-render watchdog (L2), and the reveal/switch heal (L5) all call it on the
+ * SAME active pane with no shared lock. The M9 seed gate is a SINGLE latch on the bridge, so
+ * two heals could interleave: heal H_apply closes the gate and PARKS on its (in-flight, slow)
+ * `capture-pane` while a NEWER live `%output` delta buffers behind the gate; a SIBLING heal
+ * H_open (a fast/empty capture — the #1294 starved-capture class) then reaches its
+ * `openSeedGateWithoutSeed` finally and OPENS the gate, FLUSHING H_apply's buffered delta out
+ * to the emulator; then H_apply's (older) snapshot lands and its `CSI 2J` clear WIPES the
+ * just-flushed delta. That is the exact capture-clobbers-newer-delta class M9 was built to
+ * prevent, re-introduced by concurrency. The heal's own `finally` fail-safe guards a
+ * *stuck-closed* gate, NOT a *premature open* by a sibling.
+ *
+ * ## Red -> green (LOAD-BEARING = the no-clobber / delta-preserved property, G6)
+ *
+ * [concurrentHealsDoNotClobberNewerDeltaViaPrematureGateOpen] drives H_apply (parked, applies
+ * tmux's rich snapshot) and H_open (fast, empty capture, opens the gate) CONCURRENTLY on one
+ * pane through `healActivePaneIfStaleRenderForTest()` (the real chokepoint). On BASE (no
+ * per-pane mutex) H_open crosses into H_apply's window and opens the gate before H_apply's
+ * snapshot lands → the newer delta is clobbered → the delta marker is ABSENT → RED. With the
+ * R3 per-pane single-flight, H_open BLOCKS on H_apply's pane mutex and cannot open the gate;
+ * the delta stays buffered inside H_apply's window and `seedThenOpenGate` re-applies it ON TOP
+ * of the snapshot (newest-wins) → PRESENT → GREEN.
+ *
+ * ## Per-pane, not global (the guard must not serialize DIFFERENT panes)
+ *
+ * [differentPanesAreNotSerialisedAgainstEachOther] proves the single-flight is keyed PER PANE:
+ * two heals on DIFFERENT panes both reach their parked `capture-pane` at the same time (both
+ * seed gates closed simultaneously) — a global lock would have blocked the second before it
+ * could close its gate. (The pure ownership contract — same pane id → same mutex, different id
+ * → different mutex — is asserted directly in [RenderHealCoordinatorTest].)
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class RenderHealSingleFlightTest {
+
+    private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val createdVms = mutableListOf<TmuxSessionViewModel>()
+
+    @After
+    fun tearDown() {
+        factoryScope.cancel()
+    }
+
+    // -----------------------------------------------------------------------
+    // (1) THE RACE — two concurrent heals on ONE pane must not clobber a newer
+    //     delta via a sibling's premature seed-gate open.
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun concurrentHealsDoNotClobberNewerDeltaViaPrematureGateOpen() = runVmTest {
+        val client = FakeTmuxClient().withRichInitialFrame("work", "%1")
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == "%1" }
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+
+        // The pane render looks SUSPECT (fragments-over-black), so BOTH heals quiesce (close
+        // the seed gate) and try to reseed it — the exact state where the launchers pile up.
+        pane.terminalState.appendRemoteOutput(fragmentsOverBlackFrame().toByteArray(Charsets.US_ASCII))
+        advanceUntilIdle()
+        assertTrue(
+            "precondition: the render looks suspect so both heals quiesce + reseed it",
+            pane.terminalState.renderLooksSuspect(),
+        )
+        assertFalse(
+            "precondition: the newer delta marker is not already on the visible screen",
+            visibleScreenTextFor(pane).contains(NEWER_DELTA_MARKER),
+        )
+
+        // H_apply's capture: tmux's authoritative RICH frame (cursor homed low so the flushed
+        // delta lands below the snapshot rows, on-screen). This is the snapshot that, applied
+        // with the gate wrongly opened, would clobber the delta. Reserved for the PARKED (slow)
+        // capture so it is deterministic regardless of coroutine run order.
+        client.gatedCaptureResponse =
+            CommandResponse(number = 90L, output = richFrameLines(), isError = false)
+        client.gatedCursorReply = "0,14"
+        // H_open's capture: EMPTY → scores UNVERIFIED (no snapshot), then its finally OPENS the
+        // seed gate — the premature open. Served from the FIFO to the FAST (unparked) capture.
+        client.capturePaneResponses.addLast(
+            CommandResponse(number = 91L, output = emptyList(), isError = false),
+        )
+
+        // Park H_apply's capture in flight so H_open can race it.
+        val applyGate = CompletableDeferred<Unit>()
+        client.captureWithCursorGate = applyGate
+
+        // H_apply enters first: closes the seed gate, parks on the (slow) capture.
+        val applyJob = launch { vm.healActivePaneIfStaleRenderForTest() }
+        runCurrent()
+        assertFalse(
+            "H_apply must have CLOSED the seed gate around its suspect capture",
+            isSeedGateOpenFor(pane),
+        )
+
+        // A NEWER live %output delta arrives while H_apply's capture is parked — buffered
+        // behind the closed gate (the race window).
+        feedLiveDelta(pane, "$NEWER_DELTA_MARKER\r\n")
+        assertFalse(
+            "the buffered delta must not paint while the gate is closed",
+            visibleScreenTextFor(pane).contains(NEWER_DELTA_MARKER),
+        )
+
+        // H_open enters CONCURRENTLY (its capture does NOT park). On base it opens the gate,
+        // flushing the delta out before H_apply's snapshot lands; with the R3 single-flight it
+        // blocks on H_apply's pane mutex and cannot touch the gate.
+        client.captureWithCursorGate = null
+        val openJob = launch { vm.healActivePaneIfStaleRenderForTest() }
+        runCurrent()
+
+        // Release H_apply's parked capture; it applies the rich snapshot.
+        applyGate.complete(Unit)
+        advanceUntilIdle()
+        applyJob.cancel()
+        openJob.cancel()
+
+        val visible = visibleScreenTextFor(pane)
+        assertTrue(
+            "REGRESSION (#1353 R3 concurrent premature-open clobber): a NEWER in-flight " +
+                "%output delta buffered inside one heal's seed-gate window must SURVIVE a " +
+                "CONCURRENT sibling heal on the same pane. On base the sibling opens the gate " +
+                "before this heal's snapshot lands, so the snapshot's CSI 2J clobbers the " +
+                "delta; the per-pane single-flight serializes the window so the delta stays " +
+                "buffered and is re-applied on top of the snapshot. Marker missing:\n" + visible,
+            visible.contains(NEWER_DELTA_MARKER),
+        )
+        assertTrue(
+            "the authoritative tmux frame must still be on the visible screen after the heal",
+            visible.contains("RECONCILED-VIEWPORT"),
+        )
+    }
+
+    // -----------------------------------------------------------------------
+    // (2) PER-PANE, not global — two DIFFERENT panes heal concurrently.
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun differentPanesAreNotSerialisedAgainstEachOther() = runVmTest {
+        // Two live panes on the same session. Pane A's heal PARKS on a (slow) capture; while it
+        // is parked and holding pane A's single-flight mutex, pane B's heal must run to
+        // completion and reseed pane B. A GLOBAL lock would block pane B behind pane A's held
+        // lock (pane B stays black until pane A's capture returns); per-pane, pane B heals now.
+        val client = FakeTmuxClient().withTwoRichPanes("work", "%1", "%2")
+        val vm = connectVm(client)
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+        val paneA = vm.panes.value.single { it.paneId == "%1" }
+        val paneB = vm.panes.value.single { it.paneId == "%2" }
+
+        // Pane A: suspect-but-not-blank so its active heal quiesces + parks on its capture.
+        paneA.terminalState.appendRemoteOutput(fragmentsOverBlackFrame().toByteArray(Charsets.US_ASCII))
+        // Pane B: fully blank so the force blank-reseed net targets it.
+        paneB.terminalState.appendRemoteOutput(CLEAR_HOME.toByteArray(Charsets.US_ASCII))
+        advanceUntilIdle()
+        assertTrue(paneA.terminalState.renderLooksSuspect())
+        assertTrue(paneB.terminalState.visibleScreenIsBlank())
+
+        // Pane A's PARKED capture returns tmux's rich frame (reserved for the parked capture).
+        client.gatedCaptureResponse =
+            CommandResponse(number = 90L, output = richFrameLines(), isError = false)
+        client.gatedCursorReply = "0,0"
+        // Pane B's (unparked) force reseed captures a rich frame carrying pane B's marker.
+        client.capturePaneResponses.addLast(
+            CommandResponse(number = 91L, output = paneBFrameLines(), isError = false),
+        )
+
+        // Park pane A's active heal in flight (it closes its own gate and awaits the capture).
+        val paneAGate = CompletableDeferred<Unit>()
+        client.captureWithCursorGate = paneAGate
+        val jobA = launch { vm.healActivePaneIfStaleRenderForTest() }
+        runCurrent()
+        assertFalse(
+            "pane A's heal must have closed its seed gate and parked on its capture",
+            isSeedGateOpenFor(paneA),
+        )
+        assertFalse(
+            "precondition: pane B's marker is not on pane B yet",
+            visibleScreenTextFor(paneB).contains(PANE_B_MARKER),
+        )
+
+        // Pane B's blank-reseed runs CONCURRENTLY (its capture does NOT park). With the R3
+        // per-pane single-flight it heals pane B immediately even though pane A's mutex is held.
+        client.captureWithCursorGate = null
+        val jobB = launch { vm.reseedBlankVisiblePanesForTest(vm.currentRuntimeGuardForTest()) }
+        runCurrent()
+
+        assertTrue(
+            "pane A's heal is still parked (its capture has not been released)",
+            jobA.isActive,
+        )
+        assertTrue(
+            "REGRESSION (#1353 R3 per-pane): while pane A's heal holds pane A's single-flight " +
+                "mutex (parked on its capture), a heal on the DIFFERENT pane B must run and " +
+                "reseed pane B — the guard is keyed PER PANE. A GLOBAL lock would block pane B " +
+                "behind pane A and leave it black until pane A's capture returns. Pane B:\n" +
+                visibleScreenTextFor(paneB),
+            visibleScreenTextFor(paneB).contains(PANE_B_MARKER),
+        )
+
+        paneAGate.complete(Unit)
+        advanceUntilIdle()
+        jobA.cancel()
+        jobB.cancel()
+    }
+
+    // ------------------------------------------------------------------ Frames
+
+    private fun richFrameLines(): List<String> = buildList {
+        add("RECONCILED-VIEWPORT")
+        repeat(11) { add("recovered context row $it with real rendered content") }
+    }
+
+    private fun paneBFrameLines(): List<String> = buildList {
+        add(PANE_B_MARKER)
+        repeat(11) { add("pane B recovered context row $it with real content") }
+    }
+
+    private fun fragmentsOverBlackFrame(): String = buildString {
+        append(CLEAR_HOME)
+        append("24m 3 / 8 / 4 / 3 / 31\r\n")
+        append("scattered fragment A\r\n")
+        append("scattered fragment B\r\n")
+        append("scattered fragment C\r\n")
+        append("3\r\n")
+    }
+
+    // ------------------------------------------------------------------ Harness
+
+    private fun feedLiveDelta(pane: TmuxPaneState, text: String) {
+        val bridge = bridgeFor(pane)
+        val bytes = text.toByteArray(Charsets.US_ASCII)
+        bridge.feedBytes(bytes, 0, bytes.size)
+    }
+
+    private fun bridgeFor(pane: TmuxPaneState): SshTerminalBridge {
+        val field = TerminalSurfaceState::class.java.getDeclaredField("bridge").apply {
+            isAccessible = true
+        }
+        return field.get(pane.terminalState) as SshTerminalBridge
+    }
+
+    private fun visibleScreenTextFor(pane: TmuxPaneState): String =
+        bridgeFor(pane).emulator.screen.visibleScreenText
+
+    private fun isSeedGateOpenFor(pane: TmuxPaneState): Boolean {
+        val bridge = bridgeFor(pane)
+        val field = SshTerminalBridge::class.java.getDeclaredField("gated").apply {
+            isAccessible = true
+        }
+        return !(field.getBoolean(bridge))
+    }
+
+    private fun runVmTest(body: suspend TestScope.() -> Unit) = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        LivenessProbeTestOverride.setAutoStartEnabledForTest(false)
+        try {
+            body()
+        } finally {
+            for (vm in createdVms) {
+                runCatching { vm.setProcessForegroundForClearedForTest(false) }
+                runCatching { vm.clearForTest() }
+            }
+            advanceUntilIdle()
+            createdVms.clear()
+            LivenessProbeTestOverride.clear()
+            Dispatchers.resetMain()
+        }
+    }
+
+    private fun TestScope.newVm(
+        registry: ActiveTmuxClients,
+        sshLeaseManager: SshLeaseManager,
+    ): TmuxSessionViewModel = TmuxSessionViewModel(
+        tmuxClientFactory = TmuxClientFactory(factoryScope),
+        activeTmuxClients = registry,
+        runtimeCache = TmuxSessionRuntimeCache(),
+        sshLeaseManager = sshLeaseManager,
+        sessionLifecycleSignals = null,
+    ).also {
+        it.setSeedIoDispatcherForTest(StandardTestDispatcher(testScheduler))
+        it.setConnectedBlankWatchdogAutoArmEnabledForTest(false)
+        it.setStaleRenderWatchdogAutoArmEnabledForTest(false)
+        createdVms.add(it)
+    }
+
+    private fun TestScope.connectVm(client: FakeTmuxClient): TmuxSessionViewModel {
+        val live = AlwaysConnectedSession(id = "live")
+        val connector = SingleSessionConnector(live)
+        val leaseManager =
+            testLeaseManager(connector = connector, scope = this, idleTtlMillis = 60_000L)
+        val registry = ActiveTmuxClients()
+        val vm = newVm(registry = registry, sshLeaseManager = leaseManager)
+        runCurrent()
+        vm.setTmuxClientFactoryForTest { _, _, _ -> client }
+        vm.connect(
+            hostId = 1L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            passphrase = null,
+            sessionName = "work",
+        )
+        advanceUntilIdle()
+        return vm
+    }
+
+    private fun FakeTmuxClient.withRichInitialFrame(
+        sessionName: String,
+        paneId: String,
+    ): FakeTmuxClient = apply {
+        responses.addLast(
+            CommandResponse(
+                number = 1L,
+                output = listOf("$paneId\t@0\t\$0\t$sessionName\t$sessionName\t0"),
+                isError = false,
+            ),
+        )
+        capturePaneResponses.addLast(
+            CommandResponse(
+                number = 2L,
+                output = buildList {
+                    add("initial idle frame")
+                    repeat(10) { add("seed context row $it") }
+                },
+                isError = false,
+            ),
+        )
+        cursorQueryResponses.addLast(
+            CommandResponse(number = 3L, output = listOf("0,0"), isError = false),
+        )
+    }
+
+    private fun FakeTmuxClient.withTwoRichPanes(
+        sessionName: String,
+        paneIdA: String,
+        paneIdB: String,
+    ): FakeTmuxClient = apply {
+        responses.addLast(
+            CommandResponse(
+                number = 1L,
+                output = listOf(
+                    "$paneIdA\t@0\t\$0\t$sessionName\t$sessionName\t0",
+                    "$paneIdB\t@0\t\$0\t$sessionName\t$sessionName\t0",
+                ),
+                isError = false,
+            ),
+        )
+        // Attach seeds for both panes (each pane's cold-open capture + cursor).
+        repeat(2) {
+            capturePaneResponses.addLast(
+                CommandResponse(
+                    number = 2L,
+                    output = buildList {
+                        add("initial idle frame")
+                        repeat(10) { r -> add("seed context row $r") }
+                    },
+                    isError = false,
+                ),
+            )
+            cursorQueryResponses.addLast(
+                CommandResponse(number = 3L, output = listOf("0,0"), isError = false),
+            )
+        }
+    }
+
+    private class SingleSessionConnector(
+        private val session: SshSession,
+    ) : SshLeaseConnector {
+        override suspend fun connect(target: SshLeaseTarget): Result<SshSession> =
+            Result.success(session)
+    }
+
+    private class AlwaysConnectedSession(
+        val id: String,
+    ) : SshSession {
+        @Volatile
+        var closed: Boolean = false
+
+        override val isConnected: Boolean get() = !closed
+
+        override suspend fun exec(command: String): ExecResult =
+            ExecResult(stdout = "", stderr = "", exitCode = 0)
+
+        override fun tail(path: String, onLine: (String) -> Unit): Job =
+            Job().apply { complete() }
+
+        override fun tail(path: String, fromLineExclusive: Long, onLine: (String) -> Unit): Job =
+            Job().apply { complete() }
+
+        override fun openLocalPortForward(
+            remoteHost: String,
+            remotePort: Int,
+            localPort: Int,
+        ): SshPortForward = error("not used")
+
+        override fun startShell(): SshShell = error("not used")
+
+        override suspend fun uploadFile(file: File, remotePath: String): String = error("not used")
+
+        override suspend fun uploadStream(
+            input: InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String = error("not used")
+
+        override fun close() {
+            closed = true
+        }
+    }
+
+    private companion object {
+        // ESC[H ESC[2J — home + clear, the overpaint that wipes the viewport to black.
+        const val CLEAR_HOME: String = "\u001B[H\u001B[2J"
+        const val NEWER_DELTA_MARKER: String = "NEWER-LIVE-DELTA-1353R3"
+        const val PANE_B_MARKER: String = "PANE-B-RESEEDED-1353R3"
+    }
+}


### PR DESCRIPTION
Slice **R3** of the terminal render-heal consolidation EPIC #1353 (follows R1 pre-gate unification + R2 single-reseed-path fold).

Introduces a sibling **`RenderHealCoordinator`** (per-pane `ConcurrentHashMap<String, Mutex>`, D28 extraction — keeps the VM lean); `healActivePaneIfStaleRender` body (renamed `…Locked`) is wrapped in `paneHealMutex(paneId).withLock { }` so the `closeSeedGate → capture → open` seed-gate (M9) window is **serialized per pane**. This closes the spike §3 concurrent premature-open clobber (two launchers L1/L2/L5 interleaving on one pane, flushing a newer `%output` delta before the sibling's snapshot).

- Semantics: serialize (queue, **never drop**) per pane; different panes still heal concurrently (keyed mutex, never global). `withLock` inline → non-local early returns keep the mutex always-unlocked.
- M8/M9/M1 oracle / R1 pre-gate / R2 force semantics **unchanged**. `SshTerminalBridge.kt` untouched (disjoint from the concurrent #1459 P0 `feedLock` fix).

### Review — APPROVED
https://github.com/alexeygrigorev/pocketshell/issues/1353#issuecomment-4945305538
- Reviewer-run RED→GREEN (G1/G6): bypassing the mutex reproduces the delta-clobber (`RenderHealSingleFlightTest` red); with the single-flight, green. Load-bearing assertion is the no-clobber/delta-preserved behavior.
- JVM: core-terminal 484/0/0, app 3651/0/0 (0 skipped, G3); all named heal journeys green.
- On-device (G4): `StaleRenderHealOnLiveTransportJourneyE2eTest` on emulator + Docker `agents` — heal + content recovery per kind, serialization doesn't starve/delay/drop a heal.
- Per-pane not global; mutex always unlocks; no lock inversion vs the bridge `feedLock`; VM ratchet neutral (17622), file-size improved; scope confined.

Refs #1353 (one slice of the ongoing EPIC).