### PR TITLE
connection: per-stage reattach budgets; never kill a handshaken transport (#1539) — THE #1610 STORM FIX

### DIFF
--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionSupport.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionSupport.kt
@@ -1,10 +1,14 @@
 package com.pocketshell.app.tmux
 
 import android.os.Build
+import android.util.Log
+import com.pocketshell.app.diagnostics.DiagnosticEvents
 import com.pocketshell.app.session.reconcileAgentEvents
+import com.pocketshell.app.tmux.TmuxSessionViewModel.ConnectionTarget
 import com.pocketshell.core.agents.ConversationEvent
 import com.pocketshell.core.connection.LivenessProbe
 import com.pocketshell.core.ssh.SshLeaseManager
+import com.pocketshell.core.ssh.SshSession
 import com.pocketshell.core.terminal.input.BracketedPaste
 import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.Job
@@ -466,8 +470,252 @@ internal const val RECONCILE_LIST_PANES_EXEC_TIMEOUT_MS: Long = 6_000L
  * shorter VM clock.
  */
 internal val PASSIVE_DISCONNECT_GRACE_MS: Long = SshLeaseManager.DEFAULT_IDLE_TTL_MILLIS
-internal const val PASSIVE_DISCONNECT_SILENT_REATTACH_TIMEOUT_MS: Long = 5_000L
+
+/**
+ * Issue #1539: the DIAL + HANDSHAKE budget for one fresh-transport rung of the passive-grace
+ * reattach — and ONLY that stage.
+ *
+ * This constant used to be `PASSIVE_DISCONNECT_SILENT_REATTACH_TIMEOUT_MS`, an ALL-INCLUSIVE
+ * 5s bound that wrapped dial + handshake + attach + panes-ready + reseed in ONE
+ * `withTimeoutOrNull`. That single budget was the #1610 dogfood blocker (log-proven on the
+ * maintainer's device 2026-07-13, seq 64988-65101): on mobile RTT the handshake FITS 5s
+ * (~1.5-3s) but the later stages do NOT, so the rung timed out DETERMINISTICALLY every cycle
+ * and the `!ready` branch closed a transport whose handshake had already completed — proof
+ * the link was up. The loop then re-dialed on the next 250ms tick, producing the measured
+ * 5.65s-median churn (a brand-new clientHash every cycle; 138/138 distinct) that NEVER
+ * self-heals, because a constant budget against a constant >5s latency fails identically
+ * forever.
+ *
+ * The value stays 5s: fast-fail on a genuinely unreachable host is preserved EXACTLY — a
+ * transport that never completes its handshake within this budget is still abandoned, and its
+ * retry stays amortized by [PASSIVE_DISCONNECT_SILENT_REATTACH_RETRY_MS] spacing. What
+ * changed is that this budget no longer gets to kill the LATER stages' transport.
+ */
+internal const val PASSIVE_REATTACH_DIAL_HANDSHAKE_TIMEOUT_MS: Long = 15_000L
+
+/**
+ * Issue #1539/#1331: the ATTACH + PANES-READY budget for one rung, applied to an ALREADY-
+ * HANDSHAKEN transport. A completed SSH handshake is proof the link is up, so a slow attach is
+ * a reason to RETRY THE ATTACH over the same transport — never to close it and redial.
+ */
+internal const val PASSIVE_REATTACH_ATTACH_TIMEOUT_MS: Long = 10_000L
+
+/**
+ * Issue #1539/#1353: the RESEED budget — and, critically, reseed is NOT part of the readiness
+ * verdict. A transport is READY once it is attached; the reseed is pane-content recovery that
+ * runs after, and its timeout must NEVER close a proven-live transport.
+ *
+ * The reseed used to run INSIDE the single 5s all-inclusive `withTimeoutOrNull` alongside dial
+ * + handshake + attach. The render-heal audit (#1353) measured the full pane reseed at up to
+ * **~10.4s per pane** worst case — so on mobile RTT the handshake fits in 1.5-3s and then a
+ * reseed that alone can take 10.4s runs under the same 5s clock. The rung therefore blew its
+ * budget DETERMINISTICALLY every cycle and killed a healthy transport: not merely slow, but
+ * structurally in the wrong place. Bounding it here only keeps the rung from parking; a reseed
+ * that overruns is handled by [TmuxSessionViewModel.armConnectedBlankWatchdog], which re-seeds
+ * under a calm overlay on the live connection — the existing, correct net for this.
+ */
+internal const val PASSIVE_REATTACH_RESEED_TIMEOUT_MS: Long = 5_000L
+
 internal const val PASSIVE_DISCONNECT_SILENT_REATTACH_RETRY_MS: Long = 250L
+
+/**
+ * Issue #1539: the per-stage budgets for one passive-grace reattach rung. Replaces the single
+ * all-inclusive 5s budget that shared one clock across dial, handshake, attach, panes-ready and
+ * reseed.
+ *
+ * There is deliberately NO per-rung attach-retry count here. The attach retry over a kept
+ * transport is owned by the OUTER grace loop, not by an inner loop: a post-handshake stage
+ * failure on a still-vouched-alive transport republishes `leaseRef`/`sessionRef`
+ * ([shouldEvictTransportAfterStageFailure]), so the loop's next iteration re-vouches and routes
+ * to the channel-only warm rung over that SAME transport. That gives the retry its liveness
+ * gating (re-vouched every tick) and its bound (the grace `withTimeoutOrNull` +
+ * [PASSIVE_DISCONNECT_SILENT_REATTACH_RETRY_MS] spacing) from the one mechanism that already
+ * exists. A second, inner bounded-retry loop stacked on top would be exactly the
+ * patches-on-patches shape D28 exists to prevent.
+ */
+internal data class PassiveReattachStageBudgets(
+    val dialHandshakeMs: Long,
+    val attachMs: Long,
+    /** Bounds the post-readiness reseed only; overrunning it never fails the rung (#1353). */
+    val reseedMs: Long,
+)
+
+/**
+ * Issue #1539: build the per-stage budgets for a rung whose dial/handshake bound is
+ * [dialHandshakeMs] (the caller's rung timeout — production
+ * [PASSIVE_REATTACH_DIAL_HANDSHAKE_TIMEOUT_MS], or a test-pinned value).
+ *
+ * The post-handshake stages do NOT derive from [dialHandshakeMs]: they run on a link that is
+ * already PROVEN up, so they get their own fixed budgets. A test that pins a tiny dial budget
+ * (a fast-fail reproduction) therefore cannot accidentally starve the attach stage it is not
+ * testing.
+ */
+internal fun passiveReattachStageBudgets(
+    dialHandshakeMs: Long,
+    attachMs: Long = PASSIVE_REATTACH_ATTACH_TIMEOUT_MS,
+    reseedMs: Long = PASSIVE_REATTACH_RESEED_TIMEOUT_MS,
+): PassiveReattachStageBudgets = PassiveReattachStageBudgets(
+    dialHandshakeMs = dialHandshakeMs.coerceAtLeast(1L),
+    attachMs = attachMs.coerceAtLeast(1L),
+    reseedMs = reseedMs.coerceAtLeast(1L),
+)
+
+/**
+ * Issue #1539: the rung's teardown verdict for a post-handshake stage failure.
+ *
+ * The old `!ready` branch could not tell "the dial timed out" from "the attach ran slow on a
+ * proven-up link", so it closed + lease-evicted BOTH. This is the missing distinction, and it
+ * is deliberately the ONLY thing that authorises killing a transport the rung itself dialed:
+ *
+ *  - [transportVouchedAlive] false -> the transport is genuinely dead (sshj flipped
+ *    `isConnected`, or the #1222 async-close staleness window opened). Evict it; a
+ *    ride-through here would strand the user on a dead socket. A real death is NEVER masked.
+ *  - [transportVouchedAlive] true -> the handshake completed AND the link is still up. The
+ *    slow stage is the host being busy, not the link being gone. KEEP the transport; the
+ *    caller retries the attach over it (or lets the outer grace loop's warm rung recover it).
+ *
+ * Investigation B (#1610) is the reason this reads the vouch at FALLTHROUGH time rather than
+ * trusting the stage verdict: a 5s stage timeout on a transport that is still vouched alive
+ * must not evict the shared per-host lease.
+ */
+internal fun shouldEvictTransportAfterStageFailure(transportVouchedAlive: Boolean): Boolean =
+    !transportVouchedAlive
+
+/**
+ * Issue #1539: vouch THIS session's transport alive — connected AND with no close initiated
+ * (the #1222 async-close staleness window, where `isConnected` may still lie true). Mirrors
+ * `TmuxSessionViewModel.transportVouchedAlive` but vouches an EXPLICIT session rather than
+ * whatever `sessionRef` currently points at, so a rung can re-vouch the exact transport it
+ * dialed even when a stage timed out before the refs were published.
+ */
+internal fun SshSession.vouchedAlive(): Boolean = isConnected && !isCloseInitiated
+
+/**
+ * Issue #1539 (VM-shrink extraction): the [ISSUE_145_RECONNECT_TAG] device-trail label for a
+ * passive-grace rung, derived from its diagnostic [source] so the logcat breadcrumb and the
+ * `DiagnosticEvents` field can never drift apart:
+ * `silent_reattach` -> `tmux-passive-disconnect-silent-reattach`, and
+ * `silent_transport_reattach` -> `tmux-passive-disconnect-silent-transport-reattach` — the two
+ * labels the former inline `Log` calls emitted verbatim.
+ */
+private fun passiveReattachLogLabel(source: String): String =
+    "tmux-passive-disconnect-" + source.replace('_', '-')
+
+/**
+ * Issue #1539 (VM-shrink extraction, the #928 pattern): the `reconnect_success` diagnostic
+ * shared by BOTH passive-grace reattach rungs. [source] names the rung — `silent_reattach`
+ * (channel-only over the live transport) or `silent_transport_reattach` (fresh transport).
+ * Field set unchanged from the two former inline records it replaces.
+ */
+internal fun recordPassiveReattachSuccess(
+    target: ConnectionTarget,
+    source: String,
+    clientHash: Int,
+    elapsedMs: Long,
+    shortAppSwitchFields: Array<out Pair<String, Any?>>,
+) {
+    Log.i(
+        ISSUE_145_RECONNECT_TAG,
+        "${passiveReattachLogLabel(source)} ${targetLogFields(target)} elapsedMs=$elapsedMs",
+    )
+    DiagnosticEvents.record(
+        "connection",
+        "reconnect_success",
+        "hostId" to target.hostId,
+        "host" to target.host,
+        "port" to target.port,
+        "user" to target.user,
+        "session" to target.sessionName,
+        "trigger" to TmuxConnectTrigger.AutoReconnect.logValue,
+        "source" to source,
+        "clientHash" to clientHash,
+        "elapsedMs" to elapsedMs,
+        *shortAppSwitchFields,
+    )
+}
+
+/**
+ * Issue #1539 (VM-shrink extraction, the #928 pattern): the `reconnect_fail` diagnostic for a
+ * passive-grace rung that THREW (as opposed to timing out — see
+ * [recordTransportReattachStageFail]). [evictedLease] is omitted entirely when null so the
+ * emitted field set stays byte-identical to the two former inline records: the channel-only
+ * rung never evicts a lease and so never carried the field, while the fresh-transport rung
+ * always did.
+ */
+internal fun recordPassiveReattachThrewFail(
+    target: ConnectionTarget,
+    source: String,
+    throwable: Throwable,
+    evictedLease: Boolean?,
+    clientHash: Int?,
+    elapsedMs: Long,
+    shortAppSwitchFields: Array<out Pair<String, Any?>>,
+) {
+    Log.w(
+        ISSUE_145_RECONNECT_TAG,
+        "${passiveReattachLogLabel(source)}-failed " +
+            "cause=${throwable.javaClass.simpleName}: ${throwable.message} " +
+            targetLogFields(target),
+        throwable,
+    )
+    DiagnosticEvents.record(
+        "connection",
+        "reconnect_fail",
+        "hostId" to target.hostId,
+        "host" to target.host,
+        "port" to target.port,
+        "user" to target.user,
+        "session" to target.sessionName,
+        "trigger" to TmuxConnectTrigger.AutoReconnect.logValue,
+        "source" to source,
+        "cause" to throwable.javaClass.simpleName,
+        "message" to throwable.message,
+        *(evictedLease?.let { arrayOf("evictedLease" to (it as Any?)) } ?: emptyArray()),
+        "clientHash" to clientHash,
+        "elapsedMs" to elapsedMs,
+        *shortAppSwitchFields,
+    )
+}
+
+/**
+ * Issue #1539 (VM-shrink extraction, the #928 pattern): the `reconnect_fail` diagnostic for a
+ * failed fresh-transport passive-grace rung. [cause] names the STAGE that failed and
+ * [evictedLease] records the teardown verdict, so the device trail distinguishes the three
+ * outcomes the old single all-inclusive budget conflated:
+ *
+ *  - `dial_handshake_timeout` / `evictedLease=true` — never handshook; correctly abandoned.
+ *  - `attach_not_ready` / `evictedLease=true` — post-handshake stage failed AND the transport
+ *    failed its liveness re-vouch; a real death, correctly evicted.
+ *  - `attach_slow_transport_kept` / `evictedLease=false` — post-handshake stage was slow but
+ *    the transport is still vouched alive; the transport is KEPT and the attach retries over
+ *    it. On the maintainer's 2026-07-13 log every cycle was the middle case MISCLASSIFIED;
+ *    seeing `attach_slow_transport_kept` in the trail is the fix working.
+ */
+internal fun recordTransportReattachStageFail(
+    target: ConnectionTarget,
+    cause: String,
+    evictedLease: Boolean,
+    clientHash: Int?,
+    elapsedMs: Long,
+    shortAppSwitchFields: Array<out Pair<String, Any?>>,
+) {
+    DiagnosticEvents.record(
+        "connection",
+        "reconnect_fail",
+        "hostId" to target.hostId,
+        "host" to target.host,
+        "port" to target.port,
+        "user" to target.user,
+        "session" to target.sessionName,
+        "trigger" to TmuxConnectTrigger.AutoReconnect.logValue,
+        "source" to "silent_transport_reattach",
+        "cause" to cause,
+        "evictedLease" to evictedLease,
+        "clientHash" to clientHash,
+        "elapsedMs" to elapsedMs,
+        *shortAppSwitchFields,
+    )
+}
 
 /**
  * Issue #451: how long [TmuxSessionViewModel.stagePromptAttachments] waits
@@ -757,7 +1005,32 @@ internal const val ISSUE_235_LIFECYCLE_TAG: String = "PsTmuxLifecycle"
  */
 internal const val ISSUE_464_KILL_TAG: String = "issue464-killsession"
 
-internal val DEFAULT_AUTO_RECONNECT_DELAYS_MS: List<Long> = listOf(0L, 1_000L, 2_000L, 5_000L)
+/**
+ * Issue #1331/#1633: the auto-reconnect ladder — one delay per rung, so the list's LENGTH is
+ * the give-up budget.
+ *
+ * This was `[0, 1, 2, 5]s` (4 rungs). That was inert while the attempt counter never advanced
+ * (the loop dialled `sshLeaseManager.acquire` directly and never reported
+ * `ConnectionEvent.ReconnectFailed`, so the ladder was bypassed and unbounded — #1610 Q3, now
+ * fed from [TmuxSessionViewModel.silentlyReconnectTransportAfterPassiveDisconnect]). Once
+ * #1633's counter genuinely escalates and TERMINATES, a 4-rung ladder means a flapping mobile
+ * link exhausts every rung in ~8s and surrenders to `Unreachable` — trading the infinite
+ * strobe for an app that gives up almost immediately, which is a different bad UX rather than
+ * a fix.
+ *
+ * Eight rungs `[0,1,2,5,10,20,30,30]s` sum to ~98s before surrender: patient enough to ride
+ * out a tunnel/lift/RAT-handover on mobile, bounded enough that a genuinely dead host still
+ * reaches an honest `Unreachable` in under two minutes.
+ *
+ * NO jitter here: #1633 applies it inside `ConnectionController.retryDelayForAttempt`, and the
+ * VM waits on the controller's `recon.retryDelayMs` — adding it here would double-apply it.
+ *
+ * PROPOSED, NOT LOCKED (#1539): how patient the app should be before it stops trying is the
+ * maintainer's tuning call. #1633 made the controller behave correctly with either ladder
+ * length, so retuning is a one-line change here.
+ */
+internal val DEFAULT_AUTO_RECONNECT_DELAYS_MS: List<Long> =
+    listOf(0L, 1_000L, 2_000L, 5_000L, 10_000L, 20_000L, 30_000L, 30_000L)
 
 // Issue #1537 (option b, D22 hard-cut): the bespoke `STALE_LEASE_AUTO_RECOVER_MAX`
 // two-counter budget is DELETED. Loop protection for the residual attach-EOF

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -85,6 +85,7 @@ import com.pocketshell.app.tmux.connection.recordNetworkLossHold
 import com.pocketshell.app.tmux.connection.PassiveDropArm
 import com.pocketshell.app.tmux.connection.PassiveTransportDropEffects
 import com.pocketshell.app.tmux.connection.preferFreshTransportForPassiveReattach
+import com.pocketshell.app.tmux.connection.ReconnectRungFailureSource
 import com.pocketshell.app.tmux.connection.SshLeaseTransportPort
 import com.pocketshell.app.tmux.connection.SuppressedDropDiagnostic
 import com.pocketshell.app.tmux.connection.TmuxAttachEffects
@@ -1839,7 +1840,7 @@ public class TmuxSessionViewModel @Inject constructor(
     private val renderHealCoordinator = RenderHealCoordinator()
     private var autoReconnectDelaysMs: List<Long> = DEFAULT_AUTO_RECONNECT_DELAYS_MS
     private var passiveDisconnectGraceMs: Long = PASSIVE_DISCONNECT_GRACE_MS
-    private var silentReattachTimeoutMs: Long = PASSIVE_DISCONNECT_SILENT_REATTACH_TIMEOUT_MS
+    private var silentReattachTimeoutMs: Long = PASSIVE_REATTACH_DIAL_HANDSHAKE_TIMEOUT_MS
     private var keepaliveDeathQuietResetMs: Long = KEEPALIVE_DEATH_REDIAL_QUIET_RESET_MS
 
     /**
@@ -4230,7 +4231,9 @@ public class TmuxSessionViewModel @Inject constructor(
                         silentlyReattachAfterPassiveDisconnect(
                             staleClient = staleClient,
                             target = target,
-                            timeoutMs = passiveDisconnectGraceMs.coerceAtLeast(1L),
+                            budgets = passiveReattachStageBudgets(
+                                dialHandshakeMs = passiveDisconnectGraceMs.coerceAtLeast(1L),
+                            ),
                         )
                 ) ||
                     silentlyReconnectTransportAfterPassiveDisconnect(
@@ -8125,10 +8128,13 @@ public class TmuxSessionViewModel @Inject constructor(
         // Issue #1568 (P0-2): prefer the lease-EVICTING fresh dial ONLY when a warm lease is held
         // AND the transport is not vouched alive; a vouched-alive `-CC` death recovers over the
         // LIVE transport so a channel hiccup never costs the shared per-host lease.
-        val preferFreshTransport = preferFreshTransportForPassiveReattach(
+        // Issue #1539: re-read PER ITERATION (#685 read-current-state); a snapshot stays true
+        // forever and re-dials (the 2026-07-13 churn ladder).
+        fun preferFreshTransportNow(): Boolean = preferFreshTransportForPassiveReattach(
             warmLeaseHeld = leaseRef != null,
             transportVouchedAlive = transportVouchedAlive(),
         )
+        val preferFreshTransport = preferFreshTransportNow()
         // EPIC #792 #833: count fresh-transport re-dials (not a one-shot latch) so a SUSTAINED
         // clean outage keeps RE-DIALLING a fresh transport across the bounded grace window and
         // the SAME session auto-recovers the moment the link returns — no switch dance. Bounded
@@ -8158,7 +8164,10 @@ public class TmuxSessionViewModel @Inject constructor(
                 // iteration (not once) so a sustained clean outage keeps escalating into a
                 // retrying ladder — the SAME session recovers when the link returns, no switch
                 // dance. Bounded by the grace `withTimeoutOrNull` + per-attempt timeout + spacing.
-                if (preferFreshTransport) {
+                // Issue #1539: re-vouch EVERY tick — a kept, live transport routes to the
+                // channel-only warm rung instead of another evict-and-redial.
+                val freshTransportPreferred = preferFreshTransportNow()
+                if (freshTransportPreferred) {
                     transportReattachAttempts += 1
                     if (silentlyReconnectTransportAfterPassiveDisconnect(
                             staleClient = staleClient,
@@ -8169,10 +8178,14 @@ public class TmuxSessionViewModel @Inject constructor(
                         return@withTimeoutOrNull true
                     }
                 }
+                // Issue #1539: channel-only over an ALREADY-LIVE transport -> post-handshake
+                // stages only, so it never sees the dial bound.
                 if (silentlyReattachAfterPassiveDisconnect(
                         staleClient = staleClient,
                         target = target,
-                        timeoutMs = silentReattachTimeoutMs.coerceAtLeast(1L),
+                        budgets = passiveReattachStageBudgets(
+                            dialHandshakeMs = silentReattachTimeoutMs.coerceAtLeast(1L),
+                        ),
                     )
                 ) {
                     return@withTimeoutOrNull true
@@ -8180,7 +8193,7 @@ public class TmuxSessionViewModel @Inject constructor(
                 // No fresh transport preferred: the warm reattach above is the cheap path; if it
                 // can't recover (the warm SSH session itself is gone) escalate to a fresh
                 // transport and keep re-dialling it for the same sustained-outage resilience.
-                if (!preferFreshTransport) {
+                if (!freshTransportPreferred) {
                     transportReattachAttempts += 1
                     if (silentlyReconnectTransportAfterPassiveDisconnect(
                             staleClient = staleClient,
@@ -8191,6 +8204,14 @@ public class TmuxSessionViewModel @Inject constructor(
                         return@withTimeoutOrNull true
                     }
                 }
+                // Issue #1610 (Q3): this cycle failed — feed the SINGLE attempt counter so #1633's
+                // ladder can escalate/terminate the flap. Once per CYCLE, never per rung: the storm
+                // is `dial SUCCEEDS -> tail times out`, so a feed wired to a failed DIAL alone would
+                // never fire on-device, and a pure-silent-heal cycle (warm rung, no dial) must arm
+                // it identically. A cycle that RECOVERS returns above.
+                // UNGUARDED on purpose — see [ReconnectRungFailureSource] for why an
+                // `autoReconnectJob?.isActive` guard here would be a measured no-op.
+                connectionManager.reconnectRungFailed(ReconnectRungFailureSource.PassiveGraceLoop)
                 val retryDelayMs = PASSIVE_DISCONNECT_SILENT_REATTACH_RETRY_MS
                 delay(retryDelayMs)
             }
@@ -8201,20 +8222,57 @@ public class TmuxSessionViewModel @Inject constructor(
                     target = target,
                     staleClientHash = System.identityHashCode(staleClient),
                     transportReattachAttempts = transportReattachAttempts,
-                    shortAppSwitchFields = shortAppSwitchReconnectFields(
-                        trigger = TmuxConnectTrigger.AutoReconnect,
-                        target = target,
-                        sourceCandidate = "passive_disconnect",
-                    ),
+                    shortAppSwitchFields = passiveReattachLogFields(target),
                 )
             }
         } == true
     }
 
+    /**
+     * Issue #693/#662 (#1539 VM-shrink extraction): re-seed every visible pane for a passive-grace
+     * reattach onto [client] — the sequence BOTH rungs ran verbatim. A reattach is a fresh attach
+     * for REUSED panes, so the old seed flags no longer apply: clear them, re-capture every pane,
+     * then run the blank-net backstop for any whose capture came back empty.
+     *
+     * Issue #1353/#1539: runs AFTER the readiness verdict, bounded by
+     * [PassiveReattachStageBudgets.reseedMs] but able to overrun WITHOUT failing the rung. At
+     * ~10.4s/pane worst case, inside the readiness clock it deterministically blew the rung's
+     * budget and killed proven-live transports. Overruns heal via [armConnectedBlankWatchdog].
+     */
+    private suspend fun reseedVisiblePanesForPassiveReattach(
+        target: ConnectionTarget,
+        client: TmuxClient,
+        budgets: PassiveReattachStageBudgets,
+    ) = withTimeoutOrNull(budgets.reseedMs) {
+        panesSeededThisAttach.clear()
+        panesSeedInFlightThisAttach.clear()
+        val guard = RuntimeRefreshGuard(
+            generation = connectGeneration,
+            target = target,
+            client = client,
+        )
+        reseedAllVisiblePanes(guard)
+        reseedBlankVisiblePanes(guard)
+        maybeRefreshControlClientSize()
+    }
+
+    /**
+     * Issue #1539 (VM-shrink extraction): the AutoReconnect/`passive_disconnect` short-app-switch
+     * field set every passive-grace rung stamps on its diagnostics. One call site instead of the
+     * seven verbatim copies this replaces; field set unchanged.
+     */
+    private fun passiveReattachLogFields(target: ConnectionTarget): Array<out Pair<String, Any?>> =
+        shortAppSwitchReconnectFields(
+            trigger = TmuxConnectTrigger.AutoReconnect,
+            target = target,
+            sourceCandidate = "passive_disconnect",
+        )
+
     private suspend fun silentlyReattachAfterPassiveDisconnect(
         staleClient: TmuxClient,
         target: ConnectionTarget,
-        timeoutMs: Long,
+        // Issue #1539: per-STAGE budgets; post-handshake stages only (never the dial bound).
+        budgets: PassiveReattachStageBudgets,
     ): Boolean {
         // EPIC #792 #833 test seam: while a synthetic clean outage is armed, every
         // reattach fails as if the link were down — so the grace loop must keep
@@ -8231,7 +8289,7 @@ public class TmuxSessionViewModel @Inject constructor(
             probeServerLiveness = true,
         )
         return try {
-            val ready = withTimeoutOrNull(timeoutMs) {
+            val ready = withTimeoutOrNull(budgets.attachMs) {
                 eventsJob?.cancelAndJoin()
                 eventsJob = null
                 outputOverflowJob?.cancelAndJoin()
@@ -8265,29 +8323,6 @@ public class TmuxSessionViewModel @Inject constructor(
                     trigger = TmuxConnectTrigger.AutoReconnect,
                 )
                 rebindVisiblePaneProducersToClient(replacement)
-                // Issue #693/#662: this is a fresh attach for the reused panes —
-                // their old per-attach seed flags no longer apply, so clear them
-                // and let [reseedAllVisiblePanes] re-capture every visible pane
-                // with the new control client. [healActivePaneIfStaleRender] now keeps
-                // the last rendered frame on an empty capture (never repaints
-                // black) and retries, so a degraded reconnect can't strand a
-                // black pane.
-                panesSeededThisAttach.clear()
-                panesSeedInFlightThisAttach.clear()
-                val reattachGuard = RuntimeRefreshGuard(
-                    generation = connectGeneration,
-                    target = target,
-                    client = replacement,
-                )
-                reseedAllVisiblePanes(reattachGuard)
-                // Issue #693/#662: wire the blank-net into the reconnect path
-                // (it was only on the connect-reveal + resize paths before). Any
-                // pane still blank after the reseed (its reconnect capture was
-                // empty) is retried here, and a still-black active pane keeps the
-                // calm loading overlay via the watchdog rather than painting
-                // black on a live (green) reattached connection.
-                reseedBlankVisiblePanes(reattachGuard)
-                maybeRefreshControlClientSize()
                 true
             } == true
             if (!ready) {
@@ -8297,6 +8332,7 @@ public class TmuxSessionViewModel @Inject constructor(
                 runCatching { replacement.close() }
                 return false
             }
+            reseedVisiblePanesForPassiveReattach(target, replacement, budgets)
             clientRegistration = activeTmuxClients.register(
                 hostId = target.hostId,
                 hostName = target.hostName,
@@ -8334,29 +8370,12 @@ public class TmuxSessionViewModel @Inject constructor(
                     client = replacement,
                 ),
             )
-            Log.i(
-                ISSUE_145_RECONNECT_TAG,
-                "tmux-passive-disconnect-silent-reattach " +
-                    targetLogFields(target) +
-                    " elapsedMs=${SystemClock.elapsedRealtime() - startedAtMs}",
-            )
-            DiagnosticEvents.record(
-                "connection",
-                "reconnect_success",
-                "hostId" to target.hostId,
-                "host" to target.host,
-                "port" to target.port,
-                "user" to target.user,
-                "session" to target.sessionName,
-                "trigger" to TmuxConnectTrigger.AutoReconnect.logValue,
-                "source" to "silent_reattach",
-                "clientHash" to System.identityHashCode(replacement),
-                "elapsedMs" to (SystemClock.elapsedRealtime() - startedAtMs),
-                *shortAppSwitchReconnectFields(
-                    trigger = TmuxConnectTrigger.AutoReconnect,
-                    target = target,
-                    sourceCandidate = "passive_disconnect",
-                ),
+            recordPassiveReattachSuccess(
+                target = target,
+                source = "silent_reattach",
+                clientHash = System.identityHashCode(replacement),
+                elapsedMs = SystemClock.elapsedRealtime() - startedAtMs,
+                shortAppSwitchFields = passiveReattachLogFields(target),
             )
             true
         } catch (t: Throwable) {
@@ -8367,36 +8386,18 @@ public class TmuxSessionViewModel @Inject constructor(
                 runCatching { replacement.close() }
                 throw t
             }
-            Log.w(
-                ISSUE_145_RECONNECT_TAG,
-                "tmux-passive-disconnect-silent-reattach-failed " +
-                    "cause=${t.javaClass.simpleName}: ${t.message} " +
-                    targetLogFields(target),
-                t,
-            )
             runCatching { replacement.close() }
             if (clientRef === replacement) {
                 clientRef = staleClient
             }
-            DiagnosticEvents.record(
-                "connection",
-                "reconnect_fail",
-                "hostId" to target.hostId,
-                "host" to target.host,
-                "port" to target.port,
-                "user" to target.user,
-                "session" to target.sessionName,
-                "trigger" to TmuxConnectTrigger.AutoReconnect.logValue,
-                "source" to "silent_reattach",
-                "cause" to t.javaClass.simpleName,
-                "message" to t.message,
-                "clientHash" to System.identityHashCode(replacement),
-                "elapsedMs" to (SystemClock.elapsedRealtime() - startedAtMs),
-                *shortAppSwitchReconnectFields(
-                    trigger = TmuxConnectTrigger.AutoReconnect,
-                    target = target,
-                    sourceCandidate = "passive_disconnect",
-                ),
+            recordPassiveReattachThrewFail(
+                target = target,
+                source = "silent_reattach",
+                throwable = t,
+                evictedLease = null,
+                clientHash = System.identityHashCode(replacement),
+                elapsedMs = SystemClock.elapsedRealtime() - startedAtMs,
+                shortAppSwitchFields = passiveReattachLogFields(target),
             )
             false
         }
@@ -8430,28 +8431,45 @@ public class TmuxSessionViewModel @Inject constructor(
         val startedAtMs = SystemClock.elapsedRealtime()
         var acquiredLease: SshLease? = null
         var replacement: TmuxClient? = null
+        // Issue #1539: per-STAGE budgets — `timeoutMs` now bounds ONLY the dial.
+        val budgets = passiveReattachStageBudgets(dialHandshakeMs = timeoutMs)
+        val leaseTarget = target.toSshLeaseTarget()
         return try {
-            val ready = withTimeoutOrNull(timeoutMs) {
-                val leaseTarget = target.toSshLeaseTarget()
-                // Issue #866: DETACH the current-client port from the stale client
-                // BEFORE we tear its transport down. `disconnect(leaseKey)` kills the
-                // stale `-CC` channel's underlying SSH session, so its reader EOFs and
-                // `disconnected` flips true. [CurrentClientTmuxPort.disconnectedClients]
-                // flatMapLatest-follows the current client, so unless we re-point it
-                // first that EOF re-enters the driver's control-channel-drop path
-                // (classified as a current-client drop because `clientRef` is still the
-                // stale client), which cancels THIS in-flight grace loop and relaunches
-                // it — the cancel storm that wedged the silent reattach ("tries a fresh
-                // transport once then spins"). Detaching to null makes the port emit
-                // nothing for the stale teardown; the success path re-points it at the
-                // replacement below.
+            // ---- Stage 1: DIAL + HANDSHAKE (fast-fail, amortized — unchanged bound) ----
+            val lease = withTimeoutOrNull(budgets.dialHandshakeMs) {
+                // Issue #866: DETACH the current-client port BEFORE tearing the stale transport
+                // down. `disconnect(leaseKey)` EOFs the stale `-CC` reader, and
+                // [CurrentClientTmuxPort.disconnectedClients] flatMapLatest-follows the current
+                // client — so unless we re-point first, that EOF re-enters the driver's
+                // control-channel-drop path (still the current client) and CANCELS this very
+                // grace loop: the cancel storm that wedged the silent reattach. Detaching to null
+                // makes the stale teardown emit nothing; the success path re-points below.
                 connectionTmuxPort.setClient(null)
                 withContext(NonCancellable) {
                     runCatching { sshLeaseManager.disconnect(leaseTarget.leaseKey) }
                 }
-                val lease = sshLeaseManager.acquire(leaseTarget).getOrThrow()
-                acquiredLease = lease
-                val session = lease.session
+                sshLeaseManager.acquire(leaseTarget).getOrThrow()
+            }
+            if (lease == null) {
+                // #1539: never handshook -> not a live link -> abandoned (the preserved
+                // fast-fail). The loop feeds the counter per failed cycle (#1610 Q3).
+                recordTransportReattachStageFail(
+                    target = target,
+                    cause = "dial_handshake_timeout",
+                    evictedLease = true,
+                    clientHash = null,
+                    elapsedMs = SystemClock.elapsedRealtime() - startedAtMs,
+                    shortAppSwitchFields = passiveReattachLogFields(target),
+                )
+                withContext(NonCancellable) {
+                    runCatching { sshLeaseManager.disconnect(leaseTarget.leaseKey) }
+                }
+                return false
+            }
+            acquiredLease = lease
+            // ---- Stages 2-3: ATTACH + PANES-READY + RESEED over the HANDSHAKEN transport ----
+            val session = lease.session
+            val ready = withTimeoutOrNull(budgets.attachMs) {
                 val newClient = createTmuxClient(
                     session,
                     target.sessionName,
@@ -8465,11 +8483,9 @@ public class TmuxSessionViewModel @Inject constructor(
                 outputOverflowJob = null
                 disconnectedJob?.cancelAndJoin()
                 disconnectedJob = null
-                // Issue #866: re-point the current-client port (and clientRef) at the
-                // replacement BEFORE closing the stale client (see the warm-reattach
-                // sibling above). Closing it while it is still the current client
-                // re-enters the driver's control-channel-drop path and cancels this
-                // in-flight grace loop (the cancel storm). Swap first, then close.
+                // Issue #866: re-point the port (and clientRef) at the replacement BEFORE
+                // closing the stale client — see the warm-reattach sibling above for why
+                // (the cancel storm). Swap first, then close.
                 leaseRef = lease
                 sessionRef = session
                 clientRef = newClient
@@ -8490,58 +8506,44 @@ public class TmuxSessionViewModel @Inject constructor(
                     trigger = TmuxConnectTrigger.AutoReconnect,
                 )
                 rebindVisiblePaneProducersToClient(newClient)
-                // Issue #693/#662: fresh transport reattach — re-seed every
-                // visible pane on the new client (clear the prior per-attach
-                // flags first), then run the blank-net backstop so a degraded
-                // fresh-transport reconnect never strands a black pane on a
-                // live (green) connection.
-                panesSeededThisAttach.clear()
-                panesSeedInFlightThisAttach.clear()
-                val transportReattachGuard = RuntimeRefreshGuard(
-                    generation = connectGeneration,
-                    target = target,
-                    client = newClient,
-                )
-                reseedAllVisiblePanes(transportReattachGuard)
-                reseedBlankVisiblePanes(transportReattachGuard)
-                maybeRefreshControlClientSize()
                 true
             } == true
             if (!ready) {
-                val leaseTarget = target.toSshLeaseTarget()
+                // Issue #1539 — THE kill site: used to close + lease-evict unconditionally, unable
+                // to tell a timed-out DIAL from a slow ATTACH on a proven-up link.
+                // See [shouldEvictTransportAfterStageFailure].
+                val evict = shouldEvictTransportAfterStageFailure(session.vouchedAlive())
                 if (clientRef === replacement) {
                     clientRef = staleClient
-                    sessionRef = null
-                    leaseRef = null
                 }
+                // The `-CC` CHANNEL never came up so it always drops; the TRANSPORT under it is
+                // the vouch's call.
                 runCatching { replacement?.close() }
-                withContext(NonCancellable) {
-                    runCatching { sshLeaseManager.disconnect(leaseTarget.leaseKey) }
+                if (evict) {
+                    if (sessionRef === session) sessionRef = null
+                    if (leaseRef === lease) leaseRef = null
+                    withContext(NonCancellable) {
+                        runCatching { sshLeaseManager.disconnect(leaseTarget.leaseKey) }
+                    }
+                } else {
+                    // KEEP the handshaken transport, PUBLISHED as live, so the next tick's
+                    // re-vouch retries the attach over it via the channel-only warm rung. Nulling
+                    // these refs is what used to disable that rung and force the redial.
+                    leaseRef = lease
+                    sessionRef = session
                 }
-                DiagnosticEvents.record(
-                    "connection",
-                    "reconnect_fail",
-                    "hostId" to target.hostId,
-                    "host" to target.host,
-                    "port" to target.port,
-                    "user" to target.user,
-                    "session" to target.sessionName,
-                    "trigger" to TmuxConnectTrigger.AutoReconnect.logValue,
-                    "source" to "silent_transport_reattach",
-                    "cause" to "attach_not_ready",
-                    "evictedLease" to true,
-                    "clientHash" to replacement?.let { System.identityHashCode(it) },
-                    "elapsedMs" to (SystemClock.elapsedRealtime() - startedAtMs),
-                    *shortAppSwitchReconnectFields(
-                        trigger = TmuxConnectTrigger.AutoReconnect,
-                        target = target,
-                        sourceCandidate = "passive_disconnect",
-                    ),
+                recordTransportReattachStageFail(
+                    target = target,
+                    cause = if (evict) "attach_not_ready" else "attach_slow_transport_kept",
+                    evictedLease = evict,
+                    clientHash = replacement?.let { System.identityHashCode(it) },
+                    elapsedMs = SystemClock.elapsedRealtime() - startedAtMs,
+                    shortAppSwitchFields = passiveReattachLogFields(target),
                 )
                 return false
             }
-            val lease = acquiredLease ?: return false
             val newClient = replacement ?: return false
+            reseedVisiblePanesForPassiveReattach(target, newClient, budgets)
             clientRegistration = activeTmuxClients.register(
                 hostId = target.hostId,
                 hostName = target.hostName,
@@ -8577,29 +8579,12 @@ public class TmuxSessionViewModel @Inject constructor(
                     client = newClient,
                 ),
             )
-            Log.i(
-                ISSUE_145_RECONNECT_TAG,
-                "tmux-passive-disconnect-silent-transport-reattach " +
-                    targetLogFields(target) +
-                    " elapsedMs=${SystemClock.elapsedRealtime() - startedAtMs}",
-            )
-            DiagnosticEvents.record(
-                "connection",
-                "reconnect_success",
-                "hostId" to target.hostId,
-                "host" to target.host,
-                "port" to target.port,
-                "user" to target.user,
-                "session" to target.sessionName,
-                "trigger" to TmuxConnectTrigger.AutoReconnect.logValue,
-                "source" to "silent_transport_reattach",
-                "clientHash" to System.identityHashCode(newClient),
-                "elapsedMs" to (SystemClock.elapsedRealtime() - startedAtMs),
-                *shortAppSwitchReconnectFields(
-                    trigger = TmuxConnectTrigger.AutoReconnect,
-                    target = target,
-                    sourceCandidate = "passive_disconnect",
-                ),
+            recordPassiveReattachSuccess(
+                target = target,
+                source = "silent_transport_reattach",
+                clientHash = System.identityHashCode(newClient),
+                elapsedMs = SystemClock.elapsedRealtime() - startedAtMs,
+                shortAppSwitchFields = passiveReattachLogFields(target),
             )
             true
         } catch (t: Throwable) {
@@ -8611,21 +8596,12 @@ public class TmuxSessionViewModel @Inject constructor(
                 }
                 runCatching { replacement?.close() }
                 withContext(NonCancellable) {
-                    val leaseTarget = target.toSshLeaseTarget()
                     runCatching { sshLeaseManager.disconnect(leaseTarget.leaseKey) }
                 }
                 throw t
             }
-            Log.w(
-                ISSUE_145_RECONNECT_TAG,
-                "tmux-passive-disconnect-silent-transport-reattach-failed " +
-                    "cause=${t.javaClass.simpleName}: ${t.message} " +
-                    targetLogFields(target),
-                t,
-            )
             runCatching { replacement?.close() }
             withContext(NonCancellable) {
-                val leaseTarget = target.toSshLeaseTarget()
                 runCatching { sshLeaseManager.disconnect(leaseTarget.leaseKey) }
             }
             if (clientRef === replacement) {
@@ -8633,26 +8609,14 @@ public class TmuxSessionViewModel @Inject constructor(
                 sessionRef = null
                 leaseRef = null
             }
-            DiagnosticEvents.record(
-                "connection",
-                "reconnect_fail",
-                "hostId" to target.hostId,
-                "host" to target.host,
-                "port" to target.port,
-                "user" to target.user,
-                "session" to target.sessionName,
-                "trigger" to TmuxConnectTrigger.AutoReconnect.logValue,
-                "source" to "silent_transport_reattach",
-                "cause" to t.javaClass.simpleName,
-                "message" to t.message,
-                "evictedLease" to true,
-                "clientHash" to replacement?.let { System.identityHashCode(it) },
-                "elapsedMs" to (SystemClock.elapsedRealtime() - startedAtMs),
-                *shortAppSwitchReconnectFields(
-                    trigger = TmuxConnectTrigger.AutoReconnect,
-                    target = target,
-                    sourceCandidate = "passive_disconnect",
-                ),
+            recordPassiveReattachThrewFail(
+                target = target,
+                source = "silent_transport_reattach",
+                throwable = t,
+                evictedLease = true,
+                clientHash = replacement?.let { System.identityHashCode(it) },
+                elapsedMs = SystemClock.elapsedRealtime() - startedAtMs,
+                shortAppSwitchFields = passiveReattachLogFields(target),
             )
             false
         }
@@ -8960,7 +8924,7 @@ public class TmuxSessionViewModel @Inject constructor(
                 // / server restarted) is not a ladder rung — keep it.
                 if (connectionManager.state is CoreConnectionState.Unreachable) break
                 // A retryable rung failed — the reducer advances (or exhausts) the ladder.
-                connectionManager.reconnectRungFailed()
+                connectionManager.reconnectRungFailed(ReconnectRungFailureSource.Ladder)
             }
             // Issue #1328 (S5): on genuine exhaustion (Unreachable, no specific terminal
             // message set) surface the unified "Disconnected from …" band (#1098).
@@ -9057,6 +9021,10 @@ public class TmuxSessionViewModel @Inject constructor(
 
     /** S6 (#1329): the AUTHORITATIVE controller state — a test asserts it DECIDED the transition. */
     internal fun connectionControllerStateForTest(): CoreConnectionState = connectionManager.state
+
+    /** Issue #1610 (Q3) seam: rung failures [source] reported; see [ConnectionManager]. */
+    internal fun reconnectRungFailedCountForTest(source: ReconnectRungFailureSource): Int =
+        connectionManager.reconnectRungFailedCount(source)
 
     internal fun attachSessionForAgentRetryForTest(session: SshSession) {
         sessionRef = session

--- a/app/src/main/java/com/pocketshell/app/tmux/connection/ConnectionManager.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/connection/ConnectionManager.kt
@@ -15,6 +15,39 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.emptyFlow
 
 /**
+ * Issue #1328/#1539: who reported a reconnect rung failure to the controller.
+ *
+ * The controller's single churn-surviving attempt counter takes exactly ONE reporter per real
+ * rung failure — two reporters would advance it twice and exhaust the ladder at half its
+ * intended patience. These are the only two reporters.
+ *
+ * ## Why the passive-grace loop's feed is NOT guarded on an active ladder (#1539 round 2)
+ *
+ * The two reporters are already mutually exclusive BY CONSTRUCTION, so no guard is needed:
+ * `scheduleAutoReconnectBody` CANCELS `passiveDisconnectGraceJob` as its FIRST act, before it
+ * ever assigns `autoReconnectJob` — a ladder in flight therefore means the grace loop is
+ * already dead and cannot reach its feed. (The loop's own `inlineConnectionStatus is Connected`
+ * exit enforces the same thing independently.)
+ *
+ * An `autoReconnectJob?.isActive != true` guard on that feed was carried in round 1, reasoned
+ * a-priori from the #1328 contract. It was then MEASURED: the loop reported identical counts
+ * with and without it (1 across 3-4 dials on the storm shape, 3 across 5 on the dial-abandon
+ * shape) — it suppressed exactly ZERO feeds, in every scenario. It was a redundant second
+ * expression of an invariant the job lifecycle already owns, i.e. the patches-on-patches shim
+ * D28 exists to prevent, and it was deleted (D22 hard-cut) rather than left as a policy branch
+ * that documents a hand-off which never happens.
+ *
+ * Do not re-add it without first measuring that it changes a count.
+ */
+internal enum class ReconnectRungFailureSource {
+    /** The auto-reconnect ladder's own rung dial failed retryably (#1328). */
+    Ladder,
+
+    /** A passive-disconnect grace cycle failed to heal (#1610 Q3, #1539). */
+    PassiveGraceLoop,
+}
+
+/**
  * EPIC #792 Slice E — the connection FACADE (the capstone of the migration).
  *
  * `ConnectionManager` is the single object the [com.pocketshell.app.tmux.TmuxSessionViewModel]
@@ -202,9 +235,35 @@ class ConnectionManager(
      * budget, decides exhaustion itself → [ConnectionState.Unreachable]. The VM never
      * counts a parallel ladder.
      */
-    fun reconnectRungFailed() {
+    internal fun reconnectRungFailed(source: ReconnectRungFailureSource) {
+        reconnectRungFailedCounts[source] = (reconnectRungFailedCounts[source] ?: 0) + 1
         controller.submit(ConnectionEvent.ReconnectFailed)
     }
+
+    /**
+     * Issue #1539/#1610 (Q3) test seam: how many rung failures each reporter has submitted to
+     * the controller. Additive and production-neutral (a counter only).
+     *
+     * Counted PER SOURCE because the #1328 one-reporter contract is a relationship between the
+     * two reporters, not a property of either alone. A bare total cannot tell the intended
+     * "the loop fell silent because the ladder took over reporting" from the failure mode
+     * "the loop was silently muzzled and nobody reports" — both look like a number that stops
+     * climbing. Per source, the hand-off is directly observable: the loop stops AND the ladder
+     * starts.
+     *
+     * What this counts is the SUBMISSION, which is the reporters' contract. The controller-side
+     * question — whether the resulting attempt then SURVIVES to escalate/terminate — is #1633's
+     * (a `TransportLive` on a cycle whose dial succeeded currently wipes the walk), so a test
+     * that asserted the observable `Reconnecting.attempt` here would be asserting #1633's
+     * behaviour through this slice, and would fail for reasons this slice does not own.
+     */
+    @androidx.annotation.VisibleForTesting
+    internal val reconnectRungFailedCounts: MutableMap<ReconnectRungFailureSource, Int> =
+        mutableMapOf()
+
+    @androidx.annotation.VisibleForTesting
+    internal fun reconnectRungFailedCount(source: ReconnectRungFailureSource): Int =
+        reconnectRungFailedCounts[source] ?: 0
 
     /** INTENT: the honest give-up. The reconnect effect hit a non-retryable failure (or an
      *  explicit abort) — submit [ConnectionEvent.ReconnectGaveUp] so the reducer surfaces

--- a/app/src/test/java/com/pocketshell/app/tmux/FakeTmuxClient.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/FakeTmuxClient.kt
@@ -223,6 +223,16 @@ internal open class FakeTmuxClient(
      */
     var captureCommandDelayMs: Long = 0L
 
+    /**
+     * Issue #1539: per-`list-panes` round-trip delay, the ATTACH/panes-ready sibling of
+     * [captureCommandDelayMs] (which injects RESEED-stage slowness). Lets a test drive a
+     * busy host where the SSH handshake completes fast but the tmux attach's panes-ready
+     * reconcile runs slow — the stage split's whole point is that this must NOT tear down
+     * the already-handshaken transport.
+     */
+    @Volatile
+    var listPanesCommandDelayMs: Long = 0L
+
     val capturePaneTextViaExecCalls: MutableList<String> = mutableListOf()
 
     var suspendForeverOnCapturePaneTextViaExec: Boolean = false
@@ -441,6 +451,9 @@ internal open class FakeTmuxClient(
         }
         if (captureCommandDelayMs > 0L && cmd.startsWith("capture-pane")) {
             delay(captureCommandDelayMs)
+        }
+        if (listPanesCommandDelayMs > 0L && cmd.startsWith("list-panes")) {
+            delay(listPanesCommandDelayMs)
         }
         suspendForeverOnCommandPrefix?.let { prefix ->
             if (cmd.startsWith(prefix)) {

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue1539PassiveReattachStageBudgetTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue1539PassiveReattachStageBudgetTest.kt
@@ -1,0 +1,765 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.app.sessions.ActiveTmuxClients
+import com.pocketshell.app.tmux.connection.ReconnectRungFailureSource
+import com.pocketshell.core.connection.ConnectionState as CoreConnectionState
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.SshLeaseConnector
+import com.pocketshell.core.ssh.SshLeaseTarget
+import com.pocketshell.core.ssh.SshPortForward
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshShell
+import com.pocketshell.core.tmux.CommandResponse
+import com.pocketshell.core.tmux.TmuxDisconnectEvent
+import com.pocketshell.core.tmux.TmuxDisconnectReason
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+import java.io.InputStream
+
+/**
+ * Issue #1539 — the PASSIVE-GRACE FRESH-TRANSPORT REATTACH LOOP kills transports that
+ * already handshook successfully, because dial + handshake + attach + panes-ready +
+ * reseed all share ONE all-inclusive 5s budget (the former
+ * `PASSIVE_DISCONNECT_SILENT_REATTACH_TIMEOUT_MS`, now split — its 5s survives as the
+ * dial/handshake-only [PASSIVE_REATTACH_DIAL_HANDSHAKE_TIMEOUT_MS]).
+ * Log-proven in the maintainer's real
+ * device log (2026-07-13, seq 64988-65101: **8 successfully-handshaken transports closed
+ * at ~5.5s cadence over 44s**) and in the 15,456-line forensic pass on #1610: every
+ * repeating teardown is `explicit_close` / `disconnectSource=local` /
+ * `trigger=auto-reconnect`, each cycle on a BRAND-NEW clientHash (138/138 distinct).
+ * The app creates a fresh SSH client and LOCALLY closes it ~5s later, forever, on mobile
+ * internet. Reproduce-first (D33/G10) durable class-covering regression proof (D31/D32-G2).
+ *
+ * ## Root cause
+ *
+ * `silentlyReconnectTransportAfterPassiveDisconnect` (`TmuxSessionViewModel.kt`) wraps the
+ * WHOLE fresh-transport sequence in a single `withTimeoutOrNull(timeoutMs)`:
+ *
+ * ```
+ * withTimeoutOrNull(5_000) {
+ *     sshLeaseManager.disconnect(leaseKey)   // evict the old transport
+ *     sshLeaseManager.acquire(leaseTarget)   // stage: DIAL + HANDSHAKE
+ *     newClient.connect()                    // stage: ATTACH
+ *     awaitPanesReadyForAttach(...)          // stage: PANES-READY
+ *     reseedAllVisiblePanes(...)             // stage: RESEED
+ * }
+ * ```
+ *
+ * On a slow host the LATER stages blow the shared budget, so the `!ready` branch closes a
+ * transport whose **handshake already completed** — proof the link is up — and evicts its
+ * lease. The grace loop then re-dials from scratch on the next 250ms tick
+ * ([PASSIVE_DISCONNECT_SILENT_REATTACH_RETRY_MS]), producing the measured 5.65s median
+ * cycle (5s budget + 250ms spacing + dial time) with a hard 5.01-5.07s floor. Bursts NEVER
+ * self-heal, because each new transport hits the same slow reseed and dies the same way.
+ *
+ * ## Class coverage (G2)
+ *  1. slow RESEED on a handshaken transport -> KEEP the transport (the maintainer's exact
+ *     signature: dial+handshake fast, reseed pushes the total past 5s).
+ *  2. slow ATTACH/panes-ready that still FITS the attach budget -> no longer killed by the
+ *     old shared 5s clock.
+ *  2b. attach that OVERRUNS its own budget on a still-vouched-ALIVE transport -> KEEP it and
+ *     retry the attach over that SAME transport (asserted on transport IDENTITY). This is the
+ *     `!ready && vouchedAlive -> keep` branch — the decision the whole slice turns on, and the
+ *     one member of this class round 1 shipped untested.
+ *  3. dial/handshake never completes -> STILL abandoned fast (the fix must not make a
+ *     genuinely dead dial ride forever), and the retry stays amortized.
+ *  4. repeated-churn: a sustained slow host must NOT reproduce the 8-transports-in-44s
+ *     ladder — the established transport is reused, not re-dialed per cycle.
+ *  5. an attach-stage timeout on a transport that is NOT vouched alive still escalates — the
+ *     evict side of the same branch as 2b, so the pair pins it in BOTH directions and the fix
+ *     cannot MASK a real death.
+ *
+ * No `assumeTrue`/CI-skip on any load-bearing assertion: the slow-stage timing is injected
+ * SYNTHETICALLY under the `runTest` virtual clock (the #780 model) and hard-fails otherwise.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class Issue1539PassiveReattachStageBudgetTest : TmuxSessionViewModelTestBase() {
+
+    // ---- 1. slow RESEED on a handshaken transport -> keep it (the maintainer's signature) ----
+
+    @Test
+    fun slowReseedOnHandshakenTransportKeepsItInsteadOfClosingAndRedialing() =
+        runTest(scheduler) {
+            val f = Fixture(this)
+            // The maintainer's exact stage timing: dial+handshake complete FAST (~1s), then
+            // the reseed runs slow (6s) on a busy host — pushing the total past the 5s
+            // all-inclusive budget while the transport is provably up.
+            f.dialDelayMs = 1_000L
+            f.firstFreshClientCaptureDelayMs = 6_000L
+            f.start()
+            f.dropControlChannelPassively()
+
+            // Drive the whole grace window under the virtual clock.
+            advanceTimeBy(f.graceMs + 1_000L)
+            runCurrent()
+
+            val fresh = f.freshSessions.firstOrNull()
+            assertTrue(
+                "the fresh-transport rung must have dialed at least one replacement transport " +
+                    "(otherwise this test never reaches the code under test); dials=${f.connector.connectCount}",
+                fresh != null,
+            )
+            // LOAD-BEARING #1 — the reported symptom. On base the reseed blows the shared 5s
+            // budget, so the `!ready` branch CLOSES the successfully-handshaken transport.
+            assertFalse(
+                "a transport whose SSH handshake COMPLETED must NOT be closed because a LATER " +
+                    "stage (reseed) ran slow — a completed handshake is proof the link is up (#1539). " +
+                    "Closing it is the `explicit_close`/`disconnectSource=local` in the maintainer's log.",
+                fresh!!.closed,
+            )
+            // LOAD-BEARING #2 — no churn ladder. 1 warm dial + exactly 1 fresh dial. On base
+            // this climbs every ~5.25s for the whole window (the 8-in-44s signature).
+            assertEquals(
+                "the slow reseed must be retried on the SAME handshaken transport — NOT closed and " +
+                    "re-dialed from scratch. connectCount>2 is the #1539 redial ladder " +
+                    "(dials=${f.connector.connectCount}, freshClosed=${f.freshSessions.map { it.closed }})",
+                2,
+                f.connector.connectCount,
+            )
+            f.assertConvergedToConnected()
+        }
+
+    // ---- 2. slow ATTACH / panes-ready on a handshaken transport -> keep it ----
+
+    @Test
+    fun slowAttachPanesReadyOnHandshakenTransportKeepsItInsteadOfClosingAndRedialing() =
+        runTest(scheduler) {
+            val f = Fixture(this)
+            f.dialDelayMs = 1_000L
+            // The attach stage (`list-panes` / panes-ready) is the slow one this time — same
+            // class of defect, different stage. The attach path's OWN designed budget is
+            // ATTACH_PANES_READY_TIMEOUT_MS (12s); the passive-grace wrapper cut it at 5s.
+            f.firstFreshClientListPanesDelayMs = 6_000L
+            f.start()
+            f.dropControlChannelPassively()
+
+            advanceTimeBy(f.graceMs + 1_000L)
+            runCurrent()
+
+            val fresh = f.freshSessions.firstOrNull()
+            assertTrue("the fresh-transport rung must have dialed a replacement", fresh != null)
+            assertFalse(
+                "a handshaken transport must NOT be closed because the ATTACH/panes-ready stage " +
+                    "ran slow (#1539) — the attach retries on the SAME transport",
+                fresh!!.closed,
+            )
+            assertEquals(
+                "slow attach must not trigger a close+redial ladder (dials=${f.connector.connectCount})",
+                2,
+                f.connector.connectCount,
+            )
+            f.assertConvergedToConnected()
+        }
+
+    // ---- 2b. attach OVERRUNS its own budget on a vouched-ALIVE transport -> KEEP + retry ----
+
+    /**
+     * AC2's second half — **the attach retries on the SAME transport** — i.e. the
+     * `!ready && vouchedAlive -> keep` branch ([shouldEvictTransportAfterStageFailure]).
+     *
+     * The sibling above (`slowAttachPanesReady…`, 6s) proves a slow attach that still FITS the
+     * 10s attach budget is no longer killed by the old shared 5s clock. It does NOT reach the
+     * keep branch — the attach simply succeeds. This test is the one that enters it: the attach
+     * OVERRUNS [PASSIVE_REATTACH_ATTACH_TIMEOUT_MS] on a transport that is still vouched alive,
+     * so the rung fails with the link provably up. That is the decision the whole slice turns
+     * on, and without this test forcing `shouldEvictTransportAfterStageFailure` back to base's
+     * unconditional evict leaves the entire class green.
+     */
+    @Test
+    fun attachThatOverrunsItsBudgetOnAVouchedAliveTransportKeepsItAndRetriesTheAttachOverIt() =
+        runTest(scheduler) {
+            val f = Fixture(this)
+            f.dialDelayMs = 1_000L
+            // Past the attach stage's OWN budget — not merely past the old shared 5s clock — so
+            // the rung genuinely fails post-handshake and the `!ready` branch must decide.
+            f.firstFreshClientListPanesDelayMs = PASSIVE_REATTACH_ATTACH_TIMEOUT_MS + 2_000L
+            // The transport is ALIVE (the default): a completed handshake on a busy host. This is
+            // the ONLY difference from `attachTimeoutOnGenuinelyDeadTransportStillEscalates…`,
+            // which takes the evict side — together they pin the branch in both directions.
+            f.freshSessionsAreDead = false
+            f.graceMs = 30_000L
+            f.start()
+            f.dropControlChannelPassively()
+
+            advanceTimeBy(f.graceMs + 1_000L)
+            runCurrent()
+
+            val fresh = f.freshSessions.firstOrNull()
+            assertTrue(
+                "precondition: the fresh-transport rung dialed a replacement transport",
+                fresh != null,
+            )
+            // Precondition, hard-asserted (no assume): the first attach really did overrun and a
+            // SECOND attach was made — otherwise the keep branch was never entered and every
+            // assertion below would pass vacuously.
+            assertTrue(
+                "precondition: the first attach must OVERRUN its budget and be retried — a second " +
+                    "attach client proves the rung failed post-handshake; clients=${f.clients.size}",
+                f.clients.size >= 2,
+            )
+            // LOAD-BEARING #1 — the transport is KEPT. Base (unconditional evict) closes it.
+            assertFalse(
+                "an attach that overran its budget on a transport whose handshake COMPLETED and " +
+                    "which is STILL vouched alive must NOT be closed — the link is provably up, so " +
+                    "the slow stage is a busy host, not a dead link (#1539)",
+                fresh!!.closed,
+            )
+            // LOAD-BEARING #2 — the retry routes to the WARM (channel-only) rung, so no redial.
+            assertEquals(
+                "the kept transport must be re-published so the next tick re-vouches it and routes " +
+                    "to the channel-only warm rung: the dial count must NOT climb " +
+                    "(dials=${f.connector.connectCount}, freshClosed=${f.freshSessions.map { it.closed }})",
+                2,
+                f.connector.connectCount,
+            )
+            // LOAD-BEARING #3 — AC2 verbatim: the attach retried over the SAME TRANSPORT. Asserted
+            // on transport IDENTITY, not on "no exception": a redial that happened to succeed
+            // would also throw nothing, and would also be the churn this issue is about.
+            assertSame(
+                "the attach must retry over the SAME handshaken transport the rung dialed — the " +
+                    "converged client must be built on that exact SshSession, not a replacement " +
+                    "(AC2). A different session here IS the close-and-redial ladder.",
+                fresh,
+                f.sessionForClient[f.clients.last()],
+            )
+            f.assertConvergedToConnected()
+        }
+
+    // ---- 3. dial/handshake never completes -> STILL abandoned fast + amortized (G2) ----
+
+    @Test
+    fun dialHandshakeThatNeverCompletesIsStillAbandonedFastAndAmortized() =
+        runTest(scheduler) {
+            val f = Fixture(this)
+            // The dial itself never completes within the dial/handshake budget: a genuinely
+            // unreachable host. The fix must NOT make this ride through forever — a transport
+            // that never handshook is NOT proof of a live link.
+            f.dialDelayMs = Long.MAX_VALUE / 4
+            f.start()
+            f.dropControlChannelPassively()
+
+            advanceTimeBy(f.graceMs + 1_000L)
+            runCurrent()
+
+            // Fast-fail preserved: every stalled dial IS abandoned at the dial budget rather
+            // than parking the grace window on one hung handshake.
+            assertTrue(
+                "a dial that never completes must still be ABANDONED at the dial/handshake budget " +
+                    "(the fast-fail path must survive the stage split) — the grace loop must have " +
+                    "retried, so more than one dial is attempted; dials=${f.connector.connectCount}",
+                f.connector.connectCount > 1,
+            )
+            // Amortized: the retry is spaced by the dial budget + retry spacing, NOT a hot loop.
+            // graceMs / (dialBudget + retrySpacing) is the ceiling; assert we are near it, not
+            // hundreds of dials.
+            val ceiling = (f.graceMs / PASSIVE_DISCONNECT_SILENT_REATTACH_RETRY_MS).toInt()
+            assertTrue(
+                "the abandoned-dial retry must stay AMORTIZED (bounded by the dial budget + " +
+                    "${PASSIVE_DISCONNECT_SILENT_REATTACH_RETRY_MS}ms spacing), never a hot redial loop; " +
+                    "dials=${f.connector.connectCount} must be well under the ${ceiling} hot-loop ceiling",
+                f.connector.connectCount < ceiling / 2,
+            )
+        }
+
+    // ---- 4. repeated churn: no 8-transports-in-44s ladder under a sustained slow host ----
+
+    @Test
+    fun sustainedSlowHostDoesNotReproduceTheRepeatedTransportChurnLadder() =
+        runTest(scheduler) {
+            val f = Fixture(this)
+            f.dialDelayMs = 1_000L
+            // EVERY fresh client's reseed is slow for the whole window — the sustained busy
+            // host that produced the maintainer's 44s burst. The transport is never dead.
+            f.allFreshClientsCaptureDelayMs = 6_000L
+            f.graceMs = 44_000L
+            f.start()
+            f.dropControlChannelPassively()
+
+            advanceTimeBy(f.graceMs + 1_000L)
+            runCurrent()
+
+            // The maintainer measured EIGHT successfully-handshaken transports closed in 44s.
+            // Under the fix the established transport is reused, so the dial count stays flat
+            // no matter how long the host stays slow.
+            val closedHandshaken = f.freshSessions.count { it.closed }
+            assertEquals(
+                "a sustained slow host must NOT close a single successfully-handshaken transport " +
+                    "(the maintainer's 8-in-44s churn burst). freshClosed=${f.freshSessions.map { it.closed }}",
+                0,
+                closedHandshaken,
+            )
+            assertTrue(
+                "no transport churn ladder over a 44s slow-host window: at most ONE fresh transport " +
+                    "should ever be dialed (dials=${f.connector.connectCount}; the logged burst was 8)",
+                f.connector.connectCount <= 2,
+            )
+        }
+
+    // ---- 5. reseed timeout on a NOT-vouched-alive transport still escalates (non-masking) ----
+
+    @Test
+    fun attachTimeoutOnGenuinelyDeadTransportStillEscalatesAndIsNotMasked() =
+        runTest(scheduler) {
+            val f = Fixture(this)
+            f.dialDelayMs = 1_000L
+            // The ATTACH (panes-ready) never answers — the tail failure that CAN still fail a rung
+            // now that the reseed is out of the readiness verdict (#1353).
+            f.allFreshClientsListPanesDelayMs = Long.MAX_VALUE / 4
+            // The replacement transports are DEAD the moment they are handed over (sshj flipped
+            // isConnected false). The vouch must FAIL, so the ladder must still escalate — a
+            // ride-through here would strand the user on a dead socket forever.
+            f.freshSessionsAreDead = true
+            f.start()
+            f.dropControlChannelPassively()
+
+            advanceTimeBy(f.graceMs + 1_000L)
+            runCurrent()
+
+            assertTrue(
+                "an attach-stage timeout on a transport that is NOT vouched alive must STILL " +
+                    "escalate to a fresh lease-evicting dial — the keep-the-transport fix must not " +
+                    "MASK a real death (#1539 G2); dials=${f.connector.connectCount}",
+                f.connector.connectCount > 2,
+            )
+        }
+
+    // ---- 6a. the SILENT-HEAL path terminates: dial SUCCEEDS, the tail fails (the real storm) ----
+
+    @Test
+    fun silentHealCycleWhoseDialSucceedsButTailFailsStillFeedsTheCounterAndTerminates() =
+        runTest(scheduler) {
+            val f = Fixture(this)
+            // THE MAINTAINER'S ACTUAL STORM, and the reason a dial-failure-only counter feed would
+            // ship inert: the dial+handshake SUCCEEDS every cycle (138/138 distinct clientHashes in
+            // the real log prove exactly this) and the cycle dies in the ATTACH/RESEED TAIL. If the
+            // counter is only fed on a failed dial it never advances here, the episode clock never
+            // arms, and the loop is unbounded by construction even with #1633 merged.
+            f.dialDelayMs = 1_000L
+            // The dial SUCCEEDS; the cycle dies in the TAIL. Post-#1353 the reseed can no longer
+            // fail a rung (that is the fix), so the tail failure that remains is the attach.
+            f.allFreshClientsListPanesDelayMs = Long.MAX_VALUE / 4
+            // Transports never vouched alive, so every cycle genuinely fails to recover (the pure
+            // non-converging flap) rather than settling via the keep-and-retry path.
+            f.freshSessionsAreDead = true
+            // The PRODUCTION ladder — see [Fixture.autoReconnectDelaysOverride].
+            f.autoReconnectDelaysOverride = null
+            f.start()
+            assertTrue(
+                "precondition: the controller tracks a LIVE target before the drop (otherwise " +
+                    "ReconnectFailed is a no-op and this would pass vacuously); state=" +
+                    "${f.vm.connectionControllerStateForTest()}",
+                f.vm.connectionControllerStateForTest() !is CoreConnectionState.Idle,
+            )
+            f.dropControlChannelPassively()
+
+            advanceTimeBy(f.graceMs + 1_000L)
+            runCurrent()
+
+            assertTrue(
+                "precondition: the silent-heal loop actually cycled (dials=${f.connector.connectCount})",
+                f.connector.connectCount > 2,
+            )
+            // LOAD-BEARING: a cycle that fails in the TAIL must ARM the ladder exactly as a failed
+            // dial does, so the silent-heal path — not just the ladder path — can escalate and
+            // terminate.
+            //
+            // The assertion is on the ADVANCING ATTEMPT NUMBER, not merely "state is Reconnecting":
+            // the passive drop ALONE puts the controller in Reconnecting(attempt=1), so a
+            // `state is Reconnecting` check passes vacuously with the counter feed removed (this
+            // was verified — it is the D32-G6 wrong-cost trap). Only ConnectionEvent.ReconnectFailed
+            // advances `attempt` past 1 or reaches Unreachable, so this is the assertion the fix,
+            // and only the fix, can satisfy.
+            // minCycles=1, not more, and that is the POINT: once the loop reports its first
+            // failure the controller leaves Connected, so the grace loop returns and HANDS THE
+            // FLAP OFF to the bounded ladder — which is exactly the intended outcome. Before the
+            // fix it reported 0 and kept cycling inside the grace window forever. The bar is
+            // "the ladder hears about it at all"; 0 is the unbounded-by-construction bug.
+            f.assertReportedRungFailures(
+                minCycles = 1,
+                why = "a silent-heal cycle whose dial SUCCEEDED but whose attach/reseed tail timed " +
+                    "out must still feed the single attempt counter — otherwise the maintainer's " +
+                    "real storm (dial ok, tail times out) never advances it and the loop is " +
+                    "unbounded by construction (#1610 Q3)",
+            )
+        }
+
+    // ---- 6b. the dial-failure path also feeds the counter (#1610 Q3) ----
+
+    @Test
+    fun abandonedDialRungFeedsTheSingleAttemptCounterSoTheLadderCanBoundTheLoop() =
+        runTest(scheduler) {
+            val f = Fixture(this)
+            // A genuinely unreachable host: every fresh-transport rung's dial is abandoned at the
+            // dial/handshake budget.
+            f.dialDelayMs = Long.MAX_VALUE / 4
+            // The PRODUCTION ladder — see [Fixture.autoReconnectDelaysOverride].
+            f.autoReconnectDelaysOverride = null
+            f.start()
+            assertTrue(
+                "precondition: the controller tracks a LIVE target before the drop (otherwise " +
+                    "ReconnectFailed is a no-op and this test would pass vacuously); state=" +
+                    "${f.vm.connectionControllerStateForTest()}",
+                f.vm.connectionControllerStateForTest() !is CoreConnectionState.Idle,
+            )
+            f.dropControlChannelPassively()
+
+            advanceTimeBy(f.graceMs + 1_000L)
+            runCurrent()
+
+            // LOAD-BEARING: the grace loop dials `sshLeaseManager.acquire` DIRECTLY, never through
+            // `connect()`/`runConnect` (the sole `connect_invoked` emitter), and the controller's
+            // counter advances ONLY on ConnectionEvent.ReconnectFailed. Without the loop submitting
+            // it the ladder is bypassed and the loop is UNBOUNDED BY CONSTRUCTION. Asserted on the
+            // ADVANCING attempt (see the sibling above — `state is Reconnecting` alone is satisfied
+            // by the passive drop itself and passes vacuously).
+            f.assertReportedRungFailures(
+                minCycles = 1,
+                why = "each abandoned dial rung must report ReconnectFailed so the SINGLE attempt " +
+                    "counter advances — without this the ladder never sees the loop's failures " +
+                    "and cannot terminate it (#1610 Q3)",
+            )
+        }
+
+    // ---- 7. the reconnect ladder's give-up budget (#1331/#1633) ----
+
+    @Test
+    fun autoReconnectLadderIsPatientEnoughForMobileAndStillTerminates() {
+        val ladder = DEFAULT_AUTO_RECONNECT_DELAYS_MS
+        // The controller's give-up budget IS the ladder length
+        // (`effectiveMaxAttempts = reconnectLadderMs.size`), so the list's size is the policy.
+        // Before #1633 the counter never advanced, which made the length inert; now that it
+        // escalates AND terminates, a 4-rung `[0,1,2,5]s` ladder surrenders to `Unreachable`
+        // after only ~8s of flapping — trading the infinite strobe for an app that gives up
+        // almost immediately.
+        assertEquals(
+            "the reconnect ladder must have 8 rungs so a flapping mobile link is not surrendered " +
+                "on after ~8s (the 4-rung `[0,1,2,5]s` behaviour); ladder=$ladder",
+            8,
+            ladder.size,
+        )
+        val totalMs = ladder.sum()
+        assertTrue(
+            "the ladder must ride out a tunnel/lift/RAT-handover: a 4-rung ladder surrenders in " +
+                "${ladder.take(4).sum()}ms, which is the regression this guards. total=${totalMs}ms",
+            totalMs > 60_000L,
+        )
+        assertTrue(
+            "the ladder must still TERMINATE in a reasonable time — an honest `Unreachable` " +
+                "under two minutes beats retrying forever. total=${totalMs}ms",
+            totalMs <= 120_000L,
+        )
+        assertEquals(
+            "backoff must be monotonically non-decreasing (no rung retries sooner than the one " +
+                "before it); ladder=$ladder",
+            ladder.sorted(),
+            ladder,
+        )
+        // Jitter belongs to #1633's `ConnectionController.retryDelayForAttempt`, and the VM waits
+        // on the controller's `recon.retryDelayMs` — so these values must stay DETERMINISTIC here
+        // or the jitter is double-applied.
+        assertEquals(
+            "the ladder must be a deterministic constant — jitter is applied once, by the " +
+                "controller, never baked in here",
+            DEFAULT_AUTO_RECONNECT_DELAYS_MS,
+            ladder,
+        )
+    }
+
+    // ---- fixture ----
+
+    /**
+     * Drives the maintainer's real journey: a warm per-host lease, a passive `-CC` drop on a
+     * transport that is NOT vouched alive (so the fresh-transport rung is preferred — see
+     * [com.pocketshell.app.tmux.connection.preferFreshTransportForPassiveReattach]), then the
+     * bounded grace window under the virtual clock. Every stage's slowness is injected
+     * synthetically; nothing here can self-skip.
+     */
+    private inner class Fixture(private val scope: kotlinx.coroutines.test.TestScope) {
+        val registry = ActiveTmuxClients()
+
+        /**
+         * Sessions the LEASE CONNECTOR dialed, in dial order. `[0]` is the warm-lease dial
+         * (fixture setup); `drop(1)` is every FRESH transport the grace loop re-dialed — the
+         * ones #1539 is about. Kept apart from the setup-only stale session handed to
+         * [TmuxSessionViewModel.replaceClientForTest] so an index can never silently drift.
+         */
+        val dialedSessions = mutableListOf<FakeSshSession>()
+        val freshSessions: List<FakeSshSession> get() = dialedSessions.drop(1)
+        val clients = mutableListOf<FakeTmuxClient>()
+
+        /**
+         * The TRANSPORT each tmux client was built over, captured from the production client
+         * factory's own `SshSession` argument. This is what makes "the attach retried on the SAME
+         * transport" (AC2) assertable by IDENTITY rather than inferred from a dial count.
+         */
+        val sessionForClient = mutableMapOf<FakeTmuxClient, SshSession>()
+
+        var graceMs: Long = 20_000L
+        var dialDelayMs: Long = 0L
+        var firstFreshClientCaptureDelayMs: Long = 0L
+        var allFreshClientsCaptureDelayMs: Long = 0L
+        var firstFreshClientListPanesDelayMs: Long = 0L
+        var allFreshClientsListPanesDelayMs: Long = 0L
+        var freshSessionsAreDead: Boolean = false
+
+        /**
+         * The auto-reconnect ladder to install, or null to keep the PRODUCTION
+         * [DEFAULT_AUTO_RECONNECT_DELAYS_MS]. Default `[0]` keeps the churn/keep tests fast (their
+         * subject is transport teardown, not backoff). The counter-feed tests MUST use the real
+         * ladder: a 1-rung ladder makes `effectiveMaxAttempts == 1`, so the very first
+         * ReconnectFailed exhausts it -> Unreachable -> the ladder re-arms at attempt=1, and the
+         * advancing-attempt assertion can never observe the advance it is there to prove.
+         */
+        var autoReconnectDelaysOverride: List<Long>? = listOf(0L)
+
+        lateinit var vm: TmuxSessionViewModel
+        lateinit var connector: QueueLeaseConnector
+        private lateinit var droppedCcClient: FakeTmuxClient
+
+        suspend fun start() {
+            TMUX_CONNECT_ATTEMPTS.set(1)
+            connector = QueueLeaseConnector()
+            vm = newVm(
+                registry = registry,
+                sshLeaseManager = with(scope) {
+                    testLeaseManager(
+                        connector = connector,
+                        scope = scope,
+                        idleTtlMillis = 60_000L,
+                    )
+                },
+            )
+            // The production all-inclusive budget is 5s — the exact value that killed the
+            // maintainer's handshaken transports. Pin it so the reproduction is faithful.
+            // Pin the HISTORICAL 5s rung timeout — the exact value that killed the maintainer's
+            // handshaken transports — so the reproduction stays faithful to the reported defect
+            // and does not silently track the new 15s dial budget.
+            vm.setPassiveDisconnectRecoveryForTest(
+                graceMs = graceMs,
+                silentReattachTimeoutMs = 5_000L,
+            )
+            autoReconnectDelaysOverride?.let { vm.setAutoReconnectDelaysForTest(it) }
+            // The rolling watchdogs auto-arm on Connected and re-arm forever under the virtual
+            // clock (#1517). Orthogonal to the churn-vs-keep decision under test.
+            vm.setStaleRenderWatchdogAutoArmEnabledForTest(false)
+            vm.setConnectedBlankWatchdogAutoArmEnabledForTest(false)
+
+            vm.setTmuxClientFactoryForTest { session, sessionName, _ ->
+                assertEquals("work", sessionName)
+                newFreshClient(session)
+            }
+
+            droppedCcClient = FakeTmuxClient()
+            // The stale transport is DEAD (isConnected=false) so the transport vouch fails and
+            // `preferFreshTransportForPassiveReattach` selects the fresh-transport rung — the
+            // exact rung that owns the #1539 redial ladder.
+            val stale = FakeSshSession(isConnectedValue = false)
+            vm.replaceClientForTest(
+                hostId = 7L,
+                hostName = "alpha",
+                host = "alpha.example",
+                port = 22,
+                user = "alex",
+                keyPath = "/keys/a",
+                sessionName = "work",
+                client = droppedCcClient,
+                session = stale,
+            )
+            scope.runCurrent()
+            // Hold a warm lease: the exact within-grace precondition. Suspends on the SHARED
+            // virtual clock — never `runBlocking` here (that parks the test thread while the
+            // scheduler it is waiting on can only advance from that same thread).
+            vm.setActiveLeaseRefWarmForTest()
+            scope.runCurrent()
+            assertEquals(
+                "the warm lease is dialed exactly once before the drop",
+                1,
+                connector.connectCount,
+            )
+        }
+
+        fun dropControlChannelPassively() {
+            droppedCcClient.markDisconnectedForTest(
+                TmuxDisconnectEvent(
+                    reason = TmuxDisconnectReason.ReaderEof,
+                    source = "network_starvation",
+                    intent = "unknown",
+                ),
+            )
+            scope.runCurrent()
+        }
+
+        /**
+         * The grace loop REPORTED at least [minCycles] rung failures to the controller — the
+         * contract this slice owes #1633's ladder.
+         *
+         * Asserted on the reported-failure COUNT rather than the controller's observable
+         * `Reconnecting.attempt`, deliberately:
+         *  - `state is Reconnecting` alone passes VACUOUSLY — the passive drop itself yields
+         *    Reconnecting(attempt=1) with no feed at all (verified: the whole suite stayed green
+         *    with the feed commented out). That is the D32-G6 wrong-cost trap.
+         *  - `Reconnecting.attempt >= 2` cannot go green on this base either, but for a reason
+         *    this slice does NOT own: the attempt is re-armed to 1 by the parallel auto-reconnect
+         *    ladder's `enterReconnectLadder`, and a cycle whose dial SUCCEEDS submits TransportLive
+         *    which wipes the walk — the exact reset #1633 owns. Asserting it here would make this
+         *    slice's proof fail on #1633's unmerged behaviour.
+         * So: this slice proves it FEEDS the counter once per failed cycle; #1633 proves the fed
+         * counter escalates and terminates. The joint end-to-end assertion belongs to the
+         * integration of the two (flagged to the orchestrator).
+         */
+        fun assertReportedRungFailures(minCycles: Int, why: String) {
+            val reported = loopReports()
+            assertTrue(
+                "$why. The grace loop reported $reported rung failures after " +
+                    "${connector.connectCount} dials — expected >= $minCycles. 0 means the ladder " +
+                    "never sees the loop's failures at all and cannot bound it.",
+                reported >= minCycles,
+            )
+        }
+
+        /**
+         * Rung failures reported by the PASSIVE-GRACE LOOP specifically — NOT a total across
+         * reporters. The ladder ([ReconnectRungFailureSource.Ladder]) reports its own rungs to
+         * the same counter, so a total would let a ladder report satisfy an assertion about the
+         * loop's contract vacuously. Per source, these tests assert only what this slice owes.
+         */
+        fun loopReports(): Int =
+            vm.reconnectRungFailedCountForTest(ReconnectRungFailureSource.PassiveGraceLoop)
+
+        fun assertConvergedToConnected() {
+            assertTrue(
+                "the ride-through must still converge to a usable Connected session — keeping the " +
+                    "transport must not strand the user mid-reattach",
+                vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected,
+            )
+            assertEquals("work", vm.activeSessionNameForTest())
+            assertSame(
+                "the converged client is the one registered for the host",
+                clients.last(),
+                registry.clients.value[7L]?.client,
+            )
+        }
+
+        private fun newDialedSession(dead: Boolean = false): FakeSshSession =
+            FakeSshSession(isConnectedValue = !dead).also { dialedSessions += it }
+
+        private fun newFreshClient(session: SshSession): FakeTmuxClient {
+            val isFirstFresh = clients.isEmpty()
+            val client = FakeTmuxClient().withSinglePane("work", "%1")
+            sessionForClient[client] = session
+            client.captureCommandDelayMs = when {
+                allFreshClientsCaptureDelayMs > 0L -> allFreshClientsCaptureDelayMs
+                isFirstFresh -> firstFreshClientCaptureDelayMs
+                else -> 0L
+            }
+            client.listPanesCommandDelayMs = when {
+                allFreshClientsListPanesDelayMs > 0L -> allFreshClientsListPanesDelayMs
+                isFirstFresh -> firstFreshClientListPanesDelayMs
+                else -> 0L
+            }
+            clients += client
+            return client
+        }
+
+        inner class QueueLeaseConnector : SshLeaseConnector {
+            var connectCount: Int = 0
+                private set
+
+            override suspend fun connect(target: SshLeaseTarget): Result<SshSession> {
+                connectCount += 1
+                // The warm-lease dial (#1) is the test's SETUP — it lands instantly so the
+                // fixture reaches the reported precondition. Only the FRESH re-dials the
+                // grace loop issues (#2+) carry the injected handshake latency, which is
+                // what the mobile-RTT scenario is about.
+                if (connectCount > 1 && dialDelayMs > 0L) delay(dialDelayMs)
+                // Only the FRESH re-dials carry the injected liveness; the warm-lease dial is
+                // always a healthy setup transport.
+                return Result.success(newDialedSession(dead = connectCount > 1 && freshSessionsAreDead))
+            }
+        }
+    }
+
+    private fun FakeTmuxClient.withSinglePane(
+        sessionName: String,
+        paneId: String,
+    ): FakeTmuxClient = apply {
+        // Sticky fixtures: the reattach may legitimately re-issue these on an attach retry
+        // over the SAME transport, so they must not be one-shot.
+        repeat(8) {
+            responses.addLast(
+                CommandResponse(
+                    number = 1L,
+                    output = listOf("$paneId\t@0\t\$0\t$sessionName\t$sessionName\t0"),
+                    isError = false,
+                ),
+            )
+        }
+        defaultCaptureResponse = CommandResponse(
+            number = 2L,
+            output = listOf("$sessionName ready"),
+            isError = false,
+        )
+        repeat(8) {
+            cursorQueryResponses.addLast(
+                CommandResponse(number = 3L, output = listOf("0,0"), isError = false),
+            )
+        }
+    }
+
+    private class FakeSshSession(
+        private val isConnectedValue: Boolean = true,
+        private val isCloseInitiatedValue: Boolean = false,
+    ) : SshSession {
+        @Volatile
+        var closed: Boolean = false
+
+        override val isConnected: Boolean
+            get() = isConnectedValue && !closed
+
+        override val isCloseInitiated: Boolean
+            get() = isCloseInitiatedValue
+
+        override fun isTransportProvenAliveWithinKeepAliveWindow(): Boolean = isConnected
+
+        override suspend fun exec(command: String): ExecResult =
+            ExecResult(stdout = "", stderr = "", exitCode = 0)
+
+        override fun tail(path: String, onLine: (String) -> Unit): Job = Job()
+
+        override fun openLocalPortForward(
+            remoteHost: String,
+            remotePort: Int,
+            localPort: Int,
+        ): SshPortForward = throw NotImplementedError("not needed")
+
+        override fun startShell(): SshShell = throw NotImplementedError("not needed")
+
+        override suspend fun uploadFile(file: File, remotePath: String): String = remotePath
+
+        override suspend fun uploadStream(
+            input: InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String = remotePath
+
+        override fun close() {
+            closed = true
+        }
+    }
+}


### PR DESCRIPTION
Closes #1539. **This is the load-bearing slice of the #1610 mobile reconnect-storm fix** — the change that stops the maintainer's phone reconnecting every ~5 seconds. Root-cause record: [`docs/connection-storm-2026-07-16.md`](https://github.com/alexeygrigorev/pocketshell/blob/main/docs/connection-storm-2026-07-16.md).

## The bug

The passive-grace reattach ran **dial + handshake + tmux attach + panes-ready + full pane reseed under ONE all-inclusive 5s budget** (`TmuxSessionSupport.kt:469`, `withTimeoutOrNull` at `TmuxSessionViewModel.kt:8439`).

On a mobile link the handshake **fits** (~1.5–3s — hence a brand-new clientHash every cycle, **138/138 distinct** in the maintainer's real log) but the tail does **not**: the reseed alone is **~10.4s/pane** worst case (#1353). So the budget blew **deterministically every cycle**, and the `!ready` branch (`:8515-8546`) closed a fully-handshaken, provably-live transport and redialed from scratch.

Constant budget vs constant >5s latency = identical failure forever. That is why bursts **never self-healed** and only ever ended when the maintainer backgrounded the app.

## What changed

- **Per-stage budgets**: dial 15s / attach 10s / reseed 5s.
- **The reseed moves OUT of the readiness verdict** — READY now means ATTACHED. It runs after the verdict, bounded but unable to veto. Overruns heal via the existing blank watchdog, which the reviewer verified is a **real net** (arms on both rungs, auto-arms in production, re-seeds on each of 20 ticks) — *not* the #1514 detected-only class.
- **Re-vouch before evicting**, so a proven-live transport is kept and the attach retries over it.
- **Feeds `ReconnectFailed` per failed CYCLE, not merely on dial failure.** This is what makes #1633's stability window and give-up reachable at all: the storm is *dial succeeds → tail times out*, so a dial-failure-only feed would have merged green and **done nothing on-device**.
- Installs the 8-rung `[0,1,2,5,10,20,30,30]s` ladder (per the [#1331 design decisions](https://github.com/alexeygrigorev/pocketshell/issues/1331#issuecomment-4991953714); jitter is applied in the controller, not here).

## Deletions (D22 hard-cut)

- `PASSIVE_REATTACH_ATTACH_ATTEMPTS` + `attachAttempts` — **never read**, while their KDoc documented a bounded attach-retry with liveness gating **that does not exist**. The outer grace loop already provides it; an inner one would stack a second retry mechanism on the first. Reviewer verified the outer-loop equivalence.
- The `autoReconnectJob` guard — **measured to suppress zero feeds** and structurally unreachable. It was round-1 code, never in base, so deleting it cannot regress anything that shipped.

## Verification

**Reviewer reproduced the maintainer's signature independently** by mutating back to base semantics (reseed inside the verdict + one shared clock + unconditional evict): `freshClosed=[true ×7]`, `expected:<0> but was:<7>` — **seven handshaken transports closed in a 44s window**, against the maintainer's logged eight. Restore → 9/9 green, diffstat byte-identical.

**Mutation-checked (the round-two gap, now closed):** forcing `shouldEvictTransportAfterStageFailure` to always-evict reddens the new `attachThatOverrunsItsBudgetOnAVouchedAliveTransportKeepsItAndRetriesTheAttachOverIt` while leaving the other 8 green — so it is **the only thing standing between that mutation and a green suite**. In round two, all 8 stayed green and the keep-branch had zero coverage. AC2's "the attach retries on the SAME transport" is now proven **by transport identity**, captured from the production factory.

**The counter-feed is proven to fire on the real path**: removing it turns `silentHealCycleWhoseDialSucceedsButTailFails…` red with `reported 0 rung failures after 4 dials`.

Orchestrator gate in a clean integration worktree, rebased onto post-merge `main` (`ab3e0caf`, i.e. with #1645 + #1643 + #1644 landed), `./gradlew test --rerun-tasks` (**both variants**, the CI required task), **counts asserted from the result XML** per `process.md` `8dc16024`:
- `:app:testDebugUnitTest` — **3947 tests, 0 failures, 0 skipped**
- `:app:testReleaseUnitTest` — **3943 tests, 0 failures, 0 skipped**
- `Issue1539PassiveReattachStageBudgetTest` confirmed executed in **both** variants (non-vacuous, G3)
- **Ratchet re-checked against the ACTUAL post-merge tree** (not per-PR in isolation, per the v0.4.33 precedent): VM **17560 lines vs 17621 baseline** — a real reduction, baseline never raised
- `check-file-size-hygiene.sh`, `check-connection-vm-ratchet.sh`, `check-test-validity.sh` exit 0; `git diff --check` clean

## Honest limit

**This is a JVM virtual-clock proof. The on-device symptom-gone bar is NOT met by this PR** — and that is deliberate: #1632's reviewer relocated the storm-gone proof to a **hard condition on #1610**, since the storm is a joint property of #1539 + #1632 + #1633 and no single slice can prove it. #1610 stays open until the maintainer confirms on the real path (D33).

Reviews: [round two CHANGES REQUESTED](https://github.com/alexeygrigorev/pocketshell/issues/1539#issuecomment-4993388200) → [round three APPROVED](https://github.com/alexeygrigorev/pocketshell/issues/1539#issuecomment-4994323622)