### PR TITLE
message-queue: write-ahead durable outbound row before clearing draft (#1540)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerOutboundSend.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerOutboundSend.kt
@@ -1,0 +1,357 @@
+package com.pocketshell.app.composer
+
+import androidx.lifecycle.viewModelScope
+import com.pocketshell.app.composer.PromptComposerViewModel.AttachmentUploadState
+import com.pocketshell.app.composer.PromptComposerViewModel.SendRequest
+import com.pocketshell.app.composer.PromptComposerViewModel.SendTargetSnapshot
+import com.pocketshell.app.composer.PromptComposerViewModel.StagedAttachment
+import com.pocketshell.app.diagnostics.DiagnosticEvents
+import java.util.UUID
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/**
+ * Issue #971 / #1540: the outbound-send dispatch surface of
+ * [PromptComposerViewModel], split out of the god-object VM (D28 / file-size
+ * hygiene ratchet) into cohesive same-module `internal` extensions.
+ *
+ * This is the write-ahead handoff path: [emitSendRequest] flips the composer
+ * in-flight, and the durable outbound-queue row ([enqueueOutboundSend] /
+ * [enqueueAndDispatchSidecarBackedSend]) is committed BEFORE the editable draft
+ * is cleared ([clearComposerForHandoff]) — closing the #1540 (L9) silent-LOST
+ * window where a process death between draft-clear and row-commit lost the
+ * prompt from both stores.
+ */
+/**
+ * Issue #211 / #745: compose + emit the [SendRequest] from the CURRENT draft
+ * and staged tiles, flipping the composer into the in-flight state. Split out
+ * of [dispatchSendNow] so the upload-await path ([dispatchSendAfterUpload])
+ * shares the exact same emission semantics once the upload has resolved.
+ */
+internal fun PromptComposerViewModel.emitSendRequest(
+    withEnter: Boolean,
+    sendTarget: SendTargetSnapshot = SendTargetSnapshot(),
+) {
+    if (_uiState.value.sendInFlight) return
+    // #1531 (RC2): a Send during a sidecar retry upload used to drop SILENTLY.
+    if (outboundSidecarDispatchInFlight) {
+        _uiState.update { it.copy(error = PromptComposerViewModel.SEND_BUSY_UPLOADING_MESSAGE) }
+        return
+    }
+    val draft = _uiState.value.draft
+    val attachments = _uiState.value.attachments
+    // Issue #544: compose the outgoing prompt = the user's clean draft
+    // + the "Attached files:" suffix appended at the END from whatever
+    // tiles remain at send time. The draft stayed clean while composing;
+    // the agent still receives the remote paths.
+    val text = appendAttachmentPaths(draft, attachments.map { it.remotePath })
+    // Send when there is either typed text or at least one attachment.
+    // (A pure-attachment send still has a non-empty composed `text`.)
+    if (text.isEmpty()) return
+    DiagnosticEvents.record(
+        "action",
+        "composer_send",
+        "textBytes" to text.toByteArray(Charsets.UTF_8).size,
+        "attachmentCount" to attachments.size,
+        "withEnter" to withEnter,
+    )
+    // Issue #971: HAND THE PROMPT OFF to the outbound queue so the prompt is
+    // represented EXACTLY ONCE (the "Sending…" queue row), never as BOTH the
+    // editor text AND a duplicate "1 unsent prompt" row. This reverses the
+    // #745 keep-the-draft-visible behaviour (hard-cut per D22): the queue row
+    // is the single in-flight source of truth, and the Send button reads
+    // `sendInFlight` to disable itself + show "Sending…". The clean draft +
+    // tiles still travel in the [SendRequest] / queue row, so a failed send
+    // ([restoreFailedSend]) puts the EXACT prompt back into the (now-single)
+    // composer, and a delivered send leaves it empty.
+    //
+    // Issue #1540 (L9 — the widest silent-LOST hole): the composer clear
+    // ([clearComposerForHandoff]) USED to run HERE, synchronously, BEFORE the
+    // durable outbound-queue row was committed (an async IO hop below; the
+    // sidecar path staged bytes first, widening the window). If the process
+    // died in that window the prompt existed in NEITHER the durable draft NOR
+    // the durable queue — gone with zero trace. The fix WRITE-AHEADS the
+    // durable row: the clear is deferred into each durable path and runs ONLY
+    // AFTER the row commit succeeds ([enqueueOutboundSend] /
+    // [enqueueAndDispatchSidecarBackedSend]), so a crash in the window always
+    // leaves the prompt recoverable in EXACTLY ONE durable place — the draft
+    // (before commit) or the queue row (after commit) — never lost. The
+    // no-durable-store fallback has no row to write-ahead, so it clears
+    // synchronously just before emitting (no IO hop, nothing to lose).
+    _uiState.update { it.copy(sendInFlight = true, error = null) }
+    // Issue #891: arm the overall-send watchdog the instant we go in-flight
+    // so a host `onSend` that never resolves (wedged channel / dropped
+    // emission with no live collector) can never leave the composer stuck on
+    // "Sending…" forever.
+    watchdogs.armSend()
+    val handoffRequest = SendRequest(
+        text = text,
+        withEnter = withEnter,
+        cleanDraft = draft,
+        attachments = attachments,
+        sendTarget = sendTarget,
+    )
+    inFlightSendRequest = handoffRequest
+    if (sendTarget.sessionKey.isNotBlank() && hasLocalAttachmentsForSidecars(attachments)) {
+        viewModelScope.launch(outboundQueueDispatcher) {
+            try {
+                enqueueAndDispatchSidecarBackedSend(
+                    cleanDraft = draft,
+                    attachments = attachments,
+                    withEnter = withEnter,
+                    sendTarget = sendTarget,
+                )
+            } catch (cancelled: CancellationException) {
+                // Issue #929: a real cancellation (e.g. VM cleared) — clear
+                // the in-flight gates so a recreated composer is not wedged,
+                // then rethrow to honour structured concurrency.
+                clearStrandedSendInFlight()
+                throw cancelled
+            } catch (t: Throwable) {
+                // Issue #929: any unexpected failure in the sidecar dispatch
+                // is still a non-delivering exit — clear the strand so the
+                // pipeline self-heals instead of waiting on the watchdog.
+                clearStrandedSendInFlight(
+                    error = "Send failed: reconnect, then send again or discard the draft.",
+                )
+            }
+        }
+        return
+    }
+    if (outboundQueueStore !== DisabledOutboundQueueStore &&
+        sendTarget.sessionKey.isNotBlank()
+    ) {
+        viewModelScope.launch(outboundQueueDispatcher) {
+            try {
+                val outboundItem = enqueueOutboundSend(
+                    cleanDraft = draft,
+                    attachments = attachments,
+                    withEnter = withEnter,
+                    sendTarget = sendTarget,
+                )
+                withContext(Dispatchers.Main.immediate) {
+                    // Issue #1540 (L9): the durable row is committed — NOW it
+                    // is safe to clear the editable draft + durable draft. A
+                    // crash before this point leaves the prompt in the durable
+                    // draft (nothing was cleared yet); a crash after it leaves
+                    // the prompt in the just-committed queue row. Never both
+                    // gone at once — the LOST window is closed.
+                    clearComposerForHandoff()
+                    emitPreparedSendRequest(
+                        text = text,
+                        withEnter = withEnter,
+                        cleanDraft = draft,
+                        attachments = attachments,
+                        sendTarget = sendTarget,
+                        outboundQueueItemId = outboundItem?.id,
+                    )
+                }
+            } catch (cancelled: CancellationException) {
+                clearStrandedSendInFlight()
+                throw cancelled
+            } catch (t: Throwable) {
+                clearStrandedSendInFlight(
+                    error = "Send failed: reconnect, then send again or discard the draft.",
+                )
+            }
+        }
+        return
+    }
+    // Issue #1540 (L9): the no-durable-store fallback (DisabledOutboundQueueStore
+    // or a blank sessionKey) has no queue row to write-ahead, so there is no
+    // durable-loss window — the prompt only ever travels in the in-memory
+    // [SendRequest]. Clear synchronously here, just before emitting, exactly
+    // as the pre-#1540 code did.
+    clearComposerForHandoff()
+    emitPreparedSendRequest(
+        text = text,
+        withEnter = withEnter,
+        cleanDraft = draft,
+        attachments = attachments,
+        sendTarget = sendTarget,
+        outboundQueueItemId = null,
+    )
+}
+
+internal fun PromptComposerViewModel.emitPreparedSendRequest(
+    text: String,
+    withEnter: Boolean,
+    cleanDraft: String,
+    attachments: List<StagedAttachment>,
+    sendTarget: SendTargetSnapshot,
+    outboundQueueItemId: String?,
+) {
+    // Issue #254: a `Channel.trySend` buffers the item until a collector
+    // consumes it, so a send dispatched while the sheet's collector is
+    // mid-recreate (dismiss → re-open) is delivered to the next collector.
+    val request = SendRequest(
+        text = text,
+        withEnter = withEnter,
+        cleanDraft = cleanDraft,
+        attachments = attachments,
+        sendTarget = sendTarget,
+        outboundQueueItemId = outboundQueueItemId,
+    )
+    // Issue #971: remember the in-flight prompt so wedged/cancelled send
+    // recovery restores the exact draft + tiles to the now-cleared composer.
+    inFlightSendRequest = request
+    if (_sendRequests.trySend(request).isFailure) {
+        // Issue #971/#987: a buffer-full enqueue is a transient dispatch
+        // failure, not a permanent rejection — defer to the queue so the row
+        // stays queued and auto-retries on the next flush (Option A). Falls
+        // back to a composer-restore only when there is no durable row.
+        markOutboundSendDeferred(request)
+    }
+}
+
+/**
+ * Issue #971: hand the prompt off to the outbound queue — empty the editable
+ * composer (draft text + staged attachment tiles + the persisted draft slots)
+ * so an in-flight send is represented EXACTLY ONCE by its "Sending…" queue
+ * row, never as BOTH the editor AND a duplicate "1 unsent prompt" row.
+ *
+ * This clears the in-memory draft/tiles, the [SavedStateHandle] draft slots
+ * (so a process-death recreate mid-send does not resurrect the handed-off
+ * text into the editor alongside the queue row), and the durable per-session
+ * draft store (so a session switch away-and-back mid-send does not reload the
+ * handed-off draft into the editor next to its queue row). The prompt is NOT
+ * lost: it travels in the [SendRequest] + the durable queue row, so a failed
+ * send ([restoreFailedSend]) restores the exact draft + tiles back into the
+ * (now-single) composer, and a delivered send leaves the composer empty.
+ */
+internal fun PromptComposerViewModel.clearComposerForHandoff() {
+    savedStateHandle[PromptComposerViewModel.KEY_DRAFT] = ""
+    savedStateHandle[PromptComposerViewModel.KEY_DRAFT_OWNER] = null
+    composerTarget?.let { target ->
+        clearComposerDraft(target)
+        composerDraftStore.clearAttachments(target)
+    }
+    _uiState.update { current ->
+        current.copy(
+            draft = "",
+            attachments = emptyList(),
+            attachmentUpload = AttachmentUploadState.Idle,
+        )
+    }
+    // Issue #1540 (L9): synthetic process-death seam (#780 model). Fires the
+    // INSTANT the durable draft has been cleared. A crash right here is the
+    // exact LOST window: the durable draft is gone, and — with the WRITE-AHEAD
+    // fix — the durable queue row is ALREADY committed (this runs after the
+    // commit in every durable path), so the test snapshots the durable stores
+    // and asserts the prompt survived in the queue row. On the pre-fix base
+    // this ran BEFORE the commit, so the snapshot showed the prompt gone from
+    // both stores (LOST). Production never sets this (null → no-op).
+    onDurableDraftClearedForHandoffTest?.invoke()
+}
+
+internal fun PromptComposerViewModel.hasLocalAttachmentsForSidecars(attachments: List<StagedAttachment>): Boolean =
+    outboundQueueStore !== DisabledOutboundQueueStore &&
+        outboundAttachmentSidecarStore != null &&
+        outboundAttachmentUploader != null &&
+        attachments.any { it.previewUri != null }
+
+internal suspend fun PromptComposerViewModel.enqueueAndDispatchSidecarBackedSend(
+    cleanDraft: String,
+    attachments: List<StagedAttachment>,
+    withEnter: Boolean,
+    sendTarget: SendTargetSnapshot,
+) {
+    // Issue #929: this whole dispatch runs while `sendInFlight = true` (set by
+    // [emitSendRequest] before launching us). EVERY exit that does not deliver
+    // must clear the in-flight gates, or the pipeline wedges for the watchdog
+    // window. The early config-missing returns below are non-delivering exits.
+    val sessionKey = sendTarget.sessionKey.takeIf { it.isNotBlank() }
+    val sidecarStore = outboundAttachmentSidecarStore ?: run {
+        clearStrandedSendInFlight()
+        return
+    }
+    if (sessionKey == null) {
+        clearStrandedSendInFlight()
+        return
+    }
+    val localAttachments = attachments.mapIndexedNotNull { index, attachment ->
+        attachment.previewUri?.let { index to it }
+    }
+    val itemId = UUID.randomUUID().toString()
+    val sidecars = sidecarStore.stage(
+        outboundItemId = itemId,
+        uris = localAttachments.map { it.second },
+        attachmentIndices = localAttachments.map { it.first },
+    )
+    if (sidecars.size != localAttachments.size) {
+        clearStrandedSendInFlight(
+            error = "Attachment upload failed: could not preserve selected file bytes. Your draft was kept.",
+        )
+        return
+    }
+    val item = OutboundItem(
+        id = itemId,
+        sessionKey = sessionKey,
+        cleanText = cleanDraft,
+        attachments = attachments.toSidecarAwareDurableRefs(sidecars),
+        withEnter = withEnter,
+        state = OutboundState.Queued,
+        createdAtMs = clock(),
+        paneId = sendTarget.paneId,
+        route = sendTarget.route,
+        agentKind = sendTarget.agentKind,
+        // Issue #961: coalesce a re-Send of the SAME logical prompt onto the
+        // existing un-delivered row instead of minting a duplicate.
+        sendKey = computeSendKey(cleanDraft, attachments, withEnter, sendTarget),
+    )
+    val queuedItem = outboundQueueStore.enqueueExisting(item)
+    // Issue #961: if this coalesced onto an existing un-delivered row, the
+    // freshly-staged sidecars under our throwaway `itemId` are orphaned —
+    // the existing row keeps its own staged bytes. Drop them and dispatch
+    // the row the queue actually kept, not our discarded id.
+    if (queuedItem.id != itemId) {
+        outboundAttachmentSidecarStore?.removeOutboundItem(itemId)
+    }
+    // Issue #1540 (L9): the durable row is committed (with its attachment
+    // refs AND the staged sidecar bytes above) — NOW it is safe to clear the
+    // editable draft + durable draft. This is the widest LOST window: the
+    // attachment path stages bytes BEFORE the row commit, so clearing the
+    // draft up front (the old order) meant a death between stage and commit
+    // lost the prompt AND orphaned the sidecar bytes with no owning row. The
+    // clear runs on Main ([clearComposerForHandoff] writes the SavedStateHandle
+    // draft slots, which require the Main thread).
+    withContext(Dispatchers.Main.immediate) { clearComposerForHandoff() }
+    inFlightSendRequest = SendRequest(
+        text = appendAttachmentPaths(cleanDraft, attachments.map { it.remotePath }),
+        withEnter = withEnter,
+        cleanDraft = cleanDraft,
+        attachments = attachments,
+        sendTarget = sendTarget,
+        outboundQueueItemId = queuedItem.id,
+    )
+    refreshOutboundQueueItemsFor(sessionKey)
+    dispatchPreparedOutboundItem(queuedItem.id)
+}
+
+internal fun PromptComposerViewModel.enqueueOutboundSend(
+    cleanDraft: String,
+    attachments: List<StagedAttachment>,
+    withEnter: Boolean,
+    sendTarget: SendTargetSnapshot,
+): OutboundItem? {
+    if (outboundQueueStore === DisabledOutboundQueueStore) return null
+    val sessionKey = sendTarget.sessionKey.takeIf { it.isNotBlank() } ?: return null
+    val item = outboundQueueStore.enqueue(
+        sessionKey = sessionKey,
+        cleanText = cleanDraft,
+        attachments = attachments.toDurableRefs(),
+        withEnter = withEnter,
+        paneId = sendTarget.paneId,
+        route = sendTarget.route,
+        agentKind = sendTarget.agentKind,
+        // Issue #961: coalesce a re-Send of the SAME logical prompt onto the
+        // existing un-delivered row instead of minting a duplicate.
+        sendKey = computeSendKey(cleanDraft, attachments, withEnter, sendTarget),
+    )
+    val activeItem = outboundQueueStore.markInFlight(item.id) ?: item
+    refreshOutboundQueueItemsFor(sessionKey)
+    return activeItem
+}

--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerViewModel.kt
@@ -111,16 +111,16 @@ public class PromptComposerViewModel @Inject constructor(
     // `VoiceModule` always provides the SharedPreferences-backed store so a
     // draft survives a session switch (and a process-death recreate) keyed
     // by the session it was authored in. See [ComposerDraftStore].
-    private val composerDraftStore: ComposerDraftStore = DisabledComposerDraftStore,
+    internal val composerDraftStore: ComposerDraftStore = DisabledComposerDraftStore,
     // Issue #900: durable outbound queue surface. Defaults to a no-op store so
     // direct unit/connected constructors stay source-compatible; production
     // Hilt wiring provides the SharedPreferences-backed store.
-    private val outboundQueueStore: OutboundQueueStore = DisabledOutboundQueueStore,
-    private val outboundAttachmentSidecarStore: OutboundAttachmentSidecarStore? = null,
-    private val savedStateHandle: SavedStateHandle = SavedStateHandle(),
+    internal val outboundQueueStore: OutboundQueueStore = DisabledOutboundQueueStore,
+    internal val outboundAttachmentSidecarStore: OutboundAttachmentSidecarStore? = null,
+    internal val savedStateHandle: SavedStateHandle = SavedStateHandle(),
 ) : ViewModel() {
 
-    private val _uiState: MutableStateFlow<UiState> = MutableStateFlow(
+    internal val _uiState: MutableStateFlow<UiState> = MutableStateFlow(
         UiState(
             // Issue #169 Part 2: restore the typed/dictated draft so a
             // process-death recreate (the worst-case "screen-lock kills
@@ -200,7 +200,7 @@ public class PromptComposerViewModel @Inject constructor(
      * stale draft is discarded so it never appears in a session it was not
      * authored in. Null until the host wires the first target.
      */
-    private var composerTarget: String? = null
+    internal var composerTarget: String? = null
 
     /**
      * Issue #688: ids of pending-transcription rows with a retry round-trip
@@ -245,7 +245,7 @@ public class PromptComposerViewModel @Inject constructor(
      * small buffer so [trySend] never fails for the at-most-one pending
      * send the FSM allows.
      */
-    private val _sendRequests = Channel<SendRequest>(capacity = Channel.BUFFERED)
+    internal val _sendRequests = Channel<SendRequest>(capacity = Channel.BUFFERED)
     public val sendRequests: Flow<SendRequest> = _sendRequests.receiveAsFlow()
 
     /**
@@ -268,9 +268,9 @@ public class PromptComposerViewModel @Inject constructor(
     private var pendingSendWithEnter: Boolean = false
     private var pendingSendTarget: SendTargetSnapshot = SendTargetSnapshot()
     private var attachmentJob: Job? = null
-    private var outboundAttachmentUploader: (suspend (List<LocalAttachmentSidecarRef>) -> Result<List<String>>)? =
+    internal var outboundAttachmentUploader: (suspend (List<LocalAttachmentSidecarRef>) -> Result<List<String>>)? =
         null
-    private var outboundSidecarDispatchInFlight: Boolean = false
+    internal var outboundSidecarDispatchInFlight: Boolean = false
     internal var outboundQueueDispatcher: CoroutineDispatcher = Dispatchers.IO
     private val draftPersistence = ComposerDraftPersistence(
         store = composerDraftStore,
@@ -290,9 +290,9 @@ public class PromptComposerViewModel @Inject constructor(
      * of an empty one. Set the instant a send goes in-flight; cleared the instant
      * it resolves (delivered / failed / strand-cleared / discarded).
      */
-    private var inFlightSendRequest: SendRequest? = null
+    internal var inFlightSendRequest: SendRequest? = null
 
-    private val watchdogs = PromptComposerWatchdogs(
+    internal val watchdogs = PromptComposerWatchdogs(
         scope = viewModelScope,
         sendTimeoutMs = OVERALL_SEND_TIMEOUT_MS,
         transcribeTimeoutMs = TRANSCRIBE_TIMEOUT_MS,
@@ -471,7 +471,7 @@ public class PromptComposerViewModel @Inject constructor(
         draftPersistence.save(sessionKey, draft)
     }
 
-    private fun clearComposerDraft(sessionKey: String?) {
+    internal fun clearComposerDraft(sessionKey: String?) {
         draftPersistence.clear(sessionKey)
     }
 
@@ -873,294 +873,6 @@ public class PromptComposerViewModel @Inject constructor(
     }
 
     /**
-     * Issue #211 / #745: compose + emit the [SendRequest] from the CURRENT draft
-     * and staged tiles, flipping the composer into the in-flight state. Split out
-     * of [dispatchSendNow] so the upload-await path ([dispatchSendAfterUpload])
-     * shares the exact same emission semantics once the upload has resolved.
-     */
-    private fun emitSendRequest(
-        withEnter: Boolean,
-        sendTarget: SendTargetSnapshot = SendTargetSnapshot(),
-    ) {
-        if (_uiState.value.sendInFlight) return
-        // #1531 (RC2): a Send during a sidecar retry upload used to drop SILENTLY.
-        if (outboundSidecarDispatchInFlight) {
-            _uiState.update { it.copy(error = SEND_BUSY_UPLOADING_MESSAGE) }
-            return
-        }
-        val draft = _uiState.value.draft
-        val attachments = _uiState.value.attachments
-        // Issue #544: compose the outgoing prompt = the user's clean draft
-        // + the "Attached files:" suffix appended at the END from whatever
-        // tiles remain at send time. The draft stayed clean while composing;
-        // the agent still receives the remote paths.
-        val text = appendAttachmentPaths(draft, attachments.map { it.remotePath })
-        // Send when there is either typed text or at least one attachment.
-        // (A pure-attachment send still has a non-empty composed `text`.)
-        if (text.isEmpty()) return
-        DiagnosticEvents.record(
-            "action",
-            "composer_send",
-            "textBytes" to text.toByteArray(Charsets.UTF_8).size,
-            "attachmentCount" to attachments.size,
-            "withEnter" to withEnter,
-        )
-        // Issue #971: HAND THE PROMPT OFF to the outbound queue — clear the
-        // editable draft + staged tiles the instant we go in-flight so the
-        // prompt is represented EXACTLY ONCE (the "Sending…" queue row), never
-        // as BOTH the editor text AND a duplicate "1 unsent prompt" row. This
-        // reverses the #745 keep-the-draft-visible behaviour (hard-cut per D22):
-        // the queue row is now the single in-flight source of truth, and the
-        // Send button reads `sendInFlight` to disable itself + show "Sending…".
-        // The clean draft + tiles still travel in the [SendRequest] / queue row,
-        // so a failed send ([restoreFailedSend]) puts the EXACT prompt back into
-        // the (now-single) composer, and a delivered send leaves it empty.
-        clearComposerForHandoff()
-        _uiState.update { it.copy(sendInFlight = true, error = null) }
-        // Issue #891: arm the overall-send watchdog the instant we go in-flight
-        // so a host `onSend` that never resolves (wedged channel / dropped
-        // emission with no live collector) can never leave the composer stuck on
-        // "Sending…" forever.
-        watchdogs.armSend()
-        val handoffRequest = SendRequest(
-            text = text,
-            withEnter = withEnter,
-            cleanDraft = draft,
-            attachments = attachments,
-            sendTarget = sendTarget,
-        )
-        inFlightSendRequest = handoffRequest
-        if (sendTarget.sessionKey.isNotBlank() && hasLocalAttachmentsForSidecars(attachments)) {
-            viewModelScope.launch(outboundQueueDispatcher) {
-                try {
-                    enqueueAndDispatchSidecarBackedSend(
-                        cleanDraft = draft,
-                        attachments = attachments,
-                        withEnter = withEnter,
-                        sendTarget = sendTarget,
-                    )
-                } catch (cancelled: CancellationException) {
-                    // Issue #929: a real cancellation (e.g. VM cleared) — clear
-                    // the in-flight gates so a recreated composer is not wedged,
-                    // then rethrow to honour structured concurrency.
-                    clearStrandedSendInFlight()
-                    throw cancelled
-                } catch (t: Throwable) {
-                    // Issue #929: any unexpected failure in the sidecar dispatch
-                    // is still a non-delivering exit — clear the strand so the
-                    // pipeline self-heals instead of waiting on the watchdog.
-                    clearStrandedSendInFlight(
-                        error = "Send failed: reconnect, then send again or discard the draft.",
-                    )
-                }
-            }
-            return
-        }
-        if (outboundQueueStore !== DisabledOutboundQueueStore &&
-            sendTarget.sessionKey.isNotBlank()
-        ) {
-            viewModelScope.launch(outboundQueueDispatcher) {
-                try {
-                    val outboundItem = enqueueOutboundSend(
-                        cleanDraft = draft,
-                        attachments = attachments,
-                        withEnter = withEnter,
-                        sendTarget = sendTarget,
-                    )
-                    withContext(Dispatchers.Main.immediate) {
-                        emitPreparedSendRequest(
-                            text = text,
-                            withEnter = withEnter,
-                            cleanDraft = draft,
-                            attachments = attachments,
-                            sendTarget = sendTarget,
-                            outboundQueueItemId = outboundItem?.id,
-                        )
-                    }
-                } catch (cancelled: CancellationException) {
-                    clearStrandedSendInFlight()
-                    throw cancelled
-                } catch (t: Throwable) {
-                    clearStrandedSendInFlight(
-                        error = "Send failed: reconnect, then send again or discard the draft.",
-                    )
-                }
-            }
-            return
-        }
-        emitPreparedSendRequest(
-            text = text,
-            withEnter = withEnter,
-            cleanDraft = draft,
-            attachments = attachments,
-            sendTarget = sendTarget,
-            outboundQueueItemId = null,
-        )
-    }
-
-    private fun emitPreparedSendRequest(
-        text: String,
-        withEnter: Boolean,
-        cleanDraft: String,
-        attachments: List<StagedAttachment>,
-        sendTarget: SendTargetSnapshot,
-        outboundQueueItemId: String?,
-    ) {
-        // Issue #254: a `Channel.trySend` buffers the item until a collector
-        // consumes it, so a send dispatched while the sheet's collector is
-        // mid-recreate (dismiss → re-open) is delivered to the next collector.
-        val request = SendRequest(
-            text = text,
-            withEnter = withEnter,
-            cleanDraft = cleanDraft,
-            attachments = attachments,
-            sendTarget = sendTarget,
-            outboundQueueItemId = outboundQueueItemId,
-        )
-        // Issue #971: remember the in-flight prompt so wedged/cancelled send
-        // recovery restores the exact draft + tiles to the now-cleared composer.
-        inFlightSendRequest = request
-        if (_sendRequests.trySend(request).isFailure) {
-            // Issue #971/#987: a buffer-full enqueue is a transient dispatch
-            // failure, not a permanent rejection — defer to the queue so the row
-            // stays queued and auto-retries on the next flush (Option A). Falls
-            // back to a composer-restore only when there is no durable row.
-            markOutboundSendDeferred(request)
-        }
-    }
-
-    /**
-     * Issue #971: hand the prompt off to the outbound queue — empty the editable
-     * composer (draft text + staged attachment tiles + the persisted draft slots)
-     * so an in-flight send is represented EXACTLY ONCE by its "Sending…" queue
-     * row, never as BOTH the editor AND a duplicate "1 unsent prompt" row.
-     *
-     * This clears the in-memory draft/tiles, the [SavedStateHandle] draft slots
-     * (so a process-death recreate mid-send does not resurrect the handed-off
-     * text into the editor alongside the queue row), and the durable per-session
-     * draft store (so a session switch away-and-back mid-send does not reload the
-     * handed-off draft into the editor next to its queue row). The prompt is NOT
-     * lost: it travels in the [SendRequest] + the durable queue row, so a failed
-     * send ([restoreFailedSend]) restores the exact draft + tiles back into the
-     * (now-single) composer, and a delivered send leaves the composer empty.
-     */
-    private fun clearComposerForHandoff() {
-        savedStateHandle[KEY_DRAFT] = ""
-        savedStateHandle[KEY_DRAFT_OWNER] = null
-        composerTarget?.let { target ->
-            clearComposerDraft(target)
-            composerDraftStore.clearAttachments(target)
-        }
-        _uiState.update { current ->
-            current.copy(
-                draft = "",
-                attachments = emptyList(),
-                attachmentUpload = AttachmentUploadState.Idle,
-            )
-        }
-    }
-
-    private fun hasLocalAttachmentsForSidecars(attachments: List<StagedAttachment>): Boolean =
-        outboundQueueStore !== DisabledOutboundQueueStore &&
-            outboundAttachmentSidecarStore != null &&
-            outboundAttachmentUploader != null &&
-            attachments.any { it.previewUri != null }
-
-    private suspend fun enqueueAndDispatchSidecarBackedSend(
-        cleanDraft: String,
-        attachments: List<StagedAttachment>,
-        withEnter: Boolean,
-        sendTarget: SendTargetSnapshot,
-    ) {
-        // Issue #929: this whole dispatch runs while `sendInFlight = true` (set by
-        // [emitSendRequest] before launching us). EVERY exit that does not deliver
-        // must clear the in-flight gates, or the pipeline wedges for the watchdog
-        // window. The early config-missing returns below are non-delivering exits.
-        val sessionKey = sendTarget.sessionKey.takeIf { it.isNotBlank() }
-        val sidecarStore = outboundAttachmentSidecarStore ?: run {
-            clearStrandedSendInFlight()
-            return
-        }
-        if (sessionKey == null) {
-            clearStrandedSendInFlight()
-            return
-        }
-        val localAttachments = attachments.mapIndexedNotNull { index, attachment ->
-            attachment.previewUri?.let { index to it }
-        }
-        val itemId = UUID.randomUUID().toString()
-        val sidecars = sidecarStore.stage(
-            outboundItemId = itemId,
-            uris = localAttachments.map { it.second },
-            attachmentIndices = localAttachments.map { it.first },
-        )
-        if (sidecars.size != localAttachments.size) {
-            clearStrandedSendInFlight(
-                error = "Attachment upload failed: could not preserve selected file bytes. Your draft was kept.",
-            )
-            return
-        }
-        val item = OutboundItem(
-            id = itemId,
-            sessionKey = sessionKey,
-            cleanText = cleanDraft,
-            attachments = attachments.toSidecarAwareDurableRefs(sidecars),
-            withEnter = withEnter,
-            state = OutboundState.Queued,
-            createdAtMs = clock(),
-            paneId = sendTarget.paneId,
-            route = sendTarget.route,
-            agentKind = sendTarget.agentKind,
-            // Issue #961: coalesce a re-Send of the SAME logical prompt onto the
-            // existing un-delivered row instead of minting a duplicate.
-            sendKey = computeSendKey(cleanDraft, attachments, withEnter, sendTarget),
-        )
-        val queuedItem = outboundQueueStore.enqueueExisting(item)
-        // Issue #961: if this coalesced onto an existing un-delivered row, the
-        // freshly-staged sidecars under our throwaway `itemId` are orphaned —
-        // the existing row keeps its own staged bytes. Drop them and dispatch
-        // the row the queue actually kept, not our discarded id.
-        if (queuedItem.id != itemId) {
-            outboundAttachmentSidecarStore?.removeOutboundItem(itemId)
-        }
-        inFlightSendRequest = SendRequest(
-            text = appendAttachmentPaths(cleanDraft, attachments.map { it.remotePath }),
-            withEnter = withEnter,
-            cleanDraft = cleanDraft,
-            attachments = attachments,
-            sendTarget = sendTarget,
-            outboundQueueItemId = queuedItem.id,
-        )
-        refreshOutboundQueueItemsFor(sessionKey)
-        dispatchPreparedOutboundItem(queuedItem.id)
-    }
-
-    private fun enqueueOutboundSend(
-        cleanDraft: String,
-        attachments: List<StagedAttachment>,
-        withEnter: Boolean,
-        sendTarget: SendTargetSnapshot,
-    ): OutboundItem? {
-        if (outboundQueueStore === DisabledOutboundQueueStore) return null
-        val sessionKey = sendTarget.sessionKey.takeIf { it.isNotBlank() } ?: return null
-        val item = outboundQueueStore.enqueue(
-            sessionKey = sessionKey,
-            cleanText = cleanDraft,
-            attachments = attachments.toDurableRefs(),
-            withEnter = withEnter,
-            paneId = sendTarget.paneId,
-            route = sendTarget.route,
-            agentKind = sendTarget.agentKind,
-            // Issue #961: coalesce a re-Send of the SAME logical prompt onto the
-            // existing un-delivered row instead of minting a duplicate.
-            sendKey = computeSendKey(cleanDraft, attachments, withEnter, sendTarget),
-        )
-        val activeItem = outboundQueueStore.markInFlight(item.id) ?: item
-        refreshOutboundQueueItemsFor(sessionKey)
-        return activeItem
-    }
-
-    /**
      * Issue #745: the host confirmed the send was delivered. Now — and only
      * now — clear the draft, drop the staged attachment tiles, and leave the
      * in-flight state. The sheet's `sendRequests` collector calls this on the
@@ -1412,7 +1124,7 @@ public class PromptComposerViewModel @Inject constructor(
      * immediately instead of after the watchdog window. Idempotent; safe to call
      * even when no send was in flight.
      */
-    private fun clearStrandedSendInFlight(error: String? = null) {
+    internal fun clearStrandedSendInFlight(error: String? = null) {
         watchdogs.disarmSend()
         outboundSidecarDispatchInFlight = false
         // Issue #971/#987: the composer was cleared at handoff, so a non-delivering
@@ -1774,7 +1486,7 @@ public class PromptComposerViewModel @Inject constructor(
         return true
     }
 
-    private suspend fun dispatchPreparedOutboundItem(id: String): Boolean {
+    internal suspend fun dispatchPreparedOutboundItem(id: String): Boolean {
         if (!uploadSidecarsForOutboundItem(id)) return false
         return claimAndEmitOutboundItem(id)
     }
@@ -1963,6 +1675,19 @@ public class PromptComposerViewModel @Inject constructor(
     @androidx.annotation.VisibleForTesting
     internal var sidecarRemovalForTest: (suspend (String) -> Unit)? = null
 
+    /**
+     * Issue #1540 (L9) synthetic process-death seam (#780 model). When non-null,
+     * [clearComposerForHandoff] invokes it the INSTANT the durable draft has been
+     * cleared — the exact moment a crash would leave the durable draft empty. The
+     * WRITE-AHEAD fix commits the durable queue row BEFORE this fires (in every
+     * durable path), so a test can snapshot the durable stores here and prove the
+     * prompt survived in the queue row (green); on the pre-fix base the clear ran
+     * BEFORE the commit, so the snapshot showed the prompt gone from BOTH the
+     * durable draft AND the durable queue (LOST → red). Production never sets it.
+     */
+    @androidx.annotation.VisibleForTesting
+    internal var onDurableDraftClearedForHandoffTest: (() -> Unit)? = null
+
     private fun refreshOutboundQueueItems() {
         _outboundQueueItems.value = composerTarget
             ?.takeIf { it.isNotBlank() }
@@ -1970,7 +1695,7 @@ public class PromptComposerViewModel @Inject constructor(
             .orEmpty()
     }
 
-    private fun refreshOutboundQueueItemsFor(sessionKey: String) {
+    internal fun refreshOutboundQueueItemsFor(sessionKey: String) {
         if (composerTarget == sessionKey) refreshOutboundQueueItems()
     }
 

--- a/app/src/test/java/com/pocketshell/app/composer/PromptComposerOutboundSendQueueViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/PromptComposerOutboundSendQueueViewModelTest.kt
@@ -500,13 +500,22 @@ class PromptComposerOutboundSendQueueViewModelTest {
         vm.onDraftChange("ship it later")
         vm.requestSend(withEnter = true, sendTarget = target)
 
+        // Off the caller thread: the enqueue is still deferred to the queue
+        // dispatcher (nothing sent, no row yet before advancing).
         assertTrue(vm.uiState.value.sendInFlight)
-        assertEquals("", vm.uiState.value.draft)
         assertTrue(sent.isEmpty())
         assertTrue(queue.itemsFor("1/session-a").isEmpty())
+        // Issue #1540 (L9 — write-ahead): the editable draft is NO LONGER cleared
+        // up front. The clear now runs ONLY after the durable queue row commits,
+        // so before the dispatcher advances the draft is still present — the LOST
+        // window (draft cleared but row not yet committed) no longer exists.
+        assertEquals("ship it later", vm.uiState.value.draft)
 
         advanceUntilIdle()
 
+        // After the durable row committed the composer is cleared (single
+        // representation) and the row carries the prompt.
+        assertEquals("", vm.uiState.value.draft)
         val request = sent.single()
         val queueId = requireNotNull(request.outboundQueueItemId)
         assertEquals("ship it later", request.cleanDraft)
@@ -723,6 +732,220 @@ class PromptComposerOutboundSendQueueViewModelTest {
         vm.markSendDelivered(sent.last())
         assertTrue(vm.outboundQueueItems.value.isEmpty())
         assertEquals("", vm.uiState.value.draft)
+    }
+
+    // -- Issue #1540 (L9): the widest silent-LOST hole -----------------------
+    //
+    // The Fable message-queue audit's highest-severity LOST finding: a prompt
+    // could be lost with ZERO trace if the process died in the window between
+    // "durable draft cleared" and "durable outbound-queue row committed".
+    // `emitSendRequest` used to clear the composer + durable draft SYNCHRONOUSLY
+    // up front (old :917), then commit the durable queue row on a later IO hop —
+    // the attachment path staged bytes first, WIDENING the window. A crash in
+    // that window left the prompt in NEITHER the durable draft NOR the durable
+    // queue: gone, unrecoverable, no user-visible trace.
+    //
+    // The fix WRITE-AHEADS the durable row: the clear now runs ONLY after the
+    // row commit succeeds. These tests inject the death SYNTHETICALLY (#780
+    // model — no `assumeTrue`/CI-skip) via [onDurableDraftClearedForHandoffTest],
+    // which fires the INSTANT the durable draft is cleared — the exact crash
+    // point. They snapshot the DURABLE stores at that instant (what a real crash
+    // would leave on SharedPrefs) and assert the prompt survived in the queue
+    // row. RED-on-base repro for a reviewer: move `clearComposerForHandoff()`
+    // back to before the enqueue in `emitSendRequest` /
+    // `enqueueAndDispatchSidecarBackedSend` (keep the seam) — the death snapshot's
+    // queue is then EMPTY (LOST) and every green assertion below fails.
+
+    @Test
+    fun issue1540_L9_textSend_writeAheadCommitsDurableRowBeforeDraftClearSoDeathDoesNotLosePrompt() = runTest {
+        val draftStore = InMemoryComposerDraftStore()
+        val queue = InMemoryOutboundQueueStore()
+        val vm = newVm(
+            samplerDispatcher = StandardTestDispatcher(testScheduler),
+            outboundQueueStore = queue,
+            composerDraftStore = draftStore,
+        )
+        val sent = collectSendRequests(vm)
+        val target = PromptComposerViewModel.SendTargetSnapshot(
+            sessionKey = "1/session-a",
+            paneId = "%7",
+            route = OutboundRoute.AgentPayload,
+            agentKind = "codex",
+        )
+
+        // Synthetic process death: snapshot the DURABLE stores the instant the
+        // draft is cleared — precisely what a crash right there would preserve.
+        var deathQueue: List<OutboundItem>? = null
+        var deathDraft: String? = "not-captured"
+        vm.onDurableDraftClearedForHandoffTest = {
+            if (deathQueue == null) {
+                deathQueue = queue.itemsFor("1/session-a")
+                deathDraft = draftStore.load("1/session-a")
+            }
+        }
+
+        vm.onComposerTargetChanged("1/session-a")
+        vm.onDraftChange("ship the write-ahead")
+        // Pre-condition: the draft really is persisted durably before send, so a
+        // crash BEFORE the write-ahead commit would still recover it as a draft.
+        assertEquals("ship the write-ahead", draftStore.load("1/session-a"))
+
+        vm.requestSend(withEnter = true, sendTarget = target)
+        advanceUntilIdle()
+
+        val snap = requireNotNull(deathQueue) {
+            "the draft-clear seam never fired — the send handoff path did not run"
+        }
+        // GREEN (write-ahead): at the crash instant the durable queue ALREADY
+        // holds the row carrying the prompt. On the pre-fix base (clear-before-
+        // commit) this list is EMPTY → prompt LOST → this assertion is RED.
+        assertEquals(
+            "the prompt must be durable in the queue row at the crash instant",
+            listOf("ship the write-ahead"),
+            snap.map { it.cleanText },
+        )
+        // Single representation: the durable draft was cleared, so the prompt is
+        // in the queue row ONLY — never in BOTH the draft AND the queue.
+        assertTrue("durable draft must be cleared at handoff", deathDraft.isNullOrEmpty())
+
+        // -- Recovery + EXACTLY-ONCE: a fresh VM (process restart) reads the SAME
+        // durable store (SharedPrefs survives death) and delivers the recovered
+        // row exactly once. Wire-level occurrence==1 across the crash is the
+        // #1526 S1 verify-before-resend ledger's job; L9 guarantees the SINGLE
+        // durable representation (one row, no residual draft) that makes recovery
+        // deliver the prompt exactly once rather than duplicating it. --
+        val rowId = snap.single().id
+        val vm2 = newVm(
+            samplerDispatcher = StandardTestDispatcher(testScheduler),
+            outboundQueueStore = queue,
+            composerDraftStore = draftStore,
+            savedStateHandle = SavedStateHandle(),
+            // A far-future clock so the stale-InFlight recovery cutoff is > the
+            // row's real-time createdAtMs (deterministic re-arm; no time race).
+            clock = { Long.MAX_VALUE / 2 },
+        )
+        val sent2 = collectSendRequests(vm2)
+        vm2.onComposerTargetChanged("1/session-a")
+        // The row survived as InFlight (mid-delivery when the process died); the
+        // production recovery flush re-arms the stale row to Queued.
+        assertEquals(listOf(rowId), vm2.requeueStaleOutboundInFlight(staleAfterMs = 0L).map { it.id })
+        val flushed = vm2.retryNextOutboundItem()
+        advanceUntilIdle()
+        assertEquals("recovery flush claims the recovered row", rowId, flushed)
+        assertEquals("recovery delivers exactly one send", 1, sent2.size)
+        assertEquals("ship the write-ahead", sent2.single().cleanDraft)
+
+        vm2.markSendDelivered(sent2.single())
+        // Exactly-once: the delivered row is pruned and can NOT be re-claimed, and
+        // there is no second (draft) representation to send again.
+        assertNull("no second deliverable representation after delivery", vm2.retryNextOutboundItem())
+        assertEquals("still exactly one send", 1, sent2.size)
+        assertTrue(queue.itemsFor("1/session-a").isEmpty())
+        assertTrue("no residual durable draft", draftStore.load("1/session-a").isNullOrEmpty())
+    }
+
+    @Test
+    fun issue1540_L9_singleAttachmentSend_writeAheadCommitsDurableRowWithAttachmentBeforeDraftClear() = runTest {
+        val draftStore = InMemoryComposerDraftStore()
+        val queue = InMemoryOutboundQueueStore()
+        val sidecars = newSidecarStore(ioDispatcher = StandardTestDispatcher(testScheduler))
+        val vm = newVm(
+            samplerDispatcher = StandardTestDispatcher(testScheduler),
+            outboundQueueStore = queue,
+            outboundAttachmentSidecarStore = sidecars,
+            composerDraftStore = draftStore,
+        )
+        vm.setOutboundAttachmentSidecarUploader { refs ->
+            Result.success(refs.map { "~/.pocketshell/attachments/reuploaded/${it.displayName}" })
+        }
+        val sent = collectSendRequests(vm)
+        val target = PromptComposerViewModel.SendTargetSnapshot(sessionKey = "1/session-a")
+        val local = localAttachmentFile("l9-single.txt", "attachment bytes")
+
+        // Capture ONLY the durable queue snapshot in the (non-suspend) seam; the
+        // sidecar byte store's read is suspend, so byte-ownership (L11) is out of
+        // scope here — the durable ROW carrying the attachment ref is the L9 proof.
+        var deathQueue: List<OutboundItem>? = null
+        vm.onDurableDraftClearedForHandoffTest = {
+            if (deathQueue == null) deathQueue = queue.itemsFor("1/session-a")
+        }
+
+        vm.onComposerTargetChanged("1/session-a")
+        vm.onDraftChange("review this")
+        vm.attachFiles(
+            count = 1,
+            previews = listOf(PromptComposerViewModel.AttachmentPreview(Uri.fromFile(local), "text/plain")),
+        ) {
+            Result.success(listOf("~/.pocketshell/attachments/old/l9-single.txt"))
+        }
+        settleUntil { vm.uiState.value.attachments.isNotEmpty() }
+
+        vm.requestSend(withEnter = true, sendTarget = target)
+        settleUntil { deathQueue != null }
+
+        val snap = requireNotNull(deathQueue)
+        // GREEN: the death happened AFTER the attachment bytes were staged AND the
+        // durable row committed — this is the WIDEST window (stage-then-commit).
+        // The row carries the text + the attachment ref, so the attachment send is
+        // recoverable. On base (clear up front) the queue is EMPTY at this instant
+        // → the attachment send is LOST with zero trace → red.
+        assertEquals(listOf("review this"), snap.map { it.cleanText })
+        assertEquals("row carries the single attachment ref", 1, snap.single().attachments.size)
+    }
+
+    @Test
+    fun issue1540_L9_multiAttachmentSend_writeAheadCommitsDurableRowWithAllAttachmentsBeforeDraftClear() = runTest {
+        val draftStore = InMemoryComposerDraftStore()
+        val queue = InMemoryOutboundQueueStore()
+        val sidecars = newSidecarStore(ioDispatcher = StandardTestDispatcher(testScheduler))
+        val vm = newVm(
+            samplerDispatcher = StandardTestDispatcher(testScheduler),
+            outboundQueueStore = queue,
+            outboundAttachmentSidecarStore = sidecars,
+            composerDraftStore = draftStore,
+        )
+        vm.setOutboundAttachmentSidecarUploader { refs ->
+            Result.success(refs.map { "~/.pocketshell/attachments/reuploaded/${it.displayName}" })
+        }
+        val sent = collectSendRequests(vm)
+        val target = PromptComposerViewModel.SendTargetSnapshot(sessionKey = "1/session-a")
+        val localA = localAttachmentFile("l9-multi-a.txt", "bytes a")
+        val localB = localAttachmentFile("l9-multi-b.txt", "bytes b")
+
+        var deathQueue: List<OutboundItem>? = null
+        vm.onDurableDraftClearedForHandoffTest = {
+            if (deathQueue == null) deathQueue = queue.itemsFor("1/session-a")
+        }
+
+        vm.onComposerTargetChanged("1/session-a")
+        vm.onDraftChange("review both")
+        vm.attachFiles(
+            count = 2,
+            previews = listOf(
+                PromptComposerViewModel.AttachmentPreview(Uri.fromFile(localA), "text/plain"),
+                PromptComposerViewModel.AttachmentPreview(Uri.fromFile(localB), "text/plain"),
+            ),
+        ) {
+            Result.success(
+                listOf(
+                    "~/.pocketshell/attachments/old/l9-multi-a.txt",
+                    "~/.pocketshell/attachments/old/l9-multi-b.txt",
+                ),
+            )
+        }
+        settleUntil { vm.uiState.value.attachments.size == 2 }
+
+        vm.requestSend(withEnter = true, sendTarget = target)
+        settleUntil { deathQueue != null }
+
+        val snap = requireNotNull(deathQueue)
+        // GREEN: the multi-attachment/sidecar send commits ONE durable row with
+        // BOTH attachment refs before the draft clear. Base: queue EMPTY at the
+        // crash instant → the multi-attachment send is LOST → red.
+        assertEquals(listOf("review both"), snap.map { it.cleanText })
+        assertEquals("row carries BOTH attachment refs", 2, snap.single().attachments.size)
+        // Single representation: exactly ONE durable row for the one prompt.
+        assertEquals(1, snap.size)
     }
 
     @Test


### PR DESCRIPTION
Fixes finding **L9** (#1526): a prompt is LOST with zero trace if the process dies between the composer draft-clear and the durable queue-row commit (widest on the attachment/sidecar path). `emitSendRequest` cleared the draft synchronously *before* the durable `OutboundQueueStore` row was committed on a later IO hop.

**Fix:** write-ahead the durable row — `clearComposerForHandoff()` now runs AFTER the row commit on each durable path (queue post-`enqueueOutboundSend`; sidecar post-`enqueueExisting` on `Main.immediate`; no-store fallback unchanged).

**Also (D28 win):** the outbound-send dispatch cluster is extracted to a new sibling `PromptComposerOutboundSend.kt` (internal extension fns, mirrors `PromptComposerOutboundMapping.kt`), shrinking the god-object `PromptComposerViewModel.kt` to **164721 bytes — 12803 under baseline** (a real reduction, replacing the first round's ratchet failure).

**Verification (approved twice — logic #1540 comment 4962248213, extraction re-review 4962853382):**
- Reviewer-run red→green on the real extracted path: base clear-before-commit → durable queue EMPTY at crash (`was:<[]>`, LOST); fix → recovers, exactly-once (occurrence==1). Class coverage: text + single + multi-attachment.
- Extraction confirmed a pure move (moved bodies diffed identical bar the reordering); 15 members `private`→`internal` (module-scoped, no public leak).
- Full `:app:testDebugUnitTest`: 3724 tests, 0 failures. Hygiene: file-size + VM-ratchet + test-validity exit 0.

Closes #1540
