### PR TITLE
connection: vouch transport-alive before teardown + ExplicitClose no re-arm — stop the #1562 storm (P0-2/P0-5)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -84,6 +84,7 @@ import com.pocketshell.app.tmux.connection.recordNetworkLossBandSuppressed
 import com.pocketshell.app.tmux.connection.recordNetworkLossHold
 import com.pocketshell.app.tmux.connection.PassiveDropArm
 import com.pocketshell.app.tmux.connection.PassiveTransportDropEffects
+import com.pocketshell.app.tmux.connection.preferFreshTransportForPassiveReattach
 import com.pocketshell.app.tmux.connection.SshLeaseTransportPort
 import com.pocketshell.app.tmux.connection.SuppressedDropDiagnostic
 import com.pocketshell.app.tmux.connection.TmuxAttachEffects
@@ -1142,6 +1143,14 @@ public class TmuxSessionViewModel @Inject constructor(
         return runCatching { session.isTransportProvenAliveWithinKeepAliveWindow() }
             .getOrDefault(false)
     }
+
+    /**
+     * Issue #1568 (P0-2): vouch the SSH transport alive (connected + async-close not initiated;
+     * #1222) before the ladder evicts the warm lease. A real death fails the vouch so the ladder
+     * still escalates. Feeds [preferFreshTransportForPassiveReattach].
+     */
+    private fun transportVouchedAlive(): Boolean =
+        sessionRef?.let { it.isConnected && !it.isCloseInitiated } == true
 
     /**
      * Issue #964 test seam: pin the keepalive-alive verdict the probe defers to.
@@ -3424,9 +3433,13 @@ public class TmuxSessionViewModel @Inject constructor(
      */
     private val passiveTransportDropEffects: PassiveTransportDropEffects =
         PassiveTransportDropEffects(
-            isExplicitDetach = { client ->
+            isSelfInflictedClose = { client ->
+                // Issue #1568 (P0-5): a self-inflicted close (ExplicitDetach/ExplicitClose/
+                // `detach_or_replace`) is not a passive loss and must never re-arm recovery —
+                // ignoring our own ExplicitClose breaks the #1562 dial→close→re-arm→dial storm.
                 val disconnectEvent = client.disconnectEvent.value
                 disconnectEvent?.reason == TmuxDisconnectReason.ExplicitDetach ||
+                    disconnectEvent?.reason == TmuxDisconnectReason.ExplicitClose ||
                     disconnectEvent?.intent == "detach_or_replace"
             },
             isCurrentClient = { client -> clientRef === client },
@@ -4189,16 +4202,25 @@ public class TmuxSessionViewModel @Inject constructor(
         // Issue #935 R1: contained — the within-grace heal re-opens a fresh `-CC`
         // over a fresh lease; a teardown-race throw must not crash the process.
         val healJob = launchContainedTeardown {
-            // Re-open a fresh `-CC` control client over a freshly-acquired lease and
-            // reseed — SILENTLY (the primitive never raises the Connecting overlay or a
-            // band; on success it sets [ConnectionStatus.Live] and reseeds every visible
-            // pane). `clientRef` may be null (the passive path unregistered it); the
-            // primitive's staleClient is nullable and used only for the close()/restore.
-            val recovered = silentlyReconnectTransportAfterPassiveDisconnect(
-                staleClient = clientRef,
-                target = target,
-                timeoutMs = passiveDisconnectGraceMs.coerceAtLeast(1L),
-            )
+            // Issue #1568 (P0-2): channel-dead-but-transport-warm MIDDLE rung — on a vouched-alive
+            // transport recover the `-CC` channel over the LIVE transport first (no lease
+            // eviction), else fall through to the lease-evicting fresh dial (a real death fails
+            // the vouch, so it still escalates). `clientRef` may be null; the fresh dial is null-safe.
+            val staleClient = clientRef
+            val recovered =
+                (
+                    transportVouchedAlive() && staleClient != null &&
+                        silentlyReattachAfterPassiveDisconnect(
+                            staleClient = staleClient,
+                            target = target,
+                            timeoutMs = passiveDisconnectGraceMs.coerceAtLeast(1L),
+                        )
+                ) ||
+                    silentlyReconnectTransportAfterPassiveDisconnect(
+                        staleClient = clientRef,
+                        target = target,
+                        timeoutMs = passiveDisconnectGraceMs.coerceAtLeast(1L),
+                    )
             if (!recovered) {
                 // The within-grace silent heal could not re-open the channel in time.
                 // Fall back to the normal auto-reconnect ladder — still SILENT (no manual
@@ -8081,20 +8103,18 @@ public class TmuxSessionViewModel @Inject constructor(
         target: ConnectionTarget,
     ): Boolean {
         if (passiveDisconnectGraceMs <= 0L) return false
-        val preferFreshTransport = leaseRef != null
-        // EPIC #792 #833: count fresh-transport reconnect attempts instead of a
-        // one-shot latch. A SUSTAINED clean outage fails the first fresh-transport
-        // attempt while the link is down, but the loop must keep RE-DIALLING a fresh
-        // transport across the bounded grace window so the SAME session auto-recovers
-        // the moment the link returns — WITHOUT the switch-session dance. The old
-        // `transportReattachTried` latch tried the fresh transport exactly once, and
-        // because a failed transport reconnect nulls `sessionRef`, every later
-        // iteration could only call the warm reattach (which can no longer succeed) —
-        // so the loop spun uselessly until the 60s grace elapsed, leaving the session
-        // wedged. We bound the re-dials with the existing 60s grace `withTimeoutOrNull`
-        // plus the per-attempt timeout + 250ms retry spacing (no hot loop / battery
-        // drain), and never short-circuit a HEALTHY warm reattach (the #635/#553
-        // within-grace warm path still runs first when no fresh transport is preferred).
+        // Issue #1568 (P0-2): prefer the lease-EVICTING fresh dial ONLY when a warm lease is held
+        // AND the transport is not vouched alive; a vouched-alive `-CC` death recovers over the
+        // LIVE transport so a channel hiccup never costs the shared per-host lease.
+        val preferFreshTransport = preferFreshTransportForPassiveReattach(
+            warmLeaseHeld = leaseRef != null,
+            transportVouchedAlive = transportVouchedAlive(),
+        )
+        // EPIC #792 #833: count fresh-transport re-dials (not a one-shot latch) so a SUSTAINED
+        // clean outage keeps RE-DIALLING a fresh transport across the bounded grace window and
+        // the SAME session auto-recovers the moment the link returns — no switch dance. Bounded
+        // by the 60s grace `withTimeoutOrNull` + per-attempt timeout + 250ms retry spacing (no
+        // hot loop); never short-circuits a HEALTHY warm reattach (#635/#553).
         var transportReattachAttempts = 0
         recordSilentReattachStart(
             target = target,
@@ -8115,12 +8135,10 @@ public class TmuxSessionViewModel @Inject constructor(
                 if (currentClient !== staleClient && currentClient?.disconnected?.value != true) {
                     return@withTimeoutOrNull true
                 }
-                // EPIC #792 #833: when a fresh transport is preferred, RE-DIAL it on
-                // EVERY iteration (not once) so a sustained clean outage that fails the
-                // first attempt keeps escalating into a retrying ladder — the SAME
-                // session recovers as soon as the link returns, with no switch dance.
-                // The grace `withTimeoutOrNull` + per-attempt timeout + 250ms spacing
-                // bound the re-dials.
+                // EPIC #792 #833: when a fresh transport is preferred, RE-DIAL it on EVERY
+                // iteration (not once) so a sustained clean outage keeps escalating into a
+                // retrying ladder — the SAME session recovers when the link returns, no switch
+                // dance. Bounded by the grace `withTimeoutOrNull` + per-attempt timeout + spacing.
                 if (preferFreshTransport) {
                     transportReattachAttempts += 1
                     if (silentlyReconnectTransportAfterPassiveDisconnect(
@@ -8140,11 +8158,9 @@ public class TmuxSessionViewModel @Inject constructor(
                 ) {
                     return@withTimeoutOrNull true
                 }
-                // No warm lease to prefer (preferFreshTransport=false): the warm
-                // reattach above is the cheap within-grace path; if it can't recover
-                // (the warm SSH session itself is gone) escalate to a fresh transport,
-                // and keep RE-DIALLING that on every later iteration for the same
-                // sustained-outage resilience as the preferred-transport branch.
+                // No fresh transport preferred: the warm reattach above is the cheap path; if it
+                // can't recover (the warm SSH session itself is gone) escalate to a fresh
+                // transport and keep re-dialling it for the same sustained-outage resilience.
                 if (!preferFreshTransport) {
                     transportReattachAttempts += 1
                     if (silentlyReconnectTransportAfterPassiveDisconnect(
@@ -13797,6 +13813,13 @@ public class TmuxSessionViewModel @Inject constructor(
     internal fun markActiveLeaseWarmForTest() {
         val target = activeTarget ?: connectingTarget ?: return
         liveLeaseKeys.add(target.toSshLeaseTarget().leaseKey)
+    }
+
+    /** Issue #1568 test seam: set [leaseRef] warm so a proof drives the `warmLeaseHeld` rung. */
+    @androidx.annotation.VisibleForTesting
+    internal suspend fun setActiveLeaseRefWarmForTest() {
+        val target = activeTarget ?: connectingTarget ?: return
+        leaseRef = sshLeaseManager.acquire(target.toSshLeaseTarget()).getOrNull()
     }
 
     /**

--- a/app/src/main/java/com/pocketshell/app/tmux/connection/PassiveTransportDropEffects.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/connection/PassiveTransportDropEffects.kt
@@ -53,12 +53,20 @@ enum class PassiveDropArm {
  * selector (the #685 predicate-order trap — keep the EXACT inline precedence so behavior is
  * unchanged):
  *
- *   1. [isExplicitDetach] (ExplicitDetach reason OR `detach_or_replace` intent) -> [PassiveDropArm.Ignore]
+ *   1. [isSelfInflictedClose] (ExplicitDetach/ExplicitClose reason OR `detach_or_replace` intent) -> [PassiveDropArm.Ignore]
  *   2. NOT [isCurrentClient] (the #635 client-identity guard — a stale old-client close)   -> [PassiveDropArm.Ignore]
  *   3. [hasTarget] AND NOT [screenStartedForCleared]:
  *        - [navigatingToDifferentSession] -> [PassiveDropArm.SkipInAppNavigation]
  *        - else                           -> [PassiveDropArm.PauseUntilForeground]
  *   4. else                                                                                  -> [PassiveDropArm.SilentReattachWithinGrace]
+ *
+ * Issue #1568 (P0-5): [isSelfInflictedClose] now also covers a `TmuxDisconnectReason.ExplicitClose`
+ * — a self-inflicted `TmuxClient.close()`, NOT a passive transport loss. Before this, only
+ * `ExplicitDetach`/`detach_or_replace` were ignored, so a freshly-dialed client that our OWN
+ * code explicitly closed re-armed recovery (`SilentReattachWithinGrace`) and drove the next
+ * dial → the `explicit_close → passive_disconnect` reconnect STORM (#1562: dial→close→re-arm→
+ * dial, ~6s cadence). A self-inflicted close must NEVER re-arm; only genuine passive drops
+ * (reader EOF/exception, command timeout, server exit) do.
  *
  * Issue #895 (#766 down-payment): STATUS-AGNOSTIC. There is intentionally NO
  * `inlineConnectionStatus !is Connected -> Ignore` gate — the old status gate swallowed a
@@ -70,13 +78,13 @@ enum class PassiveDropArm {
  * real transport loss and must drive recovery.
  */
 fun selectPassiveDropArm(
-    isExplicitDetach: Boolean,
+    isSelfInflictedClose: Boolean,
     isCurrentClient: Boolean,
     hasTarget: Boolean,
     screenStartedForCleared: Boolean,
     navigatingToDifferentSession: Boolean,
 ): PassiveDropArm = when {
-    isExplicitDetach -> PassiveDropArm.Ignore
+    isSelfInflictedClose -> PassiveDropArm.Ignore
     !isCurrentClient -> PassiveDropArm.Ignore
     hasTarget && !screenStartedForCleared ->
         if (navigatingToDifferentSession) {
@@ -87,6 +95,29 @@ fun selectPassiveDropArm(
 
     else -> PassiveDropArm.SilentReattachWithinGrace
 }
+
+/**
+ * Issue #1568 (P0-2): the PURE within-grace silent-reattach RUNG selector. When a warm SSH
+ * lease is held AND the SSH transport is VOUCHED alive (the `-CC` control channel died but
+ * the transport itself is healthy — `isConnected && !isCloseInitiated`), recover the channel
+ * over the LIVE transport (rung 2, [TmuxSessionViewModel.silentlyReattachAfterPassiveDisconnect]
+ * — one channel-open + tmux attach, no TCP/KEX/auth/lease churn) FIRST, instead of the
+ * lease-EVICTING fresh dial ([TmuxSessionViewModel.silentlyReconnectTransportAfterPassiveDisconnect],
+ * whose first act is `sshLeaseManager.disconnect(leaseKey)` — it shoots the shared per-host
+ * transport that the conversation loader / upload sidecar also ride, the #1562 amplification).
+ *
+ * `preferFreshTransport` is TRUE (dial fresh first) ONLY when a warm lease is held AND the
+ * transport vouch FAILS — i.e. a genuine transport death (sshj flips `isConnected` false; the
+ * #1222 `isCloseInitiated` covers the ~2s async-close staleness window). That is exactly the
+ * old `leaseRef != null` behavior for a dead transport, so a real death still escalates to the
+ * fresh dial and is never masked. With no warm lease the warm reattach is the cheap path
+ * regardless (fresh-dial fallback runs if the warm session is itself gone — unchanged). The
+ * vouch precedents are #979 (fatal-timeout ride-through) and #1533 (restore-probe vouch).
+ */
+fun preferFreshTransportForPassiveReattach(
+    warmLeaseHeld: Boolean,
+    transportVouchedAlive: Boolean,
+): Boolean = warmLeaseHeld && !transportVouchedAlive
 
 /**
  * The connection-core passive-transport-drop authority: the SINGLE owner of the passive
@@ -101,7 +132,7 @@ fun selectPassiveDropArm(
  * the DECISION; the VM holds the state + the per-arm recovery IO.
  */
 class PassiveTransportDropEffects(
-    private val isExplicitDetach: (TmuxClient) -> Boolean,
+    private val isSelfInflictedClose: (TmuxClient) -> Boolean,
     private val isCurrentClient: (TmuxClient) -> Boolean,
     private val hasTarget: () -> Boolean,
     private val screenStartedForCleared: () -> Boolean,
@@ -114,7 +145,7 @@ class PassiveTransportDropEffects(
      */
     fun classify(client: TmuxClient): PassiveDropArm =
         selectPassiveDropArm(
-            isExplicitDetach = isExplicitDetach(client),
+            isSelfInflictedClose = isSelfInflictedClose(client),
             isCurrentClient = isCurrentClient(client),
             hasTarget = hasTarget(),
             screenStartedForCleared = screenStartedForCleared(),

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelPassiveReconnectTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelPassiveReconnectTest.kt
@@ -1358,6 +1358,277 @@ class TmuxSessionViewModelPassiveReconnectTest : TmuxSessionViewModelTestBase() 
     }
 
 
+    // ------------------------------------------------------------------
+    // Issue #1568 — the #1562 reconnect STORM, at the app layer.
+    //  P0-2: a -CC reader read_failure must NOT evict the warm lease + dial a
+    //        fresh transport when the transport is VOUCHED ALIVE — recover the
+    //        channel over the LIVE transport instead (no self-storm).
+    //  P0-5: an ExplicitClose (self-inflicted TmuxClient.close()) must NOT re-arm
+    //        recovery — that is the dial->close->re-arm->dial loop.
+    // The class-coverage of the pure RUNG/Ignore selectors lives in the sibling
+    // connection.PassiveTransportDropEffectsTest; these are the real-path VM proofs.
+    // ------------------------------------------------------------------
+
+    @Test
+    fun issue1568_readerFailureOverVouchedAliveTransport_recoversOverLiveTransport_noLeaseEviction() =
+        runTest(scheduler) {
+            // P0-2 red->green (recover-not-evict). A -CC reader read_failure (ReaderException)
+            // while the SSH transport is VOUCHED ALIVE (isConnected && !isCloseInitiated) must
+            // recover the channel over the LIVE transport. BASE: preferFreshTransport =
+            // leaseRef != null = true -> the grace loop dials a FRESH lease-evicting transport
+            // FIRST (connectCount 1 -> 2, warm session closed) — the seq-66866 self-storm.
+            // GREEN: the vouch flips preferFreshTransport false -> warm channel-only reattach
+            // over the SAME live session (NO fresh dial, NO lease eviction).
+            TMUX_CONNECT_ATTEMPTS.set(1)
+            val registry = ActiveTmuxClients()
+            val warmSession = FakeSshSession() // isConnected=true, isCloseInitiated=false -> vouched alive
+            val freshSession = FakeSshSession() // only reached if the buggy fresh dial runs
+            val connector = QueueLeaseConnector(warmSession, freshSession)
+            val vm = newVm(
+                registry = registry,
+                sshLeaseManager = testLeaseManager(connector = connector, scope = this, idleTtlMillis = 60_000L),
+            )
+            vm.setPassiveDisconnectRecoveryForTest(graceMs = 5_000L, silentReattachTimeoutMs = 5_000L)
+            var factoryCalls = 0
+            val replacementClient = FakeTmuxClient().withSinglePane("work", "%1")
+            vm.setTmuxClientFactoryForTest { session, sessionName, _ ->
+                factoryCalls += 1
+                assertEquals("work", sessionName)
+                assertSame(
+                    "the vouched-alive recovery must reuse the LIVE warm transport, not a fresh dial",
+                    warmSession,
+                    session,
+                )
+                replacementClient
+            }
+            val deadClient = FakeTmuxClient()
+            vm.replaceClientForTest(
+                hostId = 7L,
+                hostName = "alpha",
+                host = "alpha.example",
+                port = 22,
+                user = "alex",
+                keyPath = "/keys/a",
+                sessionName = "work",
+                client = deadClient,
+                session = warmSession,
+            )
+            // Hold a warm lease — the exact #1562 precondition (a warm per-host transport).
+            vm.setActiveLeaseRefWarmForTest()
+            runCurrent()
+            assertEquals("the warm lease is dialed exactly once before the drop", 1, connector.connectCount)
+
+            deadClient.markDisconnectedForTest(
+                TmuxDisconnectEvent(
+                    reason = TmuxDisconnectReason.ReaderException,
+                    source = "read_failure",
+                    intent = "unknown",
+                ),
+            )
+            advanceUntilIdle()
+
+            assertEquals(
+                "vouched-alive -CC death must recover over the LIVE transport — NO fresh lease " +
+                    "dial. connectCount==2 means the lease-evicting fresh dial ran (the #1562 storm).",
+                1,
+                connector.connectCount,
+            )
+            assertFalse(
+                "the warm lease/transport must NOT be evicted on a channel-only recovery " +
+                    "(evicting it is what severs the conversation loader / upload sidecar — #1562)",
+                warmSession.closed,
+            )
+            assertSame(replacementClient, registry.clients.value[7L]?.client)
+            assertTrue(vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected)
+            assertEquals("work", vm.activeSessionNameForTest())
+            assertTrue(
+                "the channel-only reattach over the SAME live session probes server liveness",
+                vm.lastProbeServerLivenessForTest(),
+            )
+            assertEquals("exactly one recovery client is created (the warm reattach)", 1, factoryCalls)
+        }
+
+    @Test
+    fun issue1568_readerFailureOverDeadTransport_escalatesToFreshDial_notMasked() = runTest(scheduler) {
+        // P0-2 non-masking (G2): a GENUINE transport death (sshj flips isConnected false) must
+        // still evict the lease and dial a FRESH transport — the vouch fails, so the fix never
+        // masks a real death. Identical behavior on base and fix (the guard that the vouch
+        // degrades correctly).
+        TMUX_CONNECT_ATTEMPTS.set(1)
+        val registry = ActiveTmuxClients()
+        val leaseSession = FakeSshSession() // the warm-lease dial (connectCount 1)
+        val freshSession = FakeSshSession() // the escalation fresh dial (connectCount 2)
+        val connector = QueueLeaseConnector(leaseSession, freshSession)
+        val vm = newVm(
+            registry = registry,
+            sshLeaseManager = testLeaseManager(connector = connector, scope = this, idleTtlMillis = 60_000L),
+        )
+        vm.setPassiveDisconnectRecoveryForTest(graceMs = 5_000L, silentReattachTimeoutMs = 5_000L)
+        val replacementClient = FakeTmuxClient().withSinglePane("work", "%1")
+        vm.setTmuxClientFactoryForTest { _, sessionName, _ ->
+            assertEquals("work", sessionName)
+            replacementClient
+        }
+        val deadClient = FakeTmuxClient()
+        vm.replaceClientForTest(
+            hostId = 7L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            sessionName = "work",
+            client = deadClient,
+            session = FakeSshSession(isConnectedValue = false), // DEAD transport -> vouch fails
+        )
+        vm.setActiveLeaseRefWarmForTest()
+        runCurrent()
+        assertEquals(1, connector.connectCount)
+
+        deadClient.markDisconnectedForTest(
+            TmuxDisconnectEvent(
+                reason = TmuxDisconnectReason.ReaderException,
+                source = "read_failure",
+                intent = "unknown",
+            ),
+        )
+        advanceUntilIdle()
+
+        assertEquals(
+            "a genuine transport death must escalate to a FRESH dial — the vouch must NOT mask it",
+            2,
+            connector.connectCount,
+        )
+        assertSame(replacementClient, registry.clients.value[7L]?.client)
+        assertTrue(vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected)
+    }
+
+    @Test
+    fun issue1568_readerFailureWhileCloseInitiated_escalatesToFreshDial_notMasked() = runTest(scheduler) {
+        // P0-2 non-masking (G2), the #1222 async-close staleness window: isConnected still LIES
+        // true for ~2s after a close was initiated. The vouch must consult isCloseInitiated and
+        // FAIL here (a vouch that only checked isConnected would recover over the doomed session
+        // and mask the death — connectCount would stay 1). With the fix the vouch fails ->
+        // fresh dial -> connectCount 2.
+        TMUX_CONNECT_ATTEMPTS.set(1)
+        val registry = ActiveTmuxClients()
+        val leaseSession = FakeSshSession()
+        val freshSession = FakeSshSession()
+        val connector = QueueLeaseConnector(leaseSession, freshSession)
+        val vm = newVm(
+            registry = registry,
+            sshLeaseManager = testLeaseManager(connector = connector, scope = this, idleTtlMillis = 60_000L),
+        )
+        vm.setPassiveDisconnectRecoveryForTest(graceMs = 5_000L, silentReattachTimeoutMs = 5_000L)
+        val replacementClient = FakeTmuxClient().withSinglePane("work", "%1")
+        vm.setTmuxClientFactoryForTest { _, sessionName, _ ->
+            assertEquals("work", sessionName)
+            replacementClient
+        }
+        val deadClient = FakeTmuxClient()
+        vm.replaceClientForTest(
+            hostId = 7L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            sessionName = "work",
+            client = deadClient,
+            // isConnected LIES true, but the close is already initiated -> vouch must fail.
+            session = FakeSshSession(isConnectedValue = true, isCloseInitiatedValue = true),
+        )
+        vm.setActiveLeaseRefWarmForTest()
+        runCurrent()
+        assertEquals(1, connector.connectCount)
+
+        deadClient.markDisconnectedForTest(
+            TmuxDisconnectEvent(
+                reason = TmuxDisconnectReason.ReaderException,
+                source = "read_failure",
+                intent = "unknown",
+            ),
+        )
+        advanceUntilIdle()
+
+        assertEquals(
+            "a close-initiated (doomed) transport must escalate to a FRESH dial — the vouch must " +
+                "consult isCloseInitiated, not just isConnected (which lies true in the #1222 window)",
+            2,
+            connector.connectCount,
+        )
+        assertSame(replacementClient, registry.clients.value[7L]?.client)
+    }
+
+    @Test
+    fun issue1568_explicitCloseOnCurrentClientDoesNotRearmRecovery() = runTest(scheduler) {
+        // P0-5 red->green (no re-arm). A self-inflicted ExplicitClose on the CURRENT client must
+        // NOT re-arm recovery. BASE: ExplicitClose is not ignored -> SilentReattachWithinGrace
+        // -> a recovery client is dialed (the dial->close->re-arm->dial STORM). GREEN: it is
+        // classified Ignore -> no recovery client, no dial, and a passive_disconnect_ignored
+        // diagnostic is recorded.
+        val diagnostics = installRecordingDiagnosticSink()
+        TMUX_CONNECT_ATTEMPTS.set(1)
+        val registry = ActiveTmuxClients()
+        val warmSession = FakeSshSession()
+        val connector = QueueLeaseConnector(warmSession, FakeSshSession())
+        val vm = newVm(
+            registry = registry,
+            sshLeaseManager = testLeaseManager(connector = connector, scope = this, idleTtlMillis = 60_000L),
+        )
+        vm.setPassiveDisconnectRecoveryForTest(graceMs = 5_000L, silentReattachTimeoutMs = 5_000L)
+        var factoryCalls = 0
+        vm.setTmuxClientFactoryForTest { _, _, _ ->
+            factoryCalls += 1
+            FakeTmuxClient().withSinglePane("work", "%1")
+        }
+        val currentClient = FakeTmuxClient()
+        vm.replaceClientForTest(
+            hostId = 7L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            sessionName = "work",
+            client = currentClient,
+            session = warmSession,
+        )
+        vm.setActiveLeaseRefWarmForTest()
+        runCurrent()
+        val connectsBefore = connector.connectCount
+        try {
+            currentClient.markDisconnectedForTest(
+                TmuxDisconnectEvent(
+                    reason = TmuxDisconnectReason.ExplicitClose,
+                    source = "local_close",
+                    intent = "explicit_close",
+                ),
+            )
+            advanceUntilIdle()
+
+            assertEquals(
+                "a self-inflicted ExplicitClose must NOT dial a recovery transport (that is the " +
+                    "#1562 dial->close->re-arm->dial storm)",
+                connectsBefore,
+                connector.connectCount,
+            )
+            assertEquals(
+                "a self-inflicted ExplicitClose must NOT create a recovery client (no re-arm)",
+                0,
+                factoryCalls,
+            )
+            assertTrue(
+                "an ExplicitClose of the current client must classify Ignore (no re-arm)",
+                diagnostics.eventsNamed("passive_disconnect_ignored").any {
+                    it.fields["disconnectReason"] == TmuxDisconnectReason.ExplicitClose.logValue
+                },
+            )
+        } finally {
+            diagnostics.close()
+        }
+    }
+
     private class QueueLeaseConnector(
         private vararg val sessions: FakeSshSession,
     ) : SshLeaseConnector {
@@ -1441,6 +1712,9 @@ class TmuxSessionViewModelPassiveReconnectTest : TmuxSessionViewModelTestBase() 
 
     private class FakeSshSession(
         private val isConnectedValue: Boolean = true,
+        // Issue #1568 (P0-2): the #1222 async-close staleness window — `isConnected` may still
+        // lie true while a close has already been initiated. The transport vouch must fail here.
+        private val isCloseInitiatedValue: Boolean = false,
     ) : SshSession {
         @Volatile
         var closed: Boolean = false
@@ -1450,6 +1724,9 @@ class TmuxSessionViewModelPassiveReconnectTest : TmuxSessionViewModelTestBase() 
 
         override val isConnected: Boolean
             get() = isConnectedValue && !closed
+
+        override val isCloseInitiated: Boolean
+            get() = isCloseInitiatedValue
 
         override fun isTransportProvenAliveWithinKeepAliveWindow(): Boolean =
             transportProvenAlive && isConnected

--- a/app/src/test/java/com/pocketshell/app/tmux/connection/PassiveTransportDropEffectsTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/connection/PassiveTransportDropEffectsTest.kt
@@ -44,7 +44,7 @@ class PassiveTransportDropEffectsTest {
         assertEquals(
             PassiveDropArm.Ignore,
             selectPassiveDropArm(
-                isExplicitDetach = true,
+                isSelfInflictedClose = true,
                 isCurrentClient = true,
                 hasTarget = true,
                 screenStartedForCleared = false,
@@ -60,7 +60,7 @@ class PassiveTransportDropEffectsTest {
         assertEquals(
             PassiveDropArm.Ignore,
             selectPassiveDropArm(
-                isExplicitDetach = false,
+                isSelfInflictedClose = false,
                 isCurrentClient = false,
                 hasTarget = true,
                 screenStartedForCleared = false,
@@ -76,7 +76,7 @@ class PassiveTransportDropEffectsTest {
         assertEquals(
             PassiveDropArm.SkipInAppNavigation,
             selectPassiveDropArm(
-                isExplicitDetach = false,
+                isSelfInflictedClose = false,
                 isCurrentClient = true,
                 hasTarget = true,
                 screenStartedForCleared = false,
@@ -90,7 +90,7 @@ class PassiveTransportDropEffectsTest {
         assertEquals(
             PassiveDropArm.PauseUntilForeground,
             selectPassiveDropArm(
-                isExplicitDetach = false,
+                isSelfInflictedClose = false,
                 isCurrentClient = true,
                 hasTarget = true,
                 screenStartedForCleared = false,
@@ -104,7 +104,7 @@ class PassiveTransportDropEffectsTest {
         assertEquals(
             PassiveDropArm.SilentReattachWithinGrace,
             selectPassiveDropArm(
-                isExplicitDetach = false,
+                isSelfInflictedClose = false,
                 isCurrentClient = true,
                 hasTarget = false,
                 screenStartedForCleared = false,
@@ -120,7 +120,7 @@ class PassiveTransportDropEffectsTest {
         assertEquals(
             PassiveDropArm.SilentReattachWithinGrace,
             selectPassiveDropArm(
-                isExplicitDetach = false,
+                isSelfInflictedClose = false,
                 isCurrentClient = true,
                 hasTarget = true,
                 screenStartedForCleared = true,
@@ -137,7 +137,7 @@ class PassiveTransportDropEffectsTest {
         assertEquals(
             PassiveDropArm.Ignore,
             selectPassiveDropArm(
-                isExplicitDetach = false,
+                isSelfInflictedClose = false,
                 isCurrentClient = false,
                 hasTarget = true,
                 screenStartedForCleared = false,
@@ -154,11 +154,63 @@ class PassiveTransportDropEffectsTest {
         assertEquals(
             PassiveDropArm.SilentReattachWithinGrace,
             selectPassiveDropArm(
-                isExplicitDetach = false,
+                isSelfInflictedClose = false,
                 isCurrentClient = true,
                 hasTarget = false,
                 screenStartedForCleared = true,
                 navigatingToDifferentSession = false,
+            ),
+        )
+    }
+
+    // ---- Issue #1568 (P0-2): the within-grace silent-reattach RUNG selector -------------
+    // Class coverage (G2): warm-lease × transport-vouch combinations. `preferFreshTransport`
+    // (dial the lease-EVICTING fresh transport FIRST) must be TRUE only when a warm lease is
+    // held AND the transport vouch FAILS (a genuine transport death) — a vouched-alive channel
+    // death recovers over the LIVE transport (rung 2) so a `-CC` hiccup never costs the lease.
+
+    @Test
+    fun preferFreshTransport_warmLease_transportVouchedAlive_recoversOverLiveTransport() {
+        // THE #1568 load-bearing fixture (channel dead, transport warm): do NOT prefer the
+        // lease-evicting fresh dial — recover the channel over the live transport instead.
+        assertEquals(
+            false,
+            preferFreshTransportForPassiveReattach(
+                warmLeaseHeld = true,
+                transportVouchedAlive = true,
+            ),
+        )
+    }
+
+    @Test
+    fun preferFreshTransport_warmLease_transportDead_escalatesToFreshDial() {
+        // Non-masking: a genuine transport death (vouch FAILS) with a warm lease still prefers
+        // the fresh dial — exactly the old `leaseRef != null` behavior for a dead transport.
+        assertEquals(
+            true,
+            preferFreshTransportForPassiveReattach(
+                warmLeaseHeld = true,
+                transportVouchedAlive = false,
+            ),
+        )
+    }
+
+    @Test
+    fun preferFreshTransport_noWarmLease_neverPrefersFreshDial() {
+        // No warm lease to prefer: the warm reattach is the cheap path (the fresh-dial fallback
+        // still runs later if the warm session is itself gone) — never prefer fresh first.
+        assertEquals(
+            false,
+            preferFreshTransportForPassiveReattach(
+                warmLeaseHeld = false,
+                transportVouchedAlive = true,
+            ),
+        )
+        assertEquals(
+            false,
+            preferFreshTransportForPassiveReattach(
+                warmLeaseHeld = false,
+                transportVouchedAlive = false,
             ),
         )
     }
@@ -168,13 +220,13 @@ class PassiveTransportDropEffectsTest {
     private val client: TmuxClient = FakeTmuxClient()
 
     private fun effects(
-        isExplicitDetach: (TmuxClient) -> Boolean = { false },
+        isSelfInflictedClose: (TmuxClient) -> Boolean = { false },
         isCurrentClient: (TmuxClient) -> Boolean = { true },
         hasTarget: () -> Boolean = { true },
         screenStartedForCleared: () -> Boolean = { false },
         navigatingToDifferentSession: () -> Boolean = { false },
     ) = PassiveTransportDropEffects(
-        isExplicitDetach = isExplicitDetach,
+        isSelfInflictedClose = isSelfInflictedClose,
         isCurrentClient = isCurrentClient,
         hasTarget = hasTarget,
         screenStartedForCleared = screenStartedForCleared,
@@ -185,7 +237,7 @@ class PassiveTransportDropEffectsTest {
     fun classify_explicitDetach_ignored() {
         assertEquals(
             PassiveDropArm.Ignore,
-            effects(isExplicitDetach = { true }).classify(client),
+            effects(isSelfInflictedClose = { true }).classify(client),
         )
     }
 


### PR DESCRIPTION
The app-layer amplifier of the #1562 self-close storm — turns one drop into a ~6s dial→close→re-arm loop (17 consecutive BY_APPLICATION disconnects in ~2min). Sibling of #1567 (exec-containment root, merged) and #1569 (upload durable, PR #1572).

**P0-2 (recover-not-evict):** a -CC reader read_failure was promoted to a full teardown that evicted the warm lease + dialed fresh even when the SSH transport was still alive. Now gated on a transport-alive vouch (`isConnected && !isCloseInitiated`); a vouched-alive -CC death routes to the existing `silentlyReattachAfterPassiveDisconnect` (channel-only reattach over the live session). **P0-5 (no re-arm):** `ExplicitClose` no longer re-arms recovery — breaks the storm loop.

**Verification (reviewer-run — #1568 comment 4965574973):**
- Red→green: both storm signatures `expected:1 but was:2` (double-dial) on base → single recovery with fix.
- Non-masking: a genuine transport death still escalates to fresh dial (vouch consults `isCloseInitiated`, never recovers a corpse).
- **Emulator #638 journey (FastResumeReconnectE2eTest, agents:2222):** lease REUSED not evicted, resume WITHOUT reconnect, `sawReconnectingPill=false`, 1 ssh-open, 0 storm signatures, viewport preserved.
- Adjacency #1533/#635/#895 green; VM net-negative; full module green.

Closes #1568