### PR TITLE
connection: gate driver reattach edge on pendingReattach — kill double-writer race (#1545)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -927,24 +927,24 @@ public class TmuxSessionViewModel @Inject constructor(
             // owner ([graceEffects.onBackgrounded] -> launchBackgroundDetachTeardown).
             backgroundedEffect = { onControllerBackgrounded() },
             // Slice 1c-iv-c (#754): the driver OWNS the within-grace FOREGROUND reattach.
-            // On the controller's Backgrounded→Reattaching edge (within grace + warm
-            // lease) it fires the RESEED-ONLY body — re-promote Live + heal blank panes
-            // over the still-warm `-CC` lease, NO connect(), NO "Attaching…" overlay.
+            // On the controller's Backgrounded→Reattaching edge (within grace + warm lease)
+            // it fires the RESEED-ONLY body — re-promote Live + heal blank panes over the
+            // still-warm `-CC` lease, NO connect(), NO "Attaching…" overlay.
             // The same body runs directly from `onAppForegrounded(resumedWithinGrace)`
             // in production (the controller does not reach that edge there because the
             // teardown — and thus the controller's Background — is deferred to
-            // grace-elapsed); both paths route through the one [GraceEffects] owner.
-            // The deleted inline `probeCurrentRuntimeOnForegroundIfNeeded →
+            // grace-elapsed); both paths route through the one [GraceEffects] owner (EPIC #792
+            // Slice B). The deleted inline `probeCurrentRuntimeOnForegroundIfNeeded →
             // connect(LifecycleReattach)` path is the superseded behavior (D22 hard-cut).
-            // EPIC #792 Slice B: routes through the single [GraceEffects] owner.
             foregroundReattachEffect = { graceEffects.onForegroundReattachReseed() },
+            // Issue #1545 (R1, extends #904): suppress the reattach-edge reseed while a
+            // `pendingReattach` is outstanding — the pending replay owns recovery (see driver).
+            hasPendingReattach = { pendingReattach != null },
             // EPIC #766 Slice 2a: the controller's Backgrounded -> Reconnecting edge (the
-            // BEYOND-grace foreground) now DRIVES the foreground arm dispatch (the re-home
-            // of the inline foreground dispatch). [onControllerForegrounded] delegates to
-            // the connection-core [ForegroundReturnEffects] (EPIC #687 Slice 0 / #1047),
-            // which selects replay-vs-resume from the live pendingReattach /
-            // pausedAutoReconnect payloads — the controller edge is only the TRIGGER, not
-            // the divergent display-status gate.
+            // BEYOND-grace foreground) DRIVES the foreground arm dispatch. [onControllerForegrounded]
+            // delegates to the connection-core [ForegroundReturnEffects] (EPIC #687 Slice 0 / #1047),
+            // re-reading the live pendingReattach / pausedAutoReconnect payloads — the edge is only
+            // the TRIGGER, not the display-status gate.
             foregroundReconnectEffect = { onControllerForegrounded() },
             // Slice 1c-iv-b-B2 (#742): after the driver submits a TransportLive /
             // TransportDropped from the real flows, re-project _connectionStatus from

--- a/app/src/main/java/com/pocketshell/app/tmux/connection/ConnectionEffectDriver.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/connection/ConnectionEffectDriver.kt
@@ -166,6 +166,22 @@ class ConnectionEffectDriver(
     private val scope: CoroutineScope,
     private val backgroundedEffect: () -> Unit = {},
     private val foregroundReattachEffect: () -> Unit = {},
+    // Issue #1545 (Fable race audit R1, extends #904): the driver's reattach-edge
+    // suppression predicate. When it returns true a `pendingReattach` (the stashed
+    // beyond-grace replay arm) is OUTSTANDING, so the single pending path owns
+    // recovery and the driver MUST NOT ALSO fire [foregroundReattachEffect]. This
+    // closes the two-recovery-writers race: a `Foreground` arriving while a post-grace
+    // teardown close is still in flight walks `Backgrounded → Reattaching` (the
+    // controller's `isWarm` snapshot is still true because the `NonCancellable` close
+    // has not yet evicted the lease, and `now < deadline`), so this reattach edge would
+    // reseed over the DYING client WHILE `replayPendingReattach` dials a fresh transport
+    // in parallel — two writers racing on the one host. Gating on `pendingReattach ==
+    // null` here mirrors the #904 guard on the sibling Reconnecting edge (where
+    // `replayPendingReattach` consumes the stashed arm and the duplicate driver callback
+    // is a no-op). Default `{ false }` keeps the always-reseed behavior for the
+    // observe-only test harness and every within-grace reattach where nothing is
+    // pending (the normal single-reseed path is unchanged).
+    private val hasPendingReattach: () -> Boolean = { false },
     private val foregroundReconnectEffect: () -> Unit = {},
     private val onControllerTransition: () -> Unit = {},
     private val controlChannelDrops: Flow<TmuxClient>? = null,
@@ -274,7 +290,19 @@ class ConnectionEffectDriver(
             // Backgrounded -> Reattaching edge fires this; a Reattaching reached from a
             // transport DROP (the silent heal) is NOT a foreground return.
             if (current is ConnectionState.Reattaching && previous is ConnectionState.Backgrounded) {
-                foregroundReattachEffect()
+                // Issue #1545 (R1, extends #904): SUPPRESS this reseed while a
+                // `pendingReattach` is outstanding. A `Foreground` during a post-grace
+                // teardown-in-flight still resolves to Reattaching (warm-lease snapshot
+                // true + within the controller's 90 s deadline), but the App-grace
+                // teardown already stashed a `pendingReattach` that `replayPendingReattach`
+                // will dial fresh. Reseeding here too would open a SECOND recovery writer
+                // over the dying `-CC` client (the two-writers race). Let the single
+                // pending path own recovery — mirror of the #904 Reconnecting-edge guard.
+                if (!hasPendingReattach()) {
+                    foregroundReattachEffect()
+                } else {
+                    record(Observation.ReattachReseedSuppressedPendingReplay)
+                }
             }
             // Slice 2a (#766): the driver OWNS the BEYOND-grace FOREGROUND return — the
             // re-home of the inline `reduceConnection(Foreground)` arm dispatch. The
@@ -489,6 +517,17 @@ class ConnectionEffectDriver(
          */
         data object DropSuppressed : Observation {
             override fun logLine(): String = "tmux.disconnected=true SUPPRESSED (single-grace-owner)"
+        }
+
+        /**
+         * Issue #1545 (R1, extends #904): the Backgrounded -> Reattaching foreground reseed
+         * the driver SUPPRESSED because a `pendingReattach` was outstanding (a post-grace
+         * teardown-in-flight foreground). Recovery is left to the single pending replay path
+         * so no second recovery writer opens over the dying `-CC` client.
+         */
+        data object ReattachReseedSuppressedPendingReplay : Observation {
+            override fun logLine(): String =
+                "foreground reattach reseed SUPPRESSED (pending-replay owns recovery)"
         }
 
         /** A [TransportPort.transportEvents] lease up/down edge. */

--- a/app/src/test/java/com/pocketshell/app/tmux/connection/ConnectionEffectDriverTeardownRaceProofTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/connection/ConnectionEffectDriverTeardownRaceProofTest.kt
@@ -1,0 +1,341 @@
+package com.pocketshell.app.tmux.connection
+
+import com.pocketshell.core.connection.Clock
+import com.pocketshell.core.connection.ConnectionController
+import com.pocketshell.core.connection.ConnectionEvent
+import com.pocketshell.core.connection.ConnectionState
+import com.pocketshell.core.connection.HostKey
+import com.pocketshell.core.connection.SessionId
+import com.pocketshell.core.connection.TmuxPort
+import com.pocketshell.core.connection.TransportPort
+import com.pocketshell.core.connection.TransportUpDown
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1545 (Fable race/timing audit finding R1, extends #904) — DETERMINISTIC,
+ * environment-INDEPENDENT proof that a `Foreground` arriving while a POST-GRACE
+ * TEARDOWN CLOSE is still in flight must fire EXACTLY ONE recovery writer, not two.
+ *
+ * ## The race (#780 model: inject the failing state synthetically, no `assumeTrue`)
+ *
+ * The App-level grace window (#450) elapses and starts the clean detach — the full
+ * teardown runs under `NonCancellable`, which STASHES a `pendingReattach` (the
+ * beyond-grace replay arm `replayPendingReattach` will dial fresh). While that close
+ * is still running:
+ *  - the transport lease is NOT yet evicted, so `transport.isWarm(host)` snapshots
+ *    TRUE, and
+ *  - the controller's own 90 s grace deadline (`DEFAULT_GRACE_MS`, stamped at
+ *    Background) has NOT elapsed.
+ * So a `Foreground` submitted here resolves in [ConnectionController.onForeground] to
+ * `withinGrace = true` -> `Backgrounded -> Reattaching`. The [ConnectionEffectDriver]
+ * observes that edge and — before #1545 — ALWAYS fired `foregroundReattachEffect`,
+ * reseeding over the DYING `-CC` client. Meanwhile the beyond-grace lifecycle path
+ * (`dispatchPostGraceForegroundArmIfPending`) sees `pendingReattach != null` and
+ * `replayPendingReattach` dials a FRESH transport in parallel — TWO writers racing on
+ * the one host.
+ *
+ * ## The fix (mirror of #904's Reconnecting-edge guard)
+ *
+ * #904 closed the SIBLING edge (Backgrounded -> Reconnecting): there the driver's
+ * `foregroundReconnectEffect` and the lifecycle replay both call the same
+ * `ForegroundReturnEffects`, and the duplicate is a no-op because the first consumed
+ * `pendingReattach`. The Reattaching edge had NO such guard. #1545 adds the
+ * [ConnectionEffectDriver.hasPendingReattach] predicate: when a `pendingReattach` is
+ * outstanding the driver SUPPRESSES the reattach-edge reseed and lets the single
+ * pending path own recovery. `pendingReattach == null` (every normal within-grace
+ * reattach) is unchanged — the reseed still fires once.
+ *
+ * The four cases below cover the whole class (G2): the teardown-in-flight race WITHOUT
+ * the gate (base-red, two writers), WITH the gate (fix-green, one writer), the normal
+ * teardown-done within-grace reattach (single reseed, gate is inert), and the #904
+ * Reconnecting edge (unaffected by the reattach gate — still fires its replay once).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ConnectionEffectDriverTeardownRaceProofTest {
+
+    private class TestClock(var now: Long = 0L) : Clock {
+        override fun nowMs(): Long = now
+    }
+
+    private val host = HostKey("alice@example.com:22/7")
+    private val sessionA = SessionId("7/main")
+
+    private class InertTmuxPort : TmuxPort {
+        val disconnectedFlow = MutableSharedFlow<Boolean>(extraBufferCapacity = 16)
+        override val disconnected: Flow<Boolean> = disconnectedFlow
+    }
+
+    /**
+     * `warm` models the transport-lease snapshot the controller reads in
+     * `onForeground`. During a post-grace teardown-in-flight the `NonCancellable`
+     * close has NOT yet evicted the lease, so it is still `true` — the exact state
+     * that makes the Foreground resolve to Reattaching (the racing edge).
+     */
+    private class InertTransportPort(var warm: Boolean) : TransportPort {
+        val transportEventsFlow = MutableSharedFlow<TransportUpDown>(extraBufferCapacity = 16)
+        override val transportEvents: Flow<TransportUpDown> = transportEventsFlow
+        override fun isWarm(host: HostKey): Boolean = warm
+    }
+
+    /**
+     * The collector runs on an [UnconfinedTestDispatcher] so each controller submit is
+     * observed by the driver's edge collector SYNCHRONOUSLY inside the submit — the
+     * production-faithful ordering where the driver's reattach effect fires as the
+     * Foreground reduces (before the lifecycle replay dispatch runs).
+     *
+     * @param gatePending when true, the driver consults [pendingReplayStashed] via
+     *   [ConnectionEffectDriver.hasPendingReattach] — the #1545 fix wiring. When false,
+     *   the driver NEVER consults the pending state (the pre-#1545 driver that always
+     *   reseeded) — the base-red characterization.
+     */
+    private inner class Harness(
+        scope: CoroutineScope,
+        val clock: TestClock,
+        val transportPort: InertTransportPort,
+        gatePending: Boolean,
+    ) {
+        val tmuxPort = InertTmuxPort()
+        val controller = ConnectionController(clock = clock, transport = transportPort)
+
+        /** Whether the App-grace teardown stashed a `pendingReattach` (writer #2's arm). */
+        var pendingReplayStashed = false
+
+        /** Writer #1 — the driver's reattach-edge reseed over the (dying) `-CC` client. */
+        var reattachReseedCount = 0
+
+        /** Writer #2 — the beyond-grace lifecycle replay (`replayPendingReattach`). */
+        var pendingReplayCount = 0
+
+        /** The #904 sibling edge effect (Backgrounded -> Reconnecting); NOT gated by #1545. */
+        var reconnectEffectCount = 0
+
+        val driver = ConnectionEffectDriver(
+            controller = controller,
+            tmuxPort = tmuxPort,
+            transportPort = transportPort,
+            scope = scope,
+            foregroundReattachEffect = { reattachReseedCount += 1 },
+            hasPendingReattach = { if (gatePending) pendingReplayStashed else false },
+            foregroundReconnectEffect = {
+                reconnectEffectCount += 1
+                // Mirror production: the controller's foreground edge dispatches
+                // ForegroundReturnEffects, which replays (and CONSUMES) a stashed
+                // pendingReattach. The #904 guard: the lifecycle duplicate is then a no-op.
+                consumePendingReplay()
+            },
+        ).also { it.start() }
+
+        /** Drive the controller to Live (cold path) so Background has a live source. */
+        fun driveToLive() {
+            controller.submit(ConnectionEvent.Enter(host, sessionA))
+            controller.submit(ConnectionEvent.TransportLive)
+            controller.submit(ConnectionEvent.SeedLanded(sessionA, paneId = "%0"))
+        }
+
+        /**
+         * Model the beyond-grace `onAppForegrounded` ordering: submit Foreground to the
+         * controller (the driver observes the edge SYNCHRONOUSLY here and fires its
+         * reattach/reconnect effect), THEN run the lifecycle replay-arm dispatch
+         * (`dispatchPostGraceForegroundArmIfPending` -> `replayPendingReattach`) if a
+         * pending arm is still stashed.
+         */
+        fun foreground() {
+            controller.submit(ConnectionEvent.Foreground)
+            // dispatchPostGraceForegroundArmIfPending(): replays iff still stashed.
+            consumePendingReplay()
+        }
+
+        private fun consumePendingReplay() {
+            if (pendingReplayStashed) {
+                pendingReplayStashed = false
+                pendingReplayCount += 1
+            }
+        }
+
+        /** Total recovery writers that touched the host on the foreground return. */
+        fun totalRecoveryWriters(): Int = reattachReseedCount + pendingReplayCount
+    }
+
+    private fun scope(): CoroutineScope = CoroutineScope(Job() + UnconfinedTestDispatcher())
+
+    /**
+     * BASE-RED (characterization): a `Foreground` during a post-grace teardown-in-flight
+     * when the driver does NOT consult the outstanding `pendingReattach` (the pre-#1545
+     * driver) fires TWO recovery writers — the reattach-edge reseed over the dying client
+     * AND the pending replay dialing fresh. This is the race R1 reports.
+     */
+    @Test
+    fun foregroundDuringTeardownInFlight_withoutPendingGate_firesTwoRecoveryWriters() = runTest {
+        val scope = scope()
+        val transportPort = InertTransportPort(warm = true)
+        val h = Harness(scope, TestClock(), transportPort, gatePending = false)
+
+        h.driveToLive()
+        h.controller.submit(ConnectionEvent.Background) // -> Backgrounded (stamps 90 s deadline)
+
+        // Post-grace teardown-in-flight: the App-grace teardown stashed a pendingReattach,
+        // the NonCancellable close has NOT yet evicted the lease (warm stays true), and the
+        // controller's 90 s deadline has NOT elapsed (now well under DEFAULT_GRACE_MS).
+        h.pendingReplayStashed = true
+        transportPort.warm = true
+        h.clock.now = 1_000L
+        h.foreground() // Backgrounded -> Reattaching (warm + within grace)
+
+        assertTrue(
+            "sanity: warm-lease snapshot + within-grace resolves Foreground to Reattaching",
+            h.controller.state.value is ConnectionState.Reattaching,
+        )
+        assertEquals(
+            "BASE-RED: without the pending gate the driver reseeds over the dying client",
+            1,
+            h.reattachReseedCount,
+        )
+        assertEquals(
+            "BASE-RED: the pending path ALSO replays -> a second racing writer",
+            1,
+            h.pendingReplayCount,
+        )
+        assertEquals(
+            "BASE-RED: TWO recovery writers race on the one host (the R1 bug)",
+            2,
+            h.totalRecoveryWriters(),
+        )
+        scope.cancel()
+    }
+
+    /**
+     * FIX-GREEN: the SAME post-grace teardown-in-flight foreground, with the driver
+     * consulting the outstanding `pendingReattach` (the #1545 gate). The reattach-edge
+     * reseed is SUPPRESSED, the single pending path owns recovery, and EXACTLY ONE
+     * recovery writer touches the host.
+     */
+    @Test
+    fun foregroundDuringTeardownInFlight_withPendingGate_firesExactlyOneRecoveryWriter() = runTest {
+        val scope = scope()
+        val transportPort = InertTransportPort(warm = true)
+        val h = Harness(scope, TestClock(), transportPort, gatePending = true)
+
+        h.driveToLive()
+        h.controller.submit(ConnectionEvent.Background)
+
+        h.pendingReplayStashed = true
+        transportPort.warm = true
+        h.clock.now = 1_000L
+        h.foreground() // Backgrounded -> Reattaching, but gated on pendingReattach
+
+        assertTrue(
+            "sanity: still resolves to Reattaching — the fix is in the driver edge, not the reducer",
+            h.controller.state.value is ConnectionState.Reattaching,
+        )
+        assertEquals(
+            "FIX-GREEN: the reattach-edge reseed is SUPPRESSED while a pendingReattach is outstanding",
+            0,
+            h.reattachReseedCount,
+        )
+        assertEquals(
+            "FIX-GREEN: the single pending path replays exactly once",
+            1,
+            h.pendingReplayCount,
+        )
+        assertEquals(
+            "FIX-GREEN: EXACTLY ONE recovery writer touches the host",
+            1,
+            h.totalRecoveryWriters(),
+        )
+        assertTrue(
+            "the suppression is recorded as an observation for diagnostics",
+            h.driver.observations.value.any {
+                it is ConnectionEffectDriver.Observation.ReattachReseedSuppressedPendingReplay
+            },
+        )
+        scope.cancel()
+    }
+
+    /**
+     * CLASS COVERAGE — the NORMAL within-grace reattach (foreground AFTER any teardown is
+     * done / never ran): NOTHING is pending, so the gate is inert and the driver reseeds
+     * exactly once. This pins that #1545 does NOT break the healthy single-reseed path.
+     */
+    @Test
+    fun foregroundNormalWithinGrace_noPending_firesSingleReseed() = runTest {
+        val scope = scope()
+        val transportPort = InertTransportPort(warm = true)
+        val h = Harness(scope, TestClock(), transportPort, gatePending = true)
+
+        h.driveToLive()
+        h.controller.submit(ConnectionEvent.Background)
+
+        // Nothing pending — the within-grace foreground return keeps the warm lease.
+        h.pendingReplayStashed = false
+        transportPort.warm = true
+        h.clock.now = 1_000L
+        h.foreground() // Backgrounded -> Reattaching
+
+        assertTrue(h.controller.state.value is ConnectionState.Reattaching)
+        assertEquals(
+            "the normal within-grace reattach still fires its single reseed (gate inert)",
+            1,
+            h.reattachReseedCount,
+        )
+        assertEquals("no pending replay when nothing was stashed", 0, h.pendingReplayCount)
+        assertEquals("exactly one recovery writer on the normal reattach", 1, h.totalRecoveryWriters())
+        scope.cancel()
+    }
+
+    /**
+     * CLASS COVERAGE — the #904 sibling edge is PRESERVED. A beyond-grace foreground
+     * (lease evicted -> warm false) resolves to Backgrounded -> Reconnecting, NOT
+     * Reattaching. The reattach gate does not touch this edge: `foregroundReconnectEffect`
+     * still fires once (replaying the pending arm), and the lifecycle duplicate is a no-op
+     * because the first consumed the stash — the #904 guard still holds non-vacuously.
+     */
+    @Test
+    fun beyondGraceForeground_reconnectEdge_stillReplaysOnce_904Preserved() = runTest {
+        val scope = scope()
+        val transportPort = InertTransportPort(warm = true)
+        val h = Harness(scope, TestClock(), transportPort, gatePending = true)
+
+        h.driveToLive()
+        h.controller.submit(ConnectionEvent.Background)
+
+        // Beyond grace: the teardown ran and EVICTED the lease -> warm false. A stashed
+        // pendingReattach is present (the replay arm).
+        h.pendingReplayStashed = true
+        transportPort.warm = false
+        h.clock.now = ConnectionController.DEFAULT_GRACE_MS + 1L
+        h.foreground() // Backgrounded -> Reconnecting
+
+        assertTrue(
+            "beyond grace resolves to Reconnecting, not Reattaching",
+            h.controller.state.value is ConnectionState.Reconnecting,
+        )
+        assertEquals(
+            "the reattach-edge reseed never fires on the Reconnecting edge",
+            0,
+            h.reattachReseedCount,
+        )
+        assertEquals(
+            "the #904 Reconnecting edge still fires its foreground reconnect effect once",
+            1,
+            h.reconnectEffectCount,
+        )
+        assertEquals(
+            "#904 guard holds: the driver edge consumed the pending arm; the lifecycle " +
+                "duplicate is a no-op -> exactly one replay",
+            1,
+            h.pendingReplayCount,
+        )
+        assertEquals("exactly one recovery writer on the beyond-grace edge", 1, h.totalRecoveryWriters())
+        scope.cancel()
+    }
+}


### PR DESCRIPTION
Fixes finding **R1** from the Fable race audit (#843): a `Foreground` during a post-grace teardown close-in-flight fired **two recovery writers** on one host — the driver reattach edge (`ConnectionEffectDriver.kt:276`) promoted a false `Live`/reseed over the dying `-CC` client while `replayPendingReattach` dialed fresh in parallel. #904 had guarded only the sibling `Reconnecting` edge.

**Fix:** gate the driver reattach-edge reseed on a `hasPendingReattach` predicate (mirrors #904), wired from the VM as `{ pendingReattach != null }`, so the single pending path owns recovery.

**Verification (reviewer-run red→green + emulator grace journey — #1545 comment 4962843152):**
- Base red genuinely reproduces TWO writers: `reattachReseedCount==1 AND pendingReplayCount==1 AND total==2`. With fix: total==1.
- #904 `Reconnecting` edge untouched; its regression test passes non-vacuously.
- **#638 grace journey on emulator-5554 + Docker agents:2222:** `BackgroundGraceReconnectE2eTest` 3/3 — within-grace (no reconnect, correct session, no Disconnected band) + beyond-grace reattach; `main_max_stall_ms=156`.
- Hygiene: file-size + VM-ratchet (17588≤17621) + test-validity exit 0; VM net reduction.

Closes #1545
