### PR TITLE
usage: attribute the glance pill to its provider/window (#1566)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/usage/UsageGlancePillE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/usage/UsageGlancePillE2eTest.kt
@@ -73,13 +73,26 @@ class UsageGlancePillE2eTest {
         }
     }
 
-    // AC1: shows the most-constraining percent from cache.
+    // AC1 + #1566: shows the most-constraining percent from cache, ATTRIBUTED to
+    // its provider (+ window) — not a bare number.
     @Test
-    fun showsMostConstrainingPercent() {
-        appBar(pill = UsageGlancePillState(percent = 72, kind = PillKind.Warn, stale = false, capturedClock = "14:05"))
+    fun showsMostConstrainingPercentAttributed() {
+        appBar(
+            pill = UsageGlancePillState(
+                percent = 72,
+                provider = "Codex",
+                window = "7d",
+                kind = PillKind.Warn,
+                stale = false,
+                capturedClock = "14:05",
+            ),
+        )
         compose.onNodeWithTag(USAGE_GLANCE_PILL_TAG).assertIsDisplayed()
         compose.onNodeWithText("72%").assertIsDisplayed()
-        compose.onNodeWithContentDescription("Usage 72%").assertIsDisplayed()
+        // The provider (+window) attribution is visibly rendered on the pill …
+        compose.onNodeWithText("Codex 7d").assertIsDisplayed()
+        // … and the accessibility label spells out the attributed usage.
+        compose.onNodeWithContentDescription("Usage Codex 7d 72%").assertIsDisplayed()
     }
 
     // AC1: hidden when there is no data.
@@ -95,7 +108,14 @@ class UsageGlancePillE2eTest {
     @Test
     fun hiddenWhenNoUsageRoute() {
         appBar(
-            pill = UsageGlancePillState(percent = 50, kind = PillKind.Ok, stale = false, capturedClock = "14:05"),
+            pill = UsageGlancePillState(
+                percent = 50,
+                provider = "Claude",
+                window = null,
+                kind = PillKind.Ok,
+                stale = false,
+                capturedClock = "14:05",
+            ),
             onOpenUsage = null,
         )
         compose.onNodeWithTag(USAGE_GLANCE_PILL_TAG).assertDoesNotExist()
@@ -106,7 +126,14 @@ class UsageGlancePillE2eTest {
     fun tapInvokesUsageRoute() {
         var tapped = false
         appBar(
-            pill = UsageGlancePillState(percent = 88, kind = PillKind.Warn, stale = false, capturedClock = "14:05"),
+            pill = UsageGlancePillState(
+                percent = 88,
+                provider = "Claude",
+                window = "5h",
+                kind = PillKind.Warn,
+                stale = false,
+                capturedClock = "14:05",
+            ),
             onOpenUsage = { tapped = true },
         )
         compose.onNodeWithTag(USAGE_GLANCE_PILL_TAG).assertHasClickAction()
@@ -119,7 +146,18 @@ class UsageGlancePillE2eTest {
     // the window root, even alongside the forwarding indicator (the #418 guard).
     @Test
     fun pillAndSettingsAreBothFullyContained() {
-        appBar(pill = UsageGlancePillState(percent = 100, kind = PillKind.Blocked, stale = true, capturedClock = "13:40"))
+        // A LONG attribution (OpenCode + window) alongside the stale clock stresses
+        // the app-bar width — the #418 declutter guard must still fully contain it.
+        appBar(
+            pill = UsageGlancePillState(
+                percent = 100,
+                provider = "OpenCode",
+                window = "5h",
+                kind = PillKind.Blocked,
+                stale = true,
+                capturedClock = "13:40",
+            ),
+        )
         compose.assertNodeFullyWithinRoot(USAGE_GLANCE_PILL_TAG)
         compose.assertNodeFullyWithinRoot(SETTINGS_BUTTON_TAG)
     }
@@ -127,11 +165,22 @@ class UsageGlancePillE2eTest {
     // AC4: stale data is visually honest ("cached from HH:mm").
     @Test
     fun staleReadingRendersHonestly() {
-        appBar(pill = UsageGlancePillState(percent = 63, kind = PillKind.Ok, stale = true, capturedClock = "13:40"))
+        appBar(
+            pill = UsageGlancePillState(
+                percent = 63,
+                provider = "Claude",
+                window = null,
+                kind = PillKind.Ok,
+                stale = true,
+                capturedClock = "13:40",
+            ),
+        )
         compose.onNodeWithTag(USAGE_GLANCE_PILL_TAG).assertIsDisplayed()
-        // The muted capture clock is rendered inline …
+        // The provider attribution is still shown …
+        compose.onNodeWithText("Claude").assertIsDisplayed()
+        // … the muted capture clock is rendered inline …
         compose.onNodeWithText("13:40").assertIsDisplayed()
         // … and the honest provenance is in the accessibility description.
-        compose.onNodeWithContentDescription("Usage 63%, cached from 13:40").assertIsDisplayed()
+        compose.onNodeWithContentDescription("Usage Claude 63%, cached from 13:40").assertIsDisplayed()
     }
 }

--- a/app/src/main/java/com/pocketshell/app/usage/UsageGlancePill.kt
+++ b/app/src/main/java/com/pocketshell/app/usage/UsageGlancePill.kt
@@ -51,6 +51,20 @@ public data class UsageGlancePillState(
     /** Most-constraining provider percent across every cached host, rounded. */
     val percent: Int,
     /**
+     * Compact display label of the provider that OWNS this percent (e.g.
+     * "Claude", "Codex", "OpenCode"). Issue #1566: the bare "77%" was ambiguous
+     * — "77% of what?" — so the pill now names the provider the most-constraining
+     * number belongs to. See [glanceProviderLabel].
+     */
+    val provider: String,
+    /**
+     * Compact hint for WHICH window drove the percent (e.g. "5h", "7d",
+     * "weekly"), or null when the winning window has no clean short token
+     * (internal keys like "short_term" / long names are dropped — the provider
+     * label alone still answers "which provider"). See [glanceWindowHint].
+     */
+    val window: String?,
+    /**
      * Severity tint for the leading dot, derived from the winning provider's
      * threshold state so a blocked provider reads red at a glance without the
      * user opening the panel.
@@ -65,20 +79,62 @@ public data class UsageGlancePillState(
     /** Local "HH:mm" capture clock, shown only while [stale]. */
     val capturedClock: String,
 ) {
-    val label: String get() = "$percent%"
+    /**
+     * The muted attribution shown before the percent — the provider, plus the
+     * winning window when it has a clean compact token: "Codex 7d" or "Claude".
+     * Issue #1566: this is what makes the SELECTION legible so the user can tell
+     * the number is the nearest-limit provider, not a bare figure.
+     */
+    val attribution: String
+        get() = if (window != null) "$provider $window" else provider
+
+    /** Full glanceable label, provider-attributed: "Codex 7d 72%" / "Claude 60%". */
+    val label: String get() = "$attribution $percent%"
 
     /**
      * Accessibility / test-visible description. Mirrors the visual: a fresh
-     * pill is just "Usage N%"; a stale pill spells out the honest "cached from
-     * HH:mm" provenance so TalkBack users get the same signal the muted clock
-     * gives sighted users.
+     * pill is "Usage <provider> [<window>] N%"; a stale pill spells out the
+     * honest "cached from HH:mm" provenance so TalkBack users get the same
+     * signal the muted clock gives sighted users.
      */
     val contentDescription: String
         get() = if (stale) {
-            "Usage $percent%, cached from $capturedClock"
+            "Usage $label, cached from $capturedClock"
         } else {
-            "Usage $percent%"
+            "Usage $label"
         }
+}
+
+/**
+ * Compact provider label for the app-bar pill (#1566). Shorter than
+ * [com.pocketshell.core.usage.UsageProviderRecord.displayName] ("Claude Code",
+ * "GitHub Copilot") so it fits the small pill without crowding the header —
+ * "Claude" not "Claude Code". Unknown providers fall back to a title-cased
+ * token.
+ */
+internal fun glanceProviderLabel(provider: String): String = when (provider.lowercase()) {
+    "claude" -> "Claude"
+    "codex" -> "Codex"
+    "opencode", "open_code", "open-code" -> "OpenCode"
+    "copilot", "github_copilot", "github-copilot" -> "Copilot"
+    "zai", "z.ai", "z-ai" -> "Z.AI"
+    else -> provider
+        .split('-', '_', ' ')
+        .firstOrNull { it.isNotBlank() }
+        ?.replaceFirstChar { it.uppercase() }
+        ?: provider
+}
+
+/**
+ * Compact window hint for the app-bar pill (#1566). Only surfaces a CLEAN
+ * short token ("5h", "7d", "weekly") — internal-looking keys ("short_term" /
+ * "long_term") and long names are dropped (returns null) so the pill stays
+ * legible and short on the Pixel-7 app bar. The provider label alone still
+ * answers "which provider" when the window is dropped.
+ */
+internal fun glanceWindowHint(name: String?): String? {
+    val trimmed = name?.trim().orEmpty()
+    return trimmed.takeIf { it.isNotEmpty() && '_' !in it && it.length <= 6 }
 }
 
 /**
@@ -119,10 +175,22 @@ internal fun usageGlancePillState(
         .flatMap { snap -> snap.records.map { snap to it } }
         .mapNotNull { (snap, record) ->
             val state = record.thresholdState(warnPercent = warnPercent)
-            val percent = record.mostConstrainedWindow?.percent
+            val winningWindow = record.mostConstrainedWindow
+            val percent = winningWindow?.percent
                 ?: if (state == UsageThresholdState.Exceeded) 100.0 else return@mapNotNull null
-            GlanceCandidate(percent = percent, state = state, fetchedAt = snap.fetchedAt)
+            GlanceCandidate(
+                percent = percent,
+                state = state,
+                fetchedAt = snap.fetchedAt,
+                provider = glanceProviderLabel(record.provider),
+                window = glanceWindowHint(winningWindow?.name),
+            )
         }
+        // Tie-break: when two candidates share the same highest percent, the
+        // FIRST-encountered wins (maxByOrNull keeps the earliest max), which is
+        // deterministic over the snapshot/record iteration order. The percent is
+        // what matters to the user (nearest limit); the attribution just names
+        // whichever provider that peak belongs to.
         .maxByOrNull { it.percent }
         ?: return null
 
@@ -134,6 +202,8 @@ internal fun usageGlancePillState(
     val stale = Duration.between(worst.fetchedAt, now) > staleAfter
     return UsageGlancePillState(
         percent = worst.percent.roundToInt(),
+        provider = worst.provider,
+        window = worst.window,
         kind = kind,
         stale = stale,
         capturedClock = formatCapturedClock(worst.fetchedAt, zoneId),
@@ -144,6 +214,8 @@ private data class GlanceCandidate(
     val percent: Double,
     val state: UsageThresholdState,
     val fetchedAt: Instant,
+    val provider: String,
+    val window: String?,
 )
 
 /**
@@ -181,11 +253,22 @@ internal fun UsageGlancePill(
             drawCircle(color = usageGlanceKindColor(state.kind).copy(alpha = contentAlpha))
         }
         Spacer(modifier = Modifier.width(6.dp))
+        // Provider (+ window) attribution in a muted tint so the user can tell
+        // WHICH provider/window the number belongs to (#1566) …
         androidx.compose.material3.Text(
-            text = state.label,
+            text = state.attribution,
+            color = PocketShellColors.TextSecondary.copy(alpha = contentAlpha),
+            style = PocketShellType.bodyDense,
+            maxLines = 1,
+        )
+        Spacer(modifier = Modifier.width(4.dp))
+        // … and the percent itself pops in the primary text weight.
+        androidx.compose.material3.Text(
+            text = "${state.percent}%",
             color = PocketShellColors.Text.copy(alpha = contentAlpha),
             style = PocketShellType.bodyDense,
             fontWeight = FontWeight.SemiBold,
+            maxLines = 1,
         )
         if (state.stale) {
             // Honest provenance for a cached reading, consistent with the Usage

--- a/app/src/test/java/com/pocketshell/app/usage/UsageGlancePillStateTest.kt
+++ b/app/src/test/java/com/pocketshell/app/usage/UsageGlancePillStateTest.kt
@@ -6,6 +6,7 @@ import com.pocketshell.core.usage.UsageWindow
 import com.pocketshell.uikit.model.PillKind
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -27,8 +28,8 @@ class UsageGlancePillStateTest {
     private val zone = ZoneId.of("UTC")
     private val now = Instant.parse("2026-07-04T14:10:00Z")
 
-    private fun window(percent: Double): UsageWindow =
-        UsageWindow(name = "5h", used = percent, limit = 100.0, unit = "percent", resetAt = null)
+    private fun window(percent: Double, name: String = "5h"): UsageWindow =
+        UsageWindow(name = name, used = percent, limit = 100.0, unit = "percent", resetAt = null)
 
     private fun record(
         provider: String,
@@ -89,7 +90,73 @@ class UsageGlancePillStateTest {
         )
         val state = usageGlancePillState(snapshots, warnPercent = 80.0, now = now, zoneId = zone)!!
         assertEquals(72, state.percent)
-        assertEquals("72%", state.label)
+        // #1566: attributed, not a bare "72%". The winning window here is the
+        // default "5h" from the window() helper.
+        assertEquals("Codex", state.provider)
+        assertEquals("Codex 5h 72%", state.label)
+    }
+
+    // AC4 (issue #1566): REPRODUCE-FIRST — with two providers at different
+    // percents, the pill shows the HIGHER one WITH its provider attribution, not
+    // a bare number. On the pre-#1566 code the label was "72%" (bare) with no
+    // provider field; this asserts the attribution the maintainer asked for.
+    @Test
+    fun `two providers — the higher percent is shown attributed to its provider`() {
+        val snapshots = mapOf(
+            1L to snapshot(
+                1L,
+                listOf(
+                    record("claude", 40.0, windows = listOf(window(40.0, name = "7d"))),
+                    record("codex", 72.0, windows = listOf(window(72.0, name = "7d"))),
+                ),
+            ),
+        )
+        val state = usageGlancePillState(snapshots, warnPercent = 80.0, now = now, zoneId = zone)!!
+
+        // The number is the higher (nearest-limit) provider's …
+        assertEquals(72, state.percent)
+        // … and it is ATTRIBUTED to Codex, with its window, not a bare "72%".
+        assertEquals("Codex", state.provider)
+        assertEquals("7d", state.window)
+        assertEquals("Codex 7d", state.attribution)
+        assertEquals("Codex 7d 72%", state.label)
+        assertTrue("label must name the provider", state.label.contains("Codex"))
+        assertNotEquals("label must NOT be a bare percent", "72%", state.label)
+    }
+
+    @Test
+    fun `provider display label is compact — Claude not Claude Code`() {
+        val snapshots = mapOf(1L to snapshot(1L, listOf(record("claude", 60.0))))
+        val state = usageGlancePillState(snapshots, warnPercent = 80.0, now = now, zoneId = zone)!!
+        assertEquals("Claude", state.provider)
+    }
+
+    @Test
+    fun `internal-looking window keys are dropped — provider still attributes`() {
+        // copilot's "short_term" key is not a clean compact token → window null,
+        // but the provider label still answers "which provider".
+        val snapshots = mapOf(
+            1L to snapshot(1L, listOf(record("copilot", 66.0, windows = listOf(window(66.0, name = "short_term"))))),
+        )
+        val state = usageGlancePillState(snapshots, warnPercent = 80.0, now = now, zoneId = zone)!!
+        assertEquals("Copilot", state.provider)
+        assertNull(state.window)
+        assertEquals("Copilot 66%", state.label)
+    }
+
+    @Test
+    fun `blocked provider with no windows is attributed with no window hint`() {
+        val snapshots = mapOf(
+            1L to snapshot(
+                1L,
+                listOf(record("codex", 0.0, status = UsageStatus.Blocked, windows = emptyList())),
+            ),
+        )
+        val state = usageGlancePillState(snapshots, warnPercent = 80.0, now = now, zoneId = zone)!!
+        assertEquals(100, state.percent)
+        assertEquals("Codex", state.provider)
+        assertNull(state.window)
+        assertEquals("Codex 100%", state.label)
     }
 
     @Test
@@ -147,7 +214,7 @@ class UsageGlancePillStateTest {
         val snapshots = mapOf(1L to snapshot(1L, listOf(record("claude", 60.0)), fetchedAt = now.minus(Duration.ofMinutes(2))))
         val state = usageGlancePillState(snapshots, warnPercent = 80.0, now = now, zoneId = zone)!!
         assertFalse(state.stale)
-        assertEquals("Usage 60%", state.contentDescription)
+        assertEquals("Usage Claude 5h 60%", state.contentDescription)
     }
 
     @Test
@@ -157,7 +224,7 @@ class UsageGlancePillStateTest {
         val state = usageGlancePillState(snapshots, warnPercent = 80.0, now = now, zoneId = zone)!!
         assertTrue(state.stale)
         assertEquals("13:55", state.capturedClock)
-        assertEquals("Usage 60%, cached from 13:55", state.contentDescription)
+        assertEquals("Usage Claude 5h 60%, cached from 13:55", state.contentDescription)
     }
 
     @Test

--- a/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenders.kt
+++ b/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenders.kt
@@ -584,11 +584,13 @@ class DesignRenders {
      * to the forwarding indicator + Settings gear. The real pill lives in the
      * app module ([com.pocketshell.app.usage.UsageGlancePill]); this fixture
      * mirrors it with the SAME ui-kit chrome (32dp rounded SurfaceElev surface,
-     * 1dp BorderSoft hairline, kind-tinted dot + percent) the app pill composes,
-     * so the fast JVM check shows it reads as one small app-bar affordance — NOT
-     * a heavy card — and does NOT crowd the header (the #418 declutter guard).
-     * Fresh (Warn 72%) on top, stale (Ok 63% · "cached from 13:40") below to
-     * check the honest muted treatment. The emulator screenshot is the acceptance.
+     * 1dp BorderSoft hairline, kind-tinted dot + muted provider attribution +
+     * bold percent) the app pill composes, so the fast JVM check shows it reads
+     * as one small app-bar affordance — NOT a heavy card — and does NOT crowd
+     * the header (the #418 declutter guard). Issue #1566: the percent is now
+     * ATTRIBUTED to its provider/window — "Codex 7d 72%" (Warn) on top, stale
+     * "Claude 63% · cached from 13:40" (Ok) below — so it is clear WHICH provider
+     * the number represents. The emulator screenshot is the acceptance.
      */
     /**
      * Issue #1239: the host-card one-tap "Resume last session" affordance. The

--- a/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/HostRenderFixtures.kt
+++ b/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/HostRenderFixtures.kt
@@ -147,7 +147,7 @@ internal fun UsageGlancePillRender() {
             title = "Hosts",
             subtitle = "5 hosts · 4 active",
             trailing = {
-                UsageGlancePillFacsimile(percent = "72%", dot = PillKind.Warn)
+                UsageGlancePillFacsimile(attribution = "Codex 7d", percent = "72%", dot = PillKind.Warn)
                 AppBarPillFacsimile {
                     Text(
                         "2",
@@ -163,7 +163,7 @@ internal fun UsageGlancePillRender() {
             title = "Hosts",
             subtitle = "5 hosts · 4 active",
             trailing = {
-                UsageGlancePillFacsimile(percent = "63%", dot = PillKind.Ok, staleClock = "13:40")
+                UsageGlancePillFacsimile(attribution = "Claude", percent = "63%", dot = PillKind.Ok, staleClock = "13:40")
                 AppBarGearFacsimile()
             },
         )
@@ -177,7 +177,12 @@ internal fun UsageGlancePillRender() {
  * screenshot is the acceptance.
  */
 @Composable
-private fun UsageGlancePillFacsimile(percent: String, dot: PillKind, staleClock: String? = null) {
+private fun UsageGlancePillFacsimile(
+    attribution: String,
+    percent: String,
+    dot: PillKind,
+    staleClock: String? = null,
+) {
     val alpha = if (staleClock != null) 0.6f else 1f
     val dotColor = when (dot) {
         PillKind.Ok -> PocketShellColors.Green
@@ -195,6 +200,13 @@ private fun UsageGlancePillFacsimile(percent: String, dot: PillKind, staleClock:
     ) {
         Box(modifier = Modifier.size(8.dp).clip(CircleShape).background(dotColor.copy(alpha = alpha)))
         Spacer(modifier = Modifier.width(6.dp))
+        // #1566: provider (+window) attribution muted, percent bold.
+        Text(
+            text = attribution,
+            color = PocketShellColors.TextSecondary.copy(alpha = alpha),
+            style = PocketShellType.bodyDense,
+        )
+        Spacer(modifier = Modifier.width(4.dp))
         Text(
             text = percent,
             color = PocketShellColors.Text.copy(alpha = alpha),


### PR DESCRIPTION
Closes #1566

The app-bar usage glance pill showed a bare most-constraining percent ('77%') with no attribution. It now names the provider (+ window when clean) driving the number — 'Codex 7d 72%' / 'Claude 63%', attribution muted, percent bold. Most-constraining selection unchanged; stale 'cached from…' + on-tap→Usage preserved (D22 hard-cut).

## Verification (reviewer APPROVED)
- **G1 red→green**: reviewer neutralized the label → two-provider test FAILED (ComparisonFailure:122); restored → 15/15 green.
- **Emulator (G4/G6)**: `UsageGlancePillE2eTest` on emulator-5554 against production `HostsAppBar` with the forwarding indicator present — 6/6, `pillAndSettingsAreBothFullyContained` asserts `assertNodeFullyWithinRoot` (viewport containment) for pill + gear with a long `OpenCode 5h` attribution + stale clock.
- Orchestrator gate: reassembled clean, hygiene OK, `:app:` pill tests green. Wired into `ci-journey-suite.sh`.