### PR TITLE
release: v0.4.39 (versionCode 86)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,8 +65,8 @@ android {
         applicationId = "com.pocketshell.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 85
-        versionName = "0.4.38"
+        versionCode = 86
+        versionName = "0.4.39"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/tools/pocketshell/pyproject.toml
+++ b/tools/pocketshell/pyproject.toml
@@ -8,7 +8,7 @@ name = "pocketshell"
 # scripts/check-pypi-version.sh enforces this; .github/workflows/build.yml
 # runs that check before publishing to PyPI. See
 # tools/pocketshell/README.md ("Release flow") for the bump procedure.
-version = "0.4.38"
+version = "0.4.39"
 description = "Unified server-side Python utility for the PocketShell Android client."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Version bump for **v0.4.39** — the connection-manager storm-hardening wave landed on top of v0.4.38.

## What ships
- **#1641** — bounded exec must not close the shared per-host `-CC` lease (the storm root cause; a slow bounded exec previously abandoned the shared lease → reconnect storm). Merged after v0.4.38, so this is the first release carrying the root-cause fix.
- **#1672** — hide the quick-command band while the terminal is held during connect (bottom bar no longer looks operable mid-Attaching).
- **#754** — hold silent-heal across the whole within-grace foreground so a within-grace confirmed-dead resume no longer flashes the `Attaching…` overlay.

## Metadata
- versionName 0.4.38 → **0.4.39**, versionCode 85 → **86**, `tools/pocketshell` 0.4.38 → **0.4.39** (coupling guard OK).

Release-emulator-validation gate runs on the merged `main` before the tag.