### PR TITLE
host-update: lift uv exclude-newer cap for the whole pocketshell resolution (#1492)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/bootstrap/HostBootstrapScenarioSuiteTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/bootstrap/HostBootstrapScenarioSuiteTest.kt
@@ -148,7 +148,7 @@ class HostBootstrapScenarioSuiteTest {
         compose.onNodeWithText("PocketShell CLI update failed", substring = true).assertExists()
         compose.onNodeWithText("fixture refused upgrade", substring = true).assertExists()
         compose.onNodeWithText(
-            "uv tool install --upgrade --exclude-newer-package pocketshell=2099-12-31 pocketshell",
+            "uv tool install --upgrade --exclude-newer 2099-12-31 pocketshell",
             substring = true,
         ).assertExists()
         compose.onNodeWithText("Path: /usr/local/bin/pocketshell", substring = true).assertExists()
@@ -235,7 +235,7 @@ class HostBootstrapScenarioSuiteTest {
         compose.onNodeWithText("Host setup needed").assertExists()
         assertSetupRows("pocketshell")
         compose.onNodeWithText(
-            "uv tool install --exclude-newer-package pocketshell=2099-12-31 pocketshell or pipx install pocketshell",
+            "uv tool install --exclude-newer 2099-12-31 pocketshell or pipx install pocketshell",
         ).assertExists()
         capture("02-unsupported-manual-setup")
         compose.onNodeWithTag(HOST_BOOTSTRAP_INSTALL_ALL_TAG).assertExists().performClick()

--- a/app/src/androidTest/java/com/pocketshell/app/projects/CliVersionMismatchBannerUpdateButtonTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/CliVersionMismatchBannerUpdateButtonTest.kt
@@ -62,11 +62,16 @@ class CliVersionMismatchBannerUpdateButtonTest {
     @get:Rule
     val compose = createAndroidComposeRule<ComponentActivity>()
 
+    // Derived from the PRODUCTION prompt builder so the banner copy (and its
+    // embedded upgrade command) can never drift from the real one — issue #1492
+    // widened that command to the global `--exclude-newer` cap override.
     private val message =
-        "This host's pocketshell is 0.4.14; the app expects 0.4.16. " +
-            "Update it on the host:\nuv tool install --upgrade " +
-            "--exclude-newer-package pocketshell=2099-12-31 pocketshell\n" +
-            "(or: pipx upgrade pocketshell / pip install -U pocketshell)"
+        PayloadVersionCheck.outdatedHostPrompt(
+            PayloadVersionCheck.Verdict.HostOutdated(
+                hostVersion = "0.4.14",
+                expectedVersion = "0.4.16",
+            ),
+        )
 
     @Test
     fun idleState_updateAndDismissPresentReachableNotClipped() {

--- a/app/src/main/java/com/pocketshell/app/bootstrap/HostBootstrapper.kt
+++ b/app/src/main/java/com/pocketshell/app/bootstrap/HostBootstrapper.kt
@@ -65,7 +65,30 @@ public enum class PythonToolInstaller(
     Pipx("pipx"),
 }
 
-internal const val UV_POCKETSHELL_EXCLUDE_NEWER_PACKAGE: String = "pocketshell=2099-12-31"
+/**
+ * Issue #1492 (widens #779): lift uv's `exclude-newer` date cap for the ENTIRE
+ * `uv tool install` resolution, not just the `pocketshell` package.
+ *
+ * The host bakes a global `exclude-newer` cutoff (`~/.config/uv/uv.toml`, plus the
+ * pocketshell tool receipt) for reproducibility. A pocketshell release can pin an
+ * in-house sibling (`quse`, `tmuxctl`, …) to a version published AFTER that
+ * cutoff. The old per-package override `--exclude-newer-package
+ * pocketshell=<far-future>` lifted the cap for `pocketshell` ONLY, so the sibling
+ * stayed filtered out → the whole resolution was unsatisfiable → uv kept the
+ * already-installed old version and exited 0 (a silent no-op; the mismatch banner
+ * never cleared). The maintainer's real repro (hetzner, 2026-07-12): app v0.4.27,
+ * host stuck at 0.4.24 because 0.4.27 pins `quse==0.0.9` (published after the
+ * host's ~07-05 cap). Lifting the cap globally with `--exclude-newer
+ * <far-future>` covers pocketshell + its entire pinned dependency closure — the
+ * pocketshell tool install always wants the latest pocketshell + its EXACT pins,
+ * so a date cap only ever produces false "unsatisfiable" no-ops here. Hard-cut
+ * (D22): this REPLACES the narrow per-package override; there is no fallback and
+ * no hand-enumerated sibling list (the next new pin would re-break that).
+ */
+public const val UV_EXCLUDE_NEWER_DATE: String = "2099-12-31"
+
+/** The global uv flag that lifts the `exclude-newer` cap for the whole resolution. */
+public const val UV_EXCLUDE_NEWER_FLAG: String = "--exclude-newer $UV_EXCLUDE_NEWER_DATE"
 
 internal fun uvToolInstallCommand(tool: BootstrapTool, upgrade: Boolean): String =
     "uv ${uvToolInstallArgs(tool, upgrade)}"
@@ -75,7 +98,7 @@ internal fun uvToolInstallArgs(tool: BootstrapTool, upgrade: Boolean): String =
         append("tool install")
         if (upgrade) append(" --upgrade")
         if (tool == BootstrapTool.Pocketshell) {
-            append(" --exclude-newer-package $UV_POCKETSHELL_EXCLUDE_NEWER_PACKAGE")
+            append(" $UV_EXCLUDE_NEWER_FLAG")
         }
         append(" ${tool.packageName}")
     }

--- a/app/src/main/java/com/pocketshell/app/projects/AgentLaunchVersionCheck.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/AgentLaunchVersionCheck.kt
@@ -1,5 +1,7 @@
 package com.pocketshell.app.projects
 
+import com.pocketshell.app.bootstrap.UV_EXCLUDE_NEWER_FLAG
+
 /**
  * Graceful version-mismatch detection for the agent-launch flow (issue #759).
  *
@@ -41,14 +43,19 @@ object AgentLaunchVersionCheck {
      * the host's global `exclude-newer` (`~/.config/uv/uv.toml`) — when the
      * newest release is younger than that cutoff, uv reports "Nothing to
      * upgrade" and exits 0, so the upgrade is a no-op and the version mismatch
-     * never clears. The targeted `--exclude-newer-package pocketshell=<far
-     * future>` override lifts that cap for this one package only (mirroring the
-     * bootstrap installer's [com.pocketshell.app.bootstrap.UV_POCKETSHELL_EXCLUDE_NEWER_PACKAGE]),
+     * never clears.
+     *
+     * Issue #1492 widens that: the old `--exclude-newer-package
+     * pocketshell=<far future>` override lifted the cap for `pocketshell` ONLY,
+     * so a release that pins a sibling (`quse`) past the host's cutoff still
+     * failed to resolve (a silent no-op). The global
+     * [com.pocketshell.app.bootstrap.UV_EXCLUDE_NEWER_FLAG] lifts the cap for the
+     * WHOLE tool-install resolution — pocketshell + its entire pinned closure —
      * leaving the user's reproducibility setting intact for everything else.
      * `pipx upgrade` / `pip install -U` are not affected by uv's cutoff.
      */
     const val UPDATE_COMMAND: String =
-        "uv tool install --upgrade --exclude-newer-package pocketshell=2099-12-31 pocketshell"
+        "uv tool install --upgrade $UV_EXCLUDE_NEWER_FLAG pocketshell"
 
     /**
      * The server-side wrapper line the agent-launch flow types into a fresh

--- a/app/src/main/java/com/pocketshell/app/projects/HostPocketshellUpgrade.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/HostPocketshellUpgrade.kt
@@ -1,5 +1,6 @@
 package com.pocketshell.app.projects
 
+import com.pocketshell.app.bootstrap.UV_EXCLUDE_NEWER_FLAG
 import com.pocketshell.core.ssh.ExecResult
 import com.pocketshell.core.ssh.SshSession
 import kotlinx.coroutines.CancellationException
@@ -25,9 +26,10 @@ import kotlinx.coroutines.withTimeoutOrNull
  *    their shims).
  * 2. PROBES which installer owns `pocketshell` and runs the matching upgrade:
  *    - `uv tool list` mentions `pocketshell` → `uv tool install --upgrade
- *      --exclude-newer-package pocketshell=2099-12-31 pocketshell` (the #779
- *      override that lifts uv's global `exclude-newer` cap so the upgrade is
- *      never a silent no-op — mirrors [PayloadVersionCheck.UPDATE_COMMAND]).
+ *      --exclude-newer 2099-12-31 pocketshell` (the #779/#1492 override that
+ *      lifts uv's global `exclude-newer` cap for the WHOLE resolution so a
+ *      sibling pin like `quse` past the cap cannot make the upgrade a silent
+ *      no-op — mirrors [PayloadVersionCheck.UPDATE_COMMAND]).
  *    - else `pipx` present → `pipx upgrade pocketshell`.
  *    - else `pip`/`pip3` present → `pip install -U pocketshell`.
  *    - else exit `127` so the caller surfaces "no installer found".
@@ -135,8 +137,9 @@ public class HostPocketshellUpgrade {
          * The single `/bin/sh` command: augment PATH, probe the owning installer
          * (uv → pipx → pip), and run the matching upgrade. Exits 127 when none is
          * found. The uv arm mirrors [PayloadVersionCheck.UPDATE_COMMAND]
-         * (`--exclude-newer-package pocketshell=2099-12-31`, issue #779) so the
-         * upgrade is never silently capped by the host's global uv cutoff.
+         * (the global [UV_EXCLUDE_NEWER_FLAG], issue #779 widened by #1492) so the
+         * upgrade is never silently capped by the host's global uv cutoff — for
+         * pocketshell OR any of its pinned siblings.
          */
         internal val UPGRADE_COMMAND: String = buildString {
             // PATH augmentation: same per-user bin dirs PocketshellCommand prepends
@@ -150,7 +153,7 @@ public class HostPocketshellUpgrade {
             append("if command -v uv >/dev/null 2>&1 && ")
             append("uv tool list 2>/dev/null | grep -qi '^pocketshell\\b'; then ")
             append("exec uv tool install --upgrade ")
-            append("--exclude-newer-package $UV_EXCLUDE_NEWER pocketshell; ")
+            append("$UV_EXCLUDE_NEWER_FLAG pocketshell; ")
             // pipx next.
             append("elif command -v pipx >/dev/null 2>&1; then ")
             append("exec pipx upgrade pocketshell; ")
@@ -162,7 +165,5 @@ public class HostPocketshellUpgrade {
             // No installer at all.
             append("else exit 127; fi")
         }
-
-        private const val UV_EXCLUDE_NEWER: String = "pocketshell=2099-12-31"
     }
 }

--- a/app/src/main/java/com/pocketshell/app/projects/PayloadVersionCheck.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/PayloadVersionCheck.kt
@@ -1,5 +1,7 @@
 package com.pocketshell.app.projects
 
+import com.pocketshell.app.bootstrap.UV_EXCLUDE_NEWER_FLAG
+
 /**
  * Passive payload-version mismatch detection (issue #885).
  *
@@ -32,12 +34,13 @@ object PayloadVersionCheck {
     /**
      * The copy-paste command shown to bring the host's `pocketshell` up to date.
      * Mirrors [com.pocketshell.app.projects.AgentLaunchVersionCheck.UPDATE_COMMAND]
-     * — the targeted `--exclude-newer-package` override lifts the host's global
-     * `uv` `exclude-newer` cap for this one package (issue #779) so the upgrade
-     * is never a silent no-op.
+     * — the global [com.pocketshell.app.bootstrap.UV_EXCLUDE_NEWER_FLAG] lifts the
+     * host's `uv` `exclude-newer` cap for the WHOLE tool-install resolution
+     * (issue #779 for pocketshell, widened by #1492 to cover its pinned siblings
+     * like `quse`) so the upgrade is never a silent no-op.
      */
     const val UPDATE_COMMAND: String =
-        "uv tool install --upgrade --exclude-newer-package pocketshell=2099-12-31 pocketshell"
+        "uv tool install --upgrade $UV_EXCLUDE_NEWER_FLAG pocketshell"
 
     /**
      * The verdict of comparing a payload-carried [hostVersion] against the

--- a/app/src/test/java/com/pocketshell/app/bootstrap/HostBootstrapperTest.kt
+++ b/app/src/test/java/com/pocketshell/app/bootstrap/HostBootstrapperTest.kt
@@ -8,6 +8,7 @@ import com.pocketshell.core.ssh.SshShell
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -833,14 +834,23 @@ class HostBootstrapperTest {
     }
 
     @Test
-    fun uvPocketshellCommands_includeTargetedExcludeNewerOverride() {
+    fun uvPocketshellCommands_includeGlobalExcludeNewerOverride() {
+        // Issue #1492: the cap must be lifted for the WHOLE resolution (global
+        // `--exclude-newer`), NOT just the pocketshell package
+        // (`--exclude-newer-package pocketshell=…`), or a release that pins a
+        // sibling (quse) past the host's cap silently no-ops.
         assertEquals(
-            "uv tool install --exclude-newer-package pocketshell=2099-12-31 pocketshell",
+            "uv tool install --exclude-newer 2099-12-31 pocketshell",
             uvToolInstallCommand(BootstrapTool.Pocketshell, upgrade = false),
         )
         assertEquals(
-            "uv tool install --upgrade --exclude-newer-package pocketshell=2099-12-31 pocketshell",
+            "uv tool install --upgrade --exclude-newer 2099-12-31 pocketshell",
             uvToolInstallCommand(BootstrapTool.Pocketshell, upgrade = true),
+        )
+        // The narrow per-package override that broke on sibling pins must be gone.
+        assertFalse(
+            uvToolInstallCommand(BootstrapTool.Pocketshell, upgrade = true)
+                .contains("--exclude-newer-package"),
         )
         assertTrue(!upgradeCommand(PythonToolInstaller.Pipx, BootstrapTool.Pocketshell).contains("exclude-newer"))
     }
@@ -1485,9 +1495,9 @@ class HostBootstrapperTest {
 
     private companion object {
         const val UV_POCKETSHELL_INSTALL_ARGS: String =
-            "tool install --exclude-newer-package pocketshell=2099-12-31 pocketshell"
+            "tool install --exclude-newer 2099-12-31 pocketshell"
         const val UV_POCKETSHELL_UPGRADE_ARGS: String =
-            "tool install --upgrade --exclude-newer-package pocketshell=2099-12-31 pocketshell"
+            "tool install --upgrade --exclude-newer 2099-12-31 pocketshell"
         const val UV_POCKETSHELL_UPGRADE_COMMAND: String = "uv $UV_POCKETSHELL_UPGRADE_ARGS"
         const val DEFAULT_BOOTSTRAP_PATH: String =
             "/home/u/.local/bin:/home/u/bin:/home/u/.cargo/bin:/usr/local/bin:/usr/bin:/bin"

--- a/app/src/test/java/com/pocketshell/app/projects/AgentLaunchVersionCheckTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/AgentLaunchVersionCheckTest.kt
@@ -92,10 +92,15 @@ class AgentLaunchVersionCheckTest {
         // The hint names the required minimum and gives a copyable command.
         assertTrue(hint.contains(AgentLaunchVersionCheck.MIN_AGENT_POCKETSHELL_VERSION))
         assertTrue(hint.contains(AgentLaunchVersionCheck.UPDATE_COMMAND))
-        // Issue #779: the copyable command must bypass the host's global uv
-        // `exclude-newer` cutoff, or it can silently report "Nothing to
-        // upgrade" and the mismatch never clears.
-        assertTrue(hint.contains("--exclude-newer-package pocketshell="))
+        // Issue #779/#1492: the copyable command must bypass the host's global
+        // uv `exclude-newer` cutoff for the WHOLE resolution (global
+        // `--exclude-newer`), or a release that pins a sibling (quse) past the
+        // cutoff silently no-ops and the mismatch never clears.
+        assertTrue(hint.contains("--exclude-newer 2099-12-31"))
+        assertFalse(
+            "must not use the narrow per-package override that broke on sibling pins",
+            hint.contains("--exclude-newer-package"),
+        )
         assertTrue(hint.contains("uv tool install --upgrade"))
         // The raw Click jargon must NOT leak into the user-facing hint.
         assertFalse(hint.contains("No such command"))

--- a/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelHostUpgradeTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelHostUpgradeTest.kt
@@ -192,15 +192,19 @@ class FolderListViewModelHostUpgradeTest {
     }
 
     @Test
-    fun upgradeCommand_probesUvPipxPip_withUvCapOverride() {
+    fun upgradeCommand_probesUvPipxPip_withGlobalUvCapOverride() {
         // Installer-detection criterion: the single command probes uv → pipx →
-        // pip and uses the #779 uv exclude-newer override so the upgrade is not a
-        // silent no-op.
+        // pip and uses the #779/#1492 uv exclude-newer override so the upgrade is
+        // not a silent no-op.
         val cmd = HostPocketshellUpgrade.UPGRADE_COMMAND
         assertTrue("must probe uv tool ownership", cmd.contains("uv tool list"))
         assertTrue(
-            "uv arm must use the #779 exclude-newer cap override",
-            cmd.contains("--exclude-newer-package pocketshell=2099-12-31"),
+            "uv arm must lift the exclude-newer cap for the WHOLE resolution (#1492)",
+            cmd.contains("--exclude-newer 2099-12-31"),
+        )
+        assertFalse(
+            "uv arm must NOT use the narrow per-package override that broke on sibling pins (#1492)",
+            cmd.contains("--exclude-newer-package"),
         )
         assertTrue("must fall back to pipx", cmd.contains("pipx upgrade pocketshell"))
         assertTrue("must fall back to pip", cmd.contains("pip install -U pocketshell"))

--- a/app/src/test/java/com/pocketshell/app/projects/HostUpdateCommandExcludeNewerTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/HostUpdateCommandExcludeNewerTest.kt
@@ -1,0 +1,189 @@
+package com.pocketshell.app.projects
+
+import com.pocketshell.app.bootstrap.BootstrapTool
+import com.pocketshell.app.bootstrap.uvToolInstallCommand
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+/**
+ * Issue #1492 (widens #779) — REPRODUCE-FIRST, class-covering (D31/D32 G1/G2/G6,
+ * D33/G10) regression for the in-app host-updater silently no-opping whenever a
+ * new `pocketshell` release bumps a pinned in-house sibling (`quse`, `tmuxctl`,
+ * …) past the host's `uv` `exclude-newer` date cap.
+ *
+ * ## The real failure (hetzner, 2026-07-12)
+ *
+ * The host bakes `exclude-newer = "7 days"` (`~/.config/uv/uv.toml`, receipt cap
+ * ≈ 2026-07-05). `pocketshell 0.4.27` pins `quse==0.0.9`, published AFTER that
+ * cap. The old generated command
+ * `uv tool install --upgrade --exclude-newer-package pocketshell=2099-12-31 pocketshell`
+ * lifts the cap for `pocketshell` ONLY, so `quse==0.0.9` stays filtered out →
+ * `uv` reports "No solution found … pocketshell==0.4.27 depends on quse==0.0.9"
+ * and keeps the already-installed 0.4.24, exiting 0 (a silent no-op; the
+ * version-mismatch banner never clears).
+ *
+ * The maintainer's manual fix that worked lifted the cap for the WHOLE
+ * resolution. The fix here does that generally via a global `--exclude-newer`.
+ *
+ * ## What this test proves
+ *
+ * It runs a faithful model of `uv`'s exclude-newer resolver against the EXACT
+ * failing fixture (a sibling pin `quse==0.0.9` uploaded after the host cap) and
+ * asserts that EVERY host-update command PocketShell can emit (all four build
+ * sites — [AgentLaunchVersionCheck], [PayloadVersionCheck], the bootstrap
+ * [uvToolInstallCommand], and [HostPocketshellUpgrade]) resolves the host to the
+ * target version. On the OLD per-package override this resolves to a no-op (the
+ * host stays 0.4.24) → RED; with the global `--exclude-newer` cap lift it
+ * resolves to 0.4.27 → GREEN.
+ *
+ * The resolver model is self-guarded ([modelReproducesTheBugForTheNarrowOverride])
+ * so it is not a vacuous pass: the narrow override is shown to yield the no-op.
+ */
+class HostUpdateCommandExcludeNewerTest {
+
+    // --- The fixture that reproduces the bug (non-happy host state, G10) ------
+
+    /** The host's baked `exclude-newer` cutoff (uv.toml + tool receipt). */
+    private val hostCap = "2026-07-05"
+
+    /** The currently-installed (stale) host version the no-op leaves in place. */
+    private val installedVersion = "0.4.24"
+
+    /** The release we want the host to land on. */
+    private val targetVersion = "0.4.27"
+
+    /**
+     * PyPI upload dates for the packages in the target's resolution. `quse==0.0.9`
+     * is the in-house sibling pinned by `pocketshell 0.4.27`, published AFTER the
+     * host cap — this is the exact state that makes the narrow override no-op.
+     */
+    private val uploadDates = mapOf(
+        "pocketshell:$targetVersion" to "2026-07-11",
+        "quse:0.0.9" to "2026-07-08", // > hostCap 2026-07-05 → filtered unless the cap is lifted for quse
+    )
+
+    /** `pocketshell 0.4.27` pins exactly `quse==0.0.9`. */
+    private val targetDependencies = mapOf("quse" to "0.0.9")
+
+    // --- The four command build sites (class coverage, G2) --------------------
+
+    private fun allEmittedUpdateCommands(): Map<String, String> = mapOf(
+        "AgentLaunchVersionCheck.UPDATE_COMMAND" to AgentLaunchVersionCheck.UPDATE_COMMAND,
+        "PayloadVersionCheck.UPDATE_COMMAND" to PayloadVersionCheck.UPDATE_COMMAND,
+        "HostBootstrapper.uvToolInstallCommand(upgrade)" to
+            uvToolInstallCommand(BootstrapTool.Pocketshell, upgrade = true),
+        "HostBootstrapper.uvToolInstallCommand(install)" to
+            uvToolInstallCommand(BootstrapTool.Pocketshell, upgrade = false),
+        "HostPocketshellUpgrade.UPGRADE_COMMAND (uv arm)" to HostPocketshellUpgrade.UPGRADE_COMMAND,
+    )
+
+    // --- Load-bearing assertion (GREEN only with the whole-resolution fix) ----
+
+    @Test
+    fun everyHostUpdateCommand_updatesTheHost_whenASiblingPinIsPastTheHostCap() {
+        for ((site, command) in allEmittedUpdateCommands()) {
+            val resolved = resolveInstalledVersionAfter(command)
+            assertEquals(
+                "$site must lift the exclude-newer cap for the WHOLE resolution so a " +
+                    "release pinning quse==0.0.9 (past the host cap) still updates the host — " +
+                    "instead it resolved to a silent no-op (host stayed $installedVersion). " +
+                    "Command: $command",
+                targetVersion,
+                resolved,
+            )
+        }
+    }
+
+    @Test
+    fun noHostUpdateCommand_usesTheNarrowPerPackageOverride() {
+        // The narrow `--exclude-newer-package pocketshell=…` override is the bug.
+        // Guard the whole class so a future edit can't reintroduce it at any site.
+        for ((site, command) in allEmittedUpdateCommands()) {
+            assertFalse(
+                "$site must NOT use the narrow per-package override that broke on " +
+                    "sibling pins (#1492) — command: $command",
+                command.contains("--exclude-newer-package"),
+            )
+        }
+    }
+
+    // --- Self-guard: the model actually reproduces the bug (not vacuous, G3) ---
+
+    @Test
+    fun modelReproducesTheBugForTheNarrowOverride() {
+        // The OLD command shape resolves to a no-op (host stuck at the stale
+        // version) — proving the resolver model is faithful and the GREEN
+        // assertion above is load-bearing, not vacuous.
+        val narrow =
+            "uv tool install --upgrade --exclude-newer-package pocketshell=2099-12-31 pocketshell"
+        assertEquals(
+            "the narrow per-package override must reproduce the silent no-op",
+            installedVersion,
+            resolveInstalledVersionAfter(narrow),
+        )
+
+        // And the whole-resolution override resolves to the target — the fix.
+        val global = "uv tool install --upgrade --exclude-newer 2099-12-31 pocketshell"
+        assertEquals(targetVersion, resolveInstalledVersionAfter(global))
+    }
+
+    // --- The uv exclude-newer resolver model ----------------------------------
+
+    /**
+     * Model `uv tool install`'s outcome under the host's `exclude-newer` cap.
+     * Returns the version the host ends up on after running [command]:
+     *  - [targetVersion] when the whole target resolution is satisfiable, or
+     *  - [installedVersion] when any pinned dependency is filtered by the cap
+     *    (unsatisfiable → uv keeps the installed version and exits 0: the no-op).
+     */
+    private fun resolveInstalledVersionAfter(command: String): String {
+        val spec = parseExcludeNewer(command)
+        // Effective cap for a package: per-package CLI override > global CLI
+        // override > the host's baked uv.toml cutoff.
+        fun capFor(pkg: String): String = spec.perPackage[pkg] ?: spec.global ?: hostCap
+
+        // pocketshell itself must be a candidate (uploaded on/before its cap).
+        val pocketshellUpload = uploadDates.getValue("pocketshell:$targetVersion")
+        if (pocketshellUpload > capFor("pocketshell")) return installedVersion
+
+        // Every pinned dependency must be a candidate too, else the resolution is
+        // unsatisfiable and uv keeps the installed version (the reported no-op).
+        for ((dep, ver) in targetDependencies) {
+            val depUpload = uploadDates.getValue("$dep:$ver")
+            if (depUpload > capFor(dep)) return installedVersion
+        }
+        return targetVersion
+    }
+
+    private data class ExcludeNewerSpec(
+        val global: String?,
+        val perPackage: Map<String, String>,
+    )
+
+    /** Extract global `--exclude-newer <date>` and `--exclude-newer-package P=<date>` flags. */
+    private fun parseExcludeNewer(command: String): ExcludeNewerSpec {
+        val tokens = command.split(Regex("\\s+")).filter { it.isNotBlank() }
+        var global: String? = null
+        val perPackage = mutableMapOf<String, String>()
+        var i = 0
+        while (i < tokens.size) {
+            when (tokens[i]) {
+                "--exclude-newer" -> {
+                    global = tokens.getOrNull(i + 1)
+                    i += 2
+                }
+                "--exclude-newer-package" -> {
+                    val spec = tokens.getOrNull(i + 1)
+                    if (spec != null && spec.contains('=')) {
+                        val parts = spec.split('=', limit = 2)
+                        perPackage[parts[0]] = parts[1]
+                    }
+                    i += 2
+                }
+                else -> i++
+            }
+        }
+        return ExcludeNewerSpec(global, perPackage)
+    }
+}


### PR DESCRIPTION
Fixes the in-app host-updater silently no-opping when a pocketshell release bumps a pinned sibling (`quse==0.0.9`) past the host's uv `exclude-newer` cap — the version-mismatch banner never cleared. Replaces the narrow `--exclude-newer-package pocketshell=<far-future>` with a global `--exclude-newer 2099-12-31` across all four command builders via a shared constant.

Reproduced on the maintainer's real host (hetzner, stuck at 0.4.24; now manually updated to 0.4.27). Reviewer APPROVED with independent red→green. Hard-cut per D22.

Closes #1492