### PR TITLE
message-queue: persist wireAttempted on durable row to stop back-nav duplicate (#1541)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/composer/OutboundQueueStore.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/OutboundQueueStore.kt
@@ -285,7 +285,67 @@ public interface OutboundQueueStore {
 
     /** Drop every item for [sessionKey]. */
     public fun clearSession(sessionKey: String)
+
+    /**
+     * Issue #1541 (finding P9): durably mark that any un-delivered row targeting
+     * [paneId] with [payload] as its [OutboundItem.cleanText] has been **pushed to
+     * the wire** — a delivery attempt started that may have landed server-side.
+     * The flag ([OutboundItem.wireAttempted]) is persisted ON THE ROW, so it
+     * survives a plain **VM-clear / back-navigation** (which destroys the volatile
+     * [OutboundDeliveryLedger][com.pocketshell.app.tmux.OutboundDeliveryLedger]),
+     * not only live-VM retries. A rebuilt ledger reads it back via [hasWireAttempt]
+     * and runs verify-before-resend instead of a blind re-paste (server occurrence
+     * 2). No-op when no un-delivered row matches. Returns the updated row, or null.
+     *
+     * The flag lives and dies with the row: it is set here and by the InFlight
+     * claim ([claimNext] / [claim] / [markInFlight]); it is CLEARED only when the
+     * row leaves the queue ([markDelivered] prune / [remove] / [clearSession]), and
+     * PRESERVED across [requeueForRetry] / [requeueStaleInFlight] so a requeued row
+     * still verifies before re-pasting. That is what also closes the
+     * `markDelivered`-lost-on-`apply()` corner: a delivered row whose prune write
+     * was lost survives with the flag still set, so the rebuild verifies (already
+     * landed ⇒ occurrence 1) instead of blindly re-pasting.
+     */
+    public fun markWireAttempted(
+        paneId: String,
+        payload: String,
+        atMs: Long = System.currentTimeMillis(),
+    ): OutboundItem?
+
+    /**
+     * Issue #1541: whether any persisted row targeting [paneId] with [payload] as
+     * its [OutboundItem.cleanText] carries a durable [OutboundItem.wireAttempted]
+     * flag — i.e. a prior wire attempt survived a VM-clear. This is what a rebuilt
+     * ledger consults so back-navigation mid-delivery re-enters verify-before-resend.
+     */
+    public fun hasWireAttempt(paneId: String, payload: String): Boolean
 }
+
+/**
+ * Issue #1541: the durable backing the verify-before-resend
+ * [OutboundDeliveryLedger][com.pocketshell.app.tmux.OutboundDeliveryLedger] reads
+ * so a wire attempt survives VM-clear (plain back-navigation) / process death.
+ * Implemented over [OutboundQueueStore.markWireAttempted] / [OutboundQueueStore.hasWireAttempt]
+ * (the flag lives on the persisted row); see [OutboundQueueStore.asWireAttemptDurableStore].
+ */
+public interface OutboundWireAttemptDurableStore {
+    /** Persist that (`paneId`, `payload`) has been pushed to the wire. */
+    public fun recordWireAttempt(paneId: String, payload: String, atMs: Long)
+
+    /** Whether a durable wire attempt is recorded for (`paneId`, `payload`). */
+    public fun hasWireAttempt(paneId: String, payload: String): Boolean
+}
+
+/** Issue #1541: adapt this store as the ledger's durable wire-attempt backing. */
+public fun OutboundQueueStore.asWireAttemptDurableStore(): OutboundWireAttemptDurableStore =
+    object : OutboundWireAttemptDurableStore {
+        override fun recordWireAttempt(paneId: String, payload: String, atMs: Long) {
+            markWireAttempted(paneId, payload, atMs)
+        }
+
+        override fun hasWireAttempt(paneId: String, payload: String): Boolean =
+            this@asWireAttemptDurableStore.hasWireAttempt(paneId, payload)
+    }
 
 /**
  * Issue #900: the durable, process-death-survivable representation of one
@@ -314,6 +374,14 @@ public interface OutboundQueueStore {
  *   double-send (a post-failure re-Send of the restored draft must not create a
  *   second deliverable row). Empty for legacy rows / callers that do not supply
  *   a logical key; an empty `sendKey` never coalesces (each is its own row).
+ * @property wireAttempted issue #1541: durably records that this row has been
+ *   PUSHED TO THE WIRE at least once (a delivery attempt started that may have
+ *   landed server-side). Set when the row is claimed InFlight / marked via
+ *   [OutboundQueueStore.markWireAttempted]; PRESERVED across requeue so a rebuilt
+ *   verify-before-resend ledger consults it after a VM-clear / back-navigation
+ *   (survives the volatile ledger dying) and probes instead of blindly re-pasting.
+ *   Cleared only when the row leaves the queue (delivered-prune / remove / clear).
+ * @property wireAttemptedAtMs the time [wireAttempted] was first set, or `null`.
  */
 public data class OutboundItem(
     val id: String,
@@ -330,6 +398,8 @@ public data class OutboundItem(
     val route: OutboundRoute = OutboundRoute.RawBytes,
     val agentKind: String? = null,
     val sendKey: String = "",
+    val wireAttempted: Boolean = false,
+    val wireAttemptedAtMs: Long? = null,
 )
 
 /** Issue #900: persisted send route selected before an item entered the durable queue. */
@@ -561,6 +631,21 @@ public open class InMemoryOutboundQueueStore : OutboundQueueStore {
     override fun clearSession(sessionKey: String): Unit = synchronized(lock) {
         items.values.removeAll { it.sessionKey == sessionKey }
     }
+
+    override fun markWireAttempted(paneId: String, payload: String, atMs: Long): OutboundItem? =
+        synchronized(lock) {
+            val target = items.values
+                .filter { it.matchesWireTarget(paneId, payload) }
+                .minByOrNull { it.createdAtMs }
+                ?: return null
+            val updated = target.markedWireAttempted(atMs)
+            items[updated.id] = updated
+            updated
+        }
+
+    override fun hasWireAttempt(paneId: String, payload: String): Boolean = synchronized(lock) {
+        items.values.any { it.wireAttempted && it.matchesWireTarget(paneId, payload) }
+    }
 }
 
 /**
@@ -605,6 +690,8 @@ public object DisabledOutboundQueueStore : OutboundQueueStore {
     override fun requeueStaleInFlight(sessionKey: String, cutoffMs: Long): List<OutboundItem> = emptyList()
     override fun remove(id: String): Boolean = false
     override fun clearSession(sessionKey: String) = Unit
+    override fun markWireAttempted(paneId: String, payload: String, atMs: Long): OutboundItem? = null
+    override fun hasWireAttempt(paneId: String, payload: String): Boolean = false
 }
 
 /**
@@ -870,6 +957,27 @@ public class SharedPrefsOutboundQueueStore @Inject constructor(
         storeSession(sessionKey, emptyList())
     }
 
+    override fun markWireAttempted(paneId: String, payload: String, atMs: Long): OutboundItem? =
+        synchronized(lock) {
+            for (sessionKey in sessionKeys()) {
+                val list = loadSession(sessionKey)
+                val target = list
+                    .filter { it.matchesWireTarget(paneId, payload) }
+                    .minByOrNull { it.createdAtMs }
+                    ?: continue
+                val updated = target.markedWireAttempted(atMs)
+                replaceAndStore(sessionKey, list, updated)
+                return@synchronized updated
+            }
+            null
+        }
+
+    override fun hasWireAttempt(paneId: String, payload: String): Boolean = synchronized(lock) {
+        sessionKeys().any { key ->
+            loadSession(key).any { it.wireAttempted && it.matchesWireTarget(paneId, payload) }
+        }
+    }
+
     private fun replaceAndStore(sessionKey: String, list: MutableList<OutboundItem>, updated: OutboundItem) {
         val idx = list.indexOfFirst { it.id == updated.id }
         if (idx >= 0) list[idx] = updated else list.add(updated)
@@ -884,6 +992,15 @@ public class SharedPrefsOutboundQueueStore @Inject constructor(
 
 private val OutboundState.isExactClaimable: Boolean
     get() = this == OutboundState.Queued || this == OutboundState.Failed
+
+/**
+ * Issue #1541: whether this row is the durable wire-attempt record for
+ * (`paneId`, `payload`) — the ledger keys a wire attempt by pane + payload, and
+ * a row's payload is its [OutboundItem.cleanText]. `Delivered` rows are pruned
+ * so never seen here; the guard is belt-and-suspenders.
+ */
+private fun OutboundItem.matchesWireTarget(paneId: String, payload: String): Boolean =
+    this.paneId == paneId && cleanText == payload && state != OutboundState.Delivered
 
 /**
  * Issue #961: a row that a same-[OutboundItem.sendKey] enqueue should COALESCE
@@ -931,13 +1048,26 @@ private fun OutboundItem.reArmedForCoalesce(): OutboundItem =
 
 private fun OutboundItem.claimedForAttempt(): OutboundItem =
     if (state == OutboundState.InFlight) {
-        this
+        // Already InFlight — still stamp the durable wire-attempt flag (issue
+        // #1541) if a prior claim predates the flag, so verify-before-resend
+        // survives a VM-clear on this row.
+        markedWireAttempted(System.currentTimeMillis())
     } else {
         copy(
             state = OutboundState.InFlight,
             attemptCount = attemptCount + 1,
-        )
+        ).markedWireAttempted(System.currentTimeMillis())
     }
+
+/**
+ * Issue #1541: stamp the durable [OutboundItem.wireAttempted] flag (idempotent —
+ * the first-set timestamp is preserved). A claimed / wire-pushed row carries this
+ * across requeue so a rebuilt verify-before-resend ledger consults it after a
+ * VM-clear / back-navigation instead of blindly re-pasting a payload that may
+ * already have landed.
+ */
+private fun OutboundItem.markedWireAttempted(atMs: Long): OutboundItem =
+    if (wireAttempted) this else copy(wireAttempted = true, wireAttemptedAtMs = atMs)
 
 private fun OutboundItem.isStaleRecoverableAttempt(cutoffMs: Long): Boolean =
     (state == OutboundState.InFlight || state == OutboundState.Uploading) &&
@@ -949,12 +1079,13 @@ internal fun blobKey(sessionKey: String): String = "@q/$sessionKey"
 /**
  * Issue #900: encode a session's outbound items as newline-separated rows.
  * Each row is tab-delimited:
- * `id \t cleanText \t withEnter \t state \t createdAtMs \t lastAttemptAtMs \t attemptCount \t lastError \t attachmentsBlob \t paneId \t route \t agentKind \t sendKey`
+ * `id \t cleanText \t withEnter \t state \t createdAtMs \t lastAttemptAtMs \t attemptCount \t lastError \t attachmentsBlob \t paneId \t route \t agentKind \t sendKey \t wireAttempted \t wireAttemptedAtMs`
  * with the same `\`-escaping [ComposerDraftStore] uses so text/paths containing
  * tabs/newlines round-trip losslessly. The attachments field reuses
- * [encodeAttachments], itself escaped as a single field. The trailing `sendKey`
- * (issue #961) is appended last so legacy rows without it decode to an empty
- * `sendKey` (never-coalesce) rather than a malformed row.
+ * [encodeAttachments], itself escaped as a single field. Trailing fields
+ * (`sendKey` #961, `wireAttempted`/`wireAttemptedAtMs` #1541) are appended last
+ * so legacy rows without them decode to their defaults (empty `sendKey`,
+ * `wireAttempted=false`) rather than a malformed row.
  */
 internal fun encodeOutboundItems(items: List<OutboundItem>): String =
     items.joinToString(separator = "\n") { item ->
@@ -972,6 +1103,8 @@ internal fun encodeOutboundItems(items: List<OutboundItem>): String =
             item.route.name,
             item.agentKind.orEmpty(),
             item.sendKey,
+            if (item.wireAttempted) "1" else "0",
+            item.wireAttemptedAtMs?.toString().orEmpty(),
         ).joinToString(separator = "\t") { escapeQueueField(it) }
     }
 
@@ -1001,6 +1134,8 @@ internal fun decodeOutboundItems(sessionKey: String, raw: String): List<Outbound
                 .getOrDefault(OutboundRoute.RawBytes),
             agentKind = f.getOrNull(11)?.takeIf { it.isNotEmpty() },
             sendKey = f.getOrNull(12).orEmpty(),
+            wireAttempted = f.getOrNull(13) == "1",
+            wireAttemptedAtMs = f.getOrNull(14)?.takeIf { it.isNotEmpty() }?.toLongOrNull(),
         )
     }
 }

