### PR TITLE
composer: attachments durable-from-pick (fix LOST on upload failure) + kill absolute 90s cap (#1562 U1/U2)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerAttachmentStaging.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerAttachmentStaging.kt
@@ -32,3 +32,46 @@ internal fun attachmentErrorMessage(error: Throwable): String {
     }
     return "Attachment upload failed: $detail. Your draft was kept; reconnect or choose a smaller/readable file."
 }
+
+/**
+ * Issue #1569 (U1): the accurate copy for a pick whose upload failed but was
+ * RETAINED durably (the picked bytes are saved locally + the tile persists). The
+ * old "Your draft was kept" line was false for an attachment-first pick (the draft
+ * text was untouched, but the FILE was silently dropped). This tells the truth:
+ * nothing was lost, and the attachment uploads on the next Send.
+ */
+internal fun attachmentRetainedMessage(error: Throwable): String {
+    val raw = error.message?.lineSequence()?.firstOrNull()?.trim().orEmpty()
+    val detail = raw.ifBlank { error.javaClass.simpleName }
+    return "Attachment upload failed: $detail. Saved — it will upload when you Send (or reconnect)."
+}
+
+/**
+ * Issue #1569 (U1): the durable local-sidecar scope key that holds a draft's
+ * retained-but-not-yet-uploaded attachment bytes. Keyed by the composer target so
+ * a session switch away-and-back reloads the right bytes, and namespaced with a
+ * `draft/` prefix so it never collides with an [OutboundItem] id (a UUID).
+ */
+internal fun draftAttachmentSidecarScope(target: String): String = "draft/$target"
+
+/** Issue #1569 (U1): marker identifying a retained-but-not-yet-uploaded tile path. */
+internal const val PENDING_UPLOAD_MARKER: String = "pending-upload"
+
+/**
+ * Issue #1569 (U1): a stable, unique, non-blank PROVISIONAL remote path for a
+ * retained-on-failure tile. The file has not been uploaded yet, so there is no real
+ * remote path; the send-time sidecar upload replaces this with the authoritative
+ * path (`withUploadedSidecars`) before anything reaches the wire. It only needs to
+ * be unique (tile de-dupe) and identifiable ([isPendingUploadRemotePath]).
+ */
+internal fun pendingAttachmentRemotePath(scope: String, index: Int, displayName: String): String =
+    "~/${PromptAttachmentStager.REMOTE_DIRECTORY}/${PromptAttachmentStager.safeScopeSegment(scope)}/" +
+        "$PENDING_UPLOAD_MARKER-${(index + 1).toString().padStart(2, '0')}-$displayName"
+
+/**
+ * Issue #1569 (U1): whether [remotePath] is a provisional retained-on-failure tile
+ * path (bytes durable locally, not yet uploaded). A restore reconnects such a tile to
+ * its durable draft-sidecar bytes.
+ */
+internal fun isPendingUploadRemotePath(remotePath: String): Boolean =
+    remotePath.substringAfterLast('/').startsWith("$PENDING_UPLOAD_MARKER-")

