### PR TITLE
ci: self-heal corrupted-NDK-download flake on Build workflow (#1581)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,8 +52,21 @@ jobs:
       - name: Make gradlew executable
         run: chmod +x ./gradlew
 
+      # Issue #1581: Gradle auto-installs NDK 27.0.12077973 (AGP's default NDK)
+      # on demand when it configures :shared:core-terminal, and the GitHub
+      # runner intermittently receives a corrupt/incomplete NDK archive
+      # ("Error on ZipFile unknown archive"), failing the release-critical Build
+      # with no code change. Re-running over the same partial download does NOT
+      # help; the wrapper clears the partial download between attempts so a
+      # single corrupted-download attempt self-heals instead of needing a manual
+      # re-run. It only retries the specific corrupted-NDK signature, so a real
+      # compile/regression failure still fails immediately (never masked). The
+      # produced APK is unchanged. Retry/clear logic is proven by
+      # scripts/test-ci-ndk-retry.sh in the Tests workflow's Unit job.
       - name: Assemble debug APK
-        run: ./gradlew assembleDebug --stacktrace
+        run: |
+          chmod +x scripts/ci-assemble-with-ndk-retry.sh
+          scripts/ci-assemble-with-ndk-retry.sh
 
       - name: Rename APK
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -192,6 +192,19 @@ jobs:
           chmod +x scripts/lib/nightly-phase-reports.sh
           scripts/lib/nightly-phase-reports.sh --self-test
 
+      # Issue #1581: gate the Build workflow's corrupted-NDK-download retry
+      # wrapper (scripts/ci-assemble-with-ndk-retry.sh) so its clear-and-retry
+      # logic cannot silently regress. Fast, JVM-free shell test (fake build cmd,
+      # temp dirs, no Gradle/SDK/network) proving: attempt-1 corrupted-NDK
+      # failure -> CLEAR partial download -> attempt-2 success (self-healed);
+      # that the clear is load-bearing (retry alone, with the clear stubbed off,
+      # still fails); and that a non-NDK failure is NOT retried (a real
+      # regression is never masked). Cheap (< 5 s), no emulator.
+      - name: Build NDK-download retry guard (issue #1581)
+        run: |
+          chmod +x scripts/ci-assemble-with-ndk-retry.sh scripts/test-ci-ndk-retry.sh
+          scripts/test-ci-ndk-retry.sh
+
       # Issue #760: the unit job occasionally failed with ALL visible tests
       # PASSED — a gradle-daemon/runner OOM abort, not a real assertion failure.
       # ubuntu-latest gives 7 GB RAM and 2 cores; unbounded gradle worker fan-out

--- a/scripts/ci-assemble-with-ndk-retry.sh
+++ b/scripts/ci-assemble-with-ndk-retry.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Issue #1581: run the release-critical Build's `assembleDebug`, self-healing
+# the intermittent corrupted-NDK-download flake.
+#
+# Gradle auto-installs NDK 27.0.12077973 (AGP 8.9.2's default NDK) on demand
+# when it configures :shared:core-terminal (that module has an externalNativeBuild
+# CMake block). The GitHub-hosted runner occasionally receives a corrupt or
+# incomplete NDK archive and the configure phase dies with:
+#
+#     An error occurred while preparing SDK package NDK (Side by side) 27.0.12077973:
+#     Error on ZipFile unknown archive.
+#     java.io.IOException: Error on ZipFile unknown archive
+#
+# Confirmed a pure download flake: a `gh run rerun --failed` with NO code change
+# went green. Each occurrence costs a manual re-run on the release path.
+#
+# THE KEY INSIGHT: re-running the same install over the partial/corrupt archive
+# does NOT help — the downloader reuses the cached corrupt file. The partial
+# download must be CLEARED between attempts so the retry fetches a fresh archive.
+#
+# This wrapper drives Gradle's OWN SDK downloader (already working in the Build
+# job — only the archive integrity flakes), so it does not depend on the
+# runner's pre-installed `sdkmanager` binary (which issue #771 found broken on
+# some runner images). It ONLY retries when the failure carries the specific
+# corrupted-NDK signature; any other failure (a real compile error, a genuine
+# regression) fails immediately so retries cannot mask it or waste CI time.
+#
+# The retry/clear logic is exercised by scripts/test-ci-ndk-retry.sh (a fast,
+# JVM-free shell test wired into the Unit job of .github/workflows/tests.yml).
+
+set -uo pipefail
+
+SDK_ROOT="${ANDROID_SDK_ROOT:-${ANDROID_HOME:-/usr/local/lib/android/sdk}}"
+NDK_VERSION="${NDK_VERSION:-27.0.12077973}"
+MAX_ATTEMPTS="${NDK_RETRY_ATTEMPTS:-3}"
+
+# The build command. Overridable so the retry/clear logic can be unit-tested
+# without a real Gradle build or Android SDK.
+BUILD_CMD="${BUILD_CMD:-./gradlew assembleDebug --stacktrace}"
+
+# File the build output is tee'd to so the corrupted-NDK signature can be
+# scanned. Overridable for tests.
+BUILD_LOG="${BUILD_LOG:-$(mktemp)}"
+
+# Partial NDK download/extract locations + the SDK download caches. Clearing
+# these between attempts forces the next attempt to fetch a fresh archive.
+# Overridable (space-separated) so the clear-and-retry behaviour can be tested
+# against a temp dir with no real SDK present.
+: "${NDK_PARTIAL_PATHS:=$SDK_ROOT/ndk/$NDK_VERSION $SDK_ROOT/.temp ${ANDROID_PREFS_ROOT:-$HOME/.android}/cache}"
+
+# Substring that identifies the corrupted-NDK-download failure (issue #1581).
+# Only a failure whose output contains this triggers the clear-and-retry.
+NDK_CORRUPT_SIGNATURE="${NDK_CORRUPT_SIGNATURE:-Error on ZipFile unknown archive}"
+
+# Seconds to wait between attempts (0 in tests).
+NDK_RETRY_DELAY="${NDK_RETRY_DELAY:-5}"
+
+# Remove every configured partial-download/cache path so the next attempt
+# re-downloads the NDK archive from scratch. This is the load-bearing step:
+# without it, the retry reuses the corrupt cached archive and fails again.
+clear_partial_ndk_download() {
+  local p
+  for p in $NDK_PARTIAL_PATHS; do
+    if [[ -e "$p" ]]; then
+      echo "  clearing partial NDK state: $p"
+      rm -rf "$p" || true
+    fi
+  done
+}
+
+run_build_with_ndk_retry() {
+  local attempt
+  for (( attempt = 1; attempt <= MAX_ATTEMPTS; attempt++ )); do
+    echo "::group::Build attempt ${attempt}/${MAX_ATTEMPTS}"
+    # pipefail (set above) makes the pipeline's exit status the build's, not
+    # tee's, so a build failure is detected even though the output is tee'd.
+    if eval "$BUILD_CMD" 2>&1 | tee "$BUILD_LOG"; then
+      echo "::endgroup::"
+      echo "Build succeeded on attempt ${attempt}."
+      return 0
+    fi
+    echo "::endgroup::"
+
+    # Only self-heal the specific corrupted-NDK-download flake. Any other
+    # failure fails immediately — retrying would only waste CI time and could
+    # mask a real regression.
+    if ! grep -qF "$NDK_CORRUPT_SIGNATURE" "$BUILD_LOG"; then
+      echo "Build failed for a reason other than the corrupted-NDK-download flake (issue #1581); not retrying."
+      return 1
+    fi
+
+    if (( attempt >= MAX_ATTEMPTS )); then
+      echo "::error title=NDK download still corrupt after ${MAX_ATTEMPTS} attempts::The NDK ${NDK_VERSION} archive was corrupt on every attempt (issue #1581). This is a runner-network/download infra failure, not a code failure."
+      return 1
+    fi
+
+    echo "Detected the corrupted-NDK-download flake (issue #1581). Clearing the partial download so the next attempt fetches a fresh archive..."
+    clear_partial_ndk_download
+    sleep "$NDK_RETRY_DELAY"
+  done
+  return 1
+}
+
+# Run only when executed directly; sourcing (the shell test) gets the functions
+# without triggering a build.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  run_build_with_ndk_retry
+fi

--- a/scripts/test-ci-ndk-retry.sh
+++ b/scripts/test-ci-ndk-retry.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# Issue #1581: fast, JVM-free shell test for the corrupted-NDK-download retry
+# wrapper (scripts/ci-assemble-with-ndk-retry.sh).
+#
+# The wrapper's job is to survive a single corrupted-NDK-download attempt
+# ("Error on ZipFile unknown archive") WITHOUT a manual re-run, by CLEARING the
+# partial download between attempts so the retry fetches a fresh archive.
+#
+# This test proves — deterministically, with NO Gradle, NO Android SDK, NO
+# network — that:
+#   (T1) clear_partial_ndk_download removes exactly the configured partial paths;
+#   (T2) attempt-1 failure -> clear -> attempt-2 success returns 0 (self-healed);
+#   (T3) the CLEAR is load-bearing, not just the retry: with the clear stubbed
+#        to a no-op, the SAME simulated flake fails on every attempt (proving a
+#        retry-without-clear would not fix the corrupted-archive bug — the exact
+#        failure mode the issue calls out);
+#   (T4) a NON-NDK failure (a real compile error) is NOT retried — it fails
+#        immediately after one attempt, so the wrapper can never mask a real
+#        regression.
+#
+# Wired into the Unit job of .github/workflows/tests.yml (G9: a test per
+# acceptance criterion).
+#
+# Each test runs the sourced wrapper in an isolated ( ... ) subshell so its
+# functions/env do not leak between cases; the env exports are intentionally
+# subshell-local (SC2030/SC2031) and the no-op clear stub in T3 is invoked
+# indirectly (SC2317).
+# shellcheck disable=SC2030,SC2031,SC2317
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WRAPPER="$SCRIPT_DIR/ci-assemble-with-ndk-retry.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+# ---------------------------------------------------------------------------
+# T1: clear_partial_ndk_download removes exactly the configured partial paths.
+# ---------------------------------------------------------------------------
+test_clear_removes_partial_paths() {
+  local tmp; tmp="$(mktemp -d)"
+  mkdir -p "$tmp/ndk-extract" "$tmp/sdk-temp"
+  echo "corrupt-archive-bytes" > "$tmp/ndk-extract/partial.zip"
+  echo "in-progress" > "$tmp/sdk-temp/op.json"
+  local keep="$tmp/keep-me"; echo "unrelated" > "$keep"
+
+  (
+    export NDK_PARTIAL_PATHS="$tmp/ndk-extract $tmp/sdk-temp"
+    export BUILD_CMD="true"
+    # shellcheck disable=SC1090
+    source "$WRAPPER"
+    clear_partial_ndk_download
+  ) || fail "T1: clear_partial_ndk_download exited non-zero"
+
+  [[ -e "$tmp/ndk-extract" ]] && fail "T1: partial ndk-extract not removed"
+  [[ -e "$tmp/sdk-temp" ]] && fail "T1: partial sdk-temp not removed"
+  [[ -e "$keep" ]] || fail "T1: unrelated file wrongly removed"
+  rm -rf "$tmp"
+  echo "PASS T1: clear_partial_ndk_download removes exactly the configured partial paths"
+}
+
+# A fake build command whose behaviour depends on whether a "corrupt partial
+# download" marker file is present — modelling the real bug where the downloader
+# reuses a cached corrupt archive:
+#   - marker PRESENT  -> emit the corrupted-NDK signature and FAIL
+#   - marker ABSENT   -> "compile" and SUCCEED
+# The marker lives INSIDE the configured NDK_PARTIAL_PATHS dir, so the wrapper's
+# clear step removes it and lets the next attempt succeed.
+make_flaky_build_cmd() {
+  local marker="$1"
+  # Printed via the wrapper's `eval`; must be a single shell expression.
+  cat <<EOF
+if [ -e "$marker" ]; then echo "Error on ZipFile unknown archive"; exit 1; else echo "compiled ok"; exit 0; fi
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# T2: attempt-1 failure -> clear -> attempt-2 success returns 0.
+# ---------------------------------------------------------------------------
+test_retry_clear_then_success() {
+  local tmp; tmp="$(mktemp -d)"
+  local partial="$tmp/ndk-partial"
+  mkdir -p "$partial"
+  local marker="$partial/corrupt.zip"
+  echo "corrupt" > "$marker"     # pre-seed a leftover corrupt download
+  local log="$tmp/build.log"
+
+  local rc=0
+  (
+    export NDK_PARTIAL_PATHS="$partial"
+    export NDK_RETRY_DELAY=0
+    export NDK_RETRY_ATTEMPTS=3
+    export BUILD_LOG="$log"
+    export BUILD_CMD; BUILD_CMD="$(make_flaky_build_cmd "$marker")"
+    # shellcheck disable=SC1090
+    source "$WRAPPER"
+    run_build_with_ndk_retry
+  ) || rc=$?
+
+  [[ "$rc" -eq 0 ]] || fail "T2: expected self-heal to succeed (rc=0), got rc=$rc"
+  echo "PASS T2: attempt-1 corrupt-NDK failure -> clear -> attempt-2 success (self-healed)"
+  rm -rf "$tmp"
+}
+
+# ---------------------------------------------------------------------------
+# T3: the CLEAR is load-bearing. With clear stubbed to a no-op, the corrupt
+# archive is reused on every attempt and the build fails -> proves a
+# retry-WITHOUT-clear would NOT fix the flake (the issue's core point).
+# ---------------------------------------------------------------------------
+test_clear_is_load_bearing() {
+  local tmp; tmp="$(mktemp -d)"
+  local partial="$tmp/ndk-partial"
+  mkdir -p "$partial"
+  local marker="$partial/corrupt.zip"
+  echo "corrupt" > "$marker"
+  local log="$tmp/build.log"
+
+  local rc=0
+  (
+    export NDK_PARTIAL_PATHS="$partial"
+    export NDK_RETRY_DELAY=0
+    export NDK_RETRY_ATTEMPTS=3
+    export BUILD_LOG="$log"
+    export BUILD_CMD; BUILD_CMD="$(make_flaky_build_cmd "$marker")"
+    # shellcheck disable=SC1090
+    source "$WRAPPER"
+    # Defeat the clear so the corrupt archive persists across attempts.
+    clear_partial_ndk_download() { echo "  (clear stubbed to no-op)"; }
+    run_build_with_ndk_retry
+  ) || rc=$?
+
+  [[ "$rc" -ne 0 ]] || fail "T3: build unexpectedly succeeded WITHOUT clearing the corrupt archive; the clear is not actually load-bearing"
+  [[ -e "$marker" ]] || fail "T3: corrupt marker gone despite no-op clear (test wiring bug)"
+  echo "PASS T3: with clear stubbed no-op, the corrupt archive persists and the build fails -> clear is load-bearing (retry alone is not enough)"
+  rm -rf "$tmp"
+}
+
+# ---------------------------------------------------------------------------
+# T4: a NON-NDK failure is not retried — fails immediately (never masks a real
+# regression), and only ONE attempt runs.
+# ---------------------------------------------------------------------------
+test_non_ndk_failure_not_retried() {
+  local tmp; tmp="$(mktemp -d)"
+  local log="$tmp/build.log"
+  local counter="$tmp/attempts"
+  echo 0 > "$counter"
+
+  local rc=0
+  (
+    export NDK_PARTIAL_PATHS="$tmp/none"
+    export NDK_RETRY_DELAY=0
+    export NDK_RETRY_ATTEMPTS=3
+    export BUILD_LOG="$log"
+    # A real compile error: fails with a DIFFERENT message every attempt and
+    # bumps the attempt counter so we can prove it ran only once.
+    export BUILD_CMD="n=\$(cat '$counter'); echo \$((n+1)) > '$counter'; echo 'e: Unresolved reference: foo'; exit 1"
+    # shellcheck disable=SC1090
+    source "$WRAPPER"
+    run_build_with_ndk_retry
+  ) || rc=$?
+
+  [[ "$rc" -ne 0 ]] || fail "T4: non-NDK failure unexpectedly returned success"
+  local attempts; attempts="$(cat "$counter")"
+  [[ "$attempts" -eq 1 ]] || fail "T4: expected exactly 1 attempt for a non-NDK failure, got $attempts (a real compile error must not be retried)"
+  echo "PASS T4: non-NDK failure fails immediately after 1 attempt (real regressions are never masked)"
+  rm -rf "$tmp"
+}
+
+test_clear_removes_partial_paths
+test_retry_clear_then_success
+test_clear_is_load_bearing
+test_non_ndk_failure_not_retried
+
+echo "ALL PASS: scripts/test-ci-ndk-retry.sh (issue #1581)"


### PR DESCRIPTION
Closes #1581

Wraps the release-critical `assembleDebug` in `scripts/ci-assemble-with-ndk-retry.sh`: on the `Error on ZipFile unknown archive` NDK-download signature it clears the partial download and retries (bounded, default 3); any other failure fast-fails after one attempt so a real compile regression is never masked. New JVM-free shell test `scripts/test-ci-ndk-retry.sh` (T1–T4) wired into the required `Unit tests` job.

## Verification (reviewer APPROVED, red→green this run)
- `bash scripts/test-ci-ndk-retry.sh` → all 4 pass. **T3** (clear stubbed to no-op → RED, fails every attempt) vs **T2** (real clear → GREEN, self-heals) proves the clear is load-bearing.
- Exit-code propagation verified: exhausted retries → exit 1; non-NDK failure → exit 1 after exactly 1 attempt; happy path → exit 0. Cannot mask a real Build failure.
- `shellcheck` clean; both workflow YAMLs parse; `git diff --check` clean; no product code, NDK version unchanged, no APK change.
- Orchestrator gate: reassembled in a clean worktree, shell test green, YAML re-validated.