### PR TITLE
connection: drive grace teardown timer on the boot clock — fix Doze stretch (#1544)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/App.kt
+++ b/app/src/main/java/com/pocketshell/app/App.kt
@@ -1041,6 +1041,22 @@ internal const val GRACE_LIFECYCLE_TAG: String = "PsAppBgGrace"
 internal const val BACKGROUND_GRACE_MILLIS: Long = AppSettings.DEFAULT_BACKGROUND_GRACE_MILLIS
 
 /**
+ * Issue #1544 — the boot-clock re-check cadence for the bounded grace teardown
+ * timer. Instead of one uptime-clock `delay(graceMillis)` (which Doze suspends,
+ * stretching the effective grace to minutes — maintainer log seq 64937 fired
+ * 582 s late against a 90 s window), the teardown timer sleeps in bounded chunks
+ * and re-derives the remaining time from the SAME boot clock the grace decision
+ * uses (#1080). On the first wake AFTER the boot deadline the timer over-serves
+ * by at most one chunk of uptime rather than a full remaining `graceMillis` of
+ * accumulated awake time. Small enough to keep "90 s grace" honest across a Doze
+ * gap; large enough that it schedules no busy wakeups (still no wakelock /
+ * AlarmManager / WorkManager — the D21 relaxation for #450 is preserved). The
+ * `coerceAtMost` in the loop makes the final chunk land exactly on the deadline,
+ * so the sub-`graceMillis` unit tests keep their exact-boundary semantics.
+ */
+internal const val GRACE_TEARDOWN_POLL_CHUNK_MS: Long = 15_000L
+
+/**
  * Test-only override for connected lifecycle proofs that need a short grace
  * window without adding unsupported values to user-facing Settings.
  */
@@ -1072,8 +1088,12 @@ internal object BackgroundGraceTestOverride {
  * reattach.
  *
  * The controller deliberately holds NO repeating timer, no
- * `WorkManager`/`AlarmManager`, and no wakelock — it is a one-shot,
- * self-cancelling [delay] coroutine. Once the teardown has fired (or
+ * `WorkManager`/`AlarmManager`, and no wakelock — it is a single,
+ * self-cancelling [delay] coroutine that sleeps in bounded chunks and
+ * re-checks the boot-clock deadline each chunk (issue #1544, so a
+ * Doze-suspended uptime clock cannot stretch the effective grace). It
+ * never wakes the CPU on its own: a chunk resumes only when the process is
+ * already awake, so no wakelock is held. Once the teardown has fired (or
  * before any background event) it owns no scheduled work at all, so it
  * cannot keep the process awake. This is the bounded relaxation of D21
  * sanctioned for issue #450.
@@ -1171,7 +1191,24 @@ internal class BackgroundGraceController(
             "backgroundCycleId" to backgroundCycleId,
         )
         graceJob = scope.launch {
-            delay(backgroundGraceMillisForCycle)
+            // Issue #1544 — sleep in bounded chunks and re-derive the remaining
+            // time from the boot clock ([nowMillis], `SystemClock.elapsedRealtime`)
+            // that the grace decision (#1080) already uses, rather than a single
+            // uptime-clock `delay(backgroundGraceMillisForCycle)`. A single uptime
+            // delay is frozen by Doze, so the effective grace stretched to minutes
+            // (seq 64937: `elapsedMs=582480` against `graceMs=90000`). Chunking
+            // means the FIRST wake past the boot deadline fires the teardown —
+            // over-serving by at most one [GRACE_TEARDOWN_POLL_CHUNK_MS] of uptime,
+            // not a full remaining `graceMillis` of accumulated awake time. The
+            // `coerceAtMost` lands the final chunk exactly on the boot deadline so
+            // an on-time (no-Doze) window still fires at ~graceMillis. If cancelled
+            // by an in-grace [onForeground], `delay` throws and the dispatch below
+            // is skipped — identical to the old single-delay cancellation contract.
+            while (true) {
+                val remainingMs = backgroundDeadlineAtMs - nowMillis()
+                if (remainingMs <= 0L) break
+                delay(remainingMs.coerceAtMost(GRACE_TEARDOWN_POLL_CHUNK_MS))
+            }
             dispatchGraceElapsedIfNeeded(source = "timer", trigger = "grace_timeout")
         }
     }

--- a/app/src/test/java/com/pocketshell/app/BackgroundGraceControllerTest.kt
+++ b/app/src/test/java/com/pocketshell/app/BackgroundGraceControllerTest.kt
@@ -111,6 +111,9 @@ class BackgroundGraceControllerTest {
                 graceMillis = graceMillis,
                 onGraceElapsed = {},
                 onForeground = {},
+                // Issue #1544: the teardown timer now counts on the boot clock
+                // (`nowMillis`), so align it with the virtual delay clock.
+                nowMillis = { currentTime },
             )
 
             controller.onBackground()
@@ -201,6 +204,9 @@ class BackgroundGraceControllerTest {
             onForeground = { resumedWithinGrace ->
                 events += "foreground:$resumedWithinGrace"
             },
+            // Issue #1544: the teardown timer now counts on the boot clock
+            // (`nowMillis`), so align it with the virtual delay clock.
+            nowMillis = { currentTime },
         )
 
         controller.onBackground()
@@ -601,6 +607,9 @@ class BackgroundGraceControllerTest {
                     pendingNetworkChange = null
                 }
             },
+            // Issue #1544: the teardown timer now counts on the boot clock
+            // (`nowMillis`), so align it with the virtual delay clock.
+            nowMillis = { currentTime },
         )
 
         controller.onBackground()