--- a/app/src/main/java/com/pocketshell/app/tmux/OutboundDeliveryGuard.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/OutboundDeliveryGuard.kt
@@ -1,6 +1,9 @@
 package com.pocketshell.app.tmux
 
 import android.util.Log
+import com.pocketshell.app.composer.OutboundWireAttemptDurableStore
+import com.pocketshell.app.composer.SharedPrefsOutboundQueueStore
+import com.pocketshell.app.composer.asWireAttemptDurableStore
 import com.pocketshell.app.diagnostics.DiagnosticEvents
 import com.pocketshell.core.tmux.TmuxClient
 import com.pocketshell.core.tmux.TmuxDisconnectEvent
@@ -115,8 +118,23 @@ internal const val INPUT_BATCH_PROBE_MIN_NEEDLE_CHARS: Int = 8
  * exactly-once guarantees end at the client store (#961), and the watchdog /
  * strand paths can re-mint requests for the same payload. Bounded LRU so a
  * long-lived VM cannot accumulate stale entries.
+ *
+ * ## Durability across VM-clear (issue #1541)
+ *
+ * The volatile in-memory set dies with the VM — which happens on a plain
+ * **back-navigation** (VM clear), not only on process death. That let the P9
+ * duplicate through: send → tap Back mid-delivery → the row is deferred → reopen
+ * → the FRESH ledger has no memory of the in-flight attempt → the row is blindly
+ * re-pasted → server occurrence 2. [durable] closes that: a wire attempt is
+ * ALSO recorded on the durable [OutboundQueueStore][com.pocketshell.app.composer.OutboundQueueStore]
+ * row (`wireAttempted`), so a ledger rebuilt after a VM-clear consults the durable
+ * flag ([hasAmbiguousAttempt]) and runs verify-before-resend instead of a blind
+ * re-paste. Null [durable] (unit-test constructors) ⇒ in-memory only (base S1).
  */
-internal class OutboundDeliveryLedger(private val maxEntries: Int = 64) {
+internal class OutboundDeliveryLedger(
+    private val maxEntries: Int = 64,
+    private val durable: OutboundWireAttemptDurableStore? = null,
+) {
     private val lock = Any()
     private val entries = LinkedHashSet<String>()
 
@@ -130,16 +148,39 @@ internal class OutboundDeliveryLedger(private val maxEntries: Int = 64) {
         while (entries.size > maxEntries) {
             entries.remove(entries.first())
         }
+        // Issue #1541: also persist on the durable row so the attempt survives a
+        // VM-clear / back-navigation, not only this live VM.
+        durable?.recordWireAttempt(paneId, payload, System.currentTimeMillis())
     }
 
     fun clear(paneId: String, payload: String): Unit = synchronized(lock) {
+        // Only clears the volatile set: the durable flag is tied to the row's
+        // lifetime (dropped when the row is delivered-pruned / removed, PRESERVED
+        // across requeue), so an as-yet-un-acked in-flight row keeps verifying.
         entries.remove(key(paneId, payload))
     }
 
     fun hasAmbiguousAttempt(paneId: String, payload: String): Boolean = synchronized(lock) {
-        key(paneId, payload) in entries
+        // Issue #1541: the durable flag makes a back-nav-rebuilt ledger (empty
+        // in-memory set) still see a prior wire attempt.
+        key(paneId, payload) in entries || durable?.hasWireAttempt(paneId, payload) == true
     }
 }
+
+/**
+ * Issue #1541: build the production [OutboundDeliveryLedger] with its durable
+ * wire-attempt backing wired to the persisted outbound queue rows. A fresh
+ * [SharedPrefsOutboundQueueStore][com.pocketshell.app.composer.SharedPrefsOutboundQueueStore]
+ * shares the process-cached `outbound_queue` SharedPreferences with the composer's
+ * singleton, so the `wireAttempted` flag written on one instance is visible to the
+ * ledger rebuilt on the next VM — surviving VM-clear / back-navigation. A null
+ * [context] (narrow unit-test VM constructors) falls back to the in-memory-only
+ * ledger (base S1 behaviour).
+ */
+internal fun outboundDeliveryLedgerFor(context: android.content.Context?): OutboundDeliveryLedger =
+    OutboundDeliveryLedger(
+        durable = context?.let { SharedPrefsOutboundQueueStore(it).asWireAttemptDurableStore() },
+    )
 
 /**
  * Probe whether [payload] is ALREADY visible in [paneId] — i.e. a prior,

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -14029,13 +14029,11 @@ public class TmuxSessionViewModel @Inject constructor(
         return sendAgentPayloadToPaneResult(client, paneId, payload, agent)
     }
 
-    /**
-     * Issue #1526 S1: delivery-attempt ledger backing verify-before-resend. Lives
-     * on the VM (not the composer queue) because the VM spans the reconnect the
-     * ambiguity arises across; process death loses it, in which case a restart
-     * resend behaves like base (documented S1 residual).
-     */
-    private val outboundDeliveryLedger = OutboundDeliveryLedger()
+    // Issue #1526 S1 / #1541: verify-before-resend ledger. The volatile set dies
+    // on VM-clear (back-navigation), so it is backed by the durable per-row
+    // `wireAttempted` flag (see [outboundDeliveryLedgerFor]) — a rebuilt ledger
+    // verifies instead of blindly re-pasting. Null ctx (unit-test ctors) ⇒ base S1.
+    private val outboundDeliveryLedger = outboundDeliveryLedgerFor(applicationContext)
 
     private fun consumeSendResultLostSeamForTest() {
         if (!OutboundDeliverySeams.consumeSendResultLostBeforeSubmitEnter()) return

--- a/app/src/test/java/com/pocketshell/app/composer/OutboundQueueStoreEncodingTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/OutboundQueueStoreEncodingTest.kt
@@ -1,6 +1,7 @@
 package com.pocketshell.app.composer
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -130,6 +131,40 @@ class OutboundQueueStoreEncodingTest {
         assertEquals("", decoded.paneId)
         assertEquals(OutboundRoute.RawBytes, decoded.route)
         assertEquals(null, decoded.agentKind)
+    }
+
+    @Test
+    fun encodeDecodeRoundTripsWireAttempted() {
+        // Issue #1541: the durable per-row wire-attempt flag must survive process
+        // death so a ledger rebuilt after a VM-clear / restart re-enters
+        // verify-before-resend instead of blindly re-pasting.
+        val items = listOf(
+            OutboundItem(
+                id = "id-wa",
+                sessionKey = "sessA",
+                cleanText = "wire attempted payload",
+                state = OutboundState.InFlight,
+                createdAtMs = 1L,
+                paneId = "%0",
+                wireAttempted = true,
+                wireAttemptedAtMs = 1_700_000_009_000,
+            ),
+        )
+        val decoded = decodeOutboundItems("sessA", encodeOutboundItems(items))
+        assertEquals(items, decoded)
+        assertTrue(decoded.single().wireAttempted)
+        assertEquals(1_700_000_009_000, decoded.single().wireAttemptedAtMs)
+    }
+
+    @Test
+    fun decodeLegacyRowsWithoutWireAttemptedDefaultToFalse() {
+        // Issue #1541: pre-#1541 rows ended at sendKey (field 12). They must decode
+        // to wireAttempted=false (a fresh send), not a malformed row.
+        val raw = "id-legacy\tx\t1\tQueued\t100\t\t0\t\t\t%0\tRawBytes\tclaude\tsk123"
+        val decoded = decodeOutboundItems("sessA", raw).single()
+        assertFalse(decoded.wireAttempted)
+        assertEquals(null, decoded.wireAttemptedAtMs)
+        assertEquals("sk123", decoded.sendKey)
     }
 
     @Test

--- a/app/src/test/java/com/pocketshell/app/composer/OutboundQueueStoreWireAttemptTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/OutboundQueueStoreWireAttemptTest.kt
@@ -1,0 +1,207 @@
+package com.pocketshell.app.composer
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Issue #1541 (finding P9): the durable per-row `wireAttempted` flag that makes
+ * the verify-before-resend ledger survive a plain **VM-clear / back-navigation**,
+ * not only live-VM retries.
+ *
+ * The #1526 S1 exactly-once ledger is VOLATILE (held on `TmuxSessionViewModel`),
+ * so an ordinary Back mid-delivery destroyed it: reopen → the fresh ledger had no
+ * memory of the in-flight attempt → the row was blindly re-pasted → server
+ * occurrence 2. This suite proves the store side of the durable fix:
+ *
+ *  - a row PUSHED TO THE WIRE ([claimNext]/[claim]/[markInFlight] or
+ *    [OutboundQueueStore.markWireAttempted]) carries a durable
+ *    [OutboundItem.wireAttempted] flag,
+ *  - the flag survives a simulated process restart (a fresh store over the same
+ *    prefs — the SAME mechanism a VM-clear rebuild reads through),
+ *  - it is PRESERVED across requeue (deferred rows still verify), and
+ *  - it is dropped only when the row leaves the queue (delivered-prune / remove /
+ *    clear), which is exactly what also closes the `markDelivered`-lost-on-`apply()`
+ *    corner (a delivered row whose prune was lost keeps the flag → verify, not
+ *    re-paste).
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class OutboundQueueStoreWireAttemptTest {
+
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+    }
+
+    // ---------------------------------------------------------- in-memory mechanics
+
+    @Test
+    fun freshlyEnqueuedRowHasNoWireAttempt() {
+        val store = InMemoryOutboundQueueStore()
+        store.enqueue("sessA", "hello", paneId = "%0")
+        assertFalse(
+            "a queued-but-never-sent row has no wire attempt (a fresh send must not verify)",
+            store.hasWireAttempt("%0", "hello"),
+        )
+    }
+
+    @Test
+    fun claimNextStampsWireAttemptedOnTheRow() {
+        val store = InMemoryOutboundQueueStore()
+        val row = store.enqueue("sessA", "deploy now", paneId = "%0")
+        assertFalse(store.item(row.id)!!.wireAttempted)
+
+        val claimed = store.claimNext("sessA")!!
+        assertEquals(OutboundState.InFlight, claimed.state)
+        assertTrue("claiming for a wire attempt sets the durable flag", claimed.wireAttempted)
+        assertNotNull(claimed.wireAttemptedAtMs)
+        assertTrue(store.hasWireAttempt("%0", "deploy now"))
+    }
+
+    @Test
+    fun markInFlightStampsWireAttempted() {
+        val store = InMemoryOutboundQueueStore()
+        val row = store.enqueue("sessA", "restart pool", paneId = "%0")
+        val updated = store.markInFlight(row.id)!!
+        assertTrue(updated.wireAttempted)
+        assertTrue(store.hasWireAttempt("%0", "restart pool"))
+    }
+
+    @Test
+    fun markWireAttemptedMatchesByPaneAndPayloadNotId() {
+        val store = InMemoryOutboundQueueStore()
+        store.enqueue("sessA", "ship the notes", paneId = "%0")
+        // The ledger keys by pane + payload (it does not know the durable id).
+        val marked = store.markWireAttempted("%0", "ship the notes")
+        assertNotNull("markWireAttempted must locate the row by pane + payload", marked)
+        assertTrue(marked!!.wireAttempted)
+        assertTrue(store.hasWireAttempt("%0", "ship the notes"))
+        // A different pane / different payload does not match.
+        assertFalse(store.hasWireAttempt("%1", "ship the notes"))
+        assertFalse(store.hasWireAttempt("%0", "something else"))
+        assertNull(store.markWireAttempted("%9", "no such row"))
+    }
+
+    @Test
+    fun requeueForRetryPreservesWireAttempted() {
+        val store = InMemoryOutboundQueueStore()
+        val row = store.enqueue("sessA", "deferred payload", paneId = "%0")
+        store.markInFlight(row.id)
+        // The drop-failure path defers the row back to Queued (issue #987) — the
+        // wire attempt MUST persist so the re-flush verifies before re-pasting.
+        val requeued = store.requeueForRetry(row.id)!!
+        assertEquals(OutboundState.Queued, requeued.state)
+        assertTrue("a requeued row keeps its durable wire attempt", requeued.wireAttempted)
+        assertTrue(store.hasWireAttempt("%0", "deferred payload"))
+    }
+
+    @Test
+    fun requeueStaleInFlightPreservesWireAttempted() {
+        val store = InMemoryOutboundQueueStore()
+        val row = store.enqueue("sessA", "stale payload", paneId = "%0", createdAtMs = 1_000L)
+        store.markInFlight(row.id)
+        val requeued = store.requeueStaleInFlight("sessA", cutoffMs = Long.MAX_VALUE)
+        assertEquals(1, requeued.size)
+        assertTrue("a stale-recovered row keeps its durable wire attempt", requeued.single().wireAttempted)
+        assertTrue(store.hasWireAttempt("%0", "stale payload"))
+    }
+
+    @Test
+    fun deliveredPruneDropsTheWireAttemptFlag() {
+        val store = InMemoryOutboundQueueStore()
+        val row = store.enqueue("sessA", "delivered payload", paneId = "%0")
+        store.markInFlight(row.id)
+        assertTrue(store.hasWireAttempt("%0", "delivered payload"))
+        assertTrue(store.markDelivered(row.id))
+        assertFalse(
+            "a delivered+pruned row leaves no wire attempt — a deliberate identical " +
+                "re-send after delivery is a normal full send, not a verify",
+            store.hasWireAttempt("%0", "delivered payload"),
+        )
+    }
+
+    @Test
+    fun removeAndClearSessionDropTheWireAttemptFlag() {
+        val store = InMemoryOutboundQueueStore()
+        val row = store.enqueue("sessA", "cancel me", paneId = "%0")
+        store.markInFlight(row.id)
+        assertTrue(store.remove(row.id))
+        assertFalse(store.hasWireAttempt("%0", "cancel me"))
+
+        val other = store.enqueue("sessA", "clear me", paneId = "%0")
+        store.markInFlight(other.id)
+        store.clearSession("sessA")
+        assertFalse(store.hasWireAttempt("%0", "clear me"))
+    }
+
+    // ---------------------------------------------------------- durable / restart
+
+    /**
+     * THE durability proof: a wire attempt set on one store instance is visible to
+     * a FRESH instance over the same prefs — the exact mechanism the verify-before-
+     * resend ledger reads through when the VM is cleared on a back-navigation and a
+     * new VM rebuilds the ledger. On base (volatile ledger only) this cross-instance
+     * memory did not exist, so the reopened session re-pasted (occurrence 2).
+     */
+    @Test
+    fun wireAttemptSurvivesProcessRestartForTheRebuiltLedger() {
+        val first = SharedPrefsOutboundQueueStore(context)
+        val row = first.enqueue("sessA", "survive the restart", paneId = "%0")
+        first.markInFlight(row.id) // pushed to the wire → durable flag persisted
+
+        // A brand-new store over the same on-disk prefs = the fresh process / the
+        // VM-clear-rebuilt ledger's durable backing.
+        val afterRestart = SharedPrefsOutboundQueueStore(context)
+        assertTrue(
+            "the rebuilt ledger must still see the prior wire attempt (durable flag)",
+            afterRestart.hasWireAttempt("%0", "survive the restart"),
+        )
+        assertTrue(afterRestart.item(row.id)!!.wireAttempted)
+    }
+
+    /**
+     * The `markDelivered`-lost-on-`apply()` corner: the delivery succeeded but its
+     * prune write was lost (process died before flush), so the row survives. Because
+     * the wire attempt is durable, the rebuilt ledger still verifies (already landed
+     * ⇒ occurrence 1) instead of blindly re-pasting.
+     */
+    @Test
+    fun lostMarkDeliveredLeavesWireAttemptSoRebuildVerifies() {
+        val first = SharedPrefsOutboundQueueStore(context)
+        val row = first.enqueue("sessA", "delivered but prune lost", paneId = "%0")
+        first.markInFlight(row.id)
+        // markDelivered() is NEVER persisted (its apply() was lost) — the InFlight
+        // row survives the restart with the flag intact.
+        val afterRestart = SharedPrefsOutboundQueueStore(context)
+        assertEquals(OutboundState.InFlight, afterRestart.item(row.id)!!.state)
+        assertTrue(
+            "a delivered row whose prune was lost still carries the wire attempt, so " +
+                "the rebuilt ledger verifies instead of re-pasting",
+            afterRestart.hasWireAttempt("%0", "delivered but prune lost"),
+        )
+    }
+
+    /** The durable adapter the ledger consumes delegates to the store row flag. */
+    @Test
+    fun asWireAttemptDurableStoreDelegatesToTheRow() {
+        val store = InMemoryOutboundQueueStore()
+        store.enqueue("sessA", "adapter payload", paneId = "%0")
+        val durable = store.asWireAttemptDurableStore()
+        assertFalse(durable.hasWireAttempt("%0", "adapter payload"))
+        durable.recordWireAttempt("%0", "adapter payload", atMs = 123L)
+        assertTrue(durable.hasWireAttempt("%0", "adapter payload"))
+        assertTrue(store.item(store.itemsFor("sessA").single().id)!!.wireAttempted)
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/OutboundBackNavExactlyOnceTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/OutboundBackNavExactlyOnceTest.kt
@@ -1,0 +1,202 @@
+package com.pocketshell.app.tmux
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.pocketshell.app.composer.OutboundRoute
+import com.pocketshell.app.composer.SharedPrefsOutboundQueueStore
+import com.pocketshell.core.agents.AgentDetection
+import com.pocketshell.core.agents.AgentKind
+import com.pocketshell.core.tmux.CommandResponse
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Issue #1541 (finding P9): the END-TO-END back-navigation duplicate — the common
+ * real scenario, not process death. Send → tap **Back** mid-delivery → the volatile
+ * exactly-once ledger (held on `TmuxSessionViewModel`) dies with the VM → reopen the
+ * session → a FRESH VM/ledger with no memory blindly re-pastes → **server occurrence
+ * 2**.
+ *
+ * This drives the real path: TWO `TmuxSessionViewModel` instances sharing the
+ * process-cached `outbound_queue` SharedPreferences (exactly what a VM-clear
+ * rebuild sees), with a [FakeTmuxClient] acting as the server (a recorded
+ * `send-keys -l` command HAS pasted server-side). VM #1 sends and its submit-Enter
+ * result is lost after the paste landed (the ambiguous mid-send drop); VM #1 is then
+ * CLEARED (the #780 synthetic-injection model for back-navigation — NOT process
+ * death); VM #2 rebuilds and re-dispatches the SAME row.
+ *
+ * RED on base (volatile ledger only): VM #2 re-pastes ⇒ [FakeTmuxClient.pasteCount]
+ * == 1 (occurrence 2 across the two clients / one server).
+ * GREEN with the durable `wireAttempted` flag: VM #2's rebuilt ledger reads the
+ * durable flag, runs verify-before-resend, sees the payload already landed, and
+ * submits Enter ONLY ⇒ pasteCount == 0 (occurrence stays 1).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class OutboundBackNavExactlyOnceTest : TmuxSessionViewModelTestBase() {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private fun claudeDetection(): AgentDetection = AgentDetection(
+        agent = AgentKind.ClaudeCode,
+        sourcePath = "/home/u/.claude/sessions/abc.jsonl",
+        sessionId = "abc",
+        confidence = AgentDetection.Confidence.ProcessConfirmed,
+    )
+
+    private fun FakeTmuxClient.pasteCount(payload: String): Int =
+        sentCommands.count { it.startsWith("send-keys -l -t %0") && it.contains(payload) }
+
+    private fun FakeTmuxClient.enterCount(): Int =
+        sentCommands.count { it == "send-keys -t %0 Enter" }
+
+    /** A VM whose delivery ledger is durable-backed (real app context). */
+    private fun newDurableConnectedVm(client: FakeTmuxClient): TmuxSessionViewModel {
+        val vm = newVm(applicationContext = context)
+        vm.attachClientForTest(client)
+        vm.startAgentConversationForTest("%0", claudeDetection())
+        vm.setAgentSubmitEnterDelayForTest(0)
+        vm.setAgentSubmitAckTimeoutForTest(50)
+        return vm
+    }
+
+    private fun clientShowing(vararg lines: String): FakeTmuxClient = FakeTmuxClient().apply {
+        defaultCaptureResponse = CommandResponse(number = 0L, output = lines.toList(), isError = false)
+    }
+
+    /**
+     * THE load-bearing back-nav case: the paste landed server-side, the submit
+     * Enter's result was lost, the user tapped Back (VM cleared), and the reopened
+     * session re-dispatched the row. The durable `wireAttempted` flag must make the
+     * rebuilt VM verify-before-resend so the payload reaches the server EXACTLY once.
+     */
+    @Test
+    fun backNavAfterAmbiguousSendDoesNotRepasteOnRebuiltVm() = runTest(scheduler) {
+        val payload = "deploy the staging build now"
+        // The composer enqueued the row that is being delivered (Queued, matching
+        // pane + payload). Same prefs file the VMs' ledgers read.
+        val store = SharedPrefsOutboundQueueStore(context)
+        store.enqueue("sessA", payload, paneId = "%0", route = OutboundRoute.AgentConversation)
+
+        // VM #1: attempt 1 pastes, the pane shows it (ack passes), then the submit
+        // Enter's exec result is lost after the server ran the paste.
+        val client1 = clientShowing("> $payload")
+        val vm1 = newDurableConnectedVm(client1)
+        client1.throwOnCommandPrefix = "send-keys -t %0 Enter"
+        client1.throwOnCommandRemaining = 1
+        val first = async { vm1.sendAgentPayloadToPaneResult("%0", payload, AgentKind.ClaudeCode) }
+        advanceUntilIdle()
+        assertTrue("attempt 1 must surface the ambiguous failure", first.await().isFailure)
+        assertEquals("attempt 1 pastes exactly once", 1, client1.pasteCount(payload))
+        // The wire attempt is now DURABLE on the row (survives the VM-clear).
+        assertTrue(store.hasWireAttempt("%0", payload))
+
+        // The user taps BACK mid-delivery → VM #1 is cleared (its volatile ledger
+        // dies). #780 model: a synthetic VM-clear, not process death.
+        vm1.clearForTest()
+
+        // Reopen the session: a FRESH VM #2 rebuilds the ledger from the durable
+        // flag. The reconnect auto-flush re-dispatches the SAME row; the pane still
+        // shows the landed payload.
+        val client2 = clientShowing("> $payload")
+        val vm2 = newDurableConnectedVm(client2)
+        val second = async { vm2.sendAgentPayloadToPaneResult("%0", payload, AgentKind.ClaudeCode) }
+        advanceUntilIdle()
+        assertTrue("the verified resend must succeed", second.await().isSuccess)
+
+        // THE assertion (#1541 AC): the rebuilt VM must NOT re-paste. On base
+        // (volatile ledger only) VM #2 has no memory and blindly re-pastes ⇒ 1
+        // (server occurrence 2). With the durable flag ⇒ 0 (Enter-only, occurrence 1).
+        assertEquals(
+            "back-navigation mid-delivery must NOT duplicate: the rebuilt VM reads the " +
+                "durable wireAttempted flag and submits Enter only (occurrence stays 1)",
+            0,
+            client2.pasteCount(payload),
+        )
+        assertTrue("the rebuilt VM must still submit the pending row (Enter-only)", client2.enterCount() >= 1)
+    }
+
+    /**
+     * No LOST regression: a genuinely-UNDELIVERED row after back-navigation still
+     * delivers on the rebuilt VM (the durable flag makes it VERIFY, and the probe
+     * shows it never landed ⇒ a full re-paste, not a silent drop).
+     */
+    @Test
+    fun backNavWithUndeliveredRowStillDeliversOnRebuiltVm() = runTest(scheduler) {
+        val payload = "restart the worker pool"
+        val store = SharedPrefsOutboundQueueStore(context)
+        store.enqueue("sessB", payload, paneId = "%0", route = OutboundRoute.AgentConversation)
+
+        // VM #1: the paste never lands (the send fails before it reaches the pane).
+        val client1 = clientShowing("$ ")
+        val vm1 = newDurableConnectedVm(client1)
+        client1.throwOnCommandPrefix = "send-keys -l -t %0"
+        client1.throwOnCommandRemaining = 1
+        val first = async { vm1.sendAgentPayloadToPaneResult("%0", payload, AgentKind.ClaudeCode) }
+        advanceUntilIdle()
+        assertTrue(first.await().isFailure)
+        // The attempt was still recorded durably (it reached the wire, outcome lost).
+        assertTrue(store.hasWireAttempt("%0", payload))
+
+        vm1.clearForTest()
+
+        // VM #2 rebuilds: the probe shows the payload NEVER landed ⇒ full re-paste,
+        // the row is NOT dropped.
+        val client2 = clientShowing("$ ")
+        val vm2 = newDurableConnectedVm(client2)
+        val second = async { vm2.sendAgentPayloadToPaneResult("%0", payload, AgentKind.ClaudeCode) }
+        advanceUntilIdle()
+        assertTrue(second.await().isSuccess)
+        assertEquals(
+            "a genuinely-undelivered row after back-navigation must still deliver " +
+                "(verify shows NOT landed ⇒ re-paste), never silently dropped",
+            1,
+            client2.pasteCount(payload),
+        )
+    }
+
+    /**
+     * Subscriber-alive (live-VM retry) path is preserved: WITHOUT a back-nav, a
+     * deliberate repeat send after a SUCCESSFUL delivery (row delivered+pruned) is
+     * a normal full send, not suppressed by a stale durable flag.
+     */
+    @Test
+    fun deliberateRepeatAfterDeliveredRowIsNotSuppressed() = runTest(scheduler) {
+        val payload = "run the smoke suite again"
+        val store = SharedPrefsOutboundQueueStore(context)
+        val row = store.enqueue("sessC", payload, paneId = "%0", route = OutboundRoute.AgentConversation)
+
+        val client = clientShowing("> $payload")
+        val vm = newDurableConnectedVm(client)
+
+        val first = async { vm.sendAgentPayloadToPaneResult("%0", payload, AgentKind.ClaudeCode) }
+        advanceUntilIdle()
+        assertTrue(first.await().isSuccess)
+        assertEquals(1, client.pasteCount(payload))
+
+        // The composer acks delivery: the row is delivered+pruned, dropping the
+        // durable flag so a later identical send is not falsely suppressed.
+        store.markDelivered(row.id)
+        assertFalse(store.hasWireAttempt("%0", payload))
+
+        // A deliberate identical re-send is a normal full send (2 pastes total).
+        val second = async { vm.sendAgentPayloadToPaneResult("%0", payload, AgentKind.ClaudeCode) }
+        advanceUntilIdle()
+        assertTrue(second.await().isSuccess)
+        assertEquals(
+            "a deliberate repeat after a delivered (pruned) row must not be suppressed",
+            2,
+            client.pasteCount(payload),
+        )
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/OutboundDeliveryGuardTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/OutboundDeliveryGuardTest.kt
@@ -1,5 +1,6 @@
 package com.pocketshell.app.tmux
 
+import com.pocketshell.app.composer.asWireAttemptDurableStore
 import com.pocketshell.core.tmux.CommandResponse
 import com.pocketshell.core.tmux.TmuxClientException
 import com.pocketshell.core.tmux.TmuxDisconnectEvent
@@ -320,6 +321,80 @@ class OutboundDeliveryGuardTest {
             "a fresh send must not pay a capture-pane probe round-trip",
             client.capturePaneTextViaExecCalls.isEmpty(),
         )
+    }
+
+    /**
+     * Issue #1541 (finding P9) — the durable-flag mechanism at the ledger level.
+     * The volatile ledger dies on a plain VM-clear (back-navigation); a ledger
+     * REBUILT after that clear must re-read the durable per-row `wireAttempted`
+     * flag and still run verify-before-resend. RED on base: a volatile-only
+     * rebuilt ledger has no memory ⇒ the reopened session blindly re-pastes
+     * (server occurrence 2). GREEN: the durable-backed rebuild sees the attempt.
+     */
+    @Test
+    fun rebuiltLedgerConsultsDurableFlagAfterVmClear() {
+        val store = com.pocketshell.app.composer.InMemoryOutboundQueueStore()
+        // The composer enqueued the row that the VM is delivering.
+        store.enqueue("sessA", "durable payload", paneId = "%0")
+        val durable = store.asWireAttemptDurableStore()
+
+        // VM #1's ledger records the wire attempt (right before the paste).
+        val ledger1 = OutboundDeliveryLedger(durable = durable)
+        ledger1.recordWireAttempt("%0", "durable payload")
+        assertTrue(ledger1.hasAmbiguousAttempt("%0", "durable payload"))
+
+        // Back-navigation clears the VM: its volatile ledger dies. A base ledger
+        // with NO durable backing has no memory of the attempt (the P9 bug).
+        val baseRebuilt = OutboundDeliveryLedger()
+        assertFalse(
+            "RED (base): a volatile-only rebuilt ledger loses the wire attempt, so " +
+                "the reopened session blindly re-pastes (server occurrence 2)",
+            baseRebuilt.hasAmbiguousAttempt("%0", "durable payload"),
+        )
+
+        // The fix: a ledger rebuilt with the SAME durable store re-reads the flag
+        // and runs verify-before-resend (server occurrence 1).
+        val rebuilt = OutboundDeliveryLedger(durable = durable)
+        assertTrue(
+            "GREEN (fix): the durable `wireAttempted` flag makes the rebuilt ledger " +
+                "verify-before-resend instead of blindly re-pasting",
+            rebuilt.hasAmbiguousAttempt("%0", "durable payload"),
+        )
+    }
+
+    /**
+     * A FRESH send (no durable row / no prior attempt) never verifies, even with a
+     * durable backing — the hot send path stays probe-free.
+     */
+    @Test
+    fun freshSendWithDurableBackingButNoPriorAttemptDoesNotVerify() {
+        val store = com.pocketshell.app.composer.InMemoryOutboundQueueStore()
+        val ledger = OutboundDeliveryLedger(durable = store.asWireAttemptDurableStore())
+        assertFalse(ledger.hasAmbiguousAttempt("%0", "a brand new prompt"))
+    }
+
+    /**
+     * [OutboundDeliveryLedger.clear] clears only the VOLATILE set — the durable row
+     * flag persists (dropped only when the row leaves the queue), so an as-yet-
+     * un-acked in-flight row still verifies on a later rebuild. This is what closes
+     * the `markDelivered`-lost corner: a cleared-but-not-yet-pruned row keeps
+     * verifying.
+     */
+    @Test
+    fun clearKeepsDurableRowFlagForAsYetUnackedRow() {
+        val store = com.pocketshell.app.composer.InMemoryOutboundQueueStore()
+        store.enqueue("sessA", "unacked payload", paneId = "%0")
+        val durable = store.asWireAttemptDurableStore()
+        val ledger = OutboundDeliveryLedger(durable = durable)
+        ledger.recordWireAttempt("%0", "unacked payload")
+        ledger.clear("%0", "unacked payload")
+
+        assertTrue(
+            "clear() drops only the volatile entry; the durable row flag persists so " +
+                "a rebuilt ledger still verifies",
+            ledger.hasAmbiguousAttempt("%0", "unacked payload"),
+        )
+        assertTrue(store.hasWireAttempt("%0", "unacked payload"))
     }
 
     @Test

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTestBase.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTestBase.kt
@@ -157,6 +157,12 @@ abstract class TmuxSessionViewModelTestBase {
             com.pocketshell.app.agents.AgentKindRemoteSource().apply {
                 setExecDispatcherForTest(StandardTestDispatcher(scheduler))
             },
+        // Issue #1541: default null keeps every existing test's ledger in-memory
+        // only (base S1). A test that needs the durable per-row `wireAttempted`
+        // flag (survives VM-clear / back-navigation) passes the Robolectric app
+        // context, so a VM's `outboundDeliveryLedgerFor(applicationContext)` wires
+        // the durable backing over the process-cached `outbound_queue` prefs.
+        applicationContext: android.content.Context? = null,
     ): TmuxSessionViewModel =
         TmuxSessionViewModel(
             tmuxClientFactory = TmuxClientFactory(factoryScope),
@@ -169,6 +175,7 @@ abstract class TmuxSessionViewModelTestBase {
             sessionLifecycleSignals = sessionLifecycleSignals,
             agentRepository = agentRepository,
             agentKindRemoteSource = agentKindRemoteSource,
+            applicationContext = applicationContext,
         ).also {
             // Issue #576 (Slice A of #792): pin the structural-reconcile
             // dispatcher to Main (the MainDispatcherRule's


### PR DESCRIPTION
Fixes finding **P9** (#1526): duplicate re-paste on plain **back-navigation**. The #1526 S1 exactly-once ledger lived on `TmuxSessionViewModel` and was volatile — it died on VM-clear (back-nav, not just process death), so send → Back mid-delivery → reopen → the fresh ledger had no memory → blind re-paste → server occurrence 2.

**Fix:** persist a durable **`wireAttempted`** (+ timestamp) on the `OutboundQueueStore` row, stamped at wire-claim. A ledger rebuilt after VM-clear consults the durable flag and runs **verify-before-resend** — never an unconditional skip. Flag preserved across requeue, dropped on delivered-prune/remove/clear.

**Verification (reviewer-run red→green — #1541 comment 4962956871):**
- Base (durable clause neutralized): `backNavAfterAmbiguousSendDoesNotRepasteOnRebuiltVm` RED `expected:<0> but was:<1>` (rebuilt VM re-pasted = occurrence 2). Fix → occurrence 1 (Enter-only).
- **No-LOST regression proven:** `hasAmbiguousAttempt` → probe → `NotLanded` falls through to a full send; a genuinely-undelivered row after back-nav STILL delivers (non-vacuous guard).
- Class coverage: subscriber-alive + torn-down, already-landed + undelivered, `markDelivered`-lost corner.
- Full `:app:testDebugUnitTest` 3740 tests, 0 failures; hygiene guards exit 0 (VM 17586≤17621).

Closes #1541
