### PR TITLE
tmux: move session rename/create/kill/poll off shared -CC onto exec lane (#1496)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/sessions/SessionsDashboardViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/sessions/SessionsDashboardViewModel.kt
@@ -286,7 +286,14 @@ class SessionsDashboardViewModel @Inject constructor(
      * the response. Visible-for-test through [parseListSessionsRow].
      */
     private suspend fun fetchSessions(entry: ActiveTmuxClients.Entry): List<SessionSummary>? {
-        val response = entry.client.sendCommand(LIST_SESSIONS_COMMAND)
+        // Issue #1496: the live `list-sessions` poll rides the DEDICATED exec
+        // lane ([TmuxClient.sendLifecycleViaExec]), NOT the shared `-CC`
+        // control channel. On the `-CC` lane a live Codex `%output` burst
+        // head-of-line-blocked this poll's reply behind it on the one sshj
+        // reader (10s mutex acquire + 30s ceiling); the exec lane reads its own
+        // channel outside the transport dispatcher, so the dashboard stays
+        // fresh while a burst saturates `-CC`.
+        val response = entry.client.sendLifecycleViaExec(LIST_SESSIONS_COMMAND)
         if (response.isError) return null
         return response.output.mapNotNull { line ->
             parseListSessionsRow(
@@ -445,9 +452,9 @@ class SessionsDashboardViewModel @Inject constructor(
      *
      * We do NOT subscribe to `%sessions-changed` here (unlike
      * [killSession]) because tmux emits the notification BEFORE the new
-     * row is queryable in some edge cases — instead we rely on
-     * sendCommand's response correlator: when `sendCommand` returns
-     * non-error, the session exists on the server, so an immediate
+     * row is queryable in some edge cases — instead we rely on the exec
+     * lane's response (issue #1496): when [TmuxClient.sendLifecycleViaExec]
+     * returns non-error, the session exists on the server, so an immediate
      * list-sessions is guaranteed to see it.
      */
     fun createSession(
@@ -487,7 +494,10 @@ class SessionsDashboardViewModel @Inject constructor(
                 }
             }
             val sendResult = runCatching {
-                client.sendCommand(
+                // Issue #1496: Create rides the DEDICATED exec lane
+                // ([TmuxClient.sendLifecycleViaExec]), NOT the shared `-CC`
+                // control channel a live Codex burst can head-of-line-block.
+                client.sendLifecycleViaExec(
                     "new-session -d -s '${escapeSingleQuoted(creation.sessionName)}' " +
                         "-c '${escapeSingleQuoted(creation.startDirectory)}'",
                 )
@@ -524,7 +534,10 @@ class SessionsDashboardViewModel @Inject constructor(
         if (oldTrimmed.isEmpty() || newTrimmed.isEmpty()) return
         viewModelScope.launch {
             runCatching {
-                entry.client.sendCommand(
+                // Issue #1496: Rename rides the DEDICATED exec lane
+                // ([TmuxClient.sendLifecycleViaExec]), NOT the shared `-CC`
+                // control channel a live Codex burst can head-of-line-block.
+                entry.client.sendLifecycleViaExec(
                     "rename-session -t '${escapeSingleQuoted(oldTrimmed)}' " +
                         "'${escapeSingleQuoted(newTrimmed)}'",
                 )
@@ -611,7 +624,13 @@ class SessionsDashboardViewModel @Inject constructor(
             }
 
             val sendResult = runCatching {
-                client.sendCommand("kill-session -t '${escapeSingleQuoted(trimmed)}'")
+                // Issue #1496: Kill rides the DEDICATED exec lane
+                // ([TmuxClient.sendLifecycleViaExec]), NOT the shared `-CC`
+                // control channel a live Codex burst can head-of-line-block.
+                // tmux still emits `%sessions-changed` to the attached `-CC`
+                // client on teardown, so the post-kill event wait below is
+                // unaffected by moving the kill itself onto the exec lane.
+                client.sendLifecycleViaExec("kill-session -t '${escapeSingleQuoted(trimmed)}'")
             }
             val response = sendResult.getOrNull()
             val transportFailure = sendResult.exceptionOrNull()

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -16308,7 +16308,6 @@ public class TmuxSessionViewModel @Inject constructor(
         }
     }
 
-
     /**
      * Epic #821 Slice 1: read the active session's RECORDED `@ps_agent_kind`
      * fresh from the host and publish it on [currentSessionRecordedKind]. The
@@ -16488,13 +16487,10 @@ public class TmuxSessionViewModel @Inject constructor(
         }
     }
 
+    // #1496 exec off -CC (D22)
     private fun sendLifecycleCommand(command: String) {
         val client = clientRef ?: return
-        bridgeScope.launch {
-            runCatching {
-                client.sendCommand(command)
-            }
-        }
+        bridgeScope.launch { runCatching { client.sendLifecycleViaExec(command) } }
     }
 
     /**

--- a/app/src/test/java/com/pocketshell/app/sessions/SessionsDashboardViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/sessions/SessionsDashboardViewModelTest.kt
@@ -522,6 +522,66 @@ class SessionsDashboardViewModelTest {
     }
 
     /**
+     * Issue #1496: every dashboard session-management round-trip (Create,
+     * Rename, Kill, and the live `list-sessions` poll) must ride the DEDICATED
+     * exec lane ([TmuxClient.sendLifecycleViaExec]) — NOT the shared `-CC`
+     * [TmuxClient.sendCommand] a live Codex `%output` burst can
+     * head-of-line-block for 30-40s. Proven by asserting each command lands in
+     * [FakeTmuxClient.sendLifecycleViaExecCalls] (the exec lane), and that the
+     * raw `-CC` send-lane (bare [FakeTmuxClient.sendCommand]) was never used for
+     * any of them.
+     */
+    @Test
+    fun dashboardLifecycleAndPollRideTheExecLaneNotTheCcSendCommand() = runTest {
+        val vm = newVm()
+        val client = FakeTmuxClient().apply {
+            // new-session, rename-session, kill-session, then the refresh
+            // list-sessions each pop one empty success.
+            repeat(6) {
+                responses.addLast(
+                    CommandResponse(number = it.toLong(), output = emptyList(), isError = false),
+                )
+            }
+        }
+        val h = host(31L, "thirtyone")
+        val entry = ActiveTmuxClients.Entry(
+            hostId = h.id,
+            hostName = h.name,
+            hostname = h.hostname,
+            port = h.port,
+            username = h.username,
+            keyPath = "/k",
+            client = client,
+        )
+
+        vm.createSession(entry, "next")
+        vm.renameSession(entry, "next", "renamed")
+        vm.killSession(entry, "renamed")
+        runCurrent()
+        client.emittedEvents.emit(ControlEvent.SessionsChanged)
+        advanceUntilIdle()
+        // The live poll seam runs the same fetch the poll loop uses.
+        vm.fetchSessionsForTest(entry)
+
+        assertTrue(
+            "Create must ride the exec lane; calls=${client.sendLifecycleViaExecCalls}",
+            client.sendLifecycleViaExecCalls.any { it == "new-session -d -s 'next' -c '~'" },
+        )
+        assertTrue(
+            "Rename must ride the exec lane; calls=${client.sendLifecycleViaExecCalls}",
+            client.sendLifecycleViaExecCalls.any { it == "rename-session -t 'next' 'renamed'" },
+        )
+        assertTrue(
+            "Kill must ride the exec lane; calls=${client.sendLifecycleViaExecCalls}",
+            client.sendLifecycleViaExecCalls.any { it == "kill-session -t 'renamed'" },
+        )
+        assertTrue(
+            "the list-sessions poll must ride the exec lane; calls=${client.sendLifecycleViaExecCalls}",
+            client.sendLifecycleViaExecCalls.any { it.startsWith("list-sessions") },
+        )
+    }
+
+    /**
      * Issue #168 — silent kill failures (failure mode 1 from the issue
      * body) must now surface as a [killError] banner AND must not run
      * the refresh, because a refresh after a failed kill would show the

--- a/app/src/test/java/com/pocketshell/app/tmux/FakeTmuxClient.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/FakeTmuxClient.kt
@@ -346,6 +346,25 @@ internal class FakeTmuxClient(
         return handleCommand(cmd, bestEffort = false)
     }
 
+    /**
+     * Issue #1496: records the session-management commands (`rename-session`,
+     * `new-session -d`, `kill-session`, the dashboard `list-sessions` poll) the
+     * dashboard / in-session Rename routed onto the DEDICATED exec lane, so a
+     * test can prove the call site rides [sendLifecycleViaExec] (off `-CC`) and
+     * not the raw `-CC` [sendCommand]. Still routes through [handleCommand] so
+     * the existing canned-[responses] plumbing (list-sessions rows, `%error`
+     * responses) keeps working unchanged.
+     */
+    val sendLifecycleViaExecCalls: MutableList<String> = mutableListOf()
+
+    override suspend fun sendLifecycleViaExec(
+        sessionCommand: String,
+        timeoutMs: Long?,
+    ): CommandResponse {
+        sendLifecycleViaExecCalls += sessionCommand
+        return handleCommand(sessionCommand, bestEffort = false)
+    }
+
     override suspend fun sendBestEffortCommand(cmd: String): CommandResponse =
         handleCommand(cmd, bestEffort = true)
 

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionControlClientTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionControlClientTest.kt
@@ -55,6 +55,38 @@ class TmuxSessionControlClientTest : TmuxSessionViewModelTestBase() {
     }
 
     @Test
+    fun renameCurrentSessionRidesTheExecLaneNotTheCcSendCommand() = runTest(scheduler) {
+        // Issue #1496: the in-session Rename must ride the DEDICATED exec lane
+        // ([TmuxClient.sendLifecycleViaExec]) on the warm connection, NOT the
+        // shared `-CC` [TmuxClient.sendCommand] a live Codex `%output` burst can
+        // head-of-line-block for 30-40s (the maintainer's Rename froze
+        // mid-burst).
+        val vm = newVm()
+        val client = FakeTmuxClient()
+        vm.replaceClientForTest(
+            hostId = 1L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            sessionName = "work",
+            client = client,
+        )
+
+        vm.renameCurrentSession("renamed")
+        advanceUntilIdle()
+
+        // The load-bearing proof: had Rename used the raw `-CC` sendCommand
+        // path, sendLifecycleViaExecCalls would be empty. It carries the exact
+        // rename command, so the round-trip rode the exec lane.
+        assertEquals(
+            listOf("rename-session -t 'work' 'renamed'"),
+            client.sendLifecycleViaExecCalls,
+        )
+    }
+
+    @Test
     fun lifecycleCommandsDeriveCreateNameButIgnoreBlankRenameNames() = runTest(scheduler) {
         val vm = newVm()
         val client = FakeTmuxClient()

--- a/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxClient.kt
+++ b/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxClient.kt
@@ -280,6 +280,31 @@ public interface TmuxClient : AutoCloseable {
     ): CommandResponse = sendCommand(sendKeysCommand)
 
     /**
+     * Issue #1496: run a session-management tmux control command
+     * (`rename-session`, `new-session -d`, `kill-session`, or the dashboard's
+     * live `list-sessions` poll) on the DEDICATED [SshSession.exec] channel —
+     * the same independent lane [sendKeysViaExec] (#1460) / [listPanesViaExec]
+     * (#1316) use — NOT the shared per-host `-CC` channel [sendCommand] awaits
+     * `%begin`/`%end` on. These user-interactive round-trips rode `sendCommand`,
+     * so a live Codex `%output` burst head-of-line-blocked their reply behind it
+     * on the ONE sshj reader (10s mutex acquire + 30s ceiling — the Codex-freeze
+     * audit's residual transport SPOF). The exec lane reads its own channel
+     * outside the transport dispatcher, so these return fast under a burst.
+     *
+     * [sessionCommand] is the `-CC`-form command WITHOUT the leading `tmux`, so
+     * the caller's command string and error semantics are unchanged: a mutation
+     * prints nothing on success (empty non-error), `list-sessions` returns its
+     * rows, a non-zero exit surfaces an error response carrying stderr.
+     * [timeoutMs] bounds the round-trip so a wedged transport throws a
+     * [TmuxClientException] fast instead of parking the UI action. The default
+     * falls back to a `-CC` [sendCommand] for doubles with no exec lane.
+     */
+    public suspend fun sendLifecycleViaExec(
+        sessionCommand: String,
+        timeoutMs: Long? = null,
+    ): CommandResponse = sendCommand(sessionCommand)
+
+    /**
      * Subscribe to `%output` events for a single pane.
      *
      * Multiple callers may subscribe to the same pane — the underlying
@@ -1395,6 +1420,53 @@ internal class RealTmuxClient(
             )
             throw TmuxClientException(
                 "tmux send-keys (exec interactive send lane) timed out after ${effectiveTimeoutMs}ms",
+            )
+        }
+        return parseSendKeysExecResult(execResult)
+    }
+
+    /**
+     * Issue #1496: run a session-management control command (`rename-session`,
+     * `new-session -d`, `kill-session`, or the dashboard `list-sessions` poll)
+     * on the DEDICATED [SshSession.exec] channel — the same lane [sendKeysViaExec]
+     * (#1460) / [listPanesViaExec] (#1316) use — NOT the shared `-CC` [sendMutex]
+     * a live Codex `%output` burst head-of-line-blocks (10s acquire + 30s
+     * ceiling). [sessionCommand] is the `-CC`-form command (no leading `tmux`);
+     * [timeoutMs] bounds the round-trip so a wedged transport throws fast. The
+     * parse matches the `-CC` contract: empty non-error on success, rows for
+     * `list-sessions`, stderr on a non-zero exit.
+     */
+    override suspend fun sendLifecycleViaExec(
+        sessionCommand: String,
+        timeoutMs: Long?,
+    ): CommandResponse {
+        if (closed) throw TmuxClientException("client is closed")
+        if (!connected) throw TmuxClientException("client is not connected")
+        val effectiveTimeoutMs = timeoutMs?.coerceIn(1L, commandTimeoutMs) ?: commandTimeoutMs
+        val command = "tmux $sessionCommand"
+        val execResult =
+            try {
+                // Independent of the busy `-CC` channel, so this returns fast under
+                // a burst. The ceiling is the safety bound for a genuinely
+                // wedged/half-open transport; cancelling the exec closes its OWN
+                // channel (RealSshSession.exec cancellation handler), never `-CC`.
+                withTimeoutOrNull(effectiveTimeoutMs) {
+                    session.exec(command)
+                }
+            } catch (t: Throwable) {
+                throw TmuxClientException(
+                    "tmux session-lifecycle exec (dashboard/rename lane) failed: ${t.message}",
+                    t,
+                )
+            }
+        if (execResult == null) {
+            Log.w(
+                ISSUE_244_DIAG_TAG,
+                "tmux sendLifecycleViaExec exec timed out >${effectiveTimeoutMs}ms " +
+                    "(session-lifecycle lane); surfacing a best-effort failure.",
+            )
+            throw TmuxClientException(
+                "tmux session-lifecycle (exec lane) timed out after ${effectiveTimeoutMs}ms",
             )
         }
         return parseSendKeysExecResult(execResult)

--- a/shared/core-tmux/src/test/java/com/pocketshell/core/tmux/TmuxClientExecLaneTest.kt
+++ b/shared/core-tmux/src/test/java/com/pocketshell/core/tmux/TmuxClientExecLaneTest.kt
@@ -559,6 +559,324 @@ class TmuxClientExecLaneTest {
             }
         }
 
+    // ---------------------------------------------------------------------
+    // Issue #1496: the session-lifecycle wedge — the residual `sendCommand`
+    // SPOF the 2026-07-12 Codex-freeze audit found after #1460 (send lane) and
+    // #1488 (share lane). The in-session Rename and the sessions dashboard's
+    // Create / Rename / Kill actions and its live `list-sessions` poll all rode
+    // the shared per-host `-CC` `sendCommand`, so a live Codex `%output` burst
+    // head-of-line-blocked their `%begin`/`%end` reply ~30-40s behind it on the
+    // ONE sshj reader (10s mutex acquire + 30s ceiling; the 10s idle gate never
+    // fires while output flows). The RED tests document WHY each of the five
+    // command strings wedges on `-CC`; the GREEN tests prove `sendLifecycleViaExec`
+    // does NOT wedge — it rides the dedicated exec channel. Covers the CLASS: all
+    // five call sites (rename in-session + dashboard share the same command
+    // string), not one.
+    // ---------------------------------------------------------------------
+
+    @Test
+    fun `RED — rename-session on the shared -CC sendCommand wedges behind a held control channel`() =
+        runBlocking { assertSendCommandWedgesDuringCcWedge("rename-session -t 'work' 'renamed'") }
+
+    @Test
+    fun `RED — new-session -d on the shared -CC sendCommand wedges behind a held control channel`() =
+        runBlocking { assertSendCommandWedgesDuringCcWedge("new-session -d -s 'next' -c '~'") }
+
+    @Test
+    fun `RED — kill-session on the shared -CC sendCommand wedges behind a held control channel`() =
+        runBlocking { assertSendCommandWedgesDuringCcWedge("kill-session -t 'work'") }
+
+    @Test
+    fun `RED — list-sessions poll on the shared -CC sendCommand wedges behind a held control channel`() =
+        runBlocking {
+            assertSendCommandWedgesDuringCcWedge(
+                "list-sessions -F '#{session_name}::#{session_created}'",
+            )
+        }
+
+    @Test
+    fun `GREEN — rename-session completes on the exec lane while the -CC channel is wedged`() =
+        runBlocking {
+            assertSendLifecycleViaExecCompletesDuringCcWedge(
+                sessionCommand = "rename-session -t 'work' 'renamed'",
+                expectExecEquals = "tmux rename-session -t 'work' 'renamed'",
+            )
+        }
+
+    @Test
+    fun `GREEN — new-session -d completes on the exec lane while the -CC channel is wedged`() =
+        runBlocking {
+            assertSendLifecycleViaExecCompletesDuringCcWedge(
+                sessionCommand = "new-session -d -s 'next' -c '~'",
+                expectExecEquals = "tmux new-session -d -s 'next' -c '~'",
+            )
+        }
+
+    @Test
+    fun `GREEN — kill-session completes on the exec lane while the -CC channel is wedged`() =
+        runBlocking {
+            assertSendLifecycleViaExecCompletesDuringCcWedge(
+                sessionCommand = "kill-session -t 'work'",
+                expectExecEquals = "tmux kill-session -t 'work'",
+            )
+        }
+
+    @Test
+    fun `GREEN — list-sessions poll completes on the exec lane and returns rows while -CC is wedged`() =
+        runBlocking {
+            // Issue #1496 class coverage: the dashboard live poll returns rows
+            // (unlike the rename/create/kill mutations). Prove it completes fast
+            // off `-CC` under a burst AND parses the rows the caller's row
+            // parser expects — the exact `-CC` per-row contract, unchanged.
+            val rows = listOf("work::1::2::1::::", "next::3::4::0::::")
+            val listCommand = "list-sessions -F '#{session_name}::#{session_created}'"
+            val shell = FakeShell()
+            val session = FakeSession(
+                shell,
+                execHandler = sendLifecycleExecHandler(stdout = rows.joinToString("\n") + "\n"),
+            )
+            val client = RealTmuxClient(session, scope, commandTimeoutMs = 30_000L)
+            try {
+                client.connect()
+                withTimeout(2_000) {
+                    while (shell.stdinBytes().isEmpty()) { yield(); delay(10) }
+                }
+                shell.resetStdin()
+
+                val wedger = scope.async { runCatching { client.sendCommand("list-clients") } }
+                withTimeout(2_000) {
+                    while (!shell.stdinAsString().contains("list-clients")) { yield(); delay(10) }
+                }
+
+                val startedAtMs = System.currentTimeMillis()
+                val response = withTimeout(5_000) {
+                    client.sendLifecycleViaExec(listCommand)
+                }
+                val elapsedMs = System.currentTimeMillis() - startedAtMs
+
+                assertFalse("the poll must succeed during a -CC burst", response.isError)
+                assertEquals(rows, response.output)
+                assertTrue(
+                    "the poll must complete well under the -CC mutex ceiling " +
+                        "(elapsed ${elapsedMs}ms) proving it did not wait on the wedged " +
+                        "-CC sendMutex",
+                    elapsedMs < 2_000L,
+                )
+                assertEquals(
+                    "the list-sessions must ride the exec lane verbatim",
+                    "tmux $listCommand",
+                    session.execCommands.single { it.contains("list-sessions") },
+                )
+                assertFalse(
+                    "the list-sessions must NOT be written to the wedged -CC shell",
+                    shell.stdinAsString().contains("list-sessions"),
+                )
+                wedger.cancel()
+            } finally {
+                client.close()
+            }
+        }
+
+    @Test
+    fun `sendLifecycleViaExec surfaces an error response when the session is gone`() = runBlocking {
+        // Issue #1496: a non-zero exec exit (name collision, session gone) must
+        // surface as an ERROR CommandResponse carrying stderr — so a failed
+        // rename/create/kill still fails honestly (the dashboard shows its
+        // error banner), matching the `-CC` error contract exactly.
+        val shell = FakeShell()
+        val session = FakeSession(
+            shell,
+            execHandler = sendLifecycleExecHandler(
+                exitCode = 1,
+                stderr = "duplicate session: next",
+            ),
+        )
+        val client = RealTmuxClient(session, scope)
+        try {
+            client.connect()
+            val response = withTimeout(ASYNC_AWAIT_TIMEOUT_MS) {
+                client.sendLifecycleViaExec("new-session -d -s 'next'")
+            }
+            assertTrue("a gone/colliding session must surface as an error response", response.isError)
+            assertEquals(listOf("duplicate session: next"), response.output)
+        } finally {
+            client.close()
+        }
+    }
+
+    @Test
+    fun `sendLifecycleViaExec succeeds with an empty non-error response on a normal mutation`() =
+        runBlocking {
+            // Issue #1496: `rename-session` / `kill-session` print nothing on
+            // success, so a zero exit must yield an empty, non-error response
+            // (the caller treats it as success).
+            val shell = FakeShell()
+            val session = FakeSession(shell, execHandler = sendLifecycleExecHandler())
+            val client = RealTmuxClient(session, scope)
+            try {
+                client.connect()
+                val response = withTimeout(ASYNC_AWAIT_TIMEOUT_MS) {
+                    client.sendLifecycleViaExec("rename-session -t 'work' 'renamed'")
+                }
+                assertFalse("a normal mutation must not be an error", response.isError)
+                assertTrue("rename-session prints nothing on success", response.output.isEmpty())
+                assertEquals(
+                    "tmux rename-session -t 'work' 'renamed'",
+                    session.execCommands.single { it.contains("rename-session") },
+                )
+            } finally {
+                client.close()
+            }
+        }
+
+    @Test
+    fun `sendLifecycleViaExec bounds itself and throws within the short ceiling on a wedged exec`() =
+        runBlocking {
+            // Issue #1496: a genuinely wedged/half-open transport (the exec never
+            // returns) must surface a TmuxClientException within the caller's
+            // SHORT ceiling, not hang to the full command ceiling — so a
+            // dashboard action against a dead link fails fast.
+            val shell = FakeShell()
+            val neverReturns = CompletableDeferred<ExecResult>()
+            val session = FakeSession(shell, execHandler = { neverReturns.await() })
+            val client = RealTmuxClient(session, scope, commandTimeoutMs = 30_000L)
+            try {
+                client.connect()
+                val startedAtMs = System.currentTimeMillis()
+                val thrown = runCatching {
+                    withTimeout(5_000) {
+                        client.sendLifecycleViaExec("kill-session -t 'work'", timeoutMs = 250L)
+                    }
+                }.exceptionOrNull()
+                val elapsedMs = System.currentTimeMillis() - startedAtMs
+                assertTrue(
+                    "a wedged lifecycle exec must surface a TmuxClientException from " +
+                        "the short ceiling, not hang to the command ceiling (was $thrown)",
+                    thrown is TmuxClientException,
+                )
+                assertTrue(
+                    "the action must time out within ~the short ceiling (elapsed ${elapsedMs}ms)",
+                    elapsedMs < 5_000L,
+                )
+                neverReturns.cancel()
+            } finally {
+                client.close()
+            }
+        }
+
+    /**
+     * Issue #1496 RED driver: connect, wedge the shared `-CC` control channel
+     * with a never-answered command (modelling a reply stuck behind a live agent
+     * `%output` burst on the one sshj reader), then assert the OLD path
+     * [RealTmuxClient.sendCommand] on [sessionCommand] does NOT complete within a
+     * generous budget — it is wedged behind the held sendMutex. This is the
+     * reproduced freeze for each of the five session-management round-trips.
+     */
+    private suspend fun assertSendCommandWedgesDuringCcWedge(sessionCommand: String) {
+        val shell = FakeShell()
+        val session = FakeSession(shell, execHandler = sendLifecycleExecHandler())
+        val client = RealTmuxClient(session, scope, commandTimeoutMs = 30_000L)
+        try {
+            client.connect()
+            withTimeout(2_000) {
+                while (shell.stdinBytes().isEmpty()) { yield(); delay(10) }
+            }
+            shell.resetStdin()
+
+            // Wedge `-CC`: this command never gets a `%begin`/`%end` reply (the
+            // FakeShell never answers), modelling a reply stuck behind a
+            // sustained `%output` burst on the single sshj reader. It holds the
+            // sendMutex.
+            val wedger = scope.async { runCatching { client.sendCommand("list-clients") } }
+            withTimeout(2_000) {
+                while (!shell.stdinAsString().contains("list-clients")) { yield(); delay(10) }
+            }
+
+            val completed = withTimeoutOrNull(1_500) {
+                client.sendCommand(sessionCommand)
+            }
+            assertNull(
+                "BUG REPRO: '$sessionCommand' on the shared -CC sendCommand must " +
+                    "wedge behind the held control channel (it returned $completed)",
+                completed,
+            )
+            wedger.cancel()
+        } finally {
+            client.close()
+        }
+    }
+
+    /**
+     * Issue #1496 GREEN driver: same held-`-CC` wedge as the RED driver, but
+     * [sessionCommand] rides [RealTmuxClient.sendLifecycleViaExec] on the
+     * dedicated exec channel and returns WELL under the `-CC` mutex ceiling —
+     * proving it did not wait on the wedged sendMutex. Asserts the mutation is a
+     * non-error empty response, that the exec carried the command verbatim (via
+     * [expectExecEquals]), and that it never reached the wedged `-CC` stdin.
+     */
+    private suspend fun assertSendLifecycleViaExecCompletesDuringCcWedge(
+        sessionCommand: String,
+        expectExecEquals: String,
+    ) {
+        val shell = FakeShell()
+        val session = FakeSession(shell, execHandler = sendLifecycleExecHandler())
+        val client = RealTmuxClient(session, scope, commandTimeoutMs = 30_000L)
+        try {
+            client.connect()
+            withTimeout(2_000) {
+                while (shell.stdinBytes().isEmpty()) { yield(); delay(10) }
+            }
+            shell.resetStdin()
+
+            val wedger = scope.async { runCatching { client.sendCommand("list-clients") } }
+            withTimeout(2_000) {
+                while (!shell.stdinAsString().contains("list-clients")) { yield(); delay(10) }
+            }
+
+            val startedAtMs = System.currentTimeMillis()
+            val response = withTimeout(5_000) {
+                client.sendLifecycleViaExec(sessionCommand)
+            }
+            val elapsedMs = System.currentTimeMillis() - startedAtMs
+
+            assertFalse("the mutation must succeed during a -CC burst", response.isError)
+            assertTrue(
+                "a mutation prints nothing on success (was ${response.output})",
+                response.output.isEmpty(),
+            )
+            assertTrue(
+                "the mutation must complete well under the -CC mutex ceiling " +
+                    "(elapsed ${elapsedMs}ms) proving it did not wait on the wedged " +
+                    "-CC sendMutex",
+                elapsedMs < 2_000L,
+            )
+            assertTrue(
+                "the session command must ride the exec lane verbatim " +
+                    "(exec commands were ${session.execCommands})",
+                session.execCommands.contains(expectExecEquals),
+            )
+            assertFalse(
+                "the session command must NOT be written to the wedged -CC shell",
+                shell.stdinAsString().contains(sessionCommand.substringBefore(' ')),
+            )
+            wedger.cancel()
+        } finally {
+            client.close()
+        }
+    }
+
+    private fun sendLifecycleExecHandler(
+        stdout: String = "",
+        exitCode: Int = 0,
+        stderr: String = "",
+        delayMs: Long = 0L,
+    ): suspend (String) -> ExecResult = { _ ->
+        if (delayMs > 0L) delay(delayMs)
+        // A mutation prints nothing on success; a `list-sessions` read returns
+        // its rows via [stdout]; a non-zero exit carries stderr.
+        ExecResult(stdout = stdout, stderr = stderr, exitCode = exitCode)
+    }
+
     /**
      * Issue #1460 shared driver: connect, wedge the shared `-CC` control channel
      * with a never-answered command (modelling a reply stuck behind a live agent


### PR DESCRIPTION
Closes #1496 — Codex-freeze transport residual (sibling of the merged #1488).

The five user-interactive session-management round-trips — in-session **Rename**, dashboard **Create/Rename/Kill**, and the dashboard **list-sessions poll** — rode the shared `-CC` control channel and head-of-line-blocked ~30–40s behind a live Codex `%output` burst. New `TmuxClient.sendLifecycleViaExec` runs `tmux <cmd>` on the dedicated `SshSession.exec` lane; all five sites route through it and the `-CC` `sendCommand` production path is **deleted** (hard-cut, D22). Command strings + error semantics unchanged; poll stays bounded.

**Reviewer:** APPROVED — independently drove red→green (neutralized exec routing → the four lifecycle tests fail with `TimeoutCancellationException`; restored → pass), all **five** call sites covered under a saturated `-CC`, hard-cut confirmed (no production `sendCommand` remains for these), behavior-preserving, adjacency clean (doesn't touch #1488/#1489).
**Local gate (integration worktree off main 90808c44):** VM ratchet OK (17621→**17617**, shrinks), file-size improved, `git diff --check` clean; `:shared:core-tmux:…TmuxClientExecLane` + `:app:…SessionsDashboardViewModel/TmuxSessionControlClient` BUILD SUCCESSFUL.