### PR TITLE
render-heal: bound the single-flight mutex + watchdog tick (#1494)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/tmux/RenderHealCoordinator.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/RenderHealCoordinator.kt
@@ -25,42 +25,151 @@ import kotlinx.coroutines.sync.Mutex
  *
  * ## Semantics: SERIALIZE per pane (queue, never drop) — NOT coalesce
  *
- * Each pane id owns its own [Mutex]. A heal takes the pane's mutex for the whole
- * close→capture→apply→open window, so a second heal for the SAME pane WAITS and then runs
- * its own full window afterwards. We deliberately QUEUE rather than COALESCE (drop a
- * concurrent duplicate): a queued heal always performs its own fresh `capture-pane`, so no
- * heal that could have recovered a pane is ever dropped — the #1-critical guarantee is "never
- * leave a pane black", and the cost is at most one bounded capture round-trip of added
- * latency for the queued heal (the capture is bounded by the seed timeout / the force-mode
- * retry cap, so the lock is always released and there is no deadlock). Different panes hold
- * DIFFERENT mutexes, so they still heal fully concurrently (this is per-pane, never a global
- * lock). R4 (event-driven reconciler) may revisit coalescing once the six launchers collapse
- * into one loop; for R3 the safe, no-drop serialization is the correct minimal guard.
+ * Each pane id owns its own [Mutex]. A heal takes the pane's lock for the whole
+ * close→capture→apply→open window via [withPaneHealLock], so a second heal for the SAME pane
+ * WAITS and then runs its own full window afterwards. We deliberately QUEUE rather than
+ * COALESCE (drop a concurrent duplicate): a queued heal always performs its own fresh
+ * `capture-pane`, so no heal that could have recovered a pane is ever dropped — the
+ * #1-critical guarantee is "never leave a pane black". Different panes hold DIFFERENT locks,
+ * so they still heal fully concurrently (this is per-pane, never a global lock).
  *
- * Thread-safety: [paneMutexes] is a [ConcurrentHashMap] and [paneHealMutex] uses
- * [ConcurrentHashMap.getOrPut] so two launchers racing to heal a never-before-seen pane still
- * observe the SAME mutex instance (a lost-update on the map would defeat the whole guard).
- * Pane ids (`%N`) are small and reused across a session, so the map stays naturally bounded;
- * [forget]/[reset] are provided for explicit eviction and test teardown.
+ * ## Issue #1494 — the single-flight lock must never park a heal (or its supervisor) FOREVER
+ *
+ * The heal's `capture-pane` ceiling ([SEED_CAPTURE_TIMEOUT_MS]) is `withTimeoutOrNull` —
+ * **cooperative**. If the exec-lane read blocks a `Dispatchers.IO` thread uninterruptibly (a
+ * half-open TCP socket with no read timeout, no cancellation cooperation), that ceiling never
+ * trips: the heal body never returns and the pane's single-flight lock is held INDEFINITELY.
+ * Before #1494 every subsequent heal for that pane parked on `withLock` forever, so ONE
+ * uninterruptible capture wedged not just the pane but its own supervisor (the watchdog whose
+ * next tick's heal parked on the still-held lock).
+ *
+ * [withPaneHealLock] bounds that: a heal that finds the pane's lock held **past
+ * [HELD_TOO_LONG_MS]** (an order of magnitude above the longest legitimate heal — the force-
+ * mode retry budget is ≈10.5 s) treats the holder as WEDGED and **force-resets** the single-
+ * flight: it swaps in a fresh lock for the pane so THIS heal, and every future heal, proceeds
+ * instead of parking forever. The orphaned wedged heal keeps its old lock instance; its
+ * eventual unlock is harmless. A merely SLOW-BUT-ALIVE holder (still within the bound) is
+ * WAITED for, never force-reset, so single-flight is preserved for the common case (the
+ * #1484 clobber-race guarantee is untouched — see [RenderHealSingleFlightTest]). The watchdog
+ * pairs this with a per-tick `withTimeout` ([RENDER_HEAL_WATCHDOG_TICK_TIMEOUT_MS]) so the
+ * loop keeps advancing even while one heal is wedged.
+ *
+ * Thread-safety: [locks] is a [ConcurrentHashMap] keyed per pane id; [PaneHealLock] instances
+ * are obtained via [ConcurrentHashMap.getOrPut] so two launchers racing to heal a never-before-
+ * seen pane observe the SAME instance, and the force-reset swap is an atomic
+ * [ConcurrentHashMap.replace] CAS so only the first replacer wins (a loser re-enters on the
+ * live lock — never two heal bodies under two live instances). Pane ids (`%N`) are small and
+ * reused across a session, so the map stays naturally bounded; [forget]/[reset] are provided
+ * for explicit eviction and test teardown.
+ *
+ * @param nowMs monotonic millisecond clock used to measure how long a holder has held the
+ *   single-flight. Defaults to [System.nanoTime]-derived monotonic ms (no wall-clock jumps, no
+ *   Android dependency). Injectable so a virtual-time test can drive the held-too-long bound.
  */
-internal class RenderHealCoordinator {
+internal class RenderHealCoordinator(
+    private var nowMs: () -> Long = { System.nanoTime() / 1_000_000L },
+) {
 
-    private val paneMutexes = ConcurrentHashMap<String, Mutex>()
+    private class PaneHealLock {
+        val mutex = Mutex()
+
+        /** [nowMs] at which the current holder acquired, or [NOT_HELD] when free / externally held. */
+        @Volatile
+        var heldSinceMs: Long = NOT_HELD
+    }
+
+    private val locks = ConcurrentHashMap<String, PaneHealLock>()
 
     /**
      * The single-flight [Mutex] for [paneId], created on first use. Concurrent callers for
      * the same pane observe the same instance (atomic [ConcurrentHashMap.getOrPut]); callers
-     * for different panes observe distinct instances (heal concurrently).
+     * for different panes observe distinct instances (heal concurrently). This is the raw lock
+     * accessor used by the single-flight ownership tests; production heals go through
+     * [withPaneHealLock] so they inherit the #1494 held-too-long force-reset.
      */
-    fun paneHealMutex(paneId: String): Mutex = paneMutexes.getOrPut(paneId) { Mutex() }
+    fun paneHealMutex(paneId: String): Mutex = locks.getOrPut(paneId) { PaneHealLock() }.mutex
 
-    /** Drop the single-flight mutex for a pane that no longer exists. */
-    fun forget(paneId: String) {
-        paneMutexes.remove(paneId)
+    /**
+     * Issue #1494 — run [block] under [paneId]'s per-pane single-flight, BOUNDED so a wedged
+     * holder can never permanently reject future heals.
+     *
+     *  - Uncontended → acquire and run.
+     *  - Contended by a SLOW-BUT-ALIVE holder (held < [HELD_TOO_LONG_MS]) → WAIT for it (queue,
+     *    single-flight preserved). The caller's own `withTimeout` (the watchdog tick) bounds
+     *    this wait so the supervisor loop is never parked uninterruptibly here.
+     *  - Contended by a WEDGED holder (held ≥ [HELD_TOO_LONG_MS]) → FORCE-RESET: swap in a fresh
+     *    lock for the pane and run under it, so this heal — and every future heal — proceeds
+     *    instead of parking forever. The orphaned holder keeps its old instance.
+     */
+    suspend fun <T> withPaneHealLock(paneId: String, block: suspend () -> T): T {
+        while (true) {
+            val entry = locks.getOrPut(paneId) { PaneHealLock() }
+            if (!entry.mutex.tryLock()) {
+                val since = entry.heldSinceMs
+                val heldTooLong = since != NOT_HELD && (nowMs() - since) >= HELD_TOO_LONG_MS
+                if (heldTooLong) {
+                    // The holder is wedged past the bound. Swap in a fresh lock (atomic CAS so
+                    // only the first replacer wins) and run under it; a loser re-enters the
+                    // loop and acquires the winner's fresh lock.
+                    val fresh = PaneHealLock()
+                    if (locks.replace(paneId, entry, fresh)) {
+                        fresh.mutex.lock() // uncontended
+                        return runHeld(fresh, block)
+                    }
+                    continue
+                }
+                // Slow-but-alive holder: wait for it to release.
+                entry.mutex.lock()
+            }
+            // We now hold entry.mutex. Verify it is still the LIVE lock for the pane: a
+            // concurrent force-reset may have swapped in a new instance while we waited. If so,
+            // drop this orphan and re-enter so the heal body only ever runs under the live lock
+            // (never two bodies under two live instances → no double-run).
+            if (locks[paneId] !== entry) {
+                entry.mutex.unlock()
+                continue
+            }
+            return runHeld(entry, block)
+        }
     }
 
-    /** Test / teardown seam: forget every per-pane mutex. */
+    private suspend fun <T> runHeld(entry: PaneHealLock, block: suspend () -> T): T {
+        entry.heldSinceMs = nowMs()
+        try {
+            return block()
+        } finally {
+            entry.heldSinceMs = NOT_HELD
+            entry.mutex.unlock()
+        }
+    }
+
+    /** Drop the single-flight lock for a pane that no longer exists. */
+    fun forget(paneId: String) {
+        locks.remove(paneId)
+    }
+
+    /** Test / teardown seam: forget every per-pane lock. */
     fun reset() {
-        paneMutexes.clear()
+        locks.clear()
+    }
+
+    /** Test seam: drive the held-too-long clock from a virtual-time scheduler. */
+    @androidx.annotation.VisibleForTesting
+    internal fun setClockForTest(clock: () -> Long) {
+        nowMs = clock
+    }
+
+    companion object {
+        private const val NOT_HELD: Long = Long.MIN_VALUE
+
+        /**
+         * Issue #1494 — how long a heal may hold the per-pane single-flight before a contending
+         * heal treats it as WEDGED and force-resets the lock. Set an order of magnitude above the
+         * longest LEGITIMATE heal so a slow-but-alive heal is never force-reset (single-flight
+         * preserved): the force-mode reseed's worst case is [SEED_CAPTURE_EMPTY_RETRY_ATTEMPTS]
+         * captures at the [SEED_CAPTURE_TIMEOUT_MS] ceiling plus retry delays ≈ 10.5 s; 15 s
+         * cleanly separates "slow-but-alive" from "wedged for minutes on a dead socket".
+         */
+        internal const val HELD_TOO_LONG_MS: Long = 15_000L
     }
 }

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionSupport.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionSupport.kt
@@ -319,6 +319,17 @@ internal const val STALE_RENDER_WATCHDOG_BACKOFF_MAX_DOUBLINGS: Int = 3
 internal const val STALE_RENDER_WATCHDOG_MAX_TICKS: Int = 10_000
 
 /**
+ * Issue #1494 — the per-tick `withTimeout` the stale-render watchdog wraps its heal call in, so
+ * ONE hung capture can never freeze the watchdog LOOP (its own supervisor). Set slightly above
+ * the cooperative `capture-pane` ceiling ([SEED_CAPTURE_TIMEOUT_MS] = 2.5 s) so a healthy or
+ * slow-but-alive heal always completes within it, while a heal wedged on an uninterruptible
+ * exec-lane read is abandoned (scored UNVERIFIED) at this bound and the loop advances to the
+ * next tick. This is the LOOP-liveness half of #1494; the per-pane single-flight force-reset
+ * ([RenderHealCoordinator.HELD_TOO_LONG_MS]) is the future-heal half.
+ */
+internal const val RENDER_HEAL_WATCHDOG_TICK_TIMEOUT_MS: Long = 4_000L
+
+/**
  * Issue #941 (black-screen B1): after a send's submit Enter, wait this long for
  * the agent's `%output` overpaint to land before judging whether the active pane
  * settled partial-black/blank and needs the one-shot send-overpaint heal. Short

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -156,7 +156,6 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.ContinuationInterceptor
 import kotlin.coroutines.coroutineContext
@@ -11308,28 +11307,26 @@ public class TmuxSessionViewModel @Inject constructor(
                         tick = tick,
                         backedOff = stableTicks > 0,
                     )
+                    // Issue #1494 — bound the per-tick heal so one hung capture can't freeze the loop.
                     val outcome = runCatching {
-                        healActivePaneIfStaleRender(client, activePane, refreshGuard)
+                        withTimeoutOrNull(RENDER_HEAL_WATCHDOG_TICK_TIMEOUT_MS) {
+                            healActivePaneIfStaleRender(client, activePane, refreshGuard)
+                        } ?: HealOutcome.Unverified
                     }.getOrDefault(HealOutcome.Unverified)
-                    // Issue #1294 (three-state scoring — the load-bearing fix): score the
-                    // tick by WHICH of the three oracle outcomes it was, never conflating a
-                    // capture FAILURE with a confirmed-healthy tick.
+                    // Issue #1294 (three-state scoring — the load-bearing fix): score the tick by
+                    // WHICH oracle outcome it was, never conflating a capture FAILURE with healthy.
                     //
-                    //  - HEALTHY: the authoritative capture CONFIRMED the render matches tmux.
-                    //    This — and ONLY this — earns the #1219 steady-heat back-off (4s -> 8s
-                    //    -> 16s), even while the pane streams %output (the #1164 "runs warm"
-                    //    lever). Before #1294 a capture FAILURE was scored identically here, so
-                    //    consecutive failures throttled the watchdog to 16s exactly while the
-                    //    pane was black and a Claude burst had the -CC capture mutex wedged.
+                    //  - HEALTHY: the capture CONFIRMED the render matches tmux. This — and ONLY
+                    //    this — earns the #1219 steady-heat back-off (4s->8s->16s), even while the
+                    //    pane streams %output (the #1164 "runs warm" lever). Before #1294 a FAILURE
+                    //    was scored identically, throttling to 16s while the pane was black.
                     //  - HEALED: the oracle found + repaired a real divergence (black / partial-
                     //    black / stale render vs tmux's grid). Snap the cadence back to hot so a
                     //    just-blacked pane is re-checked at 4s (#1138/#1153 heal preservation).
                     //  - UNVERIFIED: the capture could NOT confirm health (timeout / error /
-                    //    empty-on-live-transport / mutex-starved). Keep the HOT cadence — never
-                    //    throttle — so a black pane whose heal captures are wedged keeps retrying
-                    //    at 4s until the mutex frees and the heal lands, instead of backing off
-                    //    to 16s while the user stares at a black pane. Record the streak into the
-                    //    exportable diagnostics (#1175) so an export tells "blind" from "idle".
+                    //    empty-on-live-transport / mutex-starved / #1494 tick-timeout). Keep the HOT
+                    //    cadence — never throttle — so a black pane keeps retrying at 4s. Record the
+                    //    streak into the exportable diagnostics (#1175) so it tells "blind" from "idle".
                     when (outcome) {
                         HealOutcome.Healthy -> {
                             stableTicks += 1
@@ -11736,8 +11733,8 @@ public class TmuxSessionViewModel @Inject constructor(
         // seed-gate (M9) window so a sibling launcher (L1 send / L2 watchdog / L5 reveal) on the
         // SAME pane can't cross into it and open the gate early, clobbering a buffered newer
         // `%output` delta (spike §3 race). Keyed per pane, so different panes heal concurrently.
-        // `withLock` is inline (early returns stay non-local, the mutex ALWAYS unlocks — bounded).
-        renderHealCoordinator.paneHealMutex(pane.paneId).withLock {
+        // Issue #1494 — [withPaneHealLock] force-resets a lock wedged past HELD_TOO_LONG_MS.
+        renderHealCoordinator.withPaneHealLock(pane.paneId) {
             healActivePaneIfStaleRenderLocked(
                 client, pane, refreshGuard, force, recordMilestone, maxAttempts,
             )

--- a/app/src/test/java/com/pocketshell/app/tmux/RenderHealCoordinatorTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/RenderHealCoordinatorTest.kt
@@ -1,9 +1,12 @@
 package com.pocketshell.app.tmux
 
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotSame
 import org.junit.Assert.assertSame
@@ -65,6 +68,89 @@ class RenderHealCoordinatorTest {
         )
 
         coordinator.paneHealMutex("%1").unlock()
+    }
+
+    // -------------------------------------------------------------------------
+    // Issue #1494 — the BOUNDED single-flight: a WEDGED holder must not permanently
+    // reject future heals, but a SLOW-BUT-ALIVE holder must still serialize (no double-run).
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun withPaneHealLockForceResetsAHolderWedgedPastTheBound() = runTest {
+        var clock = 0L
+        val coordinator = RenderHealCoordinator(nowMs = { clock })
+
+        // A heal WEDGES holding the pane's single-flight (models an uninterruptible capture on a
+        // dead socket that never returns and so never releases the lock).
+        val wedge = CompletableDeferred<Unit>()
+        val wedged = launch { coordinator.withPaneHealLock("%1") { wedge.await() } }
+        runCurrent()
+
+        // The holder has now held the lock PAST the bound.
+        clock = RenderHealCoordinator.HELD_TOO_LONG_MS
+        var laterRan = false
+        val later = launch { coordinator.withPaneHealLock("%1") { laterRan = true } }
+        runCurrent()
+
+        assertTrue(
+            "REGRESSION (#1494): a heal whose per-pane single-flight holder is WEDGED past the " +
+                "held-too-long bound must FORCE-RESET the lock and proceed — before #1494 it " +
+                "parked on withLock forever, so one hung capture wedged every future heal.",
+            laterRan,
+        )
+
+        wedged.cancel()
+        later.cancel()
+    }
+
+    @Test
+    fun withPaneHealLockWaitsForASlowButAliveHolderInsteadOfForceResetting() = runTest {
+        var clock = 0L
+        val coordinator = RenderHealCoordinator(nowMs = { clock })
+
+        val holderGate = CompletableDeferred<Unit>()
+        var holderInside = false
+        var laterRan = 0
+        var sawConcurrentDoubleRun = false
+
+        val holder = launch {
+            coordinator.withPaneHealLock("%1") {
+                holderInside = true
+                holderGate.await()
+                holderInside = false
+            }
+        }
+        runCurrent()
+
+        // A second heal arrives while the holder is only briefly held — WELL WITHIN the bound.
+        clock = RenderHealCoordinator.HELD_TOO_LONG_MS - 1
+        val later = launch {
+            coordinator.withPaneHealLock("%1") {
+                if (holderInside) sawConcurrentDoubleRun = true
+                laterRan += 1
+            }
+        }
+        runCurrent()
+
+        assertEquals(
+            "single-flight preserved (#1484): a slow-but-alive holder must be WAITED for, never " +
+                "force-reset — the second heal has not run while the holder is inside its window",
+            0,
+            laterRan,
+        )
+
+        // The holder releases; the queued heal now proceeds — SERIALIZED, never overlapping.
+        holderGate.complete(Unit)
+        runCurrent()
+
+        assertEquals("the queued heal runs exactly once after the holder releases", 1, laterRan)
+        assertFalse(
+            "the force-reset/fallback must NOT double-run a heal that is merely slow-but-alive",
+            sawConcurrentDoubleRun,
+        )
+
+        holder.cancel()
+        later.cancel()
     }
 
     @Test

--- a/app/src/test/java/com/pocketshell/app/tmux/RenderHealTimeoutTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/RenderHealTimeoutTest.kt
@@ -1,0 +1,341 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.app.sessions.ActiveTmuxClients
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.SshLeaseConnector
+import com.pocketshell.core.ssh.SshLeaseManager
+import com.pocketshell.core.ssh.SshLeaseTarget
+import com.pocketshell.core.ssh.SshPortForward
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshShell
+import com.pocketshell.core.tmux.CommandResponse
+import com.pocketshell.core.tmux.TmuxClientFactory
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.currentTime
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+import java.io.InputStream
+
+/**
+ * Issue #1494 — REPRODUCE-FIRST (D33 / G10) proof, on the REAL heal chokepoint through the
+ * production VM path, that ONE uninterruptible capture can no longer wedge the pane AND its
+ * supervisor.
+ *
+ * ## The bug
+ *
+ * The per-pane heal single-flight ([RenderHealCoordinator]) and the stale-render watchdog's
+ * per-tick heal call ([TmuxSessionViewModel.armActivePaneStaleRenderWatchdog]) had NO timeout.
+ * The `capture-pane` ceiling ([SEED_CAPTURE_TIMEOUT_MS]) is `withTimeoutOrNull` — cooperative —
+ * so a capture that blocks a `Dispatchers.IO` thread uninterruptibly (half-open socket, no read
+ * timeout) never trips it: the heal body never returns, the pane's single-flight lock is held
+ * indefinitely, and:
+ *
+ *  - the watchdog LOOP freezes inside the un-timed heal call (the supervisor stalls), and
+ *  - every subsequent heal for that pane parks on the still-held lock forever.
+ *
+ * ## Red → green — the CLASS (both bounds)
+ *
+ *  - [watchdogTickTimesOutOnAWedgedHealAndKeepsTicking] — the LOOP-liveness bound. The active
+ *    pane's heal capture wedges (never returns). On base the watchdog's first tick parks inside
+ *    the un-timed heal and the loop never advances (exactly ONE capture attempt over a long
+ *    window) — RED. With the per-tick `withTimeout` the wedged heal is abandoned at
+ *    [RENDER_HEAL_WATCHDOG_TICK_TIMEOUT_MS] (UNVERIFIED, hot cadence) and the loop keeps ticking
+ *    (many capture attempts) — GREEN.
+ *  - [laterHealIsNotPermanentlyRejectedByAWedgedSingleFlight] — the future-heal bound. One heal
+ *    WEDGES holding the pane's single-flight; a later heal for the SAME pane then runs. On base
+ *    it parks on `withLock` forever and issues no capture (the pane can never re-heal) — RED.
+ *    With the held-too-long force-reset the later heal swaps in a fresh lock, captures, and
+ *    reseeds the pane — GREEN.
+ *
+ * The pure ownership + force-reset contract (and that a slow-but-alive holder is NEVER
+ * force-reset — single-flight preserved) is asserted directly in [RenderHealCoordinatorTest].
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class RenderHealTimeoutTest {
+
+    private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val createdVms = mutableListOf<TmuxSessionViewModel>()
+
+    @After
+    fun tearDown() {
+        factoryScope.cancel()
+    }
+
+    // -------------------------------------------------------------------------
+    // (1) LOOP-LIVENESS — a wedged heal capture must not freeze the watchdog loop.
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun watchdogTickTimesOutOnAWedgedHealAndKeepsTicking() = runVmTest {
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%1")
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == "%1" }
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+
+        // The pane looks LOST (black) on a LIVE transport, so each watchdog tick tries to heal it.
+        pane.terminalState.appendRemoteOutput(CLEAR_ONLY.toByteArray(Charsets.US_ASCII))
+        advanceUntilIdle()
+        assertTrue(
+            "precondition: the pane looks suspect so the watchdog heals it every tick",
+            pane.terminalState.renderLooksSuspect(),
+        )
+
+        // Every heal `capture-pane` records then PARKS forever — models the uninterruptible
+        // exec-lane read on a half-open socket that the cooperative 2.5 s ceiling never trips.
+        client.suspendForeverOnCommandPrefix = "capture-pane"
+
+        vm.setProcessForegroundForClearedForTest(true)
+        vm.setScreenInteractiveForTest(true)
+        val guard = requireNotNull(vm.currentRuntimeGuardForTest())
+        vm.armActivePaneStaleRenderWatchdogForTest(guard)
+        runCurrent()
+
+        val before = client.captureCount()
+        // A generous window (well beyond several 4 s ticks). advanceTimeBy (NOT advanceUntilIdle,
+        // which would race the parked heals) so the timing is driven purely by the tick cadence.
+        advanceTimeBy(40_000L)
+        runCurrent()
+        val captures = client.captureCount() - before
+
+        assertTrue(
+            "REGRESSION (#1494): a heal whose capture wedges (never returns) must not freeze the " +
+                "watchdog LOOP. On base the first tick parks inside the un-timed heal and the loop " +
+                "never advances (exactly ONE capture attempt). With the per-tick withTimeout the " +
+                "wedged heal is abandoned each tick and the loop keeps ticking. Observed " +
+                "$captures capture attempts over 40s.",
+            captures >= 3,
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // (2) FUTURE-HEAL — a wedged single-flight must not permanently reject later heals.
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun laterHealIsNotPermanentlyRejectedByAWedgedSingleFlight() = runVmTest {
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%1")
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == "%1" }
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+
+        // Drive the coordinator's held-too-long clock from the virtual scheduler so advancing the
+        // test clock ages the wedged holder deterministically.
+        vm.renderHealCoordinatorForTest().setClockForTest { currentTime }
+
+        // The pane looks suspect so both heals reseed it.
+        pane.terminalState.appendRemoteOutput(
+            (CLEAR_ONLY + "ISSUE1494-LIVE-LINE 7\r\n").toByteArray(Charsets.US_ASCII),
+        )
+        advanceUntilIdle()
+        assertTrue(pane.terminalState.renderLooksSuspect())
+
+        // H1's heal capture PARKS in flight, holding the pane's single-flight lock — the wedged,
+        // never-returning capture.
+        val wedge = CompletableDeferred<Unit>()
+        client.captureWithCursorGate = wedge
+        val h1 = launch { vm.healActivePaneIfStaleRenderForTest() }
+        runCurrent()
+        val before = client.healCaptureCount()
+
+        // Age the wedged holder past the held-too-long bound.
+        advanceTimeBy(RenderHealCoordinator.HELD_TOO_LONG_MS + 2_000L)
+        runCurrent()
+
+        // H2: a later heal for the SAME pane. Its capture does NOT park and returns tmux's grid.
+        client.captureWithCursorGate = null
+        client.capturePaneResponses.addLast(
+            CommandResponse(number = 99L, output = recoveredFrameLines(), isError = false),
+        )
+        client.cursorQueryResponses.addLast(
+            CommandResponse(number = 100L, output = listOf("0,0"), isError = false),
+        )
+        val h2 = launch { vm.healActivePaneIfStaleRenderForTest() }
+        advanceUntilIdle()
+
+        assertTrue(
+            "REGRESSION (#1494): while a WEDGED heal holds pane %1's single-flight (a capture " +
+                "that never returns), a LATER heal for the same pane must NOT park on withLock " +
+                "forever. On base it is permanently rejected and issues no capture; the held-too-" +
+                "long force-reset lets it swap in a fresh lock and run. Heal captures before=" +
+                "$before after=${client.healCaptureCount()}.",
+            client.healCaptureCount() > before,
+        )
+        assertFalse(
+            "the later heal reseeded the pane from tmux's grid after the force-reset",
+            pane.terminalState.renderLooksSuspect(),
+        )
+
+        wedge.complete(Unit)
+        advanceUntilIdle()
+        h1.cancel()
+        h2.cancel()
+    }
+
+    // ------------------------------------------------------------------ Frames
+
+    private fun recoveredFrameLines(): List<String> = buildList {
+        add("ISSUE1494-RECOVERED-FRAME")
+        repeat(27) { add("recovered context row $it with real rendered content") }
+    }
+
+    // ------------------------------------------------------------------ Harness
+
+    private fun FakeTmuxClient.captureCount(): Int =
+        sentCommands.count { it.startsWith("capture-pane") }
+
+    /** HEAL captures (`capture-pane -p -e ...`), distinct from ack-gate polls. */
+    private fun FakeTmuxClient.healCaptureCount(): Int =
+        sentCommands.count { it.startsWith("capture-pane") && it.contains(" -e") }
+
+    private fun runVmTest(body: suspend TestScope.() -> Unit) = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        LivenessProbeTestOverride.setAutoStartEnabledForTest(false)
+        try {
+            body()
+        } finally {
+            for (vm in createdVms) {
+                runCatching { vm.setProcessForegroundForClearedForTest(false) }
+                runCatching { vm.clearForTest() }
+            }
+            advanceUntilIdle()
+            createdVms.clear()
+            LivenessProbeTestOverride.clear()
+            Dispatchers.resetMain()
+        }
+    }
+
+    private fun TestScope.newVm(
+        registry: ActiveTmuxClients,
+        sshLeaseManager: SshLeaseManager,
+    ): TmuxSessionViewModel = TmuxSessionViewModel(
+        tmuxClientFactory = TmuxClientFactory(factoryScope),
+        activeTmuxClients = registry,
+        runtimeCache = TmuxSessionRuntimeCache(),
+        sshLeaseManager = sshLeaseManager,
+        sessionLifecycleSignals = null,
+    ).also {
+        it.setSeedIoDispatcherForTest(StandardTestDispatcher(testScheduler))
+        it.setStaleRenderWatchdogAutoArmEnabledForTest(false)
+        it.setConnectedBlankWatchdogAutoArmEnabledForTest(false)
+        createdVms.add(it)
+    }
+
+    private fun TestScope.connectVm(client: FakeTmuxClient): TmuxSessionViewModel {
+        val live = AlwaysConnectedSession(id = "live")
+        val connector = SingleSessionConnector(live)
+        val leaseManager =
+            testLeaseManager(connector = connector, scope = this, idleTtlMillis = 60_000L)
+        val registry = ActiveTmuxClients()
+        val vm = newVm(registry = registry, sshLeaseManager = leaseManager)
+        runCurrent()
+        vm.setTmuxClientFactoryForTest { _, _, _ -> client }
+        vm.connect(
+            hostId = 1L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            passphrase = null,
+            sessionName = "work",
+        )
+        advanceUntilIdle()
+        return vm
+    }
+
+    private fun FakeTmuxClient.withSinglePaneRow(
+        sessionName: String,
+        paneId: String,
+        title: String = sessionName,
+    ): FakeTmuxClient = apply {
+        responses.addLast(
+            CommandResponse(
+                number = 1L,
+                output = listOf("$paneId\t@0\t\$0\t$sessionName\t$title\t0"),
+                isError = false,
+            ),
+        )
+        capturePaneResponses.addLast(
+            CommandResponse(number = 2L, output = listOf("$sessionName ready"), isError = false),
+        )
+        cursorQueryResponses.addLast(
+            CommandResponse(number = 3L, output = listOf("0,0"), isError = false),
+        )
+    }
+
+    private class SingleSessionConnector(
+        private val session: SshSession,
+    ) : SshLeaseConnector {
+        override suspend fun connect(target: SshLeaseTarget): Result<SshSession> =
+            Result.success(session)
+    }
+
+    private class AlwaysConnectedSession(
+        val id: String,
+    ) : SshSession {
+        @Volatile
+        var closed: Boolean = false
+
+        override val isConnected: Boolean get() = !closed
+
+        override suspend fun exec(command: String): ExecResult =
+            ExecResult(stdout = "", stderr = "", exitCode = 0)
+
+        override fun tail(path: String, onLine: (String) -> Unit): Job =
+            Job().apply { complete() }
+
+        override fun tail(path: String, fromLineExclusive: Long, onLine: (String) -> Unit): Job =
+            Job().apply { complete() }
+
+        override fun openLocalPortForward(
+            remoteHost: String,
+            remotePort: Int,
+            localPort: Int,
+        ): SshPortForward = error("not used")
+
+        override fun startShell(): SshShell = error("not used")
+
+        override suspend fun uploadFile(file: File, remotePath: String): String = error("not used")
+
+        override suspend fun uploadStream(
+            input: InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String = error("not used")
+
+        override fun close() {
+            closed = true
+        }
+    }
+
+    private companion object {
+        // ESC[H ESC[2J — home + clear, the overpaint that wipes the viewport to black.
+        const val CLEAR_ONLY: String = "\u001B[2J\u001B[H"
+    }
+}


### PR DESCRIPTION
Closes #1494 — one uninterruptible/stuck heal capture could wedge both the pane AND its supervisor (single-flight lock with no held-too-long escape + watchdog tick awaiting the heal with no timeout).

Two bounds on the **existing** #1353-R3 chokepoints (**no new mechanism/launcher** — doesn't add to the sprawl the consolidation is removing):
- `RenderHealCoordinator.withPaneHealLock` force-resets a per-pane lock held past `HELD_TOO_LONG_MS` (15s) via an atomic CAS swap + post-acquire liveness recheck; a slow-but-alive holder is waited for, never reset (single-flight preserved).
- Watchdog-tick heal wrapped in `withTimeoutOrNull(4000ms)`, scored `Unverified` on timeout so the loop stays alive.

**Reviewer:** APPROVED — drove red→green (neutralized BOTH bounds → 3 load-bearing tests fail: frozen loop / permanently-rejected heal / no force-reset; restored → green; the slow-but-alive negative test stayed green, proving precision). No new mechanism, single-flight preserved (CAS + liveness recheck, no double-run), 9 tests/0 failures.
**Local gate:** VM ratchet 17621→**17614** (shrinks), file-size improved, `:app:testDebugUnitTest` RenderHealCoordinator(5)+RenderHealTimeout(2) BUILD SUCCESSFUL.

Deferred (non-blocking, separate issue): bounding the exec-lane socket read itself.