### PR TITLE
connection: stop stable-network flap — keepalive-aware loss band + debounce + amortized reconnect (#1522)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionSupport.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionSupport.kt
@@ -465,10 +465,43 @@ internal const val RUNTIME_HEALTH_PROBE_TIMEOUT_MS: Long = 750L
  * Issue #1042 (cause #1): the small bound on the single control-channel probe the
  * liveness-first network-restore arm issues when the transport keepalive has aged
  * out. A surviving link answers well within this; a genuinely dead socket times out
- * and falls through to the #997 fresh-lease redial. Kept short so a dead socket's
- * recovery is not noticeably delayed past the old unconditional redial.
+ * and falls through to the #997 fresh-lease redial.
+ *
+ * Issue #1522 (H2): raised 2s → 5s. A LIVE-but-slow `-CC` channel right after a
+ * cellular RAT handover (the radio has just re-attached and the channel is
+ * momentarily congested) could take longer than 2s to answer the probe, so the
+ * restore arm force-redialled a socket that was actually fine — upgrading a
+ * cosmetic validation blip into a real teardown+redial (the heavier, longer-visible
+ * flap). 5s aligns with [com.pocketshell.core.connection.LivenessProbe]'s own
+ * `DEFAULT_PER_PROBE_TIMEOUT_MS` — the same budget every other single
+ * control-channel round-trip in the system gets to answer before it is declared
+ * dead — so a live-but-slow channel gets a fair chance to prove alive while a
+ * genuinely dead socket still falls through to the fresh-lease redial.
  */
-internal const val RESTORE_LIVENESS_PROBE_BUDGET_MS: Long = 2_000L
+internal const val RESTORE_LIVENESS_PROBE_BUDGET_MS: Long = 5_000L
+
+/**
+ * Issue #1522 (H1): how long a bare NetworkLost waits before painting the calm
+ * "reconnecting" band. Cellular drops `NET_CAPABILITY_VALIDATED` for sub-second
+ * windows constantly at full signal (RAT handovers, periodic re-validation, v4↔v6
+ * flips) while the TCP / tmux `-CC` channel stays alive; without a debounce each
+ * such blip painted the band immediately and the following restore flipped it back
+ * — the maintainer's connect/disconnect flap on a stable link. A blip that clears
+ * (restore) or that the keepalive can vouch for within this window never paints;
+ * only a loss that OUTLASTS it AND that the keepalive cannot vouch for surfaces the
+ * honest band. 2.5s swallows the transient cellular churn while a genuine sustained
+ * loss still surfaces promptly.
+ */
+internal const val NETWORK_LOSS_BAND_DEBOUNCE_MS: Long = 2_500L
+
+/**
+ * Issue #1522 (amortization): after the loss band has painted at least once on a
+ * flaky link, how long the link must stay quiet (no further loss) following a
+ * restore before the escalating loss-band backoff resets to the base grace. Keeps a
+ * persistently flapping link from hammering a reload every ~1s while letting a
+ * genuinely recovered link return to a snappy base grace.
+ */
+internal const val NETWORK_LOSS_BAND_BACKOFF_QUIET_RESET_MS: Long = 30_000L
 
 /**
  * Classification of a foreground tmux control-channel health probe.

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -70,6 +70,10 @@ import com.pocketshell.app.tmux.connection.debounceReconnectUi
 import com.pocketshell.app.tmux.connection.GraceEffects
 import com.pocketshell.app.tmux.connection.NetworkChangeArm
 import com.pocketshell.app.tmux.connection.NetworkChangeEffects
+import com.pocketshell.app.tmux.connection.NetworkLossBandDebouncer
+import com.pocketshell.app.tmux.connection.recordNetworkLossBandPainted
+import com.pocketshell.app.tmux.connection.recordNetworkLossBandSuppressed
+import com.pocketshell.app.tmux.connection.recordNetworkLossHold
 import com.pocketshell.app.tmux.connection.PassiveDropArm
 import com.pocketshell.app.tmux.connection.PassiveTransportDropEffects
 import com.pocketshell.app.tmux.connection.SshLeaseTransportPort
@@ -4970,6 +4974,9 @@ public class TmuxSessionViewModel @Inject constructor(
             suppressNetworkTransportProvenAlive = {
                 if (target != null) suppressNetworkTransportProvenAlive(it, target)
             },
+            suppressNetworkLostTransportProvenAlive = {
+                if (target != null) suppressNetworkLostTransportProvenAlive(it, target)
+            },
             scheduleNetworkReconnect = {
                 if (target != null) scheduleNetworkReconnect(it, target)
             },
@@ -5286,74 +5293,64 @@ public class TmuxSessionViewModel @Inject constructor(
         )
     }
 
+    /** Issue #1522: debounces + backs off the bare-loss band. */
+    private val networkLossBandDebouncer = NetworkLossBandDebouncer(
+        scope = viewModelScope,
+        baseDebounceMs = NETWORK_LOSS_BAND_DEBOUNCE_MS,
+        backoffLadderMs = { autoReconnectDelaysMs },
+        quietResetMs = NETWORK_LOSS_BAND_BACKOFF_QUIET_RESET_MS,
+        transportKeepAliveProvenAlive = { isTransportKeepAliveProvenAliveRecently() },
+    )
+
     /**
-     * Issue #997: the [NetworkChangeArm.HoldNetworkLost] body. A bare network
-     * LOSS (`onLost` / airplane mode) was observed proactively. We do NOT tear the
-     * lease down — a loss is frequently transient (pocket, elevator) — but we DO
-     * surface the calm "reconnecting" band immediately so the user is not staring
-     * at a live-but-dead session, and we suspend the keepalive probe loop for the
-     * loss window. The probe loop self-suspends: [shouldRunLivenessProbe] only
-     * fires when the controller is `Live`, and flipping to `Reconnecting` here
-     * closes that gate — so probes stop churning writes into the dead socket
-     * without a separate suspend flag. Recovery is driven by the matching
-     * [scheduleNetworkReconnectOnRestore] when validation returns.
+     * Issue #997 / #1522: [NetworkChangeArm.HoldNetworkLost] — a bare loss the
+     * keepalive could NOT vouch for. Hold the lease and DEBOUNCE the band (grace +
+     * escalating backoff): cellular clears `NET_CAPABILITY_VALIDATED` for sub-second
+     * windows constantly on a live link, so an immediate paint + restore is the
+     * maintainer's flap. The band paints only if the loss OUTLASTS the grace and the
+     * keepalive still cannot vouch; a blip that clears (restore → cancel) never flaps.
      */
     private fun holdNetworkLost(
         change: TerminalNetworkChange,
         target: ConnectionTarget,
     ) {
-        val reason = change.reason
-        Log.i(
-            ISSUE_548_NETWORK_TAG,
-            "tmux-network-loss-hold reason=$reason " +
-                "cause=bare-network-loss " +
-                "current=${change.current.logValue} " +
-                targetLogFields(target),
+        recordNetworkLossHold(change, target, connectGeneration, debounced = true)
+        networkLossBandDebouncer.schedule(
+            onSuppressedByKeepAlive = {
+                recordNetworkLossBandSuppressed(
+                    change, target, connectGeneration, cause = "transport_proven_alive_debounced",
+                )
+            },
+            onPaintBand = { graceMs ->
+                recordNetworkLossBandPainted(change, target, connectGeneration, graceMs)
+                setConnectionState(
+                    ConnectionState.Reconnecting(
+                        host = target.host,
+                        port = target.port,
+                        user = target.user,
+                        attempt = 0,
+                        maxAttempts = 0,
+                        retryDelayMs = graceMs,
+                        reason = "Network lost; waiting for it to come back.",
+                    ),
+                )
+            },
         )
-        DiagnosticEvents.record(
-            "connection",
-            "network_loss_hold",
-            "source" to "network_observer",
-            "trigger" to TmuxConnectTrigger.NetworkReconnect.logValue,
-            "reason" to reason,
-            "classification" to "bare_network_loss",
-            "reconnect" to false,
-            "probesSuspended" to true,
-            "leaseHeld" to true,
-            "sequence" to change.sequence,
-            "hostId" to target.hostId,
-            "host" to target.host,
-            "port" to target.port,
-            "user" to target.user,
-            "session" to target.sessionName,
-            "generation" to connectGeneration,
-            "deferredFromBackground" to change.deferredFromBackground,
-            *change.networkDiagnosticFields(),
-        )
-        ReconnectCauseTrail.record(
-            stage = "network_loss_decision",
-            outcome = "hold",
-            cause = "bare_network_loss",
-            trigger = TmuxConnectTrigger.NetworkReconnect.logValue,
-            "sequence" to change.sequence,
-            "hostId" to target.hostId,
-            "generation" to connectGeneration,
-            "classification" to "bare_network_loss",
-            "deferredFromBackground" to change.deferredFromBackground,
-        )
-        // Surface the calm "reconnecting" band WITHOUT launching a redial loop
-        // (the lease is held; recovery fires on restore). A reconnect already in
-        // flight is filtered out by the reducer, so this never clobbers a ladder.
-        setConnectionState(
-            ConnectionState.Reconnecting(
-                host = target.host,
-                port = target.port,
-                user = target.user,
-                attempt = 0,
-                maxAttempts = 0,
-                retryDelayMs = 0L,
-                reason = "Network lost; waiting for it to come back.",
-            ),
+    }
+
+    /**
+     * Issue #1522 (H1): [NetworkChangeArm.SuppressNetworkLostTransportProvenAlive] —
+     * a bare loss the keepalive already vouches for (not a real death). Hold the lease
+     * (still record `network_loss_hold`), suppress the band (stays Live), drop pending.
+     */
+    private fun suppressNetworkLostTransportProvenAlive(
+        change: TerminalNetworkChange,
+        target: ConnectionTarget,
+    ) {
+        networkLossBandDebouncer.cancel()
+        recordNetworkLossHold(change, target, connectGeneration, debounced = false)
+        recordNetworkLossBandSuppressed(
+            change, target, connectGeneration, cause = "transport_proven_alive",
         )
     }
 
@@ -5368,6 +5365,8 @@ public class TmuxSessionViewModel @Inject constructor(
         change: TerminalNetworkChange,
         target: ConnectionTarget,
     ) {
+        // Issue #1522: validation returned — drop any pending debounced band.
+        networkLossBandDebouncer.cancel()
         // Issue #1193: EVERY restore ride-through decision goes through the bounded
         // ACTIVE probe (require an answered round-trip). Ride through only if the
         // (possibly new) path answers; redial via the #997 fresh lease if it does

--- a/app/src/main/java/com/pocketshell/app/tmux/connection/NetworkChangeEffects.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/connection/NetworkChangeEffects.kt
@@ -9,6 +9,7 @@ internal enum class NetworkChangeArm {
     SuppressNetworkNotValidated,
     SuppressNetworkCoalesced,
     SuppressNetworkTransportProvenAlive,
+    SuppressNetworkLostTransportProvenAlive,
     ScheduleNetworkReconnect,
     HoldNetworkLost,
     ScheduleNetworkReconnectOnRestore,
@@ -42,6 +43,17 @@ internal fun selectNetworkChangeArm(
             if (!hasTarget) return NetworkChangeArm.Ignore
             if (!hasClientOrSession) return NetworkChangeArm.Ignore
             if (autoReconnectActive) return NetworkChangeArm.Ignore
+            // Issue #1522 (H1): mirror the ValidatedIdentityChange arm below — a bare
+            // loss of NET_CAPABILITY_VALIDATED on a socket the transport keepalive
+            // still vouches for is NOT a real transport death (cellular clears the
+            // validated bit for sub-second windows constantly while the TCP / -CC
+            // channel stays alive). Suppress the calm band and keep the session Live,
+            // exactly as the identity-change handoff does. When the keepalive CANNOT
+            // vouch we fall through to HoldNetworkLost, whose VM body debounces the
+            // band so a transient blip still does not flap.
+            if (transportKeepAliveProvenAlive()) {
+                return NetworkChangeArm.SuppressNetworkLostTransportProvenAlive
+            }
             return NetworkChangeArm.HoldNetworkLost
         }
         TerminalNetworkChangeKind.NetworkRestored -> {
@@ -80,6 +92,7 @@ internal class NetworkChangeEffects(
     private val suppressNetworkNotValidated: (TerminalNetworkChange) -> Unit,
     private val suppressNetworkCoalesced: (TerminalNetworkChange) -> Unit,
     private val suppressNetworkTransportProvenAlive: (TerminalNetworkChange) -> Unit,
+    private val suppressNetworkLostTransportProvenAlive: (TerminalNetworkChange) -> Unit,
     private val scheduleNetworkReconnect: (TerminalNetworkChange) -> Unit,
     private val holdNetworkLost: (TerminalNetworkChange) -> Unit,
     private val scheduleNetworkReconnectOnRestore: (TerminalNetworkChange) -> Unit,
@@ -102,6 +115,8 @@ internal class NetworkChangeEffects(
                 suppressNetworkCoalesced(change)
             NetworkChangeArm.SuppressNetworkTransportProvenAlive ->
                 suppressNetworkTransportProvenAlive(change)
+            NetworkChangeArm.SuppressNetworkLostTransportProvenAlive ->
+                suppressNetworkLostTransportProvenAlive(change)
             NetworkChangeArm.ScheduleNetworkReconnect ->
                 scheduleNetworkReconnect(change)
             NetworkChangeArm.HoldNetworkLost ->

--- a/app/src/main/java/com/pocketshell/app/tmux/connection/NetworkLossBandEffects.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/connection/NetworkLossBandEffects.kt
@@ -1,0 +1,250 @@
+package com.pocketshell.app.tmux.connection
+
+import android.util.Log
+import com.pocketshell.app.connectivity.TerminalNetworkChange
+import com.pocketshell.app.connectivity.networkDiagnosticFields
+import com.pocketshell.app.diagnostics.DiagnosticEvents
+import com.pocketshell.app.diagnostics.ReconnectCauseTrail
+import com.pocketshell.app.tmux.ISSUE_548_NETWORK_TAG
+import com.pocketshell.app.tmux.TmuxConnectTrigger
+import com.pocketshell.app.tmux.TmuxSessionViewModel.ConnectionTarget
+import com.pocketshell.app.tmux.targetLogFields
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+/**
+ * Issue #1522 (H1 + amortization): debounce AND back off the bare-network-loss
+ * ("reconnecting") band.
+ *
+ * A single sub-second loss of `NET_CAPABILITY_VALIDATED` — which cellular drops
+ * constantly at full signal (RAT handovers, periodic re-validation, v4↔v6 flips)
+ * while the TCP / tmux `-CC` channel stays perfectly alive — used to paint the
+ * calm "reconnecting" band IMMEDIATELY, then a `NetworkRestored` flipped it back:
+ * the maintainer's "it connects, it disconnects, it connects, it disconnects"
+ * flap on a stable link, RELOADING the window every ~1s with no amortization.
+ *
+ * Two levers:
+ * - **Grace (debounce).** A loss schedules the band [baseDebounceMs] later, so a
+ *   blip that clears within the window (restore → [cancel]) or that the keepalive
+ *   can vouch for by fire time NEVER paints. Only a loss that OUTLASTS the grace
+ *   AND that the keepalive cannot vouch for surfaces the honest band.
+ * - **Backoff (amortization).** Each actual band paint escalates the NEXT grace by
+ *   the connection's own auto-reconnect ladder ([backoffLadderMs]), so a
+ *   persistently flaky link reloads progressively LESS often instead of every ~1s.
+ *   A sustained quiet period (no losses for [quietResetMs] after a restore) resets
+ *   the backoff to the base grace.
+ *
+ * The jobs live on the ViewModel's [scope] so they are virtual-clock driven in
+ * tests and cancelled with the scope in production.
+ */
+internal class NetworkLossBandDebouncer(
+    private val scope: CoroutineScope,
+    private val baseDebounceMs: Long,
+    private val backoffLadderMs: () -> List<Long>,
+    private val quietResetMs: Long,
+    private val transportKeepAliveProvenAlive: () -> Boolean,
+) {
+    private var job: Job? = null
+    private var quietResetJob: Job? = null
+
+    /**
+     * How many times the band has painted in the current flap window. Drives the
+     * backoff: 0 → base grace only; N>0 → base + ladder[N-1] (the Nth reload waits
+     * longer). Reset to 0 after a [quietResetMs] lull.
+     */
+    private var reloadCount: Int = 0
+
+    /** The grace the NEXT loss will wait before painting (base + escalating backoff). */
+    fun currentGraceMs(): Long {
+        if (reloadCount == 0) return baseDebounceMs
+        val ladder = backoffLadderMs()
+        if (ladder.isEmpty()) return baseDebounceMs
+        return baseDebounceMs + ladder[(reloadCount - 1).coerceIn(0, ladder.size - 1)]
+    }
+
+    /**
+     * Schedule the calm loss band after the current grace. Re-checks the keepalive
+     * at fire time: if the transport has proven itself alive by then the blip is
+     * suppressed ([onSuppressedByKeepAlive]); otherwise the band is painted
+     * ([onPaintBand], passed the grace it waited so the band can surface it) and the
+     * backoff escalates. A newer loss cancels and reschedules.
+     */
+    fun schedule(onSuppressedByKeepAlive: () -> Unit, onPaintBand: (graceMs: Long) -> Unit) {
+        job?.cancel()
+        quietResetJob?.cancel()
+        quietResetJob = null
+        val grace = currentGraceMs()
+        job = scope.launch {
+            delay(grace)
+            if (transportKeepAliveProvenAlive()) {
+                onSuppressedByKeepAlive()
+            } else {
+                onPaintBand(grace)
+                val ladder = backoffLadderMs()
+                if (ladder.isNotEmpty()) reloadCount = (reloadCount + 1).coerceAtMost(ladder.size)
+            }
+        }
+    }
+
+    /**
+     * Drop any pending debounced band (a restore returned, or the keepalive proved
+     * the socket alive immediately) and arm the quiet-period backoff reset. Returns
+     * whether a band was pending — i.e. whether a blip was just swallowed before it
+     * could paint.
+     */
+    fun cancel(): Boolean {
+        val wasPending = job?.isActive == true
+        job?.cancel()
+        job = null
+        if (reloadCount > 0) {
+            quietResetJob?.cancel()
+            quietResetJob = scope.launch {
+                delay(quietResetMs)
+                reloadCount = 0
+            }
+        }
+        return wasPending
+    }
+}
+
+/**
+ * Issue #997 / #1522: record that a bare network LOSS was observed and the lease
+ * is HELD (no teardown). Fires the `network_loss_hold` device signal that the
+ * bare-loss journeys assert. [debounced] distinguishes the #1522 deferred-band
+ * path (keepalive could not vouch, band scheduled) from the immediate
+ * keepalive-suppressed path.
+ */
+internal fun recordNetworkLossHold(
+    change: TerminalNetworkChange,
+    target: ConnectionTarget,
+    generation: Long,
+    debounced: Boolean,
+) {
+    val reason = change.reason
+    Log.i(
+        ISSUE_548_NETWORK_TAG,
+        "tmux-network-loss-hold reason=$reason cause=bare-network-loss " +
+            "debounced=$debounced current=${change.current.logValue} " +
+            targetLogFields(target),
+    )
+    DiagnosticEvents.record(
+        "connection",
+        "network_loss_hold",
+        "source" to "network_observer",
+        "trigger" to TmuxConnectTrigger.NetworkReconnect.logValue,
+        "reason" to reason,
+        "classification" to "bare_network_loss",
+        "reconnect" to false,
+        "debounced" to debounced,
+        "leaseHeld" to true,
+        "sequence" to change.sequence,
+        "hostId" to target.hostId,
+        "host" to target.host,
+        "port" to target.port,
+        "user" to target.user,
+        "session" to target.sessionName,
+        "generation" to generation,
+        "deferredFromBackground" to change.deferredFromBackground,
+        *change.networkDiagnosticFields(),
+    )
+    ReconnectCauseTrail.record(
+        stage = "network_loss_decision",
+        outcome = "hold",
+        cause = "bare_network_loss",
+        trigger = TmuxConnectTrigger.NetworkReconnect.logValue,
+        "sequence" to change.sequence,
+        "hostId" to target.hostId,
+        "generation" to generation,
+        "classification" to "bare_network_loss",
+        "debounced" to debounced,
+        "deferredFromBackground" to change.deferredFromBackground,
+    )
+}
+
+/**
+ * Issue #1522 (H1): the loss band was SUPPRESSED — the transport keepalive
+ * vouches for the socket so the blip is not a real transport death. Either fired
+ * immediately (keepalive vouched at the loss instant) or at debounce fire time
+ * ([cause]). The session stays Live; no band, no churn.
+ */
+internal fun recordNetworkLossBandSuppressed(
+    change: TerminalNetworkChange,
+    target: ConnectionTarget,
+    generation: Long,
+    cause: String,
+) {
+    val reason = change.reason
+    Log.i(
+        ISSUE_548_NETWORK_TAG,
+        "tmux-network-loss-suppress reason=$reason cause=$cause " +
+            "current=${change.current.logValue} " + targetLogFields(target),
+    )
+    DiagnosticEvents.record(
+        "connection",
+        "network_loss_band_suppressed",
+        "source" to "network_observer",
+        "trigger" to TmuxConnectTrigger.NetworkReconnect.logValue,
+        "reason" to reason,
+        "cause" to cause,
+        "classification" to "bare_network_loss_transport_alive",
+        "reconnect" to false,
+        "leaseHeld" to true,
+        "sequence" to change.sequence,
+        "hostId" to target.hostId,
+        "generation" to generation,
+        "deferredFromBackground" to change.deferredFromBackground,
+        *change.networkDiagnosticFields(),
+    )
+    ReconnectCauseTrail.record(
+        stage = "network_loss_decision",
+        outcome = "suppress",
+        cause = cause,
+        trigger = TmuxConnectTrigger.NetworkReconnect.logValue,
+        "sequence" to change.sequence,
+        "hostId" to target.hostId,
+        "generation" to generation,
+        "classification" to "bare_network_loss_transport_alive",
+        "deferredFromBackground" to change.deferredFromBackground,
+    )
+}
+
+/**
+ * Issue #1522: a bare loss OUTLASTED the (amortized) grace and the keepalive could
+ * not vouch — surface the honest calm band. [graceMs] is the escalating grace this
+ * paint waited (base + backoff), recorded so the amortization is visible in field
+ * logs and a genuine sustained loss is not confused with the swallowed blip.
+ */
+internal fun recordNetworkLossBandPainted(
+    change: TerminalNetworkChange,
+    target: ConnectionTarget,
+    generation: Long,
+    graceMs: Long,
+) {
+    DiagnosticEvents.record(
+        "connection",
+        "network_loss_band_painted",
+        "source" to "network_observer",
+        "trigger" to TmuxConnectTrigger.NetworkReconnect.logValue,
+        "reason" to change.reason,
+        "classification" to "bare_network_loss_sustained",
+        "graceMs" to graceMs,
+        "sequence" to change.sequence,
+        "hostId" to target.hostId,
+        "generation" to generation,
+        "deferredFromBackground" to change.deferredFromBackground,
+    )
+    ReconnectCauseTrail.record(
+        stage = "network_loss_decision",
+        outcome = "paint_band",
+        cause = "bare_network_loss_sustained",
+        trigger = TmuxConnectTrigger.NetworkReconnect.logValue,
+        "sequence" to change.sequence,
+        "hostId" to target.hostId,
+        "generation" to generation,
+        "graceMs" to graceMs,
+        "classification" to "bare_network_loss",
+        "deferredFromBackground" to change.deferredFromBackground,
+    )
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelNetworkLifecycleTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelNetworkLifecycleTest.kt
@@ -665,18 +665,206 @@ class TmuxSessionViewModelNetworkLifecycleTest : TmuxSessionViewModelTestBase() 
         registry.lifecycleHooksSnapshot().single().onNetworkChanged(networkLoss())
         runCurrent()
 
-        // The calm "reconnecting" band is surfaced (UI not left on a dead-but-live
-        // session) WITHOUT launching a redial loop and WITHOUT tearing the lease.
+        // Issue #1522 (H1): the band is now DEBOUNCED — a sub-second cellular
+        // validation blip must NOT flap the UI. Right after the loss (before the
+        // debounce elapses) the session is STILL Connected, not Reconnecting.
         assertTrue(
-            "a bare loss surfaces the calm Reconnecting band immediately",
+            "a bare loss must NOT paint the Reconnecting band immediately (it is debounced) — #1522",
+            vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+        assertEquals("no redial during the loss window — lease is held", 0, connector.connectCount)
+
+        // Once the loss OUTLASTS the debounce (and the keepalive still cannot vouch —
+        // default false here) the honest calm band surfaces so the user is not left on
+        // a dead-but-live session, still WITHOUT a redial and WITHOUT tearing the lease.
+        advanceTimeBy(NETWORK_LOSS_BAND_DEBOUNCE_MS + 1)
+        runCurrent()
+        assertTrue(
+            "a sustained bare loss surfaces the calm Reconnecting band after the debounce",
             vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Reconnecting,
         )
         assertEquals("no redial during the loss window — lease is held", 0, connector.connectCount)
 
-        // No churn: even after time passes nothing redials (no ladder running).
+        // No churn: even after more time passes nothing redials (no ladder running).
         advanceTimeBy(60_000L)
         advanceUntilIdle()
         assertEquals(0, connector.connectCount)
+    }
+
+    @Test
+    fun issue1522RapidValidationBlipsOnStableLinkNeverFlapTheBandOrRedial() = runTest(scheduler) {
+        // Issue #1522 REPRODUCE-FIRST (D33/G10): the maintainer's EXACT stable-LTE
+        // flap — "it connects, it disconnects, it connects, it disconnects." Cellular
+        // drops NET_CAPABILITY_VALIDATED for sub-second windows constantly at full
+        // signal (RAT handovers, periodic re-validation, v4↔v6 flips) while the TCP /
+        // -CC socket stays perfectly alive. Each blip is a NoValidatedNetwork →
+        // Validated pair SHORTER than the loss-band debounce.
+        //
+        // RED on base (no debounce, no keepalive check on the loss arm): each loss
+        // paints the Reconnecting band SYNCHRONOUSLY in holdNetworkLost, so the
+        // "still Connected right after the loss" assertion fails on the very first
+        // blip and the band flaps N times.
+        // GREEN with #1522: the band is debounced and the restore cancels it before
+        // it can paint, so the ConnectionState NEVER leaves Connected across the whole
+        // storm and reconnect_events == 0 (no teardown).
+        TMUX_CONNECT_ATTEMPTS.set(0)
+        val registry = ActiveTmuxClients()
+        val connector = QueueLeaseConnector(FakeSshSession())
+        val vm = newVm(
+            registry = registry,
+            sshLeaseManager = testLeaseManager(connector = connector, scope = this, idleTtlMillis = 0L),
+        )
+        vm.setTmuxClientFactoryForTest { _, _, _ -> FakeTmuxClient().withSinglePane("work", "%1") }
+        vm.setAutoReconnectDelaysForTest(listOf(0L))
+        vm.replaceClientForTest(
+            hostId = 7L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            sessionName = "work",
+            client = FakeTmuxClient(),
+        )
+        runCurrent()
+        assertTrue(vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected)
+
+        // ADVERSARIAL: pin the keepalive so it CANNOT vouch (proven-alive=false) — this
+        // proves the DEBOUNCE alone holds the line, not the immediate keepalive
+        // shortcut. The socket is alive (probe-dead seam OFF) so each restore rides
+        // through with NO redial, isolating the band flap as the symptom (not a real
+        // teardown, which the connectCount assertion also guards).
+        vm.forceTransportProvenAliveForTest = false
+        vm.forceLivenessProbeDeadForTest = false
+
+        val hook = registry.lifecycleHooksSnapshot().single()
+        val blips = 8
+        for (i in 0 until blips) {
+            hook.onNetworkChanged(networkLoss(sequence = (i * 2 + 1).toLong()))
+            runCurrent()
+            // LOAD-BEARING (RED on base = Reconnecting): a sub-second validation blip
+            // must NOT flap the band to Reconnecting.
+            assertTrue(
+                "blip #$i: a transient validation loss must NOT flap the band to Reconnecting " +
+                    "(#1522); got ${vm.connectionStatus.value}",
+                vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected,
+            )
+            // The blip clears well within the debounce window.
+            advanceTimeBy(400L)
+            hook.onNetworkChanged(networkRestore(sequence = (i * 2 + 2).toLong()))
+            advanceUntilIdle()
+            assertTrue(
+                "blip #$i: the restore keeps the session Connected (no flap); " +
+                    "got ${vm.connectionStatus.value}",
+                vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected,
+            )
+        }
+
+        // LOAD-BEARING: zero teardown across the whole stable-LTE churn — the
+        // long-running-session gate's own criterion (reconnect_events == 0).
+        assertEquals(
+            "a stable link's validation churn must never redial (reconnect_events == 0) — #1522",
+            0,
+            connector.connectCount,
+        )
+        assertEquals(0, TMUX_CONNECT_ATTEMPTS.get())
+
+        vm.forceTransportProvenAliveForTest = null
+    }
+
+    @Test
+    fun issue1522SustainedFlapAmortizesBandPaintsViaBackoffNotEverySecond() = runTest(scheduler) {
+        // Issue #1522 (amortization, REPRODUCE-FIRST): the maintainer's second symptom —
+        // on a flaky link the loss reconnect "reloads the window every ~1s with NO
+        // amortization" because holdNetworkLost painted the band with retryDelayMs = 0
+        // (instant reload). The fix gives the loss band a GRACE (debounce) that ESCALATES
+        // via the connection's own auto-reconnect ladder on each actual reload, so a
+        // persistently flapping link reloads progressively LESS often, not every second.
+        //
+        // RED on base (retryDelayMs = 0, no debounce/backoff): the 2nd sustained loss
+        // paints the Reconnecting band IMMEDIATELY → the "still Connected at the base
+        // grace after the 2nd loss" assertion fails (base reloads every loss).
+        // GREEN: the 2nd loss must wait base + ladder[0] before it can paint — proving
+        // the reload is amortized (grace + backoff), not instant.
+        TMUX_CONNECT_ATTEMPTS.set(0)
+        val registry = ActiveTmuxClients()
+        val connector = QueueLeaseConnector(FakeSshSession())
+        val vm = newVm(
+            registry = registry,
+            sshLeaseManager = testLeaseManager(connector = connector, scope = this, idleTtlMillis = 0L),
+        )
+        vm.setTmuxClientFactoryForTest { _, _, _ -> FakeTmuxClient().withSinglePane("work", "%1") }
+        // The auto-reconnect ladder IS the loss-band backoff ladder (#1522).
+        vm.setAutoReconnectDelaysForTest(listOf(3_000L, 6_000L))
+        vm.replaceClientForTest(
+            hostId = 7L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            sessionName = "work",
+            client = FakeTmuxClient(),
+        )
+        runCurrent()
+        // Keepalive can NOT vouch (so a sustained loss paints); the socket is alive so
+        // each restore rides through with no redial (isolating the reload cadence).
+        vm.forceTransportProvenAliveForTest = false
+        vm.forceLivenessProbeDeadForTest = false
+        val hook = registry.lifecycleHooksSnapshot().single()
+
+        // --- Reload #1: the FIRST sustained loss paints after the BASE grace. ---
+        hook.onNetworkChanged(networkLoss(sequence = 1L))
+        advanceTimeBy(NETWORK_LOSS_BAND_DEBOUNCE_MS - 100)
+        runCurrent()
+        assertTrue(
+            "1st loss must not paint before the base grace",
+            vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+        advanceTimeBy(200)
+        runCurrent()
+        assertTrue(
+            "1st sustained loss paints the band after the base grace",
+            vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Reconnecting,
+        )
+        // Link flaps back up briefly (ride-through, no redial). Use runCurrent so the
+        // 30s quiet-reset does NOT fire and reset the backoff before the next loss.
+        hook.onNetworkChanged(networkRestore(sequence = 2L))
+        runCurrent()
+        assertTrue(
+            "the restore rides through back to Connected (no redial)",
+            vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+
+        // --- Reload #2: the SECOND loss must wait base + ladder[0] (BACKOFF). ---
+        hook.onNetworkChanged(networkLoss(sequence = 3L))
+        advanceTimeBy(NETWORK_LOSS_BAND_DEBOUNCE_MS + 100)
+        runCurrent()
+        // LOAD-BEARING (RED on base = Reconnecting instantly): after the base grace the
+        // 2nd loss must STILL be Connected — the backoff extended the grace so the flaky
+        // link is NOT reloading at the base cadence.
+        assertTrue(
+            "2nd sustained loss must be AMORTIZED — still Connected at the base grace because " +
+                "the backoff (base + ladder[0]) extended it; base reloads instantly (#1522)",
+            vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+        // Only after the additional ladder[0] backoff does the 2nd band paint.
+        advanceTimeBy(3_000L)
+        runCurrent()
+        assertTrue(
+            "the 2nd band paints only after base + ladder[0] — proving grace + backoff",
+            vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Reconnecting,
+        )
+
+        // The whole flap never tore the transport down (amortized, not a redial storm).
+        advanceUntilIdle()
+        assertEquals(
+            "a flapping link's amortized reloads must never redial (reconnect_events == 0) — #1522",
+            0,
+            connector.connectCount,
+        )
+
+        vm.forceTransportProvenAliveForTest = null
     }
 
     @Test
@@ -713,11 +901,14 @@ class TmuxSessionViewModelNetworkLifecycleTest : TmuxSessionViewModelTestBase() 
         // falls through to the fresh-lease redial being asserted here.
         vm.forceLivenessProbeDeadForTest = true
 
-        // Loss: hold + flip to Reconnecting (the loss-suspended state).
+        // Loss: hold + (issue #1522) after the debounce elapses — the keepalive is
+        // pinned DEAD here so it cannot vouch — flip to the loss-suspended Reconnecting
+        // state.
         registry.lifecycleHooksSnapshot().single().onNetworkChanged(networkLoss())
+        advanceTimeBy(NETWORK_LOSS_BAND_DEBOUNCE_MS + 1)
         runCurrent()
         assertTrue(
-            "loss leaves the session in the loss-suspended Reconnecting state",
+            "loss leaves the session in the loss-suspended Reconnecting state after the debounce",
             vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Reconnecting,
         )
         assertEquals(0, connector.connectCount)
@@ -1105,7 +1296,11 @@ class TmuxSessionViewModelNetworkLifecycleTest : TmuxSessionViewModelTestBase() 
         )
 
         // The Doze interval: network drops while backgrounded, then restores on wake.
+        // Issue #1522: the band is debounced — the keepalive is dead here so it cannot
+        // vouch, so once the loss OUTLASTS the debounce the loss-suspended Reconnecting
+        // state surfaces.
         registry.lifecycleHooksSnapshot().single().onNetworkChanged(networkLoss())
+        advanceTimeBy(NETWORK_LOSS_BAND_DEBOUNCE_MS + 1)
         runCurrent()
         assertTrue(
             "the loss leaves the session in the loss-suspended Reconnecting state",

--- a/app/src/test/java/com/pocketshell/app/tmux/connection/NetworkChangeEffectsTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/connection/NetworkChangeEffectsTest.kt
@@ -28,7 +28,15 @@ class NetworkChangeEffectsTest {
     }
 
     @Test
-    fun selector_networkLost_holdsWhenLeaseCanBeHeld() {
+    fun selector_networkLost_holdsWhenLeaseCanBeHeldAndKeepAliveCannotVouch() {
+        // Issue #1522 (G6): this is the ONLY case where a bare loss still routes to the
+        // band — the keepalive CANNOT vouch (default { false }), i.e. a genuine
+        // sustained loss. Pre-#1522 this test asserted HoldNetworkLost for EVERY bare
+        // loss regardless of keepalive, which encoded the flap bug (a transient blip on
+        // a live socket painted the band). That unconditional expectation is now split:
+        // keepalive-alive blip → SuppressNetworkLostTransportProvenAlive (no band; see
+        // selector_networkLost_suppressesBandWhenTransportKeepAliveProvenAlive), and
+        // ONLY the keepalive-unproven loss below still holds (then the VM debounces it).
         assertEquals(
             NetworkChangeArm.HoldNetworkLost,
             baseSelect(change = lostChange(), inlineConnected = false),
@@ -40,6 +48,43 @@ class NetworkChangeEffectsTest {
         assertEquals(
             NetworkChangeArm.Ignore,
             baseSelect(change = lostChange(), autoReconnectActive = true),
+        )
+    }
+
+    @Test
+    fun selector_networkLost_suppressesBandWhenTransportKeepAliveProvenAlive() {
+        // Issue #1522 (H1): a bare validation blip on a socket the keepalive still
+        // vouches for is NOT a real transport death — mirror the ValidatedIdentityChange
+        // arm and suppress the band (no flap), keeping the session Live.
+        assertEquals(
+            NetworkChangeArm.SuppressNetworkLostTransportProvenAlive,
+            baseSelect(change = lostChange(), transportKeepAliveProvenAlive = { true }),
+        )
+    }
+
+    @Test
+    fun selector_networkLost_keepAliveGateIsCheckedAfterTargetAndReconnectGuards() {
+        // Issue #1522: the keepalive suppress must not fire when there is no target /
+        // client / when a reconnect already owns the UI — those Ignore paths win first.
+        assertEquals(
+            NetworkChangeArm.Ignore,
+            baseSelect(change = lostChange(), hasTarget = false, transportKeepAliveProvenAlive = { true }),
+        )
+        assertEquals(
+            NetworkChangeArm.Ignore,
+            baseSelect(
+                change = lostChange(),
+                hasClientOrSession = false,
+                transportKeepAliveProvenAlive = { true },
+            ),
+        )
+        assertEquals(
+            NetworkChangeArm.Ignore,
+            baseSelect(
+                change = lostChange(),
+                autoReconnectActive = true,
+                transportKeepAliveProvenAlive = { true },
+            ),
         )
     }
 
@@ -161,10 +206,21 @@ class NetworkChangeEffectsTest {
         )
     }
 
+    @Test
+    fun dispatcher_networkLostProvenAlive_firesSuppressLostArmNotHold() {
+        val recorder = Recorder()
+        val arm = effects(recorder, transportKeepAliveProvenAlive = { true })
+            .dispatch(lostChange())
+
+        assertEquals(NetworkChangeArm.SuppressNetworkLostTransportProvenAlive, arm)
+        assertEquals(Recorder(lostTransportAlive = 1), recorder)
+    }
+
     private data class Recorder(
         var notValidated: Int = 0,
         var coalesced: Int = 0,
         var transportAlive: Int = 0,
+        var lostTransportAlive: Int = 0,
         var reconnect: Int = 0,
         var lost: Int = 0,
         var restored: Int = 0,
@@ -191,6 +247,7 @@ class NetworkChangeEffectsTest {
             suppressNetworkNotValidated = { recorder.notValidated += 1 },
             suppressNetworkCoalesced = { recorder.coalesced += 1 },
             suppressNetworkTransportProvenAlive = { recorder.transportAlive += 1 },
+            suppressNetworkLostTransportProvenAlive = { recorder.lostTransportAlive += 1 },
             scheduleNetworkReconnect = { recorder.reconnect += 1 },
             holdNetworkLost = { recorder.lost += 1 },
             scheduleNetworkReconnectOnRestore = { recorder.restored += 1 },


### PR DESCRIPTION
Closes #1522 — maintainer's #1 active pain: on stable LTE the session flapped (connect/disconnect, reloading the window every ~1s).

**Root cause:** the bare-network-loss band painted the disconnected band on transient losses of `NET_CAPABILITY_VALIDATED` **without consulting the keepalive** (unlike its sibling arm), with no debounce, and the loss-reconnect used `retryDelayMs=0` (immediate reload). Cellular drops the validated bit for sub-second windows constantly at full signal. Prior fixes (#997/#1042/#1193) only hardened the *restore* side.

- **H1** keepalive-aware loss band + **2.5s debounce** (new `NetworkLossBandEffects.kt`) — a blip that clears or that keepalive vouches for never flaps; a **genuine sustained loss still surfaces**.
- **H2** restore-probe budget 2s→5s (no force-redial of a slow-but-alive channel).
- **Amortization** — the loss-reconnect now carries an **escalating grace/backoff** (30s quiet-reset) so a flaky link reloads *progressively less, not every second*.
- **G6** — corrected the existing test that asserted the bug as expected.

**Reviewer:** APPROVED (reopen-class D31 gate) — drove red→green himself on all three parts; the exact rapid-blip scenario **never leaves Connected, 0 redials**; a real drop is **not** swallowed; wrong test genuinely replaced; adjacency clean (#1193 invariant intact, H3 untouched); **full `:app:testDebugUnitTest` 3681 tests / 0 failures**, VM shrank.
**Local gate:** VM ratchet 17618 (shrinks), whitespace clean, full module green (network tests: NetworkChangeEffects 16 / NetworkLifecycle 25 / detector 20, 0 failures).