### PR TITLE
core-connection: typed DropCause on TransportDropped — reducer refuses self-inflicted drops (#1666)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -1272,9 +1272,7 @@ public class TmuxSessionViewModel @Inject constructor(
     internal fun triggerCleanPassiveDropForTest(): Boolean {
         val client = clientRef ?: return false
         if (passiveTransportDropEffects.classify(client) == PassiveDropArm.Ignore) return false
-        connectionManager.submit(
-            CoreConnectionEvent.TransportDropped(reason = "test_clean_outage_seam"),
-        )
+        connectionManager.reportRemoteDrop("test_clean_outage_seam")
         projectStatusFromController()
         handlePassiveClientDisconnect(
             client = client,
@@ -1413,9 +1411,7 @@ public class TmuxSessionViewModel @Inject constructor(
         // Immediate indicator: walk the controller Live -> Reattaching now, so the
         // connection-lost indicator (header pill / band) surfaces immediately —
         // this is the #822 DETECTION half (V7).
-        connectionManager.submit(
-            CoreConnectionEvent.TransportDropped(reason = "liveness_probe_silent_drop"),
-        )
+        connectionManager.reportRemoteDrop("liveness_probe_silent_drop")
         projectStatusFromController()
         // RECOVERY half: drive the SINGLE reconnect entrypoint
         // (`scheduleAutoReconnect` → `TransportEffects`, Slice C, with the #822

--- a/app/src/main/java/com/pocketshell/app/tmux/connection/ConnectionEffectDriver.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/connection/ConnectionEffectDriver.kt
@@ -3,6 +3,7 @@ package com.pocketshell.app.tmux.connection
 import android.util.Log
 import com.pocketshell.app.diagnostics.ReconnectCauseTrail
 import com.pocketshell.core.connection.ConnectionController
+import com.pocketshell.core.connection.DropCause
 import com.pocketshell.core.connection.ConnectionEvent
 import com.pocketshell.core.connection.ConnectionState
 import com.pocketshell.core.connection.TmuxPort
@@ -331,7 +332,14 @@ class ConnectionEffectDriver(
             } else if (shouldSubmitControlChannelDrop(client)) {
                 val wasTargetless = isTargetless()
                 val changed = submitTransport(
-                    ConnectionEvent.TransportDropped(reason = "control_channel_disconnected"),
+                    // Issue #1666: carry the TYPED cause derived at the single close authority
+                    // off THIS client's disconnect event. This path is NOT pre-filtered for a
+                    // self-inflicted `-CC` close (the lease edge's `locallyInitiated` gate is
+                    // the lease side), so typing it here + the reducer's refusal is what makes
+                    // a self-inflicted control-channel close structurally inert.
+                    ConnectionEvent.TransportDropped(
+                        SelfInflictedClose.dropCauseForControlChannelClose(client.disconnectEvent.value),
+                    ),
                 )
                 if (changed || wasTargetless) {
                     controlChannelDroppedEffect(client)
@@ -362,8 +370,14 @@ class ConnectionEffectDriver(
                     )
                     record(Observation.DropSuppressed)
                 } else {
+                    // Issue #1666: the untyped boolean oracle fallback (feeds that omit the
+                    // typed drop stream) carries no per-close intent token, so it is a genuine
+                    // remote drop by construction — production uses the typed [controlChannelDrops]
+                    // path above, which derives the real cause.
                     submitTransport(
-                        ConnectionEvent.TransportDropped(reason = "control_channel_disconnected"),
+                        ConnectionEvent.TransportDropped(
+                            DropCause.RemoteFailure("control_channel_disconnected"),
+                        ),
                     )
                 }
             }
@@ -480,9 +494,14 @@ class ConnectionEffectDriver(
                             )
                             record(Observation.DropSuppressed)
                         } else {
+                            // Issue #1666: this submit is reached ONLY past the
+                            // `edge.locallyInitiated` self-inflicted gate above, so a lease
+                            // `Down` here is a GENUINE remote drop by construction — carry it
+                            // typed as [DropCause.RemoteFailure] so the reducer runs the honest
+                            // ladder (the load-bearing NEGATIVE: real deaths must still recover).
                             submitTransport(
                                 ConnectionEvent.TransportDropped(
-                                    reason = "lease_down:${edge.reason}",
+                                    DropCause.RemoteFailure("lease_down:${edge.reason}"),
                                 ),
                             )
                         }

--- a/app/src/main/java/com/pocketshell/app/tmux/connection/ConnectionManager.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/connection/ConnectionManager.kt
@@ -4,6 +4,7 @@ import com.pocketshell.core.connection.Clock
 import com.pocketshell.core.connection.ConnectionController
 import com.pocketshell.core.connection.ConnectionEvent
 import com.pocketshell.core.connection.ConnectionState
+import com.pocketshell.core.connection.DropCause
 import com.pocketshell.core.connection.HostKey
 import com.pocketshell.core.connection.SessionId
 import com.pocketshell.core.connection.TransportPort
@@ -204,7 +205,21 @@ class ConnectionManager(
         ensureTargeting(host, targetId)
         val state = controller.state.value
         if (state is ConnectionState.Reattaching || state is ConnectionState.Reconnecting) return
-        controller.submit(ConnectionEvent.TransportDropped("reconnect"))
+        // Issue #1666: a SYNTHETIC escalation intent (the inline-transition mirror), NOT a
+        // self-inflicted transport teardown — it must walk the calm ladder, so it carries a
+        // non-[DropCause.SelfInflicted] cause the reducer acts on.
+        reportRemoteDrop("reconnect")
+    }
+
+    /**
+     * Issue #1666 (D28 Layer 3): submit a GENUINE (non-self-inflicted) transport drop, typed
+     * [DropCause.RemoteFailure], so the reducer walks the honest recovery ladder. This is the
+     * ONE seam callers (the VM's liveness-probe / clean-outage detectors, the escalation
+     * mirror) use to report a real drop, so the [DropCause] construction lives here at the
+     * connection wiring rather than being re-spelled at every call site.
+     */
+    fun reportRemoteDrop(reason: String) {
+        controller.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure(reason)))
     }
 
     /**

--- a/app/src/main/java/com/pocketshell/app/tmux/connection/SelfInflictedClose.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/connection/SelfInflictedClose.kt
@@ -1,5 +1,6 @@
 package com.pocketshell.app.tmux.connection
 
+import com.pocketshell.core.connection.DropCause
 import com.pocketshell.core.ssh.SshLeaseCloseReason
 import com.pocketshell.core.tmux.TmuxDisconnectEvent
 import com.pocketshell.core.tmux.TmuxDisconnectReason
@@ -39,16 +40,23 @@ import com.pocketshell.core.tmux.TmuxDisconnectReason
 object SelfInflictedClose {
 
     /**
-     * Is this lease `Closed` edge OUR OWN teardown?
+     * Issue #1666 (D28 Layer 3) — the TYPED cause of a lease `Closed` edge. This is the
+     * ONE derivation authority for the lease edge: [isSelfInflictedLeaseClose] is now just
+     * `this is SelfInflicted`, so there is a SINGLE exhaustive `when` (no parallel filter to
+     * drift). The reducer refuses a [DropCause.SelfInflicted] drop by construction
+     * (`ConnectionController.onTransportDropped`), so the storm cannot be re-fed by any close
+     * path that carries this cause.
      *
      * @param reason the [SshLeaseCloseReason] the lease manager stamped on the edge at its
      *   emit site. The reason IS the emitter's intent token — every `emitStateLocked` call
      *   in `SshLeaseManager` names why it is closing — so this is emitter-side tagging, not
      *   consumer-side inference about "was that us?" (the inference that rotted into #1632).
      */
-    fun isSelfInflictedLeaseClose(reason: SshLeaseCloseReason?): Boolean = when (reason) {
+    fun dropCauseForLeaseClose(reason: SshLeaseCloseReason?): DropCause = when (reason) {
         // We asked for the teardown. `ExplicitDisconnect` is the reported defect itself:
-        // recovery's own first act (`TmuxSessionViewModel.kt:8455`).
+        // recovery's own first act (`TmuxSessionViewModel.kt:8455`). This is also the class
+        // the #1681 `agent_kind_classify` self-close falls into — a bounded-exec/probe that
+        // tears down (or force-refreshes) the shared lease it borrowed.
         SshLeaseCloseReason.ExplicitDisconnect,
         // We evicted a warm transport to force a fresh dial (network handoff / recovery).
         SshLeaseCloseReason.ForceRefresh,
@@ -61,47 +69,69 @@ object SelfInflictedClose {
         // We cancelled our own in-flight connect (#1185). It never produced a live
         // transport, so there is no transport to have "dropped".
         SshLeaseCloseReason.ConnectCancelled,
-        -> true
+        -> DropCause.SelfInflicted(reason.name)
 
         // The peer died under us. sshj flipped `isConnected` false — per the #1632
         // investigation a raw SSHException from a channel read means the transport was
         // ALREADY dead, so a redial is justified.
-        SshLeaseCloseReason.Disconnected,
+        SshLeaseCloseReason.Disconnected -> DropCause.RemoteFailure(reason.name)
+
         // The always-on keepalive watchdog (#945) DETECTED a silent peer death and closed
         // the corpse. We executed the close; the peer caused it. This is precisely the
         // mobile silent-drop detector — filtering it would strand the maintainer with no
         // reconnect at all, the one outcome worse than the storm.
-        SshLeaseCloseReason.KeepaliveDead,
+        SshLeaseCloseReason.KeepaliveDead -> DropCause.KeepaliveDead
+
         // An unnamed close carries no evidence of local intent; assume genuine and recover.
-        null,
-        -> false
+        null -> DropCause.Unknown
     }
 
     /**
-     * Is this `-CC` control-channel disconnect OUR OWN close? Preserves the #1568 P0-5
-     * behavior exactly — it is the same predicate, relocated from the deleted inline
-     * `TmuxSessionViewModel` lambda into this authority.
+     * Is this lease `Closed` edge OUR OWN teardown? Thin predicate over the typed
+     * [dropCauseForLeaseClose] authority so the self-inflicted answer is derived in exactly
+     * ONE place. Behaviour is unchanged from the pre-#1666 exhaustive `when`.
      */
-    fun isSelfInflictedControlChannelClose(event: TmuxDisconnectEvent?): Boolean {
-        if (event == null) return false
+    fun isSelfInflictedLeaseClose(reason: SshLeaseCloseReason?): Boolean =
+        dropCauseForLeaseClose(reason) is DropCause.SelfInflicted
+
+    /**
+     * Issue #1666 (D28 Layer 3) — the TYPED cause of a `-CC` control-channel disconnect.
+     * The ONE derivation authority for the `-CC` edge (the driver's control-channel submit
+     * carries this straight onto the [com.pocketshell.core.connection.ConnectionEvent.TransportDropped]
+     * so a self-inflicted `-CC` close the driver does NOT pre-filter is still refused by the
+     * reducer). Preserves the #1568 P0-5 classification exactly.
+     */
+    fun dropCauseForControlChannelClose(event: TmuxDisconnectEvent?): DropCause {
+        // An unnamed close carries no evidence of local intent; assume genuine and recover.
+        if (event == null) return DropCause.Unknown
         // #1568: a detach performed as part of swapping/replacing the attached client.
-        if (event.intent == DETACH_OR_REPLACE_INTENT) return true
+        if (event.intent == DETACH_OR_REPLACE_INTENT) return DropCause.SelfInflicted(DETACH_OR_REPLACE_INTENT)
         return when (event.reason) {
             // Our own `TmuxClient.close()` / detach. Ignoring these is what broke the
             // #1562 dial -> close -> re-arm -> dial storm.
             TmuxDisconnectReason.ExplicitClose,
             TmuxDisconnectReason.ExplicitDetach,
-            -> true
+            -> DropCause.SelfInflicted(event.reason.name)
 
             // Genuine passive losses — recovery depends on every one of these arming.
             TmuxDisconnectReason.ReaderEof,
             TmuxDisconnectReason.ReaderException,
             TmuxDisconnectReason.CommandTimeout,
             TmuxDisconnectReason.ServerExited,
-            TmuxDisconnectReason.Unknown,
-            -> false
+            -> DropCause.RemoteFailure(event.reason.name)
+
+            // A genuinely unattributable reader exit — the conservative not-self-inflicted
+            // bucket, still recovers.
+            TmuxDisconnectReason.Unknown -> DropCause.Unknown
         }
     }
+
+    /**
+     * Is this `-CC` control-channel disconnect OUR OWN close? Thin predicate over the typed
+     * [dropCauseForControlChannelClose] authority. Preserves the #1568 P0-5 behavior exactly.
+     */
+    fun isSelfInflictedControlChannelClose(event: TmuxDisconnectEvent?): Boolean =
+        dropCauseForControlChannelClose(event) is DropCause.SelfInflicted
 
     /** The #1568 client-swap intent marker carried on a detach we performed ourselves. */
     private const val DETACH_OR_REPLACE_INTENT = "detach_or_replace"

--- a/app/src/test/java/com/pocketshell/app/tmux/connection/ConnectionEffectDriverTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/connection/ConnectionEffectDriverTest.kt
@@ -4,6 +4,7 @@ import com.pocketshell.app.tmux.FakeTmuxClient
 import com.pocketshell.core.connection.Clock
 import com.pocketshell.core.connection.ConnectionController
 import com.pocketshell.core.connection.ConnectionEvent
+import com.pocketshell.core.connection.DropCause
 import com.pocketshell.core.connection.ConnectionState
 import com.pocketshell.core.connection.HostKey
 import com.pocketshell.core.connection.SessionId
@@ -277,7 +278,7 @@ class ConnectionEffectDriverTest {
         controller.submit(ConnectionEvent.SeedLanded(sessionA, paneId = "%0")) // Live
         controller.submit(ConnectionEvent.Switch(sessionB))
         controller.submit(ConnectionEvent.SeedLanded(sessionB, paneId = "%0")) // Live
-        controller.submit(ConnectionEvent.TransportDropped("drop")) // -> Reattaching
+        controller.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("drop"))) // -> Reattaching
 
         assertEquals("detach trigger only on Backgrounded entry", 0, detachTriggers)
         scope.cancel()
@@ -347,7 +348,7 @@ class ConnectionEffectDriverTest {
         // NOT a foreground return, so the reseed-only foreground effect must NOT fire.
         controller.submit(ConnectionEvent.Enter(host, sessionA))
         controller.submit(ConnectionEvent.SeedLanded(sessionA, paneId = "%0")) // Live
-        controller.submit(ConnectionEvent.TransportDropped("keepalive")) // Live -> Reattaching
+        controller.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("keepalive"))) // Live -> Reattaching
 
         assertEquals(
             "the within-grace foreground reseed must only fire on Backgrounded -> Reattaching",
@@ -493,8 +494,8 @@ class ConnectionEffectDriverTest {
         // must NOT fire — only the Backgrounded -> Reconnecting edge does.
         controller.submit(ConnectionEvent.Enter(host, sessionA))
         controller.submit(ConnectionEvent.SeedLanded(sessionA, paneId = "%0")) // Live
-        controller.submit(ConnectionEvent.TransportDropped("keepalive")) // -> Reattaching
-        controller.submit(ConnectionEvent.TransportDropped("keepalive")) // -> Reconnecting(1)
+        controller.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("keepalive"))) // -> Reattaching
+        controller.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("keepalive"))) // -> Reconnecting(1)
 
         assertEquals(
             "the foreground arm must only fire on Backgrounded -> Reconnecting",
@@ -1001,7 +1002,7 @@ class ConnectionEffectDriverTest {
 
         h.controller.submit(ConnectionEvent.Enter(host, sessionA))
         h.controller.submit(ConnectionEvent.SeedLanded(sessionA, paneId = "%0")) // Live
-        h.controller.submit(ConnectionEvent.TransportDropped("keepalive")) // -> Reattaching
+        h.controller.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("keepalive"))) // -> Reattaching
 
         assertEquals(listOf("Idle", "Attaching", "Live", "Reattaching"), h.stateNames())
         scope.cancel()
