### PR TITLE
connection: reset the reconnect ladder on proven stability, not on a dial (#1633)

### DIFF
--- a/shared/core-connection/src/main/java/com/pocketshell/core/connection/ConnectionController.kt
+++ b/shared/core-connection/src/main/java/com/pocketshell/core/connection/ConnectionController.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import java.util.concurrent.atomic.AtomicLong
+import kotlin.random.Random
 
 /**
  * The pure-JVM connection lifecycle state machine (EPIC #687 Phase-2, slice 1).
@@ -61,6 +62,21 @@ class ConnectionController(
     // developer debug builds, and a no-op in release. Injectable so a test can
     // pin it on/off deterministically regardless of the build variant.
     confinementAssertionsEnabled: Boolean = BuildConfig.DEBUG,
+    /**
+     * Issue #1633: how long the connection must stay continuously [ConnectionState.Live]
+     * before the current recovery EPISODE commits and the attempt counter resets.
+     */
+    private val stabilityWindowMs: Long = DEFAULT_STABILITY_WINDOW_MS,
+    /**
+     * Issue #1633: the wall-clock ceiling on one recovery episode. A flap slow enough to
+     * never exhaust the rung budget still terminates here instead of grinding forever.
+     */
+    private val episodeBudgetMs: Long = DEFAULT_EPISODE_BUDGET_MS,
+    /**
+     * Issue #1633: the jitter source for [retryDelayForAttempt] (±[RETRY_JITTER_FRACTION]).
+     * Injectable so tests pin the distribution deterministically instead of skipping it.
+     */
+    private val random: Random = Random.Default,
 ) {
     /**
      * Enforces the single-confining-dispatcher contract in DEBUG builds by
@@ -118,13 +134,50 @@ class ConnectionController(
      * controller, decoupled from the transient [ConnectionState] — because the VM's
      * re-dial IO walks the state through Connecting/Attaching/Live on every rung
      * (even one that then fails an attach), which would otherwise reset an in-state
-     * counter. 0 means "no ladder in flight"; a ladder arms it to 1
-     * ([ConnectionEvent.ReconnectLadderEntered] / a heal-failed drop) and each failed
-     * rung ([ConnectionEvent.ReconnectFailed]) advances it until the budget exhausts.
+     * counter. 0 means "no EPISODE in flight"; a ladder arms it to 1
+     * ([ConnectionEvent.ReconnectLadderEntered] / a heal-failed drop) and each rung that
+     * concludes WITHOUT a stability commit advances it until the budget exhausts.
      * A plain `var` mutated only from the confining dispatcher (same contract as
      * [graceDeadlineMs]).
+     *
+     * Issue #1633 widened its lifetime from "one dial" to "one EPISODE" — see
+     * [liveSinceMs].
      */
     private var reconnectAttempt: Int = 0
+
+    /**
+     * Issue #1633: when the CURRENT [ConnectionState.Live] began, or null when not Live.
+     *
+     * This is the whole fix. Before #1633 the attempt counter's reset condition was
+     * effectively **"a dial succeeded"** ([onReconnectLadderEntered] hard-armed at 1 on
+     * every ladder entry), not **"a connection proved stable"**. On the maintainer's mobile
+     * link — which dies ~5s after each successful dial (#1610) — every cycle therefore
+     * looked like a brand-new FIRST attempt: backoff never engaged (`retryDelayMs=0` on
+     * every one of 15,456 logged burst lines), the budget was never reached, and
+     * [ConnectionState.Unreachable] was dead code. The burst only ever ended when the
+     * maintainer backgrounded the app.
+     *
+     * The remedy is the Kubernetes CrashLoopBackOff / gRPC verified-acceptance model: the
+     * episode commits only once the link has been continuously Live for
+     * [stabilityWindowMs]. A drop before then RESUMES the episode at attempt+1.
+     *
+     * It is evaluated LAZILY, at the next drop ([onLiveDropped]) — never by a timer. The
+     * commit has no observable effect until a drop asks "was that Live stable?", so a
+     * stored stamp compared on demand is exactly equivalent to a scheduled wakeup, while
+     * keeping the reducer pure, timer-free (D21) and free of any coroutine loop.
+     */
+    private var liveSinceMs: Long? = null
+
+    /**
+     * Issue #1633: when the current recovery EPISODE began (the first drop out of a
+     * committed/fresh [ConnectionState.Live]), or null when no episode is in flight.
+     *
+     * An episode spans the WHOLE flap sequence, not one dial: exiting to Live does not end
+     * it — only the [stabilityWindowMs] commit (or explicit user intent) does. It bounds
+     * the episode by wall clock ([episodeBudgetMs]) as well as by rung count, so a flap too
+     * slow to exhaust the rungs still terminates.
+     */
+    private var episodeStartMs: Long? = null
 
     /** Current target id — the drop-by-id reference for events and seeds. */
     private val currentTargetId: SessionId?
@@ -194,17 +247,38 @@ class ConnectionController(
     private val effectiveMaxAttempts: Int
         get() = reconnectLadderMs.size.takeIf { it > 0 } ?: maxReconnectAttempts
 
-    /** Backoff before the 1-based [attempt]'s dial; clamps to the last ladder step. */
+    /**
+     * Backoff before the 1-based [attempt]'s dial; clamps to the last ladder step, then
+     * jittered ±[RETRY_JITTER_FRACTION] (issue #1633, the gRPC model).
+     *
+     * Mobile RAT handovers and NAT/keepalive reapers are PERIODIC, so a bare ladder can
+     * resonate with that cadence (and synchronize retries across sessions into a
+     * thundering herd). Jitter breaks both. Rung 1's `0ms` is left EXACTLY zero — that
+     * rung is the instant silent heal (#680/#621) and delaying it would be a visible
+     * regression — and a jittered rung never rounds down to 0, so a non-zero rung always
+     * actually waits.
+     */
     private fun retryDelayForAttempt(attempt: Int): Long {
         if (reconnectLadderMs.isEmpty()) return 0L
         val index = (attempt - 1).coerceIn(0, reconnectLadderMs.lastIndex)
-        return reconnectLadderMs[index]
+        return jittered(reconnectLadderMs[index])
+    }
+
+    /** Apply ±[RETRY_JITTER_FRACTION] full jitter to a non-zero backoff (issue #1633). */
+    private fun jittered(delayMs: Long): Long {
+        if (delayMs <= 0L) return 0L
+        val spread = delayMs * RETRY_JITTER_FRACTION
+        val offset = random.nextDouble(-spread, spread)
+        return (delayMs + offset).toLong().coerceAtLeast(1L)
     }
 
     /** Build a [ConnectionState.Reconnecting] for [attempt] from the single ladder,
-     *  syncing the churn-surviving [reconnectAttempt] counter to it. */
+     *  syncing the churn-surviving [reconnectAttempt] counter to it and stamping the
+     *  episode start if this is the episode's first rung (issue #1633). */
     private fun reconnectingAt(host: HostKey, target: SessionId, attempt: Int): ConnectionState.Reconnecting {
         reconnectAttempt = attempt
+        if (episodeStartMs == null) episodeStartMs = clock.nowMs()
+        liveSinceMs = null
         return ConnectionState.Reconnecting(
             host = host,
             targetId = target,
@@ -212,6 +286,81 @@ class ConnectionController(
             maxAttempts = effectiveMaxAttempts,
             retryDelayMs = retryDelayForAttempt(attempt),
         )
+    }
+
+    /**
+     * Issue #1633: END the current episode — the counter, the episode clock and the
+     * stability stamp all reset, so the NEXT drop starts a fresh episode at attempt 1 with
+     * the full budget and the instant first rung.
+     *
+     * Called on the stability commit ([onLiveDropped]), on explicit user intent
+     * ([onEnter]/[onSwitch]), and when a terminal state is reached.
+     */
+    private fun endEpisode() {
+        reconnectAttempt = 0
+        episodeStartMs = null
+        liveSinceMs = null
+    }
+
+    /** Enter [ConnectionState.Live], stamping the stability window's start (issue #1633). */
+    private fun liveAt(host: HostKey, target: SessionId): ConnectionState.Live {
+        liveSinceMs = clock.nowMs()
+        return ConnectionState.Live(host, target)
+    }
+
+    /** True once the current episode has burned its rung budget or its wall clock. */
+    private fun episodeExhausted(nextAttempt: Int): Boolean {
+        if (nextAttempt > effectiveMaxAttempts) return true
+        val started = episodeStartMs ?: return false
+        return clock.nowMs() - started >= episodeBudgetMs
+    }
+
+    /**
+     * Issue #1633: the [ConnectionState.Live] that is ending faces the stability question —
+     * commit the episode if it held for [stabilityWindowMs], otherwise leave the episode in
+     * flight so the caller resumes it. The ONE place the window is evaluated; every path
+     * that ends a Live must go through it, or that path becomes a counter-laundering hole.
+     */
+    private fun endLiveAndCommitIfStable() {
+        val since = liveSinceMs
+        liveSinceMs = null
+        if (since != null && clock.nowMs() - since >= stabilityWindowMs) endEpisode()
+    }
+
+    /** The rung an ending Live should resume the episode at: 1 when none is in flight. */
+    private fun resumeAttempt(): Int = if (reconnectAttempt == 0) 1 else reconnectAttempt + 1
+
+    /**
+     * Issue #1633: the transport dropped out of [ConnectionState.Live] — the ONE place the
+     * "did this connection prove stable?" question is asked, and the loop-killer.
+     *
+     * - The prior Live lasted ≥ [stabilityWindowMs] ⇒ the episode COMMITS. The counter
+     *   resets, and this drop opens a fresh episode: silent heal first, attempt 1, instant
+     *   rung. This is the load-bearing NEGATIVE case — without it every ordinary reconnect
+     *   would escalate spuriously.
+     * - An episode was already in flight and the Live did NOT prove stable ⇒ that rung
+     *   concluded WITHOUT a commit ("the dial succeeded but the link died again"), so the
+     *   episode RESUMES at attempt+1 — or gives up honestly at the budget.
+     *
+     * A drop still routes through [ConnectionState.Reattaching] either way, so the silent
+     * heal (#680/#621) and the calm band are byte-for-byte unchanged; only the counter
+     * behind them now remembers.
+     */
+    private fun onLiveDropped(host: HostKey, target: SessionId): ConnectionState {
+        endLiveAndCommitIfStable()
+
+        if (reconnectAttempt == 0) {
+            // A fresh episode: heal silently first; the counter arms only if that fails.
+            episodeStartMs = clock.nowMs()
+            return ConnectionState.Reattaching(host, target)
+        }
+        val next = reconnectAttempt + 1
+        if (episodeExhausted(next)) {
+            endEpisode()
+            return ConnectionState.Unreachable(host, target)
+        }
+        reconnectAttempt = next
+        return ConnectionState.Reattaching(host, target)
     }
 
     private fun reduce(current: ConnectionState, event: ConnectionEvent): ConnectionState =
@@ -239,9 +388,11 @@ class ConnectionController(
      */
     private fun onEnter(current: ConnectionState, event: ConnectionEvent.Enter): ConnectionState {
         // A genuine open clears any prior grace window — we are foregrounded and
-        // re-targeting. It also disarms any stale reconnect counter (#1328).
+        // re-targeting. It also disarms any stale reconnect counter (#1328) / recovery
+        // episode (#1633): an Enter is explicit user intent, and the manual Reconnect
+        // affordance out of a terminal Unreachable routes through here.
         graceDeadlineMs = null
-        reconnectAttempt = 0
+        endEpisode()
         return if (transport.isWarm(event.host)) {
             ConnectionState.Attaching(event.host, event.targetId)
         } else {
@@ -254,11 +405,20 @@ class ConnectionController(
      * state, go to [Attaching] on the new id WITHOUT a re-handshake. The VM will
      * `selectWindow` + seed the active pane. A switch from Idle is a no-op (there
      * is no host to switch on).
+     *
+     * Issue #1633 — the episode reset here is DELIBERATE and unchanged. A [ConnectionEvent.Switch]
+     * is EXPLICIT USER INTENT: the #1331 design lists Enter/Switch/manual-Reconnect as the
+     * intent-reset set, the user is watching and has asked for this target right now, and the
+     * honest response to "take me to B" is a fresh, full-budget attempt rather than one
+     * inherited from A's flap history. It cannot launder the counter back to 1 during the
+     * #1610 storm either: `Switch` is only ever submitted from a user tap (via
+     * `ConnectionManager.switchTo`/`ensureTargeting`), never by the automatic reconnect
+     * cycle, so the storm's own event sequence never reaches this arm.
      */
     private fun onSwitch(current: ConnectionState, event: ConnectionEvent.Switch): ConnectionState {
         val host = current.hostOrNull() ?: return current
         graceDeadlineMs = null
-        reconnectAttempt = 0
+        endEpisode()
         return ConnectionState.Attaching(host, event.targetId)
     }
 
@@ -300,6 +460,16 @@ class ConnectionController(
         return if (withinGrace) {
             ConnectionState.Reattaching(current.host, current.targetId)
         } else {
+            // Issue #1633: a beyond-grace return starts a FRESH episode (the #1331 design's
+            // "Foreground beyond grace -> Recovering, attempt 1"). Ending the episode first
+            // is what makes that coherent: without it the counter would say "attempt 1"
+            // while the stale episode CLOCK said "exhausted", so the first rung failure
+            // would fire an instant, wrong Unreachable at the user. Nothing dialled while
+            // backgrounded (D21), so no episode was meaningfully in flight; the user has
+            // also been away far longer than the stability window. This deliberately keeps
+            // backgrounding — today the maintainer's ONLY escape from the #1610 storm —
+            // working as a clean restart rather than a trip straight to a dead end.
+            endEpisode()
             reconnectingAt(current.host, current.targetId, attempt = 1)
         }
     }
@@ -317,7 +487,9 @@ class ConnectionController(
         val host = current.hostOrNull() ?: return current
         val target = current.targetIdOrNull() ?: return current
         return when (current) {
-            is ConnectionState.Live,
+            // Issue #1633: the ONE place the stability window is evaluated.
+            is ConnectionState.Live -> onLiveDropped(host, target)
+
             is ConnectionState.Attaching,
             is ConnectionState.Connecting,
             -> ConnectionState.Reattaching(host, target)
@@ -352,8 +524,10 @@ class ConnectionController(
      */
     private fun onTransportLive(current: ConnectionState): ConnectionState =
         when (current) {
-            is ConnectionState.Reattaching -> ConnectionState.Live(current.host, current.targetId)
-            is ConnectionState.Reconnecting -> ConnectionState.Live(current.host, current.targetId)
+            // Issue #1633: entering Live starts the stability window — it does NOT commit
+            // the episode. "The dial succeeded" is not "the connection recovered".
+            is ConnectionState.Reattaching -> liveAt(current.host, current.targetId)
+            is ConnectionState.Reconnecting -> liveAt(current.host, current.targetId)
             is ConnectionState.Connecting -> ConnectionState.Attaching(current.host, current.targetId)
             else -> current
         }
@@ -374,8 +548,23 @@ class ConnectionController(
     ): ConnectionState {
         if (!event.validatedHandoff) return current
         return when (current) {
-            is ConnectionState.Live ->
-                reconnectingAt(current.host, current.targetId, attempt = 1)
+            is ConnectionState.Live -> {
+                // Issue #1633: a validated handoff ENDS this Live, so it must face the same
+                // stability question as a drop. It used to hard-arm at attempt 1, which on
+                // the maintainer's own environment (#1610 — a flapping MOBILE link, where
+                // periodic RAT handovers are exactly what fires this event) would launder an
+                // uncommitted episode's counter back to 1 during one of the storm's brief
+                // Live moments, and the ladder could never climb. A handoff on a link that
+                // has PROVEN stable still starts fresh at attempt 1 via the commit.
+                endLiveAndCommitIfStable()
+                val next = resumeAttempt()
+                if (reconnectAttempt > 0 && episodeExhausted(next)) {
+                    endEpisode()
+                    ConnectionState.Unreachable(current.host, current.targetId)
+                } else {
+                    reconnectingAt(current.host, current.targetId, attempt = next)
+                }
+            }
             // Connecting/Attaching/Reattaching/Reconnecting already have a
             // dial/heal in flight; Backgrounded/Idle/Gone/Unreachable have no live
             // channel to proactively replace. Suppress in all of them.
@@ -401,7 +590,7 @@ class ConnectionController(
             is ConnectionState.Reattaching,
             is ConnectionState.Reconnecting,
             -> {
-                reconnectAttempt = 0
+                endEpisode()
                 ConnectionState.Unreachable(host, target)
             }
             // Idle/Backgrounded/NetworkLossSuspended/Gone/Unreachable: nothing to fail.
@@ -410,10 +599,17 @@ class ConnectionController(
     }
 
     /**
-     * Issue #1328 (S5): the VM effect entered its numbered reconnect ladder. Arm the
-     * SINGLE counter at attempt 1 and move any live-ish / recovering state to
-     * [ConnectionState.Reconnecting] attempt 1. A no-op from Idle/Gone/Unreachable
-     * (there is no channel to reconnect).
+     * Issue #1328 (S5): the VM effect entered its numbered reconnect ladder. Move any
+     * live-ish / recovering state to [ConnectionState.Reconnecting]. A no-op from
+     * Idle/Gone/Unreachable (there is no channel to reconnect — and, per #1633, a
+     * terminal give-up must NOT be re-armed out of by the VM's own ladder body, or the
+     * storm would simply resume).
+     *
+     * Issue #1633: this RESUMES the current episode instead of hard-arming at attempt 1.
+     * The old unconditional `attempt = 1` was the bad reset itself: the VM's ladder body
+     * exits the moment a dial reports Connected and re-enters here on the next drop, so on
+     * a connect-then-die link EVERY cycle re-armed at attempt 1 / `retryDelayMs=0` and the
+     * ladder could never climb. It arms at 1 only when no episode is in flight.
      */
     private fun onReconnectLadderEntered(current: ConnectionState): ConnectionState {
         val host = current.hostOrNull() ?: return current
@@ -423,7 +619,7 @@ class ConnectionController(
             is ConnectionState.Gone,
             is ConnectionState.Unreachable,
             -> current
-            else -> reconnectingAt(host, target, attempt = 1)
+            else -> reconnectingAt(host, target, attempt = reconnectAttempt.coerceAtLeast(1))
         }
     }
 
@@ -446,9 +642,11 @@ class ConnectionController(
             is ConnectionState.NetworkLossSuspended,
             -> current
             else -> {
-                val nextAttempt = (if (reconnectAttempt > 0) reconnectAttempt else 1) + 1
-                if (nextAttempt > effectiveMaxAttempts) {
-                    reconnectAttempt = 0
+                val nextAttempt = reconnectAttempt.coerceAtLeast(1) + 1
+                // Issue #1633: the episode is bounded by its wall clock as well as by the
+                // rung budget, so a flap too slow to burn the rungs still gives up.
+                if (episodeExhausted(nextAttempt)) {
+                    endEpisode()
                     ConnectionState.Unreachable(host, target)
                 } else {
                     reconnectingAt(host, target, attempt = nextAttempt)
@@ -482,10 +680,12 @@ class ConnectionController(
         }
         val host = current.hostOrNull() ?: return current
         return when (current) {
+            // Issue #1633: as with TransportLive, the seed landing opens the stability
+            // window; the episode commits only once that window closes.
             is ConnectionState.Attaching,
             is ConnectionState.Reattaching,
             is ConnectionState.Reconnecting,
-            -> ConnectionState.Live(host, event.targetId)
+            -> liveAt(host, event.targetId)
             // Already Live (a background-pane reveal seed) or any other state:
             // the landing doesn't change the lifecycle state.
             else -> current
@@ -516,6 +716,39 @@ class ConnectionController(
 
         /** Silent reconnect attempts before the only honest error ([Unreachable]). */
         const val DEFAULT_MAX_RECONNECT_ATTEMPTS: Int = 4
+
+        /**
+         * Issue #1633: how long the connection must stay continuously
+         * [ConnectionState.Live] before the recovery episode COMMITS and the attempt
+         * counter resets. A drop before the window closes resumes at attempt+1.
+         *
+         * **PROPOSED, not locked** — the value comes from the #1331 target-state-machine
+         * design (which took it from Kubernetes CrashLoopBackOff's stability window). It is
+         * the loop-killer's single tuning knob: too LOW and a flapping link's brief Lives
+         * look "stable" and the storm returns; too HIGH and a genuinely healthy connection
+         * that drops within the window inherits a stale attempt. 30s comfortably exceeds
+         * the maintainer's observed ~5s connect-then-die cadence (#1610) while staying well
+         * under a normal session's uptime. Retune with evidence.
+         */
+        const val DEFAULT_STABILITY_WINDOW_MS: Long = 30_000L
+
+        /**
+         * Issue #1633: the wall-clock ceiling on ONE recovery episode. Past it the machine
+         * gives up honestly ([ConnectionState.Unreachable]) even if rungs remain, so a flap
+         * too slow to exhaust the rung budget cannot grind forever.
+         *
+         * **PROPOSED, not locked** — from the #1331 design. 120s roughly matches the
+         * 8-rung `[0,1,2,5,10,20,30,30]s` ladder's own span, so whichever bound trips first
+         * lands in the same neighbourhood.
+         */
+        const val DEFAULT_EPISODE_BUDGET_MS: Long = 120_000L
+
+        /**
+         * Issue #1633: full jitter applied to every non-zero ladder rung (the gRPC backoff
+         * model), so retries neither resonate with a periodic mobile RAT/NAT cycle nor
+         * synchronize across sessions. **PROPOSED, not locked** — ±20% is the gRPC default.
+         */
+        const val RETRY_JITTER_FRACTION: Double = 0.2
     }
 }
 

--- a/shared/core-connection/src/test/java/com/pocketshell/core/connection/ConnectionControllerEpisodeStabilityTest.kt
+++ b/shared/core-connection/src/test/java/com/pocketshell/core/connection/ConnectionControllerEpisodeStabilityTest.kt
@@ -1,0 +1,598 @@
+package com.pocketshell.core.connection
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1633 — the connect-then-die livelock, and the stability window that ends it.
+ *
+ * ## The reported defect (issue #1610, the maintainer's mobile-internet storm)
+ * On mobile internet the app reconnects every ~5 seconds forever and never gives up.
+ * The forensics (#1610) are unambiguous: across 15,456 log lines `retryDelayMs` is
+ * non-zero only 24 times, ALL outside the bursts. Inside a burst it is **always**
+ * `attempt=1 retryDelayMs=0`, and the burst only ever ends when the maintainer
+ * backgrounds the app.
+ *
+ * ## The root cause this suite pins
+ * The attempt counter's reset condition was **"a dial succeeded"**, not **"a
+ * connection proved stable"**. A link that dies ~5s after every successful dial
+ * therefore looks like an unbroken series of FIRST attempts: backoff never engages,
+ * the attempt budget is never reached, and [ConnectionState.Unreachable] — the
+ * terminal give-up — is structurally dead code. The fix is the CrashLoopBackOff /
+ * gRPC verified-acceptance model: the episode counter commits only after the link
+ * has been continuously [ConnectionState.Live] for [STABILITY_WINDOW_MS].
+ *
+ * ## Why these are pure virtual-clock reducer tests (no `assumeTrue`, no skip)
+ * [ConnectionController] is a pure synchronous reducer over an injected [Clock] with
+ * NO coroutine and NO IO, so the maintainer's exact logged event sequence — the one
+ * `TmuxSessionViewModel.scheduleAutoReconnectBody` emits on every rung — is driven
+ * here deterministically and hard-asserted. The load-bearing assertions never skip.
+ *
+ * ## This file deliberately compiles against the UNFIXED reducer (red -> green, G1)
+ * It touches ONLY the pre-#1633 public API — the `(clock, transport)` constructor and
+ * the existing events — and mirrors the two window constants locally rather than
+ * importing them. That is what lets a reviewer revert `ConnectionController.kt` alone
+ * and watch these tests fail RED with the maintainer's exact `attempt=1 retryDelayMs=0`
+ * signature, then pass GREEN with the fix restored. The mirrors are pinned against the
+ * production constants by `ConnectionControllerJitterTest.kt` so they cannot drift.
+ */
+class ConnectionControllerEpisodeStabilityTest {
+
+    private val host = HostKey("alexey@135.181.114.209:22")
+    private val a = SessionId("A")
+
+    /** The #1331 design ladder: 8 rungs, `[0,1,2,5,10,20,30,30]s`. */
+    private val ladder = listOf(0L, 1_000L, 2_000L, 5_000L, 10_000L, 20_000L, 30_000L, 30_000L)
+
+    /** One observed ladder rung, as the VM effect reads it off `Reconnecting`. */
+    private data class Rung(val attempt: Int, val maxAttempts: Int, val retryDelayMs: Long)
+
+    private fun controller(clock: FakeClock): Pair<ConnectionController, FakeTransportPort> {
+        val transport = FakeTransportPort()
+        return ConnectionController(clock, transport) to transport
+    }
+
+    /** Cold Enter -> Connecting -> Attaching -> Live, the normal first connect. */
+    private fun ConnectionController.bringLive(transport: FakeTransportPort) {
+        transport.setWarm(host, false)
+        submit(ConnectionEvent.Enter(host, a))
+        transport.setWarm(host, true)
+        submit(ConnectionEvent.TransportLive) // Connecting -> Attaching
+        submit(ConnectionEvent.SeedLanded(a, "%0")) // Attaching -> Live
+        check(state.value is ConnectionState.Live) { "fixture must start Live, was ${state.value}" }
+    }
+
+    /**
+     * ONE connect-then-die cycle, replaying the EXACT production event sequence the VM
+     * emits per burst cycle (`TmuxSessionViewModel.scheduleAutoReconnectBody`):
+     * keepalive death -> silent heal fails -> install ladder -> enter ladder -> read the
+     * rung -> wait the rung's backoff -> the dial SUCCEEDS -> the link dies [aliveMs] later.
+     *
+     * Returns the rung the VM would have dialled, or null once the controller has left the
+     * ladder (the terminal give-up — the loop this test exists to prove is reachable).
+     */
+    private fun ConnectionController.driveConnectThenDieCycle(clock: FakeClock, aliveMs: Long): Rung? {
+        submit(ConnectionEvent.TransportDropped("keepalive death")) // Live -> Reattaching
+        submit(ConnectionEvent.TransportDropped("silent heal failed")) // -> Reconnecting
+        setReconnectLadder(ladder) // the VM installs its autoReconnectDelaysMs
+        submit(ConnectionEvent.ReconnectLadderEntered) // the VM enters the numbered ladder
+        val recon = state.value as? ConnectionState.Reconnecting ?: return null
+        val rung = Rung(recon.attempt, recon.maxAttempts, recon.retryDelayMs)
+        clock.advanceBy(recon.retryDelayMs) // the VM's `if (delayMs > 0) delay(delayMs)`
+        submit(ConnectionEvent.TransportLive) // the rung's dial SUCCEEDS
+        submit(ConnectionEvent.SeedLanded(a, "%0")) // ... and the pane seeds -> Live
+        check(state.value is ConnectionState.Live) { "the dial succeeded, expected Live, was ${state.value}" }
+        clock.advanceBy(aliveMs) // ... and the link dies again ~5s later
+        return rung
+    }
+
+    /** The ±20% jitter band around a ladder rung's base backoff. Rung 1 (0ms) stays exact. */
+    private fun assertWithinJitterBand(baseMs: Long, actualMs: Long, label: String) {
+        if (baseMs == 0L) {
+            assertEquals("$label: the silent first rung must stay instant", 0L, actualMs)
+            return
+        }
+        val low = (baseMs * 0.8).toLong()
+        val high = (baseMs * 1.2).toLong()
+        assertTrue(
+            "$label: ${actualMs}ms outside the +/-20% jitter band [$low..$high] of ${baseMs}ms",
+            actualMs in low..high,
+        )
+    }
+
+    // ------------------------------------------------------------------
+    // The reproduction (D33/G10): the maintainer's exact burst signature.
+    // ------------------------------------------------------------------
+
+    /**
+     * THE load-bearing reproduction. Drives the maintainer's storm — a link that dies ~5s
+     * after every successful dial — and requires that it TERMINATES.
+     *
+     * On the unfixed reducer this fails with every rung pinned at `attempt=1
+     * retryDelayMs=0` and no terminal state after 40 cycles: the maintainer's exact logged
+     * signature. With the stability window the episode survives each short-lived Live, the
+     * counter advances, the ladder delays engage, and the machine gives up.
+     */
+    @Test
+    fun `connect-then-die cycles escalate the ladder and reach terminal give-up`() {
+        val clock = FakeClock()
+        val (c, transport) = controller(clock)
+        c.bringLive(transport)
+
+        val rungs = mutableListOf<Rung>()
+        var cycles = 0
+        while (cycles < CYCLE_CAP && c.state.value !is ConnectionState.Unreachable) {
+            c.driveConnectThenDieCycle(clock, aliveMs = LINK_LIFETIME_MS)?.let { rungs += it }
+            cycles++
+        }
+
+        val trace = rungs.joinToString { "attempt=${it.attempt} retryDelayMs=${it.retryDelayMs}" }
+
+        // 1. The loop TERMINATES. On base this is the failure: the burst runs forever and
+        //    only the maintainer backgrounding the app ends it.
+        assertTrue(
+            "the connect-then-die loop never reached terminal give-up after $cycles cycles " +
+                "(state=${c.state.value}); observed rungs: [$trace]",
+            c.state.value is ConnectionState.Unreachable,
+        )
+        assertEquals(ConnectionState.Unreachable(host, a), c.state.value)
+
+        // 2. The counter ADVANCES across cycles instead of pinning at 1 (the bad reset).
+        assertTrue("expected several escalating rungs, got: [$trace]", rungs.size >= 4)
+        assertEquals(
+            "the attempt counter must advance once per uncommitted cycle, not pin at 1; " +
+                "observed: [$trace]",
+            (1..rungs.size).toList(),
+            rungs.map { it.attempt },
+        )
+
+        // 3. The ladder's BACKOFF engages (base rungs 0,1s,2s,5s,... jittered +/-20%).
+        rungs.forEach { rung ->
+            assertWithinJitterBand(ladder[rung.attempt - 1], rung.retryDelayMs, "rung ${rung.attempt}")
+        }
+        assertTrue(
+            "backoff never engaged — every rung still waited 0ms (the #1610 signature): [$trace]",
+            rungs.any { it.retryDelayMs > 0L },
+        )
+        // The ladder CLIMBS in order and never re-arms at the bottom. Compare the BASE
+        // sequence rather than the jittered samples: rungs 7 and 8 share a 30s base by
+        // design, so two adjacent samples may legitimately cross inside their band. Each
+        // sample is already pinned to its own base's band above, so base-order + band
+        // together fully pin the climb.
+        val bases = rungs.map { ladder[it.attempt - 1] }
+        assertEquals(
+            "the rungs must walk the ladder in order, not re-arm at the bottom: [$trace]",
+            ladder.take(rungs.size),
+            bases,
+        )
+        assertTrue("the ladder must actually climb: [$trace]", bases.last() > bases.first())
+
+        // 4. Every rung reports the real 8-rung budget, so the user-visible "(n/8)" is honest.
+        rungs.forEach { assertEquals(ladder.size, it.maxAttempts) }
+    }
+
+    /**
+     * G3 — the give-up path is currently DEAD CODE, so a test that merely "passes" without
+     * entering it is vacuous. This asserts [ConnectionState.Unreachable] is genuinely entered
+     * AND is terminal: the VM's `enterReconnectLadder` cannot silently re-arm out of it (the
+     * `while (state is Reconnecting)` ladder loop breaks), so the manual Reconnect affordance
+     * is the only way forward.
+     */
+    @Test
+    fun `terminal give-up is entered and is sticky against ladder re-entry`() {
+        val clock = FakeClock()
+        val (c, transport) = controller(clock)
+        c.bringLive(transport)
+
+        var cycles = 0
+        while (cycles < CYCLE_CAP && c.state.value !is ConnectionState.Unreachable) {
+            c.driveConnectThenDieCycle(clock, aliveMs = LINK_LIFETIME_MS)
+            cycles++
+        }
+        assertEquals(
+            "the give-up arm was never entered — the test would pass vacuously (G3)",
+            ConnectionState.Unreachable(host, a),
+            c.state.value,
+        )
+
+        // The VM's ladder body must not be able to climb back out on its own.
+        c.setReconnectLadder(ladder)
+        c.submit(ConnectionEvent.ReconnectLadderEntered)
+        assertEquals(
+            "ReconnectLadderEntered re-armed the ladder out of the terminal state — the " +
+                "storm would resume forever",
+            ConnectionState.Unreachable(host, a),
+            c.state.value,
+        )
+        c.submit(ConnectionEvent.TransportDropped("late churn"))
+        assertEquals(ConnectionState.Unreachable(host, a), c.state.value)
+
+        // Explicit user intent (the manual Reconnect affordance) starts a FRESH episode.
+        c.submit(ConnectionEvent.Enter(host, a))
+        c.submit(ConnectionEvent.TransportLive)
+        c.submit(ConnectionEvent.SeedLanded(a, "%0"))
+        assertEquals(ConnectionState.Live(host, a), c.state.value)
+        c.submit(ConnectionEvent.TransportDropped("d"))
+        c.submit(ConnectionEvent.TransportDropped("d"))
+        assertEquals(
+            "a manual reconnect must start a fresh episode at attempt 1",
+            1,
+            (c.state.value as ConnectionState.Reconnecting).attempt,
+        )
+    }
+
+    /**
+     * The reducer must not assume the numbered ladder body is the SOLE submitter of
+     * [ConnectionEvent.ReconnectFailed].
+     *
+     * Orchestrator arbitration on #1633: the passive-grace loop dials `sshLeaseManager.acquire`
+     * directly and never submits `ReconnectFailed` today, which is why the counter stays
+     * frozen; the sibling #1539 slice wires that loop's failures in. When it does, the event
+     * arrives from a NEW caller and — because each mid-cycle handshake success fires
+     * `TransportLive` — usually while the controller has ALREADY bounced back to
+     * [ConnectionState.Live]. The episode must still escalate from there and terminate.
+     *
+     * The grace loop's plumbing is #1539's; modelled here SYNTHETICALLY at the controller
+     * boundary, which is this slice's unit of proof.
+     */
+    @Test
+    fun `ReconnectFailed fed from the grace loop while Live still escalates to give-up`() {
+        val clock = FakeClock()
+        val (c, transport) = controller(clock)
+        c.setReconnectLadder(ladder)
+        c.bringLive(transport)
+
+        val attempts = mutableListOf<Int>()
+        var cycles = 0
+        while (cycles < CYCLE_CAP && c.state.value !is ConnectionState.Unreachable) {
+            // The grace loop's rung failed — reported straight from Live (#1539's wiring).
+            c.submit(ConnectionEvent.ReconnectFailed)
+            (c.state.value as? ConnectionState.Reconnecting)?.let { attempts += it.attempt }
+            // ... and its NEXT dial handshakes, bouncing the controller back to Live.
+            c.submit(ConnectionEvent.TransportLive)
+            c.submit(ConnectionEvent.SeedLanded(a, "%0"))
+            clock.advanceBy(LINK_LIFETIME_MS) // ... and dies ~5s later, as always
+            cycles++
+        }
+
+        assertEquals(
+            "a grace-loop-fed ReconnectFailed must still reach terminal give-up " +
+                "(attempts seen: $attempts)",
+            ConnectionState.Unreachable(host, a),
+            c.state.value,
+        )
+        assertEquals(
+            "a handshake success between rungs must NOT wipe the walk (attempts: $attempts)",
+            (2..attempts.size + 1).toList(),
+            attempts,
+        )
+    }
+
+    /**
+     * The same new-caller path, but the link genuinely recovers between rungs: a Live that
+     * outlasts the stability window COMMITS, so the next grace-loop failure starts over at
+     * attempt 1 rather than inheriting the old episode (G6, new-caller variant).
+     */
+    @Test
+    fun `a grace-loop rung after a proven-stable Live starts a fresh episode`() {
+        val clock = FakeClock()
+        val (c, transport) = controller(clock)
+        c.setReconnectLadder(ladder)
+        c.bringLive(transport)
+
+        repeat(3) {
+            c.submit(ConnectionEvent.ReconnectFailed)
+            c.submit(ConnectionEvent.TransportLive)
+            c.submit(ConnectionEvent.SeedLanded(a, "%0"))
+            clock.advanceBy(LINK_LIFETIME_MS)
+        }
+        // The link finally holds, well past the stability window.
+        clock.advanceBy(STABILITY_WINDOW_MS + 1_000L)
+        c.submit(ConnectionEvent.TransportDropped("a much later, unrelated drop"))
+        c.submit(ConnectionEvent.TransportDropped("heal failed"))
+        assertEquals(
+            "a proven-stable Live must commit the episode even when the rungs were " +
+                "grace-loop-fed",
+            1,
+            (c.state.value as ConnectionState.Reconnecting).attempt,
+        )
+    }
+
+    /**
+     * G2 class coverage — the counter-laundering hole a validated network handoff opens.
+     *
+     * `NetworkChanged(validatedHandoff = true)` on a Live channel proactively re-dials, and
+     * it used to hard-arm the ladder at attempt 1. That matters precisely in the
+     * maintainer's own environment: #1610 is a flapping MOBILE link, and periodic RAT
+     * handovers are exactly what fires this event — so a handoff landing on one of the
+     * storm's brief Live moments would reset the counter and the ladder could never climb.
+     * An UNCOMMITTED episode must survive a handoff; a proven-stable one must not.
+     */
+    @Test
+    fun `a validated network handoff does not launder an uncommitted episode`() {
+        val clock = FakeClock()
+        val (c, transport) = controller(clock)
+        c.setReconnectLadder(ladder)
+        c.bringLive(transport)
+
+        repeat(3) { c.driveConnectThenDieCycle(clock, aliveMs = LINK_LIFETIME_MS) }
+        // Back to a short-lived Live, mid-episode.
+        c.submit(ConnectionEvent.TransportDropped("d"))
+        c.submit(ConnectionEvent.TransportDropped("d"))
+        val mid = (c.state.value as ConnectionState.Reconnecting).attempt
+        assertTrue("fixture precondition: an episode must be in flight", mid > 1)
+        c.submit(ConnectionEvent.TransportLive)
+        c.submit(ConnectionEvent.SeedLanded(a, "%0"))
+        clock.advanceBy(LINK_LIFETIME_MS) // still well short of the stability window
+
+        c.submit(ConnectionEvent.NetworkChanged(validatedHandoff = true))
+        val afterHandoff = c.state.value as ConnectionState.Reconnecting
+        assertEquals(
+            "a RAT handoff during the storm reset the ladder to attempt 1 — the exact " +
+                "environment #1610 was reported on, so the loop would never terminate",
+            mid + 1,
+            afterHandoff.attempt,
+        )
+        assertTrue("the resumed rung must carry real backoff", afterHandoff.retryDelayMs > 0L)
+    }
+
+    /** The same handoff on a link that PROVED stable still starts fresh at attempt 1 (G6). */
+    @Test
+    fun `a validated network handoff after a proven-stable Live starts fresh`() {
+        val clock = FakeClock()
+        val (c, transport) = controller(clock)
+        c.setReconnectLadder(ladder)
+        c.bringLive(transport)
+
+        repeat(3) { c.driveConnectThenDieCycle(clock, aliveMs = LINK_LIFETIME_MS) }
+        c.submit(ConnectionEvent.TransportDropped("d"))
+        c.submit(ConnectionEvent.TransportDropped("d"))
+        c.submit(ConnectionEvent.TransportLive)
+        c.submit(ConnectionEvent.SeedLanded(a, "%0"))
+        clock.advanceBy(STABILITY_WINDOW_MS + 1_000L) // the link genuinely recovered
+
+        c.submit(ConnectionEvent.NetworkChanged(validatedHandoff = true))
+        val fresh = c.state.value as ConnectionState.Reconnecting
+        assertEquals("a handoff on a proven-stable link is a fresh episode", 1, fresh.attempt)
+        assertEquals(0L, fresh.retryDelayMs)
+    }
+
+    /**
+     * G2 class coverage — backgrounding is the maintainer's ONLY escape from the storm
+     * today, so a beyond-grace return must be a clean restart, NOT a trip straight to a
+     * dead end. The counter arms at 1 (the #1331 design) AND the episode clock restarts
+     * with it: an inherited-but-exhausted episode clock would fire an instant, wrong
+     * Unreachable on the very first rung failure after the user came back.
+     */
+    @Test
+    fun `a beyond-grace foreground return starts a fresh episode with a clean clock`() {
+        val clock = FakeClock()
+        val (c, transport) = controller(clock)
+        c.setReconnectLadder(ladder)
+        c.bringLive(transport)
+
+        // Storm until the episode clock is well past its budget, then escape by backgrounding.
+        var cycles = 0
+        while (cycles < CYCLE_CAP && c.state.value !is ConnectionState.Unreachable) {
+            c.driveConnectThenDieCycle(clock, aliveMs = LINK_LIFETIME_MS)
+            cycles++
+        }
+        c.submit(ConnectionEvent.Enter(host, a)) // the user re-opens after the give-up
+        c.submit(ConnectionEvent.TransportLive)
+        c.submit(ConnectionEvent.SeedLanded(a, "%0"))
+        c.submit(ConnectionEvent.TransportDropped("d"))
+        c.submit(ConnectionEvent.TransportDropped("d"))
+        assertTrue(c.state.value is ConnectionState.Reconnecting)
+
+        c.submit(ConnectionEvent.Background)
+        clock.advanceBy(ConnectionController.DEFAULT_GRACE_MS + 60_000L) // away, beyond grace
+        transport.setWarm(host, false)
+        c.submit(ConnectionEvent.Foreground)
+
+        val back = c.state.value as ConnectionState.Reconnecting
+        assertEquals("a beyond-grace return arms at attempt 1", 1, back.attempt)
+        assertEquals("... at the instant first rung", 0L, back.retryDelayMs)
+        // The load-bearing half: the episode CLOCK restarted too, so the first rung failure
+        // escalates normally instead of tripping a stale budget straight into Unreachable.
+        c.submit(ConnectionEvent.ReconnectFailed)
+        assertEquals(
+            "the returning user inherited a stale, already-exhausted episode clock and was " +
+                "dumped straight into Unreachable",
+            2,
+            (c.state.value as ConnectionState.Reconnecting).attempt,
+        )
+    }
+
+    // ------------------------------------------------------------------
+    // G6 — the LOAD-BEARING negative case: a stable link still resets.
+    // ------------------------------------------------------------------
+
+    /**
+     * G6. If this is wrong, EVERY normal reconnect escalates spuriously and the app becomes
+     * unusable in a new way. A connection that stays Live past the stability window COMMITS
+     * the episode: a later, unrelated drop starts fresh at attempt 1 with the full budget and
+     * the instant first rung.
+     */
+    @Test
+    fun `a connection that proves stable resets the counter so a later drop starts fresh`() {
+        val clock = FakeClock()
+        val (c, transport) = controller(clock)
+        c.bringLive(transport)
+
+        // Burn three uncommitted cycles: the counter is now deep in the ladder.
+        repeat(3) { c.driveConnectThenDieCycle(clock, aliveMs = LINK_LIFETIME_MS) }
+        c.submit(ConnectionEvent.TransportDropped("d"))
+        c.submit(ConnectionEvent.TransportDropped("d"))
+        val escalated = c.state.value as ConnectionState.Reconnecting
+        assertTrue(
+            "fixture precondition: the counter must be escalated before the stable window",
+            escalated.attempt > 1,
+        )
+
+        // This rung's dial succeeds and the link STAYS UP past the stability window.
+        c.submit(ConnectionEvent.TransportLive)
+        c.submit(ConnectionEvent.SeedLanded(a, "%0"))
+        assertEquals(ConnectionState.Live(host, a), c.state.value)
+        clock.advanceBy(STABILITY_WINDOW_MS + 1_000L)
+
+        // A later, unrelated drop: a FRESH episode, attempt 1, instant first rung.
+        c.submit(ConnectionEvent.TransportDropped("unrelated later drop"))
+        assertEquals(
+            "a proven-stable link must heal silently first, exactly as before",
+            ConnectionState.Reattaching(host, a),
+            c.state.value,
+        )
+        c.submit(ConnectionEvent.TransportDropped("heal failed"))
+        val fresh = c.state.value as ConnectionState.Reconnecting
+        assertEquals(
+            "a stable connection did NOT commit the episode — a normal reconnect would " +
+                "escalate spuriously (G6)",
+            1,
+            fresh.attempt,
+        )
+        assertEquals("the fresh episode must start at the instant first rung", 0L, fresh.retryDelayMs)
+        assertEquals("the fresh episode must get the full budget back", ladder.size, fresh.maxAttempts)
+    }
+
+    /** G2 class coverage — die-just-before the window escalates; the boundary is exclusive. */
+    @Test
+    fun `a drop one millisecond before the stability window escalates the same episode`() {
+        val clock = FakeClock()
+        val (c, transport) = controller(clock)
+        c.bringLive(transport)
+
+        c.driveConnectThenDieCycle(clock, aliveMs = LINK_LIFETIME_MS) // attempt 1 burned
+        c.submit(ConnectionEvent.TransportDropped("d"))
+        c.submit(ConnectionEvent.TransportDropped("d"))
+        val before = (c.state.value as ConnectionState.Reconnecting).attempt
+        c.submit(ConnectionEvent.TransportLive)
+        c.submit(ConnectionEvent.SeedLanded(a, "%0"))
+
+        clock.advanceBy(STABILITY_WINDOW_MS - 1)
+        c.submit(ConnectionEvent.TransportDropped("died just short of the window"))
+        c.submit(ConnectionEvent.TransportDropped("heal failed"))
+        assertEquals(
+            "a link that died 1ms short of the stability window must RESUME the episode",
+            before + 1,
+            (c.state.value as ConnectionState.Reconnecting).attempt,
+        )
+    }
+
+    /** G2 class coverage — die exactly AT the boundary commits (the window is inclusive). */
+    @Test
+    fun `a drop exactly at the stability window boundary commits the episode`() {
+        val clock = FakeClock()
+        val (c, transport) = controller(clock)
+        c.bringLive(transport)
+
+        c.driveConnectThenDieCycle(clock, aliveMs = LINK_LIFETIME_MS)
+        c.submit(ConnectionEvent.TransportDropped("d"))
+        c.submit(ConnectionEvent.TransportDropped("d"))
+        assertTrue((c.state.value as ConnectionState.Reconnecting).attempt > 0)
+        c.submit(ConnectionEvent.TransportLive)
+        c.submit(ConnectionEvent.SeedLanded(a, "%0"))
+
+        clock.advanceBy(STABILITY_WINDOW_MS)
+        c.submit(ConnectionEvent.TransportDropped("died exactly at the boundary"))
+        c.submit(ConnectionEvent.TransportDropped("heal failed"))
+        assertEquals(
+            "at exactly the stability window the connection has proven stable — commit",
+            1,
+            (c.state.value as ConnectionState.Reconnecting).attempt,
+        )
+    }
+
+    /**
+     * G2 class coverage — the episode is bounded by wall-clock too, not only by rung count.
+     * A link that flaps slowly enough to stay under the rung budget still gives up within the
+     * episode budget instead of grinding forever.
+     */
+    @Test
+    fun `the episode wall-clock budget gives up even when rungs remain`() {
+        val clock = FakeClock()
+        val (c, transport) = controller(clock)
+        // A long flat ladder: the rung budget alone would never exhaust in this window.
+        val flat = List(100) { 1_000L }
+        c.bringLive(transport)
+
+        var cycles = 0
+        while (cycles < CYCLE_CAP && c.state.value !is ConnectionState.Unreachable) {
+            c.submit(ConnectionEvent.TransportDropped("d"))
+            c.submit(ConnectionEvent.TransportDropped("d"))
+            c.setReconnectLadder(flat)
+            c.submit(ConnectionEvent.ReconnectLadderEntered)
+            val recon = c.state.value as? ConnectionState.Reconnecting ?: break
+            clock.advanceBy(recon.retryDelayMs)
+            c.submit(ConnectionEvent.TransportLive)
+            c.submit(ConnectionEvent.SeedLanded(a, "%0"))
+            clock.advanceBy(LINK_LIFETIME_MS)
+            cycles++
+        }
+        assertEquals(
+            "the episode wall-clock budget must terminate a slow flap that never exhausts " +
+                "the rung budget",
+            ConnectionState.Unreachable(host, a),
+            c.state.value,
+        )
+        assertTrue(
+            "the episode must survive at least the budget before giving up",
+            clock.nowMs() >= EPISODE_BUDGET_MS,
+        )
+    }
+
+    /**
+     * G2 class coverage — a user-initiated switch. DELIBERATE decision (issue #1633): a
+     * [ConnectionEvent.Switch] is EXPLICIT USER INTENT and therefore starts a fresh episode,
+     * preserving the pre-existing `onSwitch` reset semantics unchanged. Rationale: the #1331
+     * design lists Enter/Switch/manual-Reconnect/Send-wake as the intent-reset set, the user
+     * is watching and has asked for this target now, and `Switch` is only ever submitted from
+     * a user tap — the storm's automatic cycle never emits it, so it cannot launder the
+     * counter back to 1.
+     */
+    @Test
+    fun `a user-initiated switch deliberately starts a fresh episode`() {
+        val clock = FakeClock()
+        val (c, transport) = controller(clock)
+        val b = SessionId("B")
+        c.bringLive(transport)
+
+        repeat(3) { c.driveConnectThenDieCycle(clock, aliveMs = LINK_LIFETIME_MS) }
+        c.submit(ConnectionEvent.TransportDropped("d"))
+        c.submit(ConnectionEvent.TransportDropped("d"))
+        assertTrue((c.state.value as ConnectionState.Reconnecting).attempt > 1)
+
+        c.submit(ConnectionEvent.Switch(b))
+        assertEquals(ConnectionState.Attaching(host, b), c.state.value)
+        c.submit(ConnectionEvent.SeedLanded(b, "%1"))
+        c.submit(ConnectionEvent.TransportDropped("d"))
+        c.submit(ConnectionEvent.TransportDropped("d"))
+        val afterSwitch = c.state.value as ConnectionState.Reconnecting
+        assertEquals("a user switch is explicit intent — fresh episode at attempt 1", 1, afterSwitch.attempt)
+        assertEquals(0L, afterSwitch.retryDelayMs)
+    }
+
+    private companion object {
+        /**
+         * Local MIRRORS of the production windows. Deliberately duplicated rather than
+         * imported so this file still compiles against the unfixed reducer and can be run
+         * red on base (see the class doc). `ConnectionControllerJitterTest` asserts these
+         * equal `ConnectionController.DEFAULT_STABILITY_WINDOW_MS` /
+         * `DEFAULT_EPISODE_BUDGET_MS`, so they cannot silently drift.
+         */
+        private const val STABILITY_WINDOW_MS = 30_000L
+        private const val EPISODE_BUDGET_MS = 120_000L
+
+        /** The maintainer's observed cadence: the link dies ~5s after each successful dial. */
+        private const val LINK_LIFETIME_MS = 5_000L
+
+        /**
+         * A HARD cap on the reproduction loop. It is not a timeout — the reducer is
+         * synchronous and cannot hang — it is the bound that turns "loops forever" into a
+         * finite, readable failure carrying the observed rung trace.
+         */
+        private const val CYCLE_CAP = 40
+
+        private const val JITTER_SAMPLES = 200
+    }
+}

--- a/shared/core-connection/src/test/java/com/pocketshell/core/connection/ConnectionControllerJitterTest.kt
+++ b/shared/core-connection/src/test/java/com/pocketshell/core/connection/ConnectionControllerJitterTest.kt
@@ -1,0 +1,150 @@
+package com.pocketshell.core.connection
+
+import kotlin.random.Random
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1633 — ±20% ladder jitter (the gRPC backoff model) and the tuning constants.
+ *
+ * Mobile RAT handovers and NAT/keepalive reapers are PERIODIC. An unjittered ladder can
+ * resonate with that cadence (and, across sessions/devices, synchronize retries into a
+ * thundering herd). gRPC's standard remedy is full jitter on every non-zero rung; this
+ * suite pins it as a DISTRIBUTION property rather than a fixed value, deterministically
+ * (each sample uses an injected seed, so there is no flake and nothing is skipped).
+ *
+ * It also pins the constants that `ConnectionControllerEpisodeStabilityTest` mirrors
+ * locally — that file deliberately compiles against the UNFIXED reducer so it can be run
+ * red on base, so its window constants are copies. These assertions are the anti-drift
+ * guard for those copies.
+ */
+class ConnectionControllerJitterTest {
+
+    private val host = HostKey("alexey@135.181.114.209:22")
+    private val a = SessionId("A")
+
+    /** The #1331 design ladder: 8 rungs, `[0,1,2,5,10,20,30,30]s`. */
+    private val ladder = listOf(0L, 1_000L, 2_000L, 5_000L, 10_000L, 20_000L, 30_000L, 30_000L)
+
+    private fun ConnectionController.bringLive(transport: FakeTransportPort) {
+        transport.setWarm(host, false)
+        submit(ConnectionEvent.Enter(host, a))
+        transport.setWarm(host, true)
+        submit(ConnectionEvent.TransportLive)
+        submit(ConnectionEvent.SeedLanded(a, "%0"))
+    }
+
+    /** Drive a seeded controller to the numbered ladder and read [rungsToBurn]+1's backoff. */
+    private fun delayForRung(seed: Int, rungsToBurn: Int): Long {
+        val transport = FakeTransportPort()
+        val c = ConnectionController(FakeClock(), transport, random = Random(seed))
+        c.setReconnectLadder(ladder)
+        c.bringLive(transport)
+        c.submit(ConnectionEvent.TransportDropped("d")) // Live -> Reattaching
+        c.submit(ConnectionEvent.TransportDropped("d")) // -> Reconnecting(1)
+        repeat(rungsToBurn) { c.submit(ConnectionEvent.ReconnectFailed) }
+        return (c.state.value as ConnectionState.Reconnecting).retryDelayMs
+    }
+
+    private fun assertWithinJitterBand(baseMs: Long, actualMs: Long, label: String) {
+        val low = (baseMs * 0.8).toLong()
+        val high = (baseMs * 1.2).toLong()
+        assertTrue(
+            "$label: ${actualMs}ms outside the +/-20% jitter band [$low..$high] of ${baseMs}ms",
+            actualMs in low..high,
+        )
+    }
+
+    /**
+     * Jitter as a DISTRIBUTION: every sample inside the ±20% band, genuinely spread (not a
+     * constant), unbiased around the base rung, and reaching both sides of it.
+     */
+    @Test
+    fun `ladder backoff is jittered plus or minus 20 percent as a distribution`() {
+        val base = 1_000L // ladder rung 2
+        val samples = (0 until JITTER_SAMPLES).map { delayForRung(seed = it, rungsToBurn = 1) }
+
+        samples.forEach { assertWithinJitterBand(base, it, "jitter sample") }
+        assertTrue(
+            "jitter produced a near-constant — retries would still synchronize " +
+                "(${samples.distinct().size} distinct of $JITTER_SAMPLES)",
+            samples.distinct().size > JITTER_SAMPLES / 4,
+        )
+        val mean = samples.average()
+        assertTrue("jitter is biased: mean=$mean, expected ~$base", mean in 940.0..1_060.0)
+        assertTrue("jitter must reach below the base: ${samples.min()}", samples.any { it < base })
+        assertTrue("jitter must reach above the base: ${samples.max()}", samples.any { it > base })
+    }
+
+    /** Jitter applies to EVERY non-zero rung, not just the one sampled above. */
+    @Test
+    fun `every non-zero rung is jittered around its own base`() {
+        // rungsToBurn = n reaches attempt n+1, i.e. ladder[n].
+        (1..ladder.lastIndex).forEach { rungIndex ->
+            val base = ladder[rungIndex]
+            val samples = (0 until 40).map { delayForRung(seed = it, rungsToBurn = rungIndex) }
+            samples.forEach { assertWithinJitterBand(base, it, "rung ${rungIndex + 1}") }
+            assertTrue(
+                "rung ${rungIndex + 1} (base ${base}ms) is not jittered — it returned a constant",
+                samples.distinct().size > 1,
+            )
+        }
+    }
+
+    /** The instant first rung must NEVER be jittered — the silent heal stays immediate. */
+    @Test
+    fun `the zero-delay first rung is never jittered`() {
+        repeat(50) { seed ->
+            assertEquals(
+                "the silent first heal must stay instant",
+                0L,
+                delayForRung(seed = seed, rungsToBurn = 0),
+            )
+        }
+    }
+
+    /** Two independently-seeded controllers on the same rung do not resonate. */
+    @Test
+    fun `two controllers on the same rung do not synchronize`() {
+        assertNotEquals(delayForRung(seed = 1, rungsToBurn = 1), delayForRung(seed = 2, rungsToBurn = 1))
+    }
+
+    /** A jittered delay never collapses to zero — a non-zero rung always waits. */
+    @Test
+    fun `a jittered rung never collapses to zero`() {
+        (1..ladder.lastIndex).forEach { rungIndex ->
+            (0 until 40).forEach { seed ->
+                assertTrue(
+                    "rung ${rungIndex + 1} jittered down to 0ms — the backoff would vanish",
+                    delayForRung(seed = seed, rungsToBurn = rungIndex) > 0L,
+                )
+            }
+        }
+    }
+
+    /**
+     * Anti-drift guard: `ConnectionControllerEpisodeStabilityTest` mirrors these constants
+     * locally so it can compile against the unfixed reducer for the red run. Pin the mirrors
+     * to the real values here.
+     */
+    @Test
+    fun `the mirrored tuning constants match production`() {
+        assertEquals(
+            "ConnectionControllerEpisodeStabilityTest.STABILITY_WINDOW_MS mirror has drifted",
+            30_000L,
+            ConnectionController.DEFAULT_STABILITY_WINDOW_MS,
+        )
+        assertEquals(
+            "ConnectionControllerEpisodeStabilityTest.EPISODE_BUDGET_MS mirror has drifted",
+            120_000L,
+            ConnectionController.DEFAULT_EPISODE_BUDGET_MS,
+        )
+        assertEquals(0.2, ConnectionController.RETRY_JITTER_FRACTION, 0.0001)
+    }
+
+    private companion object {
+        private const val JITTER_SAMPLES = 200
+    }
+}

--- a/shared/core-connection/src/test/java/com/pocketshell/core/connection/ConnectionControllerReconnectLadderTest.kt
+++ b/shared/core-connection/src/test/java/com/pocketshell/core/connection/ConnectionControllerReconnectLadderTest.kt
@@ -43,31 +43,42 @@ class ConnectionControllerReconnectLadderTest {
         submit(ConnectionEvent.TransportDropped("d")) // Reattaching -> Reconnecting(1)
     }
 
+    /**
+     * Issue #1633 note: the per-attempt delay is now jittered ±20% (the gRPC model), so
+     * this asserts the rung's backoff lands in its ladder step's band rather than on the
+     * exact step. The jitter distribution itself is pinned by `ConnectionControllerJitterTest`.
+     */
+    private fun assertRung(attempt: Int, maxAttempts: Int, baseDelayMs: Long, state: ConnectionState) {
+        val recon = state as ConnectionState.Reconnecting
+        assertEquals(host, recon.host)
+        assertEquals(a, recon.targetId)
+        assertEquals(attempt, recon.attempt)
+        assertEquals(maxAttempts, recon.maxAttempts)
+        if (baseDelayMs == 0L) {
+            assertEquals("the instant first rung is never jittered", 0L, recon.retryDelayMs)
+        } else {
+            val band = (baseDelayMs * 0.8).toLong()..(baseDelayMs * 1.2).toLong()
+            assertTrue(
+                "attempt $attempt: ${recon.retryDelayMs}ms outside the +/-20% jitter band " +
+                    "$band of ${baseDelayMs}ms",
+                recon.retryDelayMs in band,
+            )
+        }
+    }
+
     @Test
     fun `injected ladder drives maxAttempts and per-attempt retry delay`() {
         val (c, transport) = controller(ladder = listOf(0L, 1_000L, 2_000L, 5_000L))
         c.bringToReconnecting(transport)
 
-        assertEquals(
-            ConnectionState.Reconnecting(host, a, attempt = 1, maxAttempts = 4, retryDelayMs = 0L),
-            c.state.value,
-        )
+        assertRung(attempt = 1, maxAttempts = 4, baseDelayMs = 0L, state = c.state.value)
         // Advancement is EXCLUSIVELY ReconnectFailed (one per real rung failure).
         c.submit(ConnectionEvent.ReconnectFailed)
-        assertEquals(
-            ConnectionState.Reconnecting(host, a, attempt = 2, maxAttempts = 4, retryDelayMs = 1_000L),
-            c.state.value,
-        )
+        assertRung(attempt = 2, maxAttempts = 4, baseDelayMs = 1_000L, state = c.state.value)
         c.submit(ConnectionEvent.ReconnectFailed)
-        assertEquals(
-            ConnectionState.Reconnecting(host, a, attempt = 3, maxAttempts = 4, retryDelayMs = 2_000L),
-            c.state.value,
-        )
+        assertRung(attempt = 3, maxAttempts = 4, baseDelayMs = 2_000L, state = c.state.value)
         c.submit(ConnectionEvent.ReconnectFailed)
-        assertEquals(
-            ConnectionState.Reconnecting(host, a, attempt = 4, maxAttempts = 4, retryDelayMs = 5_000L),
-            c.state.value,
-        )
+        assertRung(attempt = 4, maxAttempts = 4, baseDelayMs = 5_000L, state = c.state.value)
     }
 
     @Test
@@ -103,10 +114,7 @@ class ConnectionControllerReconnectLadderTest {
         // A 1-step ladder: every attempt reuses the single step's delay.
         val (c, transport) = controller(ladder = listOf(750L))
         c.bringToReconnecting(transport)
-        assertEquals(
-            ConnectionState.Reconnecting(host, a, attempt = 1, maxAttempts = 1, retryDelayMs = 750L),
-            c.state.value,
-        )
+        assertRung(attempt = 1, maxAttempts = 1, baseDelayMs = 750L, state = c.state.value)
         // attempt 2 > budget 1 -> exhausted (no over-run of the ladder).
         c.submit(ConnectionEvent.ReconnectFailed)
         assertEquals(ConnectionState.Unreachable(host, a), c.state.value)


### PR DESCRIPTION
Closes #1633. Part of the #1610 mobile reconnect-storm fix.

## Why

The maintainer cannot use PocketShell on mobile internet: it reconnects every ~5s, forever, and never gives up. Six independent investigations converged on the mechanism and **overturned #1610's own documented diagnosis** — full record in [`docs/connection-storm-2026-07-16.md`](https://github.com/alexeygrigorev/pocketshell/blob/main/docs/connection-storm-2026-07-16.md).

This slice fixes one of the three stacked defects: **the attempt counter reset on "a dial succeeded" rather than "a connection proved stable"**, so connect-then-die looked like an unbroken series of first attempts. Backoff never engaged, `maxAttempts` was never reached, and the give-up arm was dead code. Across 15,456 log lines, `retryDelayMs` is non-zero only 24 times — all *outside* bursts.

## What changed

- Reset the counter only after continuous-Live past a **stability window**; a drop before it closes resumes at attempt+1 (the Kubernetes CrashLoopBackOff model, arrived at independently by two agents).
- **Episode semantics**: an episode spans the whole flap sequence. Exiting to Live no longer ends it; the stability-window commit does.
- **Give-up becomes reachable** now that the counter advances.
- **±20% jitter** on ladder delays (gRPC model).
- Closed **two counter-laundering holes** found by the implementer reviewing its own diff — notably `onNetworkChanged(validatedHandoff=true)` hard-arming `attempt = 1` on `Live`. RAT handovers on a flapping mobile link are exactly this issue's environment, so a handover hitting a brief Live moment would have reset the ladder forever and silently defeated the fix.

Tuning values (30s window, 120s budget, ±20%) are **constructor-injectable and proposed, not locked** — pending the maintainer's tuning call.

## Honest limits

**This slice alone does not change on-device behaviour.** The passive-grace loop never submits `ReconnectFailed`, so the counter is not yet fed — **#1539 owns that wiring and is the load-bearing slice**. The D33 symptom-gone bar correctly lands on the joint #1539+#1633 journey. No on-device claim is made here.

Follow-up for #1539 (raised by this reviewer): the `attempt == 0` pure-silent-heal loop never arms the counter and re-stamps `episodeStartMs` each cycle, so neither budget can fire on that path. The joint journey must assert termination through it, not only the ladder path.

## Verification

Reviewer independently drove red→green this run (G1): base reproduces the maintainer's signature with **exactly 40×** `attempt=1 retryDelayMs=0` (counted programmatically), and fails with *"the give-up arm was never entered"* — which proves `Unreachable` was dead code and that the give-up test cannot pass vacuously (G3).

Orchestrator gate in a clean integration worktree off `origin/main`:
- `:app:testDebugUnitTest --rerun-tasks` — **3906 tests, 0 failures, 0 skipped**, 5m58s, no hang (independently confirms no unbounded loop; the #1517 class does not apply)
- `:shared:core-connection:testDebugUnitTest --rerun-tasks` — **142 tests, 0 failures, 0 skipped**; all three load-bearing classes confirmed present in the results (non-vacuous)
- `check-file-size-hygiene.sh`, `check-connection-vm-ratchet.sh` (17597 lines vs 17621 baseline), `check-test-validity.sh`, `check-version-coupling.sh` — all exit 0
- `git diff --check` clean

Review: https://github.com/alexeygrigorev/pocketshell/issues/1633#issuecomment-4991735745 (APPROVED)