### PR TITLE
release: v0.4.33 — connection + message-queue stability wave

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,8 +65,8 @@ android {
         applicationId = "com.pocketshell.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 79
-        versionName = "0.4.32"
+        versionCode = 80
+        versionName = "0.4.33"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/tools/pocketshell/pyproject.toml
+++ b/tools/pocketshell/pyproject.toml
@@ -8,7 +8,7 @@ name = "pocketshell"
 # scripts/check-pypi-version.sh enforces this; .github/workflows/build.yml
 # runs that check before publishing to PyPI. See
 # tools/pocketshell/README.md ("Release flow") for the bump procedure.
-version = "0.4.32"
+version = "0.4.33"
 description = "Unified server-side Python utility for the PocketShell Android client."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Bumps versionCode 79→80, versionName + tools/pocketshell → 0.4.33 (lockstep, coupling guard exit 0). Batches 8 Fable-audit stability fixes merged since v0.4.32: #1543 #1531 #1545 #1544 #1540 #1541 #1542 #1555. Emulator release gate runs on main after this merges, then tag.