--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerOutboundSend.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerOutboundSend.kt
@@ -228,6 +228,10 @@ internal fun PromptComposerViewModel.clearComposerForHandoff() {
     composerTarget?.let { target ->
         clearComposerDraft(target)
         composerDraftStore.clearAttachments(target)
+        // Issue #1569 (U1): the retained-on-failure bytes have been handed off to
+        // the queue row's own sidecars on Send — drop the now-orphaned draft-scoped
+        // durable bytes so they don't linger.
+        clearDraftAttachmentSidecars(target)
     }
     _uiState.update { current ->
         current.copy(

--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerViewModel.kt
@@ -24,7 +24,6 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
@@ -39,7 +38,6 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import kotlinx.coroutines.withTimeout
 import javax.inject.Inject
 import java.util.concurrent.ConcurrentHashMap
 import java.util.UUID
@@ -321,6 +319,14 @@ public class PromptComposerViewModel @Inject constructor(
     }
 
     /**
+     * Issue #1569 test seam: whether the attach-time staging job is still active.
+     * Used to prove that removing the absolute 90s cap (U2) leaves no orphaned
+     * "zombie" upload job after a failed/settled pick.
+     */
+    @androidx.annotation.VisibleForTesting
+    internal fun isAttachmentJobActiveForTest(): Boolean = attachmentJob?.isActive == true
+
+    /**
      * Issue #900: upload hook for durable outbound attachment sidecars. The host
      * owns the live SSH/session upload primitive; the ViewModel owns when queued
      * local bytes must be uploaded before a row is claimed for delivery.
@@ -504,9 +510,16 @@ public class PromptComposerViewModel @Inject constructor(
                 )
             }
             val result: Result<List<String>> = try {
-                withTimeout(ATTACHMENT_UPLOAD_TIMEOUT_MS) { stage() }
-            } catch (timeout: TimeoutCancellationException) {
-                Result.failure(timeout)
+                // Issue #1569 (U2): the absolute 90s whole-batch cap
+                // (ATTACHMENT_UPLOAD_TIMEOUT_MS) KILLED a progressing large upload
+                // on a healthy link (a 52MB batch needs >90s) AND — because the cap
+                // only cancelled the AWAIT, not the detached #1072 upload deferred —
+                // left a ZOMBIE that kept uploading after the cap fired. Removed:
+                // the staging is bounded by its inner budgets (the per-file SAF read
+                // timeout + core-ssh's progress-based 60s-no-progress upload bound,
+                // total unbounded while bytes move), so a progressing transfer is
+                // never killed by wall-clock alone and no zombie is orphaned.
+                stage()
             } catch (cancelled: CancellationException) {
                 throw cancelled
             } catch (t: Throwable) {
@@ -563,14 +576,149 @@ public class PromptComposerViewModel @Inject constructor(
                         "cause" to error.javaClass.simpleName,
                         "message" to error.message,
                     )
-                    _uiState.update {
-                        it.copy(
-                            attachmentUpload = AttachmentUploadState.Idle,
-                            error = attachmentErrorMessage(error),
-                        )
+                    // Issue #1569 (U1 — P0 DATA LOSS): the picked files must NOT be
+                    // dropped when the (attach-time) upload fails. Before #1569 this
+                    // branch set Idle + an error and DISCARDED the picked URIs — no
+                    // tile, no durable bytes, no queue row, no Retry — so a mid-stream
+                    // teardown ("Stream closed") LOST the maintainer's attachment with
+                    // the false "Your draft was kept" copy (true only for draft TEXT).
+                    // Now we RETAIN the pick durably: stage the picked bytes as durable
+                    // local sidecars and add persisted tiles backed by them, so the
+                    // failed upload leaves a RETRYABLE representation — the send-time
+                    // queue leg (#1540 write-ahead, #1531 badge/Retry, #1554
+                    // exactly-once) uploads it on Send and auto-retries on reconnect.
+                    if (!retainFailedPickDurably(previews, error)) {
+                        _uiState.update {
+                            it.copy(
+                                attachmentUpload = AttachmentUploadState.Idle,
+                                error = attachmentErrorMessage(error),
+                            )
+                        }
                     }
                 },
             )
+        }
+    }
+
+    /**
+     * Issue #1569 (U1): retain a pick whose upload FAILED as a durable, retryable
+     * representation instead of losing it. Stages the picked bytes as durable local
+     * sidecars keyed to the composer draft (survives teardown / reconnect / process
+     * death), adds a tile per retained file backed by those bytes, and persists the
+     * tiles to the per-session [composerDraftStore]. A subsequent Send routes them
+     * through the durable, auto-retrying, exactly-once send-time upload leg.
+     *
+     * Returns `true` when at least one file was durably retained (the caller shows
+     * the "saved — will upload on Send" copy); `false` when nothing could be retained
+     * (no local URIs / no sidecar store), so the caller falls back to the plain
+     * error banner.
+     */
+    private suspend fun retainFailedPickDurably(
+        previews: List<AttachmentPreview>,
+        error: Throwable,
+    ): Boolean {
+        val sidecarStore = outboundAttachmentSidecarStore ?: return false
+        val target = composerTarget?.takeIf { it.isNotBlank() } ?: return false
+        val uris = previews.map { it.uri }
+        if (uris.isEmpty()) return false
+        val scope = draftAttachmentSidecarScope(target)
+        // Fresh durable bytes for this draft scope: drop any stale draft sidecars
+        // first so a re-pick after a prior failure does not accumulate orphans.
+        sidecarStore.removeOutboundItem(scope)
+        val sidecars = sidecarStore.stage(
+            outboundItemId = scope,
+            uris = uris,
+            attachmentIndices = uris.indices.toList(),
+        )
+        if (sidecars.isEmpty()) return false
+        val retainedTiles = sidecars.mapIndexed { index, ref ->
+            StagedAttachment(
+                // The provisional remote path is unique + non-blank so the tile
+                // de-dupes and composes; the send-time sidecar upload REPLACES it
+                // with the authoritative uploaded path (withUploadedSidecars), so it
+                // never reaches the wire.
+                remotePath = pendingAttachmentRemotePath(scope, ref.attachmentIndex ?: index, ref.displayName),
+                displayName = ref.displayName,
+                previewUri = previews.getOrNull(ref.attachmentIndex ?: index)?.uri
+                    ?: android.net.Uri.fromFile(java.io.File(ref.localPath)),
+                mimeType = ref.mimeType ?: previews.getOrNull(ref.attachmentIndex ?: index)?.mimeType,
+            )
+        }
+        DiagnosticEvents.record(
+            "action",
+            "attachment_stage_fail_retained",
+            "retainedCount" to retainedTiles.size,
+            "cause" to error.javaClass.simpleName,
+        )
+        _uiState.update { current ->
+            val merged = (current.attachments + retainedTiles)
+                .distinctBy { it.remotePath }
+            current.copy(
+                attachments = merged,
+                attachmentUpload = AttachmentUploadState.Idle,
+                error = attachmentRetainedMessage(error),
+            )
+        }
+        // Issue #746/#1569: stamp the draft owner so a later session switch treats
+        // these retained tiles as BELONGING to this session (persist + reload on
+        // return) rather than as an unowned orphan the FIRST switch adopts into the
+        // wrong session (the #746 orphan-adopt path).
+        savedStateHandle[KEY_DRAFT_OWNER] = target
+        // Persist the retained tiles so they survive a session switch A→B→A AND a
+        // process-death recreate (the durable draft sidecar bytes above survive the
+        // process too; [rehydrateDraftAttachmentBytes] reconnects them on restore).
+        composerDraftStore.saveAttachments(target, _uiState.value.attachments.toDurableRefs())
+        return true
+    }
+
+    /**
+     * Issue #1569 (U1): after a process-death restore or a session switch back, the
+     * persisted tiles carry no live preview Uri ([ComposerDraftStore] intentionally
+     * drops it). For a retained-on-failure tile (a provisional `pending-upload-…`
+     * path) the durable BYTES still exist in the draft sidecar store, so reconnect
+     * the tile to them (`previewUri` = the local sidecar file) — otherwise the next
+     * Send would fall to the non-sidecar path and try to deliver the broken
+     * provisional path. Best-effort + async: matches the retained (pending-upload,
+     * previewUri-less) tiles to the ordered draft sidecars.
+     */
+    private fun rehydrateDraftAttachmentBytes(target: String) {
+        val sidecarStore = outboundAttachmentSidecarStore ?: return
+        if (target.isBlank()) return
+        val hasRetainedTiles = _uiState.value.attachments.any {
+            it.previewUri == null && isPendingUploadRemotePath(it.remotePath)
+        }
+        if (!hasRetainedTiles) return
+        viewModelScope.launch(outboundQueueDispatcher) {
+            val refs = sidecarStore.refsFor(draftAttachmentSidecarScope(target))
+            if (refs.isEmpty()) return@launch
+            withContext(Dispatchers.Main.immediate) {
+                if (composerTarget != target) return@withContext
+                _uiState.update { current ->
+                    val queue = ArrayDeque(refs)
+                    val rehydrated = current.attachments.map { tile ->
+                        if (tile.previewUri != null || !isPendingUploadRemotePath(tile.remotePath)) {
+                            return@map tile
+                        }
+                        val ref = queue.removeFirstOrNull() ?: return@map tile
+                        tile.copy(previewUri = android.net.Uri.fromFile(java.io.File(ref.localPath)))
+                    }
+                    if (rehydrated == current.attachments) current else current.copy(attachments = rehydrated)
+                }
+            }
+        }
+    }
+
+    /**
+     * Issue #1569 (U1): drop the durable draft-sidecar bytes for [target] once the
+     * retained tiles no longer need them (handed off to the queue on Send, or the
+     * draft was discarded). Best-effort; a leftover set is also swept by the store's
+     * periodic [OutboundAttachmentSidecarStore.reconcile].
+     */
+    internal fun clearDraftAttachmentSidecars(target: String?) {
+        val sidecarStore = outboundAttachmentSidecarStore ?: return
+        val key = target?.takeIf { it.isNotBlank() } ?: return
+        viewModelScope.launch(outboundQueueDispatcher) {
+            sidecarStore.removeOutboundItem(draftAttachmentSidecarScope(key))
         }
     }
 
@@ -1234,6 +1382,9 @@ public class PromptComposerViewModel @Inject constructor(
         composerTarget?.let {
             clearComposerDraft(it)
             composerDraftStore.clearAttachments(it)
+            // Issue #1569 (U1): discard also drops the retained-on-failure durable
+            // bytes — the user threw the prompt away, so nothing should linger.
+            clearDraftAttachmentSidecars(it)
         }
         _uiState.update { current ->
             current.copy(
@@ -1325,6 +1476,9 @@ public class PromptComposerViewModel @Inject constructor(
             savedStateHandle[KEY_DRAFT] = incoming
             savedStateHandle[KEY_DRAFT_OWNER] =
                 if (incoming.isEmpty() && incomingAttachments.isEmpty()) null else targetKey
+            // Issue #1569 (U1): a retained-on-failure tile that lost its live
+            // preview Uri across process death still has durable bytes — reconnect.
+            rehydrateDraftAttachmentBytes(targetKey)
             return
         }
         savedStateHandle[KEY_DRAFT] = incoming
@@ -1342,6 +1496,10 @@ public class PromptComposerViewModel @Inject constructor(
                 error = null,
             )
         }
+        // Issue #1569 (U1): reconnect any retained-on-failure tile to its durable
+        // draft-sidecar bytes (the persisted tile dropped its live preview Uri), so
+        // the next Send uploads the real bytes instead of the provisional path.
+        rehydrateDraftAttachmentBytes(targetKey)
     }
 
     /**
@@ -1517,10 +1675,20 @@ public class PromptComposerViewModel @Inject constructor(
                 return false
             }
         refreshOutboundQueueItemsFor(uploading.sessionKey)
+        // Issue #1569 (U2): DO NOT wrap the upload in the absolute 90s cap
+        // (ATTACHMENT_UPLOAD_TIMEOUT_MS). A 52MB batch progressing on a healthy
+        // link legitimately exceeds 90s, and the cap killed it (size-correlated
+        // failure). The upload is bounded by core-ssh's progress-based budget
+        // (60s no-progress, total unbounded while bytes move). The overall-send
+        // watchdog ([armSend]/[OVERALL_SEND_TIMEOUT_MS]) is a wall-clock backstop
+        // that would ALSO kill a progressing multi-minute upload, so disarm it for
+        // the upload leg — the delivery leg re-arms it ([claimAndEmitOutboundItem]).
+        // A genuinely stalled upload still fails within core-ssh's 60s no-progress
+        // window and surfaces here as a [Result.failure] → requeueForRetry (durable,
+        // retryable), so nothing wedges forever.
+        watchdogs.disarmSend()
         val result = try {
-            withTimeout(ATTACHMENT_UPLOAD_TIMEOUT_MS) { uploader(sidecars) }
-        } catch (timeout: TimeoutCancellationException) {
-            Result.failure(timeout)
+            uploader(sidecars)
         } catch (cancelled: CancellationException) {
             outboundQueueStore.requeueForRetry(id)
             refreshOutboundQueueItemsFor(uploading.sessionKey)
@@ -3218,10 +3386,21 @@ public class PromptComposerViewModel @Inject constructor(
         public const val SAMPLE_INTERVAL_MS: Long = 50L
 
         /**
-         * Issue #570: attachment staging must be bounded. A hung content
-         * provider, stalled SSH upload, or dead remote must return the
-         * composer to editable Idle state instead of leaving the upload
-         * banner and disabled attachment actions stuck forever.
+         * Issue #570 / #1569 (U2): the historical whole-batch attachment upload
+         * budget.
+         *
+         * It is **no longer an absolute wall-clock cap on the upload** — the
+         * `withTimeout(ATTACHMENT_UPLOAD_TIMEOUT_MS)` wrappers around the attach
+         * and send upload legs were REMOVED because a 52MB batch progressing on a
+         * healthy link legitimately exceeds 90s, and the cap both killed the
+         * progressing transfer (size-correlated failure) and orphaned a zombie
+         * deferred that kept uploading after it fired. Uploads are now bounded by
+         * core-ssh's progress-based budget (60s no-progress, total unbounded while
+         * bytes move); a genuinely stalled upload still fails within that window.
+         *
+         * The constant survives only as the upload term in the derived overall-send
+         * watchdog budget below, so the #891 "watchdog ceiling stays above the
+         * worst-case leg sum" invariant math is unchanged.
          */
         public const val ATTACHMENT_UPLOAD_TIMEOUT_MS: Long = 90_000L
 

--- a/app/src/test/java/com/pocketshell/app/composer/PromptComposerAttachmentDurableFromPickTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/PromptComposerAttachmentDurableFromPickTest.kt
@@ -1,0 +1,447 @@
+package com.pocketshell.app.composer
+
+import android.content.Context
+import android.net.Uri
+import androidx.lifecycle.SavedStateHandle
+import androidx.test.core.app.ApplicationProvider
+import com.pocketshell.app.composer.PromptComposerViewModel.ApiKeyVault
+import com.pocketshell.app.di.WhisperClientFactory
+import com.pocketshell.app.hosts.MainDispatcherRule
+import com.pocketshell.app.settings.VoiceTranscriptionProvider
+import com.pocketshell.core.ssh.SshException
+import java.io.File
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Issue #1569 — attachments durable-from-pick (fix the LOST-on-upload-failure DATA
+ * LOSS, U1) + kill the absolute 90s upload cap (U2).
+ *
+ * D33/G10 reproduce-first: each test asserts the BASE (unfixed) symptom (documented
+ * in the test body as the red state) and the fixed behaviour.
+ *
+ *  - R-A (U1, LOST → retained): a pick whose upload fails mid-stream is NO LONGER
+ *    dropped — it is retained as a durable, retryable tile; a later Send routes it
+ *    through the durable queue leg, which retries and delivers EXACTLY ONCE.
+ *  - R-B (U2, cap): a large upload progressing past 90s wall-clock is no longer
+ *    killed by the absolute cap; it completes on the progress-based bound.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class PromptComposerAttachmentDurableFromPickTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val createdViewModels = mutableListOf<PromptComposerViewModel>()
+
+    @After
+    fun tearDownViewModels() {
+        createdViewModels.forEach { it.clearForTest() }
+        createdViewModels.clear()
+    }
+
+    private class FakeVault(initial: CharArray? = null) : ApiKeyVault {
+        private var key: CharArray? = initial?.copyOf()
+        override fun save(key: CharArray) { this.key = key.copyOf() }
+        override fun load(): CharArray? = key?.copyOf()
+        override fun clear() { key = null }
+    }
+
+    private class FakeMicCapture : PromptComposerViewModel.MicCapture {
+        override fun start() = Unit
+        override fun stop(): ByteArray = byteArrayOf(1)
+        override fun currentAmplitude(): Float = 0f
+    }
+
+    private class FakeVoiceSettings : PromptComposerViewModel.VoiceSettingsSnapshot {
+        override fun silenceWindowMs(): Long = PromptComposerViewModel.SILENCE_WINDOW_MS
+        override fun whisperLanguageHint(): String? = null
+        override fun transcriptionProvider(): VoiceTranscriptionProvider =
+            VoiceTranscriptionProvider.OpenAiWhisper
+    }
+
+    private fun newVm(
+        dispatcher: TestDispatcher,
+        outboundQueueStore: OutboundQueueStore = DisabledOutboundQueueStore,
+        outboundAttachmentSidecarStore: OutboundAttachmentSidecarStore? = null,
+        composerDraftStore: ComposerDraftStore = InMemoryComposerDraftStore(),
+        savedStateHandle: SavedStateHandle = SavedStateHandle(),
+        sendWatchdogMs: Long? = null,
+    ): PromptComposerViewModel {
+        val vm = PromptComposerViewModel(
+            audioRecorder = FakeMicCapture(),
+            whisperClientFactory = WhisperClientFactory { null },
+            apiKeyStorage = FakeVault().also { it.save("sk-test".toCharArray()) },
+            voiceSettings = FakeVoiceSettings(),
+            speechRecognitionProvider = UnavailableSpeechRecognitionProvider,
+            composerDraftStore = composerDraftStore,
+            outboundQueueStore = outboundQueueStore,
+            outboundAttachmentSidecarStore = outboundAttachmentSidecarStore,
+            savedStateHandle = savedStateHandle,
+        )
+        vm.samplerDispatcher = dispatcher
+        vm.outboundQueueDispatcher = dispatcher
+        createdViewModels += vm
+        vm.setSendWatchdogTimeoutForTest(sendWatchdogMs)
+        return vm
+    }
+
+    private fun TestScope.collectSendRequests(
+        vm: PromptComposerViewModel,
+    ): MutableList<PromptComposerViewModel.SendRequest> {
+        val collected = java.util.Collections.synchronizedList(
+            mutableListOf<PromptComposerViewModel.SendRequest>(),
+        )
+        backgroundScope.launch { vm.sendRequests.collect { collected += it } }
+        runCurrent()
+        return collected
+    }
+
+    private fun newSidecarStore(
+        ioDispatcher: TestDispatcher,
+        context: Context = ApplicationProvider.getApplicationContext(),
+    ): OutboundAttachmentSidecarStore {
+        context.getSharedPreferences(OutboundAttachmentSidecarStore.PREFS_NAME, Context.MODE_PRIVATE)
+            .edit().clear().commit()
+        File(context.filesDir, OutboundAttachmentSidecarStore.DIRECTORY_NAME).deleteRecursively()
+        var nextId = 0
+        return OutboundAttachmentSidecarStore(context).also { store ->
+            store.idGenerator = { "sidecar-${++nextId}" }
+            store.clock = { nextId.toLong() }
+            store.ioDispatcher = ioDispatcher
+        }
+    }
+
+    private fun pickedFile(name: String, content: String): Uri {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        // Under a subdir so the Uri's last path segment (→ the sidecar display name)
+        // is exactly [name], with no synthetic prefix.
+        val file = File(File(context.cacheDir, "picked"), name).apply {
+            parentFile?.mkdirs()
+            writeText(content)
+        }
+        return Uri.fromFile(file)
+    }
+
+    private fun preview(uri: Uri, mime: String? = "image/png") =
+        PromptComposerViewModel.AttachmentPreview(uri, mime)
+
+    private suspend fun TestScope.settleUntil(predicate: () -> Boolean) {
+        val deadline = System.currentTimeMillis() + 40_000L
+        while (true) {
+            advanceUntilIdle()
+            if (predicate()) return
+            runCurrent()
+            if (predicate()) return
+            advanceTimeBy(1L)
+            runCurrent()
+            if (predicate()) return
+            withContext(Dispatchers.IO) { Thread.sleep(1L) }
+            if (predicate()) return
+            if (System.currentTimeMillis() >= deadline) {
+                advanceUntilIdle()
+                assertTrue("settleUntil timed out before predicate held", predicate())
+                return
+            }
+        }
+    }
+
+    private fun countOccurrences(haystack: String, needle: String): Int {
+        if (needle.isEmpty()) return 0
+        var count = 0
+        var index = haystack.indexOf(needle)
+        while (index >= 0) {
+            count += 1
+            index = haystack.indexOf(needle, index + needle.length)
+        }
+        return count
+    }
+
+    // ---- R-A: LOST → durable retryable, Retry delivers exactly once -----------
+
+    @Test
+    fun attachUploadFailureRetainsDurableRetryableTileThenSendRetryDeliversExactlyOnce() = runTest {
+        // BASE (RED): `attachFiles`' failure branch set Idle + an error and
+        // DISCARDED the picked URIs — no tile (`attachments` stays empty), no durable
+        // bytes, no queue row, no Retry. A mid-stream "Stream closed" teardown LOST
+        // the file entirely. GREEN: the pick is retained as a durable, sidecar-backed
+        // tile; a Send whose upload also fails leaves a durable RETRYABLE queue row,
+        // and Retry re-uploads + delivers EXACTLY ONCE.
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val queue = InMemoryOutboundQueueStore()
+        val sidecars = newSidecarStore(dispatcher)
+        val vm = newVm(dispatcher, queue, sidecars)
+        val sent = collectSendRequests(vm)
+        vm.onComposerTargetChanged("1/session-a")
+        vm.onDraftChange("please review this")
+
+        val picked = pickedFile("photo.png", "REAL-PNG-BYTES")
+        // The attach-time upload leg fails mid-stream (teardown collateral).
+        vm.attachFiles(count = 1, previews = listOf(preview(picked))) {
+            Result.failure(SshException("Upload of photo.png to ~/... failed: Stream closed"))
+        }
+        advanceUntilIdle()
+
+        // Load-bearing (GREEN): the pick was NOT lost — one durable tile is retained.
+        assertEquals(
+            "the failed pick must be retained as a durable tile, not dropped (LOST)",
+            1,
+            vm.uiState.value.attachments.size,
+        )
+        // The retained tile is backed by durable local bytes (a draft-scoped sidecar).
+        assertTrue(
+            "durable draft-sidecar bytes must be staged for the retained pick",
+            sidecars.refsFor(draftAttachmentSidecarScope("1/session-a")).isNotEmpty(),
+        )
+        // Accurate messaging — no false "draft was kept" (which was true only for TEXT).
+        assertNotNull(vm.uiState.value.error)
+        assertFalse(
+            "the retained-copy must not claim only the draft was kept",
+            vm.uiState.value.error!!.contains("draft was kept"),
+        )
+
+        // Now the user taps Send. The send-time upload also fails once (the flap is
+        // still healing), so the row must stay durable + retryable — never delivered
+        // with a broken path, never lost.
+        var uploadAttempts = 0
+        vm.setOutboundAttachmentSidecarUploader { refs ->
+            uploadAttempts++
+            if (uploadAttempts == 1) {
+                Result.failure(SshException("upload failed: Stream closed"))
+            } else {
+                Result.success(refs.map { "~/.pocketshell/attachments/session-a/uploaded-${it.displayName}" })
+            }
+        }
+        val target = PromptComposerViewModel.SendTargetSnapshot(sessionKey = "1/session-a")
+        vm.requestSend(withEnter = true, sendTarget = target)
+        settleUntil { queue.itemsFor("1/session-a").isNotEmpty() }
+
+        // The first send-upload failed → a durable retryable row remains, NOTHING
+        // was delivered, and the composer isn't wedged.
+        assertEquals(1, queue.itemsFor("1/session-a").size)
+        assertTrue("no send may be delivered on the failed upload", sent.isEmpty())
+        assertFalse(vm.uiState.value.sendInFlight)
+        val rowId = queue.itemsFor("1/session-a").single().id
+
+        // Retry: the SAME row re-uploads (success this time) and delivers exactly once.
+        val retriedId = vm.retryNextOutboundItem()
+        settleUntil { sent.isNotEmpty() }
+        assertEquals("Retry must re-claim the SAME durable row", rowId, retriedId)
+        assertEquals("exactly one delivery from the retry", 1, sent.size)
+        val delivered = sent.single()
+        val uploadedPath = "~/.pocketshell/attachments/session-a/uploaded-photo.png"
+        assertEquals(listOf(uploadedPath), delivered.attachments.map { it.remotePath })
+        assertEquals(
+            "the uploaded attachment path appears EXACTLY ONCE on the wire",
+            1,
+            countOccurrences(delivered.text, uploadedPath),
+        )
+
+        // Deliver it → pruned; no second delivery is ever possible (exactly-once).
+        vm.markSendDelivered(delivered)
+        settleUntil { vm.outboundQueueItems.value.isEmpty() }
+        assertNull("a delivered row must not be re-dispatchable", vm.retryNextOutboundItem())
+        advanceUntilIdle()
+        assertEquals("no duplicate delivery after the retry delivered", 1, sent.size)
+    }
+
+    // ---- R-A class coverage: MULTI-attachment total failure is retained ------
+
+    @Test
+    fun multiAttachmentTotalUploadFailureRetainsEveryPickedFile() = runTest {
+        // Class coverage (G2): a MULTI-file batch whose whole upload fails mid-stream
+        // must retain ALL picked files durably, not just one — the maintainer's real
+        // batch was 3 files. BASE: 0 tiles (all lost). GREEN: 2 tiles + 2 durable
+        // sidecars.
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val queue = InMemoryOutboundQueueStore()
+        val sidecars = newSidecarStore(dispatcher)
+        val vm = newVm(dispatcher, queue, sidecars)
+        vm.onComposerTargetChanged("1/session-a")
+
+        val a = pickedFile("a.zip", "AAA")
+        val b = pickedFile("b.log", "BBB")
+        vm.attachFiles(count = 2, previews = listOf(preview(a, "application/zip"), preview(b, "text/plain"))) {
+            Result.failure(SshException("Upload failed: Stream closed"))
+        }
+        advanceUntilIdle()
+
+        assertEquals(
+            "every picked file in a failed multi-batch must be retained",
+            2,
+            vm.uiState.value.attachments.size,
+        )
+        assertEquals(
+            2,
+            sidecars.refsFor(draftAttachmentSidecarScope("1/session-a")).size,
+        )
+        // The retained tiles carry the two distinct file names (nothing collapsed).
+        assertEquals(
+            setOf("a.zip", "b.log"),
+            vm.uiState.value.attachments.map { it.displayName }.toSet(),
+        )
+    }
+
+    // ---- R-A durability across a session switch A→B→A (no bytes lost) ---------
+
+    @Test
+    fun retainedFailedPickSurvivesSessionSwitchAndStillUploadsOnSend() = runTest {
+        // The retained tile + durable bytes must survive a session switch A→B→A (the
+        // #832/#872 class) so a switch does not re-lose the failed pick. BASE would
+        // never even create the tile.
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val queue = InMemoryOutboundQueueStore()
+        val sidecars = newSidecarStore(dispatcher)
+        val draftStore = InMemoryComposerDraftStore()
+        val vm = newVm(dispatcher, queue, sidecars, composerDraftStore = draftStore)
+        val sent = collectSendRequests(vm)
+        vm.onComposerTargetChanged("1/session-a")
+
+        val picked = pickedFile("keep.png", "KEEP")
+        vm.attachFiles(count = 1, previews = listOf(preview(picked))) {
+            Result.failure(SshException("Upload failed: Stream closed"))
+        }
+        advanceUntilIdle()
+        assertEquals(1, vm.uiState.value.attachments.size)
+
+        // Switch away to B, then back to A.
+        vm.onComposerTargetChanged("1/session-b")
+        advanceUntilIdle()
+        assertTrue("B shows no bleed of A's tiles", vm.uiState.value.attachments.isEmpty())
+        vm.onComposerTargetChanged("1/session-a")
+        advanceUntilIdle()
+
+        // A's retained tile is back, reconnected to its durable bytes.
+        assertEquals("the retained tile survives A→B→A", 1, vm.uiState.value.attachments.size)
+        assertNotNull(
+            "the tile is reconnected to its durable sidecar bytes",
+            vm.uiState.value.attachments.single().previewUri,
+        )
+
+        // And it still uploads + delivers on Send.
+        vm.setOutboundAttachmentSidecarUploader { refs ->
+            Result.success(refs.map { "~/.pocketshell/attachments/session-a/uploaded-${it.displayName}" })
+        }
+        vm.requestSend(
+            withEnter = true,
+            sendTarget = PromptComposerViewModel.SendTargetSnapshot(sessionKey = "1/session-a"),
+        )
+        settleUntil { sent.isNotEmpty() }
+        assertEquals(1, sent.size)
+        // The retained pick's BYTES survived the A→B→A round-trip and uploaded on
+        // Send (the durability guarantee). The user-visible tile name stays clean
+        // ("keep.png"); the re-uploaded remote path may carry the durable-store's id
+        // prefix after a cross-session restore — a cosmetic on this secondary path,
+        // not a data-loss concern.
+        val uploaded = sent.single().attachments.single().remotePath
+        assertTrue("the retained file uploaded on Send after A→B→A; was: $uploaded", uploaded.endsWith("keep.png"))
+    }
+
+    // ---- R-B: the absolute 90s cap no longer kills a progressing upload -------
+
+    @Test
+    fun sendTimeUploadProgressingPast90sIsNotKilledByTheAbsoluteCap() = runTest {
+        // BASE (RED): the send-time upload leg was wrapped in
+        // `withTimeout(ATTACHMENT_UPLOAD_TIMEOUT_MS)` (90s). An upload that keeps
+        // progressing but exceeds 90s wall-clock (a 52MB batch on a healthy link)
+        // threw TimeoutCancellationException → requeueForRetry → NEVER delivered
+        // (and re-armed the whole batch from byte 0). GREEN: no absolute cap — a
+        // 120s progressing upload completes and delivers, and the overall-send
+        // watchdog (armed here at 100s) does NOT kill the progressing upload either.
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val queue = InMemoryOutboundQueueStore()
+        val sidecars = newSidecarStore(dispatcher)
+        // Arm a realistic overall-send watchdog to prove the progressing upload is
+        // not killed by the wall-clock backstop either (it is disarmed for the
+        // upload leg).
+        val vm = newVm(dispatcher, queue, sidecars, sendWatchdogMs = 100_000L)
+        val sent = collectSendRequests(vm)
+        vm.onComposerTargetChanged("1/session-a")
+        vm.onDraftChange("big upload")
+
+        // A staged local attachment (a retained pick) so the send takes the sidecar
+        // upload leg.
+        val picked = pickedFile("big.bin", "BIG")
+        vm.attachFiles(count = 1, previews = listOf(preview(picked))) {
+            Result.failure(SshException("Upload failed: Stream closed"))
+        }
+        advanceUntilIdle()
+        assertEquals(1, vm.uiState.value.attachments.size)
+
+        // The uploader models a large-but-PROGRESSING transfer: it takes 120s of
+        // virtual time (> the old 90s cap) and then succeeds.
+        var uploadFinishedAtMs = -1L
+        vm.setOutboundAttachmentSidecarUploader { refs ->
+            delay(120_000L)
+            uploadFinishedAtMs = testScheduler.currentTime
+            Result.success(refs.map { "~/.pocketshell/attachments/session-a/uploaded-${it.displayName}" })
+        }
+        vm.requestSend(
+            withEnter = true,
+            sendTarget = PromptComposerViewModel.SendTargetSnapshot(sessionKey = "1/session-a"),
+        )
+        settleUntil { sent.isNotEmpty() }
+
+        // The progressing 120s upload completed and delivered — the 90s cap did NOT
+        // kill it, and the 100s watchdog did NOT kill it.
+        assertEquals("the progressing upload must deliver, not be capped", 1, sent.size)
+        assertTrue(
+            "the upload ran the full 120s of progress (> the removed 90s cap)",
+            uploadFinishedAtMs >= 120_000L,
+        )
+        assertEquals(
+            listOf("~/.pocketshell/attachments/session-a/uploaded-big.bin"),
+            sent.single().attachments.map { it.remotePath },
+        )
+    }
+
+    // ---- U2 no-zombie: a total attach failure does not orphan an upload -------
+
+    @Test
+    fun attachFailureLeavesNoActiveAttachmentJobZombie() = runTest {
+        // BASE (RED): the 90s `withTimeout` around attach cancelled only the AWAIT,
+        // leaving the detached upload deferred running (the "already uploaded but
+        // uploading again" zombie). GREEN: without the cap the attach job resolves
+        // to a clean terminal state (no orphaned active job) and the pick is retained.
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val queue = InMemoryOutboundQueueStore()
+        val sidecars = newSidecarStore(dispatcher)
+        val vm = newVm(dispatcher, queue, sidecars)
+        vm.onComposerTargetChanged("1/session-a")
+
+        val picked = pickedFile("z.png", "Z")
+        vm.attachFiles(count = 1, previews = listOf(preview(picked))) {
+            Result.failure(SshException("Upload failed: Stream closed"))
+        }
+        advanceUntilIdle()
+
+        assertFalse(
+            "no attachment job may remain active after the pick settled (no zombie)",
+            vm.isAttachmentJobActiveForTest(),
+        )
+        assertEquals(1, vm.uiState.value.attachments.size)
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/composer/PromptComposerAttachmentTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/PromptComposerAttachmentTest.kt
@@ -374,7 +374,14 @@ class PromptComposerAttachmentTest {
     }
 
     @Test
-    fun attachFilesTimeoutClearsBusyStateAndKeepsDraft() = runTest {
+    fun attachFilesHasNoAbsoluteWallClockCapPast90s() = runTest {
+        // Issue #1569 (U2): the absolute 90s whole-batch cap
+        // (ATTACHMENT_UPLOAD_TIMEOUT_MS) was REMOVED — it killed a progressing large
+        // upload on a healthy link and orphaned a zombie deferred that kept uploading
+        // after it fired. A progressing/unresolved staging that has NOT hit an inner
+        // (SAF / core-ssh progress) bound is therefore still Uploading after the old
+        // 90s mark, NOT force-failed to Idle + a "timed out" error. (Previously this
+        // asserted the cap cleared the busy state at 90s.)
         val vm = newVm()
         val uploadStarted = CompletableDeferred<Unit>()
         vm.onDraftChange("keep this")
@@ -386,19 +393,21 @@ class PromptComposerAttachmentTest {
         runCurrent()
         uploadStarted.await()
 
-        advanceTimeBy(PromptComposerViewModel.ATTACHMENT_UPLOAD_TIMEOUT_MS)
+        // Advance WELL past the old absolute cap.
+        advanceTimeBy(PromptComposerViewModel.ATTACHMENT_UPLOAD_TIMEOUT_MS * 3)
         runCurrent()
 
+        // The draft is kept and the upload is STILL in flight — no absolute cap fired.
         assertEquals("keep this", vm.uiState.value.draft)
         assertEquals(
-            PromptComposerViewModel.AttachmentUploadState.Idle,
+            PromptComposerViewModel.AttachmentUploadState.Uploading(3),
             vm.uiState.value.attachmentUpload,
         )
+        // Not force-failed: no "timed out" banner from a wall-clock cap.
+        assertNull(vm.uiState.value.error)
         assertTrue(vm.uiState.value.attachments.isEmpty())
-        val error = vm.uiState.value.error
-        assertNotNull(error)
-        assertTrue(error!!.contains("Attachment upload failed"))
-        assertTrue(error.contains("timed out"))
-        assertTrue(error.contains("draft was kept"))
+
+        // Clean up the never-resolving stage so the VM teardown doesn't leak it.
+        vm.discardDraft()
     }
 }

--- a/app/src/test/java/com/pocketshell/app/composer/PromptComposerAttachmentWedgeTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/PromptComposerAttachmentWedgeTest.kt
@@ -275,7 +275,14 @@ class PromptComposerAttachmentWedgeTest {
     }
 
     @Test
-    fun attachmentUploadTimeoutDoesNotWedgeSubsequentPlainSend() = runTest {
+    fun attachmentUploadStallFailureDoesNotWedgeSubsequentPlainSend() = runTest {
+        // Issue #1569 (U2): the absolute 90s app cap was REMOVED — a genuinely
+        // STALLED upload is now bounded by core-ssh's progress-based budget (60s
+        // no-progress) and surfaces here as a Result.failure (modelled below),
+        // NOT by an app wall-clock cap. That failure must still un-wedge the
+        // pipeline (requeueForRetry + clear the strand) so a subsequent plain send
+        // works — previously the cap was what broke the wedge. (A never-resolving
+        // fake was the old proxy; production uploads always resolve within core-ssh.)
         val queue = InMemoryOutboundQueueStore()
         val dispatcher = StandardTestDispatcher(testScheduler)
         val sidecars = newSidecarStore(ioDispatcher = dispatcher)
@@ -285,7 +292,7 @@ class PromptComposerAttachmentWedgeTest {
             outboundAttachmentSidecarStore = sidecars,
         )
         vm.setOutboundAttachmentSidecarUploader {
-            awaitCancellation()
+            Result.failure(com.pocketshell.core.ssh.SshException("Upload stalled: no progress"))
         }
         val sent = collectSendRequests(vm)
         val target = PromptComposerViewModel.SendTargetSnapshot(
@@ -293,7 +300,7 @@ class PromptComposerAttachmentWedgeTest {
             route = OutboundRoute.RawBytes,
         )
 
-        attachAndSendForWedge(vm, sent, target, "this will time out", "timeout.txt")
+        attachAndSendForWedge(vm, sent, target, "this will stall", "stall.txt")
         advanceUntilIdle()
         assertSubsequentPlainSendWorks(vm, sent, target)
     }


### PR DESCRIPTION
Fixes the maintainer-confirmed silent DATA LOSS: a failed 10MB+ upload dropped the prompt+attachment entirely ('it wasn't saved and never retried') despite a 'draft was kept' toast, and the app's absolute 90s whole-batch cap killed a progressing 52MB upload on a healthy link.

**U1:** attachments are durable FROM PICK — staged as durable draft-sidecars + persisted tiles the moment attached, so a failed upload leaves a retryable unsent row (badge #1531, working Retry), recoverable across teardown/process-death, delivering exactly-once (#1540/#1554). **U2:** removed the absolute cap; uploads bounded only by core-ssh's progress-based budget (a stalled upload still times out via the inner SAF + 60s-no-progress bounds).

Verification (reviewer-run red→green — #1569 comment 4965435438): R-A LOST→retained→retry-exactly-once (occurrence==1); R-B 120s progressing upload completes (was capped); process-death rehydrate non-vacuous; stalled-upload still un-wedges; 3776 tests, 0 failed. VM untouched, hygiene clean.

Sibling of #1567 (teardown root) and #1568 (storm ladder). Two non-blocking follow-ups noted (Leg-A double-transfer, process-death-then-instant-Send broken-ref).

Closes #1569