### PR TITLE
release: bump to v0.4.29 (versionCode 76)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,8 +65,8 @@ android {
         applicationId = "com.pocketshell.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 75
-        versionName = "0.4.28"
+        versionCode = 76
+        versionName = "0.4.29"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/tools/pocketshell/pyproject.toml
+++ b/tools/pocketshell/pyproject.toml
@@ -8,7 +8,7 @@ name = "pocketshell"
 # scripts/check-pypi-version.sh enforces this; .github/workflows/build.yml
 # runs that check before publishing to PyPI. See
 # tools/pocketshell/README.md ("Release flow") for the bump procedure.
-version = "0.4.28"
+version = "0.4.29"
 description = "Unified server-side Python utility for the PocketShell Android client."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Version bump 0.4.28 → **0.4.29** (versionCode 75 → 76), app + tools/pocketshell in lockstep (coupling guard green).

Ships the post-v0.4.28 merges — all reviewer-approved and merged today:
- **#1488** share picker: all four `-CC` resolution calls → exec lane (Codex-freeze H2)
- **#1489** main-looper feedLock backstop never plain-blocks (Codex-freeze deadlock residual)
- **#1496** session rename/create/kill/poll → exec lane (Codex-freeze transport)
- **#1490** host-updater `--refresh` (fixes the 'found nothing newer' no-op #1492 missed)
- **#1458** CI emulator-gate single CLEAN/RE-RUN/RED verdict
- **#1353 R4** render-heal fold

Release-emulator-validation gate runs on `main` after this merges; tag pushed from validated `main`.