### PR TITLE
diagnostics: mirror the connection lifecycle to the host, not just reconnect (#1642 slice 1)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/diagnostics/ConnectionLogHostMirrorReconnectDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/diagnostics/ConnectionLogHostMirrorReconnectDockerTest.kt
@@ -142,10 +142,10 @@ class ConnectionLogHostMirrorReconnectDockerTest {
         //    mirror writes), incl. the named keepalive_dead cause + a unique
         //    marker field so the read-back unambiguously matches THIS run.
         val recorder = seedRecorderWithTrail(marker)
-        val expectedJsonl = recorder.connectionLogJsonl()
+        val seededJsonl = recorder.connectionLogJsonl()
         assertTrue(
             "precondition: the seeded trail must be non-blank (the mirror no-ops on blank)",
-            expectedJsonl.isNotBlank() && "keepalive_dead" in expectedJsonl,
+            seededJsonl.isNotBlank() && "keepalive_dead" in seededJsonl,
         )
 
         // 2. The production VM, with a handshake-counting lease manager + the real
@@ -170,6 +170,15 @@ class ConnectionLogHostMirrorReconnectDockerTest {
         try {
             // 4. Fire the EXACT production mirror glue (activeTarget ->
             //    toLeaseSessionTarget -> warm-lease write) and await it.
+            //
+            // The expected payload is rendered HERE, immediately before the mirror
+            // fires, not back at seed time. Since #1642 slice 1 the payload carries
+            // the whole `connection` lifecycle as well as the reconnect trail, so
+            // any connection event the real VM records while being built (between
+            // seeding and mirroring) legitimately belongs in the payload. Rendering
+            // at seed time would make the byte-identity assertion below a race
+            // against the VM's own diagnostics rather than a check of the mirror.
+            val expectedJsonl = recorder.connectionLogJsonl()
             val result = withTimeout(MIRROR_TIMEOUT_MS) {
                 vm.mirrorConnectionLogToHostForTest()
             }

--- a/app/src/main/java/com/pocketshell/app/diagnostics/DiagnosticEventJson.kt
+++ b/app/src/main/java/com/pocketshell/app/diagnostics/DiagnosticEventJson.kt
@@ -123,7 +123,13 @@ internal object DiagnosticRedactor {
             return classifyFailureMessage(value.toString())
         }
         if (isSensitiveKey(key) || looksSensitive(value)) return REDACTED
-        if (isStableContextKey(key)) return DiagnosticPrivacy.stableFingerprint(value)
+        // Only an identity STRING is fingerprinted. A boolean/number under an
+        // identity-shaped key (`hasSession`, …) is not an identity: digesting it
+        // would destroy the signal AND present a yes/no as an opaque identity —
+        // two possible digests, trivially reversible, and a lie to the reader.
+        if (isStableContextKey(key) && value !is Boolean && value !is Number) {
+            return DiagnosticPrivacy.stableFingerprint(value)
+        }
         return when (value) {
             is Boolean, is Byte, is Short, is Int, is Long, is Float, is Double -> value
             is CharArray -> mapOf("chars" to value.size)
@@ -252,11 +258,30 @@ internal object DiagnosticRedactor {
         "filename",
     )
 
+    /**
+     * Matched against the key with non-alphanumerics stripped, so `pausedSession`
+     * / `currentSession` / `intentSession` / `originSession` / `activeSession` all
+     * fingerprint via the `session` suffix.
+     *
+     * The `session` suffix is the #1639 M1 fix. The rule used to match the EXACT
+     * key `session` only, so the qualified variants fell through to
+     * [sanitizeFreeText] and emitted **raw tmux session names — which are
+     * directory paths by construction** ([com.pocketshell.app.tmux.SessionNameDerivation])
+     * — into the `reconnect/cause_trail`, i.e. into a log that is mirrored to the
+     * host AND routinely quoted into PUBLIC GitHub issues by agents. It is a
+     * suffix rule rather than five literals so a NEW `*Session` field added
+     * tomorrow cannot silently opt out of redaction, which is the failure mode
+     * #1639 called out (the default-allow redactor). #1642's registry-based
+     * default-deny (slice 7) supersedes this heuristic; until then this is the
+     * line, and `Issue1642ConnectionMirrorTest` asserts it as a property over the
+     * whole mirrored document rather than per key.
+     */
     private val STABLE_CONTEXT_KEY_SUFFIXES = setOf(
         "path",
         "directory",
         "folder",
         "filename",
+        "session",
     )
 
     private val SENSITIVE_KEY_MARKERS = listOf(

--- a/app/src/main/java/com/pocketshell/app/diagnostics/DiagnosticRecorder.kt
+++ b/app/src/main/java/com/pocketshell/app/diagnostics/DiagnosticRecorder.kt
@@ -141,26 +141,28 @@ class DiagnosticRecorder @Inject constructor(
     }
 
     /**
-     * The reconnect-cause breadcrumbs ([ReconnectCauseTrail]) rendered as JSONL —
-     * one JSON object per line, the same on-disk encoding the rolling diagnostics
-     * file uses. This is the payload
-     * [com.pocketshell.app.diagnostics.ConnectionLogHostMirror] mirrors to the host
-     * so the maintainer can attribute a real-world drop in the in-app file viewer
-     * (#969/#972).
+     * The host-mirrored connection log rendered as JSONL — one JSON object per
+     * line, the same on-disk encoding the rolling diagnostics file uses. This is
+     * the payload [com.pocketshell.app.diagnostics.ConnectionLogHostMirror] writes
+     * to the host so the maintainer can attribute a real-world drop in the in-app
+     * file viewer (#969/#972).
      *
-     * Blank when nothing has been recorded yet (recording off, or no reconnect):
-     * the mirror treats a blank payload as a no-op so it never writes an empty host
-     * file.
+     * [MirroredDiagnostics] owns BOTH halves of the policy — which events belong
+     * on the host, and the byte budget for one upload. Issue #1642 slice 1 (with
+     * #1598) widened the selection from `reconnect/cause_trail`-ONLY to the whole
+     * curated connection lifecycle: the #1610 storm's engine
+     * (`connection/reconnect_fail cause=attach_not_ready`) was recorded on-device
+     * throughout and never reached the host, so six investigations re-derived what
+     * the phone already knew.
+     *
+     * Blank when nothing mirrorable has been recorded yet (recording off, or no
+     * connection activity): the mirror treats a blank payload as a no-op so it
+     * never writes an empty host file.
      */
-    suspend fun connectionLogJsonl(): String {
-        val events = readEvents(
-            DiagnosticEventFilter(
-                category = ReconnectCauseTrail.CATEGORY,
-                name = ReconnectCauseTrail.NAME,
-            ),
+    suspend fun connectionLogJsonl(): String =
+        MirroredDiagnostics.render(
+            readEvents(DiagnosticEventFilter.All).filter(MirroredDiagnostics::isMirrored),
         )
-        return events.joinToString(separator = "\n") { DiagnosticEventJson.encode(it) }
-    }
 
     /**
      * Test-only (#1124): block until the off-main store build + `lastSequence()`

--- a/app/src/main/java/com/pocketshell/app/diagnostics/MirroredDiagnostics.kt
+++ b/app/src/main/java/com/pocketshell/app/diagnostics/MirroredDiagnostics.kt
@@ -1,0 +1,97 @@
+package com.pocketshell.app.diagnostics
+
+/**
+ * The single registry of WHICH recorded diagnostic events reach the HOST
+ * connection log (`~/.pocketshell/connection-log.jsonl`), and HOW MANY BYTES of
+ * them, for [DiagnosticRecorder.connectionLogJsonl] and
+ * [ConnectionLogHostMirror].
+ *
+ * ## Why this exists (issues #1642 slice 1, #1598)
+ *
+ * The mirror used to filter to `reconnect/cause_trail` ONLY. That made the host
+ * log a **downs-only, joins-by-inference** instrument, and it cost the project a
+ * six-agent investigation: during the #1610 mobile reconnect storm the event that
+ * NAMES the storm's engine —
+ * `connection/reconnect_fail cause=attach_not_ready elapsedMs≈5000` — was being
+ * recorded on-device the whole time and never mirrored. So was
+ * `connection/pane_input_send_failed` (the #1635 amplifier) and
+ * `connection/session_fgs`, a diagnostic added by #1595 SPECIFICALLY so the FGS
+ * outcome could be confirmed remotely.
+ *
+ * The `connection` category is already curated (~34 lifecycle event names, all
+ * connection-relevant), so mirroring it whole is the highest-value/lowest-effort
+ * half of the fix. Chatter categories stay device-only — `action` alone is 67
+ * user-behaviour event names that would burn mobile data for zero connection
+ * diagnosis (#1598: "bound the volume").
+ *
+ * ## Why the payload is capped
+ *
+ * [ConnectionLogHostMirror] is **snapshot-overwrite**: it re-uploads the entire
+ * rendered window on EVERY transport-up — ~100× on a storm day, over the
+ * maintainer's MOBILE DATA. Today that payload is *unbounded*: it grows to
+ * whatever the 512KB device store happens to retain. Broadening the filter
+ * without a bound would multiply a storm day's upload.
+ *
+ * [PAYLOAD_BUDGET_BYTES] therefore hard-caps the render at roughly the payload
+ * size observed in the maintainer's real corpus today (~56KB), truncating OLDEST
+ * so the events describing the drop that just happened always survive. Slice 1
+ * consequently spends about the same bytes/upload as before while carrying
+ * strictly more diagnostic value per byte; the trade is fewer wall-clock hours of
+ * host-side coverage per upload, which #1642 slice 6 (incremental append) removes
+ * by uploading only what the host does not already have.
+ */
+internal object MirroredDiagnostics {
+
+    /** The curated connection-lifecycle category (`connect_start`, `reconnect_fail`, …). */
+    const val CONNECTION_CATEGORY: String = "connection"
+
+    /**
+     * Ceiling on the rendered host payload. Sized at ~the real per-upload payload
+     * observed in the maintainer's corpus today (56,215 bytes / 164 events), so
+     * broadening the mirror does not grow a storm day's mobile-data spend. NOT a
+     * retention policy: it bounds ONE upload, which is re-sent whole every
+     * transport-up.
+     */
+    const val PAYLOAD_BUDGET_BYTES: Int = 64 * 1024
+
+    /**
+     * True when [event] belongs on the host connection log.
+     *
+     * Deliberately a whole-category rule rather than a name list: a name list is
+     * exactly how #1598 happened — `session_fgs` was added, nobody updated the
+     * filter, and the diagnostic silently never reached the host. A new event in
+     * the [CONNECTION_CATEGORY] is mirrored by construction.
+     */
+    fun isMirrored(event: DiagnosticsEvent): Boolean = when (event.category) {
+        // Everything the reconnect breadcrumbs record (the pre-#1642 payload).
+        ReconnectCauseTrail.CATEGORY -> event.name == ReconnectCauseTrail.NAME
+        // The whole curated connection lifecycle (#1642 slice 1 / #1598).
+        CONNECTION_CATEGORY -> true
+        else -> false
+    }
+
+    /**
+     * Renders [events] as JSONL (one object per line, the same encoding the
+     * on-disk store uses), keeping the NEWEST events that fit in [budgetBytes].
+     *
+     * Truncates oldest-first: the mirror's job is attributing the drop that just
+     * happened, so the tail is what matters. A single event larger than the whole
+     * budget is still emitted (better a too-big line than a blank payload the
+     * mirror would no-op).
+     */
+    fun render(
+        events: List<DiagnosticsEvent>,
+        budgetBytes: Int = PAYLOAD_BUDGET_BYTES,
+    ): String {
+        val kept = ArrayDeque<String>()
+        var total = 0
+        for (event in events.asReversed()) {
+            val line = DiagnosticEventJson.encode(event)
+            val cost = line.toByteArray(Charsets.UTF_8).size + 1 // + the separator
+            if (kept.isNotEmpty() && total + cost > budgetBytes) break
+            kept.addFirst(line)
+            total += cost
+        }
+        return kept.joinToString(separator = "\n")
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/diagnostics/DiagnosticRecorderTest.kt
+++ b/app/src/test/java/com/pocketshell/app/diagnostics/DiagnosticRecorderTest.kt
@@ -56,16 +56,24 @@ class DiagnosticRecorderTest {
     }
 
     @Test
-    fun `connectionLogJsonl renders only the reconnect-cause trail as jsonl`() = runTest {
+    fun `connectionLogJsonl renders the reconnect trail and connection lifecycle as jsonl`() = runTest {
         // Issue #972: the payload the host mirror writes to
-        // ~/.pocketshell/connection-log.jsonl. It must carry the reconnect-cause
-        // breadcrumbs (incl. the named keepalive_dead cause) and NOTHING ELSE
-        // (other diagnostics categories are filtered out), one JSON object per line.
+        // ~/.pocketshell/connection-log.jsonl — the reconnect-cause breadcrumbs
+        // (incl. the named keepalive_dead cause), one JSON object per line.
+        //
+        // Issue #1642 slice 1 / #1598 HARD-CUT the old "reconnect/cause_trail and
+        // NOTHING ELSE" contract this test used to assert: the connection
+        // lifecycle now mirrors too, because the #1610 storm's engine
+        // (connection/reconnect_fail) was recorded on-device the whole time and
+        // never reached the host. Chatter categories are still filtered out;
+        // Issue1642ConnectionMirrorTest owns the full selection contract.
         val recorder = DiagnosticRecorder(context, settingsRepository)
         // The reconnect-cause breadcrumbs route through the globally-installed
         // sink (ReconnectCauseTrail.record -> DiagnosticEvents -> this recorder).
         DiagnosticEvents.install(recorder)
-        // Unrelated diagnostics noise that must NOT leak into the connection log.
+        // Device-only chatter that must NOT leak into the connection log.
+        recorder.record("action", "tap_send", mapOf("pane" to "%1"))
+        // The connection lifecycle, mirrored since #1642 slice 1.
         recorder.record("connection", "connect_start", mapOf("host" to "dev"))
         // The reconnect-cause breadcrumbs (what ReconnectCauseTrail records).
         ReconnectCauseTrail.record(stage = "lease_transport", outcome = "down", cause = "keepalive_dead")
@@ -73,13 +81,16 @@ class DiagnosticRecorderTest {
 
         val jsonl = recorder.connectionLogJsonl()
 
-        val lines = jsonl.split("\n").filter { it.isNotBlank() }
-        assertEquals("only the two reconnect-cause events, not the connect_start", 2, lines.size)
-        lines.forEach { line ->
-            val obj = JSONObject(line)
-            assertEquals(ReconnectCauseTrail.CATEGORY, obj.getString("category"))
-            assertEquals(ReconnectCauseTrail.NAME, obj.getString("name"))
-        }
+        val lines = jsonl.split("\n").filter { it.isNotBlank() }.map(::JSONObject)
+        assertEquals(
+            "the connection lifecycle + both reconnect-cause events, not the action chatter",
+            listOf(
+                "connection" to "connect_start",
+                ReconnectCauseTrail.CATEGORY to ReconnectCauseTrail.NAME,
+                ReconnectCauseTrail.CATEGORY to ReconnectCauseTrail.NAME,
+            ),
+            lines.map { it.getString("category") to it.getString("name") },
+        )
         assertTrue(
             "the named keepalive_dead cause must be carried to the host log",
             jsonl.contains("keepalive_dead"),
@@ -87,11 +98,13 @@ class DiagnosticRecorderTest {
     }
 
     @Test
-    fun `connectionLogJsonl is blank when no reconnect cause recorded`() = runTest {
+    fun `connectionLogJsonl is blank when nothing mirrorable was recorded`() = runTest {
         // The mirror treats a blank payload as a no-op (never writes an empty host
-        // file), so a fresh session with no reconnect must produce a blank string.
+        // file), so a session with only device-only chatter produces a blank
+        // string. (Pre-#1642 this fixture recorded a connection/connect_start,
+        // which is now — correctly — mirrored.)
         val recorder = DiagnosticRecorder(context, settingsRepository)
-        recorder.record("connection", "connect_start", mapOf("host" to "dev"))
+        recorder.record("action", "tap_send", mapOf("pane" to "%1"))
 
         assertEquals("", recorder.connectionLogJsonl())
     }

--- a/app/src/test/java/com/pocketshell/app/diagnostics/Issue1642ConnectionMirrorTest.kt
+++ b/app/src/test/java/com/pocketshell/app/diagnostics/Issue1642ConnectionMirrorTest.kt
@@ -1,0 +1,451 @@
+package com.pocketshell.app.diagnostics
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.pocketshell.app.settings.SettingsRepository
+import kotlinx.coroutines.test.runTest
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+
+/**
+ * Issue #1642 slice 1 (with #1598): the `connection` category must reach the
+ * HOST-mirrored connection log.
+ *
+ * ## The reported problem this reproduces
+ *
+ * The maintainer could not use PocketShell on mobile data — it reconnected every
+ * ~5s (#1610) — and it took SIX parallel investigations to name the mechanism.
+ * The device already knew. The event that names the storm's engine,
+ *
+ * ```
+ * connection/reconnect_fail cause=attach_not_ready elapsedMs≈5000
+ * ```
+ *
+ * (emitted by the grace loop, `TmuxSessionViewModel.kt:8526-8545`) was recorded
+ * on-device the whole time and NEVER reached the host, because
+ * [DiagnosticRecorder.connectionLogJsonl] filtered the mirrored payload down to
+ * `reconnect/cause_trail` ONLY. So did `connection/pane_input_send_failed` (the
+ * #1635 storm amplifier) and `connection/session_fgs` (#1595/#1598, a diagnostic
+ * added SPECIFICALLY so the FGS outcome could be confirmed remotely).
+ *
+ * These tests assert those events land in the mirrored payload. On the un-fixed
+ * base every one of them is RED (the payload is `reconnect/cause_trail`-only).
+ *
+ * ## Why the assertions are what they are
+ *
+ * - **No proxy** — the assertion runs against the REAL production payload
+ *   builder [DiagnosticRecorder.connectionLogJsonl] (the exact string
+ *   `ConnectionLogHostMirror` uploads), routed through the REAL global sink, with
+ *   the REAL field shapes the production emitters use.
+ * - **Class coverage** (G2) — not just the one reported event: the storm-naming
+ *   `reconnect_fail`, the amplifier `pane_input_send_failed`, the remote-
+ *   confirmation `session_fgs`, the already-mirrored `reconnect/cause_trail`
+ *   (no regression), the excluded chatter categories, and the missing-data case.
+ * - **No `assumeTrue`** anywhere: every assertion is load-bearing on every runner.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class Issue1642ConnectionMirrorTest {
+    private lateinit var context: Context
+    private lateinit var settingsRepository: SettingsRepository
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        context.getSharedPreferences("app_settings", Context.MODE_PRIVATE)
+            .edit().clear().commit()
+        File(context.filesDir, "diagnostics").deleteRecursively()
+        File(context.cacheDir, DIAGNOSTICS_EXPORT_CACHE_DIR).deleteRecursively()
+        settingsRepository = SettingsRepository(context)
+        // Reset the process-global sink so a prior test's recorder never leaks
+        // events into this one.
+        DiagnosticEvents.install(DiagnosticEventSink.Noop)
+    }
+
+    private fun newRecorder(): DiagnosticRecorder =
+        DiagnosticRecorder(context, settingsRepository).also { DiagnosticEvents.install(it) }
+
+    private fun String.mirroredLines(): List<JSONObject> =
+        split("\n").filter { it.isNotBlank() }.map(::JSONObject)
+
+    /**
+     * The #1610 storm's engine, exactly as the grace loop records it
+     * (`TmuxSessionViewModel.kt:8526-8545`). This is the reproduction: on base
+     * the host mirror never carried it, so six investigations re-derived by hand
+     * what the phone had already written down.
+     */
+    @Test
+    fun `the storm-naming reconnect_fail attach_not_ready reaches the host connection log`() = runTest {
+        val recorder = newRecorder()
+
+        DiagnosticEvents.record(
+            "connection",
+            "reconnect_fail",
+            "hostId" to 7L,
+            "host" to "dev.example.internal",
+            "port" to 22,
+            "user" to "alexey",
+            "session" to "work-pocketshell",
+            "trigger" to "auto-reconnect",
+            "source" to "silent_transport_reattach",
+            "cause" to "attach_not_ready",
+            "evictedLease" to true,
+            "clientHash" to 123456,
+            "elapsedMs" to 5004L,
+        )
+
+        val jsonl = recorder.connectionLogJsonl()
+
+        val event = jsonl.mirroredLines().singleOrNull {
+            it.getString("category") == "connection" && it.getString("name") == "reconnect_fail"
+        }
+        assertTrue(
+            "connection/reconnect_fail must reach the host log — it NAMES the #1610 storm " +
+                "and was invisible on the host while the maintainer could not use the app. " +
+                "Payload was: $jsonl",
+            event != null,
+        )
+        val metadata = event!!.getJSONObject("metadata")
+        // The two fields that name the mechanism: WHICH failure, and the 5s budget floor.
+        assertEquals("attach_not_ready", metadata.getString("cause"))
+        assertEquals(5004L, metadata.getLong("elapsedMs"))
+        assertEquals("silent_transport_reattach", metadata.getString("source"))
+        assertTrue("the lease eviction must be attributable", metadata.getBoolean("evictedLease"))
+    }
+
+    /**
+     * Class coverage (G2): the storm's OTHER already-recorded-but-invisible
+     * events. One instance passing is not the fix — the whole `connection`
+     * category must reach the host.
+     */
+    @Test
+    fun `the storm amplifier and the FGS outcome reach the host connection log`() = runTest {
+        val recorder = newRecorder()
+
+        // #1635: the outbound-queue escalation that amplifies the storm.
+        DiagnosticEvents.record(
+            "connection",
+            "pane_input_send_failed",
+            "pane" to "%3",
+            "attempt" to 2,
+            "bytes" to 12,
+            "exceptionClass" to "SSHException",
+            "clientDisconnected" to true,
+            "willRetry" to false,
+        )
+        // #1595/#1598: recorded PRECISELY so the FGS outcome could be confirmed
+        // remotely from the synced log — and it never synced.
+        DiagnosticEvents.record(
+            "connection",
+            "session_fgs",
+            "phase" to "request",
+            "outcome" to "denied",
+            "hold_active" to true,
+            "exceptionClass" to "ForegroundServiceStartNotAllowedException",
+        )
+
+        val jsonl = recorder.connectionLogJsonl()
+        val names = jsonl.mirroredLines().map { it.getString("name") }
+
+        assertTrue(
+            "connection/pane_input_send_failed (the #1635 storm amplifier) must reach the " +
+                "host log. Payload was: $jsonl",
+            "pane_input_send_failed" in names,
+        )
+        assertTrue(
+            "connection/session_fgs must reach the host log — #1598's whole point was " +
+                "confirming the FGS outcome REMOTELY. Payload was: $jsonl",
+            "session_fgs" in names,
+        )
+        val fgs = jsonl.mirroredLines().single { it.getString("name") == "session_fgs" }
+        assertEquals("denied", fgs.getJSONObject("metadata").getString("outcome"))
+    }
+
+    /**
+     * No regression: the trail that was ALREADY mirrored must still be mirrored.
+     * Broadening the filter must add to the host log, never replace it.
+     */
+    @Test
+    fun `the reconnect cause-trail is still mirrored alongside the connection category`() = runTest {
+        val recorder = newRecorder()
+
+        ReconnectCauseTrail.record(
+            stage = "lease_transport",
+            outcome = "down",
+            cause = "keepalive_dead",
+        )
+        DiagnosticEvents.record("connection", "connect_start", "attempt" to 1)
+
+        val lines = recorder.connectionLogJsonl().mirroredLines()
+
+        assertEquals(
+            listOf(
+                ReconnectCauseTrail.CATEGORY to ReconnectCauseTrail.NAME,
+                "connection" to "connect_start",
+            ),
+            lines.map { it.getString("category") to it.getString("name") },
+        )
+        assertTrue(
+            "the named keepalive_dead cause must still be carried to the host log",
+            lines.first().getJSONObject("metadata").getString("cause") == "keepalive_dead",
+        )
+    }
+
+    /**
+     * Bounding the volume (#1598's "do not flood"): the device-only chatter
+     * categories stay device-only. the `action` category alone is 67 event names of
+     * user-behaviour noise — mirroring it would burn the maintainer's mobile
+     * data for no connection-diagnosis value.
+     */
+    @Test
+    fun `device-only chatter categories never reach the host connection log`() = runTest {
+        val recorder = newRecorder()
+
+        DiagnosticEvents.record("connection", "connect_start", "attempt" to 1)
+        DiagnosticEvents.record("action", "tap_send", "pane" to "%1")
+        DiagnosticEvents.record("navigation", "screen_shown", "screen" to "hosts")
+        DiagnosticEvents.record("strictmode", "violation", "detail" to "disk read on main")
+        DiagnosticEvents.record("terminal", "frame_rendered", "rows" to 40)
+
+        val categories = recorder.connectionLogJsonl().mirroredLines()
+            .map { it.getString("category") }
+
+        assertEquals(listOf("connection"), categories)
+    }
+
+    /**
+     * The missing-data case: nothing mirrored ⇒ blank ⇒ the mirror no-ops rather
+     * than writing an empty host file.
+     */
+    @Test
+    fun `payload is blank when only device-only categories were recorded`() = runTest {
+        val recorder = newRecorder()
+
+        DiagnosticEvents.record("action", "tap_send", "pane" to "%1")
+
+        assertEquals("", recorder.connectionLogJsonl())
+    }
+
+    /**
+     * ### The #1639 M1 line, as a property over the whole document
+     *
+     * The host log is mirrored to a shared dev box AND routinely quoted into
+     * PUBLIC GitHub issues by agents. #1639 found the redactor emitting RAW tmux
+     * session names — which are directory paths by construction — through the
+     * `pausedSession`/`currentSession`/`intentSession` keys, because the
+     * fingerprint rule matched only the exact key `session`.
+     *
+     * This is asserted as a PROPERTY over the rendered document (not per-key), so
+     * a NEW `*Session` vararg field added tomorrow cannot silently opt out of
+     * redaction — the failure mode #1639 called out.
+     */
+    @Test
+    fun `no raw session name host user or path appears anywhere in the mirrored payload`() = runTest {
+        val recorder = newRecorder()
+
+        val secretSession = "home-alexey-private-client-work"
+        val secretHost = "prod-jumpbox.client.internal"
+        val secretUser = "alexey-admin"
+        val secretPath = "/home/alexey/private/client-work"
+
+        // Every mirrored shape that carries an identity string, across BOTH
+        // mirrored categories — the whole class, not one key.
+        ReconnectCauseTrail.record(
+            stage = "onScreenStarted",
+            outcome = "cleared_stale_paused_reconnect",
+            cause = "session_mismatch",
+            "pausedSession" to secretSession,
+            "currentSession" to secretSession,
+        )
+        ReconnectCauseTrail.record(
+            stage = "handlePassiveClientDisconnect",
+            outcome = "skipped_pause_in_app_navigation",
+            cause = "different_session_target",
+            "pausedSession" to secretSession,
+            "intentSession" to secretSession,
+            "hasActiveConnectJob" to true,
+        )
+        DiagnosticEvents.record(
+            "connection",
+            "reconnect_fail",
+            "host" to secretHost,
+            "user" to secretUser,
+            "session" to secretSession,
+            "activeSession" to secretSession,
+            "originSession" to secretSession,
+            "cwd" to secretPath,
+            "cause" to "attach_not_ready",
+        )
+
+        val jsonl = recorder.connectionLogJsonl()
+
+        listOf(secretSession, secretHost, secretUser, secretPath).forEach { secret ->
+            assertFalse(
+                "raw identity string '$secret' leaked into the host connection log, which is " +
+                    "mirrored to the host AND quoted into public issues (#1639 M1). " +
+                    "Payload was: $jsonl",
+                jsonl.contains(secret),
+            )
+        }
+        // ...and the diagnosis still works: the fingerprints are present and
+        // JOINABLE (same session ⇒ same fingerprint across both categories).
+        val fingerprint = DiagnosticPrivacy.stableFingerprint(secretSession)
+        assertTrue(
+            "the session fingerprint must still be present so drops stay attributable",
+            jsonl.contains(fingerprint),
+        )
+    }
+
+    /**
+     * A fingerprinted BOOLEAN is both useless (two possible digests) and a lie —
+     * it presents a yes/no as an opaque identity. `hasSession`/`hasX` booleans
+     * must survive the `*Session` fingerprint rule as booleans.
+     */
+    @Test
+    fun `a boolean field whose key ends in session stays a boolean`() = runTest {
+        val recorder = newRecorder()
+
+        DiagnosticEvents.record(
+            "connection",
+            "reconnect_fail",
+            "hasSession" to false,
+            "cause" to "attach_not_ready",
+        )
+
+        val metadata = recorder.connectionLogJsonl().mirroredLines().single()
+            .getJSONObject("metadata")
+        assertEquals(false, metadata.getBoolean("hasSession"))
+    }
+
+    /**
+     * ### The mobile-data bound
+     *
+     * The maintainer is on mobile data, and the mirror is snapshot-overwrite: it
+     * re-uploads the whole rendered window on EVERY transport-up (so ~100× on a
+     * storm day). Today that payload is UNBOUNDED — it grows to whatever the
+     * 512KB device store retains. Broadening the filter without a bound would
+     * multiply the maintainer's storm-day upload.
+     *
+     * So the rendered payload is hard-capped, keeping the NEWEST events (the ones
+     * describing the drop that just happened). The cap is what keeps slice 1's
+     * bytes/upload at roughly today's observed ~56KB while carrying strictly more
+     * diagnostic value per byte. (Slice 6's incremental append removes the
+     * re-upload entirely; this is the interim bound.)
+     */
+    @Test
+    fun `the mirrored payload is capped and keeps the newest events`() = runTest {
+        val recorder = newRecorder()
+
+        // Well past the budget: ~600 events at ~340B ≈ 204KB rendered.
+        repeat(600) { i ->
+            DiagnosticEvents.record(
+                "connection",
+                "reconnect_fail",
+                "cause" to "attach_not_ready",
+                "marker" to i,
+                "host" to "dev.example.internal",
+                "session" to "work-pocketshell",
+                "source" to "silent_transport_reattach",
+                "elapsedMs" to 5004L,
+            )
+        }
+
+        val jsonl = recorder.connectionLogJsonl()
+        val bytes = jsonl.toByteArray(Charsets.UTF_8).size
+        val markers = jsonl.mirroredLines().map { it.getJSONObject("metadata").getInt("marker") }
+        // What the recorder ACTUALLY persisted. NB: this fixture bursts 600 events
+        // through the recorder's 256-slot `trySend` channel, so the recorder itself
+        // legitimately drops some under backpressure (its documented overflow
+        // behaviour — it records `diagnostics/recorder_overflow`). Asserting
+        // against the recorded stream rather than against 0..599 keeps this test
+        // about the CAP instead of about backpressure.
+        val recorded = recorder.readEvents(DiagnosticEventFilter(category = "connection"))
+            .map { it.metadata["marker"] as Int }
+
+        assertTrue(
+            "the payload is re-uploaded on every transport-up over the maintainer's mobile " +
+                "data — it must stay within the budget, but was $bytes bytes",
+            bytes <= MirroredDiagnostics.PAYLOAD_BUDGET_BYTES,
+        )
+        assertTrue("the cap must actually have engaged for this fixture", markers.size < recorded.size)
+        assertTrue("something must survive the cap", markers.isNotEmpty())
+        // Truncate OLDEST: what survives is exactly the NEWEST slice of the
+        // recorded stream — the drop that just happened, which is the entire
+        // point of the mirror.
+        assertEquals(recorded.takeLast(markers.size), markers)
+    }
+
+    /**
+     * The cap's exact semantics, deterministically — no recorder backpressure in
+     * the way. [MirroredDiagnostics.render] is the real production renderer that
+     * [DiagnosticRecorder.connectionLogJsonl] delegates to, not a proxy.
+     */
+    @Test
+    fun `render keeps the contiguous newest slice that fits the budget`() {
+        val events = (0 until 100).map { i ->
+            DiagnosticsEvent(
+                sequence = i.toLong(),
+                wallClockTime = java.time.Instant.EPOCH.plusSeconds(i.toLong()),
+                monotonicTimestampNanos = i.toLong(),
+                category = "connection",
+                name = "reconnect_fail",
+                metadata = mapOf("cause" to "attach_not_ready", "marker" to i),
+            )
+        }
+        // Size from a LATE event: markers/sequences 90..99 are all two digits, so
+        // every line in the expected window is exactly this wide.
+        val oneLine = DiagnosticEventJson.encode(events.last()).toByteArray(Charsets.UTF_8).size + 1
+
+        // A budget with room for exactly 10 lines.
+        val jsonl = MirroredDiagnostics.render(events, budgetBytes = oneLine * 10)
+        val markers = jsonl.split("\n").filter { it.isNotBlank() }
+            .map { JSONObject(it).getJSONObject("metadata").getInt("marker") }
+
+        assertEquals("the contiguous NEWEST slice, oldest truncated", (90..99).toList(), markers)
+    }
+
+    /**
+     * A single event larger than the entire budget must still be emitted: a blank
+     * payload makes the mirror no-op, which would lose the event completely.
+     * Better one oversized line than a silently-dropped drop.
+     */
+    @Test
+    fun `render emits an oversized single event rather than a blank payload`() {
+        val event = DiagnosticsEvent(
+            sequence = 1L,
+            wallClockTime = java.time.Instant.EPOCH,
+            monotonicTimestampNanos = 1L,
+            category = "connection",
+            name = "reconnect_fail",
+            metadata = mapOf("cause" to "attach_not_ready"),
+        )
+
+        val jsonl = MirroredDiagnostics.render(listOf(event), budgetBytes = 1)
+
+        assertEquals(1, jsonl.split("\n").filter { it.isNotBlank() }.size)
+        assertTrue(jsonl.contains("attach_not_ready"))
+    }
+
+    /**
+     * Recording off ⇒ nothing recorded ⇒ nothing mirrored. The Settings toggle
+     * still governs the host mirror.
+     */
+    @Test
+    fun `nothing is mirrored when diagnostics recording is disabled`() = runTest {
+        settingsRepository.setDiagnosticsRecordingEnabled(false)
+        val recorder = newRecorder()
+
+        DiagnosticEvents.record("connection", "reconnect_fail", "cause" to "attach_not_ready")
+        ReconnectCauseTrail.record(stage = "lease_transport", outcome = "down")
+
+        assertEquals("", recorder.connectionLogJsonl())
+    }
+}


### PR DESCRIPTION
Closes #1642 (slice 1). Implements the maintainer's ask: *"I'd prefer that our logging is quite comprehensive."*

## Why

The [#1642 audit](https://github.com/alexeygrigorev/pocketshell/issues/1642) found the device was **already recording** the event that names the #1610 storm's engine — `connection/reconnect_fail cause=attach_not_ready elapsedMs≈5000` — and **never mirroring it**, because `DiagnosticRecorder.connectionLogJsonl()` filters the host mirror to `reconnect/cause_trail` only (#1598).

**At least 3 of today's 6 storm investigations re-derived facts the phone had already written down.** The live host file proves the filter exactly: **184 events, 184/184 `reconnect/cause_trail`**. The mirrored log records every *down* and not a single *up*.

## What changed

Widen the mirror to the curated `connection` lifecycle behind a new `MirroredDiagnostics` registry that owns **both halves** of the policy — which events reach the host, and the byte budget for one upload.

**The data cost was measured, not estimated.** The mirror re-uploads the whole payload every transport-up, so broadening it naively would take a storm day from ~6MB to **~15MB** of the maintainer's mobile data. A **64 KiB cap** holds it to **+5.2% worst case** and makes the cost independent of volume estimates. Today's payload is already *unbounded* (62KB and climbing toward the 512KB store cap), so the cap is a **strict improvement**. The cap truncates **oldest**, so it structurally cannot evict the storm events it exists to carry. **Device bytes added: zero.**

## The #1639 M1 leak — fixed deliberately, beyond the brief

The red **reproduced the leak live**: `pausedSession":"home-alexey-private-client-work"` raw in the mirrored payload. tmux session names are **directory paths by construction**, and this log is quoted into **public GitHub issues** by agents. Shipping more data to the host while a known raw-path leak is live is the wrong order — [#1642](https://github.com/alexeygrigorev/pocketshell/issues/1642) slice 7 flags it as the interim one-liner that must land before more mirroring.

**Important:** the leak is on `reconnect/cause_trail`, which was **already mirrored on base** — raw session names have been reaching the host log independently of this slice. This fixes a live exposure; it does not introduce one.

## Verification

**Reviewer-driven red→green** (`cp` backup → neutralise both halves → restore; diffstat returned byte-identical at 84 insertions / 35 deletions). Red was 7-of-11 with the load-bearing `Payload was: ` — **literally empty**. Green 11/11, 0 skipped.

**The reviewer closed the implementer's declared gap**: an emulator was live, so it ran the Docker journey the implementer could not — **2/2 passed, file landed on the fixture**. Approved on real-path evidence, not a JVM proxy (G4).

**Security (#1639):** the reviewer enumerated **~70 metadata keys** across every `connection` emitter mechanically and traced each through `redactValue`. The decisive check was **ordering** — `isDiagnosableMessageKey` fires *before* the raw-passthrough branch, and `classifyFailureMessage` returns a fixed token that is **never a substring of the input**, so `SshConnection.wrap()`'s `user@host` provably cannot surface. Every string key reaching the default-allow `sanitizeFreeText` branch was walked to its value expression; all are literals/enums/`simpleName`.

**"Do not log a lie"** verified independently: `ui_reconnect_state`'s projection defaults were already mirrored (a pre-existing #1642 finding), and `connection/reconnect_start` carries **real** ladder values.

Orchestrator gate in a clean integration worktree off post-merge `main`, `./gradlew test --rerun-tasks` (**both variants**), **counts asserted from the result XML** per `process.md` `8dc16024`:
- `:app:testDebugUnitTest` — **3949 tests, 0 failures, 0 skipped**
- `:app:testReleaseUnitTest` — **3945 tests, 0 failures, 0 skipped**
- Guards exit 0; `git diff --check` clean

## Three incidental fixes (verified by the reviewer, not scope creep)

- A literal `` `connection/*` `` in a KDoc opens a **nested block comment** in Kotlin and silently swallowed the class body.
- The recorder's 256-slot channel uses `trySend` and **drops events under burst backpressure** — a storm *is* a burst. Assertions split: exact cap semantics against the pure renderer; end-to-end against what the recorder actually persisted. The reviewer confirmed contiguity is **not** weakened (`assertEquals(recorded.takeLast(markers.size), markers)` still checks the full contiguous slice).
- `ConnectionLogHostMirrorReconnectDockerTest` captured its expected payload *before* building the real VM then asserted byte-identity — safe on base only because `connection/*` was filtered out. Render moved to mirror time.

## Known follow-up (filed, non-blocking)

The end-to-end claim is **compositional** — the JVM test proves the payload renders `connection/*`; the journey proves it lands byte-identically. The reviewer declined to overclaim it as literal and filed making it so.

Review: https://github.com/alexeygrigorev/pocketshell/issues/1642#issuecomment-4993236615 (APPROVED)