### PR TITLE
render-heal: fix watchdog tick-ceiling net-loss + re-arm race (#1495 pt2+3)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -2416,6 +2416,9 @@ public class TmuxSessionViewModel @Inject constructor(
     @set:androidx.annotation.VisibleForTesting
     internal var teardownLaunchFailureForTest: Throwable? = null
 
+    /** #1495 (Part 3, #780 model): inject a throw in the reseed→arm window; the finally fence must still re-arm. */
+    internal var reseedArmWindowFailureForTest: Throwable? = null
+
     // Reuse pane rows across reconciles so the attached TerminalSurfaceState
     // (and its emulator scrollback) survives layout-change events. Keyed by
     // pane ID; entries are removed when tmux drops the pane.
@@ -3757,12 +3760,15 @@ public class TmuxSessionViewModel @Inject constructor(
             // skipWhenFreshlySeeded=false forces the recapture even for a pane already seeded
             // this attach — the live client never re-attached, so the pane stays in
             // panesSeededThisAttach and a skip would leave the surface black (#1181).
-            reseedActivePaneForReattach(guard, skipWhenFreshlySeeded = false)
-            // Issue #1295: the pinned beyond-grace foreground resume is another one-shot reseed
-            // that armed NO steady watchdog. On a port-forward-pinned "always-on" connection the
-            // original connect-time watchdog may have hit its lifetime tick-ceiling across a long
-            // session, so re-arm the single lifetime net here too (arm-dedup keeps it singular).
-            if (isCurrentRuntime(guard)) armActivePaneStaleRenderWatchdog(guard)
+            // Issue #1295 + #1495(Part 3): re-arm the single lifetime net in a `finally` so a
+            // cancel/teardown throw in the reseed→arm window can't leave a still-current runtime
+            // watchdog-less. isCurrentRuntime no-ops a superseded runtime; arm-dedup keeps it singular.
+            try {
+                reseedActivePaneForReattach(guard, skipWhenFreshlySeeded = false)
+                reseedArmWindowFailureForTest?.let { throw it }
+            } finally {
+                if (isCurrentRuntime(guard)) armActivePaneStaleRenderWatchdog(guard)
+            }
         }
     }
 
@@ -3901,18 +3907,16 @@ public class TmuxSessionViewModel @Inject constructor(
             // the live line is repainted from a fresh `capture-pane`. The reseed is
             // dropped if the runtime/target was superseded mid-flight (the guard),
             // so a late seed for a switched-away session can never paint.
-            reseedActivePaneForReattach(guard)
-            // Issue #1295: the within-grace reseed-only reattach is a ONE-SHOT reseed that
-            // (pre-#1295) armed NO steady stale-render watchdog — it relied on the original
-            // connect-time watchdog having SURVIVED. But that watchdog can be gone (a
-            // superseded runtime exited its loop, a prior disconnect-recovery left it dead,
-            // the lifetime tick-ceiling elapsed), and Claude repaints only incrementally after
-            // reveal, so an idle pane that later diverges on such a runtime had NO post-reveal
-            // net and stayed black FOREVER. Re-arm the single lifetime net here so the
-            // reattached runtime always has exactly one live watchdog. [armActivePaneStaleRenderWatchdog]
-            // cancels any prior loop before launching (arm-dedup), so this can never stack a
-            // second concurrent watchdog even when the connect-time one is still alive.
-            if (isCurrentRuntime(guard)) armActivePaneStaleRenderWatchdog(guard)
+            // Issue #1295 + #1495(Part 3): re-arm the single lifetime net (the sole post-reveal
+            // net for an idle Claude pane) in a `finally` so a cancel/teardown throw in the
+            // reseed→arm window can't leave a still-current runtime watchdog-less. isCurrentRuntime
+            // no-ops a superseded runtime; arm-dedup keeps it singular.
+            try {
+                reseedActivePaneForReattach(guard)
+                reseedArmWindowFailureForTest?.let { throw it }
+            } finally {
+                if (isCurrentRuntime(guard)) armActivePaneStaleRenderWatchdog(guard)
+            }
         }
     }
 
