### PR TITLE
conversation: bounded auto-retry so load recovers after reattach (#1603)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxConversationLoadWatchdog.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxConversationLoadWatchdog.kt
@@ -1,0 +1,102 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.app.diagnostics.DiagnosticEvents
+import com.pocketshell.app.session.ConversationLoadState
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Issue #793 / #1603: the Conversation-tab first-paint load watchdog, extracted
+ * out of [TmuxSessionViewModel] (D28 god-object hygiene). It bounds the
+ * "Loading conversation…" spinner and — Issue #1603 — AUTO-RETRIES a load that
+ * raced a still-settling post-reattach transport before surfacing the Failed
+ * dead-end ("Couldn't load this conversation."), so a slow first load after a
+ * reattach recovers on its own with NO manual reconnect. The auto-retry is
+ * bounded by [CONVERSATION_LOAD_MAX_AUTO_RETRIES] so a genuinely-absent /
+ * unreachable conversation still resolves to the clear Failed terminal state
+ * instead of spinning forever.
+ *
+ * The VM wires the per-pane state accessors + the load-restart / flip-to-Failed
+ * effects as lambdas; this class owns the per-pane timer jobs, the auto-retry
+ * budget, and the timeout→retry-or-fail decision.
+ */
+internal class TmuxConversationLoadWatchdog(
+    private val scope: CoroutineScope,
+    private val timeoutMs: () -> Long,
+    private val loadStateOf: (String) -> ConversationLoadState?,
+    private val isSessionLive: () -> Boolean,
+    private val paneFor: (String) -> TmuxPaneState?,
+    // Re-run the full detect → window-read → tail load for the pane (clears the
+    // detection dedup key so the re-detection is not short-circuited).
+    private val onRetryLoad: (TmuxPaneState) -> Unit,
+    // Flip the row to the Failed terminal state IFF it is still Loading.
+    private val onExhaustedFailed: (String) -> Unit,
+) {
+    private val jobs: MutableMap<String, Job> = ConcurrentHashMap()
+    private val attempts: MutableMap<String, Int> = ConcurrentHashMap()
+
+    /** Auto-retries already spent on the CURRENT open (diagnostics only). */
+    fun attemptsSpent(paneId: String): Int = attempts[paneId] ?: 0
+
+    /**
+     * Arm for a FRESH open (or an explicit manual Retry): resets the auto-retry
+     * budget so the row gets the full [CONVERSATION_LOAD_MAX_AUTO_RETRIES]
+     * recovery attempts. The auto-retry path re-arms via [rearm], which PRESERVES
+     * the budget so the recursion is bounded.
+     */
+    fun arm(paneId: String) {
+        attempts.remove(paneId)
+        rearm(paneId)
+    }
+
+    private fun rearm(paneId: String) {
+        jobs.remove(paneId)?.cancel()
+        jobs[paneId] = scope.launch {
+            delay(timeoutMs())
+            if (loadStateOf(paneId) != ConversationLoadState.Loading) return@launch
+            val spent = attempts[paneId] ?: 0
+            val pane = paneFor(paneId)
+            if (!isSessionLive() || pane == null || spent >= CONVERSATION_LOAD_MAX_AUTO_RETRIES) {
+                // No live session, or the bounded budget is spent (the
+                // genuinely-absent / unreachable-log case) → clear Failed.
+                onExhaustedFailed(paneId)
+                return@launch
+            }
+            val attempt = spent + 1
+            attempts[paneId] = attempt
+            DiagnosticEvents.record(
+                "recoverable",
+                "tmux_agent_conversation_load_auto_retry",
+                "pane" to paneId,
+                "attempt" to attempt,
+                "maxAttempts" to CONVERSATION_LOAD_MAX_AUTO_RETRIES,
+                "timeoutMs" to timeoutMs(),
+            )
+            // Give the still-settling transport progressively more room, then
+            // re-run the load and re-arm (the row stays Loading throughout, so the
+            // user never sees the dead-end mid-recovery).
+            delay(CONVERSATION_LOAD_RETRY_BACKOFF_MS * attempt)
+            if (loadStateOf(paneId) != ConversationLoadState.Loading) return@launch
+            if (!isSessionLive()) {
+                onExhaustedFailed(paneId)
+                return@launch
+            }
+            onRetryLoad(pane)
+            rearm(paneId)
+        }
+    }
+
+    fun cancel(paneId: String) {
+        jobs.remove(paneId)?.cancel()
+        attempts.remove(paneId)
+    }
+
+    fun cancelAll() {
+        jobs.values.forEach { it.cancel() }
+        jobs.clear()
+        attempts.clear()
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionSupport.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionSupport.kt
@@ -822,6 +822,28 @@ internal const val CHANNEL_WEDGED_RECENT_OUTPUT_MS: Long = 3_000L
  */
 internal const val CONVERSATION_LOAD_TIMEOUT_MS: Long = 12_000L
 
+/**
+ * Issue #1603: how many times the conversation-load watchdog auto-retries a
+ * still-Loading first-paint read before it surfaces the
+ * [ConversationLoadState.Failed] dead-end. On a just-reattached busy session the
+ * first tail read races a still-settling transport and can miss the 12 s window
+ * even though it would succeed given a beat more; instead of hard-failing to
+ * "Couldn't load this conversation." (a dead end the user could only escape by
+ * reconnecting), the watchdog re-runs the load a bounded number of times with a
+ * backoff while the transport settles. Bounded so a genuinely-absent
+ * conversation (no agent / unreachable log) still reaches Failed and never
+ * spins forever.
+ */
+internal const val CONVERSATION_LOAD_MAX_AUTO_RETRIES: Int = 3
+
+/**
+ * Issue #1603: base backoff between conversation-load auto-retries. The Nth
+ * retry waits `CONVERSATION_LOAD_RETRY_BACKOFF_MS * N` (linear, attempt-scaled)
+ * so a still-settling transport is given progressively more room before the
+ * next re-read, without letting the total recovery window grow unbounded.
+ */
+internal const val CONVERSATION_LOAD_RETRY_BACKOFF_MS: Long = 1_000L
+
 public enum class TmuxConnectTrigger(public val logValue: String) {
     UserTap("user-tap"),
     // Issue #1155 (Part B): a NORMAL tap of a PERSISTED session row in the folder

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -2252,9 +2252,6 @@ public class TmuxSessionViewModel @Inject constructor(
     // `black_frame_observed` diagnostic. Diagnostic accounting only; it never gates a
     // heal decision.
     private val paneLastSeedAtMs: MutableMap<String, Long> = ConcurrentHashMap()
-    // Issue #793: per-pane conversation-load watchdog. Flips a never-completing
-    // "Loading conversation…" state to Failed so the tab can't spin forever.
-    private val conversationLoadWatchdogJobs: MutableMap<String, Job> = ConcurrentHashMap()
     private val paneInputQueues: MutableMap<String, TmuxPaneInputQueue> = ConcurrentHashMap()
     private val paneInputJobs: MutableMap<String, Job> = ConcurrentHashMap()
 
@@ -2376,6 +2373,21 @@ public class TmuxSessionViewModel @Inject constructor(
         viewModelScope.coroutineContext +
             SupervisorJob(viewModelScope.coroutineContext[Job]) +
             bridgeExceptionHandler,
+    )
+
+    // Issue #793/#1603: Conversation load watchdog + auto-retry, extracted (D28).
+    private val conversationLoadWatchdog = TmuxConversationLoadWatchdog(
+        scope = bridgeScope,
+        timeoutMs = { conversationLoadTimeoutMs },
+        loadStateOf = { paneId -> _agentConversations.value[paneId]?.loadState },
+        isSessionLive = { sessionRef?.isConnected == true },
+        paneFor = { paneId -> paneRows[paneId] },
+        onRetryLoad = { pane ->
+            // Manual-retry path: clear dedup, then re-run the full load.
+            paneAgentInputs.remove(pane.paneId)
+            startAgentDetectionForPane(pane)
+        },
+        onExhaustedFailed = ::flipConversationLoadToFailed,
     )
 
     // Issue #935 R1 (#928 D2): crash-containment for the bare
@@ -5869,8 +5881,7 @@ public class TmuxSessionViewModel @Inject constructor(
         paneOverflowRecoveryInFlight.clear()
         paneAgentJobs.values.forEach { it.cancel() }
         paneAgentJobs.clear()
-        conversationLoadWatchdogJobs.values.forEach { it.cancel() }
-        conversationLoadWatchdogJobs.clear()
+        conversationLoadWatchdog.cancelAll()
         paneAgentTailGenerations.clear()
         paneAgentInputs.clear()
         paneAgentNullDetections.clear()
@@ -6032,8 +6043,7 @@ public class TmuxSessionViewModel @Inject constructor(
         // Issue #793: drop any pending load watchdogs from the prior runtime so
         // a restored, already-populated conversation row is not flipped to
         // Failed by a stale timer.
-        conversationLoadWatchdogJobs.values.forEach { it.cancel() }
-        conversationLoadWatchdogJobs.clear()
+        conversationLoadWatchdog.cancelAll()
         paneAgentTailGenerations.clear()
         paneAgentInputs.clear()
         paneAgentNullDetections.clear()
@@ -9792,7 +9802,7 @@ public class TmuxSessionViewModel @Inject constructor(
             panePortDetectorClients.remove(paneId)
             panePortDetectorGenerations.remove(paneId)
             paneAgentJobs.remove(paneId)?.cancel()
-            conversationLoadWatchdogJobs.remove(paneId)?.cancel()
+            conversationLoadWatchdog.cancel(paneId)
             paneAgentTailGenerations.remove(paneId)
             paneAgentInputs.remove(paneId)
             paneAgentNullDetections.remove(paneId)
@@ -12291,7 +12301,7 @@ public class TmuxSessionViewModel @Inject constructor(
         // Issue #819 (A2): arm the load watchdog so a never-arriving live
         // re-detection resolves the placeholder to a clear terminal state
         // instead of spinning forever (mirrors seedPresumedAgentPlaceholder).
-        armConversationLoadWatchdog(pane.paneId)
+        conversationLoadWatchdog.arm(pane.paneId)
     }
 
     /**
@@ -12363,7 +12373,7 @@ public class TmuxSessionViewModel @Inject constructor(
                 .map { it.paneId }
             for (paneId in shellPaneIds) {
                 if (isAutoSeededPlaceholderUp(paneId)) {
-                    conversationLoadWatchdogJobs.remove(paneId)?.cancel()
+                    conversationLoadWatchdog.cancel(paneId)
                     paneAgentNullDetections.remove(paneId)
                     clearAgentDetectionForPane(paneId)
                 }
@@ -12535,7 +12545,7 @@ public class TmuxSessionViewModel @Inject constructor(
                 autoSeededPlaceholder = true,
             ))
         }
-        if (seeded) armConversationLoadWatchdog(pane.paneId)
+        if (seeded) conversationLoadWatchdog.arm(pane.paneId)
     }
 
     /**
@@ -13241,7 +13251,7 @@ public class TmuxSessionViewModel @Inject constructor(
         // watchdog. A KEPT (user-tapped #778) detection-less placeholder row
         // intentionally retains its watchdog so the "Loading conversation…"
         // state still resolves to a clear Failed terminal state.
-        if (rowDropped) cancelConversationLoadWatchdog(paneId)
+        if (rowDropped) conversationLoadWatchdog.cancel(paneId)
     }
 
     private suspend fun startAgentConversationForPane(
@@ -14382,7 +14392,7 @@ public class TmuxSessionViewModel @Inject constructor(
                     loadState = ConversationLoadState.Loading,
                 ),
             )
-            armConversationLoadWatchdog(paneId)
+            conversationLoadWatchdog.arm(paneId)
             DiagnosticEvents.record(
                 "action",
                 "session_tab_select",
@@ -14423,10 +14433,10 @@ public class TmuxSessionViewModel @Inject constructor(
                         current.copy(loadState = ConversationLoadState.Loading)
                     }
                 }
-                armConversationLoadWatchdog(paneId)
+                conversationLoadWatchdog.arm(paneId)
             }
         } else {
-            cancelConversationLoadWatchdog(paneId)
+            conversationLoadWatchdog.cancel(paneId)
         }
         if (changed) {
             DiagnosticEvents.record(
@@ -14796,32 +14806,23 @@ public class TmuxSessionViewModel @Inject constructor(
             rowExists = true
             current.copy(loadState = ConversationLoadState.Loading)
         }
-        if (rowExists) armConversationLoadWatchdog(paneId)
+        if (rowExists) conversationLoadWatchdog.arm(paneId)
     }
 
-    private fun armConversationLoadWatchdog(paneId: String) {
-        conversationLoadWatchdogJobs.remove(paneId)?.cancel()
-        conversationLoadWatchdogJobs[paneId] = bridgeScope.launch {
-            delay(conversationLoadTimeoutMs)
-            updateAgentConversation(paneId) { current ->
-                if (current.loadState == ConversationLoadState.Loading) {
-                    DiagnosticEvents.record(
-                        "recoverable",
-                        "tmux_agent_conversation_load_timeout",
-                        "pane" to paneId,
-                        "timeoutMs" to conversationLoadTimeoutMs,
-                    )
-                    current.copy(loadState = ConversationLoadState.Failed)
-                } else {
-                    current
-                }
-            }
+    private fun flipConversationLoadToFailed(paneId: String) {
+        updateAgentConversation(paneId) { current ->
+            if (current.loadState != ConversationLoadState.Loading) return@updateAgentConversation current
+            DiagnosticEvents.record(
+                "recoverable",
+                "tmux_agent_conversation_load_timeout",
+                "pane" to paneId,
+                "timeoutMs" to conversationLoadTimeoutMs,
+                "autoRetriesSpent" to conversationLoadWatchdog.attemptsSpent(paneId),
+            )
+            current.copy(loadState = ConversationLoadState.Failed)
         }
     }
 
-    private fun cancelConversationLoadWatchdog(paneId: String) {
-        conversationLoadWatchdogJobs.remove(paneId)?.cancel()
-    }
 
     /**
      * Record the terminal outcome of the first-paint tail read for [paneId].
@@ -14837,7 +14838,7 @@ public class TmuxSessionViewModel @Inject constructor(
         hasMoreOlder: Boolean,
         failed: Boolean,
     ) {
-        cancelConversationLoadWatchdog(paneId)
+        conversationLoadWatchdog.cancel(paneId)
         updateAgentConversation(paneId) { current ->
             // Only own the load state for the row that still matches this
             // detection (a fast switch could have replaced it).

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelConversationTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelConversationTest.kt
@@ -86,7 +86,7 @@ class TmuxSessionViewModelConversationTest : TmuxSessionViewModelTestBase() {
         private val execGate: CompletableDeferred<Unit>? = null,
         private var wcOutput: String = "0\n",
         private var initialEventsOutput: String = "",
-        private val detectionOutput: String = "",
+        private var detectionOutput: String = "",
         private val recordedKindOutput: String = "",
         private var recordedSourceGenerationOutput: String = "",
         private var recordedSourceOutput: String = "",
@@ -100,6 +100,7 @@ class TmuxSessionViewModelConversationTest : TmuxSessionViewModelTestBase() {
         fun setWcOutput(value: String) { wcOutput = value }
         fun setInitialEventsOutput(value: String) { initialEventsOutput = value }
         fun setRecordedSourceOutput(value: String) { recordedSourceOutput = value }
+        fun setDetectionOutput(value: String) { detectionOutput = value }
 
         override val isConnected: Boolean
             get() = isConnectedValue && !closed
@@ -927,4 +928,275 @@ class TmuxSessionViewModelConversationTest : TmuxSessionViewModelTestBase() {
             },
         )
     }
+
+    /**
+     * Issue #1603: connect + register a single pane carrying [cwd]/[paneTty]/[panePid]
+     * (the detection inputs) with [session] installed as the active sessionRef, so
+     * the REAL detection → window-read → tail load path runs against the fake host.
+     */
+    private fun TmuxSessionViewModel.connectPaneWithSessionForTest(
+        paneId: String,
+        cwd: String,
+        currentCommand: String,
+        session: FakeSshSession,
+        paneTty: String = "/dev/pts/7",
+        panePid: Long = 4242L,
+    ) {
+        // Terminal default → no #878 auto-seed placeholder at pane-add, so the
+        // Conversation tap below creates a USER-tapped (#778) row that a transient
+        // null detection KEEPS on "Loading…" (its watchdog resolving it), instead
+        // of an auto-seed row that a null drops. This models the reported reattach
+        // state: the user is on the Conversation tab while the load is in flight.
+        setDefaultAgentSessionViewForTest(
+            com.pocketshell.app.settings.DefaultAgentSessionView.Terminal,
+        )
+        replaceClientForTest(
+            hostId = 42L,
+            hostName = "docker",
+            host = "10.0.2.2",
+            port = 2222,
+            user = "alex",
+            keyPath = "/keys/a",
+            sessionName = "work",
+            client = FakeTmuxClient(),
+            session = session,
+        )
+        applyParsedPanesForTest(
+            listOf(
+                TmuxSessionViewModel.ParsedPane(
+                    paneId,
+                    "@0",
+                    "$0",
+                    currentCommand,
+                    paneIndex = 0,
+                    cwd = cwd,
+                    currentCommand = currentCommand,
+                    paneTty = paneTty,
+                    panePid = panePid,
+                    sessionName = "work",
+                ),
+            ),
+        )
+        setSessionRefForTest(session)
+    }
+
+    @Test
+    fun issue1603SlowFirstLoadAfterReattachAutoRetriesToReadyInsteadOfFailedDeadEnd() =
+        runTest(scheduler) {
+            // Issue #1603 (reproduce-first). On a just-reattached busy session the
+            // first-paint conversation load races a still-settling transport and
+            // misses the 12 s window. On BASE the watchdog hard-fails the row to
+            // ConversationLoadState.Failed ("Couldn't load this conversation.") — a
+            // dead end the user could only escape by reconnecting. The fix
+            // AUTO-RETRIES the load with a backoff while the transport settles, so
+            // the row stays recoverable (never dead-ends) and loads to Ready with no
+            // manual reconnect.
+            val vm = newVm()
+            vm.setConversationLoadTimeoutForTest(1_000L)
+            val now = System.currentTimeMillis() / 1000
+            val source = "/home/u/.claude/projects/-workspace-proj/live.jsonl"
+            // First attempt: transport still settling — no recorded source / no
+            // transcript candidate resolves yet → detection returns null.
+            val session = FakeSshSession(
+                recordedKindOutput = "claude\n",
+                recordedSourceOutput = "",
+                detectionOutput = "",
+                wcOutput = "1\n",
+                initialEventsOutput =
+                    """{"type":"assistant","uuid":"a1","message":{"role":"assistant","content":"hi"}}""",
+            )
+            vm.connectPaneWithSessionForTest(
+                paneId = "%0",
+                cwd = "/workspace/proj",
+                currentCommand = "node",
+                session = session,
+            )
+            // The user is on the Conversation tab (user-tapped #778 placeholder), so a
+            // transient null keeps the row on "Loading…" + its watchdog.
+            vm.selectSessionTab("%0", SessionTab.Conversation)
+            runCurrent()
+
+            // First (slow) load attempt resolves null WITHOUT advancing past the 1 s
+            // watchdog — runCurrent drains ready work but no virtual time.
+            vm.startAgentDetectionForPaneForTest("%0")
+            runCurrent()
+            assertEquals(
+                "precondition: the first load has not resolved — the row is still Loading",
+                ConversationLoadState.Loading,
+                vm.agentConversations.value["%0"]!!.loadState,
+            )
+
+            // The transport now settles: the recorded source + live transcript become
+            // observable to the NEXT read.
+            session.setRecordedSourceOutput("$source\n")
+            session.setDetectionOutput("claude|$now|/workspace/proj|$source")
+
+            // Cross the first 1 s watchdog window. BASE flips the row to Failed here;
+            // the fix keeps it recoverable (auto-retrying, still Loading).
+            advanceTimeBy(1_100L)
+            runCurrent()
+            assertNotEquals(
+                "#1603: the load must NOT dead-end to Failed on the first missed " +
+                    "window — it must stay recoverable and auto-retry without a " +
+                    "manual reconnect (RED on base: this is Failed)",
+                ConversationLoadState.Failed,
+                vm.agentConversations.value["%0"]!!.loadState,
+            )
+
+            // The auto-retry re-reads the now-settled transport and loads the
+            // conversation to Ready — recovered with no manual reconnect.
+            advanceUntilIdle()
+            assertEquals(
+                "#1603: the conversation recovers to Ready via auto-retry",
+                ConversationLoadState.Ready,
+                vm.agentConversations.value["%0"]!!.loadState,
+            )
+            assertEquals(
+                "the recovered Claude source is bound",
+                source,
+                vm.agentConversations.value["%0"]!!.detection?.sourcePath,
+            )
+        }
+
+    @Test
+    fun issue1603GenuinelyAbsentConversationStillErrorsWithNoLiveSession() =
+        runTest(scheduler) {
+            // Issue #1603 class coverage: a genuinely-absent/unreachable conversation
+            // must STILL surface the clear Failed terminal state — the auto-retry must
+            // not mask a real missing conversation as an infinite spinner. With no live
+            // session the watchdog cannot auto-retry, so it flips to Failed at once.
+            val vm = newVm()
+            vm.setConversationLoadTimeoutForTest(1_000L)
+            vm.attachClientForTest(FakeTmuxClient())
+            vm.applyParsedPanesForTest(
+                listOf(TmuxSessionViewModel.ParsedPane("%0", "@0", "$0", "node", paneIndex = 0)),
+            )
+
+            vm.selectSessionTab("%0", SessionTab.Conversation)
+            runCurrent()
+            assertEquals(
+                ConversationLoadState.Loading,
+                vm.agentConversations.value["%0"]!!.loadState,
+            )
+
+            advanceUntilIdle()
+            assertEquals(
+                "#1603: with no live session to retry against, a never-completing " +
+                    "load still resolves to the clear Failed terminal state — never an " +
+                    "infinite spinner",
+                ConversationLoadState.Failed,
+                vm.agentConversations.value["%0"]!!.loadState,
+            )
+        }
+
+    @Test
+    fun issue1603AutoRetryIsBoundedSoAPerpetuallyUnreachableLoadStillFails() =
+        runTest(scheduler) {
+            // Issue #1603 class coverage: the auto-retry is BOUNDED. Against a live
+            // session whose transport never settles (detection never resolves — the
+            // genuinely-absent / unreachable-log case), the load must NOT spin forever;
+            // after the bounded auto-retries it flips to the clear Failed terminal state.
+            val diagnostics = installRecordingDiagnosticSink()
+            val vm = newVm()
+            vm.setConversationLoadTimeoutForTest(1_000L)
+            // Detection perpetually resolves null (no source, no candidate ever).
+            val session = FakeSshSession(
+                recordedKindOutput = "claude\n",
+                recordedSourceOutput = "",
+                detectionOutput = "",
+            )
+            vm.connectPaneWithSessionForTest(
+                paneId = "%0",
+                cwd = "/workspace/proj",
+                currentCommand = "node",
+                session = session,
+            )
+            vm.selectSessionTab("%0", SessionTab.Conversation)
+            runCurrent()
+            vm.startAgentDetectionForPaneForTest("%0")
+            runCurrent()
+            assertEquals(
+                ConversationLoadState.Loading,
+                vm.agentConversations.value["%0"]!!.loadState,
+            )
+
+            // Drain every watchdog window + backoff. Bounded, so it terminates.
+            advanceUntilIdle()
+            assertEquals(
+                "#1603: a perpetually-unreachable load flips to Failed after the " +
+                    "bounded auto-retries — it does not spin forever",
+                ConversationLoadState.Failed,
+                vm.agentConversations.value["%0"]!!.loadState,
+            )
+            val retries = diagnostics.eventsNamed("tmux_agent_conversation_load_auto_retry")
+            assertTrue(
+                "#1603: the load auto-retried before giving up (recoverable path was " +
+                    "attempted); events=${diagnostics.events.map { it.name }}",
+                retries.isNotEmpty(),
+            )
+            assertTrue(
+                "#1603: the auto-retry count is bounded (<= max); retries=${retries.size}",
+                retries.size in 1..3,
+            )
+        }
+
+    @Test
+    fun issue1603SlowFirstLoadAfterReattachRecoversForCodexSourceToo() =
+        runTest(scheduler) {
+            // Issue #1603 class coverage (Claude vs Codex source): the recovery is
+            // agent-kind-agnostic. Reproduce the slow-first-load-after-reattach for a
+            // CODEX-recorded pane and confirm it likewise stays recoverable (never the
+            // Failed dead-end on the first missed window) and loads via auto-retry.
+            val vm = newVm()
+            vm.setConversationLoadTimeoutForTest(1_000L)
+            val now = System.currentTimeMillis() / 1000
+            val source = "/home/u/.codex/sessions/2026/05/22/rollout-abc.jsonl"
+            // First attempt: transport still settling — no candidate resolves yet.
+            val session = FakeSshSession(
+                recordedKindOutput = "codex\n",
+                recordedSourceOutput = "",
+                detectionOutput = "",
+                wcOutput = "1\n",
+                initialEventsOutput =
+                    """{"type":"message","role":"assistant","content":[{"type":"text","text":"hi"}]}""",
+            )
+            vm.connectPaneWithSessionForTest(
+                paneId = "%0",
+                cwd = "/workspace/proj",
+                currentCommand = "codex",
+                session = session,
+            )
+            vm.selectSessionTab("%0", SessionTab.Conversation)
+            runCurrent()
+
+            vm.startAgentDetectionForPaneForTest("%0")
+            runCurrent()
+            assertEquals(
+                "precondition: the first codex load has not resolved — still Loading",
+                ConversationLoadState.Loading,
+                vm.agentConversations.value["%0"]!!.loadState,
+            )
+
+            // Transport settles: the codex rollout candidate becomes observable.
+            session.setRecordedSourceOutput("$source\n")
+            session.setDetectionOutput("codex|$now|/workspace/proj|$source")
+
+            advanceTimeBy(1_100L)
+            runCurrent()
+            assertNotEquals(
+                "#1603 (Codex): the load must NOT dead-end to Failed on the first " +
+                    "missed window — it stays recoverable and auto-retries",
+                ConversationLoadState.Failed,
+                vm.agentConversations.value["%0"]!!.loadState,
+            )
+
+            advanceUntilIdle()
+            val state = vm.agentConversations.value["%0"]!!
+            assertNotEquals(
+                "#1603 (Codex): the conversation recovers via auto-retry to a " +
+                    "non-Failed terminal state (Ready/Empty), not the dead end",
+                ConversationLoadState.Failed,
+                state.loadState,
+            )
+        }
 }


### PR DESCRIPTION
Closes #1603 (residual from #1562).

The conversation-load watchdog did a single `delay(12s)` → `Failed` with no retry — a dead-end 'Couldn't load this conversation' escapable only by reconnecting. Now: watchdog extracted out of the VM god-object (`TmuxConversationLoadWatchdog`) + a **bounded post-reattach auto-retry** (backoff, re-arm, row stays Loading) so a first read that raced a still-settling transport recovers with no manual reconnect. Bounded by `CONVERSATION_LOAD_MAX_AUTO_RETRIES=3` → a genuinely-absent conversation still terminates to `Failed`. 12s constant unchanged.

## Verification (reviewer APPROVED)
- **G1 red→green**: 3 recovery tests FAIL on base, genuinely-absent control passes; all 4 green with fix.
- **G6 bounded termination (crux)**: proven by code (budget 0→1→2→3→Failed) + a test driving a perpetually-null transport to `Failed` — no infinite spinner.
- **#1517 virtual-clock safety**: full `:app:testDebugUnitTest --rerun-tasks` 3874 tests / 0 failures in 3:30, no hang from the re-arm loop (terminal condition = budget exhaustion).
- **Hygiene/ratchet**: VM shrank (17597 ≤ 17621 lines, bytes down); file-size + VM-ratchet + test-validity all green. Orchestrator re-gate clean.

Non-blocking: on-device real-reconnect conversation-load dogfood glance worth the maintainer's eye (the 12s-boundary state is injected synthetically).