### PR TITLE
usage: add reset countdown to notifications (#1618)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/usage/UsageThresholdNotificationE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/usage/UsageThresholdNotificationE2eTest.kt
@@ -169,9 +169,9 @@ class UsageThresholdNotificationE2eTest {
         )
         val text = posted.notification.extras
             .getCharSequence("android.text")?.toString().orEmpty()
-        assertTrue(
-            "usage notification body should prompt the user to open Usage: '$text'",
-            text.contains("Tap to open Usage"),
+        assertEquals(
+            "agent-box · 100% used · resets in 23h · Tue Jun 9, 09:00 · Tap to open Usage.",
+            text,
         )
 
         // Exactly ONE usage-alert notification is live (de-dupe within the feed
@@ -259,6 +259,7 @@ class UsageThresholdNotificationE2eTest {
         settingsRepository = SettingsRepository(context),
         stateStore = store,
         zoneId = { ZoneId.of("UTC") },
+        now = { Instant.parse("2026-06-08T10:00:00Z") },
         // default poster -> UsageNotifications.show(context, event) -> real post
     )
 
@@ -271,7 +272,15 @@ class UsageThresholdNotificationE2eTest {
                 status = UsageStatus.Blocked,
                 rawStatus = "quota_exhausted",
                 blockReason = "codex quota exhausted (weekly window at 80%)",
-                windows = listOf(UsageWindow("7d", 100.0, 100.0, "percent", null)),
+                windows = listOf(
+                    UsageWindow(
+                        "7d",
+                        100.0,
+                        100.0,
+                        "percent",
+                        Instant.parse("2026-06-09T09:00:00Z"),
+                    ),
+                ),
             ),
         ),
         fetchedAt = Instant.parse("2026-06-08T10:00:00Z"),
@@ -332,6 +341,13 @@ class UsageThresholdNotificationE2eTest {
     private fun screenshotNotificationShade() {
         instrumentation.uiAutomation
             .executeShellCommand("cmd statusbar expand-notifications").close()
+        // The AVD preserves the shade's scroll position between expansions.
+        // Pull the list back to its top so the freshly-posted alert (rather
+        // than only the lower "Silent" section) is visible in the artifact.
+        repeat(2) {
+            instrumentation.uiAutomation
+                .executeShellCommand("input swipe 540 700 540 1800 400").close()
+        }
         Thread.sleep(1_500)
         val mediaRoot = testArtifactsRoot(context)
         val artifactsDir = File(mediaRoot, "additional_test_output/usage-notification")

--- a/app/src/main/java/com/pocketshell/app/usage/UsageNotifications.kt
+++ b/app/src/main/java/com/pocketshell/app/usage/UsageNotifications.kt
@@ -15,6 +15,7 @@ import com.pocketshell.app.R
 import com.pocketshell.app.settings.SettingsRepository
 import com.pocketshell.core.usage.UsageProviderRecord
 import com.pocketshell.core.usage.UsageThresholdState
+import java.time.Instant
 import java.time.ZoneId
 
 public interface UsageNotifier {
@@ -30,6 +31,7 @@ public class DefaultUsageNotifier(
     private val settingsRepository: SettingsRepository,
     private val stateStore: UsageNotificationStateStore,
     private val zoneId: () -> ZoneId = { ZoneId.systemDefault() },
+    private val now: () -> Instant = { Instant.now() },
     private val poster: (UsageNotificationEvent) -> Unit = { event ->
         UsageNotifications.show(context.applicationContext, event)
     },
@@ -59,6 +61,7 @@ public class DefaultUsageNotifier(
                             record = record,
                             state = state,
                             warnPercent = warnPercent,
+                            now = now(),
                             zoneId = zoneId(),
                             hostName = snapshot.hostName,
                             hostId = snapshot.hostId,
@@ -103,6 +106,7 @@ internal fun usageNotificationEvent(
     record: UsageProviderRecord,
     state: UsageThresholdState,
     warnPercent: Double,
+    now: Instant = Instant.now(),
     zoneId: ZoneId = ZoneId.systemDefault(),
     hostName: String? = null,
     hostId: Long? = null,
@@ -119,13 +123,17 @@ internal fun usageNotificationEvent(
         UsageThresholdState.Ok ->
             "${record.displayName} usage"
     }
-    // Issue #1441: show an ABSOLUTE reset time, not a relative "resets in Xh Ym"
-    // computed once against `now`. A notification is fire-and-forget — a value
-    // baked in at post time must stay correct as wall-clock time passes, and a
-    // relative countdown drifts wrong (reads "resets in 2h" long after the reset
-    // already happened). The absolute local time never goes stale.
-    val resetText = formatResetAbsolute(record.mostConstrainedWindow?.resetAt, zoneId)
-        ?.let { "resets $it" }
+    // Issue #1618: the maintainer needs both the at-a-glance countdown and the
+    // exact local reset time in the notification. Reuse the same two formatters
+    // as the Usage screen; [now] is captured once when the card is posted so
+    // relative and absolute text describe the same reset instant. Issue #1441's
+    // clearing path still cancels the card as soon as the quota resets.
+    val resetAt = record.mostConstrainedWindow?.resetAt
+    val resetText = resetAt?.let {
+        val relative = formatResetRelative(now, it, zoneId)
+        val absolute = formatResetAbsolute(it, zoneId)
+        "resets $relative · $absolute"
+    }
     val hostText = hostName?.trim()?.takeIf { it.isNotEmpty() }
     val stateText = when (state) {
         UsageThresholdState.Approaching -> "Approaching limit"

--- a/app/src/test/java/com/pocketshell/app/usage/UsageNotificationsTest.kt
+++ b/app/src/test/java/com/pocketshell/app/usage/UsageNotificationsTest.kt
@@ -69,11 +69,15 @@ class UsageNotificationsTest {
             ),
             state = UsageThresholdState.Approaching,
             warnPercent = 80.0,
+            now = Instant.parse("2026-06-08T10:00:00Z"),
             zoneId = ZoneId.of("UTC"),
         )
 
         assertEquals("Codex usage: 86% used", event.title)
-        assertEquals("Approaching limit · resets Mon Jun 8, 12:00 · Tap to open Usage.", event.text)
+        assertEquals(
+            "Approaching limit · resets in 2h · Mon Jun 8, 12:00 · Tap to open Usage.",
+            event.text,
+        )
         assertFalse(event.title.contains("blocked", ignoreCase = true))
         assertFalse(event.text.contains("blocked", ignoreCase = true))
     }
@@ -127,6 +131,7 @@ class UsageNotificationsTest {
             settingsRepository = SettingsRepository(context),
             stateStore = FakeStateStore(),
             zoneId = { ZoneId.of("UTC") },
+            now = { Instant.parse("2026-06-08T10:00:00Z") },
             poster = { events += it },
         )
         val approaching = UsageSnapshot.Records(
@@ -201,6 +206,7 @@ class UsageNotificationsTest {
             settingsRepository = SettingsRepository(context),
             stateStore = FakeStateStore(),
             zoneId = { ZoneId.of("UTC") },
+            now = { Instant.parse("2026-06-08T10:00:00Z") },
             poster = { events += it },
         )
 
@@ -235,18 +241,15 @@ class UsageNotificationsTest {
         )
         assertEquals(
             listOf(
-                "agent-box · Approaching limit · resets Mon Jun 8, 15:00 · Tap to open Usage.",
+                "agent-box · Approaching limit · resets in 5h · Mon Jun 8, 15:00 · Tap to open Usage.",
             ),
             events.map { it.text },
         )
     }
 
     @Test
-    fun notificationUsesAbsoluteResetTimeNotDriftingRelative() {
-        // Issue #1441 (drift): the fire-and-forget notification must bake an
-        // ABSOLUTE reset time, not a "resets in Xh Ym" relative countdown that
-        // goes stale as wall-clock time passes (reads "resets in 2h" hours after
-        // the reset already happened).
+    fun notificationResetCopyIncludesRelativeCountdownAndAbsoluteTime() {
+        val now = Instant.parse("2026-07-15T18:59:00Z")
         val event = usageNotificationEvent(
             record = UsageProviderRecord(
                 provider = "codex",
@@ -258,23 +261,53 @@ class UsageNotificationsTest {
                         86.0,
                         100.0,
                         "percent",
-                        Instant.parse("2026-06-08T12:00:00Z"),
+                        Instant.parse("2026-07-16T17:59:00Z"),
                     ),
                 ),
             ),
             state = UsageThresholdState.Approaching,
             warnPercent = 80.0,
+            now = now,
             zoneId = ZoneId.of("UTC"),
         )
 
-        assertFalse(
-            "reset line must not bake a drifting relative time: ${event.text}",
-            event.text.contains("resets in"),
+        assertEquals(
+            "Approaching limit · resets in 23h · Thu Jul 16, 17:59 · Tap to open Usage.",
+            event.text,
         )
-        assertTrue(
-            "reset line must show an absolute (non-drifting) time: ${event.text}",
-            event.text.contains("resets Mon Jun 8, 12:00"),
+    }
+
+    @Test
+    fun notificationResetCountdownCoversMinuteHourDayBoundariesFromFixedNow() {
+        val now = Instant.parse("2026-07-15T12:00:00Z")
+        val cases = listOf(
+            Instant.parse("2026-07-15T12:30:00Z") to "in 30m",
+            Instant.parse("2026-07-15T17:45:00Z") to "in 5h 45m",
+            Instant.parse("2026-07-16T12:00:00Z") to "in 1 day",
+            Instant.parse("2026-07-18T12:00:00Z") to "in 3 days",
         )
+
+        cases.forEach { (resetAt, expectedRelative) ->
+            val event = notificationEventForProvider("codex", now, resetAt)
+            assertTrue(
+                "expected '$expectedRelative' in notification body '${event.text}'",
+                event.text.contains("resets $expectedRelative · "),
+            )
+        }
+    }
+
+    @Test
+    fun codexClaudeAndCopilotNotificationsUseTheSameRelativeAndAbsoluteResetCopy() {
+        val now = Instant.parse("2026-07-15T12:00:00Z")
+        val resetAt = Instant.parse("2026-07-16T12:00:00Z")
+
+        listOf("codex", "claude", "copilot").forEach { provider ->
+            val event = notificationEventForProvider(provider, now, resetAt)
+            assertTrue(
+                "$provider notification must use shared relative + absolute copy: ${event.text}",
+                event.text.contains("resets in 1 day · Thu Jul 16, 12:00"),
+            )
+        }
     }
 
     @Test
@@ -489,6 +522,7 @@ class UsageNotificationsTest {
         settingsRepository = SettingsRepository(context),
         stateStore = store,
         zoneId = { ZoneId.of("UTC") },
+        now = { Instant.parse("2026-06-08T10:00:00Z") },
         poster = poster,
         canceller = { cancelled += it },
     )
@@ -525,5 +559,22 @@ class UsageNotificationsTest {
         ),
         fetchedAt = Instant.parse("2026-06-08T10:00:00Z"),
         command = UsageRemoteSource.defaultUsageCommand,
+    )
+
+    private fun notificationEventForProvider(
+        provider: String,
+        now: Instant,
+        resetAt: Instant,
+    ): UsageNotificationEvent = usageNotificationEvent(
+        record = UsageProviderRecord(
+            provider = provider,
+            status = UsageStatus.Ok,
+            rawStatus = "ok",
+            windows = listOf(UsageWindow("7d", 86.0, 100.0, "percent", resetAt)),
+        ),
+        state = UsageThresholdState.Approaching,
+        warnPercent = 80.0,
+        now = now,
+        zoneId = ZoneId.of("UTC"),
     )
 }

--- a/scripts/check-ci-journey-harness.sh
+++ b/scripts/check-ci-journey-harness.sh
@@ -175,7 +175,6 @@ KNOWN_UNWIRED_ANDROID_E2E_DOCKER_CLASSES=(
   "com.pocketshell.app.tmux.TmuxSessionOpencodeInputDockerTest"
   "com.pocketshell.app.tmux.TmuxShellComposerOcclusionE2eTest"
   "com.pocketshell.app.usage.UsageScreenE2eTest"
-  "com.pocketshell.app.usage.UsageThresholdNotificationE2eTest"
 )
 
 in_list() {

--- a/scripts/check-test-validity.sh
+++ b/scripts/check-test-validity.sh
@@ -344,7 +344,6 @@ J1_UNWIRED_ANDROID_E2E_DOCKER_BASELINE=(
   "com.pocketshell.app.tmux.TmuxSessionOpencodeInputDockerTest"
   "com.pocketshell.app.tmux.TmuxShellComposerOcclusionE2eTest"
   "com.pocketshell.app.usage.UsageScreenE2eTest"
-  "com.pocketshell.app.usage.UsageThresholdNotificationE2eTest"
 )
 
 # --------------------------------------------------------------------------

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -267,6 +267,7 @@ JOURNEY_CLASSES=(
   "com.pocketshell.app.env.EnvScreenE2eTest"  # #1094 #1092 durability for ): the env edit/add on-device journeys. The
   "com.pocketshell.app.tmux.TmuxResizeSessionE2eTest#cachedSizeReplayRestoresFullWindowAndAgentPaneIsNotCut"  # #1169 #285 Codex/agent pane rendered CUT: tmux window resized too small
   "com.pocketshell.app.usage.UsageGlancePillE2eTest"  # #1241 #418 the landing app-bar usage GLANCE PILL on-device proof. The
+  "com.pocketshell.app.usage.UsageThresholdNotificationE2eTest"  # #1618 both relative countdown + absolute reset time reach the real status-bar notification
   "com.pocketshell.app.usage.Usage1318StrictSchemaRenderE2eTest"  # #1318 on-device render acceptance for the quse-v0.0.9 strict-schem…
 )
 


### PR DESCRIPTION
Reuse the existing relative and absolute reset formatters so quota notifications show both forms. Wire the real notification journey into the CI suite and cover deterministic boundaries plus provider parity.\n\nCloses #1618
