### PR TITLE
release: v0.4.36 — real /goal resume fix + message-queue hardening + passphrase reconnect

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,8 +65,8 @@ android {
         applicationId = "com.pocketshell.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 82
-        versionName = "0.4.35"
+        versionCode = 83
+        versionName = "0.4.36"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/tools/pocketshell/pyproject.toml
+++ b/tools/pocketshell/pyproject.toml
@@ -8,7 +8,7 @@ name = "pocketshell"
 # scripts/check-pypi-version.sh enforces this; .github/workflows/build.yml
 # runs that check before publishing to PyPI. See
 # tools/pocketshell/README.md ("Release flow") for the bump procedure.
-version = "0.4.35"
+version = "0.4.36"
 description = "Unified server-side Python utility for the PocketShell Android client."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Version bump 0.4.35 → 0.4.36 (versionCode 82 → 83), tools/pocketshell in lockstep.

Ships (all reviewer-APPROVED, already on main):
- **#1577 (reopen)** real-Codex /goal resume submit fix — count-baseline ack gate + gated Conversation-tab route (the v0.4.35 fix was verified on a fake Codex and was orthogonal)
- **#1586** shell/RawBytes lane delivery parity (no false-success, no blind duplicate)
- **#1587** verify-probe integrity (bounded scrollback + single store)
- **#1588** skip re-upload of already-uploaded attachment sidecars
- **#1575** passphrase-host forced-reconnect fix

Release gate + tag follow on green.