### PR TITLE
message-queue: per-send-token ledger identity, not payload-derived (#1529)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/tmux/OutboundDeliveryGuard.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/OutboundDeliveryGuard.kt
@@ -46,6 +46,16 @@ import kotlinx.coroutines.delay
 internal enum class DeliveryProbeOutcome { AlreadyLanded, NotLanded, Unknown }
 
 /**
+ * Issue #1529: an opaque, monotonic per-send-attempt delivery token for a send that has
+ * no durable outbound-queue row id to use (a non-queue-backed send). It is unique per
+ * call, so two DISTINCT sends never share ledger identity; a send whose retry must dedup
+ * threads a STABLE id (the durable row id, or the conversation turn id) instead.
+ */
+private val deliveryTokenCounter = java.util.concurrent.atomic.AtomicLong(0)
+
+internal fun newOutboundDeliveryToken(): String = "d${deliveryTokenCounter.incrementAndGet()}"
+
+/**
  * Issue #1526 test seams (#780 synthetic-injection model). Production never arms
  * them (both default false); each is consumed once.
  *
@@ -83,9 +93,10 @@ internal suspend fun verifyBeforeAgentResend(
     ledger: OutboundDeliveryLedger,
     client: TmuxClient,
     paneId: String,
+    sendToken: String,
     payload: String,
 ): DeliveryProbeOutcome? {
-    if (!ledger.hasAmbiguousAttempt(paneId, payload)) return null
+    if (!ledger.hasAmbiguousAttempt(paneId, sendToken, payload)) return null
     // Issue #1577: compare the CURRENT needle count against the pre-send baseline
     // captured at the first wire attempt. `AlreadyLanded` requires the count to have
     // INCREASED (our paste actually added an occurrence) — so a payload that was
@@ -97,7 +108,7 @@ internal suspend fun verifyBeforeAgentResend(
     // a bare Enter and silently drop the payload). [probeOutboundPayloadAlreadyLanded]
     // reports `NotLanded` for a null baseline instead, so the caller does a REAL gated
     // resend that records a fresh baseline (self-healing), never a bare Enter.
-    val baseline = ledger.needleBaseline(paneId, payload)
+    val baseline = ledger.needleBaseline(paneId, sendToken, payload)
     val outcome = probeOutboundPayloadAlreadyLanded(client, paneId, payload, baseline)
     DiagnosticEvents.record(
         "action",
@@ -151,15 +162,17 @@ internal suspend fun deliverRawInputWithGuard(
     paneId: String,
     bytes: ByteArray,
     localRenderText: String,
+    sendToken: String,
     send: suspend (TmuxClient, String, ByteArray) -> Unit,
     submitEnter: suspend (TmuxClient, String) -> Unit,
     afterDelivered: suspend (TmuxClient, String, ByteArray) -> Unit,
 ): Result<Unit> {
-    // Key the ledger on the payload WITHOUT its trailing submit CR/LF: the composer
-    // enqueues the durable row's `cleanText` without the CR it appends on the wire,
-    // so trimming aligns the (pane, payload) key with the durable `wireAttempted`
-    // row — the same VM-clear/back-nav durability the agent lane gets (#1541). The
-    // full [bytes] (CR included) are still what [send] pushes. Pure control/Enter
+    // Issue #1529: the ledger identity is the PER-SEND-ATTEMPT [sendToken] (the durable
+    // outbound row id, or an opaque per-send token), NOT the payload — so two DISTINCT
+    // user sends of identical bytes are never false-deduped. The trailing submit CR/LF is
+    // still trimmed off the [payload] used for the #869 probe needle / #1577 baseline (the
+    // composer enqueues the durable row's `cleanText` without the CR it appends on the
+    // wire). The full [bytes] (CR included) are still what [send] pushes. Pure control/Enter
     // input trims to empty — nothing meaningful to probe/dedupe, so it does a plain
     // error-checked send (H1a still applies via [send]).
     val fullText = String(bytes, Charsets.UTF_8)
@@ -170,7 +183,7 @@ internal suspend fun deliverRawInputWithGuard(
             afterDelivered(client, paneId, bytes)
         }
     }
-    when (verifyBeforeAgentResend(ledger, client, paneId, payload)) {
+    when (verifyBeforeAgentResend(ledger, client, paneId, sendToken, payload)) {
         DeliveryProbeOutcome.AlreadyLanded -> return runCatching {
             // Issue #1586 (H1b): the payload TEXT landed but the ambiguous cut may have
             // dropped its terminating submit — do NOT drop the delivery silently.
@@ -181,7 +194,7 @@ internal suspend fun deliverRawInputWithGuard(
             if (fullText.length > payload.length) {
                 submitEnter(client, paneId)
             }
-            ledger.clear(paneId, payload)
+            ledger.clear(paneId, sendToken)
             afterDelivered(client, paneId, bytes)
         }
         DeliveryProbeOutcome.Unknown -> return Result.failure(
@@ -190,9 +203,9 @@ internal suspend fun deliverRawInputWithGuard(
         DeliveryProbeOutcome.NotLanded, null -> Unit
     }
     return runCatching {
-        ledger.recordWireAttemptWithBaseline(client, paneId, payload, localRenderText)
+        ledger.recordWireAttemptWithBaseline(client, paneId, sendToken, payload, localRenderText)
         send(client, paneId, bytes)
-        ledger.clear(paneId, payload)
+        ledger.clear(paneId, sendToken)
         afterDelivered(client, paneId, bytes)
     }
 }
@@ -262,11 +275,23 @@ internal class OutboundDeliveryLedger(
     // so a VM-clear-rebuilt ledger reads it back (via [needleBaseline]).
     private val baselines = HashMap<String, Int>()
 
-    private fun key(paneId: String, payload: String): String =
-        "$paneId|${payload.length}|${payload.hashCode()}"
+    // Issue #1529: the VOLATILE identity is the per-send-attempt token (pane + token),
+    // NOT the payload. Two DISTINCT user sends of identical bytes get distinct tokens, so
+    // the guard dedups only a RETRY of the SAME attempt (same token) and never suppresses
+    // a second intentional send. The DURABLE fallback stays keyed on (pane, payload): a
+    // durable row that survives a VM-clear is re-dispatched by its retry lane, and the
+    // #961 coalesce-on-enqueue invariant means at most ONE un-delivered row exists per
+    // (pane, payload), so a payload-scoped durable lookup can never conflate two distinct
+    // durable sends (they would have coalesced into one row / one token).
+    private fun key(paneId: String, sendToken: String): String = "$paneId|$sendToken"
 
-    fun recordWireAttempt(paneId: String, payload: String, baselineCount: Int? = null): Unit = synchronized(lock) {
-        val key = key(paneId, payload)
+    fun recordWireAttempt(
+        paneId: String,
+        sendToken: String,
+        payload: String,
+        baselineCount: Int? = null,
+    ): Unit = synchronized(lock) {
+        val key = key(paneId, sendToken)
         entries.remove(key)
         entries.add(key)
         // Issue #1577: keep the FIRST captured baseline (idempotent) — a re-push after
@@ -285,28 +310,30 @@ internal class OutboundDeliveryLedger(
         durable?.recordWireAttempt(paneId, payload, System.currentTimeMillis(), baselineCount)
     }
 
-    fun clear(paneId: String, payload: String): Unit = synchronized(lock) {
+    fun clear(paneId: String, sendToken: String): Unit = synchronized(lock) {
         // Only clears the volatile set: the durable flag is tied to the row's
         // lifetime (dropped when the row is delivered-pruned / removed, PRESERVED
         // across requeue), so an as-yet-un-acked in-flight row keeps verifying.
-        val key = key(paneId, payload)
+        val key = key(paneId, sendToken)
         entries.remove(key)
         baselines.remove(key)
     }
 
-    fun hasAmbiguousAttempt(paneId: String, payload: String): Boolean = synchronized(lock) {
+    fun hasAmbiguousAttempt(paneId: String, sendToken: String, payload: String): Boolean = synchronized(lock) {
         // Issue #1541: the durable flag makes a back-nav-rebuilt ledger (empty
-        // in-memory set) still see a prior wire attempt.
-        key(paneId, payload) in entries || durable?.hasWireAttempt(paneId, payload) == true
+        // in-memory set) still see a prior wire attempt (payload-scoped — the durable
+        // row is re-dispatched under its own token, and coalescing bounds it to one row).
+        key(paneId, sendToken) in entries || durable?.hasWireAttempt(paneId, payload) == true
     }
 
     /**
-     * Issue #1577: the pre-send needle baseline for (pane, payload) — the volatile
-     * value first, else the durable one (a VM-clear-rebuilt ledger). `null` when
-     * none was captured; the caller then falls back to presence-only verification.
+     * Issue #1577: the pre-send needle baseline — the volatile value for this send's
+     * token first, else the durable one for the (pane, payload) row (a VM-clear-rebuilt
+     * ledger). `null` when none was captured; the caller then falls back to
+     * presence-only verification.
      */
-    fun needleBaseline(paneId: String, payload: String): Int? = synchronized(lock) {
-        baselines[key(paneId, payload)] ?: durable?.wireNeedleBaseline(paneId, payload)
+    fun needleBaseline(paneId: String, sendToken: String, payload: String): Int? = synchronized(lock) {
+        baselines[key(paneId, sendToken)] ?: durable?.wireNeedleBaseline(paneId, payload)
     }
 }
 
@@ -422,19 +449,20 @@ internal suspend fun captureNeedleBaseline(
 internal suspend fun OutboundDeliveryLedger.recordWireAttemptWithBaseline(
     client: TmuxClient,
     paneId: String,
+    sendToken: String,
     payload: String,
     localRenderText: String,
 ) {
-    if (needleBaseline(paneId, payload) != null) {
+    if (needleBaseline(paneId, sendToken, payload) != null) {
         // A prior push already captured the pre-send baseline; keep it (idempotent).
-        recordWireAttempt(paneId, payload, null)
+        recordWireAttempt(paneId, sendToken, payload, null)
         return
     }
     val needle = agentSubmitAckNeedle(payload)
     val alreadyVisible = needle != null &&
         agentSubmitVisibleTextNeedleCount(listOf(localRenderText), needle) > 0
     val baseline = if (alreadyVisible) captureNeedleBaseline(client, paneId, payload) else 0
-    recordWireAttempt(paneId, payload, baseline)
+    recordWireAttempt(paneId, sendToken, payload, baseline)
 }
 
 internal suspend fun probeNeedleAlreadyLanded(

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -13950,17 +13950,23 @@ public class TmuxSessionViewModel @Inject constructor(
         return clientRef?.takeUnless { it.disconnected.value }
     }
 
-    internal suspend fun sendToAgentPaneResult(paneId: String, text: String): Result<Unit> =
+    internal suspend fun sendToAgentPaneResult(
+        paneId: String,
+        text: String,
+        sendToken: String? = null,
+    ): Result<Unit> =
         sendToAgentPaneResult(
             paneId = paneId,
             text = text,
             keepFailedOptimisticOnDeliveryFailure = false,
+            sendToken = sendToken,
         )
 
     private suspend fun sendToAgentPaneResult(
         paneId: String,
         text: String,
         keepFailedOptimisticOnDeliveryFailure: Boolean,
+        sendToken: String? = null,
     ): Result<Unit> {
         val payload = text.trim()
         if (payload.isEmpty()) return Result.success(Unit)
@@ -13974,14 +13980,12 @@ public class TmuxSessionViewModel @Inject constructor(
             ?: return Result.failure(IllegalStateException("No agent conversation for pane $paneId."))
         val detection = current.detection
             ?: return Result.failure(IllegalStateException("No detected agent for pane $paneId."))
-        // Issue #494: insert the optimistic pending turn FIRST — before any
-        // delivery attempt — so the Conversation tab shows the user's own
-        // message the instant they hit Send, not after the JSONL round-trip.
-        // The turn starts as [MessageSendState.Pending] ("sending…") and is
-        // reconciled away when the real transcript entry arrives via the tail.
-        // If the unified composer send fails, PromptComposerSheet keeps the
-        // draft, so we remove this temporary row to avoid showing the same text
-        // twice. Retry taps have no draft fallback and opt into leaving a
+        // Issue #494: insert the optimistic pending turn FIRST (before any delivery attempt)
+        // so the Conversation tab shows the user's own message the instant they hit Send, not
+        // after the JSONL round-trip. It starts [MessageSendState.Pending] ("sending…") and is
+        // reconciled away when the real transcript entry arrives via the tail. On a failed
+        // composer send PromptComposerSheet keeps the draft, so this temporary row is removed
+        // to avoid showing the text twice; retry taps have no draft fallback and leave a
         // failed row instead.
         val optimisticId = "$OPTIMISTIC_USER_MESSAGE_ID_PREFIX${System.nanoTime()}"
         val optimistic = ConversationEvent.Message(
@@ -13997,7 +14001,8 @@ public class TmuxSessionViewModel @Inject constructor(
             return Result.failure(IllegalStateException("Session is disconnected."))
         }
         appendAgentEvents(paneId, listOf(optimistic))
-        val result = sendAgentPayloadToPaneResult(paneId, payload, detection.agent)
+        // Issue #1529: a fresh direct send keys on its optimistic turn id; a retry passes a STABLE token.
+        val result = sendAgentPayloadToPaneResult(paneId, payload, detection.agent, sendToken ?: optimisticId)
         if (result.isFailure) {
             if (keepFailedOptimisticOnDeliveryFailure) {
                 markOptimisticSendFailed(paneId, optimisticId)
@@ -14044,6 +14049,8 @@ public class TmuxSessionViewModel @Inject constructor(
                 paneId = paneId,
                 text = failed.text,
                 keepFailedOptimisticOnDeliveryFailure = true,
+                // Issue #1529: a retry re-uses the failed turn's id as the token.
+                sendToken = optimisticId,
             )
             if (result.isFailure) {
                 val hasFailedRetryRow = _agentConversations.value[paneId]?.events
@@ -14064,10 +14071,11 @@ public class TmuxSessionViewModel @Inject constructor(
         paneId: String,
         payload: String,
         agent: AgentKind,
+        sendToken: String = newOutboundDeliveryToken(),
     ): Result<Unit> {
         val client = awaitLiveTmuxClientForSend()
             ?: return Result.failure(IllegalStateException("Session is disconnected."))
-        return sendAgentPayloadToPaneResult(client, paneId, payload, agent)
+        return sendAgentPayloadToPaneResult(client, paneId, payload, agent, sendToken)
     }
 
     // Issue #1526 S1 / #1541 / #1587: verify-before-resend ledger, durable-backed by
@@ -14090,22 +14098,21 @@ public class TmuxSessionViewModel @Inject constructor(
         paneId: String,
         payload: String,
         agent: AgentKind,
+        sendToken: String,
     ): Result<Unit> {
         val payloadBytes = payload.toByteArray(Charsets.UTF_8)
         if (client.disconnected.value) {
             return Result.failure(IllegalStateException("Tmux client is disconnected."))
         }
-        // Issue #1526 S1 (verify-before-resend): a PRIOR ambiguous attempt at this
-        // exact (pane, payload) — timeout/drop after the paste may have run
-        // server-side (audit A1/A2) — must not blindly re-paste. Probe the pane
-        // (#869 needle, #1577 baseline-aware): already landed ⇒ submit-Enter ONLY;
-        // unknown ⇒ fail WITHOUT resending (row stays queued for a verified retry);
-        // not landed / no prior attempt ⇒ fall through to the normal full send.
-        when (verifyBeforeAgentResend(outboundDeliveryLedger, client, paneId, payload)) {
+        // Issue #1526 S1 (verify-before-resend): a PRIOR ambiguous attempt for THIS send —
+        // keyed by the #1529 [sendToken], NOT the payload, so two distinct identical sends
+        // never false-dedup — the paste may have run server-side (audit A1/A2). Probe (#869
+        // needle, #1577 baseline): landed ⇒ Enter ONLY; unknown ⇒ fail; else full send.
+        when (verifyBeforeAgentResend(outboundDeliveryLedger, client, paneId, sendToken, payload)) {
             DeliveryProbeOutcome.AlreadyLanded -> return runCatching {
                 sendNamedKeyToPane(client, paneId, "Enter")
                     .throwIfTmuxError("submit previously pasted agent input")
-                outboundDeliveryLedger.clear(paneId, payload)
+                outboundDeliveryLedger.clear(paneId, sendToken)
                 requestReconcile(client, paneId, ReconcileReason.Send)
             }
             DeliveryProbeOutcome.Unknown -> return Result.failure(
@@ -14115,11 +14122,11 @@ public class TmuxSessionViewModel @Inject constructor(
         }
         return runCatching {
             ensurePaneAcceptsInput(client, paneId)
-            outboundDeliveryLedger.recordWireAttemptWithBaseline(client, paneId, payload, localRenderTextForPane(paneId))
+            outboundDeliveryLedger.recordWireAttemptWithBaseline(client, paneId, sendToken, payload, localRenderTextForPane(paneId))
             // Issue #1577b: the pre-paste needle baseline the ack gate compares against
-            // (Codex's permanent `(/goal resume)` footer occupies the baseline, so the
-            // ack fires only on OUR paste adding an occurrence — never on the footer).
-            val ackBaseline = outboundDeliveryLedger.needleBaseline(paneId, payload) ?: 0
+            // (Codex's permanent `(/goal resume)` footer occupies it, so the ack fires
+            // only on OUR paste adding an occurrence, never on the footer).
+            val ackBaseline = outboundDeliveryLedger.needleBaseline(paneId, sendToken, payload) ?: 0
             if (payloadBytes.size > TMUX_PASTE_BODY_CHUNK_BYTES || BracketedPaste.containsLineBreak(payloadBytes)) {
                 sendBracketedPaste(client, paneId, payloadBytes)
             } else if (payload.isNotEmpty()) {
@@ -14130,10 +14137,9 @@ public class TmuxSessionViewModel @Inject constructor(
             consumeSendResultLostSeamForTest()
             sendNamedKeyToPane(client, paneId, "Enter")
                 .throwIfTmuxError("submit pasted agent input")
-            outboundDeliveryLedger.clear(paneId, payload)
-            // Issue #941/#1353 R4: after the submit Enter a full-screen agent TUI can
-            // overpaint the active pane partial-black; a guarded heal EVENT through the
-            // shared reconcile entry re-checks and re-seeds (no bespoke send-path timer).
+            outboundDeliveryLedger.clear(paneId, sendToken)
+            // Issue #941/#1353 R4: after the submit Enter a full-screen agent TUI can overpaint
+            // the active pane partial-black; a guarded heal EVENT re-checks and re-seeds.
             requestReconcile(client, paneId, ReconcileReason.Send)
         }
     }
@@ -15293,52 +15299,50 @@ public class TmuxSessionViewModel @Inject constructor(
     }
 
     /**
-     * Send a single key payload to [paneId] via `send-keys`.
-     *
-     * tmux's `send-keys` understands literal strings (passed as a single
-     * argument) and a vocabulary of named keys (`Enter`, `Tab`, `Escape`,
-     * `Up`, `Down`, ...). We forward the bytes as a literal single-quoted
-     * argument with embedded quotes doubled — the simplest encoding that
-     * round-trips arbitrary printable input. Callers that need a named
-     * key (e.g. arrows) should pass it through [sendNamedKey] instead.
-     *
-     * Per-pane I/O does NOT go through the SSH shell — `tmux -CC` does
-     * not expose a per-pane writable fd on the control channel. The
-     * canonical and only supported route to "type into a pane" through
-     * the control protocol is `send-keys`, verified by
-     * `TmuxClientIntegrationTest` against the test container.
+     * Send a single key payload to [paneId] via `send-keys`. We forward the bytes as a
+     * literal single-quoted argument with embedded quotes doubled — the simplest encoding
+     * that round-trips arbitrary printable input; callers that need a named key (`Enter`,
+     * arrows, ...) should use [sendNamedKey] instead. Per-pane I/O does NOT go through the
+     * SSH shell — `tmux -CC` exposes no per-pane writable fd; `send-keys` is the canonical
+     * route (verified by `TmuxClientIntegrationTest` against the test container).
      */
     public fun writeInputToPane(paneId: String, bytes: ByteArray) {
         if (bytes.isEmpty()) return
         DiagnosticEvents.record("action", "pane_input", "pane" to paneId, "bytes" to bytes.size)
         val client = clientRef ?: return
         bridgeScope.launch {
-            writeInputToPaneResult(client, paneId, bytes)
+            writeInputToPaneResult(client, paneId, bytes, newOutboundDeliveryToken())
         }
     }
 
-    internal suspend fun writeInputToPaneResult(paneId: String, bytes: ByteArray): Result<Unit> {
+    internal suspend fun writeInputToPaneResult(
+        paneId: String,
+        bytes: ByteArray,
+        sendToken: String = newOutboundDeliveryToken(),
+    ): Result<Unit> {
         if (bytes.isEmpty()) return Result.success(Unit)
         val client = awaitLiveTmuxClientForSend()
         if (client == null) {
             return Result.failure(IllegalStateException("Session is disconnected."))
         }
-        return writeInputToPaneResult(client, paneId, bytes)
+        return writeInputToPaneResult(client, paneId, bytes, sendToken)
     }
 
-    // Issue #1586: RawBytes lane rides the agent lane's verify-before-resend ledger (H1b).
+    // Issue #1586: RawBytes lane rides the verify-before-resend ledger (H1b); #1529: per-send token.
     private suspend fun writeInputToPaneResult(
         client: TmuxClient,
         paneId: String,
         bytes: ByteArray,
+        sendToken: String,
     ): Result<Unit> = deliverRawInputWithGuard(
         ledger = outboundDeliveryLedger,
         client = client,
         paneId = paneId,
         bytes = bytes,
         localRenderText = localRenderTextForPane(paneId),
+        sendToken = sendToken,
         send = { c, p, b -> sendInputBytesToPane(c, p, b) },
-        // Issue #1586 (H1b): AlreadyLanded -> Enter-only submit (agent-lane parity).
+        // Issue #1586 (H1b): AlreadyLanded -> Enter-only submit.
         submitEnter = { c, p ->
             sendNamedKeyToPane(c, p, "Enter").throwIfTmuxError("submit typed shell input")
         },

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue1529TokenDedupTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue1529TokenDedupTest.kt
@@ -1,0 +1,152 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.core.tmux.CommandResponse
+import com.pocketshell.core.tmux.TmuxClientException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Issue #1529 — outbound exactly-once must NOT false-dedup an intentionally-repeated
+ * identical prompt.
+ *
+ * The #1526 S1 verify-before-resend guard keyed its ambiguous-attempt ledger on the
+ * PAYLOAD (needle = whitespace-stripped payload tail; ledger key = payload hash). So
+ * two DISTINCT user sends of identical bytes collided: the second probed, saw the
+ * first send's marker already on the pane, judged `AlreadyLanded`, and suppressed the
+ * intentional second send — a false-dedup that DROPS a legitimate message.
+ *
+ * The fix makes the ledger identity a PER-SEND-ATTEMPT token (the durable outbound row
+ * id, or an opaque per-send token for non-queue sends), NOT payload-derived. Two
+ * identical payloads with distinct tokens both deliver; a RETRY of one attempt (same
+ * token) still dedups to exactly-once.
+ *
+ * RED on base (payload-keyed): [twoDistinctIdenticalSendsBothDeliver] fails — the second
+ * distinct send is suppressed (occurrence 1). GREEN (token-keyed): occurrence 2.
+ * [oneAttemptRetryStillDeliversExactlyOnce] stays GREEN in both — the dedup that #1526
+ * S1 added must not regress.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class Issue1529TokenDedupTest {
+
+    private val paneId = "%0"
+    private val payloadText = "run the full release checklist now"
+    private val bytes = "$payloadText\r".toByteArray(Charsets.UTF_8)
+
+    /** A fake server counting every distinct paste, landing then losing the FIRST send's result. */
+    private class FlapOnceServer {
+        var pastes = 0
+            private set
+        var enters = 0
+            private set
+        private var firstStillFlapping = true
+
+        suspend fun send() {
+            pastes += 1
+            if (firstStillFlapping) {
+                firstStillFlapping = false
+                // The bytes LAND server-side, but the result is lost (the ambiguous flap
+                // the #1526 audit describes): the paste ran, the client sees a failure.
+                throw TmuxClientException("tmux send-keys (exec interactive send lane) timed out after 10000ms")
+            }
+        }
+
+        fun submitEnter() {
+            enters += 1
+        }
+    }
+
+    private fun captureShowingPayload(): FakeTmuxClient =
+        FakeTmuxClient().apply {
+            defaultCaptureResponse = CommandResponse(number = 0L, output = listOf("$ $payloadText"), isError = false)
+            scrollbackCaptureResponse = CommandResponse(number = 0L, output = listOf("$ $payloadText"), isError = false)
+        }
+
+    private suspend fun deliverWithToken(
+        ledger: OutboundDeliveryLedger,
+        client: FakeTmuxClient,
+        server: FlapOnceServer,
+        sendToken: String,
+    ): Result<Unit> = deliverRawInputWithGuard(
+        ledger = ledger,
+        client = client,
+        paneId = paneId,
+        bytes = bytes,
+        localRenderText = "$ ",
+        sendToken = sendToken,
+        send = { _, _, _ -> server.send() },
+        submitEnter = { _, _ -> server.submitEnter() },
+        afterDelivered = { _, _, _ -> },
+    )
+
+    /**
+     * THE #1529 case. Two DISTINCT intentional sends of identical bytes (distinct
+     * per-send tokens). The first lands but its result is lost (flap), leaving an
+     * ambiguous ledger entry. The second is a DIFFERENT user send: it must NOT be
+     * suppressed by the first send's marker — it must deliver, so the payload reaches
+     * the server TWICE (occurrence == 2).
+     *
+     * RED on base (payload-keyed ledger): the second send's token collides on payload,
+     * the probe finds the first send's text already on the pane, judges AlreadyLanded,
+     * and drops the intentional second send (occurrence 1).
+     */
+    @Test
+    fun twoDistinctIdenticalSendsBothDeliver() = runTest {
+        val ledger = OutboundDeliveryLedger()
+        val client = captureShowingPayload()
+        val server = FlapOnceServer()
+
+        // Send #1 (its own token) — lands, then the result is lost (ambiguous flap).
+        val first = deliverWithToken(ledger, client, server, sendToken = "send-1")
+        assertTrue("the first send flaps (ambiguous failure) — its bytes landed", first.isFailure)
+        assertEquals("the first send reached the server once", 1, server.pastes)
+
+        // Send #2 — a DIFFERENT intentional user send of the identical prompt. It must
+        // deliver, not be false-deduped against send #1's marker.
+        val second = deliverWithToken(ledger, client, server, sendToken = "send-2")
+
+        assertTrue("the intentional second send must deliver", second.isSuccess)
+        assertEquals(
+            "two DISTINCT identical sends must BOTH reach the server (occurrence == 2) — " +
+                "the second must not be false-deduped against the first (RED on base: occurrence 1)",
+            2,
+            server.pastes,
+        )
+    }
+
+    /**
+     * The dedup #1526 S1 added must NOT regress: a single send whose ONE attempt flapped
+     * (ambiguous, bytes landed) and is RETRIED — same per-send token — must probe, see
+     * the payload already landed, and complete with an Enter-only submit WITHOUT
+     * re-pasting (occurrence == 1).
+     */
+    @Test
+    fun oneAttemptRetryStillDeliversExactlyOnce() = runTest {
+        val ledger = OutboundDeliveryLedger()
+        val client = captureShowingPayload()
+        val server = FlapOnceServer()
+        val token = "send-1"
+
+        val first = deliverWithToken(ledger, client, server, sendToken = token)
+        assertTrue("the attempt flaps (ambiguous failure)", first.isFailure)
+        assertEquals(1, server.pastes)
+
+        // The RETRY of the SAME attempt (same token) — the payload already landed.
+        val retry = deliverWithToken(ledger, client, server, sendToken = token)
+
+        assertTrue("the retry resolves (already landed)", retry.isSuccess)
+        assertEquals(
+            "a retry of ONE attempt must dedup to exactly-once — no re-paste (occurrence == 1)",
+            1,
+            server.pastes,
+        )
+        assertEquals("the already-landed retry completes via an Enter-only submit", 1, server.enters)
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/OutboundDeliveryGuardTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/OutboundDeliveryGuardTest.kt
@@ -293,10 +293,11 @@ class OutboundDeliveryGuardTest {
         // the pane now shows the payload (count 1 > baseline 0). Issue #1577b: a
         // production wire push ALWAYS records a baseline (recordWireAttemptWithBaseline),
         // so a genuinely-landed row is baselined — this is the production-accurate state.
-        ledger.recordWireAttempt(paneId, payload, baselineCount = 0)
+        ledger.recordWireAttempt(paneId, payload, payload, baselineCount = 0)
         val client = captureShowing("$ $payload")
 
-        val outcome = verifyBeforeAgentResend(ledger, client, paneId, payload)
+        // Issue #1529: the resend re-uses the SAME send token as the recorded attempt.
+        val outcome = verifyBeforeAgentResend(ledger, client, paneId, payload, payload)
 
         assertEquals(
             "a re-dispatched already-landed payload must resolve AlreadyLanded so the send path " +
@@ -323,11 +324,11 @@ class OutboundDeliveryGuardTest {
         val paneId = "%0"
         val payload = "/goal resume"
         // A legacy row carries the durable wire-attempt flag but NO baseline (null).
-        ledger.recordWireAttempt(paneId, payload) // 2-arg ⇒ baselineCount defaults to null
+        ledger.recordWireAttempt(paneId, payload, payload) // 3-arg ⇒ baselineCount defaults to null
         // The pane permanently shows the payload in a status footer.
         val client = captureShowing("gpt-5.6-sol · Goal blocked (/goal resume)")
 
-        val outcome = verifyBeforeAgentResend(ledger, client, paneId, payload)
+        val outcome = verifyBeforeAgentResend(ledger, client, paneId, payload, payload)
 
         assertEquals(
             "a null-baseline (untrustworthy) flag whose payload is already on the pane must NOT " +
@@ -349,7 +350,7 @@ class OutboundDeliveryGuardTest {
         val ledger = OutboundDeliveryLedger()
         val client = FakeTmuxClient()
 
-        val outcome = verifyBeforeAgentResend(ledger, client, "%0", "a brand new prompt")
+        val outcome = verifyBeforeAgentResend(ledger, client, "%0", "tok-fresh", "a brand new prompt")
 
         assertNull("a fresh send with no ambiguous prior attempt must not probe (null ⇒ normal send)", outcome)
         assertTrue(
@@ -375,8 +376,8 @@ class OutboundDeliveryGuardTest {
 
         // VM #1's ledger records the wire attempt (right before the paste).
         val ledger1 = OutboundDeliveryLedger(durable = durable)
-        ledger1.recordWireAttempt("%0", "durable payload")
-        assertTrue(ledger1.hasAmbiguousAttempt("%0", "durable payload"))
+        ledger1.recordWireAttempt("%0", "durable payload", "durable payload")
+        assertTrue(ledger1.hasAmbiguousAttempt("%0", "durable payload", "durable payload"))
 
         // Back-navigation clears the VM: its volatile ledger dies. A base ledger
         // with NO durable backing has no memory of the attempt (the P9 bug).
@@ -384,7 +385,7 @@ class OutboundDeliveryGuardTest {
         assertFalse(
             "RED (base): a volatile-only rebuilt ledger loses the wire attempt, so " +
                 "the reopened session blindly re-pastes (server occurrence 2)",
-            baseRebuilt.hasAmbiguousAttempt("%0", "durable payload"),
+            baseRebuilt.hasAmbiguousAttempt("%0", "durable payload", "durable payload"),
         )
 
         // The fix: a ledger rebuilt with the SAME durable store re-reads the flag
@@ -393,7 +394,7 @@ class OutboundDeliveryGuardTest {
         assertTrue(
             "GREEN (fix): the durable `wireAttempted` flag makes the rebuilt ledger " +
                 "verify-before-resend instead of blindly re-pasting",
-            rebuilt.hasAmbiguousAttempt("%0", "durable payload"),
+            rebuilt.hasAmbiguousAttempt("%0", "durable payload", "durable payload"),
         )
     }
 
@@ -405,7 +406,7 @@ class OutboundDeliveryGuardTest {
     fun freshSendWithDurableBackingButNoPriorAttemptDoesNotVerify() {
         val store = com.pocketshell.app.composer.InMemoryOutboundQueueStore()
         val ledger = OutboundDeliveryLedger(durable = store.asWireAttemptDurableStore())
-        assertFalse(ledger.hasAmbiguousAttempt("%0", "a brand new prompt"))
+        assertFalse(ledger.hasAmbiguousAttempt("%0", "tok-fresh", "a brand new prompt"))
     }
 
     /**
@@ -421,13 +422,13 @@ class OutboundDeliveryGuardTest {
         store.enqueue("sessA", "unacked payload", paneId = "%0")
         val durable = store.asWireAttemptDurableStore()
         val ledger = OutboundDeliveryLedger(durable = durable)
-        ledger.recordWireAttempt("%0", "unacked payload")
+        ledger.recordWireAttempt("%0", "unacked payload", "unacked payload")
         ledger.clear("%0", "unacked payload")
 
         assertTrue(
             "clear() drops only the volatile entry; the durable row flag persists so " +
                 "a rebuilt ledger still verifies",
-            ledger.hasAmbiguousAttempt("%0", "unacked payload"),
+            ledger.hasAmbiguousAttempt("%0", "unacked payload", "unacked payload"),
         )
         assertTrue(store.hasWireAttempt("%0", "unacked payload"))
     }
@@ -473,14 +474,14 @@ class OutboundDeliveryGuardTest {
         // trap) — verify-before-resend would be skipped.
         assertNull(
             "a volatile-only rebuilt ledger loses the orphaned attempt (would blind re-paste)",
-            verifyBeforeAgentResend(OutboundDeliveryLedger(), captureShowing("$ $payload"), paneId, payload),
+            verifyBeforeAgentResend(OutboundDeliveryLedger(), captureShowing("$ $payload"), paneId, payload, payload),
         )
 
         // The fix path: the ledger rebuilt from the SAME durable store re-reads the
         // claim-stamped flag → verify → the pane shows the payload → AlreadyLanded,
         // so the send path submits Enter only and never re-pastes (occurrence 1).
         val rebuilt = OutboundDeliveryLedger(durable = store.asWireAttemptDurableStore())
-        val outcome = verifyBeforeAgentResend(rebuilt, captureShowing("$ $payload"), paneId, payload)
+        val outcome = verifyBeforeAgentResend(rebuilt, captureShowing("$ $payload"), paneId, payload, payload)
         assertEquals(
             "an orphaned InFlight row that actually landed must verify AlreadyLanded (occurrence 1)",
             DeliveryProbeOutcome.AlreadyLanded,
@@ -499,17 +500,17 @@ class OutboundDeliveryGuardTest {
         val ledger = OutboundDeliveryLedger()
         val client = captureShowing("$ /goal resume") // the resend probe sees it landed
 
-        ledger.recordWireAttemptWithBaseline(client, "%0", "/goal resume", localRenderText = "$ ")
+        ledger.recordWireAttemptWithBaseline(client, "%0", "/goal resume", "/goal resume", localRenderText = "$ ")
 
         assertTrue(
             "no baseline capture round-trip when the payload is not already on the render",
             client.capturePaneTextViaExecCalls.isEmpty(),
         )
-        assertEquals(0, ledger.needleBaseline("%0", "/goal resume"))
+        assertEquals(0, ledger.needleBaseline("%0", "/goal resume", "/goal resume"))
         assertEquals(
             "a resend that finds the payload (count 1 > baseline 0) is AlreadyLanded",
             DeliveryProbeOutcome.AlreadyLanded,
-            verifyBeforeAgentResend(ledger, client, "%0", "/goal resume"),
+            verifyBeforeAgentResend(ledger, client, "%0", "/goal resume", "/goal resume"),
         )
     }
 
@@ -532,8 +533,8 @@ class OutboundDeliveryGuardTest {
         // The payload is already visible on the local render ⇒ ONE authoritative
         // baseline capture: the status line shows the needle once ⇒ baseline 1.
         client.capturePaneResponses.addLast(CommandResponse(number = 0L, output = listOf(statusLine), isError = false))
-        ledger.recordWireAttemptWithBaseline(client, "%0", "/goal resume", localRenderText = statusLine)
-        assertEquals("the pre-send baseline is captured authoritatively", 1, ledger.needleBaseline("%0", "/goal resume"))
+        ledger.recordWireAttemptWithBaseline(client, "%0", "/goal resume", "/goal resume", localRenderText = statusLine)
+        assertEquals("the pre-send baseline is captured authoritatively", 1, ledger.needleBaseline("%0", "/goal resume", "/goal resume"))
         assertEquals("exactly one baseline capture round-trip", 1, client.capturePaneTextViaExecCalls.size)
 
         // A genuine resend whose paste did NOT land: the pane still shows ONLY the
@@ -543,7 +544,7 @@ class OutboundDeliveryGuardTest {
             "a payload still only on the status line (count == baseline) must NOT be " +
                 "falsely AlreadyLanded (the #1577 false-success drop)",
             DeliveryProbeOutcome.NotLanded,
-            verifyBeforeAgentResend(ledger, client, "%0", "/goal resume"),
+            verifyBeforeAgentResend(ledger, client, "%0", "/goal resume", "/goal resume"),
         )
 
         // A resend whose paste DID land: the pane now shows the status line AND the
@@ -554,7 +555,7 @@ class OutboundDeliveryGuardTest {
         assertEquals(
             "a payload whose occurrence count INCREASED (our paste landed) is AlreadyLanded",
             DeliveryProbeOutcome.AlreadyLanded,
-            verifyBeforeAgentResend(ledger, client, "%0", "/goal resume"),
+            verifyBeforeAgentResend(ledger, client, "%0", "/goal resume", "/goal resume"),
         )
     }
 
@@ -578,7 +579,7 @@ class OutboundDeliveryGuardTest {
         val payload = "run the full integration suite now"
         // A prior ambiguous wire attempt recorded with baseline 0 (fresh payload — it
         // was NOT on the pane at send time; production always records a baseline).
-        ledger.recordWireAttempt(paneId, payload, baselineCount = 0)
+        ledger.recordWireAttempt(paneId, payload, payload, baselineCount = 0)
 
         val client = FakeTmuxClient().apply {
             // The paste LANDED, then a burst of agent output pushed it OFF the visible
@@ -593,7 +594,7 @@ class OutboundDeliveryGuardTest {
             )
         }
 
-        val outcome = verifyBeforeAgentResend(ledger, client, paneId, payload)
+        val outcome = verifyBeforeAgentResend(ledger, client, paneId, payload, payload)
 
         assertTrue(
             "the verify-before-resend probe must request BOUNDED SCROLLBACK (the H2 fix)",
@@ -617,7 +618,7 @@ class OutboundDeliveryGuardTest {
         val ledger = OutboundDeliveryLedger()
         val paneId = "%0"
         val payload = "deploy the staging build to the box"
-        ledger.recordWireAttempt(paneId, payload, baselineCount = 0)
+        ledger.recordWireAttempt(paneId, payload, payload, baselineCount = 0)
         val client = FakeTmuxClient().apply {
             // The scrollback capture (what the probe now issues) includes the visible
             // payload — it is at the bottom of the buffer, still on screen.
@@ -627,7 +628,7 @@ class OutboundDeliveryGuardTest {
 
         assertEquals(
             DeliveryProbeOutcome.AlreadyLanded,
-            verifyBeforeAgentResend(ledger, client, paneId, payload),
+            verifyBeforeAgentResend(ledger, client, paneId, payload, payload),
         )
     }
 
@@ -642,7 +643,7 @@ class OutboundDeliveryGuardTest {
         val ledger = OutboundDeliveryLedger()
         val paneId = "%0"
         val payload = "please run the deployment checklist"
-        ledger.recordWireAttempt(paneId, payload, baselineCount = 0)
+        ledger.recordWireAttempt(paneId, payload, payload, baselineCount = 0)
         val client = FakeTmuxClient().apply {
             // Neither the visible viewport nor the bounded scrollback contains the payload.
             scrollbackCaptureResponse =
@@ -653,7 +654,7 @@ class OutboundDeliveryGuardTest {
             "a payload absent from the bounded scrollback must stay NotLanded (real resend), " +
                 "never a false AlreadyLanded drop",
             DeliveryProbeOutcome.NotLanded,
-            verifyBeforeAgentResend(ledger, client, paneId, payload),
+            verifyBeforeAgentResend(ledger, client, paneId, payload, payload),
         )
     }
 
@@ -678,18 +679,18 @@ class OutboundDeliveryGuardTest {
         // AUTHORITATIVELY over the SAME bounded scrollback (not fast-pathed to 0).
         client.scrollbackCaptureResponse =
             CommandResponse(number = 0L, output = listOf("> $payload", "...later output...", "$ "), isError = false)
-        ledger.recordWireAttemptWithBaseline(client, paneId, payload, localRenderText = "> $payload")
+        ledger.recordWireAttemptWithBaseline(client, paneId, payload, payload, localRenderText = "> $payload")
         assertEquals(
             "the baseline is captured over the SAME bounded scrollback the probe uses (count 1)",
             1,
-            ledger.needleBaseline(paneId, payload),
+            ledger.needleBaseline(paneId, payload, payload),
         )
 
         // A resend whose paste did NOT land: scrollback still shows the ONE pre-existing
         // occurrence (count 1 == baseline 1) ⇒ NotLanded (no false AlreadyLanded).
         assertEquals(
             DeliveryProbeOutcome.NotLanded,
-            verifyBeforeAgentResend(ledger, client, paneId, payload),
+            verifyBeforeAgentResend(ledger, client, paneId, payload, payload),
         )
 
         // A resend whose paste DID land: scrollback now shows TWO (count 2 > baseline 1)
@@ -698,7 +699,7 @@ class OutboundDeliveryGuardTest {
             CommandResponse(number = 0L, output = listOf("> $payload", "> $payload", "$ "), isError = false)
         assertEquals(
             DeliveryProbeOutcome.AlreadyLanded,
-            verifyBeforeAgentResend(ledger, client, paneId, payload),
+            verifyBeforeAgentResend(ledger, client, paneId, payload, payload),
         )
     }
 
@@ -718,7 +719,7 @@ class OutboundDeliveryGuardTest {
         store.enqueue("sessA", "single-store payload", paneId = "%0")
         val ledger = outboundDeliveryLedgerFor(store)
 
-        ledger.recordWireAttempt("%0", "single-store payload")
+        ledger.recordWireAttempt("%0", "single-store payload", "single-store payload")
 
         assertTrue(
             "the wire attempt recorded via the ledger must be visible through the SAME store " +
@@ -731,25 +732,27 @@ class OutboundDeliveryGuardTest {
     @Test
     fun outboundDeliveryLedgerForWithNoStoreIsInMemoryOnly() {
         val ledger = outboundDeliveryLedgerFor(null)
-        ledger.recordWireAttempt("%0", "in-memory only payload")
-        assertTrue(ledger.hasAmbiguousAttempt("%0", "in-memory only payload"))
+        ledger.recordWireAttempt("%0", "in-memory only payload", "in-memory only payload")
+        assertTrue(ledger.hasAmbiguousAttempt("%0", "in-memory only payload", "in-memory only payload"))
     }
 
     @Test
     fun ledgerTracksRecordsClearsAndEvictsOldestBeyondCapacity() {
+        // Issue #1529: the volatile identity is (pane, sendToken). These tests use the payload
+        // string as each attempt's token, so distinct payloads are distinct attempts.
         val ledger = OutboundDeliveryLedger(maxEntries = 2)
-        ledger.recordWireAttempt("%0", "first payload")
-        assertTrue(ledger.hasAmbiguousAttempt("%0", "first payload"))
-        assertFalse(ledger.hasAmbiguousAttempt("%1", "first payload"))
+        ledger.recordWireAttempt("%0", "first payload", "first payload")
+        assertTrue(ledger.hasAmbiguousAttempt("%0", "first payload", "first payload"))
+        assertFalse(ledger.hasAmbiguousAttempt("%1", "first payload", "first payload"))
 
         ledger.clear("%0", "first payload")
-        assertFalse(ledger.hasAmbiguousAttempt("%0", "first payload"))
+        assertFalse(ledger.hasAmbiguousAttempt("%0", "first payload", "first payload"))
 
-        ledger.recordWireAttempt("%0", "a")
-        ledger.recordWireAttempt("%0", "b")
-        ledger.recordWireAttempt("%0", "c")
-        assertFalse("oldest entry must be evicted", ledger.hasAmbiguousAttempt("%0", "a"))
-        assertTrue(ledger.hasAmbiguousAttempt("%0", "b"))
-        assertTrue(ledger.hasAmbiguousAttempt("%0", "c"))
+        ledger.recordWireAttempt("%0", "a", "a")
+        ledger.recordWireAttempt("%0", "b", "b")
+        ledger.recordWireAttempt("%0", "c", "c")
+        assertFalse("oldest entry must be evicted", ledger.hasAmbiguousAttempt("%0", "a", "a"))
+        assertTrue(ledger.hasAmbiguousAttempt("%0", "b", "b"))
+        assertTrue(ledger.hasAmbiguousAttempt("%0", "c", "c"))
     }
 }

--- a/app/src/test/java/com/pocketshell/app/tmux/OutboundExactlyOnceDeliveryTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/OutboundExactlyOnceDeliveryTest.kt
@@ -91,13 +91,13 @@ class OutboundExactlyOnceDeliveryTest : TmuxSessionViewModelTestBase() {
         // paste (the fake records the command BEFORE throwing — it "ran").
         client.throwOnCommandPrefix = "send-keys -t %0 Enter"
         client.throwOnCommandRemaining = 1
-        val first = async { vm.sendAgentPayloadToPaneResult("%0", "deploy the staging build now", AgentKind.ClaudeCode) }
+        val first = async { vm.sendAgentPayloadToPaneResult("%0", "deploy the staging build now", AgentKind.ClaudeCode, "s-deploy") }
         advanceUntilIdle()
         assertTrue("attempt 1 must surface the ambiguous failure", first.await().isFailure)
         assertEquals("attempt 1 pastes exactly once", 1, client.pasteCount("deploy the staging build now"))
 
         // The resend (what the reconnect auto-flush / manual retry dispatches).
-        val second = async { vm.sendAgentPayloadToPaneResult("%0", "deploy the staging build now", AgentKind.ClaudeCode) }
+        val second = async { vm.sendAgentPayloadToPaneResult("%0", "deploy the staging build now", AgentKind.ClaudeCode, "s-deploy") }
         advanceUntilIdle()
         assertTrue("the verified resend must succeed", second.await().isSuccess)
 
@@ -110,6 +110,50 @@ class OutboundExactlyOnceDeliveryTest : TmuxSessionViewModelTestBase() {
             client.pasteCount("deploy the staging build now"),
         )
         assertTrue("the resend must still submit (Enter-only)", client.enterCount() >= 2)
+    }
+
+    /**
+     * Issue #1529 — the agent lane's DISTINCT-send limb (companion to the raw-lane
+     * Issue1529TokenDedupTest). Two INTENTIONAL identical agent sends — each its own
+     * per-send delivery token (the VM mints one per call when none is threaded) — must
+     * BOTH paste (server occurrence == 2). Send #1 flaps (ambiguous, its paste landed),
+     * leaving a ledger entry; send #2 is a DIFFERENT user send and must NOT be
+     * false-deduped against send #1's marker.
+     *
+     * RED on base (payload-keyed ledger): send #2's payload collides with send #1's
+     * ledger entry, the probe finds the payload already on the pane, resolves
+     * AlreadyLanded, and DROPS the intentional second send (occurrence 1).
+     * GREEN (per-send token): each send keys on its own token ⇒ occurrence 2.
+     */
+    @Test
+    fun twoDistinctIdenticalAgentSendsBothPasteOccurrenceTwo() = runTest(scheduler) {
+        val client = FakeTmuxClient()
+        client.defaultCaptureResponse = CommandResponse(
+            number = 0L,
+            output = listOf("> deploy the build"),
+            isError = false,
+        )
+        val vm = newConnectedVm(client)
+
+        // Send #1 flaps: its paste LANDS, then the submit Enter's exec result is lost.
+        client.throwOnCommandPrefix = "send-keys -t %0 Enter"
+        client.throwOnCommandRemaining = 1
+        val first = async { vm.sendAgentPayloadToPaneResult("%0", "deploy the build", AgentKind.ClaudeCode) }
+        advanceUntilIdle()
+        assertTrue("send #1 flaps (ambiguous failure — its paste landed)", first.await().isFailure)
+        assertEquals("send #1 pastes exactly once", 1, client.pasteCount("deploy the build"))
+
+        // Send #2 — a DISTINCT intentional send (its own default per-send token). It must
+        // deliver, NOT be false-deduped against send #1's marker.
+        val second = async { vm.sendAgentPayloadToPaneResult("%0", "deploy the build", AgentKind.ClaudeCode) }
+        advanceUntilIdle()
+        assertTrue("the intentional second send must deliver", second.await().isSuccess)
+        assertEquals(
+            "two DISTINCT identical agent sends must BOTH paste (occurrence == 2) — the second " +
+                "must not be false-deduped against the first (RED on base: occurrence 1)",
+            2,
+            client.pasteCount("deploy the build"),
+        )
     }
 
     /**
@@ -131,11 +175,11 @@ class OutboundExactlyOnceDeliveryTest : TmuxSessionViewModelTestBase() {
 
         client.throwOnCommandPrefix = "send-keys -t %0 Enter"
         client.throwOnCommandRemaining = 1
-        val first = async { vm.sendAgentPayloadToPaneResult("%0", "restart the worker pool", AgentKind.ClaudeCode) }
+        val first = async { vm.sendAgentPayloadToPaneResult("%0", "restart the worker pool", AgentKind.ClaudeCode, "s-restart") }
         advanceUntilIdle()
         assertTrue(first.await().isFailure)
 
-        val second = async { vm.sendAgentPayloadToPaneResult("%0", "restart the worker pool", AgentKind.ClaudeCode) }
+        val second = async { vm.sendAgentPayloadToPaneResult("%0", "restart the worker pool", AgentKind.ClaudeCode, "s-restart") }
         advanceUntilIdle()
         assertTrue(second.await().isSuccess)
 
@@ -163,7 +207,7 @@ class OutboundExactlyOnceDeliveryTest : TmuxSessionViewModelTestBase() {
 
         client.throwOnCommandPrefix = "send-keys -t %0 Enter"
         client.throwOnCommandRemaining = 1
-        val first = async { vm.sendAgentPayloadToPaneResult("%0", "ship the release notes draft", AgentKind.ClaudeCode) }
+        val first = async { vm.sendAgentPayloadToPaneResult("%0", "ship the release notes draft", AgentKind.ClaudeCode, "s-ship") }
         advanceUntilIdle()
         assertTrue(first.await().isFailure)
         val sendKeysAfterFirst = client.sentCommands.count { it.startsWith("send-keys") }
@@ -171,7 +215,7 @@ class OutboundExactlyOnceDeliveryTest : TmuxSessionViewModelTestBase() {
         // The probe's capture-pane now FAILS (flaky lane) — outcome unknown.
         client.throwOnCommandPrefix = "capture-pane"
         client.throwOnCommandRemaining = 1
-        val second = async { vm.sendAgentPayloadToPaneResult("%0", "ship the release notes draft", AgentKind.ClaudeCode) }
+        val second = async { vm.sendAgentPayloadToPaneResult("%0", "ship the release notes draft", AgentKind.ClaudeCode, "s-ship") }
         advanceUntilIdle()
         assertTrue("an unknown probe outcome must FAIL the dispatch (row stays queued)", second.await().isFailure)
         assertEquals(
@@ -182,7 +226,7 @@ class OutboundExactlyOnceDeliveryTest : TmuxSessionViewModelTestBase() {
 
         // A later retry whose probe CAN decide resolves it: payload visible ⇒
         // Enter-only, still exactly one paste.
-        val third = async { vm.sendAgentPayloadToPaneResult("%0", "ship the release notes draft", AgentKind.ClaudeCode) }
+        val third = async { vm.sendAgentPayloadToPaneResult("%0", "ship the release notes draft", AgentKind.ClaudeCode, "s-ship") }
         advanceUntilIdle()
         assertTrue(third.await().isSuccess)
         assertEquals(1, client.pasteCount("ship the release notes draft"))
@@ -203,11 +247,11 @@ class OutboundExactlyOnceDeliveryTest : TmuxSessionViewModelTestBase() {
         )
         val vm = newConnectedVm(client)
 
-        val first = async { vm.sendAgentPayloadToPaneResult("%0", "run the smoke suite again", AgentKind.ClaudeCode) }
+        val first = async { vm.sendAgentPayloadToPaneResult("%0", "run the smoke suite again", AgentKind.ClaudeCode, "s-smoke") }
         advanceUntilIdle()
         assertTrue(first.await().isSuccess)
 
-        val second = async { vm.sendAgentPayloadToPaneResult("%0", "run the smoke suite again", AgentKind.ClaudeCode) }
+        val second = async { vm.sendAgentPayloadToPaneResult("%0", "run the smoke suite again", AgentKind.ClaudeCode, "s-smoke") }
         advanceUntilIdle()
         assertTrue(second.await().isSuccess)
 

--- a/app/src/test/java/com/pocketshell/app/tmux/RawBytesSendGuardTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/RawBytesSendGuardTest.kt
@@ -178,7 +178,9 @@ class RawBytesSendGuardTest : TmuxSessionViewModelTestBase() {
         client.throwOnCommandException = TmuxClientException("tmux command timed out")
         vm.attachClientForTest(client)
 
-        val first = vm.writeInputToPaneResult("%0", "git status\r".toByteArray(Charsets.UTF_8))
+        // Issue #1529: the retry re-uses the SAME per-send token as attempt 1 (a queue-flush
+        // re-dispatches the same durable row id) so the guard dedups it as a retry.
+        val first = vm.writeInputToPaneResult("%0", "git status\r".toByteArray(Charsets.UTF_8), "r-landed")
         advanceUntilIdle()
         assertTrue("attempt 1 must surface the ambiguous failure", first.isFailure)
         assertEquals("attempt 1 pastes the literal exactly once", 1, client.literalCount("git status"))
@@ -187,7 +189,7 @@ class RawBytesSendGuardTest : TmuxSessionViewModelTestBase() {
 
         // The retry (composer auto-flush): probes ⇒ AlreadyLanded ⇒ NO second paste,
         // but DOES complete the landed-but-unsubmitted command with an Enter-only submit.
-        val second = vm.writeInputToPaneResult("%0", "git status\r".toByteArray(Charsets.UTF_8))
+        val second = vm.writeInputToPaneResult("%0", "git status\r".toByteArray(Charsets.UTF_8), "r-landed")
         advanceUntilIdle()
         assertTrue(
             "the AlreadyLanded retry must SUCCEED (the landed command is completed, not a " +
@@ -239,7 +241,8 @@ class RawBytesSendGuardTest : TmuxSessionViewModelTestBase() {
         vm.attachClientForTest(client)
 
         // NOTE: no trailing "\r" — this is the `withEnter == false` composer send.
-        val first = vm.writeInputToPaneResult("%0", "git status".toByteArray(Charsets.UTF_8))
+        // Issue #1529: the retry re-uses the SAME per-send token as attempt 1.
+        val first = vm.writeInputToPaneResult("%0", "git status".toByteArray(Charsets.UTF_8), "r-nosub")
         advanceUntilIdle()
         assertTrue("attempt 1 (no-CR literal throws) must surface the ambiguous failure", first.isFailure)
         assertEquals("attempt 1 records the literal exactly once", 1, client.literalCount("git status"))
@@ -249,7 +252,7 @@ class RawBytesSendGuardTest : TmuxSessionViewModelTestBase() {
 
         // The retry probes ⇒ AlreadyLanded. The original send carried NO submit, so the
         // guard must NOT complete it with a spurious Enter, and must NOT re-paste.
-        val second = vm.writeInputToPaneResult("%0", "git status".toByteArray(Charsets.UTF_8))
+        val second = vm.writeInputToPaneResult("%0", "git status".toByteArray(Charsets.UTF_8), "r-nosub")
         advanceUntilIdle()
         assertTrue(
             "the AlreadyLanded retry of an already-landed no-submit payload must SUCCEED " +
@@ -285,11 +288,13 @@ class RawBytesSendGuardTest : TmuxSessionViewModelTestBase() {
         client.throwOnCommandRemaining = 1
         vm.attachClientForTest(client)
 
-        val first = vm.writeInputToPaneResult("%0", "git status\r".toByteArray(Charsets.UTF_8))
+        // Issue #1529: the retry re-uses the SAME per-send token so the guard probes (and,
+        // seeing NotLanded, re-sends) rather than treating it as an unrelated fresh send.
+        val first = vm.writeInputToPaneResult("%0", "git status\r".toByteArray(Charsets.UTF_8), "r-notland")
         advanceUntilIdle()
         assertTrue("attempt 1 (literal throws before landing) must fail", first.isFailure)
 
-        val second = vm.writeInputToPaneResult("%0", "git status\r".toByteArray(Charsets.UTF_8))
+        val second = vm.writeInputToPaneResult("%0", "git status\r".toByteArray(Charsets.UTF_8), "r-notland")
         advanceUntilIdle()
         assertTrue("the genuine not-landed retry must re-send and succeed", second.isSuccess)
         assertTrue(
@@ -314,12 +319,13 @@ class RawBytesSendGuardTest : TmuxSessionViewModelTestBase() {
         client.throwOnCommandRemaining = 1
         vm.attachClientForTest(client)
 
-        val first = vm.writeInputToPaneResult("%0", "deploy\r".toByteArray(Charsets.UTF_8))
+        // Issue #1529: the retry re-uses attempt 1's per-send token so it is deduped.
+        val first = vm.writeInputToPaneResult("%0", "deploy\r".toByteArray(Charsets.UTF_8), "r-short")
         advanceUntilIdle()
         assertTrue(first.isFailure)
         assertEquals(1, client.literalCount("deploy"))
 
-        val second = vm.writeInputToPaneResult("%0", "deploy\r".toByteArray(Charsets.UTF_8))
+        val second = vm.writeInputToPaneResult("%0", "deploy\r".toByteArray(Charsets.UTF_8), "r-short")
         advanceUntilIdle()
         assertEquals(
             "the short command must be deduped to exactly one paste on the ambiguous retry",
@@ -329,9 +335,11 @@ class RawBytesSendGuardTest : TmuxSessionViewModelTestBase() {
     }
 
     /**
-     * The fix must NOT falsely suppress a DISTINCT command sent right after a
-     * different ambiguous one (the ledger is keyed per (pane, payload), so an
-     * unrelated command is unaffected).
+     * The fix must NOT falsely suppress a DISTINCT command sent right after a different
+     * ambiguous one. Issue #1529: the ledger is keyed per (pane, SEND TOKEN) — each send
+     * gets its own token — so an unrelated command (its own fresh token) is unaffected.
+     * (Two DISTINCT sends of the IDENTICAL payload are likewise independent — see
+     * Issue1529TokenDedupTest.)
      */
     @Test
     fun distinctCommandAfterLandedOneIsNotSuppressed() = runTest(scheduler) {


### PR DESCRIPTION
Closes #1529

The outbound exactly-once `OutboundDeliveryLedger.key` was payload-derived (`paneId|len|hash`), so two intentionally-repeated identical user sends shared a ledger key → the second probed, found the first's marker, resolved `AlreadyLanded`, and dropped a legitimate message. Fix (hard-cut D22): the volatile identity is now `paneId|sendToken` — a per-send-attempt opaque token, never payload-derived. `retryFailedAgentSend` reuses the failed turn's id so a genuine retry still dedups (exactly-once preserved simultaneously); the durable `wireAttempted` store stays payload-keyed (safe via the #961 coalesce invariant).

## Verification (reviewer APPROVED, red→green this run)
- **G1**: reviewer neutralized the fix → both two-distinct-sends cases FAILED red (occurrence 1); restored → all green; diff intact.
- **G6**: load-bearing assertion is real server paste occurrence (==2 / ==1), not key inequality; agent-lane test drives the real VM.
- **Regression guard**: retry reuses the token, so the #1526 duplicate-on-retry invariant is preserved alongside the fix (the crux).
- **G3**: full `:app:testDebugUnitTest` 3843 tests, 0 failures, 0 skipped; `Issue1529TokenDedupTest` executed.
- **Guards** (touches `TmuxSessionViewModel.kt`): `check-file-size-hygiene.sh` OK, `check-connection-vm-ratchet.sh` OK (17596 < 17621), no baseline raised (D28). Orchestrator re-ran both guards + focused module tests green in a clean worktree.

Non-blocking follow-up noted by reviewer: composer `computeSendKey` (#961) coalesces identical un-delivered sends at the queue layer — a separate defense-in-depth thread worth a follow-up (#1584 territory).