### PR TITLE
hygiene: extract two pure conversation helpers off TmuxSessionViewModel — restore byte headroom (#1555)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionConversationHelpers.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionConversationHelpers.kt
@@ -1,0 +1,40 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.core.agents.AgentDetection
+import com.pocketshell.core.agents.ConversationEvent
+import com.pocketshell.core.agents.ConversationRole
+
+/**
+ * Issue #1555 (D28 / file-size hygiene ratchet): pure, VM-state-free
+ * conversation/agent-detection helpers split out of the [TmuxSessionViewModel]
+ * god-object into cohesive same-package top-level functions. Extraction only —
+ * byte-identical bodies, zero behaviour change; the VM calls them unqualified
+ * (same package) exactly as it called the former private members.
+ */
+
+/**
+ * The text a conversation event contributes to port-offer scanning, or `null`
+ * when the event carries nothing scannable (assistant messages, tool results,
+ * and system notes carry offers; tool calls and blank text do not).
+ */
+internal fun ConversationEvent.portOfferText(): String? = when (this) {
+    is ConversationEvent.Message -> text.takeIf {
+        role == ConversationRole.Assistant && it.isNotBlank()
+    }
+    is ConversationEvent.ToolResult -> output.takeIf { it.isNotBlank() }
+    is ConversationEvent.SystemNote -> content.takeIf { it.isNotBlank() }
+    is ConversationEvent.ToolCall -> null
+}
+
+/**
+ * Issue #495: two detections describe the same live agent session when
+ * the agent kind and the log source path match. Confidence and
+ * sessionId can drift between a seeded reconnect verdict and the live
+ * re-detection without meaning "a different agent" — treating that as a
+ * new agent would discard the user's tab choice.
+ */
+internal fun sameAgentSource(left: AgentDetection?, right: AgentDetection?): Boolean =
+    left != null &&
+        right != null &&
+        left.agent == right.agent &&
+        left.sourcePath == right.sourcePath

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -56,7 +56,6 @@ import com.pocketshell.app.session.OPTIMISTIC_USER_MESSAGE_ID_PREFIX
 import com.pocketshell.app.session.SessionTab
 import com.pocketshell.app.session.canRetryAgentStream
 import com.pocketshell.app.session.markOptimisticFailed
-import com.pocketshell.app.session.reconcileAgentEvents
 import com.pocketshell.app.startup.StartupTiming
 import com.pocketshell.app.tmux.connection.BackgroundArm
 import com.pocketshell.app.tmux.connection.BackgroundEffects
@@ -153,7 +152,6 @@ import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -14907,28 +14905,6 @@ public class TmuxSessionViewModel @Inject constructor(
             }
         }
     }
-
-    private fun ConversationEvent.portOfferText(): String? = when (this) {
-        is ConversationEvent.Message -> text.takeIf {
-            role == ConversationRole.Assistant && it.isNotBlank()
-        }
-        is ConversationEvent.ToolResult -> output.takeIf { it.isNotBlank() }
-        is ConversationEvent.SystemNote -> content.takeIf { it.isNotBlank() }
-        is ConversationEvent.ToolCall -> null
-    }
-
-    /**
-     * Issue #495: two detections describe the same live agent session when
-     * the agent kind and the log source path match. Confidence and
-     * sessionId can drift between a seeded reconnect verdict and the live
-     * re-detection without meaning "a different agent" — treating that as a
-     * new agent would discard the user's tab choice.
-     */
-    private fun sameAgentSource(left: AgentDetection?, right: AgentDetection?): Boolean =
-        left != null &&
-            right != null &&
-            left.agent == right.agent &&
-            left.sourcePath == right.sourcePath
 
     private fun setAgentConversation(paneId: String, state: AgentConversationUiState) {
         _agentConversations.update { it + (paneId to state) }


### PR DESCRIPTION
Unblocks `main`: after #1545 and #1541 merged (both touch `TmuxSessionViewModel.kt`), the god-object breached its byte baseline by +28 bytes — each PR passed the guard individually off the shared base, but their combination on `main` breached it, so every PR's `Unit tests` check now fails on the pre-existing drift.

**Pure reduction, zero behavior change:**
- Extract `ConversationEvent.portOfferText()` and `sameAgentSource()` (byte-identical bodies) to a new sibling `TmuxSessionConversationHelpers.kt` (`internal` top-level fns, same package — call-sites resolve unqualified).
- Remove 2 genuinely-dead imports.

**Verification (reviewer-confirmed — #1555 comment 4963647301):**
- Byte-identical extraction (moved bodies character-for-character unchanged); dead imports genuinely unused (grep + compile).
- `check-file-size-hygiene.sh` EXIT 0 — `TmuxSessionViewModel.kt` = **905649 bytes, 1078 under baseline**. `check-connection-vm-ratchet.sh` EXIT 0 (17562 < 17621).
- Full `:app:testDebugUnitTest` (198 tasks executed): 3750 tests, 0 failures; the 69 helper-exercising conversation/agent-detection tests all pass.

Closes #1555