@@ -1053,7 +1054,7 @@ class ConnectionEffectDriverTest {
         h.controller.submit(ConnectionEvent.SeedLanded(sessionB, paneId = "%0"))
         h.controller.submit(ConnectionEvent.Background)
         h.controller.submit(ConnectionEvent.Foreground)
-        h.controller.submit(ConnectionEvent.TransportDropped("drop"))
+        h.controller.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("drop")))
         h.tmuxPort.disconnectedFlow.emit(true)
         h.transportPort.transportEventsFlow.emit(TransportUpDown.Down(host, "closed", locallyInitiated = false))
 

--- a/app/src/test/java/com/pocketshell/app/tmux/connection/Issue1666DropCauseMappingTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/connection/Issue1666DropCauseMappingTest.kt
@@ -1,0 +1,152 @@
+package com.pocketshell.app.tmux.connection
+
+import com.pocketshell.core.connection.DropCause
+import com.pocketshell.core.ssh.SshLeaseCloseReason
+import com.pocketshell.core.tmux.TmuxDisconnectEvent
+import com.pocketshell.core.tmux.TmuxDisconnectReason
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1666 (D28 Layer 3) — the derivation authority: [SelfInflictedClose] turns the
+ * close reason the emitter named into a TYPED [DropCause]. This pins:
+ *
+ *  - every lease/`-CC` close reason maps to the intended cause (exhaustive, both edges);
+ *  - the #1681 storm's `agent_kind_classify` self-close (a bounded-exec/probe that tears
+ *    down or force-refreshes the shared lease it borrowed) maps to [DropCause.SelfInflicted],
+ *    so the reducer refuses it;
+ *  - a GENUINE death (`Disconnected`, keepalive, reader EOF/exception, server exit) maps to
+ *    a NON-self-inflicted cause, so recovery still runs (the load-bearing negative);
+ *  - the existing boolean predicates delegate to the typed authority (ONE source of truth,
+ *    no parallel filter to drift — the #1632 rot).
+ */
+class Issue1666DropCauseMappingTest {
+
+    // ---- Lease edge ----
+
+    @Test
+    fun `self-inflicted lease reasons map to SelfInflicted`() {
+        val selfInflicted = listOf(
+            SshLeaseCloseReason.ExplicitDisconnect,
+            SshLeaseCloseReason.ForceRefresh,
+            SshLeaseCloseReason.IdleExpired,
+            SshLeaseCloseReason.IdleTrimmed,
+            SshLeaseCloseReason.ProcessStopped,
+            SshLeaseCloseReason.ManagerClosed,
+            SshLeaseCloseReason.ConnectCancelled,
+        )
+        for (reason in selfInflicted) {
+            val cause = SelfInflictedClose.dropCauseForLeaseClose(reason)
+            assertTrue("$reason should be SelfInflicted, was $cause", cause is DropCause.SelfInflicted)
+            assertEquals(reason.name, (cause as DropCause.SelfInflicted).reason)
+        }
+    }
+
+    @Test
+    fun `the #1681 agent_kind_classify self-close reason maps to SelfInflicted`() {
+        // The bounded-exec/probe self-close (the #1681 mobile-latency storm) tears down or
+        // force-refreshes the shared lease it borrowed — ExplicitDisconnect / ForceRefresh.
+        assertTrue(
+            SelfInflictedClose.dropCauseForLeaseClose(SshLeaseCloseReason.ExplicitDisconnect)
+                is DropCause.SelfInflicted,
+        )
+        assertTrue(
+            SelfInflictedClose.dropCauseForLeaseClose(SshLeaseCloseReason.ForceRefresh)
+                is DropCause.SelfInflicted,
+        )
+    }
+
+    @Test
+    fun `genuine lease deaths map to a non-self-inflicted cause`() {
+        assertEquals(
+            DropCause.RemoteFailure("Disconnected"),
+            SelfInflictedClose.dropCauseForLeaseClose(SshLeaseCloseReason.Disconnected),
+        )
+        assertEquals(
+            DropCause.KeepaliveDead,
+            SelfInflictedClose.dropCauseForLeaseClose(SshLeaseCloseReason.KeepaliveDead),
+        )
+        // An unnamed lease close carries no local-intent evidence -> conservative Unknown.
+        assertEquals(DropCause.Unknown, SelfInflictedClose.dropCauseForLeaseClose(null))
+    }
+
+    @Test
+    fun `every lease reason maps to a non-self-inflicted cause unless it is one of the seven self-close reasons`() {
+        // Exhaustive guard: keeps the mapping honest if a new SshLeaseCloseReason is added.
+        val selfCloseReasons = setOf(
+            SshLeaseCloseReason.ExplicitDisconnect,
+            SshLeaseCloseReason.ForceRefresh,
+            SshLeaseCloseReason.IdleExpired,
+            SshLeaseCloseReason.IdleTrimmed,
+            SshLeaseCloseReason.ProcessStopped,
+            SshLeaseCloseReason.ManagerClosed,
+            SshLeaseCloseReason.ConnectCancelled,
+        )
+        for (reason in SshLeaseCloseReason.entries) {
+            val cause = SelfInflictedClose.dropCauseForLeaseClose(reason)
+            val isSelf = cause is DropCause.SelfInflicted
+            assertEquals("$reason self-inflicted classification", reason in selfCloseReasons, isSelf)
+            // The boolean predicate must agree with the typed authority (single source of truth).
+            assertEquals(isSelf, SelfInflictedClose.isSelfInflictedLeaseClose(reason))
+        }
+    }
+
+    // ---- -CC control-channel edge ----
+
+    private fun ccEvent(reason: TmuxDisconnectReason, intent: String = "reader") =
+        TmuxDisconnectEvent(reason = reason, source = "test", intent = intent)
+
+    @Test
+    fun `self-inflicted control-channel closes map to SelfInflicted`() {
+        assertTrue(
+            SelfInflictedClose.dropCauseForControlChannelClose(ccEvent(TmuxDisconnectReason.ExplicitClose))
+                is DropCause.SelfInflicted,
+        )
+        assertTrue(
+            SelfInflictedClose.dropCauseForControlChannelClose(ccEvent(TmuxDisconnectReason.ExplicitDetach))
+                is DropCause.SelfInflicted,
+        )
+        // #1568: a detach performed as part of swapping/replacing the attached client.
+        val swap = SelfInflictedClose.dropCauseForControlChannelClose(
+            ccEvent(TmuxDisconnectReason.ReaderEof, intent = "detach_or_replace"),
+        )
+        assertTrue("client-swap detach is self-inflicted regardless of reason", swap is DropCause.SelfInflicted)
+    }
+
+    @Test
+    fun `genuine control-channel losses map to a non-self-inflicted cause`() {
+        assertEquals(
+            DropCause.RemoteFailure("ReaderEof"),
+            SelfInflictedClose.dropCauseForControlChannelClose(ccEvent(TmuxDisconnectReason.ReaderEof)),
+        )
+        assertEquals(
+            DropCause.RemoteFailure("ReaderException"),
+            SelfInflictedClose.dropCauseForControlChannelClose(ccEvent(TmuxDisconnectReason.ReaderException)),
+        )
+        assertEquals(
+            DropCause.RemoteFailure("CommandTimeout"),
+            SelfInflictedClose.dropCauseForControlChannelClose(ccEvent(TmuxDisconnectReason.CommandTimeout)),
+        )
+        assertEquals(
+            DropCause.RemoteFailure("ServerExited"),
+            SelfInflictedClose.dropCauseForControlChannelClose(ccEvent(TmuxDisconnectReason.ServerExited)),
+        )
+        assertEquals(
+            DropCause.Unknown,
+            SelfInflictedClose.dropCauseForControlChannelClose(ccEvent(TmuxDisconnectReason.Unknown)),
+        )
+        // A null event carries no evidence of intent -> conservative Unknown, still recovers.
+        assertEquals(DropCause.Unknown, SelfInflictedClose.dropCauseForControlChannelClose(null))
+    }
+
+    @Test
+    fun `control-channel boolean predicate delegates to the typed authority`() {
+        for (reason in TmuxDisconnectReason.entries) {
+            val event = ccEvent(reason)
+            val isSelf = SelfInflictedClose.dropCauseForControlChannelClose(event) is DropCause.SelfInflicted
+            assertEquals(isSelf, SelfInflictedClose.isSelfInflictedControlChannelClose(event))
+        }
+        assertEquals(false, SelfInflictedClose.isSelfInflictedControlChannelClose(null))
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/connection/TransportEffectsTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/connection/TransportEffectsTest.kt
@@ -1,6 +1,7 @@
 package com.pocketshell.app.tmux.connection
 
 import com.pocketshell.core.connection.ConnectionEvent
+import com.pocketshell.core.connection.DropCause
 import com.pocketshell.core.connection.ConnectionState
 import com.pocketshell.core.connection.HostKey
 import com.pocketshell.core.connection.LivenessProbe
@@ -118,7 +119,7 @@ class TransportEffectsTest {
                     override suspend fun probe(): Boolean = false
                     override fun onProbeFailed(consecutiveFailures: Int) {
                         manager.submit(
-                            ConnectionEvent.TransportDropped("liveness_probe_silent_drop"),
+                            ConnectionEvent.TransportDropped(DropCause.RemoteFailure("liveness_probe_silent_drop")),
                         )
                         effects.onAutoReconnect { io.markAutoBodyRan() }
                     }

--- a/shared/core-connection/src/main/java/com/pocketshell/core/connection/ConnectionController.kt
+++ b/shared/core-connection/src/main/java/com/pocketshell/core/connection/ConnectionController.kt
@@ -539,8 +539,22 @@ class ConnectionController(
      */
     private fun onTransportDropped(
         current: ConnectionState,
-        @Suppress("UNUSED_PARAMETER") event: ConnectionEvent.TransportDropped,
+        event: ConnectionEvent.TransportDropped,
     ): ConnectionState {
+        // Issue #1666 (D28 Layer 3) — the reducer's OWN refusal, beneath the #1643 driver
+        // filter. A SELF-INFLICTED drop is an ECHO of a teardown WE started (recovery's own
+        // disconnect, a force-refresh eviction, an idle reap, a lifecycle teardown, a
+        // client-swap detach, an agent-classify/bounded-exec self-close) — it is NOT news of
+        // a remote death. Refuse it OUTRIGHT: no episode start, no [reconnectAttempt] advance,
+        // no state change, no ladder. This is what makes the storm impossible by construction
+        // rather than by a single effect-layer branch: any future close path that submits a
+        // self-inflicted drop is structurally inert here.
+        //
+        // The load-bearing NEGATIVE (D31): a genuine death — [DropCause.RemoteFailure] /
+        // [DropCause.KeepaliveDead] / [DropCause.Unknown] — falls straight through to the
+        // honest ladder below, so over-suppression can never silence a real drop and strand
+        // the app (the one outcome worse than the storm).
+        if (event.cause is DropCause.SelfInflicted) return current
         val host = current.hostOrNull() ?: return current
         val target = current.targetIdOrNull() ?: return current
         return when (current) {

--- a/shared/core-connection/src/main/java/com/pocketshell/core/connection/ConnectionModel.kt
+++ b/shared/core-connection/src/main/java/com/pocketshell/core/connection/ConnectionModel.kt
@@ -90,10 +90,17 @@ sealed interface ConnectionEvent {
 
     /**
      * Transport dropped: `TmuxClient.disconnected == true` or lease `Closed`.
-     * `reason` is the human-readable cause for logging (never surfaced as a
-     * scary band on its own — heal first).
+     *
+     * Issue #1666 (D28 Layer 3): the drop carries a TYPED [DropCause], derived once at
+     * the app's single close authority (`SelfInflictedClose`) off the reason the emitter
+     * named. [ConnectionController.onTransportDropped] REFUSES to advance the episode when
+     * the cause is [DropCause.SelfInflicted] — our own teardown echo is not remote death —
+     * so a self-inflicted close can never storm-feed the ladder, by construction (defense
+     * in depth beneath the #1643 driver filter). A [DropCause.RemoteFailure] /
+     * [DropCause.KeepaliveDead] / [DropCause.Unknown] still walks the honest recovery
+     * ladder. The cause is never surfaced as a scary band on its own — heal first.
      */
-    data class TransportDropped(val reason: String) : ConnectionEvent
+    data class TransportDropped(val cause: DropCause) : ConnectionEvent
 
     /** Transport is live again: lease `Connected` / `-CC` attached. */
     data object TransportLive : ConnectionEvent

--- a/shared/core-connection/src/main/java/com/pocketshell/core/connection/DropCause.kt
+++ b/shared/core-connection/src/main/java/com/pocketshell/core/connection/DropCause.kt
@@ -1,0 +1,67 @@
+package com.pocketshell.core.connection
+
+/**
+ * Issue #1666 (D28 Layer 3) — the TYPED cause of a transport drop, carried on
+ * [ConnectionEvent.TransportDropped] so the reducer can PROVE why a transport went
+ * away instead of reading a free-text `reason` string it cannot reason about.
+ *
+ * ## Why the type exists
+ * The reconnect storm (#1610/#1680) is self-inflicted teardown-churn: an app-owned
+ * close site tears down the shared per-host `-CC` lease, the reader hits EOF, and that
+ * self-inflicted EOF is re-ingested as a fresh remote failure — which re-arms the loud
+ * auto-reconnect ladder against ourselves, whose own teardown echoes again. The #1643
+ * driver filter suppresses the echo at the effect layer, but the pure reducer still
+ * could not distinguish "we did this" from "the peer died": any future close path that
+ * reaches [ConnectionController.onTransportDropped] could storm-feed the machine.
+ *
+ * Typing the cause moves the self-inflicted/real decision INTO the event, so the reducer
+ * refuses a self-inflicted drop BY CONSTRUCTION — defense in depth BENEATH the driver
+ * filter (#1666). The derivation happens ONCE, at the app's single close authority
+ * (`SelfInflictedClose`), off the reason the lease manager / `-CC` channel named at its
+ * own emit site; consumers never infer "was that us?" from a string (the #1632 rot).
+ *
+ * ## The rule mirrors [SelfInflictedClose]: LOCAL INTENT, not local execution
+ * A drop is [SelfInflicted] only when WE decided the transport should go away while, as
+ * far as we knew, it was still usable. A watchdog closing a corpse it observed dead is
+ * [RemoteFailure]/[KeepaliveDead] — REPORTING a remote death, not causing one. This is
+ * deliberately conservative: suppressing a genuine failure is strictly WORSE than the
+ * storm (the app would simply stop reconnecting), so when intent is ambiguous the answer
+ * is a non-self-inflicted cause and recovery runs.
+ */
+sealed interface DropCause {
+    /**
+     * WE tore the transport/channel down on purpose while it was still usable — recovery's
+     * own `disconnect()`, a force-refresh eviction, an idle reap, a lifecycle teardown, a
+     * client-swap detach, a bounded-exec/agent-classify self-close. An ECHO of an action
+     * already in flight, NOT news of a failure. The reducer REFUSES to advance the episode
+     * on this cause: no ladder, no counter, no state change (#1666). [reason] is the
+     * canonical cause token, for the log only — it never re-enters the decision.
+     */
+    data class SelfInflicted(val reason: String) : DropCause
+
+    /**
+     * The peer died under us: sshj flipped `isConnected` false, a raw channel-read
+     * `SSHException` (the transport was already dead), the `-CC` reader hit EOF/exception,
+     * a command timed out, the server exited, a liveness probe confirmed a silent drop.
+     * A GENUINE loss — recovery MUST run. The reducer walks the honest ladder
+     * (Live → Reattaching → Reconnecting(n) → … → Unreachable).
+     */
+    data class RemoteFailure(val reason: String) : DropCause
+
+    /**
+     * The always-on keepalive watchdog (#945) DETECTED a silent peer death and closed the
+     * corpse. We executed the close; the peer caused it — precisely the mobile silent-drop
+     * detector. Filtering it would strand the maintainer with no reconnect at all, the one
+     * outcome worse than the storm, so this walks the ladder exactly like [RemoteFailure].
+     */
+    data object KeepaliveDead : DropCause
+
+    /**
+     * A drop with no evidence of local intent — the conservative not-self-inflicted bucket
+     * (a genuinely unattributable `-CC` reader exit). Carries no local-intent claim, so the
+     * reducer treats it as a real drop and recovers. NEVER used to launder a self-inflicted
+     * close into a real one: an app-originated close is stamped [SelfInflicted] at the
+     * authority; [Unknown] is only the honest "we do not know, so assume genuine" answer.
+     */
+    data object Unknown : DropCause
+}

--- a/shared/core-connection/src/test/java/com/pocketshell/core/connection/ConnectionControllerCoverageFirstTest.kt
+++ b/shared/core-connection/src/test/java/com/pocketshell/core/connection/ConnectionControllerCoverageFirstTest.kt
@@ -78,7 +78,7 @@ class ConnectionControllerCoverageFirstTest {
         // passive disconnect the #630 inline skip guards against). The
         // controller interprets the drop against the CURRENT target (B) — it
         // heals B silently and never pauses/stalls/resurrects A.
-        controller.submit(ConnectionEvent.TransportDropped("late EOF from left session A"))
+        controller.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("late EOF from left session A")))
         val state = controller.state.value
         assertEquals(ConnectionState.Reattaching(host, b), state)
         // Still on B's identity, never A.
@@ -106,7 +106,7 @@ class ConnectionControllerCoverageFirstTest {
         val transport = FakeTransportPort()
         val controller = controller(transport = transport).bringLive(transport, a)
 
-        controller.submit(ConnectionEvent.TransportDropped("network blip / non-validated change"))
+        controller.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("network blip / non-validated change")))
 
         // SILENT recovery — Reattaching, NOT Unreachable. This is the
         // suppress-don't-reconnect-on-a-blip guarantee the #548 inline decision
@@ -127,7 +127,7 @@ class ConnectionControllerCoverageFirstTest {
         controller.submit(ConnectionEvent.Enter(host, a))
         assertEquals(ConnectionState.Attaching(host, a), controller.state.value)
 
-        controller.submit(ConnectionEvent.TransportDropped("control channel closed before first seed"))
+        controller.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("control channel closed before first seed")))
 
         assertEquals(ConnectionState.Reattaching(host, a), controller.state.value)
         assertEquals(a, controller.state.value.targetIdOrNull())
@@ -144,10 +144,10 @@ class ConnectionControllerCoverageFirstTest {
         val controller = controller(transport = transport, maxReconnectAttempts = 3)
             .bringLive(transport, a)
 
-        controller.submit(ConnectionEvent.TransportDropped("drop 1"))
+        controller.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("drop 1")))
         assertEquals(ConnectionState.Reattaching(host, a), controller.state.value)
 
-        controller.submit(ConnectionEvent.TransportDropped("drop 2"))
+        controller.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("drop 2")))
         assertEquals(ConnectionState.Reconnecting(host, a, attempt = 1, maxAttempts = 3), controller.state.value)
         assertEquals(a, controller.state.value.targetIdOrNull())
 
@@ -178,11 +178,11 @@ class ConnectionControllerCoverageFirstTest {
             .bringLive(transport, a)
 
         // Live -> Reattaching (silent heal).
-        controller.submit(ConnectionEvent.TransportDropped("drop 1"))
+        controller.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("drop 1")))
         assertEquals(ConnectionState.Reattaching(host, a), controller.state.value)
 
         // Heal failed -> silent reconnect ladder (attempt 1).
-        controller.submit(ConnectionEvent.TransportDropped("drop 2"))
+        controller.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("drop 2")))
         assertEquals(ConnectionState.Reconnecting(host, a, attempt = 1, maxAttempts = 2), controller.state.value)
 
         // attempt 2 (still silent — no band). #1328: ReconnectFailed advances the ladder.

