### PR TITLE
message-queue: write-ahead durable outbound row before clearing composer draft (#1540)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerViewModel.kt
@@ -904,17 +904,29 @@ public class PromptComposerViewModel @Inject constructor(
             "attachmentCount" to attachments.size,
             "withEnter" to withEnter,
         )
-        // Issue #971: HAND THE PROMPT OFF to the outbound queue — clear the
-        // editable draft + staged tiles the instant we go in-flight so the
-        // prompt is represented EXACTLY ONCE (the "Sending…" queue row), never
-        // as BOTH the editor text AND a duplicate "1 unsent prompt" row. This
-        // reverses the #745 keep-the-draft-visible behaviour (hard-cut per D22):
-        // the queue row is now the single in-flight source of truth, and the
-        // Send button reads `sendInFlight` to disable itself + show "Sending…".
-        // The clean draft + tiles still travel in the [SendRequest] / queue row,
-        // so a failed send ([restoreFailedSend]) puts the EXACT prompt back into
-        // the (now-single) composer, and a delivered send leaves it empty.
-        clearComposerForHandoff()
+        // Issue #971: HAND THE PROMPT OFF to the outbound queue so the prompt is
+        // represented EXACTLY ONCE (the "Sending…" queue row), never as BOTH the
+        // editor text AND a duplicate "1 unsent prompt" row. This reverses the
+        // #745 keep-the-draft-visible behaviour (hard-cut per D22): the queue row
+        // is the single in-flight source of truth, and the Send button reads
+        // `sendInFlight` to disable itself + show "Sending…". The clean draft +
+        // tiles still travel in the [SendRequest] / queue row, so a failed send
+        // ([restoreFailedSend]) puts the EXACT prompt back into the (now-single)
+        // composer, and a delivered send leaves it empty.
+        //
+        // Issue #1540 (L9 — the widest silent-LOST hole): the composer clear
+        // ([clearComposerForHandoff]) USED to run HERE, synchronously, BEFORE the
+        // durable outbound-queue row was committed (an async IO hop below; the
+        // sidecar path staged bytes first, widening the window). If the process
+        // died in that window the prompt existed in NEITHER the durable draft NOR
+        // the durable queue — gone with zero trace. The fix WRITE-AHEADS the
+        // durable row: the clear is deferred into each durable path and runs ONLY
+        // AFTER the row commit succeeds ([enqueueOutboundSend] /
+        // [enqueueAndDispatchSidecarBackedSend]), so a crash in the window always
+        // leaves the prompt recoverable in EXACTLY ONE durable place — the draft
+        // (before commit) or the queue row (after commit) — never lost. The
+        // no-durable-store fallback has no row to write-ahead, so it clears
+        // synchronously just before emitting (no IO hop, nothing to lose).
         _uiState.update { it.copy(sendInFlight = true, error = null) }
         // Issue #891: arm the overall-send watchdog the instant we go in-flight
         // so a host `onSend` that never resolves (wedged channel / dropped
@@ -967,6 +979,13 @@ public class PromptComposerViewModel @Inject constructor(
                         sendTarget = sendTarget,
                     )
                     withContext(Dispatchers.Main.immediate) {
+                        // Issue #1540 (L9): the durable row is committed — NOW it
+                        // is safe to clear the editable draft + durable draft. A
+                        // crash before this point leaves the prompt in the durable
+                        // draft (nothing was cleared yet); a crash after it leaves
+                        // the prompt in the just-committed queue row. Never both
+                        // gone at once — the LOST window is closed.
+                        clearComposerForHandoff()
                         emitPreparedSendRequest(
                             text = text,
                             withEnter = withEnter,
@@ -987,6 +1006,12 @@ public class PromptComposerViewModel @Inject constructor(
             }
             return
         }
+        // Issue #1540 (L9): the no-durable-store fallback (DisabledOutboundQueueStore
+        // or a blank sessionKey) has no queue row to write-ahead, so there is no
+        // durable-loss window — the prompt only ever travels in the in-memory
+        // [SendRequest]. Clear synchronously here, just before emitting, exactly
+        // as the pre-#1540 code did.
+        clearComposerForHandoff()
         emitPreparedSendRequest(
             text = text,
             withEnter = withEnter,
@@ -1057,6 +1082,15 @@ public class PromptComposerViewModel @Inject constructor(
                 attachmentUpload = AttachmentUploadState.Idle,
             )
         }
+        // Issue #1540 (L9): synthetic process-death seam (#780 model). Fires the
+        // INSTANT the durable draft has been cleared. A crash right here is the
+        // exact LOST window: the durable draft is gone, and — with the WRITE-AHEAD
+        // fix — the durable queue row is ALREADY committed (this runs after the
+        // commit in every durable path), so the test snapshots the durable stores
+        // and asserts the prompt survived in the queue row. On the pre-fix base
+        // this ran BEFORE the commit, so the snapshot showed the prompt gone from
+        // both stores (LOST). Production never sets this (null → no-op).
+        onDurableDraftClearedForHandoffTest?.invoke()
     }
 
     private fun hasLocalAttachmentsForSidecars(attachments: List<StagedAttachment>): Boolean =
@@ -1122,6 +1156,15 @@ public class PromptComposerViewModel @Inject constructor(
         if (queuedItem.id != itemId) {
             outboundAttachmentSidecarStore?.removeOutboundItem(itemId)
         }
+        // Issue #1540 (L9): the durable row is committed (with its attachment
+        // refs AND the staged sidecar bytes above) — NOW it is safe to clear the
+        // editable draft + durable draft. This is the widest LOST window: the
+        // attachment path stages bytes BEFORE the row commit, so clearing the
+        // draft up front (the old order) meant a death between stage and commit
+        // lost the prompt AND orphaned the sidecar bytes with no owning row. The
+        // clear runs on Main ([clearComposerForHandoff] writes the SavedStateHandle
+        // draft slots, which require the Main thread).
+        withContext(Dispatchers.Main.immediate) { clearComposerForHandoff() }
         inFlightSendRequest = SendRequest(
             text = appendAttachmentPaths(cleanDraft, attachments.map { it.remotePath }),
             withEnter = withEnter,
@@ -1961,6 +2004,19 @@ public class PromptComposerViewModel @Inject constructor(
      */
     @androidx.annotation.VisibleForTesting
     internal var sidecarRemovalForTest: (suspend (String) -> Unit)? = null
+
+    /**
+     * Issue #1540 (L9) synthetic process-death seam (#780 model). When non-null,
+     * [clearComposerForHandoff] invokes it the INSTANT the durable draft has been
+     * cleared — the exact moment a crash would leave the durable draft empty. The
+     * WRITE-AHEAD fix commits the durable queue row BEFORE this fires (in every
+     * durable path), so a test can snapshot the durable stores here and prove the
+     * prompt survived in the queue row (green); on the pre-fix base the clear ran
+     * BEFORE the commit, so the snapshot showed the prompt gone from BOTH the
+     * durable draft AND the durable queue (LOST → red). Production never sets it.
+     */
+    @androidx.annotation.VisibleForTesting
+    internal var onDurableDraftClearedForHandoffTest: (() -> Unit)? = null
 
     private fun refreshOutboundQueueItems() {
         _outboundQueueItems.value = composerTarget

--- a/app/src/test/java/com/pocketshell/app/composer/PromptComposerOutboundSendQueueViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/PromptComposerOutboundSendQueueViewModelTest.kt
@@ -500,13 +500,22 @@ class PromptComposerOutboundSendQueueViewModelTest {
         vm.onDraftChange("ship it later")
         vm.requestSend(withEnter = true, sendTarget = target)
 
+        // Off the caller thread: the enqueue is still deferred to the queue
+        // dispatcher (nothing sent, no row yet before advancing).
         assertTrue(vm.uiState.value.sendInFlight)
-        assertEquals("", vm.uiState.value.draft)
         assertTrue(sent.isEmpty())
         assertTrue(queue.itemsFor("1/session-a").isEmpty())
+        // Issue #1540 (L9 — write-ahead): the editable draft is NO LONGER cleared
+        // up front. The clear now runs ONLY after the durable queue row commits,
+        // so before the dispatcher advances the draft is still present — the LOST
+        // window (draft cleared but row not yet committed) no longer exists.
+        assertEquals("ship it later", vm.uiState.value.draft)
 
         advanceUntilIdle()
 
+        // After the durable row committed the composer is cleared (single
+        // representation) and the row carries the prompt.
+        assertEquals("", vm.uiState.value.draft)
         val request = sent.single()
         val queueId = requireNotNull(request.outboundQueueItemId)
         assertEquals("ship it later", request.cleanDraft)
@@ -723,6 +732,220 @@ class PromptComposerOutboundSendQueueViewModelTest {
         vm.markSendDelivered(sent.last())
         assertTrue(vm.outboundQueueItems.value.isEmpty())
         assertEquals("", vm.uiState.value.draft)
+    }
+
+    // -- Issue #1540 (L9): the widest silent-LOST hole -----------------------
+    //
+    // The Fable message-queue audit's highest-severity LOST finding: a prompt
+    // could be lost with ZERO trace if the process died in the window between
+    // "durable draft cleared" and "durable outbound-queue row committed".
+    // `emitSendRequest` used to clear the composer + durable draft SYNCHRONOUSLY
+    // up front (old :917), then commit the durable queue row on a later IO hop —
+    // the attachment path staged bytes first, WIDENING the window. A crash in
+    // that window left the prompt in NEITHER the durable draft NOR the durable
+    // queue: gone, unrecoverable, no user-visible trace.
+    //
+    // The fix WRITE-AHEADS the durable row: the clear now runs ONLY after the
+    // row commit succeeds. These tests inject the death SYNTHETICALLY (#780
+    // model — no `assumeTrue`/CI-skip) via [onDurableDraftClearedForHandoffTest],
+    // which fires the INSTANT the durable draft is cleared — the exact crash
+    // point. They snapshot the DURABLE stores at that instant (what a real crash
+    // would leave on SharedPrefs) and assert the prompt survived in the queue
+    // row. RED-on-base repro for a reviewer: move `clearComposerForHandoff()`
+    // back to before the enqueue in `emitSendRequest` /
+    // `enqueueAndDispatchSidecarBackedSend` (keep the seam) — the death snapshot's
+    // queue is then EMPTY (LOST) and every green assertion below fails.
+
+    @Test
+    fun issue1540_L9_textSend_writeAheadCommitsDurableRowBeforeDraftClearSoDeathDoesNotLosePrompt() = runTest {
+        val draftStore = InMemoryComposerDraftStore()
+        val queue = InMemoryOutboundQueueStore()
+        val vm = newVm(
+            samplerDispatcher = StandardTestDispatcher(testScheduler),
+            outboundQueueStore = queue,
+            composerDraftStore = draftStore,
+        )
+        val sent = collectSendRequests(vm)
+        val target = PromptComposerViewModel.SendTargetSnapshot(
+            sessionKey = "1/session-a",
+            paneId = "%7",
+            route = OutboundRoute.AgentPayload,
+            agentKind = "codex",
+        )
+
+        // Synthetic process death: snapshot the DURABLE stores the instant the
+        // draft is cleared — precisely what a crash right there would preserve.
+        var deathQueue: List<OutboundItem>? = null
+        var deathDraft: String? = "not-captured"
+        vm.onDurableDraftClearedForHandoffTest = {
+            if (deathQueue == null) {
+                deathQueue = queue.itemsFor("1/session-a")
+                deathDraft = draftStore.load("1/session-a")
+            }
+        }
+
+        vm.onComposerTargetChanged("1/session-a")
+        vm.onDraftChange("ship the write-ahead")
+        // Pre-condition: the draft really is persisted durably before send, so a
+        // crash BEFORE the write-ahead commit would still recover it as a draft.
+        assertEquals("ship the write-ahead", draftStore.load("1/session-a"))
+
+        vm.requestSend(withEnter = true, sendTarget = target)
+        advanceUntilIdle()
+
+        val snap = requireNotNull(deathQueue) {
+            "the draft-clear seam never fired — the send handoff path did not run"
+        }
+        // GREEN (write-ahead): at the crash instant the durable queue ALREADY
+        // holds the row carrying the prompt. On the pre-fix base (clear-before-
+        // commit) this list is EMPTY → prompt LOST → this assertion is RED.
+        assertEquals(
+            "the prompt must be durable in the queue row at the crash instant",
+            listOf("ship the write-ahead"),
+            snap.map { it.cleanText },
+        )
+        // Single representation: the durable draft was cleared, so the prompt is
+        // in the queue row ONLY — never in BOTH the draft AND the queue.
+        assertTrue("durable draft must be cleared at handoff", deathDraft.isNullOrEmpty())
+
+        // -- Recovery + EXACTLY-ONCE: a fresh VM (process restart) reads the SAME
+        // durable store (SharedPrefs survives death) and delivers the recovered
+        // row exactly once. Wire-level occurrence==1 across the crash is the
+        // #1526 S1 verify-before-resend ledger's job; L9 guarantees the SINGLE
+        // durable representation (one row, no residual draft) that makes recovery
+        // deliver the prompt exactly once rather than duplicating it. --
+        val rowId = snap.single().id
+        val vm2 = newVm(
+            samplerDispatcher = StandardTestDispatcher(testScheduler),
+            outboundQueueStore = queue,
+            composerDraftStore = draftStore,
+            savedStateHandle = SavedStateHandle(),
+            // A far-future clock so the stale-InFlight recovery cutoff is > the
+            // row's real-time createdAtMs (deterministic re-arm; no time race).
+            clock = { Long.MAX_VALUE / 2 },
+        )
+        val sent2 = collectSendRequests(vm2)
+        vm2.onComposerTargetChanged("1/session-a")
+        // The row survived as InFlight (mid-delivery when the process died); the
+        // production recovery flush re-arms the stale row to Queued.
+        assertEquals(listOf(rowId), vm2.requeueStaleOutboundInFlight(staleAfterMs = 0L).map { it.id })
+        val flushed = vm2.retryNextOutboundItem()
+        advanceUntilIdle()
+        assertEquals("recovery flush claims the recovered row", rowId, flushed)
+        assertEquals("recovery delivers exactly one send", 1, sent2.size)
+        assertEquals("ship the write-ahead", sent2.single().cleanDraft)
+
+        vm2.markSendDelivered(sent2.single())
+        // Exactly-once: the delivered row is pruned and can NOT be re-claimed, and
+        // there is no second (draft) representation to send again.
+        assertNull("no second deliverable representation after delivery", vm2.retryNextOutboundItem())
+        assertEquals("still exactly one send", 1, sent2.size)
+        assertTrue(queue.itemsFor("1/session-a").isEmpty())
+        assertTrue("no residual durable draft", draftStore.load("1/session-a").isNullOrEmpty())
+    }
+
+    @Test
+    fun issue1540_L9_singleAttachmentSend_writeAheadCommitsDurableRowWithAttachmentBeforeDraftClear() = runTest {
+        val draftStore = InMemoryComposerDraftStore()
+        val queue = InMemoryOutboundQueueStore()
+        val sidecars = newSidecarStore(ioDispatcher = StandardTestDispatcher(testScheduler))
+        val vm = newVm(
+            samplerDispatcher = StandardTestDispatcher(testScheduler),
+            outboundQueueStore = queue,
+            outboundAttachmentSidecarStore = sidecars,
+            composerDraftStore = draftStore,
+        )
+        vm.setOutboundAttachmentSidecarUploader { refs ->
+            Result.success(refs.map { "~/.pocketshell/attachments/reuploaded/${it.displayName}" })
+        }
+        val sent = collectSendRequests(vm)
+        val target = PromptComposerViewModel.SendTargetSnapshot(sessionKey = "1/session-a")
+        val local = localAttachmentFile("l9-single.txt", "attachment bytes")
+
+        // Capture ONLY the durable queue snapshot in the (non-suspend) seam; the
+        // sidecar byte store's read is suspend, so byte-ownership (L11) is out of
+        // scope here — the durable ROW carrying the attachment ref is the L9 proof.
+        var deathQueue: List<OutboundItem>? = null
+        vm.onDurableDraftClearedForHandoffTest = {
+            if (deathQueue == null) deathQueue = queue.itemsFor("1/session-a")
+        }
+
+        vm.onComposerTargetChanged("1/session-a")
+        vm.onDraftChange("review this")
+        vm.attachFiles(
+            count = 1,
+            previews = listOf(PromptComposerViewModel.AttachmentPreview(Uri.fromFile(local), "text/plain")),
+        ) {
+            Result.success(listOf("~/.pocketshell/attachments/old/l9-single.txt"))
+        }
+        settleUntil { vm.uiState.value.attachments.isNotEmpty() }
+
+        vm.requestSend(withEnter = true, sendTarget = target)
+        settleUntil { deathQueue != null }
+
+        val snap = requireNotNull(deathQueue)
+        // GREEN: the death happened AFTER the attachment bytes were staged AND the
+        // durable row committed — this is the WIDEST window (stage-then-commit).
+        // The row carries the text + the attachment ref, so the attachment send is
+        // recoverable. On base (clear up front) the queue is EMPTY at this instant
+        // → the attachment send is LOST with zero trace → red.
+        assertEquals(listOf("review this"), snap.map { it.cleanText })
+        assertEquals("row carries the single attachment ref", 1, snap.single().attachments.size)
+    }
+
+    @Test
+    fun issue1540_L9_multiAttachmentSend_writeAheadCommitsDurableRowWithAllAttachmentsBeforeDraftClear() = runTest {
+        val draftStore = InMemoryComposerDraftStore()
+        val queue = InMemoryOutboundQueueStore()
+        val sidecars = newSidecarStore(ioDispatcher = StandardTestDispatcher(testScheduler))
+        val vm = newVm(
+            samplerDispatcher = StandardTestDispatcher(testScheduler),
+            outboundQueueStore = queue,
+            outboundAttachmentSidecarStore = sidecars,
+            composerDraftStore = draftStore,
+        )
+        vm.setOutboundAttachmentSidecarUploader { refs ->
+            Result.success(refs.map { "~/.pocketshell/attachments/reuploaded/${it.displayName}" })
+        }
+        val sent = collectSendRequests(vm)
+        val target = PromptComposerViewModel.SendTargetSnapshot(sessionKey = "1/session-a")
+        val localA = localAttachmentFile("l9-multi-a.txt", "bytes a")
+        val localB = localAttachmentFile("l9-multi-b.txt", "bytes b")
+
+        var deathQueue: List<OutboundItem>? = null
+        vm.onDurableDraftClearedForHandoffTest = {
+            if (deathQueue == null) deathQueue = queue.itemsFor("1/session-a")
+        }
+
+        vm.onComposerTargetChanged("1/session-a")
+        vm.onDraftChange("review both")
+        vm.attachFiles(
+            count = 2,
+            previews = listOf(
+                PromptComposerViewModel.AttachmentPreview(Uri.fromFile(localA), "text/plain"),
+                PromptComposerViewModel.AttachmentPreview(Uri.fromFile(localB), "text/plain"),
+            ),
+        ) {
+            Result.success(
+                listOf(
+                    "~/.pocketshell/attachments/old/l9-multi-a.txt",
+                    "~/.pocketshell/attachments/old/l9-multi-b.txt",
+                ),
+            )
+        }
+        settleUntil { vm.uiState.value.attachments.size == 2 }
+
+        vm.requestSend(withEnter = true, sendTarget = target)
+        settleUntil { deathQueue != null }
+
+        val snap = requireNotNull(deathQueue)
+        // GREEN: the multi-attachment/sidecar send commits ONE durable row with
+        // BOTH attachment refs before the draft clear. Base: queue EMPTY at the
+        // crash instant → the multi-attachment send is LOST → red.
+        assertEquals(listOf("review both"), snap.map { it.cleanText })
+        assertEquals("row carries BOTH attachment refs", 2, snap.single().attachments.size)
+        // Single representation: exactly ONE durable row for the one prompt.
+        assertEquals(1, snap.size)
     }
 
     @Test


### PR DESCRIPTION
Fixes finding **L9** from the Fable message-queue audit (#1526): a prompt is LOST with zero trace if the process dies between the composer draft-clear and the durable queue-row commit — widest on the attachment/sidecar path.

**Root cause:** `emitSendRequest` cleared the composer + durable draft synchronously up front, *before* the durable `OutboundQueueStore` row was committed on a later IO hop.

**Fix:** write-ahead the durable row first — `clearComposerForHandoff()` now runs AFTER the row commit succeeds on each durable path (queue post-`enqueueOutboundSend`; sidecar post-`enqueueExisting` on `Main.immediate`; no-store fallback unchanged). One `@VisibleForTesting` synthetic-death seam.

**Verification (reviewer-run red→green — #1540 comment 4962248213):**
- Base (ordering reverted, seam kept): durable queue EMPTY at crash (`but was:<[]>`, LOST) — reviewer independently reproduced, incl. catching a wrong-function neutralization that confirms the red is load-bearing.
- With fix: recovers the row, delivers exactly once (via #1526 S1 ledger). Class coverage: text + single- + multi-attachment.
- Full `:app:testDebugUnitTest`: 5m07s cold, exit 0, 3712 tests, 0 failures — no hang.
- `TmuxSessionViewModel.kt` untouched; test-validity PASS.

Closes #1540
