### PR TITLE
release: v0.4.34 — stop the self-close reconnect storm

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,8 +65,8 @@ android {
         applicationId = "com.pocketshell.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 80
-        versionName = "0.4.33"
+        versionCode = 81
+        versionName = "0.4.34"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/tools/pocketshell/pyproject.toml
+++ b/tools/pocketshell/pyproject.toml
@@ -8,7 +8,7 @@ name = "pocketshell"
 # scripts/check-pypi-version.sh enforces this; .github/workflows/build.yml
 # runs that check before publishing to PyPI. See
 # tools/pocketshell/README.md ("Release flow") for the bump procedure.
-version = "0.4.33"
+version = "0.4.34"
 description = "Unified server-side Python utility for the PocketShell Android client."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Version bump 0.4.33 → 0.4.34 (versionCode 80 → 81), tools/pocketshell in lockstep.

Ships the #1562 self-close storm fixes already merged to main: #1567, #1568, #1569, #1537-optb.

**Why now (expedited):** the maintainer hit a live self-close storm on v0.4.33 — 37 `explicit_close → passive_disconnect → down → reconnecting` cycles over ~50 min (connection-log 08:00–08:50), the exact signature #1568 eliminates (Fable audit verdict: CLOSED). Connection is fine; the app was self-inflicting the closes.

Release gate + tag follow once required checks are green.