### PR TITLE
connection: keepalive true-30s cadence + amortized keepalive-death redial (#928 Slice 1)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -70,7 +70,12 @@ import com.pocketshell.app.tmux.connection.debounceReconnectUi
 import com.pocketshell.app.tmux.connection.GraceEffects
 import com.pocketshell.app.tmux.connection.NetworkChangeArm
 import com.pocketshell.app.tmux.connection.NetworkChangeEffects
+import com.pocketshell.app.tmux.connection.KEEPALIVE_DEATH_REDIAL_QUIET_RESET_MS
+import com.pocketshell.app.tmux.connection.KeepaliveDeathRedialAmortizer
 import com.pocketshell.app.tmux.connection.NetworkLossBandDebouncer
+import com.pocketshell.app.tmux.connection.recordPassiveDisconnect
+import com.pocketshell.app.tmux.connection.recordSilentReattachFail
+import com.pocketshell.app.tmux.connection.recordSilentReattachStart
 import com.pocketshell.app.tmux.connection.recordNetworkLossBandPainted
 import com.pocketshell.app.tmux.connection.recordNetworkLossBandSuppressed
 import com.pocketshell.app.tmux.connection.recordNetworkLossHold
@@ -112,6 +117,7 @@ import com.pocketshell.core.ssh.SshLeaseManager
 import com.pocketshell.core.ssh.SshLeaseTarget
 import com.pocketshell.core.ssh.SshException
 import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshSessionCloseCause
 import com.pocketshell.core.terminal.bridge.TerminalSeedGateOverflowException
 import com.pocketshell.core.storage.dao.ProjectRootDao
 import com.pocketshell.core.storage.entity.ProjectRootEntity
@@ -1806,6 +1812,7 @@ public class TmuxSessionViewModel @Inject constructor(
     private var autoReconnectDelaysMs: List<Long> = DEFAULT_AUTO_RECONNECT_DELAYS_MS
     private var passiveDisconnectGraceMs: Long = PASSIVE_DISCONNECT_GRACE_MS
     private var silentReattachTimeoutMs: Long = PASSIVE_DISCONNECT_SILENT_REATTACH_TIMEOUT_MS
+    private var keepaliveDeathQuietResetMs: Long = KEEPALIVE_DEATH_REDIAL_QUIET_RESET_MS
 
     /**
      * Issue #448 (epic #432 slice C): a newly-listening remote port the
@@ -3211,9 +3218,11 @@ public class TmuxSessionViewModel @Inject constructor(
     internal fun setPassiveDisconnectRecoveryForTest(
         graceMs: Long = passiveDisconnectGraceMs,
         silentReattachTimeoutMs: Long = this.silentReattachTimeoutMs,
+        keepaliveDeathQuietResetMs: Long = this.keepaliveDeathQuietResetMs,
     ) {
         passiveDisconnectGraceMs = graceMs
         this.silentReattachTimeoutMs = silentReattachTimeoutMs
+        this.keepaliveDeathQuietResetMs = keepaliveDeathQuietResetMs
     }
 
     private fun refreshReconnectAvailability() {
@@ -5300,6 +5309,18 @@ public class TmuxSessionViewModel @Inject constructor(
         backoffLadderMs = { autoReconnectDelaysMs },
         quietResetMs = NETWORK_LOSS_BAND_BACKOFF_QUIET_RESET_MS,
         transportKeepAliveProvenAlive = { isTransportKeepAliveProvenAliveRecently() },
+    )
+
+    /**
+     * Issue #928 (T6): cross-episode amortizer for the KEEPALIVE-DEATH redial —
+     * the per-host idle-flap path outside the #1522 debouncer. Consulted by
+     * [silentReattachWithinPassiveGrace] only when the dropped transport's close
+     * cause is [SshSessionCloseCause.KeepaliveDead].
+     */
+    private val keepaliveDeathRedialAmortizer = KeepaliveDeathRedialAmortizer(
+        scope = viewModelScope,
+        backoffLadderMs = { autoReconnectDelaysMs },
+        quietResetMs = { keepaliveDeathQuietResetMs },
     )
 
     /**
@@ -7835,46 +7856,20 @@ public class TmuxSessionViewModel @Inject constructor(
         target: ConnectionTarget?,
         disconnectEvent: TmuxDisconnectEvent,
     ) {
-        DiagnosticEvents.record(
-            "connection",
-            "passive_disconnect",
-            "source" to "tmux_client_disconnected",
-            "classification" to "real_tmux_control_channel_closed",
-            "disconnectReason" to disconnectEvent.reason.logValue,
-            "disconnectSource" to disconnectEvent.source,
-            "disconnectIntent" to disconnectEvent.intent,
-            "commandKind" to disconnectEvent.commandKind,
-            "timeoutMode" to disconnectEvent.timeoutMode,
-            "exceptionClass" to disconnectEvent.exceptionClass,
-            "message" to disconnectEvent.message,
-            "hostId" to target?.hostId,
-            "host" to target?.host,
-            "port" to target?.port,
-            "user" to target?.user,
-            "session" to target?.sessionName,
-            "clientHash" to System.identityHashCode(client),
-            "generation" to connectGeneration,
-            "attempt" to activeAttachMilestone?.attempt,
-            "activeTrigger" to activeAttachMilestone?.trigger?.logValue,
-            "status" to _connectionStatus.value.javaClass.simpleName,
-            *shortAppSwitchReconnectFields(
+        // Issue #928 (VM-shrink extraction): body lives in the connection sibling.
+        recordPassiveDisconnect(
+            clientHash = System.identityHashCode(client),
+            target = target,
+            disconnectEvent = disconnectEvent,
+            generation = connectGeneration,
+            attempt = activeAttachMilestone?.attempt,
+            activeTrigger = activeAttachMilestone?.trigger?.logValue,
+            status = _connectionStatus.value.javaClass.simpleName,
+            shortAppSwitchFields = shortAppSwitchReconnectFields(
                 trigger = TmuxConnectTrigger.AutoReconnect,
                 target = target,
                 sourceCandidate = "passive_disconnect",
             ),
-        )
-        ReconnectCauseTrail.record(
-            stage = "session_disconnect",
-            outcome = "passive_disconnect",
-            cause = disconnectEvent.reason.logValue,
-            trigger = TmuxConnectTrigger.AutoReconnect.logValue,
-            "hostId" to target?.hostId,
-            "generation" to connectGeneration,
-            "attempt" to activeAttachMilestone?.attempt,
-            "clientHash" to System.identityHashCode(client),
-            "status" to _connectionStatus.value.javaClass.simpleName,
-            "disconnectSource" to disconnectEvent.source,
-            "disconnectIntent" to disconnectEvent.intent,
         )
     }
 
@@ -8037,6 +8032,11 @@ public class TmuxSessionViewModel @Inject constructor(
         disconnectEvent: TmuxDisconnectEvent,
     ) {
         passiveDisconnectGraceJob?.cancel()
+        // Issue #928 (T6): capture the #969 close attribution BEFORE the redial
+        // machinery swaps sessionRef — a keepalive-declared death enters the
+        // per-host amortizer below; every other drop class keeps today's
+        // instant silent reattach.
+        val keepaliveDeath = sessionRef?.closeCause == SshSessionCloseCause.KeepaliveDead
         // Issue #896: this silent-reattach grace loop re-dials the transport and
         // re-reads the (possibly now-gone) session right on the kill→EOF cascade,
         // racing the scope teardown — exactly where an unguarded IO throw against
@@ -8045,6 +8045,13 @@ public class TmuxSessionViewModel @Inject constructor(
         // same handler explicitly so a teardown-race throw here is swallowed +
         // recorded, never a process death.
         val graceJob = viewModelScope.launch(bridgeExceptionHandler) {
+            if (keepaliveDeath && target != null) {
+                // Issue #928 (T6): the Nth-in-a-row keepalive-death episode waits
+                // an escalating grace (honest calm band + #1521 Reconnect button
+                // shown) instead of reloading on a fixed cadence; a manual
+                // reconnect cancels this job and dials immediately (T8 bypass).
+                keepaliveDeathRedialAmortizer.awaitRedialGrace(target, connectGeneration)
+            }
             val recovered = target != null && silentlyReattachWithinPassiveGrace(
                 staleClient = client,
                 target = target,
@@ -8089,20 +8096,12 @@ public class TmuxSessionViewModel @Inject constructor(
         // drain), and never short-circuit a HEALTHY warm reattach (the #635/#553
         // within-grace warm path still runs first when no fresh transport is preferred).
         var transportReattachAttempts = 0
-        DiagnosticEvents.record(
-            "connection",
-            "silent_reattach_start",
-            "source" to "passive_disconnect",
-            "trigger" to TmuxConnectTrigger.AutoReconnect.logValue,
-            "hostId" to target.hostId,
-            "host" to target.host,
-            "port" to target.port,
-            "user" to target.user,
-            "session" to target.sessionName,
-            "clientHash" to System.identityHashCode(staleClient),
-            "timeoutMs" to passiveDisconnectGraceMs,
-            "preferFreshTransport" to preferFreshTransport,
-            *shortAppSwitchReconnectFields(
+        recordSilentReattachStart(
+            target = target,
+            staleClientHash = System.identityHashCode(staleClient),
+            graceMs = passiveDisconnectGraceMs,
+            preferFreshTransport = preferFreshTransport,
+            shortAppSwitchFields = shortAppSwitchReconnectFields(
                 trigger = TmuxConnectTrigger.AutoReconnect,
                 target = target,
                 sourceCandidate = "passive_disconnect",
@@ -8163,22 +8162,11 @@ public class TmuxSessionViewModel @Inject constructor(
             false
         }.also { recovered ->
             if (recovered != true) {
-                DiagnosticEvents.record(
-                    "connection",
-                    "silent_reattach_fail",
-                    "source" to "passive_disconnect",
-                    "trigger" to TmuxConnectTrigger.AutoReconnect.logValue,
-                    "hostId" to target.hostId,
-                    "host" to target.host,
-                    "port" to target.port,
-                    "user" to target.user,
-                    "session" to target.sessionName,
-                    "clientHash" to System.identityHashCode(staleClient),
-                    "cause" to "grace_elapsed",
-                    // EPIC #792 #833: how many fresh-transport re-dials the resilient
-                    // grace loop made across the outage window before grace elapsed.
-                    "transportReattachAttempts" to transportReattachAttempts,
-                    *shortAppSwitchReconnectFields(
+                recordSilentReattachFail(
+                    target = target,
+                    staleClientHash = System.identityHashCode(staleClient),
+                    transportReattachAttempts = transportReattachAttempts,
+                    shortAppSwitchFields = shortAppSwitchReconnectFields(
                         trigger = TmuxConnectTrigger.AutoReconnect,
                         target = target,
                         sourceCandidate = "passive_disconnect",

--- a/app/src/main/java/com/pocketshell/app/tmux/connection/KeepaliveDeathRedialAmortizer.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/connection/KeepaliveDeathRedialAmortizer.kt
@@ -1,0 +1,273 @@
+package com.pocketshell.app.tmux.connection
+
+import com.pocketshell.app.diagnostics.DiagnosticEvents
+import com.pocketshell.app.diagnostics.ReconnectCauseTrail
+import com.pocketshell.app.tmux.TmuxConnectTrigger
+import com.pocketshell.app.tmux.TmuxSessionViewModel.ConnectionTarget
+import com.pocketshell.core.tmux.TmuxDisconnectEvent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+/**
+ * Issue #928 Slice 1b (T6 from the definitive connection-stability audit):
+ * how long a host must stay free of keepalive-death episodes before its
+ * escalated redial backoff resets to the instant first-episode grace. ~5min —
+ * far beyond the observed ~2min NAT-reap flap period, so a genuinely flapping
+ * host keeps its widened cadence while a genuinely recovered one returns to
+ * seamless instant healing.
+ */
+internal const val KEEPALIVE_DEATH_REDIAL_QUIET_RESET_MS: Long = 300_000L
+
+/**
+ * Issue #928 (T6): cross-episode amortization for the KEEPALIVE-DEATH redial —
+ * the per-host idle-flap recovery path the #1522 amortization did not cover.
+ *
+ * ## Why this exists
+ *
+ * The #1522 `NetworkLossBandDebouncer` amortizes the bare-`NetworkLost` band
+ * arm only. The keepalive-death chain never passes through it: the transport
+ * keepalive declares the idle host's NAT-reaped socket dead
+ * (`SshSessionCloseCause.KeepaliveDead`) → `-CC` reader EOF → passive
+ * disconnect → `silentReattachWithinPassiveGrace` re-dials IMMEDIATELY (250ms
+ * spacing inside the episode) — and nothing counted episodes per host. A host
+ * whose carrier NAT reaps its idle mapping every ~2 minutes therefore reloaded
+ * the window every ~2 minutes forever, at a FIXED cadence with zero widening —
+ * the maintainer's per-host connect/disconnect flap.
+ *
+ * ## What it does (the exact [NetworkLossBandDebouncer] shape)
+ *
+ * The silent-reattach grace job consults [awaitRedialGrace] BEFORE its redial
+ * loop, only when the episode's close cause is `KeepaliveDead`:
+ *
+ *  - the FIRST episode waits nothing — a one-off death keeps today's seamless
+ *    instant recovery;
+ *  - the Nth-in-a-row episode waits the connection's own auto-reconnect ladder
+ *    rung ([backoffLadderMs], capped at its last rung) under the honest calm
+ *    band the controller already painted (`Live → Reattaching`), with the
+ *    working #1521 Reconnect button available the whole time;
+ *  - a sustained quiet period ([quietResetMs] with no new episode) resets the
+ *    host back to instant.
+ *
+ * A MANUAL reconnect / Send (T8) never waits here: the user path cancels the
+ * passive-disconnect grace job (this wait runs inside it) and dials through its
+ * own entrypoint immediately. Non-keepalive drop classes (plain reader EOF,
+ * explicit teardown, network handoffs) never consult this at all.
+ *
+ * Per-host state ([ConnectionTarget.hostId]-keyed) because the flap is per-host
+ * — one dying idle host must not slow a healthy sibling's recovery. All state
+ * is confined to the ViewModel's main-dispatcher [scope] (same discipline as
+ * [NetworkLossBandDebouncer]); the jobs are virtual-clock driven in tests and
+ * cancelled with the scope in production.
+ */
+internal class KeepaliveDeathRedialAmortizer(
+    private val scope: CoroutineScope,
+    private val backoffLadderMs: () -> List<Long>,
+    private val quietResetMs: () -> Long,
+) {
+    /**
+     * Keepalive-death episodes seen per host in the current flap window
+     * (capped at the ladder's last rung index so the grace saturates).
+     */
+    private val episodeCountByHost = mutableMapOf<Long, Int>()
+    private val quietResetJobByHost = mutableMapOf<Long, Job>()
+
+    /**
+     * Enter one keepalive-death episode for [target]'s host: record the
+     * amortization decision, then suspend for the episode's grace (nothing for
+     * the first episode; the escalating ladder rung for the Nth-in-a-row).
+     * Cancelling the caller (a manual reconnect superseding the passive grace
+     * job) abandons the wait — the episode still counts, so the flap window
+     * keeps escalating.
+     */
+    suspend fun awaitRedialGrace(target: ConnectionTarget, generation: Long) {
+        val hostId = target.hostId
+        quietResetJobByHost.remove(hostId)?.cancel()
+        val ladder = backoffLadderMs()
+        val count = episodeCountByHost[hostId] ?: 0
+        val graceMs =
+            if (count == 0 || ladder.isEmpty()) 0L
+            else ladder[count.coerceAtMost(ladder.size - 1)]
+        episodeCountByHost[hostId] = (count + 1).coerceAtMost(ladder.size.coerceAtLeast(1))
+        armQuietReset(hostId)
+        recordKeepaliveDeathRedialEpisode(
+            target = target,
+            generation = generation,
+            episode = count + 1,
+            graceMs = graceMs,
+        )
+        if (graceMs > 0L) delay(graceMs)
+    }
+
+    /**
+     * Arm (or re-arm) the per-host quiet window: if no new episode lands within
+     * [quietResetMs], the host's backoff resets to the instant first-episode
+     * grace. Armed from the episode START so the window measures "time since
+     * the last death", the property that distinguishes a flapping host from a
+     * recovered one.
+     */
+    private fun armQuietReset(hostId: Long) {
+        val job = scope.launch {
+            delay(quietResetMs())
+            episodeCountByHost.remove(hostId)
+        }
+        quietResetJobByHost[hostId] = job
+        job.invokeOnCompletion {
+            if (quietResetJobByHost[hostId] === job) quietResetJobByHost.remove(hostId)
+        }
+    }
+}
+
+/**
+ * Issue #928 (T6): the per-episode amortization decision, visible in field logs
+ * so a widening flap cadence is directly observable on-device (the audit's exit
+ * criterion for slice 1b).
+ */
+private fun recordKeepaliveDeathRedialEpisode(
+    target: ConnectionTarget,
+    generation: Long,
+    episode: Int,
+    graceMs: Long,
+) {
+    DiagnosticEvents.record(
+        "connection",
+        "keepalive_death_redial_amortized",
+        "source" to "passive_disconnect",
+        "trigger" to TmuxConnectTrigger.AutoReconnect.logValue,
+        "cause" to KEEPALIVE_DEAD_REASON,
+        "episode" to episode,
+        "graceMs" to graceMs,
+        "hostId" to target.hostId,
+        "host" to target.host,
+        "port" to target.port,
+        "user" to target.user,
+        "session" to target.sessionName,
+        "generation" to generation,
+    )
+    ReconnectCauseTrail.record(
+        stage = "keepalive_death_redial",
+        outcome = if (graceMs > 0L) "amortized" else "instant",
+        cause = KEEPALIVE_DEAD_REASON,
+        trigger = TmuxConnectTrigger.AutoReconnect.logValue,
+        "hostId" to target.hostId,
+        "episode" to episode,
+        "graceMs" to graceMs,
+        "generation" to generation,
+    )
+}
+
+/**
+ * Issue #928 (VM-shrink extraction): the canonical `passive_disconnect`
+ * diagnostic + `session_disconnect` reconnect-cause trail — a REAL tmux control
+ * channel closed for the current client. Field set unchanged from the former
+ * inline body of `TmuxSessionViewModel.recordPassiveDisconnectDiagnostic`.
+ */
+internal fun recordPassiveDisconnect(
+    clientHash: Int,
+    target: ConnectionTarget?,
+    disconnectEvent: TmuxDisconnectEvent,
+    generation: Long,
+    attempt: Int?,
+    activeTrigger: String?,
+    status: String,
+    shortAppSwitchFields: Array<out Pair<String, Any?>>,
+) {
+    DiagnosticEvents.record(
+        "connection",
+        "passive_disconnect",
+        "source" to "tmux_client_disconnected",
+        "classification" to "real_tmux_control_channel_closed",
+        "disconnectReason" to disconnectEvent.reason.logValue,
+        "disconnectSource" to disconnectEvent.source,
+        "disconnectIntent" to disconnectEvent.intent,
+        "commandKind" to disconnectEvent.commandKind,
+        "timeoutMode" to disconnectEvent.timeoutMode,
+        "exceptionClass" to disconnectEvent.exceptionClass,
+        "message" to disconnectEvent.message,
+        "hostId" to target?.hostId,
+        "host" to target?.host,
+        "port" to target?.port,
+        "user" to target?.user,
+        "session" to target?.sessionName,
+        "clientHash" to clientHash,
+        "generation" to generation,
+        "attempt" to attempt,
+        "activeTrigger" to activeTrigger,
+        "status" to status,
+        *shortAppSwitchFields,
+    )
+    ReconnectCauseTrail.record(
+        stage = "session_disconnect",
+        outcome = "passive_disconnect",
+        cause = disconnectEvent.reason.logValue,
+        trigger = TmuxConnectTrigger.AutoReconnect.logValue,
+        "hostId" to target?.hostId,
+        "generation" to generation,
+        "attempt" to attempt,
+        "clientHash" to clientHash,
+        "status" to status,
+        "disconnectSource" to disconnectEvent.source,
+        "disconnectIntent" to disconnectEvent.intent,
+    )
+}
+
+/**
+ * EPIC #792 #833 / issue #928 (VM-shrink extraction): the `silent_reattach_start`
+ * diagnostic — the passive-disconnect silent-reattach grace loop is starting for
+ * [target]. Field set unchanged from the former inline record in
+ * `TmuxSessionViewModel.silentlyReattachWithinPassiveGrace`.
+ */
+internal fun recordSilentReattachStart(
+    target: ConnectionTarget,
+    staleClientHash: Int,
+    graceMs: Long,
+    preferFreshTransport: Boolean,
+    shortAppSwitchFields: Array<out Pair<String, Any?>>,
+) {
+    DiagnosticEvents.record(
+        "connection",
+        "silent_reattach_start",
+        "source" to "passive_disconnect",
+        "trigger" to TmuxConnectTrigger.AutoReconnect.logValue,
+        "hostId" to target.hostId,
+        "host" to target.host,
+        "port" to target.port,
+        "user" to target.user,
+        "session" to target.sessionName,
+        "clientHash" to staleClientHash,
+        "timeoutMs" to graceMs,
+        "preferFreshTransport" to preferFreshTransport,
+        *shortAppSwitchFields,
+    )
+}
+
+/**
+ * EPIC #792 #833 / issue #928 (VM-shrink extraction): the `silent_reattach_fail`
+ * diagnostic — the grace window elapsed without recovery.
+ * [transportReattachAttempts] is how many fresh-transport re-dials the resilient
+ * grace loop made across the outage window before grace elapsed. Field set
+ * unchanged from the former inline record.
+ */
+internal fun recordSilentReattachFail(
+    target: ConnectionTarget,
+    staleClientHash: Int,
+    transportReattachAttempts: Int,
+    shortAppSwitchFields: Array<out Pair<String, Any?>>,
+) {
+    DiagnosticEvents.record(
+        "connection",
+        "silent_reattach_fail",
+        "source" to "passive_disconnect",
+        "trigger" to TmuxConnectTrigger.AutoReconnect.logValue,
+        "hostId" to target.hostId,
+        "host" to target.host,
+        "port" to target.port,
+        "user" to target.user,
+        "session" to target.sessionName,
+        "clientHash" to staleClientHash,
+        "cause" to "grace_elapsed",
+        "transportReattachAttempts" to transportReattachAttempts,
+        *shortAppSwitchFields,
+    )
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionKeepaliveDeathAmortizationTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionKeepaliveDeathAmortizationTest.kt
@@ -1,0 +1,434 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.app.diagnostics.installRecordingDiagnosticSink
+import com.pocketshell.app.sessions.ActiveTmuxClients
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.SshKey
+import com.pocketshell.core.ssh.SshLeaseConnector
+import com.pocketshell.core.ssh.SshLeaseKey
+import com.pocketshell.core.ssh.SshLeaseTarget
+import com.pocketshell.core.ssh.SshPortForward
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshSessionCloseCause
+import com.pocketshell.core.ssh.SshShell
+import com.pocketshell.core.tmux.CommandResponse
+import com.pocketshell.core.tmux.TmuxDisconnectEvent
+import com.pocketshell.core.tmux.TmuxDisconnectReason
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+import java.io.InputStream
+
+/**
+ * Issue #928 Slice 1b (T6 from the definitive connection-stability audit) — the
+ * keepalive-death redial must be AMORTIZED across episodes, not fixed-cadence.
+ *
+ * ## The reported defect (reproduced RED on base)
+ *
+ * The per-host idle flap: an idle host's NAT mapping dies, the transport
+ * keepalive declares the peer dead (`SshSessionCloseCause.KeepaliveDead`), the
+ * `-CC` reader EOFs, and `silentReattachWithinPassiveGrace` re-dials a fresh
+ * transport IMMEDIATELY — full reseed, visible window reload. The fresh idle
+ * socket then dies again ~2 minutes later, forever. The #1522 debouncer/backoff
+ * amortizes only the bare-`NetworkLost` band arm; the keepalive-death recovery
+ * path (reader-EOF → passive disconnect → silent reattach) had NO debounce and
+ * NO cross-episode amortization, so a flapping host reloaded every ~2min at a
+ * FIXED cadence with zero widening.
+ *
+ * ## The fix these tests pin (GREEN)
+ *
+ * A per-host [com.pocketshell.app.tmux.connection.KeepaliveDeathRedialAmortizer]
+ * (the exact `NetworkLossBandDebouncer` shape from #1522) consulted at the top
+ * of the silent-reattach grace job when the episode's close cause is
+ * `KeepaliveDead`:
+ *
+ *  - the FIRST episode heals instantly (today's behaviour — a one-off death
+ *    stays a seamless recovery);
+ *  - the Nth-in-a-row episode waits progressively longer (the connection's own
+ *    auto-reconnect ladder) under the honest calm band before re-dialing;
+ *  - a sustained quiet period resets the backoff to instant;
+ *  - a MANUAL reconnect (user action) bypasses the wait entirely (T8);
+ *  - a NON-keepalive drop (plain reader EOF) is never amortized — the gate is
+ *    scoped to the keepalive-death class only.
+ *
+ * Deterministic: the whole journey runs on the shared virtual clock
+ * ([TmuxSessionViewModelTestBase.scheduler]); the amortizer waits are asserted
+ * by advancing EXACTLY up to (and then past) each expected grace. No
+ * `advanceUntilIdle()` between episodes — it would fast-forward the quiet-reset
+ * window and erase the cross-episode state under test.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class TmuxSessionKeepaliveDeathAmortizationTest : TmuxSessionViewModelTestBase() {
+
+    private companion object {
+        /** The amortization ladder (the production auto-reconnect ladder shape). */
+        val LADDER_MS = listOf(0L, 1_000L, 2_000L, 5_000L)
+
+        /** Shortened quiet-reset window for the deterministic virtual-clock pin. */
+        const val QUIET_RESET_MS = 10_000L
+    }
+
+    private class Rig(
+        val vm: TmuxSessionViewModel,
+        val registry: ActiveTmuxClients,
+        val connector: QueueLeaseConnector,
+        val sessions: List<FakeSshSession>,
+        val initialSession: FakeSshSession,
+        val initialClient: FakeTmuxClient,
+        val replacementClients: List<FakeTmuxClient>,
+    ) {
+        /** The tmux client currently attached after [recovered] recoveries. */
+        fun clientAfterRecoveries(recoveries: Int): FakeTmuxClient =
+            if (recoveries == 0) initialClient else replacementClients[recoveries - 1]
+
+        /** The SSH session currently held after [recoveries] recoveries. */
+        fun sessionAfterRecoveries(recoveries: Int): FakeSshSession =
+            if (recoveries == 0) initialSession else sessions[recoveries - 1]
+    }
+
+    private fun TestScope.buildRig(): Rig {
+        val registry = ActiveTmuxClients()
+        val sessions = List(4) { FakeSshSession() }
+        val connector = QueueLeaseConnector(*sessions.toTypedArray())
+        val vm = newVm(
+            registry = registry,
+            sshLeaseManager = testLeaseManager(
+                connector = connector,
+                scope = this,
+                idleTtlMillis = 60_000L,
+            ),
+        )
+        vm.setPassiveDisconnectRecoveryForTest(
+            graceMs = 60_000L,
+            silentReattachTimeoutMs = 60_000L,
+            keepaliveDeathQuietResetMs = QUIET_RESET_MS,
+        )
+        vm.setAutoReconnectDelaysForTest(LADDER_MS)
+        val replacementClients = List(4) { i ->
+            FakeTmuxClient().withSinglePane("work", "%${i + 1}")
+        }
+        val replacementQueue = ArrayDeque(replacementClients)
+        vm.setTmuxClientFactoryForTest { _, sessionName, _ ->
+            assertEquals("work", sessionName)
+            replacementQueue.removeFirstOrNull() ?: error("unexpected tmux client factory call")
+        }
+        val initialSession = FakeSshSession()
+        val initialClient = FakeTmuxClient()
+        vm.replaceClientForTest(
+            hostId = 7L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            sessionName = "work",
+            client = initialClient,
+            session = initialSession,
+        )
+        runCurrent()
+        return Rig(
+            vm = vm,
+            registry = registry,
+            connector = connector,
+            sessions = sessions,
+            initialSession = initialSession,
+            initialClient = initialClient,
+            replacementClients = replacementClients,
+        )
+    }
+
+    /**
+     * One keepalive-death episode, exactly as production produces it: the
+     * transport keepalive stamps [SshSessionCloseCause.KeepaliveDead] BEFORE
+     * closing the dead transport (#969), then the `-CC` reader EOFs.
+     */
+    private fun killByKeepalive(session: FakeSshSession, client: FakeTmuxClient) {
+        session.closeCauseValue = SshSessionCloseCause.KeepaliveDead
+        session.closed = true
+        client.markDisconnectedForTest(
+            TmuxDisconnectEvent(
+                reason = TmuxDisconnectReason.ReaderEof,
+                source = "eof",
+                intent = "unknown",
+            ),
+        )
+    }
+
+    private fun TestScope.awaitConnected(rig: Rig) {
+        awaitCondition {
+            rig.vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected
+        }
+    }
+
+    // ---- 1. The core red→green: episodes widen instead of reloading on a fixed cadence ----
+
+    @Test
+    fun consecutiveKeepaliveDeathEpisodesRedialWithWideningGraceNotFixedCadence() = runTest(scheduler) {
+        val diagnostics = installRecordingDiagnosticSink()
+        try {
+            val rig = buildRig()
+
+            // Episode 1: the FIRST keepalive death heals instantly (today's
+            // seamless one-off recovery must be preserved).
+            killByKeepalive(rig.sessionAfterRecoveries(0), rig.clientAfterRecoveries(0))
+            runCurrent()
+            assertEquals(
+                "the FIRST keepalive-death episode must re-dial instantly (no amortizer wait)",
+                1,
+                rig.connector.connectCount,
+            )
+            awaitConnected(rig)
+
+            // Episode 2: the SECOND consecutive death must NOT re-dial instantly —
+            // this is the un-amortized fixed-cadence reload (RED on base).
+            killByKeepalive(rig.sessionAfterRecoveries(1), rig.clientAfterRecoveries(1))
+            runCurrent()
+            assertEquals(
+                "issue #928 (T6) — the 2nd consecutive keepalive-death episode must WAIT " +
+                    "the amortized grace (${LADDER_MS[1]}ms) before re-dialing. An instant " +
+                    "re-dial is the un-amortized fixed-cadence reload: a flapping idle host " +
+                    "reloads the window every ~2min forever with zero widening.",
+                1,
+                rig.connector.connectCount,
+            )
+            advanceTimeBy(LADDER_MS[1] - 1)
+            runCurrent()
+            assertEquals(
+                "the 2nd episode's re-dial must still be held 1ms before its amortized grace",
+                1,
+                rig.connector.connectCount,
+            )
+            advanceTimeBy(1)
+            runCurrent()
+            assertEquals(
+                "the 2nd episode must re-dial once its amortized grace elapses (the host " +
+                    "still auto-recovers — amortized, not abandoned)",
+                2,
+                rig.connector.connectCount,
+            )
+            awaitConnected(rig)
+
+            // Episode 3: the grace must WIDEN (next ladder rung), not repeat.
+            killByKeepalive(rig.sessionAfterRecoveries(2), rig.clientAfterRecoveries(2))
+            runCurrent()
+            advanceTimeBy(LADDER_MS[2] - 1)
+            runCurrent()
+            assertEquals(
+                "the 3rd consecutive episode's grace must WIDEN to the next ladder rung " +
+                    "(${LADDER_MS[2]}ms) — strictly widening cadence under a persistent flap",
+                2,
+                rig.connector.connectCount,
+            )
+            advanceTimeBy(1)
+            runCurrent()
+            assertEquals(3, rig.connector.connectCount)
+            awaitConnected(rig)
+
+            // The amortization is observable in field logs (the audit's exit
+            // criterion): episode + graceMs recorded per episode.
+            val episodes = diagnostics.eventsNamed("keepalive_death_redial_amortized")
+            assertEquals(
+                "every keepalive-death episode must record its amortization decision",
+                listOf(0L, LADDER_MS[1], LADDER_MS[2]),
+                episodes.map { it.fields["graceMs"] },
+            )
+            assertEquals(listOf(1, 2, 3), episodes.map { it.fields["episode"] })
+        } finally {
+            diagnostics.close()
+        }
+    }
+
+    // ---- 2. Quiet reset: a genuinely recovered host returns to instant healing ----
+
+    @Test
+    fun sustainedQuietPeriodResetsTheKeepaliveDeathBackoffToInstant() = runTest(scheduler) {
+        val rig = buildRig()
+
+        // Two episodes escalate the backoff...
+        killByKeepalive(rig.sessionAfterRecoveries(0), rig.clientAfterRecoveries(0))
+        runCurrent()
+        awaitConnected(rig)
+        killByKeepalive(rig.sessionAfterRecoveries(1), rig.clientAfterRecoveries(1))
+        runCurrent()
+        advanceTimeBy(LADDER_MS[1])
+        runCurrent()
+        assertEquals(2, rig.connector.connectCount)
+        awaitConnected(rig)
+
+        // ...then the host stays QUIET past the reset window (no further deaths).
+        advanceTimeBy(QUIET_RESET_MS + 1)
+        runCurrent()
+
+        // The next death is a FRESH first episode: instant heal again.
+        killByKeepalive(rig.sessionAfterRecoveries(2), rig.clientAfterRecoveries(2))
+        runCurrent()
+        assertEquals(
+            "after a sustained quiet period the keepalive-death backoff must RESET — " +
+                "the next episode heals instantly like a fresh first death",
+            3,
+            rig.connector.connectCount,
+        )
+        awaitConnected(rig)
+    }
+
+    // ---- 3. T8 guard: a MANUAL reconnect bypasses the amortizer wait ----
+
+    @Test
+    fun manualReconnectBypassesTheKeepaliveDeathAmortizerWait() = runTest(scheduler) {
+        val rig = buildRig()
+
+        killByKeepalive(rig.sessionAfterRecoveries(0), rig.clientAfterRecoveries(0))
+        runCurrent()
+        assertEquals(1, rig.connector.connectCount)
+        awaitConnected(rig)
+
+        // Episode 2 enters its amortized wait (1s)...
+        killByKeepalive(rig.sessionAfterRecoveries(1), rig.clientAfterRecoveries(1))
+        runCurrent()
+        assertEquals("episode 2 must be holding its amortized grace", 1, rig.connector.connectCount)
+
+        // ...and the USER taps Reconnect: a deliberate action dials NOW, with no
+        // virtual time advanced past the pending grace (the T8 bypass).
+        assertTrue("manual reconnect must be accepted", rig.vm.reconnect())
+        awaitCondition { rig.connector.connectCount >= 2 }
+        assertEquals(
+            "a manual reconnect must dial immediately — the amortizer only delays the " +
+                "AUTOMATIC keepalive-death redial, never a deliberate user action",
+            2,
+            rig.connector.connectCount,
+        )
+        awaitConnected(rig)
+    }
+
+    // ---- 4. Class guard: a NON-keepalive drop is never amortized ----
+
+    @Test
+    fun plainReaderEofDropIsNeverAmortizedEvenAfterKeepaliveEpisodes() = runTest(scheduler) {
+        val rig = buildRig()
+
+        // Elevate the keepalive-death backoff with two episodes...
+        killByKeepalive(rig.sessionAfterRecoveries(0), rig.clientAfterRecoveries(0))
+        runCurrent()
+        awaitConnected(rig)
+        killByKeepalive(rig.sessionAfterRecoveries(1), rig.clientAfterRecoveries(1))
+        runCurrent()
+        advanceTimeBy(LADDER_MS[1])
+        runCurrent()
+        assertEquals(2, rig.connector.connectCount)
+        awaitConnected(rig)
+
+        // ...then a PLAIN reader-EOF drop (closeCause stays Unknown — not a
+        // keepalive death). It must re-dial instantly: the amortizer is scoped
+        // to the keepalive-death class only.
+        val session = rig.sessionAfterRecoveries(2)
+        session.closed = true
+        rig.clientAfterRecoveries(2).markDisconnectedForTest(
+            TmuxDisconnectEvent(
+                reason = TmuxDisconnectReason.ReaderEof,
+                source = "eof",
+                intent = "unknown",
+            ),
+        )
+        runCurrent()
+        assertEquals(
+            "a NON-keepalive transport drop (plain reader EOF) must keep today's instant " +
+                "silent reattach even while the keepalive-death backoff is elevated — the " +
+                "amortizer must never delay recovery for other drop classes",
+            3,
+            rig.connector.connectCount,
+        )
+        awaitConnected(rig)
+    }
+
+    // ---- test doubles (the TmuxSessionViewModelPassiveReconnectTest shapes) ----
+
+    private class QueueLeaseConnector(
+        private vararg val sessions: FakeSshSession,
+    ) : SshLeaseConnector {
+        var connectCount: Int = 0
+            private set
+
+        override suspend fun connect(target: SshLeaseTarget): Result<SshSession> {
+            val next = sessions.getOrNull(connectCount)
+                ?: error("unexpected lease connect $connectCount for ${target.leaseKey}")
+            connectCount += 1
+            return Result.success(next)
+        }
+    }
+
+    private fun FakeTmuxClient.withSinglePane(
+        sessionName: String,
+        paneId: String,
+    ): FakeTmuxClient = apply {
+        responses.addLast(
+            CommandResponse(
+                number = 1L,
+                output = listOf("$paneId\t@0\t\$0\t$sessionName\t$sessionName\t0"),
+                isError = false,
+            ),
+        )
+        capturePaneResponses.addLast(
+            CommandResponse(number = 2L, output = listOf("$sessionName ready"), isError = false),
+        )
+        cursorQueryResponses.addLast(
+            CommandResponse(number = 3L, output = listOf("0,0"), isError = false),
+        )
+    }
+
+    private class FakeSshSession : SshSession {
+        @Volatile
+        var closed: Boolean = false
+
+        /**
+         * The #969 close attribution: the transport keepalive stamps
+         * [SshSessionCloseCause.KeepaliveDead] BEFORE closing the dead
+         * transport; a plain EOF/teardown leaves it [SshSessionCloseCause.Unknown].
+         */
+        @Volatile
+        var closeCauseValue: SshSessionCloseCause = SshSessionCloseCause.Unknown
+
+        override val closeCause: SshSessionCloseCause
+            get() = closeCauseValue
+
+        override val isConnected: Boolean
+            get() = !closed
+
+        override suspend fun exec(command: String): ExecResult =
+            ExecResult(stdout = "", stderr = "", exitCode = 0)
+
+        override fun tail(path: String, onLine: (String) -> Unit): Job = Job()
+
+        override fun openLocalPortForward(
+            remoteHost: String,
+            remotePort: Int,
+            localPort: Int,
+        ): SshPortForward = throw NotImplementedError("not needed")
+
+        override fun startShell(): SshShell = throw NotImplementedError("not needed")
+
+        override suspend fun uploadFile(file: File, remotePath: String): String = remotePath
+
+        override suspend fun uploadStream(
+            input: InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String = remotePath
+
+        override fun close() {
+            closed = true
+        }
+    }
+}

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/TransportKeepAlive.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/TransportKeepAlive.kt
@@ -159,6 +159,21 @@ internal class TransportKeepAlive(
     private var consecutiveMisses: Int = 0
 
     /**
+     * Issue #928 (T1a) — the inbound-activity watermark produced by the loop's
+     * OWN most recent successful keepalive reply (snapshotted right after
+     * [sendOne] returns true, when the reply has bumped
+     * [KeepAliveIo.lastInboundActivityNanos]). The reset-on-activity skip must
+     * key off REAL user/agent traffic only: if the watermark still equals this
+     * snapshot at the next tick, the only "recent inbound" is our own ping's
+     * reply — the link is genuinely idle and MUST be pinged on cadence, never
+     * skipped. Any newer watermark is real traffic (or a late reply after a
+     * miss — the #1059 proof-of-life, which must keep counting). The check errs
+     * toward pinging: a real byte racing the snapshot to the same nanosecond
+     * costs one extra harmless ping, never a suppressed one.
+     */
+    private var lastOwnKeepAliveReplyActivityNanos: Long = Long.MIN_VALUE
+
+    /**
      * Issue #1059 (R2) — the inbound-activity watermark captured at the START of the
      * current miss streak. If it ADVANCES before the streak would declare the peer
      * dead, a late keepalive reply (or any server byte) landed mid-streak — the link
@@ -172,11 +187,35 @@ internal class TransportKeepAlive(
 
     /**
      * Start the keepalive loop in [scope]. Idempotent: a second [start] while a
-     * loop is active is a no-op. Each tick sleeps [intervalMs], then — only if
-     * [KeepAliveIo.isAlive] and there was no recent inbound activity — sends one
-     * keepalive through the dispatcher, counting consecutive misses; on
-     * [countMax] it fires [KeepAliveIo.onKeepAliveDead] ONCE and stops counting
-     * (the recovery path now owns the transport).
+     * loop is active is a no-op. Each tick — only if [KeepAliveIo.isAlive] and
+     * there was no recent REAL inbound/outbound activity — sends one keepalive
+     * through the dispatcher, counting consecutive misses; on [countMax] it
+     * fires [KeepAliveIo.onKeepAliveDead] ONCE and stops counting (the recovery
+     * path now owns the transport).
+     *
+     * ## Issue #928 (T1a) — true-cadence anchoring (no tick-grid aliasing)
+     *
+     * The pre-#928 loop slept a FULL [intervalMs] from every tick, including a
+     * tick that SKIPPED its ping because real activity landed mid-sleep. A
+     * server byte arriving just after a tick was therefore next protected by a
+     * keep-warm ping only ~2×interval later, and a peer dying right after it was
+     * declared dead only at ~(countMax+1)×interval — so any carrier NAT whose
+     * idle window sits in the (interval, 2×interval) band reaped the idle
+     * mapping BETWEEN pings (the per-host idle flap: the busy host's own traffic
+     * keeps its mapping warm, the idle host's does not). Two corrections:
+     *
+     *  1. the skip path anchors the NEXT wake at `activity + intervalMs` (sleeps
+     *     only the remainder), so an idle-going link is pinged within one
+     *     interval of its LAST real activity regardless of tick phase; and
+     *  2. the loop's OWN reply is excluded from the skip decision
+     *     ([lastOwnKeepAliveReplyActivityNanos]), so a fully idle link holds the
+     *     true `ServerAliveInterval`-style cadence — the ping's reply can never
+     *     suppress the next scheduled ping.
+     *
+     * The busy-link intent is unchanged: REAL inbound/outbound within the last
+     * interval still skips the ping (OpenSSH reset-on-server-traffic), and the
+     * #1059/#1072 late-reply/upload ride-through still keys off the watermark
+     * advancing across a miss streak.
      *
      * ## Issue #1059 (R2) — idle high-RTT / bufferbloat false-positive bound
      *
@@ -196,9 +235,12 @@ internal class TransportKeepAlive(
         if (job?.isActive == true) return
         consecutiveMisses = 0
         missStreakStartActivityNanos = 0L
+        lastOwnKeepAliveReplyActivityNanos = Long.MIN_VALUE
         job = scope.launch {
+            var sleepMs = intervalMs
             while (isActive) {
-                delay(intervalMs)
+                delay(sleepMs)
+                sleepMs = intervalMs
                 if (!io.isAlive()) {
                     // Transport gone (closed/disconnected): end the loop. The
                     // recovery machinery owns it now.
@@ -212,16 +254,31 @@ internal class TransportKeepAlive(
                 // This is why a heavy `%output` burst is POSITIVE proof of life,
                 // not a missed probe; and why a steadily-streaming attachment
                 // upload (pure outbound) must NOT be torn down mid-upload (#1072).
-                val sinceActivityNanos = now() - io.lastActivityNanos()
-                if (sinceActivityNanos in 0 until intervalNanos()) {
+                // Issue #928 (T1a): our OWN reply is NOT such activity — a fully
+                // idle link must hold the true cadence, never skip off its own
+                // ping's echo.
+                val activityNanos = io.lastActivityNanos()
+                val sinceActivityNanos = now() - activityNanos
+                val ownReplyOnly = activityNanos == lastOwnKeepAliveReplyActivityNanos
+                if (!ownReplyOnly && sinceActivityNanos in 0 until intervalNanos()) {
                     if (consecutiveMisses != 0) {
                         log("keepalive: inbound activity, reset after $consecutiveMisses miss(es)")
                     }
                     consecutiveMisses = 0
+                    // Issue #928 (T1a): anchor the NEXT ping one interval after
+                    // the REAL activity (sleep only the remainder). Re-sleeping a
+                    // full interval from the tick grid let the wire-idle gap
+                    // reach ~2×interval — the aliasing that reaped idle carrier-
+                    // NAT mappings between pings.
+                    sleepMs = remainingMsUntil(activityNanos + intervalNanos())
                     continue
                 }
                 val alive = sendOne()
                 if (alive) {
+                    // Issue #928 (T1a): snapshot the watermark our own reply just
+                    // bumped so it can never masquerade as real inbound at the
+                    // next tick's skip decision.
+                    lastOwnKeepAliveReplyActivityNanos = io.lastActivityNanos()
                     if (consecutiveMisses != 0) {
                         log("keepalive: recovered after $consecutiveMisses miss(es)")
                     }
@@ -290,6 +347,18 @@ internal class TransportKeepAlive(
     private fun intervalNanos(): Long = intervalMs * 1_000_000L
 
     /**
+     * Issue #928 (T1a) — milliseconds (ceil, ≥1) until [deadlineNanos] on the
+     * loop's [now] clock. Ceil so the wake never lands before the deadline in
+     * this clock domain; the ≥1 floor keeps a raced/past deadline from becoming
+     * a hot `delay(0)` spin — the next tick then pings promptly.
+     */
+    private fun remainingMsUntil(deadlineNanos: Long): Long {
+        val remainingNanos = deadlineNanos - now()
+        if (remainingNanos <= 0L) return 1L
+        return ((remainingNanos + 999_999L) / 1_000_000L).coerceAtLeast(1L)
+    }
+
+    /**
      * Issue #1072 — the single "most recent proof of life" timestamp the loop
      * keys every reset/ride-through decision off: the LATER of the last inbound
      * server byte and the last outbound upload progress. Either one proves the
@@ -335,6 +404,11 @@ internal class TransportKeepAlive(
          * counter has not yet reached [countMax] when the link recovers and the
          * next keepalive (or any inbound byte) resets it — exactly the Terminus
          * "absorb the blip" behaviour PocketShell lacked.
+         *
+         * Issue #928 (T1a) made this arithmetic TRUE for every tick phase: the
+         * anchored cadence pings within one interval of the last real activity,
+         * so the worst case is genuinely countMax × interval — not the aliased
+         * (countMax+1) × interval the fixed tick grid allowed.
          */
 
         /**

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/NatIdleMappingSurvivalKeepAliveTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/NatIdleMappingSurvivalKeepAliveTest.kt
@@ -11,10 +11,10 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * Issue #1063 (R3, from the #843 round-2 mobile audit / gap C2) — the carrier-NAT
- * idle-mapping SURVIVAL regression guard for the always-on transport keepalive
- * INTERVAL. D31/D32 (G2/G6) / D33 (reproduce → fix → verify) / G9 (a test per
- * acceptance criterion).
+ * Issue #1063 (R3, from the #843 round-2 mobile audit / gap C2) + issue #928
+ * Slice 1a — the carrier-NAT idle-mapping SURVIVAL regression guard for the
+ * always-on transport keepalive CADENCE. D31/D32 (G2/G6) / D33 (reproduce →
+ * fix → verify) / G9 (a test per acceptance criterion).
  *
  * --------------------------------------------------------------------------
  * THE REAL-WORLD TRIGGER IT PINS
@@ -24,92 +24,76 @@ import org.junit.Test
  * below RFC 5382's 2h4m floor, which mobile carriers routinely violate). Once the
  * mapping is gone the path is HALF-OPEN: both ends still believe the socket is up,
  * but packets are silently dropped. PocketShell's always-on
- * [TransportKeepAlive] (#945) prevents this: on an idle link it sends one
- * `keepalive@openssh.com` per [TransportKeepAlive] `intervalMs`, and EVERY reply is
- * inbound traffic that resets the carrier-NAT idle timer — so the mapping never
- * sits idle long enough to be reaped. This is *by design*, but nothing pinned it.
- * A future interval retune (e.g. bumping it past W to "save battery") would
- * silently break long-idle survival on cellular and the maintainer would only find
- * out by losing a session after reading/recording a voice note for a minute.
+ * [TransportKeepAlive] (#945) prevents this: on an idle link it keeps the wire-idle
+ * gap below one `intervalMs`, so the mapping never sits idle long enough to be
+ * reaped. This is *by design*, but two distinct regressions can break it:
+ *
+ *  1. an interval RETUNE past W ("save battery") — the original #1063 guard; and
+ *  2. the #928 T1a TICK-GRID ALIASING: the loop skipped the ping when real
+ *     activity landed within the last interval, then re-slept a FULL interval
+ *     from the tick — so the wire-idle gap after a mid-sleep server byte could
+ *     reach ~2×interval, and any NAT window in the (interval, 2×interval) band
+ *     was reaped BETWEEN pings even though `interval < W` held on paper.
  *
  * --------------------------------------------------------------------------
- * WHY THIS LIVES AT THE KEEPALIVE LAYER, NOT THE CONNECTED `-CC` ORACLE (round 2)
+ * WHY THE PRE-#928 SHAPE OF THIS TEST MASKED THE ALIASING (the corrected model)
  *
- * Round 1 tried to prove this on the live connected session by disabling the
- * foreground `-CC` LivenessProbe and reading the production transport-liveness
- * oracle [RealSshSession.isTransportProvenAliveWithinKeepAliveWindow] across a long
- * idle, claiming the keepalive was then the SOLE inbound source. The reviewer RAN
- * it on emulator + Docker and proved that premise FALSE: with the keepalive retuned
- * to 600s (effectively OFF) the oracle still stayed proven-alive for the whole 130s
- * — so something OTHER than the keepalive refreshes inbound activity inside the
- * window. That something is the tmux `-CC` control channel itself: every byte its
- * reader decodes calls `recordInboundActivity()`
- * (`RealSshSession.startInteractiveShell`, `onInboundActivity = ::recordInbound-`
- * `Activity`), and an attached `-CC` session is never fully silent (status / layout
- * notifications). On a live attached session the keepalive can therefore NEVER be
- * isolated as the sole inbound source, so the connected oracle CANNOT give a true
- * red→green for "interval < NAT window" — the GREEN passes vacuously (it would stay
- * green through the exact interval regression it claims to guard).
+ * The old fake reported an always-stale inbound watermark (`now − 100×interval`),
+ * so the loop's reset-on-inbound skip NEVER fired — the model pinged on every
+ * tick by construction and could not exhibit the aliasing. And its parameters
+ * (1s interval vs 3s NAT window) meant even a genuinely aliased 2s effective
+ * cadence still fit inside the window. This corrected model is FAITHFUL to
+ * production [RealSshSession] semantics instead:
  *
- * So the load-bearing red→green pivots HERE, to the layer where the keepalive IS
- * the deciding factor (the #1059 / [TransportKeepAliveIdleHighRttTest] model): the
- * real [TransportKeepAlive] loop drives the inbound-refresh cadence, a faithful
- * carrier-NAT idle-timer model reaps the mapping when an idle gap exceeds W, and
- * the keepalive INTERVAL is the sole variable. The connected, real-wire RECOVERY
- * proof (the carrier NAT actually reaps the mapping mid-idle and the keepalive
- * drives recovery) stays in `app/.../proof/NatIdleMappingSurvivalE2eTest.kt` over
- * the toxiproxy half-open harness (Arm 2). This JVM pair is Arm 1 (survival) and
- * runs in the per-push Unit gate (`:shared:core-ssh:test`).
+ *  - the loop's `now` clock is the VIRTUAL scheduler clock;
+ *  - the inbound watermark starts at attach (t=0) and every successful keepalive
+ *    REPLY bumps it (issue #974 — the reply IS decoded inbound bytes);
+ *  - sporadic REAL server bytes (`-CC` status lines on a mostly-idle agent host)
+ *    bump the watermark AND refresh the NAT idle timer, exactly as on the wire;
+ *  - the NAT window sits BETWEEN 1× and 2× the interval, the band the aliasing
+ *    defect exposes and a correct anchored cadence protects.
  *
  * --------------------------------------------------------------------------
  * THE MODEL (faithful, deterministic, virtual-time)
  *
  * - [CarrierNatIdleMapping] is the carrier NAT's idle timer: it records every
- *   inbound refresh (the keepalive reply) at the VIRTUAL clock time and is "reaped"
- *   the instant the gap since the last refresh exceeds the modelled idle window W.
- *   The session attach itself is the first refresh (t=0), as on the real wire.
+ *   inbound refresh (keepalive reply or real server byte) at the VIRTUAL clock
+ *   time and is "reaped" the instant the gap since the last refresh exceeds the
+ *   modelled idle window W. The session attach itself is the first refresh (t=0).
  * - [KeepAliveDrivenNatIo] is the [TransportKeepAlive.KeepAliveIo] the real loop
- *   ticks. Its [TransportKeepAlive.KeepAliveIo.lastInboundActivityNanos] is reported
- *   far-older-than-one-interval (the #1059 trick) so reset-on-inbound never skips the
- *   ping on this idle link — i.e. the loop genuinely sends one ping per interval,
- *   exactly as on a quiet cellular link. Each
- *   [TransportKeepAlive.KeepAliveIo.sendKeepAlive] models the server answering: it
- *   refreshes the NAT mapping at the current virtual time and returns alive=true.
+ *   ticks, with the faithful watermark semantics above.
  *
- * The mapping survives iff the keepalive refreshes it within W — i.e. iff the
- * keepalive INTERVAL < W. That is the whole contract, and the interval is the only
- * thing that differs between the GREEN and the RED-control arms.
+ * The mapping survives iff the keepalive keeps every wire-idle gap below W.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class NatIdleMappingSurvivalKeepAliveTest {
 
     private companion object {
-        /**
-         * The modelled carrier-NAT idle window W. The keepalive must refresh the
-         * mapping more often than this or the NAT reaps it.
-         */
-        const val NAT_WINDOW_MS = 3_000L
+        /** The keepalive interval driving every arm below. */
+        const val INTERVAL_MS = 1_000L
 
         /**
-         * LIVE keepalive (Arm 1, GREEN): a reply lands every 1s, comfortably inside
-         * the 3s NAT window — the NAT idle timer is reset before it can fire.
+         * Issue #928 (T1a): the modelled carrier-NAT idle window W sits BETWEEN
+         * 1× and 2× the keepalive interval — the exact band the tick-grid
+         * aliasing exposed (effective idle gap up to ~2×interval) and that the
+         * anchored true-cadence loop protects (gap ≤ interval).
          */
-        const val LIVE_INTERVAL_MS = 1_000L
+        const val NAT_WINDOW_MS = 1_500L
 
         /**
-         * OVER-LONG keepalive (Arm 1, RED CONTROL / the regression): a reply lands
-         * only every 5s, longer than the 3s NAT window — so the idle mapping ages
-         * past W between refreshes and the carrier NAT reaps it.
+         * OVER-LONG keepalive (RED CONTROL / the original #1063 regression): a
+         * refresh lands only every 5s, longer than the NAT window — so the idle
+         * mapping ages past W between refreshes and the carrier NAT reaps it.
          */
         const val OVER_LONG_INTERVAL_MS = 5_000L
 
         const val COUNT_MAX = 3
 
         /** Idle hold: several NAT windows so the survival/reap outcome is stable. */
-        const val IDLE_HOLD_MS = 24_000L
+        const val IDLE_HOLD_MS = 12_000L
 
-        /** Sample the NAT idle timer this often (well below W) to catch any reap. */
-        const val SAMPLE_MS = 250L
+        /** Virtual-time step: fine enough to place chatter/samples precisely. */
+        const val STEP_MS = 50L
 
         /**
          * The minimum realistic AGGRESSIVE carrier-NAT TCP idle window. Real CGNAT
@@ -140,35 +124,40 @@ class NatIdleMappingSurvivalKeepAliveTest {
     }
 
     /**
-     * The [TransportKeepAlive.KeepAliveIo] the real loop ticks. Each keepalive
-     * reply refreshes the carrier-NAT mapping at the current virtual time.
+     * The FAITHFUL [TransportKeepAlive.KeepAliveIo]: the inbound watermark starts
+     * at attach and every successful keepalive reply bumps it (production #974
+     * semantics — this is what the pre-#928 fake masked); every reply and every
+     * real server byte refreshes the carrier-NAT idle timer at virtual time.
      */
     private class KeepAliveDrivenNatIo(
-        private val intervalMs: Long,
         private val nat: CarrierNatIdleMapping,
-        private val virtualNowMs: () -> Long,
+        private val virtualNowNanos: () -> Long,
     ) : TransportKeepAlive.KeepAliveIo {
         var pingsSent: Int = 0
         var deadDeclaredWith: Int? = null
+        private var inboundWatermarkNanos: Long = virtualNowNanos()
 
         override fun isAlive(): Boolean = true
 
-        // Far older than one interval (the #1059 trick) so reset-on-inbound never
-        // skips the ping on this idle link: the loop sends exactly one ping per
-        // interval, as on a quiet cellular link.
-        override fun lastInboundActivityNanos(): Long =
-            System.nanoTime() - 100L * intervalMs * 1_000_000L
+        override fun lastInboundActivityNanos(): Long = inboundWatermarkNanos
 
         override suspend fun sendKeepAlive(): Boolean {
             pingsSent += 1
-            // The server answered — an inbound byte that resets the carrier-NAT
-            // idle timer at the current virtual time.
-            nat.refresh(virtualNowMs())
+            // The server answered — decoded inbound bytes that reset BOTH the
+            // carrier-NAT idle timer and the session's inbound watermark (#974).
+            nat.refresh(virtualNowNanos() / 1_000_000L)
+            inboundWatermarkNanos = virtualNowNanos()
             return true
         }
 
         override fun onKeepAliveDead(consecutiveMisses: Int) {
             deadDeclaredWith = consecutiveMisses
+        }
+
+        /** A real server byte (a `-CC` status line) lands NOW: watermark + NAT. */
+        fun chatter() {
+            nat.refresh(virtualNowNanos() / 1_000_000L)
+            inboundWatermarkNanos = virtualNowNanos()
         }
     }
 
@@ -179,7 +168,9 @@ class NatIdleMappingSurvivalKeepAliveTest {
 
     /**
      * Drives the real [TransportKeepAlive] loop at [intervalMs] across the idle
-     * hold, sampling the modelled carrier NAT each [SAMPLE_MS] of virtual time.
+     * hold, sampling the modelled carrier NAT each [STEP_MS] of virtual time and
+     * injecting a real server byte at each of [chatterAtMs] (multiples of
+     * [STEP_MS]).
      *
      * Virtual time is driven by a STANDALONE [TestCoroutineScheduler] +
      * [StandardTestDispatcher], NOT `runTest`. The keepalive loop is `while (isActive)`
@@ -199,23 +190,31 @@ class NatIdleMappingSurvivalKeepAliveTest {
      * sibling's latent leak is tracked separately; the durable fix is a
      * `CoroutineExceptionHandler` on `RealSshSession`'s background scope.)
      */
-    private fun runIdleHold(intervalMs: Long): IdleHoldResult {
+    private fun runIdleHold(
+        intervalMs: Long,
+        chatterAtMs: Set<Long> = emptySet(),
+    ): IdleHoldResult {
         val scheduler = TestCoroutineScheduler()
         val scope = CoroutineScope(StandardTestDispatcher(scheduler))
         val nat = CarrierNatIdleMapping(NAT_WINDOW_MS)
         val io = KeepAliveDrivenNatIo(
-            intervalMs = intervalMs,
             nat = nat,
-            virtualNowMs = { scheduler.currentTime },
+            virtualNowNanos = { scheduler.currentTime * 1_000_000L },
         )
-        val keepAlive = TransportKeepAlive(io = io, intervalMs = intervalMs, countMax = COUNT_MAX)
+        val keepAlive = TransportKeepAlive(
+            io = io,
+            intervalMs = intervalMs,
+            countMax = COUNT_MAX,
+            now = { scheduler.currentTime * 1_000_000L },
+        )
         keepAlive.start(scope)
 
         var elapsed = 0L
         while (elapsed < IDLE_HOLD_MS) {
-            scheduler.advanceTimeBy(SAMPLE_MS)
+            scheduler.advanceTimeBy(STEP_MS)
             scheduler.runCurrent()
-            elapsed += SAMPLE_MS
+            elapsed += STEP_MS
+            if (scheduler.currentTime in chatterAtMs) io.chatter()
             nat.sample(scheduler.currentTime)
         }
         keepAlive.stop()
@@ -225,13 +224,14 @@ class NatIdleMappingSurvivalKeepAliveTest {
         return IdleHoldResult(io, nat)
     }
 
-    // ---- ARM 1: idle-mapping survival, the deterministic red→green pin ----
+    // ---- ARM 1: idle-mapping survival on the TRUE cadence (the #928 red→green pin) ----
 
     @Test
     fun liveKeepAliveKeepsIdleNatMappingWarmAcrossLongIdle() {
-        // GREEN: interval (1s) < NAT window (3s) — every reply resets the idle timer
-        // before it fires, so the carrier NAT never reaps the idle mapping.
-        val result = runIdleHold(LIVE_INTERVAL_MS)
+        // GREEN: interval (1s) < NAT window (1.5s) and the loop holds the TRUE
+        // cadence — every wire-idle gap stays ≤ interval, so the carrier NAT never
+        // reaps the fully idle mapping.
+        val result = runIdleHold(INTERVAL_MS)
 
         assertTrue(
             "the keepalive must have actually pinged the idle link (one per interval)",
@@ -243,19 +243,48 @@ class NatIdleMappingSurvivalKeepAliveTest {
         )
         assertFalse(
             "the carrier NAT must NEVER reap the mapping while the keepalive interval " +
-                "(${LIVE_INTERVAL_MS}ms) is shorter than the ${NAT_WINDOW_MS}ms idle " +
+                "(${INTERVAL_MS}ms) is shorter than the ${NAT_WINDOW_MS}ms idle " +
                 "window — every reply resets the idle timer. If this fails the keepalive " +
-                "interval was retuned past the NAT window (the regression this guards).",
+                "cadence regressed past the NAT window.",
+            result.nat.everReaped,
+        )
+    }
+
+    @Test
+    fun sporadicChatterOnIdleLinkMustNotOpenANatWindowSizedPingGap() {
+        // Issue #928 (T1a) — THE ALIASING PIN (RED on the pre-#928 loop, GREEN with
+        // the anchored cadence). A real server byte lands just AFTER a tick
+        // (t=2100, ticks on the 1000ms grid). The aliased loop then skipped the
+        // t=3000 ping and re-slept a FULL interval — no wire packet until t=4000,
+        // a 1900ms idle gap that BLOWS the 1500ms NAT window even though
+        // `interval < W` holds. The anchored loop pings at t≈3100 (one interval
+        // after the byte), keeping every gap ≤ interval and the mapping warm.
+        val result = runIdleHold(INTERVAL_MS, chatterAtMs = setOf(2_100L))
+
+        assertTrue(
+            "the keepalive must still be pinging the mostly-idle link",
+            result.io.pingsSent > 0,
+        )
+        assertNull(
+            "a live link is never declared dead while its keepalive replies keep arriving",
+            result.io.deadDeclaredWith,
+        )
+        assertFalse(
+            "issue #928 (T1a): a sporadic real server byte landing mid-sleep must NOT " +
+                "open a wire-idle gap of ~2×interval before the next keep-warm ping. The " +
+                "carrier NAT (window ${NAT_WINDOW_MS}ms, between 1× and 2× the " +
+                "${INTERVAL_MS}ms interval) reaped the idle mapping — the tick-grid " +
+                "aliasing defect that flapped exactly the maintainer's idle host.",
             result.nat.everReaped,
         )
     }
 
     @Test
     fun overLongKeepAliveLetsIdleNatMappingAgeOut() {
-        // RED CONTROL (G6): interval (5s) > NAT window (3s) — between keepalive
+        // RED CONTROL (G6): interval (5s) > NAT window (1.5s) — between keepalive
         // refreshes the mapping sits idle longer than W, so the carrier NAT reaps it.
-        // This proves the GREEN assertion above is LOAD-BEARING: with the keepalive
-        // retuned past the NAT window the mapping is genuinely lost.
+        // This proves the GREEN assertions above are LOAD-BEARING: with the keepalive
+        // cadence past the NAT window the mapping is genuinely lost.
         val result = runIdleHold(OVER_LONG_INTERVAL_MS)
 
         assertTrue(
@@ -266,7 +295,7 @@ class NatIdleMappingSurvivalKeepAliveTest {
             "with the keepalive interval (${OVER_LONG_INTERVAL_MS}ms) retuned PAST the " +
                 "${NAT_WINDOW_MS}ms NAT idle window, the idle mapping MUST age out between " +
                 "refreshes (the carrier NAT reaps it). If this does not happen the survival " +
-                "assertion in the sibling GREEN test would be vacuous.",
+                "assertions in the sibling GREEN tests would be vacuous.",
             result.nat.everReaped,
         )
     }

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/TransportKeepAliveIdleCadenceTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/TransportKeepAliveIdleCadenceTest.kt
@@ -1,0 +1,242 @@
+package com.pocketshell.core.ssh
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #928 Slice 1a (T1a from the definitive connection-stability audit) — the
+ * keepalive tick-grid ALIASING defect: on a mostly-idle link the gap between the
+ * last wire activity and the next keep-warm ping could reach ~2×interval, and
+ * dead detection could take ~(countMax+1)×interval — NOT the documented
+ * `ServerAliveInterval 30` cadence / `countMax × interval` (90s) budget.
+ *
+ * ## The defect mechanism (reproduced RED on base by this test)
+ *
+ * The loop ticked on a fixed `delay(intervalMs)` grid. When a REAL server byte
+ * landed mid-sleep (an occasional `-CC` status line on an otherwise idle agent
+ * host — exactly the maintainer's flapping idle host), the next tick saw
+ * "activity within the last interval" and SKIPPED the ping — then re-slept a
+ * FULL interval from the tick, not from the activity. So a byte landing just
+ * after a tick was next protected by a ping only ~2×interval−ε later:
+ *
+ *     tick t=60s → ping ok; real byte at t=60.1s; tick t=90s → skip (29.9s ago);
+ *     tick t=120s → ping. NAT keep-warm gap = 59.9s ≈ 2×interval.
+ *
+ * Any carrier NAT whose idle window sits in the (interval, 2×interval) band —
+ * a real 30-60s CGNAT band on cellular — is then reaped BETWEEN pings, killing
+ * exactly the idle host while the busy host stays glued (the #1522 per-host
+ * divergence). And once the peer dies right after such a byte, the first probe
+ * fires up to 2×interval later, so death lands at ~(countMax+1)×interval.
+ *
+ * ## The fix this pins (GREEN)
+ *
+ * The skip path anchors the NEXT ping one interval after the ACTIVITY (sleep
+ * only the remainder), and the loop's OWN keepalive reply is never counted as
+ * "recent inbound" that suppresses the next scheduled ping. An idle link is
+ * therefore pinged within intervalMs(+ε) of its last wire activity, and a dead
+ * peer is declared within countMax×interval(+ε) of its last proof of life.
+ *
+ * ## Determinism
+ *
+ * Same standalone-scheduler shape as [NatIdleMappingSurvivalKeepAliveTest]
+ * (no `runTest`, so no process-wide ExceptionCollector callback): the loop's
+ * `now` clock is injected from the virtual scheduler, and the IO is FAITHFUL to
+ * production [RealSshSession] semantics — a successful keepalive reply bumps the
+ * inbound watermark (issue #974/#945), which is precisely what the old fake
+ * masked (it reported an always-stale watermark, so the aliasing never showed).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class TransportKeepAliveIdleCadenceTest {
+
+    private companion object {
+        const val INTERVAL_MS = 30_000L
+        const val COUNT_MAX = 3
+
+        /**
+         * Generous tolerance for ms-ceil rounding + tick scheduling. The defect
+         * being pinned is a full-interval (30s) overshoot, so 1s of slack keeps
+         * the assertion load-bearing while never flaking on rounding.
+         */
+        const val SLACK_MS = 1_000L
+    }
+
+    /**
+     * A FAITHFUL production-shaped [TransportKeepAlive.KeepAliveIo] on the
+     * virtual clock: the inbound watermark starts at attach (t=0, as
+     * [RealSshSession]'s init stamps it), a successful keepalive reply bumps it
+     * (issue #974 — the reply IS inbound activity), and [chatter] models a real
+     * server byte (`-CC` status output) landing on the otherwise idle link.
+     */
+    private class FaithfulIdleIo(
+        private val virtualNowNanos: () -> Long,
+    ) : TransportKeepAlive.KeepAliveIo {
+        var inboundWatermarkNanos: Long = virtualNowNanos()
+        var replyAnswers: Boolean = true
+        val pingTimesMs = mutableListOf<Long>()
+        var deadDeclaredAtMs: Long? = null
+        private var alive = true
+
+        override fun isAlive(): Boolean = alive
+        override fun lastInboundActivityNanos(): Long = inboundWatermarkNanos
+
+        override suspend fun sendKeepAlive(): Boolean {
+            pingTimesMs += virtualNowNanos() / 1_000_000L
+            if (!replyAnswers) return false
+            // The server answered: the reply is decoded inbound bytes, so it
+            // bumps the SAME watermark real traffic does (production #974).
+            inboundWatermarkNanos = virtualNowNanos()
+            return true
+        }
+
+        override fun onKeepAliveDead(consecutiveMisses: Int) {
+            deadDeclaredAtMs = virtualNowNanos() / 1_000_000L
+            // Faithful to production: the dead-peer reaction closes the
+            // transport, so the loop's isAlive() gate goes false and the loop
+            // ends (the recovery machinery owns the transport from here).
+            alive = false
+        }
+
+        /** A real server byte (e.g. one `-CC` status line) lands NOW. */
+        fun chatter() {
+            inboundWatermarkNanos = virtualNowNanos()
+        }
+    }
+
+    private class Harness {
+        val scheduler = TestCoroutineScheduler()
+        val scope = CoroutineScope(StandardTestDispatcher(scheduler))
+        val io = FaithfulIdleIo(virtualNowNanos = { scheduler.currentTime * 1_000_000L })
+        val keepAlive = TransportKeepAlive(
+            io = io,
+            intervalMs = INTERVAL_MS,
+            countMax = COUNT_MAX,
+            now = { scheduler.currentTime * 1_000_000L },
+        )
+
+        fun advanceToMs(targetMs: Long) {
+            val step = 100L
+            while (scheduler.currentTime < targetMs) {
+                scheduler.advanceTimeBy(step)
+                scheduler.runCurrent()
+            }
+        }
+
+        fun finish() {
+            keepAlive.stop()
+            scope.cancel()
+        }
+    }
+
+    // ---- 1. The keep-warm gap: RED on base (~2×interval), GREEN with the fix ----
+
+    @Test
+    fun idleLinkIsPingedWithinOneIntervalOfItsLastRealActivity() {
+        val h = Harness()
+        h.keepAlive.start(h.scope)
+
+        // Settle two on-cadence pings on the fully idle link (t=30s, t=60s).
+        h.advanceToMs(60_000L)
+
+        // A single real server byte lands just AFTER the t=60s tick — the
+        // adversarial phase (an idle agent host's sporadic `-CC` status line).
+        h.advanceToMs(60_100L)
+        h.io.chatter()
+        val chatterAtMs = h.scheduler.currentTime
+
+        // Hold idle long enough for the next keep-warm ping wherever it lands.
+        h.advanceToMs(130_000L)
+
+        val nextPingAtMs = h.io.pingTimesMs.firstOrNull { it > chatterAtMs }
+        assertNotNull(
+            "the idle link must be pinged again after its last real activity",
+            nextPingAtMs,
+        )
+        val gapMs = nextPingAtMs!! - chatterAtMs
+        assertTrue(
+            "issue #928 (T1a) — the NAT keep-warm gap after the last real activity must be " +
+                "~one interval (${INTERVAL_MS}ms), got ${gapMs}ms. A gap near 2×interval is " +
+                "the tick-grid aliasing defect: the skip path re-slept a FULL interval from " +
+                "the tick instead of anchoring the next ping at lastActivity+interval, so a " +
+                "carrier NAT with an idle window in the (interval, 2×interval) band reaps " +
+                "the idle mapping between pings — the per-host idle flap.",
+            gapMs <= INTERVAL_MS + SLACK_MS,
+        )
+        assertNull("a live answering link must never be declared dead", h.io.deadDeclaredAtMs)
+        h.finish()
+    }
+
+    // ---- 2. Dead detection budget: RED on base (~4×interval), GREEN with the fix ----
+
+    @Test
+    fun deadPeerAfterMidSleepActivityIsDeclaredWithinCountMaxIntervals() {
+        val h = Harness()
+        h.keepAlive.start(h.scope)
+
+        // Settle two on-cadence pings, then the adversarial-phase real byte...
+        h.advanceToMs(60_000L)
+        h.advanceToMs(60_100L)
+        h.io.chatter()
+        val lastActivityMs = h.scheduler.currentTime
+        // ...and the peer dies silently right after it (half-open: no bytes, no
+        // replies, watermark frozen from here on).
+        h.io.replyAnswers = false
+
+        // Hold well past both the documented and the aliased budgets.
+        h.advanceToMs(lastActivityMs + 6 * INTERVAL_MS)
+
+        assertNotNull(
+            "a genuinely silent peer must be declared dead",
+            h.io.deadDeclaredAtMs,
+        )
+        val detectionMs = h.io.deadDeclaredAtMs!! - lastActivityMs
+        assertTrue(
+            "issue #928 (T1a) — dead detection must land within the documented " +
+                "countMax×interval (${COUNT_MAX * INTERVAL_MS}ms) of the last proof of " +
+                "life, got ${detectionMs}ms. ~(countMax+1)×interval means the first probe " +
+                "was aliased a full extra interval out by the tick grid, stretching the " +
+                "silent half-open window past the #945 budget.",
+            detectionMs <= COUNT_MAX * INTERVAL_MS + SLACK_MS,
+        )
+        h.finish()
+    }
+
+    // ---- 3. Steady idle cadence: the class guard (the reply must not suppress pings) ----
+
+    @Test
+    fun fullyIdleLinkIsPingedOnTheTrueIntervalCadenceNotEveryOtherInterval() {
+        // The brief's REAL-cadence pin: an idle link is pinged at ~interval
+        // (ServerAliveInterval semantics), NOT ~2×interval. This is the guard
+        // against the whole aliasing CLASS — in particular against any future
+        // change that lets the keepalive's OWN reply count as "recent inbound"
+        // and skip (suppress) the next scheduled ping.
+        val h = Harness()
+        h.keepAlive.start(h.scope)
+
+        val holdIntervals = 10
+        h.advanceToMs(holdIntervals * INTERVAL_MS + SLACK_MS)
+
+        assertEquals(
+            "a fully idle link must be pinged once per interval across the hold " +
+                "(true ${INTERVAL_MS}ms cadence — half the pings means the keepalive's own " +
+                "reply is suppressing the next tick's ping, issue #928 T1a)",
+            holdIntervals,
+            h.io.pingTimesMs.size,
+        )
+        val maxGapMs = (listOf(0L) + h.io.pingTimesMs).zipWithNext { a, b -> b - a }.max()
+        assertTrue(
+            "consecutive keep-warm pings on a fully idle link must stay ~interval apart " +
+                "(max gap ${maxGapMs}ms, budget ${INTERVAL_MS + SLACK_MS}ms)",
+            maxGapMs <= INTERVAL_MS + SLACK_MS,
+        )
+        assertNull("a live answering link must never be declared dead", h.io.deadDeclaredAtMs)
+        h.finish()
+    }
+}


### PR DESCRIPTION
Refs #928 — **Slice 1** of the definitive connection-stability roadmap: the root-cause fix for the maintainer's **per-host idle flapping**.

**Root cause:** `TransportKeepAlive` tick-grid aliasing — the keepalive ping's OWN reply counted as inbound and suppressed the next tick's ping, so an idle link was pinged every **~60s (not 30s)** and dead-detection was **~120s (not 90s)**. That halves the NAT keep-warm rate on idle hosts → carrier-NAT idle-out kills the mapping before the next ping → half-open → redial. Busy hosts stay warm.

- **1a** — deadline-anchor + own-reply-watermark exclusion → true 30s idle cadence / ~90s detection; 'busy link skips ping' preserved. Masking test rewritten (it hid the bug); new `TransportKeepAliveIdleCadenceTest`.
- **1b** — new `KeepaliveDeathRedialAmortizer` (#1522 debouncer shape), only for `KeepaliveDead` drops → amortized backoff instead of reloading every ~2min; a plain-EOF/real death still surfaces (not amortized/hidden).

**Reviewer (Fable, reopen-class D31):** APPROVED — drove both root parts red→green (1a: gap 59900ms/detection 119900ms → ≤31s/≤91s; 1b: fixed-cadence → escalating), masking test genuinely corrected, genuine dead link still declared, **core-ssh integrationTest 37/0** (mandatory contract suite), full **3685/0**, VM shrank, #1522/grace-clocks/S4 untouched, gate-wired in per-push Unit.
**Local gate:** VM ratchet 17606 (shrinks), whitespace clean, focused keepalive+amortization tests BUILD SUCCESSFUL.

Follow-ups (audit non-blocking): two-host busy/idle e2e (G-3), on-device LTE hold (G-8) before RC.