### PR TITLE
release: bump to v0.4.31 (versionCode 78)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,8 +65,8 @@ android {
         applicationId = "com.pocketshell.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 77
-        versionName = "0.4.30"
+        versionCode = 78
+        versionName = "0.4.31"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/tools/pocketshell/pyproject.toml
+++ b/tools/pocketshell/pyproject.toml
@@ -8,7 +8,7 @@ name = "pocketshell"
 # scripts/check-pypi-version.sh enforces this; .github/workflows/build.yml
 # runs that check before publishing to PyPI. See
 # tools/pocketshell/README.md ("Release flow") for the bump procedure.
-version = "0.4.30"
+version = "0.4.31"
 description = "Unified server-side Python utility for the PocketShell Android client."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Version bump 0.4.30 → **0.4.31** (versionCode 77 → 78), app + tools/pocketshell lockstep.

Ships the two **root-cause** fixes for the maintainer's connection + message-queue pain (next-release goal):
- **#928 Slice 1** — keepalive **true-30s cadence** (idle hosts stay NAT-warm → no per-host idle flapping) + **amortized keepalive-death redial** (no ~2min reload storm). Reviewer-verified red→green (gap 59900ms→≤31s), core-ssh integrationTest 37/0.
- **#1526 Slice 1** — outbound **delivery-level exactly-once** (verify-before-resend via the #869 ack-needle; , no message loss) + fixed **deferral re-dispatch** (the delayed/never half). E2E: base delivers 3× → fix exactly once.

The remaining connection/queue hardening slices (read-watchdog, single network authority, grace unification, budget-inversion) continue toward the fully-bulletproof RC; this ships the two biggest wins for on-device confirmation.