### PR TITLE
release-gate: AvdLockScript harnesses hermetic to inherited lock env (#1702)

### DIFF
--- a/app/src/test/java/com/pocketshell/app/scripts/AvdLockScriptTest.kt
+++ b/app/src/test/java/com/pocketshell/app/scripts/AvdLockScriptTest.kt
@@ -3,6 +3,7 @@ package com.pocketshell.app.scripts
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.concurrent.TimeUnit
@@ -59,10 +60,30 @@ class AvdLockScriptTest {
         val script = projectRoot.resolve(relativePath)
         assertTrue("harness is missing: $relativePath", script.toFile().exists())
 
-        val process = ProcessBuilder("bash", script.toString())
+        // Hermetic invocation (issue #1702). `scripts/pre-release-confidence-gate.sh`
+        // acquires the machine AVD lock and EXPORTS the acquire state
+        // (POCKETSHELL_AVD_LOCK_ACQUIRED and friends) BEFORE running
+        // `assembleDebug check` -> this suite. Inherited through gradle -> the test
+        // worker -> bash, that state short-circuits `pocketshell_acquire_avd_lock`
+        // so the harness self-contends with the gate's own lock. Scrub the inherited
+        // acquire state, and sandbox the lock dir + TMPDIR into a fresh per-run temp
+        // dir so no case can touch the real `$HOME/.cache/pocketshell/avd-locks/`.
+        // (The harness scripts scrub the same state themselves too; this makes the
+        // JVM boundary hermetic regardless of caller.)
+        val lockSandbox = Files.createTempDirectory("pocketshell-avd-lock-test").toFile()
+        lockSandbox.deleteOnExit()
+
+        val builder = ProcessBuilder("bash", script.toString())
             .directory(projectRoot.toFile())
             .redirectErrorStream(true)
-            .start()
+        builder.environment().apply {
+            keys.removeAll { it.startsWith("POCKETSHELL_AVD_LOCK") }
+            keys.removeAll { it.startsWith("POCKETSHELL_POOL") }
+            keys.removeAll { it.startsWith("POCKETSHELL_TOXIPROXY") }
+            put("POCKETSHELL_AVD_LOCK_DIR", lockSandbox.resolve("locks").toString())
+            put("TMPDIR", lockSandbox.toString())
+        }
+        val process = builder.start()
 
         val output = process.inputStream.bufferedReader().use { it.readText() }
         val completed = process.waitFor(timeoutSeconds, TimeUnit.SECONDS)

--- a/tests/scripts/avd-lock-sharing-test.sh
+++ b/tests/scripts/avd-lock-sharing-test.sh
@@ -27,6 +27,24 @@ set -euo pipefail
 #
 # No emulator is touched: the lock semantics are provable with two processes and
 # a lock file, and racing the real AVD would corrupt a sibling agent's run.
+#
+# Hermetic harness (issue #1702): a driving shell that already holds the machine
+# AVD lock (pre-release-confidence-gate.sh acquires it BEFORE `assembleDebug
+# check` -> this suite) EXPORTS the acquire STATE below. Inherited, it
+# short-circuits pocketshell_acquire_avd_lock in these cases (early-returns
+# "already acquired"), so worktree B "acquires" instantly while A "holds" -- the
+# gate self-contends and the load-bearing assertion fails against the gate's own
+# lock. Scrub the process-internal acquire state so the harness is correct
+# whether or not a gate holds the real lock; the #1663 anchoring is untouched.
+unset POCKETSHELL_AVD_LOCK_ACQUIRED \
+      POCKETSHELL_AVD_LOCK_FILE \
+      POCKETSHELL_AVD_LOCK_HOLDER_PID \
+      POCKETSHELL_AVD_LOCK_OWNER_PID \
+      POCKETSHELL_POOL_HOLDER_PID \
+      POCKETSHELL_POOL_OWNER_PID \
+      POCKETSHELL_POOL_SERIAL \
+      POCKETSHELL_TOXIPROXY_LOCK_HOLDER_PID \
+      POCKETSHELL_TOXIPROXY_LOCK_OWNER_PID
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
@@ -272,18 +290,30 @@ crashed_holder_does_not_wedge_the_lock() {
 # --------------------------------------------------------------------------
 default_lock_path_is_not_under_the_worktree() {
   local tmp="$1"
+  # Exercise the REAL HOME-anchored fallback (avd-lock.sh: the $HOME/.cache branch
+  # #1663), NOT the POCKETSHELL_AVD_LOCK_DIR override -- so a revert of the anchor
+  # back to $root_dir would be caught. Point HOME at a sandbox dir so the case
+  # stays hermetic (issue #1702): it resolves under the fake HOME, never the real
+  # machine lock dir, and still proves the anchor is machine-wide (same across
+  # worktrees) and not under the checkout.
   unset POCKETSHELL_AVD_LOCK_DIR || true
+  local fake_home="$tmp/home"
+  mkdir -p "$fake_home"
   make_worktree "$tmp/wt-a"
   make_worktree "$tmp/wt-b"
 
   local path_a path_b
-  path_a="$(bash -c 'source "$1/scripts/lib/avd-lock.sh"; pocketshell_avd_lock_file_for_serial "$1" emulator-5554' bash "$tmp/wt-a")"
-  path_b="$(bash -c 'source "$1/scripts/lib/avd-lock.sh"; pocketshell_avd_lock_file_for_serial "$1" emulator-5554' bash "$tmp/wt-b")"
+  path_a="$(HOME="$fake_home" bash -c 'source "$1/scripts/lib/avd-lock.sh"; pocketshell_avd_lock_file_for_serial "$1" emulator-5554' bash "$tmp/wt-a")"
+  path_b="$(HOME="$fake_home" bash -c 'source "$1/scripts/lib/avd-lock.sh"; pocketshell_avd_lock_file_for_serial "$1" emulator-5554' bash "$tmp/wt-b")"
 
   [[ "$path_a" == "$path_b" ]] \
     || fail "the same serial resolved to different lock files from two worktrees ($path_a vs $path_b) -- still worktree-anchored (issue #1657)"
   [[ "$path_a" != "$tmp/wt-a"* ]] \
     || fail "lock path is still under the worktree root: $path_a"
+  # The anchor must be the machine-wide HOME cache dir (#1663), proving it is NOT
+  # derived from the checkout.
+  [[ "$path_a" == "$fake_home/.cache/pocketshell/avd-locks/"* ]] \
+    || fail "default lock path is not HOME-anchored (#1663): $path_a"
 }
 
 with_tmpdir() {

--- a/tests/scripts/avd-lock-test.sh
+++ b/tests/scripts/avd-lock-test.sh
@@ -1,6 +1,27 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Hermetic harness (issue #1702). A driving shell that already holds the machine
+# AVD lock -- e.g. pre-release-confidence-gate.sh, which calls
+# pocketshell_acquire_avd_lock BEFORE running `assembleDebug check` -> this suite
+# -- EXPORTS the acquire STATE (POCKETSHELL_AVD_LOCK_ACQUIRED and friends). When
+# these cases fork a fresh gate, that inherited state short-circuits
+# pocketshell_acquire_avd_lock (it early-returns "already acquired"), so the lock
+# is never actually taken and the ownership assertions fail against the gate's
+# own lock -- self-contention, not a product bug. Scrub the process-internal
+# acquire state so the harness is correct whether or not a gate holds the real
+# lock. The real #1663 machine-anchoring behaviour is untouched (only avd-lock.sh
+# defines it; this only clears inherited runtime state).
+unset POCKETSHELL_AVD_LOCK_ACQUIRED \
+      POCKETSHELL_AVD_LOCK_FILE \
+      POCKETSHELL_AVD_LOCK_HOLDER_PID \
+      POCKETSHELL_AVD_LOCK_OWNER_PID \
+      POCKETSHELL_POOL_HOLDER_PID \
+      POCKETSHELL_POOL_OWNER_PID \
+      POCKETSHELL_POOL_SERIAL \
+      POCKETSHELL_TOXIPROXY_LOCK_HOLDER_PID \
+      POCKETSHELL_TOXIPROXY_LOCK_OWNER_PID
+
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 fail() {

--- a/tests/scripts/avd-pool-test.sh
+++ b/tests/scripts/avd-pool-test.sh
@@ -16,6 +16,24 @@ set -euo pipefail
 # kept the claim held forever. With a 3-emulator pool that stranded one serial
 # per run. This test would have caught it: it asserts `claimable-after-run`
 # equals the pool size, not size-1.
+#
+# Hermetic harness (issue #1702): a driving shell that already holds the machine
+# AVD lock (pre-release-confidence-gate.sh acquires it BEFORE `assembleDebug
+# check` -> this suite) EXPORTS the acquire STATE below. Inherited, it
+# short-circuits pocketshell_acquire_avd_lock inside the wrapper (early-returns
+# "already acquired"), so the base lock is never created and the non-pool
+# assertion fails -- the gate self-contends. Scrub the process-internal acquire
+# state so the harness is correct whether or not a gate holds the real lock; the
+# #1663 anchoring is untouched.
+unset POCKETSHELL_AVD_LOCK_ACQUIRED \
+      POCKETSHELL_AVD_LOCK_FILE \
+      POCKETSHELL_AVD_LOCK_HOLDER_PID \
+      POCKETSHELL_AVD_LOCK_OWNER_PID \
+      POCKETSHELL_POOL_HOLDER_PID \
+      POCKETSHELL_POOL_OWNER_PID \
+      POCKETSHELL_POOL_SERIAL \
+      POCKETSHELL_TOXIPROXY_LOCK_HOLDER_PID \
+      POCKETSHELL_TOXIPROXY_LOCK_OWNER_PID
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 


### PR DESCRIPTION
Integrates the reviewer-APPROVED fix for #1702 — the v0.4.39 release-gate blocker.

## Root cause
`AvdLockScriptTest` self-contended with the release confidence gate's own AVD lock. `pre-release-confidence-gate.sh` **exports** `POCKETSHELL_AVD_LOCK_ACQUIRED/_FILE/_HOLDER_PID/_OWNER_PID`; Gradle → test worker → `bash` inherit them, so `pocketshell_acquire_avd_lock` early-returns "already acquired" and never takes the lock — the ownership/creation assertions then fail against the gate's own lock. (A bare `flock … sleep 300` does NOT reproduce it — it never injects those env vars into Gradle, which is why the suite passed in isolation.)

## Fix (hermetic)
- Each `tests/scripts/avd-lock-*.sh` unsets the inherited acquire-state env at its top (self-hermetic regardless of caller).
- `AvdLockScriptTest.runShellHarness` scrubs inherited `POCKETSHELL_AVD_LOCK*/POOL*/TOXIPROXY*` env and sandboxes `POCKETSHELL_AVD_LOCK_DIR`+`TMPDIR` per run.
- `scripts/lib/avd-lock.sh` and `scripts/pre-release-confidence-gate.sh` **untouched** (seam already existed). The #1663 HOME-anchoring assertion is **strengthened**, not weakened.

## Verification
- Reviewer (APPROVED): reproduced RED on base with the gate lock-env exported (3 tests fail), GREEN with the fix, both variants.
- Orchestrator integration gate (this tree): per-variant `--rerun-tasks` — `:app:testDebugUnitTest` and `:app:testReleaseUnitTest` each **3 tests / 0 fail**, fresh XML, tasks executed (no UP-TO-DATE/FROM-CACHE). `git diff --check` + `bash -n` clean.

JVM `src/test` harness change, wired into the required `Unit tests` check — no emulator path. Not a reopen.

Closes #1702