### PR TITLE
msg-queue: fix delayed/never-sent — align send-cancel budget + re-dispatch deferred rows on silent heal (#1532)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerViewModel.kt
@@ -3499,39 +3499,36 @@ public class PromptComposerViewModel @Inject constructor(
          */
         public const val ATTACHMENT_UPLOAD_TIMEOUT_MS: Long = 90_000L
 
-        /**
-         * Issue #745: a send must resolve to success or failure within a
-         * BOUNDED time so the composer never hangs in the in-flight state.
-         * The host's send path is a connect-on-action call (#548) that can
-         * legitimately kick a reconnect and wait for the live client; this
-         * cap is generous enough to cover a normal reconnect attempt yet
-         * short enough that a truly dead link surfaces the "Not sent" banner
-         * promptly instead of leaving the user waiting blind. The sheet's
-         * `sendRequests` collector wraps the host `onSend` in
-         * `withTimeoutOrNull(SEND_TIMEOUT_MS)`; a null/timeout result is
-         * treated as a failed send.
-         */
-        public const val SEND_TIMEOUT_MS: Long = 12_000L
+        /** Issue #1532 (RC-A): headroom for delivery (paste, ack, Enter) atop the connect-wait. */
+        internal const val SEND_DELIVERY_HEADROOM_MS: Long = 20_000L
 
         /**
-         * Issue #891: the ViewModel-owned ceiling on the WHOLE send operation —
-         * the backstop that guarantees the composer can never sit on "Sending…"
-         * forever (the maintainer's restart-the-app bug, with a PNG attachment).
-         *
-         * Each leg of a send is already individually bounded: the
-         * [ATTACHMENT_UPLOAD_TIMEOUT_MS] (90s) upload `withTimeout`, the #886
-         * absolute per-command ceiling on the tmux control channel (30s), and
-         * the sheet's [SEND_TIMEOUT_MS] (12s) `withTimeoutOrNull` around the host
-         * `onSend`. But nothing bounded the operation END-TO-END: if the
-         * upload-await coroutine wedged, or the `sendRequests` emission landed
-         * with no live collector, `sendInFlight` never cleared. This ceiling sits
-         * deliberately ABOVE the worst-case sum of the per-leg bounds
-         * (upload 90s + onSend 12s) so the normal failure paths surface their own
-         * banner first; the watchdog only fires when NONE of them resolved the
-         * in-flight state at all, and then routes to the retryable failed-send
-         * state ([restoreFailedSend]) with the draft + attachment preserved.
+         * Issue #745 / #1532 (RC-A, audit D1): bounded cap the sheet wraps host
+         * `onSend` in (null/timeout = failed send). A flat 12s was shorter than the
+         * connect-wait it gates ([com.pocketshell.app.tmux.SEND_SESSION_WAIT_TIMEOUT_MS],
+         * 30s), so a 12-30s reconnect was always cancelled-and-deferred though the
+         * inner wait would deliver. Now DERIVED so it can't drift shorter (guarded).
          */
-        public const val OVERALL_SEND_TIMEOUT_MS: Long = 110_000L
+        public const val SEND_TIMEOUT_MS: Long =
+            com.pocketshell.app.tmux.SEND_SESSION_WAIT_TIMEOUT_MS + SEND_DELIVERY_HEADROOM_MS
+
+        /** Issue #891/#1532 (Finding 2): headroom the watchdog sits above the leg sum. */
+        internal const val OVERALL_SEND_WATCHDOG_HEADROOM_MS: Long = 20_000L
+
+        /**
+         * Issue #891 / #1532 (Finding 2): the whole-send watchdog — the backstop
+         * so the composer can never sit on "Sending…" forever. The two legs run
+         * SEQUENTIALLY: [ATTACHMENT_UPLOAD_TIMEOUT_MS] (90s) upload, then the sheet's
+         * [SEND_TIMEOUT_MS] `withTimeoutOrNull` onSend. The #891 invariant is that
+         * this ceiling stays strictly ABOVE the worst-case leg sum (`upload+onSend`)
+         * so each per-leg banner fires first and the watchdog only fires when none
+         * resolved (routing to [restoreFailedSend] with draft+attachment kept). RC-A
+         * grew onSend to 50s ⇒ leg sum 140s, ABOVE the old flat 110s ceiling (that
+         * inversion reopens the spurious-fail/duplicate window). Now DERIVED from the
+         * leg sum + headroom so it can never invert again, whichever leg grows.
+         */
+        public const val OVERALL_SEND_TIMEOUT_MS: Long =
+            ATTACHMENT_UPLOAD_TIMEOUT_MS + SEND_TIMEOUT_MS + OVERALL_SEND_WATCHDOG_HEADROOM_MS
 
         /**
          * Issue #900: an [OutboundState.InFlight] row older than the whole-send

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreenStateHelpers.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreenStateHelpers.kt
@@ -11,6 +11,11 @@ import com.pocketshell.app.composer.PromptComposerViewModel
 import com.pocketshell.app.session.AgentConversationUiState
 import com.pocketshell.app.sessions.HostTmuxSessionPickerState
 import com.pocketshell.uikit.model.SessionAgentKind
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
 
 /**
  * Issue #1158 (R2 ART VerifyError fix): the session's Terminal/Conversation
@@ -70,6 +75,19 @@ internal fun rememberTmuxSessionTabState(
     }
 }
 
+/**
+ * Issue #1532 (RC-B / audit D2): the per-row backoff between successive
+ * auto-flush re-dispatch attempts of the SAME deferred row inside one live
+ * window. Long enough that a rapid burst of queue snapshots (a deferral emits
+ * one immediately) can't hot-loop a just-tried row, short enough that a row
+ * deferred during a SILENTLY-healed flap (status never leaves `Connected`, so
+ * the `(sessionLive, target)` window never flips) still re-dispatches promptly
+ * once the transport recovers — instead of parking "Will send when reconnected."
+ * forever. Each re-dispatch funnels through the #1526 S1 verify-before-resend
+ * ledger, so a silently-landed payload is never doubled.
+ */
+internal const val OUTBOUND_DEFERRED_REDISPATCH_BACKOFF_MS: Long = 3_000L
+
 @Composable
 internal fun TmuxOutboundQueueAutoFlushEffect(
     sessionLive: Boolean,
@@ -78,23 +96,87 @@ internal fun TmuxOutboundQueueAutoFlushEffect(
     controller: OutboundQueueAutoFlushController,
 ) {
     LaunchedEffect(sessionLive, targetSessionKey, promptComposerViewModel, controller) {
-        promptComposerViewModel.outboundQueueItems.collect {
-            controller.onQueueSnapshotChanged(sessionLive) { excludingIds ->
+        runOutboundQueueAutoFlush(
+            sessionLive = sessionLive,
+            outboundQueueItems = promptComposerViewModel.outboundQueueItems,
+            controller = controller,
+            retryNext = { excludingIds ->
                 promptComposerViewModel.retryNextOutboundItem(excludingIds = excludingIds)
-            }
+            },
+        )
+    }
+}
+
+/**
+ * Issue #1532 (RC-B / audit D2): the outbound auto-flush body, extracted from
+ * [TmuxOutboundQueueAutoFlushEffect] so the LOAD-BEARING poll lane is reachable
+ * under virtual time in a plain unit test (the composable just forwards to it —
+ * no behaviour change). Two lanes race under one structured-concurrency scope:
+ *
+ *  - **Snapshot lane** — re-attempt one eligible row whenever the queue changes
+ *    (the #900 path). A deferral emits a fresh snapshot, so a row whose attempt
+ *    already outlasted the backoff (a slow connect-wait takes tens of seconds)
+ *    re-dispatches on that emission.
+ *  - **Poll lane** — re-attempt one eligible row on the
+ *    [OUTBOUND_DEFERRED_REDISPATCH_BACKOFF_MS] cadence while the session is live.
+ *    This is the ONLY thing that un-parks a row deferred inside an UNCHANGED live
+ *    window (the #928/#822 silent-heal shape emits NO further snapshot once the
+ *    row parks, so the snapshot lane alone would leave it stuck "Will send when
+ *    reconnected." forever). No window flip required. `retryNext` self-gates on
+ *    `sendInFlight` / `composerTarget`, so a poll with nothing to do is a cheap
+ *    no-op.
+ *
+ * Bounded: [coroutineScope] returns only when both children complete, and both
+ * are cancelled the moment the enclosing [LaunchedEffect] key set (sessionLive,
+ * target, VM, controller) changes or the screen leaves composition.
+ */
+internal suspend fun runOutboundQueueAutoFlush(
+    sessionLive: Boolean,
+    outboundQueueItems: Flow<*>,
+    controller: OutboundQueueAutoFlushController,
+    retryNext: (excludingIds: Set<String>) -> String?,
+): Unit = coroutineScope {
+    launch {
+        outboundQueueItems.collect {
+            controller.onQueueSnapshotChanged(sessionLive, retryNext)
+        }
+    }
+    if (sessionLive) {
+        while (isActive) {
+            delay(OUTBOUND_DEFERRED_REDISPATCH_BACKOFF_MS)
+            controller.onQueueSnapshotChanged(sessionLive, retryNext)
         }
     }
 }
 
 /**
- * Issue #900: state holder for the screen-level outbound queue auto-flush
- * effects. It resets the per-live-window failure exclusion set when the
- * connection window changes, requeues stale in-flight rows when a target becomes
- * live, and retries at most one queue row per queue snapshot.
+ * Issue #900 / #1532: state holder for the screen-level outbound queue
+ * auto-flush effects. It requeues stale in-flight rows when a target becomes
+ * live and retries at most one queue row per queue snapshot.
+ *
+ * Issue #1532 (RC-B / audit D2): the old design remembered a permanent
+ * `autoRetriedIds` exclusion set that only reset on a `(sessionLive, target)`
+ * WINDOW FLIP — so a row deferred during a SILENTLY-healed flap (status never
+ * leaves `Connected`, the window never flips) was excluded FOREVER and parked
+ * "Will send when reconnected." while the connection was actually fine (the
+ * dominant "sent long after / never" mechanic). That once-per-window exclusion
+ * is replaced by a PER-ROW time-bounded backoff: a dispatched row is suppressed
+ * only for [OUTBOUND_DEFERRED_REDISPATCH_BACKOFF_MS] after its attempt (so a
+ * snapshot burst can't hot-loop it), then becomes eligible to re-dispatch again
+ * even within the SAME live window. Exactly-once is preserved by the #1526 S1
+ * verify-before-resend ledger in the send path — a re-dispatch of an
+ * already-landed payload is suppressed there, never doubled.
  */
-internal class OutboundQueueAutoFlushController {
+internal class OutboundQueueAutoFlushController(
+    private val clock: () -> Long = { System.currentTimeMillis() },
+) {
     private var windowKey: Pair<Boolean, String>? = null
-    private var autoRetriedIds: Set<String> = emptySet()
+
+    // Issue #1532 (RC-B): per-row timestamp of the last auto-flush dispatch
+    // attempt. A row is suppressed from re-dispatch only while it is still within
+    // its [OUTBOUND_DEFERRED_REDISPATCH_BACKOFF_MS] backoff; expired entries are
+    // pruned each snapshot, which also bounds the map on a long-lived screen.
+    private val lastAttemptAtMs = mutableMapOf<String, Long>()
 
     fun onConnectionWindowChanged(
         sessionLive: Boolean,
@@ -104,7 +186,9 @@ internal class OutboundQueueAutoFlushController {
         val nextKey = sessionLive to targetSessionId
         if (nextKey == windowKey) return
         windowKey = nextKey
-        autoRetriedIds = emptySet()
+        // A genuine window flip is a fresh slate — clear all per-row backoffs so a
+        // reconnect re-arms every row immediately (the existing #900/#993 path).
+        lastAttemptAtMs.clear()
         if (sessionLive) requeueStaleInFlight()
     }
 
@@ -113,8 +197,14 @@ internal class OutboundQueueAutoFlushController {
         retryNext: (excludingIds: Set<String>) -> String?,
     ): String? {
         if (!sessionLive) return null
-        val retriedId = retryNext(autoRetriedIds) ?: return null
-        autoRetriedIds = autoRetriedIds + retriedId
+        val now = clock()
+        // Drop rows whose backoff has elapsed — they are eligible to re-dispatch
+        // again (this is what un-parks a silently-healed deferred row) and pruning
+        // keeps the map bounded.
+        lastAttemptAtMs.entries.removeAll { now - it.value >= OUTBOUND_DEFERRED_REDISPATCH_BACKOFF_MS }
+        val suppressed = lastAttemptAtMs.keys.toSet()
+        val retriedId = retryNext(suppressed) ?: return null
+        lastAttemptAtMs[retriedId] = now
         return retriedId
     }
 }

--- a/app/src/test/java/com/pocketshell/app/composer/PromptComposerOutboundSendQueueViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/PromptComposerOutboundSendQueueViewModelTest.kt
@@ -2272,4 +2272,93 @@ class PromptComposerOutboundSendQueueViewModelTest {
         assertFalse(vm.uiState.value.sendInFlight)
     }
 
+    // --- Issue #1532 (RC-A / audit D1): dispatcher cancel budget vs connect budget ---
+
+    /**
+     * Issue #1532 (RC-A / audit D1 — the S2 budget inversion). The composer's
+     * `PromptComposerSendDispatcher` bounds the host `onSend` in
+     * `withTimeoutOrNull(SEND_TIMEOUT_MS)`. That cap MUST NOT be shorter than the
+     * connect-wait budget it gates
+     * ([com.pocketshell.app.tmux.SEND_SESSION_WAIT_TIMEOUT_MS], 30s) — else any
+     * reconnect that takes 12–30s is ALWAYS cancelled-and-deferred at the cap even
+     * though the inner wait would have delivered. Guards against re-introducing the
+     * inversion (they now derive from one source so they cannot drift).
+     *
+     * RED on base (SEND_TIMEOUT_MS = 12_000): 12_000 >= 30_000 is false.
+     */
+    @Test
+    fun dispatcherSendBudgetIsNotShorterThanConnectWaitBudget() {
+        assertTrue(
+            "the dispatcher SEND_TIMEOUT_MS (${PromptComposerViewModel.SEND_TIMEOUT_MS}ms) must be " +
+                ">= the connect-wait budget SEND_SESSION_WAIT_TIMEOUT_MS " +
+                "(${com.pocketshell.app.tmux.SEND_SESSION_WAIT_TIMEOUT_MS}ms) it gates, or a 12–30s " +
+                "reconnect is always cancelled-and-deferred (audit D1)",
+            PromptComposerViewModel.SEND_TIMEOUT_MS >=
+                com.pocketshell.app.tmux.SEND_SESSION_WAIT_TIMEOUT_MS,
+        )
+        // Issue #1532 (Finding 2 — #891 budget-sum invariant). The whole-send
+        // watchdog OVERALL_SEND_TIMEOUT_MS must stay strictly ABOVE the WORST-CASE
+        // SEQUENTIAL LEG SUM (attachment upload leg + onSend leg), not merely above
+        // one leg. When RC-A grew SEND_TIMEOUT_MS to 50s, the leg sum became
+        // 90s + 50s = 140s; a flat 110s ceiling would sit BELOW it, reopening the
+        // spurious-fail / duplicate-dispatch window this epic targets. Assert the
+        // leg-sum invariant WITH headroom so the overall watchdog remains a pure
+        // last-resort backstop that fires only after every per-leg bound has.
+        val worstCaseLegSum =
+            PromptComposerViewModel.ATTACHMENT_UPLOAD_TIMEOUT_MS +
+                PromptComposerViewModel.SEND_TIMEOUT_MS
+        assertTrue(
+            "the #891 budget-sum invariant is broken: the worst-case leg sum " +
+                "(upload ${PromptComposerViewModel.ATTACHMENT_UPLOAD_TIMEOUT_MS}ms + onSend " +
+                "${PromptComposerViewModel.SEND_TIMEOUT_MS}ms = ${worstCaseLegSum}ms) must stay " +
+                "strictly below the whole-send watchdog OVERALL_SEND_TIMEOUT_MS " +
+                "(${PromptComposerViewModel.OVERALL_SEND_TIMEOUT_MS}ms), or exceeding it opens a " +
+                "spurious-fail / duplicate-dispatch window (audit Finding 2)",
+            worstCaseLegSum < PromptComposerViewModel.OVERALL_SEND_TIMEOUT_MS,
+        )
+        // OUTBOUND_IN_FLIGHT_STALE_MS (when an InFlight row is treated as abandoned
+        // and requeued) must never be below the longest a legit send can take, or a
+        // still-live send is duplicated — the same class this epic targets.
+        assertTrue(
+            "OUTBOUND_IN_FLIGHT_STALE_MS (${PromptComposerViewModel.OUTBOUND_IN_FLIGHT_STALE_MS}ms) " +
+                "must be >= the worst-case leg sum (${worstCaseLegSum}ms) so a live send is never " +
+                "requeued-and-duplicated",
+            PromptComposerViewModel.OUTBOUND_IN_FLIGHT_STALE_MS >= worstCaseLegSum,
+        )
+    }
+
+    /**
+     * Issue #1532 (RC-A) behavioural proof: model the dispatcher's exact
+     * `withTimeoutOrNull(SEND_TIMEOUT_MS) { onSend() }` where the host `onSend`
+     * spends ~15s (12s < t < 30s) waiting for a slow reconnect to become live and
+     * THEN delivers. The dispatcher must NOT cancel it before the connect budget
+     * elapses.
+     *
+     * RED on base (SEND_TIMEOUT_MS = 12_000): the 12s cap fires before the 15s
+     * connect-wait completes ⇒ `withTimeoutOrNull` returns null ⇒ delivered=false
+     * (cancelled-and-deferred). GREEN with the fix: the derived cap (50s) covers
+     * the wait ⇒ delivered.
+     */
+    @Test
+    fun sendDuringSlowReconnectIsNotCancelledBeforeConnectBudget() = runTest {
+        val connectWaitMs = 15_000L // 12s < t < the 30s connect-wait budget
+        var onSendReachedDelivery = false
+
+        val delivered = kotlinx.coroutines.withTimeoutOrNull(
+            PromptComposerViewModel.SEND_TIMEOUT_MS,
+        ) {
+            // The connect-on-action host onSend: awaitLiveTmuxClientForSend polls up
+            // to SEND_SESSION_WAIT_TIMEOUT_MS for the reconnect to land, then delivers.
+            kotlinx.coroutines.delay(connectWaitMs)
+            onSendReachedDelivery = true
+            true
+        } == true
+
+        assertTrue(
+            "a send whose reconnect completes at t=15s (inside the 30s connect budget) must " +
+                "NOT be cancelled by the dispatcher cap and must deliver (audit D1)",
+            delivered,
+        )
+        assertTrue("onSend must have reached its delivery leg, not been cancelled mid-wait", onSendReachedDelivery)
+    }
 }

--- a/app/src/test/java/com/pocketshell/app/tmux/OutboundDeliveryGuardTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/OutboundDeliveryGuardTest.kt
@@ -272,6 +272,56 @@ class OutboundDeliveryGuardTest {
         assertTrue(longText.filterNot { it.isWhitespace() }.endsWith(needle))
     }
 
+    /**
+     * Issue #1532 (RC-B no-duplicate guard): the RC-B silent-heal re-dispatch
+     * (TmuxSessionScreenStateHelpers per-row backoff) funnels back into the SAME
+     * composer-lane send that runs [verifyBeforeAgentResend] first. When the row's
+     * earlier attempt ended ambiguously (recorded on the ledger) but actually
+     * LANDED server-side, a re-dispatch MUST resolve `AlreadyLanded` so the send
+     * path submits Enter only and never re-pastes — the payload reaches the agent
+     * exactly ONCE. RED if the ledger were bypassed (a blind re-paste ⇒ occurrence
+     * 2, the maintainer's "delivered twice" class the S1 slice fixed).
+     */
+    @Test
+    fun reDispatchOfAlreadyLandedPayloadResolvesAlreadyLandedForExactlyOnce() = runTest {
+        val ledger = OutboundDeliveryLedger()
+        val paneId = "%0"
+        val payload = "deliver this exactly once please"
+        // First attempt reached the wire ambiguously (recorded) AND landed — the
+        // pane shows the payload.
+        ledger.recordWireAttempt(paneId, payload)
+        val client = captureShowing("$ $payload")
+
+        val outcome = verifyBeforeAgentResend(ledger, client, paneId, payload)
+
+        assertEquals(
+            "a re-dispatched already-landed payload must resolve AlreadyLanded so the send path " +
+                "submits Enter only and never re-pastes (occurrence stays 1)",
+            DeliveryProbeOutcome.AlreadyLanded,
+            outcome,
+        )
+    }
+
+    /**
+     * Issue #1532 (RC-B ordering/fresh-send guard): a FRESH send — no prior
+     * ambiguous attempt on the ledger — must NOT probe (null ⇒ the caller does the
+     * normal full send). The RC-B backoff never turns a fresh send into a
+     * verify-gated one, so a fresh send is not slowed or reordered by the guard.
+     */
+    @Test
+    fun freshSendWithNoPriorAttemptDoesNotProbe() = runTest {
+        val ledger = OutboundDeliveryLedger()
+        val client = FakeTmuxClient()
+
+        val outcome = verifyBeforeAgentResend(ledger, client, "%0", "a brand new prompt")
+
+        assertNull("a fresh send with no ambiguous prior attempt must not probe (null ⇒ normal send)", outcome)
+        assertTrue(
+            "a fresh send must not pay a capture-pane probe round-trip",
+            client.capturePaneTextViaExecCalls.isEmpty(),
+        )
+    }
+
     @Test
     fun ledgerTracksRecordsClearsAndEvictsOldestBeyondCapacity() {
         val ledger = OutboundDeliveryLedger(maxEntries = 2)

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionScreenTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionScreenTest.kt
@@ -25,6 +25,13 @@ import com.pocketshell.core.connection.terminalHeld
 import com.pocketshell.core.storage.entity.HostEntity
 import com.pocketshell.core.terminal.selection.LocalhostUrl
 import com.pocketshell.uikit.model.SessionAgentKind
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -2355,6 +2362,115 @@ class TmuxSessionScreenTest {
         assertEquals("failed-1", retryAfterReconnect)
         assertEquals(listOf("1/session-a", "1/session-a"), requeuedTargets)
         assertEquals(emptySet<String>(), retryExclusions.last())
+    }
+
+    @Test
+    fun deferredRowReDispatchesAfterBackoffWithinUnchangedLiveWindow_silentHeal() {
+        // Issue #1532 (RC-B / audit D2): a row deferred during a SILENTLY-healed
+        // flap. The status never leaves Connected, so the `(sessionLive, target)`
+        // window NEVER flips. On base the once-per-window `autoRetriedIds` set
+        // excludes the just-tried row forever ⇒ it parks "Will send when
+        // reconnected." indefinitely while the connection is fine (the dominant
+        // "sent long after / never" mechanic). With the per-row backoff it becomes
+        // eligible again after OUTBOUND_DEFERRED_REDISPATCH_BACKOFF_MS and
+        // re-dispatches on the SAME live window.
+        var nowMs = 100_000L
+        val controller = OutboundQueueAutoFlushController(clock = { nowMs })
+        controller.onConnectionWindowChanged(sessionLive = true, targetSessionId = "1/silent") {}
+
+        // 1) First dispatch — the send that the silent drop will defer.
+        val first = controller.onQueueSnapshotChanged(sessionLive = true) { excludingIds ->
+            assertTrue("the first attempt excludes nothing", excludingIds.isEmpty())
+            "row-1"
+        }
+        assertEquals("row-1", first)
+
+        // 2) The send fails; the deferral emits a fresh snapshot in the SAME live
+        //    window. Within the backoff the just-tried row must be suppressed so a
+        //    snapshot burst cannot hot-loop it (excludingIds carries the row).
+        nowMs += 10L // sub-backoff
+        val immediate = controller.onQueueSnapshotChanged(sessionLive = true) { excludingIds ->
+            assertTrue("within the backoff the just-tried row is suppressed", "row-1" in excludingIds)
+            if ("row-1" in excludingIds) null else "row-1"
+        }
+        assertNull("within the backoff the row is not re-dispatched (no hot loop)", immediate)
+
+        // 3) Time passes past the backoff and the transport heals SILENTLY — NO
+        //    window flip (onConnectionWindowChanged is NOT called; the same
+        //    sessionLive=true/target window). The parked row must re-dispatch.
+        nowMs += OUTBOUND_DEFERRED_REDISPATCH_BACKOFF_MS
+        val reDispatched = controller.onQueueSnapshotChanged(sessionLive = true) { excludingIds ->
+            assertTrue("after the backoff the row is no longer suppressed", "row-1" !in excludingIds)
+            if ("row-1" in excludingIds) null else "row-1"
+        }
+        assertEquals(
+            "a row deferred inside an UNCHANGED live window must re-dispatch after the backoff " +
+                "(D2 silent-heal) instead of parking forever",
+            "row-1",
+            reDispatched,
+        )
+    }
+
+    @Test
+    fun pollLaneReDispatchesDeferredRowOnQuietScreenWithNoQueueEmission() = runTest {
+        // Issue #1532 (Finding 1 — the LOAD-BEARING poll lane). RC-B's silent-heal
+        // shape: a row deferred inside an UNCHANGED live window. The queue emits ONE
+        // initial snapshot (which dispatches-then-parks the row) and then NOTHING
+        // more — no queue mutation, no `(sessionLive, target)` window flip. On a
+        // QUIET screen the snapshot lane can never fire again, so the ONLY mechanism
+        // that can un-park the row is the POLL inside `runOutboundQueueAutoFlush`.
+        //
+        // The controller clock is tied to the coroutine's virtual clock so the
+        // per-row backoff and the poll's `delay` advance together. Delete the poll
+        // block from `runOutboundQueueAutoFlush` and this test goes RED (the parked
+        // row is never re-dispatched: `dispatched` stays a single element) — proving
+        // it covers the load-bearing mechanism, not a structural proxy.
+        val controller = OutboundQueueAutoFlushController(clock = { testScheduler.currentTime })
+        controller.onConnectionWindowChanged(sessionLive = true, targetSessionId = "1/silent") {}
+
+        val dispatched = mutableListOf<String>()
+        // One deferred row that stays eligible whenever it is not currently
+        // suppressed by its own backoff.
+        val retryEligibleRow: (Set<String>) -> String? = { excludingIds ->
+            if ("row-1" in excludingIds) null else "row-1"
+        }
+        // A quiet queue: emit the initial snapshot once (the StateFlow-on-subscribe
+        // value), then never emit again — the silent-heal shape.
+        val quietQueue = flow<Any?> {
+            emit(Unit)
+            awaitCancellation()
+        }
+
+        val job = launch {
+            runOutboundQueueAutoFlush(
+                sessionLive = true,
+                outboundQueueItems = quietQueue,
+                controller = controller,
+                retryNext = { excludingIds -> retryEligibleRow(excludingIds)?.also { dispatched += it } },
+            )
+        }
+
+        // Let the initial snapshot dispatch run. The row is dispatched once and
+        // parks; the poll's first backoff `delay` is now pending.
+        runCurrent()
+        assertEquals(
+            "the initial snapshot dispatches the row exactly once, then it parks",
+            listOf("row-1"),
+            dispatched,
+        )
+
+        // NO further queue emission. Advance virtual time past the backoff so ONLY
+        // the poll can act. It must un-park the row and re-dispatch it.
+        advanceTimeBy(OUTBOUND_DEFERRED_REDISPATCH_BACKOFF_MS + 1L)
+        runCurrent()
+        assertEquals(
+            "the POLL re-dispatched the parked row on a quiet screen with no queue emission " +
+                "and no window flip (D2 silent-heal) — this is the load-bearing lane",
+            listOf("row-1", "row-1"),
+            dispatched,
+        )
+
+        job.cancelAndJoin()
     }
 
     // --- Issue #993: kebab "Reconnect" enable gate ---------------------------------


### PR DESCRIPTION
## Message-queue timeliness — fix "sent long after / never"

Kills the dominant delayed-delivery pain from the Fable queue audit (#1526). Two tightly-coupled root causes.

### RC-A / S2 — cancel budget shorter than connect budget
The dispatcher cancelled a send at a flat **12s** while the connect-wait it depends on is **30s** — so every 12–30s reconnect *always* cancelled-and-deferred a send that would have succeeded. `SEND_TIMEOUT_MS` is now **derived** = `SEND_SESSION_WAIT_TIMEOUT_MS (30s) + SEND_DELIVERY_HEADROOM_MS (20s)` = 50s, so it can never drift below the connect budget again. `OVERALL_SEND_TIMEOUT_MS` is likewise derived = `upload(90s) + onSend(50s) + headroom(20s)` = 160s so the worst-case leg-sum (140s) stays under the watchdog — restoring the #891 budget-sum invariant (a review round caught that a flat 110s would have opened a new duplicate-dispatch window).

### RC-B / D2 — deferred row never re-dispatched on a silent heal
After a deferral, the row was excluded from retry until the `(sessionLive, target)` window *flipped* — but a silently-healed flap never flips it, so the message **parked forever** showing "Will send when reconnected." while connected. Replaced with a per-row time-bounded backoff; the auto-flush poll (now extracted to a testable `runOutboundQueueAutoFlush` so it runs under virtual time) re-dispatches the row on the same live window, funnelled through the #1526 S1 verify-before-resend ledger (no duplicate).

### Verification (reviewer-run red→green, both rounds — #1532 comments 4960383737 → 4960587780)
- RC-A/RC-B load-bearing tests red on base, green with fix.
- **Poll-lane coverage proven**: deleting the poll block turns the new quiet-screen test RED (round-1 gap closed).
- **#891 leg-sum invariant test**: red on the old flat 110s ceiling, green with the derived 160s.
- Exactly-once ledger guard intact (re-dispatch of an already-landed payload → occurrence 1).
- Full `:app:testDebugUnitTest` completes in 1m45s (3706 tests, 0 failed, 0 skipped — no #1517 hang); hygiene exit 0; `TmuxSessionViewModel.kt` untouched; `git diff --check` clean.

Closes #1532