--- a/shared/core-connection/src/test/java/com/pocketshell/core/connection/ConnectionControllerEpisodeStabilityTest.kt
+++ b/shared/core-connection/src/test/java/com/pocketshell/core/connection/ConnectionControllerEpisodeStabilityTest.kt
@@ -73,8 +73,8 @@ class ConnectionControllerEpisodeStabilityTest {
      * ladder (the terminal give-up — the loop this test exists to prove is reachable).
      */
     private fun ConnectionController.driveConnectThenDieCycle(clock: FakeClock, aliveMs: Long): Rung? {
-        submit(ConnectionEvent.TransportDropped("keepalive death")) // Live -> Reattaching
-        submit(ConnectionEvent.TransportDropped("silent heal failed")) // -> Reconnecting
+        submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("keepalive death"))) // Live -> Reattaching
+        submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("silent heal failed"))) // -> Reconnecting
         setReconnectLadder(ladder) // the VM installs its autoReconnectDelaysMs
         submit(ConnectionEvent.ReconnectLadderEntered) // the VM enters the numbered ladder
         val recon = state.value as? ConnectionState.Reconnecting ?: return null
@@ -205,7 +205,7 @@ class ConnectionControllerEpisodeStabilityTest {
             ConnectionState.Unreachable(host, a),
             c.state.value,
         )
