### PR TITLE
ci: stop watch-ci.py inventing failures that never happened (#1650)

### DIFF
--- a/scripts/watch-ci.py
+++ b/scripts/watch-ci.py
@@ -22,22 +22,39 @@ Design goals (see issue #952):
    termination. A re-run that resets jobs under the same run id is NOT mistaken
    for completion — we keep watching.
 
-3. Informative. On a real failure we capture the SIGNATURE ourselves: pull the
-   failed job's failed-step log (`gh run view --job <id> --log-failed`) and grep
-   the first meaningful error line into the `signature` field, and tag known
+3. Informative, and NEVER inventive (issue #1650). On a real failure we capture
+   the SIGNATURE ourselves from output that ACTUALLY EXECUTED, and tag known
    infra signatures with `likely_infra: true` so the on-call can classify
-   flake-vs-real from this output alone.
+   flake-vs-real from this output alone. When we cannot classify confidently we
+   say "unclassified failure" and hand over the raw evidence — a FABRICATED
+   signature is worse than no signature, because it sends the on-call to the
+   wrong issue with false confidence (G5: an infra claim needs a captured
+   signature AND a clean re-run).
+
+4. Honest about non-verdicts (issue #1650). A `cancelled` run is NOT a failure.
+   `main`'s push concurrency group cancels older in-flight runs when newer
+   merges land — routine and BY DESIGN (see process.md). A watcher that cannot
+   reach a verdict reports one of the no-verdict codes below; it never invents
+   one. This matches the workflow's own classifier, which already states a
+   cancelled attempt "is NOT ... a genuine ... regression".
 
 Exit-code contract (also the final JSON's `result`):
 
     0  green       — all REQUIRED checks concluded `success` (or appropriately
                      skipped) and the run is complete.
-    1  failed      — a required check concluded `failure`/`cancelled`/`timed_out`,
-                     or the run was cancelled.
+    1  failed      — a required check GENUINELY failed (`failure`/`timed_out`/
+                     `startup_failure`/`action_required`). A real failure
+                     outranks a later cancel: red CI is never softened.
     2  hang         — no job-state progress for --no-progress-timeout, OR the run
                      exceeded --max-wall-clock. Never wait forever.
     3  unresolved  — the run / inputs couldn't be resolved, or `gh` stayed broken
                      past the retry budget.
+    4  superseded  — the run was cancelled because a NEWER run for the same
+                     workflow+branch replaced it (the `main` concurrency group).
+                     Nothing is broken; re-watch the newest head.
+    5  no_verdict  — the run was cancelled (user/API, or we could not tell why),
+                     so it produced NO trustworthy verdict. Not a pass, not a
+                     failure — unknown. Re-run to get a verdict.
 
 This module is import-safe and dependency-injectable: tests construct a Watcher
 with a fake `gh` runner and a fake clock, so the whole state machine (including
@@ -67,8 +84,17 @@ DEFAULT_REQUIRED_CHECKS = (
 )
 
 DEFAULT_INTERVAL_S = 25.0
-DEFAULT_NO_PROGRESS_TIMEOUT_S = 20 * 60
-DEFAULT_MAX_WALL_CLOCK_S = 60 * 60
+
+# Issue #1650: the no-progress guard must out-last the LONGEST single job, since
+# a healthy job that runs for its whole duration produces NO job-state change.
+# The emulator journey shards are capped at 95 min (`timeout-minutes: 95` in
+# .github/workflows/tests.yml) and routinely run 20-40 min. The old 20-min
+# default meant EVERY `main` emulator watch reported a bogus HANG while the
+# shards were perfectly healthy. Keep this strictly above the job cap, and keep
+# the wall-clock cap above it so the no-progress guard can actually fire.
+EMULATOR_JOB_CAP_S = 95 * 60  # .github/workflows/tests.yml: timeout-minutes: 95
+DEFAULT_NO_PROGRESS_TIMEOUT_S = 100 * 60
+DEFAULT_MAX_WALL_CLOCK_S = 3 * 60 * 60
 GH_RETRY_BUDGET = 3
 GH_RETRY_BACKOFF_S = 3.0
 
@@ -77,18 +103,30 @@ RESULT_GREEN = "green"
 RESULT_FAILED = "failed"
 RESULT_HANG = "hang"
 RESULT_UNRESOLVED = "unresolved"
+RESULT_SUPERSEDED = "superseded"
+RESULT_NO_VERDICT = "no_verdict"
 
 EXIT_CODE = {
     RESULT_GREEN: 0,
     RESULT_FAILED: 1,
     RESULT_HANG: 2,
     RESULT_UNRESOLVED: 3,
+    RESULT_SUPERSEDED: 4,
+    RESULT_NO_VERDICT: 5,
 }
 
-# Terminal (completed) GitHub Actions conclusions that are NOT success.
-FAILING_CONCLUSIONS = frozenset(
-    {"failure", "cancelled", "timed_out", "startup_failure", "action_required"}
+# Terminal (completed) conclusions that mean the job GENUINELY failed.
+#
+# Issue #1650: `cancelled` is deliberately NOT here. A cancel is not a failure —
+# on `main` it is the routine, by-design outcome of the push concurrency group
+# superseding an older in-flight run. Treating it as a failure made every
+# superseded-run watch a guaranteed false FAILED, on the exact path the on-call
+# is told to watch. It is handled separately (superseded vs no_verdict) below.
+GENUINE_FAILING_CONCLUSIONS = frozenset(
+    {"failure", "timed_out", "startup_failure", "action_required"}
 )
+
+CANCELLED = "cancelled"
 
 # Ordered (pattern) signatures. The first meaningful error line we grep from a
 # failed job's log.
@@ -154,19 +192,97 @@ class GhError(RuntimeError):
 # ── Pure helpers (the testable core) ─────────────────────────────────────────
 
 
-def extract_signature(log_text: str) -> Optional[str]:
-    """Return the first meaningful error line from a failed-step log, or None.
+# GitHub's "command echo": a `run:` step's own script body is printed back with
+# this ANSI wrapper before/while it executes. Such a line is SOURCE TEXT, not
+# output — an `echo "::error ..."` inside an `if` that never fired still appears
+# here verbatim.
+#
+# Issue #1650: this is THE fabrication vector. The watcher reported
+#   signature: echo "::error title=sdkmanager still broken after repair::...(#771)"
+# for a run that was merely superseded — the loose `(Install|installing).*failed`
+# pattern coincidentally matched "freshly-installed ... still failed to run"
+# inside the ECHOED script text of a conditional that never ran. A grep cannot
+# tell "this error occurred" from "this string exists in the script"; refusing
+# to read command-echo lines is what makes the difference.
+_COMMAND_ECHO_RE = re.compile(r"\x1b\[36;1m")
 
-    Scans top-to-bottom; the first line matching any signature pattern wins.
-    A known infra/flake line (e.g. `Process crashed (signal 9)`) also counts as
-    a signature so the on-call still gets the flake hint even when the log has no
-    conventional `error:`/`FAILED` line. Strips the `gh --log` timestamp/prefix
-    columns (job\\tstep\\tISO-8601 ...) so the returned line is the bare message.
+# Defence in depth for the same vector when the ANSI command-echo marker is not
+# present (e.g. a log source that strips ANSI). A REAL annotation is emitted by
+# the runner as `##[error]...` — it is NEVER the literal text `echo "::error`.
+# So a line that contains an `echo` of an annotation is, unambiguously, a script
+# body being printed rather than an error that occurred.
+_ECHOED_ANNOTATION_RE = re.compile(r"""\becho\b\s*["']?\s*::(error|warning|notice)""")
+
+# Runner-emitted annotations. Unlike an echoed `::error`, an `##[error]` line is
+# written by the runner when something ACTUALLY failed.
+_ANNOTATION_RE = re.compile(r"^##\[error\]\s*(?P<msg>.*)$")
+
+# `##[error]` wrappers that carry no diagnostic value — they say "a step exited
+# non-zero" without saying why. Never worth reporting as THE signature.
+_GENERIC_ANNOTATION_PATTERNS = [
+    re.compile(r"^The process '.*' failed with exit code \d+\.?$"),
+    re.compile(r"^Process completed with exit code \d+\.?$"),
+    re.compile(r"^The operation was canceled\.?$", re.IGNORECASE),
+    re.compile(r"^The job running has exceeded", re.IGNORECASE),
+]
+
+
+def _is_command_echo(line: str) -> bool:
+    """Is this line GitHub echoing a `run:` step's script body (not output)?"""
+    return bool(_COMMAND_ECHO_RE.search(line) or _ECHOED_ANNOTATION_RE.search(line))
+
+
+def _is_generic_annotation(msg: str) -> bool:
+    return any(pat.match(msg) for pat in _GENERIC_ANNOTATION_PATTERNS)
+
+
+def extract_signature(log_text: str, *, annotations_only: bool = False) -> Optional[str]:
+    """Return a signature for a failure from output that ACTUALLY EXECUTED.
+
+    Returns None when nothing can be attributed confidently — the caller then
+    reports an "unclassified failure" and hands over the raw evidence. Guessing
+    is not allowed (issue #1650): a wrong-but-specific signature is worse than
+    none, because the on-call acts on it.
+
+    Order of preference:
+
+    1. A runner-emitted `##[error]` annotation with real diagnostic content.
+       This is the strongest anchor: the runner only writes it when a step
+       actually failed, so it cannot come from unexecuted script text.
+    2. The heuristic error-line patterns, but ONLY over lines that are not
+       GitHub command-echo (script body). Skipped entirely when
+       `annotations_only` is set.
+
+    `annotations_only=True` is used for the whole-run-log fallback: when we
+    could not narrow the log to the FAILED STEP, a loose pattern would happily
+    match a line from an unrelated, perfectly successful step (the real #1650
+    log had `Error: No such command 'tree'.` printed by a step whose JOB was to
+    assert that very mismatch). In that case only a real annotation counts.
+
+    Strips the `gh --log` prefix columns (job\\tstep\\tISO-8601 ...) so the
+    returned line is the bare message.
     """
+    executed: list[str] = []
     for raw in log_text.splitlines():
+        if _is_command_echo(raw):
+            continue  # script text, not output — never evidence of anything
         line = _strip_gh_log_prefix(raw).strip()
-        if not line:
-            continue
+        if line:
+            executed.append(line)
+
+    # 1. A real, runner-emitted annotation wins.
+    for line in executed:
+        m = _ANNOTATION_RE.match(line)
+        if m:
+            msg = m.group("msg").strip()
+            if msg and not _is_generic_annotation(msg):
+                return msg
+
+    if annotations_only:
+        return None
+
+    # 2. Heuristic scan over executed output only.
+    for line in executed:
         for pat in _SIGNATURE_PATTERNS:
             if pat.match(line):
                 return line
@@ -263,6 +379,12 @@ class Classification:
     required: dict[str, RequiredCheck]
     failing_jobs: list[str] = field(default_factory=list)
     reason: str = ""
+    # Issue #1650: set when the run reached NO verdict because it was cancelled.
+    # The Watcher then probes whether a newer run superseded it, and only then
+    # can distinguish RESULT_SUPERSEDED from RESULT_NO_VERDICT. classify_run
+    # stays pure (no `gh` calls), so it reports the honest default —
+    # RESULT_NO_VERDICT — and lets the caller upgrade it.
+    cancelled: bool = False
 
 
 def classify_run(
@@ -282,24 +404,32 @@ def classify_run(
     must surface that gating failure — so if ANY job in the run failed, a skipped
     required check does not let the run be called green; the failing job is
     reported and the result is RESULT_FAILED.
+
+    Cancelled handling (issue #1650): `cancelled` is NOT a failure. A GENUINE
+    failure is always checked FIRST and always wins, so a run that genuinely
+    broke and was cancelled afterwards still reports RESULT_FAILED — the fix for
+    the false-alarm bug must never launder real red CI into "superseded".
+    Absent a genuine failure, a cancelled run yields NO verdict.
     """
     required = resolve_required_checks(jobs, required_names)
 
-    # Any job (required or not) that definitively failed — used both to fail the
+    # Any job (required or not) that GENUINELY failed — used both to fail the
     # run and to explain skipped required checks (gated-behind-a-failed-job).
     failed_jobs = [
         str(j.get("name", ""))
         for j in jobs
         if str(j.get("status", "")) == "completed"
-        and (j.get("conclusion") or "") in FAILING_CONCLUSIONS
+        and (j.get("conclusion") or "") in GENUINE_FAILING_CONCLUSIONS
     ]
 
-    # A required check that itself concluded a failing conclusion is a hard fail
-    # the moment we see it — no need to wait for the whole run.
+    # A required check that itself genuinely failed is a hard fail the moment we
+    # see it — no need to wait for the whole run. Checked BEFORE any cancelled
+    # handling so real failures always take precedence (G6).
     required_failures = [
         rc.name
         for rc in required.values()
-        if rc.status == "completed" and (rc.conclusion or "") in FAILING_CONCLUSIONS
+        if rc.status == "completed"
+        and (rc.conclusion or "") in GENUINE_FAILING_CONCLUSIONS
     ]
     if required_failures:
         return Classification(
@@ -312,17 +442,40 @@ def classify_run(
     run_complete = run_status == "completed"
     if not run_complete:
         # Still running; we only declare a verdict when the run is terminal,
-        # except for the explicit required-failure shortcut above.
+        # except for the explicit required-failure shortcut above. A required
+        # check that is merely `cancelled` deliberately does NOT shortcut here:
+        # we wait for the run so we can tell superseded from user-cancelled.
         return Classification(result=None, required=required, reason="in progress")
 
     # ── Run is complete. ─────────────────────────────────────────────────────
-    if (run_conclusion or "") in FAILING_CONCLUSIONS:
-        # Whole-run conclusion is failing (e.g. cancelled). Name any failed jobs.
+    if (run_conclusion or "") in GENUINE_FAILING_CONCLUSIONS:
+        # Whole-run conclusion is a genuine failure. Name any failed jobs.
         return Classification(
             result=RESULT_FAILED,
             required=required,
             failing_jobs=failed_jobs or [run_conclusion or "run"],
             reason=f"run concluded {run_conclusion}",
+        )
+
+    # No genuine failure anywhere. Was anything cancelled? Then this run reached
+    # no trustworthy verdict — the caller decides superseded vs no_verdict.
+    cancelled_required = [
+        rc.name
+        for rc in required.values()
+        if rc.status == "completed" and (rc.conclusion or "") == CANCELLED
+    ]
+    if (run_conclusion or "") == CANCELLED or cancelled_required:
+        detail = (
+            "required check(s) cancelled: " + ", ".join(cancelled_required)
+            if cancelled_required
+            else f"run concluded {run_conclusion}"
+        )
+        return Classification(
+            result=RESULT_NO_VERDICT,
+            required=required,
+            failing_jobs=[],
+            reason=f"run was cancelled, so it produced no verdict ({detail})",
+            cancelled=True,
         )
 
     # Run reports success. Validate the required checks individually.
@@ -363,7 +516,9 @@ def _required_ok(rc: RequiredCheck, any_job_failed: bool) -> bool:
     - completed/success → ok.
     - completed/skipped → ok ONLY if nothing else in the run failed. A skipped
       check whose gating job failed is NOT ok (surface the gate failure).
-    - completed/<failing> → not ok (handled earlier, defensive here).
+    - completed/<genuinely failing> → not ok (handled earlier, defensive here).
+    - completed/cancelled → not ok, but handled earlier as a no-verdict rather
+      than a failure (issue #1650).
     - missing (no matching job) → ok ONLY if nothing else failed; a missing
       required check on an otherwise-green run usually means a renamed/optional
       job, but on a run with a failed job it likely means it was gated away.
@@ -533,17 +688,33 @@ class Watcher:
         return str(rid) if rid is not None else None
 
     def _poll_run(self, run_id: str) -> dict:
+        # headBranch/workflowName/createdAt feed the #1650 supersede probe.
         return self._gh_json(
-            ["run", "view", run_id, "--json", "status,conclusion,jobs,databaseId"]
+            [
+                "run",
+                "view",
+                run_id,
+                "--json",
+                "status,conclusion,jobs,databaseId,headBranch,workflowName,createdAt",
+            ]
         )
 
     # -- signature capture ------------------------------------------------
 
     def capture_signature(self, jobs: list[dict]) -> Optional[str]:
-        """Pull the first failed job's failed-step log and extract a signature."""
+        """Pull the first GENUINELY-failed job's failed-step log for a signature.
+
+        Only ever called for RESULT_FAILED (issue #1650): a cancelled/superseded
+        run has no failure, so producing a signature for it is pure fabrication.
+
+        Anchors to the FAILED STEP's log (`--log-failed`). If that is
+        unavailable we fall back to the whole job log but demand a real runner
+        annotation (`annotations_only`), because a loose pattern over a full log
+        will match text from unrelated, successful steps.
+        """
         for j in jobs:
             if str(j.get("status", "")) == "completed" and (
-                (j.get("conclusion") or "") in FAILING_CONCLUSIONS
+                (j.get("conclusion") or "") in GENUINE_FAILING_CONCLUSIONS
             ):
                 job_id = j.get("databaseId") or j.get("id")
                 if job_id is None:
@@ -551,14 +722,82 @@ class Watcher:
                 log_text = self._gh_text(
                     ["run", "view", "--job", str(job_id), "--log-failed"]
                 )
-                if not log_text:
-                    # Some runs don't expose --log-failed; fall back to full log.
+                if log_text:
+                    sig = extract_signature(log_text)
+                else:
+                    # Some runs don't expose --log-failed; fall back to the full
+                    # log, but only trust real annotations from it.
                     log_text = self._gh_text(
                         ["run", "view", "--job", str(job_id), "--log"]
                     )
-                sig = extract_signature(log_text)
+                    sig = extract_signature(log_text, annotations_only=True)
                 if sig:
                     return sig
+        return None
+
+    # -- superseded probe (issue #1650) -----------------------------------
+
+    def find_newer_run(self, run: dict) -> Optional[str]:
+        """Return the id of a newer run for the same workflow+branch, or None.
+
+        This is how we tell "superseded by the `main` push concurrency group"
+        (routine, by design) from "somebody cancelled it" — GitHub does not
+        expose the cancel REASON, so we ask the only question that matters: did
+        a newer run replace this one?
+
+        Returns None when we cannot tell (missing branch, `gh` down, no newer
+        run). The caller then reports `no_verdict` rather than guessing.
+        """
+        branch = str(run.get("headBranch") or "")
+        if not branch:
+            return None
+        workflow = str(run.get("workflowName") or "")
+        created_at = str(run.get("createdAt") or "")
+        try:
+            run_id = int(run.get("databaseId") or 0)
+        except (TypeError, ValueError):
+            run_id = 0
+
+        try:
+            runs = self._gh_json(
+                [
+                    "run",
+                    "list",
+                    "--branch",
+                    branch,
+                    "--limit",
+                    "20",
+                    "--json",
+                    "databaseId,workflowName,headBranch,status,createdAt",
+                ]
+            )
+        except GhError as exc:
+            self._heartbeat(f"supersede probe failed: {exc}")
+            return None
+        if not isinstance(runs, list):
+            return None
+
+        for r in runs:
+            if workflow and str(r.get("workflowName") or "") != workflow:
+                continue
+            if str(r.get("headBranch") or "") != branch:
+                continue
+            try:
+                other_id = int(r.get("databaseId") or 0)
+            except (TypeError, ValueError):
+                continue
+            if other_id == run_id:
+                continue
+            other_created = str(r.get("createdAt") or "")
+            # Prefer createdAt (authoritative ordering); fall back to the id,
+            # which is monotonic per repo.
+            newer = (
+                other_created > created_at
+                if (other_created and created_at)
+                else other_id > run_id
+            )
+            if newer:
+                return str(other_id)
         return None
 
     # -- the loop ---------------------------------------------------------
@@ -626,7 +865,7 @@ class Watcher:
                 run_status, run_conclusion, jobs, self.required_checks
             )
             if verdict.result is not None:
-                return self._finalize(verdict, jobs, run_id, start, polls)
+                return self._finalize(verdict, jobs, run_id, start, polls, run=data)
 
             # No-progress timeout (catches queued-forever / no-runner too).
             if now - last_progress_at >= self.no_progress_timeout_s:
@@ -644,20 +883,44 @@ class Watcher:
 
     # -- outcome builders -------------------------------------------------
 
-    def _finalize(self, verdict, jobs, run_id, start, polls) -> WatchOutcome:
+    def _finalize(self, verdict, jobs, run_id, start, polls, run=None) -> WatchOutcome:
+        result = verdict.result
+        reason = verdict.reason
         signature = None
         likely_infra = False
-        if verdict.result == RESULT_FAILED:
+
+        # A signature is ONLY ever captured for a genuine failure. A cancelled /
+        # superseded run has no failure to diagnose, so any signature attached
+        # to it is a fabrication (issue #1650).
+        if result == RESULT_FAILED:
             signature = self.capture_signature(jobs)
             likely_infra = is_likely_infra(signature)
+        elif verdict.cancelled:
+            newer = self.find_newer_run(run or {})
+            if newer:
+                result = RESULT_SUPERSEDED
+                reason = (
+                    "superseded — a newer run for the same workflow+branch "
+                    f"({newer}) replaced this one, so the concurrency group "
+                    "cancelled it. This is routine and by design; nothing is "
+                    f"broken. Re-watch the newest head: --run-id {newer}"
+                )
+            else:
+                reason = (
+                    f"{reason}. No newer run found on the branch, so this was "
+                    "not superseded by the concurrency group (user/API cancel, "
+                    "or the probe could not tell). No verdict is available — "
+                    "re-run to get one. This is NOT a failure."
+                )
+
         return WatchOutcome(
-            result=verdict.result,
-            exit_code=EXIT_CODE[verdict.result],
+            result=result,
+            exit_code=EXIT_CODE[result],
             required=verdict.required,
             failing_jobs=verdict.failing_jobs,
             signature=signature,
             likely_infra=likely_infra,
-            reason=verdict.reason,
+            reason=reason,
             run_id=run_id,
             polls=polls,
             elapsed_s=self._clock() - start,
@@ -724,6 +987,14 @@ def render_human_summary(outcome: WatchOutcome) -> str:
         RESULT_FAILED: "FAILED — a required check failed",
         RESULT_HANG: "HANG — watcher stopped itself (no progress / wall-clock)",
         RESULT_UNRESOLVED: "UNRESOLVED — could not watch the run",
+        RESULT_SUPERSEDED: (
+            "SUPERSEDED — a newer run replaced this one (routine "
+            "concurrency-cancel; NOT a failure). Re-watch the newest head."
+        ),
+        RESULT_NO_VERDICT: (
+            "NO VERDICT — the run was cancelled, so it never reached a verdict "
+            "(NOT a failure, NOT a pass). Re-run to get one."
+        ),
     }[outcome.result]
     lines.append(f"watch-ci: {headline}")
     if outcome.run_id:
@@ -740,6 +1011,19 @@ def render_human_summary(outcome: WatchOutcome) -> str:
     if outcome.signature:
         tag = " [likely infra/flake — re-run]" if outcome.likely_infra else ""
         lines.append(f"  signature: {outcome.signature}{tag}")
+    elif outcome.result == RESULT_FAILED:
+        # Issue #1650: never guess. Say so and hand over the raw evidence — a
+        # fabricated signature sends the on-call to the wrong issue with false
+        # confidence, which is worse than admitting we could not classify it.
+        lines.append(
+            "  signature: none — unclassified failure (could not attribute it to "
+            "executed error output; read the log yourself, do NOT assume infra)"
+        )
+        if outcome.failing_jobs:
+            lines.append(
+                "  evidence:  gh run view --log-failed --job <id>  # "
+                f"job: {outcome.failing_jobs[0]}"
+            )
     return "\n".join(lines)
 
 
@@ -753,7 +1037,9 @@ def build_arg_parser() -> argparse.ArgumentParser:
             "Token-free, hang-proof GitHub Actions run watcher. Runs ONCE, blocks "
             "while the run is in flight (zero LLM tokens while waiting), then prints "
             "a compact summary + a final JSON line. Exit: 0 green / 1 real-fail / "
-            "2 hang / 3 unresolved."
+            "2 hang / 3 unresolved / 4 superseded (a newer run replaced this one — "
+            "routine on main, NOT a failure) / 5 no-verdict (cancelled, so nothing "
+            "was decided)."
         ),
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )

--- a/tools/pocketshell/tests/test_watch_ci.py
+++ b/tools/pocketshell/tests/test_watch_ci.py
@@ -9,9 +9,11 @@ without a real `gh` binary, network, or wall-clock wait.
 Exit-code contract under test:
 
     0  green       — all required checks passed
-    1  failed      — a required check failed / cancelled
+    1  failed      — a required check GENUINELY failed
     2  hang         — no progress past --no-progress-timeout OR wall-clock cap
     3  unresolved  — run / inputs couldn't be resolved (or gh stayed broken)
+    4  superseded  — a newer run replaced this one (routine concurrency-cancel)
+    5  no_verdict  — cancelled, so no verdict was reached (issue #1650)
 
 The load-bearing case is the HANG one: a run whose jobs NEVER change state must
 exit 2, not loop forever. The test drives a virtual clock so a stalled run is
@@ -198,15 +200,26 @@ def test_required_failure_exits_1_and_names_job():
     assert outcome.likely_infra is False
 
 
-def test_cancelled_run_exits_1():
+def test_cancelled_run_is_not_a_failure():
+    """Issue #1650: `cancelled` is NOT a failure — it is a NON-verdict.
+
+    This test previously asserted exit 1 and so ENCODED the bug: `main`'s push
+    concurrency group cancels superseded runs by design, which made every
+    superseded-run watch a guaranteed false FAILED. Hard-cut per D22 — the old
+    expectation is deleted, not kept alongside. Full class coverage (superseded
+    vs user-cancelled vs genuine-failure-then-cancelled) lives in
+    test_watch_ci_cancelled.py.
+    """
     gh = FakeGh()
     jobs = _all_required_jobs()
     jobs[1] = _job("Python utility tests (pocketshell)", "completed", "cancelled", db_id=7)
     gh.queue_run_state(status="completed", conclusion="cancelled", jobs=jobs)
+    gh.run_list_json = []  # no newer run → not superseded, just no verdict
     watcher, _ = _make_watcher(gh)
     outcome = watcher.watch(run_id="123")
-    assert outcome.result == wci.RESULT_FAILED
-    assert outcome.exit_code == 1
+    assert outcome.result == wci.RESULT_NO_VERDICT
+    assert outcome.exit_code == 5
+    assert outcome.signature is None
 
 
 # ── 2 hang: no-progress (the load-bearing case) ──────────────────────────────

--- a/tools/pocketshell/tests/test_watch_ci_cancelled.py
+++ b/tools/pocketshell/tests/test_watch_ci_cancelled.py
@@ -1,0 +1,558 @@
+"""Regression tests for the watch-ci.py fabricated-infra-failure defects (#1650).
+
+An on-call ran `scripts/watch-ci.py` against `main` run 29520839502 and got a
+confident, specific, and ENTIRELY FICTIONAL report:
+
+    FAILED — a required check failed
+    signature: echo "::error title=sdkmanager still broken after repair::... (issue #771).
+               Treat as EMULATOR INFRA UNAVAILABLE, not a test failure."
+
+Neither part happened. The run was merely SUPERSEDED — `#1648` landed and
+`main`'s push concurrency group cancelled the older in-flight run (the
+documented, intended design; see process.md "the `main` push concurrency group
+cancels older in-flight runs when newer merges land"). `Unit tests`, `Python
+utility tests (pocketshell)` and `Integration tests (Docker)` were all green.
+
+Two independent defects, reproduced separately below:
+
+  D1. `cancelled` was in FAILING_CONCLUSIONS, so a routine concurrency-cancel
+      became a guaranteed false `FAILED` on the exact path the on-call is told
+      to watch (process.md "Never babysit CI").
+  D2. The signature grep matched a CONDITIONAL `echo` in the workflow's script
+      body — captured by GitHub's command echo (the `ESC[36;1m` prefix) — that
+      NEVER FIRED. It could not tell "this error occurred" from "this string
+      exists in the script text", so it attached a wrong diagnosis AND a wrong
+      issue number.
+
+The load-bearing NEGATIVE cases (G6) matter more than the false alarms: a fix
+that makes the watcher blind to real failures is far worse than the bug, because
+the on-call would stop noticing red CI. `test_genuine_*` below assert that a
+real infra failure is still detected WITH its real signature, and a real test
+failure is still reported as a real failure — never softened to
+cancelled/superseded/unknown.
+
+Class coverage (G2) — not just the one reported instance:
+
+  | case                              | expected result |
+  |-----------------------------------|-----------------|
+  | superseded by concurrency         | superseded (4)  |
+  | user/API cancelled, no newer run  | no_verdict (5)  |
+  | genuine infra failure             | failed (1) + real signature, likely_infra |
+  | genuine test failure              | failed (1) + real signature |
+  | genuine failure THEN cancelled    | failed (1)      |
+  | timeout / hang                    | hang (2)        |
+  | no verdict available (probe down) | no_verdict (5)  |
+
+Fixtures are captured from the REAL run/log (`gh run view --log`), not
+hand-idealised, per the #847 happy-fixture-masks-reality lesson.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.test_watch_ci import (  # the shared offline harness
+    REQUIRED,
+    FakeGh,
+    _job,
+    _make_watcher,
+    wci,
+)
+
+# ── Real captured fixtures (run 29520839502, main @ ab3e0caf) ────────────────
+
+# The EXACT job set from `gh run view 29520839502 --json status,conclusion,jobs`.
+# The three cheap required checks passed; only the emulator shards + the
+# aggregate were cancelled when #1648 (136fe702) superseded the run at 18:50:18.
+def _superseded_main_jobs() -> list[dict]:
+    return [
+        _job("Python utility tests (pocketshell)", "completed", "success", 87697273282),
+        _job("Integration tests (Docker)", "completed", "success", 87697273298),
+        _job("Unit tests", "completed", "success", 87697273300),
+        _job(
+            "Emulator journey subset (load-bearing, Docker agents) (1)",
+            "completed",
+            "cancelled",
+            87701705006,
+        ),
+        _job(
+            "Emulator journey subset (load-bearing, Docker agents) (0)",
+            "completed",
+            "cancelled",
+            87701705021,
+        ),
+        _job(
+            "Emulator journey subset (load-bearing, Docker agents) (2)",
+            "completed",
+            "cancelled",
+            87701705035,
+        ),
+        _job(
+            "Emulator journey aggregate verdict (#1458)",
+            "completed",
+            "cancelled",
+            87713160666,
+        ),
+    ]
+
+
+# The EXACT line `gh run view --job 87701705006 --log` emitted at line 529 that
+# the watcher turned into its fabricated signature. The `ESC[36;1m ... ESC[0m`
+# wrapper is GitHub's COMMAND ECHO: it is the `run:` step's script body being
+# printed, NOT output from an executed command. The `if` guarding this echo
+# never fired — the sdkmanager was fine.
+_REAL_ECHOED_SDKMANAGER_LINE = (
+    "Emulator journey subset (load-bearing, Docker agents) (1)\t"
+    "Repair Android cmdline-tools + accept licenses (issue\t"
+    "2026-07-16T18:03:10.7886203Z \x1b[36;1m  "
+    'echo "::error title=sdkmanager still broken after repair::The '
+    "freshly-installed cmdline-tools sdkmanager still failed to run (issue "
+    '#771). Treat as EMULATOR INFRA UNAVAILABLE, not a test failure."\x1b[0m'
+)
+
+# Real surrounding context from the same captured log.
+_REAL_CANCELLED_JOB_LOG = "\n".join(
+    [
+        "Emulator journey subset (load-bearing, Docker agents) (1)\tSet up job\t"
+        "2026-07-16T18:02:55.1000000Z Job is about to start running on the runner",
+        _REAL_ECHOED_SDKMANAGER_LINE,
+        "Emulator journey subset (load-bearing, Docker agents) (1)\t"
+        "Repair Android cmdline-tools + accept licenses (issue\t"
+        "2026-07-16T18:03:12.0000000Z sdkmanager ok",
+        "Emulator journey subset (load-bearing, Docker agents) (1)\t"
+        "Retry journey subset on a fresh cold-booted emulator\t"
+        "2026-07-16T18:50:19.0573036Z ##[error]The operation was canceled.",
+    ]
+)
+
+
+def _newer_run_on_main(newer: bool = True) -> list[dict]:
+    """`gh run list --branch main` output; newest-first, as gh returns it."""
+    runs = []
+    if newer:
+        runs.append(
+            {
+                "databaseId": 29521111111,
+                "workflowName": "Tests",
+                "headBranch": "main",
+                "status": "in_progress",
+                "createdAt": "2026-07-16T18:50:18Z",
+            }
+        )
+    runs.append(
+        {
+            "databaseId": 29520839502,
+            "workflowName": "Tests",
+            "headBranch": "main",
+            "status": "completed",
+            "createdAt": "2026-07-16T18:02:40Z",
+        }
+    )
+    return runs
+
+
+def _superseded_run_state() -> dict:
+    return {
+        "status": "completed",
+        "conclusion": "cancelled",
+        "databaseId": 29520839502,
+        "headBranch": "main",
+        "workflowName": "Tests",
+        "createdAt": "2026-07-16T18:02:40Z",
+        "jobs": _superseded_main_jobs(),
+    }
+
+
+# ── D1: superseded-by-concurrency is NOT a failure ───────────────────────────
+
+
+def test_superseded_by_concurrency_is_not_reported_as_failed():
+    """THE reported instance. Run 29520839502 was superseded, not broken.
+
+    Before the fix this returned RESULT_FAILED/exit 1 — a standing false-alarm
+    generator, because `main`'s concurrency-cancel is routine and by design.
+    """
+    gh = FakeGh()
+    gh.queue_run_state(**_superseded_run_state())
+    gh.run_list_json = _newer_run_on_main(newer=True)
+    gh.log_text = _REAL_CANCELLED_JOB_LOG
+    watcher, _ = _make_watcher(gh)
+
+    outcome = watcher.watch(run_id="29520839502")
+
+    assert outcome.result != wci.RESULT_FAILED, (
+        "a concurrency-superseded run must NOT be reported as a failure "
+        f"(got {outcome.result}: {outcome.reason})"
+    )
+    assert outcome.result == wci.RESULT_SUPERSEDED
+    assert outcome.exit_code == 4
+    assert "supersed" in outcome.reason.lower()
+    # The on-call's action is to re-watch the newest head — surface it.
+    assert "29521111111" in outcome.reason
+
+
+def test_superseded_run_never_fabricates_a_signature():
+    """D1+D2 together: the fictional story is signature-free.
+
+    A superseded run has no failure, so there is nothing to diagnose. Attaching
+    ANY signature here is fabrication (G5: an infra claim needs a captured
+    signature AND a clean re-run).
+    """
+    gh = FakeGh()
+    gh.queue_run_state(**_superseded_run_state())
+    gh.run_list_json = _newer_run_on_main(newer=True)
+    gh.log_text = _REAL_CANCELLED_JOB_LOG
+    watcher, _ = _make_watcher(gh)
+
+    outcome = watcher.watch(run_id="29520839502")
+
+    assert outcome.signature is None
+    assert outcome.likely_infra is False
+    assert "771" not in wci.render_human_summary(outcome), (
+        "must never surface a guessed issue number for a run that did not fail"
+    )
+
+
+def test_cancelled_without_a_newer_run_is_no_verdict_not_failed():
+    """User/API cancelled: no newer run on the branch, so it was not superseded.
+
+    We STILL cannot claim a failure — a cancelled run produced no verdict. The
+    watcher must say exactly that rather than invent one.
+    """
+    gh = FakeGh()
+    gh.queue_run_state(**_superseded_run_state())
+    gh.run_list_json = _newer_run_on_main(newer=False)  # only ourselves
+    gh.log_text = _REAL_CANCELLED_JOB_LOG
+    watcher, _ = _make_watcher(gh)
+
+    outcome = watcher.watch(run_id="29520839502")
+
+    assert outcome.result == wci.RESULT_NO_VERDICT
+    assert outcome.exit_code == 5
+    assert outcome.signature is None
+
+
+def test_cancelled_with_unreachable_probe_is_no_verdict_not_failed():
+    """The supersede probe itself failing must not resurrect the false FAILED.
+
+    If we cannot tell WHY it was cancelled, "no verdict" is the honest answer.
+    """
+    gh = FakeGh()
+    gh.queue_run_state(**_superseded_run_state())
+    gh.run_list_json = None  # `gh run list` errors out
+    gh.log_text = _REAL_CANCELLED_JOB_LOG
+    watcher, _ = _make_watcher(gh)
+
+    outcome = watcher.watch(run_id="29520839502")
+
+    assert outcome.result == wci.RESULT_NO_VERDICT
+    assert outcome.exit_code == 5
+    assert outcome.signature is None
+
+
+# ── D2: a signature must come from output that ACTUALLY EXECUTED ─────────────
+
+
+def test_echoed_conditional_script_text_is_not_a_signature():
+    """The exact fabrication vector, at the unit level.
+
+    `extract_signature` used to return this echoed `run:` body verbatim, because
+    the loose pattern `(Install|installing).*failed` happened to match
+    "freshly-installed ... still failed to run" inside the ECHOED script text.
+    A conditional echo that never fired is not evidence of anything.
+    """
+    sig = wci.extract_signature(_REAL_CANCELLED_JOB_LOG)
+    if sig is not None:
+        assert "sdkmanager" not in sig, (
+            "matched a conditional echo that never executed — the #1650 "
+            f"fabrication: {sig!r}"
+        )
+        assert "#771" not in sig
+        assert "echo" not in sig
+
+
+def test_command_echo_lines_are_ignored_even_when_they_look_like_errors():
+    """Class coverage: ANY echoed script body, not just the sdkmanager one."""
+    log = "\n".join(
+        [
+            "j\tstep\t2026-07-16T18:03:10.0000000Z \x1b[36;1mif ! foo; then\x1b[0m",
+            "j\tstep\t2026-07-16T18:03:10.0000000Z \x1b[36;1m  "
+            'echo "error: everything is on fire"\x1b[0m',
+            "j\tstep\t2026-07-16T18:03:10.0000000Z \x1b[36;1mfi\x1b[0m",
+            "j\tstep\t2026-07-16T18:03:11.0000000Z all good",
+        ]
+    )
+    assert wci.extract_signature(log) is None
+
+
+def test_echoed_annotation_is_ignored_even_without_the_ansi_marker():
+    """Defence in depth: the vector must stay closed if ANSI is ever stripped.
+
+    A real annotation is emitted by the runner as `##[error]...`; it is never the
+    literal text `echo "::error`. So an echoed annotation is script text even
+    when the `ESC[36;1m` command-echo marker is absent.
+    """
+    log = (
+        "j\tRepair Android cmdline-tools\t2026-07-16T18:03:10.0000000Z   "
+        'echo "::error title=sdkmanager still broken after repair::The '
+        "freshly-installed cmdline-tools sdkmanager still failed to run (issue "
+        '#771). Treat as EMULATOR INFRA UNAVAILABLE, not a test failure."'
+    )
+    sig = wci.extract_signature(log)
+    assert sig is None or "sdkmanager" not in sig
+
+
+def test_usage_help_text_mentioning_an_error_is_not_a_signature():
+    """A `--help`/usage line that merely NAMES an error is not an occurrence."""
+    log = "\n".join(
+        [
+            "j\tstep\t2026-07-16T18:03:10.0000000Z \x1b[36;1m"
+            'echo "usage: gradlew [--fail-fast] # BUILD FAILED means a test broke"\x1b[0m',
+            "j\tstep\t2026-07-16T18:03:11.0000000Z done",
+        ]
+    )
+    assert wci.extract_signature(log) is None
+
+
+# ── G6 NEGATIVE CASES: real failures MUST still be caught ────────────────────
+# These are the load-bearing assertions. Going blind to real red CI would be far
+# worse than the false alarms this issue is about.
+
+
+def test_genuine_test_failure_is_still_reported_failed_with_its_signature():
+    gh = FakeGh()
+    jobs = [_job(n, "completed", "success", i) for i, n in enumerate(REQUIRED)]
+    jobs[0] = _job("Unit tests", "completed", "failure", 99)
+    gh.queue_run_state(
+        status="completed",
+        conclusion="failure",
+        databaseId=1,
+        headBranch="main",
+        workflowName="Tests",
+        createdAt="2026-07-16T18:02:40Z",
+        jobs=jobs,
+    )
+    gh.log_text = (
+        "Unit tests\tRun tests\t2026-07-16T10:00:05Z FooBarTest > checks FAILED\n"
+        "Unit tests\tRun tests\t2026-07-16T10:00:06Z BUILD FAILED in 12s\n"
+    )
+    watcher, _ = _make_watcher(gh)
+
+    outcome = watcher.watch(run_id="1")
+
+    assert outcome.result == wci.RESULT_FAILED
+    assert outcome.exit_code == 1
+    assert "Unit tests" in outcome.failing_jobs
+    assert outcome.signature is not None and "FAILED" in outcome.signature
+    assert outcome.likely_infra is False
+
+
+def test_genuine_infra_failure_is_still_detected_with_its_real_signature():
+    """A real, EXECUTED infra error keeps its signature + likely_infra tag (G5)."""
+    gh = FakeGh()
+    jobs = [_job(n, "completed", "success", i) for i, n in enumerate(REQUIRED)]
+    jobs[3] = _job(REQUIRED[3], "completed", "failure", 42)
+    gh.queue_run_state(
+        status="completed",
+        conclusion="failure",
+        databaseId=1,
+        headBranch="main",
+        workflowName="Tests",
+        createdAt="2026-07-16T18:02:40Z",
+        jobs=jobs,
+    )
+    # Note: a REAL runner-emitted annotation, not an echoed script body.
+    gh.log_text = (
+        "emu\tBoot emulator\t2026-07-16T18:10:00.0000000Z \x1b[36;1m"
+        'echo "starting emulator"\x1b[0m\n'
+        "emu\tBoot emulator\t2026-07-16T18:40:00.0000000Z "
+        "##[error]Timed out waiting for emulator to boot after 1800s\n"
+    )
+    watcher, _ = _make_watcher(gh)
+
+    outcome = watcher.watch(run_id="1")
+
+    assert outcome.result == wci.RESULT_FAILED
+    assert outcome.exit_code == 1
+    assert outcome.signature is not None
+    assert "Timed out waiting for emulator" in outcome.signature
+    assert outcome.likely_infra is True, "a real infra signature must still tag infra"
+
+
+def test_genuine_failure_that_is_later_cancelled_is_still_failed():
+    """Precedence: a real failure outranks the cancel that followed it.
+
+    The concurrency-cancel fix must not become a laundry service for real red.
+    """
+    gh = FakeGh()
+    jobs = _superseded_main_jobs()
+    jobs[2] = _job("Unit tests", "completed", "failure", 87697273300)
+    gh.queue_run_state(
+        status="completed",
+        conclusion="cancelled",  # run cancelled AFTER Unit tests genuinely failed
+        databaseId=29520839502,
+        headBranch="main",
+        workflowName="Tests",
+        createdAt="2026-07-16T18:02:40Z",
+        jobs=jobs,
+    )
+    gh.run_list_json = _newer_run_on_main(newer=True)  # a newer run DOES exist
+    gh.log_text = (
+        "Unit tests\tRun tests\t2026-07-16T18:30:00Z BUILD FAILED in 12s\n"
+    )
+    watcher, _ = _make_watcher(gh)
+
+    outcome = watcher.watch(run_id="29520839502")
+
+    assert outcome.result == wci.RESULT_FAILED, (
+        "a genuinely failed required check must stay FAILED even though the run "
+        "was later cancelled/superseded — otherwise real red CI goes unnoticed"
+    )
+    assert outcome.exit_code == 1
+    assert "Unit tests" in outcome.failing_jobs
+
+
+def test_timed_out_conclusion_is_still_a_real_failure():
+    """`timed_out` is NOT cancelled — it stays a real failure."""
+    gh = FakeGh()
+    jobs = [_job(n, "completed", "success", i) for i, n in enumerate(REQUIRED)]
+    jobs[0] = _job("Unit tests", "completed", "timed_out", 5)
+    gh.queue_run_state(
+        status="completed",
+        conclusion="failure",
+        databaseId=1,
+        headBranch="main",
+        workflowName="Tests",
+        createdAt="2026-07-16T18:02:40Z",
+        jobs=jobs,
+    )
+    gh.log_text = "Unit tests\tRun\t2026-07-16T10:00:06Z ##[error]The job running has exceeded the maximum execution time\n"
+    watcher, _ = _make_watcher(gh)
+
+    outcome = watcher.watch(run_id="1")
+
+    assert outcome.result == wci.RESULT_FAILED
+    assert outcome.exit_code == 1
+
+
+def test_unclassified_failure_reports_honestly_without_guessing():
+    """No confident signature ⇒ say 'unclassified', never guess (G5).
+
+    A fabricated signature is worse than no signature: it sends the on-call to
+    the wrong issue with false confidence.
+    """
+    gh = FakeGh()
+    jobs = [_job(n, "completed", "success", i) for i, n in enumerate(REQUIRED)]
+    jobs[0] = _job("Unit tests", "completed", "failure", 99)
+    gh.queue_run_state(
+        status="completed",
+        conclusion="failure",
+        databaseId=1,
+        headBranch="main",
+        workflowName="Tests",
+        createdAt="2026-07-16T18:02:40Z",
+        jobs=jobs,
+    )
+    gh.log_text = "Unit tests\tRun\t2026-07-16T10:00:00Z nothing conclusive here\n"
+    watcher, _ = _make_watcher(gh)
+
+    outcome = watcher.watch(run_id="1")
+
+    assert outcome.result == wci.RESULT_FAILED
+    assert outcome.signature is None
+    assert outcome.likely_infra is False
+    summary = wci.render_human_summary(outcome)
+    assert "unclassified" in summary.lower()
+
+
+# ── D3: a healthy long emulator shard must not trip the no-progress guard ────
+
+
+def test_default_no_progress_timeout_exceeds_the_emulator_job_cap():
+    """The emulator shards run 20-40 min (cap 95) with NO job-state change.
+
+    The old 1200s (20 min) default meant every `main` emulator watch reported a
+    bogus HANG while the shards were healthy and running.
+    """
+    job_cap_s = 95 * 60  # .github/workflows/tests.yml: timeout-minutes: 95
+    assert wci.DEFAULT_NO_PROGRESS_TIMEOUT_S > job_cap_s, (
+        "a healthy emulator shard would trip the no-progress guard"
+    )
+    # The wall-clock cap must leave room for the no-progress guard to be the
+    # thing that fires, otherwise raising it changes nothing.
+    assert wci.DEFAULT_MAX_WALL_CLOCK_S > wci.DEFAULT_NO_PROGRESS_TIMEOUT_S
+
+
+def test_healthy_long_running_emulator_shard_is_not_a_hang():
+    """A shard in_progress for 40 min with no state change is HEALTHY, not hung."""
+    gh = FakeGh()
+    jobs = [_job(n, "completed", "success", i) for i, n in enumerate(REQUIRED)]
+    # The emulator shard grinds away, unchanged, for 40 minutes...
+    for _ in range(200):
+        shard = list(jobs)
+        shard[3] = _job(REQUIRED[3], "in_progress", None, 42)
+        gh.queue_run_state(
+            status="in_progress",
+            conclusion=None,
+            databaseId=1,
+            headBranch="main",
+            workflowName="Tests",
+            createdAt="2026-07-16T18:02:40Z",
+            jobs=shard,
+        )
+    # ...then finishes green.
+    gh.queue_run_state(
+        status="completed",
+        conclusion="success",
+        databaseId=1,
+        headBranch="main",
+        workflowName="Tests",
+        createdAt="2026-07-16T18:02:40Z",
+        jobs=jobs,
+    )
+    gh.repeat_last_run_state = True
+    watcher, _ = _make_watcher(
+        gh,
+        interval_s=12.0,  # 200 polls * 12s = 40 min of no job-state change
+        no_progress_timeout_s=wci.DEFAULT_NO_PROGRESS_TIMEOUT_S,
+        max_wall_clock_s=wci.DEFAULT_MAX_WALL_CLOCK_S,
+    )
+
+    outcome = watcher.watch(run_id="1")
+
+    assert outcome.result == wci.RESULT_GREEN, (
+        f"healthy long shard misreported as {outcome.result}: {outcome.reason}"
+    )
+    assert outcome.exit_code == 0
+
+
+# ── The exit-code contract stays a single source of truth ────────────────────
+
+
+def test_exit_code_contract_is_complete_and_distinct():
+    codes = wci.EXIT_CODE
+    assert codes[wci.RESULT_GREEN] == 0
+    assert codes[wci.RESULT_FAILED] == 1
+    assert codes[wci.RESULT_HANG] == 2
+    assert codes[wci.RESULT_UNRESOLVED] == 3
+    assert codes[wci.RESULT_SUPERSEDED] == 4
+    assert codes[wci.RESULT_NO_VERDICT] == 5
+    # Every result must render a headline (no KeyError on a new verdict).
+    for result in codes:
+        outcome = wci.WatchOutcome(
+            result=result,
+            exit_code=codes[result],
+            required={},
+            failing_jobs=[],
+            signature=None,
+            likely_infra=False,
+            reason="x",
+            run_id="1",
+            polls=1,
+            elapsed_s=1.0,
+        )
+        assert wci.render_human_summary(outcome)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Closes #1650.

## Why this matters

`scripts/watch-ci.py` is how **every on-call decides whether CI is red** — `process.md`'s "Never babysit CI" directive mandates it. Today it returned **`FAILED`** with the signature *"sdkmanager still broken after repair, issue #771"*. **Both were fabricated.** The run had merely been superseded by concurrency-cancel; `main` was green. The on-call nearly filed a bug report about a failure that never happened, citing an unrelated issue number — it caught itself only by manually re-reading the raw logs.

This is a false-alarm generator aimed at the one role that tells us when things break.

## The two defects (measured, not assumed — both differed from the orchestrator's hypothesis)

1. **`cancelled` was in the shared failing-conclusions frozenset**, so the **required-check shortcut** returned FAILED *before the run conclusion was ever read* — the cancelled emulator shards are required checks. Concurrency-cancel is **routine and by design** on `main`. The watcher was **contradicting the workflow it watches**: `tests.yml`'s own classifier already states a cancelled attempt is not a genuine regression. Removing `cancelled` from the frozenset fixes **all four** consumers at once.
2. **The signature matcher matched text that never executed** — `(Install|installing).*failed` hit an echoed script line (`"freshly-installed ... still failed to run"`) carrying GitHub's `ESC[36;1m` command-echo marker. It could not distinguish "this error fired" from "this string exists in the log".

Together they manufacture a plausible, specific, entirely fictional infra story.

## What changed

- A superseded run reports **SUPERSEDED / no-verdict** rather than a verdict it cannot reach.
- **"Never invents" is structural**: a signature is only captured under `RESULT_FAILED`, and the supersede probe returns `no_verdict` on any error rather than guessing.
- A second echo defence beyond the ANSI marker, in case a log source strips ANSI.
- **Timeouts raised**: no-progress 20 → 100 min, wall-clock 60 min → 3 h. `tests.yml:432` sets `timeout-minutes: 95`, so a healthy shard can run **95 minutes with zero state change** — any threshold ≤95 min was a **guaranteed false HANG**. 100 min is the minimum defensible value; 3 h stays finite, so "nothing waits forever" holds. The reviewer verified the cap and agreed the backlog cost is the right side of the trade.
- **Deletes `test_cancelled_run_exits_1`** — it *encoded the bug* (asserted exit 1 on a cancelled run). Replaced, not dropped (D22 hard-cut). Our suite was actively enforcing the false-alarm behaviour.

## The load-bearing check (G6): the watcher is NOT blinded

**A watcher blind to red CI is far worse than one that cries wolf** — on-calls would stop noticing genuine failures and `main` would rot silently (the #1640 disease). Verified on **real** data, not fixtures:

- Live genuinely-failed run `29499762053` → still **exit 1**, truthful signature (`TmuxSessionViewModelReconnectTest ... FAILED` — the real #1633 flake), `likely_infra: false`, correctly declines to claim infra.
- Precedence test is non-vacuous: a run `cancelled` **with a newer run present** (so supersede would otherwise fire) but whose Unit tests genuinely failed → still **FAILED**. Not a laundry service for real red.

## Verification

**Reviewer ran the UNFIXED script against the LIVE run `29520839502`** and reproduced the maintainer's false alarm **verbatim**: exit 1, `required check(s) concluded failing: Emulator journey subset`, plus the literal fabricated `sdkmanager ... issue #771` signature with its `ESC[36;1m` marker. The fixed script on the same live run: **exit 4 `SUPERSEDED`, `signature: null`**. Symptom reproduced red on the real path, confirmed gone — not a proxy.

Reviewer-driven red→green (`cp` backup/restore): **12 failed / 4 passed** on base (the implementer under-claimed 11), **16 passed** with the fix. The 4 green-at-red are exactly the G6 negatives — itself the no-over-correction proof.

Orchestrator gate in a clean integration worktree off `origin/main`, using **CI's exact command** (`uv run pytest`, per `tests.yml:262-264`):
- **741 passed** — matching the reviewer's independent count
- `tools/pocketshell/tests/test_watch_ci_cancelled.py` (NEW, untracked — `git diff` hides it) confirmed **16 collected, 16 executed** (non-vacuous, G3)
- Wired into the required **`Python utility tests (pocketshell)`** check — not a lane where red has no consequence (#1640)
- `git diff --check` clean; workflow untouched

## Known follow-ups (filed, non-blocking)

The 95-min guard hardcodes its literal rather than deriving it from `tests.yml`, so a future cap raise would silently under-shoot again. `likely_infra` on a real *infra* run is fixture-only (no recent real infra failure available to drive live).

Review: https://github.com/alexeygrigorev/pocketshell/issues/1650#issuecomment-4995656069 (APPROVED)