### PR TITLE
connection: suppress recovery's own teardown instead of re-ingesting it (#1632)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -3455,15 +3455,10 @@ public class TmuxSessionViewModel @Inject constructor(
      */
     private val passiveTransportDropEffects: PassiveTransportDropEffects =
         PassiveTransportDropEffects(
-            isSelfInflictedClose = { client ->
-                // Issue #1568 (P0-5): a self-inflicted close (ExplicitDetach/ExplicitClose/
-                // `detach_or_replace`) is not a passive loss and must never re-arm recovery —
-                // ignoring our own ExplicitClose breaks the #1562 dial→close→re-arm→dial storm.
-                val disconnectEvent = client.disconnectEvent.value
-                disconnectEvent?.reason == TmuxDisconnectReason.ExplicitDetach ||
-                    disconnectEvent?.reason == TmuxDisconnectReason.ExplicitClose ||
-                    disconnectEvent?.intent == "detach_or_replace"
-            },
+            // Issue #1632: the self-inflicted predicate is no longer inlined here. It moved
+            // to the single `SelfInflictedClose` authority that ALSO answers for the lease
+            // edge, so recovery's own teardown can never again be self-inflicted on one edge
+            // and a fresh remote failure on the other (the #1610 storm).
             isCurrentClient = { client -> clientRef === client },
             hasTarget = { (activeTarget ?: connectingTarget) != null },
             screenStartedForCleared = { screenStartedForCleared },

--- a/app/src/main/java/com/pocketshell/app/tmux/connection/ConnectionEffectDriver.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/connection/ConnectionEffectDriver.kt
@@ -415,6 +415,48 @@ class ConnectionEffectDriver(
 
                 is TransportUpDown.Down ->
                     if (edge.host == controller.state.value.hostOrNull()) {
+                        // Issue #1632: a SELF-INFLICTED lease teardown is an ECHO of an
+                        // action already in flight — recovery's own
+                        // `sshLeaseManager.disconnect()` (the first act of
+                        // `silentlyReconnectTransportAfterPassiveDisconnect`), a
+                        // force-refresh eviction, an idle reap, a lifecycle teardown. It is
+                        // NOT news of a failure, so submitting it as `TransportDropped`
+                        // re-arms the ladder against ourselves: `Reconnecting 1/4` repaints
+                        // and recovery re-triggers, whose teardown echoes again — the #1610
+                        // storm the maintainer cannot work through on mobile (215
+                        // ExplicitDisconnect/down events vs 26 real ladder rungs ever).
+                        //
+                        // The intent is READ off the edge, never inferred here: the emitter
+                        // ([leaseStateToTransportEdge]) stamped it from the reason the lease
+                        // manager named at its own close site. Checked BEFORE the
+                        // single-grace-owner gate because "we did this on purpose" is a
+                        // stronger statement than "we are backgrounded" — it holds
+                        // regardless of lifecycle.
+                        //
+                        // A GENUINE death (peer gone, keepalive-declared dead) is NOT
+                        // locally initiated and falls straight through to the normal
+                        // submit below, so real failures still drive recovery. That
+                        // negative is load-bearing: over-filtering here would stop the app
+                        // reconnecting at all, which is worse than the storm.
+                        if (edge.locallyInitiated) {
+                            ReconnectCauseTrail.record(
+                                stage = "lease_transport",
+                                outcome = "down_self_inflicted",
+                                cause = edge.reason,
+                            )
+                            onDropSuppressed(
+                                SuppressedDropDiagnostic(
+                                    cause = edge.reason,
+                                    fields = mapOf(
+                                        "transportDropReason" to edge.reason,
+                                        "transportDropSource" to "lease_transport",
+                                        "selfInflicted" to "true",
+                                    ),
+                                ),
+                            )
+                            record(Observation.DropSuppressed)
+                            return@collect
+                        }
                         // Issue #969: stamp the NAMED drop cause into the
                         // exported reconnect trail so the maintainer can see why
                         // the terminal reconnected (e.g. `keepalive_dead`)

--- a/app/src/main/java/com/pocketshell/app/tmux/connection/ConnectionPortAdapters.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/connection/ConnectionPortAdapters.kt
@@ -125,13 +125,26 @@ class SshLeaseTransportPort(
  * out) rather than being mis-reported as a spurious up or down — the controller
  * must never see a fake edge. Exposed as a top-level pure function so it is
  * unit-testable without a real lease manager.
+ *
+ * Issue #1632: this is the EMITTER of the lease `Down` edge, so it is where the
+ * local-intent token is stamped. [SshLeaseManager] already names WHY it closed at
+ * each of its own `emitStateLocked` call sites; [SelfInflictedClose] turns that
+ * named reason into [TransportUpDown.Down.locallyInitiated] once, here, so no
+ * downstream consumer ever has to infer "was that teardown us?" from a reason
+ * string. That inference gap is the #1632 defect: recovery's own
+ * `sshLeaseManager.disconnect()` looked, downstream, exactly like a remote drop.
  */
 internal fun leaseStateToTransportEdge(event: SshLeaseStateEvent): TransportUpDown? {
     val host = hostKeyFor(event.key)
     return when (event.state) {
         SshLeaseConnectionState.Connected -> TransportUpDown.Up(host)
         SshLeaseConnectionState.Closed ->
-            TransportUpDown.Down(host, reason = transportDropReason(event.closeReason))
+            TransportUpDown.Down(
+                host = host,
+                reason = transportDropReason(event.closeReason),
+                locallyInitiated = SelfInflictedClose.isSelfInflictedLeaseClose(event.closeReason),
+            )
+
         SshLeaseConnectionState.Connecting,
         SshLeaseConnectionState.Idle,
         -> null

--- a/app/src/main/java/com/pocketshell/app/tmux/connection/PassiveTransportDropEffects.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/connection/PassiveTransportDropEffects.kt
@@ -132,7 +132,6 @@ fun preferFreshTransportForPassiveReattach(
  * the DECISION; the VM holds the state + the per-arm recovery IO.
  */
 class PassiveTransportDropEffects(
-    private val isSelfInflictedClose: (TmuxClient) -> Boolean,
     private val isCurrentClient: (TmuxClient) -> Boolean,
     private val hasTarget: () -> Boolean,
     private val screenStartedForCleared: () -> Boolean,
@@ -145,7 +144,14 @@ class PassiveTransportDropEffects(
      */
     fun classify(client: TmuxClient): PassiveDropArm =
         selectPassiveDropArm(
-            isSelfInflictedClose = isSelfInflictedClose(client),
+            // Issue #1632: the self-inflicted answer comes from the ONE authority
+            // ([SelfInflictedClose]) that also answers for the lease edge. The
+            // injectable `isSelfInflictedClose` lambda this used to take — the narrow
+            // #1568 `-CC`-only filter, inlined in `TmuxSessionViewModel` — is DELETED
+            // (D22 hard-cut): two independently-maintained filters is precisely how the
+            // lease edge silently never got one and the #1610 storm survived #1568.
+            isSelfInflictedClose =
+                SelfInflictedClose.isSelfInflictedControlChannelClose(client.disconnectEvent.value),
             isCurrentClient = isCurrentClient(client),
             hasTarget = hasTarget(),
             screenStartedForCleared = screenStartedForCleared(),

--- a/app/src/main/java/com/pocketshell/app/tmux/connection/SelfInflictedClose.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/connection/SelfInflictedClose.kt
@@ -1,0 +1,108 @@
+package com.pocketshell.app.tmux.connection
+
+import com.pocketshell.core.ssh.SshLeaseCloseReason
+import com.pocketshell.core.tmux.TmuxDisconnectEvent
+import com.pocketshell.core.tmux.TmuxDisconnectReason
+
+/**
+ * Issue #1632 — the SINGLE self-inflicted-close authority for the whole connection core.
+ *
+ * ## Why this exists
+ * The #1568 P0-5 self-inflicted filter was built ONLY on the `-CC` channel edge, as an
+ * inline lambda in `TmuxSessionViewModel` that pattern-matched `TmuxDisconnectReason`.
+ * The LEASE edge never got one. So `silentlyReconnectTransportAfterPassiveDisconnect`'s
+ * own first act — `sshLeaseManager.disconnect(leaseKey)` — emitted an `ExplicitDisconnect`
+ * lease `Closed` that [ConnectionEffectDriver] submitted to the controller as a
+ * `TransportDropped`: recovery's own teardown, re-ingested as a fresh remote failure,
+ * repainting `Reconnecting 1/4` and re-triggering recovery. That echo is the amplification
+ * engine of the #1610 storm (historically 215 `ExplicitDisconnect/down` events against
+ * only 26 numbered-ladder rungs ever — the echo dominated the real ladder ~8x).
+ *
+ * Per D22 (hard-cut) this is NOT a second filter beside the `-CC` one: the narrow inline
+ * `-CC` lambda is DELETED and both edges now route through here. One authority, one answer.
+ *
+ * ## The rule: LOCAL INTENT, not local execution
+ * A close is self-inflicted when **we decided the transport/channel should go away while,
+ * as far as we knew, it was still usable**. It is NOT self-inflicted merely because our
+ * code executed the `close()` call — a watchdog that observes a dead peer and closes the
+ * corpse is REPORTING a remote death, not causing one.
+ *
+ * This distinction is load-bearing and deliberately conservative. Suppressing a genuine
+ * failure is strictly WORSE than the storm: the app would simply stop reconnecting. So
+ * when intent is ambiguous, the answer is "not self-inflicted" and recovery runs.
+ *
+ * Both entry points are exhaustive `when`s over their enums on purpose: a new close
+ * reason must not silently default into either bucket — the compiler forces whoever adds
+ * one to state its intent here, at the authority, which is what stopped this from being
+ * maintained on the two edges independently in the first place.
+ */
+object SelfInflictedClose {
+
+    /**
+     * Is this lease `Closed` edge OUR OWN teardown?
+     *
+     * @param reason the [SshLeaseCloseReason] the lease manager stamped on the edge at its
+     *   emit site. The reason IS the emitter's intent token — every `emitStateLocked` call
+     *   in `SshLeaseManager` names why it is closing — so this is emitter-side tagging, not
+     *   consumer-side inference about "was that us?" (the inference that rotted into #1632).
+     */
+    fun isSelfInflictedLeaseClose(reason: SshLeaseCloseReason?): Boolean = when (reason) {
+        // We asked for the teardown. `ExplicitDisconnect` is the reported defect itself:
+        // recovery's own first act (`TmuxSessionViewModel.kt:8455`).
+        SshLeaseCloseReason.ExplicitDisconnect,
+        // We evicted a warm transport to force a fresh dial (network handoff / recovery).
+        SshLeaseCloseReason.ForceRefresh,
+        // Our idle reaper closed a zero-reference lease. No holder, no user-visible drop.
+        SshLeaseCloseReason.IdleExpired,
+        SshLeaseCloseReason.IdleTrimmed,
+        // App lifecycle teardown — our policy, not the peer's doing.
+        SshLeaseCloseReason.ProcessStopped,
+        SshLeaseCloseReason.ManagerClosed,
+        // We cancelled our own in-flight connect (#1185). It never produced a live
+        // transport, so there is no transport to have "dropped".
+        SshLeaseCloseReason.ConnectCancelled,
+        -> true
+
+        // The peer died under us. sshj flipped `isConnected` false — per the #1632
+        // investigation a raw SSHException from a channel read means the transport was
+        // ALREADY dead, so a redial is justified.
+        SshLeaseCloseReason.Disconnected,
+        // The always-on keepalive watchdog (#945) DETECTED a silent peer death and closed
+        // the corpse. We executed the close; the peer caused it. This is precisely the
+        // mobile silent-drop detector — filtering it would strand the maintainer with no
+        // reconnect at all, the one outcome worse than the storm.
+        SshLeaseCloseReason.KeepaliveDead,
+        // An unnamed close carries no evidence of local intent; assume genuine and recover.
+        null,
+        -> false
+    }
+
+    /**
+     * Is this `-CC` control-channel disconnect OUR OWN close? Preserves the #1568 P0-5
+     * behavior exactly — it is the same predicate, relocated from the deleted inline
+     * `TmuxSessionViewModel` lambda into this authority.
+     */
+    fun isSelfInflictedControlChannelClose(event: TmuxDisconnectEvent?): Boolean {
+        if (event == null) return false
+        // #1568: a detach performed as part of swapping/replacing the attached client.
+        if (event.intent == DETACH_OR_REPLACE_INTENT) return true
+        return when (event.reason) {
+            // Our own `TmuxClient.close()` / detach. Ignoring these is what broke the
+            // #1562 dial -> close -> re-arm -> dial storm.
+            TmuxDisconnectReason.ExplicitClose,
+            TmuxDisconnectReason.ExplicitDetach,
+            -> true
+
+            // Genuine passive losses — recovery depends on every one of these arming.
+            TmuxDisconnectReason.ReaderEof,
+            TmuxDisconnectReason.ReaderException,
+            TmuxDisconnectReason.CommandTimeout,
+            TmuxDisconnectReason.ServerExited,
+            TmuxDisconnectReason.Unknown,
+            -> false
+        }
+    }
+
+    /** The #1568 client-swap intent marker carried on a detach we performed ourselves. */
+    private const val DETACH_OR_REPLACE_INTENT = "detach_or_replace"
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/connection/ConnectionEffectDriverConnectionLogMirrorTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/connection/ConnectionEffectDriverConnectionLogMirrorTest.kt
@@ -78,7 +78,7 @@ class ConnectionEffectDriverConnectionLogMirrorTest {
         assertEquals("a foreign-host Up must not mirror", 0, mirrorFires)
 
         // A Down for the current host must NOT fire the mirror (only Up does).
-        transportPort.transportEventsFlow.emit(TransportUpDown.Down(host, reason = "closed"))
+        transportPort.transportEventsFlow.emit(TransportUpDown.Down(host, reason = "closed", locallyInitiated = false))
         assertEquals("a Down edge must not mirror", 0, mirrorFires)
 
         // The current-host Up (reconnect completed) fires the mirror exactly once.
@@ -86,7 +86,7 @@ class ConnectionEffectDriverConnectionLogMirrorTest {
         assertEquals("the current-host reconnect Up must mirror once", 1, mirrorFires)
 
         // A second reconnect cycle fires it again (it is the per-reconnect trigger).
-        transportPort.transportEventsFlow.emit(TransportUpDown.Down(host, reason = "closed"))
+        transportPort.transportEventsFlow.emit(TransportUpDown.Down(host, reason = "closed", locallyInitiated = false))
         transportPort.transportEventsFlow.emit(TransportUpDown.Up(host))
         assertEquals("each reconnect Up re-mirrors", 2, mirrorFires)
 

--- a/app/src/test/java/com/pocketshell/app/tmux/connection/ConnectionEffectDriverTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/connection/ConnectionEffectDriverTest.kt
@@ -812,7 +812,7 @@ class ConnectionEffectDriverTest {
         // A real lease `Down` for the CURRENT host is now submitted as TransportDropped:
         // the controller heals Live -> Reattaching (the first ladder rung). Slice 3
         // makes the controller authoritative for that ladder STATE.
-        transportPort.transportEventsFlow.emit(TransportUpDown.Down(host, reason = "closed"))
+        transportPort.transportEventsFlow.emit(TransportUpDown.Down(host, reason = "closed", locallyInitiated = false))
         assertEquals(
             "a foreground lease Down walks the controller Live -> Reattaching",
             listOf("Idle", "Attaching", "Live", "Reattaching"),
@@ -824,7 +824,7 @@ class ConnectionEffectDriverTest {
         )
 
         // A second lease Down escalates the ladder: Reattaching -> Reconnecting(1).
-        transportPort.transportEventsFlow.emit(TransportUpDown.Down(host, reason = "closed"))
+        transportPort.transportEventsFlow.emit(TransportUpDown.Down(host, reason = "closed", locallyInitiated = false))
         assertTrue(
             "a second lease Down escalates the ladder to Reconnecting",
             controller.state.value is ConnectionState.Reconnecting,
@@ -852,7 +852,7 @@ class ConnectionEffectDriverTest {
         controller.submit(ConnectionEvent.Enter(host, sessionA))
         assertEquals(listOf("Idle", "Attaching"), stateNamesOf(driver))
 
-        transportPort.transportEventsFlow.emit(TransportUpDown.Down(host, reason = "closed"))
+        transportPort.transportEventsFlow.emit(TransportUpDown.Down(host, reason = "closed", locallyInitiated = false))
 
         assertEquals(
             "lease Down from Attaching must submit one silent drop into Reattaching",
@@ -905,7 +905,7 @@ class ConnectionEffectDriverTest {
         // A lease Down while backgrounded must be recorded as DropSuppressed and NOT
         // submitted — submitting it would collapse the controller toward Unreachable
         // while backgrounded (the #635 band on the next within-grace foreground).
-        transportPort.transportEventsFlow.emit(TransportUpDown.Down(host, reason = "keepalive_dead"))
+        transportPort.transportEventsFlow.emit(TransportUpDown.Down(host, reason = "keepalive_dead", locallyInitiated = false))
         assertTrue(
             "a suppressed lease Down must be recorded as DropSuppressed",
             driver.observations.value.any {
@@ -950,7 +950,7 @@ class ConnectionEffectDriverTest {
         // filter — exactly as the lease Up edge already gates — so it never disturbs
         // the current target's live channel.
         transportPort.transportEventsFlow.emit(
-            TransportUpDown.Down(HostKey("bob@elsewhere.example:22/9"), reason = "closed"),
+            TransportUpDown.Down(HostKey("bob@elsewhere.example:22/9"), reason = "closed", locallyInitiated = false),
         )
         assertEquals(
             "a lease Down for an unrelated host must not move the controller",
@@ -1014,7 +1014,7 @@ class ConnectionEffectDriverTest {
 
         // The driver must SEE both port flows, independent of controller state.
         h.tmuxPort.disconnectedFlow.emit(true)
-        h.transportPort.transportEventsFlow.emit(TransportUpDown.Down(host, reason = "closed"))
+        h.transportPort.transportEventsFlow.emit(TransportUpDown.Down(host, reason = "closed", locallyInitiated = false))
         h.transportPort.transportEventsFlow.emit(TransportUpDown.Up(host))
 
         val obs = h.driver.observations.value
@@ -1055,7 +1055,7 @@ class ConnectionEffectDriverTest {
         h.controller.submit(ConnectionEvent.Foreground)
         h.controller.submit(ConnectionEvent.TransportDropped("drop"))
         h.tmuxPort.disconnectedFlow.emit(true)
-        h.transportPort.transportEventsFlow.emit(TransportUpDown.Down(host, "closed"))
+        h.transportPort.transportEventsFlow.emit(TransportUpDown.Down(host, "closed", locallyInitiated = false))
 
         // Reaching here without an AssertionError from a fake port IS the proof:
         // the driver collected/logged every signal and called zero port IO.

--- a/app/src/test/java/com/pocketshell/app/tmux/connection/ConnectionPortAdaptersTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/connection/ConnectionPortAdaptersTest.kt
@@ -63,7 +63,7 @@ class ConnectionPortAdaptersTest {
     fun `lease Closed maps to transport Down carrying the close reason`() {
         val host = hostKeyFor(leaseKey)
         assertEquals(
-            TransportUpDown.Down(host, reason = "Disconnected"),
+            TransportUpDown.Down(host, reason = "Disconnected", locallyInitiated = false),
             leaseStateToTransportEdge(
                 SshLeaseStateEvent(leaseKey, SshLeaseConnectionState.Closed, SshLeaseCloseReason.Disconnected),
             ),
@@ -85,7 +85,7 @@ class ConnectionPortAdaptersTest {
         // a keepalive-driven drop surfaced as the anonymous `Disconnected`. The
         // named token is what makes the cause visible (the #964 ambiguity).
         assertEquals(
-            TransportUpDown.Down(host, reason = "keepalive_dead"),
+            TransportUpDown.Down(host, reason = "keepalive_dead", locallyInitiated = false),
             leaseStateToTransportEdge(
                 SshLeaseStateEvent(
                     leaseKey,

--- a/app/src/test/java/com/pocketshell/app/tmux/connection/Issue1632SelfInflictedTeardownEchoTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/connection/Issue1632SelfInflictedTeardownEchoTest.kt
@@ -1,0 +1,369 @@
+package com.pocketshell.app.tmux.connection
+
+import com.pocketshell.core.connection.Clock
+import com.pocketshell.core.connection.ConnectionController
+import com.pocketshell.core.connection.ConnectionEvent
+import com.pocketshell.core.connection.ConnectionState
+import com.pocketshell.core.connection.SessionId
+import com.pocketshell.core.connection.TmuxPort
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.SshKey
+import com.pocketshell.core.ssh.SshLease
+import com.pocketshell.core.ssh.SshLeaseConnector
+import com.pocketshell.core.ssh.SshLeaseKey
+import com.pocketshell.core.ssh.SshLeaseManager
+import com.pocketshell.core.ssh.SshLeaseTarget
+import com.pocketshell.core.ssh.SshPortForward
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshSessionCloseCause
+import com.pocketshell.core.ssh.SshShell
+import com.pocketshell.core.tmux.TmuxDisconnectEvent
+import com.pocketshell.core.tmux.TmuxDisconnectReason
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+import java.io.InputStream
+
+/**
+ * Issue #1632 — PocketShell's OWN recovery teardown must not echo back as a fresh
+ * passive failure that re-arms the reconnect ladder.
+ *
+ * This is the amplification engine behind the #1610 reconnect storm the maintainer
+ * cannot work through on mobile internet: the #1568 P0-5 self-inflicted filter was
+ * built ONLY on the `-CC` channel edge (`TmuxClient.close()`), never on the LEASE
+ * edge. So `silentlyReconnectTransportAfterPassiveDisconnect`'s first act —
+ * `sshLeaseManager.disconnect(leaseKey)` — emits an `ExplicitDisconnect` lease
+ * `Closed`, which `ConnectionEffectDriver` submitted to the controller as a
+ * `TransportDropped`, repainting `Reconnecting 1/4` and re-triggering recovery.
+ * Historically 215 `ExplicitDisconnect/down` events vs only 26 numbered-ladder
+ * rungs ever — the echo path dominated the real ladder ~8x.
+ *
+ * ## Why the REAL chain (D33/G10/F2 — no proxy)
+ * These tests drive the PRODUCTION path end to end for this defect:
+ *
+ *   real [SshLeaseManager] -> real [SshLeaseTransportPort] (`leaseStateToTransportEdge`)
+ *   -> real [ConnectionEffectDriver] -> real [ConnectionController]
+ *
+ * NOT a hand-built `TransportUpDown.Down(host, reason = "ExplicitDisconnect")`. A
+ * hand-made edge would hardcode the very reason mapping under test and would pass
+ * vacuously if the emitter stopped tagging intent. The teardown here is performed by
+ * calling the SAME lease-manager APIs recovery itself calls (`disconnect` / `evictIdle`),
+ * so the tag is proven to survive the real emitter -> adapter -> driver hop.
+ *
+ * The load-bearing NEGATIVE case (G6 / brief constraint 3) is
+ * [genuineRemoteTransportDeathStillDrivesRecovery] and
+ * [keepaliveDeclaredDeathStillDrivesRecovery]: a filter that is too broad stops the
+ * app reconnecting at all, which is strictly worse than the storm. Those two assert
+ * the ladder DOES still arm, and they are the reason this filter keys on local
+ * INTENT, never on "a close happened".
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class Issue1632SelfInflictedTeardownEchoTest {
+
+    private val leaseKey = SshLeaseKey(
+        host = "dev.example",
+        port = 22,
+        user = "alexey",
+        credentialId = "cred-1",
+    )
+    private val host = hostKeyFor(leaseKey)
+    private val sessionA = SessionId("work")
+
+    // ---------------------------------------------------------------------------
+    // RED on base: recovery's own lease teardown echoes back and re-arms the ladder.
+    // ---------------------------------------------------------------------------
+
+    /**
+     * The reported defect, on the real path. `silentlyReconnectTransportAfterPassiveDisconnect`
+     * begins by evicting the shared per-host transport with `sshLeaseManager.disconnect(leaseKey)`.
+     * That is OUR OWN teardown — the first act of a recovery already in progress. On base the
+     * resulting `ExplicitDisconnect` lease `Down` was submitted as `TransportDropped` and walked
+     * the controller Live -> Reattaching, repainting the ladder and re-triggering recovery.
+     */
+    @Test
+    fun recoveryOwnLeaseDisconnectIsSuppressedAndDoesNotReArmTheLadder() = runTest {
+        val h = liveChain()
+
+        // Recovery's own first act — the EXACT call at TmuxSessionViewModel.kt:8455.
+        h.manager.disconnect(leaseKey)
+        runCurrent()
+
+        assertTrue(
+            "a self-inflicted lease disconnect (recovery's own teardown) must NOT be submitted " +
+                "as TransportDropped — it must not re-arm the reconnect ladder (#1632/#1610 storm)",
+            h.controller.state.value is ConnectionState.Live,
+        )
+        assertEquals(
+            "the ladder must never re-arm for our own teardown: no Reattaching/Reconnecting " +
+                "rung may EVER be entered (that repaint is the storm the maintainer sees)",
+            emptyList<String>(),
+            h.ladderRungs(),
+        )
+        assertTrue(
+            "a suppressed self-inflicted lease Down must still be observable for diagnostics",
+            h.driver.observations.value.any {
+                it is ConnectionEffectDriver.Observation.DropSuppressed
+            },
+        )
+        h.close()
+    }
+
+    /**
+     * Class coverage (G2): the SIBLING lease-edge teardown. `evictIdle` is the other
+     * locally-initiated lease close recovery/network-handoff code drives (`ForceRefresh`).
+     * Same local intent, same suppression — otherwise the filter is a one-instance patch.
+     */
+    @Test
+    fun forceRefreshEvictionIsSuppressedAndDoesNotReArmTheLadder() = runTest {
+        val h = liveChain()
+
+        // Drop to zero refs so evictIdle() can take the entry, then force-refresh it.
+        h.lease.release()
+        runCurrent()
+        val evicted = h.manager.evictIdle(leaseKey)
+        runCurrent()
+
+        assertTrue("evictIdle must actually have closed an idle lease", evicted)
+        assertTrue(
+            "a ForceRefresh eviction is OUR teardown for a fresh dial — it must not re-arm the ladder",
+            h.controller.state.value is ConnectionState.Live,
+        )
+        assertEquals(
+            "a ForceRefresh eviction must not enter any ladder rung",
+            emptyList<String>(),
+            h.ladderRungs(),
+        )
+        h.close()
+    }
+
+    // ---------------------------------------------------------------------------
+    // LOAD-BEARING NEGATIVE (G6): a genuine remote death must STILL drive recovery.
+    // A filter that is too broad is worse than the storm.
+    // ---------------------------------------------------------------------------
+
+    /**
+     * G6 / brief constraint 3. The transport dies remotely (sshj flips `isConnected`
+     * false — per Investigation B a raw `SSHException` from a channel read means the
+     * shared transport was ALREADY DEAD, so a redial is JUSTIFIED). The lease emits an
+     * anonymous `Disconnected`. This is NOT locally initiated and MUST still submit
+     * `TransportDropped` and arm the ladder.
+     */
+    @Test
+    fun genuineRemoteTransportDeathStillDrivesRecovery() = runTest {
+        val h = liveChain()
+
+        // The peer died under us — nothing local asked for this.
+        h.session.isConnected = false
+        h.lease.release()
+        runCurrent()
+
+        assertTrue(
+            "a GENUINE remote transport death must still be submitted as TransportDropped and " +
+                "arm the reconnect ladder — the self-inflicted filter must never swallow real failures",
+            h.controller.state.value is ConnectionState.Reattaching,
+        )
+        h.close()
+    }
+
+    /**
+     * G2 + G6: the keepalive edge. The always-on keepalive watchdog (#945) DETECTS a
+     * silent peer death and closes the corpse; the close is executed locally but the
+     * DEATH is remote, so `KeepaliveDead` is a genuine failure, not a self-inflicted
+     * teardown. This is precisely the mobile silent-drop detector — suppressing it
+     * would leave the maintainer stranded with no reconnect at all.
+     */
+    @Test
+    fun keepaliveDeclaredDeathStillDrivesRecovery() = runTest {
+        val h = liveChain()
+
+        h.session.closeCause = SshSessionCloseCause.KeepaliveDead
+        h.session.isConnected = false
+        h.lease.release()
+        runCurrent()
+
+        assertTrue(
+            "a keepalive-declared transport death is a GENUINE remote failure (the watchdog only " +
+                "executes the close) — it must still arm the reconnect ladder",
+            h.controller.state.value is ConnectionState.Reattaching,
+        )
+        h.close()
+    }
+
+    // ---------------------------------------------------------------------------
+    // Adjacency sweep (D31): the #1567/#1568 `-CC` self-inflicted cases must not
+    // regress now that the narrow filter is unified into SelfInflictedClose.
+    // ---------------------------------------------------------------------------
+
+    @Test
+    fun ccExplicitCloseAndDetachRemainSelfInflicted_issue1568NotRegressed() {
+        assertTrue(
+            "#1568 P0-5: our own TmuxClient.close() (ExplicitClose) must stay self-inflicted",
+            SelfInflictedClose.isSelfInflictedControlChannelClose(ccEvent(TmuxDisconnectReason.ExplicitClose)),
+        )
+        assertTrue(
+            "#1568: an ExplicitDetach must stay self-inflicted",
+            SelfInflictedClose.isSelfInflictedControlChannelClose(ccEvent(TmuxDisconnectReason.ExplicitDetach)),
+        )
+        assertTrue(
+            "#1568: the `detach_or_replace` intent must stay self-inflicted",
+            SelfInflictedClose.isSelfInflictedControlChannelClose(
+                ccEvent(TmuxDisconnectReason.ReaderEof, intent = "detach_or_replace"),
+            ),
+        )
+    }
+
+    @Test
+    fun ccGenuinePassiveDropsRemainActionable_issue1568NotRegressed() {
+        listOf(
+            TmuxDisconnectReason.ReaderEof,
+            TmuxDisconnectReason.ReaderException,
+            TmuxDisconnectReason.CommandTimeout,
+            TmuxDisconnectReason.ServerExited,
+            TmuxDisconnectReason.Unknown,
+        ).forEach { reason ->
+            assertFalse(
+                "a genuine passive `-CC` drop ($reason) must NOT be filtered — recovery depends on it",
+                SelfInflictedClose.isSelfInflictedControlChannelClose(ccEvent(reason)),
+            )
+        }
+        assertFalse(
+            "a null disconnect event is not evidence of a local teardown",
+            SelfInflictedClose.isSelfInflictedControlChannelClose(null),
+        )
+    }
+
+    private fun ccEvent(
+        reason: TmuxDisconnectReason,
+        intent: String = "reader",
+    ) = TmuxDisconnectEvent(reason = reason, source = "test", intent = intent)
+
+    // ---------------------------------------------------------------------------
+    // Real-chain harness: real lease manager -> real adapter -> real driver -> real controller.
+    // ---------------------------------------------------------------------------
+
+    private class TestClock(var now: Long = 0L) : Clock {
+        override fun nowMs(): Long = now
+    }
+
+    private class InertTmuxPort : TmuxPort {
+        override val disconnected: Flow<Boolean> = flowOf(false)
+    }
+
+    private class Chain(
+        val manager: SshLeaseManager,
+        val session: FakeSession,
+        val lease: SshLease,
+        val controller: ConnectionController,
+        val driver: ConnectionEffectDriver,
+        private val scope: CoroutineScope,
+    ) {
+        fun stateNames(): List<String> =
+            driver.observations.value
+                .filterIsInstance<ConnectionEffectDriver.Observation.StateTransition>()
+                .map { ConnectionEffectDriver.Observation.nameOf(it.to) }
+
+        /**
+         * Every reconnect-ladder rung the controller entered. This — not the full state
+         * list — is the user-visible symptom: each rung is a `Reconnecting n/4` repaint
+         * and another recovery trigger. Empty means the storm did not start.
+         */
+        fun ladderRungs(): List<String> =
+            stateNames().filter { it == "Reattaching" || it.startsWith("Reconnecting") }
+
+        fun close() {
+            scope.cancel()
+        }
+    }
+
+    /**
+     * Build the production chain and drive it to a healthy `Live` — a warm lease held,
+     * the session seeded. This is the state the maintainer is in when the storm hits.
+     */
+    private suspend fun TestScope.liveChain(): Chain {
+        val session = FakeSession()
+        val manager = SshLeaseManager(
+            connector = SshLeaseConnector { Result.success(session) },
+            scope = this,
+            connectTimeoutContext = StandardTestDispatcher(testScheduler),
+            nowMillis = { testScheduler.currentTime },
+        )
+        val transportPort = SshLeaseTransportPort(
+            leaseManager = manager,
+            leaseKeyFor = { SshLeaseTarget(leaseKey = leaseKey, key = SshKey.Pem("unused")) },
+        ).also { it.warmSnapshot = { true } }
+        val controller = ConnectionController(clock = TestClock(), transport = transportPort)
+        val scope = CoroutineScope(StandardTestDispatcher(testScheduler))
+        val driver = ConnectionEffectDriver(
+            controller = controller,
+            tmuxPort = InertTmuxPort(),
+            transportPort = transportPort,
+            scope = scope,
+        ).also { it.start() }
+        runCurrent()
+
+        val lease = manager.acquire(SshLeaseTarget(leaseKey = leaseKey, key = SshKey.Pem("unused"))).getOrThrow()
+        runCurrent()
+
+        controller.submit(ConnectionEvent.Enter(host, sessionA))
+        controller.submit(ConnectionEvent.SeedLanded(sessionA, paneId = "%0"))
+        runCurrent()
+        check(controller.state.value is ConnectionState.Live) {
+            "harness must reach Live before the teardown under test; was ${controller.state.value}"
+        }
+        return Chain(manager, session, lease, controller, driver, scope)
+    }
+
+    /**
+     * A controllable transport. [isConnected] and [closeCause] are `var` so a test can
+     * stage the two states the lease manager reads to name a close reason: a genuine
+     * remote death (`isConnected = false` -> `Disconnected`) and a keepalive-declared
+     * death (`closeCause = KeepaliveDead` -> `KeepaliveDead`). That staging is what
+     * makes the load-bearing negative cases real rather than a happy fixture that
+     * could never enter the failing state (the #847 lesson).
+     */
+    private class FakeSession : SshSession {
+        override var isConnected: Boolean = true
+        override var closeCause: SshSessionCloseCause = SshSessionCloseCause.Unknown
+        private var closeStarted = false
+        override val isCloseInitiated: Boolean get() = closeStarted
+
+        override fun close() {
+            closeStarted = true
+            isConnected = false
+        }
+
+        override suspend fun exec(command: String): ExecResult =
+            ExecResult(stdout = "", stderr = "", exitCode = 0)
+
+        override fun tail(path: String, onLine: (String) -> Unit): Job = error("not used")
+
+        override fun openLocalPortForward(
+            remoteHost: String,
+            remotePort: Int,
+            localPort: Int,
+        ): SshPortForward = error("not used")
+
+        override fun startShell(): SshShell = error("not used")
+
+        override suspend fun uploadFile(file: File, remotePath: String): String = error("not used")
+
+        override suspend fun uploadStream(
+            input: InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String = error("not used")
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/connection/PassiveTransportDropEffectsTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/connection/PassiveTransportDropEffectsTest.kt
@@ -2,6 +2,8 @@ package com.pocketshell.app.tmux.connection
 
 import com.pocketshell.app.tmux.FakeTmuxClient
 import com.pocketshell.core.tmux.TmuxClient
+import com.pocketshell.core.tmux.TmuxDisconnectEvent
+import com.pocketshell.core.tmux.TmuxDisconnectReason
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -220,13 +222,15 @@ class PassiveTransportDropEffectsTest {
     private val client: TmuxClient = FakeTmuxClient()
 
     private fun effects(
-        isSelfInflictedClose: (TmuxClient) -> Boolean = { false },
         isCurrentClient: (TmuxClient) -> Boolean = { true },
         hasTarget: () -> Boolean = { true },
         screenStartedForCleared: () -> Boolean = { false },
         navigatingToDifferentSession: () -> Boolean = { false },
     ) = PassiveTransportDropEffects(
-        isSelfInflictedClose = isSelfInflictedClose,
+        // Issue #1632: the `isSelfInflictedClose` injection seam is GONE — the classifier
+        // now reads the single [SelfInflictedClose] authority off the client's real
+        // `disconnectEvent`. So these tests stage a REAL disconnect event instead of
+        // stubbing the boolean, which is what makes them actually cover the predicate.
         isCurrentClient = isCurrentClient,
         hasTarget = hasTarget,
         screenStartedForCleared = screenStartedForCleared,
@@ -235,9 +239,55 @@ class PassiveTransportDropEffectsTest {
 
     @Test
     fun classify_explicitDetach_ignored() {
+        val detached = FakeTmuxClient().apply {
+            markDisconnectedForTest(
+                TmuxDisconnectEvent(
+                    reason = TmuxDisconnectReason.ExplicitDetach,
+                    source = "test",
+                    intent = "detach",
+                ),
+            )
+        }
+        assertEquals(PassiveDropArm.Ignore, effects().classify(detached))
+    }
+
+    /**
+     * Issue #1632 (adjacency, #1568 P0-5): our own `TmuxClient.close()` must still be
+     * Ignored now that the predicate lives in the shared authority rather than the
+     * deleted inline `TmuxSessionViewModel` lambda.
+     */
+    @Test
+    fun classify_explicitClose_ignored() {
+        val closed = FakeTmuxClient().apply {
+            markDisconnectedForTest(
+                TmuxDisconnectEvent(
+                    reason = TmuxDisconnectReason.ExplicitClose,
+                    source = "test",
+                    intent = "close",
+                ),
+            )
+        }
+        assertEquals(PassiveDropArm.Ignore, effects().classify(closed))
+    }
+
+    /**
+     * Issue #1632 (G6 negative): a genuine passive `-CC` loss must still be actionable
+     * through the shared authority — the filter must not swallow real failures.
+     */
+    @Test
+    fun classify_readerEof_isNotSelfInflicted_andStillRecovers() {
+        val eofed = FakeTmuxClient().apply {
+            markDisconnectedForTest(
+                TmuxDisconnectEvent(
+                    reason = TmuxDisconnectReason.ReaderEof,
+                    source = "test",
+                    intent = "reader",
+                ),
+            )
+        }
         assertEquals(
-            PassiveDropArm.Ignore,
-            effects(isSelfInflictedClose = { true }).classify(client),
+            PassiveDropArm.SilentReattachWithinGrace,
+            effects(hasTarget = { false }).classify(eofed),
         )
     }
 

--- a/shared/core-connection/src/main/java/com/pocketshell/core/connection/Ports.kt
+++ b/shared/core-connection/src/main/java/com/pocketshell/core/connection/Ports.kt
@@ -24,7 +24,30 @@ interface Clock {
  *  portfwd-reconnect subscription consumes this; the type shape is preserved). */
 sealed interface TransportUpDown {
     data class Up(val host: HostKey) : TransportUpDown
-    data class Down(val host: HostKey, val reason: String) : TransportUpDown
+
+    /**
+     * A transport `Closed` edge.
+     *
+     * @param reason the canonical lower-snake cause token for the reconnect trail (#969).
+     * @param locallyInitiated Issue #1632 — the LOCAL-INTENT token, stamped by the EMITTER
+     *   (`leaseStateToTransportEdge`, from the close reason the lease manager named at its
+     *   own emit site). True when WE tore the transport down (recovery's own
+     *   `sshLeaseManager.disconnect()`, a force-refresh eviction, idle reaping, lifecycle
+     *   teardown) — i.e. this `Down` is an ECHO of an action already in flight, not news of
+     *   a failure. False for a genuine death (peer gone, keepalive-declared dead), which
+     *   must still drive recovery.
+     *
+     *   The token rides on the edge deliberately: the consumer must NEVER infer "was that
+     *   us?" by pattern-matching the reason string. That inference is exactly what rotted
+     *   into #1632 — the `-CC` edge grew a self-inflicted filter (#1568) and the lease edge
+     *   silently did not, so recovery's own teardown re-armed the ladder forever (the #1610
+     *   storm). Intent is knowledge only the emitter has; it is carried, not guessed.
+     */
+    data class Down(
+        val host: HostKey,
+        val reason: String,
+        val locallyInitiated: Boolean,
+    ) : TransportUpDown
 }
 
 /**


### PR DESCRIPTION
Closes #1632. Part of the #1610 mobile reconnect-storm fix. Rebased onto #1633 (`0c55af4b`).

## Why

The maintainer cannot use PocketShell on mobile: it reconnects every ~5s forever. Root-cause record: [`docs/connection-storm-2026-07-16.md`](https://github.com/alexeygrigorev/pocketshell/blob/main/docs/connection-storm-2026-07-16.md).

This slice removes the storm's **amplification engine**. The #1568 self-inflicted filter existed only on the `-CC` edge (`TmuxClient.close()`), never on the lease edge — so recovery's own `sshLeaseManager.disconnect()` came back through `ConnectionEffectDriver` looking exactly like a genuine remote drop and re-armed the ladder. Historically **215 `ExplicitDisconnect/down` events against only 26 numbered-ladder rungs ever** — the echo path dominated the real ladder ~8×.

## What changed

- **Tag intent at the emitter, not the consumer.** `TransportUpDown.Down` gains `locallyInitiated`, stamped in `leaseStateToTransportEdge` and *read* — never guessed — at the driver. Inference at the consumer is what rotted here.
- **No default value on the flag**, so the compiler forced all **11** construction sites to declare intent explicitly.
- **D22 hard cut**: one `SelfInflictedClose` authority now serves both edges; the narrow inline VM lambda is **deleted**. No parallel mechanism survives.
- VM **shrank** (17592 lines vs 17621 baseline) — a real reduction, baseline not raised.

## `KeepaliveDead` is deliberately NOT filtered — and the issue text was wrong

The issue asked for keepalive-initiated closes to be filtered. **That text was my error as orchestrator** ([corrected on the issue](https://github.com/alexeygrigorev/pocketshell/issues/1632#issuecomment-4991885342)). The implementer refused and asked to be challenged; the reviewer adjudicated **for the implementer** by reading Investigation B's Q5 directly (*"justified when truly dead"*, and its recommendation targets the `-CC` classifier, not the lease edge) and the death path (`RealSshSession.kt:344-362`): `onKeepAliveDead` fires only after N consecutive missed replies and names the cause before closing. **That is detection of a remote death, not self-infliction.** Filtering it would have disabled the mobile silent-drop detector — the "never reconnects at all" outcome, strictly worse than the storm. The G6 negative case caught it.

## Verification

Reviewer independently drove red→green this run (G1, neutralised via `cp`, restored byte-exact): `6 tests, 2 failed` → `6 tests, 0 failed`, with the red asserting the *actual* symptom (ladder re-arm). It verified all 11 sites declare `false` correctly, that **zero sites outside the emitter can produce `true`**, and traced all 10 `SshLeaseCloseReason` values to their emit sites — probing `IdleExpired` hardest as a silent-swallow risk and finding it safe (the VM holds `leaseRef` for the live session, so it can only fire at refCount==0).

Orchestrator gate in a clean integration worktree, **re-run after rebasing onto merged #1633**:
- `:app:testDebugUnitTest --rerun-tasks` — **3914 tests, 0 failures, 0 skipped**
- `:shared:core-connection` (124) + `:shared:core-ssh` (231) — 0 failures, 0 skipped
- **Docker `:shared:core-ssh:integrationTest`** — 15 tasks, BUILD SUCCESSFUL, 7m (required for transport-contract changes per #1144/#1149; Unit-green alone is not sufficient)
- `Issue1632SelfInflictedTeardownEchoTest` confirmed present in results (non-vacuous, G3)
- All hygiene/ratchet/validity guards exit 0 post-rebase; `git diff --check` clean

## Known residual (not a blocker)

Investigation B's item 3 — the `-CC` echo of our own lease close — is not implemented here. Per the reviewer, #866's `setClient(null)`-before-`disconnect` closes the primary loop, so it is a duplicate arm rather than a storm engine. Filed separately rather than expanding this slice.

Review: https://github.com/alexeygrigorev/pocketshell/issues/1632#issuecomment-4991878916 (APPROVED)