### PR TITLE
test(core-connection): fix nightly phase-2 disconnect cohort budget (#1676)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/NatIdleMappingSurvivalE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/NatIdleMappingSurvivalE2eTest.kt
@@ -125,7 +125,7 @@ class NatIdleMappingSurvivalE2eTest : NetworkFaultProofBase() {
 
         // The keepalive must DETECT the dead half-open transport within its budget
         // and surface the connection-lost band (the user-visible recovery signal).
-        waitForDisconnectBand("severed NAT mapping", timeoutMillis = KEEPALIVE_DEATH_DETECT_TIMEOUT_MS)
+        waitForDisconnectBand("severed NAT mapping", detectionBudgetMs = KEEPALIVE_DEATH_DETECT_TIMEOUT_MS)
         val detectMs = SystemClock.elapsedRealtime() - severStart
         recordTiming("recover_detect_ms", detectMs)
 
@@ -246,14 +246,21 @@ class NatIdleMappingSurvivalE2eTest : NetworkFaultProofBase() {
         const val PROBE_DISABLED_TIMEOUT_MS: Long = 5_000L
         const val PROBE_FAILURE_THRESHOLD: Int = 4
 
-        val CONNECTED_TIMEOUT_MS: Long =
-            if (TerminalTestTimeouts.isRunningOnCi()) 30_000L else 20_000L
+        // Issue #1676 — these budgets are slow-hardware UNCONDITIONALLY. This proof
+        // only ever runs on the slow emulator + Docker / toxiproxy path (opt-in
+        // gated; self-skips otherwise), and the nightly runs it WITHOUT
+        // `pocketshellCi=true`, so keying the ceilings off `isRunningOnCi()` silently
+        // used the tight dev-box LOCAL values on the SLOWEST swiftshader hardware —
+        // the cohort's root cause: this test's `waitForDisconnectBand` blew its 30s
+        // LOCAL budget on ~6/8 nights while passing on faster nights. The detection
+        // itself is bounded by the SHORT keepalive death budget ([KEEPALIVE_DEATH_
+        // BUDGET_MS] = 9s); the ceiling below covers that nominal 9s plus generous
+        // swiftshader tick-stretch (~5×), so the load-bearing "detect within budget"
+        // assertion still constrains a real slow-keepalive regression (which would
+        // exceed even 50s) while absorbing runner jitter.
+        const val CONNECTED_TIMEOUT_MS: Long = 40_000L
 
-        // Detection budget + a generous reconnect/AVD margin for the half-open
-        // recovery arm.
-        val KEEPALIVE_DEATH_DETECT_TIMEOUT_MS: Long =
-            if (TerminalTestTimeouts.isRunningOnCi()) 40_000L else 30_000L
-        val RECOVERY_CONNECTED_TIMEOUT_MS: Long =
-            if (TerminalTestTimeouts.isRunningOnCi()) 60_000L else 45_000L
+        const val KEEPALIVE_DEATH_DETECT_TIMEOUT_MS: Long = 50_000L
+        const val RECOVERY_CONNECTED_TIMEOUT_MS: Long = 60_000L
     }
 }

--- a/app/src/androidTest/java/com/pocketshell/app/proof/NetworkFaultProofBase.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/NetworkFaultProofBase.kt
@@ -273,9 +273,28 @@ abstract class NetworkFaultProofBase {
         assertTrue("expected terminal input submit for $label", enterCommitted)
     }
 
+    /**
+     * Issue #1676 — the generous slow-link visibility budget every network-fault
+     * proof deserves. These proofs ONLY ever run on the slow emulator + Docker /
+     * toxiproxy path (opt-in gated; they self-skip otherwise), frequently behind a
+     * deliberately-injected multi-second bufferbloat / latency toxic, so a positive
+     * "text became visible" wait must allow the slow link its full drain time. It
+     * early-exits the instant the text appears, so a fast pass pays nothing; the
+     * generous ceiling only matters when a genuinely slow-but-progressing link is
+     * draining. Keying the whole cohort's ceilings off `pocketshellCi` alone was the
+     * root cause of the #1676 correlated cohort: the nightly runs these WITHOUT
+     * `pocketshellCi=true`, so `terminalVisibilityTimeoutMs()` silently returned the
+     * tight 60s dev-box LOCAL value on the SLOWEST swiftshader hardware — exactly the
+     * ceiling `ColdDialUnderBandwidthLimitE2eTest`'s post-dial echo blew (~98.8s vs
+     * 60s) on bad nights. This budget is the CI terminal-visibility value (180s),
+     * applied unconditionally because there is no fast-hardware case for a toxiproxy
+     * proof; it stays well under the 300s per-test ci-journey watchdog.
+     */
+    protected fun faultProofVisibilityBudgetMs(): Long = FAULT_PROOF_VISIBILITY_BUDGET_MS
+
     protected fun waitForVisibleTerminalText(
         label: String,
-        timeoutMillis: Long = TerminalTestTimeouts.terminalVisibilityTimeoutMs(),
+        timeoutMillis: Long = faultProofVisibilityBudgetMs(),
         predicate: (String) -> Boolean,
     ) {
         var last = ""
@@ -295,14 +314,86 @@ abstract class NetworkFaultProofBase {
         )
     }
 
-    protected fun waitForDisconnectBand(label: String, timeoutMillis: Long = 35_000) {
+    /**
+     * Issue #1676 — the load-bearing budget for the disconnect band to surface,
+     * with a reproduce-first measure-PAST-budget capture (D33/G10).
+     *
+     * ## Why the budget is what it is (measured from production, NOT guessed)
+     *
+     * The band is surfaced by the production dead / half-open transport detectors,
+     * whose worst-case detection latencies are DOCUMENTED PRODUCTION CONSTANTS:
+     *
+     *  - the app-level `com.pocketshell.core.connection.LivenessProbe` — the
+     *    half-open / `-CC`-wedged detector for the blackhole + sustained-cut cohort —
+     *    has a worst case of
+     *    `failureThreshold × (intervalMs + perProbeTimeoutMs)` = `4 × (7s + 5s)` = **48s**;
+     *  - the always-on `com.pocketshell.core.ssh.TransportKeepAlive` — the
+     *    silent-peer detector (e.g. `NatIdleMappingSurvivalE2eTest`) — is
+     *    `countMax × intervalMs` (prod 90s; NatIdle's override 3 × 3s = 9s).
+     *
+     * The pre-#1676 flat **35s** default was SMALLER than the LivenessProbe's own
+     * **48s** worst case — so a perfectly-functioning half-open detection could hit
+     * its documented budget and STILL time out the test. On the CI swiftshader runner
+     * the `delay()`-driven detector ticks stretch further under load, so the 35s
+     * ceiling blew on ~6/8 nights (the #1676 correlated cohort) even though detection
+     * was working. That is a HARNESS under-budgeting (a wall-clock flake), NOT a
+     * slow-detection `core-connection` regression:
+     * `Issue1676DisconnectDetectionLatencyTest` (core-connection, per-push Unit gate)
+     * proves the detection logic fires at exactly its deterministic budget on a
+     * virtual clock, decoupled from wall-clock.
+     *
+     * [detectionBudgetMs] therefore defaults to [disconnectBandBudgetMs] — the
+     * production detector worst case plus slow-emulator headroom. The LOAD-BEARING
+     * assertion ("the band surfaces within [detectionBudgetMs]") is unchanged and NOT
+     * widened into a meaningless band (G6): a genuinely never-surfacing or
+     * far-over-budget regression STILL fails, and the TRUE latency is captured up to
+     * [captureCeilingMs] (recorded even when the budget is blown) so the next nightly
+     * emits the decisive flake-vs-regression number instead of just "did not appear".
+     */
+    protected fun waitForDisconnectBand(
+        label: String,
+        detectionBudgetMs: Long = disconnectBandBudgetMs(),
+        captureCeilingMs: Long = DISCONNECT_BAND_CAPTURE_CEILING_MS,
+    ) {
         val start = SystemClock.elapsedRealtime()
-        compose.waitUntil(timeoutMillis = timeoutMillis) {
-            compose.onAllNodesWithTag(TMUX_SESSION_ERROR_TAG, useUnmergedTree = true)
-                .fetchSemanticsNodes()
-                .isNotEmpty()
-        }
-        recordTiming("${label}_disconnect_visible_ms", SystemClock.elapsedRealtime() - start)
+        // Poll PAST the load-bearing budget up to a generous capture ceiling so the
+        // TRUE detection latency is recorded even on a blown budget (reproduce-first).
+        val appeared = runCatching {
+            compose.waitUntil(timeoutMillis = captureCeilingMs) {
+                compose.onAllNodesWithTag(TMUX_SESSION_ERROR_TAG, useUnmergedTree = true)
+                    .fetchSemanticsNodes()
+                    .isNotEmpty()
+            }
+            true
+        }.getOrDefault(false)
+        val detectMs = SystemClock.elapsedRealtime() - start
+        recordTiming("${label}_disconnect_visible_ms", detectMs)
+        recordTiming("${label}_disconnect_appeared", if (appeared) 1L else 0L)
+        recordTiming("${label}_disconnect_budget_ms", detectionBudgetMs)
+        artifactFile("disconnect-band-latency-$label.txt").writeText(
+            buildString {
+                appendLine("label=$label")
+                appendLine("appeared=$appeared")
+                appendLine("disconnect_visible_ms=$detectMs")
+                appendLine("detection_budget_ms=$detectionBudgetMs")
+                appendLine("capture_ceiling_ms=$captureCeilingMs")
+                appendLine("within_budget=${appeared && detectMs <= detectionBudgetMs}")
+            },
+        )
+        val within = appeared && detectMs <= detectionBudgetMs
+        assertTrue(
+            if (appeared) {
+                "expected the disconnect band for $label to surface within " +
+                    "${detectionBudgetMs}ms (production half-open detection worst case " +
+                    "~48s, LivenessProbe); it surfaced after ${detectMs}ms" +
+                    if (within) "" else " — OVER budget (real slow-detection regression?)"
+            } else {
+                "expected the disconnect band for $label to surface within " +
+                    "${detectionBudgetMs}ms; it NEVER surfaced within the ${captureCeilingMs}ms " +
+                    "capture ceiling (real detection regression — band never appeared)"
+            },
+            within,
+        )
         val reconnectActions = compose.onAllNodesWithTag(
             TMUX_SESSION_RECONNECT_TAG,
             useUnmergedTree = true,
@@ -313,6 +404,18 @@ abstract class NetworkFaultProofBase {
             reconnectActions.isNotEmpty(),
         )
     }
+
+    /**
+     * Issue #1676 — load-bearing budget for the disconnect band to surface. These
+     * proofs ONLY ever run on the slow emulator + Docker / toxiproxy path (opt-in
+     * gated; they self-skip otherwise), so they always deserve the generous
+     * slow-hardware ceiling — there is no "fast hardware deserves a tight budget"
+     * case for a toxiproxy fault proof. The budget covers the production
+     * `LivenessProbe` half-open worst case (~48s) plus swiftshader tick-stretch
+     * headroom, and stays well under the 300s per-test ci-journey watchdog. See the
+     * [waitForDisconnectBand] KDoc for the full derivation.
+     */
+    protected fun disconnectBandBudgetMs(): Long = DISCONNECT_BAND_BUDGET_MS
 
     protected fun tapReconnectAndWait(label: String) {
         val start = SystemClock.elapsedRealtime()
@@ -730,6 +833,30 @@ abstract class NetworkFaultProofBase {
         const val TOXIPROXY_API_PORT: Int = 8474
         const val DATABASE_NAME: String = "pocketshell.db"
         const val DEVICE_DIR_NAME: String = "issue342-network-faults"
+
+        /**
+         * Issue #1676 — the load-bearing disconnect-band budget. Must be ≥ the
+         * production `LivenessProbe` half-open detection worst case (~48s) plus
+         * slow-swiftshader tick-stretch headroom. 90s ≈ 48s × ~1.9 and matches the
+         * always-on keepalive's 90s prod death budget. Pinned against the production
+         * detector budgets by `Issue1676DisconnectDetectionLatencyTest`.
+         */
+        const val DISCONNECT_BAND_BUDGET_MS: Long = 90_000L
+
+        /**
+         * Issue #1676 — poll the band this far PAST the load-bearing budget so the
+         * TRUE detection latency is captured even when the budget is blown
+         * (reproduce-first). > [DISCONNECT_BAND_BUDGET_MS] so an over-budget surface
+         * is measured, not clipped; < the 300s per-test ci-journey watchdog.
+         */
+        const val DISCONNECT_BAND_CAPTURE_CEILING_MS: Long = 120_000L
+
+        /**
+         * Issue #1676 — the generous slow-link positive-visibility budget for the
+         * network-fault proofs (the CI terminal-visibility value, 180s). See
+         * [faultProofVisibilityBudgetMs].
+         */
+        const val FAULT_PROOF_VISIBILITY_BUDGET_MS: Long = 180_000L
 
         /** Issue #1681 — the un-proxied sentinel exec-ping cadence. */
         const val SENTINEL_INTERVAL_MS: Long = 3_000L

--- a/shared/core-connection/src/test/java/com/pocketshell/core/connection/Issue1676DisconnectDetectionLatencyTest.kt
+++ b/shared/core-connection/src/test/java/com/pocketshell/core/connection/Issue1676DisconnectDetectionLatencyTest.kt
@@ -1,0 +1,212 @@
+package com.pocketshell.core.connection
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1676 — the deterministic MEASUREMENT that classifies the nightly phase-2
+ * disconnect-band cohort (`RideThroughInterruptionE2eTest.sustained`,
+ * `DisconnectBlackholeE2eTest`, `NatIdleMappingSurvivalE2eTest`,
+ * `ColdDialUnderBandwidthLimitE2eTest`) as a HARNESS wall-clock FLAKE, not a
+ * slow-detection `core-connection` regression (D33 / G10 reproduce-first, G2 class
+ * coverage, G6 load-bearing).
+ *
+ * ## What the cohort observed vs what this measures
+ *
+ * On ~6/8 nights the four E2E proofs failed together at `waitForDisconnectBand`'s
+ * old flat **35s** wall-clock ceiling; on the 2 "good" nights they passed. That
+ * all-or-nothing correlation across independent toxics points at ONE per-night
+ * variable — a runner-speed collapse on the CI swiftshader emulator — NOT four
+ * independent code faults. The decisive question the brief demands (measure, don't
+ * guess): does the production disconnect DETECTION genuinely exceed the budget (a
+ * real bug), or is it the test's wall-clock ceiling racing a starved runner (a
+ * flake)?
+ *
+ * The disconnect band is surfaced by the app-level half-open / `-CC`-wedged
+ * detector [LivenessProbe]. Its loop cadence is pure [delay], so a virtual clock
+ * advances the WHOLE detection window with ZERO wall-clock. This test drives the
+ * REAL [LivenessProbe] at its PRODUCTION default budget against a genuinely dead
+ * half-open channel (every probe hangs past its per-probe timeout, transport not
+ * proven-alive) and MEASURES the exact virtual time the drop is declared.
+ *
+ * ## The result (the number, deterministic)
+ *
+ *  - Detection fires at EXACTLY the documented worst case
+ *    `failureThreshold × (intervalMs + perProbeTimeoutMs)` = `4 × (7s + 5s)` = **48s**
+ *    of VIRTUAL time — every run, regardless of hardware — while the test consumes
+ *    only milliseconds of WALL-CLOCK. The detection latency is a function of the
+ *    scheduler cadence, not the runner's speed.
+ *  - The pre-#1676 E2E budget (**35s**) was SMALLER than this 48s production worst
+ *    case: a perfectly-functioning half-open detection could hit its own documented
+ *    budget and STILL time out the test. On the slower swiftshader nights the
+ *    `delay()`-driven ticks stretched further, blowing 35s outright — the cohort.
+ *  - The #1676 fix raises the E2E budget to **90s** (> 48s + swiftshader
+ *    tick-stretch headroom), so the load-bearing "band surfaces within budget"
+ *    assertion covers the real detector worst case without ever being satisfied by
+ *    a non-surfacing regression (a never-firing detector still blows the 120s
+ *    measure-past-budget capture ceiling).
+ *
+ * Because the detector is deterministic on a virtual clock, this test is
+ * inherently reproducible: the N≥20 determinism bar is met by construction (no
+ * randomness, no wall-clock, no I/O) and re-runnable in the per-push Unit gate.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class Issue1676DisconnectDetectionLatencyTest {
+
+    /**
+     * A genuinely DEAD half-open channel: `shouldProbe` stays open, the transport
+     * is NOT proven-alive by the keepalive, and every probe HANGS past its
+     * per-probe timeout (so the loop's `withTimeoutOrNull(perProbeTimeoutMs)`
+     * elapses the full timeout each iteration — the WORST-CASE detection path the
+     * 48s budget is derived for). Records the virtual time the drop is declared.
+     */
+    private class DeadHalfOpenProbeIo(
+        private val probeHangMs: Long,
+    ) : LivenessProbe.ProbeIo {
+        var probeCount = 0
+            private set
+        var onProbeFailedCount = 0
+            private set
+        var lastConsecutiveFailures = 0
+            private set
+
+        override fun shouldProbe(): Boolean = true
+
+        override suspend fun probe(): Boolean {
+            probeCount++
+            // Hang past the per-probe timeout so withTimeoutOrNull elapses the full
+            // budget — the half-open blackhole (bytes silently dropped, no RST/FIN).
+            delay(probeHangMs)
+            return true // never reached before the timeout cancels this coroutine
+        }
+
+        override fun onProbeFailed(consecutiveFailures: Int) {
+            onProbeFailedCount++
+            lastConsecutiveFailures = consecutiveFailures
+        }
+
+        override fun transportProvenAliveRecently(): Boolean = false
+    }
+
+    @Test
+    fun `half-open detection fires at its documented worst-case budget in virtual time only`() =
+        runTest(StandardTestDispatcher()) {
+            // PRODUCTION default budget — the exact numbers behind the 48s worst case.
+            val io = DeadHalfOpenProbeIo(probeHangMs = LivenessProbe.DEFAULT_PER_PROBE_TIMEOUT_MS * 2)
+            val probe = LivenessProbe(
+                io = io,
+                intervalMs = LivenessProbe.DEFAULT_INTERVAL_MS,
+                perProbeTimeoutMs = LivenessProbe.DEFAULT_PER_PROBE_TIMEOUT_MS,
+                failureThreshold = LivenessProbe.DEFAULT_FAILURE_THRESHOLD,
+            )
+
+            val wallStartNs = System.nanoTime()
+            probe.start(this)
+
+            var fireTimeMs = -1L
+            var elapsed = 0L
+            while (elapsed < CAPTURE_CEILING_MS && fireTimeMs < 0L) {
+                advanceTimeBy(STEP_MS)
+                runCurrent()
+                elapsed += STEP_MS
+                if (io.onProbeFailedCount >= 1) fireTimeMs = testScheduler.currentTime
+            }
+            val wallElapsedMs = (System.nanoTime() - wallStartNs) / 1_000_000L
+            probe.stop()
+
+            assertTrue(
+                "the probe must have actually run against the dead channel " +
+                    "(probeCount=${io.probeCount})",
+                io.probeCount >= LivenessProbe.DEFAULT_FAILURE_THRESHOLD,
+            )
+            assertEquals(
+                "a sustained half-open drop must declare EXACTLY once at threshold",
+                LivenessProbe.DEFAULT_FAILURE_THRESHOLD,
+                io.lastConsecutiveFailures,
+            )
+
+            // THE MEASURED NUMBER: detection fires at exactly the documented worst
+            // case, in VIRTUAL time. This is deterministic across every run — the
+            // detection latency is a function of the scheduler cadence, not hardware.
+            assertEquals(
+                "half-open disconnect detection must fire at its documented worst case " +
+                    "failureThreshold × (intervalMs + perProbeTimeoutMs)",
+                PRODUCTION_HALF_OPEN_WORST_CASE_MS,
+                fireTimeMs,
+            )
+
+            // DECOUPLED FROM WALL-CLOCK: 48s of virtual detection consumed only a
+            // few ms of real time — so the E2E cohort's failures (a 35s WALL-CLOCK
+            // ceiling blown on a starved swiftshader runner) are a HARNESS
+            // under-budgeting flake, not slow detection. A real slow-detection
+            // regression would move fireTimeMs (a VIRTUAL-time number) above the
+            // worst case here, in the per-push Unit gate — long before any runner.
+            assertTrue(
+                "the 48s detection window is VIRTUAL: this deterministic test must " +
+                    "complete in a fraction of the wall time it models (wall=${wallElapsedMs}ms)",
+                wallElapsedMs < WALL_CLOCK_DECOUPLING_CEILING_MS,
+            )
+        }
+
+    @Test
+    fun `the E2E disconnect-band budget must exceed the production detection worst case`() {
+        // The root cause + the fix, pinned. The pre-#1676 waitForDisconnectBand
+        // budget (35s) was BELOW the production half-open detection worst case (48s)
+        // — so a functioning detection could hit its documented budget and still
+        // time out the test (the structural under-budgeting the cohort exposed on
+        // slow nights). The #1676 fix raises NetworkFaultProofBase.DISCONNECT_BAND_
+        // BUDGET_MS to 90s. These literals mirror the androidTest constants (a
+        // separate sourceset, so referenced by value); if the production detector's
+        // worst case is ever retuned above the E2E budget, THIS guard fails in the
+        // per-push Unit gate rather than as a mysterious nightly flake.
+        assertEquals(
+            "the LivenessProbe half-open worst case must stay the documented 48s the " +
+                "E2E budget is derived against",
+            PRODUCTION_HALF_OPEN_WORST_CASE_MS,
+            LivenessProbe.DEFAULT_FAILURE_THRESHOLD *
+                (LivenessProbe.DEFAULT_INTERVAL_MS + LivenessProbe.DEFAULT_PER_PROBE_TIMEOUT_MS),
+        )
+        assertTrue(
+            "root cause: the pre-#1676 35s E2E budget was BELOW the 48s production " +
+                "detection worst case — a functioning detection could time out the test",
+            PRODUCTION_HALF_OPEN_WORST_CASE_MS > OLD_E2E_DISCONNECT_BAND_BUDGET_MS,
+        )
+        assertTrue(
+            "the fix: the #1676 90s E2E budget must exceed the 48s production worst " +
+                "case with slow-swiftshader headroom (NetworkFaultProofBase." +
+                "DISCONNECT_BAND_BUDGET_MS). If this fails the cohort will re-red.",
+            NEW_E2E_DISCONNECT_BAND_BUDGET_MS > PRODUCTION_HALF_OPEN_WORST_CASE_MS,
+        )
+    }
+
+    private companion object {
+        /** `failureThreshold × (intervalMs + perProbeTimeoutMs)` = `4 × (7s + 5s)`. */
+        const val PRODUCTION_HALF_OPEN_WORST_CASE_MS: Long = 48_000L
+
+        /** The pre-#1676 flat `waitForDisconnectBand` budget (the root cause). */
+        const val OLD_E2E_DISCONNECT_BAND_BUDGET_MS: Long = 35_000L
+
+        /** The #1676 `NetworkFaultProofBase.DISCONNECT_BAND_BUDGET_MS` (the fix). */
+        const val NEW_E2E_DISCONNECT_BAND_BUDGET_MS: Long = 90_000L
+
+        /** Fine virtual-time step for precise fire-time capture (48000 % 250 == 0). */
+        const val STEP_MS: Long = 250L
+
+        /** Poll ceiling for the measurement (> the 48s worst case). */
+        const val CAPTURE_CEILING_MS: Long = 120_000L
+
+        /**
+         * The 48s detection window is VIRTUAL; the deterministic test itself must
+         * finish in a tiny fraction of that wall time. Generous so a loaded CI JVM
+         * worker never flakes this, yet ≪ the 48s it models — proving the decoupling.
+         */
+        const val WALL_CLOCK_DECOUPLING_CEILING_MS: Long = 20_000L
+    }
+}


### PR DESCRIPTION
Reviewer-APPROVED. **Release-blocker CI fix** — this cohort is the sole gating failure blocking the v0.4.39 release gate (and the chronic reason releases strand).

## Root cause (measured, not guessed)
`waitForDisconnectBand` budget was **35s**, but the half-open `LivenessProbe` detector's documented worst case is **48s** = `4 × (7s interval + 5s per-probe timeout)`. A correctly-working detector hits its own budget and times out the test. Compounded by the nightly running un-CI-scaled budgets on the slowest swiftshader hardware. **Flake, not a core-connection regression** — the fault detection works.

## Fix (test-side only — no production/nightly-driver/build-config touched)
- `NetworkFaultProofBase.waitForDisconnectBand`: injectable budget (default 90s ≥ 48s+headroom) + a measure-past-budget seam recording the TRUE latency to `disconnect-band-latency-*.txt`.
- `faultProofVisibilityBudgetMs()` = 180s (ColdDial echo drain); NatIdle budgets flattened to slow-hardware-unconditional.
- New JVM guard `Issue1676DisconnectDetectionLatencyTest` (per-push `Unit tests` gate): asserts the detector fires at **exactly 48000ms** in virtual time, driving the real `LivenessProbe` (mutating production `DEFAULT_FAILURE_THRESHOLD` 4→3 moves the measured value to 36000). This is the tight constraint the loosened E2E budget no longer carries (G6-safe).

## Verification
- Reviewer: 48s derivation confirmed from production constants; JVM guard non-vacuous (2 RED controls incl. the production-threshold mutation); 90s still constrains (E2E asserts `detectMs ≤ budget`); 24/24 deterministic; scope clean.
- Orchestrator gate: `:shared:core-connection:test` both variants green, the new guard PASSED both.
- **Non-masking:** a wrong classification reds the nightly with the TRUE number rather than shipping a false-green. Final DoD = the re-dispatched nightly goes green + `disconnect-band-latency-*.txt`.

Closes #1676