### PR TITLE
composer: fix real-Codex /goal resume submit (count-baseline ack gate + Route B) (#1577 reopen)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/tmux/ConversationTuiCommandJourneyDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/ConversationTuiCommandJourneyDockerTest.kt
@@ -189,8 +189,10 @@ class ConversationTuiCommandJourneyDockerTest {
         // STEP 3 — type `/model` into the REAL composer and Send. This drives the
         // production composerSendHandler AgentConversation branch on the live
         // screen (NOT a proxy): `tmuxAgentConversationSend("/model")` =
-        // TuiCommandNoEcho → writeInputToPaneResult (no optimistic echo) → the
-        // Open-in-Terminal notice is raised.
+        // TuiCommandNoEcho → sendAgentPayloadToPaneResult (the #1577b GATED submit:
+        // floor + count-baseline ack gate + Enter; no optimistic echo) → the
+        // Open-in-Terminal notice is raised. This test is the real-path guard for
+        // the #1577b Route B routing change (Conversation slash → gated submit).
         sendFromComposer(MODEL_COMMAND)
         stamp("composer_sent text=$MODEL_COMMAND")
 

--- a/app/src/main/java/com/pocketshell/app/tmux/OutboundDeliveryGuard.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/OutboundDeliveryGuard.kt
@@ -90,8 +90,13 @@ internal suspend fun verifyBeforeAgentResend(
     // captured at the first wire attempt. `AlreadyLanded` requires the count to have
     // INCREASED (our paste actually added an occurrence) — so a payload that was
     // already on the pane before we ever pushed (a Codex `Goal blocked (/goal resume)`
-    // status line) is not a false-positive. A null baseline (legacy row / baseline
-    // capture failed) falls back to presence-only (#1541 behaviour).
+    // status line) is not a false-positive.
+    // Issue #1577b: a NULL baseline (a legacy pre-baseline row, or a failed baseline
+    // capture) is UNTRUSTWORTHY — it CANNOT distinguish "landed" from a permanent
+    // footer occurrence, so it must NEVER resolve `AlreadyLanded` (which would submit
+    // a bare Enter and silently drop the payload). [probeOutboundPayloadAlreadyLanded]
+    // reports `NotLanded` for a null baseline instead, so the caller does a REAL gated
+    // resend that records a fresh baseline (self-healing), never a bare Enter.
     val baseline = ledger.needleBaseline(paneId, payload)
     val outcome = probeOutboundPayloadAlreadyLanded(client, paneId, payload, baseline)
     DiagnosticEvents.record(
@@ -319,6 +324,12 @@ internal suspend fun probeOutboundPayloadAlreadyLanded(
     baselineCount: Int? = null,
 ): DeliveryProbeOutcome {
     val needle = agentSubmitAckNeedle(payload) ?: return DeliveryProbeOutcome.Unknown
+    // Issue #1577b: kill the presence-only fallback. A null baseline cannot tell "our
+    // paste landed" from a payload that was ALREADY on the pane (a Codex `Goal blocked
+    // (/goal resume)` footer), so a presence match would false-`AlreadyLanded` → a
+    // silent bare-Enter drop. Resolve `NotLanded` so the caller does a REAL gated
+    // resend (which records a fresh baseline), never a bare Enter — deliver-safe.
+    if (baselineCount == null) return DeliveryProbeOutcome.NotLanded
     val response = try {
         client.capturePaneTextViaExec(paneId, timeoutMs = OUTBOUND_DELIVERY_PROBE_TIMEOUT_MS)
     } catch (cancelled: CancellationException) {
@@ -327,11 +338,9 @@ internal suspend fun probeOutboundPayloadAlreadyLanded(
         return DeliveryProbeOutcome.Unknown
     }
     if (response.isError) return DeliveryProbeOutcome.Unknown
+    // Issue #1577: a captured baseline demands the count INCREASE (our paste landed).
     val count = agentSubmitVisibleTextNeedleCount(response.output, needle)
-    // Issue #1577: a captured baseline demands the count INCREASE (our paste landed);
-    // no baseline (legacy/failed capture) falls back to the #1541 presence check.
-    val landed = if (baselineCount != null) count > baselineCount else count >= 1
-    return if (landed) DeliveryProbeOutcome.AlreadyLanded else DeliveryProbeOutcome.NotLanded
+    return if (count > baselineCount) DeliveryProbeOutcome.AlreadyLanded else DeliveryProbeOutcome.NotLanded
 }
 
 /**

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
@@ -978,22 +978,19 @@ public fun TmuxSessionScreen(
                 false
             } else when (target.route) {
                 OutboundRoute.AgentConversation ->
-                    // Issue #1207: a TUI-only slash-command (/model, /config, any
-                    // picker) writes NOTHING to the transcript — it drives an
-                    // alt-screen picker in the covered Terminal pane. Echoing an
-                    // optimistic "/model" user bubble (the old `sendToAgentPaneResult`
-                    // path) is actively misleading: the bubble sits there as if a
-                    // normal turn ran while the picker is invisible on the
-                    // Conversation surface by construction. So for a slash-command we
-                    // send the keystrokes to the pane WITHOUT the optimistic echo (the
-                    // same raw text+Enter delivery a confirmed agent uses on the
-                    // Terminal tab) and raise the inline "Open in Terminal" notice.
+                    // Issue #1207: a TUI-only slash-command drives an alt-screen picker in
+                    // the covered Terminal pane, so it gets NO optimistic echo and raises
+                    // the inline "Open in Terminal" notice. Issue #1577b: deliver it through
+                    // the SAME gated agent submit (`sendAgentPayloadToPaneResult`: floor +
+                    // count-baseline ack gate + Enter) the Terminal tab uses — NOT a raw
+                    // ungated `text+"\r"` whose CR lands in Codex's same stdin read batch as
+                    // the text (paste-burst swallow → `/goal resume` unsubmitted). Hard-cut
+                    // (D22): one gated submit path for both tabs.
                     when (tmuxAgentConversationSend(request.text)) {
                         TmuxAgentConversationSend.TuiCommandNoEcho -> {
-                            val ok = viewModel.writeInputToPaneResult(
-                                paneId,
-                                (request.text.trimEnd('\n') + "\r").toByteArray(Charsets.UTF_8),
-                            ).isSuccess
+                            val ok = tmuxComposerAgentKindFromToken(target.agentKind)?.let { agentKind ->
+                                viewModel.sendAgentPayloadToPaneResult(paneId, request.text, agentKind).isSuccess
+                            } ?: false
                             if (ok) {
                                 tuiCommandNotice = request.text.trim()
                             }

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -510,6 +510,18 @@ public class TmuxSessionViewModel @Inject constructor(
         agentSubmitAckTimeoutMsOverrideForTest = timeoutMs
     }
 
+    // Issue #1577b: the pane's visible LOCAL render text the send path reads to
+    // decide whether the payload is already on screen (the #1577 baseline cost-gate)
+    // and to seed the ack gate's pre-paste needle baseline. A test override lets a
+    // unit test reproduce the production state where the app IS rendering a Codex
+    // `Goal blocked (/goal resume)` footer without wiring a full terminal producer.
+    @androidx.annotation.VisibleForTesting
+    internal val localRenderTextOverrideForTest: MutableMap<String, String> = mutableMapOf()
+
+    private fun localRenderTextForPane(paneId: String): String =
+        localRenderTextOverrideForTest[paneId]
+            ?: paneRows[paneId]?.terminalState?.visibleScreenTextSnapshot().orEmpty()
+
     /**
      * Issue #818: test override for the configured open-time default agent
      * session view. Unit tests build the view model without the
@@ -14103,26 +14115,25 @@ public class TmuxSessionViewModel @Inject constructor(
         }
         return runCatching {
             ensurePaneAcceptsInput(client, paneId)
-            val render = paneRows[paneId]?.terminalState?.visibleScreenTextSnapshot().orEmpty()
-            outboundDeliveryLedger.recordWireAttemptWithBaseline(client, paneId, payload, render)
+            outboundDeliveryLedger.recordWireAttemptWithBaseline(client, paneId, payload, localRenderTextForPane(paneId))
+            // Issue #1577b: the pre-paste needle baseline the ack gate compares against
+            // (Codex's permanent `(/goal resume)` footer occupies the baseline, so the
+            // ack fires only on OUR paste adding an occurrence — never on the footer).
+            val ackBaseline = outboundDeliveryLedger.needleBaseline(paneId, payload) ?: 0
             if (payloadBytes.size > TMUX_PASTE_BODY_CHUNK_BYTES || BracketedPaste.containsLineBreak(payloadBytes)) {
                 sendBracketedPaste(client, paneId, payloadBytes)
             } else if (payload.isNotEmpty()) {
                 sendLiteralTextKeys(client, paneId, payload)
                     .throwIfTmuxError("type agent input into pane $paneId")
             }
-            awaitAgentPasteIngestedBeforeSubmit(client, paneId, payload, agent)
+            awaitAgentPasteIngestedBeforeSubmit(client, paneId, payload, agent, ackBaseline)
             consumeSendResultLostSeamForTest()
             sendNamedKeyToPane(client, paneId, "Enter")
                 .throwIfTmuxError("submit pasted agent input")
             outboundDeliveryLedger.clear(paneId, payload)
-            // Issue #941 (black-screen B1): after the submit Enter a full-screen agent
-            // TUI can `clear`+redraw and emit a `%output` overpaint that leaves the
-            // active pane PARTIAL-black (a lone status/spinner line, the rest gone) with
-            // no heal, so it stayed black until a manual redraw. Schedule a guarded
-            // active-pane heal that fires only if the pane settles partial-black/blank.
-            // Issue #1353 R4: an EVENT through the shared reconcile entry ([requestReconcile]),
-            // not a private send-only poll — the send path owns no bespoke timer.
+            // Issue #941/#1353 R4: after the submit Enter a full-screen agent TUI can
+            // overpaint the active pane partial-black; a guarded heal EVENT through the
+            // shared reconcile entry re-checks and re-seeds (no bespoke send-path timer).
             requestReconcile(client, paneId, ReconcileReason.Send)
         }
     }
@@ -14192,48 +14203,32 @@ public class TmuxSessionViewModel @Inject constructor(
 
     /**
      * Issue #869: ack-gate the submit Enter on the pasted composer text actually
-     * landing in the agent's input, instead of the pre-#869 blind fixed sleep
-     * ([com.pocketshell.app.settings.AppSettings.agentSubmitEnterDelayMs]) that
-     * was too short under real RTT. The maintainer's on-device symptom — "most
-     * of the time when I click Send it's not really sending; I have to press
-     * Enter after" — was an Enter that raced ahead of the agent TUI finishing
-     * its paste ingestion, leaving the message sitting unsent in the input line.
+     * landing in the agent's input, instead of the pre-#869 blind fixed sleep that
+     * raced ahead of the TUI's ingestion ("I have to press Enter after"). Two parts:
+     * (1) a MINIMUM floor (the #526 setting; Codex's [CODEX_AGENT_SUBMIT_DELAY_MS]
+     * still applies) and (2) an ack poll of `capture-pane -p` for the payload,
+     * pressing Enter the instant a capture CONFIRMS the paste (RTT-adaptive for
+     * free). Bounded by [AGENT_SUBMIT_ACK_TIMEOUT_MS]; on a needle miss the Enter is
+     * held to `max(minFloor, AGENT_SUBMIT_ACK_FALLBACK_FLOOR_MS + measuredRtt)` (a
+     * WORKING delay, never the 150ms that raced), never a hung Send.
      *
-     * The gate works in two parts:
-     *
-     * 1. **Minimum floor (the #526 setting, kept tunable).** Honour the
-     *    configured [com.pocketshell.app.settings.AppSettings.agentSubmitEnterDelayMs]
-     *    (Codex's [CODEX_AGENT_SUBMIT_DELAY_MS] floor still applies) as the
-     *    SHORTEST time before Enter. A zero/low configured value no longer means
-     *    "race the Enter" — the ack poll below still waits for confirmation.
-     *
-     * 2. **Ack on the paste landing (the #869 correctness fix).** Poll
-     *    `capture-pane -p` for the payload to appear in the pane's visible text.
-     *    Press Enter the instant a capture confirms the paste is in. This is
-     *    RTT-adaptive for free — each capture is a round-trip, so a high-latency
-     *    host naturally waits longer for the confirming capture to return.
-     *    Bounded by [AGENT_SUBMIT_ACK_TIMEOUT_MS]: if the payload never shows
-     *    (an unrecognised TUI rendering, or `capture-pane` keeps failing) we
-     *    fall back to pressing Enter anyway — never a hung Send.
-     *
-     * 3. **Hardened needle-miss fallback (#869, reviewer BLOCKED follow-up).**
-     *    The fallback is the EXACT failure surface for the maintainer's report:
-     *    if the needle never matched a real agent's reflowed input box, the
-     *    pre-#869 path would press Enter after only the ~150ms floor — the very
-     *    race that left messages unsent. So when the ack is NOT observed, the
-     *    submit Enter is held to an ADEQUATE working floor instead:
-     *    `max(minFloor, AGENT_SUBMIT_ACK_FALLBACK_FLOOR_MS + measuredRtt)`,
-     *    where `measuredRtt` is the longest `capture-pane` round-trip observed
-     *    during the polls (so a high-latency host waits proportionally longer).
-     *    The worst case is therefore a WORKING delay, never the 150ms that
-     *    caused the report. The best case is unchanged — an observed ack
-     *    submits the instant ingestion is seen.
+     * Issue #1577b: the ack is COUNT-BASELINE-aware. [baselineNeedleCount] is the
+     * payload needle's pre-paste occurrence count on the pane; the ack fires only
+     * when the CURRENT count INCREASES over it (our paste added an occurrence), NOT
+     * on mere presence. On a Codex pane whose status footer permanently renders the
+     * command it wants (`Goal blocked (/goal resume)`), a presence-only ack matched
+     * that footer INSTANTLY and fired Enter before Codex had read the paste — so on
+     * a busy Codex the text and the CR landed in ONE stdin read batch and Codex's
+     * paste-burst heuristic SWALLOWED the CR, leaving `/goal resume` unsubmitted.
+     * Requiring an increase guarantees a REAL gap: Enter is sent only after the
+     * typed text is confirmed ingested, so the CR lands in a separate read.
      */
     private suspend fun awaitAgentPasteIngestedBeforeSubmit(
         client: TmuxClient,
         paneId: String,
         payload: String,
         agent: AgentKind,
+        baselineNeedleCount: Int,
     ) {
         val configured = agentSubmitEnterDelayMsOverrideForTest
             ?: settingsRepository?.settings?.value?.agentSubmitEnterDelayMs
@@ -14271,7 +14266,7 @@ public class TmuxSessionViewModel @Inject constructor(
                     return@withTimeoutOrNull false
                 }
                 val captureStartMs = agentSubmitNowMs()
-                val visible = agentPaneShowsPayload(client, paneId, ackNeedle)
+                val visible = agentPaneShowsPayload(client, paneId, ackNeedle, baselineNeedleCount)
                 maxCaptureRttMs = maxOf(maxCaptureRttMs, agentSubmitNowMs() - captureStartMs)
                 if (visible) {
                     // The paste is visible in the pane — the agent has ingested it.
@@ -14317,24 +14312,26 @@ public class TmuxSessionViewModel @Inject constructor(
     }
 
     /**
-     * Issue #869: `capture-pane -p` the pane and report whether [needle] is
-     * present in its visible text. Both the visible text and the needle are
-     * whitespace-stripped (see [agentSubmitAckNeedle]) so a wrapped/reflowed
-     * input box — whose join inserts a separator at the wrap boundary — still
-     * matches. A failed/empty capture is reported as "not yet visible" so the
-     * caller keeps polling within its bounded timeout. Best-effort: never throws
-     * — a capture failure must not fail the send, only defer the Enter.
+     * Issue #869/#1577b: `capture-pane -p` the pane and report whether OUR paste has
+     * landed — i.e. the [needle]'s whitespace-stripped occurrence count now EXCEEDS
+     * [baselineNeedleCount] (its pre-paste count). Both text and needle are
+     * whitespace-stripped so a wrapped/reflowed input box still matches. A count
+     * increase (not mere presence) is required so a payload the pane ALREADY showed
+     * before the paste — a Codex `Goal blocked (/goal resume)` footer — does not
+     * false-confirm the ack. A failed/empty capture is "not yet visible" so the
+     * caller keeps polling; best-effort, never throws.
      */
     private suspend fun agentPaneShowsPayload(
         client: TmuxClient,
         paneId: String,
         needle: String,
+        baselineNeedleCount: Int,
     ): Boolean {
         val response = runCatching {
             client.capturePaneTextViaExec(paneId)
         }.getOrNull() ?: return false
         if (response.isError) return false
-        return agentSubmitVisibleTextContainsNeedle(response.output, needle)
+        return agentSubmitVisibleTextNeedleCount(response.output, needle) > baselineNeedleCount
     }
 
     public fun selectSessionTab(paneId: String, tab: SessionTab) {
@@ -15339,7 +15336,7 @@ public class TmuxSessionViewModel @Inject constructor(
         client = client,
         paneId = paneId,
         bytes = bytes,
-        localRenderText = paneRows[paneId]?.terminalState?.visibleScreenTextSnapshot().orEmpty(),
+        localRenderText = localRenderTextForPane(paneId),
         send = { c, p, b -> sendInputBytesToPane(c, p, b) },
         // Issue #1586 (H1b): AlreadyLanded -> Enter-only submit (agent-lane parity).
         submitEnter = { c, p ->

--- a/app/src/test/java/com/pocketshell/app/tmux/FakeTmuxClient.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/FakeTmuxClient.kt
@@ -38,7 +38,7 @@ import kotlinx.coroutines.flow.filterIsInstance
  *
  * Closed state is tracked via [closed] so tests can assert teardown.
  */
-internal class FakeTmuxClient(
+internal open class FakeTmuxClient(
     paneOutputExtraBufferCapacity: Int = 64,
 ) : TmuxClient {
 

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue1577BurstTuiSubmitTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue1577BurstTuiSubmitTest.kt
@@ -1,0 +1,312 @@
+package com.pocketshell.app.tmux
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.pocketshell.core.agents.AgentDetection
+import com.pocketshell.core.agents.AgentKind
+import com.pocketshell.core.tmux.CommandResponse
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Issue #1577 (REOPENED, D31/D33/G10) — the REAL-path paste-burst swallow that
+ * v0.4.35 did NOT fix (it was verified only against a happy [FakeTmuxClient]).
+ *
+ * Reproduced on real Codex 0.144.1: when the literal text and the submit CR land
+ * in the SAME Codex stdin read batch, Codex's paste-burst heuristic SWALLOWS the
+ * CR — `/goal resume` sits UNSUBMITTED in the composer input. Two app paths put the
+ * text+CR in one batch on a busy, goal-annotated Codex pane:
+ *  - Route A (Terminal tab): the #869 ack gate presence-matched the needle over the
+ *    WHOLE viewport, so Codex's permanent `Goal blocked (/goal resume)` footer
+ *    confirmed "ingested" INSTANTLY and fired Enter at the bare floor — before Codex
+ *    had actually read the paste.
+ *  - Route B (Conversation tab): the slash command was sent as raw `text+"\r"`
+ *    through the keystroke lane with NO floor / NO ack gate at all.
+ *
+ * [BurstTuiFakeTmuxClient] is the scripted burst-TUI stand-in the brief asks for (no
+ * Codex creds, wired into the Unit CI gate): it renders a permanent goal footer, and
+ * SUBMITS a command only when the CR arrives in a read SEPARATE from the text (i.e.
+ * the app waited until the pane rendered the typed text before pressing Enter) —
+ * mimicking Codex's heuristic. The fix (count-baseline ack gate + routing Route B
+ * through the same gated submit) makes both routes wait for a REAL ingestion (the
+ * needle COUNT increasing over the footer's permanent occurrence) before Enter, so
+ * the CR lands in its own batch and the command SUBMITS even on a busy Codex.
+ *
+ * RED on base (fix reverted): the gated path fires Enter on the footer presence →
+ * text+CR one batch → NOT submitted. GREEN: the count-baseline ack gate holds Enter
+ * until the typed text renders → submitted. The raw ungated path (Route B's DELETED
+ * behaviour) is shown to swallow, proving why it had to be replaced.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class Issue1577BurstTuiSubmitTest : TmuxSessionViewModelTestBase() {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val footer = "gpt-5.6-sol medium · Context 42% · Goal blocked (/goal resume)"
+
+    private fun codexDetection(): AgentDetection = AgentDetection(
+        agent = AgentKind.Codex,
+        sourcePath = "/home/u/.codex/sessions/rollout.jsonl",
+        sessionId = "rollout",
+        confidence = AgentDetection.Confidence.ProcessConfirmed,
+    )
+
+    private fun newBurstVm(client: BurstTuiFakeTmuxClient): TmuxSessionViewModel {
+        val vm = newVm(applicationContext = context)
+        vm.attachClientForTest(client)
+        vm.startAgentConversationForTest("%0", codexDetection())
+        vm.setAgentSubmitEnterDelayForTest(0)
+        vm.setAgentSubmitAckTimeoutForTest(2_000L)
+        // Reproduce the ON-DEVICE state: the app IS rendering the Codex goal footer,
+        // so the send path's baseline cost-gate captures the authoritative pre-paste
+        // needle count (1) and the ack gate requires an INCREASE, not mere presence.
+        vm.localRenderTextOverrideForTest["%0"] = footer
+        return vm
+    }
+
+    /**
+     * Route A (Terminal tab, gated submit) — the maintainer's Codex Send+Enter. On a
+     * BUSY Codex whose footer permanently shows `(/goal resume)`, the command must
+     * SUBMIT: the count-baseline ack gate holds the Enter until the typed text renders
+     * (a read separate from the CR), so Codex does not swallow the CR.
+     *
+     * RED on base (presence-only ack): Enter fires on the footer occurrence before the
+     * text renders → text+CR one batch → NOT submitted.
+     */
+    @Test
+    fun routeAGatedSubmitDeliversSlashCommandOnBusyCodexWithFooter() = runTest(scheduler) {
+        val client = BurstTuiFakeTmuxClient(footer = footer, busyReadDelayCaptures = 1)
+        val vm = newBurstVm(client)
+
+        val result = async { vm.sendAgentPayloadToPaneResult("%0", "/goal resume", AgentKind.Codex) }
+        advanceUntilIdle()
+        assertTrue(result.await().isSuccess)
+
+        assertEquals(
+            "Route A: `/goal resume` must SUBMIT on a busy goal-annotated Codex — the " +
+                "count-baseline ack gate holds Enter until the text renders (RED on base: " +
+                "presence-ack fires on the footer → text+CR one batch → swallowed → not submitted)",
+            listOf("/goal resume"),
+            client.submittedCommands,
+        )
+    }
+
+    /**
+     * Route B (Conversation tab) — the FIX routes the slash command through the SAME
+     * gated agent submit ([TmuxSessionViewModel.sendAgentPayloadToPaneResult]); this
+     * drives that chokepoint directly (the exact call the composable now makes) and
+     * proves it SUBMITS on the busy footer pane.
+     */
+    @Test
+    fun routeBGatedSubmitDeliversSlashCommandOnBusyCodex() = runTest(scheduler) {
+        val client = BurstTuiFakeTmuxClient(footer = footer, busyReadDelayCaptures = 1)
+        val vm = newBurstVm(client)
+
+        // The Conversation-tab TuiCommandNoEcho path now delivers via this gated call.
+        val result = async { vm.sendAgentPayloadToPaneResult("%0", "/goal resume", AgentKind.Codex) }
+        advanceUntilIdle()
+        assertTrue(result.await().isSuccess)
+
+        assertEquals(listOf("/goal resume"), client.submittedCommands)
+    }
+
+    /**
+     * The DELETED Route B behaviour (raw ungated `text+"\r"` through the keystroke
+     * lane) SWALLOWS the CR on a busy Codex — proving why the fix replaced it with the
+     * gated submit. This is the standing red for Route B's old path.
+     */
+    @Test
+    fun rawUngatedKeystrokeSendSwallowsSlashCommandOnBusyCodex() = runTest(scheduler) {
+        val client = BurstTuiFakeTmuxClient(footer = footer, busyReadDelayCaptures = 1)
+        val vm = newBurstVm(client)
+
+        // Route B's OLD delivery: raw text + CR, no floor, no ack gate.
+        val result = async {
+            vm.writeInputToPaneResult("%0", "/goal resume\r".toByteArray(Charsets.UTF_8))
+        }
+        advanceUntilIdle()
+        result.await()
+
+        assertTrue(
+            "the raw ungated text+CR send lands both in Codex's SAME stdin read batch → " +
+                "the paste-burst heuristic swallows the CR → `/goal resume` is NOT submitted " +
+                "(exactly why the fix routes Route B through the gated submit instead)",
+            client.submittedCommands.isEmpty(),
+        )
+        assertTrue("the swallowed text sits UNSUBMITTED in the input box", client.inputBoxShowsPending())
+    }
+
+    /**
+     * Class coverage — IDLE Codex (renders the paste immediately). The gated submit
+     * still delivers exactly once: the ack observes the count increase on the first
+     * poll and submits.
+     */
+    @Test
+    fun gatedSubmitDeliversOnIdleCodexWithFooter() = runTest(scheduler) {
+        val client = BurstTuiFakeTmuxClient(footer = footer, busyReadDelayCaptures = 0)
+        val vm = newBurstVm(client)
+
+        val result = async { vm.sendAgentPayloadToPaneResult("%0", "/goal resume", AgentKind.Codex) }
+        advanceUntilIdle()
+        assertTrue(result.await().isSuccess)
+
+        assertEquals(listOf("/goal resume"), client.submittedCommands)
+    }
+
+    /**
+     * Class coverage — a NORMAL non-slash prompt whose text is NOT already on the pane
+     * still submits unchanged (no over-gating). Baseline 0 ⇒ the ack fires on the first
+     * capture that shows the rendered text (presence == count-increase over 0).
+     */
+    @Test
+    fun normalPromptStillSubmitsWithoutOverGating() = runTest(scheduler) {
+        val client = BurstTuiFakeTmuxClient(footer = footer, busyReadDelayCaptures = 0)
+        val vm = newVm(applicationContext = context)
+        vm.attachClientForTest(client)
+        vm.startAgentConversationForTest("%0", codexDetection())
+        vm.setAgentSubmitEnterDelayForTest(0)
+        vm.setAgentSubmitAckTimeoutForTest(2_000L)
+        // The prompt text is NOT on the local render ⇒ baseline 0 ⇒ presence is a valid
+        // ingestion signal (our paste is the ONLY occurrence).
+        vm.localRenderTextOverrideForTest["%0"] = footer
+
+        val result = async { vm.sendAgentPayloadToPaneResult("%0", "deploy the staging build", AgentKind.Codex) }
+        advanceUntilIdle()
+        assertTrue(result.await().isSuccess)
+
+        assertEquals(listOf("deploy the staging build"), client.submittedCommands)
+    }
+
+    /**
+     * Class coverage — the footer-present FALSE-MATCH itself: when the pane NEVER
+     * renders the typed input (a fully wedged busy Codex), the ack gate must NOT
+     * confirm on the permanent footer occurrence. It holds Enter to the bounded
+     * fallback floor instead of firing early on the footer — proving the count-baseline
+     * gate is not satisfied by the pre-existing `(/goal resume)`.
+     */
+    @Test
+    fun ackGateDoesNotFalseConfirmOnPermanentFooterOccurrence() = runTest(scheduler) {
+        // neverRenders = true: Codex is wedged and never echoes the paste, so the needle
+        // count stays at the footer's baseline of 1 for the whole ack window.
+        val client = BurstTuiFakeTmuxClient(footer = footer, busyReadDelayCaptures = 1, neverRenders = true)
+        val vm = newBurstVm(client)
+
+        val result = async { vm.sendAgentPayloadToPaneResult("%0", "/goal resume", AgentKind.Codex) }
+        advanceUntilIdle()
+        // The send still completes (fallback floor), but it must have POLLED capture-pane
+        // more than once — i.e. it did NOT accept the footer as an instant ack (RED on
+        // base: presence-ack fires on the first poll → exactly one poll).
+        assertTrue(result.await().isSuccess)
+        assertTrue(
+            "the count-baseline ack must NOT confirm on the permanent footer occurrence — " +
+                "it polls to the bounded fallback (multiple polls), not a first-poll footer match " +
+                "(pollCount=${client.capturePaneTextViaExecCalls.size})",
+            client.capturePaneTextViaExecCalls.size > 2,
+        )
+        assertFalse(
+            "a wedged Codex that never renders the paste must not report a swallowed-then-" +
+                "spuriously-submitted state from the footer",
+            client.submittedCommands.contains("/goal resume"),
+        )
+    }
+}
+
+/**
+ * Issue #1577b: a scripted stand-in for Codex's stdin read-batch + paste-burst
+ * heuristic — the deterministic CI tier the investigation designed (no OpenAI
+ * creds). It renders a permanent goal [footer] and:
+ *  - `send-keys -l … -- '<text>'` types <text> into a pending stdin buffer that
+ *    Codex has NOT read yet (a busy event loop);
+ *  - `capture-pane` models Codex catching up: after [busyReadDelayCaptures] captures
+ *    since the paste, Codex reads the pending TEXT and RENDERS it in the input box
+ *    (the needle count goes 1 → 2). [neverRenders] models a fully wedged Codex;
+ *  - `send-keys … Enter` SUBMITS only when the text was ALREADY read+rendered (the
+ *    CR arrives in a read SEPARATE from the text). If the text is still unread when
+ *    the Enter arrives, the CR joins the text in ONE batch and the paste-burst
+ *    heuristic SWALLOWS it — nothing is submitted (the on-device bug).
+ */
+internal class BurstTuiFakeTmuxClient(
+    private val footer: String,
+    private val busyReadDelayCaptures: Int,
+    private val neverRenders: Boolean = false,
+) : FakeTmuxClient() {
+
+    private var pendingText: String? = null
+    private var textRendered: Boolean = false
+    private var capturesSincePaste: Int = 0
+    private var submitted: Boolean = false
+    val submittedCommands: MutableList<String> = mutableListOf()
+
+    private val literalRegex = Regex("^send-keys -l -t \\S+ -- '(.*)'$")
+    private val enterRegex = Regex("^send-keys -t \\S+ Enter$")
+
+    fun inputBoxShowsPending(): Boolean = pendingText != null && !submitted
+
+    private fun interpret(cmd: String) {
+        literalRegex.find(cmd)?.let { m ->
+            pendingText = m.groupValues[1].replace("'\\''", "'")
+            textRendered = false
+            submitted = false
+            capturesSincePaste = 0
+            return
+        }
+        if (enterRegex.matches(cmd)) {
+            val text = pendingText
+            if (text != null && textRendered && !submitted) {
+                // The text was read+rendered in a PRIOR read ⇒ this CR is its own read
+                // ⇒ Codex submits. If the text is still unread (textRendered == false),
+                // the CR batches with it and the paste-burst heuristic swallows it.
+                submitted = true
+                submittedCommands.add(text)
+            }
+        }
+    }
+
+    private fun advanceCodexReadOnCapture() {
+        if (neverRenders) return
+        val text = pendingText ?: return
+        if (textRendered) return
+        capturesSincePaste += 1
+        if (capturesSincePaste > busyReadDelayCaptures) {
+            textRendered = true
+        }
+    }
+
+    private fun renderLines(): List<String> {
+        val lines = mutableListOf(footer)
+        val text = pendingText
+        if (submitted && text != null) {
+            lines.add("■ submitted $text: thread/goal set")
+        } else if (textRendered && text != null) {
+            lines.add("› $text")
+        }
+        return lines
+    }
+
+    override suspend fun sendCommand(cmd: String): CommandResponse {
+        interpret(cmd)
+        return super.sendCommand(cmd)
+    }
+
+    override suspend fun sendBestEffortCommand(cmd: String): CommandResponse {
+        interpret(cmd)
+        return super.sendBestEffortCommand(cmd)
+    }
+
+    override suspend fun capturePaneTextViaExec(paneId: String, timeoutMs: Long?): CommandResponse {
+        capturePaneTextViaExecCalls += paneId
+        advanceCodexReadOnCapture()
+        return CommandResponse(number = 0L, output = renderLines(), isError = false)
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/OutboundDeliveryGuardTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/OutboundDeliveryGuardTest.kt
@@ -288,9 +288,12 @@ class OutboundDeliveryGuardTest {
         val ledger = OutboundDeliveryLedger()
         val paneId = "%0"
         val payload = "deliver this exactly once please"
-        // First attempt reached the wire ambiguously (recorded) AND landed — the
-        // pane shows the payload.
-        ledger.recordWireAttempt(paneId, payload)
+        // First attempt reached the wire ambiguously (recorded WITH its pre-send
+        // baseline 0 — the payload was NOT on the pane before the paste) AND landed:
+        // the pane now shows the payload (count 1 > baseline 0). Issue #1577b: a
+        // production wire push ALWAYS records a baseline (recordWireAttemptWithBaseline),
+        // so a genuinely-landed row is baselined — this is the production-accurate state.
+        ledger.recordWireAttempt(paneId, payload, baselineCount = 0)
         val client = captureShowing("$ $payload")
 
         val outcome = verifyBeforeAgentResend(ledger, client, paneId, payload)
@@ -299,6 +302,38 @@ class OutboundDeliveryGuardTest {
             "a re-dispatched already-landed payload must resolve AlreadyLanded so the send path " +
                 "submits Enter only and never re-pastes (occurrence stays 1)",
             DeliveryProbeOutcome.AlreadyLanded,
+            outcome,
+        )
+    }
+
+    /**
+     * Issue #1577b: a NULL baseline (a legacy pre-baseline row, or a failed baseline
+     * capture) is UNTRUSTWORTHY — a presence-only check would false-`AlreadyLanded` on
+     * a permanent Codex `Goal blocked (/goal resume)` footer and submit a bare Enter,
+     * silently dropping the payload (the reopened #1577 symptom). The kill-the-presence-
+     * fallback fix resolves `NotLanded` instead, so the caller does a REAL gated resend
+     * (which records a fresh baseline), never a bare Enter.
+     *
+     * RED on base: the presence-only fallback (`count >= 1`) matched the footer ⇒
+     * AlreadyLanded. GREEN: null baseline ⇒ NotLanded (deliver-safe).
+     */
+    @Test
+    fun nullBaselineUntrustworthyFlagResolvesNotLandedNotBareEnter() = runTest {
+        val ledger = OutboundDeliveryLedger()
+        val paneId = "%0"
+        val payload = "/goal resume"
+        // A legacy row carries the durable wire-attempt flag but NO baseline (null).
+        ledger.recordWireAttempt(paneId, payload) // 2-arg ⇒ baselineCount defaults to null
+        // The pane permanently shows the payload in a status footer.
+        val client = captureShowing("gpt-5.6-sol · Goal blocked (/goal resume)")
+
+        val outcome = verifyBeforeAgentResend(ledger, client, paneId, payload)
+
+        assertEquals(
+            "a null-baseline (untrustworthy) flag whose payload is already on the pane must NOT " +
+                "resolve AlreadyLanded (that submits a bare Enter and silently drops the send) — " +
+                "it must be NotLanded so the caller does a real gated resend",
+            DeliveryProbeOutcome.NotLanded,
             outcome,
         )
     }
@@ -427,7 +462,7 @@ class OutboundDeliveryGuardTest {
             "the claim alone must NOT record a wire attempt (#1577)",
             store.hasWireAttempt(paneId, payload),
         )
-        store.markWireAttempted(paneId, payload) // the actual wire push
+        store.markWireAttempted(paneId, payload, baselineCount = 0) // the actual wire push (#1577b: records a baseline)
         assertTrue(
             "the wire push must durably record the wire attempt on the row",
             store.hasWireAttempt(paneId, payload),


### PR DESCRIPTION
Reviewer-APPROVED (D31 reopen, max rigor). The v0.4.35 #1577 fix was verified on a FAKE Codex and did NOT fix the maintainer's real `/goal resume` (composer fails, keyboard works). Real-Codex 0.144.1 repro found the true root cause: Codex swallows the Enter when text+CR land in one stdin read batch.

Three D22 fixes: (1) count-baseline ack gate (footer no longer false-confirms the Enter → Enter lands in a separate read after ingestion), (2) Conversation-tab slash routed through the same gated submit (not raw text+CR), (3) presence-only fallback killed.

- Reproduce-first burst-TUI fixture faithful to real Codex; both routes red→green; over-gating no-hang proven (TmuxSessionAgentSendTest 25/25, ack bounded by timeout+floor); full suite 3819/0; hygiene green.
- Final real-Codex confirmation remains the maintainer's on-device check (honest G4/G10 caveat).

For v0.4.36. Closes #1577.