### PR TITLE
message-queue: unclog outbound queue — bound HoL head + real Retry (#1602)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/composer/OutboundQueueStore.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/OutboundQueueStore.kt
@@ -254,8 +254,17 @@ public interface OutboundQueueStore {
      * re-armed; an unknown/`Delivered` id returns `null` (a late ack cannot
      * resurrect a pruned/delivered row). Attempt counts are not bumped here; the
      * next [claimNext] / [claim] records the next attempt.
+     *
+     * Issue #1602: when [resetAttempts] is true the row's
+     * [OutboundItem.attemptCount] is CLEARED to 0, granting a FRESH bounded auto-
+     * retry budget ([OUTBOUND_MAX_AUTO_ATTEMPTS]). This is
+     * for the EXPLICIT user "resend all" action ([PromptComposerViewModel.resendAllQueued]),
+     * so a row that was auto-parked (`Failed`, budget exhausted) is genuinely re-driven
+     * by the auto-flush instead of being re-parked on the very next cycle. The
+     * auto-defer path (a mid-flight drop) leaves it false so the bound still
+     * accumulates across silent reconnect retries.
      */
-    public fun requeueForRetry(id: String): OutboundItem?
+    public fun requeueForRetry(id: String, resetAttempts: Boolean = false): OutboundItem?
 
     /**
      * Requeue stale [OutboundState.InFlight] rows for [sessionKey] so a
@@ -653,10 +662,14 @@ public open class InMemoryOutboundQueueStore : OutboundQueueStore {
             updated
         }
 
-    override fun requeueForRetry(id: String): OutboundItem? = synchronized(lock) {
+    override fun requeueForRetry(id: String, resetAttempts: Boolean): OutboundItem? = synchronized(lock) {
         val existing = items[id] ?: return null
         if (existing.state == OutboundState.Delivered) return null
-        val updated = existing.copy(state = OutboundState.Queued, lastError = null)
+        val updated = existing.copy(
+            state = OutboundState.Queued,
+            lastError = null,
+            attemptCount = if (resetAttempts) 0 else existing.attemptCount,
+        )
         items[updated.id] = updated
         updated
     }
@@ -738,7 +751,7 @@ public object DisabledOutboundQueueStore : OutboundQueueStore {
     override fun markAttachmentsUploaded(id: String, attachments: List<DurableAttachmentRef>): OutboundItem? = null
     override fun markDelivered(id: String): Boolean = false
     override fun markFailed(id: String, lastError: String?, lastAttemptAtMs: Long): OutboundItem? = null
-    override fun requeueForRetry(id: String): OutboundItem? = null
+    override fun requeueForRetry(id: String, resetAttempts: Boolean): OutboundItem? = null
     override fun requeueStaleInFlight(sessionKey: String, cutoffMs: Long): List<OutboundItem> = emptyList()
     override fun remove(id: String): Boolean = false
     override fun clearSession(sessionKey: String) = Unit
@@ -976,12 +989,16 @@ public class SharedPrefsOutboundQueueStore @Inject constructor(
             updated
         }
 
-    override fun requeueForRetry(id: String): OutboundItem? = synchronized(lock) {
+    override fun requeueForRetry(id: String, resetAttempts: Boolean): OutboundItem? = synchronized(lock) {
         val sessionKey = sessionOf(id) ?: return null
         val list = loadSession(sessionKey)
         val existing = list.firstOrNull { it.id == id } ?: return null
         if (existing.state == OutboundState.Delivered) return null
-        val updated = existing.copy(state = OutboundState.Queued, lastError = null)
+        val updated = existing.copy(
+            state = OutboundState.Queued,
+            lastError = null,
+            attemptCount = if (resetAttempts) 0 else existing.attemptCount,
+        )
         replaceAndStore(sessionKey, list, updated)
         updated
     }

--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerOutboundQueueSelection.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerOutboundQueueSelection.kt
@@ -5,6 +5,22 @@ package com.pocketshell.app.composer
  * The ViewModel owns side effects; this file owns the row predicates shared by
  * retry, delete, and deferred-send recovery.
  */
+/**
+ * Issue #1602: the bounded auto-retry budget for one outbound row. The reconnect
+ * auto-flush re-claims the oldest retryable row each cycle; a row that has
+ * FAILED/wedged this many delivery attempts is a permanently-stuck head-of-line
+ * entry and is PARKED (`Failed`, surfaced) so the drain skips it and the healthy
+ * tail drains. A healthy send delivers + prunes within one or two attempts, so it
+ * never reaches this bound; only a row that fails EVERY attempt does. A user's
+ * per-row Retry bypasses the bound, and `resendAllQueued` resets it, so a parked
+ * row is only auto-skipped, never permanently un-sendable (hard-cut D22).
+ */
+internal const val OUTBOUND_MAX_AUTO_ATTEMPTS: Int = 6
+
+/** Issue #1602: surfaced "Failed — <this>" label a parked (budget-exhausted) row wears. */
+internal const val OUTBOUND_AUTO_RETRY_EXHAUSTED_MESSAGE: String =
+    "Couldn't send after several tries. Tap Retry."
+
 internal fun OutboundItem.isComposerQueueRetryable(): Boolean =
     state == OutboundState.Queued || state == OutboundState.Failed
 
@@ -20,6 +36,66 @@ internal fun Iterable<OutboundItem>.firstComposerQueueRetryable(
             item.id !in excludingIds &&
             item.isComposerQueueRetryable()
     }
+
+/**
+ * Issue #1602: the AUTO-flush selection — the oldest retryable row for
+ * [sessionKey] whose bounded auto-retry budget is NOT yet exhausted
+ * ([OutboundItem.attemptCount] < [maxAutoAttempts]). A row that has failed/wedged
+ * this many delivery attempts is a permanently-stuck HEAD; skipping it here (it is
+ * parked as `Failed` + surfaced by [autoRetryExhaustedComposerRows]) lets the
+ * healthy TAIL drain instead of the drain re-picking the stuck head forever (the
+ * head-of-line clog the #1562 audit reported after a reconnect). A user's explicit
+ * per-row Retry bypasses this bound (it dispatches the row directly), so a parked
+ * row is never permanently un-sendable — only auto-skipped.
+ */
+internal fun Iterable<OutboundItem>.firstComposerAutoFlushable(
+    sessionKey: String,
+    excludingIds: Set<String> = emptySet(),
+    maxAutoAttempts: Int,
+): OutboundItem? =
+    firstOrNull { item ->
+        item.sessionKey == sessionKey &&
+            item.id !in excludingIds &&
+            item.isComposerQueueRetryable() &&
+            item.attemptCount < maxAutoAttempts
+    }
+
+/**
+ * Issue #1602: retryable rows for [sessionKey] whose bounded auto-retry budget is
+ * exhausted ([OutboundItem.attemptCount] >= [maxAutoAttempts]) and that are still
+ * sitting `Queued` (a wedged head re-armed by the deferred/auto-retry path). The
+ * auto-flush parks these as `Failed` so they are SURFACED (the launcher badge's
+ * failure state + a "Failed — …" label) instead of silently blocking the tail —
+ * skip-AND-surface, never a silent drop.
+ */
+internal fun Iterable<OutboundItem>.autoRetryExhaustedComposerRows(
+    sessionKey: String,
+    excludingIds: Set<String> = emptySet(),
+    maxAutoAttempts: Int,
+): List<OutboundItem> =
+    filter { item ->
+        item.sessionKey == sessionKey &&
+            item.id !in excludingIds &&
+            item.state == OutboundState.Queued &&
+            item.attemptCount >= maxAutoAttempts
+    }
+
+/** Issue #1602: the auto-flush decision — ids to park (exhausted heads) + the next dispatchable id. */
+internal data class ComposerAutoFlushPlan(val parkIds: List<String>, val nextId: String?)
+
+/**
+ * Issue #1602: plan one auto-flush cycle for [sessionKey]. Parking (Queued→Failed)
+ * an exhausted head does not change whether it is dispatchable (the attempt-bound
+ * filter already excludes it), so [nextId] is computed from the same snapshot.
+ */
+internal fun Iterable<OutboundItem>.planComposerAutoFlush(
+    sessionKey: String,
+    excludingIds: Set<String> = emptySet(),
+    maxAutoAttempts: Int = OUTBOUND_MAX_AUTO_ATTEMPTS,
+): ComposerAutoFlushPlan = ComposerAutoFlushPlan(
+    parkIds = autoRetryExhaustedComposerRows(sessionKey, excludingIds, maxAutoAttempts).map { it.id },
+    nextId = firstComposerAutoFlushable(sessionKey, excludingIds, maxAutoAttempts)?.id,
+)
 
 internal fun Iterable<OutboundItem>.composerQueueRetryableItems(): List<OutboundItem> =
     filter { it.isComposerQueueRetryable() }

--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerViewModel.kt
@@ -1522,6 +1522,13 @@ public class PromptComposerViewModel @Inject constructor(
      * actual delivery and calls [markSendDelivered] / [restoreFailedSend].
      */
     public fun retryOutboundItem(id: String) {
+        // Issue #1602: an explicit Retry must re-drive THIS row. A CLOGGED pipeline
+        // (wedged in-flight send holding `sendInFlight`) makes a plain dispatch a
+        // SILENT NO-OP, so break the strand first — the watchdog recovery that DEFERS
+        // the wedged row (exactly-once via #1526/#1541). NOT the sidecar latch (#928).
+        if (_uiState.value.sendInFlight) {
+            clearStrandedSendInFlight()
+        }
         dispatchOutboundItem(id)
     }
 
@@ -1535,11 +1542,17 @@ public class PromptComposerViewModel @Inject constructor(
     public fun retryNextOutboundItem(excludingIds: Set<String> = emptySet()): String? {
         if (_uiState.value.sendInFlight) return null
         val target = composerTarget?.takeIf { it.isNotBlank() } ?: return null
-        val next = _outboundQueueItems.value.firstComposerQueueRetryable(
-            sessionKey = target,
-            excludingIds = excludingIds,
-        ) ?: return null
-        return if (dispatchOutboundItem(next.id)) next.id else null
+        // Issue #1602: PARK an auto-retry-exhausted head (Failed, surfaced) so the
+        // drain skips it and the healthy tail drains; per-row Retry re-drives it.
+        val plan = _outboundQueueItems.value.planComposerAutoFlush(target, excludingIds)
+        if (plan.parkIds.isNotEmpty()) {
+            plan.parkIds.forEach {
+                outboundQueueStore.markFailed(it, lastError = OUTBOUND_AUTO_RETRY_EXHAUSTED_MESSAGE)
+            }
+            refreshOutboundQueueItemsFor(target)
+        }
+        val nextId = plan.nextId ?: return null
+        return if (dispatchOutboundItem(nextId)) nextId else null
     }
 
     /**
@@ -1574,7 +1587,9 @@ public class PromptComposerViewModel @Inject constructor(
         val target = composerTarget?.takeIf { it.isNotBlank() } ?: return emptyList()
         val rearmedIds = outboundQueueStore.itemsFor(target)
             .composerQueueRetryableItems()
-            .mapNotNull { outboundQueueStore.requeueForRetry(it.id)?.id }
+            // Issue #1602: re-grant the bounded auto-retry budget (resetAttempts) so a
+            // parked (Failed, exhausted) row is re-driven, not re-parked next cycle.
+            .mapNotNull { outboundQueueStore.requeueForRetry(it.id, resetAttempts = true)?.id }
         if (rearmedIds.isNotEmpty()) refreshOutboundQueueItemsFor(target)
         return rearmedIds
     }

--- a/app/src/test/java/com/pocketshell/app/composer/PromptComposerOutboundQueueClogTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/PromptComposerOutboundQueueClogTest.kt
@@ -1,0 +1,326 @@
+package com.pocketshell.app.composer
+
+import androidx.lifecycle.SavedStateHandle
+import com.pocketshell.app.composer.PromptComposerViewModel.ApiKeyVault
+import com.pocketshell.app.di.WhisperClientFactory
+import com.pocketshell.app.hosts.MainDispatcherRule
+import com.pocketshell.core.voice.WhisperClient
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Issue #1602: clogged outbound queue after reconnect. Residual from the #1562
+ * message-queue epic (root reconnect-storm fixed in #1567/#1568): after a
+ * reconnect the outbound queue can CLOG. Two mechanisms, both reproduced RED on
+ * base and proven GREEN with the fix:
+ *
+ *  - **Head-of-line block.** The auto-flush drain always re-picks the OLDEST
+ *    retryable row ([firstComposerQueueRetryable]), with no attempt bound, so a
+ *    permanently-failing HEAD is re-selected forever and a healthy TAIL behind
+ *    it never gets a delivery attempt. Fix: a head that exhausts its bounded
+ *    auto-retries is PARKED (`Failed`, surfaced) and SKIPPED so the tail drains.
+ *  - **Silent Retry no-op.** While a wedged head holds `sendInFlight`, a user
+ *    tapping Retry hits `dispatchOutboundItem` returning false — nothing moves.
+ *    Fix: a manual Retry breaks the strand and produces a real delivery attempt.
+ *
+ * These are pure JVM ViewModel tests (gate-wired in the `Unit tests` job). The
+ * exactly-once (#1529) / coalesce (#961) invariants are asserted preserved.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class PromptComposerOutboundQueueClogTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val createdViewModels = mutableListOf<PromptComposerViewModel>()
+
+    @After
+    fun tearDownViewModels() {
+        createdViewModels.forEach { it.clearForTest() }
+        createdViewModels.clear()
+    }
+
+    private class FakeVault(initial: CharArray? = null) : ApiKeyVault {
+        private var key: CharArray? = initial?.copyOf()
+        override fun save(key: CharArray) { this.key = key.copyOf() }
+        override fun load(): CharArray? = this.key?.copyOf()
+        override fun clear() { this.key = null }
+    }
+
+    private fun fakeWhisperClient(): WhisperClient = object : WhisperClient {
+        override suspend fun transcribe(audio: ByteArray, language: String?): Result<String> =
+            Result.success("hello world")
+    }
+
+    private fun newVm(
+        outboundQueueStore: OutboundQueueStore,
+    ): PromptComposerViewModel {
+        val dispatcher = StandardTestDispatcher()
+        val vm = PromptComposerViewModel(
+            audioRecorder = MinimalMicCapture(),
+            whisperClientFactory = WhisperClientFactory { fakeWhisperClient() },
+            apiKeyStorage = FakeVault("sk-test".toCharArray()),
+            voiceSettings = MinimalVoiceSettings(),
+            outboundQueueStore = outboundQueueStore,
+            savedStateHandle = SavedStateHandle(),
+        )
+        vm.samplerDispatcher = dispatcher
+        // Bind the outbound-queue dispatch onto the test scheduler so the launched
+        // claim/emit coroutine drains under advanceUntilIdle.
+        vm.outboundQueueDispatcher = dispatcher
+        // Disable the ~140s overall-send watchdog by default so its `delay` does not
+        // fire during the test's virtual-time advances (the wedge is modelled by an
+        // explicit markOutboundSendDeferred, the exact production watchdog/drop path).
+        vm.setSendWatchdogTimeoutForTest(null)
+        createdViewModels += vm
+        return vm
+    }
+
+    private fun TestScope.collectSendRequests(
+        vm: PromptComposerViewModel,
+    ): MutableList<PromptComposerViewModel.SendRequest> {
+        val collected = java.util.Collections.synchronizedList(
+            mutableListOf<PromptComposerViewModel.SendRequest>(),
+        )
+        backgroundScope.launch { vm.sendRequests.collect { collected += it } }
+        runCurrent()
+        return collected
+    }
+
+    /**
+     * The send-request collector resumes on the Main test dispatcher after a
+     * channel emission, so a plain [advanceUntilIdle] alone does not always
+     * observe the newest element. Pump virtual time + yield to real dispatchers
+     * until the predicate holds; HARD-FAIL on timeout (never a self-skip).
+     */
+    private suspend fun TestScope.settleUntil(predicate: () -> Boolean) {
+        val deadline = System.currentTimeMillis() + 20_000L
+        while (true) {
+            advanceUntilIdle()
+            if (predicate()) return
+            runCurrent()
+            advanceTimeBy(1L)
+            runCurrent()
+            if (predicate()) return
+            withContext(Dispatchers.IO) { }
+            if (predicate()) return
+            if (System.currentTimeMillis() >= deadline) {
+                advanceUntilIdle()
+                assertTrue("settleUntil timed out before the predicate held (#1602)", predicate())
+                return
+            }
+        }
+    }
+
+    @Test
+    fun permanentlyFailingHeadDoesNotBlockHealthyTail() = runTest {
+        // RED on base: the drain always re-picks the oldest retryable row, so the
+        // permanently-failing HEAD blocks the healthy TAIL forever (no delivery
+        // attempt for the tail across any number of reconnect flushes). GREEN: once
+        // the head exhausts its bounded auto-retries it is PARKED (Failed, surfaced)
+        // and SKIPPED, so the tail drains.
+        val queue = InMemoryOutboundQueueStore()
+        val vm = newVm(outboundQueueStore = queue)
+        val sent = collectSendRequests(vm)
+        val session = "1/session-a"
+        vm.onComposerTargetChanged(session)
+
+        val head = queue.enqueue(sessionKey = session, cleanText = "HEAD (permanently stuck)", createdAtMs = 1)
+        val tail = queue.enqueue(sessionKey = session, cleanText = "TAIL (healthy)", createdAtMs = 2)
+        vm.refreshOutboundQueueItemsFor(session)
+
+        var tailDispatched = false
+        repeat(50) {
+            val flushedId = vm.retryNextOutboundItem()
+            advanceUntilIdle()
+            if (flushedId == tail.id) {
+                tailDispatched = true
+                return@repeat
+            }
+            if (flushedId == head.id) {
+                // The head's delivery never acks (a wedged send). Resolve it the way
+                // the ~140s send watchdog / a real drop does: defer it back to the
+                // queue for auto-retry, re-arming it at the front of the queue.
+                val request = vm.inFlightSendRequest ?: return@repeat
+                vm.markOutboundSendDeferred(request)
+                advanceUntilIdle()
+            }
+        }
+
+        assertTrue(
+            "the healthy TAIL must get a delivery attempt even though the HEAD " +
+                "permanently fails — a stuck head must not block following sends (#1602)",
+            tailDispatched,
+        )
+        settleUntil { sent.any { it.outboundQueueItemId == tail.id } }
+        assertTrue(
+            "the healthy tail's SendRequest must have been emitted",
+            sent.any { it.outboundQueueItemId == tail.id },
+        )
+        // The permanently-failing head is PARKED + SURFACED (Failed) — not silently
+        // dropped, and not left Queued (which would re-block on the next cycle).
+        assertEquals(OutboundState.Failed, requireNotNull(queue.item(head.id)).state)
+    }
+
+    @Test
+    fun manualRetryReDrivesCloggedQueueInsteadOfSilentNoOp() = runTest {
+        // RED on base: while a wedged HEAD send holds the `sendInFlight` gate, the
+        // user tapping Retry on any row is a SILENT NO-OP — retryOutboundItem →
+        // dispatchOutboundItem returns false and NO delivery attempt is produced.
+        // GREEN: the manual Retry breaks the strand and produces a delivery attempt.
+        val queue = InMemoryOutboundQueueStore()
+        val vm = newVm(outboundQueueStore = queue)
+        val sent = collectSendRequests(vm)
+        val session = "1/session-a"
+        vm.onComposerTargetChanged(session)
+
+        val head = queue.enqueue(sessionKey = session, cleanText = "HEAD wedged", createdAtMs = 1)
+        val tail = queue.enqueue(sessionKey = session, cleanText = "TAIL to retry", createdAtMs = 2)
+        vm.refreshOutboundQueueItemsFor(session)
+
+        // Head goes in-flight and WEDGES (never acked) — it holds the gate.
+        val flushedId = vm.retryNextOutboundItem()
+        advanceUntilIdle()
+        assertEquals(head.id, flushedId)
+        assertTrue("the wedged head holds the sendInFlight gate", vm.uiState.value.sendInFlight)
+        val sentBefore = sent.size
+
+        // User taps Retry on the tail while the queue is clogged.
+        vm.retryOutboundItem(tail.id)
+        settleUntil { sent.size > sentBefore && sent.any { it.outboundQueueItemId == tail.id } }
+
+        assertTrue(
+            "a manual Retry in the clogged state must produce a delivery attempt, " +
+                "not a silent no-op (#1602)",
+            sent.size > sentBefore,
+        )
+        assertTrue(
+            "the retried tail row must have produced a SendRequest",
+            sent.any { it.outboundQueueItemId == tail.id },
+        )
+        // The claim (row transitioned to InFlight) is the authoritative "delivery
+        // attempt dispatched" signal.
+        assertEquals(OutboundState.InFlight, requireNotNull(queue.item(tail.id)).state)
+    }
+
+    @Test
+    fun healthyTailDrainsInFifoOrderAfterHeadParked() = runTest {
+        // Class coverage (G2): multi-entry ordering preserved for the non-stuck
+        // tail. A permanently-failing head is parked; the two healthy rows behind
+        // it still deliver in FIFO (oldest-first) order.
+        val queue = InMemoryOutboundQueueStore()
+        val vm = newVm(outboundQueueStore = queue)
+        collectSendRequests(vm)
+        val session = "1/session-a"
+        vm.onComposerTargetChanged(session)
+
+        val head = queue.enqueue(sessionKey = session, cleanText = "HEAD stuck", createdAtMs = 1)
+        val b = queue.enqueue(sessionKey = session, cleanText = "B", createdAtMs = 2)
+        val c = queue.enqueue(sessionKey = session, cleanText = "C", createdAtMs = 3)
+        vm.refreshOutboundQueueItemsFor(session)
+
+        val deliveredHealthy = mutableListOf<String>()
+        repeat(80) {
+            if (deliveredHealthy.size == 2) return@repeat
+            val id = vm.retryNextOutboundItem() ?: return@repeat
+            advanceUntilIdle()
+            val req = vm.inFlightSendRequest ?: return@repeat
+            if (id == head.id) {
+                vm.markOutboundSendDeferred(req)
+                advanceUntilIdle()
+            } else {
+                deliveredHealthy += req.cleanDraft
+                vm.markSendDelivered(req)
+                advanceUntilIdle()
+            }
+        }
+
+        assertEquals(
+            "the healthy tail must deliver in FIFO order once the stuck head is parked",
+            listOf("B", "C"),
+            deliveredHealthy,
+        )
+        assertEquals(OutboundState.Failed, requireNotNull(queue.item(head.id)).state)
+        assertTrue("B and C are delivered (pruned)", queue.item(b.id) == null && queue.item(c.id) == null)
+    }
+
+    @Test
+    fun parkedHeadSurfacedAndManualRetryReDrivesItWithoutBreakingCoalesce() = runTest {
+        // Class coverage (G2): skip-AND-surface + the #961 coalesce / exactly-once
+        // invariant on retry. A parked head reads as Failed (surfaced, not dropped);
+        // re-enqueuing the SAME logical send coalesces instead of duplicating; a
+        // manual Retry on the parked row actually re-drives it.
+        val queue = InMemoryOutboundQueueStore()
+        val vm = newVm(outboundQueueStore = queue)
+        val sent = collectSendRequests(vm)
+        val session = "1/session-a"
+        vm.onComposerTargetChanged(session)
+
+        val head = queue.enqueue(sessionKey = session, cleanText = "stuck head", createdAtMs = 1, sendKey = "sk-head")
+        vm.refreshOutboundQueueItemsFor(session)
+
+        repeat(50) {
+            if (queue.item(head.id)?.state == OutboundState.Failed) return@repeat
+            val id = vm.retryNextOutboundItem() ?: return@repeat
+            advanceUntilIdle()
+            val req = vm.inFlightSendRequest ?: return@repeat
+            if (id == head.id) {
+                vm.markOutboundSendDeferred(req)
+                advanceUntilIdle()
+            }
+        }
+
+        val parked = requireNotNull(queue.item(head.id))
+        assertEquals(
+            "a permanently-failing head is SURFACED as Failed (skip-and-surface)",
+            OutboundState.Failed,
+            parked.state,
+        )
+        assertNotNull("the parked row carries a surfaced error label", parked.lastError)
+
+        // #961 coalesce still holds: re-enqueue of the SAME logical send re-arms the
+        // existing parked row instead of minting a second deliverable row.
+        val reEnqueued = queue.enqueue(sessionKey = session, cleanText = "stuck head", createdAtMs = 9, sendKey = "sk-head")
+        assertEquals("re-enqueue of the same logical send must coalesce, not duplicate", head.id, reEnqueued.id)
+        assertEquals(1, queue.itemsFor(session).size)
+
+        // A manual Retry on the (re-armed) parked row must actually re-drive it.
+        val before = sent.size
+        vm.retryOutboundItem(head.id)
+        settleUntil { sent.size > before && sent.any { it.outboundQueueItemId == head.id } }
+        assertTrue("manual Retry must re-drive a parked row (#1602)", sent.size > before)
+        assertTrue(sent.any { it.outboundQueueItemId == head.id })
+    }
+
+    private class MinimalMicCapture : PromptComposerViewModel.MicCapture {
+        override fun start() = Unit
+        override fun stop(): ByteArray = ByteArray(0)
+        override fun currentAmplitude(): Float = 0f
+    }
+
+    private class MinimalVoiceSettings : PromptComposerViewModel.VoiceSettingsSnapshot {
+        override fun silenceWindowMs(): Long = PromptComposerViewModel.SILENCE_WINDOW_MS
+        override fun whisperLanguageHint(): String? = null
+        override fun transcriptionProvider(): com.pocketshell.app.settings.VoiceTranscriptionProvider =
+            com.pocketshell.app.settings.VoiceTranscriptionProvider.OpenAiWhisper
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/composer/PromptComposerOutboundSendQueueViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/PromptComposerOutboundSendQueueViewModelTest.kt
@@ -1312,9 +1312,9 @@ class PromptComposerOutboundSendQueueViewModelTest {
         // — so the wait genuinely blocks until the flush has completed.
         var requeueCount = 0
         val queue = object : InMemoryOutboundQueueStore() {
-            override fun requeueForRetry(id: String): OutboundItem? {
+            override fun requeueForRetry(id: String, resetAttempts: Boolean): OutboundItem? {
                 requeueCount++
-                return super.requeueForRetry(id)
+                return super.requeueForRetry(id, resetAttempts)
             }
         }
         val sidecars = newSidecarStore(ioDispatcher = StandardTestDispatcher(testScheduler))


### PR DESCRIPTION
Closes #1602 (residual from the #1562 epic).

After a reconnect the outbound queue could clog: the head-of-line entry was re-selected with no attempt bound (a permanently-failing head starved the healthy tail), and manual **Retry** was a silent no-op while a wedged head held `sendInFlight`.

Fix (D22 hard-cut): bounded skip-and-surface (`OUTBOUND_MAX_AUTO_ATTEMPTS=6` parks an exhausted head as Failed/surfaced so the tail drains); manual Retry breaks only the `sendInFlight` strand — **not** the sidecar upload latch — to produce a real delivery attempt without double-dispatch; `resendAllQueued` resets the budget.

## Verification (reviewer APPROVED)
- **G1 red→green**: `PromptComposerOutboundQueueClogTest` 4 cases FAIL on base (tail never dispatched; manual-retry silent-no-op timeout) → PASS with fix.
- **No-double-dispatch crux**: strand-break scoped to `sendInFlight` (defers the wedged request, doesn't lose it); the sidecar dispatch-in-flight guard keeps retry-during-upload a no-op. Sibling guards `retryOutboundItemDoesNotDoubleRetryWhileInFlight` + `concurrentSidecarRetriesOnlyOneUploadAndSendOwnsTheQueuedRow` pass. #1529/#961 invariants preserved.
- **G6**: green load-bearing assertion is the tail actually delivering a `SendRequest`, not merely 'head parked'.
- **G3**: full `:app:testDebugUnitTest` 3870 tests / 0 failures / 0 skipped.
- **Hygiene**: `check-file-size-hygiene.sh` OK (VM under baseline via extraction), `check-test-validity.sh` PASS. Orchestrator re-gate clean.