### PR TITLE
connection: hold silent-heal across the whole within-grace foreground (#754)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -3318,10 +3318,17 @@ public class TmuxSessionViewModel @Inject constructor(
     // Reconnecting bar, no "Attaching…" overlay, no disconnect band. While set, the
     // displayed-status projection ([projectStatusFromController]) holds `Connected`
     // and the [RevealStateMachine] holds the live frame (see
-    // [RevealStateMachine.setSilentHealInFlight]). Set + cleared together for the
-    // bounded duration of [launchForegroundHealWithinGrace]'s heal job only, so an
-    // unexpected (non-grace) foreground drop keeps its normal calm-Reconnecting band.
+    // [RevealStateMachine.setSilentHealInFlight]). Issue #754 (re-fix): armed at the within-grace
+    // foreground DECISION POINT ([armWithinGraceSilentHealHold]), released once after the bounded
+    // grace window (NOT tied to a single recovery job), so the ride-through covers BOTH the
+    // reseed_only path AND the confirmed-dead heal path whose failed single-shot heal hands off to
+    // the loud auto-reconnect ladder — else that ladder's Reconnecting paints the overlay WITHIN
+    // grace. A real BEYOND-grace drop still surfaces once the bounded release fires.
     private var withinGraceSilentHealInFlight: Boolean = false
+
+    // Issue #754 (re-fix): SINGLE-OWNER bounded release of the hold above. A fresh within-grace
+    // foreground cancels + restarts it; only the CURRENT job's completion clears the hold.
+    private var withinGraceSilentHealReleaseJob: Job? = null
 
     // EPIC #687 slice 1c-iv-b-B1 (#738): the `preserveConnectingTarget` computed
     // SYNCHRONOUSLY by [detachForBackground] at background time, stashed for the
@@ -3651,46 +3658,31 @@ public class TmuxSessionViewModel @Inject constructor(
      */
     public fun onAppForegrounded(resumedWithinGrace: Boolean = false) {
         appActive = true
-        // EPIC #687 slice 1c-iv-c (#754): the within-grace foreground return is now
-        // owned by the driver/controller as a RESEED-ONLY effect, gated on the
-        // controller's grace predicate. Within grace the `-CC` control client was
-        // NEVER torn down (the teardown is deferred to grace-elapsed), so the warm
-        // lease is intact: we re-capture the active pane and let the existing
-        // SeedLanded feedback promote the controller back to Live. We DO NOT run the
-        // old inline `probeCurrentRuntimeOnForegroundIfNeeded → connect(LifecycleReattach)`
-        // path, which raised the reveal-machine hold (the "Attaching…" overlay) on any
-        // confirmed-dead probe verdict even inside grace — the D21 violation #754 fixes.
-        // The within-grace gate (`resumedWithinGrace && warm lease`) is exactly the
-        // controller's `onForeground` predicate (`now < deadline && transport.isWarm`),
-        // so the VM and the `ConnectionController` agree on the classification by
-        // construction; the driver's `foregroundReattachEffect` seam fires the SAME
-        // reseed body on the controller's Backgrounded→Reattaching edge (unit-tested in
-        // `ConnectionEffectDriverTest`).
+        // Issue #754 (re-fix): arm the silent-heal hold for the WHOLE bounded grace window BEFORE
+        // the reseed-vs-heal branch below, so BOTH within-grace outcomes ride through without the
+        // "Attaching…" overlay. Beyond grace we never arm, so a real outage still surfaces.
+        if (resumedWithinGrace) {
+            armWithinGraceSilentHealHold()
+        }
+        // EPIC #687 slice 1c-iv-c (#754): the within-grace foreground return is a driver/controller
+        // RESEED-ONLY effect gated on the grace predicate. Within grace the `-CC` client was NEVER
+        // torn down, so the warm lease is intact: re-capture the active pane and let SeedLanded
+        // promote the controller back to Live. NO `connect()`, NO reveal-machine "Attaching…"
+        // overlay (the D21 within-grace contract, replacing the deleted inline
+        // `probeCurrentRuntimeOnForegroundIfNeeded → connect(LifecycleReattach)` path). The gate
+        // mirrors the controller's `onForeground` predicate (`now < deadline && transport.isWarm`).
         if (resumedWithinGrace && canReseedWithinGraceForeground()) {
-            // The `-CC` control client was NEVER torn down within grace (the controller
-            // therefore stays Live in production — Background is only submitted at
-            // grace-elapsed teardown, NOT here, so the #738 driver detach never fires).
-            // Run the RESEED-ONLY effect directly: it re-promotes Live (a no-op
-            // TransportLive on an already-Live controller) and heals blank panes over
-            // the warm client. NO connect(), NO the reveal-machine hold "Attaching…"
-            // overlay — the D21 within-grace contract. The driver's
-            // `foregroundReattachEffect` seam invokes this SAME body on the controller's
-            // Backgrounded→Reattaching edge (the classification model, unit-tested in
-            // `ConnectionEffectDriverTest`); both paths share the one reseed owner.
-            // EPIC #792 Slice B: route through the single [GraceEffects] owner (the dead
-            // `foregroundReattachReseedForTest` dual-write override is deleted).
+            // EPIC #792 Slice B: route through the single [GraceEffects] owner — the driver's
+            // `foregroundReattachEffect` seam invokes this SAME reseed body on the controller's
+            // Backgrounded→Reattaching edge (unit-tested in `ConnectionEffectDriverTest`).
             graceEffects.onForegroundReattachReseed()
             return
         }
-        // EPIC #687 P2 (J1/#635): SINGLE GRACE OWNER. The App-level
-        // background-grace window (#450) is the SOLE grace authority — when it reports
-        // `resumedWithinGrace=true`, a within-grace foreground must stay CALM (no
-        // Reconnecting/Disconnected/Connecting/Attaching band or overlay) EVEN WHEN the
-        // `-CC` socket dropped while backgrounded (WiFi→cellular handoff / Doze). The
-        // reseed-only fast path above declines in that case (the dropped socket killed
-        // the warm lease / flipped the status off Connected / paused the passive
-        // auto-reconnect), so without this branch the foreground would fall into the
-        // reconnect ladder and paint the maintainer's scary band — the #635 regression.
+        // EPIC #687 P2 (J1/#635): SINGLE GRACE OWNER. The App-level background-grace window (#450)
+        // is the SOLE grace authority — a within-grace foreground must stay CALM even when the
+        // `-CC` socket dropped while backgrounded (WiFi→cellular / Doze). The reseed-only fast path
+        // above declines then (the dropped socket killed the warm lease), so without this branch
+        // the foreground would fall into the reconnect ladder and paint the #635 scary band.
         // Instead we SILENTLY heal the dropped channel within grace: re-open a fresh
         // `-CC` control client over a freshly-acquired lease and reseed, with NO band
         // and NO overlay. The inline passive-disconnect grace clock that fired while
@@ -3893,17 +3885,48 @@ public class TmuxSessionViewModel @Inject constructor(
     }
 
     /**
+     * Issue #754 (re-fix): arm the within-grace silent-heal reveal/status hold for the ENTIRE
+     * bounded grace window, at the within-grace foreground DECISION POINT (BEFORE the
+     * reseed-vs-heal branch in [onAppForegrounded]), so BOTH the reseed_only path AND the
+     * confirmed-dead heal path (a clean cut whose dead lease declines the reseed, whose failed
+     * single-shot heal hands off to the loud auto-reconnect ladder) ride through WITHOUT the
+     * "Attaching…" overlay. SINGLE OWNER: a fresh within-grace foreground cancels + restarts the
+     * bounded release, and only the CURRENT job clears it (guarded), so a genuine BEYOND-grace
+     * drop still surfaces its reconnect band the instant the release fires.
+     */
+    private fun armWithinGraceSilentHealHold() {
+        val previous = withinGraceSilentHealReleaseJob
+        withinGraceSilentHealInFlight = true
+        revealController.setSilentHealInFlight(true)
+        val job = launchContainedTeardown {
+            delay(passiveDisconnectGraceMs.coerceAtLeast(1L))
+        }
+        withinGraceSilentHealReleaseJob = job
+        job.invokeOnCompletion {
+            if (withinGraceSilentHealReleaseJob === job) {
+                withinGraceSilentHealReleaseJob = null
+                withinGraceSilentHealInFlight = false
+                revealController.setSilentHealInFlight(false)
+                // Re-drive the reveal from the CURRENT controller state so a still-failing
+                // BEYOND-grace reconnect surfaces its band the instant the hold lifts (the ongoing
+                // Reconnecting was emitted while gated and the state flow dedupes it); a recovered
+                // Live controller stays Live.
+                revealController.onConnectionState(connectionManager.state)
+                projectStatusFromController()
+            }
+        }
+        // Re-point the owner BEFORE cancelling the prior timer so its guarded handler is a no-op.
+        previous?.cancel()
+    }
+
+    /**
      * EPIC #687 slice 1c-iv-c (#754): the RESEED-ONLY within-grace foreground reattach
      * body — the hard-cut replacement for the deleted inline
      * `probeCurrentRuntimeOnForegroundIfNeeded → connect(LifecycleReattach)` path. The
-     * warm `-CC` control client is still attached (the teardown is deferred to
-     * grace-elapsed), so there is NOTHING to reconnect: the emulator still holds the
-     * live frame the channel streamed while attached. We promote the controller back
-     * to Live (the channel is live) and run the existing blank-pane safety-net reseed
-     * over the SAME live client so a pane that came back blank under a brief link blip
-     * still heals — without a handshake. Crucially this NEVER calls `connect()` and
-     * NEVER raises the reveal-machine hold, so the user sees no "Attaching…" overlay and
-     * no reconnect — the D21 within-grace contract.
+     * warm `-CC` control client is still attached (the teardown is deferred to grace-elapsed), so
+     * there is NOTHING to reconnect. We promote the controller back to Live and run the existing
+     * blank-pane safety-net reseed over the SAME live client so a pane that came back blank under a
+     * brief blip still heals — no handshake, no `connect()`, no "Attaching…" overlay (D21 contract).
      *
      * This is also the body the [ConnectionEffectDriver]'s `foregroundReattachEffect`
      * seam invokes on the controller's Backgrounded→Reattaching edge (unit-tested),
@@ -3926,6 +3949,11 @@ public class TmuxSessionViewModel @Inject constructor(
             "generation" to connectGeneration,
             "clientHash" to System.identityHashCode(client),
         )
+        // Issue #754 (re-fix): arm the SINGLE-OWNER within-grace silent-heal hold. The
+        // [onAppForegrounded] caller already armed it; this ALSO covers the
+        // [ConnectionEffectDriver.foregroundReattachEffect] seam invocation (the guard makes the
+        // double-arm a safe no-op) so a blackhole-blip Reattaching never paints the overlay.
+        armWithinGraceSilentHealHold()
         // The control channel is still live — promote the controller Reattaching → Live
         // so the displayed status stays the calm `Connected` (no Reconnecting/overlay).
         connectionManager.observeForegroundReattachLive()
@@ -3961,6 +3989,7 @@ public class TmuxSessionViewModel @Inject constructor(
                 if (isCurrentRuntime(guard)) armActivePaneStaleRenderWatchdog(guard)
             }
         }
+        // The hold's bounded release is owned by [armWithinGraceSilentHealHold].
     }
 
     /**
@@ -4216,15 +4245,13 @@ public class TmuxSessionViewModel @Inject constructor(
         // ride-through, not a reconnect. Promote the controller back toward Live so the
         // header indicator never shows Reconnecting/Disconnected during the heal.
         connectionManager.observeForegroundReattachLive()
-        // Issue #1098 (item 4 / #635): the within-grace silent heal MUST re-open the
-        // dropped `-CC` transport, which walks the controller `Live -> Reattaching ->
-        // Live`. Without this the [RevealStateMachine] would project that Reattaching as
-        // [RevealState.Seeding] → the screen paints the full-surface "Attaching…" loading
-        // overlay over the live frame (the spurious overlay #635/item-4 reproduces). Hold
-        // the reveal at its current (live) frame for the bounded duration of the heal so
-        // the ride-through stays INVISIBLE; cleared in the job's completion handler below.
-        withinGraceSilentHealInFlight = true
-        revealController.setSilentHealInFlight(true)
+        // Issue #1098 (item 4 / #635): the within-grace silent heal re-opens the dropped `-CC`
+        // transport (controller `Live -> Reattaching -> Live`); a hold keeps [RevealStateMachine]
+        // from projecting that Reattaching as [RevealState.Seeding] (the "Attaching…" overlay).
+        // Issue #754 (re-fix): the hold is armed at the foreground DECISION POINT
+        // ([armWithinGraceSilentHealHold], SINGLE OWNER) and released after the whole grace window
+        // — NOT on this heal job — so the confirmed-dead ride-through survives the single-shot
+        // heal's FAILURE + loud-ladder handoff below (clearing the hold there was the reopened bug).
         projectStatusFromController()
         // Issue #935 R1: contained — the within-grace heal re-opens a fresh `-CC`
         // over a fresh lease; a teardown-race throw must not crash the process.
@@ -4269,19 +4296,11 @@ public class TmuxSessionViewModel @Inject constructor(
                 )
             }
         }
-        // Issue #1098 (item 4): release the silent-heal reveal hold once the heal
-        // completes. On success the transport re-promoted the controller to Live, so the
-        // reveal is already a live frame; on failure the calm auto-reconnect ladder takes
-        // over and the next Reconnecting projection may show the normal loading surface.
-        // Cleared in the completion handler (success, failure, OR a teardown-race cancel)
-        // so the hold can never get stuck on, which would freeze the "Attaching…" overlay
-        // suppression across an unrelated later attach.
+        // Issue #754 (re-fix): the hold is NOT released here — that premature release (on a failed
+        // single-shot heal that hands off to the loud ladder) was the reopened bug. The SINGLE
+        // OWNER [armWithinGraceSilentHealHold] releases it after the whole grace window; we only
+        // re-project the status on completion so a success settles on the live `Connected`.
         healJob.invokeOnCompletion {
-            withinGraceSilentHealInFlight = false
-            revealController.setSilentHealInFlight(false)
-            // Re-project so a genuine heal FAILURE (the calm auto-reconnect ladder is now
-            // running) surfaces its normal Reconnecting band the instant the hold lifts,
-            // and a SUCCESS settles on the live `Connected` it already reached.
             projectStatusFromController()
         }
     }

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue754ReseedSilentHealHoldTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue754ReseedSilentHealHoldTest.kt
@@ -1,0 +1,534 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.app.diagnostics.installRecordingDiagnosticSink
+import com.pocketshell.app.sessions.ActiveTmuxClients
+import com.pocketshell.core.connection.RevealState
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.SshLeaseConnector
+import com.pocketshell.core.ssh.SshLeaseTarget
+import com.pocketshell.core.ssh.SshPortForward
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshShell
+import com.pocketshell.core.tmux.CommandResponse
+import com.pocketshell.core.tmux.TmuxDisconnectEvent
+import com.pocketshell.core.tmux.TmuxDisconnectReason
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+import java.io.InputStream
+
+/**
+ * Issue #754 (REOPENED, D31/D33/G10) — the within-grace foreground RESEED path must ride
+ * through a link-blip drop WITHOUT painting the "Attaching…" overlay.
+ *
+ * ## The reported defect (nightly-red 2026-07, on-device)
+ *
+ * On a within-grace foreground return over a still-warm `-CC` lease the driver-owned
+ * RESEED-only path ([TmuxSessionViewModel.launchForegroundReattachReseed]) runs a
+ * `capture-pane` reseed. Under a blackhole blip the link is still cut, so a foregrounded
+ * probe / `capture-pane` surfaces a `TransportDropped` — foregrounded, so NOT suppressed —
+ * which walks the controller `Live → Reattaching`. Because the reseed path (unlike its
+ * sibling [TmuxSessionViewModel.launchForegroundHealWithinGrace]) NEVER armed
+ * `revealController.setSilentHealInFlight(true)`, the [com.pocketshell.core.connection.RevealStateMachine]
+ * projects that Reattaching as [RevealState.Seeding] → the screen paints the
+ * `TMUX_SWITCHING_LOADING_TAG` "Attaching…" overlay over the live frame
+ * (`expected:<0> but was:<1>` in the release-gating fault suite).
+ *
+ * ## The fix these tests pin
+ *
+ * The reseed path now arms the silent-heal reveal/status hold for the bounded grace window
+ * (mirroring the heal path). While armed, a Reattaching projection HOLDS the current live
+ * frame (no overlay) and the status stays the calm `Connected`. The hold is released after
+ * the grace window so a genuine BEYOND-grace drop still surfaces its reconnect band.
+ *
+ * ## Deterministic red→green (the #780 synthetic-injection model, per-PR gated JVM proof)
+ *
+ * The waived nightly toxiproxy proof ([com.pocketshell.app.proof.WithinGraceResumeRideThroughE2eTest],
+ * `assumeFalse(isRunningOnCi())`) gave the regression zero per-PR coverage. This is the
+ * deterministic gate: a live VM foregrounds within grace (the RESEED path), then a
+ * confirmed drop is injected DURING the reseed window. On base the reveal flips to
+ * [RevealState.Seeding] (overlay) → RED; with the fix the reveal HOLDS Live → GREEN.
+ *
+ * Negative (non-masking): after the bounded grace window elapses the hold is cleared, so a
+ * later drop STILL surfaces [RevealState.Seeding] — arming silent-heal must never suppress a
+ * real beyond-grace drop into silence.
+ *
+ * ## Determinism (PR #1674 flake fix — the #1633 class)
+ *
+ * The original harness rolled its own `StandardTestDispatcher` Main + a private
+ * real-`Dispatchers.IO` `factoryScope` + a hand-rolled 5s wall-clock pump, and left the
+ * VM's teardown / agent-kind-exec / seed-IO / reconcile / port-detection / session-card
+ * dispatchers on their PRODUCTION real-`Dispatchers.IO` defaults. Under the full
+ * `:app:testReleaseUnitTest` module run those real threads race the virtual scheduler, so
+ * the reconnect ladder's progress (which hops through the real teardown scope) reached the
+ * assertion at a nondeterministic point — the exact release-variant-only flake #1674 hit.
+ *
+ * This suite now extends [TmuxSessionViewModelTestBase] (like the sibling
+ * [Issue1538ForegroundHealWithinGraceRideThroughTest], which exercises the SAME
+ * within-grace foreground-heal path deterministically): every real-IO dispatcher is pinned
+ * to the ONE shared virtual-clock scheduler and drained in `@After`, and the wall-clock
+ * pump is replaced by the audited `awaitCondition` (`runCurrent`-only, never advances the
+ * clock — so the bounded grace-window hold stays armed). The confirmed-dead ladder is
+ * pinned to `[0, 60_000]` so it deterministically PARKS on `Reconnecting` (the honest
+ * ongoing reconnect the hold rides through), instead of the old single `[0]` rung whose
+ * exhaustion-vs-parked outcome depended on the real-IO teardown hop landing first.
+ * The load-bearing assertions are UNCHANGED — still RED on base (Seeding overlay).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class Issue754ReseedSilentHealHoldTest : TmuxSessionViewModelTestBase() {
+
+    @Before
+    fun disableLivenessAutoStart() {
+        // The connect()-driven live seed reaches Connected, which would auto-start the
+        // periodic liveness probe loop; disable it so the `awaitCondition` runCurrent-pump
+        // that settles connect never chases a never-terminating re-arm (the #1517 class).
+        LivenessProbeTestOverride.setAutoStartEnabledForTest(false)
+    }
+
+    @After
+    fun clearLivenessOverride() {
+        LivenessProbeTestOverride.clear()
+    }
+
+    /**
+     * Connect a live single-pane session that ends up LIVE with a seeded (non-blank) pane
+     * and a WARM lease — exactly the within-grace foreground precondition
+     * ([TmuxSessionViewModel.canReseedWithinGraceForeground] true).
+     */
+    private fun TestScope.connectLiveVm(client: FakeTmuxClient): TmuxSessionViewModel {
+        val live = AlwaysConnectedSession(id = "live")
+        val connector = SingleSessionConnector(live)
+        val leaseManager =
+            testLeaseManager(connector = connector, scope = this, idleTtlMillis = 60_000L)
+        val registry = ActiveTmuxClients()
+        val vm = newVm(registry = registry, sshLeaseManager = leaseManager)
+        runCurrent()
+        // Isolate the reseed/drop interaction under test: the connect()-auto-armed blank +
+        // stale-render watchdogs would otherwise add their own capture-pane traffic and
+        // re-arm forever under the virtual clock.
+        vm.setConnectedBlankWatchdogAutoArmEnabledForTest(false)
+        vm.setStaleRenderWatchdogAutoArmEnabledForTest(false)
+        vm.setTmuxClientFactoryForTest { _, _, _ -> client }
+        vm.connect(
+            hostId = 1L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            passphrase = null,
+            sessionName = "work",
+        )
+        // Drive the connect to a seeded LIVE reveal. `advanceUntilIdle()` is safe HERE (the
+        // grace hold + auto-reconnect ladder are not armed until the later foreground) and the
+        // three periodic re-arm loops that would make it spin — the liveness probe (disabled in
+        // @Before) and the blank + stale-render watchdogs (disabled above) — are all off. Every
+        // real-IO dispatcher is pinned to the shared virtual scheduler by the base's newVm, so
+        // this drains deterministically instead of racing a real thread (the #1674 flake).
+        advanceUntilIdle()
+        // The warm lease is the within-grace reseed precondition; pin it deterministically.
+        vm.markActiveLeaseWarmForTest()
+        return vm
+    }
+
+    private val richFrame: List<String> = buildList {
+        add("╭──────────────────────────────────────────────╮")
+        repeat(10) { i -> add("│  context line $i — real rendered content here  │") }
+        add("╰──────────────────────────────────────────────╯")
+    }
+
+    private fun FakeTmuxClient.withRichInitialFrame(
+        sessionName: String,
+        paneId: String,
+    ): FakeTmuxClient = apply {
+        responses.addLast(
+            CommandResponse(
+                number = 1L,
+                output = listOf("$paneId\t@0\t\$0\t$sessionName\t$sessionName\t0"),
+                isError = false,
+            ),
+        )
+        capturePaneResponses.addLast(
+            CommandResponse(number = 2L, output = richFrame, isError = false),
+        )
+        cursorQueryResponses.addLast(
+            CommandResponse(number = 3L, output = listOf("0,0"), isError = false),
+        )
+    }
+
+    private fun linkBlipDrop(): TmuxDisconnectEvent =
+        TmuxDisconnectEvent(
+            reason = TmuxDisconnectReason.ReaderEof,
+            source = "link_blackhole",
+            intent = "unknown",
+        )
+
+    // -----------------------------------------------------------------------
+    // (1) LOAD-BEARING red→green: a drop DURING the within-grace reseed window must be
+    //     ridden through silently — NO RevealState.Seeding (the "Attaching…" overlay), and
+    //     the status stays the calm Connected. RED on base (Seeding + Reconnecting).
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun dropDuringWithinGraceReseedHoldsLiveRevealNoAttachingOverlay() = runTest(scheduler) {
+        val client = FakeTmuxClient().withRichInitialFrame("work", "%1")
+        val vm = connectLiveVm(client)
+        // Precondition: the connect settled on a LIVE reveal (the frame the user is looking at).
+        assertTrue(
+            "precondition: connect reaches RevealState.Live before the foreground reseed; got " +
+                "${vm.revealState.value}",
+            vm.revealState.value is RevealState.Live,
+        )
+        // Large grace so the bounded hold stays armed for the whole (clock-not-advanced) window.
+        vm.setPassiveDisconnectRecoveryForTest(graceMs = 300_000L)
+        vm.setProcessForegroundForClearedForTest(true)
+
+        val diagnostics = installRecordingDiagnosticSink()
+        try {
+            // The within-grace foreground return → the driver-owned RESEED-only path.
+            vm.onAppForegrounded(resumedWithinGrace = true)
+            runCurrent()
+            // Non-vacuous: the reseed path actually ran (its cause-trail), not the heal path.
+            assertTrue(
+                "the within-grace foreground must take the driver-owned reseed_only path; trail=" +
+                    "${diagnostics.eventsNamed("cause_trail")}",
+                diagnostics.eventsNamed("cause_trail").any {
+                    it.fields["stage"] == "foreground_reattach" && it.fields["outcome"] == "reseed_only"
+                },
+            )
+
+            // Inject a CONFIRMED drop DURING the reseed window while foregrounded — the still-cut
+            // link's probe/capture-pane surfacing a TransportDropped (foregrounded ⇒ NOT suppressed).
+            client.markDisconnectedForTest(linkBlipDrop())
+            awaitCondition {
+                diagnostics.eventsNamed("passive_disconnect").isNotEmpty()
+            }
+            // Let the controller Reattaching projection reach the reveal collector.
+            runCurrent()
+
+            // LOAD-BEARING: the drop drove the controller Live→Reattaching, but the armed
+            // silent-heal hold keeps the reveal on the LIVE frame — NO RevealState.Seeding, so
+            // SwitchingLoadingPlaceholder ([TMUX_SWITCHING_LOADING_TAG]) never paints "Attaching…".
+            // On base (no arm) the Reattaching projects Seeding → the #754 overlay → RED.
+            assertFalse(
+                "a drop during the within-grace reseed must be RIDDEN THROUGH — the reveal must " +
+                    "NOT drop to RevealState.Seeding (the \"Attaching…\" overlay, #754); got " +
+                    "${vm.revealState.value}",
+                vm.revealState.value is RevealState.Seeding,
+            )
+            assertTrue(
+                "the within-grace ride-through keeps the reveal on the held LIVE frame; got " +
+                    "${vm.revealState.value}",
+                vm.revealState.value is RevealState.Live,
+            )
+            // The status hold keeps the calm Connected (no Reconnecting bar) during the ride-through.
+            assertTrue(
+                "the within-grace ride-through keeps the calm Connected status (no Reconnecting " +
+                    "band); got ${vm.connectionStatus.value}",
+                vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected,
+            )
+        } finally {
+            diagnostics.close()
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // (2) NON-MASKING (bounded hold): after the grace window elapses the hold is released, so a
+    //     later drop STILL surfaces RevealState.Seeding — the arm must never suppress a real
+    //     beyond-grace drop into silence.
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun dropAfterGraceWindowElapsesStillSurfacesSeedingOverlay() = runTest(scheduler) {
+        val client = FakeTmuxClient().withRichInitialFrame("work", "%1")
+        val vm = connectLiveVm(client)
+        assertTrue(vm.revealState.value is RevealState.Live)
+        // Small grace so the bounded hold clears when we advance past it.
+        val graceMs = 1_000L
+        vm.setPassiveDisconnectRecoveryForTest(graceMs = graceMs)
+        vm.setProcessForegroundForClearedForTest(true)
+
+        val diagnostics = installRecordingDiagnosticSink()
+        try {
+            vm.onAppForegrounded(resumedWithinGrace = true)
+            runCurrent()
+            assertTrue(
+                "precondition: the reseed_only path ran; trail=${diagnostics.eventsNamed("cause_trail")}",
+                diagnostics.eventsNamed("cause_trail").any {
+                    it.fields["stage"] == "foreground_reattach" && it.fields["outcome"] == "reseed_only"
+                },
+            )
+            // Advance PAST the grace window so the bounded silent-heal hold is released.
+            advanceTimeBy(graceMs + 500L)
+            runCurrent()
+
+            // A drop now (after the window) must surface normally — the hold is gone.
+            client.markDisconnectedForTest(linkBlipDrop())
+            awaitCondition {
+                diagnostics.eventsNamed("passive_disconnect").isNotEmpty()
+            }
+            runCurrent()
+
+            assertTrue(
+                "after the grace window the hold must be released, so a real drop surfaces " +
+                    "RevealState.Seeding (the reconnect/loading surface) — the arm must NOT mask a " +
+                    "beyond-grace drop; got ${vm.revealState.value}",
+                vm.revealState.value is RevealState.Seeding,
+            )
+            assertFalse(
+                "a genuine post-window drop must NOT be held on the calm Connected status; got " +
+                    "${vm.connectionStatus.value}",
+                vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected,
+            )
+        } finally {
+            diagnostics.close()
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // (3) CONFIRMED-DEAD / dispatch class (D31/G2): the reviewer's reopened gap. On a CLEAN
+    //     CUT the `-CC` socket is already dead by foreground time, so
+    //     `canReseedWithinGraceForeground()` DECLINES the reseed and the within-grace foreground
+    //     takes the HEAL / dispatch path — NOT the reseed_only path. The single-shot heal
+    //     fast-fails a dead/unreachable host and hands off to the loud auto-reconnect ladder,
+    //     whose `Reconnecting` projection paints RevealState.Seeding ("Attaching…") — WITHIN
+    //     grace — because the reveal hold was released the instant the heal job completed.
+    //     LOAD-BEARING: the within-grace confirmed-dead foreground must RIDE THROUGH — NO
+    //     RevealState.Seeding overlay while the honest reconnect runs underneath, for the whole
+    //     bounded grace window. RED on base (Seeding), GREEN with the whole-window hold.
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun confirmedDeadWithinGraceForegroundHoldsLiveRevealNoAttachingOverlay() = runTest(scheduler) {
+        val client = FakeTmuxClient().withRichInitialFrame("work", "%1")
+        val vm = connectLiveVm(client)
+        assertTrue(
+            "precondition: connect reaches RevealState.Live before the confirmed-dead foreground; " +
+                "got ${vm.revealState.value}",
+            vm.revealState.value is RevealState.Live,
+        )
+        // Large grace so the bounded whole-window hold stays armed for the clock-not-advanced window.
+        vm.setPassiveDisconnectRecoveryForTest(graceMs = 300_000L)
+        // A first immediate rung (fails) then a LONG-delayed second rung so the ladder deterministically
+        // PARKS in `Reconnecting` (the honest ongoing reconnect over the dead host — the E2E
+        // `proxy.disable()` state) rather than exhausting to Unreachable. A single `[0]` rung would
+        // exhaust the ladder in one virtual-clock drain; the old harness only survived because the
+        // real-`Dispatchers.IO` teardown hop froze the ladder mid-rung — the exact #1674 flake source.
+        vm.setAutoReconnectDelaysForTest(listOf(0L, 60_000L))
+        // The clean-cut host is unreachable during the window: the heal's silent recovery AND the
+        // ladder's re-dial fail, so the ladder STAYS Reconnecting — a deterministic, non-flaky
+        // reproduction of the confirmed-dead honest reconnect.
+        vm.forceUnrecoverableHostForTest = true
+
+        val diagnostics = installRecordingDiagnosticSink()
+        try {
+            // --- The `-CC` socket dropped WHILE BACKGROUNDED (clean cut) ---
+            // Backgrounded drops are DEFERRED to the single grace owner (no reveal change while
+            // backgrounded), so the live frame is held into the foreground — the exact confirmed-dead
+            // precondition. `client.disconnected` is now true, so the reseed gate correctly DECLINES.
+            vm.setProcessForegroundForClearedForTest(false)
+            client.markDisconnectedForTest(cleanCutDrop())
+            // A backgrounded `-CC` drop records the canonical `passive_disconnect` breadcrumb but
+            // the driver SUPPRESSES the controller submit (single grace owner) — so the controller
+            // stays Live and the reveal holds the live frame (no Seeding while backgrounded).
+            awaitCondition {
+                diagnostics.eventsNamed("passive_disconnect").isNotEmpty()
+            }
+            runCurrent()
+            assertTrue(
+                "precondition: a backgrounded clean cut is DEFERRED — the live frame is held (no " +
+                    "Seeding while backgrounded); got ${vm.revealState.value}",
+                vm.revealState.value is RevealState.Live,
+            )
+
+            // --- Foreground return WITHIN grace over the now-dead `-CC` lease ---
+            vm.setProcessForegroundForClearedForTest(true)
+            vm.onAppForegrounded(resumedWithinGrace = true)
+            // Non-vacuous: the reseed gate DECLINED (dead lease), so the within-grace foreground
+            // took the HEAL / dispatch path, NOT the reseed_only path — the exact reopened class.
+            awaitCondition {
+                diagnostics.eventsNamed("cause_trail").any {
+                    it.fields["stage"] == "foreground_reattach" &&
+                        it.fields["outcome"] == "silent_heal_within_grace"
+                }
+            }
+            assertTrue(
+                "the confirmed-dead foreground must NOT take the reseed_only path (the dead lease " +
+                    "declines it); trail=${diagnostics.eventsNamed("cause_trail")}",
+                diagnostics.eventsNamed("cause_trail").none {
+                    it.fields["stage"] == "foreground_reattach" && it.fields["outcome"] == "reseed_only"
+                },
+            )
+            // Drive the heal to its FAILURE + the loud auto-reconnect ladder engaging — the exact
+            // window the reopened overlay painted. On base the hold is already released here.
+            awaitCondition {
+                diagnostics.eventsNamed("auto_reconnect_decision").any {
+                    it.fields["decision"] == "scheduled"
+                }
+            }
+            runCurrent()
+
+            // LOAD-BEARING: the confirmed-dead within-grace foreground must RIDE THROUGH — the
+            // honest reconnect runs underneath but the reveal HOLDS the live frame: NO
+            // RevealState.Seeding, so the "Attaching…" (TMUX_SWITCHING_LOADING_TAG) overlay never
+            // paints. On base (the whole-window hold missing / released on the heal job) the
+            // ladder's `Reconnecting` projects Seeding → the #754 overlay → RED.
+            assertFalse(
+                "a confirmed-dead within-grace foreground must be RIDDEN THROUGH — the reveal must " +
+                    "NOT drop to RevealState.Seeding (the \"Attaching…\" overlay, #754 reopened); got " +
+                    "${vm.revealState.value}",
+                vm.revealState.value is RevealState.Seeding,
+            )
+            assertTrue(
+                "the confirmed-dead ride-through keeps the reveal on the held LIVE frame; got " +
+                    "${vm.revealState.value}",
+                vm.revealState.value is RevealState.Live,
+            )
+            // The status hold keeps the calm Connected (no Reconnecting bar) across the window.
+            assertTrue(
+                "the confirmed-dead within-grace ride-through keeps the calm Connected status (no " +
+                    "Reconnecting band); got ${vm.connectionStatus.value}",
+                vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected,
+            )
+        } finally {
+            diagnostics.close()
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // (4) NON-MASKING for the confirmed-dead class (bounded hold): after the grace window elapses
+    //     a still-unreachable confirmed-dead host SURFACES RevealState.Seeding (the honest
+    //     reconnect band) — the whole-window hold must never suppress a real BEYOND-grace outage
+    //     into silence.
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun confirmedDeadAfterGraceWindowElapsesStillSurfacesSeedingOverlay() = runTest(scheduler) {
+        val client = FakeTmuxClient().withRichInitialFrame("work", "%1")
+        val vm = connectLiveVm(client)
+        assertTrue(vm.revealState.value is RevealState.Live)
+        val graceMs = 1_000L
+        vm.setPassiveDisconnectRecoveryForTest(graceMs = graceMs)
+        // A first immediate rung (fails) then a LONG-delayed second rung so the ladder stays in
+        // `Reconnecting` (not exhausted to Unreachable) across the assertion window.
+        vm.setAutoReconnectDelaysForTest(listOf(0L, 60_000L))
+        vm.forceUnrecoverableHostForTest = true
+
+        val diagnostics = installRecordingDiagnosticSink()
+        try {
+            vm.setProcessForegroundForClearedForTest(false)
+            client.markDisconnectedForTest(cleanCutDrop())
+            awaitCondition {
+                diagnostics.eventsNamed("passive_disconnect").isNotEmpty()
+            }
+            runCurrent()
+
+            vm.setProcessForegroundForClearedForTest(true)
+            vm.onAppForegrounded(resumedWithinGrace = true)
+            awaitCondition {
+                diagnostics.eventsNamed("cause_trail").any {
+                    it.fields["stage"] == "foreground_reattach" &&
+                        it.fields["outcome"] == "silent_heal_within_grace"
+                }
+            }
+            awaitCondition {
+                diagnostics.eventsNamed("auto_reconnect_decision").any {
+                    it.fields["decision"] == "scheduled"
+                }
+            }
+            // WITHIN grace: the ongoing (failing) reconnect is HELD on the live frame (proves the
+            // hold is genuinely masking the ladder — non-vacuous negative).
+            runCurrent()
+            assertFalse(
+                "precondition: WITHIN grace the confirmed-dead reconnect must be HELD silent (no " +
+                    "Seeding) — else the beyond-grace surfacing below proves nothing; got " +
+                    "${vm.revealState.value}",
+                vm.revealState.value is RevealState.Seeding,
+            )
+            // Advance PAST the grace window so the bounded whole-window hold is released.
+            advanceTimeBy(graceMs + 500L)
+            runCurrent()
+
+            assertTrue(
+                "after the grace window the whole-window hold must be released, so a still-unreachable " +
+                    "confirmed-dead host SURFACES RevealState.Seeding (the honest reconnect surface) — " +
+                    "the hold must NOT mask a beyond-grace outage; got ${vm.revealState.value}",
+                vm.revealState.value is RevealState.Seeding,
+            )
+            assertFalse(
+                "a genuine beyond-grace confirmed-dead outage must NOT be held on the calm Connected " +
+                    "status; got ${vm.connectionStatus.value}",
+                vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected,
+            )
+        } finally {
+            diagnostics.close()
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private fun cleanCutDrop(): TmuxDisconnectEvent =
+        TmuxDisconnectEvent(
+            reason = TmuxDisconnectReason.ReaderEof,
+            source = "clean_cut_confirmed_dead",
+            intent = "unknown",
+        )
+
+    private class SingleSessionConnector(
+        private val session: SshSession,
+    ) : SshLeaseConnector {
+        override suspend fun connect(target: SshLeaseTarget): Result<SshSession> =
+            Result.success(session)
+    }
+
+    private class AlwaysConnectedSession(
+        val id: String,
+    ) : SshSession {
+        @Volatile
+        var closed: Boolean = false
+
+        override val isConnected: Boolean get() = !closed
+
+        override suspend fun exec(command: String): ExecResult =
+            ExecResult(stdout = "", stderr = "", exitCode = 0)
+
+        override fun tail(path: String, onLine: (String) -> Unit): Job =
+            Job().apply { complete() }
+
+        override fun tail(path: String, fromLineExclusive: Long, onLine: (String) -> Unit): Job =
+            Job().apply { complete() }
+
+        override fun openLocalPortForward(
+            remoteHost: String,
+            remotePort: Int,
+            localPort: Int,
+        ): SshPortForward = error("not used")
+
+        override fun startShell(): SshShell = error("not used")
+
+        override suspend fun uploadFile(file: File, remotePath: String): String = error("not used")
+
+        override suspend fun uploadStream(
+            input: InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String = error("not used")
+
+        override fun close() {
+            closed = true
+        }
+    }
+}


### PR DESCRIPTION
## Reopen re-fix (D31) under reliability epic #1670

**Symptom (maintainer, on-device):** a within-grace foreground on a confirmed-dead session paints the `Attaching…` overlay. The #754 fix regressed because its proof only ran in the waived nightly.

**Root cause (round 2):** on a clean cut the `-CC` lease is dead by foreground time → reseed declined → the **heal path** runs, and `launchForegroundHealWithinGrace`'s `invokeOnCompletion` cleared the reveal hold the instant the single-shot heal failed → the ladder's `Reconnecting` painted `RevealState.Seeding` within grace.

**Fix:** single-owner `armWithinGraceSilentHealHold()` armed at the within-grace foreground decision point in `onAppForegrounded` (before the reseed-vs-heal branch), released once after the bounded grace window. Both paths share one owner; the premature clear is deleted.

## Evidence (reviewer-verified, APPROVED)
- Reviewer independently re-ran the exact on-device toxiproxy journey it found RED last round → now GREEN, **zero `TMUX_SWITCHING_LOADING_TAG` frames** across both watch windows, non-vacuous (controller walked `Live→Reattaching→Reconnecting` and reconnected underneath while the reveal held).
- Class-covering deterministic JVM proof (reseed + confirmed-dead/dispatch + 2 beyond-grace negatives) in the **non-waived** `Unit tests` gate; orchestrator re-ran on post-#1641 `main`: 4/0/0, compiles clean.
- Beyond-grace reconnect unaffected; hygiene guards green (VM net-shrink).

Rebased onto post-#1641 `main` (disjoint VM regions; C2 intact).
Reviewer APPROVED: https://github.com/alexeygrigorev/pocketshell/issues/754#issuecomment-5012035233

Closes #754