### PR TITLE
release: v0.4.28 — Codex-freeze #7 fix + host-updater cap fix

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,8 +65,8 @@ android {
         applicationId = "com.pocketshell.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 74
-        versionName = "0.4.27"
+        versionCode = 75
+        versionName = "0.4.28"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/tools/pocketshell/pyproject.toml
+++ b/tools/pocketshell/pyproject.toml
@@ -8,7 +8,7 @@ name = "pocketshell"
 # scripts/check-pypi-version.sh enforces this; .github/workflows/build.yml
 # runs that check before publishing to PyPI. See
 # tools/pocketshell/README.md ("Release flow") for the bump procedure.
-version = "0.4.27"
+version = "0.4.28"
 description = "Unified server-side Python utility for the PocketShell Android client."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Version bump to 0.4.28 (versionCode 75), tools/pocketshell in lockstep (#948).

Ships:
- **#1491** — Codex-freeze mechanism #7: seed-tail-pump/flush `feedLock` deadlock on force-reseed of a healthy live Codex pane (the residual the v0.4.27 H1 fix left open). Reviewer-APPROVED with red→green + 4 on-device render-ANR proofs green.
- **#1492** — in-app host-updater lifts the uv exclude-newer cap for the whole pocketshell resolution (fixes the never-clearing version-mismatch banner). Reviewer-APPROVED.

Release cut after both merged to main.