@@ -11253,7 +11257,7 @@ public class TmuxSessionViewModel @Inject constructor(
             // tell a genuinely-idle backed-off pane from a pane whose heal captures are
             // WEDGED while it is black. Reset on any confirming (HEALTHY/HEALED) tick.
             var unverifiedStreak = 0
-            while (tick < staleRenderWatchdogMaxTicks) {
+            while (true) {
                 // Issue #1166: wait out the (possibly backed-off) interval, but a
                 // fresh active-pane %output wake cuts a backed-off wait short so a
                 // SUSPECT (locally black/partial-black) redraw is captured within the
@@ -11346,7 +11350,10 @@ public class TmuxSessionViewModel @Inject constructor(
                         }
                     }
                 }
-                tick += 1
+                // Issue #1495 (Part 2): ROLL the tick ceiling instead of exiting — a bare
+                // `while (tick < max)` stop lost the ONLY zero-interaction net on a long-lived pinned
+                // pane. isCurrentRuntime/disconnect guards above stay the real terminators (no orphan-spin).
+                if (++tick >= staleRenderWatchdogMaxTicks) { tick = 0; stableTicks = 0; unverifiedStreak = 0 }
             }
         }
     }

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue1495WatchdogCoverageTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue1495WatchdogCoverageTest.kt
@@ -1,0 +1,417 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.app.sessions.ActiveTmuxClients
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.SshLeaseConnector
+import com.pocketshell.core.ssh.SshLeaseManager
+import com.pocketshell.core.ssh.SshLeaseTarget
+import com.pocketshell.core.ssh.SshPortForward
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshShell
+import com.pocketshell.core.terminal.bridge.SshTerminalBridge
+import com.pocketshell.core.terminal.ui.TerminalSurfaceState
+import com.pocketshell.core.tmux.CommandResponse
+import com.pocketshell.core.tmux.TmuxClientFactory
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+import java.io.InputStream
+
+/**
+ * Issue #1495 — coverage holes in the stale-render watchdog (the ONLY zero-interaction retry net
+ * for a wedged pane). This file covers the two IN-SCOPE parts (Part 1 — background panes never
+ * checked — is deferred to the #1353 single-reconciler scheduling and NOT covered here):
+ *
+ *  - **Part 2 — the 10k-tick ceiling loses the net.** Before the fix the watchdog loop was
+ *    `while (tick < staleRenderWatchdogMaxTicks)`, so after the ceiling it EXITED and a long-
+ *    lived foregrounded pinned pane lost its only net until an event re-arm. The fix rolls the
+ *    ceiling (a rolling epoch) so the loop keeps checking for the pane's lifetime.
+ *    [watchdogNetSurvivesPastTickCeilingAndHealsLaterDivergence].
+ *
+ *  - **Part 3 — the re-arm cancellation-window race.** The reattach / pinned-resume reseed
+ *    coroutines ran `reseedActivePaneForReattach(guard)` and then a BARE
+ *    `if (isCurrentRuntime(guard)) armActivePaneStaleRenderWatchdog(guard)`. A cancel / teardown
+ *    throw in that reseed→arm window SKIPPED the arm, leaving a still-current runtime watchdog-
+ *    less. The fix wraps it in try/finally so the re-arm still runs. Reproduced synthetically
+ *    (#780 model) via [TmuxSessionViewModel.reseedArmWindowFailureForTest], on BOTH named sites:
+ *    the within-grace reattach ([reseedArmWindowCancelStillArmsWatchdog_withinGraceReattach]) and
+ *    the pinned beyond-grace resume ([reseedArmWindowCancelStillArmsWatchdog_pinnedBeyondGrace]).
+ *
+ * All three tests are JVM/Robolectric and run in the per-push Unit gate (`:app:testDebugUnitTest`).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class Issue1495WatchdogCoverageTest {
+
+    private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val createdVms = mutableListOf<TmuxSessionViewModel>()
+
+    @After
+    fun tearDown() {
+        factoryScope.cancel()
+    }
+
+    // -------------------------------------------------------------------------
+    // Part 2 (red→green) — the watchdog net must SURVIVE past the old tick ceiling on a
+    // continuously-foregrounded session and heal a divergence that lands AFTER the ceiling.
+    // RED on base (`while (tick < max)` exits at the ceiling → the later divergence is never
+    // healed); GREEN with the rolling-epoch fix.
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun watchdogNetSurvivesPastTickCeilingAndHealsLaterDivergence() = runVmTest {
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%1")
+        // Sticky matching capture so pre-ceiling ticks are HEALTHY no-ops (they advance the
+        // back-off, so the ceiling is reached the way a real long idle session reaches it).
+        client.defaultCaptureResponse =
+            CommandResponse(number = 80L, output = listOf("work ready"), isError = false)
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == "%1" }
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+
+        // A TINY lifetime ceiling so the loop reaches it in a handful of ticks. The bypass seam
+        // arms the loop directly (auto-arm stays off, so this is the SOLE watchdog under test).
+        vm.setStaleRenderWatchdogMaxTicksForTest(3)
+        vm.setPaneLastOutputAtMsForTest("%1", 0L)
+        vm.setProcessForegroundForClearedForTest(true)
+        vm.setScreenInteractiveForTest(true)
+        val guard = requireNotNull(vm.currentRuntimeGuardForTest())
+        vm.armActivePaneStaleRenderWatchdogForTest(guard)
+        runCurrent()
+
+        // Run WELL past the 3-tick ceiling on a continuously-foregrounded session (healthy no-op
+        // ticks + back-off). On base the loop has long since EXITED here; on the fix it rolled.
+        advanceTimeBy(180_000L)
+        runCurrent()
+
+        // Secondary signal: on the fix the loop is still armed past the ceiling; on base it is
+        // completed. (The load-bearing assertion is the heal below.)
+        val job = vm.staleRenderWatchdogJobForTest()
+        assertTrue(
+            "Issue #1495 (Part 2): the watchdog must still be ARMED past the old tick ceiling on a " +
+                "continuously-foregrounded session (rolling epoch, not a permanent stop). job=$job",
+            job != null && job.isActive,
+        )
+
+        // The idle pane diverges LONG after the ceiling: an alt-screen overpaint wipes the
+        // viewport to a lone spinner while tmux still holds the authoritative frame.
+        pane.terminalState.appendRemoteOutput(
+            (CLEAR_ONLY + "IDLE-SPINNER-ONLY\r\n").toByteArray(Charsets.US_ASCII),
+        )
+        assertFalse(
+            "precondition: the diverged pane does NOT yet carry the recovered frame",
+            renderedTranscriptFor(pane).contains("IDLE-CLAUDE-RECOVERED"),
+        )
+        // Swap in tmux's recovered grid as the STICKY capture, so once the heal repaints it, later
+        // ticks see render == capture (HEALTHY) and never wipe it back.
+        client.defaultCaptureResponse =
+            CommandResponse(number = 91L, output = idleClaudeRecoveredFrame(), isError = false)
+
+        // LOAD-BEARING: the watchdog that survived the ceiling captures tmux's grid, sees the
+        // divergence, and repaints the diverged idle pane. RED on base — the loop exited at the
+        // ceiling, so the divergence is never healed and the pane stays black forever.
+        advanceTimeBy(STALE_RENDER_WATCHDOG_MAX_INTERVAL_MS + 1_000L)
+        runCurrent()
+        assertTrue(
+            "Issue #1495 (Part 2): the watchdog must keep healing PAST the old tick ceiling — a " +
+                "long-lived foregrounded pane may never lose its only zero-interaction net",
+            renderedTranscriptFor(pane).contains("IDLE-CLAUDE-RECOVERED"),
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // Part 3 (red→green) — the reseed→arm CANCELLATION-WINDOW race. A cancel/teardown throw
+    // between the reseed and the re-arm line must NOT leave a still-current runtime watchdog-
+    // less. Reproduced synthetically (#780 model) via `reseedArmWindowFailureForTest`. RED on
+    // base (bare `if (isCurrentRuntime) arm` — the throw skips it → un-armed); GREEN with the
+    // try/finally fence. Two sites for class coverage (G2): within-grace reattach + pinned resume.
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun reseedArmWindowCancelStillArmsWatchdog_withinGraceReattach() = runVmTest {
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%1")
+        client.defaultCaptureResponse =
+            CommandResponse(number = 80L, output = listOf("work ready"), isError = false)
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == "%1" }
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+        vm.markActiveLeaseWarmForTest()
+
+        // Precondition: no steady watchdog (connectVm disabled auto-arm — simulating a superseded/
+        // ceiling'd connect-time loop). Enable production auto-arm so the reattach path is the SOLE
+        // arming opportunity.
+        vm.staleRenderWatchdogJobForTest().let {
+            assertTrue(
+                "precondition: no watchdog before the reattach",
+                it == null || it.isCancelled,
+            )
+        }
+        vm.setStaleRenderWatchdogAutoArmEnabledForTest(true)
+        vm.setStaleRenderWatchdogMaxTicksForTest(1000)
+        vm.setPaneLastOutputAtMsForTest("%1", 0L)
+        vm.setProcessForegroundForClearedForTest(true)
+        vm.setScreenInteractiveForTest(true)
+
+        // Inject the cancellation into the reseed→arm window: the reseed completes, then the
+        // window throws (the exact interleaving the issue names). On base this skips the arm.
+        vm.reseedArmWindowFailureForTest =
+            CancellationException("synthetic #1495 reseed→arm cancel (within-grace)")
+
+        // The real within-grace background→foreground reattach reseed (site B).
+        vm.onAppForegrounded(resumedWithinGrace = true)
+        repeat(8) { runCurrent() }
+
+        // LOAD-BEARING (a): the reseed→arm window was cancelled, yet the still-current runtime must
+        // NOT be left watchdog-less. RED on base — the cancel skips the bare arm line → null.
+        val armed = vm.staleRenderWatchdogJobForTest()
+        assertTrue(
+            "Issue #1495 (Part 3): a cancel in the reseed→arm window must NOT leave the still-" +
+                "current runtime watchdog-less — the finally fence must re-arm it. job=$armed",
+            armed != null && armed.isActive,
+        )
+
+        // LOAD-BEARING (b): the re-armed watchdog is a LIVE net — it heals a divergence that lands
+        // after the cancelled reattach (not merely a launched job).
+        vm.reseedArmWindowFailureForTest = null
+        assertHealsIdleDivergence(vm, client, pane)
+    }
+
+    @Test
+    fun reseedArmWindowCancelStillArmsWatchdog_pinnedBeyondGrace() = runVmTest {
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%1")
+        client.defaultCaptureResponse =
+            CommandResponse(number = 80L, output = listOf("work ready"), isError = false)
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == "%1" }
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+
+        // Pinned beyond-grace state: live client, NOTHING pending → onAppForegrounded(false) lands
+        // on reseedActivePaneOnLivePinnedForeground() (site A).
+        assertFalse(
+            "precondition: the live pinned resume has NO pendingReattach",
+            vm.hasPendingReattachForTest(),
+        )
+        vm.staleRenderWatchdogJobForTest().let {
+            assertTrue(
+                "precondition: no watchdog before the pinned resume",
+                it == null || it.isCancelled,
+            )
+        }
+        vm.setStaleRenderWatchdogAutoArmEnabledForTest(true)
+        vm.setStaleRenderWatchdogMaxTicksForTest(1000)
+        vm.setPaneLastOutputAtMsForTest("%1", 0L)
+        vm.setProcessForegroundForClearedForTest(true)
+        vm.setScreenInteractiveForTest(true)
+
+        vm.reseedArmWindowFailureForTest =
+            CancellationException("synthetic #1495 reseed→arm cancel (pinned)")
+
+        // The real notification-tap foreground return BEYOND grace onto the live pinned client
+        // with nothing pending → reseedActivePaneOnLivePinnedForeground() (site A).
+        vm.onAppForegrounded(resumedWithinGrace = false)
+        repeat(8) { runCurrent() }
+
+        val armed = vm.staleRenderWatchdogJobForTest()
+        assertTrue(
+            "Issue #1495 (Part 3): a cancel in the pinned-resume reseed→arm window must NOT leave " +
+                "the still-current runtime watchdog-less — the finally fence must re-arm it. job=$armed",
+            armed != null && armed.isActive,
+        )
+
+        vm.reseedArmWindowFailureForTest = null
+        assertHealsIdleDivergence(vm, client, pane)
+    }
+
+    // ------------------------------------------------------------------ Harness
+
+    /** Drive an idle-pane divergence and assert the (re-)armed watchdog heals it from tmux's grid. */
+    private fun TestScope.assertHealsIdleDivergence(
+        vm: TmuxSessionViewModel,
+        client: FakeTmuxClient,
+        pane: TmuxPaneState,
+    ) {
+        pane.terminalState.appendRemoteOutput(
+            (CLEAR_ONLY + "IDLE-SPINNER-ONLY\r\n").toByteArray(Charsets.US_ASCII),
+        )
+        assertFalse(
+            "precondition: the diverged pane does NOT yet carry the recovered frame",
+            renderedTranscriptFor(pane).contains("IDLE-CLAUDE-RECOVERED"),
+        )
+        client.defaultCaptureResponse =
+            CommandResponse(number = 91L, output = idleClaudeRecoveredFrame(), isError = false)
+        advanceTimeBy(STALE_RENDER_WATCHDOG_MAX_INTERVAL_MS + 1_000L)
+        runCurrent()
+        assertTrue(
+            "Issue #1495 (Part 3): the re-armed watchdog must be a LIVE net — heal the diverged " +
+                "idle pane from tmux's grid, never leave it stranded",
+            renderedTranscriptFor(pane).contains("IDLE-CLAUDE-RECOVERED"),
+        )
+    }
+
+    private fun idleClaudeRecoveredFrame(): List<String> = buildList {
+        add("IDLE-CLAUDE-RECOVERED")
+        repeat(27) { add("recovered context row $it with real tmux content") }
+    }
+
+    private fun renderedTranscriptFor(pane: TmuxPaneState): String {
+        val state = pane.terminalState
+        val bridgeField = TerminalSurfaceState::class.java.getDeclaredField("bridge").apply {
+            isAccessible = true
+        }
+        val bridge = bridgeField.get(state) as? SshTerminalBridge ?: return ""
+        return bridge.emulator.screen.transcriptText
+    }
+
+    private fun runVmTest(body: suspend TestScope.() -> Unit) = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        LivenessProbeTestOverride.setAutoStartEnabledForTest(false)
+        try {
+            body()
+        } finally {
+            for (vm in createdVms) {
+                runCatching { vm.setProcessForegroundForClearedForTest(false) }
+                runCatching { vm.clearForTest() }
+            }
+            advanceUntilIdle()
+            createdVms.clear()
+            LivenessProbeTestOverride.clear()
+            Dispatchers.resetMain()
+        }
+    }
+
+    private fun TestScope.newVm(
+        registry: ActiveTmuxClients,
+        sshLeaseManager: SshLeaseManager,
+    ): TmuxSessionViewModel = TmuxSessionViewModel(
+        tmuxClientFactory = TmuxClientFactory(factoryScope),
+        activeTmuxClients = registry,
+        runtimeCache = TmuxSessionRuntimeCache(),
+        sshLeaseManager = sshLeaseManager,
+        sessionLifecycleSignals = null,
+    ).also {
+        it.setSeedIoDispatcherForTest(StandardTestDispatcher(testScheduler))
+        // Keep connect()'s reveal from auto-arming its own watchdogs so the arming path under
+        // test is the SOLE opportunity; individual tests re-enable auto-arm as needed.
+        it.setStaleRenderWatchdogAutoArmEnabledForTest(false)
+        it.setConnectedBlankWatchdogAutoArmEnabledForTest(false)
+        createdVms.add(it)
+    }
+
+    private fun TestScope.connectVm(client: FakeTmuxClient): TmuxSessionViewModel {
+        val live = AlwaysConnectedSession(id = "live")
+        val connector = SingleSessionConnector(live)
+        val leaseManager =
+            testLeaseManager(connector = connector, scope = this, idleTtlMillis = 60_000L)
+        val registry = ActiveTmuxClients()
+        val vm = newVm(registry = registry, sshLeaseManager = leaseManager)
+        runCurrent()
+        vm.setTmuxClientFactoryForTest { _, _, _ -> client }
+        vm.connect(
+            hostId = 1L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            passphrase = null,
+            sessionName = "work",
+        )
+        advanceUntilIdle()
+        return vm
+    }
+
+    private fun FakeTmuxClient.withSinglePaneRow(
+        sessionName: String,
+        paneId: String,
+        title: String = sessionName,
+    ): FakeTmuxClient = apply {
+        responses.addLast(
+            CommandResponse(
+                number = 1L,
+                output = listOf("$paneId\t@0\t\$0\t$sessionName\t$title\t0"),
+                isError = false,
+            ),
+        )
+        capturePaneResponses.addLast(
+            CommandResponse(number = 2L, output = listOf("$sessionName ready"), isError = false),
+        )
+        cursorQueryResponses.addLast(
+            CommandResponse(number = 3L, output = listOf("0,0"), isError = false),
+        )
+    }
+
+    private class SingleSessionConnector(
+        private val session: SshSession,
+    ) : SshLeaseConnector {
+        override suspend fun connect(target: SshLeaseTarget): Result<SshSession> =
+            Result.success(session)
+    }
+
+    private class AlwaysConnectedSession(
+        val id: String,
+    ) : SshSession {
+        @Volatile
+        var closed: Boolean = false
+
+        override val isConnected: Boolean get() = !closed
+
+        override suspend fun exec(command: String): ExecResult =
+            ExecResult(stdout = "", stderr = "", exitCode = 0)
+
+        override fun tail(path: String, onLine: (String) -> Unit): Job =
+            Job().apply { complete() }
+
+        override fun tail(path: String, fromLineExclusive: Long, onLine: (String) -> Unit): Job =
+            Job().apply { complete() }
+
+        override fun openLocalPortForward(
+            remoteHost: String,
+            remotePort: Int,
+            localPort: Int,
+        ): SshPortForward = error("not used")
+
+        override fun startShell(): SshShell = error("not used")
+
+        override suspend fun uploadFile(file: File, remotePath: String): String = error("not used")
+
+        override suspend fun uploadStream(
+            input: InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String = error("not used")
+
+        override fun close() {
+            closed = true
+        }
+    }
+
+    private companion object {
+        // ESC[2J ESC[H — a full clear + home, the overpaint that blacks a viewport.
+        const val CLEAR_ONLY: String = "[2J[H"
+    }
+}


