### PR TITLE
diagnostics: log dead-detection inputs, not just verdicts (#1683)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/App.kt
+++ b/app/src/main/java/com/pocketshell/app/App.kt
@@ -29,6 +29,8 @@ import com.pocketshell.app.startup.StartupTiming
 import com.pocketshell.app.tmux.TmuxSessionRuntimeCache
 import com.pocketshell.app.tmux.closeCachedRuntime
 import com.pocketshell.app.usage.UsageScheduler
+import com.pocketshell.core.connection.ConnectionDiagnostics
+import com.pocketshell.core.ssh.SshDiagnostics
 import com.pocketshell.core.ssh.SshLeaseManager
 import com.pocketshell.core.tmux.TmuxClientDiagnostics
 import dagger.hilt.android.HiltAndroidApp
@@ -355,6 +357,18 @@ class App : Application() {
         super.onCreate()
         DiagnosticEvents.install(diagnosticRecorder)
         TmuxClientDiagnostics.install { event, fields ->
+            DiagnosticEvents.record("connection", event, *fields.toList().toTypedArray())
+        }
+        // Issue #1683 — forward the connection-core / transport dead-detection
+        // INPUTS (liveness probe ticks + keepalive-coordination consultations;
+        // keepalive misses) into the same `connection`-category timeline as the
+        // verdicts, so they mirror to the host alongside them. Same shape as the
+        // TmuxClientDiagnostics bridge above (the core modules cannot depend on the
+        // app recorder directly).
+        ConnectionDiagnostics.install { event, fields ->
+            DiagnosticEvents.record("connection", event, *fields.toList().toTypedArray())
+        }
+        SshDiagnostics.install { event, fields ->
             DiagnosticEvents.record("connection", event, *fields.toList().toTypedArray())
         }
         DiagnosticEvents.record("app", "created")

--- a/app/src/main/java/com/pocketshell/app/connectivity/TerminalNetworkObserver.kt
+++ b/app/src/main/java/com/pocketshell/app/connectivity/TerminalNetworkObserver.kt
@@ -54,6 +54,18 @@ class TerminalNetworkObserver @Inject constructor(
     private var closed: Boolean = false
 
     /**
+     * Issue #1683 / #1631 — how many default-network callbacks the [detector]
+     * SUPPRESSED (returned null: an idempotent already-lost repeat, or a
+     * same-identity change that emits nothing). These returned before ANY record,
+     * so the #1631 finding "no repeated callbacks in the log" was
+     * unverifiable-BY-CONSTRUCTION: "it didn't happen" and "it happened but wasn't
+     * recorded" were indistinguishable. This counter closes that gap — a
+     * rate-limited `network_change_suppressed` INPUT makes the suppression volume
+     * visible without one line per callback flooding the ring.
+     */
+    private val suppressedCallbackCount = java.util.concurrent.atomic.AtomicLong(0L)
+
+    /**
      * Issue #1098 (item 5) test seam. The synthetic loss/restore proofs
      * ([emitSyntheticSnapshotForTest]) drive a NoValidatedNetwork → Validated
      * sequence through the SAME shared [detector] the real platform callbacks
@@ -157,7 +169,8 @@ class TerminalNetworkObserver @Inject constructor(
         snapshot: TerminalNetworkSnapshot,
         reason: String,
     ): TerminalNetworkChange? {
-        val change = detector.update(snapshot = snapshot, reason = reason) ?: return null
+        val change = detector.update(snapshot = snapshot, reason = reason)
+            ?: return recordSuppressedCallback(reason)
         // Issue #997: the trail outcome is kind-aware so a bare loss / restore is
         // visible in the device trail (not mislabelled as a validated handoff).
         val outcome = when (change.kind) {
@@ -191,6 +204,27 @@ class TerminalNetworkObserver @Inject constructor(
         return change
     }
 
+    /**
+     * Issue #1683 / #1631 — record a SUPPRESSED default-network callback (the
+     * [detector] returned null) as a rate-limited INPUT, then return null so the
+     * caller's suppression semantics are unchanged (diagnostics-only, no behavior
+     * change). The first suppression and then every [SUPPRESSED_LOG_INTERVAL]-th
+     * carry the running total + reason, so the exported trace shows the
+     * suppression VOLUME without one line per callback flooding the shared ring.
+     */
+    private fun recordSuppressedCallback(reason: String): TerminalNetworkChange? {
+        val total = suppressedCallbackCount.incrementAndGet()
+        if (total == 1L || total % SUPPRESSED_LOG_INTERVAL == 0L) {
+            DiagnosticEvents.record(
+                "connection",
+                "network_change_suppressed",
+                "suppressedTotal" to total,
+                "reason" to reason,
+            )
+        }
+        return null
+    }
+
     private fun currentSnapshot(): TerminalNetworkSnapshot {
         val manager = cm ?: return TerminalNetworkSnapshot.NoValidatedNetwork
         val active = manager.activeNetwork ?: return TerminalNetworkSnapshot.NoValidatedNetwork
@@ -217,6 +251,15 @@ class TerminalNetworkObserver @Inject constructor(
 
     companion object {
         private const val TAG = "PsTerminalNetwork"
+
+        /**
+         * Issue #1683 / #1631 — the suppressed-callback rate limit: emit the first
+         * suppression and then every Nth, carrying the running total. Bounds the
+         * volume so a same-identity callback storm cannot flood the shared ring
+         * while still making "the suppression happened, N times" provable.
+         */
+        @androidx.annotation.VisibleForTesting
+        internal const val SUPPRESSED_LOG_INTERVAL = 10L
     }
 }
 

--- a/app/src/main/java/com/pocketshell/app/ssh/BoundedSessionExec.kt
+++ b/app/src/main/java/com/pocketshell/app/ssh/BoundedSessionExec.kt
@@ -108,7 +108,9 @@ object BoundedSessionExec {
         timeoutMs: Long,
         dispatcher: CoroutineDispatcher,
         callerSite: String,
+        nowNanos: () -> Long = { System.nanoTime() },
     ): ExecResult? = withContext(dispatcher) {
+        val startNanos = nowNanos()
         val deferred = async { session.exec(command) }
         val result = withTimeoutOrNull(timeoutMs) { deferred.await() }
         if (result != null) return@withContext result
@@ -119,6 +121,14 @@ object BoundedSessionExec {
         // channel-local by construction (#1567).
         deferred.cancel()
 
+        // Issue #1683 — the actual wall-clock the exec ran before we abandoned it.
+        // A lease-attributable close (or a degraded/empty result) must be pinned to
+        // a specific SITE *and* the LATENCY that tripped it, so the log alone shows
+        // whether the timeout was a genuine dead link or a slow-but-alive host that
+        // over-ran its bound. Diagnostics-only: elapsed is RECORDED, never used in
+        // any close/abandon decision.
+        val elapsedMs = (nowNanos() - startNanos) / 1_000_000L
+
         // The teardown used to be invisible; the abandonment must not be.
         // Recorded BEFORE we return so the breadcrumb exists even if the caller
         // swallows the null into a degraded/empty result (all five do).
@@ -128,6 +138,11 @@ object BoundedSessionExec {
             cause = "exec_no_result_within_bound",
             "callerSite" to callerSite,
             "timeoutMs" to timeoutMs,
+            // Issue #1683 — the INPUT behind the abandonment: the site's measured
+            // latency at the moment we gave up. `timeoutMs` is the bound; `elapsedMs`
+            // is what actually elapsed (≥ the bound), so the two together attribute
+            // the close to "site X over-ran its Nms budget after Mms".
+            "elapsedMs" to elapsedMs,
             // Proof, in the trail itself, that we walked away from a transport
             // that was still ALIVE — the exact fact the silent close destroyed.
             "transportAlive" to session.isConnected,

--- a/app/src/test/java/com/pocketshell/app/connectivity/Issue1683SuppressedNetworkCallbackTest.kt
+++ b/app/src/test/java/com/pocketshell/app/connectivity/Issue1683SuppressedNetworkCallbackTest.kt
@@ -1,0 +1,95 @@
+package com.pocketshell.app.connectivity
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.pocketshell.app.diagnostics.DiagnosticEventSink
+import com.pocketshell.app.diagnostics.DiagnosticEvents
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Issue #1683 (A3) / #1631 — a SUPPRESSED default-network callback (the detector
+ * returns null: an idempotent already-lost repeat, or a same-identity change)
+ * must be recorded as a rate-limited INPUT, so "the callback didn't happen" is
+ * distinguishable from "it happened but wasn't recorded" (the #1631
+ * unverifiable-by-construction gap).
+ *
+ * On base the suppression path (`?: return null`) records NOTHING, so
+ * [firstSuppressionIsRecorded] fails; with the fix the first and every Nth
+ * suppression carry the running total.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class Issue1683SuppressedNetworkCallbackTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val events = mutableListOf<Pair<String, Map<String, Any?>>>()
+
+    @Before
+    fun installSink() {
+        events.clear()
+        DiagnosticEvents.install(
+            object : DiagnosticEventSink {
+                override fun record(category: String, event: String, fields: Map<String, Any?>) {
+                    synchronized(events) { events += "$category/$event" to fields }
+                }
+            },
+        )
+    }
+
+    @After
+    fun removeSink() {
+        DiagnosticEvents.install(DiagnosticEventSink.Noop)
+    }
+
+    @Test
+    fun firstSuppressionIsRecorded() {
+        val observer = TerminalNetworkObserver(context)
+
+        // First NoValidatedNetwork -> NetworkLost (a real change, NOT suppressed).
+        observer.emitSyntheticSnapshotForTest(TerminalNetworkSnapshot.NoValidatedNetwork, "loss")
+        // Second identical NoValidatedNetwork -> already lost -> detector returns
+        // null -> SUPPRESSED.
+        observer.emitSyntheticSnapshotForTest(TerminalNetworkSnapshot.NoValidatedNetwork, "loss-repeat")
+
+        val suppressed = suppressedEvents()
+        assertEquals("the first suppressed callback must be recorded", 1, suppressed.size)
+        assertEquals(
+            "the record carries the running suppression total",
+            1L,
+            (suppressed.single()["suppressedTotal"] as Number).toLong(),
+        )
+        assertTrue("the record carries a reason", suppressed.single()["reason"] != null)
+    }
+
+    @Test
+    fun suppressionIsRateLimited() {
+        val observer = TerminalNetworkObserver(context)
+
+        // One real Lost, then 20 identical repeats that all suppress.
+        observer.emitSyntheticSnapshotForTest(TerminalNetworkSnapshot.NoValidatedNetwork, "loss")
+        repeat(20) {
+            observer.emitSyntheticSnapshotForTest(TerminalNetworkSnapshot.NoValidatedNetwork, "repeat")
+        }
+
+        val totals = suppressedEvents().map { (it["suppressedTotal"] as Number).toLong() }
+        // Rate limit is the first + every 10th (SUPPRESSED_LOG_INTERVAL=10): so 20
+        // suppressions record at totals 1, 10, 20 — NOT one line per callback.
+        assertEquals(
+            "suppressed callbacks must be rate-limited to the 1st + every 10th",
+            listOf(1L, 10L, 20L),
+            totals,
+        )
+    }
+
+    private fun suppressedEvents(): List<Map<String, Any?>> =
+        synchronized(events) {
+            events.filter { it.first == "connection/network_change_suppressed" }.map { it.second }
+        }
+}

--- a/app/src/test/java/com/pocketshell/app/ssh/Issue1683BoundedExecInputBeforeVerdictTest.kt
+++ b/app/src/test/java/com/pocketshell/app/ssh/Issue1683BoundedExecInputBeforeVerdictTest.kt
@@ -1,0 +1,165 @@
+package com.pocketshell.app.ssh
+
+import com.pocketshell.app.diagnostics.DiagnosticEventSink
+import com.pocketshell.app.diagnostics.DiagnosticEvents
+import com.pocketshell.app.diagnostics.ReconnectCauseTrail
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.SshPortForward
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshShell
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Issue #1683 (A3) — the load-bearing acceptance test.
+ *
+ * The connection log has always recorded the VERDICT of a passive disconnect
+ * (`passive_disconnect classification=real_...`) but not the INPUT that produced
+ * it. When our OWN bounded-exec timeout abandons a slow exec on the shared lease
+ * transport (#1641), and a `-CC` reader riding that transport then surfaces a
+ * passive drop, the two were indistinguishable in the trace from a genuine
+ * remote death — because the timeout INPUT lacked the SITE + the LATENCY that
+ * tripped it.
+ *
+ * This test asserts that for a simulated bounded-exec-timeout, the trace shows
+ * the INPUT — `bounded_exec_timeout` at site X with the measured `elapsedMs` —
+ * BEFORE the verdict, on the same correlated timeline. So "self-inflicted vs
+ * real" is decidable from the log ALONE.
+ *
+ * ## Red -> green
+ *
+ * On base, [BoundedSessionExec] records the breadcrumb with `callerSite` +
+ * `timeoutMs` but NO `elapsedMs`, so [inputCarriesSiteAndElapsedBeforeVerdict]
+ * fails at the `elapsedMs` assertion (the field is null). With the fix the
+ * measured latency is recorded and the assertion passes.
+ */
+class Issue1683BoundedExecInputBeforeVerdictTest {
+
+    private val events = mutableListOf<Pair<String, Map<String, Any?>>>()
+
+    @Before
+    fun installSink() {
+        events.clear()
+        DiagnosticEvents.install(
+            object : DiagnosticEventSink {
+                override fun record(category: String, event: String, fields: Map<String, Any?>) {
+                    synchronized(events) { events += "$category/$event" to fields }
+                }
+            },
+        )
+    }
+
+    @After
+    fun removeSink() {
+        DiagnosticEvents.install(DiagnosticEventSink.Noop)
+    }
+
+    @Test
+    fun inputCarriesSiteAndElapsedBeforeVerdict() = runBlocking {
+        val session = WedgingSession()
+
+        // A deterministic clock: nowNanos() is read once at start and once at the
+        // abandonment, so the recorded elapsedMs is exactly 5000 regardless of the
+        // real wall-clock the withTimeoutOrNull(50) used.
+        val clock = AtomicInteger(0)
+        val nanos = longArrayOf(0L, 5_000_000_000L)
+
+        // 1) The INPUT: our own bounded-exec timeout abandons the slow exec.
+        val result = BoundedSessionExec.execBounded(
+            session = session,
+            command = "pocketshell classify",
+            timeoutMs = 50L,
+            dispatcher = Dispatchers.Default,
+            callerSite = "agent_kind_classify",
+            nowNanos = { nanos[clock.getAndIncrement().coerceAtMost(nanos.lastIndex)] },
+        )
+        assertNull("a wedged exec must degrade to null", result)
+
+        // 2) The VERDICT: the -CC reader riding the SAME shared transport later
+        //    surfaces a passive disconnect (what our self-close makes look real).
+        DiagnosticEvents.record(
+            "connection",
+            "passive_disconnect",
+            "classification" to "real_tmux_control_channel_closed",
+        )
+
+        val snapshot = synchronized(events) { events.toList() }
+
+        val inputIndex = snapshot.indexOfFirst {
+            it.first == "${ReconnectCauseTrail.CATEGORY}/${ReconnectCauseTrail.NAME}" &&
+                it.second["stage"] == "bounded_exec_timeout"
+        }
+        val verdictIndex = snapshot.indexOfFirst {
+            it.first == "connection/passive_disconnect"
+        }
+
+        assertTrue("the bounded-exec-timeout INPUT must be recorded", inputIndex >= 0)
+        assertTrue("the verdict must be recorded", verdictIndex >= 0)
+        assertTrue(
+            "the INPUT must precede the verdict on the correlated timeline " +
+                "(inputIndex=$inputIndex verdictIndex=$verdictIndex)",
+            inputIndex < verdictIndex,
+        )
+
+        val input = snapshot[inputIndex].second
+        assertEquals(
+            "the INPUT must attribute the timeout to its SITE",
+            "agent_kind_classify",
+            input["callerSite"],
+        )
+        // The load-bearing NEW field (red on base): the measured latency that
+        // tripped the bound. `timeoutMs` is the bound; `elapsedMs` is what actually
+        // elapsed — together they say "site X over-ran its 50ms budget after 5000ms".
+        assertNotNull(
+            "the INPUT must carry the measured elapsedMs — the latency behind the close",
+            input["elapsedMs"],
+        )
+        assertEquals(
+            "the recorded elapsedMs must be the measured latency (deterministic clock)",
+            5_000L,
+            (input["elapsedMs"] as Number).toLong(),
+        )
+        assertEquals("the bound must still be recorded alongside", 50L, (input["timeoutMs"] as Number).toLong())
+        assertEquals(
+            "the INPUT must record the transport was ALIVE when abandoned",
+            true,
+            input["transportAlive"],
+        )
+    }
+
+    /** A slow-but-ALIVE host: exec never returns within the bound. */
+    private class WedgingSession : SshSession {
+        override val isConnected: Boolean = true
+
+        override suspend fun exec(command: String): ExecResult = awaitCancellation()
+
+        override fun close() = Unit
+
+        override fun tail(path: String, onLine: (String) -> Unit): Job = error("tail not used")
+
+        override fun openLocalPortForward(remoteHost: String, remotePort: Int, localPort: Int): SshPortForward =
+            error("port forward not used")
+
+        override fun startShell(): SshShell = error("shell not used")
+
+        override suspend fun uploadFile(file: File, remotePath: String): String = error("upload not used")
+
+        override suspend fun uploadStream(
+            input: java.io.InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String = error("upload not used")
+    }
+}

--- a/shared/core-connection/src/main/java/com/pocketshell/core/connection/ConnectionDiagnostics.kt
+++ b/shared/core-connection/src/main/java/com/pocketshell/core/connection/ConnectionDiagnostics.kt
@@ -1,0 +1,49 @@
+package com.pocketshell.core.connection
+
+/**
+ * Issue #1683 — the minimal diagnostics seam for the connection core so the
+ * dead-detection INPUTS (per-tick liveness misses + latency, and every
+ * `transportProvenAliveRecently` consultation with its result) land on the SAME
+ * correlated diagnostics timeline as the connection VERDICTS the app already
+ * records.
+ *
+ * ## Why this exists
+ *
+ * The connection log has recorded VERDICTS for a while
+ * (`liveness_probe_silent_drop`, `passive_disconnect classification=...`) but not
+ * the INPUTS behind them — so an over-eager false-dead is indistinguishable from
+ * a real drop in the exported trace. [LivenessProbe] is where the miss run and
+ * the keepalive-coordination consultation happen, but core-connection is a pure
+ * module with no app / android dependency, so it cannot reach the app's
+ * `DiagnosticEvents` directly.
+ *
+ * This is the inversion: a fire-and-forget sink the app installs once at startup
+ * (forwarding into the real recorder under the `connection` category, so these
+ * inputs are mirrored to the host alongside the verdicts). The default is a
+ * no-op, so the pure [LivenessProbe] virtual-clock tests keep running with zero
+ * wiring and the loop's determinism is unchanged — recording is fire-and-forget,
+ * never awaited, so it never perturbs the probe cadence.
+ */
+fun interface ConnectionDiagnosticsSink {
+    fun record(event: String, fields: Map<String, Any?>)
+}
+
+object ConnectionDiagnostics {
+    private val noop = ConnectionDiagnosticsSink { _, _ -> }
+
+    @Volatile
+    private var sink: ConnectionDiagnosticsSink = noop
+
+    fun install(installed: ConnectionDiagnosticsSink) {
+        sink = installed
+    }
+
+    /** Test-only reset back to the no-op sink. */
+    fun reset() {
+        sink = noop
+    }
+
+    fun record(event: String, vararg fields: Pair<String, Any?>) {
+        sink.record(event, fields.toMap())
+    }
+}

--- a/shared/core-connection/src/main/java/com/pocketshell/core/connection/LivenessProbe.kt
+++ b/shared/core-connection/src/main/java/com/pocketshell/core/connection/LivenessProbe.kt
@@ -125,6 +125,14 @@ class LivenessProbe(
      * still recovers a truly-stuck control channel. A virtual-clock test shortens it.
      */
     private val absoluteWedgeBudgetMs: Long = DEFAULT_ABSOLUTE_WEDGE_BUDGET_MS,
+    /**
+     * Issue #1683 — the monotonic clock the per-tick latency INPUT is measured
+     * against. Production uses [System.nanoTime]; a test injects a controllable
+     * clock so the recorded `latencyMs` is deterministic. Diagnostics-only: the
+     * measured latency is RECORDED, never used in any detection decision, so this
+     * cannot change probe behavior.
+     */
+    private val nowNanos: () -> Long = { System.nanoTime() },
     private val log: (String) -> Unit = {},
 ) {
     init {
@@ -255,10 +263,21 @@ class LivenessProbe(
                     wedgedFailureTicks = 0
                     continue
                 }
+                val probeStartNanos = nowNanos()
                 val alive = runProbe()
+                val latencyMs = (nowNanos() - probeStartNanos) / 1_000_000L
                 if (alive) {
                     if (consecutiveFailures != 0) {
                         log("liveness-probe recovered after $consecutiveFailures failure(s)")
+                        // Issue #1683 — record the first success AFTER a miss run as an
+                        // INPUT: it is the evidence that the run was a slow-but-live
+                        // blip rather than a real death (a false-dead would NOT recover).
+                        ConnectionDiagnostics.record(
+                            "liveness_probe_tick",
+                            "result" to "recovered",
+                            "latencyMs" to latencyMs,
+                            "afterConsecutiveMisses" to consecutiveFailures,
+                        )
                     }
                     // A successful `-CC` probe clears the failure run: the control
                     // channel is answering again, so the slow-but-live blip is over
@@ -271,6 +290,17 @@ class LivenessProbe(
                     log(
                         "liveness-probe failed consecutive=$consecutiveFailures " +
                             "threshold=$failureThreshold",
+                    )
+                    // Issue #1683 — record every MISS tick as an INPUT (miss count +
+                    // latency), rate-limited by construction to misses only (a healthy
+                    // link records nothing). This is the per-tick series behind the
+                    // `liveness_probe_silent_drop` VERDICT, so a false-dead is provable.
+                    ConnectionDiagnostics.record(
+                        "liveness_probe_tick",
+                        "result" to "miss",
+                        "latencyMs" to latencyMs,
+                        "consecutiveMisses" to consecutiveFailures,
+                        "failureThreshold" to failureThreshold,
                     )
                     if (consecutiveFailures >= failureThreshold) {
                         // Re-check the gate immediately before acting: a
@@ -289,6 +319,23 @@ class LivenessProbe(
                             // interval (virtual-clock friendly — see wedgedFailureTicks).
                             val wedgedForMs = wedgedFailureTicks.toLong() * intervalMs
                             val absoluteWedgeTripped = wedgedForMs >= absoluteWedgeBudgetMs
+                            // Issue #1683 — record EVERY `transportProvenAliveRecently`
+                            // consultation and its answer. This is THE input to the
+                            // defer-vs-escalate branch below: whether the following
+                            // `liveness_probe_silent_drop` verdict was an over-eager
+                            // false-dead (keepalive still proving alive, escalated only by
+                            // the wedge backstop) or a real death (keepalive stopped
+                            // proving alive) is decidable from the log alone only if this
+                            // input is on the same timeline as the verdict.
+                            ConnectionDiagnostics.record(
+                                "liveness_probe_keepalive_consult",
+                                "keepAliveProvesAlive" to keepAliveProvesAlive,
+                                "consecutiveMisses" to consecutiveFailures,
+                                "wedgedForMs" to wedgedForMs,
+                                "absoluteWedgeBudgetMs" to absoluteWedgeBudgetMs,
+                                "absoluteWedgeTripped" to absoluteWedgeTripped,
+                                "willDeclareDrop" to (!keepAliveProvesAlive || absoluteWedgeTripped),
+                            )
                             if (keepAliveProvesAlive && !absoluteWedgeTripped) {
                                 // Issue #982/#984 — DEFER to the transport keepalive
                                 // UNCONDITIONALLY (no deferral count, no time ceiling).

--- a/shared/core-connection/src/test/java/com/pocketshell/core/connection/Issue1683LivenessProbeInputTest.kt
+++ b/shared/core-connection/src/test/java/com/pocketshell/core/connection/Issue1683LivenessProbeInputTest.kt
@@ -1,0 +1,150 @@
+package com.pocketshell.core.connection
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Issue #1683 (A3) — [LivenessProbe] records the dead-detection INPUTS, not just
+ * the eventual `liveness_probe_silent_drop` VERDICT:
+ *  - every MISS tick (miss count + latency),
+ *  - every `transportProvenAliveRecently` consultation and its RESULT — the
+ *    input to the defer-vs-escalate branch that decides whether the drop is an
+ *    over-eager false-dead or a real death.
+ *
+ * On base the probe emits nothing to the diagnostics timeline (only `log()`
+ * lines), so both assertions fail; with the fix the inputs are on the same
+ * correlated timeline as the verdict.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class Issue1683LivenessProbeInputTest {
+
+    private val events = mutableListOf<Pair<String, Map<String, Any?>>>()
+
+    @Before
+    fun installSink() {
+        events.clear()
+        ConnectionDiagnostics.install { event, fields ->
+            synchronized(events) { events += event to fields }
+        }
+    }
+
+    @After
+    fun removeSink() {
+        ConnectionDiagnostics.reset()
+    }
+
+    private class ScriptedIo(
+        private val results: ArrayDeque<Boolean>,
+        val keepAliveProvesAlive: Boolean,
+    ) : LivenessProbe.ProbeIo {
+        var onProbeFailedCount = 0
+            private set
+
+        override fun shouldProbe(): Boolean = true
+        override suspend fun probe(): Boolean = results.removeFirstOrNull() ?: true
+        override fun onProbeFailed(consecutiveFailures: Int) {
+            onProbeFailedCount++
+        }
+        override fun transportProvenAliveRecently(): Boolean = keepAliveProvesAlive
+    }
+
+    @Test
+    fun `miss ticks and the keepalive consultation are recorded before the drop`() =
+        runTest(StandardTestDispatcher()) {
+            // A monotonic clock advancing 12ms per read so latencyMs is deterministic.
+            var t = 0L
+            val io = ScriptedIo(ArrayDeque(listOf(false, false)), keepAliveProvesAlive = false)
+            val probe = LivenessProbe(
+                io = io,
+                intervalMs = 100,
+                perProbeTimeoutMs = 1_000,
+                failureThreshold = 2,
+                nowNanos = { (t++) * 12_000_000L },
+            )
+            probe.start(this)
+
+            advanceTimeBy(110) // first miss
+            runCurrent()
+            advanceTimeBy(110) // second miss -> threshold -> consult -> drop
+            runCurrent()
+
+            assertEquals("the drop must fire once", 1, io.onProbeFailedCount)
+
+            val ticks = synchronized(events) { events.filter { it.first == "liveness_probe_tick" } }
+            val misses = ticks.filter { it.second["result"] == "miss" }
+            assertTrue("both miss ticks must be recorded as INPUTS", misses.size >= 2)
+            val firstMiss = misses.first().second
+            assertEquals("miss tick carries the running miss count", 1L, (firstMiss["consecutiveMisses"] as Number).toLong())
+            assertNotNull("miss tick carries per-tick latency", firstMiss["latencyMs"])
+            assertEquals(
+                "miss tick carries the threshold it is climbing toward",
+                2L,
+                (firstMiss["failureThreshold"] as Number).toLong(),
+            )
+
+            val consults = synchronized(events) {
+                events.filter { it.first == "liveness_probe_keepalive_consult" }
+            }
+            assertEquals("exactly one keepalive consultation preceded the drop", 1, consults.size)
+            val consult = consults.single().second
+            assertEquals(
+                "the consultation records the keepalive answer (the INPUT to defer-vs-escalate)",
+                false,
+                consult["keepAliveProvesAlive"],
+            )
+            assertEquals(
+                "with the keepalive NOT proving alive, the probe declares the drop",
+                true,
+                consult["willDeclareDrop"],
+            )
+
+            probe.stop()
+        }
+
+    @Test
+    fun `a deferred-to-keepalive consultation records that no drop will fire`() =
+        runTest(StandardTestDispatcher()) {
+            // Keepalive proves the transport alive: the probe DEFERS (no drop), and
+            // the consultation must record that decision — a false-dead avoided is
+            // exactly what an over-eager-vs-real audit needs to see.
+            val io = ScriptedIo(ArrayDeque(listOf(false, false)), keepAliveProvesAlive = true)
+            val probe = LivenessProbe(
+                io = io,
+                intervalMs = 100,
+                perProbeTimeoutMs = 1_000,
+                failureThreshold = 2,
+                absoluteWedgeBudgetMs = 1_000_000,
+            )
+            probe.start(this)
+
+            advanceTimeBy(220)
+            runCurrent()
+
+            assertEquals("keepalive proving alive must suppress the drop", 0, io.onProbeFailedCount)
+            val consults = synchronized(events) {
+                events.filter { it.first == "liveness_probe_keepalive_consult" }
+            }
+            assertTrue("the consultation must be recorded even when it DEFERS", consults.isNotEmpty())
+            assertEquals(
+                "the deferred consultation records keepalive proven alive",
+                true,
+                consults.first().second["keepAliveProvesAlive"],
+            )
+            assertEquals(
+                "and records that no drop will fire",
+                false,
+                consults.first().second["willDeclareDrop"],
+            )
+
+            probe.stop()
+        }
+}

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshDiagnostics.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshDiagnostics.kt
@@ -1,0 +1,44 @@
+package com.pocketshell.core.ssh
+
+/**
+ * Issue #1683 — the minimal transport-level diagnostics seam for core-ssh.
+ *
+ * core-ssh previously emitted NOTHING to the diagnostics timeline (the #1642
+ * finding, restated by the #1680 Track A audit): keepalive misses, the
+ * ride-through window state, and every transport-liveness input were recorded
+ * only as `Level.FINE` logger lines that never reach the exported connection
+ * trace. So a transport-keepalive-driven death showed up in the log as a bare
+ * VERDICT (`KeepaliveDead` close) with none of the INPUTS (which tick missed,
+ * how many consecutive) that would let us tell an over-eager false-dead from a
+ * real silent-peer death.
+ *
+ * Like [com.pocketshell.core.connection.ConnectionDiagnostics], this is a
+ * fire-and-forget sink the app installs once at startup, forwarding into the
+ * real recorder under the `connection` category (so keepalive inputs are
+ * mirrored to the host alongside the verdicts). The default is a no-op, so the
+ * pure [TransportKeepAlive] virtual-clock tests keep running with zero wiring
+ * and the loop cadence is unchanged — recording is never awaited.
+ */
+fun interface SshDiagnosticsSink {
+    fun record(event: String, fields: Map<String, Any?>)
+}
+
+object SshDiagnostics {
+    private val noop = SshDiagnosticsSink { _, _ -> }
+
+    @Volatile
+    private var sink: SshDiagnosticsSink = noop
+
+    fun install(installed: SshDiagnosticsSink) {
+        sink = installed
+    }
+
+    /** Test-only reset back to the no-op sink. */
+    fun reset() {
+        sink = noop
+    }
+
+    fun record(event: String, vararg fields: Pair<String, Any?>) {
+        sink.record(event, fields.toMap())
+    }
+}

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/TransportKeepAlive.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/TransportKeepAlive.kt
@@ -316,13 +316,37 @@ internal class TransportKeepAlive(
                     }
                     consecutiveMisses += 1
                     log("keepalive: miss consecutive=$consecutiveMisses countMax=$countMax")
+                    // Issue #1683 — record every keepalive MISS as a transport-level
+                    // INPUT (miss count + the death budget it is climbing toward). This
+                    // is the per-tick series behind a `KeepaliveDead` VERDICT: core-ssh
+                    // emitted nothing to the trace before, so a keepalive-driven death
+                    // showed up with none of the inputs that tell an over-eager
+                    // false-dead from a real silent-peer death.
+                    SshDiagnostics.record(
+                        "keepalive_miss",
+                        "consecutiveMisses" to consecutiveMisses,
+                        "countMax" to countMax,
+                    )
                     if (consecutiveMisses >= countMax) {
                         // Re-check liveness before acting: a teardown could have
                         // raced in during the send, in which case the existing
                         // close path already owns recovery and an extra reaction
                         // would be a spurious teardown.
                         if (io.isAlive()) {
-                            if (io.lastActivityNanos() != missStreakStartActivityNanos) {
+                            val inboundAdvanced =
+                                io.lastActivityNanos() != missStreakStartActivityNanos
+                            // Issue #1683 — record the death-budget crossing and WHICH
+                            // way it resolved: rode through (inbound advanced during the
+                            // streak → slow-but-alive) vs declared dead (sustained
+                            // silence). This is the INPUT to the `KeepaliveDead` verdict.
+                            SshDiagnostics.record(
+                                "keepalive_death_budget_crossed",
+                                "consecutiveMisses" to consecutiveMisses,
+                                "countMax" to countMax,
+                                "inboundActivityAdvanced" to inboundAdvanced,
+                                "outcome" to if (inboundAdvanced) "rode_through" else "declared_dead",
+                            )
+                            if (inboundAdvanced) {
                                 // Issue #1059 (R2) / #1072 — slow-but-alive: inbound
                                 // activity OR outbound upload progress advanced during
                                 // the streak, so the peer DID answer (late) or we are

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/Issue1683KeepAliveInputTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/Issue1683KeepAliveInputTest.kt
@@ -1,0 +1,82 @@
+package com.pocketshell.core.ssh
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Issue #1683 (A3) — the transport keepalive records its INPUTS through the new
+ * minimal core-ssh diagnostics seam ([SshDiagnostics]). core-ssh previously
+ * emitted NOTHING to the exported trace, so a `KeepaliveDead` VERDICT arrived
+ * with none of the per-tick miss inputs that tell an over-eager false-dead from
+ * a real silent-peer death.
+ *
+ * On base [SshDiagnostics] does not exist and the loop records nothing, so these
+ * assertions fail; with the fix every miss and the death-budget crossing are on
+ * the timeline.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class Issue1683KeepAliveInputTest {
+
+    private val events = mutableListOf<Pair<String, Map<String, Any?>>>()
+
+    @Before
+    fun installSink() {
+        events.clear()
+        SshDiagnostics.install { event, fields ->
+            synchronized(events) { events += event to fields }
+        }
+    }
+
+    @After
+    fun removeSink() {
+        SshDiagnostics.reset()
+    }
+
+    private class FakeIo : TransportKeepAlive.KeepAliveIo {
+        override fun isAlive(): Boolean = true
+        override fun lastInboundActivityNanos(): Long = Long.MIN_VALUE
+        override fun lastOutboundActivityNanos(): Long = Long.MIN_VALUE
+        override suspend fun sendKeepAlive(): Boolean = false // dead peer: every ping misses
+        override fun onKeepAliveDead(consecutiveMisses: Int) = Unit
+    }
+
+    @Test
+    fun `every keepalive miss and the death-budget crossing are recorded as inputs`() = runTest {
+        val keepAlive = TransportKeepAlive(io = FakeIo(), intervalMs = 1_000L, countMax = 3)
+        keepAlive.start(this)
+
+        advanceTimeBy(1_000L); runCurrent() // miss 1
+        advanceTimeBy(1_000L); runCurrent() // miss 2
+        advanceTimeBy(1_000L); runCurrent() // miss 3 -> death budget crossed
+
+        val misses = synchronized(events) { events.filter { it.first == "keepalive_miss" } }
+        assertEquals("every miss tick is an INPUT", 3, misses.size)
+        assertEquals("first miss carries the running count", 1L, (misses[0].second["consecutiveMisses"] as Number).toLong())
+        assertEquals("third miss carries the running count", 3L, (misses[2].second["consecutiveMisses"] as Number).toLong())
+        assertEquals("miss carries the death budget it climbs toward", 3L, (misses[0].second["countMax"] as Number).toLong())
+
+        val crossings = synchronized(events) {
+            events.filter { it.first == "keepalive_death_budget_crossed" }
+        }
+        assertTrue("the death-budget crossing must be recorded", crossings.isNotEmpty())
+        assertEquals(
+            "a sustained-silence crossing declares dead (no inbound advance)",
+            "declared_dead",
+            crossings.last().second["outcome"],
+        )
+        assertEquals(
+            "and records that inbound activity did NOT advance during the streak",
+            false,
+            crossings.last().second["inboundActivityAdvanced"],
+        )
+
+        keepAlive.stop()
+    }
+}


### PR DESCRIPTION
Part of the #1680 storm root-cause diagnostics. Records the INPUTS behind dead-detection verdicts so an over-eager FALSE-dead is distinguishable from a REAL drop from the log alone (the gap that made the existing logging unable to diagnose the storm).

- Minimal no-op-default `ConnectionDiagnostics` / `SshDiagnostics` sinks (core-ssh emitted nothing before).
- Liveness probe miss+latency + every `transportProvenAliveRecently` consult; keepalive miss + death-budget-crossed; `bounded_exec_timeout` breadcrumb with site+elapsed; #1631 suppressed-network-callback counter.
- Diagnostics-only, no detection behavior change (reviewer-verified G1 red→green this run).

Reviewer: APPROVED (#1683). Local: 4 Issue1683 tests red→green; core-connection 152/0; A3's own core-ssh test green isolated. NOTE: `:shared:core-ssh:testDebugUnitTest` full-module has a PRE-EXISTING order-dependent flake (`SshConnectionFailureTest` real TCP connect leaking async — filed as #1689), orthogonal to this diagnostics-only change.

Closes #1683