### PR TITLE
release: v0.4.35 — dead-Reconnect recovery + slash false-success drop

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,8 +65,8 @@ android {
         applicationId = "com.pocketshell.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 81
-        versionName = "0.4.34"
+        versionCode = 82
+        versionName = "0.4.35"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/tools/pocketshell/pyproject.toml
+++ b/tools/pocketshell/pyproject.toml
@@ -8,7 +8,7 @@ name = "pocketshell"
 # scripts/check-pypi-version.sh enforces this; .github/workflows/build.yml
 # runs that check before publishing to PyPI. See
 # tools/pocketshell/README.md ("Release flow") for the bump procedure.
-version = "0.4.34"
+version = "0.4.35"
 description = "Unified server-side Python utility for the PocketShell Android client."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Version bump 0.4.34 → 0.4.35 (versionCode 81 → 82), tools/pocketshell in lockstep.

Ships #1574 (dead-Reconnect in-place recovery) + #1577 (composer slash/short-reply silent false-success drop), both reviewer-APPROVED and already merged to main. Release gate + tag follow on green.