### PR TITLE
composer: fix slash/short-reply silent false-success drop (#1577)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/composer/OutboundQueueStore.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/OutboundQueueStore.kt
@@ -312,6 +312,7 @@ public interface OutboundQueueStore {
         paneId: String,
         payload: String,
         atMs: Long = System.currentTimeMillis(),
+        baselineCount: Int? = null,
     ): OutboundItem?
 
     /**
@@ -325,6 +326,16 @@ public interface OutboundQueueStore {
      * differs from `cleanText`.
      */
     public fun hasWireAttempt(paneId: String, payload: String): Boolean
+
+    /**
+     * Issue #1577: the durable [OutboundItem.wireNeedleBaselineCount] recorded for
+     * the row matching (`paneId`, `payload`), or `null` when none was captured. A
+     * ledger rebuilt after a VM-clear reads this so a genuine resend can compare the
+     * CURRENT pane needle count against the pre-send baseline (only an INCREASE means
+     * "landed"), instead of a presence-only match that a pre-existing status line
+     * would false-trip.
+     */
+    public fun wireNeedleBaseline(paneId: String, payload: String): Int?
 }
 
 /**
@@ -335,22 +346,33 @@ public interface OutboundQueueStore {
  * (the flag lives on the persisted row); see [OutboundQueueStore.asWireAttemptDurableStore].
  */
 public interface OutboundWireAttemptDurableStore {
-    /** Persist that (`paneId`, `payload`) has been pushed to the wire. */
-    public fun recordWireAttempt(paneId: String, payload: String, atMs: Long)
+    /**
+     * Persist that (`paneId`, `payload`) has been pushed to the wire. Issue #1577:
+     * [baselineCount] is the pre-send occurrence count of the payload's verify needle
+     * on the pane (or `null` when it could not be captured), stored once with the
+     * first wire attempt so a rebuilt ledger can compare against it.
+     */
+    public fun recordWireAttempt(paneId: String, payload: String, atMs: Long, baselineCount: Int? = null)
 
     /** Whether a durable wire attempt is recorded for (`paneId`, `payload`). */
     public fun hasWireAttempt(paneId: String, payload: String): Boolean
+
+    /** Issue #1577: the durable pre-send needle baseline for (`paneId`, `payload`), or `null`. */
+    public fun wireNeedleBaseline(paneId: String, payload: String): Int?
 }
 
 /** Issue #1541: adapt this store as the ledger's durable wire-attempt backing. */
 public fun OutboundQueueStore.asWireAttemptDurableStore(): OutboundWireAttemptDurableStore =
     object : OutboundWireAttemptDurableStore {
-        override fun recordWireAttempt(paneId: String, payload: String, atMs: Long) {
-            markWireAttempted(paneId, payload, atMs)
+        override fun recordWireAttempt(paneId: String, payload: String, atMs: Long, baselineCount: Int?) {
+            markWireAttempted(paneId, payload, atMs, baselineCount)
         }
 
         override fun hasWireAttempt(paneId: String, payload: String): Boolean =
             this@asWireAttemptDurableStore.hasWireAttempt(paneId, payload)
+
+        override fun wireNeedleBaseline(paneId: String, payload: String): Int? =
+            this@asWireAttemptDurableStore.wireNeedleBaseline(paneId, payload)
     }
 
 /**
@@ -395,6 +417,15 @@ public fun OutboundQueueStore.asWireAttemptDurableStore(): OutboundWireAttemptDu
  *   (survives the volatile ledger dying) and probes instead of blindly re-pasting.
  *   Cleared only when the row leaves the queue (delivered-prune / remove / clear).
  * @property wireAttemptedAtMs the time [wireAttempted] was first set, or `null`.
+ * @property wireNeedleBaselineCount issue #1577: the pre-send occurrence count of
+ *   the payload's verify needle on the pane, captured at the FIRST wire attempt
+ *   (before the paste), or `null` when it was never captured (a legacy row / the
+ *   baseline probe failed). The verify-before-resend probe reports `AlreadyLanded`
+ *   only when the CURRENT occurrence count EXCEEDS this baseline — i.e. the paste
+ *   actually added an occurrence — so a payload that was already visible on the
+ *   pane (a Codex `Goal blocked (/goal resume)` status line) is not mistaken for a
+ *   landed send. Persisted so the refinement survives a VM-clear / back-navigation
+ *   (the rebuilt ledger reads it back); `null` falls back to presence-only (#1541).
  */
 public data class OutboundItem(
     val id: String,
@@ -413,6 +444,7 @@ public data class OutboundItem(
     val sendKey: String = "",
     val wireAttempted: Boolean = false,
     val wireAttemptedAtMs: Long? = null,
+    val wireNeedleBaselineCount: Int? = null,
 )
 
 /** Issue #900: persisted send route selected before an item entered the durable queue. */
@@ -645,19 +677,26 @@ public open class InMemoryOutboundQueueStore : OutboundQueueStore {
         items.values.removeAll { it.sessionKey == sessionKey }
     }
 
-    override fun markWireAttempted(paneId: String, payload: String, atMs: Long): OutboundItem? =
+    override fun markWireAttempted(paneId: String, payload: String, atMs: Long, baselineCount: Int?): OutboundItem? =
         synchronized(lock) {
             val target = items.values
                 .filter { it.matchesWireTarget(paneId, payload) }
                 .minByOrNull { it.createdAtMs }
                 ?: return null
-            val updated = target.markedWireAttempted(atMs)
+            val updated = target.markedWireAttempted(atMs, baselineCount)
             items[updated.id] = updated
             updated
         }
 
     override fun hasWireAttempt(paneId: String, payload: String): Boolean = synchronized(lock) {
         items.values.any { it.wireAttempted && it.matchesWireTarget(paneId, payload) }
+    }
+
+    override fun wireNeedleBaseline(paneId: String, payload: String): Int? = synchronized(lock) {
+        items.values
+            .filter { it.wireAttempted && it.matchesWireTarget(paneId, payload) }
+            .minByOrNull { it.createdAtMs }
+            ?.wireNeedleBaselineCount
     }
 }
 
@@ -703,8 +742,9 @@ public object DisabledOutboundQueueStore : OutboundQueueStore {
     override fun requeueStaleInFlight(sessionKey: String, cutoffMs: Long): List<OutboundItem> = emptyList()
     override fun remove(id: String): Boolean = false
     override fun clearSession(sessionKey: String) = Unit
-    override fun markWireAttempted(paneId: String, payload: String, atMs: Long): OutboundItem? = null
+    override fun markWireAttempted(paneId: String, payload: String, atMs: Long, baselineCount: Int?): OutboundItem? = null
     override fun hasWireAttempt(paneId: String, payload: String): Boolean = false
+    override fun wireNeedleBaseline(paneId: String, payload: String): Int? = null
 }
 
 /**
@@ -970,7 +1010,7 @@ public class SharedPrefsOutboundQueueStore @Inject constructor(
         storeSession(sessionKey, emptyList())
     }
 
-    override fun markWireAttempted(paneId: String, payload: String, atMs: Long): OutboundItem? =
+    override fun markWireAttempted(paneId: String, payload: String, atMs: Long, baselineCount: Int?): OutboundItem? =
         synchronized(lock) {
             for (sessionKey in sessionKeys()) {
                 val list = loadSession(sessionKey)
@@ -978,7 +1018,7 @@ public class SharedPrefsOutboundQueueStore @Inject constructor(
                     .filter { it.matchesWireTarget(paneId, payload) }
                     .minByOrNull { it.createdAtMs }
                     ?: continue
-                val updated = target.markedWireAttempted(atMs)
+                val updated = target.markedWireAttempted(atMs, baselineCount)
                 replaceAndStore(sessionKey, list, updated)
                 return@synchronized updated
             }
@@ -989,6 +1029,14 @@ public class SharedPrefsOutboundQueueStore @Inject constructor(
         sessionKeys().any { key ->
             loadSession(key).any { it.wireAttempted && it.matchesWireTarget(paneId, payload) }
         }
+    }
+
+    override fun wireNeedleBaseline(paneId: String, payload: String): Int? = synchronized(lock) {
+        sessionKeys()
+            .flatMap { loadSession(it) }
+            .filter { it.wireAttempted && it.matchesWireTarget(paneId, payload) }
+            .minByOrNull { it.createdAtMs }
+            ?.wireNeedleBaselineCount
     }
 
     private fun replaceAndStore(sessionKey: String, list: MutableList<OutboundItem>, updated: OutboundItem) {
@@ -1089,18 +1137,27 @@ private fun OutboundItem.claimedForAttempt(): OutboundItem {
     // #1541's [OutboundItem.wireAttemptedAtMs], which records the FIRST wire attempt
     // ever and is preserved across re-claims; the orphan sweep needs the LATEST
     // attempt, so it needs its own timestamp.
+    //
+    // Issue #1577: the claim MUST NOT stamp the durable `wireAttempted` flag. That
+    // was a #1542 regression: a queue row is claimed InFlight (`markInFlight` /
+    // `claim`) BEFORE the composer send emits a single byte, so stamping here marked
+    // every FIRST-ever send as a prior wire attempt. That forced the #1526
+    // verify-before-resend probe on the first send, and the probe's whole-viewport
+    // needle false-matched a Codex "Goal blocked (/goal resume)" status line ⇒
+    // false-`AlreadyLanded` ⇒ the payload was never pasted (silent false-success).
+    // The ONLY correct place to set `wireAttempted` is the actual wire push
+    // ([OutboundQueueStore.markWireAttempted], driven by the ledger's
+    // `recordWireAttempt` right before the first byte). A first send now has
+    // `wireAttempted=false`, so it is delivered normally with no probe.
     val atMs = System.currentTimeMillis()
     return if (state == OutboundState.InFlight) {
-        // Already InFlight — refresh the attempt timestamp and (issue #1541) stamp
-        // the durable wire-attempt flag if a prior claim predates it, so
-        // verify-before-resend survives a VM-clear on this row.
-        copy(lastAttemptAtMs = atMs).markedWireAttempted(atMs)
+        copy(lastAttemptAtMs = atMs)
     } else {
         copy(
             state = OutboundState.InFlight,
             attemptCount = attemptCount + 1,
             lastAttemptAtMs = atMs,
-        ).markedWireAttempted(atMs)
+        )
     }
 }
 
@@ -1111,8 +1168,15 @@ private fun OutboundItem.claimedForAttempt(): OutboundItem {
  * VM-clear / back-navigation instead of blindly re-pasting a payload that may
  * already have landed.
  */
-private fun OutboundItem.markedWireAttempted(atMs: Long): OutboundItem =
-    if (wireAttempted) this else copy(wireAttempted = true, wireAttemptedAtMs = atMs)
+private fun OutboundItem.markedWireAttempted(atMs: Long, baselineCount: Int? = null): OutboundItem =
+    if (wireAttempted) {
+        // Idempotent: the first wire attempt's timestamp AND baseline win. A later
+        // re-push (after a NotLanded probe) must not overwrite the pre-send baseline
+        // (issue #1577) — it is the ONE pre-first-paste snapshot the probe compares.
+        this
+    } else {
+        copy(wireAttempted = true, wireAttemptedAtMs = atMs, wireNeedleBaselineCount = baselineCount)
+    }
 
 private fun OutboundItem.isStaleRecoverableAttempt(cutoffMs: Long): Boolean =
     (state == OutboundState.InFlight || state == OutboundState.Uploading) &&
@@ -1124,13 +1188,14 @@ internal fun blobKey(sessionKey: String): String = "@q/$sessionKey"
 /**
  * Issue #900: encode a session's outbound items as newline-separated rows.
  * Each row is tab-delimited:
- * `id \t cleanText \t withEnter \t state \t createdAtMs \t lastAttemptAtMs \t attemptCount \t lastError \t attachmentsBlob \t paneId \t route \t agentKind \t sendKey \t wireAttempted \t wireAttemptedAtMs`
+ * `id \t cleanText \t withEnter \t state \t createdAtMs \t lastAttemptAtMs \t attemptCount \t lastError \t attachmentsBlob \t paneId \t route \t agentKind \t sendKey \t wireAttempted \t wireAttemptedAtMs \t wireNeedleBaselineCount`
  * with the same `\`-escaping [ComposerDraftStore] uses so text/paths containing
  * tabs/newlines round-trip losslessly. The attachments field reuses
  * [encodeAttachments], itself escaped as a single field. Trailing fields
- * (`sendKey` #961, `wireAttempted`/`wireAttemptedAtMs` #1541) are appended last
- * so legacy rows without them decode to their defaults (empty `sendKey`,
- * `wireAttempted=false`) rather than a malformed row.
+ * (`sendKey` #961, `wireAttempted`/`wireAttemptedAtMs` #1541,
+ * `wireNeedleBaselineCount` #1577) are appended last so legacy rows without them
+ * decode to their defaults (empty `sendKey`, `wireAttempted=false`,
+ * `wireNeedleBaselineCount=null`) rather than a malformed row.
  */
 internal fun encodeOutboundItems(items: List<OutboundItem>): String =
     items.joinToString(separator = "\n") { item ->
@@ -1150,6 +1215,7 @@ internal fun encodeOutboundItems(items: List<OutboundItem>): String =
             item.sendKey,
             if (item.wireAttempted) "1" else "0",
             item.wireAttemptedAtMs?.toString().orEmpty(),
+            item.wireNeedleBaselineCount?.toString().orEmpty(),
         ).joinToString(separator = "\t") { escapeQueueField(it) }
     }
 
