### PR TITLE
release: v0.4.27 — Codex-freeze feedLock deadlock fix

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,8 +65,8 @@ android {
         applicationId = "com.pocketshell.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 73
-        versionName = "0.4.26"
+        versionCode = 74
+        versionName = "0.4.27"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/tools/pocketshell/pyproject.toml
+++ b/tools/pocketshell/pyproject.toml
@@ -8,7 +8,7 @@ name = "pocketshell"
 # scripts/check-pypi-version.sh enforces this; .github/workflows/build.yml
 # runs that check before publishing to PyPI. See
 # tools/pocketshell/README.md ("Release flow") for the bump procedure.
-version = "0.4.26"
+version = "0.4.27"
 description = "Unified server-side Python utility for the PocketShell Android client."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Version bump **0.4.26 → 0.4.27** (versionCode 73 → 74; `tools/pocketshell` 0.4.27 in lockstep per the #948 guard).

### Headline — fixes the recurring Codex freeze (#1459)
v0.4.26 shipped the transport-lane fixes but the maintainer **still froze**. Root cause found: a **render-side `feedLock` main-thread deadlock** in `SshTerminalBridge` (the live `%output` producer parks holding `feedLock`; a Main-hop reseed/heal parks on the same lock → permanent deadlock). #1485 fixes it (bounded non-parking main-looper acquisition), reproduce-first RED→GREEN on the real bridge (base deadlocks/SIGKILL; fixed 0.357s), all four render-ANR proofs + 485 core-terminal tests green.

### Also in this cut (delta v0.4.26..main)
- **#1483** #1353 R2 — fold the parallel reseed sink into the single heal chokepoint.
- **#1484** #1353 R3 — per-pane single-flight (`RenderHealCoordinator`) closing the seed-gate interleave race.
- **#1482** #684 — ~344 LOC dead-code removal.
- process/cleanup commits.

### Gate
- Merge after required `Unit tests` + `Python utility tests` green.
- Tag `v0.4.27` from stable `main` after the emulator release-validation gate passes on the bumped commit.

Refs #1459.