### PR TITLE
core-ssh: stalled exec closes only its channel, not the shared session (#1562 root fix)

### DIFF
--- a/shared/core-ssh/src/integrationTest/java/com/pocketshell/core/ssh/KeepAliveIntegrationTest.kt
+++ b/shared/core-ssh/src/integrationTest/java/com/pocketshell/core/ssh/KeepAliveIntegrationTest.kt
@@ -1108,7 +1108,11 @@ class KeepAliveIntegrationTest {
  *    is delayed past the keepalive's local reply budget, which on base orphans the
  *    promise and desyncs the FIFO.
  */
-private class PausableTcpRelay(
+// Issue #1567: widened from `private` to `internal` so the exec-stall-containment
+// integration test (RealSshSessionExecStallContainmentIntegrationTest) can reuse
+// this proven in-JVM TCP relay to inject a REAL hard socket cut (a genuine
+// transport death) without duplicating the harness.
+internal class PausableTcpRelay(
     private val targetHost: String,
     private val targetPort: Int,
 ) : AutoCloseable {

--- a/shared/core-ssh/src/integrationTest/java/com/pocketshell/core/ssh/RealSshSessionExecStallContainmentIntegrationTest.kt
+++ b/shared/core-ssh/src/integrationTest/java/com/pocketshell/core/ssh/RealSshSessionExecStallContainmentIntegrationTest.kt
@@ -1,0 +1,318 @@
+package com.pocketshell.core.ssh
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.runBlocking
+import org.junit.AfterClass
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
+import org.junit.BeforeClass
+import org.junit.Test
+import org.testcontainers.DockerClientFactory
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.images.builder.ImageFromDockerfile
+import java.io.File
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.concurrent.thread
+
+/**
+ * Issue #1567 (D28 — root of the #1562 self-close reconnect storm), reproduce-first
+ * end-to-end against a real Docker OpenSSH server (the #1149 lesson: a
+ * close/session/transport CONTRACT change MUST be proven on the REAL
+ * [RealSshSession] via `:shared:core-ssh:integrationTest`, not just a unit fake).
+ *
+ * ## The bug
+ * [RealSshSession.exec] used to close the ENTIRE shared SSH session on a bounded
+ * no-progress stall. On a busy session the app runs constant execs on that one
+ * transport (agent-log reads, detection probes, attachment `cat>`/`wc`/`mv`), so
+ * a SINGLE stalled exec `close()`d the shared transport → the tmux `-CC` reader's
+ * blocking `read()` threw `SSHException` (client-local socket close) →
+ * passive_disconnect → reconnect. The host's sshd journal proved every drop was
+ * code 11 BY_APPLICATION (PocketShell's OWN disconnect), zero server/network
+ * errors — entirely self-inflicted.
+ *
+ * ## The load-bearing reproduction ([stalledExecClosesOnlyItsChannel...])
+ * Open a real session, start a long-lived sibling shell channel (the `-CC` reader
+ * stand-in) with a reader thread draining its stdout, then run an exec that
+ * stalls PAST its (short, injected) no-progress bound.
+ *
+ *  - **RED on base:** the stalled exec closes the whole session → the sibling
+ *    reader's `read()` throws (`SSHException`/`Stream closed`) and
+ *    `session.isConnected` flips false.
+ *  - **GREEN with the fix:** the stalled exec closes ONLY its own channel and
+ *    surfaces a retryable [SshExecTimeoutException]; the sibling reader keeps
+ *    receiving bytes, `session.isConnected` stays true, and a fresh exec still
+ *    round-trips on the SAME warm transport.
+ *
+ * ## Class coverage (G2)
+ * [genuineTransportDeathStillTearsTheSessionDown] proves the containment change
+ * does NOT mask a real death: a genuine hard socket cut (via [PausableTcpRelay])
+ * is still observable — a subsequent exec fails on the dead transport. The
+ * exec-timeout / exec-error / exec-cancel unit matrix (each MUST leave the shared
+ * transport alive) lives in `RealSshSessionExecReadTimeoutTest` +
+ * `RealSshSessionExecCancellationTest`.
+ *
+ * Wired into the per-push `Integration tests (Docker)` check via the
+ * `:shared:core-ssh:integrationTest` task (it runs all `*IntegrationTest`).
+ */
+class RealSshSessionExecStallContainmentIntegrationTest {
+
+    companion object {
+        private const val CONTAINER_SSH_PORT = 22
+
+        private val projectRoot: Path by lazy { findProjectRoot() }
+
+        @Volatile
+        private var container: GenericContainer<*>? = null
+
+        @BeforeClass
+        @JvmStatic
+        fun setUp() {
+            val dockerAvailable = runCatching {
+                DockerClientFactory.instance().isDockerAvailable
+            }.getOrDefault(false)
+            assumeTrue("Docker not available; skipping exec-stall containment tests", dockerAvailable)
+
+            val dockerDir = projectRoot.resolve("tests/docker")
+            val image = ImageFromDockerfile("pocketshell-test-ssh", false)
+                .withDockerfile(dockerDir.resolve("Dockerfile.ssh"))
+            container = GenericContainer(image)
+                .withExposedPorts(CONTAINER_SSH_PORT)
+                .also { it.start() }
+        }
+
+        @AfterClass
+        @JvmStatic
+        fun tearDown() {
+            container?.stop()
+            container = null
+        }
+
+        private fun findProjectRoot(): Path {
+            var dir: Path? = Paths.get(System.getProperty("user.dir")).toAbsolutePath()
+            while (dir != null) {
+                if (dir.resolve("tests/docker/Dockerfile.ssh").toFile().exists()) {
+                    return dir
+                }
+                dir = dir.parent
+            }
+            error(
+                "Could not locate tests/docker/Dockerfile.ssh from user.dir=" +
+                    System.getProperty("user.dir"),
+            )
+        }
+    }
+
+    private val sshHost: String get() = container!!.host
+    private val sshPort: Int get() = container!!.getMappedPort(CONTAINER_SSH_PORT)
+    private val privateKeyFile: File
+        get() = projectRoot.resolve("tests/docker/test_key").toFile()
+
+    /**
+     * Connect a REAL [RealSshSession] against the Docker sshd with a SHORT injected
+     * [execReadTimeoutMs] so the wedged-read bound fires in ~2s instead of the
+     * production 30s. Mirrors `SshConnection.connect`'s connector sequence but
+     * constructs the session directly so the test can inject the bound (the single
+     * production construction site hard-codes the default).
+     */
+    private fun connectRealSession(
+        execReadTimeoutMs: Long,
+        host: String = sshHost,
+        port: Int = sshPort,
+    ): RealSshSession = runBlocking {
+        val connector = SshConnection.RealSshConnector
+        val client = connector.createClient()
+        connector.applyKnownHostsPolicy(client, KnownHostsPolicy.AcceptAll)
+        connector.connect(client, host, port, 15_000)
+        connector.authenticate(client, "testuser", SshKey.Path(privateKeyFile), null)
+        RealSshSession(client, execReadTimeoutMs = execReadTimeoutMs)
+    }
+
+    @Test
+    fun stalledExecClosesOnlyItsChannelAndTheSiblingReaderSurvives() = runBlocking {
+        // ~2s no-progress bound so `sleep 20` (silent > bound) trips fast.
+        val session = connectRealSession(execReadTimeoutMs = 2_000L)
+        val readerScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        try {
+            val shell = session.startShell()
+            val ticks = AtomicInteger(0)
+            val lastReadNanos = AtomicLong(System.nanoTime())
+            val readerError = AtomicReference<Throwable?>(null)
+
+            // The sibling long-lived reader (the `-CC` control-channel stand-in): a
+            // thread draining the shell's stdout. On BASE, when the stalled exec
+            // closes the shared transport, this blocking read throws — the exact
+            // reader_exception that becomes passive_disconnect on-device.
+            val readerThread = thread(name = "ps1567-sibling-reader", isDaemon = true) {
+                val buf = ByteArray(4096)
+                try {
+                    while (true) {
+                        val n = shell.stdout.read(buf)
+                        if (n < 0) break
+                        val text = String(buf, 0, n, Charsets.UTF_8)
+                        var idx = text.indexOf("ps1567-tick")
+                        while (idx >= 0) {
+                            ticks.incrementAndGet()
+                            idx = text.indexOf("ps1567-tick", idx + 1)
+                        }
+                        lastReadNanos.set(System.nanoTime())
+                    }
+                } catch (t: Throwable) {
+                    // A genuine transport-death read throw — what the fix must PREVENT
+                    // for a mere sibling exec timeout.
+                    readerError.set(t)
+                }
+            }
+
+            // Start a server-side heartbeat: the server streams `ps1567-tick` lines
+            // on its own, so the client reader keeps getting bytes independently of
+            // any exec — proving the `-CC` channel stays live through the exec stall.
+            shell.writeStdin(
+                "while true; do printf 'ps1567-tick\\n'; sleep 0.2; done\n".toByteArray(Charsets.UTF_8),
+            )
+
+            // Confirm the sibling reader is genuinely live BEFORE the exec stall.
+            awaitAtLeast(ticks, target = 3, timeoutMs = 8_000L, what = "initial sibling ticks")
+            val ticksBeforeExec = ticks.get()
+
+            // The stalled exec: silent for 20s, far past the 2s no-progress bound.
+            val startNanos = System.nanoTime()
+            val timeout: SshExecTimeoutException = try {
+                session.exec("sleep 20")
+                throw AssertionError("a silent 20s exec must trip the 2s no-progress bound, not return")
+            } catch (e: SshExecTimeoutException) {
+                e
+            }
+            val elapsedMs = (System.nanoTime() - startNanos) / 1_000_000L
+            assertTrue(
+                "the stalled exec must surface a retryable SshExecTimeoutException near the bound " +
+                    "(elapsed=${elapsedMs}ms)",
+                timeout.command.contains("sleep 20"),
+            )
+
+            // LOAD-BEARING (#1567): the shared transport MUST stay UP. On BASE the
+            // exec `close()`d it here.
+            assertTrue(
+                "a stalled exec must NOT close the shared transport (#1567) — session.isConnected " +
+                    "must remain true after the exec timeout",
+                session.isConnected,
+            )
+
+            // The sibling `-CC` reader MUST still be alive and RECEIVING NEW bytes
+            // after the exec timed out — on BASE its read threw at the exec's close.
+            assertNull(
+                "the sibling -CC-style reader must NOT have thrown when a peer exec timed out " +
+                    "(readerError=${readerError.get()})",
+                readerError.get(),
+            )
+            awaitAtLeast(
+                ticks,
+                target = ticksBeforeExec + 2,
+                timeoutMs = 8_000L,
+                what = "sibling ticks AFTER the exec timeout (reader still live)",
+            )
+
+            // The transport is still usable: a fresh exec round-trips on the SAME
+            // warm transport (the retry the caller would make).
+            val alive = session.exec("echo ps1567-alive")
+            assertTrue(
+                "a fresh exec must round-trip on the surviving transport; got exit=${alive.exitCode} " +
+                    "stdout='${alive.stdout.trim()}'",
+                alive.exitCode == 0 && alive.stdout.contains("ps1567-alive"),
+            )
+
+            shell.close()
+            readerThread.interrupt()
+        } finally {
+            readerScope.cancel()
+            runCatching { session.close() }
+            session.awaitClosed()
+        }
+    }
+
+    @Test
+    fun genuineTransportDeathStillTearsTheSessionDown() = runBlocking {
+        // Class coverage (G2): the exec-containment change must NOT mask a REAL
+        // transport death. Connect through an in-JVM relay, hard-CUT it (a real
+        // socket close), and confirm the death is still observable — a subsequent
+        // exec FAILS on the dead transport instead of the app pretending the
+        // session is fine.
+        val relay = PausableTcpRelay(sshHost, sshPort).apply { start() }
+        val session = try {
+            connectRealSession(execReadTimeoutMs = 2_000L, host = "127.0.0.1", port = relay.localPort)
+        } catch (t: Throwable) {
+            relay.close()
+            throw t
+        }
+        try {
+            // Sanity: the freshly dialed session round-trips before the cut.
+            val before = session.exec("echo ps1567-precut")
+            assertTrue(
+                "the session must be usable before the cut; exit=${before.exitCode}",
+                before.exitCode == 0 && before.stdout.contains("ps1567-precut"),
+            )
+
+            // Genuine death: hard-close every relayed socket.
+            relay.cut()
+
+            // The death must surface — a fresh exec over the dead transport fails
+            // (channel open / read errors out). It must NOT hang forever nor report
+            // a clean success. The short exec bound also guarantees we don't wait 30s.
+            var deathObserved = false
+            val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(20)
+            while (System.nanoTime() < deadline) {
+                val result = runCatching { session.exec("echo ps1567-postcut") }
+                if (result.isFailure) {
+                    deathObserved = true
+                    break
+                }
+                // sshj's isConnected can lie briefly after a silent cut; retry until
+                // the transport surfaces the death (or isConnected finally flips).
+                if (!session.isConnected) {
+                    deathObserved = true
+                    break
+                }
+                Thread.sleep(250)
+            }
+            assertTrue(
+                "a genuine hard socket cut must still be observable — a post-cut exec must fail " +
+                    "or the session must report disconnected (the fix must not mask real death)",
+                deathObserved,
+            )
+            // And within a bound the dead reader propagates so the session reports
+            // disconnected — the transport-death detector (reader/keepalive), which
+            // the exec-containment change does NOT touch, still tears the corpse down.
+            val disconnectDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(15)
+            while (session.isConnected && System.nanoTime() < disconnectDeadline) {
+                runCatching { session.exec("echo ps1567-poll") }
+                Thread.sleep(250)
+            }
+            assertFalse(
+                "after a genuine transport death the session must NOT keep reporting connected",
+                session.isConnected,
+            )
+        } finally {
+            runCatching { session.close() }
+            session.awaitClosed()
+            relay.close()
+        }
+    }
+
+    private fun awaitAtLeast(counter: AtomicInteger, target: Int, timeoutMs: Long, what: String) {
+        val deadline = System.nanoTime() + timeoutMs * 1_000_000L
+        while (System.nanoTime() < deadline) {
+            if (counter.get() >= target) return
+            Thread.sleep(50)
+        }
+        throw AssertionError("timed out after ${timeoutMs}ms waiting for $what (have ${counter.get()}, need $target)")
+    }
+}

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshSession.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshSession.kt
@@ -694,13 +694,15 @@ internal class RealSshSession(
             // JDK read/join.
             //
             // On a genuine no-progress stall the read is mapped to a clear,
-            // RETRYABLE [SshExecTimeoutException], and we then CLOSE the session
-            // (lease pool self-heals — a now-disconnected session is discarded +
-            // re-dialed on next acquire). This is the SAME close-on-timeout intent
-            // the three bespoke gateway wraps (`FolderListGateway.execBounded`,
-            // `TreeRemoteSource`, `AgentKindRemoteSource`) implement per-caller —
-            // pulled down to the `exec` boundary so EVERY caller inherits it (D22
-            // hard-cut).
+            // RETRYABLE [SshExecTimeoutException]. Issue #1567 (D28 — root of the
+            // #1562 self-close reconnect storm): the stall then closes ONLY this
+            // exec's own channel (the `finally` below), and leaves the shared
+            // transport — and every other channel on it (the live `-CC` reader,
+            // concurrent execs, in-flight uploads) — ALIVE. A starved exec is NOT
+            // evidence of a dead link; only a genuine TRANSPORT-level death
+            // (keepalive/liveness owns that judgment) may close the session.
+            // Callers get the retryable timeout and retry on the SAME warm
+            // transport (D22 hard-cut — no per-caller close-on-timeout shim).
             try {
                 runInterruptible(Dispatchers.IO) {
                     val output = try {
@@ -734,15 +736,27 @@ internal class RealSshSession(
             } catch (timeout: SshExecTimeoutException) {
                 EXEC_LOGGER.warning(
                     "exec read made no progress for ${execReadTimeoutMs}ms (real wall-clock); closing " +
-                        "wedged session + surfacing retryable SshExecTimeoutException. cmd=${command.takeLast(48)}",
+                        "ONLY this exec channel + surfacing retryable SshExecTimeoutException — the shared " +
+                        "transport (and the live -CC reader + concurrent execs/uploads on it) stays UP. " +
+                        "cmd=${command.takeLast(48)}",
                 )
-                // CLOSE the session to tear down the transport so the lease pool
-                // discards the corpse (the watchdog already interrupted+unparked
-                // the read; this also frees the channel deterministically).
-                // NonCancellable so a cancelled/timed-out coroutine still closes.
-                withContext(NonCancellable) {
-                    runCatching { close() }
-                }
+                // Issue #1567 (D28 — root of the #1562 self-close reconnect storm):
+                // a stalled exec must close ONLY its own channel, NEVER the shared
+                // SshSession/transport. The `finally` below tears down just THIS
+                // exec's command+session channel (channel-local containment — the
+                // same shape uploads/downloads already use on a stall). The
+                // WallClockCeiling watchdog already interrupted+unparked the wedged
+                // read, so no `close()` is needed to free the read.
+                //
+                // Closing the whole session here was the in-app killer: on a busy
+                // session the app runs constant execs (agent-log reads, detection
+                // probes, attachment cat>/wc/mv) on the ONE shared transport, so a
+                // single stalled exec `close()`d it → the tmux -CC reader's `read()`
+                // threw SSHException (client-local socket close) → passive_disconnect
+                // → reconnect. The host's sshd journal proved every drop was code 11
+                // BY_APPLICATION (PocketShell's OWN disconnect), zero server/network
+                // errors — entirely self-inflicted. Only a genuine TRANSPORT-level
+                // death (keepalive/liveness) may close the session.
                 throw timeout
             }
         } finally {
@@ -2245,8 +2259,12 @@ internal const val CLOSE_LOG_TAG: String = "issue239-close-teardown"
  * `join()`) of a single [RealSshSession.exec] (#935 S4-2). A half-open / wedged
  * transport leaves the blocking JDK read parked forever; this is the boundary
  * bound that turns "the action silently never returns" into a fast, clear,
- * RETRYABLE [SshExecTimeoutException]. On expiry the session is closed so the
- * lease pool discards the corpse and re-dials on the next acquire.
+ * RETRYABLE [SshExecTimeoutException]. Issue #1567 (D28): on expiry ONLY this
+ * exec's own channel is closed — the shared transport (and the live `-CC`
+ * reader, concurrent execs, and in-flight uploads on it) stays ALIVE. A stalled
+ * exec is not evidence of a dead link; the caller retries on the same warm
+ * transport. Only a genuine transport-level death (keepalive/liveness) closes
+ * the session.
  *
  * Issue #1046: this is now a per-read NO-PROGRESS window, NOT a whole-call
  * wall-clock ceiling. The budget RESETS on every byte that arrives on either

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshSessionExecCancellationTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshSessionExecCancellationTest.kt
@@ -47,6 +47,16 @@ class RealSshSessionExecCancellationTest {
 
             assertTrue("cancelling exec must close the command channel", command.closed)
             assertTrue("cancelling exec must close the SSH session channel", sessionChannel.closed)
+            // Issue #1567 class coverage (G2 — exec-CANCEL case): cancelling an
+            // exec closes ONLY its own channel and must leave the shared transport
+            // ALIVE (the `disconnect()` tripwire on the fake client never fires).
+            // A cancelled exec is never grounds to tear the shared session — same
+            // channel-local containment contract as the exec-timeout / exec-error
+            // cases.
+            assertTrue(
+                "cancelling exec must NOT close the shared transport (#1567)",
+                session.isConnected,
+            )
         } finally {
             session.close()
         }

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshSessionExecReadTimeoutTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshSessionExecReadTimeoutTest.kt
@@ -38,13 +38,20 @@ import java.util.concurrent.atomic.AtomicInteger
  * On BASE (no fix) `exec` against a wedged read NEVER returns, so the
  * `withTimeout(...)` wrapping the call below trips and the test fails (red). With
  * the boundary read-timeout bound the exec fast-fails with a clear, retryable
- * [SshExecTimeoutException] and closes the wedged session so the lease pool
- * self-heals (green).
+ * [SshExecTimeoutException] (green).
+ *
+ * Issue #1567 (D28 — root of the #1562 self-close reconnect storm): the stalled
+ * exec closes ONLY its own exec channel and leaves the shared transport ALIVE
+ * (`isConnected` stays true). The old contract — close the WHOLE session on a
+ * stall — was the in-app killer that tore the live `-CC` reader off a busy
+ * session; these tests now PIN the channel-local containment. The `disconnect()`
+ * on the fake client is the tripwire: if `exec` ever closes the session again,
+ * `isConnected` flips false and these assertions go red.
  */
 class RealSshSessionExecReadTimeoutTest {
 
     @Test
-    fun `wedged exec read fast-fails with SshExecTimeoutException instead of hanging`() {
+    fun `wedged exec read closes only its channel and keeps the shared transport alive`() {
         runBlocking {
             val command = WedgedReadCommand()
             val sessionChannel = RecordingSessionChannel(command)
@@ -76,17 +83,28 @@ class RealSshSessionExecReadTimeoutTest {
                     thrown.command.contains("cat /tmp/wedged"),
                 )
 
-                // The timeout-close `exec` fires is ASYNC (issue #1135/#1144 —
-                // `close()` launches the transport-disconnect on closeScope and
-                // returns before `client.disconnect()` flips the flag). Join it
-                // before reading `isConnected` so the assertion is deterministic
-                // rather than racing the async disconnect (same de-flake shape as
-                // the #1149 integration-suite fix). The bound CLOSED the wedged
-                // session so the lease pool self-heals: a disconnected session is
-                // discarded + re-dialed on next acquire.
+                // Issue #1567: the stall closes ONLY this exec's own channel —
+                // both the command and its session channel — via the `finally`
+                // channel-local teardown.
+                assertTrue(
+                    "the stalled exec must close its own command channel",
+                    command.closed,
+                )
+                assertTrue(
+                    "the stalled exec must close its own session channel",
+                    sessionChannel.closed,
+                )
+                // The LOAD-BEARING assertion (#1567): the shared transport MUST
+                // stay UP. `disconnect()` on the fake client is never called by a
+                // channel-local close, so `isConnected` stays true. On BASE (the
+                // old close-the-session contract) this flipped false — the exact
+                // in-app killer that tore the live -CC reader off a busy session.
+                // (awaitClosed() is a no-op here since close() was never called;
+                // calling it makes the intent explicit and de-flakes the read.)
                 session.awaitClosed()
-                assertFalse(
-                    "wedged exec timeout must close the session (lease self-heal)",
+                assertTrue(
+                    "a stalled exec must NOT close the shared transport (#1567 — leave " +
+                        "the live -CC reader + concurrent execs/uploads alive)",
                     session.isConnected,
                 )
             } finally {
@@ -197,17 +215,19 @@ class RealSshSessionExecReadTimeoutTest {
     }
 
     /**
-     * Class coverage for #1046: an exec that PROGRESSES for a while and THEN
-     * wedges (no further bytes on either stream) must still be bounded and still
-     * close the session — the no-progress budget must not be defeated by earlier
-     * progress. The budget resets while bytes flow, then bounds the final stall.
+     * Class coverage for #1046 + #1567: an exec that PROGRESSES for a while and
+     * THEN wedges (no further bytes on either stream) must still be bounded — the
+     * no-progress budget must not be defeated by earlier progress — and, per
+     * #1567, it must close ONLY its own channel while the shared transport stays
+     * ALIVE. The budget resets while bytes flow, then bounds the final stall.
      */
     @Test
-    fun `exec that progresses then wedges is still bounded and closes the session`() {
+    fun `exec that progresses then wedges is bounded but keeps the transport alive`() {
         runBlocking {
             val command = ProgressesThenWedgesCommand(chunkCount = 3, gapMillis = 100L)
+            val sessionChannel = RecordingSessionChannel(command)
             val session = RealSshSession(
-                ConnectedClient(RecordingSessionChannel(command)),
+                ConnectedClient(sessionChannel),
                 execReadTimeoutMs = 400L,
             )
 
@@ -229,17 +249,20 @@ class RealSshSessionExecReadTimeoutTest {
                     "timeout exception must carry the wedged command",
                     thrown.command.contains("progress-then-wedge"),
                 )
-                // The timeout-close `exec` fires on a wedged read is ASYNC (issue
-                // #1135/#1144 — `close()` launches its transport-disconnect on the
-                // object-owned closeScope and returns before `client.disconnect()`
-                // flips the flag). Join that teardown before reading `isConnected`
-                // so the assertion is deterministic, not a race against the async
-                // disconnect (the intermittent-CI flake this de-flake removes; same
-                // shape as the #1149 integration-suite fix). The LOAD-BEARING
-                // property is unchanged: the wedged exec MUST close the session.
+                // Issue #1567: the mid-stream wedge closes ONLY this exec's channel.
+                assertTrue(
+                    "a mid-stream wedge must close its own command channel",
+                    command.closed,
+                )
+                assertTrue(
+                    "a mid-stream wedge must close its own session channel",
+                    sessionChannel.closed,
+                )
+                // LOAD-BEARING (#1567): the shared transport MUST stay up even
+                // after real progress then a wedge. On BASE this flipped false.
                 session.awaitClosed()
-                assertFalse(
-                    "a mid-stream wedge must still close the session (lease self-heal)",
+                assertTrue(
+                    "a mid-stream wedge must NOT close the shared transport (#1567)",
                     session.isConnected,
                 )
             } finally {
@@ -373,6 +396,15 @@ class RealSshSessionExecReadTimeoutTest {
                 thrown.message.orEmpty().contains("stdout exceeded"),
             )
             assertTrue("command channel should be closed", command.closed)
+            // Issue #1567 class coverage (G2 — exec-ERROR case): an exec that
+            // errors (here, an over-cap stdout → SshException) must close only its
+            // own channel and leave the shared transport ALIVE, exactly like the
+            // exec-timeout and exec-cancel cases. A stalled/errored/cancelled exec
+            // is never grounds to tear the shared session.
+            assertTrue(
+                "an exec error must NOT close the shared transport (#1567)",
+                session.isConnected,
+            )
         } finally {
             session.close()
         }


### PR DESCRIPTION
**The root fix for #1562** — the self-inflicted reconnect storm the maintainer hit on stable LTE.

`RealSshSession.exec()` closed the ENTIRE shared SSH session on a bounded no-progress stall. On a busy session the app runs constant execs on that one transport (agent-log reads, detection probes, attachment `cat>`/`wc`/`mv`), so one stalled exec `close()`'d the shared transport → the tmux `-CC` reader threw `SSHException` → passive_disconnect → reconnect. The host's sshd journal confirms every drop is code 11 `BY_APPLICATION` (PocketShell's own disconnect), zero server/network errors — entirely self-inflicted.

**Fix:** remove the `close()` from `exec()`'s timeout catch. A stalled/errored/cancelled exec closes only its own channel (existing `finally` teardown) and surfaces the retryable `SshExecTimeoutException`; the shared transport + every other channel stay alive. Only genuine transport death closes the session.

**Verification (reviewer-run red→green on Docker integrationTest — #1567 comment 4965369743):**
- New `RealSshSessionExecStallContainmentIntegrationTest`: sibling `-CC` reader survives a stalled exec (RED on base — session closes, reader dies; GREEN with fix). Reviewer independently neutralized-in-place to confirm.
- `genuineTransportDeathStillTearsTheSessionDown` passes with+without → real death NOT masked. #1144/#1149 close-contract adjacency all green (full integrationTest 5m57s).
- Hygiene guards + `git diff --check` clean.

Root fix only; the ladder amplifier (#1568) and upload durability (#1569) are separate coordinated siblings.

Closes #1567