-        c.submit(ConnectionEvent.TransportDropped("late churn"))
+        c.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("late churn")))
         assertEquals(ConnectionState.Unreachable(host, a), c.state.value)
 
         // Explicit user intent (the manual Reconnect affordance) starts a FRESH episode.
@@ -213,8 +213,8 @@ class ConnectionControllerEpisodeStabilityTest {
         c.submit(ConnectionEvent.TransportLive)
         c.submit(ConnectionEvent.SeedLanded(a, "%0"))
         assertEquals(ConnectionState.Live(host, a), c.state.value)
-        c.submit(ConnectionEvent.TransportDropped("d"))
-        c.submit(ConnectionEvent.TransportDropped("d"))
+        c.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("d")))
+        c.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("d")))
         assertEquals(
             "a manual reconnect must start a fresh episode at attempt 1",
             1,
@@ -289,8 +289,8 @@ class ConnectionControllerEpisodeStabilityTest {
         }
         // The link finally holds, well past the stability window.
         clock.advanceBy(STABILITY_WINDOW_MS + 1_000L)
-        c.submit(ConnectionEvent.TransportDropped("a much later, unrelated drop"))
-        c.submit(ConnectionEvent.TransportDropped("heal failed"))
+        c.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("a much later, unrelated drop")))
+        c.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("heal failed")))
         assertEquals(
             "a proven-stable Live must commit the episode even when the rungs were " +
                 "grace-loop-fed",
@@ -318,8 +318,8 @@ class ConnectionControllerEpisodeStabilityTest {
 
         repeat(3) { c.driveConnectThenDieCycle(clock, aliveMs = LINK_LIFETIME_MS) }
         // Back to a short-lived Live, mid-episode.
-        c.submit(ConnectionEvent.TransportDropped("d"))
-        c.submit(ConnectionEvent.TransportDropped("d"))
+        c.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("d")))
+        c.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("d")))
         val mid = (c.state.value as ConnectionState.Reconnecting).attempt
         assertTrue("fixture precondition: an episode must be in flight", mid > 1)
         c.submit(ConnectionEvent.TransportLive)
