### PR TITLE
connection: roll ladder jitter once per install, not per rebuild (#1633) — FIXES RED MAIN

### DIFF
--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelReconnectTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelReconnectTest.kt
@@ -4,6 +4,7 @@ import com.pocketshell.app.connectivity.TerminalNetworkChange
 import com.pocketshell.app.connectivity.TerminalNetworkSnapshot
 import com.pocketshell.app.diagnostics.installRecordingDiagnosticSink
 import com.pocketshell.app.sessions.ActiveTmuxClients
+import com.pocketshell.core.connection.ConnectionController
 import com.pocketshell.core.ssh.ExecResult
 import com.pocketshell.core.ssh.SshException
 import com.pocketshell.core.ssh.SshKey
@@ -492,7 +493,18 @@ class TmuxSessionViewModelReconnectTest : TmuxSessionViewModelTestBase() {
             assertEquals("work", sessionName)
             reconnectClient
         }
-        vm.setAutoReconnectDelaysForTest(listOf(0L, 250L, 250L))
+        // Issue #1633: the controller jitters every NON-ZERO rung by ±RETRY_JITTER_FRACTION,
+        // so a 250ms rung really fires somewhere in [200, 300). Advancing a flat 250ms (as
+        // this test did before #1638 added jitter) is a literal coin flip — it fired the rung
+        // only when the roll happened to land at or below the base, which is why this test
+        // failed ~50% of runs on `main`. Advance past the rung's GUARANTEED upper bound
+        // instead. The assertions below are UNCHANGED and stay exact: each step still demands
+        // EXACTLY one new dial, because the NEXT rung's own backoff is at least
+        // rung*(1-fraction) = 200ms and at most 100ms of it can have elapsed by then, so it
+        // cannot also have fired inside this window.
+        val rungMs = 250L
+        val rungUpperBoundMs = (rungMs * (1.0 + ConnectionController.RETRY_JITTER_FRACTION)).toLong()
+        vm.setAutoReconnectDelaysForTest(listOf(0L, rungMs, rungMs))
         val oldClient = FakeTmuxClient()
         vm.replaceClientForTest(
             hostId = 7L,
@@ -522,7 +534,7 @@ class TmuxSessionViewModelReconnectTest : TmuxSessionViewModelTestBase() {
         )
         assertEquals(1, TMUX_CONNECT_ATTEMPTS.get())
 
-        advanceTimeBy(250L)
+        advanceTimeBy(rungUpperBoundMs)
         runCurrent()
 
         assertEquals(
@@ -536,7 +548,7 @@ class TmuxSessionViewModelReconnectTest : TmuxSessionViewModelTestBase() {
         )
         assertEquals(2, TMUX_CONNECT_ATTEMPTS.get())
 
-        advanceTimeBy(250L)
+        advanceTimeBy(rungUpperBoundMs)
         advanceUntilIdle()
 
         assertEquals(

--- a/shared/core-connection/src/main/java/com/pocketshell/core/connection/ConnectionController.kt
+++ b/shared/core-connection/src/main/java/com/pocketshell/core/connection/ConnectionController.kt
@@ -231,7 +231,16 @@ class ConnectionController(
      * A confined mutator (shares the single-dispatcher contract with [submit]).
      */
     fun setReconnectLadder(delaysMs: List<Long>) = confinement.guarded("setReconnectLadder") {
-        reconnectLadderMs = delaysMs
+        // Issue #1633 (round 2): jitter is rolled EXACTLY ONCE, here, per ladder install —
+        // NOT per [reconnectingAt] state build. `reconnectingAt` is invoked repeatedly for
+        // the SAME attempt (here on re-install, on [ConnectionEvent.Enter] re-entry, and on
+        // the Reattaching/Live re-assert), so rolling inside it re-rolled that one attempt's
+        // backoff on every rebuild: the VM mirrors `retryDelayMs` into the displayed band and
+        // then sleeps on its own read, so the two could disagree, and the reducer's output
+        // stopped being a function of its input sequence. Rolling at install keeps the
+        // reducer deterministic (same inputs + same ladder -> same states) while preserving
+        // the desynchronisation property: every ladder install is a fresh independent roll.
+        reconnectLadderMs = delaysMs.map(::jittered)
         // If a reconnect is already in flight when the ladder is (re)installed — the
         // proactive network-handoff / passive-drop paths enter [ConnectionState.Reconnecting]
         // BEFORE the VM effect installs its `autoReconnectDelaysMs` — re-stamp the current
@@ -248,8 +257,20 @@ class ConnectionController(
         get() = reconnectLadderMs.size.takeIf { it > 0 } ?: maxReconnectAttempts
 
     /**
-     * Backoff before the 1-based [attempt]'s dial; clamps to the last ladder step, then
-     * jittered ±[RETRY_JITTER_FRACTION] (issue #1633, the gRPC model).
+     * Backoff before the 1-based [attempt]'s dial; clamps to the last ladder step. A PURE
+     * lookup into the already-jittered [reconnectLadderMs] (issue #1633 round 2) — the roll
+     * happens once, in [setReconnectLadder], so repeated builds of the same attempt's state
+     * always report the SAME backoff.
+     */
+    private fun retryDelayForAttempt(attempt: Int): Long {
+        if (reconnectLadderMs.isEmpty()) return 0L
+        val index = (attempt - 1).coerceIn(0, reconnectLadderMs.lastIndex)
+        return reconnectLadderMs[index]
+    }
+
+    /**
+     * Apply ±[RETRY_JITTER_FRACTION] jitter to a non-zero backoff (issue #1633, the gRPC
+     * model). Called once per rung per ladder install by [setReconnectLadder].
      *
      * Mobile RAT handovers and NAT/keepalive reapers are PERIODIC, so a bare ladder can
      * resonate with that cadence (and synchronize retries across sessions into a
@@ -258,13 +279,6 @@ class ConnectionController(
      * regression — and a jittered rung never rounds down to 0, so a non-zero rung always
      * actually waits.
      */
-    private fun retryDelayForAttempt(attempt: Int): Long {
-        if (reconnectLadderMs.isEmpty()) return 0L
-        val index = (attempt - 1).coerceIn(0, reconnectLadderMs.lastIndex)
-        return jittered(reconnectLadderMs[index])
-    }
-
-    /** Apply ±[RETRY_JITTER_FRACTION] full jitter to a non-zero backoff (issue #1633). */
     private fun jittered(delayMs: Long): Long {
         if (delayMs <= 0L) return 0L
         val spread = delayMs * RETRY_JITTER_FRACTION

--- a/shared/core-connection/src/test/java/com/pocketshell/core/connection/ConnectionControllerJitterTest.kt
+++ b/shared/core-connection/src/test/java/com/pocketshell/core/connection/ConnectionControllerJitterTest.kt
@@ -125,6 +125,72 @@ class ConnectionControllerJitterTest {
     }
 
     /**
+     * Issue #1633 (round 2) — jitter is rolled ONCE PER LADDER INSTALL, so a given attempt's
+     * backoff is STABLE however many times its state is rebuilt.
+     *
+     * RED on the round-1 reducer (jitter rolled inside `reconnectingAt`): `reconnectingAt` is
+     * re-invoked for the SAME attempt on every idempotent ladder re-entry, so each rebuild
+     * re-rolled that attempt's backoff. That is not academic — the VM's ladder body mirrors
+     * `retryDelayMs` into the displayed Reconnecting band and then sleeps on its own earlier
+     * read, so the band could advertise one backoff while the dial waited a different one,
+     * and the reducer's output stopped being a function of its input sequence. On a
+     * connect-then-die link (this issue's environment) that re-entry happens on EVERY cycle.
+     */
+    @Test
+    fun `a given attempt's jittered backoff is stable across repeated state rebuilds`() {
+        val transport = FakeTransportPort()
+        val c = ConnectionController(FakeClock(), transport, random = Random(7))
+        c.setReconnectLadder(ladder)
+        c.bringLive(transport)
+        c.submit(ConnectionEvent.TransportDropped("d"))
+        c.submit(ConnectionEvent.TransportDropped("d")) // -> Reconnecting(1)
+        c.submit(ConnectionEvent.ReconnectFailed) // -> Reconnecting(2), a jittered rung
+
+        val attempt = (c.state.value as ConnectionState.Reconnecting).attempt
+        val first = (c.state.value as ConnectionState.Reconnecting).retryDelayMs
+        assertTrue("precondition: rung $attempt must actually be jittered (non-zero)", first > 0L)
+
+        // The VM's ladder body re-enters idempotently on every connect-then-die cycle.
+        repeat(25) {
+            c.submit(ConnectionEvent.ReconnectLadderEntered)
+            val now = c.state.value as ConnectionState.Reconnecting
+            assertEquals("the re-entry must not advance the attempt", attempt, now.attempt)
+            assertEquals(
+                "attempt $attempt re-rolled its backoff on rebuild (${now.retryDelayMs}ms vs " +
+                    "${first}ms) — the displayed band and the actual dial wait can disagree",
+                first,
+                now.retryDelayMs,
+            )
+        }
+    }
+
+    /**
+     * The stability above must NOT come from jitter having silently died: a fresh ladder
+     * install is still an independent roll, which is what actually desynchronises retries.
+     * (G6: pins the load-bearing property, not just the convenient one.)
+     */
+    @Test
+    fun `each ladder install is an independent jitter roll`() {
+        val transport = FakeTransportPort()
+        val c = ConnectionController(FakeClock(), transport, random = Random(11))
+        val rungPerInstall = (0 until 30).map {
+            c.setReconnectLadder(ladder)
+            c.bringLive(transport)
+            c.submit(ConnectionEvent.TransportDropped("d"))
+            c.submit(ConnectionEvent.TransportDropped("d"))
+            c.submit(ConnectionEvent.ReconnectFailed)
+            val d = (c.state.value as ConnectionState.Reconnecting).retryDelayMs
+            assertWithinJitterBand(1_000L, d, "per-install rung 2")
+            d
+        }
+        assertTrue(
+            "every ladder install produced the SAME backoff — jitter is not re-rolling, so " +
+                "retries would still synchronize (${rungPerInstall.distinct().size} distinct of 30)",
+            rungPerInstall.distinct().size > 1,
+        )
+    }
+
+    /**
      * Anti-drift guard: `ConnectionControllerEpisodeStabilityTest` mirrors these constants
      * locally so it can compile against the unfixed reducer for the red run. Pin the mirrors
      * to the real values here.


### PR DESCRIPTION
Closes #1633 (reopened). **This fixes a red `main`**, which is currently blocking three approved slices (#1632/PR #1643, #1621/PR #1644, #1642-s1) including the #1610 connection-storm fix.

## The regression

#1633 merged as PR #1638 (`0c55af4b`) and put `main` red:

```
TmuxSessionViewModelReconnectTest > networkReconnectRetriesTransientFlapThenRecoversWithoutOverlappingAttempts
AssertionError: second network reconnect attempt should be the next bounded backoff step expected:<2> but was:<1>
:app:testReleaseUnitTest — 3902 tests completed, 1 failed
```

The test pins ladder `[0, 250, 250]` and does `advanceTimeBy(250L)`; #1638 made that rung `uniform[200,300)`. A roll > 250 means the dial hasn't fired. **Exactly one coin flip is load-bearing** — ~50% red.

## The second, real production defect found while diagnosing

`reconnectingAt()` is invoked repeatedly **for the same attempt** (`:251`, `:516`, `:636`), and #1633 rolled jitter *inside* it — so one attempt **re-rolled its own backoff on every rebuild**. The VM mirrors `retryDelayMs` into the displayed band then sleeps on its own earlier read, so the two could disagree, and the "deterministic reducer" stopped being a function of its inputs.

**`:636` is the VM ladder body re-entering — it fires on every cycle of the exact connect-then-die storm #1610 is about.** So #1633 shipped a bug directly into the maintainer's storm path, and only this red test surfaced it. Fixed by rolling jitter once per ladder install; production randomness unchanged. The reviewer independently judged the granularity correct: `episodeExhausted` makes the `coerceIn` clamp unreachable, so per-install rolling is equivalent to per-attempt-memoized in every reachable case.

## G6 — not a tolerance band

Assertions are **byte-for-byte identical** (`assertEquals(2, ...)` still exact, not `>=`). Only the time advance moved, and the result is deterministic **by construction**, not by luck: jitter draws `[200,299]` (upper-exclusive), the window is `[now, now+300)`, rung 3 lands at ≥400.

**A seeded `Random` was prescribed by the orchestrator and correctly refused.** A seed yields a *fixed but arbitrary* offset (e.g. 274ms), so `advanceTimeBy(250)` would still need a lucky, draw-order-brittle magic seed — correct determinism needs jitter **disabled** in the test, not seeded. The seam also doesn't exist (`ConnectionManager.kt:70` has no `random` passthrough) and reaching it would need `TmuxSessionViewModel.kt`, which has **37 bytes** of ratchet headroom with #1539 live in it. Injectable `jitterFraction` filed as a follow-up.

## Our determinism evidence was fake — the finding that matters most

The on-call's "20/20 in isolation" and the orchestrator's own runs were **Gradle UP-TO-DATE no-ops**: `Task :app:testDebugUnitTest UP-TO-DATE`, `BUILD SUCCESSFUL in 3s`, **zero tests executed**. Gradle skips a *passing* test task on re-run while a *failing* one always re-executes — manufacturing exactly the "1 fail then a long green streak" shape that fooled two actors into confidently wrong conclusions today. `process.md` is amended in a companion commit.

## Verification

**Reviewer-run red→green:** base `a8af5d2d` → **6 FAIL/12** isolated-debug, **2 FAIL/4** full release module (CI's exact condition). With the fix → **0 FAIL/15** and **0 FAIL/10**.

**G2 sweep:** jitter pinned to **both extremes** with the full `:app` suite green. Since the outcome is monotonic in the delay, this covers the entire distribution — strictly stronger than N random samples. Only one sensitive site across all 28 ladder-installing files.

Orchestrator gate in a clean integration worktree off `origin/main`, `./gradlew test --rerun-tasks` (**both variants**, the CI required task), with executed counts asserted from the result XML:
- `:app:testDebugUnitTest` — **3906 tests, 0 failures, 0 skipped**
- `:app:testReleaseUnitTest` — **3902 tests, 0 failures, 0 skipped** (matches CI's red-run count of 3902, now zero failures)
- `:shared:core-connection` — **288 tests, 0 failures, 0 skipped**
- `TmuxSessionViewModelReconnectTest` confirmed **present in the release results** (non-vacuous, G3)
- `check-file-size-hygiene.sh`, `check-connection-vm-ratchet.sh`, `check-test-validity.sh` — exit 0; `git diff --check` clean

## Known follow-ups (filed, not blocking)

- `Issue926SeedIoOffMainTest` failed once in the reviewer's 10 runs — a real-wall-clock thread race, structurally unreachable by jitter (no ladder, no `retryDelayMs`, no `advanceTimeBy`). The reviewer could not reproduce it on base (0/4) and explicitly declined to claim it pre-existing rather than charge it to this slice.
- Injectable `jitterFraction` seam.

Review: https://github.com/alexeygrigorev/pocketshell/issues/1633#issuecomment-4994174801 (APPROVED)