@@ -1241,6 +1250,9 @@ class BackgroundGraceControllerTest {
                 // Issue #548: always run foreground probe.
                 activeTmuxClients.lifecycleHooksSnapshot().forEach { it.onForeground(resumedWithinGrace) }
             },
+            // Issue #1544: the teardown timer now counts on the boot clock
+            // (`nowMillis`), so align it with the virtual delay clock.
+            nowMillis = { currentTime },
         )
 
         controller.onBackground()
@@ -1273,6 +1285,9 @@ class BackgroundGraceControllerTest {
             onForeground = { resumedWithinGrace ->
                 events += "tmux:foreground:resumedWithinGrace=$resumedWithinGrace"
             },
+            // Issue #1544: the teardown timer now counts on the boot clock
+            // (`nowMillis`), so align it with the virtual delay clock.
+            nowMillis = { currentTime },
         )
 
         controller.onBackground()
@@ -1332,6 +1347,9 @@ class BackgroundGraceControllerTest {
                 // Issue #548: always run foreground probe.
                 activeTmuxClients.lifecycleHooksSnapshot().forEach { it.onForeground(resumedWithinGrace) }
             },
+            // Issue #1544: the teardown timer now counts on the boot clock
+            // (`nowMillis`), so align it with the virtual delay clock.
+            nowMillis = { currentTime },
         )
 
         controller.onBackground()
