### PR TITLE
release: bump to v0.4.30 (versionCode 77)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,8 +65,8 @@ android {
         applicationId = "com.pocketshell.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 76
-        versionName = "0.4.29"
+        versionCode = 77
+        versionName = "0.4.30"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/tools/pocketshell/pyproject.toml
+++ b/tools/pocketshell/pyproject.toml
@@ -8,7 +8,7 @@ name = "pocketshell"
 # scripts/check-pypi-version.sh enforces this; .github/workflows/build.yml
 # runs that check before publishing to PyPI. See
 # tools/pocketshell/README.md ("Release flow") for the bump procedure.
-version = "0.4.29"
+version = "0.4.30"
 description = "Unified server-side Python utility for the PocketShell Android client."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Version bump 0.4.29 → **0.4.30** (versionCode 76 → 77), app + tools/pocketshell lockstep.

Ships the connection-stability fixes for the maintainer's active flapping pain:
- **#1522** — keepalive-aware loss band + 2.5s debounce + **amortized/backoff reconnect** (stops the every-~1s window reload on a flaky link)
- **#1521** — always-visible **Reconnect** button in the disconnected state (fixes 'nowhere to tap')

Note: the per-**host** idle-NAT half-open flapping (some hosts flap while others stay stable) is a *different* mechanism (#1497-area), diagnosed and tracked as the follow-up — v0.4.30 fixes the network-blip flapping class, not yet the per-host idle case.