@@ -1181,6 +1247,7 @@ internal fun decodeOutboundItems(sessionKey: String, raw: String): List<Outbound
             sendKey = f.getOrNull(12).orEmpty(),
             wireAttempted = f.getOrNull(13) == "1",
             wireAttemptedAtMs = f.getOrNull(14)?.takeIf { it.isNotEmpty() }?.toLongOrNull(),
+            wireNeedleBaselineCount = f.getOrNull(15)?.takeIf { it.isNotEmpty() }?.toIntOrNull(),
         )
     }
 }

--- a/app/src/main/java/com/pocketshell/app/tmux/AgentSubmitAck.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/AgentSubmitAck.kt
@@ -33,4 +33,30 @@ internal fun agentSubmitVisibleTextContainsNeedle(
     return visible.contains(needle)
 }
 
+/**
+ * Issue #1577: count how many times [needle] occurs (non-overlapping) in the
+ * whitespace-stripped visible text. The verify-before-resend probe uses this to
+ * tell "MY paste landed" (the occurrence count went UP vs the pre-send baseline)
+ * from "the payload text was already on the pane" — e.g. a Codex status line that
+ * permanently renders `Goal blocked (/goal resume)`, whose `/goalresume` needle a
+ * presence-only check would always false-match, dropping the send as a
+ * false-`AlreadyLanded`.
+ */
+internal fun agentSubmitVisibleTextNeedleCount(
+    visibleLines: List<String>,
+    needle: String,
+): Int {
+    if (needle.isEmpty()) return 0
+    val visible = visibleLines.joinToString(separator = "")
+        .replace(WHITESPACE_RUN_REGEX, "")
+    if (visible.isEmpty()) return 0
+    var count = 0
+    var index = visible.indexOf(needle)
+    while (index >= 0) {
+        count += 1
+        index = visible.indexOf(needle, index + needle.length)
+    }
+    return count
+}
+
 private val WHITESPACE_RUN_REGEX = Regex("\\s+")

