### PR TITLE
core-terminal: fix Codex-freeze feedLock main-thread deadlock (#1459)

### DIFF
--- a/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/bridge/SshTerminalBridge.kt
+++ b/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/bridge/SshTerminalBridge.kt
@@ -10,7 +10,9 @@ import com.termux.terminal.TerminalSessionClient
 import java.io.OutputStream
 import java.lang.reflect.Field
 import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.locks.ReentrantLock
 
 public class TerminalSeedGateOverflowException(
     public val pendingBytes: Int,
@@ -130,7 +132,23 @@ public class SshTerminalBridge(
     @Volatile
     private var inputDrainerThread: Thread? = null
     private val stopped = AtomicBoolean(false)
-    private val feedLock = Any()
+
+    /**
+     * Serializes writes to the process→terminal queue (a single producer + the
+     * seed-tail pump never interleave a partial chunk) and guards the seed-tail
+     * FIFO state.
+     *
+     * Issue #1459: a [ReentrantLock] (not a plain monitor) so a MAIN-looper feed
+     * ([feedChunks] on the handler looper) can acquire it WITHOUT ever parking —
+     * see [lockFeedOnLooperNeverParking]. An off-main live `%output` producer can
+     * hold this lock while BLOCKED in [SessionReflection.writeProcessToTerminalQueue]
+     * on a FULL process→terminal queue, waiting for the main looper to drain it; a
+     * reseed/heal apply that hops back to Main ([seedThenOpenGate]) must NOT park on
+     * the monitor there, or the looper can never run the drain that would release
+     * the producer → permanent deadlock → ANR (the live analog of the [stop]
+     * deadlock this file already documents at [stop]).
+     */
+    private val feedLock = ReentrantLock()
 
     /**
      * Issue #468: seed gate. tmux reattach paints a pane from a
@@ -353,7 +371,16 @@ public class SshTerminalBridge(
         // [dispatchMainLooperDrains] so the inline parse stops after a bounded
         // number of bytes regardless of how fast the device parses a slice.
         var inlineDrainedBytes = 0
-        synchronized(feedLock) {
+        // Issue #1459: on the main looper acquire [feedLock] WITHOUT ever parking on
+        // it — an off-main producer blocked on a full queue holds it and can only be
+        // released by a drain THIS looper must run. Off the looper a plain blocking
+        // acquire is correct (a queued producer can park safely; it is not the looper).
+        if (isHandlerLooper) {
+            lockFeedOnLooperNeverParking()
+        } else {
+            feedLock.lock()
+        }
+        try {
             // Re-entrant on-looper feed while a seed tail is already being pumped:
             // append to the FIFO so ordering (seed tail -> this feed) is preserved,
             // and let the pump drain it. Never write straight to the queue here —
@@ -373,6 +400,20 @@ public class SshTerminalBridge(
                     durationNanos = System.nanoTime() - feedStartedAtNanos,
                 )
                 return
+            }
+
+            if (isHandlerLooper) {
+                // Issue #1459: a just-unblocked producer (or one that beat a
+                // closeSeedGate) may have left live `%output` bytes queued. We hold
+                // [feedLock] now, so no producer can add more; drain the queued live
+                // (FIFO, in arrival order — older live before the seed we are about to
+                // write) so the seed write below cannot block the looper on a full
+                // queue. We are the only drainer while holding [feedLock]; a blocking
+                // write into a full queue here would be a fresh deadlock. Bounded by
+                // the current queue contents (<= one queueful).
+                while (SessionReflection.availableProcessOutputBytes(session) > 0) {
+                    handler.dispatchMessage(Message.obtain(handler, MSG_NEW_INPUT))
+                }
             }
 
             var remaining = count
@@ -450,6 +491,8 @@ public class SshTerminalBridge(
                 // budget is feed-scoped, like the wall-time budget).
                 inlineDrainedBytes += chunkLength
             }
+        } finally {
+            feedLock.unlock()
         }
         traceState?.traceSink?.onFeedCompleted(
             bytes = count,
@@ -457,6 +500,51 @@ public class SshTerminalBridge(
             durationNanos = System.nanoTime() - feedStartedAtNanos,
         )
     }
+
+    /**
+     * Issue #1459: acquire [feedLock] from the MAIN looper WITHOUT ever parking on
+     * it. An off-main live `%output` producer can hold [feedLock] while BLOCKED in
+     * [SessionReflection.writeProcessToTerminalQueue] on a FULL process→terminal
+     * queue, waiting for THIS looper to drain it. If a reseed/heal apply
+     * ([seedThenOpenGate] → [feedBytesToEmulator] → [feedChunks]) parked on the
+     * `feedLock` monitor here, the looper could never run that drain → the queue
+     * never makes room → the producer never releases [feedLock] → permanent deadlock
+     * → ANR ("Codex froze, had to force-restart"). This is the live analog of the
+     * [stop] deadlock, which escapes it by CLOSING the queue; a live reseed cannot
+     * close the queue, but it CAN drain it: dispatching `MSG_NEW_INPUT` reads the
+     * queue (no [feedLock] needed), frees room, so the blocked producer completes its
+     * feed and releases [feedLock]. Runs on the handler looper only.
+     */
+    private fun lockFeedOnLooperNeverParking() {
+        // Fast path: uncontended (the common cold-attach seed writes into an idle
+        // bridge; no producer holds [feedLock]). Acquire immediately.
+        if (feedLock.tryLock()) return
+        val handler = SessionReflection.getMainThreadHandler(session)
+        val deadline = nowMillis() + FEEDLOCK_LOOPER_ACQUIRE_DEADLINE_MS
+        while (nowMillis() < deadline) {
+            // The holder is an off-main producer blocked on a full queue: drain a
+            // slice so it can make progress toward releasing [feedLock]. Draining does
+            // NOT require [feedLock] (the read path is independent), so THIS looper
+            // frees the producer instead of deadlocking behind it.
+            if (SessionReflection.availableProcessOutputBytes(session) > 0) {
+                handler.dispatchMessage(Message.obtain(handler, MSG_NEW_INPUT))
+            }
+            if (tryAcquireFeedLock(FEEDLOCK_LOOPER_ACQUIRE_POLL_MILLIS)) return
+        }
+        // Backstop (unreachable when the holder is queue-blocked — draining always
+        // frees it first). If reached, the holder is NOT queue-blocked (the queue is
+        // drained/empty), so a plain blocking acquire cannot deadlock: it is about to
+        // release.
+        feedLock.lock()
+    }
+
+    private fun tryAcquireFeedLock(timeoutMillis: Long): Boolean =
+        try {
+            feedLock.tryLock(timeoutMillis, TimeUnit.MILLISECONDS)
+        } catch (interrupted: InterruptedException) {
+            Thread.currentThread().interrupt()
+            feedLock.tryLock()
+        }
 
     private fun recordChunkWrite(
         traceState: TraceState,
@@ -513,7 +601,14 @@ public class SshTerminalBridge(
         val turnStartedAtMillis = nowMillis()
         var pumpDone = false
         var openGateAfterPump = false
-        synchronized(feedLock) {
+        // #1459: a plain blocking acquire is safe here — the pump only ever runs
+        // during a seed while the gate is CLOSED, so no off-main producer is inside
+        // [feedChunks] holding [feedLock] blocked on a full queue (live `%output`
+        // buffers behind the gate instead). Any producer that beat the gate-close is
+        // already unblocked by the on-looper [feedChunks] drain-to-unblock before the
+        // seed that scheduled this pump could proceed.
+        feedLock.lock()
+        try {
             while (true) {
                 // Drain a slice of whatever is already queued.
                 if (SessionReflection.availableProcessOutputBytes(session) > 0) {
@@ -581,6 +676,8 @@ public class SshTerminalBridge(
                 openGateAfterPump = seedTailGateOpenPending
                 seedTailGateOpenPending = false
             }
+        } finally {
+            feedLock.unlock()
         }
         // #866 lock-ordering: [flushAndOpenGateLocked] takes `gateLock` then
         // `feedLock`; this pump must therefore NEVER take `gateLock` while holding
@@ -748,13 +845,19 @@ public class SshTerminalBridge(
         // writes and reorder bytes. Decide under [feedLock] so the pump cannot finish
         // (and clear the flag) between this check and the deferral. Defer the open to
         // the pump; otherwise open now.
-        val deferGateOpen = synchronized(feedLock) {
+        // #1459: brief non-blocking bookkeeping; a plain blocking acquire is safe —
+        // this runs while the gate is still closed (gated == true), so no off-main
+        // producer is inside [feedChunks] holding [feedLock] blocked on a full queue.
+        feedLock.lock()
+        val deferGateOpen = try {
             if (seedTailPumpScheduled) {
                 seedTailGateOpenPending = true
                 true
             } else {
                 false
             }
+        } finally {
+            feedLock.unlock()
         }
         if (!deferGateOpen) {
             gated = false
@@ -797,10 +900,13 @@ public class SshTerminalBridge(
         // Issue #866: drop any in-flight seed tail so the torn-down session leaves
         // no pending pump work. The pump turn itself guards on stopped.get() and
         // returns early; clearing the FIFO frees the retained byte arrays.
-        synchronized(feedLock) {
+        feedLock.lock()
+        try {
             seedTailSegments.clear()
             seedTailPumpScheduled = false
             seedTailGateOpenPending = false
+        } finally {
+            feedLock.unlock()
         }
         SessionReflection.closeTerminalToProcessQueue(session)
         inputDrainerThread?.interrupt()
@@ -984,6 +1090,23 @@ public class SshTerminalBridge(
          * real-wall-clock guard.
          */
         internal const val SEED_INLINE_MAX_BYTES: Int = PROCESS_TO_TERMINAL_QUEUE_CAPACITY_BYTES / 4
+
+        /**
+         * Issue #1459: backstop wall-clock ceiling for
+         * [lockFeedOnLooperNeverParking]'s drain-to-unblock loop. The loop resolves a
+         * queue-blocked producer in milliseconds (each drained slice frees room for
+         * the producer to make progress toward releasing [feedLock]); this only bounds
+         * the — unreachable when the holder is queue-blocked — pathological case, and
+         * is set well under the ~5 s input-dispatch ANR budget.
+         */
+        internal const val FEEDLOCK_LOOPER_ACQUIRE_DEADLINE_MS: Long = 2_000L
+
+        /**
+         * Issue #1459: poll interval for the timed [feedLock] `tryLock` between
+         * drain-to-unblock turns. Small so the blocked producer is freed promptly once
+         * a slice has been drained, without hot-spinning.
+         */
+        private const val FEEDLOCK_LOOPER_ACQUIRE_POLL_MILLIS: Long = 1L
 
         private const val TRACE_WAIT_THRESHOLD_NANOS: Long = 1_000_000
     }

--- a/shared/core-terminal/src/test/java/com/pocketshell/core/terminal/bridge/SshTerminalBridgeTest.kt
+++ b/shared/core-terminal/src/test/java/com/pocketshell/core/terminal/bridge/SshTerminalBridgeTest.kt
@@ -163,6 +163,122 @@ class SshTerminalBridgeTest {
         }
     }
 
+    /**
+     * Issue #1459 (the 6th Codex-freeze mechanism — a RENDER-side `feedLock`
+     * main-thread deadlock): the live Codex `%output` producer runs off-Main and,
+     * on a FULL process→terminal queue, BLOCKS in `writeProcessToTerminalQueue`
+     * WHILE HOLDING [SshTerminalBridge.feedLock] (feedChunks takes it at the top and
+     * the blocking write is inside that critical section). A reseed/heal apply
+     * (`healActivePaneIfStaleRender`/reconciler → `appendRemoteOutput` →
+     * [SshTerminalBridge.seedThenOpenGate]) deliberately hops BACK to Main (#926) and
+     * takes the SAME `feedLock` on the Main thread. On the pre-fix code the Main
+     * thread parks on the `feedLock` monitor → the looper can never run the drain
+     * that would free the blocked producer → the queue never drains → the producer
+     * never releases `feedLock` → PERMANENT deadlock → ANR → "Codex froze, had to
+     * force-restart". `stop()` documents this exact deadlock and escapes it by
+     * CLOSING the queue first; the live heal/reseed path had no such escape.
+     *
+     * This reproduces it synthetically WITHOUT an emulator (the #780 hard-assert
+     * model, no `assume`-skip): under the PAUSED Robolectric looper a >64 KB feed on
+     * a worker thread blocks in `ByteQueue.write` holding `feedLock` — the identical
+     * precondition to the on-device freeze. Then, from the MAIN looper thread (the
+     * test thread), we call the reseed apply `seedThenOpenGate(...)`.
+     *
+     * RED→GREEN: on base, `seedThenOpenGate` parks on the `feedLock` monitor held by
+     * the blocked producer and NEVER returns → the `@Test(timeout)` fires (the test
+     * HANGS → RED). With the fix the Main-looper acquisition drains the queue to
+     * unblock the producer, so the reseed COMPLETES within a bounded deadline — the
+     * load-bearing GREEN assertion below (`elapsedMs` bound). No terminal bytes are
+     * lost or reordered: the producer's older live output renders in FIFO order,
+     * then the reseed snapshot on top.
+     */
+    @Test(timeout = 30_000)
+    fun mainThreadReseedDoesNotDeadlockAgainstProducerBlockedHoldingFeedLock() {
+        assertEquals(Looper.getMainLooper(), Looper.myLooper())
+        val bridge = SshTerminalBridge(
+            columns = LINE_LENGTH,
+            rows = 24,
+            transcriptRows = 8_000,
+        )
+        val payload = uniquelyMarkedLargePayload()
+        assertTrue(
+            "producer payload must exceed one full process->terminal queue so the " +
+                "producer BLOCKS in ByteQueue.write holding feedLock",
+            payload.bytes.size > SshTerminalBridge.PROCESS_TO_TERMINAL_QUEUE_CAPACITY_BYTES,
+        )
+
+        val executor = Executors.newSingleThreadExecutor { runnable ->
+            Thread(runnable, "Issue1459BlockedProducer").apply { isDaemon = true }
+        }
+        val feed = executor.submit { bridge.feedBytes(payload.bytes) }
+        try {
+            // Deliberately DO NOT pump the PAUSED main looper: the queue fills and the
+            // producer blocks in ByteQueue.write holding feedLock — the exact #1459
+            // deadlock precondition (a live %output burst mid-flight).
+            Thread.sleep(300)
+            assertFalse(
+                "producer must be BLOCKED on the full process->terminal queue (holding " +
+                    "feedLock) for this to reproduce the #1459 reseed deadlock; it finished early",
+                feed.isDone,
+            )
+
+            // The reseed/heal apply runs on the Main looper (this test thread IS the
+            // main looper) and MUST NOT park forever on feedLock. On the pre-fix code
+            // this call deadlocks → the @Test(timeout) fires (RED).
+            val seed = "\r\nreseed-line-A\r\nreseed-line-B".toByteArray(Charsets.US_ASCII)
+            val startedAtNanos = System.nanoTime()
+            bridge.seedThenOpenGate(seed)
+            val elapsedMs = (System.nanoTime() - startedAtNanos) / 1_000_000L
+
+            // LOAD-BEARING GREEN assertion (#1459): the Main-thread reseed COMPLETED
+            // while the producer was blocked-holding-feedLock, within a bounded
+            // deadline. The deadlock manifests as this line never being reached (the
+            // @Test(timeout) hang); a real completion is fast (drain-to-unblock).
+            assertTrue(
+                "Main-thread reseed must complete within 5s while a producer is blocked " +
+                    "holding feedLock (it took ${elapsedMs}ms); the #1459 deadlock returns as a hang",
+                elapsedMs < 5_000L,
+            )
+
+            // The blocked producer must have been unblocked (the looper drained the
+            // queue so its write completed) — no wedged producer leaks.
+            val producerReleasedDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+            while (!feed.isDone && System.nanoTime() < producerReleasedDeadline) {
+                Thread.sleep(10)
+            }
+            assertTrue(
+                "the blocked producer must unwind once the Main-thread reseed drains the queue",
+                feed.isDone,
+            )
+            feed.get(1, TimeUnit.SECONDS)
+
+            // Byte-integrity: no lost/reordered bytes. All of the producer's live
+            // output renders (its LAST line is present → nothing dropped), then the
+            // reseed snapshot renders AFTER it (older live before the seed → no reorder).
+            drainMainLooperUntil {
+                bridge.emulator.screen.transcriptText.contains("reseed-line-B")
+            }
+            shadowOf(Looper.getMainLooper()).idle()
+            val transcript = bridge.emulator.screen.transcriptText
+            val lastProducerMarker = payload.transcriptText // its last marked line
+            assertTrue(
+                "all producer live output must survive the reseed (last line missing = dropped bytes)",
+                transcript.contains(lastProducerMarker),
+            )
+            assertTrue(
+                "the reseed snapshot must render",
+                transcript.contains("reseed-line-A") && transcript.contains("reseed-line-B"),
+            )
+            assertTrue(
+                "producer live output must render BEFORE the reseed snapshot (FIFO, no reorder)",
+                transcript.indexOf(lastProducerMarker) < transcript.indexOf("reseed-line-A"),
+            )
+        } finally {
+            executor.shutdownNow()
+            bridge.stop()
+        }
+    }
+
     @Test(timeout = 5_000)
     fun feedBytesOnMainLooperDrainsLargePayloadWithoutDeadlockOrLoss() {
         assertEquals(Looper.getMainLooper(), Looper.myLooper())
@@ -978,6 +1094,30 @@ class SshTerminalBridgeTest {
     }
 
     /**
+     * Issue #1459: a live-`%output`-shaped payload larger than one process→terminal
+     * queue (so the producer BLOCKS holding `feedLock`), with a UNIQUE per-line
+     * marker so the reseed regression can assert the producer's LAST line survived
+     * (no dropped bytes) and rendered BEFORE the reseed snapshot (FIFO, no reorder).
+     * Each line stays under the column width so it renders on one row (the marker is
+     * not split across a wrap).
+     */
+    private fun uniquelyMarkedLargePayload(): Payload {
+        val payloadLines = List(RESEED_PRODUCER_LINES) { line ->
+            "producer-%05d ".format(line) +
+                ('a'.code + (line % 26)).toChar().toString().repeat(LINE_LENGTH - 20)
+        }
+        val payloadWireText = payloadLines.joinToString(separator = "\r\n")
+        val payload = payloadWireText.toByteArray(Charsets.US_ASCII)
+        assertTrue(
+            "reseed producer fixture must exceed one process-to-terminal queue",
+            payload.size > SshTerminalBridge.PROCESS_TO_TERMINAL_QUEUE_CAPACITY_BYTES,
+        )
+        // transcriptText carries the LAST line's marker so the test can assert it
+        // survived and ordered before the seed.
+        return Payload(payload, payloadLines.last())
+    }
+
+    /**
      * Issue #829: a seed that fits in ONE process-to-terminal queue write (so it is
      * the final/only chunk and on-main handoff is allowed) but spans MANY drain
      * slices, so a time budget can cut the inline drain short with bytes left over
@@ -1204,6 +1344,11 @@ class SshTerminalBridgeTest {
     private companion object {
         private const val LINE_LENGTH = 100
         private const val LINES_LARGER_THAN_PROCESS_QUEUE = 900
+
+        // Issue #1459: reseed-vs-blocked-producer fixture. ~1200 * 94 B ≈ 110 KB —
+        // comfortably more than one 64 KB process->terminal queue, so the producer
+        // blocks in ByteQueue.write holding feedLock (the deadlock precondition).
+        private const val RESEED_PRODUCER_LINES = 1_200
         private const val RAW_BURST_LINES = 5_000
         private const val TMUX_BURST_LINES = 1_200
 


### PR DESCRIPTION
**P0 — the maintainer's recurring Codex freeze.** Survives v0.4.26 (which has the #1316/#1460/#1475 transport-lane fixes) because it's a different class: a **render-side main-thread deadlock**, not a transport wedge.

### The bug
The live Codex `%output` producer (off-Main) blocks in `writeProcessToTerminalQueue` on a FULL process→terminal queue **while holding `SshTerminalBridge.feedLock`**; a reseed/heal apply hops to Main (`seedThenOpenGate`) and parks on that same `feedLock` monitor → the looper can never run the drain that would free the producer → permanent deadlock → ANR / force-restart. `stop()` (:778–796) already documented this exact shape but only patched the *teardown* case; the live heal path had no escape. Widened by the #1353 R2 heal-chokepoint fold (more reseed paths through the Main `feedLock` acquisition). The **stale-render watchdog self-triggers** it during heavy Codex output — so it freezes with no user interaction (matches the report).

### The fix — Option B, scoped to `SshTerminalBridge.kt` lock discipline (no architecture/transport change)
The main looper **never parks forever** on `feedLock`: a bounded, non-parking acquisition that drains a slice to unblock the queue-blocked producer (the live analog of `stop()`'s close-queue-first escape), plus drain queued-live to empty after acquiring before the seed write (else the seed re-hangs on a still-full queue). Single-writer `feedLock` invariant preserved — Option A (release `feedLock` around the off-Main blocking write) was rejected to avoid byte interleave/reorder.

### Reproduce-first RED→GREEN (D33/G1/G10) — reviewer independently verified
`SshTerminalBridgeTest.mainThreadReseedDoesNotDeadlockAgainstProducerBlockedHoldingFeedLock` — real `SshTerminalBridge` + real Termux `ByteQueue`, producer genuinely parked HOLDING `feedLock` (#780 synthetic model, hard-assert). **Neutralized fix → test hangs 200s, SIGKILL (exit 137) = the actual deadlock; restored → 0.357s pass.** Byte integrity asserted (last producer line survives, FIFO order — no drop/reorder).

### Review — APPROVED
https://github.com/alexeygrigorev/pocketshell/issues/1459#issuecomment-4945511721
- Reviewer drove the red→green on the real bridge this run; `:shared:core-terminal` 485/0/0; all four #803/#796/#866 render-ANR proofs PASS on-device + #1286 `RenderDrainPriorityTest` green; lock discipline traced (no busy-wait/starvation/inversion); scope confined (`TmuxSessionViewModel.kt`/`TerminalSurfaceState.kt` untouched — disjoint from #1353 R3).
- Honest limitation: the exact on-device deadlock *timing race* can't be forced on the emulator, so the #780 synthetic model on the real bridge is the sanctioned reproduction; the maintainer's next dogfood is the final arbiter.

Refs #1459.