@@ -346,8 +346,8 @@ class ConnectionControllerEpisodeStabilityTest {
         c.bringLive(transport)
 
         repeat(3) { c.driveConnectThenDieCycle(clock, aliveMs = LINK_LIFETIME_MS) }
-        c.submit(ConnectionEvent.TransportDropped("d"))
-        c.submit(ConnectionEvent.TransportDropped("d"))
+        c.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("d")))
+        c.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("d")))
         c.submit(ConnectionEvent.TransportLive)
         c.submit(ConnectionEvent.SeedLanded(a, "%0"))
         clock.advanceBy(STABILITY_WINDOW_MS + 1_000L) // the link genuinely recovered
@@ -381,8 +381,8 @@ class ConnectionControllerEpisodeStabilityTest {
         c.submit(ConnectionEvent.Enter(host, a)) // the user re-opens after the give-up
         c.submit(ConnectionEvent.TransportLive)
         c.submit(ConnectionEvent.SeedLanded(a, "%0"))
-        c.submit(ConnectionEvent.TransportDropped("d"))
-        c.submit(ConnectionEvent.TransportDropped("d"))
+        c.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("d")))
+        c.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("d")))
         assertTrue(c.state.value is ConnectionState.Reconnecting)
 
         c.submit(ConnectionEvent.Background)
