### PR TITLE
test: mobile-network self-inflicted storm reproduction (#1681)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/MobileLatencyStormSelfInflictedCloseE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/MobileLatencyStormSelfInflictedCloseE2eTest.kt
@@ -1,0 +1,651 @@
+package com.pocketshell.app.proof
+
+import android.os.SystemClock
+import androidx.lifecycle.ViewModelProvider
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.pocketshell.app.MainActivity
+import com.pocketshell.app.diagnostics.DiagnosticEvents
+import com.pocketshell.app.diagnostics.ReconnectCauseTrail
+import com.pocketshell.app.pocketshell.PocketshellCommand
+import com.pocketshell.app.tmux.TmuxSessionViewModel
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.KnownHostsPolicy
+import com.pocketshell.core.ssh.SshConnection
+import com.pocketshell.core.ssh.SshKey
+import com.pocketshell.core.ssh.SshSession
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Issue #1681 — the DETERMINISTIC reproduction of the mobile-network
+ * self-inflicted lease-close storm (#1680 Track B / H1), keyed on the
+ * SELF-INFLICTED signal (G6), on the real connected + Docker + toxiproxy path.
+ *
+ * ## The maintainer's report (2026-07-18, D33)
+ *
+ * *"on WiFi it's okayish but when I'm on mobile network it starts breaking —
+ * even though everything else works fine."* The storm mechanism (#1680 Track B):
+ * on mobile latency a bounded remote exec exceeds the **3.5 s** budget → a
+ * bounded-exec site `close()`s the SHARED per-host tmux `-CC` lease → the reader
+ * EOFs → the manager mis-reads its OWN self-inflicted EOF as a genuine remote
+ * death → reconnect → reattach → reconcile re-classifies → timeout → close →
+ * repeat. WiFi RTT stays under 3.5 s so it mostly doesn't trip; mobile RTT
+ * spikes over it. #1641 (merged) routes those bounded execs through
+ * [com.pocketshell.app.ssh.BoundedSessionExec], which ABANDONS the slow exec and
+ * leaves the shared transport untouched — turning the storm into quiet.
+ *
+ * ## Why this is deterministic (and NOT a server-side sleep — the #1680 thesis)
+ *
+ * The overrun is caused by NETWORK RTT against the REAL production 3.5 s
+ * constant — no widened band, no test-only timing in the assertion path (G6).
+ * The toxiproxy `network-fault-proxy` (host 2228 → `agents:22`) applies a
+ * symmetric latency toxic so a single SSH round-trip costs ~2 × one-way:
+ *
+ *  - **Mobile pin** ([ToxiproxyControl.addMobileProfile], RTT ≈ 1.8 s): a
+ *    bounded exec is a multi-round-trip channel-open + exec + read (~5 s), so it
+ *    overruns the 3.5 s budget, while the `-CC` liveness probe (5 s, a single
+ *    round-trip refresh-client), keepalive (30 s), tmux command (10 s), and the
+ *    8 s TransportDispatcher per-op ceiling all stay green — ONLY the storm
+ *    threshold crosses. (See [ToxiproxyControl.addMobileProfile] for why the RTT
+ *    is ~1.8 s, not the recipe's ~4.0 s: at 4.0 s a raw exec trips the 8 s
+ *    transport ceiling, confounding the classify's 3.5 s attribution.)
+ *  - **WiFi pin** (RTT ≈ 150 ms, [wifiBaselineNoStormNoReconnect]): the classify
+ *    completes far under the bound — zero overruns, zero reconnects.
+ *
+ * These two pinned extremes bracket the monotonic RTT-vs-3.5 s variable, which
+ * is strictly stronger than N random samples (the #1633 both-extremes method).
+ *
+ * ## The self-inflicted signal is CONSTRUCTIVE (the honest key — G6)
+ *
+ * Pre-#1641 the close was SILENT (no log, no cause-trail), so the RED side
+ * cannot key on a breadcrumb. Instead the harness ONLY ever applies a *latency*
+ * toxic — it never disables the proxy, never blackholes, never severs the link —
+ * so the link is *delayed but never cut*, AND an UN-PROXIED [SshSentinel]
+ * exec-pings the fixture SSH port (2222, no toxiproxy) throughout, hard-proving
+ * the host + sshd + network stayed perfectly healthy. Under that invariant **any
+ * observed lease death is SELF-INFLICTED by construction**, not a real remote
+ * drop — that is the "everything else works fine" control the maintainer
+ * described, made mechanical.
+ *
+ * ## Deterministic trigger (confirmed-shell classify over the SHARED `-CC` lease)
+ *
+ * Only ONE #1680 bounded-exec site borrows the SHARED `-CC` lease the live
+ * reader rides: `agent_kind_classify` (`resolveForeignKindGuess` runs
+ * [com.pocketshell.app.agents.AgentKindRemoteSource] over the same `sessionRef`).
+ * Its overrun is the storm-bearing one — pre-#1641 its `close()` kills the reader.
+ * (The RED run PROVED `session_cards_rpc` uses a SEPARATE lease: with the shim
+ * restored, its overrun did NOT storm. So keying the fidelity/attribution
+ * assertions on ANY `bounded_exec_timeout` would let A2 pass vacuously on RED —
+ * they key strictly on `agent_kind_classify`.)
+ *
+ * The seeded session is pinned `@ps_agent_kind=shell` (confirmed-shell —
+ * [setSessionShellKind]), the exact pane class #1641 named as the storm's
+ * uncredited entry trigger: it re-runs the classify over the shared lease
+ * whenever the pane's `(cwd, command, tty)` input changes
+ * ([com.pocketshell.app.tmux.TmuxSessionViewModel] `startAgentDetectionForPane`
+ * / `refreshForeignGuessForConfirmedShellPane`). After the mobile profile is
+ * applied, [forceReclassifyOverDegradedLink] changes the ACTIVE pane's cwd and
+ * forces an active-window reconcile, so the next classify runs over the degraded
+ * `-CC` lease and overruns.
+ *
+ * ## Red → green (validating both the repro and #1641 — G1/D33)
+ *
+ * - **RED** (v0.4.38 `close()`-on-timeout shim restored in
+ *   [com.pocketshell.app.ssh.BoundedSessionExec] — the one-file revert quoted in
+ *   its own class doc): the bounded exec overruns at 3.5 s → closes the shared
+ *   lease → `-CC` reader EOF → `passive_disconnect classification=real_tmux_
+ *   control_channel_closed`. [assertConnectedStaysNoSelfInflictedDrop] FAILS with
+ *   that exact signature while the sentinel is still alive.
+ * - **GREEN** (current main, post-#1641): the bounded exec is abandoned, a
+ *   `cause_trail stage=bounded_exec_timeout outcome=abandoned_transport_preserved
+ *   transportAlive=true transportClosed=false` breadcrumb is recorded, status
+ *   never leaves Connected, and a fresh marker still round-trips.
+ *
+ * ## Gate wiring
+ *
+ * This is a [NetworkFaultProofBase] toxiproxy proof — it self-skips on per-PR CI
+ * ([assumeNetworkFaultProofsEnabled] → `tests.yml` leaves `network-fault-proxy`
+ * / toxiproxy down), so wiring it into `scripts/ci-journey-suite.sh` would only
+ * ALL-SKIP (the G3 trap). It runs in the phase-2 network-fault cohort of
+ * `scripts/nightly-extensive-suite.sh` with the proxy family up, alongside its
+ * `NatIdleMappingSurvivalE2eTest` / `PacketLossNetworkFaultE2eTest` siblings.
+ *
+ * There is NO `assumeTrue` / `assumeFalse(isRunningOnCi())` on any load-bearing
+ * assertion (D31/D32 F3): the two `assumeNetworkFaultProofsEnabled()` gates only
+ * un-gate the opt-in Docker fixture, never the storm assertion itself.
+ *
+ * @see com.pocketshell.app.ssh.BoundedSessionExec
+ * @see com.pocketshell.app.agents.AgentKindRemoteSource
+ * @see SlowClassifyKeepsSharedLeaseJourneyDockerTest
+ */
+@RunWith(AndroidJUnit4::class)
+class MobileLatencyStormSelfInflictedCloseE2eTest : NetworkFaultProofBase() {
+
+    private var diagnostics: RecordingDiagnosticSink? = null
+    private val sentinelScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private var sentinel: SshSentinel? = null
+
+    /** Every distinct connection status this run projected, sampled continuously. */
+    private val observedStatuses = mutableSetOf<String>()
+
+    @Before
+    fun installDiagnostics() {
+        clearLastSessionPrefs()
+        diagnostics = RecordingDiagnosticSink().also { DiagnosticEvents.install(it) }
+    }
+
+    @After
+    fun tearDownStorm() {
+        runCatching { sentinel?.stop() }
+        runCatching { sentinelScope.cancel() }
+        runCatching { toxiproxy().reset() }
+        runCatching { diagnostics?.close() }
+        diagnostics = null
+        clearLastSessionPrefs()
+    }
+
+    /**
+     * THE #1681 PROOF (RED-detector / GREEN load-bearer). Under the pinned MOBILE
+     * RTT profile, a confirmed-shell classify runs over the delayed-but-alive
+     * `-CC` lease and overruns its 3.5 s bound. On the pre-#1641 build this
+     * SELF-INFLICTS a lease close (storm); on current main it is abandoned and
+     * the session stays Connected.
+     */
+    @Test
+    fun mobileLatencyStormIsSelfInflicted() = runBlocking<Unit> {
+        assumeNetworkFaultProofsEnabled()
+
+        val key = readFixtureKey()
+        val marker = "ms${System.currentTimeMillis().toString(36).takeLast(5)}"
+        val sessionName = "issue1681-mobile-$marker"
+        val hostName = "Issue1681 Mobile $marker"
+
+        // (1) Seed a healthy proxy + a foreign shell session, and pin it
+        //     confirmed-shell (@ps_agent_kind=shell) so the classify re-fires on
+        //     pane-input change — the exact #1641 storm-entry trigger.
+        prepareProxyAndRemoteSession(key, sessionName, readyText = "ISSUE1681-READY-$marker")
+        setSessionShellKind(key, sessionName)
+        val hostRowTag = seedNetworkFaultHost(key, hostName)
+
+        // (2) THE SENTINEL — the un-proxied "everything else works fine" control.
+        sentinel = openUnProxiedSentinel(key, sentinelScope)
+
+        // (3) A pre-latency latency-probe connection through the PROXY (2228),
+        //     handshaked while the link is still healthy, so the fidelity check
+        //     never fights a slow handshake (#1681 attribution note).
+        val latencyProbe = openProxyLatencyProbe(key)
+        try {
+            // (4) Attach on the HEALTHY link → Connected. The first classify fires
+            //     fast here and caches; the degraded-link re-fire is forced below.
+            launchedActivity = ActivityScenario.launch(MainActivity::class.java)
+            attachToSession(hostRowTag, hostName, sessionName)
+            waitForVisibleTerminalText("initial attach") { "ISSUE1681-READY-$marker" in it }
+            waitForConnected("initial attach")
+
+            diagnostics!!.clear()
+            observedStatuses.clear()
+
+            // (5) DEGRADE the link to the mobile profile (RTT ≈ 1.8 s).
+            toxiproxy().addMobileProfile()
+
+            // (6) A1 — FIXTURE FIDELITY (hard, no assumeTrue). Prove the mobile
+            //     profile makes the EXACT bounded-exec command overrun the 3.5 s
+            //     bound while the host is still ALIVE. A too-mild profile FAILS
+            //     here rather than passing vacuously later (G3/G10).
+            assertMobileProfileOverrunsClassify(latencyProbe)
+
+            // (7) Drive the confirmed-shell classify to re-run over the degraded
+            //     `-CC` lease (cwd change + active-window reconcile) several times
+            //     while continuously sampling status + diagnostics, THEN observe a
+            //     long storm-settle window. The classify's close() is ASYNC
+            //     (#1139/#1144), so on RED the `-CC` EOF / passive_disconnect can
+            //     land seconds after the overrun — the settle window is generous so
+            //     that self-inflicted storm reliably lands in-window (a short tail
+            //     let a late-firing classify's async close storm AFTER the window,
+            //     a false pass). On GREEN nothing ever storms, so the extra wait is
+            //     simply quiet.
+            val start = SystemClock.elapsedRealtime()
+            repeat(RECLASSIFY_KICKS) { kick ->
+                forceReclassifyOverDegradedLink(key, sessionName, kick)
+                observeWindow(PER_KICK_OBSERVE_MS)
+            }
+            observeWindow(STORM_SETTLE_MS)
+            val elapsed = SystemClock.elapsedRealtime() - start
+
+            // (8) A2 — THE SELF-INFLICTED DETECTOR (the LOAD-BEARING assertion; RED
+            //     FAILS here, GREEN passes): no passive_disconnect / reconnect_fail,
+            //     status never left Connected, and the sentinel proves it was NOT
+            //     the link. Asserted FIRST because on the pre-#1641 RED build the
+            //     classify's close is SILENT (no breadcrumb — the exact silent-
+            //     close #1641 credited), so the RED signal is the lease DEATH here,
+            //     not a breadcrumb. The classify-overran fidelity is proven
+            //     build-independently at (6) by the latency probe.
+            assertConnectedStaysNoSelfInflictedDrop(elapsed)
+
+            // (9) A1b — GREEN NON-VACUITY: on GREEN the classify overran the 3.5 s
+            //     bound over the SHARED lease and was ABANDONED (not silently
+            //     closed) — the `agent_kind_classify` breadcrumb the silent close
+            //     never wrote. (Only reached on GREEN, since RED fails at A2.)
+            val breadcrumbs = classifyTimeoutBreadcrumbs()
+            assertTrue(
+                "A1b GREEN NON-VACUITY: no `agent_kind_classify` bounded_exec_timeout breadcrumb — " +
+                    "the shared-lease classify never overran/abandoned on GREEN, so the storm window " +
+                    "was vacuous. The trigger did not re-fire the confirmed-shell classify over the " +
+                    "degraded lease. cause_trails=" +
+                    "${diagnostics!!.eventsNamed(ReconnectCauseTrail.NAME).map { it.fields }}",
+                breadcrumbs.isNotEmpty(),
+            )
+
+            // (10) A3 — GREEN ATTRIBUTION: the abandonment is attributable to the
+            //      classify with the transport PRESERVED (asserted exactly as
+            //      SlowClassifyKeepsSharedLeaseJourneyDockerTest does).
+            val crumb = breadcrumbs.first()
+            assertEquals(
+                "A3: the abandoned bounded exec must record transportClosed=false — the shared lease " +
+                    "was preserved, not torn down. crumb=${crumb.fields}",
+                false,
+                crumb.fields["transportClosed"],
+            )
+            assertEquals(
+                "A3: the abandoned bounded exec must record the transport was still ALIVE when we " +
+                    "walked away. crumb=${crumb.fields}",
+                true,
+                crumb.fields["transportAlive"],
+            )
+
+            // (11) A4 — GREEN LEASE LIVENESS: the shared `-CC` lease SURVIVED the
+            //      storm and now processes cleanly on the restored link. Restore
+            //      the healthy link, re-confirm Connected (the lease a
+            //      self-inflicted close would have killed is still up), drive ONE
+            //      more shared-lease refresh (a sibling-session `%sessions-changed`)
+            //      and confirm it completes with NO new self-inflicted close and
+            //      NO overrun — proving the lease is alive and usable, keyed on the
+            //      lease itself (NOT the terminal-view render, whose storm-window
+            //      render-heal state is a #1495-class concern orthogonal to the
+            //      self-inflicted CLOSE this issue targets).
+            toxiproxy().clearToxics()
+            waitForConnected("post-storm healthy link")
+            val healthyBaselineBreadcrumbs = classifyTimeoutBreadcrumbs().size
+            forceReclassifyOverDegradedLink(key, sessionName, RECLASSIFY_KICKS)
+            observeWindow(HEALTHY_SETTLE_MS)
+            assertTrue(
+                "A4 LEASE LIVENESS: the shared `-CC` lease left Connected after the link was " +
+                    "restored (status=${currentConnectionStatus()}) — the lease did not survive the " +
+                    "storm as a usable connection.",
+                currentConnectionStatus() is TmuxSessionViewModel.ConnectionStatus.Connected,
+            )
+            assertEquals(
+                "A4 LEASE LIVENESS: a shared-lease refresh over the RESTORED healthy link still " +
+                    "overran the 3.5 s bound (new bounded_exec_timeout breadcrumbs) — the lease is " +
+                    "not processing cleanly. baseline=$healthyBaselineBreadcrumbs now=" +
+                    "${classifyTimeoutBreadcrumbs().size}",
+                healthyBaselineBreadcrumbs,
+                classifyTimeoutBreadcrumbs().size,
+            )
+            assertTrue(
+                "A4 LEASE LIVENESS: a passive_disconnect fired on the restored healthy link — the " +
+                    "lease is not usable. events=${diagnostics!!.eventsNamed("passive_disconnect").map { it.fields }}",
+                diagnostics!!.eventsNamed("passive_disconnect").isEmpty(),
+            )
+
+            writeSummary(
+                testName = "MobileLatencyStormSelfInflictedClose-mobile",
+                lines = listOf(
+                    "session=$sessionName",
+                    "marker=$marker",
+                    "profile=mobile RTT≈${ToxiproxyControl.MOBILE_RTT_MS}ms " +
+                        "(one_way=${ToxiproxyControl.MOBILE_ONE_WAY_LATENCY_MS}ms)",
+                    "reclassify_kicks=$RECLASSIFY_KICKS",
+                    "bounded_exec_timeout_breadcrumbs=${breadcrumbs.size}",
+                    "sentinel_pings=${sentinel?.pingCount} attempts=${sentinel?.attemptCount} " +
+                        "alive=${sentinel?.isAlive}",
+                    "observed_statuses=${observedStatuses.joinToString("|")}",
+                    "passive_disconnects=${diagnostics!!.eventsNamed("passive_disconnect").size}",
+                    "reconnect_fails=${diagnostics!!.eventsNamed("reconnect_fail").size}",
+                    "expectation=Connected stays, no self-inflicted drop, breadcrumb attributable, " +
+                        "marker round-trips, sentinel alive",
+                ),
+            )
+        } finally {
+            runCatching { runBlocking { latencyProbe.close() } }
+        }
+    }
+
+    /**
+     * A5 — THE WiFi BASELINE (the #1633 under-threshold extreme). Same journey at
+     * WiFi RTT (≈ 150 ms): the classify completes far under the 3.5 s bound, so
+     * there is ZERO overrun AND ZERO reconnect — proving the mobile-arm assertion
+     * constrains the THRESHOLD, not "reconnects are banned universally".
+     */
+    @Test
+    fun wifiBaselineNoStormNoReconnect() = runBlocking<Unit> {
+        assumeNetworkFaultProofsEnabled()
+
+        val key = readFixtureKey()
+        val marker = "wf${System.currentTimeMillis().toString(36).takeLast(5)}"
+        val sessionName = "issue1681-wifi-$marker"
+        val hostName = "Issue1681 WiFi $marker"
+
+        prepareProxyAndRemoteSession(key, sessionName, readyText = "ISSUE1681-WIFI-READY-$marker")
+        setSessionShellKind(key, sessionName)
+        val hostRowTag = seedNetworkFaultHost(key, hostName)
+        sentinel = openUnProxiedSentinel(key, sentinelScope)
+
+        launchedActivity = ActivityScenario.launch(MainActivity::class.java)
+        attachToSession(hostRowTag, hostName, sessionName)
+        waitForVisibleTerminalText("initial attach") { "ISSUE1681-WIFI-READY-$marker" in it }
+        waitForConnected("initial attach")
+
+        diagnostics!!.clear()
+        observedStatuses.clear()
+
+        // Degrade only to the WiFi profile (RTT ≈ 150 ms — under the 3.5 s bound).
+        toxiproxy().addSymmetricLatency(ToxiproxyControl.WIFI_ONE_WAY_LATENCY_MS)
+
+        val start = SystemClock.elapsedRealtime()
+        repeat(RECLASSIFY_KICKS) { kick ->
+            forceReclassifyOverDegradedLink(key, sessionName, kick)
+            observeWindow(PER_KICK_OBSERVE_MS)
+        }
+        observeWindow(STORM_SETTLE_MS)
+        val elapsed = SystemClock.elapsedRealtime() - start
+
+        // A5.1: ZERO bounded_exec_timeout breadcrumbs — no bounded exec overran at WiFi RTT.
+        val breadcrumbs = classifyTimeoutBreadcrumbs()
+        assertTrue(
+            "A5: a bounded_exec_timeout breadcrumb fired at WiFi RTT " +
+                "(${ToxiproxyControl.WIFI_ONE_WAY_LATENCY_MS}ms one-way) — no bounded exec must " +
+                "overrun the 3.5 s bound on WiFi. breadcrumbs=${breadcrumbs.map { it.fields }}",
+            breadcrumbs.isEmpty(),
+        )
+        // A5.2: ZERO reconnects, status never left Connected (same detector as A2).
+        assertConnectedStaysNoSelfInflictedDrop(elapsed)
+
+        writeSummary(
+            testName = "MobileLatencyStormSelfInflictedClose-wifi",
+            lines = listOf(
+                "session=$sessionName",
+                "profile=wifi RTT≈${ToxiproxyControl.WIFI_ONE_WAY_LATENCY_MS * 2}ms",
+                "bounded_exec_timeout_breadcrumbs=${breadcrumbs.size}",
+                "sentinel_alive=${sentinel?.isAlive}",
+                "observed_statuses=${observedStatuses.joinToString("|")}",
+                "expectation=zero overrun, zero reconnect (under-threshold extreme)",
+            ),
+        )
+    }
+
+    // -- assertions --------------------------------------------------------------------
+
+    /**
+     * A1 — HARD fixture fidelity. Run the EXACT `pocketshell agents kind` command
+     * shape the app runs, over the pre-established PROXY connection while the
+     * mobile latency toxic is active, and time it: it MUST take strictly longer
+     * than the app's 3.5 s bound. No `assumeTrue` — a too-mild profile FAILS here
+     * (the #847/G10 happy-fixture lesson), never passes vacuously.
+     *
+     * The exec is UN-bounded here (unlike the app's `BoundedSessionExec`), so at
+     * this RTT it either (a) returns after > 3.5 s with a valid `{"results":...}`
+     * envelope (host alive, just slow — the ideal proof), or (b) is killed by the
+     * 8 s TransportDispatcher per-op ceiling — which ALSO proves it overran the
+     * 3.5 s bound. Both branches are valid overrun proof; host aliveness is
+     * independently hard-proven by the un-proxied [SshSentinel].
+     */
+    private suspend fun assertMobileProfileOverrunsClassify(probe: SshSession) {
+        val requestJson = """{"panes":[{"pane_id":"%0","pane_pid":1}]}"""
+        val command = "printf %s ${shellQuote(requestJson)} | { " +
+            PocketshellCommand.wrap("agents kind") + " ; }"
+        val started = SystemClock.elapsedRealtime()
+        val result = runCatching { probe.exec(command) }
+        val elapsedMs = SystemClock.elapsedRealtime() - started
+        val thrown = result.exceptionOrNull()
+        assertTrue(
+            "A1 FIXTURE FIDELITY: `pocketshell agents kind` finished in ${elapsedMs}ms over the " +
+                "mobile profile, which is NOT slower than the app's ${CLASSIFY_BOUND_MS}ms bound. A " +
+                "sub-bound classify can never overrun, so it cannot reproduce the storm-entry edge " +
+                "(the #847/G10 happy-fixture lesson). Check network-fault-proxy is up and the mobile " +
+                "toxic is applied. thrown=${thrown?.javaClass?.simpleName}",
+            elapsedMs > CLASSIFY_BOUND_MS,
+        )
+        // When the un-bounded exec DID return (did not hit the 8 s ceiling), it
+        // must be a valid, ALIVE envelope — slow, not failing.
+        val ok = result.getOrNull()
+        if (ok != null) {
+            assertTrue(
+                "A1: the slow classify returned but not a valid `{\"results\":...}` envelope; " +
+                    "exit=${ok.exitCode} stdout='${ok.stdout.take(200)}' stderr='${ok.stderr.take(200)}'",
+                ok.exitCode == 0 && ok.stdout.contains("\"results\""),
+            )
+        }
+    }
+
+    /**
+     * A2 — THE SELF-INFLICTED DETECTOR. The link was only DELAYED (never cut) and
+     * the sentinel proves the host stayed healthy, so any lease death here is
+     * self-inflicted. RED fails here (the shim's close → `passive_disconnect
+     * classification=real_tmux_control_channel_closed`); GREEN is the load-bearing
+     * pass (status stayed Connected across the whole storm window).
+     */
+    private fun assertConnectedStaysNoSelfInflictedDrop(elapsedMs: Long) {
+        // The sentinel HARD-PROVES the host + network stayed healthy — this makes
+        // any observed drop self-inflicted by construction.
+        val s = sentinel
+        assertTrue(
+            "the un-proxied sentinel must have exec-pinged the healthy host throughout; " +
+                "attempts=${s?.attemptCount} pings=${s?.pingCount} failures=${s?.failureLog}",
+            s != null && s.attemptCount > 0 && s.isAlive,
+        )
+
+        val passive = diagnostics!!.eventsNamed("passive_disconnect")
+        assertEquals(
+            "A2 SELF-INFLICTED STORM: ${passive.size} passive_disconnect event(s) fired while a " +
+                "merely-SLOW classify ran over the shared lease and the un-proxied sentinel stayed " +
+                "alive (host healthy). On the pre-#1641 build these carry " +
+                "classification=real_tmux_control_channel_closed — the self-inflicted close mis-read " +
+                "as a real drop. events=${passive.map { it.fields }}",
+            0,
+            passive.size,
+        )
+        val reconnectFails = diagnostics!!.eventsNamed("reconnect_fail")
+        assertEquals(
+            "A2 SELF-INFLICTED STORM: ${reconnectFails.size} reconnect_fail event(s) fired on a " +
+                "proven-up (merely-delayed) link. events=${reconnectFails.map { it.fields }}",
+            0,
+            reconnectFails.size,
+        )
+        val nonConnected = observedStatuses.filter { it != "Connected" }
+        assertTrue(
+            "A2 SELF-INFLICTED STORM: the connection left Connected (observed=$observedStatuses) " +
+                "while a merely-SLOW classify ran over a delayed-but-alive link (elapsed=${elapsedMs}ms). " +
+                "That is the mobile-network storm — the classify's self-close flapping the status.",
+            nonConnected.isEmpty(),
+        )
+        assertTrue(
+            "the session must be Connected at the end of the storm window; " +
+                "status=${currentConnectionStatus()}",
+            currentConnectionStatus() is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+    }
+
+    /**
+     * The `agent_kind_classify` `bounded_exec_timeout` breadcrumbs — the ONE
+     * bounded-exec site that rides the SHARED `-CC` lease (`resolveForeignKindGuess`
+     * over `sessionRef`), so its overrun is the STORM-bearing one the RED v0.4.38
+     * shim self-closes into a `-CC` reader EOF. Keyed strictly on this callerSite
+     * (NOT any `bounded_exec_timeout`): the RED run proved a `session_cards_rpc`
+     * overrun uses a SEPARATE lease and does NOT storm, so accepting it would let
+     * A2 pass vacuously on RED (G3/G6). The confirmed-shell state
+     * ([setSessionShellKind] → `@ps_agent_kind=shell`) is the class this covers —
+     * the exact pane class #1641 named as the storm's uncredited entry trigger.
+     */
+    private fun classifyTimeoutBreadcrumbs(): List<RecordedDiagnosticEvent> =
+        diagnostics!!.eventsNamed(ReconnectCauseTrail.NAME).filter {
+            it.fields["callerSite"] == CLASSIFY_CALLER_SITE &&
+                it.fields["stage"] == BOUNDED_EXEC_TIMEOUT_STAGE
+        }
+
+    // -- triggers / helpers ------------------------------------------------------------
+
+    /**
+     * Re-fire the foreign `AgentKindRemoteSource.classify` — the ONE bounded-exec
+     * site that borrows the SHARED `-CC` lease (`resolveForeignKindGuess` runs it
+     * over the same `sessionRef` the live `-CC` reader rides), so its overrun is
+     * the storm-bearing one: pre-#1641 the classify's `close()` kills the reader.
+     * (A `session_cards_rpc` overrun uses a SEPARATE lease — its close does NOT
+     * kill the `-CC` reader, proven by the RED run — so it is NOT a valid storm
+     * fidelity signal and A1/A3 key strictly on `agent_kind_classify`.)
+     *
+     * Two moves, both over the UN-PROXIED port so the setup itself is not delayed:
+     *  1. Change the ACTIVE pane's cwd to a DISTINCT directory (`mkdir -p … ; cd …`)
+     *     so the pane's `(cwd, command, tty)` input triple genuinely changes — the
+     *     trigger [refreshForeignGuessForConfirmedShellPane] busts the one-shot
+     *     confirmed-shell guess cache on.
+     *  2. A background split + `kill-pane -a` (`-d`, keeping the ACTIVE pane %0)
+     *     emits a `%layout-change` on the ATTACHED window, driving a full
+     *     [reconcilePanes] → `applyParsedPanes` re-read of %0's cwd →
+     *     `startAgentDetectionForPane` → the confirmed-shell classify over the
+     *     now-delayed shared `-CC` lease. (`kill-pane -a` keeps %0, so the app
+     *     stays on the attached pane — verified via the `-active-pane` reveal
+     *     log staying on %0.)
+     */
+    private suspend fun forceReclassifyOverDegradedLink(key: String, sessionName: String, kick: Int) {
+        val s = shellQuote(sessionName)
+        // (1) distinct cwd in the active pane
+        execRemoteDirect(
+            key,
+            "tmux send-keys -t $s " +
+                shellQuote("mkdir -p /tmp/k1681-$kick; cd /tmp/k1681-$kick") + " Enter",
+        )
+        SystemClock.sleep(RECONCILE_SETTLE_MS)
+        // (2) active-window structural churn -> full pane reconcile that re-reads
+        //     %0's cwd, keeping the app on %0 (`-d` + `kill-pane -a`).
+        execRemoteDirect(
+            key,
+            "tmux split-window -d -t $s 2>/dev/null; sleep 0.4; " +
+                "tmux kill-pane -a -t $s 2>/dev/null || true",
+        )
+    }
+
+    /** Record `@ps_agent_kind=shell` on the seeded session so the app treats it confirmed-shell. */
+    private suspend fun setSessionShellKind(key: String, sessionName: String) {
+        val result = execRemoteDirect(
+            key,
+            "tmux set-option -t ${shellQuote(sessionName)} @ps_agent_kind shell; echo kind_set",
+        )
+        assertTrue(
+            "expected to set @ps_agent_kind=shell; exit=${result.exitCode} stderr='${result.stderr}'",
+            result.exitCode == 0 && result.stdout.contains("kind_set"),
+        )
+    }
+
+    /** A direct, UN-PROXIED exec on the fixture SSH port (2222) — never delayed. */
+    private suspend fun execRemoteDirect(key: String, command: String): ExecResult =
+        SshConnection.connect(
+            host = DEFAULT_HOST,
+            port = DEFAULT_PORT,
+            user = DEFAULT_USER,
+            key = SshKey.Pem(key),
+            knownHosts = KnownHostsPolicy.AcceptAll,
+            timeoutMs = 15_000,
+        ).mapCatching { session -> session.use { it.exec(command) } }.getOrThrow()
+
+    /** A PROXY (2228) connection handshaked BEFORE the latency toxic, for the fidelity probe. */
+    private suspend fun openProxyLatencyProbe(key: String): SshSession =
+        SshConnection.connect(
+            host = DEFAULT_HOST,
+            port = NETWORK_FAULT_SSH_PORT,
+            user = DEFAULT_USER,
+            key = SshKey.Pem(key),
+            knownHosts = KnownHostsPolicy.AcceptAll,
+            timeoutMs = 15_000,
+        ).getOrThrow()
+
+    private fun observeWindow(durationMs: Long) {
+        val deadline = SystemClock.elapsedRealtime() + durationMs
+        while (SystemClock.elapsedRealtime() < deadline) {
+            sampleStatus()
+            SystemClock.sleep(POLL_MS)
+        }
+        sampleStatus()
+    }
+
+    private fun sampleStatus() {
+        val status = currentConnectionStatus()
+        observedStatuses += status::class.simpleName ?: status.toString()
+    }
+
+    private fun currentConnectionStatus(): TmuxSessionViewModel.ConnectionStatus {
+        var status: TmuxSessionViewModel.ConnectionStatus =
+            TmuxSessionViewModel.ConnectionStatus.Idle
+        launchedActivity?.onActivity { activity ->
+            status = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+                .connectionStatus
+                .value
+        }
+        return status
+    }
+
+    private fun waitForConnected(label: String) {
+        compose.waitUntil(timeoutMillis = CONNECTED_TIMEOUT_MS) {
+            currentConnectionStatus() is TmuxSessionViewModel.ConnectionStatus.Connected
+        }
+        assertTrue(
+            "expected Connected after $label, observed=${currentConnectionStatus()}",
+            currentConnectionStatus() is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+    }
+
+    private fun shellQuote(value: String): String =
+        "'" + value.replace("'", "'\"'\"'") + "'"
+
+    private companion object {
+        const val POLL_MS: Long = 250L
+
+        /** The app's bounded-exec ceiling — `AgentKindRemoteSource.EXEC_READ_TIMEOUT_MS`. */
+        const val CLASSIFY_BOUND_MS: Long = 3_500L
+
+        /** Cause-trail identifiers stamped by #1641 ([com.pocketshell.app.ssh.BoundedSessionExec]). */
+        const val BOUNDED_EXEC_TIMEOUT_STAGE: String = "bounded_exec_timeout"
+
+        /**
+         * The SHARED-`-CC`-lease bounded-exec site — the storm-bearing one
+         * ([com.pocketshell.app.agents.AgentKindRemoteSource]). The RED run proved
+         * `session_cards_rpc` uses a separate lease and does NOT storm, so the
+         * fidelity/attribution assertions key strictly on this callerSite.
+         */
+        const val CLASSIFY_CALLER_SITE: String = "agent_kind_classify"
+
+        /** How many degraded-link classify kicks to fire (RED self-sustains after the first). */
+        const val RECLASSIFY_KICKS: Int = 4
+
+        /** Settle after a cwd change before the structural churn that forces the reconcile. */
+        const val RECONCILE_SETTLE_MS: Long = 1_000L
+
+        /** A4 settle window after restoring the healthy link (one clean shared-lease refresh). */
+        val HEALTHY_SETTLE_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 18_000L else 12_000L
+
+        val PER_KICK_OBSERVE_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 16_000L else 12_000L
+
+        /**
+         * Long post-kick storm-settle window. On RED the classify's ASYNC close
+         * (#1139/#1144) can land the `-CC` EOF / passive_disconnect several seconds
+         * after the last overrun, so this is generous enough that the self-inflicted
+         * storm reliably lands in-window (avoiding the false pass a short tail gave).
+         */
+        val STORM_SETTLE_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 45_000L else 35_000L
+        val CONNECTED_TIMEOUT_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 30_000L else 20_000L
+    }
+}

--- a/app/src/androidTest/java/com/pocketshell/app/proof/MobileLatencyStormSelfInflictedCloseE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/MobileLatencyStormSelfInflictedCloseE2eTest.kt
@@ -128,6 +128,14 @@ import org.junit.runner.RunWith
  * @see com.pocketshell.app.agents.AgentKindRemoteSource
  * @see SlowClassifyKeepsSharedLeaseJourneyDockerTest
  */
+// CI_JOURNEY_SUITE_JUSTIFIED: NetworkFaultProofBase toxiproxy proof; gated by
+// assumeNetworkFaultProofsEnabled() (self-skips on CI since tests.yml does not
+// start network-fault-proxy:2228). This is a heavy phase-2 fault-injection
+// reproduction — too slow for the per-push journey suite. Its durable gate is
+// the nightly phase-2 NETWORK_FAULT_CLASSES cohort
+// (scripts/nightly-extensive-suite.sh) alongside its ReconnectStormLivelockE2eTest
+// / NatIdleMappingSurvivalE2eTest / PacketLossNetworkFaultE2eTest siblings —
+// wiring it into ci-journey-suite.sh would only produce a vacuous CI skip.
 @RunWith(AndroidJUnit4::class)
 class MobileLatencyStormSelfInflictedCloseE2eTest : NetworkFaultProofBase() {
 
@@ -162,7 +170,8 @@ class MobileLatencyStormSelfInflictedCloseE2eTest : NetworkFaultProofBase() {
      * the session stays Connected.
      */
     @Test
-    fun mobileLatencyStormIsSelfInflicted() = runBlocking<Unit> {
+    fun mobileLatencyStormIsSelfInflicted() {
+        runBlocking {
         assumeNetworkFaultProofsEnabled()
 
         val key = readFixtureKey()
@@ -319,6 +328,7 @@ class MobileLatencyStormSelfInflictedCloseE2eTest : NetworkFaultProofBase() {
         } finally {
             runCatching { runBlocking { latencyProbe.close() } }
         }
+        }
     }
 
     /**
@@ -328,7 +338,8 @@ class MobileLatencyStormSelfInflictedCloseE2eTest : NetworkFaultProofBase() {
      * constrains the THRESHOLD, not "reconnects are banned universally".
      */
     @Test
-    fun wifiBaselineNoStormNoReconnect() = runBlocking<Unit> {
+    fun wifiBaselineNoStormNoReconnect() {
+        runBlocking {
         assumeNetworkFaultProofsEnabled()
 
         val key = readFixtureKey()
@@ -382,6 +393,7 @@ class MobileLatencyStormSelfInflictedCloseE2eTest : NetworkFaultProofBase() {
                 "expectation=zero overrun, zero reconnect (under-threshold extreme)",
             ),
         )
+        }
     }
 
     // -- assertions --------------------------------------------------------------------

--- a/app/src/androidTest/java/com/pocketshell/app/proof/NetworkFaultProofBase.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/NetworkFaultProofBase.kt
@@ -40,6 +40,11 @@ import com.pocketshell.core.tmux.TmuxClientFactory
 import com.termux.view.TerminalView
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import org.junit.After
@@ -47,6 +52,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Assume
 import org.junit.Rule
 import java.io.File
+import java.util.concurrent.CopyOnWriteArrayList
 
 /**
  * Shared harness for opt-in network-fault proof tests.
@@ -114,6 +120,22 @@ abstract class NetworkFaultProofBase {
 
     protected fun toxiproxy(): ToxiproxyControl =
         ToxiproxyControl(baseUrl = "http://$DEFAULT_HOST:$TOXIPROXY_API_PORT")
+
+    /**
+     * Issue #1681 — open the UN-PROXIED sentinel: a direct SSH connection to the
+     * fixture SSH port (2222, no toxiproxy in the path) that exec-pings on a fixed
+     * cadence for the whole storm window. It is the "everything else works fine"
+     * control — because it never rides the delayed proxy, it hard-proves the host
+     * + sshd + network path stayed perfectly healthy throughout, so ANY lease
+     * death the app suffers over the merely-DELAYED (never-severed) proxy is
+     * SELF-INFLICTED by construction, not a real remote drop. [SshSentinel.stop]
+     * must be called in teardown.
+     */
+    protected suspend fun openUnProxiedSentinel(
+        key: String,
+        scope: CoroutineScope,
+        intervalMs: Long = SENTINEL_INTERVAL_MS,
+    ): SshSentinel = SshSentinel.open(key, scope, intervalMs)
 
     protected suspend fun prepareProxyAndRemoteSession(
         key: String,
@@ -708,11 +730,85 @@ abstract class NetworkFaultProofBase {
         const val TOXIPROXY_API_PORT: Int = 8474
         const val DATABASE_NAME: String = "pocketshell.db"
         const val DEVICE_DIR_NAME: String = "issue342-network-faults"
+
+        /** Issue #1681 — the un-proxied sentinel exec-ping cadence. */
+        const val SENTINEL_INTERVAL_MS: Long = 3_000L
+
         val NETWORK_FAULT_FOLDER_CANDIDATES: List<String> = listOf(
             FolderListViewModel.UNTRACKED_PATH,
             "/home/testuser",
             "~",
         )
+    }
+}
+
+/**
+ * Issue #1681 — the un-proxied liveness sentinel (see
+ * [NetworkFaultProofBase.openUnProxiedSentinel]). Holds a single direct SSH
+ * session to the fixture SSH port (never through toxiproxy) and exec-pings it on
+ * a fixed cadence in the background for the life of the storm window. Every
+ * failed or timed-out ping is recorded; [isAlive] is true only when EVERY ping
+ * round-tripped and the session is still connected. That is the constructive
+ * proof the host + network stayed healthy, so a lease death over the delayed
+ * proxy is attributable to the app, not the link.
+ */
+class SshSentinel private constructor(
+    private val session: SshSession,
+    scope: CoroutineScope,
+    private val intervalMs: Long,
+) {
+    private val failures = CopyOnWriteArrayList<String>()
+
+    @Volatile
+    private var pings: Int = 0
+
+    @Volatile
+    private var attempts: Int = 0
+
+    private val job: Job = scope.launch(Dispatchers.IO) {
+        while (isActive) {
+            attempts += 1
+            val outcome = runCatching {
+                withTimeout(SENTINEL_PING_TIMEOUT_MS) { session.exec("printf pong") }
+            }.getOrNull()
+            if (outcome != null && outcome.exitCode == 0 && outcome.stdout.contains("pong")) {
+                pings += 1
+            } else {
+                failures += "ping #$attempts: exit=${outcome?.exitCode} " +
+                    "stdout='${outcome?.stdout?.take(80)}' stderr='${outcome?.stderr?.take(80)}'"
+            }
+            delay(intervalMs)
+        }
+    }
+
+    val pingCount: Int get() = pings
+    val attemptCount: Int get() = attempts
+    val failureLog: List<String> get() = failures.toList()
+
+    /** True only when no ping ever failed AND the un-proxied session is still up. */
+    val isAlive: Boolean get() = failures.isEmpty() && runCatching { session.isConnected }.getOrDefault(false)
+
+    fun stop() {
+        job.cancel()
+        runCatching { runBlocking { session.close() } }
+    }
+
+    companion object {
+        private const val SENTINEL_PING_TIMEOUT_MS: Long = 20_000L
+
+        suspend fun open(key: String, scope: CoroutineScope, intervalMs: Long): SshSentinel {
+            val session = withTimeout(20_000) {
+                SshConnection.connect(
+                    host = DEFAULT_HOST,
+                    port = DEFAULT_PORT,
+                    user = DEFAULT_USER,
+                    key = SshKey.Pem(key),
+                    knownHosts = KnownHostsPolicy.AcceptAll,
+                    timeoutMs = 15_000,
+                ).getOrThrow()
+            }
+            return SshSentinel(session, scope, intervalMs)
+        }
     }
 }
 

--- a/app/src/debug/java/com/pocketshell/app/proof/ToxiproxyControl.kt
+++ b/app/src/debug/java/com/pocketshell/app/proof/ToxiproxyControl.kt
@@ -72,6 +72,41 @@ class ToxiproxyControl(
     }
 
     /**
+     * Issue #1681 — the pinned MOBILE-SPIKE profile: a symmetric one-way latency
+     * of [MOBILE_ONE_WAY_LATENCY_MS] on BOTH directions, so a single SSH
+     * round-trip costs ~2 × that ≈ [MOBILE_RTT_MS] ms. That RTT is the
+     * deterministic "WiFi ok, mobile breaks" pin (#1680 Track B): a bounded
+     * remote exec is a channel-open + exec + read (~2–3 round-trips + host CLI),
+     * so at ~1.8 s RTT it costs ~5 s and OVERRUNS the 3.5 s bounded-exec budget
+     * (`AgentKindRemoteSource`, `SessionCardsRemoteSource`, `FolderListGateway`),
+     * while the `-CC` liveness probe (5 s per-probe, a single-round-trip
+     * refresh-client), the transport keepalive (30 s interval), the tmux command
+     * timeout (10 s), AND the 8 s TransportDispatcher per-op wall-clock ceiling
+     * (#937/#1567) all stay green — only the 3.5 s bounded-exec threshold
+     * crosses. Jitter is 0 so the RTT is a stable, citable figure (the #817
+     * fixed-RTT model, not a fuzz model), which is what makes the red→green gate
+     * deterministic.
+     *
+     * NB (#1681 implementation finding): the RTT is deliberately ~1.8 s, NOT the
+     * ~4.0 s the original #1681 recipe pinned. That recipe's budget analysis
+     * omitted the 8 s TransportDispatcher per-op ceiling; at ~4.0 s RTT a raw
+     * multi-round-trip exec exceeds 8 s and is killed by the TRANSPORT ceiling,
+     * confounding the classify's 3.5 s self-close attribution. ~1.8 s RTT (a
+     * realistic loaded-LTE figure — the design's own table calls RTT 0.5–4 s
+     * routine) crosses the 3.5 s classify bound while a fresh exec still finishes
+     * under 8 s, keeping the self-inflicted signal surgical (G6).
+     *
+     * The matching under-threshold extreme is [addSymmetricLatency] with
+     * [WIFI_ONE_WAY_LATENCY_MS] (RTT ≈ 150 ms) — the #1633 both-extremes pin:
+     * the same journey must show ZERO overruns on WiFi, bracketing the monotonic
+     * RTT-vs-3.5 s-bound variable at both ends.
+     *
+     * Folded into the standard `latency_upstream` / `latency_downstream` toxic
+     * names (via [addSymmetricLatency]) so [clearToxics] / [reset] remove it.
+     */
+    fun addMobileProfile() = addSymmetricLatency(MOBILE_ONE_WAY_LATENCY_MS)
+
+    /**
      * Issue #970 (the realistic-wifi stability gate): a STABLE-but-JITTERY link.
      * A steady base [latencyMs] one-way latency on BOTH directions WITH a
      * [jitterMs] random jitter band models a physically stable wifi/mobile link
@@ -169,9 +204,28 @@ class ToxiproxyControl(
         )
     }
 
-    private companion object {
-        const val PROXY_NAME: String = "agents_ssh"
-        val KNOWN_TOXICS: List<String> = listOf(
+    companion object {
+        /**
+         * Issue #1681 — the mobile-spike one-way latency. RTT ≈ 2× ≈ 1.8 s; a
+         * fresh multi-round-trip exec (~5 s) clears the 3.5 s bounded-exec budget
+         * while staying under the 5 s liveness-probe, 8 s transport per-op
+         * ceiling, 10 s tmux-command, and 30 s keepalive thresholds (see
+         * [addMobileProfile] for why this is ~1.8 s, not the recipe's ~4.0 s).
+         */
+        const val MOBILE_ONE_WAY_LATENCY_MS: Int = 900
+
+        /** The resulting round-trip time for [MOBILE_ONE_WAY_LATENCY_MS] (documentation only). */
+        const val MOBILE_RTT_MS: Int = MOBILE_ONE_WAY_LATENCY_MS * 2
+
+        /**
+         * Issue #1681 — the WiFi baseline one-way latency (RTT ≈ 150 ms), the
+         * #1633 both-extremes under-threshold pin: a classify at this RTT never
+         * overruns the 3.5 s bound, so the same journey shows ZERO storm.
+         */
+        const val WIFI_ONE_WAY_LATENCY_MS: Int = 75
+
+        private const val PROXY_NAME: String = "agents_ssh"
+        private val KNOWN_TOXICS: List<String> = listOf(
             "blackhole_upstream",
             "blackhole_downstream",
             "latency_upstream",

--- a/scripts/check-ci-journey-harness.sh
+++ b/scripts/check-ci-journey-harness.sh
@@ -116,6 +116,13 @@ KNOWN_UNWIRED_ANDROID_E2E_DOCKER_CLASSES=(
   "com.pocketshell.app.proof.DisconnectFlapSoakE2eTest"
   "com.pocketshell.app.proof.EmulatorWorkflowE2eTest"
   "com.pocketshell.app.proof.FastResumeReconnectE2eTest"
+  # Nightly-extensive-only mobile-network self-inflicted storm reproduction
+  # (#1681 / #1680 Track B). A NetworkFaultProofBase toxiproxy proof: it self-skips
+  # on CI (assumeNetworkFaultProofsEnabled -> tests.yml leaves network-fault-proxy:2228
+  # + toxiproxy:8474 down), so wiring it into the per-PR ci-journey-suite.sh would only
+  # ALL-SKIP (the G3 vacuous-pass trap). It is enrolled in NETWORK_FAULT_CLASSES and
+  # runs via nightly-extensive.yml / scripts/nightly-extensive-suite.sh (proxy up).
+  "com.pocketshell.app.proof.MobileLatencyStormSelfInflictedCloseE2eTest"
   "com.pocketshell.app.proof.MultiHostSessionE2eTest"
   # Nightly-extensive-only carrier-NAT idle-mapping RECOVERY proof (#1063, R3).
   # A NetworkFaultProofBase toxiproxy half-open proof: it self-skips on CI

--- a/scripts/nightly-extensive-suite.sh
+++ b/scripts/nightly-extensive-suite.sh
@@ -117,6 +117,19 @@ NETWORK_FAULT_CLASSES=(
   # keepalive layer in shared/core-ssh (NatIdleMappingSurvivalKeepAliveTest, the
   # Unit gate). Reuses network-fault-proxy:2228 + toxiproxy API:8474 (no new fixture).
   "$FQCN_PREFIX.NatIdleMappingSurvivalE2eTest"
+  # Issue #1681 (#1680 Track B / H1): the DETERMINISTIC mobile-network
+  # self-inflicted lease-close storm reproduction. A toxiproxy symmetric-latency
+  # profile (RTT ≈ 4.0s mobile pin, ≈ 150ms wifi pin) makes a confirmed-shell
+  # `agents kind` classify overrun the real 3.5s bounded-exec budget over the
+  # SHARED `-CC` lease, while an UN-PROXIED sentinel proves the host stayed healthy
+  # (so any drop is self-inflicted by construction — G6). RED on the pre-#1641
+  # close()-on-timeout shim (passive_disconnect classification=
+  # real_tmux_control_channel_closed); GREEN on merged #1641 (bounded_exec_timeout
+  # abandonment, status stays Connected). Self-skips per-push (needs
+  # network-fault-proxy:2228 + toxiproxy API:8474 which tests.yml leaves down), so
+  # it is enrolled here with its toxiproxy siblings. Reuses network-fault-proxy:2228
+  # + toxiproxy API:8474 (no new fixture).
+  "$FQCN_PREFIX.MobileLatencyStormSelfInflictedCloseE2eTest"
 )
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The D33 reproduction the maintainer asked for. Connected test + harness (`addMobileProfile()`, un-proxied sentinel) that reproduces the #1680 mobile storm on the real path — ~1.8s RTT trips only the 3.5s bounded-exec budget; sentinel proves any drop is self-inflicted. Detector keys strictly on `agent_kind_classify` (G6). Reviewer APPROVED as the Track-B regression guard (mobile arm 3/3, wifi 1/1; non-vacuity structurally enforced; the RED reproduced the exact storm signature). Deterministic synthetic-injection RED tracked as follow-up #1693. Test/harness/script only, no production change. Closes #1681