### PR TITLE
connection: ride through same-identity restore on liveness vouch — fix busy-session flap (#1533)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -73,6 +73,9 @@ import com.pocketshell.app.tmux.connection.NetworkChangeEffects
 import com.pocketshell.app.tmux.connection.KEEPALIVE_DEATH_REDIAL_QUIET_RESET_MS
 import com.pocketshell.app.tmux.connection.KeepaliveDeathRedialAmortizer
 import com.pocketshell.app.tmux.connection.NetworkLossBandDebouncer
+import com.pocketshell.app.tmux.connection.isSameIdentityNetworkRestore
+import com.pocketshell.app.tmux.connection.recordNetworkRestoreReconnectStart
+import com.pocketshell.app.tmux.connection.recordNetworkRestoreRideThrough
 import com.pocketshell.app.tmux.connection.recordPassiveDisconnect
 import com.pocketshell.app.tmux.connection.recordSilentReattachFail
 import com.pocketshell.app.tmux.connection.recordSilentReattachStart
@@ -5324,6 +5327,22 @@ public class TmuxSessionViewModel @Inject constructor(
     )
 
     /**
+     * Issue #1533: cross-episode amortization for the SAME-IDENTITY network-restore
+     * redial (the "V2" busy-session flap) — the #928/#1522 debounce shape, distinct
+     * instance ([keepaliveDeathRedialAmortizer] sibling) with honest field events.
+     */
+    private val networkRestoreRedialAmortizer = KeepaliveDeathRedialAmortizer(
+        scope = viewModelScope,
+        backoffLadderMs = { autoReconnectDelaysMs },
+        quietResetMs = { keepaliveDeathQuietResetMs },
+        episodeEventName = "network_restore_redial_amortized",
+        episodeCause = "network_restored",
+        episodeSource = "network_observer",
+        episodeTrigger = TmuxConnectTrigger.NetworkReconnect.logValue,
+        episodeStage = "network_restore_redial",
+    )
+
+    /**
      * Issue #997 / #1522: [NetworkChangeArm.HoldNetworkLost] — a bare loss the
      * keepalive could NOT vouch for. Hold the lease and DEBOUNCE the band (grace +
      * escalating backoff): cellular clears `NET_CAPABILITY_VALIDATED` for sub-second
@@ -5376,11 +5395,15 @@ public class TmuxSessionViewModel @Inject constructor(
     }
 
     /**
-     * Issue #997 / #1042 / #1193: validation returned after a loss, including from
-     * a loss-suspended Reconnecting state. Ride through only when the existing
-     * control channel answers one bounded transition probe; otherwise schedule the
-     * fresh-lease restore reconnect. Passive keepalive freshness is intentionally
-     * not a positive restore authority across WiFi/cellular transitions.
+     * Issue #997 / #1042 / #1193 / #1533: validation returned after a loss.
+     *
+     * Issue #1533 (the "V2" busy-session flap): a SAME-IDENTITY restore whose control
+     * channel is STILL delivering bytes (a `%output` burst that parks the round-trip
+     * probe past its 5s budget) is a provably-alive transport — ride through on that
+     * #927 reader-activity vouch instead of tearing it down. Strict round-trip probing
+     * stays scoped to an identity CHANGE (#1193: on a handoff the surviving bytes
+     * crossed the OLD, now-dead socket). Otherwise probe; a dead socket redials via the
+     * #997 fresh lease, and a same-identity redial is AMORTIZED so it doesn't hammer.
      */
     private fun scheduleNetworkReconnectOnRestore(
         change: TerminalNetworkChange,
@@ -5388,11 +5411,13 @@ public class TmuxSessionViewModel @Inject constructor(
     ) {
         // Issue #1522: validation returned — drop any pending debounced band.
         networkLossBandDebouncer.cancel()
-        // Issue #1193: EVERY restore ride-through decision goes through the bounded
-        // ACTIVE probe (require an answered round-trip). Ride through only if the
-        // (possibly new) path answers; redial via the #997 fresh lease if it does
-        // not. No passive-timestamp fast-path — that is what committed to a dead
-        // cellular socket.
+        val sameIdentity = change.isSameIdentityNetworkRestore()
+        // Issue #1533: same-identity + live-but-busy (recent reader activity) rides
+        // through WITHOUT the strict probe a `%output` burst would park past its budget.
+        if (sameIdentity && isRestoreTransportProvenAliveByReaderActivity()) {
+            rideThroughNetworkRestore(change, target, cause = "same_identity_reader_active")
+            return
+        }
         val probeGuard = currentNetworkTransitionProbeGuard(target)
         viewModelScope.launch {
             val alive = withTimeoutOrNull(RESTORE_LIVENESS_PROBE_BUDGET_MS) {
@@ -5405,9 +5430,32 @@ public class TmuxSessionViewModel @Inject constructor(
             if (alive) {
                 rideThroughNetworkRestore(change, target, cause = "probe_answered")
             } else {
+                // Issue #1533: amortize a real same-identity drop so a flapping host
+                // widens its cadence; an identity handoff still redials promptly.
+                if (sameIdentity) {
+                    networkRestoreRedialAmortizer.awaitRedialGrace(target, connectGeneration)
+                    // A newer reconnect generation may have superseded during the grace.
+                    if (probeGuard != null && !isCurrentNetworkTransitionProbe(probeGuard)) {
+                        recordStaleNetworkTransitionProbe(change, target, "network_restore_probe", probeGuard)
+                        return@launch
+                    }
+                }
                 forceFreshLeaseRestoreReconnect(change, target)
             }
         }
+    }
+
+    /**
+     * Issue #1533: is the current control channel proven alive by RECENT reader
+     * activity (#927)? A `%output` burst keeps advancing the reader's last-activity
+     * clock even while a `refresh-client` reply is parked — proof the SAME socket is
+     * alive. Valid ONLY on a same-identity restore (caller gates on that).
+     */
+    private fun isRestoreTransportProvenAliveByReaderActivity(): Boolean {
+        val client = clientRef ?: return false
+        return runCatching {
+            client.millisSinceLastReaderActivity() <= client.readerActivityLivenessWindowMs
+        }.getOrDefault(false)
     }
 
     private fun recordStaleNetworkTransitionProbe(
@@ -5436,11 +5484,11 @@ public class TmuxSessionViewModel @Inject constructor(
 
     /**
      * Issue #1042 (cause #1): the restore RIDE-THROUGH arm. The existing transport
-     * survived the brief loss (proven alive, or the bounded probe answered), so the
-     * `-CC` client was never torn down. We do NOT redial — we just clear the calm
-     * loss-hold band by flipping back to [ConnectionState.Live] (which re-promotes
-     * the controller via `revealLive` and reopens the liveness-probe gate). No fresh
-     * lease, no visible Reconnecting churn — exactly the spurious-reconnect this
+     * survived the loss (bounded probe answered, or #1533's same-identity reader-
+     * activity vouch), so the `-CC` client was never torn down. We do NOT redial — we
+     * clear the calm loss-hold band by flipping back to [ConnectionState.Live] (which
+     * re-promotes the controller via `revealLive` and reopens the liveness-probe gate).
+     * No fresh lease, no visible Reconnecting churn — exactly the spurious-reconnect this
      * issue kills. Records a `network_restore_ride_through` device trail so the
      * decision is visible in field logs (not mislabelled as a redial).
      */
@@ -5456,36 +5504,12 @@ public class TmuxSessionViewModel @Inject constructor(
             "tmux-network-restore-ride-through reason=$reason cause=$cause " +
                 targetLogFields(target),
         )
-        DiagnosticEvents.record(
-            "connection",
-            "network_restore_ride_through",
-            "source" to "network_observer",
-            "trigger" to TmuxConnectTrigger.NetworkReconnect.logValue,
-            "reason" to reason,
-            "cause" to cause,
-            "classification" to "network_restored_transport_alive",
-            "reconnect" to false,
-            "sequence" to change.sequence,
-            "hostId" to target.hostId,
-            "host" to target.host,
-            "port" to target.port,
-            "user" to target.user,
-            "session" to target.sessionName,
-            "generation" to connectGeneration,
-            "clientHash" to clientRef?.let { System.identityHashCode(it) },
-            "deferredFromBackground" to change.deferredFromBackground,
-            *change.networkDiagnosticFields(),
-        )
-        ReconnectCauseTrail.record(
-            stage = "network_reconnect_decision",
-            outcome = "ride_through",
+        recordNetworkRestoreRideThrough(
+            target = target,
+            change = change,
+            generation = connectGeneration,
             cause = cause,
-            trigger = TmuxConnectTrigger.NetworkReconnect.logValue,
-            "sequence" to change.sequence,
-            "hostId" to target.hostId,
-            "generation" to connectGeneration,
-            "classification" to "network_restored_transport_alive",
-            "deferredFromBackground" to change.deferredFromBackground,
+            clientHash = clientRef?.let { System.identityHashCode(it) },
         )
         // Clear the loss-hold "reconnecting" band: the surviving transport is alive,
         // so flip back to Live (the -CC client was never torn down).
@@ -5500,12 +5524,11 @@ public class TmuxSessionViewModel @Inject constructor(
     }
 
     /**
-     * Issue #997 / #1042: the restore FRESH-LEASE REDIAL arm — the #997 fallback for
-     * a genuinely dead post-outage socket (the transport did not survive the loss,
-     * so neither the keepalive nor the bounded probe answered). Drives a FAST
-     * reconnect via the existing `scheduleAutoReconnect` ladder (D28: NO new reconnect
-     * path). This is the unchanged pre-#1042 restore body — it now runs ONLY past the
-     * liveness gate in [scheduleNetworkReconnectOnRestore].
+     * Issue #997 / #1042: the restore FRESH-LEASE REDIAL arm — the #997 fallback for a
+     * genuinely dead post-outage socket (the bounded probe did not answer). Drives a
+     * FAST reconnect via the existing `scheduleAutoReconnect` ladder (D28: NO new
+     * reconnect path). Runs ONLY past the liveness gate in
+     * [scheduleNetworkReconnectOnRestore].
      */
     private fun forceFreshLeaseRestoreReconnect(
         change: TerminalNetworkChange,
@@ -5520,38 +5543,11 @@ public class TmuxSessionViewModel @Inject constructor(
             "tmux-network-restore-reconnect reason=$reason " +
                 targetLogFields(target),
         )
-        DiagnosticEvents.record(
-            "connection",
-            "network_restore_reconnect_start",
-            "source" to "network_observer",
-            "trigger" to TmuxConnectTrigger.NetworkReconnect.logValue,
-            "reason" to reason,
-            "classification" to "network_restored_fast_reconnect",
-            "reconnect" to true,
-            // Issue #1042: the redial now runs only PAST the liveness gate — the
-            // transport did NOT answer (keepalive aged out + bounded probe failed).
-            "transportAnswered" to false,
-            "sequence" to change.sequence,
-            "hostId" to target.hostId,
-            "host" to target.host,
-            "port" to target.port,
-            "user" to target.user,
-            "session" to target.sessionName,
-            "generation" to connectGeneration,
-            "clientHash" to clientRef?.let { System.identityHashCode(it) },
-            "deferredFromBackground" to change.deferredFromBackground,
-            *change.networkDiagnosticFields(),
-        )
-        ReconnectCauseTrail.record(
-            stage = "network_reconnect_decision",
-            outcome = "schedule_reconnect",
-            cause = "network_restored",
-            trigger = TmuxConnectTrigger.NetworkReconnect.logValue,
-            "sequence" to change.sequence,
-            "hostId" to target.hostId,
-            "generation" to connectGeneration,
-            "classification" to "network_restored_fast_reconnect",
-            "deferredFromBackground" to change.deferredFromBackground,
+        recordNetworkRestoreReconnectStart(
+            target = target,
+            change = change,
+            generation = connectGeneration,
+            clientHash = clientRef?.let { System.identityHashCode(it) },
         )
         unregisterCurrentClient()
         scheduleAutoReconnect(

--- a/app/src/main/java/com/pocketshell/app/tmux/connection/KeepaliveDeathRedialAmortizer.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/connection/KeepaliveDeathRedialAmortizer.kt
@@ -1,5 +1,7 @@
 package com.pocketshell.app.tmux.connection
 
+import com.pocketshell.app.connectivity.TerminalNetworkChange
+import com.pocketshell.app.connectivity.networkDiagnosticFields
 import com.pocketshell.app.diagnostics.DiagnosticEvents
 import com.pocketshell.app.diagnostics.ReconnectCauseTrail
 import com.pocketshell.app.tmux.TmuxConnectTrigger
@@ -65,6 +67,17 @@ internal class KeepaliveDeathRedialAmortizer(
     private val scope: CoroutineScope,
     private val backoffLadderMs: () -> List<Long>,
     private val quietResetMs: () -> Long,
+    /**
+     * Issue #1533: the diagnostic identity of the amortized redial so a SECOND
+     * instance (the same-identity network-restore redial) records HONEST field
+     * events instead of mislabelling itself as a keepalive death. Defaults keep
+     * the original #928 keepalive-death labels unchanged.
+     */
+    private val episodeEventName: String = "keepalive_death_redial_amortized",
+    private val episodeCause: String = KEEPALIVE_DEAD_REASON,
+    private val episodeSource: String = "passive_disconnect",
+    private val episodeTrigger: String = TmuxConnectTrigger.AutoReconnect.logValue,
+    private val episodeStage: String = "keepalive_death_redial",
 ) {
     /**
      * Keepalive-death episodes seen per host in the current flap window
@@ -91,11 +104,16 @@ internal class KeepaliveDeathRedialAmortizer(
             else ladder[count.coerceAtMost(ladder.size - 1)]
         episodeCountByHost[hostId] = (count + 1).coerceAtMost(ladder.size.coerceAtLeast(1))
         armQuietReset(hostId)
-        recordKeepaliveDeathRedialEpisode(
+        recordRedialEpisode(
             target = target,
             generation = generation,
             episode = count + 1,
             graceMs = graceMs,
+            eventName = episodeEventName,
+            cause = episodeCause,
+            source = episodeSource,
+            trigger = episodeTrigger,
+            stage = episodeStage,
         )
         if (graceMs > 0L) delay(graceMs)
     }
@@ -124,18 +142,23 @@ internal class KeepaliveDeathRedialAmortizer(
  * so a widening flap cadence is directly observable on-device (the audit's exit
  * criterion for slice 1b).
  */
-private fun recordKeepaliveDeathRedialEpisode(
+private fun recordRedialEpisode(
     target: ConnectionTarget,
     generation: Long,
     episode: Int,
     graceMs: Long,
+    eventName: String,
+    cause: String,
+    source: String,
+    trigger: String,
+    stage: String,
 ) {
     DiagnosticEvents.record(
         "connection",
-        "keepalive_death_redial_amortized",
-        "source" to "passive_disconnect",
-        "trigger" to TmuxConnectTrigger.AutoReconnect.logValue,
-        "cause" to KEEPALIVE_DEAD_REASON,
+        eventName,
+        "source" to source,
+        "trigger" to trigger,
+        "cause" to cause,
         "episode" to episode,
         "graceMs" to graceMs,
         "hostId" to target.hostId,
@@ -146,10 +169,10 @@ private fun recordKeepaliveDeathRedialEpisode(
         "generation" to generation,
     )
     ReconnectCauseTrail.record(
-        stage = "keepalive_death_redial",
+        stage = stage,
         outcome = if (graceMs > 0L) "amortized" else "instant",
-        cause = KEEPALIVE_DEAD_REASON,
-        trigger = TmuxConnectTrigger.AutoReconnect.logValue,
+        cause = cause,
+        trigger = trigger,
         "hostId" to target.hostId,
         "episode" to episode,
         "graceMs" to graceMs,
@@ -269,5 +292,98 @@ internal fun recordSilentReattachFail(
         "cause" to "grace_elapsed",
         "transportReattachAttempts" to transportReattachAttempts,
         *shortAppSwitchFields,
+    )
+}
+
+/**
+ * Issue #1042 / #1533 (VM-shrink extraction): the `network_restore_ride_through`
+ * device trail — the restore RODE THROUGH on a surviving transport (the bounded
+ * probe answered, or #1533's same-identity reader-activity vouch). Field set
+ * unchanged from the former inline record in
+ * `TmuxSessionViewModel.rideThroughNetworkRestore`.
+ */
+internal fun recordNetworkRestoreRideThrough(
+    target: ConnectionTarget,
+    change: TerminalNetworkChange,
+    generation: Long,
+    cause: String,
+    clientHash: Int?,
+) {
+    DiagnosticEvents.record(
+        "connection",
+        "network_restore_ride_through",
+        "source" to "network_observer",
+        "trigger" to TmuxConnectTrigger.NetworkReconnect.logValue,
+        "reason" to change.reason,
+        "cause" to cause,
+        "classification" to "network_restored_transport_alive",
+        "reconnect" to false,
+        "sequence" to change.sequence,
+        "hostId" to target.hostId,
+        "host" to target.host,
+        "port" to target.port,
+        "user" to target.user,
+        "session" to target.sessionName,
+        "generation" to generation,
+        "clientHash" to clientHash,
+        "deferredFromBackground" to change.deferredFromBackground,
+        *change.networkDiagnosticFields(),
+    )
+    ReconnectCauseTrail.record(
+        stage = "network_reconnect_decision",
+        outcome = "ride_through",
+        cause = cause,
+        trigger = TmuxConnectTrigger.NetworkReconnect.logValue,
+        "sequence" to change.sequence,
+        "hostId" to target.hostId,
+        "generation" to generation,
+        "classification" to "network_restored_transport_alive",
+        "deferredFromBackground" to change.deferredFromBackground,
+    )
+}
+
+/**
+ * Issue #997 / #1042 (VM-shrink extraction): the `network_restore_reconnect_start`
+ * device trail — the restore transport did NOT answer (a genuinely dead
+ * post-outage socket) so the #997 fresh-lease redial fires. Field set unchanged
+ * from the former inline record in
+ * `TmuxSessionViewModel.forceFreshLeaseRestoreReconnect`.
+ */
+internal fun recordNetworkRestoreReconnectStart(
+    target: ConnectionTarget,
+    change: TerminalNetworkChange,
+    generation: Long,
+    clientHash: Int?,
+) {
+    DiagnosticEvents.record(
+        "connection",
+        "network_restore_reconnect_start",
+        "source" to "network_observer",
+        "trigger" to TmuxConnectTrigger.NetworkReconnect.logValue,
+        "reason" to change.reason,
+        "classification" to "network_restored_fast_reconnect",
+        "reconnect" to true,
+        "transportAnswered" to false,
+        "sequence" to change.sequence,
+        "hostId" to target.hostId,
+        "host" to target.host,
+        "port" to target.port,
+        "user" to target.user,
+        "session" to target.sessionName,
+        "generation" to generation,
+        "clientHash" to clientHash,
+        "deferredFromBackground" to change.deferredFromBackground,
+        *change.networkDiagnosticFields(),
+    )
+    ReconnectCauseTrail.record(
+        stage = "network_reconnect_decision",
+        outcome = "schedule_reconnect",
+        cause = "network_restored",
+        trigger = TmuxConnectTrigger.NetworkReconnect.logValue,
+        "sequence" to change.sequence,
+        "hostId" to target.hostId,
+        "generation" to generation,
+        "classification" to "network_restored_fast_reconnect",
+        "deferredFromBackground" to change.deferredFromBackground,
     )
 }

--- a/app/src/main/java/com/pocketshell/app/tmux/connection/NetworkChangeEffects.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/connection/NetworkChangeEffects.kt
@@ -2,6 +2,7 @@ package com.pocketshell.app.tmux.connection
 
 import com.pocketshell.app.connectivity.TerminalNetworkChange
 import com.pocketshell.app.connectivity.TerminalNetworkChangeKind
+import com.pocketshell.app.connectivity.TerminalNetworkSnapshot
 import com.pocketshell.app.connectivity.hasSameNetworkIdentityAs
 
 internal enum class NetworkChangeArm {
@@ -24,6 +25,26 @@ internal fun shouldReportValidatedHandoffToController(
             !previous.hasSameNetworkIdentityAs(change.current)
         } ?: false)
     return realValidatedHandoff && !transportKeepAliveProvenAlive()
+}
+
+/**
+ * Issue #1533: is this [TerminalNetworkChangeKind.NetworkRestored] a SAME-IDENTITY
+ * restore — validation returned on the SAME validated identity it was lost on (a
+ * brief validated-bit blip / re-validation on an unchanged transport, whose socket
+ * 4-tuple was preserved) — as opposed to a genuine transport handoff (WiFi↔cellular)
+ * that restored on a DIFFERENT identity?
+ *
+ * Only the same-identity case may ride through on LOCAL liveness evidence (the #927
+ * recent-reader-activity vouch): its surviving control bytes crossed the SAME live
+ * socket, so a `%output` burst that parks the round-trip probe is proof-of-life, not
+ * a dead channel. On a real identity change the surviving bytes crossed the OLD,
+ * now-dead socket, so the strict round-trip probe (#1193) must still run.
+ */
+internal fun TerminalNetworkChange.isSameIdentityNetworkRestore(): Boolean {
+    if (kind != TerminalNetworkChangeKind.NetworkRestored) return false
+    val restored = current as? TerminalNetworkSnapshot.Validated ?: return false
+    val preLoss = previousValidated ?: return false
+    return preLoss.hasSameNetworkIdentityAs(restored)
 }
 
 internal fun selectNetworkChangeArm(

--- a/app/src/test/java/com/pocketshell/app/tmux/FakeTmuxClient.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/FakeTmuxClient.kt
@@ -188,6 +188,18 @@ internal class FakeTmuxClient(
 
     var suspendForeverOnBestEffortCommandPrefix: String? = null
 
+    /**
+     * Issue #1533: the #927 "busy ≠ dead" reader-activity clock the restore
+     * ride-through vouch reads. Default [Long.MAX_VALUE] = no reader activity known
+     * (the interface default), so existing tests keep going through the probe. A
+     * test pins a small value to model a live `%output` burst that keeps the SAME
+     * socket's reader active while the round-trip probe is parked behind the FIFO.
+     */
+    @Volatile
+    var millisSinceLastReaderActivityValue: Long = Long.MAX_VALUE
+
+    override fun millisSinceLastReaderActivity(): Long = millisSinceLastReaderActivityValue
+
     var sendCommandDelayMs: Long = 0L
 
     /**

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelRestoreRideThroughTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelRestoreRideThroughTest.kt
@@ -1,0 +1,443 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.app.connectivity.TerminalNetworkChange
+import com.pocketshell.app.connectivity.TerminalNetworkChangeKind
+import com.pocketshell.app.connectivity.TerminalNetworkSnapshot
+import com.pocketshell.app.diagnostics.installRecordingDiagnosticSink
+import com.pocketshell.app.sessions.ActiveTmuxClients
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.SshLeaseConnector
+import com.pocketshell.core.ssh.SshLeaseTarget
+import com.pocketshell.core.ssh.SshPortForward
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshShell
+import com.pocketshell.core.tmux.CommandResponse
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+import java.io.InputStream
+
+/**
+ * Issue #1533 (the connection "V2" busy-session flap) — REPRODUCE-FIRST (D33/G10).
+ *
+ * ## The reported defect (reproduced RED on base)
+ *
+ * `scheduleNetworkReconnectOnRestore` ran an unconditional 5s
+ * `requireAnsweredRoundTrip=true` probe on EVERY validated-bit restore. When an
+ * agent (Codex/Claude) emits a `%output` burst the probe reply parks behind the
+ * control-mode FIFO past the 5s budget → the probe "fails" → a provably-alive
+ * transport is TORN DOWN and redialed (un-amortized). The maintainer runs agents
+ * constantly, so busy sessions flap.
+ *
+ * ## The fix these tests pin (GREEN)
+ *
+ * A SAME-IDENTITY restore whose control channel is still delivering bytes (the
+ * #927 recent-reader-activity vouch — the very `%output` burst that parked the
+ * probe) RIDES THROUGH with no teardown. Strict round-trip probing stays scoped to
+ * a real identity CHANGE (#1193). A genuinely dead same-identity socket still
+ * redials, but the redial is AMORTIZED (the #928/#1522 debounce shape) so a
+ * flapping host widens its cadence instead of hammering.
+ *
+ * Class coverage (G2): same-identity-alive-busy (ride through),
+ * same-identity-actually-dead (amortized redial), identity-change (strict probe).
+ * No `assumeTrue`/CI-skip: the parked-probe state is injected SYNTHETICALLY
+ * (`suspendForeverOnBestEffortCommandPrefix` + the reader-activity seam), the #780
+ * model.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class TmuxSessionViewModelRestoreRideThroughTest : TmuxSessionViewModelTestBase() {
+
+    private companion object {
+        /** Ladder shared by the reconnect path AND the restore-redial amortizer. */
+        val LADDER_MS = listOf(0L, 1_000L, 2_000L)
+
+        /** Long enough that no quiet-reset fires between the amortization episodes. */
+        const val QUIET_RESET_MS = 300_000L
+    }
+
+    // ---- 1. same-identity, alive-but-busy → ride through, NO teardown (the headline) ----
+
+    @Test
+    fun sameIdentityAliveButBusyRestoreRidesThroughInsteadOfTearingDownTheTransport() =
+        runTest(scheduler) {
+            val registry = ActiveTmuxClients()
+            val connector = QueueLeaseConnector(FakeSshSession())
+            val vm = newVm(
+                registry = registry,
+                sshLeaseManager = testLeaseManager(connector = connector, scope = this, idleTtlMillis = 0L),
+            )
+            // If the (buggy) base path decides to redial, it does so IMMEDIATELY.
+            vm.setAutoReconnectDelaysForTest(listOf(0L))
+            // The alive-but-busy transport: a `%output` burst parks the round-trip
+            // probe reply FOREVER (past the 5s budget) while the SAME socket's reader
+            // stays active (recent reader-activity vouch) — the maintainer's exact state.
+            val busyClient = FakeTmuxClient().apply {
+                suspendForeverOnBestEffortCommandPrefix = "refresh-client"
+                millisSinceLastReaderActivityValue = 100L
+            }
+            vm.replaceClientForTest(
+                hostId = 7L,
+                hostName = "alpha",
+                host = "alpha.example",
+                port = 22,
+                user = "alex",
+                keyPath = "/keys/a",
+                sessionName = "work",
+                client = busyClient,
+            )
+            runCurrent()
+
+            val diagnostics = installRecordingDiagnosticSink()
+            try {
+                registry.lifecycleHooksSnapshot().single().onNetworkChanged(networkLoss())
+                runCurrent()
+                registry.lifecycleHooksSnapshot().single().onNetworkChanged(networkRestore())
+                runCurrent()
+                // Give the (base) parked probe its full 5s budget to time out and redial.
+                advanceTimeBy(RESTORE_LIVENESS_PROBE_BUDGET_MS + 1)
+                runCurrent()
+
+                // GREEN load-bearing #1: the provably-alive busy transport is NOT torn
+                // down. On base this is 1 (a spurious teardown + redial). This is the
+                // reported "V2" flap.
+                assertEquals(
+                    "a same-identity, alive-but-busy restore (`%output` burst parking the probe) " +
+                        "must RIDE THROUGH — NOT tear down + redial a provably-alive transport (#1533)",
+                    0,
+                    connector.connectCount,
+                )
+                // GREEN load-bearing #2: transport identity/generation preserved — the
+                // SAME `-CC` client is still active (never unregistered).
+                assertSame(
+                    "the same-identity ride-through must preserve the live client (no teardown)",
+                    busyClient,
+                    registry.clients.value[7L]?.client,
+                )
+                assertTrue(
+                    "the ride-through clears the loss-hold band back to Connected",
+                    vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected,
+                )
+                val rideThrough = diagnostics.eventsNamed("network_restore_ride_through")
+                assertTrue(
+                    "expected a network_restore_ride_through (proves the vouch fired, not a " +
+                        "vacuous pass); events=${diagnostics.events.map { it.name }}",
+                    rideThrough.isNotEmpty(),
+                )
+                assertEquals(
+                    "the ride-through must be attributed to the same-identity reader-activity vouch",
+                    "same_identity_reader_active",
+                    rideThrough.single().fields["cause"],
+                )
+                assertTrue(
+                    "no teardown/redial diagnostic may fire on the busy ride-through; events=" +
+                        diagnostics.events.map { it.name },
+                    diagnostics.eventsNamed("network_restore_reconnect_start").isEmpty(),
+                )
+            } finally {
+                diagnostics.close()
+            }
+        }
+
+    // ---- 2. same-identity, actually-dead → AMORTIZED redial (not immediate unconditional) ----
+
+    @Test
+    fun sameIdentityGenuinelyDeadRestoreRedialIsAmortizedAcrossEpisodesNotHammered() =
+        runTest(scheduler) {
+            val diagnostics = installRecordingDiagnosticSink()
+            try {
+                val rig = buildDeadRestoreRig()
+                // The socket is genuinely dead every episode (probe cannot round-trip)
+                // and no reader activity vouches it — the fresh-lease redial path.
+                rig.vm.forceLivenessProbeDeadForTest = true
+
+                // Episode 1: the FIRST same-identity dead restore redials INSTANTLY
+                // (a one-off drop keeps today's seamless recovery).
+                driveDeadRestore(rig, sequence = 1L)
+                assertEquals(
+                    "the FIRST same-identity dead restore must redial instantly (amortizer grace 0)",
+                    1,
+                    rig.connector.connectCount,
+                )
+                awaitConnected(rig)
+
+                // Episode 2: the SECOND consecutive dead restore must NOT redial
+                // instantly — it waits the amortized grace. On base (no restore-redial
+                // amortizer) this redials immediately → connectCount == 2 right here.
+                driveDeadRestore(rig, sequence = 3L)
+                assertEquals(
+                    "issue #1533 — the 2nd consecutive same-identity dead restore must WAIT the " +
+                        "amortized grace (${LADDER_MS[1]}ms) before redialing. An immediate redial is " +
+                        "the un-amortized hammer this fix kills.",
+                    1,
+                    rig.connector.connectCount,
+                )
+                advanceTimeBy(LADDER_MS[1] - 1)
+                runCurrent()
+                assertEquals(
+                    "the 2nd redial must still be held 1ms before its amortized grace elapses",
+                    1,
+                    rig.connector.connectCount,
+                )
+                advanceTimeBy(1)
+                runCurrent()
+                awaitCondition { rig.connector.connectCount >= 2 }
+                assertEquals(
+                    "the 2nd episode still auto-recovers once its amortized grace elapses " +
+                        "(amortized, not abandoned)",
+                    2,
+                    rig.connector.connectCount,
+                )
+                awaitConnected(rig)
+
+                // The amortization is observable in HONEST field logs (not mislabelled
+                // as a keepalive death): widening grace per episode.
+                val episodes = diagnostics.eventsNamed("network_restore_redial_amortized")
+                assertEquals(
+                    "every same-identity dead restore records its amortization decision",
+                    listOf(0L, LADDER_MS[1]),
+                    episodes.map { it.fields["graceMs"] },
+                )
+                assertEquals(listOf(1, 2), episodes.map { it.fields["episode"] })
+            } finally {
+                diagnostics.close()
+            }
+        }
+
+    // ---- 3. identity-change → strict probe still runs (do NOT regress #1193) ----
+
+    @Test
+    fun identityChangeRestoreStillStrictProbesAndRedialsDeadSocketDespiteReaderActivity() =
+        runTest(scheduler) {
+            val registry = ActiveTmuxClients()
+            val connector = QueueLeaseConnector(FakeSshSession())
+            val reconnectClient = FakeTmuxClient().withSinglePane("work", "%1")
+            val vm = newVm(
+                registry = registry,
+                sshLeaseManager = testLeaseManager(connector = connector, scope = this, idleTtlMillis = 0L),
+            )
+            vm.setTmuxClientFactoryForTest { _, _, _ -> reconnectClient }
+            vm.setAutoReconnectDelaysForTest(listOf(0L))
+            // A handoff whose OLD socket is dead — but with RECENT reader activity
+            // present (bytes crossed the OLD socket). The reader-activity vouch must
+            // NOT short-circuit an identity change (that would reintroduce #1193 — a
+            // ride-through onto a dead post-handoff socket).
+            val oldClient = FakeTmuxClient().apply { millisSinceLastReaderActivityValue = 100L }
+            vm.replaceClientForTest(
+                hostId = 7L,
+                hostName = "alpha",
+                host = "alpha.example",
+                port = 22,
+                user = "alex",
+                keyPath = "/keys/a",
+                sessionName = "work",
+                client = oldClient,
+            )
+            runCurrent()
+            vm.forceLivenessProbeDeadForTest = true
+
+            val diagnostics = installRecordingDiagnosticSink()
+            try {
+                registry.lifecycleHooksSnapshot().single().onNetworkChanged(networkLoss())
+                runCurrent()
+                // The restore arrives on a DIFFERENT validated identity (WiFi→cellular).
+                registry.lifecycleHooksSnapshot().single().onNetworkChanged(
+                    networkRestore(current = TerminalNetworkSnapshot.Validated("cell")),
+                )
+                advanceUntilIdle()
+
+                assertTrue(
+                    "an identity-change restore over a DEAD socket must NOT ride through on the " +
+                        "reader-activity vouch (that is the #1193 dead-post-handoff-socket bug); events=" +
+                        diagnostics.events.map { it.name },
+                    diagnostics.eventsNamed("network_restore_ride_through").isEmpty(),
+                )
+                assertEquals(
+                    "the identity-change dead-socket restore must redial via the strict-probe fresh lease",
+                    1,
+                    connector.connectCount,
+                )
+                assertEquals(
+                    "the redial fires with the network-reconnect trigger",
+                    TmuxConnectTrigger.NetworkReconnect,
+                    vm.latestRestoreIntentSnapshot()?.trigger,
+                )
+                assertTrue(
+                    "the strict-probe redial records the fast restore signal (not a vacuous pass); events=" +
+                        diagnostics.events.map { it.name },
+                    diagnostics.eventsNamed("network_restore_reconnect_start").isNotEmpty(),
+                )
+                assertTrue(
+                    "an identity-change redial is prompt (fresh lease), NOT routed through the " +
+                        "same-identity restore-redial amortizer; events=${diagnostics.events.map { it.name }}",
+                    diagnostics.eventsNamed("network_restore_redial_amortized").isEmpty(),
+                )
+            } finally {
+                diagnostics.close()
+            }
+        }
+
+    // ---- rig for the amortization journey (dead-socket restore, recovers between episodes) ----
+
+    private class DeadRestoreRig(
+        val vm: TmuxSessionViewModel,
+        val registry: ActiveTmuxClients,
+        val connector: QueueLeaseConnector,
+    )
+
+    private fun TestScope.buildDeadRestoreRig(): DeadRestoreRig {
+        val registry = ActiveTmuxClients()
+        val sessions = List(4) { FakeSshSession() }
+        val connector = QueueLeaseConnector(*sessions.toTypedArray())
+        val vm = newVm(
+            registry = registry,
+            sshLeaseManager = testLeaseManager(connector = connector, scope = this, idleTtlMillis = 60_000L),
+        )
+        vm.setAutoReconnectDelaysForTest(LADDER_MS)
+        vm.setPassiveDisconnectRecoveryForTest(keepaliveDeathQuietResetMs = QUIET_RESET_MS)
+        val replacementClients = ArrayDeque(List(4) { i -> FakeTmuxClient().withSinglePane("work", "%${i + 1}") })
+        vm.setTmuxClientFactoryForTest { _, sessionName, _ ->
+            assertEquals("work", sessionName)
+            replacementClients.removeFirstOrNull() ?: error("unexpected tmux client factory call")
+        }
+        vm.replaceClientForTest(
+            hostId = 7L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            sessionName = "work",
+            client = FakeTmuxClient(),
+            session = FakeSshSession(),
+        )
+        runCurrent()
+        return DeadRestoreRig(vm = vm, registry = registry, connector = connector)
+    }
+
+    /** One same-identity loss→restore round for the dead-socket amortization journey. */
+    private suspend fun TestScope.driveDeadRestore(rig: DeadRestoreRig, sequence: Long) {
+        val hook = rig.registry.lifecycleHooksSnapshot().single()
+        hook.onNetworkChanged(networkLoss(sequence = sequence))
+        runCurrent()
+        hook.onNetworkChanged(networkRestore(sequence = sequence + 1L))
+        runCurrent()
+    }
+
+    private fun TestScope.awaitConnected(rig: DeadRestoreRig) {
+        awaitCondition {
+            rig.vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected
+        }
+    }
+
+    // ---- network-change helpers (same-identity restore by default) ----
+
+    private fun networkLoss(
+        previousValidated: TerminalNetworkSnapshot.Validated = TerminalNetworkSnapshot.Validated("wifi"),
+        reason: String = "default-network-lost",
+        sequence: Long = 1L,
+    ): TerminalNetworkChange =
+        TerminalNetworkChange(
+            previous = previousValidated,
+            current = TerminalNetworkSnapshot.NoValidatedNetwork,
+            previousValidated = previousValidated,
+            reason = reason,
+            sequence = sequence,
+            kind = TerminalNetworkChangeKind.NetworkLost,
+        )
+
+    private fun networkRestore(
+        current: TerminalNetworkSnapshot.Validated = TerminalNetworkSnapshot.Validated("wifi"),
+        previousValidated: TerminalNetworkSnapshot.Validated = TerminalNetworkSnapshot.Validated("wifi"),
+        reason: String = "default-network-available",
+        sequence: Long = 2L,
+    ): TerminalNetworkChange =
+        TerminalNetworkChange(
+            previous = TerminalNetworkSnapshot.NoValidatedNetwork,
+            current = current,
+            previousValidated = previousValidated,
+            reason = reason,
+            sequence = sequence,
+            kind = TerminalNetworkChangeKind.NetworkRestored,
+        )
+
+    private fun FakeTmuxClient.withSinglePane(
+        sessionName: String,
+        paneId: String,
+    ): FakeTmuxClient = apply {
+        responses.addLast(
+            CommandResponse(
+                number = 1L,
+                output = listOf("$paneId\t@0\t\$0\t$sessionName\t$sessionName\t0"),
+                isError = false,
+            ),
+        )
+        capturePaneResponses.addLast(
+            CommandResponse(number = 2L, output = listOf("$sessionName ready"), isError = false),
+        )
+        cursorQueryResponses.addLast(
+            CommandResponse(number = 3L, output = listOf("0,0"), isError = false),
+        )
+    }
+
+    private class QueueLeaseConnector(
+        private vararg val sessions: FakeSshSession,
+    ) : SshLeaseConnector {
+        var connectCount: Int = 0
+            private set
+
+        override suspend fun connect(target: SshLeaseTarget): Result<SshSession> {
+            val next = sessions.getOrNull(connectCount)
+                ?: error("unexpected lease connect $connectCount for ${target.leaseKey}")
+            connectCount += 1
+            return Result.success(next)
+        }
+    }
+
+    private class FakeSshSession : SshSession {
+        @Volatile
+        var closed: Boolean = false
+
+        override val isConnected: Boolean
+            get() = !closed
+
+        override suspend fun exec(command: String): ExecResult =
+            ExecResult(stdout = "", stderr = "", exitCode = 0)
+
+        override fun tail(path: String, onLine: (String) -> Unit): Job = Job()
+
+        override fun openLocalPortForward(
+            remoteHost: String,
+            remotePort: Int,
+            localPort: Int,
+        ): SshPortForward = throw NotImplementedError("not needed")
+
+        override fun startShell(): SshShell = throw NotImplementedError("not needed")
+
+        override suspend fun uploadFile(file: File, remotePath: String): String = remotePath
+
+        override suspend fun uploadStream(
+            input: InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String = remotePath
+
+        override fun close() {
+            closed = true
+        }
+    }
+}


### PR DESCRIPTION
## Connection V2 busy-session flap fix

Fixes the "some sessions constantly reconnecting" flap on a **good** connection when a session is actively running an agent. Complements #928 (V1 idle-flap, shipped in v0.4.31).

### Root cause (Fable audit #843, confirmed against the maintainer's real connection log)
`scheduleNetworkReconnectOnRestore` ran an unconditional 5s `requireAnsweredRoundTrip=true` probe on every validated-bit restore, ignoring keepalive/reader vouching. An agent `%output` burst parks the probe reply >5s → full teardown + redial of a transport that was never dead.

### Fix
- Same-identity restore **rides through** on time-bounded (3s from last parsed control event) recent-reader-activity vouch (#927 signal).
- Strict round-trip probing stays scoped to an **identity change** (#1193's original purpose — preserved).
- Genuinely-dead same-identity drops still redial, **amortized** via `networkRestoreRedialAmortizer`.

### Verification (reviewer-run, red→green this run — #1533 comment 4960469773)
- 3 class-coverage tests: same-identity-alive-busy → ride through (no teardown); same-identity-dead → amortized redial; identity-change → strict probe preserved. Red on base, green with fix.
- **#1193 non-resurrection proven airtight**: vouch gated on `isSameIdentityNetworkRestore()` + 3s bound (a dead socket's clock grows unboundedly → can't vouch); dedicated adversarial test (dead socket + recent activity + identity change → no ride-through); #1193/#1042/#1080 regression tests still traverse the strict probe non-vacuously.
- Full `:app:testDebugUnitTest` green in 1m55s (3703 tests, 0 failed, 0 skipped); amortizer has no unbounded loop.
- Guards: connection-VM-ratchet exit 0 (net reduction), file-size hygiene exit 0, test-validity PASS, `git diff --check` clean.

Closes #1533