@@ -422,8 +422,8 @@ class ConnectionControllerEpisodeStabilityTest {
 
         // Burn three uncommitted cycles: the counter is now deep in the ladder.
         repeat(3) { c.driveConnectThenDieCycle(clock, aliveMs = LINK_LIFETIME_MS) }
-        c.submit(ConnectionEvent.TransportDropped("d"))
-        c.submit(ConnectionEvent.TransportDropped("d"))
+        c.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("d")))
+        c.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("d")))
         val escalated = c.state.value as ConnectionState.Reconnecting
         assertTrue(
             "fixture precondition: the counter must be escalated before the stable window",
@@ -437,13 +437,13 @@ class ConnectionControllerEpisodeStabilityTest {
         clock.advanceBy(STABILITY_WINDOW_MS + 1_000L)
 
         // A later, unrelated drop: a FRESH episode, attempt 1, instant first rung.
-        c.submit(ConnectionEvent.TransportDropped("unrelated later drop"))
+        c.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("unrelated later drop")))
         assertEquals(
             "a proven-stable link must heal silently first, exactly as before",
             ConnectionState.Reattaching(host, a),
             c.state.value,
         )
-        c.submit(ConnectionEvent.TransportDropped("heal failed"))
+        c.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("heal failed")))
         val fresh = c.state.value as ConnectionState.Reconnecting
         assertEquals(
             "a stable connection did NOT commit the episode — a normal reconnect would " +
@@ -463,15 +463,15 @@ class ConnectionControllerEpisodeStabilityTest {
         c.bringLive(transport)
 
         c.driveConnectThenDieCycle(clock, aliveMs = LINK_LIFETIME_MS) // attempt 1 burned
-        c.submit(ConnectionEvent.TransportDropped("d"))
-        c.submit(ConnectionEvent.TransportDropped("d"))
+        c.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("d")))
+        c.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("d")))
         val before = (c.state.value as ConnectionState.Reconnecting).attempt
         c.submit(ConnectionEvent.TransportLive)
         c.submit(ConnectionEvent.SeedLanded(a, "%0"))
 
         clock.advanceBy(STABILITY_WINDOW_MS - 1)
-        c.submit(ConnectionEvent.TransportDropped("died just short of the window"))
-        c.submit(ConnectionEvent.TransportDropped("heal failed"))
+        c.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("died just short of the window")))
+        c.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("heal failed")))
         assertEquals(
             "a link that died 1ms short of the stability window must RESUME the episode",
             before + 1,
@@ -487,15 +487,15 @@ class ConnectionControllerEpisodeStabilityTest {
         c.bringLive(transport)
 
         c.driveConnectThenDieCycle(clock, aliveMs = LINK_LIFETIME_MS)
-        c.submit(ConnectionEvent.TransportDropped("d"))
-        c.submit(ConnectionEvent.TransportDropped("d"))
+        c.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("d")))
+        c.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("d")))
         assertTrue((c.state.value as ConnectionState.Reconnecting).attempt > 0)
         c.submit(ConnectionEvent.TransportLive)
         c.submit(ConnectionEvent.SeedLanded(a, "%0"))
 
         clock.advanceBy(STABILITY_WINDOW_MS)
-        c.submit(ConnectionEvent.TransportDropped("died exactly at the boundary"))
-        c.submit(ConnectionEvent.TransportDropped("heal failed"))
+        c.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("died exactly at the boundary")))
+        c.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("heal failed")))
         assertEquals(
             "at exactly the stability window the connection has proven stable — commit",
             1,
@@ -518,8 +518,8 @@ class ConnectionControllerEpisodeStabilityTest {
 
         var cycles = 0
         while (cycles < CYCLE_CAP && c.state.value !is ConnectionState.Unreachable) {
-            c.submit(ConnectionEvent.TransportDropped("d"))
-            c.submit(ConnectionEvent.TransportDropped("d"))
+            c.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("d")))
+            c.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("d")))
             c.setReconnectLadder(flat)
             c.submit(ConnectionEvent.ReconnectLadderEntered)
             val recon = c.state.value as? ConnectionState.Reconnecting ?: break
@@ -558,15 +558,15 @@ class ConnectionControllerEpisodeStabilityTest {
         c.bringLive(transport)
 
         repeat(3) { c.driveConnectThenDieCycle(clock, aliveMs = LINK_LIFETIME_MS) }
-        c.submit(ConnectionEvent.TransportDropped("d"))
-        c.submit(ConnectionEvent.TransportDropped("d"))
+        c.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("d")))
+        c.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("d")))
         assertTrue((c.state.value as ConnectionState.Reconnecting).attempt > 1)
 
         c.submit(ConnectionEvent.Switch(b))
         assertEquals(ConnectionState.Attaching(host, b), c.state.value)
         c.submit(ConnectionEvent.SeedLanded(b, "%1"))
-        c.submit(ConnectionEvent.TransportDropped("d"))
-        c.submit(ConnectionEvent.TransportDropped("d"))
+        c.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("d")))
+        c.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("d")))
         val afterSwitch = c.state.value as ConnectionState.Reconnecting
         assertEquals("a user switch is explicit intent — fresh episode at attempt 1", 1, afterSwitch.attempt)
         assertEquals(0L, afterSwitch.retryDelayMs)

--- a/shared/core-connection/src/test/java/com/pocketshell/core/connection/ConnectionControllerJitterTest.kt
+++ b/shared/core-connection/src/test/java/com/pocketshell/core/connection/ConnectionControllerJitterTest.kt
@@ -42,8 +42,8 @@ class ConnectionControllerJitterTest {
         val c = ConnectionController(FakeClock(), transport, random = Random(seed))
         c.setReconnectLadder(ladder)
         c.bringLive(transport)
-        c.submit(ConnectionEvent.TransportDropped("d")) // Live -> Reattaching
-        c.submit(ConnectionEvent.TransportDropped("d")) // -> Reconnecting(1)
+        c.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("d"))) // Live -> Reattaching
+        c.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("d"))) // -> Reconnecting(1)
         repeat(rungsToBurn) { c.submit(ConnectionEvent.ReconnectFailed) }
         return (c.state.value as ConnectionState.Reconnecting).retryDelayMs
     }
@@ -142,8 +142,8 @@ class ConnectionControllerJitterTest {
         val c = ConnectionController(FakeClock(), transport, random = Random(7))
         c.setReconnectLadder(ladder)
         c.bringLive(transport)
-        c.submit(ConnectionEvent.TransportDropped("d"))
-        c.submit(ConnectionEvent.TransportDropped("d")) // -> Reconnecting(1)
+        c.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("d")))
+        c.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("d"))) // -> Reconnecting(1)
         c.submit(ConnectionEvent.ReconnectFailed) // -> Reconnecting(2), a jittered rung
 
         val attempt = (c.state.value as ConnectionState.Reconnecting).attempt
@@ -176,8 +176,8 @@ class ConnectionControllerJitterTest {
         val rungPerInstall = (0 until 30).map {
             c.setReconnectLadder(ladder)
             c.bringLive(transport)
-            c.submit(ConnectionEvent.TransportDropped("d"))
-            c.submit(ConnectionEvent.TransportDropped("d"))
+            c.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("d")))
+            c.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("d")))
             c.submit(ConnectionEvent.ReconnectFailed)
             val d = (c.state.value as ConnectionState.Reconnecting).retryDelayMs
             assertWithinJitterBand(1_000L, d, "per-install rung 2")

