### PR TITLE
diagnostics: instrument the composer outbound queue (#1682)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/composer/ComposerQueueDiagnostics.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/ComposerQueueDiagnostics.kt
@@ -1,0 +1,215 @@
+package com.pocketshell.app.composer
+
+import com.pocketshell.app.diagnostics.DiagnosticEvents
+import com.pocketshell.app.diagnostics.DiagnosticPrivacy
+
+/**
+ * Issue #1682 (Track A + Track C): the composer outbound queue's diagnostic
+ * surface — the missing-logging half of the "the queue clogs because it thinks
+ * the connection is gone" diagnosis.
+ *
+ * Before this, the entire drain-gate decision path recorded NOTHING (the queue
+ * store logged zero; the drain gate emitted zero), so the clog was invisible in
+ * a real device trace. Track C found the clog is caused by the drain being
+ * hard-gated on the `ConnectionStatus` enum (`TmuxSessionScreen.kt:425`) — so the
+ * SMOKING-GUN signal is **enum-vs-transport disagreement**: the enum says
+ * not-Connected while the wire is actually alive. [windowFlip] captures exactly
+ * that pairing (the drain-window `sessionLive` boolean AND the `ConnectionStatus`
+ * that drove it) so, cross-referenced with the `connection`-category transport
+ * events on the SAME correlated timeline, the disagreement becomes readable.
+ *
+ * ## Category — `queue`, mirrored to the host (like `connection`, unlike `action`)
+ *
+ * These events use the [CATEGORY] `queue`, which [com.pocketshell.app.diagnostics.MirroredDiagnostics]
+ * mirrors to the host connection log (`~/.pocketshell/connection-log.jsonl`) as a
+ * WHOLE category — so a real-world clog reaches the maintainer's box alongside the
+ * connection lifecycle it disagreed with. It is deliberately NOT the `action`
+ * category (67 device-only user-behaviour events that would burn mobile data for
+ * zero connection diagnosis).
+ *
+ * ## Redaction — ids and sizes only, never raw content
+ *
+ * Consistent with the existing log (`DiagnosticRedactor`): NO raw message text is
+ * ever recorded. A session key is a directory path by construction
+ * ([com.pocketshell.app.tmux.SessionNameDerivation]) so it is passed through
+ * [DiagnosticPrivacy.stableFingerprint] here — the SAME fingerprint the
+ * `connection`-category events use, so the queue timeline correlates to the
+ * connection timeline by `sessionFingerprint`. The message payload is reduced to
+ * its `itemId` (a random UUID, not content-derived) and `textLength` (a size).
+ *
+ * Diagnostics-only: this object records the queue's behaviour, it never changes
+ * it (issue #1682 is the VISIBILITY half; the enum-decoupling FIX is separate).
+ */
+internal object ComposerQueueDiagnostics {
+
+    /** The mirrored queue-diagnostic category (see [com.pocketshell.app.diagnostics.MirroredDiagnostics]). */
+    const val CATEGORY: String = "queue"
+
+    /**
+     * A message durably committed `Queued` (write-ahead), pre-drain. Ids/sizes
+     * only — NEVER the raw prompt text. A `#961` coalesced re-Send onto an
+     * existing un-delivered row surfaces here as a REPEATED [OutboundItem.id]
+     * (the kept row's id), so coalescing is readable from the timeline without a
+     * separate flag.
+     */
+    fun enqueue(item: OutboundItem) {
+        record(
+            "enqueue",
+            "itemId" to item.id,
+            "sessionFingerprint" to fingerprint(item.sessionKey),
+            "textLength" to item.cleanText.length,
+            "attachmentCount" to item.attachments.size,
+            "route" to item.route.name,
+            "agentKind" to item.agentKind,
+            "attemptCount" to item.attemptCount,
+        )
+    }
+
+    /**
+     * The drain window opening/closing, WITH [sessionLive] AND the
+     * [connectionStatusLabel] that drove it — the enum-vs-transport disagreement
+     * capture. Recorded only on a genuine flip (the controller dedups), so it
+     * marks the exact edge at which queued rows start/stop being attempted.
+     */
+    fun windowFlip(
+        sessionLive: Boolean,
+        connectionStatusLabel: String,
+        targetSessionKey: String,
+    ) {
+        record(
+            "window_flip",
+            "sessionLive" to sessionLive,
+            "connectionStatus" to connectionStatusLabel,
+            "sessionFingerprint" to fingerprint(targetSessionKey),
+        )
+    }
+
+    /**
+     * One drain tick's outcome: `dispatched` (a row went to the wire), `not_live`
+     * (the gate was shut — enum not-Connected — so nothing was attempted, the
+     * clog's core symptom), `all_suppressed` (every eligible row is within its
+     * re-dispatch backoff or budget-parked), `in_flight` (a send already owns the
+     * wire), `no_target` / `handoff` (transient self-gates).
+     */
+    fun drainAttempt(
+        outcome: String,
+        sessionKey: String?,
+        dispatchedId: String? = null,
+        queueDepth: Int = 0,
+        suppressedCount: Int = 0,
+        parkedCount: Int = 0,
+        sendInFlight: Boolean = false,
+    ) {
+        record(
+            "drain_attempt",
+            "outcome" to outcome,
+            "sessionFingerprint" to sessionKey?.let { fingerprint(it) },
+            "dispatchedId" to dispatchedId,
+            "queueDepth" to queueDepth,
+            "suppressedCount" to suppressedCount,
+            "parkedCount" to parkedCount,
+            "sendInFlight" to sendInFlight,
+        )
+    }
+
+    /**
+     * A durable row state transition with its [reason] — especially the
+     * park-at-[OUTBOUND_MAX_AUTO_ATTEMPTS] (`reason=budget_exhausted`) and whether
+     * a connected-edge recovery (`reason=stale_inflight_requeue` / `resend_all` /
+     * `manual_retry`) un-parks it. [attemptCount] is the row's post-transition
+     * budget so the trace shows a row climbing toward the park.
+     */
+    fun rowState(
+        itemId: String,
+        sessionKey: String,
+        from: String?,
+        to: String,
+        reason: String,
+        attemptCount: Int,
+    ) {
+        record(
+            "row_state",
+            "itemId" to itemId,
+            "sessionFingerprint" to fingerprint(sessionKey),
+            "fromState" to from,
+            "toState" to to,
+            "reason" to reason,
+            "attemptCount" to attemptCount,
+        )
+    }
+
+    /**
+     * Record one auto-flush drain cycle from the VM in a SINGLE call (keeps the
+     * ratcheted VM tiny): the per-row PARK (→`Failed`, `reason=budget_exhausted`)
+     * for each budget-exhausted head, then the tick outcome — `dispatched` (a row
+     * went to the wire) or `all_suppressed` (every eligible row is within its
+     * re-dispatch backoff or is budget-parked). A no-op when the target has no
+     * undelivered row, so an idle poll tick records nothing.
+     */
+    fun recordDrainCycle(
+        sessionKey: String,
+        items: List<OutboundItem>,
+        plan: ComposerAutoFlushPlan,
+        suppressedCount: Int,
+        dispatched: Boolean,
+    ) {
+        val queueDepth = items.count { it.sessionKey == sessionKey && it.isComposerQueueUndelivered() }
+        if (queueDepth == 0) return
+        val byId = items.associateBy { it.id }
+        plan.parkIds.forEach { id ->
+            byId[id]?.let { item ->
+                item.recordQueueRowState(from = item.state.name, to = "Failed", reason = "budget_exhausted")
+            }
+        }
+        drainAttempt(
+            outcome = if (dispatched) "dispatched" else "all_suppressed",
+            sessionKey = sessionKey,
+            dispatchedId = plan.nextId.takeIf { dispatched },
+            queueDepth = queueDepth,
+            suppressedCount = suppressedCount,
+            parkedCount = plan.parkIds.size,
+        )
+    }
+
+    /** The wedge discriminator's verdict at a recovery decision (issue #1621 / #1602). */
+    fun wedgeVerdict(wedged: Boolean, owningInFlightCount: Int, sendInFlight: Boolean) {
+        record(
+            "wedge_verdict",
+            "wedged" to wedged,
+            "owningInFlightCount" to owningInFlightCount,
+            "sendInFlight" to sendInFlight,
+        )
+    }
+
+    /** The overall-send watchdog fired — a delivery wedged past its budget (issue #891). */
+    fun watchdogTimeout(attachmentCount: Int, hadInFlightRequest: Boolean) {
+        record(
+            "watchdog_timeout",
+            "attachmentCount" to attachmentCount,
+            "hadInFlightRequest" to hadInFlightRequest,
+        )
+    }
+
+    private fun fingerprint(sessionKey: String): String =
+        DiagnosticPrivacy.stableFingerprint(sessionKey)
+
+    private fun record(event: String, vararg fields: Pair<String, Any?>) {
+        DiagnosticEvents.record(CATEGORY, event, *fields)
+    }
+}
+
+/**
+ * Issue #1682: thin call-site shim so the byte-ratcheted `PromptComposerViewModel`
+ * (a D28 god-object) grows as little as possible — each transition site is one
+ * short call. Records THIS row's post-transition state + budget.
+ */
+internal fun OutboundItem.recordQueueRowState(from: String?, to: String, reason: String) {
+    ComposerQueueDiagnostics.rowState(
+        itemId = id,
+        sessionKey = sessionKey,
+        from = from,
+        to = to,
+        reason = reason,
+        attemptCount = attemptCount,
+    )
+}

--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerOutboundSend.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerOutboundSend.kt
@@ -452,6 +452,8 @@ internal suspend fun PromptComposerViewModel.enqueueSidecarBackedSend(
     if (queuedItem.id != itemId) {
         outboundAttachmentSidecarStore?.removeOutboundItem(itemId)
     }
+    // Issue #1682: record the write-ahead commit on the mirrored `queue` timeline.
+    ComposerQueueDiagnostics.enqueue(queuedItem)
     outboundHandoffCommitForTest?.invoke(queuedItem)
     // Enqueue only. The normal FIFO drain owns upload, claim, watchdog,
     // singleton request state, and wire emission.
@@ -478,6 +480,8 @@ internal suspend fun PromptComposerViewModel.enqueueOutboundSend(
         // existing un-delivered row instead of minting a duplicate.
         sendKey = computeSendKey(cleanDraft, attachments, withEnter, sendTarget),
     )
+    // Issue #1682: record the write-ahead commit on the mirrored `queue` timeline.
+    ComposerQueueDiagnostics.enqueue(item)
     outboundHandoffCommitForTest?.invoke(item)
     return item
 }

--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerRetryGate.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerRetryGate.kt
@@ -70,7 +70,22 @@ internal fun PromptComposerViewModel.activeSendIsWedged(nowMs: Long = clock()): 
  * tap re-arms the row and lets the existing FIFO drain claim it after A resolves.
  */
 internal fun PromptComposerViewModel.retryOutboundItemThroughGate(id: String) {
-    if (_uiState.value.sendInFlight && !activeSendIsWedged()) {
+    val inFlight = _uiState.value.sendInFlight
+    val wedged = inFlight && activeSendIsWedged()
+    if (inFlight) {
+        // Issue #1682: record the wedge discriminator's verdict at this recovery
+        // decision (a wedged in-flight send is the #1602 clog the strand-clear rescues).
+        val owningInFlight = composerTarget?.takeIf { it.isNotBlank() }
+            ?.let { outboundQueueStore.itemsFor(it) }
+            ?.count { it.state == OutboundState.InFlight || it.state == OutboundState.Uploading }
+            ?: 0
+        ComposerQueueDiagnostics.wedgeVerdict(
+            wedged = wedged,
+            owningInFlightCount = owningInFlight,
+            sendInFlight = true,
+        )
+    }
+    if (inFlight && !wedged) {
         rearmOutboundItemForDrain(id)
         return
     }
@@ -101,5 +116,9 @@ private fun PromptComposerViewModel.rearmOutboundItemForDrain(id: String) {
     val item = outboundQueueStore.item(id) ?: return
     if (!item.isComposerQueueRetryable()) return
     outboundQueueStore.requeueForRetry(id, resetAttempts = true)
+    // Issue #1682: a user's manual Retry un-parks a row (esp. a budget-parked
+    // Failed one) — the trace shows whether a stuck row recovered by hand vs the
+    // connected edge (which does NOT auto-un-park it, the Track C clog signal).
+    item.recordQueueRowState(item.state.name, "Queued", "manual_retry")
     refreshOutboundQueueItemsFor(item.sessionKey)
 }

--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerViewModel.kt
@@ -1205,6 +1205,7 @@ public class PromptComposerViewModel @Inject constructor(
             restoreFailedSend(request, message = noRowFallbackMessage)
             return
         }
+        requeued.recordQueueRowState("InFlight", "Queued", "deferred") // #1682
         DiagnosticEvents.record(
             "action",
             "composer_send_deferred_to_queue",
@@ -1514,15 +1515,18 @@ public class PromptComposerViewModel @Inject constructor(
         val target = composerTarget?.takeIf { it.isNotBlank() } ?: return null
         // Issue #1602: PARK an auto-retry-exhausted head (Failed, surfaced) so the
         // drain skips it and the healthy tail drains; per-row Retry re-drives it.
-        val plan = _outboundQueueItems.value.planComposerAutoFlush(target, excludingIds)
+        val itemsSnapshot = _outboundQueueItems.value
+        val plan = itemsSnapshot.planComposerAutoFlush(target, excludingIds)
         if (plan.parkIds.isNotEmpty()) {
             plan.parkIds.forEach {
                 outboundQueueStore.markFailed(it, lastError = OUTBOUND_AUTO_RETRY_EXHAUSTED_MESSAGE)
             }
             refreshOutboundQueueItemsFor(target)
         }
-        val nextId = plan.nextId ?: return null
-        return if (dispatchOutboundItem(nextId)) nextId else null
+        val nextId = plan.nextId
+        val dispatched = nextId != null && dispatchOutboundItem(nextId)
+        ComposerQueueDiagnostics.recordDrainCycle(target, itemsSnapshot, plan, excludingIds.size, dispatched) // #1682
+        return if (dispatched) nextId else null
     }
 
     /**
@@ -1576,6 +1580,7 @@ public class PromptComposerViewModel @Inject constructor(
         val target = composerTarget?.takeIf { it.isNotBlank() } ?: return emptyList()
         val cutoffMs = clock() - staleAfterMs
         val requeued = outboundQueueStore.requeueStaleInFlight(target, cutoffMs)
+        requeued.forEach { it.recordQueueRowState("InFlight", "Queued", "stale_inflight_requeue") } // #1682
         if (requeued.isNotEmpty()) refreshOutboundQueueItemsFor(target)
         return requeued
     }
@@ -1733,10 +1738,12 @@ public class PromptComposerViewModel @Inject constructor(
             clearStrandedSendInFlight()
             return false
         }
+        active.recordQueueRowState("Queued", "InFlight", "claimed") // #1682
         val attachments = active.attachments.toStagedAttachments()
         val text = appendAttachmentPaths(active.cleanText, attachments.map { it.remotePath })
         if (text.isEmpty()) {
             outboundQueueStore.markFailed(id, lastError = "Nothing to send")
+            active.recordQueueRowState("InFlight", "Failed", "nothing_to_send") // #1682
             refreshOutboundQueueItemsFor(active.sessionKey)
             clearStrandedSendInFlight()
             return false
@@ -1773,6 +1780,7 @@ public class PromptComposerViewModel @Inject constructor(
 
     private fun markOutboundSendDelivered(request: SendRequest?) {
         val id = request?.outboundQueueItemId ?: return
+        outboundQueueStore.item(id)?.recordQueueRowState("InFlight", "Sent", "delivered")
         outboundQueueStore.markDelivered(id)
         launchSidecarRemoval(id)
         request.sendTarget.sessionKey

--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerWatchdogEffects.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerWatchdogEffects.kt
@@ -47,6 +47,13 @@ internal fun PromptComposerViewModel.onSendWatchdogExpired() {
         "composer_send_watchdog_timeout",
         "attachmentCount" to request.attachments.size,
     )
+    // Issue #1682: also surface the wedged-send timeout on the mirrored `queue`
+    // timeline (the `action` copy above stays device-only) so a delivery that
+    // wedged past its budget is visible in a real host-mirrored trace.
+    ComposerQueueDiagnostics.watchdogTimeout(
+        attachmentCount = request.attachments.size,
+        hadInFlightRequest = inFlightSendRequest != null,
+    )
     // Issue #971/#987: a wedged send is a connection problem, not a permanent
     // rejection — defer it to the queue so it auto-retries on reconnect
     // (Option A). When the request owns a durable queue row this keeps it

--- a/app/src/main/java/com/pocketshell/app/diagnostics/MirroredDiagnostics.kt
+++ b/app/src/main/java/com/pocketshell/app/diagnostics/MirroredDiagnostics.kt
@@ -46,6 +46,18 @@ internal object MirroredDiagnostics {
     const val CONNECTION_CATEGORY: String = "connection"
 
     /**
+     * The composer outbound-queue diagnostic category (issue #1682): `enqueue`,
+     * `window_flip`, `drain_attempt`, `row_state`, `wedge_verdict`,
+     * `watchdog_timeout`. Mirrored WHOLE (like [CONNECTION_CATEGORY], unlike the
+     * device-only `action` chatter) so a real-world clog reaches the host on the
+     * SAME correlated timeline as the connection events it disagreed with — the
+     * enum-vs-transport smoking gun Track C named. Redaction (ids/sizes only, no
+     * raw content) is enforced by
+     * [com.pocketshell.app.composer.ComposerQueueDiagnostics] at record time.
+     */
+    const val QUEUE_CATEGORY: String = "queue"
+
+    /**
      * Ceiling on the rendered host payload. Sized at ~the real per-upload payload
      * observed in the maintainer's corpus today (56,215 bytes / 164 events), so
      * broadening the mirror does not grow a storm day's mobile-data spend. NOT a
@@ -67,6 +79,8 @@ internal object MirroredDiagnostics {
         ReconnectCauseTrail.CATEGORY -> event.name == ReconnectCauseTrail.NAME
         // The whole curated connection lifecycle (#1642 slice 1 / #1598).
         CONNECTION_CATEGORY -> true
+        // The whole composer outbound-queue diagnostic surface (#1682).
+        QUEUE_CATEGORY -> true
         else -> false
     }
 

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
@@ -442,6 +442,7 @@ public fun TmuxSessionScreen(
         outboundQueueAutoFlushController.onConnectionWindowChanged(
             sessionLive = sessionLive,
             targetSessionId = targetSessionId.value,
+            connectionStatusLabel = connectionStatusDiagnosticLabel(rawStatus), // #1682
         ) {
             promptComposerViewModel.requeueStaleOutboundInFlight()
         }

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreenStateHelpers.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreenStateHelpers.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import com.pocketshell.app.composer.ComposerQueueDiagnostics
 import com.pocketshell.app.composer.OutboundLauncherBadge
 import com.pocketshell.app.composer.PromptComposerViewModel
 import com.pocketshell.app.composer.outboundLauncherBadge
@@ -168,6 +169,13 @@ internal fun TmuxOutboundQueueAutoFlushEffect(
             sweepStaleInFlight = { staleAfterMs ->
                 promptComposerViewModel.requeueStaleOutboundInFlight(staleAfterMs = staleAfterMs)
             },
+            // Issue #1682: an undelivered row for THIS target exists right now →
+            // a `not_live` drain tick is worth recording (a message waiting behind
+            // a shut gate), vs a bare idle closed window (no record).
+            hasPendingWork = {
+                promptComposerViewModel.outboundQueueItems.value
+                    .outboundLauncherBadge(targetSessionKey) != null
+            },
         )
     }
 }
@@ -210,10 +218,14 @@ internal suspend fun runOutboundQueueAutoFlush(
     // Defaulted to a no-op so existing unit tests that only exercise the redispatch
     // lanes keep compiling unchanged.
     sweepStaleInFlight: (staleAfterMs: Long) -> Unit = {},
+    // Issue #1682: whether the target has any undelivered row right now — feeds the
+    // controller's `not_live` drain diagnostic (see [OutboundQueueAutoFlushController.onQueueSnapshotChanged]).
+    // Defaulted so existing unit call sites compile.
+    hasPendingWork: () -> Boolean = { false },
 ): Unit = coroutineScope {
     launch {
         outboundQueueItems.collect {
-            controller.onQueueSnapshotChanged(sessionLive, retryNext)
+            controller.onQueueSnapshotChanged(sessionLive, hasPendingWork, retryNext)
         }
     }
     if (sessionLive) {
@@ -224,9 +236,27 @@ internal suspend fun runOutboundQueueAutoFlush(
         while (isActive) {
             delay(OUTBOUND_DEFERRED_REDISPATCH_BACKOFF_MS)
             sweepStaleInFlight(OUTBOUND_ORPHANED_INFLIGHT_SWEEP_MS)
-            controller.onQueueSnapshotChanged(sessionLive, retryNext)
+            controller.onQueueSnapshotChanged(sessionLive, hasPendingWork, retryNext)
         }
     }
+}
+
+/**
+ * Issue #1682: a SAFE, bounded label for a [TmuxSessionViewModel.ConnectionStatus]
+ * — the sealed subtype's name only (`Idle` / `Connecting` / `Switching` /
+ * `Connected` / `Reconnecting` / `Failed`). The status data classes carry
+ * host/port/user and a failure message; those are NEVER surfaced here, only the
+ * coarse shape the queue's drain gate reads. Recorded with each `window_flip`.
+ */
+internal fun connectionStatusDiagnosticLabel(
+    status: TmuxSessionViewModel.ConnectionStatus,
+): String = when (status) {
+    is TmuxSessionViewModel.ConnectionStatus.Idle -> "Idle"
+    is TmuxSessionViewModel.ConnectionStatus.Connecting -> "Connecting"
+    is TmuxSessionViewModel.ConnectionStatus.Switching -> "Switching"
+    is TmuxSessionViewModel.ConnectionStatus.Connected -> "Connected"
+    is TmuxSessionViewModel.ConnectionStatus.Reconnecting -> "Reconnecting"
+    is TmuxSessionViewModel.ConnectionStatus.Failed -> "Failed"
 }
 
 /**
@@ -261,11 +291,23 @@ internal class OutboundQueueAutoFlushController(
     fun onConnectionWindowChanged(
         sessionLive: Boolean,
         targetSessionId: String,
+        // Issue #1682: the raw `ConnectionStatus` label (`Connected` / `Reconnecting`
+        // / `Failed` / …) that drove this flip — recorded on the mirrored `queue`
+        // timeline so an enum-vs-transport disagreement is readable against the
+        // `connection`-category events. Defaulted so existing unit call sites compile.
+        connectionStatusLabel: String = "",
         requeueStaleInFlight: () -> Unit,
     ) {
         val nextKey = sessionLive to targetSessionId
         if (nextKey == windowKey) return
         windowKey = nextKey
+        // Issue #1682: the drain window opened/closed — capture WHICH status enum
+        // drove it (the smoking-gun pairing). Diagnostics-only; no behaviour change.
+        ComposerQueueDiagnostics.windowFlip(
+            sessionLive = sessionLive,
+            connectionStatusLabel = connectionStatusLabel,
+            targetSessionKey = targetSessionId,
+        )
         // A genuine window flip is a fresh slate — clear all per-row backoffs so a
         // reconnect re-arms every row immediately (the existing #900/#993 path).
         lastAttemptAtMs.clear()
@@ -274,9 +316,27 @@ internal class OutboundQueueAutoFlushController(
 
     fun onQueueSnapshotChanged(
         sessionLive: Boolean,
+        // Issue #1682: whether the target has any undelivered row RIGHT NOW. Only
+        // consulted on the closed-gate (`!sessionLive`) path so a `not_live` drain
+        // outcome — a message that arrived while the drain gate was shut and was
+        // NEVER attempted, the clog's core symptom — is recorded WITHOUT spamming an
+        // idle closed window. Defaulted (and placed BEFORE [retryNext]) so existing
+        // `onQueueSnapshotChanged(sessionLive = …) { retryNext }` trailing-lambda
+        // call sites keep binding the lambda to [retryNext] and compile unchanged.
+        hasPendingWork: () -> Boolean = { false },
         retryNext: (excludingIds: Set<String>) -> String?,
     ): String? {
-        if (!sessionLive) return null
+        if (!sessionLive) {
+            // Issue #1682: the gate is shut (enum not-Connected). If rows are
+            // waiting, record that the drain did NOT attempt them. Diagnostics-only.
+            if (hasPendingWork()) {
+                ComposerQueueDiagnostics.drainAttempt(
+                    outcome = "not_live",
+                    sessionKey = windowKey?.second,
+                )
+            }
+            return null
+        }
         val now = clock()
         // Drop rows whose backoff has elapsed — they are eligible to re-dispatch
         // again (this is what un-parks a silently-healed deferred row) and pruning

--- a/app/src/test/java/com/pocketshell/app/composer/ComposerQueueDiagnosticsHostMirrorTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/ComposerQueueDiagnosticsHostMirrorTest.kt
@@ -1,0 +1,302 @@
+package com.pocketshell.app.composer
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.pocketshell.app.diagnostics.DIAGNOSTICS_EXPORT_CACHE_DIR
+import com.pocketshell.app.diagnostics.DiagnosticEventSink
+import com.pocketshell.app.diagnostics.DiagnosticEvents
+import com.pocketshell.app.diagnostics.DiagnosticRecorder
+import com.pocketshell.app.diagnostics.MirroredDiagnostics
+import com.pocketshell.app.settings.SettingsRepository
+import com.pocketshell.app.tmux.OutboundQueueAutoFlushController
+import kotlinx.coroutines.test.runTest
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+
+/**
+ * Issue #1682 (Track A + Track C): the composer outbound queue emits NO
+ * diagnostics today — the drain-gate decision path records either `action`-only
+ * chatter or nothing at all — so "the queue clogs because it thinks the
+ * connection is gone" is INVISIBLE in a real device trace. Track C found the
+ * clog is caused by the drain being hard-gated on the `ConnectionStatus` enum
+ * (`TmuxSessionScreen.kt:425`), so the smoking-gun signal is enum-vs-transport
+ * disagreement.
+ *
+ * These tests assert the new mirrored `queue` category reaches the HOST
+ * connection log — the exact payload `ConnectionLogHostMirror` uploads
+ * ([DiagnosticRecorder.connectionLogJsonl]) — for the four load-bearing events:
+ * `enqueue`, `window_flip` (with `sessionLive` + the `ConnectionStatus` that
+ * drove it), `drain_attempt` (`dispatched` / `not_live` / `all_suppressed`),
+ * and `row_state` (esp. the park-at-6 `budget_exhausted`).
+ *
+ * ## Why the assertions are what they are
+ *
+ * - **No proxy** — every assertion runs through the REAL global sink and the
+ *   REAL production payload builder [DiagnosticRecorder.connectionLogJsonl], via
+ *   the REAL emit sites ([ComposerQueueDiagnostics], the production
+ *   [OutboundQueueAutoFlushController], the [PromptComposerViewModel] drain
+ *   helper), not a hand-built event.
+ * - **Redaction** — the enqueue/row_state events carry ids + sizes only; the
+ *   test asserts the raw prompt text and the raw session key (a directory path
+ *   by construction) NEVER appear in the host payload.
+ * - **Category discipline** — a `queue` event reaches the host like `connection`
+ *   does, while the excluded `action` chatter does NOT.
+ * - **No `assumeTrue`** anywhere: every assertion is load-bearing on every runner.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class ComposerQueueDiagnosticsHostMirrorTest {
+
+    private lateinit var context: Context
+    private lateinit var settingsRepository: SettingsRepository
+
+    private val secretText = "deploy the prod key sk-supersecret-please-never-log-me"
+    private val sessionPath = "alexey@dev/home/alexey/git/pocketshell"
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        context.getSharedPreferences("app_settings", Context.MODE_PRIVATE)
+            .edit().clear().commit()
+        File(context.filesDir, "diagnostics").deleteRecursively()
+        File(context.cacheDir, DIAGNOSTICS_EXPORT_CACHE_DIR).deleteRecursively()
+        settingsRepository = SettingsRepository(context)
+        DiagnosticEvents.install(DiagnosticEventSink.Noop)
+    }
+
+    private fun newRecorder(): DiagnosticRecorder =
+        DiagnosticRecorder(context, settingsRepository).also { DiagnosticEvents.install(it) }
+
+    private fun String.mirroredLines(): List<JSONObject> =
+        split("\n").filter { it.isNotBlank() }.map(::JSONObject)
+
+    private fun item(
+        id: String,
+        state: OutboundState = OutboundState.Queued,
+        attemptCount: Int = 0,
+        text: String = secretText,
+    ): OutboundItem = OutboundItem(
+        id = id,
+        sessionKey = sessionPath,
+        cleanText = text,
+        createdAtMs = 0L,
+        state = state,
+        attemptCount = attemptCount,
+        route = OutboundRoute.AgentPayload,
+        agentKind = "claude",
+    )
+
+    /** enqueue reaches the host log — with the id + size, and NEVER the raw text. */
+    @Test
+    fun `enqueue reaches the host connection log with ids and sizes only`() = runTest {
+        val recorder = newRecorder()
+
+        ComposerQueueDiagnostics.enqueue(item(id = "row-1"))
+
+        val jsonl = recorder.connectionLogJsonl()
+        val event = jsonl.mirroredLines().singleOrNull {
+            it.getString("category") == MirroredDiagnostics.QUEUE_CATEGORY &&
+                it.getString("name") == "enqueue"
+        }
+        assertTrue("queue/enqueue must reach the host log. Payload was: $jsonl", event != null)
+        val metadata = event!!.getJSONObject("metadata")
+        assertEquals("row-1", metadata.getString("itemId"))
+        assertEquals(secretText.length, metadata.getInt("textLength"))
+        assertEquals("AgentPayload", metadata.getString("route"))
+        // Redaction: NO raw prompt text, NO raw session directory path.
+        assertFalse("raw prompt text must never reach the host log: $jsonl", jsonl.contains(secretText))
+        assertFalse("raw session path must never reach the host log: $jsonl", jsonl.contains(sessionPath))
+        assertTrue("session must be a fingerprint: $jsonl", metadata.getString("sessionFingerprint").startsWith("sha256:"))
+    }
+
+    /**
+     * window_flip carries `sessionLive` AND the `ConnectionStatus` that drove it —
+     * the enum-vs-transport disagreement capture. This is the Track C smoking gun.
+     */
+    @Test
+    fun `window_flip reaches the host log with sessionLive and the driving status`() = runTest {
+        val recorder = newRecorder()
+
+        val controller = OutboundQueueAutoFlushController()
+        // The drain gate closes while the wire may still be alive (Reconnecting enum).
+        controller.onConnectionWindowChanged(
+            sessionLive = false,
+            targetSessionId = sessionPath,
+            connectionStatusLabel = "Reconnecting",
+            requeueStaleInFlight = {},
+        )
+
+        val jsonl = recorder.connectionLogJsonl()
+        val event = jsonl.mirroredLines().singleOrNull {
+            it.getString("category") == MirroredDiagnostics.QUEUE_CATEGORY &&
+                it.getString("name") == "window_flip"
+        }
+        assertTrue("queue/window_flip must reach the host log. Payload was: $jsonl", event != null)
+        val metadata = event!!.getJSONObject("metadata")
+        assertFalse("drain gate closed", metadata.getBoolean("sessionLive"))
+        assertEquals("Reconnecting", metadata.getString("connectionStatus"))
+        assertFalse("raw session path must never reach the host log: $jsonl", jsonl.contains(sessionPath))
+    }
+
+    /**
+     * not_live drain: a row waits behind a shut gate and is NEVER attempted — the
+     * clog's core symptom. Only recorded when there is actually pending work.
+     */
+    @Test
+    fun `a drain tick against a shut gate records not_live`() = runTest {
+        val recorder = newRecorder()
+
+        val controller = OutboundQueueAutoFlushController()
+        controller.onConnectionWindowChanged(
+            sessionLive = false,
+            targetSessionId = sessionPath,
+            connectionStatusLabel = "Reconnecting",
+            requeueStaleInFlight = {},
+        )
+        // Gate shut, a row is waiting → the drain does NOT attempt it.
+        controller.onQueueSnapshotChanged(
+            sessionLive = false,
+            retryNext = { null },
+            hasPendingWork = { true },
+        )
+
+        val jsonl = recorder.connectionLogJsonl()
+        val drain = jsonl.mirroredLines().singleOrNull {
+            it.getString("name") == "drain_attempt"
+        }
+        assertTrue("queue/drain_attempt not_live must reach the host log. Payload was: $jsonl", drain != null)
+        assertEquals("not_live", drain!!.getJSONObject("metadata").getString("outcome"))
+    }
+
+    /** An idle shut gate (no pending work) records NO drain tick — no host spam. */
+    @Test
+    fun `an idle shut gate records no drain tick`() = runTest {
+        val recorder = newRecorder()
+
+        val controller = OutboundQueueAutoFlushController()
+        controller.onConnectionWindowChanged(
+            sessionLive = false,
+            targetSessionId = sessionPath,
+            connectionStatusLabel = "Reconnecting",
+            requeueStaleInFlight = {},
+        )
+        controller.onQueueSnapshotChanged(
+            sessionLive = false,
+            retryNext = { null },
+            hasPendingWork = { false },
+        )
+
+        val names = recorder.connectionLogJsonl().mirroredLines().map { it.getString("name") }
+        assertFalse("an idle closed window must not record a drain tick: $names", "drain_attempt" in names)
+    }
+
+    /**
+     * The drain cycle: a budget-exhausted head is PARKED (`row_state` →
+     * `budget_exhausted`) and the fresh tail is `dispatched`. Class coverage for
+     * the park-at-[OUTBOUND_MAX_AUTO_ATTEMPTS] the issue calls out.
+     */
+    @Test
+    fun `the drain cycle records the park and the dispatched outcome`() = runTest {
+        val recorder = newRecorder()
+
+        val parked = item(id = "parked", attemptCount = OUTBOUND_MAX_AUTO_ATTEMPTS)
+        val fresh = item(id = "fresh", attemptCount = 0)
+        val items = listOf(parked, fresh)
+        val plan = items.planComposerAutoFlush(sessionPath)
+        // The plan parks the exhausted head and dispatches the fresh tail.
+        assertEquals(listOf("parked"), plan.parkIds)
+        assertEquals("fresh", plan.nextId)
+
+        ComposerQueueDiagnostics.recordDrainCycle(
+            sessionKey = sessionPath,
+            items = items,
+            plan = plan,
+            suppressedCount = 0,
+            dispatched = true,
+        )
+
+        val lines = recorder.connectionLogJsonl().mirroredLines()
+        val park = lines.singleOrNull {
+            it.getString("name") == "row_state" &&
+                it.getJSONObject("metadata").getString("itemId") == "parked"
+        }
+        assertTrue("the park-at-6 row_state must reach the host log. Payload was: $lines", park != null)
+        assertEquals("budget_exhausted", park!!.getJSONObject("metadata").getString("reason"))
+        assertEquals("Failed", park.getJSONObject("metadata").getString("toState"))
+        assertEquals(OUTBOUND_MAX_AUTO_ATTEMPTS.toLong(), park.getJSONObject("metadata").getLong("attemptCount"))
+
+        val drain = lines.single { it.getString("name") == "drain_attempt" }
+        assertEquals("dispatched", drain.getJSONObject("metadata").getString("outcome"))
+        assertEquals("fresh", drain.getJSONObject("metadata").getString("dispatchedId"))
+        assertEquals(1L, drain.getJSONObject("metadata").getLong("parkedCount"))
+    }
+
+    /** All eligible rows suppressed (within backoff) → all_suppressed, no dispatch. */
+    @Test
+    fun `a fully-suppressed drain cycle records all_suppressed`() = runTest {
+        val recorder = newRecorder()
+
+        val only = item(id = "only")
+        val items = listOf(only)
+        // Suppress the one eligible row → planComposerAutoFlush yields no next id.
+        val plan = items.planComposerAutoFlush(sessionPath, excludingIds = setOf("only"))
+        assertEquals(null, plan.nextId)
+
+        ComposerQueueDiagnostics.recordDrainCycle(
+            sessionKey = sessionPath,
+            items = items,
+            plan = plan,
+            suppressedCount = 1,
+            dispatched = false,
+        )
+
+        val drain = recorder.connectionLogJsonl().mirroredLines()
+            .single { it.getString("name") == "drain_attempt" }
+        assertEquals("all_suppressed", drain.getJSONObject("metadata").getString("outcome"))
+        assertEquals(1L, drain.getJSONObject("metadata").getLong("suppressedCount"))
+    }
+
+    /** row_state transitions reach the host log with reason + post-transition budget. */
+    @Test
+    fun `a row_state transition reaches the host log`() = runTest {
+        val recorder = newRecorder()
+
+        item(id = "claimed-row", state = OutboundState.InFlight, attemptCount = 1)
+            .recordQueueRowState("Queued", "InFlight", "claimed")
+
+        val event = recorder.connectionLogJsonl().mirroredLines().single {
+            it.getString("name") == "row_state"
+        }
+        val metadata = event.getJSONObject("metadata")
+        assertEquals("claimed-row", metadata.getString("itemId"))
+        assertEquals("Queued", metadata.getString("fromState"))
+        assertEquals("InFlight", metadata.getString("toState"))
+        assertEquals("claimed", metadata.getString("reason"))
+        assertEquals(1L, metadata.getLong("attemptCount"))
+    }
+
+    /**
+     * Category discipline: `queue` is mirrored WHOLE (like `connection`), while
+     * the device-only `action` chatter is NOT — the whole point of a mirrored
+     * category vs the excluded one.
+     */
+    @Test
+    fun `the queue category is mirrored while action chatter is not`() = runTest {
+        val recorder = newRecorder()
+
+        ComposerQueueDiagnostics.enqueue(item(id = "row-a"))
+        DiagnosticEvents.record("action", "composer_send_deferred_to_queue", "attachmentCount" to 0)
+
+        val categories = recorder.connectionLogJsonl().mirroredLines().map { it.getString("category") }
+        assertTrue("queue must be mirrored: $categories", MirroredDiagnostics.QUEUE_CATEGORY in categories)
+        assertFalse("action chatter must stay device-only: $categories", "action" in categories)
+    }
+}


### PR DESCRIPTION
Part of the #1680 storm root-cause diagnostics. Makes the composer-clog symptom ("queue clogs because it thinks the connection is gone") visible in a real host-mirrored trace by recording the enum-vs-transport disagreement.

- New mirrored `queue` category: `enqueue`, `window_flip` (captures `sessionLive` AND the driving `ConnectionStatus`), `drain_attempt` (dispatched/not_live/all_suppressed), `row_state` transitions, wedge verdicts, watchdog timeout.
- Diagnostics-only, no queue/drain behavior change (reviewer-verified red→green on the `window_flip` event; two restructures proven truth-table-equivalent). Redacted — ids/sizes/fingerprints only.

Reviewer: APPROVED (#1682). Local gate: new test 8/0, composer regression green, both hygiene ratchets under baseline, `git diff --check` clean. Disjoint from #1683 (reused nothing of its files).

Closes #1682