### PR TITLE
test: barrier the seed capture so #926's guard stops flaking (#1649)

### DIFF
--- a/app/src/test/java/com/pocketshell/app/tmux/Issue926SeedIoOffMainTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue926SeedIoOffMainTest.kt
@@ -173,6 +173,23 @@ class Issue926SeedIoOffMainTest {
         waitUntil("switched to other") {
             vm.panes.value.any { it.paneId == "%2" }
         }
+        // Issue #1649: the pane publish above is NOT a barrier for the seed, so it
+        // must not be used as one. The switch's `list-panes` reconcile publishes
+        // `_panes` (applyParsedPanes) and only THEN runs the seed `capture-pane`
+        // (preloadVisibleContentForNewPanes) — both inside the same applyOnMain
+        // block. A test that asserts on the capture the moment `%2` appears
+        // therefore races that round-trip and reads `null` whenever it wins
+        // (~1-in-10 on a loaded CI runner; reproduced deterministically by making
+        // the capture take wall-clock time, as a real SSH round-trip does).
+        //
+        // Wait for the thing we are about to assert about — exactly as the
+        // wedged-channel sibling below already does. This does NOT weaken the
+        // load-bearing off-Main guarantee: it only removes the "not yet" reading,
+        // so `assertRanOffMain` always judges a REAL recorded thread. Verified by
+        // mutation: forcing the seed capture onto Main still fails this test red.
+        waitUntil("seed capture round-trip recorded") {
+            switchClient.lastCaptureThreadName != null
+        }
 
         assertNotNull("the fast switch must run a list-panes round-trip", switchClient.lastListPanesThreadName)
         assertRanOffMain(


### PR DESCRIPTION
Closes #1649. **Test-only**, +17 lines, one file.

## The defect

`Issue926SeedIoOffMainTest > fastSwitchReconcileAndSeedRunOffMain` reds a **required check** ~10% on loaded runners — measured **1-in-12** at moderate load, **4-in-5** at loadavg 25, **0-in-10** idle. It cost a re-run on every merge attempt, and per [#1640](https://github.com/alexeygrigorev/pocketshell/issues/1640) gate erosion is upstream of the maintainer's #1 complaint.

The assertion at `:182` had **no barrier for the thing it asserts about**. The only wait was `waitUntil { panes.any { it.paneId == "%2" } }` — satisfied by the *list-panes* reconcile — so `:177` passed while `:182` read `null`. The fix waits for the capture round-trip.

## This issue's own diagnosis was wrong — corrected

The issue (orchestrator-written) said the capture is *"dispatched asynchronously afterwards, with nothing waiting on it"*. **It isn't.** Both the implementer and the reviewer independently read `TmuxSessionViewModel.kt:9580-9589`: `preloadVisibleContentForNewPanes` is a `suspend fun` **invoked directly — there is no `launch`** — inside the same `applyOnMain` block, and its own comment says *"Seed it **synchronously** here."* It is synchronous but **sequenced after** the `_panes` publish.

Same conclusion, same fix — but a reader chasing a `launch` that doesn't exist would have been sent to code that isn't under test. Only the *background* panes are `launch`ed post-reveal; this fixture's `%2` is `newPanes.first()`, the synchronous active-pane seed.

## Not a product defect

Publishing panes before the seed is **by design**. `assertRanOffMain` is untouched — it is load-bearing for #926/#895, and a barrier that made the test pass unconditionally would be worse than the flake it fixes.

## Verification

**The reviewer ran a mutation the implementer did not**, and it is the decisive artifact: a capture that **never records** → the barrier **times out RED at 5s, it does not mask**. So the fix has **no false-green mode** — it closes the race it targets and stays loud on any other cause. That, rather than the sampling argument, is why "could not reproduce by sampling" is acceptable here.

- **G6**: barrier in place, capture-only forced onto Main → still **RED** (`seed capture-pane IO must run on the seed-IO thread, NEVER Main`).
- **G1**: red hit **line 182, the exact reported assertion and message, the exact `3 tests, 1 failed` shape**; barrier restored under the identical harness → green. The implementer built a **deterministic** red (widening the capture to real wall-clock time — what a real SSH round-trip is) rather than sampling; 20+ stock runs never triggered it naturally.
- **Sweep**: with the barrier removed and every client slowed, only `fastSwitch` reds. (The reviewer's first sweep went 3/3 red — it caught that as **its own harness** saturating the 5s connect wait, not a finding, and re-ran unsaturated.)
- **Determinism**: implementer 20/20 with `--rerun-tasks`, `--no-daemon`, proven-fresh XML per run, under load 22–25. Reviewer: 13 PASS / 0 RED / 1 `rc=143` SIGTERM classified as a **G5 infra kill** with captured clean re-runs either side; plus 16 stock greens, zero reds, under load 15–26.
- `check-test-validity.sh` **PASS** — the fix is a **condition wait, not a sleep** (no TIMING1 smell).

Orchestrator gate in a clean integration worktree off `origin/main`, `--rerun-tasks --no-daemon`, with **all four proofs** per `process.md` `c21cac01`/`8ffde110`/`16960c79`:
- **Console scan**: no test-execution task cached or skipped
- **Counts asserted from XML**: DEBUG **3958**, RELEASE **3954** — 0 failures, 0 skipped
- **XML freshness proven** against the run's start (**0 stale**)
- **`Issue926SeedIoOffMainTest` confirmed NAMED in the results in both variants** — the check added after a killed run reported honest partial counts while the load-bearing test never ran

## Known follow-up (filed, non-blocking)

The reviewer's saturated sweep showed **`waitUntil("connected")`** — not the new barrier — is the next thing to give out on a loaded runner. The seed barrier has healthy margin under the ~2.5s `SEED_CAPTURE_TIMEOUT_MS` ceiling.

Review: https://github.com/alexeygrigorev/pocketshell/issues/1649#issuecomment-4997718374 (APPROVED)