--- a/shared/core-connection/src/test/java/com/pocketshell/core/connection/ConnectionControllerNetworkChangedTest.kt
+++ b/shared/core-connection/src/test/java/com/pocketshell/core/connection/ConnectionControllerNetworkChangedTest.kt
@@ -81,7 +81,7 @@ class ConnectionControllerNetworkChangedTest {
         val controller = controller(transport).bringLive(transport)
 
         // A transient drop puts us mid-heal (silent).
-        controller.submit(ConnectionEvent.TransportDropped("blip"))
+        controller.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("blip")))
         assertEquals(ConnectionState.Reattaching(host, a), controller.state.value)
 
         // A network change during the heal must NOT restart the ladder or surface

--- a/shared/core-connection/src/test/java/com/pocketshell/core/connection/ConnectionControllerReconnectLadderTest.kt
+++ b/shared/core-connection/src/test/java/com/pocketshell/core/connection/ConnectionControllerReconnectLadderTest.kt
@@ -39,8 +39,8 @@ class ConnectionControllerReconnectLadderTest {
         transport.setWarm(host, true)
         submit(ConnectionEvent.TransportLive)
         submit(ConnectionEvent.SeedLanded(a, "%0")) // Live
-        submit(ConnectionEvent.TransportDropped("d")) // Live -> Reattaching
-        submit(ConnectionEvent.TransportDropped("d")) // Reattaching -> Reconnecting(1)
+        submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("d"))) // Live -> Reattaching
+        submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("d"))) // Reattaching -> Reconnecting(1)
     }
 
     /**
@@ -88,8 +88,8 @@ class ConnectionControllerReconnectLadderTest {
         val (c, transport) = controller(ladder = listOf(0L, 0L, 0L))
         c.bringToReconnecting(transport)
         assertEquals(1, (c.state.value as ConnectionState.Reconnecting).attempt)
-        c.submit(ConnectionEvent.TransportDropped("incidental churn"))
-        c.submit(ConnectionEvent.TransportDropped("incidental churn"))
+        c.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("incidental churn")))
+        c.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("incidental churn")))
         assertEquals(
             "raw drops while already Reconnecting hold the attempt (loop owns advancement)",
             1,

--- a/shared/core-connection/src/test/java/com/pocketshell/core/connection/ConnectionControllerTest.kt
+++ b/shared/core-connection/src/test/java/com/pocketshell/core/connection/ConnectionControllerTest.kt
@@ -247,7 +247,7 @@ class ConnectionControllerTest {
         val transport = FakeTransportPort()
         val controller = controller(transport = transport).bringLive(transport, targetId = a)
 
-        controller.submit(ConnectionEvent.TransportDropped("eof"))
+        controller.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("eof")))
         assertEquals(ConnectionState.Reattaching(host, a), controller.state.value)
 
         controller.submit(ConnectionEvent.TransportLive)
@@ -260,10 +260,10 @@ class ConnectionControllerTest {
         val controller = controller(transport = transport, maxReconnectAttempts = 2)
             .bringLive(transport, targetId = a)
 
-        controller.submit(ConnectionEvent.TransportDropped("d1"))
+        controller.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("d1")))
         assertEquals(ConnectionState.Reattaching(host, a), controller.state.value)
 
-        controller.submit(ConnectionEvent.TransportDropped("d2"))
+        controller.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("d2")))
         assertEquals(ConnectionState.Reconnecting(host, a, attempt = 1, maxAttempts = 2), controller.state.value)
 
         // Issue #1328 (S5): within the numbered ladder, advancement is the effect's

--- a/shared/core-connection/src/test/java/com/pocketshell/core/connection/Issue1654LadderAuthorityAndGiveUpWakeTest.kt
+++ b/shared/core-connection/src/test/java/com/pocketshell/core/connection/Issue1654LadderAuthorityAndGiveUpWakeTest.kt
@@ -80,7 +80,7 @@ class Issue1654LadderAuthorityAndGiveUpWakeTest {
     private fun ConnectionController.stormToGiveUp(): List<ConnectionState.Reconnecting> {
         submit(ConnectionEvent.Enter(host, target))
         submit(ConnectionEvent.SeedLanded(target, "p"))
-        submit(ConnectionEvent.TransportDropped("blip"))
+        submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("blip")))
         val rungs = mutableListOf<ConnectionState.Reconnecting>()
         repeat(40) {
             val s = submit(ConnectionEvent.ReconnectFailed)
@@ -191,7 +191,7 @@ class Issue1654LadderAuthorityAndGiveUpWakeTest {
         val c = productionShapedController(clock = clock)
         c.submit(ConnectionEvent.Enter(host, target))
         c.submit(ConnectionEvent.SeedLanded(target, "p"))
-        c.submit(ConnectionEvent.TransportDropped("blip"))
+        c.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("blip")))
         // Two rungs, then jump the wall clock past the budget: the budget, not the rung count,
         // must be what terminates. This is the bound that stops a slow flap grinding forever.
         c.submit(ConnectionEvent.ReconnectFailed)
@@ -221,7 +221,7 @@ class Issue1654LadderAuthorityAndGiveUpWakeTest {
         // Every signal that is NOT a wake must leave the give-up alone. If any of these
         // re-armed the ladder we would have traded the strand back for the infinite storm.
         val nonWakeEvents = listOf(
-            ConnectionEvent.TransportDropped("still dead"),
+            ConnectionEvent.TransportDropped(DropCause.RemoteFailure("still dead")),
             ConnectionEvent.ReconnectFailed,
             ConnectionEvent.ReconnectLadderEntered,
             ConnectionEvent.ReconnectGaveUp,

--- a/shared/core-connection/src/test/java/com/pocketshell/core/connection/Issue1666DropCauseRefusalTest.kt
+++ b/shared/core-connection/src/test/java/com/pocketshell/core/connection/Issue1666DropCauseRefusalTest.kt
@@ -1,0 +1,185 @@
+package com.pocketshell.core.connection
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1666 (D28 Layer 3) — the pure-reducer REFUSAL of a self-inflicted drop.
+ *
+ * The reconnect storm (#1610/#1680) is self-inflicted teardown-churn: an app-owned close
+ * site tears down the shared per-host `-CC` lease, the reader hits EOF, and that
+ * self-inflicted EOF is re-ingested as a fresh remote failure that re-arms the loud
+ * auto-reconnect ladder against ourselves. The #1643 driver filter suppresses that echo at
+ * the effect layer; this issue pushes the TYPED [DropCause] into the event so
+ * [ConnectionController.onTransportDropped] refuses a [DropCause.SelfInflicted] drop in the
+ * PURE reducer — defense in depth BENEATH the driver filter, where the storm becomes
+ * impossible by construction.
+ *
+ * These are the reproduce-first tests (D33/G10 at the right level — the reducer contract):
+ *  - RED on the pre-#1666 untyped reducer (`TransportDropped(reason)` had no cause to key
+ *    on, so EVERY drop advanced the machine); GREEN once the typed refusal lands.
+ *  - The load-bearing NEGATIVE (D31): a genuine death — [DropCause.RemoteFailure] /
+ *    [DropCause.KeepaliveDead] / [DropCause.Unknown] — STILL walks the honest ladder
+ *    Live → Reattaching → Reconnecting(n) → … → Unreachable. Over-suppression must never
+ *    silence a real drop (stranding the app is the one outcome worse than the storm).
+ */
+class Issue1666DropCauseRefusalTest {
+
+    private val host = HostKey("alice@host:22")
+    private val a = SessionId("A")
+
+    /** A single-rung ladder makes exhaustion deterministic: attempt 2 > maxAttempts 1. */
+    private fun controller(ladder: List<Long> = listOf(0L)): Pair<ConnectionController, FakeTransportPort> {
+        val transport = FakeTransportPort()
+        val c = ConnectionController(FakeClock(), transport, reconnectLadderMs = ladder)
+        return c to transport
+    }
+
+    private fun ConnectionController.enterConnecting(transport: FakeTransportPort) {
+        transport.setWarm(host, false)
+        submit(ConnectionEvent.Enter(host, a)) // cold -> Connecting
+    }
+
+    private fun ConnectionController.bringToAttaching(transport: FakeTransportPort) {
+        enterConnecting(transport)
+        transport.setWarm(host, true)
+        submit(ConnectionEvent.TransportLive) // Connecting -> Attaching
+    }
+
+    private fun ConnectionController.bringToLive(transport: FakeTransportPort) {
+        bringToAttaching(transport)
+        submit(ConnectionEvent.SeedLanded(a, "%0")) // Attaching -> Live
+    }
+
+    private fun ConnectionController.bringToReattaching(transport: FakeTransportPort) {
+        bringToLive(transport)
+        submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("real"))) // Live -> Reattaching
+    }
+
+    private fun ConnectionController.bringToReconnecting(transport: FakeTransportPort) {
+        bringToReattaching(transport)
+        submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("real"))) // Reattaching -> Reconnecting(1)
+    }
+
+    private fun selfInflicted() = ConnectionEvent.TransportDropped(DropCause.SelfInflicted("ExplicitDisconnect"))
+
+    // ---- Class coverage: a self-inflicted drop from EACH live-ish state is inert. ----
+
+    @Test
+    fun `self-inflicted drop from Live leaves Live untouched`() {
+        val (c, t) = controller()
+        c.bringToLive(t)
+        val before = c.state.value
+        c.submit(selfInflicted())
+        assertEquals("a self-close is not remote death — Live must not move", before, c.state.value)
+        assertTrue(c.state.value is ConnectionState.Live)
+    }
+
+    @Test
+    fun `self-inflicted drop from Reconnecting does NOT advance the ladder`() {
+        val (c, t) = controller(ladder = listOf(0L, 1_000L, 2_000L))
+        c.bringToReconnecting(t)
+        val rung = c.state.value as ConnectionState.Reconnecting
+        assertEquals(1, rung.attempt)
+
+        c.submit(selfInflicted())
+
+        val after = c.state.value as ConnectionState.Reconnecting
+        assertEquals("self-inflicted drop must not advance the attempt counter", 1, after.attempt)
+        assertEquals(rung, after)
+    }
+
+    @Test
+    fun `self-inflicted drop from Reattaching leaves Reattaching untouched`() {
+        val (c, t) = controller()
+        c.bringToReattaching(t)
+        val before = c.state.value
+        assertTrue(before is ConnectionState.Reattaching)
+        c.submit(selfInflicted())
+        assertEquals(before, c.state.value)
+    }
+
+    @Test
+    fun `self-inflicted drop from Attaching leaves Attaching untouched`() {
+        val (c, t) = controller()
+        c.bringToAttaching(t)
+        val before = c.state.value
+        assertTrue(before is ConnectionState.Attaching)
+        c.submit(selfInflicted())
+        assertEquals(before, c.state.value)
+    }
+
+    @Test
+    fun `self-inflicted drop from Connecting leaves Connecting untouched`() {
+        val (c, t) = controller()
+        c.enterConnecting(t)
+        val before = c.state.value
+        assertTrue(before is ConnectionState.Connecting)
+        c.submit(selfInflicted())
+        assertEquals(before, c.state.value)
+    }
+
+    @Test
+    fun `a self-inflicted drop starts NO episode — the next real drop heals fresh at attempt 1`() {
+        // Proves the refusal does not secretly mutate the hidden counter: if the
+        // self-inflicted drop had opened an episode, the following real drop out of Live
+        // would resume at attempt 2 instead of healing fresh.
+        val (c, t) = controller()
+        c.bringToLive(t)
+        c.submit(selfInflicted()) // inert
+        c.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("real"))) // Live -> Reattaching
+        assertTrue("a real drop after a refused self-close still heals silently", c.state.value is ConnectionState.Reattaching)
+        c.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("real"))) // Reattaching -> Reconnecting(1)
+        assertEquals(1, (c.state.value as ConnectionState.Reconnecting).attempt)
+    }
+
+    // ---- The load-bearing NEGATIVE (D31): real deaths STILL walk to Unreachable. ----
+
+    private fun assertWalksToUnreachable(cause: DropCause) {
+        val (c, t) = controller(ladder = listOf(0L)) // 1 rung -> maxAttempts 1
+        c.bringToLive(t)
+
+        c.submit(ConnectionEvent.TransportDropped(cause)) // Live -> Reattaching
+        assertTrue("$cause must heal through Reattaching", c.state.value is ConnectionState.Reattaching)
+
+        c.submit(ConnectionEvent.TransportDropped(cause)) // Reattaching -> Reconnecting(1)
+        assertEquals("$cause must arm the ladder", 1, (c.state.value as ConnectionState.Reconnecting).attempt)
+
+        c.submit(ConnectionEvent.ReconnectFailed) // attempt 2 > budget 1 -> Unreachable
+        assertTrue(
+            "$cause must reach the honest Unreachable when the ladder exhausts",
+            c.state.value is ConnectionState.Unreachable,
+        )
+    }
+
+    @Test
+    fun `remote-failure drop still walks Live to Reattaching to Reconnecting to Unreachable`() {
+        assertWalksToUnreachable(DropCause.RemoteFailure("Disconnected"))
+    }
+
+    @Test
+    fun `keepalive-dead drop still walks the honest ladder to Unreachable`() {
+        assertWalksToUnreachable(DropCause.KeepaliveDead)
+    }
+
+    @Test
+    fun `unknown drop is treated as genuine and still walks the ladder`() {
+        assertWalksToUnreachable(DropCause.Unknown)
+    }
+
+    @Test
+    fun `a real drop out of Live opens an episode where a self-inflicted one did not`() {
+        // Direct contrast at the same state: RemoteFailure from Live -> Reattaching (moves),
+        // SelfInflicted from Live -> Live (inert). The typed cause is the ONLY difference.
+        val (c1, t1) = controller()
+        c1.bringToLive(t1)
+        c1.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("real")))
+        assertTrue(c1.state.value is ConnectionState.Reattaching)
+
+        val (c2, t2) = controller()
+        c2.bringToLive(t2)
+        c2.submit(ConnectionEvent.TransportDropped(DropCause.SelfInflicted("ForceRefresh")))
+        assertTrue(c2.state.value is ConnectionState.Live)
+    }
+}