--- a/app/src/main/java/com/pocketshell/app/tmux/OutboundDeliveryGuard.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/OutboundDeliveryGuard.kt
@@ -86,12 +86,20 @@ internal suspend fun verifyBeforeAgentResend(
     payload: String,
 ): DeliveryProbeOutcome? {
     if (!ledger.hasAmbiguousAttempt(paneId, payload)) return null
-    val outcome = probeOutboundPayloadAlreadyLanded(client, paneId, payload)
+    // Issue #1577: compare the CURRENT needle count against the pre-send baseline
+    // captured at the first wire attempt. `AlreadyLanded` requires the count to have
+    // INCREASED (our paste actually added an occurrence) — so a payload that was
+    // already on the pane before we ever pushed (a Codex `Goal blocked (/goal resume)`
+    // status line) is not a false-positive. A null baseline (legacy row / baseline
+    // capture failed) falls back to presence-only (#1541 behaviour).
+    val baseline = ledger.needleBaseline(paneId, payload)
+    val outcome = probeOutboundPayloadAlreadyLanded(client, paneId, payload, baseline)
     DiagnosticEvents.record(
         "action",
         "outbound_verify_before_resend",
         "pane" to paneId,
         "outcome" to outcome.name,
+        "baseline" to (baseline?.toString() ?: "none"),
     )
     return outcome
 }
