### PR TITLE
terminal-heal: fold L1 send-overpaint poll onto requestReconcile(reason=Send) (#1353)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionSupport.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionSupport.kt
@@ -338,6 +338,39 @@ internal const val SEND_OVERPAINT_HEAL_SETTLE_MS: Long = 350L
  */
 internal const val SEND_OVERPAINT_HEAL_MAX_TICKS: Int = 4
 
+/**
+ * Issue #1353 slice R4 — the EVENT-SUBMISSION reason for the render-heal reconciler
+ * ([TmuxSessionViewModel.requestReconcile]). A trigger submits an immediate hot reconcile via a
+ * reason instead of owning its own bespoke poll loop; the reconcile runs through the single
+ * chokepoint [TmuxSessionViewModel.healActivePaneIfStaleRender] (with the R3 per-pane
+ * single-flight). Each reason carries the settle cadence appropriate to it, so cadence is a
+ * property of the event, not of six independent timers.
+ *
+ * This slice migrates ONLY [Send] (the #941/#1153 post-send agent-overpaint heal, formerly the
+ * private `scheduleSendOverpaintHeal` poll). The rest of the spike's reasons
+ * (Reveal|Reattach|Foreground|NetworkRestore|SeedLanded|StaleTick|SurfaceBlack) fold into this
+ * entry in later slices (R5); they are intentionally NOT added yet to keep this slice's blast
+ * radius scoped to the send path.
+ */
+internal enum class ReconcileReason(
+    /** How many bounded settle ticks the reconcile re-checks the active pane over. */
+    val settleTicks: Int,
+    /** Delay before each settle tick, so a late/large redraw is still caught. */
+    val settleDelayMs: Long,
+) {
+    /**
+     * Post-send agent `%output` overpaint (#941 black-screen B1 / #1153 half-black). After a
+     * send's submit Enter the agent TUI can `clear`+redraw and leave the active pane
+     * partial/half-black on a LIVE transport; this reconcile re-checks on a fast bounded cadence
+     * (≈1.4 s over 4 ticks), scoped to the pane the send targeted, and heals only when the
+     * render is materially less than tmux's authoritative grid.
+     */
+    Send(
+        settleTicks = SEND_OVERPAINT_HEAL_MAX_TICKS,
+        settleDelayMs = SEND_OVERPAINT_HEAL_SETTLE_MS,
+    ),
+}
+
 internal const val MaxAgentEvents: Int = 500
 
 /**

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -11097,7 +11097,7 @@ public class TmuxSessionViewModel @Inject constructor(
                     // line) is healed by the switch-reveal gate BEFORE this watchdog
                     // is even armed ([awaitActivePaneSeededOrLoading]), and a
                     // send-overpaint partial-black is healed by the post-send heal
-                    // ([scheduleSendOverpaintHeal]). Extending this post-reveal net to
+                    // ([requestReconcile] with [ReconcileReason.Send]). Extending this post-reveal net to
                     // partial-black would over-heal a legitimately small single-line
                     // pane (a real one-line prompt that landed after reveal reads
                     // partial-black), reseed-thrashing it on every arming — so the
@@ -11491,6 +11491,15 @@ public class TmuxSessionViewModel @Inject constructor(
         )
         return healActivePaneIfStaleRender(client, activePane, guard)
     }
+
+    /** Issue #1353 R4 (test seam): submit a reconcile event via [requestReconcile] on the live client. */
+    internal fun requestReconcileForTest(paneId: String, reason: ReconcileReason) {
+        val client = clientRef ?: return
+        requestReconcile(client, paneId, reason)
+    }
+
+    /** Issue #1353 R4 (test seam): the R3 per-pane single-flight owner the reconcile routes through. */
+    internal fun renderHealCoordinatorForTest(): RenderHealCoordinator = renderHealCoordinator
 
     /**
      * Issue #966/#967 (test seam): is the underlying tmux control client currently
@@ -14063,42 +14072,31 @@ public class TmuxSessionViewModel @Inject constructor(
             // heals already restore a partial-black pane; a SEND-triggered overpaint had
             // NO heal, so the pane stayed black until the user manually redrew. Schedule
             // a one-shot, guarded active-pane heal that fires ONLY if the pane settles
-            // partial-black/blank after the overpaint.
-            scheduleSendOverpaintHeal(client, paneId)
+            // partial-black/blank after the overpaint. Issue #1353 R4: this is now an EVENT
+            // submission through the shared reconcile entry ([requestReconcile]) rather than a
+            // private send-only poll — the send path no longer owns a bespoke timer.
+            requestReconcile(client, paneId, ReconcileReason.Send)
         }
     }
 
     /**
-     * Issue #941 (black-screen B1) + issue #1153 (send-with-attachment half-black): after a
-     * send's submit Enter, the agent's `%output` overpaint can leave the active pane BLACK or
-     * partial-black. A composer Send WITH AN ATTACHMENT is always multi-line (it appends an
-     * "Attached files:" block), so it takes the bracketed-paste + submit branch and the
-     * alt-screen agent clear+cursor-address-redraws its WHOLE viewport — the overpaint blanks
-     * the grid and the agent only PARTIALLY repaints, leaving the maintainer's "partly redrew
-     * but still too black" pane on a LIVE transport (no reconnect).
+     * Issue #1353 slice R4 — the EVENT-SUBMISSION entry for the render-heal reconciler. A trigger
+     * submits an immediate hot reconcile for [paneId] via a [ReconcileReason] instead of owning a
+     * bespoke poll loop; the reconcile runs through the SINGLE chokepoint
+     * [healActivePaneIfStaleRender] (R3 per-pane single-flight), so two triggers on one pane can
+     * never race the M9 seed gate. This slice migrates ONLY [ReconcileReason.Send] — the #941/#1153
+     * post-send agent-overpaint heal that was the private `scheduleSendOverpaintHeal` 350 ms×4 poll;
+     * L2/L3/L5 fold into this entry in a later slice (R5).
      *
-     * The pre-#1153 heal had TWO gaps this closes:
-     *  1. It gated on the LOCAL-ONLY `visibleScreenIsBlank() || visibleScreenIsPartiallyBlank()`
-     *     heuristic (≤3 live lines / ≤25% rows). A "partly redrew" frame has MORE than 3 live
-     *     lines (input box + a few conversation lines + status) yet materially less than tmux's
-     *     full grid, so it failed the gate and the heal skipped. Now the heal judges the pane
-     *     against tmux's AUTHORITATIVE `capture-pane` via [healActivePaneIfStaleRender] — the
-     *     #1138 union oracle [TerminalSurfaceState.visibleRenderLostFrameVsCapture], widened for
-     *     #1153 to catch the >3-line half-black band — so it fires whenever the on-screen frame
-     *     is materially less than the authoritative grid, not only when ≤3 lines survive.
-     *  2. Its fixed 350 ms one-shot lost the race against the bigger attachment redraw (the pane
-     *     could still be mid-clear at 350 ms, or the redraw could land AFTER it). Now it re-checks
-     *     on a bounded cadence ([SEND_OVERPAINT_HEAL_MAX_TICKS] settle ticks), so a late/large
-     *     redraw is still caught and a re-overpaint after an early heal is re-healed.
-     *
-     * A DENSE, normally-painted response is a no-op: each tick pays only the cheap LOCAL
-     * [TerminalSurfaceState.renderLooksSuspect] pre-check and pays for the
-     * authoritative `capture-pane` diff ONLY when the render looks sparse enough to possibly be
-     * a lost frame. The heal is guarded by a [RuntimeRefreshGuard] keyed to the current
-     * generation + target + client so a late heal can never paint a switched-away session, and
-     * is scoped to the pane the send targeted while it is still the active pane.
+     * Send behaviour preserved: after a send's submit Enter the agent's `%output` overpaint can
+     * leave the active pane BLACK/partial/half-black on a LIVE transport. The reconcile re-checks
+     * on a bounded cadence ([ReconcileReason.settleTicks] × [ReconcileReason.settleDelayMs]) so a
+     * late/large redraw is still caught, judges the pane against tmux's AUTHORITATIVE `capture-pane`
+     * (the #1138/#1300 union oracle), and is a no-op on a dense frame (each tick pays only the cheap
+     * LOCAL [TerminalSurfaceState.renderLooksSuspect] pre-check). Guarded by a [RuntimeRefreshGuard]
+     * so a late heal can never paint a switched-away session, and scoped to [paneId] while active.
      */
-    private fun scheduleSendOverpaintHeal(client: TmuxClient, paneId: String) {
+    private fun requestReconcile(client: TmuxClient, paneId: String, reason: ReconcileReason) {
         val target = activeTarget ?: return
         val healGeneration = connectGeneration
         val guard = RuntimeRefreshGuard(
@@ -14107,17 +14105,15 @@ public class TmuxSessionViewModel @Inject constructor(
             client = client,
         )
         bridgeScope.launch {
-            repeat(SEND_OVERPAINT_HEAL_MAX_TICKS) { tick ->
-                // Let the post-submit agent overpaint land (and re-check on later ticks for a
-                // late/large attachment redraw) before judging the pane.
-                delay(SEND_OVERPAINT_HEAL_SETTLE_MS)
+            repeat(reason.settleTicks) { tick ->
+                // Let the overpaint land (and re-check on later ticks for a late/large redraw)
+                // before judging the pane.
+                delay(reason.settleDelayMs)
                 if (clientRef !== client) return@launch
                 if (client.disconnected.value) return@launch
                 if (inlineConnectionStatus !is ConnectionStatus.Connected) return@launch
                 if (!isCurrentRuntime(guard)) return@launch
                 val activePane = activeVisiblePane() ?: return@launch
-                // Heal only the pane the send targeted while it is still the active pane
-                // (the reported "sent a message → everything black" is the focused pane).
                 if (activePane.paneId != paneId) return@launch
                 // Cheap LOCAL pre-check: skip the capture round-trip on a dense, normally-painted
                 // response (its live rows sit above the sparse ceiling). Only a fully-blank /
@@ -14125,19 +14121,21 @@ public class TmuxSessionViewModel @Inject constructor(
                 if (!activePane.terminalState.renderLooksSuspect()) return@repeat
                 Log.i(
                     ISSUE_145_RECONNECT_TAG,
-                    "tmux-send-overpaint-active-pane-heal-check pane=${activePane.paneId} " +
-                        "window=${activePane.windowId} session=${target.sessionName} tick=$tick",
+                    "tmux-reconcile-event-active-pane-heal-check reason=$reason " +
+                        "pane=${activePane.paneId} window=${activePane.windowId} " +
+                        "session=${target.sessionName} tick=$tick",
                 )
-                // Authoritative heal: capture tmux's grid, diff it against the render, and
-                // re-seed ONLY when the render is materially less than the authoritative frame.
+                // Authoritative heal through the SINGLE chokepoint (R3 per-pane single-flight):
+                // capture tmux's grid, diff it against the render, and re-seed ONLY when the
+                // render is materially less than the authoritative frame.
                 val healed = runCatching {
                     healActivePaneIfStaleRender(client, activePane, guard)
                 }.getOrDefault(HealOutcome.Unverified) == HealOutcome.Healed
                 if (healed) {
                     Log.i(
                         ISSUE_145_RECONNECT_TAG,
-                        "tmux-send-overpaint-active-pane-heal-applied pane=${activePane.paneId} " +
-                            "session=${target.sessionName} tick=$tick",
+                        "tmux-reconcile-event-active-pane-heal-applied reason=$reason " +
+                            "pane=${activePane.paneId} session=${target.sessionName} tick=$tick",
                     )
                 }
             }
@@ -15317,9 +15315,10 @@ public class TmuxSessionViewModel @Inject constructor(
         // (vim/htop/less/…) can trigger the same clear+redraw overpaint that leaves the pane
         // half-black on a live transport. Schedule the same bounded, capture-diff-gated heal
         // ONLY for a multi-line payload — a single keystroke never overpaints the whole
-        // viewport, so per-keystroke input pays nothing.
+        // viewport, so per-keystroke input pays nothing. Issue #1353 R4: via the shared
+        // reconcile-event entry, same as the agent send path.
         if (BracketedPaste.containsLineBreak(bytes)) {
-            scheduleSendOverpaintHeal(client, paneId)
+            requestReconcile(client, paneId, ReconcileReason.Send)
         }
     }
 

--- a/app/src/test/java/com/pocketshell/app/tmux/RenderHealEventReconcileTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/RenderHealEventReconcileTest.kt
@@ -1,0 +1,366 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.app.sessions.ActiveTmuxClients
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.SshLeaseConnector
+import com.pocketshell.core.ssh.SshLeaseManager
+import com.pocketshell.core.ssh.SshLeaseTarget
+import com.pocketshell.core.ssh.SshPortForward
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshShell
+import com.pocketshell.core.tmux.CommandResponse
+import com.pocketshell.core.tmux.TmuxClientFactory
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+import java.io.InputStream
+
+/**
+ * Issue #1353 slice R4 — REPRODUCE-FIRST (D33 / G1 / G10) proof for the EVENT-SUBMISSION entry
+ * [TmuxSessionViewModel.requestReconcile]. R4's first step folds L1 (the #941/#1153 post-send
+ * agent-overpaint heal, formerly the private `scheduleSendOverpaintHeal` 350 ms×4 poll) into
+ * this shared reconcile-event entry, and DELETES the bespoke L1 poll. This test proves the two
+ * load-bearing properties of that fold:
+ *
+ *  1. **Post-send heal STILL fires via the event path** — a send-triggered
+ *     `requestReconcile(reason = Send)` on a SUSPECT active pane still runs the authoritative
+ *     `capture-pane` heal through the single chokepoint and RESEEDS the pane. If the L1 poll
+ *     were deleted WITHOUT wiring the event, no heal fires and the pane stays black → RED. With
+ *     the event wired, the heal fires and restores tmux's grid → GREEN. (The full REAL send path
+ *     — `sendAgentPayloadToPaneResult` / `writeInputToPaneResult` — is covered end-to-end by
+ *     [PartialBlackPaneHealTest]; those tests stay green precisely because this fold preserved
+ *     the post-send heal.)
+ *
+ *  2. **The event path goes through the R3 per-pane single-flight** — the reconcile heal routes
+ *     through [TmuxSessionViewModel.healActivePaneIfStaleRender], which R3 wrapped in
+ *     `renderHealCoordinator.paneHealMutex(paneId).withLock`. So while a sibling holds the pane's
+ *     single-flight mutex, a `requestReconcile(Send)` for the SAME pane must WAIT on that mutex
+ *     (no concurrent heal → no new M9 seed-gate race), and only heals once the mutex is released.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class RenderHealEventReconcileTest {
+
+    private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val createdVms = mutableListOf<TmuxSessionViewModel>()
+
+    @After
+    fun tearDown() {
+        factoryScope.cancel()
+    }
+
+    // -------------------------------------------------------------------------
+    // (1) The send reconcile EVENT heals a suspect active pane (behavior preserved
+    //     through the event path, not the deleted private send-only poll).
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun reconcileSendEventHealsSuspectActivePane() = runVmTest {
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%1", title = "codex")
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == "%1" }
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+
+        // The post-send agent overpaint left the active pane partial-black (the #941 symptom).
+        overpaintPartialBlack(pane)
+        assertTrue(
+            "precondition: the overpaint left the pane partial-black (renderLooksSuspect)",
+            pane.terminalState.renderLooksSuspect(),
+        )
+
+        // Queue the ONE recovery frame tmux's grid returns on the reconcile HEAL capture.
+        client.capturePaneResponses.addLast(
+            CommandResponse(number = 99L, output = recoveredFrameLines(), isError = false),
+        )
+        val healCapturesBefore = client.healCaptureCount()
+
+        // THE EVENT PATH: the entry the send path now calls (formerly the private
+        // `scheduleSendOverpaintHeal`).
+        vm.requestReconcileForTest("%1", ReconcileReason.Send)
+        advanceUntilIdle()
+
+        assertTrue(
+            "REGRESSION (#1353 R4): a send reconcile event on a suspect active pane must run " +
+                "the authoritative capture-pane heal through the chokepoint. If L1's private " +
+                "poll were deleted without wiring requestReconcile, no heal fires and the pane " +
+                "stays black.",
+            client.healCaptureCount() > healCapturesBefore,
+        )
+        assertFalse(
+            "the reconcile heal restored the pane (no longer suspect)",
+            pane.terminalState.renderLooksSuspect(),
+        )
+        assertTrue(
+            "the restored pane shows tmux's authoritative content",
+            renderedTranscriptFor(pane).contains(RECOVERED_FRAME),
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // (2) OVER-HEAL GUARD: a reconcile event on a DENSE, normally-painted pane must
+    //     NOT issue any heal capture (the cheap local pre-check no-ops it).
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun reconcileSendEventDoesNotHealANormallyPaintedPane() = runVmTest {
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%2", title = "codex")
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == "%2" }
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+
+        // A dense, normally-painted response — not suspect.
+        val fullFrame = buildString {
+            append(CLEAR_ONLY)
+            repeat(32) { append("agent response line $it with real content\r\n") }
+        }
+        pane.terminalState.appendRemoteOutput(fullFrame.toByteArray(Charsets.US_ASCII))
+        advanceUntilIdle()
+        assertFalse(pane.terminalState.renderLooksSuspect())
+
+        client.capturePaneResponses.addLast(
+            CommandResponse(number = 99L, output = recoveredFrameLines(), isError = false),
+        )
+        val healCapturesBefore = client.healCaptureCount()
+
+        vm.requestReconcileForTest("%2", ReconcileReason.Send)
+        advanceUntilIdle()
+
+        assertEquals(
+            "OVER-HEAL GUARD: a reconcile event onto an already-painted pane must NOT issue any " +
+                "heal capture-pane (the cheap local renderLooksSuspect pre-check no-ops it).",
+            healCapturesBefore,
+            client.healCaptureCount(),
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // (3) The reconcile event serializes behind the R3 per-pane single-flight: while
+    //     a sibling holds the pane's heal mutex, the event's heal WAITS (no concurrent
+    //     heal / no new M9 gate race) and only heals once the mutex is released.
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun reconcileSendEventSerializesBehindPerPaneSingleFlight() = runVmTest {
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%3", title = "codex")
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == "%3" }
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+
+        overpaintPartialBlack(pane)
+        assertTrue(pane.terminalState.renderLooksSuspect())
+
+        client.capturePaneResponses.addLast(
+            CommandResponse(number = 99L, output = recoveredFrameLines(), isError = false),
+        )
+        val healCapturesBefore = client.healCaptureCount()
+
+        // A SIBLING launcher holds pane %3's single-flight mutex (the SAME instance the reconcile
+        // heal will try to acquire inside healActivePaneIfStaleRender's withLock).
+        val paneMutex = vm.renderHealCoordinatorForTest().paneHealMutex("%3")
+        assertTrue("test precondition: acquire the pane's single-flight mutex", paneMutex.tryLock())
+
+        // Fire the reconcile event and let it reach its heal attempt: it must BLOCK on the held
+        // mutex before issuing any capture.
+        vm.requestReconcileForTest("%3", ReconcileReason.Send)
+        advanceUntilIdle()
+
+        assertEquals(
+            "REGRESSION (#1353 R4 / R3 single-flight): while a sibling holds pane %3's " +
+                "single-flight mutex, the reconcile event's heal must WAIT — it must NOT run a " +
+                "concurrent capture that could race the M9 seed gate. No heal capture yet.",
+            healCapturesBefore,
+            client.healCaptureCount(),
+        )
+
+        // Release the mutex: the queued reconcile heal now proceeds through the chokepoint.
+        paneMutex.unlock()
+        advanceUntilIdle()
+
+        assertTrue(
+            "once the single-flight mutex is released the reconcile heal runs and reseeds the pane",
+            client.healCaptureCount() > healCapturesBefore,
+        )
+        assertFalse(
+            "the reconcile heal restored the pane after it acquired the mutex",
+            pane.terminalState.renderLooksSuspect(),
+        )
+    }
+
+    // ------------------------------------------------------------------ Harness
+
+    private fun overpaintPartialBlack(pane: TmuxPaneState) {
+        pane.terminalState.appendRemoteOutput(
+            (CLEAR_ONLY + "ISSUE941-LIVE-LINE 7\r\n").toByteArray(Charsets.US_ASCII),
+        )
+    }
+
+    /** Count ONLY the HEAL captures (`capture-pane -p -e ...`), distinct from ack-gate polls. */
+    private fun FakeTmuxClient.healCaptureCount(): Int =
+        sentCommands.count { it.startsWith("capture-pane") && it.contains(" -e") }
+
+    private fun recoveredFrameLines(): List<String> = buildList {
+        add(RECOVERED_FRAME)
+        repeat(27) { add("recovered context row $it") }
+    }
+
+    private fun renderedTranscriptFor(pane: TmuxPaneState): String {
+        val state = pane.terminalState
+        val bridgeField = com.pocketshell.core.terminal.ui.TerminalSurfaceState::class.java
+            .getDeclaredField("bridge").apply { isAccessible = true }
+        val bridge = bridgeField.get(state)
+            as? com.pocketshell.core.terminal.bridge.SshTerminalBridge ?: return ""
+        return bridge.emulator.screen.transcriptText
+    }
+
+    private fun runVmTest(body: suspend TestScope.() -> Unit) = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        LivenessProbeTestOverride.setAutoStartEnabledForTest(false)
+        try {
+            body()
+        } finally {
+            for (vm in createdVms) {
+                runCatching { vm.setProcessForegroundForClearedForTest(false) }
+                runCatching { vm.clearForTest() }
+            }
+            advanceUntilIdle()
+            createdVms.clear()
+            LivenessProbeTestOverride.clear()
+            Dispatchers.resetMain()
+        }
+    }
+
+    private fun TestScope.newVm(
+        registry: ActiveTmuxClients,
+        sshLeaseManager: SshLeaseManager,
+    ): TmuxSessionViewModel = TmuxSessionViewModel(
+        tmuxClientFactory = TmuxClientFactory(factoryScope),
+        activeTmuxClients = registry,
+        runtimeCache = TmuxSessionRuntimeCache(),
+        sshLeaseManager = sshLeaseManager,
+        sessionLifecycleSignals = null,
+    ).also {
+        it.setSeedIoDispatcherForTest(StandardTestDispatcher(testScheduler))
+        it.setConnectedBlankWatchdogAutoArmEnabledForTest(false)
+        it.setStaleRenderWatchdogAutoArmEnabledForTest(false)
+        createdVms.add(it)
+    }
+
+    private fun TestScope.connectVm(client: FakeTmuxClient): TmuxSessionViewModel {
+        val live = AlwaysConnectedSession(id = "live")
+        val connector = SingleSessionConnector(live)
+        val leaseManager =
+            testLeaseManager(connector = connector, scope = this, idleTtlMillis = 60_000L)
+        val registry = ActiveTmuxClients()
+        val vm = newVm(registry = registry, sshLeaseManager = leaseManager)
+        runCurrent()
+        vm.setTmuxClientFactoryForTest { _, _, _ -> client }
+        vm.connect(
+            hostId = 1L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            passphrase = null,
+            sessionName = "work",
+        )
+        advanceUntilIdle()
+        return vm
+    }
+
+    private fun FakeTmuxClient.withSinglePaneRow(
+        sessionName: String,
+        paneId: String,
+        title: String = sessionName,
+    ): FakeTmuxClient = apply {
+        responses.addLast(
+            CommandResponse(
+                number = 1L,
+                output = listOf("$paneId\t@0\t\$0\t$sessionName\t$title\t0"),
+                isError = false,
+            ),
+        )
+        capturePaneResponses.addLast(
+            CommandResponse(number = 2L, output = listOf("$sessionName ready"), isError = false),
+        )
+        cursorQueryResponses.addLast(
+            CommandResponse(number = 3L, output = listOf("0,0"), isError = false),
+        )
+    }
+
+    private class SingleSessionConnector(
+        private val session: SshSession,
+    ) : SshLeaseConnector {
+        override suspend fun connect(target: SshLeaseTarget): Result<SshSession> =
+            Result.success(session)
+    }
+
+    private class AlwaysConnectedSession(
+        val id: String,
+    ) : SshSession {
+        @Volatile
+        var closed: Boolean = false
+
+        override val isConnected: Boolean get() = !closed
+
+        override suspend fun exec(command: String): ExecResult =
+            ExecResult(stdout = "", stderr = "", exitCode = 0)
+
+        override fun tail(path: String, onLine: (String) -> Unit): Job =
+            Job().apply { complete() }
+
+        override fun tail(path: String, fromLineExclusive: Long, onLine: (String) -> Unit): Job =
+            Job().apply { complete() }
+
+        override fun openLocalPortForward(
+            remoteHost: String,
+            remotePort: Int,
+            localPort: Int,
+        ): SshPortForward = error("not used")
+
+        override fun startShell(): SshShell = error("not used")
+
+        override suspend fun uploadFile(file: File, remotePath: String): String = error("not used")
+
+        override suspend fun uploadStream(
+            input: InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String = error("not used")
+
+        override fun close() {
+            closed = true
+        }
+    }
+
+    private companion object {
+        const val RECOVERED_FRAME: String = "ISSUE1353R4-RECOVERED-VIEWPORT"
+
+        // ESC[2J ESC[H — clear screen + cursor home (the overpaint preamble).
+        val CLEAR_ONLY: String = "[2J[H"
+    }
+}

--- a/scripts/connection-vm-ratchet-baseline.txt
+++ b/scripts/connection-vm-ratchet-baseline.txt
@@ -6,4 +6,4 @@
 io_count 17
 runblocking_count 13
 connection_decision_variants 0
-vm_line_count 17622
+vm_line_count 17621

--- a/scripts/file-size-hygiene-baseline.txt
+++ b/scripts/file-size-hygiene-baseline.txt
@@ -8,7 +8,7 @@
 177524 app/src/main/java/com/pocketshell/app/composer/PromptComposerViewModel.kt
 147448 app/src/main/java/com/pocketshell/app/projects/FolderListViewModel.kt
 149516 app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
-907594 app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+906727 app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
 148633 app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
 1146350 docs/mockups/feedback/folder-tree-target-20260604.png
 182790 docs/screenshots/readme-settings.png


### PR DESCRIPTION
R4 incremental slice of the render-heal consolidation epic #1353.

Migrates the L1 post-send overpaint launcher (#941/#1153) onto the shared `requestReconcile(paneId, reason=Send)` event-submission entry. Behavior-preserving fold of a single launcher; VM ratchet **shrinks** (17622→17621) and file-size hygiene holds.

**Reviewer:** APPROVED (behavior-preserving; post-send age-poll semantics preserved).
**Local pre-merge gate (this integration worktree, off freshly-tagged main b4014154):**
- `git diff --check`: clean
- `scripts/check-connection-vm-ratchet.sh`: OK (G-A/G-B/G-C within/below baseline)
- `scripts/check-file-size-hygiene.sh`: OK
- `:app:testDebugUnitTest --tests '*RenderHealEventReconcile*' --tests '*TmuxSessionViewModelTest'`: BUILD SUCCESSFUL

Refs #1353 (one R4 slice of the epic — does not close it).