### PR TITLE
test(bootstrap-fixture): accept global --exclude-newer flag from #1492 (#1501)

### DIFF
--- a/tests/docker/bootstrap-bin/uv
+++ b/tests/docker/bootstrap-bin/uv
@@ -8,12 +8,22 @@ if [ "${1:-}" = "tool" ] && [ "${2:-}" = "install" ]; then
     action="install --upgrade"
     shift
   fi
-  if [ "${1:-}" = "--exclude-newer-package" ]; then
-    shift 2
-  fi
+  # Consume any leading flags (order-independent) before the positional package:
+  #   --exclude-newer <date>          global pin (production, post-#1492) — 2 tokens
+  #   --exclude-newer-package <p=date>  legacy per-package pin (pre-#1492)  — 2 tokens
+  while true; do
+    case "${1:-}" in
+      --exclude-newer|--exclude-newer-package)
+        shift 2
+        ;;
+      *)
+        break
+        ;;
+    esac
+  done
   package="${1:-}"
   if [ -z "$package" ]; then
-    printf 'uv bootstrap fixture supports: tool install [--upgrade] [--exclude-newer-package <package=date>] <package>\n' >&2
+    printf 'uv bootstrap fixture supports: tool install [--upgrade] [--exclude-newer <date>] [--exclude-newer-package <package=date>] <package>\n' >&2
     exit 64
   fi
   target_dir="${HOME}/.local/bin"
@@ -64,5 +74,5 @@ if [ "${1:-}" = "tool" ] && [ "${2:-}" = "upgrade" ] && [ -n "${3:-}" ]; then
   exit 0
 fi
 
-printf 'uv bootstrap fixture supports: tool install [--upgrade] [--exclude-newer-package <package=date>] <package> and managed tool upgrade <package>\n' >&2
+printf 'uv bootstrap fixture supports: tool install [--upgrade] [--exclude-newer <date>] [--exclude-newer-package <package=date>] <package> and managed tool upgrade <package>\n' >&2
 exit 64


### PR DESCRIPTION
Fixture-only fix unblocking the v0.4.28 release gate. The fake `uv` in `tests/docker/bootstrap-bin/uv` only parsed the legacy `--exclude-newer-package` token; #1492's production command now emits the global `--exclude-newer <date>`, which the fixture mis-parsed → setup-detection bootstrap walkthrough timed out on 'Host ready'. Now consumes both forms. Production code was already correct.

Implementer proved red→green + all 7 setup-detection walkthrough profiles green (incl. uv-install `04-host-ready`). No production code touched.

Closes #1501