### PR TITLE
diagnostics: classify -CC reconnect exception (zero-leak) for cause-trail (#1610 step 1)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/diagnostics/DiagnosticEventJson.kt
+++ b/app/src/main/java/com/pocketshell/app/diagnostics/DiagnosticEventJson.kt
@@ -98,12 +98,30 @@ internal object DiagnosticEventJson {
 }
 
 internal object DiagnosticRedactor {
-    fun redact(fields: Map<String, Any?>): Map<String, Any?> =
+    /**
+     * [category] is the diagnostic event's category (e.g. `connection`,
+     * `reconnect`). It is threaded through so the connection/reconnect
+     * cause-trail can SURFACE which exception the -CC reader hit — which the
+     * blanket key-based redaction would otherwise drop to `[redacted]`, making a
+     * `reader_exception` teardown undiagnosable (issue #1610). Rather than pass
+     * the raw exception `message` (whose free text could carry a secret a caller
+     * folded in), the surfaced value is a BOUNDED, ALLOWLISTED classification of
+     * the failure shape — see [classifyFailureMessage]. For every other category
+     * the `message` key stays fully redacted exactly as before.
+     */
+    fun redact(fields: Map<String, Any?>, category: String? = null): Map<String, Any?> =
         fields.mapKeys { (key, _) -> sanitizeMetadataKey(key) }
-            .mapValues { (key, value) -> redactValue(key, value) }
+            .mapValues { (key, value) -> redactValue(key, value, category) }
 
-    private fun redactValue(key: String, value: Any?): Any? {
+    private fun redactValue(key: String, value: Any?, category: String?): Any? {
         if (value == null) return null
+        // Surface WHICH exception the -CC reader hit for the connection/reconnect
+        // cause-trail so a `reader_exception` teardown is diagnosable — but as a
+        // fixed classification token, never raw message text, so no secret a
+        // caller folded into the exception message can ever leak (#1610).
+        if (isDiagnosableMessageKey(key, category)) {
+            return classifyFailureMessage(value.toString())
+        }
         if (isSensitiveKey(key) || looksSensitive(value)) return REDACTED
         if (isStableContextKey(key)) return DiagnosticPrivacy.stableFingerprint(value)
         return when (value) {
@@ -113,12 +131,65 @@ internal object DiagnosticRedactor {
             is Collection<*> -> mapOf("count" to value.size)
             is Map<*, *> -> mapOf("count" to value.size)
             is Throwable -> value.javaClass.simpleName
-            else -> value.toString()
-                .replace('\n', ' ')
-                .replace('\r', ' ')
-                .replace('\t', ' ')
-                .filterNot { it.isISOControl() }
-                .take(MAX_VALUE_CHARS)
+            else -> sanitizeFreeText(value.toString())
+        }
+    }
+
+    private fun sanitizeFreeText(text: String): String =
+        text.replace('\n', ' ')
+            .replace('\r', ' ')
+            .replace('\t', ' ')
+            .filterNot { it.isISOControl() }
+            .take(MAX_VALUE_CHARS)
+
+    /**
+     * True only for the exception-message key of a connection/reconnect
+     * cause-trail event. Deliberately narrow: it opens ONLY the message field
+     * and ONLY for the reconnect-diagnosis categories, never `command` /
+     * `prompt` / `body` / `content`, and never for other categories.
+     */
+    private fun isDiagnosableMessageKey(key: String, category: String?): Boolean {
+        val normalisedCategory = category?.lowercase() ?: return false
+        if (normalisedCategory !in DIAGNOSABLE_MESSAGE_CATEGORIES) return false
+        return key.lowercase() in DIAGNOSABLE_MESSAGE_KEYS
+    }
+
+    /**
+     * Maps a connection/reconnect failure message to a BOUNDED, ALLOWLISTED
+     * classification token (#1610). This is deliberately NOT the raw message and
+     * NOT a scrubbed variant of it: the return value is ALWAYS one of the fixed
+     * lowercase `[a-z_]+` tokens below and NEVER a substring of [text]. That
+     * gives a categorical secret-safety guarantee — an `authorization:` header, a
+     * PEM private-key body, a high-entropy token, or any other secret a caller
+     * folded into the exception message can never surface, because no part of
+     * [text] is ever emitted. What the reconnect diagnosis needs (WHICH
+     * SSHException the -CC reader hit — read-timeout vs reset vs EOF vs
+     * channel-closed) is preserved; the risky free text is dropped. An
+     * unrecognised shape collapses to [OTHER_FAILURE].
+     *
+     * This is strictly stronger than the old unconditional `[redacted]` for the
+     * `message` key: it leaks strictly less (a fixed enum, never user data) while
+     * surfacing the failure shape the maintainer needs to root-cause the mobile
+     * -CC teardown.
+     */
+    private fun classifyFailureMessage(text: String): String {
+        val lower = text.lowercase()
+        return when {
+            "broken pipe" in lower -> "broken_pipe"
+            "reset by peer" in lower || "connection reset" in lower -> "connection_reset"
+            "connection refused" in lower -> "connection_refused"
+            "timed out" in lower || "timeout" in lower -> "timeout"
+            "no route to host" in lower -> "no_route_to_host"
+            "network is unreachable" in lower || "network unreachable" in lower -> "network_unreachable"
+            "channel" in lower && ("closed" in lower || "not open" in lower || "eof" in lower) ->
+                "channel_closed"
+            "premature eof" in lower || "unexpected eof" in lower ||
+                "end of file" in lower || "eof" in lower -> "eof"
+            "socket closed" in lower || "connection closed" in lower ||
+                "closed by" in lower || "disconnect" in lower -> "connection_closed"
+            "auth" in lower && "fail" in lower -> "auth_failure"
+            "host key" in lower || "verification failed" in lower -> "host_key_mismatch"
+            else -> OTHER_FAILURE
         }
     }
 
@@ -149,6 +220,22 @@ internal object DiagnosticRedactor {
     private const val MAX_KEY_CHARS = 64
     private const val MAX_VALUE_CHARS = 160
     private const val REDACTED = "[redacted]"
+    private const val OTHER_FAILURE = "other"
+
+    /**
+     * Categories whose exception `message` is surfaced (secret-scrubbed) for
+     * reconnect diagnosis (#1610): the connection lifecycle events and the
+     * [ReconnectCauseTrail]. Everything else keeps `message` fully redacted.
+     */
+    private val DIAGNOSABLE_MESSAGE_CATEGORIES = setOf(
+        "connection",
+        ReconnectCauseTrail.CATEGORY,
+    )
+
+    private val DIAGNOSABLE_MESSAGE_KEYS = setOf(
+        "message",
+        "exceptionmessage",
+    )
 
     private val STABLE_CONTEXT_KEYS = setOf(
         "host",

--- a/app/src/main/java/com/pocketshell/app/diagnostics/DiagnosticRecorder.kt
+++ b/app/src/main/java/com/pocketshell/app/diagnostics/DiagnosticRecorder.kt
@@ -200,7 +200,7 @@ class DiagnosticRecorder @Inject constructor(
             name = event,
             wallClockTime = Instant.now(clock),
             monotonicTimestampNanos = android.os.SystemClock.elapsedRealtimeNanos(),
-            metadata = DiagnosticRedactor.redact(fields),
+            metadata = DiagnosticRedactor.redact(fields, category),
         )
 
     private fun encode(pending: PendingEvent): String =

--- a/app/src/test/java/com/pocketshell/app/diagnostics/DiagnosticLogStoreTest.kt
+++ b/app/src/test/java/com/pocketshell/app/diagnostics/DiagnosticLogStoreTest.kt
@@ -71,6 +71,163 @@ class DiagnosticLogStoreTest {
     }
 
     @Test
+    fun `reconnect cause-trail classifies the reader_exception failure shape so it is diagnosable`() {
+        // Issue #1610: the mobile -CC reader SSHException tears down the shared
+        // lease transport, but the cause-trail dropped `message` to `[redacted]`
+        // so we could not tell WHICH SSHException it was. The reconnect diagnosis
+        // categories must SURFACE a bounded, allowlisted classification of the
+        // failure shape (Option A) — WHICH SSHException — with zero chance of
+        // leaking arbitrary secret text that a caller folded into the message.
+        // RED on base (blanket redaction): `message` came out `[redacted]`.
+        val reconnectFields = DiagnosticRedactor.redact(
+            mapOf(
+                "exceptionClass" to "SSHException",
+                "message" to "SSHException: connection reset by peer",
+                "transportDropSource" to "control_channel",
+                "disconnectSource" to "read_failure",
+            ),
+            category = ReconnectCauseTrail.CATEGORY,
+        )
+        assertEquals("SSHException", reconnectFields["exceptionClass"])
+        // The operator can see it was a connection-reset read failure.
+        assertEquals("connection_reset", reconnectFields["message"])
+
+        // Same surfacing for the `connection` lifecycle category (passive_disconnect):
+        // a broken-pipe read failure classifies as `broken_pipe`.
+        val connectionFields = DiagnosticRedactor.redact(
+            mapOf("message" to "Broken pipe"),
+            category = "connection",
+        )
+        assertEquals("broken_pipe", connectionFields["message"])
+
+        // Class coverage over the reader-teardown failure shapes the -CC channel hits.
+        assertEquals(
+            "eof",
+            DiagnosticRedactor.redact(
+                mapOf("message" to "SSHException: Premature EOF"),
+                category = ReconnectCauseTrail.CATEGORY,
+            )["message"],
+        )
+        assertEquals(
+            "timeout",
+            DiagnosticRedactor.redact(
+                mapOf("message" to "java.net.SocketTimeoutException: Read timed out"),
+                category = ReconnectCauseTrail.CATEGORY,
+            )["message"],
+        )
+        assertEquals(
+            "channel_closed",
+            DiagnosticRedactor.redact(
+                mapOf("message" to "TransportException: Channel closed unexpectedly"),
+                category = ReconnectCauseTrail.CATEGORY,
+            )["message"],
+        )
+        // An unrecognised shape collapses to the safe `other` token — never raw text.
+        assertEquals(
+            "other",
+            DiagnosticRedactor.redact(
+                mapOf("message" to "Some unusual internal state 0xdeadbeef"),
+                category = ReconnectCauseTrail.CATEGORY,
+            )["message"],
+        )
+    }
+
+    @Test
+    fun `surfaced reconnect message never leaks any secret shape and is always an allowlisted token`() {
+        // Issue #1610 load-bearing safety (reviewer round-1 BLOCKING finding): the
+        // round-1 marker-abutment scrubber leaked every secret shape whose token
+        // did not immediately abut one of 6 markers. Option A never emits ANY
+        // substring of the input — the surfaced value is ALWAYS one of a fixed set
+        // of lowercase `[a-z_]+` classification tokens — so NO secret shape can
+        // ever leak. Each pair is (message, the-secret-that-must-not-appear).
+        val tokenPattern = Regex("^[a-z_]+$")
+        val leakingShapes = listOf(
+            // Reviewer-named leak #1: standard HTTP header, SPACE after the colon —
+            // round-1 masked only a token ABUTTING the marker, so this leaked.
+            "authorization: aBcDeF0123456789tokenvalue" to "aBcDeF0123456789tokenvalue",
+            // Reviewer-named leak #2: PEM private-key block body (only `RSA` was
+            // masked by round-1; the base64 body surfaced verbatim).
+            "SSHException while reading -----BEGIN RSA PRIVATE KEY-----\n" +
+                "MIIEowIBAAKCAQEA7Xk2SecretKeyBodyLine1AbCdEf1234567890\n" +
+                "MIIEowIBAAKCAQEA7Xk2SecretKeyBodyLine2GhIjKl0987654321\n" +
+                "-----END RSA PRIVATE KEY-----" to "MIIEowIBAAKCAQEA7Xk2SecretKeyBodyLine1AbCdEf1234567890",
+            // OpenSSH PEM block body.
+            "-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaFNecretOpenSshBody0000\n" +
+                "-----END OPENSSH PRIVATE KEY-----" to "b3BlbnNzaFNecretOpenSshBody0000",
+            // Reviewer-named leak #3: no-marker HIGH-ENTROPY token (round-1 had no
+            // entropy detection anywhere, so it surfaced in full).
+            "connect failure near dGhpc0lzQVZlcnlIaWdoRW50cm9weVNlY3JldFRva2VuMDEyMzQ1Njc4OQ" to
+                "dGhpc0lzQVZlcnlIaWdoRW50cm9weVNlY3JldFRva2VuMDEyMzQ1Njc4OQ",
+            // Bare hex secret, no marker.
+            "state 0a1b2c3d4e5f60718293a4b5c6d7e8f9012345678 dropped" to
+                "0a1b2c3d4e5f60718293a4b5c6d7e8f9012345678",
+            // Original marker shapes (these DID get masked by round-1, kept for coverage).
+            "auth failed password=hunter2secretvalue" to "hunter2secretvalue",
+            "using key sk-live-abc123def456ghi789" to "sk-live-abc123def456ghi789",
+            "token github_pat_ABCDEF1234567890abcdef" to "github_pat_ABCDEF1234567890abcdef",
+            "header bearer AAAAsecretbearervaluebbbb" to "AAAAsecretbearervaluebbbb",
+        )
+
+        for ((message, secret) in leakingShapes) {
+            val surfaced = DiagnosticRedactor.redact(
+                mapOf("message" to message),
+                category = ReconnectCauseTrail.CATEGORY,
+            )["message"] as String
+
+            assertFalse(
+                "secret leaked for message <$message>: surfaced=<$surfaced>",
+                surfaced.contains(secret),
+            )
+            // Strongest guarantee: the output can ONLY be a fixed classification
+            // token. Any raw message text (spaces, digits, uppercase, `:`/`-`) fails
+            // this — so no arbitrary substring of the input can ever surface.
+            assertTrue(
+                "surfaced value is not an allowlisted classification token: <$surfaced>",
+                tokenPattern.matches(surfaced),
+            )
+        }
+    }
+
+    @Test
+    fun `message stays fully redacted outside the reconnect diagnosis categories`() {
+        // Class coverage: the allowlist is narrow. A non-reconnect category (and
+        // the no-category default) keeps `message` fully `[redacted]` — the
+        // surfacing does NOT over-open the redactor everywhere.
+        val actionFields = DiagnosticRedactor.redact(
+            mapOf("message" to "failed with user prompt content"),
+            category = "action",
+        )
+        assertEquals("[redacted]", actionFields["message"])
+
+        val noCategory = DiagnosticRedactor.redact(
+            mapOf("message" to "failed with user prompt content"),
+        )
+        assertEquals("[redacted]", noCategory["message"])
+    }
+
+    @Test
+    fun `reconnect category does not open other sensitive keys`() {
+        // Class coverage: opening `message` for reconnect must NOT open sibling
+        // sensitive keys (password/token/command/prompt) — they stay redacted
+        // even in the reconnect category.
+        val fields = DiagnosticRedactor.redact(
+            mapOf(
+                "message" to "SSHException: timeout",
+                "password" to "hunter2secret",
+                "apiToken" to "sk-live-secret-value",
+                "command" to "cat ~/.ssh/id_rsa",
+                "prompt" to "please run the secret",
+            ),
+            category = ReconnectCauseTrail.CATEGORY,
+        )
+        assertEquals("timeout", fields["message"])
+        assertEquals("[redacted]", fields["password"])
+        assertEquals("[redacted]", fields["apiToken"])
+        assertEquals("[redacted]", fields["command"])
+        assertEquals("[redacted]", fields["prompt"])
+    }
+
+    @Test
     fun `redactor fingerprints shareable host user session and path context`() {
         val fields = DiagnosticRedactor.redact(
             mapOf(

--- a/app/src/test/java/com/pocketshell/app/diagnostics/DiagnosticRecorderTest.kt
+++ b/app/src/test/java/com/pocketshell/app/diagnostics/DiagnosticRecorderTest.kt
@@ -5,6 +5,7 @@ import androidx.test.core.app.ApplicationProvider
 import com.pocketshell.app.settings.SettingsRepository
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -223,6 +224,45 @@ class DiagnosticRecorderTest {
         val events = store.readEvents()
         assertEquals(listOf(3L, 4L, 5L), events.map { it.sequence })
         assertEquals(listOf("tap_3", "tap_4", "tap_5"), events.map { it.name })
+    }
+
+    @Test
+    fun `reconnect cause-trail exposes the reader exception message in the host connection log`() = runTest {
+        // Issue #1610: the real ~/.pocketshell/connection-log.jsonl path. The
+        // mobile -CC reader SSHException fed a `message=[redacted]` line to the
+        // host mirror, so we could not tell WHICH SSHException tore down the
+        // shared lease transport. The reconnect cause-trail must now surface the
+        // exception class + a bounded, allowlisted classification of the failure
+        // shape (Option A) end-to-end through the recorder — with ZERO chance of
+        // leaking arbitrary secret text a caller folded into the message.
+        settingsRepository.setDiagnosticsRecordingEnabled(true)
+        val recorder = DiagnosticRecorder(context, settingsRepository)
+        DiagnosticEvents.install(recorder)
+
+        ReconnectCauseTrail.record(
+            stage = "lease_transport",
+            outcome = "down",
+            cause = "reader_exception",
+            "exceptionClass" to "SSHException",
+            "transportDropSource" to "control_channel",
+            "disconnectSource" to "read_failure",
+            "message" to "SSHException: connection reset by peer (password=hunter2secret)",
+        )
+
+        val jsonl = recorder.connectionLogJsonl()
+        val line = jsonl.split("\n").first { it.isNotBlank() }
+        val metadata = JSONObject(line).getJSONObject("metadata")
+
+        // Surfaced for diagnosis (RED on base: this was "[redacted]").
+        assertEquals("SSHException", metadata.getString("exceptionClass"))
+        // The operator can see it was a connection-reset read failure — WHICH
+        // SSHException — via a fixed classification token, not raw message text.
+        assertEquals("connection_reset", metadata.getString("message"))
+        // Load-bearing safety: the embedded secret never reaches the host log.
+        assertFalse(
+            "secret leaked into the host connection log: $jsonl",
+            jsonl.contains("hunter2secret"),
+        )
     }
 
     @Test


### PR DESCRIPTION
Part of #1610 (mobile ~1/min reconnect — D31 recurrence of #1562). **Diagnostics-only enabling step; does NOT itself fix the reconnect** (Step 2 is the maintainer's rewrite-vs-patch call).

The reconnect cause-trail redacted the -CC control-channel `SSHException` message to `[redacted]`, blocking root-cause. Now the exception is **classified** into a bounded allowlisted `[a-z_]+` token (`broken_pipe`/`connection_reset`/`eof`/`timeout`/`channel_closed`/`other`) — the surfaced value is **never a substring of the input**, a categorical zero-leak guarantee (strictly stronger than the old blanket redaction) while still surfacing WHICH SSHException the reader hit.

## Verification (2 review rounds — round 1 CHANGES REQUESTED for a demonstrated secret leak; round 2 APPROVED)
- **Round-1 scrubber leaked** `authorization: <token>`, PEM key bodies, no-marker high-entropy tokens (reviewer-demonstrated). Round 2 switched to classification.
- **Zero-leak by construction**: every `classifyFailureMessage` arm returns a fixed literal, `else` returns constant `other` — no path echoes input; the leaking scrubber is fully deleted (verified by the re-reviewer from the code).
- **G1 red→green**: leak test (all prior leak shapes, asserts `^[a-z_]+$` + secret-absent) RED on the echoing/scrubber path → GREEN.
- Scope: 4 diagnostics files only, **no connection-logic touched**; non-connection categories + sensitive keys still fully redacted. Hygiene + test-validity green.