### PR TITLE
fileviewer: reopen re-fetches so a host-side change wins (#1713)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/fileviewer/FileViewerDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/fileviewer/FileViewerDockerTest.kt
@@ -5,6 +5,9 @@ import android.graphics.Color
 import android.graphics.Paint
 import android.graphics.pdf.PdfDocument
 import android.util.Base64
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
@@ -495,6 +498,104 @@ class FileViewerDockerTest {
         composeRule.onNodeWithTag(FILE_VIEWER_REVIEW_ATTACH_TAG).performClick()
         composeRule.waitUntil(timeoutMillis = 5_000) { attachedPrompts.isNotEmpty() }
         assertEquals(reviewAttachPrompt(surfacedPath), attachedPrompts.single())
+    } }
+
+    /**
+     * Issue #1713 — reopening a file whose host content changed must show the
+     * FRESH content. Opens a text file (body v1), reads it, mutates it on the
+     * host over the same fixture, then reopens the SAME file with the SAME
+     * surviving [FileViewerViewModel] (navigate away + back, driven by toggling
+     * the screen in/out of composition so the real [FileViewerScreen]
+     * `LaunchedEffect` re-fires `bind()` on re-entry). The viewer must reconcile
+     * to the new body — before the fix, `bind()` returned early on the identical
+     * request and the stale body persisted.
+     */
+    @Test
+    fun reopeningAChangedTextFileShowsTheFreshHostContent(): Unit { runBlocking {
+        val suffix = System.currentTimeMillis().toString().takeLast(6)
+        val textPath = "/tmp/issue1713-notes-$suffix.txt"
+        val bodyV1 = "issue #1713 ORIGINAL-BODY-V1\nline two\n"
+        val bodyV2 = "issue #1713 CHANGED-ON-HOST-V2\nfresh line\n"
+        withTimeout(20_000) {
+            connect()?.use { session ->
+                val exit = session.exec("cat > '$textPath' <<'PSEOF'\n$bodyV1\nPSEOF")
+                assertEquals("seed text v1 exit", 0, exit.exitCode)
+                seededPaths += textPath
+            } ?: error("could not connect to seed fixture file")
+        }
+
+        // A single VM instance survives the reopen (as it does when navigation
+        // reuses a cached back-stack entry / activity-scoped VM).
+        val viewModel = FileViewerViewModel(
+            InstrumentationRegistry.getInstrumentation().targetContext.applicationContext,
+            leasing.manager,
+        )
+        var showViewer by mutableStateOf(true)
+        composeRule.setContent {
+            if (showViewer) {
+                FileViewerScreen(
+                    hostId = TEST_HOST_ID,
+                    hostName = "agents",
+                    hostname = DEFAULT_HOST,
+                    port = DEFAULT_PORT,
+                    username = DEFAULT_USER,
+                    keyPath = keyFile.absolutePath,
+                    passphrase = null,
+                    remotePath = textPath,
+                    cwd = null,
+                    onBack = {},
+                    viewModel = viewModel,
+                )
+            }
+        }
+
+        // v1 renders.
+        composeRule.waitUntil(timeoutMillis = 30_000) {
+            composeRule.onAllNodesWithText("ORIGINAL-BODY-V1", substring = true)
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+        composeRule.onNodeWithText("ORIGINAL-BODY-V1", substring = true).assertExists()
+        WalkthroughScreenshotArtifacts.capture("issue1713-reopen-before-v1")
+
+        // The host file changes while the viewer is open.
+        withTimeout(20_000) {
+            connect()?.use { session ->
+                val exit = session.exec("cat > '$textPath' <<'PSEOF'\n$bodyV2\nPSEOF")
+                assertEquals("mutate text v2 exit", 0, exit.exitCode)
+            } ?: error("could not connect to mutate fixture file")
+        }
+
+        // Reopen: navigate away (remove the screen), then back (re-add) — the VM
+        // survives, so this is a reopen of the identical request. The
+        // LaunchedEffect re-fires bind() on re-entry.
+        composeRule.runOnUiThread { showViewer = false }
+        composeRule.waitForIdle()
+        composeRule.runOnUiThread { showViewer = true }
+
+        // The reopen must reconcile to the fresh host content.
+        composeRule.waitUntil(timeoutMillis = 30_000) {
+            composeRule.onAllNodesWithText("CHANGED-ON-HOST-V2", substring = true)
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+        composeRule.onNodeWithText("CHANGED-ON-HOST-V2", substring = true).assertExists()
+        WalkthroughScreenshotArtifacts.capture("issue1713-reopen-after-v2")
+
+        // The authoritative viewer state carries the fresh body, and the stale
+        // body is gone.
+        val shown = viewModel.state.value
+        assertTrue(
+            "viewer state must be the fresh v2 body, was: $shown",
+            shown is FileViewerUiState.TextContent && shown.content.contains("CHANGED-ON-HOST-V2"),
+        )
+        assertTrue(
+            "stale v1 body must be gone after reopen, was: $shown",
+            shown is FileViewerUiState.TextContent && !shown.content.contains("ORIGINAL-BODY-V1"),
+        )
+        assertTrue(
+            "the stale v1 body must not be on screen after reopen",
+            composeRule.onAllNodesWithText("ORIGINAL-BODY-V1", substring = true)
+                .fetchSemanticsNodes().isEmpty(),
+        )
     } }
 
     private suspend fun connect() = SshConnection.connect(

--- a/app/src/main/java/com/pocketshell/app/fileviewer/FileViewerViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/fileviewer/FileViewerViewModel.kt
@@ -525,12 +525,29 @@ class FileViewerViewModel @Inject constructor(
         }
 
     /**
-     * Bind to a host + path and fetch. Re-binding with the identical request
-     * is a no-op so a recomposition doesn't re-download.
+     * Bind to a host + path and fetch.
+     *
+     * Re-binding distinguishes a *recomposition re-bind* from a *genuine
+     * reopen* by whether the current fetch has settled (issue #1713):
+     *
+     *  - A re-bind of the IDENTICAL request whose fetch is still **in flight**
+     *    is a true no-op recompose (a config change / composition re-entry
+     *    before the first load landed). Restarting it would cancel and re-issue
+     *    the same download for no benefit — the #697 redundant-download the old
+     *    early-return guarded against — so it is suppressed.
+     *  - A re-bind of the identical request whose fetch has **settled** is a
+     *    genuine reopen: the host-side file may have changed since we last read
+     *    it (the reported bug — the viewer showed stale content on reopen). We
+     *    run [load] again so a fresh SFTP re-fetch reconciles and the live host
+     *    content wins. [load] paints the instant LRU cache first (no flicker,
+     *    no cold handshake — #697), then the background fetch replaces it.
+     *
+     * A different request (fresh navigation) always loads.
      */
     fun bind(request: Request) {
-        if (request == lastRequest && _state.value !is FileViewerUiState.CannotPreview) return
+        val sameRequest = request == lastRequest
         lastRequest = request
+        if (sameRequest && loadJob?.isActive == true) return
         load(request)
     }
 

--- a/app/src/test/java/com/pocketshell/app/fileviewer/FileViewerReopenReconcileTest.kt
+++ b/app/src/test/java/com/pocketshell/app/fileviewer/FileViewerReopenReconcileTest.kt
@@ -1,0 +1,258 @@
+package com.pocketshell.app.fileviewer
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.pocketshell.app.hosts.MainDispatcherRule
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.RemoteListing
+import com.pocketshell.core.ssh.SshLeaseConnector
+import com.pocketshell.core.ssh.SshLeaseManager
+import com.pocketshell.core.ssh.SshLeaseTarget
+import com.pocketshell.core.ssh.SshPortForward
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshShell
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+import java.io.InputStream
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Issue #1713 — reopening a file whose host content changed must show the FRESH
+ * content. `bind()` used to return early whenever `request == lastRequest`, so a
+ * genuine reopen of the same `(host, path)` never re-ran `load()` and the viewer
+ * kept showing the STALE body. JVM-level with a fake, MUTABLE remote whose body
+ * can change between reads — no emulator.
+ *
+ * The Docker sibling ([FileViewerDockerTest.reopeningAChangedTextFileShowsTheFreshHostContent])
+ * proves the same red→green on the real SSH path.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class FileViewerReopenReconcileTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+    }
+
+    /**
+     * The reported bug, on the reused-VM-instance reopen path: open a text file,
+     * change its host content, reopen the SAME request — the viewer must
+     * reconcile to the NEW body (not keep the stale one).
+     */
+    @Test
+    fun reopeningTheSameRequestReconcilesToTheChangedHostContent() = runBlocking {
+        val session = MutableFileSession(body = "original body v1")
+        val leaseManager = SshLeaseManager(
+            connector = CountingConnector(session),
+            idleTtlMillis = 30_000L,
+        )
+        val vm = FileViewerViewModel(context, leaseManager)
+        val req = request("/srv/notes.txt")
+
+        vm.bind(req)
+        val first = vm.state.awaitText()
+        assertEquals("original body v1", first.content)
+
+        // The host file changes (an agent rewrote it) while the viewer is open.
+        session.body.set("CHANGED ON HOST v2")
+
+        // Reopen the IDENTICAL request (what a navigate-away-and-back does with a
+        // surviving VM). The fix must run a fresh fetch so the new body wins.
+        vm.bind(req)
+        val reopened = vm.state.awaitText { it.content == "CHANGED ON HOST v2" }
+        assertEquals(
+            "reopen must show the fresh host content, not the stale body",
+            "CHANGED ON HOST v2",
+            reopened.content,
+        )
+        assertEquals("reopen must issue a fresh SFTP read", 2, session.downloads.get())
+        leaseManager.close()
+    }
+
+    /**
+     * Class coverage (G2), fresh-navigation path: A → B → A reopen. After the
+     * host changes A, coming back to A must reconcile to A's new content (and the
+     * viewer must show A, not B).
+     */
+    @Test
+    fun reopeningAfterNavigatingAwayReconcilesTheFreshContent() = runBlocking {
+        val session = MutableFileSession(body = "unused")
+        val leaseManager = SshLeaseManager(
+            connector = CountingConnector(session),
+            idleTtlMillis = 30_000L,
+        )
+        val vm = FileViewerViewModel(context, leaseManager)
+
+        session.pathBodies["/srv/a.txt"] = "A original"
+        session.pathBodies["/srv/b.txt"] = "B body"
+
+        vm.bind(request("/srv/a.txt"))
+        assertEquals("A original", vm.state.awaitText { it.displayPath.endsWith("/a.txt") }.content)
+
+        vm.bind(request("/srv/b.txt"))
+        vm.state.awaitText { it.displayPath.endsWith("/b.txt") }
+
+        // A changes on the host while we're viewing B.
+        session.pathBodies["/srv/a.txt"] = "A CHANGED"
+
+        vm.bind(request("/srv/a.txt"))
+        val backToA = vm.state.awaitText { it.displayPath.endsWith("/a.txt") && it.content == "A CHANGED" }
+        assertEquals("A CHANGED", backToA.content)
+        leaseManager.close()
+    }
+
+    /**
+     * A true no-op recompose — a re-bind of the identical request while the first
+     * fetch is still IN FLIGHT — must NOT stack a duplicate download (the #697
+     * behaviour the old guard protected). We hold the first fetch open, fire a
+     * second identical bind, then release: exactly one download runs.
+     */
+    @Test
+    fun reBindingWhileTheFirstFetchIsInFlightDoesNotStackADuplicateDownload() = runBlocking {
+        val gate = CompletableDeferred<Unit>()
+        val session = MutableFileSession(body = "gated body", gate = gate)
+        val leaseManager = SshLeaseManager(
+            connector = CountingConnector(session),
+            idleTtlMillis = 30_000L,
+        )
+        val vm = FileViewerViewModel(context, leaseManager)
+        val req = request("/srv/gated.txt")
+
+        vm.bind(req)
+        // Wait until the (gated) download has actually started.
+        awaitCondition { session.downloadStarted.get() == 1 }
+
+        // Recomposition re-bind while the first fetch is still suspended on the
+        // gate — this must be suppressed, not restart the load.
+        vm.bind(req)
+        vm.bind(req)
+
+        gate.complete(Unit)
+        val settled = vm.state.awaitText()
+        assertEquals("gated body", settled.content)
+        assertEquals(
+            "an in-flight re-bind must not stack a duplicate download",
+            1,
+            session.downloads.get(),
+        )
+        leaseManager.close()
+    }
+
+    private suspend fun StateFlow<FileViewerUiState>.awaitText(
+        predicate: (FileViewerUiState.TextContent) -> Boolean = { true },
+    ): FileViewerUiState.TextContent {
+        val deadline = System.currentTimeMillis() + 10_000
+        while (System.currentTimeMillis() < deadline) {
+            val s = value
+            if (s is FileViewerUiState.TextContent && predicate(s)) return s
+            kotlinx.coroutines.delay(20)
+        }
+        error("viewer never reached the expected TextContent state; was ${value}")
+    }
+
+    private suspend fun awaitCondition(predicate: () -> Boolean) {
+        val deadline = System.currentTimeMillis() + 10_000
+        while (System.currentTimeMillis() < deadline) {
+            if (predicate()) return
+            kotlinx.coroutines.delay(20)
+        }
+        error("condition never became true")
+    }
+
+    private fun request(path: String) = FileViewerViewModel.Request(
+        hostId = 1L,
+        hostname = "10.0.2.2",
+        port = 2222,
+        username = "tester",
+        keyPath = "/tmp/key",
+        passphrase = null,
+        path = path,
+        cwd = null,
+    )
+
+    private class CountingConnector(
+        private val session: MutableFileSession,
+    ) : SshLeaseConnector {
+        var connectCount: Int = 0
+
+        override suspend fun connect(target: SshLeaseTarget): Result<SshSession> {
+            connectCount += 1
+            return Result.success(session)
+        }
+    }
+
+    /**
+     * In-memory remote whose file body can change between reads. [body] is the
+     * default returned for any path; [pathBodies] overrides per absolute path so
+     * an A/B navigation is distinguishable. An optional [gate] suspends each
+     * download until completed, so a test can hold a fetch in flight.
+     */
+    private class MutableFileSession(
+        body: String,
+        private val gate: CompletableDeferred<Unit>? = null,
+    ) : SshSession {
+        var closed: Boolean = false
+        val body = AtomicReference(body)
+        val pathBodies = mutableMapOf<String, String>()
+        val downloads = AtomicInteger(0)
+        val downloadStarted = AtomicInteger(0)
+
+        override val isConnected: Boolean
+            get() = !closed
+
+        override suspend fun exec(command: String): ExecResult =
+            ExecResult(stdout = "/home/tester\n", stderr = "", exitCode = 0)
+
+        override suspend fun downloadFile(remotePath: String, maxBytes: Long): ByteArray {
+            downloadStarted.incrementAndGet()
+            gate?.await()
+            downloads.incrementAndGet()
+            val text = pathBodies[remotePath] ?: body.get()
+            return text.toByteArray(Charsets.UTF_8)
+        }
+
+        override suspend fun listDirectory(remotePath: String, maxEntries: Int): RemoteListing =
+            error("not used")
+
+        override fun tail(path: String, onLine: (String) -> Unit): Job = error("not used")
+
+        override fun openLocalPortForward(
+            remoteHost: String,
+            remotePort: Int,
+            localPort: Int,
+        ): SshPortForward = error("not used")
+
+        override fun startShell(): SshShell = error("not used")
+
+        override suspend fun uploadFile(file: File, remotePath: String): String = error("not used")
+
+        override suspend fun uploadStream(
+            input: InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String = error("not used")
+
+        override fun close() {
+            closed = true
+        }
+    }
+}

--- a/scripts/check-ci-journey-harness.sh
+++ b/scripts/check-ci-journey-harness.sh
@@ -82,7 +82,6 @@ KNOWN_UNWIRED_ANDROID_E2E_DOCKER_CLASSES=(
   "com.pocketshell.app.costs.CostsScreenE2eTest"
   "com.pocketshell.app.crash.ShareAllReportsDockerTest"
   "com.pocketshell.app.fileexplorer.FileExplorerDockerTest"
-  "com.pocketshell.app.fileviewer.FileViewerDockerTest"
   "com.pocketshell.app.fileviewer.LinkTapParsingDockerTest"
   "com.pocketshell.app.fileviewer.TerminalFilePathTapToViewerDockerTest"
   "com.pocketshell.app.git.GitHistoryDockerTest"

--- a/scripts/check-test-validity.sh
+++ b/scripts/check-test-validity.sh
@@ -273,7 +273,6 @@ J1_UNWIRED_ANDROID_E2E_DOCKER_BASELINE=(
   "com.pocketshell.app.costs.CostsScreenE2eTest"
   "com.pocketshell.app.crash.ShareAllReportsDockerTest"
   "com.pocketshell.app.fileexplorer.FileExplorerDockerTest"
-  "com.pocketshell.app.fileviewer.FileViewerDockerTest"
   "com.pocketshell.app.fileviewer.LinkTapParsingDockerTest"
   "com.pocketshell.app.fileviewer.TerminalFilePathTapToViewerDockerTest"
   "com.pocketshell.app.git.GitHistoryDockerTest"

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -262,6 +262,7 @@ JOURNEY_CLASSES=(
   "com.pocketshell.app.fileviewer.FileViewerScaffoldTest#cannotPreviewStateShowsMessageAndRetry"
   "com.pocketshell.app.fileviewer.FileViewerScaffoldTest#cannotPreviewWithLocateCandidatesOffersOpenRows"
   "com.pocketshell.app.fileviewer.FileViewerScaffoldTest#markdownRenderedPipeTableShowsCellsNotRawDelimiter"  # #921 D32 G9): rendered Markdown shows GFM pipe tables as
+  "com.pocketshell.app.fileviewer.FileViewerDockerTest#reopeningAChangedTextFileShowsTheFreshHostContent"  # #1713 D33/G10: reopening a text file whose host content changed over the same warm lease must show the FRESH body, not the stale one (bind() no longer early-returns on the identical settled request)
   "com.pocketshell.app.bootstrap.HostReadyPrimaryActionTest"  # #885 #117 D32 G9): the post-update Host ready success sheet must
   "com.pocketshell.app.bootstrap.HostNotificationsReadinessTest"  # #1236 D26 / D32 G9): per-host notification readiness + the
   "$FQCN_PREFIX.StrictModeMainThreadIoDetectorE2eTest"  # #933 #928 #931 #926 ============================================================…


### PR DESCRIPTION
Fixes the dogfood-reported stale file-viewer content: reopening a file that changed on the host showed the OLD body.

## Root cause
`FileViewerViewModel.bind()` early-returned on request equality, so `load()` (the only path that re-fetches over SFTP and reconciles) never ran on a genuine reopen. Now `bind()` suppresses a re-bind only while its fetch is still in flight (the true no-op recompose the #697 guard protected) and runs `load()` for a settled re-bind — a fresh SFTP read reconciles and the live host content wins, keeping the #697 instant-cache paint.

## Verification (reviewer-run, this run)
- **Real path red→green**: `FileViewerDockerTest#reopeningAChangedTextFileShowsTheFreshHostContent` fails on base (`ComposeTimeoutException`, stale body) and passes with the fix; on-device screenshots show `ORIGINAL-BODY-V1` → `CHANGED-ON-HOST-V2` after reopen.
- **JVM red→green**: `FileViewerReopenReconcileTest` (new).
- **Full modules**: `:app:testDebugUnitTest` 4047/0, `:app:testReleaseUnitTest` 4043/0.
- #697 `FileViewerLeaseTest` still green (no recomposition-redownload regression); image/pdf/audio still always re-fetch.

Reviewer APPROVED: #1713

Closes #1713