### PR TITLE
host-update: add --refresh to uv tool install to bust stale index cache (#1490)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/bootstrap/HostBootstrapScenarioSuiteTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/bootstrap/HostBootstrapScenarioSuiteTest.kt
@@ -148,7 +148,7 @@ class HostBootstrapScenarioSuiteTest {
         compose.onNodeWithText("PocketShell CLI update failed", substring = true).assertExists()
         compose.onNodeWithText("fixture refused upgrade", substring = true).assertExists()
         compose.onNodeWithText(
-            "uv tool install --upgrade --exclude-newer 2099-12-31 pocketshell",
+            "uv tool install --refresh --upgrade --exclude-newer 2099-12-31 pocketshell",
             substring = true,
         ).assertExists()
         compose.onNodeWithText("Path: /usr/local/bin/pocketshell", substring = true).assertExists()
@@ -235,7 +235,7 @@ class HostBootstrapScenarioSuiteTest {
         compose.onNodeWithText("Host setup needed").assertExists()
         assertSetupRows("pocketshell")
         compose.onNodeWithText(
-            "uv tool install --exclude-newer 2099-12-31 pocketshell or pipx install pocketshell",
+            "uv tool install --refresh --exclude-newer 2099-12-31 pocketshell or pipx install pocketshell",
         ).assertExists()
         capture("02-unsupported-manual-setup")
         compose.onNodeWithTag(HOST_BOOTSTRAP_INSTALL_ALL_TAG).assertExists().performClick()

--- a/app/src/main/java/com/pocketshell/app/bootstrap/HostBootstrapSheet.kt
+++ b/app/src/main/java/com/pocketshell/app/bootstrap/HostBootstrapSheet.kt
@@ -454,7 +454,7 @@ private fun FailedContent(hostName: String, message: String, onClose: () -> Unit
     SheetColumn {
         SheetHeader(
             title = "Install failed",
-            subtitle = "$hostName · the package manager reported an error.",
+            subtitle = hostBootstrapFailedSubtitle(hostName, message),
         )
         Spacer(modifier = Modifier.height(PocketShellSpacing.md))
         Box(
@@ -491,6 +491,26 @@ private fun FailedContent(hostName: String, message: String, onClose: () -> Unit
             )
         }
     }
+}
+
+/**
+ * Issue #1490: the failure sheet subtitle must reflect the ACTUAL outcome. The
+ * old hard-coded "the package manager reported an error." was wrong for the
+ * exit-0 no-op path ([cliUpdateNoChangeMessage]) — the installer reported
+ * *success*, it just found nothing newer, so telling the user the package
+ * manager errored is misleading. Detect the no-change no-op by the message
+ * marker and give an honest subtitle; every other failure keeps the
+ * package-manager-error phrasing.
+ */
+internal fun hostBootstrapFailedSubtitle(hostName: String, message: String): String {
+    val noChange = message.contains("did not change the installed version") ||
+        message.contains("found nothing newer to install")
+    val reason = if (noChange) {
+        "the update ran but found nothing newer to install."
+    } else {
+        "the package manager reported an error."
+    }
+    return "$hostName · $reason"
 }
 
 private fun bootstrapPromptText(state: HostBootstrapSheetState.Prompt): String {

--- a/app/src/main/java/com/pocketshell/app/bootstrap/HostBootstrapper.kt
+++ b/app/src/main/java/com/pocketshell/app/bootstrap/HostBootstrapper.kt
@@ -96,6 +96,16 @@ internal fun uvToolInstallCommand(tool: BootstrapTool, upgrade: Boolean): String
 internal fun uvToolInstallArgs(tool: BootstrapTool, upgrade: Boolean): String =
     buildString {
         append("tool install")
+        // Issue #1490: `--refresh` forces uv to re-fetch the package index +
+        // metadata instead of resolving from a cache that predates the new
+        // publish. Without it, `uv tool install --upgrade` resolves the stale
+        // cache, reports success, and leaves the OLD version installed (the
+        // maintainer's "found nothing newer to install" no-op) even with the
+        // exclude-newer cap already lifted. Scoped to pocketshell (the only
+        // fast-moving tool we install) alongside the exclude-newer override.
+        if (tool == BootstrapTool.Pocketshell) {
+            append(" --refresh")
+        }
         if (upgrade) append(" --upgrade")
         if (tool == BootstrapTool.Pocketshell) {
             append(" $UV_EXCLUDE_NEWER_FLAG")

--- a/app/src/main/java/com/pocketshell/app/projects/AgentLaunchVersionCheck.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/AgentLaunchVersionCheck.kt
@@ -52,10 +52,16 @@ object AgentLaunchVersionCheck {
      * [com.pocketshell.app.bootstrap.UV_EXCLUDE_NEWER_FLAG] lifts the cap for the
      * WHOLE tool-install resolution — pocketshell + its entire pinned closure —
      * leaving the user's reproducibility setting intact for everything else.
+     *
+     * Issue #1490 adds `--refresh`: even with the cap lifted, `uv tool install
+     * --upgrade` resolves from a stale index/resolver cache that predates the new
+     * publish and reports success while leaving the old version installed (the
+     * maintainer's "found nothing newer to install" no-op). `--refresh` re-fetches
+     * the index + metadata so a freshly-published release is seen.
      * `pipx upgrade` / `pip install -U` are not affected by uv's cutoff.
      */
     const val UPDATE_COMMAND: String =
-        "uv tool install --upgrade $UV_EXCLUDE_NEWER_FLAG pocketshell"
+        "uv tool install --refresh --upgrade $UV_EXCLUDE_NEWER_FLAG pocketshell"
 
     /**
      * The server-side wrapper line the agent-launch flow types into a fresh

--- a/app/src/main/java/com/pocketshell/app/projects/HostPocketshellUpgrade.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/HostPocketshellUpgrade.kt
@@ -25,11 +25,13 @@ import kotlinx.coroutines.withTimeoutOrNull
  *    non-interactive SSH exec misses `~/.local/bin`, where uv/pipx/pip drop
  *    their shims).
  * 2. PROBES which installer owns `pocketshell` and runs the matching upgrade:
- *    - `uv tool list` mentions `pocketshell` → `uv tool install --upgrade
- *      --exclude-newer 2099-12-31 pocketshell` (the #779/#1492 override that
+ *    - `uv tool list` mentions `pocketshell` → `uv tool install --refresh
+ *      --upgrade --exclude-newer 2099-12-31 pocketshell` (the #779/#1492 override
  *      lifts uv's global `exclude-newer` cap for the WHOLE resolution so a
  *      sibling pin like `quse` past the cap cannot make the upgrade a silent
- *      no-op — mirrors [PayloadVersionCheck.UPDATE_COMMAND]).
+ *      no-op, and `--refresh` (#1490) busts uv's stale index/resolver cache so a
+ *      freshly-published release is visible — mirrors
+ *      [PayloadVersionCheck.UPDATE_COMMAND]).
  *    - else `pipx` present → `pipx upgrade pocketshell`.
  *    - else `pip`/`pip3` present → `pip install -U pocketshell`.
  *    - else exit `127` so the caller surfaces "no installer found".
@@ -152,7 +154,7 @@ public class HostPocketshellUpgrade {
             // pocketshell would wrongly try uv.
             append("if command -v uv >/dev/null 2>&1 && ")
             append("uv tool list 2>/dev/null | grep -qi '^pocketshell\\b'; then ")
-            append("exec uv tool install --upgrade ")
+            append("exec uv tool install --refresh --upgrade ")
             append("$UV_EXCLUDE_NEWER_FLAG pocketshell; ")
             // pipx next.
             append("elif command -v pipx >/dev/null 2>&1; then ")

--- a/app/src/main/java/com/pocketshell/app/projects/PayloadVersionCheck.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/PayloadVersionCheck.kt
@@ -37,10 +37,12 @@ object PayloadVersionCheck {
      * — the global [com.pocketshell.app.bootstrap.UV_EXCLUDE_NEWER_FLAG] lifts the
      * host's `uv` `exclude-newer` cap for the WHOLE tool-install resolution
      * (issue #779 for pocketshell, widened by #1492 to cover its pinned siblings
-     * like `quse`) so the upgrade is never a silent no-op.
+     * like `quse`), and `--refresh` (issue #1490) busts uv's stale index/resolver
+     * cache so a freshly-published release is visible — together they make the
+     * upgrade never a silent no-op.
      */
     const val UPDATE_COMMAND: String =
-        "uv tool install --upgrade $UV_EXCLUDE_NEWER_FLAG pocketshell"
+        "uv tool install --refresh --upgrade $UV_EXCLUDE_NEWER_FLAG pocketshell"
 
     /**
      * The verdict of comparing a payload-carried [hostVersion] against the

--- a/app/src/test/java/com/pocketshell/app/bootstrap/HostBootstrapperTest.kt
+++ b/app/src/test/java/com/pocketshell/app/bootstrap/HostBootstrapperTest.kt
@@ -834,17 +834,49 @@ class HostBootstrapperTest {
     }
 
     @Test
+    fun hostBootstrapFailedSubtitle_reflectsTheActualOutcome_notAlwaysAnError() {
+        // Issue #1490: the exit-0 no-op (installer reported success but found
+        // nothing newer) must NOT be described as "the package manager reported
+        // an error" — that is misleading. It gets an honest no-change subtitle.
+        val noChange = cliUpdateNoChangeMessage(
+            mismatch = ToolStatus.VersionMismatch(
+                path = "/home/u/.local/bin/pocketshell",
+                currentVersion = "0.4.24",
+                expectedVersion = "0.4.28",
+            ),
+            installer = PythonToolInstaller.Uv,
+        )
+        val noChangeSubtitle = hostBootstrapFailedSubtitle("hetzner", noChange)
+        assertTrue(noChangeSubtitle.contains("found nothing newer to install"))
+        assertFalse(noChangeSubtitle.contains("the package manager reported an error"))
+        assertTrue(noChangeSubtitle.contains("hetzner"))
+
+        // A real installer error keeps the package-manager-error phrasing.
+        val realError = cliUpdateFailureMessage(
+            mismatch = null,
+            installer = PythonToolInstaller.Uv,
+            stderr = "error: failed to build pocketshell",
+            exitCode = 1,
+        )
+        val errorSubtitle = hostBootstrapFailedSubtitle("hetzner", realError)
+        assertTrue(errorSubtitle.contains("the package manager reported an error"))
+    }
+
+    @Test
     fun uvPocketshellCommands_includeGlobalExcludeNewerOverride() {
         // Issue #1492: the cap must be lifted for the WHOLE resolution (global
         // `--exclude-newer`), NOT just the pocketshell package
         // (`--exclude-newer-package pocketshell=…`), or a release that pins a
         // sibling (quse) past the host's cap silently no-ops.
+        // Issue #1490: `--refresh` busts uv's stale index/resolver cache so a
+        // freshly-published release is visible (else the upgrade exits 0 having
+        // "found nothing newer to install" — the reported no-op).
         assertEquals(
-            "uv tool install --exclude-newer 2099-12-31 pocketshell",
+            "uv tool install --refresh --exclude-newer 2099-12-31 pocketshell",
             uvToolInstallCommand(BootstrapTool.Pocketshell, upgrade = false),
         )
         assertEquals(
-            "uv tool install --upgrade --exclude-newer 2099-12-31 pocketshell",
+            "uv tool install --refresh --upgrade --exclude-newer 2099-12-31 pocketshell",
             uvToolInstallCommand(BootstrapTool.Pocketshell, upgrade = true),
         )
         // The narrow per-package override that broke on sibling pins must be gone.
@@ -1310,7 +1342,7 @@ class HostBootstrapperTest {
 
         assertEquals(InstallResult.Success, result)
         assertTrue(session.recorded.contains(pathAware("'/opt/homebrew/bin/uv' $UV_POCKETSHELL_UPGRADE_ARGS")))
-        assertTrue(session.recorded.none { it.contains("PATH=") && it.contains("; uv tool install --upgrade") })
+        assertTrue(session.recorded.none { it.contains("PATH=") && it.contains("; uv tool install --refresh --upgrade") })
     }
 
     @Test
@@ -1495,9 +1527,9 @@ class HostBootstrapperTest {
 
     private companion object {
         const val UV_POCKETSHELL_INSTALL_ARGS: String =
-            "tool install --exclude-newer 2099-12-31 pocketshell"
+            "tool install --refresh --exclude-newer 2099-12-31 pocketshell"
         const val UV_POCKETSHELL_UPGRADE_ARGS: String =
-            "tool install --upgrade --exclude-newer 2099-12-31 pocketshell"
+            "tool install --refresh --upgrade --exclude-newer 2099-12-31 pocketshell"
         const val UV_POCKETSHELL_UPGRADE_COMMAND: String = "uv $UV_POCKETSHELL_UPGRADE_ARGS"
         const val DEFAULT_BOOTSTRAP_PATH: String =
             "/home/u/.local/bin:/home/u/bin:/home/u/.cargo/bin:/usr/local/bin:/usr/bin:/bin"

--- a/app/src/test/java/com/pocketshell/app/projects/AgentLaunchVersionCheckTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/AgentLaunchVersionCheckTest.kt
@@ -101,7 +101,10 @@ class AgentLaunchVersionCheckTest {
             "must not use the narrow per-package override that broke on sibling pins",
             hint.contains("--exclude-newer-package"),
         )
-        assertTrue(hint.contains("uv tool install --upgrade"))
+        assertTrue(hint.contains("uv tool install --refresh --upgrade"))
+        // Issue #1490: --refresh busts uv's stale index cache so a freshly
+        // published release is visible (else the upgrade is a silent no-op).
+        assertTrue(hint.contains("--refresh"))
         // The raw Click jargon must NOT leak into the user-facing hint.
         assertFalse(hint.contains("No such command"))
     }

--- a/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelHostUpgradeTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelHostUpgradeTest.kt
@@ -206,6 +206,10 @@ class FolderListViewModelHostUpgradeTest {
             "uv arm must NOT use the narrow per-package override that broke on sibling pins (#1492)",
             cmd.contains("--exclude-newer-package"),
         )
+        assertTrue(
+            "uv arm must pass --refresh so a stale index/resolver cache cannot no-op the upgrade (#1490)",
+            cmd.contains("--refresh"),
+        )
         assertTrue("must fall back to pipx", cmd.contains("pipx upgrade pocketshell"))
         assertTrue("must fall back to pip", cmd.contains("pip install -U pocketshell"))
         assertTrue("must exit 127 when no installer is found", cmd.contains("exit 127"))

--- a/app/src/test/java/com/pocketshell/app/projects/HostUpdateCommandExcludeNewerTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/HostUpdateCommandExcludeNewerTest.kt
@@ -4,6 +4,7 @@ import com.pocketshell.app.bootstrap.BootstrapTool
 import com.pocketshell.app.bootstrap.uvToolInstallCommand
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
@@ -91,6 +92,25 @@ class HostUpdateCommandExcludeNewerTest {
                     "Command: $command",
                 targetVersion,
                 resolved,
+            )
+        }
+    }
+
+    @Test
+    fun everyHostUpdateCommand_refreshesTheUvIndexCache() {
+        // Issue #1490: even with the exclude-newer cap lifted, `uv tool install
+        // --upgrade` resolves from a STALE index/resolver cache that predates the
+        // new publish — it reports success and leaves the old version installed
+        // (the maintainer's "found nothing newer to install" no-op on hetzner).
+        // `--refresh` forces uv to re-fetch the index + package metadata so a
+        // freshly-published release is visible. Guard the WHOLE class (all four
+        // build sites) so no call site can silently drop it and re-open the bug.
+        for ((site, command) in allEmittedUpdateCommands()) {
+            assertTrue(
+                "$site must pass --refresh so `uv tool install` busts its stale " +
+                    "index/resolver cache and sees a freshly-published pocketshell " +
+                    "release (#1490) — command: $command",
+                command.contains("--refresh"),
             )
         }
     }

--- a/app/src/test/java/com/pocketshell/app/projects/PayloadVersionCheckTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/PayloadVersionCheckTest.kt
@@ -87,5 +87,8 @@ class PayloadVersionCheckTest {
         assertTrue(prompt.contains("0.4.9"))
         assertTrue(prompt.contains("0.4.12"))
         assertTrue(prompt.contains(PayloadVersionCheck.UPDATE_COMMAND))
+        // Issue #1490: the command must carry --refresh so a stale uv index
+        // cache cannot silently no-op the host update.
+        assertTrue(PayloadVersionCheck.UPDATE_COMMAND.contains("--refresh"))
     }
 }

--- a/tests/docker/bootstrap-bin/uv
+++ b/tests/docker/bootstrap-bin/uv
@@ -4,15 +4,20 @@ set -eu
 if [ "${1:-}" = "tool" ] && [ "${2:-}" = "install" ]; then
   action="install"
   shift 2
-  if [ "${1:-}" = "--upgrade" ]; then
-    action="install --upgrade"
-    shift
-  fi
   # Consume any leading flags (order-independent) before the positional package:
-  #   --exclude-newer <date>          global pin (production, post-#1492) — 2 tokens
-  #   --exclude-newer-package <p=date>  legacy per-package pin (pre-#1492)  — 2 tokens
+  #   --refresh                         bust the stale index cache (#1490) — 1 token
+  #   --upgrade                         upgrade an installed tool            — 1 token
+  #   --exclude-newer <date>            global pin (production, post-#1492)  — 2 tokens
+  #   --exclude-newer-package <p=date>  legacy per-package pin (pre-#1492)   — 2 tokens
   while true; do
     case "${1:-}" in
+      --upgrade)
+        action="install --upgrade"
+        shift
+        ;;
+      --refresh)
+        shift
+        ;;
       --exclude-newer|--exclude-newer-package)
         shift 2
         ;;
@@ -23,7 +28,7 @@ if [ "${1:-}" = "tool" ] && [ "${2:-}" = "install" ]; then
   done
   package="${1:-}"
   if [ -z "$package" ]; then
-    printf 'uv bootstrap fixture supports: tool install [--upgrade] [--exclude-newer <date>] [--exclude-newer-package <package=date>] <package>\n' >&2
+    printf 'uv bootstrap fixture supports: tool install [--refresh] [--upgrade] [--exclude-newer <date>] [--exclude-newer-package <package=date>] <package>\n' >&2
     exit 64
   fi
   target_dir="${HOME}/.local/bin"
@@ -74,5 +79,5 @@ if [ "${1:-}" = "tool" ] && [ "${2:-}" = "upgrade" ] && [ -n "${3:-}" ]; then
   exit 0
 fi
 
-printf 'uv bootstrap fixture supports: tool install [--upgrade] [--exclude-newer <date>] [--exclude-newer-package <package=date>] <package> and managed tool upgrade <package>\n' >&2
+printf 'uv bootstrap fixture supports: tool install [--refresh] [--upgrade] [--exclude-newer <date>] [--exclude-newer-package <package=date>] <package> and managed tool upgrade <package>\n' >&2
 exit 64


### PR DESCRIPTION
Closes #1490 — real maintainer dogfood blocker: the in-app host-updater no-ops ("found nothing newer", exit 0, version unchanged) because uv resolves the upgrade from a **stale index cache** that predates the new publish. #1492 switched to the global `--exclude-newer` but did NOT add `--refresh`, so this class stayed live.

**Fix:** all five emitters now run `uv tool install --refresh --upgrade --exclude-newer 2099-12-31 pocketshell` — `--refresh` forces a re-fetch of index+metadata (verified in the spike across uv 0.5.0–0.10.11), well within `UPGRADE_TIMEOUT_MS`. Kept global `--exclude-newer` (no `--exclude-newer-package`, D22 hard-cut). The fake `uv` fixture now consumes `--refresh` (avoids re-breaking the setup-detection gate — the #1501 lesson), and the failure subtitle no longer mislabels the exit-0 no-op as a package-manager error.

**Reviewer:** APPROVED — independently drove red→green (neutralized `--refresh` → class test fails; restored → pass), all five emitters covered, fixture-regression guard clean (exit 0 all orders, upgrade-failure still exits 23, no #1501 re-break), hard-cut confirmed, subtitle fix covered, **3662 tests, 0 failures**.
**Local gate:** git diff --check clean; focused host-update tests BUILD SUCCESSFUL; fixture parses `--refresh` (exit 0 refresh+upgrade / reordered / init-install); fixture git mode unchanged (100644, chmod'd by Dockerfile.bootstrap).