### PR DESCRIPTION
Integrates the reviewer-APPROVED PR1 for #1666 (typed `DropCause` reducer refusal).

## What
`ConnectionEvent.TransportDropped` now carries a typed `DropCause` (`SelfInflicted` / `RemoteFailure` / `KeepaliveDead` / `Unknown`, derived through the `SelfInflictedClose` authority). `ConnectionController.onTransportDropped` **refuses to advance the episode on a `SelfInflicted` drop** — defense-in-depth beneath the #1643 driver filter, in the pure reducer. Dedups duplicate passive-disconnect emissions; eliminates `disconnectIntent=unknown` on app-originated closes.

## Acceptance criteria (all met — reviewer APPROVED on the issue)
- [x] `TransportDropped` carries typed `DropCause`; `SelfInflicted` drop in Live/Reconnecting does NOT advance `reconnectAttempt`/state.
- [x] **D31 negative:** `KeepaliveDead`/`RemoteFailure` STILL walks Live→…→Unreachable (over-suppression can't silence a real death).
- [x] One input-send failure ⇒ exactly one passive-disconnect submission (dedup).
- [x] `disconnectIntent=unknown` eliminated from app-originated close paths.
- [x] Runs in per-PR `Unit tests` (`Issue1666DropCauseRefusalTest` 10, `Issue1666DropCauseMappingTest` 7).

## Local gate (integration worktree, off exact current main)
- `:shared:core-connection:test` — 162 debug + 162 release, 0 fail/err (`--rerun-tasks`, tasks executed, not cached)
- `:app:testDebugUnitTest` — 4020 tests, 0 fail/err; release variant covered by the required `Unit tests` check
- `git diff --check` OK; file-size + connection-VM ratchet guards pass with `TmuxSessionViewModel.kt` **shrinking** (−126 bytes / −45 lines)

D28/D31. PR2 (BorrowedSshSession capability split) is tracked separately.

Closes #1666