### PR TITLE
session: start FGS foreground-eligibly so transport survives backgrounding (#1595 P1)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/App.kt
+++ b/app/src/main/java/com/pocketshell/app/App.kt
@@ -23,6 +23,7 @@ import com.pocketshell.app.release.UpdateCheckScheduler
 import com.pocketshell.app.settings.AppSettings
 import com.pocketshell.app.settings.SettingsRepository
 import com.pocketshell.app.sessions.ActiveTmuxClients
+import com.pocketshell.app.sessions.service.SessionForegroundServiceActivityObserver
 import com.pocketshell.app.sessions.service.SessionServiceController
 import com.pocketshell.app.startup.StartupTiming
 import com.pocketshell.app.tmux.TmuxSessionRuntimeCache
@@ -439,6 +440,21 @@ class App : Application() {
         // app-switch that returns within the grace window never tears the
         // terminal connection down.
         ProcessLifecycleOwner.get().lifecycle.addObserver(terminalLifecycleObserver)
+        // Issue #1595: start the session FGS off the ACTIVITY lifecycle (all activities STOPPED)
+        // — a FOREGROUND-ELIGIBLE moment that fires promptly — instead of only the backgrounded
+        // ProcessLifecycleOwner ON_STOP above. ProcessLifecycleOwner ON_STOP fires ~700ms into the
+        // background (a single delayed runnable), where Android 12+ rejects startForegroundService()
+        // with ForegroundServiceStartNotAllowedException — so the hold never came up and the OS
+        // killed the -CC socket ~4.4s later (device-log audit #1562). The activity's own onStop
+        // fires far earlier (still foreground-eligible), so the hold comes up before the OS can
+        // suspend the socket and the transport survives the grace window (silent reseed on return,
+        // not a redial). Round 2: keyed off the activity STARTED-count (not onPause) so transient
+        // overlays that keep the activity visible — permission dialog / share sheet / shade —
+        // never flash the FGS notification, and a short controller debounce absorbs a quick
+        // stop→resume (recents peek). Config-change stops are skipped (see the observer).
+        registerActivityLifecycleCallbacks(
+            SessionForegroundServiceActivityObserver(sessionServiceController),
+        )
         terminalNetworkScope.launch {
             terminalNetworkObserver.changes.collect { change ->
                 val runtimeDiagnostics = terminalRuntimeDiagnostics()

--- a/app/src/main/java/com/pocketshell/app/sessions/service/SessionConnectionService.kt
+++ b/app/src/main/java/com/pocketshell/app/sessions/service/SessionConnectionService.kt
@@ -17,6 +17,7 @@ import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
 import com.pocketshell.app.MainActivity
 import com.pocketshell.app.R
+import com.pocketshell.app.diagnostics.DiagnosticEvents
 import com.pocketshell.app.portfwd.DefaultDispatcher
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -64,15 +65,55 @@ class SessionConnectionService : Service() {
         const val ACTION_START = "com.pocketshell.app.sessions.action.START_SESSION_HOLD"
         const val ACTION_STOP = "com.pocketshell.app.sessions.action.STOP_SESSION_HOLD"
 
-        fun start(context: Context): Boolean {
+        /**
+         * Issue #1595: the connection-trail event recording every session-FGS start/promotion
+         * outcome. Category `connection` so it lands on the same trail the device-log audit
+         * reads (mirrors [com.pocketshell.core.tmux.TmuxClientDiagnostics], which the App wires
+         * into `DiagnosticEvents.record("connection", …)`).
+         */
+        const val DIAG_EVENT_FGS = "session_fgs"
+
+        /**
+         * Issue #1595: test seam for the `startForegroundService()` call so a JVM test can inject
+         * a background-restricted rejection (the on-device
+         * `ForegroundServiceStartNotAllowedException`). Null → the real platform call.
+         */
+        @androidx.annotation.VisibleForTesting
+        internal var startForegroundServiceForTest: ((Context, Intent) -> Unit)? = null
+
+        fun start(context: Context, holdActive: Boolean = true): Boolean {
             val intent = Intent(context, SessionConnectionService::class.java).apply {
                 action = ACTION_START
             }
             return runCatching {
-                ContextCompat.startForegroundService(context, intent)
+                startForegroundServiceForTest?.invoke(context, intent)
+                    ?: ContextCompat.startForegroundService(context, intent)
+                // Issue #1595: record the SUCCESSFUL request too, so a device background proves
+                // the foreground-eligible start actually fired (the audit could not see it —
+                // both failure paths were swallowed with a bare Log.w and NO DiagnosticEvent).
+                DiagnosticEvents.record(
+                    "connection",
+                    DIAG_EVENT_FGS,
+                    "phase" to "request",
+                    "outcome" to "ok",
+                    "hold_active" to holdActive,
+                )
                 true
             }.getOrElse {
+                // Issue #1595: was a swallowed Log.w. Emit a DiagnosticEvent capturing the
+                // exception CLASS (`ForegroundServiceStartNotAllowedException` vs a real socket
+                // error) so the connection-log can attribute the ~4.4s-after-background transport
+                // death to the background-FGS-start restriction instead of staying structurally
+                // blind to it.
                 Log.w(TAG, "session foreground service start was rejected", it)
+                DiagnosticEvents.record(
+                    "connection",
+                    DIAG_EVENT_FGS,
+                    "phase" to "request",
+                    "outcome" to "denied",
+                    "error" to it.javaClass.simpleName,
+                    "hold_active" to holdActive,
+                )
                 false
             }
         }
@@ -153,10 +194,21 @@ class SessionConnectionService : Service() {
         stopSelf()
     }
 
+    /**
+     * Issue #1595: test seam for the `startForeground()` promotion so a JVM test can inject the
+     * background-restricted `ForegroundServiceStartNotAllowedException` thrown at promotion time
+     * (Android 12+; 14+ adds specialUse throw conditions). Null → the real platform call.
+     */
+    @androidx.annotation.VisibleForTesting
+    internal var promoteForegroundForTest: ((Notification) -> Unit)? = null
+
     private fun promoteToForegroundIfNeeded(notification: Notification): Boolean {
         if (hasStartedForeground) return true
         return runCatching {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            val promoter = promoteForegroundForTest
+            if (promoter != null) {
+                promoter(notification)
+            } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
                 startForeground(
                     NOTIFICATION_ID,
                     notification,
@@ -166,9 +218,26 @@ class SessionConnectionService : Service() {
                 startForeground(NOTIFICATION_ID, notification)
             }
             hasStartedForeground = true
+            DiagnosticEvents.record(
+                "connection",
+                DIAG_EVENT_FGS,
+                "phase" to "promote",
+                "outcome" to "ok",
+            )
             true
         }.getOrElse {
+            // Issue #1595: was a swallowed Log.w. Emit a DiagnosticEvent with the exception CLASS
+            // so a device background captures whether promotion was rejected by the
+            // background-FGS-start restriction (`ForegroundServiceStartNotAllowedException`) —
+            // previously invisible to the connection-log.
             Log.w(TAG, "session foreground service promotion failed", it)
+            DiagnosticEvents.record(
+                "connection",
+                DIAG_EVENT_FGS,
+                "phase" to "promote",
+                "outcome" to "denied",
+                "error" to it.javaClass.simpleName,
+            )
             false
         }
     }

--- a/app/src/main/java/com/pocketshell/app/sessions/service/SessionForegroundServiceActivityObserver.kt
+++ b/app/src/main/java/com/pocketshell/app/sessions/service/SessionForegroundServiceActivityObserver.kt
@@ -1,0 +1,90 @@
+package com.pocketshell.app.sessions.service
+
+import android.app.Activity
+import android.app.Application
+import android.os.Bundle
+
+/**
+ * Issue #1595: drives the session foreground-service START off the ACTIVITY lifecycle so it
+ * fires while the app is still FOREGROUND-ELIGIBLE.
+ *
+ * Why an activity observer and not the existing [androidx.lifecycle.ProcessLifecycleOwner]
+ * observer: `ProcessLifecycleOwner` dispatches its `ON_STOP` from a single 700ms-delayed
+ * runnable, so it fires ~700ms INTO the background — past the point where Android 12+ still
+ * allows `startForegroundService()`. The device-log Fable audit (#1562) traced the
+ * ~4.4s-after-background `-CC` transport death to exactly this: the FGS was started only from the
+ * backgrounded `ON_STOP`, the OS rejected the start with
+ * `ForegroundServiceStartNotAllowedException`, the network hold never came up, and the OS
+ * destroyed the uid's sockets — so the foreground return was a full redial instead of a silent
+ * reseed.
+ *
+ * Round 2 (reviewer finding — the anti-thrash gate): the background signal is keyed off the
+ * activity STARTED-count going to zero (`onActivityStopped` → all activities stopped), NOT off
+ * `onActivityPaused`. `onActivityPaused` fires on EVERY transient focus loss — a permission
+ * dialog, a SAF/file picker sheet, the share sheet, the notification shade, a recents peek —
+ * where the activity stays STARTED (visible). Starting the FGS on those flashed a Stop-able
+ * "Session connected" notification into the tray and reintroduced the accidental-Stop footgun
+ * [SessionServiceController] deliberately designs against. An overlay that keeps the activity
+ * STARTED never drives `onActivityStopped` to a zero count, so it never starts the FGS — no
+ * matter how long it lingers. A genuine background (home / recents / app-switch / a full-screen
+ * picker that stops the activity) DOES drive the count to zero. The remaining transient — a
+ * quick stop→start where the activity really stopped but the user returned immediately (a
+ * recents peek) — is absorbed by the controller's short debounce
+ * ([SessionServiceController.onAppPausing]) which the next `onActivityStarted` cancels before it
+ * ever starts the FGS.
+ *
+ * The activity's `onStop` fires promptly (tens of ms after `onPause` for a home-press), FAR
+ * earlier than the ProcessLifecycleOwner debounced `ON_STOP`, so the debounced FGS start still
+ * lands while foreground-eligible and establishes the network hold BEFORE the OS can suspend
+ * the socket — the transport survives the grace window.
+ *
+ * Config-change safety: a rotation / dark-mode flip stops+recreates the activity but is NOT a
+ * real background, so the `onActivityStopped` with [Activity.isChangingConfigurations] == true
+ * is skipped (the started-count is still balanced by the recreated `onActivityStarted`). A
+ * genuine app-switch has `isChangingConfigurations == false`.
+ *
+ * The grace count-down deadline + teardown stay owned by the ProcessLifecycleOwner `ON_STOP` /
+ * `ON_START` path ([SessionServiceController.onAppBackgrounded] / [onAppForegrounded]); this
+ * observer only moves the FGS START earlier to the foreground-eligible boundary and cancels it
+ * again on resume for the transient that never reached `ON_STOP`.
+ *
+ * No-leak: the observer holds only the app-singleton controller and an int counter.
+ */
+class SessionForegroundServiceActivityObserver(
+    private val controller: SessionServiceController,
+) : Application.ActivityLifecycleCallbacks {
+
+    /** Number of currently STARTED (visible) activities. Zero ⇒ the app is backgrounded. */
+    private var startedActivityCount = 0
+
+    override fun onActivityStarted(activity: Activity) {
+        val wasBackground = startedActivityCount == 0
+        startedActivityCount++
+        if (wasBackground) {
+            // 0→1: the app (re)entered the foreground. Cancels a pending pause debounce (a
+            // transient stop→start that never confirmed a real background) and stops any FGS the
+            // debounce already started — no notification thrash.
+            controller.onAppResumed()
+        }
+    }
+
+    override fun onActivityStopped(activity: Activity) {
+        // Decrement on EVERY stop so the count stays balanced across activity→activity
+        // transitions and configuration-change recreate (old.onStop then new.onStart).
+        if (startedActivityCount > 0) startedActivityCount--
+        if (startedActivityCount == 0 && !activity.isChangingConfigurations) {
+            // 1→0 and not a config change: every activity is stopped = a genuine background.
+            // A mere overlay that keeps the activity STARTED (permission dialog / share sheet /
+            // shade / a partial dialog) never reaches here, so it never flashes the FGS
+            // notification. The controller debounces this hint so a quick stop→start (recents
+            // peek) is suppressed too.
+            controller.onAppPausing()
+        }
+    }
+
+    override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) = Unit
+    override fun onActivityResumed(activity: Activity) = Unit
+    override fun onActivityPaused(activity: Activity) = Unit
+    override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) = Unit
+    override fun onActivityDestroyed(activity: Activity) = Unit
+}

--- a/app/src/main/java/com/pocketshell/app/sessions/service/SessionServiceController.kt
+++ b/app/src/main/java/com/pocketshell/app/sessions/service/SessionServiceController.kt
@@ -67,9 +67,26 @@ class SessionServiceController @Inject constructor(
     @VisibleForTesting
     internal var nowMillis: () -> Long = { System.currentTimeMillis() }
 
+    /**
+     * Issue #1595 (round 2): debounce between the "app is going to the background" hint
+     * ([onAppPausing]) and actually starting the session FGS. The activity observer only fires
+     * that hint once EVERY activity is STOPPED (a genuine background — a mere overlay that keeps
+     * the activity STARTED, e.g. a permission dialog / share sheet / notification shade, never
+     * reaches here). A transient stop→start WITHIN this window — a recents peek, a quick
+     * app-switch that returns — is cancelled by [onAppResumed] and NEVER starts the FGS, so no
+     * Stop-able "Session connected" notification flashes into the tray on routine focus loss (the
+     * accidental-Stop footgun the #1159 comment above designs against). Kept well UNDER the
+     * ~700ms ProcessLifecycleOwner `ON_STOP` so a genuine background still starts the FGS while
+     * it is still FOREGROUND-ELIGIBLE — before Android 12+'s background-FGS-start restriction
+     * (`ForegroundServiceStartNotAllowedException`) applies.
+     */
+    @VisibleForTesting
+    internal var pauseStartDebounceMillis: Long = PAUSE_START_DEBOUNCE_MILLIS
+
     private val _snapshot = MutableStateFlow(SessionConnectionSnapshot.Empty)
     private var observeJob: Job? = null
     private var deadlineFlipJob: Job? = null
+    private var pauseDebounceJob: Job? = null
     private var holdStoppedByUser: Boolean = false
 
     /**
@@ -168,7 +185,9 @@ class SessionServiceController @Inject constructor(
                     _snapshot.value = snapshot
                     when {
                         !wasHolding && snapshot.isHoldingConnection ->
-                            SessionConnectionService.start(appContext)
+                            // Issue #1595: pass holdActive so the connection-trail diagnostic
+                            // records the hold state alongside the FGS start outcome.
+                            SessionConnectionService.start(appContext, holdActive = snapshot.isHoldingConnection)
                         wasHolding && !snapshot.isHoldingConnection ->
                             SessionConnectionService.stop(appContext)
                     }
@@ -177,12 +196,82 @@ class SessionServiceController @Inject constructor(
     }
 
     /**
+     * Issue #1595: the app is going to the BACKGROUND (the activity observer fires this once
+     * EVERY activity is STOPPED — a genuine background, not a mere overlay that keeps the
+     * activity STARTED). This is the earliest FOREGROUND-ELIGIBLE moment — the last point at
+     * which Android 12+ still permits a `startForegroundService()` before the background-FGS-start
+     * restriction applies. Starting the session FGS here (rather than only at [onAppBackgrounded],
+     * which is driven by the ProcessLifecycleOwner `ON_STOP` that fires ~700ms INTO the
+     * background) establishes the network hold while the start is still allowed, BEFORE the OS can
+     * suspend the uid's sockets.
+     *
+     * Root cause (device-log Fable audit on #1562): the FGS was started only from the
+     * backgrounded `ON_STOP`, where Android 12+ rejects the start with
+     * `ForegroundServiceStartNotAllowedException`; the hold never came up and the OS destroyed
+     * the `-CC` transport ~4.4s later, so the foreground return was a full redial instead of a
+     * silent reseed. Starting here keeps the transport alive across the grace window.
+     *
+     * Issue #1595 (round 2 — debounce): the foreground flip (and therefore the FGS start) is
+     * DEFERRED by [pauseStartDebounceMillis]. A transient stop→start WITHIN that window — a
+     * recents peek, a quick app-switch that returns — is cancelled by [onAppResumed] BEFORE the
+     * flip fires, so it NEVER starts the FGS and NO Stop-able notification flashes into the tray
+     * on routine focus loss. The delay is well under the ~700ms `ON_STOP`, so a genuine
+     * background still flips (and starts the FGS) while foreground-eligible. Overlays that keep
+     * the activity STARTED (permission dialog / share sheet / shade) never reach here at all (the
+     * observer gates on all-activities-stopped), so they never start the FGS regardless of how
+     * long they linger.
+     *
+     * Only schedules the foreground signal — the grace count-down deadline stays owned by
+     * [onAppBackgrounded] (`ON_STOP`). If no live session is held the FGS start is a no-op (the
+     * flow gates on `isHoldingConnection`). The wiring skips this on a configuration change so a
+     * rotation / dark-mode flip does not thrash the FGS (see the activity observer).
+     */
+    fun onAppPausing() {
+        // Already backgrounded (e.g. ON_STOP already flipped it) → nothing to re-arm.
+        if (!appForegrounded.value) return
+        pauseDebounceJob?.cancel()
+        pauseDebounceJob = scope.launch {
+            delay(pauseStartDebounceMillis)
+            appForegrounded.value = false
+        }
+    }
+
+    /**
+     * Issue #1595: the app RESUMED to the foreground. Mirror of [onAppPausing] — the Activity
+     * holds the connection again.
+     *
+     * Round-2 debounce: CANCELS the pending [onAppPausing] debounce so a transient stop→resume
+     * that never persisted past the window never flips the foreground signal — the FGS is never
+     * started and no notification is ever posted (no start→stop thrash). If the debounce had
+     * already fired (a longer background that then returned), flipping the signal back to `true`
+     * stops the FGS. This covers the transient that never reached `ON_STOP`, where no
+     * [onAppForegrounded] `ON_START` fires. Does NOT touch the grace deadline — a transient that
+     * never reached `ON_STOP` stamped none, and a real return clears it via [onAppForegrounded].
+     */
+    fun onAppResumed() {
+        pauseDebounceJob?.cancel()
+        pauseDebounceJob = null
+        appForegrounded.value = true
+    }
+
+    /**
      * Issue #1159 (Part 1): the app moved to the background. The FGS is (re)evaluated and
      * started if a live session is held. [disconnectAtWallClockMillis] stamps the bounded
      * count-down deadline (issue #1123) rendered by the system chronometer — no app-side
      * per-second wakeups. While a port-forward is active the deadline is ignored (Part 3).
+     *
+     * Issue #1595: [onAppPausing] normally already flipped the foreground signal false (starting
+     * the FGS foreground-eligibly), so the `appForegrounded.value = false` here is idempotent and
+     * this call is primarily the grace-deadline stamp. It remains a fallback start trigger too:
+     * if the earlier foreground-eligible start was skipped (e.g. a configuration change), the
+     * background attempt still runs exactly as before.
      */
     fun onAppBackgrounded(disconnectAtWallClockMillis: Long) {
+        // Confirmed background — the pending pause debounce is no longer needed (it either
+        // already fired the foreground flip, or was skipped for a config change and this is the
+        // fallback start). Cancel it and flip NOW so the start is idempotent / the fallback runs.
+        pauseDebounceJob?.cancel()
+        pauseDebounceJob = null
         graceDisconnectAtWallClockMillis.value = disconnectAtWallClockMillis
         // Issue #1440: a fresh grace window — clear any prior expiry and (re)schedule the flip.
         graceExpired.value = false
@@ -195,6 +284,8 @@ class SessionServiceController @Inject constructor(
      * connection, so the FGS + its tray notification are stopped and the count-down cleared.
      */
     fun onAppForegrounded() {
+        pauseDebounceJob?.cancel()
+        pauseDebounceJob = null
         cancelDeadlineFlip()
         graceDisconnectAtWallClockMillis.value = null
         appForegrounded.value = true
@@ -264,4 +355,15 @@ class SessionServiceController @Inject constructor(
         val disconnectDeadline: Long?,
         val graceExpired: Boolean,
     )
+
+    companion object {
+        /**
+         * Issue #1595 (round 2): default debounce between the all-activities-stopped background
+         * hint ([onAppPausing]) and starting the session FGS. 400ms is well UNDER the ~700ms
+         * ProcessLifecycleOwner `ON_STOP` (so a genuine background still starts the FGS while
+         * foreground-eligible) yet long enough to absorb a quick stop→resume — a recents peek /
+         * app-switch that returns — so it never flashes a Stop-able notification into the tray.
+         */
+        const val PAUSE_START_DEBOUNCE_MILLIS: Long = 400L
+    }
 }

--- a/app/src/test/java/com/pocketshell/app/sessions/service/SessionConnectionServiceFgsDiagnosticsTest.kt
+++ b/app/src/test/java/com/pocketshell/app/sessions/service/SessionConnectionServiceFgsDiagnosticsTest.kt
@@ -1,0 +1,165 @@
+package com.pocketshell.app.sessions.service
+
+import android.content.Context
+import android.content.Intent
+import androidx.test.core.app.ApplicationProvider
+import com.pocketshell.app.diagnostics.DiagnosticEventSink
+import com.pocketshell.app.diagnostics.DiagnosticEvents
+import com.pocketshell.app.sessions.ActiveTmuxClients
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Issue #1595 (diagnosability slice, red→green).
+ *
+ * Device-log root cause (Fable audit on #1562): the session FGS was started from the BACKGROUND
+ * (`ON_STOP`), where Android 12+ rejects the start with `ForegroundServiceStartNotAllowedException`.
+ * BOTH FGS failure paths — the `startForegroundService()` request and the `startForeground()`
+ * promotion — were swallowed with a bare `Log.w` and emitted NO DiagnosticEvent, so the
+ * connection-log was structurally BLIND to the mechanism and the ~4.4s-after-background transport
+ * death could not be attributed.
+ *
+ * These tests reproduce the failure paths synthetically (inject a rejecting starter/promoter) and
+ * assert a DiagnosticEvent carrying the exception CLASS is emitted on the `connection` trail.
+ *
+ * RED on base: base swallows both failures with `Log.w` and records nothing → the recording sink
+ * stays empty → every assertion below fails.
+ * GREEN with the fix: each failure records `connection`/`session_fgs` with `outcome=denied` and
+ * the exception class name.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class SessionConnectionServiceFgsDiagnosticsTest {
+
+    private lateinit var context: Context
+    private val sink = RecordingSink()
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        DiagnosticEvents.install(sink)
+    }
+
+    @After
+    fun tearDown() {
+        DiagnosticEvents.install(DiagnosticEventSink.Noop)
+        SessionConnectionService.startForegroundServiceForTest = null
+    }
+
+    @Test
+    fun `a rejected startForegroundService emits a denied diagnostic with the exception class`() {
+        // The on-device background-FGS-start restriction: startForegroundService() throws.
+        SessionConnectionService.startForegroundServiceForTest = { _, _ ->
+            throw android.app.ForegroundServiceStartNotAllowedException("bg restricted")
+        }
+
+        val started = SessionConnectionService.start(context, holdActive = true)
+
+        assertEquals("a rejected start must return false, not crash", false, started)
+        val denied = sink.find("session_fgs", phase = "request", outcome = "denied")
+        assertNotNull(
+            "the swallowed FGS start rejection must now emit a connection diagnostic (#1595)",
+            denied,
+        )
+        assertEquals(
+            "the diagnostic must capture the exception CLASS so the device log can tell " +
+                "ForegroundServiceStartNotAllowedException from a real socket error",
+            "ForegroundServiceStartNotAllowedException",
+            denied!!["error"],
+        )
+        assertEquals(true, denied["hold_active"])
+    }
+
+    @Test
+    fun `a successful startForegroundService emits an ok diagnostic so the device log proves it fired`() {
+        // No injected starter → the real ShadowApplication start succeeds.
+        val started = SessionConnectionService.start(context, holdActive = true)
+
+        assertEquals(true, started)
+        val ok = sink.find("session_fgs", phase = "request", outcome = "ok")
+        assertNotNull(
+            "a successful foreground-eligible start must also be recorded so the next device " +
+                "background proves the start actually fired (#1595)",
+            ok,
+        )
+        assertEquals(true, ok!!["hold_active"])
+    }
+
+    @Test
+    fun `a rejected startForeground promotion emits a denied diagnostic with the exception class`() {
+        val service = Robolectric.buildService(SessionConnectionService::class.java).get()
+        service.createNotificationChannel()
+        service.promoteForegroundForTest = {
+            throw android.app.ForegroundServiceStartNotAllowedException("promote restricted")
+        }
+
+        // ACTION_START drives promoteToForegroundIfNeeded → throws → getOrElse records + returns
+        // false → the service stops cleanly instead of crashing.
+        service.onStartCommand(
+            Intent(context, SessionConnectionService::class.java).apply {
+                action = SessionConnectionService.ACTION_START
+            },
+            0,
+            1,
+        )
+
+        val denied = sink.find("session_fgs", phase = "promote", outcome = "denied")
+        assertNotNull(
+            "the swallowed FGS promotion failure must now emit a connection diagnostic (#1595)",
+            denied,
+        )
+        assertEquals(
+            "ForegroundServiceStartNotAllowedException",
+            denied!!["error"],
+        )
+    }
+
+    @Test
+    fun `a successful promotion emits an ok diagnostic`() {
+        val service = Robolectric.buildService(SessionConnectionService::class.java).get()
+        service.createNotificationChannel()
+        // A successful promotion proceeds to startObserving(), which collects the controller's
+        // snapshot flow on observeDispatcher. Robolectric.buildService does NOT run Hilt field
+        // injection, so wire a real controller (else the collector touches the uninitialized
+        // @Inject lateinit and throws uncaught on Dispatchers.Default — a leaked coroutine that
+        // surfaces as UncaughtExceptionsBeforeTest in the next runTest). Run the collector on an
+        // unconfined dispatcher so the Empty snapshot immediately drives a synchronous
+        // stopSessionHold() — no leaked background coroutine.
+        service.controller = SessionServiceController(context, ActiveTmuxClients())
+        service.observeDispatcher = kotlinx.coroutines.Dispatchers.Unconfined
+
+        service.onStartCommand(
+            Intent(context, SessionConnectionService::class.java).apply {
+                action = SessionConnectionService.ACTION_START
+            },
+            0,
+            1,
+        )
+
+        val ok = sink.find("session_fgs", phase = "promote", outcome = "ok")
+        assertNotNull("a successful promotion must be recorded on the connection trail", ok)
+        service.onDestroy()
+    }
+
+    private class RecordingSink : DiagnosticEventSink {
+        val events = mutableListOf<Triple<String, String, Map<String, Any?>>>()
+        override fun record(category: String, event: String, fields: Map<String, Any?>) {
+            events.add(Triple(category, event, fields))
+        }
+
+        fun find(event: String, phase: String, outcome: String): Map<String, Any?>? =
+            events.firstOrNull { (category, e, fields) ->
+                category == "connection" &&
+                    e == event &&
+                    fields["phase"] == phase &&
+                    fields["outcome"] == outcome
+            }?.third
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/sessions/service/SessionForegroundServiceActivityObserverTest.kt
+++ b/app/src/test/java/com/pocketshell/app/sessions/service/SessionForegroundServiceActivityObserverTest.kt
@@ -1,0 +1,311 @@
+package com.pocketshell.app.sessions.service
+
+import android.app.Activity
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.pocketshell.app.sessions.ActiveTmuxClients
+import com.pocketshell.app.tmux.FakeTmuxClient
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowApplication
+
+/**
+ * Issue #1595 (lifecycle-fix slice, red→green + round-2 anti-thrash gate).
+ *
+ * The session FGS must be started while the app is still FOREGROUND-ELIGIBLE — NOT only from the
+ * backgrounded ProcessLifecycleOwner `ON_STOP` (which fires ~700ms into the background, where
+ * Android 12+ rejects the start and the OS kills the `-CC` socket ~4.4s later; device-log audit
+ * #1562). Round 2 (reviewer finding): the background signal is keyed off the activity
+ * STARTED-count reaching zero (`onActivityStopped`), NOT `onActivityPaused` — a transient overlay
+ * that keeps the activity STARTED (permission dialog / share sheet / shade) must NEVER flash the
+ * Stop-able notification, and a quick stop→start (recents peek) must be absorbed by the
+ * controller debounce.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+@OptIn(ExperimentalCoroutinesApi::class)
+class SessionForegroundServiceActivityObserverTest {
+
+    private lateinit var context: Context
+    private lateinit var shadow: ShadowApplication
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        shadow = Shadows.shadowOf(context.applicationContext as android.app.Application)
+        drainStartedServices()
+    }
+
+    @Test
+    fun `a genuine background (all activities stopped) starts the FGS foreground-eligibly after the debounce`() = runTest {
+        val activeClients = ActiveTmuxClients()
+        val controller = controller(activeClients, testScheduler)
+        val observer = SessionForegroundServiceActivityObserver(controller)
+
+        controller.observeActiveSessions()
+        runCurrent()
+        registerLive(activeClients, "alpha")
+        runCurrent()
+        // App is foreground (an activity is started): no FGS yet (#1159 Part 1).
+        observer.onActivityStarted(activity())
+        runCurrent()
+        drainStartedServices()
+
+        // The maintainer switches apps: the ONLY activity stops (all activities stopped = a real
+        // background). onAppBackgrounded (ProcessLifecycleOwner ON_STOP) has NOT run yet.
+        observer.onActivityStopped(activity())
+        runCurrent()
+        // Within the debounce window nothing has started (a transient could still resume).
+        assertNull(
+            "the FGS must not start within the debounce — a transient stop→start could resume",
+            shadow.nextStartedService,
+        )
+
+        testScheduler.advanceTimeBy(debounce() + 1)
+        runCurrent()
+
+        val started = shadow.nextStartedService
+        assertNotNull(
+            "a persisted background must start the session FGS while foreground-eligible, " +
+                "BEFORE the ~700ms ON_STOP Android 12+ rejects (#1595)",
+            started,
+        )
+        assertEquals(SessionConnectionService::class.java.name, started?.component?.className)
+        assertEquals(SessionConnectionService.ACTION_START, started?.action)
+        assertTrueMsg(
+            "the hold snapshot must be active once genuinely backgrounded with a live session",
+            controller.flowOfSnapshot().value.isHoldingConnection,
+        )
+    }
+
+    @Test
+    fun `a transient overlay that keeps the activity STARTED never starts the FGS (permission dialog, share sheet, shade)`() = runTest {
+        // Reviewer finding (round 2): a permission dialog / SAF picker sheet / share sheet /
+        // notification shade only PAUSES the activity — it stays STARTED (visible). The observer
+        // must NOT start the FGS on that, however long the overlay lingers, or a Stop-able
+        // "Session connected" notification flashes into the tray (the #1159 lines 38–44 footgun).
+        val activeClients = ActiveTmuxClients()
+        val controller = controller(activeClients, testScheduler)
+        val observer = SessionForegroundServiceActivityObserver(controller)
+
+        controller.observeActiveSessions()
+        runCurrent()
+        registerLive(activeClients, "alpha")
+        runCurrent()
+        observer.onActivityStarted(activity())
+        runCurrent()
+        drainStartedServices()
+
+        // A permission dialog pops over the activity: onActivityPaused fires, but the activity is
+        // NEVER stopped (still STARTED behind the dialog). Wait far longer than the debounce.
+        observer.onActivityPaused(activity())
+        runCurrent()
+        testScheduler.advanceTimeBy(debounce() * 10)
+        runCurrent()
+
+        assertNull(
+            "an overlay that keeps the activity STARTED must NEVER start the FGS — no tray " +
+                "notification flash on a permission dialog / picker / share sheet / shade (#1595)",
+            shadow.nextStartedService,
+        )
+        assertFalse(controller.flowOfSnapshot().value.isHoldingConnection)
+    }
+
+    @Test
+    fun `a quick stop then start within the debounce never starts the FGS — no thrash (recents peek)`() = runTest {
+        // A recents peek / quick app-switch return: the activity really STOPS then STARTS again
+        // within the debounce window. No FGS may be started (no START) and none left running
+        // (no STOP) — no start→stop thrash.
+        val activeClients = ActiveTmuxClients()
+        val controller = controller(activeClients, testScheduler)
+        val observer = SessionForegroundServiceActivityObserver(controller)
+
+        controller.observeActiveSessions()
+        runCurrent()
+        registerLive(activeClients, "alpha")
+        runCurrent()
+        observer.onActivityStarted(activity())
+        runCurrent()
+        drainStartedServices()
+
+        observer.onActivityStopped(activity())
+        runCurrent()
+        testScheduler.advanceTimeBy(debounce() / 2)
+        runCurrent()
+        // The user returns within the window.
+        observer.onActivityStarted(activity())
+        runCurrent()
+        // Advance well past the original debounce deadline — the cancelled debounce must not fire.
+        testScheduler.advanceTimeBy(debounce() * 4)
+        runCurrent()
+
+        assertNull(
+            "a quick stop→start within the debounce must issue NO service intent — no START " +
+                "(no notification) and no STOP (no thrash) (#1595 round 2)",
+            shadow.nextStartedService,
+        )
+        assertFalse(controller.flowOfSnapshot().value.isHoldingConnection)
+    }
+
+    @Test
+    fun `a configuration-change stop does NOT start the FGS (no rotation thrash)`() = runTest {
+        val activeClients = ActiveTmuxClients()
+        val controller = controller(activeClients, testScheduler)
+        val observer = SessionForegroundServiceActivityObserver(controller)
+
+        controller.observeActiveSessions()
+        runCurrent()
+        registerLive(activeClients, "alpha")
+        runCurrent()
+        observer.onActivityStarted(activity())
+        runCurrent()
+        drainStartedServices()
+
+        // A rotation / dark-mode flip: the activity stops (count 1→0) but is a config-change
+        // recreate, NOT a real background.
+        observer.onActivityStopped(configChangeActivity())
+        runCurrent()
+        // The recreated instance starts again (count 0→1).
+        observer.onActivityStarted(activity())
+        runCurrent()
+        // Advance past the debounce — nothing may have been armed.
+        testScheduler.advanceTimeBy(debounce() * 4)
+        runCurrent()
+
+        assertNull(
+            "a configuration-change stop must NOT start the FGS — it is not a real background " +
+                "and would thrash the hold on every rotation (#1595)",
+            shadow.nextStartedService,
+        )
+        assertFalse(controller.flowOfSnapshot().value.isHoldingConnection)
+    }
+
+    @Test
+    fun `background with no live session never starts the FGS (short-background class coverage)`() = runTest {
+        // Class coverage (G2): a backgrounded app with NO interactive tmux session must never
+        // start the hold — the flow gates on isHoldingConnection.
+        val activeClients = ActiveTmuxClients()
+        val controller = controller(activeClients, testScheduler)
+        val observer = SessionForegroundServiceActivityObserver(controller)
+
+        controller.observeActiveSessions()
+        runCurrent()
+        observer.onActivityStarted(activity())
+        runCurrent()
+        observer.onActivityStopped(activity())
+        runCurrent()
+        testScheduler.advanceTimeBy(debounce() * 2)
+        runCurrent()
+
+        assertNull(shadow.nextStartedService)
+        assertFalse(controller.flowOfSnapshot().value.isHoldingConnection)
+    }
+
+    @Test
+    fun `foreground-eligible start holds the transport across the whole grace window (within-grace)`() = runTest {
+        // Class coverage (G2): a longer background WITHIN grace. The FGS started at the
+        // foreground-eligible background hint; the subsequent ON_STOP stamps the count-down
+        // deadline and the hold stays active for the whole grace window (transport held → silent
+        // reseed on return instead of a redial). Beyond-grace teardown is unchanged (the last
+        // live client unregisters and drops the hold — covered by the controller suite).
+        val activeClients = ActiveTmuxClients()
+        val controller = controller(activeClients, testScheduler)
+        val observer = SessionForegroundServiceActivityObserver(controller)
+
+        controller.observeActiveSessions()
+        runCurrent()
+        registerLive(activeClients, "alpha")
+        runCurrent()
+        observer.onActivityStarted(activity())
+        runCurrent()
+        drainStartedServices()
+
+        observer.onActivityStopped(activity())
+        runCurrent()
+        testScheduler.advanceTimeBy(debounce() + 1)
+        runCurrent()
+        assertEquals(SessionConnectionService.ACTION_START, shadow.nextStartedService?.action)
+
+        // ON_STOP arrives ~700ms later and stamps the bounded deadline.
+        val deadline = 90_000L
+        controller.onAppBackgrounded(disconnectAtWallClockMillis = deadline)
+        runCurrent()
+
+        val snapshot = controller.flowOfSnapshot().value
+        assertTrueMsg(
+            "the transport hold must remain active across the grace window (silent reseed on return)",
+            snapshot.isHoldingConnection,
+        )
+        assertEquals(
+            "the ON_STOP stamps the bounded count-down deadline onto the already-held snapshot",
+            deadline,
+            snapshot.disconnectAtWallClockMillis,
+        )
+        // No duplicate start intent — the FGS was already up from the foreground-eligible hint.
+        assertNull(
+            "the ON_STOP must not re-issue a start intent — the FGS is already holding",
+            shadow.nextStartedService,
+        )
+    }
+
+    private fun debounce(): Long = SessionServiceController.PAUSE_START_DEBOUNCE_MILLIS
+
+    private fun assertTrueMsg(message: String, condition: Boolean) {
+        org.junit.Assert.assertTrue(message, condition)
+    }
+
+    private fun activity(): Activity =
+        Robolectric.buildActivity(Activity::class.java).get()
+
+    private fun configChangeActivity(): Activity =
+        Robolectric.buildActivity(ConfigChangeActivity::class.java).get()
+
+    /** An activity that reports it is being recreated for a configuration change. */
+    class ConfigChangeActivity : Activity() {
+        override fun isChangingConfigurations(): Boolean = true
+    }
+
+    private fun registerLive(activeClients: ActiveTmuxClients, hostName: String) {
+        activeClients.register(
+            hostId = 1L,
+            hostName = hostName,
+            hostname = "$hostName.example",
+            port = 22,
+            username = "alexey",
+            keyPath = "/tmp/key",
+            client = FakeTmuxClient(),
+        )
+    }
+
+    private fun controller(
+        activeClients: ActiveTmuxClients,
+        scheduler: TestCoroutineScheduler,
+    ): SessionServiceController {
+        return SessionServiceController(context, activeClients).apply {
+            scope = CoroutineScope(SupervisorJob() + StandardTestDispatcher(scheduler))
+            nowMillis = { scheduler.currentTime }
+        }
+    }
+
+    private fun drainStartedServices() {
+        while (shadow.nextStartedService != null) {
+            // Drain all queued intents.
+        }
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/sessions/service/SessionServiceControllerTest.kt
+++ b/app/src/test/java/com/pocketshell/app/sessions/service/SessionServiceControllerTest.kt
@@ -110,6 +110,160 @@ class SessionServiceControllerTest {
     }
 
     @Test
+    fun `onAppPausing starts the FGS foreground-eligibly after the debounce and onAppResumed stops it (issue 1595)`() = runTest {
+        // Issue #1595: the foreground-eligible start path. onAppPausing() (driven by the ACTIVITY
+        // going background — all activities stopped, the earliest point Android 12+ allows
+        // startForegroundService) starts the FGS BEFORE the backgrounded onAppBackgrounded
+        // (ON_STOP) ever runs; onAppResumed() stops it. On base the FGS could only start from
+        // onAppBackgrounded (background) — this method did not exist.
+        //
+        // Round 2 (debounce): the start is DEFERRED by PAUSE_START_DEBOUNCE_MILLIS so a transient
+        // stop→resume never flashes the FGS. A PERSISTED background — no resume before the window
+        // elapses — must still start the FGS (well under the ~700ms ON_STOP, so eligible).
+        val activeClients = ActiveTmuxClients()
+        val controller = controller(activeClients, testScheduler)
+
+        controller.observeActiveSessions()
+        runCurrent()
+        registerLive(activeClients, "alpha")
+        runCurrent()
+        drainStartedServices()
+
+        controller.onAppPausing()
+        runCurrent()
+        // Within the debounce window the FGS has NOT started yet (a transient could still resume).
+        assertNull(
+            "the FGS must not start until the debounce elapses — a transient could still resume",
+            shadow.nextStartedService,
+        )
+        assertFalse(controller.flowOfSnapshot().value.isHoldingConnection)
+
+        // The background persisted past the debounce → the FGS starts, still foreground-eligible.
+        testScheduler.advanceTimeBy(SessionServiceController.PAUSE_START_DEBOUNCE_MILLIS + 1)
+        runCurrent()
+
+        val started = shadow.nextStartedService
+        assertNotNull(
+            "a persisted background must start the FGS once the debounce elapses (#1595)",
+            started,
+        )
+        assertEquals(SessionConnectionService.ACTION_START, started?.action)
+        assertTrue(controller.flowOfSnapshot().value.isHoldingConnection)
+
+        controller.onAppResumed()
+        runCurrent()
+
+        val stopped = shadow.nextStartedService
+        assertNotNull("onAppResumed must stop the FGS (the Activity holds the connection)", stopped)
+        assertEquals(SessionConnectionService.ACTION_STOP, stopped?.action)
+        assertFalse(controller.flowOfSnapshot().value.isHoldingConnection)
+    }
+
+    @Test
+    fun `a quick pause then resume within the debounce never starts the FGS — no thrash (issue 1595 round 2)`() = runTest {
+        // Reviewer finding (round 2): onActivityPaused fired on EVERY transient focus loss and the
+        // FGS promoted IMMEDIATELY, flashing a Stop-able notification into the tray on a routine
+        // pause→resume (recents peek / shade / quick app-switch return). This is the RED→GREEN
+        // regression: a quick stop→resume WITHIN the debounce must post NO notification and leave
+        // NO running FGS — neither a START nor a STOP intent is issued.
+        //
+        // RED on the pre-debounce code: onAppPausing() flipped foreground=false synchronously, so
+        // a START intent was issued at once (and onAppResumed then a STOP) — the start-then-stop
+        // thrash. GREEN: the debounce is cancelled before it fires, so nothing is ever started.
+        val activeClients = ActiveTmuxClients()
+        val controller = controller(activeClients, testScheduler)
+
+        controller.observeActiveSessions()
+        runCurrent()
+        registerLive(activeClients, "alpha")
+        runCurrent()
+        drainStartedServices()
+
+        controller.onAppPausing()
+        runCurrent()
+        // Resume WELL within the debounce window (a permission dialog dismissed, picker returned,
+        // shade closed, recents peek — a quick return).
+        testScheduler.advanceTimeBy(SessionServiceController.PAUSE_START_DEBOUNCE_MILLIS / 2)
+        runCurrent()
+        controller.onAppResumed()
+        runCurrent()
+        // Advance well PAST the original debounce deadline — the cancelled debounce must not fire.
+        testScheduler.advanceTimeBy(SessionServiceController.PAUSE_START_DEBOUNCE_MILLIS * 4)
+        runCurrent()
+
+        assertNull(
+            "a quick pause→resume within the debounce must issue NO service intent — no START " +
+                "(no notification flash) and no STOP (no thrash) (#1595 round 2)",
+            shadow.nextStartedService,
+        )
+        assertFalse(
+            "no FGS hold may linger after a transient pause→resume",
+            controller.flowOfSnapshot().value.isHoldingConnection,
+        )
+    }
+
+    @Test
+    fun `onAppBackgrounded after onAppPausing stamps the deadline without a duplicate start (issue 1595)`() = runTest {
+        // Issue #1595: onAppPausing already started the FGS foreground-eligibly, so the later
+        // ON_STOP onAppBackgrounded is idempotent for the start (no duplicate intent) and only
+        // stamps the bounded count-down deadline onto the already-held snapshot.
+        val activeClients = ActiveTmuxClients()
+        val controller = controller(activeClients, testScheduler)
+
+        controller.observeActiveSessions()
+        runCurrent()
+        registerLive(activeClients, "alpha")
+        runCurrent()
+        drainStartedServices()
+
+        controller.onAppPausing()
+        runCurrent()
+        // The background persisted past the debounce → the foreground-eligible start fires.
+        testScheduler.advanceTimeBy(SessionServiceController.PAUSE_START_DEBOUNCE_MILLIS + 1)
+        runCurrent()
+        assertEquals(SessionConnectionService.ACTION_START, shadow.nextStartedService?.action)
+
+        controller.onAppBackgrounded(disconnectAtWallClockMillis = 5_000L)
+        runCurrent()
+
+        assertNull(
+            "ON_STOP after a foreground-eligible pause must NOT re-issue a start intent",
+            shadow.nextStartedService,
+        )
+        val snapshot = controller.flowOfSnapshot().value
+        assertTrue(snapshot.isHoldingConnection)
+        assertEquals(
+            "ON_STOP stamps the bounded count-down deadline onto the already-held snapshot",
+            5_000L,
+            snapshot.disconnectAtWallClockMillis,
+        )
+    }
+
+    @Test
+    fun `onAppBackgrounded still starts the FGS as a fallback when onAppPausing was skipped (issue 1595)`() = runTest {
+        // Issue #1595: config-change pauses skip onAppPausing, so the background onAppBackgrounded
+        // (ON_STOP) must still start the FGS exactly as before — the fix ADDS an earlier
+        // foreground-eligible attempt, it never removes the background fallback.
+        val activeClients = ActiveTmuxClients()
+        val controller = controller(activeClients, testScheduler)
+
+        controller.observeActiveSessions()
+        runCurrent()
+        registerLive(activeClients, "alpha")
+        runCurrent()
+        drainStartedServices()
+
+        // No onAppPausing() call (e.g. the pause was a configuration change and was skipped).
+        controller.onAppBackgrounded(disconnectAtWallClockMillis = 1_000L)
+        runCurrent()
+
+        val started = shadow.nextStartedService
+        assertNotNull("onAppBackgrounded must remain a fallback FGS start (#1595)", started)
+        assertEquals(SessionConnectionService.ACTION_START, started?.action)
+        assertTrue(controller.flowOfSnapshot().value.isHoldingConnection)
+    }
+
+    @Test
     fun `port-forward active stops the session FGS so ForwardingService owns the single notification`() = runTest {
         // Issue #1202 + #1198 (reported on-device, v0.4.23): a hetzner session is held in the
         // background — the session FGS is up and its notification (reworded "Port forwarding


### PR DESCRIPTION
Reviewer-APPROVED (2 rounds; the round-1 FGS-notification-thrash footgun was caught + fixed). Device-log P1: the SSH transport died ~4.4s after backgrounding (30-40% of app-switches) because the session FGS was started from background (ProcessLifecycleOwner ON_STOP, #1159) → Android-12 background-start restriction → silent fail → OS kills the socket.

- Fix: start the FGS off the Activity STARTED-count→0 (real background) + 400ms debounce, ~450ms after onPause / ~250ms EARLIER than the old ~700ms path (which already succeeds 60-70%) → strict eligibility improvement, transport survives grace → silent reseed not redial.
- Thrash guard: transient overlays keep the activity STARTED so never trigger the FGS (no notification flicker / accidental-Stop). red→green.
- Diagnosability: FGS start/promote failures now emit `session_fgs` DiagnosticEvents (were swallowed) — self-reports on next device background.
- Full suite deterministic green (fixed a round-1 order-dependent hang); hygiene green.
- **G4/G10 caveat:** the OS FGS-grant at ~450ms + socket-survival are device behaviors; final proof is the maintainer's post-release connection-log (orchestrator will re-read it).

For v0.4.37. Closes #1595.