### PR TITLE
diagnostics: connection-log telemetry integrity — version-stamp, lossless rotation, stranded-release guard (#1669)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -356,6 +356,20 @@ jobs:
           scripts/check-version-coupling.sh --self-test
           scripts/check-version-coupling.sh
 
+      # Issue #1669: fail at push time when the app versionName leads the newest
+      # origin release tag by more than one release — the "bumped but never
+      # tagged" miss that stranded v0.4.38 (the maintainer had to git ls-remote to
+      # discover the phone's build did not match any release). --self-test first
+      # proves the guard's own red->green logic on synthetic fixtures, then the
+      # bare run checks the real tree against origin's tags. Cheap (~1s), kept in
+      # this cheap Python job. `fetch-tags`/`ls-remote` provides the tag list even
+      # in the shallow checkout.
+      - name: "Stranded-release guard (issue #1669)"
+        run: |
+          chmod +x scripts/check-stranded-release.sh
+          scripts/check-stranded-release.sh --self-test
+          scripts/check-stranded-release.sh
+
       - name: Smoke-test installed CLI
         working-directory: tools/pocketshell
         run: |

--- a/app/src/main/java/com/pocketshell/app/diagnostics/ConnectionLogPartStore.kt
+++ b/app/src/main/java/com/pocketshell/app/diagnostics/ConnectionLogPartStore.kt
@@ -1,0 +1,177 @@
+package com.pocketshell.app.diagnostics
+
+import java.io.File
+
+/**
+ * A LOSSLESS, count-bounded, rotating part-file store for the connection log
+ * (issue #1669).
+ *
+ * ## Why this exists
+ *
+ * The field connection log is how a connection-manager storm gets reproduced
+ * locally from real device usage. Today's storm forensics recovered only ~187 of
+ * ~1,660 sequenced events from 200+ `connection-log.jsonl.part-*` files — dozens
+ * of them ZERO-LENGTH. The loss had two causes:
+ *
+ *  1. The host mirror is a **snapshot-overwrite** of a single, byte-capped file:
+ *     each transport-up re-uploads only the newest ~64KB window, so older events
+ *     fall off the host before anyone reads them.
+ *  2. Each upload creates a `<final>.part-<rand>` temp sibling (the #930 atomic
+ *     upload), and a drop mid-transfer strands it. Under a storm the strays pile
+ *     up as zero-length `.part-*` zombies that a forensic scrape then has to sift.
+ *
+ * This store is the durable, on-device archive the mirror renders FROM, so no
+ * event is dropped before the upload's budget cap. It is a classic rotating
+ * append log:
+ *
+ *  - [append] writes each line to the CURRENT part file (`…part-000001`); when a
+ *    part reaches [maxLinesPerPart] it rotates to the next index. A part file is
+ *    created lazily on its FIRST line, so a **zero-length part can never exist** —
+ *    the exact failure mode the field hit.
+ *  - [compact] folds the OLDEST parts into a single `base` file and deletes them,
+ *    bounding the on-disk part count to [maxParts]. Folding preserves every line
+ *    (append then delete), so compaction is lossless.
+ *  - [readAllLines] returns `base` followed by every part in index order —
+ *    exactly what was appended, in order.
+ *
+ * ## Concurrency / losslessness contract
+ *
+ * All mutating and reading operations serialize on a single [lock]. The
+ * production writer (the [DiagnosticRecorder] channel consumer) is already
+ * single-threaded, but the store is also driven concurrently by its stress test,
+ * so N appends from any number of threads read back as exactly N lines — never a
+ * torn line, never a dropped line, never a zero-length part.
+ */
+internal class ConnectionLogPartStore(
+    private val directory: File,
+    private val baseName: String = DEFAULT_BASE_NAME,
+    private val maxLinesPerPart: Int = DEFAULT_MAX_LINES_PER_PART,
+    private val maxParts: Int = DEFAULT_MAX_PARTS,
+) {
+    init {
+        require(maxLinesPerPart > 0) { "maxLinesPerPart must be positive" }
+        require(maxParts > 0) { "maxParts must be positive" }
+    }
+
+    private val lock = Any()
+
+    // Declared BEFORE the recovery init block below so it is initialised in
+    // Kotlin's top-to-bottom order by the time that init scans the directory
+    // (a val declared after the init block would still be null inside it).
+    private val partRegex: Regex = Regex(Regex.escape(baseName) + "\\.part-(\\d+)")
+
+    // Index (>= 1) of the newest part file, or 0 when none exist yet.
+    private var currentIndex: Int = 0
+
+    // Line count of the newest part file; drives rotation.
+    private var currentLineCount: Int = 0
+
+    init {
+        // Recover in-memory rotation state from any parts left by a prior process
+        // so appends continue the newest part instead of clobbering it.
+        synchronized(lock) {
+            val parts = partFilesLocked()
+            val newest = parts.maxByOrNull { indexOf(it) }
+            if (newest != null) {
+                currentIndex = indexOf(newest)
+                currentLineCount = newest.readNonEmptyLineCount()
+            }
+        }
+    }
+
+    /** Append one JSONL [line] durably. Rotates + compacts as needed. */
+    fun append(line: String) = synchronized(lock) {
+        if (currentIndex == 0 || currentLineCount >= maxLinesPerPart) {
+            currentIndex += 1
+            currentLineCount = 0
+        }
+        val part = partFile(currentIndex)
+        part.parentFile?.mkdirs()
+        // Append the whole line + newline in one write so a concurrent reader
+        // never observes a torn line. Creating the part here (append mode) with a
+        // non-empty write is what guarantees no zero-length part ever exists.
+        part.appendText(line + "\n")
+        currentLineCount += 1
+        if (partFilesLocked().size > maxParts) {
+            compactLocked()
+        }
+    }
+
+    /** Every line ever appended (and not lost — there is no loss), in order. */
+    fun readAllLines(): List<String> = synchronized(lock) {
+        val base = baseFile()
+        val baseLines = if (base.isFile) base.readNonEmptyLines() else emptyList()
+        baseLines + partFilesLocked().flatMap { it.readNonEmptyLines() }
+    }
+
+    /** Current on-disk part-file count (excludes the folded [baseFile]). */
+    fun partCount(): Int = synchronized(lock) { partFilesLocked().size }
+
+    /**
+     * Fold the oldest parts into [baseFile] until at most [maxParts] parts remain.
+     * Lossless: each folded part's lines are appended to base, then the part is
+     * deleted, so [readAllLines] is unchanged across a compaction.
+     */
+    fun compact() = synchronized(lock) { compactLocked() }
+
+    /** Delete every part + base file (used by the recorder's `clear`). */
+    fun clear() = synchronized(lock) {
+        baseFile().delete()
+        partFilesLocked().forEach { it.delete() }
+        currentIndex = 0
+        currentLineCount = 0
+    }
+
+    private fun compactLocked() {
+        val parts = partFilesLocked().sortedBy { indexOf(it) }
+        if (parts.size <= maxParts) return
+        val base = baseFile()
+        base.parentFile?.mkdirs()
+        // Fold all but the newest [maxParts] parts into base, oldest first.
+        val toFold = parts.dropLast(maxParts)
+        for (part in toFold) {
+            val lines = part.readNonEmptyLines()
+            if (lines.isNotEmpty()) {
+                base.appendText(lines.joinToString(separator = "\n", postfix = "\n"))
+            }
+            part.delete()
+        }
+    }
+
+    private fun baseFile(): File = File(directory, baseName)
+
+    private fun partFile(index: Int): File =
+        File(directory, "$baseName.part-" + index.toString().padStart(PART_INDEX_DIGITS, '0'))
+
+    private fun partFilesLocked(): List<File> =
+        (directory.listFiles() ?: emptyArray())
+            .filter { it.isFile && partRegex.matches(it.name) }
+            .sortedBy { indexOf(it) }
+
+    private fun indexOf(file: File): Int =
+        partRegex.matchEntire(file.name)?.groupValues?.get(1)?.toIntOrNull() ?: 0
+
+    private fun File.readNonEmptyLines(): List<String> =
+        if (isFile) readLines().filter { it.isNotEmpty() } else emptyList()
+
+    private fun File.readNonEmptyLineCount(): Int =
+        if (isFile) readLines().count { it.isNotEmpty() } else 0
+
+    companion object {
+        const val DEFAULT_BASE_NAME: String = "connection-log.jsonl"
+
+        /**
+         * Lines per part before rotation. Sized so a busy storm minute (hundreds
+         * of events) spans a handful of parts, not one file per event.
+         */
+        const val DEFAULT_MAX_LINES_PER_PART: Int = 500
+
+        /**
+         * On-disk part-file ceiling. Older parts are folded into the base file, so
+         * the directory never accumulates the 200+ parts the field forensics found.
+         */
+        const val DEFAULT_MAX_PARTS: Int = 8
+
+        private const val PART_INDEX_DIGITS = 6
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/diagnostics/DiagnosticEventJson.kt
+++ b/app/src/main/java/com/pocketshell/app/diagnostics/DiagnosticEventJson.kt
@@ -12,6 +12,13 @@ data class DiagnosticsEvent(
     val category: String,
     val name: String,
     val metadata: Map<String, Any?> = emptyMap(),
+    // Issue #1669: every event is version-stamped at record time so the field
+    // connection log is self-describing — the maintainer can read WHICH build
+    // produced a storm straight from the log, without a `git ls-remote` to guess
+    // the phone's version (which is what today's forensics had to do). Defaulted
+    // so historical lines / synthetic test events decode without a stamp.
+    val versionName: String = "",
+    val versionCode: Long = 0L,
 )
 
 data class DiagnosticEventFilter(
@@ -51,6 +58,10 @@ internal object DiagnosticEventJson {
             .put("monotonicTimestampNanos", event.monotonicTimestampNanos)
             .put("category", sanitizeToken(event.category))
             .put("name", sanitizeToken(event.name))
+            // Issue #1669: top-level (not under `metadata`) so a forensic `jq`/
+            // `head` sees the build on every line without descending into metadata.
+            .put("versionName", event.versionName)
+            .put("versionCode", event.versionCode)
         val metadata = JSONObject()
         event.metadata.toSortedMap().forEach { (key, value) ->
             metadata.put(sanitizeKey(key), JSONObject.wrap(value))
@@ -74,6 +85,8 @@ internal object DiagnosticEventJson {
             category = root.getString("category"),
             name = root.getString("name"),
             metadata = metadata,
+            versionName = root.optString("versionName", ""),
+            versionCode = root.optLong("versionCode", 0L),
         )
     }.getOrNull()
 

--- a/app/src/main/java/com/pocketshell/app/diagnostics/DiagnosticRecorder.kt
+++ b/app/src/main/java/com/pocketshell/app/diagnostics/DiagnosticRecorder.kt
@@ -60,37 +60,40 @@ class DiagnosticRecorder @Inject constructor(
      * Every store consumer (the channel loop, [exportSnapshot], [readEvents])
      * awaits this, so the warm-up runs exactly once on IO.
      */
-    private val storeDeferred: Deferred<DiagnosticLogStore> = scope.async {
+    private val storeDeferred: Deferred<RecorderStores> = scope.async {
         val store = DiagnosticLogStore(
             logFile = File(context.filesDir, "diagnostics/pocketshell-diagnostics.jsonl"),
             exportDirectory = File(context.cacheDir, DIAGNOSTICS_EXPORT_CACHE_DIR),
         )
+        val connectionLog = ConnectionLogPartStore(
+            directory = File(context.filesDir, "diagnostics/connection-log"),
+        )
         lastSequenceReadThreadName = currentPhysicalThreadName()
         sequence.set(store.lastSequence())
-        store
+        RecorderStores(events = store, connectionLog = connectionLog)
     }
 
     init {
         scope.launch {
             // Await the off-main seed BEFORE processing any command, so every
             // sequence assigned below starts from the persisted high-water mark.
-            val store = storeDeferred.await()
+            val stores = storeDeferred.await()
             for (command in commands) {
                 when (command) {
-                    is RecorderCommand.Line -> store.appendLine(encode(command.pending))
+                    is RecorderCommand.Line -> persist(stores, command.pending)
                     is RecorderCommand.Flush -> command.done.complete(Unit)
                     is RecorderCommand.Clear -> {
-                        store.clear()
+                        stores.events.clear()
+                        stores.connectionLog.clear()
                         sequence.set(0L)
                         command.done.complete(Unit)
                     }
                     is RecorderCommand.ClearAndRecord -> {
-                        store.clear()
+                        stores.events.clear()
+                        stores.connectionLog.clear()
                         sequence.set(0L)
                         if (settingsRepository.settings.value.diagnosticsRecordingEnabled) {
-                            store.appendLine(
-                                encode(pendingEvent(command.category, command.event, command.fields)),
-                            )
+                            persist(stores, pendingEvent(command.category, command.event, command.fields))
                         }
                         command.done.complete(Unit)
                     }
@@ -129,14 +132,29 @@ class DiagnosticRecorder @Inject constructor(
     suspend fun exportSnapshot(filter: DiagnosticEventFilter = DiagnosticEventFilter.All): File? {
         flush()
         return withContext(Dispatchers.IO) {
-            storeDeferred.await().exportSnapshot(deviceLabel(), appVersion(), filter)
+            storeDeferred.await().events.exportSnapshot(deviceLabel(), appVersionLabel(), filter)
         }
     }
 
     suspend fun readEvents(filter: DiagnosticEventFilter = DiagnosticEventFilter.All): List<DiagnosticsEvent> {
         flush()
         return withContext(Dispatchers.IO) {
-            storeDeferred.await().readEvents(filter)
+            storeDeferred.await().events.readEvents(filter)
+        }
+    }
+
+    /**
+     * The full, LOSSLESS connection-log archive (issue #1669): every mirrored
+     * connection-lifecycle event ever recorded (bounded only by the part store's
+     * count-compaction, not by the 64KB per-upload budget nor the 512KB device
+     * ring buffer that `readEvents` is subject to). This is the source
+     * [connectionLogJsonl] renders from, so nothing is dropped before the upload's
+     * budget cap.
+     */
+    suspend fun connectionLogArchive(): List<DiagnosticsEvent> {
+        flush()
+        return withContext(Dispatchers.IO) {
+            storeDeferred.await().connectionLog.readAllLines().mapNotNull(DiagnosticEventJson::decode)
         }
     }
 
@@ -160,9 +178,7 @@ class DiagnosticRecorder @Inject constructor(
      * never writes an empty host file.
      */
     suspend fun connectionLogJsonl(): String =
-        MirroredDiagnostics.render(
-            readEvents(DiagnosticEventFilter.All).filter(MirroredDiagnostics::isMirrored),
-        )
+        MirroredDiagnostics.render(connectionLogArchive())
 
     /**
      * Test-only (#1124): block until the off-main store build + `lastSequence()`
@@ -205,16 +221,31 @@ class DiagnosticRecorder @Inject constructor(
             metadata = DiagnosticRedactor.redact(fields, category),
         )
 
-    private fun encode(pending: PendingEvent): String =
-        DiagnosticEventJson.encode(
-            DiagnosticsEvent(
-                sequence = sequence.incrementAndGet(),
-                wallClockTime = pending.wallClockTime,
-                monotonicTimestampNanos = pending.monotonicTimestampNanos,
-                category = pending.category,
-                name = pending.name,
-                metadata = pending.metadata,
-            ),
+    /**
+     * Assign the monotonic [sequence], version-stamp (#1669), and persist [pending]
+     * to the ring-buffer store AND — when it is a mirrored connection-lifecycle
+     * event — to the lossless [ConnectionLogPartStore] archive. Runs on the single
+     * IO channel-consumer coroutine, so both writes are serialized.
+     */
+    private fun persist(stores: RecorderStores, pending: PendingEvent) {
+        val event = buildEvent(pending)
+        val line = DiagnosticEventJson.encode(event)
+        stores.events.appendLine(line)
+        if (MirroredDiagnostics.isMirrored(event)) {
+            stores.connectionLog.append(line)
+        }
+    }
+
+    private fun buildEvent(pending: PendingEvent): DiagnosticsEvent =
+        DiagnosticsEvent(
+            sequence = sequence.incrementAndGet(),
+            wallClockTime = pending.wallClockTime,
+            monotonicTimestampNanos = pending.monotonicTimestampNanos,
+            category = pending.category,
+            name = pending.name,
+            metadata = pending.metadata,
+            versionName = appVersion.name,
+            versionCode = appVersion.code,
         )
 
     private fun deviceLabel(): String =
@@ -223,7 +254,20 @@ class DiagnosticRecorder @Inject constructor(
             .joinToString(separator = " ")
             .ifBlank { "device" }
 
-    private fun appVersion(): String =
+    /**
+     * The app version used to stamp every event (#1669). Resolved lazily on first
+     * use — which happens on the IO channel-consumer coroutine, never the Main
+     * thread — so the `packageManager` read stays off the cold-launch path (#1124).
+     * A test may pin [appVersionOverride] before the first record to assert the
+     * stamp deterministically.
+     */
+    private val appVersion: AppVersion by lazy { appVersionOverride ?: readAppVersion() }
+
+    @Volatile
+    @VisibleForTesting
+    internal var appVersionOverride: AppVersion? = null
+
+    private fun readAppVersion(): AppVersion =
         runCatching {
             val info = context.packageManager.getPackageInfo(context.packageName, 0)
             val name = info.versionName?.takeIf { it.isNotBlank() } ?: "unknown"
@@ -233,8 +277,10 @@ class DiagnosticRecorder @Inject constructor(
                 @Suppress("DEPRECATION")
                 info.versionCode.toLong()
             }
-            "$name ($code)"
-        }.getOrDefault("unknown")
+            AppVersion(name = name, code = code)
+        }.getOrDefault(AppVersion(name = "unknown", code = 0L))
+
+    private fun appVersionLabel(): String = appVersion.let { "${it.name} (${it.code})" }
 
     private class PendingEvent(
         val category: String,
@@ -242,6 +288,16 @@ class DiagnosticRecorder @Inject constructor(
         val wallClockTime: Instant,
         val monotonicTimestampNanos: Long,
         val metadata: Map<String, Any?>,
+    )
+
+    /** The app version stamped onto every event (#1669). */
+    @VisibleForTesting
+    internal data class AppVersion(val name: String, val code: Long)
+
+    /** The two on-disk sinks: the ring-buffer store + the lossless archive. */
+    private class RecorderStores(
+        val events: DiagnosticLogStore,
+        val connectionLog: ConnectionLogPartStore,
     )
 
     private sealed interface RecorderCommand {

--- a/app/src/test/java/com/pocketshell/app/diagnostics/ConnectionLogPartStoreTest.kt
+++ b/app/src/test/java/com/pocketshell/app/diagnostics/ConnectionLogPartStoreTest.kt
@@ -1,0 +1,134 @@
+package com.pocketshell.app.diagnostics
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+/**
+ * Issue #1669: the field connection log must be LOSSLESS reliability evidence.
+ * Today's storm forensics recovered only ~187 of ~1,660 events from 200+
+ * `connection-log.jsonl.part-*` files (dozens ZERO-LENGTH). These tests pin the
+ * three integrity properties the store guarantees:
+ *
+ *  1. Rotation is lossless under concurrent load — write N, read back exactly N.
+ *  2. No zero-length part file is ever produced (the exact field failure mode).
+ *  3. Compaction bounds the on-disk part count without dropping a line.
+ */
+class ConnectionLogPartStoreTest {
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    private fun dir(): File = tmp.newFolder("connection-log")
+
+    @Test
+    fun `concurrent rotation is lossless — writes N reads back N`() = runBlocking {
+        // Small parts so N=4000 forces HUNDREDS of rotations — the load that
+        // stranded zero-length parts in the field. maxParts high enough that
+        // compaction folds but nothing is dropped.
+        val store = ConnectionLogPartStore(
+            directory = dir(),
+            maxLinesPerPart = 25,
+            maxParts = 1000,
+        )
+        val n = 4000
+
+        // 16 writers hammering append concurrently. On the pre-fix snapshot the
+        // host log lost ~90% of events under exactly this kind of load; here the
+        // store must read back EVERY line.
+        val perWriter = n / 16
+        (0 until 16).map { w ->
+            async(Dispatchers.IO) {
+                for (i in 0 until perWriter) {
+                    store.append("""{"seq":${w * perWriter + i},"w":$w}""")
+                }
+            }
+        }.awaitAll()
+
+        val lines = store.readAllLines()
+        assertEquals("every appended line must read back — no loss under load", n, lines.size)
+
+        // The distinct set is exactly 0..n-1: not one line torn, duplicated, or dropped.
+        val seqs = lines.map { it.substringAfter("\"seq\":").substringBefore(",").toInt() }.toSortedSet()
+        assertEquals(n, seqs.size)
+        assertEquals(0, seqs.first())
+        assertEquals(n - 1, seqs.last())
+    }
+
+    @Test
+    fun `no zero-length part file is ever produced`() = runBlocking {
+        val directory = dir()
+        val store = ConnectionLogPartStore(
+            directory = directory,
+            maxLinesPerPart = 10,
+            maxParts = 1000,
+        )
+        repeat(1000) { store.append("""{"seq":$it}""") }
+
+        val parts = directory.listFiles().orEmpty().filter { it.name.contains(".part-") }
+        assertTrue("rotation must have created multiple parts", parts.size > 1)
+        val empty = parts.filter { it.length() == 0L }
+        assertTrue("no zero-length part may exist (the field failure mode); found $empty", empty.isEmpty())
+    }
+
+    @Test
+    fun `compaction bounds the on-disk part count without dropping lines`() = runBlocking {
+        val store = ConnectionLogPartStore(
+            directory = dir(),
+            maxLinesPerPart = 10,
+            maxParts = 4,
+        )
+        val n = 500
+        repeat(n) { store.append("""{"seq":$it}""") }
+
+        // 500 lines / 10 per part = 50 parts' worth of data, but compaction keeps
+        // the on-disk part count at or below the bound by folding into the base file.
+        assertTrue(
+            "on-disk part count must be bounded to maxParts=4, was ${store.partCount()}",
+            store.partCount() <= 4,
+        )
+        // Bounding the part count must NOT lose events: all 500 still read back in order.
+        val seqs = store.readAllLines().map { it.substringAfter("\"seq\":").substringBefore("}").toInt() }
+        assertEquals((0 until n).toList(), seqs)
+    }
+
+    @Test
+    fun `explicit compact folds oldest parts into base and preserves every line`() = runBlocking {
+        val store = ConnectionLogPartStore(
+            directory = dir(),
+            maxLinesPerPart = 5,
+            maxParts = 100, // no auto-compaction; drive it explicitly
+        )
+        repeat(60) { store.append("""{"seq":$it}""") }
+        val before = store.readAllLines()
+        val partsBefore = store.partCount()
+
+        store.compact()
+
+        // compact() with maxParts=100 and only 12 parts is a no-op on count, but
+        // the read is byte-for-byte identical either way — compaction is lossless.
+        assertEquals("compaction never changes the readback", before, store.readAllLines())
+        assertTrue(partsBefore >= 1)
+    }
+
+    @Test
+    fun `rotation state recovers across store re-open so a restart never clobbers a part`() = runBlocking {
+        val directory = dir()
+        ConnectionLogPartStore(directory, maxLinesPerPart = 100, maxParts = 100).apply {
+            repeat(30) { append("""{"seq":$it}""") }
+        }
+        // A fresh store over the SAME directory (process restart) must continue the
+        // existing part, not start over and lose the 30 lines already on disk.
+        val reopened = ConnectionLogPartStore(directory, maxLinesPerPart = 100, maxParts = 100)
+        repeat(20) { reopened.append("""{"seq":${30 + it}}""") }
+
+        val seqs = reopened.readAllLines().map { it.substringAfter("\"seq\":").substringBefore("}").toInt() }
+        assertEquals((0 until 50).toList(), seqs)
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/diagnostics/Issue1669ConnectionLogTelemetryTest.kt
+++ b/app/src/test/java/com/pocketshell/app/diagnostics/Issue1669ConnectionLogTelemetryTest.kt
@@ -1,0 +1,120 @@
+package com.pocketshell.app.diagnostics
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.pocketshell.app.settings.SettingsRepository
+import kotlinx.coroutines.test.runTest
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+
+/**
+ * Issue #1669: connection-log telemetry integrity. Today's forensics could not
+ * tell WHICH build produced a storm — no event carried the app version, so it
+ * took a `git ls-remote` to discover the phone was on v0.4.37. These tests pin:
+ *
+ *  - every emitted event (device store AND the host connection log) is
+ *    version-stamped at the top level; and
+ *  - the mirrored payload renders from the LOSSLESS part-store archive, so the
+ *    curated connection lifecycle survives intact and versioned.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class Issue1669ConnectionLogTelemetryTest {
+    private lateinit var context: Context
+    private lateinit var settingsRepository: SettingsRepository
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        context.getSharedPreferences("app_settings", Context.MODE_PRIVATE)
+            .edit().clear().commit()
+        File(context.filesDir, "diagnostics").deleteRecursively()
+        File(context.cacheDir, DIAGNOSTICS_EXPORT_CACHE_DIR).deleteRecursively()
+        settingsRepository = SettingsRepository(context)
+        DiagnosticEvents.install(DiagnosticEventSink.Noop)
+    }
+
+    @Test
+    fun `every exported event carries a non-empty versionName and numeric versionCode`() = runTest {
+        // Real path: no override, so this exercises readAppVersion() end-to-end.
+        // Load-bearing: without the #1669 stamp, versionName defaults to "" and
+        // this fails.
+        val recorder = DiagnosticRecorder(context, settingsRepository)
+        recorder.record("connection", "connect_start", mapOf("host" to "dev"))
+        recorder.record("action", "tap_send", mapOf("pane" to "%1"))
+
+        val exported = recorder.exportSnapshot()!!.readLines()
+            .filter { JSONObject(it).getString("name") != "export_summary" }
+        assertTrue("expected persisted events", exported.isNotEmpty())
+        exported.forEach { line ->
+            val json = JSONObject(line)
+            assertTrue(
+                "every event must carry a non-empty versionName: $line",
+                json.optString("versionName").isNotEmpty(),
+            )
+            // versionCode must be a NUMBER (getLong throws if it is a string/absent).
+            json.getLong("versionCode")
+        }
+    }
+
+    @Test
+    fun `the version stamp is the app's build and survives the disk round-trip`() = runTest {
+        val recorder = DiagnosticRecorder(context, settingsRepository)
+        // Pin the build so the assertion is deterministic and proves the exact
+        // name+code flow through encode -> disk -> decode.
+        recorder.appVersionOverride = DiagnosticRecorder.AppVersion(name = "0.4.39", code = 86L)
+
+        recorder.record("connection", "reconnect_fail", mapOf("cause" to "attach_not_ready"))
+        val event = recorder.readEvents().single()
+
+        assertEquals("0.4.39", event.versionName)
+        assertEquals(86L, event.versionCode)
+    }
+
+    @Test
+    fun `the host connection log stamps every line with the build`() = runTest {
+        // Forensics read the HOST connection-log.jsonl. Every line it carries must
+        // name the build, so a storm is attributable to a version without guessing.
+        val recorder = DiagnosticRecorder(context, settingsRepository)
+        DiagnosticEvents.install(recorder)
+        recorder.appVersionOverride = DiagnosticRecorder.AppVersion(name = "0.4.39", code = 86L)
+
+        recorder.record("connection", "connect_start", mapOf("host" to "dev"))
+        ReconnectCauseTrail.record(stage = "lease_transport", outcome = "down", cause = "keepalive_dead")
+
+        val lines = recorder.connectionLogJsonl().split("\n").filter { it.isNotBlank() }
+        assertTrue("the host log must carry the mirrored events", lines.isNotEmpty())
+        lines.forEach { line ->
+            val json = JSONObject(line)
+            assertEquals("0.4.39", json.getString("versionName"))
+            assertEquals(86L, json.getLong("versionCode"))
+        }
+    }
+
+    @Test
+    fun `the mirrored payload renders from the lossless archive, not the ring buffer`() = runTest {
+        // The archive is the SOURCE of connectionLogJsonl. Only mirrored
+        // connection-lifecycle events reach it; device-only chatter never does.
+        val recorder = DiagnosticRecorder(context, settingsRepository)
+        DiagnosticEvents.install(recorder)
+
+        repeat(40) { recorder.record("connection", "reconnect_fail", mapOf("marker" to it)) }
+        repeat(40) { recorder.record("action", "tap_send", mapOf("pane" to "%$it")) }
+
+        val archive = recorder.connectionLogArchive()
+        assertEquals("all 40 connection events survive in the lossless archive", 40, archive.size)
+        assertTrue("the archive is connection-log only", archive.all { it.category == "connection" })
+        assertFalse(
+            "device-only chatter must never enter the connection-log archive",
+            archive.any { it.name == "tap_send" },
+        )
+    }
+}

--- a/scripts/check-stranded-release.sh
+++ b/scripts/check-stranded-release.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Stranded-release guard for issue #1669.
+#
+# The app `versionName` (app/build.gradle.kts) leads the newest pushed release
+# tag briefly and legitimately during a release: the bump PR merges, then the
+# tag is pushed. That in-flight lead is BOUNDED — at most one un-tagged version
+# ahead of the newest origin tag. When it exceeds that bound, a version was
+# BUMPED BUT NEVER TAGGED: the release was stranded.
+#
+# That is exactly what happened to v0.4.38 — the versionName moved on to the next
+# value while v0.4.38 was never tagged, so the maintainer had to `git ls-remote`
+# to discover the phone's build did not match any release. This guard turns that
+# silent miss RED at push time.
+#
+# The "bounded interval" is realized as a bounded VERSION LEAD (default 1): the
+# versionName may be at most one release ahead of the newest origin tag. Two or
+# more ahead on the patch ladder means a version in between was skipped without a
+# tag — a stranded release. It is a version-lead bound (not a wall-clock timer)
+# so it is deterministic, needs only `git ls-remote --tags`, and works in a
+# shallow CI checkout.
+#
+# Usage:
+#   scripts/check-stranded-release.sh            # check the real tree + origin
+#   scripts/check-stranded-release.sh --self-test
+#                                                # in-process red->green proof on
+#                                                # synthetic fixtures; exit 0 only
+#                                                # if every case behaves correctly
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+GRADLE_REL="app/build.gradle.kts"
+
+# Max releases the versionName may lead the newest tag by before it is stranded.
+MAX_VERSION_LEAD="${MAX_VERSION_LEAD:-1}"
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/check-stranded-release.sh [--self-test]
+
+Fails when the app versionName (app/build.gradle.kts) is ahead of the newest
+origin release tag by more than MAX_VERSION_LEAD (default 1) releases — the
+"bumped but never tagged" miss that stranded v0.4.38. Exits 0 when the lead is
+within bound (or the versionName is already tagged), non-zero when stranded.
+
+--self-test runs a synthetic red->green proof over fixed (versionName, tags)
+pairs and exits 0 only if every case yields the expected verdict.
+USAGE
+}
+
+# Extract the app `versionName` from an app/build.gradle.kts file.
+parse_version_name() {
+  local file="$1"
+  sed -n 's/^[[:space:]]*versionName[[:space:]]*=[[:space:]]*"\([^"]*\)".*$/\1/p' "$file" |
+    head -n 1
+}
+
+# Print the newest semver among the tags fed on stdin (one `vX.Y.Z` per line).
+# Ignores anything that is not a plain vMAJOR.MINOR.PATCH tag.
+newest_semver_tag() {
+  grep -oE '^v?[0-9]+\.[0-9]+\.[0-9]+$' |
+    sed 's/^v//' |
+    sort -t. -k1,1n -k2,2n -k3,3n |
+    tail -n 1
+}
+
+# List origin release tags, newest last. Falls back to local tags when the
+# remote is unreachable (offline dev box); the CI job always has the remote.
+origin_release_tags() {
+  local remote_tags
+  if remote_tags="$(git -C "$ROOT_DIR" ls-remote --tags origin 2>/dev/null)"; then
+    printf '%s\n' "$remote_tags" | grep -oE 'refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$' | sed 's#refs/tags/##'
+  fi
+  # Always also emit local tags so an offline run still has evidence; the caller
+  # takes the max across both.
+  git -C "$ROOT_DIR" tag --list 'v*' 2>/dev/null || true
+}
+
+# Compute how many releases $1 (versionName) leads $2 (newest tag) by, on the
+# release ladder. Echoes an integer lead:
+#   0  -> versionName == newest tag, or versionName is behind (already released)
+#   1  -> exactly the next patch/minor/major (the legitimate in-flight window)
+#   >1 -> a version in between was skipped -> STRANDED
+version_lead() {
+  local v="$1" t="$2"
+  local vM vm vp tM tm tp
+  IFS=. read -r vM vm vp <<<"$v"
+  IFS=. read -r tM tm tp <<<"$t"
+
+  # versionName strictly less than the tag (behind) -> already released, lead 0.
+  if [[ "$vM" -lt "$tM" ]] ||
+    { [[ "$vM" -eq "$tM" ]] && [[ "$vm" -lt "$tm" ]]; } ||
+    { [[ "$vM" -eq "$tM" ]] && [[ "$vm" -eq "$tm" ]] && [[ "$vp" -le "$tp" ]]; }; then
+    echo 0
+    return
+  fi
+
+  # Same major.minor: lead is the patch delta (…37 tag, …39 version -> lead 2).
+  if [[ "$vM" -eq "$tM" ]] && [[ "$vm" -eq "$tm" ]]; then
+    echo $((vp - tp))
+    return
+  fi
+
+  # One minor ahead, patch reset to 0 -> the single legitimate minor bump.
+  if [[ "$vM" -eq "$tM" ]] && [[ "$vm" -eq $((tm + 1)) ]] && [[ "$vp" -eq 0 ]]; then
+    echo 1
+    return
+  fi
+
+  # One major ahead, minor+patch reset -> the single legitimate major bump.
+  if [[ "$vM" -eq $((tM + 1)) ]] && [[ "$vm" -eq 0 ]] && [[ "$vp" -eq 0 ]]; then
+    echo 1
+    return
+  fi
+
+  # Any other forward jump skipped a release line -> treat as stranded (>bound).
+  echo $((MAX_VERSION_LEAD + 1))
+}
+
+# Core check. Args: <versionName> <newest-tag>. Exits 0 within bound, 1 stranded.
+check_lead() {
+  local version_name="$1" newest_tag="$2"
+
+  if [[ -z "$version_name" ]]; then
+    printf 'FAIL: could not parse versionName.\n' >&2
+    return 1
+  fi
+  if [[ -z "$newest_tag" ]]; then
+    printf 'WARN: no origin release tags found; skipping stranded-release check.\n' >&2
+    return 0
+  fi
+
+  printf 'app versionName:        %s\n' "$version_name"
+  printf 'newest origin tag:      v%s\n' "$newest_tag"
+
+  local lead
+  lead="$(version_lead "$version_name" "$newest_tag")"
+  printf 'release lead:           %s (bound %s)\n' "$lead" "$MAX_VERSION_LEAD"
+
+  if [[ "$lead" -gt "$MAX_VERSION_LEAD" ]]; then
+    printf 'FAIL: versionName %s leads newest tag v%s by %s releases (bound %s).\n' \
+      "$version_name" "$newest_tag" "$lead" "$MAX_VERSION_LEAD" >&2
+    printf '      A version between them was bumped but NEVER tagged — a stranded\n' >&2
+    printf '      release (this is the v0.4.38 miss #1669 guards). Tag the missing\n' >&2
+    printf '      release(s), or reset the bump, so the field log names a real build.\n' >&2
+    return 1
+  fi
+
+  printf 'OK: versionName is within the bounded release lead of the newest tag.\n'
+  return 0
+}
+
+run_self_test() {
+  local failures=0
+
+  # (versionName, newest-tag, expected-exit) triples. 0=pass, 1=stranded.
+  local cases=(
+    "0.4.39|0.4.38|0"   # normal in-flight: one patch ahead
+    "0.4.38|0.4.38|0"   # already tagged
+    "0.4.37|0.4.38|0"   # behind (hotfix branch): not this guard's concern
+    "0.4.39|0.4.37|1"   # STRANDED: 0.4.38 skipped without a tag
+    "0.5.0|0.4.38|0"    # legitimate minor bump
+    "0.5.2|0.4.38|1"    # STRANDED: 0.5.0/0.5.1 skipped
+    "1.0.0|0.4.38|0"    # legitimate major bump
+    "0.4.41|0.4.38|1"   # STRANDED: several patches skipped
+  )
+
+  for triple in "${cases[@]}"; do
+    IFS='|' read -r v t expected <<<"$triple"
+    local actual=0
+    check_lead "$v" "$t" >/dev/null 2>&1 || actual=1
+    if [[ "$actual" -eq "$expected" ]]; then
+      printf '  ok: (%s vs v%s) -> %s\n' "$v" "$t" "$([[ $actual -eq 0 ]] && echo PASS || echo STRANDED)"
+    else
+      printf '  FAIL: (%s vs v%s) expected %s got %s\n' "$v" "$t" "$expected" "$actual" >&2
+      failures=$((failures + 1))
+    fi
+  done
+
+  if [[ "$failures" -ne 0 ]]; then
+    printf 'SELF-TEST FAILED: %d case(s) behaved incorrectly.\n' "$failures" >&2
+    return 1
+  fi
+  printf 'SELF-TEST OK: in-flight leads pass, stranded leads fail.\n'
+  return 0
+}
+
+main() {
+  case "${1:-}" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --self-test)
+      run_self_test
+      exit $?
+      ;;
+    "")
+      local version_name newest_tag
+      version_name="$(parse_version_name "$ROOT_DIR/$GRADLE_REL")"
+      newest_tag="$(origin_release_tags | newest_semver_tag)"
+      check_lead "$version_name" "$newest_tag"
+      exit $?
+      ;;
+    *)
+      printf 'FAIL: unknown arg: %s\n' "$1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+}
+
+main "$@"


### PR DESCRIPTION
Reviewer-APPROVED (#1669). The field-log foundation for reproducing connection issues from real device usage.

## What (each criterion has a triggering test — G9)
- **Version-stamp** every event (`versionName`/`versionCode`, resolved lazily off the #1124 cold-launch path).
- **Lossless rotation**: new `ConnectionLogPartStore` — append-only, lazy part creation (zero-length parts structurally impossible), count-bounded compaction; host-mirror payload renders from it (nothing dropped before the 64KB budget).
- **Stranded-release guard**: `scripts/check-stranded-release.sh` (wired into the required `Python utility tests` job) fails when `versionName` leads the newest origin tag by >1 release (the v0.4.38 miss). **Verified exit 0 on current tree (0.4.39 vs v0.4.38, lead 1) — does NOT red the required check on merge.**

## Verification
- Reviewer (APPROVED): losslessness red→green driven (`expected:<4000> but was:<160>` → 4000), both variants (debug 4039/0, release 4035/0), guard current-tree OK + `--self-test` 8/8, scope clean.
- Orchestrator: clean apply onto current main (disjoint); guard exit 0 + self-test re-confirmed locally; `git diff --check` clean. Both unit variants gate via the required `Unit tests` check.

Non-blocking follow-ups (flagged by reviewer): base-file total-byte growth (part *count* bounded, not bytes); a guard edge where a minor/major bump masks a stranded patch.

Closes #1669