### PR TITLE
release: v0.4.38 (versionCode 85) — ends the #1610 mobile reconnect storm

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,8 +65,8 @@ android {
         applicationId = "com.pocketshell.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 84
-        versionName = "0.4.37"
+        versionCode = 85
+        versionName = "0.4.38"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/tools/pocketshell/pyproject.toml
+++ b/tools/pocketshell/pyproject.toml
@@ -8,7 +8,7 @@ name = "pocketshell"
 # scripts/check-pypi-version.sh enforces this; .github/workflows/build.yml
 # runs that check before publishing to PyPI. See
 # tools/pocketshell/README.md ("Release flow") for the bump procedure.
-version = "0.4.37"
+version = "0.4.38"
 description = "Unified server-side Python utility for the PocketShell Android client."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Version bump only. `versionCode 84 → 85`, `versionName 0.4.37 → 0.4.38`, and `tools/pocketshell` `0.4.37 → 0.4.38` **in lockstep** — `scripts/check-version-coupling.sh` green (#948; bumping only the app leaves the required Python check red at the guard step).

## What ships

The **#1610 mobile reconnect storm** fix. The maintainer's phone reconnected every ~5s on mobile and never self-healed, while every other app — and Termius on the same link at the same moment — was fine.

**The link was never the problem.** Three full TCP+KEX+auth handshakes completed in ~1s each inside a 13s window. The app killed its own healthy connections: one 5s budget covering dial + handshake + attach + **full reseed** (the reseed alone is ~10.4s/pane), so it timed out every cycle, closed a **provably-live** transport, evicted the **shared** lease, re-ingested its own teardown as a fresh failure, and never advanced the counter — so it never backed off and never gave up.

**Three prior fixes were each correct and each unreachable** (#1660): #1539's guard covered one of two exits; #1633's stability window never received a ladder; #1654's ladder never got projected. `maxAttempts=8` appears **zero times in 15 days** across **1,395** field renders.

Full record: [`docs/connection-storm-2026-07-16.md`](https://github.com/alexeygrigorev/pocketshell/blob/main/docs/connection-storm-2026-07-16.md).

## ⚠️ This PR does NOT authorise the tag

Per [#1655](https://github.com/alexeygrigorev/pocketshell/issues/1655) (SHIP-WITH-CAVEATS), the remaining conditions are **unmet**:

- [ ] **#1652's journey green on a LOCAL isolated emulator**, both directions including the G6 negative. **CI structurally cannot judge this class** — receipts: all five wave merges' `main` runs were **cancelled**; the one green since aggregated `3 INFRA → AGGREGATE_VERDICT=RE-RUN` (zero journeys reached a verdict); the only lane that sees this bug is **10/10 red Jul 8–16** and waived by `NIGHTLY_FAULT_GATE_DISABLED=1` **baked into `process.md`'s own release command**.
- [ ] `scripts/release-emulator-validation.sh` from this exact commit once merged.
- [ ] The fault-gate waiver recorded as a **deliberate per-release decision**, not boilerplate.
- [ ] **Upgrade the host CLI on Hetzner after tagging** — no guard covers it.
- [ ] **#1610 stays OPEN** pending the maintainer's on-device smoke (the D33 acceptance; smoke list at the top of #1655).

## Ships knowingly

**#1639** (CRITICAL — no SSH host-key verification anywhere; `debug.keystore` committed to a **public** repo while shipping a debug-signed `debuggable` APK). Acceptable **only** because it is not a regression, and #1655 says it must be the next slice. Its fix is blocked behind this merge — a partial fix compiles green while leaving the main tmux path MITM-able.

Also: **#1635** (#1655: "the most likely next complaint" — ~190 MB of mobile data per photo during a storm; round five in review), #1634, #1637, #1631, #1641 (round one in review).

**Rollback is weak** — downgrade needs `adb install -r -d` or uninstall-with-data-loss. **QR-export hosts before updating.**