### PR TITLE
session-ui: always show a prominent Reconnect button in the disconnected state (#1521)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxConnectingProgressOverlayTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxConnectingProgressOverlayTest.kt
@@ -250,7 +250,6 @@ class TmuxConnectingProgressOverlayTest {
                         FailedConnectionRow(
                             message = current.message,
                             onReconnect = { reconnectCalls += 1 },
-                            canReconnect = true,
                         )
                     }
 
@@ -270,26 +269,38 @@ class TmuxConnectingProgressOverlayTest {
     }
 
     @Test
-    fun failedWithoutReconnectShowsCalmMessageAndHidesReconnectAction() {
-        // EPIC #687 #720: the honest-error band is now a CALM prompt — the curated
+    fun failedBandAlwaysShowsProminentReconnectButton_1521() {
+        // EPIC #687 #720: the honest-error band stays a CALM prompt — the curated
         // message is shown as-is, NEVER appended with the old "Open the session again
-        // to reconnect." instruction. When there is genuinely nothing to reconnect to
-        // (`canReconnect = false`) the tappable action is hidden but the message stays
-        // calm and un-instructed.
+        // to reconnect." instruction.
+        //
+        // Issue #1521 (maintainer dogfood — "there's nowhere to tap"): the band MUST
+        // ALWAYS expose a prominent, tappable Reconnect control. The prior design hid
+        // the affordance whenever the VM had not preserved a reconnect target, so the
+        // disconnected screen showed the "Tap Reconnect to retry" copy with nothing
+        // tappable — a dead-end. The button is now ALWAYS present (no `canReconnect`
+        // gate) and calls the existing reconnect action.
+        var reconnectCalls = 0
         compose.setContent {
             PocketShellTheme {
                 FailedConnectionRow(
-                    message = "Disconnected. Tap to reconnect.",
-                    onReconnect = {},
-                    canReconnect = false,
+                    message = "Disconnected from alex@10.0.2.2:22. Tap Reconnect to retry.",
+                    onReconnect = { reconnectCalls += 1 },
                 )
             }
         }
 
         compose.onNodeWithTag(TMUX_SESSION_ERROR_TAG).assertIsDisplayed()
-        compose.onNodeWithText("Disconnected. Tap to reconnect.").assertIsDisplayed()
-        compose.onNodeWithText("Disconnected. Open the session again to reconnect.")
-            .assertDoesNotExist()
-        compose.onNodeWithTag(TMUX_SESSION_RECONNECT_TAG).assertDoesNotExist()
+        compose.onNodeWithText("Disconnected from alex@10.0.2.2:22. Tap Reconnect to retry.")
+            .assertIsDisplayed()
+        // The old borderless "Tap to reconnect" text button is gone — replaced by the
+        // prominent "Reconnect" CTA.
+        compose.onNodeWithText("Tap to reconnect").assertDoesNotExist()
+        // The prominent Reconnect button is present, tappable, and routes to the
+        // existing reconnect action even in this "nowhere to tap" scenario.
+        compose.onNodeWithTag(TMUX_SESSION_RECONNECT_TAG).assertIsDisplayed()
+        compose.onNodeWithText("Reconnect").assertIsDisplayed()
+        compose.onNodeWithTag(TMUX_SESSION_RECONNECT_TAG).performClick()
+        assertEquals("Reconnect button must always be tappable in the failed band", 1, reconnectCalls)
     }
 }

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxConnectingStatesScreenshotTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxConnectingStatesScreenshotTest.kt
@@ -19,7 +19,9 @@ import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
@@ -37,6 +39,7 @@ import com.pocketshell.uikit.theme.PocketShellColors
 import com.pocketshell.uikit.theme.PocketShellTheme
 import java.io.File
 import java.io.FileOutputStream
+import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -397,6 +400,12 @@ class TmuxConnectingStatesScreenshotTest {
         val failed = TmuxSessionViewModel.ConnectionStatus.Failed(
             "Connection lost. Tap Reconnect to retry.",
         )
+        // Issue #1521 (AC2, gated): tapping the band's "Reconnect" control MUST invoke
+        // the existing reconnect action. This tap→reconnect assertion is asserted HERE,
+        // inside the CI-wired [TmuxConnectingStatesScreenshotTest]
+        // (`scripts/ci-journey-suite.sh` → emulator-journey), so the affordance is
+        // guarded per-push (not only in the un-gated component test).
+        var reconnectCalls = 0
         compose.setContent {
             PocketShellTheme {
                 Column(
@@ -413,8 +422,7 @@ class TmuxConnectingStatesScreenshotTest {
                     )
                     FailedConnectionRow(
                         message = failed.message,
-                        onReconnect = {},
-                        canReconnect = true,
+                        onReconnect = { reconnectCalls += 1 },
                     )
                     Box(
                         modifier = Modifier
@@ -444,8 +452,11 @@ class TmuxConnectingStatesScreenshotTest {
                 }
             }
         }
-        // The band's "Tap to reconnect" is the SOLE reconnect affordance.
-        compose.onNodeWithText("Tap to reconnect").assertExists()
+        // Issue #1521: the band's prominent, always-present "Reconnect" button is the
+        // SOLE reconnect affordance (replacing the old borderless "Tap to reconnect"
+        // text link). Exactly one on-screen reconnect control.
+        compose.onNodeWithText("Reconnect").assertExists()
+        compose.onNodeWithText("Tap to reconnect").assertDoesNotExist()
         compose
             .onAllNodesWithTag(TMUX_SESSION_RECONNECT_TAG, useUnmergedTree = true)
             .assertCountEquals(1)
@@ -459,6 +470,15 @@ class TmuxConnectingStatesScreenshotTest {
         compose.waitForIdle()
         // ZERO animated indicators — the settled Failed state must not spin.
         assertIndeterminateIndicatorCount(0)
+        // Issue #1521 (AC2): the affordance is not just present — tapping it routes to
+        // the SAME existing reconnect action. RED without the always-present button
+        // (nothing tappable → no callback); GREEN with the fix.
+        compose.onNodeWithTag(TMUX_SESSION_RECONNECT_TAG).performClick()
+        assertEquals(
+            "Tapping the disconnected-band Reconnect button must invoke the reconnect action",
+            1,
+            reconnectCalls,
+        )
         SystemClock.sleep(300)
         captureFullDevice(File(artifactDir(), "tmux-failed-single-reconnect-control.png"))
     }
@@ -497,7 +517,6 @@ class TmuxConnectingStatesScreenshotTest {
                     FailedConnectionRow(
                         message = failureReasonSentence((hardFailureState as SessionSurfaceState.Failed).reason),
                         onReconnect = {},
-                        canReconnect = true,
                     )
                     Box(
                         modifier = Modifier
@@ -531,6 +550,17 @@ class TmuxConnectingStatesScreenshotTest {
             .assertCountEquals(1)
         compose
             .onAllNodesWithTag(TMUX_SWITCHING_LOADING_TAG, useUnmergedTree = true)
+            .assertCountEquals(0)
+        // Issue #1521 (AC3, gated): the calm center placeholder now reads a bare
+        // "Disconnected." status — the misleading "tap to reconnect above." pointer
+        // (which gestured at a non-obvious target) is GONE, since the recovery
+        // affordance is the prominent, always-present "Reconnect" button in the band.
+        // Asserted here in the CI-wired [TmuxConnectingStatesScreenshotTest] so the copy
+        // change is guarded per-push. RED on base: the placeholder said
+        // "Disconnected — tap to reconnect above." → the substring assert below fails.
+        compose.onNodeWithText("Disconnected.").assertExists()
+        compose
+            .onAllNodesWithText("tap to reconnect above", substring = true)
             .assertCountEquals(0)
         // Exactly ONE reconnect control (the band) and ZERO spinners.
         compose

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionConnectionChrome.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionConnectionChrome.kt
@@ -1,7 +1,6 @@
 package com.pocketshell.app.tmux
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.Box
@@ -14,6 +13,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -657,18 +657,19 @@ internal fun ReconnectingProgressRow(
 /**
  * Issue #145: in-session SSH-disconnect error band.
  *
- * Rendered when [TmuxSessionViewModel.connectionStatus] is
- * [TmuxSessionViewModel.ConnectionStatus.Failed]. Surfaces the
- * disconnect message and a single-tap Reconnect button that calls back
- * into [TmuxSessionViewModel.reconnect].
+ * Rendered when the fused [SessionSurfaceState] is a settled
+ * [SessionSurfaceState.Failed]. Surfaces the calm disconnect message and a
+ * prominent, ALWAYS-present Reconnect button that calls back into
+ * [TmuxSessionViewModel.reconnect].
  *
- * The message is rendered in the design-system error token
- * [PocketShellColors.Red] (see `docs/design-system.md` §1) so the band
- * reads as a real failure state instead of a muted hint.
- *
- * The Reconnect button is gated on [canReconnect] — when no target is
- * set (the ViewModel never opened) the button is hidden so the user
- * never sees a tap that silently no-ops.
+ * Issue #1521: the button is a prominent accent [PocketShellButton] (not a
+ * borderless `TextButton`) and is ALWAYS shown in the failed band — it is no
+ * longer gated on `canReconnect`. The prior gate hid the sole affordance whenever
+ * the VM had not preserved a reconnect target, producing the maintainer's reported
+ * dead-end (the copy said "Tap Reconnect to retry" while nothing on screen was
+ * tappable). The caller ([TmuxSessionScreen]) surfaces honest feedback when there is
+ * genuinely nothing to reconnect to, so an always-present button is never a silent
+ * no-op.
  *
  * The row is tagged with [TMUX_SESSION_ERROR_TAG] (root) and
  * [TMUX_SESSION_RECONNECT_TAG] (button) so the connected
@@ -679,29 +680,31 @@ internal fun ReconnectingProgressRow(
 internal fun FailedConnectionRow(
     message: String,
     onReconnect: () -> Unit,
-    canReconnect: Boolean,
 ) {
-    // EPIC #687 #720: the ONLY honest error (controller `Unreachable`) is a CALM,
-    // tappable "Tap to reconnect" affordance — never raw `TransportException`/SSH
-    // exception text, never the "Open the session again to reconnect" instruction.
-    // The whole band is tappable (taps run the existing reconnect action) and the
-    // text reads as a calm prompt, not a scary red failure. When there is genuinely
-    // nothing to reconnect to (`!canReconnect`, the VM never opened) the band is
-    // inert but still calm.
-    val rowModifier = Modifier
-        .fillMaxWidth()
-        .background(color = PocketShellColors.Surface)
-        .then(
-            if (canReconnect) {
-                Modifier.clickable(onClick = onReconnect)
-            } else {
-                Modifier
-            },
-        )
-        .padding(horizontal = 12.dp, vertical = 6.dp)
-        .testTag(TMUX_SESSION_ERROR_TAG)
+    // EPIC #687 #720: the ONLY honest error (controller `Unreachable`) is a CALM
+    // recoverable prompt — never raw `TransportException`/SSH exception text, never
+    // the "Open the session again to reconnect" instruction. The message reads as a
+    // calm prompt, not a scary red failure.
+    //
+    // Issue #1521 (maintainer dogfood — "there's nowhere to tap"): the disconnected
+    // state MUST always expose an OBVIOUS, clearly-tappable Reconnect control. The
+    // prior design rendered a borderless Material `TextButton` ("Tap to reconnect")
+    // gated on `canReconnect`, so a dropped session whose reconnect target the VM did
+    // not preserve (`canReconnect == false`) showed the "Tap Reconnect to retry" copy
+    // with NO affordance at all — the reported dead-end where the copy tells the user
+    // to reconnect but nothing reads as tappable, and the whole-row `clickable` was an
+    // invisible tap zone the user could not discover. The band now ALWAYS renders a
+    // prominent accent [PocketShellButton] (an obvious CTA, not muted text) wired to
+    // the SAME existing reconnect action ([onReconnect] → [TmuxSessionViewModel.reconnect]):
+    // no new reconnect path, no hidden whole-row tap zone. The caller surfaces honest
+    // feedback if there is genuinely nothing to reconnect to, so a tap is never a
+    // silent no-op.
     Row(
-        modifier = rowModifier,
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(color = PocketShellColors.Surface)
+            .padding(horizontal = 12.dp, vertical = 6.dp)
+            .testTag(TMUX_SESSION_ERROR_TAG),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(
@@ -712,14 +715,14 @@ internal fun FailedConnectionRow(
             fontSize = 12.sp,
             modifier = Modifier.weight(1f),
         )
-        if (canReconnect) {
-            TextButton(
-                onClick = onReconnect,
-                modifier = Modifier.testTag(TMUX_SESSION_RECONNECT_TAG),
-            ) {
-                Text("Tap to reconnect")
-            }
-        }
+        Spacer(modifier = Modifier.width(8.dp))
+        PocketShellButton(
+            text = "Reconnect",
+            onClick = onReconnect,
+            variant = ButtonVariant.Primary,
+            compact = true,
+            modifier = Modifier.testTag(TMUX_SESSION_RECONNECT_TAG),
+        )
     }
 }
 
@@ -756,7 +759,6 @@ internal fun SessionFailureBand(
     user: String,
     host: String,
     port: Int,
-    canReconnect: Boolean,
     onReconnect: () -> Unit,
 ) {
     val failed = surfaceState as? SessionSurfaceState.Failed ?: return
@@ -771,7 +773,6 @@ internal fun SessionFailureBand(
             endpoint = disconnectEndpointLabel(user = user, host = host, port = port),
         ),
         onReconnect = onReconnect,
-        canReconnect = canReconnect,
     )
 }
 
@@ -817,11 +818,11 @@ internal fun SwitchingLoadingPlaceholder() {
  * "Disconnected" pill and the "Tap to reconnect" band.
  *
  * This placeholder renders DISTINCTLY from [SwitchingLoadingPlaceholder]: NO
- * spinner, a calm muted line that points at the tappable [FailedConnectionRow]
- * band above. The surface, the pill, and the error band now agree for the failure
- * state — all derived from the ONE [SessionSurfaceState]. Deliberately does not
- * itself carry a Reconnect button — the [FailedConnectionRow] band owns the single,
- * calm reconnect affordance.
+ * spinner, a calm muted status line. The surface, the pill, and the error band now
+ * agree for the failure state — all derived from the ONE [SessionSurfaceState].
+ * Deliberately does not itself carry a Reconnect button — the [FailedConnectionRow]
+ * band owns the SINGLE, prominent, always-present reconnect affordance (#1521), so
+ * there is exactly one obvious tappable Reconnect control on screen (no duplicate).
  */
 @Composable
 internal fun RevealFailurePlaceholder() {
@@ -834,9 +835,12 @@ internal fun RevealFailurePlaceholder() {
     ) {
         Text(
             // #720/#1322: a calm, honest prompt — the muted secondary token, NOT the
-            // alarming error band and NOT a spinner. The recovery affordance is the
-            // "Tap to reconnect" band above.
-            text = "Disconnected — tap to reconnect above.",
+            // alarming error band and NOT a spinner. Issue #1521: dropped the
+            // misleading "tap to reconnect above." pointer — the recovery affordance
+            // is now the prominent, always-present "Reconnect" button in the
+            // [FailedConnectionRow] band, an obvious CTA (not a hidden target the copy
+            // vaguely gestured at), so the placeholder just states the calm status.
+            text = "Disconnected.",
             color = PocketShellColors.TextSecondary,
             fontSize = 14.sp,
             modifier = Modifier.padding(horizontal = 24.dp),

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
@@ -1076,6 +1076,19 @@ public fun TmuxSessionScreen(
     val composeRootView = LocalView.current
     val context = LocalContext.current
 
+    // Issue #993/#1521: the single reconnect-with-feedback action shared by the kebab
+    // "Reconnect" item and the disconnected band's always-present Reconnect button.
+    // Routes through the VM's single [TmuxSessionViewModel.reconnect]; a false return
+    // (no target) gives honest Toast feedback, never a silent no-op dead-end.
+    val reconnectWithFeedback: () -> Unit = {
+        val started = viewModel.reconnect()
+        Toast.makeText(
+            context,
+            if (started) "Reconnecting…" else "Nothing to reconnect to — reopen the session",
+            Toast.LENGTH_SHORT,
+        ).show()
+    }
+
     // Issue #488: a tapped server-local (loopback) URL whose remote port is not
     // yet forwarded for this host. Non-null drives the "Forward port N from
     // <host>?" confirm dialog; confirming routes through the existing
@@ -1364,22 +1377,11 @@ public fun TmuxSessionScreen(
                 viewModel.redrawActivePane()
             },
             onReconnect = {
-                // Issue #993: close the menu, then force an immediate reconnect of THIS
-                // session in place via the VM's single [TmuxSessionViewModel.reconnect]
-                // /TransportEffects entrypoint — the SAME path a session switch uses to
-                // recover a dropped session, so the user no longer has to switch away and
-                // back. `reconnect()` returns false only when there is no target (the
-                // `reconnectEnabled` gate already suppresses that), so the Toast confirms
-                // the reconnect was actually kicked off (visible feedback, no silent
-                // no-op). The terminal then shows the normal "Reconnecting…" band, and on
-                // success the #900 outbound queue auto-flushes the pending message.
+                // Issue #993: close the menu, then reconnect THIS session in place via
+                // the shared [reconnectWithFeedback] action — the SAME path a session
+                // switch uses. On success the #900 outbound queue auto-flushes.
                 moreExpanded = false
-                val started = viewModel.reconnect()
-                Toast.makeText(
-                    context,
-                    if (started) "Reconnecting…" else "Nothing to reconnect to",
-                    Toast.LENGTH_SHORT,
-                ).show()
+                reconnectWithFeedback()
             },
             // Issue #993: only actionable when there IS a target to reconnect to AND a
             // connect/reconnect is not already in flight — see [reconnectKebabEnabled].
@@ -1644,8 +1646,10 @@ public fun TmuxSessionScreen(
                 user = user,
                 host = host,
                 port = port,
-                canReconnect = canReconnect,
-                onReconnect = { viewModel.reconnect() },
+                // Issue #1521: the band's prominent Reconnect button is ALWAYS shown so
+                // the disconnected state never dead-ends with "nowhere to tap". It routes
+                // to the SAME shared [reconnectWithFeedback] action the kebab uses.
+                onReconnect = reconnectWithFeedback,
             )
             // Per [D6]: render exactly one pane at a time. The
             // HorizontalPager renders only the visible page eagerly by

--- a/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenders.kt
+++ b/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenders.kt
@@ -401,6 +401,17 @@ class DesignRenders {
     }
 
     /**
+     * Issue #1521: the DISCONNECTED session state after the "there's nowhere to tap"
+     * fix — the disconnect band now carries a prominent, always-present accent
+     * "Reconnect" button (not a borderless text link), and the centered placeholder is
+     * the calm "Disconnected." status without the misleading "tap … above." pointer.
+     */
+    @Test
+    fun tmuxDisconnectedState() = render("tmux-disconnected-state") {
+        TmuxDisconnectedStateRender()
+    }
+
+    /**
      * Issue #756: the canonical [PocketShellButton] — the single shared button
      * the ~142 raw Material `Button`/`TextButton` call sites (and the 9 files
      * that hand-re-declared the same accent `ButtonDefaults.buttonColors` block)

--- a/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/TerminalRenderFixtures.kt
+++ b/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/TerminalRenderFixtures.kt
@@ -4,15 +4,19 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.pocketshell.uikit.components.ButtonVariant
 import com.pocketshell.uikit.components.HotkeySection
 import com.pocketshell.uikit.components.LoadingIndicator
@@ -86,6 +90,59 @@ internal fun TmuxConnectingStatesRender() {
             LoadingIndicator.Spinner(
                 size = SpinnerSize.Medium,
                 label = "Attaching…",
+            )
+        }
+    }
+}
+
+/**
+ * Issue #1521: the DISCONNECTED session state — the fix for the maintainer's "there's
+ * nowhere to tap" dead-end. `FailedConnectionRow` + `RevealFailurePlaceholder` are
+ * app-only composables, so this fixture reproduces their visible chrome with ui-kit
+ * primitives: the top disconnect band ("Disconnected from …. Tap Reconnect to retry.")
+ * now carries a PROMINENT accent `PocketShellButton` ("Reconnect") instead of a
+ * borderless "Tap to reconnect" text link, and the centered placeholder is the calm
+ * "Disconnected." status (the misleading "tap to reconnect above." pointer is gone).
+ * A reviewer can eyeball that the Reconnect control reads as an obvious, tappable CTA.
+ */
+@Composable
+internal fun TmuxDisconnectedStateRender() {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        // The disconnect band (reproduces FailedConnectionRow with the #1521 button).
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(color = PocketShellColors.Surface)
+                .padding(horizontal = 12.dp, vertical = 6.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = "Disconnected from alexey@135.181.114.209:22. Tap Reconnect to retry.",
+                color = PocketShellColors.TextSecondary,
+                fontSize = 12.sp,
+                modifier = Modifier.weight(1f),
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            PocketShellButton(
+                text = "Reconnect",
+                onClick = {},
+                variant = ButtonVariant.Primary,
+                compact = true,
+            )
+        }
+        // The centered calm placeholder (reproduces RevealFailurePlaceholder).
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(360.dp)
+                .background(color = PocketShellColors.Background),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = "Disconnected.",
+                color = PocketShellColors.TextSecondary,
+                fontSize = 14.sp,
+                modifier = Modifier.padding(horizontal = 24.dp),
             )
         }
     }


### PR DESCRIPTION
Closes #1521 — maintainer dogfood 'there's nowhere to tap'. On the connect-failure path (`canReconnect==false`) the disconnect band told the user to 'Tap Reconnect' but showed **no button**.

`FailedConnectionRow` now **always** renders a prominent accent 'Reconnect' button (no `canReconnect` gate, no hidden whole-row tap zone), wired to the existing `reconnect()` path; center placeholder is a calm 'Disconnected.' (removed the misleading 'tap to reconnect above').

**Reviewer:** APPROVED — proved red→green on the emulator (button visible/in-viewport/tappable; neutralized → `assertIsDisplayed` fails). G9 gated: tap→reconnect + copy-change assertions in `TmuxConnectingStatesScreenshotTest` (in `ci-journey-suite.sh`); connected run **7/7 green**, non-vacuous (real production composables).
**Local gate:** whitespace clean, file-size improved, ci-journey-harness PASS, `:app:compileDebugAndroidTestKotlin` + `TmuxSessionScreenTest` BUILD SUCCESSFUL.

Note: in the `canReconnect==false` state `reconnect()` still no-ops (VM drops the reconnect target, ~`TmuxSessionViewModel.kt:7381`) — real recovery is folded into the #1522 connection fix; this PR fixes the missing affordance + misleading copy (the reported symptom).