### PR TITLE
ci: aggregate emulator-journey shards into one CLEAN/RE-RUN/RED verdict (#1458)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -167,6 +167,17 @@ jobs:
           chmod +x scripts/test-ci-journey-budget.sh
           scripts/test-ci-journey-budget.sh
 
+      # Issue #1458: fast, JVM-free fixture test for the emulator-journey
+      # aggregate verdict (scripts/ci-journey-aggregate-verdict.sh) + the
+      # per-shard token-writing / aggregation wiring in tests.yml. Proves the
+      # load-bearing property WITHOUT an emulator: all-green -> CLEAN,
+      # all-infra-storm -> RE-RUN (neutral, no false red email), and a genuine
+      # journey failure -> RED (never masked). Cheap (< 5 s), no emulator.
+      - name: CI journey aggregate-verdict guard (issue #1458)
+        run: |
+          chmod +x scripts/test-ci-journey-aggregate-verdict.sh
+          scripts/test-ci-journey-aggregate-verdict.sh
+
       # Issue #760: the unit job occasionally failed with ALL visible tests
       # PASSED — a gradle-daemon/runner OOM abort, not a real assertion failure.
       # ubuntu-latest gives 7 GB RAM and 2 cores; unbounded gradle worker fan-out
@@ -770,7 +781,12 @@ jobs:
           profile: pixel_7
           force-avd-creation: true
           disable-animations: true
-          emulator-options: -no-snapshot-save -no-snapshot-load -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none
+          # Issue #1458: `-memory 6144` raises the guest RAM from the pixel_7 AVD
+          # hwconfig default (2048 MB) to 6 GB so the swiftshader render pipeline
+          # + Gradle connected-test + 3 Docker fixtures stop starving the guest
+          # (the `Failed to start Emulator console` storm signature). ubuntu-latest
+          # gives ~16 GB host RAM, so 6 GB guest leaves comfortable host headroom.
+          emulator-options: -no-snapshot-save -no-snapshot-load -no-window -gpu swiftshader_indirect -memory 6144 -noaudio -no-boot-anim -camera-back none -camera-front none
           emulator-boot-timeout: 900
           script: scripts/ci-journey-suite.sh
 
@@ -871,7 +887,12 @@ jobs:
           profile: pixel_7
           force-avd-creation: true
           disable-animations: true
-          emulator-options: -no-snapshot-save -no-snapshot-load -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none
+          # Issue #1458: `-memory 6144` raises the guest RAM from the pixel_7 AVD
+          # hwconfig default (2048 MB) to 6 GB so the swiftshader render pipeline
+          # + Gradle connected-test + 3 Docker fixtures stop starving the guest
+          # (the `Failed to start Emulator console` storm signature). ubuntu-latest
+          # gives ~16 GB host RAM, so 6 GB guest leaves comfortable host headroom.
+          emulator-options: -no-snapshot-save -no-snapshot-load -no-window -gpu swiftshader_indirect -memory 6144 -noaudio -no-boot-anim -camera-back none -camera-front none
           emulator-boot-timeout: 900
           script: scripts/ci-journey-suite.sh
 
@@ -904,8 +925,23 @@ jobs:
       #     class issue #771 targets.
       # Genuine journey failures still keep the job RED (exit 1), so a real test
       # regression cannot hide behind an "infra" message.
+      # Issue #1458 (AGGREGATION): this per-shard classify step is now
+      # `continue-on-error` so a single shard's infra abort (console storm / #470
+      # cancel / #771 never-booted) can NEVER fail the whole `Tests` workflow on
+      # its own and fire a false red-CI email. Instead, EVERY branch below writes
+      # a one-word per-shard VERDICT TOKEN (CLEAN | INFRA | RED) to
+      # artifacts/ci-journey/shard-verdict.txt, which is uploaded per shard and
+      # rolled up by the downstream `emulator-journey-verdict` aggregation job
+      # into ONE overall verdict (CLEAN / RE-RUN / RED). The per-shard ::error /
+      # ::warning annotations + red step marker are PRESERVED for forensics; the
+      # exit codes below are UNCHANGED (genuine failures still exit 1 at the step
+      # level, visible in the log), but the AGGREGATION job — not this step — is
+      # what turns the run red. RED (a HEALTHY-console genuine journey failure or
+      # the #835 budget timeout) still produces an aggregate RED, so a real
+      # regression is never masked.
       - name: Classify emulator-journey result (infra-abort vs test-failure)
         if: always()
+        continue-on-error: true
         run: |
           first="${{ steps.journey.outcome }}"
           retry="${{ steps.journey_retry.outcome }}"
@@ -914,6 +950,13 @@ jobs:
           first_timeout="${{ steps.journey_summary.outputs.first_timeout }}"
           first_failure="${{ steps.journey_summary.outputs.first_failure }}"
           summary="artifacts/ci-journey/summary.md"
+          # Issue #1458: record this shard's verdict token for the aggregation
+          # job. CLEAN = passed; INFRA = environmental (storm / #470 cancel /
+          # #771 never-booted) re-run signal; RED = genuine journey failure or
+          # #835 budget timeout. Written in EVERY branch before its exit.
+          verdict_file="artifacts/ci-journey/shard-verdict.txt"
+          mkdir -p "$(dirname "$verdict_file")"
+          write_verdict() { printf '%s\n' "$1" > "$verdict_file"; echo "SHARD_VERDICT=$1 (shard ${{ matrix.shard }})"; }
           # Issue #1458: count the `Failed to start Emulator console` storm from
           # the durable journey-console capture (teed by run_bounded). On a
           # CPU/RAM-starved swiftshader AVD this ddmlib line repeats ~100×/shard
@@ -942,24 +985,29 @@ jobs:
           echo "first summary genuine failure: ${first_failure:-false}"
           if [[ "$first" == "success" ]]; then
             echo "Emulator journey passed on the first cold boot."
+            write_verdict CLEAN
             exit 0
           fi
           if [[ "$retry" == "success" ]]; then
             echo "::warning title=Emulator infra flake recovered::The first emulator bringup failed but a second cold boot passed (issue #760). Treating as a recovered infra flake, NOT a test failure. Watch for a degrading trend."
+            write_verdict CLEAN
             exit 0
           fi
           if [[ "${first_failure:-false}" == "true" ]]; then
             if (( console_storm_count >= console_storm_threshold )); then
               echo "::error title=EMULATOR INFRA UNAVAILABLE / degraded — console storm (${console_storm_count}× 'Failed to start Emulator console')::The first cold boot wrote a JOURNEY_FAILED summary, but the emulator console failed to start ${console_storm_count} times (>= ${console_storm_threshold}) — the signature of a CPU/RAM-starved swiftshader AVD (issue #1458). A JOURNEY_FAILED read off a DEGRADED emulator is NOT a trustworthy product verdict, so this is an infra abort (a re-run signal, same class as the never-booted #771 branch), NOT a genuine regression. A real regression on a HEALTHY console shows a low console-storm count and stays red."
+              write_verdict INFRA
               exit 1
             fi
             echo "::error title=Emulator journey FAILED — first attempt genuine failure::The first cold boot wrote a JOURNEY_FAILED / Failed BOTH attempts summary, and the retry did not pass cleanly. Refusing to downgrade this run to advisory timeout even if the retry overwrote summary.md with a timeout-only artifact."
+            write_verdict RED
             exit 1
           fi
           if [[ "${first_timeout:-false}" == "true" ]]; then
             timed_out_classes="$(awk '/JOURNEY_STEP_TIMEOUT|Suite step time budget exhausted/{f=1} f && /^- /{gsub(/`/,""); sub(/^- /,"    "); print}' "$summary" || true)"
             echo "::error title=Emulator journey TIMEOUT — load-bearing classes cut short (#835/#470)::The journey suite booted and ran, but exhausted its own 4200s time budget before every load-bearing class reached a verdict (issue #835 / #470). This is now a HARD RED durable guard (#835 REOPENED, D31): a budget timeout means a load-bearing class was silently cut short, which used to be masked as advisory-green. The retry is skipped because a budget timeout is deterministic. Either the enumeration stall has returned or the selection no longer fits the budget — investigate; do NOT treat as a flake. Class(es) cut short / not run:"
             [[ -n "$timed_out_classes" ]] && printf '%s\n' "$timed_out_classes"
+            write_verdict RED
             exit 1
           fi
           # If a cold-boot attempt was cancelled, do not trust summary.md for a
@@ -968,6 +1016,7 @@ jobs:
           # attempt did not produce a trustworthy final suite verdict.
           if [[ "$first" == "cancelled" || "$retry" == "cancelled" || "$first_concl" == "cancelled" || "$retry_concl" == "cancelled" ]]; then
             echo "::error title=Emulator journey TIMEOUT — step cancelled (#470 stall)::A journey cold-boot attempt was CANCELLED before producing a trustworthy final suite verdict. Any existing artifacts/ci-journey/summary.md may be stale from an earlier attempt, so this is NOT reported as a genuine failed-on-both-cold-boots test regression. This is the recurring enumeration-stall/step-timeout infra class (issue #835 / #470). Re-run."
+            write_verdict INFRA
             exit 1
           fi
           # Both attempts failed — classify from the suite's own summary artifact.
@@ -980,6 +1029,7 @@ jobs:
             # test-failure verdict below — a real regression is NEVER swallowed.
             if (( console_storm_count >= console_storm_threshold )); then
               echo "::error title=EMULATOR INFRA UNAVAILABLE / degraded — console storm (${console_storm_count}× 'Failed to start Emulator console')::A load-bearing journey class failed on both cold-boot attempts, but the emulator console failed to start ${console_storm_count} times (>= ${console_storm_threshold}) — the signature of a CPU/RAM-starved swiftshader AVD (issue #1458). A both-attempts JOURNEY_FAILED read off a DEGRADED emulator is NOT a trustworthy product verdict; this is an infra abort (a re-run signal, same class as the never-booted #771 branch), NOT a genuine test regression. A real regression on a HEALTHY console shows a low console-storm count and stays red."
+              write_verdict INFRA
               exit 1
             fi
             # The emulator booted and the suite ran to a verdict: a journey class
@@ -988,6 +1038,7 @@ jobs:
             failed_classes="$(awk '/Failed BOTH attempts/{f=1; next} f && /^- /{gsub(/`/,""); sub(/^- /,"    "); print}' "$summary" || true)"
             echo "::error title=Emulator journey FAILED — genuine test failure::A load-bearing journey class failed on BOTH cold-boot attempts AFTER the emulator booted and the suite ran to a verdict. This is a real test regression (NOT a #771 emulator-infra abort). Failing class(es):"
             [[ -n "$failed_classes" ]] && printf '%s\n' "$failed_classes"
+            write_verdict RED
             exit 1
           fi
           # Issue #835 (REOPENED, DURABLE GUARD): the suite ran (the emulator
@@ -1006,6 +1057,7 @@ jobs:
             timed_out_classes="$(awk '/JOURNEY_STEP_TIMEOUT|Suite step time budget exhausted/{f=1} f && /^- /{gsub(/`/,""); sub(/^- /,"    "); print}' "$summary" || true)"
             echo "::error title=Emulator journey TIMEOUT — load-bearing classes cut short (#835/#470)::The journey suite booted and ran, but exhausted its 4200s time budget before every load-bearing class reached a verdict (issue #835 / #470). This is now a HARD RED durable guard (#835 REOPENED, D31), NOT an advisory-green: a budget timeout means a load-bearing class was silently cut short. Either the in-emulator enumeration stall has returned or the selection no longer fits the budget — investigate. This is distinct from a never-booted emulator (#771) and from a genuine test regression. Class(es) cut short / not run:"
             [[ -n "$timed_out_classes" ]] && printf '%s\n' "$timed_out_classes"
+            write_verdict RED
             exit 1
           fi
           # No suite summary at all: the script aborted before any class reached
@@ -1013,6 +1065,7 @@ jobs:
           # so gradle could not run. This is the EMULATOR INFRA UNAVAILABLE
           # class (#771).
           echo "::error title=EMULATOR INFRA UNAVAILABLE::Both cold-boot attempts failed and the journey suite wrote NO summary (artifacts/ci-journey/summary.md missing), so no journey class ever ran to a verdict — the emulator never reached 'device' / adb never came up (boot/adb infra, issue #771). This is an infra abort, NOT a test regression."
+          write_verdict INFRA
           exit 1
 
       - name: Collect Docker logs
@@ -1065,6 +1118,61 @@ jobs:
           path: artifacts/docker/
           if-no-files-found: ignore
 
+      # Issue #1458 (AGGREGATION): upload this shard's one-word verdict token so
+      # the `emulator-journey-verdict` job can roll all shards into ONE overall
+      # verdict. Per-shard name so matrix legs don't collide; the aggregation
+      # job downloads them with the `emulator-journey-verdict-shard-*` pattern.
+      - name: Upload shard verdict token
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: emulator-journey-verdict-shard-${{ matrix.shard }}
+          path: artifacts/ci-journey/shard-verdict.txt
+          if-no-files-found: warn
+
       - name: Stop Docker fixture
         if: always()
         run: docker compose -f tests/docker/docker-compose.yml down --volumes --remove-orphans
+
+  # ---------------------------------------------------------------------------
+  # Issue #1458 (AGGREGATION): roll the per-shard emulator-journey verdict tokens
+  # into ONE overall verdict so `main`'s emulator-level health is readable at a
+  # glance and an all-infra flake run does NOT fire a false red-CI email.
+  #
+  # The research spike on #1458 found the heavy journey job flakes constantly
+  # from host-CPU starvation on 2–4 vCPU hosted runners: each console-storm shard
+  # was classified as `EMULATOR INFRA UNAVAILABLE` but STILL exited 1 (red) with
+  # no rollup, so three independent red checks left main-health unreadable and
+  # spammed red-CI email. The per-shard classify step is now `continue-on-error`
+  # and records a CLEAN | INFRA | RED token; this job consumes those tokens:
+  #   * every shard CLEAN            -> CLEAN  (green)
+  #   * no RED, at least one INFRA   -> RE-RUN (neutral green + ::warning; the
+  #                                    failures were environmental, re-run)
+  #   * any shard RED (a HEALTHY-console genuine journey failure or the #835
+  #     budget timeout)              -> RED    (exit 1, the run goes red)
+  # A genuine journey assertion failure therefore STILL turns the run red — the
+  # aggregation never masks a real regression (the #657/#844 flake-masks-real
+  # trap's inverse). Per-shard logs/annotations stay intact for forensics.
+  emulator-journey-verdict:
+    name: Emulator journey aggregate verdict (#1458)
+    needs: emulator-journey
+    if: ${{ !cancelled() && github.event_name != 'pull_request' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Download per-shard verdict tokens
+        uses: actions/download-artifact@v5
+        with:
+          pattern: emulator-journey-verdict-shard-*
+          path: artifacts/ci-journey-verdicts
+        continue-on-error: true
+
+      - name: Aggregate the per-shard verdicts into ONE verdict
+        env:
+          # Keep in sync with the length of the emulator-journey matrix.shard.
+          EXPECTED_SHARDS: 3
+        run: |
+          chmod +x scripts/ci-journey-aggregate-verdict.sh
+          scripts/ci-journey-aggregate-verdict.sh artifacts/ci-journey-verdicts

--- a/scripts/ci-journey-aggregate-verdict.sh
+++ b/scripts/ci-journey-aggregate-verdict.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Issue #1458: aggregate the per-shard emulator-journey verdict tokens into ONE
+# overall verdict so `main`'s emulator-level health is readable at a glance and
+# an all-infra flake run does NOT fire a false red-CI email.
+#
+# Background: the heavy `Emulator journey subset` job on `main` flakes constantly
+# from host-CPU starvation on 2–4 vCPU hosted runners. The per-shard classify
+# step already annotates a console-storm shard as `EMULATOR INFRA UNAVAILABLE`,
+# but before this each storm-classified shard STILL exited 1 (red) with no
+# rollup — three independent red checks with no aggregated verdict, so the
+# maintainer could not read main's health and got red-CI email spam. This helper
+# is the aggregation: it reads the one-word verdict token each shard now writes
+# and emits the single overall verdict.
+#
+# Usage:
+#   ci-journey-aggregate-verdict.sh [VERDICT_DIR]
+#     VERDICT_DIR  directory holding the downloaded per-shard verdict artifacts
+#                  (default: artifacts/ci-journey-verdicts). Each shard artifact
+#                  contributes a file whose contents are a single token:
+#                  CLEAN | INFRA | RED. Files may sit directly under VERDICT_DIR
+#                  or one level down (download-artifact per-shard subdirs) — any
+#                  regular file named `shard-verdict*.txt` (recursively) counts.
+#   EXPECTED_SHARDS (env, optional) the number of shards that should have
+#                  reported. When set and fewer tokens are found, the missing
+#                  shards downgrade the verdict to at least RE-RUN (a missing
+#                  verdict is not a clean signal), but never to RED on their own.
+#
+# Verdict / exit code:
+#   CLEAN   every shard reported CLEAN (and none are missing). exit 0.
+#   RED     at least one shard reported RED (a genuine HEALTHY-console journey
+#           failure, or the #835 budget-timeout hard-red), OR a present token
+#           file held an unrecognised value (fail-closed — corruption must not
+#           silently pass). exit 1 — the run goes red.
+#   RE-RUN  no RED shard, but at least one INFRA shard and/or a missing shard:
+#           every failing/absent shard was environmental (console storm / #470
+#           cancel / #771 never-booted / not reported). A re-run signal, NOT a
+#           product regression, so it exits 0 (neutral) with a ::warning — no
+#           false red-CI email.
+#
+# The verdict is printed as `AGGREGATE_VERDICT=<verdict>` and appended to
+# $GITHUB_STEP_SUMMARY when that env var is set, so the rollup is readable in the
+# GitHub checks UI. The load-bearing property — a genuine RED still turns the run
+# red — is proven by scripts/test-ci-journey-aggregate-verdict.sh (no emulator).
+set -uo pipefail
+
+verdict_dir="${1:-artifacts/ci-journey-verdicts}"
+expected_shards="${EXPECTED_SHARDS:-0}"
+
+have_clean=0
+have_infra=0
+have_red=0
+have_unknown=0
+count=0
+tokens=()
+
+if [[ -d "$verdict_dir" ]]; then
+  while IFS= read -r -d '' f; do
+    raw="$(cat "$f" 2>/dev/null || true)"
+    # Normalise: strip whitespace, upper-case.
+    token="$(printf '%s' "$raw" | tr -d '[:space:]' | tr '[:lower:]' '[:upper:]')"
+    [[ -z "$token" ]] && token="UNKNOWN"
+    count=$((count + 1))
+    tokens+=("$token")
+    case "$token" in
+      CLEAN) have_clean=$((have_clean + 1)) ;;
+      INFRA) have_infra=$((have_infra + 1)) ;;
+      RED)   have_red=$((have_red + 1)) ;;
+      *)     have_unknown=$((have_unknown + 1)) ;;
+    esac
+  done < <(find "$verdict_dir" -type f -name 'shard-verdict*.txt' -print0 2>/dev/null)
+fi
+
+missing=0
+if [[ "$expected_shards" =~ ^[0-9]+$ ]] && (( expected_shards > count )); then
+  missing=$((expected_shards - count))
+fi
+
+echo "per-shard verdict tokens found: ${count} ${tokens[*]:-<none>}"
+echo "  CLEAN=$have_clean  INFRA=$have_infra  RED=$have_red  UNKNOWN=$have_unknown  MISSING=$missing (expected ${expected_shards})"
+
+emit_summary() {
+  local verdict="$1" detail="$2"
+  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    {
+      echo "# Emulator journey — aggregate verdict (#1458)"
+      echo
+      echo "**${verdict}** — ${detail}"
+      echo
+      echo "| token | count |"
+      echo "| --- | --- |"
+      echo "| CLEAN | $have_clean |"
+      echo "| INFRA | $have_infra |"
+      echo "| RED | $have_red |"
+      echo "| UNKNOWN | $have_unknown |"
+      echo "| MISSING | $missing |"
+    } >> "$GITHUB_STEP_SUMMARY"
+  fi
+}
+
+# No tokens at all AND none were expected: nothing ran (e.g. the emulator job was
+# skipped). Treat as RE-RUN/neutral rather than a false red — there is no
+# evidence of a genuine regression.
+if (( count == 0 && missing == 0 )); then
+  echo "::warning title=Emulator journey verdict — RE-RUN (no shard verdicts)::No per-shard verdict tokens were found and none were expected; nothing to aggregate. Treating as neutral RE-RUN, NOT a red — there is no evidence of a genuine journey failure."
+  emit_summary "RE-RUN" "no per-shard verdict tokens were found (nothing to aggregate)"
+  echo "AGGREGATE_VERDICT=RE-RUN"
+  exit 0
+fi
+
+# RED wins: a genuine journey failure / #835 timeout, or a corrupt (unknown)
+# token which we fail closed on so a real regression can never hide behind a
+# malformed artifact.
+if (( have_red > 0 || have_unknown > 0 )); then
+  echo "::error title=Emulator journey verdict — RED::At least one shard reported a genuine journey failure (RED=$have_red) or an unrecognised verdict (UNKNOWN=$have_unknown). This is a real regression signal — the run stays red. Per-shard annotations/logs carry the failing class(es)."
+  emit_summary "RED" "a genuine journey failure (or corrupt verdict) was reported — the run stays red"
+  echo "AGGREGATE_VERDICT=RED"
+  exit 1
+fi
+
+# No RED; some shard was environmental (INFRA) or did not report (MISSING).
+if (( have_infra > 0 || missing > 0 )); then
+  echo "::warning title=Emulator journey verdict — RE-RUN (environmental)::No genuine journey failure, but ${have_infra} shard(s) hit an environmental infra abort (console storm / #470 cancel / #771 never-booted) and ${missing} shard(s) did not report. This is a re-run signal, NOT a product regression — the run stays green so main-health is readable and no false red-CI email fires. Re-run the emulator-journey job."
+  emit_summary "RE-RUN" "${have_infra} infra shard(s) + ${missing} missing shard(s), no genuine failure — re-run"
+  echo "AGGREGATE_VERDICT=RE-RUN"
+  exit 0
+fi
+
+# Every shard reported CLEAN and none are missing.
+echo "All ${count} shard(s) reported CLEAN — the emulator journey gate is trustworthy this run."
+emit_summary "CLEAN" "every shard passed"
+echo "AGGREGATE_VERDICT=CLEAN"
+exit 0

--- a/scripts/ci-journey-budget-functions.sh
+++ b/scripts/ci-journey-budget-functions.sh
@@ -124,8 +124,14 @@ run_class() {
     return 124
   fi
   attempt_start=$SECONDS
+  # Issue #1458: --max-workers=2 (parity with the Unit job) caps Gradle's worker
+  # fan-out so it stops fighting the swiftshader emulator + KVM + Docker fixtures
+  # for the 2–4 host vCPUs — the CPU starvation that triggers the
+  # `Failed to start Emulator console` storm. The Gradle DAEMON is still reused
+  # (no --no-daemon), preserving the #835 budget-fit.
   run_bounded "$cap" \
     "$GRADLEW" :app:connectedDebugAndroidTest \
+    --max-workers=2 \
     -Pandroid.testInstrumentationRunnerArguments.pocketshellCi=true \
     -Pandroid.testInstrumentationRunnerArguments.timeout_msec=300000 \
     -Pandroid.testInstrumentationRunnerArguments.class="$fqcn" \
@@ -161,8 +167,12 @@ run_ct_class() {
     return 124
   fi
   attempt_start=$SECONDS
+  # Issue #1458: --max-workers=2 (parity with the Unit job + run_class) caps
+  # Gradle's worker fan-out so it stops starving the swiftshader emulator of host
+  # vCPUs (the `Failed to start Emulator console` storm). Daemon still reused.
   run_bounded "$cap" \
     "$GRADLEW" :shared:core-terminal:connectedDebugAndroidTest \
+    --max-workers=2 \
     -Pandroid.testInstrumentationRunnerArguments.class="$fqcn" \
     --stacktrace
   rc=$?

--- a/scripts/test-ci-journey-aggregate-verdict.sh
+++ b/scripts/test-ci-journey-aggregate-verdict.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+# Issue #1458: focused, JVM-free fixture test for the emulator-journey aggregate
+# verdict (scripts/ci-journey-aggregate-verdict.sh) plus workflow-parity pins for
+# the per-shard token-writing + aggregation wiring in tests.yml.
+#
+# The load-bearing NEW behavior this issue adds is the aggregation: three
+# independent per-shard classify outcomes must roll up into ONE overall verdict,
+# and — critically — a GENUINE journey failure must still turn the run RED while
+# an all-infra flake run turns RE-RUN (neutral) so no false red-CI email fires.
+# This test drives the REAL aggregation script with fixture verdict files and
+# proves each case (CLEAN / RE-RUN / RED) red→green WITHOUT a live emulator.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AGG="$SCRIPT_DIR/ci-journey-aggregate-verdict.sh"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+WORKFLOW="$REPO_ROOT/.github/workflows/tests.yml"
+BUDGET_FN="$SCRIPT_DIR/ci-journey-budget-functions.sh"
+
+fail() { echo "TEST FAIL: $*" >&2; exit 1; }
+pass() { echo "  ok: $*"; }
+
+[[ -f "$AGG" ]] || fail "cannot find ci-journey-aggregate-verdict.sh at $AGG"
+chmod +x "$AGG"
+
+SANDBOX="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+# make_dir <name> — a fresh per-run verdict dir under the sandbox.
+make_dir() {
+  local d="$SANDBOX/$1"
+  rm -rf "$d"; mkdir -p "$d"
+  echo "$d"
+}
+
+# write_shard <dir> <shard-index> <token> — model download-artifact's per-shard
+# subdir layout: artifacts/.../emulator-journey-verdict-shard-<N>/shard-verdict.txt
+write_shard() {
+  local dir="$1" idx="$2" token="$3"
+  local sub="$dir/emulator-journey-verdict-shard-$idx"
+  mkdir -p "$sub"
+  printf '%s\n' "$token" > "$sub/shard-verdict.txt"
+}
+
+# run_agg <dir> <expected-shards> — run the real aggregation, capture verdict +
+# exit code into globals AGG_OUT / AGG_RC / AGG_VERDICT.
+run_agg() {
+  local dir="$1" expected="$2"
+  set +e
+  AGG_OUT="$(EXPECTED_SHARDS="$expected" GITHUB_STEP_SUMMARY="" bash "$AGG" "$dir" 2>&1)"
+  AGG_RC=$?
+  set -e
+  AGG_VERDICT="$(printf '%s\n' "$AGG_OUT" | sed -n 's/^AGGREGATE_VERDICT=//p' | tail -n 1)"
+}
+
+echo "== #1458 aggregation fixture cases =="
+
+# (a) all-green -> CLEAN (exit 0). This is the trustworthy-run baseline.
+d="$(make_dir all-green)"
+write_shard "$d" 0 CLEAN; write_shard "$d" 1 CLEAN; write_shard "$d" 2 CLEAN
+run_agg "$d" 3
+[[ "$AGG_VERDICT" == "CLEAN" && "$AGG_RC" -eq 0 ]] \
+  || { printf '%s\n' "$AGG_OUT"; fail "(a) all-green expected CLEAN/exit0, got $AGG_VERDICT/exit$AGG_RC"; }
+pass "(a) all shards CLEAN -> CLEAN (green, exit 0)"
+
+# (b) all-infra-storm -> RE-RUN (exit 0, NOT red). This is the #1458 core: a
+#     console-storm run must NOT fire a false red-CI email.
+d="$(make_dir all-infra)"
+write_shard "$d" 0 INFRA; write_shard "$d" 1 INFRA; write_shard "$d" 2 INFRA
+run_agg "$d" 3
+[[ "$AGG_VERDICT" == "RE-RUN" && "$AGG_RC" -eq 0 ]] \
+  || { printf '%s\n' "$AGG_OUT"; fail "(b) all-infra expected RE-RUN/exit0, got $AGG_VERDICT/exit$AGG_RC"; }
+grep -q '::warning' <<<"$AGG_OUT" \
+  || fail "(b) an all-infra RE-RUN must emit a ::warning (re-run signal), not silence"
+grep -q '::error' <<<"$AGG_OUT" \
+  && fail "(b) an all-infra RE-RUN must NOT emit a ::error (that would fire a false red-CI email)"
+pass "(b) all shards INFRA-storm -> RE-RUN (neutral green, exit 0, no false red)"
+
+# (c) one real journey failure + infra elsewhere -> RED (exit 1). The
+#     load-bearing property: a genuine regression is NEVER masked by infra.
+d="$(make_dir one-red)"
+write_shard "$d" 0 INFRA; write_shard "$d" 1 RED; write_shard "$d" 2 CLEAN
+run_agg "$d" 3
+[[ "$AGG_VERDICT" == "RED" && "$AGG_RC" -eq 1 ]] \
+  || { printf '%s\n' "$AGG_OUT"; fail "(c) one RED + infra expected RED/exit1, got $AGG_VERDICT/exit$AGG_RC"; }
+grep -q '::error' <<<"$AGG_OUT" \
+  || fail "(c) a RED verdict must emit a ::error so the run turns red"
+pass "(c) one genuine RED (+infra/clean siblings) -> RED (exit 1) — real regression NOT masked"
+
+# (c') the red→green control: the SAME shape but with the RED shard flipped to
+#     INFRA must drop to RE-RUN — proving it was the RED token, not the infra,
+#     that drove the red (the G6 load-bearing-assertion guard).
+d="$(make_dir one-red-control)"
+write_shard "$d" 0 INFRA; write_shard "$d" 1 INFRA; write_shard "$d" 2 CLEAN
+run_agg "$d" 3
+[[ "$AGG_VERDICT" == "RE-RUN" && "$AGG_RC" -eq 0 ]] \
+  || { printf '%s\n' "$AGG_OUT"; fail "(c') flipping the RED shard to INFRA must yield RE-RUN/exit0, got $AGG_VERDICT/exit$AGG_RC"; }
+pass "(c') control: RED->INFRA flip drops to RE-RUN — the RED token is the load-bearing signal"
+
+# (d) CLEAN + INFRA mix (no RED) -> RE-RUN: one healthy shard does not clean a
+#     run where another shard was environmental; a re-run is still needed.
+d="$(make_dir clean-infra)"
+write_shard "$d" 0 CLEAN; write_shard "$d" 1 INFRA; write_shard "$d" 2 CLEAN
+run_agg "$d" 3
+[[ "$AGG_VERDICT" == "RE-RUN" && "$AGG_RC" -eq 0 ]] \
+  || { printf '%s\n' "$AGG_OUT"; fail "(d) clean+infra expected RE-RUN/exit0, got $AGG_VERDICT/exit$AGG_RC"; }
+pass "(d) CLEAN+INFRA (no RED) -> RE-RUN"
+
+# (e) missing shard (fewer tokens than EXPECTED_SHARDS) -> RE-RUN, never a false
+#     CLEAN: a shard that did not report is not a clean signal.
+d="$(make_dir missing-shard)"
+write_shard "$d" 0 CLEAN; write_shard "$d" 1 CLEAN   # shard 2 missing
+run_agg "$d" 3
+[[ "$AGG_VERDICT" == "RE-RUN" && "$AGG_RC" -eq 0 ]] \
+  || { printf '%s\n' "$AGG_OUT"; fail "(e) missing shard expected RE-RUN/exit0, got $AGG_VERDICT/exit$AGG_RC"; }
+pass "(e) a missing shard downgrades CLEAN to RE-RUN (never a false clean)"
+
+# (e') missing shard NEXT TO a genuine RED still resolves RED (RED wins over a
+#      missing/re-run signal — a regression is never softened to RE-RUN).
+d="$(make_dir missing-plus-red)"
+write_shard "$d" 0 RED; write_shard "$d" 1 CLEAN     # shard 2 missing
+run_agg "$d" 3
+[[ "$AGG_VERDICT" == "RED" && "$AGG_RC" -eq 1 ]] \
+  || { printf '%s\n' "$AGG_OUT"; fail "(e') RED + missing expected RED/exit1, got $AGG_VERDICT/exit$AGG_RC"; }
+pass "(e') RED beats a missing shard -> RED (exit 1)"
+
+# (f) an unrecognised/corrupt token -> RED (fail closed): a malformed artifact
+#     must not silently pass as clean.
+d="$(make_dir corrupt-token)"
+write_shard "$d" 0 CLEAN; write_shard "$d" 1 GARBAGE; write_shard "$d" 2 CLEAN
+run_agg "$d" 3
+[[ "$AGG_VERDICT" == "RED" && "$AGG_RC" -eq 1 ]] \
+  || { printf '%s\n' "$AGG_OUT"; fail "(f) corrupt token expected RED/exit1 (fail-closed), got $AGG_VERDICT/exit$AGG_RC"; }
+pass "(f) an unrecognised token fails closed -> RED (exit 1)"
+
+# (g) lower-case / whitespace-padded tokens normalise correctly.
+d="$(make_dir normalise)"
+mkdir -p "$d/emulator-journey-verdict-shard-0"; printf '  clean \n' > "$d/emulator-journey-verdict-shard-0/shard-verdict.txt"
+mkdir -p "$d/emulator-journey-verdict-shard-1"; printf 'Infra' > "$d/emulator-journey-verdict-shard-1/shard-verdict.txt"
+mkdir -p "$d/emulator-journey-verdict-shard-2"; printf 'CLEAN\n' > "$d/emulator-journey-verdict-shard-2/shard-verdict.txt"
+run_agg "$d" 3
+[[ "$AGG_VERDICT" == "RE-RUN" && "$AGG_RC" -eq 0 ]] \
+  || { printf '%s\n' "$AGG_OUT"; fail "(g) mixed-case/padded tokens expected RE-RUN/exit0, got $AGG_VERDICT/exit$AGG_RC"; }
+pass "(g) tokens are whitespace/case normalised"
+
+# (h) nothing ran at all (empty dir, EXPECTED_SHARDS=0) -> RE-RUN neutral, never
+#     a false red on an inert run.
+d="$(make_dir empty)"
+run_agg "$d" 0
+[[ "$AGG_VERDICT" == "RE-RUN" && "$AGG_RC" -eq 0 ]] \
+  || { printf '%s\n' "$AGG_OUT"; fail "(h) empty/no-expected expected RE-RUN/exit0, got $AGG_VERDICT/exit$AGG_RC"; }
+pass "(h) no tokens + none expected -> RE-RUN (neutral, not a false red)"
+
+echo
+echo "== #1458 workflow-parity pins =="
+
+# The per-shard classify step must be continue-on-error (so an infra shard can't
+# fail the workflow on its own) and must write a verdict token in every branch.
+grep -q 'name: Classify emulator-journey result' "$WORKFLOW" \
+  || fail "(w1) tests.yml must still have the per-shard classify step"
+grep -q 'write_verdict' "$WORKFLOW" \
+  || fail "(w2) classify step must write per-shard verdict tokens (write_verdict)"
+# Every RED/INFRA/CLEAN token value must appear as a write_verdict argument.
+for tok in CLEAN INFRA RED; do
+  grep -q "write_verdict $tok" "$WORKFLOW" \
+    || fail "(w3) classify step must emit a '$tok' verdict token"
+done
+# The classify step must be continue-on-error so the AGGREGATION job — not the
+# shard — is what turns the run red.
+awk '
+  /name: Classify emulator-journey result/ { armed=1 }
+  armed && /continue-on-error: true/ { found=1 }
+  armed && /run: \|/ { armed=0 }
+  END { exit(found ? 0 : 1) }
+' "$WORKFLOW" \
+  || fail "(w4) classify step must be continue-on-error so an infra shard cannot fire a false red-CI email"
+# The aggregation job + its verdict artifact wiring must exist.
+grep -q 'emulator-journey-verdict:' "$WORKFLOW" \
+  || fail "(w5) tests.yml must define the emulator-journey-verdict aggregation job"
+grep -q 'ci-journey-aggregate-verdict.sh' "$WORKFLOW" \
+  || fail "(w6) aggregation job must invoke scripts/ci-journey-aggregate-verdict.sh"
+grep -q 'emulator-journey-verdict-shard-' "$WORKFLOW" \
+  || fail "(w7) each shard must upload an emulator-journey-verdict-shard-<N> token artifact"
+grep -q 'pattern: emulator-journey-verdict-shard-\*' "$WORKFLOW" \
+  || fail "(w8) aggregation job must download the shard verdict artifacts by pattern"
+grep -q 'EXPECTED_SHARDS: 3' "$WORKFLOW" \
+  || fail "(w9) aggregation job must pass EXPECTED_SHARDS matching the 3-shard matrix"
+pass "(w) classify continue-on-error + verdict tokens + aggregation job wired in tests.yml"
+
+# The #1458 budget-neutral emulator/Gradle contention cuts. Count only the
+# actual `emulator-options:` launch lines (not the explanatory comment) so both
+# the first-attempt and retry emulator bringups raise the guest RAM to 6 GB.
+mem_count="$(grep -cE '^\s*emulator-options:.*-memory 6144' "$WORKFLOW" || true)"
+[[ "$mem_count" -eq 2 ]] \
+  || fail "(w10) both emulator-options launches must set '-memory 6144' (first + retry), found $mem_count"
+pass "(w10) guest -memory 6144 on both emulator launches (was the pixel_7 hwconfig default 2048)"
+
+# Count only the actual Gradle-arg lines (leading whitespace then the flag), not
+# the explanatory comments that also mention it.
+mw_count="$(grep -cE '^[[:space:]]*--max-workers=2' "$BUDGET_FN" || true)"
+[[ "$mw_count" -eq 2 ]] \
+  || fail "(w11) both journey Gradle invocations (run_class + run_ct_class) must pass --max-workers=2, found $mw_count"
+# Daemon reuse (#835 budget-fit) must be preserved — no --no-daemon crept into an
+# actual Gradle-arg line (comments mentioning it are fine).
+grep -qE '^[[:space:]]*--no-daemon' "$BUDGET_FN" \
+  && fail "(w11) journey Gradle invocations must NOT use --no-daemon (would break the #835 budget-fit)"
+pass "(w11) --max-workers=2 on both journey Gradle invocations, daemon reuse preserved"
+
+echo
+echo "ALL TESTS PASSED"


### PR DESCRIPTION
Refs #1458 (budget-neutral slice — does not close it; shard-count 3→6 and self-hosted runner are maintainer-deferred cost levers).

The heavy emulator-journey job flakes from **host CPU starvation** on 2–4 vCPU runners. A classifier already labels console-storm shards as infra, but each still exited red with no rollup → unreadable main health + red-CI email spam.

**Change:**
- per-shard classify → `continue-on-error`, writes a `CLEAN|INFRA|RED` token;
- NEW `emulator-journey-verdict` job (`needs` all shards) = single gate → **CLEAN** / **RE-RUN** (all failures infra-classified → neutral, no false red email) / **RED** (≥1 genuine journey failure → exit 1). #835 budget-timeout stays hard-red; missing/corrupt tokens fail-safe to RE-RUN/RED.
- `--max-workers=2` on journey Gradle invocations + emulator guest `-memory 6144`.

**Reviewer:** APPROVED — tamper-verified the load-bearing property: neutralizing RED-detection makes the genuine-RED fixture case fail, so 'a real journey failure still goes RED' is the green thing, not a vacuous pass. Wiring confirmed (needs all shards, exits 1 on RED, continue-on-error only on classify step, #835 preserved).
**Local gate:** `test-ci-journey-aggregate-verdict.sh` PASS (CLEAN/RE-RUN/RED); pinned `test-ci-journey-budget.sh` still PASS; shellcheck clean; YAML parses; git diff --check clean. The new fixture test runs in the required Unit job.