### PR TITLE
composer: verify-probe integrity — bounded-scrollback capture + single store (#1587 H2/H3)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/tmux/OutboundDeliveryGuard.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/OutboundDeliveryGuard.kt
@@ -1,8 +1,8 @@
 package com.pocketshell.app.tmux
 
 import android.util.Log
+import com.pocketshell.app.composer.OutboundQueueStore
 import com.pocketshell.app.composer.OutboundWireAttemptDurableStore
-import com.pocketshell.app.composer.SharedPrefsOutboundQueueStore
 import com.pocketshell.app.composer.asWireAttemptDurableStore
 import com.pocketshell.app.diagnostics.DiagnosticEvents
 import com.pocketshell.core.tmux.TmuxClient
@@ -201,6 +201,24 @@ internal suspend fun deliverRawInputWithGuard(
 internal const val OUTBOUND_DELIVERY_PROBE_TIMEOUT_MS: Long = 4_000L
 
 /**
+ * Issue #1587 (H2): how many lines of scrollback the verify-before-resend probe
+ * (and its baseline snapshot) capture — `capture-pane -p -S -N`. A visible-only
+ * capture (`-p`, no `-S`) MISSES a payload that LANDED but scrolled off the
+ * visible viewport under a burst of agent output since the send, so the probe
+ * reports `NotLanded` and the retry duplicate-pastes (the reported H2 defect).
+ *
+ * Bounded (NOT full history): matches the app's established seed-scrollback depth
+ * ([SEED_SCROLLBACK_LINES] = 200), which covers several screens of agent output
+ * since a send while staying small enough that a truly ANCIENT identical occurrence
+ * is out of window (no over-suppression) and the exec round-trip stays fast. The
+ * baseline snapshot ([captureNeedleBaseline]) and the post-send probe
+ * ([probeOutboundPayloadAlreadyLanded]) MUST scope over this SAME bound so the
+ * needle-count comparison (#1577: resend requires the count to INCREASE) is
+ * meaningful — a pre-existing occurrence is then counted in BOTH.
+ */
+internal const val OUTBOUND_PROBE_SCROLLBACK_LINES: Int = SEED_SCROLLBACK_LINES
+
+/**
  * Minimum printable needle length for a keystroke-batch probe. Below this the
  * needle is too generic for a visible-viewport presence check (a lone `y` or an
  * arrow key would false-positive on almost any pane), so the probe reports
@@ -294,17 +312,22 @@ internal class OutboundDeliveryLedger(
 
 /**
  * Issue #1541: build the production [OutboundDeliveryLedger] with its durable
- * wire-attempt backing wired to the persisted outbound queue rows. A fresh
- * [SharedPrefsOutboundQueueStore][com.pocketshell.app.composer.SharedPrefsOutboundQueueStore]
- * shares the process-cached `outbound_queue` SharedPreferences with the composer's
- * singleton, so the `wireAttempted` flag written on one instance is visible to the
- * ledger rebuilt on the next VM — surviving VM-clear / back-navigation. A null
- * [context] (narrow unit-test VM constructors) falls back to the in-memory-only
+ * wire-attempt backing wired to the persisted outbound queue rows.
+ *
+ * Issue #1587 (H3): thread the INJECTED `@Singleton` [OutboundQueueStore] (the SAME
+ * instance the composer and the poll-lane orphan sweep use) — NOT a freshly
+ * `new`-ed `SharedPrefsOutboundQueueStore`. Two instances over the one `outbound_queue`
+ * SharedPreferences blob hold SEPARATE locks, so a `markWireAttempted` (this ledger)
+ * racing a `requeueStaleInFlight` orphan sweep (the composer VM's store) is a
+ * last-writer-wins lost update — the durable `wireAttempted` flag is clobbered and a
+ * rebuilt ledger blind re-pastes after a VM-clear. ONE store ⇒ ONE lock ⇒ the two
+ * read-modify-writes serialize and the flag survives. A null [store] (narrow unit-test
+ * VM constructors that don't inject the singleton) falls back to the in-memory-only
  * ledger (base S1 behaviour).
  */
-internal fun outboundDeliveryLedgerFor(context: android.content.Context?): OutboundDeliveryLedger =
+internal fun outboundDeliveryLedgerFor(store: OutboundQueueStore?): OutboundDeliveryLedger =
     OutboundDeliveryLedger(
-        durable = context?.let { SharedPrefsOutboundQueueStore(it).asWireAttemptDurableStore() },
+        durable = store?.asWireAttemptDurableStore(),
     )
 
 /**
@@ -331,7 +354,13 @@ internal suspend fun probeOutboundPayloadAlreadyLanded(
     // resend (which records a fresh baseline), never a bare Enter — deliver-safe.
     if (baselineCount == null) return DeliveryProbeOutcome.NotLanded
     val response = try {
-        client.capturePaneTextViaExec(paneId, timeoutMs = OUTBOUND_DELIVERY_PROBE_TIMEOUT_MS)
+        // Issue #1587 (H2): bounded scrollback so a landed-then-scrolled-off payload
+        // is still found (else NotLanded ⇒ duplicate paste on retry).
+        client.capturePaneTextViaExec(
+            paneId,
+            timeoutMs = OUTBOUND_DELIVERY_PROBE_TIMEOUT_MS,
+            scrollbackLines = OUTBOUND_PROBE_SCROLLBACK_LINES,
+        )
     } catch (cancelled: CancellationException) {
         throw cancelled
     } catch (_: Throwable) {
@@ -357,7 +386,14 @@ internal suspend fun captureNeedleBaseline(
 ): Int? {
     val needle = agentSubmitAckNeedle(payload) ?: return null
     val response = try {
-        client.capturePaneTextViaExec(paneId, timeoutMs = OUTBOUND_DELIVERY_PROBE_TIMEOUT_MS)
+        // Issue #1587 (H2): the baseline snapshot MUST scope over the SAME bounded
+        // scrollback the probe uses ([probeOutboundPayloadAlreadyLanded]) so the
+        // count comparison is meaningful (a pre-existing occurrence is in both).
+        client.capturePaneTextViaExec(
+            paneId,
+            timeoutMs = OUTBOUND_DELIVERY_PROBE_TIMEOUT_MS,
+            scrollbackLines = OUTBOUND_PROBE_SCROLLBACK_LINES,
+        )
     } catch (cancelled: CancellationException) {
         throw cancelled
     } catch (_: Throwable) {
@@ -408,7 +444,13 @@ internal suspend fun probeNeedleAlreadyLanded(
 ): DeliveryProbeOutcome {
     if (needle == null) return DeliveryProbeOutcome.Unknown
     val response = try {
-        client.capturePaneTextViaExec(paneId, timeoutMs = OUTBOUND_DELIVERY_PROBE_TIMEOUT_MS)
+        // Issue #1587 (H2): bounded scrollback so a landed-then-scrolled-off keystroke
+        // batch is still found by the superseded/retry probe (no duplicate send).
+        client.capturePaneTextViaExec(
+            paneId,
+            timeoutMs = OUTBOUND_DELIVERY_PROBE_TIMEOUT_MS,
+            scrollbackLines = OUTBOUND_PROBE_SCROLLBACK_LINES,
+        )
     } catch (cancelled: CancellationException) {
         throw cancelled
     } catch (_: Throwable) {

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -287,6 +287,8 @@ public class TmuxSessionViewModel @Inject constructor(
     // Nullable default keeps the existing unit-test constructors working without
     // the Hilt singleton; when absent the host mirror is simply skipped.
     private val diagnosticRecorder: com.pocketshell.app.diagnostics.DiagnosticRecorder? = null,
+    // Issue #1587 (H3): injected @Singleton store, one lock (see outboundDeliveryLedgerFor).
+    private val outboundQueueStore: com.pocketshell.app.composer.OutboundQueueStore? = null,
 ) : ViewModel() {
 
     /**
@@ -14068,11 +14070,9 @@ public class TmuxSessionViewModel @Inject constructor(
         return sendAgentPayloadToPaneResult(client, paneId, payload, agent)
     }
 
-    // Issue #1526 S1 / #1541: verify-before-resend ledger. The volatile set dies
-    // on VM-clear (back-navigation), so it is backed by the durable per-row
-    // `wireAttempted` flag (see [outboundDeliveryLedgerFor]) — a rebuilt ledger
-    // verifies instead of blindly re-pasting. Null ctx (unit-test ctors) ⇒ base S1.
-    private val outboundDeliveryLedger = outboundDeliveryLedgerFor(applicationContext)
+    // Issue #1526 S1 / #1541 / #1587: verify-before-resend ledger, durable-backed by
+    // the injected @Singleton store (see [outboundDeliveryLedgerFor]). Null ⇒ base S1.
+    private val outboundDeliveryLedger = outboundDeliveryLedgerFor(outboundQueueStore)
 
     private fun consumeSendResultLostSeamForTest() {
         if (!OutboundDeliverySeams.consumeSendResultLostBeforeSubmitEnter()) return

--- a/app/src/test/java/com/pocketshell/app/tmux/FakeTmuxClient.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/FakeTmuxClient.kt
@@ -392,12 +392,40 @@ internal open class FakeTmuxClient(
     override suspend fun sendBestEffortCommand(cmd: String): CommandResponse =
         handleCommand(cmd, bestEffort = true)
 
-    override suspend fun capturePaneTextViaExec(paneId: String, timeoutMs: Long?): CommandResponse {
+    /**
+     * Issue #1587 (H2): the scrollback bound each `capturePaneTextViaExec` call
+     * requested, in order — so a test can assert the verify-before-resend probe
+     * asks for scrollback (`> 0`), and can key a scrollback-vs-visible response off it.
+     */
+    val capturePaneTextViaExecScrollbackLines: MutableList<Int> = mutableListOf()
+
+    /**
+     * Issue #1587 (H2): when set, a `capturePaneTextViaExec` call with
+     * `scrollbackLines > 0` returns THIS (the scrollback-inclusive frame) instead of
+     * the visible-only [capturePaneResponses]/[defaultCaptureResponse]. Lets a test
+     * model a payload that landed but scrolled OFF the visible viewport: visible
+     * capture omits it, the bounded-scrollback capture finds it.
+     */
+    @Volatile
+    var scrollbackCaptureResponse: CommandResponse? = null
+
+    override suspend fun capturePaneTextViaExec(
+        paneId: String,
+        timeoutMs: Long?,
+        scrollbackLines: Int,
+    ): CommandResponse {
         capturePaneTextViaExecCalls += paneId
+        capturePaneTextViaExecScrollbackLines += scrollbackLines
         if (suspendForeverOnCapturePaneTextViaExec) {
             CompletableDeferred<Unit>().await()
         }
-        return handleCommand("capture-pane -p -t $paneId", bestEffort = false)
+        scrollbackCaptureResponse?.let { if (scrollbackLines > 0) return it }
+        val command = if (scrollbackLines > 0) {
+            "capture-pane -p -S -$scrollbackLines -t $paneId"
+        } else {
+            "capture-pane -p -t $paneId"
+        }
+        return handleCommand(command, bestEffort = false)
     }
 
     private suspend fun handleCommand(cmd: String, bestEffort: Boolean): CommandResponse {

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue1577BurstTuiSubmitTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue1577BurstTuiSubmitTest.kt
@@ -304,8 +304,13 @@ internal class BurstTuiFakeTmuxClient(
         return super.sendBestEffortCommand(cmd)
     }
 
-    override suspend fun capturePaneTextViaExec(paneId: String, timeoutMs: Long?): CommandResponse {
+    override suspend fun capturePaneTextViaExec(
+        paneId: String,
+        timeoutMs: Long?,
+        scrollbackLines: Int,
+    ): CommandResponse {
         capturePaneTextViaExecCalls += paneId
+        capturePaneTextViaExecScrollbackLines += scrollbackLines
         advanceCodexReadOnCapture()
         return CommandResponse(number = 0L, output = renderLines(), isError = false)
     }

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue1587SingleStoreWiringTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue1587SingleStoreWiringTest.kt
@@ -1,0 +1,105 @@
+package com.pocketshell.app.tmux
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.pocketshell.app.composer.InMemoryOutboundQueueStore
+import com.pocketshell.app.composer.OutboundItem
+import com.pocketshell.core.agents.AgentDetection
+import com.pocketshell.core.agents.AgentKind
+import com.pocketshell.core.tmux.CommandResponse
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Issue #1587 (H3) — the two-store lost-flag race, at the VM wiring level.
+ *
+ * `TmuxSessionViewModel`'s verify-before-resend ledger used to `new` up a SECOND
+ * `SharedPrefsOutboundQueueStore` from the app context — a DISTINCT instance, with
+ * its OWN lock, over the same `outbound_queue` SharedPreferences blob the composer
+ * and the 15s orphan sweep already own via the Hilt @Singleton. A `markWireAttempted`
+ * (this ledger) racing a `requeueStaleInFlight` orphan sweep (the singleton) is a
+ * last-writer-wins lost update: the durable `wireAttempted` flag is clobbered and a
+ * rebuilt ledger blind re-pastes after a VM-clear (the reopened duplicate class).
+ *
+ * The fix threads the INJECTED @Singleton store into the ledger (one instance, one
+ * lock). This test proves the WIRING behaviourally: it injects a spy store (the SAME
+ * object the sweep would read) and drives a real agent send; the VM's ledger MUST
+ * record the wire attempt on THAT spy.
+ *
+ * RED on base (the VM news up its own SharedPrefsOutboundQueueStore from the context
+ * — reproduce by pointing the ledger at a context-derived store instead of the
+ * injected one): the spy is never touched ⇒ `wireMarks == 0` / `hasWireAttempt ==
+ * false`. GREEN (injected singleton threaded through): the spy records the flag.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class Issue1587SingleStoreWiringTest : TmuxSessionViewModelTestBase() {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private fun claudeDetection(): AgentDetection = AgentDetection(
+        agent = AgentKind.ClaudeCode,
+        sourcePath = "/home/u/.claude/sessions/abc.jsonl",
+        sessionId = "abc",
+        confidence = AgentDetection.Confidence.ProcessConfirmed,
+    )
+
+    /** A spy over the real in-memory store that counts the durable wire-attempt writes. */
+    private class CountingOutboundQueueStore : InMemoryOutboundQueueStore() {
+        var wireMarks: Int = 0
+
+        override fun markWireAttempted(
+            paneId: String,
+            payload: String,
+            atMs: Long,
+            baselineCount: Int?,
+        ): OutboundItem? {
+            wireMarks += 1
+            return super.markWireAttempted(paneId, payload, atMs, baselineCount)
+        }
+    }
+
+    @Test
+    fun vmLedgerRecordsWireAttemptOnTheInjectedSingletonStoreTheSweepUses() = runTest(scheduler) {
+        val store = CountingOutboundQueueStore()
+        val paneId = "%0"
+        val payload = "wire this exactly once please"
+        // The composer's persisted row the sweep would also see.
+        store.enqueue("sessA", payload, paneId = paneId)
+
+        val client = FakeTmuxClient().apply {
+            // The ack gate sees the pasted payload immediately (fresh payload ⇒ baseline 0).
+            defaultCaptureResponse =
+                CommandResponse(number = 0L, output = listOf("> $payload"), isError = false)
+        }
+        val vm = newVm(applicationContext = context, outboundQueueStore = store)
+        vm.attachClientForTest(client)
+        vm.startAgentConversationForTest(paneId, claudeDetection())
+        vm.setAgentSubmitEnterDelayForTest(0)
+        vm.setAgentSubmitAckTimeoutForTest(50)
+
+        val result = async { vm.sendAgentPayloadToPaneResult(paneId, payload, AgentKind.ClaudeCode) }
+        advanceUntilIdle()
+        assertTrue("the agent send should succeed", result.await().isSuccess)
+
+        assertTrue(
+            "the VM's verify-before-resend ledger must record the wire attempt on the INJECTED " +
+                "@Singleton store (the SAME instance the orphan sweep uses) — RED on base: the VM " +
+                "news up a SECOND store from the context, so this spy is never written",
+            store.wireMarks > 0,
+        )
+        assertTrue(
+            "the durable wireAttempted flag must be readable via the SAME store the sweep reads " +
+                "(one instance, one lock — no lost-update race)",
+            store.hasWireAttempt(paneId, payload),
+        )
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/OutboundDeliveryGuardTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/OutboundDeliveryGuardTest.kt
@@ -558,6 +558,183 @@ class OutboundDeliveryGuardTest {
         )
     }
 
+    // ---------------------------------------------------------------- issue #1587 H2 (viewport-bounded probe)
+
+    /**
+     * Issue #1587 (H2) — THE reported defect. A payload that LANDED but scrolled OFF
+     * the visible viewport under a burst of agent output must still be found by the
+     * verify-before-resend probe, so an ambiguous retry submits Enter only and does
+     * NOT duplicate-paste.
+     *
+     * RED on base (visible-only `capture-pane -p`, no `-S`): the scrolled-off payload
+     * is absent from the visible capture ⇒ NotLanded ⇒ the retry re-pastes (server
+     * occurrence 2). GREEN (bounded `-S -N` scrollback capture): the payload is found
+     * in scrollback (count 1 > baseline 0) ⇒ AlreadyLanded ⇒ no duplicate.
+     */
+    @Test
+    fun landedThenScrolledOffPayloadIsFoundViaBoundedScrollbackProbeSoNoDuplicate() = runTest {
+        val ledger = OutboundDeliveryLedger()
+        val paneId = "%0"
+        val payload = "run the full integration suite now"
+        // A prior ambiguous wire attempt recorded with baseline 0 (fresh payload — it
+        // was NOT on the pane at send time; production always records a baseline).
+        ledger.recordWireAttempt(paneId, payload, baselineCount = 0)
+
+        val client = FakeTmuxClient().apply {
+            // The paste LANDED, then a burst of agent output pushed it OFF the visible
+            // viewport: a visible-only capture no longer shows it...
+            defaultCaptureResponse =
+                CommandResponse(number = 0L, output = listOf("...busy agent burst...", "$ "), isError = false)
+            // ...but it is STILL within the bounded scrollback the probe now captures.
+            scrollbackCaptureResponse = CommandResponse(
+                number = 0L,
+                output = listOf("> $payload", "...busy agent burst...", "$ "),
+                isError = false,
+            )
+        }
+
+        val outcome = verifyBeforeAgentResend(ledger, client, paneId, payload)
+
+        assertTrue(
+            "the verify-before-resend probe must request BOUNDED SCROLLBACK (the H2 fix)",
+            client.capturePaneTextViaExecScrollbackLines.any { it > 0 },
+        )
+        assertEquals(
+            "a landed-then-scrolled-off payload must be found via bounded scrollback (AlreadyLanded) " +
+                "so the retry submits Enter only — RED on base (visible-only probe ⇒ NotLanded ⇒ duplicate)",
+            DeliveryProbeOutcome.AlreadyLanded,
+            outcome,
+        )
+    }
+
+    /**
+     * Issue #1587 (H2) class-coverage — the payload still VISIBLE (never scrolled off)
+     * remains found: the bounded-scrollback capture is a SUPERSET of the visible
+     * viewport, so the common already-landed case is unchanged (AlreadyLanded).
+     */
+    @Test
+    fun stillVisiblePayloadIsFoundByTheScrollbackProbeUnchanged() = runTest {
+        val ledger = OutboundDeliveryLedger()
+        val paneId = "%0"
+        val payload = "deploy the staging build to the box"
+        ledger.recordWireAttempt(paneId, payload, baselineCount = 0)
+        val client = FakeTmuxClient().apply {
+            // The scrollback capture (what the probe now issues) includes the visible
+            // payload — it is at the bottom of the buffer, still on screen.
+            scrollbackCaptureResponse =
+                CommandResponse(number = 0L, output = listOf("$ ", "> $payload"), isError = false)
+        }
+
+        assertEquals(
+            DeliveryProbeOutcome.AlreadyLanded,
+            verifyBeforeAgentResend(ledger, client, paneId, payload),
+        )
+    }
+
+    /**
+     * Issue #1587 (H2) class-coverage — NO over-suppression. A payload GENUINELY absent
+     * from the pane (not visible AND not in the bounded scrollback) must stay NotLanded
+     * so the caller does a real gated resend — the scrollback probe must not invent a
+     * false `AlreadyLanded` and silently drop the send.
+     */
+    @Test
+    fun genuinelyAbsentPayloadStaysNotLandedNoOverSuppression() = runTest {
+        val ledger = OutboundDeliveryLedger()
+        val paneId = "%0"
+        val payload = "please run the deployment checklist"
+        ledger.recordWireAttempt(paneId, payload, baselineCount = 0)
+        val client = FakeTmuxClient().apply {
+            // Neither the visible viewport nor the bounded scrollback contains the payload.
+            scrollbackCaptureResponse =
+                CommandResponse(number = 0L, output = listOf("$ ", "unrelated output line"), isError = false)
+        }
+
+        assertEquals(
+            "a payload absent from the bounded scrollback must stay NotLanded (real resend), " +
+                "never a false AlreadyLanded drop",
+            DeliveryProbeOutcome.NotLanded,
+            verifyBeforeAgentResend(ledger, client, paneId, payload),
+        )
+    }
+
+    /**
+     * Issue #1587 (H2) consistency — the baseline snapshot and the resend probe scope
+     * over the SAME bounded scrollback, so a needle that PRE-EXISTS in scrollback (a
+     * prior scrolled-off occurrence) is counted in BOTH: a resend requires the count to
+     * INCREASE, so a pre-existing occurrence is not over-suppressed as `AlreadyLanded`.
+     *
+     * If the baseline scoped over the visible viewport while the probe scoped over
+     * scrollback, the pre-existing occurrence would inflate the probe count above a
+     * (visible-derived) baseline of 0 and FALSELY resolve AlreadyLanded → silent drop.
+     */
+    @Test
+    fun baselineAndProbeScopeOverSameScrollbackSoPreExistingOccurrenceIsNotOverSuppressed() = runTest {
+        val ledger = OutboundDeliveryLedger()
+        val paneId = "%0"
+        val payload = "/goal resume"
+        val client = FakeTmuxClient()
+        // The needle already exists ONCE in the bounded scrollback (a prior scrolled-off
+        // line). `localRenderText` carries the needle so the baseline is captured
+        // AUTHORITATIVELY over the SAME bounded scrollback (not fast-pathed to 0).
+        client.scrollbackCaptureResponse =
+            CommandResponse(number = 0L, output = listOf("> $payload", "...later output...", "$ "), isError = false)
+        ledger.recordWireAttemptWithBaseline(client, paneId, payload, localRenderText = "> $payload")
+        assertEquals(
+            "the baseline is captured over the SAME bounded scrollback the probe uses (count 1)",
+            1,
+            ledger.needleBaseline(paneId, payload),
+        )
+
+        // A resend whose paste did NOT land: scrollback still shows the ONE pre-existing
+        // occurrence (count 1 == baseline 1) ⇒ NotLanded (no false AlreadyLanded).
+        assertEquals(
+            DeliveryProbeOutcome.NotLanded,
+            verifyBeforeAgentResend(ledger, client, paneId, payload),
+        )
+
+        // A resend whose paste DID land: scrollback now shows TWO (count 2 > baseline 1)
+        // ⇒ AlreadyLanded ⇒ deduped to exactly-once.
+        client.scrollbackCaptureResponse =
+            CommandResponse(number = 0L, output = listOf("> $payload", "> $payload", "$ "), isError = false)
+        assertEquals(
+            DeliveryProbeOutcome.AlreadyLanded,
+            verifyBeforeAgentResend(ledger, client, paneId, payload),
+        )
+    }
+
+    // ---------------------------------------------------------------- issue #1587 H3 (single-store)
+
+    /**
+     * Issue #1587 (H3) — structural single-store invariant. [outboundDeliveryLedgerFor]
+     * threads the EXACT injected [OutboundQueueStore][com.pocketshell.app.composer.OutboundQueueStore]
+     * (the SAME @Singleton instance the composer and the 15s orphan sweep use) as the
+     * ledger's durable backing — it does NOT `new` up a second store. Proven by identity:
+     * a wire attempt recorded through the ledger is visible via the SAME store object the
+     * sweep reads (one instance ⇒ one lock ⇒ no lost-update race that erases the flag).
+     */
+    @Test
+    fun outboundDeliveryLedgerForThreadsTheExactInjectedStoreNotASecondInstance() {
+        val store = com.pocketshell.app.composer.InMemoryOutboundQueueStore()
+        store.enqueue("sessA", "single-store payload", paneId = "%0")
+        val ledger = outboundDeliveryLedgerFor(store)
+
+        ledger.recordWireAttempt("%0", "single-store payload")
+
+        assertTrue(
+            "the wire attempt recorded via the ledger must be visible through the SAME store " +
+                "instance the orphan sweep reads (one lock — no lost-update race)",
+            store.hasWireAttempt("%0", "single-store payload"),
+        )
+    }
+
+    /** A null store (narrow unit-test VM constructors) ⇒ base S1 in-memory-only ledger. */
+    @Test
+    fun outboundDeliveryLedgerForWithNoStoreIsInMemoryOnly() {
+        val ledger = outboundDeliveryLedgerFor(null)
+        ledger.recordWireAttempt("%0", "in-memory only payload")
+        assertTrue(ledger.hasAmbiguousAttempt("%0", "in-memory only payload"))
+    }
+
     @Test
     fun ledgerTracksRecordsClearsAndEvictsOldestBeyondCapacity() {
         val ledger = OutboundDeliveryLedger(maxEntries = 2)

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTestBase.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTestBase.kt
@@ -160,9 +160,19 @@ abstract class TmuxSessionViewModelTestBase {
         // Issue #1541: default null keeps every existing test's ledger in-memory
         // only (base S1). A test that needs the durable per-row `wireAttempted`
         // flag (survives VM-clear / back-navigation) passes the Robolectric app
-        // context, so a VM's `outboundDeliveryLedgerFor(applicationContext)` wires
-        // the durable backing over the process-cached `outbound_queue` prefs.
+        // context.
         applicationContext: android.content.Context? = null,
+        // Issue #1587 (H3): the verify-before-resend ledger's durable backing now
+        // comes from the INJECTED @Singleton OutboundQueueStore (one instance, one
+        // lock — no lost-update race with the orphan sweep), not a store the VM
+        // news up from the context. Default: build one over the same app context so
+        // durable-flag tests keep their backing over the shared `outbound_queue`
+        // prefs (production injects the singleton over the SAME prefs). A test can
+        // pass a spy/shared store to prove the VM threads that exact instance.
+        outboundQueueStore: com.pocketshell.app.composer.OutboundQueueStore? =
+            applicationContext?.let {
+                com.pocketshell.app.composer.SharedPrefsOutboundQueueStore(it)
+            },
     ): TmuxSessionViewModel =
         TmuxSessionViewModel(
             tmuxClientFactory = TmuxClientFactory(factoryScope),
@@ -176,6 +186,7 @@ abstract class TmuxSessionViewModelTestBase {
             agentRepository = agentRepository,
             agentKindRemoteSource = agentKindRemoteSource,
             applicationContext = applicationContext,
+            outboundQueueStore = outboundQueueStore,
         ).also {
             // Issue #576 (Slice A of #792): pin the structural-reconcile
             // dispatcher to Main (the MainDispatcherRule's

--- a/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxClient.kt
+++ b/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxClient.kt
@@ -174,16 +174,19 @@ public interface TmuxClient : AutoCloseable {
     }
 
     /**
-     * Capture the pane's visible text on the independent exec lane. This is for
-     * acknowledgement probes that only need `capture-pane -p`, not cursor or
-     * scrollback state. The default keeps test doubles compatible by falling
-     * back to the existing best-effort control-mode path.
+     * Capture pane text on the exec lane (verify/ack probes). Issue #1587 (H2):
+     * [scrollbackLines] > 0 captures `-S -N` scrollback so a landed-then-scrolled-off
+     * payload is still found (else NotLanded ⇒ duplicate paste); `0` = visible-only.
      */
     public suspend fun capturePaneTextViaExec(
         paneId: String,
         timeoutMs: Long? = null,
+        scrollbackLines: Int = 0,
     ): CommandResponse =
-        sendBestEffortCommand("capture-pane -p -t $paneId")
+        sendBestEffortCommand(
+            if (scrollbackLines > 0) "capture-pane -p -S -$scrollbackLines -t $paneId"
+            else "capture-pane -p -t $paneId",
+        )
 
     /**
      * Issue #692: send several tmux control-mode commands as ONE chained
@@ -1284,12 +1287,15 @@ internal class RealTmuxClient(
     override suspend fun capturePaneTextViaExec(
         paneId: String,
         timeoutMs: Long?,
+        scrollbackLines: Int,
     ): CommandResponse {
         if (closed) throw TmuxClientException("client is closed")
         if (!connected) throw TmuxClientException("client is not connected")
         val effectiveTimeoutMs = timeoutMs?.coerceIn(1L, commandTimeoutMs) ?: commandTimeoutMs
         val quotedPane = "'${escapeSingleQuoted(paneId)}'"
-        val command = "tmux capture-pane -p -t $quotedPane"
+        // Issue #1587 (H2): bounded scrollback (`-S -N`) for verify.
+        val command = if (scrollbackLines > 0) "tmux capture-pane -p -S -$scrollbackLines -t $quotedPane"
+        else "tmux capture-pane -p -t $quotedPane"
         val execResult =
             try {
                 withTimeoutOrNull(effectiveTimeoutMs) {

--- a/shared/core-tmux/src/test/java/com/pocketshell/core/tmux/TmuxClientExecLaneTest.kt
+++ b/shared/core-tmux/src/test/java/com/pocketshell/core/tmux/TmuxClientExecLaneTest.kt
@@ -162,6 +162,36 @@ class TmuxClientExecLaneTest {
     }
 
     @Test
+    fun `capturePaneTextViaExec includes bounded scrollback when requested`() = runBlocking {
+        // Issue #1587 (H2): the verify-before-resend probe requests bounded scrollback
+        // (`-S -N`) so a payload that LANDED but scrolled off the visible viewport is
+        // still found — otherwise the probe reports NotLanded and the retry duplicate-pastes.
+        val shell = FakeShell()
+        val session = FakeSession(
+            shell,
+            execHandler = {
+                ExecResult(stdout = "scrolled\noff\nline\n", stderr = "", exitCode = 0)
+            },
+        )
+        val client = RealTmuxClient(session, scope)
+        try {
+            client.connect()
+            val response = withTimeout(ASYNC_AWAIT_TIMEOUT_MS) {
+                client.capturePaneTextViaExec("%3", timeoutMs = 2_500L, scrollbackLines = 200)
+            }
+
+            assertFalse(response.isError)
+            assertEquals(listOf("scrolled", "off", "line"), response.output)
+            assertEquals(
+                "tmux capture-pane -p -S -200 -t '%3'",
+                session.execCommands.single { it.contains("capture-pane") },
+            )
+        } finally {
+            client.close()
+        }
+    }
+
+    @Test
     fun `captureWithCursor exec lane times out on a wedged transport within the short ceiling`() = runBlocking {
         // Issue #926/#1297: a genuinely wedged/half-open transport (the exec never
         // returns) must surface a TmuxClientException within the SHORT seed


### PR DESCRIPTION
Reviewer-APPROVED (#1562 audit H2+H3; H4 closed by #1577). 
- H2: verify capture now includes a bounded 200-line scrollback so a landed-then-scrolled-off payload isn't re-pasted; baseline+probe scope identically so the #1577 count-baseline stays meaningful.
- H3: single injected @Singleton store (one lock) instead of a second instance racing the orphan sweep.
- Both red→green; #1577 ack-gate no-regression (BurstTui 6 + AgentSend 25 green); over-match protected by count-must-increase; full suite 3826/0; hygiene green.

Completes the #1562 message-queue hardening wave. For v0.4.36. Closes #1587.