### PR TITLE
usage: show short weekday on reset times (#1565)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/usage/UsageFormat.kt
+++ b/app/src/main/java/com/pocketshell/app/usage/UsageFormat.kt
@@ -236,11 +236,14 @@ internal fun formatResetRelative(now: Instant, resetAt: Instant?, zoneId: ZoneId
  * under the relative string. Null `resetAt` → null (caller omits the
  * line). Zone-aware via the injected [zoneId].
  *
- * Format examples (en-US): "Jun 4, 13:10", "May 28, 09:00".
+ * Issue #1565: a short day-of-week prefix makes the reset date readable at
+ * a glance alongside the relative "in N days" line.
+ *
+ * Format examples (en-US): "Thu Jun 4, 13:10", "Wed May 28, 09:00".
  */
 internal fun formatResetAbsolute(resetAt: Instant?, zoneId: ZoneId): String? {
     if (resetAt == null) return null
-    val formatter = DateTimeFormatter.ofPattern("MMM d, HH:mm", Locale.US).withZone(zoneId)
+    val formatter = DateTimeFormatter.ofPattern("EEE MMM d, HH:mm", Locale.US).withZone(zoneId)
     return formatter.format(resetAt)
 }
 

--- a/app/src/test/java/com/pocketshell/app/usage/UsageFormatTest.kt
+++ b/app/src/test/java/com/pocketshell/app/usage/UsageFormatTest.kt
@@ -198,11 +198,26 @@ class UsageFormatTest {
     @Test
     fun formatResetAbsolute_rendersLocalDateAndTime() {
         // 13:10 UTC is 15:10 in Berlin (CEST, +02:00) — proves zone-aware.
+        // 2026-06-04 is a Thursday (issue #1565: short weekday prefix).
         assertEquals(
-            "Jun 4, 15:10",
+            "Thu Jun 4, 15:10",
             formatResetAbsolute(
                 resetAt = Instant.parse("2026-06-04T13:10:00Z"),
                 zoneId = ZoneId.of("Europe/Berlin"),
+            ),
+        )
+    }
+
+    @Test
+    fun formatResetAbsolute_includesShortWeekday() {
+        // Issue #1565: reset rows show the day of week at a glance.
+        // 2026-07-15 18:00 UTC → 2026-07-16 03:00 in Tokyo (JST, +09:00),
+        // which is a Thursday. Fixed instant + fixed zone = deterministic.
+        assertEquals(
+            "Thu Jul 16, 03:00",
+            formatResetAbsolute(
+                resetAt = Instant.parse("2026-07-15T18:00:00Z"),
+                zoneId = ZoneId.of("Asia/Tokyo"),
             ),
         )
     }

--- a/app/src/test/java/com/pocketshell/app/usage/UsageNotificationsTest.kt
+++ b/app/src/test/java/com/pocketshell/app/usage/UsageNotificationsTest.kt
@@ -73,7 +73,7 @@ class UsageNotificationsTest {
         )
 
         assertEquals("Codex usage: 86% used", event.title)
-        assertEquals("Approaching limit · resets Jun 8, 12:00 · Tap to open Usage.", event.text)
+        assertEquals("Approaching limit · resets Mon Jun 8, 12:00 · Tap to open Usage.", event.text)
         assertFalse(event.title.contains("blocked", ignoreCase = true))
         assertFalse(event.text.contains("blocked", ignoreCase = true))
     }
@@ -235,7 +235,7 @@ class UsageNotificationsTest {
         )
         assertEquals(
             listOf(
-                "agent-box · Approaching limit · resets Jun 8, 15:00 · Tap to open Usage.",
+                "agent-box · Approaching limit · resets Mon Jun 8, 15:00 · Tap to open Usage.",
             ),
             events.map { it.text },
         )
@@ -273,7 +273,7 @@ class UsageNotificationsTest {
         )
         assertTrue(
             "reset line must show an absolute (non-drifting) time: ${event.text}",
-            event.text.contains("resets Jun 8, 12:00"),
+            event.text.contains("resets Mon Jun 8, 12:00"),
         )
     }
 


### PR DESCRIPTION
Closes #1565

Maintainer request (2026-07-14): add day-of-week to reset times. `formatResetAbsolute` (the single reset-time helper, shared by the Usage screen reset foot + notification copy) now prefixes the short weekday: `MMM d, HH:mm` → `EEE MMM d, HH:mm` (e.g. `Thu Jul 16, 03:00`), across all providers.

## Verification (reviewer APPROVED)
- **G1 red→green**: reviewer reverted the pattern → `formatResetAbsolute_includesShortWeekday` + `_rendersLocalDateAndTime` FAILED; restored → green.
- **Determinism**: fixed instants + fixed zones (2026-06-04=Thu, 2026-07-16=Thu Tokyo cross-midnight, 2026-06-08=Mon) — no wall-clock flake.
- **Scope**: only `UsageFormat.kt` + 2 test files; the pill uses a separate `HH:mm` formatter (no weekday leak into #1566); no window-label (#1564) touched.
- Overflow: low-risk ~4-char addition on a no-maxLines secondary line (worst case wraps, never clips); non-blocking dogfood glance flagged.
- Orchestrator gate: reassembled clean, hygiene OK, `:app:` usage tests green.