### PR TITLE
release: v0.4.37 — transport survives backgrounding (#1595)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,8 +65,8 @@ android {
         applicationId = "com.pocketshell.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 83
-        versionName = "0.4.36"
+        versionCode = 84
+        versionName = "0.4.37"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/tools/pocketshell/pyproject.toml
+++ b/tools/pocketshell/pyproject.toml
@@ -8,7 +8,7 @@ name = "pocketshell"
 # scripts/check-pypi-version.sh enforces this; .github/workflows/build.yml
 # runs that check before publishing to PyPI. See
 # tools/pocketshell/README.md ("Release flow") for the bump procedure.
-version = "0.4.36"
+version = "0.4.37"
 description = "Unified server-side Python utility for the PocketShell Android client."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Version bump 0.4.36 → 0.4.37 (versionCode 83 → 84), tools/pocketshell in lockstep.

Ships #1595 (reviewer-APPROVED, on main): the session FGS now starts foreground-eligibly so the SSH transport survives backgrounding (was dying ~4.4s in → redial on return, the top residual after the v0.4.34 storm fix). Includes the `session_fgs` diagnostic that self-reports FGS start ok/denied on the next device background.

Release gate + tag on green.