### PR TITLE
message-queue: sweep orphaned InFlight rows on a short bound — fix Sending-forever (#1542)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/composer/OutboundQueueStore.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/OutboundQueueStore.kt
@@ -359,7 +359,14 @@ public fun OutboundQueueStore.asWireAttemptDurableStore(): OutboundWireAttemptDu
  * @property withEnter whether delivery presses Enter after the paste.
  * @property state the persisted state-machine position.
  * @property createdAtMs enqueue time — the ordering key (oldest-first).
- * @property lastAttemptAtMs time of the last delivery attempt, or `null`.
+ * @property lastAttemptAtMs time of the last delivery attempt, or `null`. Issue
+ *   #1542 (Q1): stamped when the row is claimed InFlight
+ *   ([OutboundQueueStore.claimNext]/[OutboundQueueStore.claim]/[OutboundQueueStore.markInFlight]),
+ *   as well as on [OutboundQueueStore.markUploading]/[OutboundQueueStore.markFailed].
+ *   The stale-recovery sweep ([OutboundQueueStore.requeueStaleInFlight]) ages an
+ *   InFlight/Uploading row against this so an orphaned in-flight attempt can be
+ *   swept by its CLAIM age rather than its enqueue age. `null` only for a legacy
+ *   row that was never attempted (aged by [createdAtMs] as a fallback).
  * @property attemptCount number of delivery attempts so far.
  * @property lastError the last delivery error, or `null`.
  * @property paneId pane targeted by the original send action. Empty for legacy
@@ -1046,18 +1053,31 @@ private fun List<OutboundItem>.coalesceTargetForSendKey(
 private fun OutboundItem.reArmedForCoalesce(): OutboundItem =
     if (state == OutboundState.Failed) copy(state = OutboundState.Queued, lastError = null) else this
 
-private fun OutboundItem.claimedForAttempt(): OutboundItem =
-    if (state == OutboundState.InFlight) {
-        // Already InFlight — still stamp the durable wire-attempt flag (issue
-        // #1541) if a prior claim predates the flag, so verify-before-resend
-        // survives a VM-clear on this row.
-        markedWireAttempted(System.currentTimeMillis())
+private fun OutboundItem.claimedForAttempt(): OutboundItem {
+    // Issue #1542 (enabler Q1): stamp the CLAIM time onto [OutboundItem.lastAttemptAtMs]
+    // so an InFlight row can be AGED against its actual in-flight attempt. Before
+    // this, a claim to InFlight left `lastAttemptAtMs` null, so the stale-recovery
+    // sweep ([isStaleRecoverableAttempt]) had to fall back to [OutboundItem.createdAtMs]
+    // — and an orphaned InFlight row (send coroutine died / VM churned / process
+    // death mid-send) had no claim-age to sweep against, parking on "Sending…" until
+    // only the slow ~160s watchdog re-armed it (finding D7). This is DISTINCT from
+    // #1541's [OutboundItem.wireAttemptedAtMs], which records the FIRST wire attempt
+    // ever and is preserved across re-claims; the orphan sweep needs the LATEST
+    // attempt, so it needs its own timestamp.
+    val atMs = System.currentTimeMillis()
+    return if (state == OutboundState.InFlight) {
+        // Already InFlight — refresh the attempt timestamp and (issue #1541) stamp
+        // the durable wire-attempt flag if a prior claim predates it, so
+        // verify-before-resend survives a VM-clear on this row.
+        copy(lastAttemptAtMs = atMs).markedWireAttempted(atMs)
     } else {
         copy(
             state = OutboundState.InFlight,
             attemptCount = attemptCount + 1,
-        ).markedWireAttempted(System.currentTimeMillis())
+            lastAttemptAtMs = atMs,
+        ).markedWireAttempted(atMs)
     }
+}
 
 /**
  * Issue #1541: stamp the durable [OutboundItem.wireAttempted] flag (idempotent —

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreenStateHelpers.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreenStateHelpers.kt
@@ -91,6 +91,35 @@ internal fun rememberTmuxSessionTabState(
 internal const val OUTBOUND_DEFERRED_REDISPATCH_BACKOFF_MS: Long = 3_000L
 
 /**
+ * Issue #1542 (finding D7): the age past which the auto-flush poll treats an
+ * [OutboundState.InFlight][com.pocketshell.app.composer.OutboundState.InFlight]
+ * row as ORPHANED and sweeps it back to `Queued` for a verified re-dispatch.
+ *
+ * ## Why a dedicated, SHORT bound (not the 160s send watchdog)
+ *
+ * A row claimed InFlight and then abandoned mid-send — the send coroutine died,
+ * the VM churned, or the process died between the paste and the ack — is never
+ * re-examined by the snapshot lane (it only un-parks `Queued` rows). Stale
+ * recovery re-arms InFlight rows too, but its bound was tied to
+ * `OUTBOUND_IN_FLIGHT_STALE_MS` (= the ~160s whole-send watchdog), so on a
+ * STABLE, connected session an orphaned row parked on "Sending…" for ~160s — the
+ * maintainer's "sent long after / never." The watchdog is long because an ACTIVE
+ * send can legitimately take up to `upload(90s)+onSend(50s)`; but an orphan on a
+ * stable connection has NO active send coroutine, so it can recover far sooner.
+ *
+ * A shorter orphan bound is exactly-once-safe because an actually-active send is
+ * still protected on two independent layers even if this sweep re-arms its row
+ * early: the dispatch gates (`sendInFlight` for the send leg,
+ * `outboundSidecarDispatchInFlight` for the upload leg) block a concurrent
+ * re-dispatch, and the #1526/#1541 DURABLE verify-before-resend ledger suppresses
+ * a re-paste of a payload that already landed (occurrence stays 1). The row's
+ * age is measured from its CLAIM ([OutboundItem.lastAttemptAtMs], stamped by the
+ * #1542 Q1 change), not its enqueue time, so a row that sat Queued a while before
+ * being claimed is aged from the actual in-flight attempt.
+ */
+internal const val OUTBOUND_ORPHANED_INFLIGHT_SWEEP_MS: Long = 15_000L
+
+/**
  * Issue #1531 (audit RC1): the current session's undelivered-outbound summary for
  * the DOCKED composer launcher badge (null when nothing pending). Extracted here
  * (not the ratchet-guarded `TmuxSessionScreen` god-file) so the screen call site
@@ -129,7 +158,16 @@ internal fun TmuxOutboundQueueAutoFlushEffect(
             // claim it. Without this a stranded `Uploading` row was unretryable
             // by the user and unclaimable by auto-flush until the window flipped —
             // "Uploading attachments…" forever on a session that stayed live.
-            sweepStaleInFlight = { promptComposerViewModel.requeueStaleOutboundInFlight() },
+            //
+            // Issue #1542 (finding D7): the poll passes the SHORT orphan bound
+            // ([OUTBOUND_ORPHANED_INFLIGHT_SWEEP_MS]) so an InFlight row abandoned
+            // mid-send (coroutine death / VM churn / process death) recovers fast on
+            // a stable connection instead of parking on "Sending…" for the ~160s send
+            // watchdog. Exactly-once is preserved by the dispatch gates + durable
+            // verify-before-resend (see the constant's KDoc).
+            sweepStaleInFlight = { staleAfterMs ->
+                promptComposerViewModel.requeueStaleOutboundInFlight(staleAfterMs = staleAfterMs)
+            },
         )
     }
 }
@@ -162,12 +200,16 @@ internal suspend fun runOutboundQueueAutoFlush(
     outboundQueueItems: Flow<*>,
     controller: OutboundQueueAutoFlushController,
     retryNext: (excludingIds: Set<String>) -> String?,
-    // Issue #1531 (audit RC3): re-arm a stranded `Uploading`/`InFlight` row past
-    // the stale cutoff back to `Queued` so the retry lane can claim it WITHOUT a
-    // connection-window flip. A no-op for genuinely-active uploads (their attempt
-    // is younger than the cutoff). Defaulted to a no-op so existing unit tests
-    // that only exercise the redispatch lanes keep compiling unchanged.
-    sweepStaleInFlight: () -> Unit = {},
+    // Issue #1531 (audit RC3) / #1542 (finding D7): re-arm a stranded
+    // `Uploading`/`InFlight` row whose CLAIM age exceeds [staleAfterMs] back to
+    // `Queued` so the retry lane can claim it WITHOUT a connection-window flip. A
+    // no-op for a genuinely-active attempt (its claim is younger than the bound).
+    // `runOutboundQueueAutoFlush` supplies [OUTBOUND_ORPHANED_INFLIGHT_SWEEP_MS] —
+    // the SHORT orphan bound — so an orphaned InFlight row recovers fast on a
+    // stable connection (D7) rather than parking for the ~160s send watchdog.
+    // Defaulted to a no-op so existing unit tests that only exercise the redispatch
+    // lanes keep compiling unchanged.
+    sweepStaleInFlight: (staleAfterMs: Long) -> Unit = {},
 ): Unit = coroutineScope {
     launch {
         outboundQueueItems.collect {
@@ -176,12 +218,12 @@ internal suspend fun runOutboundQueueAutoFlush(
     }
     if (sessionLive) {
         // One sweep up front so a row already stranded when the live window opens
-        // (e.g. an app restart that left an `Uploading` row) recovers promptly
-        // instead of waiting a full backoff for the first poll tick.
-        sweepStaleInFlight()
+        // (e.g. an app restart that left an `Uploading`/`InFlight` row) recovers
+        // promptly instead of waiting a full backoff for the first poll tick.
+        sweepStaleInFlight(OUTBOUND_ORPHANED_INFLIGHT_SWEEP_MS)
         while (isActive) {
             delay(OUTBOUND_DEFERRED_REDISPATCH_BACKOFF_MS)
-            sweepStaleInFlight()
+            sweepStaleInFlight(OUTBOUND_ORPHANED_INFLIGHT_SWEEP_MS)
             controller.onQueueSnapshotChanged(sessionLive, retryNext)
         }
     }

--- a/app/src/test/java/com/pocketshell/app/composer/OutboundQueueStoreTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/OutboundQueueStoreTest.kt
@@ -383,6 +383,79 @@ class OutboundQueueStoreTest {
         assertEquals(OutboundState.Queued, store.item(queued.id)!!.state)
     }
 
+    // --- Issue #1542 (enabler Q1): a claim to InFlight stamps a claim age ----
+
+    /**
+     * Issue #1542 (enabler Q1) — the regression guard. A row claimed InFlight had
+     * NO [OutboundItem.lastAttemptAtMs], so the stale-recovery sweep had no
+     * in-flight-attempt timestamp to age it against and fell back to
+     * [OutboundItem.createdAtMs]. An orphaned InFlight row (send coroutine died /
+     * VM churn / process death) therefore could not be aged by its actual attempt,
+     * which is the enabler the D7 poll-lane orphan sweep needs. Every claim primitive
+     * ([OutboundQueueStore.claimNext] / [OutboundQueueStore.claim] /
+     * [OutboundQueueStore.markInFlight]) must now stamp the claim time — RED before
+     * the fix (`lastAttemptAtMs` is null after a claim), GREEN after.
+     */
+    @Test
+    fun issue1542_Q1_everyClaimPrimitiveStampsLastAttemptAtMsOnTheInFlightRow() {
+        val store = store()
+
+        // claimNext (the oldest-queued flush primitive).
+        val a = store.enqueue("sessA", "via claimNext")
+        assertNull("pre-claim: a Queued row has no attempt timestamp", store.item(a.id)!!.lastAttemptAtMs)
+        val claimedNext = store.claimNext("sessA")!!
+        assertEquals(OutboundState.InFlight, claimedNext.state)
+        assertNotNull(
+            "Q1: claimNext must stamp the claim time so the InFlight row can be aged",
+            claimedNext.lastAttemptAtMs,
+        )
+        assertEquals(claimedNext.lastAttemptAtMs, store.item(a.id)!!.lastAttemptAtMs)
+
+        // claim(id) (the exact clicked-row primitive).
+        val b = store.enqueue("sessB", "via claim")
+        val claimedExact = store.claim(b.id)!!
+        assertEquals(OutboundState.InFlight, claimedExact.state)
+        assertNotNull("Q1: claim must stamp the claim time", claimedExact.lastAttemptAtMs)
+
+        // markInFlight(id) (the enqueue-then-mark primitive).
+        val c = store.enqueue("sessC", "via markInFlight")
+        val marked = store.markInFlight(c.id)!!
+        assertEquals(OutboundState.InFlight, marked.state)
+        assertNotNull("Q1: markInFlight must stamp the claim time", marked.lastAttemptAtMs)
+    }
+
+    /**
+     * Issue #1542 (Q1 end-to-end): the stamped claim time makes an orphaned InFlight
+     * row sweepable by its CLAIM age. A row created LONG ago but only just claimed
+     * InFlight must NOT be considered stale by a cutoff that predates its claim
+     * (aging by createdAtMs would wrongly sweep an active send); once the claim age
+     * exceeds the cutoff it IS swept. This is the age semantics the D7 orphan sweep
+     * relies on.
+     */
+    @Test
+    fun issue1542_Q1_claimedInFlightRowIsAgedByClaimTimeNotCreatedAt() {
+        // A row minted a "long time ago" (small createdAtMs) but claimed InFlight
+        // just now would, under the old createdAtMs fallback, look instantly stale.
+        // With Q1 it carries a real claim timestamp, so it is aged from the claim.
+        val store = InMemoryOutboundQueueStore()
+        store.enqueue("sessA", "claimed just now", createdAtMs = 1L)
+        val claimed = store.claimNext("sessA")!!
+        val claimAt = claimed.lastAttemptAtMs!!
+
+        // A cutoff BEFORE the claim (createdAtMs=1 is way before it) must NOT sweep:
+        // the in-flight attempt is younger than the cutoff.
+        assertTrue(
+            "an actively-claimed row must not be swept by a cutoff before its claim",
+            store.requeueStaleInFlight("sessA", cutoffMs = claimAt - 1L).isEmpty(),
+        )
+        assertEquals(OutboundState.InFlight, store.item(claimed.id)!!.state)
+
+        // A cutoff at/after the claim sweeps it (orphan recovery).
+        val swept = store.requeueStaleInFlight("sessA", cutoffMs = claimAt)
+        assertEquals(listOf(claimed.id), swept.map { it.id })
+        assertEquals(OutboundState.Queued, store.item(claimed.id)!!.state)
+    }
+
     @Test
     fun requeuedStaleInFlightRowsAreClaimableAgainInOldestFirstOrder() {
         val store = store()

--- a/app/src/test/java/com/pocketshell/app/composer/PromptComposerOutboundSendQueueViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/PromptComposerOutboundSendQueueViewModelTest.kt
@@ -9,6 +9,10 @@ import com.pocketshell.app.composer.PromptComposerViewModel.RecordingState
 import com.pocketshell.app.di.WhisperClientFactory
 import com.pocketshell.app.hosts.MainDispatcherRule
 import com.pocketshell.app.settings.VoiceTranscriptionProvider
+import com.pocketshell.app.tmux.OUTBOUND_DEFERRED_REDISPATCH_BACKOFF_MS
+import com.pocketshell.app.tmux.OUTBOUND_ORPHANED_INFLIGHT_SWEEP_MS
+import com.pocketshell.app.tmux.OutboundQueueAutoFlushController
+import com.pocketshell.app.tmux.runOutboundQueueAutoFlush
 import com.pocketshell.core.voice.AudioRecorderException
 import com.pocketshell.core.voice.SpeechAudioGuard
 import com.pocketshell.core.voice.WhisperClient
@@ -842,6 +846,171 @@ class PromptComposerOutboundSendQueueViewModelTest {
         assertEquals("still exactly one send", 1, sent2.size)
         assertTrue(queue.itemsFor("1/session-a").isEmpty())
         assertTrue("no residual durable draft", draftStore.load("1/session-a").isNullOrEmpty())
+    }
+
+    // --- Issue #1542 (finding D7): orphaned InFlight row parks on "Sending…" ---
+
+    /** Seed a durable row already left InFlight by a prior VM (the orphan). */
+    private fun InMemoryOutboundQueueStore.seedOrphanInFlightRow(
+        sessionKey: String,
+        cleanText: String,
+        claimAtMs: Long = 0L,
+    ): OutboundItem {
+        // A prior VM claimed this row InFlight (Q1 stamps the claim timestamp) and
+        // then died mid-send. `enqueueExisting` writes it verbatim so the sweep can
+        // age it against the (virtual) test clock deterministically.
+        val row = OutboundItem(
+            id = "orphan-${cleanText.hashCode()}",
+            sessionKey = sessionKey,
+            cleanText = cleanText,
+            state = OutboundState.InFlight,
+            createdAtMs = claimAtMs,
+            lastAttemptAtMs = claimAtMs,
+            attemptCount = 1,
+            paneId = "%7",
+            route = OutboundRoute.AgentPayload,
+            agentKind = "codex",
+            wireAttempted = true,
+            wireAttemptedAtMs = claimAtMs,
+        )
+        return enqueueExisting(row)
+    }
+
+    @Test
+    fun issue1542_D7_orphanedInFlightRowOnStableConnectionIsSweptAndReDispatchedExactlyOnceWithinShortBound() = runTest {
+        // Reproduce-first (D33/G10): a row left InFlight by VM churn / process death
+        // mid-send. On a STABLE, connected session the #1532 auto-flush poll un-parks
+        // only Queued rows via the snapshot lane; the InFlight orphan is recovered
+        // only by the stale-in-flight sweep — whose bound was the ~160s send watchdog.
+        // So the orphan parked on "Sending…" for ~160s ("sent long after / never").
+        //
+        // RED (base, or with OUTBOUND_ORPHANED_INFLIGHT_SWEEP_MS reverted to the 160s
+        // OUTBOUND_IN_FLIGHT_STALE_MS): advancing well past the SHORT bound but below
+        // 160s never sweeps the orphan → `sent` stays EMPTY (row parks InFlight).
+        // GREEN (fix): the poll's SHORT orphan bound sweeps it → the retry lane
+        // re-dispatches it EXACTLY ONCE within the bound.
+        //
+        // Poll-lane coverage: deleting the `sweepStaleInFlight(...)` calls from
+        // `runOutboundQueueAutoFlush` also turns this RED (the orphan is never
+        // re-armed) — the load-bearing lane, not a structural proxy.
+        val queue = InMemoryOutboundQueueStore()
+        val orphan = queue.seedOrphanInFlightRow("1/session-a", "orphaned prompt")
+        assertEquals(OutboundState.InFlight, queue.item(orphan.id)!!.state)
+
+        // The bound must be genuinely SHORTER than the ~160s send watchdog (that
+        // coupling was the D7 bug), and within the fixed 30s window this test uses
+        // to distinguish "recovers fast (fix)" from "waits ~160s (base)".
+        assertTrue(
+            "the orphan bound must be shorter than the 160s send watchdog",
+            OUTBOUND_ORPHANED_INFLIGHT_SWEEP_MS < PromptComposerViewModel.OUTBOUND_IN_FLIGHT_STALE_MS,
+        )
+        assertTrue(
+            "the orphan bound must fit the fixed 30s RED/GREEN window",
+            OUTBOUND_ORPHANED_INFLIGHT_SWEEP_MS <= 30_000L,
+        )
+
+        // Fresh VM (the churn): sendInFlight=false, but the durable row is InFlight.
+        // Clock tied to virtual time so the sweep's claim-age math advances with it.
+        val vm = newVm(
+            samplerDispatcher = StandardTestDispatcher(testScheduler),
+            outboundQueueStore = queue,
+            clock = { testScheduler.currentTime },
+        )
+        val sent = collectSendRequests(vm)
+        vm.onComposerTargetChanged("1/session-a")
+
+        // Drive the REAL poll lane. The sweep bound comes from INSIDE
+        // `runOutboundQueueAutoFlush` (OUTBOUND_ORPHANED_INFLIGHT_SWEEP_MS), so the
+        // test exercises production's actual bound choice, not a hardcoded one.
+        val job = launch {
+            runOutboundQueueAutoFlush(
+                sessionLive = true,
+                outboundQueueItems = vm.outboundQueueItems,
+                controller = OutboundQueueAutoFlushController(clock = { testScheduler.currentTime }),
+                retryNext = { excludingIds -> vm.retryNextOutboundItem(excludingIds = excludingIds) },
+                sweepStaleInFlight = { staleAfterMs ->
+                    vm.requeueStaleOutboundInFlight(staleAfterMs = staleAfterMs)
+                },
+            )
+        }
+        runCurrent()
+
+        // Sanity: at the very first poll tick (well below any orphan bound) the row
+        // is NOT yet swept — an in-flight attempt that just started must not be yanked.
+        advanceTimeBy(1_000L)
+        runCurrent()
+        assertTrue(
+            "below the orphan bound the InFlight row must not be swept/dispatched yet",
+            sent.isEmpty(),
+        )
+        assertEquals(OutboundState.InFlight, queue.item(orphan.id)!!.state)
+
+        // Advance to a FIXED 30s (independent of the bound constant, so the RED/GREEN
+        // is real): far above the SHORT orphan bound but WELL below the ~160s
+        // watchdog. RED on base (160s) — the orphan is never swept inside 30s, so
+        // `sent` stays empty. GREEN (fix) — the SHORT bound sweeps it → Queued → the
+        // retry lane re-dispatches it exactly once.
+        advanceTimeBy(30_000L)
+        runCurrent()
+
+        assertEquals("the orphan must be re-dispatched exactly once", 1, sent.size)
+        assertEquals("orphaned prompt", sent.single().cleanDraft)
+        assertEquals(orphan.id, sent.single().outboundQueueItemId)
+
+        // Delivery prunes the row (occurrence 1): there is nothing left to re-send,
+        // and no second deliverable representation exists.
+        vm.markSendDelivered(sent.single())
+        assertTrue("delivered row is pruned", queue.itemsFor("1/session-a").isEmpty())
+        assertNull("no second deliverable representation after delivery", vm.retryNextOutboundItem())
+        assertEquals("still exactly one send", 1, sent.size)
+
+        job.cancelAndJoin()
+    }
+
+    @Test
+    fun issue1542_D7_freshQueuedRowStillDispatchedByPollLane_noRegression() = runTest {
+        // Class coverage (G2): the fresh-Queued path must keep working — the D7
+        // orphan-InFlight sweep must not regress the #1532 Queued re-dispatch.
+        val queue = InMemoryOutboundQueueStore()
+        val vm = newVm(
+            samplerDispatcher = StandardTestDispatcher(testScheduler),
+            outboundQueueStore = queue,
+            clock = { testScheduler.currentTime },
+        )
+        val sent = collectSendRequests(vm)
+        val queued = queue.enqueue(
+            "1/session-a",
+            "fresh queued prompt",
+            createdAtMs = 0L,
+            paneId = "%7",
+            route = OutboundRoute.AgentPayload,
+        )
+        assertEquals(OutboundState.Queued, queue.item(queued.id)!!.state)
+        // Pull the durable row into the VM snapshot (as a real target focus would).
+        vm.onComposerTargetChanged("1/session-a")
+
+        val job = launch {
+            runOutboundQueueAutoFlush(
+                sessionLive = true,
+                outboundQueueItems = vm.outboundQueueItems,
+                controller = OutboundQueueAutoFlushController(clock = { testScheduler.currentTime }),
+                retryNext = { excludingIds -> vm.retryNextOutboundItem(excludingIds = excludingIds) },
+                sweepStaleInFlight = { staleAfterMs ->
+                    vm.requeueStaleOutboundInFlight(staleAfterMs = staleAfterMs)
+                },
+            )
+        }
+        // The snapshot lane dispatches a fresh Queued row immediately — no sweep,
+        // no bound wait.
+        runCurrent()
+
+        assertEquals("a fresh Queued row is dispatched by the poll lane", 1, sent.size)
+        assertEquals("fresh queued prompt", sent.single().cleanDraft)
+        assertEquals(queued.id, sent.single().outboundQueueItemId)
+
+        vm.markSendDelivered(sent.single())
+        assertTrue(queue.itemsFor("1/session-a").isEmpty())
+        job.cancelAndJoin()
     }
 
     @Test

--- a/app/src/test/java/com/pocketshell/app/tmux/OutboundDeliveryGuardTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/OutboundDeliveryGuardTest.kt
@@ -397,6 +397,56 @@ class OutboundDeliveryGuardTest {
         assertTrue(store.hasWireAttempt("%0", "unacked payload"))
     }
 
+    /**
+     * Issue #1542 (finding D7) — class-coverage limb: an orphaned InFlight row that
+     * ACTUALLY landed. A row claimed InFlight stamps the durable `wireAttempted`
+     * flag on the row itself (via the InFlight claim → #1541); when that VM churns /
+     * dies mid-send, the poll-lane orphan sweep re-arms the row and the retry lane
+     * re-dispatches it through the SAME verify-before-resend send path with a ledger
+     * REBUILT from the durable store. Because the earlier attempt landed server-side,
+     * the probe must resolve `AlreadyLanded` — so the re-dispatch submits Enter only
+     * and never re-pastes (occurrence stays 1, no duplicate). RED if the claim did
+     * not stamp the durable flag (rebuilt ledger has no memory ⇒ blind re-paste ⇒
+     * occurrence 2). This composes with #1541 rather than adding a second flag.
+     */
+    @Test
+    fun issue1542_D7_orphanedInFlightThatLandedVerifiesAlreadyLandedViaClaimStampedDurableFlag() = runTest {
+        val store = com.pocketshell.app.composer.InMemoryOutboundQueueStore()
+        val paneId = "%7"
+        val payload = "orphaned prompt that already landed"
+        // The prior VM enqueued and CLAIMED the row InFlight (its send began). The
+        // InFlight claim durably stamps `wireAttempted` on the row (#1541).
+        val row = store.enqueue("sessA", payload, paneId = paneId)
+        store.claim(row.id)
+        assertEquals(
+            com.pocketshell.app.composer.OutboundState.InFlight,
+            store.item(row.id)!!.state,
+        )
+        assertTrue(
+            "the InFlight claim must durably record the wire attempt on the row",
+            store.hasWireAttempt(paneId, payload),
+        )
+
+        // VM churn / process death: the volatile ledger dies. A ledger REBUILT with
+        // NO durable backing has no memory of the attempt (the pre-fix blind-repaste
+        // trap) — verify-before-resend would be skipped.
+        assertNull(
+            "a volatile-only rebuilt ledger loses the orphaned attempt (would blind re-paste)",
+            verifyBeforeAgentResend(OutboundDeliveryLedger(), captureShowing("$ $payload"), paneId, payload),
+        )
+
+        // The fix path: the ledger rebuilt from the SAME durable store re-reads the
+        // claim-stamped flag → verify → the pane shows the payload → AlreadyLanded,
+        // so the send path submits Enter only and never re-pastes (occurrence 1).
+        val rebuilt = OutboundDeliveryLedger(durable = store.asWireAttemptDurableStore())
+        val outcome = verifyBeforeAgentResend(rebuilt, captureShowing("$ $payload"), paneId, payload)
+        assertEquals(
+            "an orphaned InFlight row that actually landed must verify AlreadyLanded (occurrence 1)",
+            DeliveryProbeOutcome.AlreadyLanded,
+            outcome,
+        )
+    }
+
     @Test
     fun ledgerTracksRecordsClearsAndEvictsOldestBeyondCapacity() {
         val ledger = OutboundDeliveryLedger(maxEntries = 2)

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionScreenTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionScreenTest.kt
@@ -2509,7 +2509,9 @@ class TmuxSessionScreenTest {
                 retryNext = { _ ->
                     if (recovered) "row-1".also { dispatched += it } else null
                 },
-                sweepStaleInFlight = {
+                sweepStaleInFlight = { staleAfterMs ->
+                    // Issue #1542 (D7): the poll now supplies the SHORT orphan bound.
+                    assertEquals(OUTBOUND_ORPHANED_INFLIGHT_SWEEP_MS, staleAfterMs)
                     sweepCount++
                     if (sweepCount >= 2) recovered = true
                 },


### PR DESCRIPTION
Fixes finding **D7 + Q1** (#1526): an orphaned `InFlight` row parks on "Sending…" forever on a stable connection. The #1532 auto-flush poll only un-parked `Queued` rows; a row marked `InFlight` then orphaned (send coroutine died / VM churn mid-send) was never re-examined.

**Fix:**
- **Q1** (`OutboundQueueStore.kt`): `claimedForAttempt()` stamps `lastAttemptAtMs` (the *latest* in-flight attempt age — deliberately distinct from #1541's `wireAttemptedAtMs`, which is the *first-ever* attempt preserved across re-claims).
- **D7** (`TmuxSessionScreenStateHelpers.kt`): the auto-flush poll's `sweepStaleInFlight` carries a short `OUTBOUND_ORPHANED_INFLIGHT_SWEEP_MS = 15s` bound, so an orphaned InFlight row re-arms → re-dispatches through the durable verify-before-resend ledger, instead of waiting the ~160s watchdog.

**Exactly-once safety of the shorter bound:** the `sendInFlight`/`outboundSidecarDispatchInFlight` gates are held across the entire upload+send coroutine, so a swept-to-Queued **active** send can never be double-dispatched; a landed row verifies to occurrence 1.

**Verification (reviewer-run red→green — #1542 comment 4963635955):**
- Reverting the 15s bound to 160s → orphan test RED (parks forever); deleting the sweep block → RED (`expected:<1> but was:<0>`); neutralizing the Q1 stamp → RED. All GREEN restored.
- Active-send-not-swept safety verified (gate held across the coroutine); no #1541 back-nav-dup regression (occurrence 1); fresh Queued still works.
- Full `:app:testDebugUnitTest` --rerun-tasks: 3755 tests, 0 failures. VM-ratchet + test-validity exit 0.

Follow-up #1556 tracks a direct active->15s-upload sweep test (currently proven compositionally).

Closes #1542