### PR DESCRIPTION
Refs #1495 (parts 2+3; **part 1** background-pane coverage deferred to your #1353 scheduling — a coverage-scope decision the single reconciler should own).

- **Part 2** — the stale-render watchdog stopped checking after the ~10k-tick ceiling, so long-lived panes silently lost the net; it now survives past the ceiling and still heals a later divergence.
- **Part 3** — a re-arm cancellation-window race could leave the watchdog un-armed/double-armed; arming is now fenced to exactly-once across the cancel window, covering both #1329 within-grace-reattach and beyond-grace paths.

Hardens the existing #1353-R3 watchdog loop — **no new mechanism** (0 added `.launch`); does **not** revert #1494's bounded timeouts.

**Reviewer:** APPROVED — drove red→green for BOTH parts (neutralize ceiling → net lost; neutralize arm fences → `job=null` watchdog-less; restore → green), confirmed part 1 not implemented, #1494 tests still green (RenderHealTimeout(2)+RenderHealCoordinator(5)), #1329 arming test(7) green, guards exit 0.
**Local gate:** VM ratchet 17621 (== baseline, bytes net-negative), `:app:testDebugUnitTest` Issue1495WatchdogCoverage(3)+RenderHealTimeout BUILD SUCCESSFUL.

Non-blocking follow-ups (reviewer): broad `*StaleRender*` glob OOMs the forked test JVM (raise heap/split); possible D28 extraction to RenderHealCoordinator.kt.