@@ -1459,6 +1477,130 @@ class BackgroundGraceControllerTest {
         assertEquals(
             "the ordinary bounded timer still fires the teardown at its deadline",
             listOf("teardown"),
+            events,
+        )
+    }
+
+    // ---------------------------------------------------------------------
+    // Issue #1544 — the bounded grace teardown timer must count on the BOOT
+    // clock (SystemClock.elapsedRealtime, which counts deep sleep), the same
+    // clock the within/beyond-grace decision uses (#1080), NOT the uptime clock
+    // that backs a plain `delay()`. Under Doze the uptime clock is suspended, so
+    // the old single `delay(graceMillis)` stretched the effective 90 s grace to
+    // minutes — the maintainer's log seq 64937 fired the teardown at
+    // elapsedMs=582480 against graceMs=90000.
+    //
+    // The tests below model the two clock domains as separate seams: `delay()`
+    // advances on the runTest virtual clock (= the uptime clock), while
+    // `nowMillis` reads a test-controlled `bootNow` (= the boot clock). Doze is
+    // injected synthetically (the #780 model, no `assumeTrue`/CI-skip): between
+    // teardown-poll wakes the boot clock jumps forward while the uptime clock
+    // (virtual time) advances only a chunk. Each `advanceTimeBy(chunk + 1)` is
+    // one wake that completes exactly one poll chunk (the +1 clears the
+    // exclusive-boundary semantics of `advanceTimeBy`).
+    // ---------------------------------------------------------------------
+
+    @Test
+    fun `grace teardown under doze fires on the boot clock not stretched to the uptime clock`() = runTest {
+        val graceMs = 90_000L
+        val uptimeChunk = 15_000L
+        // Deep sleep between wakes: the boot clock runs at ~2x the uptime clock
+        // (the awake uptime is a fraction of real/boot time — the Doze signature).
+        val bootPerWake = 30_000L
+        var bootNow = 0L
+        val teardownAtBootElapsed = mutableListOf<Long>()
+        val controller = BackgroundGraceController(
+            scope = backgroundScope,
+            graceMillis = graceMs,
+            onGraceElapsed = { teardownAtBootElapsed += bootNow },
+            onForeground = {},
+            nowMillis = { bootNow },
+        )
+
+        controller.onBackground()
+        runCurrent()
+
+        var wakes = 0
+        while (teardownAtBootElapsed.isEmpty() && wakes < 40) {
+            // The boot clock advanced during deep sleep, then the process wakes
+            // for one poll chunk of uptime.
+            bootNow += bootPerWake
+            advanceTimeBy(uptimeChunk + 1)
+            runCurrent()
+            wakes++
+        }
+
+        assertTrue("the grace teardown must eventually fire under Doze", teardownAtBootElapsed.isNotEmpty())
+        val firedAtBootElapsed = teardownAtBootElapsed.single()
+        assertTrue(
+            "the bounded grace teardown must fire on the BOOT clock within tolerance of graceMs " +
+                "(fired at boot elapsedMs=$firedAtBootElapsed vs graceMs=$graceMs). The old uptime-clock " +
+                "delay(graceMillis) stretches this far past graceMs under Doze — seq 64937 fired at " +
+                "elapsedMs=582480 against graceMs=90000.",
+            firedAtBootElapsed <= graceMs + bootPerWake,
+        )
+    }
+
+    @Test
+    fun `no doze - the ninety second grace still fires at the configured deadline`() = runTest {
+        // Regression guard: when the clocks agree (no Doze) the chunked boot-clock
+        // teardown timer must still fire at ~graceMs, not early and not stretched.
+        val graceMs = 90_000L
+        val events = mutableListOf<Pair<String, Long>>()
+        val controller = BackgroundGraceController(
+            scope = backgroundScope,
+            graceMillis = graceMs,
+            onGraceElapsed = { events += "teardown" to currentTime },
+            onForeground = {},
+            nowMillis = { currentTime },
+        )
+
+        controller.onBackground()
+        runCurrent()
+        advanceTimeBy(graceMs - 1L) // just before the deadline — must not fire yet
+        runCurrent()
+        assertEquals("teardown must not fire before the deadline", emptyList<Pair<String, Long>>(), events)
+
+        advanceTimeBy(1L) // reach the deadline
+        runCurrent()
+        assertEquals(
+            "with agreeing clocks the teardown fires at the configured 90 s deadline",
+            listOf("teardown" to graceMs),
+            events,
+        )
+    }
+
+    @Test
+    fun `within grace foreground return under doze still reattaches without teardown`() = runTest {
+        // Class coverage (G2): the within-grace foreground return. Even when the
+        // uptime clock is frozen by Doze, the boot clock is the source of truth —
+        // returning to the foreground while the BOOT clock is still inside the 90 s
+        // window must reattach (resumedWithinGrace = true) and never tear down.
+        val graceMs = 90_000L
+        var bootNow = 0L
+        val events = mutableListOf<String>()
+        val controller = BackgroundGraceController(
+            scope = backgroundScope,
+            graceMillis = graceMs,
+            onGraceElapsed = { events += "teardown" },
+            onForeground = { resumedWithinGrace -> events += "foreground:within=$resumedWithinGrace" },
+            nowMillis = { bootNow },
+        )
+
+        controller.onBackground()
+        runCurrent()
+        // Doze: the uptime clock barely moves (one poll wake), but the boot clock
+        // jumps to 45 s — still inside the 90 s window.
+        bootNow = 45_000L
+        advanceTimeBy(15_001L)
+        runCurrent()
+        assertEquals("teardown must not fire before the boot deadline", emptyList<String>(), events)
+
+        controller.onForeground()
+        runCurrent()
+        assertEquals(
+            "returning within the boot-clock grace window must reattach without a teardown",
+            listOf("foreground:within=true"),
             events,
         )
     }


### PR DESCRIPTION
Fixes finding **R2** (#843): the bounded 90s background grace TEARDOWN timer ran `delay(graceMillis)` on the UPTIME clock, which Doze suspends — stretching the effective grace to minutes (maintainer log seq 64937: `elapsedMs=582480` vs `graceMs=90000`), while the grace DECISION (#1080) already ran on the boot clock.

**Fix:** drive the teardown timer onto the same BOOT clock via a chunked, boot-clock-checked sleep (`GRACE_TEARDOWN_POLL_CHUNK_MS`), so the first wake past the boot deadline fires the teardown. No wakelock/AlarmManager/WorkManager — **D21 preserved** (plain chunked coroutine sleep with a terminal break).

**Verification (reviewer-run red→green + grace journey — #1544 comment 4962853491):**
- Base (single uptime `delay`): doze reproduction fires teardown at boot `elapsedMs=180000` vs `graceMs=90000` (the seq-64937 2× stretch). Fix: fires at `elapsedMs=90000`. No-Doze fires at exactly 90s; within-grace-under-Doze reattaches with no teardown.
- **#638 grace journey (emulator-5554 + Docker agents:2222):** `BoundedGraceSessionHoldJourneyE2eTest` passed — within-grace return seamless (no reconnect, `within_grace_cycle_ms=2669`), beyond-grace teardown on time, post-grace clean reconnect (attempts 1→2), reattached viewport shows READY marker.
- No wakelock/scheduler introduced; full `:app:testDebugUnitTest` 3724 tests, 0 failures; hygiene guards exit 0.

Closes #1544
