### PR TITLE
test-infra: bound + recycle the app Robolectric test fork (#1518)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -153,6 +153,31 @@ android {
                     events("passed", "skipped", "failed")
                     showStandardStreams = true
                 }
+
+                // #1518: the Robolectric render-heal sibling suite
+                // (*StaleRender* / *RenderHeal* / *Watchdog*, plus the heavy
+                // TmuxSessionViewModel Robolectric classes the glob pulls in)
+                // loads a large amount of per-class state. Gradle's default
+                // `forkEvery = 0` keeps EVERY app test class in ONE long-lived
+                // worker JVM, so that heap/metaspace piles up across the whole
+                // run and OOMs the fork when the render-heal glob (or the whole
+                // module) runs together — narrow single-class runs stayed fine.
+                // Bound it two ways, both well under the 7 GB hosted runner
+                // (daemon -Xmx2048m + this fork ≈ 3.5 GB peak):
+                //   - an explicit, CI-budget-safe worker heap, and
+                //   - a finite `forkEvery` so the worker JVM is recycled every
+                //     N test classes and per-class Robolectric metaspace can't
+                //     accumulate unbounded. forkEvery=100 survives the exact
+                //     metaspace level that OOMs the default single fork while
+                //     costing only a few worker restarts (~+25s on this module).
+                // Both stay overridable for local repro/tuning.
+                test.maxHeapSize = providers.gradleProperty("pocketshell.test.maxHeap")
+                    .orElse("1536m").get()
+                test.setForkEvery(
+                    providers.gradleProperty("pocketshell.test.forkEvery")
+                        .orElse("100").get().toLong()
+                )
+
                 val apiVersion = providers.gradleProperty("api.version")
                     .orElse(System.getenv("DOCKER_API_VERSION") ?: "1.45")
                     .get()


### PR DESCRIPTION
Closes #1518 — the app Robolectric test fork OOMed on the render-heal sibling glob (and whole module): Gradle's default `forkEvery=0` keeps all ~368 test classes in one worker JVM, so per-class metaspace accumulates unbounded → `OutOfMemoryError: Metaspace`. (This is what made the render-heal suite unrunnable as one glob and caused an implementer's verification to hang.)

**Fix (`app/build.gradle.kts` only):** `maxHeapSize=1536m` + `forkEvery=100` (recycle the worker JVM so metaspace can't accumulate), both `-P`-overridable. Under the 7GB/2-vCPU runner; ~+12s whole-module; **no coverage change**.

**Reviewer:** APPROVED — reviewer-driven RED→GREEN with the exact synthetic condition isolated (injected `-XX:MaxMetaspaceSize=200m` via a reviewer-only init-script, flipped only `forkEvery`): `forkEvery=0` → `OutOfMemoryError: Metaspace` BUILD FAILED; `forkEvery=100` → SUCCESSFUL. No `exclude`/`filter`/`@Ignore` added — 3672 tests / 368 classes all execute (G3). CI-safe.
**Local gate:** git diff --check clean; existing test green under the new config; +25-line build.gradle.kts diff only.

Note (separate, not this PR): #1517's render-heal watchdog HANG is a distinct real defect (not OOM) being fixed under #1495.