### PR TITLE
Fix long-draft composer caret visibility (#1619)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerLongDraftCaretVisibleTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerLongDraftCaretVisibleTest.kt
@@ -1,22 +1,37 @@
 package com.pocketshell.app.composer
 
+import android.graphics.Bitmap
+import android.os.SystemClock
 import androidx.activity.ComponentActivity
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.unit.dp
+import androidx.core.graphics.Insets
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
@@ -24,14 +39,19 @@ import androidx.core.view.WindowInsetsControllerCompat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.pocketshell.app.di.WhisperClientFactory
+import com.pocketshell.app.proof.signals.assertNodeFullyAboveImeOrKeyboard
+import com.pocketshell.app.proof.signals.assertNodeFullyWithinRoot
 import com.pocketshell.app.proof.signals.waitForInputMethodVisible
 import com.pocketshell.core.voice.WhisperClient
+import com.pocketshell.app.test.testArtifactsRoot
 import com.pocketshell.uikit.theme.PocketShellColors
 import com.pocketshell.uikit.theme.PocketShellTheme
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.io.File
+import java.io.FileOutputStream
 
 /**
  * Issue #765 — long-draft caret cut-off with the keyboard up.
@@ -76,6 +96,8 @@ class PromptComposerLongDraftCaretVisibleTest {
     @get:Rule
     val compose = createAndroidComposeRule<ComponentActivity>()
 
+    private val observedImeBottomPx = mutableStateOf(0)
+
     private class TestMicCapture : PromptComposerViewModel.MicCapture {
         override fun start() {}
         override fun stop(): ByteArray = ByteArray(0)
@@ -105,6 +127,131 @@ class PromptComposerLongDraftCaretVisibleTest {
         apiKeyStorage = TestVault(),
         voiceSettings = TestVoiceSettings(),
     )
+
+    @Test
+    fun syntheticImeLongDraftOwnsContainedCaretViewportAboveStickyControls() {
+        compose.activityRule.scenario.onActivity { activity ->
+            WindowCompat.setDecorFitsSystemWindows(activity.window, false)
+        }
+
+        val longDraft = (1..18).joinToString("\n") {
+            "line $it of the long prompt; sentinel caret remains visible"
+        }
+        compose.setContent {
+            PocketShellTheme {
+                val density = LocalDensity.current
+                observedImeBottomPx.value = WindowInsets.ime.getBottom(density)
+                Box(
+                    modifier = Modifier
+                        .width(SYNTHETIC_HOST_WIDTH_DP.dp)
+                        .height(SYNTHETIC_HOST_HEIGHT_DP.dp)
+                        .background(PocketShellColors.Background)
+                        .testTag(SYNTHETIC_HOST_TAG),
+                ) {
+                    SheetContent(
+                        state = PromptComposerViewModel.UiState(
+                            draft = longDraft,
+                            recording = PromptComposerViewModel.RecordingState.Idle,
+                            connectionDegraded = true,
+                        ),
+                        onClose = {},
+                        onDraftChange = {},
+                        onMicTap = {},
+                        onSend = {},
+                        onAttachFiles = {},
+                    )
+                }
+            }
+        }
+        compose.waitForIdle()
+
+        applySyntheticInsets(
+            imeBottomPx = (SYNTHETIC_IME_HEIGHT_DP * displayDensity()).toInt(),
+            navBarBottomPx = 0,
+            statusBarTopPx = (SYNTHETIC_STATUS_BAR_DP * displayDensity()).toInt(),
+        )
+        compose.waitForIdle()
+
+        assertTrue(
+            "Synthetic ime() inset must reach Compose; keyboard-down would be vacuous. " +
+                "observedImeBottomPx=${observedImeBottomPx.value}",
+            observedImeBottomPx.value > 0,
+        )
+
+        val hostBounds = compose.onNodeWithTag(SYNTHETIC_HOST_TAG, useUnmergedTree = true)
+            .fetchSemanticsNode().boundsInRoot
+        val viewportInteraction = compose.onNodeWithTag(
+            COMPOSER_DRAFT_VIEWPORT_TAG,
+            useUnmergedTree = true,
+        )
+        val viewportBounds = viewportInteraction.getUnclippedBoundsInRoot()
+        val draftInteraction = compose.onNodeWithTag(COMPOSER_DRAFT_TAG, useUnmergedTree = true)
+        val draftNode = draftInteraction.fetchSemanticsNode()
+        val draftBounds = draftInteraction.getUnclippedBoundsInRoot()
+        val sendBounds = compose.onNodeWithTag(COMPOSER_SEND_ENTER_TAG, useUnmergedTree = true)
+            .getUnclippedBoundsInRoot()
+        val attachBounds = compose.onNodeWithTag(COMPOSER_ATTACH_TAG, useUnmergedTree = true)
+            .fetchSemanticsNode().boundsInRoot
+        val micBounds = compose.onNodeWithTag(COMPOSER_MIC_TAG, useUnmergedTree = true)
+            .fetchSemanticsNode().boundsInRoot
+        val bannerBounds = compose.onNodeWithTag(
+            COMPOSER_CONNECTION_LOST_TAG,
+            useUnmergedTree = true,
+        ).getUnclippedBoundsInRoot()
+
+        val layouts = mutableListOf<TextLayoutResult>()
+        val getLayout = draftNode.config.getOrNull(SemanticsActions.GetTextLayoutResult)
+        assertTrue("Draft editor must expose its real text layout.", getLayout != null)
+        getLayout!!.action!!.invoke(layouts)
+        val layout = layouts.single()
+        val caretRect = layout.getCursorRect(longDraft.length)
+        val density = displayDensity()
+        val draftHeightPx = (draftBounds.bottom - draftBounds.top).value * density
+
+        println(
+            "ISSUE1619_SYNTHETIC host=$hostBounds viewport=$viewportBounds " +
+                "draft=$draftBounds status=$bannerBounds send=$sendBounds attach=$attachBounds " +
+                "mic=$micBounds textHeight=${layout.size.height} draftHeightPx=$draftHeightPx " +
+                "caret=$caretRect density=$density",
+        )
+
+        assertTrue(
+            "Long text must overflow the effective editor viewport so caret-follow is exercised. " +
+                "textHeight=${layout.size.height} viewportHeight=$draftHeightPx",
+            layout.size.height > draftHeightPx + 1f,
+        )
+        assertTrue(
+            "The draft field must be fully contained by its dedicated viewport; an editor " +
+                "clipped by a smaller outer scroll cannot make its caret reliably visible. " +
+                "draft=$draftBounds viewport=$viewportBounds",
+            draftBounds.top >= viewportBounds.top - 1.dp &&
+                draftBounds.bottom <= viewportBounds.bottom + 1.dp,
+        )
+        assertTrue(
+            "Status content belongs above the editor. statusBottom=${bannerBounds.bottom} " +
+                "draftTop=${draftBounds.top}",
+            bannerBounds.bottom <= draftBounds.top + 1.dp,
+        )
+        assertTrue(
+            "The draft must retain one complete editable line. caretHeight=${caretRect.height} " +
+                "draftHeight=$draftHeightPx",
+            caretRect.height <= draftHeightPx + 1f,
+        )
+        assertTrue(
+            "Draft must end above sticky controls. draftBottom=${draftBounds.bottom} " +
+                "sendTop=${sendBounds.top}",
+            draftBounds.bottom <= sendBounds.top + 1.dp,
+        )
+        compose.assertNodeFullyWithinRoot(COMPOSER_DRAFT_TAG, useUnmergedTree = true)
+        listOf(COMPOSER_DRAFT_TAG, COMPOSER_SEND_ENTER_TAG, COMPOSER_ATTACH_TAG, COMPOSER_MIC_TAG)
+            .forEach { tag ->
+                compose.assertNodeFullyAboveImeOrKeyboard(
+                    tag,
+                    keyboardTopPx = hostBounds.bottom,
+                    useUnmergedTree = true,
+                )
+            }
+    }
 
     @Test
     fun caretStaysVisibleWhenTypingLongDraftWithImeUp() {
@@ -156,6 +303,11 @@ class PromptComposerLongDraftCaretVisibleTest {
         InstrumentationRegistry.getInstrumentation().waitForIdleSync()
         android.os.SystemClock.sleep(500)
         compose.waitForIdle()
+
+        val screenshotName = InstrumentationRegistry.getArguments()
+            .getString("issue1619ScreenshotName")
+            ?: "issue-1619-green-long-draft-caret-visible-keyboard-up.png"
+        captureFullDevice(screenshotName)
 
         // Optional hold BEFORE the assertions so a host-side full-device
         // screenshot can capture the keyboard-up composer state even on a base
@@ -238,14 +390,16 @@ class PromptComposerLongDraftCaretVisibleTest {
             caretHeightPx <= viewportHeightPx + 1f,
         )
 
-        // 3) The draft field is not squished: it keeps a healthy multi-line
-        //    height (well above a single line) so several lines around the caret
-        //    are visible.
+        // 3) The real-IME field keeps at least three complete caret lines. The
+        //    #1619 layout deliberately bounds the editor to the ACTUAL remaining
+        //    room (rather than preserving the old arbitrary 80dp floor), so use
+        //    the measured line height as the device/font-scale invariant.
         val draftHeightDp = viewportHeightPx / density
         assertTrue(
-            "Draft field collapsed below a usable multi-line height (squish). " +
+            "Draft field must retain at least three complete caret lines. " +
+                "draftHeightPx=$viewportHeightPx caretHeightPx=$caretHeightPx " +
                 "draftHeightDp=$draftHeightDp",
-            draftHeightDp >= 80f,
+            viewportHeightPx >= caretHeightPx * 3f,
         )
 
         // 4) The field's visible bottom sits ABOVE the controls row, which sits
@@ -260,6 +414,114 @@ class PromptComposerLongDraftCaretVisibleTest {
             "Send controls must stay above the IME. sendBottom=${sendBounds.bottom} " +
                 "imeTop=$imeTop",
             sendBounds.bottom <= imeTop + 2f,
+        )
+    }
+
+    @Test
+    fun offlineBannerStaysAboveLongDraftWithRealImeUp() {
+        val vm = newViewModel()
+        compose.activityRule.scenario.onActivity { activity ->
+            WindowCompat.setDecorFitsSystemWindows(activity.window, false)
+        }
+
+        compose.setContent {
+            PocketShellTheme {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(PocketShellColors.Background),
+                    contentAlignment = Alignment.TopCenter,
+                ) {
+                    FauxTerminalBackdrop()
+                    PromptComposerSheet(
+                        onDismiss = {},
+                        onSend = { _ -> true },
+                        connectionLost = true,
+                        viewModel = vm,
+                    )
+                }
+            }
+        }
+        compose.waitForIdle()
+
+        val longDraft = (1..18).joinToString("\n") {
+            "offline line $it; the reconnect queue keeps this caret visible"
+        }
+        compose.onNodeWithTag(COMPOSER_DRAFT_TAG, useUnmergedTree = true)
+            .performClick()
+            .performTextInput(longDraft)
+        assertTrue(
+            "Real IME is required for the offline keyboard-up proof.",
+            raiseSoftImeDeterministically(timeoutMs = 30_000L),
+        )
+        compose.waitUntil(timeoutMillis = 5_000) { readImeBottomPx() > 0 }
+        compose.waitForIdle()
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        SystemClock.sleep(500)
+        compose.waitForIdle()
+
+        compose.onNodeWithText(OFFLINE_COPY, useUnmergedTree = true).assertExists()
+        captureFullDevice("issue-1619-green-offline-banner-above-long-draft-keyboard-up.png")
+
+        val statusBounds = compose.onNodeWithTag(
+            COMPOSER_STATUS_VIEWPORT_TAG,
+            useUnmergedTree = true,
+        ).getUnclippedBoundsInRoot()
+        val bannerBounds = compose.onNodeWithTag(
+            COMPOSER_CONNECTION_LOST_TAG,
+            useUnmergedTree = true,
+        ).getUnclippedBoundsInRoot()
+        val draftViewportBounds = compose.onNodeWithTag(
+            COMPOSER_DRAFT_VIEWPORT_TAG,
+            useUnmergedTree = true,
+        ).getUnclippedBoundsInRoot()
+        val draftInteraction = compose.onNodeWithTag(COMPOSER_DRAFT_TAG, useUnmergedTree = true)
+            .assertIsDisplayed()
+        val draftNode = draftInteraction.fetchSemanticsNode()
+        val draftBounds = draftInteraction.getUnclippedBoundsInRoot()
+        val sendBounds = compose.onNodeWithTag(COMPOSER_SEND_ENTER_TAG, useUnmergedTree = true)
+            .getUnclippedBoundsInRoot()
+        val layouts = mutableListOf<TextLayoutResult>()
+        val getLayout = draftNode.config.getOrNull(SemanticsActions.GetTextLayoutResult)
+        assertTrue("Offline draft must expose its real text layout.", getLayout != null)
+        getLayout!!.action!!.invoke(layouts)
+        val layout = layouts.single()
+        val caretRect = layout.getCursorRect(longDraft.length)
+        val density = displayDensity()
+        val draftHeightPx = (draftBounds.bottom - draftBounds.top).value * density
+        val imeTop = readDecorHeightPx() - readImeBottomPx()
+
+        println(
+            "ISSUE1619_REAL_OFFLINE status=$statusBounds banner=$bannerBounds " +
+                "draftViewport=$draftViewportBounds draft=$draftBounds send=$sendBounds " +
+                "textHeight=${layout.size.height} caret=$caretRect imeTop=$imeTop",
+        )
+        assertTrue(
+            "Offline banner must be fully contained in its bounded status viewport. " +
+                "banner=$bannerBounds status=$statusBounds",
+            bannerBounds.top >= statusBounds.top - 1.dp &&
+                bannerBounds.bottom <= statusBounds.bottom + 1.dp,
+        )
+        assertTrue(
+            "Offline banner/status must remain above the long draft. " +
+                "bannerBottom=${bannerBounds.bottom} draftTop=${draftViewportBounds.top}",
+            bannerBounds.bottom <= draftViewportBounds.top + 1.dp,
+        )
+        assertTrue(
+            "Real offline text must overflow the editor so caret-follow is exercised.",
+            layout.size.height > draftHeightPx + 1f,
+        )
+        assertTrue(
+            "Real offline draft must retain one complete caret line.",
+            caretRect.height <= draftHeightPx + 1f,
+        )
+        assertTrue(
+            "Offline draft must end above sticky controls.",
+            draftBounds.bottom <= sendBounds.top + 1.dp,
+        )
+        assertTrue(
+            "Offline controls must remain above the real IME.",
+            sendBounds.bottom.value * density <= imeTop + 2f,
         )
     }
 
@@ -327,5 +589,68 @@ class PromptComposerLongDraftCaretVisibleTest {
             result = activity.window.decorView.height
         }
         return result
+    }
+
+    private fun applySyntheticInsets(
+        imeBottomPx: Int,
+        navBarBottomPx: Int,
+        statusBarTopPx: Int,
+    ) {
+        compose.activityRule.scenario.onActivity { activity ->
+            val insets = WindowInsetsCompat.Builder()
+                .setInsets(WindowInsetsCompat.Type.ime(), Insets.of(0, 0, 0, imeBottomPx))
+                .setInsets(
+                    WindowInsetsCompat.Type.navigationBars(),
+                    Insets.of(0, 0, 0, navBarBottomPx),
+                )
+                .setInsets(
+                    WindowInsetsCompat.Type.statusBars(),
+                    Insets.of(0, statusBarTopPx, 0, 0),
+                )
+                .setInsets(
+                    WindowInsetsCompat.Type.systemBars(),
+                    Insets.of(0, statusBarTopPx, 0, navBarBottomPx),
+                )
+                .build()
+            ViewCompat.dispatchApplyWindowInsets(activity.window.decorView, insets)
+        }
+    }
+
+    private fun displayDensity(): Float =
+        InstrumentationRegistry.getInstrumentation()
+            .targetContext.resources.displayMetrics.density
+
+    private fun captureFullDevice(name: String) {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.waitForIdleSync()
+        SystemClock.sleep(200)
+        val bitmap: Bitmap = checkNotNull(instrumentation.uiAutomation.takeScreenshot()) {
+            "Could not capture issue #1619 full-device screenshot"
+        }
+        val dir = File(
+            testArtifactsRoot(instrumentation.targetContext),
+            "additional_test_output/issue-1619-composer",
+        )
+        check(dir.exists() || dir.mkdirs()) { "Could not create ${dir.absolutePath}" }
+        val file = File(dir, name)
+        try {
+            FileOutputStream(file).use { output ->
+                check(bitmap.compress(Bitmap.CompressFormat.PNG, 100, output)) {
+                    "Could not write ${file.absolutePath}"
+                }
+            }
+            println("ISSUE1619_SCREENSHOT ${file.absolutePath}")
+        } finally {
+            bitmap.recycle()
+        }
+    }
+
+    private companion object {
+        const val SYNTHETIC_HOST_TAG = "issue1619-long-draft-host"
+        const val SYNTHETIC_HOST_WIDTH_DP = 360f
+        const val SYNTHETIC_HOST_HEIGHT_DP = 470f
+        const val SYNTHETIC_IME_HEIGHT_DP = 295f
+        const val SYNTHETIC_STATUS_BAR_DP = 52f
+        const val OFFLINE_COPY = "Offline — prompts will be queued and sent on reconnect."
     }
 }

--- a/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerOfflineComposeUsableProofTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerOfflineComposeUsableProofTest.kt
@@ -1,5 +1,6 @@
 package com.pocketshell.app.composer
 
+import android.graphics.Color as AndroidColor
 import androidx.activity.ComponentActivity
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -17,8 +18,18 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.graphics.asAndroidBitmap
+import androidx.compose.ui.graphics.compositeOver
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.unit.dp
 import androidx.core.graphics.Insets
 import androidx.core.view.ViewCompat
@@ -37,8 +48,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 /**
- * Issue #1613 — "when there's no connection I can't type anything" (reproduce-
- * first, D33 / G10).
+ * Issue #1613/#1619 — offline composing and bounded status-stack geometry.
  *
  * ## The blocker this proof pins
  *
@@ -62,13 +72,10 @@ import org.junit.runner.RunWith
  *
  * ## What this proof asserts (the reachability `performTextInput` does NOT)
  *
- * With the EMPTY draft the maintainer had (about to type), the offline banner
- * showing, and a synthetic keyboard up on the measured resized-sheet host, the
- * draft field must keep a USABLE height (not the sub-line crush) AND be fully
- * within the host AND above the keyboard — containment (#657 / F1), never a bare
- * `assertIsDisplayed()`. Both a SHELL pane (`agentKind = null`) and an AGENT pane
- * (`agentKind = ClaudeCode`) are exercised (G2 class coverage). On base the draft
- * crushes below [MIN_DRAFT_HEIGHT_DP] (RED); the #1613 fix keeps it usable (GREEN).
+ * With an overflowing long draft, the standalone offline banner, and a synthetic
+ * keyboard up on the measured resized-sheet host, the draft must retain a complete
+ * caret line while the Amber status stays fully above it. A separate multi-status
+ * case proves the status region scrolls within its 48dp cap instead of expanding.
  *
  * ## Determinism (#780 model — no real keyboard, no `assumeTrue`)
  *
@@ -88,29 +95,34 @@ class PromptComposerOfflineComposeUsableProofTest {
     private val observedStatusTopPx = mutableStateOf(0)
 
     /**
-     * The maintainer's reported state: EMPTY draft (about to type), the link down
-     * ([connectionDegraded] = true) and NO queued outbound item — the exact
-     * condition under which the standalone "Connection lost — Send will retry once
-     * reconnected." banner renders (it is suppressed once a queue banner exists).
+     * The link is down with no queued outbound item — the exact condition under
+     * which the standalone offline banner renders (it is suppressed once a queue
+     * banner exists). The long draft makes native caret-follow load-bearing.
      */
-    private fun offlineEmptyDraftState(): PromptComposerViewModel.UiState =
+    private fun offlineLongDraftState(multiStatus: Boolean): PromptComposerViewModel.UiState =
         PromptComposerViewModel.UiState(
-            draft = "",
+            draft = LONG_DRAFT,
             recording = PromptComposerViewModel.RecordingState.Idle,
             connectionDegraded = true,
+            error = if (multiStatus) "Not sent. Keep editing or discard the draft." else null,
         )
 
     @Test
     fun shellPaneComposerTypableWhileOfflineWithKeyboardUp() {
-        runOfflineComposeProof(agentKind = null)
+        runOfflineComposeProof(agentKind = null, multiStatus = false)
     }
 
     @Test
     fun agentPaneComposerTypableWhileOfflineWithKeyboardUp() {
-        runOfflineComposeProof(agentKind = AgentKind.ClaudeCode)
+        runOfflineComposeProof(agentKind = AgentKind.ClaudeCode, multiStatus = false)
     }
 
-    private fun runOfflineComposeProof(agentKind: AgentKind?) {
+    @Test
+    fun multipleStatusesScrollWithoutTakingDraftCaretLine() {
+        runOfflineComposeProof(agentKind = null, multiStatus = true)
+    }
+
+    private fun runOfflineComposeProof(agentKind: AgentKind?, multiStatus: Boolean) {
         compose.activityRule.scenario.onActivity { activity ->
             WindowCompat.setDecorFitsSystemWindows(activity.window, false)
         }
@@ -142,7 +154,7 @@ class PromptComposerOfflineComposeUsableProofTest {
                         contentAlignment = Alignment.TopCenter,
                     ) {
                         SheetContent(
-                            state = offlineEmptyDraftState(),
+                            state = offlineLongDraftState(multiStatus),
                             onClose = {},
                             onDraftChange = {},
                             onMicTap = {},
@@ -181,6 +193,26 @@ class PromptComposerOfflineComposeUsableProofTest {
         // meaningless.
         compose.onNodeWithTag(COMPOSER_CONNECTION_LOST_TAG, useUnmergedTree = true)
             .fetchSemanticsNode()
+        compose.onNodeWithText(OFFLINE_COPY, useUnmergedTree = true).assertExists()
+
+        if (multiStatus) {
+            val initialStatus = compose.onNodeWithTag(
+                COMPOSER_STATUS_VIEWPORT_TAG,
+                useUnmergedTree = true,
+            ).getUnclippedBoundsInRoot()
+            val initialBanner = compose.onNodeWithTag(
+                COMPOSER_CONNECTION_LOST_TAG,
+                useUnmergedTree = true,
+            ).getUnclippedBoundsInRoot()
+            assertTrue(
+                "Multi-status proof must begin with offline below the bounded viewport, " +
+                    "making scroll load-bearing. banner=$initialBanner status=$initialStatus",
+                initialBanner.bottom > initialStatus.bottom + 1.dp,
+            )
+            compose.onNodeWithTag(COMPOSER_CONNECTION_LOST_TAG, useUnmergedTree = true)
+                .performScrollTo()
+            compose.waitForIdle()
+        }
 
         val hostBounds = compose.onNodeWithTag(HOST_TAG, useUnmergedTree = true)
             .fetchSemanticsNode().boundsInRoot
@@ -190,6 +222,27 @@ class PromptComposerOfflineComposeUsableProofTest {
             .fetchSemanticsNode().boundsInRoot
         val bannerBounds = compose.onNodeWithTag(COMPOSER_CONNECTION_LOST_TAG, useUnmergedTree = true)
             .fetchSemanticsNode().boundsInRoot
+        val statusViewportBounds = compose.onNodeWithTag(
+            COMPOSER_STATUS_VIEWPORT_TAG,
+            useUnmergedTree = true,
+        ).getUnclippedBoundsInRoot()
+        val draftViewportBounds = compose.onNodeWithTag(
+            COMPOSER_DRAFT_VIEWPORT_TAG,
+            useUnmergedTree = true,
+        ).getUnclippedBoundsInRoot()
+        val bannerUnclippedBounds = compose.onNodeWithTag(
+            COMPOSER_CONNECTION_LOST_TAG,
+            useUnmergedTree = true,
+        ).getUnclippedBoundsInRoot()
+
+        val draftNode = compose.onNodeWithTag(COMPOSER_DRAFT_TAG, useUnmergedTree = true)
+            .fetchSemanticsNode()
+        val layouts = mutableListOf<TextLayoutResult>()
+        val getLayout = draftNode.config.getOrNull(SemanticsActions.GetTextLayoutResult)
+        assertTrue("Offline draft must expose its real text layout.", getLayout != null)
+        getLayout!!.action!!.invoke(layouts)
+        val layout = layouts.single()
+        val caretRect = layout.getCursorRect(LONG_DRAFT.length)
 
         val keyboardTopPx = hostBounds.bottom
         val draftHeightDp = draftBounds.height / density
@@ -199,6 +252,7 @@ class PromptComposerOfflineComposeUsableProofTest {
                 "draftTop=${draftBounds.top} draftBottom=${draftBounds.bottom} " +
                 "bannerTop=${bannerBounds.top} " +
                 "bannerHeightDp=${bannerBounds.height / density} " +
+                "statusViewport=$statusViewportBounds draftViewport=$draftViewportBounds " +
                 "sendBottom=${sendBounds.bottom} keyboardTopPx=$keyboardTopPx " +
                 "hostHeightDp=${(hostBounds.bottom - hostBounds.top) / density} density=$density",
         )
@@ -213,12 +267,32 @@ class PromptComposerOfflineComposeUsableProofTest {
         // the scroll region below the field, so the draft keeps its 24dp editor line
         // (GREEN). This is the assertion that is RED on base / GREEN on the fix.
         assertTrue(
-            "Draft editor crushed below one text line while offline + keyboard up " +
-                "(the #1613 blocker — the field is an unusable sliver, 'I can't type " +
-                "anything'). draftHeightDp=$draftHeightDp minDp=$MIN_DRAFT_HEIGHT_DP " +
-                "(draftTop=${draftBounds.top} draftBottom=${draftBounds.bottom})",
-            draftHeightDp >= MIN_DRAFT_HEIGHT_DP,
+            "Offline long text must overflow the editor so native caret-follow is exercised. " +
+                "textHeight=${layout.size.height} draftHeight=${draftBounds.height}",
+            layout.size.height > draftBounds.height + 1f,
         )
+        assertTrue(
+            "Offline draft must retain one complete editable caret line. " +
+                "caretHeight=${caretRect.height} draftHeight=${draftBounds.height}",
+            caretRect.height <= draftBounds.height + 1f,
+        )
+        assertTrue(
+            "Offline banner must be fully contained in the bounded status viewport. " +
+                "banner=$bannerUnclippedBounds status=$statusViewportBounds",
+            bannerUnclippedBounds.top >= statusViewportBounds.top - 1.dp &&
+                bannerUnclippedBounds.bottom <= statusViewportBounds.bottom + 1.dp,
+        )
+        assertTrue(
+            "Keyboard-up status region must remain capped at 48dp. status=$statusViewportBounds",
+            statusViewportBounds.bottom - statusViewportBounds.top <= 48.dp + 1.dp,
+        )
+        assertTrue(
+            "Offline banner/status must stay above the long draft. " +
+                "bannerBottom=${bannerUnclippedBounds.bottom} draftTop=${draftViewportBounds.top}",
+            bannerUnclippedBounds.bottom <= draftViewportBounds.top + 1.dp,
+        )
+
+        assertAmberBannerPixel()
 
         // CONTAINMENT (#657 / F1): the draft the user must type into, and the Send
         // that queues it, must be fully within the host AND above the keyboard — the
@@ -269,6 +343,38 @@ class PromptComposerOfflineComposeUsableProofTest {
         InstrumentationRegistry.getInstrumentation()
             .targetContext.resources.displayMetrics.density
 
+    private fun assertAmberBannerPixel() {
+        val bitmap = compose.onNodeWithTag(
+            COMPOSER_CONNECTION_LOST_TAG,
+            useUnmergedTree = true,
+        ).captureToImage().asAndroidBitmap()
+        try {
+            val insetPx = (6f * displayDensity()).toInt().coerceAtLeast(1)
+            val actual = bitmap.getPixel(
+                (bitmap.width - insetPx).coerceAtLeast(0),
+                bitmap.height / 2,
+            )
+            val expected = PocketShellColors.Amber.copy(alpha = 0.12f)
+                .compositeOver(PocketShellColors.Surface)
+                .toArgb()
+            fun delta(channel: (Int) -> Int): Int =
+                kotlin.math.abs(channel(actual) - channel(expected))
+            val maxDelta = maxOf(
+                delta(AndroidColor::red),
+                delta(AndroidColor::green),
+                delta(AndroidColor::blue),
+            )
+            assertTrue(
+                "Offline banner background must be Amber@12% over Surface. " +
+                    "actual=${Integer.toHexString(actual)} expected=${Integer.toHexString(expected)} " +
+                    "maxChannelDelta=$maxDelta",
+                maxDelta <= 5,
+            )
+        } finally {
+            bitmap.recycle()
+        }
+    }
+
     @androidx.compose.runtime.Composable
     private fun FauxTerminalBackdrop() {
         Text(
@@ -289,14 +395,14 @@ class PromptComposerOfflineComposeUsableProofTest {
         // is true (the field uses its 24dp keyboard-up min) while the intrusion
         // subtracted from the host is small. `availableAboveKeyboard ≈ HOST - IME`,
         // which we size into the crush→usable band (see below).
-        const val HOST_HEIGHT_DP = 188f
+        const val HOST_HEIGHT_DP = 470f
 
         // A narrow content width (the sheet's inner width after its 18dp side
         // paddings + the banner's 12dp padding + the cloud icon) so the
         // "Connection lost — Send will retry once reconnected." banner wraps to the
         // TWO lines the maintainer saw on-device — the tall sticky chrome that, on
         // base, crushes the weighted draft region below one line.
-        const val HOST_WIDTH_DP = 270f
+        const val HOST_WIDTH_DP = 360f
 
         // Small IME (keyboardUp true) with NAV 0. `availableAboveKeyboard ≈ 188-48 =
         // 140dp`. On base the sticky two-line offline banner (~56dp) + control row
@@ -304,15 +410,13 @@ class PromptComposerOfflineComposeUsableProofTest {
         // a sub-line crush (editor → ~0). The #1613 fix moves the banner into the
         // scroll region, so the sticky chrome is just the control row (~74dp) and the
         // draft region is ~66dp — the one-line field is fully visible.
-        const val IME_HEIGHT_DP = 48f
+        const val IME_HEIGHT_DP = 295f
         const val NAV_BAR_DP = 0f
         const val STATUS_BAR_DP = 52f
 
-        // The empty draft editor is a single 24dp line keyboard-up. On base the
-        // sticky offline banner crushes the weighted draft region so the editor is
-        // compressed to ~0 (a sub-line sliver); the fix keeps the full 24dp line.
-        // 20dp sits below the healthy 24dp line and well above the crush, so it is
-        // decisively red-on-base / green-on-fix while tolerating sub-dp rounding.
-        const val MIN_DRAFT_HEIGHT_DP = 20f
+        const val OFFLINE_COPY = "Offline — prompts will be queued and sent on reconnect."
+        val LONG_DRAFT = (1..18).joinToString("\n") {
+            "offline line $it; sentinel caret queued safely"
+        }
     }
 }

--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerSheet.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerSheet.kt
@@ -891,7 +891,11 @@ internal fun SheetContent(
                 .heightIn(max = availableAboveKeyboard)
                 .background(PocketShellColors.Surface)
                 .padding(horizontal = 18.dp)
-                .padding(bottom = 26.dp),
+                // Keyboard-down keeps the visual breathing room above the nav
+                // bar. Keyboard-up the IME itself is the bottom boundary; spending
+                // another 26dp here would take a complete caret line away from the
+                // weighted draft when status content is present (#1619).
+                .padding(bottom = if (keyboardUp) 0.dp else 26.dp),
         ) {
             // Issue #767: the `/`-triggered inline command autocomplete dropdown.
             // It rides the top of this same inset-anchored column (so it is never
@@ -963,124 +967,25 @@ internal fun SheetContent(
 
             Column(
                 modifier = Modifier
-                    // Issue #682/#765: the scroll region (draft + status banners +
-                    // attachment tiles) absorbs overflow so a long draft / a stack
-                    // of tiles scrolls WITHIN the compact sheet instead of forcing
-                    // the whole content taller (which would push the sticky action
-                    // row off-screen / under the keyboard). The header is PINNED
-                    // above this region (#765) so it never scrolls away.
-                    //
-                    // Issue #801: this region is WEIGHTED in both keyboard states so
-                    // it takes exactly the space left after the pinned header, the
-                    // connection-lost row, and the sticky control row are laid out —
-                    // never a hand-tuned reserve constant (the #790 cap) that could
-                    // undercut the draft's own 96dp min and crush it (the recurring
-                    // squish). `fill = false` keeps the column wrap-content for a
-                    // short/empty draft so the whole sheet sits compactly above the
-                    // keyboard with no reserved dead band (the #790 symptom). As the
-                    // draft lengthens the region grows up to its weighted share of
-                    // the room above the keyboard, then the `verticalScroll` below
-                    // absorbs the overflow so the sticky Send / attach row never
-                    // leaves the area above the keyboard (the #682 long-draft
-                    // invariant). When the keyboard is DOWN the extra
-                    // `heightIn(max = …)` keeps the sheet compact at partial-expand
-                    // (#234); when it is UP the outer
-                    // `heightIn(max = availableAboveKeyboard)` is the only ceiling,
-                    // so the field is bounded to the genuine room above the keyboard.
-                    //
-                    // Issue #873: `fill = false` keeps the column wrap-content, but
-                    // it only ACTUALLY wraps once the draft field stops greedily
-                    // filling its weighted share. That is handled in
-                    // [ComposerDraftField]: keyboard-up the field's `heightIn(min,
-                    // max)` is on the EDITOR (so a one-line draft wraps to ~one line
-                    // and self-scrolls past `max` on a long draft) rather than a
-                    // `fillMaxHeight` box that inflated a short draft to ~155dp — the
-                    // ~1cm dead band the maintainer circled.
-                    .weight(1f, fill = false)
-                    .then(
-                        if (keyboardUp) {
-                            Modifier
+                    // Issue #1619: status content owns a SEPARATE bounded scroll
+                    // ABOVE the editor. It may scroll internally when several
+                    // banners/tiles are present, but it can no longer make the
+                    // 220dp editor a child of a smaller clipping viewport. In the
+                    // measured ~175dp keyboard-up budget, 48dp is enough for the
+                    // standalone two-line Offline banner while still reserving a
+                    // complete editable line plus the sticky controls. Keyboard-
+                    // down keeps a roomier 96dp status history.
+                    .fillMaxWidth()
+                    .heightIn(
+                        max = if (keyboardUp) {
+                            PromptComposerStatusRegionImeMaxHeight
                         } else {
-                            Modifier.heightIn(max = PromptComposerScrollRegionMaxHeight)
+                            PromptComposerStatusRegionMaxHeight
                         },
                     )
+                    .testTag(COMPOSER_STATUS_VIEWPORT_TAG)
                     .verticalScroll(rememberScrollState()),
             ) {
-            // Issue #453: the composer's primary surface is state-driven.
-            //  - Idle / Text-inserted: the editable input (`Compose prompt…`).
-            //  - Recording: an amplitude-driven waveform + mm:ss timer + Stop.
-            //  - Transcribing: a "Transcribing…" spinner row.
-            // The mockup collapses these into one panel whose height adjusts to
-            // the content, so we swap the surface in place rather than stacking
-            // extra rows.
-            when (state.recording) {
-                PromptComposerViewModel.RecordingState.Recording -> {
-                    RecordingSurface(
-                        amplitude = state.amplitude,
-                        capturing = state.hasDetectedSpeech,
-                        elapsedLabel = formatElapsed(state.recordingElapsedMs),
-                        // Issue #870 (reopen): pass the RAW growing partial; the
-                        // dedicated two-line LiveTranscriptTwoLine area resolves
-                        // the visible tail width-aware at render time so the
-                        // newest words always stay visible.
-                        liveTranscript = state.liveTranscript,
-                    )
-                }
-
-                PromptComposerViewModel.RecordingState.Transcribing -> {
-                    TranscribingSurface()
-                }
-
-                PromptComposerViewModel.RecordingState.Idle -> {
-                    // The composer text area. Issue #196: shared with the
-                    // agent-pane composer via [ComposerDraftField] so both
-                    // surfaces have an identical surface-elev fill, accent
-                    // cursor, and muted placeholder. Issue #453: placeholder is
-                    // the mockup's "Compose prompt…". After a dictation lands
-                    // (Auto-send off) the transcript fills this same editable
-                    // field for the user to review before Send.
-                    ComposerDraftField(
-                        value = draftFieldValue,
-                        onValueChange = { newValue ->
-                            // Mirror every edit into the ViewModel so the draft
-                            // (and SavedStateHandle) stay in lockstep with the
-                            // editor, then keep our local TextFieldValue as the
-                            // selection-bearing source of truth.
-                            draftFieldValue = newValue
-                            if (newValue.text != state.draft) {
-                                onDraftChange(newValue.text)
-                            }
-                        },
-                        placeholder = COMPOSER_PLACEHOLDER,
-                        fieldTag = COMPOSER_DRAFT_TAG,
-                        // Issue #873: keyboard-UP the field WRAPS to its text content
-                        // (the `heightIn(min, max)` bound lives on the EDITOR in
-                        // [ComposerDraftField], not on a `fillMaxHeight` box), so a
-                        // SHORT draft is as compact as its content — one line of text
-                        // sits in a ~one-line-tall field, NOT centred in a tall box
-                        // with ~1cm of empty space below it (the dead band the
-                        // maintainer circled). `minHeight = 44.dp` keyboard-up is a
-                        // single comfortable line so the field never reserves a
-                        // multi-line void for a one-line draft; as the user types it
-                        // grows line-by-line up to `maxHeight = 220.dp`, then the
-                        // `BasicTextField` self-scrolls to the caret within that cap
-                        // (the #765 long-draft invariant). Keyboard-DOWN it keeps the
-                        // roomy 96dp min and fills its box (unchanged).
-                        //
-                        // `minHeight = 24.dp` keyboard-up is a single text line; with
-                        // the box's 14dp top + 14dp bottom padding the empty/one-line
-                        // field is ~one line tall — as compact as its content, with
-                        // no reserved multi-line void. The box stays a comfortable
-                        // tap target via that padding.
-                        minHeight = if (keyboardUp) 24.dp else 96.dp,
-                        maxHeight = 220.dp,
-                        focusRequester = draftFocusRequester,
-                    )
-                }
-            }
-
-            Spacer(modifier = Modifier.height(4.dp))
-
             // Optional error / status banner above the mic row. Keeps the
             // user informed about permission / API-key / Whisper failures
             // without a Snackbar (the sheet doesn't host a scaffold).
@@ -1220,20 +1125,12 @@ internal fun SheetContent(
             // reports the SSH/tmux link is degraded/lost, BEFORE the user taps
             // Send, so a send into a dead link is never a silent blind wait.
             //
-            // Issue #1613: this indicator lives INSIDE the scrollable upper region
-            // (BELOW the draft field, which is the first child), NOT in the sticky
-            // bottom chrome. When the maintainer is composing WHILE offline — the
-            // whole point of #1613 — the keyboard is up and there is only ~175dp
-            // above it; a sticky TWO-LINE "Connection lost…" banner + the sticky
-            // control row consumed nearly all of it and CRUSHED the weighted draft
-            // region to a sub-line sliver, so the user "couldn't type anything".
-            // Moving the banner into the scroll region (where the mutually-exclusive
-            // queue banner already lives) keeps the draft field — the top priority —
-            // full-size and reachable; the informational banner scrolls with the
-            // content. The blind-wait protection is preserved: with a short draft the
-            // banner is visible right above the always-sticky Send row, and once the
-            // user taps Send the (also in-scroll) OutboundQueueBanner carries the
-            // ongoing "Will send when reconnected." status.
+            // Issue #1613/#1619: this indicator lives in the independently bounded
+            // status scroll ABOVE the draft, never in sticky bottom chrome and never
+            // below a 220dp editor inside the editor's clipping viewport. This keeps
+            // the warning visible while the weighted field owns the actual remaining
+            // room and native caret-follow. Once Send queues a prompt, the mutually-
+            // exclusive OutboundQueueBanner carries the ongoing status instead.
             //
             // Issue #971/#987 (Option A): once there is a queued outbound prompt
             // waiting, the OutboundQueueBanner already carries the SINGLE coherent
@@ -1246,10 +1143,15 @@ internal fun SheetContent(
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(bottom = 8.dp)
                         .clip(RoundedCornerShape(8.dp))
-                        .background(PocketShellColors.AccentSoft, RoundedCornerShape(8.dp))
-                        .padding(horizontal = 12.dp, vertical = 8.dp)
+                        .background(
+                            PocketShellColors.Amber.copy(alpha = 0.12f),
+                            RoundedCornerShape(8.dp),
+                        )
+                        // Two explicit 16dp text lines plus 4dp vertical padding
+                        // keep the whole Amber banner inside the calibrated 48dp
+                        // keyboard-up status viewport.
+                        .padding(horizontal = 12.dp, vertical = 4.dp)
                         .testTag(COMPOSER_CONNECTION_LOST_TAG),
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -1257,17 +1159,63 @@ internal fun SheetContent(
                     Icon(
                         imageVector = Icons.Filled.CloudOff,
                         contentDescription = null,
-                        tint = PocketShellColors.Accent,
+                        tint = PocketShellColors.Amber,
                         modifier = Modifier.size(16.dp),
                     )
                     Text(
-                        text = "Connection lost — Send will retry once reconnected.",
-                        color = PocketShellColors.Accent,
+                        text = "Offline — prompts will be queued and sent on reconnect.",
+                        color = PocketShellColors.Amber,
                         fontSize = 12.sp,
+                        lineHeight = 16.sp,
                     )
                 }
             }
         }
+
+        // Issue #453/#1619: the primary surface is state-driven. Idle makes the
+        // real editor the DIRECT weighted child, so its effective max is the
+        // actual room left between the bounded status region and sticky controls.
+        // That restores BasicTextField's native caret-follow as the only editor
+        // scroll; no outer draft scroll competes with or clips it.
+        when (state.recording) {
+            PromptComposerViewModel.RecordingState.Recording -> {
+                RecordingSurface(
+                    amplitude = state.amplitude,
+                    capturing = state.hasDetectedSpeech,
+                    elapsedLabel = formatElapsed(state.recordingElapsedMs),
+                    liveTranscript = state.liveTranscript,
+                    modifier = Modifier.weight(1f, fill = false),
+                )
+            }
+
+            PromptComposerViewModel.RecordingState.Transcribing -> {
+                Box(modifier = Modifier.weight(1f, fill = false)) {
+                    TranscribingSurface()
+                }
+            }
+
+            PromptComposerViewModel.RecordingState.Idle -> {
+                ComposerDraftField(
+                    value = draftFieldValue,
+                    onValueChange = { newValue ->
+                        draftFieldValue = newValue
+                        if (newValue.text != state.draft) {
+                            onDraftChange(newValue.text)
+                        }
+                    },
+                    placeholder = COMPOSER_PLACEHOLDER,
+                    modifier = Modifier
+                        .weight(1f, fill = false)
+                        .testTag(COMPOSER_DRAFT_VIEWPORT_TAG),
+                    fieldTag = COMPOSER_DRAFT_TAG,
+                    minHeight = if (keyboardUp) 24.dp else 96.dp,
+                    maxHeight = 220.dp,
+                    focusRequester = draftFocusRequester,
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(if (keyboardUp) 2.dp else 4.dp))
 
         // Issue #1272: the durable "couldn't deliver — retry" surface. A voice
         // command that was transcribed successfully but never reached a pane
@@ -2088,6 +2036,12 @@ internal const val COMPOSER_SEND_IN_FLIGHT_TAG = "prompt-composer-send-in-flight
  */
 internal const val COMPOSER_CONNECTION_LOST_TAG = "prompt-composer-connection-lost"
 
+/** Issue #1619: bounded viewport that owns the draft's keyboard-up geometry. */
+internal const val COMPOSER_DRAFT_VIEWPORT_TAG = "prompt-composer-draft-viewport"
+
+/** Issue #1619: independently scrollable status region above the draft. */
+internal const val COMPOSER_STATUS_VIEWPORT_TAG = "prompt-composer-status-viewport"
+
 /**
  * Issue #767: test tags for the `/`-autocomplete dropdown. Connected tests
  * assert the dropdown appears when the draft starts with `/`, filters as more
@@ -2138,14 +2092,13 @@ internal const val COMPOSER_CANCEL_RECORDING_TAG = "prompt-composer-cancel-recor
  */
 internal const val COMPOSER_CANCEL_TRANSCRIPTION_TAG = "prompt-composer-cancel-transcription"
 
-// Issue #682: cap the scrollable upper region (draft + status banners) so the
-// content-height sheet never grows taller than this even with a long draft +
-// several banners. Keeps the composer compact above the keyboard; the inner
-// `verticalScroll` lets a long draft scroll within the cap instead of pushing
-// the sticky action row off-screen. Used ONLY when the keyboard is DOWN; when it
-// is UP the region is `weight(1f)`-sized to the genuine room above the keyboard
-// (no fixed cap — issue #801).
-private val PromptComposerScrollRegionMaxHeight = 360.dp
+// Issue #1619: status banners/tiles scroll independently above the weighted
+// editor. The tight keyboard-up cap was calibrated against the measured 175dp
+// budget: a 48dp two-line Offline banner remains whole while one complete editor
+// line and the sticky controls still fit. Keyboard-down can show two status rows
+// before this region scrolls, without changing the editor's 220dp cap.
+private val PromptComposerStatusRegionImeMaxHeight = 48.dp
+private val PromptComposerStatusRegionMaxHeight = 96.dp
 
 // Issue #767: cap the `/`-autocomplete dropdown so a long catalog scrolls
 // internally instead of squeezing the draft field / pushing the controls under

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -156,6 +156,7 @@ JOURNEY_CLASSES=(
   "com.pocketshell.app.projects.ProfileDiscoveryPickerDockerTest"  # #732 Finding B): the host server-PROFILE discovery journey. The p…
   "com.pocketshell.app.tmux.TmuxInSessionNewSessionCollisionDockerTest"  # #898 reviewer Blocker B): the in-session + New session rich-sheet
   "com.pocketshell.app.composer.PromptComposerImeSquishProofTest"  # #736 #567 #638 #657 follow-up to the review): the composer keyboard-up SQUISH re…
+  "com.pocketshell.app.composer.PromptComposerLongDraftCaretVisibleTest"  # #1619/#765 D33/G10: synthetic + real-IME long-draft caret containment above sticky controls
   "com.pocketshell.app.composer.PromptComposerImeTightScreenSquishProofTest"  # #801 #567 #780 #657 the keyboard-up squish on a REALISTIC TIGHT screen
   "com.pocketshell.app.composer.PromptComposerOfflineComposeUsableProofTest"  # #1613 #801 #780 #657 offline compose: the OFFLINE banner + keyboard up must NOT crush the draft — the user must be able to type + queue while disconnected
   "com.pocketshell.app.tmux.Issue887TerminalFixedUnderImeProofTest"  # #887 #457 #780 the terminal must stay FIXED when the soft keyboard


### PR DESCRIPTION
## Summary

- keep the long-draft editor in its own scrollable viewport above sticky composer controls
- keep offline queue status visible above the editor without shrinking the caret viewport
- add load-bearing real/synthetic IME regression proofs and wire the class into the journey suite
- preserve the newer #1618 usage-notification journey wiring from current main

## Verification

- `scripts/check-test-validity.sh`
- `scripts/check-ci-journey-harness.sh`
- `scripts/check-file-size-hygiene.sh`
- `bash -n scripts/ci-journey-suite.sh`
- `git diff --check origin/main`
- `scripts/cgroup-run.sh -- ./gradlew :app:compileDebugAndroidTestKotlin assembleDebug`
- `scripts/connected-test.sh --pool --suffix i1619int -Pandroid.testInstrumentationRunnerArguments.class=com.pocketshell.app.composer.PromptComposerLongDraftCaretVisibleTest` — 3 tests, 0 failures, 0 skipped

Approved independent review: https://github.com/alexeygrigorev/pocketshell/issues/1619#issuecomment-4986245452

Closes #1619