### PR TITLE
connection: parked-runtime health events kill the fast-switch stale-lease flap (#1537 opt b)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/MultiSessionSwitchJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/MultiSessionSwitchJourneyE2eTest.kt
@@ -21,6 +21,7 @@ import androidx.room.Room
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.pocketshell.app.MainActivity
+import com.pocketshell.app.diagnostics.DiagnosticEvents
 import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
 import com.pocketshell.app.hosts.SshKeyStorage
 import com.pocketshell.app.projects.FOLDER_LIST_BACK_TAG
@@ -151,11 +152,21 @@ class MultiSessionSwitchJourneyE2eTest {
 
     private val timings = mutableListOf<String>()
 
+    // Issue #1537 (option b): recording diagnostic sink for the parked-runtime
+    // fast-switch gate. Installed only by that test method (the other bodies do
+    // not read diagnostics) and always restored to Noop in [closeLaunchedActivity].
+    private var diagnostics: RecordingDiagnosticSink? = null
+
     private val pickerWaitMs: Long =
         if (TerminalTestTimeouts.isRunningOnCi()) 60_000L else 20_000L
 
     @After
     fun closeLaunchedActivity() {
+        // Issue #1537: restore the global DiagnosticEvents sink to Noop so this
+        // class's parked-runtime method never leaks a recording sink into a
+        // sibling test in the same instrumentation process.
+        runCatching { diagnostics?.close() }
+        diagnostics = null
         // Issue #788: the body cycles the rule-owned scenario to CREATED during
         // bg->fg grace tests; restore it to RESUMED before the compose rule's own
         // `after()` -> ActivityScenario.close() runs, so close() does not crash
@@ -298,6 +309,116 @@ class MultiSessionSwitchJourneyE2eTest {
                 "switches_asserted=${ring.size}",
                 "expectation=each switch shows correct (non-stale) content, no Disconnected band, " +
                     "pane re-seeded, no spurious SSH re-dial, input routed to shown session",
+            ),
+        )
+        writeTimings()
+        Unit
+    } }
+
+    /**
+     * Issue #1537 (option b) — the PARKED-RUNTIME fast-switch gate, on-device.
+     *
+     * The last unfixed connection flap is the fast-switch stale-lease redial: a
+     * session parked in the runtime cache while another is foreground had no
+     * subscriber watching its liveness, so its death surfaced only at switch-back
+     * as an attach EOF that forced a visible fresh redial
+     * (`stage=stale_lease_auto_recover cause=stale_lease_attach_eof
+     * outcome=fast_switch_fresh_redial`). Option (b) binds the parked client's
+     * liveness edges and evicts a corpse proactively, and routes the residual
+     * silent-TCP race into the single calm ladder instead of the bespoke counter.
+     *
+     * This drives the maintainer's real A->B->C->A fast-switch ring on the plain
+     * Docker `agents:2222` fixture and, from the connection-lifecycle diagnostics
+     * captured over the SAME run, asserts the two on-device properties the parked-
+     * health machinery must hold on the real path:
+     *
+     *  1. NO `stale_lease_attach_eof` / `fast_switch_fresh_redial` STORM on
+     *     switch-back — the warm parked runtime is reused, never discovered as a
+     *     stale corpse (the exact `cause_trail` signature the maintainer hit).
+     *  2. NO false `parked_runtime_death` — the subscriber must not evict a LIVE
+     *     parked runtime; a false-positive eviction would turn every switch-back
+     *     into the very redial this fix deletes. This is the on-device guard for
+     *     the parked-health subscriber over-firing (the JVM red->green lives in
+     *     `Issue1537ParkedRuntimeHealthTest` / `ParkedRuntimeDeathHandlerTest`;
+     *     agents:2222 cannot silently kill only a parked transport, so the death
+     *     reproduction is synthetic at the VM level while THIS gate proves the
+     *     machinery does not regress the real fast-switch on-device).
+     *
+     * Plus the reused per-switch [switchAndAssert] assertions: the CORRECT
+     * non-stale session is shown, the pane is re-seeded, no Disconnected band, no
+     * spurious reconnect, input routes to the shown session. Runs in per-push CI
+     * via the [MultiSessionSwitchJourneyE2eTest] whole-class entry in
+     * scripts/ci-journey-suite.sh (agents:2222, no toxiproxy, no self-skip).
+     */
+    @Test
+    fun parkedRuntimeFastSwitchRingNeverStormsStaleLeaseNorEvictsHealthyParkedRuntime() { runBlocking {
+        // Capture the connection-lifecycle diagnostics over the whole ring.
+        val recording = RecordingDiagnosticSink().also { DiagnosticEvents.install(it) }
+        diagnostics = recording
+
+        // ---- (0) Attach to session A from the host-detail list.
+        waitForHostRowPresent(hostRowTag)
+        compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick()
+        waitForFolderListReady(hostRowTag)
+        waitForText(SESSION_A, timeoutMs = pickerWaitMs)
+        compose.onNodeWithText(SESSION_A, useUnmergedTree = true).performClick()
+        compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertExists()
+        waitForTerminalViewAttached()
+        waitForTerminalContains(SESSION_A_MARKER, "issue1537 initial attach to A")
+
+        expectedMarker[SESSION_A] = SESSION_A_MARKER
+        expectedMarker[SESSION_B] = SESSION_B_MARKER
+        expectedMarker[SESSION_C] = SESSION_C_MARKER
+        var previousSession = SESSION_A
+        assertInputRoutesToShownSession(SESSION_A, "issue1537 initial")
+
+        // ---- The ring A -> B -> C -> A. Each switch parks the leaving same-host
+        // runtime into the cache (the parked-health subscriber binds each); the
+        // return-to-A switch is the one most prone to the stale-lease redial.
+        val ringStart = SystemClock.elapsedRealtime()
+        listOf(SESSION_B, SESSION_C, SESSION_A).forEachIndexed { index, target ->
+            switchAndAssert(step = index + 1, fromSession = previousSession, toSession = target)
+            previousSession = target
+        }
+        recordTiming("issue1537_switch_ring_ms", SystemClock.elapsedRealtime() - ringStart)
+
+        // ---- (1) NO stale-lease attach-EOF storm on switch-back.
+        val causeTrail = recording.eventsNamed("cause_trail")
+        val staleLeaseStorm = causeTrail.filter { event ->
+            event.fields["cause"] == "stale_lease_attach_eof" ||
+                event.fields["outcome"] == "fast_switch_fresh_redial"
+        }
+        writeText("issue1537-cause-trail.txt", causeTrail.joinToString("\n").ifBlank { "(none)" })
+        recordTiming("issue1537_stale_lease_storm_events", staleLeaseStorm.size.toLong())
+        assertTrue(
+            "issue1537: a HEALTHY A->B->C->A fast-switch ring must NOT storm the stale-lease " +
+                "attach-EOF fallback on switch-back (cause=stale_lease_attach_eof / " +
+                "outcome=fast_switch_fresh_redial) — the warm parked runtime must be reused, " +
+                "not discovered as a stale corpse. Saw: $staleLeaseStorm ; full trail=$causeTrail",
+            staleLeaseStorm.isEmpty(),
+        )
+
+        // ---- (2) NO false parked_runtime_death: the subscriber must not evict a
+        // LIVE parked runtime during a healthy switch (over-eviction would force
+        // the redial this fix deletes).
+        val falseDeaths = recording.eventsNamed("parked_runtime_death")
+        recordTiming("issue1537_parked_runtime_death_events", falseDeaths.size.toLong())
+        assertTrue(
+            "issue1537: a HEALTHY fast-switch ring must NOT record a parked_runtime_death — the " +
+                "parked-health subscriber must not evict a live parked runtime. Saw: $falseDeaths",
+            falseDeaths.isEmpty(),
+        )
+
+        writeSummary(
+            lines = listOf(
+                "issue=1537 option-b parked-runtime fast-switch gate",
+                "sessions=$SESSION_A,$SESSION_B,$SESSION_C",
+                "journey=A->B->C->A (parks each leaving same-host runtime)",
+                "cause_trail_events=${causeTrail.size}",
+                "stale_lease_attach_eof_or_fast_switch_fresh_redial=${staleLeaseStorm.size}",
+                "parked_runtime_death_events=${falseDeaths.size}",
+                "expectation=no stale-lease attach-EOF storm on switch-back, no false parked_runtime_death, " +
+                    "correct non-stale session each switch, no Disconnected band, no spurious reconnect",
             ),
         )
         writeTimings()

--- a/app/src/main/java/com/pocketshell/app/tmux/ParkedRuntimeDeathHandler.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/ParkedRuntimeDeathHandler.kt
@@ -1,0 +1,66 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.app.diagnostics.DiagnosticEvents
+import com.pocketshell.app.diagnostics.ReconnectCauseTrail
+import com.pocketshell.core.connection.RuntimeDeathCause
+import com.pocketshell.core.connection.RuntimeHealthKey
+import com.pocketshell.core.ssh.SshLeaseKey
+
+/**
+ * Issue #1537 (option b): the parked-runtime death effect, extracted from
+ * [TmuxSessionViewModel] so the god-object does not grow (the #1047 ratchet).
+ *
+ * A parked runtime's liveness edge declared it dead while another session is
+ * foreground — the fast-switch stale-lease blind spot the single controller was
+ * missing a subscriber for. Evict the corpse from the cache and release its
+ * lease ref NOW so the switch-back reattaches on a live transport (or dials
+ * fresh) instead of discovering the death as an attach EOF.
+ *
+ * ONE-TRANSPORT safety: only force-disconnect the pooled lease when NO live
+ * holder remains ([leaseKeyStillInUse] false — neither the foreground session
+ * nor a sibling cached runtime holds this key). A shared transport that is
+ * genuinely dead is owned by the foreground session's own recovery; the
+ * same-host silent-corpse race is caught by the attach-EOF fallback, never by
+ * killing a transport the active session is still using.
+ */
+internal fun handleParkedRuntimeDeath(
+    key: RuntimeHealthKey,
+    leaseKey: SshLeaseKey?,
+    cause: RuntimeDeathCause,
+    runtimeCache: TmuxSessionRuntimeCache,
+    // Lease keys the foreground/connecting session currently holds — a shared one
+    // must NOT be force-disconnected.
+    foregroundLeaseKeys: Set<SshLeaseKey>,
+    disconnectLease: suspend (SshLeaseKey) -> Unit,
+    launchContained: (suspend () -> Unit) -> Unit,
+) {
+    val removed = runtimeCache.removeSession(key.hostId, key.sessionName)
+    DiagnosticEvents.record(
+        "connection",
+        "parked_runtime_death",
+        "source" to "parked_health_subscriber",
+        "cause" to cause.name,
+        "hostId" to key.hostId,
+        "session" to key.sessionName,
+        "evictedRuntimes" to removed.size,
+    )
+    ReconnectCauseTrail.record(
+        stage = "parked_runtime_health",
+        outcome = "proactive_evict",
+        cause = cause.name,
+        "hostId" to key.hostId,
+    )
+    val evictedLeaseKey = leaseKey ?: removed.firstNotNullOfOrNull { it.lease?.key }
+    launchContained {
+        // closeCachedRuntime releases the lease REF (decrement refcount) — never a
+        // raw pool disconnect that would nuke a shared transport.
+        removed.forEach { runCatching { it.closeCachedRuntime() } }
+        val stillShared = evictedLeaseKey != null && (
+            evictedLeaseKey in foregroundLeaseKeys ||
+                runtimeCache.cachedRuntimesForHost(key.hostId).any { it.lease?.key == evictedLeaseKey }
+            )
+        if (evictedLeaseKey != null && !stillShared) {
+            disconnectLease(evictedLeaseKey)
+        }
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionRuntimeModels.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionRuntimeModels.kt
@@ -2,6 +2,7 @@ package com.pocketshell.app.tmux
 
 import com.pocketshell.app.sessions.LeaseSessionTarget
 import com.pocketshell.app.tmux.TmuxSessionViewModel.ConnectionTarget
+import com.pocketshell.core.connection.RuntimeHealthKey
 import com.pocketshell.core.tmux.TmuxClient
 
 /**
@@ -51,6 +52,17 @@ internal fun ConnectionTarget.toRuntimeKey(): TmuxRuntimeKey =
         sessionName = sessionName,
         durableSessionKey = durableSessionKey(),
     )
+
+/**
+ * Issue #1537 (option b): the parked-runtime health identity for this target.
+ * Keyed on host + tmux session name so it aligns with the runtime cache's
+ * per-session eviction grain (`removeSession`).
+ */
+internal fun ConnectionTarget.toHealthKey(): RuntimeHealthKey =
+    RuntimeHealthKey(hostId = hostId, sessionName = sessionName)
+
+internal fun TmuxRuntimeKey.toHealthKey(): RuntimeHealthKey =
+    RuntimeHealthKey(hostId = hostId, sessionName = sessionName)
 
 internal fun targetLogFields(target: ConnectionTarget): String = buildString {
     append("hostId=")

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionSupport.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionSupport.kt
@@ -759,15 +759,10 @@ internal const val ISSUE_464_KILL_TAG: String = "issue464-killsession"
 
 internal val DEFAULT_AUTO_RECONNECT_DELAYS_MS: List<Long> = listOf(0L, 1_000L, 2_000L, 5_000L)
 
-/**
- * Issue #621 / #634 / #636 (Slice 4): how many consecutive transparent
- * stale-lease re-dials an open/switch attach may trigger before concluding the
- * host is genuinely dead and surfacing the manual Reconnect affordance. A
- * silently-dead warm lease normally heals on the FIRST fresh transport, so a
- * small cap is enough; it exists only to stop a permanently-broken host from
- * looping forever (each fresh transport also EOFing).
- */
-internal const val STALE_LEASE_AUTO_RECOVER_MAX: Int = 2
+// Issue #1537 (option b, D22 hard-cut): the bespoke `STALE_LEASE_AUTO_RECOVER_MAX`
+// two-counter budget is DELETED. Loop protection for the residual attach-EOF
+// fallback is the SINGLE #1328 auto-reconnect ladder's own budget (the
+// [AutoReconnect] re-dial cannot re-enter the fallback arm), not a parallel seam.
 
 /**
  * Issue #1185: how many times the selected session may transparently re-dial its

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -72,6 +72,7 @@ import com.pocketshell.app.tmux.connection.NetworkChangeEffects
 import com.pocketshell.app.tmux.connection.KEEPALIVE_DEATH_REDIAL_QUIET_RESET_MS
 import com.pocketshell.app.tmux.connection.KeepaliveDeathRedialAmortizer
 import com.pocketshell.app.tmux.connection.NetworkLossBandDebouncer
+import com.pocketshell.app.tmux.connection.ParkedRuntimeHealthEffects
 import com.pocketshell.app.tmux.connection.isSameIdentityNetworkRestore
 import com.pocketshell.app.tmux.connection.recordNetworkRestoreReconnectStart
 import com.pocketshell.app.tmux.connection.recordNetworkRestoreRideThrough
@@ -95,6 +96,9 @@ import com.pocketshell.core.connection.ConnectionState as CoreConnectionState
 import com.pocketshell.core.connection.HostKey
 import com.pocketshell.core.connection.LivenessProbe
 import com.pocketshell.core.connection.RevealState
+import com.pocketshell.core.connection.RuntimeDeathCause
+import com.pocketshell.core.connection.RuntimeHealthKey
+import com.pocketshell.core.connection.RuntimeHealthLedger
 import com.pocketshell.core.connection.SessionId
 import com.pocketshell.core.assistant.AssistantLlmClientFactory
 import com.pocketshell.core.storage.dao.HostDao
@@ -1973,19 +1977,6 @@ public class TmuxSessionViewModel @Inject constructor(
     // connect attempt so a stale cause never leaks into a later decision.
     private var lastConnectFailureCause: Throwable? = null
 
-    // Issue #621 / #634 / #636 (Slice 4): how many consecutive transparent
-    // stale-lease auto-recoveries we have already kicked off for the current
-    // connect chain. A warm SSH lease can be silently dead — its transport
-    // keeps reporting `isConnected` until sshj's 60s keepalive trips — so the
-    // first `tmux -CC` open / `list-panes` over it EOFs. Rather than stranding
-    // the user on a Disconnected band + manual Reconnect, the open/switch
-    // attach evicts the poisoned lease and re-dials a FRESH transport
-    // transparently (via [scheduleAutoReconnect]). This counter caps how many
-    // times we do that before concluding the host is genuinely dead and
-    // falling back to the manual Reconnect affordance, so a permanently-broken
-    // host cannot loop forever. Reset to 0 on a successful attach.
-    private var staleLeaseAutoRecoverAttempts: Int = 0
-
     // Issue #1185: how many times the SELECTED session has transparently
     // re-dialled after its lease acquire was woken with a coalesced-connect
     // cancel (the create-then-switch supersede). The pool slot is already
@@ -1993,7 +1984,7 @@ public class TmuxSessionViewModel @Inject constructor(
     // first retry; the cap only stops a pathological repeat (a host that keeps
     // getting its in-flight connect cancelled) from looping forever, at which
     // point the honest terminal error + working Retry surfaces. Reset to 0 on a
-    // successful attach (alongside [staleLeaseAutoRecoverAttempts]).
+    // successful attach.
     private var coalescedCancelRedialAttempts: Int = 0
 
     // Issue #145: whether [reconnect] would result in a new connect
@@ -3023,10 +3014,9 @@ public class TmuxSessionViewModel @Inject constructor(
         target: ConnectionTarget,
         trigger: TmuxConnectTrigger,
     ) {
-        // Issue #621 / #634 / #636 (Slice 4): a successful attach means the
-        // stale-lease heal worked (or was never needed), so the budget resets
-        // for the next connect chain.
-        staleLeaseAutoRecoverAttempts = 0
+        // Issue #1185: a successful attach means the coalesced-cancel re-dial
+        // worked (or was never needed), so its budget resets for the next chain.
+        // (The #1537 hard-cut deleted the sibling stale-lease counter reset.)
         coalescedCancelRedialAttempts = 0
         lifecycleReattachNetworkCoalesce =
             if (trigger == TmuxConnectTrigger.LifecycleReattach) {
@@ -5324,6 +5314,20 @@ public class TmuxSessionViewModel @Inject constructor(
         quietResetMs = { keepaliveDeathQuietResetMs },
     )
 
+    // Issue #1537 (option b): the parked-runtime health ledger + edge subscriber.
+    // A parked death edge marks the ledger Dead and calls [onParkedRuntimeDeath] to
+    // evict the corpse before switch-back (the `stale_lease_attach_eof` flap becomes
+    // a proactive calm heal); the residual silent-TCP race falls to the attach-EOF
+    // fallback (single ladder).
+    private val runtimeHealthLedger = RuntimeHealthLedger()
+
+    private val parkedRuntimeHealthEffects = ParkedRuntimeHealthEffects(
+        scope = viewModelScope,
+        ledger = runtimeHealthLedger,
+        leaseStateEvents = sshLeaseManager.stateEvents,
+        onDeath = ::onParkedRuntimeDeath,
+    )
+
     /**
      * Issue #1533: cross-episode amortization for the SAME-IDENTITY network-restore
      * redial (the "V2" busy-session flap) — the #928/#1522 debounce shape, distinct
@@ -5587,6 +5591,7 @@ public class TmuxSessionViewModel @Inject constructor(
                 trigger = trigger,
                 detail = "source=runtime_cache reason=disconnected",
             )
+            parkedRuntimeHealthEffects.onEvicted(cached.key.toHealthKey()) // #1537 unbind
             // Issue #935 R1: contained — closing a stale cached runtime issues
             // `detach-client`/close IO against a dead transport.
             launchContainedTeardown {
@@ -5616,6 +5621,7 @@ public class TmuxSessionViewModel @Inject constructor(
                 trigger = trigger,
                 detail = "source=runtime_cache reason=health_probe_failed",
             )
+            parkedRuntimeHealthEffects.onEvicted(cached.key.toHealthKey()) // #1537 unbind
             runCatching { cached.client.close() }
             // Issue #935 R1: contained — closing the unhealthy cached runtime +
             // disconnecting its lease is teardown IO against a dead transport.
@@ -5627,6 +5633,7 @@ public class TmuxSessionViewModel @Inject constructor(
             }
             return false
         }
+        parkedRuntimeHealthEffects.onActivated(cached.key.toHealthKey()) // #1537 activated
         val startedAtMs = SystemClock.elapsedRealtime()
         val milestoneStartedAtMs = visibleSwitchStartedAtMs.takeIf { it > 0L } ?: startedAtMs
         closeCachedRuntimesAsync(deactivateCurrentRuntimeToCache())
@@ -5797,6 +5804,12 @@ public class TmuxSessionViewModel @Inject constructor(
             remoteRows = remoteRows,
         )
         val evicted = runtimeCache.put(runtime)
+        // Issue #1537 (option b): bind the parked runtime's liveness edges.
+        parkedRuntimeHealthEffects.bindParked(
+            key = runtime.key.toHealthKey(),
+            client = runtime.client,
+            leaseKey = runtime.lease?.key ?: target.toSshLeaseTarget().leaseKey,
+        )
         leaseRef = null
         sessionRef = null
         clientRef = null
@@ -5890,6 +5903,8 @@ public class TmuxSessionViewModel @Inject constructor(
 
     private fun closeCachedRuntimesAsync(runtimes: List<CachedTmuxRuntime>) {
         if (runtimes.isEmpty()) return
+        // Issue #1537 (option b): cancel each evicted runtime's parked-health binding.
+        runtimes.forEach { parkedRuntimeHealthEffects.onEvicted(it.key.toHealthKey()) }
         // Issue #935 R1: contained — async eviction of deactivated cached
         // runtimes is teardown IO that may race the transport drop.
         launchContainedTeardown {
@@ -5898,6 +5913,27 @@ public class TmuxSessionViewModel @Inject constructor(
             }
         }
     }
+
+    // Issue #1537 (option b): parked-runtime death effect — delegates to the
+    // extracted [handleParkedRuntimeDeath] (kept out of the god-object, #1047).
+    private fun onParkedRuntimeDeath(
+        key: RuntimeHealthKey,
+        leaseKey: SshLeaseKey?,
+        cause: RuntimeDeathCause,
+    ) = handleParkedRuntimeDeath(
+        key = key,
+        leaseKey = leaseKey,
+        cause = cause,
+        runtimeCache = runtimeCache,
+        foregroundLeaseKeys = setOfNotNull(
+            activeTarget?.toSshLeaseTarget()?.leaseKey,
+            connectingTarget?.toSshLeaseTarget()?.leaseKey,
+        ),
+        disconnectLease = { key2 ->
+            withContext(NonCancellable) { runCatching { sshLeaseManager.disconnect(key2) } }
+        },
+        launchContained = { block -> launchContainedTeardown { block() } },
+    )
 
     private suspend fun closeCachedRuntimesBounded(runtimes: List<CachedTmuxRuntime>) {
         if (runtimes.isEmpty()) return
@@ -6829,6 +6865,13 @@ public class TmuxSessionViewModel @Inject constructor(
         // Issue #440: clear any prior failure so the retry decision keys off
         // this attempt only (mirrors [runConnect]).
         lastConnectFailureCause = null
+        // Issue #1537 (option b): consult the parked-health ledger before attach.
+        parkedRuntimeHealthEffects.consumeParkedDeath(target.toHealthKey())?.let { cause ->
+            ReconnectCauseTrail.record(
+                "parked_runtime_health", "switch_consult_dead", cause.name, trigger.logValue,
+                "hostId" to target.hostId,
+            )
+        }
         try {
             val lease = acquireLeaseForTmux(
                 target = target,
@@ -6985,33 +7028,23 @@ public class TmuxSessionViewModel @Inject constructor(
             )
         } catch (t: Throwable) {
             if (t is CancellationException) throw t
-            // Issue #621 / #634 / #636 (Slice 4): the fast-switch reuses the
-            // warm SSH session directly. When that session is silently dead
-            // (`session.isConnected` lies until sshj's 60s keepalive trips),
-            // the `tmux -CC` open / `list-panes` EOFs here. Rather than
-            // surfacing a Disconnected band + manual Reconnect, evict the
-            // poisoned lease and fall back to the full [runConnect] path on a
-            // FRESH transport — INLINE in this same coroutine so the heal is
-            // transparent and never re-enters a failing connect job. The
-            // budget cap keeps a genuinely-dead host from looping forever.
-            if (
-                isStaleChannelSymptom(t) &&
-                staleLeaseAutoRecoverAttempts < STALE_LEASE_AUTO_RECOVER_MAX
-            ) {
-                staleLeaseAutoRecoverAttempts += 1
+            // Issue #1537 (option b) — the silent-TCP-death FALLBACK: the switch
+            // reused a silently-dead warm session (no parked-health edge fired in
+            // the keepalive window), so the attach EOFs here. Route it into the
+            // SINGLE #1328 ladder as a CALM hold (not the old jarring [Connecting]
+            // overlay + cleared panes, not the deleted bespoke counter). The
+            // [AutoReconnect] re-dial cannot re-enter this arm (loop protection).
+            if (isStaleChannelSymptom(t) && !trigger.isReconnectTrigger) {
                 Log.i(
                     ISSUE_145_RECONNECT_TAG,
-                    "tmux-stale-lease-auto-recover fast-switch EOF -> fresh re-dial inline; " +
-                        "attempt=$staleLeaseAutoRecoverAttempts/$STALE_LEASE_AUTO_RECOVER_MAX " +
-                        "${targetLogFields(target)}",
+                    "tmux-stale-lease-fallback fast-switch EOF -> single-ladder re-dial; " +
+                        targetLogFields(target),
                 )
                 ReconnectCauseTrail.record(
                     stage = "stale_lease_auto_recover",
                     outcome = "fast_switch_fresh_redial",
                     cause = "stale_lease_attach_eof",
                     trigger = trigger.logValue,
-                    "attempt" to staleLeaseAutoRecoverAttempts,
-                    "maxAttempts" to STALE_LEASE_AUTO_RECOVER_MAX,
                     "hostId" to target.hostId,
                     "failureClass" to t.javaClass.simpleName,
                 )
@@ -7033,18 +7066,17 @@ public class TmuxSessionViewModel @Inject constructor(
                 }
                 connectingTarget = target
                 refreshReconnectAvailability()
-                // Escalate from the keep-frame [Switching] to the full-screen
-                // [Connecting] overlay: we are now doing a real fresh handshake.
-                submitControllerOpen(target)
+                // Calm hold: keep the [Attaching]/[Switching] band (the reveal
+                // machine holds the surface), so the silent-corpse fallback never
+                // flashes the full-screen [Connecting] overlay + cleared panes.
+                submitControllerSwitch(target)
                 setConnectionState(
-                    ConnectionState.Connecting(
+                    ConnectionState.Attaching(
                         target.host,
                         target.port,
                         target.user,
                     ),
                 )
-                _panes.value = emptyList()
-                rebuildUnifiedPanes()
                 // The poisoned pooled lease was disconnected above and the
                 // cached runtimes were dropped, so the pool is empty: an
                 // [AutoReconnect] dial (which does NOT re-run the synchronous
@@ -7302,19 +7334,22 @@ public class TmuxSessionViewModel @Inject constructor(
         // existing auto-reconnect machinery transparently instead of surfacing
         // Failed, so the heal is invisible to the user.
         //
-        // We only do this for the INITIAL user-facing open/switch (the
-        // not-yet-a-reconnect triggers). When the trigger is already a
-        // reconnect trigger, the [scheduleAutoReconnect] loop that invoked us
-        // owns the retry/exhaust decision — re-entering it here would
-        // double-drive the loop. The budget cap ([STALE_LEASE_AUTO_RECOVER_MAX])
-        // ensures a genuinely-dead host (every fresh transport also EOFs) falls
-        // back to the manual Reconnect affordance instead of looping forever.
-        if (shouldTransparentlyRecoverStaleLease(staleChannelSymptom, trigger)) {
-            staleLeaseAutoRecoverAttempts += 1
+        // Only for the INITIAL user-facing open/switch (not-yet-a-reconnect
+        // triggers); a reconnect trigger is owned by the [scheduleAutoReconnect]
+        // loop. Issue #1537 (option b, D22 hard-cut): loop protection is the
+        // SINGLE ladder's own budget, not the deleted bespoke
+        // `staleLeaseAutoRecoverAttempts` seam — the [AutoReconnect] re-dial
+        // cannot re-enter this arm, so a genuinely-dead host falls through to the
+        // honest terminal Disconnected band.
+        if (
+            staleChannelSymptom &&
+            appActive &&
+            autoReconnectDelaysMs.isNotEmpty() &&
+            !trigger.isReconnectTrigger
+        ) {
             Log.i(
                 ISSUE_145_RECONNECT_TAG,
-                "tmux-stale-lease-auto-recover transparent re-dial after stale attach EOF; " +
-                    "attempt=$staleLeaseAutoRecoverAttempts/$STALE_LEASE_AUTO_RECOVER_MAX " +
+                "tmux-stale-lease-fallback transparent re-dial after stale attach EOF; " +
                     "trigger=${trigger.logValue} ${targetLogFields(target)}",
             )
             ReconnectCauseTrail.record(
@@ -7322,8 +7357,6 @@ public class TmuxSessionViewModel @Inject constructor(
                 outcome = "transparent_redial",
                 cause = "stale_lease_attach_eof",
                 trigger = trigger.logValue,
-                "attempt" to staleLeaseAutoRecoverAttempts,
-                "maxAttempts" to STALE_LEASE_AUTO_RECOVER_MAX,
                 "hostId" to target.hostId,
                 "failureClass" to cause.javaClass.simpleName,
             )
@@ -7411,33 +7444,6 @@ public class TmuxSessionViewModel @Inject constructor(
         // the user has since navigated to another session.
         driveRevealTerminalError(target, cause)
     }
-
-    /**
-     * Issue #621 / #634 / #636 (Slice 4): decide whether to transparently
-     * re-dial a fresh SSH transport after an open/switch attach EOF'd on a
-     * silently-dead warm lease, instead of surfacing a Disconnected band.
-     *
-     * Conditions:
-     *  - the failure is a stale-channel symptom (transport alive-but-dead, the
-     *    `failConnectAttempt` caller already evicted the poisoned lease);
-     *  - the app is foregrounded (a backgrounded app must not burn re-dials —
-     *    [scheduleAutoReconnect] would pause anyway, but we avoid even starting);
-     *  - auto-reconnect is enabled (the user hasn't disabled it / a test hasn't
-     *    cleared the delays);
-     *  - the trigger is an INITIAL open/switch, not already a reconnect trigger
-     *    (those are owned by the in-flight [scheduleAutoReconnect] loop);
-     *  - the per-chain budget has not been exhausted, so a genuinely-dead host
-     *    cannot loop forever.
-     */
-    private fun shouldTransparentlyRecoverStaleLease(
-        staleChannelSymptom: Boolean,
-        trigger: TmuxConnectTrigger,
-    ): Boolean =
-        staleChannelSymptom &&
-            appActive &&
-            autoReconnectDelaysMs.isNotEmpty() &&
-            !trigger.isReconnectTrigger &&
-            staleLeaseAutoRecoverAttempts < STALE_LEASE_AUTO_RECOVER_MAX
 
     /**
      * Issue #1185: decide whether to transparently re-dial the SELECTED session's

--- a/app/src/main/java/com/pocketshell/app/tmux/connection/ParkedRuntimeHealthEffects.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/connection/ParkedRuntimeHealthEffects.kt
@@ -1,0 +1,154 @@
+package com.pocketshell.app.tmux.connection
+
+import com.pocketshell.core.connection.RuntimeDeathCause
+import com.pocketshell.core.connection.RuntimeHealthEvent
+import com.pocketshell.core.connection.RuntimeHealthKey
+import com.pocketshell.core.connection.RuntimeHealthLedger
+import com.pocketshell.core.ssh.SshLeaseCloseReason
+import com.pocketshell.core.ssh.SshLeaseConnectionState
+import com.pocketshell.core.ssh.SshLeaseKey
+import com.pocketshell.core.ssh.SshLeaseStateEvent
+import com.pocketshell.core.tmux.TmuxClient
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+
+/**
+ * Issue #1537 (option b): the parked-runtime health subscriber — the ONE piece
+ * the single [com.pocketshell.core.connection.ConnectionController] authority was
+ * missing.
+ *
+ * When a same-host session is parked into the runtime cache while another
+ * session is foreground, its liveness edges keep firing but nobody listens:
+ *
+ *  - the parked [TmuxClient]'s own `disconnected` StateFlow latches `true` on
+ *    the `-CC` reader EOF (control channel death AND tmux-server death), and
+ *  - the pool broadcasts a per-key `Closed(KeepaliveDead)`/`Closed` edge on
+ *    [leaseStateEvents] when the always-on keepalive declares the transport dead.
+ *
+ * This class binds those edges at park time and, on the first death edge,
+ * records the verdict in the single [ledger] and invokes [onDeath] so the VM can
+ * evict the corpse from the cache and release its lease ref BEFORE the user
+ * switches back — turning a switch-back attach EOF (the visible drop) into a
+ * proactive, calm heal.
+ *
+ * ## Termination (the #1517 virtual-time rule)
+ *
+ * Each binding is a [scope]-owned job whose two collectors use `first { … }`, so
+ * each has a natural terminal condition (the edge, or the binding cancel at
+ * activate/evict/death). There is NO unbounded re-arm loop — under virtual time a
+ * bound-but-unfired binding is idle (a suspended `first` on a quiet flow), and a
+ * fired death cancels its own binding.
+ *
+ * All state is confined to the ViewModel's single main dispatcher ([scope]); the
+ * ledger reduce + [onDeath] fire on that dispatcher, same discipline as the
+ * controller.
+ */
+internal class ParkedRuntimeHealthEffects(
+    private val scope: CoroutineScope,
+    private val ledger: RuntimeHealthLedger,
+    private val leaseStateEvents: SharedFlow<SshLeaseStateEvent>,
+    /**
+     * Invoked on the FIRST death edge for a parked key: the VM evicts the corpse
+     * runtime from the cache and releases its lease ref (and, when the lease key
+     * is no longer shared by the active session or a sibling cached runtime,
+     * force-disconnects the pooled transport so the switch-back dials fresh
+     * instead of reusing a vouched corpse). Never disconnects a transport still
+     * shared by the foreground session — that is the same-host residual race the
+     * attach-EOF fallback covers.
+     */
+    private val onDeath: (RuntimeHealthKey, SshLeaseKey?, RuntimeDeathCause) -> Unit,
+) {
+    private val bindings = mutableMapOf<RuntimeHealthKey, Job>()
+
+    /**
+     * Bind the liveness edges for a runtime being parked into the cache. Idempotent
+     * per key — a re-park cancels the prior binding and resets the ledger to Healthy.
+     */
+    fun bindParked(key: RuntimeHealthKey, client: TmuxClient, leaseKey: SshLeaseKey?) {
+        cancelBinding(key)
+        ledger.reduce(RuntimeHealthEvent.Parked(key))
+        bindings[key] = scope.launch {
+            coroutineScope {
+                launch { awaitClientDeath(key, client) }
+                launch { awaitLeaseDeath(key, leaseKey) }
+            }
+        }
+    }
+
+    /**
+     * The parked runtime is being ACTIVATED — the live path owns its liveness
+     * again. Cancel the binding and drop it from the ledger (a Dead entry would
+     * not activate; it fell out via the health probe first).
+     */
+    fun onActivated(key: RuntimeHealthKey) {
+        cancelBinding(key)
+        ledger.reduce(RuntimeHealthEvent.Cleared(key))
+    }
+
+    /**
+     * The parked runtime is leaving the cache WITHOUT a detected death (TTL,
+     * host overflow, twin prune, or an explicit evict). Cancel the binding.
+     * A sticky [RuntimeDeathCause] verdict is preserved so an imminent
+     * switch-back can still consult it; a still-Healthy entry is dropped.
+     */
+    fun onEvicted(key: RuntimeHealthKey) {
+        cancelBinding(key)
+        if (!ledger.isDead(key)) ledger.reduce(RuntimeHealthEvent.Cleared(key))
+    }
+
+    /**
+     * Consult-and-clear: if the parked runtime for [key] was proactively marked
+     * dead, return the cause (one-shot) so the switch path can present the calm
+     * hold; otherwise `null`.
+     */
+    fun consumeParkedDeath(key: RuntimeHealthKey): RuntimeDeathCause? = ledger.consumeDead(key)
+
+    fun isTracked(key: RuntimeHealthKey): Boolean = ledger.health(key) != null
+
+    /** Cancel every binding (VM teardown). */
+    fun cancelAll() {
+        bindings.values.forEach { it.cancel() }
+        bindings.clear()
+    }
+
+    private fun cancelBinding(key: RuntimeHealthKey) {
+        bindings.remove(key)?.cancel()
+    }
+
+    private suspend fun awaitClientDeath(key: RuntimeHealthKey, client: TmuxClient) {
+        // Suspends until the parked reader latches disconnected (or returns
+        // immediately if it already died before we bound). Terminal by nature.
+        client.disconnected.first { it }
+        fireDeath(key, leaseKeyHint = null, cause = RuntimeDeathCause.ClientDisconnected)
+    }
+
+    private suspend fun awaitLeaseDeath(key: RuntimeHealthKey, leaseKey: SshLeaseKey?) {
+        if (leaseKey == null) return
+        val event = leaseStateEvents.first {
+            it.key == leaseKey && it.state == SshLeaseConnectionState.Closed
+        }
+        val cause = when (event.closeReason) {
+            SshLeaseCloseReason.KeepaliveDead -> RuntimeDeathCause.KeepaliveDead
+            else -> RuntimeDeathCause.LeaseClosed
+        }
+        fireDeath(key, leaseKeyHint = leaseKey, cause = cause)
+    }
+
+    private fun fireDeath(
+        key: RuntimeHealthKey,
+        leaseKeyHint: SshLeaseKey?,
+        cause: RuntimeDeathCause,
+    ) {
+        // Idempotent: only the FIRST edge per binding wins.
+        if (ledger.isDead(key)) return
+        ledger.reduce(RuntimeHealthEvent.Died(key, cause))
+        // Terminal: stop both collectors for this key (this cancels the job we
+        // are running inside; the non-suspending [onDeath] below still runs).
+        cancelBinding(key)
+        onDeath(key, leaseKeyHint, cause)
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue1537ParkedRuntimeHealthTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue1537ParkedRuntimeHealthTest.kt
@@ -1,0 +1,335 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.app.diagnostics.installRecordingDiagnosticSink
+import com.pocketshell.app.sessions.ActiveTmuxClients
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.SshLeaseConnector
+import com.pocketshell.core.ssh.SshLeaseManager
+import com.pocketshell.core.ssh.SshLeaseTarget
+import com.pocketshell.core.ssh.SshPortForward
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshShell
+import com.pocketshell.core.tmux.TmuxClientException
+import com.pocketshell.core.tmux.TmuxClientFactory
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+import java.io.InputStream
+
+/**
+ * Issue #1537 (option b): the parked-runtime blind spot — a session parked in
+ * the runtime cache while another is foreground had no machine watching its
+ * liveness, so its death was discovered only at switch-back as an attach EOF
+ * that forced a visible fresh redial
+ * (`stage=stale_lease_auto_recover cause=stale_lease_attach_eof
+ * outcome=fast_switch_fresh_redial`). This suite proves the two halves of the
+ * fix reproduce-first:
+ *
+ *  - the parked-client health subscriber marks the ledger Dead and evicts the
+ *    corpse PROACTIVELY while parked (Test B), and
+ *  - the residual silent-TCP-death race (no edge inside the keepalive window)
+ *    still EOFs on switch-back but now routes into the SINGLE ladder as a CALM
+ *    hold — never the jarring full-screen `Connecting` overlay of the deleted
+ *    bespoke two-counter seam (Test A, spike test v).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class Issue1537ParkedRuntimeHealthTest {
+
+    private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    @After
+    fun tearDown() {
+        factoryScope.cancel()
+    }
+
+    private fun runVmTest(body: suspend TestScope.() -> Unit) = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        LivenessProbeTestOverride.setAutoStartEnabledForTest(false)
+        try {
+            body()
+        } finally {
+            LivenessProbeTestOverride.clear()
+            Dispatchers.resetMain()
+        }
+    }
+
+    private fun newVm(
+        registry: ActiveTmuxClients,
+        sshLeaseManager: SshLeaseManager,
+        runtimeCache: TmuxSessionRuntimeCache,
+    ): TmuxSessionViewModel = TmuxSessionViewModel(
+        tmuxClientFactory = TmuxClientFactory(factoryScope),
+        activeTmuxClients = registry,
+        runtimeCache = runtimeCache,
+        sshLeaseManager = sshLeaseManager,
+        sessionLifecycleSignals = null,
+    ).also {
+        it.setSeedIoDispatcherForTest(Dispatchers.Main)
+    }
+
+    // ---------------------------------------------------------------------
+    // Test A — silent-corpse fallback (spike test v): the SAME-HOST fast switch
+    // over a silently-dead shared lease still EOFs, but the fallback is CALM
+    // (single ladder, no full-screen Connecting overlay, no infinite loop).
+    // ---------------------------------------------------------------------
+    @Test
+    fun sameHostFastSwitchSilentCorpseFallbackIsCalmSingleLadder() = runVmTest {
+        val firstSession = AlwaysConnectedSession(id = "first")
+        val freshSession = AlwaysConnectedSession(id = "fresh")
+        val connector = TwoSessionConnector(firstSession, freshSession)
+        val vm = newVm(
+            registry = ActiveTmuxClients(),
+            sshLeaseManager = testLeaseManager(connector = connector, scope = this, idleTtlMillis = 60_000L),
+            runtimeCache = TmuxSessionRuntimeCache(),
+        )
+        vm.setAutoReconnectDelaysForTest(listOf(0L))
+
+        val sessionAClient = FakeTmuxClient().withSinglePaneRow("alpha", "%1")
+        val recoveredBClient = FakeTmuxClient().withSinglePaneRow("beta", "%2")
+        vm.setTmuxClientFactoryForTest { session, sessionName, _ ->
+            when {
+                session === firstSession && sessionName == "alpha" -> sessionAClient
+                session === firstSession && sessionName == "beta" ->
+                    // The silently-dead shared transport EOFs on the switch attach.
+                    FakeTmuxClient().apply {
+                        closeAndThrowOnCommandPrefix = "list-panes"
+                        closeAndThrowException = TmuxClientException(
+                            "failed to write tmux command `list-panes`: Getting data on EOF'ed stream",
+                        )
+                    }
+                session === freshSession && sessionName == "beta" -> recoveredBClient
+                else -> error("unexpected client request: $sessionName over $session")
+            }
+        }
+
+        vm.connect(
+            hostId = 1L, hostName = "alpha", host = "alpha.example", port = 22,
+            user = "alex", keyPath = "/keys/a", passphrase = null, sessionName = "alpha",
+        )
+        advanceUntilIdle()
+        assertTrue(
+            "session A must connect first",
+            vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+
+        val diagnostics = installRecordingDiagnosticSink()
+        val statuses = mutableListOf<TmuxSessionViewModel.ConnectionStatus>()
+        val collector = launch { vm.connectionStatus.collect { statuses.add(it) } }
+
+        // Switch to B over the silently-dead shared lease.
+        vm.connect(
+            hostId = 1L, hostName = "alpha", host = "alpha.example", port = 22,
+            user = "alex", keyPath = "/keys/a", passphrase = null, sessionName = "beta",
+        )
+        advanceUntilIdle()
+        collector.cancel()
+
+        // Recovers to B on a single fresh transport — no loop.
+        assertEquals("exactly one fresh redial (single ladder, no loop)", 2, connector.connectCount)
+        assertTrue(
+            "switch over a silent corpse must auto-recover to Connected on B, got ${vm.connectionStatus.value}",
+            vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+        assertEquals(listOf("%2"), vm.panes.value.map { it.paneId })
+
+        // The fallback DID fire (spike test v — the residual race is covered).
+        val trail = diagnostics.eventsNamed("cause_trail").filter {
+            it.fields["cause"] == "stale_lease_attach_eof"
+        }
+        assertEquals(
+            "the silent-corpse fallback fires exactly once (no bespoke counter loop)",
+            1,
+            trail.size,
+        )
+
+        // GREEN: the fallback is CALM — it NEVER surfaces the jarring full-screen
+        // Connecting overlay (the deleted first-arm behaviour). Only the calm
+        // Switching hold, then Connected.
+        assertFalse(
+            "the silent-corpse fallback must NOT flash the full-screen Connecting overlay; saw: " +
+                statuses.joinToString { it::class.simpleName ?: "?" },
+            statuses.any { it is TmuxSessionViewModel.ConnectionStatus.Connecting },
+        )
+        assertFalse(
+            "no Disconnected/Failed band on a recoverable silent corpse; saw: " +
+                statuses.joinToString { it::class.simpleName ?: "?" },
+            statuses.any { it is TmuxSessionViewModel.ConnectionStatus.Failed },
+        )
+        diagnostics.close()
+    }
+
+    // ---------------------------------------------------------------------
+    // Test B — proactive parked-runtime health: a same-host session parked while
+    // another is foreground has its DEATH known via the health-event subscriber
+    // and its corpse EVICTED before any switch-back.
+    // ---------------------------------------------------------------------
+    @Test
+    fun parkedRuntimeDeathIsDetectedAndEvictedWhileParked() = runVmTest {
+        val session = AlwaysConnectedSession(id = "shared")
+        val connector = TwoSessionConnector(session, AlwaysConnectedSession(id = "unused"))
+        val runtimeCache = TmuxSessionRuntimeCache()
+        val vm = newVm(
+            registry = ActiveTmuxClients(),
+            sshLeaseManager = testLeaseManager(connector = connector, scope = this, idleTtlMillis = 60_000L),
+            runtimeCache = runtimeCache,
+        )
+        vm.setAutoReconnectDelaysForTest(listOf(0L))
+
+        val alphaClient = FakeTmuxClient().withSinglePaneRow("alpha", "%1")
+        val betaClient = FakeTmuxClient().withSinglePaneRow("beta", "%2")
+        vm.setTmuxClientFactoryForTest { s, sessionName, _ ->
+            when (sessionName) {
+                "alpha" -> alphaClient
+                "beta" -> betaClient
+                else -> error("unexpected $sessionName over $s")
+            }
+        }
+
+        vm.connect(
+            hostId = 1L, hostName = "alpha", host = "alpha.example", port = 22,
+            user = "alex", keyPath = "/keys/a", passphrase = null, sessionName = "alpha",
+        )
+        advanceUntilIdle()
+
+        // Same-host switch to beta: alpha is PARKED into the runtime cache with
+        // its own client + a shared lease ref.
+        vm.connect(
+            hostId = 1L, hostName = "alpha", host = "alpha.example", port = 22,
+            user = "alex", keyPath = "/keys/a", passphrase = null, sessionName = "beta",
+        )
+        advanceUntilIdle()
+        val alphaKey = TmuxRuntimeKey(
+            hostId = 1L, hostname = "alpha.example", port = 22, username = "alex",
+            keyPath = "/keys/a", sessionName = "alpha",
+        )
+        assertTrue("alpha must be parked in the cache after the same-host switch", runtimeCache.contains(alphaKey))
+
+        val diagnostics = installRecordingDiagnosticSink()
+
+        // The parked alpha client's -CC reader EOFs while parked (the blind spot).
+        alphaClient.disconnectedSignal.value = true
+        advanceUntilIdle()
+
+        // The health subscriber marks it dead and evicts the corpse PROACTIVELY —
+        // before the user ever switches back.
+        assertFalse(
+            "the parked corpse must be evicted from the cache proactively (no switch-back needed)",
+            runtimeCache.contains(alphaKey),
+        )
+        val deaths = diagnostics.eventsNamed("parked_runtime_death")
+        assertEquals("the parked-health subscriber records exactly one death", 1, deaths.size)
+        assertEquals("ClientDisconnected", deaths.single().fields["cause"])
+        assertEquals(1L, deaths.single().fields["hostId"])
+        diagnostics.close()
+    }
+
+    // ---------------------------------------------------------------------
+    // Deleted-path proof (D28 single active path): the bespoke
+    // `staleLeaseAutoRecoverAttempts` two-counter seam is GONE.
+    // ---------------------------------------------------------------------
+    @Test
+    fun bespokeStaleLeaseCounterSeamIsDeleted() {
+        val fields = TmuxSessionViewModel::class.java.declaredFields.map { it.name }
+        assertFalse(
+            "the bespoke stale-lease two-counter field must be deleted (D22 hard-cut); found: $fields",
+            fields.any { it == "staleLeaseAutoRecoverAttempts" },
+        )
+    }
+
+    // ------------------------------- fakes -------------------------------
+
+    private fun FakeTmuxClient.withSinglePaneRow(
+        sessionName: String,
+        paneId: String,
+    ): FakeTmuxClient = apply {
+        responses.addLast(
+            com.pocketshell.core.tmux.CommandResponse(
+                number = 1L,
+                output = listOf("$paneId\t@0\t\$0\t$sessionName\t$sessionName\t0"),
+                isError = false,
+            ),
+        )
+        capturePaneResponses.addLast(
+            com.pocketshell.core.tmux.CommandResponse(number = 2L, output = listOf("$sessionName ready"), isError = false),
+        )
+        cursorQueryResponses.addLast(
+            com.pocketshell.core.tmux.CommandResponse(number = 3L, output = listOf("0,0"), isError = false),
+        )
+    }
+
+    private class TwoSessionConnector(
+        private val first: SshSession,
+        private val second: SshSession,
+    ) : SshLeaseConnector {
+        var connectCount: Int = 0
+            private set
+
+        override suspend fun connect(target: SshLeaseTarget): Result<SshSession> {
+            val next = when (connectCount) {
+                0 -> first
+                1 -> second
+                else -> error("unexpected lease connect $connectCount for ${target.leaseKey}")
+            }
+            connectCount += 1
+            return Result.success(next)
+        }
+    }
+
+    private class AlwaysConnectedSession(val id: String) : SshSession {
+        @Volatile
+        var closed: Boolean = false
+
+        override val isConnected: Boolean get() = !closed
+
+        override suspend fun exec(command: String): ExecResult =
+            ExecResult(stdout = "", stderr = "", exitCode = 0)
+
+        override fun tail(path: String, onLine: (String) -> Unit): Job =
+            Job().apply { complete() }
+
+        override fun tail(path: String, fromLineExclusive: Long, onLine: (String) -> Unit): Job =
+            Job().apply { complete() }
+
+        override fun openLocalPortForward(
+            remoteHost: String,
+            remotePort: Int,
+            localPort: Int,
+        ): SshPortForward = error("not used")
+
+        override fun startShell(): SshShell = error("not used")
+
+        override suspend fun uploadFile(file: File, remotePath: String): String = error("not used")
+
+        override suspend fun uploadStream(
+            input: InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String = error("not used")
+
+        override fun close() {
+            closed = true
+        }
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/ParkedRuntimeDeathHandlerTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/ParkedRuntimeDeathHandlerTest.kt
@@ -1,0 +1,261 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.core.connection.RuntimeDeathCause
+import com.pocketshell.core.connection.RuntimeHealthKey
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.SshKey
+import com.pocketshell.core.ssh.SshLeaseConnector
+import com.pocketshell.core.ssh.SshLeaseKey
+import com.pocketshell.core.ssh.SshLeaseTarget
+import com.pocketshell.core.ssh.SshPortForward
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshShell
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+import java.io.InputStream
+
+/**
+ * Issue #1537 (option b) — the CATASTROPHIC-IF-WRONG safety property, given a
+ * direct executing assertion (reviewer Blocker 1).
+ *
+ * [handleParkedRuntimeDeath] evicts a dead parked runtime and releases its lease
+ * ref, and force-disconnects the pooled transport ONLY when no live holder still
+ * shares the lease key (`stillShared` false). The load-bearing invariant: a
+ * parked runtime is ALWAYS same-host as the foreground session that replaced it,
+ * so it SHARES the refcounted transport — force-disconnecting that transport on
+ * the parked death would kill the LIVE foreground session. This suite proves the
+ * `stillShared` gate directly, not by inspection:
+ *
+ *  - same-host, the FOREGROUND still holds the key      -> disconnect WITHHELD,
+ *    the shared live transport SURVIVES (Test A);
+ *  - same-host, a SIBLING cached runtime still holds it -> disconnect WITHHELD
+ *    (Test B, the `cachedRuntimesForHost` arm of `stillShared`);
+ *  - foreign / sole-holder, NO live holder shares it    -> disconnect FIRES,
+ *    the corpse transport is killed so the switch-back dials fresh (Test C).
+ *
+ * Reproduce-first (D33/G10): neutralizing the `stillShared` guard in
+ * [handleParkedRuntimeDeath] (forcing it to `false`) makes Test A go RED — the
+ * shared live transport gets force-disconnected. This is the exact regression
+ * (foreground session's transport killed) the guard exists to prevent, so it has
+ * an executing assertion here, never only inspection.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class ParkedRuntimeDeathHandlerTest {
+
+    private val leaseKey = SshLeaseKey(
+        host = "alpha.example",
+        port = 22,
+        user = "alex",
+        credentialId = "1:/keys/a",
+    )
+
+    // The parked runtime that just died: session "alpha" on host 1.
+    private val deadKey = RuntimeHealthKey(hostId = 1L, sessionName = "alpha")
+
+    // -------------------------------------------------------------------------
+    // Test A — same-host, the FOREGROUND session still holds the shared lease
+    // key: force-disconnect MUST be withheld; the live transport SURVIVES.
+    // -------------------------------------------------------------------------
+    @Test
+    fun sameHostForegroundHoldsKey_forceDisconnectWithheld_sharedLiveTransportSurvives() = runTest {
+        val sharedTransport = FakeSession()
+        val disconnectedKeys = mutableListOf<SshLeaseKey>()
+
+        handleParkedRuntimeDeath(
+            key = deadKey,
+            leaseKey = leaseKey,
+            cause = RuntimeDeathCause.ClientDisconnected,
+            runtimeCache = TmuxSessionRuntimeCache(),
+            // The FOREGROUND (or connecting) session shares the SAME host/key —
+            // this is the always-true condition for a same-host parked runtime.
+            foregroundLeaseKeys = setOf(leaseKey),
+            disconnectLease = { k ->
+                disconnectedKeys += k
+                if (k == leaseKey) sharedTransport.close()
+            },
+            launchContained = { block -> launch { block() } },
+        )
+        advanceUntilIdle()
+
+        assertTrue(
+            "a parked death on a lease the FOREGROUND still holds must NOT force-disconnect it; " +
+                "force-disconnected keys=$disconnectedKeys",
+            disconnectedKeys.isEmpty(),
+        )
+        assertTrue(
+            "the SHARED LIVE transport of the foreground session MUST survive a same-host " +
+                "parked-runtime death — force-disconnecting it would kill the live session",
+            sharedTransport.isConnected,
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // Test B — same-host, a SIBLING cached runtime (different session, same host)
+    // still holds the shared lease key: force-disconnect MUST be withheld. This
+    // exercises the `cachedRuntimesForHost(...).any { it.lease?.key == ... }` arm
+    // of `stillShared` using a REAL acquired lease.
+    // -------------------------------------------------------------------------
+    @Test
+    fun sameHostSiblingCachedRuntimeHoldsKey_forceDisconnectWithheld() = runTest {
+        val transport = FakeSession()
+        val leaseManager = testLeaseManager(
+            connector = SshLeaseConnector { Result.success(transport) },
+            scope = this,
+        )
+        val lease = leaseManager
+            .acquire(SshLeaseTarget(leaseKey = leaseKey, key = SshKey.Path(File("/keys/a"))))
+            .getOrThrow()
+        advanceUntilIdle()
+
+        val cache = TmuxSessionRuntimeCache()
+        // A DIFFERENT same-host session ("beta") is parked holding the SAME
+        // shared lease. The dying runtime is "alpha" (not cached here) — so
+        // removeSession(1,"alpha") returns nothing and the beta corpse-share
+        // must still WITHHOLD the force-disconnect.
+        cache.put(siblingRuntime(sessionName = "beta", lease = lease))
+
+        val disconnectedKeys = mutableListOf<SshLeaseKey>()
+        handleParkedRuntimeDeath(
+            key = deadKey,
+            leaseKey = lease.key,
+            cause = RuntimeDeathCause.ClientDisconnected,
+            runtimeCache = cache,
+            // The foreground does NOT hold it here — the ONLY live holder is the
+            // sibling cached runtime, which must still block the disconnect.
+            foregroundLeaseKeys = emptySet(),
+            disconnectLease = { k -> disconnectedKeys += k },
+            launchContained = { block -> launch { block() } },
+        )
+        advanceUntilIdle()
+
+        assertTrue(
+            "a sibling cached runtime still sharing the transport must WITHHOLD force-disconnect; " +
+                "force-disconnected keys=$disconnectedKeys",
+            disconnectedKeys.isEmpty(),
+        )
+        assertTrue(
+            "the shared transport a sibling cached runtime still holds must survive",
+            transport.isConnected,
+        )
+        lease.release()
+    }
+
+    // -------------------------------------------------------------------------
+    // Test C — foreign / sole-holder: NO live holder shares the lease key, so the
+    // parked corpse's pooled transport MUST be force-disconnected (the switch-back
+    // then dials fresh instead of reusing a vouched corpse).
+    // -------------------------------------------------------------------------
+    @Test
+    fun foreignSoleHolder_forceDisconnectFires_corpseTransportKilled() = runTest {
+        val corpseTransport = FakeSession()
+        val disconnectedKeys = mutableListOf<SshLeaseKey>()
+
+        handleParkedRuntimeDeath(
+            key = deadKey,
+            leaseKey = leaseKey,
+            cause = RuntimeDeathCause.KeepaliveDead,
+            runtimeCache = TmuxSessionRuntimeCache(),
+            // No foreground/connecting session shares this key, and no sibling
+            // cached runtime holds it -> sole holder -> disconnect must fire.
+            foregroundLeaseKeys = emptySet(),
+            disconnectLease = { k ->
+                disconnectedKeys += k
+                if (k == leaseKey) corpseTransport.close()
+            },
+            launchContained = { block -> launch { block() } },
+        )
+        advanceUntilIdle()
+
+        assertEquals(
+            "a foreign / sole-holder parked corpse MUST force-disconnect exactly its lease key",
+            listOf(leaseKey),
+            disconnectedKeys,
+        )
+        assertFalse(
+            "a sole-holder corpse transport MUST be force-disconnected so the switch-back dials fresh",
+            corpseTransport.isConnected,
+        )
+    }
+
+    // ------------------------------- fakes -----------------------------------
+
+    private fun siblingRuntime(
+        sessionName: String,
+        lease: com.pocketshell.core.ssh.SshLease,
+        hostId: Long = 1L,
+    ): CachedTmuxRuntime = CachedTmuxRuntime(
+        key = TmuxRuntimeKey(
+            hostId = hostId,
+            hostname = "alpha.example",
+            port = 22,
+            username = "alex",
+            keyPath = "/keys/a",
+            sessionName = sessionName,
+        ),
+        hostName = "alpha",
+        startDirectory = null,
+        session = null,
+        client = FakeTmuxClient(),
+        panes = emptyList(),
+        paneRows = emptyMap(),
+        paneProducerJobs = emptyMap(),
+        paneInputQueues = emptyMap(),
+        paneInputJobs = emptyMap(),
+        paneAgentJobs = emptyMap(),
+        paneAgentInputs = emptyMap(),
+        agentConversations = emptyMap(),
+        remoteColumns = 0,
+        remoteRows = 0,
+        lease = lease,
+    )
+
+    private class FakeSession : SshSession {
+        @Volatile
+        var closed: Boolean = false
+
+        override val isConnected: Boolean get() = !closed
+
+        override suspend fun exec(command: String): ExecResult =
+            ExecResult(stdout = "", stderr = "", exitCode = 0)
+
+        override fun tail(path: String, onLine: (String) -> Unit): Job =
+            Job().apply { complete() }
+
+        override fun tail(path: String, fromLineExclusive: Long, onLine: (String) -> Unit): Job =
+            Job().apply { complete() }
+
+        override fun openLocalPortForward(
+            remoteHost: String,
+            remotePort: Int,
+            localPort: Int,
+        ): SshPortForward = error("not used")
+
+        override fun startShell(): SshShell = error("not used")
+
+        override suspend fun uploadFile(file: File, remotePath: String): String = error("not used")
+
+        override suspend fun uploadStream(
+            input: InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String = error("not used")
+
+        override fun close() {
+            closed = true
+        }
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/connection/ParkedRuntimeHealthEffectsTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/connection/ParkedRuntimeHealthEffectsTest.kt
@@ -1,0 +1,182 @@
+package com.pocketshell.app.tmux.connection
+
+import com.pocketshell.app.tmux.FakeTmuxClient
+import com.pocketshell.core.connection.RuntimeDeathCause
+import com.pocketshell.core.connection.RuntimeHealthKey
+import com.pocketshell.core.connection.RuntimeHealthLedger
+import com.pocketshell.core.ssh.SshLeaseCloseReason
+import com.pocketshell.core.ssh.SshLeaseConnectionState
+import com.pocketshell.core.ssh.SshLeaseKey
+import com.pocketshell.core.ssh.SshLeaseStateEvent
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1537 (option b): the parked-runtime health subscriber. Proves the
+ * missing bind — a parked client's death edge and the pool's per-key Closed
+ * edge both drive the single ledger to Dead and fire the eviction callback
+ * exactly once, and that unbinding terminates cleanly under virtual time.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ParkedRuntimeHealthEffectsTest {
+
+    private val key = RuntimeHealthKey(hostId = 7L, sessionName = "beta")
+    private val leaseKey = SshLeaseKey(
+        host = "beta.example",
+        port = 22,
+        user = "alex",
+        credentialId = "7:/keys/a",
+    )
+
+    private class DeathCapture {
+        val calls = mutableListOf<Triple<RuntimeHealthKey, SshLeaseKey?, RuntimeDeathCause>>()
+        fun record(k: RuntimeHealthKey, lk: SshLeaseKey?, c: RuntimeDeathCause) {
+            calls += Triple(k, lk, c)
+        }
+    }
+
+    @Test
+    fun parkedClientDisconnectEdgeMarksDeadAndFiresEvictionOnce() = runTest {
+        val ledger = RuntimeHealthLedger()
+        val leaseEvents = MutableSharedFlow<SshLeaseStateEvent>(extraBufferCapacity = 16)
+        val capture = DeathCapture()
+        val effects = ParkedRuntimeHealthEffects(
+            scope = this,
+            ledger = ledger,
+            leaseStateEvents = leaseEvents,
+            onDeath = capture::record,
+        )
+        val client = FakeTmuxClient()
+
+        effects.bindParked(key, client, leaseKey)
+        advanceUntilIdle()
+        assertTrue("bind tracks the parked runtime as healthy", ledger.isHealthy(key))
+        assertTrue(capture.calls.isEmpty())
+
+        // The parked -CC reader EOFs while parked.
+        client.disconnectedSignal.value = true
+        advanceUntilIdle()
+
+        assertTrue("client-disconnect edge marks the parked runtime Dead", ledger.isDead(key))
+        assertEquals(RuntimeDeathCause.ClientDisconnected, ledger.deadCause(key))
+        assertEquals("eviction callback fires exactly once", 1, capture.calls.size)
+        assertEquals(key, capture.calls.single().first)
+
+        // A second edge (a late lease Closed) must NOT double-fire.
+        leaseEvents.emit(
+            SshLeaseStateEvent(leaseKey, SshLeaseConnectionState.Closed, SshLeaseCloseReason.KeepaliveDead),
+        )
+        advanceUntilIdle()
+        assertEquals("idempotent — no double eviction", 1, capture.calls.size)
+    }
+
+    @Test
+    fun keepaliveDeadLeaseEdgeMarksDeadWithKeepaliveCause() = runTest {
+        val ledger = RuntimeHealthLedger()
+        val leaseEvents = MutableSharedFlow<SshLeaseStateEvent>(extraBufferCapacity = 16)
+        val capture = DeathCapture()
+        val effects = ParkedRuntimeHealthEffects(this, ledger, leaseEvents, capture::record)
+
+        effects.bindParked(key, FakeTmuxClient(), leaseKey)
+        advanceUntilIdle()
+
+        leaseEvents.emit(
+            SshLeaseStateEvent(leaseKey, SshLeaseConnectionState.Closed, SshLeaseCloseReason.KeepaliveDead),
+        )
+        advanceUntilIdle()
+
+        assertTrue(ledger.isDead(key))
+        assertEquals(RuntimeDeathCause.KeepaliveDead, ledger.deadCause(key))
+        assertEquals(1, capture.calls.size)
+        assertEquals(leaseKey, capture.calls.single().second)
+    }
+
+    @Test
+    fun aClosedEdgeForADifferentKeyIsIgnored() = runTest {
+        val ledger = RuntimeHealthLedger()
+        val leaseEvents = MutableSharedFlow<SshLeaseStateEvent>(extraBufferCapacity = 16)
+        val capture = DeathCapture()
+        val effects = ParkedRuntimeHealthEffects(this, ledger, leaseEvents, capture::record)
+        effects.bindParked(key, FakeTmuxClient(), leaseKey)
+        advanceUntilIdle()
+
+        val otherKey = SshLeaseKey("other.example", 22, "alex", "9:/keys/b")
+        leaseEvents.emit(SshLeaseStateEvent(otherKey, SshLeaseConnectionState.Closed))
+        advanceUntilIdle()
+
+        assertTrue("a foreign key's Closed edge must not kill this parked runtime", ledger.isHealthy(key))
+        assertTrue(capture.calls.isEmpty())
+
+        // A bound-but-unfired runtime is an active binding until VM teardown.
+        effects.cancelAll()
+    }
+
+    @Test
+    fun activatingUnbindsAndClearsWithoutFiringDeath() = runTest {
+        val ledger = RuntimeHealthLedger()
+        val leaseEvents = MutableSharedFlow<SshLeaseStateEvent>(extraBufferCapacity = 16)
+        val capture = DeathCapture()
+        val effects = ParkedRuntimeHealthEffects(this, ledger, leaseEvents, capture::record)
+        val client = FakeTmuxClient()
+        effects.bindParked(key, client, leaseKey)
+        advanceUntilIdle()
+
+        effects.onActivated(key)
+        advanceUntilIdle()
+        assertNull("activation drops the ledger entry", ledger.health(key))
+
+        // A death edge AFTER unbind must not fire (the collector is cancelled).
+        client.disconnectedSignal.value = true
+        advanceUntilIdle()
+        assertTrue("no death after activation unbind", capture.calls.isEmpty())
+        assertFalse(ledger.isDead(key))
+    }
+
+    @Test
+    fun evictedPreservesAStickyDeadMarkerForSwitchBack() = runTest {
+        val ledger = RuntimeHealthLedger()
+        val leaseEvents = MutableSharedFlow<SshLeaseStateEvent>(extraBufferCapacity = 16)
+        val capture = DeathCapture()
+        val effects = ParkedRuntimeHealthEffects(this, ledger, leaseEvents, capture::record)
+        val client = FakeTmuxClient()
+        effects.bindParked(key, client, leaseKey)
+        advanceUntilIdle()
+
+        client.disconnectedSignal.value = true
+        advanceUntilIdle()
+        assertTrue(ledger.isDead(key))
+
+        // A plain evict of the corpse must not wipe the Dead marker — the
+        // switch-back still needs to consult it.
+        effects.onEvicted(key)
+        advanceUntilIdle()
+        assertEquals(RuntimeDeathCause.ClientDisconnected, effects.consumeParkedDeath(key))
+        assertNull("one-shot consult clears it", ledger.consumeDead(key))
+    }
+
+    @Test
+    fun bindingAnAlreadyDeadClientFiresImmediately() = runTest {
+        val ledger = RuntimeHealthLedger()
+        val leaseEvents = MutableSharedFlow<SshLeaseStateEvent>(extraBufferCapacity = 16)
+        val capture = DeathCapture()
+        val effects = ParkedRuntimeHealthEffects(this, ledger, leaseEvents, capture::record)
+        val client = FakeTmuxClient()
+        // The client already EOFed before we bound it (raced park/death).
+        client.disconnectedSignal.value = true
+
+        effects.bindParked(key, client, leaseKey)
+        advanceUntilIdle()
+
+        assertTrue("an already-dead parked client fires on bind", ledger.isDead(key))
+        assertEquals(1, capture.calls.size)
+
+        effects.cancelAll()
+    }
+}

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -142,7 +142,7 @@ FQCN_PREFIX="com.pocketshell.app.proof"
 JOURNEY_CLASSES=(
   "$FQCN_PREFIX.TmuxSessionScreenArtVerifyE2eTest"  # #1362 #1344 the ART dex-verification guard for the TmuxSessionScreen com…
   "$FQCN_PREFIX.DeepLinkSessionSwitchE2eTest"
-  "$FQCN_PREFIX.MultiSessionSwitchJourneyE2eTest"  # #710 the CI-AVD wedge was the unbounded VM-clear park teardown
+  "$FQCN_PREFIX.MultiSessionSwitchJourneyE2eTest"  # #710 the CI-AVD wedge was the unbounded VM-clear park teardown; #1537 also owns parkedRuntimeFastSwitchRing...NoStormStaleLease (option-b parked-corpse gate)
   "$FQCN_PREFIX.BackThenOpenSecondSessionReusesWarmLeaseE2eTest"  # #758 the maintainer's priority- back→open-another-session reconne…
   "$FQCN_PREFIX.ColdRestoreGoneSessionNoResurrectE2eTest"
   "$FQCN_PREFIX.LifecycleReattachGoneSessionNoResurrectE2eTest"  # #666 #998 a session killed on the host must NOT be

--- a/shared/core-connection/src/main/java/com/pocketshell/core/connection/RuntimeHealthLedger.kt
+++ b/shared/core-connection/src/main/java/com/pocketshell/core/connection/RuntimeHealthLedger.kt
@@ -1,0 +1,154 @@
+package com.pocketshell.core.connection
+
+/**
+ * Issue #1537 (option b): the parked-runtime health ledger.
+ *
+ * ## Why this exists
+ *
+ * The last unfixed connection-flap class is the **fast-switch stale-lease
+ * redial**: a session parked in the runtime cache while another session is
+ * foreground is a blind spot — no machine watches its liveness, so a parked
+ * runtime's death is only discovered at switch-back, as an attach EOF that
+ * forces a visible fresh redial (`stage=stale_lease_auto_recover
+ * cause=stale_lease_attach_eof outcome=fast_switch_fresh_redial`).
+ *
+ * Every liveness signal a parked runtime needs already fires while parked (the
+ * parked `TmuxClient`'s `-CC` reader still latches its `disconnected` StateFlow
+ * on EOF; the per-transport keepalive still runs; the lease pool still
+ * broadcasts per-key `Closed(KeepaliveDead)` edges). What was missing is a
+ * subscriber bound while parked plus a small health ledger consulted by the
+ * switch path. This is that ledger.
+ *
+ * ## Shape
+ *
+ * A pure, single-authority reducer mapping [RuntimeHealthKey] to
+ * [RuntimeHealth]. It holds NO IO, NO coroutines, NO android imports and NO
+ * time — the app-side `ParkedRuntimeHealthEffects` owns the edge subscriptions
+ * and feeds this reducer [RuntimeHealthEvent]s, then the switch path consults
+ * it. It is confined to the ViewModel's single main dispatcher (same discipline
+ * as [ConnectionController]); it is deliberately not internally synchronised.
+ *
+ * A [RuntimeHealthEvent.Died] verdict is **sticky** — it survives a plain
+ * [RuntimeHealthEvent.Cleared] eviction so an imminent switch-back can still
+ * consult it — and is cleared only by re-parking the key ([RuntimeHealthEvent.Parked])
+ * or by the one-shot [consumeDead].
+ */
+public class RuntimeHealthLedger {
+    private val states = linkedMapOf<RuntimeHealthKey, RuntimeHealth>()
+
+    /**
+     * Apply one [event] and return the resulting [RuntimeHealth] for its key
+     * (or `null` when the key is no longer tracked).
+     */
+    public fun reduce(event: RuntimeHealthEvent): RuntimeHealth? = when (event) {
+        is RuntimeHealthEvent.Parked -> {
+            // A fresh park always resets to Healthy — even over a stale Dead
+            // marker from a previous life of the same session.
+            states[event.key] = RuntimeHealth.Healthy
+            RuntimeHealth.Healthy
+        }
+        is RuntimeHealthEvent.Died -> {
+            val dead = RuntimeHealth.Dead(event.cause)
+            states[event.key] = dead
+            dead
+        }
+        is RuntimeHealthEvent.Cleared -> {
+            states.remove(event.key)
+            null
+        }
+    }
+
+    public fun health(key: RuntimeHealthKey): RuntimeHealth? = states[key]
+
+    public fun isHealthy(key: RuntimeHealthKey): Boolean = states[key] is RuntimeHealth.Healthy
+
+    public fun isDead(key: RuntimeHealthKey): Boolean = states[key] is RuntimeHealth.Dead
+
+    public fun deadCause(key: RuntimeHealthKey): RuntimeDeathCause? =
+        (states[key] as? RuntimeHealth.Dead)?.cause
+
+    /**
+     * One-shot consult: if [key] is currently [RuntimeHealth.Dead], remove the
+     * marker and return its cause; otherwise return `null`. The switch path
+     * uses this to decide, exactly once, that a parked runtime was known-dead
+     * before the switch-back attach so it can present the calm hold instead of
+     * discovering the death as an attach EOF.
+     */
+    public fun consumeDead(key: RuntimeHealthKey): RuntimeDeathCause? {
+        val dead = states[key] as? RuntimeHealth.Dead ?: return null
+        states.remove(key)
+        return dead.cause
+    }
+
+    public fun trackedKeys(): Set<RuntimeHealthKey> = states.keys.toSet()
+
+    public fun size(): Int = states.size
+}
+
+/**
+ * Stable, transport-agnostic identity of a parked runtime the ledger tracks.
+ * Keyed on host + tmux session name so it aligns with the runtime cache's
+ * per-session eviction grain (a session has exactly one live runtime).
+ */
+public data class RuntimeHealthKey(
+    val hostId: Long,
+    val sessionName: String,
+)
+
+public sealed interface RuntimeHealth {
+    public object Healthy : RuntimeHealth
+
+    public data class Dead(val cause: RuntimeDeathCause) : RuntimeHealth
+}
+
+/**
+ * How a parked runtime died. The switch path and diagnostics name the cause so
+ * a proactive heal is attributable in the connection log instead of surfacing
+ * only as an anonymous `stale_lease_attach_eof`.
+ */
+public enum class RuntimeDeathCause {
+    /**
+     * The parked client's own `-CC` reader latched `disconnected` — covers the
+     * control channel EOF AND tmux-server death (the login-scope teardown
+     * class), instantly and with zero new traffic.
+     */
+    ClientDisconnected,
+
+    /**
+     * The pool declared the parked lease's transport dead via the always-on
+     * keepalive watchdog (`Closed(KeepaliveDead)`) — covers a silent transport
+     * death within the keepalive's bound.
+     */
+    KeepaliveDead,
+
+    /** The pool closed the parked lease for any other reason. */
+    LeaseClosed,
+
+    /**
+     * The residual race (spike test v): a health-vouched parked lease was
+     * actually a silent corpse and only revealed itself as an attach EOF at
+     * switch-back. Recorded when the calm single-ladder fallback fires so the
+     * silent-death window is observable.
+     */
+    AttachEof,
+}
+
+public sealed interface RuntimeHealthEvent {
+    public val key: RuntimeHealthKey
+
+    /** A runtime was parked into the cache; begin tracking it as Healthy. */
+    public data class Parked(override val key: RuntimeHealthKey) : RuntimeHealthEvent
+
+    /** A liveness edge declared the parked runtime dead. */
+    public data class Died(
+        override val key: RuntimeHealthKey,
+        val cause: RuntimeDeathCause,
+    ) : RuntimeHealthEvent
+
+    /**
+     * The runtime left the cache without a detected death (activated, expired,
+     * overflowed, or explicitly evicted); stop tracking it. A sticky [Died]
+     * marker is preserved by the effects layer rather than sending this.
+     */
+    public data class Cleared(override val key: RuntimeHealthKey) : RuntimeHealthEvent
+}

--- a/shared/core-connection/src/test/java/com/pocketshell/core/connection/RuntimeHealthLedgerTest.kt
+++ b/shared/core-connection/src/test/java/com/pocketshell/core/connection/RuntimeHealthLedgerTest.kt
@@ -1,0 +1,100 @@
+package com.pocketshell.core.connection
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1537 (option b): pure reducer semantics of the parked-runtime health
+ * ledger. No IO, no coroutines — just the state machine the switch path trusts.
+ */
+class RuntimeHealthLedgerTest {
+
+    private val a = RuntimeHealthKey(hostId = 1L, sessionName = "alpha")
+    private val b = RuntimeHealthKey(hostId = 1L, sessionName = "beta")
+
+    @Test
+    fun parkedIsTrackedAsHealthy() {
+        val ledger = RuntimeHealthLedger()
+        assertNull("untracked key has no health", ledger.health(a))
+
+        ledger.reduce(RuntimeHealthEvent.Parked(a))
+        assertTrue(ledger.isHealthy(a))
+        assertFalse(ledger.isDead(a))
+        assertEquals(1, ledger.size())
+    }
+
+    @Test
+    fun diedMarksDeadWithCause() {
+        val ledger = RuntimeHealthLedger()
+        ledger.reduce(RuntimeHealthEvent.Parked(a))
+        ledger.reduce(RuntimeHealthEvent.Died(a, RuntimeDeathCause.KeepaliveDead))
+
+        assertTrue(ledger.isDead(a))
+        assertFalse(ledger.isHealthy(a))
+        assertEquals(RuntimeDeathCause.KeepaliveDead, ledger.deadCause(a))
+    }
+
+    @Test
+    fun clearedRemovesAHealthyKey() {
+        val ledger = RuntimeHealthLedger()
+        ledger.reduce(RuntimeHealthEvent.Parked(a))
+        ledger.reduce(RuntimeHealthEvent.Cleared(a))
+
+        assertNull(ledger.health(a))
+        assertEquals(0, ledger.size())
+    }
+
+    @Test
+    fun deadMarkerSurvivesClearedSoSwitchBackCanConsult() {
+        // The effects layer does NOT send Cleared for a Dead entry — it keeps
+        // the sticky marker for the imminent switch-back. Model that policy:
+        // even if a Cleared were sent, re-marking Dead restores it. The key
+        // property is that consumeDead is the one-shot the switch path uses.
+        val ledger = RuntimeHealthLedger()
+        ledger.reduce(RuntimeHealthEvent.Parked(a))
+        ledger.reduce(RuntimeHealthEvent.Died(a, RuntimeDeathCause.ClientDisconnected))
+
+        // First consult returns the cause and clears the marker.
+        assertEquals(RuntimeDeathCause.ClientDisconnected, ledger.consumeDead(a))
+        // Second consult sees nothing — it is one-shot, no leak.
+        assertNull(ledger.consumeDead(a))
+        assertNull(ledger.health(a))
+    }
+
+    @Test
+    fun consumeDeadIsNullForHealthyOrUntracked() {
+        val ledger = RuntimeHealthLedger()
+        assertNull("untracked", ledger.consumeDead(a))
+        ledger.reduce(RuntimeHealthEvent.Parked(a))
+        assertNull("healthy is not consumable", ledger.consumeDead(a))
+        assertTrue("healthy key still tracked after a no-op consult", ledger.isHealthy(a))
+    }
+
+    @Test
+    fun reParkResetsAStaleDeadMarker() {
+        val ledger = RuntimeHealthLedger()
+        ledger.reduce(RuntimeHealthEvent.Parked(a))
+        ledger.reduce(RuntimeHealthEvent.Died(a, RuntimeDeathCause.AttachEof))
+        assertTrue(ledger.isDead(a))
+
+        // A fresh park of the same session (a new live runtime) resets to healthy.
+        ledger.reduce(RuntimeHealthEvent.Parked(a))
+        assertTrue(ledger.isHealthy(a))
+        assertNull(ledger.consumeDead(a))
+    }
+
+    @Test
+    fun keysAreIndependent() {
+        val ledger = RuntimeHealthLedger()
+        ledger.reduce(RuntimeHealthEvent.Parked(a))
+        ledger.reduce(RuntimeHealthEvent.Parked(b))
+        ledger.reduce(RuntimeHealthEvent.Died(b, RuntimeDeathCause.LeaseClosed))
+
+        assertTrue("a stays healthy while b dies", ledger.isHealthy(a))
+        assertTrue(ledger.isDead(b))
+        assertEquals(setOf(a, b), ledger.trackedKeys())
+    }
+}


### PR DESCRIPTION
Closes the **last connection flap** — the fast-switch stale-lease redial (`stale_lease_attach_eof → fast_switch_fresh_redial`, 2× in the maintainer's log). **Maintainer chose option (b)**; Fable-spike-recommended.

**Fix:** bind the parked client's health edges (`disconnected` + pool `Closed(KeepaliveDead)`) into a single-authority `RuntimeHealthLedger`, so a parked runtime's death is known and its dead cached runtime evicted BEFORE switch-back. A parked runtime always shares the foreground session's refcounted transport, so proactive eviction **ref-releases and force-disconnects only when no live holder shares the key** — never kills the live transport; the same-host silent-TCP-death race routes into the calm single #1328 ladder (one redial, no storm). **Hard-cut** deletes the `staleLeaseAutoRecoverAttempts` seam (single active path). **VM net −53 lines.**

**Verification (2 review rounds; final APPROVED — #1537 comment 4964941659):**
- **Emulator A→B→C→A journey** (`connected-test.sh --suffix i1537`, agents:2222): `2/2`, **zero `stale_lease_attach_eof`, zero `fast_switch_fresh_redial`**, switch-back = warm reuse (`ssh_handshakes=0`), correct non-stale session, no Connecting overlay. `parked_runtime_death_events=0`.
- **Safety test red→green** (`ParkedRuntimeDeathHandlerTest`): shared live transport SURVIVES same-host death (withheld); foreign sole-holder → force-disconnect fires. Neutralizing `stillShared` turns both same-host tests red.
- Single-path hard-cut grep-clean; #1042/#1080/#1193 non-regression green; full `:app:testDebugUnitTest` no #1517 hang; VM-ratchet −53, file-size + test-validity exit 0. Connected test gate-wired into `ci-journey-suite.sh` (agents:2222, no self-skip).

Closes #1537
