### PR TITLE
usage: bump quse pin to 0.0.11 — fix Codex weekly-window mislabel (#1564)

### DIFF
--- a/shared/core-usage/src/test/java/com/pocketshell/core/usage/PocketshellUsageJsonParserTest.kt
+++ b/shared/core-usage/src/test/java/com/pocketshell/core/usage/PocketshellUsageJsonParserTest.kt
@@ -90,6 +90,78 @@ class PocketshellUsageJsonParserTest {
     }
 
     @Test
+    fun parse_codexNo5hWindow_rendersWeeklyOnly_noPhantom5h_noGhostRow() {
+        // #1564 regression: Codex temporarily removed its 5h window, so quse
+        // 0.0.11 now emits Codex's `primary_window` (the WEEKLY 604800s span)
+        // in `short_term` labeled from its real `limit_window_seconds` → "7d"
+        // (NOT the old positional "5h"), and the DROPPED window as a null
+        // placeholder (`long_term.percent_remaining == null`). The maintainer's
+        // v0.4.33 symptom was a "5h window · 53% · resets in 5 days" (weekly
+        // data under a 5h label) plus a "7d window · 0% · unavailable" GHOST.
+        //
+        // This is the app-side load-bearing assertion for the acceptance
+        // criteria: the parser must render the WEEKLY window labeled "7d" (no
+        // phantom 5h) and OMIT the null-percent dropped window (no ghost row).
+        // If the parser stopped omitting null-percent windows this test goes
+        // red (a 2nd ghost window would appear).
+        val codexNo5hNdjson =
+            """{"provider":"codex","status":"ok","short_term":{"percent_remaining":69.0,"reset_at":"2026-07-21T20:37:32Z","window":"7d"},"long_term":{"percent_remaining":null,"reset_at":null,"window":null},"error":null,"details":{}}"""
+        val record = parser.parse(codexNo5hNdjson).single()
+
+        // Exactly ONE renderable window — the dropped 5h is omitted (no ghost).
+        assertEquals(1, record.windows.size)
+        val weekly = record.windows.single()
+        // The weekly window is labeled "7d", NOT the phantom "5h".
+        assertEquals("7d", weekly.name)
+        assertTrue("Codex weekly window must not be mislabeled 5h", weekly.name != "5h")
+        assertEquals(31.0, weekly.percent, 0.001) // 100 - 69
+        assertEquals(Instant.parse("2026-07-21T20:37:32Z"), weekly.resetAt)
+        // No ghost "0% / unavailable" (null-reset) row survived: the only
+        // window has a real reset time.
+        assertTrue(
+            "the dropped Codex window must not render as a ghost row",
+            record.windows.all { it.resetAt != null },
+        )
+    }
+
+    @Test
+    fun parse_quse0011FullDocument_codexFixedButOtherCardsUnchanged() {
+        // #1564 class coverage: the quse 0.0.11 Codex window fix must NOT
+        // regress the other provider cards. Feeds all four providers exactly as
+        // `pocketshell usage --json` flattens quse 0.0.11 and asserts Claude
+        // (5h + 7d), Copilot (monthly), and zai (5h + weekly) are unchanged
+        // while Codex renders weekly-only.
+        val quse0011Ndjson = listOf(
+            """{"provider":"claude","status":"ok","short_term":{"percent_remaining":82.0,"reset_at":"2026-07-15T11:39:59Z","window":"5h"},"long_term":{"percent_remaining":5.0,"reset_at":"2026-07-16T14:59:59Z","window":"7d"},"error":null,"details":{}}""",
+            """{"provider":"codex","status":"ok","short_term":{"percent_remaining":69.0,"reset_at":"2026-07-21T20:37:32Z","window":"7d"},"long_term":{"percent_remaining":null,"reset_at":null,"window":null},"error":null,"details":{}}""",
+            """{"provider":"copilot","status":"ok","short_term":{"percent_remaining":100.0,"reset_at":null,"window":null},"long_term":{"percent_remaining":97.1,"reset_at":"2026-08-01T00:00:00Z","window":"monthly"},"error":null,"details":{}}""",
+            """{"provider":"zai","status":"ok","short_term":{"percent_remaining":99.0,"reset_at":null,"window":"5h"},"long_term":{"percent_remaining":75.0,"reset_at":"2026-07-18T14:04:58Z","window":"weekly"},"error":null,"details":{}}""",
+        ).joinToString("\n")
+        val records = parser.parse(quse0011Ndjson)
+        val byProvider = records.associateBy { it.provider }
+
+        // Claude: 5h + 7d, both real resets — unchanged.
+        val claude = byProvider.getValue("claude")
+        assertEquals(2, claude.windows.size)
+        assertEquals("5h", claude.windows[0].name)
+        assertEquals("7d", claude.windows[1].name)
+
+        // Codex: weekly-only, labeled "7d", no ghost.
+        val codex = byProvider.getValue("codex")
+        assertEquals(1, codex.windows.size)
+        assertEquals("7d", codex.windows.single().name)
+
+        // Copilot: monthly window unchanged (short_term null window omitted-or-generic).
+        val copilot = byProvider.getValue("copilot")
+        assertEquals("monthly", copilot.windows.last().name)
+
+        // zai: 5h + weekly unchanged.
+        val zai = byProvider.getValue("zai")
+        assertEquals("5h", zai.windows[0].name)
+        assertEquals("weekly", zai.windows[1].name)
+    }
+
+    @Test
     fun parse_displayNames() {
         val records = parser.parse(fourProviderNdjson)
         assertEquals("Claude Code", records[0].displayName)

--- a/tools/pocketshell/pyproject.toml
+++ b/tools/pocketshell/pyproject.toml
@@ -35,11 +35,18 @@ classifiers = [
 dependencies = [
     "click>=8.2.0",
     # Usage backend + single source of truth for the unified provider schema
-    # (issue #1318). Pinned exactly: `pocketshell usage --json` expects quse
-    # 0.0.9's provider-keyed `--json` document (per provider: status +
+    # (issue #1318). Pinned exactly: `pocketshell usage --json` expects quse's
+    # provider-keyed `--json` document (per provider: status +
     # short_term/long_term {percent_remaining, reset_at, window} + error) and
     # fails loudly on any schema drift, so the version is frozen, not a range.
-    "quse==0.0.9",
+    # 0.0.11 (#1564): quse labels each Codex window from its actual
+    # `limit_window_seconds` instead of assuming primary==5h / secondary==7d,
+    # and omits a window Codex drops (`present: false`) as a null placeholder
+    # rather than a phantom "0% / unavailable" ghost row. Codex temporarily
+    # removed the 5h window, so its `primary_window` now carries the WEEKLY
+    # (604800s) span — the old positional labels mislabeled weekly data as a
+    # "5h window" with a 5-day reset and left a "7d" ghost.
+    "quse==0.0.11",
     # FCM HTTP v1 push delivery (#690): service-account OAuth2 bearer minting
     # for `pocketshell push` / the `usage --capture` reset-push send. Imported
     # lazily and fail-soft — a host without it (or without a Firebase

--- a/tools/pocketshell/tests/data/quse-0.0.11-usage.json
+++ b/tools/pocketshell/tests/data/quse-0.0.11-usage.json
@@ -1,0 +1,141 @@
+{
+  "claude": {
+    "details": {
+      "limit_reached": true,
+      "subscription": null,
+      "windows": {
+        "five_hour": {
+          "reset_at": "2026-07-15T11:39:59Z",
+          "used_percent": 18.0
+        },
+        "seven_day": {
+          "reset_at": "2026-07-16T14:59:59Z",
+          "used_percent": 95.0
+        }
+      }
+    },
+    "error": null,
+    "long_term": {
+      "percent_remaining": 5.0,
+      "reset_at": "2026-07-16T14:59:59Z",
+      "window": "7d"
+    },
+    "short_term": {
+      "percent_remaining": 82.0,
+      "reset_at": "2026-07-15T11:39:59Z",
+      "window": "5h"
+    },
+    "status": "ok"
+  },
+  "codex": {
+    "details": {
+      "limit_reached": false,
+      "reset_credits": [
+        {
+          "expires_at": "2026-07-31T19:09:12Z",
+          "status": "available",
+          "title": "Full reset"
+        },
+        {
+          "expires_at": "2026-08-11T21:09:47Z",
+          "status": "available",
+          "title": "Full reset"
+        },
+        {
+          "expires_at": "2026-08-12T18:09:45Z",
+          "status": "available",
+          "title": "Full reset"
+        }
+      ],
+      "reset_credits_available": 3,
+      "reset_credits_error": null,
+      "windows": {
+        "primary_window": {
+          "limit_window_seconds": 604800,
+          "present": true,
+          "reset_at": "2026-07-21T20:37:32Z",
+          "used_percent": 31.0
+        },
+        "secondary_window": {
+          "limit_window_seconds": null,
+          "present": false,
+          "reset_at": null,
+          "used_percent": 0.0
+        }
+      }
+    },
+    "error": null,
+    "long_term": {
+      "percent_remaining": null,
+      "reset_at": null,
+      "window": null
+    },
+    "short_term": {
+      "percent_remaining": 69.0,
+      "reset_at": "2026-07-21T20:37:32Z",
+      "window": "7d"
+    },
+    "status": "ok"
+  },
+  "copilot": {
+    "details": {
+      "limit_reached": false,
+      "premium_entitlement": 1500,
+      "premium_percent_remaining": 97.1,
+      "premium_remaining": 1457
+    },
+    "error": null,
+    "long_term": {
+      "percent_remaining": 97.1,
+      "reset_at": "2026-08-01T00:00:00Z",
+      "window": "monthly"
+    },
+    "short_term": {
+      "percent_remaining": 100.0,
+      "reset_at": null,
+      "window": null
+    },
+    "status": "ok"
+  },
+  "zai": {
+    "details": {
+      "limit_reached": false,
+      "max_used_percent": 25.0,
+      "windows": {
+        "five_hour": {
+          "limit": null,
+          "remaining": null,
+          "reset_at": null,
+          "used_percent": 1.0,
+          "window_hours": 5
+        },
+        "monthly_web_search": {
+          "limit": 4000,
+          "remaining": 3962,
+          "reset_at": "2026-07-27T14:04:58Z",
+          "used_percent": 1.0,
+          "window_hours": 5
+        },
+        "weekly": {
+          "limit": null,
+          "remaining": null,
+          "reset_at": "2026-07-18T14:04:58Z",
+          "used_percent": 25.0,
+          "window_hours": null
+        }
+      }
+    },
+    "error": null,
+    "long_term": {
+      "percent_remaining": 75.0,
+      "reset_at": "2026-07-18T14:04:58Z",
+      "window": "weekly"
+    },
+    "short_term": {
+      "percent_remaining": 99.0,
+      "reset_at": null,
+      "window": "5h"
+    },
+    "status": "ok"
+  }
+}

--- a/tools/pocketshell/tests/test_usage.py
+++ b/tools/pocketshell/tests/test_usage.py
@@ -36,6 +36,16 @@ from pocketshell.usage import (
 
 _PYPROJECT = Path(__file__).resolve().parent.parent / "pyproject.toml"
 _FIXTURE = Path(__file__).resolve().parent / "data" / "quse-0.0.9-usage.json"
+# Captured LIVE from the pinned quse 0.0.11 (`quse --json`) on 2026-07-15 —
+# the exact Codex "no 5h window" shape (#1564): Codex temporarily removed the
+# 5h window, so its `primary_window` now carries the WEEKLY (604800s) span and
+# `secondary_window` is `present: false`. quse 0.0.11 labels the primary from
+# its actual `limit_window_seconds` (→ `short_term.window == "7d"`, NOT the old
+# positional "5h") and emits the dropped window as a null placeholder
+# (`long_term: {percent_remaining: null, ...}`) instead of a phantom
+# "0% / unavailable" ghost row. Claude / Copilot / zai in the same document
+# keep their correct 5h / 7d / monthly / weekly labels (class coverage).
+_FIXTURE_0011 = Path(__file__).resolve().parent / "data" / "quse-0.0.11-usage.json"
 
 
 def _fake_completed(
@@ -62,9 +72,11 @@ def _quse_keyed_json() -> str:
 
 
 def test_pyproject_pins_quse_exactly() -> None:
-    # AC: pocketshell pins quse==0.0.9 as a hard dependency (frozen contract).
+    # AC: pocketshell pins quse==0.0.11 as a hard dependency (frozen contract).
+    # 0.0.11 (#1564) labels Codex windows from the actual `limit_window_seconds`
+    # and omits a dropped window rather than emitting a phantom "5h"/ghost row.
     text = _PYPROJECT.read_text()
-    assert '"quse==0.0.9"' in text, "pyproject must pin quse==0.0.9 in dependencies"
+    assert '"quse==0.0.11"' in text, "pyproject must pin quse==0.0.11 in dependencies"
 
 
 def test_resolve_quse_binary_uses_pinned_env_next_to_interpreter(tmp_path: Path) -> None:
@@ -187,6 +199,63 @@ def test_flatten_passes_unified_fields_through_unchanged() -> None:
         "reset_at": "2026-05-28T14:59:59Z",
         "window": "7d",
     }
+
+
+def test_flatten_codex_0011_no_5h_window_weekly_only_no_ghost() -> None:
+    """#1564: quse 0.0.11 fixes Codex's mislabeled/ghost windows at the source.
+
+    Feeds the REAL captured quse 0.0.11 Codex "no 5h window" shape through the
+    flatten and asserts the corrected wire shape the app consumes:
+
+    - `short_term` is the WEEKLY window labeled **"7d"** (from Codex's real
+      `limit_window_seconds=604800`) with its real reset — NOT the old phantom
+      "5h" window that showed weekly data under a 5h label with a 5-day reset.
+    - `long_term` is a null placeholder (`percent_remaining: null`) for the
+      window Codex DROPPED — the app parser treats a null-percent window as
+      absent, so there is NO "0% / unavailable" ghost row.
+
+    The flatten passes quse's unified fields through verbatim (D22 / #1318):
+    pocketshell does NOT relabel — the correct labels come from quse 0.0.11.
+    """
+    out = normalize_usage_stdout(_FIXTURE_0011.read_text())
+    by_provider = {r["provider"]: r for r in (json.loads(ln) for ln in out.splitlines())}
+
+    codex = by_provider["codex"]
+    # The single real Codex window is the WEEKLY one, labeled "7d" — no phantom 5h.
+    assert codex["short_term"]["window"] == "7d"
+    assert codex["short_term"]["window"] != "5h"
+    assert codex["short_term"]["reset_at"] == "2026-07-21T20:37:32Z"
+    assert codex["short_term"]["percent_remaining"] == 69.0
+    # The dropped window is a null placeholder → the app parser omits it (no
+    # "0% / unavailable" ghost row). percent_remaining MUST be null here.
+    assert codex["long_term"]["percent_remaining"] is None
+    assert codex["long_term"]["window"] is None
+    assert codex["long_term"]["reset_at"] is None
+
+
+def test_flatten_codex_0011_leaves_other_providers_unchanged() -> None:
+    """#1564 class coverage: the quse Codex fix does NOT regress other cards.
+
+    Claude keeps its 5h + 7d windows, Copilot keeps its monthly window, and zai
+    keeps its 5h + weekly windows — all labeled correctly in the same quse
+    0.0.11 document. Only Codex's window shape changed.
+    """
+    out = normalize_usage_stdout(_FIXTURE_0011.read_text())
+    by_provider = {r["provider"]: r for r in (json.loads(ln) for ln in out.splitlines())}
+
+    claude = by_provider["claude"]
+    assert claude["short_term"]["window"] == "5h"
+    assert claude["short_term"]["reset_at"] == "2026-07-15T11:39:59Z"
+    assert claude["long_term"]["window"] == "7d"
+    assert claude["long_term"]["reset_at"] == "2026-07-16T14:59:59Z"
+
+    copilot = by_provider["copilot"]
+    assert copilot["long_term"]["window"] == "monthly"
+    assert copilot["long_term"]["percent_remaining"] == 97.1
+
+    zai = by_provider["zai"]
+    assert zai["short_term"]["window"] == "5h"
+    assert zai["long_term"]["window"] == "weekly"
 
 
 def test_flatten_raises_on_non_json() -> None:

--- a/tools/pocketshell/uv.lock
+++ b/tools/pocketshell/uv.lock
@@ -3,8 +3,7 @@ revision = 3
 requires-python = ">=3.11"
 
 [options]
-exclude-newer = "2026-06-18T14:08:51.166593044Z"
-exclude-newer-span = "P7D"
+exclude-newer = "2026-07-16T22:00:00Z"
 
 [[package]]
 name = "annotated-doc"
@@ -315,12 +314,13 @@ wheels = [
 
 [[package]]
 name = "pocketshell"
-version = "0.4.16"
+version = "0.4.37"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
     { name = "google-auth" },
     { name = "pyyaml" },
+    { name = "quse" },
     { name = "tmuxctl" },
 ]
 
@@ -346,6 +346,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.4.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "qrcode", extras = ["pil"], marker = "extra == 'qr'", specifier = ">=7.4" },
+    { name = "quse", specifier = "==0.0.11" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.0" },
     { name = "tmuxctl", specifier = ">=0.3.3" },
 ]
@@ -482,6 +483,18 @@ wheels = [
 [package.optional-dependencies]
 pil = [
     { name = "pillow" },
+]
+
+[[package]]
+name = "quse"
+version = "0.0.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fd/5d/c659757cf4532e8f347476881caf998e4339f1e9dc7c71ee7887270f2069/quse-0.0.11.tar.gz", hash = "sha256:3728b89b5011638a48c68465870ec9be824844ce3b1e2a8f0a9a4d3dc888124b", size = 52456, upload-time = "2026-07-15T08:26:18.888Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/c1/53e5a3ab471833b0fec1dcaaa81affd07e2bbbefa059e793ca7b333934f2/quse-0.0.11-py3-none-any.whl", hash = "sha256:2fae4365f7c9c78c544e7afff5ce9aa2e5543892c3736402ff06bb1e3d16230a", size = 19051, upload-time = "2026-07-15T08:26:18Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #1564

Root cause was the external `quse` package (hardcoded window labels, ignored `limit_window_seconds`); **quse 0.0.11 was published to PyPI** with the fix. This bumps the pocketshell pin `quse==0.0.9` → `quse==0.0.11` and adds reproduce-first coverage. No app/UI change — the Kotlin parser already omits null-percent windows.

## Verification (reviewer APPROVED)
- **G1 red→green (both layers)**: Python test RED on the old 0.0.9 shape (`assert '5h' == '7d'`) → GREEN on the real 0.0.11 fixture; Kotlin parser 'no ghost / no phantom 5h' RED with null-omit reverted → GREEN.
- **Fixture authenticity (G10)**: reviewer downloaded the published `quse-0.0.11.tar.gz` (matching the `uv.lock` sha) and confirmed the fixture matches the real serialization field-for-field — not hand-faked.
- **Coupling guard**: `check-version-coupling.sh` exit 0 (undisturbed). **uv.lock** pins quse 0.0.11 with real hashes; CI resolves directly (dev-box `exclude-newer` is local-only).
- **G2/G3**: class coverage (Claude/Copilot/zai unchanged + Codex weekly-only); 24 Python + 20 Kotlin tests, 0 skipped.
- Orchestrator gate: reassembled clean (no stray artifacts), `uv run --frozen pytest` 24 passed, `:shared:core-usage:` parser tests green, coupling guard exit 0.

Non-blocking: maintainer dogfood glance at the Codex card post-ship.