@@ -138,32 +146,56 @@ internal class OutboundDeliveryLedger(
     private val lock = Any()
     private val entries = LinkedHashSet<String>()
 
+    // Issue #1577: the pre-send needle occurrence count captured with the FIRST
+    // wire attempt, keyed the same way. Bounded alongside [entries]. Backed durably
+    // so a VM-clear-rebuilt ledger reads it back (via [needleBaseline]).
+    private val baselines = HashMap<String, Int>()
+
     private fun key(paneId: String, payload: String): String =
         "$paneId|${payload.length}|${payload.hashCode()}"
 
-    fun recordWireAttempt(paneId: String, payload: String): Unit = synchronized(lock) {
+    fun recordWireAttempt(paneId: String, payload: String, baselineCount: Int? = null): Unit = synchronized(lock) {
         val key = key(paneId, payload)
         entries.remove(key)
         entries.add(key)
+        // Issue #1577: keep the FIRST captured baseline (idempotent) — a re-push after
+        // a NotLanded probe must not overwrite the one pre-first-paste snapshot.
+        if (baselineCount != null && key !in baselines) {
+            baselines[key] = baselineCount
+        }
         while (entries.size > maxEntries) {
-            entries.remove(entries.first())
+            val evicted = entries.first()
+            entries.remove(evicted)
+            baselines.remove(evicted)
         }
         // Issue #1541: also persist on the durable row so the attempt survives a
-        // VM-clear / back-navigation, not only this live VM.
-        durable?.recordWireAttempt(paneId, payload, System.currentTimeMillis())
+        // VM-clear / back-navigation, not only this live VM. Issue #1577: the
+        // baseline rides the same durable row.
+        durable?.recordWireAttempt(paneId, payload, System.currentTimeMillis(), baselineCount)
     }
 
     fun clear(paneId: String, payload: String): Unit = synchronized(lock) {
         // Only clears the volatile set: the durable flag is tied to the row's
         // lifetime (dropped when the row is delivered-pruned / removed, PRESERVED
         // across requeue), so an as-yet-un-acked in-flight row keeps verifying.
-        entries.remove(key(paneId, payload))
+        val key = key(paneId, payload)
+        entries.remove(key)
+        baselines.remove(key)
     }
 
     fun hasAmbiguousAttempt(paneId: String, payload: String): Boolean = synchronized(lock) {
         // Issue #1541: the durable flag makes a back-nav-rebuilt ledger (empty
         // in-memory set) still see a prior wire attempt.
         key(paneId, payload) in entries || durable?.hasWireAttempt(paneId, payload) == true
+    }
+
+    /**
+     * Issue #1577: the pre-send needle baseline for (pane, payload) — the volatile
+     * value first, else the durable one (a VM-clear-rebuilt ledger). `null` when
+     * none was captured; the caller then falls back to presence-only verification.
+     */
+    fun needleBaseline(paneId: String, payload: String): Int? = synchronized(lock) {
+        baselines[key(paneId, payload)] ?: durable?.wireNeedleBaseline(paneId, payload)
     }
 }
 
@@ -196,7 +228,81 @@ internal suspend fun probeOutboundPayloadAlreadyLanded(
     client: TmuxClient,
     paneId: String,
     payload: String,
-): DeliveryProbeOutcome = probeNeedleAlreadyLanded(client, paneId, agentSubmitAckNeedle(payload))
+    baselineCount: Int? = null,
+): DeliveryProbeOutcome {
+    val needle = agentSubmitAckNeedle(payload) ?: return DeliveryProbeOutcome.Unknown
+    val response = try {
+        client.capturePaneTextViaExec(paneId, timeoutMs = OUTBOUND_DELIVERY_PROBE_TIMEOUT_MS)
+    } catch (cancelled: CancellationException) {
+        throw cancelled
+    } catch (_: Throwable) {
+        return DeliveryProbeOutcome.Unknown
+    }
+    if (response.isError) return DeliveryProbeOutcome.Unknown
+    val count = agentSubmitVisibleTextNeedleCount(response.output, needle)
+    // Issue #1577: a captured baseline demands the count INCREASE (our paste landed);
+    // no baseline (legacy/failed capture) falls back to the #1541 presence check.
+    val landed = if (baselineCount != null) count > baselineCount else count >= 1
+    return if (landed) DeliveryProbeOutcome.AlreadyLanded else DeliveryProbeOutcome.NotLanded
+}
+
+/**
+ * Issue #1577: capture the pane's CURRENT needle occurrence count (via the exec
+ * lane, the same lane the probe uses) so a wire attempt can be recorded WITH a
+ * pre-send baseline. Returns `null` when the needle is underivable or the capture
+ * failed — the caller records the attempt with a null baseline and the later probe
+ * falls back to presence-only.
+ */
+internal suspend fun captureNeedleBaseline(
+    client: TmuxClient,
+    paneId: String,
+    payload: String,
+): Int? {
+    val needle = agentSubmitAckNeedle(payload) ?: return null
+    val response = try {
+        client.capturePaneTextViaExec(paneId, timeoutMs = OUTBOUND_DELIVERY_PROBE_TIMEOUT_MS)
+    } catch (cancelled: CancellationException) {
+        throw cancelled
+    } catch (_: Throwable) {
+        return null
+    }
+    if (response.isError) return null
+    return agentSubmitVisibleTextNeedleCount(response.output, needle)
+}
+
+/**
+ * Issue #1577: record a wire attempt for (pane, payload) AND, on the FIRST push
+ * (no baseline yet), record the pre-send needle occurrence count as the baseline
+ * the later verify-before-resend compares against. Captured once — a re-push after
+ * a NotLanded probe keeps the original baseline (idempotent in [recordWireAttempt]).
+ *
+ * Cost-aware: [localRenderText] is the pane's ALREADY-rendered visible text (a free,
+ * in-memory read — no round-trip). When the payload's needle is NOT already on the
+ * local render (the overwhelmingly common case — a fresh prompt), the baseline is 0
+ * and NO capture is issued: a later probe finding the needle unambiguously means our
+ * paste landed, so presence-only is correct and the hot send path pays nothing. Only
+ * when the payload text is ALREADY visible (e.g. a Codex `Goal blocked (/goal resume)`
+ * status line — the exact #1577 false-positive) is ONE bounded authoritative capture
+ * taken to record the precise pre-send count, so a genuine resend requires the count
+ * to INCREASE and is not falsely `AlreadyLanded`.
+ */
+internal suspend fun OutboundDeliveryLedger.recordWireAttemptWithBaseline(
+    client: TmuxClient,
+    paneId: String,
+    payload: String,
+    localRenderText: String,
+) {
+    if (needleBaseline(paneId, payload) != null) {
+        // A prior push already captured the pre-send baseline; keep it (idempotent).
+        recordWireAttempt(paneId, payload, null)
+        return
+    }
+    val needle = agentSubmitAckNeedle(payload)
+    val alreadyVisible = needle != null &&
+        agentSubmitVisibleTextNeedleCount(listOf(localRenderText), needle) > 0
+    val baseline = if (alreadyVisible) captureNeedleBaseline(client, paneId, payload) else 0
+    recordWireAttempt(paneId, payload, baseline)
+}
 
 internal suspend fun probeNeedleAlreadyLanded(
     client: TmuxClient,

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -14083,13 +14083,12 @@ public class TmuxSessionViewModel @Inject constructor(
         if (client.disconnected.value) {
             return Result.failure(IllegalStateException("Tmux client is disconnected."))
         }
-        // Issue #1526 S1 (verify-before-resend): when a PRIOR attempt at this exact
-        // (pane, payload) ended ambiguously (timeout/drop after the paste may have
-        // run server-side — audit A1/A2), do NOT blindly re-paste. Probe the pane
-        // with the #869 ack needle first: already landed ⇒ submit-Enter ONLY (a
-        // no-op on an already-submitted empty input box); unknown ⇒ fail WITHOUT
-        // resending so the durable row stays queued for a later verified retry;
-        // not landed ⇒ fall through to the normal full send.
+        // Issue #1526 S1 (verify-before-resend): a PRIOR ambiguous attempt at this
+        // exact (pane, payload) — timeout/drop after the paste may have run
+        // server-side (audit A1/A2) — must not blindly re-paste. Probe the pane
+        // (#869 needle, #1577 baseline-aware): already landed ⇒ submit-Enter ONLY;
+        // unknown ⇒ fail WITHOUT resending (row stays queued for a verified retry);
+        // not landed / no prior attempt ⇒ fall through to the normal full send.
         when (verifyBeforeAgentResend(outboundDeliveryLedger, client, paneId, payload)) {
             DeliveryProbeOutcome.AlreadyLanded -> return runCatching {
                 sendNamedKeyToPane(client, paneId, "Enter")
@@ -14104,7 +14103,8 @@ public class TmuxSessionViewModel @Inject constructor(
         }
         return runCatching {
             ensurePaneAcceptsInput(client, paneId)
-            outboundDeliveryLedger.recordWireAttempt(paneId, payload)
+            val render = paneRows[paneId]?.terminalState?.visibleScreenTextSnapshot().orEmpty()
+            outboundDeliveryLedger.recordWireAttemptWithBaseline(client, paneId, payload, render)
             if (payloadBytes.size > TMUX_PASTE_BODY_CHUNK_BYTES || BracketedPaste.containsLineBreak(payloadBytes)) {
                 sendBracketedPaste(client, paneId, payloadBytes)
             } else if (payload.isNotEmpty()) {
@@ -14116,17 +14116,13 @@ public class TmuxSessionViewModel @Inject constructor(
             sendNamedKeyToPane(client, paneId, "Enter")
                 .throwIfTmuxError("submit pasted agent input")
             outboundDeliveryLedger.clear(paneId, payload)
-            // Issue #941 (black-screen B1): the maintainer's "I sent a message and
-            // everything became black" symptom. After the submit Enter, a full-screen
-            // agent TUI repaints — it can `clear`+redraw and emit a `%output` overpaint
-            // that leaves the active pane PARTIAL-black (a single live status/spinner
-            // line, the rest of the prior viewport gone). The reattach/manual-Redraw
-            // heals already restore a partial-black pane; a SEND-triggered overpaint had
-            // NO heal, so the pane stayed black until the user manually redrew. Schedule
-            // a one-shot, guarded active-pane heal that fires ONLY if the pane settles
-            // partial-black/blank after the overpaint. Issue #1353 R4: this is now an EVENT
-            // submission through the shared reconcile entry ([requestReconcile]) rather than a
-            // private send-only poll — the send path no longer owns a bespoke timer.
+            // Issue #941 (black-screen B1): after the submit Enter a full-screen agent
+            // TUI can `clear`+redraw and emit a `%output` overpaint that leaves the
+            // active pane PARTIAL-black (a lone status/spinner line, the rest gone) with
+            // no heal, so it stayed black until a manual redraw. Schedule a guarded
+            // active-pane heal that fires only if the pane settles partial-black/blank.
+            // Issue #1353 R4: an EVENT through the shared reconcile entry ([requestReconcile]),
+            // not a private send-only poll — the send path owns no bespoke timer.
             requestReconcile(client, paneId, ReconcileReason.Send)
         }
     }

--- a/app/src/test/java/com/pocketshell/app/composer/OutboundQueueStoreEncodingTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/OutboundQueueStoreEncodingTest.kt
@@ -168,6 +168,40 @@ class OutboundQueueStoreEncodingTest {
     }
 
     @Test
+    fun encodeDecodeRoundTripsWireNeedleBaselineCount() {
+        // Issue #1577: the pre-send needle baseline must survive process death so a
+        // rebuilt ledger compares the CURRENT count against it (only an increase =
+        // landed) instead of a presence-only match that a status line false-trips.
+        val items = listOf(
+            OutboundItem(
+                id = "id-baseline",
+                sessionKey = "sessA",
+                cleanText = "/goal resume",
+                state = OutboundState.InFlight,
+                createdAtMs = 1L,
+                paneId = "%0",
+                wireAttempted = true,
+                wireAttemptedAtMs = 1_700_000_009_000,
+                wireNeedleBaselineCount = 1,
+            ),
+        )
+        val decoded = decodeOutboundItems("sessA", encodeOutboundItems(items))
+        assertEquals(items, decoded)
+        assertEquals(1, decoded.single().wireNeedleBaselineCount)
+    }
+
+    @Test
+    fun decodeLegacyRowsWithoutBaselineDefaultToNull() {
+        // Issue #1577: pre-#1577 rows ended at wireAttemptedAtMs (field 14). They must
+        // decode to wireNeedleBaselineCount=null (presence-only fallback), not a
+        // malformed row.
+        val raw = "id-legacy\tx\t1\tInFlight\t100\t\t0\t\t\t%0\tRawBytes\tclaude\tsk123\t1\t1700000009000"
+        val decoded = decodeOutboundItems("sessA", raw).single()
+        assertTrue(decoded.wireAttempted)
+        assertEquals(null, decoded.wireNeedleBaselineCount)
+    }
+
+    @Test
     fun decodeUnknownRouteDefaultsToRawBytes() {
         val raw = "id-unknown\tx\t1\tQueued\t100\t\t0\t\t\t%0\tFutureRoute\tclaude"
         val decoded = decodeOutboundItems("sessA", raw).single()

--- a/app/src/test/java/com/pocketshell/app/composer/OutboundQueueStoreWireAttemptTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/OutboundQueueStoreWireAttemptTest.kt
@@ -58,25 +58,48 @@ class OutboundQueueStoreWireAttemptTest {
     }
 
     @Test
-    fun claimNextStampsWireAttemptedOnTheRow() {
+    fun claimNextDoesNotStampWireAttempted() {
+        // Issue #1577: the CLAIM (InFlight) must NOT stamp `wireAttempted` — a queue
+        // row is claimed before the composer send emits a single byte. Stamping at
+        // claim marked every FIRST send as a prior wire attempt, forcing the #1526
+        // verify-before-resend probe on the first send (the silent false-success
+        // drop). The flag is set ONLY at the actual wire push (`markWireAttempted`).
         val store = InMemoryOutboundQueueStore()
         val row = store.enqueue("sessA", "deploy now", paneId = "%0")
         assertFalse(store.item(row.id)!!.wireAttempted)
 
         val claimed = store.claimNext("sessA")!!
         assertEquals(OutboundState.InFlight, claimed.state)
-        assertTrue("claiming for a wire attempt sets the durable flag", claimed.wireAttempted)
-        assertNotNull(claimed.wireAttemptedAtMs)
-        assertTrue(store.hasWireAttempt("%0", "deploy now"))
+        assertFalse("claiming must NOT set the durable wire-attempt flag (#1577)", claimed.wireAttempted)
+        assertFalse(store.hasWireAttempt("%0", "deploy now"))
     }
 
     @Test
-    fun markInFlightStampsWireAttempted() {
+    fun markInFlightDoesNotStampWireAttempted() {
+        // Issue #1577: as with claimNext, markInFlight (what the composer runs before
+        // dispatch) must not stamp the flag before any byte is pushed.
         val store = InMemoryOutboundQueueStore()
         val row = store.enqueue("sessA", "restart pool", paneId = "%0")
         val updated = store.markInFlight(row.id)!!
-        assertTrue(updated.wireAttempted)
-        assertTrue(store.hasWireAttempt("%0", "restart pool"))
+        assertFalse(updated.wireAttempted)
+        assertFalse(store.hasWireAttempt("%0", "restart pool"))
+    }
+
+    @Test
+    fun wirePushStampsWireAttemptedWithBaseline() {
+        // Issue #1541/#1577: the ONLY correct write site — the actual wire push —
+        // sets the flag and records the pre-send needle baseline on the row.
+        val store = InMemoryOutboundQueueStore()
+        val row = store.enqueue("sessA", "deploy now", paneId = "%0")
+        store.claim(row.id) // InFlight, but no flag yet (#1577)
+        assertFalse(store.hasWireAttempt("%0", "deploy now"))
+
+        val pushed = store.markWireAttempted("%0", "deploy now", baselineCount = 0)!!
+        assertTrue("the wire push sets the durable flag", pushed.wireAttempted)
+        assertNotNull(pushed.wireAttemptedAtMs)
+        assertEquals(0, pushed.wireNeedleBaselineCount)
+        assertTrue(store.hasWireAttempt("%0", "deploy now"))
+        assertEquals(0, store.wireNeedleBaseline("%0", "deploy now"))
     }
 
     @Test
@@ -99,6 +122,8 @@ class OutboundQueueStoreWireAttemptTest {
         val store = InMemoryOutboundQueueStore()
         val row = store.enqueue("sessA", "deferred payload", paneId = "%0")
         store.markInFlight(row.id)
+        // Issue #1577: the flag is set at the wire push, not the claim.
+        store.markWireAttempted("%0", "deferred payload")
         // The drop-failure path defers the row back to Queued (issue #987) — the
         // wire attempt MUST persist so the re-flush verifies before re-pasting.
         val requeued = store.requeueForRetry(row.id)!!
@@ -112,6 +137,7 @@ class OutboundQueueStoreWireAttemptTest {
         val store = InMemoryOutboundQueueStore()
         val row = store.enqueue("sessA", "stale payload", paneId = "%0", createdAtMs = 1_000L)
         store.markInFlight(row.id)
+        store.markWireAttempted("%0", "stale payload") // #1577: flag set at the wire push
         val requeued = store.requeueStaleInFlight("sessA", cutoffMs = Long.MAX_VALUE)
         assertEquals(1, requeued.size)
         assertTrue("a stale-recovered row keeps its durable wire attempt", requeued.single().wireAttempted)
@@ -123,6 +149,7 @@ class OutboundQueueStoreWireAttemptTest {
         val store = InMemoryOutboundQueueStore()
         val row = store.enqueue("sessA", "delivered payload", paneId = "%0")
         store.markInFlight(row.id)
+        store.markWireAttempted("%0", "delivered payload") // #1577: flag set at the wire push
         assertTrue(store.hasWireAttempt("%0", "delivered payload"))
         assertTrue(store.markDelivered(row.id))
         assertFalse(
@@ -137,11 +164,14 @@ class OutboundQueueStoreWireAttemptTest {
         val store = InMemoryOutboundQueueStore()
         val row = store.enqueue("sessA", "cancel me", paneId = "%0")
         store.markInFlight(row.id)
+        store.markWireAttempted("%0", "cancel me") // #1577: flag set at the wire push
+        assertTrue(store.hasWireAttempt("%0", "cancel me"))
         assertTrue(store.remove(row.id))
         assertFalse(store.hasWireAttempt("%0", "cancel me"))
 
         val other = store.enqueue("sessA", "clear me", paneId = "%0")
         store.markInFlight(other.id)
+        store.markWireAttempted("%0", "clear me")
         store.clearSession("sessA")
         assertFalse(store.hasWireAttempt("%0", "clear me"))
     }
@@ -159,7 +189,8 @@ class OutboundQueueStoreWireAttemptTest {
     fun wireAttemptSurvivesProcessRestartForTheRebuiltLedger() {
         val first = SharedPrefsOutboundQueueStore(context)
         val row = first.enqueue("sessA", "survive the restart", paneId = "%0")
-        first.markInFlight(row.id) // pushed to the wire → durable flag persisted
+        first.markInFlight(row.id)
+        first.markWireAttempted("%0", "survive the restart") // #1577: pushed to the wire → durable flag persisted
 
         // A brand-new store over the same on-disk prefs = the fresh process / the
         // VM-clear-rebuilt ledger's durable backing.
@@ -182,6 +213,7 @@ class OutboundQueueStoreWireAttemptTest {
         val first = SharedPrefsOutboundQueueStore(context)
         val row = first.enqueue("sessA", "delivered but prune lost", paneId = "%0")
         first.markInFlight(row.id)
+        first.markWireAttempted("%0", "delivered but prune lost") // #1577: flag set at the wire push
         // markDelivered() is NEVER persisted (its apply() was lost) — the InFlight
         // row survives the restart with the flag intact.
         val afterRestart = SharedPrefsOutboundQueueStore(context)

--- a/app/src/test/java/com/pocketshell/app/tmux/OutboundDeliveryGuardTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/OutboundDeliveryGuardTest.kt
@@ -399,31 +399,37 @@ class OutboundDeliveryGuardTest {
 
     /**
      * Issue #1542 (finding D7) — class-coverage limb: an orphaned InFlight row that
-     * ACTUALLY landed. A row claimed InFlight stamps the durable `wireAttempted`
-     * flag on the row itself (via the InFlight claim → #1541); when that VM churns /
+     * ACTUALLY landed. When a send reaches the wire it durably stamps `wireAttempted`
+     * on the row (issue #1577: at the WIRE PUSH, not the claim); when that VM churns /
      * dies mid-send, the poll-lane orphan sweep re-arms the row and the retry lane
      * re-dispatches it through the SAME verify-before-resend send path with a ledger
      * REBUILT from the durable store. Because the earlier attempt landed server-side,
      * the probe must resolve `AlreadyLanded` — so the re-dispatch submits Enter only
-     * and never re-pastes (occurrence stays 1, no duplicate). RED if the claim did
+     * and never re-pastes (occurrence stays 1, no duplicate). RED if the wire push did
      * not stamp the durable flag (rebuilt ledger has no memory ⇒ blind re-paste ⇒
      * occurrence 2). This composes with #1541 rather than adding a second flag.
      */
     @Test
-    fun issue1542_D7_orphanedInFlightThatLandedVerifiesAlreadyLandedViaClaimStampedDurableFlag() = runTest {
+    fun issue1542_D7_orphanedInFlightThatLandedVerifiesAlreadyLandedViaWirePushDurableFlag() = runTest {
         val store = com.pocketshell.app.composer.InMemoryOutboundQueueStore()
         val paneId = "%7"
         val payload = "orphaned prompt that already landed"
-        // The prior VM enqueued and CLAIMED the row InFlight (its send began). The
-        // InFlight claim durably stamps `wireAttempted` on the row (#1541).
+        // The prior VM enqueued and CLAIMED the row InFlight (its send began), then
+        // PUSHED it to the wire — the push durably stamps `wireAttempted` (#1577: the
+        // claim itself no longer stamps).
         val row = store.enqueue("sessA", payload, paneId = paneId)
         store.claim(row.id)
         assertEquals(
             com.pocketshell.app.composer.OutboundState.InFlight,
             store.item(row.id)!!.state,
         )
+        assertFalse(
+            "the claim alone must NOT record a wire attempt (#1577)",
+            store.hasWireAttempt(paneId, payload),
+        )
+        store.markWireAttempted(paneId, payload) // the actual wire push
         assertTrue(
-            "the InFlight claim must durably record the wire attempt on the row",
+            "the wire push must durably record the wire attempt on the row",
             store.hasWireAttempt(paneId, payload),
         )
 
@@ -444,6 +450,76 @@ class OutboundDeliveryGuardTest {
             "an orphaned InFlight row that actually landed must verify AlreadyLanded (occurrence 1)",
             DeliveryProbeOutcome.AlreadyLanded,
             outcome,
+        )
+    }
+
+    /**
+     * Issue #1577: when the payload is NOT already on the pane's LOCAL render at push
+     * time (the common case — a fresh prompt), the wire attempt records baseline 0
+     * with NO capture round-trip; a later probe finding the payload (count 1 > 0)
+     * resolves `AlreadyLanded` (presence is unambiguous — our paste added it).
+     */
+    @Test
+    fun baselineFromLocalRenderSkipsCaptureWhenPayloadNotAlreadyVisible() = runTest {
+        val ledger = OutboundDeliveryLedger()
+        val client = captureShowing("$ /goal resume") // the resend probe sees it landed
+
+        ledger.recordWireAttemptWithBaseline(client, "%0", "/goal resume", localRenderText = "$ ")
+
+        assertTrue(
+            "no baseline capture round-trip when the payload is not already on the render",
+            client.capturePaneTextViaExecCalls.isEmpty(),
+        )
+        assertEquals(0, ledger.needleBaseline("%0", "/goal resume"))
+        assertEquals(
+            "a resend that finds the payload (count 1 > baseline 0) is AlreadyLanded",
+            DeliveryProbeOutcome.AlreadyLanded,
+            verifyBeforeAgentResend(ledger, client, "%0", "/goal resume"),
+        )
+    }
+
+    /**
+     * Issue #1577 — THE reported class at the guard level: the payload text is ALREADY
+     * on the pane (a Codex `Goal blocked (/goal resume)` status line). The wire attempt
+     * takes ONE authoritative capture to record the precise pre-send baseline, so a
+     * genuine resend requires the occurrence count to INCREASE:
+     *  - paste did NOT land (still only the status line, count == baseline) ⇒ NotLanded
+     *    ⇒ the caller re-sends (NO false-`AlreadyLanded` silent drop — the #1577 bug), and
+     *  - paste DID land (status line + submitted command, count > baseline) ⇒ AlreadyLanded
+     *    ⇒ deduped to exactly-once (the #1526 guarantee is preserved).
+     */
+    @Test
+    fun baselineCapturesPreSendCountWhenPayloadAlreadyOnRenderSoResendRequiresIncrease() = runTest {
+        val ledger = OutboundDeliveryLedger()
+        val client = FakeTmuxClient()
+        val statusLine = "gpt-5.6-sol medium · Goal blocked (/goal resume)"
+
+        // The payload is already visible on the local render ⇒ ONE authoritative
+        // baseline capture: the status line shows the needle once ⇒ baseline 1.
+        client.capturePaneResponses.addLast(CommandResponse(number = 0L, output = listOf(statusLine), isError = false))
+        ledger.recordWireAttemptWithBaseline(client, "%0", "/goal resume", localRenderText = statusLine)
+        assertEquals("the pre-send baseline is captured authoritatively", 1, ledger.needleBaseline("%0", "/goal resume"))
+        assertEquals("exactly one baseline capture round-trip", 1, client.capturePaneTextViaExecCalls.size)
+
+        // A genuine resend whose paste did NOT land: the pane still shows ONLY the
+        // status line (count 1 == baseline 1) ⇒ NotLanded ⇒ re-send (no false drop).
+        client.capturePaneResponses.addLast(CommandResponse(number = 0L, output = listOf(statusLine), isError = false))
+        assertEquals(
+            "a payload still only on the status line (count == baseline) must NOT be " +
+                "falsely AlreadyLanded (the #1577 false-success drop)",
+            DeliveryProbeOutcome.NotLanded,
+            verifyBeforeAgentResend(ledger, client, "%0", "/goal resume"),
+        )
+
+        // A resend whose paste DID land: the pane now shows the status line AND the
+        // submitted command (count 2 > baseline 1) ⇒ AlreadyLanded ⇒ deduped.
+        client.capturePaneResponses.addLast(
+            CommandResponse(number = 0L, output = listOf(statusLine, "> /goal resume"), isError = false),
+        )
+        assertEquals(
+            "a payload whose occurrence count INCREASED (our paste landed) is AlreadyLanded",
+            DeliveryProbeOutcome.AlreadyLanded,
+            verifyBeforeAgentResend(ledger, client, "%0", "/goal resume"),
         )
     }
 

--- a/app/src/test/java/com/pocketshell/app/tmux/OutboundExactlyOnceDeliveryTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/OutboundExactlyOnceDeliveryTest.kt
@@ -76,7 +76,10 @@ class OutboundExactlyOnceDeliveryTest : TmuxSessionViewModelTestBase() {
     fun resendAfterAmbiguousFailureDoesNotRepasteWhenPayloadAlreadyLanded() = runTest(scheduler) {
         val client = FakeTmuxClient()
         // The pane's visible text reflects the landed paste — what the #869
-        // needle probe (and the ack gate) will see.
+        // needle probe (and the ack gate) will see. Issue #1577: the unit VM has no
+        // attached emulator render, so the pre-send baseline is 0 (payload not on the
+        // local render) with no capture round-trip; the resend probe then sees count
+        // 1 > 0 ⇒ AlreadyLanded.
         client.defaultCaptureResponse = CommandResponse(
             number = 0L,
             output = listOf("> deploy the staging build now"),

--- a/app/src/test/java/com/pocketshell/app/tmux/OutboundSlashCommandFalseSuccessTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/OutboundSlashCommandFalseSuccessTest.kt
@@ -1,0 +1,212 @@
+package com.pocketshell.app.tmux
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.pocketshell.app.composer.OutboundRoute
+import com.pocketshell.app.composer.SharedPrefsOutboundQueueStore
+import com.pocketshell.core.agents.AgentDetection
+import com.pocketshell.core.agents.AgentKind
+import com.pocketshell.core.tmux.CommandResponse
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Issue #1577 (reproduce-first, D33/G10) — the SILENT FALSE-SUCCESS drop of a
+ * composer send whose payload text is already visible on the agent pane.
+ *
+ * The maintainer sent `/goal resume` (via the slash palette / composer, NOT the
+ * keyboard) to a Codex session whose status line permanently renders
+ * `Goal blocked (/goal resume)`. The composer cleared / the row marked Delivered,
+ * but the command never reached the agent — a bare Enter was sent instead of the
+ * payload.
+ *
+ * Root cause (proven by audit): the composer enqueues the row and immediately
+ * `markInFlight`s it — and `claimedForAttempt()` USED TO stamp the durable
+ * `wireAttempted` flag at CLAIM time, BEFORE any byte was pushed. So the #1526
+ * verify-before-resend probe ran on the FIRST send, and its whole-viewport
+ * needle (`/goalresume`) false-matched the ever-visible status line ⇒
+ * `AlreadyLanded` ⇒ Enter-only, no paste, reported success.
+ *
+ * These tests drive the REAL composer path (`enqueue` + `markInFlight` on the
+ * durable store, then `sendAgentPayloadToPaneResult` on a durable-backed VM),
+ * against a [FakeTmuxClient] whose `capture-pane` shows the pre-existing payload
+ * text — the exact on-device state.
+ *
+ * RED on base: the payload is NEVER pasted (only Enter), yet the send reports
+ * success (`pasteCount == 0`).
+ * GREEN with the fix (claim no longer stamps `wireAttempted`; the probe is
+ * baseline-aware): the FIRST send pastes the payload onto the wire
+ * (`pasteCount == 1`).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class OutboundSlashCommandFalseSuccessTest : TmuxSessionViewModelTestBase() {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private fun codexDetection(): AgentDetection = AgentDetection(
+        agent = AgentKind.Codex,
+        sourcePath = "/home/u/.codex/sessions/rollout.jsonl",
+        sessionId = "rollout",
+        confidence = AgentDetection.Confidence.ProcessConfirmed,
+    )
+
+    private fun FakeTmuxClient.literalPasteCount(payload: String): Int =
+        sentCommands.count { it.startsWith("send-keys -l -t %0") && it.contains(payload) }
+
+    private fun FakeTmuxClient.enterCount(): Int =
+        sentCommands.count { it == "send-keys -t %0 Enter" }
+
+    /** A durable-backed VM (real app context ⇒ the store-backed delivery ledger). */
+    private fun newDurableConnectedVm(client: FakeTmuxClient): TmuxSessionViewModel {
+        val vm = newVm(applicationContext = context)
+        vm.attachClientForTest(client)
+        vm.startAgentConversationForTest("%0", codexDetection())
+        vm.setAgentSubmitEnterDelayForTest(0)
+        vm.setAgentSubmitAckTimeoutForTest(50)
+        return vm
+    }
+
+    private fun clientShowing(vararg lines: String): FakeTmuxClient = FakeTmuxClient().apply {
+        defaultCaptureResponse = CommandResponse(number = 0L, output = lines.toList(), isError = false)
+    }
+
+    /**
+     * THE reported case: `/goal resume` to a Codex session whose status line shows
+     * `Goal blocked (/goal resume)`. The composer enqueues + claims the row (the
+     * markInFlight the real send path runs) and then delivers it.
+     *
+     * RED on base: `markInFlight` stamped the durable wire attempt ⇒ the first send
+     * probes ⇒ the status-line needle false-matches ⇒ Enter-only, no paste (a
+     * silent false-success). GREEN: the payload is pasted onto the wire.
+     */
+    @Test
+    fun firstSendOfSlashCommandVisibleOnStatusLinePastesThePayload() = runTest(scheduler) {
+        val payload = "/goal resume"
+        // The composer path: enqueue the row, then markInFlight (exactly what
+        // enqueueOutboundSend does before dispatch).
+        val store = SharedPrefsOutboundQueueStore(context)
+        val row = store.enqueue("sessGoal", payload, paneId = "%0", route = OutboundRoute.AgentPayload)
+        store.markInFlight(row.id)
+
+        // The Codex pane permanently advertises the command it wants sent.
+        val client = clientShowing("gpt-5.6-sol medium · Context 42% · Goal blocked (/goal resume)")
+        val vm = newDurableConnectedVm(client)
+
+        val result = async { vm.sendAgentPayloadToPaneResult("%0", payload, AgentKind.Codex) }
+        advanceUntilIdle()
+        assertTrue("the send reports success either way (the drop is silent)", result.await().isSuccess)
+
+        assertEquals(
+            "the FIRST send of a slash command must PASTE the payload onto the wire — " +
+                "not skip it as a false-`AlreadyLanded` because the status line already " +
+                "shows the command (RED on base: pasteCount == 0, Enter-only)",
+            1,
+            client.literalPasteCount(payload),
+        )
+    }
+
+    /**
+     * Class coverage (a): the same via the Conversation `Echo` route
+     * ([sendToAgentPaneResult] → the SAME `sendAgentPayloadToPaneResult` chokepoint).
+     */
+    @Test
+    fun firstSendViaEchoRouteWithVisiblePayloadPastesThePayload() = runTest(scheduler) {
+        val payload = "/goal resume"
+        val store = SharedPrefsOutboundQueueStore(context)
+        val row = store.enqueue("sessEcho", payload, paneId = "%0", route = OutboundRoute.AgentConversation)
+        store.markInFlight(row.id)
+
+        val client = clientShowing("Goal blocked (/goal resume)")
+        val vm = newDurableConnectedVm(client)
+
+        val result = async { vm.sendToAgentPaneResult("%0", payload) }
+        advanceUntilIdle()
+        assertTrue(result.await().isSuccess)
+
+        assertEquals(
+            "the Echo/Conversation route must also paste the payload on the first send",
+            1,
+            client.literalPasteCount(payload),
+        )
+    }
+
+    /**
+     * Class coverage (b): a SHORT payload ("ok") already visible on the pane. The
+     * composer needle has no minimum length, so a presence-only probe would drop
+     * every short confirmation whose text is on screen.
+     */
+    @Test
+    fun firstSendOfShortPayloadAlreadyVisiblePastesThePayload() = runTest(scheduler) {
+        val payload = "ok"
+        val store = SharedPrefsOutboundQueueStore(context)
+        val row = store.enqueue("sessOk", payload, paneId = "%0", route = OutboundRoute.AgentPayload)
+        store.markInFlight(row.id)
+
+        // "ok" is already visible (e.g. echoed in the transcript / a prior line).
+        val client = clientShowing("> ok, running the smoke suite")
+        val vm = newDurableConnectedVm(client)
+
+        val result = async { vm.sendAgentPayloadToPaneResult("%0", payload, AgentKind.Codex) }
+        advanceUntilIdle()
+        assertTrue(result.await().isSuccess)
+
+        assertEquals(
+            "a short payload already visible on the pane must still be pasted on the first send",
+            1,
+            client.literalPasteCount(payload),
+        )
+    }
+
+    /**
+     * Class coverage (c) — the GENUINE dedupe still works (proves the fix did NOT
+     * break #1526 exactly-once). A real resend whose payload DID land once (the
+     * paste ADDED an occurrence over the pre-send baseline) must be suppressed to
+     * Enter-only — the payload reaches the agent EXACTLY once across the ambiguous
+     * failure + resend.
+     */
+    @Test
+    fun genuineResendOfLandedPayloadIsDedupedToExactlyOnce() = runTest(scheduler) {
+        val payload = "/goal resume"
+        val store = SharedPrefsOutboundQueueStore(context)
+        val row = store.enqueue("sessDedupe", payload, paneId = "%0", route = OutboundRoute.AgentPayload)
+        store.markInFlight(row.id)
+
+        // The unit VM has no attached emulator render, so the pre-send baseline is 0
+        // (the payload is not on the local render) and NO baseline capture round-trip
+        // is issued. After the paste lands the pane shows the payload ⇒ the resend
+        // probe reads count 1 > baseline 0 ⇒ AlreadyLanded.
+        val client = clientShowing("$ /goal resume")
+        val vm = newDurableConnectedVm(client)
+
+        // Attempt 1: the paste lands, the submit Enter's exec result is lost.
+        client.throwOnCommandPrefix = "send-keys -t %0 Enter"
+        client.throwOnCommandRemaining = 1
+        val first = async { vm.sendAgentPayloadToPaneResult("%0", payload, AgentKind.Codex) }
+        advanceUntilIdle()
+        assertTrue("attempt 1 must surface the ambiguous failure", first.await().isFailure)
+        assertEquals("attempt 1 pastes exactly once", 1, client.literalPasteCount(payload))
+
+        // The resend (reconnect auto-flush / manual retry) probes: count (1) exceeds
+        // the baseline (0) ⇒ AlreadyLanded ⇒ Enter-only, NO second paste.
+        val second = async { vm.sendAgentPayloadToPaneResult("%0", payload, AgentKind.Codex) }
+        advanceUntilIdle()
+        assertTrue("the verified resend must succeed", second.await().isSuccess)
+        assertEquals(
+            "a genuine resend of a payload that already LANDED must be deduped to " +
+                "exactly ONE paste (the baseline-aware probe still catches real duplicates)",
+            1,
+            client.literalPasteCount(payload),
+        )
+        assertTrue("the resend must still submit (Enter-only)", client.enterCount() >= 2)
+    }
+}


### PR DESCRIPTION
Reviewer-APPROVED. Fixes a message-queue false-success: a composer send whose text was already visible on the pane (e.g. `/goal resume` on Codex's 'Goal blocked' status line, or a short 'ok') was marked Delivered while only a bare Enter reached the agent.

- Root: `wireAttempted` stamped at queue-claim forced the #1526 verify-before-resend probe on the first send; the whole-viewport needle false-matched on-screen text.
- Fix: set `wireAttempted` only at the real wire push; make the probe baseline-aware (count must INCREASE over a durable pre-send baseline), preserving #1526 exactly-once.
- Reviewer-driven red→green captured; exactly-once no-regression verified (OutboundExactlyOnceDeliveryTest + guard tests green); full 3792/0; hygiene green (VM shrank).

For v0.4.35. Closes #1577.