### PR TITLE
composer: shell (RawBytes) lane delivery parity — no false-success/duplicate (#1586)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/tmux/OutboundDeliveryGuard.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/OutboundDeliveryGuard.kt
@@ -104,6 +104,94 @@ internal suspend fun verifyBeforeAgentResend(
     return outcome
 }
 
+/**
+ * Issue #1586 — RawBytes (shell/composer) lane exactly-once send. The agent-payload
+ * lane ([TmuxSessionViewModel.sendAgentPayloadToPaneResult]) got the #1577
+ * verify-before-resend ledger + tmux-error check, but the composer RawBytes lane
+ * ([TmuxSessionViewModel.writeInputToPaneResult]) had NEITHER — two HIGH holes:
+ *
+ *  - H1a false-success: [send] must surface a tmux `%error` (dead/closed pane) as a
+ *    real failure ([throwIfTmuxError] inside [send]), so a row is not marked
+ *    Delivered with nothing delivered. That check lives in the caller's byte-send
+ *    ([TmuxSessionViewModel.sendInputBytesToPane]); this wrapper just propagates it.
+ *  - H1b blind duplicate: an ambiguous failure (bytes may have landed, exec result
+ *    lost) followed by the composer auto-retry re-ran the shell command TWICE. This
+ *    routes the SAME baseline-aware [ledger] the agent lane uses (via
+ *    [verifyBeforeAgentResend] / [recordWireAttemptWithBaseline]) so a retry PROBES
+ *    for the already-landed payload instead of blind-re-sending.
+ *
+ * On `AlreadyLanded` the payload TEXT landed server-side, but the ambiguous cut may
+ * have dropped its TERMINATING submit — the #1586 H1b case is exactly "literal lands,
+ * submit-Enter throws", which leaves the shell command TYPED-BUT-NEVER-RUN (the probe
+ * needle cannot tell "typed on the prompt" from "already ran"). So — mirroring the
+ * agent lane ([TmuxSessionViewModel.sendAgentPayloadToPaneResult], which submits
+ * Enter-only on `AlreadyLanded`) — complete the delivery with an Enter-ONLY submit
+ * ([submitEnter]), NEVER re-sending the payload text (no duplicate). The submit is
+ * issued ONLY when the original send actually carried one (a trailing CR/LF the
+ * [payload] key trimmed off); a text-only / non-submit RawBytes send (partial typed
+ * input, a caret-position send) has nothing to complete, so no spurious Enter is
+ * injected. Then clear the ledger and run [afterDelivered] (the post-send reconcile
+ * heal). `Unknown` keeps the row queued WITHOUT resending (never "unknown ⇒ resend").
+ * `NotLanded` / no-prior-attempt falls through to the full send.
+ *
+ * The ledger is keyed on the raw byte payload; a fire-and-forget keystroke send with
+ * no matching durable queue row records only a volatile attempt that is cleared on
+ * success (net zero — no durable pollution), exactly like the agent lane's transient
+ * rows. The needle-count baseline (#1577) keeps short payloads safe from a
+ * false-positive `AlreadyLanded` drop.
+ */
+internal suspend fun deliverRawInputWithGuard(
+    ledger: OutboundDeliveryLedger,
+    client: TmuxClient,
+    paneId: String,
+    bytes: ByteArray,
+    localRenderText: String,
+    send: suspend (TmuxClient, String, ByteArray) -> Unit,
+    submitEnter: suspend (TmuxClient, String) -> Unit,
+    afterDelivered: suspend (TmuxClient, String, ByteArray) -> Unit,
+): Result<Unit> {
+    // Key the ledger on the payload WITHOUT its trailing submit CR/LF: the composer
+    // enqueues the durable row's `cleanText` without the CR it appends on the wire,
+    // so trimming aligns the (pane, payload) key with the durable `wireAttempted`
+    // row — the same VM-clear/back-nav durability the agent lane gets (#1541). The
+    // full [bytes] (CR included) are still what [send] pushes. Pure control/Enter
+    // input trims to empty — nothing meaningful to probe/dedupe, so it does a plain
+    // error-checked send (H1a still applies via [send]).
+    val fullText = String(bytes, Charsets.UTF_8)
+    val payload = fullText.trimEnd('\r', '\n')
+    if (payload.isEmpty()) {
+        return runCatching {
+            send(client, paneId, bytes)
+            afterDelivered(client, paneId, bytes)
+        }
+    }
+    when (verifyBeforeAgentResend(ledger, client, paneId, payload)) {
+        DeliveryProbeOutcome.AlreadyLanded -> return runCatching {
+            // Issue #1586 (H1b): the payload TEXT landed but the ambiguous cut may have
+            // dropped its terminating submit — do NOT drop the delivery silently.
+            // Mirror the agent lane: submit Enter-ONLY (never the payload text, so no
+            // duplicate), and only when the original send actually carried a submit (a
+            // trailing CR/LF); a non-submit send has nothing to complete, so no spurious
+            // Enter is injected.
+            if (fullText.length > payload.length) {
+                submitEnter(client, paneId)
+            }
+            ledger.clear(paneId, payload)
+            afterDelivered(client, paneId, bytes)
+        }
+        DeliveryProbeOutcome.Unknown -> return Result.failure(
+            IllegalStateException("Prior shell send outcome unknown; kept queued without resend."),
+        )
+        DeliveryProbeOutcome.NotLanded, null -> Unit
+    }
+    return runCatching {
+        ledger.recordWireAttemptWithBaseline(client, paneId, payload, localRenderText)
+        send(client, paneId, bytes)
+        ledger.clear(paneId, payload)
+        afterDelivered(client, paneId, bytes)
+    }
+}
+
 /** Bounded round-trip for a verify-before-resend `capture-pane` probe. */
 internal const val OUTBOUND_DELIVERY_PROBE_TIMEOUT_MS: Long = 4_000L
 

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxInputCommands.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxInputCommands.kt
@@ -48,7 +48,11 @@ internal suspend fun sendRawInputBytes(
     // Issue #1460: the `-H` raw-byte injection rides the interactive send exec
     // lane, not the shared `-CC` channel, so it does not head-of-line-block
     // behind a live agent `%output` burst.
+    // Issue #1586 (H1a): surface a tmux `%error` (dead/closed pane) as a real
+    // failure instead of swallowing it, so a control-byte / terminal-response
+    // send to a dead pane fails visibly (agent-lane parity).
     client.sendKeysViaExec("send-keys -H -t $paneId $hex")
+        .throwIfTmuxError("send raw bytes to pane $paneId")
 }
 
 /**

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -15329,24 +15329,26 @@ public class TmuxSessionViewModel @Inject constructor(
         return writeInputToPaneResult(client, paneId, bytes)
     }
 
+    // Issue #1586: RawBytes lane rides the agent lane's verify-before-resend ledger (H1b).
     private suspend fun writeInputToPaneResult(
         client: TmuxClient,
         paneId: String,
         bytes: ByteArray,
-    ): Result<Unit> = runCatching {
-        sendInputBytesToPane(client, paneId, bytes)
-        // Issue #1153 (class coverage — shell pane): the agent send path
-        // ([sendAgentPayloadToPaneResult]) already schedules the post-send overpaint heal, but
-        // the shell `RawBytes` route had NONE. A MULTI-LINE paste into a full-screen shell TUI
-        // (vim/htop/less/…) can trigger the same clear+redraw overpaint that leaves the pane
-        // half-black on a live transport. Schedule the same bounded, capture-diff-gated heal
-        // ONLY for a multi-line payload — a single keystroke never overpaints the whole
-        // viewport, so per-keystroke input pays nothing. Issue #1353 R4: via the shared
-        // reconcile-event entry, same as the agent send path.
-        if (BracketedPaste.containsLineBreak(bytes)) {
-            requestReconcile(client, paneId, ReconcileReason.Send)
-        }
-    }
+    ): Result<Unit> = deliverRawInputWithGuard(
+        ledger = outboundDeliveryLedger,
+        client = client,
+        paneId = paneId,
+        bytes = bytes,
+        localRenderText = paneRows[paneId]?.terminalState?.visibleScreenTextSnapshot().orEmpty(),
+        send = { c, p, b -> sendInputBytesToPane(c, p, b) },
+        // Issue #1586 (H1b): AlreadyLanded -> Enter-only submit (agent-lane parity).
+        submitEnter = { c, p ->
+            sendNamedKeyToPane(c, p, "Enter").throwIfTmuxError("submit typed shell input")
+        },
+        afterDelivered = { c, p, b ->
+            if (BracketedPaste.containsLineBreak(b)) requestReconcile(c, p, ReconcileReason.Send)
+        },
+    )
 
     internal fun sendControlInputToPane(
         paneId: String,
@@ -15611,16 +15613,17 @@ public class TmuxSessionViewModel @Inject constructor(
             sendBracketedPaste(client, paneId, bytes)
             return
         }
+        // Issue #1586 (H1a): a tmux `%error` (dead pane) must FAIL the send, not false-succeed.
         for (token in inputTokens(bytes)) {
             when (token) {
-                is TmuxInputToken.Literal -> {
+                is TmuxInputToken.Literal ->
                     if (token.text.isNotEmpty()) {
                         sendLiteralTextKeys(client, paneId, token.text)
+                            .throwIfTmuxError("type into $paneId")
                     }
-                }
-                is TmuxInputToken.NamedKey -> {
+                is TmuxInputToken.NamedKey ->
                     sendNamedKeyToPane(client, paneId, token.name)
-                }
+                        .throwIfTmuxError("send ${token.name} to $paneId")
             }
         }
     }

--- a/app/src/test/java/com/pocketshell/app/tmux/FakeTmuxClient.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/FakeTmuxClient.kt
@@ -180,6 +180,18 @@ internal class FakeTmuxClient(
 
     var throwOnCommandException: Throwable = TmuxClientException("tmux command timed out")
 
+    /**
+     * Issue #1586 (H1a): return a tmux `%error` [CommandResponse] (isError=true,
+     * carrying [errorOnCommandOutput] as stderr) for the next
+     * [errorOnCommandRemaining] commands whose text starts with this prefix —
+     * modelling a `send-keys` to a dead/closed pane. Default null ⇒ no injection.
+     */
+    var errorOnCommandPrefix: String? = null
+
+    var errorOnCommandRemaining: Int = 0
+
+    var errorOnCommandOutput: List<String> = listOf("can't find pane")
+
     var failBestEffortOnCommandPrefix: String? = null
 
     var bestEffortException: Throwable = TmuxClientException("tmux best-effort command timed out")
@@ -423,6 +435,12 @@ internal class FakeTmuxClient(
             if (cmd.startsWith(prefix) && throwOnCommandRemaining > 0) {
                 throwOnCommandRemaining -= 1
                 throw throwOnCommandException
+            }
+        }
+        errorOnCommandPrefix?.let { prefix ->
+            if (cmd.startsWith(prefix) && errorOnCommandRemaining > 0) {
+                errorOnCommandRemaining -= 1
+                return CommandResponse(number = 0L, output = errorOnCommandOutput, isError = true)
             }
         }
         if (bestEffort) {

--- a/app/src/test/java/com/pocketshell/app/tmux/RawBytesSendGuardTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/RawBytesSendGuardTest.kt
@@ -1,0 +1,356 @@
+package com.pocketshell.app.tmux
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.pocketshell.core.tmux.CommandResponse
+import com.pocketshell.core.tmux.TmuxClientException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Issue #1586 (reproduce-first, D33/G10) — the composer **RawBytes lane** (shell
+ * panes, `writeInputToPaneResult`) lacked the tmux-error check AND the
+ * verify-before-resend ledger the agent-payload lane got in #1577, so it was
+ * lane-asymmetric with two HIGH holes:
+ *
+ *  - **H1a false-success:** a RawBytes `send-keys` that returns tmux `%error`
+ *    (dead/closed pane) was swallowed — the outbound row was marked Delivered with
+ *    NOTHING delivered. RED on base: the send reports success. GREEN: it FAILS
+ *    (surfaced retryable/visible).
+ *  - **H1b blind duplicate:** an ambiguous failure (bytes landed, exec result lost)
+ *    followed by the composer auto-retry re-ran the shell command TWICE. RED on
+ *    base: the literal is pasted twice. GREEN: the retry probes `AlreadyLanded` and
+ *    the literal is pasted exactly ONCE.
+ *
+ * These drive the REAL send path ([TmuxSessionViewModel.writeInputToPaneResult] —
+ * the exact method the composer's `OutboundRoute.RawBytes` branch calls) against a
+ * [FakeTmuxClient], with the ambiguous cut injected SYNTHETICALLY (#780 model, no
+ * `assumeTrue`).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class RawBytesSendGuardTest : TmuxSessionViewModelTestBase() {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private fun FakeTmuxClient.literalCount(text: String): Int =
+        sentCommands.count { it == "send-keys -l -t %0 -- '$text'" }
+
+    private fun FakeTmuxClient.enterCount(): Int =
+        sentCommands.count { it == "send-keys -t %0 Enter" }
+
+    private fun clientShowing(vararg lines: String): FakeTmuxClient = FakeTmuxClient().apply {
+        defaultCaptureResponse = CommandResponse(number = 0L, output = lines.toList(), isError = false)
+    }
+
+    // ---------------------------------------------------------------------
+    // H1a — false-success on a dead-pane RawBytes send
+    // ---------------------------------------------------------------------
+
+    /**
+     * THE H1a reported case: a single-line shell command whose literal `send-keys`
+     * hits a dead/closed pane and tmux returns `%error`. RED on base: the response
+     * is discarded ⇒ the send reports success (row marked Delivered, nothing sent).
+     * GREEN: the `%error` surfaces as a failure.
+     */
+    @Test
+    fun deadPaneLiteralSendSurfacesFailureNotFalseSuccess() = runTest(scheduler) {
+        val vm = newVm(applicationContext = context)
+        val client = FakeTmuxClient().apply {
+            errorOnCommandPrefix = "send-keys -l -t %0"
+            errorOnCommandRemaining = 1
+        }
+        vm.attachClientForTest(client)
+
+        val result = vm.writeInputToPaneResult("%0", "git status\r".toByteArray(Charsets.UTF_8))
+        advanceUntilIdle()
+
+        assertTrue(
+            "a RawBytes send whose tmux `send-keys -l` returns %error MUST fail — not be " +
+                "swallowed and reported as a false-success (RED on base: result.isSuccess)",
+            result.isFailure,
+        )
+    }
+
+    /**
+     * Class coverage — named-key send: the submit Enter of a shell command hits a
+     * dead pane (`%error`). The named-key response was ALSO discarded on base.
+     */
+    @Test
+    fun deadPaneNamedKeySendSurfacesFailure() = runTest(scheduler) {
+        val vm = newVm(applicationContext = context)
+        val client = FakeTmuxClient().apply {
+            errorOnCommandPrefix = "send-keys -t %0 Enter"
+            errorOnCommandRemaining = 1
+        }
+        vm.attachClientForTest(client)
+
+        val result = vm.writeInputToPaneResult("%0", "ls -la\r".toByteArray(Charsets.UTF_8))
+        advanceUntilIdle()
+
+        assertTrue(
+            "a named-key (Enter) send that returns %error MUST surface as a failure",
+            result.isFailure,
+        )
+    }
+
+    /**
+     * Class coverage — multi-line paste: a multi-line RawBytes payload rides the
+     * bracketed-paste `send-keys -H` route; a `%error` there must also fail (this
+     * lane already threw, this proves the CLASS is covered end to end).
+     */
+    @Test
+    fun deadPaneMultiLinePasteSurfacesFailure() = runTest(scheduler) {
+        val vm = newVm(applicationContext = context)
+        val client = FakeTmuxClient().apply {
+            errorOnCommandPrefix = "send-keys -H -t %0"
+            errorOnCommandRemaining = 1
+        }
+        vm.attachClientForTest(client)
+
+        val result = vm.writeInputToPaneResult(
+            "%0",
+            "echo one\necho two\r".toByteArray(Charsets.UTF_8),
+        )
+        advanceUntilIdle()
+
+        assertTrue("a multi-line paste `%error` must fail the send", result.isFailure)
+    }
+
+    /**
+     * A genuinely-healthy send still succeeds (the H1a error-check does not reject a
+     * normal send).
+     */
+    @Test
+    fun healthyRawBytesSendStillSucceeds() = runTest(scheduler) {
+        val vm = newVm(applicationContext = context)
+        val client = clientShowing()
+        vm.attachClientForTest(client)
+
+        val result = vm.writeInputToPaneResult("%0", "git status\r".toByteArray(Charsets.UTF_8))
+        advanceUntilIdle()
+
+        assertTrue("a healthy RawBytes send must still succeed", result.isSuccess)
+        assertEquals("and it pastes the literal exactly once", 1, client.literalCount("git status"))
+    }
+
+    // ---------------------------------------------------------------------
+    // H1b — blind duplicate on ambiguous-failure retry
+    // ---------------------------------------------------------------------
+
+    /**
+     * THE H1b reported case: attempt 1 types the shell command (literal lands) and
+     * its submit Enter's exec times out — an AMBIGUOUS failure (the Enter may have
+     * run server-side before the result was lost, the exact mid-send flap cut). The
+     * composer keeps the row and auto-retries.
+     *
+     * RED on base: the retry blind-re-sends ⇒ the literal is pasted TWICE ⇒ the
+     * shell command runs twice (dangerous for a destructive command).
+     * GREEN: the retry probes the pane, sees the payload already landed, and
+     * suppresses the resend ⇒ the literal is pasted EXACTLY ONCE.
+     *
+     * AND — the over-suppression guard (reviewer B1/B2, D33-F2): the landed-but-
+     * unsubmitted command MUST still get its terminating submit on the retry. In this
+     * exact cut the literal is typed on the prompt (`$ git status`) but attempt 1's
+     * submit Enter threw, so the command is TYPED-BUT-NEVER-RUN. The probe needle
+     * cannot tell "typed on the prompt" from "ran", so on `AlreadyLanded` the retry
+     * must submit Enter-only (agent-lane parity), exactly ONCE — not drop the delivery
+     * silently while reporting success. RED on the over-suppressing behavior (retry
+     * sends NOTHING ⇒ zero new Enters ⇒ command left unsubmitted); GREEN: the retry
+     * adds exactly one submit Enter with no second literal paste.
+     */
+    @Test
+    fun ambiguousRetryOfLandedShellCommandDoesNotDuplicate() = runTest(scheduler) {
+        val vm = newVm(applicationContext = context)
+        // The pane advertises the typed command (attempt 1's literal landed);
+        // the submit Enter times out ambiguously.
+        val client = clientShowing("$ git status")
+        client.throwOnCommandPrefix = "send-keys -t %0 Enter"
+        client.throwOnCommandRemaining = 1
+        client.throwOnCommandException = TmuxClientException("tmux command timed out")
+        vm.attachClientForTest(client)
+
+        val first = vm.writeInputToPaneResult("%0", "git status\r".toByteArray(Charsets.UTF_8))
+        advanceUntilIdle()
+        assertTrue("attempt 1 must surface the ambiguous failure", first.isFailure)
+        assertEquals("attempt 1 pastes the literal exactly once", 1, client.literalCount("git status"))
+        // Attempt 1's submit Enter reached the wire (recorded) then threw ambiguously.
+        val entersAfterFirst = client.enterCount()
+
+        // The retry (composer auto-flush): probes ⇒ AlreadyLanded ⇒ NO second paste,
+        // but DOES complete the landed-but-unsubmitted command with an Enter-only submit.
+        val second = vm.writeInputToPaneResult("%0", "git status\r".toByteArray(Charsets.UTF_8))
+        advanceUntilIdle()
+        assertTrue(
+            "the AlreadyLanded retry must SUCCEED (the landed command is completed, not a " +
+                "false-success silent drop)",
+            second.isSuccess,
+        )
+        assertEquals(
+            "an ambiguous retry of a shell command that already LANDED must be deduped to " +
+                "EXACTLY ONE paste — never re-run the command a second time (RED on base: 2)",
+            1,
+            client.literalCount("git status"),
+        )
+        assertEquals(
+            "the AlreadyLanded retry MUST submit the landed-but-unsubmitted command with " +
+                "EXACTLY ONE Enter — the over-suppressing behavior sends nothing (RED: 0 new " +
+                "Enters), leaving `git status` typed on the prompt but never run",
+            entersAfterFirst + 1,
+            client.enterCount(),
+        )
+    }
+
+    /**
+     * Reviewer B3 — the NO-SPURIOUS-ENTER direction of the same over-suppression
+     * guard. A RawBytes send with `withEnter == false` carries NO trailing CR
+     * (`TmuxSessionScreen.kt`'s composer sends the bare literal — partial typed input,
+     * a caret-position paste), so `fullText.length == payload.length` and the guard's
+     * CR/LF heuristic (`if (fullText.length > payload.length)`) must NOT fire a submit.
+     *
+     * This mirrors [ambiguousRetryOfLandedShellCommandDoesNotDuplicate] but with a
+     * no-CR payload: attempt 1's literal `send-keys -l` lands on the pane (the pane
+     * echoes it) yet throws ambiguously (result lost), recording a wire attempt. The
+     * retry probes `AlreadyLanded`. Because the original send carried NO submit, the
+     * retry MUST inject ZERO Enters (submitting an unintended command is a real
+     * shell-lane hazard) AND MUST NOT re-paste the literal.
+     *
+     * Teeth: if the `AlreadyLanded` submit branch fired UNCONDITIONALLY (dropping the
+     * `fullText.length > payload.length` guard), the retry would inject one Enter here
+     * ⇒ `enterCount()` would rise from 0 to 1 ⇒ the no-spurious-Enter assertion FAILS.
+     * With the correct guard it stays 0 (GREEN).
+     */
+    @Test
+    fun ambiguousRetryOfNoSubmitLandedPayloadInjectsNoEnter() = runTest(scheduler) {
+        val vm = newVm(applicationContext = context)
+        // The pane echoes the typed literal (it landed); the literal send itself threw
+        // ambiguously (result lost) — a no-CR, no-Enter RawBytes send.
+        val client = clientShowing("$ git status")
+        client.throwOnCommandPrefix = "send-keys -l -t %0"
+        client.throwOnCommandRemaining = 1
+        vm.attachClientForTest(client)
+
+        // NOTE: no trailing "\r" — this is the `withEnter == false` composer send.
+        val first = vm.writeInputToPaneResult("%0", "git status".toByteArray(Charsets.UTF_8))
+        advanceUntilIdle()
+        assertTrue("attempt 1 (no-CR literal throws) must surface the ambiguous failure", first.isFailure)
+        assertEquals("attempt 1 records the literal exactly once", 1, client.literalCount("git status"))
+        // A no-submit send never issues an Enter — this must be zero and STAY zero.
+        val entersAfterFirst = client.enterCount()
+        assertEquals("a no-CR send issues no submit Enter on attempt 1", 0, entersAfterFirst)
+
+        // The retry probes ⇒ AlreadyLanded. The original send carried NO submit, so the
+        // guard must NOT complete it with a spurious Enter, and must NOT re-paste.
+        val second = vm.writeInputToPaneResult("%0", "git status".toByteArray(Charsets.UTF_8))
+        advanceUntilIdle()
+        assertTrue(
+            "the AlreadyLanded retry of an already-landed no-submit payload must SUCCEED " +
+                "(the literal already landed — nothing left to deliver)",
+            second.isSuccess,
+        )
+        assertEquals(
+            "the AlreadyLanded retry of a NO-CR (withEnter==false) payload must inject ZERO " +
+                "Enters — an unconditional submit branch would fire a spurious Enter (RED: 1), " +
+                "submitting an unintended shell command",
+            entersAfterFirst,
+            client.enterCount(),
+        )
+        assertEquals(
+            "and the literal is NOT re-pasted on the AlreadyLanded retry (deduped to one)",
+            1,
+            client.literalCount("git status"),
+        )
+    }
+
+    /**
+     * Class coverage — the GENUINE not-landed failure still delivers (no
+     * over-suppression). Attempt 1 throws BEFORE the bytes land (the pane never
+     * shows the command); the retry probes `NotLanded` and re-sends, so the command
+     * is delivered on the retry.
+     */
+    @Test
+    fun genuineNotLandedFailureStillDeliversOnRetry() = runTest(scheduler) {
+        val vm = newVm(applicationContext = context)
+        // The pane never shows the command — the bytes did NOT land.
+        val client = clientShowing("$ ")
+        client.throwOnCommandPrefix = "send-keys -l -t %0"
+        client.throwOnCommandRemaining = 1
+        vm.attachClientForTest(client)
+
+        val first = vm.writeInputToPaneResult("%0", "git status\r".toByteArray(Charsets.UTF_8))
+        advanceUntilIdle()
+        assertTrue("attempt 1 (literal throws before landing) must fail", first.isFailure)
+
+        val second = vm.writeInputToPaneResult("%0", "git status\r".toByteArray(Charsets.UTF_8))
+        advanceUntilIdle()
+        assertTrue("the genuine not-landed retry must re-send and succeed", second.isSuccess)
+        assertTrue(
+            "a NOT-landed payload must NOT be suppressed as a false-`AlreadyLanded` — the " +
+                "retry must actually paste it (over-suppression would silently drop the command)",
+            client.literalCount("git status") >= 1,
+        )
+        assertTrue("the delivered retry submits the command (Enter)", client.enterCount() >= 1)
+    }
+
+    /**
+     * Class coverage — a short single-line command already visible on the pane is
+     * still deduped correctly by the baseline-aware probe (not a presence-only false
+     * positive). Attempt 1 types "deploy" (its Enter times out); the retry sees the
+     * count over the pre-send baseline ⇒ suppressed to one paste.
+     */
+    @Test
+    fun ambiguousRetryOfShortCommandDeduped() = runTest(scheduler) {
+        val vm = newVm(applicationContext = context)
+        val client = clientShowing("$ deploy")
+        client.throwOnCommandPrefix = "send-keys -t %0 Enter"
+        client.throwOnCommandRemaining = 1
+        vm.attachClientForTest(client)
+
+        val first = vm.writeInputToPaneResult("%0", "deploy\r".toByteArray(Charsets.UTF_8))
+        advanceUntilIdle()
+        assertTrue(first.isFailure)
+        assertEquals(1, client.literalCount("deploy"))
+
+        val second = vm.writeInputToPaneResult("%0", "deploy\r".toByteArray(Charsets.UTF_8))
+        advanceUntilIdle()
+        assertEquals(
+            "the short command must be deduped to exactly one paste on the ambiguous retry",
+            1,
+            client.literalCount("deploy"),
+        )
+    }
+
+    /**
+     * The fix must NOT falsely suppress a DISTINCT command sent right after a
+     * different ambiguous one (the ledger is keyed per (pane, payload), so an
+     * unrelated command is unaffected).
+     */
+    @Test
+    fun distinctCommandAfterLandedOneIsNotSuppressed() = runTest(scheduler) {
+        val vm = newVm(applicationContext = context)
+        val client = clientShowing("$ git status")
+        client.throwOnCommandPrefix = "send-keys -t %0 Enter"
+        client.throwOnCommandRemaining = 1
+        vm.attachClientForTest(client)
+
+        vm.writeInputToPaneResult("%0", "git status\r".toByteArray(Charsets.UTF_8))
+        advanceUntilIdle()
+
+        val other = vm.writeInputToPaneResult("%0", "git push\r".toByteArray(Charsets.UTF_8))
+        advanceUntilIdle()
+        assertTrue("a distinct command must send normally", other.isSuccess)
+        assertEquals(
+            "a DIFFERENT command must not be suppressed by the prior command's ledger entry",
+            1,
+            client.literalCount("git push"),
+        )
+    }
+}


### PR DESCRIPTION
Reviewer-APPROVED (#1562 audit H1a/H1b, both HIGH). Extends the #1577 delivery-guarantee machinery to the shell/RawBytes lane:
- H1a: dead-pane tmux `%error` now FAILS instead of false-succeeding as Delivered.
- H1b: ambiguous retry probes the shared baseline-aware ledger → AlreadyLanded → Enter-only submit (no re-paste, no blind duplicate of a shell command).
- Over-suppression defect caught in review (would leave a command typed-but-unsubmitted) fixed + both guard directions teeth-proven; agent-lane exactly-once no-regression green; full suite 3807/0; hygiene green.

For v0.4.36. Closes #1586.